### PR TITLE
Implement MADV_FREE in madvise

### DIFF
--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -21,9 +21,22 @@ pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallRet
         MadviseBehavior::MADV_DONTNEED => {
             warn!("MADV_DONTNEED isn't implemented, do nothing for now.");
         }
+        MadviseBehavior::MADV_FREE => madv_free(start, len)?,
         _ => todo!(),
     }
     Ok(SyscallReturn::Return(0))
+}
+
+fn madv_free(start: Vaddr, len: usize) -> Result<()> {
+    debug_assert!(start % PAGE_SIZE == 0);
+    debug_assert!(len % PAGE_SIZE == 0);
+
+    let current = current!();
+    let root_vmar = current.root_vmar();
+    let advised_range = start..start + len;
+    let _ = root_vmar.destroy(advised_range);
+
+    Ok(())
 }
 
 #[repr(i32)]


### PR DESCRIPTION
This PR adds MADV_FREE to the `madvise`, which works similarly to MADV_DONTNEED. 

Additionally, the implementation of MADV_DONTNEED requires some refactoring because applications may access the affected memory region in the future. This access would trigger a `page fault handler failed` error since the current implementation does not allocate new pages for this region. For example, in Redis:

![image](https://github.com/user-attachments/assets/2114a808-e871-4b0f-85b6-2dfa10aad7c5)
