### PR TITLE
Enable lto when building release

### DIFF
--- a/.github/workflows/kernel_test.yml
+++ b/.github/workflows/kernel_test.yml
@@ -50,36 +50,36 @@ jobs:
 
       - name: Boot Test (Multiboot)
         id: boot_test_mb
-        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=multiboot RELEASE_MODE=1
+        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=multiboot RELEASE=1
 
       - name: Boot Test (Multiboot2)
         id: boot_test_mb2
-        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE_MODE=1
+        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1
 
       - name: Boot Test (MicroVM)
         id: boot_test_microvm
-        run: make run AUTO_TEST=boot ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1
+        run: make run AUTO_TEST=boot ENABLE_KVM=0 SCHEME=microvm RELEASE=1
 
       - name: Boot Test (Linux Legacy 32-bit Boot Protocol)
         id: boot_test_linux_legacy32
-        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=linux-legacy32 RELEASE_MODE=1
+        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=linux-legacy32 RELEASE=1
 
       - name: Boot Test (Linux EFI Handover Boot Protocol)
         id: boot_test_linux_efi_handover64
-        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE_MODE=1
+        run: make run AUTO_TEST=boot ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
 
       - name: Syscall Test (Linux EFI Handover Boot Protocol)
         id: syscall_test
-        run: make run AUTO_TEST=syscall ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE_MODE=1
+        run: make run AUTO_TEST=syscall ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
 
       - name: Syscall Test at Ext2 (MicroVM)
         id: syscall_test_at_ext2
-        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1
+        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=0 SCHEME=microvm RELEASE=1
 
       - name: Syscall Test at Exfat
         id: syscall_test_at_exfat_linux
-        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE_MODE=1
+        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
         
       - name: Regression Test (Multiboot2)
         id: regression_test_linux
-        run: make run AUTO_TEST=regression ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE_MODE=1
+        run: make run AUTO_TEST=regression ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,23 @@ exclude = [
     "osdk",
     "target/osdk/base",
 ]
+
+# Cargo only looks at the profile settings 
+# in the Cargo.toml manifest at the root of the workspace
+
+[profile.release]
+lto = "thin"
+
+# Release profile configuration with Link Time Optimization (LTO) enabled.
+#
+# This profile is optimized for maximum runtime performance, 
+# (achieving a 2% reduction in latency for the getpid system call).
+# However, enabling LTO significantly increases compilation times,
+# approximately doubling them compared to when LTO is not enabled.
+[profile.release-lto]
+inherits = "release"
+lto = true
+# lto can only be enabled when panic strategy is abort
+panic = "abort"
+# set codegen-units as the smallest number
+codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ BUILD_SYSCALL_TEST ?= 0
 ENABLE_KVM ?= 1
 GDB_TCP_PORT ?= 1234
 INTEL_TDX ?= 0
-RELEASE_MODE ?= 0
+RELEASE ?= 0
+RELEASE_LTO ?= 0
 SCHEME ?= ""
 # End of global options.
 
@@ -35,8 +36,10 @@ else ifeq ($(AUTO_TEST), boot)
 CARGO_OSDK_ARGS += --init-args="/regression/boot_hello.sh"
 endif
 
-ifeq ($(RELEASE_MODE), 1)
-CARGO_OSDK_ARGS += --profile release
+ifeq ($(RELEASE_LTO), 1)
+CARGO_OSDK_ARGS += --profile release-lto
+else ifeq ($(RELEASE), 1)
+CARGO_OSDK_ARGS += --release
 endif
 
 ifeq ($(INTEL_TDX), 1)


### PR DESCRIPTION
This PR adds a profile `release-lto` to achieve best perfromance, learning from the [Rust Performance Book](https://nnethercote.github.io/perf-book/build-configuration.html#maximizing-runtime-speed):
1. set `lto` as `true`
2. set `codegen_units` as `1`

Although the book argues that lto will brings about 10%-20% performance improvement, I only witness a 2% improvement (`lto` and `codegen_units` contribute about 1% each) when running the `getpid` test. But at least, it brings performance improvement. 

### The old results, build with `RELEASE_MODE=1`

<img width="691" alt="截屏2024-05-06 14 58 04" src="https://github.com/asterinas/asterinas/assets/27764680/aa7c7f76-a842-4b5a-83f3-c8d836b5ec8c">

### The new results, build with `RELEASE_LTO=1`

<img width="730" alt="截屏2024-05-06 16 24 11" src="https://github.com/asterinas/asterinas/assets/27764680/44729738-330d-461a-b9f0-19130903df6a">

