### PR TITLE
Add LMbench pipe test

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -19,6 +19,8 @@ jobs:
           - lmbench-fork
           - lmbench-exec
           - lmbench-shell
+          - lmbench-pipe-latency
+          - lmbench-pipe-bandwidth
           # Memory-related benchmarks
           - lmbench-mem-frd
           - lmbench-mem-fwr

--- a/test/benchmark/lmbench-pipe-bandwidth/config.json
+++ b/test/benchmark/lmbench-pipe-bandwidth/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Pipe bandwidth",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-pipe-bandwidth/result_template.json
+++ b/test/benchmark/lmbench-pipe-bandwidth/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average pipe bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average pipe bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-pipe-bandwidth/run.sh
+++ b/test/benchmark/lmbench-pipe-bandwidth/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench pipe bandwidth test ***"
+
+/benchmark/bin/lmbench/bw_pipe -P 1

--- a/test/benchmark/lmbench-pipe-latency/config.json
+++ b/test/benchmark/lmbench-pipe-latency/config.json
@@ -1,0 +1,5 @@
+{
+    "alert_threshold": "125%",
+    "pattern": "Pipe latency",
+    "field": "3"
+}

--- a/test/benchmark/lmbench-pipe-latency/result_template.json
+++ b/test/benchmark/lmbench-pipe-latency/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average pipe latency on Linux",
+        "unit": "ms",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average pipe latency on Asterinas",
+        "unit": "ms",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-pipe-latency/run.sh
+++ b/test/benchmark/lmbench-pipe-latency/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench pipe latency test ***"
+
+/benchmark/bin/lmbench/lat_pipe -P 1


### PR DESCRIPTION
This PR adds the pipe benchmarks and should be merged after #1074.