### PR TITLE
Avoid dropping activated page table and check `VmSpace` activation

### DIFF
--- a/framework/aster-frame/src/vm/space.rs
+++ b/framework/aster-frame/src/vm/space.rs
@@ -44,9 +44,13 @@ impl VmSpace {
             pt: KERNEL_PAGE_TABLE.get().unwrap().create_user_page_table(),
         }
     }
-    /// Activate the page table.
+    /// Activate the page table and invalidate TLB entries.
     pub(crate) fn activate(&self) {
-        self.pt.activate();
+        // Safety: The usermode page table is safe to activate since the kernel
+        // mappings are shared.
+        unsafe {
+            self.pt.activate_unchecked();
+        }
     }
 
     /// Maps some physical memory pages into the VM space according to the given

--- a/framework/aster-frame/src/vm/space.rs
+++ b/framework/aster-frame/src/vm/space.rs
@@ -44,8 +44,12 @@ impl VmSpace {
             pt: KERNEL_PAGE_TABLE.get().unwrap().create_user_page_table(),
         }
     }
-    /// Activate the page table and invalidate TLB entries.
+    /// Activate the page table and invalidate TLB entries if not currently activated.
     pub(crate) fn activate(&self) {
+        let current_pt = crate::arch::mm::current_page_table_paddr();
+        if current_pt == self.pt.root_paddr() {
+            return;
+        }
         // Safety: The usermode page table is safe to activate since the kernel
         // mappings are shared.
         unsafe {


### PR DESCRIPTION
This is based on #713 and addresses problems raised when discussing #811.

I don't know why it causes problems on Linux EFI handover boot protocol only. So I want to address this change in a separated PR.