### PR TITLE
Add kernfs and sysfs implementation

### DIFF
--- a/kernel/src/fs/kernfs/element.rs
+++ b/kernel/src/fs/kernfs/element.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+use core::{
+    fmt::{self, Formatter},
+    sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use ostd::sync::{RwLock, RwMutex, RwMutexReadGuard};
+
+use super::KernfsNode;
+use crate::{
+    events::{Events, Observer, Subject},
+    fs::utils::{
+        DirentVisitor, FileSystem, FsFlags, Inode, InodeMode, InodeType, Metadata, SuperBlock,
+        NAME_MAX,
+    },
+    prelude::*,
+    process::{Gid, Uid},
+};
+
+#[derive(Debug)]
+pub struct KernfsElemDir {
+    children: BTreeMap<String, Arc<dyn Inode>>,
+}
+
+#[derive(Debug)]
+pub struct KernfsElemSymlink {
+    target_kn: String,
+}
+
+impl KernfsElemSymlink {
+    pub fn new(target_kn: String) -> Self {
+        KernfsElemSymlink { target_kn }
+    }
+
+    pub fn get_target_kn(&self) -> String {
+        self.target_kn.clone()
+    }
+
+    pub fn set_target_kn(&mut self, target_kn: String) {
+        self.target_kn = target_kn;
+    }
+}
+
+pub trait DataProvider: Any + Sync + Send {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize>;
+    fn write_at(&mut self, reader: &mut VmReader, offset: usize) -> Result<usize>;
+}
+
+pub struct KernfsElemAttr {
+    data: Option<Box<dyn DataProvider>>,
+}
+
+impl KernfsElemAttr {
+    pub fn new() -> Self {
+        KernfsElemAttr { data: None }
+    }
+
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) {
+        self.data = Some(data);
+    }
+
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        if let Some(data) = &self.data {
+            data.read_at(buf, offset)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        if let Some(data) = &mut self.data {
+            let new_size = data.write_at(buf, offset)?;
+            Ok(new_size)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl Default for KernfsElemAttr {
+    fn default() -> Self {
+        KernfsElemAttr::new()
+    }
+}
+
+impl fmt::Debug for KernfsElemAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "KernfsElemAttr")
+    }
+}
+
+#[derive(Debug)]
+pub enum KernfsElem {
+    Dir(KernfsElemDir),
+    Symlink(KernfsElemSymlink),
+    Attr(KernfsElemAttr),
+}
+
+impl KernfsElem {
+    pub fn new_dir() -> Self {
+        KernfsElem::Dir(KernfsElemDir {
+            children: BTreeMap::new(),
+        })
+    }
+
+    pub fn new_symlink(target_kn: String) -> Self {
+        KernfsElem::Symlink(KernfsElemSymlink::new(target_kn))
+    }
+
+    pub fn new_attr() -> Self {
+        KernfsElem::Attr(KernfsElemAttr::new())
+    }
+
+    pub fn is_dir(&self) -> bool {
+        matches!(self, KernfsElem::Dir(_))
+    }
+
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, KernfsElem::Symlink(_))
+    }
+
+    pub fn is_attr(&self) -> bool {
+        matches!(self, KernfsElem::Attr(_))
+    }
+
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) -> Result<()> {
+        match self {
+            KernfsElem::Attr(ref mut attr) => {
+                attr.set_data(data);
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        match self {
+            KernfsElem::Attr(attr) => attr.read_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        match self {
+            KernfsElem::Attr(attr) => attr.write_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn remove(&mut self, name: &str) -> Result<Arc<dyn Inode>> {
+        let node = match self {
+            KernfsElem::Dir(dir) => {
+                if let Some(node) = dir.children.remove(name) {
+                    node
+                } else {
+                    return_errno_with_message!(Errno::ENOENT, "no such file or directory");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        };
+        Ok(node)
+    }
+
+    pub fn insert(&mut self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        match self {
+            KernfsElem::Dir(dir) => {
+                if dir.children.contains_key(&name)
+                    || dir.children.insert(name.clone(), node.clone()).is_some()
+                {
+                    return_errno_with_message!(Errno::EEXIST, "file exists");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        }
+        Ok(())
+    }
+
+    pub fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        match self {
+            KernfsElem::Dir(dir) => match dir.children.get(name) {
+                Some(node) => Ok(node.clone() as Arc<dyn Inode>),
+                None => return_errno!(Errno::ENOENT),
+            },
+            _ => return_errno!(Errno::ENOTDIR),
+        }
+    }
+
+    pub fn get_children(&self) -> Option<BTreeMap<String, Arc<dyn Inode>>> {
+        match self {
+            KernfsElem::Dir(dir) => Some(dir.children.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn read_link(&self) -> Result<String> {
+        match self {
+            KernfsElem::Symlink(link) => Ok(link.get_target_kn()),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn write_link(&mut self, target_kn: &str) -> Result<()> {
+        match self {
+            KernfsElem::Symlink(link) => {
+                link.set_target_kn(target_kn.to_string());
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+}

--- a/kernel/src/fs/kernfs/element.rs
+++ b/kernel/src/fs/kernfs/element.rs
@@ -7,8 +7,6 @@ use core::{
     time::Duration,
 };
 
-use ostd::sync::{RwLock, RwMutex, RwMutexReadGuard};
-
 use super::KernfsNode;
 use crate::{
     events::{Events, Observer, Subject},

--- a/kernel/src/fs/kernfs/inode.rs
+++ b/kernel/src/fs/kernfs/inode.rs
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: MPL-2.0
+#![allow(unused)]
+
+use alloc::{
+    collections::BTreeMap,
+    string::String,
+    sync::{Arc, Weak},
+};
+use core::time::Duration;
+
+use ostd::sync::RwLock;
+
+use super::{
+    element::{DataProvider, KernfsElem},
+    PseudoFileSystem, PseudoNode, BLOCK_SIZE,
+};
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::Device,
+        utils::{
+            DirentVisitor, FallocMode, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
+            MknodType,
+        },
+        Errno,
+    },
+    prelude::*,
+    process::{signal::Poller, Gid, Uid},
+};
+
+bitflags! {
+    /// Some flags in Linux are used to indicate the status of the node. We don't need them.
+    pub struct KernfsNodeFlag: u16 {
+        /// Indicates that the node supports namespaces.
+        const KERNFS_NS         = 0x0020;
+        /// Indicates that the node supports the `seq_file` interface.
+        const KERNFS_HAS_SEQ_SHOW = 0x0040;
+        /// Indicates that the node supports the `mmap` operation.
+        const KERNFS_HAS_MMAP   = 0x0080;
+        /// Indicates that the node has lock dependency tracking enabled.
+        const KERNFS_LOCKDEP    = 0x0100;
+        /// Indicates that the node is hidden.
+        const KERNFS_HIDDEN     = 0x0200;
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    name: String,
+    flags: KernfsNodeFlag,
+    metadata: Metadata,
+    elem: KernfsElem,
+    fs: Weak<dyn PseudoFileSystem>,
+}
+
+/// Represents a node in the kernel filesystem (kernfs).
+///
+/// This struct contains the core information and functionality for a kernfs node,
+/// including its metadata, flags, and relationship to other nodes in the filesystem.
+/// It is used to implement various types of filesystem entries like directories,
+/// regular files, and special files in the kernel's pseudo-filesystem.
+#[derive(Debug)]
+pub struct KernfsNode {
+    inner: RwLock<Inner>,
+    parent: Option<Weak<dyn PseudoNode>>,
+    this: Weak<KernfsNode>,
+}
+
+impl KernfsNode {
+    pub fn new_root(
+        name: &str,
+        fs: Weak<dyn PseudoFileSystem>,
+        root_ino: u64,
+        blk_size: usize,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            inner: RwLock::new(Inner {
+                name: name.to_string(),
+                flags: KernfsNodeFlag::empty(),
+                metadata: Metadata::new_dir(
+                    root_ino,
+                    InodeMode::from_bits_truncate(0o555),
+                    blk_size,
+                ),
+                elem: KernfsElem::new_dir(),
+                fs,
+            }),
+            parent: None,
+            this: weak_self.clone(),
+        })
+    }
+
+    pub fn new_attr(
+        name: &str,
+        mode: Option<InodeMode>,
+        flags: KernfsNodeFlag,
+        parent: Weak<dyn PseudoNode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+
+        let mode = mode.unwrap_or_else(|| InodeMode::from_bits_truncate(0o777));
+        let metadata = Metadata::new_file(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            inner: RwLock::new(Inner {
+                name: name.to_string(),
+                flags,
+                metadata,
+                elem: KernfsElem::new_attr(),
+                fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            }),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+
+        Ok(new_inode)
+    }
+
+    pub fn new_dir(
+        name: &str,
+        mode: Option<InodeMode>,
+        flags: KernfsNodeFlag,
+        parent: Weak<dyn PseudoNode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = mode.unwrap_or(arc_parent.metadata().mode);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            inner: RwLock::new(Inner {
+                name: name.to_string(),
+                flags: KernfsNodeFlag::empty(),
+                metadata,
+                elem: KernfsElem::new_dir(),
+                fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            }),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        Ok(new_inode)
+    }
+
+    pub fn new_symlink(
+        name: &str,
+        flags: KernfsNodeFlag,
+        target: Arc<dyn PseudoNode>,
+        parent: Weak<dyn PseudoNode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = InodeMode::from_bits_truncate(0o777);
+        let metadata = Metadata::new_symlink(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            inner: RwLock::new(Inner {
+                name: name.to_string(),
+                flags: KernfsNodeFlag::empty(),
+                metadata,
+                elem: KernfsElem::new_symlink(target.name()),
+                fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            }),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        Ok(new_inode)
+    }
+
+    /// Get the current node.
+    pub fn this(&self) -> Arc<KernfsNode> {
+        self.this.upgrade().unwrap()
+    }
+
+    /// Get the current node as a weak reference.
+    pub fn this_weak(&self) -> Weak<KernfsNode> {
+        self.this.clone()
+    }
+}
+
+impl PseudoNode for KernfsNode {
+    /// Get the name of the current node.
+    fn name(&self) -> String {
+        self.inner.read().name.clone()
+    }
+
+    /// Get the parent of the current node.
+    fn parent(&self) -> Option<Arc<dyn PseudoNode>> {
+        self.parent.as_ref().and_then(|p| p.upgrade())
+    }
+
+    /// Get the pseudo filesystem of the current node.
+    fn pseudo_fs(&self) -> Arc<dyn PseudoFileSystem> {
+        self.inner.read().fs.upgrade().unwrap()
+    }
+
+    /// Generate a new inode number for the current node.
+    fn generate_ino(&self) -> u64 {
+        self.pseudo_fs().alloc_id()
+    }
+
+    /// Set the data of the current node.
+    fn set_data(&self, data: Box<dyn DataProvider>) -> Result<()> {
+        self.inner.write().elem.set_data(data)
+    }
+
+    /// Remove a child from the current node.
+    /// Return Ok(Arc<dyn Inode>) if the child is removed successfully.
+    /// Current node should be a directory.
+    fn remove(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        self.inner.write().elem.remove(name)
+    }
+
+    /// Insert a child to the current node.
+    /// Return Ok(()) if the child is inserted successfully.
+    /// Current node should be a directory.
+    /// The child should not exist in the current node.
+    fn insert(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        self.inner.write().elem.insert(name, node)
+    }
+}
+
+impl Drop for KernfsNode {
+    /// Drop the current node.
+    /// Remove the current node from the parent node.
+    fn drop(&mut self) {
+        let parent = if let Some(parent) = self.parent() {
+            parent
+        } else {
+            return;
+        };
+
+        let _ = parent.remove(&self.inner.read().name);
+    }
+}
+
+impl Inode for KernfsNode {
+    fn type_(&self) -> InodeType {
+        self.metadata().type_
+    }
+
+    fn resize(&self, new_size: usize) -> Result<()> {
+        self.inner.write().metadata.size = new_size;
+        // FIXME: The resize operation should be supported for regular files.
+        // A possible implementation is adding a size() for DataProvider.
+        Ok(())
+    }
+
+    fn metadata(&self) -> Metadata {
+        self.inner.read().metadata
+    }
+
+    fn ino(&self) -> u64 {
+        self.metadata().ino
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.metadata().mode)
+    }
+
+    fn size(&self) -> usize {
+        self.metadata().size
+    }
+
+    fn atime(&self) -> Duration {
+        self.metadata().atime
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.inner.write().metadata.atime = time;
+    }
+
+    fn mtime(&self) -> Duration {
+        self.metadata().mtime
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.inner.write().metadata.mtime = time;
+    }
+
+    fn ctime(&self) -> Duration {
+        self.metadata().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.inner.write().metadata.ctime = time;
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.inner.read().fs.upgrade().unwrap()
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.inner.write().metadata.mode = mode;
+        Ok(())
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata().uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        self.inner.write().metadata.uid = uid;
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.metadata().gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        self.inner.write().metadata.gid = gid;
+        Ok(())
+    }
+
+    fn page_cache(&self) -> Option<crate::vm::vmo::Vmo<aster_rights::Full>> {
+        None
+    }
+
+    fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.inner.read().elem.read_at(offset, buf)
+    }
+
+    fn read_direct_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.read_at(offset, buf)
+    }
+
+    fn write_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.inner.write().elem.write_at(offset, buf)
+    }
+
+    fn write_direct_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.write_at(offset, buf)
+    }
+
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        if self.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let new_node = match type_ {
+            InodeType::Dir => {
+                KernfsNode::new_dir(name, Some(mode), KernfsNodeFlag::empty(), self.this_weak())
+            }
+            InodeType::File => {
+                KernfsNode::new_attr(name, Some(mode), KernfsNodeFlag::empty(), self.this_weak())
+            }
+            InodeType::SymLink => KernfsNode::new_symlink(
+                name,
+                KernfsNodeFlag::empty(),
+                self.this(),
+                self.this_weak(),
+            ),
+            _ => return_errno!(Errno::EINVAL),
+        }?;
+        Ok(new_node)
+    }
+
+    fn mknod(&self, name: &str, mode: InodeMode, dev: MknodType) -> Result<Arc<dyn Inode>> {
+        Err(Error::new(Errno::ENOTDIR))
+    }
+
+    fn as_device(&self) -> Option<Arc<dyn Device>> {
+        None
+    }
+
+    fn readdir_at(&self, mut offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+            // Read the two special entries.
+            if *offset == 0 {
+                let this_inode = self.this();
+                visitor.visit(".", this_inode.ino(), this_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+            if *offset == 1 {
+                let parent_inode = self.parent().unwrap_or(self.this());
+                visitor.visit("..", parent_inode.ino(), parent_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+
+            // Read the normal child entries.
+            let cached_children = self.inner.read().elem.get_children().unwrap_or_default();
+            let start_idx = *offset;
+
+            for (name, inode) in cached_children.iter().skip(*offset - 2) {
+                visitor.visit(name, inode.ino(), inode.type_(), *offset - 2)?;
+                *offset += 1;
+            }
+
+            Ok(())
+        };
+        try_readdir(&mut offset, visitor)?;
+        Ok(offset)
+    }
+
+    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
+        // Create a hard link to the old inode.
+        // The old inode should be a regular file or a directory.
+        // The name should not be "." or "..".
+        // The name should not exist in the current directory.
+        if old.type_() != InodeType::File && old.type_() != InodeType::Dir {
+            return_errno!(Errno::EPERM);
+        }
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let target: Arc<dyn PseudoNode> = old
+            .downcast_ref::<KernfsNode>()
+            .ok_or(Error::new(Errno::EXDEV))?
+            .this();
+        let new_node =
+            KernfsNode::new_symlink(name, KernfsNodeFlag::empty(), target, self.this_weak())?;
+        Ok(())
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        // Remove a child from the current node.
+        // The child should be a regular file or a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() != InodeType::SymLink {
+            return_errno!(Errno::EPERM);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        // Remove a child from the current node.
+        // The child should be a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode: Arc<dyn Inode> = match name {
+            "." => self.this(),
+            ".." => self.parent().unwrap_or(self.this()),
+            name => self.inner.read().elem.lookup(name)?,
+        };
+        Ok(inode)
+    }
+
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "rename is not supported in pseudo filesystem");
+    }
+
+    fn read_link(&self) -> Result<String> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.inner.read().elem.read_link()
+    }
+
+    fn write_link(&self, target: &str) -> Result<()> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.inner.write().elem.write_link(target)
+    }
+
+    fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32> {
+        Err(Error::new(Errno::EISDIR))
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn sync_data(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP);
+    }
+
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        true
+    }
+}

--- a/kernel/src/fs/kernfs/mod.rs
+++ b/kernel/src/fs/kernfs/mod.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MPL-2.0
+#![allow(unused)]
+
+mod element;
+mod inode;
+
+use alloc::sync::Arc;
+
+pub use element::{DataProvider, KernfsElem};
+pub use inode::{KernfsNode, KernfsNodeFlag};
+
+use super::utils::{FileSystem, Inode};
+use crate::prelude::*;
+
+/// Block size.
+const BLOCK_SIZE: usize = 1024;
+
+/// A trait for the pseudo filesystem.
+///
+/// The pseudo filesystem is a virtual filesystem that is used to provide
+/// a consistent interface for the kernel to interact with the underlying
+/// hardware. It is typically mounted at a specific mount point (e.g., `/sys`)
+/// and provides a hierarchical view of system resources and configurations.
+///
+/// This trait defines the basic operations that a pseudo filesystem must
+/// implement, including allocating unique identifiers, initializing the
+/// filesystem, and providing access to the filesystem itself.
+///
+/// # Methods
+///
+/// - `alloc_id(&self) -> u64`: Allocates and returns a unique identifier for
+///   inodes or other filesystem entities.
+///
+/// - `init(&self) -> Result<()>`: Initializes the pseudo filesystem, setting
+///   up the root directory and any necessary internal structures.
+///
+/// - `fs(&self) -> Arc<dyn FileSystem>`: Returns a reference to the filesystem
+///   itself, allowing for dynamic dispatch to the underlying filesystem
+///   implementation.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::PseudoFileSystem;
+///
+/// struct MyPseudoFS {
+///     // Implementation details...
+/// }
+///
+/// impl PseudoFileSystem for MyPseudoFS {
+///     fn alloc_id(&self) -> u64 {
+///         // Allocate and return a unique ID
+///     }
+///
+///     fn init(&self) -> Result<()> {
+///         // Initialize the filesystem
+///     }
+///
+///     fn fs(&self) -> Arc<dyn FileSystem> {
+///         // Return a reference to the filesystem
+///     }
+/// }
+/// ```
+pub trait PseudoFileSystem: FileSystem {
+    fn alloc_id(&self) -> u64;
+
+    fn init(&self) -> Result<()>;
+
+    fn fs(&self) -> Arc<dyn FileSystem>;
+}
+
+/// A trait for pseudo filesystem nodes.
+///
+/// It extends the `Inode` trait with additional methods for working with the filesystem.
+/// It provides methods for getting the name of the node, getting the parent node,
+/// getting the filesystem that the node belongs to, generating unique inode numbers,
+/// setting the data provider for the node, removing a child node and  inserting a child node.
+/// The `PseudoNode` trait is used to represent nodes in a pseudo filesystem.
+pub trait PseudoNode: Inode {
+    fn name(&self) -> String;
+    fn parent(&self) -> Option<Arc<dyn PseudoNode>>;
+    fn pseudo_fs(&self) -> Arc<dyn PseudoFileSystem>;
+    fn generate_ino(&self) -> u64;
+    fn set_data(&self, data: Box<dyn DataProvider>) -> Result<()>;
+    fn remove(&self, name: &str) -> Result<Arc<dyn Inode>>;
+    fn insert(&self, name: String, node: Arc<dyn Inode>) -> Result<()>;
+}
+
+/// A toy pseudo filesystem that is working as sysfs.
+/// It takes effect if you mount it to `/sys`.
+#[cfg(ktest)]
+mod tests {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    use ostd::{mm::VmWriter, prelude::ktest};
+
+    use crate::{
+        fs::{
+            kernfs::{DataProvider, KernfsNode, KernfsNodeFlag, PseudoFileSystem, PseudoNode},
+            utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+        },
+        prelude::*,
+    };
+
+    /// ToySysFS filesystem.
+    /// Magic number.
+    const SYSFS_MAGIC: u64 = 0x9fa0;
+    /// Root Inode ID.
+    const SYSFS_ROOT_INO: u64 = 1;
+    /// Block size.
+    const BLOCK_SIZE: usize = 1024;
+
+    pub struct ToySysFS {
+        sb: SuperBlock,
+        root: Arc<dyn Inode>,
+        inode_allocator: AtomicU64,
+        this: Weak<Self>,
+    }
+
+    impl ToySysFS {
+        pub fn new() -> Arc<Self> {
+            Arc::new_cyclic(|weak_fs| Self {
+                sb: SuperBlock::new(SYSFS_MAGIC, BLOCK_SIZE, NAME_MAX),
+                root: SysfsRoot::new_inode(weak_fs.clone()),
+                inode_allocator: AtomicU64::new(SYSFS_ROOT_INO + 1),
+                this: weak_fs.clone(),
+            })
+        }
+    }
+
+    impl PseudoFileSystem for ToySysFS {
+        fn alloc_id(&self) -> u64 {
+            self.inode_allocator.fetch_add(1, Ordering::SeqCst)
+        }
+
+        fn init(&self) -> Result<()> {
+            let root = self.root_inode();
+            let root = root.downcast_ref::<KernfsNode>().unwrap();
+            let kernel =
+                KernfsNode::new_dir("kernel", None, KernfsNodeFlag::empty(), root.this_weak())?;
+            root.this().insert("kernel".to_string(), kernel.clone())?;
+            let ab = KernfsNode::new_attr(
+                "address_bits",
+                None,
+                KernfsNodeFlag::empty(),
+                kernel.this_weak(),
+            )?;
+            ab.set_data(Box::new(AddressBits)).unwrap();
+            kernel.insert("address_bits".to_string(), ab.clone())?;
+            let cpu_byteorder = KernfsNode::new_attr(
+                "byteorder",
+                None,
+                KernfsNodeFlag::empty(),
+                kernel.this_weak(),
+            )?;
+            cpu_byteorder
+                .set_data(Box::new(CpuByteOrder::new()))
+                .unwrap();
+            kernel.insert("byteorder".to_string(), cpu_byteorder.clone())?;
+            Ok(())
+        }
+
+        fn fs(&self) -> Arc<dyn FileSystem> {
+            self.this.upgrade().unwrap()
+        }
+    }
+
+    impl FileSystem for ToySysFS {
+        fn sync(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn root_inode(&self) -> Arc<dyn Inode> {
+            self.root.clone()
+        }
+
+        fn sb(&self) -> SuperBlock {
+            self.sb.clone()
+        }
+
+        fn flags(&self) -> FsFlags {
+            FsFlags::empty()
+        }
+    }
+
+    /// Represents the inode at `/sys`.
+    /// Root directory of the sysfs.
+    pub struct SysfsRoot;
+
+    impl SysfsRoot {
+        pub fn new_inode(fs: Weak<ToySysFS>) -> Arc<dyn Inode> {
+            KernfsNode::new_root("sysfs", fs, SYSFS_ROOT_INO, BLOCK_SIZE)
+        }
+    }
+
+    pub struct AddressBits;
+
+    impl DataProvider for AddressBits {
+        fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+            let data = "64\n".as_bytes().to_vec();
+            let start = data.len().min(offset);
+            let end = data.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&data[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+            return_errno_with_message!(Errno::EINVAL, "cpuinfo is read-only");
+        }
+    }
+
+    pub struct CpuByteOrder {
+        byte_order: Vec<u8>,
+    }
+
+    impl CpuByteOrder {
+        pub fn new() -> Self {
+            let byte_order = if cfg!(target_endian = "little") {
+                "little\n".as_bytes().to_vec()
+            } else {
+                "big\n".as_bytes().to_vec()
+            };
+            Self { byte_order }
+        }
+    }
+
+    impl Default for CpuByteOrder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl DataProvider for CpuByteOrder {
+        fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+            let start = self.byte_order.len().min(offset);
+            let end = self.byte_order.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&self.byte_order[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, reader: &mut VmReader, offset: usize) -> Result<usize> {
+            let write_len = reader.remain();
+            let end = offset + write_len;
+
+            if self.byte_order.len() < end {
+                self.byte_order.resize(end, 0);
+            }
+
+            let mut writer = VmWriter::from(&mut self.byte_order[offset..end]);
+            let value = reader.read_fallible(&mut writer)?;
+            if value != write_len {
+                return_errno!(Errno::EINVAL);
+            }
+
+            Ok(write_len)
+        }
+    }
+
+    fn load_fs() -> Arc<ToySysFS> {
+        crate::time::clocks::init_for_ktest();
+        let fs: Arc<ToySysFS> = ToySysFS::new();
+        fs
+    }
+
+    #[ktest]
+    fn new_fs() {
+        let fs = load_fs();
+        assert_eq!(fs.alloc_id(), SYSFS_ROOT_INO + 1);
+    }
+
+    #[ktest]
+    fn init_fs() {
+        let fs = load_fs();
+        fs.init().unwrap();
+    }
+
+    #[ktest]
+    fn read_address_bits() {
+        let fs = load_fs();
+        fs.init().unwrap();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let ab = kernel.lookup("address_bits").unwrap();
+        let mut read_buf = vec![0u8; "64\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        ab.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "64\n".as_bytes());
+    }
+
+    #[ktest]
+    fn read_cpu_byteorder() {
+        let fs = load_fs();
+        fs.init().unwrap();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let mut read_buf = vec![0u8; "little\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "little\n".as_bytes());
+    }
+
+    #[ktest]
+    fn write_cpu_byteorder() {
+        let fs = load_fs();
+        fs.init().unwrap();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let mut write_buf = "big\n".as_bytes().to_vec();
+        let mut reader = VmReader::from(&write_buf as &[u8]).to_fallible();
+        let write_len = cpu_byteorder.write_at(0, &mut reader).unwrap();
+        assert_eq!(write_len, "big\n".as_bytes().len());
+        let mut read_buf = vec![0u8; "big\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "big\n".as_bytes());
+    }
+}

--- a/kernel/src/fs/kernfs/mod.rs
+++ b/kernel/src/fs/kernfs/mod.rs
@@ -7,7 +7,7 @@ mod inode;
 use alloc::sync::Arc;
 
 pub use element::{DataProvider, KernfsElem};
-pub use inode::{KernfsNode, KernfsNodeFlag};
+pub use inode::KernfsNode;
 
 use super::utils::{FileSystem, Inode};
 use crate::prelude::*;
@@ -96,7 +96,7 @@ mod tests {
 
     use crate::{
         fs::{
-            kernfs::{DataProvider, KernfsNode, KernfsNodeFlag, PseudoFileSystem, PseudoNode},
+            kernfs::{DataProvider, KernfsNode, PseudoFileSystem, PseudoNode},
             utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
         },
         prelude::*,
@@ -137,12 +137,11 @@ mod tests {
             let root = self.root_inode();
             let root = root.downcast_ref::<KernfsNode>().unwrap();
             let kernel =
-                KernfsNode::new_dir("kernel", None, KernfsNodeFlag::empty(), root.this_weak())?;
+                KernfsNode::new_dir("kernel", None, root.this_weak())?;
             root.this().insert("kernel".to_string(), kernel.clone())?;
             let ab = KernfsNode::new_attr(
                 "address_bits",
                 None,
-                KernfsNodeFlag::empty(),
                 kernel.this_weak(),
             )?;
             ab.set_data(Box::new(AddressBits)).unwrap();
@@ -150,7 +149,6 @@ mod tests {
             let cpu_byteorder = KernfsNode::new_attr(
                 "byteorder",
                 None,
-                KernfsNodeFlag::empty(),
                 kernel.this_weak(),
             )?;
             cpu_byteorder

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -8,6 +8,7 @@ pub mod file_handle;
 pub mod file_table;
 pub mod fs_resolver;
 pub mod inode_handle;
+pub mod kernfs;
 pub mod named_pipe;
 pub mod path;
 pub mod pipe;
@@ -15,6 +16,7 @@ pub mod procfs;
 pub mod ramfs;
 pub mod rootfs;
 pub mod thread_info;
+pub mod sysfs;
 pub mod utils;
 
 use aster_block::BlockDevice;

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -8,9 +8,11 @@ use spin::Once;
 
 use super::{
     fs_resolver::{FsPath, FsResolver},
+    kernfs::PseudoFileSystem,
     path::MountNode,
     procfs::{self, ProcFS},
     ramfs::RamFS,
+    sysfs::SysFS,
     utils::{FileSystem, InodeMode, InodeType},
 };
 use crate::{fs::path::is_dot, prelude::*};
@@ -113,6 +115,11 @@ pub fn init(initramfs_buf: &[u8]) -> Result<()> {
     // Mount DevFS
     let dev_dentry = fs.lookup(&FsPath::try_from("/dev")?)?;
     dev_dentry.mount(RamFS::new())?;
+    // Mount SysFS
+    let sys_dentry = fs.lookup(&FsPath::try_from("/sys")?)?;
+    let sysfs: Arc<SysFS> = SysFS::new();
+    sys_dentry.mount(sysfs.clone())?;
+    sysfs.init()?;
 
     println!("[kernel] rootfs is ready");
 

--- a/kernel/src/fs/sysfs/devices/mod.rs
+++ b/kernel/src/fs/sysfs/devices/mod.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use ostd::cpu::num_cpus;
+
+use super::{inode::KObject, SysFS};
+use crate::{fs::kernfs::DataProvider, prelude::*};
+
+/// Initializes the devices in the SysFS.
+pub fn init_devices(devices_kobj: Arc<KObject>) -> Result<()> {
+    let system_kobject = SysFS::create_kobject("system", 0o755, devices_kobj.clone())?;
+    let cpu_kobject = SysFS::create_kobject("cpu", 0o755, system_kobject.clone())?;
+    SysFS::create_file("online", 0o444, cpu_kobject.clone(), Box::new(CpuOnline))?;
+    Ok(())
+}
+
+/// The data provider for the CPU online file.
+/// It returns the online CPUs in the format of "0-<num_cpus>\n".
+/// It is read-only.
+struct CpuOnline;
+
+impl DataProvider for CpuOnline {
+    fn read_at(&self, writer: &mut ostd::mm::VmWriter, offset: usize) -> Result<usize> {
+        let data = format!("0-{}\n", num_cpus() - 1).as_bytes().to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, reader: &mut ostd::mm::VmReader, offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+}

--- a/kernel/src/fs/sysfs/inode.rs
+++ b/kernel/src/fs/sysfs/inode.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::{Arc, Weak};
+
+use ostd::sync::RwMutex;
+
+use crate::{
+    events::{Events, EventsFilter, Observer, Subject},
+    fs::{
+        kernfs::{DataProvider, KernfsNode, KernfsNodeFlag, PseudoFileSystem, PseudoNode},
+        utils::{Inode, InodeMode, InodeType},
+    },
+    prelude::*,
+};
+
+/// Action of KObject event.
+#[derive(Debug, Clone, Copy)]
+pub enum Action {
+    Add,
+    Remove,
+    Offline,
+    Online,
+    Change,
+    Move,
+}
+
+/// UEvent represents a KObject event, corresponding to a UEvent in Linux.
+///
+/// It is used to notify observers of KObject events.
+/// FIXME: Currently, the UEvent is a placeholder and does not contain any useful information.
+#[derive(Debug, Clone, Copy)]
+pub struct UEvent {
+    action: Action,
+}
+
+impl UEvent {
+    pub fn new(action: Action) -> Self {
+        UEvent { action }
+    }
+}
+
+impl Events for UEvent {}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UEventFilter;
+
+impl EventsFilter<UEvent> for UEventFilter {
+    fn filter(&self, event: &UEvent) -> bool {
+        false
+    }
+}
+
+/// The core struct of the sysfs, corresponding to the KObject and KSet in Linux.
+///
+/// Represents a kernel object in the kernel filesystem, combining features of
+/// Linux sysfs kobject and kset. This struct manages the lifecycle of a kernel object
+/// and its relationships within the kernfs hierarchy.
+pub struct KObject {
+    node: Arc<KernfsNode>,                  // The associated KernfsNode
+    subject: Subject<UEvent, UEventFilter>, // Subject for event notifications
+    parent: Option<Weak<KObject>>,          // Parent of
+    this: Weak<KObject>,                    // Weak reference to self
+}
+
+impl KObject {
+    pub fn get_node(&self) -> Arc<KernfsNode> {
+        self.node.clone()
+    }
+
+    pub fn notify_observers(&self, event: UEvent) {
+        debug!("KObject: {}, uevent: {:?}", self.name(), event);
+        self.subject.notify_observers(&event);
+    }
+
+    pub fn new_root(
+        name: &str,
+        fs: Weak<dyn PseudoFileSystem>,
+        root_ino: u64,
+        blk_size: usize,
+    ) -> Arc<Self> {
+        let node = KernfsNode::new_root(name, fs, root_ino, blk_size);
+        Arc::new_cyclic(|weak_kobject| Self {
+            node,
+            subject: Subject::new(),
+            parent: None,
+            this: weak_kobject.clone(),
+        })
+    }
+
+    /// Creates a new dir KObject.
+    pub fn new_dir(name: &str, mode: u16, parent: Option<Weak<KObject>>) -> Result<Arc<Self>> {
+        let mode = InodeMode::from_bits_truncate(mode);
+        let parent_node: Arc<dyn PseudoNode> = parent.as_ref().and_then(|p| p.upgrade()).unwrap();
+        let node = KernfsNode::new_dir(
+            name,
+            Some(mode),
+            KernfsNodeFlag::empty(),
+            Arc::downgrade(&parent_node),
+        )?;
+
+        let this = Arc::new_cyclic(|weak_kobject| Self {
+            node,
+            subject: Subject::new(),
+            parent: parent.clone(),
+            this: weak_kobject.clone(),
+        });
+        parent_node.insert(name.to_string(), this.clone())?;
+        if let Some(parent) = parent {
+            parent
+                .upgrade()
+                .unwrap()
+                .notify_observers(UEvent::new(Action::Add));
+        }
+        Ok(this)
+    }
+
+    /// Creates a new symlink KObject.
+    pub fn new_link(
+        name: &str,
+        parent: Option<Weak<KObject>>,
+        target: Arc<dyn PseudoNode>,
+    ) -> Result<Arc<Self>> {
+        let parent_node: Arc<dyn PseudoNode> = parent.as_ref().and_then(|p| p.upgrade()).unwrap();
+        let node = KernfsNode::new_symlink(
+            name,
+            KernfsNodeFlag::empty(),
+            target,
+            Arc::downgrade(&parent_node),
+        )?;
+
+        let this = Arc::new_cyclic(|weak_kobject| Self {
+            node,
+            subject: Subject::new(),
+            parent: parent.clone(),
+            this: weak_kobject.clone(),
+        });
+        parent_node.insert(name.to_string(), this.clone())?;
+        if let Some(parent) = parent {
+            parent
+                .upgrade()
+                .unwrap()
+                .notify_observers(UEvent::new(Action::Add));
+        }
+
+        Ok(this)
+    }
+
+    /// Creates a new Attribute KObject.
+    pub fn new_attr(name: &str, mode: u16, parent: Option<Weak<KObject>>) -> Result<Arc<Self>> {
+        let mode = InodeMode::from_bits_truncate(mode);
+        let parent_node: Arc<dyn PseudoNode> = parent.as_ref().and_then(|p| p.upgrade()).unwrap();
+        let node = KernfsNode::new_attr(
+            name,
+            Some(mode),
+            KernfsNodeFlag::empty(),
+            Arc::downgrade(&parent_node),
+        )?;
+
+        let this = Arc::new_cyclic(|weak_kobject| Self {
+            node,
+            subject: Subject::new(),
+            parent: parent.clone(),
+            this: weak_kobject.clone(),
+        });
+        parent_node.insert(name.to_string(), this.clone())?;
+        if let Some(parent) = parent {
+            parent
+                .upgrade()
+                .unwrap()
+                .notify_observers(UEvent::new(Action::Add));
+        }
+
+        Ok(this)
+    }
+}
+
+impl PseudoNode for KObject {
+    fn name(&self) -> String {
+        self.node.name()
+    }
+
+    fn parent(&self) -> Option<Arc<dyn PseudoNode>> {
+        self.parent
+            .as_ref()
+            .and_then(|p| p.upgrade())
+            .map(|arc| arc as Arc<dyn PseudoNode>)
+    }
+
+    fn pseudo_fs(&self) -> Arc<dyn PseudoFileSystem> {
+        self.node.pseudo_fs()
+    }
+
+    fn generate_ino(&self) -> u64 {
+        self.node.generate_ino()
+    }
+
+    fn set_data(&self, data: Box<dyn DataProvider>) -> Result<()> {
+        self.node.set_data(data)
+    }
+
+    fn remove(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        let child = self.node.remove(name)?;
+        self.notify_observers(UEvent::new(Action::Remove));
+        Ok(child)
+    }
+
+    fn insert(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        self.node.insert(name, node)?;
+        self.notify_observers(UEvent::new(Action::Add));
+        Ok(())
+    }
+}
+
+impl Clone for KObject {
+    fn clone(&self) -> Self {
+        Self {
+            node: self.node.clone(),
+            subject: Subject::new(),
+            parent: self.parent.clone(),
+            this: self.this.clone(),
+        }
+    }
+}
+
+impl KObject {
+    pub fn this(&self) -> Arc<KObject> {
+        self.this.upgrade().unwrap()
+    }
+
+    pub fn this_weak(&self) -> Weak<KObject> {
+        self.this.clone()
+    }
+
+    pub fn register_observer(&self, observer: Weak<dyn Observer<UEvent>>, mask: UEventFilter) {
+        self.subject.register_observer(observer, mask);
+    }
+
+    pub fn unregister_observer(
+        &self,
+        observer: &Weak<dyn Observer<UEvent>>,
+    ) -> Option<Weak<dyn Observer<UEvent>>> {
+        self.subject.unregister_observer(observer)
+    }
+}
+
+impl Drop for KObject {
+    fn drop(&mut self) {
+        if let Some(parent) = &self.parent {
+            if let Some(parent) = parent.upgrade() {
+                parent.remove(&self.name());
+            }
+        }
+    }
+}
+
+impl Inode for KObject {
+    fn size(&self) -> usize {
+        self.node.size()
+    }
+
+    fn resize(&self, new_size: usize) -> Result<()> {
+        self.node.resize(new_size)
+    }
+
+    fn metadata(&self) -> crate::fs::utils::Metadata {
+        self.node.metadata()
+    }
+
+    fn ino(&self) -> u64 {
+        self.node.ino()
+    }
+
+    fn type_(&self) -> crate::fs::utils::InodeType {
+        self.node.type_()
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        self.node.mode()
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.node.set_mode(mode)
+    }
+
+    fn owner(&self) -> Result<crate::process::Uid> {
+        self.node.owner()
+    }
+
+    fn set_owner(&self, uid: crate::process::Uid) -> Result<()> {
+        self.node.set_owner(uid)
+    }
+
+    fn group(&self) -> Result<crate::process::Gid> {
+        self.node.group()
+    }
+
+    fn set_group(&self, gid: crate::process::Gid) -> Result<()> {
+        self.node.set_group(gid)
+    }
+
+    fn atime(&self) -> core::time::Duration {
+        self.node.atime()
+    }
+
+    fn set_atime(&self, time: core::time::Duration) {
+        self.node.set_atime(time)
+    }
+
+    fn mtime(&self) -> core::time::Duration {
+        self.node.mtime()
+    }
+
+    fn set_mtime(&self, time: core::time::Duration) {
+        self.node.set_mtime(time)
+    }
+
+    fn ctime(&self) -> core::time::Duration {
+        self.node.ctime()
+    }
+
+    fn set_ctime(&self, time: core::time::Duration) {
+        self.node.set_ctime(time)
+    }
+
+    fn fs(&self) -> Arc<dyn crate::fs::utils::FileSystem> {
+        self.node.fs()
+    }
+
+    fn page_cache(&self) -> Option<crate::vm::vmo::Vmo<aster_rights::Full>> {
+        self.node.page_cache()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        self.node.read_at(offset, writer)
+    }
+
+    fn read_direct_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        self.node.read_direct_at(offset, writer)
+    }
+
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let size = self.node.write_at(offset, reader)?;
+        self.notify_observers(UEvent::new(Action::Change));
+        Ok(size)
+    }
+
+    fn write_direct_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let size = self.node.write_direct_at(offset, reader)?;
+        self.notify_observers(UEvent::new(Action::Change));
+        Ok(size)
+    }
+
+    fn create(
+        &self,
+        name: &str,
+        type_: crate::fs::utils::InodeType,
+        mode: InodeMode,
+    ) -> Result<Arc<dyn Inode>> {
+        if self.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let new_node = match type_ {
+            InodeType::Dir => KObject::new_dir(name, mode.bits(), Some(self.this_weak()))?,
+            InodeType::File => KObject::new_attr(name, mode.bits(), Some(self.this_weak()))?,
+            _ => return_errno!(Errno::EINVAL),
+        };
+        Ok(new_node)
+    }
+
+    fn mknod(
+        &self,
+        name: &str,
+        mode: InodeMode,
+        type_: crate::fs::utils::MknodType,
+    ) -> Result<Arc<dyn Inode>> {
+        Err(Error::new(Errno::ENOTDIR))
+    }
+
+    fn as_device(&self) -> Option<Arc<dyn crate::fs::device::Device>> {
+        self.node.as_device()
+    }
+
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn crate::fs::utils::DirentVisitor,
+    ) -> Result<usize> {
+        self.node.readdir_at(offset, visitor)
+    }
+
+    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
+        if old.type_() != InodeType::File && old.type_() != InodeType::Dir {
+            return_errno!(Errno::EPERM);
+        }
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let target = old
+            .downcast_ref::<KObject>()
+            .ok_or(Error::new(Errno::EXDEV))?
+            .this();
+        let new_node = KObject::new_link(name, Some(self.this_weak()), target)?;
+        Ok(())
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        self.rmdir(name)
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        let child = self.remove(name)?;
+        Ok(())
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        self.node.lookup(name)
+    }
+
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+        self.node.rename(old_name, target, new_name)
+    }
+
+    fn read_link(&self) -> Result<String> {
+        self.node.read_link()
+    }
+
+    fn write_link(&self, target: &str) -> Result<()> {
+        self.node.write_link(target)
+    }
+
+    fn ioctl(&self, cmd: crate::fs::utils::IoctlCmd, arg: usize) -> Result<i32> {
+        self.node.ioctl(cmd, arg)
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn sync_data(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn fallocate(
+        &self,
+        mode: crate::fs::utils::FallocMode,
+        offset: usize,
+        len: usize,
+    ) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP);
+    }
+
+    fn poll(
+        &self,
+        mask: crate::events::IoEvents,
+        _poller: Option<&mut crate::process::signal::Poller>,
+    ) -> crate::events::IoEvents {
+        let events = crate::events::IoEvents::IN | crate::events::IoEvents::OUT;
+        events & mask
+    }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        true
+    }
+
+    fn is_seekable(&self) -> bool {
+        true
+    }
+
+    fn extension(&self) -> Option<&crate::fs::utils::Extension> {
+        None
+    }
+}

--- a/kernel/src/fs/sysfs/inode.rs
+++ b/kernel/src/fs/sysfs/inode.rs
@@ -7,7 +7,7 @@ use ostd::sync::RwMutex;
 use crate::{
     events::{Events, EventsFilter, Observer, Subject},
     fs::{
-        kernfs::{DataProvider, KernfsNode, KernfsNodeFlag, PseudoFileSystem, PseudoNode},
+        kernfs::{DataProvider, KernfsNode, PseudoFileSystem, PseudoNode},
         utils::{Inode, InodeMode, InodeType},
     },
     prelude::*,
@@ -94,7 +94,6 @@ impl KObject {
         let node = KernfsNode::new_dir(
             name,
             Some(mode),
-            KernfsNodeFlag::empty(),
             Arc::downgrade(&parent_node),
         )?;
 
@@ -123,7 +122,6 @@ impl KObject {
         let parent_node: Arc<dyn PseudoNode> = parent.as_ref().and_then(|p| p.upgrade()).unwrap();
         let node = KernfsNode::new_symlink(
             name,
-            KernfsNodeFlag::empty(),
             target,
             Arc::downgrade(&parent_node),
         )?;
@@ -152,7 +150,6 @@ impl KObject {
         let node = KernfsNode::new_attr(
             name,
             Some(mode),
-            KernfsNodeFlag::empty(),
             Arc::downgrade(&parent_node),
         )?;
 
@@ -458,7 +455,7 @@ impl Inode for KObject {
     fn poll(
         &self,
         mask: crate::events::IoEvents,
-        _poller: Option<&mut crate::process::signal::Poller>,
+        _poller: Option<&mut crate::process::signal::PollHandle>,
     ) -> crate::events::IoEvents {
         let events = crate::events::IoEvents::IN | crate::events::IoEvents::OUT;
         events & mask

--- a/kernel/src/fs/sysfs/kernel/mod.rs
+++ b/kernel/src/fs/sysfs/kernel/mod.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::boxed::Box;
+
+use super::{inode::KObject, SysFS};
+use crate::{fs::kernfs::DataProvider, prelude::*};
+
+/// Initializes the kernel-related files in the SysFS.
+pub fn init_kernel(kernel_kobj: Arc<KObject>) -> Result<()> {
+    let mm_kobject = SysFS::create_kobject("mm", 0o755, kernel_kobj.clone())?;
+    let transparent_hugepage_kobject =
+        SysFS::create_kobject("transparent_hugepage", 0o755, mm_kobject.clone())?;
+    SysFS::create_file(
+        "hpage_pmd_size",
+        0o444,
+        transparent_hugepage_kobject.clone(),
+        Box::new(HugepagePmdSize),
+    )?;
+    Ok(())
+}
+
+// Actually, we don't support transparent_hugepage now, so we just return 0.
+pub struct HugepagePmdSize;
+
+impl DataProvider for HugepagePmdSize {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+        let data = "0\n".as_bytes().to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "HugepagePmdSize is read-only");
+    }
+}

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+#![allow(unused)]
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use devices::init_devices;
+use inode::KObject;
+use kernel::init_kernel;
+use spin::Once;
+
+use crate::{
+    fs::{
+        kernfs::{DataProvider, PseudoFileSystem, PseudoNode},
+        utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+    },
+    prelude::*,
+};
+
+mod devices;
+pub mod inode;
+mod kernel;
+
+/// SysFS filesystem.
+/// Magic number.
+const SYSFS_MAGIC: u64 = 0x62656572;
+/// Root Inode ID.
+const SYSFS_ROOT_INO: u64 = 1;
+/// Block size.
+const BLOCK_SIZE: usize = 1024;
+
+pub struct SysFS {
+    sb: SuperBlock,
+    root: Arc<dyn Inode>,
+    inode_allocator: AtomicU64,
+    this: Weak<Self>,
+}
+
+impl SysFS {
+    pub fn new() -> Arc<Self> {
+        Arc::new_cyclic(|weak_fs| Self {
+            sb: SuperBlock::new(SYSFS_MAGIC, BLOCK_SIZE, NAME_MAX),
+            root: SysfsRoot::new_inode(weak_fs.clone()),
+            inode_allocator: AtomicU64::new(SYSFS_ROOT_INO + 1),
+            this: weak_fs.clone(),
+        })
+    }
+
+    pub fn create_file(
+        name: &str,
+        mode: u16,
+        parent: Arc<KObject>,
+        attribute: Box<dyn DataProvider>,
+    ) -> Result<Arc<KObject>> {
+        let attr = KObject::new_attr(name, mode, Some(parent.this_weak()))?;
+        attr.set_data(attribute).unwrap();
+        Ok(attr)
+    }
+
+    pub fn create_kobject(name: &str, mode: u16, parent: Arc<KObject>) -> Result<Arc<KObject>> {
+        KObject::new_dir(name, mode, Some(parent.this_weak()))
+    }
+
+    pub fn create_symlink(
+        name: &str,
+        parent: Arc<KObject>,
+        target: Arc<dyn PseudoNode>,
+    ) -> Result<Arc<KObject>> {
+        KObject::new_link(name, Some(parent.this_weak()), target)
+    }
+}
+
+impl PseudoFileSystem for SysFS {
+    fn alloc_id(&self) -> u64 {
+        self.inode_allocator.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn init(&self) -> Result<()> {
+        let root = self.root_inode().downcast_ref::<KObject>().unwrap().this();
+        let kernel_kobj = SysFS::create_kobject("kernel", 0o755, root.clone())?;
+        init_kernel(kernel_kobj)?;
+        let devices_kobj = SysFS::create_kobject("devices", 0o755, root.clone())?;
+        init_devices(devices_kobj)?;
+        let fs_kobj = SysFS::create_kobject("fs", 0o755, root.clone())?;
+        SysFS::create_kobject("cgroup", 0o755, fs_kobj.clone())?;
+        Ok(())
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.this.upgrade().unwrap()
+    }
+}
+
+impl FileSystem for SysFS {
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root.clone()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.sb.clone()
+    }
+
+    fn flags(&self) -> FsFlags {
+        FsFlags::empty()
+    }
+}
+
+/// Represents the inode at `/sys`.
+/// Root directory of the sysfs.
+pub struct SysfsRoot;
+
+impl SysfsRoot {
+    pub fn new_inode(fs: Weak<SysFS>) -> Arc<dyn Inode> {
+        KObject::new_root("sysfs", fs, SYSFS_ROOT_INO, BLOCK_SIZE)
+    }
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ INITRAMFS_EMPTY_DIRS := \
 	$(INITRAMFS)/tmp \
 	$(INITRAMFS)/opt \
 	$(INITRAMFS)/proc \
+	$(INITRAMFS)/sys \
 	$(INITRAMFS)/dev \
 	$(INITRAMFS)/ext2 \
 	$(INITRAMFS)/exfat


### PR DESCRIPTION
This pull request is an implementation of #1171, which introduces Kernfs as a general design of pseudo filesystem. Based on Kernfs, it also implements SysFS, and integrates it into the kernel. 

` /sys/devices/system/cpu/online` and `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size` are exported under `/sys` to align with the demand of #703.
* [`kernel/src/fs/sysfs/kernel/mod.rs`](diffhunk://#diff-f0e73c2b7c916d6f35b1ccf314ecdab1dac52877b4a2be7b64d271d7a238a27bR1-R38): Added kernel-related files in SysFS, including `hpage_pmd_size`, which currently returns 0 as transparent hugepages are not supported.
* [`kernel/src/fs/sysfs/devices/mod.rs`](diffhunk://#diff-7d65192d5f1f8f5242c9365085215f1c2028457125f6ccf7080ff93867ddcfb3R1-R37): Added device-related files in SysFS, such as `cpu/online`, which returns the number of online CPUs.