### PR TITLE
Fix backticks in OSDK documentations

### DIFF
--- a/docs/src/osdk/reference/manifest.md
+++ b/docs/src/osdk/reference/manifest.md
@@ -24,7 +24,7 @@ the `OSDK.toml` of the workspace will be used
 - If running commands in the crate directory
   - If the crate has `OSDK.toml`,
   the `OSDK.toml` of the crate will be used.
-  - Otherwise, `the OSDK.toml` of the workspace will be used.
+  - Otherwise, the `OSDK.toml` of the workspace will be used.
 
 ## Configurations
 


### PR DESCRIPTION
The filename is `OSDK.toml` instead of `the OSDK.toml`.