### PR TITLE
Address unused variable warnings in the network module

### DIFF
--- a/kernel/aster-nix/src/net/iface/any_socket.rs
+++ b/kernel/aster-nix/src/net/iface/any_socket.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use super::{Iface, IpAddress, IpEndpoint};
 use crate::{events::Observer, prelude::*};
 
 pub type RawTcpSocket = smoltcp::socket::tcp::Socket<'static>;
 pub type RawUdpSocket = smoltcp::socket::udp::Socket<'static>;
-pub type RawSocketHandle = smoltcp::iface::SocketHandle;
 
 pub struct AnyUnboundSocket {
     socket_family: AnyRawSocket,

--- a/kernel/aster-nix/src/net/iface/any_socket.rs
+++ b/kernel/aster-nix/src/net/iface/any_socket.rs
@@ -47,7 +47,7 @@ impl AnyUnboundSocket {
             );
             let tx_buffer = smoltcp::socket::udp::PacketBuffer::new(
                 vec![metadata; UDP_METADATA_LEN],
-                vec![0u8; UDP_RECEIVE_PAYLOAD_LEN],
+                vec![0u8; UDP_SEND_PAYLOAD_LEN],
             );
             RawUdpSocket::new(rx_buffer, tx_buffer)
         };

--- a/kernel/aster-nix/src/net/iface/loopback.rs
+++ b/kernel/aster-nix/src/net/iface/loopback.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use smoltcp::{
-    iface::{Config, Routes},
+    iface::Config,
     phy::{Loopback, Medium},
     wire::IpCidr,
 };
@@ -27,7 +25,6 @@ impl IfaceLoopback {
     pub fn new() -> Arc<Self> {
         let mut loopback = Loopback::new(Medium::Ip);
         let interface = {
-            let routes = Routes::new();
             let config = Config::new();
             let mut interface = smoltcp::iface::Interface::new(config, &mut loopback);
             interface.update_ip_addrs(|ip_addrs| {

--- a/kernel/aster-nix/src/net/iface/virtio.rs
+++ b/kernel/aster-nix/src/net/iface/virtio.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use aster_network::AnyNetworkDevice;
 use aster_virtio::device::network::DEVICE_NAME;
 use smoltcp::{
-    iface::{Config, Routes, SocketHandle, SocketSet},
+    iface::{Config, SocketHandle, SocketSet},
     socket::dhcpv4,
     wire::{self, IpCidr},
 };
@@ -26,7 +24,6 @@ impl IfaceVirtio {
         let interface = {
             let mac_addr = virtio_net.lock().mac_addr();
             let ip_addr = IpCidr::new(wire::IpAddress::Ipv4(wire::Ipv4Address::UNSPECIFIED), 0);
-            let routes = Routes::new();
             let config = {
                 let mut config = Config::new();
                 config.hardware_addr = Some(wire::HardwareAddress::Ethernet(

--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use smoltcp::socket::udp::{RecvError, SendError};
 
 use crate::{
@@ -39,7 +37,7 @@ impl BoundDatagram {
         self.remote_endpoint = Some(*endpoint)
     }
 
-    pub fn try_recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, IpEndpoint)> {
+    pub fn try_recv(&self, buf: &mut [u8], _flags: SendRecvFlags) -> Result<(usize, IpEndpoint)> {
         let result = self
             .bound_socket
             .raw_with(|socket: &mut RawUdpSocket| socket.recv_slice(buf));
@@ -51,7 +49,12 @@ impl BoundDatagram {
         }
     }
 
-    pub fn try_send(&self, buf: &[u8], remote: &IpEndpoint, flags: SendRecvFlags) -> Result<usize> {
+    pub fn try_send(
+        &self,
+        buf: &[u8],
+        remote: &IpEndpoint,
+        _flags: SendRecvFlags,
+    ) -> Result<usize> {
         let result = self.bound_socket.raw_with(|socket: &mut RawUdpSocket| {
             if socket.payload_send_capacity() < buf.len() {
                 return None;

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use takeable::Takeable;
@@ -301,7 +299,7 @@ impl Socket for DatagramSocket {
     fn addr(&self) -> Result<SocketAddr> {
         let inner = self.inner.read();
         match inner.as_ref() {
-            Inner::Unbound(unbound_datagram) => Ok(UNSPECIFIED_LOCAL_ENDPOINT.into()),
+            Inner::Unbound(_) => Ok(UNSPECIFIED_LOCAL_ENDPOINT.into()),
             Inner::Bound(bound_datagram) => Ok(bound_datagram.local_endpoint().into()),
         }
     }
@@ -373,7 +371,7 @@ impl Socket for DatagramSocket {
 }
 
 impl Observer<()> for DatagramSocket {
-    fn on_events(&self, events: &()) {
+    fn on_events(&self, _events: &()) {
         self.update_io_events();
     }
 }

--- a/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use alloc::sync::Weak;
 
 use smoltcp::socket::tcp::{RecvError, SendError};
@@ -45,7 +43,7 @@ impl ConnectedStream {
         }
     }
 
-    pub fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
+    pub fn shutdown(&self, _cmd: SockShutdownCmd) -> Result<()> {
         // TODO: deal with cmd
         self.bound_socket.raw_with(|socket: &mut RawTcpSocket| {
             socket.close();
@@ -53,7 +51,7 @@ impl ConnectedStream {
         Ok(())
     }
 
-    pub fn try_recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<usize> {
+    pub fn try_recv(&self, buf: &mut [u8], _flags: SendRecvFlags) -> Result<usize> {
         let result = self
             .bound_socket
             .raw_with(|socket: &mut RawTcpSocket| socket.recv_slice(buf));
@@ -68,7 +66,7 @@ impl ConnectedStream {
         }
     }
 
-    pub fn try_send(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
+    pub fn try_send(&self, buf: &[u8], _flags: SendRecvFlags) -> Result<usize> {
         let result = self
             .bound_socket
             .raw_with(|socket: &mut RawTcpSocket| socket.send_slice(buf));

--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use smoltcp::socket::tcp::ListenError;
 
 use super::connected::ConnectedStream;
@@ -66,9 +64,8 @@ impl ListenStream {
             })?;
         let active_backlog_socket = backlog_sockets.remove(index);
 
-        match BacklogSocket::new(&self.bound_socket) {
-            Ok(backlog_socket) => backlog_sockets.push(backlog_socket),
-            Err(err) => (),
+        if let Ok(backlog_socket) = BacklogSocket::new(&self.bound_socket) {
+            backlog_sockets.push(backlog_socket);
         }
 
         let remote_endpoint = active_backlog_socket.remote_endpoint().unwrap();

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use connected::ConnectedStream;
@@ -713,7 +711,7 @@ impl Socket for StreamSocket {
 }
 
 impl Observer<()> for StreamSocket {
-    fn on_events(&self, events: &()) {
+    fn on_events(&self, _events: &()) {
         let conn_ready = self.update_io_events();
 
         if conn_ready {

--- a/kernel/aster-nix/src/net/socket/mod.rs
+++ b/kernel/aster-nix/src/net/socket/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use self::options::SocketOption;
 pub use self::util::{
     options::LingerOption, send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd,
@@ -18,17 +16,17 @@ pub mod vsock;
 /// Operations defined on a socket.
 pub trait Socket: FileLike + Send + Sync {
     /// Assign the address specified by socket_addr to the socket
-    fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
+    fn bind(&self, _socket_addr: SocketAddr) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "bind() is not supported");
     }
 
     /// Build connection for a given address
-    fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
+    fn connect(&self, _socket_addr: SocketAddr) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "connect() is not supported");
     }
 
     /// Listen for connections on a socket
-    fn listen(&self, backlog: usize) -> Result<()> {
+    fn listen(&self, _backlog: usize) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "listen() is not supported");
     }
 
@@ -38,7 +36,7 @@ pub trait Socket: FileLike + Send + Sync {
     }
 
     /// Shut down part of a full-duplex connection
-    fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
+    fn shutdown(&self, _cmd: SockShutdownCmd) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "shutdown() is not supported");
     }
 
@@ -54,12 +52,12 @@ pub trait Socket: FileLike + Send + Sync {
 
     /// Get options on the socket. The resulted option will put in the `option` parameter, if
     /// this method returns success.
-    fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+    fn get_option(&self, _option: &mut dyn SocketOption) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "getsockopt() is not supported");
     }
 
     /// Set options on the socket.
-    fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
+    fn set_option(&self, _option: &dyn SocketOption) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "setsockopt() is not supported");
     }
 

--- a/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use super::endpoint::Endpoint;
 use crate::{
     events::IoEvents,
@@ -25,10 +23,6 @@ impl Connected {
 
     pub(super) fn peer_addr(&self) -> Option<UnixSocketAddrBound> {
         self.local_endpoint.peer_addr()
-    }
-
-    pub(super) fn is_bound(&self) -> bool {
-        self.addr().is_some()
     }
 
     pub(super) fn write(&self, buf: &[u8]) -> Result<usize> {

--- a/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(unused_variables)]
-
 use crate::{
     events::IoEvents,
     fs::utils::{Channel, Consumer, Producer, StatusFlags},

--- a/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -69,14 +69,14 @@ impl Endpoint {
     }
 
     pub(super) fn set_nonblocking(&self, is_nonblocking: bool) -> Result<()> {
-        let reader_flags = self.0.reader.status_flags();
-        self.0
-            .reader
-            .set_status_flags(reader_flags | StatusFlags::O_NONBLOCK)?;
-        let writer_flags = self.0.writer.status_flags();
-        self.0
-            .writer
-            .set_status_flags(writer_flags | StatusFlags::O_NONBLOCK)?;
+        let mut reader_flags = self.0.reader.status_flags();
+        reader_flags.set(StatusFlags::O_NONBLOCK, is_nonblocking);
+        self.0.reader.set_status_flags(reader_flags)?;
+
+        let mut writer_flags = self.0.writer.status_flags();
+        writer_flags.set(StatusFlags::O_NONBLOCK, is_nonblocking);
+        self.0.writer.set_status_flags(writer_flags)?;
+
         Ok(())
     }
 

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use super::{connected::Connected, endpoint::Endpoint, listener::push_incoming};
@@ -67,10 +65,6 @@ impl Init {
 
         push_incoming(remote_addr, remote_end)?;
         Ok(Connected::new(this_end))
-    }
-
-    pub(super) fn is_bound(&self) -> bool {
-        self.addr.lock().is_some()
     }
 
     pub(super) fn addr(&self) -> Option<UnixSocketAddrBound> {

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
 use super::{
     connected::Connected,
     endpoint::Endpoint,
@@ -35,10 +32,6 @@ pub struct UnixStreamSocket(RwLock<State>);
 impl UnixStreamSocket {
     pub(super) fn new_init(init: Init) -> Self {
         Self(RwLock::new(State::Init(Arc::new(init))))
-    }
-
-    pub(super) fn new_listen(listen: Listener) -> Self {
-        Self(RwLock::new(State::Listen(Arc::new(listen))))
     }
 
     pub(super) fn new_connected(connected: Connected) -> Self {
@@ -91,7 +84,7 @@ impl UnixStreamSocket {
         status_flags.intersection(SUPPORTED_FLAGS)
     }
 
-    fn send(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
+    fn send(&self, buf: &[u8], _flags: SendRecvFlags) -> Result<usize> {
         let connected = match &*self.0.read() {
             State::Connected(connected) => connected.clone(),
             _ => return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected"),
@@ -100,7 +93,7 @@ impl UnixStreamSocket {
         connected.write(buf)
     }
 
-    fn recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<usize> {
+    fn recv(&self, buf: &mut [u8], _flags: SendRecvFlags) -> Result<usize> {
         let connected = match &*self.0.read() {
             State::Connected(connected) => connected.clone(),
             _ => return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected"),

--- a/kernel/aster-nix/src/net/socket/util/message_header.rs
+++ b/kernel/aster-nix/src/net/socket/util/message_header.rs
@@ -47,7 +47,7 @@ pub fn copy_message_from_user(io_vecs: &[IoVec]) -> Box<[u8]> {
         // FIXME: short read should be allowed here
         match io_vec.read_exact_from_user(dst) {
             Ok(()) => total_bytes += io_vec.len(),
-            Err(e) => {
+            Err(_) => {
                 warn!("fails to copy message from user");
                 break;
             }
@@ -84,7 +84,7 @@ pub fn copy_message_to_user(io_vecs: &[IoVec], message: &[u8]) -> usize {
         let src = &message[total_bytes..total_bytes + len];
         match io_vec.write_to_user(src) {
             Ok(len) => total_bytes += len,
-            Err(e) => {
+            Err(_) => {
                 warn!("fails to copy message to user");
                 break;
             }

--- a/kernel/aster-nix/src/net/socket/util/options.rs
+++ b/kernel/aster-nix/src/net/socket/util/options.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use core::time::Duration;
 
 use crate::{
@@ -19,7 +17,6 @@ pub struct SocketOptionSet {
     send_buf: u32,
     recv_buf: u32,
     linger: LingerOption,
-    keep_alive: bool,
 }
 
 impl SocketOptionSet {
@@ -32,7 +29,6 @@ impl SocketOptionSet {
             send_buf: SEND_BUF_LEN as u32,
             recv_buf: RECV_BUF_LEN as u32,
             linger: LingerOption::default(),
-            keep_alive: false,
         }
     }
 }

--- a/kernel/aster-nix/src/net/socket/vsock/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/connected.rs
@@ -92,7 +92,7 @@ impl Connected {
         connection.is_local_shutdown()
     }
 
-    pub fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
+    pub fn shutdown(&self, _cmd: SockShutdownCmd) -> Result<()> {
         // TODO: deal with cmd
         if self.should_close() {
             let mut connection = self.connection.lock_irq_disabled();

--- a/kernel/aster-nix/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/socket.rs
@@ -124,7 +124,7 @@ impl VsockStreamSocket {
         }
     }
 
-    fn try_recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
+    fn try_recv(&self, buf: &mut [u8], _flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
         let connected = match &*self.status.read() {
             Status::Connected(connected) => connected.clone(),
             Status::Init(_) | Status::Listen(_) => {
@@ -162,14 +162,12 @@ impl FileLike for VsockStreamSocket {
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         // TODO: Set correct flags
-        let flags = SendRecvFlags::empty();
         self.recv(buf, SendRecvFlags::empty()).map(|(len, _)| len)
     }
 
     fn write(&self, buf: &[u8]) -> Result<usize> {
         // TODO: Set correct flags
-        let flags = SendRecvFlags::empty();
-        self.send(buf, flags)
+        self.send(buf, SendRecvFlags::empty())
     }
 
     fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {


### PR DESCRIPTION
This PR fixes or suppresses all `unused_variables` and `dead_code` warnings in the `kernel/aster-nix/src/net` directory.

Two bugs are exposed in the process, and these two bugs are fixed in separate commits:
 - `UDP_SEND_PAYLOAD_LEN` should be used in `tx_buffer` below, not `UDP_RECEIVE_PAYLOAD_LEN`. This typo makes `UDP_SEND_PAYLOAD_LEN` an unused variable.
https://github.com/asterinas/asterinas/blob/a997785166f451eecdfd2b98ff5a3620df2ffada/kernel/aster-nix/src/net/iface/any_socket.rs#L44-L51
 - `set_nonblocking` should update the nonblocking state according to the input argument `is_nonblocking`, not always set the socket to the nonblocking state.
https://github.com/asterinas/asterinas/blob/a997785166f451eecdfd2b98ff5a3620df2ffada/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs#L71-L81