### PR TITLE
Make background poll thread sleep

### DIFF
--- a/kernel/aster-nix/src/net/iface/mod.rs
+++ b/kernel/aster-nix/src/net/iface/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_frame::sync::WaitQueue;
 use smoltcp::iface::SocketSet;
 
 use self::common::IfaceCommon;
@@ -59,6 +60,11 @@ pub trait Iface: internal::IfaceInternal + Send + Sync {
     /// FIXME: The netmask and IP address should be one-to-one if there are multiple ip address
     fn netmask(&self) -> Option<Ipv4Address> {
         self.common().netmask()
+    }
+
+    /// The waitqueue used to background polling thread
+    fn polling_wait_queue(&self) -> &WaitQueue {
+        self.common().polling_wait_queue()
     }
 }
 

--- a/regression/apps/scripts/network.sh
+++ b/regression/apps/scripts/network.sh
@@ -18,7 +18,7 @@ echo "Start network test......"
 ./socketpair
 ./sockoption
 ./listen_backlog
-./send_buf_full
+# ./send_buf_full
 
 
 echo "All network test passed"


### PR DESCRIPTION
Fix #625.

The `send_buf_full` test is removed from regression test. 

It seems the test relies on the busy poll behavior, and the test will even fail on linux. Below is the error message when we try to run the test on linux.

The test may be added back once we fixed the problems. So we temporarily keep the code.
```test
Start receiving...
Sent bytes: 2586567
Received bytes: 2553825
Test failed: Mismatched sent bytes and received bytes
Test failed: Error occurs in child process
```