### PR TITLE
Remove redundant empty page in init stack

### DIFF
--- a/kernel/aster-nix/src/process/program_loader/elf/init_stack.rs
+++ b/kernel/aster-nix/src/process/program_loader/elf/init_stack.rs
@@ -176,14 +176,9 @@ impl InitStack {
         ldso_load_info: &Option<LdsoLoadInfo>,
         aux_vec: &mut AuxVec,
     ) -> Result<()> {
-        // write a zero page. When a user program tries to read a cstring(like argv) from init stack,
-        // it will typically read 4096 bytes and then find the first '\0' in the buffer
-        // (we now read 128 bytes, which is set by MAX_FILENAME_LEN).
-        // If we don't have this zero page, the read may go into guard page,
-        // which will cause unrecoverable page fault(The guard page is not backed up by any vmo).
-        // So we add a zero page here, to ensure the read will not go into guard page.
-        // FIXME: Some other OSes put the first page of excutable file here.
-        self.write_bytes(&[0u8; PAGE_SIZE], root_vmar)?;
+        // FIXME: Some OSes may put the first page of excutable file here
+        // for interpreting elf headers.
+
         // write envp string
         let envp_pointers = self.write_envp_strings(root_vmar)?;
         // write argv string


### PR DESCRIPTION
Currently, when we create a init stack, we will write an empty page at stack top. This will undoubtedly affect performance.

The empty page in init stack was used because the original implementation of `read_cstring_from_user` is wrong. 

Since #623 reimplements `read_cstring_from_user`, the empty page is unused.