### PR TITLE
Bind vCPUs to CPUs in benchmark

### DIFF
--- a/osdk/src/config/scheme/qemu.rs
+++ b/osdk/src/config/scheme/qemu.rs
@@ -93,10 +93,10 @@ impl QemuScheme {
 
 /// Keys with multiple values
 const MULTI_VALUE_KEYS: &[&str] = &[
-    "-device", "-chardev", "-object", "-netdev", "-drive", "-cdrom",
+    "-device", "-chardev", "-object", "-netdev", "-drive", "-cdrom", "-monitor",
 ];
 /// Keys with only single value
-const SINGLE_VALUE_KEYS: &[&str] = &["-cpu", "-machine", "-m", "-serial", "-monitor", "-display"];
+const SINGLE_VALUE_KEYS: &[&str] = &["-cpu", "-machine", "-m", "-serial", "-display"];
 /// Keys with no value
 const NO_VALUE_KEYS: &[&str] = &["--no-reboot", "-nographic", "-enable-kvm"];
 /// Keys are not allowed to set in configuration files and command line

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -64,6 +64,7 @@ run_benchmark() {
         -m 8G \
         -machine q35,kernel-irqchip=split \
         -cpu Icelake-Server,-pcid,+x2apic \
+        -monitor unix:/run/linux_monitor.socket,server,nowait \
         --enable-kvm \
         -kernel ${LINUX_KERNEL} \
         -initrd ${BENCHMARK_DIR}/../build/initramfs.cpio.gz \
@@ -101,6 +102,8 @@ run_benchmark() {
     parse_results "$benchmark" "$search_pattern" "$result_index" "$linux_output" "$aster_output" "$result_template" "$result_file"
 
     echo "Cleaning up..."
+    rm -f "/run/asterinas_monitor.socket"
+    rm -f "/run/linux_monitor.socket"
     rm -f "${linux_output}"
     rm -f "${aster_output}"
 }

--- a/tools/bind_core.sh
+++ b/tools/bind_core.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# This script binds all vCPU threads of a running QEMU process 
+# to CPUs within a single NUMA node.
+# The QEMU process must be monitored via `SOCK_MONITOR` 
+# to retrieve each vCPU's thread ID.
+
+# Usage: ./bind_core.sh <SOCK_MONITOR>
+
+set -e
+
+# Execute a command through the monitor socket and return the result.
+# Usage: exec_qemu_monitor_cmd <sock_monitor> <cmd>
+exec_qemu_monitor_cmd() {
+    local client=$1
+    local cmd=$2
+    printf "%s\n" "${cmd}" | socat unix-client:"${client}" stdio | tail -n +2 | grep -v "^(qemu)" | tr -d '\r'
+    return $?
+}
+
+# Retrieve thread IDs of all vCPUs.
+# Usage: get_vcpu_tids <sock_monitor>
+get_vcpu_tids() {
+    res=$(exec_qemu_monitor_cmd "$1" "info cpus")
+    echo $res | grep -oP 'thread_id=\K\d+'
+}
+
+# Get 'N' CPUs in the same NUMA node as CPU 0.
+# Usage: get_cpus_in_numa_node <N>
+get_cpus_in_numa_node() {
+    local required_cpus=$1
+    local total_cpus=$(lscpu | awk '/^CPU\(s\):/ {print $2}')
+    local cpu0_numa_id=$(cat "/sys/devices/system/cpu/cpu0/topology/physical_package_id")
+    local cpu_list=()
+    local count=0
+
+    for cpu in $(seq 0 $((total_cpus - 1))); do
+        local cpu_numa_id=$(cat "/sys/devices/system/cpu/cpu${cpu}/topology/physical_package_id" 2>/dev/null || echo "")
+        
+        if [ "$cpu_numa_id" = "$cpu0_numa_id" ]; then
+            cpu_list+=($cpu)
+            count=$((count + 1))
+        fi
+        
+        if [ "$count" -ge "$required_cpus" ]; then
+            break
+        fi
+    done
+    echo "${cpu_list[@]}"
+}
+
+SOCK_MONITOR=$1
+vcpu_tids=$(get_vcpu_tids "${SOCK_MONITOR}")
+vcpu_num=$(echo "${vcpu_tids}" | wc -w)
+cpus=$(get_cpus_in_numa_node "${vcpu_num}")
+
+# Bind vCPUs
+cpus_array=(${cpus})
+n=0
+for vcpu_tid in ${vcpu_tids}; do
+    cpu=${cpus_array[$n]}
+    n=$((n + 1))
+    taskset -pc ${cpu} ${vcpu_tid}
+done

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -13,6 +13,11 @@ REDIS_RAND_PORT=${REDIS_PORT:-$(shuf -i 1024-65535 -n 1)}
 IPERF_RAND_PORT=${IPERF_PORT:-$(shuf -i 1024-65535 -n 1)}
 LMBENCH_TCP_LAT_RAND_PORT=${LMBENCH_TCP_LAT_PORT:-$(shuf -i 1024-65535 -n 1)}
 
+# Start monitoring while running benchmark to obtain vCPU information and pin vCPUs.
+if [[ ! "$BENCHMARK" == *"none"* ]]; then
+    SOCK_MONITOR="-monitor unix:/run/asterinas_monitor.socket,server,nowait"
+fi
+
 # Optional QEMU arguments. Opt in them manually if needed.
 # QEMU_OPT_ARG_DUMP_PACKETS="-object filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap"
 
@@ -38,6 +43,7 @@ COMMON_QEMU_ARGS="\
     -display none \
     -serial chardev:mux \
     -monitor chardev:mux \
+    $SOCK_MONITOR \
     -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
     $NETDEV_ARGS \
     $QEMU_OPT_ARG_DUMP_PACKETS \


### PR DESCRIPTION
This PR pins all QEMU vCPUs to specific host CPUs to enhance the reliability of benchmark results. Additionally, for host-guest tests, both the iperf client and lmbench client are pinned to a host CPU. 

Initially, this PR retrieves the TID of each QEMU vCPU through the QEMU monitor and binds all CPUs to those within the same NUMA node as CPU 0 via `taskset`. 