### PR TITLE
Distinguish unmapping cursors

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -434,9 +434,9 @@ impl Vmar_ {
             // Clone mappings.
             let new_vmspace = new_vmar_.vm_space();
             let range = self.base..(self.base + self.size);
-            let mut new_cursor = new_vmspace.cursor_mut(&range).unwrap();
+            let mut new_cursor = new_vmspace.cursor_mut::<false>(&range).unwrap();
             let cur_vmspace = self.vm_space();
-            let mut cur_cursor = cur_vmspace.cursor_mut(&range).unwrap();
+            let mut cur_cursor = cur_vmspace.cursor_mut::<false>(&range).unwrap();
             for vm_mapping in inner.vm_mappings.iter() {
                 let base = vm_mapping.map_to_addr();
 

--- a/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
+++ b/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
@@ -51,7 +51,9 @@ fn create_user_space(program: &[u8]) -> UserSpace {
         // created and manipulated safely through
         // the `VmSpace` abstraction.
         let vm_space = VmSpace::new();
-        let mut cursor = vm_space.cursor_mut(&(MAP_ADDR..MAP_ADDR + nbytes)).unwrap();
+        let mut cursor = vm_space
+            .cursor_mut::<false>(&(MAP_ADDR..MAP_ADDR + nbytes))
+            .unwrap();
         let map_prop = PageProperty::new(PageFlags::RWX, CachePolicy::Writeback);
         for frame in user_pages {
             cursor.map(frame, map_prop);


### PR DESCRIPTION
Only unmap and remap needs strong TLB coherence. So there need to be two cursors.

It brings page fault scalability forward. Same as Linux 6.11 now.

![page-fault-scaling](https://github.com/user-attachments/assets/3ca803a7-1f72-4fe9-be44-62517021c4f0)
