### PR TITLE
Add guidelines for suppressing lints and introducing dead code

### DIFF
--- a/docs/src/to-contribute/style-guidelines/rust-guidelines.md
+++ b/docs/src/to-contribute/style-guidelines/rust-guidelines.md
@@ -12,3 +12,64 @@ The use of the `#[warn(missing_docs)]` lint enforces this rule.
 Asterinas adheres to the API style guidelines of the Rust community.
 The recommended API documentation style can be found at
 [how-to-write-documentation](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+
+## Lint Guidelines
+
+Lints help us improve the code quality and find more bugs.
+When suppressing lints, the suppression should affect as little scope as possible,
+to make readers aware of the exact places where the lint is generated,
+and to make it easier for subsequent committers to maintain such lint.
+
+For example, if some methods in a trait are dead code,
+marking the entire trait as dead code is unnecessary and
+can easily be misinterpreted as the trait itself being dead code.
+Instead, the following pattern is preferred:
+```rust
+trait SomeTrait {
+    #[allow(dead_code)]
+    fn foo();
+
+    #[allow(dead_code)]
+    fn bar();
+
+    fn baz();
+}
+```
+
+There is one exception:
+If it is clear enough that every member will trigger the lint,
+it is reasonable to allow the lint at the type level.
+For example, in the following code,
+we add `#[allow(non_camel_case_types)]` for the type `SomeEnum`,
+instead of for each variant of the type:
+```rust
+#[allow(non_camel_case_types)]
+enum SomeEnum {
+    FOO_ABC,
+    BAR_DEF,
+}
+```
+
+### When to `#[allow(dead_code)]`
+
+In general, dead code should be avoided because
+_(i)_ it introduces unnecessary maintenance overhead, and
+_(ii)_ its correctness can only be guaranteed by
+manual and error-pruned review of the code.
+
+In the case where allowing dead code is necessary,
+it should fulfill the following requirements:
+ 1. We have a _concrete case_ that will be implemented in the future and
+    will turn the dead code into used code.
+ 2. The semantics of the dead code are _clear_ enough
+    (perhaps with the help of some comments),
+    _even if the use case has not been added_.
+ 3. The dead code is _simple_ enough that
+    both the committer and the reviewer can be confident that
+    the code must be correct _without even testing it_.
+ 4. It serves as a counterpart to existing non-dead code.
+
+For example, it is fine to add ABI constants that are unused because
+the corresponding feature (_e.g.,_ a system call) is partially implemented.
+This is a case where all of the above requirements are met,
+so adding them as dead code is perfectly acceptable.

--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -202,30 +202,13 @@ fn read_time_from_user<T: Pod>(time_ptr: Vaddr) -> Result<(T, T)> {
     Ok((autime, mutime))
 }
 
-#[allow(dead_code)]
 trait UtimeExt {
-    fn utime_now() -> Self;
-    fn utime_omit() -> Self;
     fn is_utime_now(&self) -> bool;
     fn is_utime_omit(&self) -> bool;
     fn is_valid(&self) -> bool;
 }
 
 impl UtimeExt for timespec_t {
-    fn utime_now() -> Self {
-        Self {
-            sec: 0,
-            nsec: UTIME_NOW,
-        }
-    }
-
-    fn utime_omit() -> Self {
-        Self {
-            sec: 0,
-            nsec: UTIME_OMIT,
-        }
-    }
-
     fn is_utime_now(&self) -> bool {
         self.nsec == UTIME_NOW
     }

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap",


### PR DESCRIPTION
This PR adds some guidelines for using `#[allow(lint)]`, and even some more specific requirements for `#[allow(dead_code)]`.

I would also like to replace all `#[allow(lint)]` with `#[expect(lint)]`, which was stabilized [a few days ago](https://github.com/rust-lang/rust/pull/120924), but it seems to introduce hundreds of compile errors, which I don't understand why now.

For the last commit, see also https://github.com/asterinas/asterinas/pull/984#issuecomment-2194744545. I don't think it meets the requirements of introducing dead code, so I just remove it.