### PR TITLE
Improve the read/write efficiency of `Vmo`

### DIFF
--- a/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
+++ b/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
@@ -84,7 +84,7 @@ impl Vmo<Rights> {
     /// The method requires the Write right.
     pub fn commit(&self, range: Range<usize>) -> Result<()> {
         self.check_rights(Rights::WRITE)?;
-        self.0.commit(range, false)?;
+        self.0.commit_and_operate(&range, |_| {}, false)?;
         Ok(())
     }
 

--- a/kernel/aster-nix/src/vm/vmo/static_cap.rs
+++ b/kernel/aster-nix/src/vm/vmo/static_cap.rs
@@ -87,7 +87,7 @@ impl<R: TRights> Vmo<TRightSet<R>> {
     /// The method requires the Write right.
     #[require(R > Write)]
     pub fn commit(&self, range: Range<usize>) -> Result<()> {
-        self.0.commit(range, false)?;
+        self.0.commit_and_operate(&range, |_| {}, false)?;
         Ok(())
     }
 


### PR DESCRIPTION
Currently when performing read/write, `Vmo` needs to use an additional `VmFrameVec` to store all the operated pages first. This PR remove this additional operation and can improve the single page read and write efficiency of `Vmo` about 25%.

@liqinggd Could you give some suggestions for this PR?