### PR TITLE
Add architecture-specific processing in OSDK `make_elf_for_qemu`

### DIFF
--- a/osdk/src/bundle/bin.rs
+++ b/osdk/src/bundle/bin.rs
@@ -6,10 +6,12 @@ use std::{
 };
 
 use super::file::BundleFile;
+use crate::arch::Arch;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AsterBin {
     path: PathBuf,
+    arch: Arch,
     typ: AsterBinType,
     version: String,
     sha256sum: String,
@@ -48,9 +50,16 @@ impl BundleFile for AsterBin {
 }
 
 impl AsterBin {
-    pub fn new(path: impl AsRef<Path>, typ: AsterBinType, version: String, stripped: bool) -> Self {
+    pub fn new(
+        path: impl AsRef<Path>,
+        arch: Arch,
+        typ: AsterBinType,
+        version: String,
+        stripped: bool,
+    ) -> Self {
         let created = Self {
             path: path.as_ref().to_path_buf(),
+            arch,
             typ,
             version,
             sha256sum: String::new(),
@@ -60,6 +69,10 @@ impl AsterBin {
             sha256sum: created.calculate_sha256sum(),
             ..created
         }
+    }
+
+    pub fn arch(&self) -> Arch {
+        self.arch
     }
 
     pub fn version(&self) -> &String {
@@ -78,6 +91,7 @@ impl AsterBin {
         fs::remove_file(&self.path).unwrap();
         Self {
             path: PathBuf::from(file_name),
+            arch: self.arch,
             typ: self.typ,
             version: self.version,
             sha256sum: self.sha256sum,

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -10,6 +10,7 @@ use std::{
 use linux_bzimage_builder::{legacy32_rust_target_json, make_bzimage, BzImageType};
 
 use crate::{
+    arch::Arch,
     bundle::{
         bin::{AsterBin, AsterBinType, AsterBzImageMeta, AsterElfMeta},
         file::BundleFile,
@@ -58,6 +59,7 @@ pub fn make_install_bzimage(
 
     AsterBin::new(
         &install_path,
+        aster_elf.arch(),
         AsterBinType::BzImage(AsterBzImageMeta {
             support_legacy32_boot: linux_x86_legacy_boot,
             support_efi_boot: false,
@@ -107,25 +109,28 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
         std::fs::copy(elf.path(), &result_elf_path).unwrap();
     }
 
-    // Because QEMU denies a x86_64 multiboot ELF file (GRUB2 accept it, btw),
-    // modify `em_machine` to pretend to be an x86 (32-bit) ELF image,
-    //
-    // https://github.com/qemu/qemu/blob/950c4e6c94b15cd0d8b63891dddd7a8dbf458e6a/hw/i386/multiboot.c#L197
-    // Set EM_386 (0x0003) to em_machine.
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(&result_elf_path)
-        .unwrap();
+    if elf.arch() == Arch::X86_64 {
+        // Because QEMU denies a x86_64 multiboot ELF file (GRUB2 accept it, btw),
+        // modify `em_machine` to pretend to be an x86 (32-bit) ELF image,
+        //
+        // https://github.com/qemu/qemu/blob/950c4e6c94b15cd0d8b63891dddd7a8dbf458e6a/hw/i386/multiboot.c#L197
+        // Set EM_386 (0x0003) to em_machine.
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&result_elf_path)
+            .unwrap();
 
-    let bytes: [u8; 2] = [0x03, 0x00];
+        let bytes: [u8; 2] = [0x03, 0x00];
 
-    file.seek(SeekFrom::Start(18)).unwrap();
-    file.write_all(&bytes).unwrap();
-    file.flush().unwrap();
+        file.seek(SeekFrom::Start(18)).unwrap();
+        file.write_all(&bytes).unwrap();
+        file.flush().unwrap();
+    }
 
     AsterBin::new(
         &result_elf_path,
+        elf.arch(),
         AsterBinType::Elf(AsterElfMeta {
             has_linux_header: false,
             has_pvh_header: false,

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -150,7 +150,7 @@ pub fn do_build(
     };
 
     let aster_elf = build_kernel_elf(
-        &config.target_arch,
+        config.target_arch,
         &build.profile,
         &build.features[..],
         build.no_default_features,
@@ -187,7 +187,7 @@ pub fn do_build(
 }
 
 fn build_kernel_elf(
-    arch: &Arch,
+    arch: Arch,
     profile: &str,
     features: &[String],
     no_default_features: bool,
@@ -255,6 +255,7 @@ fn build_kernel_elf(
 
     AsterBin::new(
         aster_bin_path,
+        arch,
         AsterBinType::Elf(AsterElfMeta {
             has_linux_header: false,
             has_pvh_header: false,


### PR DESCRIPTION
Add architecture-specific processing in OSDK `make_elf_for_qemu`, so only x86 binary is set `em_machine=EM_386`, suggested by https://github.com/asterinas/asterinas/pull/924#discussion_r1634076538.