### PR TITLE
Lock free cursor creation

### DIFF
--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -349,9 +349,6 @@ impl<M: AllocatorSelector + 'static> Drop for KVirtArea<M> {
                 PageTableItem::NotMapped { .. } => {
                     break;
                 }
-                PageTableItem::PageTableNode { .. } => {
-                    panic!("Found page table node in `KVirtArea`");
-                }
             }
         }
 

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -94,9 +94,6 @@ pub enum PageTableItem {
         page: DynPage,
         prop: PageProperty,
     },
-    PageTableNode {
-        page: DynPage,
-    },
     #[allow(dead_code)]
     MappedUntracked {
         va: Vaddr,

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -176,7 +176,7 @@ where
     /// The caller must ensure that the physical address is valid and points to
     /// a forgotten page table node. A forgotten page table node can only be
     /// restored once. The level must match the level of the page table node.
-    unsafe fn from_raw_parts(paddr: Paddr, level: PagingLevel) -> Self {
+    pub(super) unsafe fn from_raw_parts(paddr: Paddr, level: PagingLevel) -> Self {
         Self {
             raw: paddr,
             level,

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -369,15 +369,6 @@ impl CursorMut<'_, '_> {
                     self.flusher
                         .issue_tlb_flush_with(TlbFlushOp::Address(va), page);
                 }
-                PageTableItem::PageTableNode { page } => {
-                    if !self.flusher.need_remote_flush() && tlb_prefer_flush_all {
-                        // Only on single-CPU cases we can drop the page immediately before flushing.
-                        drop(page);
-                        continue;
-                    }
-                    // If we unmap an entire page table node, we prefer directly flushing all TLBs.
-                    self.flusher.issue_tlb_flush_with(TlbFlushOp::All, page);
-                }
                 PageTableItem::NotMapped { .. } => {
                     break;
                 }
@@ -505,9 +496,6 @@ impl TryFrom<PageTableItem> for VmItem {
             }),
             PageTableItem::MappedUntracked { .. } => {
                 Err("found untracked memory mapped into `VmSpace`")
-            }
-            PageTableItem::PageTableNode { .. } => {
-                unreachable!()
             }
         }
     }


### PR DESCRIPTION
This PR addresses the scalability of the page table by allowing cursors to be created without holding the PML4 lock in fast paths. This PR almost resolves all contentions on the PT in handling page faults. After this the `Vmar` becomes the contention point and #1557 alleviates it. The performance gain of applying this PR is described in #1557 .

This PR is based on the observation that we do not recycle page table nodes if there may be concurrency. #1556 have already checked it.