### PR TITLE
Fix OSDK publish CI panics

### DIFF
--- a/.github/workflows/osdk_publish.yml
+++ b/.github/workflows/osdk_publish.yml
@@ -1,12 +1,15 @@
 name: OSDK Publish
 
 on:
-  workflow_dispatch:
-  push:
+  pull_request:
     paths:
+      - VERSION
       - osdk/Cargo.toml
+  push:
     branches:
       - main
+    paths: 
+      - VERSION
 
 jobs:
   osdk-publish:
@@ -15,9 +18,19 @@ jobs:
     container: asterinas/asterinas:0.4.2
     steps:
       - uses: actions/checkout@v4
-      - uses: katyo/publish-crates@v2
-        with:
-          path: './osdk'
-          args: --no-verify
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          ignore-unpublished-changes: true
+
+      - name: Check Publish
+        # On pull request, set `--dry-run` to check whether OSDK can publish
+        if: github.event_name == 'pull_request'
+        run: |
+          cd osdk
+          cargo publish --dry-run
+        
+      - name: Publish
+        # On push, OSDK will be published
+        if: github.event_name == 'push'
+        env:
+          REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cd osdk
+          cargo publish --token ${REGISTRY_TOKEN}


### PR DESCRIPTION
Fix the [OSDK CI panic](https://github.com/asterinas/asterinas/actions/runs/9330147234/job/25683418208).

The original GitHub Action does not allow specifying the path of a dependent crate if it is not one of the workspace members. However, this check is incorrect. Therefore, I have opted to use `cargo publish` directly in the workflow.

Furthermore, I have divided the workflow into two jobs. The first job checks the publishing process when a pull request is made. It runs `cargo publish --dry-run` to simulate the publishing process without actually publishing the crate. The second job handles the actual publishing when the code is merged into the main branch.