### PR TITLE
Print who and on which CPU the kernel panics

### DIFF
--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -25,6 +25,7 @@ pub mod work_queue;
 pub type Tid = u32;
 
 /// A thread is a wrapper on top of task.
+#[derive(Debug)]
 pub struct Thread {
     // immutable part
     /// Low-level info

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -26,6 +26,7 @@ use crate::{prelude::*, user::UserSpace};
 /// Each task is associated with per-task data and an optional user space.
 /// If having a user space, the task can switch to the user space to
 /// execute user code. Multiple tasks can share a single user space.
+#[derive(Debug)]
 pub struct Task {
     func: SyncUnsafeCell<Option<Box<dyn FnOnce() + Send + Sync>>>,
     data: Box<dyn Any + Send + Sync>,

--- a/ostd/src/task/scheduler/info.rs
+++ b/ostd/src/task/scheduler/info.rs
@@ -14,12 +14,14 @@ use crate::{cpu::CpuId, task::Task};
 /// define them, such as
 /// [existential types](https://github.com/rust-lang/rfcs/pull/2492) do not
 /// exist yet. So we decide to define them in OSTD.
+#[derive(Debug)]
 pub struct TaskScheduleInfo {
     /// The CPU that the task would like to be running on.
     pub cpu: AtomicCpuId,
 }
 
 /// An atomic CPUID container.
+#[derive(Debug)]
 pub struct AtomicCpuId(AtomicU32);
 
 impl AtomicCpuId {


### PR DESCRIPTION
On SMP when it panics it is good to see on which CPU it panics. Also this PR prints about which thread panics (Although the debug implementation is not quite useful for threads).

How it looks like:

```
~ # cat /proc/1/cmdline 
[    59.256] ERROR: Uncaught panic:
        Heap allocation error, layout = Layout { size: 2251799799004784, align: 8 (1 << 3) }
        at /root/asterinas/ostd/src/mm/heap_allocator/mod.rs:26
        on CPU 1 by thread Some(Thread { task: (Weak), data: Any { .. }, status: AtomicThreadStatus(1), priority: AtomicPriority(120), cpu_affinity: AtomicCpuSet { bits: [15] } })
Printing stack trace:
   1: fn 0xffffffff887fb910 - pc 0xffffffff887fb97a / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb4900;

   2: fn 0xffffffff8804abb0 - pc 0xffffffff8804bb39 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb4960;

   3: fn 0xffffffff8804aba0 - pc 0xffffffff8804abaa / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb50e0;

   4: fn 0xffffffff88049000 - pc 0xffffffff8804900a / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb50f0;

   5: fn 0xffffffff889d42e0 - pc 0xffffffff889d4324 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5100;

   6: fn 0xffffffff88828570 - pc 0xffffffff88828614 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5140;

   7: fn 0xffffffff88828620 - pc 0xffffffff8882863e / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb51e0;

   8: fn 0xffffffff889b0c70 - pc 0xffffffff889b0ca9 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5200;

   9: fn 0xffffffff889b0c5b - pc 0xffffffff889b0c6e / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5230;

  10: fn 0xffffffff889aaa8a - pc 0xffffffff889aaae1 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5250;

  11: fn 0xffffffff889a91a0 - pc 0xffffffff889a9245 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5290;

  12: fn 0xffffffff88210f80 - pc 0xffffffff88210f98 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5330;

  13: fn 0xffffffff8813a450 - pc 0xffffffff8813a473 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5350;

  14: fn 0xffffffff88133060 - pc 0xffffffff88133076 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5380;

  15: fn 0xffffffff88109a30 - pc 0xffffffff88109b6d / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb53a0;

  16: fn 0xffffffff88104970 - pc 0xffffffff881049eb / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5650;

  17: fn 0xffffffff88512870 - pc 0xffffffff885128b0 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb57c0;

  18: fn 0xffffffff88628f70 - pc 0xffffffff88629041 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5970;

  19: fn 0xffffffff88628a60 - pc 0xffffffff88628b7e / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5a00;

  20: fn 0xffffffff8862b290 - pc 0xffffffff8862b32b / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5ae0;

  21: fn 0xffffffff88603b20 - pc 0xffffffff88603b9a / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5b40;

  22: fn 0xffffffff884883c0 - pc 0xffffffff884897cc / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb5bb0;

  23: fn 0xffffffff8848fb00 - pc 0xffffffff8849cd64 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcb6930;

  24: fn 0xffffffff8848f620 - pc 0xffffffff8848f6ae / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcccfd0;

  25: fn 0xffffffff881b18d0 - pc 0xffffffff881b25ab / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccd170;

  26: fn 0xffffffff88565bd0 - pc 0xffffffff88565bd6 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdbf0;

  27: fn 0xffffffff881dadb0 - pc 0xffffffff881dadc7 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdc00;

  28: fn 0xffffffff881dc2b0 - pc 0xffffffff881dc2c8 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdc20;

  29: fn 0xffffffff881dad30 - pc 0xffffffff881dad5f / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdc40;

  30: fn 0xffffffff881b9800 - pc 0xffffffff881b9812 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdc90;

  31: fn 0xffffffff880a7720 - pc 0xffffffff880a7736 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdcc0;

  32: fn 0xffffffff881f6e60 - pc 0xffffffff881f6e6c / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdf00;

  33: fn 0xffffffff88562b20 - pc 0xffffffff88562b2e / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdf30;

  34: fn 0xffffffff888a36a0 - pc 0xffffffff888a36c8 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdf50;

  35: fn 0xffffffff88825660 - pc 0xffffffff88825727 / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffccdf90;


     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff8899ed46; rdi 0xffffffff8882c5c7; rbp                0x0; rsp 0xffffdfffffcce000;

[OSDK] The kernel seems panicked. Parsing stack trace for source lines:
(  1) /root/asterinas/ostd/src/panic.rs:107
(  2) /root/asterinas/kernel/src/thread/oops.rs:124
(  3) ??:?
(  4) 4bdh3ctc2ehskuj9t0av352n0:?
(  5) ??:?
(  6) 8mg42245vc5ptopxpzcaespmo:?
(  7) 8mg42245vc5ptopxpzcaespmo:?
(  8) alloc.42318c2d66971e9d-cgu.1:?
(  9) ??:?
( 10) ??:?
( 11) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:411
( 12) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:192
( 13) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:801
( 14) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:482
( 15) /root/asterinas/kernel/src/process/process_vm/init_stack/mod.rs:391
( 16) /root/asterinas/kernel/src/fs/procfs/pid/cmdline.rs:30
( 17) /root/asterinas/kernel/src/fs/procfs/template/file.rs:66
( 18) /root/asterinas/kernel/src/fs/inode_handle/mod.rs:95
( 19) /root/asterinas/kernel/src/fs/inode_handle/mod.rs:60
( 20) ??:?
( 21) /root/asterinas/kernel/src/fs/file_handle.rs:136
( 22) /root/asterinas/kernel/src/syscall/sendfile.rs:72
( 23) /root/asterinas/kernel/src/syscall/mod.rs:178
( 24) /root/asterinas/kernel/src/syscall/mod.rs:328
( 25) /root/asterinas/kernel/src/thread/task.rs:70
( 26) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
( 27) /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panicking.rs:56
( 28) 5trkgbttc14phs77l9etzg1hw:?
( 29) /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panicking.rs:42
( 30) /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/unwinding-0.2.3/src/panic.rs:87
( 31) /root/asterinas/kernel/src/thread/oops.rs:54
( 32) /root/asterinas/kernel/src/thread/task.rs:95
( 33) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
( 34) /root/.rustup/toolchains/nightly-2024-10-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2454
( 35) /root/asterinas/ostd/src/task/mod.rs:162
make: *** [Makefile:194: run] Error 1
```