### PR TITLE
Make test run with NETDEV=tap

### DIFF
--- a/.github/workflows/test_asterinas.yml
+++ b/.github/workflows/test_asterinas.yml
@@ -44,7 +44,9 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.9.4
+    container: 
+      image: asterinas/asterinas:0.9.4
+      options: --device=/dev/kvm --privileged
     steps:
       - run: echo "Running in asterinas/asterinas:0.9.4"
 
@@ -56,7 +58,7 @@ jobs:
 
       - name: Ktest Unit Test
         id: ktest_unit_test
-        run: make ktest
+        run: make ktest NETDEV=tap
 
       # TODO: add component check.
 
@@ -66,7 +68,7 @@ jobs:
     timeout-minutes: 15
     container:
       image: asterinas/asterinas:0.9.4
-      options: --device=/dev/kvm
+      options: --device=/dev/kvm --privileged
     strategy:
       matrix:
         # The ids of each test
@@ -90,27 +92,27 @@ jobs:
       - name: SMP Boot Test (Multiboot)
         id: boot_test_mb
         if: ${{ matrix.test_id == 'boot_test_mb' }}
-        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=multiboot RELEASE=1 SMP=4
+        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=multiboot RELEASE=1 SMP=4 NETDEV=tap
 
       - name: SMP Boot Test (Linux Legacy 32-bit Boot Protocol)
         id: boot_test_linux_legacy32
         if: ${{ matrix.test_id == 'boot_test_linux_legacy32' }}
-        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=linux-legacy32 RELEASE=1 SMP=4
+        run: make run AUTO_TEST=boot ENABLE_KVM=1 BOOT_PROTOCOL=linux-legacy32 RELEASE=1 SMP=4 NETDEV=tap
 
       - name: Syscall Test (Linux EFI Handover Boot Protocol) (Debug Build)
         id: syscall_test
         if: ${{ matrix.test_id == 'syscall_test' }}
-        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=0
+        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=0 NETDEV=tap
 
       - name: Syscall Test at Ext2 (MicroVM)
         id: syscall_test_at_ext2_microvm
         if: ${{ matrix.test_id == 'syscall_test_at_ext2_microvm' }}
-        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=1 SCHEME=microvm RELEASE=1
+        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=1 SCHEME=microvm RELEASE=1 NETDEV=tap
 
       - name: Syscall Test at Ext2 (IOMMU) (Debug Build)
         id: syscall_test_at_ext2_iommu
         if: ${{ matrix.test_id == 'syscall_test_at_ext2_iommu' }}
-        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=1 SCHEME=iommu RELEASE=0
+        run: make run AUTO_TEST=syscall SYSCALL_TEST_DIR=/ext2 ENABLE_KVM=1 SCHEME=iommu RELEASE=0 NETDEV=tap
 
       - name: Syscall Test at Exfat (Multiboot2) (without KVM enabled)
         id: syscall_test_at_exfat_linux
@@ -118,22 +120,22 @@ jobs:
         run: |
           make run AUTO_TEST=syscall \
             SYSCALL_TEST_DIR=/exfat EXTRA_BLOCKLISTS_DIRS=blocklists.exfat \
-            ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1
+            ENABLE_KVM=0 BOOT_PROTOCOL=multiboot2 RELEASE=1 NETDEV=tap
       
       - name: SMP Syscall Test (Multiboot2)
         id: smp_syscall_test_mb2
         if: ${{ matrix.test_id == 'smp_syscall_test_mb2' }}
-        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4
+        run: make run AUTO_TEST=syscall ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4 NETDEV=tap
 
       - name: General Test (Linux EFI Handover Boot Protocol)
         id: test_linux
         if: ${{ matrix.test_id == 'test_linux' }}
-        run: make run AUTO_TEST=test ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1
+        run: make run AUTO_TEST=test ENABLE_KVM=1 BOOT_PROTOCOL=linux-efi-handover64 RELEASE=1 NETDEV=tap
       
       - name: SMP General Test (Multiboot2)
         id: smp_test_mb2
         if: ${{ matrix.test_id == 'smp_test_mb2' }}
-        run: make run AUTO_TEST=test ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4
+        run: make run AUTO_TEST=test ENABLE_KVM=1 BOOT_PROTOCOL=multiboot2 RELEASE=1 SMP=4 NETDEV=tap
 
   integration-test-tdx:
     if: github.event_name == 'schedule'


### PR DESCRIPTION
All tests that initiate QEMU now use the tap backend. 

The user backend selects several random ports for port forwarding, which increases the likelihood of port conflicts that may prevent QEMU from starting. An example of such a failure can be seen in [this run](https://github.com/asterinas/asterinas/actions/runs/11961286480/job/33347170730). 

By using the tap backend, we eliminate the need for port forwarding, thereby avoiding these random failures.