### PR TITLE
Fix releasing lock during the creation of `VmMapping`

### DIFF
--- a/kernel/src/vm/vmar/dyn_cap.rs
+++ b/kernel/src/vm/vmar/dyn_cap.rs
@@ -4,7 +4,7 @@ use core::ops::Range;
 
 use aster_rights::Rights;
 
-use super::{vm_mapping::VmarMapOptions, VmPerms, Vmar, VmarRightsOp, Vmar_};
+use super::{VmPerms, Vmar, VmarMapOptions, VmarRightsOp, Vmar_};
 use crate::{
     prelude::*, thread::exception::PageFaultInfo, vm::page_fault_handler::PageFaultHandler,
 };

--- a/kernel/src/vm/vmar/static_cap.rs
+++ b/kernel/src/vm/vmar/static_cap.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 
-use super::{vm_mapping::VmarMapOptions, VmPerms, Vmar, VmarRightsOp, Vmar_};
+use super::{VmPerms, Vmar, VmarMapOptions, VmarRightsOp, Vmar_};
 use crate::{
     prelude::*, thread::exception::PageFaultInfo, vm::page_fault_handler::PageFaultHandler,
 };


### PR DESCRIPTION
Currently, when creating a new `VmMapping`, the `Vmar` acquires a write lock, allocates a free region, releases the write lock, acquires it again, and inserts the new `VmMapping` into the btree, which is clearly incorrect in parallel. 

This PR fixes the bug.