### PR TITLE
Propagate errors in futex syscall handler

### DIFF
--- a/kernel/aster-nix/src/syscall/futex.rs
+++ b/kernel/aster-nix/src/syscall/futex.rs
@@ -69,8 +69,7 @@ pub fn sys_futex(
             .map(|nwakes| nwakes as _)
         }
         _ => panic!("Unsupported futex operations"),
-    }
-    .unwrap();
+    }?;
 
     debug!("futex returns, tid= {} ", ctx.thread.tid());
     Ok(SyscallReturn::Return(res as _))


### PR DESCRIPTION
## Bug

`sysbench-threads` in benchmark CI fails (very often) after #990. 
```
*** Doing sysbench with 200 threads for 60 seconds ***
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 200
Initializing random number generator from current time


Initializing worker threads...

Threads started!

panicked at /__w/asterinas/asterinas/kernel/aster-nix/src/syscall/futex.rs:73:6:
called `Result::unwrap()` on an `Err` value: Error { errno: EAGAIN, msg: Some("futex value does not match") }
```

`pthread_mutex_lock` (used in `sysbench-threads`) is implemented using `futex`. It takes the inequivalence of the given value and the value loaded from the given address in futex syscall as a fast path back to userspace before the actual `wait`. This inequivalence should not make the kernel panic.

## Fix

Propagate instead of unwrapping the `Result` returned from futex operations.