### PR TITLE
Fix typos in docker commands within the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/asterinas/asterinas
 2. Run a Docker container as the development environment.
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v ./asterinas:/root/asterinas asterinas/asterinas:0.6.0
+docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.6.0
 ```
 
 3. Inside the container, go to the project folder to build and run Asterinas.

--- a/README_CN.md
+++ b/README_CN.md
@@ -49,7 +49,7 @@ git clone https://github.com/asterinas/asterinas
 2. 运行一个作为开发环境的Docker容器。
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v ./asterinas:/root/asterinas asterinas/asterinas:0.6.0
+docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.6.0
 ```
 
 3. 在容器内，进入项目文件夹构建并运行星绽。

--- a/docs/src/kernel/README.md
+++ b/docs/src/kernel/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/asterinas/asterinas
 2. Run a Docker container as the development environment.
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v asterinas:/root/asterinas asterinas/asterinas:0.6.0
+docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.6.0
 ```
 
 3. Inside the container, go to the project folder to build and run Asterinas.

--- a/docs/src/kernel/intel_tdx.md
+++ b/docs/src/kernel/intel_tdx.md
@@ -66,7 +66,7 @@ git clone https://github.com/asterinas/asterinas
 2. Run a Docker container as the development environment.
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v ./asterinas:/root/asterinas asterinas/asterinas:0.6.0_tdx
+docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.6.0_tdx
 ```
 
 3. Inside the container,


### PR DESCRIPTION
While running Docker with command options like `-v asterinas:/root/asterinas`, the corresponding directory within the Docker container might be vacant. One possible reason for this is using a relative path when mounting directories.

According to the official Docker documentation on [bind mounts](https://docs.docker.com/storage/bind-mounts/?highlight=v), it is highly recommended to use absolute paths when binding volumes in Docker. Instead of using a relative path like `asterinas:/root/asterinas`, it is better to use an absolute path such as `/absolute/path/to/asterinas:/root/asterinas`.

> Bind mounts have been around since the early days of Docker. Bind mounts have limited functionality compared to [volumes](https://docs.docker.com/storage/volumes/). When you use a bind mount, a file or directory on the host machine is mounted into a container. The file or directory is referenced by its **absolute path** on the host machine. By contrast, when you use a volume, a new directory is created within Docker's storage directory on the host machine, and Docker manages that directory's contents.