### PR TITLE
Fix index out of bound when `key` of `semget` too large

### DIFF
--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -235,6 +235,9 @@ pub fn create_sem_set_with_id(
 ) -> Result<()> {
     debug_assert!(nsems <= SEMMSL);
     debug_assert!(id > 0);
+    if id as usize > SEMMNI {
+        return_errno_with_message!(Errno::ENOENT, "id larger than SEMMNI");
+    }
 
     ID_ALLOCATOR
         .get()


### PR DESCRIPTION
Fix #1201 

Error code refers to https://elixir.bootlin.com/linux/v6.10.5/source/ipc/util.c#L413