### PR TITLE
Optimize two bottlenecks in virtio-net

### DIFF
--- a/kernel/comps/network/src/driver.rs
+++ b/kernel/comps/network/src/driver.rs
@@ -12,7 +12,7 @@ impl device::Device for dyn AnyNetworkDevice {
     type TxToken<'a> = TxToken<'a>;
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        if self.can_receive() {
+        if self.can_receive() && self.can_send() {
             let rx_buffer = self.receive().unwrap();
             Some((RxToken(rx_buffer), TxToken(self)))
         } else {

--- a/kernel/comps/virtio/src/device/network/config.rs
+++ b/kernel/comps/virtio/src/device/network/config.rs
@@ -63,7 +63,7 @@ pub struct VirtioNetConfig {
     pub mac: EthernetAddr,
     pub status: Status,
     max_virtqueue_pairs: u16,
-    mtu: u16,
+    pub mtu: u16,
     speed: u32,
     duplex: u8,
     rss_max_key_size: u8,

--- a/kernel/comps/virtio/src/device/socket/buffer.rs
+++ b/kernel/comps/virtio/src/device/socket/buffer.rs
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::LinkedList, sync::Arc};
+use alloc::{collections::linked_list::LinkedList, sync::Arc};
 
 use aster_network::dma_pool::DmaPool;
 use ostd::{
     mm::{DmaDirection, DmaStream},
-    sync::SpinLock,
+    sync::{LocalIrqDisabled, SpinLock},
 };
 use spin::Once;
 
 const RX_BUFFER_LEN: usize = 4096;
+const TX_BUFFER_LEN: usize = 4096;
 pub static RX_BUFFER_POOL: Once<Arc<DmaPool>> = Once::new();
-pub static TX_BUFFER_POOL: Once<SpinLock<LinkedList<DmaStream>>> = Once::new();
+pub static TX_BUFFER_POOL: Once<SpinLock<LinkedList<DmaStream>, LocalIrqDisabled>> = Once::new();
 
 pub fn init() {
     const POOL_INIT_SIZE: usize = 32;

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -190,8 +190,10 @@ impl SocketDevice {
     ) -> Result<(), SocketError> {
         debug!("Sent packet {:?}. Op {:?}", header, header.op());
         debug!("buffer in send_packet_to_tx_queue: {:?}", buffer);
-        let tx_pool = TX_BUFFER_POOL.get().unwrap();
-        let tx_buffer = TxBuffer::new(header, buffer, tx_pool);
+        let tx_buffer = {
+            let pool = TX_BUFFER_POOL.get().unwrap();
+            TxBuffer::new(header, buffer, pool)
+        };
 
         let token = self.send_queue.add_dma_buf(&[&tx_buffer], &[])?;
 

--- a/kernel/libs/aster-bigtcp/src/device.rs
+++ b/kernel/libs/aster-bigtcp/src/device.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub use smoltcp::phy::{Device, DeviceCapabilities, Loopback, Medium, RxToken, TxToken};
+pub use smoltcp::phy::{
+    Checksum, ChecksumCapabilities, Device, DeviceCapabilities, Loopback, Medium, RxToken, TxToken,
+};
 
 /// A trait that allows to obtain a mutable reference of [`Device`].
 ///

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -22,11 +22,13 @@ pub fn init() {
     });
 
     for (name, _) in aster_network::all_devices() {
-        aster_network::register_recv_callback(&name, || {
+        let callback = || {
             // TODO: further check that the irq num is the same as iface's irq num
             let iface_virtio = &IFACES.get().unwrap()[0];
             iface_virtio.poll();
-        })
+        };
+        aster_network::register_recv_callback(&name, callback);
+        aster_network::register_send_callback(&name, callback);
     }
 
     poll_ifaces();


### PR DESCRIPTION
This PR aims to optimize the bandwidth of iperf3 by enhancing virtio-net. Currently, iperf3 performs about 1000 times slower than Linux, which is unexpectedly low.

The PR addresses two clear bottlenecks:

1. Eliminating busy loops during packet transmission.
2. Optimizing the device capabilities to align with Redleaf's settings.

As a result, iperf3's performance increases from 8 Mbps to approximately 600 Mbps; however, it is still 13 times slower than Linux's 7.6 Gbps. So some further optimization is required.

The experiments were conducted on an AMD SEV machine, which is powered by an AMD EPYC 7543P 32-Core Processor. Therefore, the results may vary slightly compared to those obtained on our CI machine.