### PR TITLE
Optimize page table un-mapping and sanitize metadata mutability

### DIFF
--- a/ostd/src/mm/kspace.rs
+++ b/ostd/src/mm/kspace.rs
@@ -211,7 +211,7 @@ pub fn init_kernel_page_table(meta_pages: Vec<Page<MetaPageMeta>>) {
         };
         let mut cursor = kpt.cursor_mut(&from).unwrap();
         for frame_paddr in to.step_by(PAGE_SIZE) {
-            let page = Page::<KernelMeta>::from_unused(frame_paddr);
+            let page = Page::<KernelMeta>::from_unused(frame_paddr, KernelMeta::default());
             // SAFETY: we are doing mappings for the kernel.
             unsafe {
                 cursor.map(page.into(), prop);

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -13,31 +13,46 @@ use log::info;
 use spin::Once;
 
 use super::{cont_pages::ContPages, meta::PageMeta, Page};
-use crate::{boot::memory_region::MemoryRegionType, mm::PAGE_SIZE, sync::SpinLock};
+use crate::{
+    boot::memory_region::MemoryRegionType,
+    mm::{Paddr, PAGE_SIZE},
+    sync::SpinLock,
+};
 
 pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<FrameAllocator>> = Once::new();
 
 /// Allocate a single page.
-pub(crate) fn alloc_single<M: PageMeta>() -> Option<Page<M>> {
+///
+/// The metadata of the page is initialized with the given metadata.
+pub(crate) fn alloc_single<M: PageMeta>(metadata: M) -> Option<Page<M>> {
     PAGE_ALLOCATOR.get().unwrap().lock().alloc(1).map(|idx| {
         let paddr = idx * PAGE_SIZE;
-        Page::<M>::from_unused(paddr)
+        Page::from_unused(paddr, metadata)
     })
 }
 
 /// Allocate a contiguous range of pages of a given length in bytes.
 ///
+/// The caller must provide a closure to initialize metadata for all the pages.
+/// The closure receives the physical address of the page and returns the
+/// metadata, which is similar to [`core::array::from_fn`].
+///
 /// # Panics
 ///
 /// The function panics if the length is not base-page-aligned.
-pub(crate) fn alloc_contiguous<M: PageMeta>(len: usize) -> Option<ContPages<M>> {
+pub(crate) fn alloc_contiguous<M: PageMeta, F>(len: usize, metadata_fn: F) -> Option<ContPages<M>>
+where
+    F: FnMut(Paddr) -> M,
+{
     assert!(len % PAGE_SIZE == 0);
     PAGE_ALLOCATOR
         .get()
         .unwrap()
         .lock()
         .alloc(len / PAGE_SIZE)
-        .map(|start| ContPages::from_unused(start * PAGE_SIZE..start * PAGE_SIZE + len))
+        .map(|start| {
+            ContPages::from_unused(start * PAGE_SIZE..start * PAGE_SIZE + len, metadata_fn)
+        })
 }
 
 /// Allocate pages.
@@ -45,17 +60,24 @@ pub(crate) fn alloc_contiguous<M: PageMeta>(len: usize) -> Option<ContPages<M>> 
 /// The allocated pages are not guarenteed to be contiguous.
 /// The total length of the allocated pages is `len`.
 ///
+/// The caller must provide a closure to initialize metadata for all the pages.
+/// The closure receives the physical address of the page and returns the
+/// metadata, which is similar to [`core::array::from_fn`].
+///
 /// # Panics
 ///
 /// The function panics if the length is not base-page-aligned.
-pub(crate) fn alloc<M: PageMeta>(len: usize) -> Option<Vec<Page<M>>> {
+pub(crate) fn alloc<M: PageMeta, F>(len: usize, mut metadata_fn: F) -> Option<Vec<Page<M>>>
+where
+    F: FnMut(Paddr) -> M,
+{
     assert!(len % PAGE_SIZE == 0);
     let nframes = len / PAGE_SIZE;
     let mut allocator = PAGE_ALLOCATOR.get().unwrap().lock();
     let mut vector = Vec::new();
     for _ in 0..nframes {
         let paddr = allocator.alloc(1)? * PAGE_SIZE;
-        let page = Page::<M>::from_unused(paddr);
+        let page = Page::<M>::from_unused(paddr, metadata_fn(paddr));
         vector.push(page);
     }
     Some(vector)

--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -36,14 +36,21 @@ impl<M: PageMeta> Drop for ContPages<M> {
 impl<M: PageMeta> ContPages<M> {
     /// Create a new `ContPages` from unused pages.
     ///
+    /// The caller must provide a closure to initialize metadata for all the pages.
+    /// The closure receives the physical address of the page and returns the
+    /// metadata, which is similar to [`core::array::from_fn`].
+    ///
     /// # Panics
     ///
     /// The function panics if:
     ///  - the physical address is invalid or not aligned;
     ///  - any of the pages are already in use.
-    pub fn from_unused(range: Range<Paddr>) -> Self {
+    pub fn from_unused<F>(range: Range<Paddr>, mut metadata_fn: F) -> Self
+    where
+        F: FnMut(Paddr) -> M,
+    {
         for i in range.clone().step_by(PAGE_SIZE) {
-            let _ = ManuallyDrop::new(Page::<M>::from_unused(i));
+            let _ = ManuallyDrop::new(Page::<M>::from_unused(i, metadata_fn(i)));
         }
         Self {
             range,

--- a/ostd/src/mm/page_table/node.rs
+++ b/ostd/src/mm/page_table/node.rs
@@ -231,14 +231,8 @@ where
     /// set the lock bit for performance as it is exclusive and unlocking is an
     /// extra unnecessary expensive operation.
     pub(super) fn alloc(level: PagingLevel) -> Self {
-        let page = page::allocator::alloc_single::<PageTablePageMeta<E, C>>().unwrap();
-
-        // The lock is initialized as held.
-        page.meta().lock.store(1, Ordering::Relaxed);
-
-        // SAFETY: here the page exclusively owned by the newly created handle.
-        let inner = unsafe { &mut *page.meta().inner.get() };
-        inner.level = level;
+        let meta = PageTablePageMeta::new_locked(level);
+        let page = page::allocator::alloc_single::<PageTablePageMeta<E, C>>(meta).unwrap();
 
         // Zero out the page table node.
         let ptr = paddr_to_vaddr(page.paddr()) as *mut u8;

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -33,7 +33,7 @@ fn test_tracked_map_unmap() {
     let pt = PageTable::<UserMode>::empty();
 
     let from = PAGE_SIZE..PAGE_SIZE * 2;
-    let page = allocator::alloc_single::<FrameMeta>().unwrap();
+    let page = allocator::alloc_single(FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe { pt.cursor_mut(&from).unwrap().map(page.into(), prop) };
@@ -77,7 +77,7 @@ fn test_untracked_map_unmap() {
 fn test_user_copy_on_write() {
     let pt = PageTable::<UserMode>::empty();
     let from = PAGE_SIZE..PAGE_SIZE * 2;
-    let page = allocator::alloc_single::<FrameMeta>().unwrap();
+    let page = allocator::alloc_single(FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe { pt.cursor_mut(&from).unwrap().map(page.clone().into(), prop) };
@@ -133,7 +133,7 @@ fn test_base_protect_query() {
 
     let from_ppn = 1..1000;
     let from = PAGE_SIZE * from_ppn.start..PAGE_SIZE * from_ppn.end;
-    let to = allocator::alloc::<FrameMeta>(999 * PAGE_SIZE).unwrap();
+    let to = allocator::alloc(999 * PAGE_SIZE, |_| FrameMeta::default()).unwrap();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe {
         let mut cursor = pt.cursor_mut(&from).unwrap();

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -288,6 +288,9 @@ impl CursorMut<'_> {
     /// This method will bring the cursor forward by `len` bytes in the virtual
     /// address space after the modification.
     ///
+    /// Already-absent mappings encountered by the cursor will be skipped. It
+    /// is valid to unmap a range that is not mapped.
+    ///
     /// # Panics
     ///
     /// This method will panic if `len` is not page-aligned.


### PR DESCRIPTION
The first commit forces designating a initial page metadata value when doing allocations, rather than using `Default`. This is more "Rusty" and saves performance. This is also aligned with the modifications needed for #1077 .

The second commit sanitizes some of the unsafe code written for page table nodes. Unsafe blocks are lesser now.

The third commit introduces an performance optimization for un-mapping a long range of virtual addresses: since page tables will not be recycled, there would be empty page table nodes hanging. When un-mapping over them, we can skip instead of iterating over them. This is especially useful for #1017 .