### PR TITLE
Timeout list should be accessed with IRQ disabled

### DIFF
--- a/framework/jinux-frame/src/arch/x86/timer/mod.rs
+++ b/framework/jinux-frame/src/arch/x86/timer/mod.rs
@@ -43,7 +43,7 @@ fn timer_callback(trap_frame: &TrapFrame) {
 
     let callbacks = {
         let mut callbacks = Vec::new();
-        let mut timeout_list = TIMEOUT_LIST.get().unwrap().lock();
+        let mut timeout_list = TIMEOUT_LIST.get().unwrap().lock_irq_disabled();
 
         while let Some(t) = timeout_list.peek() {
             if t.is_cancelled() {
@@ -147,7 +147,11 @@ where
         Box::new(callback),
     );
     let arc = Arc::new(timer_callback);
-    TIMEOUT_LIST.get().unwrap().lock().push(arc.clone());
+    TIMEOUT_LIST
+        .get()
+        .unwrap()
+        .lock_irq_disabled()
+        .push(arc.clone());
     arc
 }
 


### PR DESCRIPTION
Random failures in CI are quite annoying, so let's try to fix it.

Fortunately, CI hangs can be reproduced locally, and I get the following backtrace by attaching GDB:
```
(gdb) bt
#0  0xffffffff88b7c992 in jinux_frame::arch::x86::timer::timer_callback ()
#1  0xffffffff88b908fa in jinux_frame::trap::handler::call_irq_callback_functions ()
#2  0xffffffff88b99b24 in __from_kernel ()
#3  0x0000000000000000 in ?? ()
```

Looking at the code, `TIMEOUT_LIST` can be accessed in IRQ but is locked without disabling IRQ, which causes the deadlocks in timer IRQ handlers.

I don't think I can write integration tests or unit tests for this fix, can I?

Fix #430 