### PR TITLE
Bring OSDK's full support of QCOW2 booting

### DIFF
--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -219,17 +219,30 @@ impl Bundle {
             BootMethod::GrubRescueIso => {
                 let vm_image = self.manifest.vm_image.as_ref().unwrap();
                 assert!(matches!(vm_image.typ(), AsterVmImageType::GrubIso(_)));
+                let bootdev_opts = action
+                    .qemu
+                    .bootdev_append_options
+                    .as_deref()
+                    .unwrap_or(",index=2,media=cdrom");
                 qemu_cmd.arg("-drive").arg(format!(
-                    "file={},index=2,media=cdrom",
-                    self.path.join(vm_image.path()).to_string_lossy()
+                    "file={},format=raw{}",
+                    self.path.join(vm_image.path()).to_string_lossy(),
+                    bootdev_opts,
                 ));
             }
             BootMethod::GrubQcow2 => {
                 let vm_image = self.manifest.vm_image.as_ref().unwrap();
                 assert!(matches!(vm_image.typ(), AsterVmImageType::Qcow2(_)));
+                // FIXME: this doesn't work for regular QEMU, but may work for TDX.
+                let bootdev_opts = action
+                    .qemu
+                    .bootdev_append_options
+                    .as_deref()
+                    .unwrap_or(",if=virtio");
                 qemu_cmd.arg("-drive").arg(format!(
-                    "file={},index=0,media=disk,format=qcow2",
-                    self.path.join(vm_image.path()).to_string_lossy()
+                    "file={},format=qcow2{}",
+                    self.path.join(vm_image.path()).to_string_lossy(),
+                    bootdev_opts,
                 ));
             }
         };

--- a/osdk/src/bundle/vm_image.rs
+++ b/osdk/src/bundle/vm_image.rs
@@ -72,4 +72,8 @@ impl AsterVmImage {
             sha256sum: self.sha256sum,
         }
     }
+
+    pub fn aster_version(&self) -> &String {
+        &self.aster_version
+    }
 }

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -310,6 +310,13 @@ pub struct CommonArgs {
     )]
     pub boot_method: Option<BootMethod>,
     #[arg(
+        long = "bootdev-append-options",
+        help = "Additional QEMU `-drive` options for the boot device",
+        value_name = "OPTIONS",
+        global = true
+    )]
+    pub bootdev_append_options: Option<String>,
+    #[arg(
         long = "display-grub-menu",
         help = "Display the GRUB menu if booting with GRUB",
         global = true

--- a/osdk/src/commands/build/qcow2.rs
+++ b/osdk/src/commands/build/qcow2.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::process;
+
+use crate::{
+    bundle::{
+        file::BundleFile,
+        vm_image::{AsterQcow2ImageMeta, AsterVmImage, AsterVmImageType},
+    },
+    error_msg,
+};
+
+pub fn convert_iso_to_qcow2(iso: AsterVmImage) -> AsterVmImage {
+    let AsterVmImageType::GrubIso(meta) = iso.typ() else {
+        panic!("Expected a GRUB ISO image, but got: {:?}", iso.typ());
+    };
+    let iso_path = iso.path();
+    let qcow2_path = iso_path.with_extension("qcow2");
+    // Convert the ISO to QCOW2 using `qemu-img`.
+    let mut qemu_img = process::Command::new("qemu-img");
+    qemu_img.args([
+        "convert",
+        "-O",
+        "qcow2",
+        iso_path.to_str().unwrap(),
+        qcow2_path.to_str().unwrap(),
+    ]);
+    info!("Converting the ISO to QCOW2 using {:#?}", qemu_img);
+    if !qemu_img.status().unwrap().success() {
+        error_msg!("Failed to convert the ISO to QCOW2: {:?}", qemu_img);
+        process::exit(1);
+    }
+    AsterVmImage::new(
+        qcow2_path,
+        AsterVmImageType::Qcow2(AsterQcow2ImageMeta {
+            grub_version: meta.grub_version.clone(),
+        }),
+        iso.aster_version().clone(),
+    )
+}

--- a/osdk/src/config/mod.rs
+++ b/osdk/src/config/mod.rs
@@ -72,6 +72,9 @@ fn apply_args_before_finalize(action_scheme: &mut ActionScheme, args: &CommonArg
         if let Some(path) = &args.qemu_exe {
             qemu.path = Some(path.clone());
         }
+        if let Some(bootdev_options) = &args.bootdev_append_options {
+            qemu.bootdev_append_options = Some(bootdev_options.clone());
+        }
     }
 }
 


### PR DESCRIPTION
`grub-qcow2` will fail. I don't know why.

```
BdsDxe: failed to load Boot0001 "UEFI QEMU DVD-ROM QM00005 " from PciRoot(0x0)/Pci(0x1F,0x2)/Sata(0x2,0xFFFF,0x0): Not Found
```