### PR TITLE
Fix a bug and support more clockIDs in vdso.

### DIFF
--- a/services/comps/time/src/tsc.rs
+++ b/services/comps/time/src/tsc.rs
@@ -13,7 +13,7 @@ use crate::{START_TIME, VDSO_DATA_UPDATE};
 /// A instance of TSC clocksource.
 pub static CLOCK: Once<Arc<ClockSource>> = Once::new();
 
-const MAX_DELAY_SECS: u64 = 60;
+const MAX_DELAY_SECS: u64 = 100;
 
 /// Init tsc clocksource module.
 pub(super) fn init() {
@@ -62,10 +62,11 @@ fn update_clocksource(timer: Arc<Timer>) {
 fn init_timer() {
     let timer = Timer::new(update_clocksource).unwrap();
     // The initial timer should be set as `clock.max_delay_secs() >> 1` or something much smaller than `max_delay_secs`.
-    // This is because the initialization of this timer occurs during system startup.
-    // Afterwards, the system will undergo additional initialization processes, during which time interrupts are disabled.
+    // This is because the initialization of this timer occurs during system startup,
+    // and the system will also undergo other initialization processes, during which time interrupts are disabled.
     // This results in the actual trigger time of the timer being delayed by about 5 seconds compared to the set time.
-    // TODO: This is a temporary handle, and should be modified in the future.
+    // If without KVM, the delayed time will be larger.
+    // TODO: This is a temporary solution, and should be modified in the future.
     timer.set(Duration::from_secs(
         CLOCK.get().unwrap().max_delay_secs() >> 1,
     ));

--- a/services/libs/jinux-std/src/time/mod.rs
+++ b/services/libs/jinux-std/src/time/mod.rs
@@ -14,7 +14,7 @@ pub type time_t = i64;
 pub type suseconds_t = i64;
 pub type clock_t = i64;
 
-#[derive(Debug, Copy, Clone, TryFromInt)]
+#[derive(Debug, Copy, Clone, TryFromInt, PartialEq)]
 #[repr(i32)]
 pub enum ClockID {
     CLOCK_REALTIME = 0,
@@ -26,6 +26,16 @@ pub enum ClockID {
     CLOCK_MONOTONIC_COARSE = 6,
     CLOCK_BOOTTIME = 7,
 }
+
+/// A list of all supported clock IDs for time-related functions.
+pub const ALL_SUPPORTED_CLOCK_IDS: [ClockID; 6] = [
+    ClockID::CLOCK_REALTIME,
+    ClockID::CLOCK_REALTIME_COARSE,
+    ClockID::CLOCK_MONOTONIC,
+    ClockID::CLOCK_MONOTONIC_COARSE,
+    ClockID::CLOCK_MONOTONIC_RAW,
+    ClockID::CLOCK_BOOTTIME,
+];
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Pod)]


### PR DESCRIPTION
This PR fix a bug in vdso module, that is the `VdsoInstant` should store the value of `nanos << shift` instead of `nanos * mult`. This PR also adjusts `MAX_DELAY_SECS` to 100, as currently there is a lengthy period during system startup when interruptions are not enabled, and thus TICK will not increment. This could result in the timer that updates the clocksource being delayed in its update during startup, leading to a computation overflow. At present, this treatment is just a temporary fix to ensure that the system will not experience computation overflow during startup.

Another thing is that the updates for multiple ClockIDs have been synchronized in the VDSO to support the system calls corresponding to these ClockIDs.
