### PR TITLE
 Make sys_setuid and sys_setgid behave consistently with Linux

### DIFF
--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -97,8 +97,10 @@ impl Credentials_ {
             self.ruid.store(uid, Ordering::Relaxed);
             self.euid.store(uid, Ordering::Relaxed);
             self.suid.store(uid, Ordering::Relaxed);
+            self.fsuid.store(uid, Ordering::Relaxed);
         } else {
             self.euid.store(uid, Ordering::Relaxed);
+            self.fsuid.store(uid, Ordering::Relaxed);
         }
     }
 
@@ -254,8 +256,10 @@ impl Credentials_ {
             self.rgid.store(gid, Ordering::Relaxed);
             self.egid.store(gid, Ordering::Relaxed);
             self.sgid.store(gid, Ordering::Relaxed);
+            self.fsgid.store(gid, Ordering::Relaxed);
         } else {
             self.egid.store(gid, Ordering::Relaxed);
+            self.fsgid.store(gid, Ordering::Relaxed);
         }
     }
 


### PR DESCRIPTION
Based on the information from the Linux manpage and the source code, I made the changes.

> On  Linux,  a  process has both a filesystem user ID and an effective user ID.  The (Linux-specific) filesystem
>  user ID is used for permissions checking when accessing filesystem objects, while the effective user ID is used
>  for various other kinds of permissions checks (see credentials(7)).
> 
>  Normally,  the  value  of  the  process's filesystem user ID is the same as the value of its effective user ID.
>  This is so, because whenever a process's effective user ID is changed, the kernel also changes  the  filesystem
>  user  ID  to  be  the  same  as  the  new value of the effective user ID.  A process can cause the value of its
>  filesystem user ID to diverge from its effective user ID by using setfsuid() to change its filesystem  user  ID
>  to the value given in fsuid.

> [https://elixir.bootlin.com/linux/v6.12.1/source/kernel/sys.c#L648](url)