### PR TITLE
Use `LocalIrqDisable` in `Subject`

### DIFF
--- a/kernel/src/events/subject.rs
+++ b/kernel/src/events/subject.rs
@@ -3,6 +3,7 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use keyable_arc::KeyableWeak;
+use ostd::sync::LocalIrqDisabled;
 
 use super::{Events, EventsFilter, Observer};
 use crate::prelude::*;
@@ -10,7 +11,7 @@ use crate::prelude::*;
 /// A Subject notifies interesting events to registered observers.
 pub struct Subject<E: Events, F: EventsFilter<E> = ()> {
     // A table that maintains all interesting observers.
-    observers: SpinLock<BTreeMap<KeyableWeak<dyn Observer<E>>, F>>,
+    observers: SpinLock<BTreeMap<KeyableWeak<dyn Observer<E>>, F>, LocalIrqDisabled>,
     // To reduce lock contentions, we maintain a counter for the size of the table
     num_observers: AtomicUsize,
 }


### PR DESCRIPTION
This fixes **"Bug 5: Dead lock: Missing `irq_disabled` when acquiring locks in `Pollee`/`Subject`"** mentioned in https://github.com/asterinas/asterinas/issues/1406#issuecomment-2392759804.

Note:
 - The Linux kernel also allows I/O events to be added under interrupt handlers, see [their comments](https://github.com/torvalds/linux/blob/0c559323bbaabee7346c12e74b497e283aaafef5/fs/eventpoll.c#L1989-L1990).
 - We currently abuse this even more than the Linux kernel (since much of our network stack can be run directly in IRQ handlers).

The change in this PR should be fine in both the short and long term.