### PR TITLE
Add Memcached to benchmarks

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -61,6 +61,8 @@ $(INITRAMFS)/lib/x86_64-linux-gnu: | $(VDSO_LIB)
 	@cp -L /lib/x86_64-linux-gnu/libresolv.so.2 $@
 	@# required for LevelDB-db_bench_sqlite3
 	@cp -L /lib/x86_64-linux-gnu/libsqlite3.so $@
+	@# required for memcached
+	@cp -L /lib/x86_64-linux-gnu/libevent-2.1.so.7 $@
 	@# required for VDSO
 	@cp -L $(VDSO_LIB) $@
 
@@ -101,6 +103,7 @@ $(INITRAMFS)/usr/local:
 	@mkdir -p $@
 	@cp -r /usr/local/nginx $@
 	@cp -r /usr/local/redis $@
+	@cp -r /usr/local/memcached $@
 
 .PHONY: $(INITRAMFS)/test
 $(INITRAMFS)/test:

--- a/test/benchmark/memcached/10set_90get_8t_128socks/config.json
+++ b/test/benchmark/memcached/10set_90get_8t_128socks/config.json
@@ -1,0 +1,9 @@
+{
+    "alert_threshold": "125%",
+    "alert_tool": "customBiggerIsBetter",
+    "search_pattern": "throughput summary:",
+    "result_index": "15",
+    "description": "memaslap --threads=8 --concurrency=128",
+    "title": "Memaslap 10% SET and 90% GET throughput with 8 client threads and 128 concurrency",
+    "benchmark_type": "host_guest"
+}

--- a/test/benchmark/memcached/10set_90get_8t_128socks/host.sh
+++ b/test/benchmark/memcached/10set_90get_8t_128socks/host.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    pgrep qemu | xargs kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run memaslap bench
+memaslap -s 127.0.0.1:11211 -B -S 1s --threads=8 --concurrency=128
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/memcached/10set_90get_8t_128socks/result_template.json
+++ b/test/benchmark/memcached/10set_90get_8t_128socks/result_template.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Memaslap 10% SET and 90% GET throughput with 8 client threads and 128 concurrency",
+        "unit": "operations per second",
+        "value": 0,
+        "extra": "linux_result"
+    },
+    {
+        "name": "Memaslap 10% SET and 90% GET throughput with 8 client threads and 128 concurrency",
+        "unit": "operations per second",
+        "value": 0,
+        "extra": "aster_result"
+    }
+]

--- a/test/benchmark/memcached/10set_90get_8t_128socks/run.sh
+++ b/test/benchmark/memcached/10set_90get_8t_128socks/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running Memcached server"
+/usr/local/memcached/bin/memcached --user=root --listen=10.0.2.15

--- a/test/benchmark/memcached/summary.json
+++ b/test/benchmark/memcached/summary.json
@@ -1,0 +1,5 @@
+{
+    "benchmarks": [
+        "10set_90get_8t_128socks"
+    ]
+}

--- a/tools/docker/Dockerfile.jinja
+++ b/tools/docker/Dockerfile.jinja
@@ -54,6 +54,9 @@ RUN git clone https://github.com/asterinas/lmbench.git
 RUN wget https://www.iozone.org/src/current/iozone3_506.tar
 RUN tar -x -f iozone3_506.tar
 RUN git clone -b fio-3.37 https://github.com/axboe/fio.git
+RUN wget https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz \
+    && tar -zxvf libmemcached-1.0.18.tar.gz \ 
+    && rm libmemcached-1.0.18.tar.gz
 
 # Build sysbench
 WORKDIR /root/sysbench-1.0.20
@@ -98,6 +101,14 @@ RUN ./configure --disable-shm --prefix=/usr/local/benchmark/fio \
     && make -j \ 
     && make install
 
+# Build memaslap for memcached
+WORKDIR /root/libmemcached-1.0.18
+RUN LDFLAGS='-lpthread' CPPFLAGS='-fcommon -fpermissive' CFLAGS='-fpermissive -fcommon' \
+    ./configure --enable-memaslap --prefix=/usr/local/benchmark/libmemcached \ 
+    && CPPFLAGS='-fcommon' make -j \ 
+    && make install \
+    && ldconfig
+
 # Clear cached files
 WORKDIR /root
 RUN rm -rf sysbench-1.0.20 \ 
@@ -107,7 +118,8 @@ RUN rm -rf sysbench-1.0.20 \
     byte-unixbench \
     iozone3_506.tar \
     iozone3_506 \
-    fio
+    fio \
+    libmemcached-1.0.18
 
 #= Install applications =======================================================
 
@@ -166,6 +178,18 @@ RUN wget https://download.redis.io/releases/redis-7.0.15.tar.gz \
 
 RUN rm -rf redis-7.0.15.tar.gz \ 
     redis-7.0.15 
+
+# Install Memcached v1.6.32
+WORKDIR /root
+RUN wget https://www.memcached.org/files/memcached-1.6.32.tar.gz \
+    && tar -xzvf memcached-1.6.32.tar.gz \
+    && cd memcached-1.6.32 \
+    && ./configure --prefix=/usr/local/memcached \
+    && make -j \
+    && make install
+
+RUN rm -rf memcached-1.6.32.tar.gz \
+    memcached-1.6.32
 
 # Install Nginx only with http enabled
 WORKDIR /root
@@ -376,6 +400,7 @@ RUN apt update && apt-get install -y --no-install-recommends \
     {% endif %}
     iptables \ 
     iproute2 \ 
+    libevent-dev        `# running dependency for Memcached` \ 
     libpixman-1-dev     `# running dependency for QEMU` \ 
     mtools              `# used by grub-mkrescue` \ 
     net-tools \ 


### PR DESCRIPTION
It may be another KV benchmark besides Redis. And it may offer insights about multiprocessing performance. Known issues to run it include #1557 and #1582 . It still doesn't work after them currently because of client connection failure.