### PR TITLE
Add lmbench/tcp_virtio_bw_64k in benchmark CI

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -62,10 +62,11 @@ jobs:
           - lmbench/tcp_loopback_bw_4k
           - lmbench/tcp_loopback_bw_64k
           - lmbench/tcp_loopback_lat
-          - lmbench/tcp_virtio_lat
           - lmbench/tcp_loopback_connect_lat
           - lmbench/tcp_loopback_select_lat
           - lmbench/tcp_loopback_http_bw
+          - lmbench/tcp_virtio_bw_64k
+          - lmbench/tcp_virtio_lat
           - lmbench/udp_loopback_lat
           - iperf3/tcp_virtio_bw
           # Nginx benchmarks


### PR DESCRIPTION
#1569 forgets to add `tcp_virtio_bw_64k` in CI, thus the benchmark is not run in CI. This PR fixes the problem.