### PR TITLE
Allow debugging with KVM enabled

### DIFF
--- a/docs/src/kernel/advanced-instructions.md
+++ b/docs/src/kernel/advanced-instructions.md
@@ -93,3 +93,6 @@ Your previous launch configs will be restored after the server is down.
 Press `F5`(Run and Debug) to start a debug session via VS Code. 
 Click `Continue`(or, press `F5`) at the fisrt break to resume the paused server instance,
 then it will continue until reaching your first breakpoint. 
+
+Note that if debugging with KVM enabled, you must use hardware assisted breakpoints. See "hbreak" in
+[the GDB manual](https://ftp.gnu.org/old-gnu/Manuals/gdb/html_node/gdb_28.html) for details.

--- a/osdk/src/commands/run.rs
+++ b/osdk/src/commands/run.rs
@@ -3,7 +3,7 @@
 use super::{build::create_base_and_cached_build, util::DEFAULT_TARGET_RELPATH};
 use crate::{
     cli::GdbServerArgs,
-    config::{scheme::ActionChoice, unix_args::split_to_kv_array, Config},
+    config::{scheme::ActionChoice, Config},
     util::{get_current_crate_info, get_target_directory},
 };
 
@@ -40,20 +40,6 @@ pub fn execute_run_command(config: &Config, gdb_server_args: &GdbServerArgs) {
             }
         };
         config.run.qemu.args += &qemu_gdb_args;
-
-        // FIXME: Disable KVM from QEMU args in debug mode.
-        // Currently, the QEMU GDB server does not work properly with KVM enabled.
-        let mut splitted = split_to_kv_array(&config.run.qemu.args);
-        let args_num = splitted.len();
-        splitted.retain(|x| !x.contains("kvm"));
-        if splitted.len() != args_num {
-            println!(
-                "[WARNING] KVM is forced to be disabled in GDB server currently. \
-                    Options related with KVM are ignored."
-            );
-        }
-
-        config.run.qemu.args = splitted.join(" ");
 
         // Ensure debug info added when debugging in the release profile.
         if config.run.build.profile.contains("release") {


### PR DESCRIPTION
I removed the check of debugging in KVM since we have `hbreak` to make it work, which is now documented.