### PR TITLE
Disbale dumping network packets

### DIFF
--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -12,6 +12,9 @@ NGINX_RAND_PORT=${NGINX_PORT:-$(shuf -i 1024-65535 -n 1)}
 REDIS_RAND_PORT=${REDIS_PORT:-$(shuf -i 1024-65535 -n 1)}
 IPERF_RAND_PORT=${IPERF_PORT:-$(shuf -i 1024-65535 -n 1)}
 
+# Optional QEMU arguments. Opt in them manually if needed.
+# QEMU_OPT_ARG_DUMP_PACKETS="-object filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap"
+
 echo "[$1] Forwarded QEMU guest port: $SSH_RAND_PORT->22; $NGINX_RAND_PORT->8080 $REDIS_RAND_PORT->6379 $IPERF_RAND_PORT->5201" 1>&2
 
 COMMON_QEMU_ARGS="\
@@ -25,7 +28,7 @@ COMMON_QEMU_ARGS="\
     -monitor chardev:mux \
     -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
     -netdev user,id=net01,hostfwd=tcp::$SSH_RAND_PORT-:22,hostfwd=tcp::$NGINX_RAND_PORT-:8080,hostfwd=tcp::$REDIS_RAND_PORT-:6379,hostfwd=tcp::$IPERF_RAND_PORT-:5201 \
-    -object filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap \
+    $QEMU_OPT_ARG_DUMP_PACKETS \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -drive if=none,format=raw,id=x0,file=./test/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/build/exfat.img \


### PR DESCRIPTION
This PR disables dumping network packets to a pcap file.

Orinally, each sending and receiving packets will also be dumped to a pcap file, this will largely hurt performance.

This PR will increase the iperf3 performance by about 1 times(From 1.9Gbps to 3.6Gbps, with backlog as 1).