### PR TITLE
Adjust cargo check script in rust analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,15 @@
 {
-    "rust-analyzer.check.allTargets": false,
     "rust-analyzer.cargo.target": "x86_64-unknown-none",
-    "rust-analyzer.check.extraArgs": [
+    "rust-analyzer.check.extraEnv": {
+        "RUSTFLAGS": "--check-cfg cfg(ktest) --cfg ktest"
+    },
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--message-format=json",
+        "--manifest-path",
+        "kernel/Cargo.toml",
         "--target",
         "x86_64-unknown-none",
         "-Zbuild-std=core,alloc,compiler_builtins",

--- a/kernel/aster-nix/src/fs/exfat/mod.rs
+++ b/kernel/aster-nix/src/fs/exfat/mod.rs
@@ -433,7 +433,7 @@ mod test {
         let rmdir_empty_dir = root.rmdir(parent_name);
         assert!(rmdir_empty_dir.is_ok(), "Fail to remove an empty directory");
 
-        let parent_inode_again = create_folder(root.clone(), parent_name);
+        let _parent_inode_again = create_folder(root.clone(), parent_name);
         create_file(parent_inode.clone(), child_name);
         let lookup_result = parent_inode.lookup(child_name);
         assert!(
@@ -984,7 +984,7 @@ mod test {
         let mut file_names: Vec<String> = (0..file_num).map(|x| x.to_string()).collect();
         file_names.sort();
         let mut file_inodes: Vec<Arc<dyn Inode>> = Vec::new();
-        for (file_id, file_name) in file_names.iter().enumerate() {
+        for (_file_id, file_name) in file_names.iter().enumerate() {
             let inode = create_file(root.clone(), file_name);
             file_inodes.push(inode);
         }

--- a/kernel/aster-nix/src/fs/exfat/utils.rs
+++ b/kernel/aster-nix/src/fs/exfat/utils.rs
@@ -5,7 +5,7 @@ use core::{ops::Range, time::Duration};
 use time::{OffsetDateTime, PrimitiveDateTime, Time};
 
 use super::fat::ClusterID;
-use crate::{prelude::*, time::clocks::RealTimeClock};
+use crate::prelude::*;
 
 pub fn make_hash_index(cluster: ClusterID, offset: u32) -> usize {
     (cluster as usize) << 32usize | (offset as usize & 0xffffffffusize)
@@ -59,6 +59,8 @@ impl DosTimestamp {
     pub fn now() -> Result<Self> {
         #[cfg(not(ktest))]
         {
+            use crate::time::clocks::RealTimeClock;
+
             DosTimestamp::from_duration(RealTimeClock::get().read_time())
         }
 

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -127,8 +127,6 @@ pub fn call_ostd_main() -> ! {
     }
     #[cfg(ktest)]
     unsafe {
-        use alloc::boxed::Box;
-
         use crate::task::TaskOptions;
 
         crate::init();

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -245,7 +245,7 @@ mod test {
             .alloc_contiguous()
             .unwrap();
         let vm_segment_child = vm_segment_parent.range(0..1);
-        let dma_coherent_parent = DmaCoherent::map(vm_segment_parent, false);
+        let _dma_coherent_parent = DmaCoherent::map(vm_segment_parent, false);
         let dma_coherent_child = DmaCoherent::map(vm_segment_child, false);
         assert!(dma_coherent_child.is_err());
     }

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -334,7 +334,7 @@ mod test {
             .alloc_contiguous()
             .unwrap();
         let vm_segment_child = vm_segment_parent.range(0..1);
-        let dma_stream_parent =
+        let _dma_stream_parent =
             DmaStream::map(vm_segment_parent, DmaDirection::Bidirectional, false);
         let dma_stream_child = DmaStream::map(vm_segment_child, DmaDirection::Bidirectional, false);
         assert!(dma_stream_child.is_err());

--- a/ostd/src/mm/frame/options.rs
+++ b/ostd/src/mm/frame/options.rs
@@ -120,7 +120,7 @@ fn test_alloc_dealloc() {
     let mut contiguous_options = FrameAllocOptions::new(10);
     contiguous_options.is_contiguous(true);
     let mut remember_vec = Vec::new();
-    for i in 0..10 {
+    for _ in 0..10 {
         for i in 0..10 {
             let single_frame = single_options.alloc_single().unwrap();
             if i % 3 == 0 {


### PR DESCRIPTION
The settings for the rust-analyzer don't seem to work well with the current workspace, causing thousands of errors during `cargo check`, mainly from building std in a no_std environment. This PR fixes this problem, enabling it to notify errors and warnings in time.

Also, I ignore the `unexpected_cfgs` warning because the `#[cfg(ktest)]` will introduce about 32 warnings.