### PR TITLE
Enable softirq mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,7 @@ dependencies = [
  "acpi",
  "align_ext",
  "aml",
+ "array-init",
  "aster-main",
  "bit_field",
  "bitflags 1.3.2",

--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -20,7 +20,8 @@ xarray = { git = "https://github.com/asterinas/xarray", rev = "72a4067" }
 int-to-c-enum = { path = "../../kernel/libs/int-to-c-enum" }
 # instrusive-collections of version 0.9.6 fails to compile with current rust toolchain,
 # So we set a fixed version 0.9.5 for this crate
-intrusive-collections = "=0.9.5"
+intrusive-collections = { version = "=0.9.5", features = ["nightly"] }
+array-init = "2.0"
 ktest = { path = "../libs/ktest" }
 id-alloc = { path = "../libs/id-alloc" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }

--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -162,11 +162,16 @@ pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {
     for callback_function in callback_functions.iter() {
         callback_function.call(trap_frame);
     }
+    drop(callback_functions);
+
     if !CpuException::is_cpu_exception(trap_frame.trap_num as u16) {
         crate::arch::interrupts_ack();
     }
 
     IN_INTERRUPT_CONTEXT.store(false, Ordering::Release);
+
+    crate::arch::irq::enable_local();
+    crate::trap::softirq::process_pending();
 }
 
 cpu_local! {

--- a/framework/aster-frame/src/trap/mod.rs
+++ b/framework/aster-frame/src/trap/mod.rs
@@ -2,8 +2,10 @@
 
 mod handler;
 mod irq;
+pub mod softirq;
 
 pub use handler::in_interrupt_context;
+pub use softirq::SoftIrqLine;
 pub use trapframe::TrapFrame;
 
 pub(crate) use self::handler::call_irq_callback_functions;
@@ -15,4 +17,5 @@ pub(crate) fn init() {
     unsafe {
         trapframe::init();
     }
+    softirq::init();
 }

--- a/framework/aster-frame/src/trap/softirq.rs
+++ b/framework/aster-frame/src/trap/softirq.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+use spin::Once;
+
+use crate::{cpu_local, task::disable_preempt, CpuLocal};
+
+/// A representation of a software interrupt (softirq) line.
+///
+/// # Overview
+///
+/// Softirq is an interrupt mechanism in the kernel that enables bottom-half processing;
+/// they are cheaper to execute compared to regular interrupts because softirqs are less
+/// time-critical and thus can be processed in a more flexible manner.
+///
+/// The `SoftIrqLine` struct encapsulates the data and functionality associated with each
+/// softirq line, including an identifier and an associated callback that gets triggered
+/// when the softirq is raised.
+///
+/// The `SoftIrqLine` with the smaller ID has the higher execution priority.
+///
+/// # Example
+///
+/// ```
+/// // Define an unused softirq id.
+/// const MY_SOFTIRQ_ID: u8 = 4;
+/// // Enable the softirq line of this id.
+/// SoftIrqLine::get(MY_SOFTIRQ_ID).enable(|| {
+///     // Define the action to take when the softirq with MY_SOFTIRQ_ID is raised
+///     ...
+/// });
+/// // Later on:
+/// SoftIrqLine::get(MY_SOFTIRQ_ID).raise(); // This will trigger the registered callback
+/// ```
+pub struct SoftIrqLine {
+    id: u8,
+    callback: Once<Box<dyn Fn() + 'static + Sync + Send>>,
+}
+
+impl SoftIrqLine {
+    /// The number of softirq lines.
+    const NR_LINES: u8 = 8;
+
+    /// Gets a softirq line.
+    ///
+    /// The value of `id` must be within `0..NR_LINES`.
+    pub fn get(id: u8) -> &'static SoftIrqLine {
+        &LINES.get().unwrap()[id as usize]
+    }
+
+    const fn new(id: u8) -> Self {
+        Self {
+            id,
+            callback: Once::new(),
+        }
+    }
+
+    /// Gets the ID of this softirq line.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// Raises the softirq, marking it as pending.
+    ///
+    /// If this line is not enabled yet, the method has no effect.
+    pub fn raise(&self) {
+        CpuLocal::borrow_with(&PENDING_MASK, |mask| {
+            mask.fetch_or(1 << self.id, Ordering::Release);
+        });
+    }
+
+    /// Enables a softirq line by registering its callback.
+    ///
+    /// # Panic
+    ///
+    /// Each softirq can only be enabled once.
+    pub fn enable<F>(&self, callback: F)
+    where
+        F: Fn() + 'static + Sync + Send,
+    {
+        assert!(!self.is_enabled());
+
+        self.callback.call_once(|| Box::new(callback));
+        ENABLED_MASK.fetch_or(1 << self.id, Ordering::Release);
+    }
+
+    /// Returns whether this softirq line is enabled.
+    pub fn is_enabled(&self) -> bool {
+        ENABLED_MASK.load(Ordering::Acquire) & (1 << self.id) != 0
+    }
+}
+
+/// A slice that stores the `SoftIrqLine`s, whose ID is equal to its offset in the slice.
+static LINES: Once<[SoftIrqLine; SoftIrqLine::NR_LINES as usize]> = Once::new();
+
+pub(super) fn init() {
+    let lines: [SoftIrqLine; SoftIrqLine::NR_LINES as usize] =
+        array_init::array_init(|i| SoftIrqLine::new(i as u8));
+    LINES.call_once(|| lines);
+}
+
+static ENABLED_MASK: AtomicU8 = AtomicU8::new(0);
+
+cpu_local! {
+    static PENDING_MASK: AtomicU8 = AtomicU8::new(0);
+    static IS_ENABLED: AtomicBool = AtomicBool::new(true);
+}
+
+/// Enables softirq in current processor.
+fn enable_softirq_local() {
+    CpuLocal::borrow_with(&IS_ENABLED, |is_enabled| {
+        is_enabled.store(true, Ordering::Release)
+    })
+}
+
+/// Disables softirq in current processor.
+fn disable_softirq_local() {
+    CpuLocal::borrow_with(&IS_ENABLED, |is_enabled| {
+        is_enabled.store(false, Ordering::Release)
+    })
+}
+
+/// Checks whether the softirq is enabled in current processor.
+fn is_softirq_enabled() -> bool {
+    CpuLocal::borrow_with(&IS_ENABLED, |is_enabled| is_enabled.load(Ordering::Acquire))
+}
+
+/// Processes pending softirqs.
+///
+/// The processing instructions will iterate for `SOFTIRQ_RUN_TIMES` times. If any softirq
+/// is raised during the iteration, it will be processed.
+pub(crate) fn process_pending() {
+    const SOFTIRQ_RUN_TIMES: u8 = 5;
+
+    if !is_softirq_enabled() {
+        return;
+    }
+
+    let preempt_guard = disable_preempt();
+    disable_softirq_local();
+
+    CpuLocal::borrow_with(&PENDING_MASK, |mask| {
+        for i in 0..SOFTIRQ_RUN_TIMES {
+            // will not reactive in this handling.
+            let mut action_mask = {
+                let pending_mask = mask.fetch_and(0, Ordering::Acquire);
+                pending_mask & ENABLED_MASK.load(Ordering::Acquire)
+            };
+
+            if action_mask == 0 {
+                return;
+            }
+            while action_mask > 0 {
+                let action_id = u8::trailing_zeros(action_mask) as u8;
+                SoftIrqLine::get(action_id).callback.get().unwrap()();
+                action_mask &= action_mask - 1;
+            }
+        }
+    });
+    enable_softirq_local();
+}

--- a/framework/libs/id-alloc/src/lib.rs
+++ b/framework/libs/id-alloc/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![cfg_attr(not(test), no_std)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use core::{fmt::Debug, ops::Range};
 

--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -59,7 +59,9 @@ pub mod net;
 pub mod prelude;
 mod process;
 mod sched;
+pub mod softirq_id;
 pub mod syscall;
+mod taskless;
 pub mod thread;
 pub mod time;
 mod util;
@@ -75,6 +77,7 @@ pub fn init() {
     fs::rootfs::init(boot::initramfs()).unwrap();
     device::init().unwrap();
     vdso::init();
+    taskless::init();
 }
 
 fn init_thread() {

--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The std library of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(unused_variables)]

--- a/kernel/aster-nix/src/softirq_id.rs
+++ b/kernel/aster-nix/src/softirq_id.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Defines the used IDs of software interrupt (softirq) lines.
+
+/// The corresponding softirq line is used to schedule urgent taskless jobs.
+pub const TASKLESS_URGENT_SOFTIRQ_ID: u8 = 0;
+
+/// The corresponding softirq line is used to manage timers and handle
+/// time-related jobs.
+pub const TIMER_SOFTIRQ_ID: u8 = 1;
+
+/// The corresponding softirq line is used to schedule general taskless jobs.
+pub const TASKLESS_SOFTIRQ_ID: u8 = 2;

--- a/kernel/aster-nix/src/taskless.rs
+++ b/kernel/aster-nix/src/taskless.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, sync::Arc};
+use core::{
+    cell::RefCell,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use aster_frame::{cpu_local, sync::SpinLock, trap::SoftIrqLine, CpuLocal};
+use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListAtomicLink};
+
+use crate::softirq_id::{TASKLESS_SOFTIRQ_ID, TASKLESS_URGENT_SOFTIRQ_ID};
+
+/// `Taskless` represents a _taskless_ job whose execution is deferred to a later time.
+///
+/// # Overview
+///
+/// `Taskless` provides one "bottom half" mechanism for interrupt handling.
+/// With `Taskless`, one can defer the execution of certain logic
+/// that would have been otherwise executed in interrupt handlers.
+/// `Taskless` makes interrupt handlers finish more quickly,
+/// thereby minimizing the periods of time when the interrupts are disabled.
+///
+/// `Taskless` executes the deferred jobs via the softirq mechanism,
+/// rather than doing them with `Task`s.
+/// As such, these deferred, taskless jobs can be executed within only a small delay,
+/// after the execution of an interrupt handler that schedules the taskless jobs.
+/// As the taskless jobs are not executed in the task context,
+/// they are not allowed to sleep.
+///
+/// An `Taskless` instance may be scheduled to run multiple times,
+/// but it is guaranteed that a single taskless job will not be run concurrently.
+/// Also, a taskless job will not be preempted by another.
+/// This makes the programming of a taskless job simpler.
+/// Different taskless jobs are allowed to run concurrently.
+/// Once a taskless has entered the execution state, it can be scheduled again.
+///
+/// # Example
+///
+/// Users can create a `Taskless` and schedule it at any place.
+/// ```rust
+/// #use aster_frame::softirq::Taskless;
+///
+/// #fn my_func() {}
+///
+/// let taskless = Taskless::new(my_func);
+/// // This taskless job will be executed in softirq context soon.
+/// taskless.schedule();
+///
+/// ```
+pub struct Taskless {
+    /// Whether the taskless job has been scheduled.
+    is_scheduled: AtomicBool,
+    /// Whether the taskless job is running.
+    is_running: AtomicBool,
+    /// The function that will be called when executing this taskless job.
+    callback: Box<RefCell<dyn FnMut() + Send + Sync + 'static>>,
+    /// Whether this `Taskless` is disabled.
+    is_disabled: AtomicBool,
+    link: LinkedListAtomicLink,
+}
+
+intrusive_adapter!(TasklessAdapter = Arc<Taskless>: Taskless { link: LinkedListAtomicLink });
+
+cpu_local! {
+    static TASKLESS_LIST: SpinLock<LinkedList<TasklessAdapter>> = SpinLock::new(LinkedList::new(TasklessAdapter::NEW));
+    static TASKLESS_URGENT_LIST: SpinLock<LinkedList<TasklessAdapter>> = SpinLock::new(LinkedList::new(TasklessAdapter::NEW));
+}
+
+impl Taskless {
+    /// Creates a new `Taskless` instance with its callback function.
+    pub fn new<F>(callback: F) -> Arc<Self>
+    where
+        F: FnMut() + Send + Sync + 'static,
+    {
+        // Since the same taskless will not be executed concurrently,
+        // it is safe to use a `RefCell` here though the `Taskless` will
+        // be put into an `Arc`.
+        #[allow(clippy::arc_with_non_send_sync)]
+        Arc::new(Self {
+            is_scheduled: AtomicBool::new(false),
+            is_running: AtomicBool::new(false),
+            callback: Box::new(RefCell::new(callback)),
+            is_disabled: AtomicBool::new(false),
+            link: LinkedListAtomicLink::new(),
+        })
+    }
+
+    /// Schedules this taskless job and it will be executed in later time.
+    ///
+    /// If the taskless job has been scheduled, this function will do nothing.
+    pub fn schedule(self: &Arc<Self>) {
+        do_schedule(self, &TASKLESS_LIST);
+        SoftIrqLine::get(TASKLESS_SOFTIRQ_ID).raise();
+    }
+
+    /// Schedules this taskless job and it will be executed urgently
+    /// in softirq context.
+    ///
+    /// If the taskless job has been scheduled, this function will do nothing.
+    pub fn schedule_urgent(self: &Arc<Self>) {
+        do_schedule(self, &TASKLESS_URGENT_LIST);
+        SoftIrqLine::get(TASKLESS_URGENT_SOFTIRQ_ID).raise();
+    }
+
+    /// Enables this `Taskless` so that it can be executed once it has been scheduled.
+    ///
+    /// A new `Taskless` is enabled by default.
+    pub fn enable(&self) {
+        self.is_disabled.store(false, Ordering::Release);
+    }
+
+    /// Disables this `Taskless` so that it can not be scheduled. Note that if the `Taskless`
+    /// has been scheduled, it can still continue to complete this job.
+    pub fn disable(&self) {
+        self.is_disabled.store(true, Ordering::Release);
+    }
+}
+
+fn do_schedule(
+    taskless: &Arc<Taskless>,
+    taskless_list: &'static CpuLocal<SpinLock<LinkedList<TasklessAdapter>>>,
+) {
+    if taskless.is_disabled.load(Ordering::Acquire) {
+        return;
+    }
+    if taskless
+        .is_scheduled
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+
+    CpuLocal::borrow_with(taskless_list, |list| {
+        list.lock_irq_disabled().push_front(taskless.clone());
+    });
+}
+
+pub(super) fn init() {
+    SoftIrqLine::get(TASKLESS_URGENT_SOFTIRQ_ID)
+        .enable(|| taskless_softirq_handler(&TASKLESS_URGENT_LIST, TASKLESS_URGENT_SOFTIRQ_ID));
+    SoftIrqLine::get(TASKLESS_SOFTIRQ_ID)
+        .enable(|| taskless_softirq_handler(&TASKLESS_LIST, TASKLESS_SOFTIRQ_ID));
+}
+
+/// Executes the pending taskless jobs in the input `taskless_list`.
+///
+/// This function will retrieve each `Taskless` in the input `taskless_list`
+/// and leave it empty. If a `Taskless` is running then this function will
+/// ignore it and jump to the next `Taskless`, then put it to the input `taskless_list`.
+///
+/// If the `Taskless` is ready to be executed, it will be set to not scheduled
+/// and can be scheduled again.
+fn taskless_softirq_handler(
+    taskless_list: &'static CpuLocal<SpinLock<LinkedList<TasklessAdapter>>>,
+    softirq_id: u8,
+) {
+    let mut processing_list = CpuLocal::borrow_with(taskless_list, |list| {
+        let mut list_mut = list.lock_irq_disabled();
+        LinkedList::take(&mut list_mut)
+    });
+
+    while let Some(taskless) = processing_list.pop_back() {
+        if taskless
+            .is_running
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            CpuLocal::borrow_with(taskless_list, |list| {
+                list.lock_irq_disabled().push_front(taskless);
+                SoftIrqLine::get(softirq_id).raise();
+            });
+            continue;
+        }
+
+        taskless.is_scheduled.store(false, Ordering::Release);
+
+        // The same taskless will not be executing concurrently, so it is safe to
+        // do `borrow_mut` here.
+        (taskless.callback.borrow_mut())();
+        taskless.is_running.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use core::sync::atomic::AtomicUsize;
+
+    use aster_frame::trap::enable_local;
+
+    use super::*;
+
+    fn init() {
+        static DONE: AtomicBool = AtomicBool::new(false);
+        if !DONE.load(Ordering::SeqCst) {
+            super::init();
+            enable_local();
+            DONE.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[ktest]
+    fn schedule_taskless() {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        const SCHEDULE_TIMES: usize = 10;
+
+        fn add_counter() {
+            COUNTER.fetch_add(1, Ordering::Relaxed);
+        }
+
+        init();
+        let taskless = Taskless::new(add_counter);
+        let mut counter = 0;
+
+        // Schedule this taskless for `SCHEDULE_TIMES`.
+        while taskless.is_scheduled.load(Ordering::Acquire) == false {
+            taskless.schedule();
+            counter += 1;
+            if counter == SCHEDULE_TIMES {
+                break;
+            }
+        }
+
+        // Wait for all taskless having finished.
+        while taskless.is_running.load(Ordering::Acquire)
+            || taskless.is_scheduled.load(Ordering::Acquire)
+        {}
+
+        assert_eq!(counter, COUNTER.load(Ordering::Relaxed));
+    }
+}

--- a/kernel/aster-nix/src/time/mod.rs
+++ b/kernel/aster-nix/src/time/mod.rs
@@ -12,6 +12,7 @@ use crate::prelude::*;
 
 pub mod clocks;
 mod core;
+mod softirq;
 mod system_time;
 pub mod wait;
 
@@ -23,6 +24,7 @@ pub type clock_t = i64;
 pub(super) fn init() {
     system_time::init();
     clocks::init();
+    softirq::init();
 }
 
 #[repr(C)]

--- a/kernel/aster-nix/src/time/softirq.rs
+++ b/kernel/aster-nix/src/time/softirq.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, vec::Vec};
+
+use aster_frame::{arch::timer, sync::RwLock, trap::SoftIrqLine};
+
+use crate::softirq_id::TIMER_SOFTIRQ_ID;
+
+static TIMER_SOFTIRQ_CALLBACKS: RwLock<Vec<Box<dyn Fn() + Sync + Send>>> = RwLock::new(Vec::new());
+
+pub(super) fn init() {
+    SoftIrqLine::get(TIMER_SOFTIRQ_ID).enable(timer_softirq_handler);
+
+    timer::register_callback(|| {
+        SoftIrqLine::get(TIMER_SOFTIRQ_ID).raise();
+    });
+}
+
+/// Registers a function that will be executed during timer softirq.
+pub(super) fn register_callback<F>(func: F)
+where
+    F: Fn() + Sync + Send + 'static,
+{
+    TIMER_SOFTIRQ_CALLBACKS
+        .write_irq_disabled()
+        .push(Box::new(func));
+}
+
+fn timer_softirq_handler() {
+    let callbacks = TIMER_SOFTIRQ_CALLBACKS.read_irq_disabled();
+    for callback in callbacks.iter() {
+        (callback)();
+    }
+}

--- a/kernel/comps/block/src/lib.rs
+++ b/kernel/comps/block/src/lib.rs
@@ -27,7 +27,7 @@
 //! ```
 //!
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(fn_traits)]
 #![feature(step_trait)]
 #![allow(dead_code)]

--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The console device of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(fn_traits)]
 
 extern crate alloc;

--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The framebuffer of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(strict_provenance)]
 
 extern crate alloc;

--- a/kernel/comps/input/src/lib.rs
+++ b/kernel/comps/input/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The input devices of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(fn_traits)]
 
 extern crate alloc;

--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(trait_alias)]
 #![feature(fn_traits)]
 #![feature(linked_list_cursors)]

--- a/kernel/comps/time/src/lib.rs
+++ b/kernel/comps/time/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The system time of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 extern crate alloc;
 

--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The virtio of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![allow(dead_code)]
 #![feature(fn_traits)]
 

--- a/kernel/libs/aster-util/src/lib.rs
+++ b/kernel/libs/aster-util/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! The util of Asterinas.
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(int_roundings)]
 
 extern crate alloc;

--- a/kernel/libs/comp-sys/component-macro/src/lib.rs
+++ b/kernel/libs/comp-sys/component-macro/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![feature(proc_macro_diagnostic)]
 #![allow(dead_code)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod init_comp;
 mod priority;

--- a/kernel/libs/comp-sys/component/src/lib.rs
+++ b/kernel/libs/comp-sys/component/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![feature(fn_traits)]
 
 extern crate alloc;

--- a/kernel/libs/cpio-decoder/src/lib.rs
+++ b/kernel/libs/cpio-decoder/src/lib.rs
@@ -16,7 +16,7 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![allow(dead_code)]
 
 extern crate alloc;

--- a/kernel/libs/keyable-arc/src/lib.rs
+++ b/kernel/libs/keyable-arc/src/lib.rs
@@ -104,7 +104,7 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(coerce_unsized)]
 #![feature(unsize)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 extern crate alloc;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 extern crate aster_frame;
 
 use aster_frame::prelude::*;

--- a/osdk/src/commands/new/kernel.template
+++ b/osdk/src/commands/new/kernel.template
@@ -1,5 +1,5 @@
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use aster_frame::prelude::*;
 

--- a/osdk/src/commands/new/lib.template
+++ b/osdk/src/commands/new/lib.template
@@ -1,5 +1,5 @@
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 #[macro_use]
 extern crate ktest;

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/myos/src/lib.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/myos/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use aster_frame::prelude::*;
 


### PR DESCRIPTION
Based on PR #721 

Current implementation will execute softirq at the return of the hardware interruption. Future should enable ksoftirqd/n thread.
