### PR TITLE
Enable AVX-512 flags in XCR0

### DIFF
--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -114,7 +114,10 @@ fn enable_common_cpu_features() {
     }
 
     let mut xcr0 = x86_64::registers::xcontrol::XCr0::read();
-    xcr0 |= XCr0Flags::AVX | XCr0Flags::SSE;
+    // TODO: Ensure proper saving and restoring of floating-point states
+    // to correctly support advanced instructions like AVX-512.
+    let avx512 = XCr0Flags::OPMASK | XCr0Flags::ZMM_HI256 | XCr0Flags::HI16_ZMM;
+    xcr0 |= XCr0Flags::AVX | XCr0Flags::SSE | avx512;
     unsafe {
         x86_64::registers::xcontrol::XCr0::write(xcr0);
     }


### PR DESCRIPTION
Will be used by the FIO tool