### PR TITLE
Use `Ord::clamp` to simplify the scheduling priority value

### DIFF
--- a/kernel/aster-nix/src/sched/nice.rs
+++ b/kernel/aster-nix/src/sched/nice.rs
@@ -30,12 +30,8 @@ impl Nice {
     /// Values given beyond the permissible range are automatically adjusted
     /// to the nearest boundary value.
     pub fn new(raw: i8) -> Self {
-        if raw > Self::MAX.to_raw() {
-            Self::MAX
-        } else if raw < Self::MIN.to_raw() {
-            Self::MIN
-        } else {
-            Self { value: raw }
+        Self {
+            value: raw.clamp(Self::MIN.to_raw(), Self::MAX.to_raw()),
         }
     }
 
@@ -87,12 +83,8 @@ impl Priority {
     /// Values given beyond the permissible range are automatically adjusted
     /// to the nearest boundary value.
     pub fn new(raw: u8) -> Self {
-        if raw > Self::MAX.to_raw() {
-            Self::MAX
-        } else if raw < Self::MIN.to_raw() {
-            Self::MIN
-        } else {
-            Self { value: raw }
+        Self {
+            value: raw.clamp(Self::MIN.to_raw(), Self::MAX.to_raw()),
         }
     }
 

--- a/kernel/aster-nix/src/syscall/set_get_priority.rs
+++ b/kernel/aster-nix/src/syscall/set_get_priority.rs
@@ -12,13 +12,7 @@ use crate::{
 pub fn sys_set_priority(which: i32, who: u32, prio: i32) -> Result<SyscallReturn> {
     let prio_target = PriorityTarget::new(which, who)?;
     let new_nice = {
-        let norm_prio = if prio > i8::MAX as i32 {
-            i8::MAX
-        } else if prio < i8::MIN as i32 {
-            i8::MIN
-        } else {
-            prio as i8
-        };
+        let norm_prio = prio.clamp(i8::MIN as i32, i8::MAX as i32) as i8;
         Nice::new(norm_prio)
     };
 


### PR DESCRIPTION
The [Ord::clamp](https://doc.rust-lang.org/std/cmp/trait.Ord.html#method.clamp) restricts a value to a certain interval. The scheduling priority value is a good case to use this API. So I refine the code with it.