### PR TITLE
Support running OSDK commands in workspace root

### DIFF
--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   osdk-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     container: asterinas/asterinas:0.4.1
     steps:
       - run: echo "Running in asterinas/asterinas:0.4.1"
@@ -31,3 +31,19 @@ jobs:
       - name: Unit test
         id: unit_test
         run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
+  
+  # Test OSDK in the same environment as described in the OSDK User Guide in the Asterinas Book.
+  osdk_doc_env_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container: asterinas/osdk:0.4.0
+    steps:
+      - run: echo "Running in asterinas/osdk:0.4.0"
+
+      - uses: actions/checkout@v4
+
+      - name: Unit test
+        id: unit_test
+        run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
+    
+    # TODO: test the demos in Asterinas Book

--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -32,8 +32,9 @@ jobs:
         id: unit_test
         run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
   
-  # Test OSDK in the same environment as described in the OSDK User Guide in the Asterinas Book.
-  osdk_doc_env_test:
+  # Test OSDK in the same environment 
+  # as described in the OSDK User Guide in the Asterinas Book.
+  osdk-doc-env-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container: asterinas/osdk:0.4.0
@@ -44,6 +45,10 @@ jobs:
 
       - name: Unit test
         id: unit_test
+        # Github's actions/checkout@v4 will result in a new user (not root) 
+        # and thus not using the Rust environment we set up in the container. 
+        # So the RUSTUP_HOME needs to be set here. 
+        # This only breaks when we invoke Cargo in the integration test of OSDK 
+        # since the OSDK toolchain is not nightly.
         run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
     
-    # TODO: test the demos in Asterinas Book

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ format:
 
 .PHONY: check
 check: $(CARGO_OSDK)
+	@cd osdk && cargo clippy -- -D warnings
 	@./tools/format_all.sh --check   	# Check Rust format issues
 	@# Check if STD_CRATES and NOSTD_CRATES combined is the same as all workspace members
 	@sed -n '/^\[workspace\]/,/^\[.*\]/{/members = \[/,/\]/p}' Cargo.toml | \

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ initramfs:
 
 .PHONY: build
 build: initramfs $(CARGO_OSDK)
-	@cd kernel && cargo osdk build $(CARGO_OSDK_ARGS)
+	cargo osdk build $(CARGO_OSDK_ARGS)
 
 .PHONY: tools
 tools:
@@ -130,7 +130,7 @@ tools:
 
 .PHONY: run
 run: build
-	@cd kernel && cargo osdk run $(CARGO_OSDK_ARGS)
+	@cargo osdk run $(CARGO_OSDK_ARGS)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,4 @@ clean:
 	@cargo clean
 	@cd docs && mdbook clean
 	@make --no-print-directory -C regression clean
+	@rm -f $(CARGO_OSDK)

--- a/docs/src/osdk/guide/README.md
+++ b/docs/src/osdk/guide/README.md
@@ -27,7 +27,7 @@ the following tools need to be installed:
 - cargo-binutils
 - gcc
 - qemu-system-x86_64
-- grub-mkrescue
+- grub
 - ovmf
 - xorriso
 
@@ -42,7 +42,8 @@ cargo install cargo-binutils
 
 Other tools can be installed by
 ```bash
-apt install build-essential grub2-common qemu-system-x86 ovmf xorriso
+apt install build-essential grub-efi-amd64 grub2-common \
+    libpixman-1-dev mtools qemu-system-x86 ovmf xorriso
 ```
 
 ### Install

--- a/docs/src/osdk/guide/work-in-workspace.md
+++ b/docs/src/osdk/guide/work-in-workspace.md
@@ -17,11 +17,7 @@ touch Cargo.toml
 
 Then, add the following content to `Cargo.toml`:
 
-```toml
-[workspace]
-members = []
-resolver = "2"
-```
+{{#include ../../../../osdk/tests/examples_in_book/work_in_workspace_templates/Cargo.toml}}
 
 ## Creating a kernel project and a library project
 
@@ -60,31 +56,17 @@ Next, add the following function to `mymodule/src/lib.rs`.
 This function will calculate the available memory
 after booting:
 
-```rust
-pub fn available_memory() -> usize {
-    let regions = aster_frame::boot::memory_regions();
-    regions.iter().map(|region| region.len()).sum()
-}
-```
+{{#include ../../../../osdk/tests/examples_in_book/work_in_workspace_templates/mymodule/src/lib.rs}}
 
 Then, add a dependency on `mymodule` to `myos/Cargo.toml`:
 
-```toml
-[dependencies]
-mymodule = { path = "../mymodule" }
-```
+{{#include ../../../../osdk/tests/examples_in_book/work_in_workspace_templates/myos/Cargo.toml}}
 
 In `myos/src/lib.rs`,
-modify the main function as follows.
-This function will call the function from `mymodule`:
+modify the file content as follows.
+This main function will call the function from `mymodule`:
 
-```rust
-#[aster_main]
-fn kernel_main() {
-    let avail_mem_as_mb = mymodule::available_memory() / 1_000_000;
-    println!("The available memory is {} MB", avail_mem_as_mb);
-}
-```
+{{#include ../../../../osdk/tests/examples_in_book/work_in_workspace_templates/myos/src/lib.rs}}
 
 ## Building and Running the kernel
 

--- a/docs/src/osdk/guide/work-in-workspace.md
+++ b/docs/src/osdk/guide/work-in-workspace.md
@@ -49,6 +49,9 @@ myworkspace/
           └── lib.rs
 ```
 
+At present, OSDK mandates that there must be only one kernel project
+within a workspace.
+
 In addition to the two projects,
 OSDK will also generate `OSDK.toml` and `rust-toolchain.toml`
 at the root of the workspace.
@@ -78,8 +81,8 @@ This function will call the function from `mymodule`:
 ```rust
 #[aster_main]
 fn kernel_main() {
-  let avail_mem_as_mb = mymodule::available_memory() / 1_000_000;
-  println!("The available memory is {} MB", avail_mem_as_mb);
+    let avail_mem_as_mb = mymodule::available_memory() / 1_000_000;
+    println!("The available memory is {} MB", avail_mem_as_mb);
 }
 ```
 

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -137,10 +137,12 @@ dependencies = [
  "lazy_static",
  "linux-bzimage-builder",
  "log",
+ "quote",
  "regex",
  "serde",
  "serde_json",
  "sha2",
+ "syn",
  "toml",
  "which",
 ]
@@ -534,9 +536,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -15,10 +15,12 @@ indexmap = "2.2.1"
 lazy_static = "1.4.0"
 linux-bzimage-builder = { path = "../framework/libs/linux-bzimage/builder" }
 log = "0.4.20"
+quote = "1.0.35"
 regex = "1.10.3"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 sha2 = "0.10.8"
+syn = { version = "2.0.52", features = ["extra-traits", "full", "parsing", "printing"] }
 toml = { version = "0.8.8", features = ["preserve_order"] }
 which = "6.0.0"
 

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -129,9 +129,16 @@ pub struct CargoArgs {
     #[arg(
         long,
         help = "The Cargo build profile (built-in candidates are 'dev', 'release', 'test' and 'bench')",
-        default_value = "dev"
+        default_value = "dev",
+        conflicts_with = "release"
     )]
     pub profile: String,
+    #[arg(
+        long,
+        help = "Build artifacts in release mode",
+        conflicts_with = "profile"
+    )]
+    pub release: bool,
     #[arg(long, value_name = "FEATURES", help = "List of features to activate")]
     pub features: Vec<String>,
 }

--- a/osdk/src/commands/new/kernel.template
+++ b/osdk/src/commands/new/kernel.template
@@ -1,9 +1,6 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
-#[macro_use]
-extern crate ktest;
-
 use aster_frame::prelude::*;
 
 #[aster_main]

--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -43,11 +43,7 @@ fn add_manifest_dependencies(cargo_metadata: &serde_json::Value, crate_name: &st
     dependencies.as_table_mut().unwrap().extend(aster_frame_dep);
     let ktest_dep = toml::Table::from_str(&aster_crate_dep("ktest")).unwrap();
     dependencies.as_table_mut().unwrap().extend(ktest_dep);
-
-    // If we created a workspace by `osdk new`, we should exclude the `base` crate from the workspace.
-    // let exclude = toml::Table::from_str(r#"exclude = ["target/osdk/base"]"#).unwrap();
-    // manifest.insert("workspace".to_string(), toml::Value::Table(exclude));
-
+    
     let content = toml::to_string(&manifest).unwrap();
     fs::write(mainfest_path, content).unwrap();
 }

--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -43,7 +43,7 @@ fn add_manifest_dependencies(cargo_metadata: &serde_json::Value, crate_name: &st
     dependencies.as_table_mut().unwrap().extend(aster_frame_dep);
     let ktest_dep = toml::Table::from_str(&aster_crate_dep("ktest")).unwrap();
     dependencies.as_table_mut().unwrap().extend(ktest_dep);
-    
+
     let content = toml::to_string(&manifest).unwrap();
     fs::write(mainfest_path, content).unwrap();
 }

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -90,7 +90,7 @@ fn get_workspace_default_members() -> Vec<String> {
         .map(|value| {
             // The default member is in the form of "<crate_name> <crate_version> (path+file://<crate_path>)"
             let default_member = value.as_str().unwrap();
-            let path = default_member.split(" ").nth(2).unwrap();
+            let path = default_member.split(' ').nth(2).unwrap();
             path.trim_start_matches("(path+file://")
                 .trim_end_matches(')')
                 .to_string()

--- a/osdk/src/config_manager/mod.rs
+++ b/osdk/src/config_manager/mod.rs
@@ -38,7 +38,7 @@ pub struct BuildConfig {
 
 impl BuildConfig {
     pub fn parse(args: &BuildArgs) -> Self {
-        let cargo_args = split_features(&args.cargo_args);
+        let cargo_args = parse_cargo_args(&args.cargo_args);
         let mut manifest = load_osdk_manifest(&cargo_args, args.osdk_args.select.as_ref());
         apply_cli_args(&mut manifest, &args.osdk_args);
         try_fill_system_configs(&mut manifest);
@@ -58,7 +58,7 @@ pub struct RunConfig {
 
 impl RunConfig {
     pub fn parse(args: &RunArgs) -> Self {
-        let cargo_args = split_features(&args.cargo_args);
+        let cargo_args = parse_cargo_args(&args.cargo_args);
         let mut manifest = load_osdk_manifest(&cargo_args, args.osdk_args.select.as_ref());
         apply_cli_args(&mut manifest, &args.osdk_args);
         try_fill_system_configs(&mut manifest);
@@ -79,7 +79,7 @@ pub struct TestConfig {
 
 impl TestConfig {
     pub fn parse(args: &TestArgs) -> Self {
-        let cargo_args = split_features(&args.cargo_args);
+        let cargo_args = parse_cargo_args(&args.cargo_args);
         let mut manifest = load_osdk_manifest(&cargo_args, args.osdk_args.select.as_ref());
         apply_cli_args(&mut manifest, &args.osdk_args);
         try_fill_system_configs(&mut manifest);
@@ -128,9 +128,10 @@ fn load_osdk_manifest<S: AsRef<str>>(cargo_args: &CargoArgs, selection: Option<S
     osdk_manifest
 }
 
-/// Split `features` in `cargo_args` to ensure each string contains exactly one feature.
-/// This method will spilt features seperated by comma in one string as multiple strings.
-fn split_features(cargo_args: &CargoArgs) -> CargoArgs {
+/// Parse cargo args.
+/// 1. Split `features` in `cargo_args` to ensure each string contains exactly one feature.
+/// 2. Change `profile` to `release` if `--release` is set.
+fn parse_cargo_args(cargo_args: &CargoArgs) -> CargoArgs {
     let mut features = Vec::new();
 
     for feature in cargo_args.features.iter() {
@@ -141,8 +142,15 @@ fn split_features(cargo_args: &CargoArgs) -> CargoArgs {
         }
     }
 
+    let profile = if cargo_args.release {
+        "release".to_string()
+    } else {
+        cargo_args.profile.clone()
+    };
+
     CargoArgs {
-        profile: cargo_args.profile.clone(),
+        profile,
+        release: cargo_args.release,
         features,
     }
 }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -81,12 +81,12 @@ pub struct CrateInfo {
     pub path: String,
 }
 
-/// Retrieve the default member in the workspace. 
-/// 
-/// If there is only one kernel crate, return that crate; 
-/// If there are multiple kernel crates or no kernel crates in the workspace, 
-/// this function will exit with an error. 
-/// 
+/// Retrieve the default member in the workspace.
+///
+/// If there is only one kernel crate, return that crate;
+/// If there are multiple kernel crates or no kernel crates in the workspace,
+/// this function will exit with an error.
+///
 /// A crate is considered a kernel crate if it utilizes the `aster_main` macro.
 fn get_default_member(metadata: &serde_json::Value) -> &str {
     let default_members = metadata

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -106,7 +106,7 @@ fn get_default_member(metadata: &serde_json::Value) -> &str {
             .iter()
             .filter(|package| {
                 let id = package.get("id").unwrap();
-                if !default_members.contains(&id) {
+                if !default_members.contains(id) {
                     return false;
                 }
 
@@ -128,7 +128,7 @@ fn get_default_member(metadata: &serde_json::Value) -> &str {
             .collect()
     };
 
-    if packages.len() == 0 {
+    if packages.is_empty() {
         error_msg!("OSDK requires there's at least one kernel package. Please navigate to the kernel package directory or the workspace root and run the command.");
         std::process::exit(Errno::BuildCrate as _);
     }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -2,16 +2,19 @@
 
 use std::{
     ffi::OsStr,
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
 
 use crate::{error::Errno, error_msg};
 
+use quote::ToTokens;
+
 /// FIXME: We should publish the asterinas crates to a public registry
 /// and use the published version in the generated Cargo.toml.
 pub const ASTER_GIT_LINK: &str = "https://github.com/asterinas/asterinas";
-pub const ASTER_GIT_REV: &str = "7d0ea99";
+pub const ASTER_GIT_REV: &str = "437ab80";
 pub fn aster_crate_dep(crate_name: &str) -> String {
     format!(
         "{} = {{ git = \"{}\", rev = \"{}\" }}",
@@ -78,16 +81,90 @@ pub struct CrateInfo {
     pub path: String,
 }
 
+/// Retrieve the default member in the workspace. 
+/// 
+/// If there is only one kernel crate, return that crate; 
+/// If there are multiple kernel crates or no kernel crates in the workspace, 
+/// this function will exit with an error. 
+/// 
+/// A crate is considered a kernel crate if it utilizes the `aster_main` macro.
+fn get_default_member(metadata: &serde_json::Value) -> &str {
+    let default_members = metadata
+        .get("workspace_default_members")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    if default_members.len() == 1 {
+        return default_members[0].as_str().unwrap();
+    }
+
+    let packages: Vec<_> = {
+        let packages = metadata.get("packages").unwrap().as_array().unwrap();
+
+        packages
+            .iter()
+            .filter(|package| {
+                let id = package.get("id").unwrap();
+                if !default_members.contains(&id) {
+                    return false;
+                }
+
+                let src_path = {
+                    let targets = package.get("targets").unwrap().as_array().unwrap();
+                    if targets.len() != 1 {
+                        return false;
+                    }
+                    targets[0].get("src_path").unwrap().as_str().unwrap()
+                };
+
+                let file = {
+                    let content = fs::read_to_string(src_path).unwrap();
+                    syn::parse_file(&content).unwrap()
+                };
+
+                contains_aster_main_macro(&file)
+            })
+            .collect()
+    };
+
+    if packages.len() == 0 {
+        error_msg!("OSDK requires there's at least one kernel package. Please navigate to the kernel package directory or the workspace root and run the command.");
+        std::process::exit(Errno::BuildCrate as _);
+    }
+
+    if packages.len() >= 2 {
+        error_msg!("OSDK requires there's at most one kernel package in the workspace. Please navigate to the kernel package directory and run the command.");
+        std::process::exit(Errno::BuildCrate as _);
+    }
+
+    packages[0].get("id").unwrap().as_str().unwrap()
+}
+
+fn contains_aster_main_macro(file: &syn::File) -> bool {
+    for item in &file.items {
+        let syn::Item::Fn(item_fn) = item else {
+            continue;
+        };
+
+        for attr in &item_fn.attrs {
+            let attr = format!("{}", attr.to_token_stream());
+            if attr.as_str() == "# [aster_main]" {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
 pub fn get_current_crate_info() -> CrateInfo {
     let metadata = get_cargo_metadata(None::<&str>, None::<&[&str]>).unwrap();
-    let default_members = metadata.get("workspace_default_members").unwrap();
-    assert_eq!(default_members.as_array().unwrap().len(), 1);
+
+    let default_member = get_default_member(&metadata);
+
     // The default member string here is in the form of "<crate_name> <crate_version> (path+file://<crate_path>)"
-    let default_member = default_members[0]
-        .as_str()
-        .unwrap()
-        .split(' ')
-        .collect::<Vec<&str>>();
+    let default_member = default_member.split(' ').collect::<Vec<&str>>();
     let name = default_member[0].to_string();
     let version = default_member[1].to_string();
     let path = default_member[2]

--- a/osdk/tests/bin.rs
+++ b/osdk/tests/bin.rs
@@ -6,5 +6,6 @@
 
 mod cli;
 mod commands;
+mod examples_in_book;
 mod integration;
 mod util;

--- a/osdk/tests/examples_in_book/create_os_projects.rs
+++ b/osdk/tests/examples_in_book/create_os_projects.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::{fs, path::PathBuf};
+
+use crate::util::cargo_osdk;
+
+#[test]
+fn create_a_kernel_project() {
+    let workdir = "/tmp";
+    let kernel = "my_foo_os";
+
+    let kernel_path = PathBuf::from(workdir).join(kernel);
+
+    if kernel_path.exists() {
+        fs::remove_dir_all(&kernel_path).unwrap();
+    }
+
+    cargo_osdk(&["new", "--kernel", kernel])
+        .current_dir(workdir)
+        .unwrap();
+
+    assert!(kernel_path.is_dir());
+    assert!(kernel_path.join("Cargo.toml").is_file());
+    assert!(kernel_path.join("rust-toolchain.toml").is_file());
+
+    fs::remove_dir_all(&kernel_path).unwrap();
+}
+
+#[test]
+fn create_a_library_project() {
+    let workdir = "/tmp";
+    let module = "my_foo_module";
+
+    let module_path = PathBuf::from(workdir).join(module);
+    if module_path.exists() {
+        fs::remove_dir_all(&module_path).unwrap();
+    }
+
+    cargo_osdk(&["new", module]).current_dir(workdir).unwrap();
+
+    assert!(module_path.is_dir());
+    assert!(module_path.join("Cargo.toml").is_file());
+    assert!(module_path.join("rust-toolchain.toml").is_file());
+
+    fs::remove_dir_all(&module_path).unwrap();
+}

--- a/osdk/tests/examples_in_book/mod.rs
+++ b/osdk/tests/examples_in_book/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module contains the demos in OSDK section in the Asterinas Book.
+
+mod create_os_projects;
+mod test_and_run_projects;
+mod work_in_workspace;

--- a/osdk/tests/examples_in_book/test_and_run_projects.rs
+++ b/osdk/tests/examples_in_book/test_and_run_projects.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::{fs, path::PathBuf};
+
+use crate::util::cargo_osdk;
+
+#[test]
+fn create_and_run_kernel() {
+    let work_dir = "/tmp";
+    let os_name = "myos";
+
+    let os_dir = PathBuf::from(work_dir).join(os_name);
+
+    if os_dir.exists() {
+        fs::remove_dir_all(&os_dir).unwrap();
+    }
+
+    let mut command = cargo_osdk(&["new", "--kernel", os_name]);
+    command.current_dir(work_dir);
+    command.ok().unwrap();
+
+    let mut command = cargo_osdk(&["build"]);
+    command.current_dir(&os_dir);
+    command.ok().unwrap();
+
+    let mut command = cargo_osdk(&["run"]);
+    command.current_dir(&os_dir);
+    let output = command.output().unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains("Hello world from guest kernel!"));
+
+    fs::remove_dir_all(&os_dir).unwrap();
+}
+
+#[test]
+fn create_and_test_library() {
+    let work_dir = "/tmp";
+    let module_name = "mymodule";
+
+    let module_dir = PathBuf::from(work_dir).join(module_name);
+
+    if module_dir.exists() {
+        fs::remove_dir_all(&module_dir).unwrap();
+    }
+
+    let mut command = cargo_osdk(&["new", module_name]);
+    command.current_dir(work_dir);
+    command.ok().unwrap();
+
+    let mut command = cargo_osdk(&["test"]);
+    command.current_dir(&module_dir);
+    command.output().unwrap();
+
+    fs::remove_dir_all(&module_dir).unwrap();
+}

--- a/osdk/tests/examples_in_book/work_in_workspace.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::{
+    env,
+    fs::{self, OpenOptions},
+    io::Write,
+    path::PathBuf,
+};
+
+use crate::util::cargo_osdk;
+
+#[test]
+fn work_in_workspace() {
+    let workdir = "/tmp";
+    let workspace_name = "myworkspace";
+
+    // Create workspace and its manifest
+    let workspace_dir = PathBuf::from(workdir).join(workspace_name);
+    if workspace_dir.is_dir() {
+        fs::remove_dir_all(&workspace_dir).unwrap();
+    }
+
+    fs::create_dir_all(&workspace_dir).unwrap();
+    env::set_current_dir(&workspace_dir).unwrap();
+
+    let workspace_toml = include_str!("work_in_workspace_templates/Cargo.toml");
+    fs::write(workspace_dir.join("Cargo.toml"), workspace_toml).unwrap();
+
+    // Create a kernel project and a library project
+    let kernel = "myos";
+    let module = "mymodule";
+    cargo_osdk(&["new", "--kernel", kernel]).ok().unwrap();
+    cargo_osdk(&["new", module]).ok().unwrap();
+
+    // Add a test function to mymodule/src/lib.rs
+    let module_src_path = workspace_dir.join(module).join("src").join("lib.rs");
+    assert!(module_src_path.is_file());
+    let mut module_src_file = OpenOptions::new()
+        .append(true)
+        .open(&module_src_path)
+        .unwrap();
+    module_src_file
+        .write_all(include_bytes!("work_in_workspace_templates/mymodule/src/lib.rs"))
+        .unwrap();
+    module_src_file.flush().unwrap();
+
+    // Add dependency to myos/Cargo.toml
+    let kernel_manifest_path = workspace_dir.join(kernel).join("Cargo.toml");
+    assert!(kernel_manifest_path.is_file());
+    let mut kernel_manifest_file = OpenOptions::new()
+        .append(true)
+        .open(&kernel_manifest_path)
+        .unwrap();
+    kernel_manifest_file
+        .write_all(include_bytes!("work_in_workspace_templates/myos/Cargo.toml"))
+        .unwrap();
+    kernel_manifest_file.flush().unwrap();
+
+    // Add the content to myos/src/lib.rs
+    let kernel_src_path = workspace_dir.join(kernel).join("src").join("lib.rs");
+    assert!(kernel_src_path.is_file());
+    fs::write(&kernel_src_path, include_str!("work_in_workspace_templates/myos/src/lib.rs")).unwrap();
+
+    // Run subcommand build & run
+    cargo_osdk(&["build"]).ok().unwrap();
+    let output = cargo_osdk(&["run"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains("The available memory is"));
+
+    // Run subcommand test
+    cargo_osdk(&["test"]).output().unwrap();
+
+    // Remove the directory
+    fs::remove_dir_all(&workspace_dir).unwrap();
+}

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/Cargo.toml
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = []
+resolver = "2"

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/mymodule/src/lib.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/mymodule/src/lib.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub fn available_memory() -> usize {
+    let regions = aster_frame::boot::memory_regions();
+    regions.iter().map(|region| region.len()).sum()
+}

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/myos/Cargo.toml
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/myos/Cargo.toml
@@ -1,0 +1,2 @@
+[dependencies]
+mymodule = { path = "../mymodule" }

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/myos/src/lib.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/myos/src/lib.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+use aster_frame::prelude::*;
+
+#[aster_main]
+fn kernel_main() {
+    let avail_mem_as_mb = mymodule::available_memory() / 1_000_000;
+    println!("The available memory is {} MB", avail_mem_as_mb);
+}

--- a/osdk/tests/integration/mod.rs
+++ b/osdk/tests/integration/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crate::util::{assert_success, cargo_osdk, create_workspace};
 
-// #[test]
+#[test]
 fn build_with_default_manifest() {
     let workspace = "/tmp/workspace_foo";
     if Path::new(workspace).exists() {
@@ -24,7 +24,7 @@ fn build_with_default_manifest() {
     fs::remove_dir_all(workspace).unwrap();
 }
 
-// #[test]
+#[test]
 fn build_with_conditional_manifest() {
     let workspace = "/tmp/workspace_bar";
     if Path::new(workspace).exists() {

--- a/osdk/tools/Dockerfile.ubuntu22.04
+++ b/osdk/tools/Dockerfile.ubuntu22.04
@@ -3,6 +3,15 @@
 # This image is for the OSDK GitHub CI. 
 # The environment is consistent with the one 
 # described in the OSDK User Guide section of the Asterinas Book.
+#
+# TODO: We should build the Asterinas image based on the OSDK image
+# since Asterinas is managed by OSDK itself.
+# However, currently, these two images have different contents.
+# The main distinction is that
+# QEMU, grub, and OVMF in the OSDK image are installed via apt,
+# while these tools in the Asterinas image are built from source.
+# Some boot methods in Asterinas only function properly
+# when using the tools that are built from source.
 
 FROM ubuntu:22.04
 

--- a/osdk/tools/Dockerfile.ubuntu22.04
+++ b/osdk/tools/Dockerfile.ubuntu22.04
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MPL-2.0
+
+# This image is for the OSDK GitHub CI. 
+# The environment is consistent with the one 
+# described in the OSDK User Guide section of the Asterinas Book.
+
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update \ 
+    && apt install -y \ 
+    build-essential \ 
+    curl \ 
+    grub-efi-amd64 \
+    grub2-common \ 
+    libpixman-1-dev     `# running dependency for QEMU` \
+    mtools              `# used by grub-mkrescue` \
+    ovmf \ 
+    qemu-system-x86 \ 
+    xorriso \ 
+    && apt clean \ 
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust of both nightly and stable channel
+ENV PATH="/root/.cargo/bin:${PATH}"
+ARG ASTER_RUST_VERSION
+RUN curl https://sh.rustup.rs -sSf | \ 
+        sh -s -- --default-toolchain ${ASTER_RUST_VERSION} -y \ 
+    && rustup toolchain install stable \ 
+    && rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git \ 
+    && cargo -V \ 
+    && rustup component add rust-src rustc-dev llvm-tools-preview
+
+# Install cargo-binutils
+RUN cargo install cargo-binutils
+
+VOLUME [ "/root/asterinas" ]
+
+WORKDIR /root/asterinas

--- a/osdk/tools/build_image.sh
+++ b/osdk/tools/build_image.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ASTER_ROOT_DIR=${SCRIPT_DIR}/../..
+ASTER_RUST_VERSION=$( grep -m1 -o 'nightly-[0-9]\+-[0-9]\+-[0-9]\+' ${ASTER_ROOT_DIR}/rust-toolchain.toml )
+VERSION=$( cat ${ASTER_ROOT_DIR}/VERSION )
+IMAGE_NAME=asterinas/osdk:${VERSION}
+DOCKERFILE=${SCRIPT_DIR}/Dockerfile.ubuntu22.04
+
+docker build \
+    -t ${IMAGE_NAME} \
+    --build-arg ASTER_RUST_VERSION=${ASTER_RUST_VERSION} \
+    -f ${DOCKERFILE} \
+    ${SCRIPT_DIR} 

--- a/osdk/tools/run_container.sh
+++ b/osdk/tools/run_container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ASTER_ROOT_DIR=${SCRIPT_DIR}/../..
+VERSION=$( cat ${ASTER_ROOT_DIR}/VERSION )
+IMAGE_NAME=asterinas/osdk:${VERSION}
+
+docker run -it -v ${ASTER_ROOT_DIR}:/root/asterinas ${IMAGE_NAME}


### PR DESCRIPTION
This PR makes the OSDK demos in Asterinas Book run successfully in the environment mentioned in User Guide.

After merging this PR, I think we can publish OSDK to crates.io.