### PR TITLE
Implement futex private flag

### DIFF
--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -23,7 +23,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     let mut clear_ctid = posix_thread.clear_child_tid().lock();
     // If clear_ctid !=0 ,do a futex wake and write zero to the clear_ctid addr.
     if *clear_ctid != 0 {
-        futex_wake(*clear_ctid, 1)?;
+        futex_wake(*clear_ctid, 1, None)?;
         // FIXME: the correct write length?
         CurrentUserSpace::get()
             .write_val(*clear_ctid, &0u32)
@@ -44,7 +44,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
         do_exit_group(term_status);
     }
 
-    futex_wake(Arc::as_ptr(&posix_thread.process()) as Vaddr, 1)?;
+    futex_wake(Arc::as_ptr(&posix_thread.process()) as Vaddr, 1, None)?;
     Ok(())
 }
 

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -2,10 +2,7 @@
 
 //! The implementation of robust list is from occlum.
 
-use crate::{
-    prelude::*,
-    process::{posix_thread::futex::futex_wake, Pid},
-};
+use crate::{prelude::*, process::posix_thread::futex::futex_wake, thread::Tid};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
@@ -125,7 +122,7 @@ const FUTEX_TID_MASK: u32 = 0x3FFF_FFFF;
 
 /// Wakeup one robust futex owned by the thread
 /// FIXME: requires atomic operations here
-pub fn wake_robust_futex(futex_addr: Vaddr, tid: Pid) -> Result<()> {
+pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
     let user_space = CurrentUserSpace::get();
     let futex_val = {
         if futex_addr == 0 {
@@ -150,7 +147,7 @@ pub fn wake_robust_futex(futex_addr: Vaddr, tid: Pid) -> Result<()> {
         // Wakeup one waiter
         if cur_val & FUTEX_WAITERS != 0 {
             debug!("wake robust futex addr: {:?}", futex_addr);
-            futex_wake(futex_addr, 1)?;
+            futex_wake(futex_addr, 1, None)?;
         }
         break;
     }

--- a/test/syscall_test/blocklists/futex_test
+++ b/test/syscall_test/blocklists/futex_test
@@ -1,9 +1,13 @@
+# PrivateFutexTest needs FUTEX_WAKE_OP
 PrivateFutexTest.*
 RobustFutexTest.*
 SharedFutexTest.WakeInterprocessFile_NoRandomSave
-SharedPrivate/PrivateAndSharedFutexTest.Wake0_NoRandomSave/*
+
 SharedPrivate/PrivateAndSharedFutexTest.WakeOpCondSuccess_NoRandomSave/*
 SharedPrivate/PrivateAndSharedFutexTest.WakeOpCondFailure_NoRandomSave/*
+SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon_NoRandomSave/*
+SharedPrivate/PrivateAndSharedFutexTest.WakeWrongKind_NoRandomSave/1
+
 SharedPrivate/PrivateAndSharedFutexTest.PIBasic/*
 SharedPrivate/PrivateAndSharedFutexTest.PIConcurrency_NoRandomSave/*
 SharedPrivate/PrivateAndSharedFutexTest.PIWaiters/*
@@ -12,8 +16,5 @@ SharedPrivate/PrivateAndSharedFutexTest.PITryLockConcurrency_NoRandomSave/*
 # WakeAll_NoRandomSave/* encounters a segmenation fault
 SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/0
 SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/1
-SharedPrivate/PrivateAndSharedFutexTest.WakeSome_NoRandomSave/1
-SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon_NoRandomSave/*
-SharedPrivate/PrivateAndSharedFutexTest.WakeWrongKind_NoRandomSave/*
 # WakeAfterCOWBreak_NoRandomSave/* hangs sometimes
 SharedPrivate/PrivateAndSharedFutexTest.WakeAfterCOWBreak_NoRandomSave/0


### PR DESCRIPTION
LevelDB requires this feature to prevent multiple processes from accessing the same futex item.