### PR TITLE
Move FS things to `PosixThread`

### DIFF
--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     prelude::*,
     process::{
+        posix_thread::AsPosixThread,
         signal::{PollHandle, Pollable, Pollee},
         JobControl, Terminal,
     },
@@ -191,7 +192,8 @@ impl FileIo for PtyMaster {
                 Ok(0)
             }
             IoctlCmd::TIOCGPTPEER => {
-                let current = current!();
+                let current = current_thread!();
+                let current = current.as_posix_thread().unwrap();
 
                 // TODO: deal with open options
                 let slave = {
@@ -203,7 +205,7 @@ impl FileIo for PtyMaster {
                     let fs_path = FsPath::try_from(slave_name.as_str())?;
 
                     let inode_handle = {
-                        let fs = current.fs().read();
+                        let fs = current.fs().resolver().read();
                         let flags = AccessMode::O_RDWR as u32;
                         let mode = (InodeMode::S_IRUSR | InodeMode::S_IWUSR).bits();
                         fs.open(&fs_path, flags, mode)?

--- a/kernel/src/fs/epoll/file.rs
+++ b/kernel/src/fs/epoll/file.rs
@@ -18,7 +18,10 @@ use crate::{
         utils::{InodeMode, IoctlCmd, Metadata},
     },
     prelude::*,
-    process::signal::{PollHandle, Pollable},
+    process::{
+        posix_thread::AsPosixThread,
+        signal::{PollHandle, Pollable},
+    },
 };
 
 /// A file-like object that provides epoll API.
@@ -61,7 +64,8 @@ impl EpollFile {
         };
 
         let file = {
-            let current = current!();
+            let current = current_thread!();
+            let current = current.as_posix_thread().unwrap();
             let file_table = current.file_table().lock();
             file_table.get_file(fd)?.clone()
         };

--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -9,7 +9,7 @@ use super::{
     rootfs::root_mount,
     utils::{AccessMode, CreationFlags, InodeMode, InodeType, StatusFlags, PATH_MAX, SYMLINKS_MAX},
 };
-use crate::prelude::*;
+use crate::{prelude::*, process::posix_thread::AsPosixThread};
 
 /// The file descriptor of the current working directory.
 pub const AT_FDCWD: FileDesc = -100;
@@ -285,7 +285,8 @@ impl FsResolver {
 
     /// Lookups the target dentry according to the given `fd`.
     pub fn lookup_from_fd(&self, fd: FileDesc) -> Result<Dentry> {
-        let current = current!();
+        let current = current_thread!();
+        let current = current.as_posix_thread().unwrap();
         let file_table = current.file_table().lock();
         let inode_handle = file_table
             .get_file(fd)?

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -14,6 +14,7 @@ pub mod pipe;
 pub mod procfs;
 pub mod ramfs;
 pub mod rootfs;
+pub mod thread_info;
 pub mod utils;
 
 use aster_block::BlockDevice;

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::{DirEntryVecExt, Inode},
     },
     prelude::*,
-    process::Process,
+    process::{posix_thread::AsPosixThread, Process},
 };
 
 mod cmdline;
@@ -30,7 +30,8 @@ impl PidDirOps {
             .volatile()
             .build()
             .unwrap();
-        let file_table = process_ref.file_table().lock();
+        let main_thread = process_ref.main_thread().unwrap();
+        let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
         let weak_ptr = Arc::downgrade(&pid_inode);
         file_table.register_observer(weak_ptr);
         pid_inode

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -8,6 +8,7 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
+    process::posix_thread::AsPosixThread,
     Process,
 };
 
@@ -29,6 +30,9 @@ impl StatFileOps {
 impl FileOps for StatFileOps {
     fn data(&self) -> Result<Vec<u8>> {
         let process = &self.0;
+        let main_thread = process.main_thread().unwrap();
+        let file_table = main_thread.as_posix_thread().unwrap().file_table();
+
         let mut stat_output = String::new();
         writeln!(
             stat_output,
@@ -38,7 +42,7 @@ impl FileOps for StatFileOps {
             process.pid(),
             process.parent().pid(),
             process.parent().pid(),
-            process.file_table().lock().len(),
+            file_table.lock().len(),
             process.tasks().lock().len()
         )
         .unwrap();

--- a/kernel/src/fs/thread_info.rs
+++ b/kernel/src/fs/thread_info.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::{RwLock, RwMutex};
+
+use super::{fs_resolver::FsResolver, utils::FileCreationMask};
+
+/// FS information for a POSIX thread.
+pub struct ThreadFsInfo {
+    resolver: RwMutex<FsResolver>,
+    umask: RwLock<FileCreationMask>,
+}
+
+impl ThreadFsInfo {
+    /// Returns the associated `FsResolver`.
+    pub fn resolver(&self) -> &RwMutex<FsResolver> {
+        &self.resolver
+    }
+
+    /// Returns the associated `FileCreationMask`.
+    pub fn umask(&self) -> &RwLock<FileCreationMask> {
+        &self.umask
+    }
+}
+
+impl Default for ThreadFsInfo {
+    fn default() -> Self {
+        Self {
+            resolver: RwMutex::new(FsResolver::default()),
+            umask: RwLock::new(FileCreationMask::default()),
+        }
+    }
+}
+
+impl Clone for ThreadFsInfo {
+    fn clone(&self) -> Self {
+        Self {
+            resolver: RwMutex::new(self.resolver.read().clone()),
+            umask: RwLock::new(FileCreationMask::new(self.umask.read().get())),
+        }
+    }
+}

--- a/kernel/src/net/socket/unix/ns/path.rs
+++ b/kernel/src/net/socket/unix/ns/path.rs
@@ -7,12 +7,14 @@ use crate::{
         utils::{InodeMode, InodeType},
     },
     prelude::*,
+    process::posix_thread::AsPosixThread,
 };
 
 pub fn lookup_socket_file(path: &str) -> Result<Dentry> {
     let dentry = {
-        let current = current!();
-        let fs = current.fs().read();
+        let current = current_thread!();
+        let current = current.as_posix_thread().unwrap();
+        let fs = current.fs().resolver().read();
         let fs_path = FsPath::try_from(path)?;
         fs.lookup(&fs_path)?
     };
@@ -35,8 +37,9 @@ pub fn create_socket_file(path: &str) -> Result<Dentry> {
     let (parent_pathname, file_name) = split_path(path);
 
     let parent = {
-        let current = current!();
-        let fs = current.fs().read();
+        let current = current_thread!();
+        let current = current.as_posix_thread().unwrap();
+        let fs = current.fs().resolver().read();
         let parent_path = FsPath::try_from(parent_pathname)?;
         fs.lookup(&parent_path)?
     };

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -6,6 +6,7 @@ use ostd::{cpu::CpuSet, task::Task, user::UserSpace};
 
 use super::{thread_table, PosixThread};
 use crate::{
+    fs::{file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::{
         posix_thread::name::ThreadName,
@@ -29,6 +30,8 @@ pub struct PosixThreadBuilder {
     thread_name: Option<ThreadName>,
     set_child_tid: Vaddr,
     clear_child_tid: Vaddr,
+    file_table: Option<Arc<SpinLock<FileTable>>>,
+    fs: Option<Arc<ThreadFsInfo>>,
     sig_mask: AtomicSigMask,
     sig_queues: SigQueues,
 }
@@ -43,6 +46,8 @@ impl PosixThreadBuilder {
             thread_name: None,
             set_child_tid: 0,
             clear_child_tid: 0,
+            file_table: None,
+            fs: None,
             sig_mask: AtomicSigMask::new_empty(),
             sig_queues: SigQueues::new(),
         }
@@ -68,6 +73,16 @@ impl PosixThreadBuilder {
         self
     }
 
+    pub fn file_table(mut self, file_table: Arc<SpinLock<FileTable>>) -> Self {
+        self.file_table = Some(file_table);
+        self
+    }
+
+    pub fn fs(mut self, fs: Arc<ThreadFsInfo>) -> Self {
+        self.fs = Some(fs);
+        self
+    }
+
     pub fn sig_mask(mut self, sig_mask: AtomicSigMask) -> Self {
         self.sig_mask = sig_mask;
         self
@@ -82,9 +97,16 @@ impl PosixThreadBuilder {
             thread_name,
             set_child_tid,
             clear_child_tid,
+            file_table,
+            fs,
             sig_mask,
             sig_queues,
         } = self;
+
+        let file_table =
+            file_table.unwrap_or_else(|| Arc::new(SpinLock::new(FileTable::new_with_stdio())));
+
+        let fs = fs.unwrap_or_else(|| Arc::new(ThreadFsInfo::default()));
 
         Arc::new_cyclic(|weak_task| {
             let posix_thread = {
@@ -99,6 +121,8 @@ impl PosixThreadBuilder {
                     set_child_tid: Mutex::new(set_child_tid),
                     clear_child_tid: Mutex::new(clear_child_tid),
                     credentials,
+                    file_table,
+                    fs,
                     sig_mask,
                     sig_queues,
                     sig_context: Mutex::new(None),

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{
     events::Observer,
+    fs::{file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::signal::constants::SIGCONT,
     thread::{AsThread, Thread, Tid},
@@ -57,6 +58,12 @@ pub struct PosixThread {
 
     /// Process credentials. At the kernel level, credentials are a per-thread attribute.
     credentials: Credentials,
+
+    // Files
+    /// File table
+    file_table: Arc<SpinLock<FileTable>>,
+    /// File system
+    fs: Arc<ThreadFsInfo>,
 
     // Signal
     /// Blocked signals
@@ -105,6 +112,14 @@ impl PosixThread {
 
     pub fn clear_child_tid(&self) -> &Mutex<Vaddr> {
         &self.clear_child_tid
+    }
+
+    pub fn file_table(&self) -> &Arc<SpinLock<FileTable>> {
+        &self.file_table
+    }
+
+    pub fn fs(&self) -> &Arc<ThreadFsInfo> {
+        &self.fs
     }
 
     /// Get the reference to the signal mask of the thread.

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -67,7 +67,7 @@ fn do_accept(
     }
 
     let fd = {
-        let mut file_table = ctx.process.file_table().lock();
+        let mut file_table = ctx.posix_thread.file_table().lock();
         file_table.insert(connected_socket, fd_flags)
     };
 

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -69,7 +69,7 @@ pub fn do_faccessat(
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let fs = ctx.process.fs().read();
+        let fs = ctx.posix_thread.fs().resolver().read();
         if flags.contains(FaccessatFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -14,7 +14,7 @@ pub fn sys_fchmod(fd: FileDesc, mode: u16, ctx: &Context) -> Result<SyscallRetur
     debug!("fd = {}, mode = 0o{:o}", fd, mode);
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
     file.set_mode(InodeMode::from_bits_truncate(mode))?;
@@ -42,7 +42,7 @@ pub fn sys_fchmodat(
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
     dentry.set_mode(InodeMode::from_bits_truncate(mode))?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -21,7 +21,7 @@ pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<Sys
     }
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
     if let Some(uid) = uid {
@@ -80,7 +80,7 @@ pub fn sys_fchownat(
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let fs = ctx.process.fs().read();
+        let fs = ctx.posix_thread.fs().resolver().read();
         if flags.contains(ChownFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/chroot.rs
+++ b/kernel/src/syscall/chroot.rs
@@ -11,7 +11,7 @@ pub fn sys_chroot(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let path = ctx.user_space().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
-    let mut fs = ctx.process.fs().write();
+    let mut fs = ctx.posix_thread.fs().resolver().write();
     let dentry = {
         let path = path.to_string_lossy();
         if path.is_empty() {

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -7,7 +7,7 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let file = {
-        let mut file_table = ctx.process.file_table().lock();
+        let mut file_table = ctx.posix_thread.file_table().lock();
         let _ = file_table.get_file(fd)?;
         file_table.close_file(fd).unwrap()
     };

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -41,7 +41,7 @@ pub fn sys_epoll_create1(flags: u32, ctx: &Context) -> Result<SyscallReturn> {
     };
 
     let epoll_file: Arc<EpollFile> = EpollFile::new();
-    let mut file_table = ctx.process.file_table().lock();
+    let mut file_table = ctx.posix_thread.file_table().lock();
     let fd = file_table.insert(epoll_file, fd_flags);
     Ok(SyscallReturn::Return(fd as _))
 }
@@ -80,7 +80,7 @@ pub fn sys_epoll_ctl(
     };
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(epfd)?.clone()
     };
     let epoll_file = file
@@ -110,7 +110,7 @@ fn do_epoll_wait(
     };
 
     let epoll_file_arc = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(epfd)?.clone()
     };
     let epoll_file = epoll_file_arc

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -54,7 +54,7 @@ pub fn sys_eventfd2(init_val: u64, flags: u32, ctx: &Context) -> Result<SyscallR
 fn do_sys_eventfd2(init_val: u64, flags: Flags, ctx: &Context) -> FileDesc {
     let event_file = EventFile::new(init_val, flags);
     let fd = {
-        let mut file_table = ctx.process.file_table().lock();
+        let mut file_table = ctx.posix_thread.file_table().lock();
         let fd_flags = if flags.contains(Flags::EFD_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/fallocate.rs
+++ b/kernel/src/syscall/fallocate.rs
@@ -22,7 +22,7 @@ pub fn sys_fallocate(
     check_offset_and_len(offset, len, ctx)?;
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 

--- a/kernel/src/syscall/flock.rs
+++ b/kernel/src/syscall/flock.rs
@@ -14,7 +14,7 @@ pub fn sys_flock(fd: FileDesc, ops: i32, ctx: &Context) -> Result<SyscallReturn>
     debug!("flock: fd: {}, ops: {:?}", fd, ops);
 
     let file = {
-        let current = ctx.process;
+        let current = ctx.posix_thread;
         let file_table = current.file_table().lock();
         file_table.get_file(fd)?.clone()
     };

--- a/kernel/src/syscall/fsync.rs
+++ b/kernel/src/syscall/fsync.rs
@@ -10,7 +10,7 @@ pub fn sys_fsync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let dentry = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         let file = file_table.get_file(fd)?;
         let inode_handle = file
             .downcast_ref::<InodeHandle>()
@@ -25,7 +25,7 @@ pub fn sys_fdatasync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let dentry = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         let file = file_table.get_file(fd)?;
         let inode_handle = file
             .downcast_ref::<InodeHandle>()

--- a/kernel/src/syscall/getcwd.rs
+++ b/kernel/src/syscall/getcwd.rs
@@ -7,9 +7,10 @@ use crate::{
 };
 
 pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
-    let current = ctx.process;
+    let current = ctx.posix_thread;
     let dirent = current
         .fs()
+        .resolver()
         .read()
         .lookup(&FsPath::new(AT_FDCWD, "").unwrap())
         .unwrap();

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -24,7 +24,7 @@ pub fn sys_getdents(
     );
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
     let inode_handle = file
@@ -54,7 +54,7 @@ pub fn sys_getdents64(
     );
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
     let inode_handle = file

--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -17,7 +17,7 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr, ctx: &Context) -> Result<Sy
     );
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
     let res = match ioctl_cmd {
@@ -44,14 +44,14 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr, ctx: &Context) -> Result<Sy
             // Follow the implementation of fcntl()
 
             let flags = FdFlags::CLOEXEC;
-            let file_table = ctx.process.file_table().lock();
+            let file_table = ctx.posix_thread.file_table().lock();
             let entry = file_table.get_entry(fd)?;
             entry.set_flags(flags);
             0
         }
         IoctlCmd::FIONCLEX => {
             // Clears the close-on-exec flag of the file.
-            let file_table = ctx.process.file_table().lock();
+            let file_table = ctx.posix_thread.file_table().lock();
             let entry = file_table.get_entry(fd)?;
             entry.set_flags(entry.flags() & (!FdFlags::CLOEXEC));
             0

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -44,7 +44,7 @@ pub fn sys_linkat(
 
         let old_fs_path = FsPath::new(old_dirfd, old_path.as_ref())?;
         let new_fs_path = FsPath::new(new_dirfd, new_path.as_ref())?;
-        let fs = ctx.process.fs().read();
+        let fs = ctx.posix_thread.fs().resolver().read();
         let old_dentry = if flags.contains(LinkFlags::AT_SYMLINK_FOLLOW) {
             fs.lookup(&old_fs_path)?
         } else {

--- a/kernel/src/syscall/lseek.rs
+++ b/kernel/src/syscall/lseek.rs
@@ -21,7 +21,7 @@ pub fn sys_lseek(fd: FileDesc, offset: isize, whence: u32, ctx: &Context) -> Res
         _ => return_errno!(Errno::EINVAL),
     };
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 

--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -20,9 +20,9 @@ pub fn sys_mknodat(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let path = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;
-    let current = ctx.process;
+    let current = ctx.posix_thread;
     let inode_mode = {
-        let mask_mode = mode & !current.umask().read().get();
+        let mask_mode = mode & !current.fs().umask().read().get();
         InodeMode::from_bits_truncate(mask_mode)
     };
     let inode_type = InodeType::from_raw_mode(mode)?;
@@ -39,6 +39,7 @@ pub fn sys_mknodat(
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
         current
             .fs()
+            .resolver()
             .read()
             .lookup_dir_and_new_basename(&fs_path, false)?
     };

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -116,7 +116,7 @@ fn do_sys_mmap(
             }
         } else {
             let vmo = {
-                let file_table = ctx.process.file_table().lock();
+                let file_table = ctx.posix_thread.file_table().lock();
                 let file = file_table.get_file(fd)?;
                 let inode_handle = file
                     .downcast_ref::<InodeHandle>()

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -40,7 +40,7 @@ pub fn sys_mount(
             return_errno_with_message!(Errno::ENOENT, "dirname is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, dirname.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
 
     if mount_flags.contains(MountFlags::MS_REMOUNT) && mount_flags.contains(MountFlags::MS_BIND) {
@@ -93,7 +93,7 @@ fn do_bind_mount(
             return_errno_with_message!(Errno::ENOENT, "src_name is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, src_name.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
 
     if src_dentry.type_() != InodeType::Dir {
@@ -116,7 +116,7 @@ fn do_move_mount_old(src_name: CString, dst_dentry: Dentry, ctx: &Context) -> Re
             return_errno_with_message!(Errno::ENOENT, "src_name is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, src_name.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
 
     if !src_dentry.is_root_of_mount() {

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -24,12 +24,16 @@ pub fn sys_openat(
         dirfd, path, flags, mode
     );
 
-    let current = ctx.process;
+    let current = ctx.posix_thread;
     let file_handle = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let mask_mode = mode & !current.umask().read().get();
-        let inode_handle = current.fs().read().open(&fs_path, flags, mask_mode)?;
+        let mask_mode = mode & !current.fs().umask().read().get();
+        let inode_handle = current
+            .fs()
+            .resolver()
+            .read()
+            .open(&fs_path, flags, mask_mode)?;
         Arc::new(inode_handle)
     };
     let mut file_table = current.file_table().lock();

--- a/kernel/src/syscall/pipe.rs
+++ b/kernel/src/syscall/pipe.rs
@@ -21,7 +21,7 @@ pub fn sys_pipe2(fds: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn>
         FdFlags::empty()
     };
 
-    let mut file_table = ctx.process.file_table().lock();
+    let mut file_table = ctx.posix_thread.file_table().lock();
 
     let pipe_fds = PipeFds {
         reader_fd: file_table.insert(pipe_reader, fd_flags),

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -100,7 +100,7 @@ enum FileResult {
 
 /// Holds all the files we're going to poll.
 fn hold_files(poll_fds: &[PollFd], ctx: &Context) -> (FileResult, Vec<Option<Arc<dyn FileLike>>>) {
-    let file_table = ctx.process.file_table().lock();
+    let file_table = ctx.posix_thread.file_table().lock();
 
     let mut files = Vec::with_capacity(poll_fds.len());
     let mut result = FileResult::AllValid;

--- a/kernel/src/syscall/pread64.rs
+++ b/kernel/src/syscall/pread64.rs
@@ -19,7 +19,7 @@ pub fn sys_pread64(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait

--- a/kernel/src/syscall/preadv.rs
+++ b/kernel/src/syscall/preadv.rs
@@ -66,7 +66,7 @@ fn do_sys_preadv(
     }
 
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
 
@@ -128,7 +128,7 @@ fn do_sys_readv(
     );
 
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
 

--- a/kernel/src/syscall/pwrite64.rs
+++ b/kernel/src/syscall/pwrite64.rs
@@ -18,7 +18,7 @@ pub fn sys_pwrite64(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
     // TODO: Check (f.file->f_mode & FMODE_PWRITE); We don't have f_mode in our FileLike trait

--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -61,7 +61,7 @@ fn do_sys_pwritev(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
@@ -117,7 +117,7 @@ fn do_sys_writev(
         fd, io_vec_ptr, io_vec_count
     );
     let file = {
-        let filetable = ctx.process.file_table().lock();
+        let filetable = ctx.posix_thread.file_table().lock();
         filetable.get_file(fd)?.clone()
     };
     let mut total_len = 0;

--- a/kernel/src/syscall/read.rs
+++ b/kernel/src/syscall/read.rs
@@ -15,7 +15,7 @@ pub fn sys_read(
     );
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -30,7 +30,11 @@ pub fn sys_readlinkat(
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.process.fs().read().lookup_no_follow(&fs_path)?
+        ctx.posix_thread
+            .fs()
+            .resolver()
+            .read()
+            .lookup_no_follow(&fs_path)?
     };
     let linkpath = dentry.inode().read_link()?;
     let bytes = linkpath.as_bytes();

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -26,7 +26,7 @@ pub fn sys_renameat(
         old_dirfd, old_path, new_dirfd, new_path
     );
 
-    let fs = ctx.process.fs().read();
+    let fs = ctx.posix_thread.fs().resolver().read();
 
     let (old_dir_dentry, old_name) = {
         let old_path = old_path.to_string_lossy();

--- a/kernel/src/syscall/rmdir.rs
+++ b/kernel/src/syscall/rmdir.rs
@@ -28,7 +28,11 @@ pub(super) fn sys_rmdirat(
             return_errno_with_message!(Errno::EBUSY, "is root directory");
         }
         let fs_path = FsPath::new(dirfd, path_addr.as_ref())?;
-        ctx.process.fs().read().lookup_dir_and_base_name(&fs_path)?
+        ctx.posix_thread
+            .fs()
+            .resolver()
+            .read()
+            .lookup_dir_and_base_name(&fs_path)?
     };
     dir_dentry.rmdir(name.trim_end_matches('/'))?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/sendfile.rs
+++ b/kernel/src/syscall/sendfile.rs
@@ -34,7 +34,7 @@ pub fn sys_sendfile(
     };
 
     let (out_file, in_file) = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         let out_file = file_table.get_file(out_fd)?.clone();
         // FIXME: the in_file must support mmap-like operations (i.e., it cannot be a socket).
         let in_file = file_table.get_file(in_fd)?.clone();

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -43,7 +43,7 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
         _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported domain"),
     };
     let fd = {
-        let mut file_table = ctx.process.file_table().lock();
+        let mut file_table = ctx.posix_thread.file_table().lock();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -37,7 +37,7 @@ pub fn sys_socketpair(
     };
 
     let socket_fds = {
-        let mut file_table = ctx.process.file_table().lock();
+        let mut file_table = ctx.posix_thread.file_table().lock();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -16,7 +16,7 @@ pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Result<Sys
     debug!("fd = {}, stat_buf_addr = 0x{:x}", fd, stat_buf_ptr);
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 
@@ -66,7 +66,7 @@ pub fn sys_fstatat(
     let dentry = {
         let filename = filename.to_string_lossy();
         let fs_path = FsPath::new(dirfd, filename.as_ref())?;
-        let fs = ctx.process.fs().read();
+        let fs = ctx.posix_thread.fs().resolver().read();
         if flags.contains(StatFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -19,7 +19,7 @@ pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr, ctx: &Context) -> Resu
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::try_from(path.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
     let statfs = Statfs::from(dentry.fs().sb());
     user_space.write_val(statfs_buf_ptr, &statfs)?;
@@ -30,7 +30,7 @@ pub fn sys_fstatfs(fd: FileDesc, statfs_buf_ptr: Vaddr, ctx: &Context) -> Result
     debug!("fd = {}, statfs_buf_addr = 0x{:x}", fd, statfs_buf_ptr);
 
     let fs = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         let file = file_table.get_file(fd)?;
         let inode_handle = file
             .downcast_ref::<InodeHandle>()

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -35,8 +35,9 @@ pub fn sys_symlinkat(
             return_errno_with_message!(Errno::ENOENT, "linkpath is empty");
         }
         let fs_path = FsPath::new(dirfd, linkpath.as_ref())?;
-        ctx.process
+        ctx.posix_thread
             .fs()
+            .resolver()
             .read()
             .lookup_dir_and_new_basename(&fs_path, false)?
     };

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -17,7 +17,7 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize, ctx: &Context) -> Result<SyscallR
     check_length(len, ctx)?;
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 
@@ -37,7 +37,7 @@ pub fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result<Syscal
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
     dir_dentry.resize(len as usize)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/umask.rs
+++ b/kernel/src/syscall/umask.rs
@@ -5,6 +5,6 @@ use crate::prelude::*;
 
 pub fn sys_umask(mask: u16, ctx: &Context) -> Result<SyscallReturn> {
     debug!("mask = 0o{:o}", mask);
-    let old_mask = ctx.process.umask().write().set(mask);
+    let old_mask = ctx.posix_thread.fs().umask().write().set(mask);
     Ok(SyscallReturn::Return(old_mask as _))
 }

--- a/kernel/src/syscall/umount.rs
+++ b/kernel/src/syscall/umount.rs
@@ -21,9 +21,13 @@ pub fn sys_umount(path_addr: Vaddr, flags: u64, ctx: &Context) -> Result<Syscall
     let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
 
     let target_dentry = if umount_flags.contains(UmountFlags::UMOUNT_NOFOLLOW) {
-        ctx.process.fs().read().lookup_no_follow(&fs_path)?
+        ctx.posix_thread
+            .fs()
+            .resolver()
+            .read()
+            .lookup_no_follow(&fs_path)?
     } else {
-        ctx.process.fs().read().lookup(&fs_path)?
+        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
 
     target_dentry.unmount()?;

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -34,7 +34,11 @@ pub fn sys_unlinkat(
             return_errno_with_message!(Errno::EISDIR, "unlink on directory");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.process.fs().read().lookup_dir_and_base_name(&fs_path)?
+        ctx.posix_thread
+            .fs()
+            .resolver()
+            .read()
+            .lookup_dir_and_base_name(&fs_path)?
     };
     dir_dentry.unlink(&name)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -168,7 +168,7 @@ fn do_utimes(
     let dentry = {
         // Determine the file system path and the corresponding entry
         let fs_path = FsPath::new(dirfd, pathname.as_ref())?;
-        let fs = ctx.process.fs().read();
+        let fs = ctx.posix_thread.fs().resolver().read();
         if flags.contains(UtimensFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/write.rs
+++ b/kernel/src/syscall/write.rs
@@ -15,7 +15,7 @@ pub fn sys_write(
     );
 
     let file = {
-        let file_table = ctx.process.file_table().lock();
+        let file_table = ctx.posix_thread.file_table().lock();
         file_table.get_file(fd)?.clone()
     };
 

--- a/kernel/src/util/net/mod.rs
+++ b/kernel/src/util/net/mod.rs
@@ -11,10 +11,13 @@ pub use addr::{
 pub use options::{new_raw_socket_option, CSocketOptionLevel};
 pub use socket::{CUserMsgHdr, Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
 
-use crate::{fs::file_table::FileDesc, net::socket::Socket, prelude::*};
+use crate::{
+    fs::file_table::FileDesc, net::socket::Socket, prelude::*, process::posix_thread::AsPosixThread,
+};
 
 pub fn get_socket_from_fd(sockfd: FileDesc) -> Result<Arc<dyn Socket>> {
-    let current = current!();
+    let current = current_thread!();
+    let current = current.as_posix_thread().unwrap();
     let file_table = current.file_table().lock();
     file_table.get_socket(sockfd)
 }


### PR DESCRIPTION
Having FS things in `Process` is just wrong, because Linux allows `clone(CLONE_THREAD)` _without_ `CLONE_FILES` or `CLONE_FS`.

According to the [man pages for `clone`](https://man7.org/linux/man-pages/man2/clone.2.html):
```
              Since Linux 2.5.35, the flags mask must also include
              CLONE_SIGHAND if CLONE_THREAD is specified (and note that,
              since Linux 2.6.0, CLONE_SIGHAND also requires CLONE_VM to
              be included).
```
So `CLONE_THREAD` will imply `CLONE_VM` and `CLONE_SIGHAND`, but no other flags.

See also the [Linux source code](https://elixir.bootlin.com/linux/v6.12.1/source/kernel/fork.c#L2142).