### PR TITLE
Use a spin lock to protect `APIC_INSTANCE`

### DIFF
--- a/framework/aster-frame/src/arch/x86/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn after_all_init() {
 pub(crate) fn interrupts_ack() {
     kernel::pic::ack();
     if let Some(apic) = kernel::apic::APIC_INSTANCE.get() {
-        apic.lock().eoi();
+        apic.lock_irq_disabled().eoi();
     }
 }
 


### PR DESCRIPTION
It's ridiculous to use a mutex to protect `APIC_INSTANCE`, which can be even accessed in the interrupt context (e.g., `interrupts_ack`). We should replace it by a spin lock and `lock_irq_disabled`.

Reported in https://github.com/asterinas/asterinas/issues/478#issuecomment-1807197636 last year
Reported by @chenIshi again