### PR TITLE
Remove the vmo slice child semantics and achieve shared memory at the vmo level

### DIFF
--- a/regression/apps/Makefile
+++ b/regression/apps/Makefile
@@ -3,7 +3,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 INITRAMFS ?= $(CUR_DIR)/../build/initramfs
 REGRESSION_BUILD_DIR ?= $(INITRAMFS)/regression
-TEST_APPS := signal_c pthread network hello_world hello_pie hello_c fork_c fork execve pty
+TEST_APPS := signal_c pthread network hello_world hello_pie hello_c fork_c fork execve pty mmap
 
 .PHONY: all
 

--- a/regression/apps/mmap/Makefile
+++ b/regression/apps/mmap/Makefile
@@ -1,0 +1,3 @@
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/regression/apps/mmap/map_shared_anon.c
+++ b/regression/apps/mmap/map_shared_anon.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+int main() {
+    int *shared_memory;
+    int value = 123;
+
+    // Create an anonymous memory region for sharing
+    shared_memory = mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared_memory == MAP_FAILED) {
+        perror("mmap failed");
+        exit(1);
+    }
+
+    // Create a child process
+    pid_t pid = fork();
+
+    if (pid < 0) {
+        perror("fork");
+        exit(1);
+    } else if (pid == 0) {
+        // Child process
+
+        // Modify the value in the shared memory in the child process
+        *shared_memory = value;
+
+        printf("Child process: Value in shared memory: %d\n", *shared_memory);
+
+    } else {
+        // Parent process
+
+        // Wait for the child process to finish
+        wait(NULL);
+
+        printf("Parent process: Value in shared memory: %d\n", *shared_memory);
+
+        if (*shared_memory != value) {
+            perror("shared memory contains invalid value");
+            exit(1);
+        }
+
+        // Unmap the memory
+        if (munmap(shared_memory, sizeof(int)) == -1) {
+            perror("munmap failed");
+            exit(1);
+        }
+    }
+
+    return 0;
+}

--- a/regression/apps/scripts/process.sh
+++ b/regression/apps/scripts/process.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=/regression
 cd ${SCRIPT_DIR}/..
 
 echo "Start process test......"
-tests="hello_world/hello_world fork/fork execve/execve fork_c/fork signal_c/signal_test pthread/pthread_test hello_pie/hello pty/open_pty"
+tests="hello_world/hello_world fork/fork execve/execve fork_c/fork signal_c/signal_test pthread/pthread_test hello_pie/hello pty/open_pty mmap/map_shared_anon"
 for testcase in ${tests}
 do 
     echo "Running test ${testcase}......"

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -1,7 +1,7 @@
 TESTS ?= chmod_test fsync_test getdents_test link_test lseek_test mkdir_test \
 		open_create_test open_test pty_test read_test rename_test stat_test \
 		statfs_test symlink_test sync_test uidgid_test unlink_test \
-		vdso_clock_gettime_test write_test
+		vdso_clock_gettime_test write_test mmap_test
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))

--- a/regression/syscall_test/blocklists/mmap_test
+++ b/regression/syscall_test/blocklists/mmap_test
@@ -1,0 +1,17 @@
+MMapFileTest*
+MMapNoFixtureTest*
+ReadWriteSharedPrivate*
+MMapDeathTest.TruncateAfterCOWBreak
+MMapTest.FixedAlignment
+MMapTest.InvalidLength
+MMapTest.ProtWriteOnlyReadable
+MMapTest.MprotectNotPageAligned
+MMapTest.MprotectHugeLength
+MMapTest.HugeLength
+MMapTest.ExceedLimit*
+MMapTest.NoExceedLimitAS
+MMapTest.AccessCOWInvalidatesCachedSegments
+MMapTest.MapPipe
+MMapTest.MapDevZero*
+MMapTest.MapCharDevice
+MMapTest.MapDirectory

--- a/services/libs/aster-std/src/syscall/mmap.rs
+++ b/services/libs/aster-std/src/syscall/mmap.rs
@@ -72,8 +72,8 @@ fn mmap_anonymous_vmo(
     debug_assert!(offset == 0);
 
     // TODO: implement features presented by other flags.
-    if option.typ() != MMapType::Private {
-        panic!("Unsupported mmap flags {:?} now", option);
+    if option.typ() == MMapType::File || option.typ() == MMapType::SharedValidate {
+        return_errno_with_message!(Errno::EINVAL, "invalid mmap type");
     }
 
     let vmo_options: VmoOptions<Rights> = VmoOptions::new(len);
@@ -82,6 +82,9 @@ fn mmap_anonymous_vmo(
     let root_vmar = current.root_vmar();
 
     let mut vmar_map_options = root_vmar.new_map(vmo, perms)?;
+    if option.typ() == MMapType::Shared {
+        vmar_map_options = vmar_map_options.is_shared(true);
+    }
     if option.flags().contains(MMapFlags::MAP_FIXED) {
         vmar_map_options = vmar_map_options.offset(addr).can_overwrite(true);
     }
@@ -109,18 +112,20 @@ fn mmap_filebacked_vmo(
         ))?
     };
 
-    let vmo = if option.typ() == MMapType::Private {
-        // map private
-        VmoChildOptions::new_cow(page_cache_vmo, offset..(offset + len)).alloc()?
-    } else {
-        // map shared
-        // FIXME: enable slice child to exceed parent range
-        VmoChildOptions::new_slice(page_cache_vmo, offset..(offset + len)).alloc()?
-    };
-
     let root_vmar = current.root_vmar();
     let vm_map_options = {
-        let mut options = root_vmar.new_map(vmo.to_dyn(), perms)?;
+        let mut options = if option.typ() == MMapType::Private {
+            // map private
+            let vmo = VmoChildOptions::new_cow(page_cache_vmo, offset..(offset + len)).alloc()?;
+            root_vmar.new_map(vmo.to_dyn(), perms)?
+        } else {
+            // map shared
+            // FIXME: enable slice child to exceed parent range
+            root_vmar
+                .new_map(page_cache_vmo.to_dyn(), perms)?
+                .vmo_offset(offset)
+                .size(len)
+        };
         if option.flags().contains(MMapFlags::MAP_FIXED) {
             options = options.offset(addr).can_overwrite(true);
         }

--- a/services/libs/aster-std/src/vm/vmar/dyn_cap.rs
+++ b/services/libs/aster-std/src/vm/vmar/dyn_cap.rs
@@ -150,7 +150,7 @@ impl Vmar<Rights> {
     /// The method requires the Read right.
     pub fn fork_from(vmar: &Vmar) -> Result<Self> {
         vmar.check_rights(Rights::READ)?;
-        let vmar_ = vmar.0.new_cow_root()?;
+        let vmar_ = vmar.0.new_fork_root()?;
         Ok(Vmar(vmar_, Rights::all()))
     }
 }

--- a/services/libs/aster-std/src/vm/vmar/mod.rs
+++ b/services/libs/aster-std/src/vm/vmar/mod.rs
@@ -646,16 +646,16 @@ impl Vmar_ {
         Ok(())
     }
 
-    pub(super) fn new_cow_root(self: &Arc<Self>) -> Result<Arc<Self>> {
+    pub(super) fn new_fork_root(self: &Arc<Self>) -> Result<Arc<Self>> {
         if self.parent.upgrade().is_some() {
             return_errno_with_message!(Errno::EINVAL, "can only dup cow vmar for root vmar");
         }
 
-        self.new_cow(None)
+        self.new_fork(None)
     }
 
     /// Create a new vmar by creating cow child for all mapped vmos
-    fn new_cow(&self, parent: Option<&Arc<Vmar_>>) -> Result<Arc<Self>> {
+    fn new_fork(&self, parent: Option<&Arc<Vmar_>>) -> Result<Arc<Self>> {
         let new_vmar_ = {
             let vmar_inner = VmarInner::new();
             // If this is a root vmar, we create a new vmspace,
@@ -680,7 +680,7 @@ impl Vmar_ {
 
         // clone child vmars
         for (child_vmar_base, child_vmar_) in &inner.child_vmar_s {
-            let new_child_vmar = child_vmar_.new_cow(Some(&new_vmar_))?;
+            let new_child_vmar = child_vmar_.new_fork(Some(&new_vmar_))?;
             new_vmar_
                 .inner
                 .lock()
@@ -690,7 +690,7 @@ impl Vmar_ {
 
         // clone vm mappings
         for (vm_mapping_base, vm_mapping) in &inner.vm_mappings {
-            let new_mapping = Arc::new(vm_mapping.new_cow(&new_vmar_)?);
+            let new_mapping = Arc::new(vm_mapping.new_fork(&new_vmar_)?);
             new_vmar_
                 .inner
                 .lock()

--- a/services/libs/aster-std/src/vm/vmar/static_cap.rs
+++ b/services/libs/aster-std/src/vm/vmar/static_cap.rs
@@ -157,7 +157,7 @@ impl<R: TRights> Vmar<TRightSet<R>> {
     /// The method requires the Read right.
     pub fn fork_from<R1>(vmar: &Vmar<R1>) -> Result<Self> {
         vmar.check_rights(Rights::READ)?;
-        let vmar_ = vmar.0.new_cow_root()?;
+        let vmar_ = vmar.0.new_fork_root()?;
         Ok(Vmar(vmar_, TRightSet(R::new())))
     }
 

--- a/services/libs/aster-std/src/vm/vmo/dyn_cap.rs
+++ b/services/libs/aster-std/src/vm/vmo/dyn_cap.rs
@@ -6,40 +6,9 @@ use aster_frame::vm::VmIo;
 
 use aster_rights::{Rights, TRights};
 
-use super::VmoRightsOp;
-use super::{
-    options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions,
-};
+use super::{Vmo, VmoChildOptions, VmoRightsOp};
 
 impl Vmo<Rights> {
-    /// Creates a new slice VMO through a set of VMO child options.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let parent = VmoOptions::new(PAGE_SIZE).alloc().unwrap();
-    /// let child_size = parent.size();
-    /// let child = parent.new_slice_child(0..child_size).alloc().unwrap();
-    /// assert!(child.size() == child_size);
-    /// ```
-    ///
-    /// For more details on the available options, see `VmoChildOptions`.
-    ///
-    /// # Access rights
-    ///
-    /// This method requires the Dup right.
-    ///
-    /// The new VMO child will be of the same capability flavor as the parent;
-    /// so are the access rights.
-    pub fn new_slice_child(
-        &self,
-        range: Range<usize>,
-    ) -> Result<VmoChildOptions<Rights, VmoSliceChild>> {
-        let dup_self = self.dup()?;
-        Ok(VmoChildOptions::new_slice_rights(dup_self, range))
-    }
-
     /// Creates a new COW VMO through a set of VMO child options.
     ///
     /// # Example
@@ -60,10 +29,7 @@ impl Vmo<Rights> {
     /// The new VMO child will be of the same capability flavor as the parent.
     /// The child will be given the access rights of the parent
     /// plus the Write right.
-    pub fn new_cow_child(
-        &self,
-        range: Range<usize>,
-    ) -> Result<VmoChildOptions<Rights, VmoCowChild>> {
+    pub fn new_cow_child(&self, range: Range<usize>) -> Result<VmoChildOptions<Rights>> {
         let dup_self = self.dup()?;
         Ok(VmoChildOptions::new_cow(dup_self, range))
     }

--- a/services/libs/aster-std/src/vm/vmo/static_cap.rs
+++ b/services/libs/aster-std/src/vm/vmo/static_cap.rs
@@ -5,41 +5,9 @@ use core::ops::Range;
 
 use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
 
-use super::VmoRightsOp;
-use super::{
-    options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions,
-};
+use super::{Vmo, VmoChildOptions, VmoRightsOp};
 
 impl<R: TRights> Vmo<TRightSet<R>> {
-    /// Creates a new slice VMO through a set of VMO child options.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let parent = VmoOptions::new(PAGE_SIZE).alloc().unwrap();
-    /// let child_size = parent.size();
-    /// let child = parent.new_slice_child(0..child_size).alloc().unwrap();
-    /// assert!(child.size() == child_size);
-    /// ```
-    ///
-    /// For more details on the available options, see `VmoChildOptions`.
-    ///
-    /// # Access rights
-    ///
-    /// This method requires the Dup right.
-    ///
-    /// The new VMO child will be of the same capability flavor as the parent;
-    /// so are the access rights.
-    #[require(R > Dup)]
-    pub fn new_slice_child(
-        &self,
-        range: Range<usize>,
-    ) -> Result<VmoChildOptions<TRightSet<R>, VmoSliceChild>> {
-        let dup_self = self.dup()?;
-        Ok(VmoChildOptions::new_slice(dup_self, range))
-    }
-
     /// Creates a new COW VMO through a set of VMO child options.
     ///
     /// # Example
@@ -61,10 +29,7 @@ impl<R: TRights> Vmo<TRightSet<R>> {
     /// The child will be given the access rights of the parent
     /// plus the Write right.
     #[require(R > Dup)]
-    pub fn new_cow_child(
-        &self,
-        range: Range<usize>,
-    ) -> Result<VmoChildOptions<TRightSet<R>, VmoCowChild>> {
+    pub fn new_cow_child(&self, range: Range<usize>) -> Result<VmoChildOptions<TRightSet<R>>> {
         let dup_self = self.dup()?;
         Ok(VmoChildOptions::new_cow(dup_self, range))
     }


### PR DESCRIPTION
The slice child VMO is utilized in shared memory scenarios. However, after further contemplation, I believe that this structure is not essential. Instead, shared memory functionality can be directly achieved by sharing at the VMO level itself.

Fundamentally, shared memory allows multiple processes to access the same memory region. Considering that a VMO  essentially abstracts a memory region, I believe that in shared memory situations, the same VMO can be mapped into different areas, causing these distinct mappings to correspond to the same underlying memory object, thus achieving the desired shared effect.