### PR TITLE
Runs network polling code in softirq context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 name = "aster-bigtcp"
 version = "0.1.0"
 dependencies = [
+ "aster-softirq",
  "bitflags 1.3.2",
  "jhash",
  "ostd",
@@ -167,6 +168,7 @@ name = "aster-network"
 version = "0.1.0"
 dependencies = [
  "aster-bigtcp",
+ "aster-softirq",
  "bitvec",
  "component",
  "ostd",
@@ -288,6 +290,7 @@ dependencies = [
  "aster-input",
  "aster-network",
  "aster-rights",
+ "aster-softirq",
  "aster-util",
  "bitflags 1.3.2",
  "component",

--- a/kernel/comps/network/Cargo.toml
+++ b/kernel/comps/network/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
+aster-softirq = { path = "../softirq" }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 component = { path = "../../libs/comp-sys/component" }
 ostd = { path = "../../../ostd" }

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -2,12 +2,13 @@
 
 use alloc::{collections::linked_list::LinkedList, sync::Arc};
 
+use aster_softirq::BottomHalfDisabled;
 use ostd::{
     mm::{
         Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, Infallible, VmReader,
         VmWriter, PAGE_SIZE,
     },
-    sync::{LocalIrqDisabled, SpinLock},
+    sync::SpinLock,
     Pod,
 };
 use spin::Once;
@@ -17,14 +18,14 @@ use crate::dma_pool::{DmaPool, DmaSegment};
 pub struct TxBuffer {
     dma_stream: DmaStream,
     nbytes: usize,
-    pool: &'static SpinLock<LinkedList<DmaStream>, LocalIrqDisabled>,
+    pool: &'static SpinLock<LinkedList<DmaStream>, BottomHalfDisabled>,
 }
 
 impl TxBuffer {
     pub fn new<H: Pod>(
         header: &H,
         packet: &[u8],
-        pool: &'static SpinLock<LinkedList<DmaStream>, LocalIrqDisabled>,
+        pool: &'static SpinLock<LinkedList<DmaStream>, BottomHalfDisabled>,
     ) -> Self {
         let header = header.as_bytes();
         let nbytes = header.len() + packet.len();

--- a/kernel/comps/softirq/src/lock.rs
+++ b/kernel/comps/softirq/src/lock.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{
+    cpu_local_cell,
+    sync::{GuardTransfer, SpinGuardian},
+    task::{
+        atomic_mode::{AsAtomicModeGuard, InAtomicMode},
+        disable_preempt, DisabledPreemptGuard,
+    },
+    trap::{disable_local, in_interrupt_context},
+};
+
+use crate::process_all_pending;
+
+cpu_local_cell! {
+    static DISABLE_SOFTIRQ_COUNT: u8 = 0;
+}
+
+/// Returns whether softirq is enabled on local CPU.
+pub(super) fn is_softirq_enabled() -> bool {
+    DISABLE_SOFTIRQ_COUNT.load() == 0
+}
+
+/// A guardian that disables bottom half while holding a lock.
+pub enum BottomHalfDisabled {}
+
+/// A guard for disabled local softirqs.
+pub struct DisableLocalBottomHalfGuard {
+    preempt: DisabledPreemptGuard,
+}
+
+impl AsAtomicModeGuard for DisableLocalBottomHalfGuard {
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode {
+        &self.preempt
+    }
+}
+
+impl Drop for DisableLocalBottomHalfGuard {
+    fn drop(&mut self) {
+        // Once the guard is dropped, we will process pending items within
+        // the current thread's context if softirq is going to be enabled.
+        // This behavior is similar to how Linux handles pending softirqs.
+        if DISABLE_SOFTIRQ_COUNT.load() == 1 && !in_interrupt_context() {
+            // Preemption and softirq are not really enabled at the moment,
+            // so we can guarantee that we'll process any pending softirqs for the current CPU.
+            let irq_guard = disable_local();
+            let irq_guard = process_all_pending(irq_guard);
+
+            // To avoid race conditions, we should decrease the softirq count first,
+            // then drop the IRQ guard.
+            DISABLE_SOFTIRQ_COUNT.sub_assign(1);
+            drop(irq_guard);
+            return;
+        }
+
+        DISABLE_SOFTIRQ_COUNT.sub_assign(1);
+    }
+}
+
+#[must_use]
+fn disable_local_bottom_half() -> DisableLocalBottomHalfGuard {
+    // When disabling softirq, we must also disable preemption
+    // to avoid the task to be scheduled to other CPUs.
+    let preempt = disable_preempt();
+    DISABLE_SOFTIRQ_COUNT.add_assign(1);
+    DisableLocalBottomHalfGuard { preempt }
+}
+
+impl GuardTransfer for DisableLocalBottomHalfGuard {
+    fn transfer_to(&mut self) -> Self {
+        disable_local_bottom_half()
+    }
+}
+
+impl SpinGuardian for BottomHalfDisabled {
+    type Guard = DisableLocalBottomHalfGuard;
+    type ReadGuard = DisableLocalBottomHalfGuard;
+
+    fn read_guard() -> Self::ReadGuard {
+        disable_local_bottom_half()
+    }
+
+    fn guard() -> Self::Guard {
+        disable_local_bottom_half()
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use ostd::{
+        prelude::*,
+        sync::{RwLock, SpinLock},
+    };
+
+    use super::*;
+
+    #[ktest]
+    fn spinlock_disable_bh() {
+        let lock = SpinLock::<(), BottomHalfDisabled>::new(());
+
+        assert!(is_softirq_enabled());
+
+        let guard = lock.lock();
+        assert!(!is_softirq_enabled());
+
+        drop(guard);
+        assert!(is_softirq_enabled());
+    }
+
+    #[ktest]
+    fn nested_spin_lock_disable_bh() {
+        let lock1 = SpinLock::<(), BottomHalfDisabled>::new(());
+        let lock2 = SpinLock::<(), BottomHalfDisabled>::new(());
+
+        assert!(is_softirq_enabled());
+
+        let guard1 = lock1.lock();
+        let guard2 = lock2.lock();
+        assert!(!is_softirq_enabled());
+
+        drop(guard1);
+        assert!(!is_softirq_enabled());
+
+        drop(guard2);
+        assert!(is_softirq_enabled());
+    }
+
+    #[ktest]
+    fn rwlock_disable_bh() {
+        let rwlock: RwLock<(), BottomHalfDisabled> = RwLock::new(());
+
+        assert!(is_softirq_enabled());
+
+        let write_guard = rwlock.write();
+        assert!(!is_softirq_enabled());
+
+        drop(write_guard);
+        assert!(is_softirq_enabled());
+    }
+
+    #[ktest]
+    fn nested_rwlock_disable_bh() {
+        let rwlock: RwLock<(), BottomHalfDisabled> = RwLock::new(());
+
+        assert!(is_softirq_enabled());
+
+        let read_guard1 = rwlock.read();
+        let read_guard2 = rwlock.read();
+        assert!(!is_softirq_enabled());
+
+        drop(read_guard1);
+        assert!(!is_softirq_enabled());
+
+        drop(read_guard2);
+        assert!(is_softirq_enabled());
+    }
+
+    #[test]
+    fn upgradable_rwlock_disable_bh() {
+        let rwlock: RwLock<(), BottomHalfDisabled> = RwLock::new(());
+
+        assert!(is_softirq_enabled());
+
+        let upgrade_guard = rwlock.upread();
+        assert!(!is_softirq_enabled());
+
+        let write_guard = upgrade_guard.upgrade();
+        assert!(!is_softirq_enabled());
+
+        let read_guard = write_guard.downgrade();
+        assert!(!is_softirq_enabled());
+
+        drop(read_guard);
+        assert!(is_softirq_enabled());
+    }
+}

--- a/kernel/comps/softirq/src/softirq_id.rs
+++ b/kernel/comps/softirq/src/softirq_id.rs
@@ -11,3 +11,9 @@ pub const TIMER_SOFTIRQ_ID: u8 = 1;
 
 /// The corresponding softirq line is used to schedule general taskless jobs.
 pub const TASKLESS_SOFTIRQ_ID: u8 = 2;
+
+/// The corresponding softirq line is used to handle transmission network events.
+pub const NETWORK_TX_SOFTIRQ_ID: u8 = 3;
+
+/// The corresponding softirq line is used to handle reception network events.
+pub const NETWORK_RX_SOFTIRQ_ID: u8 = 4;

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -15,6 +15,7 @@ aster-console = { path = "../console" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
+aster-softirq = { path = "../softirq"}
 id-alloc = { path = "../../../ostd/libs/id-alloc" }
 typeflags-util = { path = "../../libs/typeflags-util" }
 ostd = { path = "../../../ostd" }

--- a/kernel/comps/virtio/src/device/socket/buffer.rs
+++ b/kernel/comps/virtio/src/device/socket/buffer.rs
@@ -3,15 +3,16 @@
 use alloc::{collections::linked_list::LinkedList, sync::Arc};
 
 use aster_network::dma_pool::DmaPool;
+use aster_softirq::BottomHalfDisabled;
 use ostd::{
     mm::{DmaDirection, DmaStream},
-    sync::{LocalIrqDisabled, SpinLock},
+    sync::SpinLock,
 };
 use spin::Once;
 
 const RX_BUFFER_LEN: usize = 4096;
 pub static RX_BUFFER_POOL: Once<Arc<DmaPool>> = Once::new();
-pub static TX_BUFFER_POOL: Once<SpinLock<LinkedList<DmaStream>, LocalIrqDisabled>> = Once::new();
+pub static TX_BUFFER_POOL: Once<SpinLock<LinkedList<DmaStream>, BottomHalfDisabled>> = Once::new();
 
 pub fn init() {
     const POOL_INIT_SIZE: usize = 32;

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aster-softirq = { path = "../../comps/softirq" }
 bitflags = "1.3"
 jhash = { path = "../jhash" }
 ostd = { path = "../../../ostd" }

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -7,7 +7,8 @@ use alloc::{
     vec::Vec,
 };
 
-use ostd::sync::{LocalIrqDisabled, SpinLock, SpinLockGuard};
+use aster_softirq::BottomHalfDisabled;
+use ostd::sync::{SpinLock, SpinLockGuard};
 use smoltcp::{
     iface::{packet::Packet, Context},
     phy::Device,
@@ -30,9 +31,9 @@ use crate::{
 
 pub struct IfaceCommon<E: Ext> {
     name: String,
-    interface: SpinLock<PollableIface<E>, LocalIrqDisabled>,
-    used_ports: SpinLock<BTreeMap<u16, usize>, LocalIrqDisabled>,
-    sockets: SpinLock<SocketTable<E>, LocalIrqDisabled>,
+    interface: SpinLock<PollableIface<E>, BottomHalfDisabled>,
+    used_ports: SpinLock<BTreeMap<u16, usize>, BottomHalfDisabled>,
+    sockets: SpinLock<SocketTable<E>, BottomHalfDisabled>,
     sched_poll: E::ScheduleNextPoll,
 }
 
@@ -67,12 +68,12 @@ impl<E: Ext> IfaceCommon<E> {
 // Lock order: `interface` -> `sockets`
 impl<E: Ext> IfaceCommon<E> {
     /// Acquires the lock to the interface.
-    pub(crate) fn interface(&self) -> SpinLockGuard<'_, PollableIface<E>, LocalIrqDisabled> {
+    pub(crate) fn interface(&self) -> SpinLockGuard<'_, PollableIface<E>, BottomHalfDisabled> {
         self.interface.lock()
     }
 
     /// Acquires the lock to the socket table.
-    pub(crate) fn sockets(&self) -> SpinLockGuard<'_, SocketTable<E>, LocalIrqDisabled> {
+    pub(crate) fn sockets(&self) -> SpinLockGuard<'_, SocketTable<E>, BottomHalfDisabled> {
         self.sockets.lock()
     }
 }

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -2,7 +2,8 @@
 
 use alloc::{collections::btree_map::BTreeMap, string::String, sync::Arc};
 
-use ostd::sync::{LocalIrqDisabled, SpinLock};
+use aster_softirq::BottomHalfDisabled;
+use ostd::sync::SpinLock;
 use smoltcp::{
     iface::{packet::Packet, Config, Context},
     phy::{DeviceCapabilities, TxToken},
@@ -25,7 +26,7 @@ pub struct EtherIface<D, E: Ext> {
     driver: D,
     common: IfaceCommon<E>,
     ether_addr: EthernetAddress,
-    arp_table: SpinLock<BTreeMap<Ipv4Address, EthernetAddress>, LocalIrqDisabled>,
+    arp_table: SpinLock<BTreeMap<Ipv4Address, EthernetAddress>, BottomHalfDisabled>,
 }
 
 impl<D: WithDevice, E: Ext> EtherIface<D, E> {

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -6,7 +6,8 @@ use alloc::{
 };
 use core::ops::{Deref, DerefMut};
 
-use ostd::sync::{LocalIrqDisabled, SpinLock, SpinLockGuard};
+use aster_softirq::BottomHalfDisabled;
+use ostd::sync::{SpinLock, SpinLockGuard};
 use smoltcp::{
     socket::{tcp::State, PollAt},
     time::Duration,
@@ -34,7 +35,7 @@ pub type TcpConnection<E> = Socket<TcpConnectionInner<E>, E>;
 
 /// States needed by [`TcpConnectionBg`].
 pub struct TcpConnectionInner<E: Ext> {
-    socket: SpinLock<RawTcpSocketExt<E>, LocalIrqDisabled>,
+    socket: SpinLock<RawTcpSocketExt<E>, BottomHalfDisabled>,
     poll_key: PollKey,
     connection_key: ConnectionKey,
 }
@@ -243,7 +244,7 @@ impl<E: Ext> TcpConnectionInner<E> {
         }
     }
 
-    pub(super) fn lock(&self) -> SpinLockGuard<RawTcpSocketExt<E>, LocalIrqDisabled> {
+    pub(super) fn lock(&self) -> SpinLockGuard<RawTcpSocketExt<E>, BottomHalfDisabled> {
         self.socket.lock()
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -2,7 +2,8 @@
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, sync::Arc, vec::Vec};
 
-use ostd::sync::{LocalIrqDisabled, SpinLock};
+use aster_softirq::BottomHalfDisabled;
+use ostd::sync::SpinLock;
 use smoltcp::{
     socket::PollAt,
     time::Duration,
@@ -35,7 +36,7 @@ pub struct TcpBacklog<E: Ext> {
 
 /// States needed by [`TcpListenerBg`].
 pub struct TcpListenerInner<E: Ext> {
-    pub(super) backlog: SpinLock<TcpBacklog<E>, LocalIrqDisabled>,
+    pub(super) backlog: SpinLock<TcpBacklog<E>, BottomHalfDisabled>,
     listener_key: ListenerKey,
 }
 

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -3,7 +3,8 @@
 use alloc::{boxed::Box, sync::Arc};
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use ostd::sync::{LocalIrqDisabled, SpinLock};
+use aster_softirq::BottomHalfDisabled;
+use ostd::sync::SpinLock;
 use smoltcp::{
     iface::Context,
     socket::udp::UdpMetadata,
@@ -22,7 +23,7 @@ pub type UdpSocket<E> = Socket<UdpSocketInner, E>;
 
 /// States needed by [`UdpSocketBg`].
 pub struct UdpSocketInner {
-    socket: SpinLock<Box<RawUdpSocket>, LocalIrqDisabled>,
+    socket: SpinLock<Box<RawUdpSocket>, BottomHalfDisabled>,
     need_dispatch: AtomicBool,
 }
 

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -3,7 +3,7 @@
 use alloc::{borrow::ToOwned, sync::Arc};
 
 use aster_bigtcp::device::WithDevice;
-use ostd::sync::LocalIrqDisabled;
+use aster_softirq::BottomHalfDisabled;
 use spin::Once;
 
 use super::{poll::poll_ifaces, Iface};
@@ -52,7 +52,7 @@ fn new_virtio() -> Option<Arc<Iface>> {
 
     let ether_addr = virtio_net.lock().mac_addr().0;
 
-    struct Wrapper(Arc<SpinLock<dyn AnyNetworkDevice, LocalIrqDisabled>>);
+    struct Wrapper(Arc<SpinLock<dyn AnyNetworkDevice, BottomHalfDisabled>>);
 
     impl WithDevice for Wrapper {
         type Device = dyn AnyNetworkDevice;

--- a/ostd/src/sync/guard.rs
+++ b/ostd/src/sync/guard.rs
@@ -32,7 +32,7 @@ pub trait GuardTransfer {
 }
 
 /// A guardian that disables preemption while holding a lock.
-pub struct PreemptDisabled;
+pub enum PreemptDisabled {}
 
 impl SpinGuardian for PreemptDisabled {
     type Guard = DisabledPreemptGuard;
@@ -53,7 +53,7 @@ impl SpinGuardian for PreemptDisabled {
 /// IRQ handlers are allowed to get executed while holding the
 /// lock. For example, if a lock is never used in the interrupt
 /// context, then it is ok not to use this guardian in the process context.
-pub struct LocalIrqDisabled;
+pub enum LocalIrqDisabled {}
 
 impl SpinGuardian for LocalIrqDisabled {
     type Guard = DisabledLocalIrqGuard;
@@ -79,7 +79,7 @@ impl SpinGuardian for LocalIrqDisabled {
 ///
 /// [`RwLock`]: super::RwLock
 /// [`SpinLock`]: super::SpinLock
-pub struct WriteIrqDisabled;
+pub enum WriteIrqDisabled {}
 
 impl SpinGuardian for WriteIrqDisabled {
     type Guard = DisabledLocalIrqGuard;

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -11,9 +11,9 @@ mod rwmutex;
 mod spin;
 mod wait;
 
-pub(crate) use self::{guard::GuardTransfer, rcu::finish_grace_period};
+pub(crate) use self::rcu::finish_grace_period;
 pub use self::{
-    guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
+    guard::{GuardTransfer, LocalIrqDisabled, PreemptDisabled, SpinGuardian, WriteIrqDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
     rcu::{non_null, Rcu, RcuOption, RcuOptionReadGuard, RcuReadGuard},
     rwarc::{RoArc, RwArc},


### PR DESCRIPTION
This PR moves network polling code to softirq context.

The first commit add a new guard type which will disable bottom half when holding lock. Further, I refactor all guard type as empty enum since they can't be constructed.

The second commit refactor all locks in network subsystem. And the irq handler only raise softirq without doing any poll code.