### PR TITLE
Implement @boterinas, a triage bot for Asterinas community

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,31 @@
+# triagebot.toml
+# More information: https://forge.rust-lang.org/triagebot/index.html
+
+[assign]
+# The issue assignment commands allows any user to assign themselves to a GitHub issue.
+# Restrict to teams later.
+# @boterinas claim — Assigns the issue to yourself.
+# @boterinas release-assignment — Removes the current assignee. Only the current assignee or a team member can release an assignment.
+# @boterinas assign @user — Assigns a specific user. Only team members can assign other users.
+
+[relabel]
+# Allow triagebot to label tags starting with C- and O-
+# @boterinas label C-bug — Adds the C-bug label to the issue.
+# @boterinas label -C-bug — Removes the C-bug label from the issue.
+allow-unauthenticated = [
+    "C-*", # any C- prefixed label will be allowed for anyone
+    "!C-good-first-issue", # but not C-good-first-issue (order does not matter)
+    "O-*", # any O- prefixed label will be allowed for anyone
+    "S-stale"
+]
+
+[mentions.".github/ISSUE_TEMPLATE"]
+cc = ["@grief8"]
+
+[shortcut]
+# Shortcuts are simple commands for performing common tasks.
+# https://forge.rust-lang.org/triagebot/shortcuts.html
+# @boterinas author - This indicates that a PR is waiting on the author. This assigns the S-waiting-on-author label on the pull request and removes both S-waiting-on-review and S-blocked if present.
+# @boterinas blocked - This indicates that a PR is blocked on something. 
+# @boterinas ready - This indicates that a PR is ready for review. 
+# @boterinas review or @boterinas reviewer are aliases for ready.


### PR DESCRIPTION
This pull request introduces a new triage bot, @boterinas, tailored for the Asterinas community, which takes inspiration from the @rustbot used within the rust-lang ecosystem. The intricate details of the @rustbot functionality can be found at https://forge.rust-lang.org/triagebot/index.html. Nevertheless, our implementation aims to streamline our feature set to better align with our current community needs.

With this PR, we are rolling out essential bot commands such as relabel and assign, which greatly facilitate issue management and workflow efficiency based on #911. Below are the commands that @boterinas will support, along with their intended actions:

```log
@boterinas claim — Assigns the issue to yourself.
@boterinas release-assignment — Removes the current assignee. Only the current assignee or a team member can release an assignment.
@boterinas assign @user — Assigns a specific user. Only team members can assign other users.
@boterinas label C-bug — Adds the C-bug label to the issue.
@boterinas label -C-bug — Removes the C-bug label from the issue.
@boterinas ready — Assigns the S-waiting-on-review label on the pull request and removes both S-waiting-on-author and S-blocked if present.
@boterinas author — Assigns the S-waiting-on-author label on the pull request and removes both S-waiting-on-review and S-blocked if present.
@boterinas blocked — Assigns the S-blocked label on the pull request and removes both S-waiting-on-author and S-waiting-on-review if present. 
```

## Prerequisites

To ensure a seamless integration of this PR, a few preparatory steps must be undertaken:

- Add the label `S-waiting-on-review`, `S-waiting-on-author`, `S-blocked`.
- Provision and configuration of a server that will host the bot service, to ensure continuous and reliable operation.
- Configuration of a repository webhook to facilitate communication between the GitHub repository and the bot service, allowing automatic event handling and command execution.

