### PR TITLE
Add in_interrupt and refactor line discipline

### DIFF
--- a/framework/aster-frame/src/trap/mod.rs
+++ b/framework/aster-frame/src/trap/mod.rs
@@ -5,6 +5,7 @@ mod irq;
 
 pub(crate) use self::handler::call_irq_callback_functions;
 pub use self::irq::{disable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine};
+pub use handler::in_interrupt_context;
 pub use trapframe::TrapFrame;
 
 pub(crate) fn init() {


### PR DESCRIPTION
The line discipline will be used by both tty and pty. For tty, the `push_char` method will be called in interrupt context; For pty, this method will be called in process context. We need to update state with different methods based on the context. In interrupt context, we delay the state update in workqueue. In thread context, we can update state immediately.

So this PR introduces the `in_interrupt` function, which can be used to determine whether we're in interrupt context. Compared with `in_interrupt` for linux, this PR does not take reentrant interrupts and softirq into account.