### PR TITLE
Fix ResourceLimits and sys_ prlimit64

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -11,7 +11,7 @@ mod process_filter;
 pub mod process_table;
 mod process_vm;
 mod program_loader;
-mod rlimit;
+pub mod rlimit;
 pub mod signal;
 mod status;
 pub mod sync;


### PR DESCRIPTION
This pull request addresses the default values for ResourceLimits and enhances the validation and error handling for the `prlimit64` and `setrlimit` system calls. 

Previously, the `rlimits_test` suite did not uncover any issues due to the absence of necessary capabilities. With the resolution of issue #1650, which introduces these capabilities, the underlying bugs in `prlimit64` have been exposed and are now addressed in this PR.

### Enhancements to `rlimit` module:

* [`kernel/src/process/rlimit.rs`](diffhunk://#diff-55b67960907c43d829c223a16df4a3681ecd2d2e813a74b9451ed2c0c549dbc7R8-R66): Added constants for default resource limits and updated the `ResourceLimits` struct to use these predefined values.
* [`kernel/src/process/rlimit.rs`](diffhunk://#diff-55b67960907c43d829c223a16df4a3681ecd2d2e813a74b9451ed2c0c549dbc7L69-R102): Modified the `RLimit64` struct to include a `max` parameter in the `new` method and added an `is_valid` method to validate resource limits. [[1]](diffhunk://#diff-55b67960907c43d829c223a16df4a3681ecd2d2e813a74b9451ed2c0c549dbc7L69-R102) [[2]](diffhunk://#diff-55b67960907c43d829c223a16df4a3681ecd2d2e813a74b9451ed2c0c549dbc7R112-R122)

### Updates to `syscall` module:

* [`kernel/src/syscall/prlimit64.rs`](diffhunk://#diff-aea52363a5215dd01e506dfed2392eeeacf90f12f74f100665850b186dfdbb1aL6-R6): Updated the `sys_getrlimit`, `sys_setrlimit`, and `sys_prlimit64` functions to use the new `RLimit64` struct and added validation for resource limits. [[1]](diffhunk://#diff-aea52363a5215dd01e506dfed2392eeeacf90f12f74f100665850b186dfdbb1aL6-R6) [[2]](diffhunk://#diff-aea52363a5215dd01e506dfed2392eeeacf90f12f74f100665850b186dfdbb1aL24-R27) [[3]](diffhunk://#diff-aea52363a5215dd01e506dfed2392eeeacf90f12f74f100665850b186dfdbb1aL48-R55)