### PR TITLE
Remove pointless error codes in `unregister_observer`

### DIFF
--- a/kernel/aster-nix/src/fs/epoll/epoll_file.rs
+++ b/kernel/aster-nix/src/fs/epoll/epoll_file.rs
@@ -353,10 +353,8 @@ impl FileLike for EpollFile {
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        self.pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::ENOENT, "observer is not registered"))
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
+        self.pollee.unregister_observer(observer)
     }
 }
 

--- a/kernel/aster-nix/src/fs/file_handle.rs
+++ b/kernel/aster-nix/src/fs/file_handle.rs
@@ -96,11 +96,12 @@ pub trait FileLike: Send + Sync + Any {
         return_errno_with_message!(Errno::EINVAL, "register_observer is not supported")
     }
 
+    #[must_use]
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        return_errno_with_message!(Errno::EINVAL, "unregister_observer is not supported")
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
+        None
     }
 
     fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -71,7 +71,7 @@ impl FileLike for PipeReader {
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
         self.consumer.unregister_observer(observer)
     }
 }
@@ -137,7 +137,7 @@ impl FileLike for PipeWriter {
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
         self.producer.unregister_observer(observer)
     }
 }

--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -98,11 +98,8 @@ macro_rules! impl_common_methods_for_channel {
         pub fn unregister_observer(
             &self,
             observer: &Weak<dyn Observer<IoEvents>>,
-        ) -> Result<Weak<dyn Observer<IoEvents>>> {
-            self.this_end()
-                .pollee
-                .unregister_observer(observer)
-                .ok_or_else(|| Error::with_message(Errno::ENOENT, "the observer is not registered"))
+        ) -> Option<Weak<dyn Observer<IoEvents>>> {
+            self.this_end().pollee.unregister_observer(observer)
         }
     };
 }

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -224,10 +224,8 @@ impl FileLike for DatagramSocket {
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        self.pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::ENOENT, "observer is not registered"))
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
+        self.pollee.unregister_observer(observer)
     }
 }
 

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -366,10 +366,8 @@ impl FileLike for StreamSocket {
     fn unregister_observer(
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Result<Weak<dyn Observer<IoEvents>>> {
-        self.pollee
-            .unregister_observer(observer)
-            .ok_or_else(|| Error::with_message(Errno::ENOENT, "observer is not registered"))
+    ) -> Option<Weak<dyn Observer<IoEvents>>> {
+        self.pollee.unregister_observer(observer)
     }
 }
 


### PR DESCRIPTION
The `ENOENT` error code in `unregister_observer` is not useful, as detailed in https://github.com/asterinas/asterinas/pull/771#issuecomment-2070859595. So this PR proposes to remove this pointless error code. 