### PR TITLE
Fix OSDK CI panics

### DIFF
--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -30,7 +30,7 @@ jobs:
         # of actions/checkout@v4
       - name: Unit test
         id: unit_test
-        run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
+        run: cd osdk && RUSTUP_HOME=/root/.rustup cargo +stable build && RUSTUP_HOME=/root/.rustup cargo test
   
   # Test OSDK in the same environment 
   # as described in the OSDK User Guide in the Asterinas Book.
@@ -50,5 +50,5 @@ jobs:
         # So the RUSTUP_HOME needs to be set here. 
         # This only breaks when we invoke Cargo in the integration test of OSDK 
         # since the OSDK toolchain is not nightly.
-        run: cd osdk && cargo build && RUSTUP_HOME=/root/.rustup cargo test
+        run: cd osdk && RUSTUP_HOME=/root/.rustup cargo +stable build && RUSTUP_HOME=/root/.rustup cargo test
     

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "linux-bzimage-builder"
 version = "0.1.0"
-source = "git+https://github.com/asterinas/asterinas?rev=cc4111c#cc4111cab227f188a1170dea0aa729b410b1b509"
+source = "git+https://github.com/asterinas/asterinas?rev=c9b66bd#c9b66bddd6b77dcddcbe1b66337a76ee1e16b640"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/osdk/rust-toolchain.toml
+++ b/osdk/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"

--- a/osdk/src/commands/new/lib.OSDK.toml.template
+++ b/osdk/src/commands/new/lib.OSDK.toml.template
@@ -1,4 +1,4 @@
-project_type = "lib"
+project_type = "library"
 
 [boot]
 method = "qemu-direct"

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -7,7 +7,9 @@ use crate::{
     base_crate::new_base_crate,
     cli::TestArgs,
     config::{scheme::ActionChoice, Config},
-    util::{get_cargo_metadata, get_current_crate_info, get_target_directory},
+    util::{
+        get_cargo_metadata, get_current_crate_info, get_target_directory, parse_package_id_string,
+    },
 };
 
 pub fn execute_test_command(config: &Config, args: &TestArgs) {
@@ -81,12 +83,9 @@ fn get_workspace_default_members() -> Vec<String> {
     default_members
         .iter()
         .map(|value| {
-            // The default member is in the form of "<crate_name> <crate_version> (path+file://<crate_path>)"
             let default_member = value.as_str().unwrap();
-            let path = default_member.split(' ').nth(2).unwrap();
-            path.trim_start_matches("(path+file://")
-                .trim_end_matches(')')
-                .to_string()
+            let crate_info = parse_package_id_string(default_member);
+            crate_info.path
         })
         .collect()
 }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -163,25 +163,29 @@ pub fn get_current_crate_info() -> CrateInfo {
     let metadata = get_cargo_metadata(None::<&str>, None::<&[&str]>).unwrap();
 
     let default_member = get_default_member(&metadata);
-    // Prior 202403 (Rust 1.77.1), the default member string here is in the form of
+    parse_package_id_string(default_member)
+}
+
+pub fn parse_package_id_string(package_id: &str) -> CrateInfo {
+    // Prior to 202403 (Rust 1.77.1), the package id string here is in the form of
     // "<crate_name> <crate_version> (path+file://<crate_path>)".
     // After that, it's
     // "path+file://<crate_path>#<crate_name>@<crate_version>", in which the crate
     // name might not exist if it is the last component of the path.
-    if default_member.starts_with("path+file://") {
+    if package_id.starts_with("path+file://") {
         // After 1.77.1
-        if default_member.contains('@') {
-            let default_member = default_member.split(['#', '@']).collect::<Vec<&str>>();
+        if package_id.contains('@') {
+            let package_id_segments = package_id.split(['#', '@']).collect::<Vec<&str>>();
             CrateInfo {
-                name: default_member[1].to_string(),
-                version: default_member[2].to_string(),
-                path: default_member[0]
+                name: package_id_segments[1].to_string(),
+                version: package_id_segments[2].to_string(),
+                path: package_id_segments[0]
                     .trim_start_matches("path+file://")
                     .to_string(),
             }
         } else {
-            let default_member = default_member.split(['#']).collect::<Vec<&str>>();
-            let path = default_member[0]
+            let package_id_segments = package_id.split(['#']).collect::<Vec<&str>>();
+            let path = package_id_segments[0]
                 .trim_start_matches("path+file://")
                 .to_string();
             CrateInfo {
@@ -191,13 +195,13 @@ pub fn get_current_crate_info() -> CrateInfo {
                     .to_str()
                     .unwrap()
                     .to_string(),
-                version: default_member[1].to_string(),
+                version: package_id_segments[1].to_string(),
                 path,
             }
         }
     } else {
         // Before 1.77.1
-        let default_member = default_member.split(' ').collect::<Vec<&str>>();
+        let default_member = package_id.split(' ').collect::<Vec<&str>>();
         CrateInfo {
             name: default_member[0].to_string(),
             version: default_member[1].to_string(),

--- a/osdk/tests/examples_in_book/test_and_run_projects.rs
+++ b/osdk/tests/examples_in_book/test_and_run_projects.rs
@@ -50,7 +50,7 @@ fn create_and_test_library() {
 
     let mut command = cargo_osdk(&["test"]);
     command.current_dir(&module_dir);
-    command.output().unwrap();
+    command.ok().unwrap();
 
     fs::remove_dir_all(&module_dir).unwrap();
 }

--- a/osdk/tests/examples_in_book/work_in_workspace.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace.rs
@@ -76,7 +76,7 @@ fn work_in_workspace() {
     assert!(stdout.contains("The available memory is"));
 
     // Run subcommand test
-    cargo_osdk(&["test"]).output().unwrap();
+    cargo_osdk(&["test"]).ok().unwrap();
 
     // Remove the directory
     fs::remove_dir_all(&workspace_dir).unwrap();


### PR DESCRIPTION
I removed the `rust-toolchain.toml` from OSDK. 

The problem is that when I run `cargo test create_and_test_library` in the `asterinas/osdk` directory, the toolchain of `/tmp/mymodule` will always be overrided by the toolchain of OSDK. So the test case will panic. I choose to remove `rust-toolchain.toml` from `asterinas/osdk` (But `cargo test create_and_run_kernel` will succeed even not removing the file, this still confuses me.)

Another reason is that when I searching several cargo subcommands, like [cargo-expand](https://github.com/dtolnay/cargo-expand), [cargo-deny](https://github.com/EmbarkStudios/cargo-deny), [cargo-edit](https://github.com/killercup/cargo-edit), they all not specify the channel as stable. If we want to ensure OSDK can build with stable toolchain, we can test it in CI(I have changed the GitHub workflow). 

