### PR TITLE
Refactor `VmReader`&`VmWriter` as given fallibility marker

### DIFF
--- a/kernel/aster-nix/src/device/tty/driver.rs
+++ b/kernel/aster-nix/src/device/tty/driver.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use ostd::mm::VmReader;
+use ostd::mm::{Infallible, VmReader};
 use spin::Once;
 
 use crate::{
@@ -78,7 +78,7 @@ impl Default for TtyDriver {
     }
 }
 
-fn console_input_callback(mut reader: VmReader) {
+fn console_input_callback(mut reader: VmReader<Infallible>) {
     let tty_driver = get_tty_driver();
     while reader.remain() > 0 {
         let ch = reader.read_val().unwrap();

--- a/kernel/aster-nix/src/prelude.rs
+++ b/kernel/aster-nix/src/prelude.rs
@@ -17,7 +17,7 @@ pub(crate) use bitflags::bitflags;
 pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use log::{debug, error, info, log_enabled, trace, warn};
 pub(crate) use ostd::{
-    mm::{Vaddr, VmReader, VmWriter, PAGE_SIZE},
+    mm::{FallibleVmRead, FallibleVmWrite, Vaddr, VmReader, VmWriter, PAGE_SIZE},
     sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
     Pod,
 };

--- a/kernel/aster-nix/src/vm/vmo/mod.rs
+++ b/kernel/aster-nix/src/vm/vmo/mod.rs
@@ -11,7 +11,7 @@ use align_ext::AlignExt;
 use aster_rights::Rights;
 use ostd::{
     collections::xarray::{CursorMut, XArray},
-    mm::{Frame, FrameAllocOptions, VmReader, VmWriter},
+    mm::{Frame, FrameAllocOptions, Infallible, VmReader, VmWriter},
 };
 
 use crate::prelude::*;
@@ -304,7 +304,7 @@ impl Vmo_ {
         let read_len = buf.len();
         let read_range = offset..(offset + read_len);
         let mut read_offset = offset % PAGE_SIZE;
-        let mut buf_writer: VmWriter = buf.into();
+        let mut buf_writer: VmWriter<Infallible> = buf.into();
 
         let read = move |page: Frame| {
             page.reader().skip(read_offset).read(&mut buf_writer);
@@ -319,7 +319,7 @@ impl Vmo_ {
         let write_len = buf.len();
         let write_range = offset..(offset + write_len);
         let mut write_offset = offset % PAGE_SIZE;
-        let mut buf_reader: VmReader = buf.into();
+        let mut buf_reader: VmReader<Infallible> = buf.into();
 
         let mut write = move |page: Frame| {
             page.writer().skip(write_offset).write(&mut buf_reader);

--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -3,7 +3,7 @@
 use align_ext::AlignExt;
 use int_to_c_enum::TryFromInt;
 use ostd::{
-    mm::{Frame, Segment, VmReader, VmWriter},
+    mm::{Frame, Infallible, Segment, VmReader, VmWriter},
     sync::WaitQueue,
 };
 
@@ -423,7 +423,7 @@ impl<'a> BioSegment {
     }
 
     /// Returns a reader to read data from it.
-    pub fn reader(&'a self) -> VmReader<'a> {
+    pub fn reader(&'a self) -> VmReader<'a, Infallible> {
         self.pages
             .reader()
             .skip(self.offset.value())
@@ -431,7 +431,7 @@ impl<'a> BioSegment {
     }
 
     /// Returns a writer to write data into it.
-    pub fn writer(&'a self) -> VmWriter<'a> {
+    pub fn writer(&'a self) -> VmWriter<'a, Infallible> {
         self.pages
             .writer()
             .skip(self.offset.value())

--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -11,10 +11,13 @@ use alloc::{collections::BTreeMap, fmt::Debug, string::String, sync::Arc, vec::V
 use core::any::Any;
 
 use component::{init_component, ComponentInitError};
-use ostd::{mm::VmReader, sync::SpinLock};
+use ostd::{
+    mm::{Infallible, VmReader},
+    sync::SpinLock,
+};
 use spin::Once;
 
-pub type ConsoleCallback = dyn Fn(VmReader) + Send + Sync;
+pub type ConsoleCallback = dyn Fn(VmReader<Infallible>) + Send + Sync;
 
 pub trait AnyConsoleDevice: Send + Sync + Any + Debug {
     fn send(&self, buf: &[u8]);

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -5,7 +5,8 @@ use alloc::{collections::LinkedList, sync::Arc};
 use align_ext::AlignExt;
 use ostd::{
     mm::{
-        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, VmReader, VmWriter, PAGE_SIZE,
+        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, Infallible, VmReader,
+        VmWriter, PAGE_SIZE,
     },
     sync::SpinLock,
     Pod,
@@ -52,7 +53,7 @@ impl TxBuffer {
         tx_buffer
     }
 
-    pub fn writer(&self) -> VmWriter<'_> {
+    pub fn writer(&self) -> VmWriter<'_, Infallible> {
         self.dma_stream.writer().unwrap().limit(self.nbytes)
     }
 
@@ -106,7 +107,7 @@ impl RxBuffer {
         self.packet_len = packet_len;
     }
 
-    pub fn packet(&self) -> VmReader<'_> {
+    pub fn packet(&self) -> VmReader<'_, Infallible> {
         self.segment
             .sync(self.header_len..self.header_len + self.packet_len)
             .unwrap();
@@ -117,7 +118,7 @@ impl RxBuffer {
             .limit(self.packet_len)
     }
 
-    pub fn buf(&self) -> VmReader<'_> {
+    pub fn buf(&self) -> VmReader<'_, Infallible> {
         self.segment
             .sync(0..self.header_len + self.packet_len)
             .unwrap();

--- a/kernel/comps/network/src/dma_pool.rs
+++ b/kernel/comps/network/src/dma_pool.rs
@@ -11,7 +11,8 @@ use core::ops::Range;
 use bitvec::{array::BitArray, prelude::Lsb0};
 use ostd::{
     mm::{
-        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, VmReader, VmWriter, PAGE_SIZE,
+        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, Infallible, VmReader,
+        VmWriter, PAGE_SIZE,
     },
     sync::{RwLock, SpinLock},
 };
@@ -233,12 +234,12 @@ impl DmaSegment {
         self.size
     }
 
-    pub fn reader(&self) -> Result<VmReader<'_>, ostd::Error> {
+    pub fn reader(&self) -> Result<VmReader<'_, Infallible>, ostd::Error> {
         let offset = self.start_addr - self.dma_stream.daddr();
         Ok(self.dma_stream.reader()?.skip(offset).limit(self.size))
     }
 
-    pub fn writer(&self) -> Result<VmWriter<'_>, ostd::Error> {
+    pub fn writer(&self) -> Result<VmWriter<'_, Infallible>, ostd::Error> {
         let offset = self.start_addr - self.dma_stream.daddr();
         Ok(self.dma_stream.writer()?.skip(offset).limit(self.size))
     }

--- a/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
+++ b/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
@@ -13,8 +13,8 @@ use alloc::vec;
 use ostd::arch::qemu::{exit_qemu, QemuExitCode};
 use ostd::cpu::UserContext;
 use ostd::mm::{
-    CachePolicy, FrameAllocOptions, PageFlags, PageProperty, Vaddr, VmIo, VmSpace, VmWriter,
-    PAGE_SIZE,
+    CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PageFlags, PageProperty,
+    Vaddr, VmIo, VmSpace, VmWriter, PAGE_SIZE,
 };
 use ostd::prelude::*;
 use ostd::task::{Task, TaskOptions};

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -13,7 +13,7 @@ use crate::{
         io::VmIoOnce,
         kspace::{paddr_to_vaddr, KERNEL_PAGE_TABLE},
         page_prop::CachePolicy,
-        HasPaddr, Paddr, PodOnce, Segment, VmIo, VmReader, VmWriter, PAGE_SIZE,
+        HasPaddr, Infallible, Paddr, PodOnce, Segment, VmIo, VmReader, VmWriter, PAGE_SIZE,
     },
     prelude::*,
 };
@@ -192,12 +192,12 @@ impl VmIoOnce for DmaCoherent {
 
 impl<'a> DmaCoherent {
     /// Returns a reader to read data from it.
-    pub fn reader(&'a self) -> VmReader<'a> {
+    pub fn reader(&'a self) -> VmReader<'a, Infallible> {
         self.inner.vm_segment.reader()
     }
 
     /// Returns a writer to write data into it.
-    pub fn writer(&'a self) -> VmWriter<'a> {
+    pub fn writer(&'a self) -> VmWriter<'a, Infallible> {
         self.inner.vm_segment.writer()
     }
 }

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -11,7 +11,7 @@ use crate::{
     error::Error,
     mm::{
         dma::{dma_type, Daddr, DmaType},
-        HasPaddr, Paddr, Segment, VmIo, VmReader, VmWriter, PAGE_SIZE,
+        HasPaddr, Infallible, Paddr, Segment, VmIo, VmReader, VmWriter, PAGE_SIZE,
     },
 };
 
@@ -220,7 +220,7 @@ impl VmIo for DmaStream {
 
 impl<'a> DmaStream {
     /// Returns a reader to read data from it.
-    pub fn reader(&'a self) -> Result<VmReader<'a>, Error> {
+    pub fn reader(&'a self) -> Result<VmReader<'a, Infallible>, Error> {
         if self.inner.direction == DmaDirection::ToDevice {
             return Err(Error::AccessDenied);
         }
@@ -228,7 +228,7 @@ impl<'a> DmaStream {
     }
 
     /// Returns a writer to write data into it.
-    pub fn writer(&'a self) -> Result<VmWriter<'a>, Error> {
+    pub fn writer(&'a self) -> Result<VmWriter<'a, Infallible>, Error> {
         if self.inner.direction == DmaDirection::FromDevice {
             return Err(Error::AccessDenied);
         }

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -9,7 +9,7 @@ use super::Frame;
 use crate::{
     mm::{
         page::{cont_pages::ContPages, meta::FrameMeta, Page},
-        HasPaddr, Paddr, VmIo, VmReader, VmWriter, PAGE_SIZE,
+        HasPaddr, Infallible, Paddr, VmIo, VmReader, VmWriter, PAGE_SIZE,
     },
     Error, Result,
 };
@@ -95,7 +95,7 @@ impl Segment {
 
 impl<'a> Segment {
     /// Returns a reader to read data from it.
-    pub fn reader(&'a self) -> VmReader<'a> {
+    pub fn reader(&'a self) -> VmReader<'a, Infallible> {
         // SAFETY:
         // - The memory range points to untyped memory.
         // - The segment is alive during the lifetime `'a`.
@@ -104,7 +104,7 @@ impl<'a> Segment {
     }
 
     /// Returns a writer to write data into it.
-    pub fn writer(&'a self) -> VmWriter<'a> {
+    pub fn writer(&'a self) -> VmWriter<'a, Infallible> {
         // SAFETY:
         // - The memory range points to untyped memory.
         // - The segment is alive during the lifetime `'a`.

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -28,7 +28,10 @@ use spin::Once;
 pub use self::{
     dma::{Daddr, DmaCoherent, DmaDirection, DmaStream, DmaStreamSlice, HasDaddr},
     frame::{options::FrameAllocOptions, Frame, Segment},
-    io::{KernelSpace, PodOnce, UserSpace, VmIo, VmIoOnce, VmReader, VmWriter},
+    io::{
+        Fallible, FallibleVmRead, FallibleVmWrite, Infallible, PodOnce, VmIo, VmIoOnce, VmReader,
+        VmWriter,
+    },
     page_prop::{CachePolicy, PageFlags, PageProperty},
     vm_space::VmSpace,
 };

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -14,7 +14,7 @@ use core::ops::Range;
 use spin::Once;
 
 use super::{
-    io::UserSpace,
+    io::Fallible,
     kspace::KERNEL_PAGE_TABLE,
     page_table::{PageTable, UserMode},
     PageFlags, PageProperty, VmReader, VmWriter,
@@ -192,7 +192,7 @@ impl VmSpace {
     ///
     /// Returns `Err` if this `VmSpace` is not belonged to the user space of the current task
     /// or the `vaddr` and `len` do not represent a user space memory range.
-    pub fn reader(&self, vaddr: Vaddr, len: usize) -> Result<VmReader<'_, UserSpace>> {
+    pub fn reader(&self, vaddr: Vaddr, len: usize) -> Result<VmReader<'_, Fallible>> {
         if current_page_table_paddr() != unsafe { self.pt.root_paddr() } {
             return Err(Error::AccessDenied);
         }
@@ -206,14 +206,14 @@ impl VmSpace {
         // the `VmReader`.
         //
         // SAFETY: The memory range is in user space, as checked above.
-        Ok(unsafe { VmReader::<UserSpace>::from_user_space(vaddr as *const u8, len) })
+        Ok(unsafe { VmReader::<Fallible>::from_user_space(vaddr as *const u8, len) })
     }
 
     /// Creates a writer to write data into the user space.
     ///
     /// Returns `Err` if this `VmSpace` is not belonged to the user space of the current task
     /// or the `vaddr` and `len` do not represent a user space memory range.
-    pub fn writer(&self, vaddr: Vaddr, len: usize) -> Result<VmWriter<'_, UserSpace>> {
+    pub fn writer(&self, vaddr: Vaddr, len: usize) -> Result<VmWriter<'_, Fallible>> {
         if current_page_table_paddr() != unsafe { self.pt.root_paddr() } {
             return Err(Error::AccessDenied);
         }
@@ -227,7 +227,7 @@ impl VmSpace {
         // the `VmWriter`.
         //
         // SAFETY: The memory range is in user space, as checked above.
-        Ok(unsafe { VmWriter::<UserSpace>::from_user_space(vaddr as *mut u8, len) })
+        Ok(unsafe { VmWriter::<Fallible>::from_user_space(vaddr as *mut u8, len) })
     }
 }
 


### PR DESCRIPTION
This PR gives a try on refactoring `VmReader`&`VmWriter` by giving marker generic type `Fallible`&`NonFallible` rather `UserSpace`&`KernelSpace`.
This revision will satisfy the ongoing need of refactoring all APIs in vfs layer, that we will only take any `VmReader<Fallible>`&`VmWriter<Fallible>` by default.

@tatetian @cchanging , could you review the overall revision first? I didn't update any docs yet, it's only a draft for now.