### PR TITLE
Refine mapping-related locks

### DIFF
--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -31,6 +31,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
             .unwrap();
         *clear_ctid = 0;
     }
+    drop(clear_ctid);
     // exit the robust list: walk the robust list; mark futex words as dead and do futex wake
     wake_robust_list(posix_thread, tid);
 

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -81,8 +81,8 @@ where
         let page: Page<PageTablePageMeta<E, C>> = self.into();
 
         // Acquire the lock.
-        while page
-            .meta()
+        let meta = page.meta();
+        while meta
             .lock
             .compare_exchange(0, 1, Ordering::Acquire, Ordering::Relaxed)
             .is_err()


### PR DESCRIPTION
In our current mapping-related operations, such as handling page faults, we need to acquire the large lock of the `VmarInner` first, which prevents actual parallel operations on multiple mappings. This PR aims to modify the relevant locking operations to enable true parallelism in mapping-related operations and correct some of the originally potential lock behaviors that could break atomic mode.