### PR TITLE
Add `#[must_use]` to all guard types

### DIFF
--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -122,7 +122,7 @@ impl<T> Producer<T> {
         // Update the event of pollee in a critical region so that pollee
         // always reflects the _true_ state of the underlying ring buffer
         // regardless of any race conditions.
-        self.0.common.lock_event();
+        let _guard = self.0.common.lock_event();
 
         let rb = this_end.rb();
         if rb.is_full() {
@@ -237,7 +237,7 @@ impl<T> Drop for Producer<T> {
     fn drop(&mut self) {
         self.shutdown();
 
-        self.0.common.lock_event();
+        let _guard = self.0.common.lock_event();
 
         // When reading from a channel such as a pipe or a stream socket,
         // POLLHUP merely indicates that the peer closed its end of the channel.
@@ -261,7 +261,7 @@ impl<T> Consumer<T> {
         // Update the event of pollee in a critical region so that pollee
         // always reflects the _true_ state of the underlying ring buffer
         // regardless of any race conditions.
-        self.0.common.lock_event();
+        let _guard = self.0.common.lock_event();
 
         let rb = this_end.rb();
         if rb.is_empty() {
@@ -377,7 +377,7 @@ impl<T> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.shutdown();
 
-        self.0.common.lock_event();
+        let _guard = self.0.common.lock_event();
 
         // POLLERR is also set for a file descriptor referring to the write end of a pipe
         // when the read end has been closed.

--- a/kernel/aster-nix/src/process/process/process_group.rs
+++ b/kernel/aster-nix/src/process/process/process_group.rs
@@ -102,6 +102,8 @@ impl ProcessGroup {
 /// A scoped lock for a process group.
 ///
 /// It provides some public methods to prevent the exposure of the inner type.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct ProcessGroupGuard<'a> {
     inner: MutexGuard<'a, Inner>,
 }

--- a/ostd/src/sync/mutex.rs
+++ b/ostd/src/sync/mutex.rs
@@ -92,6 +92,7 @@ unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 
 #[clippy::has_significant_drop]
+#[must_use]
 pub struct MutexGuard_<T: ?Sized, R: Deref<Target = Mutex<T>>> {
     mutex: R,
 }

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -49,6 +49,8 @@ impl<P: OwnerPtr + Send> Rcu<P> {
     }
 }
 
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct RcuReadGuard<'a, P: OwnerPtr> {
     obj: &'a <P as OwnerPtr>::Target,
     rcu: &'a Rcu<P>,

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -563,6 +563,8 @@ impl InnerGuard {
 }
 
 /// A guard that provides immutable data access.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct RwLockReadGuard_<T: ?Sized, R: Deref<Target = RwLock<T>> + Clone> {
     inner_guard: InnerGuard,
     inner: R,

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -248,6 +248,8 @@ impl<T: ?Sized, R: Deref<Target = RwMutex<T>>> Drop for RwMutexReadGuard_<T, R> 
 }
 
 /// A guard that provides mutable data access.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct RwMutexWriteGuard_<T: ?Sized, R: Deref<Target = RwMutex<T>>> {
     inner: R,
 }

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -145,6 +145,8 @@ pub type SpinLockGuard<'a, T> = SpinLockGuard_<T, &'a SpinLock<T>>;
 pub type ArcSpinLockGuard<T> = SpinLockGuard_<T, Arc<SpinLock<T>>>;
 
 /// The guard of a spin lock that disables the local IRQs.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T>>> {
     inner_guard: InnerGuard,
     lock: R,

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -196,6 +196,8 @@ impl PreemptInfo {
 }
 
 /// A guard for disable preempt.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct DisablePreemptGuard {
     // This private field prevents user from constructing values of this type directly.
     private: (),
@@ -223,7 +225,6 @@ impl Drop for DisablePreemptGuard {
 }
 
 /// Disables preemption.
-#[must_use]
 pub fn disable_preempt() -> DisablePreemptGuard {
     DisablePreemptGuard::new()
 }

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -126,12 +126,13 @@ impl Drop for IrqLine {
 ///     todo!("do something when irqs are disabled");
 /// }
 /// ```
-#[must_use]
 pub fn disable_local() -> DisabledLocalIrqGuard {
     DisabledLocalIrqGuard::new()
 }
 
 /// A guard for disabled local IRQs.
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
     preempt_guard: DisablePreemptGuard,


### PR DESCRIPTION
Basically do the same thing with the Rust standard library:
https://github.com/rust-lang/rust/blob/6868c831a1eb45c5150ff623cef5e42a8b8946d0/library/std/src/sync/mutex.rs#L202-L208

This helps to find the bug where a mutex guard is unused and immediately dropped, wasting CPU cycles and having no effect:
https://github.com/asterinas/asterinas/blob/9e4775d9e2c013899ce50dbc33250dbd5084a5a4/kernel/aster-nix/src/fs/utils/channel.rs#L125