### PR TITLE
Print the instruction when user code reports invalid op code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "buddy_system_allocator",
  "cfg-if",
  "gimli",
+ "iced-x86",
  "inherit-methods-macro",
  "int-to-c-enum",
  "intrusive-collections",
@@ -801,6 +802,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "iced-x86"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c447cff8c7f384a7d4f741cfcff32f75f3ad02b406432e8d6c878d56b1edf6b"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "ident_case"

--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -35,6 +35,7 @@ acpi = "4.1.1"
 aml = "0.16.3"
 multiboot2 = "0.16.0"
 rsdp = "2.0.0"
+iced-x86 = { version = "1.21.0", default-features = false, features = [ "no_std", "decoder", "gas" ] }
 
 [features]
 intel_tdx = ["dep:tdx-guest"]

--- a/services/libs/aster-std/src/thread/exception.rs
+++ b/services/libs/aster-std/src/thread/exception.rs
@@ -16,6 +16,15 @@ pub fn handle_exception(context: &UserContext) {
 
     match *exception {
         PAGE_FAULT => handle_page_fault(trap_info),
+        INVALID_OPCODE => {
+            // Print the instruction if it is illegal
+            println!(
+                "Rip: 0x{:016x} Instruction: {}",
+                context.general_regs().rip,
+                context.rip_instruction()
+            );
+            generate_fault_signal(trap_info);
+        }
         _ => {
             // We current do nothing about other exceptions
             generate_fault_signal(trap_info);


### PR DESCRIPTION
The output is like this:
![image](https://github.com/asterinas/asterinas/assets/49150782/8caf37d5-8d66-4d59-930d-c6d017664252)
