### PR TITLE
Freeze the toolchain of x86-64 EFI handover boot

### DIFF
--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -166,6 +166,15 @@ fn install_setup_with_arch(
     }
     let target_dir = std::fs::canonicalize(target_dir).unwrap();
 
+    // Use `rustup override set` to set the toolchain to the frozen nightly version.
+    let nightly_version = "nightly-2024-06-20";
+    let _status = Command::new("rustup")
+        .arg("override")
+        .arg("set")
+        .arg(nightly_version)
+        .status()
+        .unwrap();
+
     let mut cmd = Command::new("cargo");
     cmd.env("RUSTFLAGS", "-Ccode-model=kernel -Crelocation-model=pie -Ctarget-feature=+crt-static -Zplt=yes -Zrelax-elf-relocations=yes -Crelro-level=full");
     cmd.arg("install").arg("linux-bzimage-setup");
@@ -190,6 +199,14 @@ fn install_setup_with_arch(
     cmd.arg("--target-dir").arg(target_dir.as_os_str());
 
     let status = cmd.status().unwrap();
+
+    // Restore the toolchain.
+    let _status = Command::new("rustup")
+        .arg("override")
+        .arg("unset")
+        .status()
+        .unwrap();
+
     if !status.success() {
         panic!(
             "Failed to build linux x86 setup header:\n\tcommand `{:?}`\n\treturned {}",

--- a/ostd/libs/linux-bzimage/setup/rust-toolchain.toml
+++ b/ostd/libs/linux-bzimage/setup/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-06-20"
+components = ["rust-src"]

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
@@ -18,6 +18,7 @@ const TABLE_ENTRY_COUNT: usize = 512;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy)]
+    #[repr(C)]
     pub struct Ia32eFlags: u64 {
         const PRESENT =         1 << 0;
         const WRITABLE =        1 << 1;
@@ -32,9 +33,11 @@ bitflags::bitflags! {
     }
 }
 
+#[repr(C)]
 pub struct Ia32eEntry(u64);
 
 /// The table in the IA32E paging specification that occupies a physical page frame.
+#[repr(C)]
 pub struct Ia32eTable([Ia32eEntry; TABLE_ENTRY_COUNT]);
 
 /// A page number. It could be either a physical page number or a virtual page number.

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/relocation.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/relocation.rs
@@ -2,6 +2,7 @@
 
 use crate::x86::get_image_loaded_offset;
 
+#[repr(C)]
 struct Elf64Rela {
     r_offset: u64,
     r_info: u64,
@@ -15,7 +16,9 @@ fn get_rela_array() -> &'static [Elf64Rela] {
     }
     let start = __rela_dyn_start as *const Elf64Rela;
     let end = __rela_dyn_end as *const Elf64Rela;
+
     let len = unsafe { end.offset_from(start) } as usize;
+
     #[cfg(feature = "debug_print")]
     unsafe {
         use crate::console::{print_hex, print_str};
@@ -27,6 +30,7 @@ fn get_rela_array() -> &'static [Elf64Rela] {
         print_hex(end as u64);
         print_str("\n");
     }
+
     // SAFETY: the linker will ensure that the symbols are valid.
     unsafe { core::slice::from_raw_parts(start, len) }
 }


### PR DESCRIPTION
I think it would freeze the development of x86-64 EFI boot, as I intend to give up maintaining it unilaterally. The value of the EFI boot compatibility is to port to TDX easily. As we already "made a POC work", I'd like to put more effort into more interesting things. ABI stuff is too tedious.

Maybe in the future we can have someone rewrite it in C... Who knows.