### PR TITLE
Fix the logics for the coarse resolution clock IDs in VDSO.

### DIFF
--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -68,6 +68,7 @@ pub mod vm;
 
 pub fn init() {
     driver::init();
+    time::init();
     net::init();
     sched::init();
     fs::rootfs::init(boot::initramfs()).unwrap();

--- a/kernel/aster-nix/src/time/mod.rs
+++ b/kernel/aster-nix/src/time/mod.rs
@@ -9,12 +9,16 @@ use crate::prelude::*;
 
 mod system_time;
 
-pub use system_time::SystemTime;
+pub use system_time::{SystemTime, START_TIME};
 
 pub type clockid_t = i32;
 pub type time_t = i64;
 pub type suseconds_t = i64;
 pub type clock_t = i64;
+
+pub(super) fn init() {
+    system_time::init_start_time();
+}
 
 #[derive(Debug, Copy, Clone, TryFromInt, PartialEq)]
 #[repr(i32)]

--- a/kernel/comps/time/src/lib.rs
+++ b/kernel/comps/time/src/lib.rs
@@ -21,7 +21,8 @@ mod rtc;
 mod tsc;
 
 pub const NANOS_PER_SECOND: u32 = 1_000_000_000;
-pub static VDSO_DATA_UPDATE: Once<Arc<dyn Fn(Instant, u64) + Sync + Send>> = Once::new();
+pub static VDSO_DATA_HIGH_RES_UPDATE_FN: Once<Arc<dyn Fn(Instant, u64) + Sync + Send>> =
+    Once::new();
 
 #[init_component]
 fn time_init() -> Result<(), ComponentInitError> {


### PR DESCRIPTION
In the VDSO, coarse resolution clock IDs directly read the instant stored in vdso data without using coefficients for calculation, thus the related instant requires more frequent updating.

Fix the problem mentioned in #761 