### PR TITLE
Add utilities for thread local

### DIFF
--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -180,7 +180,7 @@ impl Waiter {
     pub fn new_pair() -> (Self, Arc<Waker>) {
         let waker = Arc::new(Waker {
             has_woken: AtomicBool::new(false),
-            task: Task::current().unwrap(),
+            task: Task::current().unwrap().cloned(),
         });
         let waiter = Self {
             waker: waker.clone(),

--- a/ostd/src/task/utils.rs
+++ b/ostd/src/task/utils.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::fmt;
+
+/// Always [`Sync`], but unsafe to reference the data.
+pub(super) struct ForceSync<T>(T);
+
+impl<T> fmt::Debug for ForceSync<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ForceSync").finish_non_exhaustive()
+    }
+}
+
+// SAFETY: The caller of the `ForceSync::get` method must ensure that the underlying data is not
+// concurrently accessed if the underlying type is not `Sync`.
+unsafe impl<T> Sync for ForceSync<T> {}
+
+impl<T> ForceSync<T> {
+    /// Creates an instance with `data` as the inner data.
+    pub(super) fn new(data: T) -> Self {
+        Self(data)
+    }
+
+    /// Returns a reference to the inner data.
+    ///
+    /// # Safety
+    ///
+    /// If the data type is not [`Sync`], the caller must ensure that the data is not accessed
+    /// concurrently.
+    pub(super) unsafe fn get(&self) -> &T {
+        &self.0
+    }
+}

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -4,7 +4,7 @@
 
 //! User space.
 
-use crate::{cpu::UserContext, mm::VmSpace, prelude::*, task::Task, trap::TrapFrame};
+use crate::{cpu::UserContext, mm::VmSpace, prelude::*, trap::TrapFrame};
 
 /// A user space.
 ///
@@ -112,7 +112,6 @@ pub trait UserContextApi {
 /// }
 /// ```
 pub struct UserMode<'a> {
-    current: Arc<Task>,
     user_space: &'a Arc<UserSpace>,
     context: UserContext,
 }
@@ -126,7 +125,6 @@ impl<'a> UserMode<'a> {
     /// Creates a new `UserMode`.
     pub fn new(user_space: &'a Arc<UserSpace>) -> Self {
         Self {
-            current: Task::current().unwrap(),
             user_space,
             context: user_space.init_ctx,
         }
@@ -147,7 +145,6 @@ impl<'a> UserMode<'a> {
     where
         F: FnMut() -> bool,
     {
-        debug_assert!(Arc::ptr_eq(&self.current, &Task::current().unwrap()));
         crate::task::atomic_mode::might_sleep();
         self.context.execute(has_kernel_event)
     }


### PR DESCRIPTION
**Note:** Although the title of this PR claims to be about utilities for thread local, there are already use cases in our current codebase, so I think it is okay to submit it as a standalone PR and have it reviewed independently.

## `SyncWrapper`

This first commit adds a `SyncWrapper` type, it is always `Sync`, but in contrast, getting a reference to the wrapped data is unsafe. If the type is not really `Sync`, the caller of the unsafe method must respect the safety requirement, i.e. the data will not be concurrently accessed (since it is not `Sync`).

```rust
struct SyncWrapper<T>(T);

unsafe impl<T> Sync for SyncWrapper<T> {}

impl<T> SyncWrapper<T> {
    pub(super) fn new(data: T) -> Self;
    pub(super) unsafe fn get(&self) -> &T;
}
```

This type can be used to store `func` in the `Task` structure, as this field will only be accessed by the task itself.

 - In future PRs, we can use this type to store the task local/thread local in the `Task` type.

## `CurrentTask`

The second commit adds a `CurrentTask` type. It describes the current task (as opposed to `Arc<Task>` which describes an arbitrary task).

```rust
pub struct CurrentTask(NonNull<Task>);

// `NonNull` is neither `Sync` nor `Send`.

impl CurrentTask {
    pub fn cloned(&self) -> Arc<Task>;
}

impl Deref for CurrentTask {
    type Target = Task;
    fn deref(&self) -> &Self::Target;
}
impl AsRef<Task> for CurrentTask {
    fn as_ref(&self) -> &Task;
}
impl Borrow<Task> for CurrentTask {
    fn borrow(&self) -> &Task;
}
```

This type is not `Send`, so it cannot outlive the current task. With this property we can avoid incrementing the reference count of the current task in `Task::current`.

In the future,
 - This type can allow access to task local/thread local, since it is not `Sync` either. (However, we still need to manually assert that we're not in IRQ handlers).
 - We can further optimize the `current!`/`current_process!` macro to eliminate all the expensive `Arc::clone` calls in it.