### PR TITLE
Implement UNIX abstract address namespace

### DIFF
--- a/kernel/src/net/socket/unix/mod.rs
+++ b/kernel/src/net/socket/unix/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod addr;
+mod ns;
 mod stream;
 
 pub use addr::UnixSocketAddr;

--- a/kernel/src/net/socket/unix/ns/abs.rs
+++ b/kernel/src/net/socket/unix/ns/abs.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{collections::btree_map::Entry, format};
+
+use keyable_arc::KeyableArc;
+
+use crate::prelude::*;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AbstractHandle(KeyableArc<[u8]>);
+
+impl AbstractHandle {
+    fn new(name: Arc<[u8]>) -> Self {
+        Self(KeyableArc::from(name))
+    }
+
+    pub fn name(&self) -> Arc<[u8]> {
+        self.0.clone().into()
+    }
+}
+
+impl Drop for AbstractHandle {
+    fn drop(&mut self) {
+        HANDLE_TABLE.remove(self.name());
+    }
+}
+
+static HANDLE_TABLE: HandleTable = HandleTable::new();
+
+struct HandleTable {
+    handles: RwLock<BTreeMap<Arc<[u8]>, Weak<AbstractHandle>>>,
+}
+
+impl HandleTable {
+    const fn new() -> Self {
+        Self {
+            handles: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    fn create(&self, name: Arc<[u8]>) -> Option<Arc<AbstractHandle>> {
+        let mut handles = self.handles.write();
+
+        let mut entry = handles.entry(name.clone());
+
+        if let Entry::Occupied(ref occupied) = entry {
+            // The handle is in use only if its strong count is greater than zero.
+            if occupied.get().strong_count() > 0 {
+                return None;
+            }
+        }
+
+        let new_handle = Arc::new(AbstractHandle::new(name));
+        let weak_handle = Arc::downgrade(&new_handle);
+
+        match entry {
+            Entry::Occupied(ref mut occupied) => {
+                occupied.insert(weak_handle);
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(weak_handle);
+            }
+        }
+
+        Some(new_handle)
+    }
+
+    fn remove(&self, name: Arc<[u8]>) {
+        let mut handles = self.handles.write();
+
+        let Entry::Occupied(occupied) = handles.entry(name) else {
+            return;
+        };
+
+        // Due to race conditions between `AbstractHandle::drop` and `HandleTable::create`, the
+        // entry may be occupied by another handle.
+        //
+        // Therefore, before removing the entry, we must check again if the entry should be removed.
+        if occupied.get().strong_count() == 0 {
+            occupied.remove();
+        }
+    }
+
+    fn lookup(&self, name: &[u8]) -> Option<Arc<AbstractHandle>> {
+        let handles = self.handles.read();
+
+        handles.get(name).and_then(Weak::upgrade)
+    }
+
+    fn alloc_ephemeral(&self) -> Option<Arc<AbstractHandle>> {
+        // See "Autobind feature" in the man pages:
+        // <https://man7.org/linux/man-pages/man7/unix.7.html>.
+        //
+        // Note that false negatives are fine here. So we don't mind race conditions.
+        //
+        // TODO: Always starting with the first name is inefficient and leads to contention.
+        // Instead, we should generate some random names and check their availability.
+        (0..(1 << 20))
+            .map(|num| format!("{:05x}", num))
+            .map(|name| Arc::from(name.as_bytes()))
+            .filter_map(|name| self.create(name))
+            .next()
+    }
+}
+
+pub fn create_abstract_name(name: Arc<[u8]>) -> Result<Arc<AbstractHandle>> {
+    HANDLE_TABLE.create(name).ok_or_else(|| {
+        Error::with_message(Errno::EADDRINUSE, "the abstract name is already in use")
+    })
+}
+
+pub fn alloc_ephemeral_abstract_name() -> Result<Arc<AbstractHandle>> {
+    HANDLE_TABLE.alloc_ephemeral().ok_or_else(|| {
+        Error::with_message(Errno::ENOSPC, "no ephemeral abstract name is available")
+    })
+}
+
+pub fn lookup_abstract_name(name: &[u8]) -> Result<Arc<AbstractHandle>> {
+    HANDLE_TABLE
+        .lookup(name)
+        .ok_or_else(|| Error::with_message(Errno::ECONNREFUSED, "the abstract name does not exist"))
+}

--- a/kernel/src/net/socket/unix/ns/mod.rs
+++ b/kernel/src/net/socket/unix/ns/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(super) use abs::{
+    alloc_ephemeral_abstract_name, create_abstract_name, lookup_abstract_name, AbstractHandle,
+};
+pub(super) use path::{create_socket_file, lookup_socket_file};
+
+mod abs;
+mod path;

--- a/kernel/src/net/socket/unix/ns/path.rs
+++ b/kernel/src/net/socket/unix/ns/path.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        fs_resolver::{split_path, FsPath},
+        path::Dentry,
+        utils::{InodeMode, InodeType},
+    },
+    prelude::*,
+};
+
+pub fn lookup_socket_file(path: &str) -> Result<Arc<Dentry>> {
+    let dentry = {
+        let current = current!();
+        let fs = current.fs().read();
+        let fs_path = FsPath::try_from(path)?;
+        fs.lookup(&fs_path)?
+    };
+
+    if !dentry.mode()?.is_readable() || !dentry.mode()?.is_writable() {
+        return_errno_with_message!(Errno::EACCES, "the socket file cannot be read or written")
+    }
+
+    if dentry.type_() != InodeType::Socket {
+        return_errno_with_message!(
+            Errno::ECONNREFUSED,
+            "the specified file is not a socket file"
+        )
+    }
+
+    Ok(dentry)
+}
+
+pub fn create_socket_file(path: &str) -> Result<Arc<Dentry>> {
+    let (parent_pathname, file_name) = split_path(path);
+
+    let parent = {
+        let current = current!();
+        let fs = current.fs().read();
+        let parent_path = FsPath::try_from(parent_pathname)?;
+        fs.lookup(&parent_path)?
+    };
+
+    parent
+        .new_fs_child(
+            file_name,
+            InodeType::Socket,
+            InodeMode::S_IRUSR | InodeMode::S_IWUSR,
+        )
+        .map_err(|err| {
+            if err.error() == Errno::EEXIST {
+                Error::with_message(Errno::EADDRINUSE, "the socket file already exists")
+            } else {
+                err
+            }
+        })
+}

--- a/test/apps/network/unix_err.c
+++ b/test/apps/network/unix_err.c
@@ -47,22 +47,31 @@ FN_TEST(socket_addresses)
 		       "LONG_PATH has a wrong length");
 
 	MAKE_TEST("/tmp/R0", 8, 8, 8, 8, "/tmp/R0");
+	TEST_SUCC(unlink("/tmp/R0"));
 
 	MAKE_TEST("/tmp/R1", 8, 9, 8, 8, "/tmp/R1");
+	TEST_SUCC(unlink("/tmp/R1"));
 
 	MAKE_TEST("/tmp/R2", 6, 6, 8, 7, "/tmp/R");
+	TEST_SUCC(unlink("/tmp/R"));
 
 	MAKE_TEST("/tmp/R3", 7, 7, 8, 8, "/tmp/R3");
+	TEST_SUCC(unlink("/tmp/R3"));
 
 	MAKE_TEST("/tmp/R4", 7, 7, 7, 8, "/tmp/R4");
+	TEST_SUCC(unlink("/tmp/R4"));
 
 	MAKE_TEST("/tmp/R5", 7, 7, 6, 8, "/tmp/R");
+	TEST_SUCC(unlink("/tmp/R5"));
 
 	MAKE_TEST("/tmp/R6", 7, 7, 0, 8, "");
+	TEST_SUCC(unlink("/tmp/R6"));
 
 	MAKE_TEST(LONG_PATH, 107, 107, 108, 108, LONG_PATH);
+	TEST_SUCC(unlink(LONG_PATH));
 
 	MAKE_TEST(LONG_PATH "a", 108, 108, 108, 109, LONG_PATH "a");
+	TEST_SUCC(unlink(LONG_PATH "a"));
 
 #undef LONG_PATH
 #undef MAKE_TEST
@@ -294,3 +303,21 @@ FN_TEST(ns_abs)
 	TEST_SUCC(close(sk));
 }
 END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(sk_unbound));
+
+	CHECK(close(sk_bound));
+
+	CHECK(close(sk_listen));
+
+	CHECK(close(sk_connected));
+
+	CHECK(close(sk_accepted));
+
+	CHECK(unlink(BOUND_ADDR.sun_path));
+
+	CHECK(unlink(LISTEN_ADDR.sun_path));
+}
+END_SETUP()


### PR DESCRIPTION
A UNIX socket can be bound to a socket file or to an abstract name. Previously, the functions for managing socket files were spread across several unrelated files, which is not ideal:
https://github.com/asterinas/asterinas/blob/562e64437584279783f244edba10b512beddc81d/kernel/aster-nix/src/net/socket/unix/stream/init.rs#L76
https://github.com/asterinas/asterinas/blob/562e64437584279783f244edba10b512beddc81d/kernel/aster-nix/src/net/socket/unix/stream/socket.rs#L336

This PR moves them to a separate module. This PR also allows UNIX sockets to be bound to abstract names and add some related regression tests.