### PR TITLE
Move mongoose library to regression

### DIFF
--- a/regression/apps/Makefile
+++ b/regression/apps/Makefile
@@ -10,7 +10,8 @@ REGRESSION_BUILD_DIR ?= $(INITRAMFS)/regression
 
 TEST_APPS := signal_c pthread network hello_world hello_pie hello_c fork_c fork execve pty mongoose
 
-C_SOURCES := $(shell find . -type f \( -name "*.c" -or -name "*.h" \) )
+# The C head and source files of all the apps, excluding the downloaded mongoose files
+C_SOURCES := $(shell find . -type f \( -name "*.c" -or -name "*.h" \) ! -name "mongoose.c" ! -name "mongoose.h")
 
 .PHONY: all
 all: $(TEST_APPS) scripts

--- a/regression/apps/mongoose/.gitignore
+++ b/regression/apps/mongoose/.gitignore
@@ -1,0 +1,1 @@
+mongoose.*

--- a/regression/apps/mongoose/Makefile
+++ b/regression/apps/mongoose/Makefile
@@ -2,7 +2,7 @@
 
 CUR_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR := $(CUR_DIR)/../../build/initramfs/regression/network
-MONGOOSE_DIR := $(CUR_DIR)/../../build/mongoose
+MONGOOSE_DIR := $(CUR_DIR)
 MONGOOSE_C := $(MONGOOSE_DIR)/mongoose.c
 MONGOOSE_H := $(MONGOOSE_DIR)/mongoose.h
 MONGOOSE_FILES := $(MONGOOSE_C) $(MONGOOSE_H)
@@ -28,8 +28,7 @@ $(MONGOOSE_O): $(MONGOOSE_FILES)
 	$(CC) -c $(MONGOOSE_C) $(CFLAGS) -o $@
 
 $(MONGOOSE_FILES): | $(MONGOOSE_DIR)
-	wget --header="Accept: application/vnd.github.v3.raw" \
-		-O $@ "https://api.github.com/repos/cesanta/mongoose/contents/$(notdir $@)?ref=7.13"
+	wget -O $@ "https://raw.githubusercontent.com/cesanta/mongoose/7.13/$(notdir $@)"
 
 $(BUILD_DIR) $(MONGOOSE_DIR):
 	@mkdir -p $@


### PR DESCRIPTION
This PR replaces `api.github.com` with `raw.githubusercontent.com` to download mongoose library and fixes #804 . Changes includes:

- Change the directory of mongoose library.
- Add `.gitignore` for mongoose library.
- Change the rules of `make format` for regression to ignore `mongoose` in case of huge overheads.