### PR TITLE
Use matrix to simplify osdk test

### DIFF
--- a/.github/workflows/osdk_test.yml
+++ b/.github/workflows/osdk_test.yml
@@ -15,44 +15,29 @@ jobs:
   osdk-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container: asterinas/asterinas:0.5.1
+    strategy:
+      matrix:
+        # asterinas/asterinas:0.5.1 container is the developing container of asterinas,
+        # asterinas/osdk:0.5.1 container is built with the intructions from Asterinas Book
+        container: ['asterinas/asterinas:0.5.1', 'asterinas/osdk:0.5.1']
+    container: ${{ matrix.container }}
     steps:
-      - run: echo "Running in asterinas/asterinas:0.5.1"
+      - run: echo "Running in ${{ matrix.container }}"
 
       - uses: actions/checkout@v4
 
       - name: Lint
         id: lint
+        if: matrix.container == 'asterinas/asterinas:0.5.1'
         run: make check_osdk
 
-        # The OSDK unit test features a recursive call of Cargo,
-        # which will break when RUSTUP_HOME is altered in the case
-        # of actions/checkout@v4
+      # Github's actions/checkout@v4 will result in a new user (not root) 
+      # and thus not using the Rust environment we set up in the container. 
+      # So the RUSTUP_HOME needs to be set here. 
+      # This only breaks when we invoke Cargo in the integration test of OSDK 
+      # since the OSDK toolchain is not nightly.
       - name: Unit test
         id: unit_test
-        run: |
-          cd osdk
-          RUSTUP_HOME=/root/.rustup cargo +stable build
-          RUSTUP_HOME=/root/.rustup cargo test
-  
-  # Test OSDK in the same environment 
-  # as described in the OSDK User Guide in the Asterinas Book.
-  osdk-doc-env-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    container: asterinas/osdk:0.5.1
-    steps:
-      - run: echo "Running in asterinas/osdk:0.5.1"
-
-      - uses: actions/checkout@v4
-
-      - name: Unit test
-        id: unit_test
-        # Github's actions/checkout@v4 will result in a new user (not root) 
-        # and thus not using the Rust environment we set up in the container. 
-        # So the RUSTUP_HOME needs to be set here. 
-        # This only breaks when we invoke Cargo in the integration test of OSDK 
-        # since the OSDK toolchain is not nightly.
         run: |
           cd osdk
           RUSTUP_HOME=/root/.rustup cargo +stable build

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "clap",


### PR DESCRIPTION
Since the two osdk test contains the same content, and the only difference is the running container. So the `matrix` keyword is used to simplify the workflow. 