### PR TITLE
Add Nginx benchmark CI

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -63,6 +63,7 @@ jobs:
           - lmbench/tcp_loopback_http_bw
           - lmbench/udp_loopback_lat
           - iperf3/tcp_virtio_bw
+          - nginx/http_req10k_conc1_bw
       fail-fast: false
     timeout-minutes: 60
     container: 

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -84,7 +84,7 @@ run_benchmark() {
             ;;
         "host_guest")
             echo "Running benchmark ${benchmark} on host and guest..."
-            bash "${BENCHMARK_DIR}/${benchmark_root}/bench_runner.sh" \
+            bash "${BENCHMARK_DIR}/common/host_guest_bench_runner.sh" \
                 "${BENCHMARK_DIR}/${benchmark}" \
                 "${asterinas_cmd}" \
                 "${linux_cmd}" \

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -70,7 +70,7 @@ run_benchmark() {
         -drive if=none,format=raw,id=x0,file=${BENCHMARK_DIR}/../build/ext2.img \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,config-wce=off,request-merging=off,write-cache=off,backend_defaults=off,discard=off,event_idx=off,indirect_desc=off,ioeventfd=off,queue_reset=off \
         -append 'console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet' \
-        -netdev user,id=net01,hostfwd=tcp::5201-:5201 \
+        -netdev user,id=net01,hostfwd=tcp::5201-:5201,hostfwd=tcp::8080-:8080 \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off \
         -nographic \
         2>&1"

--- a/test/benchmark/common/host_guest_bench_runner.sh
+++ b/test/benchmark/common/host_guest_bench_runner.sh
@@ -14,8 +14,16 @@ LINUX_OUTPUT=$5
 BENCHMARK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/../"
 source "${BENCHMARK_DIR}/common/prepare_host.sh"
 
-# Persist iperf3 port
-export IPERF_PORT=5201
+if [[ "$BENCHMARK_PATH" =~ "iperf" ]]; then 
+    # Persist Iperf port
+    export IPERF_PORT=5201
+elif [[ "$BENCHMARK_PATH" =~ "nginx" ]]; then
+    # Persist Nginx port
+    export NGINX_PORT=8080
+elif [[ "$BENCHMARK_PATH" =~ "redis" ]]; then
+    # Persist Redis port
+    export REDIS_PORT=6379
+fi
 
 # Function to run the benchmark
 # Parameters:

--- a/test/benchmark/nginx/http_req10k_conc1_bw/config.json
+++ b/test/benchmark/nginx/http_req10k_conc1_bw/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "Transfer rate:",
+    "result_index": "3",
+    "description": "ab -n 10000 -c 1 http://localhost:8080/index.html",
+    "title": "Nginx HTTP request performance with 1 concurrency and 10000 requests in total",
+    "benchmark_type": "host_guest"
+}

--- a/test/benchmark/nginx/http_req10k_conc1_bw/host.sh
+++ b/test/benchmark/nginx/http_req10k_conc1_bw/host.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    pgrep qemu | xargs kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run apache bench
+ab -n 10000 -c 1 http://localhost:8080/index.html
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/nginx/http_req10k_conc1_bw/result_template.json
+++ b/test/benchmark/nginx/http_req10k_conc1_bw/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average HTTP Bandwidth over virtio-net between Host Linux and Guest Linux",
+        "unit": "Kbytes/sec",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average HTTP Bandwidth over virtio-net between Host Linux and Guest Asterinas",
+        "unit": "Kbytes/sec",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/nginx/http_req10k_conc1_bw/run.sh
+++ b/test/benchmark/nginx/http_req10k_conc1_bw/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+cp /benchmark/nginx/nginx.conf /usr/local/nginx/conf/
+
+echo "Running nginx server"
+/usr/local/nginx/sbin/nginx

--- a/test/benchmark/nginx/nginx.conf
+++ b/test/benchmark/nginx/nginx.conf
@@ -1,0 +1,19 @@
+user root;
+daemon off;
+worker_processes 1;
+
+events {
+}
+
+http {
+    include mime.types;
+
+    server {
+        listen 10.0.2.15:8080;
+        access_log off;
+
+        location / {
+            autoindex on;
+        }
+    }
+}

--- a/test/benchmark/nginx/summary.json
+++ b/test/benchmark/nginx/summary.json
@@ -1,0 +1,5 @@
+{
+    "benchmarks": [
+        "http_req10k_conc1_bw"
+    ]
+}


### PR DESCRIPTION
This PR adds Nginx benchmark CI. Asterinas does not support the Nginx benchmark with concurrency > 1, so I only added the benchmark with the command `ab -n 10000 -c 1`.