### PR TITLE
Implement a safe and race-free `Waiter`

### DIFF
--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -190,7 +190,9 @@ impl Task {
 pub enum TaskStatus {
     /// The task is runnable.
     Runnable,
-    /// The task is sleeping.
+    /// The task is running in the foreground but will sleep when it goes to the background.
+    Sleepy,
+    /// The task is sleeping in the background.
     Sleeping,
     /// The task has exited.
     Exited,


### PR DESCRIPTION
I fixed some race conditions in `Waiter` last year, in #565.

Unforunately, #722 re-introduces the race conditions that were already fixed in #565.

Sorry about that, but I'm a bit tired about elaborating the race conditions again. Please refer the details to #565 directly.

This PR also fixes the problem that was pointed in #565 but was not fixed there. Quoting below:
> FYI: `Waiter::wake_up()` has another problem where the same task can be added to the schedule queue multiple times before the task has ever been dequeued (`Waiter::wait()` may not call `schedule()` after all). This is a separate issue and is _not_ covered by this PR. There is actually another race condition between `task_status = TaskStatus::Sleeping` and `schedule()`, forcing us to keep additional information or add another task state in the `Task` structure before we can solve this problem. Linux has encountered [similar problems](https://elixir.bootlin.com/linux/v6.7-rc7/source/kernel/sched/core.c#L3800) either.

Moreover, #721 wants `Waiter` to have safer APIs, so that `Waiter` can be made public. This PR refines the APIs of `Waiter` and I think now there is no problem to make it public.

I think it's better to add some unit tests for the new APIs of `Waiter`, especially if we finally decide to accept them as public APIs. But I think I cannot do that due to #696.