### PR TITLE
 Remove `{,un}register_observer` from `FileLike`

### DIFF
--- a/kernel/src/device/null.rs
+++ b/kernel/src/device/null.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::inode_handle::FileIo,
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 pub struct Null;
@@ -28,7 +28,7 @@ impl Device for Null {
 }
 
 impl Pollable for Null {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -16,7 +16,7 @@ use crate::{
     get_current_userspace,
     prelude::*,
     process::{
-        signal::{Pollable, Pollee, Poller},
+        signal::{PollHandle, Pollable, Pollee},
         JobControl, Terminal,
     },
     util::ring_buffer::RingBuffer,
@@ -67,7 +67,11 @@ impl PtyMaster {
         self.update_state(&input);
     }
 
-    pub(super) fn slave_poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+    pub(super) fn slave_poll(
+        &self,
+        mask: IoEvents,
+        mut poller: Option<&mut PollHandle>,
+    ) -> IoEvents {
         let mut poll_status = IoEvents::empty();
 
         let poll_in_mask = mask & IoEvents::IN;
@@ -112,7 +116,7 @@ impl PtyMaster {
 }
 
 impl Pollable for PtyMaster {
-    fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, mut poller: Option<&mut PollHandle>) -> IoEvents {
         let mut poll_status = IoEvents::empty();
 
         let poll_in_mask = mask & IoEvents::IN;
@@ -322,7 +326,7 @@ impl Terminal for PtySlave {
 }
 
 impl Pollable for PtySlave {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.master().slave_poll(mask, poller)
     }
 }

--- a/kernel/src/device/random.rs
+++ b/kernel/src/device/random.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
     util::random::getrandom,
 };
 
@@ -38,7 +38,7 @@ impl Device for Random {
 }
 
 impl Pollable for Random {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/device/tdxguest/mod.rs
+++ b/kernel/src/device/tdxguest/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     error::Error,
     events::IoEvents,
     fs::{inode_handle::FileIo, utils::IoctlCmd},
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 const TDX_REPORTDATA_LEN: usize = 64;
@@ -58,7 +58,7 @@ impl From<TdCallError> for Error {
 }
 
 impl Pollable for TdxGuest {
-    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/device/tty/device.rs
+++ b/kernel/src/device/tty/device.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 /// Corresponds to `/dev/tty` in the file system. This device represents the controlling terminal
@@ -41,7 +41,7 @@ impl Device for TtyDevice {
 }
 
 impl Pollable for TtyDevice {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         IoEvents::empty()
     }
 }

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -16,7 +16,7 @@ use crate::{
     process::signal::{
         constants::{SIGINT, SIGQUIT},
         signals::kernel::KernelSignal,
-        Pollable, Pollee, Poller,
+        PollHandle, Pollable, Pollee,
     },
     thread::work_queue::{submit_work_item, work_item::WorkItem, WorkPriority},
     util::ring_buffer::RingBuffer,
@@ -88,7 +88,7 @@ impl CurrentLine {
 }
 
 impl Pollable for LineDiscipline {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     get_current_userspace,
     prelude::*,
     process::{
-        signal::{signals::kernel::KernelSignal, Pollable, Poller},
+        signal::{signals::kernel::KernelSignal, PollHandle, Pollable},
         JobControl, Process, Terminal,
     },
 };
@@ -73,7 +73,7 @@ impl Tty {
 }
 
 impl Pollable for Tty {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.ldisc.poll(mask, poller)
     }
 }

--- a/kernel/src/device/urandom.rs
+++ b/kernel/src/device/urandom.rs
@@ -9,7 +9,7 @@ use crate::{
         inode_handle::FileIo,
     },
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
     util::random::getrandom,
 };
 
@@ -38,7 +38,7 @@ impl Device for Urandom {
 }
 
 impl Pollable for Urandom {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/device/zero.rs
+++ b/kernel/src/device/zero.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::inode_handle::FileIo,
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 pub struct Zero;
@@ -28,7 +28,7 @@ impl Device for Zero {
 }
 
 impl Pollable for Zero {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/fs/devpts/ptmx.rs
+++ b/kernel/src/fs/devpts/ptmx.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::{
     events::IoEvents,
     fs::inode_handle::FileIo,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 /// Same major number with Linux.
@@ -182,7 +182,7 @@ impl Device for Inner {
 }
 
 impl Pollable for Inner {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         IoEvents::empty()
     }
 }

--- a/kernel/src/fs/devpts/slave.rs
+++ b/kernel/src/fs/devpts/slave.rs
@@ -8,7 +8,7 @@ use crate::{
     device::PtySlave,
     events::IoEvents,
     fs::inode_handle::FileIo,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 /// Same major number with Linux, the minor number is the index of slave.
@@ -136,7 +136,7 @@ impl Inode for PtySlaveInode {
         self.device.ioctl(cmd, arg)
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.device.poll(mask, poller)
     }
 

--- a/kernel/src/fs/epoll/epoll_file.rs
+++ b/kernel/src/fs/epoll/epoll_file.rs
@@ -344,22 +344,6 @@ impl FileLike for EpollFile {
         return_errno_with_message!(Errno::EINVAL, "epoll files do not support ioctl");
     }
 
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
-    }
-
     fn metadata(&self) -> Metadata {
         // This is a dummy implementation.
         // TODO: Add "anonymous inode fs" and link `EpollFile` to it.

--- a/kernel/src/fs/epoll/epoll_file.rs
+++ b/kernel/src/fs/epoll/epoll_file.rs
@@ -104,7 +104,7 @@ impl EpollFile {
             }
 
             let entry = EpollEntry::new(fd, Arc::downgrade(&file).into(), self.weak_self.clone());
-            let events = entry.update(ep_event, ep_flags)?;
+            let events = entry.update(ep_event, ep_flags);
 
             let ready_entry = if !events.is_empty() {
                 Some(entry.clone())
@@ -165,7 +165,7 @@ impl EpollFile {
                 .ok_or_else(|| {
                     Error::with_message(Errno::ENOENT, "the file is not in the interest list")
                 })?;
-            let events = entry.update(new_ep_event, new_ep_flags)?;
+            let events = entry.update(new_ep_event, new_ep_flags);
 
             if !events.is_empty() {
                 Some(entry.clone())
@@ -416,18 +416,7 @@ impl From<(FileDesc, &Arc<dyn FileLike>)> for EpollEntryKey {
 struct EpollEntryInner {
     event: EpollEvent,
     flags: EpollFlags,
-}
-
-impl Default for EpollEntryInner {
-    fn default() -> Self {
-        Self {
-            event: EpollEvent {
-                events: IoEvents::empty(),
-                user_data: 0,
-            },
-            flags: EpollFlags::empty(),
-        }
-    }
+    poller: PollHandle,
 }
 
 impl EpollEntry {
@@ -437,13 +426,24 @@ impl EpollEntry {
         file: KeyableWeak<dyn FileLike>,
         weak_epoll: Weak<EpollFile>,
     ) -> Arc<Self> {
-        Arc::new_cyclic(|me| Self {
-            key: EpollEntryKey { fd, file },
-            inner: Mutex::new(EpollEntryInner::default()),
-            is_enabled: AtomicBool::new(false),
-            is_ready: AtomicBool::new(false),
-            weak_epoll,
-            weak_self: me.clone(),
+        Arc::new_cyclic(|me| {
+            let inner = EpollEntryInner {
+                event: EpollEvent {
+                    events: IoEvents::empty(),
+                    user_data: 0,
+                },
+                flags: EpollFlags::empty(),
+                poller: PollHandle::new(me.clone() as _),
+            };
+
+            Self {
+                key: EpollEntryKey { fd, file },
+                inner: Mutex::new(inner),
+                is_enabled: AtomicBool::new(false),
+                is_ready: AtomicBool::new(false),
+                weak_epoll,
+                weak_self: me.clone(),
+            }
         })
     }
 
@@ -455,11 +455,6 @@ impl EpollEntry {
     /// Get an instance of `Arc` that refers to this epoll entry.
     pub fn self_arc(&self) -> Arc<Self> {
         self.weak_self.upgrade().unwrap()
-    }
-
-    /// Get an instance of `Weak` that refers to this epoll entry.
-    pub fn self_weak(&self) -> Weak<Self> {
-        self.weak_self.clone()
     }
 
     /// Get the file associated with this epoll entry.
@@ -513,30 +508,27 @@ impl EpollEntry {
     /// Updates the epoll entry by the given event masks and flags.
     ///
     /// This method needs to be called in response to `EpollCtl::Add` and `EpollCtl::Mod`.
-    pub fn update(&self, event: EpollEvent, flags: EpollFlags) -> Result<IoEvents> {
+    pub fn update(&self, event: EpollEvent, flags: EpollFlags) -> IoEvents {
         let file = self.file().unwrap();
 
         let mut inner = self.inner.lock();
 
-        file.register_observer(self.self_weak(), event.events)?;
-        *inner = EpollEntryInner { event, flags };
+        inner.event = event;
+        inner.flags = flags;
 
         self.set_enabled(&inner);
-        let events = file.poll(event.events, None);
 
-        Ok(events)
+        file.poll(event.events, Some(&mut inner.poller))
     }
 
     /// Shuts down the epoll entry.
     ///
     /// This method needs to be called in response to `EpollCtl::Del`.
     pub fn shutdown(&self) {
-        let inner = self.inner.lock();
+        let mut inner = self.inner.lock();
 
-        if let Some(file) = self.file() {
-            file.unregister_observer(&(self.self_weak() as _)).unwrap();
-        };
         self.reset_enabled(&inner);
+        inner.poller.reset();
     }
 
     /// Returns whether the epoll entry is in the ready list.

--- a/kernel/src/fs/epoll/epoll_file.rs
+++ b/kernel/src/fs/epoll/epoll_file.rs
@@ -16,7 +16,7 @@ use crate::{
         file_handle::FileLike,
         utils::{InodeMode, IoctlCmd, Metadata},
     },
-    process::signal::{Pollable, Pollee, Poller},
+    process::signal::{PollHandle, Pollable, Pollee},
 };
 
 /// A file-like object that provides epoll API.
@@ -326,7 +326,7 @@ impl EpollFile {
 }
 
 impl Pollable for EpollFile {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -35,7 +35,7 @@ use crate::{
         },
     },
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{signal::PollHandle, Gid, Uid},
     vm::vmo::Vmo,
 };
 
@@ -1695,7 +1695,7 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/fs/file_handle.rs
+++ b/kernel/src/fs/file_handle.rs
@@ -5,7 +5,6 @@
 //! Opened File Handle
 
 use crate::{
-    events::{IoEvents, Observer},
     fs::{
         device::Device,
         utils::{AccessMode, FallocMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags},
@@ -99,22 +98,6 @@ pub trait FileLike: Pollable + Send + Sync + Any {
 
     fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "fallocate is not supported");
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "register_observer is not supported")
-    }
-
-    #[must_use]
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        None
     }
 
     fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {

--- a/kernel/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/src/fs/inode_handle/dyn_cap.rs
@@ -77,7 +77,7 @@ impl Clone for InodeHandle<Rights> {
 
 #[inherit_methods(from = "self.0")]
 impl Pollable for InodeHandle<Rights> {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents;
 }
 
 #[inherit_methods(from = "self.0")]

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        signal::{Pollable, Poller},
+        signal::{PollHandle, Pollable},
         Gid, Uid,
     },
 };
@@ -189,7 +189,7 @@ impl InodeHandle_ {
         Ok(read_cnt)
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         if let Some(ref file_io) = self.file_io {
             return file_io.poll(mask, poller);
         }

--- a/kernel/src/fs/named_pipe.rs
+++ b/kernel/src/fs/named_pipe.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     events::IoEvents,
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
 };
 
 pub struct NamedPipe {
@@ -31,7 +31,7 @@ impl NamedPipe {
 }
 
 impl Pollable for NamedPipe {
-    fn poll(&self, _mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
         warn!("Named pipe doesn't support poll now, return IoEvents::empty for now.");
         IoEvents::empty()
     }

--- a/kernel/src/fs/pipe.rs
+++ b/kernel/src/fs/pipe.rs
@@ -10,7 +10,7 @@ use crate::{
     events::{IoEvents, Observer},
     prelude::*,
     process::{
-        signal::{Pollable, Poller},
+        signal::{PollHandle, Pollable},
         Gid, Uid,
     },
     time::clocks::RealTimeCoarseClock,
@@ -53,7 +53,7 @@ impl PipeReader {
 }
 
 impl Pollable for PipeReader {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.consumer.poll(mask, poller)
     }
 }
@@ -138,7 +138,7 @@ impl PipeWriter {
 }
 
 impl Pollable for PipeWriter {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.producer.poll(mask, poller)
     }
 }

--- a/kernel/src/fs/pipe.rs
+++ b/kernel/src/fs/pipe.rs
@@ -7,7 +7,7 @@ use super::{
     utils::{AccessMode, Channel, Consumer, InodeMode, InodeType, Metadata, Producer, StatusFlags},
 };
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     prelude::*,
     process::{
         signal::{PollHandle, Pollable},
@@ -104,21 +104,6 @@ impl FileLike for PipeReader {
             rdev: 0,
         }
     }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.consumer.register_observer(observer, mask)
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.consumer.unregister_observer(observer)
-    }
 }
 
 pub struct PipeWriter {
@@ -187,21 +172,6 @@ impl FileLike for PipeWriter {
             gid: Gid::new_root(),
             rdev: 0,
         }
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.producer.register_observer(observer, mask)
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.producer.unregister_observer(observer)
     }
 }
 

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -28,7 +28,7 @@ use crate::{
         },
     },
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{signal::PollHandle, Gid, Uid},
     time::clocks::RealTimeCoarseClock,
     vm::vmo::Vmo,
 };
@@ -1120,7 +1120,7 @@ impl Inode for RamInode {
         }
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         if !self.typ.is_device() {
             return (IoEvents::IN | IoEvents::OUT) & mask;
         }

--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -8,7 +8,7 @@ use aster_rights_proc::require;
 use crate::{
     events::{IoEvents, Observer},
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
     util::{
         ring_buffer::{RbConsumer, RbProducer, RingBuffer},
         MultiRead, MultiWrite,
@@ -82,7 +82,7 @@ macro_rules! impl_common_methods_for_channel {
             self.0.common.is_shutdown()
         }
 
-        pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+        pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
             self.this_end().pollee.poll(mask, poller)
         }
 

--- a/kernel/src/fs/utils/inode.rs
+++ b/kernel/src/fs/utils/inode.rs
@@ -12,7 +12,7 @@ use crate::{
     events::IoEvents,
     fs::device::{Device, DeviceType},
     prelude::*,
-    process::{signal::Poller, Gid, Uid},
+    process::{signal::PollHandle, Gid, Uid},
     time::clocks::RealTimeCoarseClock,
     vm::vmo::Vmo,
 };
@@ -398,7 +398,7 @@ pub trait Inode: Any + Sync + Send {
         return_errno!(Errno::EOPNOTSUPP);
     }
 
-    fn poll(&self, mask: IoEvents, _poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
         let events = IoEvents::IN | IoEvents::OUT;
         events & mask
     }

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         },
     },
     prelude::*,
-    process::signal::{Pollable, Pollee, Poller},
+    process::signal::{PollHandle, Pollable, Pollee},
     util::{MultiRead, MultiWrite},
 };
 
@@ -209,7 +209,7 @@ impl DatagramSocket {
 }
 
 impl Pollable for DatagramSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -8,7 +8,7 @@ use takeable::Takeable;
 use self::{bound::BoundDatagram, unbound::UnboundDatagram};
 use super::{common::get_ephemeral_endpoint, UNSPECIFIED_LOCAL_ENDPOINT};
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::{
         file_handle::FileLike,
         utils::{InodeMode, Metadata, StatusFlags},
@@ -257,22 +257,6 @@ impl FileLike for DatagramSocket {
             self.set_nonblocking(false);
         }
         Ok(())
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
     }
 
     fn metadata(&self) -> Metadata {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         },
     },
     prelude::*,
-    process::signal::{Pollable, Pollee, Poller},
+    process::signal::{PollHandle, Pollable, Pollee},
     util::{MultiRead, MultiWrite},
 };
 
@@ -376,7 +376,7 @@ impl StreamSocket {
 }
 
 impl Pollable for StreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -14,7 +14,7 @@ use util::TcpOptionSet;
 
 use super::UNSPECIFIED_LOCAL_ENDPOINT;
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::{
         file_handle::FileLike,
         utils::{InodeMode, Metadata, StatusFlags},
@@ -414,22 +414,6 @@ impl FileLike for StreamSocket {
 
     fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
         Some(self)
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
     }
 
     fn metadata(&self) -> Metadata {

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -12,7 +12,7 @@ use crate::{
         SockShutdownCmd,
     },
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
     util::{MultiRead, MultiWrite},
 };
 
@@ -89,7 +89,7 @@ impl Connected {
         }
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut PollHandle>) -> IoEvents {
         // Note that `mask | IoEvents::ALWAYS_POLL` contains all the events we care about.
         let reader_events = self.reader.poll(mask, poller.as_deref_mut());
         let writer_events = self.writer.poll(mask, poller);

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 use ostd::sync::PreemptDisabled;
 
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::utils::{Channel, Consumer, Producer},
     net::socket::{
         unix::{addr::UnixSocketAddrBound, UnixSocketAddr},
@@ -95,25 +95,6 @@ impl Connected {
         let writer_events = self.writer.poll(mask, poller);
 
         combine_io_events(mask, reader_events, writer_events)
-    }
-
-    pub(super) fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.reader.register_observer(observer.clone(), mask)?;
-        self.writer.register_observer(observer, mask)?;
-        Ok(())
-    }
-
-    pub(super) fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        let reader_observer = self.reader.unregister_observer(observer);
-        let writer_observer = self.writer.unregister_observer(observer);
-        reader_observer.or(writer_observer)
     }
 }
 

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -7,7 +7,7 @@ use super::{
     listener::Listener,
 };
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     net::socket::{
         unix::addr::{UnixSocketAddr, UnixSocketAddrBound},
         SockShutdownCmd,
@@ -121,26 +121,5 @@ impl Init {
         // According to the Linux implementation, we always have `IoEvents::HUP` in this state.
         // Meanwhile, it is in `IoEvents::ALWAYS_POLL`, so we always return it.
         combine_io_events(mask, reader_events, writer_events) | IoEvents::HUP
-    }
-
-    pub(super) fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        // To avoid loss of events, this must be compatible with
-        // `Connected::poll`/`Listener::poll`.
-        self.reader_pollee.register_observer(observer.clone(), mask);
-        self.writer_pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub(super) fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        let reader_observer = self.reader_pollee.unregister_observer(observer);
-        let writer_observer = self.writer_pollee.unregister_observer(observer);
-        reader_observer.or(writer_observer)
     }
 }

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -13,7 +13,7 @@ use crate::{
         SockShutdownCmd,
     },
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
 };
 
 pub(super) struct Init {
@@ -112,7 +112,7 @@ impl Init {
         self.addr.as_ref()
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut PollHandle>) -> IoEvents {
         // To avoid loss of events, this must be compatible with
         // `Connected::poll`/`Listener::poll`.
         let reader_events = self.reader_pollee.poll(mask, poller.as_deref_mut());

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -10,7 +10,7 @@ use super::{
     UnixStreamSocket,
 };
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::file_handle::FileLike,
     net::socket::{
         unix::addr::{UnixSocketAddrBound, UnixSocketAddrKey},
@@ -83,25 +83,6 @@ impl Listener {
         let writer_events = self.writer_pollee.poll(mask, poller);
 
         combine_io_events(mask, reader_events, writer_events)
-    }
-
-    pub(super) fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.backlog.register_observer(observer.clone(), mask)?;
-        self.writer_pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    pub(super) fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        let reader_observer = self.backlog.unregister_observer(observer);
-        let writer_observer = self.writer_pollee.unregister_observer(observer);
-        reader_observer.or(writer_observer)
     }
 }
 
@@ -228,22 +209,6 @@ impl Backlog {
 
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
     }
 }
 

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -17,7 +17,7 @@ use crate::{
         SockShutdownCmd, SocketAddr,
     },
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
 };
 
 pub(super) struct Listener {
@@ -78,7 +78,7 @@ impl Listener {
         }
     }
 
-    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut Poller>) -> IoEvents {
+    pub(super) fn poll(&self, mask: IoEvents, mut poller: Option<&mut PollHandle>) -> IoEvents {
         let reader_events = self.backlog.poll(mask, poller.as_deref_mut());
         let writer_events = self.writer_pollee.poll(mask, poller);
 
@@ -226,7 +226,7 @@ impl Backlog {
         self.wait_queue.wake_all();
     }
 
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -21,7 +21,7 @@ use crate::{
         SockShutdownCmd, Socket,
     },
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
     util::{MultiRead, MultiWrite},
 };
 
@@ -153,7 +153,7 @@ impl UnixStreamSocket {
 }
 
 impl Pollable for UnixStreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let inner = self.state.read();
         match inner.as_ref() {
             State::Init(init) => init.poll(mask, poller),

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -10,7 +10,7 @@ use super::{
     listener::{get_backlog, Backlog, Listener},
 };
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::{
         file_handle::FileLike,
         utils::{InodeMode, Metadata, StatusFlags},
@@ -192,29 +192,6 @@ impl FileLike for UnixStreamSocket {
     fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
         self.set_nonblocking(new_flags.contains(StatusFlags::O_NONBLOCK));
         Ok(())
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        match self.state.read().as_ref() {
-            State::Init(init) => init.register_observer(observer, mask),
-            State::Listen(listen) => listen.register_observer(observer, mask),
-            State::Connected(connected) => connected.register_observer(observer, mask),
-        }
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        match self.state.read().as_ref() {
-            State::Init(init) => init.unregister_observer(observer),
-            State::Listen(listen) => listen.unregister_observer(observer),
-            State::Connected(connected) => connected.unregister_observer(observer),
-        }
     }
 
     fn metadata(&self) -> Metadata {

--- a/kernel/src/net/socket/vsock/stream/connected.rs
+++ b/kernel/src/net/socket/vsock/stream/connected.rs
@@ -10,7 +10,7 @@ use crate::{
         SendRecvFlags, SockShutdownCmd,
     },
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
     util::{ring_buffer::RingBuffer, MultiRead, MultiWrite},
 };
 
@@ -126,7 +126,7 @@ impl Connected {
             .set_peer_requested_shutdown()
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/src/net/socket/vsock/stream/connecting.rs
+++ b/kernel/src/net/socket/vsock/stream/connecting.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     net::socket::vsock::{addr::VsockSocketAddr, VSOCK_GLOBAL},
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
 };
 
 pub struct Connecting {
@@ -45,7 +45,7 @@ impl Connecting {
         self.info.disable_irq().lock().update_for_event(event)
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/src/net/socket/vsock/stream/init.rs
+++ b/kernel/src/net/socket/vsock/stream/init.rs
@@ -7,7 +7,7 @@ use crate::{
         VSOCK_GLOBAL,
     },
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
 };
 
 pub struct Init {
@@ -61,7 +61,7 @@ impl Init {
         *self.bound_addr.lock()
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/net/socket/vsock/stream/listen.rs
+++ b/kernel/src/net/socket/vsock/stream/listen.rs
@@ -5,7 +5,7 @@ use crate::{
     events::IoEvents,
     net::socket::vsock::addr::VsockSocketAddr,
     prelude::*,
-    process::signal::{Pollee, Poller},
+    process::signal::{PollHandle, Pollee},
 };
 pub struct Listen {
     addr: VsockSocketAddr,
@@ -51,7 +51,7 @@ impl Listen {
         Ok(connection)
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -14,7 +14,7 @@ use crate::{
         MessageHeader, SendRecvFlags, SockShutdownCmd, Socket, SocketAddr,
     },
     prelude::*,
-    process::signal::{PollHandle, Pollable},
+    process::signal::{PollHandle, Pollable, Poller},
     util::{MultiRead, MultiWrite},
 };
 
@@ -231,9 +231,9 @@ impl Socket for VsockStreamSocket {
         vsockspace.request(&connecting.info()).unwrap();
         // wait for response from driver
         // TODO: Add timeout
-        let mut poller = PollHandle::new();
+        let mut poller = Poller::new();
         if !connecting
-            .poll(IoEvents::IN, Some(&mut poller))
+            .poll(IoEvents::IN, Some(poller.as_handle_mut()))
             .contains(IoEvents::IN)
         {
             if let Err(e) = poller.wait(None) {

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -14,7 +14,7 @@ use crate::{
         MessageHeader, SendRecvFlags, SockShutdownCmd, Socket, SocketAddr,
     },
     prelude::*,
-    process::signal::{Pollable, Poller},
+    process::signal::{PollHandle, Pollable},
     util::{MultiRead, MultiWrite},
 };
 
@@ -131,7 +131,7 @@ impl VsockStreamSocket {
 }
 
 impl Pollable for VsockStreamSocket {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         match &*self.status.read() {
             Status::Init(init) => init.poll(mask, poller),
             Status::Listen(listen) => listen.poll(mask, poller),
@@ -231,7 +231,7 @@ impl Socket for VsockStreamSocket {
         vsockspace.request(&connecting.info()).unwrap();
         // wait for response from driver
         // TODO: Add timeout
-        let mut poller = Poller::new();
+        let mut poller = PollHandle::new();
         if !connecting
             .poll(IoEvents::IN, Some(&mut poller))
             .contains(IoEvents::IN)

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -20,7 +20,7 @@ use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 use ostd::{cpu::UserContext, user::UserContextApi};
 pub use pause::{with_signal_blocked, Pause};
-pub use poll::{PollHandle, Pollable, Pollee, Poller};
+pub use poll::{PollAdaptor, PollHandle, Pollable, Pollee, Poller};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
 use sig_num::SigNum;

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -20,7 +20,7 @@ use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 use ostd::{cpu::UserContext, user::UserContextApi};
 pub use pause::{with_signal_blocked, Pause};
-pub use poll::{PollHandle, Pollable, Pollee};
+pub use poll::{PollHandle, Pollable, Pollee, Poller};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
 use sig_num::SigNum;

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -20,7 +20,7 @@ use c_types::{siginfo_t, ucontext_t};
 pub use events::{SigEvents, SigEventsFilter};
 use ostd::{cpu::UserContext, user::UserContextApi};
 pub use pause::{with_signal_blocked, Pause};
-pub use poll::{Pollable, Pollee, Poller};
+pub use poll::{PollHandle, Pollable, Pollee};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
 use sig_num::SigNum;

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -44,7 +44,7 @@ impl Pollee {
     ///
     /// This operation is _atomic_ in the sense that if there are interesting events, either the
     /// events are returned or the poller is notified.
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         let mask = mask | IoEvents::ALWAYS_POLL;
 
         // Register the provided poller.
@@ -56,7 +56,7 @@ impl Pollee {
         self.events() & mask
     }
 
-    fn register_poller(&self, poller: &mut Poller, mask: IoEvents) {
+    fn register_poller(&self, poller: &mut PollHandle, mask: IoEvents) {
         self.inner
             .subject
             .register_observer(poller.observer(), mask);
@@ -127,7 +127,7 @@ impl Pollee {
 }
 
 /// A poller gets notified when its associated pollees have interesting events.
-pub struct Poller {
+pub struct PollHandle {
     // Use event counter to wait or wake up a poller
     event_counter: Arc<EventCounter>,
     // All pollees that are interesting to this poller
@@ -136,14 +136,14 @@ pub struct Poller {
     waiter: Waiter,
 }
 
-impl Default for Poller {
+impl Default for PollHandle {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Poller {
-    /// Constructs a new `Poller`.
+impl PollHandle {
+    /// Constructs a new `PollHandle`.
     pub fn new() -> Self {
         let (waiter, waker) = Waiter::new_pair();
         Self {
@@ -167,7 +167,7 @@ impl Poller {
     }
 }
 
-impl Drop for Poller {
+impl Drop for PollHandle {
     fn drop(&mut self) {
         let observer = self.observer();
 
@@ -238,7 +238,7 @@ pub trait Pollable {
     /// poller is provided.
     ///
     /// This method has the same semantics as [`Pollee::poll`].
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents;
 
     /// Waits for events and performs event-based operations.
     ///
@@ -274,7 +274,7 @@ pub trait Pollable {
         }
 
         // Wait until the event happens.
-        let mut poller = Poller::new();
+        let mut poller = PollHandle::new();
         if self.poll(mask, Some(&mut poller)).is_empty() {
             poller.wait(timeout)?;
         }

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -37,27 +37,22 @@ impl Pollee {
         }
     }
 
-    /// Returns the current events of the pollee given an event mask.
+    /// Returns the current events of the pollee filtered by the given event mask.
     ///
-    /// If no interesting events are polled and a poller is provided, then
-    /// the poller will start monitoring the pollee and receive event
-    /// notification once the pollee gets any interesting events.
+    /// If a poller is provided, the poller will start monitoring the pollee and receive event
+    /// notification when the pollee receives interesting events.
     ///
-    /// This operation is _atomic_ in the sense that either some interesting
-    /// events are returned or the poller is registered (if a poller is provided).
+    /// This operation is _atomic_ in the sense that if there are interesting events, either the
+    /// events are returned or the poller is notified.
     pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
         let mask = mask | IoEvents::ALWAYS_POLL;
 
-        // Fast path: return events immediately
-        let revents = self.events() & mask;
-        if !revents.is_empty() || poller.is_none() {
-            return revents;
+        // Register the provided poller.
+        if let Some(poller) = poller {
+            self.register_poller(poller, mask);
         }
 
-        // Register the provided poller.
-        self.register_poller(poller.unwrap(), mask);
-
-        // It is important to check events again to handle race conditions
+        // Check events after the registration to prevent race conditions.
         self.events() & mask
     }
 
@@ -239,8 +234,8 @@ impl Observer<IoEvents> for EventCounter {
 /// have access to the internal [`Pollee`], but there is a method that provides the same semantics
 /// as [`Pollee::poll`] and we need to perform event-based operations using that method.
 pub trait Pollable {
-    /// Returns the interesting events if there are any, or waits for them to happen if there are
-    /// none.
+    /// Returns the interesting events now and monitors their occurrence in the future if the
+    /// poller is provided.
     ///
     /// This method has the same semantics as [`Pollee::poll`].
     fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents;
@@ -294,9 +289,7 @@ pub trait Pollable {
             // Wait until the next event happens.
             //
             // FIXME: We need to update `timeout` since we have waited for some time.
-            if self.poll(mask, Some(&mut poller)).is_empty() {
-                poller.wait(timeout)?;
-            }
+            poller.wait(timeout)?;
         }
     }
 }

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -59,7 +59,7 @@ impl Pollee {
     fn register_poller(&self, poller: &mut PollHandle, mask: IoEvents) {
         self.inner
             .subject
-            .register_observer(poller.observer(), mask);
+            .register_observer(poller.observer.clone(), mask);
 
         poller.pollees.push(Arc::downgrade(&self.inner));
     }
@@ -126,31 +126,108 @@ impl Pollee {
     }
 }
 
-/// A poller gets notified when its associated pollees have interesting events.
+/// An opaque handle that can be used as an argument of the [`Pollee::poll`] method.
+///
+/// This type can represent an entity of [`PollAdaptor`] or [`Poller`], which is done via the
+/// [`PollAdaptor::as_handle_mut`] and [`Poller::as_handle_mut`] methods.
+///
+/// When this handle is dropped or reset (via [`PollHandle::reset`]), the entity will no longer be
+/// notified of the events from the pollee.
 pub struct PollHandle {
-    // Use event counter to wait or wake up a poller
-    event_counter: Arc<EventCounter>,
-    // All pollees that are interesting to this poller
+    // The event observer.
+    observer: Weak<dyn Observer<IoEvents>>,
+    // The associated pollees.
     pollees: Vec<Weak<PolleeInner>>,
-    // A waiter used to pause the current thread.
-    waiter: Waiter,
-}
-
-impl Default for PollHandle {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl PollHandle {
-    /// Constructs a new `PollHandle`.
-    pub fn new() -> Self {
-        let (waiter, waker) = Waiter::new_pair();
+    /// Constructs a new handle with the observer.
+    ///
+    /// Note: It is a *logic error* to construct the multiple handles with the same observer (where
+    /// "same" means [`Weak::ptr_eq`]). If possible, consider using [`PollAdaptor::with_observer`]
+    /// instead.
+    pub fn new(observer: Weak<dyn Observer<IoEvents>>) -> Self {
         Self {
-            event_counter: Arc::new(EventCounter::new(waker)),
+            observer,
             pollees: Vec::new(),
+        }
+    }
+
+    /// Resets the handle.
+    ///
+    /// The observer will be unregistered and will no longer receive events.
+    pub fn reset(&mut self) {
+        let observer = &self.observer;
+
+        self.pollees
+            .iter()
+            .filter_map(Weak::upgrade)
+            .for_each(|pollee| {
+                pollee.subject.unregister_observer(observer);
+            });
+    }
+}
+
+impl Drop for PollHandle {
+    fn drop(&mut self) {
+        self.reset();
+    }
+}
+
+/// An adaptor to make an [`Observer`] usable for [`Pollee::poll`].
+///
+/// Normally, [`Pollee::poll`] accepts a [`Poller`] which is used to wait for events. By using this
+/// adaptor, it is possible to use any [`Observer`] with [`Pollee::poll`]. The observer will be
+/// notified whenever there are new events.
+pub struct PollAdaptor<O> {
+    // The event observer.
+    observer: Arc<O>,
+    // The inner with observer type erased.
+    inner: PollHandle,
+}
+
+impl<O: Observer<IoEvents> + 'static> PollAdaptor<O> {
+    /// Constructs a new adaptor with the specified observer.
+    pub fn with_observer(observer: O) -> Self {
+        let observer = Arc::new(observer);
+        let inner = PollHandle::new(Arc::downgrade(&observer) as _);
+
+        Self { observer, inner }
+    }
+}
+
+impl<O> PollAdaptor<O> {
+    /// Gets a reference to the observer.
+    pub fn observer(&self) -> &Arc<O> {
+        &self.observer
+    }
+
+    /// Returns a mutable reference of [`PollHandle`].
+    pub fn as_handle_mut(&mut self) -> &mut PollHandle {
+        &mut self.inner
+    }
+}
+
+/// A poller that can be used to wait for some events.
+pub struct Poller {
+    poller: PollAdaptor<EventCounter>,
+    waiter: Waiter,
+}
+
+impl Poller {
+    /// Constructs a new poller to wait for interesting events.
+    pub fn new() -> Self {
+        let (waiter, event_counter) = EventCounter::new_pair();
+
+        Self {
+            poller: PollAdaptor::with_observer(event_counter),
             waiter,
         }
+    }
+
+    /// Returns a mutable reference of [`PollHandle`].
+    pub fn as_handle_mut(&mut self) -> &mut PollHandle {
+        self.poller.as_handle_mut()
     }
 
     /// Waits until some interesting events happen since the last wait or until the timeout
@@ -158,43 +235,30 @@ impl PollHandle {
     ///
     /// The waiting process can be interrupted by a signal.
     pub fn wait(&self, timeout: Option<&Duration>) -> Result<()> {
-        self.event_counter.read(&self.waiter, timeout)?;
+        self.poller.observer().read(&self.waiter, timeout)?;
         Ok(())
     }
-
-    fn observer(&self) -> Weak<dyn Observer<IoEvents>> {
-        Arc::downgrade(&self.event_counter) as _
-    }
 }
 
-impl Drop for PollHandle {
-    fn drop(&mut self) {
-        let observer = self.observer();
-
-        self.pollees
-            .iter()
-            .filter_map(Weak::upgrade)
-            .for_each(|pollee| {
-                pollee.subject.unregister_observer(&observer);
-            });
-    }
-}
-
-/// A counter for wait and wakeup.
 struct EventCounter {
     counter: AtomicUsize,
     waker: Arc<Waker>,
 }
 
 impl EventCounter {
-    pub fn new(waker: Arc<Waker>) -> Self {
-        Self {
-            counter: AtomicUsize::new(0),
-            waker,
-        }
+    fn new_pair() -> (Waiter, Self) {
+        let (waiter, waker) = Waiter::new_pair();
+
+        (
+            waiter,
+            Self {
+                counter: AtomicUsize::new(0),
+                waker,
+            },
+        )
     }
 
-    pub fn read(&self, waiter: &Waiter, timeout: Option<&Duration>) -> Result<usize> {
+    fn read(&self, waiter: &Waiter, timeout: Option<&Duration>) -> Result<usize> {
         let cond = || {
             let val = self.counter.swap(0, Ordering::Relaxed);
             if val > 0 {
@@ -211,7 +275,7 @@ impl EventCounter {
         }
     }
 
-    pub fn write(&self) {
+    fn write(&self) {
         self.counter.fetch_add(1, Ordering::Relaxed);
         self.waker.wake_up();
     }
@@ -274,8 +338,8 @@ pub trait Pollable {
         }
 
         // Wait until the event happens.
-        let mut poller = PollHandle::new();
-        if self.poll(mask, Some(&mut poller)).is_empty() {
+        let mut poller = Poller::new();
+        if self.poll(mask, Some(poller.as_handle_mut())).is_empty() {
             poller.wait(timeout)?;
         }
 

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        signal::{Pollable, Pollee, Poller},
+        signal::{PollHandle, Pollable, Pollee},
         Gid, Uid,
     },
     time::clocks::RealTimeClock,
@@ -174,7 +174,7 @@ impl EventFile {
 }
 
 impl Pollable for EventFile {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.poll(mask, poller)
     }
 }

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -18,7 +18,7 @@ use ostd::sync::WaitQueue;
 
 use super::SyscallReturn;
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     fs::{
         file_handle::FileLike,
         file_table::{FdFlags, FileDesc},
@@ -240,22 +240,6 @@ impl FileLike for EventFile {
         // TODO: deal with other flags
 
         Ok(())
-    }
-
-    fn register_observer(
-        &self,
-        observer: Weak<dyn crate::events::Observer<IoEvents>>,
-        mask: IoEvents,
-    ) -> Result<()> {
-        self.pollee.register_observer(observer, mask);
-        Ok(())
-    }
-
-    fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.pollee.unregister_observer(observer)
     }
 
     fn metadata(&self) -> Metadata {

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{file_handle::FileLike, file_table::FileDesc},
     prelude::*,
-    process::signal::Poller,
+    process::signal::PollHandle,
 };
 
 pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32, ctx: &Context) -> Result<SyscallReturn> {
@@ -126,13 +126,13 @@ fn hold_files(poll_fds: &[PollFd], ctx: &Context) -> (FileResult, Vec<Option<Arc
 }
 
 enum PollerResult {
-    AllRegistered(Poller),
+    AllRegistered(PollHandle),
     EventFoundAt(usize),
 }
 
 /// Registers the files with a poller, or exits early if some events are detected.
 fn register_poller(poll_fds: &[PollFd], files: &[Option<Arc<dyn FileLike>>]) -> PollerResult {
-    let mut poller = Poller::new();
+    let mut poller = PollHandle::new();
 
     for (i, (poll_fd, file)) in poll_fds.iter().zip(files.iter()).enumerate() {
         let Some(file) = file else {


### PR DESCRIPTION
~~*Depends on https://github.com/asterinas/asterinas/pull/1496 and https://github.com/asterinas/asterinas/pull/1498 to avoid conflicts.*~~

This PR closes https://github.com/asterinas/asterinas/issues/1355:
 - https://github.com/asterinas/asterinas/issues/1355

A brief summary of the most important changes:
 - **Before this PR:**
   - `Poller` is a special kind of `Observer` that waits for certain events. It can be _conditionally_ registered with `FileLike::poll`.
   - Other kinds of `Observer`s must be registered with `FileLike::register_observer`.
 - **After this PR:**
   - `RawPoller` can represent arbitrary kinds of `Observer`. It can be _unconditionally_ registered with `FileLike::poll`.
     - However, `RawPoller` has generic parameters, so it cannot be used in object-safe traits. `AnyPoller` is used to erase the generic argument.
   - `Poller` is a special kind of `RawPoller` that can be used to wait for certain events.

This way, I believe no functionality is lost. However, the `FileLike` APIs are simplified.

API overview:

```rust
pub struct RawPoller<T>;
pub struct AnyPoller;

impl<T: Observer<IoEvents> + 'static> RawPoller<T> {
    pub fn with_observer(observer: T) -> Self;
    pub fn observer(&self) -> &Arc<T>;
    pub fn as_any_mut(&mut self) -> &mut AnyPoller;
}

pub trait Pollable {
    fn poll(&self, mask: IoEvents, poller: Option<&mut AnyPoller>) -> IoEvents;
}
```

```rust
pub struct Poller;

impl Poller {
    pub fn new() -> Self;
    pub fn as_any_mut(&mut self) -> &mut AnyPoller;
    pub fn wait(&self, timeout: Option<&Duration>) -> Result<()>;
}
```
