### PR TITLE
Bump smoltcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,9 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "defmt"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2d011b2fee29fb7d659b83c43fce9a2cb4df453e16d441a51448e448f3f98"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1425,7 +1425,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "git+https://github.com/asterinas/smoltcp?rev=37716bf#37716bff5ed5b16aba1b8a37e788ee5a6bf32cab"
+source = "git+https://github.com/lrh2000/smoltcp?tag=r_2024-11-08_3e68ef4#85dfcb0518f764aff1bd3bf62d14396d3c621c03"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 keyable-arc = { path = "../keyable-arc" }
 ostd = { path = "../../../ostd" }
-smoltcp = { git = "https://github.com/asterinas/smoltcp", rev = "37716bf", default-features = false, features = [
+smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f07e5b5", default-features = false, features = [
     "alloc",
     "log",
     "medium-ethernet",

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -8,7 +8,7 @@ use smoltcp::{
     phy::{DeviceCapabilities, TxToken},
     wire::{
         self, ArpOperation, ArpPacket, ArpRepr, EthernetAddress, EthernetFrame, EthernetProtocol,
-        EthernetRepr, IpAddress, Ipv4Address, Ipv4Cidr, Ipv4Packet,
+        EthernetRepr, IpAddress, Ipv4Address, Ipv4AddressExt, Ipv4Cidr, Ipv4Packet,
     },
 };
 
@@ -157,7 +157,7 @@ impl<D, E> EtherIface<D, E> {
                 ..
             } => {
                 // Ignore the ARP packet if the source addresses are not unicast.
-                if !source_hardware_addr.is_unicast() || !source_protocol_addr.is_unicast() {
+                if !source_hardware_addr.is_unicast() || !source_protocol_addr.x_is_unicast() {
                     return None;
                 }
 

--- a/kernel/src/net/socket/ip/addr.rs
+++ b/kernel/src/net/socket/ip/addr.rs
@@ -9,7 +9,7 @@ impl TryFrom<SocketAddr> for IpEndpoint {
 
     fn try_from(value: SocketAddr) -> Result<Self> {
         match value {
-            SocketAddr::IPv4(addr, port) => Ok(IpEndpoint::new(addr.into_address(), port)),
+            SocketAddr::IPv4(addr, port) => Ok(IpEndpoint::new(addr.into(), port)),
             _ => return_errno_with_message!(
                 Errno::EAFNOSUPPORT,
                 "the address is in an unsupported address family"

--- a/kernel/src/util/net/addr/ip.rs
+++ b/kernel/src/util/net/addr/ip.rs
@@ -51,13 +51,15 @@ struct CInetAddr {
 
 impl From<Ipv4Address> for CInetAddr {
     fn from(value: Ipv4Address) -> Self {
-        Self { s_addr: value.0 }
+        Self {
+            s_addr: value.octets(),
+        }
     }
 }
 
 impl From<CInetAddr> for Ipv4Address {
     fn from(value: CInetAddr) -> Self {
-        Self(value.s_addr)
+        Self::from(value.s_addr)
     }
 }
 

--- a/test/apps/network/tcp_err.c
+++ b/test/apps/network/tcp_err.c
@@ -460,3 +460,21 @@ FN_TEST(sendmsg_and_recvmsg)
 	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret <= sndbuf);
 }
 END_TEST()
+
+FN_TEST(self_connect)
+{
+	int sk;
+	char buf[5];
+
+	sk = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+
+	sk_addr.sin_port = htons(8888);
+	TEST_SUCC(bind(sk, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+	TEST_SUCC(connect(sk, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+
+	TEST_RES(write(sk, "hello", 5), _ret == 5);
+	TEST_RES(read(sk, buf, 5), _ret == 5 && memcmp(buf, "hello", 5) == 0);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()

--- a/test/apps/network/udp_err.c
+++ b/test/apps/network/udp_err.c
@@ -384,3 +384,21 @@ FN_TEST(sendmsg_and_recvmsg_bad_buffer)
 	TEST_RES(recvmsg(sk_bound, &msg, 0), _ret == strlen(good_buffer));
 }
 END_TEST()
+
+FN_TEST(self_connect)
+{
+	int sk;
+	char buf[5];
+
+	sk = TEST_SUCC(socket(PF_INET, SOCK_DGRAM, 0));
+
+	sk_addr.sin_port = htons(7777);
+	TEST_SUCC(bind(sk, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+	TEST_SUCC(connect(sk, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+
+	TEST_RES(write(sk, "hello", 5), _ret == 5);
+	TEST_RES(read(sk, buf, 5), _ret == 5 && memcmp(buf, "hello", 5) == 0);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()


### PR DESCRIPTION
PR in asterinas/smoltcp:
 - https://github.com/asterinas/smoltcp/pull/1

Important PRs in Smoltcp upstream:
 - https://github.com/smoltcp-rs/smoltcp/pull/1001
   - We can now support TCP/UDP self-connection. This enables the regression tests added in this PR.
 - https://github.com/smoltcp-rs/smoltcp/pull/1002
   - Combined with https://github.com/asterinas/asterinas/pull/1526, this allows large packets to be sent via loopback even when userspace is sending small messages.