### PR TITLE
Ensure non-tearing memory operations on `DmaCoherent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-assert"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8298db53081b3a951cadb6e0f4ebbe36def7bcb591a34676708d0d7ac87dd86"
+
+[[package]]
 name = "controlled"
 version = "0.1.0"
 dependencies = [
@@ -1070,6 +1076,7 @@ dependencies = [
  "bitvec",
  "buddy_system_allocator",
  "cfg-if",
+ "const-assert",
  "gimli 0.28.0",
  "iced-x86",
  "id-alloc",

--- a/kernel/libs/aster-util/src/safe_ptr.rs
+++ b/kernel/libs/aster-util/src/safe_ptr.rs
@@ -7,7 +7,7 @@ use aster_rights_proc::require;
 use inherit_methods_macro::inherit_methods;
 pub use ostd::Pod;
 use ostd::{
-    mm::{Daddr, DmaStream, HasDaddr, HasPaddr, Paddr, VmIo},
+    mm::{Daddr, DmaStream, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce},
     Result,
 };
 pub use typeflags_util::SetContain;
@@ -321,6 +321,28 @@ impl<T: Pod, M: VmIo, R: TRights> SafePtr<T, M, TRightSet<R>> {
             rights: TRightSet(R1::new()),
             phantom: PhantomData,
         }
+    }
+}
+
+impl<T: PodOnce, M: VmIoOnce, R: TRights> SafePtr<T, M, TRightSet<R>> {
+    /// Reads the value from the pointer using one non-tearing instruction.
+    ///
+    /// # Access rights
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn read_once(&self) -> Result<T> {
+        self.vm_obj.read_once(self.offset)
+    }
+
+    /// Overwrites the value at the pointer using one non-tearing instruction.
+    ///
+    /// # Access rights
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn write_once(&self, val: &T) -> Result<()> {
+        self.vm_obj.write_once(self.offset, val)
     }
 }
 

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -22,6 +22,7 @@ buddy_system_allocator = "0.9.0"
 bitflags = "1.3"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 cfg-if = "1.0"
+const-assert = "1.0"
 gimli = { version = "0.28", default-features = false, features = ["read-core"] }
 id-alloc = { path = "libs/id-alloc", version = "0.1.0" }
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e", version = "0.1.0" }

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -574,7 +574,7 @@ impl<'a> VmWriter<'a, KernelSpace> {
             // hence the `add` operation and `write` operation are valid and will only manipulate
             // the memory managed by this writer.
             unsafe {
-                (self.cursor as *mut T).add(i).write(value);
+                (self.cursor as *mut T).add(i).write_volatile(value);
             }
         }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -461,7 +461,7 @@ impl<'a, Space> VmReader<'a, Space> {
     /// Skips the first `nbytes` bytes of data.
     /// The length of remaining data is decreased accordingly.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// If `nbytes` is greater than `self.remain()`, then the method panics.
     pub fn skip(mut self, nbytes: usize) -> Self {
@@ -557,7 +557,7 @@ impl<'a> VmWriter<'a, KernelSpace> {
     ///
     /// Returns the number of values written.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// The size of the available space must be a multiple of the size of `value`.
     /// Otherwise, the method would panic.
@@ -650,7 +650,7 @@ impl<'a, Space> VmWriter<'a, Space> {
     /// Skips the first `nbytes` bytes of data.
     /// The length of available space is decreased accordingly.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// If `nbytes` is greater than `self.avail()`, then the method panics.
     pub fn skip(mut self, nbytes: usize) -> Self {

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -28,7 +28,7 @@ use spin::Once;
 pub use self::{
     dma::{Daddr, DmaCoherent, DmaDirection, DmaStream, DmaStreamSlice, HasDaddr},
     frame::{options::FrameAllocOptions, Frame, Segment},
-    io::{KernelSpace, UserSpace, VmIo, VmReader, VmWriter},
+    io::{KernelSpace, PodOnce, UserSpace, VmIo, VmIoOnce, VmReader, VmWriter},
     page_prop::{CachePolicy, PageFlags, PageProperty},
     vm_space::VmSpace,
 };


### PR DESCRIPTION
Fix #1089 (#1103 doesn't really fix it, I can still reproduce it both locally and in the CI environment, but the problem goes away after this PR, so I think this PR actually fixes the problem)

Previously, memory operations on `DmaCoherent` generate `memmove` which copies the memory byte by byte:
https://github.com/asterinas/asterinas/blob/bdabea09c2ecc9a5fed6fe0bb0663e865d755ff0/kernel/comps/virtio/src/queue.rs#L283

The generated assembly code looks like this (after decompilation):
```c
                  lVar4 = (uVar7 * 0x1000 + *(long *)(*(long *)(lVar5 + 0x10) + 0x10) &
                          0xfffffffffffff000) - 0x800000000000;
                  lVar5 = lVar4 + uVar2;
                  uVar2 = (uVar10 + lVar4) - lVar5;
                  uVar7 = 4;
                  if (uVar2 < 4) {
                    uVar7 = uVar2;
                  }
                  compiler_builtins::mem::memmove(&local_34,lVar5,uVar7);
                  uVar10 = (ulong)local_34 << 0x20;
```
This is because such memory operations are performed by `VmReader::read`, which truncates the number of bytes to be copied by the number of available bytes:
https://github.com/asterinas/asterinas/blob/bdabea09c2ecc9a5fed6fe0bb0663e865d755ff0/ostd/src/mm/io.rs#L360-L364

This is obviously wrong. In the case of `DmaCoherent`, the buffer can be modified by the devices and read by Asterinas at the same time. For example, we check if there is a used element by loading the index, where the loading operation _must_ be a unit memory load instead of a `memove`. Otherwise the result of the load might be wrong, leading to wrong operations afterwards:
https://github.com/asterinas/asterinas/blob/bdabea09c2ecc9a5fed6fe0bb0663e865d755ff0/kernel/comps/virtio/src/queue.rs#L228-L234

This PR attempts to use [`ptr::read_volatile`](https://doc.rust-lang.org/std/ptr/fn.read_volatile.html) and [`ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html) to solve this problem. Unfortunately, the exact conditions under which these two methods emit a single load/store operation are not yet clear (the Rust community does not guarantee this at the time of writing). But in practice, they should issue one instruction when the access size is 1, 2, 4, 8 on x86_64. This is checked by the newly added `assert_unit_memory_access` method.

After this PR, the generated assembly code for the Rust code mentioned at the beginning looks like this (after decompilation):
```c
uVar9 = (ulong)*puVar7 << 0x20;
```
So calls to `memmove` have disappeared.