### PR TITLE
Remove the `Makefile` dependency of `run` on phony `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ tools:
 	@cd kernel/libs/comp-sys && cargo install --path cargo-component
 
 .PHONY: run
-run: build
+run: initramfs $(CARGO_OSDK)
 	@cargo osdk run $(CARGO_OSDK_ARGS)
 # Check the running status of auto tests from the QEMU log
 ifeq ($(AUTO_TEST), syscall)


### PR DESCRIPTION
The `build` target is `.PHONY`, so every time `make run` is called, `cargo osdk build` will be called first. There's no need to do so since both Cargo and OSDK have build cache policies. The extra call brings latency and confusion.