### PR TITLE
Support other SigStackFlags

### DIFF
--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -40,6 +40,7 @@ TESTS ?= \
 	rename_test \
 	semaphore_test \
 	sendfile_test \
+	sigaltstack_test \
 	stat_test \
 	stat_times_test \
 	statfs_test \

--- a/test/syscall_test/blocklists/sigaltstack_test
+++ b/test/syscall_test/blocklists/sigaltstack_test
@@ -1,0 +1,3 @@
+SigaltstackTest.ResetByExecve
+SigaltstackTest.WalksOffBottom
+SigaltstackTest.SetCurrentStack


### PR DESCRIPTION
This pull request includes changes to the signal stack handling in the kernel to improve its robustness and correctness. The most important changes include the addition of new signal stack flags, modifications to the `get_old_stack` function to handle disabled stacks, and updates to the `TryFrom` implementation for `SigStack`.

### Signal Stack Flags:

* [`kernel/src/process/signal/sig_stack.rs`](diffhunk://#diff-b6c91ea692eb7c543f7b09cec5a69abfd6efa2fd54d96539cf26998c357ebb9dR21-R22): Added `SS_ONSTACK` and `SS_DISABLE` flags to the `SigStackFlags` bitflags to align with the behavior of Linux.

### Signal Stack Handling:

* [`kernel/src/syscall/sigaltstack.rs`](diffhunk://#diff-1edca6ef5b2c2e31367cfcde230a65c0770d084ceebc744e0ffa29b738a21f5bL39-R52): Modified the `get_old_stack` function to handle cases where the old stack is `None` by creating a disabled stack and writing it to user space.
* [`kernel/src/syscall/sigaltstack.rs`](diffhunk://#diff-1edca6ef5b2c2e31367cfcde230a65c0770d084ceebc744e0ffa29b738a21f5bR100-R102): Updated the `TryFrom<stack_t>` implementation for `SigStack` to return a disabled stack if the `SS_DISABLE` flag is set.