### PR TITLE
Bump the OSDK's Cargo.lock when bumping the versions

### DIFF
--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-osdk"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -131,8 +131,9 @@ update_package_version ${OSDK_CARGO_TOML_PATH}
 update_package_version ${OSDK_TEST_RUNNER_CARGO_TOML_PATH}
 update_dep_version ${OSDK_TEST_RUNNER_CARGO_TOML_PATH} ostd
 
-# Automatically bump Cargo.lock file
-cargo update -p aster-nix --precise $new_version
+# Automatically bump Cargo.lock files
+cargo update -p aster-nix --precise $new_version # For Cargo.lock
+cd osdk && cargo update -p cargo-osdk --precise $new_version # For osdk/Cargo.lock
 
 # Update Docker image versions in README files
 update_image_versions ${ASTER_SRC_DIR}/README.md


### PR DESCRIPTION
When the version is bumped with the script, `OSDK/Cargo.lock` is not automatically updated. If the developer uses rust-analyzer there would be unwanted unstaged workspace changes, which is annoying. It is better to keep the updates of the lock file within the same commit of change too.