### PR TITLE
Introduce fork-related optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,19 @@ export VSOCK=1
 CARGO_OSDK_ARGS += --init-args="/test/run_vsock_test.sh"
 endif
 
-# If the BENCHMARK is set, we will run the benchmark in the kernel mode.
-ifneq ($(BENCHMARK), none)
-CARGO_OSDK_ARGS += --init-args="/benchmark/common/runner.sh $(BENCHMARK)"
-endif
-
 ifeq ($(RELEASE_LTO), 1)
 CARGO_OSDK_ARGS += --profile release-lto
 OSTD_TASK_STACK_SIZE_IN_PAGES = 8
 else ifeq ($(RELEASE), 1)
 CARGO_OSDK_ARGS += --release
 OSTD_TASK_STACK_SIZE_IN_PAGES = 8
+endif
+
+# If the BENCHMARK is set, we will run the benchmark in the kernel mode.
+ifneq ($(BENCHMARK), none)
+CARGO_OSDK_ARGS += --init-args="/benchmark/common/runner.sh $(BENCHMARK)"
+# TODO: remove this workaround after enabling kernel virtual area.
+OSTD_TASK_STACK_SIZE_IN_PAGES = 7
 endif
 
 ifeq ($(INTEL_TDX), 1)


### PR DESCRIPTION
The first commit is a workaround. Due to our current default use of guard pages and the fact that the kva PR(#1061) has not yet been merged, setting the kstack to 8 previously required the allocation of 9 pages, which translates to 16 pages for the buddy system, resulting in some overhead. An alternative solution is to uniformly not include guard pages during performance testing. 

The second commit introduces a fast path for copying page tables during fork, allowing for an early exit once all necessary child pages have been copied. There is still room for optimization in this area, but it is not readily achievable at the moment. In Linux, page table copying is based on existing VMAs , which avoids traversing addresses that are not in use.