### PR TITLE
Use UEFI firmware to boot

### DIFF
--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -58,6 +58,8 @@ const COMMON_ARGS: &[&str] = &[
     "user,id=net01,hostfwd=tcp::30022-:22,hostfwd=tcp::30080-:8080",
     "-object",
     "filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap",
+    "-drive", "if=pflash,format=raw,unit=0,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd",
+    "-drive", "if=pflash,format=raw,unit=1,file=/usr/share/OVMF/OVMF_VARS.fd",
 ];
 
 const COMMON_DEVICE_ARGS: &[&str] = &[

--- a/framework/jinux-frame/src/arch/x86/boot/boot.S
+++ b/framework/jinux-frame/src/arch/x86/boot/boot.S
@@ -29,12 +29,23 @@ header_start:
     // Tag: information request
     .align 8
 info_request:
-    .short 1
+    .short 1            // Type: info request
     .short 0            // Required
     .long  info_request_end - info_request
     .long  6            // Memory map request
     .long  15           // ACPI (new) request
 info_request_end:
+
+    // Tag: framebuffer
+    .align 8
+framebuffer_request:
+    .short 5            // Type: framebuffer
+    .short 1            // Optional
+    .long  framebuffer_request_end - framebuffer_request
+    .long  1280         // Width
+    .long  720          // Height
+    .long  32           // Depth
+framebuffer_request_end:
 
     // Tag: header end
     .align 8

--- a/tools/docker/Dockerfile.ubuntu22.04
+++ b/tools/docker/Dockerfile.ubuntu22.04
@@ -15,10 +15,12 @@ RUN apt update && apt-get install -y --no-install-recommends \
     git-core \
     gnupg \
     grub-common \
-    grub-pc \
+    grub-efi \
     libssl-dev \
+    mtools \
     net-tools \
     openssh-server \
+    ovmf \
     pkg-config \
     python-is-python3 \
     python3-pip \


### PR DESCRIPTION
IT IS NOT READY. If we boot with UEFI, MMIO will fail to handle 64-bit PCI BAR addresses.

Blocked by #328.