### PR TITLE
Fix the misuse of spin::mutex

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     container: jinuxdev/jinux:0.2.1
     steps:
       - run: echo "Running in jinuxdev/jinux:0.2.1"

--- a/framework/jinux-frame/src/task/task.rs
+++ b/framework/jinux-frame/src/task/task.rs
@@ -2,10 +2,10 @@ use crate::arch::mm::PageTableFlags;
 use crate::config::{KERNEL_STACK_SIZE, PAGE_SIZE};
 use crate::cpu::CpuSet;
 use crate::prelude::*;
+use crate::sync::{Mutex, MutexGuard};
 use crate::user::UserSpace;
 use crate::vm::page_table::KERNEL_PAGE_TABLE;
 use crate::vm::{VmAllocOptions, VmSegment};
-use spin::{Mutex, MutexGuard};
 
 use intrusive_collections::intrusive_adapter;
 use intrusive_collections::LinkedListAtomicLink;


### PR DESCRIPTION
The problem is caused by still using spin::Mutex in task.rs.