### PR TITLE
Bump version in the documentation

### DIFF
--- a/docs/src/kernel/README.md
+++ b/docs/src/kernel/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/asterinas/asterinas
 2. Run a Docker container as the development environment.
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v asterinas:/root/asterinas asterinas/asterinas:0.3.0
+docker run -it --privileged --network=host --device=/dev/kvm -v asterinas:/root/asterinas asterinas/asterinas:0.4.2
 ```
 
 3. Inside the container, go to the project folder to build and run Asterinas.

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -15,7 +15,12 @@ git = "https://github.com/asterinas/asterinas"
 rev = "cc4111c"
 # When publishing, the crate.io version is used, make sure
 # the builder is published
-version = "0.1.0"
+# FIXME: The version is currently commented out as it is no longer in use. 
+# If this version is being used, 
+# please ensure to update `bump_version.sh` appropriately. 
+# `bump_version.sh will also update this version, 
+# however, the dependent crate may not share the same version as the whole project.
+# version = "0.1.0"
 
 [dependencies]
 clap = { version = "4.4.17", features = ["cargo", "derive"] }

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -49,6 +49,10 @@ for workflow in $WORKFLOWS; do
     update_image_versions $workflow
 done
 
+# Update Docker image versions in the documentation
+GET_STARTED_PATH=${ASTER_SRC_DIR}/docs/src/kernel/README.md
+update_image_versions $GET_STARTED_PATH
+
 # Create or update VERSION
 echo "${new_version}" > ${VERSION_PATH}
 


### PR DESCRIPTION
The `bump_version.sh` will upgrade each line in the `Cargo.toml` in the format of `version=x.x.x`. For example, It will upgrade the version of `linux-bzimage-builder` in the `Cargo.toml` of OSDK. Currently, I commented out the line.

@junyang-zh, do you think we should only upgrade `package.version` only in `Cargo.toml`? Is there any case that we need to upgrade the version of dependent crates? 