### PR TITLE
Fix docker image publication

### DIFF
--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Generate Dockerfile
         run: |
-          pip install Jinja2
+          sudo apt-get update
+          sudo apt-get install -y python3-jinja2
           python3 ./tools/docker/gen_dockerfile.py
 
       - name: Build and push development image
@@ -49,7 +50,6 @@ jobs:
 
       - name: Generate Dockerfile for Intel TDX
         run: |
-          pip install Jinja2
           python3 ./tools/docker/gen_dockerfile.py --intel-tdx
 
       - name: Build and push development image for Intel TDX


### PR DESCRIPTION
Fix asterinas docker image publication, see [this](https://github.com/grief8/asterinas/actions/runs/11313779259/job/31462940572).

* [`.github/workflows/publish_docker_images.yml`](diffhunk://#diff-9f59dd6364fb2f320d30c6187e53b3f69def4ba01da5aa70a4c219fdf366d609L36-R37): Replaced the `pip install Jinja2` command with `sudo apt-get install -y python3-jinja2` to ensure the Jinja2 library is installed via the system package manager. [[1]](diffhunk://#diff-9f59dd6364fb2f320d30c6187e53b3f69def4ba01da5aa70a4c219fdf366d609L36-R37) [[2]](diffhunk://#diff-9f59dd6364fb2f320d30c6187e53b3f69def4ba01da5aa70a4c219fdf366d609L52)