### PR TITLE
[WIP] Tracking the development of the miri testing infrastructure

### DIFF
--- a/osdk/src/base_crate/Cargo.toml.template
+++ b/osdk/src/base_crate/Cargo.toml.template
@@ -2,3 +2,6 @@
 name = "#NAME#"
 version = "#VERSION#"
 edition = "2021"
+
+[workspace]
+members = []

--- a/osdk/src/base_crate/main.rs.template
+++ b/osdk/src/base_crate/main.rs.template
@@ -1,7 +1,19 @@
+#![feature(start)]
+
 #![no_std]
-#![no_main]
+#![cfg_attr(not(miri), no_main)]
 
 extern crate #TARGET_NAME#;
+
+#[cfg(miri)]
+extern "Rust" { fn __miri_main(); }
+
+#[cfg(miri)]
+#[start]
+fn miri_start(_argc: isize, _argv: *const *const u8) -> isize {
+    unsafe { __miri_main(); }
+    return 0;
+}
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -51,7 +51,8 @@ impl Bundle {
         std::fs::create_dir_all(path.as_ref()).unwrap();
         let config_initramfs = match action {
             ActionChoice::Run => config.run.boot.initramfs.as_ref(),
-            ActionChoice::Test => config.test.boot.initramfs.as_ref(),
+            // FIXME!
+            ActionChoice::Test | ActionChoice::Miri => config.test.boot.initramfs.as_ref(),
         };
         let initramfs = if let Some(ref initramfs) = config_initramfs {
             if !initramfs.exists() {
@@ -123,10 +124,12 @@ impl Bundle {
         let self_action = match self.manifest.action {
             ActionChoice::Run => &self.manifest.config.run,
             ActionChoice::Test => &self.manifest.config.test,
+            ActionChoice::Miri => todo!(),
         };
         let config_action = match action {
             ActionChoice::Run => &config.run,
             ActionChoice::Test => &config.test,
+            ActionChoice::Miri => unreachable!(),
         };
 
         // Compare the manifest with the run configuration except the initramfs and the boot method.
@@ -198,6 +201,9 @@ impl Bundle {
         let action = match action {
             ActionChoice::Run => &config.run,
             ActionChoice::Test => &config.test,
+            ActionChoice::Miri => {
+                todo!();
+            }
         };
         let mut qemu_cmd = Command::new(&action.qemu.path);
 

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -8,7 +8,8 @@ use crate::{
     arch::Arch,
     commands::{
         execute_build_command, execute_debug_command, execute_forwarded_command,
-        execute_new_command, execute_profile_command, execute_run_command, execute_test_command,
+        execute_miri_command, execute_new_command, execute_profile_command, execute_run_command,
+        execute_test_command,
     },
     config::{
         manifest::{ProjectType, TomlManifest},
@@ -55,6 +56,9 @@ pub fn main() {
         OsdkSubcommand::Test(test_args) => {
             execute_test_command(&load_config(&test_args.common_args), test_args);
         }
+        OsdkSubcommand::Miri(test_args) => {
+            execute_miri_command(&load_config(&test_args.common_args), test_args)
+        }
         OsdkSubcommand::Check(args) => execute_forwarded_command("check", &args.args, true),
         OsdkSubcommand::Clippy(args) => execute_forwarded_command("clippy", &args.args, true),
         OsdkSubcommand::Doc(args) => execute_forwarded_command("doc", &args.args, false),
@@ -89,6 +93,8 @@ pub enum OsdkSubcommand {
     Profile(ProfileArgs),
     #[command(about = "Execute kernel mode unit test by starting a VMM")]
     Test(TestArgs),
+    #[command(about = "Use miri to run user mode tests")]
+    Miri(TestArgs),
     #[command(about = "Check a local package and all of its dependencies for errors")]
     Check(ForwardedArguments),
     #[command(about = "Checks a package to catch common mistakes and improve your Rust code")]

--- a/osdk/src/commands/build/grub.rs
+++ b/osdk/src/commands/build/grub.rs
@@ -31,6 +31,7 @@ pub fn create_bootdev_image(
     let action = match &action {
         ActionChoice::Run => &config.run,
         ActionChoice::Test => &config.test,
+        ActionChoice::Miri => todo!(),
     };
     let protocol = &action.grub.boot_protocol;
 

--- a/osdk/src/commands/miri.rs
+++ b/osdk/src/commands/miri.rs
@@ -1,0 +1,97 @@
+use crate::commands::build::do_cached_build;
+use super::util::{self, DEFAULT_MIRI_TARGET_RELPATH};
+
+use std::fs;
+
+use crate::{
+    cli::TestArgs,
+    config::{scheme::ActionChoice, Config},
+    util::{get_current_crate_info, get_target_directory},
+};
+
+use crate::{base_crate::new_base_crate, error::Errno, error_msg};
+
+pub fn execute_miri_command(config: &Config, args: &TestArgs) {
+    let crates = util::get_workspace_default_members();
+    for crate_path in crates {
+        std::env::set_current_dir(crate_path).unwrap();
+        miri_current_crate(config, args);
+    }
+}
+
+pub fn miri_current_crate(config: &Config, args: &TestArgs) {
+    let current_crate = get_current_crate_info();
+    let cargo_target_directory = get_target_directory();
+    let osdk_output_directory = cargo_target_directory.join(DEFAULT_MIRI_TARGET_RELPATH);
+    let target_crate_dir = osdk_output_directory.join("base");
+
+    // A special case is that we use OSDK to test the OSDK test runner crate
+    // itself. We check it by name.
+    let runner_self_test = if current_crate.name == "osdk-test-kernel" {
+        if matches!(option_env!("OSDK_LOCAL_DEV"), Some("1")) {
+            true
+        } else {
+            error_msg!("The tested crate name collides with the OSDK test runner crate");
+            std::process::exit(Errno::BadCrateName as _);
+        }
+    } else {
+        false
+    };
+
+    new_base_crate(
+        &target_crate_dir,
+        &current_crate.name,
+        &current_crate.path,
+        !runner_self_test,
+    );
+
+    let main_rs_path = target_crate_dir.join("src").join("main.rs");
+
+    let ktest_test_whitelist = match &args.test_name {
+        Some(name) => format!(r#"Some(&["{}"])"#, name),
+        None => r#"None"#.to_string(),
+    };
+
+    let mut ktest_crate_whitelist = vec![current_crate.name];
+    if let Some(name) = &args.test_name {
+        ktest_crate_whitelist.push(name.clone());
+    }
+
+    // Append the ktest static variable and the runner reference to the
+    // `main.rs` file.
+    let ktest_main_rs = format!(
+        r#"
+
+{}
+
+#[no_mangle]
+pub static KTEST_TEST_WHITELIST: Option<&[&str]> = {};
+#[no_mangle]
+pub static KTEST_CRATE_WHITELIST: Option<&[&str]> = Some(&{:#?});
+
+"#,
+        if runner_self_test {
+            ""
+        } else {
+            "extern crate osdk_test_kernel;"
+        },
+        ktest_test_whitelist,
+        ktest_crate_whitelist,
+    );
+    let mut main_rs_content = fs::read_to_string(&main_rs_path).unwrap();
+    main_rs_content.push_str(&ktest_main_rs);
+    fs::write(&main_rs_path, main_rs_content).unwrap();
+
+    // Build the kernel with the given base crate
+    let target_name = get_current_crate_info().name;
+    let default_bundle_directory = osdk_output_directory.join(target_name);
+    std::env::set_current_dir(&target_crate_dir).unwrap();
+    let _bundle = do_cached_build(
+        default_bundle_directory,
+        &osdk_output_directory,
+        &cargo_target_directory,
+        config,
+        ActionChoice::Miri,
+        &["--cfg ktest"],
+    );
+}

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 mod build;
 mod debug;
+mod miri;
 mod new;
 mod profile;
 mod run;
@@ -11,8 +12,9 @@ mod test;
 mod util;
 
 pub use self::{
-    build::execute_build_command, debug::execute_debug_command, new::execute_new_command,
-    profile::execute_profile_command, run::execute_run_command, test::execute_test_command,
+    build::execute_build_command, debug::execute_debug_command, miri::execute_miri_command,
+    new::execute_new_command, profile::execute_profile_command, run::execute_run_command,
+    test::execute_test_command,
 };
 
 use crate::arch::get_default_arch;

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -2,16 +2,17 @@
 
 use std::fs;
 
-use super::{build::do_cached_build, util::DEFAULT_TARGET_RELPATH};
+use super::{
+    build::do_cached_build,
+    util::{get_workspace_default_members, DEFAULT_TARGET_RELPATH},
+};
 use crate::{
     base_crate::new_base_crate,
     cli::TestArgs,
     config::{scheme::ActionChoice, Config},
     error::Errno,
     error_msg,
-    util::{
-        get_cargo_metadata, get_current_crate_info, get_target_directory, parse_package_id_string,
-    },
+    util::{get_current_crate_info, get_target_directory},
 };
 
 pub fn execute_test_command(config: &Config, args: &TestArgs) {
@@ -102,21 +103,4 @@ pub static KTEST_CRATE_WHITELIST: Option<&[&str]> = Some(&{:#?});
     std::env::set_current_dir(original_dir).unwrap();
 
     bundle.run(config, ActionChoice::Test);
-}
-
-fn get_workspace_default_members() -> Vec<String> {
-    let metadata = get_cargo_metadata(None::<&str>, None::<&[&str]>).unwrap();
-    let default_members = metadata
-        .get("workspace_default_members")
-        .unwrap()
-        .as_array()
-        .unwrap();
-    default_members
-        .iter()
-        .map(|value| {
-            let default_member = value.as_str().unwrap();
-            let crate_info = parse_package_id_string(default_member);
-            crate_info.path
-        })
-        .collect()
 }

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use crate::util::get_current_crate_info;
+use crate::util::{get_cargo_metadata, get_current_crate_info, parse_package_id_string};
 
 pub const COMMON_CARGO_ARGS: &[&str] = &[
     "-Zbuild-std=core,alloc,compiler_builtins",
@@ -24,4 +24,21 @@ pub fn profile_name_adapter(profile: &str) -> &str {
 
 pub fn bin_file_name() -> String {
     get_current_crate_info().name + "-osdk-bin"
+}
+
+pub fn get_workspace_default_members() -> Vec<String> {
+    let metadata = get_cargo_metadata(None::<&str>, None::<&[&str]>).unwrap();
+    let default_members = metadata
+        .get("workspace_default_members")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    default_members
+        .iter()
+        .map(|value| {
+            let default_member = value.as_str().unwrap();
+            let crate_info = parse_package_id_string(default_member);
+            crate_info.path
+        })
+        .collect()
 }

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -10,6 +10,7 @@ pub const COMMON_CARGO_ARGS: &[&str] = &[
 ];
 
 pub const DEFAULT_TARGET_RELPATH: &str = "osdk";
+pub const DEFAULT_MIRI_TARGET_RELPATH: &str = "osdk-miri";
 
 pub fn cargo() -> Command {
     Command::new("cargo")

--- a/osdk/src/config/scheme/action.rs
+++ b/osdk/src/config/scheme/action.rs
@@ -10,6 +10,7 @@ use crate::{cli::CommonArgs, config::Arch};
 pub enum ActionChoice {
     Run,
     Test,
+    Miri,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/osdk/test-kernel/src/lib.rs
+++ b/osdk/test-kernel/src/lib.rs
@@ -78,6 +78,14 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     ostd::prelude::abort();
 }
 
+/// The entry point of the miri runner.
+#[ostd::ktest::miri_main]
+fn miri_main() {
+    use alloc::string::ToString;
+    let test_whitelist: &[&str] = &["atomic_bits"];
+    run_ktests(Some(test_whitelist.iter().map(|s| s.to_string())), None);
+}
+
 /// Run all the tests registered by `#[ktest]` in the `.ktest_array` section.
 ///
 /// The `whitelist` argument is optional. If it is `None`, all tests compiled will be run.

--- a/osdk/test-kernel/src/lib.rs
+++ b/osdk/test-kernel/src/lib.rs
@@ -54,6 +54,7 @@ fn main() {
     unreachable!("The spawn method will NOT return in the boot context")
 }
 
+#[cfg(not(miri))]
 #[ostd::ktest::panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     let _irq_guard = ostd::trap::disable_local();
@@ -74,6 +75,14 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     // If not caught, abort the kernel.
     early_println!("An uncaught panic occurred: {:#?}", throw_info);
+
+    ostd::prelude::abort();
+}
+
+#[cfg(miri)]
+#[ostd::ktest::panic_handler]
+fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    early_println!("An uncaught panic occurred: {:#?}", info);
 
     ostd::prelude::abort();
 }

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -61,6 +61,24 @@ pub fn test_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
+#[proc_macro_attribute]
+pub fn miri_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let main_fn = parse_macro_input!(item as ItemFn);
+    let main_fn_name = &main_fn.sig.ident;
+
+    quote!(
+        #[cfg(miri)]
+        #[no_mangle]
+        extern "Rust" fn __miri_main() {
+            #main_fn_name();
+        }
+
+        #[cfg(miri)]
+        #main_fn
+    )
+    .into()
+}
+
 /// A macro attribute for the panic handler.
 ///
 /// The attributed function will be used to override OSTD's default

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -70,7 +70,6 @@ pub fn miri_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(miri)]
         #[no_mangle]
         extern "Rust" fn __miri_main() {
-            unsafe { ostd::init() };
             #main_fn_name();
             ostd::prelude::abort();
         }

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -70,7 +70,9 @@ pub fn miri_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(miri)]
         #[no_mangle]
         extern "Rust" fn __miri_main() {
+            unsafe { ostd::init() };
             #main_fn_name();
+            ostd::prelude::abort();
         }
 
         #[cfg(miri)]

--- a/ostd/src/arch/mod.rs
+++ b/ostd/src/arch/mod.rs
@@ -4,12 +4,14 @@
 //!
 //! Each architecture that Asterinas supports may contain a submodule here.
 
-#[cfg(target_arch = "riscv64")]
-pub mod riscv;
-#[cfg(target_arch = "x86_64")]
-pub mod x86;
+use cfg_if::cfg_if;
 
-#[cfg(target_arch = "riscv64")]
-pub use self::riscv::*;
-#[cfg(target_arch = "x86_64")]
-pub use self::x86::*;
+cfg_if! {
+    if #[cfg(target_arch = "riscv64")] {
+        pub mod riscv;
+        pub use self::riscv::*;
+    } else if #[cfg(target_arch = "x86_64")] {
+        pub mod x86;
+        pub use self::x86::*;
+    }
+}

--- a/ostd/src/arch/riscv/bus/mmio.rs
+++ b/ostd/src/arch/riscv/bus/mmio.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) fn init() {}

--- a/ostd/src/arch/riscv/bus/mod.rs
+++ b/ostd/src/arch/riscv/bus/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod mmio;

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     Pod,
 };
 
+pub(crate) const KERNEL_CODE_BASE_VADDR_PREFIX: usize = 0xffff_ffff_0000_0000;
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 
 #[derive(Clone, Debug, Default)]

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -3,6 +3,7 @@
 //! Platform-specific code for the RISC-V platform.
 
 pub mod boot;
+pub(crate) mod bus;
 pub(crate) mod cpu;
 pub mod device;
 pub mod iommu;
@@ -66,4 +67,9 @@ pub(crate) fn enable_cpu_features() {
     unsafe {
         riscv::register::sstatus::set_fs(riscv::register::sstatus::FS::Clean);
     }
+}
+
+/// Return the name of the register given an index
+pub fn register_name(_index: u16) -> Option<&'static str> {
+    None
 }

--- a/ostd/src/arch/riscv/pci.rs
+++ b/ostd/src/arch/riscv/pci.rs
@@ -6,3 +6,5 @@ use super::device::io_port::{IoPort, ReadWriteAccess, WriteOnlyAccess};
 
 pub static PCI_ADDRESS_PORT: IoPort<u32, WriteOnlyAccess> = unsafe { IoPort::new(0x0) };
 pub static PCI_DATA_PORT: IoPort<u32, ReadWriteAccess> = unsafe { IoPort::new(0x0) };
+
+pub(crate) fn init() {}

--- a/ostd/src/arch/x86/bus/mmio.rs
+++ b/ostd/src/arch/x86/bus/mmio.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Range;
+
+use cfg_if::cfg_if;
+use log::debug;
+
+use crate::{
+    bus::mmio::{common_device::MmioCommonDevice, MMIO_BUS, VIRTIO_MMIO_MAGIC},
+    mm::paddr_to_vaddr,
+    trap::IrqLine,
+};
+cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
+        use ::tdx_guest::tdx_is_enabled;
+        use crate::arch::tdx_guest;
+    }
+}
+
+pub(crate) fn init() {
+    #[cfg(feature = "cvm_guest")]
+    // SAFETY:
+    // This is safe because we are ensuring that the address range 0xFEB0_0000 to 0xFEB0_4000 is valid before this operation.
+    // The address range is page-aligned and falls within the MMIO range, which is a requirement for the `unprotect_gpa_range` function.
+    // We are also ensuring that we are only unprotecting four pages.
+    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
+    if tdx_is_enabled() {
+        unsafe {
+            tdx_guest::unprotect_gpa_range(0xFEB0_0000, 4).unwrap();
+        }
+    }
+    // FIXME: The address 0xFEB0_0000 is obtained from an instance of microvm, and it may not work in other architecture.
+    iter_range(0xFEB0_0000..0xFEB0_4000);
+}
+
+fn iter_range(range: Range<usize>) {
+    debug!("[Virtio]: Iter MMIO range:{:x?}", range);
+    let mut current = range.end;
+    let mut lock = MMIO_BUS.lock();
+    let io_apics = crate::arch::kernel::IO_APIC.get().unwrap();
+    let is_ioapic2 = io_apics.len() == 2;
+    let mut io_apic = if is_ioapic2 {
+        io_apics.get(1).unwrap().lock()
+    } else {
+        io_apics.first().unwrap().lock()
+    };
+    let mut device_count = 0;
+    while current > range.start {
+        current -= 0x100;
+        // SAFETY: It only read the value and judge if the magic value fit 0x74726976
+        let magic = unsafe { core::ptr::read_volatile(paddr_to_vaddr(current) as *const u32) };
+        if magic == VIRTIO_MMIO_MAGIC {
+            // SAFETY: It only read the device id
+            let device_id = unsafe { *(paddr_to_vaddr(current + 8) as *const u32) };
+            device_count += 1;
+            if device_id == 0 {
+                continue;
+            }
+            let handle = IrqLine::alloc().unwrap();
+            // If has two IOApic, then start: 24 (0 in IOApic2), end 47 (23 in IOApic2)
+            // If one IOApic, then start: 16, end 23
+            io_apic.enable(24 - device_count, handle.clone()).unwrap();
+            let device = MmioCommonDevice::new(current, handle);
+            lock.register_mmio_device(device);
+        }
+    }
+}

--- a/ostd/src/arch/x86/bus/mod.rs
+++ b/ostd/src/arch/x86/bus/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod mmio;

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 
 mod util;
 
+pub(crate) const KERNEL_CODE_BASE_VADDR_PREFIX: usize = 0xffff_ffff_8000_0000;
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 
 #[derive(Clone, Debug, Default)]

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -3,6 +3,7 @@
 //! Platform-specific code for the x86 platform.
 
 pub mod boot;
+pub(crate) mod bus;
 pub(crate) mod cpu;
 pub mod device;
 pub(crate) mod ex_table;
@@ -35,6 +36,7 @@ use core::{
     sync::atomic::Ordering,
 };
 
+use gimli::Register;
 use kernel::apic::ioapic;
 use log::{info, warn};
 
@@ -207,4 +209,9 @@ pub(crate) fn enable_cpu_features() {
             *efer |= EferFlags::NO_EXECUTE_ENABLE;
         });
     }
+}
+
+/// Return the name of the register given an index
+pub fn register_name(index: u16) -> Option<&'static str> {
+    gimli::X86_64::register_name(Register(index))
 }

--- a/ostd/src/arch/x86/pci.rs
+++ b/ostd/src/arch/x86/pci.rs
@@ -3,6 +3,17 @@
 //! PCI bus io port
 
 use super::device::io_port::{IoPort, ReadWriteAccess, WriteOnlyAccess};
+use crate::bus::pci::{common_device::PciCommonDevice, PciDeviceLocation, PCI_BUS};
 
 pub static PCI_ADDRESS_PORT: IoPort<u32, WriteOnlyAccess> = unsafe { IoPort::new(0x0CF8) };
 pub static PCI_DATA_PORT: IoPort<u32, ReadWriteAccess> = unsafe { IoPort::new(0x0CFC) };
+
+pub(crate) fn init() {
+    let mut lock = PCI_BUS.lock();
+    for location in PciDeviceLocation::all() {
+        let Some(device) = PciCommonDevice::new(location) else {
+            continue;
+        };
+        lock.register_common_device(device);
+    }
+}

--- a/ostd/src/bus/mmio/bus.rs
+++ b/ostd/src/bus/mmio/bus.rs
@@ -66,7 +66,7 @@ impl MmioBus {
         self.drivers.push(driver);
     }
 
-    pub(super) fn register_mmio_device(&mut self, mut mmio_device: MmioCommonDevice) {
+    pub(crate) fn register_mmio_device(&mut self, mut mmio_device: MmioCommonDevice) {
         let device_id = mmio_device.read_device_id().unwrap();
         for driver in self.drivers.iter() {
             mmio_device = match driver.probe(mmio_device) {
@@ -86,7 +86,7 @@ impl MmioBus {
         self.common_devices.push_back(mmio_device);
     }
 
-    pub(super) const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             common_devices: VecDeque::new(),
             devices: Vec::new(),

--- a/ostd/src/bus/mmio/common_device.rs
+++ b/ostd/src/bus/mmio/common_device.rs
@@ -25,7 +25,7 @@ pub struct MmioCommonDevice {
 }
 
 impl MmioCommonDevice {
-    pub(super) fn new(paddr: Paddr, handle: IrqLine) -> Self {
+    pub(crate) fn new(paddr: Paddr, handle: IrqLine) -> Self {
         // TODO: Implement universal access to MMIO devices since we are temporarily
         // using specific virtio device as implementation of CommonDevice.
 

--- a/ostd/src/bus/mmio/mod.rs
+++ b/ostd/src/bus/mmio/mod.rs
@@ -4,80 +4,18 @@
 
 //! Virtio over MMIO
 
+use crate::{bus::mmio::bus::MmioBus, sync::SpinLock};
+
 pub mod bus;
 pub mod common_device;
 
-use alloc::vec::Vec;
-use core::ops::Range;
-
-use cfg_if::cfg_if;
-use log::debug;
-
-use self::bus::MmioBus;
-use crate::{
-    bus::mmio::common_device::MmioCommonDevice, mm::paddr_to_vaddr, sync::SpinLock, trap::IrqLine,
-};
-
-cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
-        use ::tdx_guest::tdx_is_enabled;
-        use crate::arch::tdx_guest;
-    }
-}
-
-const VIRTIO_MMIO_MAGIC: u32 = 0x74726976;
+pub(crate) const VIRTIO_MMIO_MAGIC: u32 = 0x74726976;
 
 /// MMIO bus instance
 pub static MMIO_BUS: SpinLock<MmioBus> = SpinLock::new(MmioBus::new());
-static IRQS: SpinLock<Vec<IrqLine>> = SpinLock::new(Vec::new());
+
+use crate::arch;
 
 pub(crate) fn init() {
-    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-    // SAFETY:
-    // This is safe because we are ensuring that the address range 0xFEB0_0000 to 0xFEB0_4000 is valid before this operation.
-    // The address range is page-aligned and falls within the MMIO range, which is a requirement for the `unprotect_gpa_range` function.
-    // We are also ensuring that we are only unprotecting four pages.
-    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
-    if tdx_is_enabled() {
-        unsafe {
-            tdx_guest::unprotect_gpa_range(0xFEB0_0000, 4).unwrap();
-        }
-    }
-    // FIXME: The address 0xFEB0_0000 is obtained from an instance of microvm, and it may not work in other architecture.
-    #[cfg(target_arch = "x86_64")]
-    iter_range(0xFEB0_0000..0xFEB0_4000);
-}
-
-#[cfg(target_arch = "x86_64")]
-fn iter_range(range: Range<usize>) {
-    debug!("[Virtio]: Iter MMIO range:{:x?}", range);
-    let mut current = range.end;
-    let mut lock = MMIO_BUS.lock();
-    let io_apics = crate::arch::kernel::IO_APIC.get().unwrap();
-    let is_ioapic2 = io_apics.len() == 2;
-    let mut io_apic = if is_ioapic2 {
-        io_apics.get(1).unwrap().lock()
-    } else {
-        io_apics.first().unwrap().lock()
-    };
-    let mut device_count = 0;
-    while current > range.start {
-        current -= 0x100;
-        // SAFETY: It only read the value and judge if the magic value fit 0x74726976
-        let magic = unsafe { core::ptr::read_volatile(paddr_to_vaddr(current) as *const u32) };
-        if magic == VIRTIO_MMIO_MAGIC {
-            // SAFETY: It only read the device id
-            let device_id = unsafe { *(paddr_to_vaddr(current + 8) as *const u32) };
-            device_count += 1;
-            if device_id == 0 {
-                continue;
-            }
-            let handle = IrqLine::alloc().unwrap();
-            // If has two IOApic, then start: 24 (0 in IOApic2), end 47 (23 in IOApic2)
-            // If one IOApic, then start: 16, end 23
-            io_apic.enable(24 - device_count, handle.clone()).unwrap();
-            let device = MmioCommonDevice::new(current, handle);
-            lock.register_mmio_device(device);
-        }
-    }
+    arch::bus::mmio::init();
 }

--- a/ostd/src/bus/mod.rs
+++ b/ostd/src/bus/mod.rs
@@ -16,7 +16,6 @@ pub enum BusProbeError {
 
 /// Initializes the bus
 pub(crate) fn init() {
-    #[cfg(target_arch = "x86_64")]
     pci::init();
 
     mmio::init();

--- a/ostd/src/bus/pci/bus.rs
+++ b/ostd/src/bus/pci/bus.rs
@@ -72,7 +72,7 @@ impl PciBus {
         self.drivers.push(driver);
     }
 
-    pub(super) fn register_common_device(&mut self, mut common_device: PciCommonDevice) {
+    pub(crate) fn register_common_device(&mut self, mut common_device: PciCommonDevice) {
         debug!("Find pci common devices:{:x?}", common_device);
         let device_id = *common_device.device_id();
         for driver in self.drivers.iter() {
@@ -94,7 +94,7 @@ impl PciBus {
         self.common_devices.push_back(common_device);
     }
 
-    pub(super) const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             common_devices: VecDeque::new(),
             devices: Vec::new(),

--- a/ostd/src/bus/pci/common_device.rs
+++ b/ostd/src/bus/pci/common_device.rs
@@ -65,7 +65,7 @@ impl PciCommonDevice {
         )
     }
 
-    pub(super) fn new(location: PciDeviceLocation) -> Option<Self> {
+    pub(crate) fn new(location: PciDeviceLocation) -> Option<Self> {
         if location.read16(0) == 0xFFFF {
             // not exists
             return None;

--- a/ostd/src/bus/pci/mod.rs
+++ b/ostd/src/bus/pci/mod.rs
@@ -58,18 +58,15 @@ mod device_info;
 
 pub use device_info::{PciDeviceId, PciDeviceLocation};
 
-use self::{bus::PciBus, common_device::PciCommonDevice};
-use crate::sync::Mutex;
+use crate::{
+    arch,
+    bus::pci::{bus::PciBus, common_device::PciCommonDevice},
+    sync::Mutex,
+};
 
 /// PCI bus instance
 pub static PCI_BUS: Mutex<PciBus> = Mutex::new(PciBus::new());
 
 pub(crate) fn init() {
-    let mut lock = PCI_BUS.lock();
-    for location in PciDeviceLocation::all() {
-        let Some(device) = PciCommonDevice::new(location) else {
-            continue;
-        };
-        lock.register_common_device(device);
-    }
+    arch::pci::init();
 }

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -70,6 +70,7 @@ extern "C" {
 pub(crate) unsafe fn early_init_bsp_local_base() {
     let start_base_va = __cpu_local_start as usize as u64;
 
+    #[cfg(not(miri))]
     // SAFETY: The base to be set is the start of the `.cpu_local` section,
     // where accessing the CPU-local objects have defined behaviors.
     unsafe {
@@ -119,6 +120,7 @@ pub unsafe fn init_on_bsp() {
 
     CPU_LOCAL_STORAGES.call_once(|| cpu_local_storages);
 
+    #[cfg(not(miri))]
     arch::cpu::local::set_base(bsp_base_va as u64);
 
     has_init::set_true();
@@ -138,6 +140,7 @@ pub unsafe fn init_on_ap(cpu_id: u32) {
 
     let ap_pages_ptr = paddr_to_vaddr(ap_pages.start_paddr()) as *mut u32;
 
+    #[cfg(not(miri))]
     // SAFETY: the memory will be dedicated to the AP. And we are on the AP.
     unsafe {
         arch::cpu::local::set_base(ap_pages_ptr as u64);

--- a/ostd/src/cpu/mod.rs
+++ b/ostd/src/cpu/mod.rs
@@ -4,17 +4,10 @@
 
 pub mod local;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
-        pub use crate::arch::x86::cpu::*;
-    } else if #[cfg(target_arch = "riscv64")] {
-        pub use crate::arch::riscv::cpu::*;
-    }
-}
-
 use bitvec::prelude::BitVec;
 use spin::Once;
 
+pub use crate::arch::cpu::*;
 use crate::{
     arch::boot::smp::get_num_processors, cpu_local_cell, task::DisabledPreemptGuard,
     trap::DisabledLocalIrqGuard,

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -156,5 +156,6 @@ pub mod ktest {
     //! `ktest` attribute is sufficient for all normal use cases.
 
     pub use ostd_macros::{test_main as main, test_panic_handler as panic_handler};
+    pub use ostd_macros::miri_main;
     pub use ostd_test::*;
 }

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -937,14 +937,6 @@ pub trait PodOnce: Pod {}
 
 impl<T: Pod> PodOnce for T where Assert<{ is_pod_once::<T>() }>: IsTrue {}
 
-#[cfg(target_arch = "x86_64")]
-const fn is_pod_once<T: Pod>() -> bool {
-    let size = size_of::<T>();
-
-    size == 1 || size == 2 || size == 4 || size == 8
-}
-
-#[cfg(target_arch = "riscv64")]
 const fn is_pod_once<T: Pod>() -> bool {
     let size = size_of::<T>();
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -58,7 +58,7 @@ use super::{
     Paddr, PagingConstsTrait, Vaddr, PAGE_SIZE,
 };
 use crate::{
-    arch::mm::{PageTableEntry, PagingConsts},
+    arch::mm::{PageTableEntry, PagingConsts, KERNEL_CODE_BASE_VADDR_PREFIX},
     boot::memory_region::MemoryRegionType,
 };
 
@@ -82,10 +82,7 @@ pub fn kernel_loaded_offset() -> usize {
     KERNEL_CODE_BASE_VADDR
 }
 
-#[cfg(target_arch = "x86_64")]
-const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_8000_0000 << ADDR_WIDTH_SHIFT;
-#[cfg(target_arch = "riscv64")]
-const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000 << ADDR_WIDTH_SHIFT;
+const KERNEL_CODE_BASE_VADDR: usize = KERNEL_CODE_BASE_VADDR_PREFIX << ADDR_WIDTH_SHIFT;
 
 const FRAME_METADATA_CAP_VADDR: Vaddr = 0xffff_e100_0000_0000 << ADDR_WIDTH_SHIFT;
 const FRAME_METADATA_BASE_VADDR: Vaddr = 0xffff_e000_0000_0000 << ADDR_WIDTH_SHIFT;

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -24,6 +24,7 @@ use unwinding::abi::{
 ///
 /// The user can override it by defining their own panic handler with the macro
 /// `#[ostd::panic_handler]`.
+#[cfg(not(miri))]
 #[linkage = "weak"]
 #[no_mangle]
 pub fn __ostd_panic_handler(info: &core::panic::PanicInfo) -> ! {

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -7,6 +7,7 @@ use core::ffi::c_void;
 pub use unwinding::panic::{begin_panic, catch_unwind};
 
 use crate::{
+    arch,
     arch::qemu::{exit_qemu, QemuExitCode},
     early_print, early_println,
     sync::SpinLock,
@@ -14,8 +15,6 @@ use crate::{
 
 extern crate cfg_if;
 extern crate gimli;
-
-use gimli::Register;
 use unwinding::abi::{
     UnwindContext, UnwindReasonCode, _Unwind_Backtrace, _Unwind_FindEnclosingFunction,
     _Unwind_GetGR, _Unwind_GetIP,
@@ -83,17 +82,8 @@ pub fn print_stack_trace() {
         // the DWARF standard.
         for i in 0..8u16 {
             let reg_i = _Unwind_GetGR(unwind_ctx, i as i32);
-            cfg_if::cfg_if! {
-                if #[cfg(target_arch = "x86_64")] {
-                    let reg_name = gimli::X86_64::register_name(Register(i)).unwrap_or("unknown");
-                } else if #[cfg(target_arch = "riscv64")] {
-                    let reg_name = gimli::RiscV::register_name(Register(i)).unwrap_or("unknown");
-                } else if #[cfg(target_arch = "aarch64")] {
-                    let reg_name = gimli::AArch64::register_name(Register(i)).unwrap_or("unknown");
-                } else {
-                    let reg_name = "unknown";
-                }
-            }
+            let reg_name = arch::register_name(i).unwrap_or("unknown");
+
             if i % 4 == 0 {
                 early_print!("\n    ");
             }

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -47,9 +47,22 @@ pub fn __ostd_panic_handler(info: &core::panic::PanicInfo) -> ! {
     abort();
 }
 
+#[cfg(miri)]
+mod miri_lib {
+    extern "C" {
+        pub fn abort() -> !;
+    }
+}
+
 /// Aborts the QEMU
 pub fn abort() -> ! {
-    exit_qemu(QemuExitCode::Failed);
+    cfg_if::cfg_if! {
+        if #[cfg(miri)] {
+            unsafe{ miri_lib::abort() }
+        } else {
+            exit_qemu(QemuExitCode::Failed);
+        }
+    }
 }
 
 /// Prints the stack trace of the current thread to the console.

--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -6,8 +6,6 @@ use core::sync::atomic::{
     Ordering::{Acquire, Relaxed, Release},
 };
 
-#[cfg(target_arch = "x86_64")]
-use crate::arch::x86::cpu;
 use crate::prelude::*;
 use crate::sync::AtomicBits;
 use crate::sync::SpinLock;


### PR DESCRIPTION
Now, `cargo osdk miri` will give you a preliminary glimpse of how miri works with osdk. 

# How it works

Simply run `cargo miri` in the base crate.

You need to build `miri` at a specific revision, which is available at [this repo](https://github.com/kylerky/miri/tree/miri_asterinas). The two binaries that you will need are `cargo-miri` and `miri`.

# Blocking issues
- [ ] We need to adapt the allocator somehow

- [ ] The panic handler has assembly among other things that we may need to address

# A backtrace from a run

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.36s
     Running `/root/.cargo/bin/cargo-miri runner /root/asterinas/target/miri/x86_64-unknown-none/debug/ostd-osdk-bin`
error: unsupported operation: inline assembly is not supported
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/x86_64-0.14.12/src/registers/rflags.rs:94:13
   |
94 |             asm!("pushfq; pop {}", out(reg) r, options(nomem, preserves_flags));
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
   |
   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
   = note: BACKTRACE:
   = note: inside `x86_64::registers::rflags::x86_64::read_raw` at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/x86_64-0.14.12/src/registers/rflags.rs:94:13: 94:80
   = note: inside `ostd::arch::x86::irq::is_local_enabled` at /root/asterinas/ostd/src/arch/x86/irq.rs:57:6: 57:24
   = note: inside `ostd::trap::DisabledLocalIrqGuard::new` at /root/asterinas/ostd/src/trap/irq.rs:143:27: 143:50
   = note: inside `ostd::trap::disable_local` at /root/asterinas/ostd/src/trap/irq.rs:129:5: 129:33
   = note: inside `<ostd::mm::heap_allocator::LockedHeapWithRescue<32> as core::alloc::GlobalAlloc>::alloc` at /root/asterinas/ostd/src/mm/heap_allocator.rs:70:22: 70:37
   = note: inside `ostd::mm::heap_allocator::_::__rust_alloc` at /root/asterinas/ostd/src/mm/heap_allocator.rs:22:24: 22:48
   = note: inside `alloc::alloc::alloc` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:100:9: 100:52
   = note: inside `alloc::alloc::Global::alloc_impl` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:183:73: 183:86
   = note: inside `<alloc::alloc::Global as core::alloc::Allocator>::allocate` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:243:9: 243:39
   = note: inside `alloc::raw_vec::finish_grow::<alloc::alloc::Global>` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:573:9: 573:35
   = note: inside `alloc::raw_vec::RawVec::<u8>::grow_amortized` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:485:19: 485:82
   = note: inside `alloc::raw_vec::RawVec::<T, A>::reserve::do_reserve_and_handle::<u8, alloc::alloc::Global>` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:349:31: 349:66
   = note: inside `alloc::raw_vec::RawVec::<u8>::reserve` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:355:13: 355:57
   = note: inside `alloc::vec::Vec::<u8>::reserve` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:972:9: 972:47
   = note: inside `alloc::vec::Vec::<u8>::append_elements` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:2145:9: 2145:28
   = note: inside `<alloc::vec::Vec<u8> as alloc::vec::spec_extend::SpecExtend<&u8, core::slice::Iter<'_, u8>>>::spec_extend` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/spec_extend.rs:55:18: 55:45
   = note: inside `alloc::vec::Vec::<u8>::extend_from_slice` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:2591:9: 2591:39
   = note: inside `alloc::string::String::push_str` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs:1067:9: 1067:54
   = note: inside `<alloc::string::String as core::fmt::Write>::write_str` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs:2921:9: 2921:25
   = note: inside `core::fmt::Formatter::<'_>::pad` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:1419:20: 1419:41
   = note: inside `<str as core::fmt::Display>::fmt` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:2449:9: 2449:20
   = note: inside `<&str as core::fmt::Display>::fmt` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:2354:62: 2354:82
   = note: inside `<&str as alloc::string::ToString>::to_string` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs:2562:9: 2562:48
   = note: inside closure at /root/asterinas/osdk/test-kernel/src/lib.rs:62:51: 62:64
   = note: inside `core::ops::function::impls::<impl core::ops::FnOnce<(&&str,)> for &mut {closure@osdk_test_kernel::miri_main::{closure#0}}>::call_once` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:305:13: 305:35
   = note: inside `core::option::Option::<&&str>::map::<alloc::string::String, &mut {closure@osdk_test_kernel::miri_main::{closure#0}}>` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:1101:29: 1101:33
   = note: inside `<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}> as core::iter::Iterator>::next` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:108:9: 108:42
   = note: inside `<core::iter::Map<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>, {closure@osdk_test_kernel::run_ktests<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>>::{closure#0}::{closure#0}}> as core::iter::Iterator>::next` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:108:9: 108:25
   = note: inside `osdk_test_kernel::path::SuffixTrie::from_paths::<core::iter::Map<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>, {closure@osdk_test_kernel::run_ktests<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>>::{closure#0}::{closure#0}}>>` at /root/asterinas/osdk/test-kernel/src/path.rs:181:18: 181:23
   = note: inside closure at /root/asterinas/osdk/test-kernel/src/lib.rs:86:36: 86:94
   = note: inside `core::option::Option::<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>>::map::<osdk_test_kernel::path::SuffixTrie, {closure@osdk_test_kernel::run_ktests<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>>::{closure#0}}>` at /root/.rustup/toolchains/nightly-2024-06-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:1101:29: 1101:33
   = note: inside `osdk_test_kernel::run_ktests::<core::iter::Map<core::slice::Iter<'_, &str>, {closure@osdk_test_kernel::miri_main::{closure#0}}>>` at /root/asterinas/osdk/test-kernel/src/lib.rs:86:9: 86:95
   = note: inside `osdk_test_kernel::miri_main` at /root/asterinas/osdk/test-kernel/src/lib.rs:62:5: 62:73
   = note: inside `osdk_test_kernel::__miri_main` at /root/asterinas/osdk/test-kernel/src/lib.rs:58:1: 58:26
note: inside `miri_start`
  --> src/main.rs:13:14
   |
13 |     unsafe { __miri_main(); }
   |              ^^^^^^^^^^^^^

error: aborting due to 1 previous error

[Error]: Cargo build failed

```