### PR TITLE
Fix 'early_println' with no arguments

### DIFF
--- a/framework/aster-frame/src/console.rs
+++ b/framework/aster-frame/src/console.rs
@@ -15,6 +15,7 @@ macro_rules! early_print {
 
 #[macro_export]
 macro_rules! early_println {
+  () => { $crate::early_print!("\n") };
   ($fmt: literal $(, $($arg: tt)+)?) => {
     $crate::console::print(format_args!(concat!($fmt, "\n") $(, $($arg)+)?))
   }


### PR DESCRIPTION
add an arm in aster_frame::console::early_println!