### PR TITLE
Fix bugs that caused Jinux failed with opt-level=1 or in release mode

### DIFF
--- a/framework/jinux-frame/src/vm/frame_allocator.rs
+++ b/framework/jinux-frame/src/vm/frame_allocator.rs
@@ -63,7 +63,7 @@ pub(crate) fn init(regions: &Vec<MemoryRegion>) {
         if region.typ() == MemoryRegionType::Usable {
             // Make the memory region page-aligned
             let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
-            let end = (start + region.len()).align_down(PAGE_SIZE) / PAGE_SIZE;
+            let end = (region.base() + region.len()).align_down(PAGE_SIZE) / PAGE_SIZE;
             allocator.add_frame(start, end);
             info!(
                 "Found usable region, start:{:x}, end:{:x}",


### PR DESCRIPTION
The compiler will consider that IS_FINISH is always false and treat the while loop as a infinite loop. Set IS_FINISH as a AtomicBool can solve this problem #336. There is also a bug in frame_allocator.rs, that the calculation for `end` is wrong. After these fixings, Jinux can run in the release mode successfully.