### PR TITLE
Fix compiling `x86_64` for an API change with upstream patch bumping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
  "unwinding",
  "volatile",
  "x86",
- "x86_64 0.14.11",
+ "x86_64 0.14.10",
  "xarray",
 ]
 
@@ -1519,7 +1519,7 @@ dependencies = [
  "iced-x86",
  "lazy_static",
  "raw-cpuid",
- "x86_64 0.14.11",
+ "x86_64 0.14.10",
 ]
 
 [[package]]
@@ -1776,12 +1776,12 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.11"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b835097a84e4457323331ec5d6eb23d096066cbfb215d54096dcb4b2e85f500"
+checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
- "bitflags 2.6.0",
+ "bitflags 1.3.2",
  "rustversion",
  "volatile",
 ]

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -44,7 +44,7 @@ volatile = { version = "0.4.5", features = ["unstable"] }
 xarray = { git = "https://github.com/asterinas/xarray", version = "0.1.0" }
 
 [target.x86_64-unknown-none.dependencies]
-x86_64 = "0.14.2"
+x86_64 = "=0.14.10" # 0.14.13 broken by https://github.com/rust-osdev/x86_64/issues/512, use a newer afterwards
 x86 = "0.52.0"
 acpi = "5.1.0"
 aml = "0.16.3"

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "2.4.1"
 log = "0.4.20"
 uefi = { version = "0.32.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}
 uefi-raw = "0.8.0"
-x86_64 = "0.15.1"
+x86_64 = "=0.15.1"
 
 [features]
 default = []


### PR DESCRIPTION
Whenever an upstream updated APIs with a patch version bumping it breaks compilation. Things like this happen 1~2 times per month.

It also reminds us that if API is changed the next version bump must be minor not patch.