### PR TITLE
Set fail-fast to false to avoid cancelling normal steps

### DIFF
--- a/.github/workflows/test_asterinas.yml
+++ b/.github/workflows/test_asterinas.yml
@@ -63,6 +63,7 @@ jobs:
           - 'smp_syscall_test_mb2'
           - 'test_linux'
           - 'smp_test_mb2'
+      fail-fast: false
 
     steps:
       - run: echo "Running in asterinas/asterinas:0.8.3"

--- a/.github/workflows/test_osdk.yml
+++ b/.github/workflows/test_osdk.yml
@@ -24,6 +24,7 @@ jobs:
         # asterinas/asterinas:0.8.3 container is the developing container of asterinas,
         # asterinas/osdk:0.8.3 container is built with the intructions from Asterinas Book
         container: ['asterinas/asterinas:0.8.3', 'asterinas/osdk:0.8.3']
+      fail-fast: false
     container: ${{ matrix.container }}
     steps:
       - run: echo "Running in ${{ matrix.container }}"
@@ -56,6 +57,7 @@ jobs:
         # asterinas/asterinas:0.8.3-tdx container is the developing container of asterinas,
         # asterinas/osdk:0.8.3-tdx container is built with the intructions from Asterinas Book
         container: ['asterinas/asterinas:0.8.3-tdx', 'asterinas/osdk:0.8.3-tdx']
+      fail-fast: false
     container: 
       image: ${{ matrix.container }}
       options: --device=/dev/kvm --privileged


### PR DESCRIPTION
This PR set `fail-fast: false` for integration-test and osdk-test which avoids mutual interference between test cases.