### PR TITLE
Clean up the frame buffer state in `ostd::mm`

### DIFF
--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -16,7 +16,7 @@ use core::{
 use component::{init_component, ComponentInitError};
 use font8x8::UnicodeFonts;
 use ostd::{
-    boot,
+    boot::{self, memory_region::MemoryRegionType, memory_regions},
     io_mem::IoMem,
     mm::{VmIo, PAGE_SIZE},
     sync::SpinLock,
@@ -39,8 +39,10 @@ pub(crate) fn init() {
     let mut writer = {
         let framebuffer = boot::framebuffer_arg();
         let mut size = 0;
-        for i in ostd::mm::FRAMEBUFFER_REGIONS.get().unwrap().iter() {
-            size = i.len();
+        for region in memory_regions() {
+            if region.typ() == MemoryRegionType::Framebuffer {
+                size = region.len();
+            }
         }
 
         let page_size = size / PAGE_SIZE;

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -86,7 +86,7 @@ pub unsafe fn init() {
 
     mm::page::allocator::init();
     mm::kspace::init_kernel_page_table(mm::init_page_meta());
-    mm::misc_init();
+    mm::dma::init();
 
     // SAFETY: This function is called only once in the entire system.
     unsafe { trap::softirq::init() };

--- a/ostd/src/mm/kspace.rs
+++ b/ostd/src/mm/kspace.rs
@@ -53,9 +53,12 @@ use super::{
     },
     page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
     page_table::{KernelMode, PageTable},
-    MemoryRegionType, Paddr, PagingConstsTrait, Vaddr, PAGE_SIZE,
+    Paddr, PagingConstsTrait, Vaddr, PAGE_SIZE,
 };
-use crate::arch::mm::{PageTableEntry, PagingConsts};
+use crate::{
+    arch::mm::{PageTableEntry, PagingConsts},
+    boot::memory_region::MemoryRegionType,
+};
 
 /// The shortest supported address width is 39 bits. And the literal
 /// values are written for 48 bits address width. Adjust the values

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -20,10 +20,7 @@ pub(crate) mod page_table;
 pub mod stat;
 pub mod vm_space;
 
-use alloc::vec::Vec;
 use core::{fmt::Debug, ops::Range};
-
-use spin::Once;
 
 pub use self::{
     dma::{Daddr, DmaCoherent, DmaDirection, DmaStream, DmaStreamSlice, HasDaddr},
@@ -39,10 +36,7 @@ pub(crate) use self::{
     kspace::paddr_to_vaddr, page::meta::init as init_page_meta, page_prop::PrivilegedPageFlags,
     page_table::PageTable,
 };
-use crate::{
-    arch::mm::PagingConsts,
-    boot::memory_region::{MemoryRegion, MemoryRegionType},
-};
+use crate::arch::mm::PagingConsts;
 
 /// The level of a page table node or a frame.
 pub type PagingLevel = u8;
@@ -118,19 +112,4 @@ pub trait HasPaddr {
 /// Checks if the given address is page-aligned.
 pub const fn is_page_aligned(p: usize) -> bool {
     (p & (PAGE_SIZE - 1)) == 0
-}
-
-/// Memory regions used for frame buffer.
-pub static FRAMEBUFFER_REGIONS: Once<Vec<MemoryRegion>> = Once::new();
-
-pub(crate) fn misc_init() {
-    dma::init();
-
-    let mut framebuffer_regions = Vec::new();
-    for i in crate::boot::memory_regions() {
-        if i.typ() == MemoryRegionType::Framebuffer {
-            framebuffer_regions.push(*i);
-        }
-    }
-    FRAMEBUFFER_REGIONS.call_once(|| framebuffer_regions);
 }


### PR DESCRIPTION
Just some rudimentary clean up. The frame buffer info can be obtained from the boot API so mm can relief from it.