### PR TITLE
Implement !Sync for UserMode

### DIFF
--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -109,8 +109,10 @@ pub struct UserMode<'a> {
     context: UserContext,
 }
 
-// An instance of `UserMode` is bound to the current task. So it cannot be [`Send`].
+// An instance of `UserMode` is bound to the current task. So it must not be sent to other tasks.
 impl<'a> !Send for UserMode<'a> {}
+// An instance of `UserMode` is bound to the current task. So it must not be accessible by other tasks.
+impl<'a> !Sync for UserMode<'a> {}
 
 impl<'a> UserMode<'a> {
     /// Creates a new `UserMode`.


### PR DESCRIPTION
There is a small soundness issue of the `UserMode` API. An instance of `UserMode` should only allow the task that creates it to enter the user space, not any other tasks. Thus, `UserMode` must implement `!Sync` to prevent it from being accessed by other tasks.