### PR TITLE
Enhance the stability of Asterinas Benchmark

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -3,8 +3,8 @@ on:
   # In case of manual trigger, use workflow_dispatch
   workflow_dispatch:
   schedule:
-    # Schedule to run on every day at 00:00 UTC (08:00 CST)
-    - cron: '0 0 * * *'
+    # Schedule to run on every day at 20:00 UTC (04:00 CST)
+    - cron: '0 20 * * *'
 
 jobs:
   Benchmarks:
@@ -41,7 +41,6 @@ jobs:
         command: |
           make install_osdk
           bash test/benchmark/bench_linux_and_aster.sh ${{ matrix.benchmark }}
-        on_retry_command: make clean
 
     - name: Prepare threshold values
       run: |

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,6 +4,7 @@ VDSO_DIR := /root/dependency
 VDSO_LIB := $(VDSO_DIR)/vdso64.so
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+ATOMIC_WGET := $(CUR_DIR)/../tools/atomic_wget.sh
 BUILD_DIR := $(CUR_DIR)/build
 INITRAMFS := $(BUILD_DIR)/initramfs
 BENCHMARK_ENTRYPOINT := $(CUR_DIR)/benchmark/benchmark_entrypoint.sh
@@ -51,8 +52,8 @@ $(INITRAMFS)/lib/x86_64-linux-gnu: | $(VDSO_LIB)
 
 $(VDSO_LIB): | $(VDSO_DIR)
 	@# TODO: use a custom compiled vdso.so file in the future.
-	@wget https://raw.githubusercontent.com/asterinas/linux_vdso/2a6d2db/vdso64.so -O $@ 
-
+	$(ATOMIC_WGET) $@ "https://raw.githubusercontent.com/asterinas/linux_vdso/2a6d2db/vdso64.so"
+	
 $(VDSO_DIR):
 	@mkdir -p $@
 	

--- a/test/apps/mongoose/Makefile
+++ b/test/apps/mongoose/Makefile
@@ -2,6 +2,7 @@
 
 CUR_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR := $(CUR_DIR)/../../build/initramfs/test/network
+ATOMIC_WGET := $(CUR_DIR)/../../../tools/atomic_wget.sh
 MONGOOSE_DIR := $(CUR_DIR)
 MONGOOSE_C := $(MONGOOSE_DIR)/mongoose.c
 MONGOOSE_H := $(MONGOOSE_DIR)/mongoose.h
@@ -28,7 +29,7 @@ $(MONGOOSE_O): $(MONGOOSE_FILES)
 	$(CC) -c $(MONGOOSE_C) $(CFLAGS) -o $@
 
 $(MONGOOSE_FILES): | $(MONGOOSE_DIR)
-	wget -O $@ "https://raw.githubusercontent.com/cesanta/mongoose/7.13/$(notdir $@)"
+	$(ATOMIC_WGET) $@ "https://raw.githubusercontent.com/cesanta/mongoose/7.13/$(notdir $@)"  
 
 $(BUILD_DIR) $(MONGOOSE_DIR):
 	@mkdir -p $@

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 set -e
+set -o pipefail
 
 # Ensure all dependencies are installed
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq is not installed. Aborting."; exit 1; }
@@ -12,6 +13,8 @@ BENCHMARK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Kernel image 
 KERNEL_DIR="/root/dependency"
 LINUX_KERNEL="${KERNEL_DIR}/vmlinuz"
+# Atomic wget script
+WGET_SCRIPT="${BENCHMARK_DIR}/../../tools/atomic_wget.sh"
 
 # Generate entrypoint script for Linux cases
 generate_entrypoint_script() {
@@ -61,9 +64,7 @@ run_benchmark() {
     if [ ! -f "${LINUX_KERNEL}" ]; then
         echo "Downloading the Linux kernel image..."
         mkdir -p "${KERNEL_DIR}"
-        curl -L -o "${LINUX_KERNEL}" \
-            -H "Accept: application/vnd.github.v3.raw" \
-            "https://api.github.com/repos/asterinas/linux_kernel/contents/vmlinuz-5.15.0-105-generic?ref=9e66d28"
+        ${WGET_SCRIPT} "${LINUX_KERNEL}" "https://raw.githubusercontent.com/asterinas/linux_kernel/9e66d28/vmlinuz-5.15.0-105-generic" 
     fi
 
     echo "Running benchmark ${benchmark} on Linux and Asterinas..."

--- a/tools/atomic_wget.sh
+++ b/tools/atomic_wget.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# Ensure the script is invoked with the necessary arguments
+if [ "$#" -lt 2 ]; then
+    echo "Atomic File Download with wget."
+    echo "This script downloads a file from a specified URL using wget. \
+        The downloaded file will appear locally as a complete file or not appear at all in case of an error."
+    echo ""
+    echo "Usage: $0 <output_file> <url> [wget_options]"
+    echo ""
+    echo "Arguments:"
+    echo "  <output_file>   Name of the file to save the downloaded content."
+    echo "  <url>           URL of the file to be downloaded."
+    echo "  [wget_options]  Optional: Additional wget options for customized download behavior."
+    exit 1
+fi
+
+OUTPUT_FILE="$1"
+URL="$2"
+WGET_OPTIONS="${3:-}"
+TEMP_FILE="/tmp/$(basename "$OUTPUT_FILE")"
+
+# Download the file using wget
+if ! wget $WGET_OPTIONS -c -O "$TEMP_FILE" "$URL"; then
+    echo "Error: Failed to download $URL." >&2
+    rm -f "$TEMP_FILE"
+    exit 1
+fi
+
+# Move the temporary file to the target location
+if ! mv "$TEMP_FILE" "$OUTPUT_FILE"; then
+    echo "Error: Failed to move $TEMP_FILE to $OUTPUT_FILE." >&2
+    rm -f "$TEMP_FILE"
+    exit 1
+fi
+
+echo "File downloaded successfully to $OUTPUT_FILE."


### PR DESCRIPTION
This PR enhances the stability of benchmark CI:

1. `bench_linux_and_aster.sh` : `make run BENCHMARK=${benchmark} ENABLE_KVM=1 RELEASE=1 2>&1 | tee "${aster_output}"` cannot return a non-zero exit code, which affects the retry attempt of the action `nick-invision/retry@v2`.
2. `benchmark_asterinas.yml`: 
      - Schedule to run on every day at 20:00 UTC (04:00 UTC +8)
      - Add `make --no-print-directory -C test/apps/mongoose clean` before retrying commands to ensure that `mongoose` headers are deleted in case of empty headers.

Note: Another way to fix it is adding a header check to `test/apps/mongoose`, which forces downloading if the headers are empty. However, it doesn't seem elegant. 
```makefile
# SPDX-License-Identifier: MPL-2.0

CUR_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
BUILD_DIR := $(CUR_DIR)/../../build/initramfs/test/network
MONGOOSE_DIR := $(CUR_DIR)
MONGOOSE_C := $(MONGOOSE_DIR)/mongoose.c
MONGOOSE_H := $(MONGOOSE_DIR)/mongoose.h
MONGOOSE_FILES := $(MONGOOSE_C) $(MONGOOSE_H)
MONGOOSE_O := $(MONGOOSE_DIR)/mongoose.o
SERVER_C := http_server.c
SERVER_BIN := $(BUILD_DIR)/http_server
CLIENT_C := http_client.c
CLIENT_BIN := $(BUILD_DIR)/http_client
BINS := $(SERVER_BIN) $(CLIENT_BIN)
CC := cc
CFLAGS := -W -Wall -Wextra -g -I. -I$(MONGOOSE_DIR) -DMG_ENABLE_LINES=1

.PHONY: all 
all: check-mongoose-files $(BINS) 

$(SERVER_BIN): $(SERVER_C) $(MONGOOSE_O) | $(BUILD_DIR)
	$(CC) $^ $(CFLAGS) -o $@

$(CLIENT_BIN): $(CLIENT_C) $(MONGOOSE_O) | $(BUILD_DIR)
	$(CC) $^ $(CFLAGS) -o $@

$(MONGOOSE_O): $(MONGOOSE_FILES) 
	$(CC) -c $(MONGOOSE_C) $(CFLAGS) -o $@

check-mongoose-files: | $(MONGOOSE_DIR)
	@for file in $(MONGOOSE_FILES); do \
		if [ ! -s $$file ]; then \
			url="https://raw.githubusercontent.com/cesanta/mongoose/7.13/$$(basename $$file)"; \
			echo "Downloading $$url to $$file"; \
			wget -O $$file "$$url" || { echo "Failed to download $$url"; exit 1; }; \
		fi; \
	done

$(BUILD_DIR) $(MONGOOSE_DIR):
	@mkdir -p $@

.PHONY: clean
clean:
	@rm -f $(BINS) $(MONGOOSE_O) $(MONGOOSE_FILES)
```