### PR TITLE
Add workaround for running TDX mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acpi"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+source = "git+https://github.com/Hsy-Intel/acpi.git?rev=109aecb#109aecbb6d3c686aea4457bb98639e024162c42d"
 dependencies = [
  "bit_field",
  "log",
@@ -1361,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "trapframe"
 version = "0.9.0"
-source = "git+https://github.com/sdww0/trapframe-rs?rev=e886763#e8867631def557939be5107f2be6c8d909d72431"
+source = "git+https://github.com/Hsy-Intel/trapframe-rs?rev=fe6fc6e#fe6fc6e57417dbcb4a6d4da9aa9ea08812c40003"
 dependencies = [
  "log",
  "pod",

--- a/framework/jinux-frame/Cargo.toml
+++ b/framework/jinux-frame/Cargo.toml
@@ -16,13 +16,13 @@ align_ext = { path = "../libs/align_ext" }
 intrusive-collections = "0.9.5"
 log = "0.4"
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-trapframe = { git = "https://github.com/sdww0/trapframe-rs", rev = "e886763" }
+trapframe = { git = "https://github.com/Hsy-Intel/trapframe-rs", rev = "fe6fc6e" }
 inherit-methods-macro = { git = "https://github.com/jinzhao-dev/inherit-methods-macro", rev = "98f7e3e" }
 
 [target.x86_64-custom.dependencies]
 x86_64 = "0.14.2"
 x86 = "0.52.0"
-acpi = "4.1.1"
+acpi = { git = "https://github.com/Hsy-Intel/acpi.git", rev = "109aecb" }
 aml = "0.16.3"
 multiboot2 = "0.16.0"
 

--- a/framework/jinux-frame/src/arch/x86/device/cmos.rs
+++ b/framework/jinux-frame/src/arch/x86/device/cmos.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "intel_tdx"))]
 use acpi::{fadt::Fadt, sdt::Signature};
 use x86_64::instructions::port::{ReadOnlyAccess, WriteOnlyAccess};
 
+#[cfg(not(feature = "intel_tdx"))]
 use crate::arch::x86::kernel::acpi::ACPI_TABLES;
 
 use super::io_port::IoPort;
@@ -9,6 +11,7 @@ pub static CMOS_ADDRESS: IoPort<u8, WriteOnlyAccess> = unsafe { IoPort::new(0x70
 pub static CMOS_DATA: IoPort<u8, ReadOnlyAccess> = unsafe { IoPort::new(0x71) };
 
 pub fn get_century() -> u8 {
+    #[cfg(not(feature = "intel_tdx"))]
     unsafe {
         let a = ACPI_TABLES
             .get()
@@ -19,4 +22,6 @@ pub fn get_century() -> u8 {
             .expect("not found FACP in ACPI table");
         a.century
     }
+    #[cfg(feature = "intel_tdx")]
+    21
 }

--- a/framework/jinux-frame/src/arch/x86/kernel/apic/x2apic.rs
+++ b/framework/jinux-frame/src/arch/x86/kernel/apic/x2apic.rs
@@ -27,8 +27,10 @@ impl X2Apic {
         unsafe {
             // Enable x2APIC mode globally
             let mut base = rdmsr(IA32_APIC_BASE);
-            base = base | 0b1100_0000_0000; // Enable x2APIC and xAPIC
-            wrmsr(IA32_APIC_BASE, base);
+            if base & 0b1100_0000_0000 != 0b1100_0000_0000 {
+                base = base | 0b1100_0000_0000; // Enable x2APIC and xAPIC
+                wrmsr(IA32_APIC_BASE, base);
+            }
 
             // Set SVR, Enable APIC and set Spurious Vector to 15 (Reserved irq number)
             let svr: u64 = 1 << 8 | 15;

--- a/framework/jinux-frame/src/arch/x86/mmio.rs
+++ b/framework/jinux-frame/src/arch/x86/mmio.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "intel_tdx"))]
 use acpi::PciConfigRegions;
 
+#[cfg(not(feature = "intel_tdx"))]
 pub fn start_address() -> usize {
     let start = PciConfigRegions::new(
         &*crate::arch::x86::kernel::acpi::ACPI_TABLES
@@ -11,6 +13,11 @@ pub fn start_address() -> usize {
 
     // all zero to get the start address
     start.physical_address(0, 0, 0, 0).unwrap() as usize
+}
+
+#[cfg(feature = "intel_tdx")]
+pub fn start_address() -> usize {
+    0
 }
 
 pub fn end_address() -> usize {

--- a/framework/jinux-frame/src/arch/x86/mod.rs
+++ b/framework/jinux-frame/src/arch/x86/mod.rs
@@ -91,6 +91,7 @@ fn enable_common_cpu_features() {
         x86_64::registers::xcontrol::XCr0::write(xcr0);
     }
 
+    #[cfg(not(feature = "intel_tdx"))]
     unsafe {
         // enable non-executable page protection
         x86_64::registers::model_specific::Efer::update(|efer| {

--- a/services/libs/jinux-std/src/lib.rs
+++ b/services/libs/jinux-std/src/lib.rs
@@ -50,6 +50,7 @@ pub mod vm;
 
 pub fn init() {
     driver::init();
+    #[cfg(not(feature = "intel_tdx"))]
     net::init();
     process::fifo_scheduler::init();
     fs::rootfs::init(boot::initramfs()).unwrap();
@@ -61,6 +62,7 @@ fn init_thread() {
         "[kernel] Spawn init thread, tid = {}",
         current_thread!().tid()
     );
+    #[cfg(not(feature = "intel_tdx"))]
     net::lazy_init();
     // driver::pci::virtio::block::block_device_test();
     let thread = Thread::spawn_kernel_thread(|| {


### PR DESCRIPTION
This PR is based on TD-shim, including the following aspects:
- Change `trapframe` and `acpi` crate:
  - In TD, remove unsupported printing and efer updates in `trapframe` crate.
  - In TD, the MADT table is missing, and we use a workaround in the `acpi` crate.
  - Add a workaround for `MultiprocessorWakeup` case in `acpi` crate.
- Remove efer update for non-executable page protection. In TD, this feature is enabled by default.
- Add workaround for the acpi tables `IOAPIC`, `MCFG` and `FADT`. After using TDVF, this part can be removed.
- Disable net init for TD. Management of IOMMU is still in progress.