### PR TITLE
Use more `wait_events`

### DIFF
--- a/kernel/src/device/null.rs
+++ b/kernel/src/device/null.rs
@@ -3,7 +3,12 @@
 #![allow(unused_variables)]
 
 use super::*;
-use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
+use crate::{
+    events::IoEvents,
+    fs::inode_handle::FileIo,
+    prelude::*,
+    process::signal::{Pollable, Poller},
+};
 
 pub struct Null;
 
@@ -22,6 +27,13 @@ impl Device for Null {
     }
 }
 
+impl Pollable for Null {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+}
+
 impl FileIo for Null {
     fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
         Ok(0)
@@ -29,10 +41,5 @@ impl FileIo for Null {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         Ok(reader.remain())
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        let events = IoEvents::IN | IoEvents::OUT;
-        events & mask
     }
 }

--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -138,7 +138,7 @@ impl FileIo for PtyMaster {
         }
 
         // TODO: deal with nonblocking and timeout
-        self.wait_events(IoEvents::IN, || self.try_read(writer))
+        self.wait_events(IoEvents::IN, None, || self.try_read(writer))
     }
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {

--- a/kernel/src/device/random.rs
+++ b/kernel/src/device/random.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::Poller,
+    process::signal::{Pollable, Poller},
     util::random::getrandom,
 };
 
@@ -37,6 +37,13 @@ impl Device for Random {
     }
 }
 
+impl Pollable for Random {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+}
+
 impl FileIo for Random {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         let mut buf = vec![0; writer.avail()];
@@ -45,10 +52,5 @@ impl FileIo for Random {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         Ok(reader.remain())
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        let events = IoEvents::IN | IoEvents::OUT;
-        events & mask
     }
 }

--- a/kernel/src/device/tdxguest/mod.rs
+++ b/kernel/src/device/tdxguest/mod.rs
@@ -57,6 +57,13 @@ impl From<TdCallError> for Error {
     }
 }
 
+impl Pollable for TdxGuest {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+}
+
 impl FileIo for TdxGuest {
     fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
         return_errno_with_message!(Errno::EPERM, "Read operation not supported")
@@ -71,11 +78,6 @@ impl FileIo for TdxGuest {
             IoctlCmd::TDXGETREPORT => handle_get_report(arg),
             _ => return_errno_with_message!(Errno::EPERM, "Unsupported ioctl"),
         }
-    }
-
-    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
-        let events = IoEvents::IN | IoEvents::OUT;
-        events & mask
     }
 }
 

--- a/kernel/src/device/tty/device.rs
+++ b/kernel/src/device/tty/device.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::Poller,
+    process::signal::{Pollable, Poller},
 };
 
 /// Corresponds to `/dev/tty` in the file system. This device represents the controlling terminal
@@ -40,6 +40,12 @@ impl Device for TtyDevice {
     }
 }
 
+impl Pollable for TtyDevice {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
 impl FileIo for TtyDevice {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot read tty device");
@@ -47,9 +53,5 @@ impl FileIo for TtyDevice {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot write tty device");
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        IoEvents::empty()
     }
 }

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -235,7 +235,7 @@ impl LineDiscipline {
     }
 
     pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        self.wait_events(IoEvents::IN, || self.try_read(buf))
+        self.wait_events(IoEvents::IN, None, || self.try_read(buf))
     }
 
     /// Reads all bytes buffered to `dst`.

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     get_current_userspace,
     prelude::*,
     process::{
-        signal::{signals::kernel::KernelSignal, Poller},
+        signal::{signals::kernel::KernelSignal, Pollable, Poller},
         JobControl, Process, Terminal,
     },
 };
@@ -72,6 +72,12 @@ impl Tty {
     }
 }
 
+impl Pollable for Tty {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        self.ldisc.poll(mask, poller)
+    }
+}
+
 impl FileIo for Tty {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         let mut buf = vec![0; writer.avail()];
@@ -89,10 +95,6 @@ impl FileIo for Tty {
             println!("Not utf-8 content: {:?}", buf);
         }
         Ok(buf.len())
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        self.ldisc.poll(mask, poller)
     }
 
     fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32> {

--- a/kernel/src/device/urandom.rs
+++ b/kernel/src/device/urandom.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::Poller,
+    process::signal::{Pollable, Poller},
     util::random::getrandom,
 };
 
@@ -37,6 +37,13 @@ impl Device for Urandom {
     }
 }
 
+impl Pollable for Urandom {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+}
+
 impl FileIo for Urandom {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         let mut buf = vec![0; writer.avail()];
@@ -45,10 +52,5 @@ impl FileIo for Urandom {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         Ok(reader.remain())
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        let events = IoEvents::IN | IoEvents::OUT;
-        events & mask
     }
 }

--- a/kernel/src/device/zero.rs
+++ b/kernel/src/device/zero.rs
@@ -3,7 +3,12 @@
 #![allow(unused_variables)]
 
 use super::*;
-use crate::{events::IoEvents, fs::inode_handle::FileIo, prelude::*, process::signal::Poller};
+use crate::{
+    events::IoEvents,
+    fs::inode_handle::FileIo,
+    prelude::*,
+    process::signal::{Pollable, Poller},
+};
 
 pub struct Zero;
 
@@ -22,6 +27,13 @@ impl Device for Zero {
     }
 }
 
+impl Pollable for Zero {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+}
+
 impl FileIo for Zero {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         let read_len = writer.fill_zeros(writer.avail())?;
@@ -30,10 +42,5 @@ impl FileIo for Zero {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         Ok(reader.remain())
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        let events = IoEvents::IN | IoEvents::OUT;
-        events & mask
     }
 }

--- a/kernel/src/fs/device.rs
+++ b/kernel/src/fs/device.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// The abstract of device
-pub trait Device: Sync + Send + FileIo {
+pub trait Device: FileIo {
     /// Return the device type.
     fn type_(&self) -> DeviceType;
 

--- a/kernel/src/fs/devpts/ptmx.rs
+++ b/kernel/src/fs/devpts/ptmx.rs
@@ -4,7 +4,11 @@
 #![allow(unused_variables)]
 
 use super::*;
-use crate::{events::IoEvents, fs::inode_handle::FileIo, process::signal::Poller};
+use crate::{
+    events::IoEvents,
+    fs::inode_handle::FileIo,
+    process::signal::{Pollable, Poller},
+};
 
 /// Same major number with Linux.
 const PTMX_MAJOR_NUM: u32 = 5;
@@ -177,6 +181,12 @@ impl Device for Inner {
     }
 }
 
+impl Pollable for Inner {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
 impl FileIo for Inner {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot read ptmx");
@@ -184,9 +194,5 @@ impl FileIo for Inner {
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot write ptmx");
-    }
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
-        IoEvents::empty()
     }
 }

--- a/kernel/src/fs/devpts/slave.rs
+++ b/kernel/src/fs/devpts/slave.rs
@@ -5,7 +5,10 @@
 
 use super::*;
 use crate::{
-    device::PtySlave, events::IoEvents, fs::inode_handle::FileIo, process::signal::Poller,
+    device::PtySlave,
+    events::IoEvents,
+    fs::inode_handle::FileIo,
+    process::signal::{Pollable, Poller},
 };
 
 /// Same major number with Linux, the minor number is the index of slave.

--- a/kernel/src/fs/epoll/epoll_file.rs
+++ b/kernel/src/fs/epoll/epoll_file.rs
@@ -191,34 +191,21 @@ impl EpollFile {
     /// expires or a signal arrives.
     pub fn wait(&self, max_events: usize, timeout: Option<&Duration>) -> Result<Vec<EpollEvent>> {
         let mut ep_events = Vec::new();
-        let mut poller = None;
-        loop {
-            // Try to pop some ready entries
+
+        self.wait_events(IoEvents::IN, timeout, || {
             self.pop_multi_ready(max_events, &mut ep_events);
-            if !ep_events.is_empty() {
-                return Ok(ep_events);
+
+            if ep_events.is_empty() {
+                return Err(Error::with_message(
+                    Errno::EAGAIN,
+                    "there are no available events",
+                ));
             }
 
-            // Return immediately if specifying a timeout of zero
-            if timeout.is_some() && timeout.as_ref().unwrap().is_zero() {
-                return Ok(ep_events);
-            }
+            Ok(())
+        })?;
 
-            // If no ready entries for now, wait for them
-            if poller.is_none() {
-                poller = Some(Poller::new());
-                let events = self.pollee.poll(IoEvents::IN, poller.as_mut());
-                if !events.is_empty() {
-                    continue;
-                }
-            }
-
-            if let Some(timeout) = timeout {
-                poller.as_ref().unwrap().wait_timeout(timeout)?;
-            } else {
-                poller.as_ref().unwrap().wait()?;
-            }
-        }
+        Ok(ep_events)
     }
 
     fn push_ready(&self, entry: Arc<EpollEntry>) {

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -25,7 +25,10 @@ use crate::{
         },
     },
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{
+        signal::{Pollable, Poller},
+        Gid, Uid,
+    },
 };
 
 #[derive(Debug)]
@@ -389,12 +392,10 @@ impl<R> Drop for InodeHandle<R> {
     }
 }
 
-pub trait FileIo: Send + Sync + 'static {
+pub trait FileIo: Pollable + Send + Sync + 'static {
     fn read(&self, writer: &mut VmWriter) -> Result<usize>;
 
     fn write(&self, reader: &mut VmReader) -> Result<usize>;
-
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
 
     fn ioctl(&self, cmd: IoctlCmd, arg: usize) -> Result<i32> {
         return_errno_with_message!(Errno::EINVAL, "ioctl is not supported");

--- a/kernel/src/fs/pipe.rs
+++ b/kernel/src/fs/pipe.rs
@@ -63,7 +63,7 @@ impl FileLike for PipeReader {
         let read_len = if self.status_flags().contains(StatusFlags::O_NONBLOCK) {
             self.consumer.try_read(writer)?
         } else {
-            self.wait_events(IoEvents::IN, || self.consumer.try_read(writer))?
+            self.wait_events(IoEvents::IN, None, || self.consumer.try_read(writer))?
         };
         Ok(read_len)
     }
@@ -146,7 +146,7 @@ impl FileLike for PipeWriter {
         if self.status_flags().contains(StatusFlags::O_NONBLOCK) {
             self.producer.try_write(reader)
         } else {
-            self.wait_events(IoEvents::OUT, || self.producer.try_write(reader))
+            self.wait_events(IoEvents::OUT, None, || self.producer.try_write(reader))
         }
     }
 

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -172,7 +172,7 @@ impl DatagramSocket {
         if self.is_nonblocking() {
             self.try_recv(writer, flags)
         } else {
-            self.wait_events(IoEvents::IN, || self.try_recv(writer, flags))
+            self.wait_events(IoEvents::IN, None, || self.try_recv(writer, flags))
         }
     }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -315,7 +315,7 @@ impl StreamSocket {
         if self.is_nonblocking() {
             self.try_recv(writer, flags)
         } else {
-            self.wait_events(IoEvents::IN, || self.try_recv(writer, flags))
+            self.wait_events(IoEvents::IN, None, || self.try_recv(writer, flags))
         }
     }
 
@@ -347,7 +347,7 @@ impl StreamSocket {
         if self.is_nonblocking() {
             self.try_send(reader, flags)
         } else {
-            self.wait_events(IoEvents::OUT, || self.try_send(reader, flags))
+            self.wait_events(IoEvents::OUT, None, || self.try_send(reader, flags))
         }
     }
 
@@ -466,7 +466,7 @@ impl Socket for StreamSocket {
             return result;
         }
 
-        self.wait_events(IoEvents::OUT, || self.check_connect())
+        self.wait_events(IoEvents::OUT, None, || self.check_connect())
     }
 
     fn listen(&self, backlog: usize) -> Result<()> {
@@ -505,7 +505,7 @@ impl Socket for StreamSocket {
         if self.is_nonblocking() {
             self.try_accept()
         } else {
-            self.wait_events(IoEvents::IN, || self.try_accept())
+            self.wait_events(IoEvents::IN, None, || self.try_accept())
         }
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -66,7 +66,7 @@ impl UnixStreamSocket {
         if self.is_nonblocking() {
             self.try_send(reader, flags)
         } else {
-            self.wait_events(IoEvents::OUT, || self.try_send(reader, flags))
+            self.wait_events(IoEvents::OUT, None, || self.try_send(reader, flags))
         }
     }
 
@@ -83,7 +83,7 @@ impl UnixStreamSocket {
         if self.is_nonblocking() {
             self.try_recv(writer, flags)
         } else {
-            self.wait_events(IoEvents::IN, || self.try_recv(writer, flags))
+            self.wait_events(IoEvents::IN, None, || self.try_recv(writer, flags))
         }
     }
 
@@ -283,7 +283,7 @@ impl Socket for UnixStreamSocket {
         if self.is_nonblocking() {
             self.try_accept()
         } else {
-            self.wait_events(IoEvents::IN, || self.try_accept())
+            self.wait_events(IoEvents::IN, None, || self.try_accept())
         }
     }
 

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -122,7 +122,7 @@ impl VsockStreamSocket {
         if self.is_nonblocking() {
             self.try_recv(writer, flags)
         } else {
-            self.wait_events(IoEvents::IN, || self.try_recv(writer, flags))
+            self.wait_events(IoEvents::IN, None, || self.try_recv(writer, flags))
         }
     }
 }
@@ -223,7 +223,7 @@ impl Socket for VsockStreamSocket {
             .poll(IoEvents::IN, Some(&mut poller))
             .contains(IoEvents::IN)
         {
-            if let Err(e) = poller.wait() {
+            if let Err(e) = poller.wait(None) {
                 vsockspace
                     .remove_connecting_socket(&connecting.local_addr())
                     .unwrap();
@@ -272,7 +272,7 @@ impl Socket for VsockStreamSocket {
         if self.is_nonblocking() {
             self.try_accept()
         } else {
-            self.wait_events(IoEvents::IN, || self.try_accept())
+            self.wait_events(IoEvents::IN, None, || self.try_accept())
         }
     }
 

--- a/kernel/src/process/process/terminal.rs
+++ b/kernel/src/process/process/terminal.rs
@@ -11,7 +11,7 @@ use crate::{
 /// job control.
 ///
 /// We currently support two kinds of terminal, the tty and pty.
-pub trait Terminal: Send + Sync + FileIo {
+pub trait Terminal: FileIo {
     // *************** Foreground ***************
 
     /// Returns the foreground process group

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -190,7 +190,7 @@ impl FileLike for EventFile {
         if self.is_nonblocking() {
             self.try_read(writer)?;
         } else {
-            self.wait_events(IoEvents::IN, || self.try_read(writer))?;
+            self.wait_events(IoEvents::IN, None, || self.try_read(writer))?;
         }
 
         Ok(read_len)

--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -72,7 +72,7 @@ pub fn do_sys_select(
         readfds.as_mut(),
         writefds.as_mut(),
         exceptfds.as_mut(),
-        timeout,
+        timeout.as_ref(),
         ctx,
     )?;
 
@@ -100,7 +100,7 @@ fn do_select(
     mut readfds: Option<&mut FdSet>,
     mut writefds: Option<&mut FdSet>,
     mut exceptfds: Option<&mut FdSet>,
-    timeout: Option<Duration>,
+    timeout: Option<&Duration>,
     ctx: &Context,
 ) -> Result<usize> {
     // Convert the FdSet to an array of PollFd


### PR DESCRIPTION
~~*Depends on https://github.com/asterinas/asterinas/pull/1496 to avoid conflicts.*~~

We now have `Pollable::wait_events`. However, many subsystems built before the introduction of this method do not use it.

This PR identifies such cases and refactors the code to make use of `Pollable::wait_events`, so that the redundant code can be avoided.