### PR TITLE
Resolve `cargo publish --dry-run` check failure

### DIFF
--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -33,8 +33,8 @@ log = "0.4"
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-ostd-macros = { version = "0.9.2", path = "libs/ostd-macros" }
-ostd-test = { version = "0.9.2", path = "libs/ostd-test" }
+ostd-macros = { path = "libs/ostd-macros", version = "0.9.2" }
+ostd-test = { path = "libs/ostd-test", version = "0.9.2" }
 owo-colors = { version = "3", optional = true }
 ostd-pod = { git = "https://github.com/asterinas/ostd-pod", rev = "c4644be", version = "0.1.1" }
 spin = "0.9.4"


### PR DESCRIPTION
Fix the CI publish_ostd_and_osdk failure.

The failure can be viewed at https://github.com/asterinas/asterinas/actions/runs/11320163469/job/31477283439?pr=1443 