### PR TITLE
Implement sync for virtio-blk

### DIFF
--- a/kernel/comps/block/src/impl_block_device.rs
+++ b/kernel/comps/block/src/impl_block_device.rs
@@ -83,6 +83,18 @@ impl dyn BlockDevice {
         let bio = create_bio_from_frame(BioType::Write, bid, frame);
         bio.submit(self)
     }
+
+    /// Issues a sync request
+    pub fn sync(&self) -> Result<BioStatus, BioEnqueueError> {
+        let bio = Bio::new(
+            BioType::Flush,
+            Sid::from(Bid::from_offset(0)),
+            vec![],
+            Some(general_complete_fn),
+        );
+        let status = bio.submit_and_wait(self)?;
+        Ok(status)
+    }
 }
 
 impl VmIo for dyn BlockDevice {

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -410,7 +410,7 @@ impl DeviceInner {
     /// Flushes any cached data from the guest to the persistent storage on the host.
     /// This will be ignored if the device doesn't support the `VIRTIO_BLK_F_FLUSH` feature.
     fn flush(&self, bio_request: BioRequest) {
-        if self.transport.lock().device_features() & BlockFeatures::FLUSH.bits() == 0 {
+        if self.transport.lock().read_device_features() & BlockFeatures::FLUSH.bits() == 0 {
             bio_request.bios().for_each(|bio| {
                 bio.complete(BioStatus::Complete);
             });

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -111,6 +111,12 @@ pub struct VirtioBlockTopology {
     opt_io_size: u32,
 }
 
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct VirtioBlockFeature {
+    support_flush: bool,
+}
+
 impl VirtioBlockConfig {
     pub(self) fn new(transport: &dyn VirtioTransport) -> SafePtr<Self, IoMem> {
         let memory = transport.device_config_memory();
@@ -133,5 +139,12 @@ impl VirtioBlockConfig {
         field_ptr!(this, Self, capacity)
             .read_once()
             .map(|val| val as usize)
+    }
+}
+
+impl VirtioBlockFeature {
+    pub(self) fn new(transport: &dyn VirtioTransport) -> Self {
+        let support_flush = transport.read_device_features() & BlockFeatures::FLUSH.bits() == 1;
+        VirtioBlockFeature { support_flush }
     }
 }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -51,7 +51,7 @@ impl NetworkDevice {
     pub fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
         let virtio_net_config = VirtioNetConfig::new(transport.as_mut());
         let features = NetworkFeatures::from_bits_truncate(Self::negotiate_features(
-            transport.device_features(),
+            transport.read_device_features(),
         ));
         debug!("virtio_net_config = {:?}", virtio_net_config);
         debug!("features = {:?}", features);

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -201,7 +201,7 @@ impl VirtioTransport for VirtioMmioTransport {
         self.common_device.io_mem().slice(0x100..0x200)
     }
 
-    fn device_features(&self) -> u64 {
+    fn read_device_features(&self) -> u64 {
         // select low
         field_ptr!(&self.layout, VirtioMmioLayout, device_features_select)
             .write_once(&0u32)
@@ -219,7 +219,7 @@ impl VirtioTransport for VirtioMmioTransport {
         device_feature_high << 32 | device_feature_low as u64
     }
 
-    fn set_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {
+    fn write_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {
         let low = features as u32;
         let high = (features >> 32) as u32;
         field_ptr!(&self.layout, VirtioMmioLayout, driver_features_select)
@@ -237,7 +237,7 @@ impl VirtioTransport for VirtioMmioTransport {
         Ok(())
     }
 
-    fn device_status(&self) -> DeviceStatus {
+    fn read_device_status(&self) -> DeviceStatus {
         DeviceStatus::from_bits(
             field_ptr!(&self.layout, VirtioMmioLayout, status)
                 .read_once()
@@ -246,7 +246,7 @@ impl VirtioTransport for VirtioMmioTransport {
         .unwrap()
     }
 
-    fn set_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError> {
+    fn write_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError> {
         field_ptr!(&self.layout, VirtioMmioLayout, status)
             .write_once(&(status.bits() as u32))
             .unwrap();

--- a/kernel/comps/virtio/src/transport/mod.rs
+++ b/kernel/comps/virtio/src/transport/mod.rs
@@ -24,23 +24,24 @@ pub mod pci;
 pub trait VirtioTransport: Sync + Send + Debug {
     // ====================Device related APIs=======================
 
+    /// Get device type.
     fn device_type(&self) -> VirtioDeviceType;
 
     /// Get device features.
-    fn device_features(&self) -> u64;
+    fn read_device_features(&self) -> u64;
 
     /// Set driver features.
-    fn set_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError>;
+    fn write_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError>;
 
     /// Get device status.
-    fn device_status(&self) -> DeviceStatus;
+    fn read_device_status(&self) -> DeviceStatus;
 
     /// Set device status.
-    fn set_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError>;
+    fn write_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError>;
 
     // Set to driver ok status
     fn finish_init(&mut self) {
-        self.set_device_status(
+        self.write_device_status(
             DeviceStatus::ACKNOWLEDGE
                 | DeviceStatus::DRIVER
                 | DeviceStatus::FEATURES_OK

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -132,7 +132,7 @@ impl VirtioTransport for VirtioPciTransport {
         memory.slice(offset..offset + length)
     }
 
-    fn device_features(&self) -> u64 {
+    fn read_device_features(&self) -> u64 {
         // select low
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_feature_select)
             .write_once(&0u32)
@@ -150,7 +150,7 @@ impl VirtioTransport for VirtioPciTransport {
         device_feature_high << 32 | device_feature_low as u64
     }
 
-    fn set_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {
+    fn write_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {
         let low = features as u32;
         let high = (features >> 32) as u32;
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, driver_feature_select)
@@ -168,14 +168,14 @@ impl VirtioTransport for VirtioPciTransport {
         Ok(())
     }
 
-    fn device_status(&self) -> DeviceStatus {
+    fn read_device_status(&self) -> DeviceStatus {
         let status = field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_status)
             .read_once()
             .unwrap();
         DeviceStatus::from_bits(status).unwrap()
     }
 
-    fn set_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError> {
+    fn write_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError> {
         field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_status)
             .write_once(&(status.bits()))
             .unwrap();

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -1683,6 +1683,8 @@ impl Inode for ExfatInode {
         let fs_guard = fs.lock();
         inner.sync_all(&fs_guard)?;
 
+        fs.block_device().sync()?;
+
         Ok(())
     }
 
@@ -1691,6 +1693,8 @@ impl Inode for ExfatInode {
         let fs = inner.fs();
         let fs_guard = fs.lock();
         inner.sync_data(&fs_guard)?;
+
+        fs.block_device().sync()?;
 
         Ok(())
     }

--- a/kernel/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/ext2/impl_for_vfs/inode.rs
@@ -191,11 +191,15 @@ impl Inode for Ext2Inode {
     }
 
     fn sync_all(&self) -> Result<()> {
-        self.sync_all()
+        self.sync_all()?;
+        self.fs().block_device().sync()?;
+        Ok(())
     }
 
     fn sync_data(&self) -> Result<()> {
-        self.sync_data()
+        self.sync_data()?;
+        self.fs().block_device().sync()?;
+        Ok(())
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {


### PR DESCRIPTION
This PR is mainly to implement sync for virtio, covering the whole procedure from sync syscall to handling flush request in virtio.

Before this PR, Asterinas did not actually implement sync in virtio. We @lucassong-mh  found that when applications like fio request to flush all cached data to the persistent storage on the host, Asterinas actually does nothing. That's one of the main reasons why Asterinas's write is much faster than Linux. See more in https://github.com/asterinas/asterinas/issues/1343

This PR is about implementing sync syscall, making flush request and handling it. Based on this PR, we could see that in the end of  fio write test, one flush request is indeed sended and completed, which makes Asterinas's average write speed slows down to a reasonable level.
