### PR TITLE
Fix unused warning of `UtimeExt`

### DIFF
--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -202,9 +202,9 @@ fn read_time_from_user<T: Pod>(time_ptr: Vaddr) -> Result<(T, T)> {
     Ok((autime, mutime))
 }
 
+#[allow(dead_code)]
 trait UtimeExt {
     fn utime_now() -> Self;
-    #[allow(dead_code)]
     fn utime_omit() -> Self;
     fn is_utime_now(&self) -> bool;
     fn is_utime_omit(&self) -> bool;


### PR DESCRIPTION
This PR fixes the error of lint CI.
![image](https://github.com/asterinas/asterinas/assets/24353687/29e41c81-34e0-42ac-8f9a-538488fa6459)
