### PR TITLE
Support sigmask in pselect6

### DIFF
--- a/kernel/aster-nix/src/process/signal/sig_mask.rs
+++ b/kernel/aster-nix/src/process/signal/sig_mask.rs
@@ -186,6 +186,11 @@ impl AtomicSigSet {
         self.0.store(new_mask.into().bits, ordering);
     }
 
+    pub fn swap(&self, new_mask: impl Into<SigMask>, ordering: Ordering) -> SigSet {
+        let bits = self.0.swap(new_mask.into().bits, ordering);
+        SigSet { bits }
+    }
+
     pub fn contains(&self, signals: impl Into<SigSet>, ordering: Ordering) -> bool {
         SigSet {
             bits: self.0.load(ordering),

--- a/kernel/aster-nix/src/syscall/nanosleep.rs
+++ b/kernel/aster-nix/src/syscall/nanosleep.rs
@@ -54,7 +54,7 @@ fn do_clock_nanosleep(
 ) -> Result<SyscallReturn> {
     let request_time = {
         let timespec = read_val_from_user::<timespec_t>(request_timespec_addr)?;
-        Duration::from(timespec)
+        Duration::try_from(timespec)?
     };
 
     debug!(

--- a/kernel/aster-nix/src/syscall/pselect6.rs
+++ b/kernel/aster-nix/src/syscall/pselect6.rs
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::sync::atomic::Ordering;
+
 use super::{select::sys_select, SyscallReturn};
-use crate::{fs::file_table::FileDesc, prelude::*};
+use crate::{
+    fs::file_table::FileDesc,
+    prelude::*,
+    process::{posix_thread::PosixThreadExt, signal::sig_mask::SigMask},
+    util::read_val_from_user,
+};
 
 pub fn sys_pselect6(
     nfds: FileDesc,
@@ -11,17 +18,29 @@ pub fn sys_pselect6(
     timeval_addr: Vaddr,
     sigmask_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    // TODO: Support signal mask
-    if sigmask_addr != 0 {
-        error!("[SYS_PSELECT6] Not support sigmask now");
-        return Err(Error::new(Errno::ENOSYS));
-    }
+    let current_thread = current_thread!();
+    let posix_thread = current_thread.as_posix_thread().unwrap();
 
-    sys_select(
+    let old_simask = if sigmask_addr != 0 {
+        let new_sigmask: SigMask = read_val_from_user(sigmask_addr)?;
+        let old_sigmask = posix_thread.sig_mask().swap(new_sigmask, Ordering::Relaxed);
+
+        Some(old_sigmask)
+    } else {
+        None
+    };
+
+    let res = sys_select(
         nfds,
         readfds_addr,
         writefds_addr,
         exceptfds_addr,
         timeval_addr,
-    )
+    );
+
+    if let Some(old_mask) = old_simask {
+        posix_thread.sig_mask().store(old_mask, Ordering::Relaxed);
+    }
+
+    res
 }

--- a/kernel/aster-nix/src/syscall/timer_settime.rs
+++ b/kernel/aster-nix/src/syscall/timer_settime.rs
@@ -20,8 +20,8 @@ pub fn sys_timer_settime(
     }
 
     let new_itimerspec = read_val_from_user::<itimerspec_t>(new_itimerspec_addr)?;
-    let interval = Duration::from(new_itimerspec.it_interval);
-    let expire_time = Duration::from(new_itimerspec.it_value);
+    let interval = Duration::try_from(new_itimerspec.it_interval)?;
+    let expire_time = Duration::try_from(new_itimerspec.it_value)?;
 
     let current_process = current!();
     let Some(timer) = current_process.timer_manager().find_posix_timer(timer_id) else {

--- a/kernel/aster-nix/src/syscall/utimens.rs
+++ b/kernel/aster-nix/src/syscall/utimens.rs
@@ -120,14 +120,14 @@ fn vfs_utimes(dentry: &Arc<Dentry>, times: Option<TimeSpecPair>) -> Result<Sysca
             } else if times.atime.is_utime_now() {
                 now
             } else {
-                Duration::from(times.atime)
+                Duration::try_from(times.atime)?
             };
             let mtime = if times.mtime.is_utime_omit() {
                 dentry.mtime()
             } else if times.mtime.is_utime_now() {
                 now
             } else {
-                Duration::from(times.mtime)
+                Duration::try_from(times.mtime)?
             };
             (atime, mtime, now)
         }

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -28,6 +28,7 @@ TESTS ?= \
 	open_test \
 	pread64_test \
 	preadv2_test \
+	pselect_test \
 	pwrite64_test \
 	pwritev2_test \
 	pty_test \

--- a/test/syscall_test/blocklists/pselect_test
+++ b/test/syscall_test/blocklists/pselect_test
@@ -1,0 +1,4 @@
+PselectTest.NoTimeout_NoRandomSave
+PselectTest.NullFds
+PselectTest.SignalMaskBlocksSignal
+PselectTest.SignalMaskAllowsSignal


### PR DESCRIPTION
This feature is required when running python 3.10