### PR TITLE
Enhance the stability of lmbench-mem

### DIFF
--- a/test/benchmark/lmbench-mem-fcp/config.json
+++ b/test/benchmark/lmbench-mem-fcp/config.json
@@ -1,7 +1,7 @@
 {
     "alert_threshold": "125%",
     "alert_tool": "customBiggerIsBetter",
-    "search_pattern": "134.22",
+    "search_pattern": "536.87",
     "result_index": "2",
-    "description": "The memory bandwidth for copying 128 MB of data on a single processor using the fcp (fast copy) method."
+    "description": "The memory bandwidth for copying 512 MB of data on a single processor using the fcp (fast copy) method."
 }

--- a/test/benchmark/lmbench-mem-fcp/run.sh
+++ b/test/benchmark/lmbench-mem-fcp/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench memory-copy bandwidth test ***"
 
-/benchmark/bin/lmbench/bw_mem -P 1 128m fcp
+/benchmark/bin/lmbench/bw_mem -P 1 -N 50 512m fcp

--- a/test/benchmark/lmbench-mem-frd/config.json
+++ b/test/benchmark/lmbench-mem-frd/config.json
@@ -1,7 +1,7 @@
 {
     "alert_threshold": "125%",
     "alert_tool": "customBiggerIsBetter",
-    "search_pattern": "268.44",
+    "search_pattern": "536.87",
     "result_index": "2",
-    "description": "The memory bandwidth for reading 256 MB of data on a single processor."
+    "description": "The memory bandwidth for reading 512 MB of data on a single processor."
 }

--- a/test/benchmark/lmbench-mem-frd/run.sh
+++ b/test/benchmark/lmbench-mem-frd/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench memory-read bandwidth test ***"
 
-/benchmark/bin/lmbench/bw_mem -P 1 256m frd
+/benchmark/bin/lmbench/bw_mem -P 1 -N 50 512m frd

--- a/test/benchmark/lmbench-mem-fwr/config.json
+++ b/test/benchmark/lmbench-mem-fwr/config.json
@@ -1,7 +1,7 @@
 {
     "alert_threshold": "125%",
     "alert_tool": "customBiggerIsBetter",
-    "search_pattern": "268.44",
+    "search_pattern": "536.87",
     "result_index": "2",
-    "description": "The memory bandwidth for writing 256 MB of data on a single processor using the fwr (fast write) method."
+    "description": "The memory bandwidth for writing 512 MB of data on a single processor using the fwr (fast write) method."
 }

--- a/test/benchmark/lmbench-mem-fwr/run.sh
+++ b/test/benchmark/lmbench-mem-fwr/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench memory-write bandwidth test ***"
 
-/benchmark/bin/lmbench/bw_mem -P 1 256m fwr
+/benchmark/bin/lmbench/bw_mem -P 1 -N 50 512m fwr


### PR DESCRIPTION
This PR fixes #1155 , which describe the problem of unstable `lmbench-mem`, by increasing the number and size of tests.

Now it runs for 50 times with 512 MB workloads.