### PR TITLE
Add support for mknod syscall

### DIFF
--- a/src/services/libs/jinux-std/src/fs/fs_resolver.rs
+++ b/src/services/libs/jinux-std/src/fs/fs_resolver.rs
@@ -104,7 +104,7 @@ impl FsResolver {
                 if !dir_dentry.vnode().inode_mode().is_writable() {
                     return_errno_with_message!(Errno::EPERM, "file cannot be created");
                 }
-                let new_dentry = dir_dentry.create(&file_name, InodeType::File, inode_mode)?;
+                let new_dentry = dir_dentry.mknod(&file_name, InodeType::File, inode_mode, None)?;
                 new_dentry
             }
             Err(e) => return Err(e),

--- a/src/services/libs/jinux-std/src/fs/initramfs.rs
+++ b/src/services/libs/jinux-std/src/fs/initramfs.rs
@@ -34,14 +34,14 @@ pub fn init(ramdisk_buf: &[u8]) -> Result<()> {
         let mode = InodeMode::from_bits_truncate(metadata.permission_mode());
         match metadata.file_type() {
             FileType::File => {
-                let dentry = parent.create(name, InodeType::File, mode)?;
+                let dentry = parent.mknod(name, InodeType::File, mode, None)?;
                 dentry.vnode().write_at(0, entry.data())?;
             }
             FileType::Dir => {
-                let _ = parent.create(name, InodeType::Dir, mode)?;
+                let _ = parent.mknod(name, InodeType::Dir, mode, None)?;
             }
             FileType::Link => {
-                let dentry = parent.create(name, InodeType::SymLink, mode)?;
+                let dentry = parent.mknod(name, InodeType::SymLink, mode, None)?;
                 let link_content = core::str::from_utf8(entry.data())?;
                 dentry.vnode().write_link(link_content)?;
             }

--- a/src/services/libs/jinux-std/src/fs/ramfs/fs.rs
+++ b/src/services/libs/jinux-std/src/fs/ramfs/fs.rs
@@ -8,7 +8,8 @@ use spin::{RwLock, RwLockWriteGuard};
 
 use super::*;
 use crate::fs::utils::{
-    DirentWriterContext, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata, SuperBlock,
+    DeviceId, DirentWriterContext, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
+    SuperBlock,
 };
 
 pub struct RamFS {
@@ -309,7 +310,13 @@ impl Inode for RamInode {
         self.0.write().metadata.size = new_size;
     }
 
-    fn mknod(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+    fn mknod(
+        &self,
+        name: &str,
+        type_: InodeType,
+        mode: InodeMode,
+        dev: Option<DeviceId>,
+    ) -> Result<Arc<dyn Inode>> {
         if self.0.read().metadata.type_ != InodeType::Dir {
             return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
         }

--- a/src/services/libs/jinux-std/src/fs/stdio.rs
+++ b/src/services/libs/jinux-std/src/fs/stdio.rs
@@ -53,7 +53,7 @@ impl File for Stdin {
 
     fn metadata(&self) -> Metadata {
         Metadata {
-            dev: 0,
+            dev: Default::default(),
             ino: 0,
             size: 0,
             blk_size: 1024,
@@ -94,7 +94,7 @@ impl File for Stdout {
 
     fn metadata(&self) -> Metadata {
         Metadata {
-            dev: 0,
+            dev: Default::default(),
             ino: 0,
             size: 0,
             blk_size: 1024,
@@ -136,7 +136,7 @@ impl File for Stderr {
 
     fn metadata(&self) -> Metadata {
         Metadata {
-            dev: 0,
+            dev: Default::default(),
             ino: 0,
             size: 0,
             blk_size: 1024,

--- a/src/services/libs/jinux-std/src/fs/utils/mod.rs
+++ b/src/services/libs/jinux-std/src/fs/utils/mod.rs
@@ -7,7 +7,7 @@ pub use dirent_writer::{DirentWriter, DirentWriterContext};
 pub use events::IoEvents;
 pub use fcntl::FcntlCmd;
 pub use fs::{FileSystem, SuperBlock};
-pub use inode::{Inode, InodeMode, InodeType, Metadata, Timespec};
+pub use inode::{DeviceId, Inode, InodeMode, InodeType, Metadata, Timespec};
 pub use ioctl::IoctlCmd;
 pub use page_cache::PageCacheManager;
 pub use poll::{c_nfds, c_pollfd, PollFd};

--- a/src/services/libs/jinux-std/src/fs/utils/stat.rs
+++ b/src/services/libs/jinux-std/src/fs/utils/stat.rs
@@ -48,7 +48,7 @@ pub struct Stat {
 impl From<Metadata> for Stat {
     fn from(info: Metadata) -> Self {
         Self {
-            st_dev: info.dev,
+            st_dev: info.dev.into(),
             st_ino: info.ino,
             st_nlink: info.nlinks,
             st_mode: info.type_ as u32 | info.mode.bits() as u32,

--- a/src/services/libs/jinux-std/src/fs/utils/vnode.rs
+++ b/src/services/libs/jinux-std/src/fs/utils/vnode.rs
@@ -1,4 +1,6 @@
-use super::{DirentWriterContext, Inode, InodeMode, InodeType, Metadata, PageCacheManager};
+use super::{
+    DeviceId, DirentWriterContext, Inode, InodeMode, InodeType, Metadata, PageCacheManager,
+};
 use crate::prelude::*;
 use crate::rights::Rights;
 use crate::vm::vmo::{Vmo, VmoFlags, VmoOptions};
@@ -126,8 +128,14 @@ impl Vnode {
         Ok(len)
     }
 
-    pub fn mknod(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Self> {
-        let inode = self.inner.read().inode.mknod(name, type_, mode)?;
+    pub fn mknod(
+        &self,
+        name: &str,
+        type_: InodeType,
+        mode: InodeMode,
+        dev: Option<DeviceId>,
+    ) -> Result<Self> {
+        let inode = self.inner.read().inode.mknod(name, type_, mode, dev)?;
         Self::new(inode)
     }
 

--- a/src/services/libs/jinux-std/src/syscall/mkdir.rs
+++ b/src/services/libs/jinux-std/src/syscall/mkdir.rs
@@ -19,7 +19,7 @@ pub fn sys_mkdirat(
     log_syscall_entry!(SYS_MKDIRAT);
     let pathname = read_cstring_from_user(pathname_addr, MAX_FILENAME_LEN)?;
     debug!(
-        "dirfd = {}, pathname = {:?}, mode = {}",
+        "dirfd = {}, pathname = {:?}, mode = 0o{:o}",
         dirfd, pathname, mode
     );
 
@@ -33,7 +33,12 @@ pub fn sys_mkdirat(
         current.fs().read().lookup_dir_and_base_name(&fs_path)?
     };
     let inode_mode = InodeMode::from_bits_truncate(mode);
-    let _ = dir_dentry.create(&name.trim_end_matches('/'), InodeType::Dir, inode_mode)?;
+    let _ = dir_dentry.mknod(
+        &name.trim_end_matches('/'),
+        InodeType::Dir,
+        inode_mode,
+        None,
+    )?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/src/services/libs/jinux-std/src/syscall/mknod.rs
+++ b/src/services/libs/jinux-std/src/syscall/mknod.rs
@@ -1,0 +1,85 @@
+use crate::fs::{
+    file_table::FileDescripter,
+    fs_resolver::{FsPath, AT_FDCWD},
+    utils::{DeviceId, InodeMode, InodeType},
+};
+use crate::log_syscall_entry;
+use crate::prelude::*;
+use crate::syscall::constants::MAX_FILENAME_LEN;
+use crate::util::read_cstring_from_user;
+
+use super::SyscallReturn;
+use super::SYS_MKNODAT;
+
+pub fn sys_mknodat(
+    dirfd: FileDescripter,
+    pathname_addr: Vaddr,
+    mode: u32,
+    dev: u64,
+) -> Result<SyscallReturn> {
+    log_syscall_entry!(SYS_MKNODAT);
+    let pathname = read_cstring_from_user(pathname_addr, MAX_FILENAME_LEN)?;
+    debug!(
+        "dirfd = {}, pathname = {:?}, mode = 0o{:o}, dev = {}",
+        dirfd, pathname, mode, dev,
+    );
+
+    let inode_type = InodeType::from_mode(mode)?;
+    let inode_mode = {
+        const MODE_MASK: u32 = 0o7777;
+        let mode = (mode & MODE_MASK) as u16;
+        InodeMode::from_bits_truncate(mode)
+    };
+    let dev = if inode_type == InodeType::CharDevice || inode_type == InodeType::BlockDevice {
+        Some(DeviceId::from(dev as usize))
+    } else {
+        None
+    };
+
+    let current = current!();
+    let (dir_dentry, name) = {
+        let pathname = pathname.to_string_lossy();
+        if pathname.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "pathname is empty");
+        }
+        if pathname.ends_with("/") {
+            return_errno_with_message!(Errno::EPERM, "pathname is dir");
+        }
+        let fs_path = FsPath::new(dirfd, pathname.as_ref())?;
+        current.fs().read().lookup_dir_and_base_name(&fs_path)?
+    };
+    let _ = dir_dentry.mknod(&name, inode_type, inode_mode, dev)?;
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_mknod(pathname_addr: Vaddr, mode: u32, dev: u64) -> Result<SyscallReturn> {
+    self::sys_mknodat(AT_FDCWD, pathname_addr, mode, dev)
+}
+
+trait MknodExt: Sized {
+    fn from_mode(mode: u32) -> Result<Self>;
+}
+
+impl MknodExt for InodeType {
+    fn from_mode(mode: u32) -> Result<Self> {
+        const TYPE_MASK: u32 = 0o170000;
+        let bits = mode & TYPE_MASK;
+        let inode_type = if bits == Self::NamedPipe as u32 {
+            Self::NamedPipe
+        } else if bits == Self::CharDevice as u32 {
+            Self::CharDevice
+        } else if bits == Self::BlockDevice as u32 {
+            Self::BlockDevice
+        } else if bits == Self::File as u32 {
+            Self::File
+        } else if bits == Self::Socket as u32 {
+            Self::Socket
+        } else if bits == 0 {
+            // Zero file type is equivalent to type File
+            Self::File
+        } else {
+            return Err(Error::with_message(Errno::EINVAL, "invalid mode"));
+        };
+        Ok(inode_type)
+    }
+}

--- a/src/services/libs/jinux-std/src/syscall/mod.rs
+++ b/src/services/libs/jinux-std/src/syscall/mod.rs
@@ -30,6 +30,7 @@ use crate::syscall::link::{sys_link, sys_linkat};
 use crate::syscall::lseek::sys_lseek;
 use crate::syscall::madvise::sys_madvise;
 use crate::syscall::mkdir::{sys_mkdir, sys_mkdirat};
+use crate::syscall::mknod::{sys_mknod, sys_mknodat};
 use crate::syscall::mmap::sys_mmap;
 use crate::syscall::mprotect::sys_mprotect;
 use crate::syscall::munmap::sys_munmap;
@@ -89,6 +90,7 @@ mod link;
 mod lseek;
 mod madvise;
 mod mkdir;
+mod mknod;
 mod mmap;
 mod mprotect;
 mod munmap;
@@ -197,6 +199,7 @@ define_syscall_nums!(
     SYS_SETPGID = 109,
     SYS_GETPPID = 110,
     SYS_GETPGRP = 111,
+    SYS_MKNOD = 133,
     SYS_PRCTL = 157,
     SYS_ARCH_PRCTL = 158,
     SYS_GETTID = 186,
@@ -208,6 +211,7 @@ define_syscall_nums!(
     SYS_WAITID = 247,
     SYS_OPENAT = 257,
     SYS_MKDIRAT = 258,
+    SYS_MKNODAT = 259,
     SYS_FSTATAT = 262,
     SYS_UNLINKAT = 263,
     SYS_RENAMEAT = 264,
@@ -323,6 +327,7 @@ pub fn syscall_dispatch(
         SYS_SETPGID => syscall_handler!(2, sys_setpgid, args),
         SYS_GETPPID => syscall_handler!(0, sys_getppid),
         SYS_GETPGRP => syscall_handler!(0, sys_getpgrp),
+        SYS_MKNOD => syscall_handler!(3, sys_mknod, args),
         SYS_PRCTL => syscall_handler!(5, sys_prctl, args),
         SYS_ARCH_PRCTL => syscall_handler!(2, sys_arch_prctl, args, context),
         SYS_GETTID => syscall_handler!(0, sys_gettid),
@@ -334,6 +339,7 @@ pub fn syscall_dispatch(
         SYS_WAITID => syscall_handler!(5, sys_waitid, args),
         SYS_OPENAT => syscall_handler!(4, sys_openat, args),
         SYS_MKDIRAT => syscall_handler!(3, sys_mkdirat, args),
+        SYS_MKNODAT => syscall_handler!(4, sys_mknodat, args),
         SYS_FSTATAT => syscall_handler!(4, sys_fstatat, args),
         SYS_UNLINKAT => syscall_handler!(3, sys_unlinkat, args),
         SYS_RENAMEAT => syscall_handler!(4, sys_renameat, args),

--- a/src/services/libs/jinux-std/src/syscall/open.rs
+++ b/src/services/libs/jinux-std/src/syscall/open.rs
@@ -21,7 +21,7 @@ pub fn sys_openat(
     log_syscall_entry!(SYS_OPENAT);
     let pathname = read_cstring_from_user(pathname_addr, MAX_FILENAME_LEN)?;
     debug!(
-        "dirfd = {}, pathname = {:?}, flags = {}, mode = {}",
+        "dirfd = {}, pathname = {:?}, flags = {}, mode = 0o{:o}",
         dirfd, pathname, flags, mode
     );
 

--- a/src/services/libs/jinux-std/src/syscall/symlink.rs
+++ b/src/services/libs/jinux-std/src/syscall/symlink.rs
@@ -41,10 +41,11 @@ pub fn sys_symlinkat(
         current.fs().read().lookup_dir_and_base_name(&fs_path)?
     };
 
-    let new_dentry = dir_dentry.create(
+    let new_dentry = dir_dentry.mknod(
         &link_name,
         InodeType::SymLink,
         InodeMode::from_bits_truncate(0o777),
+        None,
     )?;
     new_dentry.write_link(&target)?;
     Ok(SyscallReturn::Return(0))


### PR DESCRIPTION
This commit provides a basic `mknod` syscall support to create file via it.

Currently, The Ramfs only support File, Dir, and SymLink types. So the `mknod` will panic if the type is not supported.