### PR TITLE
Add ldconfig to initramfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 # If the BENCHMARK is set, we will run the benchmark in the kernel mode.
 ifneq ($(BENCHMARK), none)
-CARGO_OSDK_ARGS += --init-args="/benchmark/$(BENCHMARK)/run.sh"
+CARGO_OSDK_ARGS += --init-args="/benchmark/common/runner.sh $(BENCHMARK)"
 endif
 
 ifeq ($(RELEASE_LTO), 1)

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,6 @@ INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio.gz
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
 INITRAMFS_EMPTY_DIRS := \
-	$(INITRAMFS)/sbin \
 	$(INITRAMFS)/root \
 	$(INITRAMFS)/tmp \
 	$(INITRAMFS)/opt \
@@ -26,6 +25,7 @@ INITRAMFS_ALL_DIRS := \
 	$(INITRAMFS)/lib/x86_64-linux-gnu \
 	$(INITRAMFS)/lib64 \
 	$(INITRAMFS)/bin \
+	$(INITRAMFS)/sbin \
 	$(INITRAMFS)/usr/bin \
 	$(INITRAMFS)/test \
 	$(INITRAMFS)/benchmark \
@@ -81,6 +81,11 @@ $(INITRAMFS)/etc:
 $(INITRAMFS)/bin:
 	@mkdir -p $@
 	@/bin/busybox --install -s $@
+
+$(INITRAMFS)/sbin:
+	@mkdir -p $@
+	@cp /sbin/ldconfig $@
+	@cp /sbin/ldconfig.real $@
 
 $(INITRAMFS)/usr/bin: | $(INITRAMFS)/bin
 	@mkdir -p $@

--- a/test/benchmark/common/runner.sh
+++ b/test/benchmark/common/runner.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+print_help() {
+    echo "Usage: $0 bench_name"
+    echo ""
+    echo "The bench_name argument must be one of the directory under asterinas/test/benchmark/".
+}
+
+BENCH_NAME=$1
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# Validate arguments
+check_bench_name() {
+    if [ -z "${BENCH_NAME}" ]; then
+        echo "Error: No directory provided."
+        print_help
+        exit 1
+    fi
+
+    local full_path="${SCRIPT_DIR}/../${BENCH_NAME}"
+
+    if ! [ -d "${full_path}" ]; then
+        echo "Directory '${BENCH_NAME}' does not exist in the script directory."
+        print_help
+        exit 1
+    fi
+}
+
+check_bench_name
+
+BENCH_SCRIPT=${SCRIPT_DIR}/../${BENCH_NAME}/run.sh
+
+# Prepare the environment
+if [ ! -d /tmp ]; then
+    mkdir /tmp
+fi
+/sbin/ldconfig
+chmod +x ${BENCH_SCRIPT}
+
+# Run the benchmark
+${BENCH_SCRIPT}

--- a/test/benchmark/lmbench-exec/run.sh
+++ b/test/benchmark/lmbench-exec/run.sh
@@ -6,8 +6,5 @@ set -e
 
 echo "*** Running the LMbench exec latency test ***"
 
-if [ ! -d /tmp ]; then
-    mkdir /tmp
-fi
 cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 exec

--- a/test/benchmark/lmbench-shell/run.sh
+++ b/test/benchmark/lmbench-shell/run.sh
@@ -6,8 +6,5 @@ set -e
 
 echo "*** Running the LMbench shell latency test ***"
 
-if [ ! -d /tmp ]; then
-    mkdir /tmp
-fi
 cp /benchmark/bin/lmbench/hello /tmp/
 /benchmark/bin/lmbench/lat_proc -P 1 shell


### PR DESCRIPTION
ldconfig can be used to generate the `ld.so.cache`, which can accelerate the process of locating dynamic link libraries. This PR currently generates `ld.so.cache` using ldconfig only in exec and shell tests. This operation has respectively increased the execution speed of the exec test on Asterinas and Linux by about 30 microseconds and 15 microseconds, so I think it can be added for now...