### PR TITLE
Speed up stack unwinding

### DIFF
--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -28,7 +28,7 @@ spin = "0.9.4"
 static_assertions = "1.1.0"
 tdx-guest = { path = "../libs/tdx-guest", optional = true }
 trapframe = { git = "https://github.com/asterinas/trapframe-rs", rev = "2f37590" }
-unwinding = { version = "0.2.1", default-features = false, features = ["fde-static", "hide-trace", "panic", "personality", "unwinder"] }
+unwinding = { version = "0.2.1", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = { version = "0.4.5", features = ["unstable"] }
 
 [target.x86_64-unknown-none.dependencies]

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -28,6 +28,7 @@ SECTIONS
     .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA) { *(.rodata .rodata.*) }
 
     .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA) {
+        PROVIDE(__GNU_EH_FRAME_HDR = .);
         KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
     }
     . = ALIGN(8);


### PR DESCRIPTION
As mentioned in https://github.com/asterinas/asterinas/issues/481#issuecomment-2029037340, the `unwinding` crate supports FDE [binary search](https://github.com/nbdd0121/unwinding/blob/d7cd46e009ed1dbc762dbaaf4402f57973b300bb/src/unwinder/find_fde/gnu_eh_frame_hdr.rs#L41-L52) via the [`fde-gnu-eh-frame-hdr` feature](https://github.com/nbdd0121/unwinding/blob/d7cd46e009ed1dbc762dbaaf4402f57973b300bb/src/unwinder/find_fde/mod.rs#L46-L49).

So let's enable this feature. Then even in the debug mode and with KVM disabled, the stack unwinding will finish almost immediately.

Fixes #481