### PR TITLE
Eliminate an additional `current!()` operation in user space pagefault handling

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -21,7 +21,7 @@ use self::{
     vm_mapping::VmMapping,
 };
 use super::page_fault_handler::PageFaultHandler;
-use crate::{prelude::*, thread::exception::handle_page_fault, vm::perms::VmPerms};
+use crate::{prelude::*, thread::exception::handle_page_fault_from_vm_space, vm::perms::VmPerms};
 
 /// Virtual Memory Address Regions (VMARs) are a type of capability that manages
 /// user address spaces.
@@ -228,7 +228,7 @@ impl Vmar_ {
             free_regions,
         };
         let vm_space = VmSpace::new();
-        vm_space.register_page_fault_handler(handle_page_fault);
+        vm_space.register_page_fault_handler(handle_page_fault_from_vm_space);
         Vmar_::new(vmar_inner, Arc::new(vm_space), 0, ROOT_VMAR_CAP_ADDR, None)
     }
 

--- a/test/benchmark/lmbench-mmap-latency/config.json
+++ b/test/benchmark/lmbench-mmap-latency/config.json
@@ -1,7 +1,7 @@
 {
     "alert_threshold": "125%",
     "alert_tool": "customSmallerIsBetter",
-    "search_pattern": "268.435456",
+    "search_pattern": "4.194304",
     "result_index": "2",
     "description": "The latency of mmap on a single processor."
 }

--- a/test/benchmark/lmbench-mmap-latency/run.sh
+++ b/test/benchmark/lmbench-mmap-latency/run.sh
@@ -6,5 +6,5 @@ set -e
 
 echo "*** Running the LMbench mmap latency test ***"
 
-dd if=/dev/zero of=/ext2/test_file bs=1M count=256
-/benchmark/bin/lmbench/lat_mmap 256m /ext2/test_file
+dd if=/dev/zero of=/ext2/test_file bs=1M count=4
+/benchmark/bin/lmbench/lat_mmap 4m /ext2/test_file

--- a/test/benchmark/lmbench-pagefault/run.sh
+++ b/test/benchmark/lmbench-pagefault/run.sh
@@ -6,5 +6,5 @@ set -e
 
 echo "*** Running the LMbench page fault latency test ***"
 
-dd if=/dev/zero of=/ext2/test_file bs=1M count=256
+dd if=/dev/zero of=/ext2/test_file bs=1M count=4
 /benchmark/bin/lmbench/lat_pagefault -P 1 /ext2/test_file


### PR DESCRIPTION
`current!()`  operation costs a lot and we can avoid to invoke it in the page fault handling from user space execution loop.

The second commit adjusts the parameters of the mmap and page fault tests, as it was found that Linux performs significantly better when using larger files for testing. My preliminary assumption is that this is due to the introduction of the `folio` structure in Linux, which allows for batch processing of a certain number of pages.