### PR TITLE
Improve efficiency of global TLB flushing

### DIFF
--- a/kernel/aster-nix/src/vm/vmar/mod.rs
+++ b/kernel/aster-nix/src/vm/vmar/mod.rs
@@ -101,16 +101,6 @@ pub(super) struct Vmar_ {
     parent: Weak<Vmar_>,
 }
 
-impl Drop for Vmar_ {
-    fn drop(&mut self) {
-        let mut cursor = self
-            .vm_space
-            .cursor_mut(&(self.base..self.base + self.size))
-            .unwrap();
-        cursor.unmap(self.size);
-    }
-}
-
 struct VmarInner {
     /// Whether the vmar is destroyed
     is_destroyed: bool,
@@ -295,12 +285,7 @@ impl Vmar_ {
         if !self.is_root_vmar() {
             return_errno_with_message!(Errno::EACCES, "The vmar is not root vmar");
         }
-        let mut cursor = self
-            .vm_space
-            .cursor_mut(&(self.base..self.base + self.size))
-            .unwrap();
-        cursor.unmap(self.size);
-        drop(cursor);
+        self.vm_space.clear();
         let mut inner = self.inner.lock();
         inner.child_vmar_s.clear();
         inner.vm_mappings.clear();


### PR DESCRIPTION
This PR reverts some global TLB flush behaviors to be implemented by rewriting the CR3 register, which, compared to flushing by individual addresses, can improve performance by thirty to forty microseconds on lmbench fork-related tests.