### PR TITLE
Rewrite `exit()` and `exit_group()`

### DIFF
--- a/kernel/src/fs/procfs/pid/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/cmdline.rs
@@ -23,7 +23,7 @@ impl CmdlineFileOps {
 
 impl FileOps for CmdlineFileOps {
     fn data(&self) -> Result<Vec<u8>> {
-        let cmdline_output = if self.0.is_zombie() {
+        let cmdline_output = if self.0.status().is_zombie() {
             // Returns 0 characters for zombie process.
             Vec::new()
         } else {

--- a/kernel/src/fs/procfs/pid/fd.rs
+++ b/kernel/src/fs/procfs/pid/fd.rs
@@ -24,7 +24,7 @@ impl FdDirOps {
             .parent(parent)
             .build()
             .unwrap();
-        let main_thread = process_ref.main_thread().unwrap();
+        let main_thread = process_ref.main_thread();
         let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
         let weak_ptr = Arc::downgrade(&fd_inode);
         file_table.register_observer(weak_ptr);
@@ -51,7 +51,7 @@ impl DirOps for FdDirOps {
             let fd = name
                 .parse::<FileDesc>()
                 .map_err(|_| Error::new(Errno::ENOENT))?;
-            let main_thread = self.0.main_thread().unwrap();
+            let main_thread = self.0.main_thread();
             let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
             file_table
                 .get_file(fd)
@@ -67,7 +67,7 @@ impl DirOps for FdDirOps {
             this.downcast_ref::<ProcDir<FdDirOps>>().unwrap().this()
         };
         let mut cached_children = this.cached_children().write();
-        let main_thread = self.0.main_thread().unwrap();
+        let main_thread = self.0.main_thread();
         let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
         for (fd, file) in file_table.fds_and_files() {
             cached_children.put_entry_if_not_found(&fd.to_string(), || {

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -33,7 +33,7 @@ impl PidDirOps {
             .volatile()
             .build()
             .unwrap();
-        let main_thread = process_ref.main_thread().unwrap();
+        let main_thread = process_ref.main_thread();
         let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
         let weak_ptr = Arc::downgrade(&pid_inode);
         file_table.register_observer(weak_ptr);

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -30,7 +30,7 @@ impl StatFileOps {
 impl FileOps for StatFileOps {
     fn data(&self) -> Result<Vec<u8>> {
         let process = &self.0;
-        let main_thread = process.main_thread().unwrap();
+        let main_thread = process.main_thread();
         let file_table = main_thread.as_posix_thread().unwrap().file_table();
 
         let mut stat_output = String::new();
@@ -43,7 +43,7 @@ impl FileOps for StatFileOps {
             process.parent().pid(),
             process.parent().pid(),
             file_table.lock().len(),
-            process.tasks().lock().len()
+            process.tasks().lock().as_slice().len(),
         )
         .unwrap();
         Ok(stat_output.into_bytes())

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -72,7 +72,7 @@ impl StatusFileOps {
 impl FileOps for StatusFileOps {
     fn data(&self) -> Result<Vec<u8>> {
         let process = &self.0;
-        let main_thread = process.main_thread().unwrap();
+        let main_thread = process.main_thread();
         let file_table = main_thread.as_posix_thread().unwrap().file_table();
 
         let mut status_output = String::new();
@@ -82,7 +82,12 @@ impl FileOps for StatusFileOps {
         writeln!(status_output, "PPid:\t{}", process.parent().pid()).unwrap();
         writeln!(status_output, "TracerPid:\t{}", process.parent().pid()).unwrap(); // Assuming TracerPid is the same as PPid
         writeln!(status_output, "FDSize:\t{}", file_table.lock().len()).unwrap();
-        writeln!(status_output, "Threads:\t{}", process.tasks().lock().len()).unwrap();
+        writeln!(
+            status_output,
+            "Threads:\t{}",
+            process.tasks().lock().as_slice().len()
+        )
+        .unwrap();
         Ok(status_output.into_bytes())
     }
 }

--- a/kernel/src/fs/procfs/pid/task.rs
+++ b/kernel/src/fs/procfs/pid/task.rs
@@ -63,7 +63,7 @@ impl DirOps for ThreadDirOps {
 
 impl DirOps for TaskDirOps {
     fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
-        for task in self.0.tasks().lock().iter() {
+        for task in self.0.tasks().lock().as_slice() {
             if task.as_posix_thread().unwrap().tid() != name.parse::<u32>().unwrap() {
                 continue;
             }
@@ -78,7 +78,7 @@ impl DirOps for TaskDirOps {
             this.downcast_ref::<ProcDir<TaskDirOps>>().unwrap().this()
         };
         let mut cached_children = this.cached_children().write();
-        for task in self.0.tasks().lock().iter() {
+        for task in self.0.tasks().lock().as_slice() {
             cached_children.put_entry_if_not_found(
                 &format!("{}", task.as_posix_thread().unwrap().tid()),
                 || ThreadDirOps::new_inode(self.0.clone(), this_ptr.clone()),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -150,14 +150,14 @@ fn init_thread() {
     )
     .expect("Run init process failed.");
     // Wait till initproc become zombie.
-    while !initproc.is_zombie() {
+    while !initproc.status().is_zombie() {
         // We don't have preemptive scheduler now.
         // The long running init thread should yield its own execution to allow other tasks to go on.
         Thread::yield_now();
     }
 
     // TODO: exit via qemu isa debug device should not be the only way.
-    let exit_code = if initproc.exit_code() == 0 {
+    let exit_code = if initproc.status().exit_code() == 0 {
         QemuExitCode::Success
     } else {
         QemuExitCode::Failed

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -260,7 +260,11 @@ fn clone_child_task(
         thread_builder.build()
     };
 
-    process.tasks().lock().push(child_task.clone());
+    process
+        .tasks()
+        .lock()
+        .insert(child_task.clone())
+        .map_err(|_| Error::with_message(Errno::EINTR, "the process has exited"))?;
 
     let child_posix_thread = child_task.as_posix_thread().unwrap();
     clone_parent_settid(child_tid, clone_args.parent_tid, clone_flags)?;

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1,75 +1,74 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{process_table, Pid, Process, TermStatus};
-use crate::{
-    prelude::*,
-    process::{
-        posix_thread::{do_exit, AsPosixThread},
-        signal::signals::kernel::KernelSignal,
-    },
-    thread::AsThread,
-};
+use super::{posix_thread::PosixThread, process_table, Pid, Process};
+use crate::{prelude::*, process::signal::signals::kernel::KernelSignal};
 
-pub fn do_exit_group(term_status: TermStatus) {
-    let current = current!();
-    debug!("exit group was called");
-    if current.is_zombie() {
-        return;
-    }
-    current.set_zombie(term_status);
+/// Exits the current POSIX process.
+///
+/// This is for internal use. Do NOT call this directly. When the last thread in the process exits,
+/// [`do_exit`] or [`do_exit_group`] will invoke this method automatically.
+///
+/// [`do_exit`]: crate::process::posix_thread::do_exit
+/// [`do_exit_group`]: crate::process::posix_thread::do_exit_group
+pub(super) fn exit_process(current_thread: &PosixThread, current_process: &Process) {
+    current_process.status().set_zombie();
 
-    // Exit all threads
-    let tasks = current.tasks().lock().clone();
-    for task in tasks {
-        let thread = task.as_thread().unwrap();
-        let posix_thread = thread.as_posix_thread().unwrap();
-        if let Err(e) = do_exit(thread, posix_thread, term_status) {
-            debug!("Ignore error when call exit: {:?}", e);
-        }
-    }
+    // FIXME: This is obviously wrong in a number of ways, since different threads can have
+    // different file tables, and different processes can share the same file table.
+    current_thread.file_table().lock().close_all();
 
-    // Sends parent-death signal
-    // FIXME: according to linux spec, the signal should be sent when a posix thread which
-    // creates child process exits, not when the whole process exits group.
-    for (_, child) in current.children().lock().iter() {
+    send_parent_death_signal(current_process);
+
+    move_children_to_init(current_process);
+
+    send_child_death_signal(current_process);
+}
+
+/// Sends parent-death signals to the children.
+//
+// FIXME: According to the Linux implementation, the signal should be sent when the POSIX thread
+// that created the child exits, not when the whole process exits. For more details, see the
+// "CAVEATS" section in <https://man7.org/linux/man-pages/man2/pr_set_pdeathsig.2const.html>.
+fn send_parent_death_signal(current_process: &Process) {
+    for (_, child) in current_process.children().lock().iter() {
         let Some(signum) = child.parent_death_signal() else {
             continue;
         };
 
-        // FIXME: set pid of the signal
+        // FIXME: Set `si_pid` in the `siginfo_t` argument.
         let signal = KernelSignal::new(signum);
         child.enqueue_signal(signal);
     }
+}
 
-    // Close all files then exit the process.
-    //
-    // FIXME: This is obviously wrong in a number of ways, since different threads can have
-    // different file tables, and different processes can share the same file table.
-    let main_thread = current.main_thread().unwrap();
-    let mut files = main_thread.as_posix_thread().unwrap().file_table().lock();
-    files.close_all();
-    drop(files);
-
-    // Move children to the init process
-    if !is_init_process(&current) {
-        if let Some(init_process) = get_init_process() {
-            let mut init_children = init_process.children().lock();
-            for (_, child_process) in current.children().lock().extract_if(|_, _| true) {
-                let mut parent = child_process.parent.lock();
-                init_children.insert(child_process.pid(), child_process.clone());
-                parent.set_process(&init_process);
-            }
-        }
+/// Moves the children to the init process.
+fn move_children_to_init(current_process: &Process) {
+    if is_init_process(current_process) {
+        return;
     }
 
-    let parent = current.parent().lock().process();
-    if let Some(parent) = parent.upgrade() {
-        // Notify parent
-        if let Some(signal) = current.exit_signal().map(KernelSignal::new) {
-            parent.enqueue_signal(signal);
-        };
-        parent.children_wait_queue().wake_all();
+    let Some(init_process) = get_init_process() else {
+        return;
     };
+
+    let mut init_children = init_process.children().lock();
+    for (_, child_process) in current_process.children().lock().extract_if(|_, _| true) {
+        let mut parent = child_process.parent.lock();
+        init_children.insert(child_process.pid(), child_process.clone());
+        parent.set_process(&init_process);
+    }
+}
+
+/// Sends a child-death signal to the parent.
+fn send_child_death_signal(current_process: &Process) {
+    let Some(parent) = current_process.parent().lock().process().upgrade() else {
+        return;
+    };
+
+    if let Some(signal) = current_process.exit_signal().map(KernelSignal::new) {
+        parent.enqueue_signal(signal);
+    };
+    parent.children_wait_queue().wake_all();
 }
 
 const INIT_PROCESS_PID: Pid = 1;

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -123,7 +123,7 @@ fn kill_process(process: &Process, signal: Option<UserSignal>, ctx: &Context) ->
     let sender_ids = current_thread_sender_ids(signum.as_ref(), ctx);
 
     let mut permitted_thread = None;
-    for task in tasks.iter() {
+    for task in tasks.as_slice() {
         let posix_thread = task.as_posix_thread().unwrap();
 
         // First check permission

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -15,12 +15,12 @@ pub mod rlimit;
 pub mod signal;
 mod status;
 pub mod sync;
+mod task_set;
 mod term_status;
 mod wait;
 
 pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
-pub use exit::do_exit_group;
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use process::{
     ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, Session, Sid, Terminal,

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -1,66 +1,134 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{futex::futex_wake, robust_list::wake_robust_futex, thread_table, PosixThread};
+use ostd::task::{CurrentTask, Task};
+
+use super::{
+    futex::futex_wake, robust_list::wake_robust_futex, thread_table, AsPosixThread, PosixThread,
+};
 use crate::{
     current_userspace,
     prelude::*,
-    process::{do_exit_group, TermStatus},
-    thread::{Thread, Tid},
+    process::{
+        exit::exit_process,
+        signal::{constants::SIGKILL, signals::kernel::KernelSignal},
+        task_set::TaskSet,
+        TermStatus,
+    },
+    thread::AsThread,
 };
 
-/// Exits the thread if the thread is a POSIX thread.
+/// Exits the current POSIX thread.
 ///
 /// # Panics
 ///
-/// If the thread is not a POSIX thread, this method will panic.
-pub fn do_exit(thread: &Thread, posix_thread: &PosixThread, term_status: TermStatus) -> Result<()> {
-    if thread.is_exited() {
-        return Ok(());
-    }
-    thread.exit();
-
-    let tid = posix_thread.tid;
-
-    let mut clear_ctid = posix_thread.clear_child_tid().lock();
-    // If clear_ctid !=0 ,do a futex wake and write zero to the clear_ctid addr.
-    if *clear_ctid != 0 {
-        // FIXME: the correct write length?
-        if let Err(e) = current_userspace!().write_val(*clear_ctid, &0u32) {
-            debug!("Ignore error during exit process: {:?}", e);
-        }
-        futex_wake(*clear_ctid, 1, None)?;
-        *clear_ctid = 0;
-    }
-    drop(clear_ctid);
-    // exit the robust list: walk the robust list; mark futex words as dead and do futex wake
-    wake_robust_list(posix_thread, tid);
-
-    if tid != posix_thread.process().pid() {
-        // We don't remove main thread.
-        // The main thread is removed when the process is reaped.
-        thread_table::remove_thread(tid);
-    }
-
-    if posix_thread.is_main_thread(tid) || posix_thread.is_last_thread() {
-        // exit current process.
-        do_exit_group(term_status);
-    }
-
-    futex_wake(Arc::as_ptr(&posix_thread.process()) as Vaddr, 1, None)?;
-    Ok(())
+/// If the current thread is not a POSIX thread, this method will panic.
+pub fn do_exit(term_status: TermStatus) {
+    exit_internal(term_status, false);
 }
 
-/// Walks the robust futex list, marking futex dead and wake waiters.
-/// It corresponds to Linux's exit_robust_list(), errors are silently ignored.
-fn wake_robust_list(thread: &PosixThread, tid: Tid) {
-    let mut robust_list = thread.robust_list.lock();
+/// Kills all threads and exits the current POSIX process.
+///
+/// # Panics
+///
+/// If the current thread is not a POSIX thread, this method will panic.
+pub fn do_exit_group(term_status: TermStatus) {
+    exit_internal(term_status, true);
+}
+
+/// Exits the current POSIX thread or process.
+fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
+    let current_task = Task::current().unwrap();
+    let current_thread = current_task.as_thread().unwrap();
+    let posix_thread = current_thread.as_posix_thread().unwrap();
+    let posix_process = posix_thread.process();
+
+    let is_last_thread = {
+        let mut tasks = posix_process.tasks().lock();
+        let has_exited_group = tasks.has_exited_group();
+
+        if is_exiting_group && !has_exited_group {
+            sigkill_other_threads(&current_task, &tasks);
+            tasks.set_exited_group();
+        }
+
+        // According to Linux's behavior, the last thread's exit code will become the process's
+        // exit code, so here we should just overwrite the old value (if any).
+        if !has_exited_group {
+            posix_process.status().set_exit_code(term_status.as_u32());
+        }
+
+        // We should only change the thread status when running as the thread, so no race
+        // conditions can occur in between.
+        if current_thread.is_exited() {
+            return;
+        }
+        current_thread.exit();
+
+        tasks.remove_exited(&current_task)
+    };
+
+    wake_clear_ctid(posix_thread);
+
+    wake_robust_list(posix_thread);
+
+    // According to Linux behavior, the main thread shouldn't be removed from the table until the
+    // process is reaped by its parent.
+    if posix_thread.tid() != posix_process.pid() {
+        thread_table::remove_thread(posix_thread.tid());
+    }
+
+    if is_last_thread {
+        exit_process(posix_thread, &posix_process);
+    }
+}
+
+/// Sends `SIGKILL` to all other threads in the current process.
+///
+/// This is only needed when initiating an `exit_group` for the first time.
+fn sigkill_other_threads(current_task: &CurrentTask, task_set: &TaskSet) {
+    for task in task_set.as_slice() {
+        if core::ptr::eq(current_task.as_ref(), task.as_ref()) {
+            continue;
+        }
+        task.as_posix_thread()
+            .unwrap()
+            .enqueue_signal(Box::new(KernelSignal::new(SIGKILL)));
+    }
+}
+
+/// Writes zero to `clear_child_tid` and performs a futex wake.
+fn wake_clear_ctid(current_thread: &PosixThread) {
+    let mut clear_ctid = current_thread.clear_child_tid().lock();
+
+    if *clear_ctid == 0 {
+        return;
+    }
+
+    let _ = current_userspace!()
+        .write_val(*clear_ctid, &0u32)
+        .inspect_err(|err| debug!("exit: cannot clear the child TID: {:?}", err));
+    let _ = futex_wake(*clear_ctid, 1, None)
+        .inspect_err(|err| debug!("exit: cannot wake the futex on the child TID: {:?}", err));
+
+    *clear_ctid = 0;
+}
+
+/// Walks the robust futex list, marking futex dead and waking waiters.
+///
+/// This corresponds to Linux's `exit_robust_list`. Errors are silently ignored.
+fn wake_robust_list(current_thread: &PosixThread) {
+    let mut robust_list = current_thread.robust_list.lock();
+
     let list_head = match *robust_list {
         Some(robust_list_head) => robust_list_head,
         None => return,
     };
-    trace!("wake the rubust_list: {:?}", list_head);
+
+    trace!("exit: wake up the rubust list: {:?}", list_head);
     for futex_addr in list_head.futexes() {
-        wake_robust_futex(futex_addr, tid).unwrap();
+        let _ = wake_robust_futex(futex_addr, current_thread.tid)
+            .inspect_err(|err| debug!("exit: cannot wake up the robust futex: {:?}", err));
     }
+
     *robust_list = None;
 }

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     fs::{file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::signal::constants::SIGCONT,
-    thread::{AsThread, Thread, Tid},
+    thread::{Thread, Tid},
     time::{clocks::ProfClock, Timer, TimerManager},
 };
 
@@ -37,7 +37,7 @@ mod robust_list;
 pub mod thread_table;
 
 pub use builder::PosixThreadBuilder;
-pub use exit::do_exit;
+pub use exit::{do_exit, do_exit_group};
 pub use name::{ThreadName, MAX_THREAD_NAME_LEN};
 pub use posix_thread_ext::{create_posix_task_from_executable, AsPosixThread};
 pub use robust_list::RobustListHead;
@@ -283,20 +283,6 @@ impl PosixThread {
 
     pub fn robust_list(&self) -> &Mutex<Option<RobustListHead>> {
         &self.robust_list
-    }
-
-    fn is_main_thread(&self, tid: Tid) -> bool {
-        let process = self.process();
-        let pid = process.pid();
-        tid == pid
-    }
-
-    fn is_last_thread(&self) -> bool {
-        let process = self.process.upgrade().unwrap();
-        let tasks = process.tasks().lock();
-        tasks
-            .iter()
-            .all(|task| task.as_thread().unwrap().is_exited())
     }
 
     /// Gets the read-only credentials of the thread.

--- a/kernel/src/process/process/builder.rs
+++ b/kernel/src/process/process/builder.rs
@@ -135,19 +135,15 @@ impl<'a> ProcessBuilder<'a> {
 
         let nice = nice.or_else(|| Some(Nice::default())).unwrap();
 
-        let process = {
-            let threads = Vec::new();
-            Process::new(
-                pid,
-                parent,
-                threads,
-                executable_path.to_string(),
-                process_vm,
-                resource_limits,
-                nice,
-                sig_dispositions,
-            )
-        };
+        let process = Process::new(
+            pid,
+            parent,
+            executable_path.to_string(),
+            process_vm,
+            resource_limits,
+            nice,
+            sig_dispositions,
+        );
 
         let task = if let Some(thread_builder) = main_thread_builder {
             let builder = thread_builder.process(Arc::downgrade(&process));
@@ -164,9 +160,7 @@ impl<'a> ProcessBuilder<'a> {
             )?
         };
 
-        process.tasks().lock().push(task);
-
-        process.set_runnable();
+        process.tasks().lock().insert(task).unwrap();
 
         Ok(process)
     }

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        do_exit_group,
+        posix_thread::do_exit_group,
         process_vm::{AuxKey, AuxVec, ProcessVm},
         TermStatus,
     },

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     cpu::LinuxAbi,
     current_userspace,
     prelude::*,
-    process::{do_exit_group, TermStatus},
+    process::{posix_thread::do_exit_group, TermStatus},
 };
 
 pub trait SignalContext {

--- a/kernel/src/process/task_set.rs
+++ b/kernel/src/process/task_set.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Task sets.
+
+use ostd::task::{CurrentTask, Task};
+
+use crate::prelude::*;
+
+/// A task set that maintains all tasks in a POSIX process.
+pub struct TaskSet {
+    tasks: Vec<Arc<Task>>,
+    has_exited_main: bool,
+    has_exited_group: bool,
+}
+
+impl TaskSet {
+    /// Creates a new task set.
+    pub(super) fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            has_exited_main: false,
+            has_exited_group: false,
+        }
+    }
+
+    /// Inserts a new task to the task set.
+    ///
+    /// This method will fail if [`Self::set_exited_group`] has been called before.
+    pub(super) fn insert(&mut self, task: Arc<Task>) -> core::result::Result<(), Arc<Task>> {
+        if self.has_exited_group {
+            return Err(task);
+        }
+
+        self.tasks.push(task);
+        Ok(())
+    }
+
+    /// Removes the exited task from the task set if necessary.
+    ///
+    /// The task will be removed from the task set if the corresponding thread is not the main
+    /// thread.
+    ///
+    /// This method will return true if there are no more alive tasks in the task set.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the task is not in the task set.
+    pub(super) fn remove_exited(&mut self, task: &CurrentTask) -> bool {
+        let position = self
+            .tasks
+            .iter()
+            .position(|some_task| core::ptr::eq(some_task.as_ref(), task.as_ref()))
+            .unwrap();
+
+        if position == 0 {
+            assert!(!self.has_exited_main);
+            self.has_exited_main = true;
+        } else {
+            self.tasks.swap_remove(position);
+        }
+
+        self.has_exited_main && self.tasks.len() == 1
+    }
+
+    /// Sets a flag that denotes that an `exit_group` has been initiated.
+    pub(super) fn set_exited_group(&mut self) {
+        self.has_exited_group = true;
+    }
+
+    /// Returns whether an `exit_group` has been initiated.
+    pub(super) fn has_exited_group(&self) -> bool {
+        self.has_exited_group
+    }
+}
+
+impl TaskSet {
+    /// Returns a slice of the tasks in the task set.
+    pub fn as_slice(&self) -> &[Arc<Task>] {
+        self.tasks.as_slice()
+    }
+
+    /// Returns the main task/thread.
+    pub fn main(&self) -> &Arc<Task> {
+        &self.tasks[0]
+    }
+}

--- a/kernel/src/syscall/exit.rs
+++ b/kernel/src/syscall/exit.rs
@@ -6,11 +6,11 @@ use crate::{
     syscall::SyscallReturn,
 };
 
-pub fn sys_exit(exit_code: i32, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_exit(exit_code: i32, _ctx: &Context) -> Result<SyscallReturn> {
     debug!("exid code = {}", exit_code);
 
     let term_status = TermStatus::Exited(exit_code as _);
-    do_exit(ctx.thread, ctx.posix_thread, term_status)?;
+    do_exit(term_status);
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/exit_group.rs
+++ b/kernel/src/syscall/exit_group.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     prelude::*,
-    process::{do_exit_group, TermStatus},
+    process::{posix_thread::do_exit_group, TermStatus},
     syscall::SyscallReturn,
 };
 

--- a/kernel/src/syscall/set_get_priority.rs
+++ b/kernel/src/syscall/set_get_priority.rs
@@ -72,12 +72,8 @@ fn get_processes(prio_target: PriorityTarget) -> Result<Vec<Arc<Process>>> {
             let processes: Vec<Arc<Process>> = process_table::process_table_mut()
                 .iter()
                 .filter(|process| {
-                    let Some(main_thread) = process.main_thread() else {
-                        return false;
-                    };
-                    let Some(posix_thread) = main_thread.as_posix_thread() else {
-                        return false;
-                    };
+                    let main_thread = process.main_thread();
+                    let posix_thread = main_thread.as_posix_thread().unwrap();
                     uid == posix_thread.credentials().ruid()
                 })
                 .cloned()

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -31,7 +31,7 @@ pub fn sys_wait4(
         return Ok(SyscallReturn::Return(0 as _));
     };
 
-    let (return_pid, exit_code) = (process.pid(), process.exit_code());
+    let (return_pid, exit_code) = (process.pid(), process.status().exit_code());
     if exit_status_ptr != 0 {
         ctx.user_space()
             .write_val(exit_status_ptr as _, &exit_code)?;

--- a/test/apps/Makefile
+++ b/test/apps/Makefile
@@ -18,6 +18,7 @@ TEST_APPS := \
 	epoll \
 	eventfd2 \
 	execve \
+	exit \
 	fdatasync \
 	file_io \
 	fork \

--- a/test/apps/exit/Makefile
+++ b/test/apps/exit/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS := -static -lpthread

--- a/test/apps/exit/exit_code.c
+++ b/test/apps/exit/exit_code.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../network/test.h"
+
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+
+struct exit_info {
+	int should_use_exit_group;
+	int should_exit_master_first;
+};
+
+static void *thread_slave(void *info_)
+{
+	struct exit_info *info = info_;
+
+	if (info->should_exit_master_first) {
+		if (info->should_use_exit_group)
+			sleep(3600);
+		usleep(200 * 1000);
+	}
+
+	if (info->should_use_exit_group)
+		syscall(SYS_exit_group, 55);
+	else
+		syscall(SYS_exit, 66);
+
+	exit(-1);
+}
+
+static void *thread_master(void *info_)
+{
+	struct exit_info *info = info_;
+	pthread_t tid;
+
+	CHECK(pthread_create(&tid, NULL, &thread_slave, info));
+
+	if (!info->should_exit_master_first) {
+		if (info->should_use_exit_group)
+			sleep(3600);
+		usleep(200 * 1000);
+	}
+
+	if (info->should_use_exit_group)
+		syscall(SYS_exit_group, 77);
+	else
+		syscall(SYS_exit, 88);
+
+	exit(-1);
+}
+
+FN_TEST(exit_two_threads)
+{
+	struct exit_info info;
+	int stat;
+
+	info.should_use_exit_group = 1;
+	info.should_exit_master_first = 1;
+	if (CHECK(fork()) == 0) {
+		thread_master(&info);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 77);
+
+	info.should_use_exit_group = 1;
+	info.should_exit_master_first = 0;
+	if (CHECK(fork()) == 0) {
+		thread_master(&info);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 55);
+
+	info.should_use_exit_group = 0;
+	info.should_exit_master_first = 1;
+	if (CHECK(fork()) == 0) {
+		thread_master(&info);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 66);
+
+	info.should_use_exit_group = 0;
+	info.should_exit_master_first = 0;
+	if (CHECK(fork()) == 0) {
+		thread_master(&info);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 88);
+}
+END_TEST()

--- a/test/apps/exit/exit_procfs.c
+++ b/test/apps/exit/exit_procfs.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../network/test.h"
+
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+
+#define EXIT_PARENT_FIRST ((void *)1)
+#define EXIT_CHILD_FIRST ((void *)2)
+
+// TODO: Use `system` directly after we implement `vfork`.
+static int mini_system(const char *cmd)
+{
+	int pid;
+	int stat;
+
+	pid = CHECK(fork());
+
+	if (pid == 0) {
+		CHECK(execlp("sh", "sh", "-c", cmd, NULL));
+		exit(-1);
+	}
+
+	CHECK_WITH(waitpid(pid, &stat, 0), _ret == pid && WIFEXITED(stat));
+
+	return WEXITSTATUS(stat);
+}
+
+static void *thread_slave(void *arg)
+{
+	if (arg == EXIT_CHILD_FIRST) {
+		CHECK_WITH(
+			mini_system(
+				"cat /proc/$PPID/status | grep '^Threads:\t2$'"),
+			_ret == 0);
+
+		syscall(SYS_exit, 0);
+	} else {
+		// When the main thread exits, it becomes a zombie, so we still
+		// have two threads.
+		usleep(200 * 1000);
+		CHECK_WITH(
+			mini_system(
+				"cat /proc/$PPID/status | grep '^Threads:\t2$'"),
+			_ret == 0);
+
+		syscall(SYS_exit, 0);
+	}
+
+	exit(-1);
+}
+
+static void thread_master(void *arg)
+{
+	pthread_t tid;
+
+	CHECK(pthread_create(&tid, NULL, &thread_slave, arg));
+
+	if (arg == EXIT_PARENT_FIRST) {
+		CHECK_WITH(
+			mini_system(
+				"cat /proc/$PPID/status | grep '^Threads:\t2$'"),
+			_ret == 0);
+
+		syscall(SYS_exit, 0);
+	} else {
+		// When a non-main thread exits, its resource is automatically
+		// freed, so we only have one thread.
+		usleep(200 * 1000);
+		CHECK_WITH(
+			mini_system(
+				"cat /proc/$PPID/status | grep '^Threads:\t1$'"),
+			_ret == 0);
+
+		syscall(SYS_exit, 0);
+	}
+
+	exit(-1);
+}
+
+FN_TEST(exit_procfs)
+{
+	int stat;
+
+	if (CHECK(fork()) == 0) {
+		thread_master(EXIT_CHILD_FIRST);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+
+	if (CHECK(fork()) == 0) {
+		thread_master(EXIT_PARENT_FIRST);
+	}
+	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+}
+END_TEST()

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -15,6 +15,8 @@ clone3/clone_no_exit_signal
 clone3/clone_process
 cpu_affinity/cpu_affinity
 execve/execve
+exit/exit_code
+exit/exit_procfs
 eventfd2/eventfd2
 fork/fork
 fork_c/fork


### PR DESCRIPTION
The previous `exit`/`exit_group` implementation is buggy.

- There are multiple race conditions in the following code snippet:
https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/kernel/src/process/exit.rs#L16-L19
https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/kernel/src/process/posix_thread/exit.rs#L44-L47
https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/kernel/src/process/exit.rs#L22-L23
https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/kernel/src/process/posix_thread/exit.rs#L17-L20

- Not to mention that `exit`/`exit_group` can be called concurrently by two threads in the same process.
- Moreover, the following code cannot correctly terminate threads. For example, consider that the threads may be sleeping and waiting for some events.
https://github.com/asterinas/asterinas/blob/9da6af03943c15456cdfd781021820a7da78ea40/kernel/src/process/exit.rs#L26

- Meanwhile, having a dead process for a running thread will cause the kernel to panic, as pointed out in #1614.

This PR rewrites the implementation. Similar to the Linux kernel implementation, `exit_group` now sends SIGKILL to all other threads, and the process will not exit until all threads have exited.

An additional benefit of this PR is that `exit` will only exit the _current_ thread, so more fields in `PosixThread` will be candidates for thread local.