### PR TITLE
Fix a code format error in the trap handler (which fails the CI)

### DIFF
--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -22,10 +22,7 @@ use crate::{
     boot::memory_region::MemoryRegion,
     cpu::{CpuException, PageFaultErrorCode, PAGE_FAULT},
     cpu_local,
-    vm::{
-        page_table::PageTableFlagsTrait,
-        PageTable, PHYS_MEM_BASE_VADDR,
-    },
+    vm::{page_table::PageTableFlagsTrait, PageTable, PHYS_MEM_BASE_VADDR},
 };
 
 #[cfg(feature = "intel_tdx")]


### PR DESCRIPTION
Code format check policy varies across builds (of Rust). Updating the docker image may introduce more constraints.