### PR TITLE
Move the whole kernel ELF to VMA

### DIFF
--- a/framework/aster-frame/src/arch/x86/boot/boot.S
+++ b/framework/aster-frame/src/arch/x86/boot/boot.S
@@ -17,6 +17,8 @@ ENTRYTYPE_LINUX_64      = 4
 MULTIBOOT_ENTRY_MAGIC   = 0x2BADB002
 MULTIBOOT2_ENTRY_MAGIC  = 0x36D76289
 
+KERNEL_VMA              = 0xffffffff80000000
+
 // The Linux 32-bit Boot Protocol entry point.
 // Must be located at 0x8001000, ABI immutable!
 .code32
@@ -27,7 +29,7 @@ __linux32_boot:
     cld
 
     // Set the kernel call stack.
-    mov esp, offset boot_stack_top
+    mov esp, offset boot_stack_top - KERNEL_VMA
 
     push 0      // upper 32-bits
     push esi    // boot_params ptr
@@ -43,7 +45,7 @@ __linux32_boot:
 .global __linux64_boot_tag
 __linux64_boot_tag:
     // Set the kernel call stack.
-    lea rsp, [boot_stack_top]
+    lea rsp, [boot_stack_top - KERNEL_VMA]
     push rsi    // boot_params ptr from the loader
     push ENTRYTYPE_LINUX_64
 
@@ -58,7 +60,7 @@ __multiboot_boot:
     cld
 
     // Set the kernel call stack.
-    mov esp, offset boot_stack_top
+    mov esp, offset boot_stack_top - KERNEL_VMA
 
     push 0      // Upper 32-bits.
     push eax    // multiboot magic ptr
@@ -83,11 +85,11 @@ initial_boot_setup:
     // Prepare for far return. We use a far return as a fence after setting GDT.
     mov eax, 24
     push eax
-    lea edx, [protected_mode]
+    lea edx, [protected_mode - KERNEL_VMA]
     push edx
 
     // Switch to our own temporary GDT.
-    lgdt [boot_gdtr]
+    lgdt [boot_gdtr - KERNEL_VMA]
     retf
 
 protected_mode:
@@ -101,8 +103,8 @@ protected_mode:
 page_table_setup:
     // Zero out the page table.
     mov al, 0x00
-    lea edi, [boot_page_table_start]
-    lea ecx, [boot_page_table_end]
+    lea edi, [boot_page_table_start - KERNEL_VMA]
+    lea ecx, [boot_page_table_end - KERNEL_VMA]
     sub ecx, edi
     cld
     rep stosb
@@ -117,8 +119,8 @@ PTE_GLOBAL      = (1 << 8)
     //       0x00000000_40000000 ~ 0x00000000_7fffffff
     //       0x00000000_80000000 ~ 0x00000000_bfffffff
     //       0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pml4]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pml4 - KERNEL_VMA]
+    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
@@ -127,56 +129,56 @@ PTE_GLOBAL      = (1 << 8)
     //       0xffff8000_80000000 ~ 0xffff8000_bfffffff
     //       0xffff8000_c0000000 ~ 0xffff8000_ffffffff
     //       0xffff8008_00000000 ~ 0xffff8008_3fffffff
-    lea edi, [boot_pml4 + 0x100 * 8]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pml4 - KERNEL_VMA + 0x100 * 8]
+    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PML4: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
     //       0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pml4 + 0x1ff * 8]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pml4 - KERNEL_VMA + 0x1ff * 8]
+    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_00000000 ~ 0x00000000_3fffffff
-    lea edi, [boot_pdpt]
-    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA]
+    lea eax, [boot_pd_0g_1g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_40000000 ~ 0x00000000_7fffffff
-    lea edi, [boot_pdpt + 0x1 * 8]
-    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA + 0x1 * 8]
+    lea eax, [boot_pd_1g_2g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_80000000 ~ 0x00000000_bfffffff
-    lea edi, [boot_pdpt + 0x2 * 8]
-    lea eax, [boot_pd_2g_3g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA + 0x2 * 8]
+    lea eax, [boot_pd_2g_3g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pdpt + 0x3 * 8]
-    lea eax, [boot_pd_3g_4g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA + 0x3 * 8]
+    lea eax, [boot_pd_3g_4g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
-    lea edi, [boot_pdpt + 0x1fe * 8]
-    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA + 0x1fe * 8]
+    lea eax, [boot_pd_0g_1g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pdpt + 0x1ff * 8]
-    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt - KERNEL_VMA + 0x1ff * 8]
+    lea eax, [boot_pd_1g_2g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // Page Directory: map to low 1 GiB * 4 space
-    lea edi, [boot_pd]
+    lea edi, [boot_pd - KERNEL_VMA]
     mov eax, PTE_PRESENT | PTE_WRITE | PTE_GLOBAL | PTE_HUGE
     mov ecx, 512 * 4 // (of entries in PD) * (number of PD)
 write_pd_entry:
@@ -195,7 +197,7 @@ enable_long_mode:
     mov cr4, eax
 
     // Set the page table address.
-    lea eax, [boot_pml4]
+    lea eax, [boot_pml4 - KERNEL_VMA]
     mov cr3, eax
 
     // Enable long mode.
@@ -207,7 +209,7 @@ enable_long_mode:
     // Prepare for far return.
     mov  eax, 8
     push eax
-    lea  edx, [long_mode_in_low_address]
+    lea  edx, [long_mode_in_low_address - KERNEL_VMA]
     push edx
 
     // Enable paging.
@@ -223,7 +225,7 @@ enable_long_mode:
 .global boot_gdtr
 boot_gdtr:
     .word gdt_end - gdt - 1
-    .quad gdt
+    .quad gdt - KERNEL_VMA
 
 .align 16
 gdt:
@@ -268,9 +270,9 @@ long_mode_in_low_address:
     mov gs, ax
 
     // Update RSP/RIP to use the virtual address.
-    mov rbx, 0xffffffff80000000
+    mov rbx, KERNEL_VMA
     or  rsp, rbx
-    lea rax, [long_mode - 0xffffffff80000000]
+    lea rax, [long_mode - KERNEL_VMA]
     or  rax, rbx
     jmp rax
 

--- a/framework/aster-frame/src/arch/x86/boot/multiboot2/header.S
+++ b/framework/aster-frame/src/arch/x86/boot/multiboot2/header.S
@@ -10,6 +10,7 @@ MB2_MAGIC = 0xE85250D6
 MB2_ARCHITECTURE = 0 // 32-bit (protected) mode of i386
 MB2_HEADERLEN = header_end - header_start
 MB2_CHECKSUM = -(MB2_MAGIC + MB2_ARCHITECTURE + MB2_HEADERLEN)
+KERNEL_VMA = 0xffffffff80000000
 
 header_start:
     .align 8
@@ -25,7 +26,7 @@ entry_address_tag_start:
     .short 1                // Optional
     .long  entry_address_tag_end - entry_address_tag_start
 .extern __multiboot_boot
-    .long __multiboot_boot // entry_addr
+    .long __multiboot_boot - KERNEL_VMA // entry_addr
 entry_address_tag_end:
 
     // Tag: information request

--- a/framework/aster-frame/src/boot/memory_region.rs
+++ b/framework/aster-frame/src/boot/memory_region.rs
@@ -6,6 +6,8 @@
 use alloc::{vec, vec::Vec};
 use core::mem::swap;
 
+use crate::vm::kspace::kernel_loaded_offset;
+
 /// The type of initial memory regions that are needed for the kernel.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum MemoryRegionType {
@@ -53,7 +55,7 @@ impl MemoryRegion {
             fn __kernel_end();
         }
         MemoryRegion {
-            base: __kernel_start as usize,
+            base: __kernel_start as usize - kernel_loaded_offset(),
             len: __kernel_end as usize - __kernel_start as usize,
             typ: MemoryRegionType::Kernel,
         }

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/asterinas/asterinas"
 [dependencies.linux-bzimage-builder]
 git = "https://github.com/asterinas/asterinas"
 # Make sure it syncs with `crate::util::ASTER_GIT_REV`
-rev = "cc4111c"
+rev = "c9b66bd"
 # When publishing, the crate.io version is used, make sure
 # the builder is published
 # FIXME: The version is currently commented out as it is no longer in use. 

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -8,18 +8,16 @@ KERNEL_VMA = 0xffffffff80000000;
 
 SECTIONS
 {
-    . = KERNEL_LMA;
+    . = KERNEL_LMA + KERNEL_VMA;
 
     __kernel_start = .;
-    
-    .multiboot_header       : { KEEP(*(.multiboot_header)) }
-    .multiboot2_header      : { KEEP(*(.multiboot2_header)) }
 
-    . = LINUX_32_ENTRY;
-    
-    .boot                   : { KEEP(*(.boot)) }
+    .multiboot_header       : AT(ADDR(.multiboot_header) - KERNEL_VMA) { KEEP(*(.multiboot_header)) }
+    .multiboot2_header      : AT(ADDR(.multiboot2_header) - KERNEL_VMA) { KEEP(*(.multiboot2_header)) }
 
-    . += KERNEL_VMA;
+    . = LINUX_32_ENTRY + KERNEL_VMA;
+
+    .boot                   : AT(ADDR(.boot) - KERNEL_VMA) { KEEP(*(.boot)) }
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
         *(.text .text.*)
@@ -71,5 +69,5 @@ SECTIONS
 
     . = DATA_SEGMENT_END(.);
 
-    __kernel_end = . - KERNEL_VMA;
+    __kernel_end = .;
 }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -15,7 +15,7 @@ use quote::ToTokens;
 /// and use the published version in the generated Cargo.toml.
 pub const ASTER_GIT_LINK: &str = "https://github.com/asterinas/asterinas";
 /// Make sure it syncs with the builder dependency in Cargo.toml.
-pub const ASTER_GIT_REV: &str = "cc4111c";
+pub const ASTER_GIT_REV: &str = "c9b66bd";
 pub fn aster_crate_dep(crate_name: &str) -> String {
     format!(
         "{} = {{ git = \"{}\", rev = \"{}\" }}",


### PR DESCRIPTION
### Motivation

On the original kernel ELF layout, both `__kernel_start` and `__kernel_end` lay in the LMA, while the code was placed in the VMA. This might cause some obstacles in addressing on some code model, since they spans a long distance of address space (> 4 GiB). For example, RISC-V's default addressing mode can only access symbols lain in ±2 GiB window.

### Proposal

To address the issue, here move the whole kernel into VMA, including `__kernel_start` and `__kernel_end`. Linux also does it this way. Then, all the symbols are located in adjacent memory areas, which should solve the addressing-related issue.