### PR TITLE
Fix the failing book publish CI action

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -27,8 +27,9 @@ jobs:
         env:
           BOOK_PUBLISH_KEY: ${{ secrets.BOOK_PUBLISH_KEY }}
         run: |
-          echo "$BOOK_PUBLISH_KEY " > ./book_publish_key
+          echo "$BOOK_PUBLISH_KEY\n" > ./book_publish_key
           chmod 600 ./book_publish_key
+          ssh-keygen -y -f ./book_publish_key > /dev/null
           ssh-keyscan -t rsa github.com >> ./known_hosts
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
This PR tries to solve the following error:
```
# github.com:22 SSH-2.0-babeld-05989c77
Cloning into 'temp_book'...
Load key "./book_publish_key": error in libcrypto
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

And:
- Add BOOK_PUBLISH_KEY format validation
- Append `\n` to the end of the private key file as a terminator