### PR TITLE
Optimize the lmbench-select-file latency

### DIFF
--- a/kernel/aster-nix/src/fs/utils/inode.rs
+++ b/kernel/aster-nix/src/fs/utils/inode.rs
@@ -51,6 +51,10 @@ impl InodeType {
     pub fn is_directory(&self) -> bool {
         *self == InodeType::Dir
     }
+
+    pub fn is_device(&self) -> bool {
+        *self == InodeType::BlockDevice || *self == InodeType::CharDevice
+    }
 }
 
 impl From<DeviceType> for InodeType {

--- a/kernel/aster-nix/src/syscall/select.rs
+++ b/kernel/aster-nix/src/syscall/select.rs
@@ -102,7 +102,7 @@ fn do_select(
 ) -> Result<usize> {
     // Convert the FdSet to an array of PollFd
     let poll_fds = {
-        let mut poll_fds = Vec::new();
+        let mut poll_fds = Vec::with_capacity(nfds as usize);
         for fd in 0..nfds {
             let events = {
                 let readable = readfds.as_ref().map_or(false, |fds| fds.is_set(fd));

--- a/kernel/libs/aster-util/src/slot_vec.rs
+++ b/kernel/libs/aster-util/src/slot_vec.rs
@@ -49,10 +49,7 @@ impl<T> SlotVec<T> {
     ///
     /// Return `None` if `idx` is out of bounds or the item is not exist.
     pub fn get(&self, idx: usize) -> Option<&T> {
-        if idx >= self.slots.len() {
-            return None;
-        }
-        self.slots[idx].as_ref()
+        self.slots.get(idx)?.as_ref()
     }
 
     /// Put an item into the vector.


### PR DESCRIPTION
This PR improves the latency of lmbench-select-file, reducing it from around _16ms_ to about _2ms_ in my host test. The performance should now be on par with the Linux performance in CI. 

However, when compared to the latency of my host Linux (not running with QEMU), Asterinas is still about 25% slower (2ms compared to 1.6ms). Further optimization of performance may require a reconsideration of the design of `RamInode`. Checking whether a `RamInode` is a device currently takes up approximately 10% of the time. If it is determined that a `RamInode` can never be a device, this time can be saved.
