### PR TITLE
Add syscall mknod

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -154,8 +154,6 @@ provided by Linux on x86-64 architecture.
 | 131     | sigaltstack      | ✅              |
 | 132     | utime            | ✅              |
 | 133     | mknod            | ✅              |
-| 132     | utime            | ❌              |
-| 133     | mknod            | ✅              |
 | 134     | uselib           | ❌              |
 | 135     | personality      | ❌              |
 | 136     | ustat            | ❌              |

--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -153,7 +153,9 @@ provided by Linux on x86-64 architecture.
 | 130     | rt_sigsuspend    | ✅              |
 | 131     | sigaltstack      | ✅              |
 | 132     | utime            | ✅              |
-| 133     | mknod            | ❌              |
+| 133     | mknod            | ✅              |
+| 132     | utime            | ❌              |
+| 133     | mknod            | ✅              |
 | 134     | uselib           | ❌              |
 | 135     | personality      | ❌              |
 | 136     | ustat            | ❌              |
@@ -279,7 +281,7 @@ provided by Linux on x86-64 architecture.
 | 256     | migrate_pages    | ❌              |
 | 257     | openat           | ✅              |
 | 258     | mkdirat          | ✅              |
-| 259     | mknodat          | ❌              |
+| 259     | mknodat          | ✅              |
 | 260     | fchownat         | ✅              |
 | 261     | futimesat        | ✅              |
 | 262     | newfstatat       | ✅              |

--- a/kernel/aster-nix/src/device/mod.rs
+++ b/kernel/aster-nix/src/device/mod.rs
@@ -48,12 +48,18 @@ pub fn init() -> Result<()> {
     Ok(())
 }
 
+// TODO: Implement a more scalable solution for ID-to-device mapping.
+// Instead of hardcoding every device numbers in this function,
+// a registration mechanism should be used to allow each driver to
+// allocate device IDs either statically or dynamically.
 pub fn get_device(dev: usize) -> Result<Arc<dyn Device>> {
     if dev == 0 {
         return_errno_with_message!(Errno::EPERM, "whiteout device")
     }
-    let major = ((dev >> 32) & 0xffff_f000 | (dev >> 8) & 0x0000_0fff) as u32;
-    let minor = ((dev >> 12) & 0xffff_ff00 | dev & 0x0000_00ff) as u32;
+
+    let devid = DeviceId::from(dev as u64);
+    let major = devid.major();
+    let minor = devid.minor();
 
     match (major, minor) {
         (1, 3) => Ok(Arc::new(null::Null)),

--- a/kernel/aster-nix/src/fs/device.rs
+++ b/kernel/aster-nix/src/fs/device.rs
@@ -81,6 +81,12 @@ impl From<DeviceId> for u64 {
     }
 }
 
+impl From<u64> for DeviceId {
+    fn from(raw: u64) -> Self {
+        Self(raw)
+    }
+}
+
 /// Add a device node to FS for the device.
 ///
 /// If the parent path is not existing, `mkdir -p` the parent path.

--- a/kernel/aster-nix/src/syscall/arch/x86.rs
+++ b/kernel/aster-nix/src/syscall/arch/x86.rs
@@ -55,6 +55,7 @@ use crate::syscall::{
     lseek::sys_lseek,
     madvise::sys_madvise,
     mkdir::{sys_mkdir, sys_mkdirat},
+    mknod::{sys_mknod, sys_mknodat},
     mmap::sys_mmap,
     mount::sys_mount,
     mprotect::sys_mprotect,
@@ -236,6 +237,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RT_SIGSUSPEND = 130    => sys_rt_sigsuspend(args[..2]);
     SYS_SIGALTSTACK = 131      => sys_sigaltstack(args[..2]);
     SYS_UTIME = 132            => sys_utime(args[..2]);
+    SYS_MKNOD = 133            => sys_mknod(args[..3]);
     SYS_STATFS = 137           => sys_statfs(args[..2]);
     SYS_FSTATFS = 138          => sys_fstatfs(args[..2]);
     SYS_GET_PRIORITY = 140     => sys_get_priority(args[..2]);
@@ -267,6 +269,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_WAITID = 247           => sys_waitid(args[..5]);
     SYS_OPENAT = 257           => sys_openat(args[..4]);
     SYS_MKDIRAT = 258          => sys_mkdirat(args[..3]);
+    SYS_MKNODAT = 259          => sys_mknodat(args[..4]);
     SYS_FCHOWNAT = 260         => sys_fchownat(args[..5]);
     SYS_FUTIMESAT = 261        => sys_futimesat(args[..3]);
     SYS_FSTATAT = 262          => sys_fstatat(args[..4]);

--- a/kernel/aster-nix/src/syscall/link.rs
+++ b/kernel/aster-nix/src/syscall/link.rs
@@ -37,8 +37,8 @@ pub fn sys_linkat(
             return_errno_with_message!(Errno::ENOENT, "oldpath is empty");
         }
         let new_path = new_path.to_string_lossy();
-        if new_path.ends_with('/') || new_path.is_empty() {
-            return_errno_with_message!(Errno::ENOENT, "newpath is dir or is empty");
+        if new_path.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "newpath is empty");
         }
 
         let old_fs_path = FsPath::new(old_dirfd, old_path.as_ref())?;
@@ -49,7 +49,7 @@ pub fn sys_linkat(
         } else {
             fs.lookup_no_follow(&old_fs_path)?
         };
-        let (new_dir_dentry, new_name) = fs.lookup_dir_and_base_name(&new_fs_path)?;
+        let (new_dir_dentry, new_name) = fs.lookup_dir_and_new_basename(&new_fs_path, false)?;
         (old_dentry, new_dir_dentry, new_name)
     };
 

--- a/kernel/aster-nix/src/syscall/mkdir.rs
+++ b/kernel/aster-nix/src/syscall/mkdir.rs
@@ -23,7 +23,10 @@ pub fn sys_mkdirat(dirfd: FileDesc, path_addr: Vaddr, mode: u16) -> Result<Sysca
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        current.fs().read().lookup_dir_and_base_name(&fs_path)?
+        current
+            .fs()
+            .read()
+            .lookup_dir_and_new_basename(&fs_path, true)?
     };
 
     let inode_mode = {

--- a/kernel/aster-nix/src/syscall/mknod.rs
+++ b/kernel/aster-nix/src/syscall/mknod.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{
+    device::get_device,
+    fs::{
+        file_table::FileDesc,
+        fs_resolver::{FsPath, AT_FDCWD},
+        utils::{InodeMode, InodeType},
+    },
+    prelude::*,
+    syscall::{constants::MAX_FILENAME_LEN, stat::FileTypeFlags},
+    util::read_cstring_from_user,
+};
+
+pub fn sys_mknodat(
+    dirfd: FileDesc,
+    path_addr: Vaddr,
+    mode: u16,
+    dev: usize,
+) -> Result<SyscallReturn> {
+    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let current = current!();
+    let inode_mode = {
+        let mask_mode = mode & !current.umask().read().get();
+        InodeMode::from_bits_truncate(mask_mode)
+    };
+    let file_type = FileTypeFlags::from_bits_truncate(mode);
+    debug!(
+        "dirfd = {}, path = {:?}, inode_mode = {:?}, file_type = {:?}, dev = {}",
+        dirfd, path, inode_mode, file_type, dev
+    );
+
+    let (dir_dentry, name) = {
+        let path = path.to_string_lossy();
+        if path.is_empty() {
+            return_errno_with_message!(Errno::ENOENT, "path is empty");
+        }
+        let fs_path = FsPath::new(dirfd, path.as_ref())?;
+        current.fs().read().lookup_dir_and_base_name(&fs_path)?
+    };
+
+    if file_type.contains(FileTypeFlags::S_IFREG) || file_type.is_empty() {
+        let _ = dir_dentry.new_fs_child(name.trim_end_matches('/'), InodeType::File, inode_mode)?;
+    } else if file_type.contains(FileTypeFlags::S_IFCHR)
+        || file_type.contains(FileTypeFlags::S_IFBLK)
+    {
+        let _ = dir_dentry.mknod(name.trim_end_matches('/'), inode_mode, get_device(dev)?)?;
+    } else if file_type.contains(FileTypeFlags::S_IFIFO)
+        || file_type.contains(FileTypeFlags::S_IFSOCK)
+    {
+        return_errno_with_message!(Errno::EINVAL, "unsupported file type flag");
+    } else {
+        return_errno_with_message!(Errno::EPERM, "unimplemented types");
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_mknod(path_addr: Vaddr, mode: u16, dev: usize) -> Result<SyscallReturn> {
+    self::sys_mknodat(AT_FDCWD, path_addr, mode, dev)
+}

--- a/kernel/aster-nix/src/syscall/mknod.rs
+++ b/kernel/aster-nix/src/syscall/mknod.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::{InodeMode, InodeType},
     },
     prelude::*,
-    syscall::{constants::MAX_FILENAME_LEN, stat::FileTypeFlags},
+    syscall::{constants::MAX_FILENAME_LEN, stat::FileType},
     util::read_cstring_from_user,
 };
 
@@ -25,7 +25,7 @@ pub fn sys_mknodat(
         let mask_mode = mode & !current.umask().read().get();
         InodeMode::from_bits_truncate(mask_mode)
     };
-    let file_type = FileTypeFlags::from_bits_truncate(mode);
+    let file_type = FileType::from_mode(mode);
     debug!(
         "dirfd = {}, path = {:?}, inode_mode = {:?}, file_type = {:?}, dev = {}",
         dirfd, path, inode_mode, file_type, dev
@@ -37,21 +37,24 @@ pub fn sys_mknodat(
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        current.fs().read().lookup_dir_and_base_name(&fs_path)?
+        current
+            .fs()
+            .read()
+            .lookup_dir_and_new_basename(&fs_path, false)?
     };
 
-    if file_type.contains(FileTypeFlags::S_IFREG) || file_type.is_empty() {
-        let _ = dir_dentry.new_fs_child(name.trim_end_matches('/'), InodeType::File, inode_mode)?;
-    } else if file_type.contains(FileTypeFlags::S_IFCHR)
-        || file_type.contains(FileTypeFlags::S_IFBLK)
-    {
-        let _ = dir_dentry.mknod(name.trim_end_matches('/'), inode_mode, get_device(dev)?)?;
-    } else if file_type.contains(FileTypeFlags::S_IFIFO)
-        || file_type.contains(FileTypeFlags::S_IFSOCK)
-    {
-        return_errno_with_message!(Errno::EINVAL, "unsupported file type flag");
-    } else {
-        return_errno_with_message!(Errno::EPERM, "unimplemented types");
+    match file_type {
+        FileType::RegularFile => {
+            let _ = dir_dentry.new_fs_child(&name, InodeType::File, inode_mode)?;
+        }
+        FileType::CharacterDevice | FileType::BlockDevice => {
+            let device_inode = get_device(dev)?;
+            let _ = dir_dentry.mknod(&name, inode_mode, device_inode)?;
+        }
+        FileType::Fifo | FileType::Socket => {
+            return_errno_with_message!(Errno::EINVAL, "unsupported file types")
+        }
+        _ => return_errno_with_message!(Errno::EPERM, "unimplemented file types"),
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/aster-nix/src/syscall/mod.rs
+++ b/kernel/aster-nix/src/syscall/mod.rs
@@ -62,6 +62,7 @@ mod listen;
 mod lseek;
 mod madvise;
 mod mkdir;
+mod mknod;
 mod mmap;
 mod mount;
 mod mprotect;

--- a/kernel/aster-nix/src/syscall/mount.rs
+++ b/kernel/aster-nix/src/syscall/mount.rs
@@ -165,14 +165,14 @@ fn get_fs(fs_type: CString, devname: CString) -> Result<Arc<dyn FileSystem>> {
 
 bitflags! {
     struct MountFlags: u32 {
-        const MS_RDONLY        =   1 << 0;       // Mount read-only */
-        const MS_NOSUID        =   1 << 1;       // Ignore suid and sgid bits */
-        const MS_NODEV         =   1 << 2;       // Disallow access to device special files */
-        const MS_NOEXEC        =   1 << 3;       // Disallow program execution */
-        const MS_SYNCHRONOUS   =   1 << 4;       // Writes are synced at once
+        const MS_RDONLY        =   1 << 0;       // Mount read-only.
+        const MS_NOSUID        =   1 << 1;       // Ignore suid and sgid bits.
+        const MS_NODEV         =   1 << 2;       // Disallow access to device special files.
+        const MS_NOEXEC        =   1 << 3;       // Disallow program execution.
+        const MS_SYNCHRONOUS   =   1 << 4;       // Writes are synced at once.
         const MS_REMOUNT       =   1 << 5;       // Alter flags of a mounted FS.
         const MS_MANDLOCK      =   1 << 6;       // Allow mandatory locks on an FS.
-        const MS_DIRSYNC       =   1 << 7;       // Directory modifications are synchronous
+        const MS_DIRSYNC       =   1 << 7;       // Directory modifications are synchronous.
         const MS_NOSYMFOLLOW   =   1 << 8;       // Do not follow symlinks.
         const MS_NOATIME       =   1 << 10;      // Do not update access times.
         const MS_NODIRATIME    =   1 << 11;      // Do not update directory access times.

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -77,11 +77,19 @@ pub fn sys_fstatat(
     Ok(SyscallReturn::Return(0))
 }
 
-pub const S_IFMT: u32 = 0o170000;
-pub const S_IFCHR: u32 = 0o020000;
-pub const S_IFDIR: u32 = 0o040000;
-pub const S_IFREG: u32 = 0o100000;
-pub const S_IFLNK: u32 = 0o120000;
+bitflags! {
+    /// File type.
+    pub struct FileTypeFlags: u16 {
+        const S_IFMT   = 0o170000; // File type mask.
+        const S_IFSOCK = 0o140000; // Socket.
+        const S_IFCHR  = 0o020000; // Character device.
+        const S_IFBLK  = 0o060000; // Block device.
+        const S_IFDIR  = 0o040000; // Directory.
+        const S_IFIFO  = 0o010000; // FIFO (named pipe).
+        const S_IFREG  = 0o100000; // Regular file.
+        const S_IFLNK  = 0o120000; // Symbolic link.
+    }
+}
 
 /// File Stat
 #[derive(Debug, Clone, Copy, Pod, Default)]

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -77,17 +77,35 @@ pub fn sys_fstatat(
     Ok(SyscallReturn::Return(0))
 }
 
-bitflags! {
-    /// File type.
-    pub struct FileTypeFlags: u16 {
-        const S_IFMT   = 0o170000; // File type mask.
-        const S_IFSOCK = 0o140000; // Socket.
-        const S_IFCHR  = 0o020000; // Character device.
-        const S_IFBLK  = 0o060000; // Block device.
-        const S_IFDIR  = 0o040000; // Directory.
-        const S_IFIFO  = 0o010000; // FIFO (named pipe).
-        const S_IFREG  = 0o100000; // Regular file.
-        const S_IFLNK  = 0o120000; // Symbolic link.
+/// File type mask.
+const S_IFMT: u16 = 0o170000;
+
+/// Enum representing different file types.
+#[derive(Debug, PartialEq)]
+pub enum FileType {
+    Socket,
+    CharacterDevice,
+    BlockDevice,
+    Directory,
+    Fifo,
+    RegularFile,
+    Symlink,
+    Unknown,
+}
+
+impl FileType {
+    /// Extract the file type from the mode.
+    pub fn from_mode(mode: u16) -> FileType {
+        match mode & S_IFMT {
+            0o140000 => FileType::Socket,          // Socket.
+            0o020000 => FileType::CharacterDevice, // Character device.
+            0o060000 => FileType::BlockDevice,     // Block device.
+            0o040000 => FileType::Directory,       // Directory.
+            0o010000 => FileType::Fifo,            // FIFO (named pipe).
+            0 | 0o100000 => FileType::RegularFile, // Regular file.
+            0o120000 => FileType::Symlink,         // Symbolic link.
+            _ => FileType::Unknown,                // Unkonwn file type.
+        }
     }
 }
 

--- a/kernel/aster-nix/src/syscall/symlink.rs
+++ b/kernel/aster-nix/src/syscall/symlink.rs
@@ -34,11 +34,11 @@ pub fn sys_symlinkat(
         if linkpath.is_empty() {
             return_errno_with_message!(Errno::ENOENT, "linkpath is empty");
         }
-        if linkpath.ends_with('/') {
-            return_errno_with_message!(Errno::EISDIR, "linkpath is dir");
-        }
         let fs_path = FsPath::new(dirfd, linkpath.as_ref())?;
-        current.fs().read().lookup_dir_and_base_name(&fs_path)?
+        current
+            .fs()
+            .read()
+            .lookup_dir_and_new_basename(&fs_path, false)?
     };
 
     let new_dentry = dir_dentry.new_fs_child(

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -20,6 +20,7 @@ TESTS ?= \
 	link_test \
 	lseek_test \
 	mkdir_test \
+	mknod_test \
 	mmap_test \
 	mount_test \
 	open_create_test \

--- a/test/syscall_test/blocklists.exfat/mknod_test
+++ b/test/syscall_test/blocklists.exfat/mknod_test
@@ -1,0 +1,1 @@
+MknodTest.RegularFilePermissions

--- a/test/syscall_test/blocklists/mknod_test
+++ b/test/syscall_test/blocklists/mknod_test
@@ -1,0 +1,6 @@
+MknodTest.MknodAtFIFO
+MknodTest.MknodOnExistingPathFails
+MknodTest.Socket
+MknodTest.Fifo
+MknodTest.FifoOtrunc
+MknodTest.FifoTruncNoOp


### PR DESCRIPTION
This PR implements some of the functionality of syscall `mknod`. The `mknod()` system call is responsible for creating a filesystem node with the name pathname, which can be a regular file, device special file, or named pipe, with attributes specified by mode and dev. The file type must be one of `S_IFREG`, `S_IFCHR`, `S_IFBLK`, `S_IFIFO`, or `S_IFSOCK` to indicate a regular file (which will be created empty), character special file, block special file, FIFO (named pipe), or UNIX domain socket, respectively. A zero file type is equivalent to `S_IFREG`.

The PR supports `S_IFREG`, `S_IFCHR`, `S_IFBLK`, and the zero file type. The support for `S_IFCHR` and `S_IFBLK` is implemented as dummy. The function to retrieve the device `Arc<dyn Device>` based on the device number is defined as follows:

```rust
pub fn get_device(dev: usize) -> Result<Arc<dyn Device>> {
    if dev == 0 {
        return_errno_with_message!(Errno::EPERM, "whiteout device");
    }
    let major = ((dev >> 32) & 0xffff_f000 | (dev >> 8) & 0x0000_0fff) as u32;
    let minor = ((dev >> 12) & 0xffff_ff00 | dev & 0x0000_00ff) as u32;

    match (major, minor) {
        (1, 3) => Ok(Arc::new(null::Null)),
        (1, 5) => Ok(Arc::new(zero::Zero)),
        (5, 0) => Ok(Arc::new(tty::TtyDevice)),
        (1, 8) => Ok(Arc::new(random::Random)),
        (1, 9) => Ok(Arc::new(urandom::Urandom)),
        _ => return_errno_with_message!(Errno::EINVAL, "unsupported device"),
    }
}
```
The additional mknod tests listed below require support for `S_IFIFO` and `S_IFSOCK`, which are not implemented in this PR. As a result, they have been added to the blocklist:
```
MknodTest.MknodAtFIFO
MknodTest.MknodOnExistingPathFails
MknodTest.Socket
MknodTest.Fifo
MknodTest.FifoOtrunc
MknodTest.FifoTruncNoOp
All other tests have passed.
```
It is also worth noting that the test MknodTest.RegularFilePermissions for the exFAT filesystem fails. This is because the test expects the created file to have permissions set to `0700`, but the test finds the file permissions to be `0777` when using stat. The reason for this discrepancy is found in the exFAT filesystem's code at `asterinas/kernel/aster-nix/src/fs/exfat/inode.rs`:
```rust
fn make_mode(&self) -> InodeMode {
    self.attr
        .make_mode(self.fs().mount_option(), InodeMode::all())
}
```
The permissions set for the Inode are not the actual permissions of the created file, hence the test fails.