### PR TITLE
Fix the major memory leak when spawning

### DIFF
--- a/kernel/aster-nix/src/process/mod.rs
+++ b/kernel/aster-nix/src/process/mod.rs
@@ -35,4 +35,5 @@ pub use wait::{wait_child_exit, WaitOptions};
 
 pub(super) fn init() {
     process::init();
+    posix_thread::futex::init();
 }


### PR DESCRIPTION
Fix the major cause of #785. I found out that `lazy_static` have caused the leak by multiple initialization in this case, which is really subtle.

Thanks to #966, we have a powerful tool to trace memory leakages of global allocation.

Before this fix, the leaked heap flame graph is:

![kenel](https://github.com/asterinas/asterinas/assets/30975570/2297accf-4f0c-450e-aabf-4a3b7851a4c9)

After this fix, the leaked heap flame graph is:

![kenel_after](https://github.com/asterinas/asterinas/assets/30975570/299a423d-cbca-436b-83cb-7554730d7a0b)

Also, when doing the unixbench spawn test, it will encounter a memory shortage within 20 seconds in the main branch. After this fix, it can run for over 100 seconds.

Surely there are other leakages.