### PR TITLE
Rename FileDescripter to FileDesc

### DIFF
--- a/kernel/aster-nix/src/fs/epoll/mod.rs
+++ b/kernel/aster-nix/src/fs/epoll/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::file_table::FileDescripter;
+use super::file_table::FileDesc;
 use crate::{events::IoEvents, prelude::*};
 
 mod epoll_file;
@@ -10,9 +10,9 @@ pub use self::epoll_file::EpollFile;
 /// An epoll control command.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum EpollCtl {
-    Add(FileDescripter, EpollEvent, EpollFlags),
-    Del(FileDescripter),
-    Mod(FileDescripter, EpollEvent, EpollFlags),
+    Add(FileDesc, EpollEvent, EpollFlags),
+    Del(FileDesc),
+    Mod(FileDesc, EpollEvent, EpollFlags),
 }
 
 bitflags! {

--- a/kernel/aster-nix/src/fs/fs_resolver.rs
+++ b/kernel/aster-nix/src/fs/fs_resolver.rs
@@ -3,7 +3,7 @@
 use alloc::str;
 
 use super::{
-    file_table::FileDescripter,
+    file_table::FileDesc,
     inode_handle::InodeHandle,
     rootfs::root_mount,
     utils::{
@@ -234,7 +234,7 @@ impl FsResolver {
     }
 
     /// Lookup dentry from the giving fd
-    pub fn lookup_from_fd(&self, fd: FileDescripter) -> Result<Arc<Dentry>> {
+    pub fn lookup_from_fd(&self, fd: FileDesc) -> Result<Arc<Dentry>> {
         let current = current!();
         let file_table = current.file_table().lock();
         let inode_handle = file_table
@@ -317,7 +317,7 @@ impl FsResolver {
     }
 }
 
-pub const AT_FDCWD: FileDescripter = -100;
+pub const AT_FDCWD: FileDesc = -100;
 
 #[derive(Debug)]
 pub struct FsPath<'a> {
@@ -333,13 +333,13 @@ enum FsPathInner<'a> {
     // Cwd
     Cwd,
     // path is relative to DirFd
-    FdRelative(FileDescripter, &'a str),
+    FdRelative(FileDesc, &'a str),
     // Fd
-    Fd(FileDescripter),
+    Fd(FileDesc),
 }
 
 impl<'a> FsPath<'a> {
-    pub fn new(dirfd: FileDescripter, path: &'a str) -> Result<Self> {
+    pub fn new(dirfd: FileDesc, path: &'a str) -> Result<Self> {
         if path.len() > PATH_MAX {
             return_errno_with_message!(Errno::ENAMETOOLONG, "path name too long");
         }

--- a/kernel/aster-nix/src/fs/procfs/pid/fd.rs
+++ b/kernel/aster-nix/src/fs/procfs/pid/fd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::*;
-use crate::fs::{file_handle::FileLike, file_table::FileDescripter, inode_handle::InodeHandle};
+use crate::fs::{file_handle::FileLike, file_table::FileDesc, inode_handle::InodeHandle};
 
 /// Represents the inode at `/proc/[pid]/fd`.
 pub struct FdDirOps(Arc<Process>);
@@ -36,7 +36,7 @@ impl DirOps for FdDirOps {
     fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
         let file = {
             let fd = name
-                .parse::<FileDescripter>()
+                .parse::<FileDesc>()
                 .map_err(|_| Error::new(Errno::ENOENT))?;
             let file_table = self.0.file_table().lock();
             file_table

--- a/kernel/aster-nix/src/syscall/accept.rs
+++ b/kernel/aster-nix/src/syscall/accept.rs
@@ -2,14 +2,14 @@
 
 use super::{SyscallReturn, SYS_ACCEPT};
 use crate::{
-    fs::file_table::{FdFlags, FileDescripter},
+    fs::file_table::{FdFlags, FileDesc},
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
 pub fn sys_accept(
-    sockfd: FileDescripter,
+    sockfd: FileDesc,
     sockaddr_ptr: Vaddr,
     addrlen_ptr: Vaddr,
 ) -> Result<SyscallReturn> {

--- a/kernel/aster-nix/src/syscall/bind.rs
+++ b/kernel/aster-nix/src/syscall/bind.rs
@@ -2,17 +2,13 @@
 
 use super::{SyscallReturn, SYS_BIND};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, read_socket_addr_from_user},
 };
 
-pub fn sys_bind(
-    sockfd: FileDescripter,
-    sockaddr_ptr: Vaddr,
-    addrlen: u32,
-) -> Result<SyscallReturn> {
+pub fn sys_bind(sockfd: FileDesc, sockaddr_ptr: Vaddr, addrlen: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_BIND);
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addrlen as usize)?;
     debug!("sockfd = {sockfd}, socket_addr = {socket_addr:?}");

--- a/kernel/aster-nix/src/syscall/chdir.rs
+++ b/kernel/aster-nix/src/syscall/chdir.rs
@@ -2,10 +2,7 @@
 
 use super::{SyscallReturn, SYS_CHDIR, SYS_FCHDIR};
 use crate::{
-    fs::{
-        file_table::FileDescripter, fs_resolver::FsPath, inode_handle::InodeHandle,
-        utils::InodeType,
-    },
+    fs::{file_table::FileDesc, fs_resolver::FsPath, inode_handle::InodeHandle, utils::InodeType},
     log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -34,7 +31,7 @@ pub fn sys_chdir(pathname_addr: Vaddr) -> Result<SyscallReturn> {
     Ok(SyscallReturn::Return(0))
 }
 
-pub fn sys_fchdir(fd: FileDescripter) -> Result<SyscallReturn> {
+pub fn sys_fchdir(fd: FileDesc) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCHDIR);
     debug!("fd = {}", fd);
 

--- a/kernel/aster-nix/src/syscall/chmod.rs
+++ b/kernel/aster-nix/src/syscall/chmod.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_FCHMOD, SYS_FCHMODAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, PATH_MAX},
     },
@@ -12,7 +12,7 @@ use crate::{
     util::read_cstring_from_user,
 };
 
-pub fn sys_fchmod(fd: FileDescripter, mode: u16) -> Result<SyscallReturn> {
+pub fn sys_fchmod(fd: FileDesc, mode: u16) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCHMOD);
     debug!("fd = {}, mode = 0o{:o}", fd, mode);
 
@@ -29,7 +29,7 @@ pub fn sys_chmod(path_ptr: Vaddr, mode: u16) -> Result<SyscallReturn> {
 
 // Glibc handles the `flags` argument, so we just ignore it.
 pub fn sys_fchmodat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     path_ptr: Vaddr,
     mode: u16,
     /* flags: u32, */

--- a/kernel/aster-nix/src/syscall/chown.rs
+++ b/kernel/aster-nix/src/syscall/chown.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_FCHOWN, SYS_FCHOWNAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::PATH_MAX,
     },
@@ -13,7 +13,7 @@ use crate::{
     util::read_cstring_from_user,
 };
 
-pub fn sys_fchown(fd: FileDescripter, uid: i32, gid: i32) -> Result<SyscallReturn> {
+pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCHOWN);
     debug!("fd = {}, uid = {}, gid = {}", fd, uid, gid);
 
@@ -50,7 +50,7 @@ pub fn sys_lchown(path_ptr: Vaddr, uid: i32, gid: i32) -> Result<SyscallReturn> 
 }
 
 pub fn sys_fchownat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     path_ptr: Vaddr,
     uid: i32,
     gid: i32,

--- a/kernel/aster-nix/src/syscall/close.rs
+++ b/kernel/aster-nix/src/syscall/close.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_CLOSE};
-use crate::{fs::file_table::FileDescripter, log_syscall_entry, prelude::*};
+use crate::{fs::file_table::FileDesc, log_syscall_entry, prelude::*};
 
-pub fn sys_close(fd: FileDescripter) -> Result<SyscallReturn> {
+pub fn sys_close(fd: FileDesc) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_CLOSE);
     debug!("fd = {}", fd);
     let current = current!();

--- a/kernel/aster-nix/src/syscall/connect.rs
+++ b/kernel/aster-nix/src/syscall/connect.rs
@@ -2,17 +2,13 @@
 
 use super::{SyscallReturn, SYS_CONNECT};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, read_socket_addr_from_user},
 };
 
-pub fn sys_connect(
-    sockfd: FileDescripter,
-    sockaddr_ptr: Vaddr,
-    addr_len: u32,
-) -> Result<SyscallReturn> {
+pub fn sys_connect(sockfd: FileDesc, sockaddr_ptr: Vaddr, addr_len: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_CONNECT);
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addr_len as _)?;
     debug!("fd = {sockfd}, socket_addr = {socket_addr:?}");

--- a/kernel/aster-nix/src/syscall/dup.rs
+++ b/kernel/aster-nix/src/syscall/dup.rs
@@ -2,12 +2,12 @@
 
 use super::{SyscallReturn, SYS_DUP, SYS_DUP2};
 use crate::{
-    fs::file_table::{FdFlags, FileDescripter},
+    fs::file_table::{FdFlags, FileDesc},
     log_syscall_entry,
     prelude::*,
 };
 
-pub fn sys_dup(old_fd: FileDescripter) -> Result<SyscallReturn> {
+pub fn sys_dup(old_fd: FileDesc) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_DUP);
     debug!("old_fd = {}", old_fd);
 
@@ -19,7 +19,7 @@ pub fn sys_dup(old_fd: FileDescripter) -> Result<SyscallReturn> {
     Ok(SyscallReturn::Return(new_fd as _))
 }
 
-pub fn sys_dup2(old_fd: FileDescripter, new_fd: FileDescripter) -> Result<SyscallReturn> {
+pub fn sys_dup2(old_fd: FileDesc, new_fd: FileDesc) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_DUP2);
     debug!("old_fd = {}, new_fd = {}", old_fd, new_fd);
 

--- a/kernel/aster-nix/src/syscall/epoll.rs
+++ b/kernel/aster-nix/src/syscall/epoll.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         epoll::{EpollCtl, EpollEvent, EpollFile, EpollFlags},
-        file_table::{FdFlags, FileDescripter},
+        file_table::{FdFlags, FileDesc},
         utils::CreationFlags,
     },
     log_syscall_entry,
@@ -47,9 +47,9 @@ pub fn sys_epoll_create1(flags: u32) -> Result<SyscallReturn> {
 }
 
 pub fn sys_epoll_ctl(
-    epfd: FileDescripter,
+    epfd: FileDesc,
     op: i32,
-    fd: FileDescripter,
+    fd: FileDesc,
     event_addr: Vaddr,
 ) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_EPOLL_CTL);
@@ -93,7 +93,7 @@ pub fn sys_epoll_ctl(
 }
 
 pub fn sys_epoll_wait(
-    epfd: FileDescripter,
+    epfd: FileDesc,
     events_addr: Vaddr,
     max_events: i32,
     timeout: i32,
@@ -138,7 +138,7 @@ pub fn sys_epoll_wait(
 }
 
 pub fn sys_epoll_pwait(
-    epfd: FileDescripter,
+    epfd: FileDesc,
     events_addr: Vaddr,
     max_events: i32,
     timeout: i32,

--- a/kernel/aster-nix/src/syscall/execve.rs
+++ b/kernel/aster-nix/src/syscall/execve.rs
@@ -6,7 +6,7 @@ use aster_rights::WriteOp;
 use super::{constants::*, SyscallReturn};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{Dentry, InodeType},
     },
@@ -38,7 +38,7 @@ pub fn sys_execve(
 }
 
 pub fn sys_execveat(
-    dfd: FileDescripter,
+    dfd: FileDesc,
     filename_ptr: Vaddr,
     argv_ptr_ptr: Vaddr,
     envp_ptr_ptr: Vaddr,
@@ -58,7 +58,7 @@ pub fn sys_execveat(
 }
 
 fn lookup_executable_file(
-    dfd: FileDescripter,
+    dfd: FileDesc,
     filename: String,
     flags: OpenFlags,
 ) -> Result<Arc<Dentry>> {

--- a/kernel/aster-nix/src/syscall/fcntl.rs
+++ b/kernel/aster-nix/src/syscall/fcntl.rs
@@ -3,14 +3,14 @@
 use super::{SyscallReturn, SYS_FCNTL};
 use crate::{
     fs::{
-        file_table::{FdFlags, FileDescripter},
+        file_table::{FdFlags, FileDesc},
         utils::StatusFlags,
     },
     log_syscall_entry,
     prelude::*,
 };
 
-pub fn sys_fcntl(fd: FileDescripter, cmd: i32, arg: u64) -> Result<SyscallReturn> {
+pub fn sys_fcntl(fd: FileDesc, cmd: i32, arg: u64) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FCNTL);
     let fcntl_cmd = FcntlCmd::try_from(cmd)?;
     debug!("fd = {}, cmd = {:?}, arg = {}", fd, fcntl_cmd, arg);
@@ -18,13 +18,13 @@ pub fn sys_fcntl(fd: FileDescripter, cmd: i32, arg: u64) -> Result<SyscallReturn
         FcntlCmd::F_DUPFD => {
             let current = current!();
             let mut file_table = current.file_table().lock();
-            let new_fd = file_table.dup(fd, arg as FileDescripter, FdFlags::empty())?;
+            let new_fd = file_table.dup(fd, arg as FileDesc, FdFlags::empty())?;
             Ok(SyscallReturn::Return(new_fd as _))
         }
         FcntlCmd::F_DUPFD_CLOEXEC => {
             let current = current!();
             let mut file_table = current.file_table().lock();
-            let new_fd = file_table.dup(fd, arg as FileDescripter, FdFlags::CLOEXEC)?;
+            let new_fd = file_table.dup(fd, arg as FileDesc, FdFlags::CLOEXEC)?;
             Ok(SyscallReturn::Return(new_fd as _))
         }
         FcntlCmd::F_GETFD => {

--- a/kernel/aster-nix/src/syscall/fsync.rs
+++ b/kernel/aster-nix/src/syscall/fsync.rs
@@ -2,12 +2,12 @@
 
 use super::{SyscallReturn, SYS_FSYNC};
 use crate::{
-    fs::{file_table::FileDescripter, inode_handle::InodeHandle},
+    fs::{file_table::FileDesc, inode_handle::InodeHandle},
     log_syscall_entry,
     prelude::*,
 };
 
-pub fn sys_fsync(fd: FileDescripter) -> Result<SyscallReturn> {
+pub fn sys_fsync(fd: FileDesc) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FSYNC);
     debug!("fd = {}", fd);
 

--- a/kernel/aster-nix/src/syscall/getdents64.rs
+++ b/kernel/aster-nix/src/syscall/getdents64.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use super::{SyscallReturn, SYS_GETDENTS64};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         inode_handle::InodeHandle,
         utils::{DirentVisitor, InodeType},
     },
@@ -14,11 +14,7 @@ use crate::{
     util::write_bytes_to_user,
 };
 
-pub fn sys_getdents64(
-    fd: FileDescripter,
-    buf_addr: Vaddr,
-    buf_len: usize,
-) -> Result<SyscallReturn> {
+pub fn sys_getdents64(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETDENTS64);
     debug!(
         "fd = {}, buf_addr = 0x{:x}, buf_len = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/getpeername.rs
+++ b/kernel/aster-nix/src/syscall/getpeername.rs
@@ -2,17 +2,13 @@
 
 use super::{SyscallReturn, SYS_GETPEERNAME};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
-pub fn sys_getpeername(
-    sockfd: FileDescripter,
-    addr: Vaddr,
-    addrlen_ptr: Vaddr,
-) -> Result<SyscallReturn> {
+pub fn sys_getpeername(sockfd: FileDesc, addr: Vaddr, addrlen_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETPEERNAME);
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 

--- a/kernel/aster-nix/src/syscall/getsockname.rs
+++ b/kernel/aster-nix/src/syscall/getsockname.rs
@@ -2,17 +2,13 @@
 
 use super::{SyscallReturn, SYS_GETSOCKNAME};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
-pub fn sys_getsockname(
-    sockfd: FileDescripter,
-    addr: Vaddr,
-    addrlen_ptr: Vaddr,
-) -> Result<SyscallReturn> {
+pub fn sys_getsockname(sockfd: FileDesc, addr: Vaddr, addrlen_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_GETSOCKNAME);
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 

--- a/kernel/aster-nix/src/syscall/getsockopt.rs
+++ b/kernel/aster-nix/src/syscall/getsockopt.rs
@@ -2,7 +2,7 @@
 
 use super::{SyscallReturn, SYS_SETSOCKOPT};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::{
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub fn sys_getsockopt(
-    sockfd: FileDescripter,
+    sockfd: FileDesc,
     level: i32,
     optname: i32,
     optval: Vaddr,

--- a/kernel/aster-nix/src/syscall/ioctl.rs
+++ b/kernel/aster-nix/src/syscall/ioctl.rs
@@ -2,12 +2,12 @@
 
 use super::{SyscallReturn, SYS_IOCTL};
 use crate::{
-    fs::{file_table::FileDescripter, utils::IoctlCmd},
+    fs::{file_table::FileDesc, utils::IoctlCmd},
     log_syscall_entry,
     prelude::*,
 };
 
-pub fn sys_ioctl(fd: FileDescripter, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
+pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_IOCTL);
     let ioctl_cmd = IoctlCmd::try_from(cmd)?;
     debug!(

--- a/kernel/aster-nix/src/syscall/link.rs
+++ b/kernel/aster-nix/src/syscall/link.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_LINKAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
     log_syscall_entry,
@@ -13,9 +13,9 @@ use crate::{
 };
 
 pub fn sys_linkat(
-    old_dirfd: FileDescripter,
+    old_dirfd: FileDesc,
     old_pathname_addr: Vaddr,
-    new_dirfd: FileDescripter,
+    new_dirfd: FileDesc,
     new_pathname_addr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {

--- a/kernel/aster-nix/src/syscall/listen.rs
+++ b/kernel/aster-nix/src/syscall/listen.rs
@@ -2,10 +2,10 @@
 
 use super::{SyscallReturn, SYS_LISTEN};
 use crate::{
-    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, util::net::get_socket_from_fd,
+    fs::file_table::FileDesc, log_syscall_entry, prelude::*, util::net::get_socket_from_fd,
 };
 
-pub fn sys_listen(sockfd: FileDescripter, backlog: i32) -> Result<SyscallReturn> {
+pub fn sys_listen(sockfd: FileDesc, backlog: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_LISTEN);
     debug!("sockfd = {sockfd}, backlog = {backlog}");
 

--- a/kernel/aster-nix/src/syscall/lseek.rs
+++ b/kernel/aster-nix/src/syscall/lseek.rs
@@ -2,12 +2,12 @@
 
 use super::{SyscallReturn, SYS_LSEEK};
 use crate::{
-    fs::{file_table::FileDescripter, utils::SeekFrom},
+    fs::{file_table::FileDesc, utils::SeekFrom},
     log_syscall_entry,
     prelude::*,
 };
 
-pub fn sys_lseek(fd: FileDescripter, offset: isize, whence: u32) -> Result<SyscallReturn> {
+pub fn sys_lseek(fd: FileDesc, offset: isize, whence: u32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_LSEEK);
     debug!("fd = {}, offset = {}, whence = {}", fd, offset, whence);
     let seek_from = match whence {

--- a/kernel/aster-nix/src/syscall/mkdir.rs
+++ b/kernel/aster-nix/src/syscall/mkdir.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_MKDIRAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, InodeType},
     },
@@ -13,11 +13,7 @@ use crate::{
     util::read_cstring_from_user,
 };
 
-pub fn sys_mkdirat(
-    dirfd: FileDescripter,
-    pathname_addr: Vaddr,
-    mode: u16,
-) -> Result<SyscallReturn> {
+pub fn sys_mkdirat(dirfd: FileDesc, pathname_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_MKDIRAT);
     let pathname = read_cstring_from_user(pathname_addr, MAX_FILENAME_LEN)?;
     debug!(

--- a/kernel/aster-nix/src/syscall/mmap.rs
+++ b/kernel/aster-nix/src/syscall/mmap.rs
@@ -8,7 +8,7 @@ use aster_rights::Rights;
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     syscall::SYS_MMAP,
@@ -45,7 +45,7 @@ fn do_sys_mmap(
     len: usize,
     vm_perm: VmPerm,
     option: MMapOptions,
-    fd: FileDescripter,
+    fd: FileDesc,
     offset: usize,
 ) -> Result<Vaddr> {
     debug!(
@@ -94,7 +94,7 @@ fn alloc_anonyous_vmo(len: usize) -> Result<Vmo> {
 }
 
 fn alloc_filebacked_vmo(
-    fd: FileDescripter,
+    fd: FileDesc,
     len: usize,
     offset: usize,
     option: &MMapOptions,

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -4,7 +4,7 @@ use super::{SyscallReturn, SYS_OPENAT};
 use crate::{
     fs::{
         file_handle::FileLike,
-        file_table::{FdFlags, FileDescripter},
+        file_table::{FdFlags, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
         utils::CreationFlags,
     },
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub fn sys_openat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     pathname_addr: Vaddr,
     flags: u32,
     mode: u16,

--- a/kernel/aster-nix/src/syscall/pipe.rs
+++ b/kernel/aster-nix/src/syscall/pipe.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_PIPE2};
 use crate::{
     fs::{
-        file_table::{FdFlags, FileDescripter},
+        file_table::{FdFlags, FileDesc},
         pipe::{PipeReader, PipeWriter},
         utils::{Channel, CreationFlags, StatusFlags},
     },
@@ -50,8 +50,8 @@ pub fn sys_pipe(fds: Vaddr) -> Result<SyscallReturn> {
 #[derive(Debug, Clone, Copy, Pod)]
 #[repr(C)]
 struct PipeFds {
-    reader_fd: FileDescripter,
-    writer_fd: FileDescripter,
+    reader_fd: FileDesc,
+    writer_fd: FileDesc,
 }
 
 const PIPE_BUF_SIZE: usize = 1024 * 1024;

--- a/kernel/aster-nix/src/syscall/poll.rs
+++ b/kernel/aster-nix/src/syscall/poll.rs
@@ -5,7 +5,7 @@ use core::{cell::Cell, time::Duration};
 use super::{SyscallReturn, SYS_POLL};
 use crate::{
     events::IoEvents,
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     process::signal::Poller,
@@ -112,13 +112,13 @@ struct c_pollfd {
 
 #[derive(Debug, Clone)]
 pub struct PollFd {
-    fd: Option<FileDescripter>,
+    fd: Option<FileDesc>,
     events: IoEvents,
     revents: Cell<IoEvents>,
 }
 
 impl PollFd {
-    pub fn new(fd: Option<FileDescripter>, events: IoEvents) -> Self {
+    pub fn new(fd: Option<FileDesc>, events: IoEvents) -> Self {
         let revents = Cell::new(IoEvents::empty());
         Self {
             fd,
@@ -127,7 +127,7 @@ impl PollFd {
         }
     }
 
-    pub fn fd(&self) -> Option<FileDescripter> {
+    pub fn fd(&self) -> Option<FileDesc> {
         self.fd
     }
 
@@ -143,7 +143,7 @@ impl PollFd {
 impl From<c_pollfd> for PollFd {
     fn from(raw: c_pollfd) -> Self {
         let fd = if raw.fd >= 0 {
-            Some(raw.fd as FileDescripter)
+            Some(raw.fd as FileDesc)
         } else {
             None
         };

--- a/kernel/aster-nix/src/syscall/pread64.rs
+++ b/kernel/aster-nix/src/syscall/pread64.rs
@@ -2,18 +2,13 @@
 
 use super::{SyscallReturn, SYS_PREAD64};
 use crate::{
-    fs::{file_table::FileDescripter, utils::SeekFrom},
+    fs::{file_table::FileDesc, utils::SeekFrom},
     log_syscall_entry,
     prelude::*,
     util::write_bytes_to_user,
 };
 
-pub fn sys_pread64(
-    fd: FileDescripter,
-    buf_ptr: Vaddr,
-    count: usize,
-    pos: i64,
-) -> Result<SyscallReturn> {
+pub fn sys_pread64(fd: FileDesc, buf_ptr: Vaddr, count: usize, pos: i64) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_PREAD64);
     debug!(
         "fd = {}, buf = 0x{:x}, count = 0x{:x}, pos = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/read.rs
+++ b/kernel/aster-nix/src/syscall/read.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SyscallReturn, SYS_READ};
-use crate::{
-    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, util::write_bytes_to_user,
-};
+use crate::{fs::file_table::FileDesc, log_syscall_entry, prelude::*, util::write_bytes_to_user};
 
-pub fn sys_read(fd: FileDescripter, user_buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
+pub fn sys_read(fd: FileDesc, user_buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_READ);
     debug!(
         "fd = {}, user_buf_ptr = 0x{:x}, buf_len = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/readlink.rs
+++ b/kernel/aster-nix/src/syscall/readlink.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_READLINKAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
     log_syscall_entry,
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn sys_readlinkat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     pathname_addr: Vaddr,
     usr_buf_addr: Vaddr,
     usr_buf_len: usize,

--- a/kernel/aster-nix/src/syscall/recvfrom.rs
+++ b/kernel/aster-nix/src/syscall/recvfrom.rs
@@ -2,7 +2,7 @@
 
 use super::{SyscallReturn, SYS_RECVFROM};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     net::socket::SendRecvFlags,
     prelude::*,
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn sys_recvfrom(
-    sockfd: FileDescripter,
+    sockfd: FileDesc,
     buf: Vaddr,
     len: usize,
     flags: i32,

--- a/kernel/aster-nix/src/syscall/rename.rs
+++ b/kernel/aster-nix/src/syscall/rename.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_RENAMEAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::InodeType,
     },
@@ -14,9 +14,9 @@ use crate::{
 };
 
 pub fn sys_renameat(
-    old_dirfd: FileDescripter,
+    old_dirfd: FileDesc,
     old_pathname_addr: Vaddr,
-    new_dirfd: FileDescripter,
+    new_dirfd: FileDesc,
     new_pathname_addr: Vaddr,
 ) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_RENAMEAT);

--- a/kernel/aster-nix/src/syscall/rmdir.rs
+++ b/kernel/aster-nix/src/syscall/rmdir.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_RMDIR};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
     log_syscall_entry,
@@ -16,7 +16,7 @@ pub fn sys_rmdir(pathname_addr: Vaddr) -> Result<SyscallReturn> {
     self::sys_rmdirat(AT_FDCWD, pathname_addr)
 }
 
-pub(super) fn sys_rmdirat(dirfd: FileDescripter, pathname_addr: Vaddr) -> Result<SyscallReturn> {
+pub(super) fn sys_rmdirat(dirfd: FileDesc, pathname_addr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_RMDIR);
     let pathname = read_cstring_from_user(pathname_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, pathname = {:?}", dirfd, pathname);

--- a/kernel/aster-nix/src/syscall/select.rs
+++ b/kernel/aster-nix/src/syscall/select.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     events::IoEvents,
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     time::timeval_t,
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub fn sys_select(
-    nfds: FileDescripter,
+    nfds: FileDesc,
     readfds_addr: Vaddr,
     writefds_addr: Vaddr,
     exceptfds_addr: Vaddr,
@@ -76,7 +76,7 @@ pub fn sys_select(
 }
 
 fn do_select(
-    nfds: FileDescripter,
+    nfds: FileDesc,
     mut readfds: Option<&mut FdSet>,
     mut writefds: Option<&mut FdSet>,
     mut exceptfds: Option<&mut FdSet>,
@@ -184,7 +184,7 @@ struct FdSet {
 
 impl FdSet {
     /// Equivalent to FD_SET.
-    pub fn set(&mut self, fd: FileDescripter) -> Result<()> {
+    pub fn set(&mut self, fd: FileDesc) -> Result<()> {
         let fd = fd as usize;
         if fd >= FD_SETSIZE {
             return_errno_with_message!(Errno::EINVAL, "fd exceeds FD_SETSIZE");
@@ -194,7 +194,7 @@ impl FdSet {
     }
 
     /// Equivalent to FD_CLR.
-    pub fn unset(&mut self, fd: FileDescripter) -> Result<()> {
+    pub fn unset(&mut self, fd: FileDesc) -> Result<()> {
         let fd = fd as usize;
         if fd >= FD_SETSIZE {
             return_errno_with_message!(Errno::EINVAL, "fd exceeds FD_SETSIZE");
@@ -204,7 +204,7 @@ impl FdSet {
     }
 
     /// Equivalent to FD_ISSET.
-    pub fn is_set(&self, fd: FileDescripter) -> bool {
+    pub fn is_set(&self, fd: FileDesc) -> bool {
         let fd = fd as usize;
         if fd >= FD_SETSIZE {
             return false;

--- a/kernel/aster-nix/src/syscall/sendto.rs
+++ b/kernel/aster-nix/src/syscall/sendto.rs
@@ -2,7 +2,7 @@
 
 use super::{SyscallReturn, SYS_SENDTO};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     net::socket::SendRecvFlags,
     prelude::*,
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn sys_sendto(
-    sockfd: FileDescripter,
+    sockfd: FileDesc,
     buf: Vaddr,
     len: usize,
     flags: i32,

--- a/kernel/aster-nix/src/syscall/setsockopt.rs
+++ b/kernel/aster-nix/src/syscall/setsockopt.rs
@@ -2,14 +2,14 @@
 
 use super::{SyscallReturn, SYS_SETSOCKOPT};
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
 };
 
 pub fn sys_setsockopt(
-    sockfd: FileDescripter,
+    sockfd: FileDesc,
     level: i32,
     optname: i32,
     optval: Vaddr,

--- a/kernel/aster-nix/src/syscall/shutdown.rs
+++ b/kernel/aster-nix/src/syscall/shutdown.rs
@@ -2,11 +2,11 @@
 
 use super::{SyscallReturn, SYS_SHUTDOWN};
 use crate::{
-    fs::file_table::FileDescripter, log_syscall_entry, net::socket::SockShutdownCmd, prelude::*,
+    fs::file_table::FileDesc, log_syscall_entry, net::socket::SockShutdownCmd, prelude::*,
     util::net::get_socket_from_fd,
 };
 
-pub fn sys_shutdown(sockfd: FileDescripter, how: i32) -> Result<SyscallReturn> {
+pub fn sys_shutdown(sockfd: FileDesc, how: i32) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SHUTDOWN);
     let shutdown_cmd = SockShutdownCmd::try_from(how)?;
     debug!("sockfd = {sockfd}, cmd = {shutdown_cmd:?}");

--- a/kernel/aster-nix/src/syscall/socketpair.rs
+++ b/kernel/aster-nix/src/syscall/socketpair.rs
@@ -2,7 +2,7 @@
 
 use super::{SyscallReturn, SYS_SOCKETPAIR};
 use crate::{
-    fs::file_table::{FdFlags, FileDescripter},
+    fs::file_table::{FdFlags, FileDesc},
     log_syscall_entry,
     net::socket::unix::UnixStreamSocket,
     prelude::*,
@@ -54,4 +54,4 @@ pub fn sys_socketpair(domain: i32, type_: i32, protocol: i32, sv: Vaddr) -> Resu
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod)]
-struct SocketFds(FileDescripter, FileDescripter);
+struct SocketFds(FileDesc, FileDesc);

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_FSTAT, SYS_FSTATAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::Metadata,
     },
@@ -14,7 +14,7 @@ use crate::{
     util::{read_cstring_from_user, write_val_to_user},
 };
 
-pub fn sys_fstat(fd: FileDescripter, stat_buf_ptr: Vaddr) -> Result<SyscallReturn> {
+pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FSTAT);
     debug!("fd = {}, stat_buf_addr = 0x{:x}", fd, stat_buf_ptr);
 
@@ -40,7 +40,7 @@ pub fn sys_lstat(filename_ptr: Vaddr, stat_buf_ptr: Vaddr) -> Result<SyscallRetu
 }
 
 pub fn sys_fstatat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     filename_ptr: Vaddr,
     stat_buf_ptr: Vaddr,
     flags: u32,

--- a/kernel/aster-nix/src/syscall/statfs.rs
+++ b/kernel/aster-nix/src/syscall/statfs.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_FSTATFS, SYS_STATFS};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::FsPath,
         inode_handle::InodeHandle,
         utils::{SuperBlock, PATH_MAX},
@@ -29,7 +29,7 @@ pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr) -> Result<SyscallRetur
     Ok(SyscallReturn::Return(0))
 }
 
-pub fn sys_fstatfs(fd: FileDescripter, statfs_buf_ptr: Vaddr) -> Result<SyscallReturn> {
+pub fn sys_fstatfs(fd: FileDesc, statfs_buf_ptr: Vaddr) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FSTATFS);
     debug!("fd = {}, statfs_buf_addr = 0x{:x}", fd, statfs_buf_ptr);
 

--- a/kernel/aster-nix/src/syscall/symlink.rs
+++ b/kernel/aster-nix/src/syscall/symlink.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_SYMLINKAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, InodeType},
     },
@@ -15,7 +15,7 @@ use crate::{
 
 pub fn sys_symlinkat(
     target_addr: Vaddr,
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     linkpath_addr: Vaddr,
 ) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_SYMLINKAT);

--- a/kernel/aster-nix/src/syscall/truncate.rs
+++ b/kernel/aster-nix/src/syscall/truncate.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_FTRUNCATE, SYS_TRUNCATE};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::PATH_MAX,
     },
@@ -13,7 +13,7 @@ use crate::{
     util::read_cstring_from_user,
 };
 
-pub fn sys_ftruncate(fd: FileDescripter, len: isize) -> Result<SyscallReturn> {
+pub fn sys_ftruncate(fd: FileDesc, len: isize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_FTRUNCATE);
     debug!("fd = {}, lentgh = {}", fd, len);
 

--- a/kernel/aster-nix/src/syscall/unlink.rs
+++ b/kernel/aster-nix/src/syscall/unlink.rs
@@ -3,7 +3,7 @@
 use super::{SyscallReturn, SYS_UNLINKAT};
 use crate::{
     fs::{
-        file_table::FileDescripter,
+        file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
     },
     log_syscall_entry,
@@ -12,11 +12,7 @@ use crate::{
     util::read_cstring_from_user,
 };
 
-pub fn sys_unlinkat(
-    dirfd: FileDescripter,
-    pathname_addr: Vaddr,
-    flags: u32,
-) -> Result<SyscallReturn> {
+pub fn sys_unlinkat(dirfd: FileDesc, pathname_addr: Vaddr, flags: u32) -> Result<SyscallReturn> {
     let flags =
         UnlinkFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
     if flags.contains(UnlinkFlags::AT_REMOVEDIR) {

--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use super::{SyscallReturn, SYS_UTIMENSAT};
 use crate::{
-    fs::{file_table::FileDescripter, fs_resolver::FsPath},
+    fs::{file_table::FileDesc, fs_resolver::FsPath},
     log_syscall_entry,
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn sys_utimensat(
-    dirfd: FileDescripter,
+    dirfd: FileDesc,
     pathname_ptr: Vaddr,
     timespecs_ptr: Vaddr,
     flags: u32,

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -2,18 +2,14 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDescripter, log_syscall_entry, prelude::*, syscall::SYS_WRITE,
+    fs::file_table::FileDesc, log_syscall_entry, prelude::*, syscall::SYS_WRITE,
     util::read_bytes_from_user,
 };
 
 const STDOUT: u64 = 1;
 const STDERR: u64 = 2;
 
-pub fn sys_write(
-    fd: FileDescripter,
-    user_buf_ptr: Vaddr,
-    user_buf_len: usize,
-) -> Result<SyscallReturn> {
+pub fn sys_write(fd: FileDesc, user_buf_ptr: Vaddr, user_buf_len: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_WRITE);
     debug!(
         "fd = {}, user_buf_ptr = 0x{:x}, user_buf_len = 0x{:x}",

--- a/kernel/aster-nix/src/syscall/writev.rs
+++ b/kernel/aster-nix/src/syscall/writev.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDescripter,
+    fs::file_table::FileDesc,
     log_syscall_entry,
     prelude::*,
     syscall::SYS_WRITEV,
@@ -18,17 +18,13 @@ pub struct IoVec {
     len: usize,
 }
 
-pub fn sys_writev(
-    fd: FileDescripter,
-    io_vec_ptr: Vaddr,
-    io_vec_count: usize,
-) -> Result<SyscallReturn> {
+pub fn sys_writev(fd: FileDesc, io_vec_ptr: Vaddr, io_vec_count: usize) -> Result<SyscallReturn> {
     log_syscall_entry!(SYS_WRITEV);
     let res = do_sys_writev(fd, io_vec_ptr, io_vec_count)?;
     Ok(SyscallReturn::Return(res as _))
 }
 
-fn do_sys_writev(fd: FileDescripter, io_vec_ptr: Vaddr, io_vec_count: usize) -> Result<usize> {
+fn do_sys_writev(fd: FileDesc, io_vec_ptr: Vaddr, io_vec_count: usize) -> Result<usize> {
     debug!(
         "fd = {}, io_vec_ptr = 0x{:x}, io_vec_counter = 0x{:x}",
         fd, io_vec_ptr, io_vec_count

--- a/kernel/aster-nix/src/util/net/mod.rs
+++ b/kernel/aster-nix/src/util/net/mod.rs
@@ -8,9 +8,9 @@ pub use addr::{read_socket_addr_from_user, write_socket_addr_to_user, CSocketAdd
 pub use options::{new_raw_socket_option, CSocketOptionLevel};
 pub use socket::{Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
 
-use crate::{fs::file_table::FileDescripter, net::socket::Socket, prelude::*};
+use crate::{fs::file_table::FileDesc, net::socket::Socket, prelude::*};
 
-pub fn get_socket_from_fd(sockfd: FileDescripter) -> Result<Arc<dyn Socket>> {
+pub fn get_socket_from_fd(sockfd: FileDesc) -> Result<Arc<dyn Socket>> {
     let current = current!();
     let file_table = current.file_table().lock();
     file_table.get_socket(sockfd)


### PR DESCRIPTION
I find a typo: `FileDescripter` should be `FileDescriptor`, and I shorten it as `FileDesc`.