### PR TITLE
Refine the scripts for syscall test

### DIFF
--- a/regression/syscall_test/Makefile
+++ b/regression/syscall_test/Makefile
@@ -62,7 +62,7 @@ $(TESTS): $(BIN_DIR) $(TARGET_DIR)
 ifndef ASTER_PREBUILT_SYSCALL_TEST
 $(BIN_DIR): $(SRC_DIR)
 	@if ! type bazel > /dev/null; then \
-		echo "bazel is not installed, please run $(CUR_DIR)/install_bazel.sh with sudo permission to install it."; \
+		echo "bazel is not installed, please run tools/install_bazel.sh with sudo permission to install it."; \
 		exit 1; \
 	fi
 	@rm -rf $@ && mkdir -p $@

--- a/regression/syscall_test/run_syscall_test.sh
+++ b/regression/syscall_test/run_syscall_test.sh
@@ -39,7 +39,7 @@ run_one_test(){
     ret=0
     if [ -f $TEST_BIN_DIR/$1 ]; then
         get_blocklist_subtests $1
-        $TEST_BIN_DIR/$1 --gtest_filter=-$BLOCK
+        cd $TEST_BIN_DIR && ./$1 --gtest_filter=-$BLOCK
         ret=$?
         #After executing the test, it is necessary to clean the directory to ensure no residual data remains
         rm -rf $TEST_TMP_DIR/*

--- a/tools/docker/Dockerfile.ubuntu22.04
+++ b/tools/docker/Dockerfile.ubuntu22.04
@@ -64,11 +64,10 @@ RUN rm -rf sysbench-1.0.20 \
 FROM build-base as build-bazel
 
 # Install bazel, which is required by the system call test suite from Gvisor project
+RUN mkdir -p /root/bazel
+COPY tools/install_bazel.sh /root/bazel/
 WORKDIR /root/bazel
-RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-RUN mv bazel.gpg /etc/apt/trusted.gpg.d
-RUN echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' | tee /etc/apt/sources.list.d/bazel.list
-RUN apt update && apt install bazel=5.4.0 -y
+RUN ./install_bazel.sh
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /root
 RUN rm -rf bazel

--- a/tools/install_bazel.sh
+++ b/tools/install_bazel.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+if type bazel > /dev/null; then
+    echo "Bazel has been installed already"
+    exit 0
+fi
+
+apt update && apt install curl gnupg -y
+curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+mv bazel.gpg /etc/apt/trusted.gpg.d/
+
+echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' | tee /etc/apt/sources.list.d/bazel.list
+apt update && apt install bazel=5.4.0 -y
+
+echo "Bazel is installed successfully"


### PR DESCRIPTION
1. The Makefile of syscall_test may need to install bazel manually, so we need this script here.
```
ifndef ASTER_PREBUILT_SYSCALL_TEST
$(BIN_DIR): $(SRC_DIR)
	@if ! type bazel > /dev/null; then \
		echo "bazel is not installed, please run $(CUR_DIR)/install_bazel.sh with sudo permission to install it."; \
		exit 1; \
	fi
	@rm -rf $@ && mkdir -p $@
	@cd $(SRC_DIR) && bazel build --test_tag_filters=native //test/syscalls/...
	@cp $(SRC_DIR)/bazel-bin/test/syscalls/linux/*_test $@
```

2. Some test cases need the `cwd` in the same dir of the test binary, so we modify the `run_syscall_test.sh` 