### PR TITLE
[Quick Fix] Fix missing syscall tests

### DIFF
--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -32,9 +32,20 @@ TESTS ?= \
 	pty_test \
 	read_test \
 	readv_test \
+	rename_test \
+	sendfile_test \
+	stat_test \
 	stat_times_test \
-	write_test \
+	statfs_test \
+	symlink_test \
+	sync_test \
+	timers_test \
+	truncate_test \
+	uidgid_test \
+	unlink_test \
 	utimes_test \
+	vdso_clock_gettime_test \
+	write_test \
 	# The end of the list
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
This PR fixes a slight problems:

~~1. [Avoid using root directory](https://github.com/asterinas/asterinas/commit/c71ff237bc047ec27c4ba72f622891d772fb5106) fails to check the existed `vsdo64.so` library.~~
2. [Add and refactor read-write syscalls ](https://github.com/asterinas/asterinas/pull/847/commits/f11025b1e1e15f7fafb07272b1bb85b0b3b12be9#diff-a9fa03ce4875c42605f458b25021db4cd53bafb1c31c1db42a5c543424d00bf3) deletes the following tests accidentally:
```log
	rename_test \
	sendfile_test \
	stat_test \
	statfs_test \
	symlink_test \
	sync_test \
	timers_test \
	truncate_test \
	uidgid_test \
	unlink_test \
	vdso_clock_gettime_test \
```