### PR TITLE
Fix panic in `mmap` by invalid `perms`

### DIFF
--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -24,7 +24,7 @@ pub fn sys_mmap(
     offset: u64,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let perms = VmPerms::from_posix_prot_bits(perms as u32).unwrap();
+    let perms = VmPerms::from_bits_truncate(perms as u32);
     let option = MMapOptions::try_from(flags as u32)?;
     let res = do_sys_mmap(
         addr as usize,

--- a/kernel/src/vm/perms.rs
+++ b/kernel/src/vm/perms.rs
@@ -16,12 +16,6 @@ bitflags! {
     }
 }
 
-impl VmPerms {
-    pub fn from_posix_prot_bits(bits: u32) -> Option<Self> {
-        VmPerms::from_bits(bits)
-    }
-}
-
 impl From<Rights> for VmPerms {
     fn from(rights: Rights) -> VmPerms {
         let mut vm_perm = VmPerms::empty();


### PR DESCRIPTION
Fix #1203

Asterinas shall not panic or report error when receive invalid `perms` of `mmap` syscall.

Taking the test program as an example:
```C
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <sys/mman.h>
#include <sys/wait.h>

int main(void)
{
  int fd = open("/bin/ls", O_RDWR);
  void *addr = mmap(NULL, 1, 0x4, 0x1, fd, 0);
  perror("mmap");
  printf("Memory mapped at address %p\n", addr);
  addr = mmap(NULL, 1, 0, 0x1, fd, 0);
  perror("mmap");
  printf("Memory mapped at address %p\n", addr);
  addr = mmap(NULL, 0xffffffffffffff00, 0x3, 0x1, fd, 0);
  perror("mmap");
  printf("Memory mapped at address %p\n", addr);

  return 0;
}
```

In Linux, the result is:
```
mmap: Success
Memory mapped at address 0x7fbf7bf00000
mmap: Success
Memory mapped at address 0x7fbf7beff000
mmap: Cannot allocate memory
Memory mapped at address 0xffffffffffffffff
```

Even the second `mmap` is fed with a invalid `perms` value `0`, it still allocate a memory region.