### PR TITLE
Block failed syscall tests

### DIFF
--- a/test/syscall_test/blocklists/fcntl_test
+++ b/test/syscall_test/blocklists/fcntl_test
@@ -29,3 +29,5 @@ FcntlLockTest.SetLockSymlink
 FcntlLockTest.SetLockProc
 FcntlLockTest.SetLockPipe
 FcntlLockTest.SetLockSocket
+# SetReadLockThenBlockingWriteLock suffers from a panic from ostd.
+FcntlLockTest.SetReadLockThenBlockingWriteLock

--- a/test/syscall_test/blocklists/futex_test
+++ b/test/syscall_test/blocklists/futex_test
@@ -9,7 +9,11 @@ SharedPrivate/PrivateAndSharedFutexTest.PIConcurrency_NoRandomSave/*
 SharedPrivate/PrivateAndSharedFutexTest.PIWaiters/*
 SharedPrivate/PrivateAndSharedFutexTest.PITryLock/*
 SharedPrivate/PrivateAndSharedFutexTest.PITryLockConcurrency_NoRandomSave/*
-
+# WakeAll_NoRandomSave/* encounters a segmenation fault
+SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/0
+SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/1
 SharedPrivate/PrivateAndSharedFutexTest.WakeSome_NoRandomSave/1
 SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon_NoRandomSave/*
 SharedPrivate/PrivateAndSharedFutexTest.WakeWrongKind_NoRandomSave/*
+# WakeAfterCOWBreak_NoRandomSave/* hangs sometimes
+SharedPrivate/PrivateAndSharedFutexTest.WakeAfterCOWBreak_NoRandomSave/0


### PR DESCRIPTION
Recent SMP Syscall test often fails. Locally, I find the following cases encounter segmentation fault and timeout.
```log
These two can be triggered when we run futex_test independently:
SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/0
SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/1

This one can only be triggered under the full amount of tests:
SharedPrivate/PrivateAndSharedFutexTest.WakeAfterCOWBreak_NoRandomSave/0

This one can only be triggered online:
FcntlLockTest.SetReadLockThenBlockingWriteLock
```

Another observation is that `make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4 LOG_LEVEL=debug` never fails but `make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4` does. Changing the `BOOT_PROTOCOL` to `linux-legacy32` also solves this problem.