### PR TITLE
Optimize semaphore latency

### DIFF
--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -91,9 +91,9 @@ pub struct Semaphore {
     /// - through SEM_UNDO when task exit
     latest_modified_pid: AtomicU32,
     /// Pending alter operations. For each pending operation, it has `sem_op < 0`.
-    pending_alters: Mutex<LinkedList<Box<PendingOp>>>,
+    pending_alters: Mutex<LinkedList<PendingOp>>,
     /// Pending zeros operations. For each pending operation, it has `sem_op = 0`.
-    pending_const: Mutex<LinkedList<Box<PendingOp>>>,
+    pending_const: Mutex<LinkedList<PendingOp>>,
     /// Last semop time.
     sem_otime: AtomicU64,
 }
@@ -210,13 +210,13 @@ impl Semaphore {
         // Add current to pending list
         let (waiter, waker) = Waiter::new_pair();
         let status = Arc::new(AtomicStatus::new(Status::Pending));
-        let pending_op = Box::new(PendingOp {
+        let pending_op = PendingOp {
             sem_buf: *sem_buf,
             status: status.clone(),
             waker: waker.clone(),
             process: ctx.posix_thread.weak_process(),
             pid: current_pid,
-        });
+        };
         if sem_op == 0 {
             self.pending_const.lock().push_back(pending_op);
         } else {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(trait_alias)]
 #![feature(trait_upcasting)]
 #![feature(linked_list_retain)]
+#![feature(linked_list_cursors)]
 #![register_tool(component_access_control)]
 
 use core::sync::atomic::Ordering;

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -57,10 +57,9 @@ fn do_sys_semtimedop(
         return_errno!(Errno::E2BIG);
     }
 
+    let user_space = ctx.get_user_space();
     for i in 0..nsops {
-        let sem_buf =
-            CurrentUserSpace::get().read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?;
-
+        let sem_buf = user_space.read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?;
         sem_op(sem_id, &sem_buf, timeout, ctx)?;
     }
 


### PR DESCRIPTION
This PR introduces several optimizations to the semaphore. The result of `lat_sem` dropped from 0.6420 to 0.5330 and `Linux/Asterinas` increased from 0.516 to 0.621 (Linux: 0.3311 us).