### PR TITLE
Automatically update initramfs when regression tests are changed

### DIFF
--- a/.github/workflows/kernel_test.yml
+++ b/.github/workflows/kernel_test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Ktest Unit Test
         id: ktest_unit_test
-        run: make update_initramfs && make ktest
+        run: make ktest
 
       # TODO: add component check.
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ target/
 
 **/.DS_Store
 
-# Ramdisk file
-regression/ramdisk/initramfs/
-regression/ramdisk/build/
-
 # qemu log file
 qemu.log
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SYSCALL_TEST_DIR ?= /tmp
 RELEASE_MODE ?= 0
 # End of auto test features.
 
+CARGO_OSDK := ~/.cargo/bin/cargo-osdk
+
 CARGO_OSDK_ARGS :=
 
 ifeq ($(AUTO_TEST), syscall)
@@ -104,12 +106,15 @@ all: build
 
 # Install or update OSDK from source
 # To uninstall, do `cargo uninstall cargo-osdk`
-install_osdk: osdk
+install_osdk:
 	@cargo install cargo-osdk --path osdk
 
-~/.cargo/bin/cargo-osdk: install_osdk
+# This will install OSDK if it is not already installed
+# To update OSDK, we need to run `install_osdk` manually
+$(CARGO_OSDK):
+	@make --no-print-directory install_osdk
 
-build: install_osdk ~/.cargo/bin/cargo-osdk
+build: $(CARGO_ODSK)
 	@make --no-print-directory -C regression
 	@cd kernel && cargo osdk build $(CARGO_OSDK_ARGS)
 
@@ -124,7 +129,7 @@ test:
 		(cd $$dir && cargo test) || exit 1; \
 	done
 
-ktest: install_osdk ~/.cargo/bin/cargo-osdk
+ktest: $(CARGO_ODSK)
 	@# Exclude linux-bzimage-setup from ktest since it's hard to be unit tested
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "framework/libs/linux-bzimage/setup" ] && continue; \
@@ -139,7 +144,7 @@ docs:
 format:
 	@./tools/format_all.sh
 
-check: install_osdk ~/.cargo/bin/cargo-osdk
+check: $(CARGO_ODSK)
 	@./tools/format_all.sh --check   	# Check Rust format issues
 	@# Check if STD_CRATES and NOSTD_CRATES combined is the same as all workspace members
 	@sed -n '/^\[workspace\]/,/^\[.*\]/{/members = \[/,/\]/p}' Cargo.toml | grep -v "members = \[" | tr -d '", \]' | sort > /tmp/all_crates

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,12 @@ install_osdk:
 $(CARGO_OSDK):
 	@make --no-print-directory install_osdk
 
-build: $(CARGO_ODSK)
+.PHONY: initramfs
+initramfs:
 	@make --no-print-directory -C regression
+
+.PHONY: build
+build: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk build $(CARGO_OSDK_ARGS)
 
 .PHONY: tools
@@ -133,7 +137,7 @@ test:
 	done
 
 .PHONY: ktest
-ktest: $(CARGO_OSDK)
+ktest: initramfs $(CARGO_OSDK)
 	@# Exclude linux-bzimage-setup from ktest since it's hard to be unit tested
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "framework/libs/linux-bzimage/setup" ] && continue; \
@@ -173,8 +177,3 @@ clean:
 	@cargo clean
 	@cd docs && mdbook clean
 	@make --no-print-directory -C regression clean
-
-.PHONY: update_initramfs
-update_initramfs:
-	@make --no-print-directory -C regression clean
-	@make --no-print-directory -C regression

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -26,8 +26,7 @@ INITRAMFS_ALL_DIRS := \
 	$(INITRAMFS)/benchmark \
 	$(INITRAMFS_EMPTY_DIRS)
 
-.PHONY: all clean
-
+.PHONY: all
 all: build
 
 $(INITRAMFS)/lib/x86_64-linux-gnu: $(VDSO_DIR)
@@ -100,7 +99,9 @@ $(EXT2_IMAGE):
 	@dd if=/dev/zero of=$(EXT2_IMAGE) bs=2G count=1
 	@mke2fs $(EXT2_IMAGE)
 
+.PHONY: build
 build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE)
 
+.PHONY: clean
 clean:
 	@rm -rf $(BUILD_DIR)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -5,9 +5,9 @@ CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 BUILD_DIR := $(CUR_DIR)/build
 VDSO_DIR := $(BUILD_DIR)/linux_vdso
 INITRAMFS := $(BUILD_DIR)/initramfs
+INITRAMFS_FILELIST := $(BUILD_DIR)/initramfs.filelist
 INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio.gz
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
-SHELL := /bin/bash
 INITRAMFS_EMPTY_DIRS := \
 	$(INITRAMFS)/sbin \
 	$(INITRAMFS)/root \
@@ -25,11 +25,12 @@ INITRAMFS_ALL_DIRS := \
 	$(INITRAMFS)/regression \
 	$(INITRAMFS)/benchmark \
 	$(INITRAMFS_EMPTY_DIRS)
+SYSCALL_TEST_DIR := $(INITRAMFS)/opt/syscall_test
 
 .PHONY: all
 all: build
 
-$(INITRAMFS)/lib/x86_64-linux-gnu: $(VDSO_DIR)
+$(INITRAMFS)/lib/x86_64-linux-gnu: | $(VDSO_DIR)
 	@mkdir -p $@
 	@cp -L /lib/x86_64-linux-gnu/libc.so.6 $@
 	@cp -L /lib/x86_64-linux-gnu/libstdc++.so.6 $@
@@ -64,11 +65,11 @@ $(INITRAMFS)/bin:
 	@mkdir -p $@
 	@/bin/busybox --install -s $@
 
-$(INITRAMFS)/usr/bin: $(INITRAMFS)/bin
+$(INITRAMFS)/usr/bin: | $(INITRAMFS)/bin
 	@mkdir -p $@
 	@cp /usr/bin/busybox $@
 
-# Copy from apps.
+.PHONY: $(INITRAMFS)/regression
 $(INITRAMFS)/regression:
 	@make --no-print-directory -C apps
 
@@ -82,18 +83,35 @@ $(INITRAMFS)/benchmark:
 $(INITRAMFS_EMPTY_DIRS):
 	@mkdir -p $@
 
-$(INITRAMFS)/opt/syscall_test:
+.PHONY: $(SYSCALL_TEST_DIR)
+$(SYSCALL_TEST_DIR):
 	@make --no-print-directory -C syscall_test
 
+.PHONY: $(INITRAMFS_IMAGE)
+$(INITRAMFS_IMAGE): $(INITRAMFS_FILELIST)
+	@if ! cmp -s $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous ; then \
+		echo "Generating the initramfs image..."; \
+		cp -f $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous; \
+		( \
+			cd $(INITRAMFS); \
+			# `$(INITRAMFS_FILELIST)` contains files' last modification \
+			# time in the first column, and files' relative path to \
+			# `$(INITRAMFS)` in the second column. This prunes the first \
+			# column and passes the second column to `cpio`. \
+			cut -d " " -f 2- $(INITRAMFS_FILELIST) | \
+				cpio -o -H newc | gzip \
+		) > $@; \
+	fi
+
+.PHONY: $(INITRAMFS_FILELIST)
 # If the BUILD_SYSCALL_TEST variable is set, we should depend on the
 # sub make output to do incremental building.
 ifeq ($(BUILD_SYSCALL_TEST), 1)
-$(INITRAMFS_IMAGE): $(INITRAMFS_ALL_DIRS) $(INITRAMFS)/opt/syscall_test
+$(INITRAMFS_FILELIST): | $(INITRAMFS_ALL_DIRS) $(SYSCALL_TEST_DIR)
 else
-$(INITRAMFS_IMAGE): $(INITRAMFS_ALL_DIRS)
+$(INITRAMFS_FILELIST): | $(INITRAMFS_ALL_DIRS)
 endif
-	@echo "Generating the initramfs image..."
-	@(cd $(INITRAMFS); find . | cpio -o -H newc | gzip) > $@
+	@(cd $(INITRAMFS); find . -printf "%T@ %p\n") > $(INITRAMFS_FILELIST)
 
 $(EXT2_IMAGE):
 	@dd if=/dev/zero of=$(EXT2_IMAGE) bs=2G count=1

--- a/regression/apps/Makefile
+++ b/regression/apps/Makefile
@@ -8,9 +8,15 @@ REGRESSION_BUILD_DIR ?= $(INITRAMFS)/regression
 TEST_APPS := signal_c pthread network hello_world hello_pie hello_c fork_c fork execve pty
 
 .PHONY: all
-all: 
-	@mkdir -p $(REGRESSION_BUILD_DIR)
-	@for test_app in $(TEST_APPS); \
-		do make --no-print-directory -C $${test_app}; \
-	done
+all: $(TEST_APPS) scripts
+
+.PHONY: $(TEST_APPS)
+$(TEST_APPS):
+	@make --no-print-directory -C $@
+
+$(REGRESSION_BUILD_DIR):
+	@mkdir -p $@
+
+.PHONY: scripts
+scripts: | $(REGRESSION_BUILD_DIR)
 	@make --no-print-directory BUILD_DIR=$(REGRESSION_BUILD_DIR) -C scripts

--- a/regression/apps/Makefile
+++ b/regression/apps/Makefile
@@ -8,7 +8,6 @@ REGRESSION_BUILD_DIR ?= $(INITRAMFS)/regression
 TEST_APPS := signal_c pthread network hello_world hello_pie hello_c fork_c fork execve pty
 
 .PHONY: all
-
 all: 
 	@mkdir -p $(REGRESSION_BUILD_DIR)
 	@for test_app in $(TEST_APPS); \

--- a/regression/apps/execve/Makefile
+++ b/regression/apps/execve/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static
+EXTRA_C_FLAGS := -static

--- a/regression/apps/fork/Makefile
+++ b/regression/apps/fork/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static -nostdlib
+EXTRA_C_FLAGS := -static -nostdlib

--- a/regression/apps/fork_c/Makefile
+++ b/regression/apps/fork_c/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static
+EXTRA_C_FLAGS := -static

--- a/regression/apps/hello_c/Makefile
+++ b/regression/apps/hello_c/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static -mno-sse
+EXTRA_C_FLAGS := -static -mno-sse

--- a/regression/apps/hello_world/Makefile
+++ b/regression/apps/hello_world/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static -nostdlib
+EXTRA_C_FLAGS := -static -nostdlib

--- a/regression/apps/pthread/Makefile
+++ b/regression/apps/pthread/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static -lpthread
+EXTRA_C_FLAGS := -static -lpthread

--- a/regression/apps/scripts/Makefile
+++ b/regression/apps/scripts/Makefile
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
+SOURCES := $(wildcard *.sh)
+TARGETS := $(addprefix $(BUILD_DIR)/, $(SOURCES))
+
 .PHONY: all
-all: ./*.sh
-	@cp ./*.sh $(BUILD_DIR)
+all: $(TARGETS)
+
+$(BUILD_DIR)/%.sh: %.sh
+	@cp $< $@

--- a/regression/apps/scripts/Makefile
+++ b/regression/apps/scripts/Makefile
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 .PHONY: all
-
 all: ./*.sh
 	@cp ./*.sh $(BUILD_DIR)

--- a/regression/apps/signal_c/Makefile
+++ b/regression/apps/signal_c/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=-static
+EXTRA_C_FLAGS := -static

--- a/regression/apps/test_common.mk
+++ b/regression/apps/test_common.mk
@@ -4,25 +4,30 @@ MAIN_MAKEFILE := $(firstword $(MAKEFILE_LIST))
 INCLUDE_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 CUR_DIR := $(shell dirname $(realpath $(MAIN_MAKEFILE)))
 CUR_DIR_NAME := $(shell basename $(realpath $(CUR_DIR)))
-REGRESSION_BUILD_DIR := $(CUR_DIR)/../../build/initramfs/regression
-OBJ_OUTPUT_DIR := $(REGRESSION_BUILD_DIR)/$(CUR_DIR_NAME)
+BUILD_DIR := $(CUR_DIR)/../../build
+OBJ_OUTPUT_DIR := $(BUILD_DIR)/initramfs/regression/$(CUR_DIR_NAME)
+DEP_OUTPUT_DIR := $(BUILD_DIR)/dep/$(CUR_DIR_NAME)
 C_SRCS := $(wildcard *.c)
 C_OBJS := $(addprefix $(OBJ_OUTPUT_DIR)/,$(C_SRCS:%.c=%))
+C_DEPS := $(addprefix $(DEP_OUTPUT_DIR)/,$(C_SRCS:%.c=%.d))
 ASM_SRCS := $(wildcard *.s)
 ASM_OBJS := $(addprefix $(OBJ_OUTPUT_DIR)/,$(ASM_SRCS:%.s=%))
 CC := gcc
 C_FLAGS :=
 
 .PHONY: all
-all: $(OBJ_OUTPUT_DIR) $(C_OBJS) $(ASM_OBJS)
+all: $(C_OBJS) $(ASM_OBJS)
 
-$(OBJ_OUTPUT_DIR):
-	@mkdir -p $(OBJ_OUTPUT_DIR)
+$(OBJ_OUTPUT_DIR) $(DEP_OUTPUT_DIR):
+	@mkdir -p $@
 
-$(CUR_DIR)/../../build/initramfs/regression/$(CUR_DIR_NAME)/%: %.c
-	@$(CC) $(C_FLAGS) $(EXTRA_C_FLAGS) $< -o $@
+$(OBJ_OUTPUT_DIR)/%: %.c | $(OBJ_OUTPUT_DIR) $(DEP_OUTPUT_DIR)
+	@$(CC) $(C_FLAGS) $(EXTRA_C_FLAGS) $< -o $@ \
+		-MMD -MF $(DEP_OUTPUT_DIR)/$*.d
 	@echo "CC <= $@"
 
-$(CUR_DIR)/../../build/initramfs/regression/$(CUR_DIR_NAME)/%: %.s
+-include $(C_DEPS)
+
+$(OBJ_OUTPUT_DIR)/%: %.s | $(OBJ_OUTPUT_DIR)
 	@$(CC) $(C_FLAGS) $(EXTRA_C_FLAGS) $< -o $@
 	@echo "CC <= $@"

--- a/regression/apps/test_common.mk
+++ b/regression/apps/test_common.mk
@@ -14,7 +14,6 @@ CC := gcc
 C_FLAGS :=
 
 .PHONY: all
-
 all: $(OBJ_OUTPUT_DIR) $(C_OBJS) $(ASM_OBJS)
 
 $(OBJ_OUTPUT_DIR):

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -19,8 +19,7 @@ TARGET_DIR := $(INITRAMFS)/opt/syscall_test
 RUN_BASH := $(CUR_DIR)/run_syscall_test.sh
 BLOCK_LIST := $(CUR_DIR)/blocklists
 
-.PHONY: all clean
-
+.PHONY: all
 all: $(TESTS)
 
 $(TESTS): $(BIN_DIR) $(TARGET_DIR)
@@ -50,5 +49,6 @@ $(TARGET_DIR): $(RUN_BASH) $(BLOCK_LIST)
 	@# Copy bash script
 	@cp -f $(RUN_BASH) $@
 
+.PHONY: clean
 clean:
 	@rm -rf $(TARGET_DIR)


### PR DESCRIPTION
Example:
 - If no regression tests are changed, initramfs will not be regenerated:
```
root@localhost:~/asterinas# make -s initramfs
root@localhost:~/asterinas# 
```
 - If regression tests are changed, tests will be rebuilt and initramfs will be regenerated:
```
root@localhost:~/asterinas# touch regression/apps/network/source.c 
root@localhost:~/asterinas# make -s initramfs
CC <= /root/asterinas/regression/apps/network/../../build/initramfs/regression/network/source
Generating the initramfs image...
40377 blocks
root@localhost:~/asterinas# 
```
 - Everything works properly even if regression tests include some header files:
```
root@localhost:~/asterinas# cat regression/apps/network/source.c 
#include "header.h"

int main(void) { return 0; }
root@localhost:~/asterinas# make -s initramfs
root@localhost:~/asterinas# touch regression/apps/network/header.h 
root@localhost:~/asterinas# make -s initramfs
CC <= /root/asterinas/regression/apps/network/../../build/initramfs/regression/network/source
Generating the initramfs image...
40377 blocks
root@localhost:~/asterinas# 
```
 - If regression scripts are changed, they will be copied and initramfs will be regenerated:
```
root@localhost:~/asterinas# touch regression/apps/scripts/network.sh 
root@localhost:~/asterinas# make -s initramfs
Generating the initramfs image...
40377 blocks
root@localhost:~/asterinas# 
```

Also, the following changes have been made to all `Makefile`s:
 - The `.PHONY` should be next to the actual target instead of at the beginning. I think this makes things clearer.
 - Directories should not be a normal requirement. Since `make` checks the modification time of directories instead of the files under them, the target will only be rebuilt if the directories themselves change (e.g. some new files are added or deleted), which is not normally expected behavior. Instead, make directories order-only prerequisites, so that they are called only once, usually the first time the directory needs to be created. See [the example in the official documentation](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html).
 - Use rules when we can, instead of relying on loops in shell scripts. See the [official documentation](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) for the reasons.