### PR TITLE
Fix the condition in is_last_thread

### DIFF
--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -277,7 +277,7 @@ impl PosixThread {
         let tasks = process.tasks().lock();
         tasks
             .iter()
-            .any(|task| !Thread::borrow_from_task(task).status().is_exited())
+            .all(|task| Thread::borrow_from_task(task).status().is_exited())
     }
 
     /// Gets the read-only credentials of the thread.


### PR DESCRIPTION
The original condition was reversed. The problem was introduced in #1328 