### PR TITLE
Remove the nonsense mutex in `Poller`

### DIFF
--- a/kernel/aster-nix/src/device/null.rs
+++ b/kernel/aster-nix/src/device/null.rs
@@ -27,7 +27,7 @@ impl FileIo for Null {
         Ok(buf.len())
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/device/random.rs
+++ b/kernel/aster-nix/src/device/random.rs
@@ -42,7 +42,7 @@ impl FileIo for Random {
         Ok(buf.len())
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/device/tdxguest/mod.rs
+++ b/kernel/aster-nix/src/device/tdxguest/mod.rs
@@ -74,7 +74,7 @@ impl FileIo for TdxGuest {
         }
     }
 
-    fn poll(&self, mask: IoEvents, _poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/device/tty/device.rs
+++ b/kernel/aster-nix/src/device/tty/device.rs
@@ -49,7 +49,7 @@ impl FileIo for TtyDevice {
         return_errno_with_message!(Errno::EINVAL, "cannot write tty device");
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         IoEvents::empty()
     }
 }

--- a/kernel/aster-nix/src/device/tty/line_discipline.rs
+++ b/kernel/aster-nix/src/device/tty/line_discipline.rs
@@ -250,9 +250,9 @@ impl LineDiscipline {
                 Ok(len) => return Ok(len),
                 Err(e) if e.error() != Errno::EAGAIN => return Err(e),
                 Err(_) => {
-                    let poller = Some(Poller::new());
-                    if self.poll(IoEvents::IN, poller.as_ref()).is_empty() {
-                        poller.as_ref().unwrap().wait()?
+                    let mut poller = Poller::new();
+                    if self.poll(IoEvents::IN, Some(&mut poller)).is_empty() {
+                        poller.wait()?
                     }
                 }
             }
@@ -288,7 +288,7 @@ impl LineDiscipline {
         Ok(read_len)
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/device/tty/mod.rs
+++ b/kernel/aster-nix/src/device/tty/mod.rs
@@ -87,7 +87,7 @@ impl FileIo for Tty {
         Ok(buf.len())
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.ldisc.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/device/urandom.rs
+++ b/kernel/aster-nix/src/device/urandom.rs
@@ -42,7 +42,7 @@ impl FileIo for Urandom {
         Ok(buf.len())
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/device/zero.rs
+++ b/kernel/aster-nix/src/device/zero.rs
@@ -30,7 +30,7 @@ impl FileIo for Zero {
         Ok(buf.len())
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/fs/devpts/ptmx.rs
+++ b/kernel/aster-nix/src/fs/devpts/ptmx.rs
@@ -186,7 +186,7 @@ impl FileIo for Inner {
         return_errno_with_message!(Errno::EINVAL, "cannot write ptmx");
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         IoEvents::empty()
     }
 }

--- a/kernel/aster-nix/src/fs/devpts/slave.rs
+++ b/kernel/aster-nix/src/fs/devpts/slave.rs
@@ -133,7 +133,7 @@ impl Inode for PtySlaveInode {
         self.device.ioctl(cmd, arg)
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.device.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/fs/epoll/epoll_file.rs
+++ b/kernel/aster-nix/src/fs/epoll/epoll_file.rs
@@ -187,7 +187,7 @@ impl EpollFile {
             // If no ready entries for now, wait for them
             if poller.is_none() {
                 poller = Some(Poller::new());
-                let events = self.pollee.poll(IoEvents::IN, poller.as_ref());
+                let events = self.pollee.poll(IoEvents::IN, poller.as_mut());
                 if !events.is_empty() {
                     continue;
                 }
@@ -322,7 +322,7 @@ impl Drop for EpollFile {
 }
 
 impl Pollable for EpollFile {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/fs/exfat/inode.rs
+++ b/kernel/aster-nix/src/fs/exfat/inode.rs
@@ -1698,7 +1698,7 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn poll(&self, mask: IoEvents, _poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/aster-nix/src/fs/inode_handle/dyn_cap.rs
@@ -81,7 +81,7 @@ impl Clone for InodeHandle<Rights> {
 
 #[inherit_methods(from = "self.0")]
 impl Pollable for InodeHandle<Rights> {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents;
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
 }
 
 #[inherit_methods(from = "self.0")]

--- a/kernel/aster-nix/src/fs/inode_handle/mod.rs
+++ b/kernel/aster-nix/src/fs/inode_handle/mod.rs
@@ -176,7 +176,7 @@ impl InodeHandle_ {
         Ok(read_cnt)
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         if let Some(ref file_io) = self.file_io {
             return file_io.poll(mask, poller);
         }
@@ -228,7 +228,7 @@ pub trait FileIo: Send + Sync + 'static {
 
     fn write(&self, buf: &[u8]) -> Result<usize>;
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents;
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
 
     fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32> {
         return_errno_with_message!(Errno::EINVAL, "ioctl is not supported");

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -27,7 +27,7 @@ impl PipeReader {
 }
 
 impl Pollable for PipeReader {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.consumer.poll(mask, poller)
     }
 }
@@ -96,7 +96,7 @@ impl PipeWriter {
 }
 
 impl Pollable for PipeWriter {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.producer.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/fs/ramfs/fs.rs
+++ b/kernel/aster-nix/src/fs/ramfs/fs.rs
@@ -1092,7 +1092,7 @@ impl Inode for RamInode {
         }
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         if let Some(device) = self.node.read().inner.as_device() {
             device.poll(mask, poller)
         } else {

--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -82,7 +82,7 @@ macro_rules! impl_common_methods_for_channel {
                 .contains(StatusFlags::O_NONBLOCK)
         }
 
-        pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+        pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
             self.this_end().pollee.poll(mask, poller)
         }
 
@@ -140,7 +140,7 @@ impl<T> Producer<T> {
 }
 
 impl<T> Pollable for Producer<T> {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.poll(mask, poller)
     }
 }
@@ -266,7 +266,7 @@ impl<T> Consumer<T> {
 }
 
 impl<T> Pollable for Consumer<T> {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/fs/utils/inode.rs
+++ b/kernel/aster-nix/src/fs/utils/inode.rs
@@ -348,7 +348,7 @@ pub trait Inode: Any + Sync + Send {
         Ok(())
     }
 
-    fn poll(&self, mask: IoEvents, _poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/mod.rs
@@ -180,7 +180,7 @@ impl DatagramSocket {
 }
 
 impl Pollable for DatagramSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/mod.rs
@@ -338,7 +338,7 @@ impl StreamSocket {
 }
 
 impl Pollable for StreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
@@ -45,7 +45,7 @@ impl Connected {
         self.local_endpoint.set_nonblocking(is_nonblocking).unwrap();
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.local_endpoint.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -106,10 +106,10 @@ impl Endpoint {
         self.0.peer.upgrade().is_some()
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
         let mut events = IoEvents::empty();
         // FIXME: should reader and writer use the same mask?
-        let reader_events = self.0.reader.poll(mask, poller);
+        let reader_events = self.0.reader.poll(mask, poller.as_deref_mut());
         let writer_events = self.0.writer.poll(mask, poller);
 
         if reader_events.contains(IoEvents::HUP) || self.0.reader.is_shutdown() {

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -79,7 +79,7 @@ impl Init {
         self.is_nonblocking.store(is_nonblocking, Ordering::Release);
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -104,7 +104,7 @@ impl UnixStreamSocket {
 }
 
 impl Pollable for UnixStreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let inner = self.0.read();
         match &*inner {
             State::Init(init) => init.poll(mask, poller),

--- a/kernel/aster-nix/src/net/socket/vsock/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/connected.rs
@@ -126,7 +126,7 @@ impl Connected {
             .set_peer_requested_shutdown()
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/net/socket/vsock/stream/connecting.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/connecting.rs
@@ -45,7 +45,7 @@ impl Connecting {
         self.info.lock_irq_disabled().update_for_event(event)
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/net/socket/vsock/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/init.rs
@@ -61,7 +61,7 @@ impl Init {
         *self.bound_addr.lock()
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/aster-nix/src/net/socket/vsock/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/listen.rs
@@ -50,7 +50,7 @@ impl Listen {
         Ok(connection)
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/aster-nix/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/socket.rs
@@ -123,7 +123,7 @@ impl VsockStreamSocket {
 }
 
 impl Pollable for VsockStreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         match &*self.status.read() {
             Status::Init(init) => init.poll(mask, poller),
             Status::Listen(listen) => listen.poll(mask, poller),
@@ -210,9 +210,9 @@ impl Socket for VsockStreamSocket {
         vsockspace.request(&connecting.info()).unwrap();
         // wait for response from driver
         // TODO: Add timeout
-        let poller = Poller::new();
+        let mut poller = Poller::new();
         if !connecting
-            .poll(IoEvents::IN, Some(&poller))
+            .poll(IoEvents::IN, Some(&mut poller))
             .contains(IoEvents::IN)
         {
             if let Err(e) = poller.wait() {

--- a/kernel/aster-nix/src/syscall/eventfd.rs
+++ b/kernel/aster-nix/src/syscall/eventfd.rs
@@ -151,7 +151,7 @@ impl EventFile {
 }
 
 impl Pollable for EventFile {
-    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }
@@ -175,8 +175,8 @@ impl FileLike for EventFile {
                 self.update_io_state(&counter);
                 drop(counter);
 
-                let poller = Poller::new();
-                if self.pollee.poll(IoEvents::IN, Some(&poller)).is_empty() {
+                let mut poller = Poller::new();
+                if self.pollee.poll(IoEvents::IN, Some(&mut poller)).is_empty() {
                     poller.wait()?;
                 }
                 continue;

--- a/kernel/aster-nix/src/syscall/poll.rs
+++ b/kernel/aster-nix/src/syscall/poll.rs
@@ -61,7 +61,7 @@ pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32) -> Result<SyscallReturn> {
 
 pub fn do_poll(poll_fds: &[PollFd], timeout: Option<Duration>) -> Result<usize> {
     // The main loop of polling
-    let poller = Poller::new();
+    let mut poller = Poller::new();
     loop {
         let mut num_revents = 0;
 
@@ -79,7 +79,7 @@ pub fn do_poll(poll_fds: &[PollFd], timeout: Option<Duration>) -> Result<usize> 
                 file_table.get_file(fd)?.clone()
             };
             let need_poller = if num_revents == 0 {
-                Some(&poller)
+                Some(&mut poller)
             } else {
                 None
             };


### PR DESCRIPTION
(This PR must have some conflicts with #1008, so I originally planned to do this PR after merging #1008. But #1008 is blocked for a few days, so I am doing this PR first for concurrent review.)

The `Poller` remembers all `Pollee`s the `Poller` was registered to, currently using a `Mutex<BTreeMap<KeyableWeak<PolleeInner>, ()>>`. However, when registering `Poller`, we can always require a mutable reference to the `Poller`, so the `Mutex` simply makes no sense. Note that this particular field is _never_ accessed or modified concurrently.

This PR changes the signature of the `poll` method from
```rust
    fn poll(&self, mask: IoEvents, poller: Option<&Poller>) -> IoEvents;
```
to
```rust
    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
```
So the nonsense mutex in `Pollee` can be removed.

The `BTreeMap` is not useful either, even if we register the `Poller` on the same `Pollee` multiple times (the second `unregister_observer` in `Drop` will fail silently, but that's fine). So this PR also removes it and uses a simpler `Vec` instead.