### PR TITLE
Enable tap mode network and vhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ EXTRA_BLOCKLISTS_DIRS ?= ""
 SYSCALL_TEST_DIR ?= /tmp
 # End of auto test features.
 
+# Network settings
+NETDEV ?= user 		# Possible values are user,tap
+VHOST ?= off	
+# End of network settings
+
 # ========================= End of Makefile options. ==========================
 
 CARGO_OSDK := ~/.cargo/bin/cargo-osdk

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -71,7 +71,7 @@ run_benchmark() {
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,config-wce=off,request-merging=off,write-cache=off,backend_defaults=off,discard=off,event_idx=off,indirect_desc=off,ioeventfd=off,queue_reset=off \
         -append 'console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet' \
         -netdev user,id=net01,hostfwd=tcp::5201-:5201,hostfwd=tcp::8080-:8080,hostfwd=tcp::31234-:31234 \
-        -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off \
+        -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off \
         -nographic \
         2>&1"
     case "${benchmark_type}" in

--- a/tools/docker/run_dev_container.sh
+++ b/tools/docker/run_dev_container.sh
@@ -15,4 +15,4 @@ else
     IMAGE_NAME="asterinas/asterinas:${VERSION}"
 fi
 
-docker run -it --privileged --network=host --device=/dev/kvm -v ${ASTER_SRC_DIR}:/root/asterinas ${IMAGE_NAME}
+docker run -it --privileged --network=host --device=/dev/kvm --device=/dev/vhost-net -v ${ASTER_SRC_DIR}:/root/asterinas ${IMAGE_NAME}

--- a/tools/net/qemu-ifdown.sh
+++ b/tools/net/qemu-ifdown.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# Delete the TAP interface.
+#
+# It's used for the cleanup script of QEMU netdev, DO NOT run it manually.
+
+if [ -n "$1" ]; then
+    ip link set dev "$1" down
+    ip link delete dev "$1"
+    exit
+else
+    echo "Error: no interface specified"
+    exit 1
+fi

--- a/tools/net/qemu-ifup.sh
+++ b/tools/net/qemu-ifup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# Create a TAP interface.
+#
+# It's used for the startup script of QEMU netdev, DO NOT run it manually.
+
+# This IP address should be set the same as gateway address of Asterinas
+IP=10.0.2.2/24
+
+if [ -n "$1" ]; then
+    ip addr add $IP dev "$1"
+    ip link set dev "$1" up
+    exit
+else
+    echo "Error: no interface specified"
+    exit 1
+fi


### PR DESCRIPTION
This PR addresses the following:

1. Disables virtio-net features not currently supported in benchmarks.
2. Enables the tap backend network and vhost. These features can be activated using `make run NETDEV=tap VHOST=on`.


The primary goal of introducing vhost was to assess the impact of vIOMMU. Since vhost can only be enabled with the tap backend, support for the tap backend has been included.

Preliminary experiments confirm our initial assumption: with vhost, vIOMMU has minimal effect on Asterinas's network performance. However, vIOMMU significantly impacts Linux performance, indicating that Linux uses dynamic DMA mapping. In contrast, Asterinas's DMA pool eliminates the mapping and unmapping costs.

Note: The results below are not very stable (sometimes showing up to a 50% increase or decrease). (The experiments are done on a machine equipped with CPU Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz)

VHOST | IOMMU | Linux(Mbps) | Asterinas(Mbps)
-- | -- | -- | --
off | off | 30504 | 1683
off | on | 4224 | 1240
on | off | 50323 | 3447
on | on | 749 | 3395

Currently, tap support is incomplete. When running with the tap backend, Asterinas cannot be accessed from the Internet. The tap backend is limited to host-guest communication at this time.
