### PR TITLE
Fix benchmark CI failure

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 60
     container: 
       image: asterinas/asterinas:0.9.4
-      options: --device=/dev/kvm
+      options: --device=/dev/kvm --privileged
     env:
       # Need to set up proxy since the self-hosted CI server is located in China,
       # which has poor network connection to the official Rust crate repositories.


### PR DESCRIPTION
This PR fixes the benchmark CI failure as witnessed in [this action](https://github.com/asterinas/asterinas/actions/runs/11940832528).

The error is because our benchmark container does not start with `--privileged`, so `/dev/net/tun` and `/dev/vhost-net` are not visible in the container.

I follow the options of TDX CI to start container with `--privileged`, thus these devices can be visible in the container.