### PR TITLE
Avoid adding worker during workqueue enqueueing

### DIFF
--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -92,11 +92,11 @@ impl LineDiscipline {
     pub fn new(send_signal: LdiscSignalSender) -> Arc<Self> {
         Arc::new_cyclic(move |line_ref: &Weak<LineDiscipline>| {
             let line_discipline = line_ref.clone();
-            let work_item = Arc::new(WorkItem::new(Box::new(move || {
+            let work_item = WorkItem::new(Box::new(move || {
                 if let Some(line_discipline) = line_discipline.upgrade() {
                     line_discipline.send_signal_after();
                 }
-            })));
+            }));
             Self {
                 current_line: SpinLock::new(CurrentLine::default()),
                 read_buffer: SpinLock::new(RingBuffer::new(BUFFER_CAPACITY)),

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -106,7 +106,7 @@ fn create_process_timer_callback(process_ref: &Weak<Process>) -> impl Fn() + Clo
     };
 
     let work_func = Box::new(sent_signal);
-    let work_item = Arc::new(WorkItem::new(work_func));
+    let work_item = WorkItem::new(work_func);
 
     move || {
         submit_work_item(

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -95,7 +95,7 @@ pub fn sys_timer_create(
     };
 
     let work_func = sent_signal;
-    let work_item = Arc::new(WorkItem::new(work_func));
+    let work_item = WorkItem::new(work_func);
     let func = move || {
         submit_work_item(
             work_item.clone(),

--- a/kernel/src/thread/work_queue/mod.rs
+++ b/kernel/src/thread/work_queue/mod.rs
@@ -142,9 +142,7 @@ impl WorkQueue {
             .lock()
             .pending_work_items
             .push(work_item);
-        if let Some(worker_pool) = self.worker_pool.upgrade() {
-            worker_pool.schedule()
-        }
+
         true
     }
 


### PR DESCRIPTION
Fix the bug mentioned in #1490 .

Also replacing the `Vec` with heap-free `LinkedList` and disable the irq during page allocation.