### PR TITLE
Fix a possible error of host guest benchmark

### DIFF
--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -91,11 +91,6 @@ run_benchmark() {
                 "${aster_output}" \
                 "${linux_output}"
             ;;
-        "guest-guest")
-            echo "Running benchmark ${benchmark} between guests..."
-            echo "TODO"
-            exit 1
-            ;;
         *)
             echo "Error: Unknown benchmark type '${benchmark_type}'" >&2
             exit 1

--- a/test/benchmark/common/host_guest_bench_runner.sh
+++ b/test/benchmark/common/host_guest_bench_runner.sh
@@ -48,7 +48,13 @@ run_benchmark() {
 # Use a sleep time of 2 minutes (2m) for the Asterinas VM
 run_benchmark "${ASTERINAS_GUEST_CMD}" "${ASTERINAS_OUTPUT}" "2m"
 
+# Wait for the Asterinas QEMU process to exit
+wait
+
 # Run the benchmark on the Linux VM
 # Use a sleep time of 20 seconds (20s) for the Linux VM
 prepare_fs
 run_benchmark "${LINUX_GUEST_CMD}" "${LINUX_OUTPUT}" "20s"
+
+# Wait for the Linux QEMU process to exit
+wait


### PR DESCRIPTION
Although our host_guest benchmark case, i.e., iperf3, works well on Benchmark Action, I find it would encounter errors when we run it locally. The ports are not released immediately after we kill the guest VM. It takes some time instead. Therefore, we should use `wait` to ensure the QEMU process actually exits before launching the next VM.

This pull request also removes the unused "guest-guest" benchmark type to clean up the code.