### PR TITLE
Enable handling page fault around

### DIFF
--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -233,7 +233,9 @@ fn base_map_addr(elf: &Elf, root_vmar: &Vmar<Full>) -> Result<Vaddr> {
             "executable file does not has loadable sections",
         ))?;
     let map_size = elf_size.align_up(PAGE_SIZE);
-    let vmar_map_options = root_vmar.new_map(map_size, VmPerms::empty())?;
+    let vmar_map_options = root_vmar
+        .new_map(map_size, VmPerms::empty())?
+        .handle_page_faults_around();
     vmar_map_options.build()
 }
 
@@ -333,7 +335,7 @@ fn map_segment_vmo(
         .vmo_limit(segment_offset + segment_size)
         .can_overwrite(true);
     let offset = base_addr + (program_header.virtual_addr as Vaddr).align_down(PAGE_SIZE);
-    vm_map_options = vm_map_options.offset(offset);
+    vm_map_options = vm_map_options.offset(offset).handle_page_faults_around();
     let map_addr = vm_map_options.build()?;
 
     let anonymous_map_size: usize = if total_map_size > segment_size {

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -120,7 +120,10 @@ fn do_sys_mmap(
                     .to_dyn()
             };
 
-            options = options.vmo(vmo).vmo_offset(offset);
+            options = options
+                .vmo(vmo)
+                .vmo_offset(offset)
+                .handle_page_faults_around();
         }
 
         options

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -295,7 +295,7 @@ impl CursorMut<'_> {
     /// Jump to the virtual address.
     ///
     /// This is the same as [`Cursor::jump`].
-    pub fn jump(&mut self, va: Vaddr) -> Result<()>{
+    pub fn jump(&mut self, va: Vaddr) -> Result<()> {
         self.0.jump(va)?;
         Ok(())
     }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -265,8 +265,9 @@ impl Cursor<'_> {
     }
 
     /// Jump to the virtual address.
-    pub fn jump(&mut self, va: Vaddr) {
-        self.0.jump(va);
+    pub fn jump(&mut self, va: Vaddr) -> Result<()> {
+        self.0.jump(va)?;
+        Ok(())
     }
 
     /// Get the virtual address of the current slot.
@@ -294,8 +295,9 @@ impl CursorMut<'_> {
     /// Jump to the virtual address.
     ///
     /// This is the same as [`Cursor::jump`].
-    pub fn jump(&mut self, va: Vaddr) {
-        self.0.jump(va);
+    pub fn jump(&mut self, va: Vaddr) -> Result<()>{
+        self.0.jump(va)?;
+        Ok(())
     }
 
     /// Get the virtual address of the current slot.


### PR DESCRIPTION
Enable handling surrounding pages when handling page fault. Currently do this optimization for `read` page fault in file-backed mappings. 