### PR TITLE
Avoid long lines in `Makefile`s and workflows

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Fetch versions in the repo
         id: fetch-versions
         run: |
-          echo "aster_version=$( cat VERSION )" >> "$GITHUB_OUTPUT"
-          echo "rust_version=$( grep -m1 -o 'nightly-[0-9]\+-[0-9]\+-[0-9]\+' rust-toolchain.toml )" >> "$GITHUB_OUTPUT"
+          ASTER_VERSION=$(cat VERSION)
+          RUST_VERSION=$(grep -m1 -o 'nightly-[0-9]\+-[0-9]\+-[0-9]\+' rust-toolchain.toml)
+          echo "aster_version=$ASTER_VERSION" >> "$GITHUB_OUTPUT"
+          echo "rust_version=$RUST_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate Dockerfile
         run: |

--- a/.github/workflows/kernel_test.yml
+++ b/.github/workflows/kernel_test.yml
@@ -78,7 +78,10 @@ jobs:
 
       - name: Syscall Test at Exfat
         id: syscall_test_at_exfat_linux
-        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
+        run: |
+          make run AUTO_TEST=syscall \
+            SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat \
+            ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
         
       - name: Regression Test (Linux EFI Handover Boot Protocol)
         id: regression_test_linux

--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -30,7 +30,10 @@ jobs:
         # of actions/checkout@v4
       - name: Unit test
         id: unit_test
-        run: cd osdk && RUSTUP_HOME=/root/.rustup cargo +stable build && RUSTUP_HOME=/root/.rustup cargo test
+        run: |
+          cd osdk
+          RUSTUP_HOME=/root/.rustup cargo +stable build
+          RUSTUP_HOME=/root/.rustup cargo test
   
   # Test OSDK in the same environment 
   # as described in the OSDK User Guide in the Asterinas Book.
@@ -50,5 +53,7 @@ jobs:
         # So the RUSTUP_HOME needs to be set here. 
         # This only breaks when we invoke Cargo in the integration test of OSDK 
         # since the OSDK toolchain is not nightly.
-        run: cd osdk && RUSTUP_HOME=/root/.rustup cargo +stable build && RUSTUP_HOME=/root/.rustup cargo test
-    
+        run: |
+          cd osdk
+          RUSTUP_HOME=/root/.rustup cargo +stable build
+          RUSTUP_HOME=/root/.rustup cargo test

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -39,7 +39,8 @@ jobs:
           ssh-keyscan -t rsa github.com >> ./known_hosts
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          GIT_SSH_COMMAND="ssh -i ./book_publish_key -o UserKnownHostsFile=./known_hosts" git clone git@github.com:asterinas/book.git temp_book
+          GIT_SSH_COMMAND="ssh -i ./book_publish_key -o UserKnownHostsFile=./known_hosts" \
+            git clone git@github.com:asterinas/book.git temp_book
           cd temp_book
           git checkout --orphan newBranch
           git rm -rf *
@@ -48,4 +49,5 @@ jobs:
           git commit -am "Update website"
           git branch -D main
           git branch -m main
-          GIT_SSH_COMMAND="ssh -i ../book_publish_key -o UserKnownHostsFile=../known_hosts" git push -f origin main
+          GIT_SSH_COMMAND="ssh -i ../book_publish_key -o UserKnownHostsFile=../known_hosts" \
+            git push -f origin main

--- a/.github/workflows/vsock_interaction.yml
+++ b/.github/workflows/vsock_interaction.yml
@@ -16,12 +16,15 @@ jobs:
             sudo modprobe vhost_vsock
             sudo apt-get install socat
             echo "Run vsock server on host...."
-            socat -ddd VSOCK-LISTEN:1234,fork SYSTEM:'while read cmd; do result=$(eval "$cmd" 2>&1); echo "$result"; done' &
+            socat -ddd VSOCK-LISTEN:1234,fork \
+              SYSTEM:'while read cmd; do result=$(eval "$cmd" 2>&1); echo "$result"; done' &
       - name: Run Vsock Client and Server on Guest
         id: guest_vsock_client_server
         run: |
-            docker run  --privileged --network=host --device=/dev/kvm -v ./:/root/asterinas asterinas/asterinas:0.5.0 \
-            make run AUTO_TEST=vsock ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1 &
+            docker run \
+              --privileged --network=host --device=/dev/kvm \
+              -v ./:/root/asterinas asterinas/asterinas:0.5.0 \
+              make run AUTO_TEST=vsock ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1 &
       - name: Run Vsock Client on Host
         id: host_vsock_client
         run: |

--- a/Makefile
+++ b/Makefile
@@ -142,13 +142,17 @@ run: build
 	@cargo osdk run $(CARGO_OSDK_ARGS)
 # Check the running status of auto tests from the QEMU log
 ifeq ($(AUTO_TEST), syscall)
-	@tail --lines 100 qemu.log | grep -q "^.* of .* test cases passed." || (echo "Syscall test failed" && exit 1)
+	@tail --lines 100 qemu.log | grep -q "^.* of .* test cases passed." \
+		|| (echo "Syscall test failed" && exit 1)
 else ifeq ($(AUTO_TEST), regression)
-	@tail --lines 100 qemu.log | grep -q "^All regression tests passed." || (echo "Regression test failed" && exit 1)
+	@tail --lines 100 qemu.log | grep -q "^All regression tests passed." \
+		|| (echo "Regression test failed" && exit 1)
 else ifeq ($(AUTO_TEST), boot)
-	@tail --lines 100 qemu.log | grep -q "^Successfully booted." || (echo "Boot test failed" && exit 1)
+	@tail --lines 100 qemu.log | grep -q "^Successfully booted." \
+		|| (echo "Boot test failed" && exit 1)
 else ifeq ($(AUTO_TEST), vsock)
-	@tail --lines 100 qemu.log | grep -q "^Vsock test passed." || (echo "Vsock test failed" && exit 1)
+	@tail --lines 100 qemu.log | grep -q "^Vsock test passed." \
+		|| (echo "Vsock test failed" && exit 1)
 endif
 
 gdb_server: initramfs $(CARGO_OSDK)
@@ -179,7 +183,7 @@ docs: $(CARGO_OSDK)
 	@for dir in $(OSDK_CRATES); do \
 		(cd $$dir && cargo osdk doc --no-deps) || exit 1; \
 	done
-	@echo "" 								# Add a blank line
+	@echo "" 						# Add a blank line
 	@cd docs && mdbook build 				# Build mdBook
 
 .PHONY: format
@@ -196,7 +200,8 @@ check: $(CARGO_OSDK)
 		sort > /tmp/all_crates
 	@echo $(NON_OSDK_CRATES) $(OSDK_CRATES) | tr ' ' '\n' | sort > /tmp/combined_crates
 	@diff -B /tmp/all_crates /tmp/combined_crates || \
-		(echo "Error: STD_CRATES and NOSTD_CRATES combined is not the same as all workspace members" && exit 1)
+		(echo "Error: The combination of STD_CRATES and NOSTD_CRATES" \
+			"is not the same as all workspace members" && exit 1)
 	@rm /tmp/all_crates /tmp/combined_crates
 	@for dir in $(NON_OSDK_CRATES); do \
 		echo "Checking $$dir"; \

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ else ifeq ($(AUTO_TEST), vsock)
 		|| (echo "Vsock test failed" && exit 1)
 endif
 
+.PHONY: gdb_server
 gdb_server: initramfs $(CARGO_OSDK)
 	@cargo osdk run $(CARGO_OSDK_ARGS) -G --vsc --gdb-server-addr :$(GDB_TCP_PORT)
 
@@ -176,6 +177,7 @@ ktest: initramfs $(CARGO_OSDK)
 		(cd $$dir && cargo osdk test) || exit 1; \
 	done
 
+.PHONY: docs
 docs: $(CARGO_OSDK)
 	@for dir in $(NON_OSDK_CRATES); do \
 		(cd $$dir && cargo doc --no-deps) || exit 1; \

--- a/regression/apps/Makefile
+++ b/regression/apps/Makefile
@@ -34,7 +34,9 @@ TEST_APPS := \
 	vsock \
 
 # The C head and source files of all the apps, excluding the downloaded mongoose files
-C_SOURCES := $(shell find . -type f \( -name "*.c" -or -name "*.h" \) ! -name "mongoose.c" ! -name "mongoose.h")
+C_SOURCES := \
+	$(shell find . -type f \( -name "*.c" -or -name "*.h" \) \
+		! -name "mongoose.c" ! -name "mongoose.h")
 
 .PHONY: all
 all: $(TEST_APPS) scripts


### PR DESCRIPTION
Long lines should be avoided, because they are too ugly when wrapped and significantly harm readability. So I split them into multiple lines.

Also, `docs` and `gdb_server` are phony targets, but their `.PHONY` lines are missing, so this PR fixes that problem by adding those lines.