### PR TITLE
Properly close sockets

### DIFF
--- a/kernel/aster-nix/src/net/iface/any_socket.rs
+++ b/kernel/aster-nix/src/net/iface/any_socket.rs
@@ -59,14 +59,7 @@ impl AnyUnboundSocket {
     }
 }
 
-pub struct AnyBoundSocket {
-    iface: Arc<dyn Iface>,
-    handle: smoltcp::iface::SocketHandle,
-    port: u16,
-    socket_family: SocketFamily,
-    observer: RwLock<Weak<dyn Observer<()>>>,
-    weak_self: Weak<Self>,
-}
+pub struct AnyBoundSocket(Arc<AnyBoundSocketInner>);
 
 impl AnyBoundSocket {
     pub(super) fn new(
@@ -75,21 +68,18 @@ impl AnyBoundSocket {
         port: u16,
         socket_family: SocketFamily,
         observer: Weak<dyn Observer<()>>,
-    ) -> Arc<Self> {
-        Arc::new_cyclic(|weak_self| Self {
+    ) -> Self {
+        Self(Arc::new(AnyBoundSocketInner {
             iface,
             handle,
             port,
             socket_family,
             observer: RwLock::new(observer),
-            weak_self: weak_self.clone(),
-        })
+        }))
     }
 
-    pub(super) fn on_iface_events(&self) {
-        if let Some(observer) = Weak::upgrade(&*self.observer.read()) {
-            observer.on_events(&())
-        }
+    pub(super) fn inner(&self) -> &Arc<AnyBoundSocketInner> {
+        &self.0
     }
 
     /// Set the observer whose `on_events` will be called when certain iface events happen. After
@@ -99,17 +89,101 @@ impl AnyBoundSocket {
     /// that the old observer will never be called after the setting. Users should be aware of this
     /// and proactively handle the race conditions if necessary.
     pub fn set_observer(&self, handler: Weak<dyn Observer<()>>) {
-        *self.observer.write() = handler;
+        *self.0.observer.write() = handler;
 
-        self.on_iface_events();
+        self.0.on_iface_events();
     }
 
     pub fn local_endpoint(&self) -> Option<IpEndpoint> {
         let ip_addr = {
-            let ipv4_addr = self.iface.ipv4_addr()?;
+            let ipv4_addr = self.0.iface.ipv4_addr()?;
             IpAddress::Ipv4(ipv4_addr)
         };
-        Some(IpEndpoint::new(ip_addr, self.port))
+        Some(IpEndpoint::new(ip_addr, self.0.port))
+    }
+
+    pub fn raw_with<T: smoltcp::socket::AnySocket<'static>, R, F: FnMut(&mut T) -> R>(
+        &self,
+        f: F,
+    ) -> R {
+        self.0.raw_with(f)
+    }
+
+    /// Try to connect to a remote endpoint. Tcp socket only.
+    pub fn do_connect(&self, remote_endpoint: IpEndpoint) -> Result<()> {
+        let mut sockets = self.0.iface.sockets();
+        let socket = sockets.get_mut::<RawTcpSocket>(self.0.handle);
+        let port = self.0.port;
+        let mut iface_inner = self.0.iface.iface_inner();
+        let cx = iface_inner.context();
+        socket
+            .connect(cx, remote_endpoint, port)
+            .map_err(|_| Error::with_message(Errno::ENOBUFS, "send connection request failed"))?;
+        Ok(())
+    }
+
+    pub fn iface(&self) -> &Arc<dyn Iface> {
+        &self.0.iface
+    }
+}
+
+impl Drop for AnyBoundSocket {
+    fn drop(&mut self) {
+        if self.0.start_closing() {
+            self.0.iface.common().remove_bound_socket_now(&self.0);
+        } else {
+            self.0
+                .iface
+                .common()
+                .remove_bound_socket_when_closed(&self.0);
+        }
+    }
+}
+
+pub(super) struct AnyBoundSocketInner {
+    iface: Arc<dyn Iface>,
+    handle: smoltcp::iface::SocketHandle,
+    port: u16,
+    socket_family: SocketFamily,
+    observer: RwLock<Weak<dyn Observer<()>>>,
+}
+
+impl AnyBoundSocketInner {
+    pub(super) fn on_iface_events(&self) {
+        if let Some(observer) = Weak::upgrade(&*self.observer.read()) {
+            observer.on_events(&())
+        }
+    }
+
+    pub(super) fn is_closed(&self) -> bool {
+        match self.socket_family {
+            SocketFamily::Tcp => self.raw_with(|socket: &mut RawTcpSocket| {
+                socket.state() == smoltcp::socket::tcp::State::Closed
+            }),
+            SocketFamily::Udp => true,
+        }
+    }
+
+    /// Starts closing the socket and returns whether the socket is closed.
+    ///
+    /// For sockets that can be closed immediately, such as UDP sockets and TCP listening sockets,
+    /// this method will always return `true`.
+    ///
+    /// For other sockets, such as TCP connected sockets, they cannot be closed immediately because
+    /// we at least need to send the FIN packet and wait for the remote end to send an ACK packet.
+    /// In this case, this method will return `false` and [`Self::is_closed`] can be used to
+    /// determine if the closing process is complete.
+    fn start_closing(&self) -> bool {
+        match self.socket_family {
+            SocketFamily::Tcp => self.raw_with(|socket: &mut RawTcpSocket| {
+                socket.close();
+                socket.state() == smoltcp::socket::tcp::State::Closed
+            }),
+            SocketFamily::Udp => {
+                self.raw_with(|socket: &mut RawUdpSocket| socket.close());
+                true
+            }
+        }
     }
 
     pub fn raw_with<T: smoltcp::socket::AnySocket<'static>, R, F: FnMut(&mut T) -> R>(
@@ -120,43 +194,13 @@ impl AnyBoundSocket {
         let socket = sockets.get_mut::<T>(self.handle);
         f(socket)
     }
-
-    /// Try to connect to a remote endpoint. Tcp socket only.
-    pub fn do_connect(&self, remote_endpoint: IpEndpoint) -> Result<()> {
-        let mut sockets = self.iface.sockets();
-        let socket = sockets.get_mut::<RawTcpSocket>(self.handle);
-        let port = self.port;
-        let mut iface_inner = self.iface.iface_inner();
-        let cx = iface_inner.context();
-        socket
-            .connect(cx, remote_endpoint, port)
-            .map_err(|_| Error::with_message(Errno::ENOBUFS, "send connection request failed"))?;
-        Ok(())
-    }
-
-    pub fn iface(&self) -> &Arc<dyn Iface> {
-        &self.iface
-    }
-
-    pub(super) fn weak_ref(&self) -> Weak<Self> {
-        self.weak_self.clone()
-    }
-
-    fn close(&self) {
-        match self.socket_family {
-            SocketFamily::Tcp => self.raw_with(|socket: &mut RawTcpSocket| socket.close()),
-            SocketFamily::Udp => self.raw_with(|socket: &mut RawUdpSocket| socket.close()),
-        }
-    }
 }
 
-impl Drop for AnyBoundSocket {
+impl Drop for AnyBoundSocketInner {
     fn drop(&mut self) {
-        self.close();
-        self.iface.poll();
-        self.iface.common().remove_socket(self.handle);
-        self.iface.common().release_port(self.port);
-        self.iface.common().remove_bound_socket(self.weak_ref());
+        let iface_common = self.iface.common();
+        iface_common.remove_socket(self.handle);
+        iface_common.release_port(self.port);
     }
 }
 

--- a/kernel/aster-nix/src/net/iface/common.rs
+++ b/kernel/aster-nix/src/net/iface/common.rs
@@ -171,7 +171,7 @@ impl IfaceCommon {
         drop(interface);
 
         if let Some(instant) = poll_at {
-            let old_instant = self.next_poll_at_ms.load(Ordering::Acquire);
+            let old_instant = self.next_poll_at_ms.load(Ordering::Relaxed);
             let new_instant = instant.total_millis() as u64;
             self.next_poll_at_ms.store(new_instant, Ordering::Relaxed);
 
@@ -192,7 +192,7 @@ impl IfaceCommon {
     }
 
     pub(super) fn next_poll_at_ms(&self) -> Option<u64> {
-        let millis = self.next_poll_at_ms.load(Ordering::SeqCst);
+        let millis = self.next_poll_at_ms.load(Ordering::Relaxed);
         if millis == 0 {
             None
         } else {

--- a/kernel/aster-nix/src/net/iface/common.rs
+++ b/kernel/aster-nix/src/net/iface/common.rs
@@ -177,7 +177,7 @@ impl IfaceCommon {
             let new_instant = instant.total_millis() as u64;
             self.next_poll_at_ms.store(new_instant, Ordering::Relaxed);
 
-            if new_instant < old_instant {
+            if old_instant == 0 || new_instant < old_instant {
                 self.polling_wait_queue.wake_all();
             }
         } else {

--- a/kernel/aster-nix/src/net/iface/mod.rs
+++ b/kernel/aster-nix/src/net/iface/mod.rs
@@ -45,7 +45,7 @@ pub trait Iface: internal::IfaceInternal + Send + Sync {
         &self,
         socket: Box<AnyUnboundSocket>,
         config: BindPortConfig,
-    ) -> core::result::Result<Arc<AnyBoundSocket>, (Error, Box<AnyUnboundSocket>)> {
+    ) -> core::result::Result<AnyBoundSocket, (Error, Box<AnyUnboundSocket>)> {
         let common = self.common();
         common.bind_socket(self.arc_self(), socket, config)
     }

--- a/kernel/aster-nix/src/net/socket/ip/common.rs
+++ b/kernel/aster-nix/src/net/socket/ip/common.rs
@@ -46,7 +46,7 @@ pub(super) fn bind_socket(
     unbound_socket: Box<AnyUnboundSocket>,
     endpoint: &IpEndpoint,
     can_reuse: bool,
-) -> core::result::Result<Arc<AnyBoundSocket>, (Error, Box<AnyUnboundSocket>)> {
+) -> core::result::Result<AnyBoundSocket, (Error, Box<AnyUnboundSocket>)> {
     let iface = match get_iface_to_bind(&endpoint.addr) {
         Some(iface) => iface,
         None => {

--- a/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/aster-nix/src/net/socket/ip/datagram/bound.rs
@@ -13,12 +13,12 @@ use crate::{
 };
 
 pub struct BoundDatagram {
-    bound_socket: Arc<AnyBoundSocket>,
+    bound_socket: AnyBoundSocket,
     remote_endpoint: Option<IpEndpoint>,
 }
 
 impl BoundDatagram {
-    pub fn new(bound_socket: Arc<AnyBoundSocket>) -> Self {
+    pub fn new(bound_socket: AnyBoundSocket) -> Self {
         Self {
             bound_socket,
             remote_endpoint: None,

--- a/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connected.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub struct ConnectedStream {
-    bound_socket: Arc<AnyBoundSocket>,
+    bound_socket: AnyBoundSocket,
     remote_endpoint: IpEndpoint,
     /// Indicates whether this connection is "new" in a `connect()` system call.
     ///
@@ -32,7 +32,7 @@ pub struct ConnectedStream {
 
 impl ConnectedStream {
     pub fn new(
-        bound_socket: Arc<AnyBoundSocket>,
+        bound_socket: AnyBoundSocket,
         remote_endpoint: IpEndpoint,
         is_new_connection: bool,
     ) -> Self {

--- a/kernel/aster-nix/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/connecting.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub struct ConnectingStream {
-    bound_socket: Arc<AnyBoundSocket>,
+    bound_socket: AnyBoundSocket,
     remote_endpoint: IpEndpoint,
     conn_result: RwLock<Option<ConnResult>>,
 }
@@ -26,9 +26,9 @@ pub enum NonConnectedStream {
 
 impl ConnectingStream {
     pub fn new(
-        bound_socket: Arc<AnyBoundSocket>,
+        bound_socket: AnyBoundSocket,
         remote_endpoint: IpEndpoint,
-    ) -> core::result::Result<Self, (Error, Arc<AnyBoundSocket>)> {
+    ) -> core::result::Result<Self, (Error, AnyBoundSocket)> {
         if let Err(err) = bound_socket.do_connect(remote_endpoint) {
             return Err((err, bound_socket));
         }

--- a/kernel/aster-nix/src/net/socket/ip/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/init.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub enum InitStream {
     Unbound(Box<AnyUnboundSocket>),
-    Bound(Arc<AnyBoundSocket>),
+    Bound(AnyBoundSocket),
 }
 
 impl InitStream {
@@ -23,14 +23,14 @@ impl InitStream {
         InitStream::Unbound(Box::new(AnyUnboundSocket::new_tcp(observer)))
     }
 
-    pub fn new_bound(bound_socket: Arc<AnyBoundSocket>) -> Self {
+    pub fn new_bound(bound_socket: AnyBoundSocket) -> Self {
         InitStream::Bound(bound_socket)
     }
 
     pub fn bind(
         self,
         endpoint: &IpEndpoint,
-    ) -> core::result::Result<Arc<AnyBoundSocket>, (Error, Self)> {
+    ) -> core::result::Result<AnyBoundSocket, (Error, Self)> {
         let unbound_socket = match self {
             InitStream::Unbound(unbound_socket) => unbound_socket,
             InitStream::Bound(bound_socket) => {
@@ -50,7 +50,7 @@ impl InitStream {
     fn bind_to_ephemeral_endpoint(
         self,
         remote_endpoint: &IpEndpoint,
-    ) -> core::result::Result<Arc<AnyBoundSocket>, (Error, Self)> {
+    ) -> core::result::Result<AnyBoundSocket, (Error, Self)> {
         let endpoint = get_ephemeral_endpoint(remote_endpoint);
         self.bind(&endpoint)
     }

--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -13,16 +13,16 @@ use crate::{
 pub struct ListenStream {
     backlog: usize,
     /// A bound socket held to ensure the TCP port cannot be released
-    bound_socket: Arc<AnyBoundSocket>,
+    bound_socket: AnyBoundSocket,
     /// Backlog sockets listening at the local endpoint
     backlog_sockets: RwLock<Vec<BacklogSocket>>,
 }
 
 impl ListenStream {
     pub fn new(
-        bound_socket: Arc<AnyBoundSocket>,
+        bound_socket: AnyBoundSocket,
         backlog: usize,
-    ) -> core::result::Result<Self, (Error, Arc<AnyBoundSocket>)> {
+    ) -> core::result::Result<Self, (Error, AnyBoundSocket)> {
         let listen_stream = Self {
             backlog,
             bound_socket,
@@ -99,13 +99,13 @@ impl ListenStream {
 }
 
 struct BacklogSocket {
-    bound_socket: Arc<AnyBoundSocket>,
+    bound_socket: AnyBoundSocket,
 }
 
 impl BacklogSocket {
     // FIXME: All of the error codes below seem to have no Linux equivalents, and I see no reason
     // why the error may occur. Perhaps it is better to call `unwrap()` directly?
-    fn new(bound_socket: &Arc<AnyBoundSocket>) -> Result<Self> {
+    fn new(bound_socket: &AnyBoundSocket) -> Result<Self> {
         let local_endpoint = bound_socket.local_endpoint().ok_or(Error::with_message(
             Errno::EINVAL,
             "the socket is not bound",
@@ -143,7 +143,7 @@ impl BacklogSocket {
             .raw_with(|socket: &mut RawTcpSocket| socket.remote_endpoint())
     }
 
-    fn into_bound_socket(self) -> Arc<AnyBoundSocket> {
+    fn into_bound_socket(self) -> AnyBoundSocket {
         self.bound_socket
     }
 }

--- a/test/apps/network/listen_backlog.c
+++ b/test/apps/network/listen_backlog.c
@@ -131,7 +131,7 @@ int main(void)
 
 	for (backlog = 0; backlog <= MAX_TEST_BACKLOG; ++backlog) {
 		// Avoid "bind: Address already in use"
-		addr.sin_port = htons(8080 + backlog);
+		addr.sin_port = htons(10000 + backlog);
 
 		err = test_listen_backlog(&addr, backlog);
 		if (err != 0)

--- a/test/apps/network/send_buf_full.c
+++ b/test/apps/network/send_buf_full.c
@@ -265,7 +265,7 @@ int main(void)
 	struct sockaddr_in addr;
 
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(8080);
+	addr.sin_port = htons(9999);
 	if (inet_aton("127.0.0.1", &addr.sin_addr) < 0) {
 		fprintf(stderr, "inet_aton cannot parse 127.0.0.1\n");
 		return -1;

--- a/test/apps/network/tcp_err.c
+++ b/test/apps/network/tcp_err.c
@@ -338,26 +338,23 @@ FN_TEST(sendmsg_and_recvmsg)
 
 	// Send two message and receive two message
 
-	// This test is commented out due to a known issue:
-	// See <https://github.com/asterinas/asterinas/issues/819>
+	iov[0].iov_base = message;
+	iov[0].iov_len = strlen(message);
+	msg.msg_iovlen = 1;
+	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(message));
+	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(message));
 
-	// iov[0].iov_base = message;
-	// iov[0].iov_len = strlen(message);
-	// msg.msg_iovlen = 1;
-	// TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(message));
-	// TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(message));
+	char first_buffer[BUFFER_SIZE] = { 0 };
+	char second_buffer[BUFFER_SIZE] = { 0 };
+	iov[0].iov_base = first_buffer;
+	iov[0].iov_len = BUFFER_SIZE;
+	iov[1].iov_base = second_buffer;
+	iov[1].iov_len = BUFFER_SIZE;
+	msg.msg_iovlen = 2;
 
-	// char first_buffer[BUFFER_SIZE] = { 0 };
-	// char second_buffer[BUFFER_SIZE] = { 0 };
-	// iov[0].iov_base = first_buffer;
-	// iov[0].iov_len = BUFFER_SIZE;
-	// iov[1].iov_base = second_buffer;
-	// iov[1].iov_len = BUFFER_SIZE;
-	// msg.msg_iovlen = 2;
+	// Ensure two messages are prepared for receiving
+	sleep(1);
 
-	// // Ensure two messages are prepared for receiving
-	// sleep(1);
-
-	// TEST_RES(recvmsg(sk_connected, &msg, 0), _ret == strlen(message) * 2);
+	TEST_RES(recvmsg(sk_connected, &msg, 0), _ret == strlen(message) * 2);
 }
 END_TEST()


### PR DESCRIPTION
When closing sockets, we cannot directly drop `AnyBoundSocket`, which will cause the connection to be removed from smoltcp's socket set, so the remote end will see the connection reset (this is why the `send_buf_full` test fails in https://github.com/asterinas/asterinas/issues/819#issuecomment-2175681884).

In this PR we put closing sockets in `closing_sockets`. These sockets can only be closed by network events, so we check if they are closed when polling interfaces. If the remote side refuses to close, we need to enforce a timeout in that state, but this is _not_ currently implemented in this PR.

There are some socket options related to this behavior, such as `SO_LINGER`, `SO_REUSEADDR`, and `SO_REUSEPORT`. But all of these are _not_ currently implemented in this PR. When someone encounters `bind: address already in use`, they must wait for the closing socket to pass the `TIME_WAIT` state (smoltcp [specifies 10 seconds for the state](https://github.com/smoltcp-rs/smoltcp/blob/53caf70f640d5ccb3cd1492e1cb178bc7dfa3cdd/src/socket/tcp.rs#L269)). This is the correct default behavior in Linux.

Fixes #506
Fixes #819