### PR TITLE
Optimize the latency of lat-sig-install

### DIFF
--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -13,6 +13,7 @@ use crate::{
         inode_handle::FileIo,
         utils::{AccessMode, Inode, InodeMode, IoctlCmd},
     },
+    get_current_userspace,
     prelude::*,
     process::{
         signal::{Pollee, Poller},
@@ -150,11 +151,11 @@ impl FileIo for PtyMaster {
         match cmd {
             IoctlCmd::TCGETS => {
                 let termios = self.output.termios();
-                CurrentUserSpace::get().write_val(arg, &termios)?;
+                get_current_userspace!().write_val(arg, &termios)?;
                 Ok(0)
             }
             IoctlCmd::TCSETS => {
-                let termios = CurrentUserSpace::get().read_val(arg)?;
+                let termios = get_current_userspace!().read_val(arg)?;
                 self.output.set_termios(termios);
                 Ok(0)
             }
@@ -164,7 +165,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGPTN => {
                 let idx = self.index();
-                CurrentUserSpace::get().write_val(arg, &idx)?;
+                get_current_userspace!().write_val(arg, &idx)?;
                 Ok(0)
             }
             IoctlCmd::TIOCGPTPEER => {
@@ -197,11 +198,11 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGWINSZ => {
                 let winsize = self.output.window_size();
-                CurrentUserSpace::get().write_val(arg, &winsize)?;
+                get_current_userspace!().write_val(arg, &winsize)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSWINSZ => {
-                let winsize = CurrentUserSpace::get().read_val(arg)?;
+                let winsize = get_current_userspace!().read_val(arg)?;
                 self.output.set_window_size(winsize);
                 Ok(0)
             }
@@ -213,12 +214,12 @@ impl FileIo for PtyMaster {
                     );
                 };
                 let fg_pgid = foreground.pgid();
-                CurrentUserSpace::get().write_val(arg, &fg_pgid)?;
+                get_current_userspace!().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = CurrentUserSpace::get().read_val(arg)?;
+                    let pgid: i32 = get_current_userspace!().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -238,7 +239,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::FIONREAD => {
                 let len = self.input.lock().len() as i32;
-                CurrentUserSpace::get().write_val(arg, &len)?;
+                get_current_userspace!().write_val(arg, &len)?;
                 Ok(0)
             }
             _ => Ok(0),
@@ -377,12 +378,12 @@ impl FileIo for PtySlave {
                 };
 
                 let fg_pgid = foreground.pgid();
-                CurrentUserSpace::get().write_val(arg, &fg_pgid)?;
+                get_current_userspace!().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = CurrentUserSpace::get().read_val(arg)?;
+                    let pgid: i32 = get_current_userspace!().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -402,7 +403,7 @@ impl FileIo for PtySlave {
             }
             IoctlCmd::FIONREAD => {
                 let buffer_len = self.master().slave_buf_len() as i32;
-                CurrentUserSpace::get().write_val(arg, &buffer_len)?;
+                get_current_userspace!().write_val(arg, &buffer_len)?;
                 Ok(0)
             }
             _ => Ok(0),

--- a/kernel/src/device/tdxguest/mod.rs
+++ b/kernel/src/device/tdxguest/mod.rs
@@ -82,7 +82,7 @@ impl FileIo for TdxGuest {
 fn handle_get_report(arg: usize) -> Result<i32> {
     const SHARED_BIT: u8 = 51;
     const SHARED_MASK: u64 = 1u64 << SHARED_BIT;
-    let user_space = CurrentUserSpace::get();
+    let user_space = get_current_userspace!();
     let user_request: TdxReportRequest = user_space.read_val(arg)?;
 
     let vm_segment = FrameAllocOptions::new(2)

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -13,6 +13,7 @@ use crate::{
         inode_handle::FileIo,
         utils::IoctlCmd,
     },
+    get_current_userspace,
     prelude::*,
     process::{
         signal::{signals::kernel::KernelSignal, Poller},
@@ -100,7 +101,7 @@ impl FileIo for Tty {
                 // Get terminal attributes
                 let termios = self.ldisc.termios();
                 trace!("get termios = {:?}", termios);
-                CurrentUserSpace::get().write_val(arg, &termios)?;
+                get_current_userspace!().write_val(arg, &termios)?;
                 Ok(0)
             }
             IoctlCmd::TIOCGPGRP => {
@@ -109,13 +110,13 @@ impl FileIo for Tty {
                 };
                 let fg_pgid = foreground.pgid();
                 debug!("fg_pgid = {}", fg_pgid);
-                CurrentUserSpace::get().write_val(arg, &fg_pgid)?;
+                get_current_userspace!().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 // Set the process group id of fg progress group
                 let pgid = {
-                    let pgid: i32 = CurrentUserSpace::get().read_val(arg)?;
+                    let pgid: i32 = get_current_userspace!().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -130,20 +131,20 @@ impl FileIo for Tty {
             }
             IoctlCmd::TCSETS => {
                 // Set terminal attributes
-                let termios = CurrentUserSpace::get().read_val(arg)?;
+                let termios = get_current_userspace!().read_val(arg)?;
                 debug!("set termios = {:?}", termios);
                 self.ldisc.set_termios(termios);
                 Ok(0)
             }
             IoctlCmd::TCSETSW => {
-                let termios = CurrentUserSpace::get().read_val(arg)?;
+                let termios = get_current_userspace!().read_val(arg)?;
                 debug!("set termios = {:?}", termios);
                 self.ldisc.set_termios(termios);
                 // TODO: drain output buffer
                 Ok(0)
             }
             IoctlCmd::TCSETSF => {
-                let termios = CurrentUserSpace::get().read_val(arg)?;
+                let termios = get_current_userspace!().read_val(arg)?;
                 debug!("set termios = {:?}", termios);
                 self.ldisc.set_termios(termios);
                 self.ldisc.drain_input();
@@ -152,11 +153,11 @@ impl FileIo for Tty {
             }
             IoctlCmd::TIOCGWINSZ => {
                 let winsize = self.ldisc.window_size();
-                CurrentUserSpace::get().write_val(arg, &winsize)?;
+                get_current_userspace!().write_val(arg, &winsize)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSWINSZ => {
-                let winsize = CurrentUserSpace::get().read_val(arg)?;
+                let winsize = get_current_userspace!().read_val(arg)?;
                 self.ldisc.set_window_size(winsize);
                 Ok(0)
             }

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::{
     cpu::LinuxAbi,
     fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
+    get_current_userspace,
     prelude::*,
     process::posix_thread::allocate_posix_tid,
     thread::{Thread, Tid},
@@ -338,7 +339,7 @@ fn clone_parent_settid(
     clone_flags: CloneFlags,
 ) -> Result<()> {
     if clone_flags.contains(CloneFlags::CLONE_PARENT_SETTID) {
-        CurrentUserSpace::get().write_val(parent_tidptr, &child_tid)?;
+        get_current_userspace!().write_val(parent_tidptr, &child_tid)?;
     }
     Ok(())
 }

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -2,6 +2,7 @@
 
 use super::{futex::futex_wake, robust_list::wake_robust_futex, thread_table, PosixThread};
 use crate::{
+    get_current_userspace,
     prelude::*,
     process::{do_exit_group, TermStatus},
     thread::{Thread, Tid},
@@ -25,7 +26,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     if *clear_ctid != 0 {
         futex_wake(*clear_ctid, 1, None)?;
         // FIXME: the correct write length?
-        CurrentUserSpace::get()
+        get_current_userspace!()
             .write_val(*clear_ctid, &0u32)
             .unwrap();
         *clear_ctid = 0;

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -334,7 +334,7 @@ impl Process {
             .lock()
             .iter()
             .find(|task| task.tid() == self.pid)
-            .map(Thread::borrow_from_task)
+            .map(|task| Thread::borrow_from_task(task.as_ref()))
             .cloned()
     }
 

--- a/kernel/src/process/signal/sig_disposition.rs
+++ b/kernel/src/process/signal/sig_disposition.rs
@@ -26,9 +26,9 @@ impl SigDispositions {
         self.map[idx]
     }
 
-    pub fn set(&mut self, num: SigNum, sa: SigAction) {
+    pub fn set(&mut self, num: SigNum, sa: SigAction) -> SigAction {
         let idx = Self::num_to_idx(num);
-        self.map[idx] = sa;
+        core::mem::replace(&mut self.map[idx], sa)
     }
 
     pub fn set_default(&mut self, num: SigNum) {

--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -3,6 +3,7 @@
 use core::time::Duration;
 
 use crate::{
+    get_current_userspace,
     prelude::*,
     process::posix_thread::futex::{
         futex_op_and_flags_from_u32, futex_requeue, futex_wait, futex_wait_bitset, futex_wake,
@@ -45,7 +46,7 @@ pub fn sys_futex(
         }
 
         let timeout = {
-            let time_spec: timespec_t = CurrentUserSpace::get().read_val(timeout_addr)?;
+            let time_spec: timespec_t = get_current_userspace!().read_val(timeout_addr)?;
             Duration::try_from(time_spec)?
         };
 

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -55,7 +55,7 @@ impl Thread {
     /// # Panics
     ///
     /// This method panics if the task is not a thread.
-    pub fn borrow_from_task(task: &Arc<Task>) -> &Arc<Self> {
+    pub fn borrow_from_task(task: &Task) -> &Arc<Self> {
         task.data().downcast_ref::<Arc<Thread>>().unwrap()
     }
 

--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -3,6 +3,7 @@
 use core::time::Duration;
 
 use crate::{
+    get_current_userspace,
     net::socket::{ip::stream::CongestionControl, LingerOption},
     prelude::*,
 };
@@ -46,7 +47,7 @@ macro_rules! impl_read_write_for_pod_type {
                 if (max_len as usize) < core::mem::size_of::<$pod_ty>() {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
                 }
-                crate::context::CurrentUserSpace::get().read_val::<$pod_ty>(addr)
+                crate::get_current_userspace!().read_val::<$pod_ty>(addr)
             }
         }
 
@@ -58,7 +59,7 @@ macro_rules! impl_read_write_for_pod_type {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
                 }
 
-                crate::context::CurrentUserSpace::get().write_val(addr, self)?;
+                crate::get_current_userspace!().write_val(addr, self)?;
                 Ok(write_len)
             }
         }
@@ -73,7 +74,7 @@ impl ReadFromUser for bool {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
         }
 
-        let val = CurrentUserSpace::get().read_val::<i32>(addr)?;
+        let val = get_current_userspace!().read_val::<i32>(addr)?;
 
         Ok(val != 0)
     }
@@ -88,7 +89,7 @@ impl WriteToUser for bool {
         }
 
         let val = if *self { 1i32 } else { 0i32 };
-        CurrentUserSpace::get().write_val(addr, &val)?;
+        get_current_userspace!().write_val(addr, &val)?;
         Ok(write_len)
     }
 }
@@ -106,7 +107,7 @@ impl WriteToUser for Option<Error> {
             Some(error) => error.error() as i32,
         };
 
-        CurrentUserSpace::get().write_val(addr, &val)?;
+        get_current_userspace!().write_val(addr, &val)?;
         Ok(write_len)
     }
 }
@@ -117,7 +118,7 @@ impl ReadFromUser for LingerOption {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
         }
 
-        let c_linger = CurrentUserSpace::get().read_val::<CLinger>(addr)?;
+        let c_linger = get_current_userspace!().read_val::<CLinger>(addr)?;
 
         Ok(LingerOption::from(c_linger))
     }
@@ -132,7 +133,7 @@ impl WriteToUser for LingerOption {
         }
 
         let linger = CLinger::from(*self);
-        CurrentUserSpace::get().write_val(addr, &linger)?;
+        get_current_userspace!().write_val(addr, &linger)?;
         Ok(write_len)
     }
 }
@@ -140,7 +141,7 @@ impl WriteToUser for LingerOption {
 impl ReadFromUser for CongestionControl {
     fn read_from_user(addr: Vaddr, max_len: u32) -> Result<Self> {
         let mut bytes = vec![0; max_len as usize];
-        CurrentUserSpace::get().read_bytes(addr, &mut VmWriter::from(bytes.as_mut_slice()))?;
+        get_current_userspace!().read_bytes(addr, &mut VmWriter::from(bytes.as_mut_slice()))?;
         let name = String::from_utf8(bytes).unwrap();
         CongestionControl::new(&name)
     }
@@ -155,7 +156,7 @@ impl WriteToUser for CongestionControl {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
         }
 
-        CurrentUserSpace::get().write_bytes(addr, &mut VmReader::from(name))?;
+        get_current_userspace!().write_bytes(addr, &mut VmReader::from(name))?;
 
         Ok(write_len)
     }


### PR DESCRIPTION
This PR optimizes the latency of lat-sig-install from 0.21us to 0.19us(About 9%). The main job is avoiding cloning `VmSpace` when creating `CurrentUserSpace`. 

But this PR actually breaks the abstraction of `CurrentUserSpace`, since after this PR, `CurrentUserSpace` can be built from a not current task. I'm not very sure if this PR is a suitable change.