### PR TITLE
Use pre-stored pointer to get arg and env

### DIFF
--- a/kernel/src/fs/procfs/pid/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/cmdline.rs
@@ -31,9 +31,6 @@ impl FileOps for CmdlineFileOps {
                 return Ok(Vec::new());
             };
             argv_cstrs
-                .into_iter()
-                .flat_map(|c_str| c_str.into_bytes_with_nul().into_iter())
-                .collect()
         };
         Ok(cmdline_output)
     }


### PR DESCRIPTION
Use pre-stored pointer to get `arg` and `env` instead of fetching from stack, which prevents the corrupt by the user as 
https://github.com/asterinas/asterinas/pull/1567#issuecomment-2466244369