### PR TITLE
Add several benchmarks to workflow

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -45,6 +45,7 @@ jobs:
           - lmbench-fs-create-delete-files-10k
           # Mmap-related benchmarks
           - lmbench-pagefault
+          - lmbench-mmap-bandwidth
           # Semaphore benchmark
           - lmbench-semaphore
       fail-fast: false

--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -44,6 +44,7 @@ jobs:
           - lmbench-select-file
           - lmbench-fs-create-delete-files-0k
           - lmbench-fs-create-delete-files-10k
+          - lmbench-fcntl
           # Mmap-related benchmarks
           - lmbench-pagefault
           - lmbench-mmap-bandwidth

--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -38,6 +38,7 @@ jobs:
           # Signal-related benchmarks
           - lmbench-signal
           - lmbench-signal-install
+          - lmbench-signal-prot
           # File-related benchmarks
           - lmbench-file-rd-bandwidth
           - lmbench-select-file

--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -46,6 +46,7 @@ jobs:
           # Mmap-related benchmarks
           - lmbench-pagefault
           - lmbench-mmap-bandwidth
+          - lmbench-mmap-latency
           # Semaphore benchmark
           - lmbench-semaphore
       fail-fast: false

--- a/kernel/aster-nix/src/thread/exception.rs
+++ b/kernel/aster-nix/src/thread/exception.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_page_fault(
         );
 
         if let Err(e) = root_vmar.handle_page_fault(page_fault_addr, not_present, write) {
-            error!(
+            warn!(
                 "page fault handler failed: addr: 0x{:x}, err: {:?}",
                 page_fault_addr, e
             );

--- a/test/benchmark/lmbench-fcntl/config.json
+++ b/test/benchmark/lmbench-fcntl/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "Fcntl lock latency:",
+    "result_index": "4",
+    "description": "The latency of file locking on a single processor."
+}

--- a/test/benchmark/lmbench-fcntl/result_template.json
+++ b/test/benchmark/lmbench-fcntl/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average file locking latency on Linux",
+        "unit": "µs",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average file locking latency on Asterinas",
+        "unit": "µs",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-fcntl/run.sh
+++ b/test/benchmark/lmbench-fcntl/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running lmbench-fcntl ***"
+
+/benchmark/bin/lmbench/lat_fcntl -P 1

--- a/test/benchmark/lmbench-mmap-bandwidth/config.json
+++ b/test/benchmark/lmbench-mmap-bandwidth/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "268.44",
+    "result_index": "2",
+    "description": "The bandwidth of mmap on a single processor."
+}

--- a/test/benchmark/lmbench-mmap-bandwidth/result_template.json
+++ b/test/benchmark/lmbench-mmap-bandwidth/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average mmap bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average mmap bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-mmap-bandwidth/run.sh
+++ b/test/benchmark/lmbench-mmap-bandwidth/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench mmap bandwidth test ***"
+
+dd if=/dev/zero of=/ext2/test_file bs=1M count=256
+/benchmark/bin/lmbench/bw_mmap_rd 256m mmap_only /ext2/test_file

--- a/test/benchmark/lmbench-mmap-latency/config.json
+++ b/test/benchmark/lmbench-mmap-latency/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "268.435456",
+    "result_index": "2",
+    "description": "The latency of mmap on a single processor."
+}

--- a/test/benchmark/lmbench-mmap-latency/result_template.json
+++ b/test/benchmark/lmbench-mmap-latency/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average mmap latency on Linux",
+        "unit": "µs",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average mmap latency on Asterinas",
+        "unit": "µs",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-mmap-latency/run.sh
+++ b/test/benchmark/lmbench-mmap-latency/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench mmap latency test ***"
+
+dd if=/dev/zero of=/ext2/test_file bs=1M count=256
+/benchmark/bin/lmbench/lat_mmap 256m /ext2/test_file

--- a/test/benchmark/lmbench-signal-prot/config.json
+++ b/test/benchmark/lmbench-signal-prot/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "Protection fault:",
+    "result_index": "3",
+    "description": "The latency to catch a protection fault on a single processor."
+}

--- a/test/benchmark/lmbench-signal-prot/result_template.json
+++ b/test/benchmark/lmbench-signal-prot/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average protection fault latency on Linux",
+        "unit": "µs",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average protection fault latency on Asterinas",
+        "unit": "µs",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-signal-prot/run.sh
+++ b/test/benchmark/lmbench-signal-prot/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench protection fault latency test ***"
+
+dd if=/dev/zero of=/ext2/test_file bs=1M count=256
+/benchmark/bin/lmbench/lat_sig prot /ext2/test_file


### PR DESCRIPTION
This PR adds several benchmarks to the workflow, including:
1. `bw_mmap_rd`. Asterinas: 15273.71 MB/s; Linux: 15152.15 MB/s.
2. `lat_mmap`. Asterinas: 1308 us; Linux: 1519 us.
3. `lat_sig prot`. Asterinas: 0.4326 us; Linux: 0.5536 us.
4. `lat_fcntl`. Asterinas: 0.7 us; Linux: 3.2 us.

Additionally, it changed the log level of the page fault handler failed to warn.