### PR TITLE
Fix random failures in `send_buf_full`

### DIFF
--- a/regression/apps/scripts/network.sh
+++ b/regression/apps/scripts/network.sh
@@ -18,7 +18,7 @@ echo "Start network test......"
 ./socketpair
 ./sockoption
 ./listen_backlog
-# ./send_buf_full
+./send_buf_full
 ./http_server &
 ./http_client
 ./tcp_err


### PR DESCRIPTION
Fixes #646.

I guess the reported test failure is caused by the non-blocking receiver being able to finish before the sender sends all of its data in some race conditions. The fix works as confirmed by @StevenJiang1110,  but I cannot reproduce this test failure on my machine.

Is it also a good idea to modify the CI process so that the regression tests run in both Asterinas and the host Linux?