### PR TITLE
Return when sigset size error

### DIFF
--- a/kernel/src/syscall/rt_sigaction.rs
+++ b/kernel/src/syscall/rt_sigaction.rs
@@ -22,6 +22,10 @@ pub fn sys_rt_sigaction(
         sigset_size
     );
 
+    if sigset_size != 8 {
+        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8");
+    }
+
     let mut sig_dispositions = ctx.process.sig_dispositions().lock();
 
     let old_action = if sig_action_addr != 0 {

--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -24,7 +24,7 @@ pub fn sys_rt_sigprocmask(
         mask_op, set_ptr, oldset_ptr, sigset_size
     );
     if sigset_size != 8 {
-        error!("sigset size is not equal to 8");
+        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8");
     }
     do_rt_sigprocmask(mask_op, set_ptr, oldset_ptr, ctx)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/rt_sigsuspend.rs
+++ b/kernel/src/syscall/rt_sigsuspend.rs
@@ -22,7 +22,6 @@ pub fn sys_rt_sigsuspend(
         sigmask_addr, sigmask_size
     );
 
-    debug_assert!(sigmask_size == core::mem::size_of::<SigMask>());
     if sigmask_size != core::mem::size_of::<SigMask>() {
         return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
     }


### PR DESCRIPTION
For `rt_sigaction`, add check for `sigset_size`:
https://elixir.bootlin.com/linux/v6.10.5/source/kernel/signal.c#L4530

For `rt_sigprocmask`, change from `error` to return with `Errno::EINVAL`:
https://elixir.bootlin.com/linux/v6.10.5/source/kernel/signal.c#L3239

For `rt_sigsuspend`: remove assertion
https://elixir.bootlin.com/linux/v6.10.5/source/kernel/signal.c#L4721


The assertion in `sys_rt_sigsuspend()` could be triggered by 

```C
#define _GNU_SOURCE
#include <errno.h>
#include <signal.h>
#include <stdio.h>
#include <sys/syscall.h>
#include <unistd.h>

int main() {
  sigset_t mask;
  syscall(SYS_rt_sigsuspend, &mask, 9);
  perror("syscall rt_sigsuspend");

  return 0;
}
```