### PR TITLE
Improve the latency of semop

### DIFF
--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -198,6 +198,7 @@ impl Semaphore {
         } else if zero_condition {
             return Ok(());
         }
+        drop(val);
 
         // Need to wait for the semaphore
         if flags.contains(IpcFlags::IPC_NOWAIT) {
@@ -219,7 +220,6 @@ impl Semaphore {
         } else {
             self.pending_alters.lock().push_back(pending_op);
         }
-        drop(val);
 
         // Wait
         if let Some(timeout) = timeout {

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -166,7 +166,7 @@ impl Semaphore {
         );
     }
 
-    fn sem_op(&self, sem_buf: SemBuf, timeout: Option<Duration>, ctx: &Context) -> Result<()> {
+    fn sem_op(&self, sem_buf: &SemBuf, timeout: Option<Duration>, ctx: &Context) -> Result<()> {
         let mut val = self.val.lock();
         let sem_op = sem_buf.sem_op;
         let current_pid = ctx.process.pid();
@@ -208,7 +208,7 @@ impl Semaphore {
         let (waiter, waker) = Waiter::new_pair();
         let status = Arc::new(AtomicStatus::new(Status::Pending));
         let pending_op = Box::new(PendingOp {
-            sem_buf,
+            sem_buf: *sem_buf,
             status: status.clone(),
             waker: waker.clone(),
             process: ctx.posix_thread.weak_process(),
@@ -303,7 +303,7 @@ impl Semaphore {
 
 pub fn sem_op(
     sem_id: key_t,
-    sem_buf: SemBuf,
+    sem_buf: &SemBuf,
     timeout: Option<Duration>,
     ctx: &Context,
 ) -> Result<()> {

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -58,7 +58,7 @@ pub fn sys_semctl(
                     .get(semnum as usize)
                     .ok_or(Error::new(Errno::EINVAL))?;
 
-                sem.set_val(val)?;
+                sem.set_val(val, ctx.process.pid())?;
                 sem_set.update_ctime();
 
                 Ok(())

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -61,7 +61,7 @@ fn do_sys_semtimedop(
         let sem_buf =
             CurrentUserSpace::get().read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?;
 
-        sem_op(sem_id, sem_buf, timeout, ctx)?;
+        sem_op(sem_id, &sem_buf, timeout, ctx)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -13,12 +13,12 @@ use crate::{
     time::timespec_t,
 };
 
-pub fn sys_semop(sem_id: i32, tsops: Vaddr, nsops: usize, _ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_semop(sem_id: i32, tsops: Vaddr, nsops: usize, ctx: &Context) -> Result<SyscallReturn> {
     debug!(
         "[sys_semop] sem_id = {:?}, tsops_vaddr = {:x?}, nsops = {:?}",
         sem_id, tsops, nsops
     );
-    do_sys_semtimedop(sem_id, tsops, nsops, None)
+    do_sys_semtimedop(sem_id, tsops, nsops, None, ctx)
 }
 
 pub fn sys_semtimedop(
@@ -41,7 +41,7 @@ pub fn sys_semtimedop(
         )?)
     };
 
-    do_sys_semtimedop(sem_id, tsops, nsops, timeout)
+    do_sys_semtimedop(sem_id, tsops, nsops, timeout, ctx)
 }
 
 fn do_sys_semtimedop(
@@ -49,6 +49,7 @@ fn do_sys_semtimedop(
     tsops: Vaddr,
     nsops: usize,
     timeout: Option<Duration>,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     if sem_id <= 0 || nsops == 0 {
         return_errno!(Errno::EINVAL);
@@ -64,7 +65,7 @@ fn do_sys_semtimedop(
             check_sem(sem_id, None, PermissionMode::ALTER)?;
         }
 
-        sem_op(sem_id, sem_buf, timeout)?;
+        sem_op(sem_id, sem_buf, timeout, ctx)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -6,8 +6,7 @@ use super::SyscallReturn;
 use crate::{
     ipc::semaphore::system_v::{
         sem::{sem_op, SemBuf},
-        sem_set::{check_sem, SEMOPM},
-        PermissionMode,
+        sem_set::SEMOPM,
     },
     prelude::*,
     time::timespec_t,
@@ -61,9 +60,6 @@ fn do_sys_semtimedop(
     for i in 0..nsops {
         let sem_buf =
             CurrentUserSpace::get().read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?;
-        if sem_buf.sem_op() != 0 {
-            check_sem(sem_id, None, PermissionMode::ALTER)?;
-        }
 
         sem_op(sem_id, sem_buf, timeout, ctx)?;
     }


### PR DESCRIPTION
This PR adds several commits to improve the latency of semop. The result of `lat_sem` is now 0.6157 us in Asterinas and 0.3568 us in Linux (with #1235).