### PR TITLE
Use `UnsafeCell` to store `UserContext`

### DIFF
--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -99,14 +99,14 @@ fn switch_to_task(next_task: Arc<Task>) {
         Some(current_task) => {
             let cx_ptr = current_task.ctx().get();
 
-            let mut task = current_task.inner_exclusive_access();
+            let mut task_inner = current_task.inner_exclusive_access();
 
-            debug_assert_ne!(task.task_status, TaskStatus::Sleeping);
-            if task.task_status == TaskStatus::Runnable {
-                drop(task);
+            debug_assert_ne!(task_inner.task_status, TaskStatus::Sleeping);
+            if task_inner.task_status == TaskStatus::Runnable {
+                drop(task_inner);
                 GLOBAL_SCHEDULER.lock_irq_disabled().enqueue(current_task);
-            } else if task.task_status == TaskStatus::Sleepy {
-                task.task_status = TaskStatus::Sleeping;
+            } else if task_inner.task_status == TaskStatus::Sleepy {
+                task_inner.task_status = TaskStatus::Sleeping;
             }
 
             cx_ptr

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -278,7 +278,7 @@ impl TaskOptions {
             current_task.exit();
         }
 
-        let mut result = Task {
+        let mut new_task = Task {
             func: self.func.unwrap(),
             data: self.data.unwrap(),
             user_space: self.user_space,
@@ -292,7 +292,7 @@ impl TaskOptions {
             cpu_affinity: self.cpu_affinity,
         };
 
-        let ctx = result.ctx.get_mut();
+        let ctx = new_task.ctx.get_mut();
         ctx.rip = kernel_task_entry as usize;
         // We should reserve space for the return address in the stack, otherwise
         // we will write across the page boundary due to the implementation of
@@ -302,9 +302,9 @@ impl TaskOptions {
         // to at least 16 bytes. And a larger alignment is needed if larger arguments
         // are passed to the function. The `kernel_task_entry` function does not
         // have any arguments, so we only need to align the stack pointer to 16 bytes.
-        ctx.regs.rsp = (crate::vm::paddr_to_vaddr(result.kstack.end_paddr() - 16)) as u64;
+        ctx.regs.rsp = (crate::vm::paddr_to_vaddr(new_task.kstack.end_paddr() - 16)) as u64;
 
-        Ok(Arc::new(result))
+        Ok(Arc::new(new_task))
     }
 
     /// Build a new task and run it immediately.


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/81cca422058bff9771927293f9741548a8d62c67/framework/aster-frame/src/task/task.rs#L148

This unnecessarily creates a copy of `TaskContext`.
```
ffffffff8808a40d:       49 8b 44 24 50          mov    0x50(%r12),%rax
ffffffff8808a412:       48 89 44 24 58          mov    %rax,0x58(%rsp)
ffffffff8808a417:       49 8b 44 24 48          mov    0x48(%r12),%rax
ffffffff8808a41c:       48 89 44 24 50          mov    %rax,0x50(%rsp)
ffffffff8808a421:       49 8b 44 24 40          mov    0x40(%r12),%rax
ffffffff8808a426:       48 89 44 24 48          mov    %rax,0x48(%rsp)
ffffffff8808a42b:       49 8b 44 24 38          mov    0x38(%r12),%rax
ffffffff8808a430:       48 89 44 24 40          mov    %rax,0x40(%rsp)
ffffffff8808a435:       49 8b 44 24 30          mov    0x30(%r12),%rax
ffffffff8808a43a:       48 89 44 24 38          mov    %rax,0x38(%rsp)
ffffffff8808a43f:       49 8b 44 24 28          mov    0x28(%r12),%rax
ffffffff8808a444:       48 89 44 24 30          mov    %rax,0x30(%rsp)
ffffffff8808a449:       49 8b 44 24 18          mov    0x18(%r12),%rax
ffffffff8808a44e:       49 8b 54 24 20          mov    0x20(%r12),%rdx
ffffffff8808a453:       48 89 54 24 28          mov    %rdx,0x28(%rsp)
ffffffff8808a458:       48 89 44 24 20          mov    %rax,0x20(%rsp)
```

Meanwhile, `task.ctx` should be put in a separate `UnsafeCell`, not as a part of `TaskInner`. Otherwise, it violates the sematics of `SpinLock` and Rust's memory model which requires that mutable references must be exclusive.

This PR fixes the above two problems.