### PR TITLE
Use modified trapframe

### DIFF
--- a/src/framework/jinux-frame/Cargo.toml
+++ b/src/framework/jinux-frame/Cargo.toml
@@ -22,7 +22,7 @@ intrusive-collections = "0.9.5"
 log = "0.4"
 limine = { version = "0.1.10", features = ["into-uuid"] }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-trapframe= "0.9.0"
+trapframe = { git = "https://github.com/sdww0/trapframe-rs", rev = "13e1065" }
 
 [features]
 default = ["serial_print"]


### PR DESCRIPTION
The GDT initialization process in the trapframe reads the old GDT address and then modifies the GDT. However, the modified base unit is u64, which causes problems when GDT addresses are misaligned and appears in the latest code. Therefore, the modified trapframe code needs to be used.