### PR TITLE
Fix lmbench exec and shell scripts

### DIFF
--- a/test/benchmark/lmbench-exec/run.sh
+++ b/test/benchmark/lmbench-exec/run.sh
@@ -6,4 +6,6 @@ set -e
 
 echo "*** Running the LMbench exec latency test ***"
 
+mkdir /tmp
+cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 exec

--- a/test/benchmark/lmbench-shell/run.sh
+++ b/test/benchmark/lmbench-shell/run.sh
@@ -6,4 +6,6 @@ set -e
 
 echo "*** Running the LMbench shell latency test ***"
 
+mkdir /tmp
+cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 shell


### PR DESCRIPTION
In the LMbench test, the exec and shell benchmark will find and run the `/tmp/hello` program. This PR fixes this problem.