### PR TITLE
Special treat `VmSpace` clearing.

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -339,8 +339,7 @@ impl Vmar_ {
     }
 
     fn clear_vm_space(&self) {
-        let mut cursor = self.vm_space.cursor_mut(&(0..ROOT_VMAR_CAP_ADDR)).unwrap();
-        cursor.unmap(ROOT_VMAR_CAP_ADDR);
+        self.vm_space.clear().unwrap();
     }
 
     pub fn destroy(&self, range: Range<usize>) -> Result<()> {


### PR DESCRIPTION
Currently when clearing the `VmSpace` the kernel reuses the cursor's `unmap` API. And to make it fast the cursor recycles the page table and let the drop handler do the job. We are planning to make the page table more scalable and we want to avoid page table dropping. So here's a special treatment for `VmSpace` clearing, in order not to compromise `fork/exec` performance.

Another aspect is that with page table CoW #1509 , the child unmaps all the pages before exit. If the child founds a CoW PT when unmapping, it clones the page table then do the unmap. So the page table is unnecessarily copied. This PR prevents this situation.

Built upon #1548 , merging it will successfully close that.