### PR TITLE
Switch the dependency of `unwinding` back to `crates.io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "gimli"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1088,7 @@ dependencies = [
  "bitvec",
  "buddy_system_allocator",
  "cfg-if",
- "gimli",
+ "gimli 0.28.0",
  "iced-x86",
  "id-alloc",
  "inherit-methods-macro",
@@ -1639,10 +1645,11 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unwinding"
-version = "0.2.1"
-source = "git+https://github.com/nbdd0121/unwinding.git?rev=d7cd46e#d7cd46e009ed1dbc762dbaaf4402f57973b300bb"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc55842d0db6329a669d55a623c674b02d677b16bfb2d24857d4089d41eba882"
 dependencies = [
- "gimli",
+ "gimli 0.30.0",
 ]
 
 [[package]]

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -34,15 +34,7 @@ spin = "0.9.4"
 static_assertions = "1.1.0"
 tdx-guest = { version = "0.1.0", optional = true }
 trapframe = { git = "https://github.com/asterinas/trapframe-rs", rev = "4739428" }
-# This version is in the upstream trunk branch which fixes a `r#try` usage.
-# We could switch back to "crates.io" when they publish a new version.
-unwinding = { git = "https://github.com/nbdd0121/unwinding.git", rev = "d7cd46e", default-features = false, features = [
-    "fde-gnu-eh-frame-hdr",
-    "hide-trace",
-    "panic",
-    "personality",
-    "unwinder",
-] }
+unwinding = { version = "0.2.2", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = { version = "0.4.5", features = ["unstable"] }
 owo-colors = { version = "3", optional = true }
 


### PR DESCRIPTION
The upstream crate [unwinding](https://crates.io/crates/unwinding) have bumped a version https://github.com/nbdd0121/unwinding/issues/22 fixing https://github.com/nbdd0121/unwinding/issues/26, so no need to use the Git dependency anymore.