### PR TITLE
Align the buffer size of pipes and UNIX sockets

### DIFF
--- a/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/endpoint.rs
@@ -122,4 +122,4 @@ impl Endpoint {
     }
 }
 
-const DAFAULT_BUF_SIZE: usize = 4096;
+const DAFAULT_BUF_SIZE: usize = 65536;

--- a/kernel/aster-nix/src/syscall/pipe.rs
+++ b/kernel/aster-nix/src/syscall/pipe.rs
@@ -58,4 +58,4 @@ struct PipeFds {
     writer_fd: FileDesc,
 }
 
-const PIPE_BUF_SIZE: usize = 1024 * 1024;
+const PIPE_BUF_SIZE: usize = 65536;


### PR DESCRIPTION
The value 65536 comes from the Linux kernel implementation.

For pipes, the [man pages](https://linux.die.net/man/7/pipe) say:
> Since Linux 2.6.11, the pipe capacity is 65536 bytes.

This aligns with the implementation, which allows a pipe to have up to 16 pages (65536 bytes) by default:
https://github.com/torvalds/linux/blob/d74da846046aeec9333e802f5918bd3261fb5509/include/linux/pipe_fs_i.h#L5

For sockets, the buffer size is set by default to allow 256 packets, each packet containing 256 bytes. So there are 65536 bytes, too. (However, in the Linux kernel, packet overhead can be amortized as packet size increases, but that doesn't happen in Asterinas.)
https://github.com/torvalds/linux/blob/d74da846046aeec9333e802f5918bd3261fb5509/include/net/sock.h#L2796-L2804

The benchmark results before this PR look like:
```
~ # ./benchmark/bin/lmbench/bw_unix 
AF_UNIX sock stream bandwidth: 550.35 MB/sec
~ # ./benchmark/bin/lmbench/bw_pipe
Pipe bandwidth: 7666.00 MB/sec
```

The benchmark results after this PR look like:
```
~ # ./benchmark/bin/lmbench/bw_unix
AF_UNIX sock stream bandwidth: 5906.74 MB/sec
~ # ./benchmark/bin/lmbench/bw_pipe
Pipe bandwidth: 6049.30 MB/sec
```

This PR lowers the performance of the pipe bandwidth benchmark. But I would consider it a fair comparison to the Linux kernel. Using the script provided in [this StackOverflow answer](https://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer), I confirmed that I cannot buffer more than 65536 bytes in a pipe even on the latest version of the Linux kernel (v6.10.4) with the default pipe settings:
```
write size:      65536; bytes successfully before error: 65536
write size:      65537; bytes successfully before error: 0
```