### PR TITLE
Extend socket options required for `ping`

### DIFF
--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -67,7 +67,7 @@ impl BoundDatagram {
                 return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
             }
             Some(Err(SendError::Unaddressable)) => {
-                return_errno_with_message!(Errno::EINVAL, "the destionation address is invalid")
+                return_errno_with_message!(Errno::EINVAL, "the destination address is invalid")
             }
             None => return_errno_with_message!(Errno::EMSGSIZE, "the message is too large"),
         }

--- a/kernel/aster-nix/src/net/socket/ip/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/mod.rs
@@ -4,6 +4,7 @@ use crate::net::iface::{IpAddress, IpEndpoint, Ipv4Address};
 
 mod common;
 mod datagram;
+pub mod options;
 pub mod stream;
 
 pub use datagram::DatagramSocket;

--- a/kernel/aster-nix/src/net/socket/ip/options.rs
+++ b/kernel/aster-nix/src/net/socket/ip/options.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::impl_socket_options;
+
+impl_socket_options!(
+    pub struct RetOpts(bool);
+    pub struct RecvErr(bool);
+    pub struct RecvTtl(bool);
+);

--- a/kernel/aster-nix/src/net/socket/options/mod.rs
+++ b/kernel/aster-nix/src/net/socket/options/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::time::Duration;
+
 use crate::{impl_socket_options, prelude::*};
 mod macros;
 
@@ -17,7 +19,11 @@ impl_socket_options!(
     pub struct ReusePort(bool);
     pub struct SendBuf(u32);
     pub struct RecvBuf(u32);
+    pub struct RcvTimeoOld(Duration);
+    pub struct SndTimeoOld(Duration);
+    pub struct TimestampOld(bool);
     pub struct Error(Option<crate::error::Error>);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
+    pub struct NoCheck(bool);
 );

--- a/kernel/aster-nix/src/util/net/options/ip.rs
+++ b/kernel/aster-nix/src/util/net/options/ip.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_rights::Full;
+
+use super::RawSocketOption;
+use crate::{
+    impl_raw_socket_option,
+    net::socket::ip::options::{RecvErr, RecvTtl, RetOpts},
+    prelude::*,
+    util::net::options::SocketOption,
+    vm::vmar::Vmar,
+};
+
+/// Socket level IP options.
+///
+/// The definition is from https://elixir.bootlin.com/linux/v6.0.9/source/include/uapi/linux/in.h#L94
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, TryFromInt, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
+enum CIpOptionName {
+    TOS = 1,
+    TTL = 2,
+    HDRINCL = 3,
+    OPTIONS = 4,
+    ROUTER_ALERT = 5,
+    RECVOPTS = 6,
+    RETOPTS = 7,
+    PKTINFO = 8,
+    PKTOPTIONS = 9,
+    MTU_DISCOVER = 10,
+    RECVERR = 11,
+    RECVTTL = 12,
+    RECVTOS = 13,
+    MTU = 14,
+    FREEBIND = 15,
+    IPSEC_POLICY = 16,
+    XFRM_POLICY = 17,
+    PASSSEC = 18,
+    TRANSPARENT = 19,
+    ORIGDSTADDR = 20,
+    MINTTL = 21,
+    NODEFRAG = 22,
+    CHECKSUM = 23,
+    BIND_ADDRESS_NO_PORT = 24,
+    RECVFRAGSIZE = 25,
+    RECVERR_RFC4884 = 26,
+}
+
+pub fn new_ip_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
+    let name = CIpOptionName::try_from(name)?;
+    match name {
+        CIpOptionName::RETOPTS => Ok(Box::new(RetOpts::new())),
+        CIpOptionName::RECVERR => Ok(Box::new(RecvErr::new())),
+        CIpOptionName::RECVTTL => Ok(Box::new(RecvTtl::new())),
+        _ => todo!(),
+    }
+}
+
+impl_raw_socket_option!(RetOpts);
+impl_raw_socket_option!(RecvErr);
+impl_raw_socket_option!(RecvTtl);

--- a/kernel/aster-nix/src/util/net/options/mod.rs
+++ b/kernel/aster-nix/src/util/net/options/mod.rs
@@ -55,11 +55,12 @@ use aster_rights::Full;
 
 use crate::{net::socket::options::SocketOption, prelude::*, vm::vmar::Vmar};
 
+mod ip;
 mod socket;
 mod tcp;
 mod utils;
 
-use self::{socket::new_socket_option, tcp::new_tcp_option};
+use self::{ip::new_ip_option, socket::new_socket_option, tcp::new_tcp_option};
 
 pub trait RawSocketOption: SocketOption {
     fn read_from_user(&mut self, vmar: &Vmar<Full>, addr: Vaddr, max_len: u32) -> Result<()>;
@@ -144,6 +145,7 @@ pub fn new_raw_socket_option(
     name: i32,
 ) -> Result<Box<dyn RawSocketOption>> {
     match level {
+        CSocketOptionLevel::SOL_IP => new_ip_option(name),
         CSocketOptionLevel::SOL_SOCKET => new_socket_option(name),
         CSocketOptionLevel::SOL_TCP => new_tcp_option(name),
         _ => todo!(),

--- a/kernel/aster-nix/src/util/net/options/socket.rs
+++ b/kernel/aster-nix/src/util/net/options/socket.rs
@@ -6,7 +6,8 @@ use super::RawSocketOption;
 use crate::{
     impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        Error, KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
+        Error, KeepAlive, Linger, NoCheck, RcvTimeoOld, RecvBuf, ReuseAddr, ReusePort, SendBuf,
+        SndTimeoOld, SocketOption, TimestampOld,
     },
     prelude::*,
     vm::vmar::Vmar,
@@ -28,6 +29,9 @@ enum CSocketOptionName {
     BROADCAST = 6,
     SNDBUF = 7,
     RCVBUF = 8,
+    RCVTIMEO_OLD = 20,
+    SNDTIMEO_OLD = 21,
+    TIMESTAMP_OLD = 29,
     SNDBUFFORCE = 32,
     RCVBUFFORCE = 33,
     KEEPALIVE = 9,
@@ -46,19 +50,27 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
     match name {
         CSocketOptionName::SNDBUF => Ok(Box::new(SendBuf::new())),
         CSocketOptionName::RCVBUF => Ok(Box::new(RecvBuf::new())),
+        CSocketOptionName::RCVTIMEO_OLD => Ok(Box::new(RcvTimeoOld::new())),
+        CSocketOptionName::SNDTIMEO_OLD => Ok(Box::new(SndTimeoOld::new())),
+        CSocketOptionName::TIMESTAMP_OLD => Ok(Box::new(TimestampOld::new())),
         CSocketOptionName::REUSEADDR => Ok(Box::new(ReuseAddr::new())),
         CSocketOptionName::ERROR => Ok(Box::new(Error::new())),
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
+        CSocketOptionName::NO_CHECK => Ok(Box::new(NoCheck::new())),
         _ => todo!(),
     }
 }
 
 impl_raw_socket_option!(SendBuf);
 impl_raw_socket_option!(RecvBuf);
+impl_raw_socket_option!(RcvTimeoOld);
+impl_raw_socket_option!(SndTimeoOld);
+impl_raw_socket_option!(TimestampOld);
 impl_raw_socket_option!(ReuseAddr);
 impl_raw_sock_option_get_only!(Error);
 impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
+impl_raw_socket_option!(NoCheck);


### PR DESCRIPTION
The command `ping` did some `setsockopts` before setting the socket and the follow-up `sendto`. 
Based on existing structure, I extend existing SOL_SOCKET options and also init the SOL_IP options. 
However, these options now seems to be only dummy options without actual effect.

This is a staged PR for only extending socket options, haven't port any other thing yet.
When try to run `ping 127.0.0.1`, it should shown the error message: 

> ping: can't create raw socket: Address family not supported by protocol 

for now.