### PR TITLE
Adjust and align the qemu arguments of `virtio-blk-pci`

### DIFF
--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -61,7 +61,9 @@ pub struct VirtioBlockConfig {
     /// The number of 512-byte sectors.
     capacity: u64,
     /// The maximum segment size.
-    size_max: u64,
+    size_max: u32,
+    /// The maximum number of segments.
+    seg_max: u32,
     /// The geometry of the device.
     geometry: VirtioBlockGeometry,
     /// The block size. If `logical_block_size` is not given in qemu cmdline,

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -68,7 +68,7 @@ run_benchmark() {
         -kernel ${LINUX_KERNEL} \
         -initrd ${BENCHMARK_DIR}/../build/initramfs.cpio.gz \
         -drive if=none,format=raw,id=x0,file=${BENCHMARK_DIR}/../build/ext2.img \
-        -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,config-wce=off,request-merging=off,write-cache=off,backend_defaults=off,discard=off,event_idx=off,indirect_desc=off,ioeventfd=off,queue_reset=off \
+        -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -append 'console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet' \
         -netdev user,id=net01,hostfwd=tcp::5201-:5201,hostfwd=tcp::6379-:6379,hostfwd=tcp::8080-:8080,hostfwd=tcp::31234-:31234 \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off \

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -68,8 +68,8 @@ fi
 QEMU_ARGS="\
     $COMMON_QEMU_ARGS \
     -machine q35,kernel-irqchip=split \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
     -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off$IOMMU_DEV_EXTRA \
     -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \


### PR DESCRIPTION
This PR includes two commits:

1. The first is a minor bugfix on interpreting virtio-blk's config struct, [qemu src ref](https://github.com/qemu/qemu/blob/11b8920ed2093848f79f93d106afe8a69a61a523/include/standard-headers/linux/virtio_blk.h#L64)
2. The second: Adjust and align the qemu arguments of `virtio-blk-pci` with Linux for fairness. The given arguments are referenced from [virtio spec v1.3](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html) and [qemu src ref](https://github.com/qemu/qemu/blob/master/hw/block/virtio-blk.c)