### PR TITLE
Add check during the conversion from `timeval_t` to `Duration`

### DIFF
--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -19,8 +19,10 @@ pub fn sys_select(
     let timeout = if timeval_addr == 0 {
         None
     } else {
-        let timeval = ctx.get_user_space().read_val::<timeval_t>(timeval_addr)?;
-        Some(Duration::from(timeval))
+        let mut timeval = ctx.get_user_space().read_val::<timeval_t>(timeval_addr)?;
+        timeval.sec += timeval.usec / 1_000_000;
+        timeval.usec %= 1_000_000;
+        Some(Duration::try_from(timeval)?)
     };
 
     do_sys_select(

--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -19,9 +19,10 @@ pub fn sys_select(
     let timeout = if timeval_addr == 0 {
         None
     } else {
-        let mut timeval = ctx.get_user_space().read_val::<timeval_t>(timeval_addr)?;
-        timeval.sec += timeval.usec / 1_000_000;
-        timeval.usec %= 1_000_000;
+        let timeval = ctx
+            .get_user_space()
+            .read_val::<timeval_t>(timeval_addr)?
+            .normalize();
         Some(Duration::try_from(timeval)?)
     };
 

--- a/kernel/src/syscall/setitimer.rs
+++ b/kernel/src/syscall/setitimer.rs
@@ -34,8 +34,8 @@ pub fn sys_setitimer(
     }
     let user_space = ctx.get_user_space();
     let new_itimerval = user_space.read_val::<itimerval_t>(new_itimerval_addr)?;
-    let interval = Duration::from(new_itimerval.it_interval);
-    let expire_time = Duration::from(new_itimerval.it_value);
+    let interval = Duration::try_from(new_itimerval.it_interval)?;
+    let expire_time = Duration::try_from(new_itimerval.it_value)?;
 
     let process_timer_manager = ctx.process.timer_manager();
     let timer = match ItimerType::try_from(itimer_type)? {


### PR DESCRIPTION
Fix #1349 

Linux checks the value of `timeval` when call system call `select` and `setitimer`.

Refer to check in `setitimer`:
https://elixir.bootlin.com/linux/v6.10.5/source/kernel/time/itimer.c#L321

Refer to check in `select`:
https://elixir.bootlin.com/linux/v6.10.5/source/fs/select.c#L278