### PR TITLE
Remove `destroy_all` methods

### DIFF
--- a/kernel/aster-nix/src/process/wait.rs
+++ b/kernel/aster-nix/src/process/wait.rs
@@ -78,7 +78,6 @@ pub fn wait_child_exit(
 fn reap_zombie_child(process: &Process, pid: Pid) -> ExitCode {
     let child_process = process.children().lock().remove(&pid).unwrap();
     assert!(child_process.is_zombie());
-    child_process.root_vmar().destroy_all().unwrap();
     for thread in &*child_process.threads().lock() {
         thread_table::remove_thread(thread.tid());
     }

--- a/kernel/aster-nix/src/vm/vmar/dyn_cap.rs
+++ b/kernel/aster-nix/src/vm/vmar/dyn_cap.rs
@@ -113,14 +113,6 @@ impl Vmar<Rights> {
         self.0.clear_root_vmar()
     }
 
-    /// Destroy a VMAR, including all its mappings and children VMARs.
-    ///
-    /// After being destroyed, the VMAR becomes useless and returns errors
-    /// for most of its methods.
-    pub fn destroy_all(&self) -> Result<()> {
-        self.0.destroy_all()
-    }
-
     /// Destroy all mappings and children VMARs that fall within the specified
     /// range in bytes.
     ///

--- a/kernel/aster-nix/src/vm/vmar/static_cap.rs
+++ b/kernel/aster-nix/src/vm/vmar/static_cap.rs
@@ -120,14 +120,6 @@ impl<R: TRights> Vmar<TRightSet<R>> {
         self.0.clear_root_vmar()
     }
 
-    /// Destroy a VMAR, including all its mappings and children VMARs.
-    ///
-    /// After being destroyed, the VMAR becomes useless and returns errors
-    /// for most of its methods.
-    pub fn destroy_all(&self) -> Result<()> {
-        self.0.destroy_all()
-    }
-
     /// Destroy all mappings and children VMARs that fall within the specified
     /// range in bytes.
     ///


### PR DESCRIPTION
Currently `destroy_all` methods are only used to destroy the vm of zombie vmar (in `reap_zombie_child`) and child vmar (in `destroy`).  The only practical operation this function performs in this scenario is clearing the vmar's `VmSpace` and reclaiming pages in the page tables. Other operations should be considered redundant, as the `Vmar` itself will be dropped after these actions.