### PR TITLE
Simple cleanups in bigtcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ name = "aster-network"
 version = "0.1.0"
 dependencies = [
  "align_ext",
+ "aster-bigtcp",
  "aster-rights",
  "aster-util",
  "bitflags 1.3.2",
@@ -143,7 +144,6 @@ dependencies = [
  "int-to-c-enum",
  "log",
  "ostd",
- "smoltcp",
  "spin 0.9.8",
 ]
 
@@ -246,6 +246,7 @@ name = "aster-virtio"
 version = "0.1.0"
 dependencies = [
  "align_ext",
+ "aster-bigtcp",
  "aster-block",
  "aster-console",
  "aster-input",
@@ -260,7 +261,6 @@ dependencies = [
  "int-to-c-enum",
  "log",
  "ostd",
- "smoltcp",
  "spin 0.9.8",
  "typeflags-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,14 +1328,13 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "git+https://github.com/smoltcp-rs/smoltcp?rev=dc08e0b#dc08e0b42e668c331bb2b6f8d80016301d0efe03"
+source = "git+https://github.com/smoltcp-rs/smoltcp?rev=469dccd#469dccdbaece66696494f8540615152fc5123b17"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "defmt",
  "heapless",
- "log",
  "managed",
 ]
 

--- a/kernel/comps/network/Cargo.toml
+++ b/kernel/comps/network/Cargo.toml
@@ -9,24 +9,11 @@ edition = "2021"
 align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
+aster-bigtcp = { path = "../../libs/aster-bigtcp" }
 bitflags = "1.3"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 component = { path = "../../libs/comp-sys/component" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 log = "0.4"
 ostd = { path = "../../../ostd" }
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "dc08e0b", default-features = false, features = [
-    "alloc",
-    "log",
-    "medium-ethernet",
-    "medium-ip",
-    "proto-dhcpv4",
-    "proto-ipv4",
-    "proto-igmp",
-    "socket-icmp",
-    "socket-udp",
-    "socket-tcp",
-    "socket-raw",
-    "socket-dhcpv4",
-] }
 spin = "0.9.4"

--- a/kernel/comps/network/src/driver.rs
+++ b/kernel/comps/network/src/driver.rs
@@ -2,12 +2,12 @@
 
 use alloc::vec;
 
+use aster_bigtcp::{device, time::Instant};
 use ostd::mm::VmWriter;
-use smoltcp::{phy, time::Instant};
 
 use crate::{buffer::RxBuffer, AnyNetworkDevice};
 
-impl phy::Device for dyn AnyNetworkDevice {
+impl device::Device for dyn AnyNetworkDevice {
     type RxToken<'a> = RxToken;
     type TxToken<'a> = TxToken<'a>;
 
@@ -28,13 +28,13 @@ impl phy::Device for dyn AnyNetworkDevice {
         }
     }
 
-    fn capabilities(&self) -> phy::DeviceCapabilities {
+    fn capabilities(&self) -> device::DeviceCapabilities {
         self.capabilities()
     }
 }
 pub struct RxToken(RxBuffer);
 
-impl phy::RxToken for RxToken {
+impl device::RxToken for RxToken {
     fn consume<R, F>(self, f: F) -> R
     where
         F: FnOnce(&[u8]) -> R,
@@ -48,7 +48,7 @@ impl phy::RxToken for RxToken {
 
 pub struct TxToken<'a>(&'a mut dyn AnyNetworkDevice);
 
-impl<'a> phy::TxToken for TxToken<'a> {
+impl<'a> device::TxToken for TxToken<'a> {
     fn consume<R, F>(self, len: usize, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,

--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use core::{any::Any, fmt::Debug};
 
+use aster_bigtcp::device::DeviceCapabilities;
 pub use buffer::{RxBuffer, TxBuffer, RX_BUFFER_POOL, TX_BUFFER_POOL};
 use component::{init_component, ComponentInitError};
 pub use dma_pool::DmaSegment;
@@ -22,7 +23,6 @@ use ostd::{
     sync::{LocalIrqDisabled, SpinLock},
     Pod,
 };
-use smoltcp::phy;
 use spin::Once;
 
 #[derive(Debug, Clone, Copy, Pod)]
@@ -40,7 +40,7 @@ pub trait AnyNetworkDevice: Send + Sync + Any + Debug {
     // ================Device Information=================
 
     fn mac_addr(&self) -> EthernetAddr;
-    fn capabilities(&self) -> phy::DeviceCapabilities;
+    fn capabilities(&self) -> DeviceCapabilities;
 
     // ================Device Operation===================
 

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -16,6 +16,7 @@ aster-network = { path = "../network" }
 aster-console = { path = "../console" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
+aster-bigtcp = { path = "../../libs/aster-bigtcp" }
 id-alloc = { path = "../../../ostd/libs/id-alloc" }
 typeflags-util = { path = "../../libs/typeflags-util" }
 ostd = { path = "../../../ostd" }
@@ -23,17 +24,3 @@ component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
 bit_field = "0.10.1"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "dc08e0b", default-features = false, features = [
-    "alloc",
-    "log",
-    "medium-ethernet",
-    "medium-ip",
-    "proto-dhcpv4",
-    "proto-ipv4",
-    "proto-igmp",
-    "socket-icmp",
-    "socket-udp",
-    "socket-tcp",
-    "socket-raw",
-    "socket-dhcpv4",
-] }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -3,6 +3,7 @@
 use alloc::{boxed::Box, string::ToString, sync::Arc};
 use core::{fmt::Debug, hint::spin_loop, mem::size_of};
 
+use aster_bigtcp::device::{DeviceCapabilities, Medium};
 use aster_network::{
     AnyNetworkDevice, EthernetAddr, RxBuffer, TxBuffer, VirtioNetError, RX_BUFFER_POOL,
     TX_BUFFER_POOL,
@@ -10,7 +11,6 @@ use aster_network::{
 use aster_util::slot_vec::SlotVec;
 use log::debug;
 use ostd::{sync::SpinLock, trap::TrapFrame};
-use smoltcp::phy::{DeviceCapabilities, Medium};
 
 use super::{config::VirtioNetConfig, header::VirtioNetHdr};
 use crate::{

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -8,17 +8,12 @@ edition = "2021"
 [dependencies]
 keyable-arc = { path = "../keyable-arc" }
 ostd = { path = "../../../ostd" }
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "dc08e0b", default-features = false, features = [
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "469dccd", default-features = false, features = [
     "alloc",
     "log",
     "medium-ethernet",
     "medium-ip",
-    "proto-dhcpv4",
     "proto-ipv4",
-    "proto-igmp",
-    "socket-icmp",
     "socket-udp",
     "socket-tcp",
-    "socket-raw",
-    "socket-dhcpv4",
 ] }

--- a/kernel/libs/aster-bigtcp/src/device.rs
+++ b/kernel/libs/aster-bigtcp/src/device.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub use smoltcp::phy::{Device, Loopback, Medium};
+pub use smoltcp::phy::{Device, DeviceCapabilities, Loopback, Medium, RxToken, TxToken};
 
 /// A trait that allows to obtain a mutable reference of [`Device`].
 ///

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -67,7 +67,11 @@ impl<E> IfaceCommon<E> {
         self.interface.lock().ipv4_addr()
     }
 
-    /// Alloc an unused port range from 49152 ~ 65535 (According to smoltcp docs)
+    /// Allocates an unused ephemeral port.
+    ///
+    /// We follow the port range that many Linux kernels use by default, which is 32768-60999.
+    ///
+    /// See <https://en.wikipedia.org/wiki/Ephemeral_port>.
     fn alloc_ephemeral_port(&self) -> Option<u16> {
         let mut used_ports = self.used_ports.lock();
         for port in IP_LOCAL_PORT_START..=IP_LOCAL_PORT_END {
@@ -95,7 +99,7 @@ impl<E> IfaceCommon<E> {
         true
     }
 
-    /// Release port number so the port can be used again. For reused port, the port may still be in use.
+    /// Releases the port so that it can be used again (if it is not being reused).
     pub(crate) fn release_port(&self, port: u16) {
         let mut used_ports = self.used_ports.lock();
         if let Some(used_times) = used_ports.remove(&port) {
@@ -246,5 +250,5 @@ impl<E> IfaceCommon<E> {
     }
 }
 
-const IP_LOCAL_PORT_START: u16 = 49152;
-const IP_LOCAL_PORT_END: u16 = 65535;
+const IP_LOCAL_PORT_START: u16 = 32768;
+const IP_LOCAL_PORT_END: u16 = 60999;

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -2,11 +2,9 @@
 
 use alloc::sync::Arc;
 
-use ostd::prelude::*;
 use smoltcp::{
-    iface::{Config, SocketHandle, SocketSet},
-    socket::dhcpv4,
-    wire::{self, EthernetAddress, IpCidr},
+    iface::Config,
+    wire::{self, EthernetAddress, Ipv4Address, Ipv4Cidr},
 };
 
 use crate::{
@@ -19,67 +17,35 @@ use crate::{
 pub struct EtherIface<D: WithDevice, E> {
     driver: D,
     common: IfaceCommon<E>,
-    dhcp_handle: SocketHandle,
 }
 
 impl<D: WithDevice, E> EtherIface<D, E> {
-    pub fn new(driver: D, ether_addr: EthernetAddress, ext: E) -> Arc<Self> {
+    pub fn new(
+        driver: D,
+        ether_addr: EthernetAddress,
+        ip_cidr: Ipv4Cidr,
+        gateway: Ipv4Address,
+        ext: E,
+    ) -> Arc<Self> {
         let interface = driver.with(|device| {
-            let ip_addr = IpCidr::new(wire::IpAddress::Ipv4(wire::Ipv4Address::UNSPECIFIED), 0);
             let config = Config::new(wire::HardwareAddress::Ethernet(ether_addr));
             let now = get_network_timestamp();
 
             let mut interface = smoltcp::iface::Interface::new(config, device, now);
             interface.update_ip_addrs(|ip_addrs| {
                 debug_assert!(ip_addrs.is_empty());
-                ip_addrs.push(ip_addr).unwrap();
+                ip_addrs.push(wire::IpCidr::Ipv4(ip_cidr)).unwrap();
             });
+            interface
+                .routes_mut()
+                .add_default_ipv4_route(gateway)
+                .unwrap();
             interface
         });
 
         let common = IfaceCommon::new(interface, ext);
 
-        let mut socket_set = common.sockets();
-        let dhcp_handle = init_dhcp_client(&mut socket_set);
-        drop(socket_set);
-
-        Arc::new(Self {
-            driver,
-            common,
-            dhcp_handle,
-        })
-    }
-
-    /// FIXME: Once we have user program dhcp client, we may remove dhcp logic from kernel.
-    pub fn process_dhcp(&self) {
-        let mut socket_set = self.common.sockets();
-        let dhcp_socket: &mut dhcpv4::Socket = socket_set.get_mut(self.dhcp_handle);
-
-        let Some(dhcpv4::Event::Configured(config)) = dhcp_socket.poll() else {
-            return;
-        };
-        let ip_addr = IpCidr::Ipv4(config.address);
-
-        let mut interface = self.common.interface();
-
-        println!("[DHCP] Local IP address: {:?}", ip_addr,);
-        interface.update_ip_addrs(|ipaddrs| {
-            if let Some(addr) = ipaddrs.iter_mut().next() {
-                // already has ipaddrs
-                *addr = ip_addr
-            } else {
-                // does not has ip addr
-                ipaddrs.push(ip_addr).unwrap();
-            }
-        });
-
-        if let Some(router) = config.router {
-            println!("[DHCP] Router IP address: {:?}", router);
-            interface
-                .routes_mut()
-                .add_default_ipv4_route(router)
-                .unwrap();
-        }
+        Arc::new(Self { driver, common })
     }
 }
 
@@ -94,14 +60,6 @@ impl<D: WithDevice, E: Send + Sync> Iface<E> for EtherIface<D, E> {
         self.driver.with(|device| {
             let next_poll = self.common.poll(&mut *device);
             schedule_next_poll(next_poll);
-
-            self.process_dhcp();
         });
     }
-}
-
-/// Register a dhcp socket.
-fn init_dhcp_client(socket_set: &mut SocketSet) -> SocketHandle {
-    let dhcp_socket = dhcpv4::Socket::new();
-    socket_set.add(dhcp_socket)
 }

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
@@ -2,7 +2,10 @@
 
 use alloc::sync::Arc;
 
-use smoltcp::{iface::Config, wire::IpCidr};
+use smoltcp::{
+    iface::Config,
+    wire::{self, Ipv4Cidr},
+};
 
 use crate::{
     device::WithDevice,
@@ -17,7 +20,7 @@ pub struct IpIface<D: WithDevice, E> {
 }
 
 impl<D: WithDevice, E> IpIface<D, E> {
-    pub fn new(driver: D, ip_cidr: IpCidr, ext: E) -> Arc<Self> {
+    pub fn new(driver: D, ip_cidr: Ipv4Cidr, ext: E) -> Arc<Self> {
         let interface = driver.with(|device| {
             let config = Config::new(smoltcp::wire::HardwareAddress::Ip);
             let now = get_network_timestamp();
@@ -25,7 +28,7 @@ impl<D: WithDevice, E> IpIface<D, E> {
             let mut interface = smoltcp::iface::Interface::new(config, device, now);
             interface.update_ip_addrs(|ip_addrs| {
                 debug_assert!(ip_addrs.is_empty());
-                ip_addrs.push(ip_cidr).unwrap();
+                ip_addrs.push(wire::IpCidr::Ipv4(ip_cidr)).unwrap();
             });
             interface
         });

--- a/kernel/libs/aster-bigtcp/src/lib.rs
+++ b/kernel/libs/aster-bigtcp/src/lib.rs
@@ -18,6 +18,7 @@ pub mod device;
 pub mod errors;
 pub mod iface;
 pub mod socket;
+pub mod time;
 pub mod wire;
 
 extern crate alloc;

--- a/kernel/libs/aster-bigtcp/src/time.rs
+++ b/kernel/libs/aster-bigtcp/src/time.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub use smoltcp::time::Instant;

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -33,9 +33,16 @@ pub fn init() {
 }
 
 fn new_virtio() -> Arc<Iface> {
-    use aster_bigtcp::{iface::EtherIface, wire::EthernetAddress};
+    use aster_bigtcp::{
+        iface::EtherIface,
+        wire::{EthernetAddress, Ipv4Address, Ipv4Cidr},
+    };
     use aster_network::AnyNetworkDevice;
     use aster_virtio::device::network::DEVICE_NAME;
+
+    const VIRTIO_ADDRESS: Ipv4Address = Ipv4Address::new(10, 0, 2, 15);
+    const VIRTIO_ADDRESS_PREFIX_LEN: u8 = 24; // mask: 255.255.255.0
+    const VIRTIO_GATEWAY: Ipv4Address = Ipv4Address::new(10, 0, 2, 2);
 
     let virtio_net = aster_network::get_device(DEVICE_NAME).unwrap();
 
@@ -58,6 +65,8 @@ fn new_virtio() -> Arc<Iface> {
     EtherIface::new(
         Wrapper(virtio_net),
         EthernetAddress(ether_addr),
+        Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
+        VIRTIO_GATEWAY,
         IfaceExt::new("virtio".to_owned()),
     )
 }
@@ -66,13 +75,10 @@ fn new_loopback() -> Arc<Iface> {
     use aster_bigtcp::{
         device::{Loopback, Medium},
         iface::IpIface,
-        wire::{IpAddress, IpCidr, Ipv4Address},
+        wire::{Ipv4Address, Ipv4Cidr},
     };
 
-    const LOOPBACK_ADDRESS: IpAddress = {
-        let ipv4_addr = Ipv4Address::new(127, 0, 0, 1);
-        IpAddress::Ipv4(ipv4_addr)
-    };
+    const LOOPBACK_ADDRESS: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
     const LOOPBACK_ADDRESS_PREFIX_LEN: u8 = 8; // mask: 255.0.0.0
 
     struct Wrapper(Mutex<Loopback>);
@@ -91,7 +97,7 @@ fn new_loopback() -> Arc<Iface> {
 
     IpIface::new(
         Wrapper(Mutex::new(Loopback::new(Medium::Ip))),
-        IpCidr::new(LOOPBACK_ADDRESS, LOOPBACK_ADDRESS_PREFIX_LEN),
+        Ipv4Cidr::new(LOOPBACK_ADDRESS, LOOPBACK_ADDRESS_PREFIX_LEN),
         IfaceExt::new("lo".to_owned()),
     ) as _
 }


### PR DESCRIPTION
These are some simple cleanup commits related to bigtcp. I'm working on the Ethernet/IP implementation and performance optimizations based on these commits. But these commits are mostly cleanup, just submitted as a standalone PR to make the review process a bit smoother.

 - I removed the DHCP implementation in the kernel because I don't want to deal with it in the Ethernet/IP reimplementation. We can use static IP addresses instead, which is much simpler. I've verified that our previous functionality still works:
```
(Asterinas Guest) # /benchmark/bin/iperf3 -s -B 10.0.2.15 -p 22
(  Linux Host   ) # iperf3 -c 127.0.0.1 -p 31118
```

 - I also make our `network` and `virtio` components no longer directly depend on `smoltcp`. They should depend on `bigtcp` instead.

 - The smoltcp version bump seems to bring some slight performance improvements (from ~6.8 Gbps to ~7.0 Gbps), but the reason I am doing the version bump is simply because I am doing the `s/pub(crate)/pub/` replacement in this commit (note that this PR does _not_ include the replacement, so the commit is still in the official repo).