### PR TITLE
Adjust the order publishing the bzImage crates

### DIFF
--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -71,9 +71,9 @@ do_publish_for() {
     popd
 }
 
-do_publish_for osdk
-do_publish_for ostd/libs/linux-bzimage/build
 do_publish_for ostd/libs/linux-bzimage/boot-params
+do_publish_for ostd/libs/linux-bzimage/builder
+do_publish_for osdk
 
 # All supported targets of OSTD, this array should keep consistent with
 # `package.metadata.docs.rs.targets` in `ostd/Cargo.toml`.


### PR DESCRIPTION
Forgot that we need to publish the crates in an order with respects to the dependency.