### PR TITLE
Implement a lazy TLB coherence protocol

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -320,7 +320,7 @@ impl Vmar_ {
 
     /// Clears all content of the root VMAR.
     fn clear_root_vmar(&self) -> Result<()> {
-        self.vm_space.clear().unwrap();
+        self.vm_space.clear();
         let mut inner = self.inner.write();
         inner.vm_mappings.clear();
         Ok(())
@@ -406,7 +406,6 @@ impl Vmar_ {
                 new_cursor.copy_from(&mut cur_cursor, vm_mapping.map_size(), &mut op);
             }
             cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::All);
-            cur_cursor.flusher().dispatch_tlb_flush();
         }
 
         Ok(new_vmar_)

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -182,7 +182,6 @@ impl VmMapping {
                 if self.is_shared || only_reference {
                     cursor.protect_next(PAGE_SIZE, |p| p.flags |= new_flags);
                     cursor.flusher().issue_tlb_flush(TlbFlushOp::Address(va));
-                    cursor.flusher().dispatch_tlb_flush();
                 } else {
                     let new_frame = duplicate_frame(&frame)?;
                     prop.flags |= new_flags;
@@ -403,7 +402,6 @@ impl VmMapping {
                 break;
             }
         }
-        cursor.flusher().dispatch_tlb_flush();
 
         Self { perms, ..self }
     }

--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -139,6 +139,7 @@ impl UserContextApiInternal for UserContext {
                 }
             };
             call_irq_callback_functions(&self.as_trap_frame(), self.as_trap_frame().trap_num);
+            crate::mm::tlb::process_pending_shootdowns();
             if has_kernel_event() {
                 break ReturnReason::KernelEvent;
             }

--- a/ostd/src/cpu/set.rs
+++ b/ostd/src/cpu/set.rs
@@ -56,6 +56,13 @@ impl CpuSet {
         self.bits[part_idx] |= 1 << bit_idx;
     }
 
+    /// Adds a set of CPUs to the set.
+    pub fn add_set(&mut self, set: &CpuSet) {
+        for (part, new_part) in self.bits.iter_mut().zip(set.bits.iter()) {
+            *part |= *new_part;
+        }
+    }
+
     /// Removes a CPU from the set.
     pub fn remove(&mut self, cpu_id: CpuId) {
         let part_idx = part_idx(cpu_id);
@@ -185,6 +192,13 @@ impl AtomicCpuSet {
         let bit_idx = bit_idx(cpu_id);
         if part_idx < self.bits.len() {
             self.bits[part_idx].fetch_or(1 << bit_idx, ordering);
+        }
+    }
+
+    /// Atomically adds a set of CPUs with the relaxed ordering.
+    pub fn add_set(&self, set: &CpuSet) {
+        for (part, new_part) in self.bits.iter().zip(set.bits.iter()) {
+            part.fetch_or(*new_part, Ordering::Relaxed);
         }
     }
 

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -80,7 +80,7 @@ use crate::{
         page::{meta::MapTrackingStatus, DynPage},
         Paddr, PageProperty, Vaddr,
     },
-    task::{disable_preempt, DisabledPreemptGuard},
+    trap::{self, DisabledLocalIrqGuard},
 };
 
 #[derive(Clone, Debug)]
@@ -134,7 +134,7 @@ where
     /// The virtual address range that is locked.
     barrier_va: Range<Vaddr>,
     #[allow(dead_code)]
-    preempt_guard: DisabledPreemptGuard,
+    irq_guard: DisabledLocalIrqGuard,
     _phantom: PhantomData<&'a PageTable<M, E, C>>,
 }
 
@@ -164,7 +164,7 @@ where
             guard_level: C::NR_LEVELS,
             va: va.start,
             barrier_va: va.clone(),
-            preempt_guard: disable_preempt(),
+            irq_guard: trap::disable_local(),
             _phantom: PhantomData,
         };
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -3,11 +3,12 @@
 use core::{fmt::Debug, marker::PhantomData, ops::Range};
 
 use super::{
-    nr_subpage_per_huge, page::meta::MapTrackingStatus, page_prop::PageProperty, page_size, Paddr,
-    PagingConstsTrait, PagingLevel, Vaddr,
+    nr_subpage_per_huge, page::meta::MapTrackingStatus, page_prop::PageProperty, page_size,
+    tlb::TlbFlusher, Paddr, PagingConstsTrait, PagingLevel, Vaddr,
 };
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
+    mm::page::Page,
     Pod,
 };
 
@@ -94,21 +95,19 @@ impl PageTable<UserMode> {
     }
 
     /// Clear the page table.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that:
-    ///  1. No other cursors are accessing the page table.
-    ///  2. No other CPUs activates the page table.
-    pub(in crate::mm) unsafe fn clear(&self) {
+    pub(in crate::mm) fn clear(&self, mut flusher: TlbFlusher) {
         let mut root_node = self.root.clone_shallow().lock();
         const NR_PTES_PER_NODE: usize = nr_subpage_per_huge::<PagingConsts>();
         for i in 0..NR_PTES_PER_NODE / 2 {
             let root_entry = root_node.entry(i);
             if !root_entry.is_none() {
                 let old = root_entry.replace(Child::None);
-                // Since no others are accessing the old child, dropping it is fine.
-                drop(old);
+                if let Child::PageTable(node) = old {
+                    flusher.issue_tlb_flush_with(
+                        crate::mm::tlb::TlbFlushOp::All,
+                        Page::from(node).into(),
+                    );
+                }
             }
         }
     }

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -3,93 +3,63 @@
 //! TLB flush operations.
 
 use alloc::vec::Vec;
-use core::ops::Range;
+use core::{
+    ops::Range,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 
 use super::{page::DynPage, Vaddr, PAGE_SIZE};
 use crate::{
-    cpu::{CpuId, CpuSet, PinCurrentCpu},
+    cpu::{all_cpus, AtomicCpuSet, CpuId, CpuSet, PinCurrentCpu},
     cpu_local,
+    smp::inter_processor_call,
     sync::SpinLock,
-    task::disable_preempt,
+    trap::{self, DisabledLocalIrqGuard},
 };
 
 /// A TLB flusher that is aware of which CPUs are needed to be flushed.
 ///
 /// The flusher needs to stick to the current CPU.
-pub struct TlbFlusher<G: PinCurrentCpu> {
-    target_cpus: CpuSet,
-    // Better to store them here since loading and counting them from the CPUs
-    // list brings non-trivial overhead.
-    need_remote_flush: bool,
-    need_self_flush: bool,
-    current_cpu: CpuId,
-    _pin_current: G,
+pub struct TlbFlusher<'c> {
+    target_cpus: &'c AtomicCpuSet,
+    irq_guard: DisabledLocalIrqGuard,
+    need_flush_all: bool,
+    flush_ops: Vec<TlbFlushOp>,
+    defer_pages: Vec<(TlbFlushOp, DynPage)>,
 }
 
-impl<G: PinCurrentCpu> TlbFlusher<G> {
+impl<'c> TlbFlusher<'c> {
     /// Creates a new TLB flusher with the specified CPUs to be flushed.
     ///
     /// The flusher needs to stick to the current CPU. So please provide a
     /// guard that implements [`PinCurrentCpu`].
-    pub fn new(target_cpus: CpuSet, pin_current_guard: G) -> Self {
-        let current_cpu = pin_current_guard.current_cpu();
-
-        let mut need_self_flush = false;
-        let mut need_remote_flush = false;
-
-        for cpu in target_cpus.iter() {
-            if cpu == current_cpu {
-                need_self_flush = true;
-            } else {
-                need_remote_flush = true;
-            }
-        }
+    pub fn new(target_cpus: &'c AtomicCpuSet) -> Self {
         Self {
             target_cpus,
-            need_remote_flush,
-            need_self_flush,
-            current_cpu,
-            _pin_current: pin_current_guard,
+            irq_guard: trap::disable_local(),
+            need_flush_all: false,
+            flush_ops: Vec::new(),
+            defer_pages: Vec::new(),
         }
-    }
-
-    /// Updates the CPU list with the specified CPUs to be flushed.
-    pub(crate) fn update_cpu(&mut self, target_cpus: CpuSet) {
-        let current_cpu = self.current_cpu;
-
-        let mut need_self_flush = false;
-        let mut need_remote_flush = false;
-
-        for cpu in target_cpus.iter() {
-            if cpu == current_cpu {
-                need_self_flush = true;
-            } else {
-                need_remote_flush = true;
-            }
-        }
-
-        self.target_cpus = target_cpus;
-        self.need_self_flush = need_self_flush;
-        self.need_remote_flush = need_remote_flush;
     }
 
     /// Issues a pending TLB flush request.
     ///
     /// On SMP systems, the notification is sent to all the relevant CPUs only
-    /// when [`Self::dispatch_tlb_flush`] is called.
-    pub fn issue_tlb_flush(&self, op: TlbFlushOp) {
-        self.issue_tlb_flush_(op, None);
-    }
-
-    /// Dispatches all the pending TLB flush requests.
-    ///
-    /// The pending requests are issued by [`Self::issue_tlb_flush`].
-    pub fn dispatch_tlb_flush(&self) {
-        if !self.need_remote_flush {
+    /// when the remote buffer is full. Otherwise, this is non-blocking.
+    pub fn issue_tlb_flush(&mut self, op: TlbFlushOp) {
+        if self.need_flush_all {
             return;
         }
 
-        crate::smp::inter_processor_call(&self.target_cpus, do_remote_flush);
+        let op = op.optimize_for_large_range();
+
+        if op == TlbFlushOp::All || self.flush_ops.len() >= FLUSH_ALL_OPS_THRESHOLD {
+            self.flush_ops.clear();
+            self.need_flush_all = true;
+        } else {
+            self.flush_ops.push(op);
+        }
     }
 
     /// Issues a TLB flush request that must happen before dropping the page.
@@ -99,44 +69,60 @@ impl<G: PinCurrentCpu> TlbFlusher<G> {
     /// flushed. Otherwise if the page is recycled for other purposes, the user
     /// space program can still access the page through the TLB entries. This
     /// method is designed to be used in such cases.
-    pub fn issue_tlb_flush_with(&self, op: TlbFlushOp, drop_after_flush: DynPage) {
-        self.issue_tlb_flush_(op, Some(drop_after_flush));
+    pub fn issue_tlb_flush_with(&mut self, op: TlbFlushOp, drop_after_flush: DynPage) {
+        self.defer_pages.push((op, drop_after_flush));
     }
 
-    /// Whether the TLB flusher needs to flush the TLB entries on other CPUs.
-    pub fn need_remote_flush(&self) -> bool {
-        self.need_remote_flush
-    }
+    fn dispatch_tlb_flush(&mut self) {
+        let mut target_cpus = self.target_cpus.load();
+        let this_cpu = self.irq_guard.current_cpu();
 
-    /// Whether the TLB flusher needs to flush the TLB entries on the current CPU.
-    pub fn need_self_flush(&self) -> bool {
-        self.need_self_flush
-    }
+        let need_self_flush = target_cpus.contains(this_cpu);
 
-    fn issue_tlb_flush_(&self, op: TlbFlushOp, drop_after_flush: Option<DynPage>) {
-        let op = op.optimize_for_large_range();
-
-        // Fast path for single CPU cases.
-        if !self.need_remote_flush {
-            if self.need_self_flush {
-                op.perform_on_current();
-            }
-            return;
+        if need_self_flush {
+            target_cpus.remove(this_cpu);
         }
 
-        // Slow path for multi-CPU cases.
-        for cpu in self.target_cpus.iter() {
-            let mut op_queue = FLUSH_OPS.get_on_cpu(cpu).lock();
-            if let Some(drop_after_flush) = drop_after_flush.clone() {
-                PAGE_KEEPER.get_on_cpu(cpu).lock().push(drop_after_flush);
+        let target_cpu_size = target_cpus.count();
+
+        let need_remote_flush = target_cpu_size > 1;
+
+        if need_self_flush {
+            if self.need_flush_all {
+                TlbFlushOp::All.perform_on_current();
+            } else {
+                for op in &self.flush_ops {
+                    op.perform_on_current();
+                }
+                for (op, _) in &self.defer_pages {
+                    op.perform_on_current();
+                }
             }
-            op_queue.push(op.clone());
+        }
+
+        if need_remote_flush {
+            let mut ops = Vec::new();
+            core::mem::swap(&mut self.flush_ops, &mut ops);
+            let mut defers = Vec::new();
+            core::mem::swap(&mut self.defer_pages, &mut defers);
+            PUBLIC_FLUSH_OPS
+                .get_on_cpu(this_cpu)
+                .add(ops, target_cpus.clone());
+            PUBLIC_DEFER_PAGES
+                .get_on_cpu(this_cpu)
+                .add(defers, target_cpus);
         }
     }
 }
 
+impl Drop for TlbFlusher<'_> {
+    fn drop(&mut self) {
+        self.dispatch_tlb_flush();
+    }
+}
+
 /// The operation to flush TLB entries.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TlbFlushOp {
     /// Flush all TLB entries except for the global entries.
     All,
@@ -173,72 +159,266 @@ impl TlbFlushOp {
     }
 }
 
-// The queues of pending requests on each CPU.
-//
-// Lock ordering: lock FLUSH_OPS before PAGE_KEEPER.
-cpu_local! {
-    static FLUSH_OPS: SpinLock<OpsStack> = SpinLock::new(OpsStack::new());
-    static PAGE_KEEPER: SpinLock<Vec<DynPage>> = SpinLock::new(Vec::new());
-}
-
-fn do_remote_flush() {
-    let preempt_guard = disable_preempt();
-    let current_cpu = preempt_guard.current_cpu();
-
-    let mut op_queue = FLUSH_OPS.get_on_cpu(current_cpu).lock();
-    op_queue.flush_all();
-    PAGE_KEEPER.get_on_cpu(current_cpu).lock().clear();
-}
-
 /// If a TLB flushing request exceeds this threshold, we flush all.
-pub(crate) const FLUSH_ALL_RANGE_THRESHOLD: usize = 32 * PAGE_SIZE;
+const FLUSH_ALL_RANGE_THRESHOLD: usize = 32 * PAGE_SIZE;
 
 /// If the number of pending requests exceeds this threshold, we flush all the
 /// TLB entries instead of flushing them one by one.
 const FLUSH_ALL_OPS_THRESHOLD: usize = 32;
 
-struct OpsStack {
-    ops: [Option<TlbFlushOp>; FLUSH_ALL_OPS_THRESHOLD],
-    need_flush_all: bool,
-    size: usize,
+// The queues of pending requests publicly seen on each CPU.
+//
+// On scheduler ticks or some timer interrupts, we will process the pending
+// requests on all CPUs and recycle the pages on the current CPU.
+cpu_local! {
+    static PUBLIC_FLUSH_OPS: OpsArray = OpsArray::new();
+    static PUBLIC_DEFER_PAGES: DeferPagesArray = DeferPagesArray::new();
 }
 
-impl OpsStack {
+cpu_local! {
+    static COHERENT: AtomicBool = AtomicBool::new(false);
+}
+
+/// Recycle the local pages that is delayed to be recycled.
+///
+/// This function checks if all the issued TLB flush requests of local pages
+/// are processed on all the relevant CPUs. If so, the page can be recycled.
+pub(crate) fn delayed_recycle_pages() {
+    let irq_guard = trap::disable_local();
+    let cur_cpu = irq_guard.current_cpu();
+    PUBLIC_FLUSH_OPS.get_on_cpu(cur_cpu).recycle();
+    PUBLIC_DEFER_PAGES.get_on_cpu(cur_cpu).recycle();
+    COHERENT.get_on_cpu(cur_cpu).store(true, Ordering::Relaxed);
+}
+
+/// Process the pending TLB flush requests on all the CPUs.
+///
+/// This function checks if there are any pending TLB flush requests on all the
+/// remote CPUS. If so, it will process the requests.
+pub(crate) fn process_pending_shootdowns() {
+    let irq_guard = trap::disable_local();
+    let cur_cpu = irq_guard.current_cpu();
+    for cpu_id in all_cpus() {
+        if cpu_id == cur_cpu {
+            continue;
+        }
+        PUBLIC_FLUSH_OPS
+            .get_on_cpu(cpu_id)
+            .process_remote_requests(cur_cpu);
+        PUBLIC_DEFER_PAGES
+            .get_on_cpu(cpu_id)
+            .process_remote_requests(cur_cpu);
+    }
+}
+
+struct OpsArray {
+    ops: [SpinLock<Option<(TlbFlushOp, CpuSet)>>; FLUSH_ALL_OPS_THRESHOLD],
+    size: AtomicUsize,
+    pending_flush_all: SpinLock<Option<CpuSet>>,
+}
+
+impl OpsArray {
     const fn new() -> Self {
-        const ARRAY_REPEAT_VALUE: Option<TlbFlushOp> = None;
         Self {
-            ops: [ARRAY_REPEAT_VALUE; FLUSH_ALL_OPS_THRESHOLD],
-            need_flush_all: false,
-            size: 0,
+            ops: [const { SpinLock::new(None) }; FLUSH_ALL_OPS_THRESHOLD],
+            size: AtomicUsize::new(0),
+            pending_flush_all: SpinLock::new(None),
         }
     }
 
-    fn push(&mut self, op: TlbFlushOp) {
-        if self.need_flush_all {
+    /// Recycle the operations that can be recycled.
+    ///
+    /// This should be called by the current CPU.
+    fn recycle(&self) {
+        let size = self.size.load(Ordering::Relaxed);
+        if size == 0 {
             return;
         }
-
-        if self.size < FLUSH_ALL_OPS_THRESHOLD {
-            self.ops[self.size] = Some(op);
-            self.size += 1;
-        } else {
-            self.need_flush_all = true;
-            self.size = 0;
-        }
-    }
-
-    fn flush_all(&mut self) {
-        if self.need_flush_all {
-            crate::arch::mm::tlb_flush_all_excluding_global();
-            self.need_flush_all = false;
-        } else {
-            for i in 0..self.size {
-                if let Some(op) = &self.ops[i] {
-                    op.perform_on_current();
+        for i in 0..FLUSH_ALL_OPS_THRESHOLD {
+            let mut lock = self.ops[i].lock();
+            if let Some((_, target_cpus)) = &*lock {
+                if target_cpus.is_empty() {
+                    *lock = None;
+                    self.size.fetch_sub(1, Ordering::Relaxed);
                 }
             }
         }
+    }
 
-        self.size = 0;
+    /// Adds TLB flush operations to the array.
+    ///
+    /// This should be called by the current CPU.
+    fn add(&self, mut ops: Vec<TlbFlushOp>, target_cpus: CpuSet) {
+        let size = self.size.load(Ordering::Relaxed);
+        if size + ops.len() >= FLUSH_ALL_OPS_THRESHOLD {
+            self.add_flush_all(&target_cpus);
+            return;
+        }
+
+        // Find an empty slot to store the operation.
+        for i in 0..FLUSH_ALL_OPS_THRESHOLD {
+            let mut lock = self.ops[i].lock();
+            if lock.is_none() {
+                let Some(op) = ops.pop() else {
+                    return;
+                };
+                *lock = Some((op, target_cpus.clone()));
+                self.size.fetch_add(1, Ordering::Relaxed);
+                if ops.is_empty() {
+                    return;
+                }
+            }
+        }
+        // Somebody filled the array while we were trying to add an element.
+        self.add_flush_all(&target_cpus);
+    }
+
+    /// Check the remote CPU's requests and process them.
+    ///
+    /// This should be called by the other CPUs.
+    fn process_remote_requests(&self, current: CpuId) {
+        let mut flushed_all = false;
+        if self.flush_all_contains(current) {
+            TlbFlushOp::All.perform_on_current();
+            flushed_all = true;
+        }
+        for i in 0..FLUSH_ALL_OPS_THRESHOLD {
+            let mut lock = self.ops[i].lock();
+            if let Some((op, target_cpus)) = &mut *lock {
+                if target_cpus.contains(current) {
+                    if !flushed_all {
+                        op.perform_on_current();
+                    }
+                    target_cpus.remove(current);
+                    if target_cpus.is_empty() {
+                        *lock = None;
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_flush_all(&self, target_cpus: &CpuSet) {
+        let mut lock = self.pending_flush_all.lock();
+        if let Some(cpus) = &mut *lock {
+            cpus.add_set(target_cpus);
+        } else {
+            *lock = Some(target_cpus.clone());
+        }
+    }
+
+    fn flush_all_contains(&self, current: CpuId) -> bool {
+        self.pending_flush_all
+            .lock()
+            .as_ref()
+            .map(|target_cpus| target_cpus.contains(current))
+            .unwrap_or(false)
+    }
+}
+
+/// If the number of pending pages exceeds this threshold, we need to IPI all
+/// the relevant CPUs to flush the TLB entries.
+const IPI_RECYCLE_THRESHOLD: usize = 64;
+
+struct DeferPagesArray {
+    pages: [SpinLock<Option<(TlbFlushOp, DynPage, CpuSet)>>; IPI_RECYCLE_THRESHOLD],
+    size: AtomicUsize,
+}
+
+impl DeferPagesArray {
+    const fn new() -> Self {
+        Self {
+            pages: [const { SpinLock::new(None) }; IPI_RECYCLE_THRESHOLD],
+            size: AtomicUsize::new(0),
+        }
+    }
+
+    /// Recycle the pages that can be recycled.
+    ///
+    /// This should be called by the current CPU.
+    fn recycle(&self) {
+        let size = self.size.load(Ordering::Relaxed);
+        if size == 0 {
+            return;
+        }
+        for i in 0..IPI_RECYCLE_THRESHOLD {
+            let mut lock = self.pages[i].lock();
+            if let Some((_op, _page, target_cpus)) = &*lock {
+                if target_cpus.is_empty() {
+                    *lock = None;
+                    self.size.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// Adds the pages to the array.
+    ///
+    /// This should be called by the current CPU.
+    fn add(&self, mut defers: Vec<(TlbFlushOp, DynPage)>, target_cpus: CpuSet) {
+        while defers.is_empty() {
+            let mut relevant_cpus = target_cpus.clone();
+            for i in 0..IPI_RECYCLE_THRESHOLD {
+                let mut lock = self.pages[i].lock();
+                if let Some((_, _, target_cpus)) = &*lock {
+                    relevant_cpus.add_set(target_cpus);
+                } else {
+                    let Some((op, page)) = defers.pop() else {
+                        return;
+                    };
+                    *lock = Some((op, page, target_cpus.clone()));
+                    self.size.fetch_add(1, Ordering::Relaxed);
+                    if defers.is_empty() {
+                        return;
+                    }
+                }
+            }
+            // Does not have enough slots to store all the defers.
+            // Notify all the relevant CPUs to flush the TLB entries.
+            for cpu_id in relevant_cpus.iter() {
+                COHERENT.get_on_cpu(cpu_id).store(false, Ordering::Release);
+            }
+            inter_processor_call(&relevant_cpus, || {
+                process_pending_shootdowns();
+                delayed_recycle_pages();
+            });
+            // Wait for ACKs from all the relevant CPUs.
+            for cpu_id in relevant_cpus.iter() {
+                while !COHERENT.get_on_cpu(cpu_id).load(Ordering::Acquire) {
+                    // We disabled interrupts, so we should try recycle when we are waiting.
+                    process_pending_shootdowns();
+                    delayed_recycle_pages();
+                    // Wait for the remote CPU to finish the TLB flush.
+                    core::hint::spin_loop();
+                }
+            }
+        }
+    }
+
+    /// Check the remote CPU's requests and process them.
+    ///
+    /// This should be called by the other CPUs.
+    fn process_remote_requests(&self, current: CpuId) {
+        let size = self.size.load(Ordering::Relaxed);
+        if size == 0 {
+            return;
+        }
+        let prefer_flush_all = size >= FLUSH_ALL_OPS_THRESHOLD;
+        let mut flushed_all = false;
+        for i in 0..IPI_RECYCLE_THRESHOLD {
+            let mut lock = self.pages[i].lock();
+            if let Some((op, _page, target_cpus)) = &mut *lock {
+                if target_cpus.contains(current) {
+                    if prefer_flush_all && !flushed_all {
+                        TlbFlushOp::All.perform_on_current();
+                        flushed_all = true;
+                    } else {
+                        op.perform_on_current();
+                    }
+                    target_cpus.remove(current);
+                }
+            }
+        }
     }
 }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -12,22 +12,18 @@
 use core::{ops::Range, sync::atomic::Ordering};
 
 use crate::{
-    arch::mm::{
-        current_page_table_paddr, tlb_flush_all_excluding_global, PageTableEntry, PagingConsts,
-    },
+    arch::mm::{current_page_table_paddr, PageTableEntry, PagingConsts},
     cpu::{AtomicCpuSet, CpuExceptionInfo, CpuSet, PinCurrentCpu},
     cpu_local_cell,
     mm::{
         io::Fallible,
         kspace::KERNEL_PAGE_TABLE,
-        page::DynPage,
         page_table::{self, PageTable, PageTableItem, UserMode},
-        tlb::{TlbFlushOp, TlbFlusher, FLUSH_ALL_RANGE_THRESHOLD},
+        tlb::{TlbFlushOp, TlbFlusher},
         Frame, PageProperty, VmReader, VmWriter, MAX_USERSPACE_VADDR,
     },
     prelude::*,
-    sync::{PreemptDisabled, RwLock, RwLockReadGuard},
-    task::{disable_preempt, DisabledPreemptGuard},
+    task::disable_preempt,
     Error,
 };
 
@@ -50,9 +46,6 @@ use crate::{
 pub struct VmSpace {
     pt: PageTable<UserMode>,
     page_fault_handler: Option<fn(&VmSpace, &CpuExceptionInfo) -> core::result::Result<(), ()>>,
-    /// A CPU can only activate a `VmSpace` when no mutable cursors are alive.
-    /// Cursors hold read locks and activation require a write lock.
-    activation_lock: RwLock<()>,
     cpus: AtomicCpuSet,
 }
 
@@ -62,7 +55,6 @@ impl VmSpace {
         Self {
             pt: KERNEL_PAGE_TABLE.get().unwrap().create_user_page_table(),
             page_fault_handler: None,
-            activation_lock: RwLock::new(()),
             cpus: AtomicCpuSet::new(CpuSet::new_empty()),
         }
     }
@@ -71,29 +63,9 @@ impl VmSpace {
     ///
     /// This method returns error if the page table is activated on any other
     /// CPUs or there are any cursors alive.
-    pub fn clear(&self) -> core::result::Result<(), VmSpaceClearError> {
-        let preempt_guard = disable_preempt();
-        let _guard = self
-            .activation_lock
-            .try_write()
-            .ok_or(VmSpaceClearError::CursorsAlive)?;
-
-        let cpus = self.cpus.load();
-        let cpu = preempt_guard.current_cpu();
-        let cpus_set_is_empty = cpus.is_empty();
-        let cpus_set_is_single_self = cpus.count() == 1 && cpus.contains(cpu);
-
-        if cpus_set_is_empty || cpus_set_is_single_self {
-            // SAFETY: We have ensured that the page table is not activated on
-            // other CPUs and no cursors are alive.
-            unsafe { self.pt.clear() };
-            if cpus_set_is_single_self {
-                tlb_flush_all_excluding_global();
-            }
-            Ok(())
-        } else {
-            Err(VmSpaceClearError::PageTableActivated(cpus))
-        }
+    pub fn clear(&self) {
+        let flusher = TlbFlusher::new(&self.cpus);
+        self.pt.clear(flusher);
     }
 
     /// Gets an immutable cursor in the virtual address range.
@@ -118,16 +90,10 @@ impl VmSpace {
     /// The creation of the cursor may block if another cursor having an
     /// overlapping range is alive. The modification to the mapping by the
     /// cursor may also block or be overridden the mapping of another cursor.
-    pub fn cursor_mut(&self, va: &Range<Vaddr>) -> Result<CursorMut<'_, '_, '_>> {
-        Ok(self.pt.cursor_mut(va).map(|pt_cursor| {
-            let activation_lock = self.activation_lock.read();
-
-            CursorMut {
-                space: self,
-                pt_cursor,
-                activation_lock,
-                flusher: TlbFlusher::new(self.cpus.load(), disable_preempt()),
-            }
+    pub fn cursor_mut(&self, va: &Range<Vaddr>) -> Result<CursorMut<'_, '_>> {
+        Ok(self.pt.cursor_mut(va).map(|pt_cursor| CursorMut {
+            flusher: TlbFlusher::new(&self.cpus),
+            pt_cursor,
         })?)
     }
 
@@ -141,10 +107,6 @@ impl VmSpace {
         if last_ptr == Arc::as_ptr(self) {
             return;
         }
-
-        // Ensure no mutable cursors (which holds read locks) are alive before
-        // we add the CPU to the CPU set.
-        let _activation_lock = self.activation_lock.write();
 
         // Record ourselves in the CPU set and the activated VM space pointer.
         self.cpus.add(cpu, Ordering::Relaxed);
@@ -228,17 +190,6 @@ impl Default for VmSpace {
     }
 }
 
-/// An error that may occur when doing [`VmSpace::clear`].
-#[derive(Debug)]
-pub enum VmSpaceClearError {
-    /// The page table is activated on other CPUs.
-    ///
-    /// The activated CPUs detected are contained in the error.
-    PageTableActivated(CpuSet),
-    /// There are still cursors alive.
-    CursorsAlive,
-}
-
 /// The cursor for querying over the VM space without modifying it.
 ///
 /// It exclusively owns a sub-tree of the page table, preventing others from
@@ -282,17 +233,12 @@ impl Cursor<'_> {
 ///
 /// It exclusively owns a sub-tree of the page table, preventing others from
 /// reading or modifying the same sub-tree.
-pub struct CursorMut<'a, 'b, 'c> {
-    space: &'a VmSpace,
+pub struct CursorMut<'a, 'b> {
+    flusher: TlbFlusher<'a>,
     pt_cursor: page_table::CursorMut<'b, UserMode, PageTableEntry, PagingConsts>,
-    #[allow(dead_code)]
-    activation_lock: RwLockReadGuard<'c, (), PreemptDisabled>,
-    // We have a read lock so the CPU set in the flusher is always a superset
-    // of actual activated CPUs.
-    flusher: TlbFlusher<DisabledPreemptGuard>,
 }
 
-impl CursorMut<'_, '_, '_> {
+impl<'a> CursorMut<'a, '_> {
     /// Query about the current slot.
     ///
     /// This is the same as [`Cursor::query`].
@@ -319,8 +265,8 @@ impl CursorMut<'_, '_, '_> {
     }
 
     /// Get the dedicated TLB flusher for this cursor.
-    pub fn flusher(&self) -> &TlbFlusher<DisabledPreemptGuard> {
-        &self.flusher
+    pub fn flusher<'s>(&'s mut self) -> &'s mut TlbFlusher<'a> {
+        &mut self.flusher
     }
 
     /// Map a frame into the current slot.
@@ -332,12 +278,8 @@ impl CursorMut<'_, '_, '_> {
         let old = unsafe { self.pt_cursor.map(frame.into(), prop) };
 
         if let Some(old) = old {
-            // Load the current cpu set.
-            self.flusher.update_cpu(self.space.cpus.load());
-
             self.flusher
                 .issue_tlb_flush_with(TlbFlushOp::Address(start_va), old);
-            self.flusher.dispatch_tlb_flush();
         }
     }
 
@@ -360,15 +302,14 @@ impl CursorMut<'_, '_, '_> {
     pub fn unmap(&mut self, len: usize) {
         assert!(len % super::PAGE_SIZE == 0);
         let end_va = self.virt_addr() + len;
-        let tlb_prefer_flush_all = len > FLUSH_ALL_RANGE_THRESHOLD;
 
-        let mut vec_tlb_req = Vec::<(usize, DynPage)>::new();
         loop {
             // SAFETY: It is safe to un-map memory in the userspace.
             let result = unsafe { self.pt_cursor.take_next(end_va - self.virt_addr()) };
             match result {
                 PageTableItem::Mapped { va, page, .. } => {
-                    vec_tlb_req.push((va, page));
+                    self.flusher
+                        .issue_tlb_flush_with(TlbFlushOp::Address(va), page);
                 }
                 PageTableItem::NotMapped { .. } => {
                     break;
@@ -378,20 +319,6 @@ impl CursorMut<'_, '_, '_> {
                 }
             }
         }
-
-        // Load the current cpu set.
-        self.flusher.update_cpu(self.space.cpus.load());
-
-        if !self.flusher.need_remote_flush() && tlb_prefer_flush_all {
-            self.flusher.issue_tlb_flush(TlbFlushOp::All);
-        } else {
-            for (va, page) in vec_tlb_req {
-                self.flusher
-                    .issue_tlb_flush_with(TlbFlushOp::Address(va), page);
-            }
-        }
-
-        self.flusher.dispatch_tlb_flush();
     }
 
     /// Applies the operation to the next slot of mapping within the range.

--- a/ostd/src/task/kernel_stack.rs
+++ b/ostd/src/task/kernel_stack.rs
@@ -5,6 +5,7 @@ use crate::{
         kspace::kvirt_area::{KVirtArea, Tracked},
         page::{allocator, meta::KernelStackMeta},
         page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
+        tlb::TlbFlushOp,
         PAGE_SIZE,
     },
     prelude::*,
@@ -58,6 +59,10 @@ impl KernelStack {
 
     pub fn end_vaddr(&self) -> Vaddr {
         self.end_vaddr
+    }
+
+    pub fn tlb_flush_this_cpu(&self) {
+        TlbFlushOp::Range(self.kvirt_area.range()).perform_on_current();
     }
 }
 

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -63,6 +63,10 @@ impl Task {
         &self.ctx
     }
 
+    pub(super) fn flush_kstack_tlb(&self) {
+        self.kstack.tlb_flush_this_cpu();
+    }
+
     /// Sets thread-local storage pointer.
     pub fn set_tls_pointer(&self, tls: usize) {
         let ctx_ptr = self.ctx.get();

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -52,6 +52,10 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
     let next_task_ctx_ptr = next_task.ctx().get().cast_const();
     if let Some(next_user_space) = next_task.user_space() {
         next_user_space.vm_space().activate();
+    } else {
+        // FIXME: If the current task is migrated to another CPU after enabling
+        // IRQ and before switching to the next task, we may miss the TLB flush.
+        next_task.flush_kstack_tlb();
     }
 
     // Change the current task to the next task.

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -29,6 +29,9 @@ pub fn inject_scheduler(scheduler: &'static dyn Scheduler<Task>) {
             if local_rq.update_current(UpdateFlags::Tick) {
                 cpu_local::set_need_preempt();
             }
+
+            crate::mm::tlb::process_pending_shootdowns();
+            crate::mm::tlb::delayed_recycle_pages();
         })
     });
 }
@@ -250,6 +253,9 @@ where
             }
         };
     };
+
+    crate::mm::tlb::process_pending_shootdowns();
+    crate::mm::tlb::delayed_recycle_pages();
 
     // FIXME: At this point, we need to prevent the current task from being scheduled on another
     // CPU core. However, we currently have no way to ensure this. This is a soundness hole and

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -136,6 +136,7 @@ pub fn disable_local() -> DisabledLocalIrqGuard {
 /// A guard for disabled local IRQs.
 #[clippy::has_significant_drop]
 #[must_use]
+#[derive(Debug)]
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
 }


### PR DESCRIPTION
This is inspired by a previous work "Latr: Lazy Translation Coherence" ASPLOS '18 (but slightly different). We can minimize IPIs needed for maintaining TLB coherence using this apporach.

The previous approach, though lazy, will send too many IPIs if `unmap` is called too frequent on multiple cores. Then stack overflows because after an re-enabling interrupt there comes another IPI. With this PR the kernel won't silently crash even if all cores are `unmap`ing on a single virtual memory space.

~~This is built on top of #1601 . Review that first.~~ No need