### PR TITLE
Extended timeout time to 90 minutes

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -40,7 +40,7 @@ jobs:
           # Signal-related benchmarks
           - lmbench-signal
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 90
     container: 
       image: asterinas/asterinas:0.6.2
       options: --device=/dev/kvm


### PR DESCRIPTION
As the number of benchmark use cases increases, the original 60-minute timeout is no longer sufficient. Recent tests are often canceled due to timeout, resulting in failure, so I changed this time to 90 minutes.
See [25](https://github.com/asterinas/asterinas/actions/runs/10013649149/job/27681732631), [26](https://github.com/asterinas/asterinas/actions/runs/10022743820/job/27702859334)