### PR TITLE
Implement FIFO file type

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -28,6 +28,7 @@ jobs:
           - lmbench-unix-bandwidth
           - lmbench-pipe-latency
           - lmbench-pipe-bandwidth
+          - lmbench-fifo-latency
           # Syscall-related benchmarks
           - lmbench-getpid
           - lmbench-fstat

--- a/kernel/aster-nix/src/fs/device.rs
+++ b/kernel/aster-nix/src/fs/device.rs
@@ -125,7 +125,7 @@ pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Arc<Dentry>> {
                     dentry = dentry.mknod(
                         next_name,
                         InodeMode::from_bits_truncate(0o666),
-                        device.clone(),
+                        device.clone().into(),
                     )?;
                 } else {
                     // Mkdir parent path

--- a/kernel/aster-nix/src/fs/devpts/mod.rs
+++ b/kernel/aster-nix/src/fs/devpts/mod.rs
@@ -8,6 +8,7 @@ use aster_util::slot_vec::SlotVec;
 use id_alloc::IdAlloc;
 
 use self::{ptmx::Ptmx, slave::PtySlaveInode};
+use super::utils::MknodType;
 use crate::{
     device::PtyMaster,
     fs::{
@@ -222,7 +223,7 @@ impl Inode for RootInode {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn mknod(&self, name: &str, mode: InodeMode, dev: Arc<dyn Device>) -> Result<Arc<dyn Inode>> {
+    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/aster-nix/src/fs/exfat/inode.rs
+++ b/kernel/aster-nix/src/fs/exfat/inode.rs
@@ -28,11 +28,10 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::{
-        device::Device,
         exfat::{dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFS},
         utils::{
-            DirentVisitor, Extension, Inode, InodeMode, InodeType, IoctlCmd, Metadata, PageCache,
-            PageCacheBackend,
+            DirentVisitor, Extension, Inode, InodeMode, InodeType, IoctlCmd, Metadata, MknodType,
+            PageCache, PageCacheBackend,
         },
     },
     prelude::*,
@@ -1444,7 +1443,7 @@ impl Inode for ExfatInode {
         Ok(result)
     }
 
-    fn mknod(&self, name: &str, mode: InodeMode, dev: Arc<dyn Device>) -> Result<Arc<dyn Inode>> {
+    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         return_errno_with_message!(Errno::EINVAL, "unsupported operation")
     }
 

--- a/kernel/aster-nix/src/fs/ext2/fs.rs
+++ b/kernel/aster-nix/src/fs/ext2/fs.rs
@@ -5,7 +5,7 @@
 use super::{
     block_group::{BlockGroup, RawGroupDescriptor},
     block_ptr::Ext2Bid,
-    inode::{FilePerm, FileType, Inode, InodeDesc, RawInode},
+    inode::{FilePerm, Inode, InodeDesc, RawInode},
     prelude::*,
     super_block::{RawSuperBlock, SuperBlock, SUPER_BLOCK_OFFSET},
 };
@@ -143,13 +143,13 @@ impl Ext2 {
     pub(super) fn create_inode(
         &self,
         dir_block_group_idx: usize,
-        file_type: FileType,
+        inode_type: InodeType,
         file_perm: FilePerm,
     ) -> Result<Arc<Inode>> {
         let (block_group_idx, ino) =
-            self.alloc_ino(dir_block_group_idx, file_type == FileType::Dir)?;
+            self.alloc_ino(dir_block_group_idx, inode_type == InodeType::Dir)?;
         let inode = {
-            let inode_desc = InodeDesc::new(file_type, file_perm);
+            let inode_desc = InodeDesc::new(inode_type, file_perm);
             Inode::new(ino, block_group_idx, inode_desc, self.self_ref.clone())
         };
         let block_group = &self.block_groups[block_group_idx];

--- a/kernel/aster-nix/src/fs/ext2/mod.rs
+++ b/kernel/aster-nix/src/fs/ext2/mod.rs
@@ -23,7 +23,7 @@
 //! // Lookup the root inode.
 //! let root = ext2.root_inode()?;
 //! // Create a file inside root directory.
-//! let file = root.create("file", FileType::File, FilePerm::from_bits_truncate(0o666))?;
+//! let file = root.create("file", InodeType::File, FilePerm::from_bits_truncate(0o666))?;
 //! // Write data into the file.
 //! const WRITE_DATA: &[u8] = b"Hello, World";
 //! let len = file.write_at(0, WRITE_DATA)?;
@@ -37,7 +37,7 @@
 //! 2. Handles the intermediate failure status correctly.
 
 pub use fs::Ext2;
-pub use inode::{FilePerm, FileType, Inode};
+pub use inode::{FilePerm, Inode};
 pub use super_block::{SuperBlock, MAGIC_NUM};
 
 mod block_group;

--- a/kernel/aster-nix/src/fs/mod.rs
+++ b/kernel/aster-nix/src/fs/mod.rs
@@ -8,6 +8,7 @@ pub mod file_handle;
 pub mod file_table;
 pub mod fs_resolver;
 pub mod inode_handle;
+pub mod named_pipe;
 pub mod path;
 pub mod pipe;
 pub mod procfs;

--- a/kernel/aster-nix/src/fs/named_pipe.rs
+++ b/kernel/aster-nix/src/fs/named_pipe.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    file_handle::FileLike,
+    pipe::{self, PipeReader, PipeWriter},
+    utils::{AccessMode, Metadata},
+};
+use crate::{
+    events::IoEvents,
+    prelude::*,
+    process::signal::{Pollable, Poller},
+};
+
+pub struct NamedPipe {
+    reader: Arc<PipeReader>,
+    writer: Arc<PipeWriter>,
+}
+
+impl NamedPipe {
+    pub fn new() -> Result<Self> {
+        let (reader, writer) = pipe::new_pair()?;
+
+        Ok(Self { reader, writer })
+    }
+
+    pub fn with_capacity(capacity: usize) -> Result<Self> {
+        let (reader, writer) = pipe::new_pair_with_capacity(capacity)?;
+
+        Ok(Self { reader, writer })
+    }
+}
+
+impl Pollable for NamedPipe {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+        warn!("Named pipe doesn't support poll now, return IoEvents::empty for now.");
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for NamedPipe {
+    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+        self.reader.read(writer)
+    }
+
+    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+        self.writer.write(reader)
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDWR
+    }
+
+    fn metadata(&self) -> Metadata {
+        self.reader.metadata()
+    }
+}

--- a/kernel/aster-nix/src/fs/path/dentry.rs
+++ b/kernel/aster-nix/src/fs/path/dentry.rs
@@ -12,9 +12,8 @@ use inherit_methods_macro::inherit_methods;
 
 use crate::{
     fs::{
-        device::Device,
         path::mount::MountNode,
-        utils::{FileSystem, Inode, InodeMode, InodeType, Metadata, NAME_MAX},
+        utils::{FileSystem, Inode, InodeMode, InodeType, Metadata, MknodType, NAME_MAX},
     },
     prelude::*,
     process::{Gid, Uid},
@@ -182,7 +181,7 @@ impl Dentry_ {
     }
 
     /// Create a Dentry_ by making a device inode.
-    pub fn mknod(&self, name: &str, mode: InodeMode, device: Arc<dyn Device>) -> Result<Arc<Self>> {
+    pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<Self>> {
         if self.inode.type_() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
@@ -192,7 +191,7 @@ impl Dentry_ {
         }
 
         let child = {
-            let inode = self.inode.mknod(name, mode, device)?;
+            let inode = self.inode.mknod(name, mode, type_)?;
             let dentry = Self::new(
                 inode,
                 DentryOptions::Leaf((String::from(name), self.this())),
@@ -622,9 +621,9 @@ impl Dentry {
         Ok(child_mount)
     }
 
-    /// Create a Dentry by making a device inode.
-    pub fn mknod(&self, name: &str, mode: InodeMode, device: Arc<dyn Device>) -> Result<Arc<Self>> {
-        let inner = self.inner.mknod(name, mode, device)?;
+    /// Create a Dentry by making a device inode or others.
+    pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<Self>> {
+        let inner = self.inner.mknod(name, mode, type_)?;
         Ok(Self::new(self.mount_node.clone(), inner.clone()))
     }
 

--- a/kernel/aster-nix/src/fs/procfs/template/dir.rs
+++ b/kernel/aster-nix/src/fs/procfs/template/dir.rs
@@ -9,10 +9,7 @@ use inherit_methods_macro::inherit_methods;
 
 use super::{Common, ProcFS};
 use crate::{
-    fs::{
-        device::Device,
-        utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata},
-    },
+    fs::utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata, MknodType},
     prelude::*,
     process::{Gid, Uid},
 };
@@ -97,12 +94,7 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn mknod(
-        &self,
-        _name: &str,
-        _mode: InodeMode,
-        _device: Arc<dyn Device>,
-    ) -> Result<Arc<dyn Inode>> {
+    fn mknod(&self, _name: &str, _mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/aster-nix/src/fs/utils/channel.rs
+++ b/kernel/aster-nix/src/fs/utils/channel.rs
@@ -25,7 +25,7 @@ impl<T> Channel<T> {
     /// # Panics
     ///
     /// This method will panic if the given capacity is zero.
-    pub fn new(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         let common = Arc::new(Common::new(capacity));
 
         let producer = Producer(Fifo::new(common.clone()));
@@ -391,7 +391,7 @@ mod test {
         #[derive(Clone, Debug, PartialEq, Eq)]
         struct NonCopy(Arc<usize>);
 
-        let channel = Channel::new(16);
+        let channel = Channel::with_capacity(16);
         let (producer, consumer) = channel.split();
 
         let data = NonCopy(Arc::new(99));

--- a/kernel/aster-nix/src/fs/utils/mod.rs
+++ b/kernel/aster-nix/src/fs/utils/mod.rs
@@ -11,7 +11,7 @@ pub use falloc_mode::FallocMode;
 pub use file_creation_mask::FileCreationMask;
 pub use flock::{FlockItem, FlockList, FlockType};
 pub use fs::{FileSystem, FsFlags, SuperBlock};
-pub use inode::{Extension, Inode, InodeMode, InodeType, Metadata};
+pub use inode::{Extension, Inode, InodeMode, InodeType, Metadata, MknodType};
 pub use ioctl::IoctlCmd;
 pub use page_cache::{PageCache, PageCacheBackend};
 pub use random_test::{generate_random_operation, new_fs_in_memory};

--- a/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/connected.rs
@@ -20,8 +20,8 @@ impl Connected {
         addr: Option<UnixSocketAddrBound>,
         peer_addr: Option<UnixSocketAddrBound>,
     ) -> (Connected, Connected) {
-        let (writer_this, reader_peer) = Channel::new(DAFAULT_BUF_SIZE).split();
-        let (writer_peer, reader_this) = Channel::new(DAFAULT_BUF_SIZE).split();
+        let (writer_this, reader_peer) = Channel::with_capacity(DAFAULT_BUF_SIZE).split();
+        let (writer_peer, reader_this) = Channel::with_capacity(DAFAULT_BUF_SIZE).split();
 
         let this = Connected {
             addr: addr.clone(),

--- a/kernel/aster-nix/src/syscall/mknod.rs
+++ b/kernel/aster-nix/src/syscall/mknod.rs
@@ -6,7 +6,7 @@ use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
-        utils::{InodeMode, InodeType},
+        utils::{InodeMode, InodeType, MknodType},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -53,7 +53,10 @@ pub fn sys_mknodat(
             let device_inode = get_device(dev)?;
             let _ = dir_dentry.mknod(&name, inode_mode, device_inode.into())?;
         }
-        InodeType::NamedPipe | InodeType::Socket => {
+        InodeType::NamedPipe => {
+            let _ = dir_dentry.mknod(&name, inode_mode, MknodType::NamedPipeNode)?;
+        }
+        InodeType::Socket => {
             return_errno_with_message!(Errno::EINVAL, "unsupported file types")
         }
         _ => return_errno_with_message!(Errno::EPERM, "unimplemented file types"),

--- a/kernel/aster-nix/src/syscall/mknod.rs
+++ b/kernel/aster-nix/src/syscall/mknod.rs
@@ -51,7 +51,7 @@ pub fn sys_mknodat(
         }
         InodeType::CharDevice | InodeType::BlockDevice => {
             let device_inode = get_device(dev)?;
-            let _ = dir_dentry.mknod(&name, inode_mode, device_inode)?;
+            let _ = dir_dentry.mknod(&name, inode_mode, device_inode.into())?;
         }
         InodeType::NamedPipe | InodeType::Socket => {
             return_errno_with_message!(Errno::EINVAL, "unsupported file types")

--- a/kernel/aster-nix/src/syscall/stat.rs
+++ b/kernel/aster-nix/src/syscall/stat.rs
@@ -75,38 +75,6 @@ pub fn sys_fstatat(
     Ok(SyscallReturn::Return(0))
 }
 
-/// File type mask.
-const S_IFMT: u16 = 0o170000;
-
-/// Enum representing different file types.
-#[derive(Debug, PartialEq)]
-pub enum FileType {
-    Socket,
-    CharacterDevice,
-    BlockDevice,
-    Directory,
-    Fifo,
-    RegularFile,
-    Symlink,
-    Unknown,
-}
-
-impl FileType {
-    /// Extract the file type from the mode.
-    pub fn from_mode(mode: u16) -> FileType {
-        match mode & S_IFMT {
-            0o140000 => FileType::Socket,          // Socket.
-            0o020000 => FileType::CharacterDevice, // Character device.
-            0o060000 => FileType::BlockDevice,     // Block device.
-            0o040000 => FileType::Directory,       // Directory.
-            0o010000 => FileType::Fifo,            // FIFO (named pipe).
-            0 | 0o100000 => FileType::RegularFile, // Regular file.
-            0o120000 => FileType::Symlink,         // Symbolic link.
-            _ => FileType::Unknown,                // Unkonwn file type.
-        }
-    }
-}
-
 /// File Stat
 #[derive(Debug, Clone, Copy, Pod, Default)]
 #[repr(C)]

--- a/test/benchmark/lmbench-fifo-latency/config.json
+++ b/test/benchmark/lmbench-fifo-latency/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "Fifo latency",
+    "result_index": "3",
+    "description": "The latency of fifo on a single processor."
+}

--- a/test/benchmark/lmbench-fifo-latency/result_template.json
+++ b/test/benchmark/lmbench-fifo-latency/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average fifo latency on Linux",
+        "unit": "µs",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average fifo latency on Asterinas",
+        "unit": "µs",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-fifo-latency/run.sh
+++ b/test/benchmark/lmbench-fifo-latency/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench fifo latency test ***"
+
+/benchmark/bin/lmbench/lat_fifo -P 1

--- a/test/benchmark/lmbench-lmdd/config.json
+++ b/test/benchmark/lmbench-lmdd/config.json
@@ -2,6 +2,6 @@
     "alert_threshold": "125%",
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "lmdd result:",
-    "result_index": "6",
+    "result_index": "8",
     "description": "The bandwidth of file copy."
 }


### PR DESCRIPTION
This PR implements FIFO (Named pipe) file type, including several extra modifications:
1. Remove duplicate `FileType` enumerate.
2. Change the API of `mknod` in `Inode`.

The result of `lat_fifo`:
1. Asterinas: 3.9 us
2. Linux-6.6.42: 2.52 us.

Additionally, this PR only enabling the `lat_fifo` benchmark and is not ready for usage. It also requires the PR https://github.com/asterinas/lmbench/pull/2 to be merged so that `lat_fifo` will work in Linux.