### PR TITLE
Extend user heap limit to 64MB

### DIFF
--- a/kernel/aster-nix/src/process/process_vm/heap.rs
+++ b/kernel/aster-nix/src/process/process_vm/heap.rs
@@ -17,7 +17,7 @@ use crate::{
 /// The base address of user heap
 pub const USER_HEAP_BASE: Vaddr = 0x0000_0000_1000_0000;
 /// The max allowed size of user heap
-pub const USER_HEAP_SIZE_LIMIT: usize = PAGE_SIZE * 1000; // 4MB
+pub const USER_HEAP_SIZE_LIMIT: usize = 16 * 1024 * PAGE_SIZE; // 16 * 4MB
 
 #[derive(Debug)]
 pub struct Heap {


### PR DESCRIPTION
As applications become more complex, the user heap size requirement also increases. The `stream` test in LMbench and Redis cannot run with a 4MB heap size.