### PR TITLE
Downgrade intrusive-collections to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.6"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
+checksum = "3f4f90afb01281fdeffb0f8e082d230cbe4f888f837cc90759696b858db1a700"
 dependencies = [
  "memoffset",
 ]
@@ -984,9 +984,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]

--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -17,7 +17,9 @@ cfg-if = "1.0"
 gimli = { version = "0.28", default-features = false, features = ["read-core"] }
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e" }
 int-to-c-enum = { path = "../../kernel/libs/int-to-c-enum" }
-intrusive-collections = "0.9.5"
+# instrusive-collections of version 0.9.6 fails to compile with current rust toolchain,
+# So we set a fixed version 0.9.5 for this crate
+intrusive-collections = "=0.9.5"
 ktest = { path = "../libs/ktest" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 log = "0.4"


### PR DESCRIPTION
This PR fixes the kernel test failure of main branch.

OSDK failure needs another PR to update the `aster-frame` version.