### PR TITLE
Support iperf3 UDP bitrate test

### DIFF
--- a/kernel/src/net/iface/any_socket.rs
+++ b/kernel/src/net/iface/any_socket.rs
@@ -29,8 +29,8 @@ pub(super) enum SocketFamily {
 impl AnyUnboundSocket {
     pub fn new_tcp(observer: Weak<dyn Observer<()>>) -> Self {
         let raw_tcp_socket = {
-            let rx_buffer = smoltcp::socket::tcp::SocketBuffer::new(vec![0u8; RECV_BUF_LEN]);
-            let tx_buffer = smoltcp::socket::tcp::SocketBuffer::new(vec![0u8; SEND_BUF_LEN]);
+            let rx_buffer = smoltcp::socket::tcp::SocketBuffer::new(vec![0u8; TCP_RECV_BUF_LEN]);
+            let tx_buffer = smoltcp::socket::tcp::SocketBuffer::new(vec![0u8; TCP_SEND_BUF_LEN]);
             RawTcpSocket::new(rx_buffer, tx_buffer)
         };
         AnyUnboundSocket {
@@ -44,7 +44,7 @@ impl AnyUnboundSocket {
             let metadata = smoltcp::socket::udp::PacketMetadata::EMPTY;
             let rx_buffer = smoltcp::socket::udp::PacketBuffer::new(
                 vec![metadata; UDP_METADATA_LEN],
-                vec![0u8; UDP_RECEIVE_PAYLOAD_LEN],
+                vec![0u8; UDP_RECV_PAYLOAD_LEN],
             );
             let tx_buffer = smoltcp::socket::udp::PacketBuffer::new(
                 vec![metadata; UDP_METADATA_LEN],
@@ -209,10 +209,10 @@ impl Drop for AnyBoundSocketInner {
 }
 
 // For TCP
-pub const RECV_BUF_LEN: usize = 65536;
-pub const SEND_BUF_LEN: usize = 65536;
+pub const TCP_RECV_BUF_LEN: usize = 65536;
+pub const TCP_SEND_BUF_LEN: usize = 65536;
 
 // For UDP
+pub const UDP_SEND_PAYLOAD_LEN: usize = 65536;
+pub const UDP_RECV_PAYLOAD_LEN: usize = 65536;
 const UDP_METADATA_LEN: usize = 256;
-const UDP_SEND_PAYLOAD_LEN: usize = 65536;
-const UDP_RECEIVE_PAYLOAD_LEN: usize = 65536;

--- a/kernel/src/net/iface/common.rs
+++ b/kernel/src/net/iface/common.rs
@@ -94,6 +94,7 @@ impl IfaceCommon {
         let mut used_ports = self.used_ports.write();
         if let Some(used_times) = used_ports.get_mut(&port) {
             if *used_times == 0 || can_reuse {
+                // FIXME: Check if the previous socket was bound with SO_REUSEADDR.
                 *used_times += 1;
             } else {
                 return_errno_with_message!(Errno::EADDRINUSE, "the address is already in use");

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -14,7 +14,8 @@ mod util;
 mod virtio;
 
 pub use any_socket::{
-    AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket, RECV_BUF_LEN, SEND_BUF_LEN,
+    AnyBoundSocket, AnyUnboundSocket, RawTcpSocket, RawUdpSocket, TCP_RECV_BUF_LEN,
+    TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN, UDP_SEND_PAYLOAD_LEN,
 };
 pub use loopback::IfaceLoopback;
 use ostd::sync::LocalIrqDisabled;

--- a/kernel/src/net/socket/ip/datagram/unbound.rs
+++ b/kernel/src/net/socket/ip/datagram/unbound.rs
@@ -24,8 +24,12 @@ impl UnboundDatagram {
         }
     }
 
-    pub fn bind(self, endpoint: &IpEndpoint) -> core::result::Result<BoundDatagram, (Error, Self)> {
-        let bound_socket = match bind_socket(self.unbound_socket, endpoint, false) {
+    pub fn bind(
+        self,
+        endpoint: &IpEndpoint,
+        can_reuse: bool,
+    ) -> core::result::Result<BoundDatagram, (Error, Self)> {
+        let bound_socket = match bind_socket(self.unbound_socket, endpoint, can_reuse) {
             Ok(bound_socket) => bound_socket,
             Err((err, unbound_socket)) => return Err((err, Self { unbound_socket })),
         };

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -30,6 +30,7 @@ impl InitStream {
     pub fn bind(
         self,
         endpoint: &IpEndpoint,
+        can_reuse: bool,
     ) -> core::result::Result<AnyBoundSocket, (Error, Self)> {
         let unbound_socket = match self {
             InitStream::Unbound(unbound_socket) => unbound_socket,
@@ -40,7 +41,7 @@ impl InitStream {
                 ));
             }
         };
-        let bound_socket = match bind_socket(unbound_socket, endpoint, false) {
+        let bound_socket = match bind_socket(unbound_socket, endpoint, can_reuse) {
             Ok(bound_socket) => bound_socket,
             Err((err, unbound_socket)) => return Err((err, InitStream::Unbound(unbound_socket))),
         };
@@ -52,7 +53,7 @@ impl InitStream {
         remote_endpoint: &IpEndpoint,
     ) -> core::result::Result<AnyBoundSocket, (Error, Self)> {
         let endpoint = get_ephemeral_endpoint(remote_endpoint);
-        self.bind(&endpoint)
+        self.bind(&endpoint, false)
     }
 
     pub fn connect(

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -398,6 +398,7 @@ impl Socket for StreamSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
         let endpoint = socket_addr.try_into()?;
 
+        let can_reuse = self.options.read().socket.reuse_addr();
         let mut state = self.state.write();
 
         state.borrow_result(|owned_state| {
@@ -411,7 +412,7 @@ impl Socket for StreamSocket {
                 );
             };
 
-            let bound_socket = match init_stream.bind(&endpoint) {
+            let bound_socket = match init_stream.bind(&endpoint, can_reuse) {
                 Ok(bound_socket) => bound_socket,
                 Err((err, init_stream)) => {
                     return (State::Init(init_stream), Err(err));

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -3,7 +3,13 @@
 use core::time::Duration;
 
 use crate::{
-    net::iface::{RECV_BUF_LEN, SEND_BUF_LEN},
+    match_sock_option_mut, match_sock_option_ref,
+    net::{
+        iface::{TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN, UDP_SEND_PAYLOAD_LEN},
+        socket::options::{
+            Error as SocketError, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
+        },
+    },
     prelude::*,
 };
 
@@ -26,10 +32,100 @@ impl SocketOptionSet {
             sock_errors: None,
             reuse_addr: false,
             reuse_port: false,
-            send_buf: SEND_BUF_LEN as u32,
-            recv_buf: RECV_BUF_LEN as u32,
+            send_buf: TCP_SEND_BUF_LEN as u32,
+            recv_buf: TCP_RECV_BUF_LEN as u32,
             linger: LingerOption::default(),
         }
+    }
+
+    /// Return the default socket level options for udp socket.
+    pub fn new_udp() -> Self {
+        Self {
+            sock_errors: None,
+            reuse_addr: false,
+            reuse_port: false,
+            send_buf: UDP_SEND_PAYLOAD_LEN as u32,
+            recv_buf: UDP_RECV_PAYLOAD_LEN as u32,
+            linger: LingerOption::default(),
+        }
+    }
+
+    /// Gets and clears the socket error.
+    ///
+    /// When processing the `getsockopt` system call, the socket error is automatically cleared
+    /// after reading. This method should be called to provide this behavior.
+    pub fn get_and_clear_sock_errors(&mut self, option: &mut SocketError) {
+        option.set(self.sock_errors());
+        self.set_sock_errors(None);
+    }
+
+    /// Gets socket-level options.
+    ///
+    /// Note that the socket error has to be handled separately, because it is automatically
+    /// cleared after reading. This method does not handle it. Instead,
+    /// [`Self::get_and_clear_socket_errors`] should be used.
+    pub fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+        match_sock_option_mut!(option, {
+            socket_reuse_addr: ReuseAddr => {
+                let reuse_addr = self.reuse_addr();
+                socket_reuse_addr.set(reuse_addr);
+            },
+            socket_send_buf: SendBuf => {
+                let send_buf = self.send_buf();
+                socket_send_buf.set(send_buf);
+            },
+            socket_recv_buf: RecvBuf => {
+                let recv_buf = self.recv_buf();
+                socket_recv_buf.set(recv_buf);
+            },
+            socket_reuse_port: ReusePort => {
+                let reuse_port = self.reuse_port();
+                socket_reuse_port.set(reuse_port);
+            },
+            socket_linger: Linger => {
+                let linger = self.linger();
+                socket_linger.set(linger);
+            },
+            _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option to get is unknown")
+        });
+        Ok(())
+    }
+
+    /// Sets socket-level options.
+    pub fn set_option(&mut self, option: &dyn SocketOption) -> Result<()> {
+        match_sock_option_ref!(option, {
+            socket_recv_buf: RecvBuf => {
+                let recv_buf = socket_recv_buf.get().unwrap();
+                if *recv_buf <= MIN_RECVBUF {
+                    self.set_recv_buf(MIN_RECVBUF);
+                } else {
+                    self.set_recv_buf(*recv_buf);
+                }
+            },
+            socket_send_buf: SendBuf => {
+                let send_buf = socket_send_buf.get().unwrap();
+                if *send_buf <= MIN_SENDBUF {
+                    self.set_send_buf(MIN_SENDBUF);
+                } else {
+                    self.set_send_buf(*send_buf);
+                }
+            },
+            socket_reuse_addr: ReuseAddr => {
+                let reuse_addr = socket_reuse_addr.get().unwrap();
+                self.set_reuse_addr(*reuse_addr);
+            },
+            socket_reuse_port: ReusePort => {
+                let reuse_port = socket_reuse_port.get().unwrap();
+                self.set_reuse_port(*reuse_port);
+            },
+            socket_linger: Linger => {
+                let linger = socket_linger.get().unwrap();
+                self.set_linger(*linger);
+            },
+            _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option to be set is unknown")
+        });
+
+        Ok(())
     }
 }
 

--- a/test/apps/network/udp_err.c
+++ b/test/apps/network/udp_err.c
@@ -154,6 +154,47 @@ FN_TEST(bind)
 }
 END_TEST()
 
+FN_TEST(bind_reuseaddr)
+{
+	sk_addr.sin_port = htons(8081);
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	int disable = 0;
+	int enable = 1;
+	int sk1 = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int sk2 = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+
+	TEST_SUCC(bind(sk1, psaddr, addrlen));
+
+	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
+
+	// FIXME: The test will fail in Asterinas since it doesn't check
+	// if the previous socket was bound with `SO_REUSEADDR`
+	//
+	// TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &disable,
+	// 		     sizeof(disable)));
+	// TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &enable,
+	// 		     sizeof(enable)));
+	// TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &enable,
+			     sizeof(enable)));
+	TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &disable,
+			     sizeof(disable)));
+	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &enable,
+			     sizeof(enable)));
+	TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &enable,
+			     sizeof(enable)));
+	TEST_SUCC(bind(sk2, psaddr, addrlen));
+
+	TEST_SUCC(close(sk1));
+	TEST_SUCC(close(sk2));
+}
+END_TEST()
+
 FN_TEST(listen)
 {
 	TEST_ERRNO(listen(sk_unbound, 2), EOPNOTSUPP);


### PR DESCRIPTION
This PR enables the iper3 UDP bitrate test. However, as https://github.com/asterinas/asterinas/pull/1224#issuecomment-2306946130 mentioned, this PR does not add the test to the benchmark workflow, which will be done in future PRs.

The UDP result of Asterinas is the same as Linux with 1.05 Mbits/sec.