### PR TITLE
Fix the incorrect range in `SegmentSlice`

### DIFF
--- a/kernel/libs/aster-util/src/segment_slice.rs
+++ b/kernel/libs/aster-util/src/segment_slice.rs
@@ -126,9 +126,10 @@ impl VmIo for SegmentSlice {
 
 impl From<Segment> for SegmentSlice {
     fn from(segment: Segment) -> Self {
+        let range = 0..segment.nbytes() / PAGE_SIZE;
         Self {
             inner: Arc::new(segment),
-            range: 0..1,
+            range,
         }
     }
 }


### PR DESCRIPTION
Recently I test FIO on Ext2 and panic in `SegmentSlice::range()`. Ask @junyang-zh for review.