### PR TITLE
Add `WriteIrqDisabled` as a guardian for `RwLock`

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -6,7 +6,7 @@ use aster_bigtcp::{
     socket::{SocketEventObserver, SocketEvents},
     wire::IpEndpoint,
 };
-use ostd::sync::LocalIrqDisabled;
+use ostd::sync::WriteIrqDisabled;
 use takeable::Takeable;
 
 use self::{bound::BoundDatagram, unbound::UnboundDatagram};
@@ -52,7 +52,7 @@ impl OptionSet {
 
 pub struct DatagramSocket {
     options: RwLock<OptionSet>,
-    inner: RwLock<Takeable<Inner>, LocalIrqDisabled>,
+    inner: RwLock<Takeable<Inner>, WriteIrqDisabled>,
     nonblocking: AtomicBool,
     pollee: Pollee,
 }

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -3,7 +3,7 @@
 use aster_bigtcp::{
     errors::tcp::ListenError, iface::BindPortConfig, socket::UnboundTcpSocket, wire::IpEndpoint,
 };
-use ostd::sync::LocalIrqDisabled;
+use ostd::sync::WriteIrqDisabled;
 
 use super::connected::ConnectedStream;
 use crate::{
@@ -17,7 +17,7 @@ pub struct ListenStream {
     /// A bound socket held to ensure the TCP port cannot be released
     bound_socket: BoundTcpSocket,
     /// Backlog sockets listening at the local endpoint
-    backlog_sockets: RwLock<Vec<BacklogSocket>, LocalIrqDisabled>,
+    backlog_sockets: RwLock<Vec<BacklogSocket>, WriteIrqDisabled>,
 }
 
 impl ListenStream {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -11,7 +11,7 @@ use connecting::{ConnResult, ConnectingStream};
 use init::InitStream;
 use listen::ListenStream;
 use options::{Congestion, MaxSegment, NoDelay, WindowClamp};
-use ostd::sync::{LocalIrqDisabled, PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
+use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard, WriteIrqDisabled};
 use takeable::Takeable;
 use util::TcpOptionSet;
 
@@ -50,7 +50,7 @@ pub use self::util::CongestionControl;
 
 pub struct StreamSocket {
     options: RwLock<OptionSet>,
-    state: RwLock<Takeable<State>, LocalIrqDisabled>,
+    state: RwLock<Takeable<State>, WriteIrqDisabled>,
     is_nonblocking: AtomicBool,
     pollee: Pollee,
 }
@@ -116,7 +116,7 @@ impl StreamSocket {
     /// Ensures that the socket state is up to date and obtains a read lock on it.
     ///
     /// For a description of what "up-to-date" means, see [`Self::update_connecting`].
-    fn read_updated_state(&self) -> RwLockReadGuard<Takeable<State>, LocalIrqDisabled> {
+    fn read_updated_state(&self) -> RwLockReadGuard<Takeable<State>, WriteIrqDisabled> {
         loop {
             let state = self.state.read();
             match state.as_ref() {
@@ -132,7 +132,7 @@ impl StreamSocket {
     /// Ensures that the socket state is up to date and obtains a write lock on it.
     ///
     /// For a description of what "up-to-date" means, see [`Self::update_connecting`].
-    fn write_updated_state(&self) -> RwLockWriteGuard<Takeable<State>, LocalIrqDisabled> {
+    fn write_updated_state(&self) -> RwLockWriteGuard<Takeable<State>, WriteIrqDisabled> {
         self.update_connecting().1
     }
 
@@ -149,7 +149,7 @@ impl StreamSocket {
         &self,
     ) -> (
         RwLockWriteGuard<OptionSet, PreemptDisabled>,
-        RwLockWriteGuard<Takeable<State>, LocalIrqDisabled>,
+        RwLockWriteGuard<Takeable<State>, WriteIrqDisabled>,
     ) {
         // Hold the lock in advance to avoid race conditions.
         let mut options = self.options.write();

--- a/ostd/src/sync/guard.rs
+++ b/ostd/src/sync/guard.rs
@@ -5,13 +5,17 @@ use crate::{
     trap::{disable_local, DisabledLocalIrqGuard},
 };
 
-/// A guardian that denotes the guard behavior for holding the spin lock.
+/// A guardian that denotes the guard behavior for holding a lock.
 pub trait Guardian {
-    /// The guard type.
+    /// The guard type for holding a spin lock or a write lock.
     type Guard: GuardTransfer;
+    /// The guard type for holding a read lock.
+    type ReadGuard: GuardTransfer;
 
     /// Creates a new guard.
     fn guard() -> Self::Guard;
+    /// Creates a new read guard.
+    fn read_guard() -> Self::ReadGuard;
 }
 
 /// The Guard can be transferred atomically.
@@ -25,21 +29,25 @@ pub trait GuardTransfer {
     fn transfer_to(&mut self) -> Self;
 }
 
-/// A guardian that disables preemption while holding the spin lock.
+/// A guardian that disables preemption while holding a lock.
 pub struct PreemptDisabled;
 
 impl Guardian for PreemptDisabled {
     type Guard = DisabledPreemptGuard;
+    type ReadGuard = DisabledPreemptGuard;
 
     fn guard() -> Self::Guard {
         disable_preempt()
     }
+    fn read_guard() -> Self::Guard {
+        disable_preempt()
+    }
 }
 
-/// A guardian that disables IRQs while holding the spin lock.
+/// A guardian that disables IRQs while holding a lock.
 ///
 /// This guardian would incur a certain time overhead over
-/// [`PreemptDisabled']. So prefer avoiding using this guardian when
+/// [`PreemptDisabled`]. So prefer avoiding using this guardian when
 /// IRQ handlers are allowed to get executed while holding the
 /// lock. For example, if a lock is never used in the interrupt
 /// context, then it is ok not to use this guardian in the process context.
@@ -47,8 +55,38 @@ pub struct LocalIrqDisabled;
 
 impl Guardian for LocalIrqDisabled {
     type Guard = DisabledLocalIrqGuard;
+    type ReadGuard = DisabledLocalIrqGuard;
 
     fn guard() -> Self::Guard {
         disable_local()
+    }
+    fn read_guard() -> Self::Guard {
+        disable_local()
+    }
+}
+
+/// A guardian that disables IRQs while holding a write lock.
+///
+/// This guardian should only be used for a [`RwLock`]. Using it with a [`SpinLock`] will behave in
+/// the same way as using [`LocalIrqDisabled`].
+///
+/// When using this guardian with a [`RwLock`], holding the read lock will only disable preemption,
+/// but holding a write lock will disable local IRQs. The user must ensure that the IRQ handlers
+/// never take the write lock, so we can take the read lock without disabling IRQs, but we are
+/// still free of deadlock even if the IRQ handlers are triggered in the middle.
+///
+/// [`RwLock`]: super::RwLock
+/// [`SpinLock`]: super::SpinLock
+pub struct WriteIrqDisabled;
+
+impl Guardian for WriteIrqDisabled {
+    type Guard = DisabledLocalIrqGuard;
+    type ReadGuard = DisabledPreemptGuard;
+
+    fn guard() -> Self::Guard {
+        disable_local()
+    }
+    fn read_guard() -> Self::ReadGuard {
+        disable_preempt()
     }
 }

--- a/ostd/src/sync/guard.rs
+++ b/ostd/src/sync/guard.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    task::{disable_preempt, DisabledPreemptGuard},
+    trap::{disable_local, DisabledLocalIrqGuard},
+};
+
+/// A guardian that denotes the guard behavior for holding the spin lock.
+pub trait Guardian {
+    /// The guard type.
+    type Guard: GuardTransfer;
+
+    /// Creates a new guard.
+    fn guard() -> Self::Guard;
+}
+
+/// The Guard can be transferred atomically.
+pub trait GuardTransfer {
+    /// Atomically transfers the current guard to a new instance.
+    ///
+    /// This function ensures that there are no 'gaps' between the destruction of the old guard and
+    /// the creation of the new guard, thereby maintaining the atomicity of guard transitions.
+    ///
+    /// The original guard must be dropped immediately after calling this method.
+    fn transfer_to(&mut self) -> Self;
+}
+
+/// A guardian that disables preemption while holding the spin lock.
+pub struct PreemptDisabled;
+
+impl Guardian for PreemptDisabled {
+    type Guard = DisabledPreemptGuard;
+
+    fn guard() -> Self::Guard {
+        disable_preempt()
+    }
+}
+
+/// A guardian that disables IRQs while holding the spin lock.
+///
+/// This guardian would incur a certain time overhead over
+/// [`PreemptDisabled']. So prefer avoiding using this guardian when
+/// IRQ handlers are allowed to get executed while holding the
+/// lock. For example, if a lock is never used in the interrupt
+/// context, then it is ok not to use this guardian in the process context.
+pub struct LocalIrqDisabled;
+
+impl Guardian for LocalIrqDisabled {
+    type Guard = DisabledLocalIrqGuard;
+
+    fn guard() -> Self::Guard {
+        disable_local()
+    }
+}

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -2,6 +2,7 @@
 
 //! Useful synchronization primitives.
 
+mod guard;
 mod mutex;
 // TODO: refactor this rcu implementation
 // Comment out this module since it raises lint error
@@ -12,7 +13,9 @@ mod spin;
 mod wait;
 
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};
+pub(crate) use self::guard::GuardTransfer;
 pub use self::{
+    guard::{LocalIrqDisabled, PreemptDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
@@ -22,8 +25,6 @@ pub use self::{
         ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
         RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
     },
-    spin::{
-        ArcSpinLockGuard, GuardTransfer, LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard,
-    },
+    spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
     wait::{WaitQueue, Waiter, Waker},
 };

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -15,7 +15,7 @@ mod wait;
 // pub use self::rcu::{pass_quiescent_state, OwnerPtr, Rcu, RcuReadGuard, RcuReclaimer};
 pub(crate) use self::guard::GuardTransfer;
 pub use self::{
-    guard::{LocalIrqDisabled, PreemptDisabled},
+    guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -230,7 +230,7 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
     ///
     /// This function will never spin-wait and will return immediately.
     pub fn try_read(&self) -> Option<RwLockReadGuard<T, G>> {
-        let guard = G::guard();
+        let guard = G::read_guard();
         let lock = self.lock.fetch_add(READER, Acquire);
         if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
             Some(RwLockReadGuard { inner: self, guard })
@@ -247,7 +247,7 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
     ///
     /// [`try_read`]: Self::try_read
     pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<T, G>> {
-        let guard = G::guard();
+        let guard = G::read_guard();
         let lock = self.lock.fetch_add(READER, Acquire);
         if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
             Some(ArcRwLockReadGuard {
@@ -375,7 +375,7 @@ unsafe impl<T: ?Sized + Sync, R: Deref<Target = RwLock<T, G>> + Clone + Sync, G:
 #[clippy::has_significant_drop]
 #[must_use]
 pub struct RwLockReadGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: Guardian> {
-    guard: G::Guard,
+    guard: G::ReadGuard,
     inner: R,
 }
 

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -14,7 +14,10 @@ use core::{
     },
 };
 
-use super::{spin::Guardian, GuardTransfer, PreemptDisabled};
+use super::{
+    guard::{GuardTransfer, Guardian},
+    PreemptDisabled,
+};
 
 /// Spin-based Read-write Lock
 ///

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -11,10 +11,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use crate::{
-    task::{disable_preempt, DisabledPreemptGuard},
-    trap::{disable_local, DisabledLocalIrqGuard},
-};
+use super::{guard::Guardian, LocalIrqDisabled, PreemptDisabled};
 
 /// A spin lock.
 ///
@@ -42,54 +39,6 @@ pub struct SpinLock<T: ?Sized, G = PreemptDisabled> {
 struct SpinLockInner<T: ?Sized> {
     lock: AtomicBool,
     val: UnsafeCell<T>,
-}
-
-/// A guardian that denotes the guard behavior for holding the spin lock.
-pub trait Guardian {
-    /// The guard type.
-    type Guard: GuardTransfer;
-
-    /// Creates a new guard.
-    fn guard() -> Self::Guard;
-}
-
-/// The Guard can be transferred atomically.
-pub trait GuardTransfer {
-    /// Atomically transfers the current guard to a new instance.
-    ///
-    /// This function ensures that there are no 'gaps' between the destruction of the old guard and
-    /// the creation of the new guard, thereby maintaining the atomicity of guard transitions.
-    ///
-    /// The original guard must be dropped immediately after calling this method.
-    fn transfer_to(&mut self) -> Self;
-}
-
-/// A guardian that disables preemption while holding the spin lock.
-pub struct PreemptDisabled;
-
-impl Guardian for PreemptDisabled {
-    type Guard = DisabledPreemptGuard;
-
-    fn guard() -> Self::Guard {
-        disable_preempt()
-    }
-}
-
-/// A guardian that disables IRQs while holding the spin lock.
-///
-/// This guardian would incur a certain time overhead over
-/// [`PreemptDisabled']. So prefer avoiding using this guardian when
-/// IRQ handlers are allowed to get executed while holding the
-/// lock. For example, if a lock is never used in the interrupt
-/// context, then it is ok not to use this guardian in the process context.
-pub struct LocalIrqDisabled;
-
-impl Guardian for LocalIrqDisabled {
-    type Guard = DisabledLocalIrqGuard;
-
-    fn guard() -> Self::Guard {
-        disable_local()
-    }
 }
 
 impl<T, G> SpinLock<T, G> {

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// [`disable_irq`]: Self::disable_irq
 #[repr(transparent)]
-pub struct SpinLock<T: ?Sized, G: Guardian = PreemptDisabled> {
+pub struct SpinLock<T: ?Sized, G = PreemptDisabled> {
     phantom: PhantomData<G>,
     /// Only the last field of a struct may have a dynamically sized type.
     /// That's why SpinLockInner is put in the last field.
@@ -92,7 +92,7 @@ impl Guardian for LocalIrqDisabled {
     }
 }
 
-impl<T, G: Guardian> SpinLock<T, G> {
+impl<T, G> SpinLock<T, G> {
     /// Creates a new spin lock.
     pub const fn new(val: T) -> Self {
         let lock_inner = SpinLockInner {
@@ -179,15 +179,15 @@ impl<T: ?Sized, G: Guardian> SpinLock<T, G> {
     }
 }
 
-impl<T: ?Sized + fmt::Debug, G: Guardian> fmt::Debug for SpinLock<T, G> {
+impl<T: ?Sized + fmt::Debug, G> fmt::Debug for SpinLock<T, G> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.inner.val, f)
     }
 }
 
 // SAFETY: Only a single lock holder is permitted to access the inner data of Spinlock.
-unsafe impl<T: ?Sized + Send, G: Guardian> Send for SpinLock<T, G> {}
-unsafe impl<T: ?Sized + Send, G: Guardian> Sync for SpinLock<T, G> {}
+unsafe impl<T: ?Sized + Send, G> Send for SpinLock<T, G> {}
+unsafe impl<T: ?Sized + Send, G> Sync for SpinLock<T, G> {}
 
 /// A guard that provides exclusive access to the data protected by a [`SpinLock`].
 pub type SpinLockGuard<'a, T, G> = SpinLockGuard_<T, &'a SpinLock<T, G>, G>;


### PR DESCRIPTION
The guardian for `RwLock` is added in #1625, but the code transformation in the network code is mostly not that correct (I'm not saying it's wrong, but it certainly doesn't guarantee that the semantics are kept the same).

This is because I deliberately design the `RwLock` in the network code to ensure that the IRQ handlers never take the write lock, so we can _take the read lock without disabling IRQs_. But after #1625, taking either the read lock or the write lock will result in disabled IRQs.

I think we can introduce a new type of guardian to restore the original behavior:
```rust
/// A guardian that disables IRQs while holding a write lock.
///
/// This guardian should only be used for a [`RwLock`]. Using it with a [`SpinLock`] will behave in
/// the same way as using [`LocalIrqDisabled`].
///
/// When using this guardian with a [`RwLock`], holding the read lock will only disable preemption,
/// but holding a write lock will disable local IRQs. The user must ensure that the IRQ handlers
/// never take the write lock, so we can take the read lock without disabling IRQs, but we are
/// still free of deadlock even if the IRQ handlers are triggered in the middle.
pub struct WriteIrqDisabled;

impl Guardian for WriteIrqDisabled {
    type Guard = DisabledLocalIrqGuard;
    type ReadGuard = DisabledPreemptGuard;

    fn guard() -> Self::Guard {
        disable_local()
    }
    fn read_guard() -> Self::ReadGuard {
        disable_preempt()
    }
}
```