### PR TITLE
Fix both the preempt count atomicity and the CPU-local init problem

### DIFF
--- a/.github/workflows/test_asterinas.yml
+++ b/.github/workflows/test_asterinas.yml
@@ -60,36 +60,24 @@ jobs:
         id: boot_test_mb
         run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=multiboot RELEASE=1
 
-      - name: Boot Test (Multiboot2)
-        id: boot_test_mb2
-        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1
-
-      - name: Boot Test (MicroVM)
-        id: boot_test_microvm
-        run: make run AUTO_TEST=boot ENABLE_KVM=1 SCHEME=microvm RELEASE=1
-
       - name: Boot Test (Linux Legacy 32-bit Boot Protocol)
         id: boot_test_linux_legacy32
         run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=linux-legacy32 RELEASE=1
 
-      - name: Boot Test (Linux EFI Handover Boot Protocol)
-        id: boot_test_linux_efi_handover64
-        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
-
-      - name: Syscall Test (Linux EFI Handover Boot Protocol)
+      - name: Syscall Test (Linux EFI Handover Boot Protocol) (Debug Build)
         id: syscall_test
-        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
+        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=0
 
       - name: Syscall Test at Ext2 (MicroVM)
         id: syscall_test_at_ext2
         run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=1 SCHEME=microvm RELEASE=1
 
-      - name: Syscall Test at Exfat and without KVM enabled
+      - name: Syscall Test at Exfat (Multiboot2) (without KVM enabled)
         id: syscall_test_at_exfat_linux
         run: |
           make run AUTO_TEST=syscall \
             SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat \
-            ENABLE_KVM=0 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
+            ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1
 
       - name: General Test (Linux EFI Handover Boot Protocol)
         id: test_linux

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -58,6 +58,16 @@ SECTIONS
     # areas for the application processors.
     .cpu_local              : AT(ADDR(.cpu_local) - KERNEL_VMA) {
         __cpu_local_start = .;
+
+        # These 4 bytes are used to store the CPU ID.
+        . += 4;
+
+        # These 4 bytes are used to store the number of preemption locks held.
+        # The reason is stated in the Rust documentation of
+        # [`ostd::task::processor::PreemptInfo`].
+        __cpu_local_preempt_lock_count = . - __cpu_local_start;
+        . += 4;
+
         KEEP(*(SORT(.cpu_local)))
         __cpu_local_end = .;
     }

--- a/ostd/src/arch/x86/cpu/local.rs
+++ b/ostd/src/arch/x86/cpu/local.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Architecture dependent CPU-local information utilities.
+
+use x86_64::registers::segmentation::{Segment64, FS};
+
+/// Sets the base address for the CPU local storage by writing to the FS base model-specific register.
+/// This operation is marked as `unsafe` because it directly interfaces with low-level CPU registers.
+///
+/// # Safety
+///
+///  - This function is safe to call provided that the FS register is dedicated entirely for CPU local storage
+///    and is not concurrently accessed for other purposes.
+///  - The caller must ensure that `addr` is a valid address and properly aligned, as required by the CPU.
+///  - This function should only be called in contexts where the CPU is in a state to accept such changes,
+///    such as during processor initialization.
+pub(crate) unsafe fn set_base(addr: u64) {
+    FS::write_base(x86_64::addr::VirtAddr::new(addr));
+}
+
+/// Gets the base address for the CPU local storage by reading the FS base model-specific register.
+pub(crate) fn get_base() -> u64 {
+    FS::read_base().as_u64()
+}
+
+pub mod preempt_lock_count {
+    //! We need to increment/decrement the per-CPU preemption lock count using
+    //! a single instruction. This requirement is stated by
+    //! [`crate::task::processor::PreemptInfo`].
+
+    /// The GDT ensures that the FS segment is initialized to zero on boot.
+    /// This assertion checks that the base address has been set.
+    macro_rules! debug_assert_initialized {
+        () => {
+            // The compiler may think that [`super::get_base`] has side effects
+            // so it may not be optimized out. We make sure that it will be
+            // conditionally compiled only in debug builds.
+            #[cfg(debug_assertions)]
+            debug_assert_ne!(super::get_base(), 0);
+        };
+    }
+
+    /// Increments the per-CPU preemption lock count using one instruction.
+    pub(crate) fn inc() {
+        debug_assert_initialized!();
+
+        // SAFETY: The inline assembly increments the lock count in one
+        // instruction without side effects.
+        unsafe {
+            core::arch::asm!(
+                "add dword ptr fs:[__cpu_local_preempt_lock_count], 1",
+                options(nostack),
+            );
+        }
+    }
+
+    /// Decrements the per-CPU preemption lock count using one instruction.
+    pub(crate) fn dec() {
+        debug_assert_initialized!();
+
+        // SAFETY: The inline assembly decrements the lock count in one
+        // instruction without side effects.
+        unsafe {
+            core::arch::asm!(
+                "sub dword ptr fs:[__cpu_local_preempt_lock_count], 1",
+                options(nostack),
+            );
+        }
+    }
+
+    /// Gets the per-CPU preemption lock count using one instruction.
+    pub(crate) fn get() -> u32 {
+        debug_assert_initialized!();
+
+        let count: u32;
+        // SAFETY: The inline assembly reads the lock count in one instruction
+        // without side effects.
+        unsafe {
+            core::arch::asm!(
+                "mov {0:e}, fs:[__cpu_local_preempt_lock_count]",
+                out(reg) count,
+                options(nostack, readonly),
+            );
+        }
+        count
+    }
+}

--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -2,6 +2,8 @@
 
 //! CPU.
 
+pub mod local;
+
 use alloc::vec::Vec;
 use core::{
     arch::x86_64::{_fxrstor, _fxsave},
@@ -18,10 +20,7 @@ use log::debug;
 use tdx_guest::tdcall;
 pub use trapframe::GeneralRegs as RawGeneralRegs;
 use trapframe::UserContext as RawUserContext;
-use x86_64::registers::{
-    rflags::RFlags,
-    segmentation::{Segment64, FS},
-};
+use x86_64::registers::rflags::RFlags;
 
 #[cfg(feature = "intel_tdx")]
 use crate::arch::tdx_guest::{handle_virtual_exception, TdxTrapFrame};
@@ -672,23 +671,4 @@ impl Default for FpRegs {
 #[derive(Debug, Clone, Copy)]
 struct FxsaveArea {
     data: [u8; 512], // 512 bytes
-}
-
-/// Sets the base address for the CPU local storage by writing to the FS base model-specific register.
-/// This operation is marked as `unsafe` because it directly interfaces with low-level CPU registers.
-///
-/// # Safety
-///
-///  - This function is safe to call provided that the FS register is dedicated entirely for CPU local storage
-///    and is not concurrently accessed for other purposes.
-///  - The caller must ensure that `addr` is a valid address and properly aligned, as required by the CPU.
-///  - This function should only be called in contexts where the CPU is in a state to accept such changes,
-///    such as during processor initialization.
-pub(crate) unsafe fn set_cpu_local_base(addr: u64) {
-    FS::write_base(x86_64::addr::VirtAddr::new(addr));
-}
-
-/// Gets the base address for the CPU local storage by reading the FS base model-specific register.
-pub(crate) fn get_cpu_local_base() -> u64 {
-    FS::read_base().as_u64()
 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -59,6 +59,9 @@ pub use self::{cpu::cpu_local::CpuLocal, error::Error, prelude::Result};
 pub fn init() {
     arch::before_all_init();
 
+    // SAFETY: This function is called only once and only on the BSP.
+    unsafe { cpu::cpu_local::early_init_bsp_local_base() };
+
     mm::heap_allocator::init();
 
     boot::init();

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -340,8 +340,10 @@ impl<'a> VmReader<'a, KernelSpace> {
     /// it should _not_ overlap with other `VmWriter`s.
     /// The user space memory is treated as untyped.
     pub unsafe fn from_kernel_space(ptr: *const u8, len: usize) -> Self {
-        debug_assert!(KERNEL_BASE_VADDR <= ptr as usize);
-        debug_assert!(ptr.add(len) as usize <= KERNEL_END_VADDR);
+        // If casting a zero sized slice to a pointer, the pointer may be null
+        // and does not reside in our kernel space range.
+        debug_assert!(len == 0 || KERNEL_BASE_VADDR <= ptr as usize);
+        debug_assert!(len == 0 || ptr.add(len) as usize <= KERNEL_END_VADDR);
 
         Self {
             cursor: ptr,
@@ -516,8 +518,10 @@ impl<'a> VmWriter<'a, KernelSpace> {
     /// is typed, it should _not_ overlap with other `VmReader`s and `VmWriter`s.
     /// The user space memory is treated as untyped.
     pub unsafe fn from_kernel_space(ptr: *mut u8, len: usize) -> Self {
-        debug_assert!(KERNEL_BASE_VADDR <= ptr as usize);
-        debug_assert!(ptr.add(len) as usize <= KERNEL_END_VADDR);
+        // If casting a zero sized slice to a pointer, the pointer may be null
+        // and does not reside in our kernel space range.
+        debug_assert!(len == 0 || KERNEL_BASE_VADDR <= ptr as usize);
+        debug_assert!(len == 0 || ptr.add(len) as usize <= KERNEL_END_VADDR);
 
         Self {
             cursor: ptr,


### PR DESCRIPTION
Fix #1069 and checked it using assertions to prevent happening again.

Also, this approach fixes the problem of the preempt count atomicity, as stated in the comment:

```rust
/// Currently, it only holds the number of preemption locks held by the
/// current CPU. When it has a non-zero value, the CPU cannot call
/// [`schedule()`].
///
/// For per-CPU preemption lock count, we cannot afford two non-atomic
/// operations to increment and decrement the count. The [`crate::cpu_local`]
/// implementation is free to read the base register and then calculate the
/// address of the per-CPU variable using an additional instruction. Interrupts
/// can happen between the address calculation and modification to that
/// address. If the task is preempted to another CPU by this interrupt, the
/// count of the original CPU will be mistakenly modified. To avoid this, we
/// introduce [`crate::arch::cpu::local::preempt_lock_count`]. For x86_64 we
/// can implement this using one instruction. In other less expressive
/// architectures, we may need to disable interrupts.
///
/// Also, the preemption count is reserved in the `.cpu_local` section
/// specified in the linker script. The reason is that we need to access the
/// preemption count before we can copy the section for application processors.
/// So, the preemption count is not copied from bootstrap processor's section
/// as the initialization. Instead it is initialized to zero for application
/// processors.
struct PreemptInfo {}
```

The idea is raised during a private discussion with @lrh2000. Thanks very much to him.

---

Also, in this PR the integration test in CI is adjusted to cover debug assertions and remove unnecessarily boot tests.