### PR TITLE
Fix memory leak of `Task` structures

### DIFF
--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -176,8 +176,19 @@ impl Task {
         }
     }
 
-    pub fn exit(&self) -> ! {
+    /// Exits the current task.
+    ///
+    /// The task `self` must be the task that is currently running.
+    ///
+    /// **NOTE:** If there is anything left on the stack, it will be forgotten. This behavior may
+    /// lead to resource leakage.
+    fn exit(self: Arc<Self>) -> ! {
         self.inner_exclusive_access().task_status = TaskStatus::Exited;
+
+        // `current_task()` still holds a strong reference, so nothing is destroyed at this point,
+        // neither is the kernel stack.
+        drop(self);
+
         schedule();
         unreachable!()
     }

--- a/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
@@ -4,7 +4,7 @@
 //! When create a process from elf file, we will use the elf_load_info to construct the VmSpace
 
 use align_ext::AlignExt;
-use aster_frame::{mm::VmIo, task::Task};
+use aster_frame::mm::VmIo;
 use aster_rights::{Full, Rights};
 use xmas_elf::program::{self, ProgramHeader64};
 
@@ -72,7 +72,7 @@ pub fn load_elf_to_vm(
                 user_stack_top,
             })
         }
-        Err(_) => {
+        Err(err) => {
             // Since the process_vm is in invalid state,
             // the process cannot return to user space again,
             // so `Vmar::clear` and `do_exit_group` are called here.
@@ -84,7 +84,9 @@ pub fn load_elf_to_vm(
             // the macro will panic. This corner case should be handled later.
             // FIXME: how to set the correct exit status?
             do_exit_group(TermStatus::Exited(1));
-            Task::current().exit();
+
+            // The process will exit and the error code will be ignored.
+            Err(err)
         }
     }
 }

--- a/kernel/aster-nix/src/process/signal/mod.rs
+++ b/kernel/aster-nix/src/process/signal/mod.rs
@@ -16,7 +16,7 @@ pub mod signals;
 use core::{mem, sync::atomic::Ordering};
 
 use align_ext::AlignExt;
-use aster_frame::{cpu::UserContext, task::Task, user::UserContextApi};
+use aster_frame::{cpu::UserContext, user::UserContextApi};
 use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 pub use pauser::Pauser;
@@ -90,9 +90,8 @@ pub fn handle_pending_signal(
                         current.executable_path(),
                         sig_num.sig_name()
                     );
-                    do_exit_group(TermStatus::Killed(sig_num));
                     // We should exit current here, since we cannot restore a valid status from trap now.
-                    Task::current().exit();
+                    do_exit_group(TermStatus::Killed(sig_num));
                 }
                 SigDefaultAction::Ign => {}
                 SigDefaultAction::Stop => {

--- a/kernel/aster-nix/src/thread/task.rs
+++ b/kernel/aster-nix/src/thread/task.rs
@@ -57,22 +57,20 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Weak<Thread>
                 break;
             }
             handle_pending_signal(context, &current_thread).unwrap();
-            if current_thread.status().is_exited() {
-                debug!("exit due to signal");
-                break;
-            }
             // If current is suspended, wait for a signal to wake up self
             while current_thread.status().is_stopped() {
                 Thread::yield_now();
                 debug!("{} is suspended.", current_thread.tid());
                 handle_pending_signal(context, &current_thread).unwrap();
             }
+            if current_thread.status().is_exited() {
+                debug!("exit due to signal");
+                break;
+            }
             // a preemption point after handling user event.
             preempt(current_task);
         }
         debug!("exit user loop");
-        // FIXME: This is a work around: exit in kernel task entry may be not called. Why this will happen?
-        current_task.exit();
     }
 
     TaskOptions::new(user_task_entry)


### PR DESCRIPTION
This code snippet causes all `Task` structures to leak, because the `Arc<Task>` on the stack is simply forgotten, since the `Task::exit` function never returns.
https://github.com/asterinas/asterinas/blob/0594a73ac927c20ccef8c9c2520b36b8c174eb53/framework/aster-frame/src/task/task.rs#L260-L265

Fixes https://github.com/asterinas/asterinas/issues/785 (Hopefully? Needs confirmation from @skpupil)

