### PR TITLE
Make `Pollee` (semi-)stateless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 name = "aster-bigtcp"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.3.2",
  "keyable-arc",
  "ostd",
  "smoltcp",

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "1.3"
 keyable-arc = { path = "../keyable-arc" }
 ostd = { path = "../../../ostd" }
 smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f07e5b5", default-features = false, features = [

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -220,13 +220,13 @@ impl<E> IfaceCommon<E> {
         context.poll_egress(device, dispatch_phy);
 
         tcp_sockets.iter().for_each(|socket| {
-            if socket.has_new_events() {
-                socket.on_iface_events();
+            if socket.has_events() {
+                socket.on_events();
             }
         });
         udp_sockets.iter().for_each(|socket| {
-            if socket.has_new_events() {
-                socket.on_iface_events();
+            if socket.has_events() {
+                socket.on_events();
             }
         });
 

--- a/kernel/libs/aster-bigtcp/src/socket/event.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/event.rs
@@ -3,9 +3,19 @@
 /// A observer that will be invoked whenever events occur on the socket.
 pub trait SocketEventObserver: Send + Sync {
     /// Notifies that events occurred on the socket.
-    fn on_events(&self);
+    fn on_events(&self, events: SocketEvents);
 }
 
 impl SocketEventObserver for () {
-    fn on_events(&self) {}
+    fn on_events(&self, _events: SocketEvents) {}
+}
+
+bitflags::bitflags! {
+    /// Socket events caused by the _network_.
+    pub struct SocketEvents: u8 {
+        const CAN_RECV = 1;
+        const CAN_SEND = 2;
+        const PEER_CLOSED = 4;
+        const CLOSED = 8;
+    }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -5,7 +5,7 @@ mod event;
 mod state;
 mod unbound;
 
-pub use bound::{BoundTcpSocket, BoundUdpSocket, ConnectState};
+pub use bound::{BoundTcpSocket, BoundUdpSocket, ConnectState, NeedIfacePoll};
 pub(crate) use bound::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult};
 pub use event::{SocketEventObserver, SocketEvents};
 pub use state::TcpStateCheck;

--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -2,12 +2,13 @@
 
 mod bound;
 mod event;
+mod state;
 mod unbound;
 
-pub use bound::{BoundTcpSocket, BoundUdpSocket};
+pub use bound::{BoundTcpSocket, BoundUdpSocket, ConnectState};
 pub(crate) use bound::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult};
-pub use event::SocketEventObserver;
-pub use smoltcp::socket::tcp::State as TcpState;
+pub use event::{SocketEventObserver, SocketEvents};
+pub use state::TcpStateCheck;
 pub use unbound::{
     UnboundTcpSocket, UnboundUdpSocket, TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN,
     UDP_SEND_PAYLOAD_LEN,

--- a/kernel/libs/aster-bigtcp/src/socket/state.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/state.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use smoltcp::socket::tcp::State as TcpState;
+
+use super::RawTcpSocket;
+
+pub trait TcpStateCheck {
+    /// Checks if the peer socket has closed its sending side.
+    ///
+    /// If the sending side of this socket is also closed, this method will return `false`.
+    /// In such cases, you should verify using [`is_closed`].
+    fn is_peer_closed(&self) -> bool;
+
+    /// Checks if the socket is fully closed.
+    ///
+    /// This function returns `true` if both this socket and the peer have closed their sending sides.
+    ///
+    /// This TCP state corresponds to the `Normal Close Sequence` and `Simultaneous Close Sequence`
+    /// as outlined in RFC793 (https://datatracker.ietf.org/doc/html/rfc793#page-39).
+    fn is_closed(&self) -> bool;
+}
+
+impl TcpStateCheck for RawTcpSocket {
+    fn is_peer_closed(&self) -> bool {
+        self.state() == TcpState::CloseWait
+    }
+
+    fn is_closed(&self) -> bool {
+        !self.is_open() || self.state() == TcpState::Closing || self.state() == TcpState::LastAck
+    }
+}

--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -102,7 +102,10 @@ impl PtyMaster {
             return_errno_with_message!(Errno::EAGAIN, "the buffer is empty");
         }
 
-        input.read_fallible(writer)
+        let read_len = input.read_fallible(writer)?;
+        self.pollee.invalidate();
+
+        Ok(read_len)
     }
 
     fn check_io_events(&self) -> IoEvents {

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -265,6 +265,7 @@ impl LineDiscipline {
                 unreachable!()
             }
         };
+        self.pollee.invalidate();
         Ok(read_len)
     }
 
@@ -344,6 +345,7 @@ impl LineDiscipline {
     pub fn drain_input(&self) {
         self.current_line.lock().drain();
         self.read_buffer.lock().clear();
+        self.pollee.invalidate();
     }
 
     pub fn buffer_len(&self) -> usize {

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -126,9 +126,6 @@ impl FileIo for Tty {
                 };
 
                 self.set_foreground(&pgid)?;
-                // Some background processes may be waiting on the wait queue,
-                // when set_fg, the background processes may be able to read.
-                self.ldisc.update_readable_state();
                 Ok(0)
             }
             IoctlCmd::TCSETS => {

--- a/kernel/src/fs/epoll/entry.rs
+++ b/kernel/src/fs/epoll/entry.rs
@@ -367,6 +367,11 @@ impl Iterator for ReadySetPopIter<'_> {
             // must exist, so we can just unwrap it.
             let weak_entry = entries.pop_front().unwrap();
 
+            // Clear the epoll file's events if there are no ready entries.
+            if entries.len() == 0 {
+                self.ready_set.pollee.invalidate();
+            }
+
             let Some(entry) = Weak::upgrade(&weak_entry) else {
                 // The entry has been deleted.
                 continue;

--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -6,7 +6,7 @@ use aster_rights::{Read, ReadOp, TRights, Write, WriteOp};
 use aster_rights_proc::require;
 
 use crate::{
-    events::{IoEvents, Observer},
+    events::IoEvents,
     prelude::*,
     process::signal::{PollHandle, Pollee},
     util::{
@@ -97,22 +97,6 @@ macro_rules! impl_common_methods_for_channel {
 
         pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
             self.this_end().pollee.poll(mask, poller)
-        }
-
-        pub fn register_observer(
-            &self,
-            observer: Weak<dyn Observer<IoEvents>>,
-            mask: IoEvents,
-        ) -> Result<()> {
-            self.this_end().pollee.register_observer(observer, mask);
-            Ok(())
-        }
-
-        pub fn unregister_observer(
-            &self,
-            observer: &Weak<dyn Observer<IoEvents>>,
-        ) -> Option<Weak<dyn Observer<IoEvents>>> {
-            self.this_end().pollee.unregister_observer(observer)
         }
     };
 }

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -6,7 +6,7 @@ use aster_bigtcp::device::WithDevice;
 use ostd::sync::LocalIrqDisabled;
 use spin::Once;
 
-use super::{poll_ifaces, Iface};
+use super::{poll::poll_ifaces, Iface};
 use crate::{
     net::iface::ext::{IfaceEx, IfaceExt},
     prelude::*,

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -4,8 +4,9 @@ mod ext;
 mod init;
 mod poll;
 
+pub use ext::IfaceEx;
 pub use init::{init, IFACES};
-pub use poll::{lazy_init, poll_ifaces};
+pub use poll::lazy_init;
 
 pub type Iface = dyn aster_bigtcp::iface::Iface<ext::IfaceExt>;
 pub type BoundTcpSocket = aster_bigtcp::socket::BoundTcpSocket<ext::IfaceExt>;

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -19,7 +19,7 @@ pub fn lazy_init() {
     }
 }
 
-pub fn poll_ifaces() {
+pub(super) fn poll_ifaces() {
     let ifaces = IFACES.get().unwrap();
 
     for iface in ifaces.iter() {

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -9,7 +9,6 @@ use crate::{
     events::IoEvents,
     net::{iface::BoundUdpSocket, socket::util::send_recv_flags::SendRecvFlags},
     prelude::*,
-    process::signal::Pollee,
     util::{MultiRead, MultiWrite},
 };
 
@@ -93,24 +92,19 @@ impl BoundDatagram {
         }
     }
 
-    pub(super) fn init_pollee(&self, pollee: &Pollee) {
-        pollee.reset_events();
-        self.update_io_events(pollee)
-    }
-
-    pub(super) fn update_io_events(&self, pollee: &Pollee) {
+    pub(super) fn check_io_events(&self) -> IoEvents {
         self.bound_socket.raw_with(|socket| {
+            let mut events = IoEvents::empty();
+
             if socket.can_recv() {
-                pollee.add_events(IoEvents::IN);
-            } else {
-                pollee.del_events(IoEvents::IN);
+                events |= IoEvents::IN;
             }
 
             if socket.can_send() {
-                pollee.add_events(IoEvents::OUT);
-            } else {
-                pollee.del_events(IoEvents::OUT);
+                events |= IoEvents::OUT;
             }
-        });
+
+            events
+        })
     }
 }

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -7,7 +7,10 @@ use aster_bigtcp::{
 
 use crate::{
     events::IoEvents,
-    net::{iface::BoundUdpSocket, socket::util::send_recv_flags::SendRecvFlags},
+    net::{
+        iface::{BoundUdpSocket, Iface},
+        socket::util::send_recv_flags::SendRecvFlags,
+    },
     prelude::*,
     util::{MultiRead, MultiWrite},
 };
@@ -35,6 +38,10 @@ impl BoundDatagram {
 
     pub fn set_remote_endpoint(&mut self, endpoint: &IpEndpoint) {
         self.remote_endpoint = Some(*endpoint)
+    }
+
+    pub fn iface(&self) -> &Arc<Iface> {
+        self.bound_socket.iface()
     }
 
     pub fn try_recv(

--- a/kernel/src/net/socket/ip/datagram/unbound.rs
+++ b/kernel/src/net/socket/ip/datagram/unbound.rs
@@ -8,9 +8,7 @@ use aster_bigtcp::{
 };
 
 use super::bound::BoundDatagram;
-use crate::{
-    events::IoEvents, net::socket::ip::common::bind_socket, prelude::*, process::signal::Pollee,
-};
+use crate::{events::IoEvents, net::socket::ip::common::bind_socket, prelude::*};
 
 pub struct UnboundDatagram {
     unbound_socket: Box<UnboundUdpSocket>,
@@ -44,8 +42,7 @@ impl UnboundDatagram {
         Ok(BoundDatagram::new(bound_socket))
     }
 
-    pub(super) fn init_pollee(&self, pollee: &Pollee) {
-        pollee.reset_events();
-        pollee.add_events(IoEvents::OUT);
+    pub(super) fn check_io_events(&self) -> IoEvents {
+        IoEvents::OUT
     }
 }

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -5,14 +5,14 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_bigtcp::{
     errors::tcp::{RecvError, SendError},
-    socket::{SocketEventObserver, TcpStateCheck},
+    socket::{NeedIfacePoll, SocketEventObserver, TcpStateCheck},
     wire::IpEndpoint,
 };
 
 use crate::{
     events::IoEvents,
     net::{
-        iface::BoundTcpSocket,
+        iface::{BoundTcpSocket, Iface},
         socket::util::{send_recv_flags::SendRecvFlags, shutdown_cmd::SockShutdownCmd},
     },
     prelude::*,
@@ -79,7 +79,11 @@ impl ConnectedStream {
         Ok(())
     }
 
-    pub fn try_recv(&self, writer: &mut dyn MultiWrite, _flags: SendRecvFlags) -> Result<usize> {
+    pub fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        _flags: SendRecvFlags,
+    ) -> Result<(usize, NeedIfacePoll)> {
         let result = self.bound_socket.recv(|socket_buffer| {
             match writer.write(&mut VmReader::from(&*socket_buffer)) {
                 Ok(len) => (len, Ok(len)),
@@ -88,18 +92,30 @@ impl ConnectedStream {
         });
 
         match result {
-            Ok(Ok(0)) if self.is_receiving_closed.load(Ordering::Relaxed) => Ok(0),
-            Ok(Ok(0)) => return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty"),
-            Ok(Ok(recv_bytes)) => Ok(recv_bytes),
-            Ok(Err(e)) => Err(e),
-            Err(RecvError::Finished) => Ok(0),
+            Ok((Ok(0), need_poll)) if self.is_receiving_closed.load(Ordering::Relaxed) => {
+                Ok((0, need_poll))
+            }
+            Ok((Ok(0), need_poll)) => {
+                debug_assert!(!*need_poll);
+                return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
+            }
+            Ok((Ok(recv_bytes), need_poll)) => Ok((recv_bytes, need_poll)),
+            Ok((Err(e), need_poll)) => {
+                debug_assert!(!*need_poll);
+                Err(e)
+            }
+            Err(RecvError::Finished) => Ok((0, NeedIfacePoll::FALSE)),
             Err(RecvError::InvalidState) => {
                 return_errno_with_message!(Errno::ECONNRESET, "the connection is reset")
             }
         }
     }
 
-    pub fn try_send(&self, reader: &mut dyn MultiRead, _flags: SendRecvFlags) -> Result<usize> {
+    pub fn try_send(
+        &self,
+        reader: &mut dyn MultiRead,
+        _flags: SendRecvFlags,
+    ) -> Result<(usize, NeedIfacePoll)> {
         let result = self.bound_socket.send(|socket_buffer| {
             match reader.read(&mut VmWriter::from(socket_buffer)) {
                 Ok(len) => (len, Ok(len)),
@@ -108,9 +124,15 @@ impl ConnectedStream {
         });
 
         match result {
-            Ok(Ok(0)) => return_errno_with_message!(Errno::EAGAIN, "the send buffer is full"),
-            Ok(Ok(sent_bytes)) => Ok(sent_bytes),
-            Ok(Err(e)) => Err(e),
+            Ok((Ok(0), need_poll)) => {
+                debug_assert!(!*need_poll);
+                return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
+            }
+            Ok((Ok(sent_bytes), need_poll)) => Ok((sent_bytes, need_poll)),
+            Ok((Err(e), need_poll)) => {
+                debug_assert!(!*need_poll);
+                Err(e)
+            }
             Err(SendError::InvalidState) => {
                 // FIXME: `EPIPE` is another possibility, which means that the socket is shut down
                 // for writing. In that case, we should also trigger a `SIGPIPE` if `MSG_NOSIGNAL`
@@ -126,6 +148,10 @@ impl ConnectedStream {
 
     pub fn remote_endpoint(&self) -> IpEndpoint {
         self.remote_endpoint
+    }
+
+    pub fn iface(&self) -> &Arc<Iface> {
+        self.bound_socket.iface()
     }
 
     pub fn check_new(&mut self) -> Result<()> {

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -3,7 +3,11 @@
 use aster_bigtcp::{socket::ConnectState, wire::IpEndpoint};
 
 use super::{connected::ConnectedStream, init::InitStream};
-use crate::{events::IoEvents, net::iface::BoundTcpSocket, prelude::*};
+use crate::{
+    events::IoEvents,
+    net::iface::{BoundTcpSocket, Iface},
+    prelude::*,
+};
 
 pub struct ConnectingStream {
     bound_socket: BoundTcpSocket,
@@ -70,6 +74,10 @@ impl ConnectingStream {
 
     pub fn remote_endpoint(&self) -> IpEndpoint {
         self.remote_endpoint
+    }
+
+    pub fn iface(&self) -> &Arc<Iface> {
+        self.bound_socket.iface()
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -15,7 +15,6 @@ use crate::{
         socket::ip::common::{bind_socket, get_ephemeral_endpoint},
     },
     prelude::*,
-    process::signal::Pollee,
 };
 
 pub enum InitStream {
@@ -101,9 +100,8 @@ impl InitStream {
         }
     }
 
-    pub(super) fn init_pollee(&self, pollee: &Pollee) {
-        pollee.reset_events();
+    pub(super) fn check_io_events(&self) -> IoEvents {
         // Linux adds OUT and HUP events for a newly created socket
-        pollee.add_events(IoEvents::OUT | IoEvents::HUP);
+        IoEvents::OUT | IoEvents::HUP
     }
 }

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -5,7 +5,11 @@ use aster_bigtcp::{
 };
 
 use super::connected::ConnectedStream;
-use crate::{events::IoEvents, net::iface::BoundTcpSocket, prelude::*};
+use crate::{
+    events::IoEvents,
+    net::iface::{BoundTcpSocket, Iface},
+    prelude::*,
+};
 
 pub struct ListenStream {
     backlog: usize,
@@ -78,6 +82,10 @@ impl ListenStream {
 
     pub fn local_endpoint(&self) -> IpEndpoint {
         self.bound_socket.local_endpoint().unwrap()
+    }
+
+    pub fn iface(&self) -> &Arc<Iface> {
+        self.bound_socket.iface()
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -248,6 +248,7 @@ impl StreamSocket {
         });
 
         drop(state);
+        self.pollee.invalidate();
         if let Some(iface) = iface_to_poll {
             iface.poll();
         }
@@ -286,6 +287,7 @@ impl StreamSocket {
         let iface_to_poll = listen_stream.iface().clone();
 
         drop(state);
+        self.pollee.invalidate();
         iface_to_poll.poll();
 
         accepted
@@ -313,6 +315,7 @@ impl StreamSocket {
         let remote_endpoint = connected_stream.remote_endpoint();
 
         drop(state);
+        self.pollee.invalidate();
         if let Some(iface) = iface_to_poll {
             iface.poll();
         }
@@ -352,6 +355,7 @@ impl StreamSocket {
         let iface_to_poll = need_poll.then(|| connected_stream.iface().clone());
 
         drop(state);
+        self.pollee.invalidate();
         if let Some(iface) = iface_to_poll {
             iface.poll();
         }
@@ -498,6 +502,7 @@ impl Socket for StreamSocket {
                 }
             };
 
+            self.pollee.invalidate();
             (State::Listen(listen_stream), Ok(()))
         })
     }
@@ -523,6 +528,8 @@ impl Socket for StreamSocket {
         };
 
         drop(state);
+        // No need to call `Pollee::invalidate` because `ConnectedStream::shutdown` will call
+        // `Pollee::notify`.
         iface_to_poll.poll();
 
         result

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -38,6 +38,7 @@ impl Listener {
         let backlog = BACKLOG_TABLE
             .add_backlog(addr, reader_pollee, backlog, is_read_shutdown)
             .unwrap();
+        writer_pollee.invalidate();
 
         Self {
             backlog,
@@ -130,6 +131,8 @@ impl BacklogTable {
             return None;
         }
 
+        // Note that the cached events can be correctly inherited from `Init`, so there is no need
+        // to explicitly call `Pollee::invalidate`.
         let new_backlog = Arc::new(Backlog::new(addr, pollee, backlog, is_shutdown));
         backlog_sockets.insert(addr_key, new_backlog.clone());
 

--- a/kernel/src/net/socket/vsock/stream/connected.rs
+++ b/kernel/src/net/socket/vsock/stream/connected.rs
@@ -56,6 +56,7 @@ impl Connected {
         let mut connection = self.connection.disable_irq().lock();
         let bytes_read = connection.buffer.read_fallible(writer)?;
         connection.info.done_forwarding(bytes_read);
+        self.pollee.invalidate();
 
         match bytes_read {
             0 => {

--- a/kernel/src/net/socket/vsock/stream/init.rs
+++ b/kernel/src/net/socket/vsock/stream/init.rs
@@ -7,19 +7,17 @@ use crate::{
         VSOCK_GLOBAL,
     },
     prelude::*,
-    process::signal::{PollHandle, Pollee},
+    process::signal::PollHandle,
 };
 
 pub struct Init {
     bound_addr: Mutex<Option<VsockSocketAddr>>,
-    pollee: Pollee,
 }
 
 impl Init {
     pub fn new() -> Self {
         Self {
             bound_addr: Mutex::new(None),
-            pollee: Pollee::new(IoEvents::empty()),
         }
     }
 
@@ -61,8 +59,8 @@ impl Init {
         *self.bound_addr.lock()
     }
 
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
-        self.pollee.poll(mask, poller)
+    pub fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
     }
 }
 

--- a/kernel/src/net/socket/vsock/stream/listen.rs
+++ b/kernel/src/net/socket/vsock/stream/listen.rs
@@ -51,6 +51,7 @@ impl Listen {
             .ok_or_else(|| {
                 Error::with_message(Errno::EAGAIN, "no pending connection is available")
             })?;
+        self.pollee.invalidate();
 
         Ok(connection)
     }

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -62,7 +62,6 @@ impl VsockStreamSocket {
         };
 
         let connected = listen.try_accept()?;
-        listen.update_io_events();
 
         let peer_addr = connected.peer_addr();
 
@@ -104,7 +103,6 @@ impl VsockStreamSocket {
         };
 
         let read_size = connected.try_recv(writer)?;
-        connected.update_io_events();
 
         let peer_addr = self.peer_addr()?;
         // If buffer is now empty and the peer requested shutdown, finish shutting down the

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::{
-    sync::atomic::{AtomicU32, AtomicUsize, Ordering},
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 
@@ -12,8 +12,16 @@ use crate::{
     prelude::*,
 };
 
-/// A pollee maintains a set of active events, which can be polled with
-/// pollers or be monitored with observers.
+/// A pollee represents any I/O object (e.g., a file or socket) that can be polled.
+///
+/// `Pollee` provides a standard mechanism to allow
+/// 1. An I/O object to maintain its I/O readiness; and
+/// 2. An interested part to poll the object's I/O readiness.
+///
+/// To correctly use the pollee, you need to call [`Pollee::notify`] whenever a new event arrives.
+///
+/// Then, [`Pollee::poll_with`] can allow you to register a [`Poller`] to wait for certain events,
+/// or register a [`PollAdaptor`] to be notified when certain events occur.
 pub struct Pollee {
     inner: Arc<PolleeInner>,
 }
@@ -21,30 +29,45 @@ pub struct Pollee {
 struct PolleeInner {
     // A subject which is monitored with pollers.
     subject: Subject<IoEvents, IoEvents>,
-    // For efficient manipulation, we use AtomicU32 instead of RwLock<IoEvents>.
-    events: AtomicU32,
+}
+
+impl Default for Pollee {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Pollee {
-    /// Creates a new instance of pollee.
-    pub fn new(init_events: IoEvents) -> Self {
+    /// Creates a new pollee.
+    pub fn new() -> Self {
         let inner = PolleeInner {
             subject: Subject::new(),
-            events: AtomicU32::new(init_events.bits()),
         };
         Self {
             inner: Arc::new(inner),
         }
     }
 
-    /// Returns the current events of the pollee filtered by the given event mask.
+    /// Returns the current events filtered by the given event mask.
     ///
     /// If a poller is provided, the poller will start monitoring the pollee and receive event
     /// notification when the pollee receives interesting events.
     ///
     /// This operation is _atomic_ in the sense that if there are interesting events, either the
     /// events are returned or the poller is notified.
-    pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+    ///
+    /// The above statement about atomicity is true even if `check` contains race conditions (and
+    /// in fact it always will, because even if it holds a lock, the lock will be released when
+    /// `check` returns).
+    pub fn poll_with<F>(
+        &self,
+        mask: IoEvents,
+        poller: Option<&mut PollHandle>,
+        check: F,
+    ) -> IoEvents
+    where
+        F: FnOnce() -> IoEvents,
+    {
         let mask = mask | IoEvents::ALWAYS_POLL;
 
         // Register the provided poller.
@@ -53,7 +76,7 @@ impl Pollee {
         }
 
         // Check events after the registration to prevent race conditions.
-        self.events() & mask
+        check() & mask
     }
 
     fn register_poller(&self, poller: &mut PollHandle, mask: IoEvents) {
@@ -64,41 +87,18 @@ impl Pollee {
         poller.pollees.push(Arc::downgrade(&self.inner));
     }
 
-    /// Add some events to the pollee's state.
+    /// Notifies pollers of some events.
     ///
-    /// This method wakes up all registered pollers that are interested in
-    /// the added events.
-    pub fn add_events(&self, events: IoEvents) {
-        self.inner.events.fetch_or(events.bits(), Ordering::Release);
+    /// This method wakes up all registered pollers that are interested in the events.
+    ///
+    /// The events can be spurious. This way, the caller can avoid expensive calculations and
+    /// simply add all possible ones.
+    pub fn notify(&self, events: IoEvents) {
         self.inner.subject.notify_observers(&events);
-    }
-
-    /// Remove some events from the pollee's state.
-    ///
-    /// This method will not wake up registered pollers even when
-    /// the pollee still has some interesting events to the pollers.
-    pub fn del_events(&self, events: IoEvents) {
-        self.inner
-            .events
-            .fetch_and(!events.bits(), Ordering::Release);
-    }
-
-    /// Reset the pollee's state.
-    ///
-    /// Reset means removing all events on the pollee.
-    pub fn reset_events(&self) {
-        self.inner
-            .events
-            .fetch_and(!IoEvents::all().bits(), Ordering::Release);
-    }
-
-    fn events(&self) -> IoEvents {
-        let event_bits = self.inner.events.load(Ordering::Acquire);
-        IoEvents::from_bits(event_bits).unwrap()
     }
 }
 
-/// An opaque handle that can be used as an argument of the [`Pollee::poll`] method.
+/// An opaque handle that can be used as an argument of the [`Pollable::poll`] method.
 ///
 /// This type can represent an entity of [`PollAdaptor`] or [`Poller`], which is done via the
 /// [`PollAdaptor::as_handle_mut`] and [`Poller::as_handle_mut`] methods.
@@ -146,11 +146,11 @@ impl Drop for PollHandle {
     }
 }
 
-/// An adaptor to make an [`Observer`] usable for [`Pollee::poll`].
+/// An adaptor to make an [`Observer`] usable for [`Pollable::poll`].
 ///
-/// Normally, [`Pollee::poll`] accepts a [`Poller`] which is used to wait for events. By using this
-/// adaptor, it is possible to use any [`Observer`] with [`Pollee::poll`]. The observer will be
-/// notified whenever there are new events.
+/// Normally, [`Pollable::poll`] accepts a [`Poller`] which is used to wait for events. By using
+/// this adaptor, it is possible to use any [`Observer`] with [`Pollable::poll`]. The observer will
+/// be notified whenever there are new events.
 pub struct PollAdaptor<O> {
     // The event observer.
     observer: Arc<O>,
@@ -258,18 +258,18 @@ impl Observer<IoEvents> for EventCounter {
 /// The `Pollable` trait allows for waiting for events and performing event-based operations.
 ///
 /// Implementors are required to provide a method, [`Pollable::poll`], which is usually implemented
-/// by simply calling [`Pollee::poll`] on the internal [`Pollee`]. This trait provides another
+/// by simply calling [`Pollable::poll`] on the internal [`Pollee`]. This trait provides another
 /// method, [`Pollable::wait_events`], to allow waiting for events and performing operations
 /// according to the events.
 ///
 /// This trait is added instead of creating a new method in [`Pollee`] because sometimes we do not
 /// have access to the internal [`Pollee`], but there is a method that provides the same semantics
-/// as [`Pollee::poll`] and we need to perform event-based operations using that method.
+/// as [`Pollable::poll`] and we need to perform event-based operations using that method.
 pub trait Pollable {
     /// Returns the interesting events now and monitors their occurrence in the future if the
     /// poller is provided.
     ///
-    /// This method has the same semantics as [`Pollee::poll`].
+    /// This method has the same semantics as [`Pollee::poll_with`].
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents;
 
     /// Waits for events and performs event-based operations.

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -64,34 +64,6 @@ impl Pollee {
         poller.pollees.push(Arc::downgrade(&self.inner));
     }
 
-    /// Register an IoEvents observer.
-    ///
-    /// A registered observer will get notified (through its `on_events` method)
-    /// every time new events specified by the `mask` argument happen on the
-    /// pollee (through the `add_events` method).
-    ///
-    /// If the given observer has already been registered, then its registered
-    /// event mask will be updated.
-    ///
-    /// Note that the observer will always get notified of the events in
-    /// `IoEvents::ALWAYS_POLL` regardless of the value of `mask`.
-    pub fn register_observer(&self, observer: Weak<dyn Observer<IoEvents>>, mask: IoEvents) {
-        let mask = mask | IoEvents::ALWAYS_POLL;
-        self.inner.subject.register_observer(observer, mask);
-    }
-
-    /// Unregister an IoEvents observer.
-    ///
-    /// If such an observer is found, then the registered observer will be
-    /// removed from the pollee and returned as the return value. Otherwise,
-    /// a `None` will be returned.
-    pub fn unregister_observer(
-        &self,
-        observer: &Weak<dyn Observer<IoEvents>>,
-    ) -> Option<Weak<dyn Observer<IoEvents>>> {
-        self.inner.subject.unregister_observer(observer)
-    }
-
     /// Add some events to the pollee's state.
     ///
     /// This method wakes up all registered pollers that are interested in

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -100,9 +100,10 @@ pub(crate) const fn nr_base_per_page<C: PagingConstsTrait>(level: PagingLevel) -
 pub const MAX_USERSPACE_VADDR: Vaddr = 0x0000_8000_0000_0000 - PAGE_SIZE;
 
 /// The kernel address space.
+///
 /// There are the high canonical addresses defined in most 48-bit width
 /// architectures.
-pub(crate) const KERNEL_VADDR_RANGE: Range<Vaddr> = 0xffff_8000_0000_0000..0xffff_ffff_ffff_0000;
+pub const KERNEL_VADDR_RANGE: Range<Vaddr> = 0xffff_8000_0000_0000..0xffff_ffff_ffff_0000;
 
 /// Gets physical address trait
 pub trait HasPaddr {


### PR DESCRIPTION
Closes https://github.com/asterinas/asterinas/issues/1356
 - Commit "Make `Pollee` stateless" implements https://github.com/asterinas/asterinas/issues/1356#issue-2537879395
 - Commit "Make `Pollee` semi-stateless" implements https://github.com/asterinas/asterinas/issues/1356#issuecomment-2436849331

Fixes https://github.com/asterinas/asterinas/issues/816

#### TCP bandwidth on loopback (`lmbench/tcp_loopback_bw`)

With this PR, Asterinas should stably outperform Linux with message sizes larger than 128.

| Message size (Bytes) | Linux Bandwidth (MB/s) | Asterinas Bandwidth (MB/s) |
| -------------------- | ---------------------- | -------------------------- |
| 1                    | 1.84                   | **2.13**                       |
| 2                    | **5.9**                    | 3.5                        |
| 4                    | **7.38**                   | 5.09                       |
| 8                    | **16.18**                  | 10.13                      |
| 16                   | **36.72**                  | 29.31                      |
| 32                   | **72.17**                  | 62.02                      |
| 64                   | **134.33**                 | 125.26                     |
| 128                  | 281.04                 | **325.58**                     |
| 256                  | 550.42                 | **618.63**                     |
| 512                  | 1019.39                | **1165.79**                    |
| 1024                 | 1887.29                | **2152.19**                    |
| 2048                 | 3296.83                | **3670.12**                    |
| 4096                 | 5141.14                | **5644.24**                    |
| 8192                 | 7144.19                | **7647.35**                    |
| 16384                | 8647.94                | **9383.56**                    |
| 32768                | 9031.53                | **9576.72**                    |
| 65536                | 8620.01                | **10845.79**                   |

#### `select` latency (`lmbench/tcp_loopback_select_lat`)

 - Before this PR: 3.7495 µs
 - After commit "Make `Pollee` stateless": 8.7215 µs
 - After commit "Make `Pollee` semi-stateless": 3.7858 µs

#### Semi-stateless pollee

Note, however, that a semi-stateless pollee is _very_ tricky. I had a very hard time designing it so that it doesn't accidentally cache the wrong events due to race conditions. I finally decided on a design that acts like a [`seqlock`](https://en.wikipedia.org/wiki/Seqlock), which can achieve both (i) cheap `Pollee::notify`/`Pollee::invalidate` and (ii) robust `Pollee::poll_with`. See the latest commit for details.

API overview:
```rust
pub struct Pollee;

impl Pollee {
    pub fn new() -> Self;

    // `poll_with` must be robust enough to support a racy `calc` implementation
    // WITHOUT caching the wrong events.
    pub fn poll_with<F>(&self, mask: IoEvents, poller: Option<&mut PollHandle>, calc: F) -> IoEvents
    where
        F: FnOnce() -> IoEvents;

    // `notify`/`invalidate` must be cheap and must NOT require the caller
    // to hold a lock for correctness.
    pub fn notify(&self, events: IoEvents);
    pub fn invalidate(&self);
}
```