### PR TITLE
MCS spinlock

### DIFF
--- a/kernel/comps/block/src/lib.rs
+++ b/kernel/comps/block/src/lib.rs
@@ -82,8 +82,7 @@ pub fn register_device(name: String, device: Arc<dyn BlockDevice>) {
         .get()
         .unwrap()
         .block_device_table
-        .lock()
-        .insert(name, device);
+        .lock_with(|t| t.insert(name, device));
 }
 
 pub fn get_device(str: &str) -> Option<Arc<dyn BlockDevice>> {
@@ -91,17 +90,20 @@ pub fn get_device(str: &str) -> Option<Arc<dyn BlockDevice>> {
         .get()
         .unwrap()
         .block_device_table
-        .lock()
-        .get(str)
-        .cloned()
+        .lock_with(|dev| dev.get(str).cloned())
 }
 
 pub fn all_devices() -> Vec<(String, Arc<dyn BlockDevice>)> {
-    let block_devs = COMPONENT.get().unwrap().block_device_table.lock();
-    block_devs
-        .iter()
-        .map(|(name, device)| (name.clone(), device.clone()))
-        .collect()
+    COMPONENT
+        .get()
+        .unwrap()
+        .block_device_table
+        .lock_with(|block_devs| {
+            block_devs
+                .iter()
+                .map(|(name, device)| (name.clone(), device.clone()))
+                .collect()
+        })
 }
 
 static COMPONENT: Once<Component> = Once::new();

--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -35,21 +35,23 @@ pub fn register_device(name: String, device: Arc<dyn AnyConsoleDevice>) {
         .unwrap()
         .console_device_table
         .disable_irq()
-        .lock()
-        .insert(name, device);
+        .lock_with(|console_devs| {
+            console_devs.insert(name, device);
+        });
 }
 
 pub fn all_devices() -> Vec<(String, Arc<dyn AnyConsoleDevice>)> {
-    let console_devs = COMPONENT
+    COMPONENT
         .get()
         .unwrap()
         .console_device_table
         .disable_irq()
-        .lock();
-    console_devs
-        .iter()
-        .map(|(name, device)| (name.clone(), device.clone()))
-        .collect()
+        .lock_with(|console_devs| {
+            console_devs
+                .iter()
+                .map(|(name, device)| (name.clone(), device.clone()))
+                .collect()
+        })
 }
 
 static COMPONENT: Once<Component> = Once::new();

--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -207,7 +207,5 @@ pub fn _print(args: fmt::Arguments) {
         .get()
         .unwrap()
         .disable_irq()
-        .lock()
-        .write_fmt(args)
-        .unwrap();
+        .lock_with(|writer| writer.write_fmt(args).unwrap());
 }

--- a/kernel/comps/input/src/lib.rs
+++ b/kernel/comps/input/src/lib.rs
@@ -31,8 +31,7 @@ pub fn register_device(name: String, device: Arc<dyn InputDevice>) {
         .get()
         .unwrap()
         .input_device_table
-        .lock()
-        .insert(name, device);
+        .lock_with(|t| t.insert(name, device));
 }
 
 pub fn get_device(str: &str) -> Option<Arc<dyn InputDevice>> {
@@ -40,17 +39,19 @@ pub fn get_device(str: &str) -> Option<Arc<dyn InputDevice>> {
         .get()
         .unwrap()
         .input_device_table
-        .lock()
-        .get(str)
-        .cloned()
+        .lock_with(|t| t.get(str).cloned())
 }
 
 pub fn all_devices() -> Vec<(String, Arc<dyn InputDevice>)> {
-    let input_devs = COMPONENT.get().unwrap().input_device_table.lock();
-    input_devs
-        .iter()
-        .map(|(name, device)| (name.clone(), device.clone()))
-        .collect()
+    COMPONENT
+        .get()
+        .unwrap()
+        .input_device_table
+        .lock_with(|devs| {
+            devs.iter()
+                .map(|(name, device)| (name.clone(), device.clone()))
+                .collect()
+        })
 }
 
 static COMPONENT: Once<Component> = Once::new();

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -31,7 +31,7 @@ impl TxBuffer {
 
         assert!(nbytes <= TX_BUFFER_LEN);
 
-        let dma_stream = if let Some(stream) = pool.lock().pop_front() {
+        let dma_stream = if let Some(stream) = pool.lock_with(|pool| pool.pop_front()) {
             stream
         } else {
             let segment = FrameAllocOptions::new(TX_BUFFER_LEN / PAGE_SIZE)
@@ -76,7 +76,8 @@ impl HasDaddr for TxBuffer {
 
 impl Drop for TxBuffer {
     fn drop(&mut self) {
-        self.pool.lock().push_back(self.dma_stream.clone());
+        self.pool
+            .lock_with(|pool| pool.push_back(self.dma_stream.clone()));
     }
 }
 

--- a/kernel/comps/virtio/src/transport/mmio/driver.rs
+++ b/kernel/comps/virtio/src/transport/mmio/driver.rs
@@ -22,11 +22,12 @@ pub struct VirtioMmioDriver {
 
 impl VirtioMmioDriver {
     pub fn num_devices(&self) -> usize {
-        self.devices.lock().len()
+        self.devices
+            .lock_with(|devices: &mut Vec<VirtioMmioTransport>| devices.len())
     }
 
     pub fn pop_device_transport(&self) -> Option<VirtioMmioTransport> {
-        self.devices.lock().pop()
+        self.devices.lock_with(|devices| devices.pop())
     }
 
     pub(super) fn new() -> Self {
@@ -43,7 +44,7 @@ impl MmioDriver for VirtioMmioDriver {
     ) -> Result<Arc<dyn MmioDevice>, (BusProbeError, MmioCommonDevice)> {
         let device = VirtioMmioTransport::new(device);
         let mmio_device = device.mmio_device().clone();
-        self.devices.lock().push(device);
+        self.devices.lock_with(|devices| devices.push(device));
         Ok(mmio_device)
     }
 }

--- a/kernel/comps/virtio/src/transport/mmio/mod.rs
+++ b/kernel/comps/virtio/src/transport/mmio/mod.rs
@@ -15,7 +15,7 @@ pub mod multiplex;
 pub static VIRTIO_MMIO_DRIVER: Once<Arc<VirtioMmioDriver>> = Once::new();
 pub fn virtio_mmio_init() {
     VIRTIO_MMIO_DRIVER.call_once(|| Arc::new(VirtioMmioDriver::new()));
-    MMIO_BUS
-        .lock()
-        .register_driver(VIRTIO_MMIO_DRIVER.get().unwrap().clone());
+    MMIO_BUS.lock_with(|bus| {
+        bus.register_driver(VIRTIO_MMIO_DRIVER.get().unwrap().clone());
+    });
 }

--- a/kernel/comps/virtio/src/transport/pci/driver.rs
+++ b/kernel/comps/virtio/src/transport/pci/driver.rs
@@ -22,11 +22,12 @@ pub struct VirtioPciDriver {
 
 impl VirtioPciDriver {
     pub fn num_devices(&self) -> usize {
-        self.devices.lock().len()
+        self.devices
+            .lock_with(|devices: &mut Vec<VirtioPciTransport>| devices.len())
     }
 
     pub fn pop_device_transport(&self) -> Option<VirtioPciTransport> {
-        self.devices.lock().pop()
+        self.devices.lock_with(|devices| devices.pop())
     }
 
     pub(super) fn new() -> Self {
@@ -47,7 +48,7 @@ impl PciDriver for VirtioPciDriver {
         }
         let transport = VirtioPciTransport::new(device)?;
         let device = transport.pci_device().clone();
-        self.devices.lock().push(transport);
+        self.devices.lock_with(|devices| devices.push(transport));
         Ok(device)
     }
 }

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -61,7 +61,7 @@ impl Tty {
     }
 
     pub fn set_driver(&self, driver: Weak<TtyDriver>) {
-        *self.driver.disable_irq().lock() = driver;
+        self.driver.disable_irq().lock_with(|d| *d = driver);
     }
 
     pub fn push_char(&self, ch: u8) {

--- a/kernel/src/fs/exfat/fs.rs
+++ b/kernel/src/fs/exfat/fs.rs
@@ -106,7 +106,7 @@ impl ExfatFS {
         )?;
 
         *exfat_fs.bitmap.lock() = bitmap;
-        *exfat_fs.upcase_table.lock() = upcase_table;
+        exfat_fs.upcase_table.lock_with(|tbl| *tbl = upcase_table);
 
         // TODO: Handle UTF-8
 

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -476,7 +476,8 @@ impl ExfatInodeInner {
         let fs = self.fs();
 
         let target_upcase = if !case_sensitive {
-            fs.upcase_table().lock().str_to_upcase(target_name)?
+            fs.upcase_table()
+                .lock_with(|tbl| tbl.str_to_upcase(target_name))?
         } else {
             target_name.to_string()
         };
@@ -506,7 +507,8 @@ impl ExfatInodeInner {
 
         for (name, offset) in name_and_offsets {
             let name_upcase = if !case_sensitive {
-                fs.upcase_table().lock().str_to_upcase(&name)?
+                fs.upcase_table()
+                    .lock_with(|tbl| tbl.str_to_upcase(&name))?
             } else {
                 name
             };
@@ -1616,8 +1618,12 @@ impl Inode for ExfatInode {
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
         // Rename something to itself, return success directly.
-        let up_old_name = fs.upcase_table().lock().str_to_upcase(old_name)?;
-        let up_new_name = fs.upcase_table().lock().str_to_upcase(new_name)?;
+        let up_old_name = fs
+            .upcase_table()
+            .lock_with(|tbl| tbl.str_to_upcase(old_name))?;
+        let up_new_name = fs
+            .upcase_table()
+            .lock_with(|tbl| tbl.str_to_upcase(new_name))?;
         if self.inner.read().ino == target_.inner.read().ino && up_old_name.eq(&up_new_name) {
             return Ok(());
         }

--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -287,12 +287,13 @@ impl FsResolver {
     /// Lookups the target dentry according to the given `fd`.
     pub fn lookup_from_fd(&self, fd: FileDesc) -> Result<Dentry> {
         let current = current!();
-        let file_table = current.file_table().lock();
-        let inode_handle = file_table
-            .get_file(fd)?
-            .downcast_ref::<InodeHandle>()
-            .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;
-        Ok(inode_handle.dentry().clone())
+        current.file_table().lock_with(|file_table| {
+            let inode_handle = file_table
+                .get_file(fd)?
+                .downcast_ref::<InodeHandle>()
+                .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;
+            Ok(inode_handle.dentry().clone())
+        })
     }
 
     /// Lookups the target parent directory dentry and

--- a/kernel/src/fs/pipe.rs
+++ b/kernel/src/fs/pipe.rs
@@ -259,7 +259,7 @@ mod test {
         let signal_reader = signal_writer.clone();
 
         let writer = Thread::spawn_kernel_thread(ThreadOptions::new(move || {
-            let writer = writer_with_lock.lock().take().unwrap();
+            let writer = writer_with_lock.lock_with(|writer| writer.take().unwrap());
 
             if ordering == Ordering::ReadThenWrite {
                 while !signal_writer.load(atomic::Ordering::Relaxed) {
@@ -273,7 +273,7 @@ mod test {
         }));
 
         let reader = Thread::spawn_kernel_thread(ThreadOptions::new(move || {
-            let reader = reader_with_lock.lock().take().unwrap();
+            let reader = reader_with_lock.lock_with(|reader| reader.take().unwrap());
 
             if ordering == Ordering::WriteThenRead {
                 while !signal_reader.load(atomic::Ordering::Relaxed) {

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -30,9 +30,10 @@ impl PidDirOps {
             .volatile()
             .build()
             .unwrap();
-        let file_table = process_ref.file_table().lock();
         let weak_ptr = Arc::downgrade(&pid_inode);
-        file_table.register_observer(weak_ptr);
+        process_ref.file_table().lock_with(|file_table| {
+            file_table.register_observer(weak_ptr);
+        });
         pid_inode
     }
 }

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -38,7 +38,7 @@ impl FileOps for StatFileOps {
             process.pid(),
             process.parent().pid(),
             process.parent().pid(),
-            process.file_table().lock().len(),
+            process.file_table().lock_with(|tbl| tbl.len()),
             process.tasks().lock().len()
         )
         .unwrap();

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -80,7 +80,7 @@ impl FileOps for StatusFileOps {
         writeln!(
             status_output,
             "FDSize:\t{}",
-            process.file_table().lock().len()
+            process.file_table().lock_with(|tbl| tbl.len())
         )
         .unwrap();
         writeln!(status_output, "Threads:\t{}", process.tasks().lock().len()).unwrap();

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -48,7 +48,7 @@ fn new_virtio() -> Arc<Iface> {
 
     let virtio_net = aster_network::get_device(DEVICE_NAME).unwrap();
 
-    let ether_addr = virtio_net.lock().mac_addr().0;
+    let ether_addr = virtio_net.lock_with(|net| net.mac_addr().0);
 
     struct Wrapper(Arc<SpinLock<dyn AnyNetworkDevice, LocalIrqDisabled>>);
 
@@ -59,8 +59,7 @@ fn new_virtio() -> Arc<Iface> {
         where
             F: FnOnce(&mut Self::Device) -> R,
         {
-            let mut device = self.0.lock();
-            f(&mut *device)
+            self.0.lock_with(f)
         }
     }
 

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -46,23 +46,23 @@ impl ConnectingStream {
     }
 
     pub fn has_result(&self) -> bool {
-        self.conn_result.lock().is_some()
+        self.conn_result.lock_with(|r| r.is_some())
     }
 
     pub fn into_result(self) -> core::result::Result<ConnectedStream, (Error, InitStream)> {
-        let conn_result = *self.conn_result.lock();
-        match conn_result {
-            Some(ConnResult::Connected) => Ok(ConnectedStream::new(
-                self.bound_socket,
-                self.remote_endpoint,
-                true,
-            )),
-            Some(ConnResult::Refused) => Err((
-                Error::with_message(Errno::ECONNREFUSED, "the connection is refused"),
-                InitStream::new_bound(self.bound_socket),
-            )),
-            None => unreachable!("`has_result` must be true before calling `into_result`"),
-        }
+        self.conn_result
+            .lock_with(|conn_result| match *conn_result {
+                Some(ConnResult::Connected) => Ok(ConnectedStream::new(
+                    self.bound_socket,
+                    self.remote_endpoint,
+                    true,
+                )),
+                Some(ConnResult::Refused) => Err((
+                    Error::with_message(Errno::ECONNREFUSED, "the connection is refused"),
+                    InitStream::new_bound(self.bound_socket),
+                )),
+                None => unreachable!("`has_result` must be true before calling `into_result`"),
+            })
     }
 
     pub fn local_endpoint(&self) -> IpEndpoint {
@@ -78,38 +78,39 @@ impl ConnectingStream {
     }
 
     pub(super) fn update_io_events(&self, pollee: &Pollee) {
-        if self.conn_result.lock().is_some() {
+        if self.conn_result.lock_with(|r| r.is_some()) {
             return;
         }
 
         self.bound_socket.raw_with(|socket| {
-            let mut result = self.conn_result.lock();
-            if result.is_some() {
-                return;
-            }
+            self.conn_result.lock_with(|result| {
+                if result.is_some() {
+                    return;
+                }
 
-            // Connected
-            if socket.can_send() {
-                *result = Some(ConnResult::Connected);
+                // Connected
+                if socket.can_send() {
+                    *result = Some(ConnResult::Connected);
+                    pollee.add_events(IoEvents::OUT);
+                    return;
+                }
+                // Connecting
+                if socket.is_open() {
+                    return;
+                }
+                // Refused
+                *result = Some(ConnResult::Refused);
                 pollee.add_events(IoEvents::OUT);
-                return;
-            }
-            // Connecting
-            if socket.is_open() {
-                return;
-            }
-            // Refused
-            *result = Some(ConnResult::Refused);
-            pollee.add_events(IoEvents::OUT);
 
-            // Add `IoEvents::OUT` because the man pages say "EINPROGRESS [..] It is possible to
-            // select(2) or poll(2) for completion by selecting the socket for writing". For
-            // details, see <https://man7.org/linux/man-pages/man2/connect.2.html>.
-            //
-            // TODO: It is better to do the state transition and let `ConnectedStream` or
-            // `InitStream` set the correct I/O events. However, the state transition is delayed
-            // because we're probably in IRQ handlers. Maybe mark the `pollee` as obsolete and
-            // re-calculate the I/O events in `poll`.
+                // Add `IoEvents::OUT` because the man pages say "EINPROGRESS [..] It is possible to
+                // select(2) or poll(2) for completion by selecting the socket for writing". For
+                // details, see <https://man7.org/linux/man-pages/man2/connect.2.html>.
+                //
+                // TODO: It is better to do the state transition and let `ConnectedStream` or
+                // `InitStream` set the correct I/O events. However, the state transition is delayed
+                // because we're probably in IRQ handlers. Maybe mark the `pollee` as obsolete and
+                // re-calculate the I/O events in `poll`.
+            });
         })
     }
 }

--- a/kernel/src/net/socket/vsock/stream/connecting.rs
+++ b/kernel/src/net/socket/vsock/stream/connecting.rs
@@ -38,11 +38,13 @@ impl Connecting {
     }
 
     pub fn info(&self) -> ConnectionInfo {
-        self.info.disable_irq().lock().clone()
+        self.info.disable_irq().lock_with(|info| info.clone())
     }
 
     pub fn update_info(&self, event: &VsockEvent) {
-        self.info.disable_irq().lock().update_for_event(event)
+        self.info
+            .disable_irq()
+            .lock_with(|info| info.update_for_event(event));
     }
 
     pub fn poll(&self, mask: IoEvents, poller: Option<&mut Poller>) -> IoEvents {

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -18,7 +18,7 @@ pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use log::{debug, error, info, log_enabled, trace, warn};
 pub(crate) use ostd::{
     mm::{FallibleVmRead, FallibleVmWrite, Vaddr, VmReader, VmWriter, PAGE_SIZE},
-    sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
+    sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock},
     Pod,
 };
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -460,7 +460,9 @@ fn clone_files(
     if clone_flags.contains(CloneFlags::CLONE_FILES) {
         parent_file_table.clone()
     } else {
-        Arc::new(SpinLock::new(parent_file_table.lock().clone()))
+        Arc::new(SpinLock::new(
+            parent_file_table.lock_with(|table| table.clone()),
+        ))
     }
 }
 

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -42,8 +42,7 @@ pub fn do_exit_group(term_status: TermStatus) {
     }
 
     // Close all files then exit the process
-    let files = current.file_table().lock().close_all();
-    drop(files);
+    current.file_table().lock_with(|files| files.close_all());
 
     // Move children to the init process
     if !is_init_process(&current) {

--- a/kernel/src/process/posix_thread/thread_table.rs
+++ b/kernel/src/process/posix_thread/thread_table.rs
@@ -8,15 +8,15 @@ static THREAD_TABLE: SpinLock<BTreeMap<Tid, Arc<Thread>>> = SpinLock::new(BTreeM
 /// Adds a posix thread to global thread table
 pub fn add_thread(tid: Tid, thread: Arc<Thread>) {
     debug_assert_eq!(tid, thread.tid());
-    THREAD_TABLE.lock().insert(tid, thread);
+    THREAD_TABLE.lock_with(|table| table.insert(tid, thread));
 }
 
 /// Removes a posix thread to global thread table
 pub fn remove_thread(tid: Tid) {
-    THREAD_TABLE.lock().remove(&tid);
+    THREAD_TABLE.lock_with(|table| table.remove(&tid));
 }
 
 /// Gets a posix thread from the global thread table
 pub fn get_thread(tid: Tid) -> Option<Arc<Thread>> {
-    THREAD_TABLE.lock().get(&tid).cloned()
+    THREAD_TABLE.lock_with(|table| table.get(&tid).cloned())
 }

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -66,10 +66,10 @@ fn do_accept(
         write_socket_addr_to_user(&socket_addr, sockaddr_ptr, addrlen_ptr)?;
     }
 
-    let fd = {
-        let mut file_table = ctx.process.file_table().lock();
-        file_table.insert(connected_socket, fd_flags)
-    };
+    let fd = ctx
+        .process
+        .file_table()
+        .lock_with(|file_table| file_table.insert(connected_socket, fd_flags));
 
     Ok(fd)
 }

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -13,10 +13,10 @@ use crate::{
 pub fn sys_fchmod(fd: FileDesc, mode: u16, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}, mode = 0o{:o}", fd, mode);
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     file.set_mode(InodeMode::from_bits_truncate(mode))?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -20,10 +20,10 @@ pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<Sys
         return Ok(SyscallReturn::Return(0));
     }
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     if let Some(uid) = uid {
         file.set_owner(uid)?;
     }

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -6,11 +6,10 @@ use crate::{fs::file_table::FileDesc, prelude::*};
 pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
-    let file = {
-        let mut file_table = ctx.process.file_table().lock();
+    let file = ctx.process.file_table().lock_with(|file_table| {
         let _ = file_table.get_file(fd)?;
-        file_table.close_file(fd).unwrap()
-    };
+        Result::Ok(file_table.close_file(fd).unwrap())
+    })?;
 
     // Cleanup work needs to be done in the `Drop` impl.
     //

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -53,15 +53,14 @@ pub fn sys_eventfd2(init_val: u64, flags: u32, ctx: &Context) -> Result<SyscallR
 
 fn do_sys_eventfd2(init_val: u64, flags: Flags, ctx: &Context) -> FileDesc {
     let event_file = EventFile::new(init_val, flags);
-    let fd = {
-        let mut file_table = ctx.process.file_table().lock();
+    let fd = ctx.process.file_table().lock_with(|file_table| {
         let fd_flags = if flags.contains(Flags::EFD_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {
             FdFlags::empty()
         };
         file_table.insert(Arc::new(event_file), fd_flags)
-    };
+    });
     fd
 }
 

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -107,8 +107,9 @@ fn do_execve(
     *posix_thread.clear_child_tid().lock() = 0;
 
     // Ensure that the file descriptors with the close-on-exec flag are closed.
-    let closed_files = process.file_table().lock().close_files_on_exec();
-    drop(closed_files);
+    process
+        .file_table()
+        .lock_with(|file_table| file_table.close_files_on_exec());
 
     debug!("load program to root vmar");
     let (new_executable_path, elf_load_info) = {

--- a/kernel/src/syscall/fallocate.rs
+++ b/kernel/src/syscall/fallocate.rs
@@ -21,10 +21,10 @@ pub fn sys_fallocate(
 
     check_offset_and_len(offset, len, ctx)?;
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     let falloc_mode = FallocMode::try_from(
         RawFallocMode::from_bits(mode as _)

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -33,16 +33,18 @@ pub fn sys_fcntl(fd: FileDesc, cmd: i32, arg: u64, ctx: &Context) -> Result<Sysc
 }
 
 fn handle_dupfd(fd: FileDesc, arg: u64, flags: FdFlags, ctx: &Context) -> Result<SyscallReturn> {
-    let mut file_table = ctx.process.file_table().lock();
-    let new_fd = file_table.dup(fd, arg as FileDesc, flags)?;
-    Ok(SyscallReturn::Return(new_fd as _))
+    ctx.process.file_table().lock_with(|file_table| {
+        let new_fd = file_table.dup(fd, arg as FileDesc, flags)?;
+        Ok(SyscallReturn::Return(new_fd as _))
+    })
 }
 
 fn handle_getfd(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
-    let file_table = ctx.process.file_table().lock();
-    let entry = file_table.get_entry(fd)?;
-    let fd_flags = entry.flags();
-    Ok(SyscallReturn::Return(fd_flags.bits() as _))
+    ctx.process.file_table().lock_with(|file_table| {
+        let entry = file_table.get_entry(fd)?;
+        let fd_flags = entry.flags();
+        Ok(SyscallReturn::Return(fd_flags.bits() as _))
+    })
 }
 
 fn handle_setfd(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -51,17 +53,18 @@ fn handle_setfd(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
     } else {
         FdFlags::from_bits(arg as u8).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?
     };
-    let file_table = ctx.process.file_table().lock();
-    let entry = file_table.get_entry(fd)?;
-    entry.set_flags(flags);
-    Ok(SyscallReturn::Return(0))
+    ctx.process.file_table().lock_with(|file_table| {
+        let entry = file_table.get_entry(fd)?;
+        entry.set_flags(flags);
+        Ok(SyscallReturn::Return(0))
+    })
 }
 
 fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let status_flags = file.status_flags();
     let access_mode = file.access_mode();
     Ok(SyscallReturn::Return(
@@ -70,10 +73,10 @@ fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 }
 
 fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let valid_flags_mask = StatusFlags::O_APPEND
         | StatusFlags::O_ASYNC
         | StatusFlags::O_DIRECT
@@ -87,10 +90,10 @@ fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
 }
 
 fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let lock_mut_ptr = arg as Vaddr;
     let mut lock_mut_c = ctx.get_user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
@@ -116,10 +119,10 @@ fn handle_setlk(
     is_nonblocking: bool,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let lock_mut_ptr = arg as Vaddr;
     let lock_mut_c = ctx.get_user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
@@ -135,10 +138,11 @@ fn handle_setlk(
 }
 
 fn handle_getown(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
-    let file_table = ctx.process.file_table().lock();
-    let file_entry = file_table.get_entry(fd)?;
-    let pid = file_entry.owner().unwrap_or(0);
-    Ok(SyscallReturn::Return(pid as _))
+    ctx.process.file_table().lock_with(|file_table| {
+        let file_entry = file_table.get_entry(fd)?;
+        let pid = file_entry.owner().unwrap_or(0);
+        Ok(SyscallReturn::Return(pid as _))
+    })
 }
 
 fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -159,9 +163,12 @@ fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn>
         ))?)
     };
 
-    let mut file_table = ctx.process.file_table().lock();
-    let file_entry = file_table.get_entry_mut(fd)?;
-    file_entry.set_owner(owner_process.as_ref())?;
+    ctx.process.file_table().lock_with(|file_table| {
+        let file_entry = file_table.get_entry_mut(fd)?;
+        file_entry.set_owner(owner_process.as_ref())?;
+        Result::Ok(())
+    })?;
+
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/flock.rs
+++ b/kernel/src/syscall/flock.rs
@@ -13,11 +13,10 @@ use crate::{
 pub fn sys_flock(fd: FileDesc, ops: i32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("flock: fd: {}, ops: {:?}", fd, ops);
 
-    let file = {
-        let current = ctx.process;
-        let file_table = current.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|file_table| Result::Ok(file_table.get_file(fd)?.clone()))?;
     let inode_file = file
         .downcast_ref::<InodeHandle>()
         .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;

--- a/kernel/src/syscall/fsync.rs
+++ b/kernel/src/syscall/fsync.rs
@@ -9,14 +9,14 @@ use crate::{
 pub fn sys_fsync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
-    let dentry = {
-        let file_table = ctx.process.file_table().lock();
+    let dentry = ctx.process.file_table().lock_with(|file_table| {
         let file = file_table.get_file(fd)?;
         let inode_handle = file
             .downcast_ref::<InodeHandle>()
             .ok_or(Error::with_message(Errno::EINVAL, "not inode"))?;
-        inode_handle.dentry().clone()
-    };
+        Result::Ok(inode_handle.dentry().clone())
+    })?;
+
     dentry.sync_all()?;
     Ok(SyscallReturn::Return(0))
 }
@@ -24,14 +24,14 @@ pub fn sys_fsync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 pub fn sys_fdatasync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
-    let dentry = {
-        let file_table = ctx.process.file_table().lock();
+    let dentry = ctx.process.file_table().lock_with(|file_table| {
         let file = file_table.get_file(fd)?;
         let inode_handle = file
             .downcast_ref::<InodeHandle>()
             .ok_or(Error::with_message(Errno::EINVAL, "not inode"))?;
-        inode_handle.dentry().clone()
-    };
+        Result::Ok(inode_handle.dentry().clone())
+    })?;
+
     dentry.sync_data()?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -23,10 +23,10 @@ pub fn sys_getdents(
         fd, buf_addr, buf_len
     );
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let inode_handle = file
         .downcast_ref::<InodeHandle>()
         .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;
@@ -53,10 +53,10 @@ pub fn sys_getdents64(
         fd, buf_addr, buf_len
     );
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
     let inode_handle = file
         .downcast_ref::<InodeHandle>()
         .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;

--- a/kernel/src/syscall/lseek.rs
+++ b/kernel/src/syscall/lseek.rs
@@ -20,10 +20,11 @@ pub fn sys_lseek(fd: FileDesc, offset: isize, whence: u32, ctx: &Context) -> Res
         2 => SeekFrom::End(offset),
         _ => return_errno!(Errno::EINVAL),
     };
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     let offset = file.seek(seek_from)?;
     Ok(SyscallReturn::Return(offset as _))

--- a/kernel/src/syscall/pread64.rs
+++ b/kernel/src/syscall/pread64.rs
@@ -18,10 +18,10 @@ pub fn sys_pread64(
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
     if user_buf_len == 0 {
         return Ok(SyscallReturn::Return(0));

--- a/kernel/src/syscall/preadv.rs
+++ b/kernel/src/syscall/preadv.rs
@@ -65,10 +65,10 @@ fn do_sys_preadv(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
 
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
 
     if io_vec_count == 0 {
         return Ok(0);
@@ -127,10 +127,10 @@ fn do_sys_readv(
         fd, io_vec_ptr, io_vec_count
     );
 
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
 
     if io_vec_count == 0 {
         return Ok(0);

--- a/kernel/src/syscall/pwrite64.rs
+++ b/kernel/src/syscall/pwrite64.rs
@@ -17,10 +17,10 @@ pub fn sys_pwrite64(
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
     // TODO: Check (f.file->f_mode & FMODE_PWRITE); We don't have f_mode in our FileLike trait
     if user_buf_len == 0 {
         return Ok(SyscallReturn::Return(0));

--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -60,10 +60,10 @@ fn do_sys_pwritev(
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
     if io_vec_count == 0 {
         return Ok(0);
@@ -116,10 +116,11 @@ fn do_sys_writev(
         "fd = {}, io_vec_ptr = 0x{:x}, io_vec_counter = 0x{:x}",
         fd, io_vec_ptr, io_vec_count
     );
-    let file = {
-        let filetable = ctx.process.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|filetable| Result::Ok(filetable.get_file(fd)?.clone()))?;
     let mut total_len = 0;
 
     let mut reader_array = VmReaderArray::from_user_io_vecs(ctx, io_vec_ptr, io_vec_count)?;

--- a/kernel/src/syscall/read.rs
+++ b/kernel/src/syscall/read.rs
@@ -14,10 +14,10 @@ pub fn sys_read(
         fd, user_buf_addr, buf_len
     );
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     // According to <https://man7.org/linux/man-pages/man2/read.2.html>, if
     // the user specified an empty buffer, we should detect errors by checking

--- a/kernel/src/syscall/sendfile.rs
+++ b/kernel/src/syscall/sendfile.rs
@@ -33,13 +33,12 @@ pub fn sys_sendfile(
         count as usize
     };
 
-    let (out_file, in_file) = {
-        let file_table = ctx.process.file_table().lock();
+    let (out_file, in_file) = ctx.process.file_table().lock_with(|file_table| {
         let out_file = file_table.get_file(out_fd)?.clone();
         // FIXME: the in_file must support mmap-like operations (i.e., it cannot be a socket).
         let in_file = file_table.get_file(in_fd)?.clone();
-        (out_file, in_file)
-    };
+        Result::Ok((out_file, in_file))
+    })?;
 
     // sendfile can send at most `MAX_COUNT` bytes
     const MAX_COUNT: usize = 0x7fff_f000;

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -42,14 +42,13 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
         }
         _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported domain"),
     };
-    let fd = {
-        let mut file_table = ctx.process.file_table().lock();
+    let fd = ctx.process.file_table().lock_with(|file_table| {
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {
             FdFlags::empty()
         };
         file_table.insert(file_like, fd_flags)
-    };
+    });
     Ok(SyscallReturn::Return(fd as _))
 }

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -36,8 +36,7 @@ pub fn sys_socketpair(
         ),
     };
 
-    let socket_fds = {
-        let mut file_table = ctx.process.file_table().lock();
+    let socket_fds = ctx.process.file_table().lock_with(|file_table| {
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {
@@ -46,7 +45,7 @@ pub fn sys_socketpair(
         let fd_a = file_table.insert(socket_a, fd_flags);
         let fd_b = file_table.insert(socket_b, fd_flags);
         SocketFds(fd_a, fd_b)
-    };
+    });
 
     ctx.get_user_space().write_val(sv, &socket_fds)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -15,10 +15,10 @@ use crate::{
 pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}, stat_buf_addr = 0x{:x}", fd, stat_buf_ptr);
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     let stat = Stat::from(file.metadata());
     ctx.get_user_space().write_val(stat_buf_ptr, &stat)?;

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -16,10 +16,10 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize, ctx: &Context) -> Result<SyscallR
 
     check_length(len, ctx)?;
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     file.resize(len as usize)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/write.rs
+++ b/kernel/src/syscall/write.rs
@@ -14,10 +14,10 @@ pub fn sys_write(
         fd, user_buf_ptr, user_buf_len
     );
 
-    let file = {
-        let file_table = ctx.process.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let file = ctx
+        .process
+        .file_table()
+        .lock_with(|table| table.get_file(fd).cloned())?;
 
     // According to <https://man7.org/linux/man-pages/man2/write.2.html>, if
     // the user specified an empty buffer, we should detect errors by checking

--- a/kernel/src/thread/work_queue/worker.rs
+++ b/kernel/src/thread/work_queue/worker.rs
@@ -93,10 +93,14 @@ impl Worker {
                 if self.is_destroying() {
                     break;
                 }
-                self.inner.disable_irq().lock().worker_status = WorkerStatus::Idle;
+                self.inner
+                    .disable_irq()
+                    .lock_with(|inner| inner.worker_status = WorkerStatus::Idle);
                 worker_pool.idle_current_worker(self.bound_cpu, self.clone());
                 if !self.is_destroying() {
-                    self.inner.disable_irq().lock().worker_status = WorkerStatus::Running;
+                    self.inner
+                        .disable_irq()
+                        .lock_with(|inner| inner.worker_status = WorkerStatus::Running);
                 }
             }
         }
@@ -108,22 +112,32 @@ impl Worker {
     }
 
     pub(super) fn is_idle(&self) -> bool {
-        self.inner.disable_irq().lock().worker_status == WorkerStatus::Idle
+        self.inner
+            .disable_irq()
+            .lock_with(|inner| inner.worker_status == WorkerStatus::Idle)
     }
 
     pub(super) fn is_destroying(&self) -> bool {
-        self.inner.disable_irq().lock().worker_status == WorkerStatus::Destroying
+        self.inner
+            .disable_irq()
+            .lock_with(|inner| inner.worker_status == WorkerStatus::Destroying)
     }
 
     pub(super) fn destroy(&self) {
-        self.inner.disable_irq().lock().worker_status = WorkerStatus::Destroying;
+        self.inner
+            .disable_irq()
+            .lock_with(|inner| inner.worker_status = WorkerStatus::Destroying);
     }
 
     fn exit(&self) {
-        self.inner.disable_irq().lock().worker_status = WorkerStatus::Exited;
+        self.inner
+            .disable_irq()
+            .lock_with(|inner| inner.worker_status = WorkerStatus::Exited);
     }
 
     pub(super) fn is_exit(&self) -> bool {
-        self.inner.disable_irq().lock().worker_status == WorkerStatus::Exited
+        self.inner
+            .disable_irq()
+            .lock_with(|inner| inner.worker_status == WorkerStatus::Exited)
     }
 }

--- a/kernel/src/time/clocks/cpu_clock.rs
+++ b/kernel/src/time/clocks/cpu_clock.rs
@@ -31,13 +31,13 @@ impl CpuClock {
 
     /// Adds `interval` to the original recorded time to update the `CpuClock`.
     pub fn add_time(&self, interval: Duration) {
-        *self.time.disable_irq().lock() += interval;
+        self.time.disable_irq().lock_with(|t| *t += interval);
     }
 }
 
 impl Clock for CpuClock {
     fn read_time(&self) -> Duration {
-        *self.time.disable_irq().lock()
+        self.time.disable_irq().lock_with(|t| *t)
     }
 }
 

--- a/kernel/src/time/clocks/system_wide.rs
+++ b/kernel/src/time/clocks/system_wide.rs
@@ -165,7 +165,11 @@ impl Clock for MonotonicClock {
 
 impl Clock for RealTimeCoarseClock {
     fn read_time(&self) -> Duration {
-        *Self::current_ref().get().unwrap().disable_irq().lock()
+        Self::current_ref()
+            .get()
+            .unwrap()
+            .disable_irq()
+            .lock_with(|t| *t)
     }
 }
 
@@ -278,7 +282,7 @@ fn init_jiffies_clock_manager() {
 fn update_coarse_clock() {
     let real_time = RealTimeClock::get().read_time();
     let current = RealTimeCoarseClock::current_ref().get().unwrap();
-    *current.disable_irq().lock() = real_time;
+    current.disable_irq().lock_with(|cur| *cur = real_time);
 }
 
 fn init_coarse_clock() {

--- a/kernel/src/util/net/mod.rs
+++ b/kernel/src/util/net/mod.rs
@@ -15,6 +15,5 @@ use crate::{fs::file_table::FileDesc, net::socket::Socket, prelude::*};
 
 pub fn get_socket_from_fd(sockfd: FileDesc) -> Result<Arc<dyn Socket>> {
     let current = current!();
-    let file_table = current.file_table().lock();
-    file_table.get_socket(sockfd)
+    current.file_table().lock_with(|t| t.get_socket(sockfd))
 }

--- a/kernel/src/util/random.rs
+++ b/kernel/src/util/random.rs
@@ -13,7 +13,7 @@ static RNG: Once<SpinLock<StdRng>> = Once::new();
 ///
 /// It's cryptographically secure, as documented in [`rand::rngs::StdRng`].
 pub fn getrandom(dst: &mut [u8]) -> Result<()> {
-    Ok(RNG.get().unwrap().lock().try_fill_bytes(dst)?)
+    Ok(RNG.get().unwrap().lock_with(|g| g.try_fill_bytes(dst))?)
 }
 
 pub fn init() {

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -222,71 +222,74 @@ impl VmMapping {
         }
 
         let root_vmar = self.parent.upgrade().unwrap();
-        let mut cursor = root_vmar
-            .vm_space()
-            .cursor_mut(&(page_aligned_addr..page_aligned_addr + PAGE_SIZE))?;
+        root_vmar.vm_space().cursor_mut_with(
+            &(page_aligned_addr..page_aligned_addr + PAGE_SIZE),
+            |cursor| {
+                match cursor.query().unwrap() {
+                    VmItem::Mapped {
+                        va,
+                        frame,
+                        mut prop,
+                    } if is_write => {
+                        // Perform COW if it is a write access to a shared mapping.
 
-        match cursor.query().unwrap() {
-            VmItem::Mapped {
-                va,
-                frame,
-                mut prop,
-            } if is_write => {
-                // Perform COW if it is a write access to a shared mapping.
+                        // Skip if the page fault is already handled.
+                        if prop.flags.contains(PageFlags::W) {
+                            return Result::Ok(());
+                        }
 
-                // Skip if the page fault is already handled.
-                if prop.flags.contains(PageFlags::W) {
-                    return Ok(());
-                }
+                        // If the forked child or parent immediately unmaps the page after
+                        // the fork without accessing it, we are the only reference to the
+                        // frame. We can directly map the frame as writable without
+                        // copying. In this case, the reference count of the frame is 2 (
+                        // one for the mapping and one for the frame handle itself).
+                        let only_reference = frame.reference_count() == 2;
 
-                // If the forked child or parent immediately unmaps the page after
-                // the fork without accessing it, we are the only reference to the
-                // frame. We can directly map the frame as writable without
-                // copying. In this case, the reference count of the frame is 2 (
-                // one for the mapping and one for the frame handle itself).
-                let only_reference = frame.reference_count() == 2;
+                        let new_flags = PageFlags::W | PageFlags::ACCESSED | PageFlags::DIRTY;
 
-                let new_flags = PageFlags::W | PageFlags::ACCESSED | PageFlags::DIRTY;
-
-                if self.is_shared || only_reference {
-                    cursor.protect_next(PAGE_SIZE, |p| p.flags |= new_flags);
-                    cursor.flusher().issue_tlb_flush(TlbFlushOp::Address(va));
-                    cursor.flusher().dispatch_tlb_flush();
-                } else {
-                    let new_frame = duplicate_frame(&frame)?;
-                    prop.flags |= new_flags;
-                    cursor.map(new_frame, prop);
-                }
-            }
-            VmItem::Mapped { .. } => {
-                panic!("non-COW page fault should not happen on mapped address")
-            }
-            VmItem::NotMapped { .. } => {
-                // Map a new frame to the page fault address.
-
-                let inner = self.inner.read();
-                let (frame, is_readonly) = self.prepare_page(&inner, address, is_write)?;
-
-                let vm_perms = {
-                    let mut perms = inner.perms;
-                    if is_readonly {
-                        // COW pages are forced to be read-only.
-                        perms -= VmPerms::WRITE;
+                        if self.is_shared || only_reference {
+                            cursor.protect_next(PAGE_SIZE, |p| p.flags |= new_flags);
+                            cursor.flusher().issue_tlb_flush(TlbFlushOp::Address(va));
+                            cursor.flusher().dispatch_tlb_flush();
+                        } else {
+                            let new_frame = duplicate_frame(&frame)?;
+                            prop.flags |= new_flags;
+                            cursor.map(new_frame, prop);
+                        }
                     }
-                    perms
-                };
-                drop(inner);
+                    VmItem::Mapped { .. } => {
+                        panic!("non-COW page fault should not happen on mapped address")
+                    }
+                    VmItem::NotMapped { .. } => {
+                        // Map a new frame to the page fault address.
 
-                let mut page_flags = vm_perms.into();
-                page_flags |= PageFlags::ACCESSED;
-                if is_write {
-                    page_flags |= PageFlags::DIRTY;
+                        let inner = self.inner.read();
+                        let (frame, is_readonly) = self.prepare_page(&inner, address, is_write)?;
+
+                        let vm_perms = {
+                            let mut perms = inner.perms;
+                            if is_readonly {
+                                // COW pages are forced to be read-only.
+                                perms -= VmPerms::WRITE;
+                            }
+                            perms
+                        };
+                        drop(inner);
+
+                        let mut page_flags = vm_perms.into();
+                        page_flags |= PageFlags::ACCESSED;
+                        if is_write {
+                            page_flags |= PageFlags::DIRTY;
+                        }
+                        let map_prop = PageProperty::new(page_flags, CachePolicy::Writeback);
+
+                        cursor.map(frame, map_prop);
+                    }
                 }
-                let map_prop = PageProperty::new(page_flags, CachePolicy::Writeback);
 
-                cursor.map(frame, map_prop);
-            }
-        }
+                Result::Ok(())
+            },
+        )??;
 
         Ok(())
     }
@@ -349,28 +352,31 @@ impl VmMapping {
         let vm_perms = inner.perms - VmPerms::WRITE;
         let parent = self.parent.upgrade().unwrap();
         let vm_space = parent.vm_space();
-        let mut cursor = vm_space.cursor_mut(&(start_addr..end_addr))?;
-        let operate = move |commit_fn: &mut dyn FnMut() -> Result<Frame>| {
-            if let VmItem::NotMapped { va, len } = cursor.query().unwrap() {
-                // We regard all the surrounding pages as accessed, no matter
-                // if it is really so. Then the hardware won't bother to update
-                // the accessed bit of the page table on following accesses.
-                let page_flags = PageFlags::from(vm_perms) | PageFlags::ACCESSED;
-                let page_prop = PageProperty::new(page_flags, CachePolicy::Writeback);
-                let frame = commit_fn()?;
-                cursor.map(frame, page_prop);
-            } else {
-                let next_addr = cursor.virt_addr() + PAGE_SIZE;
-                if next_addr < end_addr {
-                    let _ = cursor.jump(next_addr);
+        vm_space.cursor_mut_with(&(start_addr..end_addr), |cursor| {
+            let operate = move |commit_fn: &mut dyn FnMut() -> Result<Frame>| {
+                if let VmItem::NotMapped { va, len } = cursor.query().unwrap() {
+                    // We regard all the surrounding pages as accessed, no matter
+                    // if it is really so. Then the hardware won't bother to update
+                    // the accessed bit of the page table on following accesses.
+                    let page_flags = PageFlags::from(vm_perms) | PageFlags::ACCESSED;
+                    let page_prop = PageProperty::new(page_flags, CachePolicy::Writeback);
+                    let frame = commit_fn()?;
+                    cursor.map(frame, page_prop);
+                } else {
+                    let next_addr = cursor.virt_addr() + PAGE_SIZE;
+                    if next_addr < end_addr {
+                        let _ = cursor.jump(next_addr);
+                    }
                 }
-            }
-            Ok(())
-        };
+                Ok(())
+            };
 
-        let start_offset = vmo_offset + start_addr - inner.map_to_addr;
-        let end_offset = vmo_offset + end_addr - inner.map_to_addr;
-        vmo.operate_on_range(&(start_offset..end_offset), operate)?;
+            let start_offset = vmo_offset + start_addr - inner.map_to_addr;
+            let end_offset = vmo_offset + end_addr - inner.map_to_addr;
+            vmo.operate_on_range(&(start_offset..end_offset), operate)?;
+
+            Result::Ok(())
+        })??;
 
         Ok(())
     }
@@ -549,8 +555,9 @@ impl VmMappingInner {
         let map_addr = range.start.align_down(PAGE_SIZE);
         let map_end = range.end.align_up(PAGE_SIZE);
         let map_range = map_addr..map_end;
-        let mut cursor = vm_space.cursor_mut(&map_range)?;
-        cursor.unmap(map_range.len());
+        vm_space.cursor_mut_with(&map_range, |cursor| {
+            cursor.unmap(map_range.len());
+        })?;
 
         if may_destroy && map_range == self.range() {
             self.is_destroyed = true;
@@ -566,16 +573,19 @@ impl VmMappingInner {
     ) -> Result<()> {
         debug_assert!(range.start % PAGE_SIZE == 0);
         debug_assert!(range.end % PAGE_SIZE == 0);
-        let mut cursor = vm_space.cursor_mut(&range).unwrap();
-        let op = |p: &mut PageProperty| p.flags = perms.into();
-        while cursor.virt_addr() < range.end {
-            if let Some(va) = cursor.protect_next(range.end - cursor.virt_addr(), op) {
-                cursor.flusher().issue_tlb_flush(TlbFlushOp::Range(va));
-            } else {
-                break;
-            }
-        }
-        cursor.flusher().dispatch_tlb_flush();
+        vm_space
+            .cursor_mut_with(&range, |cursor| {
+                let op = |p: &mut PageProperty| p.flags = perms.into();
+                while cursor.virt_addr() < range.end {
+                    if let Some(va) = cursor.protect_next(range.end - cursor.virt_addr(), op) {
+                        cursor.flusher().issue_tlb_flush(TlbFlushOp::Range(va));
+                    } else {
+                        break;
+                    }
+                }
+                cursor.flusher().dispatch_tlb_flush();
+            })
+            .unwrap();
         Ok(())
     }
 

--- a/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
+++ b/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
@@ -51,12 +51,14 @@ fn create_user_space(program: &[u8]) -> UserSpace {
         // created and manipulated safely through
         // the `VmSpace` abstraction.
         let vm_space = VmSpace::new();
-        let mut cursor = vm_space.cursor_mut(&(MAP_ADDR..MAP_ADDR + nbytes)).unwrap();
-        let map_prop = PageProperty::new(PageFlags::RWX, CachePolicy::Writeback);
-        for frame in user_pages {
-            cursor.map(frame, map_prop);
-        }
-        drop(cursor);
+        vm_space
+            .cursor_mut_with(&(MAP_ADDR..MAP_ADDR + nbytes), |cursor| {
+                let map_prop = PageProperty::new(PageFlags::RWX, CachePolicy::Writeback);
+                for frame in user_pages {
+                    cursor.map(frame, map_prop);
+                }
+            })
+            .unwrap();
         Arc::new(vm_space)
     };
     let user_cpu_state = {

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -47,7 +47,10 @@ pub(crate) fn get_num_processors() -> Option<u32> {
     if !ACPI_TABLES.is_completed() {
         return None;
     }
-    let processor_info = PlatformInfo::new(&*ACPI_TABLES.get().unwrap().lock())
+    let processor_info = ACPI_TABLES
+        .get()
+        .unwrap()
+        .lock_with(|t| PlatformInfo::new(t))
         .unwrap()
         .processor_info
         .unwrap();

--- a/ostd/src/arch/x86/device/cmos.rs
+++ b/ostd/src/arch/x86/device/cmos.rs
@@ -26,7 +26,11 @@ pub fn century_register() -> Option<u8> {
     if !ACPI_TABLES.is_completed() {
         return None;
     }
-    match ACPI_TABLES.get().unwrap().lock().find_table::<Fadt>() {
+    match ACPI_TABLES
+        .get()
+        .unwrap()
+        .lock_with(|t| t.find_table::<Fadt>())
+    {
         Ok(a) => Some(a.century),
         Err(er) => None,
     }

--- a/ostd/src/arch/x86/iommu/registers/mod.rs
+++ b/ostd/src/arch/x86/iommu/registers/mod.rs
@@ -97,7 +97,7 @@ impl IommuRegisters {
     ) {
         // Set root table address
         self.root_table_address
-            .write(root_table.lock().root_paddr() as u64);
+            .write(root_table.lock_with(|t| t.root_paddr()) as u64);
         self.write_global_command(GlobalCommand::SRTP, true);
         while !self.global_status().contains(GlobalStatus::RTPS) {}
 

--- a/ostd/src/arch/x86/kernel/acpi/dmar.rs
+++ b/ostd/src/arch/x86/kernel/acpi/dmar.rs
@@ -70,9 +70,12 @@ impl Dmar {
         if !super::ACPI_TABLES.is_completed() {
             return None;
         }
-        let acpi_table_lock = super::ACPI_TABLES.get().unwrap().lock();
         // SAFETY: The DmarHeader is the header for the DMAR structure, it fits all the field described in Intel manual.
-        let dmar_mapping = acpi_table_lock.find_table::<DmarHeader>().ok()?;
+        let dmar_mapping = super::ACPI_TABLES
+            .get()
+            .unwrap()
+            .lock_with(|table| table.find_table::<DmarHeader>())
+            .ok()?;
 
         let physical_address = dmar_mapping.physical_start();
         let len = dmar_mapping.mapped_length();

--- a/ostd/src/arch/x86/kernel/apic/ioapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/ioapic.rs
@@ -188,8 +188,12 @@ pub fn init() {
         });
         return;
     }
-    let table = ACPI_TABLES.get().unwrap().lock();
-    let platform_info = PlatformInfo::new(&*table).unwrap();
+
+    let platform_info = ACPI_TABLES
+        .get()
+        .unwrap()
+        .lock_with(|tables| PlatformInfo::new(tables).unwrap());
+
     match platform_info.interrupt_model {
         acpi::InterruptModel::Unknown => panic!("not found APIC in ACPI Table"),
         acpi::InterruptModel::Apic(apic) => {

--- a/ostd/src/arch/x86/kernel/mod.rs
+++ b/ostd/src/arch/x86/kernel/mod.rs
@@ -5,4 +5,4 @@ pub(super) mod apic;
 pub(super) mod pic;
 pub(super) mod tsc;
 
-pub use apic::ioapic::IO_APIC;
+pub use apic::ioapic::{IoApic, IO_APIC};

--- a/ostd/src/arch/x86/timer/pit.rs
+++ b/ostd/src/arch/x86/timer/pit.rs
@@ -180,14 +180,26 @@ pub(crate) fn init(operating_mode: OperatingMode) {
 
 /// Enable the IOAPIC line that connected to PIC
 pub(crate) fn enable_ioapic_line(irq: IrqLine) {
-    let mut io_apic = IO_APIC.get().unwrap().first().unwrap().lock();
-    debug_assert_eq!(io_apic.interrupt_base(), 0);
-    io_apic.enable(2, irq.clone()).unwrap();
+    IO_APIC
+        .get()
+        .unwrap()
+        .first()
+        .unwrap()
+        .lock_with(|io_apic| {
+            debug_assert_eq!(io_apic.interrupt_base(), 0);
+            io_apic.enable(2, irq.clone()).unwrap();
+        });
 }
 
 /// Disable the IOAPIC line that connected to PIC
 pub(crate) fn disable_ioapic_line() {
-    let mut io_apic = IO_APIC.get().unwrap().first().unwrap().lock();
-    debug_assert_eq!(io_apic.interrupt_base(), 0);
-    io_apic.disable(2).unwrap();
+    IO_APIC
+        .get()
+        .unwrap()
+        .first()
+        .unwrap()
+        .lock_with(|io_apic| {
+            debug_assert_eq!(io_apic.interrupt_base(), 0);
+            io_apic.disable(2).unwrap();
+        });
 }

--- a/ostd/src/cpu/set.rs
+++ b/ostd/src/cpu/set.rs
@@ -141,6 +141,7 @@ impl From<CpuId> for CpuSet {
 ///
 /// It provides atomic operations for each CPU in the system. When the
 /// operation contains multiple CPUs, the ordering is not guaranteed.
+#[derive(Debug)]
 pub struct AtomicCpuSet {
     bits: SmallVec<[AtomicInnerPart; NR_PARTS_NO_ALLOC]>,
 }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -49,79 +49,81 @@ impl VirtAddrAllocator {
     ///
     /// This is currently implemented with a simple FIRST-FIT algorithm.
     fn alloc(&self, size: usize) -> Result<Range<Vaddr>> {
-        let mut lock_guard = self.freelist.lock();
-        if lock_guard.is_none() {
-            let mut freelist: BTreeMap<Vaddr, KVirtAreaFreeNode> = BTreeMap::new();
-            freelist.insert(
-                self.fullrange.start,
-                KVirtAreaFreeNode::new(self.fullrange.clone()),
-            );
-            *lock_guard = Some(freelist);
-        }
-        let freelist = lock_guard.as_mut().unwrap();
-        let mut allocate_range = None;
-        let mut to_remove = None;
-
-        for (key, value) in freelist.iter() {
-            if value.block.end - value.block.start >= size {
-                allocate_range = Some((value.block.end - size)..value.block.end);
-                to_remove = Some(*key);
-                break;
+        self.freelist.lock_with(|freelist| {
+            if freelist.is_none() {
+                let mut init_freelist: BTreeMap<Vaddr, KVirtAreaFreeNode> = BTreeMap::new();
+                init_freelist.insert(
+                    self.fullrange.start,
+                    KVirtAreaFreeNode::new(self.fullrange.clone()),
+                );
+                *freelist = Some(init_freelist);
             }
-        }
+            let freelist = freelist.as_mut().unwrap();
+            let mut allocate_range = None;
+            let mut to_remove = None;
 
-        if let Some(key) = to_remove {
-            if let Some(freenode) = freelist.get_mut(&key) {
-                if freenode.block.end - size == freenode.block.start {
-                    freelist.remove(&key);
-                } else {
-                    freenode.block.end -= size;
+            for (key, value) in freelist.iter() {
+                if value.block.end - value.block.start >= size {
+                    allocate_range = Some((value.block.end - size)..value.block.end);
+                    to_remove = Some(*key);
+                    break;
                 }
             }
-        }
 
-        if let Some(range) = allocate_range {
-            Ok(range)
-        } else {
-            Err(Error::KVirtAreaAllocError)
-        }
+            if let Some(key) = to_remove {
+                if let Some(freenode) = freelist.get_mut(&key) {
+                    if freenode.block.end - size == freenode.block.start {
+                        freelist.remove(&key);
+                    } else {
+                        freenode.block.end -= size;
+                    }
+                }
+            }
+
+            if let Some(range) = allocate_range {
+                Ok(range)
+            } else {
+                Err(Error::KVirtAreaAllocError)
+            }
+        })
     }
 
     /// Frees a kernel virtual area.
     fn free(&self, range: Range<Vaddr>) {
-        let mut lock_guard = self.freelist.lock();
-        let freelist = lock_guard.as_mut().unwrap_or_else(|| {
-            panic!("Free a 'KVirtArea' when 'VirtAddrAllocator' has not been initialized.")
-        });
-        // 1. get the previous free block, check if we can merge this block with the free one
-        //     - if contiguous, merge this area with the free block.
-        //     - if not contiguous, create a new free block, insert it into the list.
-        let mut free_range = range.clone();
+        self.freelist.lock_with(|freelist| {
+            let freelist = freelist.as_mut().unwrap_or_else(|| {
+                panic!("Free a 'KVirtArea' when 'VirtAddrAllocator' has not been initialized.")
+            });
+            // 1. get the previous free block, check if we can merge this block with the free one
+            //     - if contiguous, merge this area with the free block.
+            //     - if not contiguous, create a new free block, insert it into the list.
+            let mut free_range = range.clone();
 
-        if let Some((prev_va, prev_node)) = freelist
-            .upper_bound_mut(core::ops::Bound::Excluded(&free_range.start))
-            .peek_prev()
-        {
-            if prev_node.block.end == free_range.start {
-                let prev_va = *prev_va;
-                free_range.start = prev_node.block.start;
-                freelist.remove(&prev_va);
+            if let Some((prev_va, prev_node)) = freelist
+                .upper_bound_mut(core::ops::Bound::Excluded(&free_range.start))
+                .peek_prev()
+            {
+                if prev_node.block.end == free_range.start {
+                    let prev_va = *prev_va;
+                    free_range.start = prev_node.block.start;
+                    freelist.remove(&prev_va);
+                }
             }
-        }
-        freelist.insert(free_range.start, KVirtAreaFreeNode::new(free_range.clone()));
+            freelist.insert(free_range.start, KVirtAreaFreeNode::new(free_range.clone()));
 
-        // 2. check if we can merge the current block with the next block, if we can, do so.
-        if let Some((next_va, next_node)) = freelist
-            .lower_bound_mut(core::ops::Bound::Excluded(&free_range.start))
-            .peek_next()
-        {
-            if free_range.end == next_node.block.start {
-                let next_va = *next_va;
-                free_range.end = next_node.block.end;
-                freelist.remove(&next_va);
-                freelist.get_mut(&free_range.start).unwrap().block.end = free_range.end;
+            // 2. check if we can merge the current block with the next block, if we can, do so.
+            if let Some((next_va, next_node)) = freelist
+                .lower_bound_mut(core::ops::Bound::Excluded(&free_range.start))
+                .peek_next()
+            {
+                if free_range.end == next_node.block.start {
+                    let next_va = *next_va;
+                    free_range.end = next_node.block.end;
+                    freelist.remove(&next_va);
+                    freelist.get_mut(&free_range.start).unwrap().block.end = free_range.end;
+                }
             }
-        }
+        })
     }
 }
 

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -54,24 +54,24 @@
 //! provided by the APIs (as long as safety requirements are met) will not
 //! break the page table data structure (or other memory).
 //!
-//! However, the page table cursor creation APIs, [`CursorMut::new`] or
-//! [`Cursor::new`], do not guarantee exclusive access to the virtual address
-//! area you claim. From the lock protocol, you can see that there are chances
-//! to create 2 cursors that claim the same virtual address range (one covers
-//! another). In this case, the greater cursor may block if it wants to modify
-//! the page table entries covered by the smaller cursor. Also, if the greater
-//! cursor destructs the smaller cursor's parent page table node, it won't block
-//! and the smaller cursor's change will not be visible. The user of the page
-//! table cursor should add additional entry point checks to prevent these defined
-//! behaviors if they are not wanted.
+//! However, the page table cursor creation APIs, [`CursorMut::new`] or do not
+//! guarantee exclusive access to the virtual address area you claim. From the
+//! lock protocol, you can see that there are chances to create 2 cursors that
+//! claim the same virtual address range (one covers another). In this case,
+//! the greater cursor may block if it wants to modify the page table entries
+//! covered by the smaller cursor. Also, if the greater cursor destructs the
+//! smaller cursor's parent page table node, it won't block and the smaller
+//! cursor's change will not be visible. The user of the page table cursor
+//! should add additional entry point checks to prevent these defined behaviors
+//! if they are not wanted.
 
-use core::{any::TypeId, marker::PhantomData, ops::Range};
+use core::{any::TypeId, ops::Range, pin::Pin};
 
 use align_ext::AlignExt;
 
 use super::{
     page_size, pte_index, Child, Entry, KernelMode, PageTable, PageTableEntryTrait, PageTableError,
-    PageTableMode, PageTableNode, PagingConstsTrait, PagingLevel, UserMode,
+    PageTableMode, PageTableNode, PagingConstsTrait, PagingLevel, RawPageTableNode, UserMode,
 };
 use crate::{
     mm::{
@@ -82,6 +82,7 @@ use crate::{
         },
         Paddr, PageProperty, Vaddr,
     },
+    sync::spin::mcs,
     task::{disable_preempt, DisabledPreemptGuard},
 };
 
@@ -117,19 +118,32 @@ pub enum PageTableItem {
 /// and even to jump to a virtual address directly. We use a guard stack to
 /// simulate the recursion, and adpot a page table locking protocol to
 /// provide concurrency.
+///
+/// The cursor must be pinned ([`Pin`]) to use MCS spinlocks.
 #[derive(Debug)]
-pub struct Cursor<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait>
+pub struct CursorMut<'pt, 'mcs, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait>
 where
     [(); C::NR_LEVELS as usize]:,
 {
+    pt: &'pt PageTable<M, E, C>,
     /// The lock guards of the cursor. The level 1 page table lock guard is at
     /// index 0, and the level N page table lock guard is at index N - 1.
     ///
     /// When destructing the cursor, the locks will be released in the order
     /// from low to high, exactly the reverse order of the acquisition.
-    /// This behavior is ensured by the default drop implementation of Rust:
-    /// <https://doc.rust-lang.org/reference/destructors.html>.
-    guards: [Option<PageTableNode<E, C>>; C::NR_LEVELS as usize],
+    guards: [Option<PageTableNode<'mcs, E, C>>; C::NR_LEVELS as usize],
+    /// Pinned MCS nodes for the locks.
+    ///
+    /// The page table guards uses the MCS spin lock specified in [`mcs`].
+    /// The lock requires a node to be pinned during the lock holding.
+    ///
+    /// The MCS node in each level corresponds to the guard in the same level.
+    /// When the guard exists, the node should be `None`. When the guard is
+    /// released, the node should be `Some`.
+    ///
+    /// The length is fixed because that we cannot construct a constant generic
+    /// sized array with mutable references.
+    mcs_nodes: [Option<Pin<&'mcs mut mcs::UnsafeNode>>; 5],
     /// The level of the page table that the cursor points to.
     level: PagingLevel,
     /// From `guard_level` to `level`, the locks are held in `guards`.
@@ -140,10 +154,42 @@ where
     barrier_va: Range<Vaddr>,
     #[allow(dead_code)]
     preempt_guard: DisabledPreemptGuard,
-    _phantom: PhantomData<&'a PageTable<M, E, C>>,
 }
 
-impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> Cursor<'a, M, E, C>
+/******************************* Immutable methods ****************************/
+
+impl<M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> Drop
+    for CursorMut<'_, '_, M, E, C>
+where
+    [(); C::NR_LEVELS as usize]:,
+{
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        {
+            for i in 1..C::NR_LEVELS {
+                if self.level <= i && i <= self.guard_level {
+                    debug_assert!(self.guards[(i - 1) as usize].is_some());
+                    debug_assert!(self.mcs_nodes[(i - 1) as usize].is_none());
+                } else {
+                    debug_assert!(self.guards[(i - 1) as usize].is_none());
+                    debug_assert!(self.mcs_nodes[(i - 1) as usize].is_some());
+                }
+            }
+        }
+
+        for i in self.level..=self.guard_level {
+            drop(
+                self.guards[(i - 1) as usize]
+                    .take()
+                    .unwrap()
+                    .release_into_raw(),
+            );
+        }
+    }
+}
+
+impl<'pt, 'mcs, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait>
+    CursorMut<'pt, 'mcs, M, E, C>
 where
     [(); C::NR_LEVELS as usize]:,
 {
@@ -155,7 +201,11 @@ where
     ///
     /// Note that this function does not ensure exclusive access to the claimed
     /// virtual address range. The accesses using this cursor may block or fail.
-    pub fn new(pt: &'a PageTable<M, E, C>, va: &Range<Vaddr>) -> Result<Self, PageTableError> {
+    pub(super) fn new(
+        pt: &'pt PageTable<M, E, C>,
+        va: &Range<Vaddr>,
+        mcs_nodes: [Pin<&'mcs mut mcs::UnsafeNode>; 5],
+    ) -> Result<Self, PageTableError> {
         if !M::covers(va) || va.is_empty() {
             return Err(PageTableError::InvalidVaddrRange(va.start, va.end));
         }
@@ -163,22 +213,22 @@ where
             return Err(PageTableError::UnalignedVaddr);
         }
 
-        // Create a guard array that only hold the root node lock.
-        let guards = core::array::from_fn(|i| {
-            if i == (C::NR_LEVELS - 1) as usize {
-                Some(pt.root.clone_shallow().lock())
-            } else {
-                None
-            }
-        });
         let mut cursor = Self {
-            guards,
+            pt,
+            guards: core::array::from_fn(|_| None),
+            mcs_nodes: mcs_nodes.map(Some),
             level: C::NR_LEVELS,
             guard_level: C::NR_LEVELS,
             va: va.start,
             barrier_va: va.clone(),
             preempt_guard: disable_preempt(),
-            _phantom: PhantomData,
+        };
+
+        let mut cur_guard = {
+            let root_mcs_node = cursor.mcs_nodes[(cursor.level - 1) as usize]
+                .take()
+                .unwrap();
+            Some(cursor.lock_for(cursor.pt.root.clone_shallow(), Some(root_mcs_node)))
         };
 
         // Go down and get proper locks. The cursor should hold a lock of a
@@ -186,7 +236,7 @@ where
         //
         // While going down, previous guards of too-high levels will be released.
         loop {
-            let level_too_high = {
+            let level_too_high = cursor.level > 1 && {
                 let start_idx = pte_index::<C>(va.start, cursor.level);
                 let end_idx = pte_index::<C>(va.end - 1, cursor.level);
                 start_idx == end_idx
@@ -195,7 +245,8 @@ where
                 break;
             }
 
-            let entry = cursor.cur_entry();
+            let idx = pte_index::<C>(cursor.barrier_va.start, cursor.level);
+            let entry = cur_guard.as_mut().unwrap().entry(idx);
             if !entry.is_node() {
                 break;
             }
@@ -203,12 +254,23 @@ where
                 unreachable!("Already checked");
             };
 
-            cursor.push_level(child_pt.lock());
+            // Release the current level lock before acquiring the child level lock.
+            let (raw, mcs_node) = cur_guard.take().unwrap().release_into_raw();
+            drop(raw);
+            debug_assert!(cursor.mcs_nodes[(cursor.level - 1) as usize].is_none());
+            cursor.mcs_nodes[(cursor.level - 1) as usize] = Some(mcs_node);
 
-            // Release the guard of the previous (upper) level.
-            cursor.guards[cursor.level as usize] = None;
-            cursor.guard_level -= 1;
+            // Go down to the child level.
+            cursor.level -= 1;
+
+            let cur_mcs_node = cursor.mcs_nodes[(cursor.level - 1) as usize]
+                .take()
+                .unwrap();
+            cur_guard = Some(cursor.lock_for(child_pt, Some(cur_mcs_node)));
         }
+
+        cursor.guards[(cursor.level - 1) as usize] = cur_guard;
+        cursor.guard_level = cursor.level;
 
         Ok(cursor)
     }
@@ -225,7 +287,8 @@ where
 
             match self.cur_entry().to_owned() {
                 Child::PageTable(pt) => {
-                    self.push_level(pt.lock());
+                    let mcs_node = self.take_child_mcs_node();
+                    self.push_level(pt, mcs_node);
                     continue;
                 }
                 Child::None => {
@@ -260,6 +323,7 @@ where
         while self.level < self.guard_level && pte_index::<C>(next_va, self.level) == 0 {
             self.pop_level();
         }
+
         self.va = next_va;
     }
 
@@ -309,33 +373,85 @@ where
     /// This method requires locks acquired before calling it. The discarded
     /// level will be unlocked.
     fn pop_level(&mut self) {
-        self.guards[(self.level - 1) as usize] = None;
+        let (raw, mcs_node) = self.guards[(self.level - 1) as usize]
+            .take()
+            .unwrap()
+            .release_into_raw();
+        drop(raw);
+        // Put the MCS node back to the pool.
+        self.mcs_nodes[(self.level - 1) as usize] = Some(mcs_node);
         self.level += 1;
 
         // TODO: Drop page tables if page tables become empty.
     }
 
-    /// Goes down a level to a child page table.
-    fn push_level(&mut self, child_pt: PageTableNode<E, C>) {
+    fn lock_for(
+        &self,
+        node: RawPageTableNode<E, C>,
+        mcs_node: Option<Pin<&'mcs mut mcs::UnsafeNode>>,
+    ) -> PageTableNode<'mcs, E, C> {
+        PageTableNode::<E, C>::lock_from_raw(node, mcs_node.unwrap())
+    }
+
+    /// Goes down a level to a child page table with an unlocked child.
+    fn push_level(
+        &mut self,
+        child_pt: RawPageTableNode<E, C>,
+        mcs_node: Option<Pin<&'mcs mut mcs::UnsafeNode>>,
+    ) {
+        let locked_child = self.lock_for(child_pt, mcs_node);
+
+        self.push_locked_level(locked_child);
+    }
+
+    /// Goes down a level to a child page table with a locked child.
+    fn push_locked_level(&mut self, child_pt: PageTableNode<'mcs, E, C>) {
         self.level -= 1;
+
         debug_assert_eq!(self.level, child_pt.level());
+        debug_assert!(self.guards[(self.level - 1) as usize].is_none());
+
         self.guards[(self.level - 1) as usize] = Some(child_pt);
     }
 
-    fn should_map_as_tracked(&self) -> bool {
+    fn should_map_as_tracked(&mut self) -> bool {
         (TypeId::of::<M>() == TypeId::of::<KernelMode>()
             || TypeId::of::<M>() == TypeId::of::<UserMode>())
             && should_map_as_tracked(self.va)
     }
 
-    fn cur_entry(&mut self) -> Entry<'_, E, C> {
+    fn cur_entry<'guard>(&'guard mut self) -> Entry<'guard, 'mcs, E, C> {
         let node = self.guards[(self.level - 1) as usize].as_mut().unwrap();
+
         node.entry(pte_index::<C>(self.va, self.level))
+    }
+
+    fn take_child_mcs_node(&mut self) -> Option<Pin<&'mcs mut mcs::UnsafeNode>> {
+        if self.level == 1 {
+            return None;
+        }
+
+        let child_level = self.level - 1;
+
+        Some(self.mcs_nodes[(child_level - 1) as usize].take().unwrap())
+    }
+
+    fn put_child_mcs_node(&mut self, mcs_node: Option<Pin<&'mcs mut mcs::UnsafeNode>>) {
+        if self.level == 1 {
+            debug_assert!(mcs_node.is_none());
+            return;
+        }
+
+        let child_level = self.level - 1;
+
+        debug_assert!(self.mcs_nodes[(child_level - 1) as usize].is_none());
+
+        self.mcs_nodes[(child_level - 1) as usize] = mcs_node;
     }
 }
 
 impl<M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> Iterator
-    for Cursor<'_, M, E, C>
+    for CursorMut<'_, '_, M, E, C>
 where
     [(); C::NR_LEVELS as usize]:,
 {
@@ -350,59 +466,12 @@ where
     }
 }
 
-/// The cursor of a page table that is capable of map, unmap or protect pages.
-///
-/// Also, it has all the capabilities of a [`Cursor`]. A virtual address range
-/// in a page table can only be accessed by one cursor whether it is mutable or not.
-#[derive(Debug)]
-pub struct CursorMut<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait>(
-    Cursor<'a, M, E, C>,
-)
-where
-    [(); C::NR_LEVELS as usize]:;
+/******************************** Mutable methods ****************************/
 
-impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> CursorMut<'a, M, E, C>
+impl<M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> CursorMut<'_, '_, M, E, C>
 where
     [(); C::NR_LEVELS as usize]:,
 {
-    /// Creates a cursor claiming the write access for the given range.
-    ///
-    /// The cursor created will only be able to map, query or jump within the given
-    /// range. Out-of-bound accesses will result in panics or errors as return values,
-    /// depending on the access method.
-    ///
-    /// Note that this function, the same as [`Cursor::new`], does not ensure exclusive
-    /// access to the claimed virtual address range. The accesses using this cursor may
-    /// block or fail.
-    pub(super) fn new(
-        pt: &'a PageTable<M, E, C>,
-        va: &Range<Vaddr>,
-    ) -> Result<Self, PageTableError> {
-        Cursor::new(pt, va).map(|inner| Self(inner))
-    }
-
-    /// Jumps to the given virtual address.
-    ///
-    /// This is the same as [`Cursor::jump`].
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the address is out of the range where the cursor is required to operate,
-    /// or has bad alignment.
-    pub fn jump(&mut self, va: Vaddr) -> Result<(), PageTableError> {
-        self.0.jump(va)
-    }
-
-    /// Gets the current virtual address.
-    pub fn virt_addr(&self) -> Vaddr {
-        self.0.virt_addr()
-    }
-
-    /// Gets the information of the current slot.
-    pub fn query(&mut self) -> Result<PageTableItem, PageTableError> {
-        self.0.query()
-    }
-
     /// Maps the range starting from the current address to a [`DynPage`].
     ///
     /// It returns the previously mapped [`DynPage`] if that exists.
@@ -419,26 +488,28 @@ where
     /// The caller should ensure that the virtual range being mapped does
     /// not affect kernel's memory safety.
     pub unsafe fn map(&mut self, page: DynPage, prop: PageProperty) -> Option<DynPage> {
-        let end = self.0.va + page.size();
-        assert!(end <= self.0.barrier_va.end);
+        let end = self.va + page.size();
+        assert!(end <= self.barrier_va.end);
 
         // Go down if not applicable.
-        while self.0.level > C::HIGHEST_TRANSLATION_LEVEL
-            || self.0.va % page_size::<C>(self.0.level) != 0
-            || self.0.va + page_size::<C>(self.0.level) > end
+        while self.level > C::HIGHEST_TRANSLATION_LEVEL
+            || self.va % page_size::<C>(self.level) != 0
+            || self.va + page_size::<C>(self.level) > end
         {
-            debug_assert!(self.0.should_map_as_tracked());
-            let cur_level = self.0.level;
-            let cur_entry = self.0.cur_entry();
+            debug_assert!(self.should_map_as_tracked());
+            let cur_level = self.level;
+            let cur_entry = self.cur_entry();
             match cur_entry.to_owned() {
                 Child::PageTable(pt) => {
-                    self.0.push_level(pt.lock());
+                    let mcs_node = self.take_child_mcs_node();
+                    self.push_level(pt, mcs_node);
                 }
                 Child::None => {
                     let pt =
-                        PageTableNode::<E, C>::alloc(cur_level - 1, MapTrackingStatus::Tracked);
-                    let _ = cur_entry.replace(Child::PageTable(pt.clone_raw()));
-                    self.0.push_level(pt);
+                        RawPageTableNode::<E, C>::alloc(cur_level - 1, MapTrackingStatus::Tracked);
+                    let _ = cur_entry.replace(Child::PageTable(pt.clone_shallow()));
+                    let mcs_node = self.take_child_mcs_node();
+                    self.push_level(pt, mcs_node);
                 }
                 Child::Page(_, _) => {
                     panic!("Mapping a smaller page in an already mapped huge page");
@@ -449,11 +520,11 @@ where
             }
             continue;
         }
-        debug_assert_eq!(self.0.level, page.level());
+        debug_assert_eq!(self.level, page.level());
 
         // Map the current page.
-        let old = self.0.cur_entry().replace(Child::Page(page, prop));
-        self.0.move_forward();
+        let old = self.cur_entry().replace(Child::Page(page, prop));
+        self.move_forward();
 
         match old {
             Child::Page(old_page, _) => Some(old_page),
@@ -493,58 +564,58 @@ where
     ///  - the physical address to be mapped is valid and safe to use;
     ///  - it is allowed to map untracked pages in this virtual address range.
     pub unsafe fn map_pa(&mut self, pa: &Range<Paddr>, prop: PageProperty) {
-        let end = self.0.va + pa.len();
+        let end = self.va + pa.len();
         let mut pa = pa.start;
-        assert!(end <= self.0.barrier_va.end);
+        assert!(end <= self.barrier_va.end);
 
-        while self.0.va < end {
+        while self.va < end {
             // We ensure not mapping in reserved kernel shared tables or releasing it.
             // Although it may be an invariant for all architectures and will be optimized
             // out by the compiler since `C::NR_LEVELS - 1 > C::HIGHEST_TRANSLATION_LEVEL`.
             let is_kernel_shared_node =
-                TypeId::of::<M>() == TypeId::of::<KernelMode>() && self.0.level >= C::NR_LEVELS - 1;
-            if self.0.level > C::HIGHEST_TRANSLATION_LEVEL
+                TypeId::of::<M>() == TypeId::of::<KernelMode>() && self.level >= C::NR_LEVELS - 1;
+            if self.level > C::HIGHEST_TRANSLATION_LEVEL
                 || is_kernel_shared_node
-                || self.0.va % page_size::<C>(self.0.level) != 0
-                || self.0.va + page_size::<C>(self.0.level) > end
-                || pa % page_size::<C>(self.0.level) != 0
+                || self.va % page_size::<C>(self.level) != 0
+                || self.va + page_size::<C>(self.level) > end
+                || pa % page_size::<C>(self.level) != 0
             {
-                let cur_level = self.0.level;
-                let cur_entry = self.0.cur_entry();
+                let cur_level = self.level;
+                let child_mcs_node = self.take_child_mcs_node();
+                let cur_entry = self.cur_entry();
                 match cur_entry.to_owned() {
                     Child::PageTable(pt) => {
-                        self.0.push_level(pt.lock());
+                        self.push_level(pt, child_mcs_node);
                     }
                     Child::None => {
-                        let pt = PageTableNode::<E, C>::alloc(
+                        let pt = RawPageTableNode::<E, C>::alloc(
                             cur_level - 1,
                             MapTrackingStatus::Untracked,
                         );
-                        let _ = cur_entry.replace(Child::PageTable(pt.clone_raw()));
-                        self.0.push_level(pt);
+                        let _ = cur_entry.replace(Child::PageTable(pt.clone_shallow()));
+                        self.push_level(pt, child_mcs_node);
                     }
                     Child::Page(_, _) => {
                         panic!("Mapping a smaller page in an already mapped huge page");
                     }
                     Child::Untracked(_, _, _) => {
-                        let split_child = cur_entry.split_if_untracked_huge().unwrap();
-                        self.0.push_level(split_child);
+                        let split_child = cur_entry
+                            .split_if_untracked_huge(child_mcs_node.unwrap())
+                            .unwrap();
+                        self.push_locked_level(split_child);
                     }
                 }
                 continue;
             }
 
             // Map the current page.
-            debug_assert!(!self.0.should_map_as_tracked());
-            let level = self.0.level;
-            let _ = self
-                .0
-                .cur_entry()
-                .replace(Child::Untracked(pa, level, prop));
+            debug_assert!(!self.should_map_as_tracked());
+            let level = self.level;
+            let _ = self.cur_entry().replace(Child::Untracked(pa, level, prop));
 
             // Move forward.
             pa += page_size::<C>(level);
-            self.0.move_forward();
+            self.move_forward();
         }
     }
 
@@ -573,23 +644,25 @@ where
     /// This function will panic if the end range covers a part of a huge page
     /// and the next page is that huge page.
     pub unsafe fn take_next(&mut self, len: usize) -> PageTableItem {
-        let start = self.0.va;
+        let start = self.va;
         assert!(len % page_size::<C>(1) == 0);
         let end = start + len;
-        assert!(end <= self.0.barrier_va.end);
+        assert!(end <= self.barrier_va.end);
 
-        while self.0.va < end {
-            let cur_va = self.0.va;
-            let cur_level = self.0.level;
-            let cur_entry = self.0.cur_entry();
+        while self.va < end {
+            let cur_va = self.va;
+            let cur_level = self.level;
+            let child_mcs_node = self.take_child_mcs_node();
+            let cur_entry = self.cur_entry();
 
             // Skip if it is already absent.
             if cur_entry.is_none() {
-                if self.0.va + page_size::<C>(self.0.level) > end {
-                    self.0.va = end;
+                self.put_child_mcs_node(child_mcs_node);
+                if self.va + page_size::<C>(self.level) > end {
+                    self.va = end;
                     break;
                 }
-                self.0.move_forward();
+                self.move_forward();
                 continue;
             }
 
@@ -598,17 +671,20 @@ where
                 let child = cur_entry.to_owned();
                 match child {
                     Child::PageTable(pt) => {
-                        let pt = pt.lock();
+                        let locked_pt = self.lock_for(pt, child_mcs_node);
                         // If there's no mapped PTEs in the next level, we can
                         // skip to save time.
-                        if pt.nr_children() != 0 {
-                            self.0.push_level(pt);
+                        if locked_pt.nr_children() != 0 {
+                            self.push_locked_level(locked_pt);
                         } else {
-                            if self.0.va + page_size::<C>(self.0.level) > end {
-                                self.0.va = end;
+                            let (raw, mcs_node) = locked_pt.release_into_raw();
+                            drop(raw);
+                            self.put_child_mcs_node(Some(mcs_node));
+                            if self.va + page_size::<C>(self.level) > end {
+                                self.va = end;
                                 break;
                             }
-                            self.0.move_forward();
+                            self.move_forward();
                         }
                     }
                     Child::None => {
@@ -618,8 +694,10 @@ where
                         panic!("Removing part of a huge page");
                     }
                     Child::Untracked(_, _, _) => {
-                        let split_child = cur_entry.split_if_untracked_huge().unwrap();
-                        self.0.push_level(split_child);
+                        let split_child = cur_entry
+                            .split_if_untracked_huge(child_mcs_node.unwrap())
+                            .unwrap();
+                        self.push_locked_level(split_child);
                     }
                 }
                 continue;
@@ -628,18 +706,20 @@ where
             // Unmap the current page and return it.
             let old = cur_entry.replace(Child::None);
 
-            self.0.move_forward();
+            self.put_child_mcs_node(child_mcs_node);
+
+            self.move_forward();
 
             return match old {
                 Child::Page(page, prop) => PageTableItem::Mapped {
-                    va: self.0.va,
+                    va: self.va,
                     page,
                     prop,
                 },
                 Child::Untracked(pa, level, prop) => {
-                    debug_assert_eq!(level, self.0.level);
+                    debug_assert_eq!(level, self.level);
                     PageTableItem::MappedUntracked {
-                        va: self.0.va,
+                        va: self.va,
                         pa,
                         len: page_size::<C>(level),
                         prop,
@@ -685,17 +765,19 @@ where
         len: usize,
         op: &mut impl FnMut(&mut PageProperty),
     ) -> Option<Range<Vaddr>> {
-        let end = self.0.va + len;
-        assert!(end <= self.0.barrier_va.end);
+        let end = self.va + len;
+        assert!(end <= self.barrier_va.end);
 
-        while self.0.va < end {
-            let cur_va = self.0.va;
-            let cur_level = self.0.level;
-            let mut cur_entry = self.0.cur_entry();
+        while self.va < end {
+            let cur_va = self.va;
+            let cur_level = self.level;
+            let child_mcs_node = self.take_child_mcs_node();
+            let mut cur_entry = self.cur_entry();
 
             // Skip if it is already absent.
             if cur_entry.is_none() {
-                self.0.move_forward();
+                self.put_child_mcs_node(child_mcs_node);
+                self.move_forward();
                 continue;
             }
 
@@ -704,13 +786,16 @@ where
                 let Child::PageTable(pt) = cur_entry.to_owned() else {
                     unreachable!("Already checked");
                 };
-                let pt = pt.lock();
+                let locked_pt = self.lock_for(pt, child_mcs_node);
                 // If there's no mapped PTEs in the next level, we can
                 // skip to save time.
-                if pt.nr_children() != 0 {
-                    self.0.push_level(pt);
+                if locked_pt.nr_children() != 0 {
+                    self.push_locked_level(locked_pt);
                 } else {
-                    self.0.move_forward();
+                    let (raw, mcs_node) = locked_pt.release_into_raw();
+                    drop(raw);
+                    self.put_child_mcs_node(Some(mcs_node));
+                    self.move_forward();
                 }
                 continue;
             }
@@ -719,17 +804,19 @@ where
             // of untracked huge pages.
             if cur_va % page_size::<C>(cur_level) != 0 || cur_va + page_size::<C>(cur_level) > end {
                 let split_child = cur_entry
-                    .split_if_untracked_huge()
+                    .split_if_untracked_huge(child_mcs_node.unwrap())
                     .expect("Protecting part of a huge page");
-                self.0.push_level(split_child);
+                self.push_locked_level(split_child);
                 continue;
             }
 
             // Protect the current page.
             cur_entry.protect(op);
 
-            let protected_va = self.0.va..self.0.va + page_size::<C>(self.0.level);
-            self.0.move_forward();
+            self.put_child_mcs_node(child_mcs_node);
+
+            let protected_va = self.va..self.va + page_size::<C>(self.level);
+            self.move_forward();
 
             return Some(protected_va);
         }
@@ -766,34 +853,38 @@ where
     ///  - the current cursor's range contains mapped pages.
     pub unsafe fn copy_from(
         &mut self,
-        src: &mut Self,
+        src: &mut CursorMut<'_, '_, M, E, C>,
         len: usize,
         op: &mut impl FnMut(&mut PageProperty),
     ) {
         assert!(len % page_size::<C>(1) == 0);
-        let this_end = self.0.va + len;
-        assert!(this_end <= self.0.barrier_va.end);
-        let src_end = src.0.va + len;
-        assert!(src_end <= src.0.barrier_va.end);
+        let this_end = self.va + len;
+        assert!(this_end <= self.barrier_va.end);
+        let src_end = src.va + len;
+        assert!(src_end <= src.barrier_va.end);
 
-        while self.0.va < this_end && src.0.va < src_end {
-            let src_va = src.0.va;
-            let mut src_entry = src.0.cur_entry();
+        while self.va < this_end && src.va < src_end {
+            let src_va = src.va;
+            let mut src_entry = src.cur_entry();
 
             match src_entry.to_owned() {
                 Child::PageTable(pt) => {
-                    let pt = pt.lock();
+                    let src_child_mcs_node = src.take_child_mcs_node();
+                    let locked_pt = src.lock_for(pt, src_child_mcs_node);
                     // If there's no mapped PTEs in the next level, we can
                     // skip to save time.
-                    if pt.nr_children() != 0 {
-                        src.0.push_level(pt);
+                    if locked_pt.nr_children() != 0 {
+                        src.push_locked_level(locked_pt);
                     } else {
-                        src.0.move_forward();
+                        let (raw, mcs_node) = locked_pt.release_into_raw();
+                        drop(raw);
+                        src.put_child_mcs_node(Some(mcs_node));
+                        src.move_forward();
                     }
                     continue;
                 }
                 Child::None => {
-                    src.0.move_forward();
+                    src.move_forward();
                     continue;
                 }
                 Child::Untracked(_, _, _) => {
@@ -813,8 +904,8 @@ where
 
                     // Only move the source cursor forward since `Self::map` will do it.
                     // This assertion is to ensure that they move by the same length.
-                    debug_assert_eq!(mapped_page_size, page_size::<C>(src.0.level));
-                    src.0.move_forward();
+                    debug_assert_eq!(mapped_page_size, page_size::<C>(src.level));
+                    src.move_forward();
                 }
             }
         }

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -21,9 +21,9 @@ fn test_range_check() {
     let good_va = 0..PAGE_SIZE;
     let bad_va = 0..PAGE_SIZE + 1;
     let bad_va2 = LINEAR_MAPPING_BASE_VADDR..LINEAR_MAPPING_BASE_VADDR + PAGE_SIZE;
-    assert!(pt.cursor_mut(&good_va).is_ok());
-    assert!(pt.cursor_mut(&bad_va).is_err());
-    assert!(pt.cursor_mut(&bad_va2).is_err());
+    assert!(pt.cursor_mut_with(&good_va, |_| {}).is_ok());
+    assert!(pt.cursor_mut_with(&bad_va, |_| {}).is_err());
+    assert!(pt.cursor_mut_with(&bad_va2, |_| {}).is_err());
 }
 
 #[ktest]
@@ -34,10 +34,16 @@ fn test_tracked_map_unmap() {
     let page = allocator::alloc_single(FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
-    unsafe { pt.cursor_mut(&from).unwrap().map(page.into(), prop) };
+    unsafe {
+        pt.cursor_mut_with(&from, |c| c.map(page.into(), prop))
+            .unwrap()
+    };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert!(matches!(
-        unsafe { pt.cursor_mut(&from).unwrap().take_next(from.len()) },
+        unsafe {
+            pt.cursor_mut_with(&from, |c| c.take_next(from.len()))
+                .unwrap()
+        },
         PageTableItem::Mapped { .. }
     ));
     assert!(pt.query(from.start + 10).is_none());
@@ -55,7 +61,10 @@ fn test_untracked_map_unmap() {
     let to = PAGE_SIZE * to_ppn.start..PAGE_SIZE * to_ppn.end;
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
 
-    unsafe { pt.map(&from, &to, prop).unwrap() };
+    unsafe {
+        pt.cursor_mut_with(&from, |cursor| cursor.map_pa(&to, prop))
+            .unwrap()
+    };
     for i in 0..100 {
         let offset = i * (PAGE_SIZE + 1000);
         assert_eq!(pt.query(from.start + offset).unwrap().0, to.start + offset);
@@ -63,7 +72,10 @@ fn test_untracked_map_unmap() {
 
     let unmap = UNTRACKED_OFFSET + PAGE_SIZE * 13456..UNTRACKED_OFFSET + PAGE_SIZE * 15678;
     assert!(matches!(
-        unsafe { pt.cursor_mut(&unmap).unwrap().take_next(unmap.len()) },
+        unsafe {
+            pt.cursor_mut_with(&unmap, |c| c.take_next(unmap.len()))
+                .unwrap()
+        },
         PageTableItem::MappedUntracked { .. }
     ));
     for i in 0..100 {
@@ -90,28 +102,45 @@ fn test_user_copy_on_write() {
     let page = allocator::alloc_single(FrameMeta::default()).unwrap();
     let start_paddr = page.paddr();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
-    unsafe { pt.cursor_mut(&from).unwrap().map(page.clone().into(), prop) };
+    unsafe {
+        pt.cursor_mut_with(&from, |c| c.map(page.clone().into(), prop))
+            .unwrap()
+    };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert!(matches!(
-        unsafe { pt.cursor_mut(&from).unwrap().take_next(from.len()) },
+        unsafe {
+            pt.cursor_mut_with(&from, |c| c.take_next(from.len()))
+                .unwrap()
+        },
         PageTableItem::Mapped { .. }
     ));
     assert!(pt.query(from.start + 10).is_none());
-    unsafe { pt.cursor_mut(&from).unwrap().map(page.clone().into(), prop) };
+    unsafe {
+        pt.cursor_mut_with(&from, |c| c.map(page.clone().into(), prop))
+            .unwrap()
+    };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
 
     let child_pt = {
         let child_pt = PageTable::<UserMode>::empty();
         let range = 0..MAX_USERSPACE_VADDR;
-        let mut child_cursor = child_pt.cursor_mut(&range).unwrap();
-        let mut parent_cursor = pt.cursor_mut(&range).unwrap();
-        unsafe { child_cursor.copy_from(&mut parent_cursor, range.len(), &mut prot_op) };
+        child_pt
+            .cursor_mut_with(&range, |child_cursor| {
+                pt.cursor_mut_with(&range, |parent_cursor| {
+                    unsafe { child_cursor.copy_from(parent_cursor, range.len(), &mut prot_op) };
+                })
+                .unwrap();
+            })
+            .unwrap();
         child_pt
     };
     assert_eq!(pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert_eq!(child_pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert!(matches!(
-        unsafe { pt.cursor_mut(&from).unwrap().take_next(from.len()) },
+        unsafe {
+            pt.cursor_mut_with(&from, |c| c.take_next(from.len()))
+                .unwrap()
+        },
         PageTableItem::Mapped { .. }
     ));
     assert!(pt.query(from.start + 10).is_none());
@@ -120,9 +149,14 @@ fn test_user_copy_on_write() {
     let sibling_pt = {
         let sibling_pt = PageTable::<UserMode>::empty();
         let range = 0..MAX_USERSPACE_VADDR;
-        let mut sibling_cursor = sibling_pt.cursor_mut(&range).unwrap();
-        let mut parent_cursor = pt.cursor_mut(&range).unwrap();
-        unsafe { sibling_cursor.copy_from(&mut parent_cursor, range.len(), &mut prot_op) };
+        sibling_pt
+            .cursor_mut_with(&range, |sibling_cursor| {
+                pt.cursor_mut_with(&range, |parent_cursor| {
+                    unsafe { sibling_cursor.copy_from(parent_cursor, range.len(), &mut prot_op) };
+                })
+                .unwrap();
+            })
+            .unwrap();
         sibling_pt
     };
     assert!(sibling_pt.query(from.start + 10).is_none());
@@ -130,15 +164,18 @@ fn test_user_copy_on_write() {
     drop(pt);
     assert_eq!(child_pt.query(from.start + 10).unwrap().0, start_paddr + 10);
     assert!(matches!(
-        unsafe { child_pt.cursor_mut(&from).unwrap().take_next(from.len()) },
+        unsafe {
+            child_pt
+                .cursor_mut_with(&from, |c| c.take_next(from.len()))
+                .unwrap()
+        },
         PageTableItem::Mapped { .. }
     ));
     assert!(child_pt.query(from.start + 10).is_none());
     unsafe {
         sibling_pt
-            .cursor_mut(&from)
+            .cursor_mut_with(&from, |c| c.map(page.clone().into(), prop))
             .unwrap()
-            .map(page.clone().into(), prop)
     };
     assert_eq!(
         sibling_pt.query(from.start + 10).unwrap().0,
@@ -152,8 +189,7 @@ where
     [(); C::NR_LEVELS as usize]:,
 {
     fn protect(&self, range: &Range<Vaddr>, mut op: impl FnMut(&mut PageProperty)) {
-        let mut cursor = self.cursor_mut(range).unwrap();
-        loop {
+        self.cursor_mut_with(range, |cursor| loop {
             unsafe {
                 if cursor
                     .protect_next(range.end - cursor.virt_addr(), &mut op)
@@ -162,7 +198,8 @@ where
                     break;
                 }
             };
-        }
+        })
+        .unwrap();
     }
 }
 
@@ -174,29 +211,40 @@ fn test_base_protect_query() {
     let from = PAGE_SIZE * from_ppn.start..PAGE_SIZE * from_ppn.end;
     let to = allocator::alloc(999 * PAGE_SIZE, |_| FrameMeta::default()).unwrap();
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
-    unsafe {
-        let mut cursor = pt.cursor_mut(&from).unwrap();
+    pt.cursor_mut_with(&from, |cursor| {
         for page in to {
-            cursor.map(page.clone().into(), prop);
+            unsafe {
+                cursor.map(page.clone().into(), prop);
+            }
         }
-    }
-    for (item, i) in pt.cursor(&from).unwrap().zip(from_ppn) {
-        let PageTableItem::Mapped { va, page, prop } = item else {
-            panic!("Expected Mapped, got {:#x?}", item);
-        };
-        assert_eq!(prop.flags, PageFlags::RW);
-        assert_eq!(prop.cache, CachePolicy::Writeback);
-        assert_eq!(va..va + page.size(), i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
-    }
+    })
+    .unwrap();
+
+    pt.cursor_mut_with(&from, |cursor| {
+        for (item, i) in cursor.zip(from_ppn) {
+            let PageTableItem::Mapped { va, page, prop } = item else {
+                panic!("Expected Mapped, got {:#x?}", item);
+            };
+            assert_eq!(prop.flags, PageFlags::RW);
+            assert_eq!(prop.cache, CachePolicy::Writeback);
+            assert_eq!(va..va + page.size(), i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
+        }
+    })
+    .unwrap();
+
     let prot = PAGE_SIZE * 18..PAGE_SIZE * 20;
     pt.protect(&prot, |p| p.flags -= PageFlags::W);
-    for (item, i) in pt.cursor(&prot).unwrap().zip(18..20) {
-        let PageTableItem::Mapped { va, page, prop } = item else {
-            panic!("Expected Mapped, got {:#x?}", item);
-        };
-        assert_eq!(prop.flags, PageFlags::R);
-        assert_eq!(va..va + page.size(), i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
-    }
+
+    pt.cursor_mut_with(&prot, |cursor| {
+        for (item, i) in cursor.zip(18..20) {
+            let PageTableItem::Mapped { va, page, prop } = item else {
+                panic!("Expected Mapped, got {:#x?}", item);
+            };
+            assert_eq!(prop.flags, PageFlags::R);
+            assert_eq!(va..va + page.size(), i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
+        }
+    })
+    .unwrap();
 }
 
 #[derive(Clone, Debug, Default)]
@@ -228,66 +276,70 @@ fn test_untracked_large_protect_query() {
     let to = PAGE_SIZE * to_ppn.start..PAGE_SIZE * to_ppn.end;
     let mapped_pa_of_va = |va: Vaddr| va - (from.start - to.start);
     let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
-    unsafe { pt.map(&from, &to, prop).unwrap() };
-    for (item, i) in pt.cursor(&from).unwrap().zip(0..512 + 2 + 2) {
-        let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
-            panic!("Expected MappedUntracked, got {:#x?}", item);
-        };
-        assert_eq!(pa, mapped_pa_of_va(va));
-        assert_eq!(prop.flags, PageFlags::RW);
-        assert_eq!(prop.cache, CachePolicy::Writeback);
-        if i < 512 + 2 {
-            assert_eq!(va, from.start + i * PAGE_SIZE * 512);
-            assert_eq!(va + len, from.start + (i + 1) * PAGE_SIZE * 512);
-        } else {
-            assert_eq!(
-                va,
-                from.start + (512 + 2) * PAGE_SIZE * 512 + (i - 512 - 2) * PAGE_SIZE
-            );
-            assert_eq!(
-                va + len,
-                from.start + (512 + 2) * PAGE_SIZE * 512 + (i - 512 - 2 + 1) * PAGE_SIZE
-            );
+    unsafe { pt.cursor_mut_with(&from, |c| c.map_pa(&to, prop)).unwrap() };
+    pt.cursor_mut_with(&from, |cursor| {
+        for (item, i) in cursor.zip(0..512 + 2 + 2) {
+            let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
+                panic!("Expected MappedUntracked, got {:#x?}", item);
+            };
+            assert_eq!(pa, mapped_pa_of_va(va));
+            assert_eq!(prop.flags, PageFlags::RW);
+            assert_eq!(prop.cache, CachePolicy::Writeback);
+            if i < 512 + 2 {
+                assert_eq!(va, from.start + i * PAGE_SIZE * 512);
+                assert_eq!(va + len, from.start + (i + 1) * PAGE_SIZE * 512);
+            } else {
+                assert_eq!(
+                    va,
+                    from.start + (512 + 2) * PAGE_SIZE * 512 + (i - 512 - 2) * PAGE_SIZE
+                );
+                assert_eq!(
+                    va + len,
+                    from.start + (512 + 2) * PAGE_SIZE * 512 + (i - 512 - 2 + 1) * PAGE_SIZE
+                );
+            }
         }
-    }
+    })
+    .unwrap();
     let ppn = from_ppn.start + 18..from_ppn.start + 20;
     let va = UNTRACKED_OFFSET + PAGE_SIZE * ppn.start..UNTRACKED_OFFSET + PAGE_SIZE * ppn.end;
     pt.protect(&va, |p| p.flags -= PageFlags::W);
-    for (item, i) in pt
-        .cursor(&(va.start - PAGE_SIZE..va.start))
-        .unwrap()
-        .zip(ppn.start - 1..ppn.start)
-    {
-        let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
-            panic!("Expected MappedUntracked, got {:#x?}", item);
-        };
-        assert_eq!(pa, mapped_pa_of_va(va));
-        assert_eq!(prop.flags, PageFlags::RW);
-        let va = va - UNTRACKED_OFFSET;
-        assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
-    }
-    for (item, i) in pt.cursor(&va).unwrap().zip(ppn.clone()) {
-        let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
-            panic!("Expected MappedUntracked, got {:#x?}", item);
-        };
-        assert_eq!(pa, mapped_pa_of_va(va));
-        assert_eq!(prop.flags, PageFlags::R);
-        let va = va - UNTRACKED_OFFSET;
-        assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
-    }
-    for (item, i) in pt
-        .cursor(&(va.end..va.end + PAGE_SIZE))
-        .unwrap()
-        .zip(ppn.end..ppn.end + 1)
-    {
-        let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
-            panic!("Expected MappedUntracked, got {:#x?}", item);
-        };
-        assert_eq!(pa, mapped_pa_of_va(va));
-        assert_eq!(prop.flags, PageFlags::RW);
-        let va = va - UNTRACKED_OFFSET;
-        assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
-    }
+    pt.cursor_mut_with(&(va.start - PAGE_SIZE..va.start), |cursor| {
+        for (item, i) in cursor.zip(ppn.start - 1..ppn.start) {
+            let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
+                panic!("Expected MappedUntracked, got {:#x?}", item);
+            };
+            assert_eq!(pa, mapped_pa_of_va(va));
+            assert_eq!(prop.flags, PageFlags::RW);
+            let va = va - UNTRACKED_OFFSET;
+            assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
+        }
+    })
+    .unwrap();
+    pt.cursor_mut_with(&va, |cursor| {
+        for (item, i) in cursor.zip(ppn.clone()) {
+            let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
+                panic!("Expected MappedUntracked, got {:#x?}", item);
+            };
+            assert_eq!(pa, mapped_pa_of_va(va));
+            assert_eq!(prop.flags, PageFlags::R);
+            let va = va - UNTRACKED_OFFSET;
+            assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
+        }
+    })
+    .unwrap();
+    pt.cursor_mut_with(&(va.end..va.end + PAGE_SIZE), |cursor| {
+        for (item, i) in cursor.zip(ppn.end..ppn.end + 1) {
+            let PageTableItem::MappedUntracked { va, pa, len, prop } = item else {
+                panic!("Expected MappedUntracked, got {:#x?}", item);
+            };
+            assert_eq!(pa, mapped_pa_of_va(va));
+            assert_eq!(prop.flags, PageFlags::RW);
+            let va = va - UNTRACKED_OFFSET;
+            assert_eq!(va..va + len, i * PAGE_SIZE..(i + 1) * PAGE_SIZE);
+        }
+    })
+    .unwrap();
 
     // Since untracked mappings cannot be dropped, we just leak it here.
     let _ = ManuallyDrop::new(pt);

--- a/ostd/src/mm/stat/mod.rs
+++ b/ostd/src/mm/stat/mod.rs
@@ -10,12 +10,15 @@ use crate::mm::page::allocator::PAGE_ALLOCATOR;
 /// in most occasions. For example, bad memory, kernel statically-allocated
 /// memory or firmware reserved memories do not count.
 pub fn mem_total() -> usize {
-    PAGE_ALLOCATOR.get().unwrap().lock().mem_total()
+    PAGE_ALLOCATOR.get().unwrap().lock_with(|a| a.mem_total())
 }
 
 /// Current readily available memory (in bytes).
 ///
 /// Such memory can be directly used for allocation without reclaiming.
 pub fn mem_available() -> usize {
-    PAGE_ALLOCATOR.get().unwrap().lock().mem_available()
+    PAGE_ALLOCATOR
+        .get()
+        .unwrap()
+        .lock_with(|a| a.mem_available())
 }

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -8,7 +8,7 @@ mod mutex;
 // mod rcu;
 mod rwlock;
 mod rwmutex;
-mod spin;
+pub(crate) mod spin;
 mod wait;
 
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -22,6 +22,6 @@ pub use self::{
         ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
         RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
     },
-    spin::{ArcSpinLockGuard, LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard},
+    spin::{LocalIrqDisabled, PreemptDisabled, SpinLock},
     wait::{WaitQueue, Waiter, Waker},
 };

--- a/ostd/src/sync/spin/mcs.rs
+++ b/ostd/src/sync/spin/mcs.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This module implements the MCS (Mellor-Crummey Scott) spinlock algorithm,
+// which attribes to John Mellor-Crummey and Michael Scott for the following
+// paper:
+//
+// John M. Mellor-Crummey and Michael L. Scott. 1991. Scalable reader-writer
+// synchronization for shared-memory multiprocessors. SIGPLAN Not. 26, 7
+// (July 1991), 106–113. https://doi.org/10.1145/109626.109637
+//
+// This implementation thankfully references the following previous work:
+// [mcslock](https://crates.io/crates/mcslock).
+
+//! MCS (Mellor-Crummey Scott) spinlock algorithm.
+//!
+//! This module provides only low-level primitives for the MCS spinlock
+//! algorithm. And the primitives can be used to build higher-level, RAII-style
+//! synchronization guards.
+
+use core::{
+    marker::PhantomPinned,
+    pin::Pin,
+    sync::atomic::{fence, AtomicBool, AtomicPtr, Ordering},
+};
+
+/// A lock body for a MCS spinlock.
+///
+/// Each memory location that is shared between CPUs must have a unique
+/// instance of this type.
+pub(crate) struct LockBody {
+    tail: AtomicPtr<UnsafeNode>,
+}
+
+impl LockBody {
+    /// Creates a new lock body.
+    ///
+    /// The created lock will be in the unlocked state.
+    pub(crate) const fn new() -> Self {
+        Self {
+            tail: AtomicPtr::new(core::ptr::null_mut()),
+        }
+    }
+}
+
+/// A locking node for a MCS spinlock.
+///
+/// Each CPU that wants to acquire the lock must instantiate a node on the
+/// stack.
+///
+/// The nodes are linked together as a queue. Whenever a CPU releases the lock,
+/// it notifies the next CPU in the queue. So the lock serves as a fair FIFO
+/// coordinator.
+///
+/// Each CPU only spins on its own node, so the MCS lock is cache-friendly.
+///
+/// Directly using this type is not safe. See [`Node`] for a safe wrapper that
+/// ensures that the node state is correct at compile time.
+pub(crate) struct UnsafeNode {
+    /// Pointer to the next "acquiring" node in the queue.
+    next: AtomicPtr<UnsafeNode>,
+    /// If the node state is "acquired", this field is not used.
+    ///
+    /// Otherwise if it is "acquiring", the predecessor will notify this us by
+    /// setting this field to `true`.
+    ticket: AtomicBool,
+    // The node will be accessed by pointers so it better not to be moved.
+    _pin: PhantomPinned,
+}
+
+impl UnsafeNode {
+    /// Creates a new unsafe node in the "ready" state.
+    pub(crate) const fn new() -> Self {
+        Self {
+            next: AtomicPtr::new(core::ptr::null_mut()),
+            ticket: AtomicBool::new(false),
+            _pin: PhantomPinned,
+        }
+    }
+}
+
+/// Node with compile-time state checking.
+///
+/// See [`UnsafeNode`] for the internal representation and the usage of the node.
+///
+/// The node has two states: "acquired" and "ready". A "ready" node can be
+/// used to acquire the lock. An "acquired" node lives throughout the critical
+/// section and can be used to release the lock. After releasing the lock, the
+/// node becomes "ready".
+///
+/// Violating the node state will lead to undefined behavior. This checker
+/// ensures that the node state is correct at compile time.
+///
+/// If the node is "ready", the `READY` parameter should be `true`. Otherwise,
+/// it should be `false`.
+pub(crate) struct Node<'a, 'b, const READY: bool> {
+    lock: &'a LockBody,
+    node: Pin<&'b mut UnsafeNode>,
+}
+
+// "ready" node.
+impl<'a, 'b> Node<'a, 'b, true> {
+    /// Creates a new "ready" node that can be used to acquire a MCS lock.
+    pub(crate) fn new(lock: &'a LockBody, unsafe_node: Pin<&'b mut UnsafeNode>) -> Self {
+        Self {
+            lock,
+            node: unsafe_node,
+        }
+    }
+
+    /// Locks the MCS lock.
+    ///
+    /// This method spins until the lock is acquired. It can be used to
+    /// synchronize critical sections. The critical section should go after
+    /// this method.
+    pub(crate) fn lock(self) -> Node<'a, 'b, false> {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+
+        let pred = self.lock.tail.swap(node_ptr, Ordering::AcqRel);
+        // If we have a predecessor, complete the link so it will notify us.
+        if !pred.is_null() {
+            // SAFETY: Already verified that predecessor is not null.
+            unsafe { &*pred }.next.store(node_ptr, Ordering::Release);
+            while !self.node.ticket.load(Ordering::Relaxed) {
+                core::hint::spin_loop();
+            }
+            // Reset the ticket for the next user.
+            self.node.ticket.store(false, Ordering::Relaxed);
+            fence(Ordering::Acquire);
+        }
+
+        // The node is now "acquired".
+        Node::<false> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+
+    /// Tries locking the lock.
+    ///
+    /// If the lock is acquired, returns a `Ok(Node<false>)`, which represents
+    /// a "acquired" node. Otherwise, returns a `Err(Node<true>)`, which
+    /// represents a "ready" node.
+    ///
+    /// Looping over `try_lock` is not recommended. The caller would be least
+    /// prioritized to acquire the lock. Also it spins on a global lock, which
+    /// will cause the cache line of this CPU to be invalidated frequently.
+    pub(crate) fn try_lock(self) -> Result<Node<'a, 'b, false>, Node<'a, 'b, true>> {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+
+        let acquired = self
+            .lock
+            .tail
+            .compare_exchange(
+                core::ptr::null_mut(),
+                node_ptr,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok();
+
+        if acquired {
+            // The node is now "acquired".
+            Ok(Node::<false> {
+                lock: self.lock,
+                node: self.node,
+            })
+        } else {
+            // The node is still "ready".
+            Err(self)
+        }
+    }
+}
+
+// "acquired" node.
+impl<'a, 'b> Node<'a, 'b, false> {
+    /// Unlocks the lock.
+    ///
+    /// Critical sections should be finished before calling this method.
+    pub(crate) fn unlock(self) -> Node<'a, 'b, true> {
+        let mut next = self.node.next.load(Ordering::Relaxed);
+        if next.is_null() {
+            // We don't have a known successor currently.
+            if self.try_unlock_as_tail() {
+                // And we are the tail, then dequeue and free the lock.
+                return Node::<true> {
+                    lock: self.lock,
+                    node: self.node,
+                };
+            }
+            // But if we are not the tail, then we have a pending successor. We
+            // must wait for them to finish linking with us.
+            loop {
+                next = self.node.next.load(Ordering::Relaxed);
+                if !next.is_null() {
+                    break;
+                }
+                core::hint::spin_loop();
+            }
+        }
+        fence(Ordering::Acquire);
+        // Notify the successor that we are done.
+        // SAFETY: We already verified that our successor is not null.
+        unsafe { &*next }.ticket.store(true, Ordering::Release);
+
+        // The node is now "ready".
+        Node::<true> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+
+    /// Unlocks the lock if the candidate node is the queue's tail.
+    fn try_unlock_as_tail(&self) -> bool {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+
+        self.lock
+            .tail
+            .compare_exchange(
+                node_ptr,
+                core::ptr::null_mut(),
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+}

--- a/ostd/src/sync/spin/mcs.rs
+++ b/ostd/src/sync/spin/mcs.rs
@@ -27,6 +27,7 @@ use core::{
 ///
 /// Each memory location that is shared between CPUs must have a unique
 /// instance of this type.
+#[derive(Debug)]
 pub(crate) struct LockBody {
     tail: AtomicPtr<UnsafeNode>,
 }
@@ -55,6 +56,7 @@ impl LockBody {
 ///
 /// Directly using this type is not safe. See [`Node`] for a safe wrapper that
 /// ensures that the node state is correct at compile time.
+#[derive(Debug)]
 pub(crate) struct UnsafeNode {
     /// Pointer to the next "acquiring" node in the queue.
     next: AtomicPtr<UnsafeNode>,
@@ -92,6 +94,7 @@ impl UnsafeNode {
 ///
 /// If the node is "ready", the `READY` parameter should be `true`. Otherwise,
 /// it should be `false`.
+#[derive(Debug)]
 pub(crate) struct Node<'a, 'b, const READY: bool> {
     lock: &'a LockBody,
     node: Pin<&'b mut UnsafeNode>,
@@ -168,6 +171,11 @@ impl<'a, 'b> Node<'a, 'b, true> {
             // The node is still "ready".
             Err(self)
         }
+    }
+
+    /// Takes a ready unsafe node out of the node.
+    pub(crate) fn take_unsafe_node(self) -> Pin<&'b mut UnsafeNode> {
+        self.node
     }
 }
 

--- a/ostd/src/sync/spin/mod.rs
+++ b/ostd/src/sync/spin/mod.rs
@@ -2,6 +2,8 @@
 
 #![allow(dead_code)]
 
+pub(crate) mod mcs;
+
 use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,

--- a/ostd/src/sync/spin/mod.rs
+++ b/ostd/src/sync/spin/mod.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 pub(crate) mod mcs;
+pub(crate) mod rwmcs;
 
 use core::{cell::UnsafeCell, fmt, marker::PhantomData};
 

--- a/ostd/src/sync/spin/rwmcs.rs
+++ b/ostd/src/sync/spin/rwmcs.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This is the impl<'a, 'b>ementation of the MCS readers-writer (prefer readers) lock
+// by John M. Mellor-Crummey and Michael L. Scott., published as:
+//
+// Mellor-Crummey, John M., and Michael L. Scott. "Scalable reader-writer
+// synchronization for shared-memory multiprocessors." ACM SIGPLAN Notices
+// 26.7 (1991): 106-113.
+
+//! MCS readers-writer (prefer readers) spinlock algorithm.
+
+use core::{
+    marker::PhantomPinned,
+    pin::Pin,
+    sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering},
+};
+
+#[derive(Debug)]
+pub(crate) struct LockBody {
+    reader_head: AtomicPtr<UnsafeNode>,
+    writer_tail: AtomicPtr<UnsafeNode>,
+    writer_head: AtomicPtr<UnsafeNode>,
+    rdr_cnt_and_flags: AtomicU32,
+}
+
+// layout of rdr_cnt_and_flags:
+//  31     ...      2       1              0
+// +-----------------+-------------+-----------------+
+// | interested rdrs | active wtr? | interested wtr? |
+// +-----------------+-------------+-----------------+
+
+const WRITER_INTERESTED: u32 = 0x1;
+const WRITER_ACTIVE: u32 = 0x2;
+const READER_COUNT: u32 = 0x4;
+
+impl LockBody {
+    pub(crate) const fn new() -> Self {
+        Self {
+            reader_head: AtomicPtr::new(core::ptr::null_mut()),
+            writer_tail: AtomicPtr::new(core::ptr::null_mut()),
+            writer_head: AtomicPtr::new(core::ptr::null_mut()),
+            rdr_cnt_and_flags: AtomicU32::new(0),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UnsafeNode {
+    next: AtomicPtr<UnsafeNode>,
+    blocked: AtomicBool,
+    /// A phantom pinned marker.
+    _pinned: PhantomPinned,
+}
+
+impl UnsafeNode {
+    pub(crate) fn new_reader() -> Self {
+        Self {
+            next: AtomicPtr::new(core::ptr::null_mut()),
+            blocked: AtomicBool::new(false),
+            _pinned: PhantomPinned,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Node<'a, 'b, const IS_READER: bool, const READY: bool> {
+    lock: &'a LockBody,
+    node: Pin<&'b mut UnsafeNode>,
+}
+
+impl<'a, 'b> Node<'a, 'b, true, true> {
+    pub(crate) fn new_reader(lock: &'a LockBody, node: Pin<&'b mut UnsafeNode>) -> Self {
+        Self { lock, node }
+    }
+
+    pub(crate) fn lock_reader(self) -> Node<'a, 'b, true, false> {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+        
+        let rdr_cnt_and_flag = self
+            .lock
+            .rdr_cnt_and_flags
+            .fetch_add(READER_COUNT, Ordering::AcqRel);
+
+        let read_rdr_cnt_and_flag = || self
+            .lock
+            .rdr_cnt_and_flags
+            .load(Ordering::Relaxed);
+
+        if rdr_cnt_and_flag & WRITER_ACTIVE != 0 {
+            self.node.blocked.store(true, Ordering::Relaxed);
+            let next = self.lock.reader_head.swap(node_ptr, Ordering::AcqRel);
+            if read_rdr_cnt_and_flag() & WRITER_ACTIVE == 0 {
+                // Writer no longer active; wake any waiting readers.
+                let head = self
+                    .lock
+                    .reader_head
+                    .swap(core::ptr::null_mut(), Ordering::AcqRel);
+                if !head.is_null() {
+                    // SAFETY: Head is not null so it exists.
+                    unsafe { &*head }.blocked.store(false, Ordering::Relaxed);
+                }
+            }
+            while self.node.blocked.load(Ordering::Relaxed) {
+                core::hint::spin_loop();
+            }
+            if !next.is_null() {
+                // SAFETY: Next is not null so it exists.
+                unsafe { &*next }.blocked.store(false, Ordering::Relaxed);
+            }
+        }
+
+        Node::<true, false> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+}
+
+impl<'a, 'b> Node<'a, 'b, true, false> {
+    pub(crate) fn unlock_reader(self) -> Node<'a, 'b, true, true> {
+        let rdr_cnt_and_flag = self
+            .lock
+            .rdr_cnt_and_flags
+            .fetch_sub(READER_COUNT, Ordering::AcqRel);
+
+        // If I am the last reader, resume the first waiting writer (if any).
+        if rdr_cnt_and_flag == (READER_COUNT + WRITER_INTERESTED)
+            && self.lock.rdr_cnt_and_flags.compare_exchange(
+                WRITER_INTERESTED,
+                WRITER_ACTIVE,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) == Ok(WRITER_INTERESTED)
+        {
+            let writer_head = self.lock.writer_head.load(Ordering::Acquire);
+            if !writer_head.is_null() {
+                // SAFETY: writer_head is not null so it exists.
+                unsafe { &*writer_head }
+                    .blocked
+                    .store(false, Ordering::Relaxed);
+            }
+        }
+
+        Node::<true, true> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+}
+
+impl<'a, 'b> Node<'a, 'b, false, true> {
+    pub(crate) fn new_writer(lock: &'a LockBody, node: Pin<&'b mut UnsafeNode>) -> Self {
+        Self { lock, node }
+    }
+
+    pub(crate) fn lock_writer(self) -> Node<'a, 'b, false, false> {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+
+        self.node.blocked.store(true, Ordering::Relaxed);
+        let pred = self.lock.writer_tail.swap(node_ptr, Ordering::AcqRel);
+        if pred.is_null() {
+            self.lock.writer_head.store(node_ptr, Ordering::Relaxed);
+            if self
+                .lock
+                .rdr_cnt_and_flags
+                .fetch_or(WRITER_INTERESTED, Ordering::AcqRel)
+                == 0
+                && self.lock.rdr_cnt_and_flags.compare_exchange(
+                    WRITER_INTERESTED,
+                    WRITER_ACTIVE,
+                    Ordering::AcqRel,
+                    Ordering::Relaxed,
+                ) == Ok(WRITER_INTERESTED)
+            {
+                return Node::<false, false> {
+                    lock: self.lock,
+                    node: self.node,
+                };
+            }
+        } else {
+            // SAFETY: pred is not null so it exists.
+            unsafe { &*pred }.next.store(node_ptr, Ordering::Relaxed);
+        }
+        while self.node.blocked.load(Ordering::Relaxed) {
+            core::hint::spin_loop();
+        }
+
+        Node::<false, false> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+}
+
+impl<'a, 'b> Node<'a, 'b, false, false> {
+    pub(crate) fn unlock_writer(self) -> Node<'a, 'b, false, true> {
+        let node_ptr = (&*self.node as *const UnsafeNode).cast_mut();
+
+        self.lock
+            .writer_head
+            .store(core::ptr::null_mut(), Ordering::Relaxed);
+        // clear wtr flag and test for waiting readers
+        if self
+            .lock
+            .rdr_cnt_and_flags
+            .fetch_and(!WRITER_ACTIVE, Ordering::AcqRel)
+            != 0
+        {
+            // waiting readers exist
+            let head = self
+                .lock
+                .reader_head
+                .swap(core::ptr::null_mut(), Ordering::AcqRel);
+            if !head.is_null() {
+                // SAFETY: head is not null so it exists.
+                unsafe { &*head }.blocked.store(false, Ordering::Relaxed);
+            }
+        }
+        // testing next is strictly an optimization
+        if !self.node.next.load(Ordering::Relaxed).is_null()
+            || self
+                .lock
+                .writer_tail
+                .compare_exchange(
+                    node_ptr,
+                    core::ptr::null_mut(),
+                    Ordering::AcqRel,
+                    Ordering::Relaxed,
+                )
+                .is_err()
+        {
+            // resolve successor
+            while self.node.next.load(Ordering::Relaxed).is_null() {
+                core::hint::spin_loop();
+            }
+            self.lock
+                .writer_head
+                .store(self.node.next.load(Ordering::Relaxed), Ordering::Relaxed);
+            if self
+                .lock
+                .rdr_cnt_and_flags
+                .fetch_or(WRITER_INTERESTED, Ordering::AcqRel)
+                == 0
+                && self.lock.rdr_cnt_and_flags.compare_exchange(
+                    WRITER_INTERESTED,
+                    WRITER_ACTIVE,
+                    Ordering::AcqRel,
+                    Ordering::Relaxed,
+                ) != Ok(0)
+            {
+                let writer_head = self.lock.writer_head.load(Ordering::Acquire);
+                if !writer_head.is_null() {
+                    // SAFETY: writer_head is not null so it exists.
+                    unsafe { &*writer_head }
+                        .blocked
+                        .store(false, Ordering::Relaxed);
+                }
+            }
+            // else readers will wake up the writer
+        }
+
+        Node::<false, true> {
+            lock: self.lock,
+            node: self.node,
+        }
+    }
+}


### PR DESCRIPTION
Don't freak out once you see the gigantic diffs. I just replaced the `SpinLockGuard`-style API with the `lock_with(|inner| {})` API. So the entire code base is scratched trivially with a few minor exceptions, which will be explained in depth.

## Motivation

I'll explain the MCS spinlock briefly. The original spinlock implementation we've used, let each CPU spin on a global address until it have done the `LOCK; CMPXCHG` instruction successfully:

https://github.com/asterinas/asterinas/blob/6a33f7a6d0e52701f4267390cc2eea30590a8e45/ostd/src/sync/spin.rs#L150-L166

This implementation is known to suffer from cache-line-bouncing: whenever a CPU tries to write to the address, all corresponding cache lines in other CPUs will be invalidated. So when N CPUs are trying to acquire the lock at the same time, there would likely be N^2 cache line invalidation requests flooding over the bus. So the original spinlock scales poorly.

One of the solutions is MCS (proposed by Mellor-Crummey and Scott), which is adopted by Linux a decade ago. In the MCS lock each CPU allocates a dedicated address to store the links to other CPUs, forming a list. On locking, each CPU will only spin on dedicated addresses so only one other CPU can invalidate it's cache line. Upon unlocking, the CPU notifies the subsequent CPU by writing to the follower's address.

## Why the lock API changed

The original `.lock()` API provided by the `SpinLock<T>` structure, will return a RAII-style `SpinLockGuard` type.

On the premise that MCS spinlock requires allocating some memory for the list node when locking the lock, one may think that we can put the list node in the guard:

```rust
/// The guard of a spin lock.
#[clippy::has_significant_drop]
#[must_use]
pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> {
    guard: G::Guard,
    lock: R,
    mcs_node: mcs::Node // !!! have problems !!!
}
```

However this is not OK because the node looks like this:

```rust
// mcs.rs
struct Node {
    next: AtomicPtr<Node> // The pointer to the next node that will be waken once this CPU releases the lock.
}
```

If the node is stored in the `SpinLockGuard_` and the guard is not [pinned](https://doc.rust-lang.org/std/pin/index.html), when the guard is returned back to the `.lock` caller, the guard will be moved. If it moves, the predecessor will hold an invalid pointer, boom!

Using [`pin!`](https://doc.rust-lang.org/std/pin/macro.pin.html) doesn't help really much, because you cannot return a pinned object, which makes implementing the original API not possible.

Other ways to preserve the API when introducing MCS may exist, but the best one I can think of, #1506 , introduces many compromises (and I even don't know if it is correct). So the best way is to change the API to `with`-style APIs, which takes a closure, and the closure takes a mutable reference to the inner protected object:

```rust
    /// Acquires the spin lock and applies the closure to the inner data.
    ///
    /// If the lock is already held by another thread, the current thread will
    /// spin until the lock is released.
    pub fn lock_with<F, R>(&self, f: F) -> R
    where
        F: FnOnce(&mut T) -> R,
    {
        let _guard = G::guard();

        let mcs_unsafe_node = core::pin::pin!(mcs::UnsafeNode::new());
        let mcs_node = mcs::Node::new(&self.inner.lock, mcs_unsafe_node);

        let mcs_node = mcs_node.lock();

        // SAFETY: The lock is acquired so the critical section is safe.
        let r = f(unsafe { &mut *self.inner.val.get() });

        mcs_node.unlock();

        r
    }
```

Unfortunately the original APIs are used pervasively, so the PR is huge. And the new API is even less expressive. So some of the code transformation is not trivial (around 2 out of 300), which will be discussed in the next section.

## Non-trivial API transformations

One example is the lock usage in [a `read` function in VirtIO block driver](https://github.com/asterinas/asterinas/blob/6a33f7a6d0e52701f4267390cc2eea30590a8e45/kernel/comps/virtio/src/device/block/device.rs#L287), which does something like this:

```rust
fn read(&self, bio_request: BioRequest) {
    let descs = Vec::new(/*...*/);
    loop {
        let queue_lock = self.queue.lock();
        if descs.len() > queue_lock.available_descs() {
            continue; // realease the lock and re-gain the lock to check again.
        }
        queue_lock.push(descs); // seems to move `descs` into a loop,
                                // but the compiler knows that the loop
                                // immediately breaks after it so it is OK.
        break;
    }
}
```

A trivial transformation will look like this, but the compiler complains:

```rust
fn read(&self, bio_request: BioRequest) {
    let descs = Vec::new(/*...*/);
    loop {
        let done = self.queue.lock_with(|queue| {
            if descs.len() > queue_lock.available_descs() {
                return false; // realease the lock and re-gain the lock to check again.
            }
            queue_lock.push(descs); // Compiler complains that you moved the `descs` into a loop.
            true // break
        });
        if done { break; } // Because the compiler can't reason
                           // that returning true will lead to a loop break here.
    }
}
```

My solution is provided in the source. You can inspect it if you are interested.

## Experiments

Here I reused the micro-benchmark in #1395 to see if MCS spin lock brings scalability improvement. All of them runs on the benchmark CI machine with INTEL(R) XEON(R) PLATINUM 8575C. 64G memory allocated for the VM. Threads bind to the first socket.

![benchmark_results](https://github.com/user-attachments/assets/f37e8eff-8a64-4bd3-91d3-ca929b77a309)

`Asterinas (MCS)` is the result in this PR at 2f1dc0f11a017c13b15c7255a6ed2745d84bbe6f 
`Asterinas (Spin)` is the main branch result that contains the VmSpace flusher fix to make it fair
`Asterinas (RwSpin)` is #1476 , which uses the primitive fetch-add readers-writer lock implementation

## Alternatives

#1506 provides a (maybe, depends on your view) easier way to port our spinlocks to MCS. It instead gives up trying to allocate the node on the stack, but to allocate the node on a per-cpu area, which brings a lot of questions:

 - The allocation adds more overhead since `cpu_local_cell` is vulnerable to interrupts and atomics are too heavy, while stack allocation just need `rsp` and frankly it has no overhead;
 - The static allocation area will be capped, so nested locks cannot exceed a fixed value;
 - Need special cares since the cpu local storage will be used very early before the initialization;
 - ...

## How to review the code

If you are interested in how MCS is implemented, read the first commit.

If you care about whether the module maintained by you contains the correct source transformation, read the second commit, which is huge.

If you care about page tables, read the third commit. ~~(incorporation in page table sadly encounters the same problem of the guards. working very hard on it.)~~ (incorporation in page table done, but at a considerable cost.)