### PR TITLE
Stop allowing `dead_code` and `unused_variables` at crate level

### DIFF
--- a/framework/aster-frame/src/arch/x86/console.rs
+++ b/framework/aster-frame/src/arch/x86/console.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::{fmt, sync::Arc, vec::Vec};
 use core::fmt::Write;
 

--- a/framework/aster-frame/src/arch/x86/device/cmos.rs
+++ b/framework/aster-frame/src/arch/x86/device/cmos.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use acpi::{fadt::Fadt, sdt::Signature};
 use x86_64::instructions::port::{ReadOnlyAccess, WriteOnlyAccess};
 

--- a/framework/aster-frame/src/arch/x86/iommu/context_table.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/context_table.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::collections::BTreeMap;
 use core::mem::size_of;
 

--- a/framework/aster-frame/src/arch/x86/iommu/fault.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/fault.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::vec::Vec;
 use core::fmt::Debug;
 

--- a/framework/aster-frame/src/arch/x86/iommu/remapping.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/remapping.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use bitflags::bitflags;
 use log::debug;
 use spin::Once;

--- a/framework/aster-frame/src/arch/x86/iommu/second_stage.rs
+++ b/framework/aster-frame/src/arch/x86/iommu/second_stage.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::ops::Range;
 
 use pod::Pod;

--- a/framework/aster-frame/src/arch/x86/irq.rs
+++ b/framework/aster-frame/src/arch/x86/irq.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec::Vec};
 
 use id_alloc::IdAlloc;

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/dmar.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/dmar.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::vec::Vec;
 use core::{fmt::Debug, mem::size_of, slice::Iter};
 

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/mod.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 pub mod dmar;
 pub mod remapping;
 

--- a/framework/aster-frame/src/arch/x86/kernel/acpi/remapping.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/acpi/remapping.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! Remapping structures of DMAR table.
 //! This file defines these structures and provides a "Debug" implementation to see the value inside these structures.
 //! Most of the introduction are copied from Intel vt-directed-io-specification.

--- a/framework/aster-frame/src/arch/x86/kernel/apic/ioapic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/ioapic.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::{vec, vec::Vec};
 
 #[cfg(feature = "intel_tdx")]

--- a/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::sync::Arc;
 
 use log::info;

--- a/framework/aster-frame/src/arch/x86/kernel/apic/xapic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/apic/xapic.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use spin::Once;
 use x86::apic::xapic;
 

--- a/framework/aster-frame/src/arch/x86/kernel/pic.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/pic.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering::Relaxed};
 
 use log::info;

--- a/framework/aster-frame/src/arch/x86/kernel/tsc.rs
+++ b/framework/aster-frame/src/arch/x86/kernel/tsc.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::{
     arch::x86_64::_rdtsc,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},

--- a/framework/aster-frame/src/arch/x86/mm/mod.rs
+++ b/framework/aster-frame/src/arch/x86/mm/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::fmt;
 use core::ops::Range;
 

--- a/framework/aster-frame/src/arch/x86/timer/apic.rs
+++ b/framework/aster-frame/src/arch/x86/timer/apic.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::sync::Arc;
 use core::{
     arch::x86_64::_rdtsc,

--- a/framework/aster-frame/src/arch/x86/timer/hpet.rs
+++ b/framework/aster-frame/src/arch/x86/timer/hpet.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::vec::Vec;
 
 use acpi::{AcpiError, HpetInfo};

--- a/framework/aster-frame/src/arch/x86/timer/pit.rs
+++ b/framework/aster-frame/src/arch/x86/timer/pit.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! The Programmable Interval Timer (PIT) chip (Intel 8253/8254) basically consists of an oscillator,
 //! a prescaler and 3 independent frequency dividers. Each frequency divider has an output, which is
 //! used to allow the timer to control external circuitry (for example, IRQ 0).

--- a/framework/aster-frame/src/boot/kcmdline.rs
+++ b/framework/aster-frame/src/boot/kcmdline.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 //! The module to parse kernel command-line arguments.
 //!
 //! The format of the Asterinas command line string conforms

--- a/framework/aster-frame/src/boot/mod.rs
+++ b/framework/aster-frame/src/boot/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! The architecture-independent boot module, which provides a universal interface
 //! from the bootloader to the rest of the framework.
 //!

--- a/framework/aster-frame/src/bus/mmio/bus.rs
+++ b/framework/aster-frame/src/bus/mmio/bus.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::{collections::VecDeque, fmt::Debug, sync::Arc, vec::Vec};
 
 use log::{debug, error};

--- a/framework/aster-frame/src/bus/mmio/mod.rs
+++ b/framework/aster-frame/src/bus/mmio/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! Virtio over MMIO
 
 pub mod bus;

--- a/framework/aster-frame/src/bus/pci/bus.rs
+++ b/framework/aster-frame/src/bus/pci/bus.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 

--- a/framework/aster-frame/src/bus/pci/capability/mod.rs
+++ b/framework/aster-frame/src/bus/pci/capability/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::vec::Vec;
 
 use self::{msix::CapabilityMsixData, vendor::CapabilityVndrData};

--- a/framework/aster-frame/src/bus/pci/capability/msix.rs
+++ b/framework/aster-frame/src/bus/pci/capability/msix.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::{sync::Arc, vec::Vec};
 
 #[cfg(feature = "intel_tdx")]

--- a/framework/aster-frame/src/bus/pci/common_device.rs
+++ b/framework/aster-frame/src/bus/pci/common_device.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::vec::Vec;
 
 use super::{

--- a/framework/aster-frame/src/lib.rs
+++ b/framework/aster-frame/src/lib.rs
@@ -16,8 +16,6 @@
 #![feature(ptr_sub_ptr)]
 #![feature(strict_provenance)]
 #![feature(pointer_is_aligned)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
 // The `generic_const_exprs` feature is incomplete however required for the page table
 // const generic implementation. We are using this feature in a conservative manner.
 #![allow(incomplete_features)]

--- a/framework/aster-frame/src/mm/io.rs
+++ b/framework/aster-frame/src/mm/io.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::marker::PhantomData;
 
 use align_ext::AlignExt;

--- a/framework/aster-frame/src/mm/kspace.rs
+++ b/framework/aster-frame/src/mm/kspace.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! Kernel memory space management.
 //!
 //! The kernel memory space is currently managed as follows, if the

--- a/framework/aster-frame/src/mm/mod.rs
+++ b/framework/aster-frame/src/mm/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! Virtual memory (VM).
 
 /// Virtual addresses.

--- a/framework/aster-frame/src/mm/page/meta.rs
+++ b/framework/aster-frame/src/mm/page/meta.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! Metadata management of pages.
 //!
 //! You can picture a globally shared, static, gigantic arrary of metadata initialized for each page.

--- a/framework/aster-frame/src/mm/page/mod.rs
+++ b/framework/aster-frame/src/mm/page/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! Physical memory page management.
 //!
 //! A page is an aligned, contiguous range of bytes in physical memory. The sizes

--- a/framework/aster-frame/src/mm/page_table/cursor.rs
+++ b/framework/aster-frame/src/mm/page_table/cursor.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! The page table cursor for mapping and querying over the page table.
 //!
 //! ## The page table lock protocol

--- a/framework/aster-frame/src/mm/page_table/mod.rs
+++ b/framework/aster-frame/src/mm/page_table/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::{fmt::Debug, marker::PhantomData, ops::Range};
 
 use pod::Pod;

--- a/framework/aster-frame/src/mm/page_table/node.rs
+++ b/framework/aster-frame/src/mm/page_table/node.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! This module defines page table node abstractions and the handle.
 //!
 //! The page table node is also frequently referred to as a page table in many architectural

--- a/framework/aster-frame/src/sync/atomic_bits.rs
+++ b/framework/aster-frame/src/sync/atomic_bits.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::{
     fmt::{self},
     sync::atomic::{AtomicU64, Ordering::Relaxed},

--- a/framework/aster-frame/src/sync/rwlock.rs
+++ b/framework/aster-frame/src/sync/rwlock.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,

--- a/framework/aster-frame/src/sync/spin.rs
+++ b/framework/aster-frame/src/sync/spin.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,

--- a/framework/aster-frame/src/task/processor.rs
+++ b/framework/aster-frame/src/task/processor.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::sync::Arc;
 use core::{
     cell::RefCell,

--- a/framework/aster-frame/src/task/scheduler.rs
+++ b/framework/aster-frame/src/task/scheduler.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::collections::VecDeque;
 
 use lazy_static::lazy_static;

--- a/framework/aster-frame/src/task/task.rs
+++ b/framework/aster-frame/src/task/task.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::cell::UnsafeCell;
 
 use intrusive_collections::{intrusive_adapter, LinkedListAtomicLink};

--- a/framework/aster-frame/src/trap/irq.rs
+++ b/framework/aster-frame/src/trap/irq.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::fmt::Debug;
 
 use trapframe::TrapFrame;

--- a/framework/aster-frame/src/trap/softirq.rs
+++ b/framework/aster-frame/src/trap/softirq.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::boxed::Box;
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 

--- a/framework/aster-frame/src/user.rs
+++ b/framework/aster-frame/src/user.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! User space.
 
 use trapframe::TrapFrame;

--- a/kernel/aster-nix/src/device/null.rs
+++ b/kernel/aster-nix/src/device/null.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::*;
 use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
 

--- a/kernel/aster-nix/src/device/random.rs
+++ b/kernel/aster-nix/src/device/random.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use crate::{
     events::IoEvents,
     fs::{

--- a/kernel/aster-nix/src/device/tty/device.rs
+++ b/kernel/aster-nix/src/device/tty/device.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use crate::{
     events::IoEvents,
     fs::{

--- a/kernel/aster-nix/src/device/tty/driver.rs
+++ b/kernel/aster-nix/src/device/tty/driver.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 pub use aster_frame::arch::console;
 use aster_frame::mm::VmReader;
 use spin::Once;

--- a/kernel/aster-nix/src/device/tty/line_discipline.rs
+++ b/kernel/aster-nix/src/device/tty/line_discipline.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::format;
 
 use aster_frame::trap::{disable_local, in_interrupt_context};

--- a/kernel/aster-nix/src/device/tty/mod.rs
+++ b/kernel/aster-nix/src/device/tty/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_frame::early_print;
 use spin::Once;
 

--- a/kernel/aster-nix/src/device/tty/termio.rs
+++ b/kernel/aster-nix/src/device/tty/termio.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
 use crate::prelude::*;

--- a/kernel/aster-nix/src/device/urandom.rs
+++ b/kernel/aster-nix/src/device/urandom.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use crate::{
     events::IoEvents,
     fs::{

--- a/kernel/aster-nix/src/device/zero.rs
+++ b/kernel/aster-nix/src/device/zero.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::*;
 use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
 

--- a/kernel/aster-nix/src/error.rs
+++ b/kernel/aster-nix/src/error.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 /// Error number.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/kernel/aster-nix/src/events/observer.rs
+++ b/kernel/aster-nix/src/events/observer.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::Events;
 
 /// An observer for events.

--- a/kernel/aster-nix/src/fs/devpts/mod.rs
+++ b/kernel/aster-nix/src/fs/devpts/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::time::Duration;
 
 use aster_util::slot_vec::SlotVec;

--- a/kernel/aster-nix/src/fs/devpts/ptmx.rs
+++ b/kernel/aster-nix/src/fs/devpts/ptmx.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use super::*;
 use crate::{events::IoEvents, fs::inode_handle::FileIo, process::signal::Poller};
 

--- a/kernel/aster-nix/src/fs/devpts/slave.rs
+++ b/kernel/aster-nix/src/fs/devpts/slave.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use super::*;
 use crate::{
     device::PtySlave, events::IoEvents, fs::inode_handle::FileIo, process::signal::Poller,

--- a/kernel/aster-nix/src/fs/epoll/epoll_file.rs
+++ b/kernel/aster-nix/src/fs/epoll/epoll_file.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::{
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,

--- a/kernel/aster-nix/src/fs/exfat/bitmap.rs
+++ b/kernel/aster-nix/src/fs/exfat/bitmap.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::ops::Range;
 
 use align_ext::AlignExt;

--- a/kernel/aster-nix/src/fs/exfat/constants.rs
+++ b/kernel/aster-nix/src/fs/exfat/constants.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
+
+#![allow(dead_code)]
 pub(super) const ROOT_INODE_HASH: usize = 0;
 
 // Other pub(super) constants

--- a/kernel/aster-nix/src/fs/exfat/dentry.rs
+++ b/kernel/aster-nix/src/fs/exfat/dentry.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::ops::Range;
 
 use aster_frame::mm::VmIo;

--- a/kernel/aster-nix/src/fs/exfat/fs.rs
+++ b/kernel/aster-nix/src/fs/exfat/fs.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::{num::NonZeroUsize, ops::Range, sync::atomic::AtomicU64};
 
 use aster_block::{bio::BioWaiter, id::BlockId, BlockDevice};

--- a/kernel/aster-nix/src/fs/exfat/inode.rs
+++ b/kernel/aster-nix/src/fs/exfat/inode.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::string::String;
 use core::{cmp::Ordering, time::Duration};
 

--- a/kernel/aster-nix/src/fs/exfat/upcase_table.rs
+++ b/kernel/aster-nix/src/fs/exfat/upcase_table.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use align_ext::AlignExt;
 use aster_rights::Full;
 

--- a/kernel/aster-nix/src/fs/ext2/blocks_hole.rs
+++ b/kernel/aster-nix/src/fs/ext2/blocks_hole.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use bitvec::prelude::BitVec;
 
 /// A blocks hole descriptor implemented by the `BitVec`.

--- a/kernel/aster-nix/src/fs/ext2/dir.rs
+++ b/kernel/aster-nix/src/fs/ext2/dir.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::{
     inode::{FileType, MAX_FNAME_LEN},
     prelude::*,

--- a/kernel/aster-nix/src/fs/ext2/fs.rs
+++ b/kernel/aster-nix/src/fs/ext2/fs.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{
     block_group::{BlockGroup, RawGroupDescriptor},
     block_ptr::Ext2Bid,

--- a/kernel/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/aster-nix/src/fs/ext2/impl_for_vfs/inode.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::time::Duration;
 
 use aster_rights::Full;

--- a/kernel/aster-nix/src/fs/ext2/inode.rs
+++ b/kernel/aster-nix/src/fs/ext2/inode.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use inherit_methods_macro::inherit_methods;
 
 use super::{

--- a/kernel/aster-nix/src/fs/file_handle.rs
+++ b/kernel/aster-nix/src/fs/file_handle.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 //! Opend File Handle
 
 use crate::{

--- a/kernel/aster-nix/src/fs/file_table.rs
+++ b/kernel/aster-nix/src/fs/file_table.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::slot_vec::SlotVec;

--- a/kernel/aster-nix/src/fs/inode_handle/mod.rs
+++ b/kernel/aster-nix/src/fs/inode_handle/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 //! Opend Inode-backed File Handle
 
 mod dyn_cap;

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::{
     sync::atomic::{AtomicU32, Ordering},
     time::Duration,

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{
     file_handle::FileLike,
     utils::{AccessMode, Consumer, InodeMode, InodeType, Metadata, Producer, StatusFlags},

--- a/kernel/aster-nix/src/fs/procfs/template/builder.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/builder.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{
     dir::{DirOps, ProcDir},
     file::{FileOps, ProcFile},

--- a/kernel/aster-nix/src/fs/procfs/template/dir.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/dir.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::time::Duration;
 
 use aster_util::slot_vec::SlotVec;

--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use aster_rights::{Read, ReadOp, TRights, Write, WriteOp};

--- a/kernel/aster-nix/src/fs/utils/dirent_visitor.rs
+++ b/kernel/aster-nix/src/fs/utils/dirent_visitor.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::InodeType;
 use crate::prelude::*;
 

--- a/kernel/aster-nix/src/fs/utils/inode.rs
+++ b/kernel/aster-nix/src/fs/utils/inode.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::time::Duration;
 
 use aster_rights::Full;

--- a/kernel/aster-nix/src/fs/utils/random_test.rs
+++ b/kernel/aster-nix/src/fs/utils/random_test.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::sync::Arc;
 
 use hashbrown::HashMap;

--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -3,9 +3,7 @@
 //! The std library of Asterinas.
 #![no_std]
 #![deny(unsafe_code)]
-#![allow(dead_code)]
 #![allow(incomplete_features)]
-#![allow(unused_variables)]
 #![feature(btree_cursors)]
 #![feature(btree_extract_if)]
 #![feature(const_option)]

--- a/kernel/aster-nix/src/net/iface/any_socket.rs
+++ b/kernel/aster-nix/src/net/iface/any_socket.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{Iface, IpAddress, IpEndpoint};
 use crate::{events::Observer, prelude::*};
 

--- a/kernel/aster-nix/src/net/iface/loopback.rs
+++ b/kernel/aster-nix/src/net/iface/loopback.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use smoltcp::{
     iface::{Config, Routes},
     phy::{Loopback, Medium},

--- a/kernel/aster-nix/src/net/iface/virtio.rs
+++ b/kernel/aster-nix/src/net/iface/virtio.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use aster_network::AnyNetworkDevice;
 use aster_virtio::device::network::DEVICE_NAME;
 use smoltcp::{

--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
+
+#![allow(unused_variables)]
+
 use smoltcp::socket::udp::{RecvError, SendError};
 
 use crate::{

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use takeable::Takeable;

--- a/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use alloc::sync::Weak;
 
 use smoltcp::socket::tcp::{RecvError, SendError};

--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
+
+#![allow(unused_variables)]
+
 use smoltcp::socket::tcp::ListenError;
 
 use super::connected::ConnectedStream;

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use connected::ConnectedStream;

--- a/kernel/aster-nix/src/net/socket/mod.rs
+++ b/kernel/aster-nix/src/net/socket/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use self::options::SocketOption;
 pub use self::util::{
     options::LingerOption, send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd,

--- a/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::endpoint::Endpoint;
 use crate::{
     events::IoEvents,

--- a/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use crate::{
     events::IoEvents,
     fs::utils::{Channel, Consumer, Producer, StatusFlags},

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use super::{connected::Connected, endpoint::Endpoint, listener::push_incoming};

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use super::{
     connected::Connected,
     endpoint::Endpoint,

--- a/kernel/aster-nix/src/net/socket/util/options.rs
+++ b/kernel/aster-nix/src/net/socket/util/options.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::time::Duration;
 
 use crate::{

--- a/kernel/aster-nix/src/process/clone.rs
+++ b/kernel/aster-nix/src/process/clone.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::sync::atomic::Ordering;
 
 use aster_frame::{

--- a/kernel/aster-nix/src/process/credentials/static_cap.rs
+++ b/kernel/aster-nix/src/process/credentials/static_cap.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_frame::sync::{RwLockReadGuard, RwLockWriteGuard};
 use aster_rights::{Dup, Read, TRights, Write};
 use aster_rights_proc::require;

--- a/kernel/aster-nix/src/process/posix_thread/builder.rs
+++ b/kernel/aster-nix/src/process/posix_thread/builder.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_frame::user::UserSpace;
 
 use super::PosixThread;

--- a/kernel/aster-nix/src/process/posix_thread/futex.rs
+++ b/kernel/aster-nix/src/process/posix_thread/futex.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_frame::cpu::num_cpus;

--- a/kernel/aster-nix/src/process/posix_thread/mod.rs
+++ b/kernel/aster-nix/src/process/posix_thread/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_rights::{ReadOp, WriteOp};
 use futex::futex_wake;
 use robust_list::wake_robust_futex;

--- a/kernel/aster-nix/src/process/process/builder.rs
+++ b/kernel/aster-nix/src/process/process/builder.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{Pid, Process};
 use crate::{
     fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},

--- a/kernel/aster-nix/src/process/process/job_control.rs
+++ b/kernel/aster-nix/src/process/process/job_control.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use crate::{
     prelude::*,
     process::{

--- a/kernel/aster-nix/src/process/process_filter.rs
+++ b/kernel/aster-nix/src/process/process_filter.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{Pgid, Pid};
 use crate::prelude::*;
 

--- a/kernel/aster-nix/src/process/process_table.rs
+++ b/kernel/aster-nix/src/process/process_table.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! A global table stores the pid to process mapping.
 //! This table can be used to get process with pid.
 //! TODO: progress group, thread all need similar mapping

--- a/kernel/aster-nix/src/process/process_vm/init_stack/aux_vec.rs
+++ b/kernel/aster-nix/src/process/process_vm/init_stack/aux_vec.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use crate::prelude::*;
 
 /// Auxiliary Vector.

--- a/kernel/aster-nix/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/aster-nix/src/process/process_vm/init_stack/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! The init stack for the process.
 //! The init stack is used to store the `argv` and `envp` and auxiliary vectors.
 //! We can read `argv` and `envp` of a process from the init stack.

--- a/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! This module is used to parse elf file content to get elf_load_info.
 //! When create a process from elf file, we will use the elf_load_info to construct the VmSpace
 

--- a/kernel/aster-nix/src/process/signal/c_types.rs
+++ b/kernel/aster-nix/src/process/signal/c_types.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
 #![allow(non_camel_case_types)]
+
 use core::mem::{self, size_of};
 
 use aster_frame::cpu::GeneralRegs;

--- a/kernel/aster-nix/src/process/signal/constants.rs
+++ b/kernel/aster-nix/src/process/signal/constants.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 /// Standard signals
 pub(super) const MIN_STD_SIG_NUM: u8 = 1;
 pub(super) const MAX_STD_SIG_NUM: u8 = 31; // inclusive

--- a/kernel/aster-nix/src/process/signal/pauser.rs
+++ b/kernel/aster-nix/src/process/signal/pauser.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use core::{
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,

--- a/kernel/aster-nix/src/process/signal/signals/user.rs
+++ b/kernel/aster-nix/src/process/signal/signals/user.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::Signal;
 use crate::process::{
     signal::{

--- a/kernel/aster-nix/src/process/status.rs
+++ b/kernel/aster-nix/src/process/status.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! The process status
 
 use super::TermStatus;

--- a/kernel/aster-nix/src/process/sync/condvar.rs
+++ b/kernel/aster-nix/src/process/sync/condvar.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use alloc::sync::Arc;
 use core::time::Duration;
 

--- a/kernel/aster-nix/src/process/wait.rs
+++ b/kernel/aster-nix/src/process/wait.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::{process_filter::ProcessFilter, ExitCode, Pid, Process};
 use crate::{prelude::*, process::process_table, thread::thread_table};
 

--- a/kernel/aster-nix/src/syscall/fork.rs
+++ b/kernel/aster-nix/src/syscall/fork.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use aster_frame::cpu::UserContext;
 
 use super::SyscallReturn;

--- a/kernel/aster-nix/src/syscall/getdents64.rs
+++ b/kernel/aster-nix/src/syscall/getdents64.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::marker::PhantomData;
 
 use super::SyscallReturn;

--- a/kernel/aster-nix/src/syscall/mmap.rs
+++ b/kernel/aster-nix/src/syscall/mmap.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 //! This mod defines mmap flags and the handler to syscall mmap
 
 use align_ext::AlignExt;

--- a/kernel/aster-nix/src/syscall/prctl.rs
+++ b/kernel/aster-nix/src/syscall/prctl.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use super::SyscallReturn;
 use crate::{
     prelude::*,

--- a/kernel/aster-nix/src/syscall/rt_sigpending.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigpending.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::SyscallReturn;
 use crate::{prelude::*, process::posix_thread::PosixThreadExt, util::write_val_to_user};
 

--- a/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use aster_frame::mm::VmIo;
 
 use super::SyscallReturn;

--- a/kernel/aster-nix/src/syscall/select.rs
+++ b/kernel/aster-nix/src/syscall/select.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::time::Duration;
 
 use super::{

--- a/kernel/aster-nix/src/syscall/sigaltstack.rs
+++ b/kernel/aster-nix/src/syscall/sigaltstack.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::SyscallReturn;
 use crate::{
     prelude::*,

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::SyscallReturn;
 use crate::{
     fs::{

--- a/kernel/aster-nix/src/syscall/waitid.rs
+++ b/kernel/aster-nix/src/syscall/waitid.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use super::SyscallReturn;
 use crate::{
     prelude::*,

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::SyscallReturn;
 use crate::{fs::file_table::FileDesc, prelude::*, util::read_bytes_from_user};
 

--- a/kernel/aster-nix/src/syscall/writev.rs
+++ b/kernel/aster-nix/src/syscall/writev.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,

--- a/kernel/aster-nix/src/taskless.rs
+++ b/kernel/aster-nix/src/taskless.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use alloc::{boxed::Box, sync::Arc};
 use core::{
     cell::RefCell,

--- a/kernel/aster-nix/src/thread/exception.rs
+++ b/kernel/aster-nix/src/thread/exception.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use aster_frame::cpu::*;
 
 use crate::{

--- a/kernel/aster-nix/src/thread/work_queue/mod.rs
+++ b/kernel/aster-nix/src/thread/work_queue/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_frame::cpu::CpuSet;
 use spin::Once;
 use work_item::WorkItem;

--- a/kernel/aster-nix/src/thread/work_queue/work_item.rs
+++ b/kernel/aster-nix/src/thread/work_queue/work_item.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_frame::cpu::CpuSet;

--- a/kernel/aster-nix/src/thread/work_queue/worker.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use aster_frame::{cpu::CpuSet, task::Priority};
 
 use super::worker_pool::WorkerPool;

--- a/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_frame::{cpu::CpuSet, sync::WaitQueue, task::Priority};

--- a/kernel/aster-nix/src/util/net/addr.rs
+++ b/kernel/aster-nix/src/util/net/addr.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use crate::{
     net::{
         iface::Ipv4Address,

--- a/kernel/aster-nix/src/util/random.rs
+++ b/kernel/aster-nix/src/util/random.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 use rand::{rngs::StdRng, Error as RandError, RngCore};
 use spin::Once;
 

--- a/kernel/aster-nix/src/vdso.rs
+++ b/kernel/aster-nix/src/vdso.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! The Virtual Dynamic Shared Object (VDSO) module enables user space applications to access kernel space routines
 //! without the need for context switching. This is particularly useful for frequently invoked operations such as
 //! obtaining the current time, which can be more efficiently handled within the user space.

--- a/kernel/aster-nix/src/vm/vmar/mod.rs
+++ b/kernel/aster-nix/src/vm/vmar/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 //! Virtual Memory Address Regions (VMARs).
 
 mod dyn_cap;

--- a/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
+++ b/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use core::ops::Range;
 
 use aster_frame::mm::{Frame, FrameVec, PageFlags, VmIo, VmMapOptions, VmSpace};

--- a/kernel/aster-nix/src/vm/vmo/mod.rs
+++ b/kernel/aster-nix/src/vm/vmo/mod.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 //! Virtual Memory Objects (VMOs).
 
 use core::ops::Range;

--- a/kernel/aster-nix/src/vm/vmo/options.rs
+++ b/kernel/aster-nix/src/vm/vmo/options.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unused_variables)]
+
 //! Options for allocating root and child VMOs.
 
 use core::{marker::PhantomData, ops::Range};


### PR DESCRIPTION
We should make use of the `dead_code` and `unused_variables` lints to
 - help clean up our codebase, and
 - give a red CI status to anyone who tries to add dead code to our codebase.

These two lints are even enabled by default, but are explicitly disabled at the crate level in Asterinas.

https://github.com/asterinas/asterinas/blob/232e62b0538f9fcb28789d9d41780eccc64613c1/framework/aster-frame/src/lib.rs#L19-L20

https://github.com/asterinas/asterinas/blob/232e62b0538f9fcb28789d9d41780eccc64613c1/kernel/aster-nix/src/lib.rs#L6-L8

This PR proposes to remove the disabling. However, re-enabling these two lints generates too many warnings, and they are difficult to fix or even review in a single PR.

So instead, this PR does nothing more than move the `#![allow(dead_code)]` / `#![allow(unused_variables)]` from the crate level to the file level (more precisely, to only files that actually generate some warnings), so that we can fix the warnings file by file (or module by module) later.

*Note:* This PR currently only addresses `aster-frame` and `aster-nix`, leaving other components unchanged.