### PR TITLE
Fix OSDK lint failure

### DIFF
--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Lint
         id: lint
-        run: cd osdk && cargo clippy -- -D warnings
+        run: make check_osdk
 
         # The OSDK unit test features a recursive call of Cargo,
         # which will break when RUSTUP_HOME is altered in the case

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,6 @@ format:
 
 .PHONY: check
 check: $(CARGO_OSDK)
-	@cd osdk && cargo clippy -- -D warnings
 	@./tools/format_all.sh --check   	# Check Rust format issues
 	@# Check if STD_CRATES and NOSTD_CRATES combined is the same as all workspace members
 	@sed -n '/^\[workspace\]/,/^\[.*\]/{/members = \[/,/\]/p}' Cargo.toml | \
@@ -197,6 +196,10 @@ check: $(CARGO_OSDK)
 		(cd $$dir && cargo osdk clippy -- -- -D warnings) || exit 1; \
 	done
 	@make --no-print-directory -C regression check
+
+.PHONY: check_osdk
+check_osdk:
+	@cd osdk && cargo clippy -- -D warnings
 
 .PHONY: clean
 clean:

--- a/osdk/src/config/scheme/action.rs
+++ b/osdk/src/config/scheme/action.rs
@@ -50,7 +50,7 @@ impl Build {
     pub fn apply_common_args(&mut self, common_args: &CommonArgs) {
         let build_args = &common_args.build_args;
         if let Some(profile) = build_args.profile() {
-            self.profile = profile.clone();
+            self.profile.clone_from(&profile);
         }
         self.features.extend(build_args.features.clone());
         self.override_configs
@@ -67,7 +67,7 @@ impl Build {
 impl BuildScheme {
     pub fn inherit(&mut self, parent: &Self) {
         if self.profile.is_none() {
-            self.profile = parent.profile.clone();
+            self.profile.clone_from(&parent.profile);
         }
         self.features = {
             let mut features = parent.features.clone();

--- a/osdk/src/config/scheme/boot.rs
+++ b/osdk/src/config/scheme/boot.rs
@@ -60,7 +60,7 @@ impl BootScheme {
             init_args
         };
         if self.initramfs.is_none() {
-            self.initramfs = from.initramfs.clone();
+            self.initramfs.clone_from(&from.initramfs);
         }
         if self.method.is_none() {
             self.method = from.method;

--- a/osdk/src/config/scheme/grub.rs
+++ b/osdk/src/config/scheme/grub.rs
@@ -43,7 +43,7 @@ impl Default for Grub {
 impl GrubScheme {
     pub fn inherit(&mut self, from: &Self) {
         if self.grub_mkrescue.is_none() {
-            self.grub_mkrescue = from.grub_mkrescue.clone();
+            self.grub_mkrescue.clone_from(&from.grub_mkrescue);
         }
         if self.boot_protocol.is_none() {
             self.boot_protocol = from.boot_protocol;

--- a/osdk/src/config/scheme/mod.rs
+++ b/osdk/src/config/scheme/mod.rs
@@ -69,17 +69,17 @@ impl Scheme {
         if let Some(qemu) = &mut self.qemu {
             if let Some(from_qemu) = &from.qemu {
                 if qemu.args.is_none() {
-                    qemu.args = from_qemu.args.clone();
-                    self.work_dir = from.work_dir.clone();
+                    qemu.args.clone_from(&from_qemu.args);
+                    self.work_dir.clone_from(&from.work_dir);
                 }
                 if qemu.path.is_none() {
-                    qemu.path = from_qemu.path.clone();
-                    self.work_dir = from.work_dir.clone();
+                    qemu.path.clone_from(&from_qemu.path);
+                    self.work_dir.clone_from(&from.work_dir);
                 }
             }
         } else {
-            self.qemu = from.qemu.clone();
-            self.work_dir = from.work_dir.clone();
+            self.qemu.clone_from(&from.qemu);
+            self.work_dir.clone_from(&from.work_dir);
         }
     }
 }

--- a/osdk/src/config/scheme/qemu.rs
+++ b/osdk/src/config/scheme/qemu.rs
@@ -53,10 +53,10 @@ impl Qemu {
 impl QemuScheme {
     pub fn inherit(&mut self, from: &Self) {
         if self.args.is_none() {
-            self.args = from.args.clone();
+            self.args.clone_from(&from.args);
         }
         if self.path.is_none() {
-            self.path = from.path.clone();
+            self.path.clone_from(&from.path);
         }
     }
 


### PR DESCRIPTION
Currently CI in new PRs will fail ~~because rustup still thinks that it should use the nightly toolchain for OSDK~~. I am trying to fix it.

EDIT: they fail because rustup automatically update rust to 1.78 before checking. It seems that if we specify the version we can't make it aligned with what's installed in the image. Bad bad rustup. I just fixed the new clippy warnings. I think the best way is to use `clippy` than `clippy -- -D warnings`, as what the [unofficial document says](https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html).