### PR TITLE
Add dup3 syscall

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -312,7 +312,7 @@ provided by Linux on x86-64 architecture.
 | 289     | signalfd4        | ❌              |
 | 290     | eventfd2         | ✅              |
 | 291     | epoll_create1    | ✅              |
-| 292     | dup3             | ❌              |
+| 292     | dup3             | ✅              |
 | 293     | pipe2            | ✅              |
 | 294     | inotify_init1    | ❌              |
 | 295     | preadv           | ❌              |

--- a/kernel/aster-nix/src/fs/file_table.rs
+++ b/kernel/aster-nix/src/fs/file_table.rs
@@ -97,7 +97,7 @@ impl FileTable {
         item: Arc<dyn FileLike>,
         flags: FdFlags,
     ) -> Option<Arc<dyn FileLike>> {
-        let entry = FileTableEntry::new(item, FdFlags::empty());
+        let entry = FileTableEntry::new(item, flags);
         let entry = self.table.put_at(fd as usize, entry);
         if entry.is_some() {
             let events = FdEvents::Close(fd);

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -15,7 +15,7 @@ use crate::syscall::{
     clone::{sys_clone, sys_clone3},
     close::sys_close,
     connect::sys_connect,
-    dup::{sys_dup, sys_dup2},
+    dup::{sys_dup, sys_dup2, sys_dup3},
     epoll::{sys_epoll_create, sys_epoll_create1, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait},
     eventfd::{sys_eventfd, sys_eventfd2},
     execve::{sys_execve, sys_execveat},
@@ -247,6 +247,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 288          => sys_accept4(args[..4]);
     SYS_EVENTFD2 = 290         => sys_eventfd2(args[..2]);
     SYS_EPOLL_CREATE1 = 291    => sys_epoll_create1(args[..1]);
+    SYS_DUP3 = 292             => sys_dup3(args[..3]);
     SYS_PIPE2 = 293            => sys_pipe2(args[..2]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);

--- a/kernel/aster-nix/src/syscall/dup.rs
+++ b/kernel/aster-nix/src/syscall/dup.rs
@@ -4,6 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::file_table::{FdFlags, FileDesc},
     prelude::*,
+    process::ResourceType,
 };
 
 pub fn sys_dup(old_fd: FileDesc) -> Result<SyscallReturn> {
@@ -11,24 +12,55 @@ pub fn sys_dup(old_fd: FileDesc) -> Result<SyscallReturn> {
 
     let current = current!();
     let mut file_table = current.file_table().lock();
-    let file = file_table.get_file(old_fd)?.clone();
-    // The two file descriptors do not share the close-on-exec flag.
-    let new_fd = file_table.insert(file, FdFlags::empty());
+    let new_fd = file_table.dup(old_fd, 0, FdFlags::empty())?;
+
     Ok(SyscallReturn::Return(new_fd as _))
 }
 
 pub fn sys_dup2(old_fd: FileDesc, new_fd: FileDesc) -> Result<SyscallReturn> {
     debug!("old_fd = {}, new_fd = {}", old_fd, new_fd);
 
-    let current = current!();
-    let mut file_table = current.file_table().lock();
-    let file = file_table.get_file(old_fd)?.clone();
-    if old_fd != new_fd {
-        // The two file descriptors do not share the close-on-exec flag.
-        if let Some(old_file) = file_table.insert_at(new_fd, file, FdFlags::empty()) {
-            // If the file descriptor `new_fd` was previously open, close it silently.
-            let _ = old_file.clean_for_close();
-        }
+    if old_fd == new_fd {
+        let current = current!();
+        let file_table = current.file_table().lock();
+        let _ = file_table.get_file(old_fd)?;
+        return Ok(SyscallReturn::Return(new_fd as _));
     }
+
+    do_dup3(old_fd, new_fd, FdFlags::empty())
+}
+
+pub fn sys_dup3(old_fd: FileDesc, new_fd: FileDesc, flags: u32) -> Result<SyscallReturn> {
+    debug!("old_fd = {}, new_fd = {}", old_fd, new_fd);
+
+    let fdflag = match flags {
+        0x0 => FdFlags::empty(),
+        0x80000 => FdFlags::CLOEXEC,
+        _ => return_errno_with_message!(Errno::EINVAL, "flags must be O_CLOEXEC or 0"),
+    };
+
+    do_dup3(old_fd, new_fd, fdflag)
+}
+
+fn do_dup3(old_fd: FileDesc, new_fd: FileDesc, flags: FdFlags) -> Result<SyscallReturn> {
+    if old_fd == new_fd {
+        return_errno!(Errno::EINVAL);
+    }
+
+    let current = current!();
+    if new_fd
+        >= current
+            .resource_limits()
+            .lock()
+            .get_rlimit(ResourceType::RLIMIT_NOFILE)
+            .get_cur() as FileDesc
+    {
+        return_errno!(Errno::EBADF);
+    }
+
+    let mut file_table = current.file_table().lock();
+    let _ = file_table.close_file(new_fd);
+    let new_fd = file_table.dup(old_fd, new_fd, flags)?;
+
     Ok(SyscallReturn::Return(new_fd as _))
 }

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -11,6 +11,7 @@ TESTS ?= \
 	chown_test \
 	chroot_test \
 	creat_test \
+	dup_test \
 	epoll_test \
 	eventfd_test \
 	fsync_test \


### PR DESCRIPTION
This Pull Request introduces the implementation of the dup3 system call to our kernel. The dup3 system call extends the functionality of the existing dup2, providing the ability to duplicate file descriptors with the added advantage of setting flags at the time of duplication. This addition is motivated by the need for finer control over file descriptor behavior, especially in multi-threaded environments where the race condition around the close-on-exec flag (O_CLOEXEC) needs to be mitigated.

**Key Features:**
Extended Functionality: Unlike dup2, dup3 allows specifying flags, currently supporting O_CLOEXEC, enabling the new file descriptor to be automatically closed during an execve system call. This is crucial for security and reliability, preventing file descriptor leaks across exec calls.

**Error Handling Improvements:** 
dup3 introduces error handling for cases where the oldfd equals newfd, returning -EINVAL. This behavior aligns with the principle of explicit error reporting, enhancing the robustness of file descriptor duplication logic.

**Compatibility:** While dup3 is an extension of dup2, it preserves backward compatibility with existing system call interfaces. Applications desiring to leverage the new O_CLOEXEC functionality can do so transparently.