### PR TITLE
Introduce the log buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ name = "aster-block"
 version = "0.1.0"
 dependencies = [
  "align_ext",
+ "aster-logger",
  "aster-util",
  "bitflags 1.3.2",
  "component",
@@ -107,6 +108,7 @@ dependencies = [
 name = "aster-framebuffer"
 version = "0.1.0"
 dependencies = [
+ "aster-logger",
  "component",
  "font8x8",
  "log",
@@ -119,6 +121,7 @@ name = "aster-input"
 version = "0.1.0"
 dependencies = [
  "ascii",
+ "aster-logger",
  "aster-rights",
  "aster-util",
  "bitflags 1.3.2",
@@ -131,11 +134,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aster-logger"
+version = "0.1.0"
+dependencies = [
+ "aster-console",
+ "aster-softirq",
+ "cfg-if",
+ "component",
+ "log",
+ "ostd",
+ "owo-colors 3.5.0",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "aster-network"
 version = "0.1.0"
 dependencies = [
  "align_ext",
  "aster-bigtcp",
+ "aster-logger",
  "aster-rights",
  "aster-util",
  "bitflags 1.3.2",
@@ -158,6 +176,7 @@ dependencies = [
  "aster-console",
  "aster-framebuffer",
  "aster-input",
+ "aster-logger",
  "aster-network",
  "aster-rights",
  "aster-rights-proc",
@@ -233,6 +252,7 @@ dependencies = [
 name = "aster-time"
 version = "0.1.0"
 dependencies = [
+ "aster-logger",
  "aster-util",
  "chrono",
  "component",
@@ -261,6 +281,7 @@ dependencies = [
  "aster-block",
  "aster-console",
  "aster-input",
+ "aster-logger",
  "aster-network",
  "aster-rights",
  "aster-util",
@@ -1120,7 +1141,6 @@ dependencies = [
  "ostd-macros",
  "ostd-pod",
  "ostd-test",
- "owo-colors 3.5.0",
  "riscv",
  "sbi-rt",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "kernel/comps/input",
     "kernel/comps/network",
     "kernel/comps/softirq",
+    "kernel/comps/logger",
     "kernel/comps/time",
     "kernel/comps/virtio",
     "kernel/libs/cpio-decoder",

--- a/Components.toml
+++ b/Components.toml
@@ -6,6 +6,7 @@ input = { name = "aster-input" }
 block = { name = "aster-block" }
 console = { name = "aster-console" }
 softirq = { name = "aster-softirq" }
+logger = { name = "aster-logger" }
 time = { name = "aster-time" }
 framebuffer = { name = "aster-framebuffer" }
 network = { name = "aster-network" }

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ OSDK_CRATES := \
 	kernel/comps/input \
 	kernel/comps/network \
 	kernel/comps/softirq \
+	kernel/comps/logger \
 	kernel/comps/time \
 	kernel/comps/virtio \
 	kernel/libs/aster-util \

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -13,6 +13,7 @@ aster-network = { path = "comps/network" }
 aster-console = { path = "comps/console" }
 aster-framebuffer = { path = "comps/framebuffer" }
 aster-softirq = { path = "comps/softirq" }
+aster-logger = { path = "comps/logger" }
 aster-time = { path = "comps/time" }
 aster-virtio = { path = "comps/virtio" }
 aster-rights = { path = "libs/aster-rights" }

--- a/kernel/comps/block/Cargo.toml
+++ b/kernel/comps/block/Cargo.toml
@@ -11,6 +11,7 @@ spin = "0.9.4"
 ostd = { path = "../../../ostd" }
 align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-util = { path = "../../libs/aster-util" }
+aster-logger = { path = "../logger" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"

--- a/kernel/comps/framebuffer/Cargo.toml
+++ b/kernel/comps/framebuffer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
+aster-logger = { path = "../logger" }
 log = "0.4"
 spin = "0.9.4"
 font8x8 = { version = "0.2.5", default-features = false, features = [

--- a/kernel/comps/input/Cargo.toml
+++ b/kernel/comps/input/Cargo.toml
@@ -11,6 +11,7 @@ spin = "0.9.4"
 ostd = { path = "../../../ostd" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
+aster-logger = { path = "../logger" }
 component = { path = "../../libs/comp-sys/component" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 log = "0.4"

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aster-logger"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+component = { path = "../../libs/comp-sys/component" }
+aster-console = { path = "../console" }
+aster-softirq = { path = "../softirq" }
+log = "0.4"
+ostd = { path = "../../../ostd" }
+spin = "0.9.4"
+owo-colors = { version = "3", optional = true }
+cfg-if = "1.0"
+
+[features]
+default = ["log_color"]
+log_color = ["dep:owo-colors"]

--- a/kernel/comps/logger/src/console.rs
+++ b/kernel/comps/logger/src/console.rs
@@ -27,7 +27,7 @@ pub fn _print(args: Arguments) {
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {{
-        $crate::console::_print(format_args!($($arg)*));
+        $crate::_print(format_args!($($arg)*));
     }};
 }
 
@@ -38,6 +38,6 @@ macro_rules! println {
         $crate::print!("\n")
     };
     ($($arg:tt)*) => {{
-        $crate::console::_print(format_args_nl!($($arg)*));
+        $crate::_print(format_args_nl!($($arg)*));
     }};
 }

--- a/kernel/comps/logger/src/lib.rs
+++ b/kernel/comps/logger/src/lib.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The log service for Asterinas.
+#![no_std]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+
+use component::{init_component, ComponentInitError};
+
+mod console;
+mod log_service;
+
+pub use console::_print;
+
+#[init_component]
+fn init() -> Result<(), ComponentInitError> {
+    log_service::init();
+    Ok(())
+}

--- a/kernel/comps/logger/src/log_service.rs
+++ b/kernel/comps/logger/src/log_service.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_softirq::{softirq_id::LOG_SOFTIRQ_ID, SoftIrqLine};
+use ostd::logger::{consume_buffer_with, LogBuffer, LogRecord};
+
+fn log_handler() {
+    let f = |buffer: &mut LogBuffer| {
+        while let Some(record) = buffer.read_log() {
+            print_logs(&record);
+        }
+    };
+
+    consume_buffer_with(f);
+}
+
+#[cfg(feature = "log_color")]
+fn print_logs(record: &LogRecord<'_>) {
+    use owo_colors::Style;
+
+    let timestamp_style = Style::new().green();
+    let record_style = Style::new().default_color();
+    let level_style = match record.level() {
+        log::Level::Error => Style::new().red(),
+        log::Level::Warn => Style::new().bright_yellow(),
+        log::Level::Info => Style::new().blue(),
+        log::Level::Debug => Style::new().bright_green(),
+        log::Level::Trace => Style::new().bright_black(),
+    };
+
+    super::_print(format_args!(
+        "{} {:<5}: {}\n",
+        timestamp_style.style(format_args!("[{:>10.3}]", record.timestamp().as_secs_f64())),
+        level_style.style(record.level()),
+        record_style.style(record.context())
+    ));
+}
+
+#[cfg(not(feature = "log_color"))]
+fn print_logs(record: &Record) {
+    super::_print(format_args!(
+        "{} {:<5}: {}\n",
+        format_args!("[{:>10.3}]", record.timestamp().as_secs_f64()),
+        record.level(),
+        record.context()
+    ));
+}
+
+pub(super) fn init() {
+    SoftIrqLine::get(LOG_SOFTIRQ_ID).enable(log_handler);
+
+    ostd::timer::register_callback(|| {
+        SoftIrqLine::get(LOG_SOFTIRQ_ID).raise();
+    });
+}

--- a/kernel/comps/network/Cargo.toml
+++ b/kernel/comps/network/Cargo.toml
@@ -10,6 +10,7 @@ align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
+aster-logger = { path = "../logger" }
 bitflags = "1.3"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 component = { path = "../../libs/comp-sys/component" }

--- a/kernel/comps/softirq/src/softirq_id.rs
+++ b/kernel/comps/softirq/src/softirq_id.rs
@@ -11,3 +11,6 @@ pub const TIMER_SOFTIRQ_ID: u8 = 1;
 
 /// The corresponding softirq line is used to schedule general taskless jobs.
 pub const TASKLESS_SOFTIRQ_ID: u8 = 2;
+
+/// The corresponding softirq line is used for processing log content.
+pub const LOG_SOFTIRQ_ID: u8 = 3;

--- a/kernel/comps/time/Cargo.toml
+++ b/kernel/comps/time/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 ostd = { path = "../../../ostd" }
 aster-util = { path = "../../libs/aster-util" }
 component = { path = "../../libs/comp-sys/component" }
+aster-logger = { path = "../logger" }
 log = "0.4"
 spin = "0.9.4"
 

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { version = "1.4.0", default-features = false }
 align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-input = { path = "../input" }
 aster-block = { path = "../block" }
+aster-logger = { path = "../logger" }
 aster-network = { path = "../network" }
 aster-console = { path = "../console" }
 aster-util = { path = "../../libs/aster-util" }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,8 +30,6 @@
 #![feature(trait_upcasting)]
 #![register_tool(component_access_control)]
 
-use core::sync::atomic::Ordering;
-
 use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot,
@@ -83,7 +81,6 @@ pub fn main() {
     ostd::early_println!("[kernel] OSTD initialized. Preparing components.");
     component::init_all(component::parse_metadata!()).unwrap();
     init();
-    ostd::IN_BOOTSTRAP_CONTEXT.store(false, Ordering::Relaxed);
 
     // Spawn all AP idle threads.
     ostd::boot::smp::register_ap_entry(ap_init);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -55,7 +55,6 @@ extern crate controlled;
 extern crate getset;
 
 pub mod arch;
-pub mod console;
 pub mod context;
 pub mod cpu;
 pub mod device;

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -47,13 +47,13 @@ macro_rules! current_thread {
     };
 }
 
+pub(crate) use aster_logger::{print, println};
 pub(crate) use lazy_static::lazy_static;
 
 pub(crate) use crate::{
     context::{Context, CurrentUserSpace, ReadCString},
     current, current_thread,
     error::{Errno, Error},
-    print, println,
     process::signal::Pause,
     time::{wait::WaitTimeout, Clock},
 };

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -35,7 +35,6 @@ num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 ostd-macros = { path = "libs/ostd-macros", version = "0.9.2" }
 ostd-test = { path = "libs/ostd-test", version = "0.9.2" }
-owo-colors = { version = "3", optional = true }
 ostd-pod = { git = "https://github.com/asterinas/ostd-pod", rev = "c4644be", version = "0.1.1" }
 spin = "0.9.4"
 smallvec = "1.13.2"
@@ -63,7 +62,6 @@ sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 
 [features]
-default = ["cvm_guest", "log_color"]
-log_color = ["dep:owo-colors"]
+default = ["cvm_guest"]
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -47,7 +47,7 @@ pub mod timer;
 pub mod trap;
 pub mod user;
 
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use ostd_macros::{main, panic_handler};
 pub use ostd_pod::Pod;
@@ -101,10 +101,12 @@ unsafe fn init() {
     arch::irq::enable_local();
 
     invoke_ffi_init_funcs();
+
+    IN_BOOTSTRAP_CONTEXT.store(false, Ordering::Relaxed);
 }
 
 /// Indicates whether the kernel is in bootstrap context.
-pub static IN_BOOTSTRAP_CONTEXT: AtomicBool = AtomicBool::new(true);
+pub(crate) static IN_BOOTSTRAP_CONTEXT: AtomicBool = AtomicBool::new(true);
 
 /// Invoke the initialization functions defined in the FFI.
 /// The component system uses this function to call the initialization functions of

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -2,72 +2,279 @@
 
 //! Logging support.
 //!
-//! Currently the logger prints the logs to the console.
+//! Currently the logger writes the logs into the [`LogBuffer`].
 //!
 //! This module guarantees _atomicity_ under concurrency: messages are always
-//! printed in their entirety without being mixed with messages generated
+//! written in their entirety without being mixed with messages generated
 //! concurrently on other cores.
 //!
-//! IRQs are disabled while printing. So do not print long log messages.
+//! IRQs are disabled while writing. So do not log long log messages.
 
-use log::{LevelFilter, Metadata, Record};
+use core::{
+    cmp::min,
+    fmt::{self, Write},
+    str::FromStr,
+    time::Duration,
+};
+
+use log::{Level, LevelFilter, Metadata, Record};
 
 use crate::{
     boot::{kcmdline::ModuleArg, kernel_cmdline},
+    sync::SpinLock,
     timer::Jiffies,
 };
 
-const LOGGER: Logger = Logger {};
+/// The size of the text parts of `LogBuffer`. The maximum number of bytes that can be
+/// written to the text part of the `LogBuffer` equals to `BUFFER_SIZE` - 1
+/// (used to distinguish whether it is empty).
+const BUFFER_SIZE: usize = 64 * 1024;
+/// The maximum number of logs that the `LogBuffer` can accommodate.
+const MAX_LOG_NUM: usize = 4 * 1024;
 
-struct Logger {}
+/// `SplitStr` represents a string slice stored in a ring buffer.
+///
+/// Here `additional_text` is used to store the latter part of the string
+/// slice in case of a split at the buffer tail.
+pub struct SplitStr<'a> {
+    text: &'a str,
+    additional_text: &'a str,
+}
+
+impl fmt::Display for SplitStr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.text, self.additional_text)
+    }
+}
+
+impl<'a> SplitStr<'a> {
+    fn from_buffer_at(buffer: &'a [u8], begin_index: usize, end_index: usize) -> Self {
+        debug_assert!(begin_index < buffer.len());
+        debug_assert!(end_index < buffer.len());
+
+        if end_index >= begin_index {
+            Self {
+                text: unsafe { core::str::from_utf8_unchecked(&buffer[begin_index..end_index]) },
+                additional_text: "",
+            }
+        } else {
+            let text = unsafe { core::str::from_utf8_unchecked(&buffer[begin_index..]) };
+            let additional_text = unsafe { core::str::from_utf8_unchecked(&buffer[..end_index]) };
+            Self {
+                text,
+                additional_text,
+            }
+        }
+    }
+}
+
+/// A log record read from a [`LogBuffer`].
+pub struct LogRecord<'a> {
+    module: SplitStr<'a>,
+    context: SplitStr<'a>,
+    log_meta: &'a LogMeta,
+}
+
+impl LogRecord<'_> {
+    /// Returns the log level of this log record.
+    pub fn level(&self) -> &Level {
+        &self.log_meta.level
+    }
+
+    /// Returns the timestamp when the log was generated.
+    pub fn timestamp(&self) -> &Duration {
+        &self.log_meta.timestamp
+    }
+
+    /// Returns the module where the log was generated.
+    pub fn module(&self) -> &SplitStr<'_> {
+        &self.module
+    }
+
+    /// Returns the context of this log.
+    pub fn context(&self) -> &SplitStr<'_> {
+        &self.context
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LogMeta {
+    context_len: usize,
+    module_len: usize,
+    level: Level,
+    timestamp: Duration,
+}
+
+impl LogMeta {
+    const fn zero() -> Self {
+        Self {
+            context_len: 0,
+            module_len: 0,
+            level: Level::Error,
+            timestamp: Duration::ZERO,
+        }
+    }
+}
+
+/// A buffer for writing log content.
+///
+/// This buffer consists of two ring buffers, `text_buffer` and `meta_buffer`,
+/// which record variable-length information and fixed-length attributes of log operations
+/// respectively. When either buffer is full and a new log operation requires overwriting,
+/// the log being overwritten will be removed from both ring buffers.
+pub struct LogBuffer {
+    text_buf: [u8; BUFFER_SIZE],
+    text_read_index: usize,
+    text_write_index: usize,
+    meta_buf: [LogMeta; MAX_LOG_NUM],
+    meta_read_index: usize,
+    meta_write_index: usize,
+}
+
+impl LogBuffer {
+    const fn new() -> Self {
+        Self {
+            text_buf: [0; BUFFER_SIZE],
+            text_read_index: 0,
+            text_write_index: 0,
+            meta_buf: [LogMeta::zero(); MAX_LOG_NUM],
+            meta_read_index: 0,
+            meta_write_index: 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.text_read_index == self.text_write_index
+    }
+
+    fn advance_read_index_for_overwrite(&mut self) -> usize {
+        if self.is_empty() {
+            return 0;
+        }
+
+        let read_meta = &self.meta_buf[self.meta_read_index];
+        let offset = read_meta.context_len + read_meta.module_len;
+        self.text_read_index = (self.text_read_index + offset) % BUFFER_SIZE;
+        self.meta_read_index = (self.meta_read_index + 1) % MAX_LOG_NUM;
+
+        offset
+    }
+
+    fn write_log(&mut self, record: &Record, timestamp: Duration) -> fmt::Result {
+        if self.meta_read_index == self.meta_write_index {
+            self.advance_read_index_for_overwrite();
+        }
+
+        let module_len = if let Some(module_path) = record.module_path() {
+            self.write_str(module_path)?;
+            module_path.len()
+        } else {
+            0
+        };
+
+        let context_len = {
+            let old_index = self.text_write_index;
+            self.write_fmt(format_args!("{}", record.args()))?;
+            (self.text_write_index + BUFFER_SIZE - old_index) % BUFFER_SIZE
+        };
+
+        let new_meta = LogMeta {
+            level: record.level(),
+            timestamp,
+            context_len,
+            module_len,
+        };
+        self.meta_buf[self.meta_write_index] = new_meta;
+        self.meta_write_index = (self.meta_write_index + 1) % MAX_LOG_NUM;
+        Ok(())
+    }
+
+    /// Reads a recorded log from the buffer.
+    ///
+    /// If the buffer is empty, returns `None`.
+    pub fn read_log(&mut self) -> Option<LogRecord> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let log_meta = &self.meta_buf[self.meta_read_index];
+
+        let module_end_index = (self.text_read_index + log_meta.module_len) % BUFFER_SIZE;
+        let module =
+            SplitStr::from_buffer_at(&self.text_buf, self.text_read_index, module_end_index);
+
+        let context_end_index = (module_end_index + log_meta.context_len) % BUFFER_SIZE;
+        let context = SplitStr::from_buffer_at(&self.text_buf, module_end_index, context_end_index);
+
+        self.meta_read_index = (self.meta_read_index + 1) % MAX_LOG_NUM;
+        self.text_read_index = context_end_index;
+
+        Some(LogRecord {
+            module,
+            context,
+            log_meta,
+        })
+    }
+}
+
+impl fmt::Write for LogBuffer {
+    fn write_str(&mut self, input: &str) -> fmt::Result {
+        let mut remaining_space = if self.text_write_index >= self.text_read_index {
+            BUFFER_SIZE - self.text_write_index + self.text_read_index - 1
+        } else {
+            self.text_read_index - self.text_write_index - 1
+        };
+
+        while input.len() > remaining_space {
+            let offset = self.advance_read_index_for_overwrite();
+            if offset == 0 {
+                break;
+            }
+
+            remaining_space += offset;
+        }
+
+        let end_index = self.text_write_index + input.len();
+        let input_slice = input.as_bytes();
+        if end_index <= BUFFER_SIZE {
+            self.text_buf[self.text_write_index..end_index].copy_from_slice(input_slice);
+        } else {
+            let first_part_len = BUFFER_SIZE - self.text_write_index;
+            let second_part_len = min(BUFFER_SIZE, input.len()) - first_part_len;
+
+            self.text_buf[self.text_write_index..].copy_from_slice(&input_slice[..first_part_len]);
+            self.text_buf[..second_part_len].copy_from_slice(&input_slice[first_part_len..]);
+        }
+
+        self.text_write_index = end_index % BUFFER_SIZE;
+        Ok(())
+    }
+}
+
+struct Logger {
+    pub buffer: SpinLock<LogBuffer>,
+}
+
+impl Logger {
+    const fn new() -> Self {
+        Self {
+            buffer: SpinLock::new(LogBuffer::new()),
+        }
+    }
+}
+
+static LOGGER: Logger = Logger::new();
 
 impl log::Log for Logger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= log::max_level()
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
     }
 
     fn log(&self, record: &Record) {
-        if !self.enabled(record.metadata()) {
-            return;
-        }
+        let timestamp: Duration = Jiffies::elapsed().as_duration();
 
-        let timestamp = Jiffies::elapsed().as_duration().as_secs_f64();
-        let level = record.level();
-
-        // Use a global lock to prevent interleaving of log messages.
-        use crate::sync::SpinLock;
-        static RECORD_LOCK: SpinLock<()> = SpinLock::new(());
-        let _lock = RECORD_LOCK.disable_irq().lock();
-
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "log_color")]{
-                use owo_colors::Style;
-
-                let timestamp_style = Style::new().green();
-                let record_style = Style::new().default_color();
-                let level_style = match record.level() {
-                    log::Level::Error => Style::new().red(),
-                    log::Level::Warn => Style::new().bright_yellow(),
-                    log::Level::Info => Style::new().blue(),
-                    log::Level::Debug => Style::new().bright_green(),
-                    log::Level::Trace => Style::new().bright_black(),
-                };
-
-                crate::console::early_print(
-                    format_args!("{} {:<5}: {}\n",
-                    timestamp_style.style(format_args!("[{:>10.3}]", timestamp)),
-                    level_style.style(level),
-                    record_style.style(record.args()))
-                );
-            }else{
-                crate::console::early_print(
-                    format_args!("{} {:<5}: {}\n",
-                    format_args!("[{:>10.3}]", timestamp),
-                    level,
-                    record.args())
-                );
-            }
-        }
+        let mut buffer = self.buffer.disable_irq().lock();
+        buffer.write_log(record, timestamp).unwrap();
     }
 
     fn flush(&self) {}
@@ -76,7 +283,6 @@ impl log::Log for Logger {
 /// Initialize the logger. Users should avoid using the log macros before this function is called.
 pub(crate) fn init() {
     let level = get_log_level().unwrap_or(LevelFilter::Off);
-
     log::set_max_level(level);
     log::set_logger(&LOGGER).unwrap();
 }
@@ -84,22 +290,29 @@ pub(crate) fn init() {
 fn get_log_level() -> Option<LevelFilter> {
     let module_args = kernel_cmdline().get_module_args("ostd")?;
 
-    let arg = module_args.iter().find(|arg| match arg {
-        ModuleArg::Arg(_) => false,
-        ModuleArg::KeyVal(name, _) => name.as_bytes() == "log_level".as_bytes(),
-    })?;
-
-    let ModuleArg::KeyVal(_, value) = arg else {
-        unreachable!()
+    let value = {
+        let value = module_args.iter().find_map(|arg| match arg {
+            ModuleArg::KeyVal(name, value) if name.as_bytes() == "log_level".as_bytes() => {
+                Some(value)
+            }
+            _ => None,
+        })?;
+        value.as_c_str().to_str().ok()?
     };
-    let value = value.as_c_str().to_str().unwrap_or("off");
-    Some(match value {
-        "error" => LevelFilter::Error,
-        "warn" => LevelFilter::Warn,
-        "info" => LevelFilter::Info,
-        "debug" => LevelFilter::Debug,
-        "trace" => LevelFilter::Trace,
-        // Otherwise, OFF
-        _ => LevelFilter::Off,
-    })
+    LevelFilter::from_str(value).ok()
+}
+
+/// Consumes the contents of the log buffer.
+///
+/// Users can process the content in the log buffer using their preferred
+/// methods by passing in a closure.
+pub fn consume_buffer_with<F>(f: F)
+where
+    F: FnOnce(&mut LogBuffer),
+{
+    let mut buffer = LOGGER.buffer.disable_irq().lock();
+    if buffer.is_empty() {
+        return;
+    }
+    f(&mut buffer)
 }


### PR DESCRIPTION
Allow log operations to write to a buffer for consumption by upper-level services. 

I believe that the current implementation of `log` organization is still not an optimal choice, so I have kept it as a draft. However, this buffer should be useful in the future. My reasons are as follows: 

In this PR, the operation of outputting to the console is placed within the log service, with the timing of execution chosen during softirq. I do some testings and they has shown that it does not cause performance impact when logs are not enabled, and even when enabled, it does not degrade compared to the original version. 

However, it does indeed cause the actual output timing to be slightly slower than the log operation. This may mislead developers about the location where logs occur and may also cause stability issues. For example, in lmbench, there is a pre-bench calibration that continuously executes the same operation and measures the time for a single operation. If the time gaps between these operations are very small, it indicates higher execution and time measurement stability. However, using this PR with logs enabled would cause some logs from the previous operation to be delayed until the next operation, leading to unbalanced execution times for each operation. 

I believe the ideal scenario would be to write to the buffer and output to console simultaneously during log operations (consistent with Linux, where `printk` writes to the buffer and sends logs to the console simultaneously). However, this would require implementing the output operation within `ostd`, which would limit it to serial port output and undermine the goal of reducing the TCB. 

I am currently leaning towards using the inject logger, with the buffer writing operation also placed in the injected logger, adding suggested requirements for the injected logger in the public inject API. Although the issues mentioned in the #1538  still exist, they do not fundamentally affect safety (such as stack overflow due to recursion, which any injected code could cause, but safety only requires that the functions injected by upper-level code do not directly cross the guard page).