### PR TITLE
Clean up the kernel page table interface

### DIFF
--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -5,8 +5,7 @@ use tdx_guest::{tdcall::accept_page, tdvmcall::map_gpa, TdxTrapFrame};
 
 use crate::{
     mm::{
-        kspace::KERNEL_PAGE_TABLE,
-        paddr_to_vaddr,
+        kspace, paddr_to_vaddr,
         page_prop::{PageProperty, PrivilegedPageFlags as PrivFlags},
         page_table::boot_pt,
         PAGE_SIZE,
@@ -56,9 +55,8 @@ pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), Pag
         }
     });
     // Protect the page in the kernel page table.
-    let pt = KERNEL_PAGE_TABLE.get().unwrap();
     let vaddr = paddr_to_vaddr(gpa);
-    pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
+    kspace::protect(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
         .map_err(|_| PageConvertError::PageTable)?;
 
     map_gpa(
@@ -98,9 +96,8 @@ pub unsafe fn protect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), PageC
         }
     });
     // Protect the page in the kernel page table.
-    let pt = KERNEL_PAGE_TABLE.get().unwrap();
     let vaddr = paddr_to_vaddr(gpa);
-    pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
+    kspace::protect(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
         .map_err(|_| PageConvertError::PageTable)?;
 
     map_gpa((gpa & PAGE_MASK) as u64, (page_num * PAGE_SIZE) as u64)

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -95,7 +95,6 @@ pub enum PageTableItem {
     PageTableNode {
         page: DynPage,
     },
-    #[allow(dead_code)]
     MappedUntracked {
         va: Vaddr,
         pa: Paddr,
@@ -508,7 +507,7 @@ where
     ///  - the range being mapped does not affect kernel's memory safety;
     ///  - the physical address to be mapped is valid and safe to use;
     ///  - it is allowed to map untracked pages in this virtual address range.
-    pub unsafe fn map_pa(&mut self, pa: &Range<Paddr>, prop: PageProperty) {
+    pub unsafe fn map_untracked(&mut self, pa: &Range<Paddr>, prop: PageProperty) {
         let end = self.0.va + pa.len();
         let mut pa = pa.start;
         assert!(end <= self.0.barrier_va.end);

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -55,7 +55,7 @@ fn test_untracked_map_unmap() {
     let to = PAGE_SIZE * to_ppn.start..PAGE_SIZE * to_ppn.end;
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
 
-    unsafe { pt.map(&from, &to, prop).unwrap() };
+    unsafe { pt.cursor_mut(&from).unwrap().map_untracked(&to, prop) };
     for i in 0..100 {
         let offset = i * (PAGE_SIZE + 1000);
         assert_eq!(pt.query(from.start + offset).unwrap().0, to.start + offset);
@@ -239,7 +239,7 @@ fn test_untracked_large_protect_query() {
     let to = PAGE_SIZE * to_ppn.start..PAGE_SIZE * to_ppn.end;
     let mapped_pa_of_va = |va: Vaddr| va - (from.start - to.start);
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
-    unsafe { pt.map(&from, &to, prop).unwrap() };
+    unsafe { pt.cursor_mut(&from).unwrap().map_untracked(&to, prop) };
     for (item, i) in pt.cursor(&from).unwrap().zip(0..512 + 2 + 2) {
         let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
             panic!("Expected MappedUntracked, got {:#x?}", item);

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -20,7 +20,7 @@ use crate::{
     cpu_local,
     mm::{
         io::Fallible,
-        kspace::KERNEL_PAGE_TABLE,
+        kspace,
         page_table::{self, PageTable, PageTableItem, UserMode},
         tlb::{TlbFlushOp, TlbFlusher, FLUSH_ALL_RANGE_THRESHOLD},
         Frame, PageProperty, VmReader, VmWriter, MAX_USERSPACE_VADDR,
@@ -59,7 +59,7 @@ impl VmSpace {
     /// Creates a new VM address space.
     pub fn new() -> Self {
         Self {
-            pt: KERNEL_PAGE_TABLE.get().unwrap().create_user_page_table(),
+            pt: kspace::create_user_page_table(),
             page_fault_handler: None,
             activation_lock: RwLock::new(()),
         }


### PR DESCRIPTION
The `PageTable<KernelMode>` should be a singleton that is only accessible through `kspace`. So the special implementations like `page_table.map` or `page_table.protect_flush_tlb` can be removed and handled by `kspace` instead.