### PR TITLE
Correct lock usages in UNIX sockets

### DIFF
--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -160,7 +160,7 @@ pub(super) struct Backlog {
     addr: UnixSocketAddrBound,
     pollee: Pollee,
     backlog: AtomicUsize,
-    incoming_conns: Mutex<Option<VecDeque<Connected>>>,
+    incoming_conns: SpinLock<Option<VecDeque<Connected>>>,
     wait_queue: WaitQueue,
 }
 
@@ -176,7 +176,7 @@ impl Backlog {
             addr,
             pollee,
             backlog: AtomicUsize::new(backlog),
-            incoming_conns: Mutex::new(incoming_sockets),
+            incoming_conns: SpinLock::new(incoming_sockets),
             wait_queue: WaitQueue::new(),
         }
     }

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -24,21 +24,21 @@ use crate::{
 };
 
 pub struct UnixStreamSocket {
-    state: RwLock<Takeable<State>>,
+    state: RwMutex<Takeable<State>>,
     is_nonblocking: AtomicBool,
 }
 
 impl UnixStreamSocket {
     pub(super) fn new_init(init: Init, is_nonblocking: bool) -> Arc<Self> {
         Arc::new(Self {
-            state: RwLock::new(Takeable::new(State::Init(init))),
+            state: RwMutex::new(Takeable::new(State::Init(init))),
             is_nonblocking: AtomicBool::new(is_nonblocking),
         })
     }
 
     pub(super) fn new_connected(connected: Connected, is_nonblocking: bool) -> Arc<Self> {
         Arc::new(Self {
-            state: RwLock::new(Takeable::new(State::Connected(connected))),
+            state: RwMutex::new(Takeable::new(State::Connected(connected))),
             is_nonblocking: AtomicBool::new(is_nonblocking),
         })
     }


### PR DESCRIPTION
This is a simple PR to fix the lock usage, so it fixes https://github.com/asterinas/asterinas/issues/1304.

> For this particular case related to UNIX sockets, the RwLock should be quickly replaced with RwMutex. This is necessary because https://github.com/asterinas/asterinas/pull/1294 tries to copy directly to/from userspace while holding the lock, and the copy can sleep indefinitely.