### PR TITLE
Bump and publish `ostd-test` and `ostd-macros`

### DIFF
--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -13,62 +13,22 @@ on:
       - VERSION
 
 jobs:
-  osdk-publish:
+  publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: asterinas/asterinas:0.8.0
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check Publish OSDK
-        # On pull request, set `--dry-run` to check whether OSDK can publish
+      - name: Publish OSTD and OSDK (dry run)
+        # On pull request, set `--dry-run` to check whether they can be published
         if: github.event_name == 'pull_request'
         run: |
-          cd osdk
-          cargo publish --dry-run
-        
-      - name: Publish OSDK
-        # On push, OSDK will be published
+          ./tools/github_workflows/publish_osdk_and_ostd.sh --dry-run
+      
+      - name: Publish OSTD and OSDK
         if: github.event_name == 'push'
         env:
           REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cd osdk
-          cargo publish --token ${REGISTRY_TOKEN}
-
-  ostd-publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    container: asterinas/asterinas:0.8.0
-    strategy:
-      matrix:
-        # All supported targets, this array should keep consistent with
-        # `package.metadata.docs.rs.targets` in `ostd/Cargo.toml`
-        target: ['x86_64-unknown-none']
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check Publish OSTD and the test runner
-        # On pull request, set `--dry-run` to check whether OSDK can publish
-        if: github.event_name == 'pull_request'
-        run: |
-          cd ostd
-          cargo publish --target ${{ matrix.target }} --dry-run
-          cargo doc --target ${{ matrix.target }}
-          cd osdk/test-kernel
-          cargo publish --target ${{ matrix.target }} --dry-run
-          cargo doc --target ${{ matrix.target }}
-      
-      - name: Publish OSTD and the test runner
-        if: github.event_name == 'push'
-        env:
-          REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        # Using any target that OSTD supports for publishing is ok.
-        # Here we use the same target as 
-        # `package.metadata.docs.rs.default-target` in `ostd/Cargo.toml`.
-        run: |
-          cd ostd
-          cargo publish --target x86_64-unknown-none --token ${REGISTRY_TOKEN}
-          cd osdk/test-kernel
-          cargo publish --target x86_64-unknown-none --token ${REGISTRY_TOKEN}
-      
+          ./tools/github_workflows/publish_osdk_and_ostd.sh --token ${REGISTRY_TOKEN}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,18 +320,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.5.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "ostd-macros"
-version = "0.1.4"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "ostd-test"
-version = "0.1.0"
+version = "0.8.0"
 
 [[package]]
 name = "owo-colors"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -69,8 +69,8 @@ static_assertions = "1.1.0"
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e" }
 getset = "0.1.2"
 atomic = "0.6"
-bytemuck = "1.14.3"
-bytemuck_derive = "1.5.0"
+bytemuck = "1.17.0"
+bytemuck_derive = "1.7.1"
 takeable = "0.2.2"
 cfg-if = "1.0"
 

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -34,8 +34,8 @@ log = "0.4"
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-ostd-macros = { path = "libs/ostd-macros", version = "0.1.4" }
-ostd-test = { path = "libs/ostd-test", version = "0.1.0" }
+ostd-macros = { version = "0.8.0", path = "libs/ostd-macros" }
+ostd-test = { version = "0.8.0", path = "libs/ostd-test" }
 owo-colors = { version = "3", optional = true }
 ostd-pod = { git = "https://github.com/asterinas/ostd-pod", rev = "c4644be", version = "0.1.1" }
 spin = "0.9.4"

--- a/ostd/libs/linux-bzimage/builder/Cargo.toml
+++ b/ostd/libs/linux-bzimage/builder/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/asterinas/asterinas"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytemuck = { version = "1.14.0", features = ["derive"] }
+bytemuck = { version = "1.17.0", features = ["derive"] }
 bitflags = "1.3"
 libflate = "2.1.0"
 serde = { version = "1.0.192", features = ["derive"] }

--- a/ostd/libs/ostd-macros/Cargo.toml
+++ b/ostd/libs/ostd-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ostd-macros"
-version = "0.1.4"
+version = "0.8.0"
 edition = "2021"
 description = "OSTD's proc macros"
 license = "MPL-2.0"

--- a/ostd/libs/ostd-test/Cargo.toml
+++ b/ostd/libs/ostd-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ostd-test"
-version = "0.1.0"
+version = "0.8.0"
 edition = "2021"
 description = "The kernel mode unit testing framework of OSTD"
 license = "MPL-2.0"

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -20,11 +20,11 @@ update_package_version() {
     sed -i "0,/${pattern}/s/${pattern}/version = \"${new_version}\"/1" $1
 }
 
-# Update the version of the `ostd` dependency (`ostd = { version = "", ...`) in file $1
-update_ostd_dep_version() {
-    echo "Updating file $1"
-    pattern="^ostd = { version = \"[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\""
-    sed -i "0,/${pattern}/s/${pattern}/ostd = { version = \"${new_version}\"/1" $1
+# Update the version of the $2 dependency (`$2 = { version = "", ...`) in file $1
+update_dep_version() {
+    echo "Updating the version of $2 in file $1"
+    pattern="^$2 = { version = \"[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\""
+    sed -i "0,/${pattern}/s/${pattern}/$2 = { version = \"${new_version}\"/1" $1
 }
 
 # Update Docker image versions (`asterinas/asterinas:{version}`) in file $1
@@ -104,8 +104,10 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ASTER_SRC_DIR=${SCRIPT_DIR}/..
 DOCS_DIR=${ASTER_SRC_DIR}/docs
 OSTD_CARGO_TOML_PATH=${ASTER_SRC_DIR}/ostd/Cargo.toml
+OSTD_TEST_CARGO_TOML_PATH=${ASTER_SRC_DIR}/ostd/libs/ostd-test/Cargo.toml
+OSTD_MACROS_CARGO_TOML_PATH=${ASTER_SRC_DIR}/ostd/libs/ostd-macros/Cargo.toml
 OSDK_CARGO_TOML_PATH=${ASTER_SRC_DIR}/osdk/Cargo.toml
-OSTD_TEST_RUNNER_CARGO_TOML_PATH=${ASTER_SRC_DIR}/osdk/test-kernel/Cargo.toml
+OSDK_TEST_RUNNER_CARGO_TOML_PATH=${ASTER_SRC_DIR}/osdk/test-kernel/Cargo.toml
 VERSION_PATH=${ASTER_SRC_DIR}/VERSION
 
 current_version=$(cat ${VERSION_PATH})
@@ -119,11 +121,15 @@ fi
 validate_bump_type
 new_version=$(bump_version ${current_version})
 
-# Update the package version in Cargo.toml
+# Update the versions in Cargo.toml
+update_package_version ${OSTD_TEST_CARGO_TOML_PATH}
+update_package_version ${OSTD_MACROS_CARGO_TOML_PATH}
 update_package_version ${OSTD_CARGO_TOML_PATH}
+update_dep_version ${OSTD_CARGO_TOML_PATH} ostd-test
+update_dep_version ${OSTD_CARGO_TOML_PATH} ostd-macros
 update_package_version ${OSDK_CARGO_TOML_PATH}
-update_package_version ${OSTD_TEST_RUNNER_CARGO_TOML_PATH}
-update_ostd_dep_version ${OSTD_TEST_RUNNER_CARGO_TOML_PATH}
+update_package_version ${OSDK_TEST_RUNNER_CARGO_TOML_PATH}
+update_dep_version ${OSDK_TEST_RUNNER_CARGO_TOML_PATH} ostd
 
 # Automatically bump Cargo.lock file
 cargo update -p aster-nix --precise $new_version

--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Publish OSDK and OSTD to crates.io
+#
+# Usage: publish_osdk_and_ostd.sh [--dry-run | --token REGISTRY_TOKEN]
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ASTER_SRC_DIR=${SCRIPT_DIR}/../..
+
+# Print help message
+print_help() {
+    echo "Usage: $0 [--dry-run | --token REGISTRY_TOKEN]"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run:               Execute the publish check without actually publishing it."
+    echo "  --token REGISTRY_TOKEN:  The token to authenticate with crates.io."
+}
+
+# Parse the parameters
+DRY_RUN=""
+TOKEN=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        --token)
+            TOKEN="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Invalid parameter: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+done
+
+# Performs the publish check or publish the crate in directory $1, with
+# optional target $2. If the target is not specified, cargo will decide
+# the target automatically.
+do_publish_for() {
+    pushd $ASTER_SRC_DIR/$1
+    TARGET_ARGS=""
+    if [ -n "$2" ]; then
+        TARGET_ARGS="--target $2"
+    fi
+    if [ -n "$DRY_RUN" ]; then
+        cargo publish --dry-run $TARGET_ARGS
+        cargo doc $TARGET_ARGS
+    else
+        cargo publish --token $TOKEN $TARGET_ARGS
+    fi
+    popd
+}
+
+do_publish_for osdk
+
+# All supported targets of OSTD, this array should keep consistent with
+# `package.metadata.docs.rs.targets` in `ostd/Cargo.toml`.
+TARGETS="x86_64-unknown-none"
+for TARGET in $TARGETS; do
+    do_publish_for ostd/libs/ostd-macros $TARGET
+    do_publish_for ostd/libs/ostd-test $TARGET
+    do_publish_for ostd $TARGET
+    do_publish_for osdk/test-kernel $TARGET
+
+    # For actual publishing, we should only publish once. Using any target that
+    # OSTD supports is OK. Here we use the first target in the list.
+    if [ -z "$DRY_RUN" ]; then
+        break
+    fi
+done


### PR DESCRIPTION
I realized that the two crates `ostd-test` and `ostd-macros` are not automatically bumped and published. It introduces troubles for #1159 .