### PR TITLE
Remove assert in `check_segment_align`

### DIFF
--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -370,11 +370,9 @@ fn check_segment_align(program_header: &ProgramHeader64) -> Result<()> {
         // no align requirement
         return Ok(());
     }
-    debug_assert!(align.is_power_of_two());
     if !align.is_power_of_two() {
         return_errno_with_message!(Errno::ENOEXEC, "segment align is invalid.");
     }
-    debug_assert!(program_header.offset % align == program_header.virtual_addr % align);
     if program_header.offset % align != program_header.virtual_addr % align {
         return_errno_with_message!(Errno::ENOEXEC, "segment align is not satisfied.");
     }


### PR DESCRIPTION
Fix #1656 

It is worth noting that for [program whose `align` is not the power of 2 (i.e., 0x1001)](https://github.com/Marsman1996/pocs/raw/refs/heads/master/asterinas/syscall-execve-5313689-check_segment_align-panic-2), Linux could execute this program.

```
# readelf -l ./syscall-execve-5313689-check_segment_align-panic-2 

Elf file type is EXEC (Executable file)
Entry point 0x401650
There are 10 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000000000 0x0000000000400000 0x0000000000400000
                 0x0000000000000528 0x0000000000000528  R      0x1000
  LOAD           0x0000000000001000 0x0000000000401000 0x0000000000401000
                 0x000000000009665d 0x000000000009665d  R E    0x1000
  LOAD           0x0000000000098000 0x0000000000498000 0x0000000000498000
                 0x000000000002853c 0x000000000002853c  R      0x1000
  LOAD           0x00000000000c07b0 0x00000000004c17b0 0x00000000004c17b0
                 0x0000000000005ae0 0x000000000000b490  RW     0x1001

# ./syscall-execve-5313689-check_segment_align-panic-2 
Hello, World!
```