### PR TITLE
 Fix many wrong error codes in TCP/UDP system calls

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -9,6 +9,7 @@ header:
       - '**/*.S'
       - '**/*.s'
       - '**/*.c'
+      - '**/*.h'
       - '**/*.sh'
       - '**/Makefile'
       - '**/Dockerfile.*'
@@ -58,4 +59,3 @@ header:
       content: |
         Licensed under the Apache License, Version 2.0 or the MIT License.
         Copyright (C) 2023-2024 Ant Group.
-  

--- a/kernel/aster-nix/src/net/iface/common.rs
+++ b/kernel/aster-nix/src/net/iface/common.rs
@@ -77,7 +77,7 @@ impl IfaceCommon {
                 return Ok(port);
             }
         }
-        return_errno_with_message!(Errno::EAGAIN, "cannot find unused high port");
+        return_errno_with_message!(Errno::EAGAIN, "no ephemeral port is available");
     }
 
     fn bind_port(&self, port: u16, can_reuse: bool) -> Result<()> {
@@ -86,7 +86,7 @@ impl IfaceCommon {
             if *used_times == 0 || can_reuse {
                 *used_times += 1;
             } else {
-                return_errno_with_message!(Errno::EADDRINUSE, "cannot bind port");
+                return_errno_with_message!(Errno::EADDRINUSE, "the address is already in use");
             }
         } else {
             used_ports.insert(port, 1);

--- a/kernel/aster-nix/src/net/iface/mod.rs
+++ b/kernel/aster-nix/src/net/iface/mod.rs
@@ -17,7 +17,7 @@ pub use any_socket::{
     AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket, RECV_BUF_LEN, SEND_BUF_LEN,
 };
 pub use loopback::IfaceLoopback;
-pub use smoltcp::wire::{EthernetAddress, IpAddress, IpEndpoint, IpListenEndpoint, Ipv4Address};
+pub use smoltcp::wire::{EthernetAddress, IpAddress, IpEndpoint, Ipv4Address};
 pub use util::{spawn_background_poll_thread, BindPortConfig};
 pub use virtio::IfaceVirtio;
 

--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
+use smoltcp::socket::udp::{RecvError, SendError};
 
 use crate::{
     events::IoEvents,
@@ -40,24 +41,39 @@ impl BoundDatagram {
         buf: &mut [u8],
         flags: SendRecvFlags,
     ) -> Result<(usize, IpEndpoint)> {
-        self.bound_socket
-            .raw_with(|socket: &mut RawUdpSocket| socket.recv_slice(buf))
-            .map_err(|_| Error::with_message(Errno::EAGAIN, "recv buf is empty"))
+        let result = self
+            .bound_socket
+            .raw_with(|socket: &mut RawUdpSocket| socket.recv_slice(buf));
+        match result {
+            Ok((recv_len, endpoint)) => Ok((recv_len, endpoint)),
+            Err(RecvError::Exhausted) => {
+                return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
+            }
+        }
     }
 
     pub fn try_sendto(
         &self,
         buf: &[u8],
-        remote: Option<IpEndpoint>,
+        remote: &IpEndpoint,
         flags: SendRecvFlags,
     ) -> Result<usize> {
-        let remote_endpoint = remote
-            .or(self.remote_endpoint)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "udp should provide remote addr"))?;
-        self.bound_socket
-            .raw_with(|socket: &mut RawUdpSocket| socket.send_slice(buf, remote_endpoint))
-            .map(|_| buf.len())
-            .map_err(|_| Error::with_message(Errno::EAGAIN, "send udp packet fails"))
+        let result = self.bound_socket.raw_with(|socket: &mut RawUdpSocket| {
+            if socket.payload_send_capacity() < buf.len() {
+                return None;
+            }
+            Some(socket.send_slice(buf, *remote))
+        });
+        match result {
+            Some(Ok(())) => Ok(buf.len()),
+            Some(Err(SendError::BufferFull)) => {
+                return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
+            }
+            Some(Err(SendError::Unaddressable)) => {
+                return_errno_with_message!(Errno::EINVAL, "the destionation address is invalid")
+            }
+            None => return_errno_with_message!(Errno::EMSGSIZE, "the message is too large"),
+        }
     }
 
     pub(super) fn init_pollee(&self, pollee: &Pollee) {

--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -27,9 +27,8 @@ impl BoundDatagram {
         self.bound_socket.local_endpoint().unwrap()
     }
 
-    pub fn remote_endpoint(&self) -> Result<IpEndpoint> {
+    pub fn remote_endpoint(&self) -> Option<IpEndpoint> {
         self.remote_endpoint
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "remote endpoint is not specified"))
     }
 
     pub fn set_remote_endpoint(&mut self, endpoint: &IpEndpoint) {

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -88,6 +88,15 @@ impl DatagramSocket {
         self.nonblocking.store(nonblocking, Ordering::SeqCst);
     }
 
+    fn remote_endpoint(&self) -> Option<IpEndpoint> {
+        let inner = self.inner.read();
+
+        match inner.as_ref() {
+            Inner::Bound(bound_datagram) => bound_datagram.remote_endpoint(),
+            Inner::Unbound(_) => None,
+        }
+    }
+
     fn try_bind_empheral(&self, remote_endpoint: &IpEndpoint) -> Result<()> {
         // Fast path
         if let Inner::Bound(_) = self.inner.read().as_ref() {
@@ -110,24 +119,23 @@ impl DatagramSocket {
 
     fn try_recvfrom(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
         let inner = self.inner.read();
+
         let Inner::Bound(bound_datagram) = inner.as_ref() else {
-            return_errno_with_message!(Errno::EINVAL, "the socket is not bound");
+            return_errno_with_message!(Errno::EAGAIN, "the socket is not bound");
         };
+
         let (recv_bytes, remote_endpoint) = bound_datagram.try_recvfrom(buf, flags)?;
         bound_datagram.update_io_events(&self.pollee);
         Ok((recv_bytes, remote_endpoint.into()))
     }
 
-    fn try_sendto(
-        &self,
-        buf: &[u8],
-        remote: Option<IpEndpoint>,
-        flags: SendRecvFlags,
-    ) -> Result<usize> {
+    fn try_sendto(&self, buf: &[u8], remote: &IpEndpoint, flags: SendRecvFlags) -> Result<usize> {
         let inner = self.inner.read();
+
         let Inner::Bound(bound_datagram) = inner.as_ref() else {
-            return_errno_with_message!(Errno::EINVAL, "the socket is not bound");
+            return_errno_with_message!(Errno::EAGAIN, "the socket is not bound")
         };
+
         let sent_bytes = bound_datagram.try_sendto(buf, remote, flags)?;
         bound_datagram.update_io_events(&self.pollee);
         Ok(sent_bytes)
@@ -244,12 +252,7 @@ impl Socket for DatagramSocket {
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
-        let inner = self.inner.read();
-        let Inner::Bound(bound_datagram) = inner.as_ref() else {
-            return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected")
-        };
-        bound_datagram
-            .remote_endpoint()
+        self.remote_endpoint()
             .map(|endpoint| endpoint.into())
             .ok_or_else(|| Error::with_message(Errno::ENOTCONN, "the socket is not connected"))
     }
@@ -275,15 +278,21 @@ impl Socket for DatagramSocket {
         debug_assert!(flags.is_all_supported());
 
         let remote_endpoint = match remote {
-            Some(remote_addr) => Some(remote_addr.try_into()?),
-            None => None,
+            Some(remote_addr) => {
+                let endpoint = remote_addr.try_into()?;
+                self.try_bind_empheral(&endpoint)?;
+                endpoint
+            }
+            None => self.remote_endpoint().ok_or_else(|| {
+                Error::with_message(
+                    Errno::EDESTADDRREQ,
+                    "the destination address is not specified",
+                )
+            })?,
         };
-        if let Some(endpoint) = remote_endpoint {
-            self.try_bind_empheral(&endpoint)?;
-        }
 
         // TODO: Block if the send buffer is full
-        let sent_bytes = self.try_sendto(buf, remote_endpoint, flags)?;
+        let sent_bytes = self.try_sendto(buf, &remote_endpoint, flags)?;
         poll_ifaces();
         Ok(sent_bytes)
     }

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -115,7 +115,7 @@ impl DatagramSocket {
         };
         let (recv_bytes, remote_endpoint) = bound_datagram.try_recvfrom(buf, flags)?;
         bound_datagram.update_io_events(&self.pollee);
-        Ok((recv_bytes, remote_endpoint.try_into()?))
+        Ok((recv_bytes, remote_endpoint.into()))
     }
 
     fn try_sendto(
@@ -240,7 +240,7 @@ impl Socket for DatagramSocket {
         let Inner::Bound(bound_datagram) = inner.as_ref() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is not bound");
         };
-        bound_datagram.local_endpoint().try_into()
+        Ok(bound_datagram.local_endpoint().into())
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -248,7 +248,7 @@ impl Socket for DatagramSocket {
         let Inner::Bound(bound_datagram) = inner.as_ref() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is not bound");
         };
-        bound_datagram.remote_endpoint()?.try_into()
+        Ok(bound_datagram.remote_endpoint()?.into())
     }
 
     // FIXME: respect RecvFromFlags

--- a/kernel/aster-nix/src/net/socket/ip/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/mod.rs
@@ -1,8 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::net::iface::{IpAddress, IpEndpoint, Ipv4Address};
+
 mod common;
 mod datagram;
 pub mod stream;
 
 pub use datagram::DatagramSocket;
 pub use stream::StreamSocket;
+
+/// A local endpoint, which indicates that the local endpoint is unspecified.
+///
+/// According to the Linux man pages and the Linux implementation, `getsockname()` will _not_ fail
+/// even if the socket is unbound. Instead, it will return an unspecified socket address. This
+/// unspecified endpoint helps with that.
+const UNSPECIFIED_LOCAL_ENDPOINT: IpEndpoint =
+    IpEndpoint::new(IpAddress::Ipv4(Ipv4Address::UNSPECIFIED), 0);

--- a/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -2,6 +2,8 @@
 
 use alloc::sync::Weak;
 
+use smoltcp::socket::tcp::{RecvError, SendError};
+
 use crate::{
     events::{IoEvents, Observer},
     net::{
@@ -34,25 +36,33 @@ impl ConnectedStream {
     }
 
     pub fn try_recvfrom(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<usize> {
-        let recv_bytes = self
+        let result = self
             .bound_socket
-            .raw_with(|socket: &mut RawTcpSocket| socket.recv_slice(buf))
-            .map_err(|_| Error::with_message(Errno::ENOTCONN, "fail to recv packet"))?;
-        if recv_bytes == 0 {
-            return_errno_with_message!(Errno::EAGAIN, "try to recv again");
+            .raw_with(|socket: &mut RawTcpSocket| socket.recv_slice(buf));
+        match result {
+            Ok(0) => return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty"),
+            Ok(recv_bytes) => Ok(recv_bytes),
+            Err(RecvError::Finished) => Ok(0),
+            Err(RecvError::InvalidState) => {
+                return_errno_with_message!(Errno::ECONNRESET, "the connection is reset")
+            }
         }
-        Ok(recv_bytes)
     }
 
     pub fn try_sendto(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
-        let sent_bytes = self
+        let result = self
             .bound_socket
-            .raw_with(|socket: &mut RawTcpSocket| socket.send_slice(buf))
-            .map_err(|_| Error::with_message(Errno::ENOBUFS, "cannot send packet"))?;
-        if sent_bytes == 0 {
-            return_errno_with_message!(Errno::EAGAIN, "try to send again");
+            .raw_with(|socket: &mut RawTcpSocket| socket.send_slice(buf));
+        match result {
+            Ok(0) => return_errno_with_message!(Errno::EAGAIN, "the send buffer is full"),
+            Ok(sent_bytes) => Ok(sent_bytes),
+            Err(SendError::InvalidState) => {
+                // FIXME: `EPIPE` is another possibility, which means that the socket is shut down
+                // for writing. In that case, we should also trigger a `SIGPIPE` if `MSG_NOSIGNAL`
+                // is not specified.
+                return_errno_with_message!(Errno::ECONNRESET, "the connection is reset");
+            }
         }
-        Ok(sent_bytes)
     }
 
     pub fn local_endpoint(&self) -> IpEndpoint {

--- a/kernel/aster-nix/src/net/socket/ip/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/init.rs
@@ -83,12 +83,10 @@ impl InitStream {
             .map_err(|(err, bound_socket)| (err, InitStream::Bound(bound_socket)))
     }
 
-    pub fn local_endpoint(&self) -> Result<IpEndpoint> {
+    pub fn local_endpoint(&self) -> Option<IpEndpoint> {
         match self {
-            InitStream::Unbound(_) => {
-                return_errno_with_message!(Errno::EINVAL, "does not has local endpoint")
-            }
-            InitStream::Bound(bound_socket) => Ok(bound_socket.local_endpoint().unwrap()),
+            InitStream::Unbound(_) => None,
+            InitStream::Bound(bound_socket) => Some(bound_socket.local_endpoint().unwrap()),
         }
     }
 

--- a/kernel/aster-nix/src/net/socket/ip/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/init.rs
@@ -73,8 +73,11 @@ impl InitStream {
 
     pub fn listen(self, backlog: usize) -> core::result::Result<ListenStream, (Error, Self)> {
         let InitStream::Bound(bound_socket) = self else {
+            // FIXME: The socket should be bound to INADDR_ANY (i.e., 0.0.0.0) with an ephemeral
+            // port. However, INADDR_ANY is not yet supported, so we need to return an error first.
+            debug_assert!(false, "listen() without bind() is not implemented");
             return Err((
-                Error::with_message(Errno::EINVAL, "cannot listen without bound"),
+                Error::with_message(Errno::EINVAL, "listen() without bind() is not implemented"),
                 self,
             ));
         };

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -177,7 +177,7 @@ impl StreamSocket {
 
         let remote_endpoint = connected_stream.remote_endpoint();
         let accepted_socket = Self::new_connected(connected_stream);
-        Ok((accepted_socket, remote_endpoint.try_into()?))
+        Ok((accepted_socket, remote_endpoint.into()))
     }
 
     fn try_recvfrom(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
@@ -188,7 +188,7 @@ impl StreamSocket {
         };
         let recv_bytes = connected_stream.try_recvfrom(buf, flags)?;
         connected_stream.update_io_events(&self.pollee);
-        Ok((recv_bytes, connected_stream.remote_endpoint().try_into()?))
+        Ok((recv_bytes, connected_stream.remote_endpoint().into()))
     }
 
     fn try_sendto(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
@@ -390,7 +390,7 @@ impl Socket for StreamSocket {
             State::Listen(listen_stream) => listen_stream.local_endpoint(),
             State::Connected(connected_stream) => connected_stream.local_endpoint(),
         };
-        local_endpoint.try_into()
+        Ok(local_endpoint.into())
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -405,7 +405,7 @@ impl Socket for StreamSocket {
             }
             State::Connected(connected_stream) => connected_stream.remote_endpoint(),
         };
-        remote_endpoint.try_into()
+        Ok(remote_endpoint.into())
     }
 
     fn recvfrom(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {

--- a/kernel/aster-nix/src/net/socket/mod.rs
+++ b/kernel/aster-nix/src/net/socket/mod.rs
@@ -16,53 +16,53 @@ mod util;
 pub trait Socket: FileLike + Send + Sync {
     /// Assign the address specified by socket_addr to the socket
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "bind not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "bind() is not supported");
     }
 
     /// Build connection for a given address
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "connect not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "connect() is not supported");
     }
 
     /// Listen for connections on a socket
     fn listen(&self, backlog: usize) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "connect not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "connect() is not supported");
     }
 
     /// Accept a connection on a socket
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        return_errno_with_message!(Errno::EINVAL, "accept not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "accept() is not supported");
     }
 
     /// Shut down part of a full-duplex connection
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "shutdown not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "shutdown() is not supported");
     }
 
     /// Get address of this socket.
     fn addr(&self) -> Result<SocketAddr> {
-        return_errno_with_message!(Errno::EINVAL, "getsockname not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "getsockname() is not supported");
     }
 
     /// Get address of peer socket
     fn peer_addr(&self) -> Result<SocketAddr> {
-        return_errno_with_message!(Errno::EINVAL, "getpeername not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "getpeername() is not supported");
     }
 
     /// Get options on the socket. The resulted option will put in the `option` parameter, if
     /// this method returns success.
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "getsockopt not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "getsockopt() is not supported");
     }
 
     /// Set options on the socket.
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "setsockopt not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "setsockopt() is not supported");
     }
 
     /// Receive a message from a socket
     fn recvfrom(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
-        return_errno_with_message!(Errno::EINVAL, "recvfrom not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "recvfrom() is not supported");
     }
 
     /// Send a message on a socket
@@ -72,6 +72,6 @@ pub trait Socket: FileLike + Send + Sync {
         remote: Option<SocketAddr>,
         flags: SendRecvFlags,
     ) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "recvfrom not implemented");
+        return_errno_with_message!(Errno::EOPNOTSUPP, "recvfrom() is not supported");
     }
 }

--- a/kernel/aster-nix/src/net/socket/util/socket_addr.rs
+++ b/kernel/aster-nix/src/net/socket/util/socket_addr.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     net::{
-        iface::{IpAddress, IpEndpoint, IpListenEndpoint, Ipv4Address},
+        iface::{IpAddress, IpEndpoint, Ipv4Address},
         socket::unix::UnixSocketAddr,
     },
     prelude::*,
@@ -24,34 +24,19 @@ impl TryFrom<SocketAddr> for IpEndpoint {
         match value {
             SocketAddr::IPv4(addr, port) => Ok(IpEndpoint::new(addr.into_address(), port)),
             _ => return_errno_with_message!(
-                Errno::EINVAL,
-                "sock addr cannot be converted as IpEndpoint"
+                Errno::EAFNOSUPPORT,
+                "the address is in an unsupported address family"
             ),
         }
     }
 }
 
-impl TryFrom<IpEndpoint> for SocketAddr {
-    type Error = Error;
-
-    fn try_from(endpoint: IpEndpoint) -> Result<Self> {
+impl From<IpEndpoint> for SocketAddr {
+    fn from(endpoint: IpEndpoint) -> Self {
         let port = endpoint.port;
-        let socket_addr = match endpoint.addr {
-            IpAddress::Ipv4(addr) => SocketAddr::IPv4(addr, port), // TODO: support IPv6
-        };
-        Ok(socket_addr)
-    }
-}
-
-impl TryFrom<IpListenEndpoint> for SocketAddr {
-    type Error = Error;
-
-    fn try_from(value: IpListenEndpoint) -> Result<Self> {
-        let port = value.port;
-        let socket_addr = match value.addr {
-            None => return_errno_with_message!(Errno::EINVAL, "address is unspecified"),
-            Some(IpAddress::Ipv4(address)) => SocketAddr::IPv4(address, port),
-        };
-        Ok(socket_addr)
+        match endpoint.addr {
+            IpAddress::Ipv4(addr) => SocketAddr::IPv4(addr, port),
+            // TODO: support IPv6
+        }
     }
 }

--- a/regression/apps/network/tcp_err.c
+++ b/regression/apps/network/tcp_err.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <unistd.h>
+#include <sys/signal.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "test.h"
+
+static struct sockaddr_in sk_addr;
+
+#define C_PORT htons(0x1234)
+#define S_PORT htons(0x1235)
+
+FN_SETUP(general)
+{
+	sk_addr.sin_family = AF_INET;
+	sk_addr.sin_port = htons(8080);
+	CHECK(inet_aton("127.0.0.1", &sk_addr.sin_addr));
+
+	signal(SIGPIPE, SIG_IGN);
+}
+END_SETUP()
+
+static int sk_unbound;
+static int sk_bound;
+static int sk_listen;
+static int sk_connected;
+static int sk_accepted;
+
+FN_SETUP(unbound)
+{
+	sk_unbound = CHECK(socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0));
+}
+END_SETUP()
+
+FN_SETUP(bound)
+{
+	sk_bound = CHECK(socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0));
+
+	sk_addr.sin_port = C_PORT;
+	CHECK(bind(sk_bound, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+}
+END_SETUP()
+
+FN_SETUP(listen)
+{
+	sk_listen = CHECK(socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0));
+
+	sk_addr.sin_port = S_PORT;
+	CHECK(bind(sk_listen, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+
+	CHECK(listen(sk_listen, 2));
+}
+END_SETUP()
+
+FN_SETUP(connected)
+{
+	sk_connected = CHECK(socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0));
+
+	sk_addr.sin_port = S_PORT;
+	CHECK_WITH(connect(sk_connected, (struct sockaddr *)&sk_addr,
+			   sizeof(sk_addr)),
+		   _ret == 0 || errno == EINPROGRESS);
+}
+END_SETUP()
+
+FN_SETUP(accpected)
+{
+	struct sockaddr addr;
+	socklen_t addrlen = sizeof(addr);
+
+	do {
+		sk_accepted = CHECK_WITH(accept(sk_listen, &addr, &addrlen),
+					 _ret >= 0 || errno == EAGAIN);
+	} while (sk_accepted < 0);
+}
+END_SETUP()

--- a/regression/apps/network/tcp_err.c
+++ b/regression/apps/network/tcp_err.c
@@ -181,3 +181,48 @@ FN_TEST(send_and_recv)
 	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
 }
 END_TEST()
+
+FN_TEST(bind)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_ERRNO(bind(sk_bound, psaddr, addrlen), EINVAL);
+
+	TEST_ERRNO(bind(sk_listen, psaddr, addrlen), EINVAL);
+
+	TEST_ERRNO(bind(sk_connected, psaddr, addrlen), EINVAL);
+
+	TEST_ERRNO(bind(sk_accepted, psaddr, addrlen), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listen)
+{
+	// The second `listen` does nothing but succeed.
+	// TODO: Will it update the backlog?
+	TEST_SUCC(listen(sk_listen, 2));
+
+	TEST_ERRNO(listen(sk_connected, 2), EINVAL);
+
+	TEST_ERRNO(listen(sk_accepted, 2), EINVAL);
+}
+END_TEST()
+
+FN_TEST(accept)
+{
+	struct sockaddr_in saddr;
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_ERRNO(accept(sk_unbound, psaddr, &addrlen), EINVAL);
+
+	TEST_ERRNO(accept(sk_bound, psaddr, &addrlen), EINVAL);
+
+	TEST_ERRNO(accept(sk_listen, psaddr, &addrlen), EAGAIN);
+
+	TEST_ERRNO(accept(sk_connected, psaddr, &addrlen), EINVAL);
+
+	TEST_ERRNO(accept(sk_accepted, psaddr, &addrlen), EINVAL);
+}
+END_TEST()

--- a/regression/apps/network/test.h
+++ b/regression/apps/network/test.h
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/*
+ * A framework for writing regression tests.
+ *
+ * A regression test typically consists of two parts, the setup part and the
+ * test part. The setup part contains setup functions that set up the context
+ * for the subsequent tests to run. The setup functions cannot fail, and if they
+ * do, execution is aborted because the subsequent tests will not work as
+ * expected either. The test functions, on the other hand, can fail, and if they
+ * do, they are reported as test failures.
+ *
+ * The framework provides basic utilities for writing regression tests:
+ *
+ *  - To define a setup function or a test function, FN_SETUP() or FN_TEST() can
+ * be used. These functions are automatically executed in the order of their
+ * definiton. Note that the order of execution is _not_ related to whether a
+ * function is a setup function or a test function.
+ *
+ *  - Within a setup function, CHECK() can be used to write a setup expression
+ * that must succeed. If the expression fails, a fatal error will be reported
+ * and the execution will be aborted.
+ *
+ *  - Within a test function, TEST_SUCC() can be used to write a test expression
+ * that should succeed. If the expression fails, a test failure will be reported
+ * but the execution will continue.
+ *
+ *  - The number of successful and failed tests is tracked. When a test function
+ * finishes, a summary sentence is printed describing the number of test
+ * failures. The program will exit with a non-zero code if and only if there is
+ * at least one test failure.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Starts the definition of a setup function. */
+#define FN_SETUP(name)                                                        \
+	void setup_##name(void) __attribute__((constructor(__LINE__ + 200))); \
+                                                                              \
+	void setup_##name(void)                                               \
+	{
+/** Ends the definition of a setup function. */
+#define END_SETUP() }
+
+#define __CHECK(func, cond)                                                   \
+	errno = 0;                                                            \
+	long _ret = (func);                                                   \
+	if (!(cond)) {                                                        \
+		fprintf(stderr,                                               \
+			"fatal error: %s: `" #cond "` is false after `" #func \
+			"` [got %s]\n",                                       \
+			__func__, strerror(errno));                           \
+		exit(EXIT_FAILURE);                                           \
+	}
+
+/**
+ * Makes a fucntion call and checks its return value is positive.
+ *
+ * The execution will be aborted if the check fails.
+ */
+#define CHECK(func)                       \
+	({                                \
+		__CHECK(func, _ret >= 0); \
+		_ret;                     \
+	})
+
+/**
+ * Makes a function call and checks its result with the specified condition.
+ *
+ * The execution will be aborted if the check fails.
+ *
+ * The return value of the function can be accessed with a local variable named
+ * _ret.
+ */
+#define CHECK_WITH(func, cond)       \
+	({                           \
+		__CHECK(func, cond); \
+		_ret;                \
+	})
+
+static int __total_failures;
+
+/** Starts the definition of a test function. */
+#define FN_TEST(name)                                                        \
+	void test_##name(void) __attribute__((constructor(__LINE__ + 200))); \
+                                                                             \
+	void test_##name(void)                                               \
+	{                                                                    \
+		int __tests_passed = 0, __tests_failed = 0;
+
+/** Ends the definition of a test function. */
+#define END_TEST()                                                        \
+	fprintf(stderr, "%s summary: %d tests passed, %d tests failed\n", \
+		__func__, __tests_passed, __tests_failed);                \
+	__total_failures += __tests_failed;                               \
+	}
+
+#define __TEST(func, err, cond)                                                \
+	errno = 0;                                                             \
+	long _ret = (func);                                                    \
+	if (errno != (err)) {                                                  \
+		__tests_failed++;                                              \
+		fprintf(stderr,                                                \
+			"%s: `" #func "` failed [got %s, but expected %s]\n",  \
+			__func__, strerror(errno), strerror(err));             \
+	} else if (!(cond)) {                                                  \
+		__tests_failed++;                                              \
+		fprintf(stderr,                                                \
+			"%s: `" #func "` failed [got %s, but `" #cond          \
+			"` is false]\n",                                       \
+			__func__, strerror(errno));                            \
+	} else {                                                               \
+		__tests_passed++;                                              \
+		fprintf(stderr, "%s: `" #func "` passed [got %s]\n", __func__, \
+			strerror(errno));                                      \
+	}
+
+/**
+ * Makes a function call and checks its result.
+ *
+ * A test failure will be reported if the function does not set the specified
+ * errno or the specified condition does not meet.
+ *
+ * The return value of the function can be accessed with a local variable named
+ * _ret.
+ */
+#define TEST(func, err, cond)            \
+	({                               \
+		__TEST(func, err, cond); \
+		_ret;                    \
+	})
+/**
+ * Makes a function call and checks whether it succeeds.
+ *
+ * A test failure will be reported if the function sets a non-zero errno.
+ */
+#define TEST_SUCC(func) TEST(func, 0, 1)
+
+/**
+ * Makes a function call and checks whether it fails in the specified way.
+ *
+ * A test failure will be reported if the function does not set the specified
+ * errno.
+ */
+#define TEST_ERRNO(func, err) TEST(func, err, 1)
+
+/**
+ * Makes a function call and checks whether it produces expected results.
+ *
+ * A test failure will be reported if the function sets a non-zero errno or the
+ * specified condition does not meet.
+ *
+ * The return value of the function can be accessed with a local variable named
+ * _ret.
+ */
+#define TEST_RES(func, cond) TEST(func, 0, cond)
+
+int main(void)
+{
+	return __total_failures ? 1 : 0;
+}

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -50,3 +50,35 @@ FN_SETUP(connected)
 		      sizeof(sk_addr)));
 }
 END_SETUP()
+
+FN_TEST(getsockname)
+{
+	struct sockaddr_in saddr = { .sin_port = 0xbeef };
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_RES(getsockname(sk_unbound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.sin_port == 0);
+
+	TEST_RES(getsockname(sk_bound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.sin_port == C_PORT);
+
+	TEST_RES(getsockname(sk_connected, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.sin_port != C_PORT);
+}
+END_TEST()
+
+FN_TEST(getpeername)
+{
+	struct sockaddr_in saddr = { .sin_port = 0xbeef };
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_ERRNO(getpeername(sk_unbound, psaddr, &addrlen), ENOTCONN);
+
+	TEST_ERRNO(getpeername(sk_bound, psaddr, &addrlen), ENOTCONN);
+
+	TEST_RES(getpeername(sk_connected, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.sin_port == C_PORT);
+}
+END_TEST()

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <unistd.h>
+#include <sys/signal.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "test.h"
+
+static struct sockaddr_in sk_addr;
+
+#define C_PORT htons(0x1234)
+
+FN_SETUP(general)
+{
+	sk_addr.sin_family = AF_INET;
+	sk_addr.sin_port = htons(8080);
+	CHECK(inet_aton("127.0.0.1", &sk_addr.sin_addr));
+
+	signal(SIGPIPE, SIG_IGN);
+}
+END_SETUP()
+
+static int sk_unbound;
+static int sk_bound;
+static int sk_connected;
+
+FN_SETUP(unbound)
+{
+	sk_unbound = CHECK(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+}
+END_SETUP()
+
+FN_SETUP(bound)
+{
+	sk_bound = CHECK(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+
+	sk_addr.sin_port = C_PORT;
+	CHECK(bind(sk_bound, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+}
+END_SETUP()
+
+FN_SETUP(connected)
+{
+	sk_connected = CHECK(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+
+	sk_addr.sin_port = C_PORT;
+	CHECK(connect(sk_connected, (struct sockaddr *)&sk_addr,
+		      sizeof(sk_addr)));
+}
+END_SETUP()

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -135,3 +135,38 @@ FN_TEST(send_and_recv)
 			 saddr.sin_port != C_PORT && buf[0] == 'b');
 }
 END_TEST()
+
+FN_TEST(bind)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_ERRNO(bind(sk_bound, psaddr, addrlen), EINVAL);
+
+	TEST_ERRNO(bind(sk_connected, psaddr, addrlen), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listen)
+{
+	TEST_ERRNO(listen(sk_unbound, 2), EOPNOTSUPP);
+
+	TEST_ERRNO(listen(sk_bound, 2), EOPNOTSUPP);
+
+	TEST_ERRNO(listen(sk_connected, 2), EOPNOTSUPP);
+}
+END_TEST()
+
+FN_TEST(accept)
+{
+	struct sockaddr_in saddr;
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_ERRNO(accept(sk_unbound, psaddr, &addrlen), EOPNOTSUPP);
+
+	TEST_ERRNO(accept(sk_bound, psaddr, &addrlen), EOPNOTSUPP);
+
+	TEST_ERRNO(accept(sk_connected, psaddr, &addrlen), EOPNOTSUPP);
+}
+END_TEST()

--- a/regression/apps/scripts/network.sh
+++ b/regression/apps/scripts/network.sh
@@ -21,5 +21,7 @@ echo "Start network test......"
 # ./send_buf_full
 ./http_server &
 ./http_client
+./tcp_err
+./udp_err
 
 echo "All network test passed"


### PR DESCRIPTION
Reopening https://github.com/asterinas/asterinas/pull/584.

This PR introduces a framework for writing regression tests:
```c
/*
 * A framework for writing regression tests.
 *
 * A regression test typically consists of two parts, the setup part and the
 * test part. The setup part contains setup functions that set up the context
 * for the subsequent tests to run. The setup functions cannot fail, and if they
 * do, execution is aborted because the subsequent tests will not work as
 * expected either. The test functions, on the other hand, can fail, and if they
 * do, they are reported as test failures.
 *
 * The framework provides basic utilities for writing regression tests:
 *
 *  - To define a setup function or a test function, FN_SETUP() or FN_TEST() can
 * be used. These functions are automatically executed in the order of their
 * definiton. Note that the order of execution is _not_ related to whether a
 * function is a setup function or a test function.
 *
 *  - Within a setup function, CHECK() can be used to write a setup expression
 * that must succeed. If the expression fails, a fatal error will be reported
 * and the execution will be aborted.
 *
 *  - Within a test function, TEST_SUCC() can be used to write a test expression
 * that should succeed. If the expression fails, a test failure will be reported
 * but the execution will continue.
 *
 *  - The number of successful and failed tests is tracked. When a test function
 * finishes, a summary sentence is printed describing the number of test
 * failures. The program will exit with a non-zero code if and only if there is
 * at least one test failure.
 */
```

Based on the regression framework, this PR fixes a number of wrong error codes in TCP/UDP system calls and adds regression tests for them.