### PR TITLE
Stabilize the benchmark results of FIO

### DIFF
--- a/test/benchmark/fio/ext2_iommu_seq_read_bw/run.sh
+++ b/test/benchmark/fio/ext2_iommu_seq_read_bw/run.sh
@@ -9,4 +9,4 @@ echo "*** Running the FIO sequential read test (Ext2) ***"
 /benchmark/bin/fio -rw=read -filename=/ext2/fio-test -name=seqread \
 -size=1G -bs=1M \
 -ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
--time_based=1 -runtime=60
+-time_based=1 -ramp_time=60 -runtime=100

--- a/test/benchmark/fio/ext2_iommu_seq_write_bw/run.sh
+++ b/test/benchmark/fio/ext2_iommu_seq_write_bw/run.sh
@@ -9,4 +9,4 @@ echo "*** Running the FIO sequential write test (Ext2) ***"
 /benchmark/bin/fio -rw=write -filename=/ext2/fio-test -name=seqwrite \
 -size=1G -bs=1M \
 -ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
--time_based=1 -runtime=60
+-time_based=1 -ramp_time=60 -runtime=100

--- a/test/benchmark/fio/ext2_seq_read_bw/run.sh
+++ b/test/benchmark/fio/ext2_seq_read_bw/run.sh
@@ -9,4 +9,4 @@ echo "*** Running the FIO sequential read test (Ext2) ***"
 /benchmark/bin/fio -rw=read -filename=/ext2/fio-test -name=seqread \
 -size=1G -bs=1M \
 -ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
--time_based=1 -runtime=60
+-time_based=1 -ramp_time=60 -runtime=100

--- a/test/benchmark/fio/ext2_seq_write_bw/run.sh
+++ b/test/benchmark/fio/ext2_seq_write_bw/run.sh
@@ -9,4 +9,4 @@ echo "*** Running the FIO sequential write test (Ext2) ***"
 /benchmark/bin/fio -rw=write -filename=/ext2/fio-test -name=seqwrite \
 -size=1G -bs=1M \
 -ioengine=sync -direct=1 -numjobs=1 -fsync_on_close=1 \
--time_based=1 -runtime=60
+-time_based=1 -ramp_time=60 -runtime=100


### PR DESCRIPTION
This PR attempts to stabilize the benchmark results of FIO in the current CI to avoid false alarms.

Specifically, the FIO time-related command changes from `-runtime 60` to `-ramp_time=60 -runtime=100`. This results into a 60s first for warming up without any logging, then a 100s of testing for logging.

Before this change, the most fluctuating group 'seq-read' in CI has the `max_res_bw - min_res_bw = 1320`, `min_res_bw / max_res_bw = 63.82%`, showed [here](https://asterinas.github.io/benchmark/fio/#:~:text=1M%20%2Ddirect%3D1-,%5BExt2%5D%20The%20bandwidth%20of%20sequential%20reads,-fio%20%2Dfilename%3D/ext2).
After this change, the group 'seq-read' locally (10 times) has the `max_res_bw - min_res_bw = 233`, `min_res_bw / max_res_bw = 87.16%`.

Reference: https://fio.readthedocs.io/en/latest/fio_doc.html