### PR TITLE
Add sys_creat

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -105,7 +105,7 @@ provided by Linux on x86-64 architecture.
 | 82      | rename           | ✅              |
 | 83      | mkdir            | ✅              |
 | 84      | rmdir            | ✅              |
-| 85      | creat            | ❌              |
+| 85      | creat            | ✅              |
 | 86      | link             | ✅              |
 | 87      | unlink           | ✅              |
 | 88      | symlink          | ✅              |

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -56,7 +56,7 @@ use crate::syscall::{
     mprotect::sys_mprotect,
     munmap::sys_munmap,
     nanosleep::{sys_clock_nanosleep, sys_nanosleep},
-    open::{sys_open, sys_openat},
+    open::{sys_creat, sys_open, sys_openat},
     pause::sys_pause,
     pipe::{sys_pipe, sys_pipe2},
     poll::sys_poll,
@@ -172,6 +172,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RENAME = 82            => sys_rename(args[..2]);
     SYS_MKDIR = 83             => sys_mkdir(args[..2]);
     SYS_RMDIR = 84             => sys_rmdir(args[..1]);
+    SYS_CREAT = 85             => sys_creat(args[..2]);
     SYS_LINK = 86              => sys_link(args[..2]);
     SYS_UNLINK = 87            => sys_unlink(args[..1]);
     SYS_SYMLINK = 88           => sys_symlink(args[..2]);

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -50,6 +50,12 @@ pub fn sys_open(path_addr: Vaddr, flags: u32, mode: u16) -> Result<SyscallReturn
     self::sys_openat(AT_FDCWD, path_addr, flags, mode)
 }
 
+pub fn sys_creat(path_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
+    // CreationFlags::O_CREAT | AccessMode::O_WRONLY | CreationFlags::O_TRUNC;
+    let flags: u32 = 0x241;
+    self::sys_openat(AT_FDCWD, path_addr, flags, mode)
+}
+
 /// File for output busybox ash log.
 struct BusyBoxTraceFile;
 

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -10,6 +10,7 @@ TESTS ?= \
 	chmod_test \
 	chown_test \
 	chroot_test \
+	creat_test \
 	epoll_test \
 	eventfd_test \
 	fsync_test \

--- a/regression/syscall_test/blocklists/creat_test
+++ b/regression/syscall_test/blocklists/creat_test
@@ -1,0 +1,1 @@
+CreatTest.CreatTruncatesExistingFile


### PR DESCRIPTION
This PR adds `sys_creat`, a wrapper around `sys_openat`, enhancing the compatibility and usability of file creation operations across different platforms. `sys_creat` function internally calls `sys_openat` with flags `O_CREAT | O_WRONLY | O_TRUNC`.

`sys_creat` simplifies the process of file creation by abstracting away the more complex `sys_openat` interface. Users can create or truncate files directly without needing to specify additional flags or navigate through directory file descriptors.