### PR TITLE
Check CPUID before enabling AVX512

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,13 +1455,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tdx-guest"
-version = "0.1.0"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675bd99b7b81320678a9e9e524041b1f57fa68c965524413740d6cbe83d687f6"
+checksum = "d08fda76b8a438b7d926a92217a709ba39ef9031b8544a9a3f3af08d1b3f87e9"
 dependencies = [
  "bitflags 1.3.2",
+ "iced-x86",
  "lazy_static",
- "rand_core",
  "raw-cpuid",
  "x86_64",
 ]


### PR DESCRIPTION
Fix the CI failure.

Of course, we need to have CPUID support for OSTD users and organize the CPUID calls into a CPU feature module.

Here is just a fix.