### PR TITLE
Fix incorrect behaviors of accessing the boot PT after dismissal

### DIFF
--- a/ostd/src/mm/kspace.rs
+++ b/ostd/src/mm/kspace.rs
@@ -236,7 +236,7 @@ pub unsafe fn activate_kernel_page_table() {
     }
 
     // SAFETY: the boot page table is OK to be dismissed now since
-    // the kernel page table is activated.
+    // the kernel page table is activated just now.
     unsafe {
         crate::mm::page_table::boot_pt::dismiss();
     }


### PR DESCRIPTION
The previous implementation will surely fail in TDX since non-TD environments need not to protect the boot page table. We currently don't have CI always run for TD so it is discovered by @Hsy-Intel when doing #1428 .

It is extremely hard to discover since the boot pt leaks unsafe behaviors (writing to the current page table unauthorized).