### PR TITLE
Fix irq guard in `preempt` 

### DIFF
--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -10,7 +10,7 @@ use super::{
     task::{context_switch, TaskContext},
     Task, TaskStatus,
 };
-use crate::{cpu_local, sync::Mutex, trap::disable_local};
+use crate::{cpu_local, sync::Mutex};
 
 pub struct Processor {
     current: Option<Arc<Task>>,
@@ -62,8 +62,8 @@ pub fn schedule() {
 }
 
 pub fn preempt() {
-    // disable interrupts to avoid nested preemption.
-    let disable_irq = disable_local();
+    // TODO: Refactor `preempt` and `schedule`
+    // after the Atomic mode and `might_break` is enabled.
     let Some(curr_task) = current_task() else {
         return;
     };


### PR DESCRIPTION
This PR can only fix #478 .
Since #624 won't be merged, and flag `in_preemption` won't be added in `PreemptInfo`, here's a seperate solution for the issue.
There must be potential similiar misbehaviors that can trigger a panic from context switch but have no relation with `preempt`. I guess they will be left to *Atomic mode* and the `might_break`.