### PR TITLE
Change idle task to lowest priority

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -37,6 +37,7 @@ use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot,
     cpu::PinCurrentCpu,
+    task::Priority,
 };
 use process::Process;
 
@@ -90,7 +91,7 @@ pub fn main() {
     ostd::boot::smp::register_ap_entry(ap_init);
 
     // Spawn the first kernel thread on BSP.
-    Thread::spawn_kernel_thread(ThreadOptions::new(init_thread));
+    Thread::spawn_kernel_thread(ThreadOptions::new(init_thread).priority(Priority::lowest()));
     // Spawning functions in the bootstrap context will not return.
     unreachable!()
 }
@@ -122,7 +123,11 @@ fn ap_init() -> ! {
     let cpu_id = preempt_guard.current_cpu();
     drop(preempt_guard);
 
-    Thread::spawn_kernel_thread(ThreadOptions::new(ap_idle_thread).cpu_affinity(cpu_id.into()));
+    Thread::spawn_kernel_thread(
+        ThreadOptions::new(ap_idle_thread)
+            .cpu_affinity(cpu_id.into())
+            .priority(Priority::lowest()),
+    );
     // Spawning functions in the bootstrap context will not return.
     unreachable!()
 }

--- a/ostd/src/task/scheduler/info.rs
+++ b/ostd/src/task/scheduler/info.rs
@@ -35,39 +35,45 @@ pub const REAL_TIME_TASK_PRIORITY: u16 = 100;
 pub struct Priority(u16);
 
 impl Priority {
+    const LOWEST: u16 = 139;
+    const LOW: u16 = 110;
+    const NORMAL: u16 = 100;
+    const HIGH: u16 = 10;
+    const HIGHEST: u16 = 0;
+
     /// Creates a new `Priority` with the specified value.
     ///
     /// # Panics
     ///
     /// Panics if the `val` is greater than 139.
     pub const fn new(val: u16) -> Self {
-        assert!(val <= 139);
+        assert!(val <= Self::LOWEST);
         Self(val)
     }
 
     /// Returns a `Priority` representing the lowest priority (139).
     pub const fn lowest() -> Self {
-        Self::new(139)
+        Self::new(Self::LOWEST)
     }
 
     /// Returns a `Priority` representing a low priority.
     pub const fn low() -> Self {
-        Self::new(110)
+        Self::new(Self::LOW)
     }
 
     /// Returns a `Priority` representing a normal priority.
     pub const fn normal() -> Self {
-        Self::new(100)
+        Self::new(Self::NORMAL)
     }
 
     /// Returns a `Priority` representing a high priority.
     pub const fn high() -> Self {
-        Self::new(10)
+        Self::new(Self::HIGH)
     }
 
     /// Returns a `Priority` representing the highest priority (0).
     pub const fn highest() -> Self {
-        Self::new(0)
+        Self::new(Self::HIGHEST)
     }
 
     /// Sets the value of the `Priority`.


### PR DESCRIPTION
The idle task is used to wait for the init process to become a zombie. It should have the lowest priority to avoid consuming CPU time. This will improve the latency of semaphore (`lat_sem`) from 0.4996 us to 0.4759 us.