### PR TITLE
Implement atomic signal masks (`AtomicSigMask`) and refactor `SigSet`

### DIFF
--- a/kernel/aster-nix/src/process/clone.rs
+++ b/kernel/aster-nix/src/process/clone.rs
@@ -175,8 +175,10 @@ fn clone_child_thread(parent_context: &UserContext, clone_args: CloneArgs) -> Re
     let sig_mask = {
         let current_thread = current_thread!();
         let current_posix_thread = current_thread.as_posix_thread().unwrap();
-        let sigmask = current_posix_thread.sig_mask().lock();
-        *sigmask
+        current_posix_thread
+            .sig_mask()
+            .load(Ordering::Relaxed)
+            .into()
     };
 
     let child_tid = allocate_tid();
@@ -258,8 +260,7 @@ fn clone_child_process(
     let child_sig_mask = {
         let current_thread = current_thread!();
         let posix_thread = current_thread.as_posix_thread().unwrap();
-        let sigmask = posix_thread.sig_mask().lock();
-        *sigmask
+        posix_thread.sig_mask().load(Ordering::Relaxed).into()
     };
 
     // inherit parent's nice value

--- a/kernel/aster-nix/src/process/posix_thread/builder.rs
+++ b/kernel/aster-nix/src/process/posix_thread/builder.rs
@@ -9,7 +9,7 @@ use crate::{
     prelude::*,
     process::{
         posix_thread::name::ThreadName,
-        signal::{sig_mask::SigMask, sig_queues::SigQueues},
+        signal::{sig_mask::AtomicSigMask, sig_queues::SigQueues},
         Credentials, Process,
     },
     thread::{status::ThreadStatus, task, thread_table, Thread, Tid},
@@ -28,7 +28,7 @@ pub struct PosixThreadBuilder {
     thread_name: Option<ThreadName>,
     set_child_tid: Vaddr,
     clear_child_tid: Vaddr,
-    sig_mask: SigMask,
+    sig_mask: AtomicSigMask,
     sig_queues: SigQueues,
 }
 
@@ -42,7 +42,7 @@ impl PosixThreadBuilder {
             thread_name: None,
             set_child_tid: 0,
             clear_child_tid: 0,
-            sig_mask: SigMask::new_empty(),
+            sig_mask: AtomicSigMask::new_empty(),
             sig_queues: SigQueues::new(),
         }
     }
@@ -67,7 +67,7 @@ impl PosixThreadBuilder {
         self
     }
 
-    pub fn sig_mask(mut self, sig_mask: SigMask) -> Self {
+    pub fn sig_mask(mut self, sig_mask: AtomicSigMask) -> Self {
         self.sig_mask = sig_mask;
         self
     }
@@ -99,7 +99,7 @@ impl PosixThreadBuilder {
                 set_child_tid: Mutex::new(set_child_tid),
                 clear_child_tid: Mutex::new(clear_child_tid),
                 credentials,
-                sig_mask: Mutex::new(sig_mask),
+                sig_mask,
                 sig_queues,
                 sig_context: Mutex::new(None),
                 sig_stack: Mutex::new(None),

--- a/kernel/aster-nix/src/process/process/mod.rs
+++ b/kernel/aster-nix/src/process/process/mod.rs
@@ -9,7 +9,6 @@ use super::{
     signal::{
         constants::SIGCHLD,
         sig_disposition::SigDispositions,
-        sig_mask::SigMask,
         sig_num::{AtomicSigNum, SigNum},
         signals::Signal,
         Pauser,
@@ -120,12 +119,9 @@ impl Process {
         nice: Nice,
         sig_dispositions: Arc<Mutex<SigDispositions>>,
     ) -> Arc<Self> {
-        let children_pauser = {
-            // SIGCHID does not interrupt pauser. Child process will
-            // resume paused parent when doing exit.
-            let sigmask = SigMask::from(SIGCHLD);
-            Pauser::new_with_mask(sigmask)
-        };
+        // SIGCHID does not interrupt pauser. Child process will
+        // resume paused parent when doing exit.
+        let children_pauser = Pauser::new_with_mask(SIGCHLD.into());
 
         let prof_clock = ProfClock::new();
 

--- a/kernel/aster-nix/src/process/signal/sig_action.rs
+++ b/kernel/aster-nix/src/process/signal/sig_action.rs
@@ -28,7 +28,7 @@ impl TryFrom<sigaction_t> for SigAction {
             SIG_IGN => SigAction::Ign,
             _ => {
                 let flags = SigActionFlags::from_bits_truncate(input.flags);
-                let mask = SigMask::from(input.mask);
+                let mask = input.mask.into();
                 SigAction::User {
                     handler_addr: input.handler_ptr,
                     flags,
@@ -65,7 +65,7 @@ impl SigAction {
                 handler_ptr: *handler_addr,
                 flags: flags.as_u32(),
                 restorer_ptr: *restorer_addr,
-                mask: mask.as_u64(),
+                mask: (*mask).into(),
             },
         }
     }

--- a/kernel/aster-nix/src/process/signal/sig_queues.rs
+++ b/kernel/aster-nix/src/process/signal/sig_queues.rs
@@ -222,14 +222,14 @@ impl Queues {
         // Process standard signal queues
         for (idx, signal) in self.std_queues.iter().enumerate() {
             if signal.is_some() {
-                pending.add_signal(SigNum::from_u8(idx as u8 + MIN_STD_SIG_NUM));
+                pending += SigNum::from_u8(idx as u8 + MIN_STD_SIG_NUM);
             }
         }
 
         // Process real-time signal queues
         for (idx, signals) in self.rt_queues.iter().enumerate() {
             if !signals.is_empty() {
-                pending.add_signal(SigNum::from_u8(idx as u8 + MIN_RT_SIG_NUM));
+                pending += SigNum::from_u8(idx as u8 + MIN_RT_SIG_NUM);
             }
         }
 

--- a/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
@@ -26,8 +26,8 @@ pub fn sys_rt_sigsuspend(sigmask_addr: Vaddr, sigmask_size: usize) -> Result<Sys
         let mut mask: SigMask = read_val_from_user(sigmask_addr)?;
         // It is not possible to block SIGKILL or SIGSTOP,
         // specifying these signals in mask has no effect.
-        mask.remove_signal(SIGKILL);
-        mask.remove_signal(SIGSTOP);
+        mask -= SIGKILL;
+        mask -= SIGSTOP;
         mask
     };
 


### PR DESCRIPTION
As discussed in #1106 , the signal mask need to be atomic to improve performance. Also, the `SigSet` and `SigMask` is not differentiated in the current code base. This PR alters most of the usage of `SigMask` to `SigSet`, to improve soundness.

Meanwhile, this PR still allows threads other than the current thread to write to the mask, although it is definitely not advised to do so. The implementation will assume that only the current thread can write to the mask. So when modifying a mask, the old value is not fetched at the most appropriate time.