### PR TITLE
Manage S-waiting-on-author and S-waiting-on-review automatically

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -29,3 +29,16 @@ cc = ["@grief8"]
 # @boterinas blocked - This indicates that a PR is blocked on something. 
 # @boterinas ready - This indicates that a PR is ready for review. 
 # @boterinas review or @boterinas reviewer are aliases for ready.
+
+[review-submitted]
+# This label is added when a "request changes" review is submitted.
+reviewed_label = "S-waiting-on-author"
+# These labels are removed when a "request changes" review is submitted.
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+# Those labels are removed when PR author requests a review from an assignee
+remove_labels = ["S-waiting-on-author"]
+# Those labels are added when PR author requests a review from an assignee
+add_labels = ["S-waiting-on-review"]
+


### PR DESCRIPTION
This pull request includes changes to the `triagebot.toml` file to enhance the labeling system for pull requests. The most important changes include adding new sections for handling labels when reviews are submitted or requested.

Labeling system enhancements:

* [`triagebot.toml`](diffhunk://#diff-f36fda2d2992797cfaf9e91ada422272b2311c6d30230f6a72b86c9a42f864bcR32-R44): Added a `[review-submitted]` section to manage labels when a "request changes" review is submitted. This includes adding the `reviewed_label` as "S-waiting-on-author" and removing `review_labels` as "S-waiting-on-review".
* [`triagebot.toml`](diffhunk://#diff-f36fda2d2992797cfaf9e91ada422272b2311c6d30230f6a72b86c9a42f864bcR32-R44): Added a `[review-requested]` section to manage labels when a review is requested from an assignee. This includes removing `remove_labels` as "S-waiting-on-author" and adding `add_labels` as "S-waiting-on-review".