### PR TITLE
Enabling lmbench unix connect latency test

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -26,6 +26,7 @@ jobs:
           # IPC-related benchmarks
           - lmbench-unix-latency
           - lmbench-unix-bandwidth
+          - lmbench-unix-connect-latency
           - lmbench-pipe-latency
           - lmbench-pipe-bandwidth
           # Syscall-related benchmarks

--- a/kernel/aster-nix/src/net/socket/unix/stream/init.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/init.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{connected::Connected, listener::push_incoming};
 use crate::{
     events::{IoEvents, Observer},
     fs::{
@@ -42,10 +41,6 @@ impl Init {
         self.addr = Some(bound_addr);
 
         Ok(())
-    }
-
-    pub(super) fn connect(&self, remote_addr: &UnixSocketAddrBound) -> Result<Connected> {
-        push_incoming(remote_addr, self.addr.clone())
     }
 
     pub(super) fn addr(&self) -> Option<&UnixSocketAddrBound> {

--- a/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
+++ b/kernel/aster-nix/src/net/socket/unix/stream/listener.rs
@@ -161,7 +161,7 @@ impl Backlog {
 
         if incoming_conns.len() >= self.backlog.load(Ordering::Relaxed) {
             return_errno_with_message!(
-                Errno::ECONNREFUSED,
+                Errno::EAGAIN,
                 "the pending connection queue on the listening socket is full"
             );
         }

--- a/test/benchmark/lmbench-unix-connect-latency/config.json
+++ b/test/benchmark/lmbench-unix-connect-latency/config.json
@@ -1,0 +1,7 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "UNIX connection cost:",
+    "result_index": "4",
+    "description": "The latency of UNIX domain socket connection on a single processor."
+}

--- a/test/benchmark/lmbench-unix-connect-latency/result_template.json
+++ b/test/benchmark/lmbench-unix-connect-latency/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average unix connect latency on Linux",
+        "unit": "µs",
+        "value": 0,
+        "extra": "linux_avg"
+    },
+    {
+        "name": "Average unix connect latency on Asterinas",
+        "unit": "µs",
+        "value": 0,
+        "extra": "aster_avg"
+    }
+]

--- a/test/benchmark/lmbench-unix-connect-latency/run.sh
+++ b/test/benchmark/lmbench-unix-connect-latency/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the LMbench unix connect latency test ***"
+
+/benchmark/bin/lmbench/lat_unix_connect -s
+/benchmark/bin/lmbench/lat_unix_connect -P 1


### PR DESCRIPTION
This PR add lmbench unix connect latency test and needs #1195 to be answered. Convert to draft now.