### PR TITLE
Optimize virtio-net sending bandwidth

### DIFF
--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -273,7 +273,10 @@ impl VirtioTransport for VirtioMmioTransport {
         single_interrupt: bool,
     ) -> Result<(), VirtioTransportError> {
         if single_interrupt {
-            return Err(VirtioTransportError::NotEnoughResources);
+            warn!(
+                "{:?}: `single_interrupt` ignored: no support for virtio-mmio devices",
+                self.device_type()
+            );
         }
         self.multiplex.write().register_queue_callback(func);
         Ok(())

--- a/kernel/comps/virtio/src/transport/mod.rs
+++ b/kernel/comps/virtio/src/transport/mod.rs
@@ -78,8 +78,12 @@ pub trait VirtioTransport: Sync + Send + Debug {
 
     // ====================Device interrupt APIs=====================
 
-    /// Register queue interrupt callback. The transport will try to allocate single IRQ line if
-    /// `single_interrupt` is set.
+    /// Registers a callback for queue interrupts.
+    ///
+    /// If `single_interrupt` is enabled, the transport will initially
+    /// attempt to allocate a single IRQ line for the callback.
+    /// If no available IRQ lines are found for allocation, the
+    /// transport may assign the callback to a shared IRQ line.
     fn register_queue_callback(
         &mut self,
         index: u16,

--- a/kernel/comps/virtio/src/transport/pci/msix.rs
+++ b/kernel/comps/virtio/src/transport/pci/msix.rs
@@ -42,10 +42,10 @@ impl VirtioMsixManager {
         )
     }
 
-    /// Get shared interrupt IRQ used by virtqueue. If a virtqueue will not send interrupt frequently.
+    /// Get shared IRQ line used by virtqueue. If a virtqueue will not send interrupt frequently.
     /// Then this virtqueue should use shared interrupt IRQ.
     /// This function will return the MSI-X vector and corresponding IRQ.
-    pub fn shared_interrupt_irq(&mut self) -> (u16, &mut IrqLine) {
+    pub fn shared_irq_line(&mut self) -> (u16, &mut IrqLine) {
         (
             self.shared_interrupt_vector,
             self.msix

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -76,7 +76,7 @@ run_benchmark() {
         -drive if=none,format=raw,id=x0,file=${BENCHMARK_DIR}/../build/ext2.img \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -append 'console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet' \
-        -netdev user,id=net01,hostfwd=tcp::5201-:5201,hostfwd=tcp::6379-:6379,hostfwd=tcp::8080-:8080,hostfwd=tcp::31234-:31234 \
+        -netdev user,id=net01,hostfwd=tcp::5201-:5201,hostfwd=tcp::6379-:6379,hostfwd=tcp::8080-:8080,hostfwd=tcp::31234-:31234,hostfwd=tcp::31236-:31236 \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off \
         -nographic \
         2>&1"

--- a/test/benchmark/common/host_guest_bench_runner.sh
+++ b/test/benchmark/common/host_guest_bench_runner.sh
@@ -29,6 +29,9 @@ elif [[ "$BENCHMARK_PATH" =~ "redis" ]]; then
 elif [[ "$BENCHMARK_PATH" =~ "tcp_virtio_lat" ]]; then
     # Persist lmbench/tcp_lat port
     export LMBENCH_TCP_LAT_PORT=31234
+elif [[ "$BENCHMARK_PATH" =~ "tcp_virtio_bw" ]]; then
+    # Persist lmbench/bw_tcp port
+    export LMBENCH_TCP_BW_PORT=31236
 fi
 
 # Function to run the benchmark

--- a/test/benchmark/lmbench/summary.json
+++ b/test/benchmark/lmbench/summary.json
@@ -32,6 +32,7 @@
     "tcp_loopback_connect_lat",
     "tcp_loopback_select_lat",
     "tcp_loopback_http_bw",
+    "tcp_virtio_bw_64k",
     "udp_loopback_lat"
   ]
 }

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/config.json
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "0.065536 ",
+    "result_index": "2",
+    "description": "bw_tcp -l",
+    "title": "[TCP sockets] The bandwidth (virtio-net, 64KB message)",
+    "benchmark_type": "host_guest"
+}

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/host.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/host.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run lmbench tcp client
+echo "Running lmbench tcp client"
+/usr/local/benchmark/lmbench/bw_tcp -m 65536 -P 1 127.0.0.1
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/result_template.json
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Average TCP bandwidth on Linux",
+        "unit": "MB/sec",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Average TCP bandwidth on Asterinas",
+        "unit": "MB/sec",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running lmbench TCP latency over virtio-net..."
+
+# Start the server
+/benchmark/bin/lmbench/bw_tcp -s 10.0.2.15 -b 1
+
+# Sleep for a long time to ensure VM won't exit
+sleep 200

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -23,13 +23,14 @@ NGINX_RAND_PORT=${NGINX_PORT:-$(shuf -i 1024-65535 -n 1)}
 REDIS_RAND_PORT=${REDIS_PORT:-$(shuf -i 1024-65535 -n 1)}
 IPERF_RAND_PORT=${IPERF_PORT:-$(shuf -i 1024-65535 -n 1)}
 LMBENCH_TCP_LAT_RAND_PORT=${LMBENCH_TCP_LAT_PORT:-$(shuf -i 1024-65535 -n 1)}
+LMBENCH_TCP_BW_RAND_PORT=${LMBENCH_TCP_BW_PORT:-$(shuf -i 1024-65535 -n 1)}
 
 # Optional QEMU arguments. Opt in them manually if needed.
 # QEMU_OPT_ARG_DUMP_PACKETS="-object filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap"
 
 if [[ "$NETDEV" =~ "user" ]]; then
-    echo "[$1] Forwarded QEMU guest port: $SSH_RAND_PORT->22; $NGINX_RAND_PORT->8080 $REDIS_RAND_PORT->6379 $IPERF_RAND_PORT->5201 $LMBENCH_TCP_LAT_RAND_PORT->31234" 1>&2
-    NETDEV_ARGS="-netdev user,id=net01,hostfwd=tcp::$SSH_RAND_PORT-:22,hostfwd=tcp::$NGINX_RAND_PORT-:8080,hostfwd=tcp::$REDIS_RAND_PORT-:6379,hostfwd=tcp::$IPERF_RAND_PORT-:5201,hostfwd=tcp::$LMBENCH_TCP_LAT_RAND_PORT-:31234"
+    echo "[$1] Forwarded QEMU guest port: $SSH_RAND_PORT->22; $NGINX_RAND_PORT->8080 $REDIS_RAND_PORT->6379 $IPERF_RAND_PORT->5201 $LMBENCH_TCP_LAT_RAND_PORT->31234 $LMBENCH_TCP_BW_RAND_PORT->31236" 1>&2
+    NETDEV_ARGS="-netdev user,id=net01,hostfwd=tcp::$SSH_RAND_PORT-:22,hostfwd=tcp::$NGINX_RAND_PORT-:8080,hostfwd=tcp::$REDIS_RAND_PORT-:6379,hostfwd=tcp::$IPERF_RAND_PORT-:5201,hostfwd=tcp::$LMBENCH_TCP_LAT_RAND_PORT-:31234,hostfwd=tcp::$LMBENCH_TCP_BW_RAND_PORT-:31236"
 elif [[ "$NETDEV" =~ "tap" ]]; then 
     THIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     QEMU_IFUP_SCRIPT_PATH=$THIS_SCRIPT_DIR/net/qemu-ifup.sh


### PR DESCRIPTION
This pull request introduces the `lmbench/bw_tcp_virtio_64K` benchmark. Since iperf3 involves multiple subsystems, making it challenging to pinpoint the network bottleneck, I switched to this simpler benchmark for optimizing virtio-net performance.  Unlike iperf3, this `bw_tcp` benchmark simplifies the process by having only the guest server in Asterinas send messages to the host client, which then replies with ACKs. Consequently, this benchmark is designed solely to evaluate the sending bandwidth. The guest server makes only the write syscall, and there are no polling calls involved, meaning it is independent of our scheduler system.

Before optimization, the performance was approximately 80%-90% of Linux’s performance. Upon further analysis, I identified the bottleneck as the acknowledgment of interrupts, specifically the operation of writing to the EOI MSR register of the X2APIC, which accounts for nearly 70%-80% of the total time.

![bw-tcp-raw](https://github.com/user-attachments/assets/3235d23e-dd72-4da4-932a-d9e339b30f95)

This pull request also aims to optimize the number of interrupts. Initially, the send queue generates interrupts whenever a sent packet is processed, allowing us to free used send buffers within the IRQ handler. However, this is not essential; we can also free used send buffers when sending the next packet. The only exception occurs when send requests are received too quickly, causing the send queue to become full before any send buffers can be freed. In this case, we should indeed free send buffers in the IRQ handler. The virt queue includes a mechanism to temporarily disable and enable interrupts, which this pull request leverages to optimize performance.

After optimization, Asterinas performance is now comparable to that of Linux. Therefore, I have also added this benchmark to summary.json.