### PR TITLE
Enable IRQ before leaving OSTD & remove preempt guard from IRQ guard

### DIFF
--- a/kernel/aster-nix/src/lib.rs
+++ b/kernel/aster-nix/src/lib.rs
@@ -89,9 +89,6 @@ fn init_thread() {
     // Work queue should be initialized before interrupt is enabled,
     // in case any irq handler uses work queue as bottom half
     thread::work_queue::init();
-    // FIXME: Remove this if we move the step of mounting
-    // the filesystems to be done within the init process.
-    ostd::trap::enable_local();
     net::lazy_init();
     fs::lazy_init();
     // driver::pci::virtio::block::block_device_test();

--- a/kernel/aster-nix/src/taskless.rs
+++ b/kernel/aster-nix/src/taskless.rs
@@ -190,7 +190,7 @@ fn taskless_softirq_handler(
 mod test {
     use core::sync::atomic::AtomicUsize;
 
-    use ostd::{prelude::*, trap::enable_local};
+    use ostd::prelude::*;
 
     use super::*;
 
@@ -198,7 +198,6 @@ mod test {
         static DONE: AtomicBool = AtomicBool::new(false);
         if !DONE.load(Ordering::SeqCst) {
             super::init();
-            enable_local();
             DONE.store(true, Ordering::SeqCst);
         }
     }

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -119,6 +119,7 @@ fn ap_early_entry(local_apic_id: u32) -> ! {
     }
 
     trap::init();
+    crate::arch::irq::enable_local();
 
     // Mark the AP as started.
     let ap_boot_info = AP_BOOT_INFO.get().unwrap();

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -86,6 +86,8 @@ pub fn init() {
 
     mm::kspace::activate_kernel_page_table();
 
+    arch::irq::enable_local();
+
     invoke_ffi_init_funcs();
 }
 

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -172,18 +172,3 @@ impl Drop for DisabledLocalIrqGuard {
         }
     }
 }
-
-/// Enables all IRQs on the current CPU.
-///
-/// FIXME: The reason we need to add this API is that currently IRQs
-/// are enabled when the CPU enters the user space for the first time,
-/// which is too late. During the OS initialization phase,
-/// we need to get the block device working and mount the filesystems,
-/// thus requiring the IRQs should be enabled as early as possible.
-///
-/// FIXME: this method may be unsound.
-pub fn enable_local() {
-    if !crate::arch::irq::is_local_enabled() {
-        crate::arch::irq::enable_local();
-    }
-}

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -9,7 +9,6 @@ use trapframe::TrapFrame;
 use crate::{
     arch::irq::{self, IrqCallbackHandle, IRQ_ALLOCATOR},
     prelude::*,
-    task::{disable_preempt, DisablePreemptGuard},
     Error,
 };
 
@@ -135,7 +134,6 @@ pub fn disable_local() -> DisabledLocalIrqGuard {
 #[must_use]
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
-    preempt_guard: DisablePreemptGuard,
 }
 
 impl !Send for DisabledLocalIrqGuard {}
@@ -146,11 +144,7 @@ impl DisabledLocalIrqGuard {
         if was_enabled {
             irq::disable_local();
         }
-        let preempt_guard = disable_preempt();
-        Self {
-            was_enabled,
-            preempt_guard,
-        }
+        Self { was_enabled }
     }
 
     /// Transfers the saved IRQ status of this guard to a new guard.
@@ -158,10 +152,7 @@ impl DisabledLocalIrqGuard {
     pub fn transfer_to(&mut self) -> Self {
         let was_enabled = self.was_enabled;
         self.was_enabled = false;
-        Self {
-            was_enabled,
-            preempt_guard: disable_preempt(),
-        }
+        Self { was_enabled }
     }
 }
 

--- a/ostd/src/trap/mod.rs
+++ b/ostd/src/trap/mod.rs
@@ -11,9 +11,7 @@ pub use softirq::SoftIrqLine;
 pub use trapframe::TrapFrame;
 
 pub(crate) use self::handler::call_irq_callback_functions;
-pub use self::irq::{
-    disable_local, enable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine,
-};
+pub use self::irq::{disable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine};
 
 pub(crate) fn init() {
     unsafe {


### PR DESCRIPTION
This PR 1) removes the unsound API `ostd::trap::enable_local` and 2) fix #1130 