### PR TITLE
[Bug Fix]Fix `poll time out` when typing esc

### DIFF
--- a/kernel/aster-nix/src/syscall/poll.rs
+++ b/kernel/aster-nix/src/syscall/poll.rs
@@ -36,7 +36,16 @@ pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32) -> Result<SyscallReturn> {
         poll_fds, nfds, timeout
     );
 
-    let num_revents = do_poll(&poll_fds, timeout)?;
+    let num_revents = match do_poll(&poll_fds, timeout) {
+        Ok(num_events) => num_events,
+        Err(e) if e.error() == Errno::ETIME => {
+            // If the system call timed out
+            // before any file descriptors became ready,
+            // return 0.
+            return Ok(SyscallReturn::Return(0));
+        }
+        Err(e) => return Err(e),
+    };
 
     // Write back
     let mut write_addr = fds;


### PR DESCRIPTION
The problem is that poll should not return `ETIME`, but return 0. The similar problem in select is also fixed. 

The epoll case has been fixed by #1049.