### PR TITLE
Fix a bug of InitStack during doing fork+exec

### DIFF
--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -54,8 +54,7 @@ pub fn load_elf_to_vm(
                     .unwrap();
             }
 
-            let init_stack_writer = process_vm.init_stack_writer(argv, envp, aux_vec);
-            init_stack_writer.write().unwrap();
+            process_vm.map_and_write_init_stack(argv, envp, aux_vec)?;
 
             let user_stack_top = process_vm.user_stack_top();
             Ok(ElfLoadInfo {


### PR DESCRIPTION
Currently when doing `exec`, the VMO and `pos` in InitStack are not independent and will be shared with parent process, which is wrong. 