### PR TITLE
Add timeout for CI jobs

### DIFF
--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: jinuxdev/jinux:0.2.0
     steps:
       - run: echo "Running in jinuxdev/jinux:0.2.0"

--- a/.github/workflows/syscall_test.yml
+++ b/.github/workflows/syscall_test.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container: jinuxdev/jinux:0.2.0
     steps:
       - run: echo "Running in jinuxdev/jinux:0.2.0"


### PR DESCRIPTION
Sometimes CI would hang up and run for hundreds of hours till it's manually stopped. Maybe that's why our time is depleted now. We should set some timeout mechanisms.