### PR TITLE
Set tcp benchmarks' backlog as 1

### DIFF
--- a/test/benchmark/lmbench/tcp_loopback_bw_4k/run.sh
+++ b/test/benchmark/lmbench/tcp_loopback_bw_4k/run.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "*** Running lmbench TCP bandwidth test ***"
 
-/benchmark/bin/lmbench/bw_tcp -s
+/benchmark/bin/lmbench/bw_tcp -s 127.0.0.1 -b 1
 /benchmark/bin/lmbench/bw_tcp -m 4096 -P 1 127.0.0.1
 /benchmark/bin/lmbench/bw_tcp -S 127.0.0.1

--- a/test/benchmark/lmbench/tcp_loopback_bw_64k/run.sh
+++ b/test/benchmark/lmbench/tcp_loopback_bw_64k/run.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "*** Running lmbench TCP bandwidth test ***"
 
-/benchmark/bin/lmbench/bw_tcp -s
+/benchmark/bin/lmbench/bw_tcp -s 127.0.0.1 -b 1
 /benchmark/bin/lmbench/bw_tcp -m 65536 -P 1 127.0.0.1
 /benchmark/bin/lmbench/bw_tcp -S 127.0.0.1

--- a/test/benchmark/lmbench/tcp_loopback_connect_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_loopback_connect_lat/run.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "*** Running lmbench TCP connection latency test***"
 
-/benchmark/bin/lmbench/lat_connect -s
+/benchmark/bin/lmbench/lat_connect -s 127.0.0.1
 /benchmark/bin/lmbench/lat_connect 127.0.0.1
 /benchmark/bin/lmbench/lat_connect -S 127.0.0.1

--- a/test/benchmark/lmbench/tcp_loopback_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_loopback_lat/run.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "*** Running lmbench TCP latency test ***"
 
-/benchmark/bin/lmbench/lat_tcp -s 127.0.0.1
+/benchmark/bin/lmbench/lat_tcp -s 127.0.0.1 -b 1
 /benchmark/bin/lmbench/lat_tcp -P 1 127.0.0.1
 /benchmark/bin/lmbench/lat_tcp -S 127.0.0.1

--- a/test/benchmark/lmbench/tcp_virtio_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_lat/run.sh
@@ -7,7 +7,7 @@ set -e
 echo "Running lmbench TCP latency over virtio-net..."
 
 # Start the server
-/benchmark/bin/lmbench/lat_tcp -s 10.0.2.15
+/benchmark/bin/lmbench/lat_tcp -s 10.0.2.15 -b 1
 
 # Sleep for a long time to ensure VM won't exit
 sleep 200

--- a/test/benchmark/lmbench/udp_loopback_lat/run.sh
+++ b/test/benchmark/lmbench/udp_loopback_lat/run.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "*** Running lmbench UDP latency test ***"
 
-/benchmark/bin/lmbench/lat_udp -s
+/benchmark/bin/lmbench/lat_udp -s 127.0.0.1
 /benchmark/bin/lmbench/lat_udp -P 1 127.0.0.1
 /benchmark/bin/lmbench/lat_udp -S 127.0.0.1


### PR DESCRIPTION
Since we don't have implemented efficient support of TCP backlog, temporarily set backlog as 1 in lmbench test.