### PR TITLE
Fix lmbench-ctx extraction

### DIFF
--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -88,9 +88,9 @@ run_benchmark() {
 
     echo "Parsing results..."
     local linux_avg aster_avg
-    linux_avg=$(awk "/${search_pattern}/{print \$$result_index}" "${linux_output}" | tr -d '\r')
-    aster_avg=$(awk "/${search_pattern}/{print \$$result_index}" "${aster_output}" | tr -d '\r')
-
+    linux_avg=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${linux_output}" | tr -d '\r')
+    aster_avg=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${aster_output}" | tr -d '\r')
+    
     if [ -z "${linux_avg}" ] || [ -z "${aster_avg}" ]; then
         echo "Error: Failed to parse the average value from the benchmark output" >&2
         exit 1


### PR DESCRIPTION
The `lmbench-ctx` script occasionally extracts an excessive number of values due to its search pattern being set as `18 `. Unfortunately, there is no more suitable pattern available for the output. Typically, the benchmark terminates promptly upon completion, making it logical to opt for the final matched data as the conclusive result. This pull request introduces the use of `tail -n 1` to guarantee that solely the last matched result is selected.

An alternative is using other tools like `grep`, which needs more modifications on existed benchmarks.