### PR TITLE
Fix child-parent scheduling order dependency

### DIFF
--- a/services/libs/jinux-std/src/process/wait.rs
+++ b/services/libs/jinux-std/src/process/wait.rs
@@ -61,9 +61,10 @@ pub fn wait_child_exit(
             }
         }
 
-        if wait_options.contains(WaitOptions::WNOHANG) {
-            return Some(Ok((0, 0)));
-        }
+        // Temporary ignores WNOHANG. See https://github.com/jinzhao-dev/jinux/issues/530.
+        // if wait_options.contains(WaitOptions::WNOHANG) {
+        //     return Some(Ok((0, 0)));
+        // }
 
         // wait
         None

--- a/services/libs/jinux-std/src/vm/vmar/vm_mapping.rs
+++ b/services/libs/jinux-std/src/vm/vmar/vm_mapping.rs
@@ -240,7 +240,10 @@ impl VmMapping {
         let child_vmo = {
             let parent_vmo = vmo.dup().unwrap();
             let vmo_size = parent_vmo.size();
-            VmoChildOptions::new_cow(parent_vmo, 0..vmo_size).alloc()?
+            let child_vmo = VmoChildOptions::new_cow(parent_vmo, 0..vmo_size).alloc()?;
+            // Temporary solution for https://github.com/jinzhao-dev/jinux/issues/531
+            child_vmo.commits_with_write_access();
+            child_vmo
         };
 
         let new_inner = {

--- a/services/libs/jinux-std/src/vm/vmo/dyn_cap.rs
+++ b/services/libs/jinux-std/src/vm/vmo/dyn_cap.rs
@@ -147,6 +147,13 @@ impl Vmo<Rights> {
         self.check_rights(Rights::from_bits(R1::BITS).ok_or(Error::new(Errno::EINVAL))?)?;
         Ok(Vmo(self.0, R1::new()))
     }
+
+    /// Commits all pages with write access.
+    pub fn commits_with_write_access(&self) {
+        self.0
+            .ensure_all_pages_exist(&(0..self.0.size()), true)
+            .unwrap();
+    }
 }
 
 impl VmIo for Vmo<Rights> {


### PR DESCRIPTION
This is a temporary solution for #518 by fixing #530 and #531.

This PR actually diables cow and will GREATLY damage performance. For pty test, the clone syscall will consume more than 3 seconds in my test.