### PR TITLE
Add /proc/meminfo support

### DIFF
--- a/kernel/aster-nix/src/fs/procfs/meminfo.rs
+++ b/kernel/aster-nix/src/fs/procfs/meminfo.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module offers `/proc/meminfo` file support, which tells the user space
+//! about the memory statistics in the entire system. The definition of the
+//! fields are similar to that of Linux's but there exist differences.
+//!
+//! Reference: <https://man7.org/linux/man-pages/man5/proc_meminfo.5.html>
+
+use alloc::format;
+
+use ostd::mm::stat;
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::Inode,
+    },
+    prelude::*,
+};
+
+/// Represents the inode at `/proc/meminfo`.
+pub struct MemInfoFileOps;
+
+impl MemInfoFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+    }
+}
+
+/// Total memory in the entire system in bytes.
+fn mem_total() -> usize {
+    stat::mem_total()
+}
+
+/// An estimation of how much memory is available for starting new
+/// applications, without disk operations.
+fn mem_available() -> usize {
+    stat::mem_available()
+}
+
+impl FileOps for MemInfoFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let total = mem_total();
+        let available = mem_available();
+        let output = format!("MemTotal:\t{}\nMemAvailable:\t{}\n", total, available);
+        Ok(output.into_bytes())
+    }
+}

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -17,6 +17,7 @@ mod offset;
 pub(crate) mod page;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;
+pub mod stat;
 pub mod vm_space;
 
 use alloc::vec::Vec;

--- a/ostd/src/mm/stat/mod.rs
+++ b/ostd/src/mm/stat/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! APIs for memory statistics.
+
+use crate::mm::page::allocator::PAGE_ALLOCATOR;
+
+/// Total memory available for any usages in the system (in bytes).
+///
+/// It would be only a slightly less than total physical memory of the system
+/// in most occasions. For example, bad memory, kernel statically-allocated
+/// memory or firmware reserved memories do not count.
+pub fn mem_total() -> usize {
+    PAGE_ALLOCATOR.get().unwrap().lock().mem_total()
+}
+
+/// Current readily available memory (in bytes).
+///
+/// Such memory can be directly used for allocation without reclaiming.
+pub fn mem_available() -> usize {
+    PAGE_ALLOCATOR.get().unwrap().lock().mem_available()
+}


### PR DESCRIPTION
Related issue: https://github.com/asterinas/asterinas/issues/946

This PR only adds `MemTotal` and `MemAvailable` for `/proc/meminfo`, the other statistics will be added later.