### PR TITLE
Workaround for QEMU BUG that causes CI to hang

### DIFF
--- a/framework/jinux-frame/src/arch/x86/irq.rs
+++ b/framework/jinux-frame/src/arch/x86/irq.rs
@@ -27,6 +27,10 @@ pub(crate) fn init() {
 
 pub(crate) fn enable_local() {
     x86_64::instructions::interrupts::enable();
+    // When emulated with QEMU, interrupts may not be delivered if a STI instruction is immediately
+    // followed by a RET instruction. It is a BUG of QEMU, see the following patch for details.
+    // https://lore.kernel.org/qemu-devel/20231210190147.129734-2-lrh2000@pku.edu.cn/
+    x86_64::instructions::nop();
 }
 
 pub(crate) fn disable_local() {


### PR DESCRIPTION
The issue was originally reported in #430. Then #489 was proposed to fix it, but CI still hangs frequently after that.

In https://github.com/jinzhao-dev/jinux/pull/515#issuecomment-1836248833, I tried to analyze the problem and suspected that it might be caused by a QEMU BUG.

Now I think I found the QEMU BUG, and I've submitted a patch to QEMU [here](https://lore.kernel.org/qemu-devel/20231210190147.129734-2-lrh2000@pku.edu.cn/), as quoted below:
```
When emulated with QEMU, interrupts will never come in the following
loop. However, if the NOP instruction is uncommented, interrupts will
fire as normal.

	loop:
		cli
    		call do_sti
		jmp loop

	do_sti:
		sti
		# nop
		ret

This behavior is different from that of a real processor. For example,
if KVM is enabled, interrupts will always fire regardless of whether the
NOP instruction is commented or not. Also, the Intel Software Developer
Manual states that after the STI instruction is executed, the interrupt
inhibit should end as soon as the next instruction (e.g., the RET
instruction if the NOP instruction is commented) is executed.

This problem is caused because the previous code may choose not to end
the TB even if the HF_INHIBIT_IRQ_MASK has just been reset (e.g., in the
case where the RET instruction is immediately followed by the STI
instruction), so that IRQs may not have a change to trigger. This commit
fixes the problem by always terminating the current TB to give IRQs a
chance to trigger when HF_INHIBIT_IRQ_MASK is reset.
```

To work around the problem, we can avoid the `sti; ret` assembly pattern, but manually insert a `nop` instruction between them, which is what this PR attempts to do.