### PR TITLE
Improve page allocator's efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "aster-input",
  "aster-logger",
  "aster-network",
+ "aster-page-allocator",
  "aster-rights",
  "aster-rights-proc",
  "aster-softirq",
@@ -214,6 +215,16 @@ dependencies = [
  "typeflags-util",
  "vte",
  "xmas-elf 0.8.0",
+]
+
+[[package]]
+name = "aster-page-allocator"
+version = "0.1.0"
+dependencies = [
+ "align_ext",
+ "id-alloc",
+ "log",
+ "ostd",
 ]
 
 [[package]]
@@ -1139,6 +1150,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 name = "osdk-test-kernel"
 version = "0.10.1"
 dependencies = [
+ "aster-page-allocator",
  "ostd",
  "owo-colors 4.0.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "kernel/libs/typeflags",
     "kernel/libs/typeflags-util",
     "kernel/libs/atomic-integer-wrapper",
+    "kernel/libs/aster-page-allocator",
 ]
 exclude = [
     "kernel/libs/comp-sys/cargo-component",

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,8 @@ OSDK_CRATES := \
 	kernel/comps/time \
 	kernel/comps/virtio \
 	kernel/libs/aster-util \
-	kernel/libs/aster-bigtcp
+	kernel/libs/aster-bigtcp \
+	kernel/libs/aster-page-allocator
 
 .PHONY: all
 all: build

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -29,6 +29,7 @@ atomic-integer-wrapper = { path = "libs/atomic-integer-wrapper" }
 id-alloc = { path = "../ostd/libs/id-alloc" }
 int-to-c-enum = { path = "libs/int-to-c-enum" }
 cpio-decoder = { path = "libs/cpio-decoder" }
+aster-page-allocator = { path = "libs/aster-page-allocator" }
 ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 intrusive-collections = "0.9.5"
 paste = "1.0"

--- a/kernel/libs/aster-page-allocator/Cargo.toml
+++ b/kernel/libs/aster-page-allocator/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "aster-page-allocator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+align_ext = { path = "../../../ostd/libs/align_ext" }
+id-alloc = { path = "../../../ostd/libs/id-alloc" }
+log = "0.4"
+ostd = { path = "../../../ostd" }

--- a/kernel/libs/aster-page-allocator/src/buddy_allocator.rs
+++ b/kernel/libs/aster-page-allocator/src/buddy_allocator.rs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MPL-2.0 OR MIT
+
+// To be specific, the original source code is from
+// [buddy_system_allocator](https://github.com/rcore-os/buddy_system_allocator),
+// which licensed under the following license.
+//
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2019-2020 Jiajie Chen
+//
+// We make the following new changes:
+// * Add `alloc_specific` to allocate a specific range of frames.
+// * Implement `PageAlloc` trait for `BuddyFrameAllocator`.
+//!  * Add statistics for the total memory and free memory.
+// * Refactor API to differentiate count and size of frames.
+//
+// These changes are released under the following license:
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::collections::btree_set::BTreeSet;
+use core::{alloc::Layout, array, cmp::min, ops::Range};
+
+use ostd::mm::{page::allocator::PageAlloc, Paddr, PAGE_SIZE};
+
+/// Buddy Frame allocator is a frame allocator based on buddy system, which
+/// allocates memory in power-of-two sizes.
+///
+/// ## Introduction
+///
+/// The max order of the allocator is specified via the const generic parameter
+/// `ORDER`. The frame allocator will only be able to allocate ranges of size
+/// up to 2<sup>ORDER</sup>, out of a total range of size at most 2<sup>ORDER +
+/// 1</sup> - 1.
+pub struct BuddyFrameAllocator<const ORDER: usize = 32> {
+    // buddy system with max order of ORDER
+    free_list: [BTreeSet<usize>; ORDER],
+
+    // statistics
+    allocated: usize,
+    total: usize,
+}
+
+pub(crate) fn prev_power_of_two(num: usize) -> usize {
+    1 << (usize::BITS as usize - num.leading_zeros() as usize - 1)
+}
+
+impl<const ORDER: usize> BuddyFrameAllocator<ORDER> {
+    /// Create an empty frame allocator
+    pub fn new() -> Self {
+        Self {
+            free_list: array::from_fn(|_| BTreeSet::default()),
+            allocated: 0,
+            total: 0,
+        }
+    }
+
+    /// Add a range of free pages, described by the **frame number**
+    /// [start, end), for the allocator to manage.
+    fn add_free_pages(&mut self, range: Range<usize>) {
+        let start = range.start;
+        let end = range.end;
+        assert!(start <= end);
+
+        let mut total = 0;
+        let mut current_start = start;
+
+        while current_start < end {
+            let lowbit = if current_start > 0 {
+                current_start & (!current_start + 1)
+            } else {
+                32
+            };
+            let size = min(
+                min(lowbit, prev_power_of_two(end - current_start)),
+                1 << (ORDER - 1),
+            );
+            total += size;
+
+            self.free_list[size.trailing_zeros() as usize].insert(current_start);
+            current_start += size;
+        }
+
+        self.total += total;
+    }
+
+    /// Allocate a range of frames from the allocator, returning the first frame of the allocated
+    /// range.
+    pub fn alloc(&mut self, count: usize) -> Option<usize> {
+        self.alloc_power_of_two(count.next_power_of_two().trailing_zeros())
+    }
+
+    /// Allocate a range of frames of the given count's power of two from the
+    /// allocator. The allocated range will have alignment equal to the power.
+    fn alloc_power_of_two(&mut self, power: u32) -> Option<usize> {
+        let class = power as usize;
+        for i in class..self.free_list.len() {
+            // Find the first non-empty size class
+            if !self.free_list[i].is_empty() {
+                // Split buffers
+                for j in (class + 1..i + 1).rev() {
+                    if let Some(block_ref) = self.free_list[j].iter().next() {
+                        let block = *block_ref;
+                        self.free_list[j - 1].insert(block + (1 << (j - 1)));
+                        self.free_list[j - 1].insert(block);
+                        self.free_list[j].remove(&block);
+                    } else {
+                        return None;
+                    }
+                }
+
+                let result = self.free_list[class].iter().next();
+                if let Some(result_ref) = result {
+                    let result = *result_ref;
+                    self.free_list[class].remove(&result);
+                    self.allocated += 1 << class;
+                    return Some(result);
+                } else {
+                    return None;
+                }
+            }
+        }
+        None
+    }
+
+    /// Deallocate a range of frames [frame, frame+count) from the frame
+    /// allocator.
+    ///
+    /// The range should be exactly the same when it was allocated, as in heap
+    /// allocator.
+    ///
+    /// # Safety
+    ///
+    /// Do not deallocate the same range twice.
+    pub fn dealloc(&mut self, start_frame: usize, count: usize) {
+        self.dealloc_power_of_two(start_frame, count.next_power_of_two().trailing_zeros())
+    }
+
+    /// Deallocate a range of frames described by count's power of two from the
+    /// allocator.
+    fn dealloc_power_of_two(&mut self, start_frame: usize, power: u32) {
+        let class = power as usize;
+
+        // Merge free buddy lists
+        let mut current_ptr = start_frame;
+        let mut current_class = class;
+        while current_class < self.free_list.len() {
+            let buddy = current_ptr ^ (1 << current_class);
+            if self.free_list[current_class].remove(&buddy) {
+                // Free buddy found
+                current_ptr = min(current_ptr, buddy);
+                current_class += 1;
+            } else {
+                self.free_list[current_class].insert(current_ptr);
+                break;
+            }
+        }
+
+        self.allocated -= 1 << class;
+    }
+
+    /// Given frames, described by a range of **frame number** [start, end),
+    /// mark them as allocated. Make sure they can be correctly deallocated
+    /// afterwards, while will not be allocated before deallocation.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if no suitable block found for the given range.
+    ///
+    pub fn alloc_specific(&mut self, start: usize, end: usize) {
+        let mut current_start = start;
+        while current_start < end {
+            /*
+            Algorithm:
+
+            1. Find one free block(begin_frame, class) already in the free
+            list, which contains at least one frame described by
+            current_start. If not, panic.
+
+            2. Split the block corresponding to the buddy algorithm. Find
+            the biggest sub-block which begins with current_start. The end of sublock should be smaller than end.
+            */
+
+            let mut size = 0;
+            // # TODO
+            //
+            // We are working on a more efficient implementation, based on free meta
+            // (i.e., current unused meta) and in the format of linked list. By
+            // introducing the free meta, we can reduce the time complexity of
+            // deleting blocks from O(log(n)) to O(1).
+            for i in (0..self.free_list.len()).rev() {
+                if self.free_list[i].is_empty() {
+                    continue;
+                }
+                // Traverse the blocks in the btree list
+                for block_iter in self.free_list[i].iter() {
+                    let block = *block_iter;
+                    // block means the start frame of the block
+                    if block > current_start {
+                        break;
+                    }
+                    if block <= current_start && block + (1 << i) > current_start {
+                        if block == current_start && block + (1 << i) <= end {
+                            self.free_list[i].remove(&block);
+                            size = 1 << i;
+                        } else if i > 0 {
+                            self.free_list[i - 1].insert(block);
+                            self.free_list[i - 1].insert(block + (1 << (i - 1)));
+                            self.free_list[i].remove(&block);
+                        }
+                        break;
+                    }
+                }
+
+                if size != 0 {
+                    // Already found the suitable block
+                    break;
+                }
+            }
+
+            if size == 0 {
+                panic!(
+                    "No suitable block found for current_start: {:x}",
+                    current_start
+                );
+            }
+
+            current_start += size;
+            // Update statistics
+            self.allocated += size;
+        }
+    }
+}
+
+impl PageAlloc for BuddyFrameAllocator<32> {
+    fn add_free_pages(&mut self, range: Range<usize>) {
+        BuddyFrameAllocator::add_free_pages(self, range)
+    }
+
+    fn alloc(&mut self, layout: Layout) -> Option<Paddr> {
+        assert!(layout.size() & (PAGE_SIZE - 1) == 0);
+        BuddyFrameAllocator::alloc(self, layout.size() / PAGE_SIZE).map(|idx| idx * PAGE_SIZE)
+    }
+
+    fn dealloc(&mut self, addr: Paddr, nr_pages: usize) {
+        BuddyFrameAllocator::dealloc(self, addr / PAGE_SIZE, nr_pages)
+    }
+
+    fn total_mem(&self) -> usize {
+        self.total * PAGE_SIZE
+    }
+
+    fn free_mem(&self) -> usize {
+        (self.total - self.allocated) * PAGE_SIZE
+    }
+}

--- a/kernel/libs/aster-page-allocator/src/lib.rs
+++ b/kernel/libs/aster-page-allocator/src/lib.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! An implementation of the global page allocator for
+//! [OSTD](https://crates.io/crates/ostd) based kernels.
+//!
+//! # Background
+//!
+//! `OSTD` has provided a page allocator interface, namely [`PageAlloc`] trait
+//! and [`page_allocator_init_fn`] procedure macro, allowing users to plug in
+//! their own page allocator wherever they want. You can refer to
+//! `ostd/src/mm/page/allocator.rs` for detailed introduction.
+//!
+//! # Introduction
+//!
+//! This crate is the template of how to inject a page allocator into the OSTD.
+//! Currently, the page allocator is implemented by the buddy system, as the
+//! details listed in the file `buddy_allocator.rs`.
+//!
+//! This file is the entry point of the page allocator. It provides the
+//! `init` function to initialize the global page allocator.
+
+#![no_std]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+extern crate ostd;
+pub(crate) mod buddy_allocator;
+
+use alloc::boxed::Box;
+use core::ops::Range;
+
+use align_ext::AlignExt;
+use buddy_allocator::BuddyFrameAllocator;
+use log::info;
+use ostd::{
+    boot::memory_region::MemoryRegionType,
+    mm::{page, page::allocator::PageAlloc, PAGE_SIZE},
+};
+
+pub fn init() -> Box<dyn PageAlloc> {
+    let regions = ostd::boot::memory_regions();
+    let mut allocator = Box::new(BuddyFrameAllocator::<32>::new());
+    for region in regions.iter() {
+        if region.typ() == MemoryRegionType::Usable {
+            // Make the memory region page-aligned, and skip if it is too small.
+            let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
+            let region_end = region.base().checked_add(region.len()).unwrap();
+            let end = region_end.align_down(PAGE_SIZE) / PAGE_SIZE;
+            if end <= start {
+                continue;
+            }
+            // Add global free pages to the frame allocator.
+            allocator.add_free_pages(Range { start, end });
+            info!(
+                "Found usable region, start:{:x}, end:{:x}",
+                region.base(),
+                region.base() + region.len()
+            );
+
+            for frame in start..end {
+                if page::Page::<page::meta::FrameMeta>::is_page_allocated(frame * PAGE_SIZE) {
+                    allocator.alloc_specific(frame, frame + 1);
+                }
+            }
+        }
+    }
+    info!(
+        "Global page allocator is initialized, total memory: {}, allocated memory: {}",
+        (allocator.total_mem()) / PAGE_SIZE,
+        (allocator.total_mem() - allocator.free_mem()) / PAGE_SIZE
+    );
+
+    allocator
+}

--- a/kernel/libs/aster-page-allocator/src/lib.rs
+++ b/kernel/libs/aster-page-allocator/src/lib.rs
@@ -34,7 +34,7 @@ use buddy_allocator::BuddyFrameAllocator;
 use log::info;
 use ostd::{
     boot::memory_region::MemoryRegionType,
-    mm::{page, page::allocator::PageAlloc, PAGE_SIZE},
+    mm::{page::allocator::PageAlloc, PAGE_SIZE},
 };
 
 pub fn init() -> Box<dyn PageAlloc> {
@@ -56,12 +56,6 @@ pub fn init() -> Box<dyn PageAlloc> {
                 region.base(),
                 region.base() + region.len()
             );
-
-            for frame in start..end {
-                if page::Page::<page::meta::FrameMeta>::is_page_allocated(frame * PAGE_SIZE) {
-                    allocator.alloc_specific(frame, frame + 1);
-                }
-            }
         }
     }
     info!(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -34,6 +34,7 @@ use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot,
     cpu::PinCurrentCpu,
+    mm::page::allocator::PageAlloc,
 };
 use process::Process;
 
@@ -118,6 +119,11 @@ fn ap_init() {
         .cpu_affinity(cpu_id.into())
         .priority(Priority::idle())
         .spawn();
+}
+
+#[ostd::page_allocator_init_fn]
+fn init_page_allocator() -> Box<dyn PageAlloc> {
+    aster_page_allocator::init()
 }
 
 fn init_thread() {

--- a/osdk/src/base_crate/main.rs.template
+++ b/osdk/src/base_crate/main.rs.template
@@ -1,7 +1,12 @@
 #![no_std]
 #![no_main]
+#![feature(linkage)]
 
 extern crate #TARGET_NAME#;
+extern crate alloc;
+
+use ostd::mm::page::allocator::PageAlloc;
+use alloc::boxed::Box;
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
@@ -9,4 +14,9 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         pub fn __ostd_panic_handler(info: &core::panic::PanicInfo) -> !;
     }
     unsafe { __ostd_panic_handler(info); }
+}
+
+#[ostd::default_page_allocator_init_fn]
+fn init_page_allocator() -> Box<dyn PageAlloc> {
+    aster_page_allocator::init()
 }

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -89,6 +89,14 @@ pub fn new_base_crate(
     // Add dependencies to the Cargo.toml
     add_manifest_dependency(dep_crate_name, dep_crate_path, link_unit_test_runner);
 
+    // Set the dependencies of base crate
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR").to_string());
+    add_base_dependency("ostd", manifest_path.join("../ostd"));
+    add_base_dependency(
+        "aster-page-allocator",
+        manifest_path.join("../kernel/libs/aster-page-allocator"),
+    );
+
     // Copy the manifest configurations from the target crate to the base crate
     copy_profile_configurations(workspace_root);
 
@@ -97,6 +105,55 @@ pub fn new_base_crate(
 
     // Get back to the original directory
     std::env::set_current_dir(original_dir).unwrap();
+}
+
+fn add_base_dependency(crate_name: &str, crate_path: impl AsRef<Path>) {
+    let manifest_path = "Cargo.toml";
+
+    let mut manifest: toml::Table = {
+        let content = fs::read_to_string(manifest_path).unwrap();
+        toml::from_str(&content).unwrap()
+    };
+
+    // Check if "dependencies" key exists, create it if it doesn't
+    if !manifest.contains_key("dependencies") {
+        manifest.insert(
+            "dependencies".to_string(),
+            toml::Value::Table(toml::Table::new()),
+        );
+    }
+
+    let dependencies = manifest.get_mut("dependencies").unwrap();
+
+    let target_dep = toml::Table::from_str(&format!(
+        "{} = {{ path = \"{}\", default-features = false }}",
+        crate_name,
+        crate_path.as_ref().display()
+    ))
+    .unwrap();
+    dependencies.as_table_mut().unwrap().extend(target_dep);
+
+    let base_dep_str = match option_env!("OSDK_LOCAL_DEV") {
+        Some("1") => {
+            format!(
+                "{} = {{ path = \"{}\" }}",
+                crate_name,
+                crate_path.as_ref().display()
+            )
+        }
+        _ => {
+            format!(
+                "{} = {{ version = \"{}\" }}",
+                crate_name,
+                env!("CARGO_PKG_VERSION")
+            )
+        }
+    };
+    let base_dep = toml::Table::from_str(&base_dep_str).unwrap();
+    dependencies.as_table_mut().unwrap().extend(base_dep);
+
+    let content = toml::to_string(&manifest).unwrap();
+    fs::write(manifest_path, content).unwrap();
 }
 
 fn add_manifest_dependency(

--- a/osdk/test-kernel/Cargo.toml
+++ b/osdk/test-kernel/Cargo.toml
@@ -11,3 +11,4 @@ repository ="https://github.com/asterinas/asterinas"
 [dependencies]
 ostd = { version = "0.10.1", path = "../../ostd" }
 owo-colors = "4.0.0"
+aster-page-allocator = { version = "0.1.0", path = "../../kernel/libs/aster-page-allocator" }

--- a/osdk/test-kernel/src/lib.rs
+++ b/osdk/test-kernel/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![forbid(unsafe_code)]
+#![feature(linkage)]
 
 extern crate alloc;
 
@@ -20,6 +21,7 @@ use ostd::{
     ktest::{
         get_ktest_crate_whitelist, get_ktest_test_whitelist, KtestError, KtestItem, KtestIter,
     },
+    mm::page::allocator::PageAlloc,
 };
 use owo_colors::OwoColorize;
 use path::{KtestPath, SuffixTrie};
@@ -74,6 +76,11 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     early_println!("An uncaught panic occurred: {:#?}", throw_info);
 
     ostd::prelude::abort();
+}
+
+#[ostd::ktest::page_allocator_init_fn]
+fn init_page_allocator() -> Box<dyn PageAlloc> {
+    aster_page_allocator::init()
 }
 
 /// Run all the tests registered by `#[ktest]` in the `.ktest_array` section.

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![feature(proc_macro_span)]
+#![feature(linkage)]
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -252,6 +253,63 @@ pub fn ktest(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #input
 
         #register_ktest_item
+    };
+
+    TokenStream::from(output)
+}
+
+/// This macro is used to mark the page allocator initialization function.
+///
+/// # Example
+///
+/// ```ignore
+/// #[ostd::page_allocator_init_fn]
+/// pub fn init_page_allocator() -> Box<dyn ostd::mm::page::allocator::PageAlloc> {
+/// // Your page allocator initialization code here
+/// }
+/// ```
+///
+/// It is a strong version of the `default_page_allocator_init_fn` macro
+/// attribute. So if it exists, the actual global page allocator will be
+/// replaced by this one.
+#[proc_macro_attribute]
+pub fn page_allocator_init_fn(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let init_fn = parse_macro_input!(item as ItemFn);
+    let init_fn_name = &init_fn.sig.ident;
+
+    let output = quote! {
+        #[no_mangle]
+        pub fn __ostd_page_allocator_init_fn() -> Box<dyn ostd::mm::page::allocator::PageAlloc> {
+            #init_fn_name()
+        }
+
+        #[allow(unused)]
+        #init_fn
+    };
+
+    TokenStream::from(output)
+}
+
+/// This macro is used to mark the page allocator initialization function by
+/// default for all kernels.
+///
+/// # Safety
+///
+/// This macro is used for internal OSDK implementation. Do not use it
+/// directly.
+#[proc_macro_attribute]
+pub fn default_page_allocator_init_fn(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let init_fn = parse_macro_input!(item as ItemFn);
+    let init_fn_name = &init_fn.sig.ident;
+
+    let output = quote! {
+        #[linkage = "weak"]
+        #[no_mangle]
+        pub fn __ostd_page_allocator_init_fn() -> Box<dyn ostd::mm::page::allocator::PageAlloc> {
+            #init_fn_name()
+        }
+
+        #init_fn
     };
 
     TokenStream::from(output)

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -62,14 +62,19 @@ pub fn boot_all_aps() {
     AP_BOOT_INFO.call_once(|| {
         let mut per_ap_info = BTreeMap::new();
         // Use two pages to place stack pointers of all APs, thus support up to 1024 APs.
-        let boot_stack_array =
-            page::allocator::alloc_contiguous(2 * PAGE_SIZE, |_| KernelMeta::default()).unwrap();
+        let boot_stack_array = page::allocator::alloc_contiguous(
+            core::alloc::Layout::from_size_align(2 * PAGE_SIZE, PAGE_SIZE).unwrap(),
+            |_| KernelMeta::default(),
+        )
+        .unwrap();
         assert!(num_cpus < 1024);
 
         for ap in 1..num_cpus {
-            let boot_stack_pages =
-                page::allocator::alloc_contiguous(AP_BOOT_STACK_SIZE, |_| KernelMeta::default())
-                    .unwrap();
+            let boot_stack_pages = page::allocator::alloc_contiguous(
+                core::alloc::Layout::from_size_align(AP_BOOT_STACK_SIZE, PAGE_SIZE).unwrap(),
+                |_| KernelMeta::default(),
+            )
+            .unwrap();
             let boot_stack_ptr = paddr_to_vaddr(boot_stack_pages.end_paddr());
             let stack_array_ptr = paddr_to_vaddr(boot_stack_array.start_paddr()) as *mut u64;
             // SAFETY: The `stack_array_ptr` is valid and aligned.

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -99,7 +99,11 @@ pub unsafe fn init_on_bsp() {
     for _ in 1..num_cpus {
         let ap_pages = {
             let nbytes = (bsp_end_va - bsp_base_va).align_up(PAGE_SIZE);
-            page::allocator::alloc_contiguous(nbytes, |_| KernelMeta::default()).unwrap()
+            page::allocator::alloc_contiguous(
+                core::alloc::Layout::from_size_align(nbytes, PAGE_SIZE).unwrap(),
+                |_| KernelMeta::default(),
+            )
+            .unwrap()
         };
         let ap_pages_ptr = paddr_to_vaddr(ap_pages.start_paddr()) as *mut u8;
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -82,8 +82,10 @@ unsafe fn init() {
     boot::init();
     logger::init();
 
+    mm::page::allocator::bootstrap_init();
+    let meta_vec = mm::init_page_meta();
     mm::page::allocator::init();
-    mm::kspace::init_kernel_page_table(mm::init_page_meta());
+    mm::kspace::init_kernel_page_table(meta_vec);
     mm::dma::init();
 
     arch::init_on_bsp();

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -48,7 +48,9 @@ pub mod user;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-pub use ostd_macros::{main, panic_handler};
+pub use ostd_macros::{
+    default_page_allocator_init_fn, main, page_allocator_init_fn, panic_handler,
+};
 pub use ostd_pod::Pod;
 
 pub use self::{error::Error, prelude::Result};
@@ -158,6 +160,9 @@ pub mod ktest {
     //! It is rather discouraged to use the definitions here directly. The
     //! `ktest` attribute is sufficient for all normal use cases.
 
-    pub use ostd_macros::{test_main as main, test_panic_handler as panic_handler};
+    pub use ostd_macros::{
+        default_page_allocator_init_fn as page_allocator_init_fn, test_main as main,
+        test_panic_handler as panic_handler,
+    };
     pub use ostd_test::*;
 }

--- a/ostd/src/mm/frame/options.rs
+++ b/ostd/src/mm/frame/options.rs
@@ -76,7 +76,7 @@ impl FrameAllocOptions {
             let mut vector = Vec::new();
             for _ in 0..self.nframes {
                 let paddr = allocator.alloc_page(PAGE_SIZE).ok_or(Error::NoMemory)?;
-                let page = page::Page::from_unused(paddr, FrameMeta::default());
+                let page = page::Page::from_free(paddr, FrameMeta::default());
                 vector.push(page);
             }
             vector

--- a/ostd/src/mm/frame/options.rs
+++ b/ostd/src/mm/frame/options.rs
@@ -2,10 +2,18 @@
 
 //! Options for allocating frames
 
+use core::alloc::Layout;
+
+use page::allocator::PAGE_ALLOCATOR;
+
 use super::{Frame, Segment};
 use crate::{
     mm::{
-        page::{self, meta::FrameMeta},
+        page::{
+            self,
+            allocator::{self, alloc_contiguous},
+            meta::FrameMeta,
+        },
         PAGE_SIZE,
     },
     prelude::*,
@@ -56,13 +64,22 @@ impl FrameAllocOptions {
 
     /// Allocates a collection of page frames according to the given options.
     pub fn alloc(&self) -> Result<Vec<Frame>> {
+        let size = self.nframes * PAGE_SIZE;
         let pages = if self.is_contiguous {
-            page::allocator::alloc(self.nframes * PAGE_SIZE, |_| FrameMeta::default())
-                .ok_or(Error::NoMemory)?
+            alloc_contiguous(Layout::from_size_align(size, PAGE_SIZE).unwrap(), |_| {
+                FrameMeta::default()
+            })
+            .ok_or(Error::NoMemory)?
+            .into()
         } else {
-            page::allocator::alloc_contiguous(self.nframes * PAGE_SIZE, |_| FrameMeta::default())
-                .ok_or(Error::NoMemory)?
-                .into()
+            let mut allocator = PAGE_ALLOCATOR.get().unwrap().disable_irq().lock();
+            let mut vector = Vec::new();
+            for _ in 0..self.nframes {
+                let paddr = allocator.alloc_page(PAGE_SIZE).ok_or(Error::NoMemory)?;
+                let page = page::Page::from_unused(paddr, FrameMeta::default());
+                vector.push(page);
+            }
+            vector
         };
         let frames: Vec<_> = pages.into_iter().map(|page| Frame { page }).collect();
         if !self.uninit {
@@ -80,7 +97,8 @@ impl FrameAllocOptions {
             return Err(Error::InvalidArgs);
         }
 
-        let page = page::allocator::alloc_single(FrameMeta::default()).ok_or(Error::NoMemory)?;
+        let page =
+            allocator::alloc_single(PAGE_SIZE, FrameMeta::default()).ok_or(Error::NoMemory)?;
         let frame = Frame { page };
         if !self.uninit {
             frame.writer().fill(0);
@@ -98,10 +116,13 @@ impl FrameAllocOptions {
             return Err(Error::InvalidArgs);
         }
 
+        let size = self.nframes * PAGE_SIZE;
         let segment: Segment =
-            page::allocator::alloc_contiguous(self.nframes * PAGE_SIZE, |_| FrameMeta::default())
-                .ok_or(Error::NoMemory)?
-                .into();
+            allocator::alloc_contiguous(Layout::from_size_align(size, PAGE_SIZE).unwrap(), |_| {
+                FrameMeta::default()
+            })
+            .ok_or(Error::NoMemory)?
+            .into();
         if !self.uninit {
             segment.writer().fill(0);
         }

--- a/ostd/src/mm/heap_allocator/mod.rs
+++ b/ostd/src/mm/heap_allocator/mod.rs
@@ -93,13 +93,19 @@ impl LockedHeapWithRescue {
             size / PAGE_SIZE
         };
 
-        let allocation_start = {
-            let mut page_allocator = PAGE_ALLOCATOR.get().unwrap().lock();
+        let allocation_start_paddr = {
+            let mut page_allocator = PAGE_ALLOCATOR.get().unwrap().disable_irq().lock();
             if num_frames >= MIN_NUM_FRAMES {
-                page_allocator.alloc(num_frames).ok_or(Error::NoMemory)?
+                page_allocator
+                    .alloc(Layout::from_size_align(num_frames * PAGE_SIZE, PAGE_SIZE).unwrap())
+                    .ok_or(Error::NoMemory)?
             } else {
-                match page_allocator.alloc(MIN_NUM_FRAMES) {
-                    None => page_allocator.alloc(num_frames).ok_or(Error::NoMemory)?,
+                match page_allocator
+                    .alloc(Layout::from_size_align(MIN_NUM_FRAMES * PAGE_SIZE, PAGE_SIZE).unwrap())
+                {
+                    None => page_allocator
+                        .alloc(Layout::from_size_align(num_frames * PAGE_SIZE, PAGE_SIZE).unwrap())
+                        .ok_or(Error::NoMemory)?,
                     Some(start) => {
                         num_frames = MIN_NUM_FRAMES;
                         start
@@ -109,7 +115,7 @@ impl LockedHeapWithRescue {
         };
         // FIXME: the alloc function internally allocates heap memory(inside FrameAllocator).
         // So if the heap is nearly run out, allocating frame will fail too.
-        let vaddr = paddr_to_vaddr(allocation_start * PAGE_SIZE);
+        let vaddr = paddr_to_vaddr(allocation_start_paddr);
 
         // SAFETY: the frame is allocated from FrameAllocator and never be deallocated,
         // so the addr is always valid.

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -215,7 +215,7 @@ pub fn init_kernel_page_table(meta_pages: Vec<Page<MetaPageMeta>>) {
         };
         let mut cursor = kpt.cursor_mut(&from).unwrap();
         for frame_paddr in to.step_by(PAGE_SIZE) {
-            let page = Page::<KernelMeta>::from_unused(frame_paddr, KernelMeta::default());
+            let page = Page::<KernelMeta>::from_free(frame_paddr, KernelMeta::default());
             // SAFETY: we are doing mappings for the kernel.
             unsafe {
                 let _old = cursor.map(page.into(), prop);

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod heap_allocator;
 mod io;
 pub(crate) mod kspace;
 mod offset;
-pub(crate) mod page;
+pub mod page;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;
 pub mod stat;

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -1,80 +1,106 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: MPL-2.0 OR MIT
 
 //! The physical page memory allocator.
+
+//！ To be specific, the original source code is from
+//！ [buddy_system_allocator](https://github.com/rcore-os/buddy_system_allocator),
+//！ which licensed under the following license.
+//！
+//！ SPDX-License-Identifier: MIT
+//！
+//！ Copyright (c) 2019-2020 Jiajie Chen
+//！
+//！ We make the following new changes:
+//！ * Implement `PageAlloc` trait for `BuddyFrameAllocator`.
+//!  * Add statistics for the total memory and free memory.
+//！ * Refactor API to differentiate count and size of frames.
+//！
+//！ These changes are released under the following license:
+//！
+//！ SPDX-License-Identifier: MPL-2.0
 //!
 //! TODO: Decouple it with the frame allocator in [`crate::mm::frame::options`] by
 //! allocating pages rather untyped memory from this module.
 
-use alloc::vec::Vec;
+use alloc::{boxed::Box, collections::btree_set::BTreeSet};
+use core::{alloc::Layout, array, cmp::min, ops::Range};
 
 use align_ext::AlignExt;
-use buddy_system_allocator::FrameAllocator;
 use log::info;
 use spin::Once;
 
-use super::{cont_pages::ContPages, meta::PageMeta, Page};
 use crate::{
     boot::memory_region::MemoryRegionType,
-    mm::{Paddr, PAGE_SIZE},
+    mm::{
+        page::{meta::PageMeta, ContPages, Page},
+        Paddr, PAGE_SIZE,
+    },
     sync::SpinLock,
 };
 
-/// FrameAllocator with a counter for allocated memory
-pub(in crate::mm) struct CountingFrameAllocator {
-    allocator: FrameAllocator,
-    total: usize,
-    allocated: usize,
+pub trait PageAlloc: Sync + Send {
+    /// Add a range of free pages, described by the **frame number**
+    /// [start, end), for the allocator to manage.
+    ///
+    /// Warning! May lead to panic when afterwards allocation while using
+    /// out-of `ostd`
+    fn add_free_pages(&mut self, range: Range<usize>);
+
+    /// Allocates a contiguous range of pages described by the layout.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the layout.size is not base-page-aligned or
+    /// if the layout.align is less than the PAGE_SIZE.
+    fn alloc(&mut self, layout: Layout) -> Option<Paddr>;
+
+    /// Allocates one page with specific alignment
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the align is not a power-of-two
+    fn alloc_page(&mut self, align: usize) -> Option<Paddr> {
+        // CHeck whether the align is always a power-of-two
+        assert!(align.is_power_of_two());
+        let alignment = core::cmp::max(align, PAGE_SIZE);
+        self.alloc(Layout::from_size_align(PAGE_SIZE, alignment).unwrap())
+    }
+
+    /// Deallocates a specified number of consecutive pages.
+    ///
+    /// # Warning
+    ///
+    /// In `ostd`, the correctness of the allocation / deallocation is
+    /// guaranteed by the meta system ( [`crate::mm::page::meta`] ), while the
+    /// page allocator is only responsible for managing the allocation
+    /// metadata. The meta system can only be used within the `ostd` crate.
+    ///
+    /// Therefore, deallocating pages out-of `ostd` without coordination with
+    /// the meta system may lead to unexpected behavior, such as panics during
+    /// afterwards allocation.
+    fn dealloc(&mut self, addr: Paddr, nr_pages: usize);
+
+    /// Returns the total number of bytes managed by the allocator.
+    fn total_mem(&self) -> usize;
+
+    /// Returns the total number of bytes available for allocation.
+    fn free_mem(&self) -> usize;
 }
 
-impl CountingFrameAllocator {
-    pub fn new(allocator: FrameAllocator, total: usize) -> Self {
-        CountingFrameAllocator {
-            allocator,
-            total,
-            allocated: 0,
-        }
-    }
-
-    pub fn alloc(&mut self, count: usize) -> Option<usize> {
-        match self.allocator.alloc(count) {
-            Some(value) => {
-                self.allocated += count * PAGE_SIZE;
-                Some(value)
-            }
-            None => None,
-        }
-    }
-
-    pub fn dealloc(&mut self, start_frame: usize, count: usize) {
-        self.allocator.dealloc(start_frame, count);
-        self.allocated -= count * PAGE_SIZE;
-    }
-
-    pub fn mem_total(&self) -> usize {
-        self.total
-    }
-
-    pub fn mem_available(&self) -> usize {
-        self.total - self.allocated
-    }
-}
-
-pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<CountingFrameAllocator>> = Once::new();
+#[export_name = "PAGE_ALLOCATOR"]
+pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
 
 /// Allocate a single page.
 ///
 /// The metadata of the page is initialized with the given metadata.
-pub(crate) fn alloc_single<M: PageMeta>(metadata: M) -> Option<Page<M>> {
+pub(crate) fn alloc_single<M: PageMeta>(align: usize, metadata: M) -> Option<Page<M>> {
     PAGE_ALLOCATOR
         .get()
         .unwrap()
         .disable_irq()
         .lock()
-        .alloc(1)
-        .map(|idx| {
-            let paddr = idx * PAGE_SIZE;
-            Page::from_unused(paddr, metadata)
-        })
+        .alloc_page(align)
+        .map(|paddr| Page::from_unused(paddr, metadata))
 }
 
 /// Allocate a contiguous range of pages of a given length in bytes.
@@ -86,54 +112,180 @@ pub(crate) fn alloc_single<M: PageMeta>(metadata: M) -> Option<Page<M>> {
 /// # Panics
 ///
 /// The function panics if the length is not base-page-aligned.
-pub(crate) fn alloc_contiguous<M: PageMeta, F>(len: usize, metadata_fn: F) -> Option<ContPages<M>>
+pub(crate) fn alloc_contiguous<M: PageMeta, F>(
+    layout: Layout,
+    metadata_fn: F,
+) -> Option<ContPages<M>>
 where
     F: FnMut(Paddr) -> M,
 {
-    assert!(len % PAGE_SIZE == 0);
+    assert!(layout.size() % PAGE_SIZE == 0);
     PAGE_ALLOCATOR
         .get()
         .unwrap()
         .disable_irq()
         .lock()
-        .alloc(len / PAGE_SIZE)
-        .map(|start| {
-            ContPages::from_unused(start * PAGE_SIZE..start * PAGE_SIZE + len, metadata_fn)
+        .alloc(layout)
+        .map(|begin_paddr| {
+            ContPages::from_unused(begin_paddr..begin_paddr + layout.size(), metadata_fn)
         })
 }
 
-/// Allocate pages.
+/// Buddy Frame allocator is a frame allocator based on buddy system, which
+/// allocates memory in power-of-two sizes.
 ///
-/// The allocated pages are not guaranteed to be contiguous.
-/// The total length of the allocated pages is `len`.
-///
-/// The caller must provide a closure to initialize metadata for all the pages.
-/// The closure receives the physical address of the page and returns the
-/// metadata, which is similar to [`core::array::from_fn`].
-///
-/// # Panics
-///
-/// The function panics if the length is not base-page-aligned.
-pub(crate) fn alloc<M: PageMeta, F>(len: usize, mut metadata_fn: F) -> Option<Vec<Page<M>>>
-where
-    F: FnMut(Paddr) -> M,
-{
-    assert!(len % PAGE_SIZE == 0);
-    let nframes = len / PAGE_SIZE;
-    let mut allocator = PAGE_ALLOCATOR.get().unwrap().disable_irq().lock();
-    let mut vector = Vec::new();
-    for _ in 0..nframes {
-        let paddr = allocator.alloc(1)? * PAGE_SIZE;
-        let page = Page::<M>::from_unused(paddr, metadata_fn(paddr));
-        vector.push(page);
+/// The max order of the allocator is specified via the const generic parameter
+/// `ORDER`. The frame allocator will only be able to allocate ranges of size
+/// up to 2<sup>ORDER</sup>, out of a total range of size at most 2<sup>ORDER +
+/// 1</sup> - 1.
+pub struct BuddyFrameAllocator<const ORDER: usize = 32> {
+    // buddy system with max order of ORDER
+    free_list: [BTreeSet<usize>; ORDER],
+
+    // statistics
+    allocated: usize,
+    total: usize,
+}
+
+pub(crate) fn prev_power_of_two(num: usize) -> usize {
+    1 << (8 * (size_of::<usize>()) - num.leading_zeros() as usize - 1)
+}
+
+impl<const ORDER: usize> BuddyFrameAllocator<ORDER> {
+    /// Create an empty frame allocator
+    pub fn new() -> Self {
+        Self {
+            free_list: array::from_fn(|_| BTreeSet::default()),
+            allocated: 0,
+            total: 0,
+        }
     }
-    Some(vector)
+
+    /// Add a range of free pages, described by the **frame number**
+    /// [start, end), for the allocator to manage.
+    fn add_free_pages(&mut self, range: Range<usize>) {
+        let start = range.start;
+        let end = range.end;
+        assert!(start <= end);
+
+        let mut total = 0;
+        let mut current_start = start;
+
+        while current_start < end {
+            let lowbit = if current_start > 0 {
+                current_start & (!current_start + 1)
+            } else {
+                32
+            };
+            let size = min(
+                min(lowbit, prev_power_of_two(end - current_start)),
+                1 << (ORDER - 1),
+            );
+            total += size;
+
+            self.free_list[size.trailing_zeros() as usize].insert(current_start);
+            current_start += size;
+        }
+
+        self.total += total;
+    }
+
+    /// Allocate a range of frames from the allocator, returning the first frame of the allocated
+    /// range.
+    pub fn alloc(&mut self, count: usize) -> Option<usize> {
+        self.alloc_power_of_two(count.next_power_of_two())
+    }
+
+    /// Allocate a range of frames of the given size from the allocator. The size must be a power of
+    /// two. The allocated range will have alignment equal to the size.
+    fn alloc_power_of_two(&mut self, count: usize) -> Option<usize> {
+        let class = count.trailing_zeros() as usize;
+        for i in class..self.free_list.len() {
+            // Find the first non-empty size class
+            if !self.free_list[i].is_empty() {
+                // Split buffers
+                for j in (class + 1..i + 1).rev() {
+                    if let Some(block_ref) = self.free_list[j].iter().next() {
+                        let block = *block_ref;
+                        self.free_list[j - 1].insert(block + (1 << (j - 1)));
+                        self.free_list[j - 1].insert(block);
+                        self.free_list[j].remove(&block);
+                    } else {
+                        return None;
+                    }
+                }
+
+                let result = self.free_list[class].iter().next().clone();
+                if let Some(result_ref) = result {
+                    let result = *result_ref;
+                    self.free_list[class].remove(&result);
+                    self.allocated += count;
+                    return Some(result);
+                } else {
+                    return None;
+                }
+            }
+        }
+        None
+    }
+
+    /// Deallocate a range of frames [frame, frame+count) from the frame allocator.
+    ///
+    /// The range should be exactly the same when it was allocated, as in heap allocator
+    pub fn dealloc(&mut self, start_frame: usize, count: usize) {
+        self.dealloc_power_of_two(start_frame, count.next_power_of_two())
+    }
+
+    /// Deallocate a range of frames with the given size from the allocator. The size must be a
+    /// power of two.
+    fn dealloc_power_of_two(&mut self, start_frame: usize, count: usize) {
+        let class = count.trailing_zeros() as usize;
+
+        // Merge free buddy lists
+        let mut current_ptr = start_frame;
+        let mut current_class = class;
+        while current_class < self.free_list.len() {
+            let buddy = current_ptr ^ (1 << current_class);
+            if self.free_list[current_class].remove(&buddy) == true {
+                // Free buddy found
+                current_ptr = min(current_ptr, buddy);
+                current_class += 1;
+            } else {
+                self.free_list[current_class].insert(current_ptr);
+                break;
+            }
+        }
+
+        self.allocated -= count;
+    }
+}
+
+impl PageAlloc for BuddyFrameAllocator<32> {
+    fn add_free_pages(&mut self, range: Range<usize>) {
+        BuddyFrameAllocator::add_free_pages(self, range)
+    }
+
+    fn alloc(&mut self, layout: Layout) -> Option<Paddr> {
+        assert!(layout.size() & (PAGE_SIZE - 1) == 0);
+        BuddyFrameAllocator::alloc(self, layout.size() / PAGE_SIZE).map(|idx| idx * PAGE_SIZE)
+    }
+
+    fn dealloc(&mut self, addr: Paddr, nr_pages: usize) {
+        BuddyFrameAllocator::dealloc(self, addr / PAGE_SIZE, nr_pages)
+    }
+
+    fn total_mem(&self) -> usize {
+        self.total * PAGE_SIZE
+    }
+
+    fn free_mem(&self) -> usize {
+        (self.total - self.allocated) * PAGE_SIZE
+    }
 }
 
 pub(crate) fn init() {
     let regions = crate::boot::memory_regions();
-    let mut total: usize = 0;
-    let mut allocator = FrameAllocator::<32>::new();
+    let mut allocator = Box::new(BuddyFrameAllocator::<32>::new());
     for region in regions.iter() {
         if region.typ() == MemoryRegionType::Usable {
             // Make the memory region page-aligned, and skip if it is too small.
@@ -144,8 +296,7 @@ pub(crate) fn init() {
                 continue;
             }
             // Add global free pages to the frame allocator.
-            allocator.add_frame(start, end);
-            total += (end - start) * PAGE_SIZE;
+            allocator.add_free_pages(Range { start, end });
             info!(
                 "Found usable region, start:{:x}, end:{:x}",
                 region.base(),
@@ -153,6 +304,5 @@ pub(crate) fn init() {
             );
         }
     }
-    let counting_allocator = CountingFrameAllocator::new(allocator, total);
-    PAGE_ALLOCATOR.call_once(|| SpinLock::new(counting_allocator));
+    PAGE_ALLOCATOR.call_once(|| SpinLock::new(allocator));
 }

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -26,13 +26,13 @@ use alloc::{boxed::Box, collections::btree_set::BTreeSet};
 use core::{alloc::Layout, array, cmp::min, ops::Range};
 
 use align_ext::AlignExt;
-use log::{debug, info, warn};
+use log::{info, warn};
 use spin::Once;
 
 use crate::{
     boot::memory_region::MemoryRegionType,
     mm::{
-        page::{meta::PageMeta, ContPages, Page},
+        page::{self, meta::PageMeta, ContPages, Page},
         Paddr, PAGE_SIZE,
     },
     sync::SpinLock,
@@ -89,8 +89,6 @@ pub trait PageAlloc: Sync + Send {
 
 #[export_name = "PAGE_ALLOCATOR"]
 pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
-#[export_name = "BOOTSTRAP_PAGE_ALLOCATOR"]
-pub(in crate::mm) static BOOTSTRAP_PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
 
 /// Allocate a single page.
 ///
@@ -302,11 +300,12 @@ impl<const ORDER: usize> BuddyFrameAllocator<ORDER> {
                         break;
                     }
                     if block <= current_start && block + (1 << i) > current_start {
-                        if block == current_start {
+                        if block == current_start && block + (1 << i) <= end {
+                            self.free_list[i].remove(&block);
                             size = 1 << i;
                         } else if i > 0 {
                             self.free_list[i - 1].insert(block);
-                            self.free_list[i - 1].insert(block + 1 << (i - 1));
+                            self.free_list[i - 1].insert(block + (1 << (i - 1)));
                             self.free_list[i].remove(&block);
                         }
                         break;
@@ -375,8 +374,20 @@ pub(crate) fn init() {
                 region.base(),
                 region.base() + region.len()
             );
+
+            for frame in start..end {
+                if page::Page::<page::meta::FrameMeta>::check_page_status(frame * PAGE_SIZE) {
+                    allocator.set_frames_allocated(frame, frame + 1);
+                }
+            }
         }
     }
+    info!(
+        "Global page allocator is initialized, total memory: {}, allocated memory: {}",
+        (allocator.total_mem()) / PAGE_SIZE,
+        (allocator.total_mem() - allocator.free_mem()) / PAGE_SIZE
+    );
+
     PAGE_ALLOCATOR.call_once(|| SpinLock::new(allocator));
 }
 
@@ -389,6 +400,9 @@ pub(crate) struct BootstrapFrameAllocator {
     // allocated.
     frame_cursor: usize,
 }
+
+pub(in crate::mm) static BOOTSTRAP_PAGE_ALLOCATOR: Once<SpinLock<BootstrapFrameAllocator>> =
+    Once::new();
 
 impl BootstrapFrameAllocator {
     pub fn new() -> Self {
@@ -425,10 +439,6 @@ impl BootstrapFrameAllocator {
             frame_cursor: first_frame,
         }
     }
-
-    pub fn get_frame_cursor(self) -> usize {
-        self.frame_cursor
-    }
 }
 
 impl PageAlloc for BootstrapFrameAllocator {
@@ -443,7 +453,7 @@ impl PageAlloc for BootstrapFrameAllocator {
 
     fn alloc_page(&mut self, _align: usize) -> Option<Paddr> {
         let frame = self.frame_cursor;
-        debug!("allocating frame: {:#x}", frame * PAGE_SIZE,);
+        // debug!("allocating frame: {:#x}", frame * PAGE_SIZE,);
         // Update idx and cursor
         let regions = crate::boot::memory_regions();
         self.frame_cursor += 1;
@@ -476,7 +486,7 @@ impl PageAlloc for BootstrapFrameAllocator {
                 panic!("no more usable memory regions for boot page table");
             }
         }
-        Some(frame)
+        Some(frame * PAGE_SIZE)
     }
 
     fn dealloc(&mut self, _addr: Paddr, _nr_pages: usize) {
@@ -495,5 +505,6 @@ impl PageAlloc for BootstrapFrameAllocator {
 }
 
 pub(crate) fn bootstrap_init() {
-    BOOTSTRAP_PAGE_ALLOCATOR.call_once(|| SpinLock::new(Box::new(BootstrapFrameAllocator::new())));
+    info!("Initializing the bootstrap page allocator");
+    BOOTSTRAP_PAGE_ALLOCATOR.call_once(|| SpinLock::new(BootstrapFrameAllocator::new()));
 }

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -98,7 +98,7 @@ pub(crate) fn alloc_single<M: PageMeta>(align: usize, metadata: M) -> Option<Pag
         .disable_irq()
         .lock()
         .alloc_page(align)
-        .map(|paddr| Page::from_unused(paddr, metadata))
+        .map(|paddr| Page::from_free(paddr, metadata))
 }
 
 /// Allocate a contiguous range of pages of a given length in bytes.
@@ -125,7 +125,7 @@ where
         .lock()
         .alloc(layout)
         .map(|begin_paddr| {
-            ContPages::from_unused(begin_paddr..begin_paddr + layout.size(), metadata_fn)
+            ContPages::from_free(begin_paddr..begin_paddr + layout.size(), metadata_fn)
         })
 }
 

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -26,7 +26,7 @@ use alloc::{boxed::Box, collections::btree_set::BTreeSet};
 use core::{alloc::Layout, array, cmp::min, ops::Range};
 
 use align_ext::AlignExt;
-use log::info;
+use log::{debug, info, warn};
 use spin::Once;
 
 use crate::{
@@ -89,6 +89,8 @@ pub trait PageAlloc: Sync + Send {
 
 #[export_name = "PAGE_ALLOCATOR"]
 pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
+#[export_name = "BOOTSTRAP_PAGE_ALLOCATOR"]
+pub(in crate::mm) static BOOTSTRAP_PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
 
 /// Allocate a single page.
 ///
@@ -131,8 +133,11 @@ where
         })
 }
 
-/// Buddy Frame allocator is a frame allocator based on buddy system, which
-/// allocates memory in power-of-two sizes.
+/// ## Bootstrap page allocator
+///
+/// originated from crate `buddy_system_allocator`
+///
+/// # Introduction
 ///
 /// The max order of the allocator is specified via the const generic parameter
 /// `ORDER`. The frame allocator will only be able to allocate ranges of size
@@ -258,6 +263,74 @@ impl<const ORDER: usize> BuddyFrameAllocator<ORDER> {
 
         self.allocated -= count;
     }
+
+    /// set_frames_allocated
+    ///
+    /// # Description
+    ///
+    /// Given frames, described by a range of **frame number** [start, end),
+    /// mark them as allocated. Make sure they can be correctly deallocated
+    /// afterwards, while will not be allocated before deallocation.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if no suitable block found for the given range.
+    pub fn set_frames_allocated(&mut self, start: usize, end: usize) {
+        let mut current_start = start;
+        while current_start < end {
+            /*
+            Algorithm:
+
+            1. Find one free block(begin_frame, class) already in the free
+            list, which contains at least one frame described by
+            current_start. If not, panic.
+
+            2. Split the block corresponding to the buddy algorithm. Find
+            the biggest sub-block which begins with current_start. The end of sublock should be smaller than end.
+            */
+
+            let mut size = 0;
+            for i in (0..self.free_list.len()).rev() {
+                if self.free_list[i].is_empty() {
+                    continue;
+                }
+                // Traverse the blocks in the btree list
+                for block_iter in self.free_list[i].iter() {
+                    let block = *block_iter;
+                    // block means the start frame of the block
+                    if block > current_start {
+                        break;
+                    }
+                    if block <= current_start && block + (1 << i) > current_start {
+                        if block == current_start {
+                            size = 1 << i;
+                        } else if i > 0 {
+                            self.free_list[i - 1].insert(block);
+                            self.free_list[i - 1].insert(block + 1 << (i - 1));
+                            self.free_list[i].remove(&block);
+                        }
+                        break;
+                    }
+                }
+
+                if size != 0 {
+                    // Already found the suitable block
+                    break;
+                }
+            }
+
+            if size == 0 {
+                panic!(
+                    "No suitable block found for current_start: {:x}",
+                    current_start
+                );
+            }
+
+            current_start += size;
+            // Update statistics
+            self.allocated += size;
+        }
+    }
 }
 
 impl PageAlloc for BuddyFrameAllocator<32> {
@@ -305,4 +378,122 @@ pub(crate) fn init() {
         }
     }
     PAGE_ALLOCATOR.call_once(|| SpinLock::new(allocator));
+}
+
+/// The bootstrapping phase page allocator.
+pub(crate) struct BootstrapFrameAllocator {
+    // memory region idx: The index for the global memory region indicates the
+    // current memory region in use, facilitating rapid boot page allocation.
+    mem_region_idx: usize,
+    // frame cursor: The cursor for the frame which is the next frame to be
+    // allocated.
+    frame_cursor: usize,
+}
+
+impl BootstrapFrameAllocator {
+    pub fn new() -> Self {
+        // Get the first frame for allocation
+        let mut first_idx = 0;
+        let mut first_frame = 0;
+        let regions = crate::boot::memory_regions();
+        for i in 0..regions.len() {
+            if regions[i].typ() == crate::boot::memory_region::MemoryRegionType::Usable {
+                // Make the memory region page-aligned, and skip if it is too small.
+                let start = regions[i].base().align_up(PAGE_SIZE) / PAGE_SIZE;
+                let end = regions[i]
+                    .base()
+                    .checked_add(regions[i].len())
+                    .unwrap()
+                    .align_down(PAGE_SIZE)
+                    / PAGE_SIZE;
+                log::debug!(
+                    "Found usable region, start:{:x}, end:{:x}",
+                    regions[i].base(),
+                    regions[i].base() + regions[i].len()
+                );
+                if end <= start {
+                    continue;
+                } else {
+                    first_idx = i;
+                    first_frame = start;
+                    break;
+                }
+            }
+        }
+        Self {
+            mem_region_idx: first_idx,
+            frame_cursor: first_frame,
+        }
+    }
+
+    pub fn get_frame_cursor(self) -> usize {
+        self.frame_cursor
+    }
+}
+
+impl PageAlloc for BootstrapFrameAllocator {
+    fn add_free_pages(&mut self, _range: Range<usize>) {
+        warn!("BootstrapFrameAllocator does not need to add frames");
+    }
+
+    fn alloc(&mut self, _layout: Layout) -> Option<Paddr> {
+        warn!("BootstrapFrameAllocator does not support to allocate memory described by range");
+        None
+    }
+
+    fn alloc_page(&mut self, _align: usize) -> Option<Paddr> {
+        let frame = self.frame_cursor;
+        debug!("allocating frame: {:#x}", frame * PAGE_SIZE,);
+        // Update idx and cursor
+        let regions = crate::boot::memory_regions();
+        self.frame_cursor += 1;
+        loop {
+            let region = regions[self.mem_region_idx];
+            if region.typ() == crate::boot::memory_region::MemoryRegionType::Usable {
+                let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
+                let end = region
+                    .base()
+                    .checked_add(region.len())
+                    .unwrap()
+                    .align_down(PAGE_SIZE)
+                    / PAGE_SIZE;
+                if end <= start {
+                    self.mem_region_idx += 1;
+                    continue;
+                }
+                if self.frame_cursor < start {
+                    self.frame_cursor = start;
+                }
+                if self.frame_cursor >= end {
+                    self.mem_region_idx += 1;
+                } else {
+                    break;
+                }
+            } else {
+                self.mem_region_idx += 1;
+            }
+            if self.mem_region_idx >= regions.len() {
+                panic!("no more usable memory regions for boot page table");
+            }
+        }
+        Some(frame)
+    }
+
+    fn dealloc(&mut self, _addr: Paddr, _nr_pages: usize) {
+        panic!("BootstrapFrameAllocator does support frames deallocation!");
+    }
+
+    fn total_mem(&self) -> usize {
+        warn!("BootstrapFrameAllocator does not support to calculate total memory");
+        0
+    }
+
+    fn free_mem(&self) -> usize {
+        warn!("BootstrapFrameAllocator does not support to calculate free memory");
+        0
+    }
+}
+
+pub(crate) fn bootstrap_init() {
+    BOOTSTRAP_PAGE_ALLOCATOR.call_once(|| SpinLock::new(Box::new(BootstrapFrameAllocator::new())));
 }

--- a/ostd/src/mm/page/allocator.rs
+++ b/ostd/src/mm/page/allocator.rs
@@ -1,43 +1,36 @@
-// SPDX-License-Identifier: MPL-2.0 OR MIT
+// SPDX-License-Identifier: MPL-2.0
 
 //! The physical page memory allocator.
-
-//！ To be specific, the original source code is from
-//！ [buddy_system_allocator](https://github.com/rcore-os/buddy_system_allocator),
-//！ which licensed under the following license.
-//！
-//！ SPDX-License-Identifier: MIT
-//！
-//！ Copyright (c) 2019-2020 Jiajie Chen
-//！
-//！ We make the following new changes:
-//！ * Implement `PageAlloc` trait for `BuddyFrameAllocator`.
-//!  * Add statistics for the total memory and free memory.
-//！ * Refactor API to differentiate count and size of frames.
-//！
-//！ These changes are released under the following license:
-//！
-//！ SPDX-License-Identifier: MPL-2.0
 //!
 //! TODO: Decouple it with the frame allocator in [`crate::mm::frame::options`] by
 //! allocating pages rather untyped memory from this module.
 
-use alloc::{boxed::Box, collections::btree_set::BTreeSet};
-use core::{alloc::Layout, array, cmp::min, ops::Range};
+use alloc::boxed::Box;
+use core::{alloc::Layout, ops::Range};
 
 use align_ext::AlignExt;
 use log::{info, warn};
 use spin::Once;
 
 use crate::{
-    boot::memory_region::MemoryRegionType,
     mm::{
-        page::{self, meta::PageMeta, ContPages, Page},
+        page::{meta::PageMeta, ContPages, Page},
         Paddr, PAGE_SIZE,
     },
     sync::SpinLock,
 };
 
+/// # PageAlloc trait
+///
+/// The PageAlloc Trait provides the interface for the page allocator.
+/// `PageAlloc` Trait decouples the page allocator implementation from the
+/// `ostd`. By corporating with the [`PageAlloc`] trait and
+/// [`page_allocator_init_fn`] procedure macro, page allocator's implementation
+/// can be decoupled from the OSTD and can be easily replaced to serve
+/// designated purposes.
+///
+/// You can refer to `kernel/libs/aster-page-allocator` for the example
+/// implementation.
 pub trait PageAlloc: Sync + Send {
     /// Add a range of free pages, described by the **frame number**
     /// [start, end), for the allocator to manage.
@@ -52,6 +45,10 @@ pub trait PageAlloc: Sync + Send {
     ///
     /// The function panics if the layout.size is not base-page-aligned or
     /// if the layout.align is less than the PAGE_SIZE.
+    // TODO(Comments from pr #1137): Refactor the trait to support lock-free
+    // design of local page allocation cache. Specifically, change all the
+    // signatures to `&self` and require the implementor to use their own
+    // synchronization primitives to manage their locking scheme.
     fn alloc(&mut self, layout: Layout) -> Option<Paddr>;
 
     /// Allocates one page with specific alignment
@@ -87,8 +84,9 @@ pub trait PageAlloc: Sync + Send {
     fn free_mem(&self) -> usize;
 }
 
+/// The global page allocator, described by the `PageAlloc` trait.
 #[export_name = "PAGE_ALLOCATOR"]
-pub(in crate::mm) static PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
+pub static PAGE_ALLOCATOR: Once<SpinLock<Box<dyn PageAlloc>>> = Once::new();
 
 /// Allocate a single page.
 ///
@@ -131,263 +129,14 @@ where
         })
 }
 
-/// ## Bootstrap page allocator
-///
-/// originated from crate `buddy_system_allocator`
-///
-/// # Introduction
-///
-/// The max order of the allocator is specified via the const generic parameter
-/// `ORDER`. The frame allocator will only be able to allocate ranges of size
-/// up to 2<sup>ORDER</sup>, out of a total range of size at most 2<sup>ORDER +
-/// 1</sup> - 1.
-pub struct BuddyFrameAllocator<const ORDER: usize = 32> {
-    // buddy system with max order of ORDER
-    free_list: [BTreeSet<usize>; ORDER],
-
-    // statistics
-    allocated: usize,
-    total: usize,
-}
-
-pub(crate) fn prev_power_of_two(num: usize) -> usize {
-    1 << (8 * (size_of::<usize>()) - num.leading_zeros() as usize - 1)
-}
-
-impl<const ORDER: usize> BuddyFrameAllocator<ORDER> {
-    /// Create an empty frame allocator
-    pub fn new() -> Self {
-        Self {
-            free_list: array::from_fn(|_| BTreeSet::default()),
-            allocated: 0,
-            total: 0,
-        }
-    }
-
-    /// Add a range of free pages, described by the **frame number**
-    /// [start, end), for the allocator to manage.
-    fn add_free_pages(&mut self, range: Range<usize>) {
-        let start = range.start;
-        let end = range.end;
-        assert!(start <= end);
-
-        let mut total = 0;
-        let mut current_start = start;
-
-        while current_start < end {
-            let lowbit = if current_start > 0 {
-                current_start & (!current_start + 1)
-            } else {
-                32
-            };
-            let size = min(
-                min(lowbit, prev_power_of_two(end - current_start)),
-                1 << (ORDER - 1),
-            );
-            total += size;
-
-            self.free_list[size.trailing_zeros() as usize].insert(current_start);
-            current_start += size;
-        }
-
-        self.total += total;
-    }
-
-    /// Allocate a range of frames from the allocator, returning the first frame of the allocated
-    /// range.
-    pub fn alloc(&mut self, count: usize) -> Option<usize> {
-        self.alloc_power_of_two(count.next_power_of_two())
-    }
-
-    /// Allocate a range of frames of the given size from the allocator. The size must be a power of
-    /// two. The allocated range will have alignment equal to the size.
-    fn alloc_power_of_two(&mut self, count: usize) -> Option<usize> {
-        let class = count.trailing_zeros() as usize;
-        for i in class..self.free_list.len() {
-            // Find the first non-empty size class
-            if !self.free_list[i].is_empty() {
-                // Split buffers
-                for j in (class + 1..i + 1).rev() {
-                    if let Some(block_ref) = self.free_list[j].iter().next() {
-                        let block = *block_ref;
-                        self.free_list[j - 1].insert(block + (1 << (j - 1)));
-                        self.free_list[j - 1].insert(block);
-                        self.free_list[j].remove(&block);
-                    } else {
-                        return None;
-                    }
-                }
-
-                let result = self.free_list[class].iter().next().clone();
-                if let Some(result_ref) = result {
-                    let result = *result_ref;
-                    self.free_list[class].remove(&result);
-                    self.allocated += count;
-                    return Some(result);
-                } else {
-                    return None;
-                }
-            }
-        }
-        None
-    }
-
-    /// Deallocate a range of frames [frame, frame+count) from the frame allocator.
-    ///
-    /// The range should be exactly the same when it was allocated, as in heap allocator
-    pub fn dealloc(&mut self, start_frame: usize, count: usize) {
-        self.dealloc_power_of_two(start_frame, count.next_power_of_two())
-    }
-
-    /// Deallocate a range of frames with the given size from the allocator. The size must be a
-    /// power of two.
-    fn dealloc_power_of_two(&mut self, start_frame: usize, count: usize) {
-        let class = count.trailing_zeros() as usize;
-
-        // Merge free buddy lists
-        let mut current_ptr = start_frame;
-        let mut current_class = class;
-        while current_class < self.free_list.len() {
-            let buddy = current_ptr ^ (1 << current_class);
-            if self.free_list[current_class].remove(&buddy) == true {
-                // Free buddy found
-                current_ptr = min(current_ptr, buddy);
-                current_class += 1;
-            } else {
-                self.free_list[current_class].insert(current_ptr);
-                break;
-            }
-        }
-
-        self.allocated -= count;
-    }
-
-    /// set_frames_allocated
-    ///
-    /// # Description
-    ///
-    /// Given frames, described by a range of **frame number** [start, end),
-    /// mark them as allocated. Make sure they can be correctly deallocated
-    /// afterwards, while will not be allocated before deallocation.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if no suitable block found for the given range.
-    pub fn set_frames_allocated(&mut self, start: usize, end: usize) {
-        let mut current_start = start;
-        while current_start < end {
-            /*
-            Algorithm:
-
-            1. Find one free block(begin_frame, class) already in the free
-            list, which contains at least one frame described by
-            current_start. If not, panic.
-
-            2. Split the block corresponding to the buddy algorithm. Find
-            the biggest sub-block which begins with current_start. The end of sublock should be smaller than end.
-            */
-
-            let mut size = 0;
-            for i in (0..self.free_list.len()).rev() {
-                if self.free_list[i].is_empty() {
-                    continue;
-                }
-                // Traverse the blocks in the btree list
-                for block_iter in self.free_list[i].iter() {
-                    let block = *block_iter;
-                    // block means the start frame of the block
-                    if block > current_start {
-                        break;
-                    }
-                    if block <= current_start && block + (1 << i) > current_start {
-                        if block == current_start && block + (1 << i) <= end {
-                            self.free_list[i].remove(&block);
-                            size = 1 << i;
-                        } else if i > 0 {
-                            self.free_list[i - 1].insert(block);
-                            self.free_list[i - 1].insert(block + (1 << (i - 1)));
-                            self.free_list[i].remove(&block);
-                        }
-                        break;
-                    }
-                }
-
-                if size != 0 {
-                    // Already found the suitable block
-                    break;
-                }
-            }
-
-            if size == 0 {
-                panic!(
-                    "No suitable block found for current_start: {:x}",
-                    current_start
-                );
-            }
-
-            current_start += size;
-            // Update statistics
-            self.allocated += size;
-        }
-    }
-}
-
-impl PageAlloc for BuddyFrameAllocator<32> {
-    fn add_free_pages(&mut self, range: Range<usize>) {
-        BuddyFrameAllocator::add_free_pages(self, range)
-    }
-
-    fn alloc(&mut self, layout: Layout) -> Option<Paddr> {
-        assert!(layout.size() & (PAGE_SIZE - 1) == 0);
-        BuddyFrameAllocator::alloc(self, layout.size() / PAGE_SIZE).map(|idx| idx * PAGE_SIZE)
-    }
-
-    fn dealloc(&mut self, addr: Paddr, nr_pages: usize) {
-        BuddyFrameAllocator::dealloc(self, addr / PAGE_SIZE, nr_pages)
-    }
-
-    fn total_mem(&self) -> usize {
-        self.total * PAGE_SIZE
-    }
-
-    fn free_mem(&self) -> usize {
-        (self.total - self.allocated) * PAGE_SIZE
-    }
-}
-
 pub(crate) fn init() {
-    let regions = crate::boot::memory_regions();
-    let mut allocator = Box::new(BuddyFrameAllocator::<32>::new());
-    for region in regions.iter() {
-        if region.typ() == MemoryRegionType::Usable {
-            // Make the memory region page-aligned, and skip if it is too small.
-            let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
-            let region_end = region.base().checked_add(region.len()).unwrap();
-            let end = region_end.align_down(PAGE_SIZE) / PAGE_SIZE;
-            if end <= start {
-                continue;
-            }
-            // Add global free pages to the frame allocator.
-            allocator.add_free_pages(Range { start, end });
-            info!(
-                "Found usable region, start:{:x}, end:{:x}",
-                region.base(),
-                region.base() + region.len()
-            );
-
-            for frame in start..end {
-                if page::Page::<page::meta::FrameMeta>::check_page_status(frame * PAGE_SIZE) {
-                    allocator.set_frames_allocated(frame, frame + 1);
-                }
-            }
+    let allocator: Box<dyn PageAlloc>;
+    unsafe {
+        extern "Rust" {
+            fn __ostd_page_allocator_init_fn() -> Box<dyn PageAlloc>;
         }
+        allocator = __ostd_page_allocator_init_fn();
     }
-    info!(
-        "Global page allocator is initialized, total memory: {}, allocated memory: {}",
-        (allocator.total_mem()) / PAGE_SIZE,
-        (allocator.total_mem() - allocator.free_mem()) / PAGE_SIZE
-    );
-
     PAGE_ALLOCATOR.call_once(|| SpinLock::new(allocator));
 }
 
@@ -410,20 +159,20 @@ impl BootstrapFrameAllocator {
         let mut first_idx = 0;
         let mut first_frame = 0;
         let regions = crate::boot::memory_regions();
-        for i in 0..regions.len() {
-            if regions[i].typ() == crate::boot::memory_region::MemoryRegionType::Usable {
+        for (i, region) in regions.iter().enumerate() {
+            if region.typ() == crate::boot::memory_region::MemoryRegionType::Usable {
                 // Make the memory region page-aligned, and skip if it is too small.
-                let start = regions[i].base().align_up(PAGE_SIZE) / PAGE_SIZE;
-                let end = regions[i]
+                let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
+                let end = region
                     .base()
-                    .checked_add(regions[i].len())
+                    .checked_add(region.len())
                     .unwrap()
                     .align_down(PAGE_SIZE)
                     / PAGE_SIZE;
                 log::debug!(
                     "Found usable region, start:{:x}, end:{:x}",
-                    regions[i].base(),
-                    regions[i].base() + regions[i].len()
+                    region.base(),
+                    region.base() + region.len()
                 );
                 if end <= start {
                     continue;
@@ -453,7 +202,6 @@ impl PageAlloc for BootstrapFrameAllocator {
 
     fn alloc_page(&mut self, _align: usize) -> Option<Paddr> {
         let frame = self.frame_cursor;
-        // debug!("allocating frame: {:#x}", frame * PAGE_SIZE,);
         // Update idx and cursor
         let regions = crate::boot::memory_regions();
         self.frame_cursor += 1;

--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -49,7 +49,7 @@ impl<M: PageMeta> Clone for ContPages<M> {
 }
 
 impl<M: PageMeta> ContPages<M> {
-    /// Creates a new `ContPages` from unused pages.
+    /// Creates a new `ContPages` from free pages.
     ///
     /// The caller must provide a closure to initialize metadata for all the pages.
     /// The closure receives the physical address of the page and returns the
@@ -60,12 +60,12 @@ impl<M: PageMeta> ContPages<M> {
     /// The function panics if:
     ///  - the physical address is invalid or not aligned;
     ///  - any of the pages are already in use.
-    pub fn from_unused<F>(range: Range<Paddr>, mut metadata_fn: F) -> Self
+    pub fn from_free<F>(range: Range<Paddr>, mut metadata_fn: F) -> Self
     where
         F: FnMut(Paddr) -> M,
     {
         for paddr in range.clone().step_by(PAGE_SIZE) {
-            let _ = ManuallyDrop::new(Page::<M>::from_unused(paddr, metadata_fn(paddr)));
+            let _ = ManuallyDrop::new(Page::<M>::from_free(paddr, metadata_fn(paddr)));
         }
         Self {
             range,

--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -73,6 +73,34 @@ impl<M: PageMeta> ContPages<M> {
         }
     }
 
+    /// Forget the handle and return the raw range.
+    ///
+    /// This is the same as [`Page::into_raw`] and [`DynPage::into_raw`].
+    ///
+    /// This will result in the designated range of pages being leaked without
+    /// calling the custom dropper.
+    ///
+    /// The range of physical address to the page is returned in case the page
+    /// needs to be restored using [`Self::from_raw`] later.
+    pub(in crate::mm) fn into_raw(self) -> Range<Paddr> {
+        let range = self.range.clone();
+        core::mem::forget(self);
+        range
+    }
+
+    /// Restore the handle from the raw range.
+    ///
+    /// # Safety
+    ///
+    /// The safety concerns are the same as [`Page::from_raw`].
+    #[allow(unused)]
+    pub(in crate::mm) fn from_raw(range: Range<Paddr>) -> Self {
+        Self {
+            range,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
     /// Gets the start physical address of the contiguous pages.
     pub fn start_paddr(&self) -> Paddr {
         self.range.start

--- a/ostd/src/mm/page/meta.rs
+++ b/ostd/src/mm/page/meta.rs
@@ -83,6 +83,8 @@ pub enum PageUsage {
 
     /// The page stores data for kernel stack.
     KernelStack = 67,
+    /// The page is used by the boot page table.
+    BootPageTable = 68,
 }
 
 #[repr(C)]
@@ -281,6 +283,18 @@ impl Sealed for KernelStackMeta {}
 impl PageMeta for KernelStackMeta {
     const USAGE: PageUsage = PageUsage::KernelStack;
     fn on_drop(_page: &mut Page<Self>) {}
+}
+
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct BootPageTableMeta {}
+
+impl Sealed for BootPageTableMeta {}
+impl PageMeta for BootPageTableMeta {
+    const USAGE: PageUsage = PageUsage::BootPageTable;
+    fn on_drop(_page: &mut Page<Self>) {
+        // Do noting.
+    }
 }
 
 // ======== End of all the specific metadata structures definitions ===========

--- a/ostd/src/mm/page/meta.rs
+++ b/ostd/src/mm/page/meta.rs
@@ -85,6 +85,8 @@ pub enum PageUsage {
     KernelStack = 67,
     /// The page is used by the boot page table.
     BootPageTable = 68,
+    /// The page is used as a heap page.
+    Heap = 69,
 }
 
 #[repr(C)]
@@ -294,6 +296,19 @@ impl PageMeta for BootPageTableMeta {
     const USAGE: PageUsage = PageUsage::BootPageTable;
     fn on_drop(_page: &mut Page<Self>) {
         // Do noting.
+    }
+}
+
+/// The metadata of a heap page.
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct HeapMeta {}
+impl Sealed for HeapMeta {}
+impl PageMeta for HeapMeta {
+    const USAGE: PageUsage = PageUsage::Heap;
+    fn on_drop(_page: &mut Page<Self>) {
+        // Nothing should be done so far since dropping the page would
+        // have all taken care of.
     }
 }
 

--- a/ostd/src/mm/page/meta.rs
+++ b/ostd/src/mm/page/meta.rs
@@ -44,6 +44,7 @@ use core::{
     sync::atomic::{AtomicU32, AtomicU8, Ordering},
 };
 
+use allocator::{PageAlloc, BOOTSTRAP_PAGE_ALLOCATOR};
 use log::info;
 use num_derive::FromPrimitive;
 use static_assertions::const_assert_eq;
@@ -348,6 +349,10 @@ pub(crate) fn init() -> Vec<Page<MetaPageMeta>> {
     })
     .unwrap();
     // Now the metadata pages are mapped, we can initialize the metadata.
+    boot_pt::with_borrow(|boot_pt| {
+        boot_pt.manage_frames_with_meta();
+    })
+    .expect("Failed to manage frames with metadata");
     meta_pages
         .into_iter()
         .map(|paddr| Page::<MetaPageMeta>::from_unused(paddr, MetaPageMeta::default()))
@@ -356,19 +361,15 @@ pub(crate) fn init() -> Vec<Page<MetaPageMeta>> {
 
 fn alloc_meta_pages(nframes: usize) -> Vec<Paddr> {
     let mut meta_pages = Vec::new();
-    let start_frame = allocator::PAGE_ALLOCATOR
-        .get()
-        .unwrap()
-        .disable_irq()
-        .lock()
-        .alloc(core::alloc::Layout::from_size_align(nframes * PAGE_SIZE, PAGE_SIZE).unwrap())
-        .expect("Failed to allocate metadata pages");
-    // Zero them out as initialization.
-    let vaddr = paddr_to_vaddr(start_frame) as *mut u8;
-    unsafe { core::ptr::write_bytes(vaddr, 0, PAGE_SIZE * nframes) };
-    for i in 0..nframes {
-        let paddr = start_frame + i * PAGE_SIZE;
-        meta_pages.push(paddr);
+    let mut allocator = BOOTSTRAP_PAGE_ALLOCATOR.get().unwrap().disable_irq().lock();
+    for _ in 0..nframes {
+        let frame_paddr = allocator
+            .alloc_page(PAGE_SIZE)
+            .unwrap_or_else(|| panic!("Failed to allocate metadata pages"));
+        // Zero them out as initialization.
+        let vaddr = paddr_to_vaddr(frame_paddr) as *mut u8;
+        unsafe { core::ptr::write_bytes(vaddr, 0, PAGE_SIZE) };
+        meta_pages.push(frame_paddr);
     }
     meta_pages
 }

--- a/ostd/src/mm/page/meta.rs
+++ b/ostd/src/mm/page/meta.rs
@@ -153,10 +153,12 @@ pub(super) unsafe fn drop_as_last<M: PageMeta>(ptr: *const MetaSlot) {
     // It would return the page to the allocator for further use. This would be done
     // after the release of the metadata to avoid re-allocation before the metadata
     // is reset.
-    allocator::PAGE_ALLOCATOR.get().unwrap().lock().dealloc(
-        mapping::meta_to_page::<PagingConsts>(ptr as Vaddr) / PAGE_SIZE,
-        1,
-    );
+    allocator::PAGE_ALLOCATOR
+        .get()
+        .unwrap()
+        .disable_irq()
+        .lock()
+        .dealloc(mapping::meta_to_page::<PagingConsts>(ptr as Vaddr), 1);
 }
 
 mod private {
@@ -328,10 +330,10 @@ fn alloc_meta_pages(nframes: usize) -> Vec<Paddr> {
     let start_frame = allocator::PAGE_ALLOCATOR
         .get()
         .unwrap()
+        .disable_irq()
         .lock()
-        .alloc(nframes)
-        .unwrap()
-        * PAGE_SIZE;
+        .alloc(core::alloc::Layout::from_size_align(nframes * PAGE_SIZE, PAGE_SIZE).unwrap())
+        .expect("Failed to allocate metadata pages");
     // Zero them out as initialization.
     let vaddr = paddr_to_vaddr(start_frame) as *mut u8;
     unsafe { core::ptr::write_bytes(vaddr, 0, PAGE_SIZE * nframes) };

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -83,12 +83,13 @@ impl<M: PageMeta> Page<M> {
         }
     }
 
-    /// Check whether the page described by paddr is allocated.
-    /// true if the page is allocated, false otherwise.
+    /// Check whether the page described at the physical address is allocated.
+    /// True if the page is allocated, false otherwise.
     ///
     /// # Warning
     ///
-    /// Page status checked by this function may be outdated, since other running threads may change them after the atomic load.
+    /// Page status checked by this function may be outdated, since other
+    /// running threads may change them after the atomic load.
     ///
     /// Caller should make sure that:
     ///
@@ -104,9 +105,10 @@ impl<M: PageMeta> Page<M> {
     ///
     // # TODO
     //
-    // Use a unique handle to check the page status.
-    // Current implementation is not safe in multi-threading environment.
-    pub fn check_page_status(paddr: Paddr) -> bool {
+    // Use a unique handle `FreePage` to check the page status.
+    // Current implementation is not safe if checking page status and changing
+    // page status happens concurrently.
+    pub fn is_page_allocated(paddr: Paddr) -> bool {
         assert!(paddr % PAGE_SIZE == 0);
         assert!(paddr < MAX_PADDR.load(Ordering::Relaxed) as Paddr);
         let vaddr = mapping::page_to_meta::<PagingConsts>(paddr);

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -321,6 +321,9 @@ impl Drop for DynPage {
                     PageUsage::KernelStack => {
                         meta::drop_as_last::<meta::KernelStackMeta>(self.ptr);
                     }
+                    PageUsage::BootPageTable => {
+                        meta::drop_as_last::<meta::BootPageTableMeta>(self.ptr);
+                    }
                     // The following pages don't have metadata and can't be dropped.
                     PageUsage::Unused
                     | PageUsage::Reserved

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -44,7 +44,7 @@ unsafe impl<M: PageMeta> Send for Page<M> {}
 unsafe impl<M: PageMeta> Sync for Page<M> {}
 
 impl<M: PageMeta> Page<M> {
-    /// Concurrent-safety page alloc function.b
+    /// Concurrent-safety page alloc function.
     ///
     /// The assurance of safety is facilitated by the function
     /// `FreePage::try_lock`, which serves as the exclusive gateway for
@@ -98,46 +98,6 @@ impl<M: PageMeta> Page<M> {
         Freepage is already in use when trying to get a new handle",
         );
         Self::from_freepage(freepage, metadata)
-    }
-
-    /// Check whether the page described at the physical address is allocated.
-    /// True if the page is allocated, false otherwise.
-    ///
-    /// # Warning
-    ///
-    /// Page status checked by this function may be outdated, since other
-    /// running threads may change them after the atomic load.
-    ///
-    /// Caller should make sure that:
-    ///
-    /// 1. No other threads will do `from_unused` or `drop`.
-    ///
-    /// 2. Lock the global page allocator.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if:
-    ///
-    /// - the physical address is out of bound or not aligned.
-    ///
-    // # TODO
-    //
-    // Use a unique handle `FreePage` to check the page status.
-    // Current implementation is not safe if checking page status and changing
-    // page status happens concurrently.
-    pub fn is_page_allocated(paddr: Paddr) -> bool {
-        assert!(paddr % PAGE_SIZE == 0);
-        assert!(paddr < MAX_PADDR.load(Ordering::Relaxed) as Paddr);
-        let vaddr = mapping::page_to_meta::<PagingConsts>(paddr);
-        let ptr = vaddr as *const MetaSlot;
-
-        // SAFETY: The aligned pointer points to a initialized `MetaSlot`.
-        let usage = unsafe { &(*ptr).usage };
-
-        if let 0 = usage.load(Ordering::SeqCst) {
-            return false;
-        }
-        true
     }
 
     /// Forget the handle to the page.

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -324,6 +324,9 @@ impl Drop for DynPage {
                     PageUsage::BootPageTable => {
                         meta::drop_as_last::<meta::BootPageTableMeta>(self.ptr);
                     }
+                    PageUsage::Heap => {
+                        meta::drop_as_last::<meta::HeapMeta>(self.ptr);
+                    }
                     // The following pages don't have metadata and can't be dropped.
                     PageUsage::Unused
                     | PageUsage::Reserved

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -44,7 +44,7 @@ unsafe impl<M: PageMeta> Send for Page<M> {}
 unsafe impl<M: PageMeta> Sync for Page<M> {}
 
 impl<M: PageMeta> Page<M> {
-    /// Concurrent-safety page alloc function.
+    /// Concurrent-safety page alloc function.b
     ///
     /// The assurance of safety is facilitated by the function
     /// `FreePage::try_lock`, which serves as the exclusive gateway for

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -18,7 +18,7 @@ use crate::{
     mm::{
         nr_subpage_per_huge, paddr_to_vaddr,
         page::{
-            allocator::{PageAlloc, BOOTSTRAP_PAGE_ALLOCATOR, PAGE_ALLOCATOR},
+            allocator::{PageAlloc, BOOTSTRAP_PAGE_ALLOCATOR},
             meta::BootPageTableMeta,
             Page,
         },
@@ -225,7 +225,7 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
     }
 
     fn alloc_frame(&mut self) -> FrameNumber {
-        let frame = PAGE_ALLOCATOR
+        let frame = BOOTSTRAP_PAGE_ALLOCATOR
             .get()
             .unwrap()
             .disable_irq()

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -242,10 +242,10 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
 
     /// Converts the frame numbers to pages.
     ///
-    /// Boot page table is designed for supporting intialization of meta
+    /// Boot page table is designed for supporting initialization of meta
     /// utities. The pages used by the boot page table are not automatically
     /// managed by meta and it is manually managed by the boot page table in
-    /// the frame number form. To coodinate with later page manage utilities,
+    /// the frame number form. To coordinate with later page manage utilities,
     /// the boot page table should convert the aforementioned frame numbers to
     /// pages.
     pub fn manage_frames_with_meta(&mut self) {
@@ -254,8 +254,8 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
                 BootPageTableFrame::Number(frame) => {
                     BootPageTableFrame::Page(Page::<BootPageTableMeta>::from_unused(*frame * PAGE_SIZE, BootPageTableMeta::default()))
                 }
-                BootPageTableFrame::Page(_) => {
-                    panic!("Should not convert frame number to page while pages are already in the boot page table");
+                BootPageTableFrame::Page(page) => {
+                    panic!("Should not convert frame number to page while pages are already in the boot page table, page = {:?}", page);
                 }
             }
         }).collect::<Vec<BootPageTableFrame>>();

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -252,7 +252,7 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
         self.frames = self.frames.iter().map(|frame| {
             match frame {
                 BootPageTableFrame::Number(frame) => {
-                    BootPageTableFrame::Page(Page::<BootPageTableMeta>::from_unused(*frame * PAGE_SIZE, BootPageTableMeta::default()))
+                    BootPageTableFrame::Page(Page::<BootPageTableMeta>::from_free(frame * PAGE_SIZE, BootPageTableMeta::default()))
                 }
                 BootPageTableFrame::Page(page) => {
                     panic!("Should not convert frame number to page while pages are already in the boot page table, page = {:?}", page);

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     mm::{
         paddr_to_vaddr,
         page::{
-            self, inc_page_ref_count,
+            allocator, inc_page_ref_count,
             meta::{MapTrackingStatus, PageMeta, PageTablePageMeta, PageUsage},
             DynPage, Page,
         },
@@ -259,8 +259,9 @@ where
     /// set the lock bit for performance as it is exclusive and unlocking is an
     /// extra unnecessary expensive operation.
     pub(super) fn alloc(level: PagingLevel, is_tracked: MapTrackingStatus) -> Self {
-        let meta = PageTablePageMeta::new_locked(level, is_tracked);
-        let page = page::allocator::alloc_single::<PageTablePageMeta<E, C>>(meta).unwrap();
+        let page =
+            allocator::alloc_single(PAGE_SIZE, PageTablePageMeta::new_locked(level, is_tracked))
+                .expect("Failed to allocate a page for a page table node");
 
         // Zero out the page table node.
         let ptr = paddr_to_vaddr(page.paddr()) as *mut u8;

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::{
     mm::{
         kspace::LINEAR_MAPPING_BASE_VADDR,
+        page,
         page::{allocator, meta::FrameMeta},
         page_prop::{CachePolicy, PageFlags},
         MAX_USERSPACE_VADDR,
@@ -31,7 +32,7 @@ fn test_tracked_map_unmap() {
     let pt = PageTable::<UserMode>::empty();
 
     let from = PAGE_SIZE..PAGE_SIZE * 2;
-    let page = allocator::alloc_single(FrameMeta::default()).unwrap();
+    let page = allocator::alloc_single(PAGE_SIZE, FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe { pt.cursor_mut(&from).unwrap().map(page.into(), prop) };
@@ -87,7 +88,7 @@ fn test_user_copy_on_write() {
 
     let pt = PageTable::<UserMode>::empty();
     let from = PAGE_SIZE..PAGE_SIZE * 2;
-    let page = allocator::alloc_single(FrameMeta::default()).unwrap();
+    let page = allocator::alloc_single(PAGE_SIZE, FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe { pt.cursor_mut(&from).unwrap().map(page.clone().into(), prop) };
@@ -172,7 +173,22 @@ fn test_base_protect_query() {
 
     let from_ppn = 1..1000;
     let from = PAGE_SIZE * from_ppn.start..PAGE_SIZE * from_ppn.end;
-    let to = allocator::alloc(999 * PAGE_SIZE, |_| FrameMeta::default()).unwrap();
+    let to = {
+        let mut v = Vec::new();
+        let mut cur_allocator = allocator::PAGE_ALLOCATOR
+            .get()
+            .unwrap()
+            .disable_irq()
+            .lock();
+        for _ in 0..999 {
+            let page = cur_allocator
+                .alloc_page(PAGE_SIZE)
+                .map(|p| page::Page::from_unused(p, FrameMeta::default()))
+                .unwrap();
+            v.push(page);
+        }
+        v
+    };
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
     unsafe {
         let mut cursor = pt.cursor_mut(&from).unwrap();

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -183,7 +183,7 @@ fn test_base_protect_query() {
         for _ in 0..999 {
             let page = cur_allocator
                 .alloc_page(PAGE_SIZE)
-                .map(|p| page::Page::from_unused(p, FrameMeta::default()))
+                .map(|p| page::Page::from_free(p, FrameMeta::default()))
                 .unwrap();
             v.push(page);
         }

--- a/ostd/src/mm/stat/mod.rs
+++ b/ostd/src/mm/stat/mod.rs
@@ -10,12 +10,22 @@ use crate::mm::page::allocator::PAGE_ALLOCATOR;
 /// in most occasions. For example, bad memory, kernel statically-allocated
 /// memory or firmware reserved memories do not count.
 pub fn mem_total() -> usize {
-    PAGE_ALLOCATOR.get().unwrap().lock().mem_total()
+    PAGE_ALLOCATOR
+        .get()
+        .unwrap()
+        .disable_irq()
+        .lock()
+        .total_mem()
 }
 
 /// Current readily available memory (in bytes).
 ///
 /// Such memory can be directly used for allocation without reclaiming.
 pub fn mem_available() -> usize {
-    PAGE_ALLOCATOR.get().unwrap().lock().mem_available()
+    PAGE_ALLOCATOR
+        .get()
+        .unwrap()
+        .disable_irq()
+        .lock()
+        .free_mem()
 }


### PR DESCRIPTION
This is the subsequent pull request of #1137, as the final solution to issue #1044. 

In this PR, we refactor the meta-system and import `FreePage` as the only handle of `Free Meta` to enhance concurrency safety. Based on the new context provided by `Free Meta`, we further implement safe linked list methods for `FreePage` and transplant the current page allocator to make use of it. 

With all the aforementioned efforts, the new page allocator can manage pages at `O(1)` complexity under most scenarios(e.g., allocate, deallocate), while not depending on the heap allocator.

Fix #1044 .