### PR TITLE
Improve the fs subsystem in several aspects

### DIFF
--- a/kernel/aster-nix/src/fs/exfat/inode.rs
+++ b/kernel/aster-nix/src/fs/exfat/inode.rs
@@ -613,7 +613,7 @@ impl ExfatInode {
         let fs = inner.fs();
         let fs_guard = fs.lock();
         self.inner.write().resize(0, &fs_guard)?;
-        self.inner.read().page_cache.pages().resize(0)?;
+        self.inner.read().page_cache.resize(0)?;
         Ok(())
     }
 
@@ -860,7 +860,7 @@ impl ExfatInode {
             inner.size_allocated = new_size_allocated;
             inner.size = new_size_allocated;
 
-            inner.page_cache.pages().resize(new_size_allocated)?;
+            inner.page_cache.resize(new_size_allocated)?;
         }
         let inner = self.inner.read();
 
@@ -1040,7 +1040,7 @@ impl ExfatInode {
         if delete_contents {
             if is_dir {
                 inode.inner.write().resize(0, fs_guard)?;
-                inode.inner.read().page_cache.pages().resize(0)?;
+                inode.inner.read().page_cache.resize(0)?;
             }
             // Set the delete flag.
             inode.inner.write().is_deleted = true;
@@ -1110,7 +1110,7 @@ impl Inode for ExfatInode {
 
         // We will delay updating the page_cache size when enlarging an inode until the real write.
         if new_size < file_size {
-            self.inner.read().page_cache.pages().resize(new_size)?;
+            self.inner.read().page_cache.resize(new_size)?;
         }
 
         // Sync this inode since size has changed.
@@ -1310,7 +1310,7 @@ impl Inode for ExfatInode {
                 if new_size > file_allocated_size {
                     inner.resize(new_size, &fs_guard)?;
                 }
-                inner.page_cache.pages().resize(new_size)?;
+                inner.page_cache.resize(new_size)?;
             }
             new_size.max(file_size)
         };
@@ -1364,7 +1364,7 @@ impl Inode for ExfatInode {
                 if end_offset > file_allocated_size {
                     inner.resize(end_offset, &fs_guard)?;
                 }
-                inner.page_cache.pages().resize(end_offset)?;
+                inner.page_cache.resize(end_offset)?;
             }
             file_size.max(end_offset)
         };

--- a/kernel/aster-nix/src/fs/ext2/blocks_hole.rs
+++ b/kernel/aster-nix/src/fs/ext2/blocks_hole.rs
@@ -2,6 +2,8 @@
 
 #![allow(dead_code)]
 
+use core::ops::Range;
+
 use bitvec::prelude::BitVec;
 
 /// A blocks hole descriptor implemented by the `BitVec`.
@@ -49,6 +51,17 @@ impl BlocksHoleDesc {
         self.0.set(idx, true);
     }
 
+    /// Marks all blocks within the `range` as holes.
+    ///
+    /// # Panic
+    ///
+    /// If the `range` is out of bounds, this method will panic.
+    pub fn set_range(&mut self, range: Range<usize>) {
+        for idx in range {
+            self.0.set(idx, true);
+        }
+    }
+
     /// Unmarks the block `idx` as a hole.
     ///
     /// # Panics
@@ -56,5 +69,16 @@ impl BlocksHoleDesc {
     /// If the `idx` is out of bounds, this method will panic.
     pub fn unset(&mut self, idx: usize) {
         self.0.set(idx, false);
+    }
+
+    /// Unmarks all blocks within the `range` as holes.
+    ///
+    /// # Panic
+    ///
+    /// If the `range` is out of bounds, this method will panic.
+    pub fn unset_range(&mut self, range: Range<usize>) {
+        for idx in range {
+            self.0.set(idx, false);
+        }
     }
 }

--- a/kernel/aster-nix/src/fs/ext2/dir.rs
+++ b/kernel/aster-nix/src/fs/ext2/dir.rs
@@ -250,7 +250,7 @@ impl<'a> DirEntryWriter<'a> {
             // Resize and append it at the new block.
             let old_size = self.page_cache.pages().size();
             let new_size = old_size + BLOCK_SIZE;
-            self.page_cache.pages().resize(new_size)?;
+            self.page_cache.resize(new_size)?;
             new_entry.set_record_len(BLOCK_SIZE);
             self.offset = old_size;
             self.write_entry(&new_entry)?;
@@ -285,7 +285,7 @@ impl<'a> DirEntryWriter<'a> {
         {
             // Shrink the size.
             let new_size = pre_offset.align_up(BLOCK_SIZE);
-            self.page_cache.pages().resize(new_size)?;
+            self.page_cache.resize(new_size)?;
             pre_entry.set_record_len(new_size - pre_offset);
             self.offset = pre_offset;
             self.write_entry(&pre_entry)?;

--- a/kernel/aster-nix/src/fs/ext2/fs.rs
+++ b/kernel/aster-nix/src/fs/ext2/fs.rs
@@ -303,6 +303,14 @@ impl Ext2 {
         }
     }
 
+    /// Reads contiguous blocks starting from the `bid` asynchronously.
+    pub(super) fn read_blocks_async(&self, bid: Ext2Bid, segment: &Segment) -> Result<BioWaiter> {
+        let waiter = self
+            .block_device
+            .read_blocks(Bid::new(bid as u64), segment)?;
+        Ok(waiter)
+    }
+
     /// Reads one block indicated by the `bid` synchronously.
     pub(super) fn read_block(&self, bid: Ext2Bid, frame: &Frame) -> Result<()> {
         let status = self
@@ -329,6 +337,14 @@ impl Ext2 {
             BioStatus::Complete => Ok(()),
             err_status => Err(Error::from(err_status)),
         }
+    }
+
+    /// Writes contiguous blocks starting from the `bid` asynchronously.
+    pub(super) fn write_blocks_async(&self, bid: Ext2Bid, segment: &Segment) -> Result<BioWaiter> {
+        let waiter = self
+            .block_device
+            .write_blocks(Bid::new(bid as u64), segment)?;
+        Ok(waiter)
     }
 
     /// Writes one block indicated by the `bid` synchronously.

--- a/kernel/aster-nix/src/fs/ext2/inode.rs
+++ b/kernel/aster-nix/src/fs/ext2/inode.rs
@@ -856,8 +856,8 @@ impl Inner {
     }
 
     pub fn resize(&mut self, new_size: usize) -> Result<()> {
+        self.page_cache.resize(new_size)?;
         self.inode_impl.resize(new_size)?;
-        self.page_cache.pages().resize(new_size)?;
         Ok(())
     }
 
@@ -905,7 +905,7 @@ impl Inner {
 
     pub fn extend_write_at(&mut self, offset: usize, buf: &[u8]) -> Result<usize> {
         let new_size = offset + buf.len();
-        self.page_cache.pages().resize(new_size)?;
+        self.page_cache.resize(new_size)?;
         self.page_cache.pages().write_bytes(offset, buf)?;
         self.inode_impl.resize(new_size)?;
         Ok(buf.len())
@@ -947,7 +947,7 @@ impl Inner {
             return self.inode_impl.write_link(target);
         }
 
-        self.page_cache.pages().resize(target.len())?;
+        self.page_cache.resize(target.len())?;
         self.page_cache.pages().write_bytes(0, target.as_bytes())?;
         let file_size = self.inode_impl.file_size();
         if file_size != target.len() {

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -165,7 +165,7 @@ impl Dentry_ {
     }
 
     /// Lookup a Dentry_ from filesystem.
-    pub fn lookuop_via_fs(&self, name: &str) -> Result<Arc<Dentry_>> {
+    pub fn lookup_via_fs(&self, name: &str) -> Result<Arc<Dentry_>> {
         let mut children = self.children.lock();
         let inode = self.inode.lookup(name)?;
         let inner = Self::new(
@@ -483,7 +483,7 @@ impl Dentry {
                 match children_inner {
                     Some(inner) => Self::new(self.mount_node().clone(), inner.clone()),
                     None => {
-                        let fs_inner = self.inner.lookuop_via_fs(name)?;
+                        let fs_inner = self.inner.lookup_via_fs(name)?;
                         Self::new(self.mount_node().clone(), fs_inner.clone())
                     }
                 }

--- a/kernel/aster-nix/src/fs/ramfs/fs.rs
+++ b/kernel/aster-nix/src/fs/ramfs/fs.rs
@@ -557,7 +557,7 @@ impl Inode for RamInode {
         let new_size = offset + buf.len();
         let should_expand_size = new_size > file_size;
         if should_expand_size {
-            page_cache.pages().resize(new_size)?;
+            page_cache.resize(new_size)?;
         }
         page_cache.pages().write_bytes(offset, buf)?;
 
@@ -599,7 +599,7 @@ impl Inode for RamInode {
 
         let self_inode = self_inode.downgrade();
         let page_cache = self_inode.inner.as_file().unwrap();
-        page_cache.pages().resize(new_size)?;
+        page_cache.resize(new_size)?;
 
         Ok(())
     }

--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(int_roundings)]
+#![feature(iter_repeat_n)]
 #![feature(let_chains)]
 #![feature(linked_list_remove)]
 #![feature(register_tool)]

--- a/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
+++ b/kernel/aster-nix/src/vm/vmo/dyn_cap.rs
@@ -162,6 +162,7 @@ impl VmIo for Vmo<Rights> {
         self.0.write_bytes(offset, buf)?;
         Ok(())
     }
+    // TODO: Support efficient `write_vals()`
 }
 
 impl VmoRightsOp for Vmo<Rights> {

--- a/kernel/comps/block/src/impl_block_device.rs
+++ b/kernel/comps/block/src/impl_block_device.rs
@@ -11,6 +11,7 @@ use crate::prelude::*;
 
 /// Implements several commonly used APIs for the block device to conveniently
 /// read and write block(s).
+// TODO: Add API to submit bio with multiple segments in scatter/gather manner.
 impl dyn BlockDevice {
     /// Synchronously reads contiguous blocks starting from the `bid`.
     pub fn read_blocks_sync(


### PR DESCRIPTION
This PR includes:
- bugfix: when shrink page cache size (truncate file), the gap within one page should be zeroed
- opt: Optimize `evict_range()` in page cache
- perf: Introduce a unified function to read/write one or multiple block(s) of inode
before this opt:
![image](https://github.com/asterinas/asterinas/assets/22837133/d159350d-dc67-408a-85b2-fd54d1880162)
after this opt:
![image](https://github.com/asterinas/asterinas/assets/22837133/d997c40c-4f1c-459b-b354-a64de22960b4)