### PR TITLE
Fix the page fault handling performance regression

### DIFF
--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -350,12 +350,13 @@ impl CursorMut<'_, '_> {
     /// This method will bring the cursor to the next slot after the modification.
     pub fn map(&mut self, frame: Frame, prop: PageProperty) {
         let start_va = self.virt_addr();
-        let end_va = start_va + frame.size();
         // SAFETY: It is safe to map untyped memory into the userspace.
         let old = unsafe { self.pt_cursor.map(frame.into(), prop) };
 
-        self.issue_tlb_flush(TlbFlushOp::Range(start_va..end_va), old);
-        self.dispatch_tlb_flush();
+        if old.is_some() {
+            self.issue_tlb_flush(TlbFlushOp::Address(start_va), old);
+            self.dispatch_tlb_flush();
+        }
     }
 
     /// Clear the mapping starting from the current slot.


### PR DESCRIPTION
#1158 introduces some performance regression on the lmbench page fault benchmark.

On the `INTEL(R) XEON(R) PLATINUM 8575C` CI machine, for the current main branch the result is:

```
[
  {
    "name": "Average page fault latency on Linux",
    "unit": "µs",
    "value": "0.1110",
    "extra": "linux_result"
  },
  {
    "name": "Average page fault latency on Asterinas",
    "unit": "µs",
    "value": "0.6302",
    "extra": "aster_result"
  }
]
```

After the first commit:

```
[
  {
    "name": "Average page fault latency on Linux",
    "unit": "µs",
    "value": "0.1116",
    "extra": "linux_result"
  },
  {
    "name": "Average page fault latency on Asterinas",
    "unit": "µs",
    "value": "0.5072",
    "extra": "aster_result"
  }
]
```

After the second commit:

```
[
  {
    "name": "Average page fault latency on Linux",
    "unit": "µs",
    "value": "0.1127",
    "extra": "linux_result"
  },
  {
    "name": "Average page fault latency on Asterinas",
    "unit": "µs",
    "value": "0.4647",
    "extra": "aster_result"
  }
]
```

After the third:

```
[
  {
    "name": "Average page fault latency on Linux",
    "unit": "µs",
    "value": "0.1118",
    "extra": "linux_result"
  },
  {
    "name": "Average page fault latency on Asterinas",
    "unit": "µs",
    "value": "0.0998",
    "extra": "aster_result"
  }
]
```

We are even better.