### PR TITLE
Fix deadlock in `FLUSH_OPS` by disabling IRQ

### DIFF
--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -9,7 +9,7 @@ use super::{page::DynPage, Vaddr, PAGE_SIZE};
 use crate::{
     cpu::{CpuSet, PinCurrentCpu},
     cpu_local,
-    sync::SpinLock,
+    sync::{LocalIrqDisabled, SpinLock},
     task::disable_preempt,
 };
 
@@ -155,8 +155,8 @@ impl TlbFlushOp {
 //
 // Lock ordering: lock FLUSH_OPS before PAGE_KEEPER.
 cpu_local! {
-    static FLUSH_OPS: SpinLock<OpsStack> = SpinLock::new(OpsStack::new());
-    static PAGE_KEEPER: SpinLock<Vec<DynPage>> = SpinLock::new(Vec::new());
+    static FLUSH_OPS: SpinLock<OpsStack, LocalIrqDisabled> = SpinLock::new(OpsStack::new());
+    static PAGE_KEEPER: SpinLock<Vec<DynPage>, LocalIrqDisabled> = SpinLock::new(Vec::new());
 }
 
 fn do_remote_flush() {


### PR DESCRIPTION
Fixes #1602

An unrelated concern, it looks like a GC, could it cause performance hiccups when using SMP?

https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/ostd/src/mm/tlb.rs#L162-L169