### PR TITLE
Fix panic when listen backlog is one

### DIFF
--- a/regression/apps/network/listen_backlog.c
+++ b/regression/apps/network/listen_backlog.c
@@ -1,0 +1,140 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int new_bound_socket(struct sockaddr_in *addr)
+{
+    int sockfd;
+
+    sockfd = socket(PF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        perror("new_bound_socket: socket");
+        return -1;
+    }
+
+    if (bind(sockfd, (struct sockaddr *)addr, sizeof(*addr)) < 0) {
+        perror("new_bound_socket: bind");
+        close(sockfd);
+        return -1;
+    }
+
+    return sockfd;
+}
+
+static int new_connected_socket(struct sockaddr_in *addr)
+{
+    int sockfd;
+
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        perror("new_connected_socket: socket");
+        return -1;
+    }
+
+    if (connect(sockfd, (struct sockaddr *)addr, sizeof(*addr)) < 0) {
+        perror("new_connected_socket: connect");
+        close(sockfd);
+        return -1;
+    }
+
+    return sockfd;
+}
+
+#define MAX_TEST_BACKLOG 5
+
+int test_listen_backlog(struct sockaddr_in *addr, int backlog)
+{
+    int listenfd;
+    int connectfd[MAX_TEST_BACKLOG], acceptfd[MAX_TEST_BACKLOG];
+    int num_connectfd = 0, num_acceptfd = 0;
+    int ret = -1;
+    struct sockaddr caddr;
+    socklen_t caddrlen = sizeof(caddr);
+
+    listenfd = new_bound_socket(addr);
+    if (listenfd < 0) {
+        fprintf(stderr,
+            "Test failed: Error occurs in new_bound_socket\n");
+        return -1;
+    }
+
+    if (listen(listenfd, backlog) < 0) {
+        perror("listen");
+        fprintf(stderr, "Test failed: Error occurs in listen\n");
+        goto out;
+    }
+
+    for (; num_connectfd < backlog; ++num_connectfd) {
+        connectfd[num_connectfd] = new_connected_socket(addr);
+        if (connectfd[num_connectfd] < 0)
+            break;
+    }
+
+    if (num_connectfd != backlog) {
+        fprintf(stderr,
+            "Test failed: listen(backlog=%d) allows only %d pending connections\n",
+            backlog, num_connectfd);
+        goto out;
+    }
+    fprintf(stderr,
+        "Test passed: listen(backlog=%d) allows >=%d pending connections\n",
+        backlog, num_connectfd);
+
+    for (; num_acceptfd < num_connectfd; ++num_acceptfd) {
+        acceptfd[num_acceptfd] = accept(listenfd, &caddr, &caddrlen);
+        if (acceptfd[num_acceptfd] < 0) {
+            perror("accept");
+            break;
+        }
+    }
+
+    if (num_acceptfd != num_connectfd) {
+        fprintf(stderr,
+            "Test failed: Only %d pending connections can be accept()'ed out "
+            "of %d\n",
+            num_acceptfd, num_connectfd);
+        goto out;
+    }
+    fprintf(stderr,
+        "Test passed: All of %d pending connections can be accept()'ed\n",
+        num_acceptfd);
+
+    ret = 0;
+
+out:
+    while (--num_acceptfd >= 0)
+        close(acceptfd[num_acceptfd]);
+
+    while (--num_connectfd >= 0)
+        close(connectfd[num_connectfd]);
+
+    close(listenfd);
+
+    return ret;
+}
+
+int main(void)
+{
+    struct sockaddr_in addr;
+    int backlog;
+    int err = 0;
+
+    addr.sin_family = AF_INET;
+    if (inet_aton("127.0.0.1", &addr.sin_addr) < 0) {
+        fprintf(stderr, "inet_aton cannot parse 127.0.0.1\n");
+        return -1;
+    }
+
+    for (backlog = 0; backlog <= MAX_TEST_BACKLOG; ++backlog) {
+        // Avoid "bind: Address already in use"
+        addr.sin_port = htons(8080 + backlog);
+
+        err = test_listen_backlog(&addr, backlog);
+        if (err != 0)
+            break;
+    }
+
+    return err ? -1 : 0;
+}


### PR DESCRIPTION
The `listen(1)` system call will cause the kernel to panic, as shown below:
```
[panic]:PanicInfo {
    payload: Any { .. },
    message: Some(
        index out of bounds: the len is 0 but the index is 0,
    ),
    location: Location {
        file: "services/libs/jinux-std/src/net/socket/ip/stream/listen.rs",
        line: 74,
        col: 43,
    },
    can_unwind: true,
    force_no_backtrace: false,
}
```
However, using 1 as the backlog number is reasonable, and definitely shouldn't cause the kernel to panic.

The reason for this is that once all the sockets have been removed from the backlog list, one cannot refill the backlog list by simply trying to clone sockets from the first element of the backlog list:
https://github.com/jinzhao-dev/jinux/blob/0c7df54513163441d0837fe410858c9ccf8f0cf8/services/libs/jinux-std/src/net/socket/ip/stream/listen.rs#L74
Instead of trying to clone old sockets, a more elegant way to create backlog sockets is to just use the interface and the local endpoint, which is what this PR tries to do.

Note: Calling `listen(0)` will also cause a kernel panic due to the following `debug_assert`, which may not be reasonable either (not handled by this PR):
https://github.com/jinzhao-dev/jinux/blob/0c7df54513163441d0837fe410858c9ccf8f0cf8/services/libs/jinux-std/src/net/socket/ip/stream/listen.rs#L25