### PR TITLE
Fix OSDK_LOCAL_DEV and let CI test on local versions.

### DIFF
--- a/.github/workflows/test_osdk.yml
+++ b/.github/workflows/test_osdk.yml
@@ -40,10 +40,7 @@ jobs:
       # So the RUSTUP_HOME needs to be set here. 
       - name: Unit test
         id: unit_test
-        run: |
-          cd osdk
-          RUSTUP_HOME=/root/.rustup cargo build
-          RUSTUP_HOME=/root/.rustup cargo test
+        run: RUSTUP_HOME=/root/.rustup make test_osdk
 
   osdk-test-tdx:
     if: github.event_name == 'schedule'
@@ -74,7 +71,4 @@ jobs:
       # So the RUSTUP_HOME needs to be set here. 
       - name: Unit test
         id: unit_test
-        run: |
-          cd osdk
-          RUSTUP_HOME=/root/.rustup INTEL_TDX=1 cargo build
-          RUSTUP_HOME=/root/.rustup INTEL_TDX=1 cargo test
+        run: RUSTUP_HOME=/root/.rustup INTEL_TDX=1 make test_osdk

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,16 @@ install_osdk:
 $(CARGO_OSDK):
 	@make --no-print-directory install_osdk
 
+.PHONY: check_osdk
+check_osdk:
+	@cd osdk && cargo clippy -- -D warnings
+
+.PHONY: test_osdk
+test_osdk:
+	@cd osdk && \
+		OSDK_LOCAL_DEV=1 cargo build && \
+		OSDK_LOCAL_DEV=1 cargo test
+
 .PHONY: initramfs
 initramfs:
 	@make --no-print-directory -C test
@@ -230,13 +240,15 @@ check: initramfs $(CARGO_OSDK)
 	done
 	@make --no-print-directory -C test check
 
-.PHONY: check_osdk
-check_osdk:
-	@cd osdk && cargo clippy -- -D warnings
-
 .PHONY: clean
 clean:
+	@echo "Cleaning up Asterinas workspace target files"
 	@cargo clean
+	@echo "Cleaning up OSDK workspace target files"
+	@cd osdk && cargo clean
+	@echo "Cleaning up documentation target files"
 	@cd docs && mdbook clean
+	@echo "Cleaning up test target files"
 	@make --no-print-directory -C test clean
+	@echo "Uninstalling OSDK"
 	@rm -f $(CARGO_OSDK)

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -131,14 +131,22 @@ fn add_manifest_dependency(
 
     if link_unit_test_runner {
         let dep_str = match option_env!("OSDK_LOCAL_DEV") {
-            Some("1") => "osdk-test-kernel = { path = \"../../../osdk/test-kernel\" }",
+            Some("1") => {
+                let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                let test_kernel_dir = crate_dir.join("test-kernel");
+                format!(
+                    "osdk-test-kernel = {{ path = \"{}\" }}",
+                    test_kernel_dir.display()
+                )
+            }
             _ => concat!(
                 "osdk-test-kernel = { version = \"",
                 env!("CARGO_PKG_VERSION"),
                 "\" }"
-            ),
+            )
+            .to_owned(),
         };
-        let test_runner_dep = toml::Table::from_str(dep_str).unwrap();
+        let test_runner_dep = toml::Table::from_str(&dep_str).unwrap();
         dependencies.as_table_mut().unwrap().extend(test_runner_dep);
     }
 

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -172,8 +172,9 @@ fn install_setup_with_arch(
     cmd.arg("--force");
     cmd.arg("--root").arg(install_dir.as_ref());
     if matches!(option_env!("OSDK_LOCAL_DEV"), Some("1")) {
-        cmd.arg("--path")
-            .arg("../../../ostd/libs/linux-bzimage/setup");
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let setup_dir = crate_dir.join("../ostd/libs/linux-bzimage/setup");
+        cmd.arg("--path").arg(setup_dir);
     }
     // Remember to upgrade this version if new version of linux-bzimage-setup is released.
     const LINUX_BZIMAGE_SETUP_VERSION: &str = "0.1.0";

--- a/osdk/tests/util/mod.rs
+++ b/osdk/tests/util/mod.rs
@@ -146,7 +146,7 @@ pub(crate) fn add_tdx_scheme(osdk_path: impl AsRef<Path>) -> std::io::Result<()>
 }
 
 pub(crate) fn is_tdx_enabled() -> bool {
-    std::env::var("INTEL_TDX").is_ok()
+    std::env::var("INTEL_TDX").is_ok_and(|s| s == "1")
 }
 
 fn conditionally_add_tdx_args<T: AsRef<OsStr>, I: IntoIterator<Item = T> + Copy>(


### PR DESCRIPTION
Fix the recent CI failure on OSDK test: `test_examples_in_book`.

Originally the CI wants to test the local OSDK with remote published `osdk-test-kernel`, which leads to dual existence of OSTD. Now this PR always uses the local development version of every crate (OSTD, OSDK, `osdk-test-kernel`) for CI.

The updated behavior is desired, we do not actually want to require local modifications of OSDK always compatible with the published `crates.io`'s `osdk-test-kernel` (vice versa). So does CI. CI now uses all local crates. The downside is that we don't really ensure what users get are working, by the current CI infrastructures. `OSDK_LOCAL_DEV`, though used conservatively for testing, would lead to the differences between the local and the published version.

The way to ensure what users get are working seems to add another CI workflow post-publishing (or daily), which may be out of the scope of this PR.