### PR TITLE
Avoid `Arc::{clone,drop}` in `switch_to_task`

### DIFF
--- a/ostd/src/cpu/local/cell.rs
+++ b/ostd/src/cpu/local/cell.rs
@@ -109,7 +109,7 @@ impl<T: 'static> CpuLocalCell<T> {
     ///   data should be done with interrupts disabled. Otherwise, more care
     ///   must be taken to ensure that the borrowing rules are correctly
     ///   enforced, since the interrupts may come asynchronously.
-    pub fn as_ptr_mut(&'static self) -> *mut T {
+    pub fn as_mut_ptr(&'static self) -> *mut T {
         super::has_init::assert_true();
 
         let offset = {

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -163,6 +163,9 @@ impl TaskOptions {
         /// all task will entering this function
         /// this function is mean to executing the task_fn in Task
         extern "C" fn kernel_task_entry() -> ! {
+            // See `switch_to_task` for why we need this.
+            crate::arch::irq::enable_local();
+
             let current_task = Task::current()
                 .expect("no current task, it should have current task in kernel task entry");
 

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -39,19 +39,14 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
     let irq_guard = crate::trap::disable_local();
 
     let current_task_ptr = CURRENT_TASK_PTR.load();
-    let current_task_ctx_ptr = if current_task_ptr.is_null() {
+    let current_task_ctx_ptr = if !current_task_ptr.is_null() {
+        // SAFETY: The current task is always alive.
+        let current_task = unsafe { &*current_task_ptr };
+        // Throughout this method, the task's context is alive and can be exclusively used.
+        current_task.ctx.get()
+    } else {
         // SAFETY: Interrupts are disabled, so the pointer is safe to be fetched.
         unsafe { BOOTSTRAP_CONTEXT.as_ptr_mut() }
-    } else {
-        // SAFETY: The pointer is not NULL and set as the current task.
-        let cur_task_arc = unsafe {
-            let restored = Arc::from_raw(current_task_ptr);
-            let _ = core::mem::ManuallyDrop::new(restored.clone());
-            restored
-        };
-        let ctx_ptr = cur_task_arc.ctx().get();
-
-        ctx_ptr
     };
 
     let next_task_ctx_ptr = next_task.ctx().get().cast_const();

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -46,7 +46,7 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
         current_task.ctx.get()
     } else {
         // Throughout this method, interrupts are disabled and the context can be exclusively used.
-        BOOTSTRAP_CONTEXT.as_ptr_mut()
+        BOOTSTRAP_CONTEXT.as_mut_ptr()
     };
 
     let next_task_ctx_ptr = next_task.ctx().get().cast_const();

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -45,8 +45,8 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
         // Throughout this method, the task's context is alive and can be exclusively used.
         current_task.ctx.get()
     } else {
-        // SAFETY: Interrupts are disabled, so the pointer is safe to be fetched.
-        unsafe { BOOTSTRAP_CONTEXT.as_ptr_mut() }
+        // Throughout this method, interrupts are disabled and the context can be exclusively used.
+        BOOTSTRAP_CONTEXT.as_ptr_mut()
     };
 
     let next_task_ctx_ptr = next_task.ctx().get().cast_const();


### PR DESCRIPTION
In `switch_to_task`, we create an `Arc<task>` for the current task, and then immediately drop it.
https://github.com/asterinas/asterinas/blob/1fac73764621fd8c4959c5eff0f2aa81109f7120/ostd/src/task/processor.rs#L46-L52

This is not necessary, and can be avoided.

Besides, we drop `irq_guard` before calling `context_switch`, which is a somehow wired implementation.
https://github.com/asterinas/asterinas/blob/1fac73764621fd8c4959c5eff0f2aa81109f7120/ostd/src/task/processor.rs#L77
https://github.com/asterinas/asterinas/blob/1fac73764621fd8c4959c5eff0f2aa81109f7120/ostd/src/task/processor.rs#L86
 - If we don't consider kernel preemption, we should just remove this IRQ guard, as it is not necessary.
 - If we consider kernel preemption, we should keep IRQ disabled during `context_switch`.

So, I'm converting the code to disable IRQ during `context_switch`.

Finally, `CpuLocalCell::as_ptr_mut` should be safe to call. The real unsafety comes when we dereference the pointer, and requiring "preemption disabled" when calling `as_ptr_mut` just doesn't help. Instead, we should require preemption to be disabled from the time we call `as_ptr_mut` _to the time we dereference the pointer_.