### PR TITLE
Enable RCU (again)

### DIFF
--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -7,7 +7,7 @@ use aster_console::{AnyConsoleDevice, ConsoleCallback};
 use log::debug;
 use ostd::{
     mm::{DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions, VmReader},
-    sync::{LocalIrqDisabled, RwLock, SpinLock},
+    sync::{Rcu, SpinLock},
     trap::TrapFrame,
 };
 
@@ -25,7 +25,8 @@ pub struct ConsoleDevice {
     transmit_queue: SpinLock<VirtQueue>,
     send_buffer: DmaStream,
     receive_buffer: DmaStream,
-    callbacks: RwLock<Vec<&'static ConsoleCallback>, LocalIrqDisabled>,
+    #[expect(clippy::box_collection)]
+    callbacks: Rcu<Box<Vec<&'static ConsoleCallback>>>,
 }
 
 impl AnyConsoleDevice for ConsoleDevice {
@@ -52,7 +53,19 @@ impl AnyConsoleDevice for ConsoleDevice {
     }
 
     fn register_callback(&self, callback: &'static ConsoleCallback) {
-        self.callbacks.write().push(callback);
+        loop {
+            let callbacks = self.callbacks.read();
+            let mut callbacks_cloned = callbacks.clone();
+            callbacks_cloned.push(callback);
+            if callbacks
+                .compare_exchange(Box::new(callbacks_cloned))
+                .is_ok()
+            {
+                break;
+            }
+            // Contention on pushing, retry.
+            core::hint::spin_loop();
+        }
     }
 }
 
@@ -103,7 +116,7 @@ impl ConsoleDevice {
             transmit_queue,
             send_buffer,
             receive_buffer,
-            callbacks: RwLock::new(Vec::new()),
+            callbacks: Rcu::new(Box::new(Vec::new())),
         });
 
         device.activate_receive_buffer(&mut device.receive_queue.disable_irq().lock());

--- a/kernel/src/time/softirq.rs
+++ b/kernel/src/time/softirq.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 
 use aster_softirq::{softirq_id::TIMER_SOFTIRQ_ID, SoftIrqLine};
-use ostd::{
-    sync::{LocalIrqDisabled, RwLock},
-    timer,
-};
+use ostd::{sync::RcuOption, timer};
 
-static TIMER_SOFTIRQ_CALLBACKS: RwLock<Vec<Box<dyn Fn() + Sync + Send>>, LocalIrqDisabled> =
-    RwLock::new(Vec::new());
+#[allow(clippy::type_complexity)]
+#[allow(clippy::box_collection)]
+static TIMER_SOFTIRQ_CALLBACKS: RcuOption<Box<Vec<fn()>>> = RcuOption::new_none();
 
 pub(super) fn init() {
     SoftIrqLine::get(TIMER_SOFTIRQ_ID).enable(timer_softirq_handler);
@@ -20,16 +18,41 @@ pub(super) fn init() {
 }
 
 /// Registers a function that will be executed during timer softirq.
-pub(super) fn register_callback<F>(func: F)
-where
-    F: Fn() + Sync + Send + 'static,
-{
-    TIMER_SOFTIRQ_CALLBACKS.write().push(Box::new(func));
+pub(super) fn register_callback(func: fn()) {
+    loop {
+        let callbacks = TIMER_SOFTIRQ_CALLBACKS.read();
+        match callbacks.get() {
+            // Initialized, copy the vector, push the function and update.
+            Some(callbacks_vec) => {
+                let mut callbacks_cloned = callbacks_vec.clone();
+                callbacks_cloned.push(func);
+                if callbacks
+                    .compare_exchange(Some(Box::new(callbacks_cloned)))
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+            // Uninitialized, initialize it.
+            None => {
+                if callbacks
+                    .compare_exchange(Some(Box::new(vec![func])))
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+        }
+        // Contention on initialization or pushing, retry.
+        core::hint::spin_loop();
+    }
 }
 
 fn timer_softirq_handler() {
     let callbacks = TIMER_SOFTIRQ_CALLBACKS.read();
-    for callback in callbacks.iter() {
-        (callback)();
+    if let Some(callbacks) = callbacks.get() {
+        for callback in callbacks.iter() {
+            (callback)();
+        }
     }
 }

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -92,6 +92,8 @@ pub(crate) fn init_on_bsp() {
     // we are on the BSP.
     unsafe { crate::cpu::local::init_on_bsp() };
 
+    crate::sync::init();
+
     crate::boot::smp::boot_all_aps();
 
     timer::init();

--- a/ostd/src/cpu/set.rs
+++ b/ostd/src/cpu/set.rs
@@ -85,6 +85,18 @@ impl CpuSet {
         self.bits.iter().all(|part| *part == 0)
     }
 
+    /// Returns true if the set is full.
+    pub fn is_full(&self) -> bool {
+        let num_cpus = num_cpus();
+        self.bits.iter().enumerate().all(|(idx, part)| {
+            if idx == self.bits.len() - 1 && num_cpus % BITS_PER_PART != 0 {
+                *part == (1 << (num_cpus % BITS_PER_PART)) - 1
+            } else {
+                *part == !0
+            }
+        })
+    }
+
     /// Adds all CPUs to the set.
     pub fn add_all(&mut self) {
         self.bits.fill(!0);

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use self::{guard::GuardTransfer, rcu::finish_grace_period};
 pub use self::{
     guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
-    rcu::{OwnerPtr, Rcu, RcuReadGuard},
+    rcu::{OwnerPtr, Rcu, RcuOption, RcuReadGuard},
     rwarc::{RoArc, RwArc},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -4,20 +4,18 @@
 
 mod guard;
 mod mutex;
-// TODO: refactor this rcu implementation
-// Comment out this module since it raises lint error
-// mod rcu;
+mod rcu;
 mod rwarc;
 mod rwlock;
 mod rwmutex;
 mod spin;
 mod wait;
 
-// pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};
-pub(crate) use self::guard::GuardTransfer;
+pub(crate) use self::{guard::GuardTransfer, rcu::finish_grace_period};
 pub use self::{
     guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
+    rcu::{OwnerPtr, Rcu, RcuReadGuard},
     rwarc::{RoArc, RwArc},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
@@ -30,3 +28,7 @@ pub use self::{
     spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
     wait::{WaitQueue, Waiter, Waker},
 };
+
+pub(crate) fn init() {
+    rcu::init();
+}

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -5,6 +5,7 @@
 use core::{
     marker::PhantomData,
     ops::Deref,
+    ptr::NonNull,
     sync::atomic::{
         AtomicPtr,
         Ordering::{AcqRel, Acquire},
@@ -21,120 +22,261 @@ mod owner_ptr;
 
 pub use owner_ptr::OwnerPtr;
 
-/// Read-Copy Update Synchronization Mechanism
+/// A Read-Copy Update (RCU) cell for sharing a pointer between threads.
+///
+/// The pointer should be a owning pointer with type `P`, which implements
+/// [`OwnerPtr`]. For example, `P` can be `Box<T>` or `Arc<T>`.
 ///
 /// # Overview
 ///
-/// RCU avoids the use of lock primitives lock primitives while multiple threads
-/// concurrently read and update elements that are linked through pointers and that
-/// belong to shared data structures.
-///
-/// Whenever a thread is inserting or deleting elements of data structures in shared
-/// memory, all readers are guaranteed to see and traverse either the older or the
-/// new structure, therefore avoiding inconsistencies and allowing readers to not be
-/// blocked by writers.
-///
-/// The type parameter `P` represents the data that this rcu is protecting. The type
-/// parameter `P` must implement [`OwnerPtr`].
-///
-/// # Usage
-///
-/// It is used when performance of reads is crucial and is an example of space–time
-/// tradeoff, enabling fast operations at the cost of more space.
-///
-/// Use [`Rcu`] in scenarios that require frequent reads and infrequent
-/// updates (read-mostly).
-///
-/// Use [`Rcu`] in scenarios that require high real-time reading.
-///
-/// Rcu should not to be used in the scenarios that write-mostly and which need
-/// consistent data.
+/// Read-Copy-Update (RCU) is a synchronization mechanism designed for high-
+/// performance, low-latency read operations in concurrent systems. It allows
+/// multiple readers to access shared data simultaneously without contention,
+/// while writers can update the data safely in a way that does not disrupt
+/// ongoing reads. RCU is particularly suited for situations where reads are
+/// far more frequent than writes.  
+///  
+/// The original design and implementation of RCU is described in paper _The
+/// Read-Copy-Update Mechanism for Supporting Real-Time Applications on Shared-
+/// Memory Multiprocessor Systems with Linux_ published on IBM Systems Journal
+/// 47.2 (2008).
 ///
 /// # Examples
 ///
 /// ```
-/// use aster_frame::sync::{Rcu, RcuReadGuard, RcuReclaimer};
+/// use ostd::sync::Rcu;
 ///
 /// let rcu = Rcu::new(Box::new(42));
 ///
-/// // Read the data protected by rcu
+/// let rcu_guard = rcu.read();
+///
+/// assert_eq!(*rcu_guard, Some(&42));
+///
+/// rcu_guard.compare_exchange(Box::new(43)).unwrap();
+///
+/// let rcu_guard = rcu.read();
+///
+/// assert_eq!(*rcu_guard, Some(&43));
+/// ```
+#[repr(transparent)]
+pub struct Rcu<P: OwnerPtr, const NULLABLE: bool = false> {
+    ptr: AtomicPtr<<P as OwnerPtr>::Target>,
+    // We want to implement Send and Sync explicitly.
+    // Having a pointer field prevents them from being implemented
+    // automatically by the compiler.
+    _marker: PhantomData<*const P::Target>,
+}
+
+/// A Read-Copy Update (RCU) cell for sharing a _nullable_ pointer.  
+///
+/// This is a variant of [`Rcu`] that allows the contained pointer to be null.
+/// So that it can implement `Rcu<Option<P>>` where `P` is not a nullable
+/// pointer. It is the same as [`Rcu`] in other aspects.
+///
+/// # Examples
+///
+/// ```
+/// use ostd::sync::RcuOption;
+///
+/// // Also allows lazy initialization.
+/// static RCU: RcuOption<Box<usize>> = RcuOption::new_none();
+///
+/// // Not initialized yet.
+/// assert!(RCU.read().try_get().is_none());
+///
+/// // Initialize the data protected by RCU.
+/// RCU.update(Box::new(42));
+///
+/// // Read the data protected by RCU
 /// {
-///     let rcu_guard = rcu.get();
+///     let rcu_guard = RCU.read().try_get().unwrap();
 ///     assert_eq!(*rcu_guard, 42);
 /// }
 ///
-/// // Update the data protected by rcu
+/// // Update the data protected by RCU
 /// {
-///     let reclaimer = rcu.replace(Box::new(43));
+///     let rcu_guard = RCU.read().try_get().unwrap();
 ///
-///     let rcu_guard = rcu.get();
+///     rcu_guard.compare_exchange(Box::new(43)).unwrap();
+///
+///     let rcu_guard = RCU.read().try_get().unwrap();
 ///     assert_eq!(*rcu_guard, 43);
 /// }
 /// ```
-pub struct Rcu<P: OwnerPtr> {
-    ptr: AtomicPtr<<P as OwnerPtr>::Target>,
-    marker: PhantomData<P::Target>,
+pub type RcuOption<P> = Rcu<P, true>;
+
+// SAFETY: It is apparent that if `P::Target` is `Send`, then `Rcu<P>` is `Send`.
+unsafe impl<P: OwnerPtr, const NULLABLE: bool> Send for Rcu<P, NULLABLE> where
+    <P as OwnerPtr>::Target: Send
+{
 }
 
-impl<P: OwnerPtr> Rcu<P> {
-    /// Creates a new instance of Rcu with the given pointer.
-    pub fn new(ptr: P) -> Self {
-        let ptr = AtomicPtr::new(OwnerPtr::into_raw(ptr) as *mut _);
+// SAFETY: To implement `Sync` for `Rcu<P>`, we need to meet two conditions:
+//  1. `P::Target` must be `Sync` because `Rcu::get` allows concurrent access.
+//  2. `P::Target` must be `Send` because `Rcu::update` may obtain an object
+//     of `P` created on another thread.
+unsafe impl<P: OwnerPtr, const NULLABLE: bool> Sync for Rcu<P, NULLABLE> where
+    <P as OwnerPtr>::Target: Send + Sync
+{
+}
+
+// Non-nullable RCU cell.
+impl<P: OwnerPtr> Rcu<P, false> {
+    /// Creates a new RCU cell with the given pointer.
+    pub fn new(pointer: P) -> Self {
+        let ptr = <P as OwnerPtr>::into_raw(pointer).cast_mut();
+        let ptr = AtomicPtr::new(ptr);
         Self {
             ptr,
-            marker: PhantomData,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// Nullable RCU cell.
+impl<P: OwnerPtr> Rcu<P, true> {
+    /// Creates a new uninitialized RCU cell.
+    ///
+    /// Initialization can be done by calling
+    /// [`RcuReadGuard::compare_exchange`] after getting a read
+    /// guard using [`Rcu::read`]. Then only the first initialization will be
+    /// successful. If initialization can be done multiple times, using
+    /// [`Rcu::update`] is fine.
+    pub const fn new_none() -> Self {
+        let ptr = AtomicPtr::new(core::ptr::null_mut());
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P: OwnerPtr + Send, const NULLABLE: bool> Rcu<P, NULLABLE> {
+    /// Replaces the current pointer with a new pointer.
+    ///
+    /// This function updates the pointer to the new pointer regardless of the
+    /// original pointer. If the original pointer is not NULL, it will be
+    /// dropped after the grace period.
+    ///
+    /// Oftentimes this function is not recommended unless you have
+    /// synchronized writes with locks. Otherwise, you can use [`Self::read`]
+    /// and then [`RcuReadGuard::compare_exchange`] to update the pointer.
+    pub fn update(&self, new_ptr: P) {
+        let new_ptr = <P as OwnerPtr>::into_raw(new_ptr).cast_mut();
+        let old_raw_ptr = self.ptr.swap(new_ptr, AcqRel);
+
+        if let Some(p) = NonNull::new(old_raw_ptr) {
+            // SAFETY: It was previously returned by `into_raw`.
+            unsafe { delay_drop::<P>(p) };
         }
     }
 
-    /// Retrieves a read guard for the RCU mechanism.
+    /// Retrieves a read guard for the RCU cell.
     ///
-    /// This method returns a `RcuReadGuard` which allows read-only access to the
-    /// underlying data protected by the RCU mechanism.
-    pub fn get(&self) -> RcuReadGuard<'_, P> {
+    /// The guard allows read-only access to the data protected by RCU.
+    ///
+    /// If the RCU cell is nullable, the guard will be nullable and you can
+    /// only dereference it after checking with [`RcuReadGuard::try_get`].
+    /// If the RCU cell is non-nullable, the guard will be non-nullable and
+    /// you can dereference it directly.
+    pub fn read(&self) -> RcuReadGuard<'_, P, NULLABLE> {
         let guard = disable_preempt();
-        let obj = unsafe { &*self.ptr.load(Acquire) };
         RcuReadGuard {
-            obj,
-            _rcu: self,
+            obj_ptr: self.ptr.load(Acquire),
+            rcu: self,
             _inner_guard: guard,
         }
     }
 }
 
-impl<P: OwnerPtr + Send> Rcu<P> {
-    /// Replaces the current pointer with a new pointer.
-    pub fn replace(&self, new_ptr: P) {
-        let new_ptr = <P as OwnerPtr>::into_raw(new_ptr) as *mut _;
-        let old_ptr = {
-            let old_raw_ptr = self.ptr.swap(new_ptr, AcqRel);
-            // SAFETY: It is valid because it was previously returned by `into_raw`.
-            unsafe { <P as OwnerPtr>::from_raw(old_raw_ptr) }
-        };
-
-        let rcu_monitor = RCU_MONITOR.get().unwrap();
-        rcu_monitor.after_grace_period(move || {
-            drop(old_ptr);
-        });
-    }
-}
-
-/// A guard that allows read-only access to the data protected by the RCU
-/// mechanism.
-///
-/// Note that the data read can be outdated if the data is updated by another
-/// task after acquiring the guard.
-pub struct RcuReadGuard<'a, P: OwnerPtr> {
-    obj: &'a <P as OwnerPtr>::Target,
-    _rcu: &'a Rcu<P>,
+/// A guard that allows read-only access to the initialized data protected
+/// by the RCU mechanism.
+pub struct RcuReadGuard<'a, P: OwnerPtr, const NULLABLE: bool> {
+    /// If maybe uninitialized, the pointer can be NULL.
+    obj_ptr: *mut <P as OwnerPtr>::Target,
+    rcu: &'a Rcu<P, NULLABLE>,
     _inner_guard: DisabledPreemptGuard,
 }
 
-impl<P: OwnerPtr> Deref for RcuReadGuard<'_, P> {
+// Non-nullable RCU guard can be directly dereferenced.
+impl<P: OwnerPtr> Deref for RcuReadGuard<'_, P, false> {
     type Target = <P as OwnerPtr>::Target;
 
     fn deref(&self) -> &Self::Target {
-        self.obj
+        // SAFETY: Since the preemption is disabled, the pointer is valid
+        // because other writers won't release the allocation until this task
+        // passes the quiescent state.
+        // And this pointer is not NULL.
+        unsafe { &*self.obj_ptr }
     }
+}
+
+// Nullable RCU guard can be dereferenced after checking.
+impl<'a, P: OwnerPtr> RcuReadGuard<'a, P, true> {
+    /// Tries to get the initialized read guard.
+    ///
+    /// If the RCU cell is not initialized, this function will return
+    /// [`Err`] with the guard itself unchanged. Otherwise a dereferenceable
+    /// read guard will be returned.
+    pub fn try_get(self) -> Result<RcuReadGuard<'a, P, false>, Self> {
+        if self.obj_ptr.is_null() {
+            return Err(self);
+        }
+        Ok(RcuReadGuard {
+            obj_ptr: self.obj_ptr,
+            // SAFETY: It is initialized. The layout is the same.
+            rcu: unsafe { core::mem::transmute::<&Rcu<P, true>, &Rcu<P, false>>(self.rcu) },
+            _inner_guard: self._inner_guard,
+        })
+    }
+}
+
+impl<P: OwnerPtr + Send, const NULLABLE: bool> RcuReadGuard<'_, P, NULLABLE> {
+    /// Tries to replace the already read pointer with a new pointer.
+    ///
+    /// If another thread has updated the pointer after the read, this
+    /// function will fail and return the new pointer. Otherwise, it will
+    /// replace the pointer with the new one and drop the old pointer after
+    /// the grace period.
+    ///
+    /// If spinning on this function, it is recommended to relax the CPU
+    /// or yield the task on failure. Otherwise contention will occur.
+    ///
+    /// This API does not help to avoid
+    /// [the ABA problem](https://en.wikipedia.org/wiki/ABA_problem).
+    pub fn compare_exchange(self, new_ptr: P) -> Result<(), P> {
+        let new_ptr = <P as OwnerPtr>::into_raw(new_ptr).cast_mut();
+
+        if self
+            .rcu
+            .ptr
+            .compare_exchange(self.obj_ptr, new_ptr, AcqRel, Acquire)
+            .is_err()
+        {
+            // SAFETY: It was previously returned by `into_raw`.
+            return Err(unsafe { <P as OwnerPtr>::from_raw(new_ptr) });
+        }
+
+        if let Some(p) = NonNull::new(self.obj_ptr) {
+            // SAFETY: It was previously returned by `into_raw`.
+            unsafe { delay_drop::<P>(p) };
+        }
+
+        Ok(())
+    }
+}
+
+/// # Safety
+///
+/// The pointer must be previously returned by `into_raw` and the pointer
+/// must be only be dropped once.
+unsafe fn delay_drop<P: OwnerPtr + Send>(pointer: NonNull<<P as OwnerPtr>::Target>) {
+    // SAFETY: The pointer is not NULL.
+    let p = unsafe { <P as OwnerPtr>::from_raw(pointer.as_ptr().cast_const()) };
+    let rcu_monitor = RCU_MONITOR.get().unwrap();
+    rcu_monitor.after_grace_period(move || {
+        drop(p);
+    });
 }
 
 /// Finishes the current grace period.

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -2,28 +2,82 @@
 
 //! Read-copy update (RCU).
 
-use core::marker::PhantomData;
-use core::ops::Deref;
-use core::sync::atomic::{
-    AtomicPtr,
-    Ordering::{AcqRel, Acquire},
+use core::{
+    marker::PhantomData,
+    ops::Deref,
+    sync::atomic::{
+        AtomicPtr,
+        Ordering::{AcqRel, Acquire},
+    },
 };
 
+use spin::once::Once;
+
 use self::monitor::RcuMonitor;
-use crate::prelude::*;
-use crate::sync::WaitQueue;
+use crate::task::{disable_preempt, DisabledPreemptGuard};
 
 mod monitor;
 mod owner_ptr;
 
 pub use owner_ptr::OwnerPtr;
 
+/// Read-Copy Update Synchronization Mechanism
+///
+/// # Overview
+///
+/// RCU avoids the use of lock primitives lock primitives while multiple threads
+/// concurrently read and update elements that are linked through pointers and that
+/// belong to shared data structures.
+///
+/// Whenever a thread is inserting or deleting elements of data structures in shared
+/// memory, all readers are guaranteed to see and traverse either the older or the
+/// new structure, therefore avoiding inconsistencies and allowing readers to not be
+/// blocked by writers.
+///
+/// The type parameter `P` represents the data that this rcu is protecting. The type
+/// parameter `P` must implement [`OwnerPtr`].
+///
+/// # Usage
+///
+/// It is used when performance of reads is crucial and is an example of space–time
+/// tradeoff, enabling fast operations at the cost of more space.
+///
+/// Use [`Rcu`] in scenarios that require frequent reads and infrequent
+/// updates (read-mostly).
+///
+/// Use [`Rcu`] in scenarios that require high real-time reading.
+///
+/// Rcu should not to be used in the scenarios that write-mostly and which need
+/// consistent data.
+///
+/// # Examples
+///
+/// ```
+/// use aster_frame::sync::{Rcu, RcuReadGuard, RcuReclaimer};
+///
+/// let rcu = Rcu::new(Box::new(42));
+///
+/// // Read the data protected by rcu
+/// {
+///     let rcu_guard = rcu.get();
+///     assert_eq!(*rcu_guard, 42);
+/// }
+///
+/// // Update the data protected by rcu
+/// {
+///     let reclaimer = rcu.replace(Box::new(43));
+///
+///     let rcu_guard = rcu.get();
+///     assert_eq!(*rcu_guard, 43);
+/// }
+/// ```
 pub struct Rcu<P: OwnerPtr> {
     ptr: AtomicPtr<<P as OwnerPtr>::Target>,
     marker: PhantomData<P::Target>,
 }
 
 impl<P: OwnerPtr> Rcu<P> {
+    /// Creates a new instance of Rcu with the given pointer.
     pub fn new(ptr: P) -> Self {
         let ptr = AtomicPtr::new(OwnerPtr::into_raw(ptr) as *mut _);
         Self {
@@ -32,31 +86,50 @@ impl<P: OwnerPtr> Rcu<P> {
         }
     }
 
+    /// Retrieves a read guard for the RCU mechanism.
+    ///
+    /// This method returns a `RcuReadGuard` which allows read-only access to the
+    /// underlying data protected by the RCU mechanism.
     pub fn get(&self) -> RcuReadGuard<'_, P> {
+        let guard = disable_preempt();
         let obj = unsafe { &*self.ptr.load(Acquire) };
-        RcuReadGuard { obj, rcu: self }
+        RcuReadGuard {
+            obj,
+            _rcu: self,
+            _inner_guard: guard,
+        }
     }
 }
 
 impl<P: OwnerPtr + Send> Rcu<P> {
-    pub fn replace(&self, new_ptr: P) -> RcuReclaimer<P> {
+    /// Replaces the current pointer with a new pointer.
+    pub fn replace(&self, new_ptr: P) {
         let new_ptr = <P as OwnerPtr>::into_raw(new_ptr) as *mut _;
         let old_ptr = {
             let old_raw_ptr = self.ptr.swap(new_ptr, AcqRel);
+            // SAFETY: It is valid because it was previously returned by `into_raw`.
             unsafe { <P as OwnerPtr>::from_raw(old_raw_ptr) }
         };
-        RcuReclaimer { ptr: old_ptr }
+
+        let rcu_monitor = RCU_MONITOR.get().unwrap();
+        rcu_monitor.after_grace_period(move || {
+            drop(old_ptr);
+        });
     }
 }
 
-#[clippy::has_significant_drop]
-#[must_use]
+/// A guard that allows read-only access to the data protected by the RCU
+/// mechanism.
+///
+/// Note that the data read can be outdated if the data is updated by another
+/// task after acquiring the guard.
 pub struct RcuReadGuard<'a, P: OwnerPtr> {
     obj: &'a <P as OwnerPtr>::Target,
-    rcu: &'a Rcu<P>,
+    _rcu: &'a Rcu<P>,
+    _inner_guard: DisabledPreemptGuard,
 }
 
-impl<'a, P: OwnerPtr> Deref for RcuReadGuard<'a, P> {
+impl<P: OwnerPtr> Deref for RcuReadGuard<'_, P> {
     type Target = <P as OwnerPtr>::Target;
 
     fn deref(&self) -> &Self::Target {
@@ -64,43 +137,26 @@ impl<'a, P: OwnerPtr> Deref for RcuReadGuard<'a, P> {
     }
 }
 
-#[repr(transparent)]
-pub struct RcuReclaimer<P> {
-    ptr: P,
-}
-
-impl<P: Send + 'static> RcuReclaimer<P> {
-    pub fn delay(mut self) {
-        let ptr: P = unsafe {
-            let ptr = core::mem::replace(&mut self.ptr, core::mem::uninitialized());
-
-            core::mem::forget(self);
-
-            ptr
-        };
-        get_singleton().after_grace_period(move || {
-            drop(ptr);
-        });
+/// Finishes the current grace period.
+///
+/// This function is called when the current grace period on current CPU is
+/// finished. If this CPU is the last CPU to finish the current grace period,
+/// it takes all the current callbacks and invokes them.
+///
+/// # Safety
+///
+/// The caller must ensure that this CPU is not executing in a RCU read-side
+/// critical section.
+pub unsafe fn finish_grace_period() {
+    let rcu_monitor = RCU_MONITOR.get().unwrap();
+    // SAFETY: The caller ensures safety.
+    unsafe {
+        rcu_monitor.finish_grace_period();
     }
 }
 
-impl<P> Drop for RcuReclaimer<P> {
-    fn drop(&mut self) {
-        let wq = Arc::new(WaitQueue::new());
-        get_singleton().after_grace_period({
-            let wq = wq.clone();
-            move || {
-                wq.wake_one();
-            }
-        });
-        wq.wait_until(|| Some(0u8));
-    }
-}
+static RCU_MONITOR: Once<RcuMonitor> = Once::new();
 
-pub unsafe fn pass_quiescent_state() {
-    get_singleton().pass_quiescent_state()
-}
-
-fn get_singleton() -> &'static RcuMonitor {
-    todo!()
+pub fn init() {
+    RCU_MONITOR.call_once(RcuMonitor::new);
 }

--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -3,14 +3,14 @@
 use alloc::collections::VecDeque;
 use core::sync::atomic::{
     AtomicBool,
-    Ordering::{Acquire, Relaxed, Release},
+    Ordering::{self, Relaxed},
 };
 
-#[cfg(target_arch = "x86_64")]
-use crate::arch::x86::cpu;
-use crate::prelude::*;
-use crate::sync::AtomicBits;
-use crate::sync::SpinLock;
+use crate::{
+    cpu::{AtomicCpuSet, CpuId, CpuSet, PinCurrentCpu},
+    prelude::*,
+    sync::SpinLock,
+};
 
 /// A RCU monitor ensures the completion of _grace periods_ by keeping track
 /// of each CPU's passing _quiescent states_.
@@ -20,14 +20,18 @@ pub struct RcuMonitor {
 }
 
 impl RcuMonitor {
-    pub fn new(num_cpus: usize) -> Self {
+    /// Creates a new RCU monitor.
+    ///
+    /// This function is used to initialize a singleton instance of `RcuMonitor`.
+    /// The singleton instance is globally accessible via the `RCU_MONITOR`.
+    pub fn new() -> Self {
         Self {
             is_monitoring: AtomicBool::new(false),
-            state: SpinLock::new(State::new(num_cpus)),
+            state: SpinLock::new(State::new()),
         }
     }
 
-    pub unsafe fn pass_quiescent_state(&self) {
+    pub(super) unsafe fn finish_grace_period(&self) {
         // Fast path
         if !self.is_monitoring.load(Relaxed) {
             return;
@@ -38,11 +42,12 @@ impl RcuMonitor {
         // GP.
         let callbacks = {
             let mut state = self.state.disable_irq().lock();
+            let cpu = state.guard().current_cpu();
             if state.current_gp.is_complete() {
                 return;
             }
 
-            state.current_gp.pass_quiescent_state();
+            state.current_gp.finish_grace_period(cpu);
             if !state.current_gp.is_complete() {
                 return;
             }
@@ -50,7 +55,7 @@ impl RcuMonitor {
             // Now that the current GP is complete, take its callbacks
             let current_callbacks = state.current_gp.take_callbacks();
 
-            // Check if we need to70G watch for a next GP
+            // Check if we need to watch for a next GP
             if !state.next_callbacks.is_empty() {
                 let callbacks = core::mem::take(&mut state.next_callbacks);
                 state.current_gp.restart(callbacks);
@@ -69,7 +74,7 @@ impl RcuMonitor {
 
     pub fn after_grace_period<F>(&self, f: F)
     where
-        F: FnOnce() -> () + Send + 'static,
+        F: FnOnce() + Send + 'static,
     {
         let mut state = self.state.disable_irq().lock();
 
@@ -91,28 +96,28 @@ struct State {
 }
 
 impl State {
-    pub fn new(num_cpus: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            current_gp: GracePeriod::new(num_cpus),
+            current_gp: GracePeriod::new(),
             next_callbacks: VecDeque::new(),
         }
     }
 }
 
-type Callbacks = VecDeque<Box<dyn FnOnce() -> () + Send + 'static>>;
+type Callbacks = VecDeque<Box<dyn FnOnce() + Send + 'static>>;
 
 struct GracePeriod {
     callbacks: Callbacks,
-    cpu_mask: AtomicBits,
+    cpu_mask: AtomicCpuSet,
     is_complete: bool,
 }
 
 impl GracePeriod {
-    pub fn new(num_cpus: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            callbacks: Default::default(),
-            cpu_mask: AtomicBits::new_zeroes(num_cpus),
-            is_complete: false,
+            callbacks: Callbacks::new(),
+            cpu_mask: AtomicCpuSet::new(CpuSet::new_empty()),
+            is_complete: true,
         }
     }
 
@@ -120,11 +125,10 @@ impl GracePeriod {
         self.is_complete
     }
 
-    pub unsafe fn pass_quiescent_state(&mut self) {
-        let this_cpu = cpu::this_cpu();
-        self.cpu_mask.set(this_cpu as usize, true);
+    unsafe fn finish_grace_period(&mut self, this_cpu: CpuId) {
+        self.cpu_mask.add(this_cpu, Ordering::Relaxed);
 
-        if self.cpu_mask.is_full() {
+        if self.cpu_mask.load().is_full() {
             self.is_complete = true;
         }
     }
@@ -135,7 +139,7 @@ impl GracePeriod {
 
     pub fn restart(&mut self, callbacks: Callbacks) {
         self.is_complete = false;
-        self.cpu_mask.clear();
+        self.cpu_mask.store(&CpuSet::new_empty());
         self.callbacks = callbacks;
     }
 }

--- a/ostd/src/sync/rcu/owner_ptr.rs
+++ b/ostd/src/sync/rcu/owner_ptr.rs
@@ -17,7 +17,7 @@ use crate::prelude::*;
 /// raw pointers.
 ///
 /// [`Rcu`]: super::Rcu
-pub unsafe trait OwnerPtr: 'static {
+pub unsafe trait OwnerPtr: Send + 'static {
     /// The target type that this pointer refers to.
     // TODO: allow ?Sized
     type Target;
@@ -49,7 +49,7 @@ pub unsafe trait OwnerPtr: 'static {
     unsafe fn from_raw(ptr: NonNull<Self::Target>) -> Self;
 }
 
-unsafe impl<T: 'static> OwnerPtr for Box<T> {
+unsafe impl<T: Send + 'static> OwnerPtr for Box<T> {
     type Target = T;
 
     fn new(value: Self::Target) -> Self {
@@ -71,7 +71,7 @@ unsafe impl<T: 'static> OwnerPtr for Box<T> {
     }
 }
 
-unsafe impl<T: 'static> OwnerPtr for Arc<T> {
+unsafe impl<T: Send + Sync + 'static> OwnerPtr for Arc<T> {
     type Target = T;
 
     fn new(value: Self::Target) -> Self {

--- a/ostd/src/sync/rcu/owner_ptr.rs
+++ b/ostd/src/sync/rcu/owner_ptr.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ptr::NonNull;
-
 use crate::prelude::*;
 
 /// A trait that abstracts pointers that have the ownership of the objects they
@@ -10,7 +8,7 @@ use crate::prelude::*;
 /// The most typical examples smart pointer types like `Box<T>` and `Arc<T>`.
 ///
 /// which can be converted to and from the raw pointer type of `*const T`.
-pub trait OwnerPtr {
+pub trait OwnerPtr: 'static {
     /// The target type that this pointer refers to.
     // TODO: allow ?Sized
     type Target;
@@ -30,7 +28,7 @@ pub trait OwnerPtr {
     unsafe fn from_raw(ptr: *const Self::Target) -> Self;
 }
 
-impl<T> OwnerPtr for Box<T> {
+impl<T: 'static> OwnerPtr for Box<T> {
     type Target = T;
 
     fn into_raw(self) -> *const Self::Target {
@@ -42,7 +40,7 @@ impl<T> OwnerPtr for Box<T> {
     }
 }
 
-impl<T> OwnerPtr for Arc<T> {
+impl<T: 'static> OwnerPtr for Arc<T> {
     type Target = T;
 
     fn into_raw(self) -> *const Self::Target {

--- a/ostd/src/sync/rcu/owner_ptr.rs
+++ b/ostd/src/sync/rcu/owner_ptr.rs
@@ -13,6 +13,9 @@ pub trait OwnerPtr: 'static {
     // TODO: allow ?Sized
     type Target;
 
+    /// Creates a new pointer with the given value.
+    fn new(value: Self::Target) -> Self;
+
     /// Converts to a raw pointer.
     ///
     /// If `Self` owns the object that it refers to (e.g., `Box<_>`), then
@@ -31,6 +34,10 @@ pub trait OwnerPtr: 'static {
 impl<T: 'static> OwnerPtr for Box<T> {
     type Target = T;
 
+    fn new(value: Self::Target) -> Self {
+        Box::new(value)
+    }
+
     fn into_raw(self) -> *const Self::Target {
         Box::into_raw(self) as *const _
     }
@@ -42,6 +49,10 @@ impl<T: 'static> OwnerPtr for Box<T> {
 
 impl<T: 'static> OwnerPtr for Arc<T> {
     type Target = T;
+
+    fn new(value: Self::Target) -> Self {
+        Arc::new(value)
+    }
 
     fn into_raw(self) -> *const Self::Target {
         Arc::into_raw(self)
@@ -62,6 +73,10 @@ where
     <P as OwnerPtr>::Target: Sized,
 {
     type Target = P::Target;
+
+    fn new(value: Self::Target) -> Self {
+        Some(P::new(value))
+    }
 
     fn into_raw(self) -> *const Self::Target {
         self.map(|p| <P as OwnerPtr>::into_raw(p))

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(dead_code)]
-
 use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,
@@ -157,6 +155,13 @@ pub type ArcSpinLockGuard<T, G> = SpinLockGuard_<T, Arc<SpinLock<T, G>>, G>;
 pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> {
     guard: G::Guard,
     lock: R,
+}
+
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> SpinLockGuard_<T, R, G> {
+    /// Returns a reference to the guard.
+    pub fn guard(&self) -> &G::Guard {
+        &self.guard
+    }
 }
 
 impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> Deref for SpinLockGuard_<T, R, G> {


### PR DESCRIPTION
#752 is stale ~~and I want to revive it for VMA scalability experiments.~~

I skimmed through the implementation in #752 and found `RcuReclaimer` really suspicious. It should be a linear type that registers itself to the monitor when it goes out of scope. But if the caller of `replace` don't call `delay` on the returned reclaimer the ~~pointer is immediately dropped and it becomes unsafe~~ it waits on drop. So I adjusted it according to my understanding.

And I also added the `try_compare_update` method and the `LazyRcu` to make it actually useful.

~~I may find further usages to it.~~ call back vectors are excellent candidates, refactoring:

 - The third commit uses the lazy RCU to implement the softirq callbacks;
 - The fourth commits uses RCU to implement the console callbacks.
