### PR TITLE
Fix RamFS readahead

### DIFF
--- a/test/apps/mmap/mmap_readahead.c
+++ b/test/apps/mmap/mmap_readahead.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <sys/mman.h>
+#include <sys/fcntl.h>
+#include <unistd.h>
+
+#include "../network/test.h"
+
+#define FILE_NAME "/tmp/mmap_readahead.txt"
+
+#define PAGE_SIZE 4096
+#define NR_PAGES 16
+
+static char *addr;
+
+FN_SETUP(mmap_readahead)
+{
+	int fd;
+
+	fd = CHECK(open(FILE_NAME, O_RDWR | O_CREAT));
+	CHECK(unlink(FILE_NAME));
+
+	CHECK(ftruncate(fd, PAGE_SIZE * NR_PAGES));
+
+	addr = mmap(NULL, PAGE_SIZE * NR_PAGES, PROT_READ | PROT_WRITE,
+		    MAP_SHARED, fd, 0);
+	CHECK(addr == MAP_FAILED ? -1 : 0);
+}
+END_SETUP()
+
+FN_TEST(mmap_readahead)
+{
+	int i;
+
+	for (i = 0; i < NR_PAGES; ++i) {
+		TEST_RES(addr[i * PAGE_SIZE], _ret == 0);
+	}
+}
+END_TEST()

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -22,6 +22,7 @@ itimer/setitimer
 itimer/timer_create
 mmap/mmap_and_fork
 mmap/mmap_shared_filebacked
+mmap/mmap_readahead
 pthread/pthread_test
 pty/open_pty
 signal_c/parent_death_signal


### PR DESCRIPTION
`RamInode::read_page_async` does not make BIO requests, but fills the page directly:
https://github.com/asterinas/asterinas/blob/22b04ceae47cd7939acd162d48c8d970f40f211a/kernel/src/fs/ramfs/fs.rs#L543-L551

However, when conducting the readahead, the page is still marked as `Uninit`:
https://github.com/asterinas/asterinas/blob/22b04ceae47cd7939acd162d48c8d970f40f211a/kernel/src/fs/utils/page_cache.rs#L308-L310

This will later confuse the page fault handler, because it sees the `Uninit` page, but there are no pending BIO requests:
https://github.com/asterinas/asterinas/blob/22b04ceae47cd7939acd162d48c8d970f40f211a/kernel/src/fs/utils/page_cache.rs#L396-L399

This eventually leads to unexpected segmentation faults.

This PR fixes the problem and adds a regression test.