### PR TITLE
Refactor logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "ostd-macros",
+ "owo-colors",
  "pod",
  "rsdp",
  "spin 0.9.8",

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GDB_TCP_PORT ?= 1234
 INTEL_TDX ?= 0
 RELEASE ?= 0
 RELEASE_LTO ?= 0
+LOG_LEVEL ?= error
 SCHEME ?= ""
 # End of global options.
 
@@ -24,7 +25,7 @@ SYSCALL_TEST_DIR ?= /tmp
 
 CARGO_OSDK := ~/.cargo/bin/cargo-osdk
 
-CARGO_OSDK_ARGS := --target-arch=$(ARCH)
+CARGO_OSDK_ARGS := --target-arch=$(ARCH) --kcmd-args="ostd.log_level=$(LOG_LEVEL)"
 
 ifeq ($(AUTO_TEST), syscall)
 BUILD_SYSCALL_TEST := 1

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -36,8 +36,15 @@ tdx-guest = { version = "0.1.0", optional = true }
 trapframe = { git = "https://github.com/asterinas/trapframe-rs", rev = "4739428" }
 # This version is in the upstream trunk branch which fixes a `r#try` usage.
 # We could switch back to "crates.io" when they publish a new version.
-unwinding = { git = "https://github.com/nbdd0121/unwinding.git", rev = "d7cd46e", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+unwinding = { git = "https://github.com/nbdd0121/unwinding.git", rev = "d7cd46e", default-features = false, features = [
+    "fde-gnu-eh-frame-hdr",
+    "hide-trace",
+    "panic",
+    "personality",
+    "unwinder",
+] }
 volatile = { version = "0.4.5", features = ["unstable"] }
+owo-colors = { version = "3", optional = true }
 
 [target.x86_64-unknown-none.dependencies]
 x86_64 = "0.14.2"
@@ -46,7 +53,13 @@ acpi = "4.1.1"
 aml = "0.16.3"
 multiboot2 = "0.20.2"
 rsdp = "2.0.0"
-iced-x86 = { version = "1.21.0", default-features = false, features = [ "no_std", "decoder", "gas" ], optional = true }
+iced-x86 = { version = "1.21.0", default-features = false, features = [
+    "no_std",
+    "decoder",
+    "gas",
+], optional = true }
 
 [features]
+default = ["log_color"]
+log_color = ["dep:owo-colors"]
 intel_tdx = ["dep:tdx-guest", "dep:iced-x86"]

--- a/ostd/src/boot/kcmdline.rs
+++ b/ostd/src/boot/kcmdline.rs
@@ -18,7 +18,7 @@ use alloc::{
     vec::Vec,
 };
 
-use log::warn;
+use crate::early_println;
 
 #[derive(PartialEq, Debug)]
 struct InitprocArgs {
@@ -116,7 +116,10 @@ impl From<&str> for KCmdlineArg {
                 1 => (arg_pattern[0], None),
                 2 => (arg_pattern[0], Some(arg_pattern[1])),
                 _ => {
-                    warn!("Unable to parse kernel argument {}, skip for now", arg);
+                    early_println!(
+                        "[KCmdline] Unable to parse kernel argument {}, skip for now",
+                        arg
+                    );
                     continue;
                 }
             };
@@ -126,9 +129,10 @@ impl From<&str> for KCmdlineArg {
                 1 => (None, entry_pattern[0]),
                 2 => (Some(entry_pattern[0]), entry_pattern[1]),
                 _ => {
-                    warn!(
-                        "Unable to parse entry {} in argument {}, skip for now",
-                        entry, arg
+                    early_println!(
+                        "[KCmdline] Unable to parse entry {} in argument {}, skip for now",
+                        entry,
+                        arg
                     );
                     continue;
                 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -59,7 +59,6 @@ pub use self::{cpu::CpuLocal, error::Error, prelude::Result};
 /// boot stage only global variables.
 pub fn init() {
     arch::before_all_init();
-    logger::init();
 
     #[cfg(feature = "intel_tdx")]
     let td_info = init_tdx().unwrap();
@@ -73,6 +72,7 @@ pub fn init() {
     mm::heap_allocator::init();
 
     boot::init();
+    logger::init();
 
     mm::page::allocator::init();
     mm::kspace::init_boot_page_table();

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -2,23 +2,20 @@
 
 //! Logging support.
 
-use log::{Level, Metadata, Record};
+use log::{LevelFilter, Metadata, Record};
 
-use crate::early_println;
+use crate::{
+    boot::{kcmdline::ModuleArg, kernel_cmdline},
+    early_println,
+};
 
 const LOGGER: Logger = Logger {};
-
-/// The log level.
-///
-/// FIXME: The logs should be able to be read from files in the userspace,
-/// and the log level should be configurable.
-pub const INIT_LOG_LEVEL: Level = Level::Error;
 
 struct Logger {}
 
 impl log::Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= INIT_LOG_LEVEL
+        metadata.level() <= log::max_level()
     }
 
     fn log(&self, record: &Record) {
@@ -30,8 +27,33 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
+/// Initialize the logger. Users should avoid using the log macros before this function is called.
 pub(crate) fn init() {
-    log::set_logger(&LOGGER)
-        .map(|()| log::set_max_level(INIT_LOG_LEVEL.to_level_filter()))
-        .unwrap();
+    let level = get_log_level().unwrap_or(LevelFilter::Off);
+
+    log::set_max_level(level);
+    log::set_logger(&LOGGER).unwrap();
+}
+
+fn get_log_level() -> Option<LevelFilter> {
+    let module_args = kernel_cmdline().get_module_args("ostd")?;
+
+    let arg = module_args.iter().find(|arg| match arg {
+        ModuleArg::Arg(_) => false,
+        ModuleArg::KeyVal(name, _) => name.as_bytes() == "log_level".as_bytes(),
+    })?;
+
+    let ModuleArg::KeyVal(_, value) = arg else {
+        unreachable!()
+    };
+    let value = value.as_c_str().to_str().unwrap_or("off");
+    Some(match value {
+        "error" => LevelFilter::Error,
+        "warn" => LevelFilter::Warn,
+        "info" => LevelFilter::Info,
+        "debug" => LevelFilter::Debug,
+        "trace" => LevelFilter::Trace,
+        // Otherwise, OFF
+        _ => LevelFilter::Off,
+    })
 }


### PR DESCRIPTION
The current `ostd` requires changing the log output by setting `INIT_LOGGER_LEVEL` in `logger.rs`, which is unfriendly for developing a new kernel and debugging in Asterinas.

This PR updates the log level setting process by using the log levels from the kernel command line option. Additionally, to make it easier to read the logs, the PR modifies the log format as follows:

![4e6e055560a56c6552e61ea0cae6b99](https://github.com/asterinas/asterinas/assets/60682162/0e8d937d-1eea-4b88-a8a0-1fe582c03040)

![13a0d51d0e651fd49b7b82cad41be2a](https://github.com/asterinas/asterinas/assets/60682162/8ea06322-51c5-4a57-ab4a-367a7138a8b5)

