### PR TITLE
Fix the case that you can protect an present PTE to absent in x86

### DIFF
--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
@@ -158,7 +158,9 @@ impl PageTableCreator {
         }
         let pt = unsafe { &mut *(pde.paddr() as *mut Ia32eTable) };
         let pte = pt.index(1, from.addr());
-        pte.update(to.addr(), flags);
+        // In level-1 PTE, the HUGE bit is the PAT bit (page attribute table).
+        // We use it as the "valid" bit for the page table entry.
+        pte.update(to.addr(), flags | Ia32eFlags::HUGE);
     }
 
     pub fn nr_frames_used(&self) -> usize {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -327,6 +327,10 @@ pub trait PageTableEntryTrait: Clone + Copy + Debug + Default + Pod + Sized + Sy
     }
 
     /// If the flags are present with valid mappings.
+    ///
+    /// For PTEs created by [`Self::new_absent`], this method should return
+    /// false. And for PTEs created by [`Self::new_page`] or [`Self::new_pt`]
+    /// and modified with [`Self::set_prop`] this method should return true.
     fn is_present(&self) -> bool;
 
     /// Create a new PTE with the given physical address and flags that map to a page.
@@ -343,6 +347,10 @@ pub trait PageTableEntryTrait: Clone + Copy + Debug + Default + Pod + Sized + Sy
 
     fn prop(&self) -> PageProperty;
 
+    /// Set the page property of the PTE.
+    ///
+    /// This will be only done if the PTE is present. If not, this method will
+    /// do nothing.
     fn set_prop(&mut self, prop: PageProperty);
 
     /// If the PTE maps a page rather than a child page table.

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -57,9 +57,6 @@ where
     /// Operates on the mapping properties of the entry.
     ///
     /// It only modifies the properties if the entry is present.
-    // FIXME: in x86_64, you can protect a page with neither of the RWX
-    // permissions. This would make the page not accessible and leaked. Such a
-    // behavior is memory-safe but wrong. In RISC-V there's no problem.
     pub(in crate::mm) fn protect(&mut self, op: &mut impl FnMut(&mut PageProperty)) {
         if !self.pte.is_present() {
             return;


### PR DESCRIPTION
Should go after #1372 

It fixes the case that you can `protect` a `present` PTE to `absent`, making the mapped page leaked. In RISC-V it can be easily fixed. ~~But in x86 we need to define an additional invalid physical address.~~

I found it easier that I thought. The "huge" bit can be used to track the validity. In the last (=1) level, HUGE is interpreted as "PAT" (Page Attribute Table) by the hardware, and it has no effects in our current settings.