### PR TITLE
Declare `kernel_task_entry` as `extern "C"`

### DIFF
--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -272,7 +272,7 @@ impl TaskOptions {
     pub fn build(self) -> Result<Arc<Task>> {
         /// all task will entering this function
         /// this function is mean to executing the task_fn in Task
-        extern "sysv64" fn kernel_task_entry() {
+        extern "C" fn kernel_task_entry() {
             let current_task = current_task()
                 .expect("no current task, it should have current task in kernel task entry");
             current_task.func.call(());


### PR DESCRIPTION
~~It seems `sysv64` is not available on some architectures, for example, RISC-V (https://godbolt.org/z/oqbfb6Er4). So for such architectures, other ABIs are needed instead.~~

~~So, a specific ABI should not appear outside `arch` since it's architecture-dependent. For this reason, this PR introduces a macro `export_functions` to add ABI specification to the functions that needs to be exposed out of Rust.~~

Update:

Declare `kernel_task_entry` as `extern "C"` instead.