### PR TITLE
Hide Semaphores on the overview temporarily

### DIFF
--- a/test/benchmark/lmbench/semaphore_lat/config.json
+++ b/test/benchmark/lmbench/semaphore_lat/config.json
@@ -4,5 +4,6 @@
     "search_pattern": "Semaphore latency:",
     "result_index": "3",
     "description": "lat_sem",
-    "title": "[Semaphores] The cost of semop"
+    "title": "[Semaphores] The cost of semop",
+    "show_in_overview": "false"
 }


### PR DESCRIPTION
This PR hides [Semaphores] of lmbench on the overview temporarily. 