### PR TITLE
A failed attempt of generalizing single instruction CPU local operations

### DIFF
--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -122,13 +122,7 @@ SECTIONS
 
         # These 4 bytes are used to store the CPU ID.
         . += 4;
-
-        # These 4 bytes are used to store the number of preemption locks held.
-        # The reason is stated in the Rust documentation of
-        # [`ostd::task::processor::PreemptInfo`].
-        __cpu_local_preempt_lock_count = . - __cpu_local_start;
-        . += 4;
-
+        
         KEEP(*(SORT(.cpu_local)))
         __cpu_local_end = .;
     }

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn init_on_bsp() {
 
     // SAFETY: no CPU local objects have been accessed by this far. And
     // we are on the BSP.
-    unsafe { crate::cpu::cpu_local::init_on_bsp() };
+    unsafe { crate::cpu::local::init_on_bsp() };
 
     crate::boot::smp::boot_all_aps();
 

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -115,7 +115,7 @@ fn ap_early_entry(local_apic_id: u32) -> ! {
 
     // SAFETY: we are on the AP.
     unsafe {
-        cpu::cpu_local::init_on_ap(local_apic_id);
+        cpu::local::init_on_ap(local_apic_id);
     }
 
     trap::init();

--- a/ostd/src/cpu/local/single_instr.rs
+++ b/ostd/src/cpu/local/single_instr.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Extensions for CPU-local types that allows single-instruction operations.
+
+use super::CpuLocal;
+
+/// Architecture-specific implementations of single-instruction operations.
+///
+/// For some per-CPU objects, fetching or modifying the values of them can be
+/// done in a single instruction. Then we would avoid turning off interrupts
+/// when accessing them, which incurs non-trivial overhead.
+///
+/// This trait is the architecture-specific interface for single-instruction
+/// operations. The architecture-specific module can implement this trait for
+/// common integer types.
+///
+/// Currently we don't plan to implement most of the [`core::ops`] operations
+/// for the sake of simplicity. The status-quos are sufficient enough.
+pub trait SingleInstructionOps {
+    /// The right hand side type for the operations.
+    type Rhs;
+
+    /// Adds a value to the per-CPU object.
+    ///
+    /// This operation wraps on overflow.
+    ///
+    /// The offset of the object is relative to the base address of the CPU-
+    /// local storage.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure that the offset is valid to be written to.
+    /// This operation is not atomic. Accessing the same address from multiple
+    /// threads produces undefined behavior.
+    unsafe fn cpu_local_add_assign(offset: *mut Self, rhs: Self::Rhs);
+
+    /// Subtracts a value to the per-CPU object.
+    ///
+    /// This operation wraps on overflow.
+    ///
+    /// The offset of the object is relative to the base address of the CPU-
+    /// local storage.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure that the offset is valid to be written to.
+    /// This operation is not atomic. Accessing the same address from multiple
+    /// threads produces undefined behavior.
+    unsafe fn cpu_local_sub_assign(offset: *mut Self, rhs: Self::Rhs);
+
+    /// Gets the value of the per-CPU object.
+    ///
+    /// The offset of the object is relative to the base address of the CPU-
+    /// local storage.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure that the offset is valid to be read from.
+    /// This operation is not atomic. Accessing the same address from multiple
+    /// threads produces undefined behavior.
+    unsafe fn cpu_local_read(offset: *const Self) -> Self;
+
+    /// Writes a value to the per-CPU object.
+    ///
+    /// The offset of the object is relative to the base address of the CPU-
+    /// local storage.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure that the offset is valid to be written to.
+    /// This operation is not atomic. Accessing the same address from multiple
+    /// threads produces undefined behavior.
+    unsafe fn cpu_local_write(offset: *mut Self, val: Self);
+}
+
+impl<T: SingleInstructionOps> CpuLocal<T> {
+    /// Adds a value to the per-CPU object in a single instruction.
+    ///
+    /// # Safety
+    ///
+    /// Since the operation does not forbid shared references, the caller
+    /// should ensure that the object is not accessed by multiple tasks.
+    /// The safety requirement for the object is the same as [`UnsafeCell`].
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub unsafe fn add_assign(&self, rhs: T::Rhs) {
+        // SAFETY: The CPU-local object is defined in the `.cpu_local` section,
+        // so the pointer to the object is valid.
+        unsafe {
+            T::cpu_local_add_assign(self as *const _ as usize as *mut T, rhs);
+        }
+    }
+
+    /// Subtracts a value to the per-CPU object in a single instruction.
+    ///
+    /// # Safety
+    ///
+    /// Since the operation does not forbid shared references, the caller
+    /// should ensure that the object is not accessed by multiple tasks.
+    /// The safety requirement for the object is the same as [`UnsafeCell`].
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub unsafe fn sub_assign(&self, rhs: T::Rhs) {
+        // SAFETY: The CPU-local object is defined in the `.cpu_local` section,
+        // so the pointer to the object is valid.
+        unsafe {
+            T::cpu_local_sub_assign(self as *const _ as usize as *mut T, rhs);
+        }
+    }
+
+    /// Gets the value of the per-CPU object in a single instruction.
+    ///
+    /// # Safety
+    ///
+    /// Since the operation does not forbid shared references, the caller
+    /// should ensure that the object is not accessed by multiple tasks.
+    /// The safety requirement for the object is the same as [`UnsafeCell`].
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub unsafe fn read(&self) -> T {
+        // SAFETY: The CPU-local object is defined in the `.cpu_local` section,
+        // so the pointer to the object is valid.
+        unsafe { T::cpu_local_read(self as *const _ as usize as *const T) }
+    }
+
+    /// Writes a value to the per-CPU object in a single instruction.
+    ///
+    /// # Safety
+    ///
+    /// Since the operation does not forbid shared references, the caller
+    /// should ensure that the object is not accessed by multiple tasks.
+    /// The safety requirement for the object is the same as [`UnsafeCell`].
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub unsafe fn write(&mut self, val: T) {
+        // SAFETY: The CPU-local object is defined in the `.cpu_local` section,
+        // so the pointer to the object is valid.
+        unsafe {
+            T::cpu_local_write(self as *const _ as usize as *mut T, val);
+        }
+    }
+}

--- a/ostd/src/cpu/mod.rs
+++ b/ostd/src/cpu/mod.rs
@@ -2,7 +2,7 @@
 
 //! CPU-related definitions.
 
-pub mod cpu_local;
+pub mod local;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")]{
@@ -18,7 +18,7 @@ use bitvec::{
     slice::IterOnes,
 };
 
-use crate::{arch::boot::smp::get_num_processors, cpu};
+use crate::arch::{self, boot::smp::get_num_processors};
 
 /// The number of CPUs. Zero means uninitialized.
 static NUM_CPUS: AtomicU32 = AtomicU32::new(0);
@@ -47,7 +47,7 @@ pub fn num_cpus() -> u32 {
 pub fn this_cpu() -> u32 {
     // SAFETY: the cpu ID is stored at the beginning of the cpu local area, provided
     // by the linker script.
-    unsafe { (cpu::local::get_base() as usize as *mut u32).read() }
+    unsafe { (arch::cpu::local::get_base() as usize as *mut u32).read() }
 }
 
 /// A subset of all CPUs in the system.

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -46,7 +46,7 @@ pub mod user;
 pub use ostd_macros::main;
 pub use ostd_pod::Pod;
 
-pub use self::{cpu::cpu_local::CpuLocal, error::Error, prelude::Result};
+pub use self::{cpu::local::CpuLocal, error::Error, prelude::Result};
 
 /// Initializes OSTD.
 ///
@@ -64,7 +64,7 @@ pub fn init() {
     arch::check_tdx_init();
 
     // SAFETY: This function is called only once and only on the BSP.
-    unsafe { cpu::cpu_local::early_init_bsp_local_base() };
+    unsafe { cpu::local::early_init_bsp_local_base() };
 
     mm::heap_allocator::init();
 

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -8,7 +8,7 @@ use super::{
     task::{context_switch, TaskContext},
     Task, TaskStatus,
 };
-use crate::{arch, cpu_local};
+use crate::{cpu::local::PREEMPT_LOCK_COUNT, cpu_local};
 
 pub struct Processor {
     current: Option<Arc<Task>>,
@@ -91,10 +91,12 @@ pub fn preempt(task: &Arc<Task>) {
 ///
 /// before context switch, current task will switch to the next task
 fn switch_to_task(next_task: Arc<Task>) {
-    if !PREEMPT_COUNT.is_preemptive() {
+    // SAFETY: The value is only accessed in the current CPU.
+    let preemt_lock_count = unsafe { PREEMPT_LOCK_COUNT.read() };
+    if preemt_lock_count != 0 {
         panic!(
             "Calling schedule() while holding {} locks",
-            PREEMPT_COUNT.num_locks()
+            preemt_lock_count
         );
     }
 
@@ -151,53 +153,6 @@ fn switch_to_task(next_task: Arc<Task>) {
     // to the next task switching.
 }
 
-static PREEMPT_COUNT: PreemptInfo = PreemptInfo::new();
-
-/// Currently, it only holds the number of preemption locks held by the
-/// current CPU. When it has a non-zero value, the CPU cannot call
-/// [`schedule()`].
-///
-/// For per-CPU preemption lock count, we cannot afford two non-atomic
-/// operations to increment and decrement the count. The [`crate::cpu_local`]
-/// implementation is free to read the base register and then calculate the
-/// address of the per-CPU variable using an additional instruction. Interrupts
-/// can happen between the address calculation and modification to that
-/// address. If the task is preempted to another CPU by this interrupt, the
-/// count of the original CPU will be mistakenly modified. To avoid this, we
-/// introduce [`crate::arch::cpu::local::preempt_lock_count`]. For x86_64 we
-/// can implement this using one instruction. In other less expressive
-/// architectures, we may need to disable interrupts.
-///
-/// Also, the preemption count is reserved in the `.cpu_local` section
-/// specified in the linker script. The reason is that we need to access the
-/// preemption count before we can copy the section for application processors.
-/// So, the preemption count is not copied from bootstrap processor's section
-/// as the initialization. Instead it is initialized to zero for application
-/// processors.
-struct PreemptInfo {}
-
-impl PreemptInfo {
-    const fn new() -> Self {
-        Self {}
-    }
-
-    fn increase_num_locks(&self) {
-        arch::cpu::local::preempt_lock_count::inc();
-    }
-
-    fn decrease_num_locks(&self) {
-        arch::cpu::local::preempt_lock_count::dec();
-    }
-
-    fn is_preemptive(&self) -> bool {
-        arch::cpu::local::preempt_lock_count::get() == 0
-    }
-
-    fn num_locks(&self) -> usize {
-        arch::cpu::local::preempt_lock_count::get() as usize
-    }
-}
-
 /// A guard for disable preempt.
 #[clippy::has_significant_drop]
 #[must_use]
@@ -210,7 +165,8 @@ impl !Send for DisablePreemptGuard {}
 
 impl DisablePreemptGuard {
     fn new() -> Self {
-        PREEMPT_COUNT.increase_num_locks();
+        // SAFETY: The value is only accessed in the current CPU.
+        unsafe { PREEMPT_LOCK_COUNT.add_assign(1) };
         Self { _private: () }
     }
 
@@ -223,7 +179,8 @@ impl DisablePreemptGuard {
 
 impl Drop for DisablePreemptGuard {
     fn drop(&mut self) {
-        PREEMPT_COUNT.decrease_num_locks();
+        // SAFETY: The value is only accessed in the current CPU.
+        unsafe { PREEMPT_LOCK_COUNT.sub_assign(1) };
     }
 }
 


### PR DESCRIPTION
This PR is to demonstrate why I have failed to generalize the technique shown by #1073 . The motivation to generalize the single instruction CPU local operations is that not only the `PREEMPT_COUNT` should be implemented with a single instruction, the upcoming optimization of `current!` depends on it as well.

Then I'll explain why it failed. For a global variable (let's say `A`), the address of `A` is known at link-time and the address can be known at runtime in the code by casting the reference to the global variable to a pointer (`&A as *const _`). However, operations on CPU local objects need to know the offset of the pointer from the beginning of the section `.cpu_local`. If we calculate the offset dynamically using another instruction (`read(&A as *const _  as usize - cpu_local_start)`) then we failed. The offset sure can be known at link-time, but it is only possible to utilize this link-time implementation by 1) defining the variable using procedural macro, and 2) operate on the variable using procedural macros. Such an approach will lead to much hard-to-understand code. And if the user has not used the operating macros correctly, it will give error only at link-time. Link time errors are mind-blowingly hard to understand.

~~So that's why I give up. The `current!` optimization might as well be done in an ad-hoc way like #1073. The preferred PR is pending.~~

EDIT: actually I find it working, closing.