### PR TITLE
Remove the additional IRQ disable during EOI

### DIFF
--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -61,13 +61,14 @@ impl super::Apic for X2Apic {
         unsafe { rdmsr(IA32_X2APIC_VERSION) as u32 }
     }
 
-    fn eoi(&mut self) {
+    fn eoi(&self) {
         unsafe {
             wrmsr(IA32_X2APIC_EOI, 0);
         }
     }
 
-    unsafe fn send_ipi(&mut self, icr: super::Icr) {
+    unsafe fn send_ipi(&self, icr: super::Icr) {
+        let _guard = crate::trap::disable_local();
         wrmsr(IA32_X2APIC_ESR, 0);
         wrmsr(IA32_X2APIC_ICR, icr.0);
         loop {
@@ -83,7 +84,7 @@ impl super::Apic for X2Apic {
 }
 
 impl ApicTimer for X2Apic {
-    fn set_timer_init_count(&mut self, value: u64) {
+    fn set_timer_init_count(&self, value: u64) {
         unsafe {
             wrmsr(IA32_X2APIC_INIT_COUNT, value);
         }
@@ -93,13 +94,13 @@ impl ApicTimer for X2Apic {
         unsafe { rdmsr(IA32_X2APIC_CUR_COUNT) }
     }
 
-    fn set_lvt_timer(&mut self, value: u64) {
+    fn set_lvt_timer(&self, value: u64) {
         unsafe {
             wrmsr(IA32_X2APIC_LVT_TIMER, value);
         }
     }
 
-    fn set_timer_div_config(&mut self, div_config: super::DivideConfig) {
+    fn set_timer_div_config(&self, div_config: super::DivideConfig) {
         unsafe {
             wrmsr(IA32_X2APIC_DIV_CONF, div_config as u64);
         }

--- a/ostd/src/cpu/local/cpu_local.rs
+++ b/ostd/src/cpu/local/cpu_local.rs
@@ -108,7 +108,7 @@ impl<T: 'static> CpuLocal<T> {
     /// # Safety
     ///
     /// The caller must ensure that the reference to `self` is static.
-    unsafe fn as_ptr(&'static self) -> *const T {
+    pub(crate) unsafe fn as_ptr(&'static self) -> *const T {
         super::has_init::assert_true();
 
         let offset = self.get_offset();


### PR DESCRIPTION
Many performance traces have shown that during interrupt handling, the EOI (end of interrupt) function would take some time checking if the IRQ is disabled. This is not necessary since the only requirement of disabling the IRQ when EOI is to access CPU local data. However this requirement is too strong and we can guarantee safe access of the local APIC instance without compile-time checked exclusive access.

Because that the reads and writes to MSRs are single-instruction in x86, there's no need to turn off IRQs when accessing the local APIC either. So every one can access the local APIC instance with a `&Apic` rather than `&mut Apic`.

This PR removes most redundant IRQ disables in APIC (except for non-single-instruction IPI sending), especially for EOI, which would improve some performance in some extreme scenarios.