### PR TITLE
Increase user stack size

### DIFF
--- a/kernel/aster-nix/src/process/program_loader/elf/init_stack.rs
+++ b/kernel/aster-nix/src/process/program_loader/elf/init_stack.rs
@@ -20,7 +20,8 @@ use crate::{
     vm::{perms::VmPerms, vmar::Vmar, vmo::VmoOptions},
 };
 
-pub const INIT_STACK_SIZE: usize = 64 * 1024; // 64 KiB
+/// Set the initial stack size to 8 megabytes, following the default Linux stack size limit.
+pub const INIT_STACK_SIZE: usize = 8 * 1024 * 1024; // 8 MB
 
 /*
  * Illustration of the virtual memory space containing the processes' init stack:


### PR DESCRIPTION
Related to #670 . 
The error of "page fault addr is not in current vmar" when running SPEC program is solved. The reason is that our user stack is too small.