### PR TITLE
Rename `get_user_space` to `user_space`

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -26,7 +26,7 @@ pub struct Context<'a> {
 
 impl Context<'_> {
     /// Gets the userspace of the current task.
-    pub fn get_user_space(&self) -> CurrentUserSpace {
+    pub fn user_space(&self) -> CurrentUserSpace {
         CurrentUserSpace::new(self.task)
     }
 }
@@ -38,7 +38,7 @@ pub struct CurrentUserSpace<'a>(&'a VmSpace);
 
 /// Gets the [`CurrentUserSpace`] from the current task.
 ///
-/// This is slower than [`Context::get_user_space`]. Don't use this getter
+/// This is slower than [`Context::user_space`]. Don't use this getter
 /// If you get the access to the [`Context`].
 #[macro_export]
 macro_rules! get_current_userspace {
@@ -53,7 +53,7 @@ impl<'a> CurrentUserSpace<'a> {
     /// This method is _not_ recommended for use, as it does not verify whether the provided
     /// `task` is the current task in release builds.
     ///
-    /// If you have access to a [`Context`], it is preferable to call [`Context::get_user_space`].
+    /// If you have access to a [`Context`], it is preferable to call [`Context::user_space`].
     ///
     /// Otherwise, you can use the `get_current_userspace` macro
     /// to obtain an instance of `CurrentUserSpace` if it will only be used once.

--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -41,7 +41,7 @@ pub struct CurrentUserSpace<'a>(&'a VmSpace);
 /// This is slower than [`Context::user_space`]. Don't use this getter
 /// If you get the access to the [`Context`].
 #[macro_export]
-macro_rules! get_current_userspace {
+macro_rules! current_userspace {
     () => {
         CurrentUserSpace::new(&ostd::task::Task::current().unwrap())
     };
@@ -55,7 +55,7 @@ impl<'a> CurrentUserSpace<'a> {
     ///
     /// If you have access to a [`Context`], it is preferable to call [`Context::user_space`].
     ///
-    /// Otherwise, you can use the `get_current_userspace` macro
+    /// Otherwise, you can use the `current_userspace` macro
     /// to obtain an instance of `CurrentUserSpace` if it will only be used once.
     ///
     /// # Panics

--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -3,6 +3,7 @@
 use alloc::format;
 
 use crate::{
+    current_userspace,
     device::tty::{line_discipline::LineDiscipline, new_job_control_and_ldisc},
     events::IoEvents,
     fs::{
@@ -13,7 +14,6 @@ use crate::{
         inode_handle::FileIo,
         utils::{AccessMode, Inode, InodeMode, IoctlCmd},
     },
-    get_current_userspace,
     prelude::*,
     process::{
         signal::{PollHandle, Pollable, Pollee},
@@ -165,11 +165,11 @@ impl FileIo for PtyMaster {
         match cmd {
             IoctlCmd::TCGETS => {
                 let termios = self.output.termios();
-                get_current_userspace!().write_val(arg, &termios)?;
+                current_userspace!().write_val(arg, &termios)?;
                 Ok(0)
             }
             IoctlCmd::TCSETS => {
-                let termios = get_current_userspace!().read_val(arg)?;
+                let termios = current_userspace!().read_val(arg)?;
                 self.output.set_termios(termios);
                 Ok(0)
             }
@@ -179,7 +179,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGPTN => {
                 let idx = self.index();
-                get_current_userspace!().write_val(arg, &idx)?;
+                current_userspace!().write_val(arg, &idx)?;
                 Ok(0)
             }
             IoctlCmd::TIOCGPTPEER => {
@@ -212,11 +212,11 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::TIOCGWINSZ => {
                 let winsize = self.output.window_size();
-                get_current_userspace!().write_val(arg, &winsize)?;
+                current_userspace!().write_val(arg, &winsize)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSWINSZ => {
-                let winsize = get_current_userspace!().read_val(arg)?;
+                let winsize = current_userspace!().read_val(arg)?;
                 self.output.set_window_size(winsize);
                 Ok(0)
             }
@@ -228,12 +228,12 @@ impl FileIo for PtyMaster {
                     );
                 };
                 let fg_pgid = foreground.pgid();
-                get_current_userspace!().write_val(arg, &fg_pgid)?;
+                current_userspace!().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = get_current_userspace!().read_val(arg)?;
+                    let pgid: i32 = current_userspace!().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -253,7 +253,7 @@ impl FileIo for PtyMaster {
             }
             IoctlCmd::FIONREAD => {
                 let len = self.input.lock().len() as i32;
-                get_current_userspace!().write_val(arg, &len)?;
+                current_userspace!().write_val(arg, &len)?;
                 Ok(0)
             }
             _ => Ok(0),
@@ -376,12 +376,12 @@ impl FileIo for PtySlave {
                 };
 
                 let fg_pgid = foreground.pgid();
-                get_current_userspace!().write_val(arg, &fg_pgid)?;
+                current_userspace!().write_val(arg, &fg_pgid)?;
                 Ok(0)
             }
             IoctlCmd::TIOCSPGRP => {
                 let pgid = {
-                    let pgid: i32 = get_current_userspace!().read_val(arg)?;
+                    let pgid: i32 = current_userspace!().read_val(arg)?;
                     if pgid < 0 {
                         return_errno_with_message!(Errno::EINVAL, "negative pgid");
                     }
@@ -401,7 +401,7 @@ impl FileIo for PtySlave {
             }
             IoctlCmd::FIONREAD => {
                 let buffer_len = self.master().slave_buf_len() as i32;
-                get_current_userspace!().write_val(arg, &buffer_len)?;
+                current_userspace!().write_val(arg, &buffer_len)?;
                 Ok(0)
             }
             _ => Ok(0),

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -17,8 +17,8 @@ use super::{
 };
 use crate::{
     cpu::LinuxAbi,
+    current_userspace,
     fs::{file_table::FileTable, fs_resolver::FsResolver, utils::FileCreationMask},
-    get_current_userspace,
     prelude::*,
     process::posix_thread::allocate_posix_tid,
     thread::{AsThread, Tid},
@@ -392,7 +392,7 @@ fn clone_parent_settid(
     if let Some(addr) =
         parent_tidptr.filter(|_| clone_flags.contains(CloneFlags::CLONE_PARENT_SETTID))
     {
-        get_current_userspace!().write_val(addr, &child_tid)?;
+        current_userspace!().write_val(addr, &child_tid)?;
     }
     Ok(())
 }

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -2,7 +2,7 @@
 
 use super::{futex::futex_wake, robust_list::wake_robust_futex, thread_table, PosixThread};
 use crate::{
-    get_current_userspace,
+    current_userspace,
     prelude::*,
     process::{do_exit_group, TermStatus},
     thread::{Thread, Tid},
@@ -25,7 +25,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     // If clear_ctid !=0 ,do a futex wake and write zero to the clear_ctid addr.
     if *clear_ctid != 0 {
         // FIXME: the correct write length?
-        if let Err(e) = get_current_userspace!().write_val(*clear_ctid, &0u32) {
+        if let Err(e) = current_userspace!().write_val(*clear_ctid, &0u32) {
             debug!("Ignore error during exit process: {:?}", e);
         }
         futex_wake(*clear_ctid, 1, None)?;

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -350,7 +350,7 @@ impl FutexKey {
     pub fn load_val(&self, ctx: &Context) -> Result<i32> {
         // FIXME: how to implement a atomic load?
         warn!("implement an atomic load");
-        ctx.get_user_space().read_val(self.addr)
+        ctx.user_space().read_val(self.addr)
     }
 
     pub fn addr(&self) -> Vaddr {

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -4,9 +4,7 @@
 
 use ostd::task::Task;
 
-use crate::{
-    get_current_userspace, prelude::*, process::posix_thread::futex::futex_wake, thread::Tid,
-};
+use crate::{current_userspace, prelude::*, process::posix_thread::futex::futex_wake, thread::Tid};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
@@ -105,7 +103,7 @@ impl Iterator for FutexIter<'_> {
             } else {
                 None
             };
-            let Ok(robust_list) = get_current_userspace!().read_val::<RobustList>(self.entry_ptr)
+            let Ok(robust_list) = current_userspace!().read_val::<RobustList>(self.entry_ptr)
             else {
                 return None;
             };

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -159,7 +159,7 @@ pub fn handle_user_signal(
     // To avoid corrupting signal stack, we minus 128 first.
     stack_pointer -= 128;
 
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     // 1. write siginfo_t
     stack_pointer -= mem::size_of::<siginfo_t>() as u64;

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -28,7 +28,7 @@ pub use sig_stack::{SigStack, SigStackFlags};
 
 use super::posix_thread::PosixThread;
 use crate::{
-    get_current_userspace,
+    current_userspace,
     prelude::*,
     process::{do_exit_group, TermStatus},
 };
@@ -249,7 +249,7 @@ fn use_alternate_signal_stack(posix_thread: &PosixThread) -> Option<usize> {
 
 fn write_u64_to_user_stack(rsp: u64, value: u64) -> Result<u64> {
     let rsp = rsp - 8;
-    get_current_userspace!().write_val(rsp as Vaddr, &value)?;
+    current_userspace!().write_val(rsp as Vaddr, &value)?;
     Ok(rsp)
 }
 

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -60,7 +60,7 @@ pub fn do_faccessat(
     let flags = FaccessatFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "Invalid flags"))?;
 
-    let path = ctx.get_user_space().read_cstring(path_ptr, PATH_MAX)?;
+    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
     debug!(
         "dirfd = {}, path = {:?}, mode = {:o}, flags = {:?}",
         dirfd, path, mode, flags

--- a/kernel/src/syscall/capget.rs
+++ b/kernel/src/syscall/capget.rs
@@ -13,7 +13,7 @@ pub fn sys_capget(
     cap_user_data_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let cap_user_header: cap_user_header_t =
         user_space.read_val::<cap_user_header_t>(cap_user_header_addr)?;
 

--- a/kernel/src/syscall/capset.rs
+++ b/kernel/src/syscall/capset.rs
@@ -18,7 +18,7 @@ pub fn sys_capset(
     cap_user_data_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let cap_user_header: cap_user_header_t =
         user_space.read_val::<cap_user_header_t>(cap_user_header_addr)?;
 

--- a/kernel/src/syscall/chdir.rs
+++ b/kernel/src/syscall/chdir.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 
 pub fn sys_chdir(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_ptr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
     let mut fs = ctx.process.fs().write();

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -33,7 +33,7 @@ pub fn sys_fchmodat(
     /* flags: u32, */
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx.get_user_space().read_cstring(path_ptr, PATH_MAX)?;
+    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
     debug!("dirfd = {}, path = {:?}, mode = 0o{:o}", dirfd, path, mode,);
 
     let dentry = {

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -56,7 +56,7 @@ pub fn sys_fchownat(
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx.get_user_space().read_cstring(path_ptr, PATH_MAX)?;
+    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
     let flags = ChownFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(

--- a/kernel/src/syscall/chroot.rs
+++ b/kernel/src/syscall/chroot.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 
 pub fn sys_chroot(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_ptr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
     let mut fs = ctx.process.fs().write();

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -31,7 +31,7 @@ pub fn sys_clock_gettime(
     let time_duration = read_clock(clockid, ctx)?;
 
     let timespec = timespec_t::from(time_duration);
-    ctx.get_user_space().write_val(timespec_addr, &timespec)?;
+    ctx.user_space().write_val(timespec_addr, &timespec)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -43,7 +43,7 @@ pub fn sys_clone3(
     }
 
     let clone_args = {
-        let args: Clone3Args = ctx.get_user_space().read_val(clong_args_addr)?;
+        let args: Clone3Args = ctx.user_space().read_val(clong_args_addr)?;
         trace!("clone3 args = {:x?}", args);
         CloneArgs::from(args)
     };

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -64,14 +64,14 @@ pub fn sys_epoll_ctl(
 
     let cmd = match op {
         EPOLL_CTL_ADD => {
-            let c_epoll_event = ctx.get_user_space().read_val::<c_epoll_event>(event_addr)?;
+            let c_epoll_event = ctx.user_space().read_val::<c_epoll_event>(event_addr)?;
             let event = EpollEvent::from(&c_epoll_event);
             let flags = EpollFlags::from_bits_truncate(c_epoll_event.events);
             EpollCtl::Add(fd, event, flags)
         }
         EPOLL_CTL_DEL => EpollCtl::Del(fd),
         EPOLL_CTL_MOD => {
-            let c_epoll_event = ctx.get_user_space().read_val::<c_epoll_event>(event_addr)?;
+            let c_epoll_event = ctx.user_space().read_val::<c_epoll_event>(event_addr)?;
             let event = EpollEvent::from(&c_epoll_event);
             let flags = EpollFlags::from_bits_truncate(c_epoll_event.events);
             EpollCtl::Mod(fd, event, flags)
@@ -147,7 +147,7 @@ pub fn sys_epoll_wait(
 
     // Write back
     let mut write_addr = events_addr;
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     for epoll_event in epoll_events.iter() {
         let c_epoll_event = c_epoll_event::from(epoll_event);
         user_space.write_val(write_addr, &c_epoll_event)?;
@@ -159,7 +159,7 @@ pub fn sys_epoll_wait(
 
 fn set_signal_mask(set_ptr: Vaddr, ctx: &Context) -> Result<SigMask> {
     let new_mask: Option<SigMask> = if set_ptr != 0 {
-        Some(ctx.get_user_space().read_val::<u64>(set_ptr)?.into())
+        Some(ctx.user_space().read_val::<u64>(set_ptr)?.into())
     } else {
         None
     };
@@ -215,7 +215,7 @@ pub fn sys_epoll_pwait(
 
     // Write back
     let mut write_addr = events_addr;
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     for event in ready_events.iter() {
         let c_event = c_epoll_event::from(event);
         user_space.write_val(write_addr, &c_event)?;

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -153,7 +153,7 @@ bitflags::bitflags! {
 
 fn read_filename(filename_ptr: Vaddr, ctx: &Context) -> Result<String> {
     let filename = ctx
-        .get_user_space()
+        .user_space()
         .read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
     Ok(filename.into_string().unwrap())
 }
@@ -171,7 +171,7 @@ fn read_cstring_vec(
     }
     let mut read_addr = array_ptr;
     let mut find_null = false;
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     for _ in 0..max_string_number {
         let cstring_ptr = user_space.read_val::<usize>(read_addr)?;
         read_addr += 8;

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -92,7 +92,7 @@ fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
         file_table.get_file(fd)?.clone()
     };
     let lock_mut_ptr = arg as Vaddr;
-    let mut lock_mut_c = ctx.get_user_space().read_val::<c_flock>(lock_mut_ptr)?;
+    let mut lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
     if lock_type == RangeLockType::Unlock {
         return_errno_with_message!(Errno::EINVAL, "invalid flock type for getlk");
@@ -106,7 +106,7 @@ fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
         .ok_or(Error::with_message(Errno::EBADF, "not inode"))?;
     lock = inode_file.test_range_lock(lock)?;
     lock_mut_c.copy_from_range_lock(&lock);
-    ctx.get_user_space().write_val(lock_mut_ptr, &lock_mut_c)?;
+    ctx.user_space().write_val(lock_mut_ptr, &lock_mut_c)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -121,7 +121,7 @@ fn handle_setlk(
         file_table.get_file(fd)?.clone()
     };
     let lock_mut_ptr = arg as Vaddr;
-    let lock_mut_c = ctx.get_user_space().read_val::<c_flock>(lock_mut_ptr)?;
+    let lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
     let lock = RangeLockItemBuilder::new()
         .type_(lock_type)

--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -3,7 +3,7 @@
 use core::time::Duration;
 
 use crate::{
-    get_current_userspace,
+    current_userspace,
     prelude::*,
     process::posix_thread::futex::{
         futex_op_and_flags_from_u32, futex_requeue, futex_wait, futex_wait_bitset, futex_wake,
@@ -46,7 +46,7 @@ pub fn sys_futex(
         }
 
         let timeout = {
-            let time_spec: timespec_t = get_current_userspace!().read_val(timeout_addr)?;
+            let time_spec: timespec_t = current_userspace!().read_val(timeout_addr)?;
             Duration::try_from(time_spec)?
         };
 

--- a/kernel/src/syscall/getcwd.rs
+++ b/kernel/src/syscall/getcwd.rs
@@ -20,7 +20,7 @@ pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn
     let cwd = CString::new(name)?;
     let bytes = cwd.as_bytes_with_nul();
     let write_len = len.min(bytes.len());
-    ctx.get_user_space()
+    ctx.user_space()
         .write_bytes(buf, &mut VmReader::from(&bytes[..write_len]))?;
 
     Ok(SyscallReturn::Return(write_len as _))

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -37,7 +37,7 @@ pub fn sys_getdents(
     let mut reader = DirentBufferReader::<Dirent>::new(&mut buffer); // Use the non-64-bit reader
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    ctx.get_user_space()
+    ctx.user_space()
         .write_bytes(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }
@@ -67,7 +67,7 @@ pub fn sys_getdents64(
     let mut reader = DirentBufferReader::<Dirent64>::new(&mut buffer);
     let _ = inode_handle.readdir(&mut reader)?;
     let read_len = reader.read_len();
-    ctx.get_user_space()
+    ctx.user_space()
         .write_bytes(buf_addr, &mut VmReader::from(&buffer[..read_len]))?;
     Ok(SyscallReturn::Return(read_len as _))
 }

--- a/kernel/src/syscall/getgroups.rs
+++ b/kernel/src/syscall/getgroups.rs
@@ -24,7 +24,7 @@ pub fn sys_getgroups(size: i32, group_list_addr: Vaddr, ctx: &Context) -> Result
         );
     }
 
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     for (idx, gid) in groups.iter().enumerate() {
         let addr = group_list_addr + idx * core::mem::size_of_val(gid);
         user_space.write_val(addr, gid)?;

--- a/kernel/src/syscall/getrandom.rs
+++ b/kernel/src/syscall/getrandom.rs
@@ -17,7 +17,7 @@ pub fn sys_getrandom(buf: Vaddr, count: usize, flags: u32, ctx: &Context) -> Res
     } else {
         device::Urandom::getrandom(&mut buffer)?
     };
-    ctx.get_user_space()
+    ctx.user_space()
         .write_bytes(buf, &mut VmReader::from(buffer.as_slice()))?;
     Ok(SyscallReturn::Return(read_len as isize))
 }

--- a/kernel/src/syscall/getresgid.rs
+++ b/kernel/src/syscall/getresgid.rs
@@ -12,7 +12,7 @@ pub fn sys_getresgid(
     debug!("rgid_ptr = 0x{rgid_ptr:x}, egid_ptr = 0x{egid_ptr:x}, sgid_ptr = 0x{sgid_ptr:x}");
 
     let credentials = ctx.posix_thread.credentials();
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     let rgid = credentials.rgid();
     user_space.write_val(rgid_ptr, &rgid)?;

--- a/kernel/src/syscall/getresuid.rs
+++ b/kernel/src/syscall/getresuid.rs
@@ -12,7 +12,7 @@ pub fn sys_getresuid(
     debug!("ruid_ptr = 0x{ruid_ptr:x}, euid_ptr = 0x{euid_ptr:x}, suid_ptr = 0x{suid_ptr:x}");
 
     let credentials = ctx.posix_thread.credentials();
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     let ruid = credentials.ruid();
     user_space.write_val(ruid_ptr, &ruid)?;

--- a/kernel/src/syscall/getrusage.rs
+++ b/kernel/src/syscall/getrusage.rs
@@ -48,7 +48,7 @@ pub fn sys_getrusage(target: i32, rusage_addr: Vaddr, ctx: &Context) -> Result<S
             }
         };
 
-        ctx.get_user_space().write_val(rusage_addr, &rusage)?;
+        ctx.user_space().write_val(rusage_addr, &rusage)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/getsockopt.rs
+++ b/kernel/src/syscall/getsockopt.rs
@@ -19,7 +19,7 @@ pub fn sys_getsockopt(
     if optval == 0 || optlen_addr == 0 {
         return_errno_with_message!(Errno::EINVAL, "optval or optlen_addr is null pointer");
     }
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     let optlen: u32 = user_space.read_val(optlen_addr)?;
     debug!("level = {level:?}, sockfd = {sockfd}, optname = {optname:?}, optlen = {optlen}");

--- a/kernel/src/syscall/gettimeofday.rs
+++ b/kernel/src/syscall/gettimeofday.rs
@@ -21,7 +21,7 @@ pub fn sys_gettimeofday(
         let time_duration = now.duration_since(&SystemTime::UNIX_EPOCH)?;
         timeval_t::from(time_duration)
     };
-    ctx.get_user_space().write_val(timeval_addr, &time_val)?;
+    ctx.user_space().write_val(timeval_addr, &time_val)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -22,14 +22,14 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr, ctx: &Context) -> Result<Sy
     };
     let res = match ioctl_cmd {
         IoctlCmd::FIONBIO => {
-            let is_nonblocking = ctx.get_user_space().read_val::<i32>(arg)? != 0;
+            let is_nonblocking = ctx.user_space().read_val::<i32>(arg)? != 0;
             let mut flags = file.status_flags();
             flags.set(StatusFlags::O_NONBLOCK, is_nonblocking);
             file.set_status_flags(flags)?;
             0
         }
         IoctlCmd::FIOASYNC => {
-            let is_async = ctx.get_user_space().read_val::<i32>(arg)? != 0;
+            let is_async = ctx.user_space().read_val::<i32>(arg)? != 0;
             let mut flags = file.status_flags();
 
             // Set `O_ASYNC` flags will send `SIGIO` signal to a process when

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -18,7 +18,7 @@ pub fn sys_linkat(
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     let old_path = user_space.read_cstring(old_path_addr, MAX_FILENAME_LEN)?;
     let new_path = user_space.read_cstring(new_path_addr, MAX_FILENAME_LEN)?;

--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -38,7 +38,7 @@ pub fn sys_madvise(
         | MadviseBehavior::MADV_WILLNEED => {
             // perform a read at first
             let mut buffer = vec![0u8; len];
-            ctx.get_user_space()
+            ctx.user_space()
                 .read_bytes(start, &mut VmWriter::from(buffer.as_mut_slice()))?;
         }
         MadviseBehavior::MADV_DONTNEED => {

--- a/kernel/src/syscall/mkdir.rs
+++ b/kernel/src/syscall/mkdir.rs
@@ -17,9 +17,7 @@ pub fn sys_mkdirat(
     mode: u16,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}, mode = {}", dirfd, path, mode);
 
     let current = ctx.process;

--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -19,9 +19,7 @@ pub fn sys_mknodat(
     dev: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     let current = ctx.process;
     let inode_mode = {
         let mask_mode = mode & !current.umask().read().get();

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -25,7 +25,7 @@ pub fn sys_mount(
     data: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let devname = user_space.read_cstring(devname_addr, MAX_FILENAME_LEN)?;
     let dirname = user_space.read_cstring(dirname_addr, MAX_FILENAME_LEN)?;
     let mount_flags = MountFlags::from_bits_truncate(flags as u32);
@@ -142,9 +142,7 @@ fn do_new_mount(
         return_errno_with_message!(Errno::ENOTDIR, "mountpoint must be directory");
     };
 
-    let fs_type = ctx
-        .get_user_space()
-        .read_cstring(fs_type, MAX_FILENAME_LEN)?;
+    let fs_type = ctx.user_space().read_cstring(fs_type, MAX_FILENAME_LEN)?;
     if fs_type.is_empty() {
         return_errno_with_message!(Errno::EINVAL, "fs_type is empty");
     }

--- a/kernel/src/syscall/nanosleep.rs
+++ b/kernel/src/syscall/nanosleep.rs
@@ -66,7 +66,7 @@ fn do_clock_nanosleep(
 ) -> Result<SyscallReturn> {
     let request_time = {
         let timespec = ctx
-            .get_user_space()
+            .user_space()
             .read_val::<timespec_t>(request_timespec_addr)?;
         Duration::try_from(timespec)?
     };
@@ -126,7 +126,7 @@ fn do_clock_nanosleep(
             if remain_timespec_addr != 0 && !is_abs_time {
                 let remaining_duration = (start_time + duration) - end_time;
                 let remaining_timespec = timespec_t::from(remaining_duration);
-                ctx.get_user_space()
+                ctx.user_space()
                     .write_val(remain_timespec_addr, &remaining_timespec)?;
             }
 

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -18,9 +18,7 @@ pub fn sys_openat(
     mode: u16,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "dirfd = {}, path = {:?}, flags = {}, mode = {}",
         dirfd, path, flags, mode

--- a/kernel/src/syscall/pipe.rs
+++ b/kernel/src/syscall/pipe.rs
@@ -29,7 +29,7 @@ pub fn sys_pipe2(fds: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn>
     };
     debug!("pipe_fds: {:?}", pipe_fds);
 
-    if let Err(err) = ctx.get_user_space().write_val(fds, &pipe_fds) {
+    if let Err(err) = ctx.user_space().write_val(fds, &pipe_fds) {
         file_table.close_file(pipe_fds.reader_fd).unwrap();
         file_table.close_file(pipe_fds.writer_fd).unwrap();
         return Err(err);

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
 
     let poll_fds = {
         let mut read_addr = fds;

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -28,7 +28,7 @@ pub fn sys_prctl(
                 }
             };
 
-            ctx.get_user_space().write_val(write_to_addr, &write_val)?;
+            ctx.user_space().write_val(write_to_addr, &write_val)?;
         }
         PrctlCmd::PR_GET_DUMPABLE => {
             // TODO: when coredump is supported, return the actual value
@@ -45,7 +45,7 @@ pub fn sys_prctl(
             let thread_name = ctx.posix_thread.thread_name().lock();
             if let Some(thread_name) = &*thread_name {
                 if let Some(thread_name) = thread_name.name()? {
-                    ctx.get_user_space().write_bytes(
+                    ctx.user_space().write_bytes(
                         write_to_addr,
                         &mut VmReader::from(thread_name.to_bytes_with_nul()),
                     )?;
@@ -56,7 +56,7 @@ pub fn sys_prctl(
             let mut thread_name = ctx.posix_thread.thread_name().lock();
             if let Some(thread_name) = &mut *thread_name {
                 let new_thread_name = ctx
-                    .get_user_space()
+                    .user_space()
                     .read_cstring(read_addr, MAX_THREAD_NAME_LEN)?;
                 thread_name.set_name(&new_thread_name)?;
             }

--- a/kernel/src/syscall/prlimit64.rs
+++ b/kernel/src/syscall/prlimit64.rs
@@ -11,7 +11,7 @@ pub fn sys_getrlimit(resource: u32, rlim_addr: Vaddr, ctx: &Context) -> Result<S
     debug!("resource = {:?}, rlim_addr = 0x{:x}", resource, rlim_addr);
     let resource_limits = ctx.process.resource_limits().lock();
     let rlimit = resource_limits.get_rlimit(resource);
-    ctx.get_user_space().write_val(rlim_addr, rlimit)?;
+    ctx.user_space().write_val(rlim_addr, rlimit)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -21,7 +21,7 @@ pub fn sys_setrlimit(resource: u32, new_rlim_addr: Vaddr, ctx: &Context) -> Resu
         "resource = {:?}, new_rlim_addr = 0x{:x}",
         resource, new_rlim_addr
     );
-    let new_rlimit = ctx.get_user_space().read_val(new_rlim_addr)?;
+    let new_rlimit = ctx.user_space().read_val(new_rlim_addr)?;
     let mut resource_limits = ctx.process.resource_limits().lock();
     *resource_limits.get_rlimit_mut(resource) = new_rlimit;
     Ok(SyscallReturn::Return(0))
@@ -42,10 +42,10 @@ pub fn sys_prlimit64(
     let mut resource_limits = ctx.process.resource_limits().lock();
     if old_rlim_addr != 0 {
         let rlimit = resource_limits.get_rlimit(resource);
-        ctx.get_user_space().write_val(old_rlim_addr, rlimit)?;
+        ctx.user_space().write_val(old_rlim_addr, rlimit)?;
     }
     if new_rlim_addr != 0 {
-        let new_rlimit = ctx.get_user_space().read_val(new_rlim_addr)?;
+        let new_rlimit = ctx.user_space().read_val(new_rlim_addr)?;
         *resource_limits.get_rlimit_mut(resource) = new_rlimit;
     }
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/pselect6.rs
+++ b/kernel/src/syscall/pselect6.rs
@@ -16,7 +16,7 @@ pub fn sys_pselect6(
     sigmask_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let old_simask = if sigmask_addr != 0 {
         let sigmask_with_size: SigMaskWithSize = user_space.read_val(sigmask_addr)?;
 

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -17,7 +17,7 @@ pub fn sys_readlinkat(
     usr_buf_len: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let path = user_space.read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!(
         "dirfd = {}, path = {:?}, usr_buf_addr = 0x{:x}, usr_buf_len = 0x{:x}",

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -14,7 +14,7 @@ pub fn sys_recvmsg(
     flags: i32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let c_user_msghdr: CUserMsgHdr = ctx.get_user_space().read_val(user_msghdr_ptr)?;
+    let c_user_msghdr: CUserMsgHdr = ctx.user_space().read_val(user_msghdr_ptr)?;
     let flags = SendRecvFlags::from_bits_truncate(flags);
 
     debug!(

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -18,7 +18,7 @@ pub fn sys_renameat(
     new_path_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let old_path = user_space.read_cstring(old_path_addr, MAX_FILENAME_LEN)?;
     let new_path = user_space.read_cstring(new_path_addr, MAX_FILENAME_LEN)?;
     debug!(

--- a/kernel/src/syscall/rmdir.rs
+++ b/kernel/src/syscall/rmdir.rs
@@ -19,9 +19,7 @@ pub(super) fn sys_rmdirat(
     path_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path_addr = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path_addr = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path_addr = {:?}", dirfd, path_addr);
 
     let (dir_dentry, name) = {

--- a/kernel/src/syscall/rt_sigaction.rs
+++ b/kernel/src/syscall/rt_sigaction.rs
@@ -29,9 +29,7 @@ pub fn sys_rt_sigaction(
     let mut sig_dispositions = ctx.process.sig_dispositions().lock();
 
     let old_action = if sig_action_addr != 0 {
-        let sig_action_c = ctx
-            .get_user_space()
-            .read_val::<sigaction_t>(sig_action_addr)?;
+        let sig_action_c = ctx.user_space().read_val::<sigaction_t>(sig_action_addr)?;
         let sig_action = SigAction::try_from(sig_action_c).unwrap();
         trace!("sig action = {:?}", sig_action);
         sig_dispositions.set(sig_num, sig_action)
@@ -41,7 +39,7 @@ pub fn sys_rt_sigaction(
 
     if old_sig_action_addr != 0 {
         let old_action_c = old_action.as_c_type();
-        ctx.get_user_space()
+        ctx.user_space()
             .write_val(old_sig_action_addr, &old_action_c)?;
     }
 

--- a/kernel/src/syscall/rt_sigpending.rs
+++ b/kernel/src/syscall/rt_sigpending.rs
@@ -28,7 +28,7 @@ fn do_rt_sigpending(set_ptr: Vaddr, ctx: &Context) -> Result<()> {
         sig_mask_value & sig_pending_value
     };
 
-    ctx.get_user_space()
+    ctx.user_space()
         .write_val(set_ptr, &u64::from(combined_signals))?;
     Ok(())
 }

--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -39,13 +39,13 @@ fn do_rt_sigprocmask(
     let old_sig_mask_value = ctx.posix_thread.sig_mask().load(Ordering::Relaxed);
     debug!("old sig mask value: 0x{:x}", old_sig_mask_value);
     if oldset_ptr != 0 {
-        ctx.get_user_space()
+        ctx.user_space()
             .write_val(oldset_ptr, &old_sig_mask_value)?;
     }
 
     let sig_mask_ref = ctx.posix_thread.sig_mask();
     if set_ptr != 0 {
-        let mut read_mask = ctx.get_user_space().read_val::<SigMask>(set_ptr)?;
+        let mut read_mask = ctx.user_space().read_val::<SigMask>(set_ptr)?;
         match mask_op {
             MaskOp::Block => {
                 // According to man pages, "it is not possible to block SIGKILL or SIGSTOP.

--- a/kernel/src/syscall/rt_sigreturn.rs
+++ b/kernel/src/syscall/rt_sigreturn.rs
@@ -24,9 +24,7 @@ pub fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Result<Sys
     // However, for most glibc applications, the restorer codes is provided by glibc and RESTORER flag is set.
     debug_assert!(sig_context_addr == user_ctx.stack_pointer() as Vaddr);
 
-    let ucontext = ctx
-        .get_user_space()
-        .read_val::<ucontext_t>(sig_context_addr)?;
+    let ucontext = ctx.user_space().read_val::<ucontext_t>(sig_context_addr)?;
 
     // If the sig stack is active and used by current handler, decrease handler counter.
     if let Some(sig_stack) = posix_thread.sig_stack().lock().as_mut() {

--- a/kernel/src/syscall/rt_sigsuspend.rs
+++ b/kernel/src/syscall/rt_sigsuspend.rs
@@ -27,7 +27,7 @@ pub fn sys_rt_sigsuspend(
     }
 
     let sigmask = {
-        let mut mask: SigMask = ctx.get_user_space().read_val(sigmask_addr)?;
+        let mut mask: SigMask = ctx.user_space().read_val(sigmask_addr)?;
         // It is not possible to block SIGKILL or SIGSTOP,
         // specifying these signals in mask has no effect.
         mask -= SIGKILL;

--- a/kernel/src/syscall/sched_affinity.rs
+++ b/kernel/src/syscall/sched_affinity.rs
@@ -21,7 +21,7 @@ pub fn sys_sched_getaffinity(
         },
     };
 
-    let bytes_written = write_cpu_set_to(ctx.get_user_space(), &cpu_set, cpuset_size, cpu_set_ptr)?;
+    let bytes_written = write_cpu_set_to(ctx.user_space(), &cpu_set, cpuset_size, cpu_set_ptr)?;
 
     Ok(SyscallReturn::Return(bytes_written as isize))
 }
@@ -36,7 +36,7 @@ pub fn sys_sched_setaffinity(
     cpu_set_ptr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_cpu_set = read_cpu_set_from(ctx.get_user_space(), cpuset_size, cpu_set_ptr)?;
+    let user_cpu_set = read_cpu_set_from(ctx.user_space(), cpuset_size, cpu_set_ptr)?;
 
     match tid {
         0 => ctx.thread.atomic_cpu_affinity().store(&user_cpu_set),

--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -20,7 +20,7 @@ pub fn sys_select(
         None
     } else {
         let timeval = ctx
-            .get_user_space()
+            .user_space()
             .read_val::<timeval_t>(timeval_addr)?
             .normalize();
         Some(Duration::try_from(timeval)?)
@@ -48,7 +48,7 @@ pub fn do_sys_select(
         return_errno_with_message!(Errno::EINVAL, "nfds is negative or exceeds the FD_SETSIZE");
     }
 
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let get_fdset = |fdset_addr: Vaddr| -> Result<Option<FdSet>> {
         let fdset = if fdset_addr == 0 {
             None

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -36,7 +36,7 @@ pub fn sys_semtimedop(
         None
     } else {
         Some(Duration::try_from(
-            ctx.get_user_space().read_val::<timespec_t>(timeout)?,
+            ctx.user_space().read_val::<timespec_t>(timeout)?,
         )?)
     };
 
@@ -57,7 +57,7 @@ fn do_sys_semtimedop(
         return_errno!(Errno::E2BIG);
     }
 
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let mut semops = Vec::with_capacity(nsops);
     for i in 0..nsops {
         semops.push(user_space.read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?);

--- a/kernel/src/syscall/sendfile.rs
+++ b/kernel/src/syscall/sendfile.rs
@@ -15,7 +15,7 @@ pub fn sys_sendfile(
     let offset = if offset_ptr == 0 {
         None
     } else {
-        let offset: isize = ctx.get_user_space().read_val(offset_ptr)?;
+        let offset: isize = ctx.user_space().read_val(offset_ptr)?;
         if offset < 0 {
             return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
         }
@@ -109,8 +109,7 @@ pub fn sys_sendfile(
     }
 
     if let Some(offset) = offset {
-        ctx.get_user_space()
-            .write_val(offset_ptr, &(offset as isize))?;
+        ctx.user_space().write_val(offset_ptr, &(offset as isize))?;
     }
 
     Ok(SyscallReturn::Return(total_len as _))

--- a/kernel/src/syscall/sendmsg.rs
+++ b/kernel/src/syscall/sendmsg.rs
@@ -14,7 +14,7 @@ pub fn sys_sendmsg(
     flags: i32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let c_user_msghdr: CUserMsgHdr = ctx.get_user_space().read_val(user_msghdr_ptr)?;
+    let c_user_msghdr: CUserMsgHdr = ctx.user_space().read_val(user_msghdr_ptr)?;
     let flags = SendRecvFlags::from_bits_truncate(flags);
 
     debug!(

--- a/kernel/src/syscall/set_robust_list.rs
+++ b/kernel/src/syscall/set_robust_list.rs
@@ -18,7 +18,7 @@ pub fn sys_set_robust_list(
             "The len is not equal to the size of robust list head"
         );
     }
-    let robust_list_head: RobustListHead = ctx.get_user_space().read_val(robust_list_head_ptr)?;
+    let robust_list_head: RobustListHead = ctx.user_space().read_val(robust_list_head_ptr)?;
     debug!("{:x?}", robust_list_head);
     let mut robust_list = ctx.posix_thread.robust_list().lock();
     *robust_list = Some(robust_list_head);

--- a/kernel/src/syscall/setgroups.rs
+++ b/kernel/src/syscall/setgroups.rs
@@ -15,7 +15,7 @@ pub fn sys_setgroups(size: usize, group_list_addr: Vaddr, ctx: &Context) -> Resu
     let mut new_groups = BTreeSet::new();
     for idx in 0..size {
         let addr = group_list_addr + idx * core::mem::size_of::<Gid>();
-        let gid = ctx.get_user_space().read_val(addr)?;
+        let gid = ctx.user_space().read_val(addr)?;
         new_groups.insert(gid);
     }
 

--- a/kernel/src/syscall/setitimer.rs
+++ b/kernel/src/syscall/setitimer.rs
@@ -32,7 +32,7 @@ pub fn sys_setitimer(
     if new_itimerval_addr == 0 {
         return_errno_with_message!(Errno::EINVAL, "invalid pointer to new value");
     }
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let new_itimerval = user_space.read_val::<itimerval_t>(new_itimerval_addr)?;
     let interval = Duration::try_from(new_itimerval.it_interval)?;
     let expire_time = Duration::try_from(new_itimerval.it_value)?;
@@ -92,7 +92,7 @@ pub fn sys_getitimer(
         it_interval: interval,
         it_value: remain,
     };
-    ctx.get_user_space().write_val(itimerval_addr, &itimerval)?;
+    ctx.user_space().write_val(itimerval_addr, &itimerval)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/sigaltstack.rs
+++ b/kernel/src/syscall/sigaltstack.rs
@@ -40,7 +40,7 @@ fn get_old_stack(
         debug!("old stack = {:?}", old_stack);
 
         let stack = stack_t::from(old_stack.clone());
-        ctx.get_user_space()
+        ctx.user_space()
             .write_val::<stack_t>(old_sig_stack_addr, &stack)?;
     } else {
         let stack = stack_t {
@@ -48,7 +48,7 @@ fn get_old_stack(
             flags: SigStackFlags::SS_DISABLE.bits() as i32,
             size: 0,
         };
-        ctx.get_user_space()
+        ctx.user_space()
             .write_val::<stack_t>(old_sig_stack_addr, &stack)?;
     }
 
@@ -67,7 +67,7 @@ fn set_new_stack(sig_stack_addr: Vaddr, old_stack: Option<&SigStack>, ctx: &Cont
     }
 
     let new_stack = {
-        let stack = ctx.get_user_space().read_val::<stack_t>(sig_stack_addr)?;
+        let stack = ctx.user_space().read_val::<stack_t>(sig_stack_addr)?;
         SigStack::try_from(stack)?
     };
 

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -48,7 +48,7 @@ pub fn sys_socketpair(
         SocketFds(fd_a, fd_b)
     };
 
-    ctx.get_user_space().write_val(sv, &socket_fds)?;
+    ctx.user_space().write_val(sv, &socket_fds)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -21,7 +21,7 @@ pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Result<Sys
     };
 
     let stat = Stat::from(file.metadata());
-    ctx.get_user_space().write_val(stat_buf_ptr, &stat)?;
+    ctx.user_space().write_val(stat_buf_ptr, &stat)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -46,7 +46,7 @@ pub fn sys_fstatat(
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let filename = user_space.read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
     let flags =
         StatFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let path = user_space.read_cstring(path_ptr, PATH_MAX)?;
     debug!("path = {:?}, statfs_buf_ptr = 0x{:x}", path, statfs_buf_ptr,);
 
@@ -39,7 +39,7 @@ pub fn sys_fstatfs(fd: FileDesc, statfs_buf_ptr: Vaddr, ctx: &Context) -> Result
     };
 
     let statfs = Statfs::from(fs.sb());
-    ctx.get_user_space().write_val(statfs_buf_ptr, &statfs)?;
+    ctx.user_space().write_val(statfs_buf_ptr, &statfs)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -17,7 +17,7 @@ pub fn sys_symlinkat(
     linkpath_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let target = user_space.read_cstring(target_addr, MAX_FILENAME_LEN)?;
     let linkpath = user_space.read_cstring(linkpath_addr, MAX_FILENAME_LEN)?;
     debug!(

--- a/kernel/src/syscall/time.rs
+++ b/kernel/src/syscall/time.rs
@@ -12,7 +12,7 @@ pub fn sys_time(tloc: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     };
 
     if tloc != 0 {
-        ctx.get_user_space().write_val(tloc, &now_as_secs)?;
+        ctx.user_space().write_val(tloc, &now_as_secs)?;
     }
 
     Ok(SyscallReturn::Return(now_as_secs as _))

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -48,7 +48,7 @@ pub fn sys_timer_create(
             })
         // Determine the timeout action through `sigevent`.
         } else {
-            let sig_event = ctx.get_user_space().read_val::<sigevent_t>(sigevent_addr)?;
+            let sig_event = ctx.user_space().read_val::<sigevent_t>(sigevent_addr)?;
             let sigev_notify = SigNotify::try_from(sig_event.sigev_notify)?;
             let signo = sig_event.sigev_signo;
             match sigev_notify {
@@ -143,7 +143,7 @@ pub fn sys_timer_create(
     };
 
     let timer_id = process_timer_manager.add_posix_timer(timer);
-    ctx.get_user_space().write_val(timer_id_addr, &timer_id)?;
+    ctx.user_space().write_val(timer_id_addr, &timer_id)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/timer_settime.rs
+++ b/kernel/src/syscall/timer_settime.rs
@@ -19,7 +19,7 @@ pub fn sys_timer_settime(
         return_errno_with_message!(Errno::EINVAL, "invalid pointer to new value");
     }
 
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let new_itimerspec = user_space.read_val::<itimerspec_t>(new_itimerspec_addr)?;
     let interval = Duration::try_from(new_itimerspec.it_interval)?;
     let expire_time = Duration::try_from(new_itimerspec.it_value)?;
@@ -74,8 +74,7 @@ pub fn sys_timer_gettime(
         it_interval: interval,
         it_value: remain,
     };
-    ctx.get_user_space()
-        .write_val(itimerspec_addr, &itimerspec)?;
+    ctx.user_space().write_val(itimerspec_addr, &itimerspec)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -26,7 +26,7 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize, ctx: &Context) -> Result<SyscallR
 }
 
 pub fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result<SyscallReturn> {
-    let path = ctx.get_user_space().read_cstring(path_ptr, PATH_MAX)?;
+    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
     debug!("path = {:?}, length = {}", path, len);
 
     check_length(len, ctx)?;

--- a/kernel/src/syscall/umount.rs
+++ b/kernel/src/syscall/umount.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 
 pub fn sys_umount(path_addr: Vaddr, flags: u64, ctx: &Context) -> Result<SyscallReturn> {
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     let umount_flags = UmountFlags::from_bits_truncate(flags as u32);
     debug!("path = {:?}, flags = {:?}", path, umount_flags);
 

--- a/kernel/src/syscall/uname.rs
+++ b/kernel/src/syscall/uname.rs
@@ -59,6 +59,6 @@ fn copy_cstring_to_u8_slice(src: &CStr, dst: &mut [u8]) {
 
 pub fn sys_uname(old_uname_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("old uname addr = 0x{:x}", old_uname_addr);
-    ctx.get_user_space().write_val(old_uname_addr, &*UTS_NAME)?;
+    ctx.user_space().write_val(old_uname_addr, &*UTS_NAME)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -22,9 +22,7 @@ pub fn sys_unlinkat(
         return super::rmdir::sys_rmdirat(dirfd, path_addr, ctx);
     }
 
-    let path = ctx
-        .get_user_space()
-        .read_cstring(path_addr, MAX_FILENAME_LEN)?;
+    let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!("dirfd = {}, path = {:?}", dirfd, path);
 
     let (dir_dentry, name) = {

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -78,7 +78,7 @@ pub fn sys_utime(pathname_ptr: Vaddr, utimbuf_ptr: Vaddr, ctx: &Context) -> Resu
         pathname_ptr, utimbuf_ptr
     );
     let times = if utimbuf_ptr != 0 {
-        let utimbuf = ctx.get_user_space().read_val::<Utimbuf>(utimbuf_ptr)?;
+        let utimbuf = ctx.user_space().read_val::<Utimbuf>(utimbuf_ptr)?;
         let atime = timespec_t {
             sec: utimbuf.actime,
             nsec: 0,
@@ -161,7 +161,7 @@ fn do_utimes(
         String::new()
     } else {
         let cstring = ctx
-            .get_user_space()
+            .user_space()
             .read_cstring(pathname_ptr, MAX_FILENAME_LEN)?;
         cstring.to_string_lossy().into_owned()
     };
@@ -211,7 +211,7 @@ fn do_futimesat(
 
 fn read_time_from_user<T: Pod>(time_ptr: Vaddr, ctx: &Context) -> Result<(T, T)> {
     let mut time_addr = time_ptr;
-    let user_space = ctx.get_user_space();
+    let user_space = ctx.user_space();
     let autime = user_space.read_val::<T>(time_addr)?;
     time_addr += core::mem::size_of::<T>();
     let mutime = user_space.read_val::<T>(time_addr)?;

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -29,7 +29,7 @@ pub fn sys_wait4(
 
     let (return_pid, exit_code) = (process.pid(), process.exit_code());
     if exit_status_ptr != 0 {
-        ctx.get_user_space()
+        ctx.user_space()
             .write_val(exit_status_ptr as _, &exit_code)?;
     }
 
@@ -40,7 +40,7 @@ pub fn sys_wait4(
             ..Default::default()
         };
 
-        ctx.get_user_space().write_val(rusage_addr, &rusage)?;
+        ctx.user_space().write_val(rusage_addr, &rusage)?;
     }
 
     Ok(SyscallReturn::Return(return_pid as _))

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -8,7 +8,7 @@ use ostd::{
 use super::{oops, Thread};
 use crate::{
     cpu::LinuxAbi,
-    get_current_userspace,
+    current_userspace,
     prelude::*,
     process::{posix_thread::AsPosixThread, signal::handle_pending_signal},
     syscall::handle_syscall,
@@ -47,7 +47,7 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
         // Make sure the store operation completes before the clone call returns control to user space
         // in the child process.
         if is_userspace_vaddr(child_tid_ptr) {
-            get_current_userspace!()
+            current_userspace!()
                 .write_val(child_tid_ptr, &current_posix_thread.tid())
                 .unwrap();
         }

--- a/kernel/src/util/net/addr/family.rs
+++ b/kernel/src/util/net/addr/family.rs
@@ -5,7 +5,7 @@ use core::cmp::min;
 use ostd::task::Task;
 
 use super::{ip::CSocketAddrInet, unix, vsock::CSocketAddrVm};
-use crate::{get_current_userspace, net::socket::SocketAddr, prelude::*};
+use crate::{current_userspace, net::socket::SocketAddr, prelude::*};
 
 /// Address family.
 ///
@@ -146,7 +146,7 @@ pub fn read_socket_addr_from_user(addr: Vaddr, addr_len: usize) -> Result<Socket
     }
 
     let mut storage = Storage::new_zeroed();
-    get_current_userspace!().read_bytes(
+    current_userspace!().read_bytes(
         addr,
         &mut VmWriter::from(&mut storage.as_bytes_mut()[..addr_len]),
     )?;


### PR DESCRIPTION
 - Rename `Context::get_user_space` to `Context::user_space`
 - Rename `get_current_userspace!()` to `current_userspace!()`

Not sure why we have a `get` here? It does not seem necessary. 

After all, `Context::user_space` is more consistent with `Task::user_space`, and `current_userspace!()` is more consistent with `current!()`.