### PR TITLE
Stabilize some benchmark results

### DIFF
--- a/test/benchmark/lmbench/mem_mmap_bw/run.sh
+++ b/test/benchmark/lmbench/mem_mmap_bw/run.sh
@@ -7,4 +7,4 @@ set -e
 echo "*** Running the LMbench mmap bandwidth test ***"
 
 dd if=/dev/zero of=/ext2/test_file bs=1M count=256
-/benchmark/bin/lmbench/bw_mmap_rd 256m mmap_only /ext2/test_file
+/benchmark/bin/lmbench/bw_mmap_rd -W 30 -N 300 256m mmap_only /ext2/test_file

--- a/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/run.sh
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench file system create/delete test (Ramfs) ***"
 
-/benchmark/bin/lmbench/lat_fs -s 0k -P 1
+/benchmark/bin/lmbench/lat_fs -s 0k -P 1 -W 30 -N 200

--- a/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/run.sh
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench file system create/delete test (Ramfs) ***"
 
-/benchmark/bin/lmbench/lat_fs -s 10k -P 1
+/benchmark/bin/lmbench/lat_fs -s 10k -P 1 -W 30 -N 300

--- a/test/benchmark/lmbench/semaphore_lat/run.sh
+++ b/test/benchmark/lmbench/semaphore_lat/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running the LMbench semaphore latency test ***"
 
-/benchmark/bin/lmbench/lat_sem -P 1
+/benchmark/bin/lmbench/lat_sem -P 1 -N 21

--- a/test/benchmark/lmbench/signal_prot_lat/run.sh
+++ b/test/benchmark/lmbench/signal_prot_lat/run.sh
@@ -7,4 +7,4 @@ set -e
 echo "*** Running the LMbench protection fault latency test ***"
 
 dd if=/dev/zero of=/ext2/test_file bs=1M count=256
-/benchmark/bin/lmbench/lat_sig -N 100 prot /ext2/test_file
+/benchmark/bin/lmbench/lat_sig -W 30 -N 300 prot /ext2/test_file

--- a/test/benchmark/lmbench/vfs_fcntl_lat/run.sh
+++ b/test/benchmark/lmbench/vfs_fcntl_lat/run.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "*** Running lmbench-fcntl ***"
 
-/benchmark/bin/lmbench/lat_fcntl -P 1
+/benchmark/bin/lmbench/lat_fcntl -P 1 -W 30 -N 200

--- a/test/benchmark/lmbench/vfs_read_pagecache_bw/run.sh
+++ b/test/benchmark/lmbench/vfs_read_pagecache_bw/run.sh
@@ -7,4 +7,4 @@ set -e
 echo "*** Running the LMbench file read bandwidth test ***"
 
 dd if=/dev/zero of=/ext2/test_file bs=1M count=512
-/benchmark/bin/lmbench/bw_file_rd -P 1 512m io_only /ext2/test_file
+/benchmark/bin/lmbench/bw_file_rd -P 1 -W 30 -N 300 512m io_only /ext2/test_file


### PR DESCRIPTION
Benchmarks like `bw_mmap_rd` or `lat_fs -s 10K` are quite unstable. This PR increases warmup and repetitions of these benchmarks.