### PR TITLE
Fix I/O events, error codes, and blocking behavior in UNIX sockets

### DIFF
--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -59,15 +59,11 @@ pub struct Consumer<T>(Fifo<T, ReadOp>);
 macro_rules! impl_common_methods_for_channel {
     () => {
         pub fn shutdown(&self) {
-            self.this_end().shutdown()
+            self.0.common.shutdown()
         }
 
         pub fn is_shutdown(&self) -> bool {
-            self.this_end().is_shutdown()
-        }
-
-        pub fn is_peer_shutdown(&self) -> bool {
-            self.peer_end().is_shutdown()
+            self.0.common.is_shutdown()
         }
 
         pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
@@ -109,7 +105,7 @@ impl<T> Producer<T> {
 
         let this_end = self.this_end();
         let rb = this_end.rb();
-        if self.is_shutdown() || self.is_peer_shutdown() {
+        if self.is_shutdown() {
             // The POLLOUT event is always set in this case. Don't try to remove it.
         } else if rb.is_full() {
             this_end.pollee.del_events(IoEvents::OUT);
@@ -139,7 +135,7 @@ impl Producer<u8> {
             return Ok(0);
         }
 
-        if self.is_shutdown() || self.is_peer_shutdown() {
+        if self.is_shutdown() {
             return_errno_with_message!(Errno::EPIPE, "the channel is shut down");
         }
 
@@ -161,7 +157,7 @@ impl<T: Pod> Producer<T> {
     /// - Returns `Err(EPIPE)` if the channel is shut down.
     /// - Returns `Err(EAGAIN)` if the channel is full.
     pub fn try_push(&self, item: T) -> core::result::Result<(), (Error, T)> {
-        if self.is_shutdown() || self.is_peer_shutdown() {
+        if self.is_shutdown() {
             let err = Error::with_message(Errno::EPIPE, "the channel is shut down");
             return Err((err, item));
         }
@@ -179,11 +175,6 @@ impl<T: Pod> Producer<T> {
 impl<T> Drop for Producer<T> {
     fn drop(&mut self) {
         self.shutdown();
-
-        // The POLLHUP event indicates that the write end is shut down.
-        //
-        // No need to take a lock. There is no race because no one is modifying this particular event.
-        self.peer_end().pollee.add_events(IoEvents::HUP);
     }
 }
 
@@ -232,7 +223,7 @@ impl Consumer<u8> {
         }
 
         // This must be recorded before the actual operation to avoid race conditions.
-        let is_shutdown = self.is_shutdown() || self.is_peer_shutdown();
+        let is_shutdown = self.is_shutdown();
 
         let read_len = self.0.read(writer);
         self.update_pollee();
@@ -255,7 +246,7 @@ impl<T: Pod> Consumer<T> {
     /// - Returns `Err(EAGAIN)` if the channel is empty.
     pub fn try_pop(&self) -> Result<Option<T>> {
         // This must be recorded before the actual operation to avoid race conditions.
-        let is_shutdown = self.is_shutdown() || self.is_peer_shutdown();
+        let is_shutdown = self.is_shutdown();
 
         let item = self.0.pop();
         self.update_pollee();
@@ -273,15 +264,6 @@ impl<T: Pod> Consumer<T> {
 impl<T> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.shutdown();
-
-        // The POLLERR event indicates that the read end is closed (so any subsequent writes will
-        // fail with an `EPIPE` error).
-        //
-        // The lock is taken because we are also adding the POLLOUT event, which may have races
-        // with the event updates triggered by the writer.
-        let peer_end = self.peer_end();
-        let _rb = peer_end.rb();
-        peer_end.pollee.add_events(IoEvents::ERR | IoEvents::OUT);
     }
 }
 
@@ -346,6 +328,7 @@ impl<T: Pod, R: TRights> Fifo<T, R> {
 struct Common<T> {
     producer: FifoInner<RbProducer<T>>,
     consumer: FifoInner<RbConsumer<T>>,
+    is_shutdown: AtomicBool,
 }
 
 impl<T> Common<T> {
@@ -356,18 +339,46 @@ impl<T> Common<T> {
         let producer = FifoInner::new(rb_producer, IoEvents::OUT);
         let consumer = FifoInner::new(rb_consumer, IoEvents::empty());
 
-        Self { producer, consumer }
+        Self {
+            producer,
+            consumer,
+            is_shutdown: AtomicBool::new(false),
+        }
     }
 
     pub fn capacity(&self) -> usize {
         self.producer.rb().capacity()
+    }
+
+    pub fn is_shutdown(&self) -> bool {
+        self.is_shutdown.load(Ordering::Relaxed)
+    }
+
+    pub fn shutdown(&self) {
+        if self.is_shutdown.swap(true, Ordering::Relaxed) {
+            return;
+        }
+
+        // The POLLHUP event indicates that the write end is shut down.
+        //
+        // No need to take a lock. There is no race because no one is modifying this particular event.
+        self.consumer.pollee.add_events(IoEvents::HUP);
+
+        // The POLLERR event indicates that the read end is shut down (so any subsequent writes
+        // will fail with an `EPIPE` error).
+        //
+        // The lock is taken because we are also adding the POLLOUT event, which may have races
+        // with the event updates triggered by the writer.
+        let _rb = self.producer.rb();
+        self.producer
+            .pollee
+            .add_events(IoEvents::ERR | IoEvents::OUT);
     }
 }
 
 struct FifoInner<T> {
     rb: Mutex<T>,
     pollee: Pollee,
-    is_shutdown: AtomicBool,
 }
 
 impl<T> FifoInner<T> {
@@ -375,20 +386,11 @@ impl<T> FifoInner<T> {
         Self {
             rb: Mutex::new(rb),
             pollee: Pollee::new(init_events),
-            is_shutdown: AtomicBool::new(false),
         }
     }
 
     pub fn rb(&self) -> MutexGuard<T> {
         self.rb.lock()
-    }
-
-    pub fn is_shutdown(&self) -> bool {
-        self.is_shutdown.load(Ordering::Acquire)
-    }
-
-    pub fn shutdown(&self) {
-        self.is_shutdown.store(true, Ordering::Release)
     }
 }
 

--- a/kernel/src/net/socket/unix/addr.rs
+++ b/kernel/src/net/socket/unix/addr.rs
@@ -30,6 +30,14 @@ impl UnixSocketAddr {
         Ok(bound)
     }
 
+    pub(super) fn bind_unnamed(&self) -> Result<()> {
+        if matches!(self, UnixSocketAddr::Unnamed) {
+            Ok(())
+        } else {
+            return_errno_with_message!(Errno::EINVAL, "the socket is already bound");
+        }
+    }
+
     pub(super) fn connect(&self) -> Result<UnixSocketAddrKey> {
         let bound = match self {
             Self::Unnamed => return_errno_with_message!(

--- a/kernel/src/net/socket/unix/addr.rs
+++ b/kernel/src/net/socket/unix/addr.rs
@@ -54,7 +54,10 @@ impl TryFrom<SocketAddr> for UnixSocketAddr {
     fn try_from(value: SocketAddr) -> Result<Self> {
         match value {
             SocketAddr::Unix(unix_socket_addr) => Ok(unix_socket_addr),
-            _ => return_errno_with_message!(Errno::EINVAL, "Invalid unix socket addr"),
+            _ => return_errno_with_message!(
+                Errno::EINVAL,
+                "the socket address is not a valid UNIX domain socket address"
+            ),
         }
     }
 }

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -1,16 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::ops::Deref;
+
+use ostd::sync::PreemptDisabled;
+
 use crate::{
     events::{IoEvents, Observer},
     fs::utils::{Channel, Consumer, Producer},
-    net::socket::{unix::addr::UnixSocketAddrBound, SockShutdownCmd},
+    net::socket::{
+        unix::{addr::UnixSocketAddrBound, UnixSocketAddr},
+        SockShutdownCmd,
+    },
     prelude::*,
     process::signal::{Pollee, Poller},
 };
 
 pub(super) struct Connected {
-    addr: Option<UnixSocketAddrBound>,
-    peer_addr: Option<UnixSocketAddrBound>,
+    addr: AddrView,
     reader: Consumer<u8>,
     writer: Producer<u8>,
 }
@@ -27,15 +33,15 @@ impl Connected {
         let (writer_this, reader_peer) =
             Channel::with_capacity_and_pollees(DEFAULT_BUF_SIZE, writer_pollee, None).split();
 
+        let (addr_this, addr_peer) = AddrView::new_pair(addr, peer_addr);
+
         let this = Connected {
-            addr: addr.clone(),
-            peer_addr: peer_addr.clone(),
+            addr: addr_this,
             reader: reader_this,
             writer: writer_this,
         };
         let peer = Connected {
-            addr: peer_addr,
-            peer_addr: addr,
+            addr: addr_peer,
             reader: reader_peer,
             writer: writer_peer,
         };
@@ -43,12 +49,25 @@ impl Connected {
         (this, peer)
     }
 
-    pub(super) fn addr(&self) -> Option<&UnixSocketAddrBound> {
-        self.addr.as_ref()
+    pub(super) fn addr(&self) -> Option<UnixSocketAddrBound> {
+        self.addr.addr().deref().as_ref().cloned()
     }
 
-    pub(super) fn peer_addr(&self) -> Option<&UnixSocketAddrBound> {
-        self.peer_addr.as_ref()
+    pub(super) fn peer_addr(&self) -> Option<UnixSocketAddrBound> {
+        self.addr.peer_addr()
+    }
+
+    pub(super) fn bind(&self, addr_to_bind: UnixSocketAddr) -> Result<()> {
+        let mut addr = self.addr.addr();
+
+        if addr.is_some() {
+            return addr_to_bind.bind_unnamed();
+        }
+
+        let bound_addr = addr_to_bind.bind()?;
+        *addr = Some(bound_addr);
+
+        Ok(())
     }
 
     pub(super) fn try_read(&self, buf: &mut [u8]) -> Result<usize> {
@@ -121,6 +140,40 @@ pub(super) fn combine_io_events(
     events |= (reader_events & IoEvents::IN) | (writer_events & IoEvents::OUT);
 
     events & (mask | IoEvents::ALWAYS_POLL)
+}
+
+struct AddrView {
+    addr: Arc<SpinLock<Option<UnixSocketAddrBound>>>,
+    peer: Arc<SpinLock<Option<UnixSocketAddrBound>>>,
+}
+
+impl AddrView {
+    fn new_pair(
+        first: Option<UnixSocketAddrBound>,
+        second: Option<UnixSocketAddrBound>,
+    ) -> (AddrView, AddrView) {
+        let first = Arc::new(SpinLock::new(first));
+        let second = Arc::new(SpinLock::new(second));
+
+        let view1 = AddrView {
+            addr: first.clone(),
+            peer: second.clone(),
+        };
+        let view2 = AddrView {
+            addr: second,
+            peer: first,
+        };
+
+        (view1, view2)
+    }
+
+    fn addr(&self) -> SpinLockGuard<Option<UnixSocketAddrBound>, PreemptDisabled> {
+        self.addr.lock()
+    }
+
+    fn peer_addr(&self) -> Option<UnixSocketAddrBound> {
+        self.peer.lock().as_ref().cloned()
+    }
 }
 
 const DEFAULT_BUF_SIZE: usize = 65536;

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -5,7 +5,7 @@ use crate::{
     fs::utils::{Channel, Consumer, Producer},
     net::socket::{unix::addr::UnixSocketAddrBound, SockShutdownCmd},
     prelude::*,
-    process::signal::Poller,
+    process::signal::{Pollee, Poller},
 };
 
 pub(super) struct Connected {
@@ -19,9 +19,13 @@ impl Connected {
     pub(super) fn new_pair(
         addr: Option<UnixSocketAddrBound>,
         peer_addr: Option<UnixSocketAddrBound>,
+        reader_pollee: Option<Pollee>,
+        writer_pollee: Option<Pollee>,
     ) -> (Connected, Connected) {
-        let (writer_this, reader_peer) = Channel::with_capacity(DEFAULT_BUF_SIZE).split();
-        let (writer_peer, reader_this) = Channel::with_capacity(DEFAULT_BUF_SIZE).split();
+        let (writer_peer, reader_this) =
+            Channel::with_capacity_and_pollees(DEFAULT_BUF_SIZE, None, reader_pollee).split();
+        let (writer_this, reader_peer) =
+            Channel::with_capacity_and_pollees(DEFAULT_BUF_SIZE, writer_pollee, None).split();
 
         let this = Connected {
             addr: addr.clone(),

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -37,7 +37,7 @@ impl Init {
 
     pub(super) fn bind(&mut self, addr_to_bind: UnixSocketAddr) -> Result<()> {
         if self.addr.is_some() {
-            return_errno_with_message!(Errno::EINVAL, "the socket is already bound");
+            return addr_to_bind.bind_unnamed();
         }
 
         let bound_addr = addr_to_bind.bind()?;

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{connected::Connected, listener::Listener};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use super::{
+    connected::{combine_io_events, Connected},
+    listener::Listener,
+};
 use crate::{
     events::{IoEvents, Observer},
-    net::socket::unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
+    net::socket::{
+        unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
+        SockShutdownCmd,
+    },
     prelude::*,
     process::signal::{Pollee, Poller},
 };
@@ -12,6 +20,8 @@ pub(super) struct Init {
     addr: Option<UnixSocketAddrBound>,
     reader_pollee: Pollee,
     writer_pollee: Pollee,
+    is_read_shutdown: AtomicBool,
+    is_write_shutdown: AtomicBool,
 }
 
 impl Init {
@@ -19,7 +29,9 @@ impl Init {
         Self {
             addr: None,
             reader_pollee: Pollee::new(IoEvents::empty()),
-            writer_pollee: Pollee::new(IoEvents::empty()),
+            writer_pollee: Pollee::new(IoEvents::OUT),
+            is_read_shutdown: AtomicBool::new(false),
+            is_write_shutdown: AtomicBool::new(false),
         }
     }
 
@@ -39,14 +51,26 @@ impl Init {
             addr,
             reader_pollee,
             writer_pollee,
+            is_read_shutdown,
+            is_write_shutdown,
         } = self;
 
-        Connected::new_pair(
+        let (this_conn, peer_conn) = Connected::new_pair(
             addr,
             Some(peer_addr),
             Some(reader_pollee),
             Some(writer_pollee),
-        )
+        );
+
+        if is_read_shutdown.into_inner() {
+            this_conn.shutdown(SockShutdownCmd::SHUT_RD);
+        }
+
+        if is_write_shutdown.into_inner() {
+            this_conn.shutdown(SockShutdownCmd::SHUT_WR)
+        }
+
+        (this_conn, peer_conn)
     }
 
     pub(super) fn listen(self, backlog: usize) -> core::result::Result<Listener, (Error, Self)> {
@@ -57,8 +81,31 @@ impl Init {
             ));
         };
 
-        // There is no `writer_pollee` in `Listener`.
-        Ok(Listener::new(addr, self.reader_pollee, backlog))
+        Ok(Listener::new(
+            addr,
+            self.reader_pollee,
+            self.writer_pollee,
+            backlog,
+            self.is_read_shutdown.into_inner(),
+        ))
+    }
+
+    pub(super) fn shutdown(&self, cmd: SockShutdownCmd) {
+        match cmd {
+            SockShutdownCmd::SHUT_WR | SockShutdownCmd::SHUT_RDWR => {
+                self.is_write_shutdown.store(true, Ordering::Relaxed);
+                self.writer_pollee.add_events(IoEvents::ERR);
+            }
+            SockShutdownCmd::SHUT_RD => (),
+        }
+
+        match cmd {
+            SockShutdownCmd::SHUT_RD | SockShutdownCmd::SHUT_RDWR => {
+                self.is_read_shutdown.store(true, Ordering::Relaxed);
+                self.reader_pollee.add_events(IoEvents::HUP);
+            }
+            SockShutdownCmd::SHUT_WR => (),
+        }
     }
 
     pub(super) fn addr(&self) -> Option<&UnixSocketAddrBound> {
@@ -68,10 +115,12 @@ impl Init {
     pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
         // To avoid loss of events, this must be compatible with
         // `Connected::poll`/`Listener::poll`.
-        self.reader_pollee.poll(mask, poller.as_deref_mut());
-        self.writer_pollee.poll(mask, poller);
+        let reader_events = self.reader_pollee.poll(mask, poller.as_deref_mut());
+        let writer_events = self.writer_pollee.poll(mask, poller);
 
-        (IoEvents::OUT | IoEvents::HUP) & (mask | IoEvents::ALWAYS_POLL)
+        // According to the Linux implementation, we always have `IoEvents::HUP` in this state.
+        // Meanwhile, it is in `IoEvents::ALWAYS_POLL`, so we always return it.
+        combine_io_events(mask, reader_events, writer_events) | IoEvents::HUP
     }
 
     pub(super) fn register_observer(

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use super::{connected::Connected, listener::Listener};
 use crate::{
     events::{IoEvents, Observer},
     net::socket::unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
@@ -9,14 +10,16 @@ use crate::{
 
 pub(super) struct Init {
     addr: Option<UnixSocketAddrBound>,
-    pollee: Pollee,
+    reader_pollee: Pollee,
+    writer_pollee: Pollee,
 }
 
 impl Init {
     pub(super) fn new() -> Self {
         Self {
             addr: None,
-            pollee: Pollee::new(IoEvents::empty()),
+            reader_pollee: Pollee::new(IoEvents::empty()),
+            writer_pollee: Pollee::new(IoEvents::empty()),
         }
     }
 
@@ -31,12 +34,44 @@ impl Init {
         Ok(())
     }
 
+    pub(super) fn into_connected(self, peer_addr: UnixSocketAddrBound) -> (Connected, Connected) {
+        let Init {
+            addr,
+            reader_pollee,
+            writer_pollee,
+        } = self;
+
+        Connected::new_pair(
+            addr,
+            Some(peer_addr),
+            Some(reader_pollee),
+            Some(writer_pollee),
+        )
+    }
+
+    pub(super) fn listen(self, backlog: usize) -> core::result::Result<Listener, (Error, Self)> {
+        let Some(addr) = self.addr else {
+            return Err((
+                Error::with_message(Errno::EINVAL, "the socket is not bound"),
+                self,
+            ));
+        };
+
+        // There is no `writer_pollee` in `Listener`.
+        Ok(Listener::new(addr, self.reader_pollee, backlog))
+    }
+
     pub(super) fn addr(&self) -> Option<&UnixSocketAddrBound> {
         self.addr.as_ref()
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        self.pollee.poll(mask, poller)
+    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+        // To avoid loss of events, this must be compatible with
+        // `Connected::poll`/`Listener::poll`.
+        self.reader_pollee.poll(mask, poller.as_deref_mut());
+        self.writer_pollee.poll(mask, poller);
+
+        (IoEvents::OUT | IoEvents::HUP) & (mask | IoEvents::ALWAYS_POLL)
     }
 
     pub(super) fn register_observer(
@@ -44,7 +79,10 @@ impl Init {
         observer: Weak<dyn Observer<IoEvents>>,
         mask: IoEvents,
     ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
+        // To avoid loss of events, this must be compatible with
+        // `Connected::poll`/`Listener::poll`.
+        self.reader_pollee.register_observer(observer.clone(), mask);
+        self.writer_pollee.register_observer(observer, mask);
         Ok(())
     }
 
@@ -52,6 +90,8 @@ impl Init {
         &self,
         observer: &Weak<dyn Observer<IoEvents>>,
     ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
+        let reader_observer = self.reader_pollee.unregister_observer(observer);
+        let writer_observer = self.writer_pollee.unregister_observer(observer);
+        reader_observer.or(writer_observer)
     }
 }

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -50,7 +50,7 @@ impl Listener {
 
     pub(super) fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         let connected = self.backlog.pop_incoming()?;
-        let peer_addr = connected.peer_addr().cloned().into();
+        let peer_addr = connected.peer_addr().into();
 
         let socket = UnixStreamSocket::new_connected(connected, false);
         Ok((socket, peer_addr))

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -297,9 +297,12 @@ impl Socket for UnixStreamSocket {
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
         match self.state.read().as_ref() {
+            State::Init(init) => init.shutdown(cmd),
+            State::Listen(listen) => listen.shutdown(cmd),
             State::Connected(connected) => connected.shutdown(cmd),
-            _ => return_errno_with_message!(Errno::ENOTCONN, "the socked is not connected"),
         }
+
+        Ok(())
     }
 
     fn addr(&self) -> Result<SocketAddr> {

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -13,7 +13,6 @@ use crate::{
 
 /// A pollee maintains a set of active events, which can be polled with
 /// pollers or be monitored with observers.
-#[derive(Clone)]
 pub struct Pollee {
     inner: Arc<PolleeInner>,
 }

--- a/test/apps/network/unix_err.c
+++ b/test/apps/network/unix_err.c
@@ -247,6 +247,42 @@ FN_TEST(listen)
 }
 END_TEST()
 
+FN_TEST(accept)
+{
+	TEST_ERRNO(accept(sk_unbound, NULL, NULL), EINVAL);
+
+	TEST_ERRNO(accept(sk_bound, NULL, NULL), EINVAL);
+
+	TEST_ERRNO(accept(sk_connected, NULL, NULL), EINVAL);
+
+	TEST_ERRNO(accept(sk_accepted, NULL, NULL), EINVAL);
+}
+END_TEST()
+
+FN_TEST(send)
+{
+	char buf[1] = { 'z' };
+
+	TEST_ERRNO(send(sk_unbound, buf, 1, 0), ENOTCONN);
+
+	TEST_ERRNO(send(sk_bound, buf, 1, 0), ENOTCONN);
+
+	TEST_ERRNO(send(sk_listen, buf, 1, 0), ENOTCONN);
+}
+END_TEST()
+
+FN_TEST(recv)
+{
+	char buf[1] = { 'z' };
+
+	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), EINVAL);
+
+	TEST_ERRNO(recv(sk_bound, buf, 1, 0), EINVAL);
+
+	TEST_ERRNO(recv(sk_listen, buf, 1, 0), EINVAL);
+}
+END_TEST()
+
 FN_TEST(ns_path)
 {
 	int fd;


### PR DESCRIPTION
OK, this should be the last PR aimed at fixing the "correctness" of UNIX sockets. Hopefully the PR is not too big. All fixed behavior has corresponding regression tests, so it should not be hard to understand.

The trickiest one is that previously different states in a UNIX socket can use different `Pollee`s to maintain I/O events. This is pretty wired, and I don't think it makes sense (for example, if someone uses `poll`/`register_observer` in one state, it won't be notified after the socket switches to another state, which is really buggy).
 - After this PR, since the `Connected` states use two `Pollee`s for the two communication directions, I have to use two polls in the remaining two states (`Init`, `Listen`). This is not perfect, but hopefully it's at least correct.
 - See the second commit "Fix I/O events cross different states" for more details.