### PR TITLE
Add rustfmt.toml configuration to adjust the format of imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,11 @@ docs:
 	@echo "" 								# Add a blank line
 	@cd docs && mdbook build 				# Build mdBook
 
+format:
+	./tools/format_all.sh
+
 check:
-	@cargo fmt --check              # Check Rust format issues
+	./tools/format_all.sh --check   # Check Rust format issues
 	@cargo kclippy -- -D warnings   # Make build fail if any warnings are found by rustc and clippy
 
 clean:

--- a/framework/aster-frame/src/arch/x86/boot/linux_boot/mod.rs
+++ b/framework/aster-frame/src/arch/x86/boot/linux_boot/mod.rs
@@ -3,19 +3,21 @@
 //! The Linux 64-bit Boot Protocol supporting module.
 //!
 
-use linux_boot_params::{BootParams, E820Type, LINUX_BOOT_HEADER_MAGIC};
-
-use crate::boot::{
-    kcmdline::KCmdlineArg,
-    memory_region::{non_overlapping_regions_from, MemoryRegion, MemoryRegionType},
-    BootloaderAcpiArg, BootloaderFramebufferArg,
-};
-use crate::{config::PHYS_OFFSET, vm::paddr_to_vaddr};
-
 use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
 use core::ffi::CStr;
 
+use linux_boot_params::{BootParams, E820Type, LINUX_BOOT_HEADER_MAGIC};
 use spin::Once;
+
+use crate::{
+    boot::{
+        kcmdline::KCmdlineArg,
+        memory_region::{non_overlapping_regions_from, MemoryRegion, MemoryRegionType},
+        BootloaderAcpiArg, BootloaderFramebufferArg,
+    },
+    config::PHYS_OFFSET,
+    vm::paddr_to_vaddr,
+};
 
 static BOOT_PARAMS: Once<BootParams> = Once::new();
 

--- a/framework/aster-frame/src/arch/x86/boot/multiboot/mod.rs
+++ b/framework/aster-frame/src/arch/x86/boot/multiboot/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{string::String, vec::Vec};
+use core::arch::global_asm;
+
 use multiboot2::MemoryAreaType;
 use spin::Once;
 
@@ -13,8 +15,6 @@ use crate::{
     config::PHYS_OFFSET,
     vm::paddr_to_vaddr,
 };
-
-use core::arch::global_asm;
 
 global_asm!(include_str!("header.S"));
 

--- a/framework/aster-frame/src/arch/x86/boot/multiboot2/mod.rs
+++ b/framework/aster-frame/src/arch/x86/boot/multiboot2/mod.rs
@@ -4,16 +4,16 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use core::arch::global_asm;
+
 use multiboot2::{BootInformation, BootInformationHeader, MemoryAreaType};
+use spin::Once;
 
 use crate::boot::{
     kcmdline::KCmdlineArg,
     memory_region::{non_overlapping_regions_from, MemoryRegion, MemoryRegionType},
     BootloaderAcpiArg, BootloaderFramebufferArg,
 };
-use spin::Once;
-
-use core::arch::global_asm;
 
 global_asm!(include_str!("header.S"));
 

--- a/framework/aster-frame/src/arch/x86/console.rs
+++ b/framework/aster-frame/src/arch/x86/console.rs
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{fmt, sync::Arc, vec::Vec};
 use core::fmt::Write;
 
-use crate::sync::SpinLock;
-use crate::trap::IrqLine;
-use alloc::fmt;
-use alloc::{sync::Arc, vec::Vec};
 use log::debug;
 use spin::Once;
 use trapframe::TrapFrame;
 
-use super::device::serial::SerialPort;
-use super::kernel::IO_APIC;
+use super::{device::serial::SerialPort, kernel::IO_APIC};
+use crate::{sync::SpinLock, trap::IrqLine};
 
 #[inline]
 pub fn print(args: fmt::Arguments) {

--- a/framework/aster-frame/src/arch/x86/cpu.rs
+++ b/framework/aster-frame/src/arch/x86/cpu.rs
@@ -2,23 +2,28 @@
 
 //! CPU.
 
-use core::arch::x86_64::{_fxrstor, _fxsave};
-use core::fmt::Debug;
-
 use alloc::vec::Vec;
-use bitvec::{prelude::Lsb0, slice::IterOnes};
-use trapframe::{GeneralRegs, UserContext as RawUserContext};
+use core::{
+    arch::x86_64::{_fxrstor, _fxsave},
+    fmt::Debug,
+};
 
-#[cfg(feature = "intel_tdx")]
-use crate::arch::tdx_guest::{handle_virtual_exception, TdxTrapFrame};
-use bitvec::prelude::BitVec;
+use bitvec::{
+    prelude::{BitVec, Lsb0},
+    slice::IterOnes,
+};
 use log::debug;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::tdcall;
+use trapframe::{GeneralRegs, UserContext as RawUserContext};
 use x86_64::registers::rflags::RFlags;
 
-use crate::trap::call_irq_callback_functions;
-use crate::user::{UserContextApi, UserContextApiInternal, UserEvent};
+#[cfg(feature = "intel_tdx")]
+use crate::arch::tdx_guest::{handle_virtual_exception, TdxTrapFrame};
+use crate::{
+    trap::call_irq_callback_functions,
+    user::{UserContextApi, UserContextApiInternal, UserEvent},
+};
 
 /// Returns the number of CPUs.
 pub fn num_cpus() -> u32 {

--- a/framework/aster-frame/src/arch/x86/device/cmos.rs
+++ b/framework/aster-frame/src/arch/x86/device/cmos.rs
@@ -3,9 +3,8 @@
 use acpi::{fadt::Fadt, sdt::Signature};
 use x86_64::instructions::port::{ReadOnlyAccess, WriteOnlyAccess};
 
-use crate::arch::x86::kernel::acpi::ACPI_TABLES;
-
 use super::io_port::IoPort;
+use crate::arch::x86::kernel::acpi::ACPI_TABLES;
 
 pub static CMOS_ADDRESS: IoPort<u8, WriteOnlyAccess> = unsafe { IoPort::new(0x70) };
 pub static CMOS_DATA: IoPort<u8, ReadOnlyAccess> = unsafe { IoPort::new(0x71) };

--- a/framework/aster-frame/src/arch/x86/device/io_port.rs
+++ b/framework/aster-frame/src/arch/x86/device/io_port.rs
@@ -2,11 +2,13 @@
 
 use core::marker::PhantomData;
 
-pub use x86_64::instructions::port::{
-    PortReadAccess as IoPortReadAccess, PortWriteAccess as IoPortWriteAccess, ReadOnlyAccess,
-    ReadWriteAccess, WriteOnlyAccess,
+pub use x86_64::{
+    instructions::port::{
+        PortReadAccess as IoPortReadAccess, PortWriteAccess as IoPortWriteAccess, ReadOnlyAccess,
+        ReadWriteAccess, WriteOnlyAccess,
+    },
+    structures::port::{PortRead, PortWrite},
 };
-pub use x86_64::structures::port::{PortRead, PortWrite};
 
 /// An I/O port, representing a specific address in the I/O address of x86.
 ///

--- a/framework/aster-frame/src/arch/x86/iommu/context_table.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/context_table.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::collections::BTreeMap;
 use core::mem::size_of;
 
-use alloc::collections::BTreeMap;
 use log::warn;
 use pod::Pod;
 
+use super::second_stage::{PageTableEntry, PageTableFlags};
 use crate::{
     bus::pci::PciDeviceLocation,
     vm::{
@@ -14,8 +15,6 @@ use crate::{
         Paddr, PageTable, VmAllocOptions, VmFrame, VmIo,
     },
 };
-
-use super::second_stage::{PageTableEntry, PageTableFlags};
 
 /// Bit 0 is `Present` bit, indicating whether this entry is present.
 /// Bit 63:12 is the context-table pointer pointing to this bus's context-table.

--- a/framework/aster-frame/src/arch/x86/iommu/fault.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/fault.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
-use alloc::vec::Vec;
 use bitflags::bitflags;
 use log::info;
 use spin::Once;
 use trapframe::TrapFrame;
 use volatile::{access::ReadWrite, Volatile};
 
-use crate::{trap::IrqLine, vm::Vaddr};
-
 use super::remapping::Capability;
+use crate::{trap::IrqLine, vm::Vaddr};
 
 #[derive(Debug)]
 pub struct FaultEventRegisters {

--- a/framework/aster-frame/src/arch/x86/iommu/remapping.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/remapping.rs
@@ -8,6 +8,7 @@ use volatile::{
     Volatile,
 };
 
+use super::{context_table::RootTable, IommuError};
 use crate::{
     arch::{
         iommu::fault,
@@ -18,8 +19,6 @@ use crate::{
     },
     vm::paddr_to_vaddr,
 };
-
-use super::{context_table::RootTable, IommuError};
 
 #[derive(Debug)]
 pub struct RemappingRegisters {

--- a/framework/aster-frame/src/arch/x86/irq.rs
+++ b/framework/aster-frame/src/arch/x86/irq.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::sync::Mutex;
 use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec::Vec};
+
 use spin::Once;
 use trapframe::TrapFrame;
 
 use crate::{
-    sync::{SpinLock, SpinLockGuard},
+    sync::{Mutex, SpinLock, SpinLockGuard},
     util::recycle_allocator::RecycleAllocator,
 };
 

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/dmar.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/dmar.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::vec::Vec;
 use core::{fmt::Debug, mem::size_of, slice::Iter};
 
 use acpi::{sdt::Signature, AcpiTable};
-use alloc::vec::Vec;
-
-use crate::vm::paddr_to_vaddr;
 
 use super::{
     remapping::{Andd, Atsr, Drhd, Rhsa, Rmrr, Satc, Sidp},
     SdtHeaderWrapper,
 };
+use crate::vm::paddr_to_vaddr;
 
 /// DMA Remapping structure. When IOMMU is enabled, the structure should be present in the ACPI table,
 /// and the user can use the DRHD table in this structure to obtain the register base addresses used to configure functions such as IOMMU.

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/mod.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/mod.rs
@@ -3,20 +3,21 @@
 pub mod dmar;
 pub mod remapping;
 
+use alloc::borrow::ToOwned;
 use core::{
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
 
-use crate::vm::paddr_to_vaddr;
+use acpi::{sdt::SdtHeader, AcpiHandler, AcpiTable, AcpiTables};
+use log::{info, warn};
+use spin::Once;
+
 use crate::{
     boot::{self, BootloaderAcpiArg},
     sync::SpinLock,
+    vm::paddr_to_vaddr,
 };
-use acpi::{sdt::SdtHeader, AcpiHandler, AcpiTable, AcpiTables};
-use alloc::borrow::ToOwned;
-use log::{info, warn};
-use spin::Once;
 
 /// RSDP information, key is the signature, value is the virtual address of the signature
 pub static ACPI_TABLES: Once<SpinLock<AcpiTables<AcpiMemoryHandler>>> = Once::new();

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/remapping.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/remapping.rs
@@ -4,9 +4,8 @@
 //! This file defines these structures and provides a "Debug" implementation to see the value inside these structures.
 //! Most of the introduction are copied from Intel vt-directed-io-specification.
 
-use core::{fmt::Debug, mem::size_of};
-
 use alloc::{string::String, vec::Vec};
+use core::{fmt::Debug, mem::size_of};
 
 /// DMA-remapping hardware unit definition (DRHD).
 ///

--- a/framework/aster-frame/src/arch/x86/kernel/apic/ioapic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/ioapic.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{vec, vec::Vec};
+
 use acpi::PlatformInfo;
-use alloc::vec;
-use alloc::vec::Vec;
 use bit_field::BitField;
 use log::info;
 use spin::Once;

--- a/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::sync::Mutex;
-use alloc::boxed::Box;
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
+
 use log::info;
 use spin::Once;
+
+use crate::sync::Mutex;
 
 pub mod ioapic;
 pub mod x2apic;

--- a/framework/aster-frame/src/arch/x86/kernel/apic/xapic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/xapic.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::sync::Mutex;
-use crate::vm;
 use spin::Once;
 use x86::apic::xapic;
 
 use super::ApicTimer;
+use crate::{sync::Mutex, vm};
 
 const IA32_APIC_BASE_MSR: u32 = 0x1B;
 const IA32_APIC_BASE_MSR_BSP: u32 = 0x100; // Processor is a BSP

--- a/framework/aster-frame/src/arch/x86/kernel/pic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/pic.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::arch::x86::device::io_port::{IoPort, WriteOnlyAccess};
-use crate::trap::IrqLine;
-use core::sync::atomic::Ordering::Relaxed;
-use core::sync::atomic::{AtomicBool, AtomicU8};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering::Relaxed};
 
 use log::info;
+
+use crate::{
+    arch::x86::device::io_port::{IoPort, WriteOnlyAccess},
+    trap::IrqLine,
+};
 
 static MASTER_CMD: IoPort<u8, WriteOnlyAccess> = unsafe { IoPort::new(0x20) };
 static MASTER_DATA: IoPort<u8, WriteOnlyAccess> = unsafe { IoPort::new(0x21) };

--- a/framework/aster-frame/src/arch/x86/kernel/tsc.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/tsc.rs
@@ -4,6 +4,7 @@ use core::{
     arch::x86_64::_rdtsc,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
+
 use log::info;
 use trapframe::TrapFrame;
 use x86::cpuid::cpuid;

--- a/framework/aster-frame/src/arch/x86/mm/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mm/mod.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::sync::Mutex;
 use alloc::{collections::BTreeMap, fmt};
+
 use pod::Pod;
 use x86_64::{instructions::tlb, structures::paging::PhysFrame, VirtAddr};
 
 use crate::{
     config::ENTRY_COUNT,
+    sync::Mutex,
     vm::{
         page_table::{table_of, PageTableEntryTrait, PageTableFlagsTrait},
         Paddr, Vaddr,

--- a/framework/aster-frame/src/arch/x86/tdx_guest.rs
+++ b/framework/aster-frame/src/arch/x86/tdx_guest.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use tdx_guest::{
+    serial_println, tdcall,
     tdcall::TdgVeInfo,
+    tdvmcall,
     tdvmcall::{cpuid, hlt, rdmsr, wrmsr, IoSize},
-    {serial_println, tdcall, tdvmcall, TdxVirtualExceptionType},
+    TdxVirtualExceptionType,
 };
 
 pub trait TdxTrapFrame {

--- a/framework/aster-frame/src/arch/x86/timer/apic.rs
+++ b/framework/aster-frame/src/arch/x86/timer/apic.rs
@@ -1,22 +1,31 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
-use core::arch::x86_64::_rdtsc;
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use x86::cpuid::cpuid;
+use core::{
+    arch::x86_64::_rdtsc,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
 use log::info;
 use spin::Once;
 use trapframe::TrapFrame;
-use x86::msr::{wrmsr, IA32_TSC_DEADLINE};
-
-use crate::arch::kernel::tsc::init_tsc_freq;
-use crate::arch::timer::pit::OperatingMode;
-use crate::arch::x86::kernel::apic::{DivideConfig, APIC_INSTANCE};
-use crate::arch::x86::kernel::tsc::TSC_FREQ;
-use crate::trap::IrqLine;
+use x86::{
+    cpuid::cpuid,
+    msr::{wrmsr, IA32_TSC_DEADLINE},
+};
 
 use super::TIMER_FREQ;
+use crate::{
+    arch::{
+        kernel::tsc::init_tsc_freq,
+        timer::pit::OperatingMode,
+        x86::kernel::{
+            apic::{DivideConfig, APIC_INSTANCE},
+            tsc::TSC_FREQ,
+        },
+    },
+    trap::IrqLine,
+};
 
 pub fn init() {
     init_tsc_freq();

--- a/framework/aster-frame/src/arch/x86/timer/hpet.rs
+++ b/framework/aster-frame/src/arch/x86/timer/hpet.rs
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{trap::IrqLine, vm::paddr_to_vaddr};
-use acpi::{AcpiError, HpetInfo};
 use alloc::vec::Vec;
+
+use acpi::{AcpiError, HpetInfo};
 use spin::Once;
 use volatile::{
     access::{ReadOnly, ReadWrite},
     Volatile,
 };
 
-use crate::arch::x86::kernel::{acpi::ACPI_TABLES, apic::ioapic};
+use crate::{
+    arch::x86::kernel::{acpi::ACPI_TABLES, apic::ioapic},
+    trap::IrqLine,
+    vm::paddr_to_vaddr,
+};
 static HPET_INSTANCE: Once<Hpet> = Once::new();
 
 const OFFSET_ID_REGISTER: usize = 0x000;

--- a/framework/aster-frame/src/arch/x86/timer/mod.rs
+++ b/framework/aster-frame/src/arch/x86/timer/mod.rs
@@ -4,18 +4,17 @@ pub mod apic;
 pub mod hpet;
 pub mod pit;
 
-use core::any::Any;
-use core::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
-
 use alloc::{boxed::Box, collections::BinaryHeap, sync::Arc, vec::Vec};
+use core::{
+    any::Any,
+    sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
+};
+
 use spin::Once;
 use trapframe::TrapFrame;
 
-use crate::arch::x86::kernel;
-use crate::sync::SpinLock;
-use crate::trap::IrqLine;
-
 use self::apic::APIC_TIMER_CALLBACK;
+use crate::{arch::x86::kernel, sync::SpinLock, trap::IrqLine};
 
 /// The timer frequency (Hz). Here we choose 1000Hz since 1000Hz is easier for unit conversion and
 /// convenient for timer. What's more, the frequency cannot be set too high or too low, 1000Hz is

--- a/framework/aster-frame/src/boot/kcmdline.rs
+++ b/framework/aster-frame/src/boot/kcmdline.rs
@@ -15,6 +15,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
+
 use log::warn;
 
 #[derive(PartialEq, Debug)]

--- a/framework/aster-frame/src/boot/mod.rs
+++ b/framework/aster-frame/src/boot/mod.rs
@@ -7,12 +7,12 @@
 pub mod kcmdline;
 pub mod memory_region;
 
+use alloc::{string::String, vec::Vec};
+
 use kcmdline::KCmdlineArg;
+use spin::Once;
 
 use self::memory_region::MemoryRegion;
-
-use alloc::{string::String, vec::Vec};
-use spin::Once;
 
 /// ACPI information from the bootloader.
 ///
@@ -119,9 +119,10 @@ pub fn call_aster_main() -> ! {
     }
     #[cfg(ktest)]
     {
-        use crate::arch::qemu::{exit_qemu, QemuExitCode};
         use alloc::{boxed::Box, string::ToString};
         use core::any::Any;
+
+        use crate::arch::qemu::{exit_qemu, QemuExitCode};
         crate::init();
         let fn_catch_unwind = &(unwinding::panic::catch_unwind::<(), fn()>
             as fn(fn()) -> Result<(), Box<(dyn Any + Send + 'static)>>);

--- a/framework/aster-frame/src/bus/mmio/bus.rs
+++ b/framework/aster-frame/src/bus/mmio/bus.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{collections::VecDeque, fmt::Debug, sync::Arc, vec::Vec};
+
 use log::{debug, error};
 
-use crate::bus::BusProbeError;
-
 use super::device::MmioCommonDevice;
+use crate::bus::BusProbeError;
 
 pub trait MmioDevice: Sync + Send + Debug {
     fn device_id(&self) -> u32;

--- a/framework/aster-frame/src/bus/mmio/device.rs
+++ b/framework/aster-frame/src/bus/mmio/device.rs
@@ -3,13 +3,12 @@
 use int_to_c_enum::TryFromInt;
 use log::info;
 
+use super::VIRTIO_MMIO_MAGIC;
 use crate::{
     io_mem::IoMem,
     trap::IrqLine,
     vm::{paddr_to_vaddr, Paddr, VmIo},
 };
-
-use super::VIRTIO_MMIO_MAGIC;
 
 /// MMIO Common device.
 /// TODO: Implement universal access to MMIO devices since we are temporarily

--- a/framework/aster-frame/src/bus/mmio/mod.rs
+++ b/framework/aster-frame/src/bus/mmio/mod.rs
@@ -5,17 +5,16 @@
 pub mod bus;
 pub mod device;
 
+use alloc::vec::Vec;
 use core::ops::Range;
 
-use alloc::vec::Vec;
 use log::debug;
 
+use self::bus::MmioBus;
 use crate::{
     arch::kernel::IO_APIC, bus::mmio::device::MmioCommonDevice, sync::SpinLock, trap::IrqLine,
     vm::paddr_to_vaddr,
 };
-
-use self::bus::MmioBus;
 
 const VIRTIO_MMIO_MAGIC: u32 = 0x74726976;
 

--- a/framework/aster-frame/src/bus/pci/bus.rs
+++ b/framework/aster-frame/src/bus/pci/bus.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
-use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 use log::{debug, error};
 
-use crate::bus::BusProbeError;
-
 use super::{device_info::PciDeviceId, PciCommonDevice};
+use crate::bus::BusProbeError;
 
 pub trait PciDevice: Sync + Send + Debug {
     fn device_id(&self) -> PciDeviceId;

--- a/framework/aster-frame/src/bus/pci/capability/mod.rs
+++ b/framework/aster-frame/src/bus/pci/capability/mod.rs
@@ -3,7 +3,6 @@
 use alloc::vec::Vec;
 
 use self::{msix::CapabilityMsixData, vendor::CapabilityVndrData};
-
 use super::{
     cfg_space::{PciDeviceCommonCfgOffset, Status},
     common_device::PciCommonDevice,

--- a/framework/aster-frame/src/bus/pci/capability/vendor.rs
+++ b/framework/aster-frame/src/bus/pci/capability/vendor.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::bus::pci::{common_device::PciCommonDevice, device_info::PciDeviceLocation};
-use crate::{Error, Result};
+use crate::{
+    bus::pci::{common_device::PciCommonDevice, device_info::PciDeviceLocation},
+    Error, Result,
+};
 
 /// Vendor specific capability. Users can access this capability area at will,
 /// except for the PCI configuration space which cannot be accessed at will through this structure.

--- a/framework/aster-frame/src/bus/pci/cfg_space.rs
+++ b/framework/aster-frame/src/bus/pci/cfg_space.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
+
 use bitflags::bitflags;
 
-use crate::{io_mem::IoMem, Error, Result};
-
 use super::PciDeviceLocation;
+use crate::{io_mem::IoMem, Error, Result};
 
 #[repr(u16)]
 pub enum PciDeviceCommonCfgOffset {

--- a/framework/aster-frame/src/bus/pci/device_info.rs
+++ b/framework/aster-frame/src/bus/pci/device_info.rs
@@ -2,9 +2,8 @@
 
 use core::iter;
 
-use crate::arch::pci::{PCI_ADDRESS_PORT, PCI_DATA_PORT};
-
 use super::cfg_space::PciDeviceCommonCfgOffset;
+use crate::arch::pci::{PCI_ADDRESS_PORT, PCI_DATA_PORT};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PciDeviceId {

--- a/framework/aster-frame/src/bus/pci/mod.rs
+++ b/framework/aster-frame/src/bus/pci/mod.rs
@@ -56,10 +56,10 @@ pub mod cfg_space;
 pub mod common_device;
 mod device_info;
 
-use crate::sync::Mutex;
 pub use device_info::{PciDeviceId, PciDeviceLocation};
 
 use self::{bus::PciBus, common_device::PciCommonDevice};
+use crate::sync::Mutex;
 
 pub static PCI_BUS: Mutex<PciBus> = Mutex::new(PciBus::new());
 

--- a/framework/aster-frame/src/cpu.rs
+++ b/framework/aster-frame/src/cpu.rs
@@ -2,9 +2,9 @@
 
 //! CPU.
 
+use core::{cell::UnsafeCell, ops::Deref};
+
 use crate::trap::disable_local;
-use core::cell::UnsafeCell;
-use core::ops::Deref;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")]{

--- a/framework/aster-frame/src/io_mem.rs
+++ b/framework/aster-frame/src/io_mem.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::{mem::size_of, ops::Range};
+
 use pod::Pod;
 
 use crate::{

--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -43,11 +43,10 @@ pub mod user;
 mod util;
 pub mod vm;
 
-pub use self::cpu::CpuLocal;
-pub use self::error::Error;
-pub use self::prelude::Result;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::init_tdx;
+
+pub use self::{cpu::CpuLocal, error::Error, prelude::Result};
 
 pub fn init() {
     arch::before_all_init();

--- a/framework/aster-frame/src/logger.rs
+++ b/framework/aster-frame/src/logger.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{config::DEFAULT_LOG_LEVEL, early_println};
-
 use log::{Metadata, Record};
+
+use crate::{config::DEFAULT_LOG_LEVEL, early_println};
 
 const LOGGER: Logger = Logger {};
 

--- a/framework/aster-frame/src/panicking.rs
+++ b/framework/aster-frame/src/panicking.rs
@@ -5,14 +5,16 @@
 use alloc::{boxed::Box, string::ToString};
 use core::ffi::c_void;
 
-use crate::arch::qemu::{exit_qemu, QemuExitCode};
-use crate::{early_print, early_println};
 use log::error;
+
+use crate::{
+    arch::qemu::{exit_qemu, QemuExitCode},
+    early_print, early_println,
+};
 
 extern crate cfg_if;
 extern crate gimli;
 use gimli::Register;
-
 use unwinding::{
     abi::{
         UnwindContext, UnwindReasonCode, _Unwind_Backtrace, _Unwind_FindEnclosingFunction,

--- a/framework/aster-frame/src/prelude.rs
+++ b/framework/aster-frame/src/prelude.rs
@@ -4,9 +4,7 @@
 
 pub type Result<T> = core::result::Result<T, crate::error::Error>;
 
-pub(crate) use alloc::boxed::Box;
-pub(crate) use alloc::sync::Arc;
-pub(crate) use alloc::vec::Vec;
+pub(crate) use alloc::{boxed::Box, sync::Arc, vec::Vec};
 pub(crate) use core::any::Any;
 
 pub use crate::vm::{Paddr, Vaddr};

--- a/framework/aster-frame/src/sync/atomic_bits.rs
+++ b/framework/aster-frame/src/sync/atomic_bits.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt::{self};
-use core::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use core::{
+    fmt::{self},
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+};
 
 use align_ext::AlignExt;
 

--- a/framework/aster-frame/src/sync/mod.rs
+++ b/framework/aster-frame/src/sync/mod.rs
@@ -10,10 +10,12 @@ mod rwmutex;
 mod spin;
 mod wait;
 
-pub use self::atomic_bits::AtomicBits;
-pub use self::mutex::{Mutex, MutexGuard};
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};
-pub use self::rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard};
-pub use self::rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard};
-pub use self::spin::{SpinLock, SpinLockGuard};
-pub use self::wait::WaitQueue;
+pub use self::{
+    atomic_bits::AtomicBits,
+    mutex::{Mutex, MutexGuard},
+    rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard},
+    rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
+    spin::{SpinLock, SpinLockGuard},
+    wait::WaitQueue,
+};

--- a/framework/aster-frame/src/sync/mutex.rs
+++ b/framework/aster-frame/src/sync/mutex.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::WaitQueue;
-use core::cell::UnsafeCell;
-use core::ops::{Deref, DerefMut};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
+};
 
-use core::fmt;
-use core::sync::atomic::{AtomicBool, Ordering};
+use super::WaitQueue;
 
 /// A mutex with waitqueue.
 pub struct Mutex<T> {

--- a/framework/aster-frame/src/sync/rwlock.rs
+++ b/framework/aster-frame/src/sync/rwlock.rs
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::ops::{Deref, DerefMut};
-use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::atomic::{
+        AtomicUsize,
+        Ordering::{AcqRel, Acquire, Relaxed, Release},
+    },
+};
 
-use crate::task::{disable_preempt, DisablePreemptGuard};
-use crate::trap::disable_local;
-use crate::trap::DisabledLocalIrqGuard;
+use crate::{
+    task::{disable_preempt, DisablePreemptGuard},
+    trap::{disable_local, DisabledLocalIrqGuard},
+};
 
 /// Spin-based Read-write Lock
 ///

--- a/framework/aster-frame/src/sync/rwmutex.rs
+++ b/framework/aster-frame/src/sync/rwmutex.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::ops::{Deref, DerefMut};
-use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::atomic::{
+        AtomicUsize,
+        Ordering::{AcqRel, Acquire, Relaxed, Release},
+    },
+};
 
 use super::WaitQueue;
 

--- a/framework/aster-frame/src/sync/spin.rs
+++ b/framework/aster-frame/src/sync/spin.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
+};
 
-use crate::task::{disable_preempt, DisablePreemptGuard};
-use crate::trap::disable_local;
-use crate::trap::DisabledLocalIrqGuard;
+use crate::{
+    task::{disable_preempt, DisablePreemptGuard},
+    trap::{disable_local, DisabledLocalIrqGuard},
+};
 
 /// A spin lock.
 pub struct SpinLock<T> {

--- a/framework/aster-frame/src/sync/wait.rs
+++ b/framework/aster-frame/src/sync/wait.rs
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SpinLock;
-use crate::arch::timer::{add_timeout_list, TIMER_FREQ};
 use alloc::{collections::VecDeque, sync::Arc};
-use bitflags::bitflags;
-use core::sync::atomic::{AtomicBool, Ordering};
-use core::time::Duration;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
-use crate::task::{add_task, current_task, schedule, Task, TaskStatus};
+use bitflags::bitflags;
+
+use super::SpinLock;
+use crate::{
+    arch::timer::{add_timeout_list, TIMER_FREQ},
+    task::{add_task, current_task, schedule, Task, TaskStatus},
+};
 
 /// A wait queue.
 ///

--- a/framework/aster-frame/src/task/mod.rs
+++ b/framework/aster-frame/src/task/mod.rs
@@ -8,7 +8,9 @@ mod scheduler;
 #[allow(clippy::module_inception)]
 mod task;
 
-pub use self::priority::Priority;
-pub use self::processor::{current_task, disable_preempt, preempt, schedule, DisablePreemptGuard};
-pub use self::scheduler::{add_task, set_scheduler, Scheduler};
-pub use self::task::{Task, TaskAdapter, TaskOptions, TaskStatus};
+pub use self::{
+    priority::Priority,
+    processor::{current_task, disable_preempt, preempt, schedule, DisablePreemptGuard},
+    scheduler::{add_task, set_scheduler, Scheduler},
+    task::{Task, TaskAdapter, TaskOptions, TaskStatus},
+};

--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -1,20 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::AtomicUsize;
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
-use crate::cpu_local;
-use crate::sync::Mutex;
-use crate::trap::disable_local;
-
-use core::sync::atomic::Ordering::Relaxed;
+use lazy_static::lazy_static;
 
 use super::{
     scheduler::{fetch_task, GLOBAL_SCHEDULER},
     task::{context_switch, TaskContext},
     Task, TaskStatus,
 };
-use alloc::sync::Arc;
-use lazy_static::lazy_static;
+use crate::{cpu_local, sync::Mutex, trap::disable_local};
 
 pub struct Processor {
     current: Option<Arc<Task>>,

--- a/framework/aster-frame/src/task/scheduler.rs
+++ b/framework/aster-frame/src/task/scheduler.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use crate::sync::SpinLock;
-use crate::task::Task;
-
 use lazy_static::lazy_static;
+
+use crate::{prelude::*, sync::SpinLock, task::Task};
 
 lazy_static! {
     pub(crate) static ref GLOBAL_SCHEDULER: SpinLock<GlobalScheduler> =

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::arch::mm::PageTableFlags;
-use crate::config::{KERNEL_STACK_SIZE, PAGE_SIZE};
-use crate::cpu::CpuSet;
-use crate::prelude::*;
-use crate::sync::{Mutex, MutexGuard};
-use crate::user::UserSpace;
-use crate::vm::page_table::KERNEL_PAGE_TABLE;
-use crate::vm::{VmAllocOptions, VmSegment};
+use intrusive_collections::{intrusive_adapter, LinkedListAtomicLink};
 
-use intrusive_collections::intrusive_adapter;
-use intrusive_collections::LinkedListAtomicLink;
-
-use super::add_task;
-use super::priority::Priority;
-use super::processor::{current_task, schedule};
+use super::{
+    add_task,
+    priority::Priority,
+    processor::{current_task, schedule},
+};
+use crate::{
+    arch::mm::PageTableFlags,
+    config::{KERNEL_STACK_SIZE, PAGE_SIZE},
+    cpu::CpuSet,
+    prelude::*,
+    sync::{Mutex, MutexGuard},
+    user::UserSpace,
+    vm::{page_table::KERNEL_PAGE_TABLE, VmAllocOptions, VmSegment},
+};
 
 core::arch::global_asm!(include_str!("switch.S"));
 

--- a/framework/aster-frame/src/timer.rs
+++ b/framework/aster-frame/src/timer.rs
@@ -2,12 +2,14 @@
 
 //! Timer.
 
-use crate::arch::timer::{add_timeout_list, TimerCallback, TICK};
-use crate::prelude::*;
-use crate::{arch::timer::TIMER_FREQ, sync::SpinLock};
 use core::{sync::atomic::Ordering, time::Duration};
 
 pub use crate::arch::timer::read_monotonic_milli_seconds;
+use crate::{
+    arch::timer::{add_timeout_list, TimerCallback, TICK, TIMER_FREQ},
+    prelude::*,
+    sync::SpinLock,
+};
 
 /// A timer invokes a callback function after a specified span of time elapsed.
 ///

--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -2,13 +2,13 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::{arch::irq::IRQ_LIST, cpu::CpuException, cpu_local};
-
-#[cfg(feature = "intel_tdx")]
-use crate::arch::tdx_guest::{handle_virtual_exception, TdxTrapFrame};
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::tdcall;
 use trapframe::TrapFrame;
+
+#[cfg(feature = "intel_tdx")]
+use crate::arch::tdx_guest::{handle_virtual_exception, TdxTrapFrame};
+use crate::{arch::irq::IRQ_LIST, cpu::CpuException, cpu_local};
 
 #[cfg(feature = "intel_tdx")]
 impl TdxTrapFrame for TrapFrame {

--- a/framework/aster-frame/src/trap/irq.rs
+++ b/framework/aster-frame/src/trap/irq.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::arch::irq::{self, IrqCallbackHandle, NOT_USING_IRQ};
-use crate::task::{disable_preempt, DisablePreemptGuard};
-use crate::{prelude::*, Error};
-
 use core::fmt::Debug;
+
 use trapframe::TrapFrame;
+
+use crate::{
+    arch::irq::{self, IrqCallbackHandle, NOT_USING_IRQ},
+    prelude::*,
+    task::{disable_preempt, DisablePreemptGuard},
+    Error,
+};
 
 pub type IrqCallbackFunction = dyn Fn(&TrapFrame) + Sync + Send + 'static;
 

--- a/framework/aster-frame/src/trap/mod.rs
+++ b/framework/aster-frame/src/trap/mod.rs
@@ -3,10 +3,11 @@
 mod handler;
 mod irq;
 
-pub(crate) use self::handler::call_irq_callback_functions;
-pub use self::irq::{disable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine};
 pub use handler::in_interrupt_context;
 pub use trapframe::TrapFrame;
+
+pub(crate) use self::handler::call_irq_callback_functions;
+pub use self::irq::{disable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine};
 
 pub(crate) fn init() {
     unsafe {

--- a/framework/aster-frame/src/user.rs
+++ b/framework/aster-frame/src/user.rs
@@ -2,11 +2,9 @@
 
 //! User space.
 
-use crate::cpu::UserContext;
-use crate::prelude::*;
-use crate::task::Task;
-use crate::vm::VmSpace;
 use trapframe::TrapFrame;
+
+use crate::{cpu::UserContext, prelude::*, task::Task, vm::VmSpace};
 
 /// A user space.
 ///

--- a/framework/aster-frame/src/vm/dma/dma_coherent.rs
+++ b/framework/aster-frame/src/vm/dma/dma_coherent.rs
@@ -3,15 +3,16 @@
 use alloc::sync::Arc;
 use core::ops::Deref;
 
-use crate::arch::{iommu, mm::PageTableFlags};
-use crate::vm::{
-    dma::{dma_type, Daddr, DmaType},
-    paddr_to_vaddr,
-    page_table::KERNEL_PAGE_TABLE,
-    HasPaddr, Paddr, VmIo, VmReader, VmSegment, VmWriter, PAGE_SIZE,
-};
-
 use super::{check_and_insert_dma_mapping, remove_dma_mapping, DmaError, HasDaddr};
+use crate::{
+    arch::{iommu, mm::PageTableFlags},
+    vm::{
+        dma::{dma_type, Daddr, DmaType},
+        paddr_to_vaddr,
+        page_table::KERNEL_PAGE_TABLE,
+        HasPaddr, Paddr, VmIo, VmReader, VmSegment, VmWriter, PAGE_SIZE,
+    },
+};
 
 /// A coherent (or consistent) DMA mapping,
 /// which guarantees that the device and the CPU can
@@ -163,9 +164,10 @@ impl HasPaddr for DmaCoherent {
 
 #[if_cfg_ktest]
 mod test {
+    use alloc::vec;
+
     use super::*;
     use crate::vm::VmAllocOptions;
-    use alloc::vec;
 
     #[ktest]
     fn map_with_coherent_device() {

--- a/framework/aster-frame/src/vm/dma/dma_stream.rs
+++ b/framework/aster-frame/src/vm/dma/dma_stream.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
-use core::arch::x86_64::_mm_clflush;
-use core::ops::Range;
-
-use crate::arch::iommu;
-use crate::error::Error;
-use crate::vm::{
-    dma::{dma_type, Daddr, DmaType},
-    HasPaddr, Paddr, VmSegment, PAGE_SIZE,
-};
-use crate::vm::{VmIo, VmReader, VmWriter};
+use core::{arch::x86_64::_mm_clflush, ops::Range};
 
 use super::{check_and_insert_dma_mapping, remove_dma_mapping, DmaError, HasDaddr};
+use crate::{
+    arch::iommu,
+    error::Error,
+    vm::{
+        dma::{dma_type, Daddr, DmaType},
+        HasPaddr, Paddr, VmIo, VmReader, VmSegment, VmWriter, PAGE_SIZE,
+    },
+};
 
 /// A streaming DMA mapping. Users must synchronize data
 /// before reading or after writing to ensure consistency.
@@ -198,9 +197,10 @@ impl HasPaddr for DmaStream {
 
 #[if_cfg_ktest]
 mod test {
+    use alloc::vec;
+
     use super::*;
     use crate::vm::VmAllocOptions;
-    use alloc::vec;
 
     #[ktest]
     fn streaming_map() {

--- a/framework/aster-frame/src/vm/dma/mod.rs
+++ b/framework/aster-frame/src/vm/dma/mod.rs
@@ -4,14 +4,13 @@ mod dma_coherent;
 mod dma_stream;
 
 use alloc::collections::BTreeSet;
-use spin::Once;
-
-use crate::{arch::iommu::has_iommu, config::PAGE_SIZE, sync::SpinLock};
-
-use super::Paddr;
 
 pub use dma_coherent::DmaCoherent;
 pub use dma_stream::{DmaDirection, DmaStream};
+use spin::Once;
+
+use super::Paddr;
+use crate::{arch::iommu::has_iommu, config::PAGE_SIZE, sync::SpinLock};
 
 /// If a device performs DMA to read or write system
 /// memory, the addresses used by the device are device addresses.

--- a/framework/aster-frame/src/vm/frame.rs
+++ b/framework/aster-frame/src/vm/frame.rs
@@ -6,12 +6,11 @@ use core::{
     marker::PhantomData,
     ops::{BitAnd, BitOr, Not, Range},
 };
+
 use pod::Pod;
 
+use super::{frame_allocator, HasPaddr, Paddr, VmIo};
 use crate::{config::PAGE_SIZE, prelude::*, Error};
-
-use super::{frame_allocator, HasPaddr};
-use super::{Paddr, VmIo};
 
 /// A collection of page frames (physical memory pages).
 ///

--- a/framework/aster-frame/src/vm/frame_allocator.rs
+++ b/framework/aster-frame/src/vm/frame_allocator.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use align_ext::AlignExt;
 use alloc::vec::Vec;
+
+use align_ext::AlignExt;
 use buddy_system_allocator::FrameAllocator;
 use log::info;
 use spin::Once;
 
-use crate::boot::memory_region::{MemoryRegion, MemoryRegionType};
-use crate::{config::PAGE_SIZE, sync::SpinLock};
-
 use super::{frame::VmFrameFlags, VmFrame, VmFrameVec, VmSegment};
+use crate::{
+    boot::memory_region::{MemoryRegion, MemoryRegionType},
+    config::PAGE_SIZE,
+    sync::SpinLock,
+};
 
 pub(super) static FRAME_ALLOCATOR: Once<SpinLock<FrameAllocator>> = Once::new();
 

--- a/framework/aster-frame/src/vm/heap_allocator.rs
+++ b/framework/aster-frame/src/vm/heap_allocator.rs
@@ -1,20 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::config::{KERNEL_HEAP_SIZE, PAGE_SIZE};
-use crate::prelude::*;
-use crate::sync::SpinLock;
-use crate::trap::disable_local;
-use crate::vm::frame_allocator::FRAME_ALLOCATOR;
-use crate::Error;
-use align_ext::AlignExt;
-use buddy_system_allocator::Heap;
 use core::{
     alloc::{GlobalAlloc, Layout},
     ptr::NonNull,
 };
+
+use align_ext::AlignExt;
+use buddy_system_allocator::Heap;
 use log::debug;
 
 use super::paddr_to_vaddr;
+use crate::{
+    config::{KERNEL_HEAP_SIZE, PAGE_SIZE},
+    prelude::*,
+    sync::SpinLock,
+    trap::disable_local,
+    vm::frame_allocator::FRAME_ALLOCATOR,
+    Error,
+};
 
 #[global_allocator]
 static HEAP_ALLOCATOR: LockedHeapWithRescue<32> = LockedHeapWithRescue::new(rescue);

--- a/framework/aster-frame/src/vm/io.rs
+++ b/framework/aster-frame/src/vm/io.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use inherit_methods_macro::inherit_methods;
 use pod::Pod;
 
-use inherit_methods_macro::inherit_methods;
+use crate::prelude::*;
 
 /// A trait that enables reading/writing data from/to a VM object,
 /// e.g., `VmSpace`, `VmFrameVec`, and `VmFrame`.

--- a/framework/aster-frame/src/vm/memory_set.rs
+++ b/framework/aster-frame/src/vm/memory_set.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::collections::{btree_map::Entry, BTreeMap};
+use core::fmt;
+
 use super::page_table::{PageTable, PageTableConfig, UserMode};
 use crate::{
     arch::mm::{PageTableEntry, PageTableFlags},
     config::{PAGE_SIZE, PHYS_OFFSET},
-    vm::is_page_aligned,
-    vm::{VmAllocOptions, VmFrame, VmFrameVec, VmReader, VmWriter},
+    prelude::*,
+    vm::{is_page_aligned, VmAllocOptions, VmFrame, VmFrameVec, VmReader, VmWriter},
+    Error,
 };
-use crate::{prelude::*, Error};
-use alloc::collections::{btree_map::Entry, BTreeMap};
-use core::fmt;
 
 #[derive(Debug)]
 pub struct MapArea {

--- a/framework/aster-frame/src/vm/mod.rs
+++ b/framework/aster-frame/src/vm/mod.rs
@@ -19,24 +19,23 @@ mod options;
 pub(crate) mod page_table;
 mod space;
 
-use crate::config::{KERNEL_OFFSET, PAGE_SIZE, PHYS_OFFSET};
+use alloc::{borrow::ToOwned, vec::Vec};
 
-pub use self::dma::{DmaCoherent, DmaDirection, DmaStream, HasDaddr};
-pub use self::frame::{VmFrame, VmFrameVec, VmFrameVecIter, VmReader, VmSegment, VmWriter};
-pub use self::io::VmIo;
-pub use self::options::VmAllocOptions;
-pub use self::space::{VmMapOptions, VmPerm, VmSpace};
-
-pub use self::{
-    memory_set::{MapArea, MemorySet},
-    page_table::PageTable,
-};
-
-use alloc::borrow::ToOwned;
-use alloc::vec::Vec;
 use spin::Once;
 
-use crate::boot::memory_region::{MemoryRegion, MemoryRegionType};
+pub use self::{
+    dma::{DmaCoherent, DmaDirection, DmaStream, HasDaddr},
+    frame::{VmFrame, VmFrameVec, VmFrameVecIter, VmReader, VmSegment, VmWriter},
+    io::VmIo,
+    memory_set::{MapArea, MemorySet},
+    options::VmAllocOptions,
+    page_table::PageTable,
+    space::{VmMapOptions, VmPerm, VmSpace},
+};
+use crate::{
+    boot::memory_region::{MemoryRegion, MemoryRegionType},
+    config::{KERNEL_OFFSET, PAGE_SIZE, PHYS_OFFSET},
+};
 
 /// Get physical address trait
 pub trait HasPaddr {

--- a/framework/aster-frame/src/vm/options.rs
+++ b/framework/aster-frame/src/vm/options.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{prelude::*, Error};
-
 use super::{frame::VmFrameFlags, frame_allocator, VmFrame, VmFrameVec, VmSegment};
+use crate::{prelude::*, Error};
 
 /// Options for allocating physical memory pages (or frames).
 ///

--- a/framework/aster-frame/src/vm/page_table.rs
+++ b/framework/aster-frame/src/vm/page_table.rs
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{vec, vec::Vec};
+use core::{fmt::Debug, marker::PhantomData, mem::size_of};
+
+use log::trace;
+use pod::Pod;
+use spin::Once;
+
 use super::{paddr_to_vaddr, Paddr, Vaddr, VmAllocOptions};
 use crate::{
     arch::mm::{is_kernel_vaddr, is_user_vaddr, tlb_flush, PageTableEntry},
@@ -7,11 +14,6 @@ use crate::{
     sync::SpinLock,
     vm::VmFrame,
 };
-use alloc::{vec, vec::Vec};
-use core::{fmt::Debug, marker::PhantomData, mem::size_of};
-use log::trace;
-use pod::Pod;
-use spin::Once;
 
 pub trait PageTableFlagsTrait: Clone + Copy + Sized + Pod + Debug {
     fn new() -> Self;

--- a/framework/aster-frame/src/vm/space.rs
+++ b/framework/aster-frame/src/vm/space.rs
@@ -1,17 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::arch::mm::PageTableFlags;
-use crate::config::PAGE_SIZE;
-use crate::sync::Mutex;
-use bitflags::bitflags;
 use core::ops::Range;
 
-use super::VmFrameVec;
-use super::{is_page_aligned, Vaddr};
-use super::{MapArea, MemorySet};
-use crate::{prelude::*, Error};
+use bitflags::bitflags;
 
-use super::VmIo;
+use super::{is_page_aligned, MapArea, MemorySet, Vaddr, VmFrameVec, VmIo};
+use crate::{arch::mm::PageTableFlags, config::PAGE_SIZE, prelude::*, sync::Mutex, Error};
 
 /// Virtual memory space.
 ///

--- a/framework/libs/ktest/src/runner.rs
+++ b/framework/libs/ktest/src/runner.rs
@@ -3,16 +3,16 @@
 //! Test runner enabling control over the tests.
 //!
 
+use alloc::{string::String, vec::Vec};
+use core::format_args;
+
+use owo_colors::OwoColorize;
+
 use crate::{
     path::{KtestPath, SuffixTrie},
     tree::{KtestCrate, KtestTree},
     CatchUnwindImpl, KtestError, KtestItem, KtestIter,
 };
-
-use alloc::{string::String, vec::Vec};
-use core::format_args;
-
-use owo_colors::OwoColorize;
 
 pub enum KtestResult {
     Ok,

--- a/framework/libs/linux-bzimage/boot-params/src/lib.rs
+++ b/framework/libs/linux-bzimage/boot-params/src/lib.rs
@@ -262,9 +262,9 @@ const EDDMAXNR: usize = 6;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use core::mem::offset_of;
+
+    use super::*;
 
     #[test]
     fn test_screen_info_offsets() {

--- a/framework/libs/linux-bzimage/builder/src/lib.rs
+++ b/framework/libs/linux-bzimage/builder/src/lib.rs
@@ -22,9 +22,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use xmas_elf::program::SegmentData;
-
 use mapping::{SetupFileOffset, SetupVA};
+use xmas_elf::program::SegmentData;
 
 /// The type of the bzImage that we are building through `make_bzimage`.
 ///

--- a/framework/libs/linux-bzimage/builder/src/pe_header.rs
+++ b/framework/libs/linux-bzimage/builder/src/pe_header.rs
@@ -8,10 +8,10 @@
 //! The reference to the Linux PE header definition:
 //! https://github.com/torvalds/linux/blob/master/include/linux/pe.h
 
+use std::{mem::size_of, ops::Range};
+
 use bytemuck::{Pod, Zeroable};
 use serde::Serialize;
-
-use std::{mem::size_of, ops::Range};
 
 use crate::mapping::{SetupFileOffset, SetupVA, LEGACY_SETUP_SEC_SIZE, SETUP32_LMA};
 

--- a/framework/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/framework/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use linux_boot_params::BootParams;
 use uefi::{
     data_types::Handle,
     proto::loaded_image::LoadedImage,
     table::{boot::MemoryMap, Boot, Runtime, SystemTable},
 };
 
-use linux_boot_params::BootParams;
-
-use super::paging::{Ia32eFlags, PageNumber, PageTableCreator};
-use super::relocation::apply_rela_dyn_relocations;
+use super::{
+    paging::{Ia32eFlags, PageNumber, PageTableCreator},
+    relocation::apply_rela_dyn_relocations,
+};
 
 #[export_name = "efi_stub_entry"]
 extern "sysv64" fn efi_stub_entry(handle: Handle, mut system_table: SystemTable<Boot>) -> ! {

--- a/framework/libs/linux-bzimage/setup/src/x86/legacy_i386/mod.rs
+++ b/framework/libs/linux-bzimage/setup/src/x86/legacy_i386/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use linux_boot_params::BootParams;
-
 use core::arch::{asm, global_asm};
+
+use linux_boot_params::BootParams;
 
 global_asm!(include_str!("header.S"));
 

--- a/framework/libs/tdx-guest/src/asm/mod.rs
+++ b/framework/libs/tdx-guest/src/asm/mod.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright(c) 2023-2024 Intel Corporation.
 
-use crate::{tdcall::TdcallArgs, tdvmcall::TdVmcallArgs};
 use core::arch::global_asm;
+
+use crate::{tdcall::TdcallArgs, tdvmcall::TdVmcallArgs};
 
 global_asm!(include_str!("tdcall.asm"));
 global_asm!(include_str!("tdvmcall.asm"));

--- a/framework/libs/tdx-guest/src/lib.rs
+++ b/framework/libs/tdx-guest/src/lib.rs
@@ -11,11 +11,13 @@ mod asm;
 pub mod tdcall;
 pub mod tdvmcall;
 
-pub use self::tdcall::{get_veinfo, TdxVirtualExceptionType};
-pub use self::tdvmcall::print;
-
 use raw_cpuid::{native_cpuid::cpuid_count, CpuIdResult};
 use tdcall::{InitError, TdgVpInfo};
+
+pub use self::{
+    tdcall::{get_veinfo, TdxVirtualExceptionType},
+    tdvmcall::print,
+};
 
 pub fn init_tdx() -> Result<TdgVpInfo, InitError> {
     check_tdx_guest()?;

--- a/framework/libs/tdx-guest/src/tdcall.rs
+++ b/framework/libs/tdx-guest/src/tdcall.rs
@@ -5,9 +5,11 @@
 //! It is used to call guest-side Intel TDX functions. For more information about
 //! TDCALL, please refer to the [Intel® TDX Module v1.5 ABI Specification](https://cdrdv2.intel.com/v1/dl/getContent/733579)
 
-use crate::asm::asm_td_call;
-use bitflags::bitflags;
 use core::fmt;
+
+use bitflags::bitflags;
+
+use crate::asm::asm_td_call;
 
 /// TDCALL Instruction Leaf Numbers Definition.
 #[repr(u64)]

--- a/framework/libs/tdx-guest/src/tdvmcall.rs
+++ b/framework/libs/tdx-guest/src/tdvmcall.rs
@@ -8,14 +8,16 @@
 //! resumes the TD via a SEAMCALL [TDH.VP.ENTER] invocation.
 extern crate alloc;
 
-use crate::asm::asm_td_vmcall;
 use alloc::fmt;
-use bitflags::bitflags;
 use core::fmt::Write;
+
+use bitflags::bitflags;
 use x86_64::{
     registers::rflags::{self, RFlags},
     structures::port::PortRead,
 };
+
+use crate::asm::asm_td_vmcall;
 
 /// TDVMCALL Instruction Leaf Numbers Definition.
 #[repr(u64)]

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -4,10 +4,14 @@ use std::path::PathBuf;
 
 use clap::{crate_version, Args, Parser};
 
-use crate::commands::{execute_check_command, execute_clippy_command, execute_new_command};
-use crate::config_manager::boot::{BootLoader, BootProtocol};
-use crate::config_manager::qemu::QemuMachine;
-use crate::config_manager::{BuildConfig, RunConfig, TestConfig};
+use crate::{
+    commands::{execute_check_command, execute_clippy_command, execute_new_command},
+    config_manager::{
+        boot::{BootLoader, BootProtocol},
+        qemu::QemuMachine,
+        BuildConfig, RunConfig, TestConfig,
+    },
+};
 
 pub fn main() {
     let osdk_subcommand = match Cli::parse() {

--- a/osdk/src/commands/check.rs
+++ b/osdk/src/commands/check.rs
@@ -2,12 +2,10 @@
 
 use std::process;
 
-use crate::commands::utils::create_target_json;
-use crate::error::Errno;
-use crate::error_msg;
-use crate::utils::get_cargo_metadata;
-
 use super::utils::{cargo, COMMON_CARGO_ARGS};
+use crate::{
+    commands::utils::create_target_json, error::Errno, error_msg, utils::get_cargo_metadata,
+};
 
 pub fn execute_check_command() {
     let target_json_path = {

--- a/osdk/src/commands/clippy.rs
+++ b/osdk/src/commands/clippy.rs
@@ -2,11 +2,10 @@
 
 use std::process;
 
-use crate::error_msg;
-use crate::utils::get_cargo_metadata;
-use crate::{commands::utils::create_target_json, error::Errno};
-
 use super::utils::{cargo, COMMON_CARGO_ARGS};
+use crate::{
+    commands::utils::create_target_json, error::Errno, error_msg, utils::get_cargo_metadata,
+};
 
 pub fn execute_clippy_command() {
     let target_json_path = {

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -7,6 +7,6 @@ mod clippy;
 mod new;
 mod utils;
 
-pub use self::check::execute_check_command;
-pub use self::clippy::execute_clippy_command;
-pub use self::new::execute_new_command;
+pub use self::{
+    check::execute_check_command, clippy::execute_clippy_command, new::execute_new_command,
+};

--- a/osdk/src/commands/new.rs
+++ b/osdk/src/commands/new.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::{fs, process};
+use std::{fs, path::PathBuf, process, str::FromStr};
 
-use crate::cli::NewArgs;
-use crate::error::Errno;
-use crate::error_msg;
-use crate::utils::{cargo_new_lib, get_cargo_metadata, ASTER_FRAME_DEP};
+use crate::{
+    cli::NewArgs,
+    error::Errno,
+    error_msg,
+    utils::{cargo_new_lib, get_cargo_metadata, ASTER_FRAME_DEP},
+};
 
 pub fn execute_new_command(args: &NewArgs) {
     cargo_new_lib(&args.crate_name);

--- a/osdk/src/commands/utils.rs
+++ b/osdk/src/commands/utils.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 pub const COMMON_CARGO_ARGS: &[&str] = &[
     "-Zbuild-std=core,alloc,compiler_builtins",

--- a/osdk/src/config_manager/boot.rs
+++ b/osdk/src/config_manager/boot.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::path::PathBuf;
-use std::process;
+use std::{path::PathBuf, process};
 
-use crate::error::Errno;
-use crate::error_msg;
+use crate::{error::Errno, error_msg};
 
 /// Arguments for creating bootdev image and how to boot with vmm.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/osdk/src/config_manager/manifest.rs
+++ b/osdk/src/config_manager/manifest.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::path::PathBuf;
-use std::process;
+use std::{path::PathBuf, process};
 
 use regex::Regex;
 use serde::Deserialize;
 
-use crate::error::Errno;
-use crate::error_msg;
-
-use super::boot::Boot;
-use super::qemu::{CfgQemu, Qemu};
+use super::{
+    boot::Boot,
+    qemu::{CfgQemu, Qemu},
+};
+use crate::{error::Errno, error_msg};
 
 /// The osdk manifest from configuration file and command line arguments.
 #[derive(Debug)]

--- a/osdk/src/config_manager/mod.rs
+++ b/osdk/src/config_manager/mod.rs
@@ -9,18 +9,22 @@ pub mod boot;
 pub mod manifest;
 pub mod qemu;
 
-use std::path::PathBuf;
-use std::{fs, process};
+use std::{fs, path::PathBuf, process};
 
 use indexmap::{IndexMap, IndexSet};
 use which::which;
 
-use self::boot::BootLoader;
-use self::manifest::{OsdkManifest, TomlManifest};
-use crate::cli::{BuildArgs, CargoArgs, OsdkArgs, RunArgs, TestArgs};
-use crate::error::Errno;
-use crate::utils::get_cargo_metadata;
-use crate::{error_msg, warn_msg};
+use self::{
+    boot::BootLoader,
+    manifest::{OsdkManifest, TomlManifest},
+};
+use crate::{
+    cli::{BuildArgs, CargoArgs, OsdkArgs, RunArgs, TestArgs},
+    error::Errno,
+    error_msg,
+    utils::get_cargo_metadata,
+    warn_msg,
+};
 
 /// Configurations for build subcommand
 #[derive(Debug)]

--- a/osdk/src/config_manager/qemu.rs
+++ b/osdk/src/config_manager/qemu.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::BTreeMap;
-use std::path::PathBuf;
-use std::{fmt, process};
+use std::{collections::BTreeMap, fmt, path::PathBuf, process};
 
-use serde::de::{self, Visitor};
-use serde::{Deserialize, Deserializer};
-
-use crate::error::Errno;
-use crate::error_msg;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer,
+};
 
 use super::get_key;
+use crate::{error::Errno, error_msg};
 
 /// Arguments for creating bootdev image and how to boot with vmm.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/osdk/src/test/config_manager/manifest.rs
+++ b/osdk/src/test/config_manager/manifest.rs
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-use crate::config_manager::manifest::{OsdkManifest, TomlManifest, FEATURE_REGEX};
-
-use crate::cli::CargoArgs;
-use crate::config_manager::get_feature_strings;
-use crate::test::utils::{assert_success, cargo_osdk, create_workspace};
+use crate::{
+    cli::CargoArgs,
+    config_manager::{
+        get_feature_strings,
+        manifest::{OsdkManifest, TomlManifest, FEATURE_REGEX},
+    },
+    test::utils::{assert_success, cargo_osdk, create_workspace},
+};
 
 #[test]
 fn deserialize_osdk_manifest() {

--- a/osdk/src/test/utils.rs
+++ b/osdk/src/test/utils.rs
@@ -2,11 +2,14 @@
 
 //! The common utils for crate unit test
 
+use std::{
+    ffi::OsStr,
+    fs::{self, create_dir_all},
+    path::{Path, PathBuf},
+    process::Output,
+};
+
 use assert_cmd::Command;
-use std::ffi::OsStr;
-use std::fs::{self, create_dir_all};
-use std::path::{Path, PathBuf};
-use std::process::Output;
 
 pub fn cargo_osdk<T: AsRef<OsStr>, I: IntoIterator<Item = T>>(args: I) -> Command {
     let mut command = Command::cargo_bin("cargo-osdk").unwrap();

--- a/osdk/src/utils.rs
+++ b/osdk/src/utils.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::ffi::OsStr;
-use std::path::Path;
-use std::process::Command;
+use std::{ffi::OsStr, path::Path, process::Command};
 
-use crate::error::Errno;
-use crate::error_msg;
+use crate::{error::Errno, error_msg};
 
-// FIXME: Crates belonging to Asterinas require a different dependency format. The dependency 
+// FIXME: Crates belonging to Asterinas require a different dependency format. The dependency
 // should be specified using a relative path instead of a URL.
 pub const ASTER_FRAME_DEP: &str =
     "aster-frame = { git = \"https://github.com/asterinas/asterinas\", rev = \"f2f991b\" }";

--- a/runner/src/gdb.rs
+++ b/runner/src/gdb.rs
@@ -2,8 +2,9 @@
 
 //! Providing the utility to run the GDB scripts for the runner.
 
-use crate::qemu_grub_efi;
 use std::{fs::OpenOptions, io::Write, path::PathBuf, process::Command};
+
+use crate::qemu_grub_efi;
 
 /// Run a GDB client.
 ///

--- a/runner/src/machine/qemu_grub_efi.rs
+++ b/runner/src/machine/qemu_grub_efi.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use linux_bzimage_builder::{make_bzimage, BzImageType};
-
 use std::{
     fs,
     io::Read,
     path::{Path, PathBuf},
 };
+
+use linux_bzimage_builder::{make_bzimage, BzImageType};
 
 use crate::BootProtocol;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+imports_granularity="Crate"
+group_imports="StdExternalCrate"
+reorder_imports=true

--- a/services/aster-nix/src/device/mod.rs
+++ b/services/aster-nix/src/device/mod.rs
@@ -9,16 +9,17 @@ pub mod tty;
 mod urandom;
 mod zero;
 
-use crate::fs::device::{add_node, Device, DeviceId, DeviceType};
-use crate::prelude::*;
-pub use pty::new_pty_pair;
-pub use pty::{PtyMaster, PtySlave};
+pub use pty::{new_pty_pair, PtyMaster, PtySlave};
 pub use random::Random;
 #[cfg(feature = "intel_tdx")]
 pub use tdxguest::TdxGuest;
 pub use urandom::Urandom;
 
 use self::tty::get_n_tty;
+use crate::{
+    fs::device::{add_node, Device, DeviceId, DeviceType},
+    prelude::*,
+};
 
 /// Init the device node in fs, must be called after mounting rootfs.
 pub fn init() -> Result<()> {

--- a/services/aster-nix/src/device/null.rs
+++ b/services/aster-nix/src/device/null.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::*;
-use crate::events::IoEvents;
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
 
 pub struct Null;
 

--- a/services/aster-nix/src/device/pty/mod.rs
+++ b/services/aster-nix/src/device/pty/mod.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::devpts::DevPts;
-use crate::fs::fs_resolver::{FsPath, FsResolver};
-use crate::fs::utils::{Dentry, Inode, InodeMode, InodeType};
-use crate::prelude::*;
+use crate::{
+    fs::{
+        devpts::DevPts,
+        fs_resolver::{FsPath, FsResolver},
+        utils::{Dentry, Inode, InodeMode, InodeType},
+    },
+    prelude::*,
+};
 
 #[allow(clippy::module_inception)]
 mod pty;

--- a/services/aster-nix/src/device/pty/pty.rs
+++ b/services/aster-nix/src/device/pty/pty.rs
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::format;
+
 use ringbuf::{ring_buffer::RbBase, HeapRb, Rb};
 
-use crate::device::tty::line_discipline::LineDiscipline;
-use crate::device::tty::new_job_control_and_ldisc;
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::devpts::DevPts;
-use crate::fs::fs_resolver::FsPath;
-use crate::fs::inode_handle::FileIo;
-use crate::fs::utils::{AccessMode, Inode, InodeMode, IoctlCmd};
-use crate::prelude::*;
-use crate::process::signal::{Pollee, Poller};
-use crate::process::{JobControl, Terminal};
-use crate::util::{read_val_from_user, write_val_to_user};
+use crate::{
+    device::tty::{line_discipline::LineDiscipline, new_job_control_and_ldisc},
+    events::IoEvents,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        devpts::DevPts,
+        fs_resolver::FsPath,
+        inode_handle::FileIo,
+        utils::{AccessMode, Inode, InodeMode, IoctlCmd},
+    },
+    prelude::*,
+    process::{
+        signal::{Pollee, Poller},
+        JobControl, Terminal,
+    },
+    util::{read_val_from_user, write_val_to_user},
+};
 
 const BUFFER_CAPACITY: usize = 4096;
 

--- a/services/aster-nix/src/device/random.rs
+++ b/services/aster-nix/src/device/random.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        inode_handle::FileIo,
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 pub struct Random;
 

--- a/services/aster-nix/src/device/tdxguest/mod.rs
+++ b/services/aster-nix/src/device/tdxguest/mod.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::*;
-use crate::error::Error;
-use crate::events::IoEvents;
-use crate::fs::inode_handle::FileIo;
-use crate::fs::utils::IoctlCmd;
-use crate::process::signal::Poller;
-use crate::util::{read_val_from_user, write_val_to_user};
 use tdx_guest::tdcall::{get_report, TdCallError};
+
+use super::*;
+use crate::{
+    error::Error,
+    events::IoEvents,
+    fs::{inode_handle::FileIo, utils::IoctlCmd},
+    process::signal::Poller,
+    util::{read_val_from_user, write_val_to_user},
+};
 
 const TDX_REPORTDATA_LEN: usize = 64;
 const TDX_REPORT_LEN: usize = 1024;

--- a/services/aster-nix/src/device/tty/device.rs
+++ b/services/aster-nix/src/device/tty/device.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        inode_handle::FileIo,
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 /// Corresponds to `/dev/tty` in the file system. This device represents the controlling terminal
 /// of the session of current process.

--- a/services/aster-nix/src/device/tty/line_discipline.rs
+++ b/services/aster-nix/src/device/tty/line_discipline.rs
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::prelude::*;
-use crate::process::signal::constants::{SIGINT, SIGQUIT};
-use crate::process::signal::signals::kernel::KernelSignal;
-use crate::process::signal::{Pollee, Poller};
-use crate::thread::work_queue::work_item::WorkItem;
-use crate::thread::work_queue::{submit_work_item, WorkPriority};
 use alloc::format;
+
 use aster_frame::trap::{disable_local, in_interrupt_context};
 use ringbuf::{ring_buffer::RbBase, Rb, StaticRb};
 
 use super::termio::{KernelTermios, WinSize, CC_C_CHAR};
+use crate::{
+    events::IoEvents,
+    prelude::*,
+    process::signal::{
+        constants::{SIGINT, SIGQUIT},
+        signals::kernel::KernelSignal,
+        Pollee, Poller,
+    },
+    thread::work_queue::{submit_work_item, work_item::WorkItem, WorkPriority},
+};
 
 // This implementation refers the implementation of linux
 // https://elixir.bootlin.com/linux/latest/source/include/linux/tty_ldisc.h

--- a/services/aster-nix/src/device/tty/mod.rs
+++ b/services/aster-nix/src/device/tty/mod.rs
@@ -2,17 +2,21 @@
 
 use spin::Once;
 
-use self::driver::TtyDriver;
-use self::line_discipline::LineDiscipline;
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::inode_handle::FileIo;
-use crate::fs::utils::IoctlCmd;
-use crate::prelude::*;
-use crate::process::signal::signals::kernel::KernelSignal;
-use crate::process::signal::Poller;
-use crate::process::{JobControl, Process, Terminal};
-use crate::util::{read_val_from_user, write_val_to_user};
+use self::{driver::TtyDriver, line_discipline::LineDiscipline};
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        inode_handle::FileIo,
+        utils::IoctlCmd,
+    },
+    prelude::*,
+    process::{
+        signal::{signals::kernel::KernelSignal, Poller},
+        JobControl, Process, Terminal,
+    },
+    util::{read_val_from_user, write_val_to_user},
+};
 
 mod device;
 pub mod driver;

--- a/services/aster-nix/src/device/urandom.rs
+++ b/services/aster-nix/src/device/urandom.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        inode_handle::FileIo,
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 pub struct Urandom;
 

--- a/services/aster-nix/src/device/zero.rs
+++ b/services/aster-nix/src/device/zero.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::*;
-use crate::events::IoEvents;
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
 
 pub struct Zero;
 

--- a/services/aster-nix/src/events/mod.rs
+++ b/services/aster-nix/src/events/mod.rs
@@ -6,7 +6,10 @@ mod io_events;
 mod observer;
 mod subject;
 
-pub use self::events::{Events, EventsFilter};
-pub use self::observer::Observer;
-pub use self::subject::Subject;
 pub use io_events::IoEvents;
+
+pub use self::{
+    events::{Events, EventsFilter},
+    observer::Observer,
+    subject::Subject,
+};

--- a/services/aster-nix/src/events/subject.rs
+++ b/services/aster-nix/src/events/subject.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
 use core::sync::atomic::{AtomicUsize, Ordering};
+
 use keyable_arc::KeyableWeak;
 
 use super::{Events, EventsFilter, Observer};
+use crate::prelude::*;
 
 /// A Subject notifies interesting events to registered observers.
 pub struct Subject<E: Events, F: EventsFilter<E> = ()> {

--- a/services/aster-nix/src/fs/device.rs
+++ b/services/aster-nix/src/fs/device.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::fs_resolver::{FsPath, FsResolver};
-use crate::fs::utils::Dentry;
-use crate::fs::utils::{InodeMode, InodeType};
-use crate::prelude::*;
-
 use super::inode_handle::FileIo;
+use crate::{
+    fs::{
+        fs_resolver::{FsPath, FsResolver},
+        utils::{Dentry, InodeMode, InodeType},
+    },
+    prelude::*,
+};
 
 /// The abstract of device
 pub trait Device: Sync + Send + FileIo {

--- a/services/aster-nix/src/fs/devpts/mod.rs
+++ b/services/aster-nix/src/fs/devpts/mod.rs
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::device::PtyMaster;
-use crate::fs::device::{Device, DeviceId, DeviceType};
-use crate::fs::utils::{
-    DirentVisitor, FileSystem, FsFlags, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
-    SuperBlock, NAME_MAX,
-};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
-use aster_util::{id_allocator::IdAlloc, slot_vec::SlotVec};
 use core::time::Duration;
 
-use self::ptmx::Ptmx;
-use self::slave::PtySlaveInode;
+use aster_util::{id_allocator::IdAlloc, slot_vec::SlotVec};
+
+use self::{ptmx::Ptmx, slave::PtySlaveInode};
+use crate::{
+    device::PtyMaster,
+    fs::{
+        device::{Device, DeviceId, DeviceType},
+        utils::{
+            DirentVisitor, FileSystem, FsFlags, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
+            SuperBlock, NAME_MAX,
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 mod ptmx;
 mod slave;

--- a/services/aster-nix/src/fs/devpts/ptmx.rs
+++ b/services/aster-nix/src/fs/devpts/ptmx.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::device::PtyMaster;
-use crate::events::IoEvents;
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-
 use super::*;
+use crate::{
+    device::PtyMaster, events::IoEvents, fs::inode_handle::FileIo, process::signal::Poller,
+};
 
 /// Same major number with Linux.
 const PTMX_MAJOR_NUM: u32 = 5;

--- a/services/aster-nix/src/fs/devpts/slave.rs
+++ b/services/aster-nix/src/fs/devpts/slave.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-
 use super::*;
-
-use crate::device::PtySlave;
+use crate::{
+    device::PtySlave,
+    events::IoEvents,
+    fs::inode_handle::FileIo,
+    process::{signal::Poller, Gid, Uid},
+};
 
 /// Same major number with Linux, the minor number is the index of slave.
 const SLAVE_MAJOR_NUM: u32 = 3;

--- a/services/aster-nix/src/fs/epoll/epoll_file.rs
+++ b/services/aster-nix/src/fs/epoll/epoll_file.rs
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::{IoEvents, Observer};
-use crate::fs::file_handle::FileLike;
-use crate::fs::file_table::{FdEvents, FileDescripter};
-use crate::fs::utils::IoctlCmd;
-use crate::process::signal::{Pollee, Poller};
-
-use core::sync::atomic::{AtomicBool, Ordering};
-use core::time::Duration;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use super::*;
+use crate::{
+    events::{IoEvents, Observer},
+    fs::{
+        file_handle::FileLike,
+        file_table::{FdEvents, FileDescripter},
+        utils::IoctlCmd,
+    },
+    process::signal::{Pollee, Poller},
+};
 
 /// A file-like object that provides epoll API.
 ///

--- a/services/aster-nix/src/fs/epoll/mod.rs
+++ b/services/aster-nix/src/fs/epoll/mod.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::file_table::FileDescripter;
-use crate::events::IoEvents;
-use crate::prelude::*;
+use crate::{events::IoEvents, prelude::*};
 
 mod epoll_file;
 

--- a/services/aster-nix/src/fs/ext2/block_group.rs
+++ b/services/aster-nix/src/fs/ext2/block_group.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::fs::Ext2;
-use super::inode::{Inode, InodeDesc, RawInode};
-use super::prelude::*;
-use super::super_block::SuperBlock;
-
 use aster_util::id_allocator::IdAlloc;
+
+use super::{
+    fs::Ext2,
+    inode::{Inode, InodeDesc, RawInode},
+    prelude::*,
+    super_block::SuperBlock,
+};
 
 /// Blocks are clustered into block groups in order to reduce fragmentation and minimise
 /// the amount of head seeking when reading a large amount of consecutive data.

--- a/services/aster-nix/src/fs/ext2/dir.rs
+++ b/services/aster-nix/src/fs/ext2/dir.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::inode::{FileType, MAX_FNAME_LEN};
-use super::prelude::*;
-
 use core::iter::Iterator;
+
+use super::{
+    inode::{FileType, MAX_FNAME_LEN},
+    prelude::*,
+};
 
 /// The data structure in a directory's data block. It is stored in a linked list.
 ///

--- a/services/aster-nix/src/fs/ext2/fs.rs
+++ b/services/aster-nix/src/fs/ext2/fs.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::block_group::{BlockGroup, RawGroupDescriptor};
-use super::inode::{FilePerm, FileType, Inode, InodeDesc, RawInode};
-use super::prelude::*;
-use super::super_block::{RawSuperBlock, SuperBlock, SUPER_BLOCK_OFFSET};
+use super::{
+    block_group::{BlockGroup, RawGroupDescriptor},
+    inode::{FilePerm, FileType, Inode, InodeDesc, RawInode},
+    prelude::*,
+    super_block::{RawSuperBlock, SuperBlock, SUPER_BLOCK_OFFSET},
+};
 
 /// The root inode number.
 const ROOT_INO: u32 = 2;

--- a/services/aster-nix/src/fs/ext2/impl_for_vfs/fs.rs
+++ b/services/aster-nix/src/fs/ext2/impl_for_vfs/fs.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::ext2::{utils::Dirty, Ext2, SuperBlock as Ext2SuperBlock, MAGIC_NUM as EXT2_MAGIC};
-use crate::fs::utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX};
-use crate::prelude::*;
-
 use aster_frame::sync::RwMutexReadGuard;
+
+use crate::{
+    fs::{
+        ext2::{utils::Dirty, Ext2, SuperBlock as Ext2SuperBlock, MAGIC_NUM as EXT2_MAGIC},
+        utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+    },
+    prelude::*,
+};
 
 impl FileSystem for Ext2 {
     fn sync(&self) -> Result<()> {

--- a/services/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/services/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::device::Device;
-use crate::fs::ext2::{FilePerm, FileType, Inode as Ext2Inode};
-use crate::fs::utils::{
-    DirentVisitor, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
-};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-use crate::vm::vmo::Vmo;
+use core::time::Duration;
 
 use aster_rights::Full;
-use core::time::Duration;
+
+use crate::{
+    fs::{
+        device::Device,
+        ext2::{FilePerm, FileType, Inode as Ext2Inode},
+        utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata},
+    },
+    prelude::*,
+    process::{Gid, Uid},
+    vm::vmo::Vmo,
+};
 
 impl Inode for Ext2Inode {
     fn size(&self) -> usize {

--- a/services/aster-nix/src/fs/ext2/inode.rs
+++ b/services/aster-nix/src/fs/ext2/inode.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::blocks_hole::BlocksHoleDesc;
-use super::dir::{DirEntry, DirEntryReader, DirEntryWriter};
-use super::fs::Ext2;
-use super::prelude::*;
-
 use core::cmp::Ordering;
+
 use inherit_methods_macro::inherit_methods;
+
+use super::{
+    blocks_hole::BlocksHoleDesc,
+    dir::{DirEntry, DirEntryReader, DirEntryWriter},
+    fs::Ext2,
+    prelude::*,
+};
 
 mod field {
     pub type Field = core::ops::Range<usize>;

--- a/services/aster-nix/src/fs/ext2/prelude.rs
+++ b/services/aster-nix/src/fs/ext2/prelude.rs
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub(super) use super::utils::{Dirty, IsPowerOf};
-
-pub(super) use crate::fs::utils::{
-    CStr256, DirentVisitor, InodeType, PageCache, PageCacheBackend, Str16, Str64,
+pub(super) use core::{
+    ops::{Deref, DerefMut},
+    time::Duration,
 };
-pub(super) use crate::prelude::*;
-pub(super) use crate::time::UnixTime;
-pub(super) use crate::vm::vmo::Vmo;
 
 pub(super) use align_ext::AlignExt;
 pub(super) use aster_block::{
@@ -15,11 +11,17 @@ pub(super) use aster_block::{
     id::Bid,
     BlockDevice, BLOCK_SIZE,
 };
-pub(super) use aster_frame::sync::{RwMutex, RwMutexReadGuard};
-pub(super) use aster_frame::vm::VmAllocOptions;
-pub(super) use aster_frame::vm::VmIo;
-pub(super) use aster_frame::vm::{VmFrame, VmSegment};
+pub(super) use aster_frame::{
+    sync::{RwMutex, RwMutexReadGuard},
+    vm::{VmAllocOptions, VmFrame, VmIo, VmSegment},
+};
 pub(super) use aster_rights::Full;
-pub(super) use core::ops::{Deref, DerefMut};
-pub(super) use core::time::Duration;
 pub(super) use static_assertions::const_assert;
+
+pub(super) use super::utils::{Dirty, IsPowerOf};
+pub(super) use crate::{
+    fs::utils::{CStr256, DirentVisitor, InodeType, PageCache, PageCacheBackend, Str16, Str64},
+    prelude::*,
+    time::UnixTime,
+    vm::vmo::Vmo,
+};

--- a/services/aster-nix/src/fs/ext2/super_block.rs
+++ b/services/aster-nix/src/fs/ext2/super_block.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::inode::RawInode;
-use super::prelude::*;
+use super::{inode::RawInode, prelude::*};
 
 /// The magic number of Ext2.
 pub const MAGIC_NUM: u16 = 0xef53;

--- a/services/aster-nix/src/fs/ext2/utils.rs
+++ b/services/aster-nix/src/fs/ext2/utils.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::prelude::*;
-
 use core::ops::MulAssign;
+
+use super::prelude::*;
 
 pub trait IsPowerOf: Copy + Sized + MulAssign + PartialOrd {
     /// Returns true if and only if `self == x^k` for some `k` where `k > 0`.

--- a/services/aster-nix/src/fs/file_handle.rs
+++ b/services/aster-nix/src/fs/file_handle.rs
@@ -2,15 +2,18 @@
 
 //! Opend File Handle
 
-use crate::events::{IoEvents, Observer};
-use crate::fs::device::Device;
-use crate::fs::utils::{AccessMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags};
-use crate::net::socket::Socket;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-
 use core::any::Any;
+
+use crate::{
+    events::{IoEvents, Observer},
+    fs::{
+        device::Device,
+        utils::{AccessMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags},
+    },
+    net::socket::Socket,
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+};
 
 /// The basic operations defined on a file
 pub trait FileLike: Send + Sync + Any {

--- a/services/aster-nix/src/fs/file_table.rs
+++ b/services/aster-nix/src/fs/file_table.rs
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::{Events, Observer, Subject};
-use crate::net::socket::Socket;
-use crate::prelude::*;
-
-use aster_util::slot_vec::SlotVec;
 use core::cell::Cell;
 
-use super::file_handle::FileLike;
-use super::fs_resolver::{FsPath, FsResolver, AT_FDCWD};
-use super::utils::{AccessMode, InodeMode};
+use aster_util::slot_vec::SlotVec;
+
+use super::{
+    file_handle::FileLike,
+    fs_resolver::{FsPath, FsResolver, AT_FDCWD},
+    utils::{AccessMode, InodeMode},
+};
+use crate::{
+    events::{Events, Observer, Subject},
+    net::socket::Socket,
+    prelude::*,
+};
 
 pub type FileDescripter = i32;
 

--- a/services/aster-nix/src/fs/fs_resolver.rs
+++ b/services/aster-nix/src/fs/fs_resolver.rs
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use alloc::str;
 
-use super::file_table::FileDescripter;
-use super::inode_handle::InodeHandle;
-use super::rootfs::root_mount;
-use super::utils::{
-    AccessMode, CreationFlags, Dentry, InodeMode, InodeType, StatusFlags, PATH_MAX, SYMLINKS_MAX,
+use super::{
+    file_table::FileDescripter,
+    inode_handle::InodeHandle,
+    rootfs::root_mount,
+    utils::{
+        AccessMode, CreationFlags, Dentry, InodeMode, InodeType, StatusFlags, PATH_MAX,
+        SYMLINKS_MAX,
+    },
 };
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub struct FsResolver {

--- a/services/aster-nix/src/fs/inode_handle/dyn_cap.rs
+++ b/services/aster-nix/src/fs/inode_handle/dyn_cap.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-
 use aster_rights::{Rights, TRights};
 use inherit_methods_macro::inherit_methods;
 
 use super::*;
+use crate::{
+    events::IoEvents,
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+};
 
 impl InodeHandle<Rights> {
     pub fn new(

--- a/services/aster-nix/src/fs/inode_handle/mod.rs
+++ b/services/aster-nix/src/fs/inode_handle/mod.rs
@@ -6,19 +6,23 @@ mod dyn_cap;
 mod static_cap;
 
 use core::sync::atomic::{AtomicU32, Ordering};
+
+use aster_rights::Rights;
 use inherit_methods_macro::inherit_methods;
 
-use crate::events::IoEvents;
-use crate::fs::device::Device;
-use crate::fs::file_handle::FileLike;
-use crate::fs::utils::{
-    AccessMode, Dentry, DirentVisitor, InodeMode, InodeType, IoctlCmd, Metadata, SeekFrom,
-    StatusFlags,
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::Device,
+        file_handle::FileLike,
+        utils::{
+            AccessMode, Dentry, DirentVisitor, InodeMode, InodeType, IoctlCmd, Metadata, SeekFrom,
+            StatusFlags,
+        },
+    },
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
 };
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-use aster_rights::Rights;
 
 #[derive(Debug)]
 pub struct InodeHandle<R = Rights>(Arc<InodeHandle_>, R);

--- a/services/aster-nix/src/fs/inode_handle/static_cap.rs
+++ b/services/aster-nix/src/fs/inode_handle/static_cap.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_rights::{Read, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 
 use super::*;
+use crate::prelude::*;
 
 impl<R: TRights> InodeHandle<TRightSet<R>> {
     #[require(R > Read)]

--- a/services/aster-nix/src/fs/mod.rs
+++ b/services/aster-nix/src/fs/mod.rs
@@ -14,11 +14,15 @@ pub mod ramfs;
 pub mod rootfs;
 pub mod utils;
 
-use crate::fs::{ext2::Ext2, fs_resolver::FsPath};
-use crate::prelude::*;
-use crate::thread::kernel_thread::KernelThreadExt;
-use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
-use aster_virtio::device::block::DEVICE_NAME as VIRTIO_BLOCK_NAME;
+use aster_virtio::device::block::{
+    device::BlockDevice as VirtIoBlockDevice, DEVICE_NAME as VIRTIO_BLOCK_NAME,
+};
+
+use crate::{
+    fs::{ext2::Ext2, fs_resolver::FsPath},
+    prelude::*,
+    thread::kernel_thread::KernelThreadExt,
+};
 
 pub fn lazy_init() {
     let block_device = aster_block::get_device(VIRTIO_BLOCK_NAME).unwrap();

--- a/services/aster-nix/src/fs/pipe.rs
+++ b/services/aster-nix/src/fs/pipe.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::{IoEvents, Observer};
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-
-use super::file_handle::FileLike;
-use super::utils::{AccessMode, Consumer, InodeMode, InodeType, Metadata, Producer, StatusFlags};
+use super::{
+    file_handle::FileLike,
+    utils::{AccessMode, Consumer, InodeMode, InodeType, Metadata, Producer, StatusFlags},
+};
+use crate::{
+    events::{IoEvents, Observer},
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+};
 
 pub struct PipeReader {
     consumer: Consumer<u8>,

--- a/services/aster-nix/src/fs/procfs/mod.rs
+++ b/services/aster-nix/src/fs/procfs/mod.rs
@@ -2,14 +2,17 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::events::Observer;
-use crate::fs::utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX};
-use crate::prelude::*;
-use crate::process::{process_table, process_table::PidEvent, Pid};
-
-use self::pid::PidDirOps;
-use self::self_::SelfSymOps;
-use self::template::{DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps};
+use self::{
+    pid::PidDirOps,
+    self_::SelfSymOps,
+    template::{DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
+};
+use crate::{
+    events::Observer,
+    fs::utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+    prelude::*,
+    process::{process_table, process_table::PidEvent, Pid},
+};
 
 mod pid;
 mod self_;

--- a/services/aster-nix/src/fs/procfs/pid/fd.rs
+++ b/services/aster-nix/src/fs/procfs/pid/fd.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::*;
-use crate::fs::file_handle::FileLike;
-use crate::fs::file_table::FileDescripter;
-use crate::fs::inode_handle::InodeHandle;
+use crate::fs::{file_handle::FileLike, file_table::FileDescripter, inode_handle::InodeHandle};
 
 /// Represents the inode at `/proc/[pid]/fd`.
 pub struct FdDirOps(Arc<Process>);

--- a/services/aster-nix/src/fs/procfs/pid/mod.rs
+++ b/services/aster-nix/src/fs/procfs/pid/mod.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::Observer;
-use crate::fs::file_table::FdEvents;
-use crate::fs::utils::{DirEntryVecExt, Inode};
-use crate::prelude::*;
-use crate::process::Process;
-
-use self::comm::CommFileOps;
-use self::exe::ExeSymOps;
-use self::fd::FdDirOps;
+use self::{comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps};
 use super::template::{
     DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder, ProcSymBuilder, SymOps,
+};
+use crate::{
+    events::Observer,
+    fs::{
+        file_table::FdEvents,
+        utils::{DirEntryVecExt, Inode},
+    },
+    prelude::*,
+    process::Process,
 };
 
 mod comm;

--- a/services/aster-nix/src/fs/procfs/template/builder.rs
+++ b/services/aster-nix/src/fs/procfs/template/builder.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::utils::{FileSystem, Inode};
-use crate::prelude::*;
-
 use super::{
     dir::{DirOps, ProcDir},
     file::{FileOps, ProcFile},
     sym::{ProcSym, SymOps},
+};
+use crate::{
+    fs::utils::{FileSystem, Inode},
+    prelude::*,
 };
 
 pub struct ProcDirBuilder<O: DirOps> {

--- a/services/aster-nix/src/fs/procfs/template/dir.rs
+++ b/services/aster-nix/src/fs/procfs/template/dir.rs
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::slot_vec::SlotVec;
 use core::time::Duration;
+
+use aster_util::slot_vec::SlotVec;
 use inherit_methods_macro::inherit_methods;
 
-use crate::fs::device::Device;
-use crate::fs::utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
 use super::{Common, ProcFS};
+use crate::{
+    fs::{
+        device::Device,
+        utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata},
+    },
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 pub struct ProcDir<D: DirOps> {
     inner: D,

--- a/services/aster-nix/src/fs/procfs/template/file.rs
+++ b/services/aster-nix/src/fs/procfs/template/file.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::time::Duration;
+
 use inherit_methods_macro::inherit_methods;
 
-use crate::fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
 use super::{Common, ProcFS};
+use crate::{
+    fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata},
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 pub struct ProcFile<F: FileOps> {
     inner: F,

--- a/services/aster-nix/src/fs/procfs/template/mod.rs
+++ b/services/aster-nix/src/fs/procfs/template/mod.rs
@@ -2,16 +2,18 @@
 
 use core::time::Duration;
 
-use crate::fs::utils::{FileSystem, InodeMode, Metadata};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
+pub use self::{
+    builder::{ProcDirBuilder, ProcFileBuilder, ProcSymBuilder},
+    dir::{DirOps, ProcDir},
+    file::FileOps,
+    sym::SymOps,
+};
 use super::ProcFS;
-
-pub use self::builder::{ProcDirBuilder, ProcFileBuilder, ProcSymBuilder};
-pub use self::dir::{DirOps, ProcDir};
-pub use self::file::FileOps;
-pub use self::sym::SymOps;
+use crate::{
+    fs::utils::{FileSystem, InodeMode, Metadata},
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 mod builder;
 mod dir;

--- a/services/aster-nix/src/fs/procfs/template/sym.rs
+++ b/services/aster-nix/src/fs/procfs/template/sym.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::time::Duration;
+
 use inherit_methods_macro::inherit_methods;
 
-use crate::fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata};
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
 use super::{Common, ProcFS};
+use crate::{
+    fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata},
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 pub struct ProcSym<S: SymOps> {
     inner: S,

--- a/services/aster-nix/src/fs/ramfs/fs.rs
+++ b/services/aster-nix/src/fs/ramfs/fs.rs
@@ -1,24 +1,31 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::sync::RwLockWriteGuard;
-use aster_frame::vm::VmFrame;
-use aster_frame::vm::VmIo;
+use core::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use aster_frame::{
+    sync::RwLockWriteGuard,
+    vm::{VmFrame, VmIo},
+};
 use aster_rights::Full;
 use aster_util::slot_vec::SlotVec;
-use core::sync::atomic::{AtomicUsize, Ordering};
-use core::time::Duration;
 
 use super::*;
-use crate::events::IoEvents;
-use crate::fs::device::Device;
-use crate::fs::utils::{
-    CStr256, DirentVisitor, FileSystem, FsFlags, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
-    PageCache, PageCacheBackend, SuperBlock,
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::Device,
+        utils::{
+            CStr256, DirentVisitor, FileSystem, FsFlags, Inode, InodeMode, InodeType, IoctlCmd,
+            Metadata, PageCache, PageCacheBackend, SuperBlock,
+        },
+    },
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+    vm::vmo::Vmo,
 };
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-use crate::vm::vmo::Vmo;
 
 /// A volatile file system whose data and metadata exists only in memory.
 pub struct RamFS {

--- a/services/aster-nix/src/fs/rootfs.rs
+++ b/services/aster-nix/src/fs/rootfs.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
-use super::fs_resolver::{FsPath, FsResolver};
-use super::procfs::ProcFS;
-use super::ramfs::RamFS;
-use super::utils::{FileSystem, InodeMode, InodeType, MountNode};
-
 use cpio_decoder::{CpioDecoder, FileType};
 use lending_iterator::LendingIterator;
 use libflate::gzip::Decoder as GZipDecoder;
 use spin::Once;
+
+use super::{
+    fs_resolver::{FsPath, FsResolver},
+    procfs::ProcFS,
+    ramfs::RamFS,
+    utils::{FileSystem, InodeMode, InodeType, MountNode},
+};
+use crate::prelude::*;
 
 /// Unpack and prepare the rootfs from the initramfs CPIO buffer.
 pub fn init(initramfs_buf: &[u8]) -> Result<()> {

--- a/services/aster-nix/src/fs/utils/access_mode.rs
+++ b/services/aster-nix/src/fs/utils/access_mode.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_rights::Rights;
+
+use crate::prelude::*;
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]

--- a/services/aster-nix/src/fs/utils/channel.rs
+++ b/services/aster-nix/src/fs/utils/channel.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_rights_proc::require;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use aster_rights::{Read, ReadOp, TRights, Write, WriteOp};
+use aster_rights_proc::require;
 use ringbuf::{HeapConsumer as HeapRbConsumer, HeapProducer as HeapRbProducer, HeapRb};
 
-use crate::events::IoEvents;
-use crate::events::Observer;
-use crate::prelude::*;
-use crate::process::signal::{Pollee, Poller};
-use aster_rights::{Read, ReadOp, TRights, Write, WriteOp};
-
 use super::StatusFlags;
+use crate::{
+    events::{IoEvents, Observer},
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 /// A unidirectional communication channel, intended to implement IPC, e.g., pipe,
 /// unix domain sockets, etc.

--- a/services/aster-nix/src/fs/utils/dentry.rs
+++ b/services/aster-nix/src/fs/utils/dentry.rs
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::device::Device;
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-
 use alloc::string::String;
-use core::sync::atomic::{AtomicU32, Ordering};
-use core::time::Duration;
+use core::{
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
+
 use inherit_methods_macro::inherit_methods;
 
 use super::{FileSystem, Inode, InodeMode, InodeType, Metadata, MountNode, NAME_MAX};
+use crate::{
+    fs::device::Device,
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 lazy_static! {
     static ref DCACHE: Mutex<BTreeMap<DentryKey, Arc<Dentry>>> = Mutex::new(BTreeMap::new());

--- a/services/aster-nix/src/fs/utils/direntry_vec.rs
+++ b/services/aster-nix/src/fs/utils/direntry_vec.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_util::slot_vec::SlotVec;
+
 use super::Inode;
 use crate::prelude::*;
-
-use aster_util::slot_vec::SlotVec;
 
 pub trait DirEntryVecExt {
     /// If the entry is not found by `name`, use `f` to get the inode, then put the entry into vec.

--- a/services/aster-nix/src/fs/utils/inode.rs
+++ b/services/aster-nix/src/fs/utils/inode.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_rights::Full;
 use core::time::Duration;
+
+use aster_rights::Full;
 use core2::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
 
 use super::{DirentVisitor, FileSystem, IoctlCmd, SuperBlock};
-use crate::events::IoEvents;
-use crate::fs::device::{Device, DeviceType};
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::process::{Gid, Uid};
-use crate::vm::vmo::Vmo;
+use crate::{
+    events::IoEvents,
+    fs::device::{Device, DeviceType},
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+    vm::vmo::Vmo,
+};
 
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromInt)]

--- a/services/aster-nix/src/fs/utils/mount.rs
+++ b/services/aster-nix/src/fs/utils/mount.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
 use super::{Dentry, DentryKey, FileSystem, InodeType};
+use crate::prelude::*;
 
 /// The MountNode can form a mount tree to maintain the mount information.
 pub struct MountNode {

--- a/services/aster-nix/src/fs/utils/page_cache.rs
+++ b/services/aster-nix/src/fs/utils/page_cache.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use crate::vm::vmo::{get_page_idx_range, Pager, Vmo, VmoFlags, VmoOptions};
-use aster_rights::Full;
+use core::ops::Range;
 
 use aster_frame::vm::{VmAllocOptions, VmFrame};
-use core::ops::Range;
+use aster_rights::Full;
 use lru::LruCache;
+
+use crate::{
+    prelude::*,
+    vm::vmo::{get_page_idx_range, Pager, Vmo, VmoFlags, VmoOptions},
+};
 
 pub struct PageCache {
     pages: Vmo<Full>,

--- a/services/aster-nix/src/lib.rs
+++ b/services/aster-nix/src/lib.rs
@@ -25,6 +25,12 @@
 #![feature(btree_cursors)]
 #![register_tool(component_access_control)]
 
+use aster_frame::{
+    arch::qemu::{exit_qemu, QemuExitCode},
+    boot,
+};
+use process::Process;
+
 use crate::{
     prelude::*,
     thread::{
@@ -32,11 +38,6 @@ use crate::{
         Thread,
     },
 };
-use aster_frame::{
-    arch::qemu::{exit_qemu, QemuExitCode},
-    boot,
-};
-use process::Process;
 
 extern crate alloc;
 extern crate lru;

--- a/services/aster-nix/src/net/iface/any_socket.rs
+++ b/services/aster-nix/src/net/iface/any_socket.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::Observer;
-use crate::prelude::*;
-
-use super::Iface;
-use super::{IpAddress, IpEndpoint};
+use super::{Iface, IpAddress, IpEndpoint};
+use crate::{events::Observer, prelude::*};
 
 pub type RawTcpSocket = smoltcp::socket::tcp::Socket<'static>;
 pub type RawUdpSocket = smoltcp::socket::udp::Socket<'static>;

--- a/services/aster-nix/src/net/iface/common.rs
+++ b/services/aster-nix/src/net/iface/common.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::collections::btree_map::Entry;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use super::Ipv4Address;
-use crate::prelude::*;
-use alloc::collections::btree_map::Entry;
 use keyable_arc::KeyableWeak;
 use smoltcp::{
     iface::{SocketHandle, SocketSet},
@@ -16,8 +14,9 @@ use super::{
     any_socket::{AnyBoundSocket, AnyRawSocket, AnyUnboundSocket},
     time::get_network_timestamp,
     util::BindPortConfig,
-    Iface,
+    Iface, Ipv4Address,
 };
+use crate::prelude::*;
 
 pub struct IfaceCommon {
     interface: SpinLock<smoltcp::iface::Interface>,

--- a/services/aster-nix/src/net/iface/loopback.rs
+++ b/services/aster-nix/src/net/iface/loopback.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{IpAddress, Ipv4Address};
-use crate::prelude::*;
 use smoltcp::{
     iface::{Config, Routes},
     phy::{Loopback, Medium},
     wire::IpCidr,
 };
 
-use super::{common::IfaceCommon, internal::IfaceInternal, Iface};
+use super::{common::IfaceCommon, internal::IfaceInternal, Iface, IpAddress, Ipv4Address};
+use crate::prelude::*;
 
 pub const LOOPBACK_ADDRESS: IpAddress = {
     let ipv4_addr = Ipv4Address::new(127, 0, 0, 1);

--- a/services/aster-nix/src/net/iface/mod.rs
+++ b/services/aster-nix/src/net/iface/mod.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use smoltcp::iface::SocketSet;
+
 use self::common::IfaceCommon;
 use crate::prelude::*;
-use smoltcp::iface::SocketSet;
 
 mod any_socket;
 mod common;
@@ -11,8 +12,9 @@ mod time;
 mod util;
 mod virtio;
 
-pub use any_socket::{AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket};
-pub use any_socket::{RECV_BUF_LEN, SEND_BUF_LEN};
+pub use any_socket::{
+    AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket, RECV_BUF_LEN, SEND_BUF_LEN,
+};
 pub use loopback::IfaceLoopback;
 pub use smoltcp::wire::{EthernetAddress, IpAddress, IpEndpoint, IpListenEndpoint, Ipv4Address};
 pub use util::{spawn_background_poll_thread, BindPortConfig};

--- a/services/aster-nix/src/net/iface/util.rs
+++ b/services/aster-nix/src/net/iface/util.rs
@@ -2,6 +2,7 @@
 
 use aster_frame::timer::read_monotonic_milli_seconds;
 
+use super::Iface;
 use crate::{
     prelude::*,
     thread::{
@@ -9,8 +10,6 @@ use crate::{
         Thread,
     },
 };
-
-use super::Iface;
 
 pub enum BindPortConfig {
     CanReuse(u16),

--- a/services/aster-nix/src/net/iface/virtio.rs
+++ b/services/aster-nix/src/net/iface/virtio.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_frame::sync::SpinLock;
 use aster_network::AnyNetworkDevice;
 use aster_virtio::device::network::DEVICE_NAME;
@@ -11,6 +10,7 @@ use smoltcp::{
 };
 
 use super::{common::IfaceCommon, internal::IfaceInternal, Iface};
+use crate::prelude::*;
 
 pub struct IfaceVirtio {
     driver: Arc<SpinLock<Box<dyn AnyNetworkDevice>>>,

--- a/services/aster-nix/src/net/mod.rs
+++ b/services/aster-nix/src/net/mod.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use spin::Once;
+
+use self::iface::spawn_background_poll_thread;
 use crate::{
     net::iface::{Iface, IfaceLoopback, IfaceVirtio},
     prelude::*,
 };
-use spin::Once;
-
-use self::iface::spawn_background_poll_thread;
 
 pub static IFACES: Once<Vec<Arc<dyn Iface>>> = Once::new();
 

--- a/services/aster-nix/src/net/socket/ip/always_some.rs
+++ b/services/aster-nix/src/net/socket/ip/always_some.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use core::ops::{Deref, DerefMut};
+
+use crate::prelude::*;
 
 /// AlwaysSome is a wrapper for Option.
 ///

--- a/services/aster-nix/src/net/socket/ip/common.rs
+++ b/services/aster-nix/src/net/socket/ip/common.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::net::iface::BindPortConfig;
-use crate::net::iface::Iface;
-use crate::net::iface::{AnyBoundSocket, AnyUnboundSocket};
-use crate::net::iface::{IpAddress, IpEndpoint};
-use crate::net::IFACES;
-use crate::prelude::*;
+use crate::{
+    net::{
+        iface::{AnyBoundSocket, AnyUnboundSocket, BindPortConfig, Iface, IpAddress, IpEndpoint},
+        IFACES,
+    },
+    prelude::*,
+};
 
 pub fn get_iface_to_bind(ip_addr: &IpAddress) -> Option<Arc<dyn Iface>> {
     let ifaces = IFACES.get().unwrap();

--- a/services/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/services/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::{IoEvents, Observer};
-use crate::net::iface::IpEndpoint;
-
-use crate::net::poll_ifaces;
-use crate::process::signal::{Pollee, Poller};
 use crate::{
+    events::{IoEvents, Observer},
     net::{
-        iface::{AnyBoundSocket, RawUdpSocket},
+        iface::{AnyBoundSocket, IpEndpoint, RawUdpSocket},
+        poll_ifaces,
         socket::util::send_recv_flags::SendRecvFlags,
     },
     prelude::*,
+    process::signal::{Pollee, Poller},
 };
 
 pub struct BoundDatagram {

--- a/services/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/services/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -2,21 +2,21 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::events::IoEvents;
-use crate::fs::file_handle::FileLike;
-use crate::fs::utils::StatusFlags;
-use crate::net::iface::IpEndpoint;
-use crate::net::socket::util::send_recv_flags::SendRecvFlags;
-use crate::net::socket::util::socket_addr::SocketAddr;
-use crate::net::socket::Socket;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-
-use self::bound::BoundDatagram;
-use self::unbound::UnboundDatagram;
-
-use super::always_some::AlwaysSome;
-use super::common::get_ephemeral_endpoint;
+use self::{bound::BoundDatagram, unbound::UnboundDatagram};
+use super::{always_some::AlwaysSome, common::get_ephemeral_endpoint};
+use crate::{
+    events::IoEvents,
+    fs::{file_handle::FileLike, utils::StatusFlags},
+    net::{
+        iface::IpEndpoint,
+        socket::{
+            util::{send_recv_flags::SendRecvFlags, socket_addr::SocketAddr},
+            Socket,
+        },
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 mod bound;
 mod unbound;

--- a/services/aster-nix/src/net/socket/ip/datagram/unbound.rs
+++ b/services/aster-nix/src/net/socket/ip/datagram/unbound.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::net::iface::IpEndpoint;
-
-use crate::net::socket::ip::common::bind_socket;
-use crate::process::signal::{Pollee, Poller};
-use crate::{
-    net::iface::{AnyUnboundSocket, RawUdpSocket},
-    prelude::*,
-};
-
 use super::bound::BoundDatagram;
+use crate::{
+    events::IoEvents,
+    net::{
+        iface::{AnyUnboundSocket, IpEndpoint, RawUdpSocket},
+        socket::ip::common::bind_socket,
+    },
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub struct UnboundDatagram {
     unbound_socket: Box<AnyUnboundSocket>,

--- a/services/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -2,16 +2,15 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::events::{IoEvents, Observer};
-use crate::net::iface::IpEndpoint;
-use crate::process::signal::{Pollee, Poller};
 use crate::{
+    events::{IoEvents, Observer},
     net::{
-        iface::{AnyBoundSocket, RawTcpSocket},
+        iface::{AnyBoundSocket, IpEndpoint, RawTcpSocket},
         poll_ifaces,
         socket::util::{send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd},
     },
     prelude::*,
+    process::signal::{Pollee, Poller},
 };
 
 pub struct ConnectedStream {

--- a/services/aster-nix/src/net/socket/ip/stream/connecting.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/connecting.rs
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use alloc::sync::Arc;
-
-use crate::events::{IoEvents, Observer};
-use crate::net::iface::RawTcpSocket;
-use crate::net::poll_ifaces;
-use crate::prelude::*;
-
-use crate::net::iface::{AnyBoundSocket, IpEndpoint};
-use crate::process::signal::{Pollee, Poller};
-
-use super::connected::ConnectedStream;
-use super::init::InitStream;
+use super::{connected::ConnectedStream, init::InitStream};
+use crate::{
+    events::{IoEvents, Observer},
+    net::{
+        iface::{AnyBoundSocket, IpEndpoint, RawTcpSocket},
+        poll_ifaces,
+    },
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub struct ConnectingStream {
     nonblocking: AtomicBool,

--- a/services/aster-nix/src/net/socket/ip/stream/init.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/init.rs
@@ -2,18 +2,19 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::events::IoEvents;
-use crate::net::iface::Iface;
-use crate::net::iface::IpEndpoint;
-use crate::net::iface::{AnyBoundSocket, AnyUnboundSocket};
-use crate::net::socket::ip::always_some::AlwaysSome;
-use crate::net::socket::ip::common::{bind_socket, get_ephemeral_endpoint};
-use crate::prelude::*;
-use crate::process::signal::Pollee;
-use crate::process::signal::Poller;
-
-use super::connecting::ConnectingStream;
-use super::listen::ListenStream;
+use super::{connecting::ConnectingStream, listen::ListenStream};
+use crate::{
+    events::IoEvents,
+    net::{
+        iface::{AnyBoundSocket, AnyUnboundSocket, Iface, IpEndpoint},
+        socket::ip::{
+            always_some::AlwaysSome,
+            common::{bind_socket, get_ephemeral_endpoint},
+        },
+    },
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub struct InitStream {
     inner: RwLock<Inner>,

--- a/services/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -2,14 +2,16 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::events::{IoEvents, Observer};
-use crate::net::iface::{AnyUnboundSocket, BindPortConfig, IpEndpoint};
-
-use crate::net::iface::{AnyBoundSocket, RawTcpSocket};
-use crate::process::signal::{Pollee, Poller};
-use crate::{net::poll_ifaces, prelude::*};
-
 use super::connected::ConnectedStream;
+use crate::{
+    events::{IoEvents, Observer},
+    net::{
+        iface::{AnyBoundSocket, AnyUnboundSocket, BindPortConfig, IpEndpoint, RawTcpSocket},
+        poll_ifaces,
+    },
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub struct ListenStream {
     is_nonblocking: AtomicBool,

--- a/services/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::file_handle::FileLike;
-use crate::fs::utils::StatusFlags;
-use crate::net::socket::options::{
-    Error, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
-};
-use crate::net::socket::util::options::{SocketOptionSet, MIN_RECVBUF, MIN_SENDBUF};
-use crate::net::socket::util::{
-    send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd, socket_addr::SocketAddr,
-};
-use crate::net::socket::Socket;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::{match_sock_option_mut, match_sock_option_ref};
-use options::{Congestion, MaxSegment, WindowClamp};
-use util::{TcpOptionSet, DEFAULT_MAXSEG};
-
 use connected::ConnectedStream;
 use connecting::ConnectingStream;
 use init::InitStream;
 use listen::ListenStream;
-use options::NoDelay;
+use options::{Congestion, MaxSegment, NoDelay, WindowClamp};
 use smoltcp::wire::IpEndpoint;
+use util::{TcpOptionSet, DEFAULT_MAXSEG};
+
+use crate::{
+    events::IoEvents,
+    fs::{file_handle::FileLike, utils::StatusFlags},
+    match_sock_option_mut, match_sock_option_ref,
+    net::socket::{
+        options::{Error, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption},
+        util::{
+            options::{SocketOptionSet, MIN_RECVBUF, MIN_SENDBUF},
+            send_recv_flags::SendRecvFlags,
+            shutdown_cmd::SockShutdownCmd,
+            socket_addr::SocketAddr,
+        },
+        Socket,
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 mod connected;
 mod connecting;

--- a/services/aster-nix/src/net/socket/ip/stream/options.rs
+++ b/services/aster-nix/src/net/socket/ip/stream/options.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::impl_socket_options;
-
 use super::CongestionControl;
+use crate::impl_socket_options;
 
 impl_socket_options!(
     pub struct NoDelay(bool);

--- a/services/aster-nix/src/net/socket/mod.rs
+++ b/services/aster-nix/src/net/socket/mod.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{fs::file_handle::FileLike, prelude::*};
-
 use self::options::SocketOption;
-pub use self::util::options::LingerOption;
-pub use self::util::send_recv_flags::SendRecvFlags;
-pub use self::util::shutdown_cmd::SockShutdownCmd;
-pub use self::util::socket_addr::SocketAddr;
+pub use self::util::{
+    options::LingerOption, send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd,
+    socket_addr::SocketAddr,
+};
+use crate::{fs::file_handle::FileLike, prelude::*};
 
 pub mod ip;
 pub mod options;

--- a/services/aster-nix/src/net/socket/options/mod.rs
+++ b/services/aster-nix/src/net/socket/options/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::impl_socket_options;
-use crate::prelude::*;
+use crate::{impl_socket_options, prelude::*};
 mod macros;
 
 use super::LingerOption;

--- a/services/aster-nix/src/net/socket/unix/addr.rs
+++ b/services/aster-nix/src/net/socket/unix/addr.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::utils::Dentry;
-use crate::net::socket::util::socket_addr::SocketAddr;
-use crate::prelude::*;
+use crate::{fs::utils::Dentry, net::socket::util::socket_addr::SocketAddr, prelude::*};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UnixSocketAddr {

--- a/services/aster-nix/src/net/socket/unix/stream/connected.rs
+++ b/services/aster-nix/src/net/socket/unix/stream/connected.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::endpoint::Endpoint;
-use crate::events::IoEvents;
-use crate::net::socket::{unix::addr::UnixSocketAddrBound, SockShutdownCmd};
-use crate::prelude::*;
-use crate::process::signal::Poller;
+use crate::{
+    events::IoEvents,
+    net::socket::{unix::addr::UnixSocketAddrBound, SockShutdownCmd},
+    prelude::*,
+    process::signal::Poller,
+};
 
 pub(super) struct Connected {
     local_endpoint: Arc<Endpoint>,

--- a/services/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/services/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::process::signal::Poller;
 use crate::{
+    events::IoEvents,
     fs::utils::{Channel, Consumer, Producer, StatusFlags},
     net::socket::{unix::addr::UnixSocketAddrBound, SockShutdownCmd},
     prelude::*,
+    process::signal::Poller,
 };
 
 pub(super) struct Endpoint(Inner);

--- a/services/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/services/aster-nix/src/net/socket/unix/stream/init.rs
@@ -2,16 +2,17 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::events::IoEvents;
-use crate::fs::fs_resolver::{split_path, FsPath};
-use crate::fs::utils::{Dentry, InodeMode, InodeType};
-use crate::net::socket::unix::addr::{UnixSocketAddr, UnixSocketAddrBound};
-use crate::prelude::*;
-use crate::process::signal::{Pollee, Poller};
-
-use super::connected::Connected;
-use super::endpoint::Endpoint;
-use super::listener::push_incoming;
+use super::{connected::Connected, endpoint::Endpoint, listener::push_incoming};
+use crate::{
+    events::IoEvents,
+    fs::{
+        fs_resolver::{split_path, FsPath},
+        utils::{Dentry, InodeMode, InodeType},
+    },
+    net::socket::unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub(super) struct Init {
     is_nonblocking: AtomicBool,

--- a/services/aster-nix/src/net/socket/unix/stream/listener.rs
+++ b/services/aster-nix/src/net/socket/unix/stream/listener.rs
@@ -1,15 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{connected::Connected, endpoint::Endpoint, UnixStreamSocket};
-use crate::events::IoEvents;
-use crate::fs::file_handle::FileLike;
-use crate::fs::utils::{Dentry, Inode};
-use crate::net::socket::unix::addr::{UnixSocketAddr, UnixSocketAddrBound};
-use crate::net::socket::SocketAddr;
-use crate::prelude::*;
-use crate::process::signal::{Pollee, Poller};
 use core::sync::atomic::{AtomicBool, Ordering};
+
 use keyable_arc::KeyableWeak;
+
+use super::{connected::Connected, endpoint::Endpoint, UnixStreamSocket};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file_handle::FileLike,
+        utils::{Dentry, Inode},
+    },
+    net::socket::{
+        unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
+        SocketAddr,
+    },
+    prelude::*,
+    process::signal::{Pollee, Poller},
+};
 
 pub(super) struct Listener {
     addr: UnixSocketAddrBound,

--- a/services/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/services/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -1,21 +1,26 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::fs::file_handle::FileLike;
-use crate::fs::fs_resolver::FsPath;
-use crate::fs::utils::{Dentry, InodeType, StatusFlags};
-use crate::net::socket::unix::addr::UnixSocketAddrBound;
-use crate::net::socket::unix::UnixSocketAddr;
-use crate::net::socket::util::send_recv_flags::SendRecvFlags;
-use crate::net::socket::util::socket_addr::SocketAddr;
-use crate::net::socket::{SockShutdownCmd, Socket};
-use crate::prelude::*;
-use crate::process::signal::Poller;
-
-use super::connected::Connected;
-use super::endpoint::Endpoint;
-use super::init::Init;
-use super::listener::{unregister_backlog, Listener};
+use super::{
+    connected::Connected,
+    endpoint::Endpoint,
+    init::Init,
+    listener::{unregister_backlog, Listener},
+};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file_handle::FileLike,
+        fs_resolver::FsPath,
+        utils::{Dentry, InodeType, StatusFlags},
+    },
+    net::socket::{
+        unix::{addr::UnixSocketAddrBound, UnixSocketAddr},
+        util::{send_recv_flags::SendRecvFlags, socket_addr::SocketAddr},
+        SockShutdownCmd, Socket,
+    },
+    prelude::*,
+    process::signal::Poller,
+};
 
 pub struct UnixStreamSocket(RwLock<State>);
 

--- a/services/aster-nix/src/net/socket/util/options.rs
+++ b/services/aster-nix/src/net/socket/util/options.rs
@@ -2,8 +2,10 @@
 
 use core::time::Duration;
 
-use crate::net::iface::{RECV_BUF_LEN, SEND_BUF_LEN};
-use crate::prelude::*;
+use crate::{
+    net::iface::{RECV_BUF_LEN, SEND_BUF_LEN},
+    prelude::*,
+};
 
 #[derive(Debug, Clone, CopyGetters, Setters)]
 #[get_copy = "pub"]

--- a/services/aster-nix/src/net/socket/util/socket_addr.rs
+++ b/services/aster-nix/src/net/socket/util/socket_addr.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::net::iface::{IpAddress, Ipv4Address};
-use crate::net::iface::{IpEndpoint, IpListenEndpoint};
-use crate::net::socket::unix::UnixSocketAddr;
-use crate::prelude::*;
+use crate::{
+    net::{
+        iface::{IpAddress, IpEndpoint, IpListenEndpoint, Ipv4Address},
+        socket::unix::UnixSocketAddr,
+    },
+    prelude::*,
+};
 
 type PortNum = u16;
 

--- a/services/aster-nix/src/prelude.rs
+++ b/services/aster-nix/src/prelude.rs
@@ -2,25 +2,23 @@
 
 #![allow(unused)]
 
-pub(crate) use alloc::boxed::Box;
-pub(crate) use alloc::collections::BTreeMap;
-pub(crate) use alloc::collections::BTreeSet;
-pub(crate) use alloc::collections::LinkedList;
-pub(crate) use alloc::collections::VecDeque;
-pub(crate) use alloc::ffi::CString;
-pub(crate) use alloc::string::String;
-pub(crate) use alloc::string::ToString;
-pub(crate) use alloc::sync::Arc;
-pub(crate) use alloc::sync::Weak;
-pub(crate) use alloc::vec;
-pub(crate) use alloc::vec::Vec;
-pub(crate) use aster_frame::config::PAGE_SIZE;
-pub(crate) use aster_frame::sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard};
-pub(crate) use aster_frame::vm::Vaddr;
+pub(crate) use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
+    ffi::CString,
+    string::{String, ToString},
+    sync::{Arc, Weak},
+    vec,
+    vec::Vec,
+};
+pub(crate) use core::{any::Any, ffi::CStr, fmt::Debug};
+
+pub(crate) use aster_frame::{
+    config::PAGE_SIZE,
+    sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
+    vm::Vaddr,
+};
 pub(crate) use bitflags::bitflags;
-pub(crate) use core::any::Any;
-pub(crate) use core::ffi::CStr;
-pub(crate) use core::fmt::Debug;
 pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use log::{debug, error, info, trace, warn};
 pub(crate) use pod::Pod;
@@ -41,10 +39,12 @@ macro_rules! current_thread {
     };
 }
 
-pub(crate) use crate::current;
-pub(crate) use crate::current_thread;
-pub(crate) use crate::error::{Errno, Error};
-pub(crate) use crate::{print, println};
 pub(crate) use lazy_static::lazy_static;
+
+pub(crate) use crate::{
+    current, current_thread,
+    error::{Errno, Error},
+    print, println,
+};
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 pub(crate) use crate::{return_errno, return_errno_with_message};

--- a/services/aster-nix/src/process/clone.rs
+++ b/services/aster-nix/src/process/clone.rs
@@ -1,21 +1,24 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::posix_thread::{PosixThread, PosixThreadBuilder, PosixThreadExt, ThreadName};
-use super::process_vm::ProcessVm;
-use super::signal::sig_disposition::SigDispositions;
-use super::{credentials, process_table, Credentials, Process, ProcessBuilder};
-use crate::current_thread;
-use crate::fs::file_table::FileTable;
-use crate::fs::fs_resolver::FsResolver;
-use crate::fs::utils::FileCreationMask;
-use crate::prelude::*;
-use crate::thread::{allocate_tid, thread_table, Thread, Tid};
-use crate::util::write_val_to_user;
-use crate::vm::vmar::Vmar;
-use aster_frame::cpu::UserContext;
-use aster_frame::user::UserSpace;
-use aster_frame::vm::VmIo;
+use aster_frame::{cpu::UserContext, user::UserSpace, vm::VmIo};
 use aster_rights::Full;
+
+use super::{
+    credentials,
+    posix_thread::{PosixThread, PosixThreadBuilder, PosixThreadExt, ThreadName},
+    process_table,
+    process_vm::ProcessVm,
+    signal::sig_disposition::SigDispositions,
+    Credentials, Process, ProcessBuilder,
+};
+use crate::{
+    current_thread,
+    fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
+    prelude::*,
+    thread::{allocate_tid, thread_table, Thread, Tid},
+    util::write_val_to_user,
+    vm::vmar::Vmar,
+};
 
 bitflags! {
     pub struct CloneFlags: u32 {

--- a/services/aster-nix/src/process/credentials/credentials_.rs
+++ b/services/aster-nix/src/process/credentials/credentials_.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::group::AtomicGid;
-use super::user::AtomicUid;
-use super::{Gid, Uid};
-use crate::prelude::*;
 use aster_frame::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+use super::{group::AtomicGid, user::AtomicUid, Gid, Uid};
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub(super) struct Credentials_ {

--- a/services/aster-nix/src/process/credentials/mod.rs
+++ b/services/aster-nix/src/process/credentials/mod.rs
@@ -5,14 +5,13 @@ mod group;
 mod static_cap;
 mod user;
 
-use crate::prelude::*;
 use aster_rights::{FullOp, ReadOp, WriteOp};
 use credentials_::Credentials_;
-
 pub use group::Gid;
 pub use user::Uid;
 
 use super::posix_thread::PosixThreadExt;
+use crate::prelude::*;
 
 /// `Credentials` represents a set of associated numeric user ids (UIDs) and group identifiers (GIDs)
 /// for a process.

--- a/services/aster-nix/src/process/credentials/static_cap.rs
+++ b/services/aster-nix/src/process/credentials/static_cap.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::credentials_::Credentials_;
-use super::{Credentials, Gid, Uid};
-use crate::prelude::*;
 use aster_frame::sync::{RwLockReadGuard, RwLockWriteGuard};
 use aster_rights::{Dup, Read, TRights, Write};
 use aster_rights_proc::require;
+
+use super::{credentials_::Credentials_, Credentials, Gid, Uid};
+use crate::prelude::*;
 
 impl<R: TRights> Credentials<R> {
     /// Creates a root `Credentials`. This method can only be used when creating the first process

--- a/services/aster-nix/src/process/exit.rs
+++ b/services/aster-nix/src/process/exit.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::posix_thread::PosixThreadExt;
-use crate::process::signal::signals::kernel::KernelSignal;
-use crate::{prelude::*, process::signal::constants::SIGCHLD};
-
 use super::{process_table, Pid, Process, TermStatus};
+use crate::{
+    prelude::*,
+    process::{
+        posix_thread::PosixThreadExt,
+        signal::{constants::SIGCHLD, signals::kernel::KernelSignal},
+    },
+};
 
 pub fn do_exit_group(term_status: TermStatus) {
     let current = current!();

--- a/services/aster-nix/src/process/kill.rs
+++ b/services/aster-nix/src/process/kill.rs
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::posix_thread::PosixThreadExt;
-use super::signal::signals::user::UserSignal;
-use super::signal::signals::Signal;
-use super::{credentials, process_table, Pgid, Pid, Process, Sid, Uid};
-use crate::prelude::*;
-use crate::thread::{thread_table, Tid};
+use super::{
+    credentials,
+    posix_thread::PosixThreadExt,
+    process_table,
+    signal::signals::{user::UserSignal, Signal},
+    Pgid, Pid, Process, Sid, Uid,
+};
+use crate::{
+    prelude::*,
+    thread::{thread_table, Tid},
+};
 
 /// Sends a signal to a process, using the current process as the sender.
 ///

--- a/services/aster-nix/src/process/mod.rs
+++ b/services/aster-nix/src/process/mod.rs
@@ -21,9 +21,9 @@ pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{credentials, credentials_mut, Credentials, Gid, Uid};
 pub use exit::do_exit_group;
 pub use kill::{kill, kill_all, kill_group, tgkill};
-pub use process::ProcessBuilder;
 pub use process::{
-    current, ExitCode, JobControl, Pgid, Pid, Process, ProcessGroup, Session, Sid, Terminal,
+    current, ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, Session, Sid,
+    Terminal,
 };
 pub use process_filter::ProcessFilter;
 pub use program_loader::{check_executable_file, load_program_to_vm};

--- a/services/aster-nix/src/process/posix_thread/builder.rs
+++ b/services/aster-nix/src/process/posix_thread/builder.rs
@@ -2,6 +2,7 @@
 
 use aster_frame::user::UserSpace;
 
+use super::PosixThread;
 use crate::{
     prelude::*,
     process::{
@@ -11,8 +12,6 @@ use crate::{
     },
     thread::{status::ThreadStatus, task::create_new_user_task, thread_table, Thread, Tid},
 };
-
-use super::PosixThread;
 
 /// The builder to build a posix thread
 pub struct PosixThreadBuilder {

--- a/services/aster-nix/src/process/posix_thread/mod.rs
+++ b/services/aster-nix/src/process/posix_thread/mod.rs
@@ -1,20 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::kill::SignalSenderIds;
-use super::signal::sig_mask::SigMask;
-use super::signal::sig_num::SigNum;
-use super::signal::sig_queues::SigQueues;
-use super::signal::signals::Signal;
-use super::signal::{SigEvents, SigEventsFilter, SigStack};
-use super::{do_exit_group, Credentials, Process, TermStatus};
-use crate::events::Observer;
-use crate::prelude::*;
-use crate::process::signal::constants::SIGCONT;
-use crate::thread::{thread_table, Tid};
-use crate::util::write_val_to_user;
 use aster_rights::{ReadOp, WriteOp};
 use futex::futex_wake;
 use robust_list::wake_robust_futex;
+
+use super::{
+    do_exit_group,
+    kill::SignalSenderIds,
+    signal::{
+        sig_mask::SigMask, sig_num::SigNum, sig_queues::SigQueues, signals::Signal, SigEvents,
+        SigEventsFilter, SigStack,
+    },
+    Credentials, Process, TermStatus,
+};
+use crate::{
+    events::Observer,
+    prelude::*,
+    process::signal::constants::SIGCONT,
+    thread::{thread_table, Tid},
+    util::write_val_to_user,
+};
 
 mod builder;
 pub mod futex;

--- a/services/aster-nix/src/process/posix_thread/posix_thread_ext.rs
+++ b/services/aster-nix/src/process/posix_thread/posix_thread_ext.rs
@@ -2,14 +2,13 @@
 
 use aster_frame::{cpu::UserContext, user::UserSpace};
 
+use super::{builder::PosixThreadBuilder, name::ThreadName, PosixThread};
 use crate::{
     fs::fs_resolver::{FsPath, FsResolver, AT_FDCWD},
     prelude::*,
     process::{process_vm::ProcessVm, program_loader::load_program_to_vm, Credentials, Process},
     thread::{Thread, Tid},
 };
-
-use super::{builder::PosixThreadBuilder, name::ThreadName, PosixThread};
 pub trait PosixThreadExt {
     fn as_posix_thread(&self) -> Option<&PosixThread>;
     #[allow(clippy::too_many_arguments)]

--- a/services/aster-nix/src/process/process/builder.rs
+++ b/services/aster-nix/src/process/process/builder.rs
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileTable;
-use crate::fs::fs_resolver::FsResolver;
-use crate::fs::utils::FileCreationMask;
-use crate::process::posix_thread::{PosixThreadBuilder, PosixThreadExt};
-use crate::process::process_vm::ProcessVm;
-use crate::process::rlimit::ResourceLimits;
-use crate::process::signal::sig_disposition::SigDispositions;
-use crate::process::Credentials;
-use crate::thread::Thread;
-
 use super::{Pid, Process};
-use crate::prelude::*;
+use crate::{
+    fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
+    prelude::*,
+    process::{
+        posix_thread::{PosixThreadBuilder, PosixThreadExt},
+        process_vm::ProcessVm,
+        rlimit::ResourceLimits,
+        signal::sig_disposition::SigDispositions,
+        Credentials,
+    },
+    thread::Thread,
+};
 
 pub struct ProcessBuilder<'a> {
     // Essential parts

--- a/services/aster-nix/src/process/process/job_control.rs
+++ b/services/aster-nix/src/process/process/job_control.rs
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use crate::process::signal::constants::{SIGCONT, SIGHUP};
-use crate::process::signal::signals::kernel::KernelSignal;
-use crate::process::signal::Pauser;
-use crate::process::{ProcessGroup, Session};
+use crate::{
+    prelude::*,
+    process::{
+        signal::{
+            constants::{SIGCONT, SIGHUP},
+            signals::kernel::KernelSignal,
+            Pauser,
+        },
+        ProcessGroup, Session,
+    },
+};
 
 /// The job control for terminals like tty and pty.
 ///

--- a/services/aster-nix/src/process/process/mod.rs
+++ b/services/aster-nix/src/process/process/mod.rs
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::posix_thread::PosixThreadExt;
-use super::process_vm::user_heap::UserHeap;
-use super::process_vm::ProcessVm;
-use super::rlimit::ResourceLimits;
-use super::signal::constants::SIGCHLD;
-use super::signal::sig_disposition::SigDispositions;
-use super::signal::sig_mask::SigMask;
-use super::signal::signals::Signal;
-use super::signal::Pauser;
-use super::status::ProcessStatus;
-use super::{process_table, Credentials, TermStatus};
-use crate::device::tty::open_ntty_as_controlling_terminal;
-use crate::fs::file_table::FileTable;
-use crate::fs::fs_resolver::FsResolver;
-use crate::fs::utils::FileCreationMask;
-use crate::prelude::*;
-use crate::thread::{allocate_tid, Thread};
-use crate::vm::vmar::Vmar;
+use super::{
+    posix_thread::PosixThreadExt,
+    process_table,
+    process_vm::{user_heap::UserHeap, ProcessVm},
+    rlimit::ResourceLimits,
+    signal::{
+        constants::SIGCHLD, sig_disposition::SigDispositions, sig_mask::SigMask, signals::Signal,
+        Pauser,
+    },
+    status::ProcessStatus,
+    Credentials, TermStatus,
+};
+use crate::{
+    device::tty::open_ntty_as_controlling_terminal,
+    fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
+    prelude::*,
+    thread::{allocate_tid, Thread},
+    vm::vmar::Vmar,
+};
 
 mod builder;
 mod job_control;

--- a/services/aster-nix/src/process/process/process_group.rs
+++ b/services/aster-nix/src/process/process/process_group.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{Pgid, Pid, Process, Session};
-use crate::prelude::*;
-use crate::process::signal::signals::Signal;
+use crate::{prelude::*, process::signal::signals::Signal};
 
 /// `ProcessGroup` represents a set of processes. Each `ProcessGroup` has a unique
 /// identifier `pgid`.

--- a/services/aster-nix/src/process/process/session.rs
+++ b/services/aster-nix/src/process/process/session.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
 use super::{Pgid, Process, ProcessGroup, Sid, Terminal};
+use crate::prelude::*;
 
 /// A `Session` is a collection of related process groups. Each session has a
 /// unique identifier `sid`. Process groups and sessions form a two-level

--- a/services/aster-nix/src/process/process/terminal.rs
+++ b/services/aster-nix/src/process/process/terminal.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::inode_handle::FileIo;
-use crate::prelude::*;
-use crate::process::{process_table, Pgid, ProcessGroup};
-
 use super::JobControl;
+use crate::{
+    fs::inode_handle::FileIo,
+    prelude::*,
+    process::{process_table, Pgid, ProcessGroup},
+};
 
 /// A termial is used to interact with system. A terminal can support the shell
 /// job control.

--- a/services/aster-nix/src/process/process_table.rs
+++ b/services/aster-nix/src/process/process_table.rs
@@ -4,10 +4,11 @@
 //! This table can be used to get process with pid.
 //! TODO: progress group, thread all need similar mapping
 
-use crate::events::{Events, Observer, Subject};
-use crate::prelude::*;
-
 use super::{Pgid, Pid, Process, ProcessGroup, Session, Sid};
+use crate::{
+    events::{Events, Observer, Subject},
+    prelude::*,
+};
 
 static PROCESS_TABLE: Mutex<BTreeMap<Pid, Arc<Process>>> = Mutex::new(BTreeMap::new());
 static PROCESS_GROUP_TABLE: Mutex<BTreeMap<Pgid, Arc<ProcessGroup>>> = Mutex::new(BTreeMap::new());

--- a/services/aster-nix/src/process/process_vm/user_heap.rs
+++ b/services/aster-nix/src/process/process_vm/user_heap.rs
@@ -2,14 +2,17 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::vm::perms::VmPerms;
-use crate::vm::vmar::Vmar;
-use crate::{
-    prelude::*,
-    vm::vmo::{VmoFlags, VmoOptions},
-};
 use align_ext::AlignExt;
 use aster_rights::{Full, Rights};
+
+use crate::{
+    prelude::*,
+    vm::{
+        perms::VmPerms,
+        vmar::Vmar,
+        vmo::{VmoFlags, VmoOptions},
+    },
+};
 
 pub const USER_HEAP_BASE: Vaddr = 0x0000_0000_1000_0000;
 pub const USER_HEAP_SIZE_LIMIT: usize = PAGE_SIZE * 1000;

--- a/services/aster-nix/src/process/program_loader/elf/init_stack.rs
+++ b/services/aster-nix/src/process/program_loader/elf/init_stack.rs
@@ -4,19 +4,21 @@
 //! The process initial stack, contains arguments, environmental variables and auxiliary vectors
 //! The data layout of init stack can be seen in Figure 3.9 in https://uclibc.org/docs/psABI-x86_64.pdf
 
-use crate::vm::perms::VmPerms;
-use crate::{
-    prelude::*,
-    vm::{vmar::Vmar, vmo::VmoOptions},
-};
+use core::mem;
+
 use align_ext::AlignExt;
 use aster_frame::vm::{VmIo, VmPerm};
 use aster_rights::{Full, Rights};
-use core::mem;
 
-use super::aux_vec::{AuxKey, AuxVec};
-use super::elf_file::Elf;
-use super::load_elf::LdsoLoadInfo;
+use super::{
+    aux_vec::{AuxKey, AuxVec},
+    elf_file::Elf,
+    load_elf::LdsoLoadInfo,
+};
+use crate::{
+    prelude::*,
+    vm::{perms::VmPerms, vmar::Vmar, vmo::VmoOptions},
+};
 
 pub const INIT_STACK_BASE: Vaddr = 0x0000_0000_2000_0000;
 pub const INIT_STACK_SIZE: usize = 0x1000 * 16; // 64KB

--- a/services/aster-nix/src/process/program_loader/elf/load_elf.rs
+++ b/services/aster-nix/src/process/program_loader/elf/load_elf.rs
@@ -3,24 +3,33 @@
 //! This module is used to parse elf file content to get elf_load_info.
 //! When create a process from elf file, we will use the elf_load_info to construct the VmSpace
 
-use crate::fs::fs_resolver::{FsPath, FsResolver, AT_FDCWD};
-use crate::fs::utils::Dentry;
-use crate::process::process_vm::ProcessVm;
-use crate::process::program_loader::elf::init_stack::{init_aux_vec, InitStack};
-use crate::process::{do_exit_group, TermStatus};
-use crate::vm::perms::VmPerms;
-use crate::vm::vmo::{VmoOptions, VmoRightsOp};
-use crate::{
-    prelude::*,
-    vm::{vmar::Vmar, vmo::Vmo},
-};
 use align_ext::AlignExt;
-use aster_frame::task::Task;
-use aster_frame::vm::{VmIo, VmPerm};
+use aster_frame::{
+    task::Task,
+    vm::{VmIo, VmPerm},
+};
 use aster_rights::{Full, Rights};
 use xmas_elf::program::{self, ProgramHeader64};
 
 use super::elf_file::Elf;
+use crate::{
+    fs::{
+        fs_resolver::{FsPath, FsResolver, AT_FDCWD},
+        utils::Dentry,
+    },
+    prelude::*,
+    process::{
+        do_exit_group,
+        process_vm::ProcessVm,
+        program_loader::elf::init_stack::{init_aux_vec, InitStack},
+        TermStatus,
+    },
+    vm::{
+        perms::VmPerms,
+        vmar::Vmar,
+        vmo::{Vmo, VmoOptions, VmoRightsOp},
+    },
+};
 
 /// load elf to the root vmar. this function will  
 /// 1. read the vaddr of each segment to get all elf pages.  

--- a/services/aster-nix/src/process/program_loader/mod.rs
+++ b/services/aster-nix/src/process/program_loader/mod.rs
@@ -3,16 +3,20 @@
 pub mod elf;
 mod shebang;
 
-use crate::fs::fs_resolver::{FsPath, FsResolver, AT_FDCWD};
-use crate::fs::utils::Dentry;
-use crate::prelude::*;
-use crate::vdso::vdso_vmo;
-use crate::vm::perms::VmPerms;
-
-use self::elf::{load_elf_to_vm, ElfLoadInfo};
-use self::shebang::parse_shebang_line;
-
+use self::{
+    elf::{load_elf_to_vm, ElfLoadInfo},
+    shebang::parse_shebang_line,
+};
 use super::process_vm::ProcessVm;
+use crate::{
+    fs::{
+        fs_resolver::{FsPath, FsResolver, AT_FDCWD},
+        utils::Dentry,
+    },
+    prelude::*,
+    vdso::vdso_vmo,
+    vm::perms::VmPerms,
+};
 
 /// Map the vdso vmo to the corresponding virtual memory address.
 pub fn map_vdso_to_vm(process_vm: &ProcessVm) -> Vaddr {

--- a/services/aster-nix/src/process/rlimit.rs
+++ b/services/aster-nix/src/process/rlimit.rs
@@ -2,9 +2,8 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::prelude::*;
-
 use super::{process_vm::user_heap::USER_HEAP_SIZE_LIMIT, program_loader::elf::INIT_STACK_SIZE};
+use crate::prelude::*;
 
 pub struct ResourceLimits {
     rlimits: [RLimit64; RLIMIT_COUNT],

--- a/services/aster-nix/src/process/signal/c_types.rs
+++ b/services/aster-nix/src/process/signal/c_types.rs
@@ -6,12 +6,11 @@ use core::mem;
 use aster_frame::cpu::GeneralRegs;
 use aster_util::{read_union_fields, union_read_ptr::UnionReadPtr};
 
+use super::sig_num::SigNum;
 use crate::{
     prelude::*,
     process::{Pid, Uid},
 };
-
-use super::sig_num::SigNum;
 
 pub type sigset_t = u64;
 // FIXME: this type should be put at suitable place

--- a/services/aster-nix/src/process/signal/events.rs
+++ b/services/aster-nix/src/process/signal/events.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::{Events, EventsFilter};
-use crate::prelude::*;
-
-use super::sig_mask::SigMask;
-use super::sig_num::SigNum;
+use super::{sig_mask::SigMask, sig_num::SigNum};
+use crate::{
+    events::{Events, EventsFilter},
+    prelude::*,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SigEvents(SigNum);

--- a/services/aster-nix/src/process/signal/mod.rs
+++ b/services/aster-nix/src/process/signal/mod.rs
@@ -13,24 +13,25 @@ pub mod sig_queues;
 mod sig_stack;
 pub mod signals;
 
+use core::mem;
+
+use align_ext::AlignExt;
+use aster_frame::{cpu::UserContext, task::Task};
+use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 pub use pauser::Pauser;
 pub use poll::{Pollee, Poller};
-pub use sig_stack::{SigStack, SigStackFlags};
-
-use align_ext::AlignExt;
-use aster_frame::cpu::UserContext;
-use aster_frame::task::Task;
-use core::mem;
-
-use super::posix_thread::{PosixThread, PosixThreadExt};
-use crate::prelude::*;
-use crate::process::{do_exit_group, TermStatus};
-use crate::util::{write_bytes_to_user, write_val_to_user};
-use c_types::{siginfo_t, ucontext_t};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
 use sig_num::SigNum;
+pub use sig_stack::{SigStack, SigStackFlags};
+
+use super::posix_thread::{PosixThread, PosixThreadExt};
+use crate::{
+    prelude::*,
+    process::{do_exit_group, TermStatus},
+    util::{write_bytes_to_user, write_val_to_user},
+};
 
 /// Handle pending signal for current process
 pub fn handle_pending_signal(context: &mut UserContext) -> Result<()> {

--- a/services/aster-nix/src/process/signal/pauser.rs
+++ b/services/aster-nix/src/process/signal/pauser.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-use core::time::Duration;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use aster_frame::sync::WaitQueue;
 
-use crate::events::Observer;
-use crate::prelude::*;
-use crate::process::posix_thread::PosixThreadExt;
-
-use super::sig_mask::SigMask;
-use super::{SigEvents, SigEventsFilter};
+use super::{sig_mask::SigMask, SigEvents, SigEventsFilter};
+use crate::{events::Observer, prelude::*, process::posix_thread::PosixThreadExt};
 
 /// A `Pauser` allows pausing the execution of the current thread until certain conditions are reached.
 ///

--- a/services/aster-nix/src/process/signal/poll.rs
+++ b/services/aster-nix/src/process/signal/poll.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::events::IoEvents;
-use crate::events::{Observer, Subject};
-use crate::prelude::*;
-use crate::process::signal::Pauser;
+use core::{
+    sync::atomic::{AtomicU32, AtomicUsize, Ordering},
+    time::Duration,
+};
 
-use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
-use core::time::Duration;
 use keyable_arc::KeyableWeak;
+
+use crate::{
+    events::{IoEvents, Observer, Subject},
+    prelude::*,
+    process::signal::Pauser,
+};
 
 /// A pollee maintains a set of active events, which can be polled with
 /// pollers or be monitored with observers.

--- a/services/aster-nix/src/process/signal/sig_action.rs
+++ b/services/aster-nix/src/process/signal/sig_action.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use bitflags::bitflags;
+
 use super::{c_types::sigaction_t, constants::*, sig_mask::SigMask, sig_num::SigNum};
 use crate::prelude::*;
-use bitflags::bitflags;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum SigAction {

--- a/services/aster-nix/src/process/signal/sig_queues.rs
+++ b/services/aster-nix/src/process/signal/sig_queues.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{constants::*, SigEvents, SigEventsFilter};
-use crate::events::{Observer, Subject};
-use crate::prelude::*;
-
-use super::sig_mask::SigMask;
-use super::sig_num::SigNum;
-use super::signals::Signal;
+use super::{
+    constants::*, sig_mask::SigMask, sig_num::SigNum, signals::Signal, SigEvents, SigEventsFilter,
+};
+use crate::{
+    events::{Observer, Subject},
+    prelude::*,
+};
 
 pub struct SigQueues {
     count: usize,

--- a/services/aster-nix/src/process/signal/signals/fault.rs
+++ b/services/aster-nix/src/process/signal/signals/fault.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::cpu::{CpuException, CpuExceptionInfo};
 use aster_frame::cpu::{
-    ALIGNMENT_CHECK, BOUND_RANGE_EXCEEDED, DIVIDE_BY_ZERO, GENERAL_PROTECTION_FAULT,
-    INVALID_OPCODE, PAGE_FAULT, SIMD_FLOATING_POINT_EXCEPTION, X87_FLOATING_POINT_EXCEPTION,
+    CpuException, CpuExceptionInfo, ALIGNMENT_CHECK, BOUND_RANGE_EXCEEDED, DIVIDE_BY_ZERO,
+    GENERAL_PROTECTION_FAULT, INVALID_OPCODE, PAGE_FAULT, SIMD_FLOATING_POINT_EXCEPTION,
+    X87_FLOATING_POINT_EXCEPTION,
 };
 
-use crate::prelude::*;
-use crate::process::signal::c_types::siginfo_t;
-use crate::process::signal::constants::*;
-use crate::process::signal::sig_num::SigNum;
-
 use super::Signal;
+use crate::{
+    prelude::*,
+    process::signal::{c_types::siginfo_t, constants::*, sig_num::SigNum},
+};
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FaultSignal {
     num: SigNum,

--- a/services/aster-nix/src/process/signal/signals/kernel.rs
+++ b/services/aster-nix/src/process/signal/signals/kernel.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::Signal;
-use crate::process::signal::c_types::siginfo_t;
-use crate::process::signal::constants::SI_KERNEL;
-use crate::process::signal::sig_num::SigNum;
+use crate::process::signal::{c_types::siginfo_t, constants::SI_KERNEL, sig_num::SigNum};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KernelSignal {

--- a/services/aster-nix/src/process/signal/signals/mod.rs
+++ b/services/aster-nix/src/process/signal/signals/mod.rs
@@ -4,10 +4,9 @@ pub mod fault;
 pub mod kernel;
 pub mod user;
 
-use super::c_types::siginfo_t;
-use super::sig_num::SigNum;
-use core::any::Any;
-use core::fmt::Debug;
+use core::{any::Any, fmt::Debug};
+
+use super::{c_types::siginfo_t, sig_num::SigNum};
 
 pub trait Signal: Send + Sync + Debug + Any {
     /// Returns the number of the signal.

--- a/services/aster-nix/src/process/signal/signals/user.rs
+++ b/services/aster-nix/src/process/signal/signals/user.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::Signal;
-use crate::process::signal::c_types::siginfo_t;
-use crate::process::signal::constants::{SI_QUEUE, SI_TKILL, SI_USER};
-use crate::process::signal::sig_num::SigNum;
-use crate::process::{Pid, Uid};
+use crate::process::{
+    signal::{
+        c_types::siginfo_t,
+        constants::{SI_QUEUE, SI_TKILL, SI_USER},
+        sig_num::SigNum,
+    },
+    Pid, Uid,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct UserSignal {

--- a/services/aster-nix/src/process/wait.rs
+++ b/services/aster-nix/src/process/wait.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{prelude::*, process::process_table, thread::thread_table};
-
 use super::{process_filter::ProcessFilter, ExitCode, Pid, Process};
+use crate::{prelude::*, process::process_table, thread::thread_table};
 
 // The definition of WaitOptions is from Occlum
 bitflags! {

--- a/services/aster-nix/src/sched/priority_scheduler.rs
+++ b/services/aster-nix/src/sched/priority_scheduler.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_frame::task::{set_scheduler, Scheduler, Task, TaskAdapter};
 use intrusive_collections::LinkedList;
+
+use crate::prelude::*;
 
 pub fn init() {
     let preempt_scheduler = Box::new(PreemptScheduler::new());

--- a/services/aster-nix/src/syscall/accept.rs
+++ b/services/aster-nix/src/syscall/accept.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, write_socket_addr_to_user};
-
 use super::{SyscallReturn, SYS_ACCEPT};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, write_socket_addr_to_user},
+};
 
 pub fn sys_accept(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/arch_prctl.rs
+++ b/services/aster-nix/src/syscall/arch_prctl.rs
@@ -2,10 +2,8 @@
 
 use aster_frame::cpu::UserContext;
 
-use crate::syscall::SYS_ARCH_PRCTL;
-use crate::{log_syscall_entry, prelude::*};
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_ARCH_PRCTL};
 
 #[allow(non_camel_case_types)]
 #[repr(u64)]

--- a/services/aster-nix/src/syscall/bind.rs
+++ b/services/aster-nix/src/syscall/bind.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, read_socket_addr_from_user};
-
 use super::{SyscallReturn, SYS_BIND};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, read_socket_addr_from_user},
+};
 
 pub fn sys_bind(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/brk.rs
+++ b/services/aster-nix/src/syscall/brk.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use crate::syscall::SyscallReturn;
-use crate::syscall::SYS_BRK;
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    syscall::{SyscallReturn, SYS_BRK},
+};
 
 /// expand the user heap to new heap end, returns the new heap end if expansion succeeds.
 pub fn sys_brk(heap_end: u64) -> Result<SyscallReturn> {

--- a/services/aster-nix/src/syscall/chdir.rs
+++ b/services/aster-nix/src/syscall/chdir.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter, fs_resolver::FsPath, inode_handle::InodeHandle, utils::InodeType,
+use super::{SyscallReturn, SYS_CHDIR, SYS_FCHDIR};
+use crate::{
+    fs::{
+        file_table::FileDescripter, fs_resolver::FsPath, inode_handle::InodeHandle,
+        utils::InodeType,
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::{SYS_CHDIR, SYS_FCHDIR};
 
 pub fn sys_chdir(pathname_addr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_CHDIR);

--- a/services/aster-nix/src/syscall/chmod.rs
+++ b/services/aster-nix/src/syscall/chmod.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::{InodeMode, PATH_MAX},
+use super::{SyscallReturn, SYS_FCHMOD, SYS_FCHMODAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::{InodeMode, PATH_MAX},
+    },
+    log_syscall_entry,
+    prelude::*,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::{SYS_FCHMOD, SYS_FCHMODAT};
 
 pub fn sys_fchmod(fd: FileDescripter, mode: u16) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCHMOD);

--- a/services/aster-nix/src/syscall/chown.rs
+++ b/services/aster-nix/src/syscall/chown.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::PATH_MAX,
+use super::{SyscallReturn, SYS_FCHOWN, SYS_FCHOWNAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::PATH_MAX,
+    },
+    log_syscall_entry,
+    prelude::*,
+    process::{Gid, Uid},
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{Gid, Uid};
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::{SYS_FCHOWN, SYS_FCHOWNAT};
 
 pub fn sys_fchown(fd: FileDescripter, uid: i32, gid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCHOWN);

--- a/services/aster-nix/src/syscall/clock_gettime.rs
+++ b/services/aster-nix/src/syscall/clock_gettime.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
-use super::SYS_CLOCK_GETTIME;
-use crate::time::now_as_duration;
+use super::{SyscallReturn, SYS_CLOCK_GETTIME};
 use crate::{
     log_syscall_entry,
     prelude::*,
-    time::{clockid_t, timespec_t, ClockID},
+    time::{clockid_t, now_as_duration, timespec_t, ClockID},
     util::write_val_to_user,
 };
 

--- a/services/aster-nix/src/syscall/clock_nanosleep.rs
+++ b/services/aster-nix/src/syscall/clock_nanosleep.rs
@@ -2,13 +2,14 @@
 
 use core::time::Duration;
 
-use super::SyscallReturn;
-use super::SYS_CLOCK_NANOSLEEP;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::signal::Pauser;
-use crate::time::{clockid_t, now_as_duration, timespec_t, ClockID, TIMER_ABSTIME};
-use crate::util::{read_val_from_user, write_val_to_user};
+use super::{SyscallReturn, SYS_CLOCK_NANOSLEEP};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::signal::Pauser,
+    time::{clockid_t, now_as_duration, timespec_t, ClockID, TIMER_ABSTIME},
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_clock_nanosleep(
     clockid: clockid_t,

--- a/services/aster-nix/src/syscall/clone.rs
+++ b/services/aster-nix/src/syscall/clone.rs
@@ -2,11 +2,13 @@
 
 use aster_frame::cpu::UserContext;
 
-use crate::log_syscall_entry;
-use crate::process::{clone_child, CloneArgs, CloneFlags};
-use crate::{prelude::*, syscall::SYS_CLONE};
-
 use super::SyscallReturn;
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{clone_child, CloneArgs, CloneFlags},
+    syscall::SYS_CLONE,
+};
 
 // The order of arguments for clone differs in different architecture.
 // This order we use here is the order for x86_64. See https://man7.org/linux/man-pages/man2/clone.2.html.

--- a/services/aster-nix/src/syscall/close.rs
+++ b/services/aster-nix/src/syscall/close.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
-use super::SYS_CLOSE;
-use crate::log_syscall_entry;
-use crate::{fs::file_table::FileDescripter, prelude::*};
+use super::{SyscallReturn, SYS_CLOSE};
+use crate::{fs::file_table::FileDescripter, log_syscall_entry, prelude::*};
 
 pub fn sys_close(fd: FileDescripter) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_CLOSE);

--- a/services/aster-nix/src/syscall/connect.rs
+++ b/services/aster-nix/src/syscall/connect.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, read_socket_addr_from_user};
-
 use super::{SyscallReturn, SYS_CONNECT};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, read_socket_addr_from_user},
+};
 
 pub fn sys_connect(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/dup.rs
+++ b/services/aster-nix/src/syscall/dup.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::{SYS_DUP, SYS_DUP2};
+use super::{SyscallReturn, SYS_DUP, SYS_DUP2};
+use crate::{fs::file_table::FileDescripter, log_syscall_entry, prelude::*};
 
 pub fn sys_dup(old_fd: FileDescripter) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_DUP);

--- a/services/aster-nix/src/syscall/epoll.rs
+++ b/services/aster-nix/src/syscall/epoll.rs
@@ -2,16 +2,18 @@
 
 use core::time::Duration;
 
-use crate::events::IoEvents;
-use crate::fs::epoll::{EpollCtl, EpollEvent, EpollFile, EpollFlags};
-use crate::fs::file_table::FileDescripter;
-use crate::fs::utils::CreationFlags;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::{read_val_from_user, write_val_to_user};
-
-use super::SyscallReturn;
-use super::{SYS_EPOLL_CREATE1, SYS_EPOLL_CTL, SYS_EPOLL_WAIT};
+use super::{SyscallReturn, SYS_EPOLL_CREATE1, SYS_EPOLL_CTL, SYS_EPOLL_WAIT};
+use crate::{
+    events::IoEvents,
+    fs::{
+        epoll::{EpollCtl, EpollEvent, EpollFile, EpollFlags},
+        file_table::FileDescripter,
+        utils::CreationFlags,
+    },
+    log_syscall_entry,
+    prelude::*,
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_epoll_create(size: i32) -> Result<SyscallReturn> {
     if size <= 0 {

--- a/services/aster-nix/src/syscall/execve.rs
+++ b/services/aster-nix/src/syscall/execve.rs
@@ -4,15 +4,22 @@ use aster_frame::cpu::UserContext;
 use aster_rights::WriteOp;
 
 use super::{constants::*, SyscallReturn};
-use crate::fs::file_table::FileDescripter;
-use crate::fs::fs_resolver::{FsPath, AT_FDCWD};
-use crate::fs::utils::{Dentry, InodeType};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::posix_thread::{PosixThreadExt, ThreadName};
-use crate::process::{check_executable_file, credentials_mut, load_program_to_vm, Credentials};
-use crate::syscall::{SYS_EXECVE, SYS_EXECVEAT};
-use crate::util::{read_cstring_from_user, read_val_from_user};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::{Dentry, InodeType},
+    },
+    log_syscall_entry,
+    prelude::*,
+    process::{
+        check_executable_file, credentials_mut, load_program_to_vm,
+        posix_thread::{PosixThreadExt, ThreadName},
+        Credentials,
+    },
+    syscall::{SYS_EXECVE, SYS_EXECVEAT},
+    util::{read_cstring_from_user, read_val_from_user},
+};
 
 pub fn sys_execve(
     filename_ptr: Vaddr,

--- a/services/aster-nix/src/syscall/exit.rs
+++ b/services/aster-nix/src/syscall/exit.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::posix_thread::PosixThreadExt;
-use crate::process::TermStatus;
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::{SyscallReturn, SYS_EXIT};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{posix_thread::PosixThreadExt, TermStatus},
+    syscall::{SyscallReturn, SYS_EXIT},
+};
 
 pub fn sys_exit(exit_code: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_EXIT);

--- a/services/aster-nix/src/syscall/exit_group.rs
+++ b/services/aster-nix/src/syscall/exit_group.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::{do_exit_group, TermStatus};
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::{SyscallReturn, SYS_EXIT_GROUP};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{do_exit_group, TermStatus},
+    syscall::{SyscallReturn, SYS_EXIT_GROUP},
+};
 
 /// Exit all thread in a process.
 pub fn sys_exit_group(exit_code: u64) -> Result<SyscallReturn> {

--- a/services/aster-nix/src/syscall/fcntl.rs
+++ b/services/aster-nix/src/syscall/fcntl.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_FCNTL};
-use crate::log_syscall_entry;
 use crate::{
     fs::{file_table::FileDescripter, utils::StatusFlags},
+    log_syscall_entry,
     prelude::*,
 };
 

--- a/services/aster-nix/src/syscall/fork.rs
+++ b/services/aster-nix/src/syscall/fork.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_frame::cpu::UserContext;
+
+use super::SyscallReturn;
 use crate::{
     log_syscall_entry,
     prelude::*,
     process::{clone_child, CloneArgs},
+    syscall::SYS_FORK,
 };
-use aster_frame::cpu::UserContext;
-
-use crate::syscall::SYS_FORK;
-
-use super::SyscallReturn;
 
 pub fn sys_fork(parent_context: UserContext) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FORK);

--- a/services/aster-nix/src/syscall/fsync.rs
+++ b/services/aster-nix/src/syscall/fsync.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
+use super::{SyscallReturn, SYS_FSYNC};
 use crate::{
     fs::{file_table::FileDescripter, inode_handle::InodeHandle},
+    log_syscall_entry,
     prelude::*,
 };
-
-use super::SyscallReturn;
-use super::SYS_FSYNC;
 
 pub fn sys_fsync(fd: FileDescripter) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FSYNC);

--- a/services/aster-nix/src/syscall/futex.rs
+++ b/services/aster-nix/src/syscall/futex.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::posix_thread::futex::{
-    futex_op_and_flags_from_u32, futex_requeue, futex_wait, futex_wait_bitset, futex_wake,
-    futex_wake_bitset, FutexOp, FutexTimeout,
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::posix_thread::futex::{
+        futex_op_and_flags_from_u32, futex_requeue, futex_wait, futex_wait_bitset, futex_wake,
+        futex_wake_bitset, FutexOp, FutexTimeout,
+    },
+    syscall::{SyscallReturn, SYS_FUTEX},
 };
-use crate::syscall::SyscallReturn;
-use crate::syscall::SYS_FUTEX;
-
-use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_futex(
     futex_addr: Vaddr,

--- a/services/aster-nix/src/syscall/getcwd.rs
+++ b/services/aster-nix/src/syscall/getcwd.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::write_bytes_to_user;
-
-use super::SyscallReturn;
-use super::SYS_GETCWD;
+use super::{SyscallReturn, SYS_GETCWD};
+use crate::{log_syscall_entry, prelude::*, util::write_bytes_to_user};
 
 pub fn sys_getcwd(buf: Vaddr, len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETCWD);

--- a/services/aster-nix/src/syscall/getdents64.rs
+++ b/services/aster-nix/src/syscall/getdents64.rs
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    inode_handle::InodeHandle,
-    utils::{DirentVisitor, InodeType},
-};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::write_bytes_to_user;
 use core::marker::PhantomData;
 
-use super::SyscallReturn;
-use super::SYS_GETDENTS64;
+use super::{SyscallReturn, SYS_GETDENTS64};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        inode_handle::InodeHandle,
+        utils::{DirentVisitor, InodeType},
+    },
+    log_syscall_entry,
+    prelude::*,
+    util::write_bytes_to_user,
+};
 
 pub fn sys_getdents64(
     fd: FileDescripter,

--- a/services/aster-nix/src/syscall/getegid.rs
+++ b/services/aster-nix/src/syscall/getegid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
-
 use super::{SyscallReturn, SYS_GETEGID};
+use crate::{log_syscall_entry, prelude::*, process::credentials};
 
 pub fn sys_getegid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETEGID);

--- a/services/aster-nix/src/syscall/geteuid.rs
+++ b/services/aster-nix/src/syscall/geteuid.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETEUID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
+use crate::{log_syscall_entry, prelude::*, process::credentials};
 
 pub fn sys_geteuid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETEUID);

--- a/services/aster-nix/src/syscall/getgid.rs
+++ b/services/aster-nix/src/syscall/getgid.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETGID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
+use crate::{log_syscall_entry, prelude::*, process::credentials};
 
 pub fn sys_getgid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETGID);

--- a/services/aster-nix/src/syscall/getgroups.rs
+++ b/services/aster-nix/src/syscall/getgroups.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETGROUPS};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
-use crate::util::write_val_to_user;
+use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getgroups(size: i32, group_list_addr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETGROUPS);

--- a/services/aster-nix/src/syscall/getpeername.rs
+++ b/services/aster-nix/src/syscall/getpeername.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, write_socket_addr_to_user};
-
 use super::{SyscallReturn, SYS_GETPEERNAME};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, write_socket_addr_to_user},
+};
 
 pub fn sys_getpeername(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/getpid.rs
+++ b/services/aster-nix/src/syscall/getpid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_GETPID;
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_GETPID};
 
 pub fn sys_getpid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETPID);

--- a/services/aster-nix/src/syscall/getppid.rs
+++ b/services/aster-nix/src/syscall/getppid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::SYS_GETPPID;
+use super::{SyscallReturn, SYS_GETPPID};
+use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_getppid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETPPID);

--- a/services/aster-nix/src/syscall/getrandom.rs
+++ b/services/aster-nix/src/syscall/getrandom.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::device;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::SYS_GETRANDOM;
-use crate::util::write_bytes_to_user;
-
 use super::SyscallReturn;
+use crate::{
+    device, log_syscall_entry, prelude::*, syscall::SYS_GETRANDOM, util::write_bytes_to_user,
+};
 
 pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETRANDOM);

--- a/services/aster-nix/src/syscall/getresgid.rs
+++ b/services/aster-nix/src/syscall/getresgid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETRESGID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
-use crate::util::write_val_to_user;
+use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getresgid(rgid_ptr: Vaddr, egid_ptr: Vaddr, sgid_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETRESGID);

--- a/services/aster-nix/src/syscall/getresuid.rs
+++ b/services/aster-nix/src/syscall/getresuid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETRESUID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
-use crate::util::write_val_to_user;
+use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getresuid(ruid_ptr: Vaddr, euid_ptr: Vaddr, suid_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETRESUID);

--- a/services/aster-nix/src/syscall/getsid.rs
+++ b/services/aster-nix/src/syscall/getsid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{process_table, Pid};
-
 use super::{SyscallReturn, SYS_GETSID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{process_table, Pid},
+};
 
 pub fn sys_getsid(pid: Pid) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETSID);

--- a/services/aster-nix/src/syscall/getsockname.rs
+++ b/services/aster-nix/src/syscall/getsockname.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, write_socket_addr_to_user};
-
 use super::{SyscallReturn, SYS_GETSOCKNAME};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, write_socket_addr_to_user},
+};
 
 pub fn sys_getsockname(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/getsockopt.rs
+++ b/services/aster-nix/src/syscall/getsockopt.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel};
-use crate::util::{read_val_from_user, write_val_to_user};
-
 use super::{SyscallReturn, SYS_SETSOCKOPT};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::{
+        net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
+        read_val_from_user, write_val_to_user,
+    },
+};
 
 pub fn sys_getsockopt(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/gettid.rs
+++ b/services/aster-nix/src/syscall/gettid.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_GETTID;
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_GETTID};
 
 pub fn sys_gettid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETTID);

--- a/services/aster-nix/src/syscall/gettimeofday.rs
+++ b/services/aster-nix/src/syscall/gettimeofday.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
-use super::SYS_GETTIMEOFDAY;
+use super::{SyscallReturn, SYS_GETTIMEOFDAY};
 use crate::{
     log_syscall_entry,
     prelude::*,

--- a/services/aster-nix/src/syscall/getuid.rs
+++ b/services/aster-nix/src/syscall/getuid.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_GETUID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::credentials;
+use crate::{log_syscall_entry, prelude::*, process::credentials};
 
 pub fn sys_getuid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETUID);

--- a/services/aster-nix/src/syscall/ioctl.rs
+++ b/services/aster-nix/src/syscall/ioctl.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::fs::utils::IoctlCmd;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::SYS_IOCTL;
+use super::{SyscallReturn, SYS_IOCTL};
+use crate::{
+    fs::{file_table::FileDescripter, utils::IoctlCmd},
+    log_syscall_entry,
+    prelude::*,
+};
 
 pub fn sys_ioctl(fd: FileDescripter, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_IOCTL);

--- a/services/aster-nix/src/syscall/kill.rs
+++ b/services/aster-nix/src/syscall/kill.rs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_KILL};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::kill;
-use crate::process::kill_all;
-use crate::process::kill_group;
-use crate::process::signal::sig_num::SigNum;
-use crate::process::signal::signals::user::{UserSignal, UserSignalKind};
-use crate::process::{credentials, ProcessFilter};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{
+        credentials, kill, kill_all, kill_group,
+        signal::{
+            sig_num::SigNum,
+            signals::user::{UserSignal, UserSignalKind},
+        },
+        ProcessFilter,
+    },
+};
 
 pub fn sys_kill(process_filter: u64, sig_num: u64) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_KILL);

--- a/services/aster-nix/src/syscall/link.rs
+++ b/services/aster-nix/src/syscall/link.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
+use super::{SyscallReturn, SYS_LINKAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_LINKAT;
 
 pub fn sys_linkat(
     old_dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/listen.rs
+++ b/services/aster-nix/src/syscall/listen.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::get_socket_from_fd;
-
 use super::{SyscallReturn, SYS_LISTEN};
+use crate::{
+    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, util::net::get_socket_from_fd,
+};
 
 pub fn sys_listen(sockfd: FileDescripter, backlog: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_LISTEN);

--- a/services/aster-nix/src/syscall/lseek.rs
+++ b/services/aster-nix/src/syscall/lseek.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{file_table::FileDescripter, utils::SeekFrom};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::SYS_LSEEK;
+use super::{SyscallReturn, SYS_LSEEK};
+use crate::{
+    fs::{file_table::FileDescripter, utils::SeekFrom},
+    log_syscall_entry,
+    prelude::*,
+};
 
 pub fn sys_lseek(fd: FileDescripter, offset: isize, whence: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_LSEEK);

--- a/services/aster-nix/src/syscall/madvise.rs
+++ b/services/aster-nix/src/syscall/madvise.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::util::read_bytes_from_user;
-use crate::{log_syscall_entry, prelude::*};
-
-use super::SyscallReturn;
-use super::SYS_MADVISE;
+use super::{SyscallReturn, SYS_MADVISE};
+use crate::{log_syscall_entry, prelude::*, util::read_bytes_from_user};
 
 pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_MADVISE);

--- a/services/aster-nix/src/syscall/mkdir.rs
+++ b/services/aster-nix/src/syscall/mkdir.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::{InodeMode, InodeType},
+use super::{SyscallReturn, SYS_MKDIRAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::{InodeMode, InodeType},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_MKDIRAT;
 
 pub fn sys_mkdirat(
     dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/mmap.rs
+++ b/services/aster-nix/src/syscall/mmap.rs
@@ -2,17 +2,21 @@
 
 //! This mod defines mmap flags and the handler to syscall mmap
 
-use crate::fs::file_table::FileDescripter;
-use crate::vm::perms::VmPerms;
-use crate::vm::vmo::{Vmo, VmoChildOptions, VmoOptions, VmoRightsOp};
-use crate::{log_syscall_entry, prelude::*};
 use align_ext::AlignExt;
 use aster_frame::vm::VmPerm;
 use aster_rights::Rights;
 
-use crate::syscall::SYS_MMAP;
-
 use super::SyscallReturn;
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    syscall::SYS_MMAP,
+    vm::{
+        perms::VmPerms,
+        vmo::{Vmo, VmoChildOptions, VmoOptions, VmoRightsOp},
+    },
+};
 
 pub fn sys_mmap(
     addr: u64,

--- a/services/aster-nix/src/syscall/mod.rs
+++ b/services/aster-nix/src/syscall/mod.rs
@@ -2,112 +2,96 @@
 
 //! Read the Cpu context content then dispatch syscall to corrsponding handler
 //! The each sub module contains functions that handle real syscall logic.
-use crate::prelude::*;
-use crate::syscall::access::sys_access;
-use crate::syscall::arch_prctl::sys_arch_prctl;
-use crate::syscall::brk::sys_brk;
-use crate::syscall::chdir::{sys_chdir, sys_fchdir};
-use crate::syscall::chmod::{sys_chmod, sys_fchmod, sys_fchmodat};
-use crate::syscall::chown::{sys_chown, sys_fchown, sys_fchownat, sys_lchown};
-use crate::syscall::clock_gettime::sys_clock_gettime;
-use crate::syscall::clock_nanosleep::sys_clock_nanosleep;
-use crate::syscall::clone::sys_clone;
-use crate::syscall::close::sys_close;
-use crate::syscall::dup::{sys_dup, sys_dup2};
-use crate::syscall::epoll::{sys_epoll_create, sys_epoll_create1, sys_epoll_ctl, sys_epoll_wait};
-use crate::syscall::execve::sys_execve;
-use crate::syscall::exit::sys_exit;
-use crate::syscall::exit_group::sys_exit_group;
-use crate::syscall::fcntl::sys_fcntl;
-use crate::syscall::fork::sys_fork;
-use crate::syscall::fsync::sys_fsync;
-use crate::syscall::futex::sys_futex;
-use crate::syscall::getcwd::sys_getcwd;
-use crate::syscall::getdents64::sys_getdents64;
-use crate::syscall::getegid::sys_getegid;
-use crate::syscall::geteuid::sys_geteuid;
-use crate::syscall::getgid::sys_getgid;
-use crate::syscall::getpgrp::sys_getpgrp;
-use crate::syscall::getpid::sys_getpid;
-use crate::syscall::getppid::sys_getppid;
-use crate::syscall::gettid::sys_gettid;
-use crate::syscall::gettimeofday::sys_gettimeofday;
-use crate::syscall::getuid::sys_getuid;
-use crate::syscall::ioctl::sys_ioctl;
-use crate::syscall::kill::sys_kill;
-use crate::syscall::link::{sys_link, sys_linkat};
-use crate::syscall::lseek::sys_lseek;
-use crate::syscall::madvise::sys_madvise;
-use crate::syscall::mkdir::{sys_mkdir, sys_mkdirat};
-use crate::syscall::mmap::sys_mmap;
-use crate::syscall::mprotect::sys_mprotect;
-use crate::syscall::munmap::sys_munmap;
-use crate::syscall::open::{sys_open, sys_openat};
-use crate::syscall::pause::sys_pause;
-use crate::syscall::pipe::{sys_pipe, sys_pipe2};
-use crate::syscall::poll::sys_poll;
-use crate::syscall::prctl::sys_prctl;
-use crate::syscall::prlimit64::sys_prlimit64;
-use crate::syscall::read::sys_read;
-use crate::syscall::readlink::{sys_readlink, sys_readlinkat};
-use crate::syscall::rename::{sys_rename, sys_renameat};
-use crate::syscall::rmdir::sys_rmdir;
-use crate::syscall::rt_sigaction::sys_rt_sigaction;
-use crate::syscall::rt_sigprocmask::sys_rt_sigprocmask;
-use crate::syscall::rt_sigreturn::sys_rt_sigreturn;
-use crate::syscall::sched_yield::sys_sched_yield;
-use crate::syscall::select::sys_select;
-use crate::syscall::set_robust_list::sys_set_robust_list;
-use crate::syscall::set_tid_address::sys_set_tid_address;
-use crate::syscall::setpgid::sys_setpgid;
-use crate::syscall::stat::{sys_fstat, sys_fstatat, sys_lstat, sys_stat};
-use crate::syscall::statfs::{sys_fstatfs, sys_statfs};
-use crate::syscall::symlink::{sys_symlink, sys_symlinkat};
-use crate::syscall::sync::sys_sync;
-use crate::syscall::tgkill::sys_tgkill;
-use crate::syscall::time::sys_time;
-use crate::syscall::truncate::{sys_ftruncate, sys_truncate};
-use crate::syscall::umask::sys_umask;
-use crate::syscall::uname::sys_uname;
-use crate::syscall::unlink::{sys_unlink, sys_unlinkat};
-use crate::syscall::utimens::sys_utimensat;
-use crate::syscall::wait4::sys_wait4;
-use crate::syscall::waitid::sys_waitid;
-use crate::syscall::write::sys_write;
-use crate::syscall::writev::sys_writev;
 use aster_frame::cpu::UserContext;
 
-use self::accept::sys_accept;
-use self::bind::sys_bind;
-use self::connect::sys_connect;
-use self::execve::sys_execveat;
-use self::getgroups::sys_getgroups;
-use self::getpeername::sys_getpeername;
-use self::getrandom::sys_getrandom;
-use self::getresgid::sys_getresgid;
-use self::getresuid::sys_getresuid;
-use self::getsid::sys_getsid;
-use self::getsockname::sys_getsockname;
-use self::getsockopt::sys_getsockopt;
-use self::listen::sys_listen;
-use self::pread64::sys_pread64;
-use self::recvfrom::sys_recvfrom;
-use self::sendto::sys_sendto;
-use self::setfsgid::sys_setfsgid;
-use self::setfsuid::sys_setfsuid;
-use self::setgid::sys_setgid;
-use self::setgroups::sys_setgroups;
-use self::setregid::sys_setregid;
-use self::setresgid::sys_setresgid;
-use self::setresuid::sys_setresuid;
-use self::setreuid::sys_setreuid;
-use self::setsid::sys_setsid;
-use self::setsockopt::sys_setsockopt;
-use self::setuid::sys_setuid;
-use self::shutdown::sys_shutdown;
-use self::sigaltstack::sys_sigaltstack;
-use self::socket::sys_socket;
-use self::socketpair::sys_socketpair;
+use self::{
+    accept::sys_accept, bind::sys_bind, connect::sys_connect, execve::sys_execveat,
+    getgroups::sys_getgroups, getpeername::sys_getpeername, getrandom::sys_getrandom,
+    getresgid::sys_getresgid, getresuid::sys_getresuid, getsid::sys_getsid,
+    getsockname::sys_getsockname, getsockopt::sys_getsockopt, listen::sys_listen,
+    pread64::sys_pread64, recvfrom::sys_recvfrom, sendto::sys_sendto, setfsgid::sys_setfsgid,
+    setfsuid::sys_setfsuid, setgid::sys_setgid, setgroups::sys_setgroups, setregid::sys_setregid,
+    setresgid::sys_setresgid, setresuid::sys_setresuid, setreuid::sys_setreuid, setsid::sys_setsid,
+    setsockopt::sys_setsockopt, setuid::sys_setuid, shutdown::sys_shutdown,
+    sigaltstack::sys_sigaltstack, socket::sys_socket, socketpair::sys_socketpair,
+};
+use crate::{
+    prelude::*,
+    syscall::{
+        access::sys_access,
+        arch_prctl::sys_arch_prctl,
+        brk::sys_brk,
+        chdir::{sys_chdir, sys_fchdir},
+        chmod::{sys_chmod, sys_fchmod, sys_fchmodat},
+        chown::{sys_chown, sys_fchown, sys_fchownat, sys_lchown},
+        clock_gettime::sys_clock_gettime,
+        clock_nanosleep::sys_clock_nanosleep,
+        clone::sys_clone,
+        close::sys_close,
+        dup::{sys_dup, sys_dup2},
+        epoll::{sys_epoll_create, sys_epoll_create1, sys_epoll_ctl, sys_epoll_wait},
+        execve::sys_execve,
+        exit::sys_exit,
+        exit_group::sys_exit_group,
+        fcntl::sys_fcntl,
+        fork::sys_fork,
+        fsync::sys_fsync,
+        futex::sys_futex,
+        getcwd::sys_getcwd,
+        getdents64::sys_getdents64,
+        getegid::sys_getegid,
+        geteuid::sys_geteuid,
+        getgid::sys_getgid,
+        getpgrp::sys_getpgrp,
+        getpid::sys_getpid,
+        getppid::sys_getppid,
+        gettid::sys_gettid,
+        gettimeofday::sys_gettimeofday,
+        getuid::sys_getuid,
+        ioctl::sys_ioctl,
+        kill::sys_kill,
+        link::{sys_link, sys_linkat},
+        lseek::sys_lseek,
+        madvise::sys_madvise,
+        mkdir::{sys_mkdir, sys_mkdirat},
+        mmap::sys_mmap,
+        mprotect::sys_mprotect,
+        munmap::sys_munmap,
+        open::{sys_open, sys_openat},
+        pause::sys_pause,
+        pipe::{sys_pipe, sys_pipe2},
+        poll::sys_poll,
+        prctl::sys_prctl,
+        prlimit64::sys_prlimit64,
+        read::sys_read,
+        readlink::{sys_readlink, sys_readlinkat},
+        rename::{sys_rename, sys_renameat},
+        rmdir::sys_rmdir,
+        rt_sigaction::sys_rt_sigaction,
+        rt_sigprocmask::sys_rt_sigprocmask,
+        rt_sigreturn::sys_rt_sigreturn,
+        sched_yield::sys_sched_yield,
+        select::sys_select,
+        set_robust_list::sys_set_robust_list,
+        set_tid_address::sys_set_tid_address,
+        setpgid::sys_setpgid,
+        stat::{sys_fstat, sys_fstatat, sys_lstat, sys_stat},
+        statfs::{sys_fstatfs, sys_statfs},
+        symlink::{sys_symlink, sys_symlinkat},
+        sync::sys_sync,
+        tgkill::sys_tgkill,
+        time::sys_time,
+        truncate::{sys_ftruncate, sys_truncate},
+        umask::sys_umask,
+        uname::sys_uname,
+        unlink::{sys_unlink, sys_unlinkat},
+        utimens::sys_utimensat,
+        wait4::sys_wait4,
+        waitid::sys_waitid,
+        write::sys_write,
+        writev::sys_writev,
+    },
+};
 
 mod accept;
 mod access;

--- a/services/aster-nix/src/syscall/mprotect.rs
+++ b/services/aster-nix/src/syscall/mprotect.rs
@@ -2,12 +2,8 @@
 
 use align_ext::AlignExt;
 
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_MPROTECT;
-use crate::vm::perms::VmPerms;
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_MPROTECT, vm::perms::VmPerms};
 
 pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_MPROTECT);

--- a/services/aster-nix/src/syscall/munmap.rs
+++ b/services/aster-nix/src/syscall/munmap.rs
@@ -2,11 +2,8 @@
 
 use align_ext::AlignExt;
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::SYS_MUNMAP;
+use super::{SyscallReturn, SYS_MUNMAP};
+use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_munmap(addr: Vaddr, len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_MUNMAP);

--- a/services/aster-nix/src/syscall/open.rs
+++ b/services/aster-nix/src/syscall/open.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_handle::FileLike,
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
+use super::{SyscallReturn, SYS_OPENAT};
+use crate::{
+    fs::{
+        file_handle::FileLike,
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_OPENAT;
 
 pub fn sys_openat(
     dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/pause.rs
+++ b/services/aster-nix/src/syscall/pause.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::signal::Pauser;
-
 use super::{SyscallReturn, SYS_PAUSE};
+use crate::{log_syscall_entry, prelude::*, process::signal::Pauser};
 
 pub fn sys_pause() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_PAUSE);

--- a/services/aster-nix/src/syscall/pipe.rs
+++ b/services/aster-nix/src/syscall/pipe.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::fs::pipe::{PipeReader, PipeWriter};
-use crate::fs::utils::{Channel, StatusFlags};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::{read_val_from_user, write_val_to_user};
-
-use super::SyscallReturn;
-use super::SYS_PIPE2;
+use super::{SyscallReturn, SYS_PIPE2};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        pipe::{PipeReader, PipeWriter},
+        utils::{Channel, StatusFlags},
+    },
+    log_syscall_entry,
+    prelude::*,
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_pipe2(fds: Vaddr, flags: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_PIPE2);

--- a/services/aster-nix/src/syscall/poll.rs
+++ b/services/aster-nix/src/syscall/poll.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::cell::Cell;
-use core::time::Duration;
+use core::{cell::Cell, time::Duration};
 
-use crate::events::IoEvents;
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::signal::Poller;
-use crate::util::{read_val_from_user, write_val_to_user};
-
-use super::SyscallReturn;
-use super::SYS_POLL;
+use super::{SyscallReturn, SYS_POLL};
+use crate::{
+    events::IoEvents,
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    process::signal::Poller,
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_POLL);

--- a/services/aster-nix/src/syscall/prctl.rs
+++ b/services/aster-nix/src/syscall/prctl.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::posix_thread::PosixThreadExt;
-use crate::process::posix_thread::MAX_THREAD_NAME_LEN;
-use crate::util::read_cstring_from_user;
-use crate::util::write_bytes_to_user;
-
-use super::SyscallReturn;
-use super::SYS_PRCTL;
+use super::{SyscallReturn, SYS_PRCTL};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::posix_thread::{PosixThreadExt, MAX_THREAD_NAME_LEN},
+    util::{read_cstring_from_user, write_bytes_to_user},
+};
 pub fn sys_prctl(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_PRCTL);
     let prctl_cmd = PrctlCmd::from_args(option, arg2, arg3, arg4, arg5)?;

--- a/services/aster-nix/src/syscall/pread64.rs
+++ b/services/aster-nix/src/syscall/pread64.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::fs::utils::SeekFrom;
-use crate::util::write_bytes_to_user;
-use crate::{log_syscall_entry, prelude::*};
-
-use super::SyscallReturn;
-use super::SYS_PREAD64;
+use super::{SyscallReturn, SYS_PREAD64};
+use crate::{
+    fs::{file_table::FileDescripter, utils::SeekFrom},
+    log_syscall_entry,
+    prelude::*,
+    util::write_bytes_to_user,
+};
 
 pub fn sys_pread64(
     fd: FileDescripter,

--- a/services/aster-nix/src/syscall/prlimit64.rs
+++ b/services/aster-nix/src/syscall/prlimit64.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::ResourceType;
-use crate::util::{read_val_from_user, write_val_to_user};
-use crate::{log_syscall_entry, prelude::*, process::Pid};
-
-use super::SyscallReturn;
-use super::SYS_PRLIMIT64;
+use super::{SyscallReturn, SYS_PRLIMIT64};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{Pid, ResourceType},
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_prlimit64(
     pid: Pid,

--- a/services/aster-nix/src/syscall/read.rs
+++ b/services/aster-nix/src/syscall/read.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::util::write_bytes_to_user;
-use crate::{fs::file_table::FileDescripter, prelude::*};
-
-use super::SyscallReturn;
-use super::SYS_READ;
+use super::{SyscallReturn, SYS_READ};
+use crate::{
+    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, util::write_bytes_to_user,
+};
 
 pub fn sys_read(fd: FileDescripter, user_buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_READ);

--- a/services/aster-nix/src/syscall/readlink.rs
+++ b/services/aster-nix/src/syscall/readlink.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
+use super::{SyscallReturn, SYS_READLINKAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::{read_cstring_from_user, write_bytes_to_user},
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::{read_cstring_from_user, write_bytes_to_user};
-
-use super::SyscallReturn;
-use super::SYS_READLINKAT;
 
 pub fn sys_readlinkat(
     dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/recvfrom.rs
+++ b/services/aster-nix/src/syscall/recvfrom.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::net::socket::SendRecvFlags;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, write_socket_addr_to_user};
-use crate::util::write_bytes_to_user;
-
 use super::{SyscallReturn, SYS_RECVFROM};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    net::socket::SendRecvFlags,
+    prelude::*,
+    util::{
+        net::{get_socket_from_fd, write_socket_addr_to_user},
+        write_bytes_to_user,
+    },
+};
 
 pub fn sys_recvfrom(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/rename.rs
+++ b/services/aster-nix/src/syscall/rename.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::InodeType,
+use super::{SyscallReturn, SYS_RENAMEAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::InodeType,
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_RENAMEAT;
 
 pub fn sys_renameat(
     old_dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/rmdir.rs
+++ b/services/aster-nix/src/syscall/rmdir.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
+use super::{SyscallReturn, SYS_RMDIR};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_RMDIR;
 
 pub fn sys_rmdir(pathname_addr: Vaddr) -> Result<SyscallReturn> {
     self::sys_rmdirat(AT_FDCWD, pathname_addr)

--- a/services/aster-nix/src/syscall/rt_sigaction.rs
+++ b/services/aster-nix/src/syscall/rt_sigaction.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use super::SyscallReturn;
 use crate::{
     log_syscall_entry,
     prelude::*,
@@ -7,8 +8,6 @@ use crate::{
     syscall::SYS_RT_SIGACTION,
     util::{read_val_from_user, write_val_to_user},
 };
-
-use super::SyscallReturn;
 
 pub fn sys_rt_sigaction(
     sig_num: u8,

--- a/services/aster-nix/src/syscall/rt_sigprocmask.rs
+++ b/services/aster-nix/src/syscall/rt_sigprocmask.rs
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_RT_SIGPROCMASK};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::posix_thread::PosixThreadExt;
-use crate::process::signal::constants::{SIGKILL, SIGSTOP};
-use crate::process::signal::sig_mask::SigMask;
 use aster_frame::vm::VmIo;
+
+use super::{SyscallReturn, SYS_RT_SIGPROCMASK};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{
+        posix_thread::PosixThreadExt,
+        signal::{
+            constants::{SIGKILL, SIGSTOP},
+            sig_mask::SigMask,
+        },
+    },
+};
 
 pub fn sys_rt_sigprocmask(
     how: u32,

--- a/services/aster-nix/src/syscall/rt_sigreturn.rs
+++ b/services/aster-nix/src/syscall/rt_sigreturn.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_frame::cpu::UserContext;
+
+use super::{SyscallReturn, SYS_RT_SIGRETRUN};
 use crate::{
     log_syscall_entry,
     prelude::*,
     process::{posix_thread::PosixThreadExt, signal::c_types::ucontext_t},
     util::read_val_from_user,
 };
-use aster_frame::cpu::UserContext;
-
-use super::{SyscallReturn, SYS_RT_SIGRETRUN};
 
 pub fn sys_rt_sigreturn(context: &mut UserContext) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_RT_SIGRETRUN);

--- a/services/aster-nix/src/syscall/sched_yield.rs
+++ b/services/aster-nix/src/syscall/sched_yield.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::thread::Thread;
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_SCHED_YIELD;
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_SCHED_YIELD, thread::Thread};
 
 pub fn sys_sched_yield() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SCHED_YIELD);

--- a/services/aster-nix/src/syscall/select.rs
+++ b/services/aster-nix/src/syscall/select.rs
@@ -2,16 +2,18 @@
 
 use core::time::Duration;
 
-use crate::events::IoEvents;
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::time::timeval_t;
-use crate::util::{read_val_from_user, write_val_to_user};
-
-use super::poll::{do_poll, PollFd};
-use super::SyscallReturn;
-use super::SYS_SELECT;
+use super::{
+    poll::{do_poll, PollFd},
+    SyscallReturn, SYS_SELECT,
+};
+use crate::{
+    events::IoEvents,
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    time::timeval_t,
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_select(
     nfds: FileDescripter,

--- a/services/aster-nix/src/syscall/sendto.rs
+++ b/services/aster-nix/src/syscall/sendto.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::net::socket::SendRecvFlags;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, read_socket_addr_from_user};
-use crate::util::read_bytes_from_user;
-
 use super::{SyscallReturn, SYS_SENDTO};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    net::socket::SendRecvFlags,
+    prelude::*,
+    util::{
+        net::{get_socket_from_fd, read_socket_addr_from_user},
+        read_bytes_from_user,
+    },
+};
 
 pub fn sys_sendto(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/set_tid_address.rs
+++ b/services/aster-nix/src/syscall/set_tid_address.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
-use super::SYS_SET_TID_ADDRESS;
-use crate::process::posix_thread::PosixThreadExt;
-use crate::{log_syscall_entry, prelude::*};
+use super::{SyscallReturn, SYS_SET_TID_ADDRESS};
+use crate::{log_syscall_entry, prelude::*, process::posix_thread::PosixThreadExt};
 
 pub fn sys_set_tid_address(tidptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SET_TID_ADDRESS);

--- a/services/aster-nix/src/syscall/setfsgid.rs
+++ b/services/aster-nix/src/syscall/setfsgid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Gid};
-
 use super::{SyscallReturn, SYS_SETFSGID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Gid},
+};
 
 pub fn sys_setfsgid(gid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETFSGID);

--- a/services/aster-nix/src/syscall/setfsuid.rs
+++ b/services/aster-nix/src/syscall/setfsuid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Uid};
-
 use super::{SyscallReturn, SYS_SETFSUID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Uid},
+};
 
 pub fn sys_setfsuid(uid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETFSUID);

--- a/services/aster-nix/src/syscall/setgid.rs
+++ b/services/aster-nix/src/syscall/setgid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Gid};
-
 use super::{SyscallReturn, SYS_SETGID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Gid},
+};
 
 pub fn sys_setgid(gid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETGID);

--- a/services/aster-nix/src/syscall/setgroups.rs
+++ b/services/aster-nix/src/syscall/setgroups.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_SETGROUPS};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Gid};
-use crate::util::read_val_from_user;
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Gid},
+    util::read_val_from_user,
+};
 
 pub fn sys_setgroups(size: usize, group_list_addr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETGROUPS);

--- a/services/aster-nix/src/syscall/setpgid.rs
+++ b/services/aster-nix/src/syscall/setpgid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{process_table, Pgid, Pid};
-
 use super::{SyscallReturn, SYS_SETPGID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{process_table, Pgid, Pid},
+};
 
 pub fn sys_setpgid(pid: Pid, pgid: Pgid) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETPGID);

--- a/services/aster-nix/src/syscall/setregid.rs
+++ b/services/aster-nix/src/syscall/setregid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Gid};
-
 use super::{SyscallReturn, SYS_SETREGID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Gid},
+};
 
 pub fn sys_setregid(rgid: i32, egid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETREGID);

--- a/services/aster-nix/src/syscall/setresgid.rs
+++ b/services/aster-nix/src/syscall/setresgid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Gid};
-
 use super::{SyscallReturn, SYS_SETRESGID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Gid},
+};
 
 pub fn sys_setresgid(rgid: i32, egid: i32, sgid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETRESGID);

--- a/services/aster-nix/src/syscall/setresuid.rs
+++ b/services/aster-nix/src/syscall/setresuid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Uid};
-
 use super::{SyscallReturn, SYS_SETRESUID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Uid},
+};
 
 pub fn sys_setresuid(ruid: i32, euid: i32, suid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETRESUID);

--- a/services/aster-nix/src/syscall/setreuid.rs
+++ b/services/aster-nix/src/syscall/setreuid.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Uid};
-
 use super::{SyscallReturn, SYS_SETREUID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Uid},
+};
 
 pub fn sys_setreuid(ruid: i32, euid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETREUID);

--- a/services/aster-nix/src/syscall/setsid.rs
+++ b/services/aster-nix/src/syscall/setsid.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
 use super::{SyscallReturn, SYS_SETSID};
+use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_setsid() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETSID);

--- a/services/aster-nix/src/syscall/setsockopt.rs
+++ b/services/aster-nix/src/syscall/setsockopt.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel};
-
 use super::{SyscallReturn, SYS_SETSOCKOPT};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
+};
 
 pub fn sys_setsockopt(
     sockfd: FileDescripter,

--- a/services/aster-nix/src/syscall/setuid.rs
+++ b/services/aster-nix/src/syscall/setuid.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_SETUID};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::{credentials_mut, Uid};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{credentials_mut, Uid},
+};
 
 pub fn sys_setuid(uid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SETUID);

--- a/services/aster-nix/src/syscall/shutdown.rs
+++ b/services/aster-nix/src/syscall/shutdown.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::log_syscall_entry;
-use crate::net::socket::SockShutdownCmd;
-use crate::prelude::*;
-use crate::util::net::get_socket_from_fd;
-
 use super::{SyscallReturn, SYS_SHUTDOWN};
+use crate::{
+    fs::file_table::FileDescripter, log_syscall_entry, net::socket::SockShutdownCmd, prelude::*,
+    util::net::get_socket_from_fd,
+};
 
 pub fn sys_shutdown(sockfd: FileDescripter, how: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SHUTDOWN);

--- a/services/aster-nix/src/syscall/sigaltstack.rs
+++ b/services/aster-nix/src/syscall/sigaltstack.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::posix_thread::PosixThreadExt;
-use crate::process::signal::SigStack;
-use crate::process::signal::SigStackFlags;
-use crate::util::read_val_from_user;
-use crate::util::write_val_to_user;
-
 use super::{SyscallReturn, SYS_SIGALTSTACK};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{
+        posix_thread::PosixThreadExt,
+        signal::{SigStack, SigStackFlags},
+    },
+    util::{read_val_from_user, write_val_to_user},
+};
 
 pub fn sys_sigaltstack(sig_stack_addr: Vaddr, old_sig_stack_addr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SIGALTSTACK);

--- a/services/aster-nix/src/syscall/socket.rs
+++ b/services/aster-nix/src/syscall/socket.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_handle::FileLike;
-use crate::net::socket::ip::{DatagramSocket, StreamSocket};
-use crate::net::socket::unix::UnixStreamSocket;
-use crate::util::net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
-use crate::{log_syscall_entry, prelude::*};
-
-use super::SyscallReturn;
-use super::SYS_SOCKET;
+use super::{SyscallReturn, SYS_SOCKET};
+use crate::{
+    fs::file_handle::FileLike,
+    log_syscall_entry,
+    net::socket::{
+        ip::{DatagramSocket, StreamSocket},
+        unix::UnixStreamSocket,
+    },
+    prelude::*,
+    util::net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK},
+};
 
 pub fn sys_socket(domain: i32, type_: i32, protocol: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SOCKET);

--- a/services/aster-nix/src/syscall/socketpair.rs
+++ b/services/aster-nix/src/syscall/socketpair.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::net::socket::unix::UnixStreamSocket;
-use crate::util::net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
-use crate::util::write_val_to_user;
-use crate::{log_syscall_entry, prelude::*};
-
-use super::SyscallReturn;
-use super::SYS_SOCKETPAIR;
+use super::{SyscallReturn, SYS_SOCKETPAIR};
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    net::socket::unix::UnixStreamSocket,
+    prelude::*,
+    util::{
+        net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK},
+        write_val_to_user,
+    },
+};
 
 pub fn sys_socketpair(domain: i32, type_: i32, protocol: i32, sv: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SOCKETPAIR);

--- a/services/aster-nix/src/syscall/stat.rs
+++ b/services/aster-nix/src/syscall/stat.rs
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::Metadata,
+use super::{SyscallReturn, SYS_FSTAT, SYS_FSTATAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::Metadata,
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    time::timespec_t,
+    util::{read_cstring_from_user, write_val_to_user},
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::time::timespec_t;
-use crate::util::{read_cstring_from_user, write_val_to_user};
-
-use super::SyscallReturn;
-use super::{SYS_FSTAT, SYS_FSTATAT};
 
 pub fn sys_fstat(fd: FileDescripter, stat_buf_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FSTAT);

--- a/services/aster-nix/src/syscall/statfs.rs
+++ b/services/aster-nix/src/syscall/statfs.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::FsPath,
-    inode_handle::InodeHandle,
-    utils::{SuperBlock, PATH_MAX},
+use super::{SyscallReturn, SYS_FSTATFS, SYS_STATFS};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::FsPath,
+        inode_handle::InodeHandle,
+        utils::{SuperBlock, PATH_MAX},
+    },
+    log_syscall_entry,
+    prelude::*,
+    util::{read_cstring_from_user, write_val_to_user},
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::util::{read_cstring_from_user, write_val_to_user};
-
-use super::SyscallReturn;
-use super::{SYS_FSTATFS, SYS_STATFS};
 
 pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_STATFS);

--- a/services/aster-nix/src/syscall/symlink.rs
+++ b/services/aster-nix/src/syscall/symlink.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::{InodeMode, InodeType},
+use super::{SyscallReturn, SYS_SYMLINKAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::{InodeMode, InodeType},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_SYMLINKAT;
 
 pub fn sys_symlinkat(
     target_addr: Vaddr,

--- a/services/aster-nix/src/syscall/sync.rs
+++ b/services/aster-nix/src/syscall/sync.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-
-use super::SyscallReturn;
-use super::SYS_SYNC;
+use super::{SyscallReturn, SYS_SYNC};
+use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_sync() -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SYNC);

--- a/services/aster-nix/src/syscall/tgkill.rs
+++ b/services/aster-nix/src/syscall/tgkill.rs
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::signal::sig_num::SigNum;
-use crate::process::signal::signals::user::{UserSignal, UserSignalKind};
-use crate::process::tgkill;
-use crate::process::{credentials, Pid};
-use crate::syscall::SYS_TGKILL;
-use crate::thread::Tid;
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{
+        credentials,
+        signal::{
+            sig_num::SigNum,
+            signals::user::{UserSignal, UserSignalKind},
+        },
+        tgkill, Pid,
+    },
+    syscall::SYS_TGKILL,
+    thread::Tid,
+};
 
 /// tgkill send a signal to a thread with pid as its thread id, and tgid as its thread group id.
 pub fn sys_tgkill(tgid: Pid, tid: Tid, sig_num: u8) -> Result<SyscallReturn> {

--- a/services/aster-nix/src/syscall/time.rs
+++ b/services/aster-nix/src/syscall/time.rs
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::time::SystemTime;
-use crate::util::write_val_to_user;
-
-use super::SyscallReturn;
-use super::SYS_TIME;
+use super::{SyscallReturn, SYS_TIME};
+use crate::{log_syscall_entry, prelude::*, time::SystemTime, util::write_val_to_user};
 
 pub fn sys_time(tloc: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_TIME);

--- a/services/aster-nix/src/syscall/truncate.rs
+++ b/services/aster-nix/src/syscall/truncate.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
-    utils::PATH_MAX,
+use super::{SyscallReturn, SYS_FTRUNCATE, SYS_TRUNCATE};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::PATH_MAX,
+    },
+    log_syscall_entry,
+    prelude::*,
+    process::ResourceType,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::process::ResourceType;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::{SYS_FTRUNCATE, SYS_TRUNCATE};
 
 pub fn sys_ftruncate(fd: FileDescripter, len: isize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FTRUNCATE);

--- a/services/aster-nix/src/syscall/umask.rs
+++ b/services/aster-nix/src/syscall/umask.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
-use super::SYS_UMASK;
+use super::{SyscallReturn, SYS_UMASK};
 use crate::{log_syscall_entry, prelude::*};
 
 pub fn sys_umask(mask: u16) -> Result<SyscallReturn> {

--- a/services/aster-nix/src/syscall/uname.rs
+++ b/services/aster-nix/src/syscall/uname.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_UNAME;
-use crate::util::write_val_to_user;
-
 use super::SyscallReturn;
+use crate::{log_syscall_entry, prelude::*, syscall::SYS_UNAME, util::write_val_to_user};
 
 // We don't use the real name and version of our os here. Instead, we pick up fake values witch is the same as the ones of linux.
 // The values are used to fool glibc since glibc will check the version and os name.

--- a/services/aster-nix/src/syscall/unlink.rs
+++ b/services/aster-nix/src/syscall/unlink.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{
-    file_table::FileDescripter,
-    fs_resolver::{FsPath, AT_FDCWD},
+use super::{SyscallReturn, SYS_UNLINKAT};
+use crate::{
+    fs::{
+        file_table::FileDescripter,
+        fs_resolver::{FsPath, AT_FDCWD},
+    },
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
 };
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::util::read_cstring_from_user;
-
-use super::SyscallReturn;
-use super::SYS_UNLINKAT;
 
 pub fn sys_unlinkat(
     dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/utimens.rs
+++ b/services/aster-nix/src/syscall/utimens.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::{file_table::FileDescripter, fs_resolver::FsPath};
-use crate::log_syscall_entry;
-use crate::prelude::*;
-use crate::syscall::constants::MAX_FILENAME_LEN;
-use crate::time::timespec_t;
-use crate::util::{read_cstring_from_user, read_val_from_user};
 use core::time::Duration;
 
-use super::SyscallReturn;
-use super::SYS_UTIMENSAT;
+use super::{SyscallReturn, SYS_UTIMENSAT};
+use crate::{
+    fs::{file_table::FileDescripter, fs_resolver::FsPath},
+    log_syscall_entry,
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    time::timespec_t,
+    util::{read_cstring_from_user, read_val_from_user},
+};
 
 pub fn sys_utimensat(
     dirfd: FileDescripter,

--- a/services/aster-nix/src/syscall/wait4.rs
+++ b/services/aster-nix/src/syscall/wait4.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use super::SyscallReturn;
 use crate::{
     log_syscall_entry,
-    process::{wait_child_exit, ProcessFilter},
+    prelude::*,
+    process::{wait_child_exit, ProcessFilter, WaitOptions},
     syscall::SYS_WAIT4,
     util::write_val_to_user,
 };
-
-use crate::prelude::*;
-use crate::process::WaitOptions;
-
-use super::SyscallReturn;
 
 pub fn sys_wait4(wait_pid: u64, exit_status_ptr: u64, wait_options: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_WAIT4);

--- a/services/aster-nix/src/syscall/waitid.rs
+++ b/services/aster-nix/src/syscall/waitid.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::process::{wait_child_exit, ProcessFilter};
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::process::WaitOptions;
-
-use super::SyscallReturn;
-use super::SYS_WAITID;
+use super::{SyscallReturn, SYS_WAITID};
+use crate::{
+    log_syscall_entry,
+    prelude::*,
+    process::{wait_child_exit, ProcessFilter, WaitOptions},
+};
 
 pub fn sys_waitid(
     which: u64,

--- a/services/aster-nix/src/syscall/write.rs
+++ b/services/aster-nix/src/syscall/write.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_WRITE;
-use crate::util::read_bytes_from_user;
-
 use super::SyscallReturn;
+use crate::{
+    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, syscall::SYS_WRITE,
+    util::read_bytes_from_user,
+};
 
 const STDOUT: u64 = 1;
 const STDERR: u64 = 2;

--- a/services/aster-nix/src/syscall/writev.rs
+++ b/services/aster-nix/src/syscall/writev.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::fs::file_table::FileDescripter;
-use crate::{log_syscall_entry, prelude::*};
-
-use crate::syscall::SYS_WRITEV;
-use crate::util::{read_bytes_from_user, read_val_from_user};
-
 use super::SyscallReturn;
+use crate::{
+    fs::file_table::FileDescripter,
+    log_syscall_entry,
+    prelude::*,
+    syscall::SYS_WRITEV,
+    util::{read_bytes_from_user, read_val_from_user},
+};
 
 const IOVEC_MAX: usize = 256;
 

--- a/services/aster-nix/src/thread/exception.rs
+++ b/services/aster-nix/src/thread/exception.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use crate::process::signal::signals::fault::FaultSignal;
-use crate::vm::page_fault_handler::PageFaultHandler;
-use aster_frame::cpu::*;
-use aster_frame::vm::VmIo;
+use aster_frame::{cpu::*, vm::VmIo};
+
+use crate::{
+    prelude::*, process::signal::signals::fault::FaultSignal,
+    vm::page_fault_handler::PageFaultHandler,
+};
 
 /// We can't handle most exceptions, just send self a fault signal before return to user space.
 pub fn handle_exception(context: &UserContext) {

--- a/services/aster-nix/src/thread/kernel_thread.rs
+++ b/services/aster-nix/src/thread/kernel_thread.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::cpu::CpuSet;
-use aster_frame::task::{Priority, TaskOptions};
-
-use crate::prelude::*;
+use aster_frame::{
+    cpu::CpuSet,
+    task::{Priority, TaskOptions},
+};
 
 use super::{allocate_tid, status::ThreadStatus, thread_table, Thread};
+use crate::prelude::*;
 
 /// The inner data of a kernel thread
 pub struct KernelThread;

--- a/services/aster-nix/src/thread/mod.rs
+++ b/services/aster-nix/src/thread/mod.rs
@@ -9,9 +9,8 @@ use core::{
 
 use aster_frame::task::Task;
 
-use crate::prelude::*;
-
 use self::status::ThreadStatus;
+use crate::prelude::*;
 
 pub mod exception;
 pub mod kernel_thread;

--- a/services/aster-nix/src/thread/task.rs
+++ b/services/aster-nix/src/thread/task.rs
@@ -6,12 +6,11 @@ use aster_frame::{
     user::{UserContextApi, UserEvent, UserMode, UserSpace},
 };
 
+use super::Thread;
 use crate::{
     prelude::*, process::signal::handle_pending_signal, syscall::handle_syscall,
     thread::exception::handle_exception,
 };
-
-use super::Thread;
 
 /// create new task with userspace and parent process
 pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Weak<Thread>) -> Arc<Task> {

--- a/services/aster-nix/src/thread/thread_table.rs
+++ b/services/aster-nix/src/thread/thread_table.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
 use super::{Thread, Tid};
+use crate::prelude::*;
 
 lazy_static! {
     static ref THREAD_TABLE: Mutex<BTreeMap<Tid, Arc<Thread>>> = Mutex::new(BTreeMap::new());

--- a/services/aster-nix/src/thread/work_queue/mod.rs
+++ b/services/aster-nix/src/thread/work_queue/mod.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_frame::cpu::CpuSet;
 use spin::Once;
 use work_item::WorkItem;
 use worker_pool::WorkerPool;
+
+use crate::prelude::*;
 
 mod simple_scheduler;
 pub mod work_item;

--- a/services/aster-nix/src/thread/work_queue/work_item.rs
+++ b/services/aster-nix/src/thread/work_queue/work_item.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use aster_frame::cpu::CpuSet;
-use core::sync::atomic::AtomicBool;
-use core::sync::atomic::Ordering;
+
+use crate::prelude::*;
 
 /// A task to be executed by a worker thread.
 pub struct WorkItem {

--- a/services/aster-nix/src/thread/work_queue/worker.rs
+++ b/services/aster-nix/src/thread/work_queue/worker.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_frame::{cpu::CpuSet, task::Priority};
+
 use super::worker_pool::WorkerPool;
-use crate::prelude::*;
-use crate::thread::kernel_thread::{KernelThreadExt, ThreadOptions};
-use crate::Thread;
-use aster_frame::cpu::CpuSet;
-use aster_frame::task::Priority;
+use crate::{
+    prelude::*,
+    thread::kernel_thread::{KernelThreadExt, ThreadOptions},
+    Thread,
+};
 
 /// A worker thread. A `Worker` will attempt to retrieve unfinished
 /// work items from its corresponding `WorkerPool`. If there are none,

--- a/services/aster-nix/src/thread/work_queue/worker_pool.rs
+++ b/services/aster-nix/src/thread/work_queue/worker_pool.rs
@@ -2,13 +2,14 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use aster_frame::{cpu::CpuSet, sync::WaitQueue, task::Priority};
+
 use super::{simple_scheduler::SimpleScheduler, worker::Worker, WorkItem, WorkPriority, WorkQueue};
-use crate::prelude::*;
-use crate::thread::kernel_thread::{KernelThreadExt, ThreadOptions};
-use crate::Thread;
-use aster_frame::cpu::CpuSet;
-use aster_frame::sync::WaitQueue;
-use aster_frame::task::Priority;
+use crate::{
+    prelude::*,
+    thread::kernel_thread::{KernelThreadExt, ThreadOptions},
+    Thread,
+};
 
 /// A pool of workers.
 ///

--- a/services/aster-nix/src/time/mod.rs
+++ b/services/aster-nix/src/time/mod.rs
@@ -3,9 +3,9 @@
 #![allow(non_camel_case_types)]
 use core::time::Duration;
 
-use crate::prelude::*;
-
 use aster_time::read_monotonic_time;
+
+use crate::prelude::*;
 
 mod system_time;
 

--- a/services/aster-nix/src/time/system_time.rs
+++ b/services/aster-nix/src/time/system_time.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_time::{read_monotonic_time, read_start_time};
 use core::time::Duration;
+
+use aster_time::{read_monotonic_time, read_start_time};
 use time::{Date, Month, PrimitiveDateTime, Time};
 
 use crate::prelude::*;

--- a/services/aster-nix/src/util/mod.rs
+++ b/services/aster-nix/src/util/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_frame::vm::VmIo;
+
+use crate::prelude::*;
 pub mod net;
 
 /// copy bytes from user space of current process. The bytes len is the len of dest.

--- a/services/aster-nix/src/util/net/addr.rs
+++ b/services/aster-nix/src/util/net/addr.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::net::iface::Ipv4Address;
-use crate::net::socket::unix::UnixSocketAddr;
-use crate::net::socket::SocketAddr;
-use crate::prelude::*;
-use crate::util::{read_bytes_from_user, read_val_from_user, write_val_to_user};
+use crate::{
+    net::{
+        iface::Ipv4Address,
+        socket::{unix::UnixSocketAddr, SocketAddr},
+    },
+    prelude::*,
+    util::{read_bytes_from_user, read_val_from_user, write_val_to_user},
+};
 
 pub fn read_socket_addr_from_user(addr: Vaddr, addr_len: usize) -> Result<SocketAddr> {
     debug_assert!(addr_len >= core::mem::size_of::<CSocketAddr>());

--- a/services/aster-nix/src/util/net/mod.rs
+++ b/services/aster-nix/src/util/net/mod.rs
@@ -8,9 +8,7 @@ pub use addr::{read_socket_addr_from_user, write_socket_addr_to_user, CSocketAdd
 pub use options::{new_raw_socket_option, CSocketOptionLevel};
 pub use socket::{Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
 
-use crate::fs::file_table::FileDescripter;
-use crate::net::socket::Socket;
-use crate::prelude::*;
+use crate::{fs::file_table::FileDescripter, net::socket::Socket, prelude::*};
 
 pub fn get_socket_from_fd(sockfd: FileDescripter) -> Result<Arc<dyn Socket>> {
     let current = current!();

--- a/services/aster-nix/src/util/net/options/mod.rs
+++ b/services/aster-nix/src/util/net/options/mod.rs
@@ -47,17 +47,15 @@
 //! At the syscall level, the interface is unified for all options and does not need to be modified.
 //!
 
-use crate::net::socket::options::SocketOption;
-use crate::prelude::*;
-use crate::vm::vmar::Vmar;
 use aster_rights::Full;
+
+use crate::{net::socket::options::SocketOption, prelude::*, vm::vmar::Vmar};
 
 mod socket;
 mod tcp;
 mod utils;
 
-use self::socket::new_socket_option;
-use self::tcp::new_tcp_option;
+use self::{socket::new_socket_option, tcp::new_tcp_option};
 
 pub trait RawSocketOption: SocketOption {
     fn read_from_user(&mut self, vmar: &Vmar<Full>, addr: Vaddr, max_len: u32) -> Result<()>;

--- a/services/aster-nix/src/util/net/options/socket.rs
+++ b/services/aster-nix/src/util/net/options/socket.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::RawSocketOption;
-use crate::net::socket::options::{
-    Error, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
-};
-use crate::prelude::*;
-use crate::vm::vmar::Vmar;
-use crate::{impl_raw_sock_option_get_only, impl_raw_socket_option};
 use aster_rights::Full;
+
+use super::RawSocketOption;
+use crate::{
+    impl_raw_sock_option_get_only, impl_raw_socket_option,
+    net::socket::options::{Error, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption},
+    prelude::*,
+    vm::vmar::Vmar,
+};
 
 /// Socket level options.
 ///

--- a/services/aster-nix/src/util/net/options/tcp.rs
+++ b/services/aster-nix/src/util/net/options/tcp.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::RawSocketOption;
-use crate::impl_raw_socket_option;
-use crate::net::socket::ip::stream::options::{Congestion, MaxSegment, NoDelay, WindowClamp};
-use crate::prelude::*;
-use crate::util::net::options::SocketOption;
-use crate::vm::vmar::Vmar;
 use aster_rights::Full;
+
+use super::RawSocketOption;
+use crate::{
+    impl_raw_socket_option,
+    net::socket::ip::stream::options::{Congestion, MaxSegment, NoDelay, WindowClamp},
+    prelude::*,
+    util::net::options::SocketOption,
+    vm::vmar::Vmar,
+};
 
 /// Sock options for tcp socket.
 ///

--- a/services/aster-nix/src/util/net/options/utils.rs
+++ b/services/aster-nix/src/util/net/options/utils.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::net::socket::ip::stream::CongestionControl;
-use crate::net::socket::LingerOption;
-use crate::prelude::*;
-use crate::vm::vmar::Vmar;
+use core::time::Duration;
+
 use aster_frame::vm::VmIo;
 use aster_rights::Full;
-use core::time::Duration;
+
+use crate::{
+    net::socket::{ip::stream::CongestionControl, LingerOption},
+    prelude::*,
+    vm::vmar::Vmar,
+};
 
 /// Create an object by reading its C counterpart from the user space.
 ///

--- a/services/aster-nix/src/vdso.rs
+++ b/services/aster-nix/src/vdso.rs
@@ -11,8 +11,8 @@
 //! The module is initialized with `init`, which sets up the `START_SECS_COUNT` and prepares the VDSO instance for
 //! use. It also hooks up the VDSO data update routine to the time management subsystem for periodic updates.
 
-use alloc::boxed::Box;
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
+
 use aster_frame::{config::PAGE_SIZE, sync::Mutex, vm::VmIo};
 use aster_rights::Rights;
 use aster_time::Instant;

--- a/services/aster-nix/src/vm/vmar/dyn_cap.rs
+++ b/services/aster-nix/src/vm/vmar/dyn_cap.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::vm::{Vaddr, VmIo};
-use aster_rights::Rights;
 use core::ops::Range;
 
-use crate::prelude::*;
-
-use crate::vm::{page_fault_handler::PageFaultHandler, vmo::Vmo};
+use aster_frame::vm::{Vaddr, VmIo};
+use aster_rights::Rights;
 
 use super::{
     options::VmarChildOptions, vm_mapping::VmarMapOptions, VmPerms, Vmar, VmarRightsOp, Vmar_,
+};
+use crate::{
+    prelude::*,
+    vm::{page_fault_handler::PageFaultHandler, vmo::Vmo},
 };
 
 impl Vmar<Rights> {

--- a/services/aster-nix/src/vm/vmar/mod.rs
+++ b/services/aster-nix/src/vm/vmar/mod.rs
@@ -8,21 +8,23 @@ mod options;
 mod static_cap;
 pub mod vm_mapping;
 
-use crate::prelude::*;
-use crate::vm::perms::VmPerms;
-use align_ext::AlignExt;
-use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
-use alloc::sync::Weak;
-use alloc::vec::Vec;
-use aster_frame::vm::VmSpace;
-use aster_rights::Rights;
+use alloc::{
+    collections::BTreeMap,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 use core::ops::Range;
 
-use self::interval::{Interval, IntervalSet};
-use self::vm_mapping::VmMapping;
+use align_ext::AlignExt;
+use aster_frame::vm::VmSpace;
+use aster_rights::Rights;
 
+use self::{
+    interval::{Interval, IntervalSet},
+    vm_mapping::VmMapping,
+};
 use super::page_fault_handler::PageFaultHandler;
+use crate::{prelude::*, vm::perms::VmPerms};
 
 /// Virtual Memory Address Regions (VMARs) are a type of capability that manages
 /// user address spaces.

--- a/services/aster-nix/src/vm/vmar/options.rs
+++ b/services/aster-nix/src/vm/vmar/options.rs
@@ -2,8 +2,7 @@
 
 //! Options for allocating child VMARs.
 
-use aster_frame::config::PAGE_SIZE;
-use aster_frame::{Error, Result};
+use aster_frame::{config::PAGE_SIZE, Error, Result};
 
 use super::Vmar;
 
@@ -136,13 +135,16 @@ impl<R> VmarChildOptions<R> {
 
 #[if_cfg_ktest]
 mod test {
-    use super::*;
-    use crate::vm::page_fault_handler::PageFaultHandler;
-    use crate::vm::perms::VmPerms;
-    use crate::vm::vmo::VmoRightsOp;
-    use crate::vm::{vmar::ROOT_VMAR_HIGHEST_ADDR, vmo::VmoOptions};
     use aster_frame::vm::VmIo;
     use aster_rights::Full;
+
+    use super::*;
+    use crate::vm::{
+        page_fault_handler::PageFaultHandler,
+        perms::VmPerms,
+        vmar::ROOT_VMAR_HIGHEST_ADDR,
+        vmo::{VmoOptions, VmoRightsOp},
+    };
 
     #[ktest]
     fn root_vmar() {

--- a/services/aster-nix/src/vm/vmar/static_cap.rs
+++ b/services/aster-nix/src/vm/vmar/static_cap.rs
@@ -2,15 +2,16 @@
 
 use core::ops::Range;
 
-use crate::prelude::*;
 use aster_frame::vm::VmIo;
 use aster_rights::{Dup, Rights, TRightSet, TRights};
 use aster_rights_proc::require;
 
-use crate::vm::{page_fault_handler::PageFaultHandler, vmo::Vmo};
-
 use super::{
     options::VmarChildOptions, vm_mapping::VmarMapOptions, VmPerms, Vmar, VmarRightsOp, Vmar_,
+};
+use crate::{
+    prelude::*,
+    vm::{page_fault_handler::PageFaultHandler, vmo::Vmo},
 };
 
 impl<R: TRights> Vmar<TRightSet<R>> {

--- a/services/aster-nix/src/vm/vmar/vm_mapping.rs
+++ b/services/aster-nix/src/vm/vmar/vm_mapping.rs
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use aster_frame::sync::Mutex;
-use aster_frame::vm::{VmFrame, VmFrameVec, VmIo, VmMapOptions, VmPerm, VmSpace};
 use core::ops::Range;
 
-use crate::vm::{
-    vmo::get_page_idx_range,
-    vmo::{Vmo, VmoChildOptions},
+use aster_frame::{
+    sync::Mutex,
+    vm::{VmFrame, VmFrameVec, VmIo, VmMapOptions, VmPerm, VmSpace},
 };
 
-use super::{is_intersected, Vmar, Vmar_};
-use crate::vm::perms::VmPerms;
-use crate::vm::vmar::Rights;
-use crate::vm::vmo::VmoRightsOp;
-
-use super::interval::Interval;
+use super::{interval::Interval, is_intersected, Vmar, Vmar_};
+use crate::{
+    prelude::*,
+    vm::{
+        perms::VmPerms,
+        vmar::Rights,
+        vmo::{get_page_idx_range, Vmo, VmoChildOptions, VmoRightsOp},
+    },
+};
 
 /// A VmMapping represents mapping a vmo into a vmar.
 /// A vmar can has multiple VmMappings, which means multiple vmos are mapped to a vmar.

--- a/services/aster-nix/src/vm/vmo/dyn_cap.rs
+++ b/services/aster-nix/src/vm/vmo/dyn_cap.rs
@@ -2,17 +2,14 @@
 
 use core::ops::Range;
 
-use crate::prelude::*;
-
 use aster_frame::vm::VmIo;
-
 use aster_rights::{Rights, TRights};
 
-use super::VmoRightsOp;
 use super::{
     options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions,
+    Vmo, VmoChildOptions, VmoRightsOp,
 };
+use crate::prelude::*;
 
 impl Vmo<Rights> {
     /// Creates a new slice VMO through a set of VMO child options.

--- a/services/aster-nix/src/vm/vmo/options.rs
+++ b/services/aster-nix/src/vm/vmo/options.rs
@@ -2,22 +2,19 @@
 
 //! Options for allocating root and child VMOs.
 
-use core::marker::PhantomData;
-use core::ops::Range;
+use core::{marker::PhantomData, ops::Range};
 
 use align_ext::AlignExt;
 use aster_frame::vm::{VmAllocOptions, VmFrame};
+use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 use typeflags_util::{SetExtend, SetExtendOp};
 
-use crate::prelude::*;
-
-use crate::vm::vmo::get_inherited_frames_from_parent;
-use crate::vm::vmo::{VmoInner, Vmo_};
-use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
-
-use super::VmoRightsOp;
-use super::{Pager, Vmo, VmoFlags};
+use super::{Pager, Vmo, VmoFlags, VmoRightsOp};
+use crate::{
+    prelude::*,
+    vm::vmo::{get_inherited_frames_from_parent, VmoInner, Vmo_},
+};
 
 /// Options for allocating a root VMO.
 ///
@@ -520,9 +517,10 @@ impl VmoChildType for VmoCowChild {}
 
 #[if_cfg_ktest]
 mod test {
-    use super::*;
     use aster_frame::vm::VmIo;
     use aster_rights::Full;
+
+    use super::*;
 
     #[ktest]
     fn alloc_vmo() {

--- a/services/aster-nix/src/vm/vmo/pager.rs
+++ b/services/aster-nix/src/vm/vmo/pager.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
 use aster_frame::vm::VmFrame;
+
+use crate::prelude::*;
 
 /// Pagers provide frame to a VMO.
 ///

--- a/services/aster-nix/src/vm/vmo/static_cap.rs
+++ b/services/aster-nix/src/vm/vmo/static_cap.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-use aster_frame::vm::VmIo;
-use aster_rights_proc::require;
 use core::ops::Range;
 
+use aster_frame::vm::VmIo;
 use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
+use aster_rights_proc::require;
 
-use super::VmoRightsOp;
 use super::{
     options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions,
+    Vmo, VmoChildOptions, VmoRightsOp,
 };
+use crate::prelude::*;
 
 impl<R: TRights> Vmo<TRightSet<R>> {
     /// Creates a new slice VMO through a set of VMO child options.

--- a/services/comps/block/src/bio.rs
+++ b/services/comps/block/src/bio.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
-
-use super::{id::Sid, BlockDevice};
-
 use aster_frame::{
     sync::WaitQueue,
     vm::{VmFrame, VmReader, VmSegment, VmWriter},
 };
 use int_to_c_enum::TryFromInt;
+
+use super::{id::Sid, BlockDevice};
+use crate::prelude::*;
 
 /// The unit for block I/O.
 ///

--- a/services/comps/block/src/id.rs
+++ b/services/comps/block/src/id.rs
@@ -4,6 +4,7 @@ use core::{
     iter::Step,
     ops::{Add, Sub},
 };
+
 use pod::Pod;
 use static_assertions::const_assert;
 

--- a/services/comps/block/src/impl_block_device.rs
+++ b/services/comps/block/src/impl_block_device.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use aster_frame::vm::{VmAllocOptions, VmFrame, VmIo, VmSegment};
 
 use super::{
     bio::{Bio, BioEnqueueError, BioSegment, BioStatus, BioType, BioWaiter, SubmittedBio},
     id::{Bid, Sid},
     BlockDevice, BLOCK_SIZE, SECTOR_SIZE,
 };
-
-use aster_frame::vm::{VmAllocOptions, VmFrame, VmIo, VmSegment};
+use crate::prelude::*;
 
 /// Implements several commonly used APIs for the block device to conveniently
 /// read and write block(s).

--- a/services/comps/block/src/lib.rs
+++ b/services/comps/block/src/lib.rs
@@ -40,14 +40,14 @@ mod impl_block_device;
 mod prelude;
 pub mod request_queue;
 
-use self::bio::{BioEnqueueError, SubmittedBio};
-use self::prelude::*;
-
 use aster_frame::sync::SpinLock;
-use component::init_component;
-use component::ComponentInitError;
-
+use component::{init_component, ComponentInitError};
 use spin::Once;
+
+use self::{
+    bio::{BioEnqueueError, SubmittedBio},
+    prelude::*,
+};
 
 pub const BLOCK_SIZE: usize = aster_frame::config::PAGE_SIZE;
 pub const SECTOR_SIZE: usize = 512;

--- a/services/comps/block/src/prelude.rs
+++ b/services/comps/block/src/prelude.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub(crate) use alloc::collections::{BTreeMap, VecDeque};
-pub(crate) use alloc::string::String;
-pub(crate) use alloc::sync::Arc;
-pub(crate) use alloc::vec;
-pub(crate) use alloc::vec::Vec;
-pub(crate) use core::any::Any;
-pub(crate) use core::fmt::Debug;
-pub(crate) use core::ops::Range;
-pub(crate) use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+pub(crate) use alloc::{
+    collections::{BTreeMap, VecDeque},
+    string::String,
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+pub(crate) use core::{
+    any::Any,
+    fmt::Debug,
+    ops::Range,
+    sync::atomic::{AtomicU32, AtomicUsize, Ordering},
+};

--- a/services/comps/block/src/request_queue.rs
+++ b/services/comps/block/src/request_queue.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use aster_frame::sync::{Mutex, WaitQueue};
 
 use super::{
     bio::{BioEnqueueError, BioType, SubmittedBio},
     id::Sid,
 };
-
-use aster_frame::sync::{Mutex, WaitQueue};
+use crate::prelude::*;
 
 /// A simple block I/O request queue backed by one internal FIFO queue.
 ///

--- a/services/comps/framebuffer/src/lib.rs
+++ b/services/comps/framebuffer/src/lib.rs
@@ -8,12 +8,13 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use aster_frame::{boot, config::PAGE_SIZE, io_mem::IoMem, sync::SpinLock, vm::VmIo};
-use component::{init_component, ComponentInitError};
 use core::{
     fmt,
     ops::{Index, IndexMut},
 };
+
+use aster_frame::{boot, config::PAGE_SIZE, io_mem::IoMem, sync::SpinLock, vm::VmIo};
+use component::{init_component, ComponentInitError};
 use font8x8::UnicodeFonts;
 use spin::Once;
 

--- a/services/comps/input/src/lib.rs
+++ b/services/comps/input/src/lib.rs
@@ -9,21 +9,13 @@ extern crate alloc;
 
 pub mod key;
 
-use core::any::Any;
-use core::fmt::Debug;
-
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use component::init_component;
-use component::ComponentInitError;
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use core::{any::Any, fmt::Debug};
 
 use aster_frame::sync::SpinLock;
+use component::{init_component, ComponentInitError};
+use key::{Key, KeyStatus};
 use spin::Once;
-
-use key::Key;
-use key::KeyStatus;
 
 #[derive(Debug, Clone, Copy)]
 pub enum InputEvent {

--- a/services/comps/network/src/driver.rs
+++ b/services/comps/network/src/driver.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::vec;
+
 use smoltcp::{phy, time::Instant};
 
 use crate::{

--- a/services/comps/network/src/lib.rs
+++ b/services/comps/network/src/lib.rs
@@ -10,19 +10,13 @@ pub mod driver;
 
 extern crate alloc;
 
-use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::sync::Arc;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use core::{any::Any, fmt::Debug};
+
 use aster_frame::sync::SpinLock;
 use aster_util::safe_ptr::Pod;
-use buffer::RxBuffer;
-use buffer::TxBuffer;
-use component::init_component;
-use component::ComponentInitError;
-use core::any::Any;
-use core::fmt::Debug;
+use buffer::{RxBuffer, TxBuffer};
+use component::{init_component, ComponentInitError};
 use smoltcp::phy;
 use spin::Once;
 

--- a/services/comps/time/src/clocksource.rs
+++ b/services/comps/time/src/clocksource.rs
@@ -8,9 +8,10 @@
 //! It can be integrated into larger systems to provide timing capabilities, or used standalone for time tracking and elapsed time measurements.
 
 use alloc::sync::Arc;
+use core::{cmp::max, ops::Add, time::Duration};
+
 use aster_frame::sync::SpinLock;
 use aster_util::coeff::Coeff;
-use core::{cmp::max, ops::Add, time::Duration};
 
 use crate::NANOS_PER_SECOND;
 

--- a/services/comps/time/src/lib.rs
+++ b/services/comps/time/src/lib.rs
@@ -7,15 +7,14 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use aster_frame::sync::Mutex;
-use component::{init_component, ComponentInitError};
 use core::{sync::atomic::Ordering::Relaxed, time::Duration};
-use spin::Once;
 
+use aster_frame::sync::Mutex;
 use clocksource::ClockSource;
-use rtc::{get_cmos, is_updating, CENTURY_REGISTER};
-
 pub use clocksource::Instant;
+use component::{init_component, ComponentInitError};
+use rtc::{get_cmos, is_updating, CENTURY_REGISTER};
+use spin::Once;
 
 mod clocksource;
 mod rtc;

--- a/services/comps/time/src/rtc.rs
+++ b/services/comps/time/src/rtc.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::sync::atomic::{AtomicU8, Ordering::Relaxed};
+
 use aster_frame::arch::x86::device::cmos::{get_century_register, CMOS_ADDRESS, CMOS_DATA};
-use core::sync::atomic::AtomicU8;
-use core::sync::atomic::Ordering::Relaxed;
 
 pub(crate) static CENTURY_REGISTER: AtomicU8 = AtomicU8::new(0);
 

--- a/services/comps/time/src/tsc.rs
+++ b/services/comps/time/src/tsc.rs
@@ -4,13 +4,18 @@
 //!
 //! Use `init` to initialize this module.
 use alloc::sync::Arc;
-use aster_frame::arch::{read_tsc, x86::tsc_freq};
-use aster_frame::timer::Timer;
 use core::time::Duration;
+
+use aster_frame::{
+    arch::{read_tsc, x86::tsc_freq},
+    timer::Timer,
+};
 use spin::Once;
 
-use crate::clocksource::{ClockSource, Instant};
-use crate::{START_TIME, VDSO_DATA_UPDATE};
+use crate::{
+    clocksource::{ClockSource, Instant},
+    START_TIME, VDSO_DATA_UPDATE,
+};
 
 /// A instance of TSC clocksource.
 pub static CLOCK: Once<Arc<ClockSource>> = Once::new();

--- a/services/comps/virtio/src/device/block/device.rs
+++ b/services/comps/virtio/src/device/block/device.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use core::{fmt::Debug, hint::spin_loop, mem::size_of};
 
-use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use aster_block::{
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio},
     id::Sid,
@@ -18,14 +18,15 @@ use aster_util::safe_ptr::SafePtr;
 use log::info;
 use pod::Pod;
 
+use super::{BlockFeatures, VirtioBlockConfig};
 use crate::{
-    device::block::{ReqType, RespStatus},
-    device::VirtioDeviceError,
+    device::{
+        block::{ReqType, RespStatus},
+        VirtioDeviceError,
+    },
     queue::VirtQueue,
     transport::VirtioTransport,
 };
-
-use super::{BlockFeatures, VirtioBlockConfig};
 
 #[derive(Debug)]
 pub struct BlockDevice {

--- a/services/comps/virtio/src/device/console/device.rs
+++ b/services/comps/virtio/src/device/console/device.rs
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec::Vec};
 use core::hint::spin_loop;
 
-use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec::Vec};
 use aster_console::{AnyConsoleDevice, ConsoleCallback};
 use aster_frame::{config::PAGE_SIZE, io_mem::IoMem, sync::SpinLock, trap::TrapFrame};
 use aster_util::safe_ptr::SafePtr;
 use log::debug;
 
+use super::{config::VirtioConsoleConfig, DEVICE_NAME};
 use crate::{
     device::{console::config::ConsoleFeatures, VirtioDeviceError},
     queue::VirtQueue,
     transport::VirtioTransport,
 };
-
-use super::{config::VirtioConsoleConfig, DEVICE_NAME};
 
 pub struct ConsoleDevice {
     config: SafePtr<VirtioConsoleConfig, IoMem>,

--- a/services/comps/virtio/src/device/input/device.rs
+++ b/services/comps/virtio/src/device/input/device.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt::Debug;
-
-use crate::{device::VirtioDeviceError, queue::VirtQueue, transport::VirtioTransport};
 use alloc::{
     boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
 };
+use core::fmt::Debug;
+
 use aster_frame::{io_mem::IoMem, offset_of, sync::SpinLock, trap::TrapFrame};
 use aster_input::{
     key::{Key, KeyStatus},
@@ -20,6 +19,7 @@ use log::{debug, info};
 use pod::Pod;
 
 use super::{InputConfigSelect, VirtioInputConfig, VirtioInputEvent, QUEUE_EVENT, QUEUE_STATUS};
+use crate::{device::VirtioDeviceError, queue::VirtQueue, transport::VirtioTransport};
 
 bitflags! {
     /// The properties of input device.

--- a/services/comps/virtio/src/device/input/mod.rs
+++ b/services/comps/virtio/src/device/input/mod.rs
@@ -27,10 +27,11 @@
 //
 
 pub mod device;
-use crate::transport::VirtioTransport;
 use aster_frame::io_mem::IoMem;
 use aster_util::safe_ptr::SafePtr;
 use pod::Pod;
+
+use crate::transport::VirtioTransport;
 
 pub static DEVICE_NAME: &str = "Virtio-Input";
 

--- a/services/comps/virtio/src/device/mod.rs
+++ b/services/comps/virtio/src/device/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::queue::QueueError;
 use int_to_c_enum::TryFromInt;
+
+use crate::queue::QueueError;
 
 pub mod block;
 pub mod console;

--- a/services/comps/virtio/src/device/network/device.rs
+++ b/services/comps/virtio/src/device/network/device.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use core::{fmt::Debug, hint::spin_loop, mem::size_of};
 
-use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use aster_frame::{offset_of, sync::SpinLock, trap::TrapFrame};
 use aster_network::{
     buffer::{RxBuffer, TxBuffer},
@@ -13,13 +13,12 @@ use log::debug;
 use pod::Pod;
 use smoltcp::phy::{DeviceCapabilities, Medium};
 
+use super::{config::VirtioNetConfig, header::VirtioNetHdr};
 use crate::{
     device::{network::config::NetworkFeatures, VirtioDeviceError},
     queue::{QueueError, VirtQueue},
     transport::VirtioTransport,
 };
-
-use super::{config::VirtioNetConfig, header::VirtioNetHdr};
 
 pub struct NetworkDevice {
     config: VirtioNetConfig,

--- a/services/comps/virtio/src/lib.rs
+++ b/services/comps/virtio/src/lib.rs
@@ -8,11 +8,10 @@
 
 extern crate alloc;
 
-use component::init_component;
-
 use alloc::boxed::Box;
+
 use bitflags::bitflags;
-use component::ComponentInitError;
+use component::{init_component, ComponentInitError};
 use device::{
     block::device::BlockDevice, console::device::ConsoleDevice, input::device::InputDevice,
     network::device::NetworkDevice, VirtioDeviceType,

--- a/services/comps/virtio/src/queue.rs
+++ b/services/comps/virtio/src/queue.rs
@@ -2,9 +2,12 @@
 
 //! Virtqueue
 
-use crate::transport::VirtioTransport;
-
 use alloc::vec::Vec;
+use core::{
+    mem::size_of,
+    sync::atomic::{fence, Ordering},
+};
+
 use aster_frame::{
     io_mem::IoMem,
     offset_of,
@@ -13,12 +16,10 @@ use aster_frame::{
 use aster_rights::{Dup, TRightSet, TRights, Write};
 use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
-use core::{
-    mem::size_of,
-    sync::atomic::{fence, Ordering},
-};
 use log::debug;
 use pod::Pod;
+
+use crate::transport::VirtioTransport;
 
 #[derive(Debug)]
 pub enum QueueError {

--- a/services/comps/virtio/src/transport/mmio/device.rs
+++ b/services/comps/virtio/src/transport/mmio/device.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{boxed::Box, sync::Arc};
+use core::mem::size_of;
+
 use aster_frame::{
     bus::mmio::{
         bus::MmioDevice,
@@ -15,16 +17,14 @@ use aster_frame::{
 };
 use aster_rights::{ReadOp, WriteOp};
 use aster_util::{field_ptr, safe_ptr::SafePtr};
-use core::mem::size_of;
 use log::warn;
 
+use super::{layout::VirtioMmioLayout, multiplex::MultiplexIrq};
 use crate::{
     queue::{AvailRing, Descriptor, UsedRing},
     transport::{DeviceStatus, VirtioTransport, VirtioTransportError},
     VirtioDeviceType,
 };
-
-use super::{layout::VirtioMmioLayout, multiplex::MultiplexIrq};
 
 #[derive(Debug)]
 pub struct VirtioMmioDevice {

--- a/services/comps/virtio/src/transport/mmio/driver.rs
+++ b/services/comps/virtio/src/transport/mmio/driver.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{sync::Arc, vec::Vec};
+
 use aster_frame::{
     bus::{
         mmio::{

--- a/services/comps/virtio/src/transport/mmio/mod.rs
+++ b/services/comps/virtio/src/transport/mmio/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
+
 use aster_frame::bus::mmio::MMIO_BUS;
 use spin::Once;
 

--- a/services/comps/virtio/src/transport/mmio/multiplex.rs
+++ b/services/comps/virtio/src/transport/mmio/multiplex.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use aster_frame::{
     io_mem::IoMem,
     sync::RwLock,

--- a/services/comps/virtio/src/transport/mod.rs
+++ b/services/comps/virtio/src/transport/mod.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::boxed::Box;
 use core::fmt::Debug;
 
-use alloc::boxed::Box;
 use aster_frame::{io_mem::IoMem, trap::IrqCallbackFunction, vm::DmaCoherent};
 use aster_util::safe_ptr::SafePtr;
 
+use self::{mmio::virtio_mmio_init, pci::virtio_pci_init};
 use crate::{
     queue::{AvailRing, Descriptor, UsedRing},
     VirtioDeviceType,
 };
-
-use self::{mmio::virtio_mmio_init, pci::virtio_pci_init};
 
 pub mod mmio;
 pub mod pci;

--- a/services/comps/virtio/src/transport/pci/capability.rs
+++ b/services/comps/virtio/src/transport/pci/capability.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
+
 use aster_frame::bus::pci::{
     capability::vendor::CapabilityVndrData,
     cfg_space::{Bar, IoBar, MemoryBar},

--- a/services/comps/virtio/src/transport/pci/common_cfg.rs
+++ b/services/comps/virtio/src/transport/pci/common_cfg.rs
@@ -4,9 +4,8 @@ use aster_frame::io_mem::IoMem;
 use aster_util::safe_ptr::SafePtr;
 use pod::Pod;
 
-use crate::transport::pci::capability::VirtioPciCpabilityType;
-
 use super::capability::VirtioPciCapabilityData;
+use crate::transport::pci::capability::VirtioPciCpabilityType;
 
 #[derive(Debug, Default, Copy, Clone, Pod)]
 #[repr(C)]

--- a/services/comps/virtio/src/transport/pci/device.rs
+++ b/services/comps/virtio/src/transport/pci/device.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::{boxed::Box, sync::Arc};
+use core::fmt::Debug;
+
 use aster_frame::{
     bus::{
         pci::{
@@ -12,10 +15,7 @@ use aster_frame::{
     trap::IrqCallbackFunction,
     vm::DmaCoherent,
 };
-
-use alloc::{boxed::Box, sync::Arc};
 use aster_util::{field_ptr, safe_ptr::SafePtr};
-use core::fmt::Debug;
 use log::{info, warn};
 
 use super::{common_cfg::VirtioPciCommonCfg, msix::VirtioMsixManager};

--- a/services/comps/virtio/src/transport/pci/driver.rs
+++ b/services/comps/virtio/src/transport/pci/driver.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{sync::Arc, vec::Vec};
+
 use aster_frame::{
     bus::{
         pci::{

--- a/services/comps/virtio/src/transport/pci/mod.rs
+++ b/services/comps/virtio/src/transport/pci/mod.rs
@@ -7,6 +7,7 @@ pub mod driver;
 pub(super) mod msix;
 
 use alloc::sync::Arc;
+
 use aster_frame::bus::pci::PCI_BUS;
 use spin::Once;
 

--- a/services/comps/virtio/src/transport/pci/msix.rs
+++ b/services/comps/virtio/src/transport/pci/msix.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::vec::Vec;
+
 use aster_frame::{bus::pci::capability::msix::CapabilityMsixData, trap::IrqLine};
 
 pub struct VirtioMsixManager {

--- a/services/libs/aster-rights-proc/src/lib.rs
+++ b/services/libs/aster-rights-proc/src/lib.rs
@@ -78,8 +78,7 @@
 use require_item::RequireItem;
 use syn::parse_macro_input;
 
-use crate::require_attr::expand_require;
-use crate::require_attr::RequireAttr;
+use crate::require_attr::{expand_require, RequireAttr};
 
 mod require_attr;
 mod require_item;

--- a/services/libs/aster-util/src/coeff.rs
+++ b/services/libs/aster-util/src/coeff.rs
@@ -129,8 +129,9 @@ impl Mul<u32> for Coeff {
 
 #[if_cfg_ktest]
 mod test {
-    use super::*;
     use ktest::ktest;
+
+    use super::*;
     #[ktest]
     fn calculation() {
         let coeff = Coeff::new(23456, 56789, 1_000_000_000);

--- a/services/libs/aster-util/src/id_allocator.rs
+++ b/services/libs/aster-util/src/id_allocator.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use bitvec::prelude::BitVec;
 use core::fmt::Debug;
+
+use bitvec::prelude::BitVec;
 
 /// An id allocator implemented by the bitmap.
 /// The true bit implies that the id is allocated, and vice versa.

--- a/services/libs/aster-util/src/safe_ptr.rs
+++ b/services/libs/aster-util/src/safe_ptr.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::vm::Paddr;
-use aster_frame::vm::{HasPaddr, VmIo};
-use aster_frame::Result;
+use core::{fmt::Debug, marker::PhantomData};
+
+use aster_frame::{
+    vm::{HasPaddr, Paddr, VmIo},
+    Result,
+};
 use aster_rights::{Dup, Exec, Full, Read, Signal, TRightSet, TRights, Write};
 use aster_rights_proc::require;
-use core::fmt::Debug;
-use core::marker::PhantomData;
 pub use pod::Pod;
 pub use typeflags_util::SetContain;
 

--- a/services/libs/comp-sys/component/src/lib.rs
+++ b/services/libs/comp-sys/component/src/lib.rs
@@ -9,14 +9,17 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
-use alloc::{borrow::ToOwned, fmt::Debug};
-use log::{debug, error, info};
+use alloc::{
+    borrow::ToOwned,
+    collections::BTreeMap,
+    fmt::Debug,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 pub use component_macro::*;
 pub use inventory::submit;
+use log::{debug, error, info};
 
 #[derive(Debug)]
 pub enum ComponentInitError {

--- a/services/libs/cpio-decoder/src/lib.rs
+++ b/services/libs/cpio-decoder/src/lib.rs
@@ -21,13 +21,17 @@
 
 extern crate alloc;
 
-use crate::error::{Error, Result};
-use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 use core::cmp::min;
+
 use core2::io::{Read, Write};
 use int_to_c_enum::TryFromInt;
 use lending_iterator::prelude::*;
+
+use crate::error::{Error, Result};
 
 pub mod error;
 

--- a/services/libs/cpio-decoder/src/test.rs
+++ b/services/libs/cpio-decoder/src/test.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::error::*;
-use super::{CpioDecoder, FileType};
 use lending_iterator::LendingIterator;
+
+use super::{error::*, CpioDecoder, FileType};
 
 #[test]
 fn test_decoder() {

--- a/services/libs/keyable-arc/src/lib.rs
+++ b/services/libs/keyable-arc/src/lib.rs
@@ -109,13 +109,15 @@
 extern crate alloc;
 
 use alloc::sync::{Arc, Weak};
-use core::borrow::Borrow;
-use core::cmp::Ordering;
-use core::convert::AsRef;
-use core::fmt;
-use core::hash::{Hash, Hasher};
-use core::marker::Unsize;
-use core::ops::{CoerceUnsized, Deref};
+use core::{
+    borrow::Borrow,
+    cmp::Ordering,
+    convert::AsRef,
+    fmt,
+    hash::{Hash, Hasher},
+    marker::Unsize,
+    ops::{CoerceUnsized, Deref},
+};
 
 /// Same as the standard `Arc`, except that it can be used as the key type of a hash table.
 #[repr(transparent)]

--- a/services/libs/typeflags-util/src/bool.rs
+++ b/services/libs/typeflags-util/src/bool.rs
@@ -2,9 +2,7 @@
 
 //! Type level bools
 
-pub use core::ops::BitAnd as And;
-pub use core::ops::BitOr as Or;
-pub use core::ops::Not;
+pub use core::ops::{BitAnd as And, BitOr as Or, Not};
 use core::unimplemented;
 
 pub trait Bool {}

--- a/services/libs/typeflags-util/src/lib.rs
+++ b/services/libs/typeflags-util/src/lib.rs
@@ -12,8 +12,11 @@ pub mod if_;
 pub mod same;
 pub mod set;
 
-pub use crate::bool::{And, AndOp, False, IsFalse, IsTrue, Not, NotOp, Or, OrOp, True};
-pub use crate::extend::{SetExtend, SetExtendOp};
-pub use crate::same::{SameAs, SameAsOp};
-pub use crate::set::{Cons, Nil, Set, SetContain, SetContainOp, SetInclude, SetIncludeOp};
 pub use assert::AssertTypeSame;
+
+pub use crate::{
+    bool::{And, AndOp, False, IsFalse, IsTrue, Not, NotOp, Or, OrOp, True},
+    extend::{SetExtend, SetExtendOp},
+    same::{SameAs, SameAsOp},
+    set::{Cons, Nil, Set, SetContain, SetContainOp, SetInclude, SetIncludeOp},
+};

--- a/services/libs/typeflags-util/src/set.rs
+++ b/services/libs/typeflags-util/src/set.rs
@@ -2,14 +2,12 @@
 
 //! Common types and traits to deal with type-level sets
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::BitOr as Or};
 
 use crate::{
     if_::{If, IfOp},
     And, AndOp, False, OrOp, SameAs, SameAsOp, True,
 };
-
-use core::ops::BitOr as Or;
 
 /// A marker trait for type-level sets.
 pub trait Set {}

--- a/tools/format_all.sh
+++ b/tools/format_all.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+WORKSPACE_ROOT="$(dirname "$(readlink -f "$0")")/.."
+
+EXCLUDED_CRATES=$(sed -n '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
+
+
+CHECK_MODE=false
+
+if [ "$#" -eq 1 ]; then
+    if [ "$1" == "--check" ]; then
+        CHECK_MODE=true
+    else
+        echo "Error: Invalid argument. Only '--check' is allowed."
+        exit 1
+    fi
+elif [ "$#" -gt 1 ]; then
+    echo "Error: Too many arguments. Only '--check' is allowed."
+    exit 1
+fi
+
+cd $WORKSPACE_ROOT
+if [ "$CHECK_MODE" = true ]; then
+    cargo fmt --check
+else
+    cargo fmt
+fi
+
+for CRATE in $EXCLUDED_CRATES; do
+    CRATE_DIR="$WORKSPACE_ROOT/$CRATE"
+
+    # `cargo-component` crate currently is pinned to use Rust nightly-2023-02-05 version, 
+    # and when using this script in the current Docker environment, it will 
+    # additionally download this version of Rust. 
+    # Here temporarily skip processing this crate for now considering that this crate 
+    # is not currently in use or under development. 
+    case "$CRATE" in
+        *cargo-component*)
+            continue 
+            ;;
+    esac
+
+    if [ -d "$CRATE_DIR" ]; then
+        if [ "$CHECK_MODE" = true ]; then
+            (cd "$CRATE_DIR" && cargo fmt --check)
+        else
+            (cd "$CRATE_DIR" && cargo fmt)
+        fi
+    else
+        echo "Directory for crate $CRATE does not exist"
+    fi
+done
+


### PR DESCRIPTION
Add a rustfmt.toml file to the project to configure the behavior of `cargo fmt` for formatting imports:
- Import types from the same module should be placed within the same block.
- Module imports should be grouped according to the following rules:
    - Imports from std, core, and alloc modules should be placed at the beginning.
    - Imports from third-party libraries should be placed in the middle.
    - Imports from local modules with self, super, and crate prefixes should be placed at the end.