### PR TITLE
Lower the priority of the init thread

### DIFF
--- a/framework/aster-frame/src/task/priority.rs
+++ b/framework/aster-frame/src/task/priority.rs
@@ -17,7 +17,11 @@ impl Priority {
         Self::new(139)
     }
 
-    pub const fn low() -> Self {
+    pub const fn low_normal() -> Self {
+        Self::new(130)
+    }
+
+    pub const fn high_normal() -> Self {
         Self::new(110)
     }
 
@@ -25,7 +29,11 @@ impl Priority {
         Self::new(100)
     }
 
-    pub const fn high() -> Self {
+    pub const fn low_rt() -> Self {
+        Self::new(90)
+    }
+
+    pub const fn high_rt() -> Self {
         Self::new(10)
     }
 

--- a/services/libs/aster-std/src/lib.rs
+++ b/services/libs/aster-std/src/lib.rs
@@ -119,7 +119,8 @@ fn init_thread() {
 /// first process never return
 #[controlled]
 pub fn run_first_process() -> ! {
-    Thread::spawn_kernel_thread(ThreadOptions::new(init_thread));
+    let prio = aster_frame::task::Priority::low_normal();
+    Thread::spawn_kernel_thread(ThreadOptions::new(init_thread).priority(prio));
     unreachable!()
 }
 

--- a/services/libs/aster-std/src/thread/work_queue/worker.rs
+++ b/services/libs/aster-std/src/thread/work_queue/worker.rs
@@ -43,7 +43,7 @@ impl Worker {
             cpu_affinity.add(bound_cpu);
             let mut priority = Priority::normal();
             if worker_pool.upgrade().unwrap().is_high_priority() {
-                priority = Priority::high();
+                priority = Priority::high_rt();
             }
             let bound_thread = Thread::new_kernel_thread(
                 ThreadOptions::new(task_fn)


### PR DESCRIPTION
The initial kernel thread only yields again and again until "initproc becomes zombie".

https://github.com/asterinas/asterinas/blob/11ff35d34e8d3d1bf88bd17b774d53b128a27b7d/services/libs/aster-std/src/lib.rs#L103-L108

The PR won't affect the current scheduling, since the RR scheduler has no preemption among normal tasks(prioritized within $[100,139]$).