### PR TITLE
Bump version in github workflows to 0.4.2

### DIFF
--- a/.github/workflows/kernel_test.yml
+++ b/.github/workflows/kernel_test.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.4.1
+    container: asterinas/asterinas:0.4.2
     steps:
-      - run: echo "Running in asterinas/asterinas:0.4.1"
+      - run: echo "Running in asterinas/asterinas:0.4.2"
 
       - uses: actions/checkout@v4
       
@@ -23,9 +23,9 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.4.1
+    container: asterinas/asterinas:0.4.2
     steps:
-      - run: echo "Running in asterinas/asterinas:0.4.1"
+      - run: echo "Running in asterinas/asterinas:0.4.2"
 
       - uses: actions/checkout@v4
 
@@ -42,9 +42,9 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container: asterinas/asterinas:0.4.1
+    container: asterinas/asterinas:0.4.2
     steps:
-      - run: echo "Running in asterinas/asterinas:0.4.1"
+      - run: echo "Running in asterinas/asterinas:0.4.2"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/osdk_publish.yml
+++ b/.github/workflows/osdk_publish.yml
@@ -12,7 +12,7 @@ jobs:
   osdk-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: asterinas/asterinas:0.4.1
+    container: asterinas/asterinas:0.4.2
     steps:
       - uses: actions/checkout@v4
       - uses: katyo/publish-crates@v2

--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -14,10 +14,10 @@ on:
 jobs:
   osdk-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    container: asterinas/asterinas:0.4.1
+    timeout-minutes: 30
+    container: asterinas/asterinas:0.4.2
     steps:
-      - run: echo "Running in asterinas/asterinas:0.4.1"
+      - run: echo "Running in asterinas/asterinas:0.4.2"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.4.0
+    container: asterinas/asterinas:0.4.2
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Asterinas version has been bumped to 0.4.2, but some old workflow still uses the old version.

Further, increase the osdk test timeout from 15mins to 30mins. After adding to tests, the test seems does not finish in 15 mins.