### PR TITLE
Implement `VmIoOnce` for `IoMem`

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -81,10 +81,9 @@ impl aster_block::BlockDevice for BlockDevice {
     }
 
     fn metadata(&self) -> BlockDeviceMeta {
-        let device_config = self.device.config.read().unwrap();
         BlockDeviceMeta {
             max_nr_segments_per_bio: self.queue.max_nr_segments_per_bio(),
-            nr_sectors: device_config.capacity_sectors(),
+            nr_sectors: VirtioBlockConfig::read_capacity_sectors(&self.device.config).unwrap(),
         }
     }
 }
@@ -107,7 +106,7 @@ impl DeviceInner {
     pub fn init(mut transport: Box<dyn VirtioTransport>) -> Result<Arc<Self>, VirtioDeviceError> {
         let config = VirtioBlockConfig::new(transport.as_mut());
         assert_eq!(
-            config.read().unwrap().block_size(),
+            VirtioBlockConfig::read_block_size(&config).unwrap(),
             VirtioBlockConfig::sector_size(),
             "currently not support customized device logical block size"
         );

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -3,7 +3,7 @@
 pub mod device;
 
 use aster_block::SECTOR_SIZE;
-use aster_util::safe_ptr::SafePtr;
+use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use int_to_c_enum::TryFromInt;
 use ostd::{io_mem::IoMem, Pod};
@@ -119,15 +119,17 @@ impl VirtioBlockConfig {
         SECTOR_SIZE
     }
 
-    pub(self) fn block_size(&self) -> usize {
-        self.blk_size as usize
+    pub(self) fn read_block_size(this: &SafePtr<Self, IoMem>) -> ostd::prelude::Result<usize> {
+        field_ptr!(this, Self, blk_size)
+            .read_once()
+            .map(|val| val as usize)
     }
 
-    pub(self) fn capacity_sectors(&self) -> usize {
-        self.capacity as usize
-    }
-
-    pub(self) fn capacity_bytes(&self) -> usize {
-        self.capacity_sectors() * Self::sector_size()
+    pub(self) fn read_capacity_sectors(
+        this: &SafePtr<Self, IoMem>,
+    ) -> ostd::prelude::Result<usize> {
+        field_ptr!(this, Self, capacity)
+            .read_once()
+            .map(|val| val as usize)
     }
 }

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -171,15 +171,17 @@ impl InputDevice {
     /// result to `out`, return the result size.
     pub fn query_config_select(&self, select: InputConfigSelect, subsel: u8, out: &mut [u8]) -> u8 {
         field_ptr!(&self.config, VirtioInputConfig, select)
-            .write(&(select as u8))
+            .write_once(&(select as u8))
             .unwrap();
         field_ptr!(&self.config, VirtioInputConfig, subsel)
-            .write(&subsel)
+            .write_once(&subsel)
             .unwrap();
         let size = field_ptr!(&self.config, VirtioInputConfig, size)
-            .read()
+            .read_once()
             .unwrap();
         let data: [u8; 128] = field_ptr!(&self.config, VirtioInputConfig, data)
+            // FIXME: It is impossible to call `read_once` on `[u8; 128]`. What's the proper way to
+            // read this field out?
             .read()
             .unwrap();
         out[..size as usize].copy_from_slice(&data[..size as usize]);

--- a/kernel/comps/virtio/src/device/network/config.rs
+++ b/kernel/comps/virtio/src/device/network/config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_network::EthernetAddr;
-use aster_util::safe_ptr::SafePtr;
+use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use ostd::{io_mem::IoMem, Pod};
 
@@ -75,5 +75,26 @@ impl VirtioNetConfig {
     pub(super) fn new(transport: &dyn VirtioTransport) -> SafePtr<Self, IoMem> {
         let memory = transport.device_config_memory();
         SafePtr::new(memory, 0)
+    }
+
+    pub(super) fn read(this: &SafePtr<Self, IoMem>) -> ostd::prelude::Result<Self> {
+        Ok(Self {
+            // FIXME: It is impossible to call `read_once` on `EthernetAddr`. What's the proper way
+            // to read this field out?
+            mac: field_ptr!(this, Self, mac).read()?,
+            status: field_ptr!(this, Self, status).read_once()?,
+            max_virtqueue_pairs: field_ptr!(this, Self, max_virtqueue_pairs).read_once()?,
+            mtu: field_ptr!(this, Self, mtu).read_once()?,
+            speed: field_ptr!(this, Self, speed).read_once()?,
+            duplex: field_ptr!(this, Self, duplex).read_once()?,
+            rss_max_key_size: field_ptr!(this, Self, rss_max_key_size).read_once()?,
+            rss_max_indirection_table_length: field_ptr!(
+                this,
+                Self,
+                rss_max_indirection_table_length
+            )
+            .read_once()?,
+            supported_hash_types: field_ptr!(this, Self, supported_hash_types).read_once()?,
+        })
     }
 }

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -53,10 +53,10 @@ impl SocketDevice {
         let virtio_vsock_config = VirtioVsockConfig::new(transport.as_mut());
         debug!("virtio_vsock_config = {:?}", virtio_vsock_config);
         let guest_cid = field_ptr!(&virtio_vsock_config, VirtioVsockConfig, guest_cid_low)
-            .read()
+            .read_once()
             .unwrap() as u64
             | (field_ptr!(&virtio_vsock_config, VirtioVsockConfig, guest_cid_high)
-                .read()
+                .read_once()
                 .unwrap() as u64)
                 << 32;
 
@@ -83,7 +83,7 @@ impl SocketDevice {
         }
 
         let mut device = Self {
-            config: virtio_vsock_config.read().unwrap(),
+            config: virtio_vsock_config.read_once().unwrap(),
             guest_cid,
             send_queue,
             recv_queue,

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -342,7 +342,7 @@ impl VirtQueue {
 
     /// notify that there are available rings
     pub fn notify(&mut self) {
-        self.notify.write(&self.queue_idx).unwrap();
+        self.notify.write_once(&self.queue_idx).unwrap();
     }
 }
 

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -198,10 +198,7 @@ impl VirtioTransport for VirtioMmioTransport {
 
     fn device_config_memory(&self) -> IoMem {
         // offset: 0x100~0x200
-        let mut io_mem = self.common_device.io_mem().clone();
-        let paddr = io_mem.paddr();
-        io_mem.resize((paddr + 0x100)..(paddr + 0x200)).unwrap();
-        io_mem
+        self.common_device.io_mem().slice(0x100..0x200)
     }
 
     fn device_features(&self) -> u64 {

--- a/kernel/comps/virtio/src/transport/mmio/multiplex.rs
+++ b/kernel/comps/virtio/src/transport/mmio/multiplex.rs
@@ -44,7 +44,7 @@ impl MultiplexIrq {
                 return;
             };
             let irq = multiplex_irq.read();
-            let interrupt_status = irq.interrupt_status.read().unwrap();
+            let interrupt_status = irq.interrupt_status.read_once().unwrap();
             let callbacks = if interrupt_status & 0x01 == 1 {
                 // Used buffer notification
                 &irq.queue_callbacks
@@ -55,7 +55,7 @@ impl MultiplexIrq {
             for callback in callbacks.iter() {
                 callback.call((trap_frame,));
             }
-            irq.interrupt_ack.write(&interrupt_status).unwrap();
+            irq.interrupt_ack.write_once(&interrupt_status).unwrap();
         };
         lock.irq.on_active(callback);
         drop(lock);

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -80,30 +80,30 @@ impl VirtioTransport for VirtioPciTransport {
             return Err(VirtioTransportError::InvalidArgs);
         }
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-            .write(&idx)
+            .write_once(&idx)
             .unwrap();
         debug_assert_eq!(
             field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-                .read()
+                .read_once()
                 .unwrap(),
             idx
         );
 
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_size)
-            .write(&queue_size)
+            .write_once(&queue_size)
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_desc)
-            .write(&(descriptor_ptr.paddr() as u64))
+            .write_once(&(descriptor_ptr.paddr() as u64))
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_driver)
-            .write(&(avail_ring_ptr.paddr() as u64))
+            .write_once(&(avail_ring_ptr.paddr() as u64))
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_device)
-            .write(&(used_ring_ptr.paddr() as u64))
+            .write_once(&(used_ring_ptr.paddr() as u64))
             .unwrap();
         // Enable queue
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_enable)
-            .write(&1u16)
+            .write_once(&1u16)
             .unwrap();
         Ok(())
     }
@@ -120,7 +120,7 @@ impl VirtioTransport for VirtioPciTransport {
 
     fn num_queues(&self) -> u16 {
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, num_queues)
-            .read()
+            .read_once()
             .unwrap()
     }
 
@@ -142,17 +142,17 @@ impl VirtioTransport for VirtioPciTransport {
     fn device_features(&self) -> u64 {
         // select low
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_feature_select)
-            .write(&0u32)
+            .write_once(&0u32)
             .unwrap();
         let device_feature_low = field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_features)
-            .read()
+            .read_once()
             .unwrap();
         // select high
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_feature_select)
-            .write(&1u32)
+            .write_once(&1u32)
             .unwrap();
         let device_feature_high = field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_features)
-            .read()
+            .read_once()
             .unwrap() as u64;
         device_feature_high << 32 | device_feature_low as u64
     }
@@ -161,47 +161,47 @@ impl VirtioTransport for VirtioPciTransport {
         let low = features as u32;
         let high = (features >> 32) as u32;
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, driver_feature_select)
-            .write(&0u32)
+            .write_once(&0u32)
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, driver_features)
-            .write(&low)
+            .write_once(&low)
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, driver_feature_select)
-            .write(&1u32)
+            .write_once(&1u32)
             .unwrap();
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, driver_features)
-            .write(&high)
+            .write_once(&high)
             .unwrap();
         Ok(())
     }
 
     fn device_status(&self) -> DeviceStatus {
         let status = field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_status)
-            .read()
+            .read_once()
             .unwrap();
         DeviceStatus::from_bits(status).unwrap()
     }
 
     fn set_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError> {
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_status)
-            .write(&(status.bits()))
+            .write_once(&(status.bits()))
             .unwrap();
         Ok(())
     }
 
     fn max_queue_size(&self, idx: u16) -> Result<u16, crate::transport::VirtioTransportError> {
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-            .write(&idx)
+            .write_once(&idx)
             .unwrap();
         debug_assert_eq!(
             field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-                .read()
+                .read_once()
                 .unwrap(),
             idx
         );
 
         Ok(field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_size)
-            .read()
+            .read_once()
             .unwrap())
     }
 
@@ -223,16 +223,16 @@ impl VirtioTransport for VirtioPciTransport {
         };
         irq.on_active(func);
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-            .write(&index)
+            .write_once(&index)
             .unwrap();
         debug_assert_eq!(
             field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-                .read()
+                .read_once()
                 .unwrap(),
             index
         );
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_msix_vector)
-            .write(&vector)
+            .write_once(&vector)
             .unwrap();
         Ok(())
     }

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -125,18 +125,11 @@ impl VirtioTransport for VirtioPciTransport {
     }
 
     fn device_config_memory(&self) -> IoMem {
-        let mut memory = self
-            .device_cfg
-            .memory_bar()
-            .as_ref()
-            .unwrap()
-            .io_mem()
-            .clone();
-        let new_paddr = memory.paddr() + self.device_cfg.offset() as usize;
-        memory
-            .resize(new_paddr..(self.device_cfg.length() as usize + new_paddr))
-            .unwrap();
-        memory
+        let memory = self.device_cfg.memory_bar().as_ref().unwrap().io_mem();
+
+        let offset = self.device_cfg.offset() as usize;
+        let length = self.device_cfg.length() as usize;
+        memory.slice(offset..offset + length)
     }
 
     fn device_features(&self) -> u64 {

--- a/ostd/src/bus/mmio/bus.rs
+++ b/ostd/src/bus/mmio/bus.rs
@@ -47,7 +47,7 @@ impl MmioBus {
         let length = self.common_devices.len();
         for i in (0..length).rev() {
             let common_device = self.common_devices.pop_front().unwrap();
-            let device_id = common_device.device_id();
+            let device_id = common_device.read_device_id().unwrap();
             let device = match driver.probe(common_device) {
                 Ok(device) => {
                     debug_assert!(device_id == device.device_id());
@@ -58,7 +58,6 @@ impl MmioBus {
                     if err != BusProbeError::DeviceNotMatch {
                         error!("MMIO device construction failed, reason: {:?}", err);
                     }
-                    debug_assert!(device_id == device.device_id());
                     device
                 }
             };
@@ -68,7 +67,7 @@ impl MmioBus {
     }
 
     pub(super) fn register_mmio_device(&mut self, mut mmio_device: MmioCommonDevice) {
-        let device_id = mmio_device.device_id();
+        let device_id = mmio_device.read_device_id().unwrap();
         for driver in self.drivers.iter() {
             mmio_device = match driver.probe(mmio_device) {
                 Ok(device) => {
@@ -80,7 +79,6 @@ impl MmioBus {
                     if err != BusProbeError::DeviceNotMatch {
                         error!("MMIO device construction failed, reason: {:?}", err);
                     }
-                    debug_assert!(device_id == common_device.device_id());
                     common_device
                 }
             };

--- a/ostd/src/bus/mmio/common_device.rs
+++ b/ostd/src/bus/mmio/common_device.rs
@@ -10,6 +10,7 @@ use crate::{
     io_mem::IoMem,
     mm::{paddr_to_vaddr, Paddr, VmIoOnce},
     trap::IrqLine,
+    Error, Result,
 };
 
 /// MMIO Common device.
@@ -37,7 +38,7 @@ impl MmioCommonDevice {
         };
         info!(
             "[Virtio]: Found Virtio mmio device, device id:{:?}, irq number:{:?}",
-            res.device_id(),
+            res.read_device_id().unwrap(),
             res.irq.num()
         );
         res
@@ -54,13 +55,14 @@ impl MmioCommonDevice {
     }
 
     /// Device ID
-    pub fn device_id(&self) -> u32 {
-        self.io_mem.read_once::<u32>(8).unwrap()
+    pub fn read_device_id(&self) -> Result<u32> {
+        self.io_mem.read_once::<u32>(8)
     }
 
     /// Version of the MMIO device.
-    pub fn version(&self) -> VirtioMmioVersion {
-        VirtioMmioVersion::try_from(self.io_mem.read_once::<u32>(4).unwrap()).unwrap()
+    pub fn read_version(&self) -> Result<VirtioMmioVersion> {
+        VirtioMmioVersion::try_from(self.io_mem.read_once::<u32>(4)?)
+            .map_err(|_| Error::InvalidArgs)
     }
 
     /// Interrupt line

--- a/ostd/src/bus/mmio/common_device.rs
+++ b/ostd/src/bus/mmio/common_device.rs
@@ -8,7 +8,7 @@ use log::info;
 use super::VIRTIO_MMIO_MAGIC;
 use crate::{
     io_mem::IoMem,
-    mm::{paddr_to_vaddr, Paddr, VmIo},
+    mm::{paddr_to_vaddr, Paddr, VmIoOnce},
     trap::IrqLine,
 };
 
@@ -55,12 +55,12 @@ impl MmioCommonDevice {
 
     /// Device ID
     pub fn device_id(&self) -> u32 {
-        self.io_mem.read_val::<u32>(8).unwrap()
+        self.io_mem.read_once::<u32>(8).unwrap()
     }
 
     /// Version of the MMIO device.
     pub fn version(&self) -> VirtioMmioVersion {
-        VirtioMmioVersion::try_from(self.io_mem.read_val::<u32>(4).unwrap()).unwrap()
+        VirtioMmioVersion::try_from(self.io_mem.read_once::<u32>(4).unwrap()).unwrap()
     }
 
     /// Interrupt line

--- a/ostd/src/bus/pci/capability/msix.rs
+++ b/ostd/src/bus/pci/capability/msix.rs
@@ -15,7 +15,7 @@ use crate::{
         common_device::PciCommonDevice,
         device_info::PciDeviceLocation,
     },
-    mm::VmIo,
+    mm::VmIoOnce,
     trap::IrqLine,
 };
 
@@ -121,15 +121,15 @@ impl CapabilityMsixData {
             // Set message address and disable this msix entry
             table_bar
                 .io_mem()
-                .write_val((16 * i) as usize + table_offset, &message_address)
+                .write_once((16 * i) as usize + table_offset, &message_address)
                 .unwrap();
             table_bar
                 .io_mem()
-                .write_val((16 * i + 4) as usize + table_offset, &message_upper_address)
+                .write_once((16 * i + 4) as usize + table_offset, &message_upper_address)
                 .unwrap();
             table_bar
                 .io_mem()
-                .write_val((16 * i + 12) as usize + table_offset, &1_u32)
+                .write_once((16 * i + 12) as usize + table_offset, &1_u32)
                 .unwrap();
         }
 
@@ -169,7 +169,7 @@ impl CapabilityMsixData {
         }
         self.table_bar
             .io_mem()
-            .write_val(
+            .write_once(
                 (16 * index + 8) as usize + self.table_offset,
                 &(handle.num() as u32),
             )
@@ -178,7 +178,7 @@ impl CapabilityMsixData {
         // Enable this msix vector
         self.table_bar
             .io_mem()
-            .write_val((16 * index + 12) as usize + self.table_offset, &0_u32)
+            .write_once((16 * index + 12) as usize + self.table_offset, &0_u32)
             .unwrap();
     }
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(coroutines)]
 #![feature(fn_traits)]
 #![feature(generic_const_exprs)]
+#![feature(is_none_or)]
 #![feature(iter_from_coroutine)]
 #![feature(let_chains)]
 #![feature(min_specialization)]


### PR DESCRIPTION
`IoMem` needs the `read_once`/`write_once` semantics, so we should implement `VmIoOnce` for it.

Also, https://github.com/asterinas/asterinas/pull/1156 makes `VmIo` accept `VmReader<_, Fallible>`/`VmWriter<_, Fallible>`, then the current implementation of `IoMem` becomes incorrect. While I don't think there are any use cases where we need to copy from I/O memory to fallible memory (e.g. user space), the current APIs _do_ allow it:
https://github.com/asterinas/asterinas/blob/e50b05d1ee71f52679e8ed8ea310cda6bfcd7e0c/ostd/src/io_mem.rs#L23-L34

Then this PR tries to reuse the logic provided by `VmReader` or `VmWriter` to implement `VmIoOnce` and solve the problem mentioned above. I'm not sure if this is a good idea, but I think it should be the simplest solution for now:
```rust
// For now, we reuse `VmReader` and `VmWriter` to access I/O memory.
//
// Note that I/O memory is not normal typed or untyped memory. Strictly speaking, it is not
// "memory", but rather I/O ports that communicate directly with the hardware. However, this code
// is in OSTD, so we can rely on the implementation details of `VmReader` and `VmWriter`, which we
// know are also suitable for accessing I/O memory.
```

After that, this PR changes all uses of `read/write` on `IoMem` to `read_once/write_once`, except for:
 - In `asterinas/kernel/comps/framebuffer/src/lib.rs`:
https://github.com/asterinas/asterinas/blob/e50b05d1ee71f52679e8ed8ea310cda6bfcd7e0c/kernel/comps/framebuffer/src/lib.rs#L92-L98
 - In [`kernel/comps/virtio/src/device/input/device.rs`](https://github.com/lrh2000/asterinas/blob/0ff2b5fa1836fdf1520eea1f8751e88f599adc83/kernel/comps/virtio/src/device/input/device.rs#L183-L187):
```rust
        let data: [u8; 128] = field_ptr!(&self.config, VirtioInputConfig, data)
            // FIXME: It is impossible to call `read_once` on `[u8; 128]`. What's the proper way to
            // read this field out?
            .read()
            .unwrap();
```
 - In [`kernel/comps/virtio/src/device/network/config.rs`](https://github.com/lrh2000/asterinas/blob/iomem-once/kernel/comps/virtio/src/device/network/config.rs#L82-L84):
```rust
            // FIXME: It is impossible to call `read_once` on `EthernetAddr`. What's the proper way
            // to read this field out?
            mac: field_ptr!(this, Self, mac).read().unwrap(),
```

It looks like Linux [forces byte-by-byte access](https://elixir.bootlin.com/linux/v6.10.6/source/include/linux/virtio_config.h#L478) if the field size is not 1, 2, 4. We don't have such an API, as `read`/`write` makes literally no guarantee about the access size (it can be byte-by-byte, word-by-word, or something else). It does not seem right to me, but I considered it outside the scope of this PR.