### PR TITLE
Add `sockopt`'s `KEEPALIVE` to `SocketOptionSet`

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket/bound.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound.rs
@@ -288,10 +288,18 @@ impl<E> BoundTcpSocket<E> {
         self.0.update_next_poll_at_ms(PollAt::Now);
     }
 
+    /// Calls `f` with a mutable reference to the associated [`RawTcpSocket`].
+    pub fn raw_with_mut<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut RawTcpSocket) -> R,
+    {
+        let mut socket = self.0.socket.lock();
+        let r = f(&mut socket);
+        self.0.update_next_poll_at_ms(PollAt::Now);
+        r
+    }
+
     /// Calls `f` with an immutable reference to the associated [`RawTcpSocket`].
-    //
-    // NOTE: If a mutable reference is required, add a method above that correctly updates the next
-    // polling time.
     pub fn raw_with<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&RawTcpSocket) -> R,

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -9,7 +9,8 @@ use aster_bigtcp::socket::{
 use crate::{
     match_sock_option_mut, match_sock_option_ref,
     net::socket::options::{
-        Error as SocketError, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
+        Error as SocketError, KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf,
+        SocketOption,
     },
     prelude::*,
 };
@@ -24,6 +25,7 @@ pub struct SocketOptionSet {
     send_buf: u32,
     recv_buf: u32,
     linger: LingerOption,
+    keep_alive: bool,
 }
 
 impl SocketOptionSet {
@@ -36,6 +38,7 @@ impl SocketOptionSet {
             send_buf: TCP_SEND_BUF_LEN as u32,
             recv_buf: TCP_RECV_BUF_LEN as u32,
             linger: LingerOption::default(),
+            keep_alive: false,
         }
     }
 
@@ -48,6 +51,7 @@ impl SocketOptionSet {
             send_buf: UDP_SEND_PAYLOAD_LEN as u32,
             recv_buf: UDP_RECV_PAYLOAD_LEN as u32,
             linger: LingerOption::default(),
+            keep_alive: false,
         }
     }
 
@@ -122,6 +126,10 @@ impl SocketOptionSet {
             socket_linger: Linger => {
                 let linger = socket_linger.get().unwrap();
                 self.set_linger(*linger);
+            },
+            socket_keep_alive: KeepAlive => {
+                let keep_alive = socket_keep_alive.get().unwrap();
+                self.set_keep_alive(*keep_alive);
             },
             _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option to be set is unknown")
         });


### PR DESCRIPTION
I am running memcached and `setsockopt` fails reporting that `KeepAlive` is not implemented. Is it the correct way to implement this? Seems that we don't have methods to handle it and where should I put the warnings to?