### PR TITLE
Reduce some redundant usage of current and current_thread

### DIFF
--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -61,14 +61,15 @@ pub fn schedule() {
     }
 }
 
-pub fn preempt() {
+// TODO: This interface of this method is error prone.
+// The method takes an argument for the current task to optimize its efficiency,
+// but the argument provided by the caller may not be the current task, really.
+// Thus, this method should be removed or reworked in the future.
+pub fn preempt(task: &Arc<Task>) {
     // TODO: Refactor `preempt` and `schedule`
     // after the Atomic mode and `might_break` is enabled.
-    let Some(curr_task) = current_task() else {
-        return;
-    };
     let mut scheduler = GLOBAL_SCHEDULER.lock_irq_disabled();
-    if !scheduler.should_preempt(&curr_task) {
+    if !scheduler.should_preempt(task) {
         return;
     }
     let Some(next_task) = scheduler.dequeue() else {

--- a/kernel/aster-nix/src/prelude.rs
+++ b/kernel/aster-nix/src/prelude.rs
@@ -19,7 +19,7 @@ pub(crate) use aster_frame::{
 };
 pub(crate) use bitflags::bitflags;
 pub(crate) use int_to_c_enum::TryFromInt;
-pub(crate) use log::{debug, error, info, trace, warn};
+pub(crate) use log::{debug, error, info, log_enabled, trace, warn};
 pub(crate) use pod::Pod;
 
 /// return current process

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -568,12 +568,14 @@ pub fn syscall_dispatch(
 #[macro_export]
 macro_rules! log_syscall_entry {
     ($syscall_name: tt) => {
-        let syscall_name_str = stringify!($syscall_name);
-        let pid = $crate::current!().pid();
-        let tid = $crate::current_thread!().tid();
-        info!(
-            "[pid={}][tid={}][id={}][{}]",
-            pid, tid, $syscall_name, syscall_name_str
-        );
+        if log_enabled!(log::Level::Info) {
+            let syscall_name_str = stringify!($syscall_name);
+            let pid = $crate::current!().pid();
+            let tid = $crate::current_thread!().tid();
+            info!(
+                "[pid={}][tid={}][id={}][{}]",
+                pid, tid, $syscall_name, syscall_name_str
+            );
+        }
     };
 }

--- a/kernel/aster-nix/src/thread/mod.rs
+++ b/kernel/aster-nix/src/thread/mod.rs
@@ -61,6 +61,10 @@ impl Thread {
             .expect("[Internal Error] current thread cannot be None")
     }
 
+    pub(in crate::thread) fn task(&self) -> &Arc<Task> {
+        &self.task
+    }
+
     /// Run this thread at once.
     pub fn run(&self) {
         self.status.lock().set_running();


### PR DESCRIPTION
The current implementation of `current` and `current_thread` is time-consuming. Even a single syscall will call these macros many times. This commit can reduce the latency of `getpid` from **1290 nanoseconds** to **863 nanoseconds**, resulting in a 33.1% performance improvement.

Refer issue #791 