### PR TITLE
Avoid potential deadlock in iommu remapping

### DIFF
--- a/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     bus::pci::PciDeviceLocation,
     mm::{Daddr, PageTable},
     prelude::Paddr,
-    sync::SpinLock,
+    sync::{LocalIrqDisabled, SpinLock},
 };
 
 mod context_table;
@@ -74,4 +74,7 @@ pub fn init() {
     info!("[IOMMU] DMA remapping enabled");
 }
 
-static PAGE_TABLE: Once<SpinLock<RootTable>> = Once::new();
+// TODO: Currently `map()` or `unmap()` could be called in both task and interrupt
+// contexts (e.g., within the virtio-blk module), potentially leading to deadlocks.
+// Once this issue is resolved, `LocalIrqDisabled` is no longer needed.
+static PAGE_TABLE: Once<SpinLock<RootTable, LocalIrqDisabled>> = Once::new();

--- a/ostd/src/arch/x86/iommu/registers/mod.rs
+++ b/ostd/src/arch/x86/iommu/registers/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         x86::kernel::acpi::dmar::{Dmar, Remapping},
     },
     mm::paddr_to_vaddr,
-    sync::SpinLock,
+    sync::{LocalIrqDisabled, SpinLock},
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -91,7 +91,10 @@ impl IommuRegisters {
     }
 
     /// Enable DMA remapping with static RootTable
-    pub(super) fn enable_dma_remapping(&mut self, root_table: &'static SpinLock<RootTable>) {
+    pub(super) fn enable_dma_remapping(
+        &mut self,
+        root_table: &'static SpinLock<RootTable, LocalIrqDisabled>,
+    ) {
         // Set root table address
         self.root_table_address
             .write(root_table.lock().root_paddr() as u64);


### PR DESCRIPTION
Recently I run FIO tests on ext2 with iommu-enabled and the process hangs most of the time. After I debugged I found that in `iommu::map()` we should lock the page table with irq disabled to prevent interrupts from other modules (like network) who trys to do the mapping with the same global page table of iommu.
