### PR TITLE
Make `current!` fast

### DIFF
--- a/kernel/aster-nix/src/thread/mod.rs
+++ b/kernel/aster-nix/src/thread/mod.rs
@@ -56,7 +56,7 @@ impl Thread {
     /// when writing code that can be called directly by unit tests. If this isn't the case,
     /// consider using [`current_thread!`] instead.
     pub fn current() -> Option<Arc<Self>> {
-        Task::current()
+        Task::current_on_processor()
             .data()
             .downcast_ref::<Weak<Thread>>()?
             .upgrade()

--- a/kernel/aster-nix/src/thread/task.rs
+++ b/kernel/aster-nix/src/thread/task.rs
@@ -22,7 +22,7 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Weak<Thread>
         let user_space = current_task
             .user_space()
             .expect("user task should have user space");
-        let mut user_mode = UserMode::new(user_space);
+        let mut user_mode = UserMode::new(&Task::current(), user_space);
         debug!(
             "[Task entry] rip = 0x{:x}",
             user_mode.context().instruction_pointer()

--- a/kernel/aster-nix/src/util/mod.rs
+++ b/kernel/aster-nix/src/util/mod.rs
@@ -5,7 +5,7 @@ use core::mem;
 use aster_rights::Full;
 use ostd::{
     mm::{KernelSpace, VmIo, VmReader, VmWriter},
-    task::current_task,
+    task::{current_task, CurrentTaskError},
 };
 
 use crate::{prelude::*, vm::vmar::Vmar};
@@ -34,10 +34,14 @@ pub fn read_bytes_from_user(src: Vaddr, dest: &mut VmWriter<'_>) -> Result<()> {
         check_vaddr(src)?;
     }
 
-    let current_task = current_task().ok_or(Error::with_message(
-        Errno::EFAULT,
-        "the current task is missing",
-    ))?;
+    let current_task = current_task().map_err(|e| match e {
+        CurrentTaskError::NotAvailable => {
+            Error::with_message(Errno::EFAULT, "the current task is missing")
+        }
+        CurrentTaskError::InInterruptContext => {
+            panic!("`read_bytes_from_user` called from interrupt context")
+        }
+    })?;
     let user_space = current_task.user_space().ok_or(Error::with_message(
         Errno::EFAULT,
         "the user space is missing",
@@ -54,10 +58,14 @@ pub fn read_val_from_user<T: Pod>(src: Vaddr) -> Result<T> {
         check_vaddr(src)?;
     }
 
-    let current_task = current_task().ok_or(Error::with_message(
-        Errno::EFAULT,
-        "the current task is missing",
-    ))?;
+    let current_task = current_task().map_err(|e| match e {
+        CurrentTaskError::NotAvailable => {
+            Error::with_message(Errno::EFAULT, "the current task is missing")
+        }
+        CurrentTaskError::InInterruptContext => {
+            panic!("`read_bytes_from_user` called from interrupt context")
+        }
+    })?;
     let user_space = current_task.user_space().ok_or(Error::with_message(
         Errno::EFAULT,
         "the user space is missing",
@@ -88,10 +96,14 @@ pub fn write_bytes_to_user(dest: Vaddr, src: &mut VmReader<'_, KernelSpace>) -> 
         check_vaddr(dest)?;
     }
 
-    let current_task = current_task().ok_or(Error::with_message(
-        Errno::EFAULT,
-        "the current task is missing",
-    ))?;
+    let current_task = current_task().map_err(|e| match e {
+        CurrentTaskError::NotAvailable => {
+            Error::with_message(Errno::EFAULT, "the current task is missing")
+        }
+        CurrentTaskError::InInterruptContext => {
+            panic!("`read_bytes_from_user` called from interrupt context")
+        }
+    })?;
     let user_space = current_task.user_space().ok_or(Error::with_message(
         Errno::EFAULT,
         "the user space is missing",
@@ -108,10 +120,14 @@ pub fn write_val_to_user<T: Pod>(dest: Vaddr, val: &T) -> Result<()> {
         check_vaddr(dest)?;
     }
 
-    let current_task = current_task().ok_or(Error::with_message(
-        Errno::EFAULT,
-        "the current task is missing",
-    ))?;
+    let current_task = current_task().map_err(|e| match e {
+        CurrentTaskError::NotAvailable => {
+            Error::with_message(Errno::EFAULT, "the current task is missing")
+        }
+        CurrentTaskError::InInterruptContext => {
+            panic!("`read_bytes_from_user` called from interrupt context")
+        }
+    })?;
     let user_space = current_task.user_space().ok_or(Error::with_message(
         Errno::EFAULT,
         "the user space is missing",

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -129,6 +129,13 @@ SECTIONS
         __cpu_local_preempt_lock_count = . - __cpu_local_start;
         . += 4;
 
+        # These 4 bytes are used to store the raw pointer form of
+        # `Arc<ostd::Task>`.
+        # It is to accelerate `ostd::Task::current()` accesses by using one
+        # instruction, then we don't need to disable interrupts or preemption.
+        __cpu_local_current_task_ptr = . - __cpu_local_start;
+        . += 8;
+
         KEEP(*(SORT(.cpu_local)))
         __cpu_local_end = .;
     }

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -230,7 +230,7 @@ pub fn trace_panic_from_log(qemu_log: File, bin_path: PathBuf) {
         .spawn()
         .unwrap();
     for line in lines.into_iter().rev() {
-        if line.contains("printing stack trace:") {
+        if line.contains("Printing stack trace:") {
             println!("[OSDK] The kernel seems panicked. Parsing stack trace for source lines:");
             trace_exists = true;
         }

--- a/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
+++ b/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
@@ -77,7 +77,7 @@ fn create_user_task(user_space: Arc<UserSpace>) -> Arc<Task> {
         // performed via the UserMode abstraction.
         let mut user_mode = {
             let user_space = current.user_space().unwrap();
-            UserMode::new(user_space)
+            UserMode::new(&current, user_space)
         };
 
         loop {

--- a/ostd/libs/ostd-test/src/lib.rs
+++ b/ostd/libs/ostd-test/src/lib.rs
@@ -103,6 +103,7 @@ pub struct PanicInfo {
     pub file: String,
     pub line: usize,
     pub col: usize,
+    pub resolve_panic: fn(),
 }
 
 impl core::fmt::Display for PanicInfo {
@@ -174,6 +175,7 @@ impl KtestItem {
                 Ok(()) => Err(KtestError::ShouldPanicButNoPanic),
                 Err(e) => match e.downcast::<PanicInfo>() {
                     Ok(s) => {
+                        (s.resolve_panic)();
                         if let Some(expected) = self.should_panic.1 {
                             if s.message == expected {
                                 Ok(())

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -48,6 +48,7 @@ use crate::{
 /// A `VmSpace` can also attach a page fault handler, which will be invoked to
 /// handle page faults generated from user space.
 #[allow(clippy::type_complexity)]
+#[derive(Debug)]
 pub struct VmSpace {
     pt: PageTable<UserMode>,
     page_fault_handler: Once<fn(&VmSpace, &CpuExceptionInfo) -> core::result::Result<(), ()>>,

--- a/ostd/src/panicking.rs
+++ b/ostd/src/panicking.rs
@@ -2,11 +2,14 @@
 
 //! Panic support.
 
-use core::ffi::c_void;
+use core::{
+    ffi::c_void,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::{
     arch::qemu::{exit_qemu, QemuExitCode},
-    early_print, early_println,
+    cpu_local, early_print, early_println,
 };
 
 extern crate cfg_if;
@@ -17,12 +20,25 @@ use unwinding::abi::{
     _Unwind_GetGR, _Unwind_GetIP,
 };
 
+cpu_local! {
+    static IN_PANIC: AtomicBool = AtomicBool::new(false);
+}
+
 /// The panic handler must be defined in the binary crate or in the crate that the binary
 /// crate explicity declares by `extern crate`. We cannot let the base crate depend on OSTD
 /// due to prismatic dependencies. That's why we export this symbol and state the
 /// panic handler in the binary crate.
 #[export_name = "__aster_panic_handler"]
 pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    if IN_PANIC
+        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        early_println!("{}", info);
+        early_println!("The panic handler panicked when processing the above panic. Aborting.");
+        abort();
+    }
+
     // If in ktest, we would like to catch the panics and resume the test.
     #[cfg(ktest)]
     {
@@ -35,12 +51,15 @@ pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             file: info.location().unwrap().file().to_string(),
             line: info.location().unwrap().line() as usize,
             col: info.location().unwrap().column() as usize,
+            resolve_panic: || {
+                IN_PANIC.store(false, Ordering::Relaxed);
+            },
         };
         // Throw an exception and expecting it to be caught.
         begin_panic(Box::new(throw_info.clone()));
     }
     early_println!("{}", info);
-    early_println!("printing stack trace:");
+    early_println!("Printing stack trace:");
     print_stack_trace();
     abort();
 }

--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -4,7 +4,7 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use super::SpinLock;
-use crate::task::{add_task, current_task, schedule, Task, TaskStatus};
+use crate::task::{add_task, current_task_on_processor, schedule, Task, TaskStatus};
 
 // # Explanation on the memory orders
 //
@@ -209,7 +209,7 @@ impl Waiter {
     pub fn new_pair() -> (Self, Arc<Waker>) {
         let waker = Arc::new(Waker {
             has_woken: AtomicBool::new(false),
-            task: current_task().unwrap(),
+            task: current_task_on_processor().unwrap(),
         });
         let waiter = Self {
             waker: waker.clone(),

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -10,7 +10,10 @@ mod task;
 
 pub use self::{
     priority::Priority,
-    processor::{current_task, disable_preempt, preempt, schedule, DisablePreemptGuard},
+    processor::{
+        current_task, current_task_on_processor, disable_preempt, preempt, schedule,
+        CurrentTaskError, CurrentTaskRef, DisablePreemptGuard,
+    },
     scheduler::{add_task, set_scheduler, FifoScheduler, Scheduler},
     task::{Task, TaskAdapter, TaskContextApi, TaskOptions, TaskStatus},
 };

--- a/ostd/src/task/priority.rs
+++ b/ostd/src/task/priority.rs
@@ -7,7 +7,7 @@ pub const REAL_TIME_TASK_PRIORITY: u16 = 100;
 /// Similar to Linux, a larger value represents a lower priority,
 /// with a range of 0 to 139. Priorities ranging from 0 to 99 are considered real-time,
 /// while those ranging from 100 to 139 are considered normal.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Priority(u16);
 
 impl Priority {

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -22,10 +22,10 @@ pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame, irq_number: us
 
     crate::arch::interrupts_ack(irq_number);
 
-    IN_INTERRUPT_CONTEXT.store(false, Ordering::Release);
-
     crate::arch::irq::enable_local();
     crate::trap::softirq::process_pending();
+
+    IN_INTERRUPT_CONTEXT.store(false, Ordering::Release);
 }
 
 cpu_local! {
@@ -33,9 +33,6 @@ cpu_local! {
 }
 
 /// Returns whether we are in the interrupt context.
-///
-/// FIXME: Here only hardware irq is taken into account. According to linux implementation, if
-/// we are in softirq context, or bottom half is disabled, this function also returns true.
 pub fn in_interrupt_context() -> bool {
     IN_INTERRUPT_CONTEXT.load(Ordering::Acquire)
 }


### PR DESCRIPTION
This PR intends to optimize the current task/thread/process API by a single-instruction operation CPU local field.

Now it only implements the API. `aster-nix` have not got it into full use yet.

Fix #1108 , improves #1105 , prefer this than #1122 and #1108 