### PR TITLE
Optimize SQLite performance

### DIFF
--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -960,7 +960,7 @@ impl Inner {
     pub fn extend_write_at(&mut self, offset: usize, reader: &mut VmReader) -> Result<usize> {
         let write_len = reader.remain();
         let new_size = offset + write_len;
-        self.page_cache.resize(new_size)?;
+        self.page_cache.resize(new_size.align_up(BLOCK_SIZE))?;
         self.page_cache.pages().write(offset, reader)?;
         self.inode_impl.resize(new_size)?;
         Ok(write_len)

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -5,6 +5,7 @@ use core::{
     time::Duration,
 };
 
+use align_ext::AlignExt;
 use aster_block::bio::BioWaiter;
 use aster_rights::Full;
 use aster_util::slot_vec::SlotVec;
@@ -614,7 +615,7 @@ impl Inode for RamInode {
                 let new_size = offset + write_len;
                 let should_expand_size = new_size > file_size;
                 if should_expand_size {
-                    page_cache.resize(new_size)?;
+                    page_cache.resize(new_size.align_up(BLOCK_SIZE))?;
                 }
                 page_cache.pages().write(offset, reader)?;
 


### PR DESCRIPTION
This PR will optimize the performance of SQLite in ramfs and ext2:
1. SQLite-ramfs: Performance improves from 3.759s to 2.201s, reaching 94% of Linux performance.
2. SQLite-ext2: Performance improves from 4.839s to 3.376s, reaching 97.6% of Linux performance.

