### PR TITLE
Fix #1244: unwrap in clock_gettime syscall

### DIFF
--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -138,7 +138,9 @@ pub fn read_clock(clockid: clockid_t, ctx: &Context) -> Result<Duration> {
             DynamicClockIdInfo::Tid(tid, clock_type) => {
                 let thread = thread_table::get_thread(tid)
                     .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
-                let posix_thread = thread.as_posix_thread().unwrap();
+                let posix_thread = thread
+                    .as_posix_thread()
+                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
                 match clock_type {
                     DynamicClockType::Profiling => Ok(posix_thread.prof_clock().read_time()),
                     DynamicClockType::Virtual => {


### PR DESCRIPTION
Fix for #1244 

From what I understand, the thread returned by `thread_table::get_thread(tid)` can be a `KernelThread` because tid is fully controlled and the downcast in the call to `to_posix_thread()` fails.
The current behavior on my linux install is to just return `EINVAL`.