### PR TITLE
Refine release workflow

### DIFF
--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -2,11 +2,23 @@ name: Publish Docker images
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - VERSION
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      build:
+        description: 'Whether to build image'
+        required: false
+        default: false
+        type: 'boolean'
+      push:
+        description: 'Whether to push image to docker hub'
+        required: false
+        default: false
+        type: 'boolean'
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 
 jobs:
   docker:
@@ -16,6 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
+        if: ${{ inputs.push }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -37,12 +50,13 @@ jobs:
           python3 ./tools/docker/gen_dockerfile.py
 
       - name: Build and push development image
+        if: ${{ inputs.build }}
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./tools/docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ inputs.push }}
           tags: asterinas/asterinas:${{ steps.fetch-versions.outputs.aster_version }}
           build-args: |
             "ASTER_RUST_VERSION=${{ steps.fetch-versions.outputs.rust_version }}"
@@ -53,12 +67,13 @@ jobs:
           python3 ./tools/docker/gen_dockerfile.py --intel-tdx
 
       - name: Build and push development image for Intel TDX
+        if: ${{ inputs.build }}
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./tools/docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ inputs.push }}
           tags: asterinas/asterinas:${{ steps.fetch-versions.outputs.aster_version }}-tdx
           build-args: |
             "ASTER_RUST_VERSION=${{ steps.fetch-versions.outputs.rust_version }}"
@@ -68,12 +83,13 @@ jobs:
           python3 ./osdk/tools/docker/gen_dockerfile.py
 
       - name: Build and push OSDK test image
+        if: ${{ inputs.build }}
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./osdk/tools/docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ inputs.push }}
           tags: asterinas/osdk:${{ steps.fetch-versions.outputs.aster_version }}
           build-args: |
             "ASTER_RUST_VERSION=${{ steps.fetch-versions.outputs.rust_version }}"
@@ -83,12 +99,13 @@ jobs:
           python3 ./osdk/tools/docker/gen_dockerfile.py --intel-tdx
 
       - name: Build and push OSDK test image for Intel TDX
+        if: ${{ inputs.build }}
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./osdk/tools/docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ inputs.push }}
           tags: asterinas/osdk:${{ steps.fetch-versions.outputs.aster_version }}-tdx
           build-args: |
             "ASTER_RUST_VERSION=${{ steps.fetch-versions.outputs.rust_version }}"

--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -1,19 +1,27 @@
 name: Publish OSDK and OSTD
 
 on:
-  pull_request:
-    paths:
-      - VERSION
-      - ostd/**
-      - osdk/**
-  push:
-    branches:
-      - main
-    paths: 
-      - VERSION
+  workflow_call:
+    inputs:
+      skip: 
+        description: 'Whether to skip the osdk-publish and ostd-publish job'
+        required: false
+        default: true
+        type: 'boolean'
+      publish:
+        description: 'Whether to publish osdk and ostd'
+        required: false
+        default: false
+        type: 'boolean'
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: false
+  workflow_dispatch:
+
 
 jobs:
   osdk-publish:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: asterinas/asterinas:0.6.2
@@ -21,15 +29,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check Publish OSDK
-        # On pull request, set `--dry-run` to check whether OSDK can publish
-        if: github.event_name == 'pull_request'
+        if: ${{ !inputs.publish }}
         run: |
           cd osdk
           cargo publish --dry-run
         
       - name: Publish OSDK
-        # On push, OSDK will be published
-        if: github.event_name == 'push'
+        if: ${{ inputs.publish }}
         env:
           REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
@@ -37,6 +43,7 @@ jobs:
           cargo publish --token ${REGISTRY_TOKEN}
 
   ostd-publish:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: asterinas/asterinas:0.6.2
@@ -49,15 +56,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check Publish OSTD
-        # On pull request, set `--dry-run` to check whether OSDK can publish
-        if: github.event_name == 'pull_request'
+        if: ${{ !inputs.publish }}
         run: |
           cd ostd
           cargo publish --target ${{ matrix.target }} --dry-run
           cargo doc --target ${{ matrix.target }}
       
       - name: Publish OSTD
-        if: github.event_name == 'push'
+        if: ${{ inputs.publish }}
         env:
           REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         # Using any target that OSTD supports for publishing is ok.

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -1,19 +1,26 @@
 name: Publish website
 
 on:
-  pull_request:
-    paths:
-      - docs/**
-      - .github/workflows/update-website.yml
-  push:
-    branches:
-      - main
-    paths:
-      - docs/**
-      - .github/workflows/update-website.yml
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      skip: 
+        description: 'Whether to skip the job'
+        required: false
+        default: false
+        type: 'boolean'
+      deploy:
+        description: 'Whether to upload doc to online website'
+        required: false
+        default: false
+        type: 'boolean'
+    secrets:
+      BOOK_PUBLISH_KEY:
+        required: false
 
 jobs:
   build_and_deploy:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container: asterinas/asterinas:0.6.2
@@ -29,7 +36,7 @@ jobs:
           mdbook build
 
       - name: Deploy website
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: ${{ inputs.deploy }}
         env:
           BOOK_PUBLISH_KEY: ${{ secrets.BOOK_PUBLISH_KEY }}
         run: |

--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -1,0 +1,70 @@
+# Jobs that will be run when a pull request is opened 
+# and when the pull request is added to the merge queue.
+
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  check_changed_files:
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.echo_results.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Whether VERSION Changes
+        id: changed-version
+        uses: tj-actions/changed-files@v44
+        with:
+          since_last_remote_commit: true 
+          files: VERSION
+
+      - name: Echo Results
+        id: echo_results
+        env:
+          VERSION_CHANGED: ${{ steps.changed-version.outputs.any_changed }}
+        run: |
+          echo "VERSION changed: $VERSION_CHANGED"
+          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
+
+  docker_build_and_push:
+    needs: [check_changed_files]
+    uses: ./.github/workflows/publish_docker_images.yml
+    with:
+      build: ${{ needs.check_changed_files.outputs.version_changed == 'true' }}
+      push: ${{ needs.check_changed_files.outputs.version_changed == 'true' && github.event_name == 'merge_group' }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  osdk_test:
+    needs: [check_changed_files, docker_build_and_push]
+    uses: ./.github/workflows/test_osdk.yml
+    with:
+      skip: ${{ needs.check_changed_files.outputs.version_changed == 'true' && github.event_name == 'pull_request' }}
+  
+  kernel_test:
+    needs: [check_changed_files, docker_build_and_push]
+    uses: ./.github/workflows/test_asterinas.yml
+    with:
+      skip: ${{ needs.check_changed_files.outputs.version_changed == 'true' && github.event_name == 'pull_request' }}
+
+  check_publish_osdk_and_ostd:
+    needs: [check_changed_files, docker_build_and_push]
+    uses: ./.github/workflows/publish_osdk_and_ostd.yml
+    with:
+      skip: ${{ needs.check_changed_files.outputs.version_changed == 'true' && github.event_name == 'pull_request' }}
+      publish: false
+  
+  check_build_website:
+    needs: [check_changed_files, docker_build_and_push]
+    uses: ./.github/workflows/publish_website.yml
+    with:
+      skip: ${{ needs.check_changed_files.outputs.version_changed == 'true' && github.event_name == 'pull_request' }}
+      deploy: false

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -1,0 +1,76 @@
+# CI will be triggered when the code be merged into main branch.
+
+name: Push CI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  check_changed_files:
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.echo_results.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check Whether VERSION Changes
+        id: changed-version
+        uses: tj-actions/changed-files@v44
+        with:
+          files: VERSION
+
+      - name: Echo Results
+        id: echo_results
+        env:
+          VERSION_CHANGED: ${{ steps.changed-version.outputs.any_changed }}
+        run: |
+          echo "VERSION changed: $VERSION_CHANGED"
+          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
+
+  docker_push:
+    needs: check_changed_files
+    uses: ./.github/workflows/publish_docker_images.yml
+    with:
+      build: ${{ needs.check_changed_files.outputs.version_changed == 'true' }}
+      push: ${{ needs.check_changed_files.outputs.version_changed == 'true' }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  kernel_test:
+    needs: [docker_push]
+    uses: ./.github/workflows/test_asterinas.yml
+
+  osdk_test:
+    needs: [docker_push]
+    uses: ./.github/workflows/test_osdk.yml
+
+  update_website:
+    needs: [kernel_test, osdk_test]
+    uses: ./.github/workflows/publish_website.yml
+    with:
+      deploy: true
+    secrets:
+      BOOK_PUBLISH_KEY: ${{ secrets.BOOK_PUBLISH_KEY }}
+
+  release_tag:
+    needs: [kernel_test, osdk_test]
+    if: ${{ needs.check_changed_files.outputs.version_changed == 'true' }}
+    uses: ./.github/workflows/push_git_tag.yml
+
+  publish_osdk_and_ostd:
+    needs: [kernel_test, osdk_test]
+    uses: ./.github/workflows/publish_osdk_and_ostd.yml
+    with:
+      publish: true
+    # FIXME: Github allows inherit secrets from caller workflow,
+    # with a simple `secrets: inherit`.
+    # But this syntax is only supported for organization account
+    # Ref: <https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow>
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/push_git_tag.yml
+++ b/.github/workflows/push_git_tag.yml
@@ -3,11 +3,8 @@
 name: Push release tag
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - VERSION
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   tag_main_branch:

--- a/.github/workflows/test_asterinas.yml
+++ b/.github/workflows/test_asterinas.yml
@@ -1,17 +1,21 @@
 name: Test Asterinas
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
   # Schedule to run on every day at 15:00 UTC (23:00 CST)
   schedule:
     - cron: '0 15 * * *'
+  workflow_call:
+    inputs:
+      skip: 
+        description: 'Whether to check publish'
+        required: false
+        default: false
+        type: 'boolean'
+  workflow_dispatch:
 
 jobs:
   lint:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: ${{ github.event_name != 'schedule' && !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container: asterinas/asterinas:0.6.2
@@ -25,7 +29,7 @@ jobs:
         run: make check
 
   unit-test:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: ${{ github.event_name != 'schedule' && !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container: asterinas/asterinas:0.6.2
@@ -45,7 +49,7 @@ jobs:
       # TODO: add component check.
 
   integration-test:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: ${{ github.event_name != 'schedule' && !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:

--- a/.github/workflows/test_asterinas_vsock.yml
+++ b/.github/workflows/test_asterinas_vsock.yml
@@ -1,6 +1,7 @@
 name: Test Asterinas Vsock
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_osdk.yml
+++ b/.github/workflows/test_osdk.yml
@@ -1,15 +1,14 @@
 name: Test OSDK
 
 on:
-  pull_request:
-    paths:
-      - osdk/**
-      - ostd/**
-      - tools/**
-      - Cargo.toml
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      skip: 
+        description: 'Whether to skip osdk test'
+        required: false
+        default: false
+        type: 'boolean'
+  workflow_dispatch:
 
 jobs:
   osdk-test:
@@ -17,18 +16,23 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # asterinas/asterinas:0.6.2 container is the developing container of asterinas,
-        # asterinas/osdk:0.6.2 container is built with the intructions from Asterinas Book
-        container: ['asterinas/asterinas:0.6.2', 'asterinas/osdk:0.6.2']
-    container: ${{ matrix.container }}
+        # asterinas/asterinas container is the developing container of asterinas,
+        # asterinas/osdk container is built with the intructions from Asterinas Book
+        container: ['asterinas/asterinas', 'asterinas/osdk']
+    # GitHub status check requires `osdk_test / osdk-test (asterinas/asterinas)` 
+    # and `osdk_test / osdk-test (asterinas/osdk)` to be run successfully,
+    # so we can't skip the whole osdk-test job, 
+    # otherwise the two jobs on matrix values will not even be generated.
+    # ubuntu:22.04 is a randomly-chosen image which will be used to run echo.
+    container: ${{ !inputs.skip && format('{0}:0.2.0', matrix.container) || 'ubuntu:22.04' }}
     steps:
-      - run: echo "Running in ${{ matrix.container }}"
+      - run: echo "Running in ${{ !inputs.skip && format('{0}:0.2.0', matrix.container) || 'ubuntu:22.04' }}"
 
       - uses: actions/checkout@v4
 
       - name: Lint
         id: lint
-        if: matrix.container == 'asterinas/asterinas:0.6.2'
+        if: ${{ matrix.container == 'asterinas/asterinas' && !inputs.skip }}
         run: make check_osdk
 
       # Github's actions/checkout@v4 will result in a new user (not root) 
@@ -38,6 +42,7 @@ jobs:
       # since the OSDK toolchain is not nightly.
       - name: Unit test
         id: unit_test
+        if: ${{ !inputs.skip }}
         run: |
           cd osdk
           RUSTUP_HOME=/root/.rustup cargo +stable build

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -134,6 +134,10 @@ done
 RELEASE_TAG_WORKFLOW=${ASTER_SRC_DIR}/.github/workflows/push_git_tag.yml
 update_tag_version $RELEASE_TAG_WORKFLOW
 
+# Bump version in test_osdk workflow
+TEST_OSDK_WORKFLOW=${ASTER_SRC_DIR}/.github/workflows/test_osdk.yml
+sed -i "s/:[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+/:${new_version}/g" $TEST_OSDK_WORKFLOW
+
 # Update Docker image versions in the documentation
 GET_STARTED_PATH=${ASTER_SRC_DIR}/docs/src/kernel/README.md
 update_image_versions $GET_STARTED_PATH


### PR DESCRIPTION
This PR refines the workflow when publishing new release.

1. Adding two workflow pull_request_ci, and push_ci, which will be triggered as its name shows.
2. All existing workflows will be called by these two workflows. And the order of this workflows are properly sorted to eusure presquite jobs are run first.
3. This PR relies on the Github branch protection rules and merge_queue to trigger docker_push when a PR is added to merge queue. But these features should only be activated _AFTER_ this PR is merged.