### PR TITLE
Allow the page table un-mapper to flush the TLB precisely

### DIFF
--- a/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
+++ b/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
@@ -5,9 +5,7 @@
 
 use core::ops::Range;
 
-use ostd::mm::{
-    vm_space::VmQueryResult, CachePolicy, Frame, PageFlags, PageProperty, VmIo, VmSpace,
-};
+use ostd::mm::{vm_space::VmItem, CachePolicy, Frame, PageFlags, PageProperty, VmIo, VmSpace};
 
 use super::{interval::Interval, is_intersected, Vmar, Vmar_};
 use crate::{
@@ -221,12 +219,12 @@ impl VmMapping {
                 drop(cursor);
 
                 match map_info {
-                    VmQueryResult::Mapped { va, prop, .. } => {
+                    VmItem::Mapped { va, prop, .. } => {
                         if !prop.flags.contains(PageFlags::W) {
                             self.handle_page_fault(va, false, true)?;
                         }
                     }
-                    VmQueryResult::NotMapped { va, .. } => {
+                    VmItem::NotMapped { va, .. } => {
                         self.handle_page_fault(va, true, true)?;
                     }
                 }

--- a/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
+++ b/kernel/aster-nix/src/vm/vmar/vm_mapping.rs
@@ -538,7 +538,7 @@ impl VmMappingInner {
         debug_assert!(range.start % PAGE_SIZE == 0);
         debug_assert!(range.end % PAGE_SIZE == 0);
         let mut cursor = vm_space.cursor_mut(&range).unwrap();
-        cursor.protect(range.len(), |p| p.flags = perms.into(), true)?;
+        cursor.protect(range.len(), |p| p.flags = perms.into());
         Ok(())
     }
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 mod node;
 use node::*;
 pub mod cursor;
-pub use cursor::{Cursor, CursorMut, PageTableQueryResult};
+pub use cursor::{Cursor, CursorMut, PageTableItem};
 #[cfg(ktest)]
 mod test;
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -213,11 +213,6 @@ where
         Ok(())
     }
 
-    pub unsafe fn unmap(&self, vaddr: &Range<Vaddr>) -> Result<(), PageTableError> {
-        self.cursor_mut(vaddr)?.unmap(vaddr.len());
-        Ok(())
-    }
-
     pub unsafe fn protect(
         &self,
         vaddr: &Range<Vaddr>,
@@ -296,7 +291,7 @@ pub(super) unsafe fn page_walk<E: PageTableEntryTrait, C: PagingConstsTrait>(
 ) -> Option<(Paddr, PageProperty)> {
     use super::paddr_to_vaddr;
 
-    let preempt_guard = crate::task::disable_preempt();
+    let _guard = crate::trap::disable_local();
 
     let mut cur_level = C::NR_LEVELS;
     let mut cur_pte = {


### PR DESCRIPTION
Now the `page_table::Cursor::unmap` method is replaced with `page_table::Cursor::take_next`, which only unmaps at most a page. The caller is then enabled to decide how to flush the TLB entries.