### PR TITLE
Fix the nested bottom half

### DIFF
--- a/kernel/comps/softirq/src/lib.rs
+++ b/kernel/comps/softirq/src/lib.rs
@@ -119,36 +119,14 @@ static ENABLED_MASK: AtomicU8 = AtomicU8::new(0);
 
 cpu_local_cell! {
     static PENDING_MASK: u8 = 0;
-    static IS_ENABLED: bool = true;
-}
-
-/// Enables softirq in current processor.
-fn enable_softirq_local() {
-    IS_ENABLED.store(true);
-}
-
-/// Disables softirq in current processor.
-fn disable_softirq_local() {
-    IS_ENABLED.store(false);
-}
-
-/// Checks whether the softirq is enabled in current processor.
-fn is_softirq_enabled() -> bool {
-    IS_ENABLED.load()
 }
 
 /// Processes pending softirqs.
 ///
 /// The processing instructions will iterate for `SOFTIRQ_RUN_TIMES` times. If any softirq
 /// is raised during the iteration, it will be processed.
-pub(crate) fn process_pending() {
+fn process_pending() {
     const SOFTIRQ_RUN_TIMES: u8 = 5;
-
-    if !is_softirq_enabled() {
-        return;
-    }
-
-    disable_softirq_local();
 
     for _i in 0..SOFTIRQ_RUN_TIMES {
         let mut action_mask = {
@@ -166,6 +144,4 @@ pub(crate) fn process_pending() {
             action_mask &= action_mask - 1;
         }
     }
-
-    enable_softirq_local();
 }

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -34,35 +34,53 @@ fn process_top_half(trap_frame: &TrapFrame, irq_number: usize) {
 }
 
 fn process_bottom_half() {
+    let Some(handler) = BOTTOM_HALF_HANDLER.get() else {
+        return;
+    };
+
     // We need to disable preemption when processing bottom half since
     // the interrupt is enabled in this context.
-    let _preempt_guard = disable_preempt();
+    // This needs to be done before enabling the local interrupts to
+    // avoid race conditions.
+    let preempt_guard = disable_preempt();
+    crate::arch::irq::enable_local();
 
-    if let Some(handler) = BOTTOM_HALF_HANDLER.get() {
-        handler()
-    }
+    handler();
+
+    crate::arch::irq::disable_local();
+    drop(preempt_guard);
 }
 
 pub(crate) fn call_irq_callback_functions(trap_frame: &TrapFrame, irq_number: usize) {
-    // For x86 CPUs, interrupts are not re-entrant. Local interrupts will be disabled when
-    // an interrupt handler is called (Unless interrupts are re-enabled in an interrupt handler).
+    // We do not provide support for reentrant interrupt handlers. Otherwise, it's very hard to
+    // guarantee the absence of stack overflows.
     //
-    // FIXME: For arch that supports re-entrant interrupts, we may need to record nested level here.
-    IN_INTERRUPT_CONTEXT.store(true);
+    // As a concrete example, Linux once supported them in its early days, but has dropped support
+    // for this very reason. See
+    // <https://github.com/torvalds/linux/commit/d8bf368d0631d4bc2612d8bf2e4e8e74e620d0cc>.
+    //
+    // Nevertheless, we still need a counter to track the nested level because interrupts are
+    // enabled while the bottom half is being processing. The counter cannot exceed two because the
+    // bottom half cannot be reentrant for the same reason.
+    INTERRUPT_NESTED_LEVEL.add_assign(1);
 
     process_top_half(trap_frame, irq_number);
     crate::arch::interrupts_ack(irq_number);
-    crate::arch::irq::enable_local();
-    process_bottom_half();
 
-    IN_INTERRUPT_CONTEXT.store(false);
+    if INTERRUPT_NESTED_LEVEL.load() == 1 {
+        process_bottom_half();
+    }
+
+    INTERRUPT_NESTED_LEVEL.sub_assign(1);
 }
 
 cpu_local_cell! {
-    static IN_INTERRUPT_CONTEXT: bool = false;
+    static INTERRUPT_NESTED_LEVEL: u8 = 0;
 }
 
 /// Returns whether we are in the interrupt context.
+///
+/// Note that both the top half and the bottom half is processed in the interrupt context.
 pub fn in_interrupt_context() -> bool {
-    IN_INTERRUPT_CONTEXT.load()
+    INTERRUPT_NESTED_LEVEL.load() != 0
 }


### PR DESCRIPTION
There are several issues in `call_irq_callback_functions` regarding the processing of the bottom half.

 - First, there is even a FIXME to note that `IN_INTERRUPT_CONTEXT` won't work if the interrupts are enabled in the middle! But the FIXME is apparently ignored when the bottom half support is added.
https://github.com/asterinas/asterinas/blob/6d3bb5a9d0b1d4d53e298402bc8fec57dc899f15/ostd/src/trap/handler.rs#L50
https://github.com/asterinas/asterinas/blob/6d3bb5a9d0b1d4d53e298402bc8fec57dc899f15/ostd/src/trap/handler.rs#L55

 - Second, the current implementation allows an unlimited number of nested interrupts, because the interrupts are _unconditionally_ re-enabled after the top half is processed. Another interrupt can come immediately, causing stack overflows.
    - See also the newly added comments in this PR:
```rust
    // We do not provide support for reentrant interrupt handlers. Otherwise, it's very hard to
    // guarantee the absence of stack overflows.
    //
    // As a concrete example, Linux once supported them in its early days, but has dropped support
    // for this very reason. See
    // <https://github.com/torvalds/linux/commit/d8bf368d0631d4bc2612d8bf2e4e8e74e620d0cc>.
    //
    // Nevertheless, we still need a counter to track the nested level because interrupts are
    // enabled while the bottom half is being processing. The counter cannot exceed two because the
    // bottom half cannot be reentrant for the same reason.
```

 - Third, we should disable preemption _before_ re-enabling the interrupts. Otherwise, race conditions can occur in the middle, triggering unexpected preemption.
https://github.com/asterinas/asterinas/blob/6d3bb5a9d0b1d4d53e298402bc8fec57dc899f15/ostd/src/trap/handler.rs#L37-L39

Another thing is that I don't think it's necessary to use `Box<dyn Fn>` for the bottom half handler, so I change it to `fn()`.

Fix #1648