### PR TITLE
Fix panic in `madv_free()`

### DIFF
--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -14,6 +14,14 @@ pub fn sys_madvise(
         "start = 0x{:x}, len = 0x{:x}, behavior = {:?}",
         start, len, behavior
     );
+
+    if start % PAGE_SIZE != 0 {
+        return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
+    }
+    if len == 0 {
+        return Ok(SyscallReturn::Return(0));
+    }
+
     match behavior {
         MadviseBehavior::MADV_NORMAL
         | MadviseBehavior::MADV_SEQUENTIAL
@@ -33,16 +41,8 @@ pub fn sys_madvise(
 }
 
 fn madv_free(start: Vaddr, len: usize, ctx: &Context) -> Result<()> {
-    if start % PAGE_SIZE != 0 {
-        return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
-    }
-
     if len % PAGE_SIZE != 0 {
-        return_errno_with_message!(Errno::EINVAL, "the length should be page aligned");
-    }
-
-    if len == 0 {
-        return_errno_with_message!(Errno::EINVAL, "madv_free len cannot be zero");
+        return Ok(());
     }
 
     let root_vmar = ctx.process.root_vmar();

--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -33,8 +33,17 @@ pub fn sys_madvise(
 }
 
 fn madv_free(start: Vaddr, len: usize, ctx: &Context) -> Result<()> {
-    debug_assert!(start % PAGE_SIZE == 0);
-    debug_assert!(len % PAGE_SIZE == 0);
+    if start % PAGE_SIZE != 0 {
+        return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
+    }
+
+    if len % PAGE_SIZE != 0 {
+        return_errno_with_message!(Errno::EINVAL, "the length should be page aligned");
+    }
+
+    if len == 0 {
+        return_errno_with_message!(Errno::EINVAL, "madv_free len cannot be zero");
+    }
 
     let root_vmar = ctx.process.root_vmar();
     let advised_range = start..start + len;

--- a/kernel/aster-nix/src/syscall/madvise.rs
+++ b/kernel/aster-nix/src/syscall/madvise.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use align_ext::AlignExt;
+
 use super::SyscallReturn;
 use crate::prelude::*;
 
@@ -22,6 +24,7 @@ pub fn sys_madvise(
         return Ok(SyscallReturn::Return(0));
     }
 
+    let len = len.align_up(PAGE_SIZE);
     match behavior {
         MadviseBehavior::MADV_NORMAL
         | MadviseBehavior::MADV_SEQUENTIAL
@@ -41,10 +44,6 @@ pub fn sys_madvise(
 }
 
 fn madv_free(start: Vaddr, len: usize, ctx: &Context) -> Result<()> {
-    if len % PAGE_SIZE != 0 {
-        return Ok(());
-    }
-
     let root_vmar = ctx.process.root_vmar();
     let advised_range = start..start + len;
     let _ = root_vmar.destroy(advised_range);


### PR DESCRIPTION
Fix the reachable `debug_assert` in `madv_free()` and `get_intersected_range()` through `madvise` syscall.

When Asterinas make a syscall `madvise` with specific args, it will panic and exit.


```C
#include <errno.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/mman.h>

int main() {
  madvise((void *)0x291d002, 0, 0x8);
  void *addr = mmap(NULL, 4096, 0x3, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
  madvise(addr, 0, 0x8);

  return EXIT_SUCCESS;
}
```

The first panic log is:
```log
~ # /root/madvise.c 
panicked at /root/asterinas/kernel/aster-nix/src/syscall/madvise.rs:36:5:
assertion failed: start % PAGE_SIZE == 0
Printing stack trace:
   1: fn 0xffffffff887ccdf0 - pc 0xffffffff887cce08 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa4c0;

   2: fn 0xffffffff887ccbd0 - pc 0xffffffff887ccd48 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa4d0;

   3: fn 0xffffffff88049000 - pc 0xffffffff8804900a / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa650;

   4: fn 0xffffffff8895bcb0 - pc 0xffffffff8895bd32 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa660;

   5: fn 0xffffffff8895be50 - pc 0xffffffff8895be90 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa6f0;

   6: fn 0xffffffff880b2330 - pc 0xffffffff880b2397 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa760;

   7: fn 0xffffffff880b1c20 - pc 0xffffffff880b21b2 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa7f0;

   8: fn 0xffffffff8852ef80 - pc 0xffffffff885388ae / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aab40;

   9: fn 0xffffffff8852eb50 - pc 0xffffffff8852ebde / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c03d0;

  10: fn 0xffffffff880f4360 - pc 0xffffffff880f4edf / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0570;

  11: fn 0xffffffff884084b0 - pc 0xffffffff884084be / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0f90;

  12: fn 0xffffffff887a7210 - pc 0xffffffff887a7226 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0fb0;

  13: fn 0xffffffff88843ae0 - pc 0xffffffff88843b49 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0fd0;

  14: fn                0x0 - pc                0x0 / registers:

     rax               0x12; rdx 0xffffffff889e54a0; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c1000;

[OSDK] The kernel seems panicked. Parsing stack trace for source lines:
(  1) /root/asterinas/ostd/src/panicking.rs:107
(  2) /root/asterinas/ostd/src/panicking.rs:59
(  3) 86161ztg45fpd9b1tjbn4gsl1:?
(  4) ??:?
(  5) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:220
(  6) 015v570fhs2wfmf9h68d8bdrd:?
(  7) /root/asterinas/kernel/aster-nix/src/syscall/madvise.rs:29
(  8) /root/asterinas/kernel/aster-nix/src/syscall/mod.rs:166
(  9) /root/asterinas/kernel/aster-nix/src/syscall/mod.rs:323
( 10) /root/asterinas/kernel/aster-nix/src/thread/task.rs:69
( 11) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79
( 12) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2077
( 13) /root/asterinas/ostd/src/task/task/mod.rs:310
make: *** [Makefile:153: run] Error 1
```

The second panic log is:
```log
~ # /root/madvise.c 
panicked at /root/asterinas/kernel/aster-nix/src/vm/vmar/mod.rs:364:13:
assertion failed: is_intersected(&vm_mapping_range, &range)
Printing stack trace:
   1: fn 0xffffffff887cce60 - pc 0xffffffff887cce78 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3a9fa0;

   2: fn 0xffffffff887ccc40 - pc 0xffffffff887ccdb8 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3a9fb0;

   3: fn 0xffffffff88049000 - pc 0xffffffff8804900a / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa130;

   4: fn 0xffffffff8895bd20 - pc 0xffffffff8895bda2 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa140;

   5: fn 0xffffffff8895bec0 - pc 0xffffffff8895bf00 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa1d0;

   6: fn 0xffffffff88140950 - pc 0xffffffff8814126c / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa240;

   7: fn 0xffffffff88524fe0 - pc 0xffffffff88525030 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa6d0;

   8: fn 0xffffffff881b5980 - pc 0xffffffff881b5ac3 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa720;

   9: fn 0xffffffff881b5270 - pc 0xffffffff881b5802 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aa7f0;

  10: fn 0xffffffff88222e40 - pc 0xffffffff8822c76e / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3aab40;

  11: fn 0xffffffff88108c50 - pc 0xffffffff88108cde / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c03d0;

  12: fn 0xffffffff8813d610 - pc 0xffffffff8813e18f / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0570;

  13: fn 0xffffffff88454ce0 - pc 0xffffffff88454cee / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0f90;

  14: fn 0xffffffff887a7280 - pc 0xffffffff887a7296 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0fb0;

  15: fn 0xffffffff88843b50 - pc 0xffffffff88843bb9 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c0fd0;

  16: fn                0x0 - pc                0x0 / registers:

     rax               0x12; rdx 0xffffffff889e54f8; rcx                0x1; rbx                0x0;
     rsi                0x0; rdi                0x0; rbp                0x0; rsp 0xffff80007f3c1000;

[OSDK] The kernel seems panicked. Parsing stack trace for source lines:
(  1) /root/asterinas/ostd/src/panicking.rs:107
(  2) /root/asterinas/ostd/src/panicking.rs:59
(  3) 86161ztg45fpd9b1tjbn4gsl1:?
(  4) ??:?
(  5) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:220
(  6) /root/asterinas/kernel/aster-nix/src/vm/vmar/mod.rs:364
(  7) /root/asterinas/kernel/aster-nix/src/vm/vmar/static_cap.rs:131
(  8) /root/asterinas/kernel/aster-nix/src/syscall/madvise.rs:45
(  9) /root/asterinas/kernel/aster-nix/src/syscall/madvise.rs:29
( 10) /root/asterinas/kernel/aster-nix/src/syscall/mod.rs:166
( 11) /root/asterinas/kernel/aster-nix/src/syscall/mod.rs:323
( 12) /root/asterinas/kernel/aster-nix/src/thread/task.rs:69
( 13) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79
( 14) /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2077
( 15) /root/asterinas/ostd/src/task/task/mod.rs:310
make: *** [Makefile:153: run] Error 1
```