### PR TITLE
Add workflow to update the website for the book automatically

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,42 @@
+name: Update Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container: asterinas/asterinas:0.4.0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'asterinas/asterinas'
+          path: 'asterinas'
+      
+      - name: Build the website
+        run: |
+          cd asterinas/docs
+          mdbook build
+
+      - name: Deploy website
+        env:
+          BOOK_PUBLISH_KEY: ${{ secrets.BOOK_PUBLISH_KEY }}
+        run: |
+          echo "$BOOK_PUBLISH_KEY " > ./book_publish_key
+          chmod 600 ./book_publish_key
+          ssh-keyscan -t rsa github.com >> ./known_hosts
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          GIT_SSH_COMMAND="ssh -i ./book_publish_key -o UserKnownHostsFile=./known_hosts" git clone git@github.com:asterinas/book.git temp_book
+          cd temp_book
+          git checkout --orphan newBranch
+          git add -A
+          git commit -am "Update website"
+          git branch -D main
+          git branch -m main
+          GIT_SSH_COMMAND="ssh -i ../book_publish_key -o UserKnownHostsFile=../known_hosts" git push -f origin main


### PR DESCRIPTION
This pull request allows updating the book once the `docs/` is updated. However, another setting should be applied to `asterinas/asterinas`:

- Enter `Settings -> Pages -> Build and deployment -> Branch`. 
- Select `gh-pages` and `Save`.
- Then you can access the book through `https://asterinas.github.io/asterinas/`.