### PR TITLE
Fix thread priority issue

### DIFF
--- a/framework/aster-frame/src/arch/x86/timer/jiffies.rs
+++ b/framework/aster-frame/src/arch/x86/timer/jiffies.rs
@@ -18,7 +18,7 @@ pub(super) static ELAPSED: AtomicU64 = AtomicU64::new(0);
 
 impl Jiffies {
     /// Creates a new instance.
-    pub fn new(value: u64) -> Self {
+    pub const fn new(value: u64) -> Self {
         Self(value)
     }
 

--- a/kernel/aster-nix/src/thread/kernel_thread.rs
+++ b/kernel/aster-nix/src/thread/kernel_thread.rs
@@ -44,6 +44,7 @@ impl KernelThreadExt for Thread {
             let weal_thread = thread_ref.clone();
             let task = TaskOptions::new(thread_fn)
                 .data(weal_thread)
+                .priority(thread_options.priority)
                 .build()
                 .unwrap();
             let status = ThreadStatus::Init;


### PR DESCRIPTION
This PR fixes #774 and #790.

After fixing these issues, the `switch_to_task` function in preempt is called after each syscall, resulting in low performance. So I set a time interval for preemption to resolve the issue temporarily.