### PR TITLE
Make the behavior of `sys_execve` be consistent with Linux.

### DIFF
--- a/kernel/aster-nix/src/syscall/execve.rs
+++ b/kernel/aster-nix/src/syscall/execve.rs
@@ -159,6 +159,10 @@ fn read_cstring_vec(
     max_string_len: usize,
 ) -> Result<Vec<CString>> {
     let mut res = Vec::new();
+    // On Linux, argv pointer and envp pointer can be specified as NULL.
+    if array_ptr == 0 {
+        return Ok(res);
+    }
     let mut read_addr = array_ptr;
     let mut find_null = false;
     for _ in 0..max_string_number {


### PR DESCRIPTION
Currently, we force the argv pointer and envp pointer to be valid in `sys_execve` syscall. However, Linux allow these two pointers to be NULL. In the lmbench fork-exec test, the test program do `sys_execve` with a NULL envp pointer which will cause the syscall return due to the checking in `read_cstring_from_user` (This is why fork-exec test will be faster in Asterinas now). 