### PR TITLE
Improve shared locks (`Arc<*Lock>`) by allowing dynamically borrowed lock guards

### DIFF
--- a/framework/aster-frame/src/arch/x86/irq.rs
+++ b/framework/aster-frame/src/arch/x86/irq.rs
@@ -88,7 +88,7 @@ impl IrqLine {
         self.irq_num
     }
 
-    pub fn callback_list(&self) -> SpinLockGuard<'_, alloc::vec::Vec<CallbackElement>> {
+    pub fn callback_list(&self) -> SpinLockGuard<alloc::vec::Vec<CallbackElement>> {
         self.callback_list.lock()
     }
 

--- a/framework/aster-frame/src/sync/mod.rs
+++ b/framework/aster-frame/src/sync/mod.rs
@@ -16,6 +16,6 @@ pub use self::{
     mutex::{Mutex, MutexGuard},
     rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard},
     rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
-    spin::{SpinLock, SpinLockGuard},
+    spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
     wait::WaitQueue,
 };

--- a/framework/aster-frame/src/sync/mod.rs
+++ b/framework/aster-frame/src/sync/mod.rs
@@ -18,7 +18,10 @@ pub use self::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
         RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,
     },
-    rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
+    rwmutex::{
+        ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
+        RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
+    },
     spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
     wait::WaitQueue,
 };

--- a/framework/aster-frame/src/sync/mod.rs
+++ b/framework/aster-frame/src/sync/mod.rs
@@ -14,7 +14,10 @@ mod wait;
 pub use self::{
     atomic_bits::AtomicBits,
     mutex::{Mutex, MutexGuard},
-    rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard},
+    rwlock::{
+        ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
+        RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,
+    },
     rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
     spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
     wait::WaitQueue,

--- a/framework/aster-frame/src/sync/mod.rs
+++ b/framework/aster-frame/src/sync/mod.rs
@@ -13,7 +13,7 @@ mod wait;
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};
 pub use self::{
     atomic_bits::AtomicBits,
-    mutex::{Mutex, MutexGuard},
+    mutex::{ArcMutexGuard, Mutex, MutexGuard},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
         RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -130,7 +130,7 @@ impl Task {
     }
 
     /// get inner
-    pub(crate) fn inner_exclusive_access(&self) -> SpinLockGuard<'_, TaskInner> {
+    pub(crate) fn inner_exclusive_access(&self) -> SpinLockGuard<TaskInner> {
         self.task_inner.lock_irq_disabled()
     }
 

--- a/kernel/aster-nix/src/fs/exfat/fat.rs
+++ b/kernel/aster-nix/src/fs/exfat/fat.rs
@@ -202,7 +202,7 @@ impl ExfatChain {
     fn alloc_cluster_from_empty(
         &mut self,
         num_to_be_allocated: u32,
-        bitmap: &mut MutexGuard<'_, ExfatBitmap>,
+        bitmap: &mut MutexGuard<ExfatBitmap>,
         sync_bitmap: bool,
     ) -> Result<ClusterID> {
         // Search for a continuous chunk big enough
@@ -228,7 +228,7 @@ impl ExfatChain {
         &mut self,
         num_to_be_allocated: u32,
         sync: bool,
-        bitmap: &mut MutexGuard<'_, ExfatBitmap>,
+        bitmap: &mut MutexGuard<ExfatBitmap>,
     ) -> Result<ClusterID> {
         let fs = self.fs();
         let mut alloc_start_cluster = 0;
@@ -255,7 +255,7 @@ impl ExfatChain {
         start_physical_cluster: ClusterID,
         drop_num: u32,
         sync_bitmap: bool,
-        bitmap: &mut MutexGuard<'_, ExfatBitmap>,
+        bitmap: &mut MutexGuard<ExfatBitmap>,
     ) -> Result<()> {
         let fs = self.fs();
 

--- a/kernel/aster-nix/src/fs/exfat/fs.rs
+++ b/kernel/aster-nix/src/fs/exfat/fs.rs
@@ -325,7 +325,7 @@ impl ExfatFS {
         self.super_block.cluster_size as usize * self.super_block.num_clusters as usize
     }
 
-    pub(super) fn lock(&self) -> MutexGuard<'_, ()> {
+    pub(super) fn lock(&self) -> MutexGuard<()> {
         self.mutex.lock()
     }
 

--- a/kernel/aster-nix/src/fs/ext2/fs.rs
+++ b/kernel/aster-nix/src/fs/ext2/fs.rs
@@ -117,7 +117,7 @@ impl Ext2 {
     }
 
     /// Returns the super block.
-    pub fn super_block(&self) -> RwMutexReadGuard<'_, Dirty<SuperBlock>> {
+    pub fn super_block(&self) -> RwMutexReadGuard<Dirty<SuperBlock>> {
         self.super_block.read()
     }
 

--- a/kernel/aster-nix/src/process/credentials/credentials_.rs
+++ b/kernel/aster-nix/src/process/credentials/credentials_.rs
@@ -364,11 +364,11 @@ impl Credentials_ {
     }
 
     //  ******* Supplementary groups methods *******
-    pub(super) fn groups(&self) -> RwLockReadGuard<'_, BTreeSet<Gid>> {
+    pub(super) fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>> {
         self.supplementary_gids.read()
     }
 
-    pub(super) fn groups_mut(&self) -> RwLockWriteGuard<'_, BTreeSet<Gid>> {
+    pub(super) fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>> {
         self.supplementary_gids.write()
     }
 }

--- a/kernel/aster-nix/src/process/credentials/static_cap.rs
+++ b/kernel/aster-nix/src/process/credentials/static_cap.rs
@@ -236,7 +236,7 @@ impl<R: TRights> Credentials<R> {
     ///
     /// This method requies the `Read` right.
     #[require(R > Read)]
-    pub fn groups(&self) -> RwLockReadGuard<'_, BTreeSet<Gid>> {
+    pub fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>> {
         self.0.groups()
     }
 
@@ -244,7 +244,7 @@ impl<R: TRights> Credentials<R> {
     ///
     /// This method requires the `Write` right.
     #[require(R > Write)]
-    pub fn groups_mut(&self) -> RwLockWriteGuard<'_, BTreeSet<Gid>> {
+    pub fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>> {
         self.0.groups_mut()
     }
 }


### PR DESCRIPTION
Assume that we have such code:

```rust
struct Foo {
    bar: Arc<SpinLock<Bar>>
}
impl Foo {
    fn get_bar_guard(&self) -> SpinLockGuard<'_, Bar> {
        self.bar.lock()
    }
}
```

It won't compile since `SpinLockGuard` has a reference to the lock and the lifetime need to be statically checked.

This PR might improve the situation. But we might end up writing all implementations twice since https://github.com/rust-lang/rust/issues/124225 is unusable currently. Otherwise heavy proc macros are needed to reuse code.

This feature is a must for #713. I suggest to implement `Arc` version of guards for methods that are needed.