### PR TITLE
Refactor the read/write operations to userspace

### DIFF
--- a/kernel/aster-nix/src/device/tty/driver.rs
+++ b/kernel/aster-nix/src/device/tty/driver.rs
@@ -82,7 +82,7 @@ impl Default for TtyDriver {
 fn console_input_callback(mut reader: VmReader) {
     let tty_driver = get_tty_driver();
     while reader.remain() > 0 {
-        let ch = reader.read_val();
+        let ch = reader.read_val().unwrap();
         tty_driver.push_char(ch);
     }
 }

--- a/kernel/aster-nix/src/prelude.rs
+++ b/kernel/aster-nix/src/prelude.rs
@@ -17,7 +17,7 @@ pub(crate) use bitflags::bitflags;
 pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use log::{debug, error, info, log_enabled, trace, warn};
 pub(crate) use ostd::{
-    mm::{Vaddr, PAGE_SIZE},
+    mm::{Vaddr, VmReader, VmWriter, PAGE_SIZE},
     sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
 };
 pub(crate) use pod::Pod;

--- a/kernel/aster-nix/src/process/signal/mod.rs
+++ b/kernel/aster-nix/src/process/signal/mod.rs
@@ -195,7 +195,7 @@ pub fn handle_user_signal(
         ];
         stack_pointer -= TRAMPOLINE.len() as u64;
         let trampoline_rip = stack_pointer;
-        write_bytes_to_user(stack_pointer as Vaddr, TRAMPOLINE)?;
+        write_bytes_to_user(stack_pointer as Vaddr, &mut VmReader::from(TRAMPOLINE))?;
         stack_pointer = write_u64_to_user_stack(stack_pointer, trampoline_rip)?;
     }
 

--- a/kernel/aster-nix/src/syscall/execve.rs
+++ b/kernel/aster-nix/src/syscall/execve.rs
@@ -115,6 +115,10 @@ fn do_execve(
         let process_vm = current.vm();
         load_program_to_vm(process_vm, elf_file.clone(), argv, envp, fs_resolver, 1)?
     };
+
+    // After the program has been successfully loaded, the virtual memory of the current process
+    // is initialized. Hence, it is necessary to clear the previously recorded robust list.
+    *posix_thread.robust_list().lock() = None;
     debug!("load elf in execve succeeds");
 
     let credentials = credentials_mut();

--- a/kernel/aster-nix/src/syscall/getcwd.rs
+++ b/kernel/aster-nix/src/syscall/getcwd.rs
@@ -8,6 +8,6 @@ pub fn sys_getcwd(buf: Vaddr, len: usize) -> Result<SyscallReturn> {
     let fake_cwd = CString::new("/")?;
     let bytes = fake_cwd.as_bytes_with_nul();
     let write_len = len.min(bytes.len());
-    write_bytes_to_user(buf, &bytes[..write_len])?;
+    write_bytes_to_user(buf, &mut VmReader::from(&bytes[..write_len]))?;
     Ok(SyscallReturn::Return(write_len as _))
 }

--- a/kernel/aster-nix/src/syscall/getdents64.rs
+++ b/kernel/aster-nix/src/syscall/getdents64.rs
@@ -36,7 +36,7 @@ pub fn sys_getdents(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<Sys
     let mut reader = DirentBufferReader::<Dirent>::new(&mut buffer); // Use the non-64-bit reader
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    write_bytes_to_user(buf_addr, &buffer[..read_len])?;
+    write_bytes_to_user(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }
 
@@ -61,7 +61,7 @@ pub fn sys_getdents64(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<S
     let mut reader = DirentBufferReader::<Dirent64>::new(&mut buffer);
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    write_bytes_to_user(buf_addr, &buffer[..read_len])?;
+    write_bytes_to_user(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }
 

--- a/kernel/aster-nix/src/syscall/getrandom.rs
+++ b/kernel/aster-nix/src/syscall/getrandom.rs
@@ -17,7 +17,7 @@ pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32) -> Result<SyscallRetu
     } else {
         device::Urandom::getrandom(&mut buffer)?
     };
-    write_bytes_to_user(buf, &buffer)?;
+    write_bytes_to_user(buf, &mut VmReader::from(buffer.as_slice()))?;
     Ok(SyscallReturn::Return(read_len as isize))
 }
 

--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -15,7 +15,7 @@ pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallRet
         | MadviseBehavior::MADV_WILLNEED => {
             // perform a read at first
             let mut buffer = vec![0u8; len];
-            read_bytes_from_user(start, &mut buffer)?;
+            read_bytes_from_user(start, &mut VmWriter::from(buffer.as_mut_slice()))?;
         }
         MadviseBehavior::MADV_DONTNEED => madv_dontneed(start, len)?,
         _ => todo!(),

--- a/kernel/aster-nix/src/syscall/prctl.rs
+++ b/kernel/aster-nix/src/syscall/prctl.rs
@@ -39,7 +39,10 @@ pub fn sys_prctl(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Res
             let thread_name = posix_thread.thread_name().lock();
             if let Some(thread_name) = &*thread_name {
                 if let Some(thread_name) = thread_name.name()? {
-                    write_bytes_to_user(write_to_addr, thread_name.to_bytes_with_nul())?;
+                    write_bytes_to_user(
+                        write_to_addr,
+                        &mut VmReader::from(thread_name.to_bytes_with_nul()),
+                    )?;
                 }
             }
         }

--- a/kernel/aster-nix/src/syscall/pread64.rs
+++ b/kernel/aster-nix/src/syscall/pread64.rs
@@ -33,7 +33,7 @@ pub fn sys_pread64(
     let read_len = {
         let mut buffer = vec![0u8; user_buf_len];
         let read_len = file.read_at(offset as usize, &mut buffer)?;
-        write_bytes_to_user(user_buf_ptr, &buffer)?;
+        write_bytes_to_user(user_buf_ptr, &mut VmReader::from(buffer.as_slice()))?;
         read_len
     };
 

--- a/kernel/aster-nix/src/syscall/pwrite64.rs
+++ b/kernel/aster-nix/src/syscall/pwrite64.rs
@@ -30,7 +30,7 @@ pub fn sys_pwrite64(
     }
 
     let mut buffer = vec![0u8; user_buf_len];
-    read_bytes_from_user(user_buf_ptr, &mut buffer)?;
+    read_bytes_from_user(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
     let write_len = file.write_at(offset as _, &buffer)?;
     Ok(SyscallReturn::Return(write_len as _))
 }

--- a/kernel/aster-nix/src/syscall/read.rs
+++ b/kernel/aster-nix/src/syscall/read.rs
@@ -17,6 +17,6 @@ pub fn sys_read(fd: FileDesc, user_buf_addr: Vaddr, buf_len: usize) -> Result<Sy
 
     let mut read_buf = vec![0u8; buf_len];
     let read_len = file.read(&mut read_buf)?;
-    write_bytes_to_user(user_buf_addr, &read_buf)?;
+    write_bytes_to_user(user_buf_addr, &mut VmReader::from(read_buf.as_slice()))?;
     Ok(SyscallReturn::Return(read_len as _))
 }

--- a/kernel/aster-nix/src/syscall/readlink.rs
+++ b/kernel/aster-nix/src/syscall/readlink.rs
@@ -35,7 +35,7 @@ pub fn sys_readlinkat(
     let linkpath = dentry.inode().read_link()?;
     let bytes = linkpath.as_bytes();
     let write_len = bytes.len().min(usr_buf_len);
-    write_bytes_to_user(usr_buf_addr, &bytes[..write_len])?;
+    write_bytes_to_user(usr_buf_addr, &mut VmReader::from(&bytes[..write_len]))?;
     Ok(SyscallReturn::Return(write_len as _))
 }
 

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -25,7 +25,7 @@ pub fn sys_write(fd: FileDesc, user_buf_ptr: Vaddr, user_buf_len: usize) -> Resu
     }
 
     let mut buffer = vec![0u8; user_buf_len];
-    read_bytes_from_user(user_buf_ptr, &mut buffer)?;
+    read_bytes_from_user(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
     debug!("write content = {:?}", buffer);
     let write_len = file.write(&buffer)?;
     Ok(SyscallReturn::Return(write_len as _))

--- a/kernel/aster-nix/src/thread/exception.rs
+++ b/kernel/aster-nix/src/thread/exception.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_variables)]
 
-use ostd::cpu::*;
+use ostd::{cpu::*, mm::VmSpace};
 
 use crate::{
     prelude::*, process::signal::signals::fault::FaultSignal,
@@ -18,7 +18,11 @@ pub fn handle_exception(context: &UserContext) {
     let root_vmar = current.root_vmar();
 
     match *exception {
-        PAGE_FAULT => handle_page_fault(trap_info),
+        PAGE_FAULT => {
+            if handle_page_fault(root_vmar.vm_space(), trap_info).is_err() {
+                generate_fault_signal(trap_info);
+            }
+        }
         _ => {
             // We current do nothing about other exceptions
             generate_fault_signal(trap_info);
@@ -26,7 +30,11 @@ pub fn handle_exception(context: &UserContext) {
     }
 }
 
-fn handle_page_fault(trap_info: &CpuExceptionInfo) {
+/// Handles the page fault occurs in the input `VmSpace`.
+pub(crate) fn handle_page_fault(
+    vm_space: &VmSpace,
+    trap_info: &CpuExceptionInfo,
+) -> core::result::Result<(), ()> {
     const PAGE_NOT_PRESENT_ERROR_MASK: usize = 0x1 << 0;
     const WRITE_ACCESS_MASK: usize = 0x1 << 1;
     let page_fault_addr = trap_info.page_fault_addr as Vaddr;
@@ -41,16 +49,23 @@ fn handle_page_fault(trap_info: &CpuExceptionInfo) {
         // If page is not present or due to write access, we should ask the vmar try to commit this page
         let current = current!();
         let root_vmar = current.root_vmar();
+
+        debug_assert_eq!(
+            Arc::as_ptr(root_vmar.vm_space()),
+            vm_space as *const VmSpace
+        );
+
         if let Err(e) = root_vmar.handle_page_fault(page_fault_addr, not_present, write) {
             error!(
                 "page fault handler failed: addr: 0x{:x}, err: {:?}",
                 page_fault_addr, e
             );
-            generate_fault_signal(trap_info);
+            return Err(());
         }
+        Ok(())
     } else {
         // Otherwise, the page fault cannot be handled
-        generate_fault_signal(trap_info);
+        Err(())
     }
 }
 

--- a/kernel/aster-nix/src/util/iovec.rs
+++ b/kernel/aster-nix/src/util/iovec.rs
@@ -75,7 +75,7 @@ impl IoVec {
         assert_eq!(dst.len(), self.len);
         assert!(!self.is_empty());
 
-        read_bytes_from_user(self.base, dst)
+        read_bytes_from_user(self.base, &mut VmWriter::from(dst))
     }
 
     /// Writes bytes from the `src` buffer
@@ -92,7 +92,7 @@ impl IoVec {
         assert_eq!(src.len(), self.len);
         assert!(!self.is_empty());
 
-        write_bytes_to_user(self.base, src)
+        write_bytes_to_user(self.base, &mut VmReader::from(src))
     }
 
     /// Reads bytes to the `dst` buffer
@@ -101,7 +101,7 @@ impl IoVec {
     /// If successful, returns the length of actually read bytes.
     pub fn read_from_user(&self, dst: &mut [u8]) -> Result<usize> {
         let len = self.len.min(dst.len());
-        read_bytes_from_user(self.base, &mut dst[..len])?;
+        read_bytes_from_user(self.base, &mut VmWriter::from(&mut dst[..len]))?;
         Ok(len)
     }
 
@@ -111,7 +111,7 @@ impl IoVec {
     /// If successful, returns the length of actually written bytes.
     pub fn write_to_user(&self, src: &[u8]) -> Result<usize> {
         let len = self.len.min(src.len());
-        write_bytes_to_user(self.base, &src[..len])?;
+        write_bytes_to_user(self.base, &mut VmReader::from(&src[..len]))?;
         Ok(len)
     }
 }

--- a/kernel/aster-nix/src/util/net/addr.rs
+++ b/kernel/aster-nix/src/util/net/addr.rs
@@ -27,7 +27,10 @@ pub fn read_socket_addr_from_user(addr: Vaddr, addr_len: usize) -> Result<Socket
             let bytes = {
                 let bytes_len = addr_len - core::mem::size_of::<u16>();
                 let mut bytes = vec![0u8; bytes_len];
-                read_bytes_from_user(addr + core::mem::size_of::<u16>(), &mut bytes)?;
+                read_bytes_from_user(
+                    addr + core::mem::size_of::<u16>(),
+                    &mut VmWriter::from(bytes.as_mut_slice()),
+                )?;
                 bytes
             };
 

--- a/kernel/aster-nix/src/vm/vmar/mod.rs
+++ b/kernel/aster-nix/src/vm/vmar/mod.rs
@@ -21,7 +21,7 @@ use self::{
     vm_mapping::VmMapping,
 };
 use super::page_fault_handler::PageFaultHandler;
-use crate::{prelude::*, vm::perms::VmPerms};
+use crate::{prelude::*, thread::exception::handle_page_fault, vm::perms::VmPerms};
 
 /// Virtual Memory Address Regions (VMARs) are a type of capability that manages
 /// user address spaces.
@@ -165,13 +165,9 @@ impl Vmar_ {
             vm_mappings: BTreeMap::new(),
             free_regions,
         };
-        Vmar_::new(
-            vmar_inner,
-            Arc::new(VmSpace::new()),
-            0,
-            ROOT_VMAR_CAP_ADDR,
-            None,
-        )
+        let vm_space = VmSpace::new();
+        vm_space.register_page_fault_handler(handle_page_fault);
+        Vmar_::new(vmar_inner, Arc::new(vm_space), 0, ROOT_VMAR_CAP_ADDR, None)
     }
 
     fn is_root_vmar(&self) -> bool {

--- a/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
+++ b/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
@@ -752,6 +752,10 @@ impl<R1, R2> VmarMapOptions<R1, R2> {
         if self.align % PAGE_SIZE != 0 || !self.align.is_power_of_two() {
             return_errno_with_message!(Errno::EINVAL, "invalid align");
         }
+        debug_assert!(self.size % self.align == 0);
+        if self.size % self.align != 0 {
+            return_errno_with_message!(Errno::EINVAL, "invalid mapping size");
+        }
         debug_assert!(self.vmo_offset % self.align == 0);
         if self.vmo_offset % self.align != 0 {
             return_errno_with_message!(Errno::EINVAL, "invalid vmo offset");

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -58,6 +58,16 @@ SECTIONS
         __bss_end = .;
     }
 
+    # The section to store exception table (ExTable).
+    # This table is used for recovering from specific exception handling faults
+    # occurring at known points in the code.
+    # Ref: /aster-frame/src/arch/x86/ex_table.rs
+    .ex_table               : AT(ADDR(.ex_table) - KERNEL_VMA) {
+        __ex_table = .;
+        KEEP(*(SORT(.ex_table)))
+        __ex_table_end = .;
+    }
+
     .ktest_array            : AT(ADDR(.ktest_array) - KERNEL_VMA) {
         __ktest_array = .;
         KEEP(*(SORT(.ktest_array)))

--- a/ostd/src/arch/x86/ex_table.rs
+++ b/ostd/src/arch/x86/ex_table.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::Vaddr;
+
+#[repr(C)]
+struct ExTableItem {
+    inst_addr: Vaddr,
+    recovery_inst_addr: Vaddr,
+}
+
+extern "C" {
+    fn __ex_table();
+    fn __ex_table_end();
+}
+
+/// A structure representing the usage of exception table (ExTable).
+/// This table is used for recovering from specific exception handling faults
+/// occurring at known points in the code.
+///
+/// To add a recovery instruction for a target assembly instruction, one should add
+/// the following statements:
+///
+/// ```
+/// .pushsection .ex_table, "a"
+/// .align 8
+/// .quad [.target_label],
+/// .quad [.recovery_label],
+/// .popsection
+/// ```
+///
+/// where the `target_label` and `recovery_label` are the labels of the target instruction
+/// and the label of recovery instruction respectively.
+///
+/// For example, we have the following assembly code snippets in an input file:
+/// ```
+/// .label1:    
+///     rep movsb
+///     mov rax, rcx
+/// .label2:
+///     ret
+/// ```
+///
+/// We can add the following statements in the same file (`label1` and `label2` are local
+/// labels):
+///
+/// ```
+/// .pushsection .ex_table, "a"
+/// .align 8
+/// .quad [.label1],
+/// .quad [.label2],
+/// .popsection
+/// ```
+///
+/// After that, we can use the API of `ExTable` to resume execution when handling
+/// exceptions caused by `rep movsb` (which `label1` point to) failing.
+pub(crate) struct ExTable;
+
+impl ExTable {
+    /// Finds the recovery instruction address for a given instruction address.
+    ///
+    /// This function is generally used when an exception (such as a page fault) occurs.
+    /// if the exception handling fails and there is a predefined recovery action,
+    /// then the found recovery action will be taken.
+    pub fn find_recovery_inst_addr(inst_addr: Vaddr) -> Option<Vaddr> {
+        let table_size =
+            (__ex_table_end as usize - __ex_table as usize) / core::mem::size_of::<ExTableItem>();
+        // SAFETY: `__ex_table` is a static section consisting of `ExTableItem`.
+        let ex_table =
+            unsafe { core::slice::from_raw_parts(__ex_table as *const ExTableItem, table_size) };
+        for item in ex_table {
+            if item.inst_addr == inst_addr {
+                return Some(item.recovery_inst_addr);
+            }
+        }
+        None
+    }
+}

--- a/ostd/src/arch/x86/mm/memcpy_fallible.S
+++ b/ostd/src/arch/x86/mm/memcpy_fallible.S
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// Copies `size` bytes from `src` to `dst`. This function works with exception handling
+// and can recover from a page fault. The source range must not overlap with the destination range
+// (In virtual address level. Their corresponding physical addresses can be overlapped).
+// 
+// Returns number of bytes that failed to copy.
+//
+// Ref: [https://github.com/torvalds/linux/blob/2ab79514109578fc4b6df90633d500cf281eb689/arch/x86/lib/copy_user_64.S]
+.text
+.global __memcpy_fallible
+.code64
+__memcpy_fallible: # (dst: *mut u8, src: *const u8, size: usize) -> usize
+    mov rcx, rdx
+.move:
+    rep movsb
+
+.exit:
+    mov rax, rcx
+    ret
+
+.pushsection .ex_table, "a"
+    .align 8
+    .quad [.move]
+    .quad [.exit]
+.popsection

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -6,6 +6,7 @@ use alloc::fmt;
 use core::ops::Range;
 
 use pod::Pod;
+pub(crate) use util::__memcpy_fallible;
 use x86_64::{instructions::tlb, structures::paging::PhysFrame, VirtAddr};
 
 use crate::mm::{
@@ -13,6 +14,8 @@ use crate::mm::{
     page_table::PageTableEntryTrait,
     Paddr, PagingConstsTrait, PagingLevel, Vaddr, PAGE_SIZE,
 };
+
+mod util;
 
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 

--- a/ostd/src/arch/x86/mm/util.rs
+++ b/ostd/src/arch/x86/mm/util.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+
+core::arch::global_asm!(include_str!("memcpy_fallible.S"));
+
+extern "C" {
+    /// Copies `size` bytes from `src` to `dst`. This function works with exception handling
+    /// and can recover from page fault.
+    /// Returns number of bytes that failed to copy.
+    pub(crate) fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize;
+}

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -6,6 +6,7 @@ pub mod boot;
 pub mod console;
 pub(crate) mod cpu;
 pub mod device;
+pub(crate) mod ex_table;
 pub mod iommu;
 pub(crate) mod irq;
 pub(crate) mod kernel;

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -114,14 +114,20 @@ impl HasPaddr for Frame {
 impl<'a> Frame {
     /// Returns a reader to read data from it.
     pub fn reader(&'a self) -> VmReader<'a> {
-        // SAFETY: the memory of the page is contiguous and is valid during `'a`.
-        unsafe { VmReader::from_raw_parts(self.as_ptr(), self.size()) }
+        // SAFETY: the memory of the page is untyped, contiguous and is valid during `'a`.
+        // Currently, only slice can generate `VmWriter` with typed memory, and this `Frame` cannot
+        // generate or be generated from an alias slice, so the reader will not overlap with `VmWriter`
+        // with typed memory.
+        unsafe { VmReader::from_kernel_space(self.as_ptr(), self.size()) }
     }
 
     /// Returns a writer to write data into it.
     pub fn writer(&'a self) -> VmWriter<'a> {
-        // SAFETY: the memory of the page is contiguous and is valid during `'a`.
-        unsafe { VmWriter::from_raw_parts_mut(self.as_mut_ptr(), self.size()) }
+        // SAFETY: the memory of the page is untyped, contiguous and is valid during `'a`.
+        // Currently, only slice can generate `VmReader` with typed memory, and this `Frame` cannot
+        // generate or be generated from an alias slice, so the writer will not overlap with `VmReader`
+        // with typed memory.
+        unsafe { VmWriter::from_kernel_space(self.as_mut_ptr(), self.size()) }
     }
 }
 

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -101,14 +101,20 @@ impl Segment {
 impl<'a> Segment {
     /// Returns a reader to read data from it.
     pub fn reader(&'a self) -> VmReader<'a> {
-        // SAFETY: the memory of the page frames is contiguous and is valid during `'a`.
-        unsafe { VmReader::from_raw_parts(self.as_ptr(), self.nbytes()) }
+        // SAFETY: the memory of the page frames is untyped, contiguous and is valid during `'a`.
+        // Currently, only slice can generate `VmWriter` with typed memory, and this `Segment` cannot
+        // generate or be generated from an alias slice, so the reader will not overlap with `VmWriter`
+        // with typed memory.
+        unsafe { VmReader::from_kernel_space(self.as_ptr(), self.nbytes()) }
     }
 
     /// Returns a writer to write data into it.
     pub fn writer(&'a self) -> VmWriter<'a> {
-        // SAFETY: the memory of the page frames is contiguous and is valid during `'a`.
-        unsafe { VmWriter::from_raw_parts_mut(self.as_mut_ptr(), self.nbytes()) }
+        // SAFETY: the memory of the page frames is untyped, contiguous and is valid during `'a`.
+        // Currently, only slice can generate `VmReader` with typed memory, and this `Segment` cannot
+        // generate or be generated from an alias slice, so the writer will not overlap with `VmReader`
+        // with typed memory.
+        unsafe { VmWriter::from_kernel_space(self.as_mut_ptr(), self.nbytes()) }
     }
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -8,7 +8,15 @@ use align_ext::AlignExt;
 use inherit_methods_macro::inherit_methods;
 use pod::Pod;
 
-use crate::prelude::*;
+use crate::{
+    arch::mm::__memcpy_fallible,
+    mm::{
+        kspace::{KERNEL_BASE_VADDR, KERNEL_END_VADDR},
+        MAX_USERSPACE_VADDR,
+    },
+    prelude::*,
+    Error,
+};
 
 /// A trait that enables reading/writing data from/to a VM object,
 /// e.g., [`VmSpace`], [`FrameVec`], and [`Frame`].
@@ -168,21 +176,160 @@ impl_vmio_pointer!(&mut T, "(**self)");
 impl_vmio_pointer!(Box<T>, "(**self)");
 impl_vmio_pointer!(Arc<T>, "(**self)");
 
-/// VmReader is a reader for reading data from a contiguous range of memory.
-pub struct VmReader<'a> {
-    cursor: *const u8,
-    end: *const u8,
-    phantom: PhantomData<&'a [u8]>,
+/// A marker structure used for [`VmReader`] and [`VmWriter`],
+/// representing their operated memory scope is in user space.
+pub struct UserSpace;
+
+/// A marker structure used for [`VmReader`] and [`VmWriter`],
+/// representing their operated memory scope is in kernel space.
+pub struct KernelSpace;
+
+/// Copies `len` bytes from `src` to `dst`.
+///
+/// # Safety
+///
+/// - Mappings of virtual memory range [`src`..`src` + len] and [`dst`..`dst` + len]
+///   must be [valid].
+/// - If one of the memory represents typed memory, these two virtual
+///   memory ranges and their corresponding physical pages should _not_ overlap.
+///
+/// Operation on typed memory may be safe only if it is plain-old-data. Otherwise
+/// the safety requirements of [`core::ptr::copy`] should also be considered.
+///
+/// [valid]: core::ptr#safety
+unsafe fn memcpy(src: *const u8, dst: *mut u8, len: usize) {
+    core::ptr::copy(src, dst, len);
 }
 
-impl<'a> VmReader<'a> {
-    /// Constructs a VmReader from a pointer and a length.
+/// Copies `len` bytes from `src` to `dst`.
+/// This function will early stop copying if encountering an unresolvable page fault.
+///
+/// Returns the number of successfully copied bytes.
+///
+/// # Safety
+///
+/// - Users should ensure one of [`src`..`src` + len] and [`dst`..`dst` + len]
+///   is in user space, and the other virtual memory range is in kernel space
+///   and is ensured to be [valid].
+/// - Users should ensure this function only be invoked when a suitable page
+///   table is activated.
+/// - The underlying physical memory range of [`src`..`src` + len] and [`dst`..`dst` + len]
+///   should _not_ overlap if the kernel space memory represent typed memory.
+///
+/// [valid]: core::ptr#safety
+unsafe fn memcpy_fallible(src: *const u8, dst: *mut u8, len: usize) -> usize {
+    let failed_bytes = __memcpy_fallible(dst, src, len);
+    len - failed_bytes
+}
+
+/// `VmReader` is a reader for reading data from a contiguous range of memory.
+///
+/// The memory range read by `VmReader` can be in either kernel space or user space.
+/// When the operating range is in kernel space, the memory within that range
+/// is guaranteed to be valid.
+/// When the operating range is in user space, it is ensured that the page table of
+/// the process creating the `VmReader` is active for the duration of `'a`.
+///
+/// When perform reading with a `VmWriter`, if one of them represents typed memory,
+/// it can ensure that the reading range in this reader and writing range in the
+/// writer are not overlapped.
+///
+/// NOTE: The overlap mentioned above is at both the virtual address level
+/// and physical address level. There is not guarantee for the operation results
+/// of `VmReader` and `VmWriter` in overlapping untyped addresses, and it is
+/// the user's responsibility to handle this situation.
+pub struct VmReader<'a, Space = KernelSpace> {
+    cursor: *const u8,
+    end: *const u8,
+    phantom: PhantomData<(&'a [u8], Space)>,
+}
+
+macro_rules! impl_read_fallible {
+    ($read_space:ty, $write_space:ty) => {
+        impl<'a> VmReader<'a, $read_space> {
+            /// Reads all data into the writer until one of the three conditions is met:
+            /// 1. The reader has no remaining data.
+            /// 2. The writer has no available space.
+            /// 3. The reader/writer encounters some error.
+            ///
+            /// On success, the number of bytes read is returned;
+            /// On error, both the error and the number of bytes read so far are returned.
+            pub fn read_fallible(
+                &mut self,
+                writer: &mut VmWriter<'_, $write_space>,
+            ) -> core::result::Result<usize, (Error, usize)> {
+                let copy_len = self.remain().min(writer.avail());
+                if copy_len == 0 {
+                    return Ok(0);
+                }
+
+                // SAFETY: This method is only implemented when one of the operated
+                // `VmReader` or `VmWriter` is in user space.
+                // The the corresponding page table of the user space memory is
+                // guaranteed to be activated due to its construction requirement.
+                // The kernel space memory range will be valid since `copy_len` is the minimum
+                // of the reader's remaining data and the writer's available space, and will
+                // not overlap with user space memory range in physical address level if it
+                // represents typed memory.
+                let copied_len = unsafe {
+                    let copied_len = memcpy_fallible(self.cursor, writer.cursor, copy_len);
+                    self.cursor = self.cursor.add(copied_len);
+                    writer.cursor = writer.cursor.add(copied_len);
+                    copied_len
+                };
+                if copied_len < copy_len {
+                    Err((Error::PageFault, copied_len))
+                } else {
+                    Ok(copied_len)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_write_fallible {
+    ($read_space:ty, $write_space:ty) => {
+        impl<'a> VmWriter<'a, $write_space> {
+            /// Writes all data from the reader until one of the three conditions is met:
+            /// 1. The reader has no remaining data.
+            /// 2. The writer has no available space.
+            /// 3. The reader/writer encounters some error.
+            ///
+            /// On success, the number of bytes written is returned;
+            /// On error, both the error and the number of bytes written so far are returned.
+            pub fn write_fallible(
+                &mut self,
+                reader: &mut VmReader<'_, $read_space>,
+            ) -> core::result::Result<usize, (Error, usize)> {
+                reader.read_fallible(self)
+            }
+        }
+    };
+}
+
+// TODO: implement an additional function `memcpy_nonoverlapping_fallible`
+// to implement read/write instruction from user space to user space.
+impl_read_fallible!(UserSpace, KernelSpace);
+impl_read_fallible!(KernelSpace, UserSpace);
+impl_write_fallible!(UserSpace, KernelSpace);
+impl_write_fallible!(KernelSpace, UserSpace);
+
+impl<'a> VmReader<'a, KernelSpace> {
+    /// Constructs a `VmReader` from a pointer and a length, which represents
+    /// a memory range in kernel space.
     ///
     /// # Safety
     ///
-    /// User must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
-    /// User must ensure the memory is valid during the entire period of `'a`.
-    pub const unsafe fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
+    /// Users must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
+    /// Users must ensure the memory is valid during the entire period of `'a`.
+    /// Users must ensure the memory should _not_ overlap with other `VmWriter`s
+    /// with typed memory, and if the memory range in this `VmReader` is typed,
+    /// it should _not_ overlap with other `VmWriter`s.
+    /// The user space memory is treated as untyped.
+    pub unsafe fn from_kernel_space(ptr: *const u8, len: usize) -> Self {
+        debug_assert!(KERNEL_BASE_VADDR <= ptr as usize);
+        debug_assert!(ptr.add(len) as usize <= KERNEL_END_VADDR);
+
         Self {
             cursor: ptr,
             end: ptr.add(len),
@@ -190,6 +337,85 @@ impl<'a> VmReader<'a> {
         }
     }
 
+    /// Reads all data into the writer until one of the two conditions is met:
+    /// 1. The reader has no remaining data.
+    /// 2. The writer has no available space.
+    ///
+    /// Returns the number of bytes read.
+    pub fn read(&mut self, writer: &mut VmWriter<'_, KernelSpace>) -> usize {
+        let copy_len = self.remain().min(writer.avail());
+        if copy_len == 0 {
+            return 0;
+        }
+
+        // SAFETY: the reading memory range and writing memory range will be valid
+        // since `copy_len` is the minimum of the reader's remaining data and the
+        // writer's available space, and will not overlap if one of them represents
+        // typed memory.
+        unsafe {
+            memcpy(self.cursor, writer.cursor, copy_len);
+            self.cursor = self.cursor.add(copy_len);
+            writer.cursor = writer.cursor.add(copy_len);
+        }
+
+        copy_len
+    }
+
+    /// Reads a value of `Pod` type.
+    ///
+    /// If the length of the `Pod` type exceeds `self.remain()`,
+    /// this method will return `Err`.
+    pub fn read_val<T: Pod>(&mut self) -> Result<T> {
+        if self.remain() < core::mem::size_of::<T>() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let mut val = T::new_uninit();
+        let mut writer = VmWriter::from(val.as_bytes_mut());
+
+        self.read(&mut writer);
+        Ok(val)
+    }
+}
+
+impl<'a> VmReader<'a, UserSpace> {
+    /// Constructs a `VmReader` from a pointer and a length, which represents
+    /// a memory range in user space.
+    ///
+    /// # Safety
+    ///
+    /// Users must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
+    /// Users must ensure that the page table for the process in which this constructor is called
+    /// are active during the entire period of `'a`.
+    pub unsafe fn from_user_space(ptr: *const u8, len: usize) -> Self {
+        debug_assert!((ptr as usize).checked_add(len).unwrap_or(usize::MAX) <= MAX_USERSPACE_VADDR);
+
+        Self {
+            cursor: ptr,
+            end: ptr.add(len),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Reads a value of `Pod` type.
+    ///
+    /// If the length of the `Pod` type exceeds `self.remain()`,
+    /// or the value can not be read completely,
+    /// this method will return `Err`.
+    pub fn read_val<T: Pod>(&mut self) -> Result<T> {
+        if self.remain() < core::mem::size_of::<T>() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let mut val = T::new_uninit();
+        let mut writer = VmWriter::from(val.as_bytes_mut());
+        self.read_fallible(&mut writer)
+            .map(|_| val)
+            .map_err(|err| err.0)
+    }
+}
+
+impl<'a, Space> VmReader<'a, Space> {
     /// Returns the number of bytes for the remaining data.
     pub const fn remain(&self) -> usize {
         // SAFETY: the end is equal to or greater than the cursor.
@@ -208,7 +434,7 @@ impl<'a> VmReader<'a> {
 
     /// Limits the length of remaining data.
     ///
-    /// This method ensures the postcondition of `self.remain() <= max_remain`.
+    /// This method ensures the post condition of `self.remain() <= max_remain`.
     pub const fn limit(mut self, max_remain: usize) -> Self {
         if max_remain < self.remain() {
             // SAFETY: the new end is less than the old end.
@@ -230,69 +456,56 @@ impl<'a> VmReader<'a> {
         unsafe { self.cursor = self.cursor.add(nbytes) };
         self
     }
-
-    /// Reads all data into the writer until one of the two conditions is met:
-    /// 1. The reader has no remaining data.
-    /// 2. The writer has no available space.
-    ///
-    /// Returns the number of bytes read.
-    ///
-    /// It pulls the number of bytes data from the reader and
-    /// fills in the writer with the number of bytes.
-    pub fn read(&mut self, writer: &mut VmWriter<'_>) -> usize {
-        let copy_len = self.remain().min(writer.avail());
-        if copy_len == 0 {
-            return 0;
-        }
-
-        // SAFETY: the memory range is valid since `copy_len` is the minimum
-        // of the reader's remaining data and the writer's available space.
-        unsafe {
-            core::ptr::copy(self.cursor, writer.cursor, copy_len);
-            self.cursor = self.cursor.add(copy_len);
-            writer.cursor = writer.cursor.add(copy_len);
-        }
-        copy_len
-    }
-
-    /// Read a value of `Pod` type.
-    ///
-    /// # Panic
-    ///
-    /// If the length of the `Pod` type exceeds `self.remain()`, then this method will panic.
-    pub fn read_val<T: Pod>(&mut self) -> T {
-        assert!(self.remain() >= core::mem::size_of::<T>());
-
-        let mut val = T::new_uninit();
-        let mut writer = VmWriter::from(val.as_bytes_mut());
-        let read_len = self.read(&mut writer);
-
-        val
-    }
 }
 
 impl<'a> From<&'a [u8]> for VmReader<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        // SAFETY: the range of memory is contiguous and is valid during `'a`.
-        unsafe { Self::from_raw_parts(slice.as_ptr(), slice.len()) }
+        // SAFETY: the range of memory is contiguous and is valid during `'a`,
+        // and will not overlap with other `VmWriter` since the slice already has
+        // an immutable reference. The slice will not be mapped to the user space hence
+        // it will also not overlap with `VmWriter` generated from user space.
+        unsafe { Self::from_kernel_space(slice.as_ptr(), slice.len()) }
     }
 }
 
-/// VmWriter is a writer for writing data to a contiguous range of memory.
-pub struct VmWriter<'a> {
+/// `VmWriter` is a writer for writing data to a contiguous range of memory.
+///
+/// The memory range write by `VmWriter` can be in either kernel space or user space.
+/// When the operating range is in kernel space, the memory within that range
+/// is guaranteed to be valid.
+/// When the operating range is in user space, it is ensured that the page table of
+/// the process creating the `VmWriter` is active for the duration of `'a`.
+///
+/// When perform writing with a `VmReader`, if one of them represents typed memory,
+/// it can ensure that the writing range in this writer and reading range in the
+/// reader are not overlapped.
+///
+/// NOTE: The overlap mentioned above is at both the virtual address level
+/// and physical address level. There is not guarantee for the operation results
+/// of `VmReader` and `VmWriter` in overlapping untyped addresses, and it is
+/// the user's responsibility to handle this situation.
+pub struct VmWriter<'a, Space = KernelSpace> {
     cursor: *mut u8,
     end: *mut u8,
-    phantom: PhantomData<&'a mut [u8]>,
+    phantom: PhantomData<(&'a mut [u8], Space)>,
 }
 
-impl<'a> VmWriter<'a> {
-    /// Constructs a VmWriter from a pointer and a length.
+impl<'a> VmWriter<'a, KernelSpace> {
+    /// Constructs a `VmWriter` from a pointer and a length, which represents
+    /// a memory range in kernel space.
     ///
     /// # Safety
     ///
-    /// User must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
-    /// User must ensure the memory is valid during the entire period of `'a`.
-    pub const unsafe fn from_raw_parts_mut(ptr: *mut u8, len: usize) -> Self {
+    /// Users must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
+    /// Users must ensure the memory is valid during the entire period of `'a`.
+    /// Users must ensure the memory should _not_ overlap with other `VmWriter`s
+    /// and `VmReader`s with typed memory, and if the memory range in this `VmWriter`
+    /// is typed, it should _not_ overlap with other `VmReader`s and `VmWriter`s.
+    /// The user space memory is treated as untyped.
+    pub unsafe fn from_kernel_space(ptr: *mut u8, len: usize) -> Self {
+        debug_assert!(KERNEL_BASE_VADDR <= ptr as usize);
+        debug_assert!(ptr.add(len) as usize <= KERNEL_END_VADDR);
+
         Self {
             cursor: ptr,
             end: ptr.add(len),
@@ -300,69 +513,27 @@ impl<'a> VmWriter<'a> {
         }
     }
 
-    /// Returns the number of bytes for the available space.
-    pub const fn avail(&self) -> usize {
-        // SAFETY: the end is equal to or greater than the cursor.
-        unsafe { self.end.sub_ptr(self.cursor) }
-    }
-
-    /// Returns the cursor pointer, which refers to the address of the next byte to write.
-    pub const fn cursor(&self) -> *mut u8 {
-        self.cursor
-    }
-
-    /// Returns if it has avaliable space to write.
-    pub const fn has_avail(&self) -> bool {
-        self.avail() > 0
-    }
-
-    /// Limits the length of available space.
-    ///
-    /// This method ensures the postcondition of `self.avail() <= max_avail`.
-    pub const fn limit(mut self, max_avail: usize) -> Self {
-        if max_avail < self.avail() {
-            // SAFETY: the new end is less than the old end.
-            unsafe { self.end = self.cursor.add(max_avail) };
-        }
-        self
-    }
-
-    /// Skips the first `nbytes` bytes of data.
-    /// The length of available space is decreased accordingly.
-    ///
-    /// # Panic
-    ///
-    /// If `nbytes` is greater than `self.avail()`, then the method panics.
-    pub fn skip(mut self, nbytes: usize) -> Self {
-        assert!(nbytes <= self.avail());
-
-        // SAFETY: the new cursor is less than or equal to the end.
-        unsafe { self.cursor = self.cursor.add(nbytes) };
-        self
-    }
-
-    /// Writes data from the reader until one of the two conditions is met:
-    /// 1. The writer has no available space.
-    /// 2. The reader has no remaining data.
+    /// Writes all data from the reader until one of the two conditions is met:
+    /// 1. The reader has no remaining data.
+    /// 2. The writer has no available space.
     ///
     /// Returns the number of bytes written.
+    pub fn write(&mut self, reader: &mut VmReader<'_, KernelSpace>) -> usize {
+        reader.read(self)
+    }
+
+    /// Writes a value of `Pod` type.
     ///
-    /// It pulls the number of bytes data from the reader and
-    /// fills in the writer with the number of bytes.
-    pub fn write(&mut self, reader: &mut VmReader<'_>) -> usize {
-        let copy_len = self.avail().min(reader.remain());
-        if copy_len == 0 {
-            return 0;
+    /// If the length of the `Pod` type exceeds `self.avail()`,
+    /// this method will return `Err`.
+    pub fn write_val<T: Pod>(&mut self, new_val: &T) -> Result<()> {
+        if self.avail() < core::mem::size_of::<T>() {
+            return Err(Error::InvalidArgs);
         }
 
-        // SAFETY: the memory range is valid since `copy_len` is the minimum
-        // of the reader's remaining data and the writer's available space.
-        unsafe {
-            core::ptr::copy(reader.cursor, self.cursor, copy_len);
-            self.cursor = self.cursor.add(copy_len);
-            reader.cursor = reader.cursor.add(copy_len);
-        }
-        copy_len
+        let mut reader = VmReader::from(new_val.as_bytes());
+        self.write(&mut reader);
+        Ok(())
     }
 
     /// Fills the available space by repeating `value`.
@@ -396,9 +567,91 @@ impl<'a> VmWriter<'a> {
     }
 }
 
+impl<'a> VmWriter<'a, UserSpace> {
+    /// Constructs a `VmWriter` from a pointer and a length, which represents
+    /// a memory range in user space.
+    ///
+    /// # Safety
+    ///
+    /// Users must ensure the memory from `ptr` to `ptr.add(len)` is contiguous.
+    /// Users must ensure that the page table for the process in which this constructor is called
+    /// are active during the entire period of `'a`.
+    pub unsafe fn from_user_space(ptr: *mut u8, len: usize) -> Self {
+        debug_assert!((ptr as usize).checked_add(len).unwrap_or(usize::MAX) <= MAX_USERSPACE_VADDR);
+
+        Self {
+            cursor: ptr,
+            end: ptr.add(len),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Writes a value of `Pod` type.
+    ///
+    /// If the length of the `Pod` type exceeds `self.avail()`,
+    /// or the value can not be write completely,
+    /// this method will return `Err`.
+    pub fn write_val<T: Pod>(&mut self, new_val: &T) -> Result<()> {
+        if self.avail() < core::mem::size_of::<T>() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let mut reader = VmReader::from(new_val.as_bytes());
+        self.write_fallible(&mut reader).map_err(|err| err.0)?;
+        Ok(())
+    }
+}
+
+impl<'a, Space> VmWriter<'a, Space> {
+    /// Returns the number of bytes for the available space.
+    pub const fn avail(&self) -> usize {
+        // SAFETY: the end is equal to or greater than the cursor.
+        unsafe { self.end.sub_ptr(self.cursor) }
+    }
+
+    /// Returns the cursor pointer, which refers to the address of the next byte to write.
+    pub const fn cursor(&self) -> *mut u8 {
+        self.cursor
+    }
+
+    /// Returns if it has available space to write.
+    pub const fn has_avail(&self) -> bool {
+        self.avail() > 0
+    }
+
+    /// Limits the length of available space.
+    ///
+    /// This method ensures the post condition of `self.avail() <= max_avail`.
+    pub const fn limit(mut self, max_avail: usize) -> Self {
+        if max_avail < self.avail() {
+            // SAFETY: the new end is less than the old end.
+            unsafe { self.end = self.cursor.add(max_avail) };
+        }
+        self
+    }
+
+    /// Skips the first `nbytes` bytes of data.
+    /// The length of available space is decreased accordingly.
+    ///
+    /// # Panic
+    ///
+    /// If `nbytes` is greater than `self.avail()`, then the method panics.
+    pub fn skip(mut self, nbytes: usize) -> Self {
+        assert!(nbytes <= self.avail());
+
+        // SAFETY: the new cursor is less than or equal to the end.
+        unsafe { self.cursor = self.cursor.add(nbytes) };
+        self
+    }
+}
+
 impl<'a> From<&'a mut [u8]> for VmWriter<'a> {
     fn from(slice: &'a mut [u8]) -> Self {
-        // SAFETY: the range of memory is contiguous and is valid during `'a`.
-        unsafe { Self::from_raw_parts_mut(slice.as_mut_ptr(), slice.len()) }
+        // SAFETY: the range of memory is contiguous and is valid during `'a`, and
+        // will not overlap with other `VmWriter`s and `VmReader`s since the slice
+        // already has an mutable reference. The slice will not be mapped to the user
+        // space hence it will also not overlap with `VmWriter`s and `VmReader`s
+        // generated from user space.
+        unsafe { Self::from_kernel_space(slice.as_mut_ptr(), slice.len()) }
     }
 }

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -27,7 +27,7 @@ use spin::Once;
 pub use self::{
     dma::{Daddr, DmaCoherent, DmaDirection, DmaStream, DmaStreamSlice, HasDaddr},
     frame::{options::FrameAllocOptions, Frame, FrameVec, FrameVecIter, Segment},
-    io::{VmIo, VmReader, VmWriter},
+    io::{KernelSpace, UserSpace, VmIo, VmReader, VmWriter},
     page_prop::{CachePolicy, PageFlags, PageProperty},
     space::{VmMapOptions, VmSpace},
 };

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -178,7 +178,7 @@ impl PreemptInfo {
         }
     }
 
-    fn incease_num_locks(&self) {
+    fn increase_num_locks(&self) {
         self.num_locks.fetch_add(1, Relaxed);
     }
 
@@ -205,7 +205,7 @@ impl !Send for DisablePreemptGuard {}
 
 impl DisablePreemptGuard {
     fn new() -> Self {
-        PREEMPT_COUNT.incease_num_locks();
+        PREEMPT_COUNT.increase_num_locks();
         Self { private: () }
     }
 


### PR DESCRIPTION
The current implementation utilizes an additional register to achieve the effect of resuming execution from an exception. In the future, it should be implemented with an `exception table` for a more robust solution. Issues that need discussion:

1. Whether a read/write operation that is partially successful should return `Ok` or `Err`? If returning `Ok`, additional checks might be required in scenarios where only full success allows the process to continue. Conversely, if returning `Err`, the current `Error` type may not effectively convey the information about the failed bytes.
2. Whether the size of the mapping needs to be aligned with `PAGE_SIZE` in the internal implementation. Currently, our mapping's size is set based on the parameters to mmap, which might result in mappings like `0x5000-0x5111`. However, in this situation, the entire page from `0x5000-0x6000` is already in the page table, which might lead to accessing unmapped address space. To maintain consistency, I think the mapping operations should probably be aligned with `PAGE_SIZE`.