### PR TITLE
Add several FIO tests to the benchmark CI

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -54,6 +54,10 @@ jobs:
           - lmbench/ext2_create_delete_files_0k_ops
           - lmbench/ext2_create_delete_files_10k_ops
           - lmbench/ext2_copy_files_bw
+          - fio/ext2_seq_write_bw
+          - fio/ext2_seq_read_bw
+          - fio/ext2_iommu_seq_write_bw
+          - fio/ext2_iommu_seq_read_bw
           # Network-related benchmark
           - lmbench/tcp_loopback_bw_4k
           - lmbench/tcp_loopback_bw_64k

--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -101,7 +101,8 @@ jobs:
         command: |
           make install_osdk
           BENCHMARK_TYPE=$(jq -r '.benchmark_type' test/benchmark/${{ matrix.benchmark }}/config.json)
-          bash test/benchmark/bench_linux_and_aster.sh ${{ matrix.benchmark }} $BENCHMARK_TYPE
+          ASTER_SCHEME=$(jq -r '.aster_scheme' test/benchmark/${{ matrix.benchmark }}/config.json)
+          bash test/benchmark/bench_linux_and_aster.sh ${{ matrix.benchmark }} $BENCHMARK_TYPE $ASTER_SCHEME
 
     - name: Set up benchmark configuration
       run: |

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -84,7 +84,8 @@ To add a new benchmark to the Asternias Continuous Integration (CI) system, foll
         "result_index": "3",
         "description": "lat_syscall null",
         "title": "[Process] The cost of getpid",
-        "benchmark_type": "host_guest"
+        "benchmark_type": "host_guest",
+        "aster_scheme": "iommu"
       } 
      ```
      
@@ -97,6 +98,7 @@ To add a new benchmark to the Asternias Continuous Integration (CI) system, foll
     - `benchmark_type`: This parameter defines the type of benchmark to be executed. The default value is `guest_only`. The available options include `guest_only`, and `host_guest`.
       - `guest_only`: Use this option when the benchmark is intended solely for the guest environment.
       - `host_guest`: Choose this option when the benchmark involves both the host and guest environments. When using this option, you will need to define your own `host.sh` and `bench_runner.sh` scripts to handle the host-side operations and benchmark execution.
+    - `aster_scheme`: Specify the scheme used in Asterinas. The optional values, e.g., `iommu`, are aligned with the `SCHEME` parameter in `asterinas/Makefile`.
 
     For example, if the benchmark output is "Syscall average latency: 1000 ns", the `search_pattern` is "Syscall average latency:", and the `result_index` is "4". `awk` will extract "1000" as the benchmark result. See the `awk` [manual](https://www.gnu.org/software/gawk/manual/gawk.html#Getting-Started) for more information.
 

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -24,9 +24,10 @@ parse_results() {
     local result_template="$6"
     local result_file="$7"
 
+    # Extract numeric result from a specific field in the matching line
     local linux_result aster_result
-    linux_result=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${linux_output}" | tr -d '\r')
-    aster_result=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${aster_output}" | tr -d '\r')
+    linux_result=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${linux_output}" | tr -d '\r' | sed 's/[^0-9.]*//g')
+    aster_result=$(awk "/${search_pattern}/ {result=\$$result_index} END {print result}" "${aster_output}" | tr -d '\r' | sed 's/[^0-9.]*//g')
     
     if [ -z "${linux_result}" ] || [ -z "${aster_result}" ]; then
         echo "Error: Failed to parse the results from the benchmark output" >&2

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -45,8 +45,9 @@ parse_results() {
 run_benchmark() {
     local benchmark="$1"
     local benchmark_type="$2"
-    local search_pattern="$3"
-    local result_index="$4"
+    local aster_scheme="$3"
+    local search_pattern="$4"
+    local result_index="$5"
 
     local linux_output="${BENCHMARK_DIR}/linux_output.txt"
     local aster_output="${BENCHMARK_DIR}/aster_output.txt"
@@ -58,7 +59,11 @@ run_benchmark() {
     echo "Preparing libraries..."
     prepare_libs
 
-    local asterinas_cmd="make run BENCHMARK=${benchmark} ENABLE_KVM=1 RELEASE_LTO=1 2>&1"
+    local aster_scheme_cmd=""
+    if [ -n "$aster_scheme" ] && [ "$aster_scheme" != "null" ]; then
+        aster_scheme_cmd="SCHEME=${aster_scheme}"
+    fi
+    local asterinas_cmd="make run BENCHMARK=${benchmark} ${aster_scheme_cmd} ENABLE_KVM=1 RELEASE_LTO=1 2>&1"
     local linux_cmd="/usr/local/qemu/bin/qemu-system-x86_64 \
         --no-reboot \
         -smp 1 \
@@ -114,6 +119,7 @@ if [ -z "$2" ] || [ "$2" = "null" ]; then
 else
     BENCHMARK_TYPE="$2"
 fi
+ASTER_SCHEME="$3"
 
 echo "Running benchmark ${BENCHMARK}..."
 pwd
@@ -125,6 +131,6 @@ fi
 search_pattern=$(jq -r '.search_pattern' "$BENCHMARK_DIR/$BENCHMARK/config.json")
 result_index=$(jq -r '.result_index' "$BENCHMARK_DIR/$BENCHMARK/config.json")
 
-run_benchmark "$BENCHMARK" "$BENCHMARK_TYPE" "$search_pattern" "$result_index"
+run_benchmark "$BENCHMARK" "$BENCHMARK_TYPE" "$ASTER_SCHEME" "$search_pattern" "$result_index"
 
 echo "Benchmark completed successfully."

--- a/test/benchmark/fio/ext2_iommu_seq_read_bw/config.json
+++ b/test/benchmark/fio/ext2_iommu_seq_read_bw/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "bw=",
+    "result_index": "2",
+    "description": "fio -filename=/ext2/fio-test -size=1G -bs=1M -direct=1",
+    "title": "[Ext2] The bandwidth of sequential reads (IOMMU enabled on Asterinas)",
+    "aster_scheme": "iommu"
+}

--- a/test/benchmark/fio/ext2_iommu_seq_read_bw/result_template.json
+++ b/test/benchmark/fio/ext2_iommu_seq_read_bw/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average file read bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average file read bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/fio/ext2_iommu_seq_read_bw/run.sh
+++ b/test/benchmark/fio/ext2_iommu_seq_read_bw/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the FIO sequential read test (Ext2) ***"
+
+/benchmark/bin/fio -rw=read -filename=/ext2/fio-test -name=seqread \
+-size=1G -bs=1M \
+-ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
+-time_based=1 -runtime=60

--- a/test/benchmark/fio/ext2_iommu_seq_write_bw/config.json
+++ b/test/benchmark/fio/ext2_iommu_seq_write_bw/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "bw=",
+    "result_index": "2",
+    "description": "fio -filename=/ext2/fio-test -size=1G -bs=1M -direct=1",
+    "title": "[Ext2] The bandwidth of sequential writes (IOMMU enabled on Asterinas)",
+    "aster_scheme": "iommu"
+}

--- a/test/benchmark/fio/ext2_iommu_seq_write_bw/result_template.json
+++ b/test/benchmark/fio/ext2_iommu_seq_write_bw/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average file write bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average file write bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/fio/ext2_iommu_seq_write_bw/run.sh
+++ b/test/benchmark/fio/ext2_iommu_seq_write_bw/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the FIO sequential write test (Ext2) ***"
+
+/benchmark/bin/fio -rw=write -filename=/ext2/fio-test -name=seqwrite \
+-size=1G -bs=1M \
+-ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
+-time_based=1 -runtime=60

--- a/test/benchmark/fio/ext2_seq_read_bw/config.json
+++ b/test/benchmark/fio/ext2_seq_read_bw/config.json
@@ -1,0 +1,8 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "bw=",
+    "result_index": "2",
+    "description": "fio -filename=/ext2/fio-test -size=1G -bs=1M -direct=1",
+    "title": "[Ext2] The bandwidth of sequential reads"
+}

--- a/test/benchmark/fio/ext2_seq_read_bw/result_template.json
+++ b/test/benchmark/fio/ext2_seq_read_bw/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average file read bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average file read bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/fio/ext2_seq_read_bw/run.sh
+++ b/test/benchmark/fio/ext2_seq_read_bw/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the FIO sequential read test (Ext2) ***"
+
+/benchmark/bin/fio -rw=read -filename=/ext2/fio-test -name=seqread \
+-size=1G -bs=1M \
+-ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
+-time_based=1 -runtime=60

--- a/test/benchmark/fio/ext2_seq_write_bw/config.json
+++ b/test/benchmark/fio/ext2_seq_write_bw/config.json
@@ -1,0 +1,8 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "bw=",
+    "result_index": "2",
+    "description": "fio -filename=/ext2/fio-test -size=1G -bs=1M -direct=1",
+    "title": "[Ext2] The bandwidth of sequential writes"
+}

--- a/test/benchmark/fio/ext2_seq_write_bw/result_template.json
+++ b/test/benchmark/fio/ext2_seq_write_bw/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average file write bandwidth on Linux",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average file write bandwidth on Asterinas",
+        "unit": "MB/s",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/fio/ext2_seq_write_bw/run.sh
+++ b/test/benchmark/fio/ext2_seq_write_bw/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running the FIO sequential write test (Ext2) ***"
+
+/benchmark/bin/fio -rw=write -filename=/ext2/fio-test -name=seqwrite \
+-size=1G -bs=1M \
+-ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
+-time_based=1 -runtime=60

--- a/test/benchmark/fio/summary.json
+++ b/test/benchmark/fio/summary.json
@@ -1,0 +1,8 @@
+{
+    "benchmarks": [
+        "ext2_seq_write_bw",
+        "ext2_seq_read_bw",
+        "ext2_iommu_seq_write_bw",
+        "ext2_iommu_seq_read_bw"
+    ]
+}

--- a/test/benchmark/lmbench/ext2_copy_files_bw/config.json
+++ b/test/benchmark/lmbench/ext2_copy_files_bw/config.json
@@ -4,5 +4,5 @@
     "search_pattern": "lmdd result:",
     "result_index": "8",
     "description": "lmdd",
-    "title": "[EXT2] The bandwidth of copying data between files"
+    "title": "[Ext2] The bandwidth of copying data between files"
 }


### PR DESCRIPTION
This PR includes 3 commits:
1. Ensure only numeric values are extracted from the benchmark results. The motivation is that the result value and text are packed in FIO's output.
2. Support specifying `SCHEME` in the benchmark for enabling IOMMU.
3. Add four groups of FIO tests (seq-w-1g-1m, seq-r-1g-1m, seq-w-1g-1m-iommu, seq-r-1g-1m-iommu) to the benchmark CI.
