### PR TITLE
Make sure KPTI is off for the Linux benchmark baseline

### DIFF
--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -46,8 +46,9 @@ run_benchmark() {
     local initramfs_entrypoint_script="${BENCHMARK_DIR}/benchmark_entrypoint.sh"
     generate_entrypoint_script "${benchmark}" > "${initramfs_entrypoint_script}"
     chmod +x "${initramfs_entrypoint_script}"
-        
-    # TODO: enable nopti for Linux to make the comparison more fair
+    
+    # The QEMU command to run benchmarks in Linux
+    # We would try to make these options the same as Asterinas' scripts
     local qemu_cmd="/usr/local/qemu/bin/qemu-system-x86_64 \
         --no-reboot \
         -smp 1 \
@@ -57,7 +58,7 @@ run_benchmark() {
         --enable-kvm \
         -kernel ${LINUX_KERNEL} \
         -initrd ${BENCHMARK_DIR}/../build/initramfs.cpio.gz \
-        -append 'console=ttyS0 rdinit=/benchmark/benchmark_entrypoint.sh' \
+        -append 'console=ttyS0 nokaslr nopti rdinit=/benchmark/benchmark_entrypoint.sh' \
         -nographic \
         2>&1 | tee ${linux_output}" 
 


### PR DESCRIPTION
Actually we do run the Linux benchmark baseline with KPTI off, since the benchmark machine is relatively new, without the vulnerabilities.

This PR makes sure that no one would misunderstand our results.