### PR TITLE
Access the console device table with IRQ disabled

### DIFF
--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -28,7 +28,7 @@ pub fn register_device(name: String, device: Arc<dyn AnyConsoleDevice>) {
         .get()
         .unwrap()
         .console_device_table
-        .lock()
+        .lock_irq_disabled()
         .insert(name, device);
 }
 
@@ -37,13 +37,17 @@ pub fn get_device(str: &str) -> Option<Arc<dyn AnyConsoleDevice>> {
         .get()
         .unwrap()
         .console_device_table
-        .lock()
+        .lock_irq_disabled()
         .get(str)
         .cloned()
 }
 
 pub fn all_devices() -> Vec<(String, Arc<dyn AnyConsoleDevice>)> {
-    let console_devs = COMPONENT.get().unwrap().console_device_table.lock();
+    let console_devs = COMPONENT
+        .get()
+        .unwrap()
+        .console_device_table
+        .lock_irq_disabled();
     console_devs
         .iter()
         .map(|(name, device)| (name.clone(), device.clone()))


### PR DESCRIPTION
I've run into a hang with the following backtrace:
```
(gdb) bt
#0  core::sync::atomic::AtomicBool::compare_exchange (self=0xffffffff894b9a30 <aster_console::COMPONENT+24>, current=false, new=true, 
    success=core::sync::atomic::Ordering::Acquire, failure=core::sync::atomic::Ordering::Relaxed)
    at /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs:802
#1  0xffffffff88ffc88e in aster_frame::sync::spin::SpinLock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>>::try_acquire_lock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>> (self=0xffffffff894b9a18 <aster_console::COMPONENT>)
    at /root/asterinas/framework/aster-frame/src/sync/spin.rs:95
#2  0xffffffff88ffc818 in aster_frame::sync::spin::SpinLock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>>::acquire_lock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>> (self=0xffffffff894b9a18 <aster_console::COMPONENT>)
    at /root/asterinas/framework/aster-frame/src/sync/spin.rs:89
#3  0xffffffff88ffc96d in aster_frame::sync::spin::SpinLock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>>::lock<alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::sync::Arc<dyn aster_console::AnyConsoleDevice, alloc::alloc::Global>, alloc::alloc::Global>> (self=0xffffffff894b9a18 <aster_console::COMPONENT>)
    at /root/asterinas/framework/aster-frame/src/sync/spin.rs:67
#4  0xffffffff88ffc41b in aster_console::get_device (str=...) at src/lib.rs:36
#5  0xffffffff88f59fec in aster_virtio::device::console::device::handle_console_input () at src/device/console/device.rs:141
#6  0xffffffff88f85d18 in core::ops::function::Fn::call<fn(&trapframe::arch::trap::TrapFrame), (&trapframe::arch::trap::TrapFrame)> ()
    at /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79
#7  0xffffffff8910d053 in alloc::boxed::{impl#49}::call<(&trapframe::arch::trap::TrapFrame), (dyn core::ops::function::Fn<(&trapframe::arch::trap::TrapFrame), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=0xffffffff895b4380 <aster_frame::vm::heap_allocator::HEAP_SPACE+1025552>, 
    args=...) at /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2029
#8  0xffffffff88f89997 in aster_virtio::transport::mmio::multiplex::{impl#0}::new::{closure#0} (trap_frame=0xffff80007f0bf2b0)
    at src/transport/mmio/multiplex.rs:56
#9  0xffffffff8910d053 in alloc::boxed::{impl#49}::call<(&trapframe::arch::trap::TrapFrame), (dyn core::ops::function::Fn<(&trapframe::arch::trap::TrapFrame), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=0xffffffff895b5600 <aster_frame::vm::heap_allocator::HEAP_SPACE+1030288>, 
    args=...) at /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2029
#10 0xffffffff8914a22b in aster_frame::arch::x86::irq::CallbackElement::call (self=0xffffffff895b5600 <aster_frame::vm::heap_allocator::HEAP_SPACE+1030288>, 
    element=0xffff80007f0bf2b0) at src/arch/x86/irq.rs:55
#11 0xffffffff891225da in aster_frame::trap::handler::call_irq_callback_functions (trap_frame=0xffff80007f0bf2b0) at src/trap/handler.rs:162
#12 0xffffffff89121eae in aster_frame::trap::handler::trap_handler (f=0xffff80007f0bf2b0) at src/trap/handler.rs:148
#13 0xffffffff891ddafc in __from_kernel ()
```

Note that `console_device_table` is accessed in the IRQ handler. So it must be protected with `lock_irq_disabled()`.