### PR TITLE
Fix the booting `init` problem

### DIFF
--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -299,7 +299,7 @@ impl PosixThread {
     }
 }
 
-static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(0);
+static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(1);
 
 /// Allocates a new tid for the new posix thread
 pub fn allocate_posix_tid() -> Tid {


### PR DESCRIPTION
This is a simple modification to solve the problem in #1429 . This modification allows asterinas to boot with busybox init process (like embedded Linux system)

> Change `init_args = ["sh", "-l"]` into `init_args = ["init"]` to relocates the booting process to start with the init process of busybox.

Before the modification, this will cause #1429 and stop the normal booting. With the modification, the booting process will continue. However, there are `init` related problems to be solved.