### PR TITLE
Fix compile error caused by updated `Step::steps_between` in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
  "uart_16550",
  "uefi",
  "uefi-raw",
- "x86_64 0.15.1",
+ "x86_64 0.15.2",
  "xmas-elf 0.9.1",
 ]
 
@@ -1162,7 +1162,7 @@ dependencies = [
  "unwinding",
  "volatile",
  "x86",
- "x86_64 0.14.11",
+ "x86_64 0.14.13",
  "xarray",
 ]
 
@@ -1519,7 +1519,7 @@ dependencies = [
  "iced-x86",
  "lazy_static",
  "raw-cpuid",
- "x86_64 0.14.11",
+ "x86_64 0.14.13",
 ]
 
 [[package]]
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.11"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b835097a84e4457323331ec5d6eb23d096066cbfb215d54096dcb4b2e85f500"
+checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
 dependencies = [
  "bit_field",
  "bitflags 2.6.0",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc79523af8abf92fb1a970c3e086c5a343f6bcc1a0eb890f575cbb3b45743df"
+checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
  "bitflags 2.6.0",

--- a/kernel/comps/block/src/id.rs
+++ b/kernel/comps/block/src/id.rs
@@ -89,7 +89,7 @@ impl<const N: u16> Sub<u64> for BlockId<N> {
 
 /// Implements the `Step` trait to iterate over `Range<Id>`.
 impl<const N: u16> Step for BlockId<N> {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         u64::steps_between(&start.0, &end.0)
     }
 

--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -3,7 +3,6 @@
 //! The framebuffer of Asterinas.
 #![no_std]
 #![deny(unsafe_code)]
-#![feature(strict_provenance)]
 
 extern crate alloc;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -9,7 +9,6 @@
 #![allow(incomplete_features)]
 #![feature(btree_cursors)]
 #![feature(btree_extract_if)]
-#![feature(const_option)]
 #![feature(extend_one)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]

--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -108,9 +108,9 @@ fn do_select(
         let mut poll_fds = Vec::with_capacity(nfds as usize);
         for fd in 0..nfds {
             let events = {
-                let readable = readfds.as_ref().map_or(false, |fds| fds.is_set(fd));
-                let writable = writefds.as_ref().map_or(false, |fds| fds.is_set(fd));
-                let except = exceptfds.as_ref().map_or(false, |fds| fds.is_set(fd));
+                let readable = readfds.as_ref().is_some_and(|fds| fds.is_set(fd));
+                let writable = writefds.as_ref().is_some_and(|fds| fds.is_set(fd));
+                let except = exceptfds.as_ref().is_some_and(|fds| fds.is_set(fd));
                 convert_rwe_to_events(readable, writable, except)
             };
 

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -195,7 +195,6 @@ dependencies = [
  "indexmap",
  "indicatif",
  "inferno",
- "lazy_static",
  "linux-bzimage-builder",
  "log",
  "quote",

--- a/osdk/src/commands/new/rust-toolchain.toml.template
+++ b/osdk/src/commands/new/rust-toolchain.toml.template
@@ -1,5 +1,5 @@
 # One should also update asterinas/rust-toolchain.toml when updating this.
 # The first two lines will be deleted when generating the user's toolchain file.
 [toolchain]
-channel = "nightly-2024-10-12"
+channel = "nightly-2024-11-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -44,7 +44,7 @@ volatile = { version = "0.4.5", features = ["unstable"] }
 xarray = { git = "https://github.com/asterinas/xarray", version = "0.1.0" }
 
 [target.x86_64-unknown-none.dependencies]
-x86_64 = "0.14.2"
+x86_64 = "0.14.13"
 x86 = "0.52.0"
 acpi = "5.1.0"
 aml = "0.16.3"

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -16,7 +16,6 @@
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(ptr_sub_ptr)]
-#![feature(strict_provenance)]
 #![feature(sync_unsafe_cell)]
 // The `generic_const_exprs` feature is incomplete however required for the page table
 // const generic implementation. We are using this feature in a conservative manner.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # One should also update osdk/src/commands/new/rust-toolchain.toml.template
 # when updating this
 [toolchain]
-channel = "nightly-2024-10-12"
+channel = "nightly-2024-11-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
 targets = ["x86_64-unknown-none"]


### PR DESCRIPTION
The compile error is caused by the update of `Step::steps_between` in Rust https://github.com/rust-lang/rust/pull/130867, and then x86_64 updates itself in https://github.com/rust-osdev/x86_64/pull/513.

I updated the Rust version and x86_64 version