### PR TITLE
Fix Monitor priority issue 

### DIFF
--- a/kernel/aster-nix/src/thread/work_queue/mod.rs
+++ b/kernel/aster-nix/src/thread/work_queue/mod.rs
@@ -141,6 +141,9 @@ impl WorkQueue {
             .lock_irq_disabled()
             .pending_work_items
             .push(work_item);
+        if let Some(worker_pool) = self.worker_pool.upgrade() {
+            worker_pool.schedule()
+        }
         true
     }
 

--- a/kernel/aster-nix/src/thread/work_queue/worker.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker.rs
@@ -97,6 +97,10 @@ impl Worker {
         self.exit();
     }
 
+    pub(super) fn bound_thread(&self) -> &Arc<Thread> {
+        &self.bound_thread
+    }
+
     pub(super) fn is_idle(&self) -> bool {
         self.inner.lock_irq_disabled().worker_status == WorkerStatus::Idle
     }

--- a/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
@@ -139,7 +139,7 @@ impl WorkerPool {
             }
             WorkerPool {
                 local_pools,
-                monitor: Monitor::new(pool_ref.clone()),
+                monitor: Monitor::new(pool_ref.clone(), &priority),
                 priority,
                 cpu_set,
                 scheduler: Arc::new(SimpleScheduler::new(pool_ref.clone())),
@@ -230,7 +230,7 @@ impl Drop for WorkerPool {
 }
 
 impl Monitor {
-    pub fn new(worker_pool: Weak<WorkerPool>) -> Arc<Self> {
+    pub fn new(worker_pool: Weak<WorkerPool>, priority: &WorkPriority) -> Arc<Self> {
         Arc::new_cyclic(|monitor_ref| {
             let weal_monitor = monitor_ref.clone();
             let task_fn = Box::new(move || {
@@ -238,10 +238,14 @@ impl Monitor {
                 current_monitor.run_monitor_loop();
             });
             let cpu_affinity = CpuSet::new_full();
+            let priority = match priority {
+                WorkPriority::High => Priority::high(),
+                WorkPriority::Normal => Priority::normal(),
+            };
             let bound_thread = Thread::new_kernel_thread(
                 ThreadOptions::new(task_fn)
                     .cpu_affinity(cpu_affinity)
-                    .priority(Priority::normal()),
+                    .priority(priority),
             );
             Self {
                 worker_pool,
@@ -255,6 +259,8 @@ impl Monitor {
     }
 
     fn run_monitor_loop(self: &Arc<Self>) {
+        let sleep_queue = WaitQueue::new();
+        let sleep_duration = Duration::from_millis(100);
         loop {
             let worker_pool = self.worker_pool.upgrade();
             let Some(worker_pool) = worker_pool else {
@@ -264,7 +270,7 @@ impl Monitor {
             for local_pool in worker_pool.local_pools.iter() {
                 local_pool.set_heartbeat(false);
             }
-            Thread::yield_now();
+            sleep_queue.wait_until_or_timeout(|| -> Option<()> { None }, &sleep_duration);
         }
     }
 }

--- a/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker_pool.rs
@@ -2,9 +2,16 @@
 
 #![allow(dead_code)]
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
-use aster_frame::{cpu::CpuSet, sync::WaitQueue, task::Priority};
+use aster_frame::{
+    cpu::CpuSet,
+    sync::WaitQueue,
+    task::{add_task, Priority},
+};
 
 use super::{simple_scheduler::SimpleScheduler, worker::Worker, WorkItem, WorkPriority, WorkQueue};
 use crate::{
@@ -74,7 +81,7 @@ impl LocalWorkerPool {
     fn add_worker(&self) {
         let worker = Worker::new(self.parent.clone(), self.cpu_id);
         self.workers.lock_irq_disabled().push_back(worker.clone());
-        worker.run();
+        add_task(worker.bound_thread().task().clone());
     }
 
     fn remove_worker(&self) {


### PR DESCRIPTION
PR #782 has fixed issue #774. However, I found that the syscall, and fstime benchmark in Unixbench have failed in the newest commit. This PR will fix this problem.

The `Workerpool` and `Monitor` have different priorities, which has led to the following issues:
1. The `WorkerScheduler` cannot schedule pending work items in time to process them.
2. The `Monitor` fails to set the heartbeat (for example, in the syscall test) on time, causing the schedule function to incorrectly determine that the worker does not need to be awakened.

Due to these issues, we need to either redesign the `Monitor` or temporarily synchronize its priorities with the worker pool. In this pull request, I also set the interval for the `Monitor` to 100ms instead of calling `Thread::yield_now()`.