### PR TITLE
Fix panic when transfer `how` to enum in sys_rt_sigprocmask()

### DIFF
--- a/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
+++ b/kernel/aster-nix/src/syscall/rt_sigprocmask.rs
@@ -18,7 +18,7 @@ pub fn sys_rt_sigprocmask(
     sigset_size: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let mask_op = MaskOp::try_from(how).unwrap();
+    let mask_op = MaskOp::try_from(how)?;
     debug!(
         "mask op = {:?}, set_ptr = 0x{:x}, oldset_ptr = 0x{:x}, sigset_size = {}",
         mask_op, set_ptr, oldset_ptr, sigset_size


### PR DESCRIPTION
Fix #1173 