### PR TITLE
Fix the title of ext2 and ramfs benchmark

### DIFF
--- a/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/config.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/config.json
@@ -4,5 +4,5 @@
     "search_pattern": "^0k",
     "result_index": "2",
     "description": "lat_fs -s 0k /ext2",
-    "title": "[Ext2] The cost of creating/deleting small files (0KB)"
+    "title": "[Ext2] The throughput of creating/deleting small files (0KB)"
 }

--- a/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/config.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/config.json
@@ -4,5 +4,5 @@
     "search_pattern": "10k",
     "result_index": "2",
     "description": "lat_fs -s 10K /ext2",
-    "title": "[Ext2] The cost of creating/deleting small files (10KB)"
+    "title": "[Ext2] The throughput of creating/deleting small files (10KB)"
 }

--- a/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/config.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/config.json
@@ -4,5 +4,5 @@
     "search_pattern": "^0k",
     "result_index": "2",
     "description": "lat_fs -s 0k",
-    "title": "[Ramfs] The cost of creating/deleting small files (0KB)"
+    "title": "[Ramfs] The throughput of creating/deleting small files (0KB)"
 }

--- a/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/config.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/config.json
@@ -4,5 +4,5 @@
     "search_pattern": "10k",
     "result_index": "2",
     "description": "lat_fs -s 10K",
-    "title": "[Ramfs] The cost of creating/deleting small files (10KB)"
+    "title": "[Ramfs] The throughput of creating/deleting small files (10KB)"
 }


### PR DESCRIPTION
This pull request updates the titles in several benchmark configuration files to use the term "throughput" instead of "cost" for clarity.

Changes in benchmark titles:

* [`test/benchmark/lmbench/ext2_create_delete_files_0k_ops/config.json`](diffhunk://#diff-19310d47811225a1a77c1fc06c574d3046a9280a2abb53ba35be63ef0ca80516L7-R7): Updated title to "[Ext2] The throughput of creating/deleting small files (0KB)"
* [`test/benchmark/lmbench/ext2_create_delete_files_10k_ops/config.json`](diffhunk://#diff-ca9925493204dc240bdfb0699f7a9b63067f75401779bd9e199ba527b71ae3e7L7-R7): Updated title to "[Ext2] The throughput of creating/deleting small files (10KB)"
* [`test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/config.json`](diffhunk://#diff-a1d1670b774160ba208aef51259b5dc7f6c2556b0e99e0218b9cd402ee9fff44L7-R7): Updated title to "[Ramfs] The throughput of creating/deleting small files (0KB)"
* [`test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/config.json`](diffhunk://#diff-7aebb9af84b826462add828531378cae31ea7c2c88c20f7ce9783fa90df7f73aL7-R7): Updated title to "[Ramfs] The throughput of creating/deleting small files (10KB)"