### PR TITLE
Implement non-blocking behavior for TCP `connect()`

### DIFF
--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -72,6 +72,7 @@ impl DatagramSocket {
         Arc::new_cyclic(|me| {
             let unbound_datagram = UnboundDatagram::new(me.clone() as _);
             let pollee = Pollee::new(IoEvents::empty());
+            unbound_datagram.init_pollee(&pollee);
             Self {
                 inner: RwLock::new(Takeable::new(Inner::Unbound(unbound_datagram))),
                 nonblocking: AtomicBool::new(nonblocking),

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -210,6 +210,24 @@ impl FileLike for DatagramSocket {
         }
         Ok(())
     }
+
+    fn register_observer(
+        &self,
+        observer: Weak<dyn Observer<IoEvents>>,
+        mask: IoEvents,
+    ) -> Result<()> {
+        self.pollee.register_observer(observer, mask);
+        Ok(())
+    }
+
+    fn unregister_observer(
+        &self,
+        observer: &Weak<dyn Observer<IoEvents>>,
+    ) -> Result<Weak<dyn Observer<IoEvents>>> {
+        self.pollee
+            .unregister_observer(observer)
+            .ok_or_else(|| Error::with_message(Errno::ENOENT, "observer is not registered"))
+    }
 }
 
 impl Socket for DatagramSocket {

--- a/kernel/aster-nix/src/net/socket/ip/datagram/unbound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/unbound.rs
@@ -4,12 +4,13 @@ use alloc::sync::Weak;
 
 use super::bound::BoundDatagram;
 use crate::{
-    events::Observer,
+    events::{IoEvents, Observer},
     net::{
         iface::{AnyUnboundSocket, IpEndpoint, RawUdpSocket},
         socket::ip::common::bind_socket,
     },
     prelude::*,
+    process::signal::Pollee,
 };
 
 pub struct UnboundDatagram {
@@ -35,5 +36,10 @@ impl UnboundDatagram {
         });
 
         Ok(BoundDatagram::new(bound_socket))
+    }
+
+    pub(super) fn init_pollee(&self, pollee: &Pollee) {
+        pollee.reset_events();
+        pollee.add_events(IoEvents::OUT);
     }
 }

--- a/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -78,26 +78,6 @@ impl ConnectedStream {
         self.update_io_events(pollee);
     }
 
-    pub fn register_observer(
-        &self,
-        pollee: &Pollee,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub fn unregister_observer(
-        &self,
-        pollee: &Pollee,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "fails to unregister observer"))
-    }
-
     pub(super) fn update_io_events(&self, pollee: &Pollee) {
         self.bound_socket.raw_with(|socket: &mut RawTcpSocket| {
             if socket.can_recv() {

--- a/kernel/aster-nix/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connecting.rs
@@ -2,7 +2,7 @@
 
 use super::{connected::ConnectedStream, init::InitStream};
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     net::iface::{AnyBoundSocket, IpEndpoint, RawTcpSocket},
     prelude::*,
     process::signal::Pollee,
@@ -69,26 +69,6 @@ impl ConnectingStream {
     pub(super) fn init_pollee(&self, pollee: &Pollee) {
         pollee.reset_events();
         self.update_io_events(pollee);
-    }
-
-    pub fn register_observer(
-        &self,
-        pollee: &Pollee,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub fn unregister_observer(
-        &self,
-        pollee: &Pollee,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "fails to unregister observer"))
     }
 
     pub(super) fn update_io_events(&self, pollee: &Pollee) {

--- a/kernel/aster-nix/src/net/socket/ip/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/init.rs
@@ -4,13 +4,12 @@ use alloc::sync::Weak;
 
 use super::{connecting::ConnectingStream, listen::ListenStream};
 use crate::{
-    events::{IoEvents, Observer},
+    events::Observer,
     net::{
         iface::{AnyBoundSocket, AnyUnboundSocket, IpEndpoint},
         socket::ip::common::{bind_socket, get_ephemeral_endpoint},
     },
     prelude::*,
-    process::signal::Pollee,
 };
 
 pub enum InitStream {
@@ -91,25 +90,5 @@ impl InitStream {
             InitStream::Unbound(_) => None,
             InitStream::Bound(bound_socket) => Some(bound_socket.local_endpoint().unwrap()),
         }
-    }
-
-    pub fn register_observer(
-        &self,
-        pollee: &Pollee,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub fn unregister_observer(
-        &self,
-        pollee: &Pollee,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "fails to unregister observer"))
     }
 }

--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -72,6 +72,7 @@ impl ListenStream {
         Ok(ConnectedStream::new(
             active_backlog_socket.into_bound_socket(),
             remote_endpoint,
+            false,
         ))
     }
 

--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -3,7 +3,7 @@ use smoltcp::socket::tcp::ListenError;
 
 use super::connected::ConnectedStream;
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     net::iface::{AnyBoundSocket, AnyUnboundSocket, BindPortConfig, IpEndpoint, RawTcpSocket},
     prelude::*,
     process::signal::Pollee,
@@ -94,26 +94,6 @@ impl ListenStream {
         } else {
             pollee.del_events(IoEvents::IN);
         }
-    }
-
-    pub fn register_observer(
-        &self,
-        pollee: &Pollee,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub fn unregister_observer(
-        &self,
-        pollee: &Pollee,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "fails to unregister observer"))
     }
 }
 

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -82,6 +82,7 @@ impl StreamSocket {
         Arc::new_cyclic(|me| {
             let init_stream = InitStream::new(me.clone() as _);
             let pollee = Pollee::new(IoEvents::empty());
+            init_stream.init_pollee(&pollee);
             Self {
                 options: RwLock::new(OptionSet::new()),
                 state: RwLock::new(Takeable::new(State::Init(init_stream))),
@@ -154,6 +155,7 @@ impl StreamSocket {
             let connected_stream = match connecting_stream.into_result() {
                 Ok(connected_stream) => connected_stream,
                 Err((err, NonConnectedStream::Init(init_stream))) => {
+                    init_stream.init_pollee(&self.pollee);
                     return (State::Init(init_stream), Err(err));
                 }
                 Err((err, NonConnectedStream::Connecting(connecting_stream))) => {

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -296,32 +296,20 @@ impl FileLike for StreamSocket {
 
     fn register_observer(
         &self,
-        observer: Weak<dyn crate::events::Observer<IoEvents>>,
+        observer: Weak<dyn Observer<IoEvents>>,
         mask: IoEvents,
     ) -> Result<()> {
-        let state = self.state.read();
-        match state.as_ref() {
-            State::Init(init) => init.register_observer(&self.pollee, observer, mask),
-            State::Connecting(connecting) => {
-                connecting.register_observer(&self.pollee, observer, mask)
-            }
-            State::Connected(connected) => {
-                connected.register_observer(&self.pollee, observer, mask)
-            }
-            State::Listen(listen) => listen.register_observer(&self.pollee, observer, mask),
-        }
+        self.pollee.register_observer(observer, mask);
+        Ok(())
     }
 
     fn unregister_observer(
         &self,
-        observer: &Weak<dyn crate::events::Observer<IoEvents>>,
-    ) -> Result<Weak<dyn crate::events::Observer<IoEvents>>> {
-        match self.state.read().as_ref() {
-            State::Init(init) => init.unregister_observer(&self.pollee, observer),
-            State::Connecting(connecting) => connecting.unregister_observer(&self.pollee, observer),
-            State::Connected(connected) => connected.unregister_observer(&self.pollee, observer),
-            State::Listen(listen) => listen.unregister_observer(&self.pollee, observer),
-        }
+        observer: &Weak<dyn Observer<IoEvents>>,
+    ) -> Result<Weak<dyn Observer<IoEvents>>> {
+        self.pollee
+            .unregister_observer(observer)
+            .ok_or_else(|| Error::with_message(Errno::ENOENT, "observer is not registered"))
     }
 }
 

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -114,26 +114,61 @@ impl StreamSocket {
         self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
     }
 
-    fn start_connect(&self, remote_endpoint: &IpEndpoint) -> Result<()> {
+    // Returns `None` to block the task and wait for the connection to be established, and returns
+    // `Some(_)` if blocking is not necessary or not allowed.
+    fn start_connect(&self, remote_endpoint: &IpEndpoint) -> Option<Result<()>> {
+        let is_nonblocking = self.is_nonblocking();
         let mut state = self.state.write();
 
-        state.borrow_result(|owned_state| {
-            let State::Init(init_stream) = owned_state else {
-                return (
-                    owned_state,
-                    Err(Error::with_message(Errno::EINVAL, "cannot connect")),
-                );
+        state.borrow_result(|mut owned_state| {
+            let init_stream = match owned_state {
+                State::Init(init_stream) => init_stream,
+                State::Connecting(_) if is_nonblocking => {
+                    return (
+                        owned_state,
+                        Some(Err(Error::with_message(
+                            Errno::EALREADY,
+                            "the socket is connecting",
+                        ))),
+                    );
+                }
+                State::Connecting(_) => {
+                    return (owned_state, None);
+                }
+                State::Connected(ref mut connected_stream) => {
+                    let err = connected_stream.check_new();
+                    return (owned_state, Some(err));
+                }
+                State::Listen(_) => {
+                    return (
+                        owned_state,
+                        Some(Err(Error::with_message(
+                            Errno::EISCONN,
+                            "the socket is listening",
+                        ))),
+                    );
+                }
             };
 
             let connecting_stream = match init_stream.connect(remote_endpoint) {
                 Ok(connecting_stream) => connecting_stream,
                 Err((err, init_stream)) => {
-                    return (State::Init(init_stream), Err(err));
+                    return (State::Init(init_stream), Some(Err(err)));
                 }
             };
             connecting_stream.init_pollee(&self.pollee);
 
-            (State::Connecting(connecting_stream), Ok(()))
+            (
+                State::Connecting(connecting_stream),
+                if is_nonblocking {
+                    Some(Err(Error::with_message(
+                        Errno::EINPROGRESS,
+                        "the socket is connecting",
+                    )))
+                } else {
+                    None
+                },
+            )
         })
     }
 
@@ -166,6 +201,21 @@ impl StreamSocket {
 
             (State::Connected(connected_stream), Ok(()))
         })
+    }
+
+    fn check_connect(&self) -> Result<()> {
+        let mut state = self.state.write();
+
+        match state.as_mut() {
+            State::Connecting(_) => {
+                return_errno_with_message!(Errno::EAGAIN, "the connection is pending")
+            }
+            State::Connected(connected_stream) => connected_stream.check_new(),
+            State::Init(_) | State::Listen(_) => {
+                // FIXME: The error code should be retrieved via the `SO_ERROR` socket option
+                return_errno_with_message!(Errno::ECONNREFUSED, "the connection is refused");
+            }
+        }
     }
 
     fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
@@ -244,15 +294,20 @@ impl StreamSocket {
         }
     }
 
-    fn update_io_events(&self) {
+    #[must_use]
+    fn update_io_events(&self) -> bool {
         let state = self.state.read();
         match state.as_ref() {
-            State::Init(_) => (),
-            State::Connecting(connecting_stream) => {
-                connecting_stream.update_io_events(&self.pollee)
+            State::Init(_) => false,
+            State::Connecting(connecting_stream) => connecting_stream.update_io_events(),
+            State::Listen(listen_stream) => {
+                listen_stream.update_io_events(&self.pollee);
+                false
             }
-            State::Listen(listen_stream) => listen_stream.update_io_events(&self.pollee),
-            State::Connected(connected_stream) => connected_stream.update_io_events(&self.pollee),
+            State::Connected(connected_stream) => {
+                connected_stream.update_io_events(&self.pollee);
+                false
+            }
         }
     }
 }
@@ -343,13 +398,16 @@ impl Socket for StreamSocket {
         })
     }
 
-    // TODO: Support nonblocking mode
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
         let remote_endpoint = socket_addr.try_into()?;
-        self.start_connect(&remote_endpoint)?;
 
+        if let Some(result) = self.start_connect(&remote_endpoint) {
+            poll_ifaces();
+            return result;
+        }
         poll_ifaces();
-        self.wait_events(IoEvents::OUT, || self.finish_connect())
+
+        self.wait_events(IoEvents::OUT, || self.check_connect())
     }
 
     fn listen(&self, backlog: usize) -> Result<()> {
@@ -583,6 +641,12 @@ impl Socket for StreamSocket {
 
 impl Observer<()> for StreamSocket {
     fn on_events(&self, events: &()) {
-        self.update_io_events();
+        let conn_ready = self.update_io_events();
+
+        if conn_ready {
+            // FIXME: The error code should be stored as the `SO_ERROR` socket option. Since it
+            // does not exist yet, we ignore the return value below.
+            let _ = self.finish_connect();
+        }
     }
 }

--- a/regression/apps/network/tcp_err.c
+++ b/regression/apps/network/tcp_err.c
@@ -234,14 +234,12 @@ FN_TEST(poll)
 	struct pollfd pfd = { .events = POLLIN | POLLOUT };
 
 	pfd.fd = sk_unbound;
-	// FIXME: Uncomment this
-	// TEST_RES(poll(&pfd, 1, 0),
-	// 	 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
 
 	pfd.fd = sk_bound;
-	// FIXME: Uncomment this
-	// TEST_RES(poll(&pfd, 1, 0),
-	// 	 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
 
 	pfd.fd = sk_listen;
 	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & (POLLIN | POLLOUT)) == 0);

--- a/regression/apps/network/tcp_err.c
+++ b/regression/apps/network/tcp_err.c
@@ -63,7 +63,7 @@ FN_SETUP(connected)
 	sk_addr.sin_port = S_PORT;
 	CHECK_WITH(connect(sk_connected, (struct sockaddr *)&sk_addr,
 			   sizeof(sk_addr)),
-		   _ret == 0 || errno == EINPROGRESS);
+		   _ret < 0 && errno == EINPROGRESS);
 }
 END_SETUP()
 
@@ -251,5 +251,20 @@ FN_TEST(poll)
 	pfd.fd = sk_accepted;
 	TEST_RES(poll(&pfd, 1, 0),
 		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+}
+END_TEST()
+
+FN_TEST(connect)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_ERRNO(connect(sk_listen, psaddr, addrlen), EISCONN);
+
+	TEST_ERRNO(connect(sk_connected, psaddr, addrlen), 0);
+
+	TEST_ERRNO(connect(sk_connected, psaddr, addrlen), EISCONN);
+
+	TEST_ERRNO(connect(sk_accepted, psaddr, addrlen), EISCONN);
 }
 END_TEST()

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <sys/signal.h>
 #include <sys/socket.h>
+#include <sys/poll.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
@@ -168,5 +169,24 @@ FN_TEST(accept)
 	TEST_ERRNO(accept(sk_bound, psaddr, &addrlen), EOPNOTSUPP);
 
 	TEST_ERRNO(accept(sk_connected, psaddr, &addrlen), EOPNOTSUPP);
+}
+END_TEST()
+
+FN_TEST(poll)
+{
+	struct pollfd pfd = { .events = POLLIN | POLLOUT };
+
+	pfd.fd = sk_unbound;
+	// FIXME: Uncomment this
+	// TEST_RES(poll(&pfd, 1, 0),
+	// 	 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+
+	pfd.fd = sk_bound;
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+
+	pfd.fd = sk_connected;
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
 }
 END_TEST()

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -189,3 +189,12 @@ FN_TEST(poll)
 		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
 }
 END_TEST()
+
+FN_TEST(connect)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_SUCC(connect(sk_connected, psaddr, addrlen));
+}
+END_TEST()

--- a/regression/apps/network/udp_err.c
+++ b/regression/apps/network/udp_err.c
@@ -177,9 +177,8 @@ FN_TEST(poll)
 	struct pollfd pfd = { .events = POLLIN | POLLOUT };
 
 	pfd.fd = sk_unbound;
-	// FIXME: Uncomment this
-	// TEST_RES(poll(&pfd, 1, 0),
-	// 	 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
 
 	pfd.fd = sk_bound;
 	TEST_RES(poll(&pfd, 1, 0),


### PR DESCRIPTION
Reopening https://github.com/asterinas/asterinas/pull/585.

Quoted from the original PR:
> Besides the non-blocking behavior for TCP `connect()`, the `(un)register_observer()` methods for TCP streams and UDP datagrams are also implemented, making the `poll()` system call available for TCP/UDP sockets. This allows the integration tests to check the more socket events using `poll()`.