### PR TITLE
Revert "Make `pause_timeout` return `EINTR`"

### DIFF
--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -89,7 +89,8 @@ pub trait Pause: WaitTimeout {
     /// This method will return an error with [`ETIME`] if the timeout is reached.
     ///
     /// Unlike other methods in the trait, this method will _not_ return an error with [`EINTR`] if
-    /// a signal is received (FIXME).
+    /// a signal is received (FIXME: See <https://github.com/asterinas/asterinas/pull/1577> for why
+    /// we cannot fix this directly).
     ///
     /// [`ETIME`]: crate::error::Errno::ETIME
     /// [`EINTR`]: crate::error::Errno::EINTR


### PR DESCRIPTION
This reverts commit 6421fd0b36aafb3fcd9a8f12d5bc6e89f3f86546.

**TLDR:** The commit is a broken fix. Neither _with_ nor _without_ the fix does our `futex` syscall behavior match the Linux kernel behavior, so I'd like to revert it since it leads to failed CI.

Here is the Linux kernel implementation of the `futex` syscall:
https://github.com/torvalds/linux/blob/da4373fbcf006deda90e5e6a87c499e0ff747572/kernel/futex/waitwake.c#L671-L685
Note that `EINTR`/`ERESTARTSYS` is not returned (on line 685) when the futex is awakened (on line 673).

For the failed gvisor syscall call test, look at the following code:
https://github.com/google/gvisor/blob/7c2bcddc13c1729e345cfd9a75b910822e4ddcd1/test/syscalls/linux/futex.cc#L70-L81
If the `futex` syscall returns `EINTR`, the function will automatically retry another `futex` syscall. However, if the futex is woken up before, the next `futex` syscall will return `EAGAIN`:

The error codes alone are correct, as can be seen in the [man pages](https://man7.org/linux/man-pages/man2/futex.2.html):
> EAGAIN (FUTEX_WAIT, FUTEX_WAIT_BITSET, FUTEX_WAIT_REQUEUE_PI)
> The value pointed to by uaddr was not equal to the expected value val at the time of the call.
>
> EINTR
> A FUTEX_WAIT or FUTEX_WAIT_BITSET operation was interrupted by a signal (see signal(7)).

The `EAGAIN` makes the `PrivateAndSharedFutexTest` syscall test fail:
https://github.com/google/gvisor/blob/7c2bcddc13c1729e345cfd9a75b910822e4ddcd1/test/syscalls/linux/futex.cc#L497-L499

The [failed CI](https://github.com/asterinas/asterinas/actions/runs/11752512470/job/32744153947) shows:
```
 [ RUN      ] SharedPrivate/PrivateAndSharedFutexTest.WakeAfterCOWBreak_NoRandomSave/1
test/syscalls/linux/futex.cc:498: Failure
Value of: futex_wait(IsPrivate(), ptr, kInitialValue)
Expected: not -1 (success)
  Actual: -1 (of type int), with errno PosixError(errno=11 Resource temporarily unavailable)
```

cc @StevenJiang1110 since we originally discussed this in https://github.com/asterinas/asterinas/pull/1547#discussion_r1828773469, but unfortunately the conclusion reached there is wrong.