### PR TITLE
Add mount namespace and dummy implementation of syscall unshare.

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -292,7 +292,7 @@ provided by Linux on x86-64 architecture.
 | 269     | faccessat        | ✅              |
 | 270     | pselect6         | ✅              |
 | 271     | ppoll            | ❌              |
-| 272     | unshare          | ❌              |
+| 272     | unshare          | ✅              |
 | 273     | set_robust_list  | ✅              |
 | 274     | get_robust_list  | ❌              |
 | 275     | splice           | ❌              |

--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -698,7 +698,7 @@ impl Dentry {
     /// Unmounts and returns the mounted child mount.
     ///
     /// Note that the root mount cannot be unmounted.
-    pub fn unmount(&self) -> Result<Arc<MountNode>> {
+    pub(super) fn unmount(&self) -> Result<Arc<MountNode>> {
         if !self.inner.is_root_of_mount() {
             return_errno_with_message!(Errno::EINVAL, "not mounted");
         }
@@ -752,7 +752,7 @@ impl Dentry {
     /// If `recursive` is true, it will bind mount the whole mount tree
     /// to the destination `Dentry`. Otherwise, it will only bind mount
     /// the root mount node.
-    pub fn bind_mount_to(&self, dst_dentry: &Self, recursive: bool) -> Result<()> {
+    pub(super) fn bind_mount_to(&self, dst_dentry: &Self, recursive: bool) -> Result<()> {
         let src_mount = self
             .mount_node
             .clone_mount_node_tree(&self.inner, recursive);

--- a/kernel/src/fs/path/mnt_namespace.rs
+++ b/kernel/src/fs/path/mnt_namespace.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::Arc;
+
+use crate::{
+    fs::{
+        path::{Dentry, MountNode},
+        rootfs::root_mount,
+        thread_info::ThreadFsInfo,
+    },
+    prelude::*,
+};
+
+pub struct MntNamespace_ {
+    root: Arc<MountNode>,
+}
+
+impl MntNamespace_ {
+    pub fn default() -> Self {
+        Self {
+            root: root_mount().clone(),
+        }
+    }
+
+    pub fn copy_mnt_ns(&self, fs: &Arc<ThreadFsInfo>) -> Self {
+        let old_mount_node = self.root.clone();
+        let new_mount_node = old_mount_node.clone_mount_node_tree_and_move(fs);
+        Self {
+            root: new_mount_node,
+        }
+    }
+
+    pub fn sync(&self, mount: Arc<MountNode>) -> Result<()> {
+        mount.sync()?;
+        Ok(())
+    }
+
+    pub fn graft_mount_node_tree(&self, mount: Arc<MountNode>, mountpoint: &Dentry) -> Result<()> {
+        mount.graft_mount_node_tree(mountpoint)?;
+        Ok(())
+    }
+
+    pub fn bind_mount_to(
+        &self,
+        src_dentry: &Dentry,
+        dst_dentry: &Dentry,
+        recursive: bool,
+    ) -> Result<()> {
+        src_dentry.bind_mount_to(dst_dentry, recursive)?;
+        Ok(())
+    }
+
+    pub fn umount(&self, dentry: &Dentry) -> Result<Arc<MountNode>> {
+        dentry.unmount()
+    }
+}

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -3,9 +3,11 @@
 //! Form file paths within and across FSes with dentries and mount points.
 
 pub use dentry::{Dentry, DentryKey};
+pub use mnt_namespace::MntNamespace_;
 pub use mount::MountNode;
 
 mod dentry;
+mod mnt_namespace;
 mod mount;
 
 /// Checks if the file name is ".", indicating it's the current directory.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -4,6 +4,7 @@ mod clone;
 pub mod credentials;
 mod exit;
 mod kill;
+mod namespaces;
 pub mod posix_thread;
 #[expect(clippy::module_inception)]
 mod process;
@@ -19,9 +20,10 @@ mod task_set;
 mod term_status;
 mod wait;
 
-pub use clone::{clone_child, CloneArgs, CloneFlags};
+pub use clone::{clone_child, unshare, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
+pub use namespaces::Namespaces;
 pub use process::{
     ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, Session, Sid, Terminal,
 };

--- a/kernel/src/process/namespaces/mnt_namespace.rs
+++ b/kernel/src/process/namespaces/mnt_namespace.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{path::MountNode, rootfs::root_mount, thread_info::ThreadFsInfo},
+    prelude::*,
+};
+
+pub struct MntNamespace {
+    root: Arc<MountNode>,
+}
+
+impl Default for MntNamespace {
+    fn default() -> Self {
+        Self {
+            root: root_mount().clone(),
+        }
+    }
+}
+
+impl MntNamespace {
+    fn new(mount_node: Arc<MountNode>) -> Arc<Self> {
+        Arc::new(Self { root: mount_node })
+    }
+
+    pub fn root(&self) -> &Arc<MountNode> {
+        &self.root
+    }
+
+    /// Copy the mount namespace.
+    ///
+    /// This function is used to create a new mount namespace for a process.
+    /// process's root and cwd will be updated to the new mount namespace.
+    /// In syscall clone, `process` is the new process that is created by clone.
+    /// In syscall unshare and setns, `process` is the current process
+    pub fn copy_mnt_ns(&self, fs: &Arc<ThreadFsInfo>) -> Arc<Self> {
+        let old_mount_node = self.root();
+        let new_mount_node = old_mount_node.clone_mount_node_tree_and_move(fs);
+        Self::new(new_mount_node)
+    }
+}

--- a/kernel/src/process/namespaces/mod.rs
+++ b/kernel/src/process/namespaces/mod.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub mod mnt_namespace;
+
+use crate::{prelude::*, process::namespaces::mnt_namespace::MntNamespace};
+pub struct Namespaces {
+    mnt_ns: Arc<MntNamespace>,
+}
+
+impl Default for Namespaces {
+    fn default() -> Self {
+        Self {
+            mnt_ns: Arc::new(MntNamespace::default()),
+        }
+    }
+}
+
+impl Namespaces {
+    pub fn new(mnt_ns: Arc<MntNamespace>) -> Self {
+        Self { mnt_ns }
+    }
+
+    pub fn mnt_ns(&self) -> &Arc<MntNamespace> {
+        &self.mnt_ns
+    }
+
+    /// Reset the namespaces of the process.
+    pub fn reset_namespaces(&mut self, namespaces: Mutex<Namespaces>) {
+        let namespaces = namespaces.lock();
+        self.mnt_ns = namespaces.mnt_ns().clone();
+    }
+}

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -15,7 +15,7 @@ use super::{
         signals::Signal,
         SigEvents, SigEventsFilter,
     },
-    Credentials, Process,
+    Credentials, Namespaces, Process,
 };
 use crate::{
     events::Observer,
@@ -58,6 +58,9 @@ pub struct PosixThread {
     file_table: RoArc<FileTable>,
     /// File system
     fs: Arc<ThreadFsInfo>,
+
+    // Namespace
+    namespaces: Mutex<Namespaces>,
 
     // Signal
     /// Blocked signals
@@ -102,6 +105,15 @@ impl PosixThread {
 
     pub fn fs(&self) -> &Arc<ThreadFsInfo> {
         &self.fs
+    }
+
+    pub fn namespaces(&self) -> &Mutex<Namespaces> {
+        &self.namespaces
+    }
+
+    pub fn switch_namespaces(&self, new_namespaces: Mutex<Namespaces>) {
+        let old_namespaces = &mut self.namespaces.lock();
+        old_namespaces.reset_namespaces(new_namespaces);
     }
 
     /// Get the reference to the signal mask of the thread.

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -189,7 +189,6 @@ impl Process {
         parent: Weak<Process>,
         executable_path: String,
         process_vm: ProcessVm,
-
         resource_limits: ResourceLimits,
         nice: Nice,
         sig_dispositions: Arc<Mutex<SigDispositions>>,

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -145,6 +145,7 @@ use crate::syscall::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
+    unshare::sys_unshare,
     utimens::{sys_futimesat, sys_utime, sys_utimensat, sys_utimes},
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -335,6 +336,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FCHMODAT = 268         => sys_fchmodat(args[..3]);
     SYS_FACCESSAT = 269        => sys_faccessat(args[..3]);
     SYS_PSELECT6 = 270         => sys_pselect6(args[..6]);
+    SYS_UNSHARE = 272          => sys_unshare(args[..1]);
     SYS_SET_ROBUST_LIST = 273  => sys_set_robust_list(args[..2]);
     SYS_UTIMENSAT = 280        => sys_utimensat(args[..4]);
     SYS_EPOLL_PWAIT = 281      => sys_epoll_pwait(args[..6]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -152,6 +152,7 @@ mod umask;
 mod umount;
 mod uname;
 mod unlink;
+mod unshare;
 mod utimens;
 mod wait4;
 mod waitid;

--- a/kernel/src/syscall/sync.rs
+++ b/kernel/src/syscall/sync.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::prelude::*;
+use crate::{prelude::*, process::posix_thread::AsPosixThread};
 
 pub fn sys_sync(_ctx: &Context) -> Result<SyscallReturn> {
-    crate::fs::rootfs::root_mount().sync()?;
+    let current_thread = current_thread!();
+    let posix_thread = current_thread.as_posix_thread().unwrap();
+    let namespaces = posix_thread.namespaces().lock();
+    let mnt_ns = namespaces.mnt_ns().inner();
+    mnt_ns.sync(crate::fs::rootfs::root_mount().clone())?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MPL-2.0
+use super::SyscallReturn;
+use crate::{
+    prelude::*,
+    process::{unshare, CloneFlags},
+};
+
+pub fn sys_unshare(unshare_flags: u64, _ctx: &Context) -> Result<SyscallReturn> {
+    let unshare_flags = CloneFlags::from(unshare_flags);
+    debug!("flags = {:?}", unshare_flags);
+    unshare(unshare_flags, &_ctx.posix_thread.fs())?;
+    Ok(SyscallReturn::Return(0))
+}

--- a/test/apps/Makefile
+++ b/test/apps/Makefile
@@ -31,6 +31,7 @@ TEST_APPS := \
 	itimer \
 	mmap \
 	mongoose \
+	namespaces \
 	network \
 	pipe \
 	prctl \

--- a/test/apps/namespaces/Makefile
+++ b/test/apps/namespaces/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/apps/namespaces/mount_namespace_clone.c
+++ b/test/apps/namespaces/mount_namespace_clone.c
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+// Function to list contents of a directory.
+void list_dir(const char *path)
+{
+	DIR *d;
+	struct dirent *dir;
+	d = opendir(path);
+	if (d) {
+		printf("------Contents of %s:\n", path);
+		while ((dir = readdir(d)) != NULL) {
+			printf("%s\n", dir->d_name);
+		}
+		closedir(d);
+	} else {
+		perror("opendir");
+	}
+}
+
+int child_fn(void *arg)
+{
+	printf("--------In child process---------\n");
+
+	// Mount a new ext2 filesystem.
+	if (mount("vext2", "/mnt", "ext2", 0, "") != 0) {
+		perror("mount");
+		return 1;
+	}
+
+	printf("Mounted ext2 on /mnt in new namespace\n");
+
+	// Check the mount status in the new namespace.
+	list_dir("/mnt");
+
+	// Unmount the old ext2 filesystem.
+	if (umount("/ext2") != 0) {
+		perror("umount");
+		return 1;
+	}
+
+	printf("Unmounted /ext2 in new namespace\n");
+
+	// Check the mount status again after unmounting.
+	list_dir("/ext2");
+
+	return 0;
+}
+
+#define STACK_SIZE (1024 * 1024) // Define the stack size for the child process.
+
+int main()
+{
+	printf("--------In parent process---------\n");
+
+	// Create the /mnt directory if it doesn't exist
+	if (mkdir("/mnt", 0755) == -1 && errno != EEXIST) {
+		perror("mkdir");
+		exit(EXIT_FAILURE);
+	}
+
+	// Check the initial mount status in the old namespace.
+	printf("Check old namespace mounts:\n");
+	list_dir("/mnt");
+	list_dir("/ext2");
+
+	// Allocate stack for the child process.
+	char *stack = malloc(STACK_SIZE);
+	if (stack == NULL) {
+		perror("malloc");
+		exit(EXIT_FAILURE);
+	}
+
+	// Create a new child process using clone.
+	pid_t pid = clone(child_fn, stack + STACK_SIZE, CLONE_NEWNS | SIGCHLD,
+			  NULL);
+	if (pid == -1) {
+		perror("clone");
+		free(stack);
+		exit(EXIT_FAILURE);
+	}
+
+	// In parent process, wait for the child to finish.
+	if (waitpid(pid, NULL, 0) == -1) {
+		perror("waitpid");
+		free(stack);
+		exit(EXIT_FAILURE);
+	}
+	printf("--------Child process exited--------\n");
+
+	// Free the allocated stack.
+	free(stack);
+
+	// Check mounts in the parent namespace after child exits.
+	printf("Check old namespace mounts:\n");
+	list_dir("/mnt");
+	list_dir("/ext2");
+
+	return 0;
+}

--- a/test/apps/namespaces/mount_namespace_unshare.c
+++ b/test/apps/namespaces/mount_namespace_unshare.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+// Function to list contents of a directory.
+void list_dir(const char *path)
+{
+	DIR *d;
+	struct dirent *dir;
+	d = opendir(path);
+	if (d) {
+		printf("------Contents of %s:\n", path);
+		while ((dir = readdir(d)) != NULL) {
+			printf("%s\n", dir->d_name);
+		}
+		closedir(d);
+	} else {
+		perror("opendir");
+	}
+}
+
+int child_fn()
+{
+	printf("--------In child process---------\n");
+
+	// Use unshare to create new mount namespace.
+	if (unshare(CLONE_NEWNS) == -1) {
+		perror("unshare");
+		return 1;
+	}
+
+	// Mount a new ext2 filesystem.
+	if (mount("vext2", "/mnt", "ext2", 0, "") != 0) {
+		perror("mount");
+		return 1;
+	}
+
+	printf("Mounted ext2 on /mnt in new namespace\n");
+
+	// Check the mount status in the new namespace.
+	list_dir("/mnt");
+
+	// Unmount the old ext2 filesystem.
+	if (umount("/ext2") != 0) {
+		perror("umount");
+		return 1;
+	}
+
+	printf("Unmounted /ext2 in new namespace\n");
+
+	// Check the mount status again after unmounting.
+	list_dir("/ext2");
+
+	return 0;
+}
+
+int main()
+{
+	printf("--------In parent process---------\n");
+
+	// Create the /mnt directory if it doesn't exist
+	if (mkdir("/mnt", 0755) == -1 && errno != EEXIST) {
+		perror("mkdir");
+		exit(EXIT_FAILURE);
+	}
+
+	// Check the initial mount status in the old namespace.
+	printf("Check old namespace mounts:\n");
+	list_dir("/mnt");
+	list_dir("/ext2");
+
+	// Create a new child process.
+	pid_t pid = fork();
+	if (pid == -1) {
+		perror("fork");
+		exit(EXIT_FAILURE);
+	}
+
+	if (pid == 0) {
+		// In child process run the child function.
+		exit(child_fn());
+	} else {
+		// In parent process, wait for the child to finish.
+		if (waitpid(pid, NULL, 0) == -1) {
+			perror("waitpid");
+			exit(EXIT_FAILURE);
+		}
+		printf("--------Child process exited--------\n");
+
+		// Check mounts in the parent namespace after child exits.
+		printf("Check old namespace mounts:\n");
+		list_dir("/mnt");
+		list_dir("/ext2");
+	}
+
+	return 0;
+}

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -58,6 +58,7 @@ TESTS ?= \
 	uidgid_test \
 	unlink_test \
 	utimes_test \
+	unshare_test \
 	vdso_clock_gettime_test \
 	vfork_test \
 	write_test \

--- a/test/syscall_test/blocklists/unshare_test
+++ b/test/syscall_test/blocklists/unshare_test
@@ -1,0 +1,1 @@
+UnshareTest.ThreadFlagFailsIfMultithreaded


### PR DESCRIPTION
This PR primarily accomplishes the following tasks:

#### Introduction of `Mount Namespace`:

- The `struct Process` has been augmented with a `namespaces` field: `Arc<Mutex<Namespaces>>`
- A new `struct Namespace` has been introduced to manage all namespaces.
- A new `struct MntNamespace` has been created to handle the management of the mount namespace.
#### Enhancements at the VFS layer:

- Code has been added to facilitate the movement of a process's root and current working directory (cwd) within the VFS layer.
#### Implementation of unshare system call:

- A dummy implementation of the unshare system call has been added, with support for the `CLONE_NEWNS` flag only, enabling the creation of a new mount namespace.
#### Test cases for Mount Namespace:

- Test cases have been added to verify the isolation of mount and unmount operations within the mount namespace, using `clone(CLONE_NEWNS)` and `unshare(CLONE_NEWNS)`.