### PR TITLE
Update book with grammar and link fixes

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -16,17 +16,17 @@ This book is divided into five distinct parts:
 
 Explore the modern OS kernel at the heart of Asterinas.
 Designed to realize the full potential of Rust,
-Asterinas Kernel implements Linux ABI in a safe and efficient way.
+Asterinas Kernel implements the Linux ABI in a safe and efficient way.
 This means it can seamlessly replace Linux,
 offering enhanced safety and security.
 
 #### [Part 2: Asterinas OSTD](ostd/)
 
-Asterinas OSTD lays down a minimalistic, powerful, and solid foundation
+The Asterinas OSTD lays down a minimalistic, powerful, and solid foundation
 for OS development.
 It's akin to Rust's `std` crate
 but crafted for the demands of _safe_ Rust OS development.
-Asterinas Kernel is built on this very OSTD.
+The Asterinas Kernel is built on this very OSTD.
 
 #### [Part 3: Asterinas OSDK](osdk/guide/)
 

--- a/docs/src/kernel/README.md
+++ b/docs/src/kernel/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Asterinas is a _secure_, _fast_, and _general-purpose_ OS kernel
-that provides _Linux-compatible_ ABI.
+that provides an _Linux-compatible_ ABI.
 It can serve as a seamless replacement for Linux
 while enhancing _memory safety_ and _developer friendliness_.
 
@@ -44,7 +44,11 @@ git clone https://github.com/asterinas/asterinas
 2. Run a Docker container as the development environment.
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.9.0
+docker run -it --privileged \
+               --network=host \
+               --device=/dev/kvm \
+               -v $(pwd)/asterinas:/root/asterinas \
+               asterinas/asterinas:0.9.0
 ```
 
 3. Inside the container, go to the project folder to build and run Asterinas.

--- a/docs/src/kernel/advanced-instructions.md
+++ b/docs/src/kernel/advanced-instructions.md
@@ -64,8 +64,8 @@ Then, in the interactive shell, run the following script to start the syscall te
 
 ### Using GDB to Debug
 
-To debug Asterinas by [QEMU GDB support](https://qemu-project.gitlab.io/qemu/system/gdb.html),
-one could compile Asterinas in the debug profile,
+To debug Asterinas via [QEMU GDB support](https://qemu-project.gitlab.io/qemu/system/gdb.html),
+you can compile Asterinas in the debug profile,
 start an Asterinas instance and run the GDB interactive shell in another terminal.
 
 Start a GDB-enabled VM of Asterinas with OSDK and wait for debugging connection:

--- a/docs/src/kernel/roadmap.md
+++ b/docs/src/kernel/roadmap.md
@@ -18,7 +18,7 @@ which would take a significant amount of time.
 
 To address this obstacle,
 we have decided to enter the cloud market first.
-In an IaaS cloud, workloads of different tenants are run in VMs
+In an IaaS (Infrastructure-as-a-Service) cloud, workloads of different tenants are run in VMs
 or [VM-style bare-metal servers](https://dl.acm.org/doi/10.1145/3373376.3378507)
 for maximum isolation and elasticity.
 The main device driver requirement for the VM environment is virtio,
@@ -28,7 +28,7 @@ or the host OS of a VM-style bare-metal server in production
 looks quite feasible in the near future.
 
 Asterinas provides high assurance of memory safety
-thanks to [the framekernel architecture]().
+thanks to [the framekernel architecture](the-framekernel-architecture.md).
 Thus, in the cloud setting,
 Asterinas is attractive for usage scenarios
 where Linux ABI is necessary but Linux itself is considered insecure

--- a/docs/src/kernel/the-framekernel-architecture.md
+++ b/docs/src/kernel/the-framekernel-architecture.md
@@ -47,7 +47,7 @@ It must concurrently fulfill four criteria.
 The safe APIs of the framework are considered sound
 if no [undefined behaviors](https://doc.rust-lang.org/reference/behavior-considered-undefined.html#behavior-considered-undefined) shall be triggered
 by whatever safe Rust code that a programmer may write using the APIs
----as long as the code is verified by the Rust toolchain.
+- as long as the code is verified by the Rust toolchain.
 Soundness ensures that the OS framework,
 in conjunction with the Rust toolchain,
 bears the full responsibility for the kernel's memory safety.

--- a/docs/src/osdk/guide/README.md
+++ b/docs/src/osdk/guide/README.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-OSDK (short for Operating System Development Kit) 
+The Asterinas OSDK (short for Operating System Development Kit) 
 is designed to simplify the development of Rust operating systems.
 It aims to streamline the process 
 by leveraging [the framekernel architecture](../../kernel/the-framekernel-architecture.md). 
 
-OSDK provides a command-line tool `cargo-osdk`,
+The OSDK provides a command-line tool `cargo-osdk`,
 which facilitates project management 
 for those developed on the framekernel architecture.
 `cargo-osdk` can be used as a subcommand of Cargo.
@@ -18,7 +18,7 @@ and testing projects conveniently.
 ## Install OSDK
 
 ### Requirements
-Currently, OSDK only works on x86_64 ubuntu system.
+Currently, OSDK is only supported on x86_64 Ubuntu systems.
 We will add support for more operating systems in the future.
 
 To run a kernel developed by OSDK with QEMU,
@@ -50,14 +50,14 @@ cargo install cargo-binutils
 ### Install
 
 `cargo-osdk` is published on [crates.io](https://crates.io/),
-and can be installed by
+and can be installed by running
 ```bash
 cargo install cargo-osdk
 ```
 
 ### Upgrade
 If `cargo-osdk` is already installed,
-the tool can be upgraded by
+the tool can be upgraded by running
 ```bash
 cargo install --force cargo-osdk
 ```

--- a/docs/src/osdk/guide/create-project.md
+++ b/docs/src/osdk/guide/create-project.md
@@ -1,6 +1,6 @@
 # Creating an OS Project
 
-OSDK can be used to create a new kernel project
+The OSDK can be used to create a new kernel project
 or a new library project.
 A kernel project defines the entry point of the kernel
 and can be run with QEMU.
@@ -112,4 +112,4 @@ The default manifest of a kernel project:
 ### `rust-toolchain.toml`
 
 The Rust toolchain for the kernel.
-It aligns with the toolchain of the Asterinas OSTD.
+It is the same as the toolchain of the Asterinas OSTD.

--- a/docs/src/osdk/guide/intel-tdx.md
+++ b/docs/src/osdk/guide/intel-tdx.md
@@ -1,6 +1,6 @@
 # Running an OS in Intel TDX env
 
-OSDK supports running your OS in an [Intel TDX](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html) environment conveniently.
+The OSDK supports running your OS in an [Intel TDX](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html) environment conveniently.
 Intel TDX can provide a more secure environment for your OS.
 
 ## Prepare the Intel TDX Environment
@@ -39,7 +39,7 @@ docker run -it --privileged --network=host --device=/dev/kvm asterinas/osdk-tdx:
 
 As Intel TDX has extra requirements or restrictions for VMs,
 it demands adjusting the OSDK configurations accordingly.
-This can be easily achieved with the `scheme` feature of OSDK,
+This can be easily achieved with the `scheme` feature of the OSDK,
 which provides a convenient way to override the default OSDK configurations
 for a specific environment.
 

--- a/docs/src/osdk/guide/run-project.md
+++ b/docs/src/osdk/guide/run-project.md
@@ -1,6 +1,6 @@
 # Running or Testing an OS Project
 
-OSDK allows for convenient building, running,
+The OSDK allows for convenient building, running,
 and testing of an OS project.
 The following example shows the typical workflow.
 
@@ -76,12 +76,12 @@ cargo osdk test foo
 
 ## Options
 
-Both `build`, `run`, and `test` commands accept options
+All of the `build`, `run`, and `test` commands accept options
 to control their behavior, such as how to compile and
 launch the kernel.
 The following documentations provide details on
 all the available options:
 
-- [build options](../reference/commands/build.md)
-- [run options](../reference/commands/run.md)
-- [test options](../reference/commands/test.md)
+- [`build` options](../reference/commands/build.md)
+- [`run` options](../reference/commands/run.md)
+- [`test` options](../reference/commands/test.md)

--- a/docs/src/osdk/guide/why.md
+++ b/docs/src/osdk/guide/why.md
@@ -9,7 +9,7 @@ This is important to Asterinas
 as we believe that the project's success
 is intricately tied to the productivity and happiness
 of its developers.
-So OSDK is here to upgrade your dev experience.
+So the OSDK is here to upgrade your dev experience.
 
 To be honest, writing OS kernels is hard.
 Even when you're using Rust,
@@ -24,7 +24,7 @@ no stack, no heap, no threads, not even the standard I/O.
 It's just you and the no_std world of Rust.
 You have to implement these basic programming primitives
 by getting your hands dirty with the most low-level,
-error-prone, nitty-gritty of computer architecture.
+error-prone, and nitty-gritty details of computer architecture.
 It's a journey of learning, doing, and
 a whole lot of finger-crossing
 to make sure everything clicks into place.
@@ -35,7 +35,7 @@ reuse OS-related libraries/crates across projects.
 Think about it:
 most applications share a common groundwork,
 like libc, Rust's std library, or an SDK.
-This isn't the case with kernels --
+This isn't the case with kernels -
 they lack this shared starting point,
 forcing each one to craft its own set of tools
 from the ground up.
@@ -83,4 +83,4 @@ as reported by [RustSec Advisory Database](https://rustsec.org).
 Despite having [a whole book](https://doc.rust-lang.org/nomicon/)
 to document "the Dark Arts of Unsafe Rust",
 unsafe Rust is still tricky to use correctly,
-even among reasoned Rust developers.
+even among seasoned Rust developers.

--- a/docs/src/osdk/guide/work-in-workspace.md
+++ b/docs/src/osdk/guide/work-in-workspace.md
@@ -2,7 +2,7 @@
 
 Typically, an operating system may consist of multiple crates,
 and these crates may be organized in a workspace.
-OSDK also supports managing projects in a workspace.
+The OSDK also supports managing projects in a workspace.
 Below is an example that demonstrates
 how to create, build, run, and test projects in a workspace.
 
@@ -47,11 +47,11 @@ myworkspace/
           └── lib.rs
 ```
 
-At present, OSDK mandates that there must be only one kernel project
+At present, the OSDK mandates that there must be only one kernel project
 within a workspace.
 
 In addition to the two projects,
-OSDK will also generate `OSDK.toml` and `rust-toolchain.toml`
+the OSDK will also generate `OSDK.toml` and `rust-toolchain.toml`
 at the root of the workspace.
 
 Next, add the following function to `mylib/src/lib.rs`.

--- a/docs/src/osdk/reference/README.md
+++ b/docs/src/osdk/reference/README.md
@@ -1,6 +1,6 @@
 # OSDK User Reference
 
-OSDK is a command line tool that can be used
+The Asterinas OSDK is a command line tool that can be used
 as a subcommand of Cargo.
 The common usage of OSDK is:
 
@@ -15,7 +15,7 @@ you can use `cargo osdk help <COMMAND>`.
 
 ## Manifest
 
-OSDK utilizes a manifest named `OSDK.toml`
+The OSDK utilizes a manifest named `OSDK.toml`
 to define its precise behavior regarding
 how to run a kernel with QEMU.
 The `OSDK.toml` file should be placed

--- a/docs/src/osdk/reference/commands/profile.md
+++ b/docs/src/osdk/reference/commands/profile.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The profile command is used to collect stack traces when running the target
-kernel in QEMU. It attaches to the GDB server initiated with the run subcommand
+kernel in QEMU. It attaches to the GDB server, initiated with the run subcommand,
 and collects the stack trace periodically. The collected information can be
 used to directly generate a flame graph, or be stored for later analysis using
 [the original flame graph tool](https://github.com/brendangregg/FlameGraph).

--- a/docs/src/osdk/reference/commands/run.md
+++ b/docs/src/osdk/reference/commands/run.md
@@ -33,6 +33,9 @@ Launch a debug server via QEMU with an unix socket stub, e.g. `.debug`:
 
 ```bash
 cargo osdk run --gdb-server addr=.debug
+
+```bash
+cargo osdk run --gdb-server --gdb-server-addr .debug
 ```
 
 Launch a debug server via QEMU with a TCP stub, e.g., `localhost:1234`:
@@ -45,4 +48,10 @@ Launch a debug server via QEMU and use VSCode to interact with:
 
 ```bash
 cargo osdk run --gdb-server wait-client,vscode,addr=:1234
+```
+
+Launch a debug server via QEMU and use VSCode to interact with:
+
+```bash
+cargo osdk run --gdb-server --gdb-vsc --gdb-server-addr :1234
 ```

--- a/docs/src/osdk/reference/commands/test.md
+++ b/docs/src/osdk/reference/commands/test.md
@@ -5,12 +5,12 @@ execute kernel mode unit test by starting QEMU.
 The usage is as follows:
 
 ```bash
-cargo osdk test [OPTIONS] [TESTNAME]
+cargo osdk test [TESTNAME] [OPTIONS] 
 ```
 
 ## Arguments 
 
-[TESTNAME]:
+`TESTNAME`:
 Only run tests containing this string in their names
 
 ## Options

--- a/docs/src/osdk/reference/manifest.md
+++ b/docs/src/osdk/reference/manifest.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OSDK utilizes a manifest to define its precise behavior.
+The OSDK tool utilizes a manifest to define its precise behavior.
 Typically, the configuration file is named `OSDK.toml`
 and is placed in the root directory of the workspace
 (the same directory as the workspace's `Cargo.toml`).

--- a/docs/src/ostd/README.md
+++ b/docs/src/ostd/README.md
@@ -7,10 +7,10 @@
 > 子曰：
 > "从心所欲，不逾矩。"
 
-With Asterinas OSTD,
+With the Asterinas OSTD (Operating System Standard Library), 
 you don't have to learn the dark art of unsafe Rust programming
 and risk shooting yourself in the foot.
-You will be doing whatever your heart desired
+You will be doing whatever your heart desires,
 and be confident that your kernel will never crash
 or be hacked due to undefined behaviors,
 even if today marks your Day 1 as a Rust programmer.
@@ -58,28 +58,27 @@ by leveraging OSTD.
 Adopting a minimalist philosophy,
 OSTD has a small codebase.
 At its core lies the `ostd` crate,
-currently encompassing about 10K lines of code
----a figure that is even smaller than those of many microkernels.
+currently encompassing about 10K lines of code - a figure 
+that is even smaller than those of many microkernels.
 As OSTD evolves,
 its codebase will expand,
 albeit at a relatively slow rate
 in comparison to the OS services layered atop it.
 
-OSTD's efficiency is measurable
+The OSTD's efficiency is measurable
 through the performance metrics of its APIs
 and the system calls of Asterinas Kernel.
 No intrinsic limitations have been identified within Rust
 or the framekernel architecture
 that could hinder kernel performance.
 
-Soundness,
-unlike the other three requirements,
+Soundness, unlike the other three requirements,
 is not as easily quantified or proved.
 While formal verification stands as the gold standard,
 it requires considerable resources and time
 and is not an immediate priority.
 As a more pragmatic approach,
 we will explain why the high-level design is sound
-in the [soundness analysis]()
-and rely on the many eyes of the community
-to catch any potential flaws in the implementation.
+in the soundness analysis and rely on the many 
+eyes of the community to catch any potential flaws 
+in the implementation.

--- a/docs/src/to-contribute/style-guidelines/rust-guidelines.md
+++ b/docs/src/to-contribute/style-guidelines/rust-guidelines.md
@@ -11,7 +11,7 @@ The use of the `#[warn(missing_docs)]` lint enforces this rule.
 
 Asterinas adheres to the API style guidelines of the Rust community.
 The recommended API documentation style can be found at
-[how-to-write-documentation](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+[How to write documentation - The rustdoc book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
 
 ## Lint Guidelines
 


### PR DESCRIPTION
Hi there, I was reading through the Asterinas book and found some grammar errors and a few broken links, so I've tried to fix them.

I also propose a bit of a solution for #1014, with a placeholder name (something that I figured OSTD stood for) for the Asterinas OSTD index in the book