### PR TITLE
Add several LMbench tests

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -14,15 +14,31 @@ jobs:
         benchmark: 
           - sysbench-cpu
           - sysbench-thread
-          - lmbench-getpid
+          # Process-related benchmarks
+          - lmbench-ctx
           - lmbench-fork
-          - lmbench-signal
+          - lmbench-exec
+          - lmbench-shell
+          # Memory-related benchmarks
+          - lmbench-mem-frd
+          - lmbench-mem-fwr
+          - lmbench-mem-fcp
+          # Network-related benchmarks
+          - lmbench-unix-latency
+          # Syscall-related benchmarks
+          - lmbench-getpid
+          - lmbench-fstat
+          - lmbench-open
+          - lmbench-stat
           # TODO: The following benchmarks are disabled now for some reasons.
           #
           # In Linux, lack of /dev/null device
           # - lmbench-write
           # In Linux, lack of /dev/zero device
           # - lmbench-read
+          #
+          # Signal-related benchmarks
+          - lmbench-signal
       fail-fast: false
     timeout-minutes: 60
     container: 

--- a/test/benchmark/lmbench-ctx/config.json
+++ b/test/benchmark/lmbench-ctx/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "18 ",
+    "field": "2"
+}

--- a/test/benchmark/lmbench-ctx/result_template.json
+++ b/test/benchmark/lmbench-ctx/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average context switch latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average context switch latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-ctx/run.sh
+++ b/test/benchmark/lmbench-ctx/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench context switch latency test ***"
+
+/benchmark/bin/lmbench/lat_ctx -P 1 18

--- a/test/benchmark/lmbench-exec/config.json
+++ b/test/benchmark/lmbench-exec/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Process fork\\+execve",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-exec/result_template.json
+++ b/test/benchmark/lmbench-exec/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average exec latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average exec latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-exec/run.sh
+++ b/test/benchmark/lmbench-exec/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench exec latency test ***"
+
+/benchmark/bin/lmbench/lat_proc -P 1 exec

--- a/test/benchmark/lmbench-fstat/config.json
+++ b/test/benchmark/lmbench-fstat/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Simple fstat",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-fstat/result_template.json
+++ b/test/benchmark/lmbench-fstat/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average fstat latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average fstat latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-fstat/run.sh
+++ b/test/benchmark/lmbench-fstat/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench fstat latency test ***"
+
+touch test_file
+/benchmark/bin/lmbench/lat_syscall -P 1 fstat test_file

--- a/test/benchmark/lmbench-mem-fcp/config.json
+++ b/test/benchmark/lmbench-mem-fcp/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "134.22",
+    "field": "2"
+}

--- a/test/benchmark/lmbench-mem-fcp/result_template.json
+++ b/test/benchmark/lmbench-mem-fcp/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average memory copy bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average memory copy bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-mem-fcp/run.sh
+++ b/test/benchmark/lmbench-mem-fcp/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench memory-copy bandwidth test ***"
+
+/benchmark/bin/lmbench/bw_mem -P 1 128m fcp

--- a/test/benchmark/lmbench-mem-frd/config.json
+++ b/test/benchmark/lmbench-mem-frd/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "268.44",
+    "field": "2"
+}

--- a/test/benchmark/lmbench-mem-frd/result_template.json
+++ b/test/benchmark/lmbench-mem-frd/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average memory read bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average memory read bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-mem-frd/run.sh
+++ b/test/benchmark/lmbench-mem-frd/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench memory-read bandwidth test ***"
+
+/benchmark/bin/lmbench/bw_mem -P 1 256m frd

--- a/test/benchmark/lmbench-mem-fwr/config.json
+++ b/test/benchmark/lmbench-mem-fwr/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "268.44",
+    "field": "2"
+}

--- a/test/benchmark/lmbench-mem-fwr/result_template.json
+++ b/test/benchmark/lmbench-mem-fwr/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average memory write bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average memory write bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-mem-fwr/run.sh
+++ b/test/benchmark/lmbench-mem-fwr/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench memory-write bandwidth test ***"
+
+/benchmark/bin/lmbench/bw_mem -P 1 256m fwr

--- a/test/benchmark/lmbench-open/config.json
+++ b/test/benchmark/lmbench-open/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Simple open\\/close",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-open/result_template.json
+++ b/test/benchmark/lmbench-open/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average open latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average open latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-open/run.sh
+++ b/test/benchmark/lmbench-open/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench open latency test ***"
+
+touch test_file
+/benchmark/bin/lmbench/lat_syscall -P 1 open test_file

--- a/test/benchmark/lmbench-shell/config.json
+++ b/test/benchmark/lmbench-shell/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Process fork\\+\\/bin\\/sh",
+    "field": "4"
+}

--- a/test/benchmark/lmbench-shell/result_template.json
+++ b/test/benchmark/lmbench-shell/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average shell latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average shell latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-shell/run.sh
+++ b/test/benchmark/lmbench-shell/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench shell latency test ***"
+
+/benchmark/bin/lmbench/lat_proc -P 1 shell

--- a/test/benchmark/lmbench-stat/config.json
+++ b/test/benchmark/lmbench-stat/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Simple stat",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-stat/result_template.json
+++ b/test/benchmark/lmbench-stat/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average stat latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average stat latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-stat/run.sh
+++ b/test/benchmark/lmbench-stat/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench stat latency test ***"
+
+touch test_file
+/benchmark/bin/lmbench/lat_syscall -P 1 stat test_file

--- a/test/benchmark/lmbench-unix-latency/config.json
+++ b/test/benchmark/lmbench-unix-latency/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "sock stream latency",
+    "field": "5"
+}

--- a/test/benchmark/lmbench-unix-latency/result_template.json
+++ b/test/benchmark/lmbench-unix-latency/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average unix latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average unix latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-unix-latency/run.sh
+++ b/test/benchmark/lmbench-unix-latency/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench unix latency test ***"
+
+/benchmark/bin/lmbench/lat_unix -P 1


### PR DESCRIPTION
This PR adds several LMbench tests. Other benchmarks such as `lat_mmap`, `lat_tcp`, and `bw_file_rd` are in progress.

Preview: https://sdww0.github.io/benchmark/