### PR TITLE
Disable racy `EpollTest.UnblockWithSignal`

### DIFF
--- a/test/syscall_test/blocklists/epoll_test
+++ b/test/syscall_test/blocklists/epoll_test
@@ -7,3 +7,6 @@ EpollTest.OneshotAndEdgeTriggered
 EpollTest.CycleOfOneDisallowed
 EpollTest.CycleOfThreeDisallowed
 EpollTest.CloseFile
+# `UnblockWithSignal` contains races. Better not to enable it.
+# See https://github.com/asterinas/asterinas/pull/1035 for details.
+EpollTest.UnblockWithSignal

--- a/test/syscall_test/run_syscall_test.sh
+++ b/test/syscall_test/run_syscall_test.sh
@@ -17,7 +17,7 @@ NC='\033[0m'
 
 get_blocklist_subtests(){
     if [ -f $BLOCKLIST_DIR/$1 ]; then
-        BLOCK=$(sed ':a;N;$!ba;s/\n/:/g' $BLOCKLIST_DIR/$1)
+        BLOCK=$(grep -v '^#' $BLOCKLIST_DIR/$1 | tr '\n' ':')
     else
         BLOCK=""
         return 1
@@ -25,7 +25,7 @@ get_blocklist_subtests(){
 
     for extra_dir in $EXTRA_BLOCKLISTS_DIRS ; do
         if [ -f $SCRIPT_DIR/$extra_dir/$1 ]; then
-            BLOCK="${BLOCK}:$(sed ':a;N;$!ba;s/\n/:/g' $SCRIPT_DIR/$extra_dir/$1)"
+            BLOCK="${BLOCK}:$(grep -v '^#' $SCRIPT_DIR/$extra_dir/$1 | tr '\n' ':')"
         fi
     done
 


### PR DESCRIPTION
`EpollTest.UnblockWithSignal` contains a race:

https://github.com/google/gvisor/blob/222258a585465cdc0072dc44e676d8b5e48304b2/test/syscalls/linux/epoll.cc#L243-L281

The `signaler` thread keeps dereferencing `t`, which is a pointer to a stack variable in the main thread. Although the main thread tries to stop the `signaler` thread by calling `pthread_cancel(thread)` before the stack variable goes out of scope, the main thread does not join the `signaler` thread, but instead detaches the `signaler` thread. So there is no guarantee that the `signaler` thread will be finished before the stack variable goes out of scope.

Theoretically, this race cannot happen in non-SMP Linux, because Linux always checks the pending signals before returning to userspace. Therefore, the canceling signal is always processed before the vulnerable code is executed, thus avoiding the race problem.

However, the above argument does not apply to Asterinas. In the following code snippet, pending signals are checked before the user preemption, so there may be pending signals after the preemption, but they will not be addressed in time.

https://github.com/asterinas/asterinas/blob/990bd846cd1930b2435f910ca0c215c74bc44ac0/ostd/src/arch/x86/cpu.rs#L327-L332

Maybe I should change the latter behavior altogether to conform the Linux behavior? This is not currently done in this PR.

Fix #977
Fix #868