### PR TITLE
Modify inc_ref_count to satisfy the reference counting invariant

### DIFF
--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -126,8 +126,8 @@ impl<M: PageMeta> Page<M> {
     /// The physical address must represent a valid page and the caller must already hold one
     /// reference count.
     pub(in crate::mm) unsafe fn inc_ref_count(paddr: Paddr) {
-        let page = unsafe { ManuallyDrop::new(Self::from_raw(paddr)) };
-        let _page = page.clone();
+        let vaddr: Vaddr = mapping::page_to_meta::<PagingConsts>(paddr);
+        unsafe{ &(*(vaddr as *const MetaSlot)).ref_count }.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Get the physical address.
@@ -232,8 +232,8 @@ impl DynPage {
     /// The physical address must represent a valid page and the caller must already hold one
     /// reference count.
     pub(in crate::mm) unsafe fn inc_ref_count(paddr: Paddr) {
-        let page = unsafe { ManuallyDrop::new(Self::from_raw(paddr)) };
-        let _page = page.clone();
+        let vaddr: Vaddr = mapping::page_to_meta::<PagingConsts>(paddr);
+        unsafe{ &(*(vaddr as *const MetaSlot)).ref_count }.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Get the physical address of the start of the page


### PR DESCRIPTION
Refactor function `inc_ref_count` for `Page` and `DynPage` to satisfy the invariant that the reference count is always greater than or equal to the number of page owners. Now the function directly increases the reference counter instead of temporarily creating a page handler by 'from_raw'.