### PR TITLE
Remove read/write from `Vmar` and provide new read/write APIs to interact with user space.

### DIFF
--- a/kernel/aster-nix/src/device/pty/pty.rs
+++ b/kernel/aster-nix/src/device/pty/pty.rs
@@ -20,7 +20,6 @@ use crate::{
         signal::{Pollee, Poller},
         JobControl, Terminal,
     },
-    util::{read_val_from_user, write_val_to_user},
 };
 
 const BUFFER_CAPACITY: usize = 4096;
@@ -150,11 +149,11 @@ impl FileIo for PtyMaster {
         match cmd {
             IoctlCmd::TCGETS => {
                 let termios = self.output.termios();
-                write_val_to_user(arg, &termios)?;
+                CurrentUserSpace::get().write_val(arg, &termios)?;
                 Ok(0)
             }
             IoctlCmd::TCSETS => {
-                let termios = read_val_from_user(arg)?;
+                let termios = CurrentUserSpace::get().read_val(arg)?;
                 self.output.set_termios(termios);
                 Ok(0)
             }
@@ -164,7 +163,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGPTN => {
                 let idx = self.index();
-                write_val_to_user(arg, &idx)?;
+                CurrentUserSpace::get().write_val(arg, &idx)?;
                 Ok(0)
             }
             IoctlCmd::TIOCGPTPEER => {
@@ -197,11 +196,11 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGWINSZ => {
                 let winsize = self.output.window_size();
-                write_val_to_user(arg, &winsize)?;
+                CurrentUserSpace::get().write_val(arg, &winsize)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSWINSZ => {
-                let winsize = read_val_from_user(arg)?;
+                let winsize = CurrentUserSpace::get().read_val(arg)?;
                 self.output.set_window_size(winsize);
                 Ok(0)
             }
@@ -213,12 +212,12 @@ impl FileIo for PtyMaster {
                     );
                 };
                 let fg_pgid = foreground.pgid();
-                write_val_to_user(arg, &fg_pgid)?;
+                CurrentUserSpace::get().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = read_val_from_user(arg)?;
+                    let pgid: i32 = CurrentUserSpace::get().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -238,7 +237,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::FIONREAD => {
                 let len = self.input.lock().len() as i32;
-                write_val_to_user(arg, &len)?;
+                CurrentUserSpace::get().write_val(arg, &len)?;
                 Ok(0)
             }
             _ => Ok(0),
@@ -372,12 +371,12 @@ impl FileIo for PtySlave {
                 };
 
                 let fg_pgid = foreground.pgid();
-                write_val_to_user(arg, &fg_pgid)?;
+                CurrentUserSpace::get().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = read_val_from_user(arg)?;
+                    let pgid: i32 = CurrentUserSpace::get().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -397,7 +396,7 @@ impl FileIo for PtySlave {
             }
             IoctlCmd::FIONREAD => {
                 let buffer_len = self.master().slave_buf_len() as i32;
-                write_val_to_user(arg, &buffer_len)?;
+                CurrentUserSpace::get().write_val(arg, &buffer_len)?;
                 Ok(0)
             }
             _ => Ok(0),

--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(iter_repeat_n)]
 #![feature(let_chains)]
 #![feature(linked_list_remove)]
+#![feature(negative_impls)]
 #![feature(register_tool)]
 // FIXME: This feature is used to support vm capbility now as a work around.
 // Since this is an incomplete feature, use this feature is unsafe.

--- a/kernel/aster-nix/src/prelude.rs
+++ b/kernel/aster-nix/src/prelude.rs
@@ -54,6 +54,7 @@ pub(crate) use crate::{
     error::{Errno, Error},
     print, println,
     time::{wait::WaitTimeout, Clock},
+    util::{CurrentUserSpace, ReadCString},
 };
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 pub(crate) use crate::{return_errno, return_errno_with_message};

--- a/kernel/aster-nix/src/process/posix_thread/exit.rs
+++ b/kernel/aster-nix/src/process/posix_thread/exit.rs
@@ -5,7 +5,6 @@ use crate::{
     prelude::*,
     process::{do_exit_group, TermStatus},
     thread::{thread_table, Thread, Tid},
-    util::write_val_to_user,
 };
 
 /// Exits the thread if the thread is a POSIX thread.
@@ -28,7 +27,9 @@ pub fn do_exit(thread: Arc<Thread>, term_status: TermStatus) -> Result<()> {
     if *clear_ctid != 0 {
         futex_wake(*clear_ctid, 1)?;
         // FIXME: the correct write length?
-        write_val_to_user(*clear_ctid, &0u32).unwrap();
+        CurrentUserSpace::get()
+            .write_val(*clear_ctid, &0u32)
+            .unwrap();
         *clear_ctid = 0;
     }
     // exit the robust list: walk the robust list; mark futex words as dead and do futex wake

--- a/kernel/aster-nix/src/process/posix_thread/futex.rs
+++ b/kernel/aster-nix/src/process/posix_thread/futex.rs
@@ -9,7 +9,7 @@ use ostd::{
 };
 use spin::Once;
 
-use crate::{prelude::*, util::read_val_from_user};
+use crate::prelude::*;
 
 type FutexBitSet = u32;
 type FutexBucketRef = Arc<Mutex<FutexBucket>>;
@@ -330,7 +330,7 @@ impl FutexKey {
     pub fn load_val(&self) -> i32 {
         // FIXME: how to implement a atomic load?
         warn!("implement an atomic load");
-        read_val_from_user(self.addr).unwrap()
+        CurrentUserSpace::get().read_val(self.addr).unwrap()
     }
 
     pub fn addr(&self) -> Vaddr {

--- a/kernel/aster-nix/src/process/process_vm/mod.rs
+++ b/kernel/aster-nix/src/process/process_vm/mod.rs
@@ -83,7 +83,7 @@ impl ProcessVm {
     pub fn alloc() -> Self {
         let root_vmar = Vmar::<Full>::new_root();
         let init_stack = InitStack::new();
-        init_stack.alloc_and_map_vmo(&root_vmar).unwrap();
+        init_stack.map_init_stack_vmo(&root_vmar).unwrap();
         let heap = Heap::new();
         heap.alloc_and_map_vmo(&root_vmar).unwrap();
         Self {
@@ -112,7 +112,12 @@ impl ProcessVm {
     /// Returns a reader for reading contents from
     /// the `InitStack`.
     pub fn init_stack_reader(&self) -> InitStackReader {
-        self.init_stack.reader(&self.root_vmar)
+        self.init_stack.reader()
+    }
+
+    /// Returns the top address of the user stack.
+    pub fn user_stack_top(&self) -> Vaddr {
+        self.init_stack.user_stack_top()
     }
 
     pub(super) fn init_stack_writer(
@@ -121,7 +126,7 @@ impl ProcessVm {
         envp: Vec<CString>,
         aux_vec: AuxVec,
     ) -> InitStackWriter {
-        self.init_stack.writer(&self.root_vmar, argv, envp, aux_vec)
+        self.init_stack.writer(argv, envp, aux_vec)
     }
 
     pub(super) fn heap(&self) -> &Heap {
@@ -131,7 +136,7 @@ impl ProcessVm {
     /// Clears existing mappings and then maps stack and heap vmo.
     pub(super) fn clear_and_map(&self) {
         self.root_vmar.clear().unwrap();
-        self.init_stack.alloc_and_map_vmo(&self.root_vmar).unwrap();
+        self.init_stack.map_init_stack_vmo(&self.root_vmar).unwrap();
         self.heap.alloc_and_map_vmo(&self.root_vmar).unwrap();
     }
 }

--- a/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/aster-nix/src/process/program_loader/elf/load_elf.rs
@@ -61,7 +61,7 @@ pub fn load_elf_to_vm(
             let init_stack_writer = process_vm.init_stack_writer(argv, envp, aux_vec);
             init_stack_writer.write().unwrap();
 
-            let user_stack_top = process_vm.init_stack_reader().user_stack_top();
+            let user_stack_top = process_vm.user_stack_top();
             Ok(ElfLoadInfo {
                 entry_point,
                 user_stack_top,

--- a/kernel/aster-nix/src/syscall/access.rs
+++ b/kernel/aster-nix/src/syscall/access.rs
@@ -8,7 +8,6 @@ use crate::{
         utils::PATH_MAX,
     },
     prelude::*,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_faccessat(dirfd: FileDesc, path_ptr: Vaddr, mode: u16) -> Result<SyscallReturn> {
@@ -55,7 +54,7 @@ pub fn do_faccessat(
     let flags = FaccessatFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "Invalid flags"))?;
 
-    let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, PATH_MAX)?;
     debug!(
         "dirfd = {}, path = {:?}, mode = {:o}, flags = {:?}",
         dirfd, path, mode, flags

--- a/kernel/aster-nix/src/syscall/capget.rs
+++ b/kernel/aster-nix/src/syscall/capget.rs
@@ -7,12 +7,12 @@ use crate::{
         credentials,
         credentials::c_types::{cap_user_data_t, cap_user_header_t, LINUX_CAPABILITY_VERSION_3},
     },
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_capget(cap_user_header_addr: Vaddr, cap_user_data_addr: Vaddr) -> Result<SyscallReturn> {
+    let user_space = CurrentUserSpace::get();
     let cap_user_header: cap_user_header_t =
-        read_val_from_user::<cap_user_header_t>(cap_user_header_addr)?;
+        user_space.read_val::<cap_user_header_t>(cap_user_header_addr)?;
 
     if cap_user_header.version != LINUX_CAPABILITY_VERSION_3 {
         return_errno_with_message!(Errno::EINVAL, "not supported (capability version is not 3)");
@@ -42,6 +42,6 @@ pub fn sys_capget(cap_user_header_addr: Vaddr, cap_user_data_addr: Vaddr) -> Res
         inheritable: inheritable_capset.as_u32(),
     };
 
-    write_val_to_user(cap_user_data_addr, &result)?;
+    user_space.write_val(cap_user_data_addr, &result)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/capset.rs
+++ b/kernel/aster-nix/src/syscall/capset.rs
@@ -10,7 +10,6 @@ use crate::{
         },
         credentials_mut,
     },
-    util::read_val_from_user,
 };
 
 fn make_kernel_cap(low: u32, high: u32) -> u64 {
@@ -18,8 +17,9 @@ fn make_kernel_cap(low: u32, high: u32) -> u64 {
 }
 
 pub fn sys_capset(cap_user_header_addr: Vaddr, cap_user_data_addr: Vaddr) -> Result<SyscallReturn> {
+    let user_space = CurrentUserSpace::get();
     let cap_user_header: cap_user_header_t =
-        read_val_from_user::<cap_user_header_t>(cap_user_header_addr)?;
+        user_space.read_val::<cap_user_header_t>(cap_user_header_addr)?;
 
     if cap_user_header.version != LINUX_CAPABILITY_VERSION_3 {
         return_errno_with_message!(Errno::EINVAL, "not supported (capability version is not 3)");
@@ -33,7 +33,8 @@ pub fn sys_capset(cap_user_header_addr: Vaddr, cap_user_data_addr: Vaddr) -> Res
     }
 
     // Convert the cap(u32) to u64
-    let cap_user_data: cap_user_data_t = read_val_from_user::<cap_user_data_t>(cap_user_data_addr)?;
+    let cap_user_data: cap_user_data_t =
+        user_space.read_val::<cap_user_data_t>(cap_user_data_addr)?;
     let inheritable = make_kernel_cap(cap_user_data.inheritable, 0);
     let permitted = make_kernel_cap(cap_user_data.permitted, 0);
     let effective = make_kernel_cap(cap_user_data.effective, 0);

--- a/kernel/aster-nix/src/syscall/chdir.rs
+++ b/kernel/aster-nix/src/syscall/chdir.rs
@@ -5,11 +5,10 @@ use crate::{
     fs::{file_table::FileDesc, fs_resolver::FsPath, inode_handle::InodeHandle, utils::InodeType},
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_chdir(path_ptr: Vaddr) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_ptr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/chmod.rs
+++ b/kernel/aster-nix/src/syscall/chmod.rs
@@ -8,7 +8,6 @@ use crate::{
         utils::{InodeMode, PATH_MAX},
     },
     prelude::*,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_fchmod(fd: FileDesc, mode: u16) -> Result<SyscallReturn> {
@@ -32,7 +31,7 @@ pub fn sys_fchmodat(
     mode: u16,
     /* flags: u32, */
 ) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, PATH_MAX)?;
     debug!("dirfd = {}, path = {:?}, mode = 0o{:o}", dirfd, path, mode,);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/chown.rs
+++ b/kernel/aster-nix/src/syscall/chown.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    util::read_cstring_from_user,
 };
 
 pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32) -> Result<SyscallReturn> {
@@ -54,7 +53,7 @@ pub fn sys_fchownat(
     gid: i32,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, PATH_MAX)?;
     let flags = ChownFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(

--- a/kernel/aster-nix/src/syscall/chroot.rs
+++ b/kernel/aster-nix/src/syscall/chroot.rs
@@ -5,11 +5,10 @@ use crate::{
     fs::{fs_resolver::FsPath, utils::InodeType},
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_chroot(path_ptr: Vaddr) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_ptr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/clock_gettime.rs
+++ b/kernel/aster-nix/src/syscall/clock_gettime.rs
@@ -18,7 +18,6 @@ use crate::{
         },
         timespec_t, Clock,
     },
-    util::write_val_to_user,
 };
 
 pub fn sys_clock_gettime(clockid: clockid_t, timespec_addr: Vaddr) -> Result<SyscallReturn> {
@@ -27,7 +26,7 @@ pub fn sys_clock_gettime(clockid: clockid_t, timespec_addr: Vaddr) -> Result<Sys
     let time_duration = read_clock(clockid)?;
 
     let timespec = timespec_t::from(time_duration);
-    write_val_to_user(timespec_addr, &timespec)?;
+    CurrentUserSpace::get().write_val(timespec_addr, &timespec)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/clone.rs
+++ b/kernel/aster-nix/src/syscall/clone.rs
@@ -6,7 +6,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{clone_child, signal::constants::SIGCHLD, CloneArgs, CloneFlags},
-    util::read_val_from_user,
 };
 
 // The order of arguments for clone differs in different architecture.
@@ -41,7 +40,7 @@ pub fn sys_clone3(
     }
 
     let clone_args = {
-        let args: Clone3Args = read_val_from_user(clong_args_addr)?;
+        let args: Clone3Args = CurrentUserSpace::get().read_val(clong_args_addr)?;
         trace!("clone3 args = {:x?}", args);
         CloneArgs::from(args)
     };

--- a/kernel/aster-nix/src/syscall/getcwd.rs
+++ b/kernel/aster-nix/src/syscall/getcwd.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, util::write_bytes_to_user};
+use crate::prelude::*;
 
 pub fn sys_getcwd(buf: Vaddr, len: usize) -> Result<SyscallReturn> {
     // TODO: getcwd only return a fake result now
     let fake_cwd = CString::new("/")?;
     let bytes = fake_cwd.as_bytes_with_nul();
     let write_len = len.min(bytes.len());
-    write_bytes_to_user(buf, &mut VmReader::from(&bytes[..write_len]))?;
+    CurrentUserSpace::get().write_bytes(buf, &mut VmReader::from(&bytes[..write_len]))?;
     Ok(SyscallReturn::Return(write_len as _))
 }

--- a/kernel/aster-nix/src/syscall/getdents64.rs
+++ b/kernel/aster-nix/src/syscall/getdents64.rs
@@ -12,7 +12,6 @@ use crate::{
         utils::{DirentVisitor, InodeType},
     },
     prelude::*,
-    util::write_bytes_to_user,
 };
 
 pub fn sys_getdents(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
@@ -36,7 +35,7 @@ pub fn sys_getdents(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<Sys
     let mut reader = DirentBufferReader::<Dirent>::new(&mut buffer); // Use the non-64-bit reader
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    write_bytes_to_user(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
+    CurrentUserSpace::get().write_bytes(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }
 
@@ -61,7 +60,7 @@ pub fn sys_getdents64(fd: FileDesc, buf_addr: Vaddr, buf_len: usize) -> Result<S
     let mut reader = DirentBufferReader::<Dirent64>::new(&mut buffer);
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    write_bytes_to_user(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
+    CurrentUserSpace::get().write_bytes(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }
 

--- a/kernel/aster-nix/src/syscall/getgroups.rs
+++ b/kernel/aster-nix/src/syscall/getgroups.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::credentials, util::write_val_to_user};
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getgroups(size: i32, group_list_addr: Vaddr) -> Result<SyscallReturn> {
     debug!("size = {}, group_list_addr = 0x{:x}", size, group_list_addr);
@@ -24,9 +24,10 @@ pub fn sys_getgroups(size: i32, group_list_addr: Vaddr) -> Result<SyscallReturn>
         );
     }
 
+    let user_space = CurrentUserSpace::get();
     for (idx, gid) in groups.iter().enumerate() {
         let addr = group_list_addr + idx * core::mem::size_of_val(gid);
-        write_val_to_user(addr, gid)?;
+        user_space.write_val(addr, gid)?;
     }
 
     Ok(SyscallReturn::Return(groups.len() as _))

--- a/kernel/aster-nix/src/syscall/getrandom.rs
+++ b/kernel/aster-nix/src/syscall/getrandom.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{device, prelude::*, util::write_bytes_to_user};
+use crate::{device, prelude::*};
 
 pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32) -> Result<SyscallReturn> {
     let flags = GetRandomFlags::from_bits_truncate(flags);
@@ -17,7 +17,7 @@ pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32) -> Result<SyscallRetu
     } else {
         device::Urandom::getrandom(&mut buffer)?
     };
-    write_bytes_to_user(buf, &mut VmReader::from(buffer.as_slice()))?;
+    CurrentUserSpace::get().write_bytes(buf, &mut VmReader::from(buffer.as_slice()))?;
     Ok(SyscallReturn::Return(read_len as isize))
 }
 

--- a/kernel/aster-nix/src/syscall/getresgid.rs
+++ b/kernel/aster-nix/src/syscall/getresgid.rs
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::credentials, util::write_val_to_user};
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getresgid(rgid_ptr: Vaddr, egid_ptr: Vaddr, sgid_ptr: Vaddr) -> Result<SyscallReturn> {
     debug!("rgid_ptr = 0x{rgid_ptr:x}, egid_ptr = 0x{egid_ptr:x}, sgid_ptr = 0x{sgid_ptr:x}");
 
     let credentials = credentials();
+    let user_space = CurrentUserSpace::get();
 
     let rgid = credentials.rgid();
-    write_val_to_user(rgid_ptr, &rgid)?;
+    user_space.write_val(rgid_ptr, &rgid)?;
 
     let egid = credentials.egid();
-    write_val_to_user(egid_ptr, &egid)?;
+    user_space.write_val(egid_ptr, &egid)?;
 
     let sgid = credentials.sgid();
-    write_val_to_user(sgid_ptr, &sgid)?;
+    user_space.write_val(sgid_ptr, &sgid)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/getresuid.rs
+++ b/kernel/aster-nix/src/syscall/getresuid.rs
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::credentials, util::write_val_to_user};
+use crate::{prelude::*, process::credentials};
 
 pub fn sys_getresuid(ruid_ptr: Vaddr, euid_ptr: Vaddr, suid_ptr: Vaddr) -> Result<SyscallReturn> {
     debug!("ruid_ptr = 0x{ruid_ptr:x}, euid_ptr = 0x{euid_ptr:x}, suid_ptr = 0x{suid_ptr:x}");
 
     let credentials = credentials();
+    let user_space = CurrentUserSpace::get();
 
     let ruid = credentials.ruid();
-    write_val_to_user(ruid_ptr, &ruid)?;
+    user_space.write_val(ruid_ptr, &ruid)?;
 
     let euid = credentials.euid();
-    write_val_to_user(euid_ptr, &euid)?;
+    user_space.write_val(euid_ptr, &euid)?;
 
     let suid = credentials.suid();
-    write_val_to_user(suid_ptr, &suid)?;
+    user_space.write_val(suid_ptr, &suid)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/getrusage.rs
+++ b/kernel/aster-nix/src/syscall/getrusage.rs
@@ -5,9 +5,7 @@
 use int_to_c_enum::TryFromInt;
 
 use super::SyscallReturn;
-use crate::{
-    prelude::*, process::posix_thread::PosixThreadExt, time::timeval_t, util::write_val_to_user,
-};
+use crate::{prelude::*, process::posix_thread::PosixThreadExt, time::timeval_t};
 
 #[derive(Debug, Copy, Clone, TryFromInt, PartialEq)]
 #[repr(i32)]
@@ -53,7 +51,7 @@ pub fn sys_getrusage(target: i32, rusage_addr: Vaddr) -> Result<SyscallReturn> {
             }
         };
 
-        write_val_to_user(rusage_addr, &rusage)?;
+        CurrentUserSpace::get().write_val(rusage_addr, &rusage)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/aster-nix/src/syscall/gettimeofday.rs
+++ b/kernel/aster-nix/src/syscall/gettimeofday.rs
@@ -4,7 +4,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     time::{timeval_t, SystemTime},
-    util::write_val_to_user,
 };
 
 // The use of the timezone structure is obsolete.
@@ -19,7 +18,7 @@ pub fn sys_gettimeofday(timeval_addr: Vaddr, /* timezone_addr: Vaddr */) -> Resu
         let time_duration = now.duration_since(&SystemTime::UNIX_EPOCH)?;
         timeval_t::from(time_duration)
     };
-    write_val_to_user(timeval_addr, &time_val)?;
+    CurrentUserSpace::get().write_val(timeval_addr, &time_val)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/ioctl.rs
+++ b/kernel/aster-nix/src/syscall/ioctl.rs
@@ -7,7 +7,6 @@ use crate::{
         utils::{IoctlCmd, StatusFlags},
     },
     prelude::*,
-    util::read_val_from_user,
 };
 
 pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
@@ -21,14 +20,14 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr) -> Result<SyscallReturn> {
     let file = file_table.get_file(fd)?;
     let res = match ioctl_cmd {
         IoctlCmd::FIONBIO => {
-            let is_nonblocking = read_val_from_user::<i32>(arg)? != 0;
+            let is_nonblocking = CurrentUserSpace::get().read_val::<i32>(arg)? != 0;
             let mut flags = file.status_flags();
             flags.set(StatusFlags::O_NONBLOCK, is_nonblocking);
             file.set_status_flags(flags)?;
             0
         }
         IoctlCmd::FIOASYNC => {
-            let is_async = read_val_from_user::<i32>(arg)? != 0;
+            let is_async = CurrentUserSpace::get().read_val::<i32>(arg)? != 0;
             let mut flags = file.status_flags();
 
             // Set `O_ASYNC` flags will send `SIGIO` signal to a process when

--- a/kernel/aster-nix/src/syscall/link.rs
+++ b/kernel/aster-nix/src/syscall/link.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_linkat(
@@ -18,8 +17,10 @@ pub fn sys_linkat(
     new_path_addr: Vaddr,
     flags: u32,
 ) -> Result<SyscallReturn> {
-    let old_path = read_cstring_from_user(old_path_addr, MAX_FILENAME_LEN)?;
-    let new_path = read_cstring_from_user(new_path_addr, MAX_FILENAME_LEN)?;
+    let user_space = CurrentUserSpace::get();
+
+    let old_path = user_space.read_cstring(old_path_addr, MAX_FILENAME_LEN)?;
+    let new_path = user_space.read_cstring(new_path_addr, MAX_FILENAME_LEN)?;
     let flags =
         LinkFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(

--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, util::read_bytes_from_user};
+use crate::prelude::*;
 
 pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallReturn> {
     let behavior = MadviseBehavior::try_from(behavior)?;
@@ -15,7 +15,8 @@ pub fn sys_madvise(start: Vaddr, len: usize, behavior: i32) -> Result<SyscallRet
         | MadviseBehavior::MADV_WILLNEED => {
             // perform a read at first
             let mut buffer = vec![0u8; len];
-            read_bytes_from_user(start, &mut VmWriter::from(buffer.as_mut_slice()))?;
+            CurrentUserSpace::get()
+                .read_bytes(start, &mut VmWriter::from(buffer.as_mut_slice()))?;
         }
         MadviseBehavior::MADV_DONTNEED => {
             warn!("MADV_DONTNEED isn't implemented, do nothing for now.");

--- a/kernel/aster-nix/src/syscall/mkdir.rs
+++ b/kernel/aster-nix/src/syscall/mkdir.rs
@@ -9,11 +9,10 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_mkdirat(dirfd: FileDesc, path_addr: Vaddr, mode: u16) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}, mode = {}", dirfd, path, mode);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/mknod.rs
+++ b/kernel/aster-nix/src/syscall/mknod.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     prelude::*,
     syscall::{constants::MAX_FILENAME_LEN, stat::FileType},
-    util::read_cstring_from_user,
 };
 
 pub fn sys_mknodat(
@@ -19,7 +18,7 @@ pub fn sys_mknodat(
     mode: u16,
     dev: usize,
 ) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     let current = current!();
     let inode_mode = {
         let mask_mode = mode & !current.umask().read().get();

--- a/kernel/aster-nix/src/syscall/open.rs
+++ b/kernel/aster-nix/src/syscall/open.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_openat(
@@ -18,7 +17,7 @@ pub fn sys_openat(
     flags: u32,
     mode: u16,
 ) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "dirfd = {}, path = {:?}, flags = {}, mode = {}",
         dirfd, path, flags, mode

--- a/kernel/aster-nix/src/syscall/pipe.rs
+++ b/kernel/aster-nix/src/syscall/pipe.rs
@@ -8,7 +8,6 @@ use crate::{
         utils::{Channel, CreationFlags, StatusFlags},
     },
     prelude::*,
-    util::write_val_to_user,
 };
 
 pub fn sys_pipe2(fds: Vaddr, flags: u32) -> Result<SyscallReturn> {
@@ -40,7 +39,7 @@ pub fn sys_pipe2(fds: Vaddr, flags: u32) -> Result<SyscallReturn> {
     };
     debug!("pipe_fds: {:?}", pipe_fds);
 
-    if let Err(err) = write_val_to_user(fds, &pipe_fds) {
+    if let Err(err) = CurrentUserSpace::get().write_val(fds, &pipe_fds) {
         file_table.close_file(pipe_fds.reader_fd).unwrap();
         file_table.close_file(pipe_fds.writer_fd).unwrap();
         return Err(err);

--- a/kernel/aster-nix/src/syscall/pread64.rs
+++ b/kernel/aster-nix/src/syscall/pread64.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::write_bytes_to_user};
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 pub fn sys_pread64(
     fd: FileDesc,
@@ -33,7 +33,8 @@ pub fn sys_pread64(
     let read_len = {
         let mut buffer = vec![0u8; user_buf_len];
         let read_len = file.read_at(offset as usize, &mut buffer)?;
-        write_bytes_to_user(user_buf_ptr, &mut VmReader::from(buffer.as_slice()))?;
+        CurrentUserSpace::get()
+            .write_bytes(user_buf_ptr, &mut VmReader::from(buffer.as_slice()))?;
         read_len
     };
 

--- a/kernel/aster-nix/src/syscall/prlimit64.rs
+++ b/kernel/aster-nix/src/syscall/prlimit64.rs
@@ -4,7 +4,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{Pid, ResourceType},
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_prlimit64(
@@ -22,10 +21,10 @@ pub fn sys_prlimit64(
     let mut resource_limits = current.resource_limits().lock();
     if old_rlim_addr != 0 {
         let rlimit = resource_limits.get_rlimit(resource);
-        write_val_to_user(old_rlim_addr, rlimit)?;
+        CurrentUserSpace::get().write_val(old_rlim_addr, rlimit)?;
     }
     if new_rlim_addr != 0 {
-        let new_rlimit = read_val_from_user(new_rlim_addr)?;
+        let new_rlimit = CurrentUserSpace::get().read_val(new_rlim_addr)?;
         *resource_limits.get_rlimit_mut(resource) = new_rlimit;
     }
     Ok(SyscallReturn::Return(0))

--- a/kernel/aster-nix/src/syscall/pwrite64.rs
+++ b/kernel/aster-nix/src/syscall/pwrite64.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::read_bytes_from_user};
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 pub fn sys_pwrite64(
     fd: FileDesc,
@@ -30,7 +30,7 @@ pub fn sys_pwrite64(
     }
 
     let mut buffer = vec![0u8; user_buf_len];
-    read_bytes_from_user(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
+    CurrentUserSpace::get().read_bytes(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
     let write_len = file.write_at(offset as _, &buffer)?;
     Ok(SyscallReturn::Return(write_len as _))
 }

--- a/kernel/aster-nix/src/syscall/read.rs
+++ b/kernel/aster-nix/src/syscall/read.rs
@@ -3,7 +3,7 @@
 use core::cmp::min;
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::write_bytes_to_user};
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 pub fn sys_read(fd: FileDesc, user_buf_addr: Vaddr, buf_len: usize) -> Result<SyscallReturn> {
     debug!(
@@ -23,7 +23,7 @@ pub fn sys_read(fd: FileDesc, user_buf_addr: Vaddr, buf_len: usize) -> Result<Sy
     let read_len = if buf_len != 0 {
         let mut read_buf = vec![0u8; buf_len];
         let read_len = file.read(&mut read_buf)?;
-        write_bytes_to_user(
+        CurrentUserSpace::get().write_bytes(
             user_buf_addr,
             &mut VmReader::from(&read_buf[..min(read_len, buf_len)]),
         )?;

--- a/kernel/aster-nix/src/syscall/recvmsg.rs
+++ b/kernel/aster-nix/src/syscall/recvmsg.rs
@@ -5,14 +5,11 @@ use crate::{
     fs::file_table::FileDesc,
     net::socket::SendRecvFlags,
     prelude::*,
-    util::{
-        net::{get_socket_from_fd, CUserMsgHdr},
-        read_val_from_user,
-    },
+    util::net::{get_socket_from_fd, CUserMsgHdr},
 };
 
 pub fn sys_recvmsg(sockfd: FileDesc, user_msghdr_ptr: Vaddr, flags: i32) -> Result<SyscallReturn> {
-    let c_user_msghdr: CUserMsgHdr = read_val_from_user(user_msghdr_ptr)?;
+    let c_user_msghdr: CUserMsgHdr = CurrentUserSpace::get().read_val(user_msghdr_ptr)?;
     let flags = SendRecvFlags::from_bits_truncate(flags);
 
     debug!(

--- a/kernel/aster-nix/src/syscall/rename.rs
+++ b/kernel/aster-nix/src/syscall/rename.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_renameat(
@@ -18,8 +17,9 @@ pub fn sys_renameat(
     new_dirfd: FileDesc,
     new_path_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    let old_path = read_cstring_from_user(old_path_addr, MAX_FILENAME_LEN)?;
-    let new_path = read_cstring_from_user(new_path_addr, MAX_FILENAME_LEN)?;
+    let user_space = CurrentUserSpace::get();
+    let old_path = user_space.read_cstring(old_path_addr, MAX_FILENAME_LEN)?;
+    let new_path = user_space.read_cstring(new_path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "old_dirfd = {}, old_path = {:?}, new_dirfd = {}, new_path = {:?}",
         old_dirfd, old_path, new_dirfd, new_path

--- a/kernel/aster-nix/src/syscall/rmdir.rs
+++ b/kernel/aster-nix/src/syscall/rmdir.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_rmdir(path_addr: Vaddr) -> Result<SyscallReturn> {
@@ -16,7 +15,7 @@ pub fn sys_rmdir(path_addr: Vaddr) -> Result<SyscallReturn> {
 }
 
 pub(super) fn sys_rmdirat(dirfd: FileDesc, path_addr: Vaddr) -> Result<SyscallReturn> {
-    let path_addr = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path_addr = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path_addr = {:?}", dirfd, path_addr);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/rt_sigaction.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigaction.rs
@@ -4,7 +4,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::signal::{c_types::sigaction_t, sig_action::SigAction, sig_num::SigNum},
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_rt_sigaction(
@@ -26,10 +25,10 @@ pub fn sys_rt_sigaction(
     let old_action = sig_dispositions.get(sig_num);
     let old_action_c = old_action.as_c_type();
     if old_sig_action_addr != 0 {
-        write_val_to_user(old_sig_action_addr, &old_action_c)?;
+        CurrentUserSpace::get().write_val(old_sig_action_addr, &old_action_c)?;
     }
     if sig_action_addr != 0 {
-        let sig_action_c = read_val_from_user::<sigaction_t>(sig_action_addr)?;
+        let sig_action_c = CurrentUserSpace::get().read_val::<sigaction_t>(sig_action_addr)?;
         let sig_action = SigAction::try_from(sig_action_c).unwrap();
         trace!("sig action = {:?}", sig_action);
         sig_dispositions.set(sig_num, sig_action);

--- a/kernel/aster-nix/src/syscall/rt_sigpending.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigpending.rs
@@ -3,7 +3,7 @@
 use core::sync::atomic::Ordering;
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::posix_thread::PosixThreadExt, util::write_val_to_user};
+use crate::{prelude::*, process::posix_thread::PosixThreadExt};
 
 pub fn sys_rt_sigpending(u_set_ptr: Vaddr, sigset_size: usize) -> Result<SyscallReturn> {
     debug!(
@@ -27,6 +27,6 @@ fn do_rt_sigpending(set_ptr: Vaddr) -> Result<()> {
         sig_mask_value & sig_pending_value
     };
 
-    write_val_to_user(set_ptr, &u64::from(combined_signals))?;
+    CurrentUserSpace::get().write_val(set_ptr, &u64::from(combined_signals))?;
     Ok(())
 }

--- a/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
@@ -12,7 +12,6 @@ use crate::{
             sig_mask::SigMask,
         },
     },
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_rt_sigprocmask(
@@ -40,12 +39,12 @@ fn do_rt_sigprocmask(mask_op: MaskOp, set_ptr: Vaddr, oldset_ptr: Vaddr) -> Resu
     let old_sig_mask_value = posix_thread.sig_mask().load(Ordering::Relaxed);
     debug!("old sig mask value: 0x{:x}", old_sig_mask_value);
     if oldset_ptr != 0 {
-        write_val_to_user(oldset_ptr, &old_sig_mask_value)?;
+        CurrentUserSpace::get().write_val(oldset_ptr, &old_sig_mask_value)?;
     }
 
     let sig_mask_ref = posix_thread.sig_mask();
     if set_ptr != 0 {
-        let mut read_mask = read_val_from_user::<SigMask>(set_ptr)?;
+        let mut read_mask = CurrentUserSpace::get().read_val::<SigMask>(set_ptr)?;
         match mask_op {
             MaskOp::Block => {
                 // According to man pages, "it is not possible to block SIGKILL or SIGSTOP.

--- a/kernel/aster-nix/src/syscall/rt_sigreturn.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigreturn.rs
@@ -8,7 +8,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{posix_thread::PosixThreadExt, signal::c_types::ucontext_t},
-    util::read_val_from_user,
 };
 
 pub fn sys_rt_sigreturn(context: &mut UserContext) -> Result<SyscallReturn> {
@@ -24,7 +23,7 @@ pub fn sys_rt_sigreturn(context: &mut UserContext) -> Result<SyscallReturn> {
     // However, for most glibc applications, the restorer codes is provided by glibc and RESTORER flag is set.
     debug_assert!(sig_context_addr == context.stack_pointer() as Vaddr);
 
-    let ucontext = read_val_from_user::<ucontext_t>(sig_context_addr)?;
+    let ucontext = CurrentUserSpace::get().read_val::<ucontext_t>(sig_context_addr)?;
 
     // If the sig stack is active and used by current handler, decrease handler counter.
     if let Some(sig_stack) = posix_thread.sig_stack().lock().as_mut() {

--- a/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigsuspend.rs
@@ -8,7 +8,6 @@ use crate::{
         sig_mask::SigMask,
         Pauser,
     },
-    util::read_val_from_user,
 };
 
 pub fn sys_rt_sigsuspend(sigmask_addr: Vaddr, sigmask_size: usize) -> Result<SyscallReturn> {
@@ -23,7 +22,7 @@ pub fn sys_rt_sigsuspend(sigmask_addr: Vaddr, sigmask_size: usize) -> Result<Sys
     }
 
     let sigmask = {
-        let mut mask: SigMask = read_val_from_user(sigmask_addr)?;
+        let mut mask: SigMask = CurrentUserSpace::get().read_val(sigmask_addr)?;
         // It is not possible to block SIGKILL or SIGSTOP,
         // specifying these signals in mask has no effect.
         mask -= SIGKILL;

--- a/kernel/aster-nix/src/syscall/sched_getaffinity.rs
+++ b/kernel/aster-nix/src/syscall/sched_getaffinity.rs
@@ -6,7 +6,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{process_table, Pid},
-    util::write_val_to_user,
 };
 
 fn get_num_cpus() -> usize {
@@ -41,7 +40,7 @@ pub fn sys_sched_getaffinity(
 
     let dummy_cpu_set = cpu_set_t::new(num_cpus);
 
-    write_val_to_user(cpu_set_ptr, &dummy_cpu_set)?;
+    CurrentUserSpace::get().write_val(cpu_set_ptr, &dummy_cpu_set)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/sendfile.rs
+++ b/kernel/aster-nix/src/syscall/sendfile.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc,
-    prelude::*,
-    util::{read_val_from_user, write_val_to_user},
-};
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 pub fn sys_sendfile(
     out_fd: FileDesc,
@@ -18,7 +14,7 @@ pub fn sys_sendfile(
     let offset = if offset_ptr == 0 {
         None
     } else {
-        let offset: isize = read_val_from_user(offset_ptr)?;
+        let offset: isize = CurrentUserSpace::get().read_val(offset_ptr)?;
         if offset < 0 {
             return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
         }
@@ -113,7 +109,7 @@ pub fn sys_sendfile(
     }
 
     if let Some(offset) = offset {
-        write_val_to_user(offset_ptr, &(offset as isize))?;
+        CurrentUserSpace::get().write_val(offset_ptr, &(offset as isize))?;
     }
 
     Ok(SyscallReturn::Return(total_len as _))

--- a/kernel/aster-nix/src/syscall/sendmsg.rs
+++ b/kernel/aster-nix/src/syscall/sendmsg.rs
@@ -5,14 +5,11 @@ use crate::{
     fs::file_table::FileDesc,
     net::socket::{MessageHeader, SendRecvFlags},
     prelude::*,
-    util::{
-        net::{get_socket_from_fd, CUserMsgHdr},
-        read_val_from_user,
-    },
+    util::net::{get_socket_from_fd, CUserMsgHdr},
 };
 
 pub fn sys_sendmsg(sockfd: FileDesc, user_msghdr_ptr: Vaddr, flags: i32) -> Result<SyscallReturn> {
-    let c_user_msghdr: CUserMsgHdr = read_val_from_user(user_msghdr_ptr)?;
+    let c_user_msghdr: CUserMsgHdr = CurrentUserSpace::get().read_val(user_msghdr_ptr)?;
     let flags = SendRecvFlags::from_bits_truncate(flags);
 
     debug!(

--- a/kernel/aster-nix/src/syscall/set_robust_list.rs
+++ b/kernel/aster-nix/src/syscall/set_robust_list.rs
@@ -4,7 +4,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::posix_thread::{PosixThreadExt, RobustListHead},
-    util::read_val_from_user,
 };
 
 pub fn sys_set_robust_list(robust_list_head_ptr: Vaddr, len: usize) -> Result<SyscallReturn> {
@@ -18,7 +17,8 @@ pub fn sys_set_robust_list(robust_list_head_ptr: Vaddr, len: usize) -> Result<Sy
             "The len is not equal to the size of robust list head"
         );
     }
-    let robust_list_head: RobustListHead = read_val_from_user(robust_list_head_ptr)?;
+    let robust_list_head: RobustListHead =
+        CurrentUserSpace::get().read_val(robust_list_head_ptr)?;
     debug!("{:x?}", robust_list_head);
     let current_thread = current_thread!();
     let posix_thread = current_thread.as_posix_thread().unwrap();

--- a/kernel/aster-nix/src/syscall/setgroups.rs
+++ b/kernel/aster-nix/src/syscall/setgroups.rs
@@ -4,7 +4,6 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{credentials_mut, Gid},
-    util::read_val_from_user,
 };
 
 pub fn sys_setgroups(size: usize, group_list_addr: Vaddr) -> Result<SyscallReturn> {
@@ -19,7 +18,7 @@ pub fn sys_setgroups(size: usize, group_list_addr: Vaddr) -> Result<SyscallRetur
     let mut new_groups = BTreeSet::new();
     for idx in 0..size {
         let addr = group_list_addr + idx * core::mem::size_of::<Gid>();
-        let gid = read_val_from_user(addr)?;
+        let gid = CurrentUserSpace::get().read_val(addr)?;
         new_groups.insert(gid);
     }
 

--- a/kernel/aster-nix/src/syscall/setsockopt.rs
+++ b/kernel/aster-nix/src/syscall/setsockopt.rs
@@ -29,9 +29,7 @@ pub fn sys_setsockopt(
     let raw_option = {
         let mut option = new_raw_socket_option(level, optname)?;
 
-        let current = current!();
-        let vmar = current.root_vmar();
-        option.read_from_user(vmar, optval, optlen)?;
+        option.read_from_user(optval, optlen)?;
 
         option
     };

--- a/kernel/aster-nix/src/syscall/sigaltstack.rs
+++ b/kernel/aster-nix/src/syscall/sigaltstack.rs
@@ -9,7 +9,6 @@ use crate::{
         posix_thread::PosixThreadExt,
         signal::{SigStack, SigStackFlags},
     },
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_sigaltstack(sig_stack_addr: Vaddr, old_sig_stack_addr: Vaddr) -> Result<SyscallReturn> {
@@ -43,7 +42,7 @@ fn get_old_stack(old_sig_stack_addr: Vaddr, old_stack: Option<&SigStack>) -> Res
     debug!("old stack = {:?}", old_stack);
 
     let stack = stack_t::from(old_stack.clone());
-    write_val_to_user(old_sig_stack_addr, &stack)
+    CurrentUserSpace::get().write_val(old_sig_stack_addr, &stack)
 }
 
 fn set_new_stack(sig_stack_addr: Vaddr, old_stack: Option<&SigStack>) -> Result<()> {
@@ -58,7 +57,7 @@ fn set_new_stack(sig_stack_addr: Vaddr, old_stack: Option<&SigStack>) -> Result<
     }
 
     let new_stack = {
-        let stack = read_val_from_user::<stack_t>(sig_stack_addr)?;
+        let stack = CurrentUserSpace::get().read_val::<stack_t>(sig_stack_addr)?;
         SigStack::try_from(stack)?
     };
 

--- a/kernel/aster-nix/src/syscall/socketpair.rs
+++ b/kernel/aster-nix/src/syscall/socketpair.rs
@@ -5,10 +5,7 @@ use crate::{
     fs::file_table::{FdFlags, FileDesc},
     net::socket::unix::UnixStreamSocket,
     prelude::*,
-    util::{
-        net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK},
-        write_val_to_user,
-    },
+    util::net::{CSocketAddrFamily, Protocol, SockFlags, SockType, SOCK_TYPE_MASK},
 };
 
 pub fn sys_socketpair(domain: i32, type_: i32, protocol: i32, sv: Vaddr) -> Result<SyscallReturn> {
@@ -46,7 +43,7 @@ pub fn sys_socketpair(domain: i32, type_: i32, protocol: i32, sv: Vaddr) -> Resu
         SocketFds(fd_a, fd_b)
     };
 
-    write_val_to_user(sv, &socket_fds)?;
+    CurrentUserSpace::get().write_val(sv, &socket_fds)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/aster-nix/src/syscall/symlink.rs
+++ b/kernel/aster-nix/src/syscall/symlink.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_symlinkat(
@@ -17,8 +16,9 @@ pub fn sys_symlinkat(
     dirfd: FileDesc,
     linkpath_addr: Vaddr,
 ) -> Result<SyscallReturn> {
-    let target = read_cstring_from_user(target_addr, MAX_FILENAME_LEN)?;
-    let linkpath = read_cstring_from_user(linkpath_addr, MAX_FILENAME_LEN)?;
+    let user_space = CurrentUserSpace::get();
+    let target = user_space.read_cstring(target_addr, MAX_FILENAME_LEN)?;
+    let linkpath = user_space.read_cstring(linkpath_addr, MAX_FILENAME_LEN)?;
     debug!(
         "target = {:?}, dirfd = {}, linkpath = {:?}",
         target, dirfd, linkpath

--- a/kernel/aster-nix/src/syscall/time.rs
+++ b/kernel/aster-nix/src/syscall/time.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, time::SystemTime, util::write_val_to_user};
+use crate::{prelude::*, time::SystemTime};
 
 pub fn sys_time(tloc: Vaddr) -> Result<SyscallReturn> {
     debug!("tloc = 0x{tloc:x}");
@@ -12,7 +12,7 @@ pub fn sys_time(tloc: Vaddr) -> Result<SyscallReturn> {
     };
 
     if tloc != 0 {
-        write_val_to_user(tloc, &now_as_secs)?;
+        CurrentUserSpace::get().write_val(tloc, &now_as_secs)?;
     }
 
     Ok(SyscallReturn::Return(now_as_secs as _))

--- a/kernel/aster-nix/src/syscall/timer_create.rs
+++ b/kernel/aster-nix/src/syscall/timer_create.rs
@@ -25,7 +25,6 @@ use crate::{
         clockid_t,
         clocks::{BootTimeClock, MonotonicClock, RealTimeClock},
     },
-    util::{read_val_from_user, write_val_to_user},
 };
 
 pub fn sys_timer_create(
@@ -51,7 +50,7 @@ pub fn sys_timer_create(
             })
         // Determine the timeout action through `sigevent`.
         } else {
-            let sig_event = read_val_from_user::<sigevent_t>(sigevent_addr)?;
+            let sig_event = CurrentUserSpace::get().read_val::<sigevent_t>(sigevent_addr)?;
             let sigev_notify = SigNotify::try_from(sig_event.sigev_notify)?;
             let signo = sig_event.sigev_signo;
             match sigev_notify {
@@ -152,7 +151,7 @@ pub fn sys_timer_create(
     };
 
     let timer_id = process_timer_manager.add_posix_timer(timer);
-    write_val_to_user(timer_id_addr, &timer_id)?;
+    CurrentUserSpace::get().write_val(timer_id_addr, &timer_id)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/aster-nix/src/syscall/truncate.rs
+++ b/kernel/aster-nix/src/syscall/truncate.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     prelude::*,
     process::ResourceType,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_ftruncate(fd: FileDesc, len: isize) -> Result<SyscallReturn> {
@@ -25,7 +24,7 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize) -> Result<SyscallReturn> {
 }
 
 pub fn sys_truncate(path_ptr: Vaddr, len: isize) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_ptr, PATH_MAX)?;
+    let path = CurrentUserSpace::get().read_cstring(path_ptr, PATH_MAX)?;
     debug!("path = {:?}, length = {}", path, len);
 
     check_length(len)?;

--- a/kernel/aster-nix/src/syscall/umount.rs
+++ b/kernel/aster-nix/src/syscall/umount.rs
@@ -5,11 +5,10 @@ use crate::{
     fs::fs_resolver::{FsPath, AT_FDCWD},
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_umount(path_addr: Vaddr, flags: u64) -> Result<SyscallReturn> {
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     let umount_flags = UmountFlags::from_bits_truncate(flags as u32);
     debug!("path = {:?}, flags = {:?}", path, umount_flags);
 

--- a/kernel/aster-nix/src/syscall/uname.rs
+++ b/kernel/aster-nix/src/syscall/uname.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{prelude::*, util::write_val_to_user};
+use crate::prelude::*;
 
 // We don't use the real name and version of our os here. Instead, we pick up fake values witch is the same as the ones of linux.
 // The values are used to fool glibc since glibc will check the version and os name.
@@ -59,6 +59,6 @@ fn copy_cstring_to_u8_slice(src: &CStr, dst: &mut [u8]) {
 
 pub fn sys_uname(old_uname_addr: Vaddr) -> Result<SyscallReturn> {
     debug!("old uname addr = 0x{:x}", old_uname_addr);
-    write_val_to_user(old_uname_addr, &*UTS_NAME)?;
+    CurrentUserSpace::get().write_val(old_uname_addr, &*UTS_NAME)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/aster-nix/src/syscall/unlink.rs
+++ b/kernel/aster-nix/src/syscall/unlink.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    util::read_cstring_from_user,
 };
 
 pub fn sys_unlinkat(dirfd: FileDesc, path_addr: Vaddr, flags: u32) -> Result<SyscallReturn> {
@@ -18,7 +17,7 @@ pub fn sys_unlinkat(dirfd: FileDesc, path_addr: Vaddr, flags: u32) -> Result<Sys
         return super::rmdir::sys_rmdirat(dirfd, path_addr);
     }
 
-    let path = read_cstring_from_user(path_addr, MAX_FILENAME_LEN)?;
+    let path = CurrentUserSpace::get().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}", dirfd, path);
 
     let current = current!();

--- a/kernel/aster-nix/src/syscall/wait4.rs
+++ b/kernel/aster-nix/src/syscall/wait4.rs
@@ -4,7 +4,6 @@ use super::{getrusage::rusage_t, SyscallReturn};
 use crate::{
     prelude::*,
     process::{wait_child_exit, ProcessFilter, WaitOptions},
-    util::write_val_to_user,
 };
 
 pub fn sys_wait4(
@@ -29,7 +28,7 @@ pub fn sys_wait4(
 
     let (return_pid, exit_code) = (process.pid(), process.exit_code().unwrap());
     if exit_status_ptr != 0 {
-        write_val_to_user(exit_status_ptr as _, &exit_code)?;
+        CurrentUserSpace::get().write_val(exit_status_ptr as _, &exit_code)?;
     }
 
     if rusage_addr != 0 {
@@ -39,7 +38,7 @@ pub fn sys_wait4(
             ..Default::default()
         };
 
-        write_val_to_user(rusage_addr, &rusage)?;
+        CurrentUserSpace::get().write_val(rusage_addr, &rusage)?;
     }
 
     Ok(SyscallReturn::Return(return_pid as _))

--- a/kernel/aster-nix/src/syscall/write.rs
+++ b/kernel/aster-nix/src/syscall/write.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::read_bytes_from_user};
+use crate::{fs::file_table::FileDesc, prelude::*};
 
 const STDOUT: u64 = 1;
 const STDERR: u64 = 2;
@@ -25,7 +25,8 @@ pub fn sys_write(fd: FileDesc, user_buf_ptr: Vaddr, user_buf_len: usize) -> Resu
     // the file discriptor. If no errors detected, return 0 successfully.
     let write_len = if user_buf_len != 0 {
         let mut buffer = vec![0u8; user_buf_len];
-        read_bytes_from_user(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
+        CurrentUserSpace::get()
+            .read_bytes(user_buf_ptr, &mut VmWriter::from(buffer.as_mut_slice()))?;
         debug!("write content = {:?}", buffer);
         file.write(&buffer)?
     } else {

--- a/kernel/aster-nix/src/util/net/options/socket.rs
+++ b/kernel/aster-nix/src/util/net/options/socket.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_rights::Full;
-
 use super::RawSocketOption;
 use crate::{
     impl_raw_sock_option_get_only, impl_raw_socket_option,
@@ -9,7 +7,6 @@ use crate::{
         Error, KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
     },
     prelude::*,
-    vm::vmar::Vmar,
 };
 
 /// Socket level options.

--- a/kernel/aster-nix/src/util/net/options/tcp.rs
+++ b/kernel/aster-nix/src/util/net/options/tcp.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_rights::Full;
-
 use super::RawSocketOption;
 use crate::{
     impl_raw_socket_option,
     net::socket::ip::stream::options::{Congestion, MaxSegment, NoDelay, WindowClamp},
     prelude::*,
     util::net::options::SocketOption,
-    vm::vmar::Vmar,
 };
 
 /// Sock options for tcp socket.

--- a/kernel/aster-nix/src/vm/vmar/mod.rs
+++ b/kernel/aster-nix/src/vm/vmar/mod.rs
@@ -143,6 +143,11 @@ impl VmarInner {
 pub const ROOT_VMAR_LOWEST_ADDR: Vaddr = 0x001_0000; // 64 KiB is the Linux configurable default
 const ROOT_VMAR_CAP_ADDR: Vaddr = MAX_USERSPACE_VADDR;
 
+/// Returns whether the input `vaddr` is a legal user space virtual address.
+pub fn is_userspace_vaddr(vaddr: Vaddr) -> bool {
+    (ROOT_VMAR_LOWEST_ADDR..ROOT_VMAR_CAP_ADDR).contains(&vaddr)
+}
+
 impl Interval<usize> for Arc<Vmar_> {
     fn range(&self) -> Range<usize> {
         self.base..(self.base + self.size)

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -30,7 +30,7 @@ impl UserSpace {
     }
 
     /// Returns the VM address space.
-    pub fn vm_space(&self) -> &VmSpace {
+    pub fn vm_space(&self) -> &Arc<VmSpace> {
         &self.vm_space
     }
 


### PR DESCRIPTION
Splitted from #1017 

Remove the `VmIO` implementation in `Vmar` and refine the APIs for reading and writing in user space.