### PR TITLE
Allow commit author emails to be @[stu.]pku.edu.cn

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -7,7 +7,7 @@ mergeable:
     validate:
       - do: commit
         message:
-          regex: ^.*(@antgroup\.com|@alibaba-inc\.com|@intel\.com)$
+          regex: ^.*(@antgroup\.com|@alibaba-inc\.com|@intel\.com|@pku\.edu\.cn|@stu\.pku\.edu\.cn)$
           message: Check if the author emails belong to Ant Group or its partners
           message_type: author_email
           skip_merge: false # If true, will skip commit with message that includes 'Merge'


### PR DESCRIPTION
For students who join Peking University after 2020 (included), they will use the `@stu.pku.edu.cn` email addresses. But for students who join Peking University before 2020, they are more likely to use the old `@pku.edu.cn` email addresses. This PR allows both to be commit author emails.