### PR TITLE
Handle exit_signal during `clone()` and `clone3()` syscalls

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -345,6 +345,10 @@ fn clone_child_process(
         process_builder.build()?
     };
 
+    if let Some(sig) = clone_args.exit_signal {
+        child.set_exit_signal(sig);
+    };
+
     // Deals with clone flags
     let child_thread = thread_table::get_thread(child_tid).unwrap();
     let child_posix_thread = child_thread.as_posix_thread().unwrap();

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -101,6 +101,9 @@ pub struct Process {
     /// The signal that the process should receive when parent process exits.
     parent_death_signal: AtomicSigNum,
 
+    /// The signal that should be sent to the parent when this process exits.
+    exit_signal: AtomicSigNum,
+
     /// A profiling clock measures the user CPU time and kernel CPU time of the current process.
     prof_clock: Arc<ProfClock>,
 
@@ -218,6 +221,7 @@ impl Process {
             umask,
             sig_dispositions,
             parent_death_signal: AtomicSigNum::new_empty(),
+            exit_signal: AtomicSigNum::new_empty(),
             resource_limits: Mutex::new(resource_limits),
             nice: Atomic::new(nice),
             timer_manager: PosixTimerManager::new(&prof_clock, process_ref),
@@ -688,6 +692,14 @@ impl Process {
     /// when the process exits.
     pub fn parent_death_signal(&self) -> Option<SigNum> {
         self.parent_death_signal.as_sig_num()
+    }
+
+    pub fn set_exit_signal(&self, sig_num: SigNum) {
+        self.exit_signal.set(sig_num);
+    }
+
+    pub fn exit_signal(&self) -> Option<SigNum> {
+        self.exit_signal.as_sig_num()
     }
 
     // ******************* Status ********************

--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -7,11 +7,7 @@ use ostd::cpu::UserContext;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{
-        clone_child,
-        signal::{constants::SIGCHLD, sig_num::SigNum},
-        CloneArgs, CloneFlags,
-    },
+    process::{clone_child, signal::sig_num::SigNum, CloneArgs, CloneFlags},
 };
 
 // The order of arguments for clone differs in different architecture.
@@ -87,11 +83,7 @@ struct Clone3Args {
 
 impl From<Clone3Args> for CloneArgs {
     fn from(value: Clone3Args) -> Self {
-        // TODO: deal with pidfd, exit_signal, set_tid, set_tid_size, cgroup
-        if value.exit_signal != 0 || value.exit_signal as u8 != SIGCHLD.as_u8() {
-            warn!("exit signal is not supported");
-        }
-
+        // TODO: deal with pidfd, set_tid, set_tid_size, cgroup
         if value.pidfd != 0 {
             warn!("pidfd is not supported");
         }

--- a/test/apps/clone3/clone_exit_signal.c
+++ b/test/apps/clone3/clone_exit_signal.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <linux/sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+
+static pid_t sys_clone3(struct clone_args *args)
+{
+	return syscall(SYS_clone3, args, sizeof(struct clone_args));
+}
+
+int child_exit_recv = 0;
+
+void sig_handler(int signal)
+{
+	printf("Received child exit signal\n");
+	child_exit_recv++;
+}
+
+int main(int argc, char *argv[])
+{
+	pid_t pid;
+	struct clone_args args = {
+		.exit_signal = SIGUSR2,
+	};
+
+	signal(SIGUSR2, sig_handler);
+
+	pid = sys_clone3(&args);
+	if (pid < 0)
+		err(EXIT_FAILURE, "Failed to create new process");
+
+	if (pid == 0) {
+		printf("Child process with pid %d\n", getpid());
+		exit(EXIT_SUCCESS);
+	}
+
+	/*
+	 * From the clone(2) manual:
+	 * If [the exit signal] is specified as anything other than SIGCHLD,
+	 * then the parent process must specify the __WALL or __WCLONE
+	 * options when waiting for the child with wait(2).
+	 */
+	waitpid(pid, NULL, __WALL);
+
+	if (child_exit_recv != 1)
+		errx(EXIT_FAILURE, "did not receive exit signal from child");
+
+	return 0;
+}

--- a/test/apps/clone3/clone_no_exit_signal.c
+++ b/test/apps/clone3/clone_no_exit_signal.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <linux/sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+
+static pid_t sys_clone3(struct clone_args *args)
+{
+	return syscall(SYS_clone3, args, sizeof(struct clone_args));
+}
+
+int main(int argc, char *argv[])
+{
+	pid_t pid;
+	struct clone_args args = {
+		.exit_signal = 0,
+	};
+
+	pid = sys_clone3(&args);
+	if (pid < 0)
+		err(EXIT_FAILURE, "Failed to create new process");
+
+	if (pid == 0) {
+		printf("Child process with pid %d\n", getpid());
+		exit(EXIT_SUCCESS);
+	}
+
+	/*
+	 * From the clone(2) manual:
+	 * If [the exit signal] is specified as anything other than SIGCHLD,
+	 * then the parent process must specify the __WALL or __WCLONE
+	 * options when waiting for the child with wait(2).
+	 */
+	waitpid(pid, NULL, __WALL);
+
+	/* We should have gotten this far without receiving any signals */
+	return 0;
+}

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -10,6 +10,8 @@ cd ${SCRIPT_DIR}/..
 echo "Start process test......"
 # These test programs are sorted by name.
 tests="
+clone3/clone_exit_signal
+clone3/clone_no_exit_signal
 clone3/clone_process
 execve/execve
 eventfd2/eventfd2


### PR DESCRIPTION
When calling `clone()` and `clone3()`, the user is allowed to specify a signal to be sent to the parent process on exit. Respect this value by storing it in the `Process` struct and sending the signal on exit.

Add a new test as well to verify that the signal is properly delivered to the parent.

The implementation requires a refactor to unify the arguments for the `clone()` and `clone3()` syscalls.