### PR TITLE
Timeout earlier in CI's integration test

### DIFF
--- a/.github/workflows/test_asterinas.yml
+++ b/.github/workflows/test_asterinas.yml
@@ -47,7 +47,7 @@ jobs:
   integration-test:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     container:
       image: asterinas/asterinas:0.8.3
       options: --device=/dev/kvm


### PR DESCRIPTION
This PR makes integration test fail after 15 minutes (30 minutes previously), since the tests now run in parallel and random hangs are frequent.