### PR TITLE
Fix the lmbench-exec/shell error when /tmp exists

### DIFF
--- a/test/benchmark/lmbench-exec/run.sh
+++ b/test/benchmark/lmbench-exec/run.sh
@@ -6,6 +6,8 @@ set -e
 
 echo "*** Running the LMbench exec latency test ***"
 
-mkdir /tmp
+if [ ! -d /tmp ]; then
+    mkdir /tmp
+fi
 cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 exec

--- a/test/benchmark/lmbench-shell/run.sh
+++ b/test/benchmark/lmbench-shell/run.sh
@@ -6,6 +6,8 @@ set -e
 
 echo "*** Running the LMbench shell latency test ***"
 
-mkdir /tmp
+if [ ! -d /tmp ]; then
+    mkdir /tmp
+fi
 cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 shell


### PR DESCRIPTION
I find recent benchmark CI always [fails](https://github.com/asterinas/asterinas/actions/runs/10290932106/job/28482076509) on `lmbench-exec` and `lmbench-shell` because their `run.sh` lacks the check on `/tmp`.

This PR fixes this problem by add:
```shell
if [ ! -d /tmp ]; then
    mkdir /tmp
fi
```