### PR TITLE
Prefer `into_raw()` than `paddr()` + `forget()` in PT

### DIFF
--- a/framework/aster-frame/src/mm/page/mod.rs
+++ b/framework/aster-frame/src/mm/page/mod.rs
@@ -202,7 +202,6 @@ impl DynPage {
     ///
     /// A physical address to the page is returned in case the page needs to be
     /// restored using [`Self::from_raw`] later.
-    #[allow(unused)]
     pub(in crate::mm) fn into_raw(self) -> Paddr {
         let paddr = self.paddr();
         core::mem::forget(self);

--- a/framework/aster-frame/src/mm/page_table/node.rs
+++ b/framework/aster-frame/src/mm/page_table/node.rs
@@ -382,10 +382,10 @@ where
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         debug_assert_eq!(page.level(), self.level());
 
-        let pte = Some(E::new_page(page.paddr(), self.level(), prop));
+        // Use the physical address rather than the page handle to track
+        // the page, and record the physical address in the PTE.
+        let pte = Some(E::new_page(page.into_raw(), self.level(), prop));
         self.overwrite_pte(idx, pte, true);
-        // The ownership is transferred to a raw PTE. Don't drop the handle.
-        let _ = ManuallyDrop::new(page);
     }
 
     /// Sets an untracked child page at a given index.


### PR DESCRIPTION
It's a minor API preference issue. This was introduced in #938. It can be recognized as part of the page table cleanup work #918.

The `Page<M>::into_raw` is still unused, for it's designed to be used for page tables but the page table node has it's implementation due to the move constraint. However the function exists to improve readability as an immediate reference to the `Page<M>::from_raw` method, which is used.