### PR TITLE
Qspinlock~

### DIFF
--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -54,11 +54,11 @@ extern "C" {
 
 /// Sets the base address of the CPU-local storage for the bootstrap processor.
 ///
-/// It should be called early to let [`crate::task::disable_preempt`] work,
-/// which needs to update a CPU-local preemption info. Otherwise it may
-/// panic when calling [`crate::task::disable_preempt`]. It is needed since
-/// heap allocations need to disable preemption, which would happen in the
-/// very early stage of the kernel.
+// It should be called early to let [`crate::task::disable_preempt`] and
+/// [`crate::sync::spin::queued`] to work, which needs to CPU-local info.
+///
+/// It is needed since heap allocations need to disable preemption and acquire
+/// spin locks, which would happen in the very early stage of the kernel.
 ///
 /// # Safety
 ///
@@ -142,7 +142,12 @@ pub unsafe fn init_on_ap(cpu_id: u32) {
         arch::cpu::local::set_base(ap_pages_ptr as u64);
     }
 
-    crate::task::reset_preempt_info();
+    // SAFETY: They are called only once on AP and no preemption or queued
+    // locks are acquired at this point.
+    unsafe {
+        crate::task::reset_preempt_info_for_ap();
+        crate::sync::spin::queued::reset_node_alloc_info_for_ap();
+    }
 }
 
 mod has_init {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
+    task::disable_preempt,
     util::SameSizeAs,
     Pod,
 };
@@ -127,6 +128,7 @@ impl PageTable<KernelMode> {
     /// This should be the only way to create the user page table, that is to
     /// duplicate the kernel page table with all the kernel mappings shared.
     pub fn create_user_page_table(&self) -> PageTable<UserMode> {
+        let _preempt_guard = disable_preempt();
         let mut root_node = self.root.clone_shallow().lock();
         let mut new_node =
             PageTableNode::alloc(PagingConsts::NR_LEVELS, MapTrackingStatus::NotApplicable);

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -28,12 +28,7 @@
 mod child;
 mod entry;
 
-use core::{
-    cell::SyncUnsafeCell,
-    marker::PhantomData,
-    mem::ManuallyDrop,
-    sync::atomic::{AtomicU8, Ordering},
-};
+use core::{cell::SyncUnsafeCell, marker::PhantomData, mem::ManuallyDrop, sync::atomic::Ordering};
 
 pub(in crate::mm) use self::{child::Child, entry::Entry};
 use super::{nr_subpage_per_huge, PageTableEntryTrait};
@@ -45,6 +40,7 @@ use crate::{
         page_table::{load_pte, store_pte},
         FrameAllocOptions, Infallible, Paddr, PagingConstsTrait, PagingLevel, VmReader,
     },
+    sync::spin,
 };
 
 /// The raw handle to a page table node.
@@ -78,21 +74,24 @@ where
     }
 
     /// Converts a raw handle to an accessible handle by pertaining the lock.
+    ///
+    /// This should be an unsafe function that requires the caller to ensure
+    /// that preemption is disabled while the lock is held, or if the page is
+    /// not shared with other CPUs.
+    ///
+    // FIXME: To avoid extra preemption count increment and decrement we should
+    // mark it unsafe. We cannot let this guard take the reference of the preempt
+    // guard because a field cannot reference another field in the same structure.
     pub(super) fn lock(self) -> PageTableNode<E, C> {
         let level = self.level;
         let page: Frame<PageTablePageMeta<E, C>> = self.into();
 
-        // Acquire the lock.
-        let meta = page.meta();
-        while meta
-            .lock
-            .compare_exchange(0, 1, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            core::hint::spin_loop();
-        }
-
         debug_assert_eq!(page.meta().level, level);
+
+        // SAFETY: Preemption is disabled.
+        unsafe {
+            page.meta().lock.lock();
+        }
 
         PageTableNode::<E, C> { page }
     }
@@ -277,7 +276,11 @@ where
         let this = ManuallyDrop::new(self);
 
         // Release the lock.
-        this.page.meta().lock.store(0, Ordering::Release);
+        // SAFETY:
+        //  - The lock stays at the metadata slot so it's pinned.
+        //  - The constructor of the node guard ensures that the lock is held,
+        //    and no preemption is allowed.
+        unsafe { this.page.meta().lock.unlock() };
 
         // SAFETY: The provided physical address is valid and the level is
         // correct. The reference count is not changed.
@@ -352,7 +355,13 @@ where
 {
     fn drop(&mut self) {
         // Release the lock.
-        self.page.meta().lock.store(0, Ordering::Release);
+        // SAFETY:
+        //  - The lock stays at the metadata slot so it's pinned.
+        //  - The constructor of the node guard ensures that the lock is held,
+        //    and no preemption is allowed.
+        unsafe {
+            self.page.meta().lock.unlock();
+        }
     }
 }
 
@@ -365,13 +374,13 @@ pub(in crate::mm) struct PageTablePageMeta<
 > where
     [(); C::NR_LEVELS as usize]:,
 {
+    /// The lock for the page table page.
+    pub lock: spin::queued::LockBody,
     /// The number of valid PTEs. It is mutable if the lock is held.
     pub nr_children: SyncUnsafeCell<u16>,
     /// The level of the page table page. A page table page cannot be
     /// referenced by page tables of different levels.
     pub level: PagingLevel,
-    /// The lock for the page table page.
-    pub lock: AtomicU8,
     /// Whether the pages mapped by the node is tracked.
     pub is_tracked: MapTrackingStatus,
     _phantom: core::marker::PhantomData<(E, C)>,
@@ -401,7 +410,7 @@ where
         Self {
             nr_children: SyncUnsafeCell::new(0),
             level,
-            lock: AtomicU8::new(1),
+            lock: spin::queued::LockBody::new_locked(),
             is_tracked,
             _phantom: PhantomData,
         }

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -10,7 +10,7 @@ mod mutex;
 mod rwarc;
 mod rwlock;
 mod rwmutex;
-mod spin;
+pub(crate) mod spin;
 mod wait;
 
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -17,16 +17,10 @@ mod wait;
 pub(crate) use self::guard::GuardTransfer;
 pub use self::{
     guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
-    mutex::{ArcMutexGuard, Mutex, MutexGuard},
+    mutex::{Mutex, MutexGuard},
     rwarc::{RoArc, RwArc},
-    rwlock::{
-        ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
-        RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,
-    },
-    rwmutex::{
-        ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
-        RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
-    },
-    spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
+    rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard},
+    rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
+    spin::{SpinLock, SpinLockGuard},
     wait::{WaitQueue, Waiter, Waker},
 };

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -2,7 +2,6 @@
 
 #![expect(dead_code)]
 
-use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -142,22 +141,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         }
     }
 
-    /// Acquires a read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`read`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the read guard.
-    ///
-    /// [`read`]: Self::read
-    pub fn read_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<T, G> {
-        loop {
-            if let Some(readguard) = self.try_read_arc() {
-                return readguard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
     /// Acquires a write lock and spin-wait until it can be acquired.
     ///
     /// The calling thread will spin-wait until there are no other writers,
@@ -167,22 +150,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
     pub fn write(&self) -> RwLockWriteGuard<T, G> {
         loop {
             if let Some(writeguard) = self.try_write() {
-                return writeguard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
-    /// Acquires a write lock through an [`Arc`].
-    ///
-    /// The method is similar to [`write`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`write`]: Self::write
-    pub fn write_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<T, G> {
-        loop {
-            if let Some(writeguard) = self.try_write_arc() {
                 return writeguard;
             } else {
                 core::hint::spin_loop();
@@ -210,22 +177,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         }
     }
 
-    /// Acquires an upgradeable read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`upread`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`upread`]: Self::upread
-    pub fn upread_arc(self: &Arc<Self>) -> ArcRwLockUpgradeableGuard<T, G> {
-        loop {
-            if let Some(guard) = self.try_upread_arc() {
-                return guard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
     /// Attempts to acquire a read lock.
     ///
     /// This function will never spin-wait and will return immediately.
@@ -234,26 +185,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         let lock = self.lock.fetch_add(READER, Acquire);
         if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
             Some(RwLockReadGuard { inner: self, guard })
-        } else {
-            self.lock.fetch_sub(READER, Release);
-            None
-        }
-    }
-
-    /// Attempts to acquire an read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_read`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_read`]: Self::try_read
-    pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<T, G>> {
-        let guard = G::read_guard();
-        let lock = self.lock.fetch_add(READER, Acquire);
-        if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
-            Some(ArcRwLockReadGuard {
-                inner: self.clone(),
-                guard,
-            })
         } else {
             self.lock.fetch_sub(READER, Release);
             None
@@ -276,28 +207,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         }
     }
 
-    /// Attempts to acquire a write lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_write`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_write`]: Self::try_write
-    fn try_write_arc(self: &Arc<Self>) -> Option<ArcRwLockWriteGuard<T, G>> {
-        let guard = G::guard();
-        if self
-            .lock
-            .compare_exchange(0, WRITER, Acquire, Relaxed)
-            .is_ok()
-        {
-            Some(ArcRwLockWriteGuard {
-                inner: self.clone(),
-                guard,
-            })
-        } else {
-            None
-        }
-    }
-
     /// Attempts to acquire an upread lock.
     ///
     /// This function will never spin-wait and will return immediately.
@@ -306,26 +215,6 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire) & (WRITER | UPGRADEABLE_READER);
         if lock == 0 {
             return Some(RwLockUpgradeableGuard { inner: self, guard });
-        } else if lock == WRITER {
-            self.lock.fetch_sub(UPGRADEABLE_READER, Release);
-        }
-        None
-    }
-
-    /// Attempts to acquire an upgradeable read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_upread`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_upread`]: Self::try_upread
-    pub fn try_upread_arc(self: &Arc<Self>) -> Option<ArcRwLockUpgradeableGuard<T, G>> {
-        let guard = G::guard();
-        let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire) & (WRITER | UPGRADEABLE_READER);
-        if lock == 0 {
-            return Some(ArcRwLockUpgradeableGuard {
-                inner: self.clone(),
-                guard,
-            });
         } else if lock == WRITER {
             self.lock.fetch_sub(UPGRADEABLE_READER, Release);
         }
@@ -398,9 +287,6 @@ pub struct RwLockReadGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, 
 /// A guard that provides shared read access to the data protected by a [`RwLock`].
 pub type RwLockReadGuard<'a, T, G> = RwLockReadGuard_<T, &'a RwLock<T, G>, G>;
 
-/// A guard that provides shared read access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockReadGuard<T, G> = RwLockReadGuard_<T, Arc<RwLock<T, G>>, G>;
-
 impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: Guardian> Deref
     for RwLockReadGuard_<T, R, G>
 {
@@ -435,8 +321,6 @@ pub struct RwLockWriteGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone,
 
 /// A guard that provides exclusive write access to the data protected by a [`RwLock`].
 pub type RwLockWriteGuard<'a, T, G> = RwLockWriteGuard_<T, &'a RwLock<T, G>, G>;
-/// A guard that provides exclusive write access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockWriteGuard<T, G> = RwLockWriteGuard_<T, Arc<RwLock<T, G>>, G>;
 
 impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: Guardian> Deref
     for RwLockWriteGuard_<T, R, G>
@@ -513,8 +397,6 @@ pub struct RwLockUpgradeableGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + 
 
 /// A upgradable guard that provides read access to the data protected by a [`RwLock`].
 pub type RwLockUpgradeableGuard<'a, T, G> = RwLockUpgradeableGuard_<T, &'a RwLock<T, G>, G>;
-/// A upgradable guard that provides read access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockUpgradeableGuard<T, G> = RwLockUpgradeableGuard_<T, Arc<RwLock<T, G>>, G>;
 
 impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: Guardian>
     RwLockUpgradeableGuard_<T, R, G>

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(dead_code)]
-
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -280,6 +278,7 @@ unsafe impl<T: ?Sized + Sync, R: Deref<Target = RwLock<T, G>> + Clone + Sync, G:
 #[clippy::has_significant_drop]
 #[must_use]
 pub struct RwLockReadGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: Guardian> {
+    #[expect(dead_code)]
     guard: G::ReadGuard,
     inner: R,
 }

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -238,8 +237,6 @@ pub struct RwMutexReadGuard_<T: ?Sized, R: Deref<Target = RwMutex<T>>> {
 
 /// A guard that provides shared read access to the data protected by a [`RwMutex`].
 pub type RwMutexReadGuard<'a, T> = RwMutexReadGuard_<T, &'a RwMutex<T>>;
-/// A guard that provides shared read access to the data protected by a `Arc<RwMutex>`.
-pub type ArcRwMutexReadGuard<T> = RwMutexReadGuard_<T, Arc<RwMutex<T>>>;
 
 impl<T: ?Sized, R: Deref<Target = RwMutex<T>>> Deref for RwMutexReadGuard_<T, R> {
     type Target = T;
@@ -267,8 +264,6 @@ pub struct RwMutexWriteGuard_<T: ?Sized, R: Deref<Target = RwMutex<T>>> {
 
 /// A guard that provides exclusive write access to the data protected by a [`RwMutex`].
 pub type RwMutexWriteGuard<'a, T> = RwMutexWriteGuard_<T, &'a RwMutex<T>>;
-/// A guard that provides exclusive write access to the data protected by a `Arc<RwMutex>`.
-pub type ArcRwMutexWriteGuard<T> = RwMutexWriteGuard_<T, Arc<RwMutex<T>>>;
 
 impl<T: ?Sized, R: Deref<Target = RwMutex<T>>> Deref for RwMutexWriteGuard_<T, R> {
     type Target = T;
@@ -334,8 +329,6 @@ pub struct RwMutexUpgradeableGuard_<T: ?Sized, R: Deref<Target = RwMutex<T>>> {
 
 /// A upgradable guard that provides read access to the data protected by a [`RwMutex`].
 pub type RwMutexUpgradeableGuard<'a, T> = RwMutexUpgradeableGuard_<T, &'a RwMutex<T>>;
-/// A upgradable guard that provides read access to the data protected by a `Arc<RwMutex>`.
-pub type ArcRwMutexUpgradeableGuard<T> = RwMutexUpgradeableGuard_<T, Arc<RwMutex<T>>>;
 
 impl<T: ?Sized, R: Deref<Target = RwMutex<T>> + Clone> RwMutexUpgradeableGuard_<T, R> {
     /// Upgrades this upread guard to a write guard atomically.

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(dead_code)]
-
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -137,6 +135,7 @@ pub type SpinLockGuard<'a, T, G> = SpinLockGuard_<T, &'a SpinLock<T, G>, G>;
 #[clippy::has_significant_drop]
 #[must_use]
 pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> {
+    #[expect(dead_code)]
     guard: G::Guard,
     lock: R,
 }

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -2,7 +2,6 @@
 
 #![expect(dead_code)]
 
-use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -81,21 +80,6 @@ impl<T: ?Sized, G: Guardian> SpinLock<T, G> {
         }
     }
 
-    /// Acquires the spin lock through an [`Arc`].
-    ///
-    /// The method is similar to [`lock`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`lock`]: Self::lock
-    pub fn lock_arc(self: &Arc<Self>) -> ArcSpinLockGuard<T, G> {
-        let inner_guard = G::guard();
-        self.acquire_lock();
-        SpinLockGuard_ {
-            lock: self.clone(),
-            guard: inner_guard,
-        }
-    }
-
     /// Tries acquiring the spin lock immedidately.
     pub fn try_lock(&self) -> Option<SpinLockGuard<T, G>> {
         let inner_guard = G::guard();
@@ -148,8 +132,6 @@ unsafe impl<T: ?Sized + Send, G> Sync for SpinLock<T, G> {}
 
 /// A guard that provides exclusive access to the data protected by a [`SpinLock`].
 pub type SpinLockGuard<'a, T, G> = SpinLockGuard_<T, &'a SpinLock<T, G>, G>;
-/// A guard that provides exclusive access to the data protected by a `Arc<SpinLock>`.
-pub type ArcSpinLockGuard<T, G> = SpinLockGuard_<T, Arc<SpinLock<T, G>>, G>;
 
 /// The guard of a spin lock.
 #[clippy::has_significant_drop]

--- a/ostd/src/sync/spin/queued.rs
+++ b/ostd/src/sync/spin/queued.rs
@@ -173,6 +173,16 @@ impl LockBody {
         }
     }
 
+    /// Create a new queued spinlock, which is locked.
+    ///
+    /// To use it, the caller must subsequently call `unlock` to release the
+    /// lock for others.
+    pub(crate) const fn new_locked() -> Self {
+        Self {
+            val: ManuallyDrop::new(UnsafeCell::new(Self::LOCKED_VAL)),
+        }
+    }
+
     /// Try to lock the queued spinlock.
     ///
     /// If the lock is acquired successfully, return an acquired guard.

--- a/ostd/src/sync/spin/queued.rs
+++ b/ostd/src/sync/spin/queued.rs
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This module provides a Rust-implementation of the [Linux queued-spinlock]
+// (https://github.com/torvalds/linux/blob/master/kernel/locking/qspinlock.c),
+// which is released under:
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Original copyright remarks:
+//
+// (C) Copyright 2013-2015 Hewlett-Packard Development Company, L.P.
+// (C) Copyright 2013-2014,2018 Red Hat, Inc.
+// (C) Copyright 2015 Intel Corp.
+// (C) Copyright 2015 Hewlett-Packard Enterprise Development LP
+//
+// Original Authors: Waiman Long <longman@redhat.com>
+//                   Peter Zijlstra <peterz@infradead.org>
+//
+// Authors of this Rust adaptation:
+//                   Junyang Zhang <junyang@stu.pku.edu.cn>
+
+//! Queued spin lock algorithm.
+//!
+//! This module provides only low-level primitives for the queued spin lock
+//! algorithm. And the primitives can be used to build higher-level, RAII-style
+//! synchronization guards.
+//!
+//! This queued spin lock implementation is based on the MCS lock, but it
+//! allows optimistic spinning when there's no contention observed. When
+//! there's contention, it will fall back to the MCS lock for queueing.
+
+use core::{
+    cell::UnsafeCell,
+    fmt::Debug,
+    intrinsics,
+    mem::{offset_of, ManuallyDrop},
+    sync::atomic::{AtomicBool, AtomicPtr, Ordering},
+};
+
+use crate::{
+    cpu::{current_cpu_unchecked, CpuId},
+    cpu_local, cpu_local_cell,
+};
+
+/// A lock body for a queue spinlock.
+///
+/// Each memory location that is shared between CPUs must have a unique
+/// instance of this type.
+#[repr(C)]
+pub(crate) union LockBody {
+    /// Layout of the value:
+    ///
+    /// ```text
+    /// Bits:
+    /// |31            18|17        16| |        8| |       0|
+    /// +----------------+------------+ +---------+ +--------+
+    /// | tail CPU ID +1 | tail index | | pending | | locked |
+    /// +----------------+------------| +---------+ +--------+
+    /// Bytes (little-endian):
+    /// |     3    |       2          | |    1    | |    0   |
+    /// Bytes (big-endian):
+    /// |     0    |       1          | |    2    | |    3   |
+    /// ```
+    val: ManuallyDrop<UnsafeCell<u32>>,
+    /// We would access the fields separately to optimize atomic operations.
+    inner_repr1: ManuallyDrop<InnerRepr1>,
+    /// We would access the locked and pending bits together to optimize
+    /// atomic operations.
+    inner_repr2: ManuallyDrop<InnerRepr2>,
+}
+
+// SAFETY: The structure will be used for synchronization by design.
+unsafe impl Sync for LockBody {}
+// SAFETY: When sending a lock body there will be no shared references to it.
+// So there's no race that could happen.
+unsafe impl Send for LockBody {}
+
+#[cfg(target_endian = "little")]
+#[repr(C)]
+struct InnerRepr1 {
+    locked: UnsafeCell<u8>,
+    pending: UnsafeCell<u8>,
+    tail: UnsafeCell<u16>,
+}
+
+#[cfg(target_endian = "little")]
+#[repr(C)]
+struct InnerRepr2 {
+    locked_pending: UnsafeCell<u16>,
+    _tail: UnsafeCell<u16>,
+}
+
+#[cfg(target_endian = "big")]
+#[repr(C)]
+struct InnerRepr1 {
+    tail: UnsafeCell<u16>,
+    pending: UnsafeCell<u8>,
+    locked: UnsafeCell<u8>,
+}
+
+#[cfg(target_endian = "big")]
+#[repr(C)]
+struct InnerRepr2 {
+    _tail: UnsafeCell<u16>,
+    locked_pending: UnsafeCell<u16>,
+}
+
+impl LockBody {
+    const LOCKED_OFFSET: usize = offset_of!(InnerRepr1, locked) * 8;
+    const LOCKED_VAL: u32 = 0x1 << Self::LOCKED_OFFSET;
+    const LOCKED_MASK: u32 = 0xff << Self::LOCKED_OFFSET;
+
+    const PENDING_OFFSET: usize = offset_of!(InnerRepr1, pending) * 8;
+    const PENDING_VAL: u32 = 0x1 << Self::PENDING_OFFSET;
+    const PENDING_MASK: u32 = 0xff << Self::PENDING_OFFSET;
+
+    const TAIL_OFFSET: usize = offset_of!(InnerRepr1, tail) * 8;
+    const TAIL_MASK: u32 = 0xffff << Self::TAIL_OFFSET;
+    const TAIL_TOP_BITS: usize = 2;
+    const TAIL_TOP_MASK_IN_TAIL: u16 = (0x1 << Self::TAIL_TOP_BITS) - 1;
+    const MAX_CPU_COUNT: usize = (u16::MAX as usize >> Self::TAIL_TOP_BITS) - 1;
+
+    fn encode_tail(cpu: CpuId, top: usize) -> u16 {
+        debug_assert!(cpu.as_usize() < Self::MAX_CPU_COUNT);
+        ((cpu.as_usize() as u16 + 1) << Self::TAIL_TOP_BITS)
+            | (top as u16 & Self::TAIL_TOP_MASK_IN_TAIL)
+    }
+
+    fn get_tail(tail: u16) -> &'static QueueNode {
+        let cpu = (tail >> Self::TAIL_TOP_BITS) - 1;
+        let cpu_id = CpuId::try_from(cpu as usize).unwrap();
+
+        let index = tail & Self::TAIL_TOP_MASK_IN_TAIL;
+
+        &QUEUE_NODES.get_on_cpu(cpu_id)[index as usize]
+    }
+}
+
+impl InnerRepr2 {
+    #[cfg(target_endian = "little")]
+    const FIRST_OFFSET: usize = 0;
+    #[cfg(target_endian = "big")]
+    const FIRST_OFFSET: usize = 16;
+
+    const LOCKED_OFFSET: usize = offset_of!(InnerRepr1, locked) * 8 - Self::FIRST_OFFSET;
+    const LOCKED_VAL: u16 = 0x1 << Self::LOCKED_OFFSET;
+    #[expect(dead_code)]
+    const LOCKED_MASK: u16 = 0xff << Self::LOCKED_OFFSET;
+
+    const PENDING_OFFSET: usize = offset_of!(InnerRepr1, pending) * 8 - Self::FIRST_OFFSET;
+    #[expect(dead_code)]
+    const PENDING_VAL: u16 = 0x1 << Self::PENDING_OFFSET;
+    #[expect(dead_code)]
+    const PENDING_MASK: u16 = 0xff << Self::PENDING_OFFSET;
+}
+
+impl Debug for LockBody {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let val = unsafe { intrinsics::atomic_load_relaxed(self.val_ptr()) };
+        f.debug_struct("LockBody")
+            .field("locked", &(val & LockBody::LOCKED_MASK != 0))
+            .field("pending", &(val & LockBody::PENDING_MASK != 0))
+            .field("tail", &(val >> LockBody::TAIL_OFFSET))
+            .finish()
+    }
+}
+
+impl LockBody {
+    /// Create a new queued spinlock, which is unlocked.
+    pub(crate) const fn new() -> Self {
+        Self {
+            val: ManuallyDrop::new(UnsafeCell::new(0)),
+        }
+    }
+
+    /// Try to lock the queued spinlock.
+    ///
+    /// If the lock is acquired successfully, return an acquired guard.
+    /// Otherwise, return a guard that haven't acquired the lock.
+    ///
+    /// If it returns an acquired guard the critical section can commence.
+    pub(crate) fn try_lock(&self) -> bool {
+        self.try_lock_impl().is_ok()
+    }
+
+    /// Unlock the queued spin-lock.
+    ///
+    /// This function will release the lock and allow other CPUs to acquire the
+    /// lock. Call this function after the critical section is finished.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the following properties:
+    ///  - The lock is pinned after any one acquired it and before every one
+    ///    unlocks it (i.e. no lock-stealing).
+    ///  - The lock was acquired by the current CPU for once and not unlocked.
+    ///  - preemption is disabled after the current CPU acquired the lock.
+    pub(crate) unsafe fn unlock(&self) {
+        // 0,0,1 -> 0,0,0
+        unsafe {
+            intrinsics::atomic_store_release(self.locked_ptr(), 0);
+        }
+    }
+
+    /// Lock the queued spinlock.
+    ///
+    /// This function will spin until the lock is acquired. When the function
+    /// returns, the critical section can commence.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the current task is pinned to the current
+    /// CPU.
+    pub(crate) unsafe fn lock(&self) {
+        // (queue tail, pending bit, lock value)
+        //
+        //              fast     :    slow                                  :    unlock
+        //                       :                                          :
+        // uncontended  (0,0,0) -:--> (0,0,1) ------------------------------:--> (*,*,0)
+        //                       :       | ^--------.------.             /  :
+        //                       :       v           \      \            |  :
+        // pending               :    (0,1,1) +--> (0,1,0)   \           |  :
+        //                       :       | ^--'              |           |  :
+        //                       :       v                   |           |  :
+        // uncontended           :    (n,x,y) +--> (n,0,0) --'           |  :
+        //   queue               :       | ^--'                          |  :
+        //                       :       v                               |  :
+        // contended             :    (*,x,y) +--> (*,0,0) ---> (*,0,1) -'  :
+        //   queue               :         ^--'                             :
+
+        match self.try_lock_impl() {
+            Ok(()) => {}
+            Err(val) => {
+                // Slow path. There are pending spinners or queued spinners.
+                self.lock_slow(val);
+            }
+        }
+    }
+
+    /// Acquire the spinlock in a slow path.
+    fn lock_slow(&self, mut lock_val: u32) {
+        // Wait for in-progress pending->locked hand-overs with a bounded
+        // number of spins so that we guarantee forward progress.
+        // 0,1,0 -> 0,0,1
+        if lock_val == Self::PENDING_VAL {
+            /// The pending bit spinning loop count.
+            const QUEUE_PENDING_LOOPS: usize = 1;
+
+            for _ in 0..QUEUE_PENDING_LOOPS {
+                core::hint::spin_loop();
+                lock_val = unsafe { intrinsics::atomic_load_relaxed(self.val_ptr()) };
+                if lock_val != Self::PENDING_VAL {
+                    break;
+                }
+            }
+        }
+
+        // If we observe any contention, we enqueue ourselves.
+        if lock_val & !Self::LOCKED_MASK != 0 {
+            self.lock_enqueue();
+            return;
+        }
+
+        // 0,0,* -> 0,1,* -> 0,0,1 pending, trylock
+        lock_val = unsafe { intrinsics::atomic_or_acquire(self.val_ptr(), Self::PENDING_VAL) };
+
+        // If we observe contention, there is a concurrent locker.
+        if lock_val & !Self::LOCKED_MASK != 0 {
+            // Undo the pending bit if we set it.
+            if (lock_val & Self::PENDING_MASK) == 0 {
+                unsafe {
+                    self.pending_ptr().write_volatile(0);
+                };
+            }
+            self.lock_enqueue();
+            return;
+        }
+
+        // We're pending, wait for the owner to go away.
+        // 0,1,1 -> *,1,0
+        if lock_val & Self::LOCKED_MASK != 0 {
+            while unsafe { intrinsics::atomic_load_acquire(self.locked_ptr()) } != 0 {
+                core::hint::spin_loop();
+            }
+        }
+
+        // Take the ownership and clear the pending bit.
+        // 0,1,0 -> 0,0,1
+        unsafe {
+            self.locked_pending_ptr()
+                .write_volatile(InnerRepr2::LOCKED_VAL)
+        };
+
+        // We're done.
+    }
+
+    /// Try to lock the spinlock in an optimistic path.
+    ///
+    /// If the lock is acquired successfully, return `Ok(())`. Otherwise, return
+    /// `Err(prev_val)`.
+    fn try_lock_impl(&self) -> Result<(), u32> {
+        let (val, ret) = unsafe {
+            intrinsics::atomic_cxchg_acquire_relaxed(self.val_ptr(), 0, LockBody::LOCKED_VAL)
+        };
+        if ret {
+            Ok(())
+        } else {
+            Err(val)
+        }
+    }
+
+    /// Acquire the spinlock in a very-slow path.
+    ///
+    /// If we cannot lock optimistically (likely due to contention), we enqueue
+    /// ourselves and spin on local MCS nodes.
+    fn lock_enqueue(&self) {
+        // SAFETY: The caller of `lock` ensures that the current task is
+        // pinned to the current CPU.
+        let cur_cpu = unsafe { current_cpu_unchecked() };
+
+        let top = TOP.load();
+        TOP.store(top + 1);
+
+        macro_rules! cleanup_and_return {
+            () => {
+                TOP.store(top);
+                return;
+            };
+        }
+
+        if top >= MAX_NESTED_ACQUIRE_DEPTH {
+            // If this function (`lock_queue`) is interrupted by either IRQ/
+            // softirq/NMI, and the interrupt handler tries to acquire other
+            // spin-locks and gets into the same situation, we may end up with
+            // exceeding the maximum nested queued-spin-lock acquire depth.
+            // This is extremely unlikely to happen.
+            crate::early_println!("Exceeded the maximum nested queued-spin-lock acquire depth");
+            // Fall back to spinning on the global lock.
+            while self.try_lock_impl().is_err() {
+                core::hint::spin_loop();
+            }
+            cleanup_and_return!();
+        }
+
+        let node = &QUEUE_NODES.get_on_cpu(cur_cpu)[top];
+
+        // Prevent the compiler from reordering the write to `TOP` after the
+        // initialization of the node. This will likely to become a problem
+        // if interrupts happen between the write to `node` and the write
+        // to `TOP`.
+        core::sync::atomic::compiler_fence(Ordering::Release);
+
+        // Initialize the node.
+        node.locked.store(false, Ordering::Relaxed);
+        node.next.store(core::ptr::null_mut(), Ordering::Relaxed);
+
+        // We touched a (possibly) cold cacheline in the per-CPU queue node;
+        // attempt the try lock once more in the hope someone let go while we
+        // weren't watching.
+        if self.try_lock_impl().is_ok() {
+            cleanup_and_return!();
+        }
+
+        // Ensure that the initialization of the node is complete before we
+        // publish the updated tail via swap and potentially link the node
+        // into the wait queue.
+        core::sync::atomic::fence(Ordering::Release);
+
+        // Publish the updated tail.
+        // p,*,* -> n,*,*
+        let this_node_encoded = Self::encode_tail(cur_cpu, top);
+        let old_tail =
+            unsafe { intrinsics::atomic_xchg_relaxed(self.tail_ptr(), this_node_encoded) };
+        let mut next: *mut QueueNode = core::ptr::null_mut();
+
+        // If the old tail was not null, link the node into the queue.
+        if old_tail != 0 {
+            let prev_node = Self::get_tail(old_tail);
+
+            // Link the node into the queue so that the predecessor can notify us.
+            prev_node
+                .next
+                .store((node as *const QueueNode).cast_mut(), Ordering::Relaxed);
+
+            // Spin on the locked bit.
+            while !node.locked.load(Ordering::Relaxed) {
+                core::hint::spin_loop();
+            }
+
+            // While waiting for the MCS lock, the next pointer may have been
+            // updated. If so, we optimitically load it for writing now as we
+            // may soon need it.
+            next = node.next.load(Ordering::Relaxed);
+            if !next.is_null() {
+                unsafe {
+                    intrinsics::prefetch_write_data(next.cast_const(), 0);
+                }
+            }
+        }
+
+        // We're now at the head of the queue, wait for the owner & pending to
+        // go away.
+        // *,x,y -> *,0,0
+
+        let mut val;
+
+        loop {
+            val = unsafe { intrinsics::atomic_load_acquire(self.val_ptr()) };
+            if val & (Self::LOCKED_MASK | Self::PENDING_MASK) == 0 {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+
+        // Claim the lock.
+        // n,0,0 -> 0,0,1 : lock, uncontented
+        // *,*,0 -> 0,0,1 : lock, contended
+
+        if val & Self::TAIL_MASK == (this_node_encoded as u32) << Self::TAIL_OFFSET {
+            // If the queue head is the only one in the queue, and nobody is
+            // pending, clear the tail.
+            let (_, unlocked_as_tail) = unsafe {
+                intrinsics::atomic_cxchg_relaxed_relaxed(self.val_ptr(), val, Self::LOCKED_VAL)
+            };
+            if unlocked_as_tail {
+                // Uncontended.
+                cleanup_and_return!();
+            }
+        }
+
+        // Contended.
+
+        // Either somebody is queued behind us, or somebody is sets the
+        // pending bit. If that one set a pending bit then it will be
+        // queued behind us. So we will see a `next`.
+        unsafe {
+            self.locked_ptr().write_volatile(1);
+        }
+
+        // Wait for next if not observed yet.
+        while next.is_null() {
+            next = node.next.load(Ordering::Relaxed);
+            core::hint::spin_loop();
+        }
+
+        // Notify the next node.
+        // SAFETY: The next node is guaranteed to be valid.
+        let next_node = unsafe { &*next };
+        next_node.locked.store(true, Ordering::Release);
+
+        cleanup_and_return!();
+    }
+
+    fn val_ptr(&self) -> *mut u32 {
+        // SAFETY: All the fields in this union are pairwise transmutable.
+        unsafe { self.val.get() }
+    }
+
+    fn locked_ptr(&self) -> *mut u8 {
+        // SAFETY: All the fields in this union are pairwise transmutable.
+        unsafe { self.inner_repr1.locked.get() }
+    }
+
+    fn pending_ptr(&self) -> *mut u8 {
+        // SAFETY: All the fields in this union are pairwise transmutable.
+        unsafe { self.inner_repr1.pending.get() }
+    }
+
+    fn tail_ptr(&self) -> *mut u16 {
+        // SAFETY: All the fields in this union are pairwise transmutable.
+        unsafe { self.inner_repr1.tail.get() }
+    }
+
+    fn locked_pending_ptr(&self) -> *mut u16 {
+        // SAFETY: All the fields in this union are pairwise transmutable.
+        unsafe { self.inner_repr2.locked_pending.get() }
+    }
+}
+
+struct QueueNode {
+    next: AtomicPtr<QueueNode>,
+    locked: AtomicBool,
+}
+
+impl QueueNode {
+    const fn new() -> Self {
+        Self {
+            next: AtomicPtr::new(core::ptr::null_mut()),
+            locked: AtomicBool::new(false),
+        }
+    }
+}
+
+/// The number of maximum nested queued acquire depth.
+const MAX_NESTED_ACQUIRE_DEPTH: usize = 1 << LockBody::TAIL_TOP_BITS;
+
+// Per-CPU queue node structures; it is expected that we can never have more
+// than 4 nested contexts.
+cpu_local! {
+    static QUEUE_NODES: [QueueNode; MAX_NESTED_ACQUIRE_DEPTH] = [const { QueueNode::new() }; MAX_NESTED_ACQUIRE_DEPTH];
+}
+
+cpu_local_cell! {
+    static TOP: usize = 0;
+}
+
+/// Resets the node allocation info for the application processor (AP).
+///
+/// It exists because that the BSP may acquire locks early before the CPU-local
+/// storage for APs is initialized. So the AP may boot with the CPU local
+/// storage dirty.
+///
+/// # Safety
+///
+/// It should only be called on the AP and only once when initializing the AP's
+/// CPU-local storage. No queued spinlock should be acquired before this
+/// function is called.
+pub(crate) unsafe fn reset_node_alloc_info_for_ap() {
+    TOP.store(0);
+}

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -18,7 +18,7 @@ use core::{
 };
 
 use kernel_stack::KernelStack;
-pub(crate) use preempt::cpu_local::reset_preempt_info;
+pub(crate) use preempt::cpu_local::reset_preempt_info_for_ap;
 use processor::current_task;
 use utils::ForceSync;
 

--- a/ostd/src/task/preempt/cpu_local.rs
+++ b/ostd/src/task/preempt/cpu_local.rs
@@ -67,7 +67,7 @@ cpu_local_cell! {
 /// initialize the CPU-local storage for APs, the value of the AP's
 /// `PREEMPT_INFO` would be that of the BSP's. Therefore, we need to reset the
 /// `PREEMPT_INFO` to the initial state on APs' initialization.
-pub(crate) unsafe fn reset_preempt_info() {
+pub(crate) unsafe fn reset_preempt_info_for_ap() {
     PREEMPT_INFO.store(NEED_PREEMPT_MASK);
 }
 


### PR DESCRIPTION
The queued spin-lock, comparing to the MCS lock, make the lock acquiring more optimistic thus faster in the fast path. This is the default implementation of spin locks in Linux. Also because that the spinner would kick the successor into the pending state before the lock is acquired (rather than kicking during unlock), there's no need to preserve per-core space for owners. So the guard-style API can be untouched.

Prefer this over #1514 and #1506 

Closes #1528 