### PR TITLE
Add asynchronous I/O support for page cache

### DIFF
--- a/kernel/aster-nix/src/fs/ext2/block_group.rs
+++ b/kernel/aster-nix/src/fs/ext2/block_group.rs
@@ -306,16 +306,14 @@ impl Debug for BlockGroup {
 }
 
 impl PageCacheBackend for BlockGroupImpl {
-    fn read_page(&self, idx: usize, frame: &VmFrame) -> Result<()> {
+    fn read_page(&self, idx: usize, frame: &VmFrame) -> Result<BioWaiter> {
         let bid = self.inode_table_bid + idx as u64;
-        self.fs.upgrade().unwrap().read_block(bid, frame)?;
-        Ok(())
+        self.fs.upgrade().unwrap().read_block_async(bid, frame)
     }
 
-    fn write_page(&self, idx: usize, frame: &VmFrame) -> Result<()> {
+    fn write_page(&self, idx: usize, frame: &VmFrame) -> Result<BioWaiter> {
         let bid = self.inode_table_bid + idx as u64;
-        self.fs.upgrade().unwrap().write_block(bid, frame)?;
-        Ok(())
+        self.fs.upgrade().unwrap().write_block_async(bid, frame)
     }
 
     fn npages(&self) -> usize {

--- a/kernel/aster-nix/src/fs/ext2/fs.rs
+++ b/kernel/aster-nix/src/fs/ext2/fs.rs
@@ -263,6 +263,12 @@ impl Ext2 {
         }
     }
 
+    /// Reads one block indicated by the `bid` asynchronously.
+    pub(super) fn read_block_async(&self, bid: Bid, frame: &VmFrame) -> Result<BioWaiter> {
+        let waiter = self.block_device.read_block(bid, frame)?;
+        Ok(waiter)
+    }
+
     /// Writes contiguous blocks starting from the `bid` synchronously.
     pub(super) fn write_blocks(&self, bid: Bid, segment: &VmSegment) -> Result<()> {
         let status = self.block_device.write_blocks_sync(bid, segment)?;
@@ -279,6 +285,12 @@ impl Ext2 {
             BioStatus::Complete => Ok(()),
             err_status => Err(Error::from(err_status)),
         }
+    }
+
+    /// Writes one block indicated by the `bid` asynchronously.
+    pub(super) fn write_block_async(&self, bid: Bid, frame: &VmFrame) -> Result<BioWaiter> {
+        let waiter = self.block_device.write_block(bid, frame)?;
+        Ok(waiter)
     }
 
     /// Writes back the metadata to the block device.

--- a/kernel/aster-nix/src/fs/ramfs/fs.rs
+++ b/kernel/aster-nix/src/fs/ramfs/fs.rs
@@ -5,6 +5,7 @@ use core::{
     time::Duration,
 };
 
+use aster_block::bio::BioWaiter;
 use aster_frame::{
     sync::RwLockWriteGuard,
     vm::{VmFrame, VmIo},
@@ -420,15 +421,15 @@ impl RamInode {
 }
 
 impl PageCacheBackend for RamInode {
-    fn read_page(&self, _idx: usize, frame: &VmFrame) -> Result<()> {
+    fn read_page(&self, _idx: usize, frame: &VmFrame) -> Result<BioWaiter> {
         // Initially, any block/page in a RamFs inode contains all zeros
         frame.writer().fill(0);
-        Ok(())
+        Ok(BioWaiter::new())
     }
 
-    fn write_page(&self, _idx: usize, _frame: &VmFrame) -> Result<()> {
+    fn write_page(&self, _idx: usize, _frame: &VmFrame) -> Result<BioWaiter> {
         // do nothing
-        Ok(())
+        Ok(BioWaiter::new())
     }
 
     fn npages(&self) -> usize {


### PR DESCRIPTION
Asynchronous I/O is crucial for enabling read-ahead in page caches and permits issuing multiple block I/O requests simultaneously, rather than sequentially. This improves the efficiency of our filesystems, particularly noticeable when dealing with a low queue depth.