### PR TITLE
Add `.code64` to the x86 trap assembly

### DIFF
--- a/ostd/src/arch/x86/trap/syscall.S
+++ b/ostd/src/arch/x86/trap/syscall.S
@@ -15,6 +15,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+.code64
+
 .text
     # extern "sysv64" fn syscall_return(&mut GeneralRegs)
 .global syscall_return

--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -15,6 +15,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+.code64
+
 .equ NUM_INT, 256
 
 .altmacro


### PR DESCRIPTION
Sometimes the compiling non-deterministically fail to infer that this is 64-bit code (, for example, https://github.com/asterinas/asterinas/actions/runs/11178915165/job/31077462022 and ktest). This PR provides a fix.