### PR TITLE
Modify ostd to optimize performance

### DIFF
--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -9,6 +9,7 @@ use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec::Vec};
 use id_alloc::IdAlloc;
 use spin::Once;
 use trapframe::TrapFrame;
+use x86_64::registers::rflags::{self, RFlags};
 
 use crate::sync::{Mutex, PreemptDisabled, SpinLock, SpinLockGuard};
 
@@ -53,7 +54,7 @@ pub(crate) fn disable_local() {
 }
 
 pub(crate) fn is_local_enabled() -> bool {
-    x86_64::instructions::interrupts::are_enabled()
+    (rflags::read_raw() & RFlags::INTERRUPT_FLAG.bits()) != 0
 }
 
 static CALLBACK_ID_ALLOCATOR: Once<Mutex<IdAlloc>> = Once::new();

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -130,7 +130,7 @@ pub unsafe fn activate_page_table(root_paddr: Paddr, root_pt_cache: CachePolicy)
 }
 
 pub fn current_page_table_paddr() -> Paddr {
-    x86_64::registers::control::Cr3::read()
+    x86_64::registers::control::Cr3::read_raw()
         .0
         .start_address()
         .as_u64() as Paddr

--- a/ostd/src/arch/x86/trap.rs
+++ b/ostd/src/arch/x86/trap.rs
@@ -51,7 +51,7 @@ extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
                 *f = *trapframe_wrapper.0;
             }
             &PAGE_FAULT => {
-                let page_fault_addr = x86_64::registers::control::Cr2::read().as_u64();
+                let page_fault_addr = x86_64::registers::control::Cr2::read_raw();
                 // The actual user space implementation should be responsible
                 // for providing mechanism to treat the 0 virtual address.
                 if (0..MAX_USERSPACE_VADDR).contains(&(page_fault_addr as usize)) {


### PR DESCRIPTION
This PR will slightly improve the performance of almost all benchmarks. For example, the result `lat_sem` will drop from 0.6548 to 0.6340 us. The `lat_syscall null` will drop from 0.1006 to 0.996.

This PR makes the following changes:
1. Replace the read method with read_raw to avoid the unnecessary call of `BitFlags::from_bits_truncate`.
2. Inline functions in ostd.