### PR TITLE
Extract the status of guest VM from its log

### DIFF
--- a/test/benchmark/common/bench_runner.sh
+++ b/test/benchmark/common/bench_runner.sh
@@ -6,6 +6,7 @@
 set -e
 
 BENCHMARK_DIR="/benchmark"
+READY_MESSAGE="The VM is ready for the benchmark."
 
 BENCH_NAME=$1
 SYSTEM="${2:-asterinas}"
@@ -66,6 +67,10 @@ main() {
 
     # Prepare the system
     prepare_system
+    
+    # Message to notify the host script. It must align with the READY_MESSAGE in host_guest_bench_runner.sh.
+    # DO NOT REMOVE THIS LINE!!!
+    echo "${READY_MESSAGE}"
 
     # Run the benchmark
     BENCH_SCRIPT=${BENCHMARK_DIR}/${BENCH_NAME}/run.sh


### PR DESCRIPTION
This pull request updates the benchmark scripts to use a log file and start signal mechanism instead of a fixed sleep time. This ensures that the host benchmark starts only after the guest benchmark is ready, improving synchronization and accuracy.

### Synchronization improvements:

* [`test/benchmark/common/host_guest_bench_runner.sh`](diffhunk://#diff-c09adf499c3eb1157916c8a1dd229aa0ba9c8671031174058c81a8d712cd20e9L32-R67): Replaced the sleep time parameter with a log file and start signal string to monitor the readiness of the guest benchmark before starting the host benchmark.

### Benchmark preparation messages:

* [`test/benchmark/iperf3/tcp_virtio_bw/run.sh`](diffhunk://#diff-4828c22dcfcf83cbbe6645d481c0ef8b375dcb6b6d881b9f4b6c2ff9b7d4f9f2R7): Added a message indicating that all preparations are done before starting the iperf3 server.
* [`test/benchmark/nginx/http_req10k_conc1_bw/run.sh`](diffhunk://#diff-5f9efe63580e74935aba746dc7584526fbbcfc63bd684be1269643bd09828577R9): Added a message indicating that all preparations are done before starting the nginx server.