### PR TITLE
Fix a typo when assign 'dst.rbx' at `copy_gp_regs`

### DIFF
--- a/kernel/aster-nix/src/arch/x86/cpu.rs
+++ b/kernel/aster-nix/src/arch/x86/cpu.rs
@@ -69,7 +69,7 @@ pub struct GpRegs {
 macro_rules! copy_gp_regs {
     ($src: ident, $dst: ident) => {
         $dst.rax = $src.rax;
-        $dst.rbx = $src.rax;
+        $dst.rbx = $src.rbx;
         $dst.rcx = $src.rcx;
         $dst.rdx = $src.rdx;
         $dst.rsi = $src.rsi;


### PR DESCRIPTION
relate https://github.com/asterinas/asterinas/issues/1078