### PR TITLE
Check negative `sec` before timespec_t::from<timeval_t>

### DIFF
--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -189,7 +189,13 @@ fn do_futimesat(
 ) -> Result<SyscallReturn> {
     let times = if timeval_ptr != 0 {
         let (autime, mutime) = read_time_from_user::<timeval_t>(timeval_ptr, ctx)?;
-        if autime.usec >= 1000000 || autime.usec < 0 || mutime.usec >= 1000000 || mutime.usec < 0 {
+        if autime.usec >= 1000000
+            || autime.usec < 0
+            || autime.sec < 0
+            || mutime.usec >= 1000000
+            || mutime.usec < 0
+            || mutime.sec < 0
+        {
             return_errno_with_message!(Errno::EINVAL, "Invalid time");
         }
         let (autime, mutime) = (timespec_t::from(autime), timespec_t::from(mutime));


### PR DESCRIPTION
Fix #1348 

Linux accept negative `sec` in system call `utimes` to change the file time to before UNIX time 0 (1970.1.1):
```bash
root@tca:~/asterinas/test# ls -ll /dev/null 
crw-rw-rw- 1 root root 1, 3 Sep 20 02:00 /dev/null
root@tca:~/asterinas/test# ls -ll /dev/null 
crw-rw-rw- 1 root root 1, 3 Sep 20 02:00 /dev/null
root@tca:~/asterinas/test# ./build/initramfs/root/utimes.c 
utimes: Success
root@tca:~/asterinas/test# ls -ll /dev/null 
crw-rw-rw- 1 root root 1, 3 Dec 31  1969 /dev/null
```

Since Asterinas only calls `timespec_t::from<timeval_t>` in `do_futimesat()`, it should be OK to remove the `assert` of `sec` here.