### PR TITLE
Fix `writev` panic when `io_vec.len` is 0

### DIFF
--- a/kernel/aster-nix/src/syscall/writev.rs
+++ b/kernel/aster-nix/src/syscall/writev.rs
@@ -41,7 +41,7 @@ fn do_sys_writev(fd: FileDescripter, io_vec_ptr: Vaddr, io_vec_count: usize) -> 
     let mut total_len = 0;
     for i in 0..io_vec_count {
         let io_vec = read_val_from_user::<IoVec>(io_vec_ptr + i * core::mem::size_of::<IoVec>())?;
-        if io_vec.base == 0 {
+        if io_vec.base == 0 || io_vec.len == 0 {
             continue;
         }
         let buffer = {


### PR DESCRIPTION
## Fault

If a userspace program passes an `io_vec` such that `io_vec.len == 0`, and writes to a VirtIO device (e.g. console), the kernel might panic.

### Cause

When `io_vec.len == 0`, the kernel will allocate a zero-length `Vec`.

https://github.com/asterinas/asterinas/blob/485120405939fc1ffa23ff7bf396ada18a4f792d/kernel/aster-nix/src/syscall/writev.rs#L50

When writing to Virt-IO, the kernel will get the address of this `Vec` (or slice), and translate it to physical address.

https://github.com/asterinas/asterinas/blob/485120405939fc1ffa23ff7bf396ada18a4f792d/kernel/comps/virtio/src/queue.rs#L461-L462

However, the documentation of [`Vec::as_ptr`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.as_ptr) says that
> Returns a raw pointer to the vector’s buffer, or a dangling raw pointer valid for zero sized reads if the vector didn’t allocate.

So the kernel might translate an invalid virtual address, and `.unwrap()` a `None`, which leads to panic.

## Fix

Skipping an `io_vec` if `io_vec.len == 0` could fix the problem, and it should be semantically equivalent to the original code.

```diff
     let mut total_len = 0;
     for i in 0..io_vec_count {
         let io_vec = read_val_from_user::<IoVec>(io_vec_ptr + i * core::mem::size_of::<IoVec>())?;
-        if io_vec.base == 0 {
+        if io_vec.base == 0 || io_vec.len == 0 {
             continue;
         }
         let buffer = {
```

Or, maybe it would be better to add this check to VirtIO part?