### PR TITLE
Fix panic when OSDK creating crate with `-` in its name

### DIFF
--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -163,18 +163,13 @@ fn get_manifest_path<'a>(cargo_metadata: &'a serde_json::Value, crate_name: &str
 fn get_src_path<'a>(cargo_metadata: &'a serde_json::Value, crate_name: &str) -> &'a str {
     let metadata = get_package_metadata(cargo_metadata, crate_name);
     let targets = metadata.get("targets").unwrap().as_array().unwrap();
-
-    for target in targets {
-        let name = target.get("name").unwrap().as_str().unwrap();
-        if name != crate_name {
-            continue;
-        }
-
+    if targets.len() == 1 {
+        let target = &targets[0];
         let src_path = target.get("src_path").unwrap();
         return src_path.as_str().unwrap();
     }
 
-    panic!("the crate name does not match with any target");
+    panic!("there is no target generated");
 }
 
 fn get_workspace_root(cargo_metadata: &serde_json::Value) -> &str {

--- a/osdk/src/commands/new/mod.rs
+++ b/osdk/src/commands/new/mod.rs
@@ -163,13 +163,14 @@ fn get_manifest_path<'a>(cargo_metadata: &'a serde_json::Value, crate_name: &str
 fn get_src_path<'a>(cargo_metadata: &'a serde_json::Value, crate_name: &str) -> &'a str {
     let metadata = get_package_metadata(cargo_metadata, crate_name);
     let targets = metadata.get("targets").unwrap().as_array().unwrap();
-    if targets.len() == 1 {
-        let target = &targets[0];
-        let src_path = target.get("src_path").unwrap();
-        return src_path.as_str().unwrap();
-    }
+    assert!(
+        targets.len() == 1,
+        "there must be one and only one target generated"
+    );
 
-    panic!("there is no target generated");
+    let target = &targets[0];
+    let src_path = target.get("src_path").unwrap();
+    return src_path.as_str().unwrap();
 }
 
 fn get_workspace_root(cargo_metadata: &serde_json::Value) -> &str {

--- a/osdk/tests/cli/mod.rs
+++ b/osdk/tests/cli/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use std::fs;
+
 use crate::util::*;
 
 #[test]
@@ -49,4 +51,14 @@ fn cli_clippy_help_message() {
     let output = cargo_osdk(&["clippy", "-h"]).output().unwrap();
     assert_success(&output);
     assert_stdout_contains_msg(&output, "cargo osdk clippy");
+}
+
+#[test]
+fn cli_new_crate_with_hyphen() {
+    let output = cargo_osdk(&["new", "--kernel", "my-first-os"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert!(fs::metadata("my-first-os").is_ok());
+    fs::remove_dir_all("my-first-os");
 }


### PR DESCRIPTION
This should fix #1135 

Since `get_src_path()` is only called during the `cargo osdk new` process, its target is only one here. It looks like we do not need to traverse the `targets` array.

The OSDK supports creating crate with - now.
```
root@tca:~/asterinas# cargo osdk new --kernel my-first-os
args.crate_name: my-first-os
cargo_new_lib: my-first-os
    Creating library `my-first-os` package
      Adding `my-first-os` as member of workspace at `/root/asterinas`
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
Current directory: "my-first-os"

root@tca:~# cargo osdk new --kernel my-first-os
args.crate_name: my-first-os
cargo_new_lib: my-first-os
    Creating library `my-first-os` package
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
Current directory: "my-first-os"
```