### PR TITLE
Fix a race condition in `Waiter`

### DIFF
--- a/framework/aster-frame/src/sync/wait.rs
+++ b/framework/aster-frame/src/sync/wait.rs
@@ -99,7 +99,8 @@ impl WaitQueue {
             if let Some(ref timer_callback) = timer_callback
                 && timer_callback.is_expired()
             {
-                return None;
+                self.dequeue(&waiter);
+                return cond();
             }
 
             waiter.wait();


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/ddca4fb2fc443b538d31ee3e12304c4d8a51117e/framework/aster-frame/src/sync/wait.rs#L88-L104

If the timer expires after the `timer_callback.is_expired()` check but before the `waiter.wait()` call, the event is silently ignored because the `waiter.wait()` overwrites its `is_woken_up` state at the beginning.

https://github.com/asterinas/asterinas/blob/ddca4fb2fc443b538d31ee3e12304c4d8a51117e/framework/aster-frame/src/sync/wait.rs#L164-L165

```
timer_callback.is_expired()
                                *** TIMER INTERRUPT BEGIN **
				waiter.wake_up()
				*** TIMER INTERRUPT END **
waiter.wait()
```

The `is_woken_up` should be set to `false` *before* any waiting condition checks (including `cond()` and `timer_callback.is_expired()`). The correct place to do this is in its constructor (which has already been correctly done) and at the end of `waiter.wake_up()` (not at its beginning).

Also note that `is_woken_up` should be an internal state, and there is no point in making it available for external use. So the public method `is_woken_up()` is removed.

FYI: `Waiter::wake_up()` has another problem where the same task can be added to the schedule queue multiple times before the task has ever been dequeued (`Waiter::wait()` may not call `schedule()` after all). This is a separate issue and is *not* covered by this PR. There is actually another race condition between `task_status = TaskStatus::Sleeping` and `schedule()`, forcing us to keep additional information or add another task state in the `Task` structure before we can solve this problem. Linux has encountered [similar problems](https://elixir.bootlin.com/linux/v6.7-rc7/source/kernel/sched/core.c#L3800) either.