### PR TITLE
Reconstruct sys_utimenstat and add sys_futimesat/sys_utimes/sys_utime

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -152,7 +152,7 @@ provided by Linux on x86-64 architecture.
 | 129     | rt_sigqueueinfo  | ❌              |
 | 130     | rt_sigsuspend    | ✅              |
 | 131     | sigaltstack      | ✅              |
-| 132     | utime            | ❌              |
+| 132     | utime            | ✅              |
 | 133     | mknod            | ❌              |
 | 134     | uselib           | ❌              |
 | 135     | personality      | ❌              |
@@ -255,7 +255,7 @@ provided by Linux on x86-64 architecture.
 | 232     | epoll_wait       | ✅              |
 | 233     | epoll_ctl        | ✅              |
 | 234     | tgkill           | ✅              |
-| 235     | utimes           | ❌              |
+| 235     | utimes           | ✅              |
 | 236     | vserver          | ❌              |
 | 237     | mbind            | ❌              |
 | 238     | set_mempolicy    | ❌              |
@@ -281,7 +281,7 @@ provided by Linux on x86-64 architecture.
 | 258     | mkdirat          | ✅              |
 | 259     | mknodat          | ❌              |
 | 260     | fchownat         | ✅              |
-| 261     | futimesat        | ❌              |
+| 261     | futimesat        | ✅              |
 | 262     | newfstatat       | ✅              |
 | 263     | unlinkat         | ✅              |
 | 264     | renameat         | ✅              |

--- a/kernel/aster-nix/src/fs/devpts/mod.rs
+++ b/kernel/aster-nix/src/fs/devpts/mod.rs
@@ -210,6 +210,14 @@ impl Inode for RootInode {
         self.metadata.write().mtime = time;
     }
 
+    fn ctime(&self) -> Duration {
+        self.metadata.read().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::EPERM))
     }

--- a/kernel/aster-nix/src/fs/devpts/ptmx.rs
+++ b/kernel/aster-nix/src/fs/devpts/ptmx.rs
@@ -124,6 +124,14 @@ impl Inode for Ptmx {
         self.metadata.write().mtime = time;
     }
 
+    fn ctime(&self) -> Duration {
+        self.metadata.read().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         Ok(0)
     }

--- a/kernel/aster-nix/src/fs/devpts/slave.rs
+++ b/kernel/aster-nix/src/fs/devpts/slave.rs
@@ -105,6 +105,14 @@ impl Inode for PtySlaveInode {
         self.metadata.write().mtime = time;
     }
 
+    fn ctime(&self) -> Duration {
+        self.metadata.read().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         self.device.read(buf)
     }

--- a/kernel/aster-nix/src/fs/exfat/inode.rs
+++ b/kernel/aster-nix/src/fs/exfat/inode.rs
@@ -1171,6 +1171,14 @@ impl Inode for ExfatInode {
         self.inner.write().mtime = DosTimestamp::from_duration(time).unwrap_or_default();
     }
 
+    fn ctime(&self) -> Duration {
+        self.inner.read().ctime.as_duration().unwrap_or_default()
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.inner.write().ctime = DosTimestamp::from_duration(time).unwrap_or_default();
+    }
+
     fn owner(&self) -> Result<Uid> {
         Ok(Uid::new(
             self.inner.read().fs().mount_option().fs_uid as u32,

--- a/kernel/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
@@ -61,6 +61,14 @@ impl Inode for Ext2Inode {
         self.set_mtime(time)
     }
 
+    fn ctime(&self) -> Duration {
+        self.ctime()
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.set_ctime(time)
+    }
+
     fn ino(&self) -> u64 {
         self.ino() as _
     }

--- a/kernel/aster-nix/src/fs/ext2/inode.rs
+++ b/kernel/aster-nix/src/fs/ext2/inode.rs
@@ -13,6 +13,7 @@ use super::{
     indirect_block_cache::{IndirectBlock, IndirectBlockCache},
     prelude::*,
 };
+use crate::time::clocks::RealTimeCoarseClock;
 
 /// Max length of file name.
 pub const MAX_FNAME_LEN: usize = 255;
@@ -572,6 +573,7 @@ impl Inode {
     pub fn set_gid(&self, gid: u32);
     pub fn set_atime(&self, time: Duration);
     pub fn set_mtime(&self, time: Duration);
+    pub fn set_ctime(&self, time: Duration);
 }
 
 impl Debug for Inode {
@@ -609,6 +611,7 @@ impl Inner {
     pub fn mtime(&self) -> Duration;
     pub fn set_mtime(&mut self, time: Duration);
     pub fn ctime(&self) -> Duration;
+    pub fn set_ctime(&mut self, time: Duration);
     pub fn set_device_id(&mut self, device_id: u64);
     pub fn device_id(&self) -> u64;
     pub fn sync_metadata(&self) -> Result<()>;
@@ -1534,6 +1537,11 @@ impl InodeImpl {
         self.0.read().desc.ctime
     }
 
+    pub fn set_ctime(&self, time: Duration) {
+        let mut inner = self.0.write();
+        inner.desc.ctime = time;
+    }
+
     pub fn read_block_sync(&self, bid: Ext2Bid, block: &Frame) -> Result<()> {
         self.0.read().read_block_sync(bid, block)
     }
@@ -1710,15 +1718,16 @@ impl TryFrom<RawInode> for InodeDesc {
 
 impl InodeDesc {
     pub fn new(type_: FileType, perm: FilePerm) -> Dirty<Self> {
+        let now = RealTimeCoarseClock::get().read_time();
         Dirty::new_dirty(Self {
             type_,
             perm,
             uid: 0,
             gid: 0,
             size: 0,
-            atime: Duration::ZERO,
-            ctime: Duration::ZERO,
-            mtime: Duration::ZERO,
+            atime: now,
+            ctime: now,
+            mtime: now,
             dtime: Duration::ZERO,
             hard_links: 1,
             blocks_count: 0,

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -314,6 +314,8 @@ impl Dentry_ {
     pub fn set_atime(&self, time: Duration);
     pub fn mtime(&self) -> Duration;
     pub fn set_mtime(&self, time: Duration);
+    pub fn ctime(&self) -> Duration;
+    pub fn set_ctime(&self, time: Duration);
 }
 
 impl Debug for Dentry_ {
@@ -693,6 +695,8 @@ impl Dentry {
     pub fn set_atime(&self, time: Duration);
     pub fn mtime(&self) -> Duration;
     pub fn set_mtime(&self, time: Duration);
+    pub fn ctime(&self) -> Duration;
+    pub fn set_ctime(&self, time: Duration);
     pub fn key(&self) -> DentryKey;
     pub fn inode(&self) -> &Arc<dyn Inode>;
     pub fn is_root_of_mount(&self) -> bool;

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -10,6 +10,7 @@ use crate::{
     events::{IoEvents, Observer},
     prelude::*,
     process::{signal::Poller, Gid, Uid},
+    time::clocks::RealTimeCoarseClock,
 };
 
 pub struct PipeReader {
@@ -44,15 +45,16 @@ impl FileLike for PipeReader {
     }
 
     fn metadata(&self) -> Metadata {
+        let now = RealTimeCoarseClock::get().read_time();
         Metadata {
             dev: 0,
             ino: 0,
             size: 0,
             blk_size: 0,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::NamedPipe,
             mode: InodeMode::from_bits_truncate(0o400),
             nlinks: 1,
@@ -110,15 +112,16 @@ impl FileLike for PipeWriter {
     }
 
     fn metadata(&self) -> Metadata {
+        let now = RealTimeCoarseClock::get().read_time();
         Metadata {
             dev: 0,
             ino: 0,
             size: 0,
             blk_size: 0,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::NamedPipe,
             mode: InodeMode::from_bits_truncate(0o200),
             nlinks: 1,

--- a/kernel/aster-nix/src/fs/procfs/template/dir.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/dir.rs
@@ -81,6 +81,8 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
     fn set_atime(&self, time: Duration);
     fn mtime(&self) -> Duration;
     fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/aster-nix/src/fs/procfs/template/file.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/file.rs
@@ -50,6 +50,8 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
     fn set_atime(&self, time: Duration);
     fn mtime(&self) -> Duration;
     fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/aster-nix/src/fs/procfs/template/mod.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/mod.rs
@@ -71,6 +71,14 @@ impl Common {
         self.metadata.write().mtime = time;
     }
 
+    pub fn ctime(&self) -> Duration {
+        self.metadata.read().ctime
+    }
+
+    pub fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
     pub fn mode(&self) -> Result<InodeMode> {
         Ok(self.metadata.read().mode)
     }

--- a/kernel/aster-nix/src/fs/procfs/template/sym.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/sym.rs
@@ -47,6 +47,8 @@ impl<S: SymOps + 'static> Inode for ProcSym<S> {
     fn set_atime(&self, time: Duration);
     fn mtime(&self) -> Duration;
     fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/aster-nix/src/fs/ramfs/fs.rs
+++ b/kernel/aster-nix/src/fs/ramfs/fs.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     prelude::*,
     process::{signal::Poller, Gid, Uid},
+    time::clocks::RealTimeCoarseClock,
     vm::vmo::Vmo,
 };
 
@@ -188,12 +189,13 @@ struct InodeMeta {
 
 impl InodeMeta {
     pub fn new(mode: InodeMode, uid: Uid, gid: Gid) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             size: 0,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             mode,
             nlinks: 1,
             uid,
@@ -202,12 +204,13 @@ impl InodeMeta {
     }
 
     pub fn new_dir(mode: InodeMode, uid: Uid, gid: Gid) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             size: 2,
             blocks: 1,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             mode,
             nlinks: 2,
             uid,
@@ -572,6 +575,14 @@ impl Inode for RamInode {
 
     fn set_mtime(&self, time: Duration) {
         self.node.write().metadata.mtime = time;
+    }
+
+    fn ctime(&self) -> Duration {
+        self.node.read().metadata.ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.node.write().metadata.ctime = time;
     }
 
     fn ino(&self) -> u64 {

--- a/kernel/aster-nix/src/fs/utils/inode.rs
+++ b/kernel/aster-nix/src/fs/utils/inode.rs
@@ -13,6 +13,7 @@ use crate::{
     fs::device::{Device, DeviceType},
     prelude::*,
     process::{signal::Poller, Gid, Uid},
+    time::clocks::RealTimeCoarseClock,
     vm::vmo::Vmo,
 };
 
@@ -137,15 +138,16 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn new_dir(ino: u64, mode: InodeMode, blk_size: usize) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             dev: 0,
             ino,
             size: 2,
             blk_size,
             blocks: 1,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::Dir,
             mode,
             nlinks: 2,
@@ -156,15 +158,16 @@ impl Metadata {
     }
 
     pub fn new_file(ino: u64, mode: InodeMode, blk_size: usize) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             dev: 0,
             ino,
             size: 0,
             blk_size,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::File,
             mode,
             nlinks: 1,
@@ -175,15 +178,16 @@ impl Metadata {
     }
 
     pub fn new_symlink(ino: u64, mode: InodeMode, blk_size: usize) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             dev: 0,
             ino,
             size: 0,
             blk_size,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::SymLink,
             mode,
             nlinks: 1,
@@ -193,15 +197,16 @@ impl Metadata {
         }
     }
     pub fn new_device(ino: u64, mode: InodeMode, blk_size: usize, device: &dyn Device) -> Self {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             dev: 0,
             ino,
             size: 0,
             blk_size,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::from(device.type_()),
             mode,
             nlinks: 1,
@@ -212,15 +217,16 @@ impl Metadata {
     }
 
     pub fn new_socket(ino: u64, mode: InodeMode, blk_size: usize) -> Metadata {
+        let now = RealTimeCoarseClock::get().read_time();
         Self {
             dev: 0,
             ino,
             size: 0,
             blk_size,
             blocks: 0,
-            atime: Default::default(),
-            mtime: Default::default(),
-            ctime: Default::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
             type_: InodeType::Socket,
             mode,
             nlinks: 1,
@@ -261,6 +267,10 @@ pub trait Inode: Any + Sync + Send {
     fn mtime(&self) -> Duration;
 
     fn set_mtime(&self, time: Duration);
+
+    fn ctime(&self) -> Duration;
+
+    fn set_ctime(&self, time: Duration);
 
     fn page_cache(&self) -> Option<Vmo<Full>> {
         None

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -115,7 +115,7 @@ use crate::syscall::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
-    utimens::sys_utimensat,
+    utimens::{sys_futimesat, sys_utime, sys_utimensat, sys_utimes},
     wait4::sys_wait4,
     waitid::sys_waitid,
     write::sys_write,
@@ -225,6 +225,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RT_SIGPENDING = 127    => sys_rt_sigpending(args[..2]);
     SYS_RT_SIGSUSPEND = 130    => sys_rt_sigsuspend(args[..2]);
     SYS_SIGALTSTACK = 131      => sys_sigaltstack(args[..2]);
+    SYS_UTIME = 132            => sys_utime(args[..2]);
     SYS_STATFS = 137           => sys_statfs(args[..2]);
     SYS_FSTATFS = 138          => sys_fstatfs(args[..2]);
     SYS_GET_PRIORITY = 140     => sys_get_priority(args[..2]);
@@ -252,10 +253,12 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EPOLL_WAIT = 232       => sys_epoll_wait(args[..4]);
     SYS_EPOLL_CTL = 233        => sys_epoll_ctl(args[..4]);
     SYS_TGKILL = 234           => sys_tgkill(args[..3]);
+    SYS_UTIMES = 235           => sys_utimes(args[..2]);
     SYS_WAITID = 247           => sys_waitid(args[..5]);
     SYS_OPENAT = 257           => sys_openat(args[..4]);
     SYS_MKDIRAT = 258          => sys_mkdirat(args[..3]);
     SYS_FCHOWNAT = 260         => sys_fchownat(args[..5]);
+    SYS_FUTIMESAT = 261        => sys_futimesat(args[..3]);
     SYS_FSTATAT = 262          => sys_fstatat(args[..4]);
     SYS_UNLINKAT = 263         => sys_unlinkat(args[..3]);
     SYS_RENAMEAT = 264         => sys_renameat(args[..4]);

--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -2,69 +2,168 @@
 
 use core::time::Duration;
 
-use super::SyscallReturn;
+use super::{constants::MAX_FILENAME_LEN, SyscallReturn};
 use crate::{
-    fs::{file_table::FileDesc, fs_resolver::FsPath},
+    fs::{
+        file_table::FileDesc,
+        fs_resolver::{FsPath, AT_FDCWD},
+        path::Dentry,
+    },
     prelude::*,
-    syscall::constants::MAX_FILENAME_LEN,
-    time::timespec_t,
+    time::{clocks::RealTimeCoarseClock, timespec_t, timeval_t},
     util::{read_cstring_from_user, read_val_from_user},
 };
 
+/// The 'sys_utimensat' system call sets the access and modification times of a file.
+/// The times are defined by an array of two timespec structures, where times[0] represents the access time,
+/// and times[1] represents the modification time.
+/// The `flags` argument is a bit mask that can include the following values:
+/// - `AT_SYMLINK_NOFOLLOW`: If set, the file is not dereferenced if it is a symbolic link.
 pub fn sys_utimensat(
     dirfd: FileDesc,
-    path_addr: Vaddr,
+    pathname_ptr: Vaddr,
     timespecs_ptr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
-    let (atime, mtime) = {
-        let (autime, mutime) = if timespecs_ptr == 0 {
-            (timespec_t::utime_now(), timespec_t::utime_now())
-        } else {
-            let mut timespecs_addr = timespecs_ptr;
-            let autime = read_val_from_user::<timespec_t>(timespecs_addr)?;
-            timespecs_addr += core::mem::size_of::<timespec_t>();
-            let mutime = read_val_from_user::<timespec_t>(timespecs_addr)?;
-            (autime, mutime)
-        };
-
-        // TODO: Get current time
-        let current_time: timespec_t = Default::default();
-
-        let atime = if autime.is_utime_omit() {
-            None
-        } else if autime.is_utime_now() {
-            Some(current_time)
-        } else {
-            Some(autime)
-        };
-        let mtime = if mutime.is_utime_omit() {
-            None
-        } else if mutime.is_utime_now() {
-            Some(current_time)
-        } else {
-            Some(mutime)
-        };
-        (atime, mtime)
+    debug!(
+        "utimensat: dirfd: {}, pathname_ptr: {:#x}, timespecs_ptr: {:#x}, flags: {:#x}",
+        dirfd, pathname_ptr, timespecs_ptr, flags
+    );
+    let times = if timespecs_ptr != 0 {
+        let (autime, mutime) = read_time_from_user::<timespec_t>(timespecs_ptr)?;
+        if autime.is_utime_omit() && mutime.is_utime_omit() {
+            return Ok(SyscallReturn::Return(0));
+        }
+        Some(TimeSpecPair {
+            atime: autime,
+            mtime: mutime,
+        })
+    } else {
+        None
     };
+    do_utimes(dirfd, pathname_ptr, times, flags)
+}
+
+/// The 'sys_futimesat' system call sets the access and modification times of a file.
+/// Unlike 'sys_utimensat', it receives time values in the form of timeval structures,
+/// and it does not support the 'flags' argument.
+pub fn sys_futimesat(
+    dirfd: FileDesc,
+    pathname_ptr: Vaddr,
+    timeval_ptr: Vaddr,
+) -> Result<SyscallReturn> {
+    debug!(
+        "futimesat: dirfd: {}, pathname_ptr: {:#x}, timeval_ptr: {:#x}",
+        dirfd, pathname_ptr, timeval_ptr
+    );
+    do_futimesat(dirfd, pathname_ptr, timeval_ptr)
+}
+
+/// The 'sys_utimes' system call sets the access and modification times of a file.
+/// It receives time values in the form of timeval structures like 'sys_futimesat',
+/// but it uses the current working directory as the base directory.
+pub fn sys_utimes(pathname_ptr: Vaddr, timeval_ptr: Vaddr) -> Result<SyscallReturn> {
+    debug!(
+        "utimes: pathname_ptr: {:#x}, timeval_ptr: {:#x}",
+        pathname_ptr, timeval_ptr
+    );
+    do_futimesat(AT_FDCWD, pathname_ptr, timeval_ptr)
+}
+
+/// The 'sys_utime' system call is similar to 'sys_utimes' but uses the older 'utimbuf' structure to specify times.
+pub fn sys_utime(pathname_ptr: Vaddr, utimbuf_ptr: Vaddr) -> Result<SyscallReturn> {
+    debug!(
+        "utime: pathname_ptr: {:#x}, utimbuf_ptr: {:#x}",
+        pathname_ptr, utimbuf_ptr
+    );
+    let times = if utimbuf_ptr != 0 {
+        let utimbuf = read_val_from_user::<Utimbuf>(utimbuf_ptr)?;
+        let atime = timespec_t {
+            sec: utimbuf.actime,
+            nsec: 0,
+        };
+        let mtime = timespec_t {
+            sec: utimbuf.modtime,
+            nsec: 0,
+        };
+        Some(TimeSpecPair { atime, mtime })
+    } else {
+        None
+    };
+    do_utimes(AT_FDCWD, pathname_ptr, times, 0)
+}
+
+// Structure to hold access and modification times
+#[derive(Debug)]
+struct TimeSpecPair {
+    atime: timespec_t,
+    mtime: timespec_t,
+}
+
+/// This struct is corresponding to the `utimbuf` struct in Linux.
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Pod)]
+struct Utimbuf {
+    actime: i64,
+    modtime: i64,
+}
+
+fn vfs_utimes(dentry: &Arc<Dentry>, times: Option<TimeSpecPair>) -> Result<SyscallReturn> {
+    let (atime, mtime) = match times {
+        Some(times) => {
+            if !times.atime.is_valid() || !times.mtime.is_valid() {
+                return_errno_with_message!(Errno::EINVAL, "invalid time")
+            }
+            let now = RealTimeCoarseClock::get().read_time();
+            let atime = if times.atime.is_utime_omit() {
+                dentry.atime()
+            } else if times.atime.is_utime_now() {
+                now
+            } else {
+                Duration::from(times.atime)
+            };
+            let mtime = if times.mtime.is_utime_omit() {
+                dentry.mtime()
+            } else if times.mtime.is_utime_now() {
+                now
+            } else {
+                Duration::from(times.mtime)
+            };
+            (atime, mtime)
+        }
+        None => {
+            let now = RealTimeCoarseClock::get().read_time();
+            (now, now)
+        }
+    };
+
+    // Update times
+    dentry.set_atime(atime);
+    dentry.set_mtime(mtime);
+
+    Ok(SyscallReturn::Return(0))
+}
+
+// Common function to handle updating file times, supporting both fd and path based operations
+fn do_utimes(
+    dirfd: FileDesc,
+    pathname_ptr: Vaddr,
+    times: Option<TimeSpecPair>,
+    flags: u32,
+) -> Result<SyscallReturn> {
     let flags = UtimensFlags::from_bits(flags)
         .ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
-    debug!(
-        "dirfd = {}, path = {:?}, atime = {:?}, mtime = {:?}, flags = {:?}",
-        dirfd, path, atime, mtime, flags
-    );
 
-    if atime.is_none() && mtime.is_none() {
-        return Ok(SyscallReturn::Return(0));
-    }
+    let pathname = if pathname_ptr == 0 {
+        String::new()
+    } else {
+        let cstring = read_cstring_from_user(pathname_ptr, MAX_FILENAME_LEN)?;
+        cstring.to_string_lossy().into_owned()
+    };
     let current = current!();
     let dentry = {
-        let path = path.to_string_lossy();
-        if path.is_empty() {
-            return_errno_with_message!(Errno::ENOENT, "path is empty");
-        }
-        let fs_path = FsPath::new(dirfd, path.as_ref())?;
+        // Determine the file system path and the corresponding entry
+        let fs_path = FsPath::new(dirfd, pathname.as_ref())?;
         let fs = current.fs().read();
         if flags.contains(UtimensFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
@@ -72,13 +171,35 @@ pub fn sys_utimensat(
             fs.lookup(&fs_path)?
         }
     };
-    if let Some(time) = atime {
-        dentry.set_atime(Duration::from(time));
-    }
-    if let Some(time) = mtime {
-        dentry.set_mtime(Duration::from(time));
-    }
-    Ok(SyscallReturn::Return(0))
+
+    vfs_utimes(&dentry, times)
+}
+
+// Sets the access and modification times for a file,
+// specified by a pathname relative to the directory file descriptor `dirfd`.
+fn do_futimesat(dirfd: FileDesc, pathname_ptr: Vaddr, timeval_ptr: Vaddr) -> Result<SyscallReturn> {
+    let times = if timeval_ptr != 0 {
+        let (autime, mutime) = read_time_from_user::<timeval_t>(timeval_ptr)?;
+        if autime.usec >= 1000000 || autime.usec < 0 || mutime.usec >= 1000000 || mutime.usec < 0 {
+            return_errno_with_message!(Errno::EINVAL, "Invalid time");
+        }
+        let (autime, mutime) = (timespec_t::from(autime), timespec_t::from(mutime));
+        Some(TimeSpecPair {
+            atime: autime,
+            mtime: mutime,
+        })
+    } else {
+        None
+    };
+    do_utimes(dirfd, pathname_ptr, times, 0)
+}
+
+fn read_time_from_user<T: Pod>(time_ptr: Vaddr) -> Result<(T, T)> {
+    let mut time_addr = time_ptr;
+    let autime = read_val_from_user::<T>(time_addr)?;
+    time_addr += core::mem::size_of::<T>();
+    let mutime = read_val_from_user::<T>(time_addr)?;
+    Ok((autime, mutime))
 }
 
 trait UtimeExt {
@@ -86,6 +207,7 @@ trait UtimeExt {
     fn utime_omit() -> Self;
     fn is_utime_now(&self) -> bool;
     fn is_utime_omit(&self) -> bool;
+    fn is_valid(&self) -> bool;
 }
 
 impl UtimeExt for timespec_t {
@@ -109,6 +231,12 @@ impl UtimeExt for timespec_t {
 
     fn is_utime_omit(&self) -> bool {
         self.nsec == UTIME_OMIT
+    }
+
+    fn is_valid(&self) -> bool {
+        self.nsec == UTIME_OMIT
+            || self.nsec == UTIME_NOW
+            || (self.nsec >= 0 && self.nsec <= 999_999_999)
     }
 }
 

--- a/kernel/aster-nix/src/time/mod.rs
+++ b/kernel/aster-nix/src/time/mod.rs
@@ -43,6 +43,15 @@ impl From<Duration> for timespec_t {
     }
 }
 
+impl From<timeval_t> for timespec_t {
+    fn from(timeval: timeval_t) -> timespec_t {
+        let sec = timeval.sec;
+        let nsec = timeval.usec * 1000;
+        debug_assert!(sec >= 0); // nsec >= 0 always holds
+        timespec_t { sec, nsec }
+    }
+}
+
 impl From<timespec_t> for Duration {
     fn from(timespec: timespec_t) -> Self {
         Duration::new(timespec.sec as u64, timespec.nsec as u32)

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -37,6 +37,7 @@ TESTS ?= \
 	unlink_test \
 	vdso_clock_gettime_test \
 	write_test \
+	utimes_test \
 	# The end of the list
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/regression/syscall_test/blocklists.exfat/utimes_test
+++ b/regression/syscall_test/blocklists.exfat/utimes_test
@@ -1,0 +1,8 @@
+UtimesTest.OnFile
+UtimesTest.OnDir
+FutimesatTest.OnAbsPath
+FutimesatTest.OnRelPath
+UtimensatTest.OnAbsPath
+UtimensatTest.OnRelPath
+UtimeTest.ZeroAtimeandMtime
+Utimensat.NullPath


### PR DESCRIPTION
This pull request encompasses a series of improvements and additions pertaining to file time manipulation syscalls within the codebase. I have reconstructed the `sys_utimensat` syscall to enhance its clarity, efficiency, and maintainability. 

Key highlights and benefits include:

**Reconstruction of `sys_utimensat`**:
- Refactored the `sys_utimensat` implementation to streamline the logic and improve code readability.
- Consolidated common functionalities used by time-related syscalls to reduce code duplication and potential bugs.
- Updated documentation comments across the modified functions to provide better clarity on the implementation details and expected behavior.

**New syscall implementations**:
- Introduced `sys_futimesat`: A syscall that extends `sys_utimenstat`'s capabilities by allowing users to set the access and modification times of files using file descriptors and paths.
- Introduced `sys_utimes`: This syscall offers an API to update file access and modification times via pathnames, utilizing libc's `utimes` convention.
- Introduced `sys_utime`: Implements the older POSIX `utime` function, which permits setting file access and modification times, albeit without nanosecond precision.

All new syscalls are designed to comply with their respective POSIX specifications, ensuring compatibility and expected behavior across different environments.

**Testing and Verification**:
- Added `utimes_test` and `utimensat_test` in `syscall_test` to cover the introduced syscalls, ensuring their correct behavior and interaction with the file system. (Cannot pass all tests)
- Validated existing functionality remains intact and unaffected by new changes through regression tests.

These enhancements aim to solidify time-related syscalls' functionality and expand the system's capabilities in file time management. I welcome all reviews, comments, and suggestions for further improvement on this PR.

**Add `ctime` implementation for existed inode**
- Define the `ctime` attribute in iNode implementations.
- Update the methods that read filesystem metadata to return the ctime to calling processes.

**Fix the time of inode**
- Replace the old implementation, `Default::default()`, with `now_as_duration`.
---

## Issues

**Path look-up**
This PR need slight modifications after #758 , so it should be draft now.

**utimes_test**
Gvisor's syscall tests obtain realtime from **vdso**. However, the initialization time and the time obtained by the system call are not aligned now in Asterinas. The vdso real_time_coarse reading mechanism is also different. Things would be fixed by @cchanging in #783 .