### PR TITLE
Add SQLite benchmarks CI

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -54,6 +54,25 @@ jobs:
           - lmbench/ext2_create_delete_files_0k_ops
           - lmbench/ext2_create_delete_files_10k_ops
           - lmbench/ext2_copy_files_bw
+          # File-SQLlite benchmarks
+          - sqlite/ext2_deletes_between
+          - sqlite/ext2_deletes_individual
+          - sqlite/ext2_refill_replace
+          - sqlite/ext2_selects_ipk
+          - sqlite/ext2_selects_text_pk
+          - sqlite/ext2_total
+          - sqlite/ext2_updates_between
+          - sqlite/ext2_updates_big_one
+          - sqlite/ext2_updates_individual
+          - sqlite/ext2_vacuum
+          - sqlite/ramfs_deletes_between
+          - sqlite/ramfs_deletes_individual
+          - sqlite/ramfs_refill_replace
+          - sqlite/ramfs_total
+          - sqlite/ramfs_updates_between
+          - sqlite/ramfs_updates_big_one
+          - sqlite/ramfs_updates_individual
+          - sqlite/ramfs_vacuum
           # Network-related benchmark
           - lmbench/tcp_loopback_bw
           - lmbench/tcp_loopback_lat

--- a/.typos.toml
+++ b/.typos.toml
@@ -25,4 +25,9 @@ extend-exclude = [
     "test/build/initramfs/opt/syscall_test/blocklists/pty_test",
     "test/syscall_test/blocklists/sync_test",
     "test/build/initramfs/opt/syscall_test/blocklists/sync_test",
+    
+    "test/benchmark/sqlite/ext2_deletes_between/config.json",
+    "test/benchmark/sqlite/ext2_deletes_individual/config.json",
+    "test/benchmark/sqlite/ramfs_deletes_between/config.json",
+    "test/benchmark/sqlite/ramfs_deletes_individual/config.json",
 ]

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -82,6 +82,7 @@ To add a new benchmark to the Asternias Continuous Integration (CI) system, foll
         "alert_tool": "customSmallerIsBetter",
         "search_pattern": "Simple syscall:",
         "result_index": "3",
+        "result_substring": "null",
         "description": "lat_syscall null",
         "title": "[Process] The cost of getpid",
         "show_in_overview": "false"
@@ -92,6 +93,7 @@ To add a new benchmark to the Asternias Continuous Integration (CI) system, foll
     - `alert_tool`: Choose the validation tool to use. The available options are `customBiggerIsBetter` and `customSmallerIsBetter`. Refer to [this](https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#tool-required) for more details. If using `customBiggerIsBetter`, the alert will be triggered when `prev.value / current.value` exceeds the threshold. If using `customSmallerIsBetter`, the alert will be triggered when `current.value / prev.value` exceeds the threshold.
     - `search_pattern`: Define a regular expression to extract benchmark results from the output using `awk`. This regular expression is designed to match specific patterns in the output, effectively isolating the benchmark results and producing a set of fragments.
     - `result_index`: Specify the index of the result in the extracted output. This field is aligned with `awk`'s action.
+    - `result_substring`: Specify the substring in the result as the final output. `null` indicates that no substring is specified. The format is `{start_index},{length}` where `start_index` begins at 1.
     - `description`: Provide a brief description of the benchmark.
     - `title`: Set the title of the benchmark.
     - `show_in_overview`: Default is true. Set to `false` to avoid displaying the benchmark in the overview results.

--- a/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/config.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "^0k",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_fs -s 0k /ext2",
     "title": "[Ext2] The cost of creating/deleting small files (0KB)"
 }

--- a/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/config.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "10k",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_fs -s 10K /ext2",
     "title": "[Ext2] The cost of creating/deleting small files (10KB)"
 }

--- a/test/benchmark/lmbench/fifo_lat/config.json
+++ b/test/benchmark/lmbench/fifo_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Fifo latency",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_fifo",
     "title": "[FIFO] The cost of write+read (1B)"
 }

--- a/test/benchmark/lmbench/mem_copy_bw/config.json
+++ b/test/benchmark/lmbench/mem_copy_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "536.87",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_mem fcp",
     "title": "[Memory] The bandwidth of copying integers"
 }

--- a/test/benchmark/lmbench/mem_mmap_bw/config.json
+++ b/test/benchmark/lmbench/mem_mmap_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "268.44",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_mmap",
     "title": "[Memory] The bandwidth of mmap"
 }

--- a/test/benchmark/lmbench/mem_mmap_lat/config.json
+++ b/test/benchmark/lmbench/mem_mmap_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "4.194304",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_mmap",
     "title": "[Memory] The cost of mmap+unmap"
 }

--- a/test/benchmark/lmbench/mem_pagefault_lat/config.json
+++ b/test/benchmark/lmbench/mem_pagefault_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Pagefaults on ",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_pagefault",
     "title": "[Memory] The cost of page fault handling"
 }

--- a/test/benchmark/lmbench/mem_read_bw/config.json
+++ b/test/benchmark/lmbench/mem_read_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "536.87",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_mem frd",
     "title": "[Memory] The bandwidth of reading integers"
 }

--- a/test/benchmark/lmbench/mem_write_bw/config.json
+++ b/test/benchmark/lmbench/mem_write_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "536.87",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_mem fwr",
     "title": "[Memory] The bandwidth of writing integers"
 }

--- a/test/benchmark/lmbench/pipe_bw/config.json
+++ b/test/benchmark/lmbench/pipe_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "Pipe bandwidth",
     "result_index": "3",
+    "result_substring": "null",
     "description": "bw_pipe",
     "title": "[Pipes] The bandwidth"
 }

--- a/test/benchmark/lmbench/pipe_lat/config.json
+++ b/test/benchmark/lmbench/pipe_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Pipe latency",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_pipe",
     "title": "[Pipes] The cost of write+read (1B)"
 }

--- a/test/benchmark/lmbench/process_ctx_lat/config.json
+++ b/test/benchmark/lmbench/process_ctx_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "18 ",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_ctx 2",
     "title": "[Process] The cost of context switching"
 }

--- a/test/benchmark/lmbench/process_exec_lat/config.json
+++ b/test/benchmark/lmbench/process_exec_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Process fork\\+execve",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_proc exec",
     "title": "[Process] The cost of fork+exec+exit"
 }

--- a/test/benchmark/lmbench/process_fork_lat/config.json
+++ b/test/benchmark/lmbench/process_fork_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Process fork",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_proc fork",
     "title": "[Process] The cost of fork+exit"
 }

--- a/test/benchmark/lmbench/process_getppid_lat/config.json
+++ b/test/benchmark/lmbench/process_getppid_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple syscall:",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall null",
     "title": "[Process] The cost of getppid"
 }

--- a/test/benchmark/lmbench/process_shell_lat/config.json
+++ b/test/benchmark/lmbench/process_shell_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Process fork\\+\\/bin\\/sh",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_proc shell",
     "title": "[Process] The cost of fork+exec+shell+exit"
 }

--- a/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/config.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "^0k",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_fs -s 0k",
     "title": "[Ramfs] The cost of creating/deleting small files (0KB)"
 }

--- a/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/config.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "10k",
     "result_index": "2",
+    "result_substring": "null",
     "description": "lat_fs -s 10K",
     "title": "[Ramfs] The cost of creating/deleting small files (10KB)"
 }

--- a/test/benchmark/lmbench/semaphore_lat/config.json
+++ b/test/benchmark/lmbench/semaphore_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Semaphore latency:",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_sem",
     "title": "[Semaphores] The cost of semop"
 }

--- a/test/benchmark/lmbench/signal_catch_lat/config.json
+++ b/test/benchmark/lmbench/signal_catch_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Signal handler overhead:",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_sig catch",
     "title": "[Signals] The cost of catching a signal"
 }

--- a/test/benchmark/lmbench/signal_install_lat/config.json
+++ b/test/benchmark/lmbench/signal_install_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Signal handler installation:",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_sig install",
     "title": "[Signals] The cost of installing a signal handler"
 }

--- a/test/benchmark/lmbench/signal_prot_lat/config.json
+++ b/test/benchmark/lmbench/signal_prot_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Protection fault:",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_sig prot",
     "title": "[Signals] The cost of catching a segfault"
 }

--- a/test/benchmark/lmbench/tcp_loopback_bw/config.json
+++ b/test/benchmark/lmbench/tcp_loopback_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "0.004096 ",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_tcp -l",
     "title": "[TCP sockets] The bandwidth (localhost)"
 }

--- a/test/benchmark/lmbench/tcp_loopback_connect_lat/config.json
+++ b/test/benchmark/lmbench/tcp_loopback_connect_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "TCP\\/IP connection cost to 127.0.0.1:",
     "result_index": "6",
+    "result_substring": "null",
     "description": "lat_connect",
     "title": "[TCP sockets] The latency of connect"
 }

--- a/test/benchmark/lmbench/tcp_loopback_http_bw/config.json
+++ b/test/benchmark/lmbench/tcp_loopback_http_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "Avg xfer: ",
     "result_index": "8",
+    "result_substring": "null",
     "description": "bw_http",
     "title": "[HTTP] The bandwidth"
 }

--- a/test/benchmark/lmbench/tcp_loopback_lat/config.json
+++ b/test/benchmark/lmbench/tcp_loopback_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "TCP latency using 127.0.0.1:",
     "result_index": "5",
+    "result_substring": "null",
     "description": "lat_tcp",
     "title": "[TCP sockets] The latency of write+read"
 }

--- a/test/benchmark/lmbench/tcp_loopback_select_lat/config.json
+++ b/test/benchmark/lmbench/tcp_loopback_select_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Select on 200 tcp fd's:",
     "result_index": "6",
+    "result_substring": "null",
     "description": "lat_select",
     "title": "[Network] The cost of select (TCP fds)"
 }

--- a/test/benchmark/lmbench/udp_loopback_lat/config.json
+++ b/test/benchmark/lmbench/udp_loopback_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "UDP latency using 127.0.0.1:",
     "result_index": "5",
+    "result_substring": "null",
     "description": "lat_udp",
     "title": "[UDP sockets] The latency of write+read"
 }

--- a/test/benchmark/lmbench/unix_bw/config.json
+++ b/test/benchmark/lmbench/unix_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "sock stream bandwidth",
     "result_index": "5",
+    "result_substring": "null",
     "description": "bw_unix",
     "title": "[Unix sockets] The bandwidth"
 }

--- a/test/benchmark/lmbench/unix_connect_lat/config.json
+++ b/test/benchmark/lmbench/unix_connect_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "UNIX connection cost:",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_connect",
     "title": "[Unix sockets] The latency of connect"
 }

--- a/test/benchmark/lmbench/unix_lat/config.json
+++ b/test/benchmark/lmbench/unix_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "sock stream latency",
     "result_index": "5",
+    "result_substring": "null",
     "description": "lat_unix",
     "title": "[Unix sockets] The latency of write+read"
 }

--- a/test/benchmark/lmbench/vfs_fcntl_lat/config.json
+++ b/test/benchmark/lmbench/vfs_fcntl_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Fcntl lock latency:",
     "result_index": "4",
+    "result_substring": "null",
     "description": "lat_fcntl",
     "title": "[VFS] The cost of record locking/unlocking via fcntl"
 }

--- a/test/benchmark/lmbench/vfs_fstat_lat/config.json
+++ b/test/benchmark/lmbench/vfs_fstat_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple fstat",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall fstat",
     "title": "[VFS] The cost of fstat"
 }

--- a/test/benchmark/lmbench/vfs_open_lat/config.json
+++ b/test/benchmark/lmbench/vfs_open_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple open\\/close",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall open",
     "title": "[VFS] The cost of open+close"
 }

--- a/test/benchmark/lmbench/vfs_read_lat/config.json
+++ b/test/benchmark/lmbench/vfs_read_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple read:",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall read",
     "title": "[VFS] The cost of read (/dev/zero)"
 }

--- a/test/benchmark/lmbench/vfs_read_pagecache_bw/config.json
+++ b/test/benchmark/lmbench/vfs_read_pagecache_bw/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customBiggerIsBetter",
     "search_pattern": "536.87",
     "result_index": "2",
+    "result_substring": "null",
     "description": "bw_file_rd",
     "title": "[VFS] The bandwidth of file reads via page cache"
 }

--- a/test/benchmark/lmbench/vfs_select_lat/config.json
+++ b/test/benchmark/lmbench/vfs_select_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Select on ",
     "result_index": "5",
+    "result_substring": "null",
     "description": "lat_select",
     "title": "[Network] The cost of select (file fds)"
 }

--- a/test/benchmark/lmbench/vfs_stat_lat/config.json
+++ b/test/benchmark/lmbench/vfs_stat_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple stat",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall stat",
     "title": "[VFS] The cost of stat"
 }

--- a/test/benchmark/lmbench/vfs_write_lat/config.json
+++ b/test/benchmark/lmbench/vfs_write_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "Simple write:",
     "result_index": "3",
+    "result_substring": "null",
     "description": "lat_syscall write",
     "title": "[VFS] The cost of write (/dev/null)"
 }

--- a/test/benchmark/sqlite/ext2_deletes_between/config.json
+++ b/test/benchmark/sqlite/ext2_deletes_between/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "10000 DELETEs, numeric BETWEEN, indexed....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 10000 DELETEs, numeric BETWEEN, indexed",
+    "title": "[Ext2] The deletes-between result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_deletes_between/result_template.json
+++ b/test/benchmark/sqlite/ext2_deletes_between/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of deletes-between on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of deletes-between on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_deletes_between/run.sh
+++ b/test/benchmark/sqlite/ext2_deletes_between/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_deletes_individual/config.json
+++ b/test/benchmark/sqlite/ext2_deletes_individual/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "50000 DELETEs of individual rows....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 50000 DELETEs of individual rows",
+    "title": "[Ext2] The deletes-individual result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_deletes_individual/result_template.json
+++ b/test/benchmark/sqlite/ext2_deletes_individual/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of deletes-individual on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of deletes-individual on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_deletes_individual/run.sh
+++ b/test/benchmark/sqlite/ext2_deletes_individual/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_refill_replace/config.json
+++ b/test/benchmark/sqlite/ext2_refill_replace/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "Refill two 50000-row tables using REPLACE....",
+    "result_index": "9",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: Refill two 50000-row tables using REPLACE",
+    "title": "[Ext2] The refill-replace result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_refill_replace/result_template.json
+++ b/test/benchmark/sqlite/ext2_refill_replace/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of refill-replace on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of refill-replace on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_refill_replace/run.sh
+++ b/test/benchmark/sqlite/ext2_refill_replace/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_selects_ipk/config.json
+++ b/test/benchmark/sqlite/ext2_selects_ipk/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "70000 SELECTS on an IPK....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 70000 SELECTS on an IPK",
+    "title": "[Ext2] The selects-ipk result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_selects_ipk/result_template.json
+++ b/test/benchmark/sqlite/ext2_selects_ipk/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of selects-ipk on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of selects-ipk on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_selects_ipk/run.sh
+++ b/test/benchmark/sqlite/ext2_selects_ipk/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_selects_text_pk/config.json
+++ b/test/benchmark/sqlite/ext2_selects_text_pk/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "70000 SELECTS on a TEXT PK....",
+    "result_index": "9",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 70000 SELECTS on a TEXT PK",
+    "title": "[Ext2] The selects-text-pk result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_selects_text_pk/result_template.json
+++ b/test/benchmark/sqlite/ext2_selects_text_pk/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of selects-text-pk on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of selects-text-pk on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_selects_text_pk/run.sh
+++ b/test/benchmark/sqlite/ext2_selects_text_pk/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_total/config.json
+++ b/test/benchmark/sqlite/ext2_total/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "TOTAL....",
+    "result_index": "2",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: total",
+    "title": "[Ext2] The total result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_total/result_template.json
+++ b/test/benchmark/sqlite/ext2_total/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Total speed on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Total speed on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_total/run.sh
+++ b/test/benchmark/sqlite/ext2_total/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_updates_between/config.json
+++ b/test/benchmark/sqlite/ext2_updates_between/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "10000 UPDATES, numeric BETWEEN, indexed....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 10000 UPDATES, numeric BETWEEN, indexed",
+    "title": "[Ext2] The updates-between result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_updates_between/result_template.json
+++ b/test/benchmark/sqlite/ext2_updates_between/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-between on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-between on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_updates_between/run.sh
+++ b/test/benchmark/sqlite/ext2_updates_between/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_updates_big_one/config.json
+++ b/test/benchmark/sqlite/ext2_updates_big_one/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "One big UPDATE of the whole 50000-row table....",
+    "result_index": "11",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: One big UPDATE of the whole 50000-row table",
+    "title": "[Ext2] The updates-big-one result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_updates_big_one/result_template.json
+++ b/test/benchmark/sqlite/ext2_updates_big_one/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-big-one on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-big-one Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_updates_big_one/run.sh
+++ b/test/benchmark/sqlite/ext2_updates_big_one/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_updates_individual/config.json
+++ b/test/benchmark/sqlite/ext2_updates_individual/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "50000 UPDATES of individual rows....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 50000 UPDATES of individual rows",
+    "title": "[Ext2] The updates-individual result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_updates_individual/result_template.json
+++ b/test/benchmark/sqlite/ext2_updates_individual/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-individual on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-individual on Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_updates_individual/run.sh
+++ b/test/benchmark/sqlite/ext2_updates_individual/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ext2_vacuum/config.json
+++ b/test/benchmark/sqlite/ext2_vacuum/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "VACUUM....",
+    "result_index": "4",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: repacking database file into a minimal amount of disk space",
+    "title": "[Ext2] The 'VACUUM' result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ext2_vacuum/result_template.json
+++ b/test/benchmark/sqlite/ext2_vacuum/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of VACUUM on Linux (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of VACUUM Asterinas (Ext2)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ext2_vacuum/run.sh
+++ b/test/benchmark/sqlite/ext2_vacuum/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/benchmark/bin/sqlite-speedtest1 /ext2/test.db

--- a/test/benchmark/sqlite/ramfs_deletes_between/config.json
+++ b/test/benchmark/sqlite/ramfs_deletes_between/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "10000 DELETEs, numeric BETWEEN, indexed....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 10000 DELETEs, numeric BETWEEN, indexed",
+    "title": "[Ramfs] The deletes-between result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_deletes_between/result_template.json
+++ b/test/benchmark/sqlite/ramfs_deletes_between/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of deletes-between on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of deletes-between on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_deletes_between/run.sh
+++ b/test/benchmark/sqlite/ramfs_deletes_between/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_deletes_individual/config.json
+++ b/test/benchmark/sqlite/ramfs_deletes_individual/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "50000 DELETEs of individual rows....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 50000 DELETEs of individual rows",
+    "title": "[Ramfs] The deletes-individual result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_deletes_individual/result_template.json
+++ b/test/benchmark/sqlite/ramfs_deletes_individual/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of deletes-individual on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of deletes-individual on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_deletes_individual/run.sh
+++ b/test/benchmark/sqlite/ramfs_deletes_individual/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_refill_replace/config.json
+++ b/test/benchmark/sqlite/ramfs_refill_replace/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "Refill two 50000-row tables using REPLACE....",
+    "result_index": "9",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: Refill two 50000-row tables using REPLACE",
+    "title": "[Ramfs] The refill-replace result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_refill_replace/result_template.json
+++ b/test/benchmark/sqlite/ramfs_refill_replace/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of refill-replace on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of refill-replace on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_refill_replace/run.sh
+++ b/test/benchmark/sqlite/ramfs_refill_replace/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_total/config.json
+++ b/test/benchmark/sqlite/ramfs_total/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "TOTAL....",
+    "result_index": "2",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: total",
+    "title": "[Ramfs] The total result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_total/result_template.json
+++ b/test/benchmark/sqlite/ramfs_total/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Total speed on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Total speed on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_total/run.sh
+++ b/test/benchmark/sqlite/ramfs_total/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_updates_between/config.json
+++ b/test/benchmark/sqlite/ramfs_updates_between/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "10000 UPDATES, numeric BETWEEN, indexed....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 10000 UPDATES, numeric BETWEEN, indexed",
+    "title": "[Ramfs] The updates-between result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_updates_between/result_template.json
+++ b/test/benchmark/sqlite/ramfs_updates_between/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-between on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-between on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_updates_between/run.sh
+++ b/test/benchmark/sqlite/ramfs_updates_between/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_updates_big_one/config.json
+++ b/test/benchmark/sqlite/ramfs_updates_big_one/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "One big UPDATE of the whole 50000-row table....",
+    "result_index": "11",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: One big UPDATE of the whole 50000-row table",
+    "title": "[Ramfs] The updates-big-one result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_updates_big_one/result_template.json
+++ b/test/benchmark/sqlite/ramfs_updates_big_one/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-big-one on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-big-one Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_updates_big_one/run.sh
+++ b/test/benchmark/sqlite/ramfs_updates_big_one/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_updates_individual/config.json
+++ b/test/benchmark/sqlite/ramfs_updates_individual/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "50000 UPDATES of individual rows....",
+    "result_index": "8",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: 50000 UPDATES of individual rows",
+    "title": "[Ramfs] The updates-individual result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_updates_individual/result_template.json
+++ b/test/benchmark/sqlite/ramfs_updates_individual/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of updates-individual on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of updates-individual on Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_updates_individual/run.sh
+++ b/test/benchmark/sqlite/ramfs_updates_individual/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sqlite/ramfs_vacuum/config.json
+++ b/test/benchmark/sqlite/ramfs_vacuum/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customSmallerIsBetter",
+    "search_pattern": "VACUUM....",
+    "result_index": "4",
+    "result_substring": "1,5",
+    "description": "sqlite-speed-test: repacking database file into a minimal amount of disk space",
+    "title": "[Ramfs] The 'VACUUM' result of sqlite speedtest"
+}

--- a/test/benchmark/sqlite/ramfs_vacuum/result_template.json
+++ b/test/benchmark/sqlite/ramfs_vacuum/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "The speed of VACUUM on Linux (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "The speed of VACUUM Asterinas (Ramfs)",
+        "unit": "second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/sqlite/ramfs_vacuum/run.sh
+++ b/test/benchmark/sqlite/ramfs_vacuum/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+mkdir -p /tmp
+/benchmark/bin/sqlite-speedtest1 /tmp/test.db

--- a/test/benchmark/sysbench/cpu_lat/config.json
+++ b/test/benchmark/sysbench/cpu_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "avg:",
     "result_index": "NF",
+    "result_substring": "null",
     "description": "sysbench cpu",
     "title": "[CPU] CPU performance"
 }

--- a/test/benchmark/sysbench/thread_lat/config.json
+++ b/test/benchmark/sysbench/thread_lat/config.json
@@ -3,6 +3,7 @@
     "alert_tool": "customSmallerIsBetter",
     "search_pattern": "avg:",
     "result_index": "NF",
+    "result_substring": "null",
     "description": "sysbench threads",
     "title": "[Threads] Threads performance"
 }


### PR DESCRIPTION
I added some of the tests from `speedtest1` to the benchmark CI. The results of these tests are much slower than those of Linux.

~~Since many benchmark CIs have been added, I need to double-check these tests. Draft for now.~~
All tests have been tested, this PR is ready for review.