### PR TITLE
Fix Asterinas dependencies in OSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
     <img src="docs/src/images/logo_en.svg" alt="asterinas-logo" width="620"><br>
     A secure, fast, and general-purpose OS kernel written in Rust and compatible with Linux<br/>
-    <a href="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg" alt="OSDK Test" style="max-width: 100%;"></a>
-    <a href="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml/badge.svg" alt="Kernel Test" style="max-width: 100%;"></a>
+    <a href="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg?event=push" alt="OSDK Test" style="max-width: 100%;"></a>
+    <a href="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml/badge.svg?event=push" alt="Kernel Test" style="max-width: 100%;"></a>
     <br/>
 </p>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,8 +1,8 @@
 <p align="center">
     <img src="docs/src/images/logo_cn.svg" alt="asterinas-logo" width="620"><br>
     一个安全、快速、通用的操作系统内核，使用Rust编写，并与Linux兼容<br/>
-    <a href="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg" alt="OSDK Test" style="max-width: 100%;"></a>
-    <a href="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml/badge.svg" alt="Kernel Test" style="max-width: 100%;"></a>
+    <a href="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg?event=push" alt="OSDK Test" style="max-width: 100%;"></a>
+    <a href="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/kernel_test.yml/badge.svg?event=push" alt="Kernel Test" style="max-width: 100%;"></a>
     <br/>
 </p>
 

--- a/osdk/README.md
+++ b/osdk/README.md
@@ -1,7 +1,7 @@
 # Accelerate OS development with Asterinas OSDK
 
 [![Crates.io](https://img.shields.io/crates/v/cargo-osdk.svg)](https://crates.io/crates/cargo-osdk)
-[![OSDK Test](https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg)](https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml)
+[![OSDK Test](https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml/badge.svg?event=push)](https://github.com/asterinas/asterinas/actions/workflows/osdk_test.yml)
 
 ### What is it?
 

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -155,8 +155,8 @@ fn install_setup_with_arch(
     cmd.arg("--root").arg(install_dir.as_ref());
     // TODO: Use the latest revision when modifications on the `osdk` branch is merged.
     cmd.arg("--git")
-        .arg("https://github.com/junyang-zh/asterinas");
-    cmd.arg("--branch").arg("osdk");
+        .arg(crate::util::ASTER_GIT_LINK);
+    cmd.arg("--rev").arg(crate::util::ASTER_GIT_REV);
     cmd.arg("--target").arg(match arch {
         SetupInstallArch::X86_64 => "x86_64-unknown-none",
         SetupInstallArch::Other(path) => path.to_str().unwrap(),

--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     cli::NewArgs,
     error::Errno,
     error_msg,
-    util::{cargo_new_lib, get_cargo_metadata, ASTER_FRAME_DEP, KTEST_DEP},
+    util::{cargo_new_lib, get_cargo_metadata, aster_crate_dep},
 };
 
 pub fn execute_new_command(args: &NewArgs) {
@@ -44,9 +44,9 @@ fn add_manifest_dependencies(cargo_metadata: &serde_json::Value, crate_name: &st
 
     let dependencies = manifest.get_mut("dependencies").unwrap();
 
-    let aster_frame_dep = toml::Table::from_str(ASTER_FRAME_DEP).unwrap();
+    let aster_frame_dep = toml::Table::from_str(&aster_crate_dep("aster-frame")).unwrap();
     dependencies.as_table_mut().unwrap().extend(aster_frame_dep);
-    let ktest_dep = toml::Table::from_str(KTEST_DEP).unwrap();
+    let ktest_dep = toml::Table::from_str(&aster_crate_dep("ktest")).unwrap();
     dependencies.as_table_mut().unwrap().extend(ktest_dep);
 
     // If we created a workspace by `osdk new`, we should exclude the `base` crate from the workspace.

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -8,13 +8,16 @@ use std::{
 
 use crate::{error::Errno, error_msg};
 
-// FIXME: Crates belonging to Asterinas require a different dependency format. The dependency
-// should be specified using a relative path instead of a URL.
-// TODO: The dependency should be corrected when this branch is merged.
-pub const ASTER_FRAME_DEP: &str =
-    "aster-frame = { git = \"https://github.com/junyang-zh/asterinas\", branch = \"osdk\" }";
-pub const KTEST_DEP: &str =
-    "ktest = { git = \"https://github.com/junyang-zh/asterinas\", branch = \"osdk\" }";
+/// FIXME: We should publish the asterinas crates to a public registry
+/// and use the published version in the generated Cargo.toml.
+pub const ASTER_GIT_LINK: &str = "https://github.com/asterinas/asterinas";
+pub const ASTER_GIT_REV: &str = "7d0ea99";
+pub fn aster_crate_dep(crate_name: &str) -> String {
+    format!(
+        "{} = {{ git = \"{}\", rev = \"{}\" }}",
+        crate_name, ASTER_GIT_LINK, ASTER_GIT_REV
+    )
+}
 
 fn cargo() -> Command {
     Command::new("cargo")


### PR DESCRIPTION
We developed OSDK in another repo and we had to use git urls. Since OSDK is merged we can finally point to the upstream repo.