### PR TITLE
Make POSIX thread caller aware of belonged process death

### DIFF
--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -78,7 +78,7 @@ pub fn tgkill(tid: Tid, tgid: Pid, signal: Option<UserSignal>, ctx: &Context) ->
     let posix_thread = thread.as_posix_thread().unwrap();
 
     // Check tgid
-    let pid = posix_thread.process().pid();
+    let pid = posix_thread.process().unwrap().pid();
     if pid != tgid {
         return_errno_with_message!(
             Errno::EINVAL,

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -35,7 +35,8 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
     // exit the robust list: walk the robust list; mark futex words as dead and do futex wake
     wake_robust_list(posix_thread, tid);
 
-    if tid != posix_thread.process().pid() {
+    let process = posix_thread.process().unwrap();
+    if tid != process.pid() {
         // We don't remove main thread.
         // The main thread is removed when the process is reaped.
         thread_table::remove_thread(tid);
@@ -46,7 +47,7 @@ pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermSta
         do_exit_group(term_status);
     }
 
-    futex_wake(Arc::as_ptr(&posix_thread.process()) as Vaddr, 1, None)?;
+    futex_wake(Arc::as_ptr(&process) as Vaddr, 1, None)?;
     Ok(())
 }
 

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -174,7 +174,7 @@ impl Process {
     ///  - the function is called in the bootstrap context;
     ///  - or if the current task is not associated with a process.
     pub fn current() -> Option<Arc<Process>> {
-        Some(Task::current()?.as_posix_thread()?.process())
+        Task::current()?.as_posix_thread()?.process()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -42,7 +42,9 @@ fn update_cpu_time() {
     let Some(posix_thread) = current_thread.as_posix_thread() else {
         return;
     };
-    let process = posix_thread.process();
+    let Some(process) = posix_thread.process() else {
+        return;
+    };
     let timer_manager = process.timer_manager();
     let jiffies_interval = Duration::from_millis(1000 / TIMER_FREQ);
     // Based on whether the timer interrupt occurs in kernel mode or user mode,

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -55,7 +55,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) -> Resul
 
     let sig_num = signal.num();
     trace!("sig_num = {:?}, sig_name = {}", sig_num, sig_num.sig_name());
-    let current = posix_thread.process();
+    let current = posix_thread.process().unwrap();
     let mut sig_dispositions = current.sig_dispositions().lock();
     let sig_action = sig_dispositions.get(sig_num);
     trace!("sig action: {:x?}", sig_action);

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -21,7 +21,11 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
     fn user_task_entry() {
         let current_thread = current_thread!();
         let current_posix_thread = current_thread.as_posix_thread().unwrap();
-        let current_process = current_posix_thread.process();
+        let Some(current_process) = current_posix_thread.process() else {
+            // The process may exit before this thread gets scheduled. So we
+            // just don't run this thread.
+            return;
+        };
         let current_task = Task::current().unwrap();
 
         let user_space = current_task


### PR DESCRIPTION
The reference to the belonged process of a POSIX thread is a weak pointer. It is common for a thread to outlive the process when the thread is running on anther CPU and the process is exited. So by the time that thread is timer interrupted, or performs some syscalls, the kernel panics. It is discovered when running `memcached -d` (daemon mode) and Metis, a memory intensive benchmark.

This is an example trace:
https://github.com/asterinas/asterinas/actions/runs/11855215313/job/33038978950?pr=1601#step:11:1169