### PR TITLE
Revise `Waiter`-related APIs and add unit tests

### DIFF
--- a/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
@@ -87,11 +87,7 @@ impl LocalWorkerPool {
     }
 
     fn wake_worker(&self) -> bool {
-        if !self.idle_wait_queue.is_empty() {
-            self.idle_wait_queue.wake_one();
-            return true;
-        }
-        false
+        self.idle_wait_queue.wake_one()
     }
 
     fn has_pending_work_items(&self) -> bool {


### PR DESCRIPTION
`WaitQueue::is_empty` shouldn't be a public API as it can easily cause race conditions, so this PR makes it private.

Besides, this PR refines the documentations of some `WaitQueue` APIs.

In addition, this PR adds unit tests for most public APIs of `WaitQueue`, `Waiter`, and `Waker`. I originally want to do that in https://github.com/asterinas/asterinas/pull/743, but https://github.com/asterinas/asterinas/pull/748 hasn't been merged at that time.