### PR TITLE
Clear TID before doing futex_wake when exiting a POSIX thread

### DIFF
--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -24,11 +24,11 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     let mut clear_ctid = posix_thread.clear_child_tid().lock();
     // If clear_ctid !=0 ,do a futex wake and write zero to the clear_ctid addr.
     if *clear_ctid != 0 {
-        futex_wake(*clear_ctid, 1, None)?;
         // FIXME: the correct write length?
         if let Err(e) = get_current_userspace!().write_val(*clear_ctid, &0u32) {
             debug!("Ignore error during exit process: {:?}", e);
         }
+        futex_wake(*clear_ctid, 1, None)?;
         *clear_ctid = 0;
     }
     // exit the robust list: walk the robust list; mark futex words as dead and do futex wake


### PR DESCRIPTION
## Problem

Currently the SMP syscall test in CI ocassionally hangs on futex_test and semaphore_test. I believe the reason is a lost-wakeup problem after the main thread of test joins its child thread. 

The child thread (cloned with `CLONE_CHILD_CLEARTID` flag) will exit after it finishes its task, executing the code below.

https://github.com/asterinas/asterinas/blob/2f511069eecf521661aa4d8ee3020863be75b543/kernel/src/process/posix_thread/exit.rs#L26-L33

If the main (parent) thread joins between L26 and L29-31, it will never get waked up and therefore hang the test.

## Solution

Swap the two operations mentioned above, i.e. change the futex value before futex_wake.