### PR TITLE
Clean up thread-related APIs

### DIFF
--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -26,7 +26,6 @@ use crate::{
         fs_resolver::FsPath,
     },
     prelude::*,
-    thread::kernel_thread::KernelThreadExt,
 };
 
 fn start_block_device(device_name: &str) -> Result<Arc<dyn BlockDevice>> {
@@ -39,7 +38,7 @@ fn start_block_device(device_name: &str) -> Result<Arc<dyn BlockDevice>> {
                 virtio_block_device.handle_requests();
             }
         };
-        crate::Thread::spawn_kernel_thread(crate::ThreadOptions::new(task_fn));
+        crate::ThreadOptions::new(task_fn).spawn();
         Ok(device)
     } else {
         return_errno_with_message!(Errno::ENOENT, "Device does not exist")

--- a/kernel/src/fs/pipe.rs
+++ b/kernel/src/fs/pipe.rs
@@ -230,10 +230,7 @@ mod test {
     use super::*;
     use crate::{
         fs::utils::Channel,
-        thread::{
-            kernel_thread::{KernelThreadExt, ThreadOptions},
-            Thread,
-        },
+        thread::{kernel_thread::ThreadOptions, Thread},
     };
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -262,7 +259,7 @@ mod test {
         let signal_writer = Arc::new(AtomicBool::new(false));
         let signal_reader = signal_writer.clone();
 
-        let writer = Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        let writer = ThreadOptions::new(move || {
             let writer = writer_with_lock.lock().take().unwrap();
 
             if ordering == Ordering::ReadThenWrite {
@@ -274,9 +271,10 @@ mod test {
             }
 
             write(writer);
-        }));
+        })
+        .spawn();
 
-        let reader = Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        let reader = ThreadOptions::new(move || {
             let reader = reader_with_lock.lock().take().unwrap();
 
             if ordering == Ordering::WriteThenRead {
@@ -288,7 +286,8 @@ mod test {
             }
 
             read(reader);
-        }));
+        })
+        .spawn();
 
         writer.join();
         reader.join();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -43,10 +43,7 @@ use sched::priority::PriorityRange;
 use crate::{
     prelude::*,
     sched::priority::Priority,
-    thread::{
-        kernel_thread::{KernelThreadExt, ThreadOptions},
-        Thread,
-    },
+    thread::{kernel_thread::ThreadOptions, Thread},
 };
 
 extern crate alloc;
@@ -89,10 +86,9 @@ pub fn main() {
     ostd::boot::smp::register_ap_entry(ap_init);
 
     // Spawn the first kernel thread on BSP.
-    Thread::spawn_kernel_thread(
-        ThreadOptions::new(init_thread)
-            .priority(Priority::new(PriorityRange::new(PriorityRange::MAX))),
-    );
+    ThreadOptions::new(init_thread)
+        .priority(Priority::new(PriorityRange::new(PriorityRange::MAX)))
+        .spawn();
 }
 
 pub fn init() {
@@ -122,11 +118,10 @@ fn ap_init() {
     let cpu_id = preempt_guard.current_cpu();
     drop(preempt_guard);
 
-    Thread::spawn_kernel_thread(
-        ThreadOptions::new(ap_idle_thread)
-            .cpu_affinity(cpu_id.into())
-            .priority(Priority::new(PriorityRange::new(PriorityRange::MAX))),
-    );
+    ThreadOptions::new(ap_idle_thread)
+        .cpu_affinity(cpu_id.into())
+        .priority(Priority::new(PriorityRange::new(PriorityRange::MAX)))
+        .spawn();
 }
 
 fn init_thread() {
@@ -139,9 +134,10 @@ fn init_thread() {
     fs::lazy_init();
     ipc::init();
     // driver::pci::virtio::block::block_device_test();
-    let thread = Thread::spawn_kernel_thread(ThreadOptions::new(|| {
+    let thread = ThreadOptions::new(|| {
         println!("[kernel] Hello world from kernel!");
-    }));
+    })
+    .spawn();
     thread.join();
 
     print_banner();

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -9,10 +9,7 @@ use ostd::timer::Jiffies;
 use super::{ext::IfaceEx, Iface, IFACES};
 use crate::{
     sched::priority::{Priority, PriorityRange},
-    thread::{
-        kernel_thread::{KernelThreadExt, ThreadOptions},
-        Thread,
-    },
+    thread::kernel_thread::ThreadOptions,
     WaitTimeout,
 };
 
@@ -70,6 +67,7 @@ fn spawn_background_poll_thread(iface: Arc<Iface>) {
     };
 
     // FIXME: remove the use of real-time priority.
-    let options = ThreadOptions::new(task_fn).priority(Priority::new(PriorityRange::new(0)));
-    Thread::spawn_kernel_thread(options);
+    ThreadOptions::new(task_fn)
+        .priority(Priority::new(PriorityRange::new(0)))
+        .spawn();
 }

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -21,7 +21,7 @@ use crate::{
     get_current_userspace,
     prelude::*,
     process::posix_thread::allocate_posix_tid,
-    thread::{Thread, Tid},
+    thread::{ThreadExt, Tid},
 };
 
 bitflags! {
@@ -183,10 +183,10 @@ pub fn clone_child(
     clone_args.flags.check_unsupported_flags()?;
     if clone_args.flags.contains(CloneFlags::CLONE_THREAD) {
         let child_task = clone_child_task(ctx, parent_context, clone_args)?;
-        let child_thread = Thread::borrow_from_task(&child_task);
+        let child_thread = child_task.as_thread().unwrap();
         child_thread.run();
 
-        let child_tid = child_thread.tid();
+        let child_tid = child_thread.as_posix_thread().unwrap().tid();
         Ok(child_tid)
     } else {
         let child_process = clone_child_process(ctx, parent_context, clone_args)?;

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -9,7 +9,7 @@ use ostd::{
 };
 
 use super::{
-    posix_thread::{thread_table, PosixThread, PosixThreadBuilder, PosixThreadExt, ThreadName},
+    posix_thread::{thread_table, AsPosixThread, PosixThread, PosixThreadBuilder, ThreadName},
     process_table,
     process_vm::ProcessVm,
     signal::{constants::SIGCHLD, sig_disposition::SigDispositions, sig_num::SigNum},
@@ -21,7 +21,7 @@ use crate::{
     get_current_userspace,
     prelude::*,
     process::posix_thread::allocate_posix_tid,
-    thread::{ThreadExt, Tid},
+    thread::{AsThread, Tid},
 };
 
 bitflags! {

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -7,7 +7,7 @@ use crate::{
         posix_thread::{do_exit, PosixThreadExt},
         signal::signals::kernel::KernelSignal,
     },
-    thread::Thread,
+    thread::ThreadExt,
 };
 
 pub fn do_exit_group(term_status: TermStatus) {
@@ -21,7 +21,7 @@ pub fn do_exit_group(term_status: TermStatus) {
     // Exit all threads
     let tasks = current.tasks().lock().clone();
     for task in tasks {
-        let thread = Thread::borrow_from_task(&task);
+        let thread = task.as_thread().unwrap();
         let posix_thread = thread.as_posix_thread().unwrap();
         if let Err(e) = do_exit(thread, posix_thread, term_status) {
             debug!("Ignore error when call exit: {:?}", e);

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -4,10 +4,10 @@ use super::{process_table, Pid, Process, TermStatus};
 use crate::{
     prelude::*,
     process::{
-        posix_thread::{do_exit, PosixThreadExt},
+        posix_thread::{do_exit, AsPosixThread},
         signal::signals::kernel::KernelSignal,
     },
-    thread::ThreadExt,
+    thread::AsThread,
 };
 
 pub fn do_exit_group(term_status: TermStatus) {

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{
-    posix_thread::{thread_table, PosixThreadExt},
+    posix_thread::{thread_table, AsPosixThread},
     process_table,
     signal::{
         constants::SIGCONT,

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     events::Observer,
     prelude::*,
     process::signal::constants::SIGCONT,
-    thread::{Thread, ThreadExt, Tid},
+    thread::{AsThread, Thread, Tid},
     time::{clocks::ProfClock, Timer, TimerManager},
 };
 
@@ -37,7 +37,7 @@ pub mod thread_table;
 pub use builder::PosixThreadBuilder;
 pub use exit::do_exit;
 pub use name::{ThreadName, MAX_THREAD_NAME_LEN};
-pub use posix_thread_ext::{create_posix_task_from_executable, PosixThreadExt};
+pub use posix_thread_ext::{create_posix_task_from_executable, AsPosixThread};
 pub use robust_list::RobustListHead;
 
 pub struct PosixThread {

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     events::Observer,
     prelude::*,
     process::signal::constants::SIGCONT,
-    thread::{Thread, Tid},
+    thread::{Thread, ThreadExt, Tid},
     time::{clocks::ProfClock, Timer, TimerManager},
 };
 
@@ -277,7 +277,7 @@ impl PosixThread {
         let tasks = process.tasks().lock();
         tasks
             .iter()
-            .all(|task| Thread::borrow_from_task(task).is_exited())
+            .all(|task| task.as_thread().unwrap().is_exited())
     }
 
     /// Gets the read-only credentials of the thread.

--- a/kernel/src/process/posix_thread/posix_thread_ext.rs
+++ b/kernel/src/process/posix_thread/posix_thread_ext.rs
@@ -11,17 +11,12 @@ use crate::{
     fs::fs_resolver::{FsPath, FsResolver, AT_FDCWD},
     prelude::*,
     process::{process_vm::ProcessVm, program_loader::load_program_to_vm, Credentials, Process},
-    thread::{Thread, Tid},
+    thread::{Thread, ThreadExt, Tid},
 };
+
+/// An extension trait for some [`PosixThread`]-like types.
 pub trait PosixThreadExt {
-    /// Returns the thread id.
-    ///
-    /// # Panics
-    ///
-    /// If the thread is not posix thread, this method will panic.
-    fn tid(&self) -> Tid {
-        self.as_posix_thread().unwrap().tid()
-    }
+    /// Returns the associated [`PosixThread`].
     fn as_posix_thread(&self) -> Option<&PosixThread>;
 }
 
@@ -31,9 +26,9 @@ impl PosixThreadExt for Thread {
     }
 }
 
-impl PosixThreadExt for Arc<Task> {
+impl PosixThreadExt for Task {
     fn as_posix_thread(&self) -> Option<&PosixThread> {
-        Thread::borrow_from_task(self).as_posix_thread()
+        self.as_thread()?.as_posix_thread()
     }
 }
 

--- a/kernel/src/process/posix_thread/posix_thread_ext.rs
+++ b/kernel/src/process/posix_thread/posix_thread_ext.rs
@@ -11,22 +11,22 @@ use crate::{
     fs::fs_resolver::{FsPath, FsResolver, AT_FDCWD},
     prelude::*,
     process::{process_vm::ProcessVm, program_loader::load_program_to_vm, Credentials, Process},
-    thread::{Thread, ThreadExt, Tid},
+    thread::{AsThread, Thread, Tid},
 };
 
-/// An extension trait for some [`PosixThread`]-like types.
-pub trait PosixThreadExt {
+/// A trait to provide the `as_posix_thread` method for tasks and threads.
+pub trait AsPosixThread {
     /// Returns the associated [`PosixThread`].
     fn as_posix_thread(&self) -> Option<&PosixThread>;
 }
 
-impl PosixThreadExt for Thread {
+impl AsPosixThread for Thread {
     fn as_posix_thread(&self) -> Option<&PosixThread> {
         self.data().downcast_ref::<PosixThread>()
     }
 }
 
-impl PosixThreadExt for Task {
+impl AsPosixThread for Task {
     fn as_posix_thread(&self) -> Option<&PosixThread> {
         self.as_thread()?.as_posix_thread()
     }

--- a/kernel/src/process/posix_thread/thread_table.rs
+++ b/kernel/src/process/posix_thread/thread_table.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{Thread, Tid};
-use crate::{prelude::*, process::posix_thread::PosixThreadExt};
+use crate::{prelude::*, process::posix_thread::AsPosixThread};
 
 static THREAD_TABLE: SpinLock<BTreeMap<Tid, Arc<Thread>>> = SpinLock::new(BTreeMap::new());
 

--- a/kernel/src/process/posix_thread/thread_table.rs
+++ b/kernel/src/process/posix_thread/thread_table.rs
@@ -7,7 +7,7 @@ static THREAD_TABLE: SpinLock<BTreeMap<Tid, Arc<Thread>>> = SpinLock::new(BTreeM
 
 /// Adds a posix thread to global thread table
 pub fn add_thread(tid: Tid, thread: Arc<Thread>) {
-    debug_assert_eq!(tid, thread.tid());
+    debug_assert_eq!(tid, thread.as_posix_thread().unwrap().tid());
     THREAD_TABLE.lock().insert(tid, thread);
 }
 

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use self::timer_manager::PosixTimerManager;
 use super::{
-    posix_thread::{allocate_posix_tid, PosixThreadExt},
+    posix_thread::{allocate_posix_tid, AsPosixThread},
     process_table,
     process_vm::{Heap, InitStackReader, ProcessVm},
     rlimit::ResourceLimits,
@@ -21,7 +21,7 @@ use crate::{
     fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
     prelude::*,
     sched::priority::{AtomicNice, Nice},
-    thread::{Thread, ThreadExt},
+    thread::{AsThread, Thread},
     time::clocks::ProfClock,
     vm::vmar::Vmar,
 };

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -17,7 +17,7 @@ use ostd::{
 use super::Process;
 use crate::{
     process::{
-        posix_thread::PosixThreadExt,
+        posix_thread::AsPosixThread,
         signal::{constants::SIGALRM, signals::kernel::KernelSignal},
     },
     thread::{

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -7,8 +7,8 @@ use ostd::sync::{WaitQueue, Waiter};
 use super::sig_mask::SigMask;
 use crate::{
     prelude::*,
-    process::posix_thread::PosixThreadExt,
-    thread::ThreadExt,
+    process::posix_thread::AsPosixThread,
+    thread::AsThread,
     time::wait::{ManagedTimeout, TimeoutExt},
 };
 

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -8,7 +8,7 @@ use super::sig_mask::SigMask;
 use crate::{
     prelude::*,
     process::posix_thread::PosixThreadExt,
-    thread::Thread,
+    thread::ThreadExt,
     time::wait::{ManagedTimeout, TimeoutExt},
 };
 
@@ -109,7 +109,7 @@ impl Pause for Waiter {
         // No fast paths for `Waiter`. If the caller wants a fast path, it should do so _before_
         // the waiter is created.
 
-        let current_thread = self.task().data().downcast_ref::<Arc<Thread>>();
+        let current_thread = self.task().as_thread();
 
         let Some(posix_thread) = current_thread
             .as_ref()
@@ -143,7 +143,7 @@ impl Pause for Waiter {
             })
         });
 
-        let current_thread = self.task().data().downcast_ref::<Arc<Thread>>();
+        let current_thread = self.task().as_thread();
 
         if let Some(posix_thread) = current_thread
             .as_ref()

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -217,10 +217,7 @@ mod test {
     use ostd::prelude::*;
 
     use super::*;
-    use crate::thread::{
-        kernel_thread::{KernelThreadExt, ThreadOptions},
-        Thread,
-    };
+    use crate::thread::{kernel_thread::ThreadOptions, Thread};
 
     #[ktest]
     fn test_waiter_pause() {
@@ -230,12 +227,13 @@ mod test {
         let boolean = Arc::new(AtomicBool::new(false));
         let boolean_cloned = boolean.clone();
 
-        let thread = Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        let thread = ThreadOptions::new(move || {
             Thread::yield_now();
 
             boolean_cloned.store(true, Ordering::Relaxed);
             wait_queue_cloned.wake_all();
-        }));
+        })
+        .spawn();
 
         wait_queue
             .pause_until(|| boolean.load(Ordering::Relaxed).then_some(()))

--- a/kernel/src/process/sync/condvar.rs
+++ b/kernel/src/process/sync/condvar.rs
@@ -52,20 +52,21 @@ impl<Guard> LockErr<Guard> {
 /// ```rust
 /// use alloc::sync::Arc;
 /// use ostd::sync::Mutex;
-/// use crate::{process::sync::Condvar, thread::{kernel_thread::KernelThreadExt, Thread}};
+/// use crate::{process::sync::Condvar, thread::kernel_thread::Thread};
 ///
 /// // Initializing a shared condition between threads
 /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
 /// let pair2 = Arc::clone(&pair);
 ///
 /// // Spawning a new kernel thread to change a shared state and notify the Condvar
-/// Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+/// ThreadOptions::new(move || {
 ///     let (lock, cvar) = &*pair2;
 ///     Thread::yield_now();
 ///     let mut started = lock.lock();
 ///     *started = true; // Modifying the shared state
 ///     cvar.notify_one(); // Notifying one waiting thread
-/// }));
+/// })
+/// .spawn();
 ///
 /// // Main thread waiting for the shared state to be set to true
 /// {
@@ -267,23 +268,21 @@ mod test {
     use ostd::{prelude::*, sync::Mutex};
 
     use super::*;
-    use crate::thread::{
-        kernel_thread::{KernelThreadExt, ThreadOptions},
-        Thread,
-    };
+    use crate::thread::{kernel_thread::ThreadOptions, Thread};
 
     #[ktest]
     fn test_condvar_wait() {
         let pair = Arc::new((Mutex::new(false), Condvar::new()));
         let pair2 = Arc::clone(&pair);
 
-        Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        ThreadOptions::new(move || {
             Thread::yield_now();
             let (lock, cvar) = &*pair2;
             let mut started = lock.lock();
             *started = true;
             cvar.notify_one();
-        }));
+        })
+        .spawn();
 
         {
             let (lock, cvar) = &*pair;
@@ -300,13 +299,14 @@ mod test {
         let pair = Arc::new((Mutex::new(false), Condvar::new()));
         let pair2 = Arc::clone(&pair);
 
-        Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        ThreadOptions::new(move || {
             Thread::yield_now();
             let (lock, cvar) = &*pair2;
             let mut started = lock.lock();
             *started = true;
             cvar.notify_one();
-        }));
+        })
+        .spawn();
 
         {
             let (lock, cvar) = &*pair;
@@ -325,13 +325,14 @@ mod test {
         let pair = Arc::new((Mutex::new(true), Condvar::new()));
         let pair2 = Arc::clone(&pair);
 
-        Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        ThreadOptions::new(move || {
             Thread::yield_now();
             let (lock, cvar) = &*pair2;
             let mut started = lock.lock();
             *started = false;
             cvar.notify_one();
-        }));
+        })
+        .spawn();
 
         {
             let (lock, cvar) = &*pair;
@@ -347,13 +348,14 @@ mod test {
         let pair = Arc::new((Mutex::new(true), Condvar::new()));
         let pair2 = Arc::clone(&pair);
 
-        Thread::spawn_kernel_thread(ThreadOptions::new(move || {
+        ThreadOptions::new(move || {
             Thread::yield_now();
             let (lock, cvar) = &*pair2;
             let mut started = lock.lock();
             *started = false;
             cvar.notify_one();
-        }));
+        })
+        .spawn();
 
         {
             let (lock, cvar) = &*pair;

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -6,7 +6,7 @@ use super::{process_filter::ProcessFilter, signal::constants::SIGCHLD, ExitCode,
 use crate::{
     prelude::*,
     process::{
-        posix_thread::{thread_table, PosixThreadExt},
+        posix_thread::{thread_table, AsPosixThread},
         process_table,
         signal::with_signal_blocked,
     },

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -92,7 +92,7 @@ fn reap_zombie_child(process: &Process, pid: Pid) -> ExitCode {
     let child_process = process.children().lock().remove(&pid).unwrap();
     assert!(child_process.is_zombie());
     for task in &*child_process.tasks().lock() {
-        thread_table::remove_thread(task.tid());
+        thread_table::remove_thread(task.as_posix_thread().unwrap().tid());
     }
 
     // Lock order: session table -> group table -> process table -> group of process

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -8,7 +8,7 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{
-        posix_thread::{thread_table, PosixThreadExt},
+        posix_thread::{thread_table, AsPosixThread},
         process_table,
     },
     time::{

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -348,7 +348,7 @@ macro_rules! log_syscall_entry {
             let pid = $crate::current!().pid();
             let tid = {
                 use $crate::process::posix_thread::PosixThreadExt;
-                $crate::current_thread!().tid()
+                $crate::current_thread!().as_posix_thread().unwrap().tid()
             };
             log::info!(
                 "[pid={}][tid={}][id={}][{}]",

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -347,7 +347,7 @@ macro_rules! log_syscall_entry {
             let syscall_name_str = stringify!($syscall_name);
             let pid = $crate::current!().pid();
             let tid = {
-                use $crate::process::posix_thread::PosixThreadExt;
+                use $crate::process::posix_thread::AsPosixThread;
                 $crate::current_thread!().as_posix_thread().unwrap().tid()
             };
             log::info!(

--- a/kernel/src/syscall/set_get_priority.rs
+++ b/kernel/src/syscall/set_get_priority.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::Ordering;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{posix_thread::PosixThreadExt, process_table, Pgid, Pid, Process, Uid},
+    process::{posix_thread::AsPosixThread, process_table, Pgid, Pid, Process, Uid},
     sched::priority::{Nice, NiceRange},
 };
 

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     prelude::*,
     process::{
-        posix_thread::{thread_table, PosixThreadExt},
+        posix_thread::{thread_table, AsPosixThread},
         process_table,
         signal::{
             c_types::{sigevent_t, SigNotify},

--- a/kernel/src/thread/kernel_thread.rs
+++ b/kernel/src/thread/kernel_thread.rs
@@ -5,7 +5,7 @@ use ostd::{
     task::{Task, TaskOptions},
 };
 
-use super::{oops, status::ThreadStatus, Thread};
+use super::{oops, status::ThreadStatus, Thread, ThreadExt};
 use crate::{prelude::*, sched::priority::Priority};
 
 /// The inner data of a kernel thread.
@@ -77,7 +77,7 @@ impl ThreadOptions {
     /// Builds a new kernel thread and runs it immediately.
     pub fn spawn(self) -> Arc<Thread> {
         let task = self.build();
-        let thread = Thread::borrow_from_task(&task).clone();
+        let thread = task.as_thread().unwrap().clone();
         thread.run();
         thread
     }

--- a/kernel/src/thread/kernel_thread.rs
+++ b/kernel/src/thread/kernel_thread.rs
@@ -5,7 +5,7 @@ use ostd::{
     task::{Task, TaskOptions},
 };
 
-use super::{oops, status::ThreadStatus, Thread, ThreadExt};
+use super::{oops, status::ThreadStatus, AsThread, Thread};
 use crate::{prelude::*, sched::priority::Priority};
 
 /// The inner data of a kernel thread.

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -152,8 +152,20 @@ impl Thread {
         &self.cpu_affinity
     }
 
+    /// Yields the execution to another thread.
+    ///
+    /// This method will return once the current thread is scheduled again.
     pub fn yield_now() {
         Task::yield_now()
+    }
+
+    /// Joins the execution of the thread.
+    ///
+    /// This method will return after the thread exits.
+    pub fn join(&self) {
+        while !self.is_exited() {
+            Self::yield_now();
+        }
     }
 
     /// Returns the associated data.

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -162,13 +162,13 @@ impl Thread {
     }
 }
 
-/// An extension trait for [`Thread`]-like types.
-pub trait ThreadExt {
+/// A trait to provide the `as_thread` method for tasks.
+pub trait AsThread {
     /// Returns the associated [`Thread`].
     fn as_thread(&self) -> Option<&Arc<Thread>>;
 }
 
-impl ThreadExt for Task {
+impl AsThread for Task {
     fn as_thread(&self) -> Option<&Arc<Thread>> {
         self.data().downcast_ref::<Arc<Thread>>()
     }

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -65,24 +65,12 @@ impl Thread {
     /// This function returns `None` if the current task is not associated with
     /// a thread, or if called within the bootstrap context.
     pub fn current() -> Option<Arc<Self>> {
-        Task::current()?
-            .data()
-            .downcast_ref::<Arc<Thread>>()
-            .cloned()
+        Task::current()?.as_thread().cloned()
     }
 
     /// Returns the task associated with this thread.
     pub fn task(&self) -> Arc<Task> {
         self.task.upgrade().unwrap()
-    }
-
-    /// Gets the Thread from task's data.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the task is not a thread.
-    pub fn borrow_from_task(task: &Task) -> &Arc<Self> {
-        task.data().downcast_ref::<Arc<Thread>>().unwrap()
     }
 
     /// Runs this thread at once.
@@ -171,5 +159,17 @@ impl Thread {
     /// Returns the associated data.
     pub fn data(&self) -> &(dyn Send + Sync + Any) {
         &*self.data
+    }
+}
+
+/// An extension trait for [`Thread`]-like types.
+pub trait ThreadExt {
+    /// Returns the associated [`Thread`].
+    fn as_thread(&self) -> Option<&Arc<Thread>>;
+}
+
+impl ThreadExt for Task {
+    fn as_thread(&self) -> Option<&Arc<Thread>> {
+        self.data().downcast_ref::<Arc<Thread>>()
     }
 }

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -157,10 +157,7 @@ impl Thread {
     }
 
     /// Returns the associated data.
-    ///
-    /// The return type must be borrowed box, otherwise the `downcast_ref` will fail.
-    #[allow(clippy::borrowed_box)]
-    pub fn data(&self) -> &Box<dyn Send + Sync + Any> {
-        &self.data
+    pub fn data(&self) -> &(dyn Send + Sync + Any) {
+        &*self.data
     }
 }

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -10,7 +10,7 @@ use crate::{
     cpu::LinuxAbi,
     get_current_userspace,
     prelude::*,
-    process::{posix_thread::PosixThreadExt, signal::handle_pending_signal},
+    process::{posix_thread::AsPosixThread, signal::handle_pending_signal},
     syscall::handle_syscall,
     thread::exception::handle_exception,
     vm::vmar::is_userspace_vaddr,

--- a/kernel/src/thread/work_queue/worker.rs
+++ b/kernel/src/thread/work_queue/worker.rs
@@ -11,7 +11,7 @@ use super::worker_pool::WorkerPool;
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::{kernel_thread::ThreadOptions, ThreadExt},
+    thread::{kernel_thread::ThreadOptions, AsThread},
 };
 
 /// A worker thread. A `Worker` will attempt to retrieve unfinished

--- a/kernel/src/thread/work_queue/worker.rs
+++ b/kernel/src/thread/work_queue/worker.rs
@@ -11,7 +11,7 @@ use super::worker_pool::WorkerPool;
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::kernel_thread::{create_new_kernel_task, ThreadOptions},
+    thread::kernel_thread::ThreadOptions,
     Thread,
 };
 
@@ -56,11 +56,10 @@ impl Worker {
                 // FIXME: remove the use of real-time priority.
                 priority = Priority::new(PriorityRange::new(0));
             }
-            let bound_task = create_new_kernel_task(
-                ThreadOptions::new(task_fn)
-                    .cpu_affinity(cpu_affinity)
-                    .priority(priority),
-            );
+            let bound_task = ThreadOptions::new(task_fn)
+                .cpu_affinity(cpu_affinity)
+                .priority(priority)
+                .build();
             Self {
                 worker_pool,
                 bound_task,

--- a/kernel/src/thread/work_queue/worker.rs
+++ b/kernel/src/thread/work_queue/worker.rs
@@ -11,8 +11,7 @@ use super::worker_pool::WorkerPool;
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::kernel_thread::ThreadOptions,
-    Thread,
+    thread::{kernel_thread::ThreadOptions, ThreadExt},
 };
 
 /// A worker thread. A `Worker` will attempt to retrieve unfinished
@@ -72,7 +71,7 @@ impl Worker {
     }
 
     pub(super) fn run(&self) {
-        let thread = Thread::borrow_from_task(&self.bound_task);
+        let thread = self.bound_task.as_thread().unwrap();
         thread.run();
     }
 

--- a/kernel/src/thread/work_queue/worker_pool.rs
+++ b/kernel/src/thread/work_queue/worker_pool.rs
@@ -17,7 +17,7 @@ use super::{simple_scheduler::SimpleScheduler, worker::Worker, WorkItem, WorkPri
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::kernel_thread::{create_new_kernel_task, ThreadOptions},
+    thread::kernel_thread::ThreadOptions,
     Thread,
 };
 
@@ -246,11 +246,10 @@ impl Monitor {
                 WorkPriority::High => Priority::new(PriorityRange::new(0)),
                 WorkPriority::Normal => Priority::default(),
             };
-            let bound_task = create_new_kernel_task(
-                ThreadOptions::new(task_fn)
-                    .cpu_affinity(cpu_affinity)
-                    .priority(priority),
-            );
+            let bound_task = ThreadOptions::new(task_fn)
+                .cpu_affinity(cpu_affinity)
+                .priority(priority)
+                .build();
             Self {
                 worker_pool,
                 bound_task,

--- a/kernel/src/thread/work_queue/worker_pool.rs
+++ b/kernel/src/thread/work_queue/worker_pool.rs
@@ -17,7 +17,7 @@ use super::{simple_scheduler::SimpleScheduler, worker::Worker, WorkItem, WorkPri
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::{kernel_thread::ThreadOptions, ThreadExt},
+    thread::{kernel_thread::ThreadOptions, AsThread},
 };
 
 /// A pool of workers.

--- a/kernel/src/thread/work_queue/worker_pool.rs
+++ b/kernel/src/thread/work_queue/worker_pool.rs
@@ -17,8 +17,7 @@ use super::{simple_scheduler::SimpleScheduler, worker::Worker, WorkItem, WorkPri
 use crate::{
     prelude::*,
     sched::priority::{Priority, PriorityRange},
-    thread::kernel_thread::ThreadOptions,
-    Thread,
+    thread::{kernel_thread::ThreadOptions, ThreadExt},
 };
 
 /// A pool of workers.
@@ -83,7 +82,7 @@ impl LocalWorkerPool {
     fn add_worker(&self) {
         let worker = Worker::new(self.parent.clone(), self.cpu_id);
         self.workers.disable_irq().lock().push_back(worker.clone());
-        Thread::borrow_from_task(worker.bound_task()).run();
+        worker.bound_task().as_thread().unwrap().run();
     }
 
     fn remove_worker(&self) {
@@ -258,7 +257,7 @@ impl Monitor {
     }
 
     pub fn run(&self) {
-        Thread::borrow_from_task(&self.bound_task).run()
+        self.bound_task.as_thread().unwrap().run()
     }
 
     fn run_monitor_loop(self: &Arc<Self>) {

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -199,7 +199,7 @@ impl TaskOptions {
         Ok(new_task)
     }
 
-    /// Builds a new task and run it immediately.
+    /// Builds a new task and runs it immediately.
     pub fn spawn(self) -> Result<Arc<Task>> {
         let task = Arc::new(self.build()?);
         task.run();


### PR DESCRIPTION
The thread-related APIs are designed in a very odd way.

https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/thread/kernel_thread.rs#L18
 - It is not clear why `KernelThreadExt::spawn_kernel_thread` is not a method that belongs to `ThreadOptions`.

https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/thread/kernel_thread.rs#L25
 - It is not clear why `KernelThreadExt::join` is not a method that belongs to `Thread`.

https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/thread/kernel_thread.rs#L45
 - It is not clear why `create_new_kernel_task` is not a method that belongs to `ThreadOptions`.

https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/thread/kernel_thread.rs#L16
 - This is just a useless method since `KernelThread` is an empty type.

So `KernelThreadExt` is a completely useless trait that should be removed.

Instead, a `ThreadExt` trait can be added to provide an `as_thread` method for `Task`, thus avoiding some redundant code like this:
https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/process/signal/pause.rs#L112

Meanwhile, this PR also fixes some problems with the `PosixThreadExt` trait. For example, it should be implemented directly for `Task` instead of `Arc<Task>`:
https://github.com/asterinas/asterinas/blob/1f612e45f7fccb4caa3901ee26605f828ec64a06/kernel/src/process/posix_thread/posix_thread_ext.rs#L34
