### PR TITLE
Fix bad `ASTER_GIT_REV`

### DIFF
--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -16,7 +16,7 @@ use quote::ToTokens;
 /// and use the published version in the generated Cargo.toml.
 pub const ASTER_GIT_LINK: &str = "https://github.com/asterinas/asterinas";
 /// Make sure it syncs with the builder dependency in Cargo.toml.
-pub const ASTER_GIT_REV: &str = "c9b66bd";
+pub const ASTER_GIT_REV: &str = "ccc4e6e";
 pub fn aster_crate_dep(crate_name: &str) -> String {
     format!(
         "{} = {{ git = \"{}\", rev = \"{}\" }}",


### PR DESCRIPTION
I don't understand why this BUG hasn't been discovered before. But this time, when I tried to build Asterinas, I encountered this error:
```
    Updating git repository `https://github.com/asterinas/asterinas`
error: revspec 'c9b66bd' not found; class=Reference (4); code=NotFound (-3)
thread 'main' panicked at src/commands/build/bin.rs:174:9:
Failed to build linux x86 setup header:
        command `RUSTFLAGS="-Ccode-model=kernel -Crelocation-model=pie -Ctarget-feature=+crt-static -Zplt=yes -Zrelax-elf-relocations=yes -Zrelro-level=full" "c
argo" "install" "linux-bzimage-setup" "--force" "--root" "/root/asterinas/target/osdk" "--git" "https://github.com/asterinas/asterinas" "--rev" "c9b66bd" "--tar
get" "x86_64-unknown-none" "-Zbuild-std=core,alloc,compiler_builtins" "-Zbuild-std-features=compiler-builtins-mem" "--target-dir" "/root/asterinas/target/osdk/l
inux-bzimage-setup"`
        returned exit status: 101
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [Makefile:132: build] Error 101
```

`git` tells me that there is no such commit as `c9b66bd`.
```
> git show c9b66bd
fatal: ambiguous argument 'c9b66bd': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

After checking the git blame, I found that `c9b66bd` is only a commit in #805, and never in the mainline. It should be replaced with the appropriate mainline commit instead:
 - https://github.com/asterinas/asterinas/pull/805/commits/c9b66bddd6b77dcddcbe1b66337a76ee1e16b640
 - https://github.com/asterinas/asterinas/commit/ccc4e6ec6b91dfdf7df1b70a990369416fee56e6