### PR TITLE
Move x86-specific syscall dispatch to arch/x86

### DIFF
--- a/kernel/aster-nix/src/syscall/accept.rs
+++ b/kernel/aster-nix/src/syscall/accept.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_ACCEPT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::{FdFlags, FileDesc},
         utils::{CreationFlags, StatusFlags},
     },
-    log_syscall_entry,
     prelude::*,
-    syscall::SYS_ACCEPT4,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
@@ -17,7 +15,6 @@ pub fn sys_accept(
     sockaddr_ptr: Vaddr,
     addrlen_ptr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_ACCEPT);
     debug!("sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let fd = do_accept(sockfd, sockaddr_ptr, addrlen_ptr, Flags::empty())?;
@@ -30,7 +27,6 @@ pub fn sys_accept4(
     addrlen_ptr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_ACCEPT4);
     trace!("raw flags = 0x{:x}", flags);
     let flags = Flags::from_bits_truncate(flags);
     debug!(

--- a/kernel/aster-nix/src/syscall/access.rs
+++ b/kernel/aster-nix/src/syscall/access.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{constants::*, SyscallReturn};
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_ACCESS, util::read_cstring_from_user};
+use crate::{prelude::*, util::read_cstring_from_user};
 
 pub fn sys_access(filename_ptr: Vaddr, file_mode: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_ACCESS);
     let filename = read_cstring_from_user(filename_ptr, MAX_FILENAME_LEN)?;
     debug!("filename: {:?}, file_mode = {}", filename, file_mode);
     // TODO: access currenly does not check and just return success

--- a/kernel/aster-nix/src/syscall/alarm.rs
+++ b/kernel/aster-nix/src/syscall/alarm.rs
@@ -2,11 +2,10 @@
 
 use core::time::Duration;
 
-use super::{SyscallReturn, SYS_ALARM};
-use crate::{log_syscall_entry, prelude::*, process::posix_thread::PosixThreadExt};
+use super::SyscallReturn;
+use crate::{prelude::*, process::posix_thread::PosixThreadExt};
 
 pub fn sys_alarm(seconds: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_ALARM);
     debug!("seconds = {}", seconds);
 
     let current_thread = current_thread!();

--- a/kernel/aster-nix/src/syscall/arch/mod.rs
+++ b/kernel/aster-nix/src/syscall/arch/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implement the `syscall_dispatch` function and the const values of system call number such as `SYS_READ`.
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86;
+#[cfg(target_arch = "x86_64")]
+pub use self::x86::*;

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::syscall::{
+    accept::{sys_accept, sys_accept4},
+    access::sys_access,
+    alarm::sys_alarm,
+    arch_prctl::sys_arch_prctl,
+    bind::sys_bind,
+    brk::sys_brk,
+    chdir::{sys_chdir, sys_fchdir},
+    chmod::{sys_chmod, sys_fchmod, sys_fchmodat},
+    chown::{sys_chown, sys_fchown, sys_fchownat, sys_lchown},
+    chroot::sys_chroot,
+    clock_gettime::sys_clock_gettime,
+    clone::sys_clone,
+    close::sys_close,
+    connect::sys_connect,
+    dup::{sys_dup, sys_dup2},
+    epoll::{sys_epoll_create, sys_epoll_create1, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait},
+    eventfd::{sys_eventfd, sys_eventfd2},
+    execve::{sys_execve, sys_execveat},
+    exit::sys_exit,
+    exit_group::sys_exit_group,
+    fcntl::sys_fcntl,
+    fork::sys_fork,
+    fsync::sys_fsync,
+    futex::sys_futex,
+    getcwd::sys_getcwd,
+    getdents64::sys_getdents64,
+    getegid::sys_getegid,
+    geteuid::sys_geteuid,
+    getgid::sys_getgid,
+    getgroups::sys_getgroups,
+    getpeername::sys_getpeername,
+    getpgrp::sys_getpgrp,
+    getpid::sys_getpid,
+    getppid::sys_getppid,
+    getrandom::sys_getrandom,
+    getresgid::sys_getresgid,
+    getresuid::sys_getresuid,
+    getsid::sys_getsid,
+    getsockname::sys_getsockname,
+    getsockopt::sys_getsockopt,
+    gettid::sys_gettid,
+    gettimeofday::sys_gettimeofday,
+    getuid::sys_getuid,
+    impl_syscall_nums_and_dispatch_fn,
+    ioctl::sys_ioctl,
+    kill::sys_kill,
+    link::{sys_link, sys_linkat},
+    listen::sys_listen,
+    lseek::sys_lseek,
+    madvise::sys_madvise,
+    mkdir::{sys_mkdir, sys_mkdirat},
+    mmap::sys_mmap,
+    mprotect::sys_mprotect,
+    munmap::sys_munmap,
+    nanosleep::{sys_clock_nanosleep, sys_nanosleep},
+    open::{sys_open, sys_openat},
+    pause::sys_pause,
+    pipe::{sys_pipe, sys_pipe2},
+    poll::sys_poll,
+    prctl::sys_prctl,
+    pread64::sys_pread64,
+    prlimit64::sys_prlimit64,
+    read::sys_read,
+    readlink::{sys_readlink, sys_readlinkat},
+    recvfrom::sys_recvfrom,
+    rename::{sys_rename, sys_renameat},
+    rmdir::sys_rmdir,
+    rt_sigaction::sys_rt_sigaction,
+    rt_sigprocmask::sys_rt_sigprocmask,
+    rt_sigreturn::sys_rt_sigreturn,
+    rt_sigsuspend::sys_rt_sigsuspend,
+    sched_yield::sys_sched_yield,
+    select::sys_select,
+    sendto::sys_sendto,
+    set_get_priority::{sys_get_priority, sys_set_priority},
+    set_robust_list::sys_set_robust_list,
+    set_tid_address::sys_set_tid_address,
+    setfsgid::sys_setfsgid,
+    setfsuid::sys_setfsuid,
+    setgid::sys_setgid,
+    setgroups::sys_setgroups,
+    setpgid::sys_setpgid,
+    setregid::sys_setregid,
+    setresgid::sys_setresgid,
+    setresuid::sys_setresuid,
+    setreuid::sys_setreuid,
+    setsid::sys_setsid,
+    setsockopt::sys_setsockopt,
+    setuid::sys_setuid,
+    shutdown::sys_shutdown,
+    sigaltstack::sys_sigaltstack,
+    socket::sys_socket,
+    socketpair::sys_socketpair,
+    stat::{sys_fstat, sys_fstatat, sys_lstat, sys_stat},
+    statfs::{sys_fstatfs, sys_statfs},
+    symlink::{sys_symlink, sys_symlinkat},
+    sync::sys_sync,
+    tgkill::sys_tgkill,
+    time::sys_time,
+    truncate::{sys_ftruncate, sys_truncate},
+    umask::sys_umask,
+    uname::sys_uname,
+    unlink::{sys_unlink, sys_unlinkat},
+    utimens::sys_utimensat,
+    wait4::sys_wait4,
+    waitid::sys_waitid,
+    write::sys_write,
+    writev::sys_writev,
+};
+
+impl_syscall_nums_and_dispatch_fn! {
+    SYS_READ = 0               => sys_read(args[..3]);
+    SYS_WRITE = 1              => sys_write(args[..3]);
+    SYS_OPEN = 2               => sys_open(args[..3]);
+    SYS_CLOSE = 3              => sys_close(args[..1]);
+    SYS_STAT = 4               => sys_stat(args[..2]);
+    SYS_FSTAT = 5              => sys_fstat(args[..2]);
+    SYS_LSTAT = 6              => sys_lstat(args[..2]);
+    SYS_POLL = 7               => sys_poll(args[..3]);
+    SYS_LSEEK = 8              => sys_lseek(args[..3]);
+    SYS_MMAP = 9               => sys_mmap(args[..6]);
+    SYS_MPROTECT = 10          => sys_mprotect(args[..3]);
+    SYS_MUNMAP = 11            => sys_munmap(args[..2]);
+    SYS_BRK = 12               => sys_brk(args[..1]);
+    SYS_RT_SIGACTION = 13      => sys_rt_sigaction(args[..4]);
+    SYS_RT_SIGPROCMASK = 14    => sys_rt_sigprocmask(args[..4]);
+    SYS_RT_SIGRETURN = 15      => sys_rt_sigreturn(args[..0], &mut context);
+    SYS_IOCTL = 16             => sys_ioctl(args[..3]);
+    SYS_PREAD64 = 17           => sys_pread64(args[..4]);
+    SYS_WRITEV = 20            => sys_writev(args[..3]);
+    SYS_ACCESS = 21            => sys_access(args[..2]);
+    SYS_PIPE = 22              => sys_pipe(args[..1]);
+    SYS_SELECT = 23            => sys_select(args[..5]);
+    SYS_SCHED_YIELD = 24       => sys_sched_yield(args[..0]);
+    SYS_MADVISE = 28           => sys_madvise(args[..3]);
+    SYS_DUP = 32               => sys_dup(args[..1]);
+    SYS_DUP2 = 33              => sys_dup2(args[..2]);
+    SYS_PAUSE = 34             => sys_pause(args[..0]);
+    SYS_NANOSLEEP = 35         => sys_nanosleep(args[..2]);
+    SYS_ALARM = 37             => sys_alarm(args[..1]);
+    SYS_GETPID = 39            => sys_getpid(args[..0]);
+    SYS_SOCKET = 41            => sys_socket(args[..3]);
+    SYS_CONNECT = 42           => sys_connect(args[..3]);
+    SYS_ACCEPT = 43            => sys_accept(args[..3]);
+    SYS_SENDTO = 44            => sys_sendto(args[..6]);
+    SYS_RECVFROM = 45          => sys_recvfrom(args[..6]);
+    SYS_SHUTDOWN = 48          => sys_shutdown(args[..2]);
+    SYS_BIND = 49              => sys_bind(args[..3]);
+    SYS_LISTEN = 50            => sys_listen(args[..2]);
+    SYS_GETSOCKNAME = 51       => sys_getsockname(args[..3]);
+    SYS_GETPEERNAME = 52       => sys_getpeername(args[..3]);
+    SYS_SOCKETPAIR = 53        => sys_socketpair(args[..4]);
+    SYS_SETSOCKOPT = 54        => sys_setsockopt(args[..5]);
+    SYS_GETSOCKOPT = 55        => sys_getsockopt(args[..5]);
+    SYS_CLONE = 56             => sys_clone(args[..5], &context);
+    SYS_FORK = 57              => sys_fork(args[..0], &context);
+    SYS_EXECVE = 59            => sys_execve(args[..3], &mut context);
+    SYS_EXIT = 60              => sys_exit(args[..1]);
+    SYS_WAIT4 = 61             => sys_wait4(args[..3]);
+    SYS_KILL = 62              => sys_kill(args[..2]);
+    SYS_UNAME = 63             => sys_uname(args[..1]);
+    SYS_FCNTL = 72             => sys_fcntl(args[..3]);
+    SYS_FSYNC = 74             => sys_fsync(args[..1]);
+    SYS_TRUNCATE = 76          => sys_truncate(args[..2]);
+    SYS_FTRUNCATE = 77         => sys_ftruncate(args[..2]);
+    SYS_GETCWD = 79            => sys_getcwd(args[..2]);
+    SYS_CHDIR = 80             => sys_chdir(args[..1]);
+    SYS_FCHDIR = 81            => sys_fchdir(args[..1]);
+    SYS_RENAME = 82            => sys_rename(args[..2]);
+    SYS_MKDIR = 83             => sys_mkdir(args[..2]);
+    SYS_RMDIR = 84             => sys_rmdir(args[..1]);
+    SYS_LINK = 86              => sys_link(args[..2]);
+    SYS_UNLINK = 87            => sys_unlink(args[..1]);
+    SYS_SYMLINK = 88           => sys_symlink(args[..2]);
+    SYS_READLINK = 89          => sys_readlink(args[..3]);
+    SYS_CHMOD = 90             => sys_chmod(args[..2]);
+    SYS_FCHMOD = 91            => sys_fchmod(args[..2]);
+    SYS_CHOWN = 92             => sys_chown(args[..3]);
+    SYS_FCHOWN = 93            => sys_fchown(args[..3]);
+    SYS_LCHOWN = 94            => sys_lchown(args[..3]);
+    SYS_UMASK = 95             => sys_umask(args[..1]);
+    SYS_GETTIMEOFDAY = 96      => sys_gettimeofday(args[..1]);
+    SYS_GETUID = 102           => sys_getuid(args[..0]);
+    SYS_GETGID = 104           => sys_getgid(args[..0]);
+    SYS_SETUID = 105           => sys_setuid(args[..1]);
+    SYS_SETGID = 106           => sys_setgid(args[..1]);
+    SYS_GETEUID = 107          => sys_geteuid(args[..0]);
+    SYS_GETEGID = 108          => sys_getegid(args[..0]);
+    SYS_SETPGID = 109          => sys_setpgid(args[..2]);
+    SYS_GETPPID = 110          => sys_getppid(args[..0]);
+    SYS_GETPGRP = 111          => sys_getpgrp(args[..0]);
+    SYS_SETSID = 112           => sys_setsid(args[..0]);
+    SYS_SETREUID = 113         => sys_setreuid(args[..2]);
+    SYS_SETREGID = 114         => sys_setregid(args[..2]);
+    SYS_GETGROUPS = 115        => sys_getgroups(args[..2]);
+    SYS_SETGROUPS = 116        => sys_setgroups(args[..2]);
+    SYS_SETRESUID = 117        => sys_setresuid(args[..3]);
+    SYS_GETRESUID = 118        => sys_getresuid(args[..3]);
+    SYS_SETRESGID = 119        => sys_setresgid(args[..3]);
+    SYS_GETRESGID = 120        => sys_getresgid(args[..3]);
+    SYS_SETFSUID = 122         => sys_setfsuid(args[..1]);
+    SYS_SETFSGID = 123         => sys_setfsgid(args[..1]);
+    SYS_GETSID = 124           => sys_getsid(args[..1]);
+    SYS_RT_SIGSUSPEND = 130    => sys_rt_sigsuspend(args[..2]);
+    SYS_SIGALTSTACK = 131      => sys_sigaltstack(args[..2]);
+    SYS_STATFS = 137           => sys_statfs(args[..2]);
+    SYS_FSTATFS = 138          => sys_fstatfs(args[..2]);
+    SYS_GET_PRIORITY = 140     => sys_get_priority(args[..2]);
+    SYS_SET_PRIORITY = 141     => sys_set_priority(args[..3]);
+    SYS_PRCTL = 157            => sys_prctl(args[..5]);
+    SYS_ARCH_PRCTL = 158       => sys_arch_prctl(args[..2], &mut context);
+    SYS_CHROOT = 161           => sys_chroot(args[..1]);
+    SYS_SYNC = 162             => sys_sync(args[..0]);
+    SYS_GETTID = 186           => sys_gettid(args[..0]);
+    SYS_TIME = 201             => sys_time(args[..1]);
+    SYS_FUTEX = 202            => sys_futex(args[..6]);
+    SYS_EPOLL_CREATE = 213     => sys_epoll_create(args[..1]);
+    SYS_GETDENTS64 = 217       => sys_getdents64(args[..3]);
+    SYS_SET_TID_ADDRESS = 218  => sys_set_tid_address(args[..1]);
+    SYS_CLOCK_GETTIME = 228    => sys_clock_gettime(args[..2]);
+    SYS_CLOCK_NANOSLEEP = 230  => sys_clock_nanosleep(args[..4]);
+    SYS_EXIT_GROUP = 231       => sys_exit_group(args[..1]);
+    SYS_EPOLL_WAIT = 232       => sys_epoll_wait(args[..4]);
+    SYS_EPOLL_CTL = 233        => sys_epoll_ctl(args[..4]);
+    SYS_TGKILL = 234           => sys_tgkill(args[..3]);
+    SYS_WAITID = 247           => sys_waitid(args[..5]);
+    SYS_OPENAT = 257           => sys_openat(args[..4]);
+    SYS_MKDIRAT = 258          => sys_mkdirat(args[..3]);
+    SYS_FCHOWNAT = 260         => sys_fchownat(args[..5]);
+    SYS_FSTATAT = 262          => sys_fstatat(args[..4]);
+    SYS_UNLINKAT = 263         => sys_unlinkat(args[..3]);
+    SYS_RENAMEAT = 264         => sys_renameat(args[..4]);
+    SYS_LINKAT = 265           => sys_linkat(args[..5]);
+    SYS_SYMLINKAT = 266        => sys_symlinkat(args[..3]);
+    SYS_READLINKAT = 267       => sys_readlinkat(args[..4]);
+    SYS_FCHMODAT = 268         => sys_fchmodat(args[..3]);
+    SYS_SET_ROBUST_LIST = 273  => sys_set_robust_list(args[..2]);
+    SYS_UTIMENSAT = 280        => sys_utimensat(args[..4]);
+    SYS_EPOLL_PWAIT = 281      => sys_epoll_pwait(args[..5]);
+    SYS_EVENTFD = 284          => sys_eventfd(args[..1]);
+    SYS_ACCEPT4 = 288          => sys_accept4(args[..4]);
+    SYS_EVENTFD2 = 290         => sys_eventfd2(args[..2]);
+    SYS_EPOLL_CREATE1 = 291    => sys_epoll_create1(args[..1]);
+    SYS_PIPE2 = 293            => sys_pipe2(args[..2]);
+    SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
+    SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut context);
+}

--- a/kernel/aster-nix/src/syscall/arch_prctl.rs
+++ b/kernel/aster-nix/src/syscall/arch_prctl.rs
@@ -3,7 +3,7 @@
 use aster_frame::cpu::UserContext;
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_ARCH_PRCTL};
+use crate::prelude::*;
 
 #[allow(non_camel_case_types)]
 #[repr(u64)]
@@ -16,7 +16,6 @@ pub enum ArchPrctlCode {
 }
 
 pub fn sys_arch_prctl(code: u64, addr: u64, context: &mut UserContext) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_ARCH_PRCTL);
     let arch_prctl_code = ArchPrctlCode::try_from(code)?;
     debug!(
         "arch_prctl_code: {:?}, addr = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/bind.rs
+++ b/kernel/aster-nix/src/syscall/bind.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_BIND};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, read_socket_addr_from_user},
 };
 
 pub fn sys_bind(sockfd: FileDesc, sockaddr_ptr: Vaddr, addrlen: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_BIND);
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addrlen as usize)?;
     debug!("sockfd = {sockfd}, socket_addr = {socket_addr:?}");
 

--- a/kernel/aster-nix/src/syscall/brk.rs
+++ b/kernel/aster-nix/src/syscall/brk.rs
@@ -1,14 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{
-    log_syscall_entry,
-    prelude::*,
-    syscall::{SyscallReturn, SYS_BRK},
-};
+use crate::{prelude::*, syscall::SyscallReturn};
 
 /// expand the user heap to new heap end, returns the new heap end if expansion succeeds.
 pub fn sys_brk(heap_end: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_BRK);
     let new_heap_end = if heap_end == 0 {
         None
     } else {

--- a/kernel/aster-nix/src/syscall/chdir.rs
+++ b/kernel/aster-nix/src/syscall/chdir.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_CHDIR, SYS_FCHDIR};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, fs_resolver::FsPath, inode_handle::InodeHandle, utils::InodeType},
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
 };
 
 pub fn sys_chdir(path_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CHDIR);
     let path = read_cstring_from_user(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
@@ -32,7 +30,6 @@ pub fn sys_chdir(path_ptr: Vaddr) -> Result<SyscallReturn> {
 }
 
 pub fn sys_fchdir(fd: FileDesc) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCHDIR);
     debug!("fd = {}", fd);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/chmod.rs
+++ b/kernel/aster-nix/src/syscall/chmod.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FCHMOD, SYS_FCHMODAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, PATH_MAX},
     },
-    log_syscall_entry,
     prelude::*,
     util::read_cstring_from_user,
 };
 
 pub fn sys_fchmod(fd: FileDesc, mode: u16) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCHMOD);
     debug!("fd = {}, mode = 0o{:o}", fd, mode);
 
     let current = current!();
@@ -34,7 +32,6 @@ pub fn sys_fchmodat(
     mode: u16,
     /* flags: u32, */
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCHMODAT);
     let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
     debug!("dirfd = {}, path = {:?}, mode = 0o{:o}", dirfd, path, mode,);
 

--- a/kernel/aster-nix/src/syscall/chown.rs
+++ b/kernel/aster-nix/src/syscall/chown.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FCHOWN, SYS_FCHOWNAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::PATH_MAX,
     },
-    log_syscall_entry,
     prelude::*,
     process::{Gid, Uid},
     util::read_cstring_from_user,
 };
 
 pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCHOWN);
     debug!("fd = {}, uid = {}, gid = {}", fd, uid, gid);
 
     let uid = to_optional_id(uid, Uid::new)?;
@@ -56,7 +54,6 @@ pub fn sys_fchownat(
     gid: i32,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCHOWNAT);
     let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
     let flags = ChownFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;

--- a/kernel/aster-nix/src/syscall/chroot.rs
+++ b/kernel/aster-nix/src/syscall/chroot.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_CHROOT};
+use super::SyscallReturn;
 use crate::{
     fs::{fs_resolver::FsPath, utils::InodeType},
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
 };
 
 pub fn sys_chroot(path_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CHROOT);
     let path = read_cstring_from_user(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 

--- a/kernel/aster-nix/src/syscall/clock_gettime.rs
+++ b/kernel/aster-nix/src/syscall/clock_gettime.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_CLOCK_GETTIME};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     time::{clockid_t, now_as_duration, timespec_t, ClockID},
     util::write_val_to_user,
 };
 
 pub fn sys_clock_gettime(clockid: clockid_t, timespec_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CLOCK_GETTIME);
     let clock_id = ClockID::try_from(clockid)?;
     debug!("clockid = {:?}", clock_id);
 

--- a/kernel/aster-nix/src/syscall/clone.rs
+++ b/kernel/aster-nix/src/syscall/clone.rs
@@ -4,10 +4,8 @@ use aster_frame::cpu::UserContext;
 
 use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{clone_child, CloneArgs, CloneFlags},
-    syscall::SYS_CLONE,
 };
 
 // The order of arguments for clone differs in different architecture.
@@ -18,12 +16,11 @@ pub fn sys_clone(
     parent_tidptr: Vaddr,
     child_tidptr: Vaddr,
     tls: u64,
-    parent_context: UserContext,
+    parent_context: &UserContext,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CLONE);
     let clone_flags = CloneFlags::from(clone_flags);
     debug!("flags = {:?}, child_stack_ptr = 0x{:x}, parent_tid_ptr = 0x{:x}, child tid ptr = 0x{:x}, tls = 0x{:x}", clone_flags, new_sp, parent_tidptr, child_tidptr, tls);
     let clone_args = CloneArgs::new(new_sp, parent_tidptr, child_tidptr, tls, clone_flags);
-    let child_pid = clone_child(parent_context, clone_args).unwrap();
+    let child_pid = clone_child(*parent_context, clone_args).unwrap();
     Ok(SyscallReturn::Return(child_pid as _))
 }

--- a/kernel/aster-nix/src/syscall/close.rs
+++ b/kernel/aster-nix/src/syscall/close.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_CLOSE};
-use crate::{fs::file_table::FileDesc, log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 pub fn sys_close(fd: FileDesc) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CLOSE);
     debug!("fd = {}", fd);
     let current = current!();
     let mut file_table = current.file_table().lock();

--- a/kernel/aster-nix/src/syscall/connect.rs
+++ b/kernel/aster-nix/src/syscall/connect.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_CONNECT};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, read_socket_addr_from_user},
 };
 
 pub fn sys_connect(sockfd: FileDesc, sockaddr_ptr: Vaddr, addr_len: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CONNECT);
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addr_len as _)?;
     debug!("fd = {sockfd}, socket_addr = {socket_addr:?}");
 

--- a/kernel/aster-nix/src/syscall/dup.rs
+++ b/kernel/aster-nix/src/syscall/dup.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_DUP, SYS_DUP2};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::{FdFlags, FileDesc},
-    log_syscall_entry,
     prelude::*,
 };
 
 pub fn sys_dup(old_fd: FileDesc) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_DUP);
     debug!("old_fd = {}", old_fd);
 
     let current = current!();
@@ -20,7 +18,6 @@ pub fn sys_dup(old_fd: FileDesc) -> Result<SyscallReturn> {
 }
 
 pub fn sys_dup2(old_fd: FileDesc, new_fd: FileDesc) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_DUP2);
     debug!("old_fd = {}, new_fd = {}", old_fd, new_fd);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/epoll.rs
+++ b/kernel/aster-nix/src/syscall/epoll.rs
@@ -2,7 +2,7 @@
 
 use core::time::Duration;
 
-use super::{SyscallReturn, SYS_EPOLL_CREATE1, SYS_EPOLL_CTL, SYS_EPOLL_PWAIT, SYS_EPOLL_WAIT};
+use super::SyscallReturn;
 use crate::{
     events::IoEvents,
     fs::{
@@ -10,7 +10,6 @@ use crate::{
         file_table::{FdFlags, FileDesc},
         utils::CreationFlags,
     },
-    log_syscall_entry,
     prelude::*,
     util::{read_val_from_user, write_val_to_user},
 };
@@ -23,7 +22,6 @@ pub fn sys_epoll_create(size: i32) -> Result<SyscallReturn> {
 }
 
 pub fn sys_epoll_create1(flags: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EPOLL_CREATE1);
     debug!("flags = 0x{:x}", flags);
 
     let fd_flags = {
@@ -52,7 +50,6 @@ pub fn sys_epoll_ctl(
     fd: FileDesc,
     event_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EPOLL_CTL);
     debug!(
         "epfd = {}, op = {}, fd = {}, event_addr = 0x{:x}",
         epfd, op, fd, event_addr
@@ -98,8 +95,6 @@ pub fn sys_epoll_wait(
     max_events: i32,
     timeout: i32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EPOLL_WAIT);
-
     let max_events = {
         if max_events <= 0 {
             return_errno_with_message!(Errno::EINVAL, "max_events is not positive");
@@ -144,7 +139,6 @@ pub fn sys_epoll_pwait(
     timeout: i32,
     sigmask: Vaddr, //TODO: handle sigmask
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EPOLL_PWAIT);
     if sigmask != 0 {
         warn!("epoll_pwait cannot handle signal mask, yet");
     }

--- a/kernel/aster-nix/src/syscall/eventfd.rs
+++ b/kernel/aster-nix/src/syscall/eventfd.rs
@@ -14,7 +14,7 @@
 //! refer to the man 2 eventfd documentation.
 //!
 
-use super::{SyscallReturn, SYS_EVENTFD, SYS_EVENTFD2};
+use super::SyscallReturn;
 use crate::{
     events::{IoEvents, Observer},
     fs::{
@@ -22,13 +22,11 @@ use crate::{
         file_table::{FdFlags, FileDesc},
         utils::{CreationFlags, StatusFlags},
     },
-    log_syscall_entry,
     prelude::*,
     process::signal::{Pauser, Pollee, Poller},
 };
 
 pub fn sys_eventfd(init_val: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EVENTFD);
     debug!("init_val = 0x{:x}", init_val);
 
     let fd = do_sys_eventfd2(init_val, Flags::empty());
@@ -37,7 +35,6 @@ pub fn sys_eventfd(init_val: u64) -> Result<SyscallReturn> {
 }
 
 pub fn sys_eventfd2(init_val: u64, flags: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EVENTFD2);
     trace!("raw flags = {}", flags);
     let flags = Flags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown flags"))?;

--- a/kernel/aster-nix/src/syscall/execve.rs
+++ b/kernel/aster-nix/src/syscall/execve.rs
@@ -11,14 +11,12 @@ use crate::{
         path::Dentry,
         utils::InodeType,
     },
-    log_syscall_entry,
     prelude::*,
     process::{
         check_executable_file, credentials_mut, load_program_to_vm,
         posix_thread::{PosixThreadExt, ThreadName},
         Credentials, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
     },
-    syscall::{SYS_EXECVE, SYS_EXECVEAT},
     util::{read_cstring_from_user, read_val_from_user},
 };
 
@@ -28,7 +26,6 @@ pub fn sys_execve(
     envp_ptr_ptr: Vaddr,
     context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EXECVE);
     let elf_file = {
         let executable_path = read_filename(filename_ptr)?;
         lookup_executable_file(AT_FDCWD, executable_path, OpenFlags::empty())?
@@ -46,8 +43,6 @@ pub fn sys_execveat(
     flags: u32,
     context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EXECVEAT);
-
     let elf_file = {
         let flags = OpenFlags::from_bits_truncate(flags);
         let filename = read_filename(filename_ptr)?;

--- a/kernel/aster-nix/src/syscall/exit.rs
+++ b/kernel/aster-nix/src/syscall/exit.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{posix_thread::PosixThreadExt, TermStatus},
-    syscall::{SyscallReturn, SYS_EXIT},
+    syscall::SyscallReturn,
 };
 
 pub fn sys_exit(exit_code: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EXIT);
     debug!("exid code = {}", exit_code);
 
     let current_thread = current_thread!();

--- a/kernel/aster-nix/src/syscall/exit_group.rs
+++ b/kernel/aster-nix/src/syscall/exit_group.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{do_exit_group, TermStatus},
-    syscall::{SyscallReturn, SYS_EXIT_GROUP},
+    syscall::SyscallReturn,
 };
 
 /// Exit all thread in a process.
 pub fn sys_exit_group(exit_code: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_EXIT_GROUP);
     // Exit all thread in current process
     let term_status = TermStatus::Exited(exit_code as _);
     do_exit_group(term_status);

--- a/kernel/aster-nix/src/syscall/fcntl.rs
+++ b/kernel/aster-nix/src/syscall/fcntl.rs
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FCNTL};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::{FdFlags, FileDesc},
         utils::StatusFlags,
     },
-    log_syscall_entry,
     prelude::*,
 };
 
 pub fn sys_fcntl(fd: FileDesc, cmd: i32, arg: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FCNTL);
     let fcntl_cmd = FcntlCmd::try_from(cmd)?;
     debug!("fd = {}, cmd = {:?}, arg = {}", fd, fcntl_cmd, arg);
     match fcntl_cmd {

--- a/kernel/aster-nix/src/syscall/fork.rs
+++ b/kernel/aster-nix/src/syscall/fork.rs
@@ -4,17 +4,14 @@ use aster_frame::cpu::UserContext;
 
 use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{clone_child, CloneArgs},
-    syscall::SYS_FORK,
 };
 
-pub fn sys_fork(parent_context: UserContext) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FORK);
+pub fn sys_fork(parent_context: &UserContext) -> Result<SyscallReturn> {
     let current = current!();
     // FIXME: set correct args for fork
     let clone_args = CloneArgs::default();
-    let child_pid = clone_child(parent_context, clone_args).unwrap();
+    let child_pid = clone_child(*parent_context, clone_args).unwrap();
     Ok(SyscallReturn::Return(child_pid as _))
 }

--- a/kernel/aster-nix/src/syscall/fsync.rs
+++ b/kernel/aster-nix/src/syscall/fsync.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FSYNC};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, inode_handle::InodeHandle},
-    log_syscall_entry,
     prelude::*,
 };
 
 pub fn sys_fsync(fd: FileDesc) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FSYNC);
     debug!("fd = {}", fd);
 
     let dentry = {

--- a/kernel/aster-nix/src/syscall/futex.rs
+++ b/kernel/aster-nix/src/syscall/futex.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::posix_thread::futex::{
         futex_op_and_flags_from_u32, futex_requeue, futex_wait, futex_wait_bitset, futex_wake,
         futex_wake_bitset, FutexOp, FutexTimeout,
     },
-    syscall::{SyscallReturn, SYS_FUTEX},
+    syscall::SyscallReturn,
 };
 
 pub fn sys_futex(
@@ -18,7 +17,6 @@ pub fn sys_futex(
     futex_new_addr: u64,
     bitset: u64,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FUTEX);
     // FIXME: we current ignore futex flags
     let (futex_op, futex_flags) = futex_op_and_flags_from_u32(futex_op as _).unwrap();
     debug!(

--- a/kernel/aster-nix/src/syscall/getcwd.rs
+++ b/kernel/aster-nix/src/syscall/getcwd.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETCWD};
-use crate::{log_syscall_entry, prelude::*, util::write_bytes_to_user};
+use super::SyscallReturn;
+use crate::{prelude::*, util::write_bytes_to_user};
 
 pub fn sys_getcwd(buf: Vaddr, len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETCWD);
     // TODO: getcwd only return a fake result now
     let fake_cwd = CString::new("/")?;
     let bytes = fake_cwd.as_bytes_with_nul();

--- a/kernel/aster-nix/src/syscall/getdents64.rs
+++ b/kernel/aster-nix/src/syscall/getdents64.rs
@@ -2,20 +2,18 @@
 
 use core::marker::PhantomData;
 
-use super::{SyscallReturn, SYS_GETDENTS64};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         inode_handle::InodeHandle,
         utils::{DirentVisitor, InodeType},
     },
-    log_syscall_entry,
     prelude::*,
     util::write_bytes_to_user,
 };
 
 pub fn sys_getdents64(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETDENTS64);
     debug!(
         "fd = {}, buf_addr = 0x{:x}, buf_len = 0x{:x}",
         fd, buf_addr, buf_len

--- a/kernel/aster-nix/src/syscall/getegid.rs
+++ b/kernel/aster-nix/src/syscall/getegid.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETEGID};
-use crate::{log_syscall_entry, prelude::*, process::credentials};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getegid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETEGID);
-
     let egid = {
         let credentials = credentials();
         credentials.egid()

--- a/kernel/aster-nix/src/syscall/geteuid.rs
+++ b/kernel/aster-nix/src/syscall/geteuid.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETEUID};
-use crate::{log_syscall_entry, prelude::*, process::credentials};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_geteuid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETEUID);
-
     let euid = {
         let credentials = credentials();
         credentials.euid()

--- a/kernel/aster-nix/src/syscall/getgid.rs
+++ b/kernel/aster-nix/src/syscall/getgid.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETGID};
-use crate::{log_syscall_entry, prelude::*, process::credentials};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getgid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETGID);
-
     let gid = {
         let credentials = credentials();
         credentials.rgid()

--- a/kernel/aster-nix/src/syscall/getgroups.rs
+++ b/kernel/aster-nix/src/syscall/getgroups.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETGROUPS};
-use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getgroups(size: i32, group_list_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETGROUPS);
     debug!("size = {}, group_list_addr = 0x{:x}", size, group_list_addr);
 
     if size < 0 {

--- a/kernel/aster-nix/src/syscall/getpeername.rs
+++ b/kernel/aster-nix/src/syscall/getpeername.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETPEERNAME};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
 pub fn sys_getpeername(sockfd: FileDesc, addr: Vaddr, addrlen_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETPEERNAME);
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let peer_addr = {

--- a/kernel/aster-nix/src/syscall/getpgrp.rs
+++ b/kernel/aster-nix/src/syscall/getpgrp.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETPGRP};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_getpgrp() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETPGRP);
     let current = current!();
     Ok(SyscallReturn::Return(current.pgid() as _))
 }

--- a/kernel/aster-nix/src/syscall/getpid.rs
+++ b/kernel/aster-nix/src/syscall/getpid.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_GETPID};
+use crate::prelude::*;
 
 pub fn sys_getpid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETPID);
     let pid = current!().pid();
     debug!("[sys_getpid]: pid = {}", pid);
     Ok(SyscallReturn::Return(pid as _))

--- a/kernel/aster-nix/src/syscall/getppid.rs
+++ b/kernel/aster-nix/src/syscall/getppid.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETPPID};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_getppid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETPPID);
     let current = current!();
     let parent = current.parent();
     match parent {

--- a/kernel/aster-nix/src/syscall/getrandom.rs
+++ b/kernel/aster-nix/src/syscall/getrandom.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    device, log_syscall_entry, prelude::*, syscall::SYS_GETRANDOM, util::write_bytes_to_user,
-};
+use crate::{device, prelude::*, util::write_bytes_to_user};
 
 pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETRANDOM);
     let flags = GetRandomFlags::from_bits_truncate(flags);
     debug!(
         "buf = 0x{:x}, count = 0x{:x}, flags = {:?}",

--- a/kernel/aster-nix/src/syscall/getresgid.rs
+++ b/kernel/aster-nix/src/syscall/getresgid.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETRESGID};
-use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getresgid(rgid_ptr: Vaddr, egid_ptr: Vaddr, sgid_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETRESGID);
     debug!("rgid_ptr = 0x{rgid_ptr:x}, egid_ptr = 0x{egid_ptr:x}, sgid_ptr = 0x{sgid_ptr:x}");
 
     let credentials = credentials();

--- a/kernel/aster-nix/src/syscall/getresuid.rs
+++ b/kernel/aster-nix/src/syscall/getresuid.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETRESUID};
-use crate::{log_syscall_entry, prelude::*, process::credentials, util::write_val_to_user};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials, util::write_val_to_user};
 
 pub fn sys_getresuid(ruid_ptr: Vaddr, euid_ptr: Vaddr, suid_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETRESUID);
     debug!("ruid_ptr = 0x{ruid_ptr:x}, euid_ptr = 0x{euid_ptr:x}, suid_ptr = 0x{suid_ptr:x}");
 
     let credentials = credentials();

--- a/kernel/aster-nix/src/syscall/getsid.rs
+++ b/kernel/aster-nix/src/syscall/getsid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETSID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{process_table, Pid},
 };
 
 pub fn sys_getsid(pid: Pid) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETSID);
     debug!("pid = {}", pid);
 
     let session = current!().session().unwrap();

--- a/kernel/aster-nix/src/syscall/getsockname.rs
+++ b/kernel/aster-nix/src/syscall/getsockname.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETSOCKNAME};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
 pub fn sys_getsockname(sockfd: FileDesc, addr: Vaddr, addrlen_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETSOCKNAME);
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let socket_addr = {

--- a/kernel/aster-nix/src/syscall/getsockopt.rs
+++ b/kernel/aster-nix/src/syscall/getsockopt.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETSOCKOPT};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::{
         net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
@@ -18,7 +17,6 @@ pub fn sys_getsockopt(
     optval: Vaddr,
     optlen_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETSOCKOPT);
     let level = CSocketOptionLevel::try_from(level)?;
     if optval == 0 || optlen_addr == 0 {
         return_errno_with_message!(Errno::EINVAL, "optval or optlen_addr is null pointer");

--- a/kernel/aster-nix/src/syscall/gettid.rs
+++ b/kernel/aster-nix/src/syscall/gettid.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_GETTID};
+use crate::prelude::*;
 
 pub fn sys_gettid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETTID);
     let current_thread = current_thread!();
     let tid = current_thread.tid();
     Ok(SyscallReturn::Return(tid as _))

--- a/kernel/aster-nix/src/syscall/gettimeofday.rs
+++ b/kernel/aster-nix/src/syscall/gettimeofday.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETTIMEOFDAY};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     time::{timeval_t, SystemTime},
     util::write_val_to_user,
@@ -11,7 +10,6 @@ use crate::{
 // The use of the timezone structure is obsolete.
 // Glibc sets the timezone_addr argument to NULL, so just ignore it.
 pub fn sys_gettimeofday(timeval_addr: Vaddr, /* timezone_addr: Vaddr */) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETTIMEOFDAY);
     if timeval_addr == 0 {
         return Ok(SyscallReturn::Return(0));
     }

--- a/kernel/aster-nix/src/syscall/getuid.rs
+++ b/kernel/aster-nix/src/syscall/getuid.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_GETUID};
-use crate::{log_syscall_entry, prelude::*, process::credentials};
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getuid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GETUID);
-
     let uid = {
         let credentials = credentials();
         credentials.ruid()

--- a/kernel/aster-nix/src/syscall/ioctl.rs
+++ b/kernel/aster-nix/src/syscall/ioctl.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_IOCTL};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, utils::IoctlCmd},
-    log_syscall_entry,
     prelude::*,
 };
 
 pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_IOCTL);
     let ioctl_cmd = IoctlCmd::try_from(cmd)?;
     debug!(
         "fd = {}, ioctl_cmd = {:?}, arg = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/kill.rs
+++ b/kernel/aster-nix/src/syscall/kill.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_KILL};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{
         credentials, kill, kill_all, kill_group,
@@ -15,7 +14,6 @@ use crate::{
 };
 
 pub fn sys_kill(process_filter: u64, sig_num: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_KILL);
     let process_filter = ProcessFilter::from_id(process_filter as _);
     let sig_num = if sig_num == 0 {
         None

--- a/kernel/aster-nix/src/syscall/link.rs
+++ b/kernel/aster-nix/src/syscall/link.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_LINKAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -19,7 +18,6 @@ pub fn sys_linkat(
     new_path_addr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_LINKAT);
     let old_path = read_cstring_from_user(old_path_addr, MAX_FILENAME_LEN)?;
     let new_path = read_cstring_from_user(new_path_addr, MAX_FILENAME_LEN)?;
     let flags =

--- a/kernel/aster-nix/src/syscall/listen.rs
+++ b/kernel/aster-nix/src/syscall/listen.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_LISTEN};
-use crate::{
-    fs::file_table::FileDesc, log_syscall_entry, prelude::*, util::net::get_socket_from_fd,
-};
+use super::SyscallReturn;
+use crate::{fs::file_table::FileDesc, prelude::*, util::net::get_socket_from_fd};
 
 pub fn sys_listen(sockfd: FileDesc, backlog: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_LISTEN);
     debug!("sockfd = {sockfd}, backlog = {backlog}");
 
     let socket = get_socket_from_fd(sockfd)?;

--- a/kernel/aster-nix/src/syscall/lseek.rs
+++ b/kernel/aster-nix/src/syscall/lseek.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_LSEEK};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, utils::SeekFrom},
-    log_syscall_entry,
     prelude::*,
 };
 
 pub fn sys_lseek(fd: FileDesc, offset: isize, whence: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_LSEEK);
     debug!("fd = {}, offset = {}, whence = {}", fd, offset, whence);
     let seek_from = match whence {
         0 => {

--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_MADVISE};
-use crate::{log_syscall_entry, prelude::*, util::read_bytes_from_user};
+use super::SyscallReturn;
+use crate::{prelude::*, util::read_bytes_from_user};
 
 pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_MADVISE);
     let behavior = MadviseBehavior::try_from(behavior)?;
     debug!(
         "start = 0x{:x}, len = 0x{:x}, behavior = {:?}",

--- a/kernel/aster-nix/src/syscall/mkdir.rs
+++ b/kernel/aster-nix/src/syscall/mkdir.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_MKDIRAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, InodeType},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
 };
 
 pub fn sys_mkdirat(dirfd: FileDesc, path_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_MKDIRAT);
     let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}, mode = {}", dirfd, path, mode);
 

--- a/kernel/aster-nix/src/syscall/mmap.rs
+++ b/kernel/aster-nix/src/syscall/mmap.rs
@@ -8,9 +8,7 @@ use aster_rights::Rights;
 use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
-    syscall::SYS_MMAP,
     vm::{
         perms::VmPerms,
         vmo::{Vmo, VmoChildOptions, VmoOptions, VmoRightsOp},
@@ -25,7 +23,6 @@ pub fn sys_mmap(
     fd: u64,
     offset: u64,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_MMAP);
     let perms = VmPerms::from_posix_prot_bits(perms as u32).unwrap();
     let option = MMapOptions::try_from(flags as u32)?;
     let res = do_sys_mmap(

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -4,127 +4,12 @@
 //! The each sub module contains functions that handle real syscall logic.
 use aster_frame::cpu::UserContext;
 
-use self::{
-    accept::{sys_accept, sys_accept4},
-    alarm::sys_alarm,
-    bind::sys_bind,
-    connect::sys_connect,
-    eventfd::{sys_eventfd, sys_eventfd2},
-    execve::sys_execveat,
-    getgroups::sys_getgroups,
-    getpeername::sys_getpeername,
-    getrandom::sys_getrandom,
-    getresgid::sys_getresgid,
-    getresuid::sys_getresuid,
-    getsid::sys_getsid,
-    getsockname::sys_getsockname,
-    getsockopt::sys_getsockopt,
-    listen::sys_listen,
-    pread64::sys_pread64,
-    recvfrom::sys_recvfrom,
-    rt_sigsuspend::sys_rt_sigsuspend,
-    sendto::sys_sendto,
-    setfsgid::sys_setfsgid,
-    setfsuid::sys_setfsuid,
-    setgid::sys_setgid,
-    setgroups::sys_setgroups,
-    setregid::sys_setregid,
-    setresgid::sys_setresgid,
-    setresuid::sys_setresuid,
-    setreuid::sys_setreuid,
-    setsid::sys_setsid,
-    setsockopt::sys_setsockopt,
-    setuid::sys_setuid,
-    shutdown::sys_shutdown,
-    sigaltstack::sys_sigaltstack,
-    socket::sys_socket,
-    socketpair::sys_socketpair,
-};
-use crate::{
-    prelude::*,
-    syscall::{
-        access::sys_access,
-        arch_prctl::sys_arch_prctl,
-        brk::sys_brk,
-        chdir::{sys_chdir, sys_fchdir},
-        chmod::{sys_chmod, sys_fchmod, sys_fchmodat},
-        chown::{sys_chown, sys_fchown, sys_fchownat, sys_lchown},
-        chroot::sys_chroot,
-        clock_gettime::sys_clock_gettime,
-        clone::sys_clone,
-        close::sys_close,
-        dup::{sys_dup, sys_dup2},
-        epoll::{
-            sys_epoll_create, sys_epoll_create1, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait,
-        },
-        execve::sys_execve,
-        exit::sys_exit,
-        exit_group::sys_exit_group,
-        fcntl::sys_fcntl,
-        fork::sys_fork,
-        fsync::sys_fsync,
-        futex::sys_futex,
-        getcwd::sys_getcwd,
-        getdents64::sys_getdents64,
-        getegid::sys_getegid,
-        geteuid::sys_geteuid,
-        getgid::sys_getgid,
-        getpgrp::sys_getpgrp,
-        getpid::sys_getpid,
-        getppid::sys_getppid,
-        gettid::sys_gettid,
-        gettimeofday::sys_gettimeofday,
-        getuid::sys_getuid,
-        ioctl::sys_ioctl,
-        kill::sys_kill,
-        link::{sys_link, sys_linkat},
-        lseek::sys_lseek,
-        madvise::sys_madvise,
-        mkdir::{sys_mkdir, sys_mkdirat},
-        mmap::sys_mmap,
-        mprotect::sys_mprotect,
-        munmap::sys_munmap,
-        nanosleep::{sys_clock_nanosleep, sys_nanosleep},
-        open::{sys_open, sys_openat},
-        pause::sys_pause,
-        pipe::{sys_pipe, sys_pipe2},
-        poll::sys_poll,
-        prctl::sys_prctl,
-        prlimit64::sys_prlimit64,
-        read::sys_read,
-        readlink::{sys_readlink, sys_readlinkat},
-        rename::{sys_rename, sys_renameat},
-        rmdir::sys_rmdir,
-        rt_sigaction::sys_rt_sigaction,
-        rt_sigprocmask::sys_rt_sigprocmask,
-        rt_sigreturn::sys_rt_sigreturn,
-        sched_yield::sys_sched_yield,
-        select::sys_select,
-        set_get_priority::{sys_get_priority, sys_set_priority},
-        set_robust_list::sys_set_robust_list,
-        set_tid_address::sys_set_tid_address,
-        setpgid::sys_setpgid,
-        stat::{sys_fstat, sys_fstatat, sys_lstat, sys_stat},
-        statfs::{sys_fstatfs, sys_statfs},
-        symlink::{sys_symlink, sys_symlinkat},
-        sync::sys_sync,
-        tgkill::sys_tgkill,
-        time::sys_time,
-        truncate::{sys_ftruncate, sys_truncate},
-        umask::sys_umask,
-        uname::sys_uname,
-        unlink::{sys_unlink, sys_unlinkat},
-        utimens::sys_utimensat,
-        wait4::sys_wait4,
-        waitid::sys_waitid,
-        write::sys_write,
-        writev::sys_writev,
-    },
-};
+use crate::prelude::*;
 
 mod accept;
 mod access;
 mod alarm;
+mod arch;
 mod arch_prctl;
 mod bind;
 mod brk;
@@ -231,22 +116,14 @@ mod waitid;
 mod write;
 mod writev;
 
-macro_rules! define_syscall_nums {
-    ( $( $name: ident = $num: expr ),+ ) => {
-        $(
-            const $name: u64  = $num;
-        )*
-    }
-}
-
 /// This macro is used to define syscall handler.
 /// The first param is ths number of parameters,
 /// The second param is the function name of syscall handler,
 /// The third is optional, means the args(if parameter number > 0),
 /// The third is optional, means if cpu context is required.
 macro_rules! syscall_handler {
-    (0, $fn_name: ident) => { $fn_name() };
-    (0, $fn_name: ident, $context: expr) => { $fn_name($context) };
+    (0, $fn_name: ident, $args: ident) => { $fn_name() };
+    (0, $fn_name: ident, $args: ident, $context: expr) => { $fn_name($context) };
     (1, $fn_name: ident, $args: ident) => { $fn_name($args[0] as _) };
     (1, $fn_name: ident, $args: ident, $context: expr) => { $fn_name($args[0] as _, $context) };
     (2, $fn_name: ident, $args: ident) => { $fn_name($args[0] as _, $args[1] as _)};
@@ -261,144 +138,54 @@ macro_rules! syscall_handler {
     (6, $fn_name: ident, $args: ident, $context: expr) => { $fn_name($args[0] as _, $args[1] as _, $args[2] as _, $args[3] as _, $args[4] as _, $args[5] as _, $context)};
 }
 
-define_syscall_nums!(
-    SYS_READ = 0,
-    SYS_WRITE = 1,
-    SYS_OPEN = 2,
-    SYS_CLOSE = 3,
-    SYS_STAT = 4,
-    SYS_FSTAT = 5,
-    SYS_LSTAT = 6,
-    SYS_POLL = 7,
-    SYS_LSEEK = 8,
-    SYS_MMAP = 9,
-    SYS_MPROTECT = 10,
-    SYS_MUNMAP = 11,
-    SYS_BRK = 12,
-    SYS_RT_SIGACTION = 13,
-    SYS_RT_SIGPROCMASK = 14,
-    SYS_RT_SIGRETURN = 15,
-    SYS_IOCTL = 16,
-    SYS_PREAD64 = 17,
-    SYS_WRITEV = 20,
-    SYS_ACCESS = 21,
-    SYS_PIPE = 22,
-    SYS_SELECT = 23,
-    SYS_SCHED_YIELD = 24,
-    SYS_MADVISE = 28,
-    SYS_DUP = 32,
-    SYS_DUP2 = 33,
-    SYS_PAUSE = 34,
-    SYS_NANOSLEEP = 35,
-    SYS_ALARM = 37,
-    SYS_GETPID = 39,
-    SYS_SOCKET = 41,
-    SYS_CONNECT = 42,
-    SYS_ACCEPT = 43,
-    SYS_SENDTO = 44,
-    SYS_RECVFROM = 45,
-    SYS_SHUTDOWN = 48,
-    SYS_BIND = 49,
-    SYS_LISTEN = 50,
-    SYS_GETSOCKNAME = 51,
-    SYS_GETPEERNAME = 52,
-    SYS_SOCKETPAIR = 53,
-    SYS_SETSOCKOPT = 54,
-    SYS_GETSOCKOPT = 55,
-    SYS_CLONE = 56,
-    SYS_FORK = 57,
-    SYS_EXECVE = 59,
-    SYS_EXIT = 60,
-    SYS_WAIT4 = 61,
-    SYS_KILL = 62,
-    SYS_UNAME = 63,
-    SYS_FCNTL = 72,
-    SYS_FSYNC = 74,
-    SYS_TRUNCATE = 76,
-    SYS_FTRUNCATE = 77,
-    SYS_GETCWD = 79,
-    SYS_CHDIR = 80,
-    SYS_FCHDIR = 81,
-    SYS_RENAME = 82,
-    SYS_MKDIR = 83,
-    SYS_RMDIR = 84,
-    SYS_LINK = 86,
-    SYS_UNLINK = 87,
-    SYS_SYMLINK = 88,
-    SYS_READLINK = 89,
-    SYS_CHMOD = 90,
-    SYS_FCHMOD = 91,
-    SYS_CHOWN = 92,
-    SYS_FCHOWN = 93,
-    SYS_LCHOWN = 94,
-    SYS_UMASK = 95,
-    SYS_GETTIMEOFDAY = 96,
-    SYS_GETUID = 102,
-    SYS_GETGID = 104,
-    SYS_SETUID = 105,
-    SYS_SETGID = 106,
-    SYS_GETEUID = 107,
-    SYS_GETEGID = 108,
-    SYS_SETPGID = 109,
-    SYS_GETPPID = 110,
-    SYS_GETPGRP = 111,
-    SYS_SETSID = 112,
-    SYS_SETREUID = 113,
-    SYS_SETREGID = 114,
-    SYS_GETGROUPS = 115,
-    SYS_SETGROUPS = 116,
-    SYS_SETRESUID = 117,
-    SYS_GETRESUID = 118,
-    SYS_SETRESGID = 119,
-    SYS_GETRESGID = 120,
-    SYS_SETFSUID = 122,
-    SYS_SETFSGID = 123,
-    SYS_GETSID = 124,
-    SYS_RT_SIGSUSPEND = 130,
-    SYS_SIGALTSTACK = 131,
-    SYS_STATFS = 137,
-    SYS_FSTATFS = 138,
-    SYS_GET_PRIORITY = 140,
-    SYS_SET_PRIORITY = 141,
-    SYS_PRCTL = 157,
-    SYS_ARCH_PRCTL = 158,
-    SYS_CHROOT = 161,
-    SYS_SYNC = 162,
-    SYS_GETTID = 186,
-    SYS_TIME = 201,
-    SYS_FUTEX = 202,
-    SYS_EPOLL_CREATE = 213,
-    SYS_GETDENTS64 = 217,
-    SYS_SET_TID_ADDRESS = 218,
-    SYS_CLOCK_GETTIME = 228,
-    SYS_CLOCK_NANOSLEEP = 230,
-    SYS_EXIT_GROUP = 231,
-    SYS_EPOLL_WAIT = 232,
-    SYS_EPOLL_CTL = 233,
-    SYS_TGKILL = 234,
-    SYS_WAITID = 247,
-    SYS_OPENAT = 257,
-    SYS_MKDIRAT = 258,
-    SYS_FCHOWNAT = 260,
-    SYS_FSTATAT = 262,
-    SYS_UNLINKAT = 263,
-    SYS_RENAMEAT = 264,
-    SYS_LINKAT = 265,
-    SYS_SYMLINKAT = 266,
-    SYS_READLINKAT = 267,
-    SYS_FCHMODAT = 268,
-    SYS_SET_ROBUST_LIST = 273,
-    SYS_UTIMENSAT = 280,
-    SYS_EPOLL_PWAIT = 281,
-    SYS_EVENTFD = 284,
-    SYS_ACCEPT4 = 288,
-    SYS_EVENTFD2 = 290,
-    SYS_EPOLL_CREATE1 = 291,
-    SYS_PIPE2 = 293,
-    SYS_PRLIMIT64 = 302,
-    SYS_GETRANDOM = 318,
-    SYS_EXECVEAT = 322
-);
+macro_rules! dispatch_fn_inner {
+    ( $args: ident, $context: ident, $handler: ident ( args[ .. $cnt: tt ] ) ) => {
+        $crate::syscall::syscall_handler!($cnt, $handler, $args)
+    };
+    ( $args: ident, $context: ident, $handler: ident ( args[ .. $cnt: tt ] , &context ) ) => {
+        $crate::syscall::syscall_handler!($cnt, $handler, $args, &$context)
+    };
+    ( $args: ident, $context: ident, $handler: ident ( args[ .. $cnt: tt ] , &mut context ) ) => {
+        // `$context` is already of type `&mut aster_frame::cpu::UserContext`,
+        // so no need to take `&mut` again
+        $crate::syscall::syscall_handler!($cnt, $handler, $args, $context)
+    };
+}
+
+macro_rules! impl_syscall_nums_and_dispatch_fn {
+    // $args, $context, and $dispatcher_name are needed since Rust macro is hygienic
+    ( $( $name: ident = $num: literal => $handler: ident $args: tt );* $(;)? ) => {
+        // First, define the syscall numbers
+        $(
+            pub const $name: u64 = $num;
+        )*
+
+        // Then, define the dispatcher function
+        pub fn syscall_dispatch(
+            syscall_number: u64,
+            args: [u64; 6],
+            context: &mut aster_frame::cpu::UserContext,
+        ) -> $crate::prelude::Result<$crate::syscall::SyscallReturn> {
+            match syscall_number {
+                $(
+                    $num => {
+                        $crate::log_syscall_entry!($name);
+                        $crate::syscall::dispatch_fn_inner!(args, context, $handler $args)
+                    }
+                )*
+                _ => {
+                    log::warn!("Unimplemented syscall number: {}", syscall_number);
+                    $crate::return_errno_with_message!($crate::error::Errno::ENOSYS, "Syscall was unimplemented");
+                }
+            }
+        }
+    }
+}
+
+// Export macros to sub-modules
+use dispatch_fn_inner;
+use impl_syscall_nums_and_dispatch_fn;
+use syscall_handler;
 
 pub struct SyscallArgument {
     syscall_number: u64,
@@ -434,7 +221,7 @@ impl SyscallArgument {
 pub fn handle_syscall(context: &mut UserContext) {
     let syscall_frame = SyscallArgument::new_from_context(context);
     let syscall_return =
-        syscall_dispatch(syscall_frame.syscall_number, syscall_frame.args, context);
+        arch::syscall_dispatch(syscall_frame.syscall_number, syscall_frame.args, context);
 
     match syscall_return {
         Ok(return_value) => {
@@ -450,165 +237,19 @@ pub fn handle_syscall(context: &mut UserContext) {
     }
 }
 
-pub fn syscall_dispatch(
-    syscall_number: u64,
-    args: [u64; 6],
-    context: &mut UserContext,
-) -> Result<SyscallReturn> {
-    match syscall_number {
-        SYS_READ => syscall_handler!(3, sys_read, args),
-        SYS_WRITE => syscall_handler!(3, sys_write, args),
-        SYS_OPEN => syscall_handler!(3, sys_open, args),
-        SYS_CLOSE => syscall_handler!(1, sys_close, args),
-        SYS_STAT => syscall_handler!(2, sys_stat, args),
-        SYS_FSTAT => syscall_handler!(2, sys_fstat, args),
-        SYS_LSTAT => syscall_handler!(2, sys_lstat, args),
-        SYS_POLL => syscall_handler!(3, sys_poll, args),
-        SYS_LSEEK => syscall_handler!(3, sys_lseek, args),
-        SYS_MMAP => syscall_handler!(6, sys_mmap, args),
-        SYS_MPROTECT => syscall_handler!(3, sys_mprotect, args),
-        SYS_MUNMAP => syscall_handler!(2, sys_munmap, args),
-        SYS_BRK => syscall_handler!(1, sys_brk, args),
-        SYS_RT_SIGACTION => syscall_handler!(4, sys_rt_sigaction, args),
-        SYS_RT_SIGPROCMASK => syscall_handler!(4, sys_rt_sigprocmask, args),
-        SYS_RT_SIGRETURN => syscall_handler!(0, sys_rt_sigreturn, context),
-        SYS_IOCTL => syscall_handler!(3, sys_ioctl, args),
-        SYS_PREAD64 => syscall_handler!(4, sys_pread64, args),
-        SYS_WRITEV => syscall_handler!(3, sys_writev, args),
-        SYS_ACCESS => syscall_handler!(2, sys_access, args),
-        SYS_PIPE => syscall_handler!(1, sys_pipe, args),
-        SYS_SELECT => syscall_handler!(5, sys_select, args),
-        SYS_SCHED_YIELD => syscall_handler!(0, sys_sched_yield),
-        SYS_MADVISE => syscall_handler!(3, sys_madvise, args),
-        SYS_DUP => syscall_handler!(1, sys_dup, args),
-        SYS_DUP2 => syscall_handler!(2, sys_dup2, args),
-        SYS_PAUSE => syscall_handler!(0, sys_pause),
-        SYS_NANOSLEEP => syscall_handler!(2, sys_nanosleep, args),
-        SYS_ALARM => syscall_handler!(1, sys_alarm, args),
-        SYS_GETPID => syscall_handler!(0, sys_getpid),
-        SYS_SOCKET => syscall_handler!(3, sys_socket, args),
-        SYS_CONNECT => syscall_handler!(3, sys_connect, args),
-        SYS_ACCEPT => syscall_handler!(3, sys_accept, args),
-        SYS_SENDTO => syscall_handler!(6, sys_sendto, args),
-        SYS_RECVFROM => syscall_handler!(6, sys_recvfrom, args),
-        SYS_SHUTDOWN => syscall_handler!(2, sys_shutdown, args),
-        SYS_BIND => syscall_handler!(3, sys_bind, args),
-        SYS_LISTEN => syscall_handler!(2, sys_listen, args),
-        SYS_GETSOCKNAME => syscall_handler!(3, sys_getsockname, args),
-        SYS_GETPEERNAME => syscall_handler!(3, sys_getpeername, args),
-        SYS_SOCKETPAIR => syscall_handler!(4, sys_socketpair, args),
-        SYS_SETSOCKOPT => syscall_handler!(5, sys_setsockopt, args),
-        SYS_GETSOCKOPT => syscall_handler!(5, sys_getsockopt, args),
-        SYS_CLONE => syscall_handler!(5, sys_clone, args, *context),
-        SYS_FORK => syscall_handler!(0, sys_fork, *context),
-        SYS_EXECVE => syscall_handler!(3, sys_execve, args, context),
-        SYS_EXIT => syscall_handler!(1, sys_exit, args),
-        SYS_WAIT4 => syscall_handler!(3, sys_wait4, args),
-        SYS_KILL => syscall_handler!(2, sys_kill, args),
-        SYS_UNAME => syscall_handler!(1, sys_uname, args),
-        SYS_FCNTL => syscall_handler!(3, sys_fcntl, args),
-        SYS_FSYNC => syscall_handler!(1, sys_fsync, args),
-        SYS_TRUNCATE => syscall_handler!(2, sys_truncate, args),
-        SYS_FTRUNCATE => syscall_handler!(2, sys_ftruncate, args),
-        SYS_GETCWD => syscall_handler!(2, sys_getcwd, args),
-        SYS_CHDIR => syscall_handler!(1, sys_chdir, args),
-        SYS_FCHDIR => syscall_handler!(1, sys_fchdir, args),
-        SYS_RENAME => syscall_handler!(2, sys_rename, args),
-        SYS_MKDIR => syscall_handler!(2, sys_mkdir, args),
-        SYS_RMDIR => syscall_handler!(1, sys_rmdir, args),
-        SYS_LINK => syscall_handler!(2, sys_link, args),
-        SYS_UNLINK => syscall_handler!(1, sys_unlink, args),
-        SYS_SYMLINK => syscall_handler!(2, sys_symlink, args),
-        SYS_READLINK => syscall_handler!(3, sys_readlink, args),
-        SYS_CHMOD => syscall_handler!(2, sys_chmod, args),
-        SYS_FCHMOD => syscall_handler!(2, sys_fchmod, args),
-        SYS_CHOWN => syscall_handler!(3, sys_chown, args),
-        SYS_FCHOWN => syscall_handler!(3, sys_fchown, args),
-        SYS_LCHOWN => syscall_handler!(3, sys_lchown, args),
-        SYS_UMASK => syscall_handler!(1, sys_umask, args),
-        SYS_GETTIMEOFDAY => syscall_handler!(1, sys_gettimeofday, args),
-        SYS_GETUID => syscall_handler!(0, sys_getuid),
-        SYS_GETGID => syscall_handler!(0, sys_getgid),
-        SYS_SETUID => syscall_handler!(1, sys_setuid, args),
-        SYS_SETGID => syscall_handler!(1, sys_setgid, args),
-        SYS_GETEUID => syscall_handler!(0, sys_geteuid),
-        SYS_GETEGID => syscall_handler!(0, sys_getegid),
-        SYS_SETPGID => syscall_handler!(2, sys_setpgid, args),
-        SYS_GETPPID => syscall_handler!(0, sys_getppid),
-        SYS_GETPGRP => syscall_handler!(0, sys_getpgrp),
-        SYS_SETSID => syscall_handler!(0, sys_setsid),
-        SYS_SETREUID => syscall_handler!(2, sys_setreuid, args),
-        SYS_SETREGID => syscall_handler!(2, sys_setregid, args),
-        SYS_GETGROUPS => syscall_handler!(2, sys_getgroups, args),
-        SYS_SETGROUPS => syscall_handler!(2, sys_setgroups, args),
-        SYS_SETRESUID => syscall_handler!(3, sys_setresuid, args),
-        SYS_GETRESUID => syscall_handler!(3, sys_getresuid, args),
-        SYS_SETRESGID => syscall_handler!(3, sys_setresgid, args),
-        SYS_GETRESGID => syscall_handler!(3, sys_getresgid, args),
-        SYS_SETFSUID => syscall_handler!(1, sys_setfsuid, args),
-        SYS_SETFSGID => syscall_handler!(1, sys_setfsgid, args),
-        SYS_GETSID => syscall_handler!(1, sys_getsid, args),
-        SYS_RT_SIGSUSPEND => syscall_handler!(2, sys_rt_sigsuspend, args),
-        SYS_SIGALTSTACK => syscall_handler!(2, sys_sigaltstack, args),
-        SYS_STATFS => syscall_handler!(2, sys_statfs, args),
-        SYS_FSTATFS => syscall_handler!(2, sys_fstatfs, args),
-        SYS_GET_PRIORITY => syscall_handler!(2, sys_get_priority, args),
-        SYS_SET_PRIORITY => syscall_handler!(3, sys_set_priority, args),
-        SYS_PRCTL => syscall_handler!(5, sys_prctl, args),
-        SYS_ARCH_PRCTL => syscall_handler!(2, sys_arch_prctl, args, context),
-        SYS_CHROOT => syscall_handler!(1, sys_chroot, args),
-        SYS_SYNC => syscall_handler!(0, sys_sync),
-        SYS_GETTID => syscall_handler!(0, sys_gettid),
-        SYS_TIME => syscall_handler!(1, sys_time, args),
-        SYS_FUTEX => syscall_handler!(6, sys_futex, args),
-        SYS_EPOLL_CREATE => syscall_handler!(1, sys_epoll_create, args),
-        SYS_GETDENTS64 => syscall_handler!(3, sys_getdents64, args),
-        SYS_SET_TID_ADDRESS => syscall_handler!(1, sys_set_tid_address, args),
-        SYS_CLOCK_GETTIME => syscall_handler!(2, sys_clock_gettime, args),
-        SYS_CLOCK_NANOSLEEP => syscall_handler!(4, sys_clock_nanosleep, args),
-        SYS_EXIT_GROUP => syscall_handler!(1, sys_exit_group, args),
-        SYS_EPOLL_WAIT => syscall_handler!(4, sys_epoll_wait, args),
-        SYS_EPOLL_CTL => syscall_handler!(4, sys_epoll_ctl, args),
-        SYS_TGKILL => syscall_handler!(3, sys_tgkill, args),
-        SYS_WAITID => syscall_handler!(5, sys_waitid, args),
-        SYS_OPENAT => syscall_handler!(4, sys_openat, args),
-        SYS_MKDIRAT => syscall_handler!(3, sys_mkdirat, args),
-        SYS_FCHOWNAT => syscall_handler!(5, sys_fchownat, args),
-        SYS_FSTATAT => syscall_handler!(4, sys_fstatat, args),
-        SYS_UNLINKAT => syscall_handler!(3, sys_unlinkat, args),
-        SYS_RENAMEAT => syscall_handler!(4, sys_renameat, args),
-        SYS_LINKAT => syscall_handler!(5, sys_linkat, args),
-        SYS_SYMLINKAT => syscall_handler!(3, sys_symlinkat, args),
-        SYS_READLINKAT => syscall_handler!(4, sys_readlinkat, args),
-        SYS_FCHMODAT => syscall_handler!(3, sys_fchmodat, args),
-        SYS_SET_ROBUST_LIST => syscall_handler!(2, sys_set_robust_list, args),
-        SYS_UTIMENSAT => syscall_handler!(4, sys_utimensat, args),
-        SYS_EPOLL_PWAIT => syscall_handler!(5, sys_epoll_pwait, args),
-        SYS_EVENTFD => syscall_handler!(1, sys_eventfd, args),
-        SYS_ACCEPT4 => syscall_handler!(4, sys_accept4, args),
-        SYS_EVENTFD2 => syscall_handler!(2, sys_eventfd2, args),
-        SYS_EPOLL_CREATE1 => syscall_handler!(1, sys_epoll_create1, args),
-        SYS_PIPE2 => syscall_handler!(2, sys_pipe2, args),
-        SYS_PRLIMIT64 => syscall_handler!(4, sys_prlimit64, args),
-        SYS_GETRANDOM => syscall_handler!(3, sys_getrandom, args),
-        SYS_EXECVEAT => syscall_handler!(5, sys_execveat, args, context),
-        _ => {
-            warn!("Unimplemented syscall number: {}", syscall_number);
-            return_errno_with_message!(Errno::ENOSYS, "Syscall was unimplemented");
-        }
-    }
-}
-
 #[macro_export]
 macro_rules! log_syscall_entry {
     ($syscall_name: tt) => {
-        if log_enabled!(log::Level::Info) {
+        if log::log_enabled!(log::Level::Info) {
             let syscall_name_str = stringify!($syscall_name);
             let pid = $crate::current!().pid();
             let tid = $crate::current_thread!().tid();
-            info!(
+            log::info!(
                 "[pid={}][tid={}][id={}][{}]",
-                pid, tid, $syscall_name, syscall_name_str
+                pid,
+                tid,
+                $syscall_name,
+                syscall_name_str
             );
         }
     };

--- a/kernel/aster-nix/src/syscall/mprotect.rs
+++ b/kernel/aster-nix/src/syscall/mprotect.rs
@@ -3,10 +3,9 @@
 use align_ext::AlignExt;
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_MPROTECT, vm::perms::VmPerms};
+use crate::{prelude::*, vm::perms::VmPerms};
 
 pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_MPROTECT);
     let vm_perms = VmPerms::from_bits_truncate(perms as u32);
     debug!(
         "addr = 0x{:x}, len = 0x{:x}, perms = {:?}",

--- a/kernel/aster-nix/src/syscall/munmap.rs
+++ b/kernel/aster-nix/src/syscall/munmap.rs
@@ -2,11 +2,10 @@
 
 use align_ext::AlignExt;
 
-use super::{SyscallReturn, SYS_MUNMAP};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_munmap(addr: Vaddr, len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_MUNMAP);
     debug!("addr = 0x{:x}, len = {}", addr, len);
     let current = current!();
     let root_vmar = current.root_vmar();

--- a/kernel/aster-nix/src/syscall/nanosleep.rs
+++ b/kernel/aster-nix/src/syscall/nanosleep.rs
@@ -2,9 +2,8 @@
 
 use core::time::Duration;
 
-use super::{SyscallReturn, SYS_CLOCK_NANOSLEEP, SYS_NANOSLEEP};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::signal::Pauser,
     time::{clockid_t, now_as_duration, timespec_t, ClockID, TIMER_ABSTIME},
@@ -15,7 +14,6 @@ pub fn sys_nanosleep(
     request_timespec_addr: Vaddr,
     remain_timespec_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_NANOSLEEP);
     let clock_id = ClockID::CLOCK_MONOTONIC;
 
     do_clock_nanosleep(clock_id, false, request_timespec_addr, remain_timespec_addr)
@@ -27,7 +25,6 @@ pub fn sys_clock_nanosleep(
     request_timespec_addr: Vaddr,
     remain_timespec_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_CLOCK_NANOSLEEP);
     let clock_id = ClockID::try_from(clockid)?;
     let is_abs_time = if flags == 0 {
         false

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_OPENAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_handle::FileLike,
@@ -8,7 +8,6 @@ use crate::{
         fs_resolver::{FsPath, AT_FDCWD},
         utils::CreationFlags,
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -20,7 +19,6 @@ pub fn sys_openat(
     flags: u32,
     mode: u16,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_OPENAT);
     let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "dirfd = {}, path = {:?}, flags = {}, mode = {}",

--- a/kernel/aster-nix/src/syscall/pause.rs
+++ b/kernel/aster-nix/src/syscall/pause.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_PAUSE};
-use crate::{log_syscall_entry, prelude::*, process::signal::Pauser};
+use super::SyscallReturn;
+use crate::{prelude::*, process::signal::Pauser};
 
 pub fn sys_pause() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_PAUSE);
-
     // FIXME: like sleep, paused thread can only be interrupted by signals that will call signal
     // handler or terminate current process
     let pauser = Pauser::new();

--- a/kernel/aster-nix/src/syscall/pipe.rs
+++ b/kernel/aster-nix/src/syscall/pipe.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_PIPE2};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::{FdFlags, FileDesc},
         pipe::{PipeReader, PipeWriter},
         utils::{Channel, CreationFlags, StatusFlags},
     },
-    log_syscall_entry,
     prelude::*,
     util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_pipe2(fds: Vaddr, flags: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_PIPE2);
     debug!("flags: {:?}", flags);
 
     let mut pipe_fds = read_val_from_user::<PipeFds>(fds)?;

--- a/kernel/aster-nix/src/syscall/poll.rs
+++ b/kernel/aster-nix/src/syscall/poll.rs
@@ -2,19 +2,16 @@
 
 use core::{cell::Cell, time::Duration};
 
-use super::{SyscallReturn, SYS_POLL};
+use super::SyscallReturn;
 use crate::{
     events::IoEvents,
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     process::signal::Poller,
     util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_POLL);
-
     let poll_fds = {
         let mut read_addr = fds;
         let mut poll_fds = Vec::with_capacity(nfds as _);

--- a/kernel/aster-nix/src/syscall/prctl.rs
+++ b/kernel/aster-nix/src/syscall/prctl.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_PRCTL};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::posix_thread::{PosixThreadExt, MAX_THREAD_NAME_LEN},
     util::{read_cstring_from_user, write_bytes_to_user},
 };
 pub fn sys_prctl(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_PRCTL);
     let prctl_cmd = PrctlCmd::from_args(option, arg2, arg3, arg4, arg5)?;
     debug!("prctl cmd = {:x?}", prctl_cmd);
     let current_thread = current_thread!();

--- a/kernel/aster-nix/src/syscall/pread64.rs
+++ b/kernel/aster-nix/src/syscall/pread64.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_PREAD64};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, utils::SeekFrom},
-    log_syscall_entry,
     prelude::*,
     util::write_bytes_to_user,
 };
 
 pub fn sys_pread64(fd: FileDesc, buf_ptr: Vaddr, count: usize, pos: i64) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_PREAD64);
     debug!(
         "fd = {}, buf = 0x{:x}, count = 0x{:x}, pos = 0x{:x}",
         fd, buf_ptr, count, pos

--- a/kernel/aster-nix/src/syscall/prlimit64.rs
+++ b/kernel/aster-nix/src/syscall/prlimit64.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_PRLIMIT64};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{Pid, ResourceType},
     util::{read_val_from_user, write_val_to_user},
@@ -14,7 +13,6 @@ pub fn sys_prlimit64(
     new_rlim_addr: Vaddr,
     old_rlim_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_PRLIMIT64);
     let resource = ResourceType::try_from(resource)?;
     debug!(
         "pid = {}, resource = {:?}, new_rlim_addr = 0x{:x}, old_rlim_addr = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/read.rs
+++ b/kernel/aster-nix/src/syscall/read.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_READ};
-use crate::{fs::file_table::FileDesc, log_syscall_entry, prelude::*, util::write_bytes_to_user};
+use super::SyscallReturn;
+use crate::{fs::file_table::FileDesc, prelude::*, util::write_bytes_to_user};
 
 pub fn sys_read(fd: FileDesc, user_buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_READ);
     debug!(
         "fd = {}, user_buf_ptr = 0x{:x}, buf_len = 0x{:x}",
         fd, user_buf_addr, buf_len

--- a/kernel/aster-nix/src/syscall/readlink.rs
+++ b/kernel/aster-nix/src/syscall/readlink.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_READLINKAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::{read_cstring_from_user, write_bytes_to_user},
@@ -18,7 +17,6 @@ pub fn sys_readlinkat(
     usr_buf_addr: Vaddr,
     usr_buf_len: usize,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_READLINKAT);
     let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "dirfd = {}, path = {:?}, usr_buf_addr = 0x{:x}, usr_buf_len = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/recvfrom.rs
+++ b/kernel/aster-nix/src/syscall/recvfrom.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_RECVFROM};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     net::socket::SendRecvFlags,
     prelude::*,
     util::{
@@ -20,7 +19,6 @@ pub fn sys_recvfrom(
     src_addr: Vaddr,
     addrlen_ptr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RECVFROM);
     let flags = SendRecvFlags::from_bits_truncate(flags);
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = {len}, flags = {flags:?}, src_addr = 0x{src_addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 

--- a/kernel/aster-nix/src/syscall/rename.rs
+++ b/kernel/aster-nix/src/syscall/rename.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_RENAMEAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::InodeType,
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -19,7 +18,6 @@ pub fn sys_renameat(
     new_dirfd: FileDesc,
     new_path_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RENAMEAT);
     let old_path = read_cstring_from_user(old_path_addr, MAX_FILENAME_LEN)?;
     let new_path = read_cstring_from_user(new_path_addr, MAX_FILENAME_LEN)?;
     debug!(

--- a/kernel/aster-nix/src/syscall/rmdir.rs
+++ b/kernel/aster-nix/src/syscall/rmdir.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_RMDIR};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -17,7 +16,6 @@ pub fn sys_rmdir(path_addr: Vaddr) -> Result<SyscallReturn> {
 }
 
 pub(super) fn sys_rmdirat(dirfd: FileDesc, path_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RMDIR);
     let path_addr = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path_addr = {:?}", dirfd, path_addr);
 

--- a/kernel/aster-nix/src/syscall/rt_sigaction.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigaction.rs
@@ -2,10 +2,8 @@
 
 use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::signal::{c_types::sigaction_t, sig_action::SigAction, sig_num::SigNum},
-    syscall::SYS_RT_SIGACTION,
     util::{read_val_from_user, write_val_to_user},
 };
 
@@ -15,7 +13,6 @@ pub fn sys_rt_sigaction(
     old_sig_action_addr: Vaddr,
     sigset_size: u64,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RT_SIGACTION);
     let sig_num = SigNum::try_from(sig_num)?;
     debug!(
         "signal = {}, sig_action_addr = 0x{:x}, old_sig_action_addr = 0x{:x}, sigset_size = {}",

--- a/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
@@ -2,9 +2,8 @@
 
 use aster_frame::vm::VmIo;
 
-use super::{SyscallReturn, SYS_RT_SIGPROCMASK};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{
         posix_thread::PosixThreadExt,
@@ -21,7 +20,6 @@ pub fn sys_rt_sigprocmask(
     oldset_ptr: Vaddr,
     sigset_size: usize,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RT_SIGPROCMASK);
     let mask_op = MaskOp::try_from(how).unwrap();
     debug!(
         "mask op = {:?}, set_ptr = 0x{:x}, oldset_ptr = 0x{:x}, sigset_size = {}",

--- a/kernel/aster-nix/src/syscall/rt_sigreturn.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigreturn.rs
@@ -2,16 +2,14 @@
 
 use aster_frame::cpu::UserContext;
 
-use super::{SyscallReturn, SYS_RT_SIGRETURN};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{posix_thread::PosixThreadExt, signal::c_types::ucontext_t},
     util::read_val_from_user,
 };
 
 pub fn sys_rt_sigreturn(context: &mut UserContext) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RT_SIGRETURN);
     let current_thread = current_thread!();
     let posix_thread = current_thread.as_posix_thread().unwrap();
     let mut sig_context = posix_thread.sig_context().lock();

--- a/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_RT_SIGSUSPEND};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::signal::{
         constants::{SIGKILL, SIGSTOP},
@@ -13,7 +12,6 @@ use crate::{
 };
 
 pub fn sys_rt_sigsuspend(sigmask_addr: Vaddr, sigmask_size: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_RT_SIGSUSPEND);
     debug!(
         "sigmask_addr = 0x{:x}, sigmask_size = {}",
         sigmask_addr, sigmask_size

--- a/kernel/aster-nix/src/syscall/sched_yield.rs
+++ b/kernel/aster-nix/src/syscall/sched_yield.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_SCHED_YIELD, thread::Thread};
+use crate::{prelude::*, thread::Thread};
 
 pub fn sys_sched_yield() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SCHED_YIELD);
     Thread::yield_now();
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/select.rs
+++ b/kernel/aster-nix/src/syscall/select.rs
@@ -4,12 +4,11 @@ use core::time::Duration;
 
 use super::{
     poll::{do_poll, PollFd},
-    SyscallReturn, SYS_SELECT,
+    SyscallReturn,
 };
 use crate::{
     events::IoEvents,
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     time::timeval_t,
     util::{read_val_from_user, write_val_to_user},
@@ -22,8 +21,6 @@ pub fn sys_select(
     exceptfds_addr: Vaddr,
     timeval_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SELECT);
-
     if nfds < 0 || nfds as usize > FD_SETSIZE {
         return_errno_with_message!(Errno::EINVAL, "nfds is negative or exceeds the FD_SETSIZE");
     }

--- a/kernel/aster-nix/src/syscall/sendto.rs
+++ b/kernel/aster-nix/src/syscall/sendto.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SENDTO};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     net::socket::SendRecvFlags,
     prelude::*,
     util::{
@@ -20,7 +19,6 @@ pub fn sys_sendto(
     dest_addr: Vaddr,
     addrlen: usize,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SENDTO);
     let flags = SendRecvFlags::from_bits_truncate(flags);
     let socket_addr = if dest_addr == 0 {
         None

--- a/kernel/aster-nix/src/syscall/set_get_priority.rs
+++ b/kernel/aster-nix/src/syscall/set_get_priority.rs
@@ -2,16 +2,14 @@
 
 use core::sync::atomic::Ordering;
 
-use super::{SyscallReturn, SYS_GET_PRIORITY, SYS_SET_PRIORITY};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials, posix_thread::PosixThreadExt, process_table, Pgid, Pid, Process, Uid},
     sched::nice::Nice,
 };
 
 pub fn sys_set_priority(which: i32, who: u32, prio: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SET_PRIORITY);
     let prio_target = PriorityTarget::new(which, who)?;
     let new_nice = {
         let norm_prio = if prio > i8::MAX as i32 {
@@ -38,7 +36,6 @@ pub fn sys_set_priority(which: i32, who: u32, prio: i32) -> Result<SyscallReturn
 }
 
 pub fn sys_get_priority(which: i32, who: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_GET_PRIORITY);
     let prio_target = PriorityTarget::new(which, who)?;
     debug!("get_priority prio_target: {:?}", prio_target);
 

--- a/kernel/aster-nix/src/syscall/set_robust_list.rs
+++ b/kernel/aster-nix/src/syscall/set_robust_list.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SET_ROBUST_LIST};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::posix_thread::{PosixThreadExt, RobustListHead},
     util::read_val_from_user,
 };
 
 pub fn sys_set_robust_list(robust_list_head_ptr: Vaddr, len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SET_ROBUST_LIST);
     debug!(
         "robust list head ptr: 0x{:x}, len = {}",
         robust_list_head_ptr, len

--- a/kernel/aster-nix/src/syscall/set_tid_address.rs
+++ b/kernel/aster-nix/src/syscall/set_tid_address.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SET_TID_ADDRESS};
-use crate::{log_syscall_entry, prelude::*, process::posix_thread::PosixThreadExt};
+use super::SyscallReturn;
+use crate::{prelude::*, process::posix_thread::PosixThreadExt};
 
 pub fn sys_set_tid_address(tidptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SET_TID_ADDRESS);
     debug!("tidptr = 0x{:x}", tidptr);
     let current_thread = current_thread!();
     let posix_thread = current_thread.as_posix_thread().unwrap();

--- a/kernel/aster-nix/src/syscall/setfsgid.rs
+++ b/kernel/aster-nix/src/syscall/setfsgid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETFSGID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Gid},
 };
 
 pub fn sys_setfsgid(gid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETFSGID);
     debug!("gid = {}", gid);
 
     let fsgid = if gid < 0 {

--- a/kernel/aster-nix/src/syscall/setfsuid.rs
+++ b/kernel/aster-nix/src/syscall/setfsuid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETFSUID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Uid},
 };
 
 pub fn sys_setfsuid(uid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETFSUID);
     debug!("uid = {}", uid);
 
     let fsuid = if uid < 0 {

--- a/kernel/aster-nix/src/syscall/setgid.rs
+++ b/kernel/aster-nix/src/syscall/setgid.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETGID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Gid},
 };
 
 pub fn sys_setgid(gid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETGID);
-
     debug!("gid = {}", gid);
 
     if gid < 0 {

--- a/kernel/aster-nix/src/syscall/setgroups.rs
+++ b/kernel/aster-nix/src/syscall/setgroups.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETGROUPS};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Gid},
     util::read_val_from_user,
 };
 
 pub fn sys_setgroups(size: usize, group_list_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETGROUPS);
     debug!("size = {}, group_list_addr = 0x{:x}", size, group_list_addr);
 
     // TODO: check perm: the calling process should have the CAP_SETGID capability

--- a/kernel/aster-nix/src/syscall/setpgid.rs
+++ b/kernel/aster-nix/src/syscall/setpgid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETPGID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{process_table, Pgid, Pid},
 };
 
 pub fn sys_setpgid(pid: Pid, pgid: Pgid) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETPGID);
     let current = current!();
     // if pid is 0, pid should be the pid of current process
     let pid = if pid == 0 { current.pid() } else { pid };

--- a/kernel/aster-nix/src/syscall/setregid.rs
+++ b/kernel/aster-nix/src/syscall/setregid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETREGID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Gid},
 };
 
 pub fn sys_setregid(rgid: i32, egid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETREGID);
     debug!("rgid = {}, egid = {}", rgid, egid);
 
     let rgid = if rgid > 0 {

--- a/kernel/aster-nix/src/syscall/setresgid.rs
+++ b/kernel/aster-nix/src/syscall/setresgid.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETRESGID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Gid},
 };
 
 pub fn sys_setresgid(rgid: i32, egid: i32, sgid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETRESGID);
-
     let rgid = if rgid > 0 {
         Some(Gid::new(rgid as u32))
     } else {

--- a/kernel/aster-nix/src/syscall/setresuid.rs
+++ b/kernel/aster-nix/src/syscall/setresuid.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETRESUID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Uid},
 };
 
 pub fn sys_setresuid(ruid: i32, euid: i32, suid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETRESUID);
-
     let ruid = if ruid > 0 {
         Some(Uid::new(ruid as u32))
     } else {

--- a/kernel/aster-nix/src/syscall/setreuid.rs
+++ b/kernel/aster-nix/src/syscall/setreuid.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETREUID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Uid},
 };
 
 pub fn sys_setreuid(ruid: i32, euid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETREUID);
     debug!("ruid = {}, euid = {}", ruid, euid);
 
     let ruid = if ruid > 0 {

--- a/kernel/aster-nix/src/syscall/setsid.rs
+++ b/kernel/aster-nix/src/syscall/setsid.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETSID};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_setsid() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETSID);
-
     let current = current!();
     let session = current.to_new_session()?;
 

--- a/kernel/aster-nix/src/syscall/setsockopt.rs
+++ b/kernel/aster-nix/src/syscall/setsockopt.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETSOCKOPT};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
 };
@@ -15,7 +14,6 @@ pub fn sys_setsockopt(
     optval: Vaddr,
     optlen: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETSOCKOPT);
     let level = CSocketOptionLevel::try_from(level)?;
     if optval == 0 {
         return_errno_with_message!(Errno::EINVAL, "optval is null pointer");

--- a/kernel/aster-nix/src/syscall/setuid.rs
+++ b/kernel/aster-nix/src/syscall/setuid.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SETUID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{credentials_mut, Uid},
 };
 
 pub fn sys_setuid(uid: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SETUID);
-
     debug!("uid = {}", uid);
 
     if uid < 0 {

--- a/kernel/aster-nix/src/syscall/shutdown.rs
+++ b/kernel/aster-nix/src/syscall/shutdown.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SHUTDOWN};
+use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDesc, log_syscall_entry, net::socket::SockShutdownCmd, prelude::*,
+    fs::file_table::FileDesc, net::socket::SockShutdownCmd, prelude::*,
     util::net::get_socket_from_fd,
 };
 
 pub fn sys_shutdown(sockfd: FileDesc, how: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SHUTDOWN);
     let shutdown_cmd = SockShutdownCmd::try_from(how)?;
     debug!("sockfd = {sockfd}, cmd = {shutdown_cmd:?}");
 

--- a/kernel/aster-nix/src/syscall/sigaltstack.rs
+++ b/kernel/aster-nix/src/syscall/sigaltstack.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SIGALTSTACK};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{
         posix_thread::PosixThreadExt,
@@ -12,8 +11,6 @@ use crate::{
 };
 
 pub fn sys_sigaltstack(sig_stack_addr: Vaddr, old_sig_stack_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SIGALTSTACK);
-
     debug!(
         "sig_stack_addr = 0x{:x}, old_sig_stack_addr: 0x{:x}",
         sig_stack_addr, old_sig_stack_addr

--- a/kernel/aster-nix/src/syscall/socket.rs
+++ b/kernel/aster-nix/src/syscall/socket.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SOCKET};
+use super::SyscallReturn;
 use crate::{
     fs::{file_handle::FileLike, file_table::FdFlags},
-    log_syscall_entry,
     net::socket::{
         ip::{DatagramSocket, StreamSocket},
         unix::UnixStreamSocket,
@@ -13,7 +12,6 @@ use crate::{
 };
 
 pub fn sys_socket(domain: i32, type_: i32, protocol: i32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SOCKET);
     let domain = CSocketAddrFamily::try_from(domain)?;
     let sock_type = SockType::try_from(type_ & SOCK_TYPE_MASK)?;
     let sock_flags = SockFlags::from_bits_truncate(type_ & !SOCK_TYPE_MASK);

--- a/kernel/aster-nix/src/syscall/socketpair.rs
+++ b/kernel/aster-nix/src/syscall/socketpair.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SOCKETPAIR};
+use super::SyscallReturn;
 use crate::{
     fs::file_table::{FdFlags, FileDesc},
-    log_syscall_entry,
     net::socket::unix::UnixStreamSocket,
     prelude::*,
     util::{
@@ -13,7 +12,6 @@ use crate::{
 };
 
 pub fn sys_socketpair(domain: i32, type_: i32, protocol: i32, sv: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SOCKETPAIR);
     let domain = CSocketAddrFamily::try_from(domain)?;
     let sock_type = SockType::try_from(type_ & SOCK_TYPE_MASK)?;
     let sock_flags = SockFlags::from_bits_truncate(type_ & !SOCK_TYPE_MASK);

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FSTAT, SYS_FSTATAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::Metadata,
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     time::timespec_t,
@@ -15,7 +14,6 @@ use crate::{
 };
 
 pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FSTAT);
     debug!("fd = {}, stat_buf_addr = 0x{:x}", fd, stat_buf_ptr);
 
     let current = current!();
@@ -45,7 +43,6 @@ pub fn sys_fstatat(
     stat_buf_ptr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FSTATAT);
     let filename = read_cstring_from_user(filename_ptr, MAX_FILENAME_LEN)?;
     let flags =
         StatFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;

--- a/kernel/aster-nix/src/syscall/statfs.rs
+++ b/kernel/aster-nix/src/syscall/statfs.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FSTATFS, SYS_STATFS};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
@@ -8,13 +8,11 @@ use crate::{
         inode_handle::InodeHandle,
         utils::{SuperBlock, PATH_MAX},
     },
-    log_syscall_entry,
     prelude::*,
     util::{read_cstring_from_user, write_val_to_user},
 };
 
 pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_STATFS);
     let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
     debug!("path = {:?}, statfs_buf_ptr = 0x{:x}", path, statfs_buf_ptr,);
 
@@ -30,7 +28,6 @@ pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr) -> Result<SyscallRetur
 }
 
 pub fn sys_fstatfs(fd: FileDesc, statfs_buf_ptr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FSTATFS);
     debug!("fd = {}, statfs_buf_addr = 0x{:x}", fd, statfs_buf_ptr);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/symlink.rs
+++ b/kernel/aster-nix/src/syscall/symlink.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SYMLINKAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, InodeType},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -18,7 +17,6 @@ pub fn sys_symlinkat(
     dirfd: FileDesc,
     linkpath_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SYMLINKAT);
     let target = read_cstring_from_user(target_addr, MAX_FILENAME_LEN)?;
     let linkpath = read_cstring_from_user(linkpath_addr, MAX_FILENAME_LEN)?;
     debug!(

--- a/kernel/aster-nix/src/syscall/sync.rs
+++ b/kernel/aster-nix/src/syscall/sync.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_SYNC};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_sync() -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_SYNC);
-
     crate::fs::rootfs::root_mount().sync()?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/tgkill.rs
+++ b/kernel/aster-nix/src/syscall/tgkill.rs
@@ -2,7 +2,6 @@
 
 use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{
         credentials,
@@ -12,13 +11,11 @@ use crate::{
         },
         tgkill, Pid,
     },
-    syscall::SYS_TGKILL,
     thread::Tid,
 };
 
 /// tgkill send a signal to a thread with pid as its thread id, and tgid as its thread group id.
 pub fn sys_tgkill(tgid: Pid, tid: Tid, sig_num: u8) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_TGKILL);
     let sig_num = if sig_num == 0 {
         None
     } else {

--- a/kernel/aster-nix/src/syscall/time.rs
+++ b/kernel/aster-nix/src/syscall/time.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_TIME};
-use crate::{log_syscall_entry, prelude::*, time::SystemTime, util::write_val_to_user};
+use super::SyscallReturn;
+use crate::{prelude::*, time::SystemTime, util::write_val_to_user};
 
 pub fn sys_time(tloc: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_TIME);
     debug!("tloc = 0x{tloc:x}");
 
     let now_as_secs = {

--- a/kernel/aster-nix/src/syscall/truncate.rs
+++ b/kernel/aster-nix/src/syscall/truncate.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_FTRUNCATE, SYS_TRUNCATE};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::PATH_MAX,
     },
-    log_syscall_entry,
     prelude::*,
     process::ResourceType,
     util::read_cstring_from_user,
 };
 
 pub fn sys_ftruncate(fd: FileDesc, len: isize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_FTRUNCATE);
     debug!("fd = {}, lentgh = {}", fd, len);
 
     check_length(len)?;
@@ -27,7 +25,6 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize) -> Result<SyscallReturn> {
 }
 
 pub fn sys_truncate(path_ptr: Vaddr, len: isize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_TRUNCATE);
     let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
     debug!("path = {:?}, length = {}", path, len);
 

--- a/kernel/aster-nix/src/syscall/umask.rs
+++ b/kernel/aster-nix/src/syscall/umask.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_UMASK};
-use crate::{log_syscall_entry, prelude::*};
+use super::SyscallReturn;
+use crate::prelude::*;
 
 pub fn sys_umask(mask: u16) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_UMASK);
     debug!("mask = 0o{:o}", mask);
     let current = current!();
     let old_mask = current.umask().write().set(mask);

--- a/kernel/aster-nix/src/syscall/uname.rs
+++ b/kernel/aster-nix/src/syscall/uname.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{log_syscall_entry, prelude::*, syscall::SYS_UNAME, util::write_val_to_user};
+use crate::{prelude::*, util::write_val_to_user};
 
 // We don't use the real name and version of our os here. Instead, we pick up fake values witch is the same as the ones of linux.
 // The values are used to fool glibc since glibc will check the version and os name.
@@ -58,7 +58,6 @@ fn copy_cstring_to_u8_slice(src: &CStr, dst: &mut [u8]) {
 }
 
 pub fn sys_uname(old_uname_addr: Vaddr) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_UNAME);
     debug!("old uname addr = 0x{:x}", old_uname_addr);
     write_val_to_user(old_uname_addr, &*UTS_NAME)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/aster-nix/src/syscall/unlink.rs
+++ b/kernel/aster-nix/src/syscall/unlink.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_UNLINKAT};
+use super::SyscallReturn;
 use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     util::read_cstring_from_user,
@@ -19,7 +18,6 @@ pub fn sys_unlinkat(dirfd: FileDesc, path_addr: Vaddr, flags: u32) -> Result<Sys
         return super::rmdir::sys_rmdirat(dirfd, path_addr);
     }
 
-    log_syscall_entry!(SYS_UNLINKAT);
     let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}", dirfd, path);
 

--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -2,10 +2,9 @@
 
 use core::time::Duration;
 
-use super::{SyscallReturn, SYS_UTIMENSAT};
+use super::SyscallReturn;
 use crate::{
     fs::{file_table::FileDesc, fs_resolver::FsPath},
-    log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
     time::timespec_t,
@@ -18,7 +17,6 @@ pub fn sys_utimensat(
     timespecs_ptr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_UTIMENSAT);
     let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
     let (atime, mtime) = {
         let (autime, mutime) = if timespecs_ptr == 0 {

--- a/kernel/aster-nix/src/syscall/wait4.rs
+++ b/kernel/aster-nix/src/syscall/wait4.rs
@@ -2,15 +2,12 @@
 
 use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{wait_child_exit, ProcessFilter, WaitOptions},
-    syscall::SYS_WAIT4,
     util::write_val_to_user,
 };
 
 pub fn sys_wait4(wait_pid: u64, exit_status_ptr: u64, wait_options: u32) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_WAIT4);
     let wait_options = WaitOptions::from_bits(wait_options)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown wait option"))?;
     debug!(

--- a/kernel/aster-nix/src/syscall/waitid.rs
+++ b/kernel/aster-nix/src/syscall/waitid.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, SYS_WAITID};
+use super::SyscallReturn;
 use crate::{
-    log_syscall_entry,
     prelude::*,
     process::{wait_child_exit, ProcessFilter, WaitOptions},
 };
@@ -15,7 +14,6 @@ pub fn sys_waitid(
     rusage_addr: u64,
 ) -> Result<SyscallReturn> {
     // FIXME: what does infoq and rusage use for?
-    log_syscall_entry!(SYS_WAITID);
     let process_filter = ProcessFilter::from_which_and_id(which, upid);
     let wait_options = WaitOptions::from_bits(options as u32).expect("Unknown wait options");
     let (exit_code, pid) = wait_child_exit(process_filter, wait_options)?;

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc, log_syscall_entry, prelude::*, syscall::SYS_WRITE,
-    util::read_bytes_from_user,
-};
+use crate::{fs::file_table::FileDesc, prelude::*, util::read_bytes_from_user};
 
 const STDOUT: u64 = 1;
 const STDERR: u64 = 2;
 
 pub fn sys_write(fd: FileDesc, user_buf_ptr: Vaddr, user_buf_len: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_WRITE);
     debug!(
         "fd = {}, user_buf_ptr = 0x{:x}, user_buf_len = 0x{:x}",
         fd, user_buf_ptr, user_buf_len

--- a/kernel/aster-nix/src/syscall/writev.rs
+++ b/kernel/aster-nix/src/syscall/writev.rs
@@ -3,9 +3,7 @@
 use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
-    log_syscall_entry,
     prelude::*,
-    syscall::SYS_WRITEV,
     util::{read_bytes_from_user, read_val_from_user},
 };
 
@@ -19,7 +17,6 @@ pub struct IoVec {
 }
 
 pub fn sys_writev(fd: FileDesc, io_vec_ptr: Vaddr, io_vec_count: usize) -> Result<SyscallReturn> {
-    log_syscall_entry!(SYS_WRITEV);
     let res = do_sys_writev(fd, io_vec_ptr, io_vec_count)?;
     Ok(SyscallReturn::Return(res as _))
 }


### PR DESCRIPTION
**Motivation**: Syscall number may be different among architectures. So syscall dispatcher should be moved to the architecture-specific directory.

What's more, some syscalls only exist on some of the architectures, that is, `SYS_*` constants are not always available, so `log_syscall_entry` also need to be hoisted to the dispatcher.

For the above reasons, this PR basically does two things:
- Move x86_64 syscall dispatcher to `syscall/arch/x86.rs` (with a new macro `syscall_dispatch` which generates `SYS_*` constants and the `match` block, to avoid redundant `SYS_*` on both sides of the arms).
- Hoist `log_syscall_entry` to the dispatch level.

But I'm not sure if I'm doing it in the right way, so suggestions are welcome.