### PR TITLE
Use IoVec-based reader&writer to refactor all network APIs

### DIFF
--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -124,10 +124,7 @@ impl FileIo for PtyMaster {
                 continue;
             }
 
-            let read_len = match input.read_fallible(writer) {
-                Ok(len) => len,
-                Err((_, len)) => len,
-            };
+            let read_len = input.read_fallible(writer)?;
             self.update_state(&input);
             return Ok(read_len);
         }

--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -155,7 +155,7 @@ impl Producer<u8> {
             return_errno_with_message!(Errno::EPIPE, "the channel is shut down");
         }
 
-        let written_len = self.0.write(reader);
+        let written_len = self.0.write(reader)?;
         self.update_pollee();
 
         if written_len > 0 {
@@ -241,7 +241,7 @@ impl Consumer<u8> {
         // This must be recorded before the actual operation to avoid race conditions.
         let is_shutdown = self.is_shutdown();
 
-        let read_len = self.0.read(writer);
+        let read_len = self.0.read(writer)?;
         self.update_pollee();
 
         if read_len > 0 {
@@ -301,25 +301,13 @@ impl<R: TRights> Fifo<u8, R> {
     #[require(R > Read)]
     pub fn read(&self, writer: &mut dyn MultiWrite) -> Result<usize> {
         let mut rb = self.common.consumer.rb();
-        match rb.read_fallible(writer) {
-            Ok(len) => len,
-            Err(e) => {
-                error!("memory read failed on the ring buffer, error: {e:?}");
-                0
-            }
-        }
+        rb.read_fallible(writer)
     }
 
     #[require(R > Write)]
     pub fn write(&self, reader: &mut dyn MultiRead) -> Result<usize> {
         let mut rb = self.common.producer.rb();
-        match rb.write_fallible(reader) {
-            Ok(len) => len,
-            Err(e) => {
-                error!("memory write failed on the ring buffer, error: {e:?}");
-                0
-            }
-        }
+        rb.write_fallible(reader)
     }
 }
 

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -11,6 +11,7 @@ use crate::{
     net::{iface::AnyBoundSocket, socket::util::send_recv_flags::SendRecvFlags},
     prelude::*,
     process::signal::Pollee,
+    util::{MultiRead, MultiWrite},
 };
 
 pub struct BoundDatagram {
@@ -38,43 +39,63 @@ impl BoundDatagram {
         self.remote_endpoint = Some(*endpoint)
     }
 
-    pub fn try_recv(&self, buf: &mut [u8], _flags: SendRecvFlags) -> Result<(usize, IpEndpoint)> {
-        let result = self
-            .bound_socket
-            .raw_with(|socket: &mut RawUdpSocket| socket.recv_slice(buf));
+    pub fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        _flags: SendRecvFlags,
+    ) -> Result<(usize, IpEndpoint)> {
+        let result = self.bound_socket.raw_with(|socket: &mut RawUdpSocket| {
+            socket.recv().map(|(packet, udp_metadata)| {
+                let copied_res = writer.write(&mut VmReader::from(packet));
+                let endpoint = udp_metadata.endpoint;
+                (copied_res, endpoint)
+            })
+        });
+
         match result {
-            Ok((recv_len, udp_metadata)) => Ok((recv_len, udp_metadata.endpoint)),
+            Ok((Ok(res), endpoint)) => Ok((res, endpoint)),
+            Ok((Err(e), _)) => Err(e),
             Err(RecvError::Exhausted) => {
                 return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
             }
             Err(RecvError::Truncated) => {
-                todo!();
+                unreachable!("`Socket::recv` should never fail with `RecvError::Truncated`")
             }
         }
     }
 
     pub fn try_send(
         &self,
-        buf: &[u8],
+        reader: &mut dyn MultiRead,
         remote: &IpEndpoint,
         _flags: SendRecvFlags,
     ) -> Result<usize> {
-        let result = self.bound_socket.raw_with(|socket: &mut RawUdpSocket| {
-            if socket.payload_send_capacity() < buf.len() {
-                return None;
+        let reader_len = reader.sum_lens();
+
+        self.bound_socket.raw_with(|socket: &mut RawUdpSocket| {
+            if socket.payload_send_capacity() < reader_len {
+                return_errno_with_message!(Errno::EMSGSIZE, "the message is too large");
             }
-            Some(socket.send_slice(buf, *remote))
-        });
-        match result {
-            Some(Ok(())) => Ok(buf.len()),
-            Some(Err(SendError::BufferFull)) => {
-                return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
-            }
-            Some(Err(SendError::Unaddressable)) => {
-                return_errno_with_message!(Errno::EINVAL, "the destination address is invalid")
-            }
-            None => return_errno_with_message!(Errno::EMSGSIZE, "the message is too large"),
-        }
+
+            let socket_buffer = match socket.send(reader_len, *remote) {
+                Ok(socket_buffer) => socket_buffer,
+                Err(SendError::BufferFull) => {
+                    return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
+                }
+                Err(SendError::Unaddressable) => {
+                    return_errno_with_message!(Errno::EINVAL, "the destination address is invalid")
+                }
+            };
+
+            // FIXME: If copy failed, we should not send any packet.
+            // But current smoltcp API seems not to support this behavior.
+            reader
+                .read(&mut VmWriter::from(socket_buffer))
+                .map_err(|e| {
+                    warn!("unexpected UDP packet will be sent");
+                    e
+                })
+        })
     }
 
     pub(super) fn init_pollee(&self, pollee: &Pollee) {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -21,7 +21,6 @@ use crate::{
         socket::{
             options::{Error as SocketError, SocketOption},
             util::{
-                copy_message_from_user, copy_message_to_user, create_message_buffer,
                 options::SocketOptionSet, send_recv_flags::SendRecvFlags,
                 shutdown_cmd::SockShutdownCmd, socket_addr::SocketAddr, MessageHeader,
             },
@@ -30,7 +29,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{Pollable, Pollee, Poller},
-    util::IoVec,
+    util::{MultiRead, MultiWrite},
 };
 
 mod connected;
@@ -245,7 +244,11 @@ impl StreamSocket {
         accepted
     }
 
-    fn try_recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
+    fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, SocketAddr)> {
         let state = self.state.read();
 
         let connected_stream = match state.as_ref() {
@@ -258,7 +261,7 @@ impl StreamSocket {
             }
         };
 
-        let received = connected_stream.try_recv(buf, flags).map(|recv_bytes| {
+        let received = connected_stream.try_recv(writer, flags).map(|recv_bytes| {
             connected_stream.update_io_events(&self.pollee);
 
             let remote_endpoint = connected_stream.remote_endpoint();
@@ -271,15 +274,19 @@ impl StreamSocket {
         received
     }
 
-    fn recv(&self, buf: &mut [u8], flags: SendRecvFlags) -> Result<(usize, SocketAddr)> {
+    fn recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, SocketAddr)> {
         if self.is_nonblocking() {
-            self.try_recv(buf, flags)
+            self.try_recv(writer, flags)
         } else {
-            self.wait_events(IoEvents::IN, || self.try_recv(buf, flags))
+            self.wait_events(IoEvents::IN, || self.try_recv(writer, flags))
         }
     }
 
-    fn try_send(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
+    fn try_send(&self, reader: &mut dyn MultiRead, flags: SendRecvFlags) -> Result<usize> {
         let state = self.state.read();
 
         let connected_stream = match state.as_ref() {
@@ -295,7 +302,7 @@ impl StreamSocket {
             }
         };
 
-        let sent_bytes = connected_stream.try_send(buf, flags).map(|sent_bytes| {
+        let sent_bytes = connected_stream.try_send(reader, flags).map(|sent_bytes| {
             connected_stream.update_io_events(&self.pollee);
             sent_bytes
         });
@@ -306,11 +313,11 @@ impl StreamSocket {
         sent_bytes
     }
 
-    fn send(&self, buf: &[u8], flags: SendRecvFlags) -> Result<usize> {
+    fn send(&self, reader: &mut dyn MultiRead, flags: SendRecvFlags) -> Result<usize> {
         if self.is_nonblocking() {
-            self.try_send(buf, flags)
+            self.try_send(reader, flags)
         } else {
-            self.wait_events(IoEvents::OUT, || self.try_send(buf, flags))
+            self.wait_events(IoEvents::OUT, || self.try_send(reader, flags))
         }
     }
 
@@ -340,19 +347,15 @@ impl Pollable for StreamSocket {
 
 impl FileLike for StreamSocket {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        let mut buf = vec![0u8; writer.avail()];
         // TODO: Set correct flags
         let flags = SendRecvFlags::empty();
-        let read_len = self.recv(&mut buf, flags).map(|(len, _)| len)?;
-        writer.write_fallible(&mut buf.as_slice().into())?;
-        Ok(read_len)
+        self.recv(writer, flags).map(|(len, _)| len)
     }
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
-        let buf = reader.collect()?;
         // TODO: Set correct flags
         let flags = SendRecvFlags::empty();
-        self.send(&buf, flags)
+        self.send(reader, flags)
     }
 
     fn status_flags(&self) -> StatusFlags {
@@ -509,7 +512,7 @@ impl Socket for StreamSocket {
 
     fn sendmsg(
         &self,
-        io_vecs: &[IoVec],
+        reader: &mut dyn MultiRead,
         message_header: MessageHeader,
         flags: SendRecvFlags,
     ) -> Result<usize> {
@@ -529,23 +532,18 @@ impl Socket for StreamSocket {
             warn!("sending control message is not supported");
         }
 
-        let buf = copy_message_from_user(io_vecs);
-
-        self.send(&buf, flags)
+        self.send(reader, flags)
     }
 
-    fn recvmsg(&self, io_vecs: &[IoVec], flags: SendRecvFlags) -> Result<(usize, MessageHeader)> {
+    fn recvmsg(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, MessageHeader)> {
         // TODO: Deal with flags
         debug_assert!(flags.is_all_supported());
 
-        let mut buf = create_message_buffer(io_vecs);
-
-        let (received_bytes, _) = self.recv(&mut buf, flags)?;
-
-        let copied_bytes = {
-            let message = &buf[..received_bytes];
-            copy_message_to_user(io_vecs, message)
-        };
+        let (received_bytes, _) = self.recv(writer, flags)?;
 
         // TODO: Receive control message
 
@@ -553,7 +551,7 @@ impl Socket for StreamSocket {
         // peer address is ignored for connected socket.
         let message_header = MessageHeader::new(None, None);
 
-        Ok((copied_bytes, message_header))
+        Ok((received_bytes, message_header))
     }
 
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -5,7 +5,11 @@ pub use self::util::{
     options::LingerOption, send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd,
     socket_addr::SocketAddr, MessageHeader,
 };
-use crate::{fs::file_handle::FileLike, prelude::*, util::IoVec};
+use crate::{
+    fs::file_handle::FileLike,
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
 
 pub mod ip;
 pub mod options;
@@ -64,7 +68,7 @@ pub trait Socket: FileLike + Send + Sync {
     /// Sends a message on a socket.
     fn sendmsg(
         &self,
-        io_vecs: &[IoVec],
+        reader: &mut dyn MultiRead,
         message_header: MessageHeader,
         flags: SendRecvFlags,
     ) -> Result<usize>;
@@ -74,5 +78,9 @@ pub trait Socket: FileLike + Send + Sync {
     /// If successful, the `io_vecs` buffer will be filled with the received content.
     /// This method returns the length of the received message,
     /// and the message header.
-    fn recvmsg(&self, io_vecs: &[IoVec], flags: SendRecvFlags) -> Result<(usize, MessageHeader)>;
+    fn recvmsg(
+        &self,
+        writers: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, MessageHeader)>;
 }

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{Pollee, Poller},
+    util::{MultiRead, MultiWrite},
 };
 
 pub(super) struct Connected {
@@ -70,14 +71,12 @@ impl Connected {
         Ok(())
     }
 
-    pub(super) fn try_read(&self, buf: &mut [u8]) -> Result<usize> {
-        let mut writer = VmWriter::from(buf).to_fallible();
-        self.reader.try_read(&mut writer)
+    pub(super) fn try_read(&self, writer: &mut dyn MultiWrite) -> Result<usize> {
+        self.reader.try_read(writer)
     }
 
-    pub(super) fn try_write(&self, buf: &[u8]) -> Result<usize> {
-        let mut reader = VmReader::from(buf).to_fallible();
-        self.writer.try_write(&mut reader)
+    pub(super) fn try_write(&self, reader: &mut dyn MultiRead) -> Result<usize> {
+        self.writer.try_write(reader)
     }
 
     pub(super) fn shutdown(&self, cmd: SockShutdownCmd) {

--- a/kernel/src/net/socket/util/message_header.rs
+++ b/kernel/src/net/socket/util/message_header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::socket_addr::SocketAddr;
-use crate::{prelude::*, util::IoVec};
+use crate::prelude::*;
 
 /// Message header used for sendmsg/recvmsg.
 #[derive(Debug)]
@@ -30,66 +30,3 @@ impl MessageHeader {
 /// TODO: Implement the struct. The struct is empty now.
 #[derive(Debug)]
 pub struct ControlMessage;
-
-/// Copies a message from user space.
-///
-/// Since udp allows sending and receiving packet of length 0,
-/// The returned buffer may have length of zero.
-pub fn copy_message_from_user(io_vecs: &[IoVec]) -> Box<[u8]> {
-    let mut buffer = create_message_buffer(io_vecs);
-
-    let mut total_bytes = 0;
-    for io_vec in io_vecs {
-        if io_vec.is_empty() {
-            continue;
-        }
-        let dst = &mut buffer[total_bytes..total_bytes + io_vec.len()];
-        // FIXME: short read should be allowed here
-        match io_vec.read_exact_from_user(dst) {
-            Ok(()) => total_bytes += io_vec.len(),
-            Err(_) => {
-                warn!("fails to copy message from user");
-                break;
-            }
-        }
-    }
-
-    buffer.truncate(total_bytes);
-    buffer.into_boxed_slice()
-}
-
-/// Creates a buffer whose length
-/// is equal to the total length of `io_vecs`.
-pub fn create_message_buffer(io_vecs: &[IoVec]) -> Vec<u8> {
-    let buffer_len: usize = io_vecs.iter().map(|iovec| iovec.len()).sum();
-    vec![0; buffer_len]
-}
-
-/// Copies a message to user space.
-///
-/// This method returns the actual copied length.
-pub fn copy_message_to_user(io_vecs: &[IoVec], message: &[u8]) -> usize {
-    let mut total_bytes = 0;
-
-    for io_vec in io_vecs {
-        if io_vec.is_empty() {
-            continue;
-        }
-
-        let len = io_vec.len().min(message.len() - total_bytes);
-        if len == 0 {
-            break;
-        }
-
-        let src = &message[total_bytes..total_bytes + len];
-        match io_vec.write_to_user(src) {
-            Ok(len) => total_bytes += len,
-            Err(_) => {
-                warn!("fails to copy message to user");
-                break;
-            }
-        }
-    }
-
-    total_bytes
-}

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -7,6 +7,3 @@ pub mod shutdown_cmd;
 pub mod socket_addr;
 
 pub use message_header::MessageHeader;
-pub(in crate::net) use message_header::{
-    copy_message_from_user, copy_message_to_user, create_message_buffer,
-};

--- a/kernel/src/syscall/recvfrom.rs
+++ b/kernel/src/syscall/recvfrom.rs
@@ -5,10 +5,7 @@ use crate::{
     fs::file_table::FileDesc,
     net::socket::SendRecvFlags,
     prelude::*,
-    util::{
-        net::{get_socket_from_fd, write_socket_addr_to_user},
-        IoVec,
-    },
+    util::net::{get_socket_from_fd, write_socket_addr_to_user},
 };
 
 pub fn sys_recvfrom(
@@ -18,15 +15,19 @@ pub fn sys_recvfrom(
     flags: i32,
     src_addr: Vaddr,
     addrlen_ptr: Vaddr,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     let flags = SendRecvFlags::from_bits_truncate(flags);
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = {len}, flags = {flags:?}, src_addr = 0x{src_addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let socket = get_socket_from_fd(sockfd)?;
 
-    let io_vecs = [IoVec::new(buf, len)];
-    let (recv_size, message_header) = socket.recvmsg(&io_vecs, flags)?;
+    let mut writers = {
+        let vm_space = ctx.process.root_vmar().vm_space();
+        vm_space.writer(buf, len)?
+    };
+
+    let (recv_size, message_header) = socket.recvmsg(&mut writers, flags)?;
 
     if let Some(socket_addr) = message_header.addr()
         && src_addr != 0

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -24,8 +24,8 @@ pub fn sys_recvmsg(
 
     let (total_bytes, message_header) = {
         let socket = get_socket_from_fd(sockfd)?;
-        let io_vecs = c_user_msghdr.copy_iovs_from_user()?;
-        socket.recvmsg(&io_vecs, flags)?
+        let mut io_vec_writer = c_user_msghdr.copy_writer_array_from_user(ctx)?;
+        socket.recvmsg(&mut io_vec_writer, flags)?
     };
 
     if let Some(addr) = message_header.addr() {

--- a/kernel/src/syscall/sendmsg.rs
+++ b/kernel/src/syscall/sendmsg.rs
@@ -24,9 +24,9 @@ pub fn sys_sendmsg(
 
     let socket = get_socket_from_fd(sockfd)?;
 
-    let (io_vecs, message_header) = {
+    let (mut io_vec_reader, message_header) = {
         let addr = c_user_msghdr.read_socket_addr_from_user()?;
-        let io_vecs = c_user_msghdr.copy_iovs_from_user()?;
+        let io_vec_reader = c_user_msghdr.copy_reader_array_from_user(ctx)?;
 
         let control_message = {
             if c_user_msghdr.msg_control != 0 {
@@ -36,10 +36,10 @@ pub fn sys_sendmsg(
             None
         };
 
-        (io_vecs, MessageHeader::new(addr, control_message))
+        (io_vec_reader, MessageHeader::new(addr, control_message))
     };
 
-    let total_bytes = socket.sendmsg(&io_vecs, message_header, flags)?;
+    let total_bytes = socket.sendmsg(&mut io_vec_reader, message_header, flags)?;
 
     Ok(SyscallReturn::Return(total_bytes as _))
 }

--- a/kernel/src/util/iovec.rs
+++ b/kernel/src/util/iovec.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::mm::{Infallible, VmSpace};
+
 use crate::prelude::*;
 
 /// A kernel space IO vector.
 #[derive(Debug, Clone, Copy)]
-pub struct IoVec {
+struct IoVec {
     base: Vaddr,
     len: usize,
 }
@@ -37,92 +39,194 @@ impl TryFrom<UserIoVec> for IoVec {
 }
 
 impl IoVec {
-    /// Creates a new `IoVec`.
-    pub const fn new(base: Vaddr, len: usize) -> Self {
-        Self { base, len }
-    }
-
-    /// Returns the base address.
-    pub const fn base(&self) -> Vaddr {
-        self.base
-    }
-
-    /// Returns the length.
-    pub const fn len(&self) -> usize {
-        self.len
-    }
-
     /// Returns whether the `IoVec` points to an empty user buffer.
-    pub const fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.len == 0 || self.base == 0
     }
 
-    /// Reads bytes from the user space buffer pointed by
-    /// the `IoVec` to `dst`.
-    ///
-    /// If successful, the read length will be equal to `dst.len()`.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if
-    /// 1.`dst.len()` is not the same as `self.len()`;
-    /// 2. `self.is_empty()` is `true`.
-    pub fn read_exact_from_user(&self, dst: &mut [u8]) -> Result<()> {
-        assert_eq!(dst.len(), self.len);
-        assert!(!self.is_empty());
-
-        CurrentUserSpace::get().read_bytes(self.base, &mut VmWriter::from(dst))
+    fn reader<'a>(&self, vm_space: &'a VmSpace) -> Result<VmReader<'a>> {
+        Ok(vm_space.reader(self.base, self.len)?)
     }
 
-    /// Writes bytes from the `src` buffer
-    /// to the user space buffer pointed by the `IoVec`.
-    ///
-    /// If successful, the written length will be equal to `src.len()`.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if
-    /// 1. `src.len()` is not the same as `self.len()`;
-    /// 2. `self.is_empty()` is `true`.
-    pub fn write_exact_to_user(&self, src: &[u8]) -> Result<()> {
-        assert_eq!(src.len(), self.len);
-        assert!(!self.is_empty());
-
-        CurrentUserSpace::get().write_bytes(self.base, &mut VmReader::from(src))
-    }
-
-    /// Reads bytes to the `dst` buffer
-    /// from the user space buffer pointed by the `IoVec`.
-    ///
-    /// If successful, returns the length of actually read bytes.
-    pub fn read_from_user(&self, dst: &mut [u8]) -> Result<usize> {
-        let len = self.len.min(dst.len());
-        CurrentUserSpace::get().read_bytes(self.base, &mut VmWriter::from(&mut dst[..len]))?;
-        Ok(len)
-    }
-
-    /// Writes bytes from the `src` buffer
-    /// to the user space buffer pointed by the `IoVec`.
-    ///
-    /// If successful, returns the length of actually written bytes.
-    pub fn write_to_user(&self, src: &[u8]) -> Result<usize> {
-        let len = self.len.min(src.len());
-        CurrentUserSpace::get().write_bytes(self.base, &mut VmReader::from(&src[..len]))?;
-        Ok(len)
+    fn writer<'a>(&self, vm_space: &'a VmSpace) -> Result<VmWriter<'a>> {
+        Ok(vm_space.writer(self.base, self.len)?)
     }
 }
 
-/// Copies IO vectors from user space.
-pub fn copy_iovs_from_user(start_addr: Vaddr, count: usize) -> Result<Box<[IoVec]>> {
-    let mut io_vecs = Vec::with_capacity(count);
+/// The util function for create [`VmReader`]/[`VmWriter`]s.
+fn copy_iovs_and_convert<'a, T: 'a>(
+    ctx: &'a Context,
+    start_addr: Vaddr,
+    count: usize,
+    convert_iovec: impl Fn(&IoVec, &'a VmSpace) -> Result<T>,
+) -> Result<Box<[T]>> {
+    let vm_space = ctx.process.root_vmar().vm_space();
 
-    let user_space = CurrentUserSpace::get();
+    let mut v = Vec::with_capacity(count);
     for idx in 0..count {
-        let addr = start_addr + idx * core::mem::size_of::<UserIoVec>();
-        let uiov = user_space.read_val::<UserIoVec>(addr)?;
-        let iov = IoVec::try_from(uiov)?;
-        io_vecs.push(iov);
+        let iov = {
+            let addr = start_addr + idx * core::mem::size_of::<UserIoVec>();
+            let uiov: UserIoVec = vm_space
+                .reader(addr, core::mem::size_of::<UserIoVec>())?
+                .read_val()?;
+            IoVec::try_from(uiov)?
+        };
+
+        if iov.is_empty() {
+            continue;
+        }
+
+        let converted = convert_iovec(&iov, vm_space)?;
+        v.push(converted)
     }
 
-    Ok(io_vecs.into_boxed_slice())
+    Ok(v.into_boxed_slice())
+}
+
+/// A collection of [`VmReader`]s.
+///
+/// Such readers are built from user-provided buffer, so it's always fallible.
+pub struct VmReaderArray<'a>(Box<[VmReader<'a>]>);
+
+/// A collection of [`VmWriter`]s.
+///
+/// Such writers are built from user-provided buffer, so it's always fallible.
+pub struct VmWriterArray<'a>(Box<[VmWriter<'a>]>);
+
+impl<'a> VmReaderArray<'a> {
+    /// Creates a new `IoVecReader` from user-provided io vec buffer.
+    pub fn from_user_io_vecs(
+        ctx: &'a Context<'a>,
+        start_addr: Vaddr,
+        count: usize,
+    ) -> Result<Self> {
+        let readers = copy_iovs_and_convert(ctx, start_addr, count, IoVec::reader)?;
+        Ok(Self(readers))
+    }
+
+    /// Returns mutable reference to [`VmReader`]s.
+    pub fn readers_mut(&'a mut self) -> &'a mut [VmReader<'a>] {
+        &mut self.0
+    }
+}
+
+impl<'a> VmWriterArray<'a> {
+    /// Creates a new `IoVecWriter` from user-provided io vec buffer.
+    pub fn from_user_io_vecs(
+        ctx: &'a Context<'a>,
+        start_addr: Vaddr,
+        count: usize,
+    ) -> Result<Self> {
+        let writers = copy_iovs_and_convert(ctx, start_addr, count, IoVec::writer)?;
+        Ok(Self(writers))
+    }
+
+    /// Returns mutable reference to [`VmWriter`]s.
+    pub fn writers_mut(&'a mut self) -> &'a mut [VmWriter<'a>] {
+        &mut self.0
+    }
+}
+
+/// Trait defining the read behavior for a collection of [`VmReader`]s.
+pub trait MultiRead {
+    /// Reads the exact number of bytes required to exhaust `self` or fill `writer`,
+    /// accumulating total bytes read.
+    ///
+    /// If the return value is `Ok(n)`,
+    /// then `n` should be `min(self.sum_lens(), writer.avail())`.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`Errno::EFAULT`] if a page fault occurs.
+    /// The position of `self` and the `writer` is left unspecified when this method returns error.
+    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize>;
+
+    /// Calculates the total length of data remaining to read.
+    fn sum_lens(&self) -> usize;
+
+    /// Checks if the data remaining to read is empty.
+    fn is_empty(&self) -> bool {
+        self.sum_lens() == 0
+    }
+}
+
+/// Trait defining the write behavior for a collection of [`VmWriter`]s.
+pub trait MultiWrite {
+    /// Writes the exact number of bytes required to exhaust `writer` or fill `self`,
+    /// accumulating total bytes read.
+    ///
+    /// If the return value is `Ok(n)`,
+    /// then `n` should be `min(self.sum_lens(), reader.remain())`.
+    ///
+    /// # Errors
+    ///
+    /// This method returns [`Errno::EFAULT`] if a page fault occurs.
+    /// The position of `self` and the `reader` is left unspecified when this method returns error.
+    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize>;
+
+    /// Calculates the length of space available to write.
+    fn sum_lens(&self) -> usize;
+
+    /// Checks if the space available to write is empty.
+    fn is_empty(&self) -> bool {
+        self.sum_lens() == 0
+    }
+}
+
+impl<'a> MultiRead for VmReaderArray<'a> {
+    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize> {
+        let mut total_len = 0;
+
+        for reader in &mut self.0 {
+            let copied_len = reader.read_fallible(writer)?;
+            total_len += copied_len;
+            if !writer.has_avail() {
+                break;
+            }
+        }
+        Ok(total_len)
+    }
+
+    fn sum_lens(&self) -> usize {
+        self.0.iter().map(|vm_reader| vm_reader.remain()).sum()
+    }
+}
+
+impl<'a> MultiRead for VmReader<'a> {
+    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize> {
+        Ok(self.read_fallible(writer)?)
+    }
+
+    fn sum_lens(&self) -> usize {
+        self.remain()
+    }
+}
+
+impl<'a> MultiWrite for VmWriterArray<'a> {
+    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize> {
+        let mut total_len = 0;
+
+        for writer in &mut self.0 {
+            let copied_len = writer.write_fallible(reader)?;
+            total_len += copied_len;
+            if !reader.has_remain() {
+                break;
+            }
+        }
+        Ok(total_len)
+    }
+
+    fn sum_lens(&self) -> usize {
+        self.0.iter().map(|vm_writer| vm_writer.avail()).sum()
+    }
+}
+
+impl<'a> MultiWrite for VmWriter<'a> {
+    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize> {
+        Ok(self.write_fallible(reader)?)
+    }
+
+    fn sum_lens(&self) -> usize {
+        self.avail()
+    }
 }

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -5,4 +5,4 @@ pub mod net;
 pub mod random;
 pub mod ring_buffer;
 
-pub use iovec::{copy_iovs_from_user, IoVec};
+pub use iovec::{MultiRead, MultiWrite, VmReaderArray, VmWriterArray};

--- a/kernel/src/util/net/socket.rs
+++ b/kernel/src/util/net/socket.rs
@@ -4,7 +4,7 @@ use super::read_socket_addr_from_user;
 use crate::{
     net::socket::SocketAddr,
     prelude::*,
-    util::{copy_iovs_from_user, net::write_socket_addr_with_max_len, IoVec},
+    util::{net::write_socket_addr_with_max_len, VmReaderArray, VmWriterArray},
 };
 
 /// Standard well-defined IP protocols.
@@ -112,7 +112,11 @@ impl CUserMsgHdr {
         Ok(())
     }
 
-    pub fn copy_iovs_from_user(&self) -> Result<Box<[IoVec]>> {
-        copy_iovs_from_user(self.msg_iov, self.msg_iovlen as usize)
+    pub fn copy_reader_array_from_user<'a>(&self, ctx: &'a Context) -> Result<VmReaderArray<'a>> {
+        VmReaderArray::from_user_io_vecs(ctx, self.msg_iov, self.msg_iovlen as usize)
+    }
+
+    pub fn copy_writer_array_from_user<'a>(&self, ctx: &'a Context) -> Result<VmWriterArray<'a>> {
+        VmWriterArray::from_user_io_vecs(ctx, self.msg_iov, self.msg_iovlen as usize)
     }
 }

--- a/test/apps/network/tcp_err.c
+++ b/test/apps/network/tcp_err.c
@@ -364,7 +364,8 @@ FN_TEST(sendmsg_and_recvmsg)
 	msg.msg_iov = iov;
 	msg.msg_iovlen = 2;
 
-	// Send one message and recv one message
+	// TEST CASE 1: Send one message and recv one message
+
 	TEST_RES(sendmsg(sk_connected, &msg, 0),
 		 _ret == strlen(message) + strlen(message2));
 
@@ -382,7 +383,7 @@ FN_TEST(sendmsg_and_recvmsg)
 		 _ret == strlen(concatenated) &&
 			 strcmp(buffer, concatenated) == 0);
 
-	// Send two message and receive two message
+	// TEST CASE 2: Send two message and receive two message
 
 	iov[0].iov_base = message;
 	iov[0].iov_len = strlen(message);
@@ -402,5 +403,60 @@ FN_TEST(sendmsg_and_recvmsg)
 	sleep(1);
 
 	TEST_RES(recvmsg(sk_connected, &msg, 0), _ret == strlen(message) * 2);
+
+	// TEST CASE 3: Send via a partially bad send buffer
+
+	char *good_buffer = "abc";
+	char *bad_buffer = (char *)1;
+	iov[0].iov_base = good_buffer;
+	iov[0].iov_len = strlen(good_buffer);
+	iov[1].iov_base = bad_buffer;
+	iov[1].iov_len = 1;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 2;
+	TEST_ERRNO(sendmsg(sk_accepted, &msg, 0), EFAULT);
+
+	// TEST CASE 4: Receive via a partially bad receive buffer
+
+	iov[0].iov_base = good_buffer;
+	iov[0].iov_len = strlen(good_buffer);
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+
+	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(good_buffer));
+
+	sleep(1);
+
+	char recv_buffer[4096] = { 0 };
+	iov[0].iov_base = recv_buffer;
+	iov[0].iov_len = 1;
+	TEST_RES(recvmsg(sk_connected, &msg, 0), _ret == 1);
+
+	iov[0].iov_base = recv_buffer;
+	iov[0].iov_len = 1;
+	iov[1].iov_base = (char *)1;
+	iov[1].iov_len = 1;
+	msg.msg_iovlen = 2;
+	TEST_ERRNO(recvmsg(sk_connected, &msg, 0), EFAULT);
+
+	iov[0].iov_base = recv_buffer;
+	iov[0].iov_len = 4096;
+	msg.msg_iovlen = 1;
+	TEST_RES(recvmsg(sk_connected, &msg, 0),
+		 _ret == strlen(good_buffer) - 1);
+
+	// TEST CASE 5: Send a large buffer
+
+	int big_buffer_size = 1000000;
+	char *big_buffer = (char *)calloc(0, big_buffer_size);
+	iov[0].iov_base = big_buffer;
+	iov[0].iov_len = big_buffer_size;
+	msg.msg_iovlen = 2;
+
+	int sndbuf = 0;
+	socklen_t optlen = sizeof(sndbuf);
+	TEST_SUCC(getsockopt(sk_accepted, SOL_SOCKET, SO_SNDBUF, &sndbuf,
+			     &optlen));
+	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret <= sndbuf);
 }
 END_TEST()

--- a/test/apps/pipe/short_rw.c
+++ b/test/apps/pipe/short_rw.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <unistd.h>
+#include <sys/mman.h>
+#include <stdio.h>
+
+#include "../network/test.h"
+
+#define PAGE_SIZE 4096
+
+static void *page;
+static int rfd, wfd;
+
+FN_SETUP(short_read_and_write)
+{
+	int fildes[2];
+
+	page = mmap((void *)0x20000000, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+	CHECK(page == NULL ? -1 : 0);
+
+	CHECK(pipe(fildes));
+	rfd = fildes[0];
+	wfd = fildes[1];
+
+	CHECK_WITH(write(wfd, "ab", 2), _ret == 2);
+}
+END_SETUP()
+
+FN_TEST(short_read_and_write)
+{
+	char *buf = page + PAGE_SIZE - 1;
+	buf[0] = 'x';
+
+	TEST_ERRNO(read(rfd, buf, 2), EFAULT);
+
+	TEST_RES(read(rfd, buf, 1), _ret == 1 && buf[0] == 'a');
+
+	TEST_ERRNO(write(wfd, buf, 2), EFAULT);
+
+	TEST_RES(write(wfd, buf, 1), _ret == 1);
+}
+END_TEST()

--- a/test/apps/scripts/fs.sh
+++ b/test/apps/scripts/fs.sh
@@ -62,4 +62,5 @@ test_fdatasync
 echo "All fdatasync test passed."
 
 pipe/pipe_err
+pipe/short_rw
 epoll/epoll_err


### PR DESCRIPTION
This PR aims to optimize the latency of `lat-udp`, reducing it from 350 microseconds to approximately 5 microseconds, which is comparable to the Linux latency of 4 microseconds.

The primary focus of this effort is to enable direct data transfers between user space and the socket buffer, both for sending and receiving, thereby eliminating the need for temporary kernel buffers. The original bottleneck arose from users providing very large buffer sizes for receiving data (often several million bytes), which was time-consuming to allocate. 