### PR TITLE
Refactor the API of SpinLock to improve the ergonomics when using spinlocks with IRQ disabled

### DIFF
--- a/kernel/aster-nix/src/device/pty/pty.rs
+++ b/kernel/aster-nix/src/device/pty/pty.rs
@@ -62,7 +62,7 @@ impl PtyMaster {
     }
 
     pub(super) fn slave_push_char(&self, ch: u8) {
-        let mut input = self.input.lock_irq_disabled();
+        let mut input = self.input.disable_irq().lock();
         input.push_overwrite(ch);
         self.update_state(&input);
     }
@@ -107,7 +107,7 @@ impl FileIo for PtyMaster {
 
         let mut poller = Poller::new();
         loop {
-            let mut input = self.input.lock_irq_disabled();
+            let mut input = self.input.disable_irq().lock();
 
             if input.is_empty() {
                 let events = self.pollee.poll(IoEvents::IN, Some(&mut poller));

--- a/kernel/aster-nix/src/device/tty/mod.rs
+++ b/kernel/aster-nix/src/device/tty/mod.rs
@@ -60,7 +60,7 @@ impl Tty {
     }
 
     pub fn set_driver(&self, driver: Weak<TtyDriver>) {
-        *self.driver.lock_irq_disabled() = driver;
+        *self.driver.disable_irq().lock() = driver;
     }
 
     pub fn push_char(&self, ch: u8) {

--- a/kernel/aster-nix/src/fs/pipe.rs
+++ b/kernel/aster-nix/src/fs/pipe.rs
@@ -233,8 +233,8 @@ mod test {
         // FIXME: `ThreadOptions::new` currently accepts `Fn`, forcing us to use `SpinLock` to gain
         // internal mutability. We should avoid this `SpinLock` by making `ThreadOptions::new`
         // accept `FnOnce`.
-        let writer_with_lock = SpinLock::new(Some(writer));
-        let reader_with_lock = SpinLock::new(Some(reader));
+        let writer_with_lock: SpinLock<_> = SpinLock::new(Some(writer));
+        let reader_with_lock: SpinLock<_> = SpinLock::new(Some(reader));
 
         let signal_writer = Arc::new(AtomicBool::new(false));
         let signal_reader = signal_writer.clone();

--- a/kernel/aster-nix/src/net/iface/mod.rs
+++ b/kernel/aster-nix/src/net/iface/mod.rs
@@ -17,6 +17,7 @@ pub use any_socket::{
     AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket, RECV_BUF_LEN, SEND_BUF_LEN,
 };
 pub use loopback::IfaceLoopback;
+use ostd::sync::LocalIrqDisabled;
 pub use smoltcp::wire::EthernetAddress;
 pub use util::{spawn_background_poll_thread, BindPortConfig};
 pub use virtio::IfaceVirtio;
@@ -77,11 +78,11 @@ mod internal {
     pub trait IfaceInternal {
         fn common(&self) -> &IfaceCommon;
         /// The inner socket set
-        fn sockets(&self) -> SpinLockGuard<SocketSet<'static>> {
+        fn sockets(&self) -> SpinLockGuard<SocketSet<'static>, LocalIrqDisabled> {
             self.common().sockets()
         }
         /// The inner iface.
-        fn iface_inner(&self) -> SpinLockGuard<smoltcp::iface::Interface> {
+        fn iface_inner(&self) -> SpinLockGuard<smoltcp::iface::Interface, LocalIrqDisabled> {
             self.common().interface()
         }
         /// The time we should do another poll.

--- a/kernel/aster-nix/src/net/socket/vsock/stream/connecting.rs
+++ b/kernel/aster-nix/src/net/socket/vsock/stream/connecting.rs
@@ -38,11 +38,11 @@ impl Connecting {
     }
 
     pub fn info(&self) -> ConnectionInfo {
-        self.info.lock_irq_disabled().clone()
+        self.info.disable_irq().lock().clone()
     }
 
     pub fn update_info(&self, event: &VsockEvent) {
-        self.info.lock_irq_disabled().update_for_event(event)
+        self.info.disable_irq().lock().update_for_event(event)
     }
 
     pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {

--- a/kernel/aster-nix/src/sched/priority_scheduler.rs
+++ b/kernel/aster-nix/src/sched/priority_scheduler.rs
@@ -56,7 +56,7 @@ impl<T: Sync + Send + PreemptSchedInfo> Scheduler<T> for PreemptScheduler<T> {
             cpu_id
         };
 
-        let mut rq = self.rq[target_cpu as usize].lock_irq_disabled();
+        let mut rq = self.rq[target_cpu as usize].disable_irq().lock();
         if still_in_rq && let Err(_) = runnable.cpu().set_if_is_none(target_cpu) {
             return None;
         }
@@ -71,13 +71,13 @@ impl<T: Sync + Send + PreemptSchedInfo> Scheduler<T> for PreemptScheduler<T> {
     }
 
     fn local_rq_with(&self, f: &mut dyn FnMut(&dyn LocalRunQueue<T>)) {
-        let local_rq: &PreemptRunQueue<T> = &self.rq[this_cpu() as usize].lock_irq_disabled();
+        let local_rq: &PreemptRunQueue<T> = &self.rq[this_cpu() as usize].disable_irq().lock();
         f(local_rq);
     }
 
     fn local_mut_rq_with(&self, f: &mut dyn FnMut(&mut dyn LocalRunQueue<T>)) {
         let local_rq: &mut PreemptRunQueue<T> =
-            &mut self.rq[this_cpu() as usize].lock_irq_disabled();
+            &mut self.rq[this_cpu() as usize].disable_irq().lock();
         f(local_rq);
     }
 }

--- a/kernel/aster-nix/src/thread/work_queue/mod.rs
+++ b/kernel/aster-nix/src/thread/work_queue/mod.rs
@@ -138,7 +138,8 @@ impl WorkQueue {
             return false;
         }
         self.inner
-            .lock_irq_disabled()
+            .disable_irq()
+            .lock()
             .pending_work_items
             .push(work_item);
         if let Some(worker_pool) = self.worker_pool.upgrade() {
@@ -150,7 +151,7 @@ impl WorkQueue {
     /// Request a pending work item. The `request_cpu` indicates the CPU where
     /// the calling worker is located.
     fn dequeue(&self, request_cpu: u32) -> Option<Arc<WorkItem>> {
-        let mut inner = self.inner.lock_irq_disabled();
+        let mut inner = self.inner.disable_irq().lock();
         let index = inner
             .pending_work_items
             .iter()
@@ -161,7 +162,8 @@ impl WorkQueue {
 
     fn has_pending_work_items(&self, request_cpu: u32) -> bool {
         self.inner
-            .lock_irq_disabled()
+            .disable_irq()
+            .lock()
             .pending_work_items
             .iter()
             .any(|item| item.is_valid_cpu(request_cpu))

--- a/kernel/aster-nix/src/thread/work_queue/worker.rs
+++ b/kernel/aster-nix/src/thread/work_queue/worker.rs
@@ -87,10 +87,10 @@ impl Worker {
                 if self.is_destroying() {
                     break;
                 }
-                self.inner.lock_irq_disabled().worker_status = WorkerStatus::Idle;
+                self.inner.disable_irq().lock().worker_status = WorkerStatus::Idle;
                 worker_pool.idle_current_worker(self.bound_cpu, self.clone());
                 if !self.is_destroying() {
-                    self.inner.lock_irq_disabled().worker_status = WorkerStatus::Running;
+                    self.inner.disable_irq().lock().worker_status = WorkerStatus::Running;
                 }
             }
         }
@@ -102,22 +102,22 @@ impl Worker {
     }
 
     pub(super) fn is_idle(&self) -> bool {
-        self.inner.lock_irq_disabled().worker_status == WorkerStatus::Idle
+        self.inner.disable_irq().lock().worker_status == WorkerStatus::Idle
     }
 
     pub(super) fn is_destroying(&self) -> bool {
-        self.inner.lock_irq_disabled().worker_status == WorkerStatus::Destroying
+        self.inner.disable_irq().lock().worker_status == WorkerStatus::Destroying
     }
 
     pub(super) fn destroy(&self) {
-        self.inner.lock_irq_disabled().worker_status = WorkerStatus::Destroying;
+        self.inner.disable_irq().lock().worker_status = WorkerStatus::Destroying;
     }
 
     fn exit(&self) {
-        self.inner.lock_irq_disabled().worker_status = WorkerStatus::Exited;
+        self.inner.disable_irq().lock().worker_status = WorkerStatus::Exited;
     }
 
     pub(super) fn is_exit(&self) -> bool {
-        self.inner.lock_irq_disabled().worker_status == WorkerStatus::Exited
+        self.inner.disable_irq().lock().worker_status == WorkerStatus::Exited
     }
 }

--- a/kernel/aster-nix/src/time/clocks/cpu_clock.rs
+++ b/kernel/aster-nix/src/time/clocks/cpu_clock.rs
@@ -30,13 +30,13 @@ impl CpuClock {
 
     /// Adds `interval` to the original recorded time to update the `CpuClock`.
     pub fn add_time(&self, interval: Duration) {
-        *self.time.lock_irq_disabled() += interval;
+        *self.time.disable_irq().lock() += interval;
     }
 }
 
 impl Clock for CpuClock {
     fn read_time(&self) -> Duration {
-        *self.time.lock_irq_disabled()
+        *self.time.disable_irq().lock()
     }
 }
 

--- a/kernel/aster-nix/src/time/clocks/system_wide.rs
+++ b/kernel/aster-nix/src/time/clocks/system_wide.rs
@@ -153,7 +153,7 @@ impl Clock for MonotonicClock {
 
 impl Clock for RealTimeCoarseClock {
     fn read_time(&self) -> Duration {
-        *Self::current_ref().get().unwrap().lock_irq_disabled()
+        *Self::current_ref().get().unwrap().disable_irq().lock()
     }
 }
 
@@ -264,7 +264,7 @@ fn init_jiffies_clock_manager() {
 fn update_coarse_clock() {
     let real_time = RealTimeClock::get().read_time();
     let current = RealTimeCoarseClock::current_ref().get().unwrap();
-    *current.lock_irq_disabled() = real_time;
+    *current.disable_irq().lock() = real_time;
 }
 
 fn init_coarse_clock() {

--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -31,7 +31,8 @@ pub fn register_device(name: String, device: Arc<dyn AnyConsoleDevice>) {
         .get()
         .unwrap()
         .console_device_table
-        .lock_irq_disabled()
+        .disable_irq()
+        .lock()
         .insert(name, device);
 }
 
@@ -40,7 +41,8 @@ pub fn all_devices() -> Vec<(String, Arc<dyn AnyConsoleDevice>)> {
         .get()
         .unwrap()
         .console_device_table
-        .lock_irq_disabled();
+        .disable_irq()
+        .lock();
     console_devs
         .iter()
         .map(|(name, device)| (name.clone(), device.clone()))

--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -204,7 +204,8 @@ pub fn _print(args: fmt::Arguments) {
     WRITER
         .get()
         .unwrap()
-        .lock_irq_disabled()
+        .disable_irq()
+        .lock()
         .write_fmt(args)
         .unwrap();
 }

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -74,7 +74,8 @@ impl HasDaddr for TxBuffer {
 impl Drop for TxBuffer {
     fn drop(&mut self) {
         self.pool
-            .lock_irq_disabled()
+            .disable_irq()
+            .lock()
             .push_back(self.dma_stream.clone());
     }
 }
@@ -145,7 +146,7 @@ fn get_tx_stream_from_pool(
     nbytes: usize,
     tx_buffer_pool: &'static SpinLock<LinkedList<DmaStream>>,
 ) -> Option<DmaStream> {
-    let mut pool = tx_buffer_pool.lock_irq_disabled();
+    let mut pool = tx_buffer_pool.disable_irq().lock();
     let mut cursor = pool.cursor_front_mut();
     while let Some(current) = cursor.current() {
         if current.nbytes() >= nbytes {

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -122,7 +122,7 @@ impl InputDevice {
         let input_prop = InputProp::from_bits(prop[0]).unwrap();
         debug!("input device prop:{:?}", input_prop);
 
-        let mut transport = device.transport.lock_irq_disabled();
+        let mut transport = device.transport.disable_irq().lock();
         fn config_space_change(_: &TrapFrame) {
             debug!("input device config space change");
         }
@@ -148,7 +148,7 @@ impl InputDevice {
 
     /// Pop the pending event.
     fn pop_pending_events(&self, handle_event: &impl Fn(&EventBuf) -> bool) {
-        let mut event_queue = self.event_queue.lock_irq_disabled();
+        let mut event_queue = self.event_queue.disable_irq().lock();
 
         // one interrupt may contain several input events, so it should loop
         while let Ok((token, _)) = event_queue.pop_used() {

--- a/kernel/comps/virtio/src/device/socket/mod.rs
+++ b/kernel/comps/virtio/src/device/socket/mod.rs
@@ -21,18 +21,19 @@ pub fn register_device(name: String, device: Arc<SpinLock<SocketDevice>>) {
     VSOCK_DEVICE_TABLE
         .get()
         .unwrap()
-        .lock_irq_disabled()
+        .disable_irq()
+        .lock()
         .insert(name, (Arc::new(SpinLock::new(Vec::new())), device));
 }
 
 pub fn get_device(str: &str) -> Option<Arc<SpinLock<SocketDevice>>> {
-    let lock = VSOCK_DEVICE_TABLE.get().unwrap().lock_irq_disabled();
+    let lock = VSOCK_DEVICE_TABLE.get().unwrap().disable_irq().lock();
     let (_, device) = lock.get(str)?;
     Some(device.clone())
 }
 
 pub fn all_devices() -> Vec<(String, Arc<SpinLock<SocketDevice>>)> {
-    let vsock_devs = VSOCK_DEVICE_TABLE.get().unwrap().lock_irq_disabled();
+    let vsock_devs = VSOCK_DEVICE_TABLE.get().unwrap().disable_irq().lock();
     vsock_devs
         .iter()
         .map(|(name, (_, device))| (name.clone(), device.clone()))
@@ -40,19 +41,19 @@ pub fn all_devices() -> Vec<(String, Arc<SpinLock<SocketDevice>>)> {
 }
 
 pub fn register_recv_callback(name: &str, callback: impl VsockDeviceIrqHandler) {
-    let lock = VSOCK_DEVICE_TABLE.get().unwrap().lock_irq_disabled();
+    let lock = VSOCK_DEVICE_TABLE.get().unwrap().disable_irq().lock();
     let Some((callbacks, _)) = lock.get(name) else {
         return;
     };
-    callbacks.lock_irq_disabled().push(Arc::new(callback));
+    callbacks.disable_irq().lock().push(Arc::new(callback));
 }
 
 pub fn handle_recv_irq(name: &str) {
-    let lock = VSOCK_DEVICE_TABLE.get().unwrap().lock_irq_disabled();
+    let lock = VSOCK_DEVICE_TABLE.get().unwrap().disable_irq().lock();
     let Some((callbacks, _)) = lock.get(name) else {
         return;
     };
-    let lock = callbacks.lock_irq_disabled();
+    let lock = callbacks.disable_irq().lock();
     for callback in lock.iter() {
         callback.call(())
     }

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -10,7 +10,7 @@ use id_alloc::IdAlloc;
 use spin::Once;
 use trapframe::TrapFrame;
 
-use crate::sync::{Mutex, SpinLock, SpinLockGuard};
+use crate::sync::{Mutex, PreemptDisabled, SpinLock, SpinLockGuard};
 
 /// The global allocator for software defined IRQ lines.
 pub(crate) static IRQ_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
@@ -101,7 +101,9 @@ impl IrqLine {
         self.irq_num
     }
 
-    pub fn callback_list(&self) -> SpinLockGuard<alloc::vec::Vec<CallbackElement>> {
+    pub fn callback_list(
+        &self,
+    ) -> SpinLockGuard<alloc::vec::Vec<CallbackElement>, PreemptDisabled> {
         self.callback_list.lock()
     }
 

--- a/ostd/src/arch/x86/serial.rs
+++ b/ostd/src/arch/x86/serial.rs
@@ -26,7 +26,10 @@ pub type InputCallback = dyn Fn(u8) + Send + Sync + 'static;
 
 /// Registers a callback function to be called when there is console input.
 pub fn register_console_input_callback(f: &'static InputCallback) {
-    SERIAL_INPUT_CALLBACKS.lock_irq_disabled().push(Arc::new(f));
+    SERIAL_INPUT_CALLBACKS
+        .disable_irq()
+        .lock()
+        .push(Arc::new(f));
 }
 
 struct Stdout;
@@ -77,7 +80,8 @@ where
     CONSOLE_IRQ_CALLBACK
         .get()
         .unwrap()
-        .lock_irq_disabled()
+        .disable_irq()
+        .lock()
         .on_active(callback);
 }
 

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -59,7 +59,7 @@ impl log::Log for Logger {
         // Use a global lock to prevent interleaving of log messages.
         use crate::sync::SpinLock;
         static RECORD_LOCK: SpinLock<()> = SpinLock::new(());
-        let _lock = RECORD_LOCK.lock_irq_disabled();
+        let _lock = RECORD_LOCK.disable_irq().lock();
 
         early_println!("{} {}: {}", timestamp, level, record_str);
     }

--- a/ostd/src/mm/dma/mod.rs
+++ b/ostd/src/mm/dma/mod.rs
@@ -63,7 +63,7 @@ pub fn init() {
 /// Checks whether the physical addresses has dma mapping.
 /// Fail if they have been mapped, otherwise insert them.
 fn check_and_insert_dma_mapping(start_paddr: Paddr, num_pages: usize) -> bool {
-    let mut mapping_set = DMA_MAPPING_SET.get().unwrap().lock_irq_disabled();
+    let mut mapping_set = DMA_MAPPING_SET.get().unwrap().disable_irq().lock();
     // Ensure that the addresses used later will not overflow
     start_paddr.checked_add(num_pages * PAGE_SIZE).unwrap();
     for i in 0..num_pages {
@@ -81,7 +81,7 @@ fn check_and_insert_dma_mapping(start_paddr: Paddr, num_pages: usize) -> bool {
 
 /// Removes a physical address from the dma mapping set.
 fn remove_dma_mapping(start_paddr: Paddr, num_pages: usize) {
-    let mut mapping_set = DMA_MAPPING_SET.get().unwrap().lock_irq_disabled();
+    let mut mapping_set = DMA_MAPPING_SET.get().unwrap().disable_irq().lock();
     // Ensure that the addresses used later will not overflow
     start_paddr.checked_add(num_pages * PAGE_SIZE).unwrap();
     for i in 0..num_pages {

--- a/ostd/src/mm/heap_allocator.rs
+++ b/ostd/src/mm/heap_allocator.rs
@@ -53,13 +53,14 @@ impl<const ORDER: usize> LockedHeapWithRescue<ORDER> {
 
     /// SAFETY: The range [start, start + size) must be a valid memory region.
     pub unsafe fn init(&self, start: *const u8, size: usize) {
-        self.heap.lock_irq_disabled().init(start as usize, size);
+        self.heap.disable_irq().lock().init(start as usize, size);
     }
 
     /// SAFETY: The range [start, start + size) must be a valid memory region.
     unsafe fn add_to_heap(&self, start: usize, size: usize) {
         self.heap
-            .lock_irq_disabled()
+            .disable_irq()
+            .lock()
             .add_to_heap(start, start + size)
     }
 }
@@ -88,7 +89,8 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         debug_assert!(ptr as usize != 0);
         self.heap
-            .lock_irq_disabled()
+            .disable_irq()
+            .lock()
             .dealloc(NonNull::new_unchecked(ptr), layout)
     }
 }

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -24,6 +24,6 @@ pub use self::{
         ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
         RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
     },
-    spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
+    spin::{ArcSpinLockGuard, LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard},
     wait::{WaitQueue, Waiter, Waker},
 };

--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -37,7 +37,7 @@ impl RcuMonitor {
         // on the current CPU. If GP is complete, take the callbacks of the current
         // GP.
         let callbacks = {
-            let mut state = self.state.lock_irq_disabled();
+            let mut state = self.state.disable_irq().lock();
             if state.current_gp.is_complete() {
                 return;
             }
@@ -71,7 +71,7 @@ impl RcuMonitor {
     where
         F: FnOnce() -> () + Send + 'static,
     {
-        let mut state = self.state.lock_irq_disabled();
+        let mut state = self.state.disable_irq().lock();
 
         state.next_callbacks.push_back(Box::new(f));
 

--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -123,7 +123,7 @@ impl WaitQueue {
         }
 
         loop {
-            let mut wakers = self.wakers.lock_irq_disabled();
+            let mut wakers = self.wakers.disable_irq().lock();
             let Some(waker) = wakers.pop_front() else {
                 return false;
             };
@@ -147,7 +147,7 @@ impl WaitQueue {
         let mut num_woken = 0;
 
         loop {
-            let mut wakers = self.wakers.lock_irq_disabled();
+            let mut wakers = self.wakers.disable_irq().lock();
             let Some(waker) = wakers.pop_front() else {
                 break;
             };
@@ -171,7 +171,7 @@ impl WaitQueue {
     }
 
     fn enqueue(&self, waker: Arc<Waker>) {
-        let mut wakers = self.wakers.lock_irq_disabled();
+        let mut wakers = self.wakers.disable_irq().lock();
         wakers.push_back(waker);
         self.num_wakers.fetch_add(1, Ordering::Acquire);
     }

--- a/ostd/src/task/scheduler/fifo_scheduler.rs
+++ b/ostd/src/task/scheduler/fifo_scheduler.rs
@@ -51,7 +51,7 @@ impl<T: FifoSchedInfo + Send + Sync> Scheduler<T> for FifoScheduler<T> {
             cpu_id
         };
 
-        let mut rq = self.rq[target_cpu as usize].lock_irq_disabled();
+        let mut rq = self.rq[target_cpu as usize].disable_irq().lock();
         if still_in_rq && let Err(_) = runnable.cpu().set_if_is_none(target_cpu) {
             return None;
         }
@@ -61,12 +61,12 @@ impl<T: FifoSchedInfo + Send + Sync> Scheduler<T> for FifoScheduler<T> {
     }
 
     fn local_rq_with(&self, f: &mut dyn FnMut(&dyn LocalRunQueue<T>)) {
-        let local_rq: &FifoRunQueue<T> = &self.rq[this_cpu() as usize].lock_irq_disabled();
+        let local_rq: &FifoRunQueue<T> = &self.rq[this_cpu() as usize].disable_irq().lock();
         f(local_rq);
     }
 
     fn local_mut_rq_with(&self, f: &mut dyn FnMut(&mut dyn LocalRunQueue<T>)) {
-        let local_rq: &mut FifoRunQueue<T> = &mut self.rq[this_cpu() as usize].lock_irq_disabled();
+        let local_rq: &mut FifoRunQueue<T> = &mut self.rq[this_cpu() as usize].disable_irq().lock();
         f(local_rq);
     }
 }


### PR DESCRIPTION
This PR is related to Issue #1117, which proposes to refactor the API of SpinLock to improve the ergonomics when using spinlocks with IRQ disabled.

I followed three steps:
1. Modify SpinLock ergonomics in spin.rs file, considering draft implementations in Issue #1117
2. Modify the use of SpinLock in other files
3. Improve the implementations, considering lrh2000's advice to abandon `repr(C)`

Now the code could compile successfully, and pass almost every tests, except one ktest. However, there is one _FIXME_ note above the source code, and in other similar situations it passes successfully, so I'm not sure if the error is my fault.