### PR TITLE
Install cargo-osdk in  OSDK Docker image

### DIFF
--- a/osdk/tools/docker/Dockerfile.template
+++ b/osdk/tools/docker/Dockerfile.template
@@ -31,6 +31,9 @@ RUN curl https://sh.rustup.rs -sSf | \
 # Install cargo-binutils
 RUN cargo install cargo-binutils
 
+# Install cargo-osdk
+RUN cargo install cargo-osdk
+
 VOLUME [ "/root/asterinas" ]
 
 WORKDIR /root/asterinas

--- a/osdk/tools/docker/run_container.sh
+++ b/osdk/tools/docker/run_container.sh
@@ -5,7 +5,7 @@
 set -e
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-ASTER_ROOT_DIR=${SCRIPT_DIR}/../..
+ASTER_ROOT_DIR=${SCRIPT_DIR}/../../..
 VERSION=$( cat ${ASTER_ROOT_DIR}/VERSION )
 
 if [ "$1" = "intel-tdx" ]; then


### PR DESCRIPTION
I was looking around at the Docker image `asterinas/osdk` and saw that the `cargo-osdk` crate was not installed. I woudl think that this Docker image is especially made for using the osdk crate.

I added the installation of the `cargo-osdk` crate and fixed an issue with getting the Asterinas root dir in the `run_container.sh` script. It failed to get the version when running it.

I could add version pinning as well to the installation command like:
`cargo install --version 0.9.4 cargo-osdk`

I hope that I am correct that `cargo-osdk` is missing from this Docker image. Otherwise I would love to know why the decision was made not to install it here!