### PR TITLE
Avoid using root directory

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
-VDSO_DIR := /root/dependency
+VDSO_DIR := ../target
 VDSO_LIB := $(VDSO_DIR)/vdso64.so
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))


### PR DESCRIPTION
I keep encountering permission denied issue when attempting to run Asterinas without using Docker. It seems unnecessary to use the `vdso64.so` in the root directory. We could use the target directory instead, as Asterinas will check whether `vdso64.so` exists.