### PR TITLE
Add more boundary checks for epoll_wait

### DIFF
--- a/test/syscall_test/blocklists/epoll_test
+++ b/test/syscall_test/blocklists/epoll_test
@@ -1,12 +1,6 @@
 EpollTest.Timeout_NoRandomSave
-EpollTest.TimeoutNoFds
-EpollTest.UnblockWithNewFD
-EpollTest.Oneshot
-EpollTest.EdgeTriggered_NoRandomSave
-EpollTest.OneshotAndEdgeTriggered
 EpollTest.CycleOfOneDisallowed
 EpollTest.CycleOfThreeDisallowed
-EpollTest.CloseFile
 # `UnblockWithSignal` contains races. Better not to enable it.
 # See https://github.com/asterinas/asterinas/pull/1035 for details.
 EpollTest.UnblockWithSignal


### PR DESCRIPTION
This pull request to `kernel/src/syscall/epoll.rs` and `test/syscall_test/blocklists/epoll_test` includes changes to enhance the validation and handling of epoll-related system calls. The most important changes involve adding a constant for maximum events, updating validation logic, and modifying test blocklists.

### Enhancements to validation and handling:

* [`kernel/src/syscall/epoll.rs`](diffhunk://#diff-9d18325416ee33243634eb878bdbef7a64e9e8bb6e5109887b35541402ac60f9R17-R19): Added a constant `EP_MAX_EVENTS` to define the maximum number of events and updated the `do_epoll_wait` function to validate `max_events` against this constant. [[1]](diffhunk://#diff-9d18325416ee33243634eb878bdbef7a64e9e8bb6e5109887b35541402ac60f9R17-R19) [[2]](diffhunk://#diff-9d18325416ee33243634eb878bdbef7a64e9e8bb6e5109887b35541402ac60f9L98-R102)
* [`kernel/src/syscall/epoll.rs`](diffhunk://#diff-9d18325416ee33243634eb878bdbef7a64e9e8bb6e5109887b35541402ac60f9L195-R198): Modified the `sys_epoll_pwait` function to include an additional check for `sigmask` before validating `sigset_size`. See [this](https://elixir.bootlin.com/linux/v3.19.8/source/fs/eventpoll.c#L2018).

### Test blocklist updates:

* [`test/syscall_test/blocklists/epoll_test`](diffhunk://#diff-090ce438e700cbf007e2af085b792b8c3681f13e5a9589e21ec5f063220d8421L2-L9): Removed several tests from the blocklist to ensure only relevant tests are skipped.