### PR TITLE
Facilitate dynamic detection of Sleep-in-Atomic-Context (and similar) bugs

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,6 +30,8 @@
 #![feature(linked_list_retain)]
 #![register_tool(component_access_control)]
 
+use core::sync::atomic::Ordering;
+
 use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot,
@@ -80,6 +82,7 @@ pub fn main() {
     ostd::early_println!("[kernel] OSTD initialized. Preparing components.");
     component::init_all(component::parse_metadata!()).unwrap();
     init();
+    ostd::IN_BOOTSTRAP_CONTEXT.store(false, Ordering::Relaxed);
     Thread::spawn_kernel_thread(ThreadOptions::new(init_thread));
     unreachable!()
 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -44,6 +44,8 @@ pub mod task;
 pub mod trap;
 pub mod user;
 
+use core::sync::atomic::AtomicBool;
+
 pub use ostd_macros::main;
 pub use ostd_pod::Pod;
 
@@ -95,6 +97,9 @@ pub unsafe fn init() {
 
     invoke_ffi_init_funcs();
 }
+
+/// Indicates whether the kernel is in bootstrap context.
+pub static IN_BOOTSTRAP_CONTEXT: AtomicBool = AtomicBool::new(true);
 
 /// Invoke the initialization functions defined in the FFI.
 /// The component system uses this function to call the initialization functions of

--- a/ostd/src/task/atomic_mode.rs
+++ b/ostd/src/task/atomic_mode.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Atomic Mode
+//!
+//! Multitasking, while powerful, can sometimes lead to undesirable
+//! or catastrophic consequences if being misused.
+//! For instance, a user of OSTD might accidentally write an IRQ handler
+//! that relies on mutexes,
+//! which could attempt to sleep within an interrupt context---something that must be avoided.
+//! Another common mistake is
+//! acquiring a spinlock in a task context and then attempting to yield or sleep,
+//! which can easily lead to deadlocks.
+//!
+//! To mitigate the risks associated with improper multitasking,
+//! we introduce the concept of atomic mode.
+//! Kernel code is considered to be running in atomic mode
+//! if one of the following conditions is met:
+//!
+//! 1. Task preemption is disabled, such as when a spinlock is held.
+//! 2. Local IRQs are disabled, such as during interrupt context.
+//!
+//! While in atomic mode,
+//! any attempt to perform "sleep-like" actions will trigger a panic:
+//!
+//! 1. Switching to another task.
+//! 2. Switching to user space.
+//!
+//! This module provides API to detect such "sleep-like" actions.
+
+use core::sync::atomic::Ordering;
+
+/// Marks a function as one that might sleep.
+///
+/// This function will panic if it is executed in atomic mode.
+pub fn might_sleep() {
+    let preempt_count = super::preempt::cpu_local::get_guard_count();
+    let is_local_irq_enabled = crate::arch::irq::is_local_enabled();
+    if (preempt_count != 0 || !is_local_irq_enabled)
+        && !crate::IN_BOOTSTRAP_CONTEXT.load(Ordering::Relaxed)
+    {
+        panic!(
+            "This function might break atomic mode (preempt_count = {}, is_local_irq_enabled = {})",
+            preempt_count, is_local_irq_enabled
+        );
+    }
+}

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -2,6 +2,7 @@
 
 //! Tasks are the unit of code execution.
 
+pub(crate) mod atomic_mode;
 mod preempt;
 mod processor;
 pub mod scheduler;

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -140,6 +140,7 @@ impl<'a> UserMode<'a> {
         F: FnMut() -> bool,
     {
         debug_assert!(Arc::ptr_eq(&self.current, &Task::current().unwrap()));
+        crate::task::atomic_mode::might_sleep();
         self.context.execute(has_kernel_event)
     }
 


### PR DESCRIPTION
This PR introduces checks of atomic context and non-block section into OSTD, which enables us to do dynamic detection of Sleep-in-Atomic-Context (SAC) bugs in runtime.

## Background

### Atomic Context
There should not be any kind of context switch (`sleep`, `wait`, `yield`, etc.) on the CPU when kernel begins to handle interrupt or holds a spinlock. Otherwise it will raise bugs like dead-lock or broken interrupt handler, which can be very hard to locate. We refer to this kind of execution context as atomic context.

### Non-block Section
There's also cases when we'd like to run preemptibly but without being blocked. This kind of critical section is called non-block section.  Michal Hocko once gave a specific [use case](https://lore.kernel.org/all/20190815084429.GE9477@dhcp22.suse.cz/) of non-block section in Linux.

## Implementation
This PR uses the existing per-CPU preempt counter to check whether current task is in atomic context since this counter catches every `disable_preempt` and `disable_local`.

For non-block section this PR introduces a per-Task variable `non_block_count`, which is almost parallel with `PREEMPT_COUNT` in functionality. We increase the counter value once we start a non-block section and the start operation can be nested just like `disable_preempt`. Also, like `PREEMPT_COUNT`, we also adopt a guard-like RAII approach for `non_block_count`.

## Usage
What this PR finally brings to OSTD developers/users is a set of function markers below which can facilitate the dynamic detection of SAC bugs. 
```rust
/// Annotates a function as one that might sleep.
fn might_sleep()

/// Annotates a function as one that might break atomic context.
///
/// Note: Logically, all that may break atomic context (e.g., sleep,
/// schedule, go to userspace, ...) should be annotated with this function.
/// However, one should always prefer `might_sleep` if possible since
/// we transfer to `might_sleep` the responsibility for checking sleep/block
/// operations in atomic context.
fn might_break_atomic_context()

/// Annotates a function as one that must run to completion.
fn should_in_preempt()
```
One can call these marker function at the very beginning (actually not necessary) of relavant functions or use the corresponding attribute macros we provided. Anyway we recommend the second approach.

## TBD
- Whether we should make all the markers and checks `#[cfg(debug_assertions)]` though I don't see a notable drop in performance at this moment.