### PR TITLE
Fix debug target path in OSDK

### DIFF
--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -2,17 +2,17 @@
 
 use crate::{
     cli::DebugArgs,
-    commands::util::{bin_file_name, profile_name_adapter},
-    util::get_target_directory,
+    commands::util::bin_file_name,
+    util::{get_current_crate_info, get_target_directory},
 };
 use std::process::Command;
 
-pub fn execute_debug_command(profile: &str, args: &DebugArgs) {
+pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
     let remote = &args.remote;
 
     let file_path = get_target_directory()
-        .join("x86_64-unknown-none")
-        .join(profile_name_adapter(profile))
+        .join("osdk")
+        .join(get_current_crate_info().name)
         .join(bin_file_name());
     println!("Debugging {}", file_path.display());
 

--- a/osdk/src/commands/launch.json.template
+++ b/osdk/src/commands/launch.json.template
@@ -5,7 +5,7 @@
             "name": "Debug Asterinas(#PROFILE#)",
             "type": "lldb",
             "request": "custom",
-            "targetCreateCommands": ["target create ${workspaceFolder}/target/x86_64-unknown-none/#PROFILE#/#BIN_NAME#"],
+            "targetCreateCommands": ["target create ${workspaceFolder}/target/osdk/#CRATE_NAME#/#BIN_NAME#"],
             "processCreateCommands": ["gdb-remote #ADDR_PORT#"]
         }
     ]


### PR DESCRIPTION
- Fix the outdated target path generated for the `--vsc` feature and `cargo osdk debug`;
- Fix the profile tag source for `.vscode/launch.json` which is from `config.run: Action` now.