### PR TITLE
Extract x86-specific code from `call_irq_callback_functions`

### DIFF
--- a/ostd/src/arch/x86/cpu.rs
+++ b/ostd/src/arch/x86/cpu.rs
@@ -323,7 +323,7 @@ impl UserContextApiInternal for UserContext {
                     }
                 }
             };
-            call_irq_callback_functions(&self.as_trap_frame());
+            call_irq_callback_functions(&self.as_trap_frame(), self.as_trap_frame().trap_num);
             if has_kernel_event() {
                 return_reason = ReturnReason::KernelEvent;
                 break;

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -64,10 +64,12 @@ pub(crate) fn after_all_init() {
     kernel::pic::init();
 }
 
-pub(crate) fn interrupts_ack() {
-    kernel::pic::ack();
-    if let Some(apic) = kernel::apic::APIC_INSTANCE.get() {
-        apic.lock_irq_disabled().eoi();
+pub(crate) fn interrupts_ack(irq_number: usize) {
+    if !cpu::CpuException::is_cpu_exception(irq_number as u16) {
+        kernel::pic::ack();
+        if let Some(apic) = kernel::apic::APIC_INSTANCE.get() {
+            apic.lock_irq_disabled().eoi();
+        }
     }
 }
 

--- a/ostd/src/arch/x86/trap.rs
+++ b/ostd/src/arch/x86/trap.rs
@@ -65,7 +65,7 @@ extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
         }
     } else {
         IS_KERNEL_INTERRUPTED.store(true, Ordering::Release);
-        call_irq_callback_functions(f);
+        call_irq_callback_functions(f, f.trap_num);
         IS_KERNEL_INTERRUPTED.store(false, Ordering::Release);
     }
 }

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -4,25 +4,23 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use trapframe::TrapFrame;
 
-use crate::{arch::irq::IRQ_LIST, cpu::CpuException, cpu_local};
+use crate::{arch::irq::IRQ_LIST, cpu_local};
 
-pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame) {
+pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame, irq_number: usize) {
     // For x86 CPUs, interrupts are not re-entrant. Local interrupts will be disabled when
     // an interrupt handler is called (Unless interrupts are re-enabled in an interrupt handler).
     //
     // FIXME: For arch that supports re-entrant interrupts, we may need to record nested level here.
     IN_INTERRUPT_CONTEXT.store(true, Ordering::Release);
 
-    let irq_line = IRQ_LIST.get().unwrap().get(trap_frame.trap_num).unwrap();
+    let irq_line = IRQ_LIST.get().unwrap().get(irq_number).unwrap();
     let callback_functions = irq_line.callback_list();
     for callback_function in callback_functions.iter() {
         callback_function.call(trap_frame);
     }
     drop(callback_functions);
 
-    if !CpuException::is_cpu_exception(trap_frame.trap_num as u16) {
-        crate::arch::interrupts_ack();
-    }
+    crate::arch::interrupts_ack(irq_number);
 
     IN_INTERRUPT_CONTEXT.store(false, Ordering::Release);
 


### PR DESCRIPTION
As title.

1. `TrapFrame.trap_num` is unique to x86, so extract to `arch/x86`
2. Refactor `crate::arch::interrupts_ack`, so `call_irq_callback_functions` just needs to call `interrupts_ack`, and `interrupts_ack` to determinate the actual behavior.