### PR TITLE
Don't preempt without good reason

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -93,8 +93,6 @@ pub fn main() {
         ThreadOptions::new(init_thread)
             .priority(Priority::new(PriorityRange::new(PriorityRange::MAX))),
     );
-    // Spawning functions in the bootstrap context will not return.
-    unreachable!()
 }
 
 pub fn init() {
@@ -110,7 +108,7 @@ pub fn init() {
     process::init();
 }
 
-fn ap_init() -> ! {
+fn ap_init() {
     fn ap_idle_thread() {
         let preempt_guard = ostd::task::disable_preempt();
         let cpu_id = preempt_guard.current_cpu();
@@ -129,8 +127,6 @@ fn ap_init() -> ! {
             .cpu_affinity(cpu_id.into())
             .priority(Priority::new(PriorityRange::new(PriorityRange::MAX))),
     );
-    // Spawning functions in the bootstrap context will not return.
-    unreachable!()
 }
 
 fn init_thread() {

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -21,6 +21,9 @@ bitflags! {
         const WEXITED = 0x4;
         const WCONTINUED = 0x8;
         const WNOWAIT = 0x01000000;
+        const WNOTHREAD = 0x20000000;
+        const WALL = 0x40000000;
+        const WCLONE = 0x80000000;
     }
 }
 

--- a/kernel/src/sched/priority_scheduler.rs
+++ b/kernel/src/sched/priority_scheduler.rs
@@ -93,6 +93,9 @@ impl<T: Sync + Send + PreemptSchedInfo + FromTask<U>, U: Sync + Send + CommonSch
         if still_in_rq && let Err(_) = entity.task.cpu().set_if_is_none(target_cpu) {
             return None;
         }
+
+        let new_priority = entity.thread.priority();
+
         if entity.thread.is_real_time() {
             rq.real_time_entities.push_back(entity);
         } else if entity.thread.is_lowest() {
@@ -101,7 +104,17 @@ impl<T: Sync + Send + PreemptSchedInfo + FromTask<U>, U: Sync + Send + CommonSch
             rq.normal_entities.push_back(entity);
         }
 
-        Some(target_cpu)
+        // Preempt the current task, but only if the newly queued task has a strictly higher
+        // priority (i.e., a lower value returned by the `priority` method) than the current task.
+        if rq
+            .current
+            .as_ref()
+            .is_some_and(|current| new_priority < current.thread.priority())
+        {
+            Some(target_cpu)
+        } else {
+            None
+        }
     }
 
     fn local_rq_with(&self, f: &mut dyn FnMut(&dyn LocalRunQueue<U>)) {

--- a/kernel/src/sched/priority_scheduler.rs
+++ b/kernel/src/sched/priority_scheduler.rs
@@ -77,16 +77,16 @@ impl<T: Sync + Send + PreemptSchedInfo + FromTask<U>, U: Sync + Send + CommonSch
 {
     fn enqueue(&self, task: Arc<U>, flags: EnqueueFlags) -> Option<CpuId> {
         let entity = PreemptSchedEntity::new(task);
-        let mut still_in_rq = false;
-        let target_cpu = {
-            let mut cpu_id = self.select_cpu(&entity);
-            if let Err(task_cpu_id) = entity.task.cpu().set_if_is_none(cpu_id) {
-                debug_assert!(flags != EnqueueFlags::Spawn);
-                still_in_rq = true;
-                cpu_id = task_cpu_id;
-            }
 
-            cpu_id
+        let (still_in_rq, target_cpu) = {
+            let selected_cpu_id = self.select_cpu(&entity);
+
+            if let Err(task_cpu_id) = entity.task.cpu().set_if_is_none(selected_cpu_id) {
+                debug_assert!(flags != EnqueueFlags::Spawn);
+                (true, task_cpu_id)
+            } else {
+                (false, selected_cpu_id)
+            }
         };
 
         let mut rq = self.rq[target_cpu.as_usize()].disable_irq().lock();

--- a/osdk/test-kernel/src/lib.rs
+++ b/osdk/test-kernel/src/lib.rs
@@ -49,9 +49,7 @@ fn main() {
         };
     };
 
-    let _ = TaskOptions::new(test_task).data(()).spawn();
-
-    unreachable!("The spawn method will NOT return in the boot context")
+    TaskOptions::new(test_task).data(()).spawn().unwrap();
 }
 
 #[ostd::ktest::panic_handler]

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -30,8 +30,10 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(not(ktest))]
         #[no_mangle]
         extern "Rust" fn __ostd_main() -> ! {
-            #main_fn_name();
-            ostd::prelude::abort();
+            let _: () = #main_fn_name();
+
+            ostd::task::Task::yield_now();
+            unreachable!("`yield_now` in the boot context should not return");
         }
 
         #[allow(unused)]
@@ -52,8 +54,10 @@ pub fn test_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     quote!(
         #[no_mangle]
         extern "Rust" fn __ostd_main() -> ! {
-            #main_fn_name();
-            ostd::prelude::abort();
+            let _: () = #main_fn_name();
+
+            ostd::task::Task::yield_now();
+            unreachable!("`yield_now` in the boot context should not return");
         }
 
         #main_fn

--- a/ostd/src/task/scheduler/fifo_scheduler.rs
+++ b/ostd/src/task/scheduler/fifo_scheduler.rs
@@ -58,7 +58,8 @@ impl<T: CommonSchedInfo + Send + Sync> Scheduler<T> for FifoScheduler<T> {
         }
         rq.queue.push_back(runnable);
 
-        Some(target_cpu)
+        // All tasks are important. Do not preempt the current task without good reason.
+        None
     }
 
     fn local_rq_with(&self, f: &mut dyn FnMut(&dyn LocalRunQueue<T>)) {

--- a/test/apps/clone3/clone_exit_signal.c
+++ b/test/apps/clone3/clone_exit_signal.c
@@ -46,7 +46,8 @@ int main(int argc, char *argv[])
 	 * then the parent process must specify the __WALL or __WCLONE
 	 * options when waiting for the child with wait(2).
 	 */
-	waitpid(pid, NULL, __WALL);
+	if (waitpid(pid, NULL, __WALL) < 0)
+		err(EXIT_FAILURE, "cannot wait child process");
 
 	if (child_exit_recv != 1)
 		errx(EXIT_FAILURE, "did not receive exit signal from child");


### PR DESCRIPTION
I notice that there are an enormous number of context switches during the TCP small message benchmark. This is because every time `send()` completes, the receiving process gets woken up and immediately preempts the sending process.

While this is not currently the performance bottleneck, it's still worth fixing. We should only preempt the current task if the newly enqueued task has a strictly higher priority, as I am trying to do with this PR.