### PR TITLE
Fix the kernel page fault handler

### DIFF
--- a/framework/aster-frame/src/vm/mod.rs
+++ b/framework/aster-frame/src/vm/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod page_table;
 mod space;
 
 use alloc::{borrow::ToOwned, vec::Vec};
+use core::ops::Range;
 
 use spin::Once;
 
@@ -48,22 +49,41 @@ pub const PAGE_SIZE: usize = 0x1000;
 /// for the rationale.
 pub const MAX_USERSPACE_VADDR: Vaddr = 0x0000_8000_0000_0000 - PAGE_SIZE;
 
-/// Start of the kernel address space.
-///
-/// This is the _lowest_ address of the x86-64's _high_ canonical addresses.
-///
-/// This is also the base address of the direct mapping of all physical
-/// memory in the kernel address space.
+/// The base address of the direct mapping of physical memory.
 pub(crate) const PHYS_MEM_BASE_VADDR: Vaddr = 0xffff_8000_0000_0000;
+
+/// The maximum size of the direct mapping of physical memory.
+///
+/// This size acts as a cap. If the actual memory size exceeds this value,
+/// the remaining memory cannot be included in the direct mapping because
+/// the maximum size of the direct mapping is limited by this value. On
+/// the other hand, if the actual memory size is smaller, the direct
+/// mapping can shrink to save memory consumption due to the page table.
+///
+/// We do not currently have APIs to manually map MMIO pages, so we have
+/// to rely on the direct mapping to perform MMIO operations. Therefore,
+/// we set the maximum size to 127 TiB, which makes some surprisingly
+/// high MMIO addresses usable (e.g., `0x7000_0000_7004` for VirtIO
+/// devices in the TDX environment) and leaves the last 1 TiB for other
+/// uses (e.g., the kernel code starting at [`kernel_loaded_offset()`]).
+pub(crate) const PHYS_MEM_MAPPING_MAX_SIZE: usize = 127 << 40;
+
+/// The address range of the direct mapping of physical memory.
+///
+/// This range is constructed based on [`PHYS_MEM_BASE_VADDR`] and
+/// [`PHYS_MEM_MAPPING_MAX_SIZE`].
+pub(crate) const PHYS_MEM_VADDR_RANGE: Range<Vaddr> =
+    PHYS_MEM_BASE_VADDR..(PHYS_MEM_BASE_VADDR + PHYS_MEM_MAPPING_MAX_SIZE);
 
 /// The kernel code is linear mapped to this address.
 ///
 /// FIXME: This offset should be randomly chosen by the loader or the
 /// boot compatibility layer. But we disabled it because the framework
 /// doesn't support relocatable kernel yet.
-pub fn kernel_loaded_offset() -> usize {
+pub const fn kernel_loaded_offset() -> usize {
     0xffff_ffff_8000_0000
 }
+const_assert!(PHYS_MEM_VADDR_RANGE.end < kernel_loaded_offset());
 
 /// Get physical address trait
 pub trait HasPaddr {
@@ -71,7 +91,7 @@ pub trait HasPaddr {
 }
 
 pub fn vaddr_to_paddr(va: Vaddr) -> Option<Paddr> {
-    if (PHYS_MEM_BASE_VADDR..=kernel_loaded_offset()).contains(&va) {
+    if PHYS_MEM_VADDR_RANGE.contains(&va) {
         // can use offset to get the physical address
         Some(va - PHYS_MEM_BASE_VADDR)
     } else {


### PR DESCRIPTION
Address https://github.com/asterinas/asterinas/pull/672#discussion_r1536848178:

> I think that the page fault should _not_ be handled unless we have _verified_ that handling it is correct. So we should never use `debug_assert` here. At least we should use `assert`, and even explicitly using `panic` might be worthwhile.
> 
> This also means that, we should check the conditions under which handling page fault _is_ correct (e.g., the page fault address falls in some range), not exclude the situations where handling page faults is _not_ correct (e.g., the page fault address falls out of some range).
> 
> In the following code, this argument actually appears in the comments: `Safety: The page fault address has been checked`. However, the statement is simply not true since `debug_assert` is used here.
> 
> I would suggest adding a constant `PHYS_MEM_CAP_VADDR`, which is `PHYS_MEM_BASE_VADDR + N TiB`, and checking that the page fault address actually falls within this range.

I think this is a huge soundness hole, and I don't think it's acceptable that even the kernel page fault handler is only a temporary workaround.

This PR introduces `PHYS_MEM_VADDR_RANGE`, which describes the (maximum allowed) address range for direct mapping of physical memory, and checks in the page fault handler if the fault address actually falls within this range.

NOTE: https://github.com/asterinas/asterinas/pull/672#issuecomment-2016872939 is *not* addressed, so the newly added pages in the direct physical memory mapping are still on a per-process basis. As a temporary workaround, this is fine for me, so I leave it as is.