### PR TITLE
Skip bottom half if preemption is disabled

### DIFF
--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -11,7 +11,7 @@ pub mod scheduler;
 use core::{any::Any, cell::SyncUnsafeCell};
 
 use kernel_stack::KernelStack;
-pub(crate) use preempt::cpu_local::reset_preempt_info;
+pub(crate) use preempt::cpu_local::{reset_preempt_info, should_preempt};
 use processor::current_task;
 
 pub use self::{

--- a/ostd/src/task/preempt/cpu_local.rs
+++ b/ostd/src/task/preempt/cpu_local.rs
@@ -23,7 +23,7 @@ use crate::cpu_local_cell;
 /// Returns whether the current task _should_ be preempted or not.
 ///
 /// `should_preempt() == need_preempt() && get_guard_count() == 0`.
-pub(in crate::task) fn should_preempt() -> bool {
+pub(crate) fn should_preempt() -> bool {
     PREEMPT_INFO.load() == 0
 }
 

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -4,18 +4,21 @@ use alloc::boxed::Box;
 
 use spin::Once;
 
-use crate::{arch::irq::IRQ_LIST, cpu_local_cell, task::disable_preempt, trap::TrapFrame};
+use crate::{arch::irq::IRQ_LIST, cpu_local_cell, trap::TrapFrame};
 
 static BOTTOM_HALF_HANDLER: Once<Box<dyn Fn() + Sync + Send>> = Once::new();
 
 /// Register a function to the interrupt bottom half execution.
 ///
-/// The handling of an interrupt can be divided into two parts: top half and bottom half.
-/// Top half typically performs critical tasks and runs at a high priority.
-/// Relatively, bottom half defers less critical tasks to reduce the time spent in
-/// hardware interrupt context, thus allowing the interrupts to be handled more quickly.
+/// The handling of an interrupt can be divided into two parts: top half and
+/// bottom half. Top half typically performs critical tasks and runs at a high
+/// priority. Relatively, bottom half defers less critical tasks to reduce the
+/// time spent in hardware interrupt context, thus allowing the interrupts to
+/// be handled more quickly.
 ///
-/// The bottom half handler will be called after the top half with interrupts enabled.
+/// The bottom half handler will be called after the top half with interrupts
+/// enabled. If preemtion is disabled when the interrupt is raised, the bottom
+/// half handler will be ignored.
 ///
 /// This function can only be registered once. Subsequent calls will do nothing.
 pub fn register_bottom_half_handler<F>(func: F)
@@ -34,10 +37,6 @@ fn process_top_half(trap_frame: &TrapFrame, irq_number: usize) {
 }
 
 fn process_bottom_half() {
-    // We need to disable preemption when processing bottom half since
-    // the interrupt is enabled in this context.
-    let _preempt_guard = disable_preempt();
-
     if let Some(handler) = BOTTOM_HALF_HANDLER.get() {
         handler()
     }
@@ -51,9 +50,14 @@ pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame, irq_number: us
     IN_INTERRUPT_CONTEXT.store(true);
 
     process_top_half(trap_frame, irq_number);
+
     crate::arch::interrupts_ack(irq_number);
+
     crate::arch::irq::enable_local();
-    process_bottom_half();
+
+    if crate::task::should_preempt() {
+        process_bottom_half();
+    }
 
     IN_INTERRUPT_CONTEXT.store(false);
 }


### PR DESCRIPTION
The OSTD user (untrusted components) can execute arbitrary code when the kernel is interrupted, including doing a reschedule. So when preemption is disabled, the bottom half should not be executed at all.

Besides the preemption, the bottom half can also indirectly access all OSTD global locks and they may only disable preemption because they think in the interrupt handler no one can access them. This PR only mitigates part of the problem. The top half code also can be injected so there would still be dead locks in the top half.

Here's some traces that the bottom half trying to allocate pages or modify page table mappings:

<details><summary>Details</summary>
<p>

```
#0  ostd::sync::spin::SpinLock<ostd::mm::page::allocator::CountingFrameAllocator, ostd::sync::spin::PreemptDisabled>::acquire_lock<ostd::mm::page::allocator::CountingFrameAllocator, ostd::sync::spin::PreemptDisabled> (
    self=0xffffffff8850a488 <ostd::mm::page::allocator::PAGE_ALLOCATOR>) at src/sync/spin.rs:151
#1  ostd::sync::spin::SpinLock<ostd::mm::page::allocator::CountingFrameAllocator, ostd::sync::spin::PreemptDisabled>::lock<ostd::mm::page::allocator::CountingFrameAllocator, ostd::sync::spin::PreemptDisabled> (
    self=0xffffffff8850a488 <ostd::mm::page::allocator::PAGE_ALLOCATOR>) at src/sync/spin.rs:114
#2  ostd::mm::page::allocator::alloc<ostd::mm::page::meta::KernelStackMeta, ostd::task::kernel_stack::{impl#0}::new_with_guard_page::{closure_env#0}> (len=32768, metadata_fn=...) at src/mm/page/allocator.rs:121
#3  0xffffffff882e6cf8 in ostd::task::kernel_stack::KernelStack::new_with_guard_page () at src/task/kernel_stack.rs:44
#4  ostd::task::TaskOptions::build (self=...) at src/task/mod.rs:165
#5  0xffffffff881d520e in aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#1} (weak_task=<optimized out>)
    at src/thread/kernel_thread.rs:68
#6  alloc::sync::Arc<ostd::task::Task, alloc::alloc::Global>::new_cyclic_in<ostd::task::Task, alloc::alloc::Global, aster_nix::thread::kernel_thread::create_new_kernel_task::{closure_env#1}> (data_fn=..., alloc=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:795
#7  alloc::sync::Arc<ostd::task::Task, alloc::alloc::Global>::new_cyclic<ostd::task::Task, aster_nix::thread::kernel_thread::create_new_kernel_task::{closure_env#1}> (data_fn=...)
--Type <RET> for more, q to quit, c to continue without paging--
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:454
#8  aster_nix::thread::kernel_thread::create_new_kernel_task (thread_options=...) at src/thread/kernel_thread.rs:53
#9  0xffffffff882389d6 in aster_nix::thread::work_queue::worker::{impl#0}::new::{closure#0} (worker_ref=<optimized out>)
    at src/thread/work_queue/worker.rs:56
#10 alloc::sync::Arc<aster_nix::thread::work_queue::worker::Worker, alloc::alloc::Global>::new_cyclic_in<aster_nix::thread::work_queue::worker::Worker, alloc::alloc::Global, aster_nix::thread::work_queue::worker::{impl#0}::new::{closure_env#0}> (
    data_fn=..., alloc=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:795
#11 alloc::sync::Arc<aster_nix::thread::work_queue::worker::Worker, alloc::alloc::Global>::new_cyclic<aster_nix::thread::work_queue::worker::Worker, aster_nix::thread::work_queue::worker::{impl#0}::new::{closure_env#0}> (data_fn=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:454
#12 aster_nix::thread::work_queue::worker::Worker::new (worker_pool=..., bound_cpu=0) at src/thread/work_queue/worker.rs:43
#13 0xffffffff881d5ae8 in aster_nix::thread::work_queue::worker_pool::LocalWorkerPool::add_worker (self=0xffff800078468c10)
    at src/thread/work_queue/worker_pool.rs:80
#14 aster_nix::thread::work_queue::worker_pool::WorkerPool::add_worker (cpu_id=<optimized out>, self=<optimized out>)
--Type <RET> for more, q to quit, c to continue without paging--
    at src/thread/work_queue/worker_pool.rs:196
#15 aster_nix::thread::work_queue::simple_scheduler::{impl#1}::schedule (self=<optimized out>)
    at src/thread/work_queue/simple_scheduler.rs:32
#16 0xffffffff88239364 in aster_nix::thread::work_queue::worker_pool::WorkerPool::schedule (self=0xffff800078468c90)
    at src/thread/work_queue/worker_pool.rs:163
#17 aster_nix::thread::work_queue::WorkQueue::enqueue (self=<optimized out>, work_item=...)
    at src/thread/work_queue/mod.rs:146
#18 0xffffffff88238f3d in aster_nix::thread::work_queue::submit_work_item (work_item=..., work_priority=<optimized out>)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:2179
#19 0xffffffff88239f39 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=0xffff800078478e98, args=<optimized out>)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2468
#20 aster_nix::time::core::timer::interval_timer_callback (timer=...) at src/time/core/timer.rs:137
#21 aster_nix::time::core::timer::{impl#0}::set_timeout::{closure#0} () at src/time/core/timer.rs:89
#22 0xffffffff8823a3f7 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=<optimized out>, args=<optimized out>)
--Type <RET> for more, q to quit, c to continue without paging--
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2468
#23 aster_nix::time::core::timer::TimerManager::process_expired_timers (self=<optimized out>) at src/time/core/timer.rs:206
#24 0xffffffff8820e0c7 in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=<optimized out>, args=<optimized out>)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2468
#25 aster_nix::time::softirq::timer_softirq_handler () at src/time/softirq.rs:31
#26 core::ops::function::Fn::call<fn(), ()> ()
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79
#27 0xffffffff8823e42a in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=<optimized out>, args=<optimized out>)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2468
#28 aster_softirq::process_pending () at src/lib.rs:165
#29 0xffffffff882ecdfc in alloc::boxed::{impl#50}::call<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=<optimized out>, args=<optimized out>)
--Type <RET> for more, q to quit, c to continue without paging--
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2468
#30 ostd::trap::handler::process_bottom_half () at src/trap/handler.rs:42
#31 ostd::trap::handler::call_irq_callback_functions (trap_frame=<optimized out>, irq_number=33) at src/trap/handler.rs:56
#32 0xffffffff882df880 in ostd::arch::x86::trap::trap_handler (f=0xffffdfffffbff120) at src/arch/x86/trap/mod.rs:251
#33 0xffffffff882e3006 in __from_kernel ()
#34 0x000000000000001b in ?? ()
#35 0x0000000000000002 in ?? ()
#36 0x0000000000000002 in ?? ()
#37 0x000000000000001b in ?? ()
#38 0xffffffff88319680 in ?? ()
#39 0xffffdf001b01c000 in ?? ()
#40 0xffffdfffffbff604 in ?? ()
#41 0xffffdfffffbff1c8 in ?? ()
#42 0x00000000000000c0 in ?? ()
#43 0xffffdfffffbff139 in ?? ()
#44 0xffffffff8838f0c0 in ?? ()
#45 0xffffffff8838f0c1 in ?? ()
--Type <RET> for more, q to quit, c to continue without paging--
#46 0x0000000000000014 in ?? ()
#47 0x0000000000000010 in ?? ()
#48 0x0000000000000001 in ?? ()
#49 0x0000000000000000 in ?? ()
```

```
#0  core::result::Result<u32, u32>::is_ok<u32, u32> (self=<optimized out>)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/macros/mod.rs:475
#1  core::result::Result<u32, u32>::is_err<u32, u32> (self=<optimized out>) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:607
#2  ostd::mm::page::meta::PageTablePageMeta<ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>::lock_write<ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>
    (self=0xffffe000005ffff0) at src/mm/page/meta.rs:254
#3  ostd::mm::page_table::node::RawPageTableNode<ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>::lock_write<ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts> (self=...) at src/mm/page_table/node/mod.rs:88
#4  ostd::mm::page_table::cursor::Cursor<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>::new<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts> (pt=<optimized out>, va=<optimized out>) at src/mm/page_table/cursor.rs:210
#5  0xffffffff882dd3c8 in ostd::mm::page_table::cursor::CursorMut<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>::new<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts> (va=0xffffdfffffffd7d8, pt=<optimized out>) at src/mm/page_table/cursor.rs:380
#6  ostd::mm::page_table::PageTable<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts>::cursor_mut<ostd::mm::page_table::KernelMode, ostd::arch::x86::mm::PageTableEntry, ostd::arch::x86::mm::PagingConsts> (va=0xffffdfffffffd7d8, self=<optimized out>) at src/mm/page_table/mod.rs:236
#7  ostd::mm::kspace::kvirt_area::KVirtArea<ostd::mm::kspace::kvirt_area::Tracked>::map_pages<ostd::mm::page::meta::KernelStackMeta, core::iter::adapters::cloned::Cloned<core::slice::iter::Iter<ostd::mm::page::Page<ostd::mm::page::meta::KernelStackMeta>>>> (self=<optimized out>, range=..., pages=..., prop=...) at src/mm/kspace/kvirt_area.rs:215
#8  0xffffffff882f9cff in ostd::task::kernel_stack::KernelStack::new_with_guard_page () at src/task/kernel_stack.rs:50
#9  ostd::task::TaskOptions::build (self=...) at src/task/mod.rs:165
#10 0xffffffff880c528a in aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#1} (weak_task=<optimized out>) at src/thread/kernel_thread.rs:68
#11 alloc::sync::Arc<ostd::task::Task, alloc::alloc::Global>::new_cyclic_in<ostd::task::Task, alloc::alloc::Global, aster_nix::thread::kernel_thread::create_new_kernel_task::{closure_env#1}> (
    data_fn=..., alloc=...) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:795
#12 alloc::sync::Arc<ostd::task::Task, alloc::alloc::Global>::new_cyclic<ostd::task::Task, aster_nix::thread::kernel_thread::create_new_kernel_task::{closure_env#1}> (data_fn=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:454
#13 aster_nix::thread::kernel_thread::create_new_kernel_task (thread_options=...) at src/thread/kernel_thread.rs:53
#14 0xffffffff880c711c in aster_nix::thread::work_queue::worker_pool::{impl#3}::new::{closure#0} (monitor_ref=<optimized out>) at src/thread/work_queue/worker_pool.rs:249
#15 alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::Monitor, alloc::alloc::Global>::new_cyclic_in<aster_nix::thread::work_queue::worker_pool::Monitor, alloc::alloc::Global, aster_nix::thread::work_queue::worker_pool::{impl#3}::new::{closure_env#0}> (data_fn=..., alloc=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:795
#16 alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::Monitor, alloc::alloc::Global>::new_cyclic<aster_nix::thread::work_queue::worker_pool::Monitor, aster_nix::thread::work_queue::worker_pool::{impl#3}::new::{closure_env#0}> (data_fn=...) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:454
#17 aster_nix::thread::work_queue::worker_pool::Monitor::new (worker_pool=..., priority=0xffffdfffffffdc10) at src/thread/work_queue/worker_pool.rs:234
#18 0xffffffff880c6764 in aster_nix::thread::work_queue::worker_pool::{impl#1}::new::{closure#0} (pool_ref=<optimized out>) at src/thread/work_queue/worker_pool.rs:141
#19 alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>::new_cyclic_in<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global, aster_nix::thread::work_queue::worker_pool::{impl#1}::new::{closure_env#0}> (data_fn=..., alloc=...)
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:795
#20 alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>::new_cyclic<aster_nix::thread::work_queue::worker_pool::WorkerPool, aster_nix::thread::work_queue::worker_pool::{impl#1}::new::{closure_env#0}> (data_fn=...) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:454
#21 aster_nix::thread::work_queue::worker_pool::WorkerPool::new (priority=<optimized out>, cpu_set=...) at src/thread/work_queue/worker_pool.rs:134
#22 0xffffffff880eca21 in aster_nix::thread::work_queue::init::{closure#0} () at src/thread/work_queue/mod.rs:177
#23 spin::once::{impl#4}::call_once::{closure#0}<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, aster_nix::thread::work_queue::init::{closure_env#0}> () at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/spin-0.9.8/src/once.rs:169
#24 spin::once::Once<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin>::try_call_once_slow<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, spin::once::{impl#4}::call_once::{closure_env#0}<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, aster_nix::thread::work_queue::init::{closure_env#0}>, core::convert::Infallible> (self=0xffffffff887fe108 <aster_nix::thread::work_queue::WORKERPOOL_NORMAL>, 
    f=...) at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/spin-0.9.8/src/once.rs:255
#25 0xffffffff880c7b53 in spin::once::Once<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin>::try_call_once<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, spin::once::{impl#4}::call_once::{closure_env#0}<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, aster_nix::thread::work_queue::init::{closure_env#0}>, core::convert::Infallible> (self=<optimized out>, f=...)
    at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/spin-0.9.8/src/once.rs:212
#26 spin::once::Once<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin>::call_once<alloc::sync::Arc<aster_nix::thread::work_queue::worker_pool::WorkerPool, alloc::alloc::Global>, spin::relax::Spin, aster_nix::thread::work_queue::init::{closure_env#0}> ()
    at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/spin-0.9.8/src/once.rs:169
#27 aster_nix::thread::work_queue::init () at src/thread/work_queue/mod.rs:175
#28 0xffffffff881e6337 in aster_nix::init_thread () at src/lib.rs:140
#29 0xffffffff880b7382 in alloc::boxed::{impl#48}::call_once<(), (dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=..., 
    args=<optimized out>) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2454
#30 0xffffffff880af3b6 in unwinding::panicking::catch_unwind::do_call<alloc::boxed::Box<(dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global>, ()> (data=<optimized out>) at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panicking.rs:54
#31 unwinding::panicking::catch_unwind<unwinding::panic::RustPanic, (), alloc::boxed::Box<(dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global>> (f=...) at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panicking.rs:42
#32 unwinding::panic::catch_unwind<(), alloc::boxed::Box<(dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global>> (f=...)
    at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panic.rs:87
#33 aster_nix::thread::oops::catch_panics_as_oops<alloc::boxed::Box<(dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global>, ()> (f=...)
    at src/thread/oops.rs:54
#34 aster_nix::thread::kernel_thread::create_new_kernel_task::{closure#0} () at src/thread/kernel_thread.rs:48
#35 core::ops::function::FnOnce::call_once<aster_nix::thread::kernel_thread::create_new_kernel_task::{closure_env#0}, ()> ()
    at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
#36 0xffffffff882fa07d in alloc::boxed::{impl#48}::call_once<(), (dyn core::ops::function::FnOnce<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> (self=..., 
    args=<optimized out>) at /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2454
#37 ostd::task::{impl#1}::build::kernel_task_entry () at src/task/mod.rs:161
#38 0x0000000000000000 in ?? ()
```

</p>
</details> 