### PR TITLE
Manage `Heap` with `Meta`

### DIFF
--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -74,13 +74,13 @@ impl<M: PageMeta> ContPages<M> {
     }
 
     /// Forget the handle and return the raw range.
-    /// 
+    ///
     /// This is the same as [`Page::into_raw`] and [`DynPage::into_raw`].
-    /// 
-    /// This will result in the designated range of pages being leaked without 
+    ///
+    /// This will result in the designated range of pages being leaked without
     /// calling the custom dropper.
-    /// 
-    /// The range of physical address to the page is returned in case the page 
+    ///
+    /// The range of physical address to the page is returned in case the page
     /// needs to be restored using [`Self::from_raw`] later.
     pub(in crate::mm) fn into_raw(self) -> Range<Paddr> {
         let range = self.range.clone();
@@ -89,10 +89,11 @@ impl<M: PageMeta> ContPages<M> {
     }
 
     /// Restore the handle from the raw range.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// The safety concerns are the same as [`Page::from_raw`].
+    #[allow(unused)]
     pub(in crate::mm) fn from_raw(range: Range<Paddr>) -> Self {
         Self {
             range,

--- a/ostd/src/mm/page/cont_pages.rs
+++ b/ostd/src/mm/page/cont_pages.rs
@@ -73,6 +73,33 @@ impl<M: PageMeta> ContPages<M> {
         }
     }
 
+    /// Forget the handle and return the raw range.
+    /// 
+    /// This is the same as [`Page::into_raw`] and [`DynPage::into_raw`].
+    /// 
+    /// This will result in the designated range of pages being leaked without 
+    /// calling the custom dropper.
+    /// 
+    /// The range of physical address to the page is returned in case the page 
+    /// needs to be restored using [`Self::from_raw`] later.
+    pub(in crate::mm) fn into_raw(self) -> Range<Paddr> {
+        let range = self.range.clone();
+        core::mem::forget(self);
+        range
+    }
+
+    /// Restore the handle from the raw range.
+    /// 
+    /// # Safety
+    /// 
+    /// The safety concerns are the same as [`Page::from_raw`].
+    pub(in crate::mm) fn from_raw(range: Range<Paddr>) -> Self {
+        Self {
+            range,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
     /// Gets the start physical address of the contiguous pages.
     pub fn start_paddr(&self) -> Paddr {
         self.range.start

--- a/ostd/src/mm/page/meta.rs
+++ b/ostd/src/mm/page/meta.rs
@@ -80,6 +80,8 @@ pub enum PageUsage {
     Meta = 65,
     /// The page stores the kernel such as kernel code, data, etc.
     Kernel = 66,
+    /// The page is used as a heap page.
+    Heap = 67,
 }
 
 #[repr(C)]
@@ -265,6 +267,18 @@ impl PageMeta for KernelMeta {
     const USAGE: PageUsage = PageUsage::Kernel;
     fn on_drop(_page: &mut Page<Self>) {
         panic!("Kernel pages are not allowed to be dropped");
+    }
+}
+
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct HeapMeta {}
+impl Sealed for HeapMeta {}
+impl PageMeta for HeapMeta {
+    const USAGE: PageUsage = PageUsage::Heap;
+    fn on_drop(_page: &mut Page<Self>) {
+        // Nothing should be done so far since dropping the page would
+        // have all taken care of.
     }
 }
 

--- a/ostd/src/mm/page/mod.rs
+++ b/ostd/src/mm/page/mod.rs
@@ -318,6 +318,9 @@ impl Drop for DynPage {
                     PageUsage::PageTable => {
                         meta::drop_as_last::<meta::PageTablePageMeta>(self.ptr);
                     }
+                    PageUsage::Heap => {
+                        meta::drop_as_last::<meta::HeapMeta>(self.ptr);
+                    }
                     // The following pages don't have metadata and can't be dropped.
                     PageUsage::Unused
                     | PageUsage::Reserved


### PR DESCRIPTION
This is a minor refactor to the current `Heap` and `Meta` system. It seems the previous implementation forgot to include heap memory to be managed by meta. So this PR added the corresponding code to fix the problem. It is a minor revision and the pre-condition of later PR.