### PR TITLE
Fix README of OSDK

### DIFF
--- a/osdk/README.md
+++ b/osdk/README.md
@@ -56,12 +56,12 @@ Here we provide a simple demo to demonstrate how to create and run a simple kern
 
 With `cargo-osdk`, a kernel project can be created by one command
 ```bash
-cargo osdk new --kernel my-first-os
+cargo osdk new --kernel myos
 ```
 
 Then, you can run the kernel with
 ```bash
-cd my-first-os && cargo osdk run
+cd myos && cargo osdk run
 ```
 
 You will see `Hello world from guest kernel!` from your console. 


### PR DESCRIPTION
The user should not use `cargo osdk new` to create crate whose name contains `-`.

If user executes the command as the original README.md, it will panic in src/commands/new/mod.rs:177

```
root@tca:~/asterinas# cargo osdk new --kernel my-first-os
    Creating library `my-first-os` package
      Adding `my-first-os` as member of workspace at `/root/asterinas`
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
thread 'main' panicked at src/commands/new/mod.rs:177:5:
the crate name does not match with any target
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

https://github.com/asterinas/asterinas/blob/b1ea422efaf6b0becd7d6cd99d270ae01fcd12de/osdk/src/commands/new/mod.rs#L163-L178

This is caused by the convert from `-` to `_`, as a result, OSDK cannot match crate_name in the loop.

The conversion happened in `get_cargo_metadata()`:
https://github.com/asterinas/asterinas/blob/b1ea422efaf6b0becd7d6cd99d270ae01fcd12de/osdk/src/util.rs#L41-L64  

Here OSDK runs `cargo metadata --no-deps --format-version 1`, and get the result as:
```json
{
      "name": "my-first-os",
      "version": "0.1.0",
      "id": "path+file:///root/asterinas/my-first-os#0.1.0",
      "license": null,
      "license_file": null,
      "description": null,
      "source": null,
      "dependencies": [],
      "targets": [
        {
          "kind": [
            "lib"
          ],
          "crate_types": [
            "lib"
          ],
          "name": "my_first_os",
          "src_path": "/root/asterinas/my-first-os/src/lib.rs",
          "edition": "2021",
          "doc": true,
          "doctest": true,
          "test": true
        }
      ],
```

Finally, in `get_src_path`, the `name` variable is from the `targets`, `name` keywords, which is `my_first_os` here.