### PR TITLE
Support update rusage in wait4 syscall

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -56,9 +56,9 @@ provided by Linux on x86-64 architecture.
 | 33      | dup2             | ✅              |
 | 34      | pause            | ✅              |
 | 35      | nanosleep        | ✅              |
-| 36      | getitimer        | ❌              |
+| 36      | getitimer        | ✅              |
 | 37      | alarm            | ✅              |
-| 38      | setitimer        | ❌              |
+| 38      | setitimer        | ✅              |
 | 39      | getpid           | ✅              |
 | 40      | sendfile         | ✅              |
 | 41      | socket           | ✅              |
@@ -118,7 +118,7 @@ provided by Linux on x86-64 architecture.
 | 95      | umask            | ✅              |
 | 96      | gettimeofday     | ✅              |
 | 97      | getrlimit        | ❌              |
-| 98      | getrusage        | ❌              |
+| 98      | getrusage        | ✅              |
 | 99      | sysinfo          | ❌              |
 | 100     | times            | ❌              |
 | 101     | ptrace           | ❌              |
@@ -242,11 +242,11 @@ provided by Linux on x86-64 architecture.
 | 219     | restart_syscall  | ❌              |
 | 220     | semtimedop       | ❌              |
 | 221     | fadvise64        | ❌              |
-| 222     | timer_create     | ❌              |
-| 223     | timer_settime    | ❌              |
-| 224     | timer_gettime    | ❌              |
+| 222     | timer_create     | ✅              |
+| 223     | timer_settime    | ✅              |
+| 224     | timer_gettime    | ✅              |
 | 225     | timer_getoverrun | ❌              |
-| 226     | timer_delete     | ❌              |
+| 226     | timer_delete     | ✅              |
 | 227     | clock_settime    | ❌              |
 | 228     | clock_gettime    | ✅              |
 | 229     | clock_getres     | ❌              |

--- a/kernel/aster-nix/src/process/process/mod.rs
+++ b/kernel/aster-nix/src/process/process/mod.rs
@@ -45,7 +45,7 @@ pub type Pgid = u32;
 /// Session Id.
 pub type Sid = u32;
 
-pub type ExitCode = i32;
+pub type ExitCode = u32;
 
 pub(super) fn init() {
     timer_manager::init();
@@ -605,7 +605,7 @@ impl Process {
         *self.status.lock() = ProcessStatus::Zombie(term_status);
     }
 
-    pub fn exit_code(&self) -> Option<u32> {
+    pub fn exit_code(&self) -> Option<ExitCode> {
         match &*self.status.lock() {
             ProcessStatus::Runnable | ProcessStatus::Uninit => None,
             ProcessStatus::Zombie(term_status) => Some(term_status.as_u32()),

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -40,6 +40,7 @@ use crate::syscall::{
     getrandom::sys_getrandom,
     getresgid::sys_getresgid,
     getresuid::sys_getresuid,
+    getrusage::sys_getrusage,
     getsid::sys_getsid,
     getsockname::sys_getsockname,
     getsockopt::sys_getsockopt,
@@ -172,7 +173,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FORK = 57              => sys_fork(args[..0], &context);
     SYS_EXECVE = 59            => sys_execve(args[..3], &mut context);
     SYS_EXIT = 60              => sys_exit(args[..1]);
-    SYS_WAIT4 = 61             => sys_wait4(args[..3]);
+    SYS_WAIT4 = 61             => sys_wait4(args[..4]);
     SYS_KILL = 62              => sys_kill(args[..2]);
     SYS_UNAME = 63             => sys_uname(args[..1]);
     SYS_FCNTL = 72             => sys_fcntl(args[..3]);
@@ -197,6 +198,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_LCHOWN = 94            => sys_lchown(args[..3]);
     SYS_UMASK = 95             => sys_umask(args[..1]);
     SYS_GETTIMEOFDAY = 96      => sys_gettimeofday(args[..1]);
+    SYS_GETRUSAGE = 98         => sys_getrusage(args[..2]);
     SYS_GETUID = 102           => sys_getuid(args[..0]);
     SYS_GETGID = 104           => sys_getgid(args[..0]);
     SYS_SETUID = 105           => sys_setuid(args[..1]);

--- a/kernel/aster-nix/src/syscall/getrusage.rs
+++ b/kernel/aster-nix/src/syscall/getrusage.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![allow(non_camel_case_types)]
+
+use int_to_c_enum::TryFromInt;
+
+use super::SyscallReturn;
+use crate::{
+    prelude::*, process::posix_thread::PosixThreadExt, time::timeval_t, util::write_val_to_user,
+};
+
+#[derive(Debug, Copy, Clone, TryFromInt, PartialEq)]
+#[repr(i32)]
+enum RusageTarget {
+    ForSelf = 0,
+    Children = -1,
+    Both = -2,
+    Thread = 1,
+}
+
+pub fn sys_getrusage(target: i32, rusage_addr: Vaddr) -> Result<SyscallReturn> {
+    let rusage_target = RusageTarget::try_from(target)?;
+
+    debug!(
+        "target = {:?}, rusage_addr = {}",
+        rusage_target, rusage_addr,
+    );
+
+    if rusage_addr != 0 {
+        let rusage = match rusage_target {
+            RusageTarget::ForSelf => {
+                let process = current!();
+                rusage_t {
+                    ru_utime: process.prof_clock().user_clock().read_time().into(),
+                    ru_stime: process.prof_clock().kernel_clock().read_time().into(),
+                    ..Default::default()
+                }
+            }
+            RusageTarget::Thread => {
+                let thread = current_thread!();
+                let posix_thread = thread.as_posix_thread().unwrap();
+                rusage_t {
+                    ru_utime: posix_thread.prof_clock().user_clock().read_time().into(),
+                    ru_stime: posix_thread.prof_clock().kernel_clock().read_time().into(),
+                    ..Default::default()
+                }
+            }
+            // To support `Children` and `Both` we need to implement the functionality to
+            // accumulate the resources of a child process back to the parent process
+            // upon the child's termination.
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "the target type is not supported")
+            }
+        };
+
+        write_val_to_user(rusage_addr, &rusage)?;
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Pod)]
+pub struct rusage_t {
+    /// user time used
+    pub ru_utime: timeval_t,
+    /// system time used
+    pub ru_stime: timeval_t,
+    /// maximum resident set size
+    pub ru_maxrss: u64,
+    /// integral shared memory size
+    pub ru_ixrss: u64,
+    /// integral unshared data size
+    pub ru_idrss: u64,
+    /// integral unshared stack size
+    pub ru_isrss: u64,
+    /// page reclaims
+    pub ru_minflt: u64,
+    /// page faults
+    pub ru_majflt: u64,
+    /// swaps
+    pub ru_nswap: u64,
+    /// block input operations
+    pub ru_inblock: u64,
+    /// block output operations
+    pub ru_oublock: u64,
+    /// messages sent
+    pub ru_msgsnd: u64,
+    /// messages received
+    pub ru_msgrcv: u64,
+    /// signals received
+    pub ru_nsignals: u64,
+    /// voluntary context switches
+    pub ru_nvcsw: u64,
+    /// involuntary
+    pub ru_nivcsw: u64,
+}

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -48,6 +48,7 @@ mod getppid;
 mod getrandom;
 mod getresgid;
 mod getresuid;
+mod getrusage;
 mod getsid;
 mod getsockname;
 mod getsockopt;

--- a/kernel/aster-nix/src/syscall/wait4.rs
+++ b/kernel/aster-nix/src/syscall/wait4.rs
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
+use super::{getrusage::rusage_t, SyscallReturn};
 use crate::{
     prelude::*,
     process::{wait_child_exit, ProcessFilter, WaitOptions},
     util::write_val_to_user,
 };
 
-pub fn sys_wait4(wait_pid: u64, exit_status_ptr: u64, wait_options: u32) -> Result<SyscallReturn> {
+pub fn sys_wait4(
+    wait_pid: u64,
+    exit_status_ptr: u64,
+    wait_options: u32,
+    rusage_addr: Vaddr,
+) -> Result<SyscallReturn> {
     let wait_options = WaitOptions::from_bits(wait_options)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown wait option"))?;
     debug!(
@@ -16,9 +21,26 @@ pub fn sys_wait4(wait_pid: u64, exit_status_ptr: u64, wait_options: u32) -> Resu
     );
     debug!("wait4 current pid = {}", current!().pid());
     let process_filter = ProcessFilter::from_id(wait_pid as _);
-    let (return_pid, exit_code) = wait_child_exit(process_filter, wait_options)?;
-    if return_pid != 0 && exit_status_ptr != 0 {
+
+    let waited_process = wait_child_exit(process_filter, wait_options)?;
+    let Some(process) = waited_process else {
+        return Ok(SyscallReturn::Return(0 as _));
+    };
+
+    let (return_pid, exit_code) = (process.pid(), process.exit_code().unwrap());
+    if exit_status_ptr != 0 {
         write_val_to_user(exit_status_ptr as _, &exit_code)?;
     }
+
+    if rusage_addr != 0 {
+        let rusage = rusage_t {
+            ru_utime: process.prof_clock().user_clock().read_time().into(),
+            ru_stime: process.prof_clock().kernel_clock().read_time().into(),
+            ..Default::default()
+        };
+
+        write_val_to_user(rusage_addr, &rusage)?;
+    }
+
     Ok(SyscallReturn::Return(return_pid as _))
 }

--- a/kernel/aster-nix/src/syscall/waitid.rs
+++ b/kernel/aster-nix/src/syscall/waitid.rs
@@ -18,6 +18,7 @@ pub fn sys_waitid(
     // FIXME: what does infoq and rusage use for?
     let process_filter = ProcessFilter::from_which_and_id(which, upid);
     let wait_options = WaitOptions::from_bits(options as u32).expect("Unknown wait options");
-    let (exit_code, pid) = wait_child_exit(process_filter, wait_options)?;
+    let waited_process = wait_child_exit(process_filter, wait_options)?;
+    let pid = waited_process.map_or(0, |process| process.pid());
     Ok(SyscallReturn::Return(pid as _))
 }


### PR DESCRIPTION
Based on PR #733.

This PR add the missing parameter `rusage` to `wait4` syscall. This parameter is used to record some statistics about the waited process. 

Currently `rusage` only records cpu time. With this PR and additionally adding a dummy `vfork` using `fork`, we can get the correct results from `time` command.

This PR also add a `resource` module which is aimed at providing structs and APIs for resources managements. 