### PR TITLE
Polish the page table safety model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,8 @@ ktest: initramfs $(CARGO_OSDK)
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "ostd/libs/linux-bzimage/setup" ] && continue; \
 		(cd $$dir && cargo osdk test) || exit 1; \
+		tail --lines 10 qemu.log | grep -q "^\\[ktest runner\\] All crates tested." \
+			|| (echo "Test failed" && exit 1); \
 	done
 
 .PHONY: docs

--- a/ostd/src/mm/kspace.rs
+++ b/ostd/src/mm/kspace.rs
@@ -13,13 +13,13 @@
 //!
 //! ```text
 //! +-+ <- the highest used address (0xffff_ffff_ffff_0000)
-//! | |         For the kernel code, 1 GiB. Mapped frames are untracked.
+//! | |         For the kernel code, 1 GiB. Mapped frames are tracked.
 //! +-+ <- 0xffff_ffff_8000_0000
 //! | |
 //! | |         Unused hole.
 //! +-+ <- 0xffff_ff00_0000_0000
 //! | |         For frame metadata, 1 TiB.
-//! | |         Mapped frames are untracked.
+//! | |         Mapped frames are tracked with handles.
 //! +-+ <- 0xffff_fe00_0000_0000
 //! | |         For vm alloc/io mappings, 1 TiB.
 //! | |         Mapped frames are tracked with handles.
@@ -102,6 +102,13 @@ pub const LINEAR_MAPPING_VADDR_RANGE: Range<Vaddr> = LINEAR_MAPPING_BASE_VADDR..
 pub fn paddr_to_vaddr(pa: Paddr) -> usize {
     debug_assert!(pa < VMALLOC_BASE_VADDR - LINEAR_MAPPING_BASE_VADDR);
     pa + LINEAR_MAPPING_BASE_VADDR
+}
+
+/// Returns whether the given address should be mapped as tracked.
+///
+/// About what is tracked mapping, see [`crate::mm::page::meta::MapTrackingStatus`].
+pub(crate) fn should_map_as_tracked(addr: Vaddr) -> bool {
+    !LINEAR_MAPPING_VADDR_RANGE.contains(&addr)
 }
 
 /// The kernel page table instance.

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -65,7 +65,7 @@
 //! table cursor should add additional entry point checks to prevent these defined
 //! behaviors if they are not wanted.
 
-use core::{any::TypeId, marker::PhantomData, mem::ManuallyDrop, ops::Range};
+use core::{any::TypeId, marker::PhantomData, ops::Range};
 
 use align_ext::AlignExt;
 
@@ -640,11 +640,9 @@ where
                         prop,
                     }
                 }
-                Child::PageTable(node) => {
-                    let node = ManuallyDrop::new(node);
-                    let page = Page::<PageTablePageMeta<E, C>>::from_raw(node.paddr());
-                    PageTableItem::PageTableNode { page: page.into() }
-                }
+                Child::PageTable(node) => PageTableItem::PageTableNode {
+                    page: Page::<PageTablePageMeta<E, C>>::from(node).into(),
+                },
                 Child::None => unreachable!(),
             };
         }

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module specifies the type of the children of a page table node.
+
+use core::{mem::ManuallyDrop, panic};
+
+use super::{PageTableEntryTrait, RawPageTableNode};
+use crate::{
+    arch::mm::{PageTableEntry, PagingConsts},
+    mm::{
+        page::{
+            meta::{MapTrackingStatus, PageTablePageMeta},
+            DynPage, Page,
+        },
+        page_prop::PageProperty,
+        Paddr, PagingConstsTrait, PagingLevel,
+    },
+};
+
+/// A child of a page table node.
+#[derive(Debug)]
+pub(in crate::mm) enum Child<
+    E: PageTableEntryTrait = PageTableEntry,
+    C: PagingConstsTrait = PagingConsts,
+> where
+    [(); C::NR_LEVELS as usize]:,
+{
+    PageTable(RawPageTableNode<E, C>),
+    Page(DynPage, PageProperty),
+    /// Pages not tracked by handles.
+    Untracked(Paddr, PagingLevel, PageProperty),
+    None,
+}
+
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> Child<E, C>
+where
+    [(); C::NR_LEVELS as usize]:,
+{
+    /// Returns whether the child does not map to anything.
+    pub(in crate::mm) fn is_none(&self) -> bool {
+        matches!(self, Child::None)
+    }
+
+    /// Converts a child into a owning PTE.
+    ///
+    /// By conversion it loses information about whether the page is tracked
+    /// or not. Also it loses the level information. However, the returned PTE
+    /// takes the ownership (reference count) of the child.
+    ///
+    /// Usually this is for recording the PTE into a page table node. When the
+    /// child is needed again by reading the PTE of a page table node, extra
+    /// information should be provided using the [`Child::from_pte`] method.
+    pub(super) fn into_pte(self) -> E {
+        match self {
+            Child::PageTable(pt) => {
+                let pt = ManuallyDrop::new(pt);
+                E::new_pt(pt.paddr())
+            }
+            Child::Page(page, prop) => {
+                let level = page.level();
+                E::new_page(page.into_raw(), level, prop)
+            }
+            Child::Untracked(pa, level, prop) => E::new_page(pa, level, prop),
+            Child::None => E::new_absent(),
+        }
+    }
+
+    /// Converts a PTE back to a child.
+    ///
+    /// # Safety
+    ///
+    /// The provided PTE must be originated from [`Child::into_pte`]. And the
+    /// provided information (level and tracking status) must align with the
+    /// lost information during the conversion.
+    ///
+    /// This method should be only used no more than once for a PTE that has
+    /// been converted from a child using the [`Child::into_pte`] method.
+    pub(super) unsafe fn from_pte(
+        pte: E,
+        level: PagingLevel,
+        is_tracked: MapTrackingStatus,
+    ) -> Self {
+        if !pte.is_present() {
+            Child::None
+        } else {
+            let paddr = pte.paddr();
+            if !pte.is_last(level) {
+                Child::PageTable(RawPageTableNode::from_paddr(paddr))
+            } else {
+                match is_tracked {
+                    MapTrackingStatus::Tracked => Child::Page(DynPage::from_raw(paddr), pte.prop()),
+                    MapTrackingStatus::Untracked => Child::Untracked(paddr, level, pte.prop()),
+                    MapTrackingStatus::NotApplicable => panic!("Invalid tracking status"),
+                }
+            }
+        }
+    }
+
+    /// Gains an extra owning reference to the child.
+    ///
+    /// # Safety
+    ///
+    /// The provided PTE must be originated from [`Child::into_pte`]. And the
+    /// provided information (level and tracking status) must align with the
+    /// lost information during the conversion.
+    ///
+    /// This method must not be used with a PTE that has been restored to a
+    /// child using the [`Child::from_pte`] method.
+    pub(super) unsafe fn clone_from_pte(
+        pte: &E,
+        level: PagingLevel,
+        is_tracked: MapTrackingStatus,
+    ) -> Self {
+        if !pte.is_present() {
+            Child::None
+        } else {
+            let paddr = pte.paddr();
+            if !pte.is_last(level) {
+                Page::<PageTablePageMeta<E, C>>::inc_ref_count(paddr);
+                Child::PageTable(RawPageTableNode::from_paddr(paddr))
+            } else {
+                match is_tracked {
+                    MapTrackingStatus::Tracked => {
+                        DynPage::inc_ref_count(paddr);
+                        Child::Page(DynPage::from_raw(paddr), pte.prop())
+                    }
+                    MapTrackingStatus::Untracked => Child::Untracked(paddr, level, pte.prop()),
+                    MapTrackingStatus::NotApplicable => panic!("Invalid tracking status"),
+                }
+            }
+        }
+    }
+}

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -18,6 +18,10 @@ use crate::{
 };
 
 /// A child of a page table node.
+///
+/// This is a owning handle to a child of a page table node. If the child is
+/// either a page table node or a page, it holds a reference count to the
+/// corresponding page.
 #[derive(Debug)]
 pub(in crate::mm) enum Child<
     E: PageTableEntryTrait = PageTableEntry,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module provides accessors to the page table entries in a node.
+
+use super::{Child, PageTableEntryTrait, PageTableNode};
+use crate::mm::{
+    nr_subpage_per_huge, page::meta::MapTrackingStatus, page_prop::PageProperty, page_size,
+    PagingConstsTrait,
+};
+
+/// A view of an entry in a page table node.
+///
+/// It can be borrowed from a node using the [`PageTableNode::entry`] method.
+///
+/// This is a static reference to an entry in a node that does not account for
+/// a dynamic reference count to the child. It can be used to create a owned
+/// handle, which is a [`Child`].
+pub(in crate::mm) struct Entry<'a, E: PageTableEntryTrait, C: PagingConstsTrait>
+where
+    [(); C::NR_LEVELS as usize]:,
+{
+    /// The page table entry.
+    ///
+    /// We store the page table entry here to optimize the number of reads from
+    /// the node. We cannot hold a `&mut E` reference to the entry because that
+    /// other CPUs may modify the memory location for accessed/dirty bits. Such
+    /// accesses will violate the aliasing rules of Rust and cause undefined
+    /// behaviors.
+    pte: E,
+    /// The index of the entry in the node.
+    idx: usize,
+    /// The node that contains the entry.
+    node: &'a mut PageTableNode<E, C>,
+}
+
+impl<'a, E: PageTableEntryTrait, C: PagingConstsTrait> Entry<'a, E, C>
+where
+    [(); C::NR_LEVELS as usize]:,
+{
+    /// Returns if the entry does not map to anything.
+    pub(in crate::mm) fn is_none(&self) -> bool {
+        !self.pte.is_present()
+    }
+
+    /// Returns if the entry maps to a page table node.
+    pub(in crate::mm) fn is_node(&self) -> bool {
+        self.pte.is_present() && !self.pte.is_last(self.node.level())
+    }
+
+    /// Gets a owned handle to the child.
+    pub(in crate::mm) fn to_owned(&self) -> Child<E, C> {
+        // SAFETY: The entry structure represents an existent entry with the
+        // right node information.
+        unsafe { Child::clone_from_pte(&self.pte, self.node.level(), self.node.is_tracked()) }
+    }
+
+    /// Operates on the mapping properties of the entry.
+    ///
+    /// It only modifies the properties if the entry is present.
+    // FIXME: in x86_64, you can protect a page with neither of the RWX
+    // permissions. This would make the page not accessible and leaked. Such a
+    // behavior is memory-safe but wrong. In RISC-V there's no problem.
+    pub(in crate::mm) fn protect(&mut self, op: &mut impl FnMut(&mut PageProperty)) {
+        if !self.pte.is_present() {
+            return;
+        }
+
+        let prop = self.pte.prop();
+        let mut new_prop = prop;
+        op(&mut new_prop);
+
+        if prop == new_prop {
+            return;
+        }
+
+        self.pte.set_prop(new_prop);
+
+        // SAFETY:
+        //  1. The index is within the bounds.
+        //  2. We replace the PTE with a new one, which differs only in
+        //     `PageProperty`, so it is still compatible with the current
+        //     page table node.
+        unsafe { self.node.write_pte(self.idx, self.pte) };
+    }
+
+    /// Replaces the entry with a new child.
+    ///
+    /// The old child is returned.
+    ///
+    /// # Panics
+    ///
+    /// The method panics if the given child is not compatible with the node.
+    /// The compatibility is specified by the [`Child::is_compatible`].
+    pub(in crate::mm) fn replace(self, new_child: Child<E, C>) -> Child<E, C> {
+        assert!(new_child.is_compatible(self.node.level(), self.node.is_tracked()));
+
+        // SAFETY: The entry structure represents an existent entry with the
+        // right node information. The old PTE is overwritten by the new child
+        // so that it is not used anymore.
+        let old_child =
+            unsafe { Child::from_pte(self.pte, self.node.level(), self.node.is_tracked()) };
+
+        if old_child.is_none() && !new_child.is_none() {
+            *self.node.nr_children_mut() += 1;
+        } else if !old_child.is_none() && new_child.is_none() {
+            *self.node.nr_children_mut() -= 1;
+        }
+
+        // SAFETY:
+        //  1. The index is within the bounds.
+        //  2. The new PTE is compatible with the page table node, as asserted above.
+        unsafe { self.node.write_pte(self.idx, new_child.into_pte()) };
+
+        old_child
+    }
+
+    /// Splits the entry to smaller pages if it maps to a untracked huge page.
+    ///
+    /// If the entry does map to a untracked huge page, it is split into smaller
+    /// pages mapped by a child page table node. The new child page table node
+    /// is returned.
+    ///
+    /// If the entry does not map to a untracked huge page, the method returns
+    /// `None`.
+    pub(in crate::mm) fn split_if_untracked_huge(self) -> Option<PageTableNode<E, C>> {
+        let level = self.node.level();
+
+        if !(self.pte.is_last(level)
+            && level > 1
+            && self.node.is_tracked() == MapTrackingStatus::Untracked)
+        {
+            return None;
+        }
+
+        let pa = self.pte.paddr();
+        let prop = self.pte.prop();
+
+        let mut new_page = PageTableNode::<E, C>::alloc(level - 1, MapTrackingStatus::Untracked);
+        for i in 0..nr_subpage_per_huge::<C>() {
+            let small_pa = pa + i * page_size::<C>(level - 1);
+            let _ = new_page
+                .entry(i)
+                .replace(Child::Untracked(small_pa, level - 1, prop));
+        }
+
+        let _ = self.replace(Child::PageTable(new_page.clone_raw()));
+
+        Some(new_page)
+    }
+
+    /// Create a new entry at the node.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the index is within the bounds of the node.
+    pub(super) unsafe fn new_at(node: &'a mut PageTableNode<E, C>, idx: usize) -> Self {
+        // SAFETY: The index is within the bound.
+        let pte = unsafe { node.read_pte(idx) };
+        Self { pte, idx, node }
+    }
+}


### PR DESCRIPTION
Addresses the same problem pointed out by #919 , but in a somewhat different implementation.

This is based on #1369 

Fix #1399 
close #919

This PR contains many commits, but they serve one purpose as a whole: remove soundness problems and fix soundness bugs already popping up.

Big commits:
 1. The first commit fixes the problem that untracked mappings will be dropped as tracked;
 4. The fourth commit organizes the `page_table::node` implementation so the properties are expressed more clearly;