### PR TITLE
Support FPU state Save/Restore

### DIFF
--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -62,6 +62,8 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
         };
 
         loop {
+            // Restore the FP state before returning to user space.
+            ctx.task.restore_fp_states();
             let return_reason = user_mode.execute(has_kernel_event_fn);
             let user_ctx = user_mode.context_mut();
             // handle user event:

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -112,6 +112,21 @@ impl Task {
             None
         }
     }
+
+    /// Restores the FP states of the user task.
+    ///
+    /// # Panics
+    ///
+    /// If the task is not a user task.
+    pub fn restore_fp_states(&self) {
+        assert!(self.user_space.is_some());
+        let ctx_ptr = self.ctx.get();
+
+        // SAFETY: it's safe to restore FP states in user context.
+        unsafe {
+            (*ctx_ptr).restore_fp_states();
+        }
+    }
 }
 
 /// Options to create or spawn a new task.


### PR DESCRIPTION
This PR corrects the behavior of FPU state transfer between user and kernel space. It adds the eagerly FPU state save/restore support with XSAVE/XRSTOR (Besides there exists the lazy mechanism: https://en.wikipedia.org/wiki/Lazy_FP_state_restore).

Background and motivation: 1. The bug discovered in https://github.com/asterinas/asterinas/issues/1619; 2. The feature request in https://github.com/asterinas/asterinas/issues/1058.

The change's effect has been initially testified by @tangruize to resolve the https://github.com/asterinas/asterinas/issues/1619.

WIP: Measure the performance burden.
WIP: Evaluate the overhead differences among various `xsave/xrstor` instructions, listed in https://doc.rust-lang.org/nightly/core/arch/x86_64/fn._fxsave64.html?search=xsave.
WIP: Add clearing of FPU registers at the correct timings.