### PR TITLE
Improve the `VmSpace` forking API & performance

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -229,7 +229,7 @@ impl Vmar_ {
             vm_mappings: BTreeMap::new(),
             free_regions,
         };
-        let vm_space = VmSpace::new();
+        let mut vm_space = VmSpace::new();
         vm_space.register_page_fault_handler(handle_page_fault_wrapper);
         Vmar_::new(vmar_inner, Arc::new(vm_space), 0, ROOT_VMAR_CAP_ADDR, None)
     }
@@ -661,7 +661,7 @@ impl Vmar_ {
             let vm_space = if let Some(parent) = parent {
                 parent.vm_space().clone()
             } else {
-                let new_space = VmSpace::new();
+                let mut new_space = VmSpace::new();
                 new_space.register_page_fault_handler(handle_page_fault_wrapper);
                 Arc::new(new_space)
             };

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -16,7 +16,7 @@ use align_ext::AlignExt;
 use aster_rights::Rights;
 use ostd::{
     cpu::CpuExceptionInfo,
-    mm::{PageFlags, PageProperty, VmSpace, MAX_USERSPACE_VADDR},
+    mm::{tlb::TlbFlushOp, PageFlags, PageProperty, VmSpace, MAX_USERSPACE_VADDR},
 };
 
 use self::{
@@ -706,6 +706,8 @@ impl Vmar_ {
                 };
                 new_cursor.copy_from(&mut cur_cursor, vm_mapping.map_size(), &mut op);
             }
+            cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::All);
+            cur_cursor.flusher().dispatch_tlb_flush();
         }
 
         drop(new_inner);

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod page;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;
 pub mod stat;
+pub mod tlb;
 pub mod vm_space;
 
 use core::{fmt::Debug, ops::Range};

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -823,10 +823,6 @@ where
         }
     }
 
-    pub fn preempt_guard(&self) -> &DisabledPreemptGuard {
-        &self.0.preempt_guard
-    }
-
     /// Goes down a level assuming the current slot is absent.
     ///
     /// This method will create a new child page table node and go down to it.

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -81,6 +81,10 @@ fn test_untracked_map_unmap() {
 
 #[ktest]
 fn test_user_copy_on_write() {
+    fn prot_op(prop: &mut PageProperty) {
+        prop.flags -= PageFlags::W;
+    }
+
     let pt = PageTable::<UserMode>::empty();
     let from = PAGE_SIZE..PAGE_SIZE * 2;
     let page = allocator::alloc_single(FrameMeta::default()).unwrap();
@@ -96,7 +100,14 @@ fn test_user_copy_on_write() {
     unsafe { pt.cursor_mut(&from).unwrap().map(page.clone().into(), prop) };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
 
-    let child_pt = pt.clone_with(pt.cursor_mut(&(0..MAX_USERSPACE_VADDR)).unwrap());
+    let child_pt = {
+        let child_pt = PageTable::<UserMode>::empty();
+        let range = 0..MAX_USERSPACE_VADDR;
+        let mut child_cursor = child_pt.cursor_mut(&range).unwrap();
+        let mut parent_cursor = pt.cursor_mut(&range).unwrap();
+        unsafe { child_cursor.copy_from(&mut parent_cursor, range.len(), &mut prot_op) };
+        child_pt
+    };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert_eq!(child_pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert!(matches!(
@@ -106,7 +117,14 @@ fn test_user_copy_on_write() {
     assert!(pt.query(from.start + 10).is_none());
     assert_eq!(child_pt.query(from.start + 10).unwrap().0, start_paddr + 10);
 
-    let sibling_pt = pt.clone_with(pt.cursor_mut(&(0..MAX_USERSPACE_VADDR)).unwrap());
+    let sibling_pt = {
+        let sibling_pt = PageTable::<UserMode>::empty();
+        let range = 0..MAX_USERSPACE_VADDR;
+        let mut sibling_cursor = sibling_pt.cursor_mut(&range).unwrap();
+        let mut parent_cursor = pt.cursor_mut(&range).unwrap();
+        unsafe { sibling_cursor.copy_from(&mut parent_cursor, range.len(), &mut prot_op) };
+        sibling_pt
+    };
     assert!(sibling_pt.query(from.start + 10).is_none());
     assert_eq!(child_pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     drop(pt);

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! TLB flush operations.
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+use super::{page::DynPage, Vaddr, PAGE_SIZE};
+use crate::{
+    cpu::{CpuSet, PinCurrentCpu},
+    cpu_local,
+    sync::SpinLock,
+    task::disable_preempt,
+};
+
+/// A TLB flusher that is aware of which CPUs are needed to be flushed.
+///
+/// The flusher needs to stick to the current CPU.
+pub struct TlbFlusher<G: PinCurrentCpu> {
+    target_cpus: CpuSet,
+    // Better to store them here since loading and counting them from the CPUs
+    // list brings non-trivial overhead.
+    need_remote_flush: bool,
+    need_self_flush: bool,
+    _pin_current: G,
+}
+
+impl<G: PinCurrentCpu> TlbFlusher<G> {
+    /// Creates a new TLB flusher with the specified CPUs to be flushed.
+    ///
+    /// The flusher needs to stick to the current CPU. So please provide a
+    /// guard that implements [`PinCurrentCpu`].
+    pub fn new(target_cpus: CpuSet, pin_current_guard: G) -> Self {
+        let current_cpu = pin_current_guard.current_cpu();
+
+        let mut need_self_flush = false;
+        let mut need_remote_flush = false;
+
+        for cpu in target_cpus.iter() {
+            if cpu == current_cpu {
+                need_self_flush = true;
+            } else {
+                need_remote_flush = true;
+            }
+        }
+        Self {
+            target_cpus,
+            need_remote_flush,
+            need_self_flush,
+            _pin_current: pin_current_guard,
+        }
+    }
+
+    /// Issues a pending TLB flush request.
+    ///
+    /// On SMP systems, the notification is sent to all the relevant CPUs only
+    /// when [`Self::dispatch_tlb_flush`] is called.
+    pub fn issue_tlb_flush(&self, op: TlbFlushOp) {
+        self.issue_tlb_flush_(op, None);
+    }
+
+    /// Dispatches all the pending TLB flush requests.
+    ///
+    /// The pending requests are issued by [`Self::issue_tlb_flush`].
+    pub fn dispatch_tlb_flush(&self) {
+        if !self.need_remote_flush {
+            return;
+        }
+
+        crate::smp::inter_processor_call(&self.target_cpus, do_remote_flush);
+    }
+
+    /// Issues a TLB flush request that must happen before dropping the page.
+    ///
+    /// If we need to remove a mapped page from the page table, we can only
+    /// recycle the page after all the relevant TLB entries in all CPUs are
+    /// flushed. Otherwise if the page is recycled for other purposes, the user
+    /// space program can still access the page through the TLB entries. This
+    /// method is designed to be used in such cases.
+    pub fn issue_tlb_flush_with(&self, op: TlbFlushOp, drop_after_flush: DynPage) {
+        self.issue_tlb_flush_(op, Some(drop_after_flush));
+    }
+
+    /// Whether the TLB flusher needs to flush the TLB entries on other CPUs.
+    pub fn need_remote_flush(&self) -> bool {
+        self.need_remote_flush
+    }
+
+    /// Whether the TLB flusher needs to flush the TLB entries on the current CPU.
+    pub fn need_self_flush(&self) -> bool {
+        self.need_self_flush
+    }
+
+    fn issue_tlb_flush_(&self, op: TlbFlushOp, drop_after_flush: Option<DynPage>) {
+        let op = op.optimize_for_large_range();
+
+        // Fast path for single CPU cases.
+        if !self.need_remote_flush {
+            if self.need_self_flush {
+                op.perform_on_current();
+            }
+            return;
+        }
+
+        // Slow path for multi-CPU cases.
+        for cpu in self.target_cpus.iter() {
+            let mut op_queue = FLUSH_OPS.get_on_cpu(cpu).lock();
+            if let Some(drop_after_flush) = drop_after_flush.clone() {
+                PAGE_KEEPER.get_on_cpu(cpu).lock().push(drop_after_flush);
+            }
+            op_queue.push(op.clone());
+        }
+    }
+}
+
+/// The operation to flush TLB entries.
+#[derive(Debug, Clone)]
+pub enum TlbFlushOp {
+    /// Flush all TLB entries except for the global entries.
+    All,
+    /// Flush the TLB entry for the specified virtual address.
+    Address(Vaddr),
+    /// Flush the TLB entries for the specified virtual address range.
+    Range(Range<Vaddr>),
+}
+
+impl TlbFlushOp {
+    /// Performs the TLB flush operation on the current CPU.
+    pub fn perform_on_current(&self) {
+        use crate::arch::mm::{
+            tlb_flush_addr, tlb_flush_addr_range, tlb_flush_all_excluding_global,
+        };
+        match self {
+            TlbFlushOp::All => tlb_flush_all_excluding_global(),
+            TlbFlushOp::Address(addr) => tlb_flush_addr(*addr),
+            TlbFlushOp::Range(range) => tlb_flush_addr_range(range),
+        }
+    }
+
+    fn optimize_for_large_range(self) -> Self {
+        match self {
+            TlbFlushOp::Range(range) => {
+                if range.len() > FLUSH_ALL_RANGE_THRESHOLD {
+                    TlbFlushOp::All
+                } else {
+                    TlbFlushOp::Range(range)
+                }
+            }
+            _ => self,
+        }
+    }
+}
+
+// The queues of pending requests on each CPU.
+//
+// Lock ordering: lock FLUSH_OPS before PAGE_KEEPER.
+cpu_local! {
+    static FLUSH_OPS: SpinLock<OpsStack> = SpinLock::new(OpsStack::new());
+    static PAGE_KEEPER: SpinLock<Vec<DynPage>> = SpinLock::new(Vec::new());
+}
+
+fn do_remote_flush() {
+    let preempt_guard = disable_preempt();
+    let current_cpu = preempt_guard.current_cpu();
+
+    let mut op_queue = FLUSH_OPS.get_on_cpu(current_cpu).lock();
+    op_queue.flush_all();
+    PAGE_KEEPER.get_on_cpu(current_cpu).lock().clear();
+}
+
+/// If a TLB flushing request exceeds this threshold, we flush all.
+pub(crate) const FLUSH_ALL_RANGE_THRESHOLD: usize = 32 * PAGE_SIZE;
+
+/// If the number of pending requests exceeds this threshold, we flush all the
+/// TLB entries instead of flushing them one by one.
+const FLUSH_ALL_OPS_THRESHOLD: usize = 32;
+
+struct OpsStack {
+    ops: [Option<TlbFlushOp>; FLUSH_ALL_OPS_THRESHOLD],
+    need_flush_all: bool,
+    size: usize,
+}
+
+impl OpsStack {
+    const fn new() -> Self {
+        const ARRAY_REPEAT_VALUE: Option<TlbFlushOp> = None;
+        Self {
+            ops: [ARRAY_REPEAT_VALUE; FLUSH_ALL_OPS_THRESHOLD],
+            need_flush_all: false,
+            size: 0,
+        }
+    }
+
+    fn push(&mut self, op: TlbFlushOp) {
+        if self.need_flush_all {
+            return;
+        }
+
+        if self.size < FLUSH_ALL_OPS_THRESHOLD {
+            self.ops[self.size] = Some(op);
+            self.size += 1;
+        } else {
+            self.need_flush_all = true;
+            self.size = 0;
+        }
+    }
+
+    fn flush_all(&mut self) {
+        if self.need_flush_all {
+            crate::arch::mm::tlb_flush_all_excluding_global();
+            self.need_flush_all = false;
+        } else {
+            for i in 0..self.size {
+                if let Some(op) = &self.ops[i] {
+                    op.perform_on_current();
+                }
+            }
+        }
+
+        self.size = 0;
+    }
+}


### PR DESCRIPTION
~~Still a draft.~~ It should improve forking performance. The behavior is more aligned to Linux's too (conditionally copy PT according to `vma`).

Thanks to @cchanging about the investigation efforts for the cause of low PT copying performance.

~~EDIT: extra thoughts: the PR also resolves #919 and https://github.com/asterinas/asterinas/pull/1369#discussion_r1772480996 in an unanimous way.~~
EDIT of EDIT: nevermind. I created another PR #1372 addressing #919 and https://github.com/asterinas/asterinas/pull/1369#discussion_r1772480996, which is far beyond reach of what this PR intended to do. That PR needs more thoughts, and this PR should be decided more quickly to improve the performance.

benchmark results on the TDX CI machine (TLDR 22% better for `fork` and negligible for `shell`. `fork` approaches Linux):

`lmbench-fork` (before) (https://github.com/asterinas/asterinas/commit/4d36dd541f3ea4ec6ac72681feb6d587f87bab6d):

```json
[
  {
    "name": "Average Fork latency on Linux",
    "unit": "µs",
    "value": "56.0938",
    "extra": "linux_result"
  },
  {
    "name": "Average Fork latency on Asterinas",
    "unit": "µs",
    "value": "72.0519",
    "extra": "aster_result"
  }
]
```


`lmbench-fork` (after) (https://github.com/asterinas/asterinas/pull/1369/commits/6bd12917e09df3f6e6901f9573bd8a8c1ed071c5):

```json
[
  {
    "name": "Average Fork latency on Linux",
    "unit": "µs",
    "value": "52.8317",
    "extra": "linux_result"
  },
  {
    "name": "Average Fork latency on Asterinas",
    "unit": "µs",
    "value": "56.6289",
    "extra": "aster_result"
  }
]

```

https://github.com/asterinas/asterinas/pull/1369/commits/a7392c4b3281b22a814df4943af9a3526b0c99e2:

```json
[
  {
    "name": "Average Fork latency on Linux",
    "unit": "µs",
    "value": "55.1789",
    "extra": "linux_result"
  },
  {
    "name": "Average Fork latency on Asterinas",
    "unit": "µs",
    "value": "55.2959",
    "extra": "aster_result"
  }
]
```


`lmbench-shell` (before) (https://github.com/asterinas/asterinas/commit/4d36dd541f3ea4ec6ac72681feb6d587f87bab6d):

```json
[
  {
    "name": "Average shell latency on Linux",
    "unit": "µs",
    "value": "316.5294",
    "extra": "linux_result"
  },
  {
    "name": "Average shell latency on Asterinas",
    "unit": "µs",
    "value": "451.4167",
    "extra": "aster_result"
  }
]
```

`lmbench-shell` (after) (https://github.com/asterinas/asterinas/pull/1369/commits/6bd12917e09df3f6e6901f9573bd8a8c1ed071c5):

```json
[
  {
    "name": "Average shell latency on Linux",
    "unit": "µs",
    "value": "318.8125",
    "extra": "linux_result"
  },
  {
    "name": "Average shell latency on Asterinas",
    "unit": "µs",
    "value": "447.2500",
    "extra": "aster_result"
  }
]
```