### PR TITLE
Add syscall mount and umount

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -185,8 +185,8 @@ provided by Linux on x86-64 architecture.
 | 162     | sync             | ✅              |
 | 163     | acct             | ❌              |
 | 164     | settimeofday     | ❌              |
-| 165     | mount            | ❌              |
-| 166     | umount2          | ❌              |
+| 165     | mount            | ✅              |
+| 166     | umount2          | ✅              |
 | 167     | swapon           | ❌              |
 | 168     | swapoff          | ❌              |
 | 169     | reboot           | ❌              |

--- a/kernel/aster-nix/src/fs/mod.rs
+++ b/kernel/aster-nix/src/fs/mod.rs
@@ -23,7 +23,6 @@ use crate::{
         exfat::{ExfatFS, ExfatMountOptions},
         ext2::Ext2,
         fs_resolver::FsPath,
-        utils::FileSystem,
     },
     prelude::*,
     thread::kernel_thread::KernelThreadExt,
@@ -63,28 +62,5 @@ pub fn lazy_init() {
         let target_path = FsPath::try_from("/exfat").unwrap();
         println!("[kernel] Mount ExFat fs at {:?} ", target_path);
         self::rootfs::mount_fs_at(exfat_fs, &target_path).unwrap();
-    }
-}
-
-pub fn get_fs(fs_type: &str) -> Result<Arc<dyn FileSystem>> {
-    match fs_type {
-        "ext2" => {
-            if let Ok(block_device_ext2) = start_block_device("vext2") {
-                let ext2_fs = Ext2::open(block_device_ext2).unwrap();
-                Ok(ext2_fs)
-            } else {
-                return_errno_with_message!(Errno::EINVAL, "Ext2 fs does not exist")
-            }
-        }
-        "exfat" => {
-            if let Ok(block_device_exfat) = start_block_device("vexfat") {
-                let exfat_fs =
-                    ExfatFS::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
-                Ok(exfat_fs)
-            } else {
-                return_errno_with_message!(Errno::EINVAL, "Exfat fs dose not exist")
-            }
-        }
-        _ => return_errno_with_message!(Errno::EINVAL, "Invalid fs type"),
     }
 }

--- a/kernel/aster-nix/src/fs/mod.rs
+++ b/kernel/aster-nix/src/fs/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         exfat::{ExfatFS, ExfatMountOptions},
         ext2::Ext2,
         fs_resolver::FsPath,
+        utils::FileSystem,
     },
     prelude::*,
     thread::kernel_thread::KernelThreadExt,
@@ -62,5 +63,28 @@ pub fn lazy_init() {
         let target_path = FsPath::try_from("/exfat").unwrap();
         println!("[kernel] Mount ExFat fs at {:?} ", target_path);
         self::rootfs::mount_fs_at(exfat_fs, &target_path).unwrap();
+    }
+}
+
+pub fn get_fs(fs_type: &str) -> Result<Arc<dyn FileSystem>> {
+    match fs_type {
+        "ext2" => {
+            if let Ok(block_device_ext2) = start_block_device("vext2") {
+                let ext2_fs = Ext2::open(block_device_ext2).unwrap();
+                Ok(ext2_fs)
+            } else {
+                return_errno_with_message!(Errno::EINVAL, "Ext2 fs does not exist")
+            }
+        }
+        "exfat" => {
+            if let Ok(block_device_exfat) = start_block_device("vexfat") {
+                let exfat_fs =
+                    ExfatFS::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
+                Ok(exfat_fs)
+            } else {
+                return_errno_with_message!(Errno::EINVAL, "Exfat fs dose not exist")
+            }
+        }
+        _ => return_errno_with_message!(Errno::EINVAL, "Invalid fs type"),
     }
 }

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -101,11 +101,12 @@ impl Dentry_ {
         DentryFlags::from_bits(flags).unwrap()
     }
 
-    /// Check if the Dentry_ is a subdir of the given Dentry_.
-    pub fn is_subdir(&self, dentry: Arc<Self>) -> bool {
+    /// Check if this dentry is a descendant (child, grandchild, or
+    /// great-grandchild, etc.) of another dentry.
+    pub fn is_descendant_of(&self, ancestor: &Arc<Self>) -> bool {
         let mut parent = self.parent();
         while let Some(p) = parent {
-            if Arc::ptr_eq(&p, &dentry) {
+            if Arc::ptr_eq(&p, ancestor) {
                 return true;
             }
             parent = p.parent();
@@ -568,10 +569,10 @@ impl Dentry {
         }
     }
 
-    /// Make this Dentry' inner to be a mountpoint,
+    /// Make this Dentry's inner to be a mountpoint,
     /// and set the mountpoint of the child mount to this Dentry's inner.
-    pub fn set_mountpoint(&self, child_mount: Arc<MountNode>) {
-        child_mount.set_mountpoint_dentry(self.inner.clone());
+    pub(super) fn set_mountpoint(&self, child_mount: Arc<MountNode>) {
+        child_mount.set_mountpoint_dentry(&self.inner);
         self.inner.set_mountpoint_dentry();
     }
 
@@ -597,7 +598,7 @@ impl Dentry {
     /// Unmount and return the mounted child mount.
     ///
     /// Note that the root mount cannot be unmounted.
-    pub fn umount(&self) -> Result<Arc<MountNode>> {
+    pub fn unmount(&self) -> Result<Arc<MountNode>> {
         if !self.inner.is_root_of_mount() {
             return_errno_with_message!(Errno::EINVAL, "not mounted");
         }
@@ -610,7 +611,7 @@ impl Dentry {
         let mountpoint_mount_node = mount_node.parent().unwrap().upgrade().unwrap();
         let mountpoint = Self::new(mountpoint_mount_node.clone(), mountpoint_dentry.clone());
 
-        let child_mount = mountpoint_mount_node.umount(&mountpoint)?;
+        let child_mount = mountpoint_mount_node.unmount(&mountpoint)?;
         mountpoint_dentry.clear_mountpoint();
         Ok(child_mount)
     }
@@ -647,12 +648,17 @@ impl Dentry {
         self.inner.rename(old_name, &new_dir.inner, new_name)
     }
 
-    pub fn do_loopback(&self, recursive: bool) -> Arc<MountNode> {
-        if recursive {
-            self.mount_node.copy_mount_node_tree(self.inner.clone())
-        } else {
-            self.mount_node.clone_mount_node(self.inner.clone())
-        }
+    /// Bind mount the Dentry to the destination Dentry.
+    ///
+    /// If recursive is true, it will bind mount the whole mount tree
+    /// to the destination Dentry. Otherwise, it will only bind mount
+    /// the root mount node.
+    pub fn bind_mount_to(&self, dst_dentry: &Arc<Self>, recursive: bool) -> Result<()> {
+        let src_mount = self
+            .mount_node
+            .clone_mount_node_tree(&self.inner, recursive);
+        src_mount.graft_mount_node_tree(dst_dentry)?;
+        Ok(())
     }
 
     /// Get the arc reference to self.

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -649,9 +649,9 @@ impl Dentry {
 
     pub fn do_loopback(&self, recursive: bool) -> Arc<MountNode> {
         if recursive {
-            self.mount_node.copy_mount_tree(self.inner.clone())
+            self.mount_node.copy_mount_node_tree(self.inner.clone())
         } else {
-            self.mount_node.clone_mount(self.inner.clone())
+            self.mount_node.clone_mount_node(self.inner.clone())
         }
     }
 

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -101,6 +101,18 @@ impl Dentry_ {
         DentryFlags::from_bits(flags).unwrap()
     }
 
+    /// Check if the Dentry_ is a subdir of the given Dentry_.
+    pub fn is_subdir(&self, dentry: Arc<Self>) -> bool {
+        let mut parent = self.parent();
+        while let Some(p) = parent {
+            if Arc::ptr_eq(&p, &dentry) {
+                return true;
+            }
+            parent = p.parent();
+        }
+        false
+    }
+
     pub fn is_mountpoint(&self) -> bool {
         self.flags().contains(DentryFlags::MOUNTED)
     }
@@ -558,7 +570,7 @@ impl Dentry {
 
     /// Make this Dentry' inner to be a mountpoint,
     /// and set the mountpoint of the child mount to this Dentry's inner.
-    fn set_mountpoint(&self, child_mount: Arc<MountNode>) {
+    pub fn set_mountpoint(&self, child_mount: Arc<MountNode>) {
         child_mount.set_mountpoint_dentry(self.inner.clone());
         self.inner.set_mountpoint_dentry();
     }
@@ -635,6 +647,14 @@ impl Dentry {
         self.inner.rename(old_name, &new_dir.inner, new_name)
     }
 
+    pub fn do_loopback(&self, recursive: bool) -> Arc<MountNode> {
+        if recursive {
+            self.mount_node.copy_mount_tree(self.inner.clone())
+        } else {
+            self.mount_node.clone_mount(self.inner.clone())
+        }
+    }
+
     /// Get the arc reference to self.
     fn this(&self) -> Arc<Self> {
         self.this.upgrade().unwrap()
@@ -666,4 +686,6 @@ impl Dentry {
     pub fn set_mtime(&self, time: Duration);
     pub fn key(&self) -> DentryKey;
     pub fn inode(&self) -> &Arc<dyn Inode>;
+    pub fn is_root_of_mount(&self) -> bool;
+    pub fn is_mountpoint(&self) -> bool;
 }

--- a/kernel/aster-nix/src/fs/path/mount.rs
+++ b/kernel/aster-nix/src/fs/path/mount.rs
@@ -84,7 +84,7 @@ impl MountNode {
     /// Unmount a child mount node from the mountpoint and return it.
     ///
     /// The mountpoint should belong to this mount node, or an error is returned.
-    pub fn umount(&self, mountpoint: &Dentry) -> Result<Arc<Self>> {
+    pub fn unmount(&self, mountpoint: &Dentry) -> Result<Arc<Self>> {
         if !Arc::ptr_eq(mountpoint.mount_node(), &self.this()) {
             return_errno_with_message!(Errno::EINVAL, "mountpoint not belongs to this");
         }
@@ -97,12 +97,13 @@ impl MountNode {
         Ok(child_mount)
     }
 
-    /// Clone a mount node with the an root Dentry_.
+    /// Clone a mount node with the an root `Dentry_`.
+    ///
     /// The new mount node will have the same fs as the original one and
     /// have no parent and children. We should set the parent and children manually.
-    pub fn clone_mount_node(&self, root_dentry: Arc<Dentry_>) -> Arc<Self> {
+    fn clone_mount_node(&self, root_dentry: &Arc<Dentry_>) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| Self {
-            root_dentry,
+            root_dentry: root_dentry.clone(),
             mountpoint_dentry: RwLock::new(None),
             parent: RwLock::new(None),
             children: Mutex::new(BTreeMap::new()),
@@ -111,37 +112,46 @@ impl MountNode {
         })
     }
 
-    /// Copies a mount tree starting from the specified root `Dentry_`.
+    /// Clone a mount tree starting from the specified root `Dentry_`.
+    ///
     /// The new mount tree will replicate the structure of the original tree.
     /// The new tree is a separate entity rooted at the given `Dentry_`,
     /// and the original tree remains unchanged.
-    pub fn copy_mount_node_tree(&self, root_dentry: Arc<Dentry_>) -> Arc<Self> {
+    ///
+    /// If `recursive` is set to `true`, the entire tree will be copied.
+    /// Otherwise, only the root mount node will be copied.
+    pub(super) fn clone_mount_node_tree(
+        &self,
+        root_dentry: &Arc<Dentry_>,
+        recursive: bool,
+    ) -> Arc<Self> {
         let new_root_mount = self.clone_mount_node(root_dentry);
+        if !recursive {
+            return new_root_mount.clone();
+        }
         let mut stack = vec![self.this()];
         let mut new_stack = vec![new_root_mount.clone()];
 
-        let mut dentry = new_root_mount.root_dentry.clone();
         while let Some(old_mount) = stack.pop() {
             let new_parent_mount = new_stack.pop().unwrap().clone();
             let old_children = old_mount.children.lock();
             for old_child_mount in old_children.values() {
                 let mountpoint_dentry = old_child_mount.mountpoint_dentry().unwrap();
-                if !dentry.is_subdir(mountpoint_dentry.clone()) {
+                if !mountpoint_dentry.is_descendant_of(old_mount.root_dentry()) {
                     continue;
                 }
-                stack.push(old_child_mount.clone());
                 let new_child_mount =
-                    old_child_mount.clone_mount_node(old_child_mount.root_dentry.clone());
+                    old_child_mount.clone_mount_node(old_child_mount.root_dentry());
                 let key = mountpoint_dentry.key();
                 new_parent_mount
                     .children
                     .lock()
                     .insert(key, new_child_mount.clone());
-                new_child_mount.set_parent(new_parent_mount.clone());
+                new_child_mount.set_parent(&new_parent_mount);
                 new_child_mount
-                    .set_mountpoint_dentry(old_child_mount.mountpoint_dentry().unwrap().clone());
+                    .set_mountpoint_dentry(&old_child_mount.mountpoint_dentry().unwrap());
+                stack.push(old_child_mount.clone());
                 new_stack.push(new_child_mount.clone());
-                dentry = new_child_mount.root_dentry.clone();
             }
         }
         new_root_mount.clone()
@@ -159,24 +169,24 @@ impl MountNode {
     }
 
     /// Attach the mount node to the mountpoint.
-    fn attach_mount_node(&self, mountpoint: Arc<Dentry>) {
+    fn attach_mount_node(&self, mountpoint: &Arc<Dentry>) {
         let key = mountpoint.key();
         mountpoint
             .mount_node()
             .children
             .lock()
             .insert(key, self.this());
-        self.set_parent(mountpoint.mount_node().clone());
+        self.set_parent(mountpoint.mount_node());
         mountpoint.set_mountpoint(self.this());
     }
 
     /// Graft the mount node tree to the mountpoint.
-    pub fn graft_mount_node_tree(&self, mountpoint: Arc<Dentry>) -> Result<()> {
+    pub fn graft_mount_node_tree(&self, mountpoint: &Arc<Dentry>) -> Result<()> {
         if mountpoint.type_() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
         self.detach_mount_node();
-        self.attach_mount_node(mountpoint.clone());
+        self.attach_mount_node(mountpoint);
         Ok(())
     }
 
@@ -188,12 +198,12 @@ impl MountNode {
         self.children.lock().get(&mountpoint.key()).cloned()
     }
 
-    /// Get the root Dentry_ of this mount node.
+    /// Get the root `Dentry_` of this mount node.
     pub fn root_dentry(&self) -> &Arc<Dentry_> {
         &self.root_dentry
     }
 
-    /// Try to get the mountpoint Dentry_ of this mount node.
+    /// Try to get the mountpoint `Dentry_` of this mount node.
     pub fn mountpoint_dentry(&self) -> Option<Arc<Dentry_>> {
         self.mountpoint_dentry.read().clone()
     }
@@ -202,9 +212,9 @@ impl MountNode {
     ///
     /// In some cases we may need to reset the mountpoint of
     /// the created MountNode, such as move mount.
-    pub fn set_mountpoint_dentry(&self, inner: Arc<Dentry_>) {
+    pub fn set_mountpoint_dentry(&self, inner: &Arc<Dentry_>) {
         let mut mountpoint_dentry = self.mountpoint_dentry.write();
-        *mountpoint_dentry = Some(inner);
+        *mountpoint_dentry = Some(inner.clone());
     }
 
     /// Flushes all pending filesystem metadata and cached file data to the device.
@@ -228,9 +238,9 @@ impl MountNode {
     ///
     /// In some cases we may need to reset the parent of
     /// the created MountNode, such as move mount.
-    pub fn set_parent(&self, mount_node: Arc<MountNode>) {
+    pub fn set_parent(&self, mount_node: &Arc<MountNode>) {
         let mut parent = self.parent.write();
-        *parent = Some(Arc::downgrade(&mount_node));
+        *parent = Some(Arc::downgrade(mount_node));
     }
 
     /// Get strong reference to self.

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -53,6 +53,7 @@ use crate::syscall::{
     madvise::sys_madvise,
     mkdir::{sys_mkdir, sys_mkdirat},
     mmap::sys_mmap,
+    mount::sys_mount,
     mprotect::sys_mprotect,
     munmap::sys_munmap,
     nanosleep::{sys_clock_nanosleep, sys_nanosleep},
@@ -214,6 +215,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ARCH_PRCTL = 158       => sys_arch_prctl(args[..2], &mut context);
     SYS_CHROOT = 161           => sys_chroot(args[..1]);
     SYS_SYNC = 162             => sys_sync(args[..0]);
+    SYS_MOUNT = 165            => sys_mount(args[..5]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);
     SYS_TIME = 201             => sys_time(args[..1]);
     SYS_FUTEX = 202            => sys_futex(args[..6]);

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -217,7 +217,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_CHROOT = 161           => sys_chroot(args[..1]);
     SYS_SYNC = 162             => sys_sync(args[..0]);
     SYS_MOUNT = 165            => sys_mount(args[..5]);
-    SYS_UMOUNT = 166           => sys_umount(args[..2]);
+    SYS_UMOUNT2 = 166           => sys_umount(args[..2]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);
     SYS_TIME = 201             => sys_time(args[..1]);
     SYS_FUTEX = 202            => sys_futex(args[..6]);

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -103,6 +103,7 @@ use crate::syscall::{
     time::sys_time,
     truncate::{sys_ftruncate, sys_truncate},
     umask::sys_umask,
+    umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
     utimens::sys_utimensat,
@@ -216,6 +217,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_CHROOT = 161           => sys_chroot(args[..1]);
     SYS_SYNC = 162             => sys_sync(args[..0]);
     SYS_MOUNT = 165            => sys_mount(args[..5]);
+    SYS_UMOUNT = 166           => sys_umount(args[..2]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);
     SYS_TIME = 201             => sys_time(args[..1]);
     SYS_FUTEX = 202            => sys_futex(args[..6]);

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -59,6 +59,7 @@ mod lseek;
 mod madvise;
 mod mkdir;
 mod mmap;
+mod mount;
 mod mprotect;
 mod munmap;
 mod nanosleep;

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -109,6 +109,7 @@ mod tgkill;
 mod time;
 mod truncate;
 mod umask;
+mod umount;
 mod uname;
 mod unlink;
 mod utimens;

--- a/kernel/aster-nix/src/syscall/mount.rs
+++ b/kernel/aster-nix/src/syscall/mount.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{
+    fs::{
+        fs_resolver::{FsPath, AT_FDCWD},
+        path::Dentry,
+    },
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
+};
+
+pub fn sys_mount(
+    devname_addr: Vaddr,
+    dirname_addr: Vaddr,
+    fstype_addr: Vaddr,
+    flags: u64,
+    data: Vaddr,
+) -> Result<SyscallReturn> {
+    let devname = read_cstring_from_user(devname_addr, MAX_FILENAME_LEN)?;
+    let dirname = read_cstring_from_user(dirname_addr, MAX_FILENAME_LEN)?;
+    let mount_flags = MountFlags::from_bits_truncate(flags as u32);
+    debug!(
+        "devname = {:?}, dirname = {:?}, fstype = 0x{:x}, flags = {:?}, data = 0x{:x}",
+        devname, dirname, fstype_addr, mount_flags, data,
+    );
+
+    let current = current!();
+    let target_dentry = {
+        let dirname = dirname.to_string_lossy();
+        if dirname.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "dirname is empty");
+        }
+        let fs_path = FsPath::new(AT_FDCWD, dirname.as_ref())?;
+        current.fs().read().lookup(&fs_path)?
+    };
+
+    if mount_flags.contains(MountFlags::MS_REMOUNT) && mount_flags.contains(MountFlags::MS_BIND) {
+        do_reconfigure_mnt()?;
+    } else if mount_flags.contains(MountFlags::MS_REMOUNT) {
+        do_remount()?;
+    } else if mount_flags.contains(MountFlags::MS_BIND) {
+        do_loopback(
+            devname.clone(),
+            target_dentry.clone(),
+            mount_flags.contains(MountFlags::MS_REC),
+        )?;
+    } else if mount_flags.contains(MountFlags::MS_SHARED)
+        | mount_flags.contains(MountFlags::MS_PRIVATE)
+        | mount_flags.contains(MountFlags::MS_SLAVE)
+        | mount_flags.contains(MountFlags::MS_UNBINDABLE)
+    {
+        do_change_type()?;
+    } else if mount_flags.contains(MountFlags::MS_MOVE) {
+        do_move_mount_old(devname, target_dentry)?;
+    } else {
+        do_new_mount(devname, fstype_addr, target_dentry)?;
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn do_reconfigure_mnt() -> Result<()> {
+    todo!()
+}
+
+fn do_remount() -> Result<()> {
+    todo!()
+}
+
+/// Bind a mount to a new location.
+fn do_loopback(old_name: CString, new_dentry: Arc<Dentry>, recursive: bool) -> Result<()> {
+    let current = current!();
+    let old_dentry = {
+        let old_name = old_name.to_string_lossy();
+        if old_name.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "old_name is empty");
+        }
+        let fs_path = FsPath::new(AT_FDCWD, old_name.as_ref())?;
+        current.fs().read().lookup(&fs_path)?
+    };
+
+    let new_mount = old_dentry.do_loopback(recursive);
+    new_mount.graft_mount_tree(new_dentry.clone())?;
+    Ok(())
+}
+
+fn do_change_type() -> Result<()> {
+    todo!()
+}
+
+/// Move a mount from old location to new location.
+fn do_move_mount_old(old_name: CString, new_dentry: Arc<Dentry>) -> Result<()> {
+    let current = current!();
+    let old_dentry = {
+        let old_name = old_name.to_string_lossy();
+        if old_name.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "old_name is empty");
+        }
+        let fs_path = FsPath::new(AT_FDCWD, old_name.as_ref())?;
+        current.fs().read().lookup(&fs_path)?
+    };
+
+    if !old_dentry.is_root_of_mount() {
+        return_errno_with_message!(Errno::EINVAL, "old_name can not be moved");
+    };
+    if old_dentry.mount_node().parent().is_none() {
+        return_errno_with_message!(Errno::EINVAL, "old_name can not be moved");
+    }
+
+    old_dentry
+        .mount_node()
+        .graft_mount_tree(new_dentry.clone())?;
+
+    Ok(())
+}
+
+/// Mount a new filesystem.
+fn do_new_mount(devname: CString, fs_type: Vaddr, target_dentry: Arc<Dentry>) -> Result<()> {
+    let fs_type = read_cstring_from_user(fs_type, MAX_FILENAME_LEN)?;
+    if fs_type.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "fs_type is empty");
+    }
+    let fs_type = fs_type.to_str().unwrap();
+    let fs = crate::fs::get_fs(fs_type)?;
+    target_dentry.mount(fs)?;
+    Ok(())
+}
+
+bitflags! {
+    struct MountFlags: u32 {
+        const MS_RDONLY = 1;              /* Mount read-only */
+        const MS_NOSUID = 1<<1;           /* Ignore suid and sgid bits */
+        const MS_NODEV = 1<<2;            /* Disallow access to device special files */
+        const MS_NOEXEC = 1<<3;           /* Disallow program execution */
+        const MS_SYNCHRONOUS = 1<<4;      /* Writes are synced at once */
+        const MS_REMOUNT = 1<<5;          /* Alter flags of a mounted FS */
+        const MS_MANDLOCK = 1<<6;         /* Allow mandatory locks on an FS */
+        const MS_DIRSYNS = 1<<7;          /* Directory modifications are synchronous */
+        const MS_NOSYMFOLLOW = 1<<8;      /* Do not follow symlinks */
+        const MS_NOATIME = 1<<10;         /* Do not update access times. */
+        const MS_NODIRATIME = 1<<11;      /* Do not update directory access times. */
+        const MS_BIND = 1<<12;            /* Bind directory at different place. */
+        const MS_MOVE = 1<<13;            /* Move mount from old to new. */
+        const MS_REC = 1<<14;
+        const MS_VERBOSE = 1<<15;         /* War is peace. Verbosity is silence. MS_VERBOSE is deprecated. */
+
+        const MS_SILENT = 1<<15;
+        const MS_POSIXACL = 1<<16;        /* VFS does not apply the umask. */
+        const MS_UNBINDABLE = 1<<17;      /* Change to unbindable. */
+        const MS_PRIVATE = 1<<18; 	      /* Change to private. */
+        const MS_SLAVE = 1<<19;           /* Change to slave. */
+        const MS_SHARED = 1<<20;          /* Change to shared. */
+        const MS_RELATIME = 1<<21; 	      /* Update atime relative to mtime/ctime. */
+        const MS_KERNMOUNT = 1<<22;       /* This is a kern_mount call. */
+    }
+}

--- a/kernel/aster-nix/src/syscall/umount.rs
+++ b/kernel/aster-nix/src/syscall/umount.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{
+    fs::fs_resolver::{FsPath, AT_FDCWD},
+    prelude::*,
+    syscall::constants::MAX_FILENAME_LEN,
+    util::read_cstring_from_user,
+};
+
+pub fn sys_umount(path_addr: Vaddr, flags: u64) -> Result<SyscallReturn> {
+    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let umount_flags = UmountFlags::from_bits_truncate(flags as u32);
+    debug!("path = {:?}, flags = {:?}", path, umount_flags);
+
+    umount_flags.check_unsupported_flags()?;
+
+    let current = current!();
+    let path = path.to_string_lossy();
+    if path.is_empty() {
+        return_errno_with_message!(Errno::ENOENT, "path is empty");
+    }
+    let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
+
+    let target_dentry = if umount_flags.contains(UmountFlags::UMOUNT_NOFOLLOW) {
+        current.fs().read().lookup_no_follow(&fs_path)?
+    } else {
+        current.fs().read().lookup(&fs_path)?
+    };
+
+    target_dentry.umount()?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+bitflags! {
+    struct UmountFlags: u32 {
+        const MNT_FORCE = 0x00000001;	/* Attempt to forcibily umount */
+        const MNT_DETACH = 0x00000002;	/* Just detach from the tree */
+        const MNT_EXPIRE = 0x00000004;	/* Mark for expiry */
+        const UMOUNT_NOFOLLOW = 0x00000008;	/* Don't follow symlink on umount */
+    }
+}
+
+impl UmountFlags {
+    fn check_unsupported_flags(&self) -> Result<()> {
+        let supported_flags = UmountFlags::MNT_FORCE
+            | UmountFlags::MNT_DETACH
+            | UmountFlags::MNT_EXPIRE
+            | UmountFlags::UMOUNT_NOFOLLOW;
+        let unsupported_flags = *self - supported_flags;
+        if !unsupported_flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported flags");
+        }
+        Ok(())
+    }
+}

--- a/kernel/aster-nix/src/syscall/umount.rs
+++ b/kernel/aster-nix/src/syscall/umount.rs
@@ -28,17 +28,17 @@ pub fn sys_umount(path_addr: Vaddr, flags: u64) -> Result<SyscallReturn> {
         current.fs().read().lookup(&fs_path)?
     };
 
-    target_dentry.umount()?;
+    target_dentry.unmount()?;
 
     Ok(SyscallReturn::Return(0))
 }
 
 bitflags! {
     struct UmountFlags: u32 {
-        const MNT_FORCE = 0x00000001;	/* Attempt to forcibily umount */
-        const MNT_DETACH = 0x00000002;	/* Just detach from the tree */
-        const MNT_EXPIRE = 0x00000004;	/* Mark for expiry */
-        const UMOUNT_NOFOLLOW = 0x00000008;	/* Don't follow symlink on umount */
+        const MNT_FORCE       = 0x00000001;	// Attempt to forcibily umount.
+        const MNT_DETACH      = 0x00000002;	// Just detach from the tree.
+        const MNT_EXPIRE      = 0x00000004;	// Mark for expiry.
+        const UMOUNT_NOFOLLOW = 0x00000008;	// Don't follow symlink on umount.
     }
 }
 

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -18,6 +18,7 @@ TESTS ?= \
 	lseek_test \
 	mkdir_test \
 	mmap_test \
+	mount_test \
 	open_create_test \
 	open_test \
 	pty_test \

--- a/regression/syscall_test/blocklists/mount_test
+++ b/regression/syscall_test/blocklists/mount_test
@@ -1,0 +1,17 @@
+MountTest.MountBadFilesystem
+MountTest.MountInvalidTarget
+MountTest.MountPermDenied
+MountTest.UmountPermDenied
+MountTest.MountOverBusy
+MountTest.OpenFileBusy
+MountTest.UmountDetach
+MountTest.ActiveSubmountBusy
+MountTest.MountTmpfs
+MountTest.MountTmpfsMagicValIgnored
+MountTest.NullData
+MountTest.MountReadonly
+MountTest.MountNoAtime
+MountTest.MountNoExec
+MountTest.RenameRemoveMountPoint
+MountTest.MountFuseFilesystemNoDevice
+MountTest.MountFuseFilesystem


### PR DESCRIPTION
This PR introduces incomplete implementations of the `mount` and `umount` system calls. The primary changes are as follows:

# `syscall mount`

The `syscall mount` is a complex system call with various functionalities. A call to **mount()** performs one of several operations based on the bits specified in _mountflags_. The operation to perform is determined by testing the bits set in _mountflags_, in the following order:

- **Modify mount options of a file system**（do_reconfigure_mnt）: _mountflags_ includes **MS_REMOUNT** and **MS_BIND**
- **Remount an existing mount**(do_remount): _mountflags_ includes **MS_REMOUNT**
- **Create a bind mount**(do_loopback): _mountflags_ includes **MS_BIND**
- **Change the propagation type of an existing mount**(do_change_type): _mountflags_ includes one of **MS_SHARED**, **MS_PRIVATE**, **MS_SLAVE**, or **MS_UNBINDABLE**
- **Move an existing mount to a new location**(do_move_mount_old): _mountflags_ includes **MS_MOVE**
- **Create a new mount**(do_new_mount): _mountflags_ includes none of the above flags

This PR primarily implements the `do_loopback`, `do_move_mount_old`, and `do_new_mount` functions.

## `do_loopback`

This function handles the main implementation for bind mounts. A bind mount makes a file or a directory subtree visible at another point within the single directory hierarchy. By default, only the directory itself is mounted. If the **MS_REC** flag is specified, a recursive bind mount operation is performed, making all submounts under the _source_ subtree (except unbindable mounts) also bind mounted at the corresponding location in the _target_ subtree. The primary method involves copying the subtree of the directory to be bind-mounted and grafting it to another directory's subtree.

## `do_move_mount_old`

This function moves an existing mount by detaching it from its current location in the mount tree and grafting it onto a new directory's subtree.

## `do_new_mount`

This function mounts a new file system. Currently, I only supports mounting ext2 and exfat file systems due to limited support for file system types and device names. The implementation uses the following function to get the file system type and then perform the mount operation:

```rust
pub fn get_fs(fs_type: &str) -> Result<Arc<dyn FileSystem>> {
    match fs_type {
        "ext2" => {
            if let Ok(block_device_ext2) = start_block_device("vext2") {
                let ext2_fs = Ext2::open(block_device_ext2).unwrap();
                Ok(ext2_fs)
            } else {
                return_errno_with_message!(Errno::EINVAL, "Ext2 fs does not exist")
            }
        }
        "exfat" => {
            if let Ok(block_device_exfat) = start_block_device("vexfat") {
                let exfat_fs =
                    ExfatFS::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
                Ok(exfat_fs)
            } else {
                return_errno_with_message!(Errno::EINVAL, "Exfat fs dose not exist")
            }
        }
        _ => return_errno_with_message!(Errno::EINVAL, "Invalid fs type"),
    }
}
```

# `syscall umount`

The `syscall umount` mainly handles the unmounting of a mounted file system using the `umount` method defined in the `impl Dentry`. Further functionality requires additional features like mount namespace.

# VFS Layer Changes

The VFS layer includes the following new methods:

## `MountNode`

- **clone_mount**: Clones a mount node with a root `Dentry_`, setting the parent and children manually.
- **copy_mount_tree**: Copies a mount tree rooted at a given `Dentry_`, maintaining the same structure as the original tree.
- **detach_mount**: Detaches a mount node from its parent.
- **attach_mount**: Attaches a mount node to the mountpoint.
- **graft_mount_tree**: Grafts a mount tree to the mountpoint.

## `Dentry_`

- **is_subdir**: Determines if one `Dentry_` is a subdirectory of another.

## `Dentry`

- **do_loopback**: Used in bind mount implementation to copy the current directory or all submounts recursively based on the recursive flag.

# Testing

Tests for `syscall mount` and `umount` are included in `mount_test`. Both require `CAP_SYS_ADMIN` capabilities, necessitating support for capabilities to run the tests. To test, run the following commands in the shell:

```shell
mount --bind dir1 dir2 # bind mount, makes dir1's contents visible in dir2
mount --move dir1 dir2 # dir1 must be a mount point, moves the ext2 file system originally at /ext2 to dir2 
mount -t ext2 vext2 dir # currently only supports ext2 and exfat file systems, devname can be vext2 or vexfat, creates an ext2 or exfat file system mounted at dir.
```

