### PR TITLE
Fix integer overflow in memory related syscall

### DIFF
--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -20,7 +20,7 @@ pub fn sys_madvise(
     if start % PAGE_SIZE != 0 {
         return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
     }
-    if len == 0 {
+    if len == 0 || len > usize::MAX - PAGE_SIZE + 1 {
         return Ok(SyscallReturn::Return(0));
     }
 

--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -20,7 +20,10 @@ pub fn sys_madvise(
     if start % PAGE_SIZE != 0 {
         return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
     }
-    if len == 0 || len > usize::MAX - PAGE_SIZE + 1 {
+    if len > usize::MAX - PAGE_SIZE + 1 {
+        return_errno_with_message!(Errno::EINVAL, "len align overflow");
+    }
+    if len == 0 {
         return Ok(SyscallReturn::Return(0));
     }
 

--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -20,7 +20,7 @@ pub fn sys_madvise(
     if start % PAGE_SIZE != 0 {
         return_errno_with_message!(Errno::EINVAL, "the start address should be page aligned");
     }
-    if len > usize::MAX - PAGE_SIZE + 1 {
+    if len > isize::MAX as usize {
         return_errno_with_message!(Errno::EINVAL, "len align overflow");
     }
     if len == 0 {

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -57,6 +57,9 @@ fn do_sys_mmap(
     if len == 0 {
         return_errno_with_message!(Errno::EINVAL, "mmap len cannot be zero");
     }
+    if len > usize::MAX - PAGE_SIZE + 1 {
+        return_errno_with_message!(Errno::ENOMEM, "mmap len align overflow");
+    }
 
     let len = len.align_up(PAGE_SIZE);
 

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -57,14 +57,21 @@ fn do_sys_mmap(
     if len == 0 {
         return_errno_with_message!(Errno::EINVAL, "mmap len cannot be zero");
     }
-    if len > usize::MAX - PAGE_SIZE + 1 {
-        return_errno_with_message!(Errno::ENOMEM, "mmap len align overflow");
+    if len > isize::MAX as usize {
+        return_errno_with_message!(Errno::ENOMEM, "mmap len too large");
     }
 
     let len = len.align_up(PAGE_SIZE);
 
     if offset % PAGE_SIZE != 0 {
         return_errno_with_message!(Errno::EINVAL, "mmap only support page-aligned offset");
+    }
+    offset.checked_add(len).ok_or(Error::with_message(
+        Errno::EOVERFLOW,
+        "integer overflow when (offset + len)",
+    ))?;
+    if addr > isize::MAX as usize - len {
+        return_errno_with_message!(Errno::ENOMEM, "mmap (addr + len) too large");
     }
 
     let root_vmar = ctx.process.root_vmar();

--- a/kernel/src/syscall/mprotect.rs
+++ b/kernel/src/syscall/mprotect.rs
@@ -22,6 +22,9 @@ pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64, ctx: &Context) -> Resul
     if len == 0 {
         return Ok(SyscallReturn::Return(0));
     }
+    if len > usize::MAX - PAGE_SIZE + 1 {
+        return_errno_with_message!(Errno::ENOMEM, "len align overflow");
+    }
 
     let len = len.align_up(PAGE_SIZE);
     let end = addr.checked_add(len).ok_or(Error::with_message(

--- a/kernel/src/syscall/mprotect.rs
+++ b/kernel/src/syscall/mprotect.rs
@@ -24,7 +24,11 @@ pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64, ctx: &Context) -> Resul
     }
 
     let len = len.align_up(PAGE_SIZE);
-    let range = addr..(addr + len);
+    let end = addr.checked_add(len).ok_or(Error::with_message(
+        Errno::ENOMEM,
+        "integer overflow when (addr + len)",
+    ))?;
+    let range = addr..end;
     root_vmar.protect(vm_perms, range)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/mprotect.rs
+++ b/kernel/src/syscall/mprotect.rs
@@ -22,7 +22,7 @@ pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64, ctx: &Context) -> Resul
     if len == 0 {
         return Ok(SyscallReturn::Return(0));
     }
-    if len > usize::MAX - PAGE_SIZE + 1 {
+    if len > isize::MAX as usize {
         return_errno_with_message!(Errno::ENOMEM, "len align overflow");
     }
 

--- a/kernel/src/syscall/munmap.rs
+++ b/kernel/src/syscall/munmap.rs
@@ -14,6 +14,9 @@ pub fn sys_munmap(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallRetur
     if len == 0 {
         return_errno_with_message!(Errno::EINVAL, "munmap len cannot be zero");
     }
+    if len > usize::MAX - PAGE_SIZE + 1 {
+        return_errno_with_message!(Errno::ENOMEM, "munmap len align overflow");
+    }
 
     let root_vmar = ctx.process.root_vmar();
     let len = len.align_up(PAGE_SIZE);

--- a/kernel/src/syscall/munmap.rs
+++ b/kernel/src/syscall/munmap.rs
@@ -17,7 +17,11 @@ pub fn sys_munmap(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallRetur
 
     let root_vmar = ctx.process.root_vmar();
     let len = len.align_up(PAGE_SIZE);
-    debug!("unmap range = 0x{:x} - 0x{:x}", addr, addr + len);
-    root_vmar.destroy(addr..addr + len)?;
+    let end = addr.checked_add(len).ok_or(Error::with_message(
+        Errno::EINVAL,
+        "integer overflow when (addr + len)",
+    ))?;
+    debug!("unmap range = 0x{:x} - 0x{:x}", addr, end);
+    root_vmar.destroy(addr..end)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/munmap.rs
+++ b/kernel/src/syscall/munmap.rs
@@ -14,7 +14,7 @@ pub fn sys_munmap(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallRetur
     if len == 0 {
         return_errno_with_message!(Errno::EINVAL, "munmap len cannot be zero");
     }
-    if len > usize::MAX - PAGE_SIZE + 1 {
+    if len > isize::MAX as usize {
         return_errno_with_message!(Errno::ENOMEM, "munmap len align overflow");
     }
 

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -169,7 +169,7 @@ impl VmarInner {
                         .checked_add(child_size)
                         .ok_or(Error::with_message(
                             Errno::ENOMEM,
-                            "integer overflow whem (child_vmar_real_start + child_size)",
+                            "integer overflow when (child_vmar_real_start + child_size)",
                         ))?;
                 if region_start <= child_vmar_real_start && child_vmar_real_end <= region_end {
                     return Ok((*region_base, child_vmar_real_start));

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -164,7 +164,13 @@ impl VmarInner {
                 let region_start = free_region.start();
                 let region_end = free_region.end();
                 let child_vmar_real_start = region_start.align_up(align);
-                let child_vmar_real_end = child_vmar_real_start + child_size;
+                let child_vmar_real_end =
+                    child_vmar_real_start
+                        .checked_add(child_size)
+                        .ok_or(Error::with_message(
+                            Errno::ENOMEM,
+                            "integer overflow whem (child_vmar_real_start + child_size)",
+                        ))?;
                 if region_start <= child_vmar_real_start && child_vmar_real_end <= region_end {
                     return Ok((*region_base, child_vmar_real_start));
                 }


### PR DESCRIPTION
Fix #1213 

`mprotect` refers https://elixir.bootlin.com/linux/v6.10.5/source/mm/mprotect.c#L707

`madvise` refers https://elixir.bootlin.com/linux/v6.0.9/source/mm/madvise.c#L1404

`munmap` refers https://elixir.bootlin.com/linux/v6.10.5/source/mm/mmap.c#L2734

`mmap` refers https://elixir.bootlin.com/linux/v6.10.5/source/mm/mmap.c#L1729