### PR TITLE
Better timestamp in logging

### DIFF
--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -34,7 +34,7 @@ impl log::Log for Logger {
             return;
         }
 
-        let timestamp = format!("[{:>10?}]", Jiffies::elapsed().as_duration().as_secs_f64());
+        let timestamp = format!("[{:>10.3}]", Jiffies::elapsed().as_duration().as_secs_f64());
         let level = format!("{:<5}", record.level());
         let record_str = format!("{}", record.args());
 


### PR DESCRIPTION
Use `{:>10.3}` instead of `{:>10?}` for the timestamps in console logging, so that the logging can be something like
```
[     3.259] TRACE: [Trap][PAGE_FAULT][page fault addr = 0x46d262, err = 20]
[     3.260] TRACE: page fault error code: 0x14, Page fault address: 0x46d262
[     3.260] INFO : [pid=8][tid=8][id=257][SYS_OPENAT]
[     3.261] DEBUG: dirfd = -100, path = "//.profile", flags = 524288, mode = 0
[     3.261] DEBUG: syscall return error: Error { errno: ENOENT, msg: None }
[     3.262] TRACE: [Trap][PAGE_FAULT][page fault addr = 0x264240, err = 20]
[     3.262] TRACE: page fault error code: 0x14, Page fault address: 0x264240
```
instead of something misaligned like `7.4879999999999995` and `7.49`:
```
[     7.487] INFO : [pid=11][tid=11][id=9][SYS_MMAP]
[     7.487] DEBUG: addr = 0x26c000000000, len = 0x4000000, perms = (empty), option = MMapOptions { typ: Private, flags: MAP_ANONYMOUS }, fd = -1, offset = 0x0
[7.4879999999999995] TRACE: allocate free region, map_size = 0x4000000, offset = None, align = 0x1000, can_overwrite = false
[     7.489] TRACE: build mapping, map_range = 0xa84e000- 0xe84e000
[     7.489] INFO : [pid=11][tid=11][id=11][SYS_MUNMAP]
[      7.49] DEBUG: addr = 0xa84e000, len = 67108864
[      7.49] DEBUG: unmap range = 0xa84e000 - 0xe84e000
[     7.491] INFO : [pid=11][tid=11][id=9][SYS_MMAP]
```