### PR TITLE
Add TDX support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acpi"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+source = "git+https://github.com/Hsy-Intel/acpi.git?rev=109aecb#109aecbb6d3c686aea4457bb98639e024162c42d"
 dependencies = [
  "bit_field",
  "log",
@@ -488,6 +487,7 @@ dependencies = [
  "jinux-framebuffer",
  "jinux-std",
  "jinux-time",
+ "tdx-guest",
  "x86_64",
 ]
 
@@ -532,6 +532,7 @@ dependencies = [
  "multiboot2",
  "pod",
  "spin 0.9.8",
+ "tdx-guest",
  "trapframe",
  "volatile",
  "x86",
@@ -644,6 +645,7 @@ dependencies = [
  "ringbuf",
  "smoltcp",
  "spin 0.9.8",
+ "tdx-guest",
  "time",
  "typeflags",
  "typeflags-util",
@@ -1135,6 +1137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tdx-guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags 1.3.2",
+ "lazy_static",
+ "raw-cpuid",
+ "x86_64",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "trapframe"
 version = "0.9.0"
-source = "git+https://github.com/sdww0/trapframe-rs?rev=e886763#e8867631def557939be5107f2be6c8d909d72431"
+source = "git+https://github.com/Hsy-Intel/trapframe-rs?rev=fe6fc6e#fe6fc6e57417dbcb4a6d4da9aa9ea08812c40003"
 dependencies = [
  "log",
  "pod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "kernel/main.rs"
 jinux-frame = { path = "framework/jinux-frame" }
 jinux-std = { path = "services/libs/jinux-std" }
 component = { path = "services/libs/comp-sys/component" }
+tdx-guest = { path = "framework/libs/tdx-guest", optional = true }
 
 [dev-dependencies]
 x86_64 = "0.14.2"
@@ -39,3 +40,6 @@ members = [
 ]
 
 exclude = ["services/libs/comp-sys/controlled", "services/libs/comp-sys/cargo-component"]
+
+[features]
+intel_tdx = ["dep:tdx-guest", "jinux-frame/intel_tdx", "jinux-std/intel_tdx"]

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ build:
 	@make --no-print-directory -C regression
 	@cargo kbuild
 
+build_td:
+	@make --no-print-directory -C regression
+	@cargo kbuild --features intel_tdx
+
 tools:
 	@cd services/libs/comp-sys && cargo install --path cargo-component
 

--- a/framework/jinux-frame/Cargo.toml
+++ b/framework/jinux-frame/Cargo.toml
@@ -16,14 +16,16 @@ align_ext = { path = "../libs/align_ext" }
 intrusive-collections = "0.9.5"
 log = "0.4"
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-trapframe = { git = "https://github.com/sdww0/trapframe-rs", rev = "e886763" }
+trapframe = { git = "https://github.com/Hsy-Intel/trapframe-rs", rev = "fe6fc6e" }
 inherit-methods-macro = { git = "https://github.com/jinzhao-dev/inherit-methods-macro", rev = "98f7e3e" }
 multiboot2 = "0.16.0"
+tdx-guest = { path = "../libs/tdx-guest", optional = true }
 
 [target.x86_64-custom.dependencies]
 x86_64 = "0.14.2"
 x86 = "0.52.0"
-acpi = "4.1.1"
+acpi = { git = "https://github.com/Hsy-Intel/acpi.git", rev = "109aecb" }
 aml = "0.16.3"
 
 [features]
+intel_tdx = ["dep:tdx-guest"]

--- a/framework/jinux-frame/src/arch/x86/boot/memory_region.rs
+++ b/framework/jinux-frame/src/arch/x86/boot/memory_region.rs
@@ -28,9 +28,9 @@ pub enum MemoryRegionType {
 /// The sections are **not** guaranteed to not overlap. The region must be page aligned.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct MemoryRegion {
-    base: usize,
-    len: usize,
-    typ: MemoryRegionType,
+    pub base: usize,
+    pub len: usize,
+    pub typ: MemoryRegionType,
 }
 
 impl MemoryRegion {

--- a/framework/jinux-frame/src/arch/x86/device/cmos.rs
+++ b/framework/jinux-frame/src/arch/x86/device/cmos.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "intel_tdx"))]
 use acpi::{fadt::Fadt, sdt::Signature};
 use x86_64::instructions::port::{ReadOnlyAccess, WriteOnlyAccess};
 
+#[cfg(not(feature = "intel_tdx"))]
 use crate::arch::x86::kernel::acpi::ACPI_TABLES;
 
 use super::io_port::IoPort;
@@ -9,6 +11,7 @@ pub static CMOS_ADDRESS: IoPort<u8, WriteOnlyAccess> = unsafe { IoPort::new(0x70
 pub static CMOS_DATA: IoPort<u8, ReadOnlyAccess> = unsafe { IoPort::new(0x71) };
 
 pub fn get_century() -> u8 {
+    #[cfg(not(feature = "intel_tdx"))]
     unsafe {
         let a = ACPI_TABLES
             .get()
@@ -19,4 +22,6 @@ pub fn get_century() -> u8 {
             .expect("not found FACP in ACPI table");
         a.century
     }
+    #[cfg(feature = "intel_tdx")]
+    21
 }

--- a/framework/jinux-frame/src/arch/x86/kernel/apic/x2apic.rs
+++ b/framework/jinux-frame/src/arch/x86/kernel/apic/x2apic.rs
@@ -27,8 +27,10 @@ impl X2Apic {
         unsafe {
             // Enable x2APIC mode globally
             let mut base = rdmsr(IA32_APIC_BASE);
-            base = base | 0b1100_0000_0000; // Enable x2APIC and xAPIC
-            wrmsr(IA32_APIC_BASE, base);
+            if base & 0b1100_0000_0000 != 0b1100_0000_0000 {
+                base = base | 0b1100_0000_0000; // Enable x2APIC and xAPIC
+                wrmsr(IA32_APIC_BASE, base);
+            }
 
             // Set SVR, Enable APIC and set Spurious Vector to 15 (Reserved irq number)
             let svr: u64 = 1 << 8 | 15;

--- a/framework/jinux-frame/src/arch/x86/mm/mod.rs
+++ b/framework/jinux-frame/src/arch/x86/mm/mod.rs
@@ -11,6 +11,9 @@ use crate::{
     },
 };
 
+#[cfg(feature = "intel_tdx")]
+use crate::linux_boot::E820Entry;
+
 bitflags::bitflags! {
     #[derive(Pod)]
     #[repr(C)]

--- a/framework/jinux-frame/src/arch/x86/mmio.rs
+++ b/framework/jinux-frame/src/arch/x86/mmio.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "intel_tdx"))]
 use acpi::PciConfigRegions;
 
+#[cfg(not(feature = "intel_tdx"))]
 pub fn start_address() -> usize {
     let start = PciConfigRegions::new(
         &*crate::arch::x86::kernel::acpi::ACPI_TABLES
@@ -11,6 +13,11 @@ pub fn start_address() -> usize {
 
     // all zero to get the start address
     start.physical_address(0, 0, 0, 0).unwrap() as usize
+}
+
+#[cfg(feature = "intel_tdx")]
+pub fn start_address() -> usize {
+    0
 }
 
 pub fn end_address() -> usize {

--- a/framework/jinux-frame/src/linux_boot.rs
+++ b/framework/jinux-frame/src/linux_boot.rs
@@ -1,0 +1,123 @@
+use core::mem::size_of;
+
+#[derive(Clone, Copy, Default, Debug)]
+#[repr(C, packed)]
+pub struct SetupHeader {
+    pub setup_sects: u8,
+    pub root_flags: u16,
+    pub syssize: u32,
+    pub ram_size: u16,
+    pub vid_mode: u16,
+    pub root_dev: u16,
+    pub boot_flag: u16,
+    pub jump: u16,
+    pub header: u32,
+    pub version: u16,
+    pub realmode_swtch: u32,
+    pub start_sys_seg: u16,
+    pub kernel_version: u16,
+    pub type_of_loader: u8,
+    pub loadflags: u8,
+    pub setup_move_size: u16,
+    pub code32_start: u32,
+    pub ramdisk_image: u32,
+    pub ramdisk_size: u32,
+    pub bootsect_kludge: u32,
+    pub heap_end_ptr: u16,
+    pub ext_loader_ver: u8,
+    pub ext_loader_type: u8,
+    pub cmd_line_ptr: u32,
+    pub initrd_addr_max: u32,
+    pub kernel_alignment: u32,
+    pub relocatable_kernel: u8,
+    pub min_alignment: u8,
+    pub xloadflags: u16,
+    pub cmdline_size: u32,
+    pub hardware_subarch: u32,
+    pub hardware_subarch_data: u64,
+    pub payload_offset: u32,
+    pub payload_length: u32,
+    pub setup_data: u64,
+    pub pref_address: u64,
+    pub init_size: u32,
+    pub handover_offset: u32,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct BootParams {
+    screen_info: ScreenInfo,        // 0x000/0x040
+    apm_bios_info: ApmBiosInfo,     // 0x040/0x014
+    _pad2: [u8; 4],                 // 0x054/0x004
+    tboot_addr: u64,                // 0x058/0x002
+    ist_info: IstInfo,              // 0x060/0x010
+    pub acpi_rsdp_addr: u64,        // 0x070/0x008
+    pub unaccepted_memory: u64,     // 0x078/0x008
+    hd0_info: [u8; 16],             // 0x080/0x010 - obsolete
+    hd1_info: [u8; 16],             // 0x090/0x010 - obsolete
+    sys_desc_table: SysDescTable,   // 0x0a0/0x010 - obsolete
+    olpc_ofw_header: OlpcOfwHeader, // 0x0b0/0x010
+    ext_ramdisk_image: u32,         // 0x0c0/0x004
+    ext_ramdisk_size: u32,          // 0x0c4/0x004
+    ext_cmd_line_ptr: u32,          // 0x0c8/0x004
+    _pad4: [u8; 116],               // 0x0cc/0x074
+    edd_info: EdidInfo,             // 0x140/0x080
+    efi_info: EfiInfo,              // 0x1c0/0x020
+    alt_mem_k: u32,                 // 0x1e0/0x004
+    scratch: u32,                   // 0x1e4/0x004
+    pub e820_entries: u8,           // 0x1e8/0x001
+    eddbuf_entries: u8,             // 0x1e9/0x001
+    edd_mbr_sig_buf_entries: u8,    // 0x1ea/0x001
+    kbd_status: u8,                 // 0x1eb/0x001
+    secure_boot: u8,                // 0x1ec/0x001
+    _pad5: [u8; 2],                 // 0x1ed/0x002
+    sentinel: u8,                   // 0x1ef/0x001
+    _pad6: [u8; 1],                 // 0x1f0/0x001
+    pub hdr: SetupHeader,           // 0x1f1
+    _pad7: [u8; 0x290 - 0x1f1 - size_of::<SetupHeader>()],
+    edd_mbr_sig_buffer: [u32; 16],    // 0x290
+    pub e820_table: [E820Entry; 128], // 0x2d0
+    _pad8: [u8; 48],                  // 0xcd0
+    eddbuf: [EddInfo; 6],             // 0xd00
+    _pad9: [u8; 276],                 // 0xeec
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct ScreenInfo([u8; 0x40]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct ApmBiosInfo([u8; 0x14]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct IstInfo([u8; 0x10]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct SysDescTable([u8; 0x10]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct OlpcOfwHeader([u8; 0x10]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EdidInfo([u8; 0x80]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EfiInfo([u8; 0x20]);
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EddInfo([u8; 0x52]);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C, packed)]
+pub struct E820Entry {
+    pub addr: u64,
+    pub size: u64,
+    pub r#type: u32,
+}

--- a/framework/jinux-frame/src/trap/handler.rs
+++ b/framework/jinux-frame/src/trap/handler.rs
@@ -1,14 +1,73 @@
 use crate::{arch::irq::IRQ_LIST, cpu::CpuException};
 
+#[cfg(feature = "intel_tdx")]
+use tdx_guest::*;
 use trapframe::TrapFrame;
+
+#[cfg(feature = "intel_tdx")]
+struct VeTrapFrame<'a>(&'a mut TrapFrame);
+
+#[cfg(feature = "intel_tdx")]
+impl TdxTrapFrame for VeTrapFrame<'_> {
+    fn rax(&self) -> usize {
+        self.0.rax
+    }
+    fn set_rax(&mut self, rax: usize) {
+        self.0.rax = rax;
+    }
+    fn rbx(&self) -> usize {
+        self.0.rbx
+    }
+    fn set_rbx(&mut self, rbx: usize) {
+        self.0.rbx = rbx;
+    }
+    fn rcx(&self) -> usize {
+        self.0.rcx
+    }
+    fn set_rcx(&mut self, rcx: usize) {
+        self.0.rcx = rcx;
+    }
+    fn rdx(&self) -> usize {
+        self.0.rdx
+    }
+    fn set_rdx(&mut self, rdx: usize) {
+        self.0.rdx = rdx;
+    }
+    fn rsi(&self) -> usize {
+        self.0.rsi
+    }
+    fn set_rsi(&mut self, rsi: usize) {
+        self.0.rsi = rsi;
+    }
+    fn rdi(&self) -> usize {
+        self.0.rdi
+    }
+    fn set_rdi(&mut self, rdi: usize) {
+        self.0.rdi = rdi;
+    }
+    fn rip(&self) -> usize {
+        self.0.rip
+    }
+    fn set_rip(&mut self, rip: usize) {
+        self.0.rip = rip;
+    }
+}
 
 /// Only from kernel
 #[no_mangle]
 extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
     if CpuException::is_cpu_exception(f.trap_num as u16) {
+        #[cfg(feature = "intel_tdx")]
+        if f.trap_num as u16 == 20 {
+            let ve_info = tdg_vp_veinfo_get().expect("#VE handler: fail to get VE info\n");
+            let mut ve_f = VeTrapFrame(f);
+            virtual_exception_handler(&mut ve_f, &ve_info);
+        }
+        #[cfg(not(feature = "intel_tdx"))]
         panic!("cannot handle kernel cpu fault now, information:{:#x?}", f);
+    } else {
+        call_irq_callback_functions(f);
     }
-    call_irq_callback_functions(f);
 }
 
 pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {

--- a/framework/libs/tdx-guest/.gitignore
+++ b/framework/libs/tdx-guest/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/framework/libs/tdx-guest/Cargo.toml
+++ b/framework/libs/tdx-guest/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tdx-guest"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+x86_64 = "0.14.10"
+bitflags = "1.3"
+raw-cpuid = "10"
+lazy_static = "1.4.0"
+

--- a/framework/libs/tdx-guest/src/asm/mod.rs
+++ b/framework/libs/tdx-guest/src/asm/mod.rs
@@ -1,0 +1,11 @@
+use crate::{tdcall::TdcallArgs, tdvmcall::TdVmcallArgs};
+use core::arch::global_asm;
+
+global_asm!(include_str!("tdcall.asm"));
+global_asm!(include_str!("tdvmcall.asm"));
+
+// TODO: Use sysv64
+extern "win64" {
+    pub(crate) fn asm_td_call(args: *mut TdcallArgs) -> u64;
+    pub(crate) fn asm_td_vmcall(args: *mut TdVmcallArgs) -> u64;
+}

--- a/framework/libs/tdx-guest/src/asm/tdcall.asm
+++ b/framework/libs/tdx-guest/src/asm/tdcall.asm
@@ -1,0 +1,78 @@
+.section .text
+
+# Arguments offsets in TdVmcallArgs struct
+.equ TDCALL_ARG_RAX, 0x0
+.equ TDCALL_ARG_RCX, 0x8
+.equ TDCALL_ARG_RDX, 0x10
+.equ TDCALL_ARG_R8,  0x18
+.equ TDCALL_ARG_R9,  0x20
+.equ TDCALL_ARG_R10, 0x28
+.equ TDCALL_ARG_R11, 0x30
+.equ TDCALL_ARG_R12, 0x38
+.equ TDCALL_ARG_R13, 0x40
+
+# asm_td_call -> u64 (
+#   args: *mut TdcallArgs,  //rcx
+# )
+.global asm_td_call
+asm_td_call:
+        endbr64
+        # Save the registers accroding to MS x64 calling convention
+        push rbp
+        mov rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+        # Use RDI to save RCX value
+        mov rdi, rcx
+
+        # Test if input pointer is valid
+        test rdi, rdi
+        jz td_call_exit
+
+        # Copy the input operands from memory to registers 
+        mov rax, [rdi + TDCALL_ARG_RAX]
+        mov rcx, [rdi + TDCALL_ARG_RCX]
+        mov rdx, [rdi + TDCALL_ARG_RDX]
+        mov r8,  [rdi + TDCALL_ARG_R8]
+        mov r9,  [rdi + TDCALL_ARG_R9]
+        mov r10, [rdi + TDCALL_ARG_R10]
+        mov r11, [rdi + TDCALL_ARG_R11]
+        mov r12, [rdi + TDCALL_ARG_R12]
+        mov r13, [rdi + TDCALL_ARG_R13]
+
+        # tdcall
+        .byte 0x66,0x0f,0x01,0xcc
+
+        # Exit if tdcall reports failure.
+        test rax, rax
+        jnz td_call_exit
+
+        # Copy the output operands from registers to the struct
+        mov [rdi + TDCALL_ARG_RAX], rax
+        mov [rdi + TDCALL_ARG_RCX], rcx
+        mov [rdi + TDCALL_ARG_RDX], rdx
+        mov [rdi + TDCALL_ARG_R8],  r8
+        mov [rdi + TDCALL_ARG_R9],  r9
+        mov [rdi + TDCALL_ARG_R10], r10
+        mov [rdi + TDCALL_ARG_R11], r11
+        mov [rdi + TDCALL_ARG_R12], r12
+        mov [rdi + TDCALL_ARG_R13], r13
+
+td_call_exit:
+        # Pop out saved registers from stack
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+        ret

--- a/framework/libs/tdx-guest/src/asm/tdvmcall.asm
+++ b/framework/libs/tdx-guest/src/asm/tdvmcall.asm
@@ -1,0 +1,96 @@
+.section .text
+
+# Mask used to control which part of the guest TD GPR and XMM
+# state is exposed to the VMM. A bit value of 1 indicates the
+# corresponding register is passed to VMM. Refer to TDX Module
+# ABI specification section TDG.VP.VMCALL for detail.
+# Here we expose R10 - R15 to VMM in td_vm_call()
+.equ TDVMCALL_EXPOSE_REGS_MASK, 0xfc00
+
+# TDG.VP.VMCALL leaf number
+.equ TDVMCALL, 0
+
+# Arguments offsets in TdVmcallArgs struct
+.equ VMCALL_ARG_R10, 0x0
+.equ VMCALL_ARG_R11, 0x8
+.equ VMCALL_ARG_R12, 0x10
+.equ VMCALL_ARG_R13, 0x18
+.equ VMCALL_ARG_R14, 0x20
+.equ VMCALL_ARG_R15, 0x28
+
+# asm_td_vmcall -> u64 (
+#   args: *mut TdVmcallArgs,
+# )
+.global asm_td_vmcall
+asm_td_vmcall:
+        endbr64
+        # Save the registers accroding to MS x64 calling convention
+        push rbp
+        mov rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+        # Use RDI to save RCX value
+        mov rdi, rcx
+
+        # Test if input pointer is valid
+        test rdi, rdi
+        jz vmcall_exit
+
+        # Copy the input operands from memory to registers
+        mov r10, [rdi + VMCALL_ARG_R10]
+        mov r11, [rdi + VMCALL_ARG_R11]
+        mov r12, [rdi + VMCALL_ARG_R12]
+        mov r13, [rdi + VMCALL_ARG_R13]
+        mov r14, [rdi + VMCALL_ARG_R14]
+        mov r15, [rdi + VMCALL_ARG_R15]
+
+        # Set TDCALL leaf number
+        mov rax, TDVMCALL
+
+        # Set exposed register mask
+        mov ecx, TDVMCALL_EXPOSE_REGS_MASK
+
+        # TDCALL
+       .byte 0x66,0x0f,0x01,0xcc
+
+        # RAX should always be zero for TDVMCALL, panic if it is not.
+        test rax, rax
+        jnz vmcall_panic
+
+        # Copy the output operands from registers to the struct
+        mov [rdi + VMCALL_ARG_R10], r10
+        mov [rdi + VMCALL_ARG_R11], r11
+        mov [rdi + VMCALL_ARG_R12], r12
+        mov [rdi + VMCALL_ARG_R13], r13
+        mov [rdi + VMCALL_ARG_R14], r14
+        mov [rdi + VMCALL_ARG_R15], r15
+
+        mov rax, r10
+
+vmcall_exit:
+        # Clean the registers that are exposed to VMM to
+        # protect against speculative attack, others will
+        # be restored to the values saved in stack
+        xor r10, r10
+        xor r11, r11
+
+        # Pop out saved registers from stack
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+        ret
+
+vmcall_panic:
+        ud2

--- a/framework/libs/tdx-guest/src/lib.rs
+++ b/framework/libs/tdx-guest/src/lib.rs
@@ -1,0 +1,82 @@
+#![no_std]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+extern crate alloc;
+
+pub mod asm;
+pub mod tdcall;
+pub mod tdvmcall;
+
+pub use self::tdcall::{deadloop, tdg_vp_veinfo_get, TdxVirtualExceptionType};
+pub use self::tdvmcall::print;
+
+use alloc::string::{String, ToString};
+use raw_cpuid::{native_cpuid::cpuid_count, CpuIdResult};
+use tdcall::{tdg_vp_vmcall, InitError, TdgVeInfo, TdgVpInfo};
+
+const TDX_CPUID_LEAF_ID: u64 = 0x21;
+
+pub fn tdx_early_init() -> Result<TdgVpInfo, InitError> {
+    match is_tdx_guest() {
+        Ok(_) => Ok(tdcall::tdg_vp_info()?),
+        Err(err) => Err(err),
+    }
+}
+
+fn is_tdx_guest() -> Result<(), InitError> {
+    let cpuid_leaf = cpuid_count(0, 0).eax as u64;
+    if cpuid_leaf < TDX_CPUID_LEAF_ID {
+        return Err(InitError::TdxCpuLeafIdError);
+    }
+    let cpuid_result: CpuIdResult = cpuid_count(TDX_CPUID_LEAF_ID as u32, 0);
+    if convert_ascii(cpuid_result.ebx) == "Inte"
+        && convert_ascii(cpuid_result.edx) == "lTDX"
+        && convert_ascii(cpuid_result.ecx) == "    "
+    {
+        Ok(())
+    } else {
+        Err(InitError::TdxVendorIdError)
+    }
+}
+
+fn convert_ascii(reg: u32) -> String {
+    let bytes = [
+        (reg & 0xFF) as u8,
+        ((reg >> 8) & 0xFF) as u8,
+        ((reg >> 16) & 0xFF) as u8,
+        ((reg >> 24) & 0xFF) as u8,
+    ];
+    String::from_utf8_lossy(&bytes).to_string()
+}
+
+pub trait TdxTrapFrame {
+    fn rax(&self) -> usize;
+    fn set_rax(&mut self, rax: usize);
+    fn rbx(&self) -> usize;
+    fn set_rbx(&mut self, rbx: usize);
+    fn rcx(&self) -> usize;
+    fn set_rcx(&mut self, rcx: usize);
+    fn rdx(&self) -> usize;
+    fn set_rdx(&mut self, rdx: usize);
+    fn rsi(&self) -> usize;
+    fn set_rsi(&mut self, rsi: usize);
+    fn rdi(&self) -> usize;
+    fn set_rdi(&mut self, rdi: usize);
+    fn rip(&self) -> usize;
+    fn set_rip(&mut self, rip: usize);
+}
+
+pub fn virtual_exception_handler(trapframe: &mut impl TdxTrapFrame, ve_info: &TdgVeInfo) {
+    match ve_info.exit_reason.into() {
+        TdxVirtualExceptionType::Hlt
+        | TdxVirtualExceptionType::Io
+        | TdxVirtualExceptionType::MsrRead
+        | TdxVirtualExceptionType::MsrWrite
+        | TdxVirtualExceptionType::CpuId => tdg_vp_vmcall(trapframe, ve_info),
+        TdxVirtualExceptionType::Other => panic!("Unknown TDX vitrual exception type"),
+        _ => return,
+    };
+    trapframe.set_rip(trapframe.rip() + ve_info.exit_instruction_length as usize);
+}
+

--- a/framework/libs/tdx-guest/src/tdcall.rs
+++ b/framework/libs/tdx-guest/src/tdcall.rs
@@ -1,0 +1,596 @@
+use super::tdvmcall::*;
+use crate::{asm::asm_td_call, serial_println, TdxTrapFrame};
+use bitflags::bitflags;
+use core::fmt;
+
+const TDCALL_VP_INFO: u64 = 1;
+const TDCALL_MR_RTMR_EXTEND: u64 = 2;
+const TDCALL_VP_VEINFO_GET: u64 = 3;
+const TDCALL_MR_REPORT: u64 = 4;
+const TDCALL_VP_CPUIDVE_SET: u64 = 5;
+const TDCALL_MEM_PAGE_ACCEPT: u64 = 6;
+const TDCALL_VM_RD: u64 = 7;
+const TDCALL_VM_WR: u64 = 8;
+const TDCALL_MR_VERIFYREPORT: u64 = 22;
+const TDCALL_MEM_PAGE_ATTR_RD: u64 = 23;
+const TDCALL_MEM_PAGE_ATTR_WR: u64 = 24;
+
+bitflags! {
+    pub struct Attributes: u64 {
+        /// Guest TD runs in off-TD debug mode.
+        /// Its VCPU state and private memory are accessible by the host VMM.
+        const DEBUG = 1;
+        /// TD is migratable (using a Migration TD).
+        const MIGRATABLE = 1 << 29;
+        /// TD is allowed to use Supervisor Protection Keys.
+        const PKS = 1 << 30;
+        /// TD is allowed to use Key Locker. Must be 0.
+        const KL = 1 << 31;
+        /// TD is allowed to use Perfmon and PERF_METRICS capabilities.
+        const PERFMON = 1 << 63;
+    }
+}
+
+bitflags! {
+    /// Controls whether CPUID executed by the guest TD will cause #VE unconditionally.
+    struct CpuidveFlag: u64 {
+        /// Flags that when CPL is 0, a CPUID executed
+        /// by the guest TD will cause a #VE unconditionally.
+        const SUPERVISOR = 1;
+        /// Flags that when CPL > 0, a CPUID executed
+        /// by the guest TD will cause a #VE unconditionally.
+        const USER = 1 << 1;
+    }
+}
+
+bitflags! {
+    /// GPA Attributes (Single VM) Definition.
+    pub struct GpaAttr: u16 {
+        /// Read.
+        const R = 1;
+        /// Write.
+        const W = 1 << 1;
+        /// Execute (Supervisor).
+        const XS = 1 << 2;
+        /// Execute (User).
+        const XU = 1 << 3;
+        /// Verify Guest Paging.
+        const VGP = 1 << 4;
+        /// Paging-Write Access.
+        const PWA = 1 << 5;
+        /// Supervisor Shadow Stack.
+        const SSS = 1 << 6;
+        /// Suppress #VE.
+        const SVE = 1 << 7;
+        /// Indicates that the other bits are valid.
+        /// If its value is 0, other fields are reserved and must be 0.
+        const VALID = 1 << 15;
+    }
+}
+pub struct PageAttr {
+    /// Actual GPA mapping of the page.
+    gpa_mapping: u64,
+    /// Guest-visible page attributes.
+    gpa_attr: GpaAttrAll,
+}
+
+/// GPA Attributes (all VMs) Definition.
+pub struct GpaAttrAll {
+    /// L1 GPA attributes.
+    l1_attr: GpaAttr,
+    /// GPA attributes for L2 VM #1.
+    vm1_attr: GpaAttr,
+    /// GPA attributes for L2 VM #2.
+    vm2_attr: GpaAttr,
+    /// GPA attributes for L2 VM #3.
+    vm3_attr: GpaAttr,
+}
+
+impl From<u64> for GpaAttrAll {
+    fn from(val: u64) -> Self {
+        GpaAttrAll {
+            l1_attr: GpaAttr::from_bits_truncate((val & 0xFFFF) as u16),
+            vm1_attr: GpaAttr::from_bits_truncate(((val >> 16) & 0xFFFF) as u16),
+            vm2_attr: GpaAttr::from_bits_truncate(((val >> 32) & 0xFFFF) as u16),
+            vm3_attr: GpaAttr::from_bits_truncate(((val >> 48) & 0xFFFF) as u16),
+        }
+    }
+}
+
+impl From<GpaAttrAll> for u64 {
+    fn from(s: GpaAttrAll) -> Self {
+        let field1 = s.l1_attr.bits() as u64;
+        let field2 = (s.vm1_attr.bits() as u64) << 16;
+        let field3 = (s.vm2_attr.bits() as u64) << 32;
+        let field4 = (s.vm3_attr.bits() as u64) << 48;
+        field4 | field3 | field2 | field1
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TdReport {
+    /// REPORTMACSTRUCT for the TDG.MR.REPORT.
+    pub report_mac: ReportMac,
+    /// Additional attestable elements in the TD’s TCB are not reflected in the
+    /// REPORTMACSTRUCT.CPUSVN – includes the Intel TDX module measurements.
+    pub tee_tcb_info: [u8; 239],
+    pub reserved: [u8; 17],
+    /// TD’s attestable properties.
+    pub tdinfo: TdInfo,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ReportMac {
+    /// Type Header Structure.
+    pub report_type: ReportType,
+    pub cpu_svn: [u8; 16],
+    /// SHA384 of TEE_TCB_INFO for TEEs implemented using Intel TDX.
+    pub tee_tcb_info_hash: [u8; 48],
+    /// SHA384 of TEE_INFO: a TEE-specific info structure (TDINFO_STRUCT or SGXINFO)
+    /// or 0 if no TEE is represented.
+    pub tee_info_hash: [u8; 48],
+    /// A set of data used for communication between the caller and the target.
+    pub report_data: [u8; 64],
+    pub reserved: [u8; 32],
+    /// The MAC over the REPORTMACSTRUCT with model-specific MAC.
+    pub mac: [u8; 32],
+}
+
+#[derive(Debug)]
+pub enum TeeType {
+    SGX,
+    TDX,
+}
+
+/// REPORTTYPE indicates the reported Trusted Execution Environment (TEE) type,
+/// sub-type and version.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ReportType {
+    /// Trusted Execution Environment (TEE) Type. 0x00: SGX, 0x81: TDX.
+    pub tee_type: TeeType,
+    /// TYPE-specific subtype.
+    pub sub_type: u8,
+    /// TYPE-specific version.
+    pub version: u8,
+    pub reserved: u8,
+}
+
+/// TDINFO_STRUCT is defined as the TDX-specific TEE_INFO part of TDG.MR.REPORT.
+/// It contains the measurements and initial configuration of the TD that was
+/// locked at initialization and a set of measurement registers that are run-time
+/// extendable. These values are copied from the TDCS by the TDG.MR.REPORT function.
+/// Refer to the [TDX Module Base Spec] for additional details.
+#[repr(C)]
+#[derive(Debug)]
+pub struct TdInfo {
+    /// TD’s ATTRIBUTES.
+    pub attributes: u64,
+    /// TD’s XFAM.
+    pub xfam: u64,
+    /// Measurement of the initial contents of the TD.
+    pub mrtd: [u8; 48],
+    /// Software-defined ID for non-owner-defined configuration of the
+    /// guest TD – e.g., run-time or OS configuration.
+    pub mr_config_id: [u8; 48],
+    /// Software-defined ID for the guest TD’s owner.
+    pub mr_owner: [u8; 48],
+    /// Software-defined ID for owner-defined configuration of the
+    /// guest TD – e.g., specific to the workload rather than the run-time or OS.
+    pub mr_owner_config: [u8; 48],
+    /// Array of NUM_RTMRS (4) run-time extendable measurement registers.
+    pub rtmr0: [u8; 48],
+    pub rtmr1: [u8; 48],
+    pub rtmr2: [u8; 48],
+    pub rtmr3: [u8; 48],
+    /// If is one or more bound or pre-bound service TDs, SERVTD_HASH is the SHA384 hash of the
+    /// TDINFO_STRUCTs of those service TDs bound. Else, SERVTD_HASH is 0.
+    pub servtd_hash: [u8; 48],
+    pub reserved: [u8; 64],
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TdgVeInfo {
+    pub exit_reason: u32,
+    /// the 64-bit value that would have been saved into the VMCS as an exit qualification
+    /// if a legacy VM exit had occurred instead of the virtualization exception.
+    pub exit_qualification: u64,
+    /// the 64-bit value that would have been saved into the VMCS as a guestlinear address
+    /// if a legacy VM exit had occurred instead of the virtualization exception.
+    pub guest_linear_address: u64,
+    /// the 64-bit value that would have been saved into the VMCS as a guestphysical address
+    /// if a legacy VM exit had occurred instead of the virtualization exception.
+    pub guest_physical_address: u64,
+    /// The 32-bit value that would have been saved into the VMCS as VM-exit instruction
+    /// length if a legacy VM exit had occurred instead of the virtualization exception.
+    pub exit_instruction_length: u32,
+    /// The 32-bit value that would have been saved into the VMCS as VM-exit instruction
+    /// information if a legacy VM exit had occurred instead of the virtualization exception.
+    pub exit_instruction_info: u32,
+}
+
+#[derive(Debug)]
+pub enum Gpaw {
+    Bit48,
+    Bit52,
+}
+
+impl From<u64> for Gpaw {
+    fn from(val: u64) -> Self {
+        match val {
+            48 => Self::Bit48,
+            52 => Self::Bit52,
+            _ => panic!("Invalid gpaw"),
+        }
+    }
+}
+
+impl From<Gpaw> for u64 {
+    fn from(s: Gpaw) -> Self {
+        match s {
+            Gpaw::Bit48 => 48,
+            Gpaw::Bit52 => 52,
+        }
+    }
+}
+
+impl fmt::Display for Gpaw {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Gpaw::Bit48 => write!(f, "48-bit"),
+            Gpaw::Bit52 => write!(f, "52-bit"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TdgVpInfo {
+    /// The effective GPA width (in bits) for this TD (do not confuse with MAXPA).
+    /// SHARED bit is at GPA bit GPAW-1.
+    ///
+    /// Only GPAW values 48 and 52 are possible.
+    pub gpaw: Gpaw,
+    /// The TD's ATTRIBUTES (provided as input to TDH.MNG.INIT)
+    pub attributes: Attributes,
+    pub num_vcpus: u32,
+    pub max_vcpus: u32,
+    pub vcpu_index: u32,
+    /// Indicates that the TDG.SYS.RD/RDM/RDCALL function are avaliable.
+    pub sys_rd: u32,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TdCallError {
+    /// There is no valid #VE information.
+    TdxNoValidVeInfo,
+    /// Operand is invalid.
+    TdxOperandInvalid,
+    /// The operand is busy (e.g., it is locked in Exclusive mode).
+    TdxOperandBusy,
+    /// Page has already been accepted.
+    TdxPageAlreadyAccepted,
+    /// Requested page size does not match the current GPA mapping size.
+    TdxPageSizeMismatch,
+    Other,
+}
+
+impl From<u64> for TdCallError {
+    fn from(val: u64) -> Self {
+        match val {
+            0xC000_0704 => Self::TdxNoValidVeInfo,
+            0xC000_0100 => Self::TdxOperandInvalid,
+            0x8000_0200 => Self::TdxOperandBusy,
+            0x0000_0B0A => Self::TdxPageAlreadyAccepted,
+            0xC000_0B0B => Self::TdxPageSizeMismatch,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct TdcallArgs {
+    rax: u64,
+    rcx: u64,
+    rdx: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+}
+
+pub enum TdxVirtualExceptionType {
+    Hlt,
+    Io,
+    MsrRead,
+    MsrWrite,
+    CpuId,
+    VmCall,
+    Mwait,
+    Monitor,
+    Wbinvd,
+    Rdpmc,
+    Other,
+}
+
+impl From<u32> for TdxVirtualExceptionType {
+    fn from(val: u32) -> Self {
+        match val {
+            10 => Self::CpuId,
+            12 => Self::Hlt,
+            15 => Self::Rdpmc,
+            18 => Self::VmCall,
+            30 => Self::Io,
+            31 => Self::MsrRead,
+            32 => Self::MsrWrite,
+            36 => Self::Mwait,
+            39 => Self::Monitor,
+            54 => Self::Wbinvd,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InitError {
+    TdxVendorIdError,
+    TdxCpuLeafIdError,
+    TdxGetVpInfoError(TdCallError),
+}
+
+impl From<TdCallError> for InitError {
+    fn from(error: TdCallError) -> Self {
+        InitError::TdxGetVpInfoError(error)
+    }
+}
+
+/// Get guest TD execution environment information.
+pub(crate) fn tdg_vp_info() -> Result<TdgVpInfo, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_VP_INFO,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => {
+            let td_info = TdgVpInfo {
+                gpaw: Gpaw::from(args.rcx),
+                attributes: Attributes::from_bits_truncate(args.rdx),
+                num_vcpus: args.r8 as u32,
+                max_vcpus: (args.r8 >> 32) as u32,
+                vcpu_index: args.r9 as u32,
+                sys_rd: args.r10 as u32,
+            };
+            Ok(td_info)
+        }
+        Err(res) => Err(res),
+    }
+}
+
+/// Get Virtualization Exception Information for the recent #VE exception.
+pub fn tdg_vp_veinfo_get() -> Result<TdgVeInfo, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_VP_VEINFO_GET,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => {
+            let ve_info = TdgVeInfo {
+                exit_reason: args.rcx as u32,
+                exit_qualification: args.rdx,
+                guest_linear_address: args.r8,
+                guest_physical_address: args.r9,
+                exit_instruction_length: args.r10 as u32,
+                exit_instruction_info: (args.r10 >> 32) as u32,
+            };
+            Ok(ve_info)
+        }
+        Err(res) => Err(res),
+    }
+}
+
+/// Perform a TD Exit to the host VMM.
+pub(crate) fn tdg_vp_vmcall(trapframe: &mut impl TdxTrapFrame, ve_info: &TdgVeInfo) {
+    match ve_info.exit_reason.into() {
+        TdxVirtualExceptionType::Hlt => {
+            serial_println!("Ready to halt");
+            tdvmcall_hlt();
+        }
+        TdxVirtualExceptionType::Io => {
+            if !tdvmcall_io(trapframe, ve_info) {
+                serial_println!("Handle tdx ioexit errors, ready to halt");
+                tdvmcall_hlt();
+            }
+        }
+        TdxVirtualExceptionType::MsrRead => {
+            let msr = tdvmcall_rdmsr(trapframe.rcx() as u32).unwrap();
+            trapframe.set_rax((msr as u32 & u32::MAX) as usize);
+            trapframe.set_rdx(((msr >> 32) as u32 & u32::MAX) as usize);
+        }
+        TdxVirtualExceptionType::MsrWrite => {
+            let data = trapframe.rax() as u64 | ((trapframe.rdx() as u64) << 32);
+            tdvmcall_wrmsr(trapframe.rcx() as u32, data).unwrap();
+        }
+        TdxVirtualExceptionType::CpuId => {
+            let cpuid = tdvmcall_cpuid(trapframe.rax() as u32, trapframe.rcx() as u32).unwrap();
+            let mask = 0xFFFF_FFFF_0000_0000_usize;
+            trapframe.set_rax((trapframe.rax() & mask) | cpuid.eax);
+            trapframe.set_rbx((trapframe.rbx() & mask) | cpuid.ebx);
+            trapframe.set_rcx((trapframe.rcx() & mask) | cpuid.ecx);
+            trapframe.set_rdx((trapframe.rdx() & mask) | cpuid.edx);
+        }
+        _ => {
+            unreachable!()
+        }
+    };
+}
+
+#[allow(dead_code)]
+pub fn deadloop() {
+    #[allow(clippy::empty_loop)]
+    loop {
+        x86_64::instructions::interrupts::enable();
+        x86_64::instructions::hlt();
+    }
+}
+
+fn td_call(args: &mut TdcallArgs) -> Result<(), TdCallError> {
+    let td_call_result = unsafe { asm_td_call(args) };
+    if td_call_result == 0 {
+        Ok(())
+    } else {
+        Err(td_call_result.into())
+    }
+}
+
+/// Extend a TDCS.RTMR measurement register.
+fn tdg_mr_rtmr_extend() -> Result<(), TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MR_RTMR_EXTEND,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+/// TDG.MR.REPORT creates a TDREPORT_STRUCT structure that contains the measurements/configuration
+/// information of the guest TD that called the function, measurements/configuration information
+/// of the Intel TDX module and a REPORTMACSTRUCT.
+fn tdg_mr_report(report_addr: u64, data_addr: u64) -> Result<(), TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MR_REPORT,
+        rcx: report_addr,
+        rdx: data_addr,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+/// Verify a cryptographic REPORTMACSTRUCT that describes the contents of a TD,
+/// to determine that it was created on the current TEE on the current platform.
+fn tdg_mr_verifyreport(report_mac_addr: u64) -> Result<(), TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MR_VERIFYREPORT,
+        rcx: report_mac_addr,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+/// Accept a pending private page and initialize it to all-0 using the TD ephemeral private key.
+fn tdg_mem_page_accept(sept_level: u64, addr: u64) -> Result<(), TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MEM_PAGE_ACCEPT,
+        rcx: sept_level | (addr << 12),
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+/// Read the GPA mapping and attributes of a TD private page.
+fn tdg_mem_page_attr_rd(phy_addr: u64) -> Result<PageAttr, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MEM_PAGE_ATTR_RD,
+        rcx: phy_addr,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => {
+            let page_attr = PageAttr {
+                gpa_mapping: args.rcx,
+                gpa_attr: GpaAttrAll::from(args.rdx),
+            };
+            Ok(page_attr)
+        }
+        Err(res) => Err(res),
+    }
+}
+
+/// Write the attributes of a private page. Create or remove L2 page aliases as required.
+fn tdg_mem_page_attr_wr(page_attr: PageAttr, attr_flags: u64) -> Result<PageAttr, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_MEM_PAGE_ATTR_WR,
+        rcx: page_attr.gpa_mapping,
+        rdx: u64::from(page_attr.gpa_attr),
+        r8: attr_flags,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => {
+            let page_attr = PageAttr {
+                gpa_mapping: args.rcx,
+                gpa_attr: GpaAttrAll::from(args.rdx),
+            };
+            Ok(page_attr)
+        }
+        Err(res) => Err(res),
+    }
+}
+
+/// Read a TD-scope metadata field (control structure field) of a TD.
+fn tdg_vm_rd(field_identifier: u64) -> Result<u64, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_VM_RD,
+        rdx: field_identifier,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(args.r8),
+        Err(res) => Err(res),
+    }
+}
+
+/// Write a TD-scope metadata field (control structure field) of a TD.
+///
+/// - data: data to write to the field
+///
+/// - write_mask: a 64b write mask to indicate which bits of the value
+/// in R8 are to be written to the field.
+///
+/// It returns previous contents of the field.
+fn tdg_vm_wr(field_identifier: u64, data: u64, write_mask: u64) -> Result<u64, TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_VM_WR,
+        rdx: field_identifier,
+        r8: data,
+        r9: write_mask,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(args.r8),
+        Err(res) => Err(res),
+    }
+}
+
+/// TDG.VP.CPUIDVE.SET controls unconditional #VE on CPUID execution by the guest TD.
+///
+/// Note: TDG.VP.CPUIDVE.SET is provided for backward compatibility.
+///
+/// The guest TD may control the same settings by writing to the
+/// VCPU-scope metadata fields CPUID_SUPERVISOR_VE and CPUID_USER_VE using TDG.VP.WR.
+fn tdg_vp_cpuidve_set(cpuidve_flag: u64) -> Result<(), TdCallError> {
+    let mut args = TdcallArgs {
+        rax: TDCALL_VP_CPUIDVE_SET,
+        rcx: cpuidve_flag,
+        ..Default::default()
+    };
+    match td_call(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}

--- a/framework/libs/tdx-guest/src/tdvmcall.rs
+++ b/framework/libs/tdx-guest/src/tdvmcall.rs
@@ -1,0 +1,340 @@
+extern crate alloc;
+
+use crate::{asm::asm_td_vmcall, tdcall::TdgVeInfo, TdxTrapFrame};
+use alloc::fmt;
+use bitflags::bitflags;
+use core::fmt::Write;
+use x86_64::{
+    registers::rflags::{self, RFlags},
+    structures::port::PortRead,
+};
+
+const TDVMCALL_CPUID: u64 = 0x0000a;
+const TDVMCALL_HLT: u64 = 0x0000c;
+const TDVMCALL_IO: u64 = 0x0001e;
+const TDVMCALL_RDMSR: u64 = 0x0001f;
+const TDVMCALL_WRMSR: u64 = 0x00020;
+const TDVMCALL_REQUEST_MMIO: u64 = 0x00030;
+const TDVMCALL_WBINVD: u64 = 0x00036;
+const TDVMCALL_PCONFIG: u64 = 0x00041;
+const TDVMCALL_MAPGPA: u64 = 0x10001;
+
+const SERIAL_IO_PORT: u16 = 0x3F8;
+const SERIAL_LINE_STS: u16 = 0x3FD;
+const IO_READ: u64 = 0;
+const IO_WRITE: u64 = 1;
+
+#[derive(Debug, PartialEq)]
+pub enum TdVmcallError {
+    /// TDCALL[TDG.VP.VMCALL] sub-function invocation must be retried.
+    TdxRetry,
+    /// Invalid operand to TDG.VP.VMCALL sub-function.
+    TdxInvalidOperand,
+    /// GPA already mapped.
+    TdxGpaInuse,
+    /// Operand (address) aligned error.
+    TdxAlignError,
+    Other,
+}
+
+impl From<u64> for TdVmcallError {
+    fn from(val: u64) -> Self {
+        match val {
+            0x1 => Self::TdxRetry,
+            0x8000_0000_0000_0000 => Self::TdxInvalidOperand,
+            0x8000_0000_0000_0001 => Self::TdxGpaInuse,
+            0x8000_0000_0000_0002 => Self::TdxAlignError,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct TdVmcallArgs {
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub(crate) struct CpuIdInfo {
+    pub eax: usize,
+    pub ebx: usize,
+    pub ecx: usize,
+    pub edx: usize,
+}
+
+enum Direction {
+    In,
+    Out,
+}
+
+enum Operand {
+    Dx,
+    Immediate,
+}
+
+pub(crate) fn tdvmcall_cpuid(eax: u32, ecx: u32) -> Result<CpuIdInfo, TdVmcallError> {
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_CPUID,
+        r12: eax as u64,
+        r13: ecx as u64,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(CpuIdInfo {
+            eax: args.r12 as usize,
+            ebx: args.r13 as usize,
+            ecx: args.r14 as usize,
+            edx: args.r15 as usize,
+        }),
+        Err(res) => Err(res),
+    }
+}
+
+pub(crate) fn tdvmcall_hlt() {
+    let interrupt_blocked = !rflags::read().contains(RFlags::INTERRUPT_FLAG);
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_HLT,
+        r12: interrupt_blocked as u64,
+        ..Default::default()
+    };
+    let _ = td_vmcall(&mut args);
+}
+
+pub(crate) fn tdvmcall_rdmsr(index: u32) -> Result<u64, TdVmcallError> {
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_RDMSR,
+        r12: index as u64,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(args.r11),
+        Err(res) => Err(res),
+    }
+}
+
+pub(crate) fn tdvmcall_wrmsr(index: u32, value: u64) -> Result<(), TdVmcallError> {
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_WRMSR,
+        r12: index as u64,
+        r13: value,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+/// Used to help perform WBINVD operation.
+pub(crate) fn tdvmcall_wbinvd(wbinvd: u64) -> Result<(), TdVmcallError> {
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_WBINVD,
+        r12: wbinvd,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+pub(crate) fn tdvmcall_read_mmio(size: u64, mmio_addr: u64) -> Result<u64, TdVmcallError> {
+    match size {
+        1 | 2 | 4 | 8 => {}
+        _ => return Err(TdVmcallError::TdxInvalidOperand),
+    }
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_REQUEST_MMIO,
+        r12: size,
+        r13: 0,
+        r14: mmio_addr,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(args.r11),
+        Err(res) => Err(res),
+    }
+}
+
+pub(crate) fn tdvmcall_write_mmio(
+    size: u64,
+    mmio_addr: u64,
+    data: u64,
+) -> Result<(), TdVmcallError> {
+    match size {
+        1 | 2 | 4 | 8 => {}
+        _ => {
+            return Err(TdVmcallError::TdxInvalidOperand);
+        }
+    }
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_REQUEST_MMIO,
+        r12: size,
+        r13: 1,
+        r14: mmio_addr,
+        r15: data,
+        ..Default::default()
+    };
+    match td_vmcall(&mut args) {
+        Ok(()) => Ok(()),
+        Err(res) => Err(res),
+    }
+}
+
+pub(crate) fn tdvmcall_io(trapframe: &mut impl TdxTrapFrame, ve_info: &TdgVeInfo) -> bool {
+    let size = match ve_info.exit_qualification & 0x3 {
+        0 => 1,
+        1 => 2,
+        3 => 4,
+        _ => panic!("Invalid size value"),
+    };
+    let direction = if (ve_info.exit_qualification >> 3) & 0x1 == 0 {
+        Direction::Out
+    } else {
+        Direction::In
+    };
+    let string = (ve_info.exit_qualification >> 4) & 0x1 == 1;
+    let repeat = (ve_info.exit_qualification >> 5) & 0x1 == 1;
+    let operand = if (ve_info.exit_qualification >> 6) & 0x1 == 0 {
+        Operand::Dx
+    } else {
+        Operand::Immediate
+    };
+    let port = (ve_info.exit_qualification >> 16) as u16;
+
+    match direction {
+        Direction::In => {
+            trapframe.set_rax(io_read(size, port).unwrap() as usize);
+        }
+        Direction::Out => {
+            io_write(size, port, trapframe.rax() as u32).unwrap();
+        }
+    };
+    true
+}
+
+macro_rules! tdvmcall_io_read {
+    ($port:expr, $ty:ty) => {{
+        let mut args = TdVmcallArgs {
+            r11: TDVMCALL_IO,
+            r12: core::mem::size_of::<$ty>() as u64,
+            r13: IO_READ,
+            r14: $port as u64,
+            ..Default::default()
+        };
+        match td_vmcall(&mut args) {
+            Ok(()) => Ok(args.r11 as u32),
+            Err(res) => Err(res),
+        }
+    }};
+}
+
+fn io_read(size: usize, port: u16) -> Result<u32, TdVmcallError> {
+    match size {
+        1 => tdvmcall_io_read!(port, u8),
+        2 => tdvmcall_io_read!(port, u16),
+        4 => tdvmcall_io_read!(port, u32),
+        _ => unreachable!(),
+    }
+}
+
+macro_rules! tdvmcall_io_write {
+    ($port:expr, $byte:expr, $size:expr) => {{
+        let mut args = TdVmcallArgs {
+            r11: TDVMCALL_IO,
+            r12: core::mem::size_of_val(&$byte) as u64,
+            r13: IO_WRITE,
+            r14: $port as u64,
+            r15: $byte as u64,
+            ..Default::default()
+        };
+        match td_vmcall(&mut args) {
+            Ok(()) => Ok(()),
+            Err(res) => Err(res),
+        }
+    }};
+}
+
+fn io_write(size: usize, port: u16, byte: u32) -> Result<(), TdVmcallError> {
+    match size {
+        1 => tdvmcall_io_write!(port, byte, u8),
+        2 => tdvmcall_io_write!(port, byte, u16),
+        4 => tdvmcall_io_write!(port, byte, u32),
+        _ => unreachable!(),
+    }
+}
+
+fn td_vmcall(args: &mut TdVmcallArgs) -> Result<(), TdVmcallError> {
+    let td_vmcall_result = unsafe { asm_td_vmcall(args) };
+    if td_vmcall_result == 0 {
+        Ok(())
+    } else {
+        Err(td_vmcall_result.into())
+    }
+}
+
+bitflags! {
+  struct LineSts: u8 {
+    const INPUT_FULL = 1;
+    const OUTPUT_EMPTY = 1 << 5;
+  }
+}
+
+fn line_sts() -> LineSts {
+    LineSts::from_bits_truncate(unsafe { PortRead::read_from_port(SERIAL_LINE_STS) })
+}
+
+struct Serial;
+
+impl Write for Serial {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for &c in s.as_bytes() {
+            serial_write_byte(c);
+        }
+        Ok(())
+    }
+}
+
+pub fn print(args: fmt::Arguments) {
+    Serial
+        .write_fmt(args)
+        .expect("Failed to write to serial port");
+}
+
+fn serial_write_byte(byte: u8) {
+    match byte {
+        8 | 0x7F => {
+            while !line_sts().contains(LineSts::OUTPUT_EMPTY) {}
+            tdvmcall_io_write!(SERIAL_IO_PORT, 8, u8).unwrap();
+            while !line_sts().contains(LineSts::OUTPUT_EMPTY) {}
+            tdvmcall_io_write!(SERIAL_IO_PORT, b' ', u8).unwrap();
+            while !line_sts().contains(LineSts::OUTPUT_EMPTY) {}
+            tdvmcall_io_write!(SERIAL_IO_PORT, 8, u8).unwrap();
+        }
+        _ => {
+            while !line_sts().contains(LineSts::OUTPUT_EMPTY) {}
+            tdvmcall_io_write!(SERIAL_IO_PORT, byte, u8).unwrap();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! serial_print {
+    ($fmt: literal $(, $($arg: tt)+)?) => {
+        $crate::tdvmcall::print(format_args!($fmt $(, $($arg)+)?));
+    }
+}
+
+#[macro_export]
+macro_rules! serial_println {
+  ($fmt: literal $(, $($arg: tt)+)?) => {
+    $crate::tdvmcall::print(format_args!(concat!($fmt, "\n") $(, $($arg)+)?))
+  }
+}

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -10,12 +10,31 @@ extern crate jinux_frame;
 
 use core::panic::PanicInfo;
 use jinux_frame::println;
+#[cfg(feature = "intel_tdx")]
+use jinux_frame::{config::PHYS_OFFSET, linux_boot::BootParams};
 
+#[cfg(not(feature = "intel_tdx"))]
 #[no_mangle]
 pub fn jinux_main() -> ! {
     #[cfg(test)]
     test_main();
     jinux_frame::init();
+    println!("[kernel] finish init jinux_frame");
+    component::init_all(component::parse_metadata!()).unwrap();
+    jinux_std::init();
+    jinux_std::run_first_process();
+}
+
+#[cfg(feature = "intel_tdx")]
+#[no_mangle]
+pub fn jinux_main(boot_params: &'static BootParams) -> ! {
+    #[cfg(test)]
+    test_main();
+    let rsdp_addr = boot_params.acpi_rsdp_addr;
+    let memory = boot_params.e820_table;
+    let _ramdisk_offset = boot_params.hdr.ramdisk_image;
+    let _ramdisk_size = boot_params.hdr.ramdisk_size;
+    jinux_frame::init(memory, rsdp_addr);
     println!("[kernel] finish init jinux_frame");
     component::init_all(component::parse_metadata!()).unwrap();
     jinux_std::init();

--- a/services/libs/jinux-std/Cargo.toml
+++ b/services/libs/jinux-std/Cargo.toml
@@ -26,6 +26,7 @@ ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 intrusive-collections = "0.9.5"
 time = { version = "0.3", default-features = false, features = ["alloc"] }
 smoltcp = { version = "0.9.1", default-features = false, features = ["alloc", "log", "medium-ethernet", "medium-ip", "proto-dhcpv4", "proto-ipv4", "proto-igmp", "socket-icmp", "socket-udp", "socket-tcp", "socket-raw", "socket-dhcpv4"] }
+tdx-guest = { path = "../../../framework/libs/tdx-guest", optional = true }
 
 # parse elf file
 xmas-elf = "0.8.0"
@@ -47,3 +48,6 @@ getrandom = { version = "0.2.10", default-features = false, features = ["rdrand"
 [dependencies.lazy_static]
 version = "1.0"
 features = ["spin_no_std"]
+
+[features]
+intel_tdx = ["dep:tdx-guest"]

--- a/services/libs/jinux-std/src/lib.rs
+++ b/services/libs/jinux-std/src/lib.rs
@@ -50,6 +50,7 @@ pub mod vm;
 
 pub fn init() {
     driver::init();
+    #[cfg(not(feature = "intel_tdx"))]
     net::init();
     process::fifo_scheduler::init();
     fs::initramfs::init(boot::get_initramfs()).unwrap();
@@ -61,6 +62,7 @@ fn init_thread() {
         "[kernel] Spawn init thread, tid = {}",
         current_thread!().tid()
     );
+    #[cfg(not(feature = "intel_tdx"))]
     net::lazy_init();
     // driver::pci::virtio::block::block_device_test();
     let thread = Thread::spawn_kernel_thread(|| {


### PR DESCRIPTION
This PR is based on TD-shim, including the following aspects:
- Add `intel_tdx` conditional compilation.
- Since some ACPI tables are not included in TD-shim, some workarounds have been done **temporarily**.
- Add codes for obtaining TD info and virtualization exception handler.
- The acquisition of acpi_addr, memory region and ramdisk is a **temporary** method.
- Changed `trapframe` and `acpi` crate:
    - In TD, removed unsupported printing and efer update in `trapframe` crate.
    - In TD, the MADT table is missing, and we use a workaround in the `acpi` crate.
- Add `tdx-guest` module.