### PR TITLE
Refactor architecture-specific page fault handling

### DIFF
--- a/kernel/src/vm/page_fault_handler.rs
+++ b/kernel/src/vm/page_fault_handler.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use crate::{prelude::*, thread::exception::PageFaultInfo};
 
 /// This trait is implemented by structs which can handle a user space page fault.
 pub trait PageFaultHandler {
-    /// Handle a page fault at a specific addr. if not_present is true, the page fault is caused by page not present.
-    /// Otherwise, it's caused by page protection error.
-    /// if write is true, the page fault is caused by a write access,
-    /// otherwise, the page fault is caused by a read access.
-    /// If the page fault can be handled successfully, this function will return Ok(()).
-    /// Otherwise, this function will return Err.
-    fn handle_page_fault(&self, offset: Vaddr, not_present: bool, write: bool) -> Result<()>;
+    /// Handle a page fault, whose information is provided in `page_fault_info`.
+    ///
+    /// Returns `Ok` if the page fault is handled successfully, `Err` otherwise.
+    fn handle_page_fault(&self, page_fault_info: &PageFaultInfo) -> Result<()>;
 }

--- a/kernel/src/vm/vmar/options.rs
+++ b/kernel/src/vm/vmar/options.rs
@@ -142,7 +142,7 @@ mod test {
     use crate::vm::{
         page_fault_handler::PageFaultHandler,
         perms::VmPerms,
-        vmar::ROOT_VMAR_CAP_ADDR,
+        vmar::{PageFaultInfo, ROOT_VMAR_CAP_ADDR},
         vmo::{VmoOptions, VmoRightsOp},
     };
 
@@ -192,7 +192,12 @@ mod test {
         const OFFSET: usize = 0x1000_0000;
         let root_vmar = Vmar::<Full>::new_root();
         // the page is not mapped by a vmo
-        assert!(root_vmar.handle_page_fault(OFFSET, true, true).is_err());
+        assert!(root_vmar
+            .handle_page_fault(&PageFaultInfo {
+                address: OFFSET,
+                required_perms: VmPerms::WRITE,
+            })
+            .is_err());
         // the page is mapped READ
         let vmo = VmoOptions::<Full>::new(PAGE_SIZE).alloc().unwrap().to_dyn();
         let perms = VmPerms::READ;
@@ -204,6 +209,11 @@ mod test {
             .offset(OFFSET)
             .build()
             .unwrap();
-        root_vmar.handle_page_fault(OFFSET, true, false).unwrap();
+        root_vmar
+            .handle_page_fault(&PageFaultInfo {
+                address: OFFSET,
+                required_perms: VmPerms::READ,
+            })
+            .unwrap();
     }
 }

--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -196,7 +196,7 @@ impl UserContextApiInternal for UserContext {
 ///
 /// But there exists some vector which are special. Vector 1 can be both fault or trap and vector 2 is interrupt.
 /// So here we also define FaultOrTrap and Interrupt
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum CpuExceptionType {
     /// CPU faults. Faults can be corrected, and the program may continue as if nothing happened.
     Fault,
@@ -213,7 +213,7 @@ pub enum CpuExceptionType {
 }
 
 /// CPU exception.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct CpuException {
     /// The ID of the CPU exception.
     pub number: u16,
@@ -320,6 +320,13 @@ impl CpuException {
     /// Maps a `trap_num` to its corresponding CPU exception.
     pub fn to_cpu_exception(trap_num: u16) -> Option<&'static CpuException> {
         EXCEPTION_LIST.get(trap_num as usize)
+    }
+}
+
+impl CpuExceptionInfo {
+    /// Get corresponding CPU exception
+    pub fn cpu_exception(&self) -> CpuException {
+        EXCEPTION_LIST[self.id]
     }
 }
 


### PR DESCRIPTION
Follows https://github.com/asterinas/asterinas/pull/1071#issue-2418368378.

It's not always possible to obtain `not_present` in all architectures, that is, page fault exception in some architectures, say RISC-V, cannot distinguish whether it's caused by PTE missing or mismatched permission. In this case, it's necessary to lookup the page table manually (in a software way) to distinguish them.

To give a proper abstraction for different architectures (at least for x86 and RISC-V), this PR makes page fault handler always lookup the page table with the `required_perms` of the memory operation, and the `required_perms` will be checked before a PTE is mapped. This sacrifices the performance of handling a problematic page fault (i.e. the one that causes SIGSEGV), but as it's unlikely to happen, so I think it would be OK.