### PR TITLE
Refactor Rwlock to take type parameter

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket/bound.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound.rs
@@ -46,7 +46,7 @@ pub struct BoundSocketInner<T, E> {
     iface: Arc<dyn Iface<E>>,
     port: u16,
     socket: T,
-    observer: RwLock<Weak<dyn SocketEventObserver>>,
+    observer: RwLock<Weak<dyn SocketEventObserver>, LocalIrqDisabled>,
     events: AtomicU8,
     next_poll_at_ms: AtomicU64,
 }
@@ -223,7 +223,7 @@ impl<T: AnySocket, E> BoundSocket<T, E> {
     /// that the old observer will never be called after the setting. Users should be aware of this
     /// and proactively handle the race conditions if necessary.
     pub fn set_observer(&self, new_observer: Weak<dyn SocketEventObserver>) {
-        *self.0.observer.write_irq_disabled() = new_observer;
+        *self.0.observer.write() = new_observer;
 
         self.0.on_events();
     }

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -12,7 +12,7 @@ use aster_util::slot_vec::SlotVec;
 use hashbrown::HashMap;
 use ostd::{
     mm::{Frame, VmIo},
-    sync::RwLockWriteGuard,
+    sync::{PreemptDisabled, RwLockWriteGuard},
 };
 
 use super::*;
@@ -1195,8 +1195,8 @@ fn write_lock_two_direntries_by_ino<'a>(
     this: (u64, &'a RwLock<DirEntry>),
     other: (u64, &'a RwLock<DirEntry>),
 ) -> (
-    RwLockWriteGuard<'a, DirEntry>,
-    RwLockWriteGuard<'a, DirEntry>,
+    RwLockWriteGuard<'a, DirEntry, PreemptDisabled>,
+    RwLockWriteGuard<'a, DirEntry, PreemptDisabled>,
 ) {
     if this.0 < other.0 {
         let this = this.1.write();

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -290,11 +290,11 @@ pub fn create_sem_set(nsems: usize, mode: u16, credentials: Credentials<ReadOp>)
     Ok(id)
 }
 
-pub fn sem_sets<'a>() -> RwLockReadGuard<'a, BTreeMap<key_t, SemaphoreSet>> {
+pub fn sem_sets<'a>() -> RwLockReadGuard<'a, BTreeMap<key_t, SemaphoreSet>, PreemptDisabled> {
     SEMAPHORE_SETS.read()
 }
 
-pub fn sem_sets_mut<'a>() -> RwLockWriteGuard<'a, BTreeMap<key_t, SemaphoreSet>> {
+pub fn sem_sets_mut<'a>() -> RwLockWriteGuard<'a, BTreeMap<key_t, SemaphoreSet>, PreemptDisabled> {
     SEMAPHORE_SETS.write()
 }
 

--- a/kernel/src/net/socket/vsock/common.rs
+++ b/kernel/src/net/socket/vsock/common.rs
@@ -7,6 +7,7 @@ use aster_virtio::device::socket::{
     device::SocketDevice,
     error::SocketError,
 };
+use ostd::sync::LocalIrqDisabled;
 
 use super::{
     addr::VsockSocketAddr,
@@ -26,7 +27,7 @@ pub struct VsockSpace {
     // (key, value) = (local_addr, listen)
     listen_sockets: SpinLock<BTreeMap<VsockSocketAddr, Arc<Listen>>>,
     // (key, value) = (id(local_addr,peer_addr), connected)
-    connected_sockets: RwLock<BTreeMap<ConnectionID, Arc<Connected>>>,
+    connected_sockets: RwLock<BTreeMap<ConnectionID, Arc<Connected>>, LocalIrqDisabled>,
     // Used ports
     used_ports: SpinLock<BTreeSet<u32>>,
 }
@@ -54,10 +55,7 @@ impl VsockSpace {
                 .disable_irq()
                 .lock()
                 .contains_key(&event.destination.into())
-            || self
-                .connected_sockets
-                .read_irq_disabled()
-                .contains_key(&(*event).into())
+            || self.connected_sockets.read().contains_key(&(*event).into())
     }
 
     /// Alloc an unused port range
@@ -91,13 +89,13 @@ impl VsockSpace {
         id: ConnectionID,
         connected: Arc<Connected>,
     ) -> Option<Arc<Connected>> {
-        let mut connected_sockets = self.connected_sockets.write_irq_disabled();
+        let mut connected_sockets = self.connected_sockets.write();
         connected_sockets.insert(id, connected)
     }
 
     /// Remove a connected socket
     pub fn remove_connected_socket(&self, id: &ConnectionID) -> Option<Arc<Connected>> {
-        let mut connected_sockets = self.connected_sockets.write_irq_disabled();
+        let mut connected_sockets = self.connected_sockets.write();
         connected_sockets.remove(id)
     }
 
@@ -214,11 +212,7 @@ impl VsockSpace {
 
             debug!("vsock receive event: {:?}", event);
             // The socket must be stored in the VsockSpace.
-            if let Some(connected) = self
-                .connected_sockets
-                .read_irq_disabled()
-                .get(&event.into())
-            {
+            if let Some(connected) = self.connected_sockets.read().get(&event.into()) {
                 connected.update_info(&event);
             }
 
@@ -255,7 +249,7 @@ impl VsockSpace {
                     connecting.set_connected();
                 }
                 VsockEventType::Disconnected { .. } => {
-                    let connected_sockets = self.connected_sockets.read_irq_disabled();
+                    let connected_sockets = self.connected_sockets.read();
                     let Some(connected) = connected_sockets.get(&event.into()) else {
                         return_errno_with_message!(Errno::ENOTCONN, "the socket hasn't connected");
                     };
@@ -263,7 +257,7 @@ impl VsockSpace {
                 }
                 VsockEventType::Received { .. } => {}
                 VsockEventType::CreditRequest => {
-                    let connected_sockets = self.connected_sockets.read_irq_disabled();
+                    let connected_sockets = self.connected_sockets.read();
                     let Some(connected) = connected_sockets.get(&event.into()) else {
                         return_errno_with_message!(Errno::ENOTCONN, "the socket hasn't connected");
                     };
@@ -272,7 +266,7 @@ impl VsockSpace {
                     })?;
                 }
                 VsockEventType::CreditUpdate => {
-                    let connected_sockets = self.connected_sockets.read_irq_disabled();
+                    let connected_sockets = self.connected_sockets.read();
                     let Some(connected) = connected_sockets.get(&event.into()) else {
                         return_errno_with_message!(Errno::ENOTCONN, "the socket hasn't connected");
                     };
@@ -289,7 +283,7 @@ impl VsockSpace {
                 // Deal with Received before the buffer are recycled.
                 if let VsockEventType::Received { .. } = event.event_type {
                     // Only consider the connected socket and copy body to buffer
-                    let connected_sockets = self.connected_sockets.read_irq_disabled();
+                    let connected_sockets = self.connected_sockets.read();
                     let connected = connected_sockets.get(&event.into()).unwrap();
                     debug!("Rw matches a connection with id {:?}", connected.id());
                     if !connected.add_connection_buffer(body) {

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -2,7 +2,7 @@
 
 use core::sync::atomic::Ordering;
 
-use ostd::sync::{RwLockReadGuard, RwLockWriteGuard};
+use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{group::AtomicGid, user::AtomicUid, Gid, Uid};
 use crate::{
@@ -387,11 +387,11 @@ impl Credentials_ {
 
     //  ******* Supplementary groups methods *******
 
-    pub(super) fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>> {
+    pub(super) fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>, PreemptDisabled> {
         self.supplementary_gids.read()
     }
 
-    pub(super) fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>> {
+    pub(super) fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>, PreemptDisabled> {
         self.supplementary_gids.write()
     }
 

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -4,7 +4,7 @@
 
 use aster_rights::{Dup, Read, TRights, Write};
 use aster_rights_proc::require;
-use ostd::sync::{RwLockReadGuard, RwLockWriteGuard};
+use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{capabilities::CapSet, credentials_::Credentials_, Credentials, Gid, Uid};
 use crate::prelude::*;
@@ -239,7 +239,7 @@ impl<R: TRights> Credentials<R> {
     ///
     /// This method requires the `Read` right.
     #[require(R > Read)]
-    pub fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>> {
+    pub fn groups(&self) -> RwLockReadGuard<BTreeSet<Gid>, PreemptDisabled> {
         self.0.groups()
     }
 
@@ -247,7 +247,7 @@ impl<R: TRights> Credentials<R> {
     ///
     /// This method requires the `Write` right.
     #[require(R > Write)]
-    pub fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>> {
+    pub fn groups_mut(&self) -> RwLockWriteGuard<BTreeSet<Gid>, PreemptDisabled> {
         self.0.groups_mut()
     }
 

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -13,7 +13,7 @@ use x86_64::registers::rflags::{self, RFlags};
 use super::iommu::{alloc_irt_entry, has_interrupt_remapping, IrtEntryHandle};
 use crate::{
     cpu::CpuId,
-    sync::{LocalIrqDisabled, Mutex, RwLock, RwLockReadGuard, SpinLock},
+    sync::{LocalIrqDisabled, Mutex, PreemptDisabled, RwLock, RwLockReadGuard, SpinLock},
     trap::TrapFrame,
 };
 
@@ -119,7 +119,9 @@ impl IrqLine {
         self.irq_num
     }
 
-    pub fn callback_list(&self) -> RwLockReadGuard<alloc::vec::Vec<CallbackElement>> {
+    pub fn callback_list(
+        &self,
+    ) -> RwLockReadGuard<alloc::vec::Vec<CallbackElement>, PreemptDisabled> {
         self.callback_list.read()
     }
 

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -25,7 +25,7 @@ use crate::{
         Frame, PageProperty, VmReader, VmWriter, MAX_USERSPACE_VADDR,
     },
     prelude::*,
-    sync::{RwLock, RwLockReadGuard},
+    sync::{PreemptDisabled, RwLock, RwLockReadGuard},
     task::{disable_preempt, DisabledPreemptGuard},
     Error,
 };
@@ -283,7 +283,7 @@ impl Cursor<'_> {
 pub struct CursorMut<'a, 'b> {
     pt_cursor: page_table::CursorMut<'a, UserMode, PageTableEntry, PagingConsts>,
     #[allow(dead_code)]
-    activation_lock: RwLockReadGuard<'b, ()>,
+    activation_lock: RwLockReadGuard<'b, (), PreemptDisabled>,
     // We have a read lock so the CPU set in the flusher is always a superset
     // of actual activated CPUs.
     flusher: TlbFlusher<DisabledPreemptGuard>,

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -22,6 +22,8 @@ pub use self::{
         ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
         RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
     },
-    spin::{ArcSpinLockGuard, LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard},
+    spin::{
+        ArcSpinLockGuard, GuardTransfer, LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard,
+    },
     wait::{WaitQueue, Waiter, Waker},
 };

--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::sync::GuardTransfer;
+
 /// A guard for disable preempt.
 #[clippy::has_significant_drop]
 #[must_use]
@@ -16,10 +18,10 @@ impl DisabledPreemptGuard {
         super::cpu_local::inc_guard_count();
         Self { _private: () }
     }
+}
 
-    /// Transfer this guard to a new guard.
-    /// This guard must be dropped after this function.
-    pub fn transfer_to(&self) -> Self {
+impl GuardTransfer for DisabledPreemptGuard {
+    fn transfer_to(&mut self) -> Self {
         disable_preempt()
     }
 }

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -7,6 +7,7 @@ use core::fmt::Debug;
 use crate::{
     arch::irq::{self, IrqCallbackHandle, IRQ_ALLOCATOR},
     prelude::*,
+    sync::GuardTransfer,
     trap::TrapFrame,
     Error,
 };
@@ -149,10 +150,10 @@ impl DisabledLocalIrqGuard {
         }
         Self { was_enabled }
     }
+}
 
-    /// Transfers the saved IRQ status of this guard to a new guard.
-    /// The saved IRQ status of this guard is cleared.
-    pub fn transfer_to(&mut self) -> Self {
+impl GuardTransfer for DisabledLocalIrqGuard {
+    fn transfer_to(&mut self) -> Self {
         let was_enabled = self.was_enabled;
         self.was_enabled = false;
         Self { was_enabled }


### PR DESCRIPTION
This PR aims to allow `RwLock` to accept the same type parameter as `SpinLock`, enabling `RwLock` to be used in a manner similar to `SpinLock`, such as `RwLock<T, LocalIrqDisabled>`. This PR does NOT introduce any functional changes to `RwLock`.

I proposed this change because I want to introduce locks that can disable the bottom half in #1623. Since softirq is defined outside of OSTD, it follows that these locks should also be defined outside of OSTD. While it is straightforward to define a bottom-half-disabled `SpinLock` outside of OSTD using the current APIs, doing the same for `RwLock` is not as simple. Consequently, I have refactored the `RwLock` APIs in a similar fashion.