### PR TITLE
Enable RTC explicitly in MircoVM machine

### DIFF
--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -158,7 +158,7 @@ impl Bundle {
         }
         match config.manifest.qemu.machine {
             QemuMachine::Microvm => {
-                qemu_cmd.arg("-machine").arg("microvm");
+                qemu_cmd.arg("-machine").arg("microvm,rtc=on");
                 let Some(ref aster_bin) = self.manifest.aster_bin else {
                     error_msg!("Kernel ELF binary is required for Microvm");
                     std::process::exit(Errno::RunBundle as _);


### PR DESCRIPTION
When we run `make run AUTO_TEST=regression ENABLE_KVM=1 QEMU_MACHINE=microvm RELEASE_MODE=1` the kernel hangs at:
https://github.com/asterinas/asterinas/blob/437ab804f3b8fbccdf8b6ed41a772e62df1d5b4a/kernel/comps/time/src/lib.rs#L60

According to QEMU's [implementation](https://github.com/qemu/qemu/blob/db596ae19040574e41d086e78469014191d7d7fc/hw/i386/microvm.c#L269-L272), RTC will be automatically disabled if it is not explicitly enabled *and* KVM is enabled. However, Asterinas will not work without RTC. It is suggested that kvmclock is a good alternative, but Asterinas does not currently support it.

As GitHub CI does not support KVM, our CI only checks the non-KVM scenarios, which does not detect this issue in time.

