### PR TITLE
Remove instruction pointer etc. functions in UserSpace

### DIFF
--- a/src/framework/jinux-frame/src/user.rs
+++ b/src/framework/jinux-frame/src/user.rs
@@ -26,18 +26,6 @@ impl UserSpace {
         Self { vm_space, init_ctx }
     }
 
-    pub fn instruction_pointer(&self) -> usize {
-        self.init_ctx.instruction_pointer()
-    }
-
-    pub fn stack_pointer(&self) -> usize {
-        self.init_ctx.stack_pointer()
-    }
-
-    pub fn syscall_ret(&self) -> usize {
-        self.init_ctx.syscall_ret()
-    }
-
     /// Returns the VM address space.
     pub fn vm_space(&self) -> &VmSpace {
         &self.vm_space

--- a/src/services/libs/jinux-std/src/thread/task.rs
+++ b/src/services/libs/jinux-std/src/thread/task.rs
@@ -1,7 +1,7 @@
 use jinux_frame::{
     cpu::UserContext,
     task::Task,
-    user::{UserEvent, UserMode, UserSpace},
+    user::{UserEvent, UserMode, UserSpace, UserContextApi},
 };
 
 use crate::{
@@ -19,10 +19,10 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Weak<Thread>
         let mut user_mode = UserMode::new(user_space);
         debug!(
             "[Task entry] rip = 0x{:x}",
-            user_space.instruction_pointer()
+            user_mode.context().instruction_pointer()
         );
-        debug!("[Task entry] rsp = 0x{:x}", user_space.stack_pointer());
-        debug!("[Task entry] rax = 0x{:x}", user_space.syscall_ret());
+        debug!("[Task entry] rsp = 0x{:x}", user_mode.context().stack_pointer());
+        debug!("[Task entry] rax = 0x{:x}", user_mode.context().syscall_ret());
         loop {
             let user_event = user_mode.execute();
             let context = user_mode.context_mut();


### PR DESCRIPTION
This commit was omitted when rebasing in the #170, and the commit is made up here.