### PR TITLE
Basic cleanup of the page table implementation

### DIFF
--- a/framework/aster-frame/Cargo.toml
+++ b/framework/aster-frame/Cargo.toml
@@ -45,6 +45,3 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [ "no_std"
 
 [features]
 intel_tdx = ["dep:tdx-guest", "dep:iced-x86"]
-# To actively recycle page table nodes while the `VmSpace` is alive, this saves
-# memory but may lead to the page table free-reuse-then-read problem.
-page_table_recycle = []

--- a/framework/aster-frame/src/mm/mod.rs
+++ b/framework/aster-frame/src/mm/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 //! Virtual memory (VM).
 
 /// Virtual addresses.
@@ -85,6 +83,7 @@ pub(crate) const fn nr_subpage_per_huge<C: PagingConstsTrait>() -> usize {
 }
 
 /// The number of base pages in a huge page at a given level.
+#[allow(dead_code)]
 pub(crate) const fn nr_base_per_page<C: PagingConstsTrait>(level: PagingLevel) -> usize {
     page_size::<C>(level) / C::BASE_PAGE_SIZE
 }

--- a/framework/aster-frame/src/mm/page/meta.rs
+++ b/framework/aster-frame/src/mm/page/meta.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
 //! Metadata management of pages.
 //!
 //! You can picture a globally shared, static, gigantic arrary of metadata initialized for each page.
@@ -67,8 +64,10 @@ use crate::{
 pub enum PageUsage {
     // The zero variant is reserved for the unused type. Only an unused page
     // can be designated for one of the other purposes.
+    #[allow(dead_code)]
     Unused = 0,
     /// The page is reserved or unusable. The kernel should not touch it.
+    #[allow(dead_code)]
     Reserved = 1,
 
     /// The page is used as a frame, i.e., a page of untyped memory.
@@ -98,9 +97,9 @@ pub(in crate::mm) struct MetaSlot {
 }
 
 pub(super) union MetaSlotInner {
-    frame: ManuallyDrop<FrameMeta>,
+    _frame: ManuallyDrop<FrameMeta>,
     // Make sure the the generic parameters don't effect the memory layout.
-    pt: ManuallyDrop<PageTablePageMeta<PageTableEntry, PagingConsts>>,
+    _pt: ManuallyDrop<PageTablePageMeta<PageTableEntry, PagingConsts>>,
 }
 
 // Currently the sizes of the `MetaSlotInner` union variants are no larger
@@ -169,7 +168,7 @@ pub struct MetaPageMeta {}
 impl Sealed for MetaPageMeta {}
 impl PageMeta for MetaPageMeta {
     const USAGE: PageUsage = PageUsage::Meta;
-    fn on_drop(page: &mut Page<Self>) {
+    fn on_drop(_page: &mut Page<Self>) {
         panic!("Meta pages are currently not allowed to be dropped");
     }
 }
@@ -181,7 +180,7 @@ pub struct KernelMeta {}
 impl Sealed for KernelMeta {}
 impl PageMeta for KernelMeta {
     const USAGE: PageUsage = PageUsage::Kernel;
-    fn on_drop(page: &mut Page<Self>) {
+    fn on_drop(_page: &mut Page<Self>) {
         panic!("Kernel pages are not allowed to be dropped");
     }
 }

--- a/framework/aster-frame/src/mm/page/mod.rs
+++ b/framework/aster-frame/src/mm/page/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 //! Physical memory page management.
 //!
 //! A page is an aligned, contiguous range of bytes in physical memory. The sizes
@@ -147,18 +145,6 @@ impl<M: PageMeta> Page<M> {
     /// Get the physical address.
     pub fn paddr(&self) -> Paddr {
         mapping::meta_to_page::<PagingConsts>(self.ptr as Vaddr)
-    }
-
-    /// Load the current reference count of this page.
-    ///
-    /// # Safety
-    ///
-    /// This method by itself is safe, but using it correctly requires extra care.
-    /// Another thread can change the reference count at any time, including
-    /// potentially between calling this method and the action depending on the
-    /// result.
-    pub fn count(&self) -> u32 {
-        self.get_ref_count().load(Ordering::Relaxed)
     }
 
     /// Get the metadata of this page.

--- a/framework/aster-frame/src/mm/page_table/mod.rs
+++ b/framework/aster-frame/src/mm/page_table/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use core::{fmt::Debug, marker::PhantomData, ops::Range};
 
 use pod::Pod;
@@ -179,10 +177,6 @@ where
             root: PageTableNode::<E, C>::alloc(C::NR_LEVELS).into_raw(),
             _phantom: PhantomData,
         }
-    }
-
-    pub(crate) unsafe fn activate_unchecked(&self) {
-        self.root.activate();
     }
 
     pub(in crate::mm) unsafe fn first_activate_unchecked(&self) {

--- a/framework/aster-frame/src/mm/page_table/node.rs
+++ b/framework/aster-frame/src/mm/page_table/node.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 //! This module defines page table node abstractions and the handle.
 //!
 //! The page table node is also frequently referred to as a page table in many architectural
@@ -98,15 +96,6 @@ where
             level: self.level,
             _phantom: PhantomData,
         }
-    }
-
-    pub(super) fn nr_valid_children(&self) -> u16 {
-        // SAFETY: The physical address in the raw handle is valid and we are
-        // accessing the page table node. We forget the handle when finished.
-        let page = unsafe { Page::<PageTablePageMeta<E, C>>::from_raw(self.paddr()) };
-        let nr = page.meta().nr_children;
-        core::mem::forget(page);
-        nr
     }
 
     /// Activates the page table assuming it is a root page table.
@@ -390,12 +379,6 @@ where
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         let pte = Some(E::new_frame(pa, self.level(), prop));
         self.overwrite_pte(idx, pte, true);
-    }
-
-    /// The number of mapped frames or page tables.
-    /// This is to track if we can free itself.
-    pub(super) fn nr_valid_children(&self) -> u16 {
-        self.page.meta().nr_children
     }
 
     /// Reads the info from a page table entry at a given index.

--- a/framework/aster-frame/src/mm/page_table/node.rs
+++ b/framework/aster-frame/src/mm/page_table/node.rs
@@ -265,7 +265,7 @@ where
     }
 
     /// Gets an extra reference of the child at the given index.
-    pub(super) fn child(&self, idx: usize, tracked: bool) -> Child<E, C> {
+    pub(super) fn child(&self, idx: usize, in_tracked_range: bool) -> Child<E, C> {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
 
         let pte = self.read_pte(idx);
@@ -286,7 +286,7 @@ where
                     level: self.level() - 1,
                     _phantom: PhantomData,
                 })
-            } else if tracked {
+            } else if in_tracked_range {
                 // SAFETY: The physical address is recorded in a valid PTE
                 // which would be casted from a handle. We are incrementing
                 // the reference count so we restore and forget a cloned one.
@@ -319,7 +319,7 @@ where
         let mut new_frame = Self::alloc(self.level());
 
         for i in deep {
-            match self.child(i, /*meaningless*/ true) {
+            match self.child(i, true) {
                 Child::PageTable(pt) => {
                     let guard = pt.clone_shallow().lock();
                     let new_child = guard.make_copy(0..nr_subpage_per_huge::<C>(), 0..0);
@@ -353,10 +353,10 @@ where
     }
 
     /// Removes a child if the child at the given index is present.
-    pub(super) fn unset_child(&mut self, idx: usize, in_untracked_range: bool) {
+    pub(super) fn unset_child(&mut self, idx: usize, in_tracked_range: bool) {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
 
-        self.overwrite_pte(idx, None, in_untracked_range);
+        self.overwrite_pte(idx, None, in_tracked_range);
     }
 
     /// Sets a child page table at a given index.
@@ -364,14 +364,14 @@ where
         &mut self,
         idx: usize,
         pt: RawPageTableNode<E, C>,
-        in_untracked_range: bool,
+        in_tracked_range: bool,
     ) {
         // They should be ensured by the cursor.
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         debug_assert_eq!(pt.level, self.level() - 1);
 
         let pte = Some(E::new_pt(pt.paddr()));
-        self.overwrite_pte(idx, pte, in_untracked_range);
+        self.overwrite_pte(idx, pte, in_tracked_range);
         // The ownership is transferred to a raw PTE. Don't drop the handle.
         let _ = ManuallyDrop::new(pt);
     }
@@ -383,7 +383,7 @@ where
         debug_assert_eq!(frame.level(), self.level());
 
         let pte = Some(E::new_frame(frame.start_paddr(), self.level(), prop));
-        self.overwrite_pte(idx, pte, false);
+        self.overwrite_pte(idx, pte, true);
         // The ownership is transferred to a raw PTE. Don't drop the handle.
         let _ = ManuallyDrop::new(frame);
     }
@@ -398,7 +398,7 @@ where
         debug_assert!(idx < nr_subpage_per_huge::<C>());
 
         let pte = Some(E::new_frame(pa, self.level(), prop));
-        self.overwrite_pte(idx, pte, true);
+        self.overwrite_pte(idx, pte, false);
     }
 
     /// Reads the info from a page table entry at a given index.
@@ -425,7 +425,7 @@ where
             unsafe { new_frame.set_child_untracked(i, small_pa, prop) };
         }
 
-        self.set_child_pt(idx, new_frame.into_raw(), true);
+        self.set_child_pt(idx, new_frame.into_raw(), false);
     }
 
     /// Protects an already mapped child at a given index.
@@ -460,7 +460,7 @@ where
     ///
     /// The caller in this module will ensure that the PTE points to initialized
     /// memory if the child is a page table.
-    fn overwrite_pte(&mut self, idx: usize, pte: Option<E>, in_untracked_range: bool) {
+    fn overwrite_pte(&mut self, idx: usize, pte: Option<E>, in_tracked_range: bool) {
         let existing_pte = self.read_pte(idx);
 
         if existing_pte.is_present() {
@@ -483,7 +483,7 @@ where
                 if !existing_pte.is_last(self.level()) {
                     // This is a page table.
                     drop(Page::<PageTablePageMeta<E, C>>::from_raw(paddr));
-                } else if !in_untracked_range {
+                } else if in_tracked_range {
                     // This is a frame.
                     drop(Page::<FrameMeta>::from_raw(paddr));
                 }

--- a/framework/aster-frame/src/mm/page_table/node.rs
+++ b/framework/aster-frame/src/mm/page_table/node.rs
@@ -74,6 +74,7 @@ where
         // count is needed.
         let page = unsafe { Page::<PageTablePageMeta<E, C>>::from_raw(self.paddr()) };
         debug_assert!(page.meta().level == self.level);
+
         // Acquire the lock.
         while page
             .meta()
@@ -83,14 +84,17 @@ where
         {
             core::hint::spin_loop();
         }
+
         // Prevent dropping the handle.
         let _ = ManuallyDrop::new(self);
+
         PageTableNode::<E, C> { page }
     }
 
     /// Creates a copy of the handle.
     pub(super) fn clone_shallow(&self) -> Self {
         self.inc_ref();
+
         Self {
             raw: self.raw,
             level: self.level,
@@ -143,8 +147,11 @@ where
     /// with [`Self::activate()`] in other senses.
     pub(super) unsafe fn first_activate(&self) {
         use crate::{arch::mm::activate_page_table, mm::CachePolicy};
+
         debug_assert_eq!(self.level, PagingConsts::NR_LEVELS);
+
         self.inc_ref();
+
         activate_page_table(self.raw, CachePolicy::Writeback);
     }
 
@@ -210,6 +217,7 @@ where
     pub(super) fn alloc(level: PagingLevel) -> Self {
         let frame = FRAME_ALLOCATOR.get().unwrap().lock().alloc(1).unwrap() * PAGE_SIZE;
         let mut page = Page::<PageTablePageMeta<E, C>>::from_unused(frame);
+
         // The lock is initialized as held.
         page.meta().lock.store(1, Ordering::Relaxed);
 
@@ -234,8 +242,10 @@ where
     pub(super) fn into_raw(self) -> RawPageTableNode<E, C> {
         let level = self.level();
         let raw = self.page.paddr();
+
         self.page.meta().lock.store(0, Ordering::Release);
         core::mem::forget(self);
+
         RawPageTableNode {
             raw,
             level,
@@ -246,6 +256,7 @@ where
     /// Gets a raw handle while still preserving the original handle.
     pub(super) fn clone_raw(&self) -> RawPageTableNode<E, C> {
         core::mem::forget(self.page.clone());
+
         RawPageTableNode {
             raw: self.page.paddr(),
             level: self.level(),
@@ -256,6 +267,7 @@ where
     /// Gets an extra reference of the child at the given index.
     pub(super) fn child(&self, idx: usize, tracked: bool) -> Child<E, C> {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
+
         let pte = self.read_pte(idx);
         if !pte.is_present() {
             Child::None
@@ -300,10 +312,12 @@ where
     ///
     /// The ranges must be disjoint.
     pub(super) unsafe fn make_copy(&self, deep: Range<usize>, shallow: Range<usize>) -> Self {
-        let mut new_frame = Self::alloc(self.level());
         debug_assert!(deep.end <= nr_subpage_per_huge::<C>());
         debug_assert!(shallow.end <= nr_subpage_per_huge::<C>());
         debug_assert!(deep.end <= shallow.start || deep.start >= shallow.end);
+
+        let mut new_frame = Self::alloc(self.level());
+
         for i in deep {
             match self.child(i, /*meaningless*/ true) {
                 Child::PageTable(pt) => {
@@ -321,6 +335,7 @@ where
                 }
             }
         }
+
         for i in shallow {
             debug_assert_eq!(self.level(), C::NR_LEVELS);
             match self.child(i, /*meaningless*/ true) {
@@ -333,12 +348,14 @@ where
                 }
             }
         }
+
         new_frame
     }
 
     /// Removes a child if the child at the given index is present.
     pub(super) fn unset_child(&mut self, idx: usize, in_untracked_range: bool) {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
+
         self.overwrite_pte(idx, None, in_untracked_range);
     }
 
@@ -352,6 +369,7 @@ where
         // They should be ensured by the cursor.
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         debug_assert_eq!(pt.level, self.level() - 1);
+
         let pte = Some(E::new_pt(pt.paddr()));
         self.overwrite_pte(idx, pte, in_untracked_range);
         // The ownership is transferred to a raw PTE. Don't drop the handle.
@@ -363,6 +381,7 @@ where
         // They should be ensured by the cursor.
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         debug_assert_eq!(frame.level(), self.level());
+
         let pte = Some(E::new_frame(frame.start_paddr(), self.level(), prop));
         self.overwrite_pte(idx, pte, false);
         // The ownership is transferred to a raw PTE. Don't drop the handle.
@@ -377,6 +396,7 @@ where
     pub(super) unsafe fn set_child_untracked(&mut self, idx: usize, pa: Paddr, prop: PageProperty) {
         // It should be ensured by the cursor.
         debug_assert!(idx < nr_subpage_per_huge::<C>());
+
         let pte = Some(E::new_frame(pa, self.level(), prop));
         self.overwrite_pte(idx, pte, true);
     }
@@ -396,6 +416,7 @@ where
             panic!("`split_untracked_huge` not called on an untracked huge page");
         };
         let prop = self.read_pte_prop(idx);
+
         let mut new_frame = PageTableNode::<E, C>::alloc(self.level() - 1);
         for i in 0..nr_subpage_per_huge::<C>() {
             let small_pa = pa + i * page_size::<C>(self.level() - 1);
@@ -403,6 +424,7 @@ where
             // the property are valid.
             unsafe { new_frame.set_child_untracked(i, small_pa, prop) };
         }
+
         self.set_child_pt(idx, new_frame.into_raw(), true);
     }
 
@@ -410,7 +432,9 @@ where
     pub(super) fn protect(&mut self, idx: usize, prop: PageProperty) {
         let mut pte = self.read_pte(idx);
         debug_assert!(pte.is_present()); // This should be ensured by the cursor.
+
         pte.set_prop(prop);
+
         // SAFETY: the index is within the bound and the PTE is valid.
         unsafe {
             (self.as_ptr() as *mut E).add(idx).write(pte);
@@ -420,6 +444,7 @@ where
     pub(super) fn read_pte(&self, idx: usize) -> E {
         // It should be ensured by the cursor.
         debug_assert!(idx < nr_subpage_per_huge::<C>());
+
         // SAFETY: the index is within the bound and PTE is plain-old-data.
         unsafe { self.as_ptr().add(idx).read() }
     }
@@ -437,6 +462,7 @@ where
     /// memory if the child is a page table.
     fn overwrite_pte(&mut self, idx: usize, pte: Option<E>, in_untracked_range: bool) {
         let existing_pte = self.read_pte(idx);
+
         if existing_pte.is_present() {
             // SAFETY: The index is within the bound and the address is aligned.
             // The validity of the PTE is checked within this module.
@@ -500,6 +526,7 @@ where
     fn on_drop(page: &mut Page<Self>) {
         let paddr = page.paddr();
         let level = page.meta().level;
+
         // Drop the children.
         for i in 0..nr_subpage_per_huge::<C>() {
             // SAFETY: The index is within the bound and PTE is plain-old-data. The
@@ -524,6 +551,7 @@ where
                 }
             }
         }
+
         // Recycle this page table node.
         FRAME_ALLOCATOR
             .get()


### PR DESCRIPTION
(https://github.com/asterinas/asterinas/pull/918 is too large and contains too many unrelated minor changes, splitting)

Some really basic cleanup, like removing dead code and unused variables (including the `page_table_recycle` feature, see https://github.com/asterinas/asterinas/pull/918#discussion_r1629707308), inserting empty lines for readability.

I also notice that some methods use `in_untracked_range` (e.g., `PageTableNode::unset_child`) and some methods use `is_tracked` (e.g., `PageTableNode::child`). I think they should be unified to the positive one, as negative boolean variables always cause confusion.