### PR TITLE
Fix OSDK publishing

### DIFF
--- a/framework/libs/linux-bzimage/builder/Cargo.toml
+++ b/framework/libs/linux-bzimage/builder/Cargo.toml
@@ -2,6 +2,9 @@
 name = "linux-bzimage-builder"
 version = "0.1.0"
 edition = "2021"
+description = "Linux boot compatibility for modern OSes"
+license = "MPL-2.0"
+repository = "https://github.com/asterinas/asterinas"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -321,6 +321,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "linux-bzimage-builder"
 version = "0.1.0"
+source = "git+https://github.com/asterinas/asterinas?rev=cc4111c#cc4111cab227f188a1170dea0aa729b410b1b509"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -5,15 +5,23 @@ edition = "2021"
 description = "Accelerate OS development with Asterinas OSDK"
 license = "MPL-2.0"
 readme = "README.md"
+repository = "https://github.com/asterinas/asterinas"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.linux-bzimage-builder]
+git = "https://github.com/asterinas/asterinas"
+# Make sure it syncs with `crate::util::ASTER_GIT_REV`
+rev = "cc4111c"
+# When publishing, the crate.io version is used, make sure
+# the builder is published
+version = "0.1.0"
 
 [dependencies]
 clap = { version = "4.4.17", features = ["cargo", "derive"] }
 env_logger = "0.11.0"
 indexmap = "2.2.1"
 lazy_static = "1.4.0"
-linux-bzimage-builder = { path = "../framework/libs/linux-bzimage/builder" }
 log = "0.4.20"
 quote = "1.0.35"
 serde = { version = "1.0.195", features = ["derive"] }

--- a/osdk/README.md
+++ b/osdk/README.md
@@ -80,6 +80,7 @@ Currently we support following commands:
 - **test**: Execute kernel mode unit test by starting a VMM
 - **check**: Analyze the current package and report errors
 - **clippy**: Check the current package and catch common mistakes
+- **doc**: Build Rust documentations
 
 The following command can be used to discover the available options for each command.
 ```bash
@@ -92,7 +93,7 @@ cargo osdk help <COMMAND>
 
 ### Contributing
 
-Asterinas OSDK is developed as a sub-project of [Asterinas](https://github.com/asterinas/asterinas). It shares the same repository with the kernel. Please contribute to OSDK according to the contribution guide of Asterinas.
+Asterinas OSDK is developed as a sub-project of [Asterinas](https://github.com/asterinas/asterinas). It shares the same repository and versioning rules with the kernel. Please contribute to OSDK according to the contribution guide of Asterinas.
 
 #### Note for Visual Studio Code users
 

--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -22,8 +22,12 @@ pub fn execute_new_command(args: &NewArgs) {
 
 /// OSDK assumes that the toolchain used by the kernel should be same same as the toolchain
 /// specified in the asterinas workspace.
-fn aster_rust_toolchain() -> &'static str {
-    include_str!("../../../../rust-toolchain.toml")
+fn aster_rust_toolchain() -> String {
+    // Here we can't just include it in the repository root because that can't be
+    // read when publishing. Please ensure update both files when updating the toolchain.
+    let template = include_str!("./rust-toolchain.toml.template");
+    // Delete first two lines of comments.
+    template.lines().skip(2).collect::<Vec<_>>().join("\n")
 }
 
 fn add_manifest_dependencies(cargo_metadata: &serde_json::Value, crate_name: &str) {
@@ -190,7 +194,7 @@ fn get_package_metadata<'a>(
 fn check_rust_toolchain(toolchain: &toml::Table) {
     let expected = {
         let contents = aster_rust_toolchain();
-        toml::Table::from_str(contents).unwrap()
+        toml::Table::from_str(&contents).unwrap()
     };
 
     let expected = expected.get("toolchain").unwrap().as_table().unwrap();

--- a/osdk/src/commands/new/rust-toolchain.toml.template
+++ b/osdk/src/commands/new/rust-toolchain.toml.template
@@ -1,0 +1,5 @@
+# One should also update asterinas/rust-toolchain.toml when updating this.
+# The first two lines will be deleted when generating the user's toolchain file.
+[toolchain]
+channel = "nightly-2024-01-01"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -14,7 +14,8 @@ use quote::ToTokens;
 /// FIXME: We should publish the asterinas crates to a public registry
 /// and use the published version in the generated Cargo.toml.
 pub const ASTER_GIT_LINK: &str = "https://github.com/asterinas/asterinas";
-pub const ASTER_GIT_REV: &str = "1069006";
+/// Make sure it syncs with the builder dependency in Cargo.toml.
+pub const ASTER_GIT_REV: &str = "cc4111c";
 pub fn aster_crate_dep(crate_name: &str) -> String {
     format!(
         "{} = {{ git = \"{}\", rev = \"{}\" }}",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,5 @@
+# One should also update asterinas/src/commands/new/rust-toolchain.toml.template
+# when updating this
 [toolchain]
 channel = "nightly-2024-01-01"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
This MAY fix the workflow publishing OSDK to crates.io.
At least it is a improvement not a workaround.