### PR TITLE
Atomic mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "-Zbuild-std=core,alloc,compiler_builtins",
         "-Zbuild-std-features=compiler-builtins-mem"
     ],
-    "rust-analyzer.showUnlinkedFileNotification": false
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    "rust-analyzer.procMacro.enable": true,
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "align_ext",
  "aml",
  "aster-main",
+ "atomic-mode-proc-macro",
  "bit_field",
  "bitflags 1.3.2",
  "bitvec",
@@ -321,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "atomic-mode-proc-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "framework/aster-frame",
     "framework/libs/align_ext",
     "framework/libs/aster-main",
+    "framework/libs/atomic-mode-proc-macro",
     "framework/libs/linux-bzimage/builder",
     "framework/libs/linux-bzimage/boot-params",
     "framework/libs/linux-bzimage/setup",

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ export
 NON_OSDK_CRATES := \
 	framework/libs/align_ext \
 	framework/libs/aster-main \
+	framework/libs/atomic-mode-proc-macro \
 	framework/libs/linux-bzimage/builder \
 	framework/libs/linux-bzimage/boot-params \
 	framework/libs/ktest \

--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 align_ext = { path = "../libs/align_ext" }
 aster-main = { path = "../libs/aster-main" }
+atomic-mode-proc-macro = { path = "../libs/atomic-mode-proc-macro" }
 bit_field = "0.10.1"
 bitflags = "1.3"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(panic_info_message)]
 #![feature(ptr_sub_ptr)]
 #![feature(strict_provenance)]
+#![feature(offset_of)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![no_std]

--- a/framework/aster-frame/src/prelude.rs
+++ b/framework/aster-frame/src/prelude.rs
@@ -9,9 +9,11 @@ pub(crate) use core::any::Any;
 
 pub use aster_main::aster_main;
 
-pub use crate::task::atomic::{enter_atomic_mode, might_break_atomic_mode, AtomicModeGuard};
 pub use crate::{
     early_print as print, early_println as println,
     panicking::abort,
+    task::atomic::{
+        atomic_procedure, enter_atomic_mode, might_break, might_break_atomic_mode, AtomicModeGuard,
+    },
     vm::{Paddr, Vaddr},
 };

--- a/framework/aster-frame/src/prelude.rs
+++ b/framework/aster-frame/src/prelude.rs
@@ -9,6 +9,7 @@ pub(crate) use core::any::Any;
 
 pub use aster_main::aster_main;
 
+pub use crate::task::atomic::{enter_atomic_mode, might_break_atomic_mode, AtomicModeGuard};
 pub use crate::{
     early_print as print, early_println as println,
     panicking::abort,

--- a/framework/aster-frame/src/sync/wait.rs
+++ b/framework/aster-frame/src/sync/wait.rs
@@ -11,6 +11,7 @@ use bitflags::bitflags;
 use super::SpinLock;
 use crate::{
     arch::timer::{add_timeout_list, TIMER_FREQ},
+    // prelude::*,
     task::{add_task, current_task, schedule, Task, TaskStatus},
 };
 
@@ -58,6 +59,8 @@ impl WaitQueue {
         self.do_wait(cond, Some(timeout))
     }
 
+    // FIXME
+    // #[might_break]
     fn do_wait<F, R>(&self, mut cond: F, timeout: Option<&Duration>) -> Option<R>
     where
         F: FnMut() -> Option<R>,

--- a/framework/aster-frame/src/task/atomic.rs
+++ b/framework/aster-frame/src/task/atomic.rs
@@ -32,7 +32,7 @@ use core::{
 extern crate alloc;
 use alloc::{format, string::String};
 
-// pub use atomic_mode_proc_macro::{atomic_procedure, might_break};
+pub use atomic_mode_proc_macro::{atomic_procedure, might_break};
 
 crate::cpu_local! {
     static ATOMIC_MODE: AtomicMode = AtomicMode::new(PreemptInfo::new());
@@ -214,22 +214,22 @@ mod test {
             might_break_atomic_mode();
         }
     }
-    // mod macros {
-    //     use super::*;
-    //     #[might_break]
-    //     fn breakable_func() {
-    //         // do something might break atomic mode
-    //     }
+    mod macros {
+        use super::*;
+        #[might_break]
+        fn breakable_func() {
+            // do something might break atomic mode
+        }
 
-    //     #[atomic_procedure]
-    //     fn breakable_func_in_atomic_context() {
-    //         breakable_func();
-    //     }
+        #[atomic_procedure]
+        fn breakable_func_in_atomic_context() {
+            breakable_func();
+        }
 
-    //     #[ktest]
-    //     #[should_panic]
-    //     fn panics_at_func_in_atomic_mode() {
-    //         breakable_func_in_atomic_context();
-    //     }
-    // }
+        #[ktest]
+        #[should_panic]
+        fn panics_at_func_in_atomic_mode() {
+            breakable_func_in_atomic_context();
+        }
+    }
 }

--- a/framework/aster-frame/src/task/atomic.rs
+++ b/framework/aster-frame/src/task/atomic.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! # Atomic Execution Mode
+//!
+//! When a CPU core runs in the **atomic mode**,
+//! the kernel code must be executed _atomically_.
+//! Specifically, a kernel panic would be triggered
+//! if such forbidden behaviors are captured from the kernel code in the atomic mode:
+//!
+//! - Any operation that can incur scheduling / context switching:
+//!     - Sleeping;
+//!     - Waiting for I/O;
+//!     - Yielding: yield the processor to other tasks voluntarily;
+//!     - Preemption: get preempted by other tasks;
+//! - And switching to the user space.
+//!
+//! Note that the kernel code is allowed to handle interrupts within the atomic mode.
+//!
+//! The concept of the atomic mode is connected with those of process and interrupt contexts.
+//! A broad classification of execution contexts in a classic monolithic kernel can be:
+//!
+//! | Context Type in Kernel | Process                                 | Interrupt                 |
+//! | ---------------------- | --------------------------------------- | ------------------------- |
+//! | Execution Target       | kernel code on behalf of a user process | interrupt handler         |
+//! | Atomic Requirement     | may switch into or out on demand        | always in the atomic mode |
+//!
+
+use core::{
+    panic,
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+};
+extern crate alloc;
+use alloc::{format, string::String};
+
+// pub use atomic_mode_proc_macro::{atomic_procedure, might_break};
+
+crate::cpu_local! {
+    static ATOMIC_MODE: AtomicMode = AtomicMode::new(PreemptInfo::new());
+}
+
+/// When `PreemptInfo` is non-zero, the CPU cannot call `schedule()`.
+#[derive(Debug, Default)]
+struct PreemptInfo {
+    /// The number of locks and IRQ-disabled contexts held by the current CPU.
+    num_locks: AtomicUsize,
+}
+
+impl PreemptInfo {
+    const fn new() -> Self {
+        Self {
+            num_locks: AtomicUsize::new(0),
+        }
+    }
+    fn inc_num(&self) {
+        self.num_locks.fetch_add(1, Relaxed);
+    }
+    fn dec_num(&self) {
+        self.num_locks.fetch_sub(1, Relaxed);
+    }
+    fn num(&self) -> usize {
+        self.num_locks.load(Relaxed)
+    }
+}
+
+pub struct AtomicMode {
+    delegate: PreemptInfo,
+}
+
+impl AtomicMode {
+    const fn new(delegate: PreemptInfo) -> Self {
+        Self { delegate }
+    }
+
+    #[must_use]
+    pub fn new_guard(&self) -> AtomicModeGuard {
+        self.delegate.inc_num();
+        AtomicModeGuard {
+            atomic_info: self,
+            _thread_unsafe: core::marker::PhantomData,
+        }
+    }
+
+    pub fn in_atomic_mode(&self) -> bool {
+        self.delegate.num() != 0
+    }
+
+    fn on_guard_drop(&self) {
+        self.delegate.dec_num();
+    }
+
+    pub fn info(&self) -> String {
+        format!("PREEMPT_COUNT = {}", self.delegate.num())
+    }
+}
+
+/// The guard of the atomic mode.
+/// The CPU shall exit the atomic mode only after the last guard object is dropped.
+pub struct AtomicModeGuard<'a> {
+    atomic_info: &'a AtomicMode,
+    _thread_unsafe: core::marker::PhantomData<*const ()>,
+}
+
+impl<'a> Drop for AtomicModeGuard<'a> {
+    fn drop(&mut self) {
+        self.atomic_info.on_guard_drop();
+    }
+}
+
+// FIXME: remove this usage by `MannuallyDrop`
+/// Transfer out the onwership of the given guard.
+pub fn transferred<'a>(_orgin: &mut AtomicModeGuard<'a>) -> AtomicModeGuard<'a> {
+    enter_atomic_mode()
+}
+
+/// Enter the atomic mode, and return a guard for exiting the current atomic mode.
+/// Nested calls of this method are permitted.
+/// The CPU shall exit the atomic mode only after the last guard object is dropped.
+///
+/// # Example
+///
+/// ```rust
+/// // enters the atomic mode
+/// let guard = enter_atomic_mode();
+/// {
+///     let nested_guard = enter_atomic_mode();
+///     assert!(is_in_atomic_mode());
+///     // do something in atomic mode
+/// }
+/// assert!(is_in_atomic_mode());
+/// drop(guard);    // drop to exit the current atomic mode
+/// assert!(!is_in_atomic_mode());
+/// ```
+#[must_use]
+pub fn enter_atomic_mode<'a>() -> AtomicModeGuard<'a> {
+    ATOMIC_MODE.new_guard()
+}
+
+/// Whether the current context is in atomic mode.
+pub fn is_in_atomic_mode() -> bool {
+    ATOMIC_MODE.in_atomic_mode()
+}
+
+/// Mark a point after which the code in scope may break the rules of the atomic mode.
+/// Nothing will happen if the current context is not in atomic mode.
+///
+/// # Panic
+///
+/// If the current context is in atomic mode,
+/// a panic will be triggered to indicate the violation of the atomic mode rules.
+pub fn might_break_atomic_mode() {
+    if is_in_atomic_mode() {
+        panic!("Break atomic mode: {}", ATOMIC_MODE.info());
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use super::*;
+    mod preempt_info {
+        use super::*;
+        #[ktest]
+        fn inc_num() {
+            let info = PreemptInfo::new();
+            info.inc_num();
+            assert_eq!(info.num(), 1);
+        }
+        #[ktest]
+        fn dec_num() {
+            let info = PreemptInfo::new();
+            info.inc_num();
+            info.inc_num();
+            info.dec_num();
+            assert_eq!(info.num(), 1);
+        }
+    }
+    mod atomic_mode_env {
+        use super::*;
+        #[ktest]
+        fn is_in() {
+            let guard = enter_atomic_mode();
+            assert!(is_in_atomic_mode());
+        }
+        #[ktest]
+        fn is_not_in() {
+            assert!(!is_in_atomic_mode());
+        }
+
+        #[ktest]
+        fn entry_multiple_times() {
+            assert!(!is_in_atomic_mode());
+            let guard1 = enter_atomic_mode();
+            let guard2 = enter_atomic_mode();
+            assert!(is_in_atomic_mode());
+            drop(guard1);
+            assert!(is_in_atomic_mode());
+            drop(guard2);
+            assert!(!is_in_atomic_mode());
+        }
+    }
+    mod break_atomic {
+        use super::*;
+        #[ktest]
+        #[should_panic]
+        fn panic_in_atomic_mode() {
+            let _guard = enter_atomic_mode();
+            might_break_atomic_mode();
+        }
+        #[ktest]
+        fn no_panic_out_of_atomic_mode() {
+            assert!(
+                !is_in_atomic_mode(),
+                "Test environment should not be in atomic mode"
+            );
+            might_break_atomic_mode();
+        }
+    }
+    // mod macros {
+    //     use super::*;
+    //     #[might_break]
+    //     fn breakable_func() {
+    //         // do something might break atomic mode
+    //     }
+
+    //     #[atomic_procedure]
+    //     fn breakable_func_in_atomic_context() {
+    //         breakable_func();
+    //     }
+
+    //     #[ktest]
+    //     #[should_panic]
+    //     fn panics_at_func_in_atomic_mode() {
+    //         breakable_func_in_atomic_context();
+    //     }
+    // }
+}

--- a/framework/aster-frame/src/task/mod.rs
+++ b/framework/aster-frame/src/task/mod.rs
@@ -2,15 +2,17 @@
 
 //! Tasks are the unit of code execution.
 
+pub mod atomic;
 mod priority;
 mod processor;
 mod scheduler;
+
 #[allow(clippy::module_inception)]
 mod task;
 
 pub use self::{
     priority::Priority,
-    processor::{current_task, disable_preempt, preempt, schedule, DisablePreemptGuard},
+    processor::{current_task, preempt, schedule},
     scheduler::{add_task, set_scheduler, Scheduler},
     task::{Task, TaskAdapter, TaskOptions, TaskStatus},
 };

--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -54,14 +54,14 @@ pub(crate) fn get_idle_task_cx_ptr() -> *mut TaskContext {
 }
 
 /// call this function to switch to other task by using GLOBAL_SCHEDULER
-// #[might_break]
+#[might_break]
 pub fn schedule() {
     if let Some(task) = fetch_task() {
         switch_to_task(task);
     }
 }
 
-// #[might_break]
+#[might_break]
 pub fn preempt() {
     // disable interrupts to avoid nested preemption.
     let disable_irq = disable_local();
@@ -86,7 +86,7 @@ pub fn preempt() {
 /// if current task status is exit, then it will not add to the scheduler
 ///
 /// before context switch, current task will switch to the next task
-// #[might_break]
+#[might_break]
 fn switch_to_task(next_task: Arc<Task>) {
     let current_task_option = current_task();
     let next_task_cx_ptr = &next_task.inner_ctx() as *const TaskContext;

--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -15,7 +15,7 @@ use crate::arch::{
 };
 #[cfg(feature = "intel_tdx")]
 use crate::vm::{page_table::KERNEL_PAGE_TABLE, vaddr_to_paddr};
-use crate::{arch::irq::IRQ_LIST, cpu::CpuException, cpu_local};
+use crate::{arch::irq::IRQ_LIST, cpu::CpuException, cpu_local, prelude::*};
 
 #[cfg(feature = "intel_tdx")]
 impl TdxTrapFrame for TrapFrame {
@@ -152,6 +152,7 @@ extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
     }
 }
 
+#[atomic_procedure]
 pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {
     // For x86 CPUs, interrupts are not re-entrant. Local interrupts will be disabled when
     // an interrupt handler is called (Unless interrupts are re-enabled in an interrupt handler).

--- a/framework/libs/atomic-mode-proc-macro/Cargo.toml
+++ b/framework/libs/atomic-mode-proc-macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "atomic-mode-proc-macro"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.69"
+quote = "1.0.33"
+syn = { version = "2.0.29", features = ["full"] }

--- a/framework/libs/atomic-mode-proc-macro/src/lib.rs
+++ b/framework/libs/atomic-mode-proc-macro/src/lib.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This crate provides macros to help writing atomic-mode-safe code.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Expr, ItemFn};
+
+/// The name of the default atomic-mode guard factory function
+const DEFAULT_ATOMIC_GUARD_FACTORY_NAME: &str = "enter_atomic_mode";
+
+/// Marks a function as being executed under the atomic mode.
+/// The marked function enters the atomic mode context automatically
+/// before the execution of its function body,
+/// and exits the atomic mode when the function returns.
+///
+/// <div class="note">
+///     Nested calls of functions with this attribute is permitted.
+///     The CPU shall exit the atomic mode
+///     only after the last atomic mode context ends.
+/// </div>
+///
+/// # Argument
+///
+/// - `arg`: The function that creates an atomic-mode guard.
+///             It should be a function or a path to a function.
+///             If it is not provided, the default function `enter_atomic_mode`
+///             will be used when there is one in the scope.
+///             Avoid using functions with the same name as the default one.
+///
+/// # Examples
+///
+/// Use the default atomic mode guard factory function defined in the scope.
+///
+/// ```rust
+/// struct AtomicModeGuard;
+/// fn enter_atomic_mode() -> AtomicModeGuard {
+///     AtomicModeGuard {}
+/// }
+///
+/// #[atomic_mode_proc_macro::atomic_procedure]
+/// fn atomic_function() {
+///     // The function body is executed in atomic mode,
+///     // i.e., guarded by the `AtomicModeGuard` until the function returns.
+/// }
+/// ```
+///
+/// Or, specify the guard factory function via the argument.
+///
+/// ```rust
+/// struct AtomicModeGuard;
+/// fn custom_enter_atomic_mode() -> AtomicModeGuard {
+///     AtomicModeGuard {}
+/// }
+///
+/// #[atomic_mode_proc_macro::atomic_procedure(custom_enter_atomic_mode)]
+/// fn atomic_function() -> i8 {
+///     1
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn atomic_procedure(arg: TokenStream, input: TokenStream) -> TokenStream {
+    let factory = if arg.is_empty() {
+        syn::parse_str::<Expr>(DEFAULT_ATOMIC_GUARD_FACTORY_NAME).unwrap()
+    } else {
+        parse_macro_input!(arg as Expr)
+    };
+
+    let atomic_gaurd = match factory {
+        Expr::Path(_) | Expr::Closure(_) => quote! {
+            let _atomic_mode_guard = #factory();
+        },
+        _ => quote! {
+            compile_error!("Expects an expression representing a function.");
+        },
+    };
+
+    exec_at_begin(atomic_gaurd, input)
+}
+
+/// The name of the default break-atomic-mode function
+const DEFAULT_CHECK_NAME: &str = "might_break_atomic_mode";
+
+/// Marks a function as a potential atomic-mode breaker.
+/// A check will be performed before the execution of the function body,
+/// and a panic will be triggered if the context where the function is called
+/// is in the atomic mode.
+///
+/// # Argument
+///
+/// - `arg`: The function that panics if the current context is in the atomic mode.
+///             It should be a function or a path to a function.
+///             If it is not provided, the default function `might_break_atomic_mode`
+///             will be used when there is one in the scope.
+///             Avoid using functions with the same name as the default one.
+///
+/// # Examples
+///
+/// Use the default check function defined in the scope.
+///
+/// ```rust
+/// fn might_break_atomic_mode() {
+///     // check if the current context is in the atomic mode,
+///     // and panic if it is
+/// }
+///
+/// #[atomic_mode_proc_macro::might_break]
+/// fn schedule() {
+///     // The check happens at the beginning.
+///     // Executes only if the current context is not in the atomic mode.
+/// }
+/// ```
+///
+/// Or, specify the check function via the argument.
+///
+/// ```rust
+/// fn custom_might_break_atomic_mode() {
+///     // check, panic if in atomic mode
+/// }
+///
+/// #[atomic_mode_proc_macro::might_break(custom_might_break_atomic_mode)]
+/// fn schedule() {
+///     // `custom_might_break_atomic_mode`
+///     // ....
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn might_break(arg: TokenStream, input: TokenStream) -> TokenStream {
+    let destructive_check_expr = if arg.is_empty() {
+        syn::parse_str::<Expr>(DEFAULT_CHECK_NAME).unwrap()
+    } else {
+        parse_macro_input!(arg as Expr)
+    };
+
+    let destructive_check = match destructive_check_expr {
+        Expr::Path(_) | Expr::Closure(_) => quote! {
+            let _atomic_breakable_check: fn() = #destructive_check_expr;
+            _atomic_breakable_check();
+        },
+        _ => quote! {
+            compile_error!("Expects an expression representing a function.");
+        },
+    };
+
+    exec_at_begin(destructive_check, input)
+}
+
+fn exec_at_begin(foreword: proc_macro2::TokenStream, func_token: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(func_token as ItemFn);
+    let function_name = &func.sig.ident;
+    let visibility = &func.vis;
+    let generics = &func.sig.generics;
+    let constness = &func.sig.constness;
+    let inputs = &func.sig.inputs;
+    let output = &func.sig.output;
+    let body = &func.block;
+    let attributes = &func.attrs;
+    let constraints = &func.sig.generics.where_clause;
+    quote! {
+        #(#attributes)*
+        #visibility #constness fn #function_name #generics (#inputs) #output
+        #constraints
+        {
+            #foreword
+            #body
+        }
+    }
+    .into()
+}

--- a/kernel/aster-nix/src/thread/task.rs
+++ b/kernel/aster-nix/src/thread/task.rs
@@ -31,10 +31,14 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Weak<Thread>
             user_mode.context().syscall_ret()
         );
         loop {
+            // Panics if in atomic mode
+            // Kernel should not return to user space when in atomic mode.
+            aster_frame::task::atomic::might_break_atomic_mode();
+
             let user_event = user_mode.execute();
             let context = user_mode.context_mut();
-            // handle user event:
             handle_user_event(user_event, context);
+
             let current_thread = current_thread!();
             // should be do this comparison before handle signal?
             if current_thread.status().lock().is_exited() {


### PR DESCRIPTION
Use atomic mode & `might_break` instead of the previous `PREEMPT_COUNT`.

When `#[might_break]` is added to `WaitQueue::do_wait`, the kernel runs into a panic: PREEMPT_COUNT = 2. There might be some misuse.