### PR TITLE
Clear `DF` flag during trap handling

### DIFF
--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -57,6 +57,7 @@ trap_handler_table:
 .section .text
 .global trap_common
 trap_common:
+    cld                     # clear DF before calling/returning to any C function to conform to x86-64 calling convention
     push rax
     mov ax, [rsp + 4*8]     # load cs
     and ax, 0x3             # test


### PR DESCRIPTION
Fixes #1606

This PR ensures that the `DF` (Direction Flag) is cleared during trap handling.

I also tested `print_stack_trace` because I recalled it using memory functions. This fix may also fix the deadlock issue in `print_stack_trace`.

Test case:

```c
#include <stdio.h>

int main() {
    asm("std");
    printf("Direction Flag (DF) is set.\n");
    return 0;
}
```

Results:

- If `DF` is cleared in `trap_common` (both `__from_user` and `__from_kernel` paths), the test case does not trigger kernel panic.
- If `DF` is only cleared in `__from_kernel`, the test case triggers kernel panic, and `print_stack_trace` successfully prints stack trace.
- If `DF` is not cleared, the test case triggers a kernel panic, but `print_stack_trace` fails to print stack trace.

But we still need to reevaluate all reported deadlock issues related to `print_stack_trace`.