### PR TITLE
do_exit: Fix unwrap panic caused by munmap

### DIFF
--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -26,9 +26,9 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     if *clear_ctid != 0 {
         futex_wake(*clear_ctid, 1, None)?;
         // FIXME: the correct write length?
-        get_current_userspace!()
-            .write_val(*clear_ctid, &0u32)
-            .unwrap();
+        if let Err(e) = get_current_userspace!().write_val(*clear_ctid, &0u32) {
+            debug!("Ignore error during exit process: {:?}", e);
+        }
         *clear_ctid = 0;
     }
     // exit the robust list: walk the robust list; mark futex words as dead and do futex wake


### PR DESCRIPTION
Fix #1194 

The address `0x10001690` is the `clear_child_tid` of a POSIX thread, and it together with the pointed memory will be set as 0 when exit.
However, when user calls syscall `munmap` for invalid address (i.e., 0x15000 - 0x100014000) in the example code, it will fail and fall into the exit process. Meanwhile the corresponding memory region is already unmapped, and the exit process will access this memory region and trigger this bug.


Before munmap, the memory info:
```
Mapped { va: 0x10001000, frame: Frame { page: Page { ptr: 0xfffffe00007e5700, _marker: PhantomData<ostd::mm::page::meta::FrameMeta> } }, prop: PageProperty { flags: R | W | RW | ACCESSED | DIRTY, cache: Writeback, priv_flags: USER } }
```

After munmap, the memory info:
```
NotMapped { va: 0x10001000, len: 0x1000 }
```