### PR TITLE
Fix sys_select bug

### DIFF
--- a/kernel/aster-nix/src/syscall/poll.rs
+++ b/kernel/aster-nix/src/syscall/poll.rs
@@ -36,16 +36,7 @@ pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32) -> Result<SyscallReturn> {
         poll_fds, nfds, timeout
     );
 
-    let num_revents = match do_poll(&poll_fds, timeout) {
-        Ok(num_events) => num_events,
-        Err(e) if e.error() == Errno::ETIME => {
-            // If the system call timed out
-            // before any file descriptors became ready,
-            // return 0.
-            return Ok(SyscallReturn::Return(0));
-        }
-        Err(e) => return Err(e),
-    };
+    let num_revents = do_poll(&poll_fds, timeout)?;
 
     // Write back
     let mut write_addr = fds;

--- a/kernel/aster-nix/src/syscall/select.rs
+++ b/kernel/aster-nix/src/syscall/select.rs
@@ -52,21 +52,13 @@ pub fn sys_select(
         nfds, readfds, writefds, exceptfds, timeout
     );
 
-    let num_revents = match do_select(
+    let num_revents = do_select(
         nfds,
         readfds.as_mut(),
         writefds.as_mut(),
         exceptfds.as_mut(),
         timeout,
-    ) {
-        Ok(num_revents) => num_revents,
-        Err(e) if e.error() == Errno::ETIME => {
-            // The return value is zero if the timeout expires
-            // before any file descriptors became ready
-            return Ok(SyscallReturn::Return(0));
-        }
-        Err(e) => return Err(e),
-    };
+    )?;
 
     // FIXME: The Linux select() and pselect6() system call
     // modifies its timeout argument to reflect the amount of time not slept.


### PR DESCRIPTION
The `sys_select` forgets to write the result back to the user after the timer expires.