### PR TITLE
Let OSDK print source line stack traces after panicking

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -27,6 +27,7 @@ args = "$(./tools/qemu_args.sh test)"
 
 [scheme."microvm"]
 boot.method = "qemu-direct"
+build.strip_elf = true
 qemu.args = "$(./tools/qemu_args.sh microvm)"
 
 [scheme."iommu"]

--- a/docs/src/osdk/reference/commands/build.md
+++ b/docs/src/osdk/reference/commands/build.md
@@ -54,6 +54,8 @@ To display the GRUB menu if booting with GRUB
 Path of QEMU
 - `--qemu-args <ARGS>`:
 Extra arguments for running QEMU
+- `--strip-elf`:
+Whether to strip the built kernel ELF using `rust-strip`
 
 ## Examples
 

--- a/docs/src/osdk/reference/manifest.md
+++ b/docs/src/osdk/reference/manifest.md
@@ -43,6 +43,7 @@ supported_archs = ["x86_64"]# List of strings, that the arch the schema can appl
 [build]
 features = []               # List of strings, the same as Cargo
 profile = "dev"             # String, the same as Cargo
+strip_elf = false           # Whether to strip the built kernel ELF using `rust-strip`
 [boot]
 method = "qemu-direct"      # "grub-rescue-iso"/"qemu-direct"/"grub-qcow2"
 kcmd_args = []              # <1>

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -132,6 +132,8 @@ dependencies = [
  "linux-bzimage-builder",
  "log",
  "quote",
+ "regex",
+ "rev_buf_reader",
  "serde",
  "serde_json",
  "sha2",
@@ -321,7 +323,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "linux-bzimage-builder"
 version = "0.1.0"
-source = "git+https://github.com/asterinas/asterinas?rev=cc4111c#cc4111cab227f188a1170dea0aa729b410b1b509"
+source = "git+https://github.com/asterinas/asterinas?rev=c9b66bd#c9b66bddd6b77dcddcbe1b66337a76ee1e16b640"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -388,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -414,6 +416,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rev_buf_reader"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0f2e47e00e29920959826e2e1784728a3780d1a784247be5257258cc75f910"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ryu"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -29,6 +29,8 @@ indexmap = "2.2.1"
 lazy_static = "1.4.0"
 log = "0.4.20"
 quote = "1.0.35"
+regex = "1.10.4"
+rev_buf_reader = "0.3.0"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 sha2 = "0.10.8"

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -265,6 +265,12 @@ pub struct CommonArgs {
     )]
     pub linux_x86_legacy_boot: bool,
     #[arg(
+        long = "strip-elf",
+        help = "Strip the built kernel ELF file for a smaller size",
+        global = true
+    )]
+    pub strip_elf: bool,
+    #[arg(
         long = "target-arch",
         value_name = "ARCH",
         help = "The architecture to build for",

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use bin::strip_elf_for_qemu;
+use bin::make_elf_for_qemu;
 
 use super::util::{cargo, profile_name_adapter, COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH};
 use crate::{
@@ -169,10 +169,11 @@ pub fn do_build(
                 action,
             );
             bundle.consume_vm_image(bootdev_image);
+            bundle.consume_aster_bin(aster_elf);
         }
         BootMethod::QemuDirect => {
-            let stripped_elf = strip_elf_for_qemu(&osdk_output_directory, &aster_elf);
-            bundle.consume_aster_bin(stripped_elf);
+            let qemu_elf = make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf);
+            bundle.consume_aster_bin(qemu_elf);
         }
         BootMethod::GrubQcow2 => {
             todo!()

--- a/osdk/src/config/scheme/action.rs
+++ b/osdk/src/config/scheme/action.rs
@@ -13,6 +13,7 @@ pub enum ActionChoice {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuildScheme {
     pub profile: Option<String>,
+    #[serde(default)]
     pub features: Vec<String>,
     #[serde(default)]
     pub no_default_features: bool,
@@ -20,11 +21,14 @@ pub struct BuildScheme {
     /// [Linux legacy x86 32-bit boot protocol](https://www.kernel.org/doc/html/v5.6/x86/boot.html)
     #[serde(default)]
     pub linux_x86_legacy_boot: bool,
+    #[serde(default)]
+    pub strip_elf: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Build {
     pub profile: String,
+    #[serde(default)]
     pub features: Vec<String>,
     #[serde(default)]
     pub no_default_features: bool,
@@ -32,6 +36,8 @@ pub struct Build {
     pub override_configs: Vec<String>,
     #[serde(default)]
     pub linux_x86_legacy_boot: bool,
+    #[serde(default)]
+    pub strip_elf: bool,
 }
 
 impl Default for Build {
@@ -42,6 +48,7 @@ impl Default for Build {
             no_default_features: false,
             override_configs: Vec::new(),
             linux_x86_legacy_boot: false,
+            strip_elf: false,
         }
     }
 }
@@ -61,6 +68,9 @@ impl Build {
         if common_args.linux_x86_legacy_boot {
             self.linux_x86_legacy_boot = true;
         }
+        if common_args.strip_elf {
+            self.strip_elf = true;
+        }
     }
 }
 
@@ -74,9 +84,12 @@ impl BuildScheme {
             features.extend(self.features.clone());
             features
         };
-        // no_default_features is not inherited
+        // `no_default_features` is not inherited
         if parent.linux_x86_legacy_boot {
             self.linux_x86_legacy_boot = true;
+        }
+        if parent.strip_elf {
+            self.strip_elf = true;
         }
     }
 
@@ -87,6 +100,7 @@ impl BuildScheme {
             no_default_features: self.no_default_features,
             override_configs: Vec::new(),
             linux_x86_legacy_boot: self.linux_x86_legacy_boot,
+            strip_elf: self.strip_elf,
         }
     }
 }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -2,7 +2,8 @@
 
 use std::{
     ffi::OsStr,
-    fs,
+    fs::{self, File},
+    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -205,6 +206,46 @@ pub fn get_current_crate_info() -> CrateInfo {
                 .trim_start_matches("(path+file://")
                 .trim_end_matches(')')
                 .to_string(),
+        }
+    }
+}
+
+/// Print source line stack trace if a panic is detected from QEMU log.
+///
+/// The source line is produced with the `addr2line` command using the PC values in the panic
+/// stack trace.
+pub fn trace_panic_from_log(qemu_log: File, bin_path: PathBuf) {
+    // We read last 500 lines since more than 100 layers of stack trace is unlikely.
+    let reader = rev_buf_reader::RevBufReader::new(qemu_log);
+    let lines: Vec<String> = reader.lines().take(500).map(|l| l.unwrap()).collect();
+    let mut trace_exists = false;
+    let mut stack_num = 0;
+    let pc_matcher = regex::Regex::new(r" - pc (0x[0-9a-fA-F]+)").unwrap();
+    let exe = bin_path.to_string_lossy();
+    let mut addr2line = Command::new("addr2line");
+    addr2line.args(["-e", &exe]);
+    let mut addr2line_proc = addr2line
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    for line in lines.into_iter().rev() {
+        if line.contains("printing stack trace:") {
+            println!("[OSDK] The kernel seems panicked. Parsing stack trace for source lines:");
+            trace_exists = true;
+        }
+        if trace_exists {
+            if let Some(cap) = pc_matcher.captures(&line) {
+                let pc = cap.get(1).unwrap().as_str();
+                let mut stdin = addr2line_proc.stdin.as_ref().unwrap();
+                stdin.write_all(pc.as_bytes()).unwrap();
+                stdin.write_all(b"\n").unwrap();
+                let mut line = String::new();
+                let mut stdout = BufReader::new(addr2line_proc.stdout.as_mut().unwrap());
+                stdout.read_line(&mut line).unwrap();
+                stack_num += 1;
+                println!("({: >3}) {}", stack_num, line.trim());
+            }
         }
     }
 }


### PR DESCRIPTION
In #836 the CI fails but cannot be reproduced locally. Since the PC address of each compilation varies, the current panic stack trace is pretty much not helpful in this case.

In this PR the OSDK will check the QEMU output and automatically print the source line stack trace for the user if the kernel panics.

Here's an example output.

```
[kernel] Hello world from kernel!


   _   ___ _____ ___ ___ ___ _  _   _   ___
  /_\ / __|_   _| __| _ \_ _| \| | /_\ / __|
 / _ \\__ \ | | | _||   /| || .` |/ _ \\__ \
/_/ \_\___/ |_| |___|_|_\___|_|\_/_/ \_\___/


[ERROR]: Uncaught panic!
panicked at /root/asterinas/kernel/aster-nix/src/process/process/job_control.rs:41:5:
a panic for testing
printing stack trace:
   1: fn 0xffffffff886f3dd0 - pc 0xffffffff886f3de8 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c04b0;

   2: fn 0xffffffff886f38d0 - pc 0xffffffff886f3d87 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c04c0;

   3: fn 0xffffffff88048030 - pc 0xffffffff8804803a / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0710;

   4: fn 0xffffffff888606f0 - pc 0xffffffff8886073f / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0720;

   5: fn 0xffffffff880f12a0 - pc 0xffffffff880f12d5 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0770;

   6: fn 0xffffffff880f12e0 - pc 0xffffffff880f133d / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c07c0;

   7: fn 0xffffffff884db6b0 - pc 0xffffffff884db6ed / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0840;

   8: fn 0xffffffff8851af00 - pc 0xffffffff8851afd8 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0870;

   9: fn 0xffffffff881f4a00 - pc 0xffffffff881f4b25 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c09a0;

  10: fn 0xffffffff884c80e0 - pc 0xffffffff884c832b / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0b10;

  11: fn 0xffffffff8804a4b0 - pc 0xffffffff8804a975 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0c90;

  12: fn 0xffffffff88472750 - pc 0xffffffff8847275e / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0f40;

  13: fn 0xffffffff88701ab0 - pc 0xffffffff88701ac6 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0f60;

  14: fn 0xffffffff882c9b00 - pc 0xffffffff882c9b0e / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0f80;

  15: fn 0xffffffff88701ab0 - pc 0xffffffff88701ac6 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0fb0;

  16: fn 0xffffffff886fdfb0 - pc 0xffffffff886fe014 / registers:

     rax                0x1; rdx 0xffffffff888e5058; rcx               0x16; rbx                0x0;
     rsi 0xffffffff888e4fc0; rdi 0xffff8000004c0678; rbp                0x0; rsp 0xffff8000004c0fd0;

[OSDK] The kernel seems panicked. Parsing source line stack trace:
(  1) /root/asterinas/framework/aster-frame/src/panicking.rs:90
(  2) /root/asterinas/framework/aster-frame/src/panicking.rs:45
(  3) 23xxnbp8ar4351kn:?
(  4) /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/cor4
(  5) 2objm4fch4xr17bm:?
(  6) /root/asterinas/kernel/aster-nix/src/process/process/job_control.rs:51
(  7) /root/asterinas/kernel/aster-nix/src/device/tty/mod.rs:220
(  8) /root/asterinas/kernel/aster-nix/src/process/process/session.rs:106
(  9) /root/asterinas/kernel/aster-nix/src/device/tty/mod.rs:219
( 10) /root/asterinas/kernel/aster-nix/src/process/process/mod.rs:138
( 11) /root/asterinas/kernel/aster-nix/src/lib.rs:110
( 12) /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/cor9
( 13) /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/all0
( 14) /root/asterinas/kernel/aster-nix/src/thread/kernel_thread.rs:38
( 15) /root/.rustup/toolchains/nightly-2024-01-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/all0
( 16) /root/asterinas/framework/aster-frame/src/task/task.rs:277
```