### PR TITLE
Add /proc/sys/kernel/cap_last_cap support

### DIFF
--- a/kernel/aster-nix/src/fs/procfs/self_.rs
+++ b/kernel/aster-nix/src/fs/procfs/self_.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::*;
+use crate::{
+    fs::{
+        procfs::{ProcSymBuilder, SymOps},
+        utils::Inode,
+    },
+    prelude::*,
+};
 
 /// Represents the inode at `/proc/self`.
 pub struct SelfSymOps;

--- a/kernel/aster-nix/src/fs/procfs/sys/kernel/cap_last_cap.rs
+++ b/kernel/aster-nix/src/fs/procfs/sys/kernel/cap_last_cap.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::Inode,
+    },
+    prelude::*,
+    process::credentials::capabilities::CapSet,
+};
+
+/// Represents the inode at `/proc/sys/kernel/cap_last_cap`.
+pub struct CapLastCapFileOps;
+
+impl CapLastCapFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+    }
+}
+
+impl FileOps for CapLastCapFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let cap_last_cap_value = CapSet::most_significant_bit();
+        let output = format!("{}\n", cap_last_cap_value);
+        Ok(output.into_bytes())
+    }
+}

--- a/kernel/aster-nix/src/fs/procfs/sys/kernel/mod.rs
+++ b/kernel/aster-nix/src/fs/procfs/sys/kernel/mod.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        procfs::{
+            sys::kernel::cap_last_cap::CapLastCapFileOps,
+            template::{DirOps, ProcDirBuilder},
+            ProcDir,
+        },
+        utils::{DirEntryVecExt, Inode},
+    },
+    prelude::*,
+};
+
+mod cap_last_cap;
+
+/// Represents the inode at `/proc/sys/kernel`.
+
+pub struct KernelDirOps;
+
+impl KernelDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+    }
+}
+
+impl DirOps for KernelDirOps {
+    fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode = match name {
+            "cap_last_cap" => CapLastCapFileOps::new_inode(this_ptr.clone()),
+            _ => return_errno!(Errno::ENOENT),
+        };
+        Ok(inode)
+    }
+
+    fn populate_children(&self, this_ptr: Weak<dyn Inode>) {
+        let this = {
+            let this = this_ptr.upgrade().unwrap();
+            this.downcast_ref::<ProcDir<KernelDirOps>>().unwrap().this()
+        };
+        let mut cached_children = this.cached_children().write();
+        cached_children.put_entry_if_not_found("cap_last_cap", || {
+            CapLastCapFileOps::new_inode(this_ptr.clone())
+        });
+    }
+}

--- a/kernel/aster-nix/src/fs/procfs/sys/mod.rs
+++ b/kernel/aster-nix/src/fs/procfs/sys/mod.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use self::kernel::KernelDirOps;
+use crate::{
+    fs::{
+        procfs::template::{DirOps, ProcDir, ProcDirBuilder},
+        utils::{DirEntryVecExt, Inode},
+    },
+    prelude::*,
+};
+
+mod kernel;
+
+/// Represents the inode at `/proc/sys`.
+pub struct SysDirOps;
+
+impl SysDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+    }
+}
+
+impl DirOps for SysDirOps {
+    fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode = match name {
+            "kernel" => KernelDirOps::new_inode(this_ptr.clone()),
+            _ => return_errno!(Errno::ENOENT),
+        };
+        Ok(inode)
+    }
+
+    fn populate_children(&self, this_ptr: Weak<dyn Inode>) {
+        let this = {
+            let this = this_ptr.upgrade().unwrap();
+            this.downcast_ref::<ProcDir<SysDirOps>>().unwrap().this()
+        };
+        let mut cached_children = this.cached_children().write();
+        cached_children
+            .put_entry_if_not_found("kernel", || KernelDirOps::new_inode(this_ptr.clone()))
+    }
+}

--- a/kernel/aster-nix/src/process/credentials/capabilities.rs
+++ b/kernel/aster-nix/src/process/credentials/capabilities.rs
@@ -62,6 +62,12 @@ impl CapSet {
     pub const fn new_root() -> Self {
         CapSet::SYS_ADMIN
     }
+
+    /// The most significant bit in a 64-bit `CapSet` that may be set to represent a Linux capability.
+    pub fn most_significant_bit() -> u8 {
+        // CHECKPOINT_RESTORE is the Linux capability with the largest numerical value
+        40
+    }
 }
 
 #[derive(Debug)]

--- a/kernel/aster-nix/src/syscall/capset.rs
+++ b/kernel/aster-nix/src/syscall/capset.rs
@@ -13,11 +13,8 @@ use crate::{
     util::read_val_from_user,
 };
 
-const CAP_LAST_CAP: u64 = 40; // Number of the last capability (CAP_CHECKPOINT_RESTORE)
-const CAP_VALID_MASK: u64 = (1u64 << (CAP_LAST_CAP + 1)) - 1;
-
 fn make_kernel_cap(low: u32, high: u32) -> u64 {
-    ((low as u64) | ((high as u64) << 32)) & CAP_VALID_MASK
+    ((low as u64) | ((high as u64) << 32)) & ((1u64 << (CapSet::most_significant_bit() + 1)) - 1)
 }
 
 pub fn sys_capset(cap_user_header_addr: Vaddr, cap_user_data_addr: Vaddr) -> Result<SyscallReturn> {


### PR DESCRIPTION
This PR provides the ability to get the last capability, e.g., when running

```
# cat /proc/sys/kernel/cap_last_cap 
40
```
 The user can get `40` (which is the number of the last capability (`CAP_CHECKPOINT_RESTORE`)).