### PR TITLE
Move arch specific code in ostd to the arch directory

### DIFF
--- a/ostd/src/arch/mod.rs
+++ b/ostd/src/arch/mod.rs
@@ -4,12 +4,14 @@
 //!
 //! Each architecture that Asterinas supports may contain a submodule here.
 
-#[cfg(target_arch = "riscv64")]
-pub mod riscv;
-#[cfg(target_arch = "x86_64")]
-pub mod x86;
+use cfg_if::cfg_if;
 
-#[cfg(target_arch = "riscv64")]
-pub use self::riscv::*;
-#[cfg(target_arch = "x86_64")]
-pub use self::x86::*;
+cfg_if! {
+    if #[cfg(target_arch = "riscv64")] {
+        pub mod riscv;
+        pub use self::riscv::*;
+    } else if #[cfg(target_arch = "x86_64")] {
+        pub mod x86;
+        pub use self::x86::*;
+    }
+}

--- a/ostd/src/arch/riscv/bus/mmio.rs
+++ b/ostd/src/arch/riscv/bus/mmio.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) fn init() {}

--- a/ostd/src/arch/riscv/bus/mod.rs
+++ b/ostd/src/arch/riscv/bus/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod mmio;

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     Pod,
 };
 
+pub(crate) const KERNEL_CODE_BASE_VADDR_PREFIX: usize = 0xffff_ffff_0000_0000;
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 
 #[derive(Clone, Debug, Default)]

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -3,6 +3,7 @@
 //! Platform-specific code for the RISC-V platform.
 
 pub mod boot;
+pub(crate) mod bus;
 pub(crate) mod cpu;
 pub mod device;
 pub mod iommu;
@@ -66,4 +67,9 @@ pub(crate) fn enable_cpu_features() {
     unsafe {
         riscv::register::sstatus::set_fs(riscv::register::sstatus::FS::Clean);
     }
+}
+
+/// Return the name of the register given an index
+pub fn register_name(_index: u16) -> Option<&'static str> {
+    None
 }

--- a/ostd/src/arch/riscv/pci.rs
+++ b/ostd/src/arch/riscv/pci.rs
@@ -6,3 +6,5 @@ use super::device::io_port::{IoPort, ReadWriteAccess, WriteOnlyAccess};
 
 pub static PCI_ADDRESS_PORT: IoPort<u32, WriteOnlyAccess> = unsafe { IoPort::new(0x0) };
 pub static PCI_DATA_PORT: IoPort<u32, ReadWriteAccess> = unsafe { IoPort::new(0x0) };
+
+pub(crate) fn init() {}

--- a/ostd/src/arch/x86/bus/mmio.rs
+++ b/ostd/src/arch/x86/bus/mmio.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Range;
+
+use cfg_if::cfg_if;
+use log::debug;
+
+use crate::{
+    bus::mmio::{common_device::MmioCommonDevice, MMIO_BUS, VIRTIO_MMIO_MAGIC},
+    mm::paddr_to_vaddr,
+    trap::IrqLine,
+};
+cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
+        use ::tdx_guest::tdx_is_enabled;
+        use crate::arch::tdx_guest;
+    }
+}
+
+pub(crate) fn init() {
+    #[cfg(feature = "cvm_guest")]
+    // SAFETY:
+    // This is safe because we are ensuring that the address range 0xFEB0_0000 to 0xFEB0_4000 is valid before this operation.
+    // The address range is page-aligned and falls within the MMIO range, which is a requirement for the `unprotect_gpa_range` function.
+    // We are also ensuring that we are only unprotecting four pages.
+    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
+    if tdx_is_enabled() {
+        unsafe {
+            tdx_guest::unprotect_gpa_range(0xFEB0_0000, 4).unwrap();
+        }
+    }
+    // FIXME: The address 0xFEB0_0000 is obtained from an instance of microvm, and it may not work in other architecture.
+    iter_range(0xFEB0_0000..0xFEB0_4000);
+}
+
+fn iter_range(range: Range<usize>) {
+    debug!("[Virtio]: Iter MMIO range:{:x?}", range);
+    let mut current = range.end;
+    let mut lock = MMIO_BUS.lock();
+    let io_apics = crate::arch::kernel::IO_APIC.get().unwrap();
+    let is_ioapic2 = io_apics.len() == 2;
+    let mut io_apic = if is_ioapic2 {
+        io_apics.get(1).unwrap().lock()
+    } else {
+        io_apics.first().unwrap().lock()
+    };
+    let mut device_count = 0;
+    while current > range.start {
+        current -= 0x100;
+        // SAFETY: It only read the value and judge if the magic value fit 0x74726976
+        let magic = unsafe { core::ptr::read_volatile(paddr_to_vaddr(current) as *const u32) };
+        if magic == VIRTIO_MMIO_MAGIC {
+            // SAFETY: It only read the device id
+            let device_id = unsafe { *(paddr_to_vaddr(current + 8) as *const u32) };
+            device_count += 1;
+            if device_id == 0 {
+                continue;
+            }
+            let handle = IrqLine::alloc().unwrap();
+            // If has two IOApic, then start: 24 (0 in IOApic2), end 47 (23 in IOApic2)
+            // If one IOApic, then start: 16, end 23
+            io_apic.enable(24 - device_count, handle.clone()).unwrap();
+            let device = MmioCommonDevice::new(current, handle);
+            lock.register_mmio_device(device);
+        }
+    }
+}

--- a/ostd/src/arch/x86/bus/mod.rs
+++ b/ostd/src/arch/x86/bus/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod mmio;

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 
 mod util;
 
+pub(crate) const KERNEL_CODE_BASE_VADDR_PREFIX: usize = 0xffff_ffff_8000_0000;
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 
 #[derive(Clone, Debug, Default)]

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -3,6 +3,7 @@
 //! Platform-specific code for the x86 platform.
 
 pub mod boot;
+pub(crate) mod bus;
 pub(crate) mod cpu;
 pub mod device;
 pub(crate) mod ex_table;
@@ -35,6 +36,7 @@ use core::{
     sync::atomic::Ordering,
 };
 
+use gimli::Register;
 use kernel::apic::ioapic;
 use log::{info, warn};
 
@@ -207,4 +209,9 @@ pub(crate) fn enable_cpu_features() {
             *efer |= EferFlags::NO_EXECUTE_ENABLE;
         });
     }
+}
+
+/// Return the name of the register given an index
+pub fn register_name(index: u16) -> Option<&'static str> {
+    gimli::X86_64::register_name(Register(index))
 }

--- a/ostd/src/arch/x86/pci.rs
+++ b/ostd/src/arch/x86/pci.rs
@@ -3,6 +3,17 @@
 //! PCI bus io port
 
 use super::device::io_port::{IoPort, ReadWriteAccess, WriteOnlyAccess};
+use crate::bus::pci::{common_device::PciCommonDevice, PciDeviceLocation, PCI_BUS};
 
 pub static PCI_ADDRESS_PORT: IoPort<u32, WriteOnlyAccess> = unsafe { IoPort::new(0x0CF8) };
 pub static PCI_DATA_PORT: IoPort<u32, ReadWriteAccess> = unsafe { IoPort::new(0x0CFC) };
+
+pub(crate) fn init() {
+    let mut lock = PCI_BUS.lock();
+    for location in PciDeviceLocation::all() {
+        let Some(device) = PciCommonDevice::new(location) else {
+            continue;
+        };
+        lock.register_common_device(device);
+    }
+}

--- a/ostd/src/bus/mmio/bus.rs
+++ b/ostd/src/bus/mmio/bus.rs
@@ -66,7 +66,7 @@ impl MmioBus {
         self.drivers.push(driver);
     }
 
-    pub(super) fn register_mmio_device(&mut self, mut mmio_device: MmioCommonDevice) {
+    pub(crate) fn register_mmio_device(&mut self, mut mmio_device: MmioCommonDevice) {
         let device_id = mmio_device.read_device_id().unwrap();
         for driver in self.drivers.iter() {
             mmio_device = match driver.probe(mmio_device) {
@@ -86,7 +86,7 @@ impl MmioBus {
         self.common_devices.push_back(mmio_device);
     }
 
-    pub(super) const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             common_devices: VecDeque::new(),
             devices: Vec::new(),

--- a/ostd/src/bus/mmio/common_device.rs
+++ b/ostd/src/bus/mmio/common_device.rs
@@ -21,7 +21,7 @@ pub struct MmioCommonDevice {
 }
 
 impl MmioCommonDevice {
-    pub(super) fn new(paddr: Paddr, handle: IrqLine) -> Self {
+    pub(crate) fn new(paddr: Paddr, handle: IrqLine) -> Self {
         // TODO: Implement universal access to MMIO devices since we are temporarily
         // using specific virtio device as implementation of CommonDevice.
 

--- a/ostd/src/bus/mmio/mod.rs
+++ b/ostd/src/bus/mmio/mod.rs
@@ -4,80 +4,18 @@
 
 //! Virtio over MMIO
 
+use crate::{bus::mmio::bus::MmioBus, sync::SpinLock};
+
 pub mod bus;
 pub mod common_device;
 
-use alloc::vec::Vec;
-use core::ops::Range;
-
-use cfg_if::cfg_if;
-use log::debug;
-
-use self::bus::MmioBus;
-use crate::{
-    bus::mmio::common_device::MmioCommonDevice, mm::paddr_to_vaddr, sync::SpinLock, trap::IrqLine,
-};
-
-cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
-        use ::tdx_guest::tdx_is_enabled;
-        use crate::arch::tdx_guest;
-    }
-}
-
-const VIRTIO_MMIO_MAGIC: u32 = 0x74726976;
+pub(crate) const VIRTIO_MMIO_MAGIC: u32 = 0x74726976;
 
 /// MMIO bus instance
 pub static MMIO_BUS: SpinLock<MmioBus> = SpinLock::new(MmioBus::new());
-static IRQS: SpinLock<Vec<IrqLine>> = SpinLock::new(Vec::new());
+
+use crate::arch;
 
 pub(crate) fn init() {
-    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-    // SAFETY:
-    // This is safe because we are ensuring that the address range 0xFEB0_0000 to 0xFEB0_4000 is valid before this operation.
-    // The address range is page-aligned and falls within the MMIO range, which is a requirement for the `unprotect_gpa_range` function.
-    // We are also ensuring that we are only unprotecting four pages.
-    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
-    if tdx_is_enabled() {
-        unsafe {
-            tdx_guest::unprotect_gpa_range(0xFEB0_0000, 4).unwrap();
-        }
-    }
-    // FIXME: The address 0xFEB0_0000 is obtained from an instance of microvm, and it may not work in other architecture.
-    #[cfg(target_arch = "x86_64")]
-    iter_range(0xFEB0_0000..0xFEB0_4000);
-}
-
-#[cfg(target_arch = "x86_64")]
-fn iter_range(range: Range<usize>) {
-    debug!("[Virtio]: Iter MMIO range:{:x?}", range);
-    let mut current = range.end;
-    let mut lock = MMIO_BUS.lock();
-    let io_apics = crate::arch::kernel::IO_APIC.get().unwrap();
-    let is_ioapic2 = io_apics.len() == 2;
-    let mut io_apic = if is_ioapic2 {
-        io_apics.get(1).unwrap().lock()
-    } else {
-        io_apics.first().unwrap().lock()
-    };
-    let mut device_count = 0;
-    while current > range.start {
-        current -= 0x100;
-        // SAFETY: It only read the value and judge if the magic value fit 0x74726976
-        let magic = unsafe { core::ptr::read_volatile(paddr_to_vaddr(current) as *const u32) };
-        if magic == VIRTIO_MMIO_MAGIC {
-            // SAFETY: It only read the device id
-            let device_id = unsafe { *(paddr_to_vaddr(current + 8) as *const u32) };
-            device_count += 1;
-            if device_id == 0 {
-                continue;
-            }
-            let handle = IrqLine::alloc().unwrap();
-            // If has two IOApic, then start: 24 (0 in IOApic2), end 47 (23 in IOApic2)
-            // If one IOApic, then start: 16, end 23
-            io_apic.enable(24 - device_count, handle.clone()).unwrap();
-            let device = MmioCommonDevice::new(current, handle);
-            lock.register_mmio_device(device);
-        }
-    }
+    arch::bus::mmio::init();
 }

--- a/ostd/src/bus/mod.rs
+++ b/ostd/src/bus/mod.rs
@@ -16,7 +16,6 @@ pub enum BusProbeError {
 
 /// Initializes the bus
 pub(crate) fn init() {
-    #[cfg(target_arch = "x86_64")]
     pci::init();
 
     mmio::init();

--- a/ostd/src/bus/pci/bus.rs
+++ b/ostd/src/bus/pci/bus.rs
@@ -72,7 +72,7 @@ impl PciBus {
         self.drivers.push(driver);
     }
 
-    pub(super) fn register_common_device(&mut self, mut common_device: PciCommonDevice) {
+    pub(crate) fn register_common_device(&mut self, mut common_device: PciCommonDevice) {
         debug!("Find pci common devices:{:x?}", common_device);
         let device_id = *common_device.device_id();
         for driver in self.drivers.iter() {
@@ -94,7 +94,7 @@ impl PciBus {
         self.common_devices.push_back(common_device);
     }
 
-    pub(super) const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             common_devices: VecDeque::new(),
             devices: Vec::new(),

--- a/ostd/src/bus/pci/common_device.rs
+++ b/ostd/src/bus/pci/common_device.rs
@@ -65,7 +65,7 @@ impl PciCommonDevice {
         )
     }
 
-    pub(super) fn new(location: PciDeviceLocation) -> Option<Self> {
+    pub(crate) fn new(location: PciDeviceLocation) -> Option<Self> {
         if location.read16(0) == 0xFFFF {
             // not exists
             return None;

--- a/ostd/src/bus/pci/mod.rs
+++ b/ostd/src/bus/pci/mod.rs
@@ -58,18 +58,15 @@ mod device_info;
 
 pub use device_info::{PciDeviceId, PciDeviceLocation};
 
-use self::{bus::PciBus, common_device::PciCommonDevice};
-use crate::sync::Mutex;
+use crate::{
+    arch,
+    bus::pci::{bus::PciBus, common_device::PciCommonDevice},
+    sync::Mutex,
+};
 
 /// PCI bus instance
 pub static PCI_BUS: Mutex<PciBus> = Mutex::new(PciBus::new());
 
 pub(crate) fn init() {
-    let mut lock = PCI_BUS.lock();
-    for location in PciDeviceLocation::all() {
-        let Some(device) = PciCommonDevice::new(location) else {
-            continue;
-        };
-        lock.register_common_device(device);
-    }
+    arch::pci::init();
 }

--- a/ostd/src/cpu/mod.rs
+++ b/ostd/src/cpu/mod.rs
@@ -4,18 +4,11 @@
 
 pub mod local;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
-        pub use crate::arch::x86::cpu::*;
-    } else if #[cfg(target_arch = "riscv64")] {
-        pub use crate::arch::riscv::cpu::*;
-    }
-}
-
 use bitvec::prelude::BitVec;
 use local::cpu_local_cell;
 use spin::Once;
 
+pub use crate::arch::cpu::*;
 use crate::{
     arch::boot::smp::get_num_processors, task::DisabledPreemptGuard, trap::DisabledLocalIrqGuard,
 };

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -937,14 +937,6 @@ pub trait PodOnce: Pod {}
 
 impl<T: Pod> PodOnce for T where Assert<{ is_pod_once::<T>() }>: IsTrue {}
 
-#[cfg(target_arch = "x86_64")]
-const fn is_pod_once<T: Pod>() -> bool {
-    let size = size_of::<T>();
-
-    size == 1 || size == 2 || size == 4 || size == 8
-}
-
-#[cfg(target_arch = "riscv64")]
 const fn is_pod_once<T: Pod>() -> bool {
     let size = size_of::<T>();
 

--- a/ostd/src/mm/kspace.rs
+++ b/ostd/src/mm/kspace.rs
@@ -56,7 +56,7 @@ use super::{
     Paddr, PagingConstsTrait, Vaddr, PAGE_SIZE,
 };
 use crate::{
-    arch::mm::{PageTableEntry, PagingConsts},
+    arch::mm::{PageTableEntry, PagingConsts, KERNEL_CODE_BASE_VADDR_PREFIX},
     boot::memory_region::MemoryRegionType,
 };
 
@@ -80,10 +80,7 @@ pub fn kernel_loaded_offset() -> usize {
     KERNEL_CODE_BASE_VADDR
 }
 
-#[cfg(target_arch = "x86_64")]
-const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_8000_0000 << ADDR_WIDTH_SHIFT;
-#[cfg(target_arch = "riscv64")]
-const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000 << ADDR_WIDTH_SHIFT;
+const KERNEL_CODE_BASE_VADDR: usize = KERNEL_CODE_BASE_VADDR_PREFIX << ADDR_WIDTH_SHIFT;
 
 const FRAME_METADATA_CAP_VADDR: Vaddr = 0xffff_ff00_0000_0000 << ADDR_WIDTH_SHIFT;
 const FRAME_METADATA_BASE_VADDR: Vaddr = 0xffff_fe00_0000_0000 << ADDR_WIDTH_SHIFT;

--- a/ostd/src/panicking.rs
+++ b/ostd/src/panicking.rs
@@ -5,6 +5,7 @@
 use core::ffi::c_void;
 
 use crate::{
+    arch,
     arch::qemu::{exit_qemu, QemuExitCode},
     cpu_local_cell, early_print, early_println,
     sync::SpinLock,
@@ -12,7 +13,6 @@ use crate::{
 
 extern crate cfg_if;
 extern crate gimli;
-use gimli::Register;
 use unwinding::abi::{
     UnwindContext, UnwindReasonCode, _Unwind_Backtrace, _Unwind_FindEnclosingFunction,
     _Unwind_GetGR, _Unwind_GetIP,
@@ -93,13 +93,8 @@ fn print_stack_trace() {
         // the DWARF standard.
         for i in 0..8u16 {
             let reg_i = _Unwind_GetGR(unwind_ctx, i as i32);
-            cfg_if::cfg_if! {
-                if #[cfg(target_arch = "x86_64")] {
-                    let reg_name = gimli::X86_64::register_name(Register(i)).unwrap_or("unknown");
-                } else {
-                    let reg_name = "unknown";
-                }
-            }
+            let reg_name = arch::register_name(i).unwrap_or("unknown");
+
             if i % 4 == 0 {
                 early_print!("\n    ");
             }

--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -6,8 +6,6 @@ use core::sync::atomic::{
     Ordering::{Acquire, Relaxed, Release},
 };
 
-#[cfg(target_arch = "x86_64")]
-use crate::arch::x86::cpu;
 use crate::prelude::*;
 use crate::sync::AtomicBits;
 use crate::sync::SpinLock;


### PR DESCRIPTION
This pull request aims to move all architecture specific code in `ostd` to the arch specific directory in order to ease the support for additional architectures.