### PR TITLE
Fix some behavior in `get{sock,peer}name()` and `connect()` for UNIX sockets

### DIFF
--- a/kernel/aster-nix/src/net/socket/unix/addr.rs
+++ b/kernel/aster-nix/src/net/socket/unix/addr.rs
@@ -48,9 +48,17 @@ impl From<UnixSocketAddrBound> for UnixSocketAddr {
     }
 }
 
-impl From<UnixSocketAddrBound> for SocketAddr {
-    fn from(value: UnixSocketAddrBound) -> Self {
-        let unix_socket_addr = UnixSocketAddr::from(value);
-        SocketAddr::Unix(unix_socket_addr)
+impl From<Option<UnixSocketAddrBound>> for UnixSocketAddr {
+    fn from(value: Option<UnixSocketAddrBound>) -> Self {
+        match value {
+            Some(addr) => addr.into(),
+            None => Self::Unnamed,
+        }
+    }
+}
+
+impl<T: Into<UnixSocketAddr>> From<T> for SocketAddr {
+    fn from(value: T) -> Self {
+        SocketAddr::Unix(value.into())
     }
 }

--- a/kernel/aster-nix/src/net/socket/unix/addr.rs
+++ b/kernel/aster-nix/src/net/socket/unix/addr.rs
@@ -5,14 +5,14 @@ use crate::{fs::path::Dentry, net::socket::util::socket_addr::SocketAddr, prelud
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UnixSocketAddr {
     Unnamed,
-    Path(String),
-    Abstract(Vec<u8>),
+    Path(Arc<str>),
+    Abstract(Arc<[u8]>),
 }
 
 #[derive(Clone, Debug)]
 pub(super) enum UnixSocketAddrBound {
-    Path(Arc<Dentry>),
-    Abstract(Vec<u8>),
+    Path(Arc<str>, Arc<Dentry>),
+    Abstract(Arc<[u8]>),
 }
 
 impl TryFrom<SocketAddr> for UnixSocketAddr {
@@ -29,10 +29,7 @@ impl TryFrom<SocketAddr> for UnixSocketAddr {
 impl From<UnixSocketAddrBound> for UnixSocketAddr {
     fn from(value: UnixSocketAddrBound) -> Self {
         match value {
-            UnixSocketAddrBound::Path(dentry) => {
-                let abs_path = dentry.abs_path();
-                Self::Path(abs_path)
-            }
+            UnixSocketAddrBound::Path(path, _) => Self::Path(path),
             UnixSocketAddrBound::Abstract(name) => Self::Abstract(name),
         }
     }

--- a/kernel/aster-nix/src/net/socket/unix/addr.rs
+++ b/kernel/aster-nix/src/net/socket/unix/addr.rs
@@ -9,20 +9,10 @@ pub enum UnixSocketAddr {
     Abstract(Vec<u8>),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) enum UnixSocketAddrBound {
     Path(Arc<Dentry>),
     Abstract(Vec<u8>),
-}
-
-impl PartialEq for UnixSocketAddrBound {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Abstract(l0), Self::Abstract(r0)) => l0 == r0,
-            (Self::Path(l0), Self::Path(r0)) => Arc::ptr_eq(l0.inode(), r0.inode()),
-            _ => false,
-        }
-    }
 }
 
 impl TryFrom<SocketAddr> for UnixSocketAddr {

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -45,17 +45,11 @@ impl Init {
     }
 
     pub(super) fn connect(&self, remote_addr: &UnixSocketAddrBound) -> Result<Connected> {
-        let addr = self.addr();
-
-        if let Some(addr) = addr {
-            if *addr == *remote_addr {
-                return_errno_with_message!(Errno::EINVAL, "try to connect to self is invalid");
-            }
-        }
-
-        let (this_end, remote_end) = Endpoint::new_pair(addr.cloned(), Some(remote_addr.clone()));
+        let (this_end, remote_end) =
+            Endpoint::new_pair(self.addr.clone(), Some(remote_addr.clone()));
 
         push_incoming(remote_addr, remote_end)?;
+
         Ok(Connected::new(this_end))
     }
 

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -26,7 +26,7 @@ impl Init {
         }
     }
 
-    pub(super) fn bind(&mut self, addr_to_bind: &UnixSocketAddr) -> Result<()> {
+    pub(super) fn bind(&mut self, addr_to_bind: UnixSocketAddr) -> Result<()> {
         if self.addr.is_some() {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound");
         }
@@ -35,8 +35,8 @@ impl Init {
             UnixSocketAddr::Unnamed => todo!(),
             UnixSocketAddr::Abstract(_) => todo!(),
             UnixSocketAddr::Path(path) => {
-                let dentry = create_socket_file(path)?;
-                UnixSocketAddrBound::Path(dentry)
+                let dentry = create_socket_file(&path)?;
+                UnixSocketAddrBound::Path(path, dentry)
             }
         };
         self.addr = Some(bound_addr);

--- a/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
@@ -82,7 +82,7 @@ impl BacklogTable {
 
     fn add_backlog(&self, addr: &UnixSocketAddrBound, backlog: usize) -> Result<()> {
         let inode = {
-            let UnixSocketAddrBound::Path(dentry) = addr else {
+            let UnixSocketAddrBound::Path(_, dentry) = addr else {
                 todo!()
             };
             create_keyable_inode(dentry)
@@ -99,7 +99,7 @@ impl BacklogTable {
 
     fn get_backlog(&self, addr: &UnixSocketAddrBound) -> Result<Arc<Backlog>> {
         let inode = {
-            let UnixSocketAddrBound::Path(dentry) = addr else {
+            let UnixSocketAddrBound::Path(_, dentry) = addr else {
                 todo!()
             };
             create_keyable_inode(dentry)
@@ -134,7 +134,7 @@ impl BacklogTable {
     }
 
     fn remove_backlog(&self, addr: &UnixSocketAddrBound) {
-        let UnixSocketAddrBound::Path(dentry) = addr else {
+        let UnixSocketAddrBound::Path(_, dentry) = addr else {
             todo!()
         };
 

--- a/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
@@ -6,10 +6,7 @@ use super::{connected::Connected, endpoint::Endpoint, UnixStreamSocket};
 use crate::{
     events::{IoEvents, Observer},
     fs::{file_handle::FileLike, path::Dentry, utils::Inode},
-    net::socket::{
-        unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
-        SocketAddr,
-    },
+    net::socket::{unix::addr::UnixSocketAddrBound, SocketAddr},
     prelude::*,
     process::signal::{Pollee, Poller},
 };
@@ -36,10 +33,7 @@ impl Listener {
             Connected::new(local_endpoint)
         };
 
-        let peer_addr = match connected.peer_addr() {
-            None => SocketAddr::Unix(UnixSocketAddr::Path(String::new())),
-            Some(addr) => SocketAddr::from(addr.clone()),
-        };
+        let peer_addr = connected.peer_addr().cloned().into();
 
         let socket = UnixStreamSocket::new_connected(connected, false);
 

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -198,7 +198,7 @@ impl Socket for UnixStreamSocket {
         let addr = UnixSocketAddr::try_from(socket_addr)?;
 
         match &mut *self.state.write() {
-            State::Init(init) => init.bind(&addr),
+            State::Init(init) => init.bind(addr),
             _ => return_errno_with_message!(
                 Errno::EINVAL,
                 "cannot bind a listening or connected socket"
@@ -217,7 +217,7 @@ impl Socket for UnixStreamSocket {
                 }
                 UnixSocketAddr::Path(path) => {
                     let dentry = lookup_socket_file(&path)?;
-                    UnixSocketAddrBound::Path(dentry)
+                    UnixSocketAddrBound::Path(path, dentry)
                 }
             }
         };

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -74,7 +74,7 @@ impl UnixStreamSocket {
     fn bound_addr(&self) -> Option<UnixSocketAddrBound> {
         let state = self.state.read();
         match &*state {
-            State::Init(init) => init.addr(),
+            State::Init(init) => init.addr().cloned(),
             State::Listen(listen) => Some(listen.addr().clone()),
             State::Connected(connected) => connected.addr().cloned(),
         }
@@ -197,7 +197,7 @@ impl Socket for UnixStreamSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
         let addr = UnixSocketAddr::try_from(socket_addr)?;
 
-        match &*self.state.read() {
+        match &mut *self.state.write() {
             State::Init(init) => init.bind(&addr),
             _ => return_errno_with_message!(
                 Errno::EINVAL,
@@ -273,7 +273,7 @@ impl Socket for UnixStreamSocket {
 
     fn addr(&self) -> Result<SocketAddr> {
         let addr = match &*self.state.read() {
-            State::Init(init) => init.addr(),
+            State::Init(init) => init.addr().cloned(),
             State::Listen(listen) => Some(listen.addr().clone()),
             State::Connected(connected) => connected.addr().cloned(),
         };

--- a/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/socket.rs
@@ -278,11 +278,7 @@ impl Socket for UnixStreamSocket {
             State::Connected(connected) => connected.addr().cloned(),
         };
 
-        addr.map(Into::<SocketAddr>::into)
-            .ok_or(Error::with_message(
-                Errno::EINVAL,
-                "the socket does not bind to addr",
-            ))
+        Ok(addr.into())
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -291,10 +287,7 @@ impl Socket for UnixStreamSocket {
             _ => return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected"),
         };
 
-        match peer_addr {
-            None => Ok(SocketAddr::Unix(UnixSocketAddr::Path(String::new()))),
-            Some(peer_addr) => Ok(SocketAddr::from(peer_addr)),
-        }
+        Ok(peer_addr.into())
     }
 
     fn sendmsg(

--- a/kernel/aster-nix/src/util/net/addr/unix.rs
+++ b/kernel/aster-nix/src/util/net/addr/unix.rs
@@ -91,16 +91,16 @@ pub(super) fn from_c_bytes(bytes: &[u8]) -> Result<UnixSocketAddr> {
     }
 
     if sun_path[0] == 0 {
-        return Ok(UnixSocketAddr::Abstract(Vec::from(&sun_path[1..])));
+        return Ok(UnixSocketAddr::Abstract(Arc::from(&sun_path[1..])));
     }
 
     // Again, Linux always appends a null terminator to the pathname if none is supplied. So we
     // need to deal with the case where `CStr::from_bytes_until_nul` fails.
     if let Ok(c_str) = CStr::from_bytes_until_nul(sun_path) {
-        Ok(UnixSocketAddr::Path(c_str.to_string_lossy().to_string()))
+        Ok(UnixSocketAddr::Path(Arc::from(c_str.to_string_lossy())))
     } else {
-        Ok(UnixSocketAddr::Path(
-            String::from_utf8_lossy(sun_path).to_string(),
-        ))
+        Ok(UnixSocketAddr::Path(Arc::from(String::from_utf8_lossy(
+            sun_path,
+        ))))
     }
 }

--- a/test/apps/network/unix_err.c
+++ b/test/apps/network/unix_err.c
@@ -194,3 +194,27 @@ FN_TEST(getpeername)
 			 memcmp(&addr, &UNNAMED_ADDR, UNNAMED_ADDRLEN) == 0);
 }
 END_TEST()
+
+FN_TEST(connect)
+{
+	TEST_ERRNO(connect(sk_unbound, (struct sockaddr *)&BOUND_ADDR,
+			   BOUND_ADDRLEN),
+		   ECONNREFUSED);
+
+	TEST_ERRNO(connect(sk_bound, (struct sockaddr *)&BOUND_ADDR,
+			   BOUND_ADDRLEN),
+		   ECONNREFUSED);
+
+	TEST_ERRNO(connect(sk_listen, (struct sockaddr *)&LISTEN_ADDR,
+			   LISTEN_ADDRLEN),
+		   EINVAL);
+
+	TEST_ERRNO(connect(sk_connected, (struct sockaddr *)&LISTEN_ADDR,
+			   LISTEN_ADDRLEN),
+		   EISCONN);
+
+	TEST_ERRNO(connect(sk_connected, (struct sockaddr *)&LISTEN_ADDR,
+			   LISTEN_ADDRLEN),
+		   EISCONN);
+}
+END_TEST()

--- a/test/apps/network/unix_err.c
+++ b/test/apps/network/unix_err.c
@@ -88,12 +88,12 @@ static int sk_accepted;
 #define UNNAMED_ADDRLEN PATH_OFFSET
 
 #define BOUND_ADDR \
-	((struct sockaddr_un){ .sun_family = AF_UNIX, .sun_path = "/tmp/B0" })
-#define BOUND_ADDRLEN (PATH_OFFSET + 8)
+	((struct sockaddr_un){ .sun_family = AF_UNIX, .sun_path = "//tmp/B0" })
+#define BOUND_ADDRLEN (PATH_OFFSET + 9)
 
 #define LISTEN_ADDR \
-	((struct sockaddr_un){ .sun_family = AF_UNIX, .sun_path = "/tmp/L0" })
-#define LISTEN_ADDRLEN (PATH_OFFSET + 8)
+	((struct sockaddr_un){ .sun_family = AF_UNIX, .sun_path = "/tmp//L0" })
+#define LISTEN_ADDRLEN (PATH_OFFSET + 9)
 
 FN_SETUP(unbound)
 {


### PR DESCRIPTION
I have ~15 commits that fix all the bugs (or just inconsistencies with the Linux kernel implementation) that I know of in UNIX sockets. This PR contains the first four commits.

This PR mainly focuses on fixing some incorrect results generated by `get{sock,peer}name()`:
 - `getsockname()` will never fail, even if the socket is unbound.
 - `get{sock,peer}name()` must always return the original bound name. Using `dentry.abs_path()` to regenerate the name is incorrect because the absolute path may be too long, exceeding the length limit required by `struct sockaddr_un`.

This PR also contains some other random fixes, because they probably aren't worth opening another PR for, and there will be conflicts if I do.
 - `Init::bind` should take `&mut self`, so we don't need another layer of locks.
 - The self-connecting check in `Init::connect` seems to be pointless and leads to wrong error codes. So the check is removed.
