### PR TITLE
Make `{wait,pause}_until_or_timeout` APIs concise

### DIFF
--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -9,7 +9,7 @@ use ostd::{
 };
 use spin::Once;
 
-use crate::{prelude::*, process::Pid, time::wait::TimerBuilder};
+use crate::{prelude::*, process::Pid, time::wait::ManagedTimeout};
 
 type FutexBitSet = u32;
 type FutexBucketRef = Arc<Mutex<FutexBucket>>;
@@ -22,14 +22,14 @@ const FUTEX_BITSET_MATCH_ANY: FutexBitSet = 0xFFFF_FFFF;
 pub fn futex_wait(
     futex_addr: u64,
     futex_val: i32,
-    timer_builder: Option<TimerBuilder>,
+    timeout: Option<ManagedTimeout>,
     ctx: &Context,
     pid: Option<Pid>,
 ) -> Result<()> {
     futex_wait_bitset(
         futex_addr as _,
         futex_val,
-        timer_builder,
+        timeout,
         FUTEX_BITSET_MATCH_ANY,
         ctx,
         pid,
@@ -40,7 +40,7 @@ pub fn futex_wait(
 pub fn futex_wait_bitset(
     futex_addr: Vaddr,
     futex_val: i32,
-    timer_builder: Option<TimerBuilder>,
+    timeout: Option<ManagedTimeout>,
     bitset: FutexBitSet,
     ctx: &Context,
     pid: Option<Pid>,
@@ -73,7 +73,7 @@ pub fn futex_wait_bitset(
     // drop lock
     drop(futex_bucket);
 
-    waiter.pause_timer_timeout(timer_builder.as_ref())
+    waiter.pause_timeout(timeout)
 }
 
 /// Does futex wake

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -209,11 +209,7 @@ impl EventCounter {
             }
         };
 
-        if let Some(timeout) = timeout {
-            waiter.pause_until_or_timeout(cond, timeout)
-        } else {
-            waiter.pause_until(cond)
-        }
+        waiter.pause_until_or_timeout(cond, timeout)
     }
 
     pub fn write(&self) {

--- a/kernel/src/time/wait.rs
+++ b/kernel/src/time/wait.rs
@@ -9,9 +9,14 @@ use crate::prelude::*;
 
 /// A trait that provide the timeout related function for [`Waiter`] and [`WaitQueue`]`.
 pub trait WaitTimeout {
-    /// Waits until some condition returns `Some(_)`, or a given timeout is reached. If
-    /// the condition does not becomes `Some(_)` before the timeout is reached,
-    /// this function will return `ETIME` error.
+    /// Waits until some condition returns `Some(_)` or a given timeout is reached.
+    ///
+    /// # Errors
+    ///
+    /// If the condition does not become `Some(_)` before the timeout is reached, this function
+    /// will return an error with [`ETIME`].
+    ///
+    /// [`ETIME`]: crate::error::Errno::ETIME
     fn wait_until_or_timeout<'a, F, T, R>(&self, mut cond: F, timeout: T) -> Result<R>
     where
         F: FnMut() -> Option<R>,
@@ -26,10 +31,15 @@ pub trait WaitTimeout {
         self.wait_until_or_timeout_cancelled(cond, || Ok(()), timeout_inner)
     }
 
-    /// Waits until some condition returns `Some(_)`, or be cancelled due to
-    /// reaching the timeout or the inputted cancel condition. If the condition
-    /// does not becomes `Some(_)` before the timeout is reached or `cancel_cond`
-    /// returns `Err`, this function will return corresponding `Err`.
+    /// Waits until some condition returns `Some(_)` or is cancelled by the timeout or cancel
+    /// condition.
+    ///
+    /// # Errors
+    ///
+    /// If the condition does not become `Some(_)` before the cancellation, this function
+    /// will return:
+    ///  - an error with [`ETIME`] if the timeout is reached;
+    ///  - the error returned by the cancel condition if the cancel condition returns `Err(_)`.
     #[doc(hidden)]
     fn wait_until_or_timeout_cancelled<F, R, FCancel>(
         &self,

--- a/kernel/src/time/wait.rs
+++ b/kernel/src/time/wait.rs
@@ -12,23 +12,18 @@ pub trait WaitTimeout {
     /// Waits until some condition returns `Some(_)`, or a given timeout is reached. If
     /// the condition does not becomes `Some(_)` before the timeout is reached,
     /// this function will return `ETIME` error.
-    fn wait_until_or_timeout<F, R>(&self, cond: F, timeout: &Duration) -> Result<R>
+    fn wait_until_or_timeout<'a, F, T, R>(&self, mut cond: F, timeout: T) -> Result<R>
     where
         F: FnMut() -> Option<R>,
+        T: Into<TimeoutExt<'a>>,
     {
-        let timer_builder = TimerBuilder::new(timeout);
-        self.wait_until_or_timer_timeout(cond, &timer_builder)
-    }
+        let timeout = timeout.into();
+        let timeout_inner = match timeout.check_expired() {
+            Ok(inner) => inner,
+            Err(err) => return cond().ok_or(err),
+        };
 
-    /// Similar to [`WaitTimeout::wait_until_or_timeout`].
-    ///
-    /// The difference is that the timeout of this method is against the specified clock,
-    /// which is defined in `timer_builder`.
-    fn wait_until_or_timer_timeout<F, R>(&self, cond: F, timer_builder: &TimerBuilder) -> Result<R>
-    where
-        F: FnMut() -> Option<R>,
-    {
-        self.wait_until_or_timer_timeout_cancelled(cond, || Ok(()), timer_builder)
+        self.wait_until_or_timeout_cancelled(cond, || Ok(()), timeout_inner)
     }
 
     /// Waits until some condition returns `Some(_)`, or be cancelled due to
@@ -36,114 +31,152 @@ pub trait WaitTimeout {
     /// does not becomes `Some(_)` before the timeout is reached or `cancel_cond`
     /// returns `Err`, this function will return corresponding `Err`.
     #[doc(hidden)]
-    fn wait_until_or_timer_timeout_cancelled<F, R, FCancel>(
+    fn wait_until_or_timeout_cancelled<F, R, FCancel>(
         &self,
         cond: F,
         cancel_cond: FCancel,
-        timer_builder: &TimerBuilder,
+        timeout: Option<&ManagedTimeout>,
     ) -> Result<R>
     where
         F: FnMut() -> Option<R>,
         FCancel: Fn() -> Result<()>;
 }
 
-/// A helper structure to build timers from a specified timeout and timer manager.
-pub struct TimerBuilder<'a> {
-    timeout: Timeout,
-    timer_manager: &'a Arc<TimerManager>,
+/// A timeout with extended semantics.
+pub enum TimeoutExt<'a> {
+    /// The timeout will never fire.
+    Never,
+    /// The timeout will expire later according to [`ManagedTimeout`].
+    At(ManagedTimeout<'a>),
 }
 
-impl<'a> TimerBuilder<'a> {
-    /// Creates a new `TimerBuilder` against the default JIFFIES clock.
-    pub fn new(timeout: &Duration) -> Self {
-        let timeout = Timeout::After(*timeout);
-        let jiffies_timer_manager = JIFFIES_TIMER_MANAGER.get().unwrap();
-        Self::new_with_timer_manager(timeout, jiffies_timer_manager)
-    }
-
-    /// Creates a new `TimerBuilder` with given timer manager.
-    pub const fn new_with_timer_manager(
-        timeout: Timeout,
-        timer_manager: &'a Arc<TimerManager>,
-    ) -> Self {
-        Self {
-            timeout,
-            timer_manager,
+impl<'a> TimeoutExt<'a> {
+    /// Checks whether the timeout is expired.
+    ///
+    /// This method will return:
+    ///  - `Ok(Some(_))` if the timeout isn't expired but it may be expired later.
+    ///  - `Ok(None)` if the timeout will never be expired.
+    ///  - `Err(ETIME)` if the timeout is expired.
+    pub fn check_expired(&self) -> Result<Option<&ManagedTimeout<'a>>> {
+        match self {
+            TimeoutExt::At(inner) if inner.is_expired() => {
+                return_errno_with_message!(Errno::ETIME, "the time limit is reached")
+            }
+            TimeoutExt::At(inner) => Ok(Some(inner)),
+            TimeoutExt::Never => Ok(None),
         }
     }
+}
 
-    /// Returns the timeout
-    pub const fn timeout(&self) -> &Timeout {
-        &self.timeout
+impl From<&Duration> for TimeoutExt<'_> {
+    fn from(value: &Duration) -> Self {
+        Self::At(ManagedTimeout::new(*value))
+    }
+}
+
+impl From<Option<&Duration>> for TimeoutExt<'_> {
+    fn from(value: Option<&Duration>) -> Self {
+        match value {
+            Some(duration) => duration.into(),
+            None => Self::Never,
+        }
+    }
+}
+
+impl<'a> From<ManagedTimeout<'a>> for TimeoutExt<'a> {
+    fn from(value: ManagedTimeout<'a>) -> Self {
+        Self::At(value)
+    }
+}
+
+impl<'a> From<Option<ManagedTimeout<'a>>> for TimeoutExt<'a> {
+    fn from(value: Option<ManagedTimeout<'a>>) -> Self {
+        match value {
+            Some(timeout) => timeout.into(),
+            None => Self::Never,
+        }
+    }
+}
+
+/// A [`Timeout`] with the associated [`TimerManager`].
+pub struct ManagedTimeout<'a> {
+    timeout: Timeout,
+    manager: &'a Arc<TimerManager>,
+}
+
+impl<'a> ManagedTimeout<'a> {
+    /// Creates a new `ManagedTimeout` with the JIFFIES timer manager.
+    pub fn new(timeout: Duration) -> Self {
+        let timeout = Timeout::After(timeout);
+        let manager = JIFFIES_TIMER_MANAGER.get().unwrap();
+        Self::new_with_manager(timeout, manager)
     }
 
-    fn is_expired(&self) -> bool {
-        self.timer_manager.is_expired_timeout(&self.timeout)
+    /// Creates a new `ManagedTimeout` with the given timer manager.
+    pub const fn new_with_manager(timeout: Timeout, manager: &'a Arc<TimerManager>) -> Self {
+        Self { timeout, manager }
     }
 
-    /// Builds and sets a timer,
-    /// which will trigger `callback` when `self.timeout()` is reached.
-    pub fn fire<F>(&self, callback: F) -> Arc<Timer>
+    /// Returns weather the timeout is expired.
+    pub fn is_expired(&self) -> bool {
+        self.manager.is_expired_timeout(&self.timeout)
+    }
+
+    /// Creates a timer for the timeout.
+    pub fn create_timer<F>(&self, callback: F) -> Arc<Timer>
     where
         F: Fn() + Send + Sync + 'static,
     {
-        let timer = self.timer_manager.create_timer(callback);
+        let timer = self.manager.create_timer(callback);
         timer.set_timeout(self.timeout.clone());
         timer
     }
 }
 
 impl WaitTimeout for Waiter {
-    fn wait_until_or_timer_timeout_cancelled<F, R, FCancel>(
+    fn wait_until_or_timeout_cancelled<F, R, FCancel>(
         &self,
-        mut cond: F,
+        cond: F,
         cancel_cond: FCancel,
-        timer_builder: &TimerBuilder,
+        timeout: Option<&ManagedTimeout>,
     ) -> Result<R>
     where
         F: FnMut() -> Option<R>,
         FCancel: Fn() -> Result<()>,
     {
-        if timer_builder.is_expired() {
-            return cond()
-                .ok_or_else(|| Error::with_message(Errno::ETIME, "the time limit is reached"));
-        }
+        // No fast paths for `Waiter`. If the caller wants a fast path, it should do so _before_
+        // the waiter is created.
 
-        if let Some(res) = cond() {
-            return Ok(res);
-        }
-
-        let waker = self.waker();
-        let timer = timer_builder.fire(move || {
-            waker.wake_up();
+        let timer = timeout.map(|timeout| {
+            let waker = self.waker();
+            timeout.create_timer(move || {
+                waker.wake_up();
+            })
         });
 
-        let timeout_cond = {
+        let cancel_cond = {
             let timer = timer.clone();
-            move || {
-                if timer.remain() != Duration::ZERO {
-                    Ok(())
-                } else {
-                    Err(Error::with_message(
-                        Errno::ETIME,
-                        "the time limit is reached",
-                    ))
-                }
-            }
-        };
 
-        let cancel_cond = || {
-            timeout_cond()?;
-            cancel_cond()
+            move || {
+                if timer
+                    .as_ref()
+                    .is_some_and(|timer| timer.remain() == Duration::ZERO)
+                {
+                    return_errno_with_message!(Errno::ETIME, "the time limit is reached");
+                }
+
+                cancel_cond()
+            }
         };
 
         let res = self.wait_until_or_cancelled(cond, cancel_cond);
 
         // If `res` is not `ETIME` error, then the timeout may not have been expired.
         // We cancel it manually.
-        if !res
-            .as_ref()
-            .is_err_and(|e: &Error| e.error() == Errno::ETIME)
+        if let Some(timer) = timer
+            && !res
+                .as_ref()
+                .is_err_and(|e: &Error| e.error() == Errno::ETIME)
         {
             timer.cancel();
         }
@@ -153,21 +186,17 @@ impl WaitTimeout for Waiter {
 }
 
 impl WaitTimeout for WaitQueue {
-    fn wait_until_or_timer_timeout_cancelled<F, R, FCancel>(
+    fn wait_until_or_timeout_cancelled<F, R, FCancel>(
         &self,
         mut cond: F,
         cancel_cond: FCancel,
-        timer_builder: &TimerBuilder,
+        timeout: Option<&ManagedTimeout>,
     ) -> Result<R>
     where
         F: FnMut() -> Option<R>,
         FCancel: Fn() -> Result<()>,
     {
-        if timer_builder.is_expired() {
-            return cond()
-                .ok_or_else(|| Error::with_message(Errno::ETIME, "the time limit is reached"));
-        }
-
+        // Fast path:
         if let Some(res) = cond() {
             return Ok(res);
         }
@@ -177,6 +206,6 @@ impl WaitTimeout for WaitQueue {
             self.enqueue(waiter.waker());
             cond()
         };
-        waiter.wait_until_or_timer_timeout_cancelled(cond, cancel_cond, timer_builder)
+        waiter.wait_until_or_timeout_cancelled(cond, cancel_cond, timeout)
     }
 }


### PR DESCRIPTION
I think the `{wait,pause}_until_or_timeout` related APIs are not very well designed.

## Problem 1: The fragile APIs

https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L35
https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L54
https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L69
https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L88

Well, there are too many APIs and the API names are too long and therefore too ugly.

I would suggest something like this:
```rust
trait Pause {
    // An API without timeout.
    fn pause_until<F, R>(&self, cond: F) -> Result<R>
    where
        F: FnMut() -> Option<R>;

    // An API with timeout.
    fn pause_until_or_timeout<'a, F, T, R>(&self, mut cond: F, timeout: T) -> Result<R>
    where
        F: FnMut() -> Option<R>,
        T: Into<TimeoutExt<'a>>;
}

impl From<&Duration> for TimeoutExt<'_> {}
impl From<Option<&Duration>> for TimeoutExt<'_> {}
impl<'a> From<ManagedTimeout<'a>> for TimeoutExt<'a> {}
impl<'a> From<Option<ManagedTimeout<'a>>> for TimeoutExt<'a> {}
```

So,
 - If we don't want to specify the timeout, we can use the first API `Pause::pause_until`.
 - If we want to specify the timeout, no matter if we want to specify it conditionally (`Duration` or `Option<Duration>`), no matter if we want to specify the timer manager (`Duration` or `ManagedTimeout`), we can always use the second API `Pause::pause_until_or_timeout`.

## Problem 2: The fast paths

There are too many fast paths. These eventually lead to redundant checks, so I don't think they should be considered "fast" at all.

For example, `Waiter::pause_until_or_timer_timeout_opt` has a fast path:
https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L116-L118

But `WaitQueue::pause_until_or_timer_timeout_opt` has another fast path before calling `Waiter::pause_until_or_timer_timeout_opt`:
https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/process/signal/pause.rs#L195-L204

To solve this problem, I would like to remove all fast paths from the `Waiter` APIs. This is because the _caller_ should be responsible for adding fast paths to `Waiter`, as only the caller can do this _before_ actually creating the waiter:
```rust
        // No fast paths for `Waiter`. If the caller wants a fast path, it should do so _before_
        // the waiter is created.
```

## Problem 3: Bad API names

https://github.com/asterinas/asterinas/blob/50773de35fc154877abc1e143fa03dd6e7e0e525/kernel/src/time/wait.rs#L84-L86

I'm very confused when I see this. I think `fire` actually means that the timer expires and its callback needs to be called, it should _not_ be used to describe an action that literally just _creates_ a timer.

So I did some renaming of the related types and methods.