### PR TITLE
Introduce somaxconn to restrict backlog

### DIFF
--- a/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
+++ b/kernel/aster-nix/src/net/socket/ip/stream/listen.rs
@@ -23,8 +23,11 @@ impl ListenStream {
         bound_socket: AnyBoundSocket,
         backlog: usize,
     ) -> core::result::Result<Self, (Error, AnyBoundSocket)> {
+        const SOMAXCONN: usize = 4096;
+        let somaxconn = SOMAXCONN.min(backlog);
+
         let listen_stream = Self {
-            backlog,
+            backlog: somaxconn,
             bound_socket,
             backlog_sockets: RwLock::new(Vec::new()),
         };


### PR DESCRIPTION
Fix: #866.
Related issue: #1086.

This PR introduces SOMAXCONN to restrict the backlog. Ref: [tcp.h in Linux](https://github.com/torvalds/linux/blob/master/include/linux/tcp.h#L570). The default value comes from: [socket.h in Linux](https://github.com/torvalds/linux/blob/master/include/linux/socket.h#L298)