### PR TITLE
Add syscall creat and solve the memory shortage problem in CI

### DIFF
--- a/.github/workflows/kernel_test.yml
+++ b/.github/workflows/kernel_test.yml
@@ -80,6 +80,6 @@ jobs:
         id: syscall_test_at_exfat_linux
         run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
         
-      - name: Regression Test (Multiboot2)
+      - name: Regression Test (Linux EFI Handover Boot Protocol)
         id: regression_test_linux
-        run: make run AUTO_TEST=regression ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1
+        run: make run AUTO_TEST=regression ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1

--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -15,7 +15,7 @@ support the loading of Linux kernel modules.
 ## System Calls
 
 At the time of writing,
-Asterinas implements 130 out of the 310+ system calls
+Asterinas implements 138 out of the 310+ system calls
 provided by Linux on x86-64 architecture.
 
 | Numbers | Names            | Is Implemented  |
@@ -49,15 +49,15 @@ provided by Linux on x86-64 architecture.
 | 26      | msync            | ❌              |
 | 27      | mincore          | ❌              |
 | 28      | madvise          | ✅              |
-| 29      | shmget           | ✅              |
-| 30      | shmat            | ✅              |
-| 31      | shmctl           | ✅              |
+| 29      | shmget           | ❌              |
+| 30      | shmat            | ❌              |
+| 31      | shmctl           | ❌              |
 | 32      | dup              | ✅              |
 | 33      | dup2             | ✅              |
 | 34      | pause            | ✅              |
 | 35      | nanosleep        | ✅              |
 | 36      | getitimer        | ❌              |
-| 37      | alarm            | ❌              |
+| 37      | alarm            | ✅              |
 | 38      | setitimer        | ❌              |
 | 39      | getpid           | ✅              |
 | 40      | sendfile         | ❌              |
@@ -96,8 +96,8 @@ provided by Linux on x86-64 architecture.
 | 73      | flock            | ❌              |
 | 74      | fsync            | ✅              |
 | 75      | fdatasync        | ❌              |
-| 76      | truncate         | ❌              |
-| 77      | ftruncate        | ❌              |
+| 76      | truncate         | ✅              |
+| 77      | ftruncate        | ✅              |
 | 78      | getdents         | ❌              |
 | 79      | getcwd           | ✅              |
 | 80      | chdir            | ✅              |
@@ -105,7 +105,7 @@ provided by Linux on x86-64 architecture.
 | 82      | rename           | ✅              |
 | 83      | mkdir            | ✅              |
 | 84      | rmdir            | ✅              |
-| 85      | creat            | ❌              |
+| 85      | creat            | ✅              |
 | 86      | link             | ✅              |
 | 87      | unlink           | ✅              |
 | 88      | symlink          | ✅              |
@@ -160,8 +160,8 @@ provided by Linux on x86-64 architecture.
 | 137     | statfs           | ✅              |
 | 138     | fstatfs          | ✅              |
 | 139     | sysfs            | ❌              |
-| 140     | getpriority      | ❌              |
-| 141     | setpriority      | ❌              |
+| 140     | getpriority      | ✅              |
+| 141     | setpriority      | ✅              |
 | 142     | sched_setparam   | ❌              |
 | 143     | sched_getparam   | ❌              |
 | 144     | sched_setscheduler | ❌            |

--- a/kernel/aster-nix/src/fs/fs_resolver.rs
+++ b/kernel/aster-nix/src/fs/fs_resolver.rs
@@ -114,7 +114,12 @@ impl FsResolver {
             Err(e) => return Err(e),
         };
 
+        if creation_flags.contains(CreationFlags::O_TRUNC) {
+            dentry.resize(0)?;
+        }
+
         let inode_handle = InodeHandle::new(dentry, access_mode, status_flags)?;
+
         Ok(inode_handle)
     }
 

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -56,7 +56,7 @@ use crate::syscall::{
     mprotect::sys_mprotect,
     munmap::sys_munmap,
     nanosleep::{sys_clock_nanosleep, sys_nanosleep},
-    open::{sys_open, sys_openat},
+    open::{sys_creat, sys_open, sys_openat},
     pause::sys_pause,
     pipe::{sys_pipe, sys_pipe2},
     poll::sys_poll,
@@ -172,6 +172,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RENAME = 82            => sys_rename(args[..2]);
     SYS_MKDIR = 83             => sys_mkdir(args[..2]);
     SYS_RMDIR = 84             => sys_rmdir(args[..1]);
+    SYS_CREAT = 85             => sys_creat(args[..2]);
     SYS_LINK = 86              => sys_link(args[..2]);
     SYS_UNLINK = 87            => sys_unlink(args[..1]);
     SYS_SYMLINK = 88           => sys_symlink(args[..2]);

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -6,7 +6,7 @@ use crate::{
         file_handle::FileLike,
         file_table::{FdFlags, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
-        utils::CreationFlags,
+        utils::{AccessMode, CreationFlags},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -47,6 +47,12 @@ pub fn sys_openat(
 }
 
 pub fn sys_open(path_addr: Vaddr, flags: u32, mode: u16) -> Result<SyscallReturn> {
+    self::sys_openat(AT_FDCWD, path_addr, flags, mode)
+}
+
+pub fn sys_creat(path_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
+    let flags =
+        AccessMode::O_WRONLY as u32 | CreationFlags::O_CREAT.bits() | CreationFlags::O_TRUNC.bits();
     self::sys_openat(AT_FDCWD, path_addr, flags, mode)
 }
 

--- a/osdk/src/commands/new/kernel.OSDK.toml.template
+++ b/osdk/src/commands/new/kernel.OSDK.toml.template
@@ -8,7 +8,7 @@ args = """\
     -machine q35,kernel-irqchip=split \
     -cpu Icelake-Server,+x2apic \
     --no-reboot \
-    -m 2G \
+    -m 8G \
     -smp 1 \
     -nographic \
     -serial chardev:mux \

--- a/osdk/src/commands/new/lib.OSDK.toml.template
+++ b/osdk/src/commands/new/lib.OSDK.toml.template
@@ -8,7 +8,7 @@ args = """\
     -machine q35,kernel-irqchip=split \
     -cpu Icelake-Server,+x2apic \
     --no-reboot \
-    -m 2G \
+    -m 8G \
     -smp 1 \
     -nographic \
     -serial chardev:mux \

--- a/osdk/src/config/unix_args.rs
+++ b/osdk/src/config/unix_args.rs
@@ -154,7 +154,7 @@ pub mod test {
         let key = get_key(string1, "=").unwrap();
         assert_eq!(key.as_str(), "init");
 
-        let string2 = "-m 2G";
+        let string2 = "-m 8G";
         let key = get_key(string2, " ").unwrap();
         assert_eq!(key.as_str(), "-m");
 
@@ -170,7 +170,7 @@ pub mod test {
     fn test_apply_kv_array() {
         let qemu_args = &[
             "-enable-kvm",
-            "-m 2G",
+            "-m 8G",
             "-device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,disable-legacy=on,disable-modern=off",
             "-device virtio-keyboard-pci,disable-legacy=on,disable-modern=off",
         ];

--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -10,6 +10,7 @@ TESTS ?= \
 	chmod_test \
 	chown_test \
 	chroot_test \
+	creat_test \
 	epoll_test \
 	eventfd_test \
 	fsync_test \

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -14,7 +14,7 @@ echo "[$1] Forwarded QEMU guest port: $RAND_PORT_NUM1->22; $RAND_PORT_NUM2->8080
 COMMON_QEMU_ARGS="\
     -cpu Icelake-Server,+x2apic \
     -smp ${SMP:-1} \
-    -m ${MEM:-2G} \
+    -m ${MEM:-8G} \
     --no-reboot \
     -nographic \
     -display none \


### PR DESCRIPTION
I accidentally shut down the previous pr.

After I add system calls, I do system call tests. When I run the command: `make run AUTO_TEST=syscall ENABLE_KVM=0 RELEASE=1`, it no longer runs correctly. This issue started occurring after the PR (Fix OSDK CI bugs & Build OSDK with stable channel in CI). This issue also comes up occasionally in github's CI tests. I reproduced the bug. The root cause is insufficient memory, increasing memory and cleaning previously compiled code in time can effectively solve this problem. Therefore, I increased the memory size and make clean code  in time. Then the test was able to run properly.  Review it please. @tatetian @StevenJiang1110 

![4ae35634295eab058fe15f4ff600876c_](https://github.com/asterinas/asterinas/assets/56211074/3d6c42a4-b288-471f-bb23-413439623f4e)