### PR TITLE
Make `Pauser` work in kernel threads

### DIFF
--- a/kernel/aster-nix/src/prelude.rs
+++ b/kernel/aster-nix/src/prelude.rs
@@ -30,11 +30,20 @@ macro_rules! current {
     };
 }
 
-/// return current thread
+/// Returns the current thread.
+///
+/// # Panics
+///
+/// This macro will panic if the current task is not associated with a thread.
+///
+/// Except for unit tests, all tasks should be associated with threads. To write code that can be
+/// called directly in unit tests, consider using [`Thread::current`] instead.
+///
+/// [`Thread::current`]: crate::thread::Thread::current
 #[macro_export]
 macro_rules! current_thread {
     () => {
-        $crate::thread::Thread::current()
+        $crate::thread::Thread::current().expect("the current task is not associated with a thread")
     };
 }
 

--- a/kernel/aster-nix/src/process/process/mod.rs
+++ b/kernel/aster-nix/src/process/process/mod.rs
@@ -641,7 +641,7 @@ impl Process {
 }
 
 pub fn current() -> Arc<Process> {
-    let current_thread = Thread::current();
+    let current_thread = current_thread!();
     if let Some(posix_thread) = current_thread.as_posix_thread() {
         posix_thread.process()
     } else {

--- a/kernel/aster-nix/src/process/process/timer_manager.rs
+++ b/kernel/aster-nix/src/process/process/timer_manager.rs
@@ -18,14 +18,12 @@ use ostd::{
 
 use super::Process;
 use crate::{
+    prelude::*,
     process::{
         posix_thread::PosixThreadExt,
         signal::{constants::SIGALRM, signals::kernel::KernelSignal},
     },
-    thread::{
-        work_queue::{submit_work_item, work_item::WorkItem},
-        Thread,
-    },
+    thread::work_queue::{submit_work_item, work_item::WorkItem},
     time::{
         clocks::{ProfClock, RealTimeClock},
         Timer, TimerManager,
@@ -38,7 +36,7 @@ use crate::{
 /// invoke the callbacks of expired timers which are based on the updated
 /// CPU clock.
 fn update_cpu_time() {
-    let current_thread = Thread::current();
+    let current_thread = current_thread!();
     if let Some(posix_thread) = current_thread.as_posix_thread() {
         let process = posix_thread.process();
         let timer_manager = process.timer_manager();

--- a/kernel/aster-nix/src/syscall/clock_gettime.rs
+++ b/kernel/aster-nix/src/syscall/clock_gettime.rs
@@ -9,7 +9,7 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{posix_thread::PosixThreadExt, process_table},
-    thread::{thread_table, Thread},
+    thread::thread_table,
     time::{
         clockid_t,
         clocks::{
@@ -121,7 +121,7 @@ pub fn read_clock(clockid: clockid_t) -> Result<Duration> {
                 Ok(process.prof_clock().read_time())
             }
             ClockId::CLOCK_THREAD_CPUTIME_ID => {
-                let thread = Thread::current();
+                let thread = current_thread!();
                 Ok(thread.as_posix_thread().unwrap().prof_clock().read_time())
             }
         }

--- a/kernel/aster-nix/src/syscall/timer_create.rs
+++ b/kernel/aster-nix/src/syscall/timer_create.rs
@@ -20,7 +20,6 @@ use crate::{
     thread::{
         thread_table,
         work_queue::{submit_work_item, work_item::WorkItem},
-        Thread,
     },
     time::{
         clockid_t,
@@ -113,7 +112,7 @@ pub fn sys_timer_create(
         match clock_id {
             ClockId::CLOCK_PROCESS_CPUTIME_ID => process_timer_manager.create_prof_timer(func),
             ClockId::CLOCK_THREAD_CPUTIME_ID => {
-                let current_thread = Thread::current();
+                let current_thread = current_thread!();
                 current_thread
                     .as_posix_thread()
                     .unwrap()

--- a/kernel/aster-nix/src/thread/mod.rs
+++ b/kernel/aster-nix/src/thread/mod.rs
@@ -50,15 +50,16 @@ impl Thread {
         }
     }
 
-    pub fn current() -> Arc<Self> {
-        let task = Task::current();
-        let thread = task
+    /// Returns the current thread, or `None` if the current task is not associated with a thread.
+    ///
+    /// Except for unit tests, all tasks should be associated with threads. This method is useful
+    /// when writing code that can be called directly by unit tests. If this isn't the case,
+    /// consider using [`current_thread!`] instead.
+    pub fn current() -> Option<Arc<Self>> {
+        Task::current()
             .data()
-            .downcast_ref::<Weak<Thread>>()
-            .expect("[Internal Error] task data should points to weak<thread>");
-        thread
+            .downcast_ref::<Weak<Thread>>()?
             .upgrade()
-            .expect("[Internal Error] current thread cannot be None")
     }
 
     pub(in crate::thread) fn task(&self) -> &Arc<Task> {


### PR DESCRIPTION
Following discussion on https://github.com/asterinas/asterinas/pull/1008#issuecomment-2210412072 and https://github.com/asterinas/asterinas/pull/1008#issuecomment-2210454519, cc @StevenJiang1110.

This PR makes `Pauser` work in kernel threads. This is essential for making `Pollee` work in kernel threads, so that many file and network operations can be used by kernel threads (including unit tests).

In Linux, kernel threads cannot receive signals, and in fact any signals delivered to a kernel thread are silently ignored. So `Pauser` simply doesn't need to do anything with signals when it finds out it's being called by a kernel thread.