### PR TITLE
Make the epoll implementation correct and consistent with Linux

### DIFF
--- a/kernel/libs/keyable-arc/src/lib.rs
+++ b/kernel/libs/keyable-arc/src/lib.rs
@@ -315,6 +315,12 @@ impl<T: ?Sized> From<KeyableWeak<T>> for Weak<T> {
     }
 }
 
+impl<T: ?Sized> Clone for KeyableWeak<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T: ?Sized + fmt::Debug> fmt::Debug for KeyableWeak<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(KeyableWeak)")

--- a/test/apps/epoll/epoll_err.c
+++ b/test/apps/epoll/epoll_err.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../network/test.h"
+#include <unistd.h>
+#include <sys/epoll.h>
+
+FN_TEST(epoll_add_del)
+{
+	int fildes[2];
+	int epfd, rfd, wfd, rfd2;
+	struct epoll_event ev;
+
+	// Setup pipes
+	TEST_SUCC(pipe(fildes));
+	rfd = fildes[0];
+	wfd = fildes[1];
+	TEST_SUCC(write(wfd, "", 1));
+
+	// Setup epoll
+	epfd = TEST_SUCC(epoll_create1(0));
+	ev.events = EPOLLIN;
+	ev.data.fd = rfd;
+	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_ADD, rfd, &ev));
+
+	// Dup and close
+	rfd2 = dup(rfd);
+	close(rfd);
+
+	// No way to operate on closed file descriptors
+	TEST_RES(epoll_wait(epfd, &ev, 1, 0), _ret == 1 && ev.data.fd == rfd);
+	TEST_ERRNO(epoll_ctl(epfd, EPOLL_CTL_DEL, rfd, NULL), EBADF);
+	TEST_ERRNO(epoll_ctl(epfd, EPOLL_CTL_DEL, rfd2, NULL), ENOENT);
+
+	// Old file descriptor and new file
+	TEST_RES(pipe(fildes), fildes[0] == rfd);
+	TEST_ERRNO(epoll_ctl(epfd, EPOLL_CTL_DEL, rfd, NULL), ENOENT);
+	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_ADD, rfd, &ev));
+	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_DEL, rfd, NULL));
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+
+	// Old file descriptor and old file
+	TEST_RES(dup(rfd2), _ret == rfd);
+	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_DEL, rfd, NULL));
+
+	// Clean up
+	TEST_SUCC(close(epfd));
+	TEST_SUCC(close(rfd));
+	TEST_SUCC(close(wfd));
+	TEST_SUCC(close(rfd2));
+}
+END_TEST()

--- a/test/apps/scripts/fs.sh
+++ b/test/apps/scripts/fs.sh
@@ -62,3 +62,4 @@ test_fdatasync
 echo "All fdatasync test passed."
 
 pipe/pipe_err
+epoll/epoll_err


### PR DESCRIPTION
So far, we use the file descriptor as the key in the epoll implementation. Unfortunately, this forces us to listen to the file descriptor events, which is hard to do correctly (consider that if we fork a process and close the file descriptor in the new process, this will mess up the epoll file shared with the old process). Also, this behavior is inconsistent with the Linux kernel.

According to the [Linux man pages](https://man7.org/linux/man-pages/man7/epoll.7.html):
>       •  Will closing a file descriptor cause it to be removed from all
>          epoll interest lists?
>
>          Yes, but be aware of the following point.  A file descriptor
>          is a reference to an open file description (see open(2)).
>          Whenever a file descriptor is duplicated via dup(2), dup2(2),
>          fcntl(2) F_DUPFD, or fork(2), a new file descriptor referring
>          to the same open file description is created.  An open file
>          description continues to exist until all file descriptors
>          referring to it have been closed.
>
>          A file descriptor is removed from an interest list only after
>          all the file descriptors referring to the underlying open file
>          description have been closed.  This means that even after a
>          file descriptor that is part of an interest list has been
>          closed, events may be reported for that file descriptor if
>          other file descriptors referring to the same underlying file
>          description remain open.  To prevent this happening, the file
>          descriptor must be explicitly removed from the interest list
>          (using epoll_ctl(2) EPOLL_CTL_DEL) before it is duplicated.
>          Alternatively, the application must ensure that all file
>          descriptors are closed (which may be difficult if file
>          descriptors were duplicated behind the scenes by library
>          functions that used dup(2) or fork(2)).

According to the [Linux implementation](https://github.com/torvalds/linux/blob/c9f016e72b5cc7d4d68fac51f8e72c8c7a69c06e/fs/eventpoll.c#L357):
```c
/* Compare RB tree keys */
static inline int ep_cmp_ffd(struct epoll_filefd *p1,
			     struct epoll_filefd *p2)
{
	return (p1->file > p2->file ? +1:
	        (p1->file < p2->file ? -1 : p1->fd - p2->fd));
}
```

So we should use a tuple of the file descriptor and the file itself as the key in the epoll implementation.

This PR first cleans up some code (which should not affect the behavior) in the first four commits, then fixes some buggy behavior (including the one mentioned above) in the following two commits, and also adds regression testing.