### PR TITLE
Avoid creating linear mappings with the SHARED flag set

### DIFF
--- a/framework/aster-frame/src/trap/handler.rs
+++ b/framework/aster-frame/src/trap/handler.rs
@@ -216,7 +216,7 @@ fn handle_kernel_page_fault(f: &TrapFrame) {
     // Do the mapping
     let page_table = KERNEL_PAGE_TABLE
         .get()
-        .expect("The kernel page table is not initialized when kernel page fault happens");
+        .expect("kernel page fault: the kernel page table is not initialized");
     let vaddr = (page_fault_vaddr as usize).align_down(PAGE_SIZE);
     let paddr = vaddr - LINEAR_MAPPING_BASE_VADDR;
 
@@ -225,7 +225,6 @@ fn handle_kernel_page_fault(f: &TrapFrame) {
     //    mapping of physical memory.
     // 2. We map the address to the correct physical page with the correct flags, where the
     //    correctness follows the semantics of the direct mapping of physical memory.
-    // Do the mapping
     unsafe {
         page_table
             .map(
@@ -234,10 +233,7 @@ fn handle_kernel_page_fault(f: &TrapFrame) {
                 PageProperty {
                     flags: PageFlags::RW,
                     cache: CachePolicy::Uncacheable,
-                    #[cfg(not(feature = "intel_tdx"))]
                     priv_flags: PrivFlags::GLOBAL,
-                    #[cfg(feature = "intel_tdx")]
-                    priv_flags: PrivFlags::SHARED | PrivFlags::GLOBAL,
                 },
             )
             .unwrap();


### PR DESCRIPTION
We should not set the shared flag when extending the linear mapping in the kernel page fault handler because:
 1. To maximize security, pages should not be shared by default. Instead, they must be set to shared on request and explicitly.
 2. The linear mapping created at boot time does not have the shared flag set. Removing the shared flag is necessary for better consistency.
 3. The shared flag was mistakenly introduced in #713. It's a refactor PR and should not change the semantics here, as confirmed by @junyang-zh in https://github.com/asterinas/asterinas/pull/713#discussion_r1616551153.