### PR TITLE
Introduce `cargo osdk profile` for flame graph profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
 
 # GDB debugging and profiling options.
 GDB_TCP_PORT ?= 1234
-GDB_PROFILE_FORMAT ?= folded
+GDB_PROFILE_FORMAT ?= flame-graph
 GDB_PROFILE_COUNT ?= 200
 GDB_PROFILE_INTERVAL ?= 0.1
 # End of GDB options.

--- a/Makefile
+++ b/Makefile
@@ -199,8 +199,7 @@ endif
 
 .PHONY: gdb_server
 gdb_server: initramfs $(CARGO_OSDK)
-	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server --gdb-wait-client --gdb-vsc \
-		--gdb-server-addr :$(GDB_TCP_PORT)
+	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server wait-client,vscode,addr=:$(GDB_TCP_PORT)
 
 .PHONY: gdb_client
 gdb_client: $(CARGO_OSDK)
@@ -208,7 +207,7 @@ gdb_client: $(CARGO_OSDK)
 
 .PHONY: profile_server
 profile_server: initramfs $(CARGO_OSDK)
-	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server --gdb-server-addr :$(GDB_TCP_PORT)
+	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server addr=:$(GDB_TCP_PORT)
 
 .PHONY: profile_client
 profile_client: $(CARGO_OSDK)

--- a/docs/src/osdk/reference/commands/README.md
+++ b/docs/src/osdk/reference/commands/README.md
@@ -11,6 +11,7 @@ Currently, OSDK supports the following subcommands:
 - **run**: Run the kernel with a VMM
 - **test**: Execute kernel mode unit test by starting a VMM
 - **debug**: Debug a remote target via GDB
+- **profile**: Profile a remote GDB debug target to collect stack traces
 - **check**: Analyze the current package and report errors
 - **clippy**: Check the current package and catch common mistakes
 

--- a/docs/src/osdk/reference/commands/debug.md
+++ b/docs/src/osdk/reference/commands/debug.md
@@ -2,12 +2,17 @@
 
 ## Overview
 
-`cargo osdk debug` is used to debug a remote target via GDB.
-The usage is as follows:
+`cargo osdk debug` is used to debug a remote target via GDB. You need to start
+a running server to debug with. This is accomplished by the `run` subcommand
+with `--gdb-server`. Then you can use the following command to attach to the
+server and do debugging.
 
 ```bash
 cargo osdk debug [OPTIONS]
 ```
+
+Note that when KVM is enabled, hardware-assisted break points (`hbreak`) are
+needed instead of the normal break points (`break`/`b`) in GDB.
 
 ## Options
 
@@ -18,13 +23,18 @@ or a TCP port on an IP address.
 
 ## Examples
 
-- To debug a remote target via a
-[QEMU GDB stub](https://www.qemu.org/docs/master/system/gdb.html),
-    - connect to an unix socket, e.g., `./debug`;
-    ```bash
-    cargo osdk debug --remote ./debug
-    ```
-    - connect to a TCP port (`[IP]:PORT`), e.g., `localhost:1234`.
-    ```bash
-    cargo osdk debug --remote localhost:1234
-    ```
+To debug a remote target started with
+[QEMU GDB stub](https://www.qemu.org/docs/master/system/gdb.html) or the `run`
+subcommand, use the following commands.
+
+Connect to an unix socket, e.g., `./debug`:
+
+```bash
+cargo osdk debug --remote ./debug
+```
+
+Connect to a TCP port (`[IP]:PORT`), e.g., `localhost:1234`:
+
+```bash
+cargo osdk debug --remote localhost:1234
+```

--- a/docs/src/osdk/reference/commands/debug.md
+++ b/docs/src/osdk/reference/commands/debug.md
@@ -17,7 +17,7 @@ needed instead of the normal break points (`break`/`b`) in GDB.
 ## Options
 
 `--remote <REMOTE>`:
-Specify the address of the remote target [default: .aster-gdb-socket].
+Specify the address of the remote target [default: .osdk-gdb-socket].
 The address can be either a path for the UNIX domain socket
 or a TCP port on an IP address.
 

--- a/docs/src/osdk/reference/commands/profile.md
+++ b/docs/src/osdk/reference/commands/profile.md
@@ -13,7 +13,7 @@ used to directly generate a flame graph, or be stored for later analysis using
 `--remote <REMOTE>`:
 
 Specify the address of the remote target.
-By default this is `.aster-gdb-socket`
+By default this is `.osdk-gdb-socket`
 
 `--samples <SAMPLES>`:
 

--- a/docs/src/osdk/reference/commands/profile.md
+++ b/docs/src/osdk/reference/commands/profile.md
@@ -1,0 +1,74 @@
+# cargo osdk profile
+
+## Overview
+
+The profile command is used to collect stack traces when running the target
+kernel in QEMU. It attaches to the GDB server initiated with the run subcommand
+and collects the stack trace periodically. The collected data can be
+further analyzed using tools like
+[flame graph](https://github.com/brendangregg/FlameGraph).
+
+## Options
+
+`--remote <REMOTE>`:
+
+Specify the address of the remote target.
+By default this is `.aster-gdb-socket`
+
+`--samples <SAMPLES>`:
+
+The number of samples to collect (default 200).
+It is recommended to go beyond 100 for performance analysis.
+
+`--interval <INTERVAL>`:
+
+The interval between samples in seconds (default 0.1).
+
+`--parse <PATH>`:
+
+Parse a collected JSON profile file into other formats.
+
+`--format <FORMAT>`:
+
+Possible values:
+    - `json`:   The parsed stack trace log from GDB in JSON.
+    - `folded`: The folded stack trace for flame graph.
+
+If the user does not specify the format, it will be inferred from the
+output file extension. If the output file does not have an extension,
+the default format is folded stack traces.
+
+`--cpu-mask <CPU_MASK>`:
+
+The mask of the CPU to generate traces for in the output profile data
+(default first 128 cores). This mask is presented as an integer.
+
+`--output <PATH>`:
+
+The path to the output profile data file.
+
+If the user does not specify the output path, it will be generated from
+the crate name, current time stamp and the format.
+
+## Examples
+
+To profile a remote QEMU GDB server running some workload for flame graph, do:
+
+```bash
+cargo osdk profile --remote :1234 \
+	--samples 100 --interval 0.01
+```
+
+If wanted a detailed analysis, do:
+
+```bash
+cargo osdk profile --remote :1234 \
+	--samples 100 --interval 0.01 --output trace.json
+```
+
+When you get the above detailed analysis, you can also use the JSON file
+to generate the folded format for flame graph.
+
+```bash
+cargo osdk profile --parse trace.json --output trace.folded
+```

--- a/docs/src/osdk/reference/commands/profile.md
+++ b/docs/src/osdk/reference/commands/profile.md
@@ -4,9 +4,9 @@
 
 The profile command is used to collect stack traces when running the target
 kernel in QEMU. It attaches to the GDB server initiated with the run subcommand
-and collects the stack trace periodically. The collected data can be
-further analyzed using tools like
-[flame graph](https://github.com/brendangregg/FlameGraph).
+and collects the stack trace periodically. The collected information can be
+used to directly generate a flame graph, or be stored for later analysis using
+[the original flame graph tool](https://github.com/brendangregg/FlameGraph).
 
 ## Options
 
@@ -33,10 +33,11 @@ Parse a collected JSON profile file into other formats.
 Possible values:
     - `json`:   The parsed stack trace log from GDB in JSON.
     - `folded`: The folded stack trace for flame graph.
+    - `flame-graph`: A SVG flame graph.
 
 If the user does not specify the format, it will be inferred from the
 output file extension. If the output file does not have an extension,
-the default format is folded stack traces.
+the default format is flame graph.
 
 `--cpu-mask <CPU_MASK>`:
 

--- a/docs/src/osdk/reference/commands/run.md
+++ b/docs/src/osdk/reference/commands/run.md
@@ -17,9 +17,10 @@ for more details.
 
 Options related with debugging:
 
-- `-G, --enable-gdb`: Enable QEMU GDB server for debugging.
-- `--vsc`: Generate a '.vscode/launch.json' for debugging kernel with Visual Studio Code
-(only works when QEMU GDB server is enabled, i.e., `--enable-gdb`).
+- `--gdb-server`: Enable QEMU GDB server for debugging.
+- `--gdb-wait-client`: Let the QEMU GDB server wait for the client connection before execution.
+- `--gdb-vsc`: Generate a '.vscode/launch.json' for debugging kernel with Visual Studio Code
+(only works when QEMU GDB server is enabled, i.e., `--gdb-server`).
 Requires [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
 - `--gdb-server-addr <ADDR>`: The network address on which the GDB server listens,
 it can be either a path for the UNIX domain socket or a TCP port on an IP address.
@@ -29,20 +30,20 @@ See [Debug Command](debug.md) to interact with the GDB server in terminal.
 
 ## Examples
 
-- Launch a debug server via QEMU with an unix socket stub, e.g. `.debug`:
+Launch a debug server via QEMU with an unix socket stub, e.g. `.debug`:
 
 ```bash
-cargo osdk run --enable-gdb --gdb-server-addr .debug
+cargo osdk run --gdb-server --gdb-server-addr .debug
 ```
 
-- Launch a debug server via QEMU with a TCP stub, e.g., `localhost:1234`:
+Launch a debug server via QEMU with a TCP stub, e.g., `localhost:1234`:
 
 ```bash
-cargo osdk run --enable-gdb --gdb-server-addr :1234
+cargo osdk run --gdb-server --gdb-server-addr :1234
 ```
 
-- Launch a debug server via QEMU and use VSCode to interact:
+Launch a debug server via QEMU and use VSCode to interact:
 
 ```bash
-cargo osdk run --enable-gdb --vsc --gdb-server-addr :1234
+cargo osdk run --gdb-server --gdb-vsc --gdb-server-addr :1234
 ```

--- a/docs/src/osdk/reference/commands/run.md
+++ b/docs/src/osdk/reference/commands/run.md
@@ -24,7 +24,7 @@ Options related with debugging:
 Requires [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
 - `--gdb-server-addr <ADDR>`: The network address on which the GDB server listens,
 it can be either a path for the UNIX domain socket or a TCP port on an IP address.
-[default: `.aster-gdb-socket`(a local UNIX socket)]
+[default: `.osdk-gdb-socket`(a local UNIX socket)]
 
 See [Debug Command](debug.md) to interact with the GDB server in terminal.
 

--- a/docs/src/osdk/reference/commands/run.md
+++ b/docs/src/osdk/reference/commands/run.md
@@ -15,16 +15,15 @@ Most options are the same as those of `cargo osdk build`.
 Refer to the [documentation](build.md) of `cargo osdk build`
 for more details.
 
-Options related with debugging:
+Additionally, when running the kernel using QEMU, we can setup the QEMU as a
+debug server using option `--gdb-server`. This option supports an additional
+comma separated configuration list:
 
-- `--gdb-server`: Enable QEMU GDB server for debugging.
-- `--gdb-wait-client`: Let the QEMU GDB server wait for the client connection before execution.
-- `--gdb-vsc`: Generate a '.vscode/launch.json' for debugging kernel with Visual Studio Code
-(only works when QEMU GDB server is enabled, i.e., `--gdb-server`).
-Requires [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
-- `--gdb-server-addr <ADDR>`: The network address on which the GDB server listens,
-it can be either a path for the UNIX domain socket or a TCP port on an IP address.
-[default: `.osdk-gdb-socket`(a local UNIX socket)]
+ - `addr=ADDR`: the network or unix socket address on which the GDB server listens
+    (default: `.osdk-gdb-socket`, a local UNIX socket);
+ - `wait-client`: let the GDB server wait for the GDB client before execution;
+ - `vscode`: generate a '.vscode/launch.json' for debugging with Visual Studio Code
+    (Requires [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)).
 
 See [Debug Command](debug.md) to interact with the GDB server in terminal.
 
@@ -33,17 +32,17 @@ See [Debug Command](debug.md) to interact with the GDB server in terminal.
 Launch a debug server via QEMU with an unix socket stub, e.g. `.debug`:
 
 ```bash
-cargo osdk run --gdb-server --gdb-server-addr .debug
+cargo osdk run --gdb-server addr=.debug
 ```
 
 Launch a debug server via QEMU with a TCP stub, e.g., `localhost:1234`:
 
 ```bash
-cargo osdk run --gdb-server --gdb-server-addr :1234
+cargo osdk run --gdb-server addr=:1234
 ```
 
-Launch a debug server via QEMU and use VSCode to interact:
+Launch a debug server via QEMU and use VSCode to interact with:
 
 ```bash
-cargo osdk run --gdb-server --gdb-vsc --gdb-server-addr :1234
+cargo osdk run --gdb-server wait-client,vscode,addr=:1234
 ```

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -36,6 +36,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "bytemuck"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,9 +176,11 @@ name = "cargo-osdk"
 version = "0.8.3"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "env_logger",
  "indexmap",
+ "indicatif",
  "lazy_static",
  "linux-bzimage-builder",
  "log",
@@ -167,10 +196,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "clap"
@@ -217,6 +269,25 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -284,6 +355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +422,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,10 +455,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -420,10 +551,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "portable-atomic"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
 name = "predicates"
@@ -648,6 +800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +824,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -99,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +131,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -181,6 +194,7 @@ dependencies = [
  "env_logger",
  "indexmap",
  "indicatif",
+ "inferno",
  "lazy_static",
  "linux-bzimage-builder",
  "log",
@@ -317,6 +331,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +360,20 @@ name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "difflib"
@@ -400,6 +443,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +468,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "humantime"
@@ -468,12 +528,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -499,9 +593,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libflate"
@@ -531,11 +625,21 @@ dependencies = [
 name = "linux-bzimage-builder"
 version = "0.2.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "libflate",
  "serde",
  "xmas-elf",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -549,6 +653,16 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-traits"
@@ -570,6 +684,19 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -614,12 +741,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -661,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +825,12 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -728,6 +888,18 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strsim"
@@ -825,6 +997,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -19,8 +19,10 @@ version = "0.2.0"
 
 [dependencies]
 clap = { version = "4.4.17", features = ["cargo", "derive"] }
+chrono = "0.4.38"
 env_logger = "0.11.0"
 indexmap = "2.2.1"
+indicatif = "0.17.8" # For a commandline progress bar
 lazy_static = "1.4.0"
 log = "0.4.20"
 quote = "1.0.35"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -21,6 +21,7 @@ version = "0.2.0"
 clap = { version = "4.4.17", features = ["cargo", "derive"] }
 chrono = "0.4.38"
 env_logger = "0.11.0"
+inferno = "0.11.21"
 indexmap = "2.2.1"
 indicatif = "0.17.8" # For a commandline progress bar
 lazy_static = "1.4.0"

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -37,7 +37,7 @@ pub fn main() {
         OsdkSubcommand::Run(run_args) => {
             execute_run_command(
                 &load_config(&run_args.common_args),
-                &run_args.gdb_server_args,
+                run_args.gdb_server.as_deref(),
             );
         }
         OsdkSubcommand::Debug(debug_args) => {
@@ -168,44 +168,20 @@ pub struct BuildArgs {
 
 #[derive(Debug, Parser)]
 pub struct RunArgs {
-    #[command(flatten)]
-    pub gdb_server_args: GdbServerArgs,
-    #[command(flatten)]
-    pub common_args: CommonArgs,
-}
-
-#[derive(Debug, Args, Clone, Default)]
-pub struct GdbServerArgs {
     #[arg(
         long = "gdb-server",
-        help = "Enable the QEMU GDB server for debugging",
-        default_value_t
+        help = "Enable the QEMU GDB server for debugging\n\
+                This option supports an additional comma separated configuration list:\n\t \
+                    addr=ADDR:   the network or unix socket address on which the GDB server listens, \
+                                 `.osdk-gdb-socket` by default;\n\t \
+                    wait-client: let the GDB server wait for the GDB client before execution;\n\t \
+                    vscode:      generate a '.vscode/launch.json' for debugging with Visual Studio Code.",
+        value_name = "[addr=ADDR][,wait-client][,vscode]",
+        default_missing_value = ""
     )]
-    pub enabled: bool,
-    #[arg(
-        long = "gdb-wait-client",
-        help = "Let the QEMU GDB server wait for the GDB client before execution",
-        default_value_t,
-        requires = "enabled"
-    )]
-    pub wait_client: bool,
-    #[arg(
-        long = "gdb-vsc",
-        help = "Generate a '.vscode/launch.json' for debugging with Visual Studio Code \
-                (only works when '--enable-gdb' is enabled)",
-        default_value_t,
-        requires = "enabled"
-    )]
-    pub vsc_launch_file: bool,
-    #[arg(
-        long = "gdb-server-addr",
-        help = "The network address on which the GDB server listens, \
-        it can be either a path for the UNIX domain socket or a TCP port on an IP address.",
-        value_name = "ADDR",
-        default_value = ".osdk-gdb-socket",
-        requires = "enabled"
-    )]
-    pub host_addr: String,
+    pub gdb_server: Option<String>,
+    #[command(flatten)]
+    pub common_args: CommonArgs,
 }
 
 #[derive(Debug, Parser)]

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -254,9 +254,11 @@ pub struct ProfileArgs {
 pub enum ProfileFormat {
     /// The raw stack trace log parsed from GDB in JSON
     Json,
-    /// The folded stack trace for a
-    /// [flame graph](https://github.com/brendangregg/FlameGraph)
+    /// The folded stack trace for generating a flame graph later using
+    /// [the original tool](https://github.com/brendangregg/FlameGraph)
     Folded,
+    /// A SVG flame graph
+    FlameGraph,
 }
 
 impl ProfileFormat {
@@ -264,6 +266,7 @@ impl ProfileFormat {
         match self {
             ProfileFormat::Json => "json",
             ProfileFormat::Folded => "folded",
+            ProfileFormat::FlameGraph => "svg",
         }
     }
 }
@@ -291,17 +294,18 @@ impl DebugProfileOutArgs {
     ///
     /// If the user does not specify the format, it will be inferred from the
     /// output file extension. If the output file does not have an extension,
-    /// the default format is folded stack traces.
+    /// the default format is flame graph.
     pub fn format(&self) -> ProfileFormat {
         self.format.unwrap_or_else(|| {
             if self.output.is_some() {
                 match self.output.as_ref().unwrap().extension() {
                     Some(ext) if ext == "folded" => ProfileFormat::Folded,
                     Some(ext) if ext == "json" => ProfileFormat::Json,
-                    _ => ProfileFormat::Folded,
+                    Some(ext) if ext == "svg" => ProfileFormat::FlameGraph,
+                    _ => ProfileFormat::FlameGraph,
                 }
             } else {
-                ProfileFormat::Folded
+                ProfileFormat::FlameGraph
             }
         })
     }

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -202,7 +202,7 @@ pub struct GdbServerArgs {
         help = "The network address on which the GDB server listens, \
         it can be either a path for the UNIX domain socket or a TCP port on an IP address.",
         value_name = "ADDR",
-        default_value = ".aster-gdb-socket",
+        default_value = ".osdk-gdb-socket",
         requires = "enabled"
     )]
     pub host_addr: String,
@@ -213,7 +213,7 @@ pub struct DebugArgs {
     #[arg(
         long,
         help = "Specify the address of the remote target",
-        default_value = ".aster-gdb-socket"
+        default_value = ".osdk-gdb-socket"
     )]
     pub remote: String,
     #[command(flatten)]
@@ -225,7 +225,7 @@ pub struct ProfileArgs {
     #[arg(
         long,
         help = "Specify the address of the remote target",
-        default_value = ".aster-gdb-socket"
+        default_value = ".osdk-gdb-socket"
     )]
     pub remote: String,
     #[arg(long, help = "The number of samples to collect", default_value = "200")]

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -2,13 +2,13 @@
 
 use std::path::PathBuf;
 
-use clap::{crate_version, Args, Parser};
+use clap::{crate_version, Args, Parser, ValueEnum};
 
 use crate::{
     arch::Arch,
     commands::{
         execute_build_command, execute_debug_command, execute_forwarded_command,
-        execute_new_command, execute_run_command, execute_test_command,
+        execute_new_command, execute_profile_command, execute_run_command, execute_test_command,
     },
     config::{
         manifest::{ProjectType, TomlManifest},
@@ -46,6 +46,12 @@ pub fn main() {
                 debug_args,
             );
         }
+        OsdkSubcommand::Profile(profile_args) => {
+            execute_profile_command(
+                &load_config(&profile_args.common_args).run.build.profile,
+                profile_args,
+            );
+        }
         OsdkSubcommand::Test(test_args) => {
             execute_test_command(&load_config(&test_args.common_args), test_args);
         }
@@ -79,6 +85,8 @@ pub enum OsdkSubcommand {
     Run(RunArgs),
     #[command(about = "Debug a remote target via GDB")]
     Debug(DebugArgs),
+    #[command(about = "Profile a remote GDB debug target to collect stack traces for flame graph")]
+    Profile(ProfileArgs),
     #[command(about = "Execute kernel mode unit test by starting a VMM")]
     Test(TestArgs),
     #[command(about = "Check a local package and all of its dependencies for errors")]
@@ -168,19 +176,25 @@ pub struct RunArgs {
 
 #[derive(Debug, Args, Clone, Default)]
 pub struct GdbServerArgs {
-    /// Whether to enable QEMU GDB server for debugging
     #[arg(
-        long = "enable-gdb",
-        short = 'G',
-        help = "Enable QEMU GDB server for debugging",
+        long = "gdb-server",
+        help = "Enable the QEMU GDB server for debugging",
         default_value_t
     )]
-    pub is_gdb_enabled: bool,
+    pub enabled: bool,
     #[arg(
-        long = "vsc",
+        long = "gdb-wait-client",
+        help = "Let the QEMU GDB server wait for the GDB client before execution",
+        default_value_t,
+        requires = "enabled"
+    )]
+    pub wait_client: bool,
+    #[arg(
+        long = "gdb-vsc",
         help = "Generate a '.vscode/launch.json' for debugging with Visual Studio Code \
                 (only works when '--enable-gdb' is enabled)",
-        default_value_t
+        default_value_t,
+        requires = "enabled"
     )]
     pub vsc_launch_file: bool,
     #[arg(
@@ -188,9 +202,10 @@ pub struct GdbServerArgs {
         help = "The network address on which the GDB server listens, \
         it can be either a path for the UNIX domain socket or a TCP port on an IP address.",
         value_name = "ADDR",
-        default_value = ".aster-gdb-socket"
+        default_value = ".aster-gdb-socket",
+        requires = "enabled"
     )]
-    pub gdb_server_addr: String,
+    pub host_addr: String,
 }
 
 #[derive(Debug, Parser)]
@@ -203,6 +218,120 @@ pub struct DebugArgs {
     pub remote: String,
     #[command(flatten)]
     pub common_args: CommonArgs,
+}
+
+#[derive(Debug, Parser)]
+pub struct ProfileArgs {
+    #[arg(
+        long,
+        help = "Specify the address of the remote target",
+        default_value = ".aster-gdb-socket"
+    )]
+    pub remote: String,
+    #[arg(long, help = "The number of samples to collect", default_value = "200")]
+    pub samples: usize,
+    #[arg(
+        long,
+        help = "The interval between samples in seconds",
+        default_value = "0.1"
+    )]
+    pub interval: f64,
+    #[arg(
+        long,
+        help = "Parse a collected JSON profile file into other formats",
+        value_name = "PATH",
+        conflicts_with = "samples",
+        conflicts_with = "interval"
+    )]
+    pub parse: Option<PathBuf>,
+    #[command(flatten)]
+    pub out_args: DebugProfileOutArgs,
+    #[command(flatten)]
+    pub common_args: CommonArgs,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ProfileFormat {
+    /// The raw stack trace log parsed from GDB in JSON
+    Json,
+    /// The folded stack trace for a
+    /// [flame graph](https://github.com/brendangregg/FlameGraph)
+    Folded,
+}
+
+impl ProfileFormat {
+    pub fn file_extension(&self) -> &'static str {
+        match self {
+            ProfileFormat::Json => "json",
+            ProfileFormat::Folded => "folded",
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct DebugProfileOutArgs {
+    #[arg(long, help = "The output format for the profile data")]
+    format: Option<ProfileFormat>,
+    #[arg(
+        long,
+        help = "The mask of the CPU to generate traces for in the output profile data",
+        default_value_t = u128::MAX
+    )]
+    pub cpu_mask: u128,
+    #[arg(
+        long,
+        help = "The path to the output profile data file",
+        value_name = "PATH"
+    )]
+    output: Option<PathBuf>,
+}
+
+impl DebugProfileOutArgs {
+    /// Get the output format for the profile data.
+    ///
+    /// If the user does not specify the format, it will be inferred from the
+    /// output file extension. If the output file does not have an extension,
+    /// the default format is folded stack traces.
+    pub fn format(&self) -> ProfileFormat {
+        self.format.unwrap_or_else(|| {
+            if self.output.is_some() {
+                match self.output.as_ref().unwrap().extension() {
+                    Some(ext) if ext == "folded" => ProfileFormat::Folded,
+                    Some(ext) if ext == "json" => ProfileFormat::Json,
+                    _ => ProfileFormat::Folded,
+                }
+            } else {
+                ProfileFormat::Folded
+            }
+        })
+    }
+
+    /// Get the output path for the profile data.
+    ///
+    /// If the user does not specify the output path, it will be generated from
+    /// the current time stamp and the format. The caller can provide a hint
+    /// output path to the file to override the file name.
+    pub fn output_path(&self, hint: Option<&PathBuf>) -> PathBuf {
+        self.output.clone().unwrap_or_else(|| {
+            use chrono::{offset::Local, DateTime};
+            let file_stem = if let Some(hint) = hint {
+                format!(
+                    "{}",
+                    hint.parent()
+                        .unwrap()
+                        .join(hint.file_stem().unwrap())
+                        .display()
+                )
+            } else {
+                let crate_name = crate::util::get_current_crate_info().name;
+                let time_stamp = std::time::SystemTime::now();
+                let time_stamp: DateTime<Local> = time_stamp.into();
+                let time_stamp = time_stamp.format("%H%M%S");
+                format!("{}-profile-{}", crate_name, time_stamp)
+            };
+            PathBuf::from(format!("{}.{}", file_stem, self.format().file_extension()))
+        })
+    }
 }
 
 #[derive(Debug, Parser)]

--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -18,10 +18,9 @@ pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
 
     let mut gdb = Command::new("gdb");
     gdb.args([
+        format!("{}", file_path.display()).as_str(),
         "-ex",
         format!("target remote {}", remote).as_str(),
-        "-ex",
-        format!("file {}", file_path.display()).as_str(),
     ]);
     gdb.status().unwrap();
 }

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -5,13 +5,14 @@
 mod build;
 mod debug;
 mod new;
+mod profile;
 mod run;
 mod test;
 mod util;
 
 pub use self::{
     build::execute_build_command, debug::execute_debug_command, new::execute_new_command,
-    run::execute_run_command, test::execute_test_command,
+    profile::execute_profile_command, run::execute_run_command, test::execute_test_command,
 };
 
 use crate::arch::get_default_arch;

--- a/osdk/src/commands/profile.rs
+++ b/osdk/src/commands/profile.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! OSDK profile command implementation.
+//!
+//! The profile command is used to collect stack traces when running the target
+//! kernel in QEMU. It attaches to the GDB server initiated with [`super::run`]
+//! and collects the stack trace periodically. The collected data can be
+//! further analyzed using tools like
+//! [flame graph](https://github.com/brendangregg/FlameGraph).
+
+use crate::{
+    cli::{ProfileArgs, ProfileFormat},
+    commands::util::bin_file_name,
+    util::{get_current_crate_info, get_target_directory},
+};
+use regex::Regex;
+use std::{collections::HashMap, fs::File, io::Write, path::PathBuf, process::Command};
+
+pub fn execute_profile_command(_profile: &str, args: &ProfileArgs) {
+    if let Some(parse_input) = &args.parse {
+        do_parse_stack_traces(parse_input, args);
+    } else {
+        do_collect_stack_traces(args);
+    }
+}
+
+fn do_parse_stack_traces(target_file: &PathBuf, args: &ProfileArgs) {
+    let out_args = &args.out_args;
+    let in_file = File::open(target_file).expect("Failed to open input file");
+    let profile: Profile =
+        serde_json::from_reader(in_file).expect("Failed to parse the input JSON file");
+    let out_file = File::create(out_args.output_path(Some(target_file)))
+        .expect("Failed to create output file");
+
+    let out_format = out_args.format();
+    if matches!(out_format, ProfileFormat::Json) {
+        println!("Warning: parsing JSON profile to the same format.");
+        return;
+    }
+    profile.serialize_to(out_format, out_args.cpu_mask, out_file);
+}
+
+fn do_collect_stack_traces(args: &ProfileArgs) {
+    let file_path = get_target_directory()
+        .join("osdk")
+        .join(get_current_crate_info().name)
+        .join(bin_file_name());
+
+    let remote = &args.remote;
+    let samples = &args.samples;
+    let interval = &args.interval;
+
+    let mut profile_buffer = ProfileBuffer::new();
+
+    println!("Profiling \"{}\" at \"{}\".", file_path.display(), remote);
+    use indicatif::{ProgressIterator, ProgressStyle};
+    let style = ProgressStyle::default_bar().progress_chars("#>-");
+    for _ in (0..*samples).progress_with_style(style) {
+        // Use GDB to halt the remote, get stack traces, and resume
+        let output = Command::new("gdb")
+            .args([
+                "-batch",
+                "-ex",
+                "set pagination 0",
+                "-ex",
+                &format!("file {}", file_path.display()),
+                "-ex",
+                &format!("target remote {}", remote),
+                "-ex",
+                "thread apply all bt -frame-arguments presence -frame-info short-location",
+            ])
+            .output()
+            .expect("Failed to execute gdb");
+
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            profile_buffer.append_raw_line(line);
+        }
+
+        // Sleep between samples
+        std::thread::sleep(std::time::Duration::from_secs_f64(*interval));
+    }
+
+    let out_args = &args.out_args;
+    let out_path = out_args.output_path(None);
+    println!(
+        "Profile data collected. Writing the output to \"{}\".",
+        out_path.display()
+    );
+
+    let out_file = File::create(out_path).expect("Failed to create output file");
+    profile_buffer
+        .cur_profile
+        .serialize_to(out_args.format(), out_args.cpu_mask, out_file);
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Profile {
+    // Index 0: capture; Index 1: CPU ID; Index 2: stack frame
+    stack_traces: Vec<HashMap<u32, Vec<String>>>,
+}
+
+impl Profile {
+    fn serialize_to<W: Write>(&self, format: ProfileFormat, cpu_mask: u128, mut target: W) {
+        match format {
+            ProfileFormat::Folded => {
+                let mut folded = HashMap::new();
+
+                // Process each stack trace and fold it for flame graph format
+                for capture in &self.stack_traces {
+                    for (cpu_id, stack) in capture {
+                        if *cpu_id >= 128 || cpu_mask & (1u128 << *cpu_id) == 0 {
+                            continue;
+                        }
+
+                        // Fold the stack trace
+                        let folded_key = stack.iter().rev().cloned().collect::<Vec<_>>().join(";");
+                        *folded.entry(folded_key).or_insert(0) += 1;
+                    }
+                }
+
+                // Write the folded traces
+                for (key, count) in folded {
+                    writeln!(&mut target, "{} {}", key, count)
+                        .expect("Failed to write folded output");
+                }
+            }
+            ProfileFormat::Json => {
+                // Filter out the stack traces based on the CPU mask
+                let filtered_traces = self
+                    .stack_traces
+                    .iter()
+                    .map(|capture| {
+                        capture
+                            .iter()
+                            .filter(|(cpu_id, _)| {
+                                **cpu_id < 128 && cpu_mask & (1u128 << **cpu_id) != 0
+                            })
+                            .map(|(cpu_id, stack)| (*cpu_id, stack.clone()))
+                            .collect::<HashMap<_, _>>()
+                    })
+                    .collect::<Vec<_>>();
+
+                let filtered = Profile {
+                    stack_traces: filtered_traces,
+                };
+
+                serde_json::to_writer(target, &filtered).expect("Failed to write JSON output");
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProfileBuffer {
+    cur_profile: Profile,
+    // Pre-compile regex patterns for cleaning the input.
+    hex_in_pattern: Regex,
+    impl_pattern: Regex,
+    // The state
+    cur_cpu: Option<u32>,
+}
+
+impl ProfileBuffer {
+    fn new() -> Self {
+        Self {
+            cur_profile: Profile::default(),
+            hex_in_pattern: Regex::new(r"0x[0-9a-f]+ in").unwrap(),
+            impl_pattern: Regex::new(r"::\{.*?\}").unwrap(),
+            cur_cpu: None,
+        }
+    }
+
+    fn append_raw_line(&mut self, line: &str) {
+        // Lines starting with '#' are stack frames
+        if !line.starts_with('#') {
+            // Otherwise it may initiate a new capture or a new CPU stack trace
+
+            // Check if this is a new CPU trace (starts with `Thread` and contains `CPU#N`)
+            if line.starts_with("Thread") {
+                let cpu_id_idx = line.find("CPU#").unwrap();
+                let cpu_id = line[cpu_id_idx + 4..]
+                    .split_whitespace()
+                    .next()
+                    .unwrap()
+                    .parse::<u32>()
+                    .unwrap();
+                self.cur_cpu = Some(cpu_id);
+
+                // if the new CPU id is already in the stack traces, start a new capture
+                match self.cur_profile.stack_traces.last() {
+                    Some(capture) => {
+                        if capture.contains_key(&cpu_id) {
+                            self.cur_profile.stack_traces.push(HashMap::new());
+                        }
+                    }
+                    None => {
+                        self.cur_profile.stack_traces.push(HashMap::new());
+                    }
+                }
+            }
+
+            return;
+        }
+
+        // Clean the input line
+        let mut processed = line.trim().to_string();
+
+        // Remove everything between angle brackets '<...>'
+        processed = Self::remove_generics(&processed);
+
+        // Remove "::impl{}" and hex addresses
+        processed = self.impl_pattern.replace_all(&processed, "").to_string();
+        processed = self.hex_in_pattern.replace_all(&processed, "").to_string();
+
+        // Remove unnecessary parts like "()" and "(...)"
+        processed = processed.replace("(...)", "");
+        processed = processed.replace("()", "");
+
+        // Split the line by spaces and expect the second part to be the function name
+        let parts: Vec<&str> = processed.split_whitespace().collect();
+        if parts.len() > 1 {
+            let func_name = parts[1].to_string();
+
+            // Append the function name to the latest stack trace
+            let current_capture = self.cur_profile.stack_traces.last_mut().unwrap();
+            let cur_cpu = self.cur_cpu.unwrap();
+            current_capture.entry(cur_cpu).or_default().push(func_name);
+        }
+    }
+
+    fn remove_generics(line: &str) -> String {
+        let mut result = String::new();
+        let mut bracket_depth = 0;
+
+        for c in line.chars() {
+            match c {
+                '<' => bracket_depth += 1,
+                '>' => {
+                    if bracket_depth > 0 {
+                        bracket_depth -= 1;
+                    }
+                }
+                _ => {
+                    if bracket_depth == 0 {
+                        result.push(c);
+                    }
+                }
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_profile_parse_raw() {
+    let test_case = r#"
+0xffffffff880b0f6f in aster_nix::sched::priority_scheduler::{impl#4}::pick_next_current<ostd::task::Task> (self=0xffffffff88489808 <_ZN4ostd2mm14heap_allocator10HEAP_SPACE17h85a5340e6564f69dE.llvm.15305379556759765072+992480>) at src/sched/priority_scheduler.rs:156
+156	        let next_entity = if !self.real_time_entities.is_empty() {
+
+Thread 2 (Thread 1.2 (CPU#1 [running])):
+#0  ostd::sync::spin::SpinLock<aster_nix::sched::priority_scheduler::PreemptRunQueue<ostd::task::Task>, ostd::sync::spin::PreemptDisabled>::acquire_lock<aster_nix::sched::priority_scheduler::PreemptRunQueue<ostd::task::Task>, ostd::sync::spin::PreemptDisabled> (...)
+#1  ostd::sync::spin::SpinLock<aster_nix::sched::priority_scheduler::PreemptRunQueue<ostd::task::Task>, ostd::sync::spin::PreemptDisabled>::lock<aster_nix::sched::priority_scheduler::PreemptRunQueue<ostd::task::Task>, ostd::sync::spin::PreemptDisabled> (...)
+#2  aster_nix::sched::priority_scheduler::{impl#1}::local_mut_rq_with<ostd::task::Task> (...)
+#3  0xffffffff8826b205 in ostd::task::scheduler::reschedule<ostd::task::scheduler::yield_now::{closure_env#0}> (...)
+#4  ostd::task::scheduler::yield_now ()
+#5  0xffffffff880a92c5 in ostd::task::Task::yield_now ()
+#6  aster_nix::thread::Thread::yield_now ()
+#7  aster_nix::ap_init::ap_idle_thread ()
+#8  core::ops::function::Fn::call<fn(), ()> ()
+#9  0xffffffff880b341e in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#10 aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#0} ()
+#11 0xffffffff882a3ea8 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#12 ostd::task::{impl#2}::build::kernel_task_entry ()
+#13 0x0000000000000000 in ?? ()
+
+Thread 1 (Thread 1.1 (CPU#0 [running])):
+#0  aster_nix::sched::priority_scheduler::{impl#1}::local_mut_rq_with<ostd::task::Task> (...)
+#1  0xffffffff8826b205 in ostd::task::scheduler::reschedule<ostd::task::scheduler::yield_now::{closure_env#0}> (...)
+#2  ostd::task::scheduler::yield_now ()
+#3  0xffffffff880a92c5 in ostd::task::Task::yield_now ()
+#4  aster_nix::thread::Thread::yield_now ()
+#5  aster_nix::ap_init::ap_idle_thread ()
+#6  core::ops::function::Fn::call<fn(), ()> ()
+#7  0xffffffff880b341e in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#8  aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#0} ()
+#9  0xffffffff882a3ea8 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#10 ostd::task::{impl#2}::build::kernel_task_entry ()
+#11 0x0000000000000000 in ?? ()
+[Inferior 1 (process 1) detached]
+0xffffffff880b0f6f in aster_nix::sched::priority_scheduler::{impl#4}::pick_next_current<ostd::task::Task> (self=0xffffffff88489808 <_ZN4ostd2mm14heap_allocator10HEAP_SPACE17h85a5340e6564f69dE.llvm.15305379556759765072+992480>) at src/sched/priority_scheduler.rs:156
+156	        let next_entity = if !self.real_time_entities.is_empty() {
+
+Thread 2 (Thread 1.2 (CPU#1 [running])):
+#0  0xffffffff880b0f6f in aster_nix::sched::priority_scheduler::{impl#4}::pick_next_current<ostd::task::Task> (...)
+#1  0xffffffff8826b3e0 in ostd::task::scheduler::yield_now::{closure#0} (...)
+#2  ostd::task::scheduler::reschedule::{closure#0}<ostd::task::scheduler::yield_now::{closure_env#0}> (...)
+#3  0xffffffff880b0cff in aster_nix::sched::priority_scheduler::{impl#1}::local_mut_rq_with<ostd::task::Task> (...)
+#4  0xffffffff8826b205 in ostd::task::scheduler::reschedule<ostd::task::scheduler::yield_now::{closure_env#0}> (...)
+#5  ostd::task::scheduler::yield_now ()
+#6  0xffffffff880a92c5 in ostd::task::Task::yield_now ()
+#7  aster_nix::thread::Thread::yield_now ()
+#8  aster_nix::ap_init::ap_idle_thread ()
+#9  core::ops::function::Fn::call<fn(), ()> ()
+#10 0xffffffff880b341e in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#11 aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#0} ()
+#12 0xffffffff882a3ea8 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (...)
+#13 ostd::task::{impl#2}::build::kernel_task_entry ()
+#14 0x0000000000000000 in ?? ()
+
+Thread 1 (Thread 1.1 (CPU#0 [running])):
+#0  ostd::arch::x86::interrupts_ack (...)
+#1  0xffffffff8828d704 in ostd::trap::handler::call_irq_callback_functions (...)
+#2  0xffffffff88268e48 in ostd::arch::x86::trap::trap_handler (...)
+#3  0xffffffff88274db6 in __from_kernel ()
+#4  0x0000000000000001 in ?? ()
+#5  0x0000000000000001 in ?? ()
+#6  0x00000000000001c4 in ?? ()
+#7  0xffffffff882c8580 in ?? ()
+#8  0x0000000000000002 in ?? ()
+#9  0xffffffff88489808 in _ZN4ostd2mm14heap_allocator10HEAP_SPACE17h85a5340e6564f69dE.llvm.15305379556759765072 ()
+#10 0x0000000000000000 in ?? ()
+[Inferior 1 (process 1) detached]
+"#;
+
+    let mut buffer = ProfileBuffer::new();
+    for line in test_case.lines() {
+        buffer.append_raw_line(line);
+    }
+
+    let profile = &buffer.cur_profile;
+    assert_eq!(profile.stack_traces.len(), 2);
+    assert_eq!(profile.stack_traces[0].len(), 2);
+    assert_eq!(profile.stack_traces[1].len(), 2);
+
+    let stack00 = profile.stack_traces[0].get(&0).unwrap();
+    assert_eq!(stack00.len(), 12);
+    assert_eq!(
+        stack00[0],
+        "aster_nix::sched::priority_scheduler::local_mut_rq_with"
+    );
+    assert_eq!(stack00[11], "??");
+
+    let stack01 = profile.stack_traces[0].get(&1).unwrap();
+    assert_eq!(stack01.len(), 14);
+    assert_eq!(stack01[9], "alloc::boxed::call");
+
+    let stack10 = profile.stack_traces[1].get(&0).unwrap();
+    assert_eq!(stack10.len(), 11);
+    assert_eq!(
+        stack10[9],
+        "_ZN4ostd2mm14heap_allocator10HEAP_SPACE17h85a5340e6564f69dE.llvm.15305379556759765072"
+    );
+
+    let stack11 = profile.stack_traces[1].get(&1).unwrap();
+    assert_eq!(stack11.len(), 15);
+    assert_eq!(
+        stack11[0],
+        "aster_nix::sched::priority_scheduler::pick_next_current"
+    );
+    assert_eq!(stack11[14], "??");
+}

--- a/osdk/src/commands/run.rs
+++ b/osdk/src/commands/run.rs
@@ -224,7 +224,7 @@ mod vsc {
             exit(Errno::ParseMetadata as _);
         }
         if gdb::stub_type_of(gdb_stub_addr) != gdb::StubAddrType::Tcp {
-            error_msg!("Non-TCP GDB server address is not supported under '--vsc' currently");
+            error_msg!("Non-TCP GDB server address is not supported under '--gdb-vsc' currently");
             exit(Errno::ParseMetadata as _);
         }
     }

--- a/osdk/src/error.rs
+++ b/osdk/src/error.rs
@@ -3,14 +3,15 @@
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Errno {
-    CreateCrate = 1,
-    GetMetadata = 2,
-    AddRustToolchain = 3,
-    ParseMetadata = 4,
-    ExecuteCommand = 5,
-    BuildCrate = 6,
-    RunBundle = 7,
-    BadCrateName = 8,
+    Cli = 1,
+    CreateCrate = 2,
+    GetMetadata = 3,
+    AddRustToolchain = 4,
+    ParseMetadata = 5,
+    ExecuteCommand = 6,
+    BuildCrate = 7,
+    RunBundle = 8,
+    BadCrateName = 9,
 }
 
 /// Print error message to console

--- a/osdk/tests/commands/run.rs
+++ b/osdk/tests/commands/run.rs
@@ -82,9 +82,7 @@ mod qemu_gdb_feature {
         let mut instance = cargo_osdk([
             "run",
             "--gdb-server",
-            "--gdb-wait-client",
-            "--gdb-server-addr",
-            unix_socket.as_str(),
+            format!("addr={},wait-client", unix_socket.as_str()).as_str(),
         ]);
         instance.current_dir(&workspace.os_dir());
 
@@ -112,8 +110,8 @@ mod qemu_gdb_feature {
         let mut gdb = Command::new("gdb");
         gdb.args(["-ex", format!("target remote {}", addr).as_str()]);
         gdb.write_stdin("\n")
-            .write_stdin("c\n")
-            .write_stdin("quit\n");
+            .write_stdin("quit\n")
+            .write_stdin("y\n");
         gdb.assert().success();
     }
     mod vsc {
@@ -132,18 +130,15 @@ mod qemu_gdb_feature {
             let mut instance = cargo_osdk([
                 "run",
                 "--gdb-server",
-                "--gdb-wait-client",
-                "--gdb-vsc",
-                "--gdb-server-addr",
-                addr,
+                format!("wait-client,vscode,addr={}", addr).as_str(),
             ]);
             instance.current_dir(&workspace.os_dir());
 
             let dir = workspace.os_dir();
             let bin_file_path = Path::new(&workspace.os_dir())
                 .join("target")
-                .join("x86_64-unknown-none")
-                .join("debug")
+                .join("osdk")
+                .join(kernel_name)
                 .join(format!("{}-osdk-bin", kernel_name));
             let _gdb = std::thread::spawn(move || {
                 while !bin_file_path.exists() {

--- a/osdk/tests/commands/run.rs
+++ b/osdk/tests/commands/run.rs
@@ -79,7 +79,13 @@ mod qemu_gdb_feature {
             path.to_string_lossy().to_string()
         };
 
-        let mut instance = cargo_osdk(["run", "-G", "--gdb-server-addr", unix_socket.as_str()]);
+        let mut instance = cargo_osdk([
+            "run",
+            "--gdb-server",
+            "--gdb-wait-client",
+            "--gdb-server-addr",
+            unix_socket.as_str(),
+        ]);
         instance.current_dir(&workspace.os_dir());
 
         let sock = unix_socket.clone();
@@ -123,7 +129,14 @@ mod qemu_gdb_feature {
             let workspace = workspace::WorkSpace::new(WORKSPACE, kernel_name);
             let addr = ":50001";
 
-            let mut instance = cargo_osdk(["run", "-G", "--vsc", "--gdb-server-addr", addr]);
+            let mut instance = cargo_osdk([
+                "run",
+                "--gdb-server",
+                "--gdb-wait-client",
+                "--gdb-vsc",
+                "--gdb-server-addr",
+                addr,
+            ]);
             instance.current_dir(&workspace.os_dir());
 
             let dir = workspace.os_dir();


### PR DESCRIPTION
I couldn't stand copying the script from #964 every time either, so here it is in OSDK. It would be much nicer than the scripts since the OSDK CLI is further crafted for our day-to-day use.

Fix #964 .

Now using the Makefile, one can:

```bash
# in one shell
make profile_server RELEASE_LTO=1
# and then call some long-running workload in Asterinas busybox shell

# in another later
make profile_client GDB_PROFILE_COUNT=200
```

Then something like `./aster-nix-profile-132740.svg` is directly available.

Under the hood, OSDK re-uses the GDB server utilities and added a profile-subcommand for finer control.

```
# cargo osdk profile --help
Profile a remote GDB debug target to collect stack traces for flame graph

Usage: cargo osdk profile [OPTIONS]

Options:
      --remote <REMOTE>
          Specify the address of the remote target
          
          [default: .aster-gdb-socket]

      --samples <SAMPLES>
          The number of samples to collect
          
          [default: 200]

      --interval <INTERVAL>
          The interval between samples in seconds
          
          [default: 0.1]

      --parse <PATH>
          Parse a collected JSON profile file into other formats

      --format <FORMAT>
          The output format for the profile data

          Possible values:
          - json:   The parsed stack trace log from GDB in JSON
          - folded: The folded stack trace for flame graph
          - flame-graph: A SVG flame graph

      --cpu-mask <CPU_MASK>
          The mask of the CPU to generate traces for in the output profile data
          
          [default: 340282366920938463463374607431768211455]

      --output <PATH>
          The path to the output profile data file
```