### PR TITLE
Fix IRQ-related socket locks

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -130,7 +130,7 @@ impl DatagramSocket {
         }
 
         // Slow path
-        let mut inner = self.inner.write();
+        let mut inner = self.inner.write_irq_disabled();
         inner.borrow_result(|owned_inner| {
             let bound_datagram = match owned_inner.bind_to_ephemeral_endpoint(remote_endpoint) {
                 Ok(bound_datagram) => bound_datagram,
@@ -278,7 +278,7 @@ impl Socket for DatagramSocket {
         let endpoint = socket_addr.try_into()?;
 
         let can_reuse = self.options.read().socket.reuse_addr();
-        let mut inner = self.inner.write();
+        let mut inner = self.inner.write_irq_disabled();
         inner.borrow_result(|owned_inner| {
             let bound_datagram = match owned_inner.bind(&endpoint, can_reuse) {
                 Ok(bound_datagram) => bound_datagram,
@@ -296,7 +296,7 @@ impl Socket for DatagramSocket {
 
         self.try_bind_ephemeral(&endpoint)?;
 
-        let mut inner = self.inner.write();
+        let mut inner = self.inner.write_irq_disabled();
         let Inner::Bound(bound_datagram) = inner.as_mut() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is not bound")
         };

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -36,7 +36,7 @@ impl ListenStream {
 
     /// Append sockets listening at LocalEndPoint to support backlog
     fn fill_backlog_sockets(&self) -> Result<()> {
-        let mut backlog_sockets = self.backlog_sockets.write();
+        let mut backlog_sockets = self.backlog_sockets.write_irq_disabled();
 
         let backlog = self.backlog;
         let current_backlog_len = backlog_sockets.len();
@@ -54,7 +54,7 @@ impl ListenStream {
     }
 
     pub fn try_accept(&self) -> Result<ConnectedStream> {
-        let mut backlog_sockets = self.backlog_sockets.write();
+        let mut backlog_sockets = self.backlog_sockets.write_irq_disabled();
 
         let index = backlog_sockets
             .iter()


### PR DESCRIPTION
This fixes **"Bug 3: Dead lock: Missing `irq_disabled` when acquiring various `StreamSocket`-related locks"** mentioned in https://github.com/asterinas/asterinas/issues/1406#issuecomment-2392759804.

Currently, we hold too many locks in IRQ handlers, which means that all involved locks have to be protected with IRQ-disabled guards, which seems a bit excessive:
 https://github.com/asterinas/asterinas/blob/96efd620072a0cbdccc95b58901894111f17bb3a/kernel/src/net/socket/ip/stream/mod.rs#L640-L648

This PR tries to make some more changes by delaying the state transition (lines 642 - 648 above) until some user events occur.
- Note that `IoEvents::OUT` is added by `ConnectingStream::update_io_events` when the state transition is needed, but the actual state transition is delayed until one of `StreamSocket::update_options_and_state`/`read_updated_state`/`write_updated_state` is called.
- I think things can be better with https://github.com/asterinas/asterinas/issues/1356, so instead of letting `ConnectingStream::update_io_events` add `IoEvents::OUT`, we can let the target state calculate the I/O events in `StreamSocket::poll`.