### PR TITLE
Refactor process table

### DIFF
--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -130,7 +130,7 @@ impl DirOps for RootDirOps {
         cached_children
             .put_entry_if_not_found("meminfo", || MemInfoFileOps::new_inode(this_ptr.clone()));
 
-        for process in process_table::process_table().iter() {
+        for process in process_table::process_table_mut().iter() {
             let pid = process.pid().to_string();
             cached_children.put_entry_if_not_found(&pid, || {
                 PidDirOps::new_inode(process.clone(), this_ptr.clone())

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -105,7 +105,7 @@ pub fn tgkill(tid: Tid, tgid: Pid, signal: Option<UserSignal>, ctx: &Context) ->
 /// if it is authorized to send the signal to the target group.
 pub fn kill_all(signal: Option<UserSignal>, ctx: &Context) -> Result<()> {
     let current = current!();
-    for process in process_table::process_table().iter() {
+    for process in process_table::process_table_mut().iter() {
         if Arc::ptr_eq(&current, process) || process.is_init_process() {
             continue;
         }

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -118,6 +118,6 @@ fn reap_zombie_child(process: &Process, pid: Pid) -> ExitCode {
         }
     }
 
-    process_table_mut.remove(&child_process.pid());
+    process_table_mut.remove(child_process.pid());
     child_process.exit_code()
 }

--- a/kernel/src/syscall/set_get_priority.rs
+++ b/kernel/src/syscall/set_get_priority.rs
@@ -69,7 +69,7 @@ fn get_processes(prio_target: PriorityTarget) -> Result<Vec<Arc<Process>>> {
         }
         PriorityTarget::User(uid) => {
             // Get the processes that are running under the specified user
-            let processes: Vec<Arc<Process>> = process_table::process_table()
+            let processes: Vec<Arc<Process>> = process_table::process_table_mut()
                 .iter()
                 .filter(|process| {
                     let Some(main_thread) = process.main_thread() else {


### PR DESCRIPTION
## Problem

Under current implementation, the `PROCESS_TABLE` and the `PROCESS_TABLE_SUBJECT` are two separated statics. A `remove` in `PROCESS_TABLE` will not trigger a `notify_observer` in `PROCESS_TABLE_SUBJECT` unless you explicitly call it. Thus the observer on `PidEvent` will do nothing at all. 

One example is in ProcFS. It waits for a `PidEvent::Exit` to remove the PID directory from `/proc`'s cached children. But now it never does so and the result of `ls /proc` is wrong. Furthermore, this can cause the `Process` and `Task` to leak. (See https://github.com/asterinas/asterinas/issues/1491#issuecomment-2439183169 and https://github.com/asterinas/asterinas/issues/1491#issuecomment-2439189083)
```sh
~ # ls proc
1            2            filesystems  meminfo      self         sys
~ # ls proc
1            3            meminfo      sys
2            filesystems  self
```

## Solution

This PR combines the two statics into one `PROCESS_TABLE` and provides a robust `remove` API which automatically notify observers.

Now `ls /proc` should works well.
```sh
~ # ls proc
1            2            filesystems  meminfo      self         sys
~ # ls proc
1            3            filesystems  meminfo      self         sys
```