### PR TITLE
Fix GDB server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ virtio-net.pcap
 
 # vscode launch config file
 .vscode/launch.json
+.vscode/launch.bak

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SKIP_GRUB_MENU ?= 1
 SYSCALL_TEST_DIR ?= /tmp
 EXTRA_BLOCKLISTS_DIRS ?= ""
 RELEASE_MODE ?= 0
+GDB_TCP_PORT ?= 1234
 # End of auto test features.
 
 CARGO_OSDK := ~/.cargo/bin/cargo-osdk
@@ -139,12 +140,12 @@ else ifeq ($(AUTO_TEST), boot)
 endif
 
 .PHONY: gdb_server
-gdb_server: build
-	@cd kernel && cargo osdk run $(CARGO_OSDK_ARGS) -G --vsc --gdb-server-addr :1234
+gdb_server: initramfs $(CARGO_OSDK)
+	@cargo osdk run $(CARGO_OSDK_ARGS) -G --vsc --gdb-server-addr :$(GDB_TCP_PORT)
 
 .PHONY: gdb_client
 gdb_client: $(CARGO_OSDK)
-	@cd kernel && cargo osdk debug $(CARGO_OSDK_ARGS) --remote :1234
+	@cd kernel && cargo osdk debug $(CARGO_OSDK_ARGS) --remote :$(GDB_TCP_PORT)
 
 .PHONY: test
 test:

--- a/docs/src/kernel/advanced-instructions.md
+++ b/docs/src/kernel/advanced-instructions.md
@@ -74,6 +74,10 @@ Start a GDB-enabled VM of Asterinas with OSDK and wait for debugging connection:
 make gdb_server
 ```
 
+The server will listen at the default address specified in `Makefile`, i.e., a local TCP port `:1234`.
+Change the address in `Makefile` for your convenience,
+and check `cargo osdk run -h` for more details about the address.
+
 Two options are provided to interact with the debug server.
 
 - A GDB client: start a GDB client in another terminal.

--- a/docs/src/osdk/reference/commands/run.md
+++ b/docs/src/osdk/reference/commands/run.md
@@ -23,7 +23,7 @@ Options related with debugging:
 Requires [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
 - `--gdb-server-addr <ADDR>`: The network address on which the GDB server listens,
 it can be either a path for the UNIX domain socket or a TCP port on an IP address.
-[default: .aster-gdb-socket]
+[default: `.aster-gdb-socket`(a local UNIX socket)]
 
 See [Debug Command](debug.md) to interact with the GDB server in terminal.
 

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -190,6 +190,12 @@ pub struct CargoArgs {
     pub release: bool,
     #[arg(long, value_name = "FEATURES", help = "List of features to activate")]
     pub features: Vec<String>,
+    #[arg(
+        long = "config",
+        help = "Override a configuration value",
+        value_name = "KEY=VALUE"
+    )]
+    pub override_configs: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -7,7 +7,7 @@ use std::{path::Path, process};
 
 use bin::strip_elf_for_qemu;
 
-use super::util::{cargo, COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH};
+use super::util::{cargo, profile_name_adapter, COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH};
 use crate::{
     base_crate::new_base_crate,
     bundle::{
@@ -155,12 +155,9 @@ fn build_kernel_elf(
     }
 
     let aster_bin_path = cargo_target_directory.as_ref().join(target);
-    let aster_bin_path = if args.profile == "dev" {
-        aster_bin_path.join("debug")
-    } else {
-        aster_bin_path.join(&args.profile)
-    }
-    .join(get_current_crate_info().name);
+    let aster_bin_path = aster_bin_path
+        .join(profile_name_adapter(&args.profile))
+        .join(get_current_crate_info().name);
 
     AsterBin::new(
         aster_bin_path,

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -148,6 +148,10 @@ fn build_kernel_elf(
         .arg(cargo_target_directory.as_ref());
     command.args(COMMON_CARGO_ARGS);
     command.arg("--profile=".to_string() + &args.profile);
+    for override_config in &args.override_configs {
+        command.arg("--config").arg(override_config);
+    }
+
     let status = command.status().unwrap();
     if !status.success() {
         error_msg!("Cargo build failed");

--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::commands::util::{bin_file_name, profile_adapter};
+use crate::commands::util::{bin_file_name, profile_name_adapter};
 use crate::config_manager::DebugConfig;
 
 use crate::util::get_target_directory;
@@ -9,7 +9,7 @@ use std::process::Command;
 pub fn execute_debug_command(config: &DebugConfig) {
     let DebugConfig { cargo_args, remote } = config;
 
-    let profile = profile_adapter(&cargo_args.profile);
+    let profile = profile_name_adapter(&cargo_args.profile);
     let file_path = get_target_directory()
         .join("x86_64-unknown-none")
         .join(profile)

--- a/osdk/src/commands/run.rs
+++ b/osdk/src/commands/run.rs
@@ -60,6 +60,18 @@ pub fn execute_run_command(config: &RunConfig) {
                     .collect();
                 let mut manifest = config.manifest.clone();
                 manifest.qemu.args.extend(qemu_gdb_args);
+
+                // FIXME: Disable KVM from QEMU args in debug mode.
+                // Currently, the QEMU GDB server does not work properly with KVM enabled.
+                let args_num = manifest.qemu.args.len();
+                manifest.qemu.args.retain(|x| !x.contains("kvm"));
+                if manifest.qemu.args.len() != args_num {
+                    println!(
+                        "[WARNING] KVM is forced to be disabled in GDB server currently. \
+                         Options related with KVM are ignored."
+                    );
+                }
+
                 manifest
             } else {
                 config.manifest.clone()
@@ -69,7 +81,7 @@ pub fn execute_run_command(config: &RunConfig) {
     };
     let _vsc_launch_file = config.gdb_server_args.vsc_launch_file.then(|| {
         vsc::check_gdb_config(&config.gdb_server_args);
-        let profile = super::util::profile_adapter(&config.cargo_args.profile);
+        let profile = super::util::profile_name_adapter(&config.cargo_args.profile);
         vsc::VscLaunchConfig::new(profile, &config.gdb_server_args.gdb_server_addr)
     });
 

--- a/osdk/src/commands/run.rs
+++ b/osdk/src/commands/run.rs
@@ -77,6 +77,20 @@ pub fn execute_run_command(config: &RunConfig) {
                 config.manifest.clone()
             }
         },
+        cargo_args: {
+            fn is_release_profile(cfg: &RunConfig) -> bool {
+                cfg.cargo_args.profile == "release" || cfg.cargo_args.release
+            }
+            if config.gdb_server_args.is_gdb_enabled && is_release_profile(config) {
+                let mut cargo_args = config.cargo_args.clone();
+                cargo_args
+                    .override_configs
+                    .push("profile.release.debug=true".to_owned());
+                cargo_args
+            } else {
+                config.cargo_args.clone()
+            }
+        },
         ..config.clone()
     };
     let _vsc_launch_file = config.gdb_server_args.vsc_launch_file.then(|| {
@@ -110,7 +124,6 @@ pub fn execute_run_command(config: &RunConfig) {
         manifest: config.manifest.clone(),
         cargo_args: config.cargo_args.clone(),
     };
-
     let bundle = create_base_and_build(
         default_bundle_directory,
         &osdk_target_directory,

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -15,7 +15,7 @@ pub fn cargo() -> Command {
     Command::new("cargo")
 }
 
-pub fn profile_adapter(profile: &str) -> &str {
+pub fn profile_name_adapter(profile: &str) -> &str {
     match profile {
         "dev" => "debug",
         _ => profile,

--- a/osdk/src/config_manager/mod.rs
+++ b/osdk/src/config_manager/mod.rs
@@ -147,15 +147,13 @@ fn load_osdk_manifest<S: AsRef<str>>(cargo_args: &CargoArgs, selection: Option<S
 /// 1. Split `features` in `cargo_args` to ensure each string contains exactly one feature.
 /// 2. Change `profile` to `release` if `--release` is set.
 fn parse_cargo_args(cargo_args: &CargoArgs) -> CargoArgs {
-    let mut features = Vec::new();
-
-    for feature in cargo_args.features.iter() {
-        for feature in feature.split(',') {
-            if !feature.is_empty() {
-                features.push(feature.to_string());
-            }
-        }
-    }
+    let features = cargo_args
+        .features
+        .iter()
+        .flat_map(|feature| feature.split(','))
+        .filter(|feature| !feature.is_empty())
+        .map(|feature| feature.to_string())
+        .collect();
 
     let profile = if cargo_args.release {
         "release".to_string()
@@ -167,6 +165,7 @@ fn parse_cargo_args(cargo_args: &CargoArgs) -> CargoArgs {
         profile,
         release: cargo_args.release,
         features,
+        override_configs: cargo_args.override_configs.clone(),
     }
 }
 


### PR DESCRIPTION
The GDB server does not work properly (dead breakpoints) with `--enable-kvm`.
The option is disabled when using GDB in OSDK.