### PR TITLE
Reduce the kernel stack size in release mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ RELEASE_LTO ?= 0
 LOG_LEVEL ?= error
 SCHEME ?= ""
 SMP ?= 1
+OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
 # End of global options.
 
 # The Makefile provides a way to run arbitrary tests in the kernel
@@ -50,8 +51,10 @@ endif
 
 ifeq ($(RELEASE_LTO), 1)
 CARGO_OSDK_ARGS += --profile release-lto
+OSTD_TASK_STACK_SIZE_IN_PAGES = 8
 else ifeq ($(RELEASE), 1)
 CARGO_OSDK_ARGS += --release
+OSTD_TASK_STACK_SIZE_IN_PAGES = 8
 endif
 
 ifeq ($(INTEL_TDX), 1)

--- a/ostd/src/task/task/mod.rs
+++ b/ostd/src/task/task/mod.rs
@@ -24,7 +24,38 @@ use crate::{
     user::UserSpace,
 };
 
-pub const KERNEL_STACK_SIZE: usize = PAGE_SIZE * 64;
+/// The kernel stack size of a task, specified in pages.
+///
+/// By default, we choose a rather large stack size.
+/// OSTD users can choose a smaller size by specifying
+/// the `OSTD_TASK_STACK_SIZE_IN_PAGES` environment variable
+/// at build time.
+pub static STACK_SIZE_IN_PAGES: u32 = parse_u32_or_default(
+    option_env!("OSTD_TASK_STACK_SIZE_IN_PAGES"),
+    DEFAULT_STACK_SIZE_IN_PAGES,
+);
+
+/// The default kernel stack size of a task, specified in pages.
+pub const DEFAULT_STACK_SIZE_IN_PAGES: u32 = 128;
+
+const fn parse_u32_or_default(size: Option<&str>, default: u32) -> u32 {
+    match size {
+        Some(value) => parse_u32(value),
+        None => default,
+    }
+}
+
+const fn parse_u32(input: &str) -> u32 {
+    let mut output: u32 = 0;
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let digit = (bytes[i] - b'0') as u32;
+        output = output * 10 + digit;
+        i += 1;
+    }
+    output
+}
 
 /// Trait for manipulating the task context.
 pub trait TaskContextApi {
@@ -50,7 +81,7 @@ pub struct KernelStack {
 impl KernelStack {
     pub fn new() -> Result<Self> {
         Ok(Self {
-            segment: FrameAllocOptions::new(KERNEL_STACK_SIZE / PAGE_SIZE).alloc_contiguous()?,
+            segment: FrameAllocOptions::new(STACK_SIZE_IN_PAGES as usize).alloc_contiguous()?,
             has_guard_page: false,
         })
     }
@@ -59,7 +90,7 @@ impl KernelStack {
     /// An additional page is allocated and be regarded as a guard page, which should not be accessed.  
     pub fn new_with_guard_page() -> Result<Self> {
         let stack_segment =
-            FrameAllocOptions::new(KERNEL_STACK_SIZE / PAGE_SIZE + 1).alloc_contiguous()?;
+            FrameAllocOptions::new(STACK_SIZE_IN_PAGES as usize + 1).alloc_contiguous()?;
         // FIXME: modifying the the linear mapping is bad.
         let page_table = KERNEL_PAGE_TABLE.get().unwrap();
         let guard_page_vaddr = {


### PR DESCRIPTION
Initially, my thought was to specify `release_feature` under the profile.release condition, but it didn't work. @junyang-zh @StevenJiang1110 Do you think this is a suitable approach, and is it possible to achieve this functionality within osdk?