### PR TITLE
Separate `SegmentSlice` from `Segment` to remove heap allocation in `Segment`

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use align_ext::AlignExt;
+use aster_util::segment_slice::SegmentSlice;
 use int_to_c_enum::TryFromInt;
 use ostd::{
-    mm::{Frame, Infallible, Segment, VmReader, VmWriter},
+    mm::{Frame, Infallible, VmReader, VmWriter},
     sync::WaitQueue,
 };
 
@@ -366,7 +367,7 @@ pub enum BioStatus {
 #[derive(Debug, Clone)]
 pub struct BioSegment {
     /// The contiguous pages on which this segment resides.
-    pages: Segment,
+    pages: SegmentSlice,
     /// The starting offset (in bytes) within the first page.
     /// The offset should always be aligned to the sector size and
     /// must not exceed the size of a single page.
@@ -381,9 +382,8 @@ const SECTOR_SIZE: u16 = super::SECTOR_SIZE as u16;
 
 impl<'a> BioSegment {
     /// Constructs a new `BioSegment` from `Segment`.
-    pub fn from_segment(segment: Segment, offset: usize, len: usize) -> Self {
+    pub fn from_segment(segment: SegmentSlice, offset: usize, len: usize) -> Self {
         assert!(offset + len <= segment.nbytes());
-
         Self {
             pages: segment.range(frame_range(&(offset..offset + len))),
             offset: AlignedUsize::<SECTOR_SIZE>::new(offset % super::BLOCK_SIZE).unwrap(),
@@ -396,7 +396,7 @@ impl<'a> BioSegment {
         assert!(offset + len <= super::BLOCK_SIZE);
 
         Self {
-            pages: Segment::from(frame),
+            pages: SegmentSlice::from(frame),
             offset: AlignedUsize::<SECTOR_SIZE>::new(offset).unwrap(),
             len: AlignedUsize::<SECTOR_SIZE>::new(len).unwrap(),
         }
@@ -418,7 +418,7 @@ impl<'a> BioSegment {
     }
 
     /// Returns the contiguous pages on which this segment resides.
-    pub fn pages(&self) -> &Segment {
+    pub fn pages(&self) -> &SegmentSlice {
         &self.pages
     }
 

--- a/kernel/comps/network/src/dma_pool.rs
+++ b/kernel/comps/network/src/dma_pool.rs
@@ -152,9 +152,9 @@ impl DmaPage {
         pool: Weak<DmaPool>,
     ) -> Result<Self, ostd::Error> {
         let dma_stream = {
-            let vm_segment = FrameAllocOptions::new(1).alloc_contiguous()?;
+            let segment = FrameAllocOptions::new(1).alloc_contiguous()?;
 
-            DmaStream::map(vm_segment, direction, is_cache_coherent)
+            DmaStream::map(segment, direction, is_cache_coherent)
                 .map_err(|_| ostd::Error::AccessDenied)?
         };
 

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -419,7 +419,8 @@ impl DeviceInner {
             .flat_map(|bio| {
                 bio.segments().iter().map(|segment| {
                     let dma_stream =
-                        DmaStream::map(segment.pages().clone(), dma_direction, false).unwrap();
+                        DmaStream::map(segment.pages().clone().into(), dma_direction, false)
+                            .unwrap();
                     (dma_stream, segment.offset(), segment.nbytes())
                 })
             })

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -81,10 +81,8 @@ impl VirtQueue {
             let desc_size = size_of::<Descriptor>() * size as usize;
 
             let (seg1, seg2) = {
-                let continue_segment = FrameAllocOptions::new(2).alloc_contiguous().unwrap();
-                let seg1 = continue_segment.range(0..1);
-                let seg2 = continue_segment.range(1..2);
-                (seg1, seg2)
+                let segment = FrameAllocOptions::new(2).alloc_contiguous().unwrap();
+                segment.split(ostd::mm::PAGE_SIZE)
             };
             let desc_frame_ptr: SafePtr<Descriptor, DmaCoherent> =
                 SafePtr::new(DmaCoherent::map(seg1, true).unwrap(), 0);

--- a/kernel/libs/aster-util/src/lib.rs
+++ b/kernel/libs/aster-util/src/lib.rs
@@ -10,5 +10,6 @@ extern crate alloc;
 pub mod coeff;
 pub mod dup;
 pub mod safe_ptr;
+pub mod segment_slice;
 pub mod slot_vec;
 pub mod union_read_ptr;

--- a/kernel/libs/aster-util/src/segment_slice.rs
+++ b/kernel/libs/aster-util/src/segment_slice.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// SPDX-License-Identifier: MPL-2.0
+
+//! Provides [`SegmentSlice`] for quick duplication and slicing over [`Segment`].
+
+use alloc::sync::Arc;
+use core::ops::Range;
+
+use ostd::{
+    mm::{
+        FallibleVmRead, FallibleVmWrite, Frame, Infallible, Paddr, Segment, VmIo, VmReader,
+        VmWriter, PAGE_SIZE,
+    },
+    Error, Result,
+};
+
+/// A reference to a slice of a [`Segment`].
+///
+/// Cloning a [`SegmentSlice`] is cheap, as it only increments one reference
+/// count. While cloning a [`Segment`] will increment the reference count of
+/// many underlying pages.
+///
+/// The downside is that the [`SegmentSlice`] requires heap allocation. Also,
+/// if any [`SegmentSlice`] of the original [`Segment`] is alive, all pages in
+/// the original [`Segment`], including the pages that are not referenced, will
+/// not be freed.
+#[derive(Debug, Clone)]
+pub struct SegmentSlice {
+    inner: Arc<Segment>,
+    range: Range<usize>,
+}
+
+impl SegmentSlice {
+    /// Returns a part of the `Segment`.
+    ///
+    /// # Panics
+    ///
+    /// If `range` is not within the range of this `Segment`,
+    /// then the method panics.
+    pub fn range(&self, range: Range<usize>) -> Self {
+        let orig_range = &self.range;
+        let adj_range = (range.start + orig_range.start)..(range.end + orig_range.start);
+        assert!(!adj_range.is_empty() && adj_range.end <= orig_range.end);
+
+        Self {
+            inner: self.inner.clone(),
+            range: adj_range,
+        }
+    }
+
+    /// Returns the start physical address.
+    pub fn start_paddr(&self) -> Paddr {
+        self.start_frame_index() * PAGE_SIZE
+    }
+
+    /// Returns the end physical address.
+    pub fn end_paddr(&self) -> Paddr {
+        (self.start_frame_index() + self.nframes()) * PAGE_SIZE
+    }
+
+    /// Returns the number of page frames.
+    pub fn nframes(&self) -> usize {
+        self.range.len()
+    }
+
+    /// Returns the number of bytes.
+    pub fn nbytes(&self) -> usize {
+        self.nframes() * PAGE_SIZE
+    }
+
+    /// Gets a reader for the slice.
+    pub fn reader(&self) -> VmReader<'_, Infallible> {
+        self.inner
+            .reader()
+            .skip(self.start_paddr() - self.inner.start_paddr())
+            .limit(self.nbytes())
+    }
+
+    /// Gets a writer for the slice.
+    pub fn writer(&self) -> VmWriter<'_, Infallible> {
+        self.inner
+            .writer()
+            .skip(self.start_paddr() - self.inner.start_paddr())
+            .limit(self.nbytes())
+    }
+
+    fn start_frame_index(&self) -> usize {
+        self.inner.start_paddr() / PAGE_SIZE + self.range.start
+    }
+}
+
+impl VmIo for SegmentSlice {
+    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
+        let read_len = writer.avail();
+        // Do bound check with potential integer overflow in mind
+        let max_offset = offset.checked_add(read_len).ok_or(Error::Overflow)?;
+        if max_offset > self.nbytes() {
+            return Err(Error::InvalidArgs);
+        }
+        let len = self
+            .reader()
+            .skip(offset)
+            .read_fallible(writer)
+            .map_err(|(e, _)| e)?;
+        debug_assert!(len == read_len);
+        Ok(())
+    }
+
+    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
+        let write_len = reader.remain();
+        // Do bound check with potential integer overflow in mind
+        let max_offset = offset.checked_add(reader.remain()).ok_or(Error::Overflow)?;
+        if max_offset > self.nbytes() {
+            return Err(Error::InvalidArgs);
+        }
+        let len = self
+            .writer()
+            .skip(offset)
+            .write_fallible(reader)
+            .map_err(|(e, _)| e)?;
+        debug_assert!(len == write_len);
+        Ok(())
+    }
+}
+
+impl From<Segment> for SegmentSlice {
+    fn from(segment: Segment) -> Self {
+        Self {
+            inner: Arc::new(segment),
+            range: 0..1,
+        }
+    }
+}
+
+impl From<SegmentSlice> for Segment {
+    fn from(slice: SegmentSlice) -> Self {
+        let start = slice.range.start * PAGE_SIZE;
+        let end = slice.range.end * PAGE_SIZE;
+        slice.inner.slice(&(start..end))
+    }
+}
+
+impl From<Frame> for SegmentSlice {
+    fn from(frame: Frame) -> Self {
+        SegmentSlice::from(Segment::from(frame))
+    }
+}

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -22,7 +22,7 @@ mod test {
         BlockDevice, BlockDeviceMeta,
     };
     use ostd::{
-        mm::{FrameAllocOptions, Segment, VmIo},
+        mm::{FrameAllocOptions, Segment, VmIo, PAGE_SIZE},
         prelude::*,
     };
     use rand::{rngs::SmallRng, RngCore, SeedableRng};
@@ -48,7 +48,7 @@ mod test {
         }
 
         pub fn sectors_count(&self) -> usize {
-            self.0.nframes() * (PAGE_SIZE / SECTOR_SIZE)
+            self.0.nbytes() / SECTOR_SIZE
         }
     }
 
@@ -111,13 +111,10 @@ mod test {
 
     /// Read exfat disk image
     fn new_vm_segment_from_image() -> Segment {
-        let vm_segment = {
-            FrameAllocOptions::new(EXFAT_IMAGE.len() / PAGE_SIZE)
-                .is_contiguous(true)
-                .uninit(true)
-                .alloc_contiguous()
-                .unwrap()
-        };
+        let vm_segment = FrameAllocOptions::new(EXFAT_IMAGE.len().div_ceil(PAGE_SIZE))
+            .uninit(true)
+            .alloc_contiguous()
+            .unwrap();
 
         vm_segment.write_bytes(0, EXFAT_IMAGE).unwrap();
         vm_segment

--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -28,7 +28,7 @@ struct BlockGroupImpl {
 impl BlockGroup {
     /// Loads and constructs a block group.
     pub fn load(
-        group_descriptors_segment: &Segment,
+        group_descriptors_segment: &SegmentSlice,
         idx: usize,
         block_device: &dyn BlockDevice,
         super_block: &SuperBlock,

--- a/kernel/src/fs/ext2/prelude.rs
+++ b/kernel/src/fs/ext2/prelude.rs
@@ -12,8 +12,9 @@ pub(super) use aster_block::{
     BlockDevice, BLOCK_SIZE,
 };
 pub(super) use aster_rights::Full;
+pub(super) use aster_util::segment_slice::SegmentSlice;
 pub(super) use ostd::{
-    mm::{Frame, FrameAllocOptions, Segment, VmIo},
+    mm::{Frame, FrameAllocOptions, VmIo},
     sync::{RwMutex, RwMutexReadGuard, RwMutexWriteGuard},
 };
 pub(super) use static_assertions::const_assert;

--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -5,7 +5,7 @@
 use alloc::vec::Vec;
 use core::{mem::ManuallyDrop, ops::Range};
 
-use super::{meta::PageMeta, Page};
+use super::{inc_page_ref_count, meta::PageMeta, Page};
 use crate::mm::{Paddr, PAGE_SIZE};
 
 /// A contiguous range of physical memory pages.
@@ -25,16 +25,31 @@ pub struct ContPages<M: PageMeta> {
 
 impl<M: PageMeta> Drop for ContPages<M> {
     fn drop(&mut self) {
-        for i in self.range.clone().step_by(PAGE_SIZE) {
+        for paddr in self.range.clone().step_by(PAGE_SIZE) {
             // SAFETY: for each page there would be a forgotten handle
             // when creating the `ContPages` object.
-            drop(unsafe { Page::<M>::from_raw(i) });
+            drop(unsafe { Page::<M>::from_raw(paddr) });
+        }
+    }
+}
+
+impl<M: PageMeta> Clone for ContPages<M> {
+    fn clone(&self) -> Self {
+        for paddr in self.range.clone().step_by(PAGE_SIZE) {
+            // SAFETY: for each page there would be a forgotten handle
+            // when creating the `ContPages` object, so we already have
+            // reference counts for the pages.
+            unsafe { inc_page_ref_count(paddr) };
+        }
+        Self {
+            range: self.range.clone(),
+            _marker: core::marker::PhantomData,
         }
     }
 }
 
 impl<M: PageMeta> ContPages<M> {
-    /// Create a new `ContPages` from unused pages.
+    /// Creates a new `ContPages` from unused pages.
     ///
     /// The caller must provide a closure to initialize metadata for all the pages.
     /// The closure receives the physical address of the page and returns the
@@ -49,8 +64,8 @@ impl<M: PageMeta> ContPages<M> {
     where
         F: FnMut(Paddr) -> M,
     {
-        for i in range.clone().step_by(PAGE_SIZE) {
-            let _ = ManuallyDrop::new(Page::<M>::from_unused(i, metadata_fn(i)));
+        for paddr in range.clone().step_by(PAGE_SIZE) {
+            let _ = ManuallyDrop::new(Page::<M>::from_unused(paddr, metadata_fn(paddr)));
         }
         Self {
             range,
@@ -58,19 +73,75 @@ impl<M: PageMeta> ContPages<M> {
         }
     }
 
-    /// Get the start physical address of the contiguous pages.
+    /// Gets the start physical address of the contiguous pages.
     pub fn start_paddr(&self) -> Paddr {
         self.range.start
     }
 
-    /// Get the end physical address of the contiguous pages.
+    /// Gets the end physical address of the contiguous pages.
     pub fn end_paddr(&self) -> Paddr {
         self.range.end
     }
 
-    /// Get the length in bytes of the contiguous pages.
-    pub fn len(&self) -> usize {
+    /// Gets the length in bytes of the contiguous pages.
+    pub fn nbytes(&self) -> usize {
         self.range.end - self.range.start
+    }
+
+    /// Splits the pages into two at the given byte offset from the start.
+    ///
+    /// The resulting pages cannot be empty. So the offset cannot be neither
+    /// zero nor the length of the pages.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the offset is out of bounds, at either ends, or
+    /// not base-page-aligned.
+    pub fn split(self, offset: usize) -> (Self, Self) {
+        assert!(offset % PAGE_SIZE == 0);
+        assert!(0 < offset && offset < self.nbytes());
+
+        let old = ManuallyDrop::new(self);
+        let at = old.range.start + offset;
+
+        (
+            Self {
+                range: old.range.start..at,
+                _marker: core::marker::PhantomData,
+            },
+            Self {
+                range: at..old.range.end,
+                _marker: core::marker::PhantomData,
+            },
+        )
+    }
+
+    /// Gets an extra handle to the pages in the byte offset range.
+    ///
+    /// The sliced byte offset range in indexed by the offset from the start of
+    /// the contiguous pages. The resulting pages holds extra reference counts.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the byte offset range is out of bounds, or if
+    /// any of the ends of the byte offset range is not base-page aligned.
+    pub fn slice(&self, range: &Range<usize>) -> Self {
+        assert!(range.start % PAGE_SIZE == 0 && range.end % PAGE_SIZE == 0);
+        let start = self.range.start + range.start;
+        let end = self.range.start + range.end;
+        assert!(start <= end && end <= self.range.end);
+
+        for paddr in (start..end).step_by(PAGE_SIZE) {
+            // SAFETY: We already have reference counts for the pages since
+            // for each page there would be a forgotten handle when creating
+            // the `ContPages` object.
+            unsafe { inc_page_ref_count(paddr) };
+        }
+
+        Self {
+            range: start..end,
+            _marker: core::marker::PhantomData,
+        }
     }
 }
 
@@ -98,5 +169,23 @@ impl<M: PageMeta> From<ContPages<M>> for Vec<Page<M>> {
             .collect();
         let _ = ManuallyDrop::new(pages);
         vector
+    }
+}
+
+impl<M: PageMeta> Iterator for ContPages<M> {
+    type Item = Page<M>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.range.start < self.range.end {
+            // SAFETY: each page in the range would be a handle forgotten
+            // when creating the `ContPages` object.
+            let page = unsafe { Page::<M>::from_raw(self.range.start) };
+            self.range.start += PAGE_SIZE;
+            // The end cannot be non-page-aligned.
+            debug_assert!(self.range.start <= self.range.end);
+            Some(page)
+        } else {
+            None
+        }
     }
 }

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -15,7 +15,7 @@
 //! the handle only a pointer to the metadata.
 
 pub mod allocator;
-pub mod cont_pages;
+mod cont_pages;
 pub mod meta;
 
 use core::{


### PR DESCRIPTION
This is cherry-picked from #1287 (already reviewed). As the major function of #1287 needs to wait, the first commit can be merged earlier to facilitate iteration. This PR helps for stability since it tackles some chicken-egg problem.