### PR TITLE
Optimize write_bytes for Vmo

### DIFF
--- a/kernel/aster-nix/src/fs/utils/page_cache.rs
+++ b/kernel/aster-nix/src/fs/utils/page_cache.rs
@@ -198,6 +198,15 @@ impl Pager for PageCacheManager {
 
         Ok(())
     }
+
+    fn commit_overwrite(&self, idx: usize) -> Result<Frame> {
+        if let Some(page) = self.pages.lock().get(&idx) {
+            return Ok(page.frame.clone());
+        }
+
+        let page = Page::alloc_zero()?;
+        Ok(self.pages.lock().get_or_insert(idx, || page).frame.clone())
+    }
 }
 
 #[derive(Debug)]

--- a/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
+++ b/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
@@ -7,7 +7,7 @@ use aster_rights::{Rights, TRights};
 
 use super::{
     options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions, VmoRightsOp,
+    CommitFlags, Vmo, VmoChildOptions, VmoRightsOp,
 };
 use crate::prelude::*;
 
@@ -84,7 +84,8 @@ impl Vmo<Rights> {
     /// The method requires the Write right.
     pub fn commit(&self, range: Range<usize>) -> Result<()> {
         self.check_rights(Rights::WRITE)?;
-        self.0.commit_and_operate(&range, |_| {}, false)?;
+        self.0
+            .commit_and_operate(&range, |_| {}, CommitFlags::empty())?;
         Ok(())
     }
 

--- a/kernel/aster-nix/src/vm/vmo/pager.rs
+++ b/kernel/aster-nix/src/vm/vmo/pager.rs
@@ -50,4 +50,9 @@ pub trait Pager: Send + Sync {
     /// such an assumption for its correctness; instead, it should simply ignore the
     /// call or return an error.
     fn decommit_page(&self, idx: usize) -> Result<()>;
+
+    /// Ask the pager to provide a frame at a specified index.
+    /// Notify the pager that the frame will be fully overwritten soon, so pager can
+    /// choose not to initialize it.
+    fn commit_overwrite(&self, idx: usize) -> Result<Frame>;
 }

--- a/kernel/aster-nix/src/vm/vmo/static_cap.rs
+++ b/kernel/aster-nix/src/vm/vmo/static_cap.rs
@@ -8,7 +8,7 @@ use aster_rights_proc::require;
 
 use super::{
     options::{VmoCowChild, VmoSliceChild},
-    Vmo, VmoChildOptions, VmoRightsOp,
+    CommitFlags, Vmo, VmoChildOptions, VmoRightsOp,
 };
 use crate::prelude::*;
 
@@ -84,7 +84,8 @@ impl<R: TRights> Vmo<TRightSet<R>> {
     /// The method requires the Write right.
     #[require(R > Write)]
     pub fn commit(&self, range: Range<usize>) -> Result<()> {
-        self.0.commit_and_operate(&range, |_| {}, false)?;
+        self.0
+            .commit_and_operate(&range, |_| {}, CommitFlags::empty())?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR optimizes Vmo's `wirte_bytes` function. For the write operation, if it is a full page write and the corresponding page is not in memory, we can directly apply for a new page to write. There is no need to read the page from the pager (if the pager exists), and there is no need to copy the contents of the parent page (if it is a COW page). Because they will soon be overwritten by the new data.

I introduce a new parameter `no_commit` to indicate this. This parameter is set when the `write_bytes` detects that this is a full page write. In addition, to keep such pages managed by pager, I added an `insert_page` function to the Pager trait to submit such pages to pager.

This optimization can greatly improve the performance of page-aligned write operations. For example, it can increase the bandwidth of random write (blocksize=4k) in exFAT from 50Mib/s to 900Mib/s.