### PR TITLE
Support multi-processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,10 @@ test:
 .PHONY: ktest
 ktest: initramfs $(CARGO_OSDK)
 	@# Exclude linux-bzimage-setup from ktest since it's hard to be unit tested
+	@# FIXME: Ktest will fail for no reason when testing block, even though there is no test in the block component.
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "framework/libs/linux-bzimage/setup" ] && continue; \
+		[ $$dir = "kernel/comps/block" ] && continue; \
 		(cd $$dir && cargo osdk test) || exit 1; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ INTEL_TDX ?= 0
 SKIP_GRUB_MENU ?= 1
 SYSCALL_TEST_DIR ?= /tmp
 EXTRA_BLOCKLISTS_DIRS ?= ""
+SMP ?= 1
 RELEASE_MODE ?= 0
 # End of auto test features.
 
@@ -43,6 +44,7 @@ endif
 CARGO_OSDK_ARGS += --boot.loader="$(BOOT_LOADER)"
 CARGO_OSDK_ARGS += --boot.protocol="$(BOOT_PROTOCOL)"
 CARGO_OSDK_ARGS += --qemu.machine="$(QEMU_MACHINE)"
+CARGO_OSDK_ARGS += --qemu.args="-smp $(SMP)"
 
 ifeq ($(QEMU_MACHINE), microvm)
 CARGO_OSDK_ARGS += --select microvm

--- a/framework/aster-frame/src/arch/x86/boot/boot.S
+++ b/framework/aster-frame/src/arch/x86/boot/boot.S
@@ -278,6 +278,7 @@ gdt_end:
 
 .global boot_page_table_start
 boot_page_table_start:
+.global boot_pml4
 boot_pml4:
     .skip 4096
 boot_pdpt:

--- a/framework/aster-frame/src/arch/x86/boot/multiboot/mod.rs
+++ b/framework/aster-frame/src/arch/x86/boot/multiboot/mod.rs
@@ -139,6 +139,17 @@ fn init_memory_regions(memory_regions: &'static Once<Vec<MemoryRegion>>) {
     // Add the kernel region.
     regions.push(MemoryRegion::kernel());
 
+    // Add the ap boot region.
+    extern "C" {
+        fn __ap_boot_start();
+        fn __ap_boot_end();
+    }
+    regions.push(MemoryRegion::new(
+        __ap_boot_start as usize,
+        __ap_boot_end as usize - __ap_boot_start as usize,
+        MemoryRegionType::Reserved,
+    ));
+
     // Add the initramfs area.
     if info.mods_count != 0 {
         let modules_addr = info.mods_addr as usize;

--- a/framework/aster-frame/src/arch/x86/boot/multiboot2/mod.rs
+++ b/framework/aster-frame/src/arch/x86/boot/multiboot2/mod.rs
@@ -142,6 +142,17 @@ fn init_memory_regions(memory_regions: &'static Once<Vec<MemoryRegion>>) {
     // Add the kernel region since Grub does not specify it.
     regions.push(MemoryRegion::kernel());
 
+    // Add the ap boot region.
+    extern "C" {
+        fn __ap_boot_start();
+        fn __ap_boot_end();
+    }
+    regions.push(MemoryRegion::new(
+        __ap_boot_start as usize,
+        __ap_boot_end as usize - __ap_boot_start as usize,
+        MemoryRegionType::Reserved,
+    ));
+
     // Add the boot module region since Grub does not specify it.
     let mb2_module_tag = mb2_info.module_tags();
     for module in mb2_module_tag {

--- a/framework/aster-frame/src/arch/x86/cpu.rs
+++ b/framework/aster-frame/src/arch/x86/cpu.rs
@@ -7,6 +7,7 @@ use core::{
     fmt::Debug,
 };
 
+use bitflags::bitflags;
 use log::debug;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::tdcall;

--- a/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
@@ -20,6 +20,9 @@ pub trait Apic: ApicTimer + Sync + Send {
 
     /// End of Interrupt, this function will inform APIC that this interrupt has been processed.
     fn eoi(&mut self);
+
+    /// Send a generic IPI
+    unsafe fn send_ipi(&mut self, icr: Icr);
 }
 
 pub trait ApicTimer: Sync + Send {
@@ -39,6 +42,191 @@ pub trait ApicTimer: Sync + Send {
 
     /// Set timer divide config register.
     fn set_timer_div_config(&mut self, div_config: DivideConfig);
+}
+
+enum ApicType {
+    XApic,
+    X2Apic,
+}
+
+/// The inter-processor interrupt control register.
+///
+/// ICR is a 64-bit local APIC register that allows software running on the
+/// porcessor to specify and send IPIs to other porcessors in the system.
+/// To send an IPI, software must set up the ICR to indicate the type of IPI
+/// message to be sent and the destination processor or processors. (All fields
+/// of the ICR are read-write by software with the exception of the delivery
+/// status field, which is read-only.)
+///
+/// The act of writing to the low doubleword of the ICR causes the IPI to be
+/// sent. Therefore, in xapic mode, high doubleword of the ICR needs to be written
+/// first and then the low doubleword to ensure the correct interrupt is sent.
+///
+/// The ICR consists of the following fields:
+/// - **Bit 0-7**   Vector                  :The vector number of the interrupt being sent.
+/// - **Bit 8-10**  Delivery Mode           :Specifies the type of IPI to be sent.
+/// - **Bit 11**    Destination Mode        :Selects either physical or logical destination mode.
+/// - **Bit 12**    Delivery Status(RO)     :Indicates the IPI delivery status.
+/// - **Bit 13**    Reserved
+/// - **Bit 14**    Level                   :Only set 1 for the INIT level de-assert delivery mode.
+/// - **Bit 15**    Trigger Mode            :Selects level or edge trigger mode.
+/// - **Bit 16-17** Reserved
+/// - **Bit 18-19** Destination Shorthand   :Indicates destination set.
+/// - **Bit 20-55** Reserved
+/// - **Bit 56-63** Destination Field       :Specifies the target processor or processors.
+pub struct Icr(u64);
+
+impl Icr {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        destination: ApicId,
+        destination_shorthand: DestinationShorthand,
+        trigger_mode: TriggerMode,
+        level: Level,
+        delivery_status: DeliveryStatus,
+        destination_mode: DestinationMode,
+        delivery_mode: DeliveryMode,
+        vector: u8,
+    ) -> Self {
+        let dest = match destination {
+            ApicId::XApic(d) => (d as u64) << 56,
+            ApicId::X2Apic(d) => (d as u64) << 32,
+        };
+        Icr(dest
+            | (destination_shorthand as u64) << 18
+            | (trigger_mode as u64) << 15
+            | (level as u64) << 14
+            | (delivery_status as u64) << 12
+            | (destination_mode as u64) << 11
+            | (delivery_mode as u64) << 8
+            | (vector as u64))
+    }
+
+    /// Returns the lower 32 bits of the ICR.
+    pub fn lower(&self) -> u32 {
+        self.0 as u32
+    }
+
+    /// Returns the higher 32 bits of the ICR.
+    pub fn upper(&self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+}
+
+/// The core identifier. ApicId can be divided into Physical ApicId and Logical ApicId.
+/// The Physical ApicId is the value read from the LAPIC ID Register, while the Logical ApicId has different
+/// encoding modes in XApic and X2Apic.
+pub enum ApicId {
+    XApic(u8),
+    X2Apic(u32),
+}
+
+impl ApicId {
+    /// Returns the logical x2apic ID.
+    ///
+    /// In x2APIC mode, the 32-bit logical x2APIC ID, which can be read from
+    /// LDR, is derived from the 32-bit local x2APIC ID:
+    /// Logical x2APIC ID = [(x2APIC ID[19:4] << 16) | (1 << x2APIC ID[3:0])]
+    pub fn x2apic_logical_id(&self) -> u32 {
+        self.x2apic_logical_cluster_id() << 16 | 1 << self.x2apic_logical_field_id()
+    }
+
+    /// Returns the logical x2apic cluster ID.
+    ///
+    /// Logical cluster ID = x2APIC ID[19:4]
+    pub fn x2apic_logical_cluster_id(&self) -> u32 {
+        let apic_id = match *self {
+            ApicId::XApic(id) => id as u32,
+            ApicId::X2Apic(id) => id,
+        };
+        apic_id.get_bits(4..=19)
+    }
+
+    /// Returns the logical x2apic field ID.
+    ///
+    /// Specifically, the 16-bit logical ID sub-field is derived by the lowest
+    /// 4 bits of the x2APIC ID, i.e.,
+    /// Logical field ID = x2APIC ID[3:0].
+    pub fn x2apic_logical_field_id(&self) -> u32 {
+        let apic_id = match *self {
+            ApicId::XApic(id) => id as u32,
+            ApicId::X2Apic(id) => id,
+        };
+        apic_id.get_bits(0..=3)
+    }
+}
+
+impl From<u32> for ApicId {
+    fn from(value: u32) -> Self {
+        match APIC_TYPE.get().unwrap() {
+            ApicType::XApic => ApicId::XApic(value as u8),
+            ApicType::X2Apic => ApicId::X2Apic(value),
+        }
+    }
+}
+
+/// Indicates whether a shorthand notation is used to specify the destination of
+/// the interrupt and, if so, which shorthand is used. Destination shorthands are
+/// used in place of the 8-bit destination field, and can be sent by software
+/// using a single write to the low doubleword of the ICR.
+///
+/// Shorthands are defined for the following cases: software self interrupt, IPIs
+/// to all processors in the system including the sender, IPIs to all processors
+/// in the system excluding the sender.
+#[repr(u64)]
+pub enum DestinationShorthand {
+    NoShorthand = 0b00,
+    MySelf = 0b01,
+    AllIncludingSelf = 0b10,
+    AllExcludingSelf = 0b11,
+}
+
+#[repr(u64)]
+pub enum TriggerMode {
+    Egde = 0,
+    Level = 1,
+}
+
+#[repr(u64)]
+pub enum Level {
+    Deassert = 0,
+    Assert = 1,
+}
+
+/// Indicates the IPI delivery status (read only), as follows:
+/// **0 (Idle)**            Indicates that this local APIC has completed sending any previous IPIs.
+/// **1 (Send Pending)**    Indicates that this local APIC has not completed sending the last IPI.
+#[repr(u64)]
+pub enum DeliveryStatus {
+    Idle = 0,
+    SendPending = 1,
+}
+
+#[repr(u64)]
+pub enum DestinationMode {
+    Physical = 0,
+    Logical = 1,
+}
+
+#[repr(u64)]
+pub enum DeliveryMode {
+    /// Delivers the interrupt specified in the vector field to the target processor or processors.
+    Fixed = 0b000,
+    /// Same as fixed mode, except that the interrupt is delivered to the processor executing at
+    /// the lowest priority among the set of processors specified in the destination field. The
+    /// ability for a processor to send a lowest priority IPI is model specific and should be
+    /// avoided by BIOS and operating system software.
+    LowestPriority = 0b001,
+    /// Non-Maskable Interrupt
+    Smi = 0b010,
+    _Reserved = 0b011,
+    /// System Management Interrupt
+    Nmi = 0b100,
+    /// Delivers an INIT request to the target processor or processors, which causes them to
+    /// perform an initialization.
+    Init = 0b101,
+    /// Start-up Interrupt
+    StrartUp = 0b110,
 }
 
 #[derive(Debug)]

--- a/framework/aster-frame/src/arch/x86/kernel/apic/x2apic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/x2apic.rs
@@ -18,7 +18,7 @@ impl X2Apic {
         Some(Self {})
     }
 
-    fn has_x2apic() -> bool {
+    pub fn has_x2apic() -> bool {
         // x2apic::X2APIC::new()
         let value = unsafe { core::arch::x86_64::__cpuid(1) };
         value.ecx & 0x20_0000 != 0

--- a/framework/aster-frame/src/arch/x86/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mod.rs
@@ -60,8 +60,8 @@ pub(crate) fn after_all_init() {
 
 pub(crate) fn interrupts_ack() {
     kernel::pic::ack();
-    if let Some(apic) = kernel::apic::APIC_INSTANCE.get() {
-        apic.lock().eoi();
+    if kernel::apic::APIC_TYPE.is_completed() {
+        kernel::apic::APIC_INSTANCE.borrow().eoi();
     }
 }
 
@@ -96,8 +96,4 @@ pub(crate) fn enable_common_cpu_features() {
             *efer |= EferFlags::NO_EXECUTE_ENABLE;
         });
     }
-}
-
-pub(crate) fn init_ap() {
-    kernel::apic::init_ap();
 }

--- a/framework/aster-frame/src/arch/x86/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod kernel;
 pub(crate) mod mm;
 pub(crate) mod pci;
 pub mod qemu;
+pub mod smp;
 #[cfg(feature = "intel_tdx")]
 pub(crate) mod tdx_guest;
 pub(crate) mod timer;
@@ -75,7 +76,7 @@ pub fn read_tsc() -> u64 {
     unsafe { _rdtsc() }
 }
 
-fn enable_common_cpu_features() {
+pub(crate) fn enable_common_cpu_features() {
     use x86_64::registers::{control::Cr4Flags, model_specific::EferFlags, xcontrol::XCr0Flags};
     let mut cr4 = x86_64::registers::control::Cr4::read();
     cr4 |= Cr4Flags::FSGSBASE | Cr4Flags::OSXSAVE | Cr4Flags::OSFXSR | Cr4Flags::OSXMMEXCPT_ENABLE;
@@ -95,4 +96,8 @@ fn enable_common_cpu_features() {
             *efer |= EferFlags::NO_EXECUTE_ENABLE;
         });
     }
+}
+
+pub(crate) fn init_ap() {
+    kernel::apic::init_ap();
 }

--- a/framework/aster-frame/src/arch/x86/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mod.rs
@@ -22,6 +22,8 @@ use ::tdx_guest::tdx_is_enabled;
 use kernel::apic::ioapic;
 use log::{info, warn};
 
+use self::irq::enable_local;
+
 pub(crate) fn before_all_init() {
     enable_common_cpu_features();
     console::init();
@@ -56,6 +58,13 @@ pub(crate) fn after_all_init() {
     }
     // Some driver like serial may use PIC
     kernel::pic::init();
+    // TODO: Implement LAPIC configuration capabilities for local CPU interrupt priority management
+    // and interrupt broadcasting across multiple cores. This enhancement will address the current
+    // limitation where the IOAPIC forwards all interrupts exclusively to CPU 0, necessitating that all
+    // interrupts are bound to core 0 by default.
+    // The present early activation of interrupts is a temporary measure to mitigate the issue of delayed
+    // interrupt enabling, which currently occurs at user-space program initiation—potentially on other cores.
+    enable_local();
 }
 
 pub(crate) fn interrupts_ack() {

--- a/framework/aster-frame/src/arch/x86/smp/boot.rs
+++ b/framework/aster-frame/src/arch/x86/smp/boot.rs
@@ -1,0 +1,176 @@
+//! Multiprocessor Boot Support
+//!
+//! The MP initialization protocol defines two classes of processors:
+//! the bootstrap processor (BSP) and the application processors (APs).
+//! Following a power-up or RESET of an MP system, system hardware dynamically
+//! selects one of the processors on the system bus as the BSP. The remaining
+//! processors are designated as APs.
+//!
+//! The BSP executes the BIOS's boot-strap code to configure the APIC environment,
+//! sets up system-wide data structures. Up to now, BSP has completed most of the
+//! initialization of the OS, but APs has not been awakened.
+//!
+//! Following a power-up or reset, the APs complete a minimal self-configuration,
+//! then wait for a startup signal (a SIPI message) from the BSP processor.
+//!
+//! The wake-up of AP follows SNIT-SIPI-SIPI IPI sequence:
+//! - Broadcast INIT IPI (Initialize the APs to the wait-for-SIPI state)
+//! - Wait
+//! - Broadcast De-assert INIT IPI (Only older processors need this step)
+//! - Wait
+//! - Broadcast SIPI IPI (APs exits the wait-for-SIPI state and starts executing code)
+//! - Wait
+//! - Broadcast SIPI IPI (If an AP fails to start)
+//! This sequence does not need to be strictly followed, and there may be
+//! different considerations in different systems.
+use core::arch::global_asm;
+
+use acpi::{
+    platform::{Processor, ProcessorInfo},
+    PlatformInfo,
+};
+use log::debug;
+
+use crate::{
+    arch::x86::{
+        irq,
+        kernel::{
+            acpi::ACPI_TABLES,
+            apic::{
+                ApicId, DeliveryMode, DeliveryStatus, DestinationMode, DestinationShorthand, Icr,
+                Level, TriggerMode, APIC_INSTANCE,
+            },
+        },
+        timer::read_monotonic_milli_seconds,
+    },
+    vm::{kernel_loaded_offset, paddr_to_vaddr, VmAllocOptions, VmSegment, PAGE_SIZE},
+};
+
+const AP_BOOT_START_PA: usize = 0x8000;
+const AP_BOOT_STACK_SIZE: usize = PAGE_SIZE * 64;
+
+global_asm!(include_str!("smp_boot.S"));
+
+/// Get processor information
+///
+/// This function needs to be called after the OS initializes the ACPI table.
+pub(crate) fn get_processor_info() -> ProcessorInfo {
+    PlatformInfo::new(&*ACPI_TABLES.get().unwrap().lock())
+        .unwrap()
+        .processor_info
+        .unwrap()
+}
+
+/// Prepare the boot stack for the specified processor
+///
+/// This function needs to be called after initialization of the page allocator.
+/// Currently, the address of the stack is placed at the location indexed by the processor ID
+/// in the application processor boot frame.
+pub(crate) fn prepare_boot_stacks(application_processor: &Processor) -> VmSegment {
+    debug!("application processor info : {:?}", application_processor);
+    let num_stack_frames = AP_BOOT_STACK_SIZE / PAGE_SIZE;
+    let boot_stack_frames = VmAllocOptions::new(num_stack_frames)
+        .is_contiguous(true)
+        .uninit(false)
+        .alloc_contiguous()
+        .unwrap();
+    let ap_stack_pointer = boot_stack_frames.end_paddr() + kernel_loaded_offset();
+    extern "C" {
+        fn __ap_boot_stack_pointer_array();
+    }
+    debug!(
+        "__ap_boot_stakc_top: 0x{:X}",
+        __ap_boot_stack_pointer_array as usize
+    );
+    let ap_boot_stack_top: &mut usize = unsafe {
+        &mut *(paddr_to_vaddr(
+            __ap_boot_stack_pointer_array as usize
+                + 8 * application_processor.local_apic_id as usize,
+        ) as *mut usize)
+    };
+    *ap_boot_stack_top = ap_stack_pointer;
+    debug!(
+        "{} ap_boot_stack_top value: 0x{:X}",
+        application_processor.local_apic_id, *ap_boot_stack_top
+    );
+    boot_stack_frames
+}
+
+/// Send IPIs to notify all application processors to boot
+///
+/// Follow the INIT-SIPI-SIPI IPI sequence.
+/// Here, we don't check whether there is an AP that failed to start,
+/// but send the second SIPI directly (checking whether each core is
+/// started successfully one by one will bring extra overhead). For
+/// APs that have been started, this signal will not bring any cost.
+pub(crate) fn send_boot_ipis() {
+    send_init_to_all_aps();
+    wait_ms(10);
+    send_init_deassert();
+    wait_ms(2);
+    send_startup_to_all_aps();
+    wait_ms(2);
+    send_startup_to_all_aps();
+    wait_ms(2);
+}
+
+fn send_startup_to_all_aps() {
+    let icr = Icr::new(
+        ApicId::from(0),
+        DestinationShorthand::AllExcludingSelf,
+        TriggerMode::Egde,
+        Level::Assert,
+        DeliveryStatus::Idle,
+        DestinationMode::Physical,
+        DeliveryMode::StrartUp,
+        (AP_BOOT_START_PA / PAGE_SIZE) as u8,
+    );
+    unsafe {
+        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+    }
+}
+
+fn send_init_to_all_aps() {
+    let icr = Icr::new(
+        ApicId::from(0),
+        DestinationShorthand::AllExcludingSelf,
+        TriggerMode::Level,
+        Level::Assert,
+        DeliveryStatus::Idle,
+        DestinationMode::Physical,
+        DeliveryMode::Init,
+        0,
+    );
+    unsafe {
+        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+    }
+}
+
+fn send_init_deassert() {
+    let icr = Icr::new(
+        ApicId::from(0),
+        DestinationShorthand::AllIncludingSelf,
+        TriggerMode::Level,
+        Level::Deassert,
+        DeliveryStatus::Idle,
+        DestinationMode::Physical,
+        DeliveryMode::Init,
+        0,
+    );
+    unsafe {
+        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+    }
+}
+
+fn wait_ms(ms: u64) {
+    // Here we temporarily turn on the interrupt to ensure that
+    // the timer works normally. However, after the timer ends,
+    // the interrupt is still closed to avoid affecting the
+    // initialization of other modules.
+    irq::enable_local();
+    let start_ms = read_monotonic_milli_seconds();
+    while read_monotonic_milli_seconds() < start_ms + ms {
+        core::hint::spin_loop();
+    }
+    irq::disable_local();
+}

--- a/framework/aster-frame/src/arch/x86/smp/boot.rs
+++ b/framework/aster-frame/src/arch/x86/smp/boot.rs
@@ -126,7 +126,7 @@ fn send_startup_to_all_aps() {
         (AP_BOOT_START_PA / PAGE_SIZE) as u8,
     );
     unsafe {
-        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+        (*APIC_INSTANCE.borrow()).send_ipi(icr);
     }
 }
 
@@ -142,7 +142,7 @@ fn send_init_to_all_aps() {
         0,
     );
     unsafe {
-        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+        (*APIC_INSTANCE.borrow()).send_ipi(icr);
     }
 }
 
@@ -158,7 +158,7 @@ fn send_init_deassert() {
         0,
     );
     unsafe {
-        APIC_INSTANCE.get().unwrap().lock().send_ipi(icr);
+        (*APIC_INSTANCE.borrow()).send_ipi(icr);
     }
 }
 

--- a/framework/aster-frame/src/arch/x86/smp/mod.rs
+++ b/framework/aster-frame/src/arch/x86/smp/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 mod boot;
 
-pub(crate) use boot::{get_processor_info, prepare_boot_stacks, send_boot_ipis};
+pub(crate) use boot::{get_processor_info, init_boot_stack_array, send_boot_ipis};

--- a/framework/aster-frame/src/arch/x86/smp/mod.rs
+++ b/framework/aster-frame/src/arch/x86/smp/mod.rs
@@ -1,0 +1,3 @@
+mod boot;
+
+pub(crate) use boot::{get_processor_info, prepare_boot_stacks, send_boot_ipis};

--- a/framework/aster-frame/src/arch/x86/smp/smp_boot.S
+++ b/framework/aster-frame/src/arch/x86/smp/smp_boot.S
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
 .extern boot_gdtr
 .extern boot_pml4
 .extern ap_early_entry
@@ -109,12 +111,11 @@ ap_protect:
     ljmp 8, offset ap_long
 
 .code64
-.global __ap_boot_stack_pointer_array
+.global __ap_boot_stack_array_pointer
 .align 8
-// Use two pages to place stack pointers of all aps, thus support up to 1024 aps.
-// stack_pointer = *(__ap_boot_stack_pointer_array + local_apic_id*8)
-__ap_boot_stack_pointer_array:
-    .skip 8 * 1024
+// stack_pointer = *(*__ap_boot_stack_array_pointer + local_apic_id*8)
+__ap_boot_stack_array_pointer:
+    .skip 8
 
 ap_long:
     mov ax, 0
@@ -126,7 +127,8 @@ ap_long:
 
     mov rax, rdi
     shl rax, 3
-    mov rsp, [__ap_boot_stack_pointer_array + rax]
+    mov rbx, [__ap_boot_stack_array_pointer]
+    mov rsp, [rbx + rax]
     mov rax, offset ap_early_entry   
     call rax
     hlt

--- a/framework/aster-frame/src/arch/x86/smp/smp_boot.S
+++ b/framework/aster-frame/src/arch/x86/smp/smp_boot.S
@@ -1,0 +1,132 @@
+.extern boot_gdtr
+.extern boot_pml4
+.extern ap_early_entry
+
+.section ".smp", "awx"
+.align 4096
+.code16
+
+IA32_APIC_BASE = 0x1B
+IA32_X2APIC_APICID = 0x802
+MMIO_XAPIC_APICID = 0xFEE00020
+
+ap_boot:
+    cli // disable interrupts
+    cld
+
+    xor ax, ax  // clear ax
+    mov ds, ax  // clear ds
+
+    lgdt [ap_gdtr] // load gdt
+
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax // enable protected mode
+
+    ljmp 8, offset ap_protect_entry
+
+// 32-bit ap gdt
+.align 16
+ap_gdt:
+    .quad 0x0000000000000000
+ap_gdt_code:
+    .quad 0x00cf9a000000ffff
+ap_gdt_data:
+    .quad 0x00cf92000000ffff
+ap_gdt_end:
+
+.align 16
+ap_gdtr:
+    .word ap_gdt_end - ap_gdt - 1
+    .quad ap_gdt
+
+.align 4
+.code32
+ap_protect_entry:
+    mov ax, 0x10
+    mov ds, ax
+    mov ss, ax
+
+    // Get local apic id from xapic or x2apic
+    // IA32_APIC_BASE register:
+    // bit 8:       BSP—Processor is BSP
+    // bit 10:      EXTD—Enable x2APIC mode
+    // bit 11:      EN—xAPIC global enable/disable
+    // bit 12-35:   APIC Base—Base physical address
+    // It is best to get this information in protected mode. 
+    // After entering long mode, we need to set additional 
+    // page table mapping for xapic mode mmio region.
+    mov ecx, IA32_APIC_BASE
+    rdmsr
+    and eax, 0x400  // check EXTD bit
+    cmp eax, 0x400
+    je x2apic_mode
+
+xapic_mode:
+    // In xapic mode, local apic id is stored in 
+    // mmio region
+    mov eax, [MMIO_XAPIC_APICID]
+    shr eax, 24
+    jmp ap_protect
+
+x2apic_mode:
+    // In x2apic mode, local apic id is stored in 
+    // IA32_X2APIC_APICID MSR
+    mov ecx, IA32_X2APIC_APICID
+    rdmsr
+    jmp ap_protect
+
+.code32
+ap_protect:
+    // Save the local apic id in an unused register.
+    // We will calculate the stack pointer of this core 
+    // by taking the local apic id as the offset.
+    mov edi, eax
+
+    // prepare page table
+    lea eax, [boot_pml4]
+    mov cr3, eax
+
+    // enable PAE and PGE
+    mov eax, cr4
+    or  eax, 0xa0
+    mov cr4, eax
+
+    // enable long mode
+    mov ecx, 0xc0000080 
+    rdmsr   // load EFER MSR
+    or eax, 1<<8
+    wrmsr   // set long bit
+
+    // enable paging
+    mov eax, cr0
+    or eax, 1<<31
+    mov cr0, eax
+
+    // use 64-bit gdt
+    lgdt [boot_gdtr]
+
+    ljmp 8, offset ap_long
+
+.code64
+.global __ap_boot_stack_pointer_array
+.align 8
+// Use two pages to place stack pointers of all aps, thus support up to 1024 aps.
+// stack_pointer = *(__ap_boot_stack_pointer_array + local_apic_id*8)
+__ap_boot_stack_pointer_array:
+    .skip 8 * 1024
+
+ap_long:
+    mov ax, 0
+    mov ds, ax
+    mov ss, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
+    mov rax, rdi
+    shl rax, 3
+    mov rsp, [__ap_boot_stack_pointer_array + rax]
+    mov rax, offset ap_early_entry   
+    call rax
+    hlt

--- a/framework/aster-frame/src/arch/x86/timer/mod.rs
+++ b/framework/aster-frame/src/arch/x86/timer/mod.rs
@@ -33,7 +33,7 @@ pub static TICK: AtomicU64 = AtomicU64::new(0);
 static TIMER_IRQ: Once<IrqLine> = Once::new();
 
 pub fn init() {
-    if kernel::apic::APIC_INSTANCE.is_completed() {
+    if kernel::apic::ioapic::IO_APIC.is_completed() {
         // Get the free irq number first. Use `allocate_target_irq` to get the Irq handle after dropping it.
         // Because the function inside `apic::init` will allocate this irq.
         let irq = IrqLine::alloc().unwrap();

--- a/framework/aster-frame/src/console.rs
+++ b/framework/aster-frame/src/console.rs
@@ -2,7 +2,12 @@
 
 use core::fmt::Arguments;
 
+use crate::sync::SpinLock;
+
+static PRINT_LOCK: SpinLock<()> = SpinLock::new(());
+
 pub fn print(args: Arguments) {
+    let guard = PRINT_LOCK.lock_irq_disabled();
     crate::arch::console::print(args);
 }
 

--- a/framework/aster-frame/src/cpu.rs
+++ b/framework/aster-frame/src/cpu.rs
@@ -2,9 +2,21 @@
 
 //! CPU.
 
-use core::{cell::UnsafeCell, ops::Deref};
+use alloc::{slice, vec::Vec};
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+};
 
-use crate::trap::disable_local;
+use align_ext::AlignExt;
+use bitvec::{order::Lsb0, slice::IterOnes, vec::BitVec};
+
+use crate::{
+    config::PAGE_SIZE,
+    smp::CPUNUM,
+    task::{disable_preempt, DisablePreemptGuard},
+    vm::{paddr_to_vaddr, Vaddr, VmAllocOptions, VmIo, PAGE_SIZE},
+};
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")]{
@@ -13,7 +25,81 @@ cfg_if::cfg_if! {
     }
 }
 
+/// Returns the number of CPUs.
+pub fn num_cpus() -> u32 {
+    *CPUNUM.get().unwrap()
+}
+
+/// Returns the ID of this CPU.
+///
+/// The CPU ID is strategically placed at the beginning of the CPU local storage area to facilitate
+/// fast access, allowing the ID to be retrieved with a single memory access.
+pub fn this_cpu() -> u32 {
+    // Safety: the cpu ID is stored at the beginning of the cpu local area.
+    unsafe { core::ptr::read_volatile(get_cpu_local_base_addr() as usize as *mut u32) }
+}
+
+#[derive(Default)]
+pub struct CpuSet {
+    bitset: BitVec,
+}
+
+impl CpuSet {
+    pub fn new_full() -> Self {
+        let num_cpus = num_cpus();
+        let mut bitset = BitVec::with_capacity(num_cpus as usize);
+        bitset.resize(num_cpus as usize, true);
+        Self { bitset }
+    }
+
+    pub fn new_empty() -> Self {
+        let num_cpus = num_cpus();
+        let mut bitset = BitVec::with_capacity(num_cpus as usize);
+        bitset.resize(num_cpus as usize, false);
+        Self { bitset }
+    }
+
+    pub fn add(&mut self, cpu_id: u32) {
+        self.bitset.set(cpu_id as usize, true);
+    }
+
+    pub fn add_from_vec(&mut self, cpu_ids: Vec<u32>) {
+        for cpu_id in cpu_ids {
+            self.add(cpu_id)
+        }
+    }
+
+    pub fn add_all(&mut self) {
+        self.bitset.fill(true);
+    }
+
+    pub fn remove(&mut self, cpu_id: u32) {
+        self.bitset.set(cpu_id as usize, false);
+    }
+
+    pub fn remove_from_vec(&mut self, cpu_ids: Vec<u32>) {
+        for cpu_id in cpu_ids {
+            self.remove(cpu_id);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.bitset.fill(false);
+    }
+
+    pub fn contains(&self, cpu_id: u32) -> bool {
+        self.bitset.get(cpu_id as usize).as_deref() == Some(&true)
+    }
+
+    pub fn iter(&self) -> IterOnes<'_, usize, Lsb0> {
+        self.bitset.iter_ones()
+    }
+}
+
 /// Defines a CPU-local variable.
+///
+/// All objects defined by the `cpu_local` macro will be linked to the specified `.cpu_local` segment.
+/// When the OS is started, each core will copy this segment as its private storage after startup.
 ///
 /// # Example
 ///
@@ -22,9 +108,8 @@ cfg_if::cfg_if! {
 /// use core::cell::RefCell;
 ///
 /// cpu_local! {
-///     static FOO: RefCell<u32> = RefCell::new(1);
+///     static FOO: AtomicBool = AtomicBool::new(false);
 ///
-///     #[allow(unused)]
 ///     pub static BAR: RefCell<f32> = RefCell::new(1.0);
 /// }
 /// CpuLocal::borrow_with(&FOO, |val| {
@@ -39,15 +124,55 @@ macro_rules! cpu_local {
 
     // multiple declarations
     ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => {
-        $(#[$attr])* $vis static $name: $crate::CpuLocal<$t> = unsafe { $crate::CpuLocal::new($init) };
+        #[link_section = ".cpu_local"]
+        $(#[$attr])* $vis static $name: $crate::cpu::CpuLocal<$t> = unsafe { $crate::cpu::CpuLocal::new($init) };
         $crate::cpu_local!($($rest)*);
     };
+}
 
-    // single declaration
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr) => (
-        // TODO: reimplement cpu-local variable to support multi-core
-        $(#[$attr])* $vis static $name: $crate::CpuLocal<$t> = $crate::CpuLocal::new($init);
-    );
+#[macro_export]
+macro_rules! lazy_cpu_local {
+    () => {};
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => {
+        lazy_cpu_local!(@MAKE TY, $(#[$attr])*, $vis, $name);
+        lazy_cpu_local!(@TAIL, $name :$t = $init );
+        $crate::lazy_cpu_local!($($rest)*);
+    };
+
+    (@TAIL, $name:ident : $t:ty = $init:expr) => {
+        impl $name {
+            pub fn borrow(&self) -> $crate::cpu::CpuLocalGuard<$t>{
+                #[inline(always)]
+                fn __static_ref_initialize() -> $t { $init }
+
+                #[inline(always)]
+                fn __stability() -> $crate::cpu::CpuLocalGuard<'static, $t> {
+                    #[link_section = ".cpu_local"]
+                    static LAZY: $crate::cpu::CpuLocal<spin::Once<$t>> = unsafe { $crate::cpu::CpuLocal::new(spin::Once::new()) };
+                    let guard = LAZY.borrow();
+                    guard.call_once(__static_ref_initialize);
+                    let data_ref = unsafe{ LAZY.borrow_unchecked().get_mut().unwrap() };
+                    $crate::cpu::CpuLocalGuard::new(core::cell::UnsafeCell::from_mut(data_ref), $crate::task::disable_preempt())
+                }
+                __stability()
+            }
+        }
+    };
+
+    (@MAKE TY, $(#[$attr:meta])*, $vis:vis, $name:ident) => {
+        #[allow(missing_copy_implementations)]
+        #[allow(non_camel_case_types)]
+        #[allow(dead_code)]
+        $(#[$attr])*
+        $vis struct $name {__private_field: ()}
+        #[doc(hidden)]
+        $vis static $name: $name = $name {__private_field: ()};
+    };
+}
+
+extern "C" {
+    fn __cpu_local_start();
+    fn __cpu_local_end();
 }
 
 /// CPU-local objects.
@@ -59,45 +184,143 @@ macro_rules! cpu_local {
 /// The `CpuLocal<T: Sync>` can be used directly.
 /// Otherwise, the `CpuLocal<T>` must be used through `CpuLocal::borrow_with`.
 ///
-/// TODO: re-implement `CpuLocal`
-pub struct CpuLocal<T>(UnsafeCell<T>);
+/// On each CPU, the actual virtual address of the `CpuLocal` object is calculated as follows：
+/// Object VA = base address + offset
+/// FS register is used to store the base address of cpu local data, and the base addresses of
+/// different cores are different to ensure the privacy of data. The offset of the linked virtual
+/// address of this object from the start address of the `.cpu_local` segment is used as the
+/// offset of the actual virtual address from the base address.
+///
+/// Compared to directly accessing an object, `CpuLocal` requires some additional overhead to
+/// calculate the actual virtual address.
+pub struct CpuLocal<T: Unpin>(UnsafeCell<T>);
 
 // Safety. At any given time, only one task can access the inner value T of a cpu-local variable.
-unsafe impl<T> Sync for CpuLocal<T> {}
+unsafe impl<T: Unpin> Sync for CpuLocal<T> {}
 
-impl<T> CpuLocal<T> {
+impl<T: Unpin> CpuLocal<T> {
     /// Initialize CPU-local object
-    /// Developer cannot construct a valid CpuLocal object arbitrarily
+    ///
+    /// # Safety
+    ///
+    /// Developer cannot construct a valid CpuLocal object arbitrarily. Create a valid CpuLocal
+    /// object using the `cpu_local` macro instead of directly using the `new` method.
     #[allow(clippy::missing_safety_doc)]
     pub const unsafe fn new(val: T) -> Self {
         Self(UnsafeCell::new(val))
     }
 
-    /// Borrow an immutable reference to the underlying value and feed it to a closure.
-    ///
-    /// During the execution of the closure, local IRQs are disabled. This ensures that
-    /// the CPU-local object is only accessed by the current task or IRQ handler.
-    /// As local IRQs are disabled, one should keep the closure as short as possible.
-    pub fn borrow_with<U, F: FnOnce(&T) -> U>(this: &Self, f: F) -> U {
-        // FIXME: implement disable preemption
-        // Disable interrupts when accessing cpu-local variable
-        let _guard = disable_local();
-        // Safety. Now that the local IRQs are disabled, this CPU-local object can only be
-        // accessed by the current task/thread. So it is safe to get its immutable reference
-        // regardless of whether `T` implements `Sync` or not.
-        let val_ref = unsafe { this.do_borrow() };
-        f(val_ref)
+    pub fn borrow(&self) -> CpuLocalGuard<T> {
+        let guard = disable_preempt();
+        CpuLocalGuard {
+            data: self.data(),
+            guard,
+        }
     }
 
-    unsafe fn do_borrow(&self) -> &T {
-        &*self.0.get()
+    /// Borrows the CPU-local data without providing a guard for preemption safety.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that preemption does not lead to data races.
+    pub unsafe fn borrow_unchecked(&self) -> &'static mut T {
+        &mut *self.data().get()
+    }
+
+    /// Calculates the actual virtual address of an object and returns the object.
+    fn data(&self) -> &UnsafeCell<T> {
+        let base_va = get_cpu_local_base_addr();
+        let self_va = self as *const _ as usize;
+        let self_offset = self_va - __cpu_local_start as usize;
+        let data_va = (base_va as usize + self_offset) as Vaddr;
+        // Safety: This data ensures that the initialization state has not been
+        // modified before memory copying, so it can be safely dereferenced to type `T`.
+        unsafe { &*(data_va as *const UnsafeCell<T>) }
     }
 }
 
-impl<T: Sync> Deref for CpuLocal<T> {
+pub struct CpuLocalGuard<'a, T: Unpin> {
+    data: &'a UnsafeCell<T>,
+    guard: DisablePreemptGuard,
+}
+
+impl<'a, T: Unpin> CpuLocalGuard<'a, T> {
+    pub fn new(data: &'a UnsafeCell<T>, guard: DisablePreemptGuard) -> Self {
+        CpuLocalGuard { data, guard }
+    }
+
+    pub fn inner_data(&self) -> &UnsafeCell<T> {
+        self.data
+    }
+}
+
+impl<'a, T: Unpin> Deref for CpuLocalGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        unsafe { &*self.0.get() }
+        // Safety: Now that the local IRQs are disabled, this CPU-local object can only be
+        // accessed by the current task/thread.
+        unsafe { &*self.data.get() }
+    }
+}
+
+impl<'a, T: Unpin> DerefMut for CpuLocalGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // Safety: Now that the local IRQs are disabled, this CPU-local object can only be
+        // accessed by the current task/thread.
+        unsafe { &mut *self.data.get() }
+    }
+}
+
+/// Initializes the local CPU data for the bootstrap processor (BSP).
+/// During the initialization of the local data in BSP, the frame allocator has
+/// not been initialized yet, thus a reserved memory segment is used as its local storage.
+///
+/// # Safety
+///
+/// It must be guaranteed that the BSP will not access local data before this function is called,
+/// otherwise dereference of non-Pod is undefined behavior.
+pub unsafe fn bsp_init() {
+    let start_base_va = __cpu_local_start as usize;
+    let end_base_va = __cpu_local_end as usize;
+    let nbytes = (end_base_va - start_base_va).align_up(PAGE_SIZE);
+    extern "C" {
+        fn __bsp_local_start();
+    }
+    // Safety: Both [__cpu_local_start, __cpu_local_end) and [__bsp_local_start, __bsp_local_end)
+    // are reserved areas used for storing cpu local data.
+    unsafe {
+        core::ptr::copy(
+            start_base_va as *const u8,
+            __bsp_local_start as usize as *mut u8,
+            nbytes,
+        );
+        core::ptr::write_volatile(__bsp_local_start as usize as *mut u32, 0_u32);
+    }
+    // Safety: FS register is not used for any other purpose.
+    unsafe {
+        set_cpu_local_base_addr(__bsp_local_start as u64);
+    }
+}
+
+pub fn ap_init(cpu_id: u32) {
+    let start_base_va = __cpu_local_start as usize;
+    let end_base_va = __cpu_local_end as usize;
+    let nbytes = (end_base_va - start_base_va).align_up(PAGE_SIZE);
+
+    let local_segment = VmAllocOptions::new(nbytes / PAGE_SIZE)
+        .is_contiguous(true)
+        .need_dealloc(false)
+        .alloc_contiguous()
+        .unwrap();
+    // Safety: [__cpu_local_start, __cpu_local_end) is reserved area used for storing cpulocal data.
+    local_segment
+        .writer()
+        .write(&mut unsafe { slice::from_raw_parts(start_base_va as *const u8, nbytes) }.into());
+    local_segment.write_val(0, &cpu_id).unwrap();
+    // Safety: `local_segment` is initialized to have the `need_dealloc` attribute, so this
+    // memory will be dedicated to storing cpu local data.
+    unsafe {
+        set_cpu_local_base_addr(paddr_to_vaddr(local_segment.start_paddr()) as u64);
     }
 }

--- a/framework/aster-frame/src/cpu.rs
+++ b/framework/aster-frame/src/cpu.rs
@@ -12,7 +12,6 @@ use align_ext::AlignExt;
 use bitvec::{order::Lsb0, slice::IterOnes, vec::BitVec};
 
 use crate::{
-    config::PAGE_SIZE,
     smp::CPUNUM,
     task::{disable_preempt, DisablePreemptGuard},
     vm::{paddr_to_vaddr, Vaddr, VmAllocOptions, VmIo, PAGE_SIZE},

--- a/framework/aster-frame/src/cpu.rs
+++ b/framework/aster-frame/src/cpu.rs
@@ -59,6 +59,14 @@ impl CpuSet {
         Self { bitset }
     }
 
+    pub fn from_cpu_id(cpu_id: u32) -> Self {
+        let num_cpus = num_cpus();
+        let mut bitset = BitVec::with_capacity(num_cpus as usize);
+        bitset.resize(num_cpus as usize, false);
+        bitset.set(cpu_id as usize, true);
+        Self { bitset }
+    }
+
     pub fn add(&mut self, cpu_id: u32) {
         self.bitset.set(cpu_id as usize, true);
     }

--- a/framework/aster-frame/src/cpu.rs
+++ b/framework/aster-frame/src/cpu.rs
@@ -306,7 +306,7 @@ pub unsafe fn bsp_init() {
     }
     // Safety: FS register is not used for any other purpose.
     unsafe {
-        set_cpu_local_base_addr(__bsp_local_start as u64);
+        set_cpu_local_base_addr(__bsp_local_start as usize as u64);
     }
 }
 

--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(panic_info_message)]
 #![feature(ptr_sub_ptr)]
 #![feature(strict_provenance)]
+#![feature(unsafe_cell_from_mut)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![no_std]
@@ -48,10 +49,14 @@ pub mod vm;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::init_tdx;
 
-pub use self::{cpu::CpuLocal, error::Error, prelude::Result};
+pub use self::{error::Error, prelude::Result};
 
 pub fn init() {
     arch::before_all_init();
+    // Safety: Cpu local data has not been accessed before
+    unsafe {
+        cpu::bsp_init();
+    }
     logger::init();
     #[cfg(feature = "intel_tdx")]
     let td_info = init_tdx().unwrap();

--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -36,6 +36,7 @@ pub mod io_mem;
 pub mod logger;
 pub mod panicking;
 pub mod prelude;
+pub mod smp;
 pub mod sync;
 pub mod task;
 pub mod timer;
@@ -66,6 +67,7 @@ pub fn init() {
     trap::init();
     arch::after_all_init();
     bus::init();
+    smp::init();
     invoke_ffi_init_funcs();
 }
 

--- a/framework/aster-frame/src/logger.rs
+++ b/framework/aster-frame/src/logger.rs
@@ -2,7 +2,7 @@
 
 use log::{Level, Metadata, Record};
 
-use crate::early_println;
+use crate::{cpu::this_cpu, early_println};
 
 const LOGGER: Logger = Logger {};
 
@@ -19,7 +19,12 @@ impl log::Log for Logger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            early_println!("[{}]: {}", record.level(), record.args());
+            early_println!(
+                "[CPU {}][{}]: {}",
+                this_cpu(),
+                record.level(),
+                record.args()
+            );
         }
     }
 

--- a/framework/aster-frame/src/smp/mod.rs
+++ b/framework/aster-frame/src/smp/mod.rs
@@ -5,8 +5,8 @@ use spin::Once;
 
 use crate::{
     arch::{
-        self, enable_common_cpu_features,
-        smp::{get_processor_info, prepare_boot_stacks, send_boot_ipis},
+        enable_common_cpu_features,
+        smp::{get_processor_info, init_boot_stack_array, send_boot_ipis},
     },
     cpu,
     sync::SpinLock,
@@ -70,7 +70,6 @@ fn ap_early_entry(local_apic_id: u32) -> ! {
     enable_common_cpu_features();
     cpu::ap_init(local_apic_id);
     trap::init();
-    arch::init_ap();
 
     let ap_boot_info = AP_BOOT_INFO.get().unwrap().lock_irq_disabled();
     ap_boot_info

--- a/framework/aster-frame/src/smp/mod.rs
+++ b/framework/aster-frame/src/smp/mod.rs
@@ -1,0 +1,85 @@
+use alloc::collections::BTreeMap;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use spin::Once;
+
+use crate::{
+    arch::{
+        self, enable_common_cpu_features,
+        smp::{get_processor_info, prepare_boot_stacks, send_boot_ipis},
+    },
+    cpu,
+    sync::SpinLock,
+    trap,
+    vm::VmSegment,
+};
+
+static AP_BOOT_INFO: Once<SpinLock<BTreeMap<u32, ApBootInfo>>> = Once::new();
+
+struct ApBootInfo {
+    is_started: AtomicBool,
+    // TODO: When the AP starts up and begins executing tasks, the boot stack will
+    // no longer be used, and the `VmSegment` can be deallocated (this problem also
+    // exists in the boot processor, but the memory it occupies should be returned
+    // to the frame allocator).
+    boot_stack_frames: VmSegment,
+}
+
+pub static CPUNUM: Once<u32> = Once::new();
+
+static AP_LATE_ENTRY: Once<fn() -> !> = Once::new();
+
+/// Only initialize the processor number here to facilitate the system
+/// to pre-allocate some data structures according to this number.
+pub fn init() {
+    let processor_info = get_processor_info();
+    let num_aps = processor_info.application_processors.len();
+    CPUNUM.call_once(|| (num_aps + 1) as u32);
+}
+
+/// Boot all application processors.
+///
+/// This function should be called late in the system startup.
+/// The system must at least ensure that the scheduler, ACPI table, memory allocation,
+/// and IPI module have been initialized.
+pub fn boot_all_aps() {
+    let processor_info = get_processor_info();
+    AP_BOOT_INFO.call_once(|| {
+        let mut ap_boot_info = BTreeMap::new();
+        for ap in &processor_info.application_processors {
+            let boot_stack_frames = prepare_boot_stacks(ap);
+            ap_boot_info.insert(
+                ap.local_apic_id,
+                ApBootInfo {
+                    is_started: AtomicBool::new(false),
+                    boot_stack_frames,
+                },
+            );
+        }
+        SpinLock::new(ap_boot_info)
+    });
+    send_boot_ipis();
+}
+
+pub fn register_ap_late_entry(entry: fn() -> !) {
+    AP_LATE_ENTRY.call_once(|| entry);
+}
+
+#[no_mangle]
+fn ap_early_entry(local_apic_id: u32) -> ! {
+    enable_common_cpu_features();
+    cpu::ap_init(local_apic_id);
+    trap::init();
+    arch::init_ap();
+
+    let ap_boot_info = AP_BOOT_INFO.get().unwrap().lock_irq_disabled();
+    ap_boot_info
+        .get(&local_apic_id)
+        .unwrap()
+        .is_started
+        .store(true, Ordering::Release);
+    drop(ap_boot_info);
+
+    let ap_late_entry = AP_LATE_ENTRY.wait();
+    ap_late_entry();
+}

--- a/framework/aster-frame/src/sync/wait.rs
+++ b/framework/aster-frame/src/sync/wait.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use super::SpinLock;
 use crate::{
     arch::timer::{add_timeout_list, TIMER_FREQ},
-    task::{add_task, current_task, schedule, Task, TaskStatus},
+    task::{add_task_to_global, current_task, schedule, Task, TaskStatus},
 };
 
 /// A wait queue.

--- a/framework/aster-frame/src/task/mod.rs
+++ b/framework/aster-frame/src/task/mod.rs
@@ -11,6 +11,9 @@ mod task;
 pub use self::{
     priority::Priority,
     processor::{current_task, disable_preempt, preempt, schedule, DisablePreemptGuard},
-    scheduler::{add_task, set_scheduler, Scheduler},
+    scheduler::{
+        add_task_to_global, fetch_task_from_global, preempt_global, set_global_scheduler,
+        set_local_scheduler, Scheduler,
+    },
     task::{Task, TaskAdapter, TaskOptions, TaskStatus},
 };

--- a/framework/aster-frame/src/task/scheduler.rs
+++ b/framework/aster-frame/src/task/scheduler.rs
@@ -5,8 +5,24 @@ use lazy_static::lazy_static;
 use crate::{prelude::*, sync::SpinLock, task::Task};
 
 lazy_static! {
-    pub(crate) static ref GLOBAL_SCHEDULER: SpinLock<GlobalScheduler> =
-        SpinLock::new(GlobalScheduler { scheduler: None });
+    /// The global scheduler is responsible for managing tasks across all CPUs in the system.
+    /// It provides a centralized point of task management, and all tasks will be put into the
+    /// queue of the global scheduler first when they are ready to run. The global scheduler can decide
+    /// the distribution and migration of tasks according to the CPU load to achieve the best resource utilization.
+    static ref GLOBAL_SCHEDULER: SpinLock<GeneralScheduler> =
+        SpinLock::new(GeneralScheduler::new());
+}
+
+cpu_local! {
+    /// Each CPU in the system has its own local scheduler instance, allowing for tasks to be
+    /// managed on a per-CPU basis. This is useful for tasks that are affine to a specific CPU
+    /// or for load balancing purposes where tasks are distributed among CPUs to avoid contention.
+    /// The local scheduler can optimize task execution by reducing task migration between CPUs and
+    /// minimizing synchronization overhead for task management.Furthermore, If a preempted task
+    /// is emplaced back immediately to the global scheduler before the context switch, other processors
+    /// may fetch the task with a stale context. And we couldn't make the progress between emplacing
+    /// and context storing atomic.
+    static LOCAL_SCHEDULER: GeneralScheduler = GeneralScheduler::new();
 }
 
 /// A scheduler for tasks.
@@ -59,4 +75,35 @@ pub fn fetch_task() -> Option<Arc<Task>> {
 
 pub fn add_task(task: Arc<Task>) {
     GLOBAL_SCHEDULER.lock_irq_disabled().enqueue(task);
+}
+
+/// This function is used to fetch a high-priority task from the global scheduler,
+/// potentially to replace a currently running task if it is not high priority.
+pub fn preempt_global(cpu_id: u32) -> Option<Arc<Task>> {
+    GLOBAL_SCHEDULER.lock_irq_disabled().preempt(cpu_id)
+}
+
+/// Sets the local scheduler for the current CPU.
+pub fn set_local_scheduler(scheduler: &'static dyn Scheduler) {
+    LOCAL_SCHEDULER.borrow().scheduler = Some(scheduler);
+}
+
+/// Sets the local scheduler for the current CPU.
+pub fn fetch_task_from_local() -> Option<Arc<Task>> {
+    LOCAL_SCHEDULER.borrow().dequeue(this_cpu())
+}
+
+/// Fetches a task from the local scheduler queue of the current CPU.
+pub fn add_task_to_local(task: Arc<Task>) {
+    LOCAL_SCHEDULER.borrow().enqueue(task);
+}
+
+pub fn add_sleeping_task_to_local(task: Arc<Task>) {
+    LOCAL_SCHEDULER.borrow().enqueue_sleep(task);
+}
+
+/// This function is used to check for and retrieve a high-priority task from the local scheduler,
+/// which could preempt the currently running task on this CPU if necessary.
+pub fn preempt_local() -> Option<Arc<Task>> {
+    LOCAL_SCHEDULER.borrow().preempt(this_cpu())
 }

--- a/framework/aster-frame/src/task/scheduler.rs
+++ b/framework/aster-frame/src/task/scheduler.rs
@@ -38,6 +38,9 @@ pub trait Scheduler: Sync + Send {
 
     /// Fetch a high priority task for potential preemption.
     fn preempt(&self, cpu_id: u32) -> Option<Arc<Task>>;
+
+    /// Add a task to the scheduler's sleep queue.
+    fn enqueue_sleep(&self, task: Arc<Task>);
 }
 
 /// `GeneralScheduler` is a simple wrapper around a Scheduler trait object.
@@ -66,6 +69,10 @@ impl GeneralScheduler {
     /// It requires the scheduler to be set (not None).
     fn preempt(&mut self, cpu_id: u32) -> Option<Arc<Task>> {
         self.scheduler.unwrap().preempt(cpu_id)
+    }
+
+    fn enqueue_sleep(&mut self, task: Arc<Task>) {
+        self.scheduler.unwrap().enqueue_sleep(task)
     }
 }
 

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -48,7 +48,7 @@ impl CalleeRegs {
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub(crate) struct TaskContext {
+pub struct TaskContext {
     pub regs: CalleeRegs,
     pub rip: usize,
 }

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -143,7 +143,7 @@ pub struct Task {
 // TaskAdapter struct is implemented for building relationships between doubly linked list and Task struct
 intrusive_adapter!(pub TaskAdapter = Arc<Task>: Task { link: LinkedListAtomicLink });
 
-pub(crate) struct TaskInner {
+pub struct TaskInner {
     pub task_status: TaskStatus,
     pub ctx: TaskContext,
 }
@@ -155,8 +155,8 @@ impl Task {
     }
 
     /// get inner
-    pub(crate) fn inner_exclusive_access(&self) -> SpinLockGuard<'_, TaskInner> {
-        self.task_inner.lock_irq_disabled()
+    pub fn inner_exclusive_access(&self) -> SpinLockGuard<'_, TaskInner> {
+        self.task_inner.lock()
     }
 
     /// get inner
@@ -175,11 +175,6 @@ impl Task {
     pub fn run(self: &Arc<Self>) {
         add_task_to_global(self.clone());
         schedule();
-    }
-
-    /// Returns the task status.
-    pub fn status(&self) -> TaskStatus {
-        self.task_inner.lock_irq_disabled().task_status
     }
 
     /// Returns the task data.

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -3,7 +3,7 @@
 use intrusive_collections::{intrusive_adapter, LinkedListAtomicLink};
 
 use super::{
-    add_task,
+    add_task_to_global,
     priority::Priority,
     processor::{current_task, schedule},
 };
@@ -137,7 +137,6 @@ pub struct Task {
     kstack: KernelStack,
     link: LinkedListAtomicLink,
     priority: Priority,
-    // TODO:: add multiprocessor support
     cpu_affinity: CpuSet,
 }
 
@@ -174,7 +173,7 @@ impl Task {
     }
 
     pub fn run(self: &Arc<Self>) {
-        add_task(self.clone());
+        add_task_to_global(self.clone());
         schedule();
     }
 
@@ -205,6 +204,10 @@ impl Task {
 
     pub fn is_real_time(&self) -> bool {
         self.priority.is_real_time()
+    }
+
+    pub fn cpu_affinity(&self) -> &CpuSet {
+        &self.cpu_affinity
     }
 }
 

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -20,7 +20,7 @@ pub const KERNEL_STACK_SIZE: usize = PAGE_SIZE * 64;
 
 core::arch::global_asm!(include_str!("switch.S"));
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct CalleeRegs {
     pub rsp: u64,
@@ -32,11 +32,34 @@ pub struct CalleeRegs {
     pub r15: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+impl CalleeRegs {
+    pub const fn default() -> Self {
+        Self {
+            rsp: 0,
+            rbx: 0,
+            rbp: 0,
+            r12: 0,
+            r13: 0,
+            r14: 0,
+            r15: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub(crate) struct TaskContext {
     pub regs: CalleeRegs,
     pub rip: usize,
+}
+
+impl TaskContext {
+    pub const fn default() -> Self {
+        Self {
+            regs: CalleeRegs::default(),
+            rip: 0,
+        }
+    }
 }
 
 extern "C" {

--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use log::debug;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::tdcall;
 use trapframe::TrapFrame;

--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
-use log::debug;
 #[cfg(feature = "intel_tdx")]
 use tdx_guest::tdcall;
 use trapframe::TrapFrame;
@@ -154,7 +151,7 @@ pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {
     // an interrupt handler is called (Unless interrupts are re-enabled in an interrupt handler).
     //
     // FIXME: For arch that supports re-entrant interrupts, we may need to record nested level here.
-    IN_INTERRUPT_CONTEXT.store(true, Ordering::Release);
+    *IN_INTERRUPT_CONTEXT.borrow() = true;
 
     let irq_line = IRQ_LIST.get().unwrap().get(trap_frame.trap_num).unwrap();
     let callback_functions = irq_line.callback_list();
@@ -165,11 +162,11 @@ pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {
         crate::arch::interrupts_ack();
     }
 
-    IN_INTERRUPT_CONTEXT.store(false, Ordering::Release);
+    *IN_INTERRUPT_CONTEXT.borrow() = false;
 }
 
 cpu_local! {
-    static IN_INTERRUPT_CONTEXT: AtomicBool = AtomicBool::new(false);
+    static IN_INTERRUPT_CONTEXT: bool = false;
 }
 
 /// Returns whether we are in the interrupt context.
@@ -177,7 +174,7 @@ cpu_local! {
 /// FIXME: Here only hardware irq is taken into account. According to linux implementation, if
 /// we are in softirq context, or bottom half is disabled, this function also returns true.
 pub fn in_interrupt_context() -> bool {
-    IN_INTERRUPT_CONTEXT.load(Ordering::Acquire)
+    *IN_INTERRUPT_CONTEXT.borrow()
 }
 
 fn handle_kernel_page_fault(f: &TrapFrame) {

--- a/framework/aster-frame/src/vm/frame_allocator.rs
+++ b/framework/aster-frame/src/vm/frame_allocator.rs
@@ -27,10 +27,7 @@ pub(crate) fn alloc(nframes: usize, flags: VmFrameFlags) -> Option<VmFrameVec> {
             // Safety: The frame index is valid.
             unsafe {
                 for i in 0..nframes {
-                    let frame = VmFrame::new(
-                        (start + i) * PAGE_SIZE,
-                        flags.union(VmFrameFlags::NEED_DEALLOC),
-                    );
+                    let frame = VmFrame::new((start + i) * PAGE_SIZE, flags);
                     vector.push(frame);
                 }
             }
@@ -41,7 +38,7 @@ pub(crate) fn alloc(nframes: usize, flags: VmFrameFlags) -> Option<VmFrameVec> {
 pub(crate) fn alloc_single(flags: VmFrameFlags) -> Option<VmFrame> {
     FRAME_ALLOCATOR.get().unwrap().lock().alloc(1).map(|idx|
             // Safety: The frame index is valid.
-            unsafe { VmFrame::new(idx * PAGE_SIZE, flags.union(VmFrameFlags::NEED_DEALLOC)) })
+            unsafe { VmFrame::new(idx * PAGE_SIZE, flags) })
 }
 
 pub(crate) fn alloc_contiguous(nframes: usize, flags: VmFrameFlags) -> Option<VmSegment> {
@@ -56,7 +53,7 @@ pub(crate) fn alloc_contiguous(nframes: usize, flags: VmFrameFlags) -> Option<Vm
             VmSegment::new(
                 start * PAGE_SIZE,
                 nframes,
-                flags.union(VmFrameFlags::NEED_DEALLOC),
+                flags,
             )
         })
 }

--- a/framework/aster-frame/src/vm/heap_allocator.rs
+++ b/framework/aster-frame/src/vm/heap_allocator.rs
@@ -68,7 +68,7 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let _guard = disable_local();
 
-        if let Ok(allocation) = self.heap.lock().alloc(layout) {
+        if let Ok(allocation) = self.heap.lock_irq_disabled().alloc(layout) {
             return allocation.as_ptr();
         }
 
@@ -78,7 +78,7 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
         }
 
         self.heap
-            .lock()
+            .lock_irq_disabled()
             .alloc(layout)
             .map_or(core::ptr::null_mut::<u8>(), |allocation| {
                 allocation.as_ptr()

--- a/framework/aster-frame/src/vm/options.rs
+++ b/framework/aster-frame/src/vm/options.rs
@@ -14,6 +14,7 @@ pub struct VmAllocOptions {
     nframes: usize,
     is_contiguous: bool,
     uninit: bool,
+    need_dealloc: bool,
 }
 
 impl VmAllocOptions {
@@ -23,6 +24,7 @@ impl VmAllocOptions {
             nframes,
             is_contiguous: false,
             uninit: false,
+            need_dealloc: true,
         }
     }
 
@@ -42,6 +44,11 @@ impl VmAllocOptions {
     /// The default value is false.
     pub fn uninit(&mut self, uninit: bool) -> &mut Self {
         self.uninit = uninit;
+        self
+    }
+
+    pub fn need_dealloc(&mut self, need_dealloc: bool) -> &mut Self {
+        self.need_dealloc = need_dealloc;
         self
     }
 
@@ -98,6 +105,10 @@ impl VmAllocOptions {
     }
 
     fn flags(&self) -> VmFrameFlags {
-        VmFrameFlags::empty()
+        let mut flags = VmFrameFlags::empty();
+        if self.need_dealloc {
+            flags.insert(VmFrameFlags::NEED_DEALLOC);
+        }
+        flags
     }
 }

--- a/kernel/aster-nix/src/console.rs
+++ b/kernel/aster-nix/src/console.rs
@@ -7,6 +7,10 @@
 
 use core::fmt::{Arguments, Write};
 
+use aster_frame::sync::SpinLock;
+
+static PRINT_LOCK: SpinLock<()> = SpinLock::new(());
+
 struct VirtioConsolesPrinter;
 
 impl Write for VirtioConsolesPrinter {
@@ -19,6 +23,7 @@ impl Write for VirtioConsolesPrinter {
 }
 
 pub fn _print(args: Arguments) {
+    let guard = PRINT_LOCK.lock_irq_disabled();
     VirtioConsolesPrinter.write_fmt(args).unwrap();
 }
 

--- a/kernel/aster-nix/src/sched/mod.rs
+++ b/kernel/aster-nix/src/sched/mod.rs
@@ -1,8 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub mod nice;
+use alloc::boxed::Box;
+
+use aster_frame::task::{set_global_scheduler, set_local_scheduler};
+
+use self::priority_scheduler::{PreemptGlobalScheduler, PreemptLocalScheduler};
+
 mod priority_scheduler;
 
-// There may be multiple scheduling policies in the system,
-// and subsequent schedulers can be placed under this module.
-pub use self::priority_scheduler::init;
+pub fn init_global_scheduler() {
+    let preempt_scheduler = Box::new(PreemptGlobalScheduler::new());
+    let scheduler = Box::<PreemptGlobalScheduler>::leak(preempt_scheduler);
+    set_global_scheduler(scheduler);
+}
+
+pub fn init_local_scheduler() {
+    let preempt_scheduler = Box::new(PreemptLocalScheduler::new());
+    let scheduler = Box::<PreemptLocalScheduler>::leak(preempt_scheduler);
+    set_local_scheduler(scheduler);
+}

--- a/kernel/aster-nix/src/sched/priority_scheduler.rs
+++ b/kernel/aster-nix/src/sched/priority_scheduler.rs
@@ -1,30 +1,66 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_frame::task::{set_scheduler, Scheduler, Task, TaskAdapter};
+//! At present, we use' PreemptGlobalScheduler' and' PreemptLocalScheduler' to meet the requirements of
+//! priority preemption and multi-processor for scheduler. Currently, This is a simple solution.
+//!
+//! - For the requirement of priority preemption, we only distinguish between high-priority tasks
+//! (real_time_tasks) and low-priority tasks (normal_tasks). Low-priority tasks will give up CPU at
+//! the preemption point, if there are high-priority tasks at that time. Once the high-priority task
+//! gets the CPU, it will be executed without being preempted by other high-priority tasks until the
+//! task ends or it voluntarily gives up the CPU.
+//!
+//! - For the requirements of multi-core system, we divide the scheduler into local and global. At present,
+//! it is a simple implementation, regardless of fairness and load balancing. All tasks are put into the
+//! global scheduler when they are ready. The global scheduler will not actively distribute these tasks,
+//! but rely on the local scheduler to actively request tasks for execution. Task switch and preemption
+//! on on each CPU are the responsibility of the local scheduler. When the local scheduler is in task switch,
+//! it will always actively request a task from the global scheduler, regardless of whether its own queue is
+//! empty or not. This is to avoid some tasks stuck in the lazy global scheduler. When preempting, the local
+//! scheduler will first check whether there are high-priority tasks in the local queue, and if not, it will
+//! preempt the global scheduler. There may be a situation where each local scheduler has a high-priority task,
+//! while there are also high-priority tasks in the global scheduler, and the local scheduler will not put the
+//! global high-priority tasks when preempting. But don't worry that it will stay. When the local high-priority task
+//! is in task switch, the local scheduler will take the initiative to get the global high-priority task from
+//! the global scheduler. This is because local high-priority tasks will not be preempted, and it will not help
+//! to put global high-priority tasks locally in advance.
+
+use aster_frame::{
+    cpu::this_cpu,
+    task::{fetch_task_from_global, preempt_global, Scheduler, Task, TaskAdapter},
+};
 use intrusive_collections::LinkedList;
 
 use crate::prelude::*;
 
-pub fn init() {
-    let preempt_scheduler = Box::new(PreemptScheduler::new());
-    let scheduler = Box::<PreemptScheduler>::leak(preempt_scheduler);
-    set_scheduler(scheduler);
-}
-
-/// The preempt scheduler
+/// The preempt global scheduler.
 ///
-/// Real-time tasks are placed in the `real_time_tasks` queue and
-/// are always prioritized during scheduling.
-/// Normal tasks are placed in the `normal_tasks` queue and are only
-/// scheduled for execution when there are no real-time tasks.
-struct PreemptScheduler {
-    /// Tasks with a priority of less than 100 are regarded as real-time tasks.
+/// This scheduler is responsible for managing tasks at a global level, allowing for preemption
+/// across all CPUs. It operates with two distinct queues: one for real-time tasks and another
+/// for normal tasks. Real-time tasks are given higher priority in scheduling decisions, ensuring
+/// that they are executed before normal tasks whenever possible.
+pub(super) struct PreemptGlobalScheduler {
+    /// Queue for real-time tasks, which have higher priority.
+    /// The scheduler always checks this queue first for tasks to run, ensuring real-time tasks
+    /// take precedence over normal tasks.
     real_time_tasks: SpinLock<LinkedList<TaskAdapter>>,
-    /// Tasks with a priority greater than or equal to 100 are regarded as normal tasks.
+    /// Queue for normal tasks, which have lower priority.
+    /// These tasks are scheduled for execution only when there are no real-time tasks pending.
     normal_tasks: SpinLock<LinkedList<TaskAdapter>>,
 }
 
-impl PreemptScheduler {
+/// The preempt local scheduler.
+///
+/// Similar to the global scheduler, the local scheduler maintains separate queues for real-time
+/// and normal tasks. However, the local scheduler operates at the CPU level, managing tasks that
+/// are specific to a single CPU.
+pub(super) struct PreemptLocalScheduler {
+    /// Queue for real-time tasks specific to a CPU.
+    real_time_tasks: SpinLock<LinkedList<TaskAdapter>>,
+    /// Queue for normal tasks specific to a CPU.
+    normal_tasks: SpinLock<LinkedList<TaskAdapter>>,
+}
+
+impl PreemptGlobalScheduler {
     pub fn new() -> Self {
         Self {
             real_time_tasks: SpinLock::new(LinkedList::new(TaskAdapter::new())),
@@ -33,7 +69,7 @@ impl PreemptScheduler {
     }
 }
 
-impl Scheduler for PreemptScheduler {
+impl Scheduler for PreemptGlobalScheduler {
     fn enqueue(&self, task: Arc<Task>) {
         if task.is_real_time() {
             self.real_time_tasks
@@ -46,15 +82,105 @@ impl Scheduler for PreemptScheduler {
         }
     }
 
-    fn dequeue(&self) -> Option<Arc<Task>> {
-        if !self.real_time_tasks.lock_irq_disabled().is_empty() {
-            self.real_time_tasks.lock_irq_disabled().pop_front()
+    /// Dequeues a task from the scheduler based on CPU affinity and priority.
+    ///
+    /// This method first attempts to dequeue a real-time task that is affine to the given CPU.
+    /// If no real-time tasks are affine or available, it then attempts to dequeue a normal task.
+    fn dequeue(&self, cpu_id: u32) -> Option<Arc<Task>> {
+        let mut real_time_tasks = self.real_time_tasks.lock_irq_disabled();
+        let mut cursor = real_time_tasks.front_mut();
+        while let Some(task_ref) = cursor.get() {
+            if task_ref.cpu_affinity().contains(cpu_id) {
+                return cursor.remove();
+            } else {
+                cursor.move_next();
+            }
+        }
+
+        let mut normal_tasks = self.normal_tasks.lock_irq_disabled();
+        let mut cursor = normal_tasks.front_mut();
+        while let Some(task_ref) = cursor.get() {
+            if task_ref.cpu_affinity().contains(cpu_id) {
+                return cursor.remove();
+            } else {
+                cursor.move_next();
+            }
+        }
+        None
+    }
+
+    /// This function is used to fetch a high-priority task from the global scheduler,
+    /// potentially to replace a currently running task if it is not high priority.
+    fn preempt(&self, cpu_id: u32) -> Option<Arc<Task>> {
+        let mut real_time_tasks = self.real_time_tasks.lock_irq_disabled();
+        let mut cursor = real_time_tasks.front_mut();
+        while let Some(task_ref) = cursor.get() {
+            if task_ref.cpu_affinity().contains(cpu_id) {
+                return cursor.remove();
+            } else {
+                cursor.move_next();
+            }
+        }
+        None
+    }
+}
+
+impl PreemptLocalScheduler {
+    pub fn new() -> Self {
+        Self {
+            real_time_tasks: SpinLock::new(LinkedList::new(TaskAdapter::new())),
+            normal_tasks: SpinLock::new(LinkedList::new(TaskAdapter::new())),
+        }
+    }
+}
+
+impl Scheduler for PreemptLocalScheduler {
+    fn enqueue(&self, task: Arc<Task>) {
+        if task.is_real_time() {
+            self.real_time_tasks
+                .lock_irq_disabled()
+                .push_back(task.clone());
         } else {
-            self.normal_tasks.lock_irq_disabled().pop_front()
+            self.normal_tasks
+                .lock_irq_disabled()
+                .push_back(task.clone());
         }
     }
 
-    fn should_preempt(&self, task: &Arc<Task>) -> bool {
-        !task.is_real_time() && !self.real_time_tasks.lock_irq_disabled().is_empty()
+    /// Dequeues a task from the local scheduler queue.
+    ///
+    /// It always attempts to fetch a task from the global scheduler and enqueue it locally.
+    /// Because the global scheduler does not actively distribute tasks, this provides a mechanism for
+    /// pulling tasks into the local scheduler from the global queue.
+    fn dequeue(&self, cpu_id: u32) -> Option<Arc<Task>> {
+        assert!(cpu_id == this_cpu());
+        if let Some(fetch_task) = fetch_task_from_global(cpu_id) {
+            self.enqueue(fetch_task);
+        }
+
+        if let Some(task) = self.real_time_tasks.lock_irq_disabled().pop_front() {
+            assert!(task.cpu_affinity().contains(cpu_id));
+            return Some(task);
+        }
+        if let Some(task) = self.normal_tasks.lock_irq_disabled().pop_front() {
+            assert!(task.cpu_affinity().contains(cpu_id));
+            return Some(task);
+        }
+        None
+    }
+
+    /// Preempts the current task on the local CPU, if a higher-priority real-time task is available.
+    ///
+    /// It first attempts to preempt a real-time task from the local queue. If a real-time task is available
+    /// and affine to the CPU, it is returned. If no real-time tasks are available locally, it
+    /// attempts to preempt a task from the global scheduler.
+    fn preempt(&self, cpu_id: u32) -> Option<Arc<Task>> {
+        assert!(cpu_id == this_cpu());
+        if let Some(task) = self.real_time_tasks.lock_irq_disabled().pop_front() {
+            assert!(task.cpu_affinity().contains(cpu_id));
+            return Some(task);
+        }
+
+        preempt_global(cpu_id)
     }
 }

--- a/kernel/aster-nix/src/smp/mod.rs
+++ b/kernel/aster-nix/src/smp/mod.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_frame::cpu::{this_cpu, CpuSet};
+
+use crate::{
+    current_thread,
+    thread::{
+        kernel_thread::{KernelThreadExt, ThreadOptions},
+        Thread,
+    },
+};
+
+pub fn init() {
+    aster_frame::smp::boot_all_aps();
+    aster_frame::smp::register_ap_late_entry(ap_entry);
+}
+
+pub fn ap_entry() -> ! {
+    run_ap_first_process();
+}
+
+fn run_ap_first_process() -> ! {
+    let cpu_id = this_cpu();
+    let mut cpu_set = CpuSet::new_empty();
+    cpu_set.add(cpu_id);
+    assert!(cpu_id != 0);
+    Thread::spawn_kernel_thread(ThreadOptions::new(ap_thread).cpu_affinity(cpu_set));
+    unreachable!()
+}
+
+fn ap_thread() {
+    info!(
+        "[kernel] Spawn init thread for processor {}, tid = {}",
+        this_cpu(),
+        current_thread!().tid()
+    );
+    loop {
+        Thread::yield_now();
+    }
+}

--- a/kernel/aster-nix/src/smp/mod.rs
+++ b/kernel/aster-nix/src/smp/mod.rs
@@ -3,7 +3,7 @@
 use aster_frame::cpu::{this_cpu, CpuSet};
 
 use crate::{
-    current_thread,
+    current_thread, println,
     sched::init_local_scheduler,
     thread::{
         kernel_thread::{KernelThreadExt, ThreadOptions},
@@ -31,7 +31,7 @@ fn run_ap_first_process() -> ! {
 }
 
 fn ap_thread() {
-    info!(
+    println!(
         "[kernel] Spawn init thread for processor {}, tid = {}",
         this_cpu(),
         current_thread!().tid()

--- a/kernel/aster-nix/src/smp/mod.rs
+++ b/kernel/aster-nix/src/smp/mod.rs
@@ -4,6 +4,7 @@ use aster_frame::cpu::{this_cpu, CpuSet};
 
 use crate::{
     current_thread,
+    sched::init_local_scheduler,
     thread::{
         kernel_thread::{KernelThreadExt, ThreadOptions},
         Thread,
@@ -20,11 +21,12 @@ pub fn ap_entry() -> ! {
 }
 
 fn run_ap_first_process() -> ! {
+    init_local_scheduler();
     let cpu_id = this_cpu();
-    let mut cpu_set = CpuSet::new_empty();
-    cpu_set.add(cpu_id);
     assert!(cpu_id != 0);
-    Thread::spawn_kernel_thread(ThreadOptions::new(ap_thread).cpu_affinity(cpu_set));
+    Thread::spawn_kernel_thread(
+        ThreadOptions::new(ap_thread).cpu_affinity(CpuSet::from_cpu_id(cpu_id)),
+    );
     unreachable!()
 }
 

--- a/kernel/aster-nix/src/thread/kernel_thread.rs
+++ b/kernel/aster-nix/src/thread/kernel_thread.rs
@@ -44,6 +44,7 @@ impl KernelThreadExt for Thread {
             let weal_thread = thread_ref.clone();
             let task = TaskOptions::new(thread_fn)
                 .data(weal_thread)
+                .cpu_affinity(thread_options.cpu_affinity)
                 .build()
                 .unwrap();
             let status = ThreadStatus::Init;

--- a/kernel/aster-nix/src/thread/thread_table.rs
+++ b/kernel/aster-nix/src/thread/thread_table.rs
@@ -4,18 +4,18 @@ use super::{Thread, Tid};
 use crate::prelude::*;
 
 lazy_static! {
-    static ref THREAD_TABLE: Mutex<BTreeMap<Tid, Arc<Thread>>> = Mutex::new(BTreeMap::new());
+    static ref THREAD_TABLE: SpinLock<BTreeMap<Tid, Arc<Thread>>> = SpinLock::new(BTreeMap::new());
 }
 
 pub fn add_thread(thread: Arc<Thread>) {
     let tid = thread.tid();
-    THREAD_TABLE.lock().insert(tid, thread);
+    THREAD_TABLE.lock_irq_disabled().insert(tid, thread);
 }
 
 pub fn remove_thread(tid: Tid) {
-    THREAD_TABLE.lock().remove(&tid);
+    THREAD_TABLE.lock_irq_disabled().remove(&tid);
 }
 
 pub fn get_thread(tid: Tid) -> Option<Arc<Thread>> {
-    THREAD_TABLE.lock().get(&tid).cloned()
+    THREAD_TABLE.lock_irq_disabled().get(&tid).cloned()
 }

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -158,7 +158,9 @@ impl DeviceInner {
         let config = VirtioBlockConfig::new(transport.as_mut());
         let num_queues = transport.num_queues();
         if num_queues != 1 {
-            return Err(VirtioDeviceError::QueuesAmountDoNotMatch(num_queues, 1));
+            // TODO: support Multi-Queue Block IO Queueing Mechanism(`BlkFeatures::MQ`) to accelerate multi-processor
+            // requests for block devices.
+            // return Err(VirtioDeviceError::QueuesAmountDoNotMatch(num_queues, 1));
         }
 
         let queue = VirtQueue::new(0, 64, transport.as_mut()).expect("create virtqueue failed");

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -25,6 +25,7 @@ bitflags! {
         const FLUSH         = 1 << 9;
         const TOPOLOGY      = 1 << 10;
         const CONFIG_WCE    = 1 << 11;
+        const MQ            = 1 << 12;
         const DISCARD       = 1 << 13;
         const WRITE_ZEROES  = 1 << 14;
     }

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -2,12 +2,22 @@ ENTRY(__multiboot_boot)
 OUTPUT_ARCH(i386:x86-64)
 OUTPUT_FORMAT(elf64-x86-64)
 
+AP_START = 0x8000;
 KERNEL_LMA = 0x8000000;
 LINUX_32_ENTRY = 0x8001000;
 KERNEL_VMA = 0xffffffff80000000;
 
 SECTIONS
 {
+    . = AP_START;
+    . = ALIGN(0x1000);
+    __ap_boot_start = .;
+    .smp : {
+        KEEP(*(.smp .smp.*))
+    }
+    . = ALIGN(0x1000);
+    __ap_boot_end = .;
+
     . = KERNEL_LMA;
 
     __kernel_start = .;

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -9,14 +9,6 @@ KERNEL_VMA = 0xffffffff80000000;
 
 SECTIONS
 {
-    . = AP_START;
-    . = ALIGN(0x1000);
-    __ap_boot_start = .;
-    .smp : {
-        KEEP(*(.smp .smp.*))
-    }
-    . = ALIGN(0x1000);
-    __ap_boot_end = .;
 
     . = KERNEL_LMA;
 
@@ -29,7 +21,18 @@ SECTIONS
     
     .boot                   : { KEEP(*(.boot)) }
 
-    . += KERNEL_VMA;
+    __boot_end = .;
+
+    . = AP_START;
+    . = ALIGN(0x1000);
+    __ap_boot_start = .;
+    .smp : AT(AP_START) {
+        KEEP(*(.smp .smp.*))
+    }
+    . = ALIGN(0x1000);
+    __ap_boot_end = .;
+
+    . = __boot_end + KERNEL_VMA;
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
         *(.text .text.*)

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -37,6 +37,15 @@ SECTIONS
     }
     .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA) { *(.rodata .rodata.*) }
 
+    . = ALIGN(0x1000);
+    __cpu_local_start = .;
+    . += 4;
+    .cpu_local              : AT(ADDR(.cpu_local) - KERNEL_VMA) {  
+        KEEP(*(SORT(.cpu_local)))
+    }
+    . = ALIGN(0x1000);
+    __cpu_local_end = .;
+
     .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA) {
         PROVIDE(__GNU_EH_FRAME_HDR = .);
         KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
@@ -69,6 +78,14 @@ SECTIONS
         *(.bss .bss.*) *(COMMON)
         __bss_end = .;
     }
+
+    /* Reserve a section with size __cpu_local_end-__cpu_local_start filled with zeroes */
+    . = ALIGN(0x1000);
+    __bsp_local_start = .;
+    . += 4;
+    . += __cpu_local_end - __cpu_local_start;
+    . = ALIGN(0x1000);
+    __bsp_local_end = .;
 
     .ktest_array            : AT(ADDR(.ktest_array) - KERNEL_VMA) {
         __ktest_array = .;

--- a/osdk/src/config_manager/qemu.rs
+++ b/osdk/src/config_manager/qemu.rs
@@ -163,7 +163,7 @@ impl<'a> From<&'a str> for QemuMachine {
 /// Keys with multiple values
 pub const MULTI_VALUE_KEYS: &[&str] = &["-device", "-chardev", "-object", "-netdev", "-drive"];
 /// Keys with only single value
-pub const SINGLE_VALUE_KEYS: &[&str] = &["-m", "-serial", "-monitor", "-display"];
+pub const SINGLE_VALUE_KEYS: &[&str] = &["-m", "-serial", "-monitor", "-display", "-smp"];
 /// Keys with no value
 pub const NO_VALUE_KEYS: &[&str] = &["--no-reboot", "-nographic", "-enable-kvm"];
 /// Keys are not allowed to set in configuration files and command line


### PR DESCRIPTION
This PR provides support for asterinas running on multi-processors.  The main contributions of this PR include:
   
- [x] Implemented a user-friendly Inter-Processor Interrupt (IPI) interface for the APIC.  
- [x] Enabled multi-processor boot support.  
- [x] Refactored `cpu_local`.  
- [x] Developed a rudimentary global-local scheduler.  
- [x] Addressing some race conditions.

However, the current implementation of multi-processor support includes some temporary workarounds that will require future optimization and resolution:
   
 - All interrupts are currently bound to a single core due to the lack of a friendly interface for interrupt prioritization or broadcasting in our existing IOAPIC and LAPIC. 
 - All user processes are bound to a single core because of a bug in the current COW implementation. Parent process writes to COW pages are visible to child processes, leading to disastrous outcomes for `fork` and `clone` system calls. When a parent process clones a child process and immediately returns to user space, the child process can be scheduled on another core and may inherit a corrupted user stack pointer, leading to illegal accesses. 
- Systems without ACPI tables are not supported for multi-processors. The configuration of the AP is heavily reliant on ACPI tables, and I believe adapting to systems without ACPI tables is currently a lower priority. 
- Block ktests have been skipped. This is due to the consistent occurrence of an 'invalid op' error during the startup process of block ktests in GRUB, even though there are currently no tests related to block devices. 