### PR TITLE
Support TDX SMP

### DIFF
--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -135,6 +135,7 @@ fn efi_phase_runtime(memory_map: MemoryMapOwned, boot_params: &mut BootParams) -
                 #[cfg(feature = "cvm_guest")]
                 uefi::table::boot::MemoryType::UNACCEPTED => {
                     unsafe {
+                        crate::console::print_str("[EFI stub] Accepting pending pages...\n");
                         for page_idx in 0..md.page_count {
                             tdx_guest::tdcall::accept_page(0, md.phys_start + page_idx * PAGE_SIZE)
                                 .unwrap();

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -14,13 +14,77 @@ IA32_APIC_BASE = 0x1B
 IA32_X2APIC_APICID = 0x802
 MMIO_XAPIC_APICID = 0xFEE00020
 
-ap_real_mode_boot:
+start:
     cli // disable interrupts
     cld
 
     xor ax, ax  // clear ax
     mov ds, ax  // clear ds
 
+    // In the Intel Trust Domain, the APs awakened by the operating system are in long mode.
+    // We can determine this using the value of the CS register.
+    // FIXME: This method will not affect the booting of linux-efi-handover64,
+    // multiboot and multiboot2 in non-TDX environments.
+    // However, it cannot guarantee the impact on other booting methods added in the future.
+    mov ax, cs
+    cmp ax, 0x38
+    jne ap_real_mode_boot
+
+.code64
+ap_long_mode_tdx:
+    // The Local APIC ID information is stored in r8d by Intel TDX Virtual Firmware.
+    mov edi, r8d
+
+    lgdt [boot_gdtr]
+
+    // Enable PAE and PGE.
+    mov rax, cr4
+    or  rax, 0xa0
+    mov cr4, rax
+
+    // Set the page table. The application processors use
+    // the same page table as the bootstrap processor's
+    // boot phase page table.
+    mov rax, 0
+    mov rax, __boot_page_table_pointer
+    mov cr3, rax
+
+    push 0x8
+    mov rax, offset ap_long_mode_in_low_address
+    push rax
+    retfq
+
+ap_long_mode_in_low_address:
+    mov ax, 0
+    mov ds, ax
+    mov ss, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
+    // Update RIP to use the virtual address.
+    mov rax, offset ap_long_mode
+    jmp rax
+
+ap_long_mode:
+    // The local APIC ID is in the RDI.
+    mov rax, rdi
+    shl rax, 3
+
+    // Setup the stack.
+    mov rbx, [__ap_boot_stack_array_pointer]
+    mov rsp, [rbx + rax]
+    xor rbp, rbp
+
+    // Go to Rust code.
+    mov rax, offset ap_early_entry
+    call rax
+
+.extern halt # bsp_boot.S
+    jmp halt
+
+.code16
+ap_real_mode_boot:
     lgdt [ap_gdtr] // load gdt
 
     mov eax, cr0
@@ -86,9 +150,9 @@ x2apic_mode:
 // This is a pointer to the page table used by the APs.
 // The BSP will fill this pointer before kicking the APs.
 .global __boot_page_table_pointer
-.align 4
+.align 8
 __boot_page_table_pointer:
-    .skip 4
+    .skip 8
 
 ap_protect:
     // Save the local APIC ID in an unused register.
@@ -125,19 +189,6 @@ ap_protect:
 
     ljmp 0x8, offset ap_long_mode_in_low_address
 
-.code64
-ap_long_mode_in_low_address:
-    mov ax, 0
-    mov ds, ax
-    mov ss, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-
-    // Update RIP to use the virtual address.
-    mov rax, offset ap_long_mode
-    jmp rax
-
 .data
 // This is a pointer to be filled by the BSP when boot stacks
 // of all APs are allocated and initialized.
@@ -145,22 +196,3 @@ ap_long_mode_in_low_address:
 .align 8
 __ap_boot_stack_array_pointer:
     .skip 8
-
-.text
-.code64
-ap_long_mode:
-    // The local APIC ID is in the RDI.
-    mov rax, rdi
-    shl rax, 3
-
-    // Setup the stack.
-    mov rbx, [__ap_boot_stack_array_pointer]
-    mov rsp, [rbx + rax]
-    xor rbp, rbp
-
-    // Go to Rust code.
-    mov rax, offset ap_early_entry
-    call rax
-
-.extern halt # bsp_boot.S
-    jmp halt

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -27,6 +27,8 @@
 //! This sequence does not need to be strictly followed, and there may be
 //! different considerations in different systems.
 
+use cfg_if::cfg_if;
+
 use crate::{
     arch::x86::kernel::{
         acpi::get_acpi_tables,
@@ -37,6 +39,14 @@ use crate::{
     },
     mm::{paddr_to_vaddr, PAGE_SIZE},
 };
+
+cfg_if! {
+    if #[cfg(feature = "cvm_guest")] {
+        use tdx_guest::tdx_is_enabled;
+        use crate::arch::x86::kernel::acpi::AcpiMemoryHandler;
+        use acpi::platform::wakeup_aps;
+    }
+}
 
 /// Get the number of processors
 ///
@@ -59,11 +69,30 @@ pub(crate) fn get_num_processors() -> Option<u32> {
 }
 
 /// Brings up all application processors.
-pub(crate) fn bringup_all_aps() {
+pub(crate) fn bringup_all_aps(num_cpus: u32) {
     copy_ap_boot_code();
     fill_boot_stack_array_ptr();
     fill_boot_pt_ptr();
-    send_boot_ipis();
+    cfg_if! {
+        if #[cfg(feature = "cvm_guest")] {
+            if tdx_is_enabled() {
+                for ap_num in 1..num_cpus {
+                    wakeup_aps(
+                        &ACPI_TABLES.get().unwrap().lock(),
+                        AcpiMemoryHandler {},
+                        ap_num,
+                        AP_BOOT_START_PA as u64,
+                        1000,
+                    )
+                    .unwrap();
+                }
+            } else {
+                send_boot_ipis();
+            }
+        } else {
+            send_boot_ipis();
+        }
+    }
 }
 
 /// This is where the linker load the symbols in the `.ap_boot` section.

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -27,10 +27,7 @@ cfg_if! {
     if #[cfg(feature = "cvm_guest")] {
         pub(crate) mod tdx_guest;
 
-        use {
-            crate::early_println,
-            ::tdx_guest::{init_tdx, tdcall::InitError},
-        };
+        use ::tdx_guest::{init_tdx, tdcall::InitError};
     }
 }
 
@@ -44,9 +41,11 @@ use log::{info, warn};
 
 #[cfg(feature = "cvm_guest")]
 pub(crate) fn init_cvm_guest() {
+    use ::tdx_guest::serial_println;
+
     match init_tdx() {
         Ok(td_info) => {
-            early_println!(
+            serial_println!(
                 "[kernel] Intel TDX initialized\n[kernel] td gpaw: {}, td attributes: {:?}",
                 td_info.gpaw,
                 td_info.attributes

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -28,7 +28,7 @@ use super::ex_table::ExTable;
 use crate::{
     arch::irq::{disable_local, enable_local},
     cpu::{CpuException, CpuExceptionInfo, PageFaultErrorCode},
-    cpu_local_cell,
+    cpu_local_cell, if_tdx_enabled,
     mm::{
         kspace::{KERNEL_PAGE_TABLE, LINEAR_MAPPING_BASE_VADDR, LINEAR_MAPPING_VADDR_RANGE},
         page_prop::{CachePolicy, PageProperty},
@@ -40,7 +40,7 @@ use crate::{
 
 cfg_if! {
     if #[cfg(feature = "cvm_guest")] {
-        use tdx_guest::{tdcall, tdx_is_enabled, handle_virtual_exception};
+        use tdx_guest::{tdcall, handle_virtual_exception};
         use crate::arch::tdx_guest::TrapFrameWrapper;
     }
 }
@@ -343,17 +343,11 @@ fn handle_kernel_page_fault(f: &TrapFrame, page_fault_vaddr: u64) {
     let vaddr = (page_fault_vaddr as usize).align_down(PAGE_SIZE);
     let paddr = vaddr - LINEAR_MAPPING_BASE_VADDR;
 
-    cfg_if! {
-        if #[cfg(feature = "cvm_guest")] {
-            let priv_flags = if tdx_is_enabled() {
-                PrivFlags::SHARED | PrivFlags::GLOBAL
-            } else {
-                PrivFlags::GLOBAL
-            };
-        } else {
-            let priv_flags = PrivFlags::GLOBAL;
-        }
-    }
+    let priv_flags = if_tdx_enabled!({
+        PrivFlags::SHARED | PrivFlags::GLOBAL
+    } else {
+        PrivFlags::GLOBAL
+    });
 
     // SAFETY:
     // 1. We have checked that the page fault address falls within the address range of the direct

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -7,6 +7,8 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use spin::Once;
 
+#[cfg(feature = "cvm_guest")]
+use crate::mm::frame::allocator;
 use crate::{
     arch::boot::smp::{bringup_all_aps, get_num_processors},
     cpu,
@@ -98,8 +100,11 @@ pub fn boot_all_aps() {
 
     log::info!("Booting all application processors...");
 
-    bringup_all_aps();
+    bringup_all_aps(num_cpus);
     wait_for_all_aps_started();
+
+    #[cfg(feature = "cvm_guest")]
+    allocator::reclaim_tdx_ap_boot_memory();
 
     log::info!("All application processors started. The BSP continues to run.");
 }

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -7,8 +7,6 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use spin::Once;
 
-#[cfg(feature = "cvm_guest")]
-use crate::mm::frame::allocator;
 use crate::{
     arch::boot::smp::{bringup_all_aps, get_num_processors},
     cpu,
@@ -102,9 +100,6 @@ pub fn boot_all_aps() {
 
     bringup_all_aps(num_cpus);
     wait_for_all_aps_started();
-
-    #[cfg(feature = "cvm_guest")]
-    allocator::reclaim_tdx_ap_boot_memory();
 
     log::info!("All application processors started. The BSP continues to run.");
 }

--- a/ostd/src/bus/pci/capability/msix.rs
+++ b/ostd/src/bus/pci/capability/msix.rs
@@ -16,13 +16,13 @@ use crate::{
         common_device::PciCommonDevice,
         device_info::PciDeviceLocation,
     },
+    if_tdx_enabled,
     mm::VmIoOnce,
     trap::IrqLine,
 };
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
-        use ::tdx_guest::tdx_is_enabled;
         use crate::arch::tdx_guest;
     }
 }
@@ -108,20 +108,20 @@ impl CapabilityMsixData {
 
         // Set message address 0xFEE0_0000
         for i in 0..table_size {
-            #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-            // SAFETY:
-            // This is safe because we are ensuring that the physical address of the MSI-X table is valid before this operation.
-            // We are also ensuring that we are only unprotecting a single page.
-            // The MSI-X table will not exceed one page size, because the size of an MSI-X entry is 16 bytes, and 256 entries are required to fill a page,
-            // which is just equal to the number of all the interrupt numbers on the x86 platform.
-            // It is better to add a judgment here in case the device deliberately uses so many interrupt numbers.
-            // In addition, due to granularity, the minimum value that can be set here is only one page.
-            // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
-            if tdx_is_enabled() {
+            if_tdx_enabled!({
+                #[cfg(target_arch = "x86_64")]
+                // SAFETY:
+                // This is safe because we are ensuring that the physical address of the MSI-X table is valid before this operation.
+                // We are also ensuring that we are only unprotecting a single page.
+                // The MSI-X table will not exceed one page size, because the size of an MSI-X entry is 16 bytes, and 256 entries are required to fill a page,
+                // which is just equal to the number of all the interrupt numbers on the x86 platform.
+                // It is better to add a judgment here in case the device deliberately uses so many interrupt numbers.
+                // In addition, due to granularity, the minimum value that can be set here is only one page.
+                // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `unprotect_gpa_range` function.
                 unsafe {
                     tdx_guest::unprotect_gpa_range(table_bar.io_mem().paddr(), 1).unwrap();
                 }
-            }
+            });
             // Set message address and disable this msix entry
             table_bar
                 .io_mem()

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -77,7 +77,10 @@ unsafe fn init() {
         mm::frame::allocator::init_early_allocator();
     }
 
-    arch::serial::init();
+    if_tdx_enabled!({
+    } else {
+        arch::serial::init();
+    });
 
     logger::init();
 
@@ -105,6 +108,10 @@ unsafe fn init() {
     mm::dma::init();
 
     unsafe { arch::late_init_on_bsp() };
+
+    if_tdx_enabled!({
+        arch::serial::init();
+    });
 
     smp::init();
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -79,9 +79,6 @@ unsafe fn init() {
 
     arch::serial::init();
 
-    #[cfg(feature = "cvm_guest")]
-    arch::init_cvm_guest();
-
     logger::init();
 
     // SAFETY: They are only called once on BSP and ACPI has been initialized.

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -8,6 +8,7 @@ use cfg_if::cfg_if;
 use super::{check_and_insert_dma_mapping, remove_dma_mapping, DmaError, HasDaddr};
 use crate::{
     arch::iommu,
+    if_tdx_enabled,
     mm::{
         dma::{dma_type, Daddr, DmaType},
         io::VmIoOnce,
@@ -21,7 +22,6 @@ use crate::{
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
-        use ::tdx_guest::tdx_is_enabled;
         use crate::arch::tdx_guest;
     }
 }
@@ -75,17 +75,17 @@ impl DmaCoherent {
         }
         let start_daddr = match dma_type() {
             DmaType::Direct => {
-                #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-                // SAFETY:
-                // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                // The `check_and_insert_dma_mapping` function checks if the physical address range is already mapped.
-                // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                // Therefore, we are not causing any undefined behavior or violating any of the requirements of the 'unprotect_gpa_range' function.
-                if tdx_is_enabled() {
+                if_tdx_enabled!({
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY:
+                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
+                    // The `check_and_insert_dma_mapping` function checks if the physical address range is already mapped.
+                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
+                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the 'unprotect_gpa_range' function.
                     unsafe {
                         tdx_guest::unprotect_gpa_range(start_paddr, frame_count).unwrap();
                     }
-                }
+                });
                 start_paddr as Daddr
             }
             DmaType::Iommu => {
@@ -135,17 +135,17 @@ impl Drop for DmaCoherentInner {
         start_paddr.checked_add(frame_count * PAGE_SIZE).unwrap();
         match dma_type() {
             DmaType::Direct => {
-                #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-                // SAFETY:
-                // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                // The `start_paddr()` ensures the `start_paddr` is page-aligned.
-                // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `protect_gpa_range` function.
-                if tdx_is_enabled() {
+                if_tdx_enabled!({
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY:
+                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
+                    // The `start_paddr()` ensures the `start_paddr` is page-aligned.
+                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
+                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `protect_gpa_range` function.
                     unsafe {
                         tdx_guest::protect_gpa_range(start_paddr, frame_count).unwrap();
                     }
-                }
+                });
             }
             DmaType::Iommu => {
                 for i in 0..frame_count {

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -356,38 +356,3 @@ pub(crate) unsafe fn init_early_allocator() {
     let mut early_allocator = EARLY_ALLOCATOR.lock();
     *early_allocator = Some(EarlyFrameAllocator::new());
 }
-
-#[cfg(feature = "cvm_guest")]
-pub(crate) fn reclaim_tdx_ap_boot_memory() {
-    let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
-    for region in regions.iter() {
-        if region.typ() == MemoryRegionType::Usable {
-            // Make the memory region page-aligned, and skip if it is too small.
-            let start = region.base().align_up(PAGE_SIZE) / PAGE_SIZE;
-            let region_end = region.base().checked_add(region.len()).unwrap();
-            let end = region_end.align_down(PAGE_SIZE) / PAGE_SIZE;
-            if end <= start {
-                continue;
-            }
-            // 0x800000 is temporarily used for AP boot in Intel TDX environment.
-            // We should include this frame into page allocator after AP initialization.
-            if (start..end).contains(&(0x800000 / PAGE_SIZE)) {
-                info!(
-                    "Found usable region, start:{:x}, end:{:x}",
-                    region.base(),
-                    region.base() + region.len()
-                );
-                FRAME_ALLOCATOR
-                    .get()
-                    .unwrap()
-                    .disable_irq()
-                    .lock()
-                    .allocator
-                    .add_frame(start, end);
-
-                FRAME_ALLOCATOR.get().unwrap().disable_irq().lock().total +=
-                    (end - start) * PAGE_SIZE;
-            }
-        }
-    }
-}

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -53,7 +53,7 @@ use log::info;
 
 use crate::{
     arch::mm::PagingConsts,
-    const_assert,
+    const_assert, if_tdx_enabled,
     mm::{
         frame::allocator::{self, EarlyAllocatedFrameMeta},
         kspace::LINEAR_MAPPING_BASE_VADDR,
@@ -447,10 +447,15 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         regions.iter().map(|r| r.base() + r.len()).max().unwrap()
     };
 
-    info!(
-        "Initializing frame metadata for physical memory up to {:x}",
-        max_paddr
-    );
+    if_tdx_enabled!({
+        use tdx_guest::serial_println;
+
+        serial_println!("Initializing frame metadata for physical memory up to {:x}",
+            max_paddr)
+    } else {
+        info!("Initializing frame metadata for physical memory up to {:x}",
+            max_paddr);
+    });
 
     add_temp_linear_mapping(max_paddr);
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -59,6 +59,7 @@ use super::{
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
     boot::memory_region::MemoryRegionType,
+    if_tdx_enabled,
 };
 
 /// The shortest supported address width is 39 bits. And the literal
@@ -132,7 +133,13 @@ pub static KERNEL_PAGE_TABLE: Once<PageTable<KernelMode, PageTableEntry, PagingC
 /// This function should be called before:
 ///  - any initializer that modifies the kernel page table.
 pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
-    info!("Initializing the kernel page table");
+    if_tdx_enabled!({
+        use tdx_guest::serial_println;
+
+        serial_println!("Initializing the kernel page table");
+    } else {
+        info!("Initializing the kernel page table");
+    });
 
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
     let phys_mem_cap = regions.iter().map(|r| r.base() + r.len()).max().unwrap();


### PR DESCRIPTION
In Intel TDX, the APs (Application Processors) startup protocol is different from the traditional protocol.

The traditional method is called "INIT/SIPI protocol", This protocol requires assistance from VMMs to boot guests.  That support can not be provided to TDX guests because TDX VMMs are not trusted.

Intel TDX uses the "Multiprocessor Wakeup" protocol, which was first introduced in [ACPI specification r6.4](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#multiprocessor-wakeup-structure). The APs are preloaded into the TDVF security environment through this protocol and waits for the kernel to wake up through the mailbox communication mechanism in ACPI MADT.
