### PR TITLE
Fix panic in syscall `waitid` caused by invalid `option` and `which`

### DIFF
--- a/kernel/aster-nix/src/process/process_filter.rs
+++ b/kernel/aster-nix/src/process/process_filter.rs
@@ -14,14 +14,15 @@ pub enum ProcessFilter {
 
 impl ProcessFilter {
     // used for waitid
-    pub fn from_which_and_id(which: u64, id: u64) -> Self {
+    pub fn from_which_and_id(which: u64, id: u64) -> Result<Self> {
         // Does not support PID_FD now(which = 3)
         // https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/wait.h#L20
         match which {
-            0 => ProcessFilter::Any,
-            1 => ProcessFilter::WithPid(id as Pid),
-            2 => ProcessFilter::WithPgid(id as Pgid),
-            _ => panic!("Unknown id type"),
+            0 => Ok(ProcessFilter::Any),
+            1 => Ok(ProcessFilter::WithPid(id as Pid)),
+            2 => Ok(ProcessFilter::WithPgid(id as Pgid)),
+            3 => todo!(),
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid which"),
         }
     }
 

--- a/kernel/aster-nix/src/syscall/waitid.rs
+++ b/kernel/aster-nix/src/syscall/waitid.rs
@@ -16,7 +16,8 @@ pub fn sys_waitid(
 ) -> Result<SyscallReturn> {
     // FIXME: what does infoq and rusage use for?
     let process_filter = ProcessFilter::from_which_and_id(which, upid)?;
-    let wait_options = WaitOptions::from_bits(options as u32).expect("Unknown wait options");
+    let wait_options = WaitOptions::from_bits(options as u32)
+        .ok_or(Error::with_message(Errno::EINVAL, "invalid options"))?;
     let waited_process = wait_child_exit(process_filter, wait_options)?;
     let pid = waited_process.map_or(0, |process| process.pid());
     Ok(SyscallReturn::Return(pid as _))

--- a/kernel/aster-nix/src/syscall/waitid.rs
+++ b/kernel/aster-nix/src/syscall/waitid.rs
@@ -15,7 +15,7 @@ pub fn sys_waitid(
     _ctx: &Context,
 ) -> Result<SyscallReturn> {
     // FIXME: what does infoq and rusage use for?
-    let process_filter = ProcessFilter::from_which_and_id(which, upid);
+    let process_filter = ProcessFilter::from_which_and_id(which, upid)?;
     let wait_options = WaitOptions::from_bits(options as u32).expect("Unknown wait options");
     let waited_process = wait_child_exit(process_filter, wait_options)?;
     let pid = waited_process.map_or(0, |process| process.pid());


### PR DESCRIPTION
Fix #1197 
return EINVAL according to https://elixir.bootlin.com/linux/v6.10.5/source/kernel/exit.c#L1688