### PR TITLE
Enable restart of signal-interrupted syscalls on x86-64 platform

### DIFF
--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -22,6 +22,10 @@ impl LinuxAbi for UserContext {
         self.rax()
     }
 
+    fn set_syscall_num(&mut self, num: usize) {
+        self.set_rax(num);
+    }
+
     fn set_syscall_ret(&mut self, ret: usize) {
         self.set_rax(ret);
     }

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -7,6 +7,9 @@ pub trait LinuxAbi {
     /// Get return value of syscall
     fn syscall_ret(&self) -> usize;
 
+    /// Set number of syscall
+    fn set_syscall_num(&mut self, num: usize);
+
     /// Set return value of syscall
     fn set_syscall_ret(&mut self, ret: usize);
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -150,6 +150,8 @@ pub enum Errno {
     ERFKILL = 132, /* Operation not possible due to RF-kill */
 
     EHWPOISON = 133, /* Memory page has hardware error */
+
+    ERESTARTSYS = 512, /* Restart of an interrupted system call. For kernel internal use only. */
 }
 
 /// error used in this crate

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -74,6 +74,15 @@ pub fn futex_wait_bitset(
     drop(futex_bucket);
 
     waiter.pause_timeout(timeout)
+
+    // TODO: Ensure the futex item is dequeued and dropped.
+    //
+    // The enqueued futex item remain undequeued
+    // if the futex wait operation is interrupted by a signal or times out.
+    // In such cases, the `Box<FutexItem>` would persist in memory,
+    // leaving our implementation vulnerable to exploitation by user programs
+    // that could repeatedly issue futex wait operations
+    // to exhaust kernel memory.
 }
 
 /// Does futex wake

--- a/kernel/src/process/signal/sig_action.rs
+++ b/kernel/src/process/signal/sig_action.rs
@@ -90,9 +90,6 @@ impl TryFrom<u32> for SigActionFlags {
     fn try_from(bits: u32) -> Result<Self> {
         let flags = SigActionFlags::from_bits(bits)
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid sig action flag"))?;
-        if flags.contains(SigActionFlags::SA_RESTART) {
-            warn!("SA_RESTART is not supported");
-        }
         Ok(flags)
     }
 }

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -26,7 +26,10 @@ pub fn sys_fcntl(fd: FileDesc, cmd: i32, arg: u64, ctx: &Context) -> Result<Sysc
         FcntlCmd::F_SETFL => handle_setfl(fd, arg, ctx),
         FcntlCmd::F_GETLK => handle_getlk(fd, arg, ctx),
         FcntlCmd::F_SETLK => handle_setlk(fd, arg, true, ctx),
-        FcntlCmd::F_SETLKW => handle_setlk(fd, arg, false, ctx),
+        FcntlCmd::F_SETLKW => handle_setlk(fd, arg, false, ctx).map_err(|err| match err.error() {
+            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+            _ => err,
+        }),
         FcntlCmd::F_GETOWN => handle_getown(fd, ctx),
         FcntlCmd::F_SETOWN => handle_setown(fd, arg, ctx),
     }

--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -56,6 +56,7 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr, ctx: &Context) -> Result<Sy
             entry.set_flags(entry.flags() & (!FdFlags::CLOEXEC));
             0
         }
+        // FIXME: ioctl operations involving blocking I/O should be able to restart if interrupted
         _ => file.ioctl(ioctl_cmd, arg)?,
     };
     Ok(SyscallReturn::Return(res as _))

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -33,7 +33,11 @@ pub fn sys_openat(
             .fs()
             .resolver()
             .read()
-            .open(&fs_path, flags, mask_mode)?;
+            .open(&fs_path, flags, mask_mode)
+            .map_err(|err| match err.error() {
+                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+                _ => err,
+            })?;
         Arc::new(inode_handle)
     };
     let mut file_table = current.file_table().lock();

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -22,7 +22,11 @@ pub fn sys_wait4(
     debug!("wait4 current pid = {}", ctx.process.pid());
     let process_filter = ProcessFilter::from_id(wait_pid as _);
 
-    let waited_process = wait_child_exit(process_filter, wait_options, ctx)?;
+    let waited_process =
+        wait_child_exit(process_filter, wait_options, ctx).map_err(|err| match err.error() {
+            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+            _ => err,
+        })?;
     let Some(process) = waited_process else {
         return Ok(SyscallReturn::Return(0 as _));
     };

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -18,7 +18,11 @@ pub fn sys_waitid(
     let process_filter = ProcessFilter::from_which_and_id(which, upid)?;
     let wait_options = WaitOptions::from_bits(options as u32)
         .ok_or(Error::with_message(Errno::EINVAL, "invalid options"))?;
-    let waited_process = wait_child_exit(process_filter, wait_options, ctx)?;
+    let waited_process =
+        wait_child_exit(process_filter, wait_options, ctx).map_err(|err| match err.error() {
+            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+            _ => err,
+        })?;
     let pid = waited_process.map_or(0, |process| process.pid());
     Ok(SyscallReturn::Return(pid as _))
 }

--- a/ostd/src/arch/x86/trap/syscall.S
+++ b/ostd/src/arch/x86/trap/syscall.S
@@ -18,7 +18,7 @@
 .code64
 
 .text
-    # extern "sysv64" fn syscall_return(&mut GeneralRegs)
+    # extern "sysv64" fn syscall_return(&mut UserContext)
 .global syscall_return
 syscall_return:
     # disable interrupt
@@ -34,7 +34,7 @@ syscall_return:
 
     push rdi                # keep rsp 16 bytes align
     mov gs:4, rsp           # store kernel rsp -> TSS.sp0
-    mov rsp, rdi            # set rsp -> GeneralRegs
+    mov rsp, rdi            # set rsp -> UserContext
 
     # restore user gsbase
     swapgs
@@ -99,8 +99,8 @@ syscall_entry:
     swapgs                  # swap in kernel gs
     mov gs:12, rsp          # store user rsp -> scratch at TSS.sp1
     mov rsp, gs:4           # load kernel rsp <- TSS.sp0
-    pop rsp                 # load rsp -> GeneralRegs
-    add rsp, 21*8           # rsp -> error code of GeneralRegs
+    pop rsp                 # load rsp <- UserContext
+    add rsp, 21*8           # rsp -> error code of UserContext
 
     push 0x100              # push trap_num
     sub rsp, 16             # skip fsbase, gsbase

--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -66,7 +66,7 @@ trap_common:
 __from_user:
     /*
     kernel stack:
-    - ptr to GeneralRegs
+    - ptr to UserContext
     - ss
     - rsp
     - rflags
@@ -80,8 +80,8 @@ __from_user:
     mov rax, [rsp + 6*8]    # rax = user rsp
     mov gs:12, rax          # store user rsp -> scratch at TSS.sp1
 
-    mov rsp, [rsp + 8*8]    # load rsp -> GeneralRegs
-    add rsp, 22*8           # rsp -> top of GeneralRegs
+    mov rsp, [rsp + 8*8]    # load rsp <- UserContext
+    add rsp, 22*8           # rsp -> top of UserContext
     mov rax, gs:4           # rax = kernel stack
 
     # push trap_num, error_code

--- a/test/syscall_test/blocklists/alarm_test
+++ b/test/syscall_test/blocklists/alarm_test
@@ -1,2 +1,0 @@
-AlarmTest.UserModeSpinning
-AlarmTest.Restart_NoRandomSave


### PR DESCRIPTION
This PR may close #1578 (though the CI failure mentioned there seems irrelevant to the topic according to the comments) and maybe #1587 (?).

## How this PR implements syscall restart

This PR relies on the interrupted syscall to return a newly introduced errno `ERESTARTSYS`. We check that when we are handling possibly pending signals on our way back to userspace from a syscall; if we see an `ERESTARTSYS`, then we reset the syscall number and set back the instruction pointer by 2 byte (the length of x86-64 `syscall` instruction) therefore we can re-excute the syscall once we go back to userspace.

## Known issues
- the futex implementation may still be wrong since this PR doesn't try to solve the problems discussed in #1578
    - plus, I don't quite like the idea of the `pause_timeout` API. However, I didn't find an appropriate way to get rid of it.
- some syscalls like `getrandom` still doesn't support restart because we currently even don't support their blocking.
