### PR TITLE
Support eagerly FPU state save/restore

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -414,7 +414,7 @@ fn clone_cpu_context(
     tls: u64,
     clone_flags: CloneFlags,
 ) -> UserContext {
-    let mut child_context = *parent_context;
+    let mut child_context = parent_context.clone();
     // The return value of child thread is zero
     child_context.set_syscall_ret(0);
 
@@ -435,6 +435,10 @@ fn clone_cpu_context(
     if clone_flags.contains(CloneFlags::CLONE_SETTLS) {
         child_context.set_tls_pointer(tls as usize);
     }
+
+    // New threads inherit the FPU state of the parent thread and
+    // the state is private to the thread thereafter.
+    child_context.fpu_state().save();
 
     child_context
 }

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -12,13 +12,13 @@ pub use super::trap::GeneralRegs as RawGeneralRegs;
 use super::trap::{TrapFrame, UserContext as RawUserContext};
 use crate::user::{ReturnReason, UserContextApi, UserContextApiInternal};
 
-/// Cpu context, including both general-purpose registers and floating-point registers.
+/// Cpu context, including both general-purpose registers and FPU state.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct UserContext {
     user_context: RawUserContext,
     trap: Trap,
-    fp_regs: (), // TODO
+    fpu_state: (), // TODO
     cpu_exception_info: CpuExceptionInfo,
 }
 
@@ -38,7 +38,7 @@ impl Default for UserContext {
         UserContext {
             user_context: RawUserContext::default(),
             trap: Trap::Exception(Exception::Unknown),
-            fp_regs: (),
+            fpu_state: (),
             cpu_exception_info: CpuExceptionInfo::default(),
         }
     }
@@ -77,14 +77,14 @@ impl UserContext {
         &self.cpu_exception_info
     }
 
-    /// Returns a reference to the floating point registers
-    pub fn fp_regs(&self) -> &() {
-        &self.fp_regs
+    /// Returns a reference to the FPU state.
+    pub fn fpu_state(&self) -> &() {
+        &self.fpu_state
     }
 
-    /// Returns a mutable reference to the floating point registers
-    pub fn fp_regs_mut(&mut self) -> &mut () {
-        &mut self.fp_regs
+    /// Returns a mutable reference to the FPU state.
+    pub fn fpu_state_mut(&mut self) -> &mut () {
+        &mut self.fpu_state
     }
 
     /// Sets thread-local storage pointer.

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -112,6 +112,24 @@ impl Task {
             None
         }
     }
+
+    /// Saves the FPU state for user task.
+    pub fn save_fpu_state(&self) {
+        let Some(user_space) = self.user_space.as_ref() else {
+            return;
+        };
+
+        user_space.fpu_state().save();
+    }
+
+    /// Restores the FPU state for user task.
+    pub fn restore_fpu_state(&self) {
+        let Some(user_space) = self.user_space.as_ref() else {
+            return;
+        };
+
+        user_space.fpu_state().restore();
+    }
 }
 
 /// Options to create or spawn a new task.
@@ -168,6 +186,8 @@ impl TaskOptions {
 
             let current_task = Task::current()
                 .expect("no current task, it should have current task in kernel task entry");
+
+            current_task.restore_fpu_state();
 
             // SAFETY: The `func` field will only be accessed by the current task in the task
             // context, so the data won't be accessed concurrently.

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -4,7 +4,12 @@
 
 //! User space.
 
-use crate::{cpu::UserContext, mm::VmSpace, prelude::*, trap::TrapFrame};
+use crate::{
+    cpu::{FpuState, UserContext},
+    mm::VmSpace,
+    prelude::*,
+    trap::TrapFrame,
+};
 
 /// A user space.
 ///
@@ -54,6 +59,11 @@ impl UserSpace {
     /// Gets thread-local storage pointer.
     pub fn tls_pointer(&self) -> usize {
         self.init_ctx.tls_pointer()
+    }
+
+    /// Gets a reference to the FPU state.
+    pub fn fpu_state(&self) -> &FpuState {
+        self.init_ctx.fpu_state()
     }
 }
 
@@ -126,7 +136,7 @@ impl<'a> UserMode<'a> {
     pub fn new(user_space: &'a Arc<UserSpace>) -> Self {
         Self {
             user_space,
-            context: user_space.init_ctx,
+            context: user_space.init_ctx.clone(),
         }
     }
 


### PR DESCRIPTION
This PR save/restore more FPU states using `xsave/xrstor` instructions, compared with the original PR #1632.

The overhead of `fxsave` and `xsave` is listed as follows:

| lmbench | [5313689](https://github.com/asterinas/asterinas/commit/5313689d6fa91596f4bc52bf6fb866bf6a7a706f) | `fxsave` | `xsave` |
|----------------------|--------|--------|--------|
| process_getppid_lat | 0.077   | 0.080   | 0.080   |
| process_ctx_lat         | 0.73     | 0.81 (~__10.9%__) | 0.85(~__16.4%__) |
| process_fork_lat       | 43.25   | 44.64   | 43.77   |
| process_exec_lat      | 166.53 | 165.54 | 165.95 |
| process_shell_lat     | 288.07 | 287.44 | 288.58 |