### PR TITLE
Make benchmark CI more fair

### DIFF
--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -61,13 +61,13 @@ run_benchmark() {
         -smp 1 \
         -m 8G \
         -machine q35,kernel-irqchip=split \
-        -cpu Icelake-Server,+x2apic \
+        -cpu Icelake-Server,-pcid,+x2apic \
         --enable-kvm \
         -kernel ${LINUX_KERNEL} \
         -initrd ${BENCHMARK_DIR}/../build/initramfs.cpio.gz \
         -drive if=none,format=raw,id=x0,file=${BENCHMARK_DIR}/../build/ext2.img \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,config-wce=off,request-merging=off,write-cache=off,backend_defaults=off,discard=off,event_idx=off,indirect_desc=off,ioeventfd=off,queue_reset=off \
-        -append 'console=ttyS0 rdinit=/benchmark/benchmark_entrypoint.sh mitigations=off' \
+        -append 'console=ttyS0 rdinit=/benchmark/benchmark_entrypoint.sh mitigations=off hugepages=0 transparent_hugepage=never' \
         -nographic \
         2>&1 | tee ${linux_output}" 
 


### PR DESCRIPTION
This PR attempts to disable huge pages and PCID in the Linux during the benchmark CI to avoid one side gaining better efficiency due to the implementation of additional features. 

After multiple rounds of testing, it turns out that disabling these features has little impact on the current test results for Linux (Only test exec/pagefault/ctx/mmap tests, sometimes it seems to have an effect, but it might actually be due to fluctuations). Yet at least it helps to eliminate interference during optimization. If you feel that there are additional features in Linux that need to be enabled or disabled in the CI, welcome to supplement.
 