### PR TITLE
Revise the pipe implementation and fix many wrong error codes

### DIFF
--- a/kernel/aster-nix/src/fs/file_handle.rs
+++ b/kernel/aster-nix/src/fs/file_handle.rs
@@ -18,11 +18,11 @@ use crate::{
 /// The basic operations defined on a file
 pub trait FileLike: Pollable + Send + Sync + Any {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "read is not supported");
+        return_errno_with_message!(Errno::EBADF, "the file is not valid for reading");
     }
 
     fn write(&self, buf: &[u8]) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "write is not supported");
+        return_errno_with_message!(Errno::EBADF, "the file is not valid for writing");
     }
 
     /// Read at the given file offset.

--- a/kernel/aster-nix/src/fs/file_handle.rs
+++ b/kernel/aster-nix/src/fs/file_handle.rs
@@ -12,11 +12,11 @@ use crate::{
     },
     net::socket::Socket,
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{signal::Pollable, Gid, Uid},
 };
 
 /// The basic operations defined on a file
-pub trait FileLike: Send + Sync + Any {
+pub trait FileLike: Pollable + Send + Sync + Any {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "read is not supported");
     }
@@ -48,10 +48,6 @@ pub trait FileLike: Send + Sync + Any {
 
     fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32> {
         return_errno_with_message!(Errno::EINVAL, "ioctl is not supported");
-    }
-
-    fn poll(&self, _mask: IoEvents, _poller: Option<&Poller>) -> IoEvents {
-        IoEvents::empty()
     }
 
     fn resize(&self, new_size: usize) -> Result<()> {

--- a/kernel/aster-nix/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/aster-nix/src/fs/inode_handle/dyn_cap.rs
@@ -4,7 +4,7 @@ use aster_rights::TRights;
 use inherit_methods_macro::inherit_methods;
 
 use super::*;
-use crate::prelude::*;
+use crate::{prelude::*, process::signal::Pollable};
 
 impl InodeHandle<Rights> {
     pub fn new(
@@ -70,8 +70,12 @@ impl Clone for InodeHandle<Rights> {
 }
 
 #[inherit_methods(from = "self.0")]
-impl FileLike for InodeHandle<Rights> {
+impl Pollable for InodeHandle<Rights> {
     fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents;
+}
+
+#[inherit_methods(from = "self.0")]
+impl FileLike for InodeHandle<Rights> {
     fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32>;
     fn status_flags(&self) -> StatusFlags;
     fn access_mode(&self) -> AccessMode;

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -9,7 +9,10 @@ use super::{
 use crate::{
     events::{IoEvents, Observer},
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{
+        signal::{Pollable, Poller},
+        Gid, Uid,
+    },
     time::clocks::RealTimeCoarseClock,
 };
 
@@ -23,13 +26,15 @@ impl PipeReader {
     }
 }
 
+impl Pollable for PipeReader {
+    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+        self.consumer.poll(mask, poller)
+    }
+}
+
 impl FileLike for PipeReader {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         self.consumer.read(buf)
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
-        self.consumer.poll(mask, poller)
     }
 
     fn status_flags(&self) -> StatusFlags {
@@ -90,13 +95,15 @@ impl PipeWriter {
     }
 }
 
+impl Pollable for PipeWriter {
+    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+        self.producer.poll(mask, poller)
+    }
+}
+
 impl FileLike for PipeWriter {
     fn write(&self, buf: &[u8]) -> Result<usize> {
         self.producer.write(buf)
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
-        self.producer.poll(mask, poller)
     }
 
     fn status_flags(&self) -> StatusFlags {

--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use aster_rights::{Read, ReadOp, TRights, Write, WriteOp};
@@ -29,8 +27,8 @@ impl<T> Channel<T> {
 
     pub fn with_capacity_and_flags(capacity: usize, flags: StatusFlags) -> Result<Self> {
         let common = Arc::new(Common::with_capacity_and_flags(capacity, flags)?);
-        let producer = Producer(EndPoint::new(common.clone(), WriteOp::new()));
-        let consumer = Consumer(EndPoint::new(common, ReadOp::new()));
+        let producer = Producer(EndPoint::new(common.clone()));
+        let consumer = Consumer(EndPoint::new(common));
         Ok(Self { producer, consumer })
     }
 
@@ -387,12 +385,15 @@ impl<T> Drop for Consumer<T> {
 
 struct EndPoint<T, R: TRights> {
     common: Arc<Common<T>>,
-    rights: R,
+    _rights: R,
 }
 
 impl<T, R: TRights> EndPoint<T, R> {
-    pub fn new(common: Arc<Common<T>>, rights: R) -> Self {
-        Self { common, rights }
+    pub fn new(common: Arc<Common<T>>) -> Self {
+        Self {
+            common,
+            _rights: R::new(),
+        }
     }
 }
 

--- a/kernel/aster-nix/src/process/signal/mod.rs
+++ b/kernel/aster-nix/src/process/signal/mod.rs
@@ -20,7 +20,7 @@ use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 use ostd::{cpu::UserContext, user::UserContextApi};
 pub use pauser::Pauser;
-pub use poll::{Pollee, Poller};
+pub use poll::{Pollable, Pollee, Poller};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
 use sig_num::SigNum;

--- a/kernel/aster-nix/src/syscall/eventfd.rs
+++ b/kernel/aster-nix/src/syscall/eventfd.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        signal::{Pauser, Pollee, Poller},
+        signal::{Pauser, Pollable, Pollee, Poller},
         Gid, Uid,
     },
     time::clocks::RealTimeClock,
@@ -150,6 +150,12 @@ impl EventFile {
     }
 }
 
+impl Pollable for EventFile {
+    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+        self.pollee.poll(mask, poller)
+    }
+}
+
 impl FileLike for EventFile {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         let read_len = core::mem::size_of::<u64>();
@@ -214,10 +220,6 @@ impl FileLike for EventFile {
             .pause_until(|| self.add_counter_val(supplied_value).ok())?;
 
         Ok(write_len)
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
-        self.pollee.poll(mask, poller)
     }
 
     fn status_flags(&self) -> StatusFlags {

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -3,7 +3,6 @@
 use super::SyscallReturn;
 use crate::{
     fs::{
-        file_handle::FileLike,
         file_table::{FdFlags, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{AccessMode, CreationFlags},
@@ -54,15 +53,4 @@ pub fn sys_creat(path_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
     let flags =
         AccessMode::O_WRONLY as u32 | CreationFlags::O_CREAT.bits() | CreationFlags::O_TRUNC.bits();
     self::sys_openat(AT_FDCWD, path_addr, flags, mode)
-}
-
-/// File for output busybox ash log.
-#[allow(dead_code)]
-struct BusyBoxTraceFile;
-
-impl FileLike for BusyBoxTraceFile {
-    fn write(&self, buf: &[u8]) -> Result<usize> {
-        debug!("ASH TRACE: {}", core::str::from_utf8(buf)?);
-        Ok(buf.len())
-    }
 }

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -20,10 +20,6 @@ pub fn sys_write(fd: FileDesc, user_buf_ptr: Vaddr, user_buf_len: usize) -> Resu
         file_table.get_file(fd)?.clone()
     };
 
-    if user_buf_len == 0 {
-        return Ok(SyscallReturn::Return(0));
-    }
-
     let mut buffer = vec![0u8; user_buf_len];
     read_bytes_from_user(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
     debug!("write content = {:?}", buffer);

--- a/test/apps/Makefile
+++ b/test/apps/Makefile
@@ -29,6 +29,7 @@ TEST_APPS := \
 	mmap \
 	mongoose \
 	network \
+	pipe \
 	pthread \
 	pty \
 	signal_c \

--- a/test/apps/pipe/Makefile
+++ b/test/apps/pipe/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/apps/pipe/pipe_err.c
+++ b/test/apps/pipe/pipe_err.c
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../network/test.h"
+#include <signal.h>
+#include <string.h>
+#include <sys/poll.h>
+#include <unistd.h>
+
+FN_SETUP()
+{
+	signal(SIGPIPE, SIG_IGN);
+}
+END_SETUP()
+
+FN_TEST(close_without_data_then_read)
+{
+	int fildes[2];
+	char buf[8] = { 0 };
+
+	CHECK(pipe(fildes));
+
+	TEST_SUCC(close(fildes[1]));
+
+	TEST_RES(read(fildes[0], buf, sizeof(buf)), _ret == 0);
+	TEST_ERRNO(write(fildes[0], buf, sizeof(buf)), EBADF);
+
+	TEST_RES(read(fildes[0], buf, 0), _ret == 0);
+	TEST_ERRNO(write(fildes[0], buf, 0), EBADF);
+
+	TEST_SUCC(close(fildes[0]));
+}
+END_TEST()
+
+FN_TEST(close_without_data_then_write)
+{
+	int fildes[2];
+	char buf[8] = { 0 };
+
+	CHECK(pipe(fildes));
+
+	TEST_SUCC(close(fildes[0]));
+
+	TEST_ERRNO(read(fildes[1], buf, sizeof(buf)), EBADF);
+	TEST_ERRNO(write(fildes[1], buf, sizeof(buf)), EPIPE);
+
+	TEST_ERRNO(read(fildes[1], buf, 0), EBADF);
+	TEST_RES(write(fildes[1], buf, 0), _ret == 0);
+
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+FN_TEST(close_with_data_then_read)
+{
+	int fildes[2];
+	char buf[8] = { 0 };
+
+	CHECK(pipe(fildes));
+
+	TEST_RES(write(fildes[1], "hello", 5), _ret == 5);
+	TEST_SUCC(close(fildes[1]));
+
+	TEST_RES(read(fildes[0], buf, 2),
+		 _ret == 2 && strncmp(buf, "he", 2) == 0);
+	TEST_RES(read(fildes[0], buf, sizeof(buf)),
+		 _ret == 3 && strncmp(buf, "llo", 3) == 0);
+
+	TEST_RES(read(fildes[0], buf, sizeof(buf)), _ret == 0);
+	TEST_ERRNO(write(fildes[0], buf, sizeof(buf)), EBADF);
+
+	TEST_RES(read(fildes[0], buf, 0), _ret == 0);
+	TEST_ERRNO(write(fildes[0], buf, 0), EBADF);
+
+	TEST_SUCC(close(fildes[0]));
+}
+END_TEST()
+
+FN_TEST(close_with_data_then_write)
+{
+	int fildes[2];
+	char buf[8] = { 0 };
+
+	CHECK(pipe(fildes));
+
+	TEST_RES(write(fildes[1], "hello", 5), _ret == 5);
+	TEST_SUCC(close(fildes[0]));
+
+	TEST_ERRNO(read(fildes[1], buf, sizeof(buf)), EBADF);
+	TEST_ERRNO(write(fildes[1], buf, sizeof(buf)), EPIPE);
+
+	TEST_ERRNO(read(fildes[1], buf, 0), EBADF);
+	TEST_RES(write(fildes[1], buf, 0), _ret == 0);
+
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+#define POLL_MASK (POLLIN | POLLOUT | POLLHUP | POLLERR)
+
+FN_TEST(poll_basic)
+{
+	int fildes[2];
+	char buf[8];
+	struct pollfd pfd = { .events = POLL_MASK };
+
+	CHECK(pipe(fildes));
+
+	pfd.fd = fildes[0];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == 0);
+
+	pfd.fd = fildes[1];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == POLLOUT);
+
+	TEST_RES(write(fildes[1], "hello", 5), _ret == 5);
+
+	pfd.fd = fildes[0];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == POLLIN);
+
+	pfd.fd = fildes[1];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == POLLOUT);
+
+	TEST_RES(read(fildes[0], buf, sizeof(buf)), _ret == 5);
+
+	pfd.fd = fildes[0];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == 0);
+
+	pfd.fd = fildes[1];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == POLLOUT);
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+FN_TEST(close_first_then_poll)
+{
+	int fildes[2];
+	struct pollfd pfd = { .events = POLLIN | POLLOUT };
+
+	CHECK(pipe(fildes));
+
+	TEST_RES(write(fildes[1], "hello", 5), _ret == 5);
+	TEST_SUCC(close(fildes[0]));
+
+	pfd.fd = fildes[1];
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & POLL_MASK) == (POLLOUT | POLLERR));
+
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+FN_TEST(close_second_then_poll)
+{
+	int fildes[2];
+	char buf[8];
+	struct pollfd pfd = { .events = POLLIN | POLLOUT };
+
+	CHECK(pipe(fildes));
+
+	TEST_RES(write(fildes[1], "hello", 5), _ret == 5);
+	TEST_SUCC(close(fildes[1]));
+
+	pfd.fd = fildes[0];
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & POLL_MASK) == (POLLIN | POLLHUP));
+
+	TEST_RES(read(fildes[0], buf, sizeof(buf)),
+		 _ret == 5 && strncmp(buf, "hello", 5) == 0);
+
+	pfd.fd = fildes[0];
+	TEST_RES(poll(&pfd, 1, 0), (pfd.revents & POLL_MASK) == POLLHUP);
+
+	TEST_SUCC(close(fildes[0]));
+}
+END_TEST()

--- a/test/apps/scripts/fs.sh
+++ b/test/apps/scripts/fs.sh
@@ -60,3 +60,5 @@ echo "All ext2 fs test passed."
 echo "Start fdatasync test......"
 test_fdatasync
 echo "All fdatasync test passed."
+
+pipe/pipe_err


### PR DESCRIPTION
Basically, I'm starting to do some refactoring work for UNIX sockets, just as I did for TCP sockets (#644 and #699). However, UNIX sockets are implemented based on pipes, so I start by refactoring the pipe implementation.

This PR makes the `wait_events` method reusable on TCP/UDP/vsock sockets as well as pipes (and UNIX sockets in the future), adjusts lock usage for updating I/O events, and fixes many wrong error codes according to the newly added regression test.