### PR TITLE
Make the allocated segment uninitialized in the ring buffer (mitigate the performance degradation of `lmbench-unix-connect-latency`)

### DIFF
--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -77,7 +77,10 @@ impl<T> RingBuffer<T> {
             "capacity must be a power of two"
         );
         let nframes = capacity.saturating_mul(Self::T_SIZE).align_up(PAGE_SIZE) / PAGE_SIZE;
-        let segment = FrameAllocOptions::new(nframes).alloc_contiguous().unwrap();
+        let segment = FrameAllocOptions::new(nframes)
+            .uninit(true)
+            .alloc_contiguous()
+            .unwrap();
         Self {
             segment,
             capacity,


### PR DESCRIPTION
This PR can mitigate the performance degradation of the `lmbench-unix-connect-latency` test.