### PR TITLE
Improve the efficiency of `fill` method in `VmWriter`

### DIFF
--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(panic_info_message)]
 #![feature(ptr_sub_ptr)]
 #![feature(strict_provenance)]
+#![feature(pointer_is_aligned)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![no_std]


### PR DESCRIPTION
Solves an important performance bottleneck in handle page fault. Improve the performance in #763 

Currently if we use `VmAllocOption::alloc_single` to alloc a `VmFrame`, the internal implementation will init the `VmFrame` with zero by `self.writer().fill(0)`, which will write 0 bytes by bytes. This is an O(n) instruction and is slow.

This PR improve the efficiency of `fill` method in `VmWriter`, making the process more than 50 times faster.