### PR TITLE
Clean up some scheduler APIs

### DIFF
--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -266,9 +266,8 @@ impl Waker {
     }
 
     fn do_wait(&self) {
-        let has_woken = &self.has_woken;
-        while !has_woken.swap(false, Ordering::Acquire) {
-            scheduler::park_current(has_woken);
+        while !self.has_woken.swap(false, Ordering::Acquire) {
+            scheduler::park_current(|| self.has_woken.load(Ordering::Acquire));
         }
     }
 


### PR DESCRIPTION
### The PR description below is outdated, please see https://github.com/asterinas/asterinas/pull/1472#issuecomment-2444496855 and https://github.com/asterinas/asterinas/pull/1472#issuecomment-2427078063 directly.

I'm not sure why we introduce `ReschedAction::Retry`:
https://github.com/asterinas/asterinas/blob/2f511069eecf521661aa4d8ee3020863be75b543/ostd/src/task/scheduler/mod.rs#L236-L244

Looking at the code, `ReschedAction::Retry` is clearly redundant because we can loop over `reschedule()`:
https://github.com/asterinas/asterinas/blob/2f511069eecf521661aa4d8ee3020863be75b543/ostd/src/task/scheduler/mod.rs#L209-L230

In some cases the outer loop already exists, so the inner loop doesn't make much sense to me:
https://github.com/asterinas/asterinas/blob/2f511069eecf521661aa4d8ee3020863be75b543/ostd/src/sync/wait.rs#L270-L272

The outer loop in `Waiter` checks `has_woken` on every iteration (as shown above). However, in the inner loop we can only check the flag on the first iteration. Ideally we should check the flag on every iteration, but we cannot do that because we cannot return `DoNothing` on the second or later iteration unless `pick_next_current` returns the original current.
https://github.com/asterinas/asterinas/blob/2f511069eecf521661aa4d8ee3020863be75b543/ostd/src/task/scheduler/mod.rs#L113-L134

To solve the problem, I think we should merge `dequeue_current` and `pick_next_current` into one method. The proposed API is:
```rust
/// The state of the current task at the time of scheduling.
#[derive(PartialEq, Copy, Clone)]
pub enum CurrentState {
    /// The current task is still runnable, so it will be kept in the runqueue.
    Runnable,
    /// The current task needs to go to sleep, so it will leave the runqueue.
    NeedSleep,
}

pub trait LocalRunQueue<T = Task> {
    /// Picks the next runnable task.
    ///
    /// This method returns the selected next runnable task. This task will replace the current
    /// runnable task after the method returns. If there is no candidate for such a task, this
    /// method will do nothing but return `None`.
    ///
    /// After the next runnable task is selected, `current_state` will decide whether or not to
    /// keep the current runnable task in the run queue. See [`CurrentState`] for details.
    fn pick_next(&mut self, current_state: CurrentState) -> Option<&Arc<T>>;
}
```