### PR TITLE
Add options to skip recompilation, network access, and compression to speed up testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ install_osdk:
 # This will install OSDK if it is not already installed
 # To update OSDK, we need to run `install_osdk` manually
 $(CARGO_OSDK):
-	@make --no-print-directory install_osdk
+	@$(MAKE) --no-print-directory install_osdk
 
 .PHONY: check_osdk
 check_osdk:
@@ -177,9 +177,13 @@ test_osdk:
 		OSDK_LOCAL_DEV=1 cargo build && \
 		OSDK_LOCAL_DEV=1 cargo test
 
+.PHONY: _initramfs
+_initramfs:
+	@$(MAKE) --no-print-directory -C test
+
 .PHONY: initramfs
-initramfs:
-	@make --no-print-directory -C test
+initramfs: _initramfs
+	$(eval CARGO_OSDK_ARGS += --initramfs=$(shell cat test/build/initramfs_path.txt))
 
 .PHONY: build
 build: initramfs $(CARGO_OSDK)
@@ -254,7 +258,7 @@ docs: $(CARGO_OSDK)
 .PHONY: format
 format:
 	@./tools/format_all.sh
-	@make --no-print-directory -C test format
+	@$(MAKE) --no-print-directory -C test format
 
 .PHONY: check
 check: initramfs $(CARGO_OSDK)
@@ -276,7 +280,7 @@ check: initramfs $(CARGO_OSDK)
 		echo "Checking $$dir"; \
 		(cd $$dir && cargo osdk clippy -- -- -D warnings) || exit 1; \
 	done
-	@make --no-print-directory -C test check
+	@$(MAKE) --no-print-directory -C test check
 	@typos
 
 .PHONY: clean
@@ -288,6 +292,6 @@ clean:
 	@echo "Cleaning up documentation target files"
 	@cd docs && mdbook clean
 	@echo "Cleaning up test target files"
-	@make --no-print-directory -C test clean
+	@$(MAKE) --no-print-directory -C test clean
 	@echo "Uninstalling OSDK"
 	@rm -f $(CARGO_OSDK)

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -23,7 +23,7 @@ impl<'a> BoxedReader<'a> {
     }
 }
 
-impl<'a> Read for BoxedReader<'a> {
+impl Read for BoxedReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> core2::io::Result<usize> {
         self.0.read(buf)
     }

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core2::io::{Cursor, Read};
 use cpio_decoder::{CpioDecoder, FileType};
 use lending_iterator::LendingIterator;
 use libflate::gzip::Decoder as GZipDecoder;
@@ -14,17 +15,42 @@ use super::{
 };
 use crate::prelude::*;
 
+struct BoxedReader<'a>(Box<dyn Read + 'a>);
+
+impl<'a> BoxedReader<'a> {
+    pub fn new(reader: Box<dyn Read + 'a>) -> Self {
+        BoxedReader(reader)
+    }
+}
+
+impl<'a> Read for BoxedReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> core2::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
 /// Unpack and prepare the rootfs from the initramfs CPIO buffer.
 pub fn init(initramfs_buf: &[u8]) -> Result<()> {
     init_root_mount();
     procfs::init();
 
-    println!("[kernel] unpacking the initramfs.cpio.gz to rootfs ...");
-    let fs = FsResolver::new();
-    let mut decoder = CpioDecoder::new(
-        GZipDecoder::new(initramfs_buf)
-            .map_err(|_| Error::with_message(Errno::EINVAL, "invalid gzip buffer"))?,
+    let mut initramfs_suffix = "";
+    let reader = match &initramfs_buf[..4] {
+        // Gzip magic number: 0x1F 0x8B
+        &[0x1F, 0x8B, _, _] => {
+            initramfs_suffix = ".gz";
+            let gzip_decoder = GZipDecoder::new(initramfs_buf)
+                .map_err(|_| Error::with_message(Errno::EINVAL, "invalid gzip buffer"))?;
+            BoxedReader::new(Box::new(gzip_decoder))
+        }
+        _ => BoxedReader::new(Box::new(Cursor::new(initramfs_buf))),
+    };
+    println!(
+        "[kernel] unpacking the initramfs.cpio{} to rootfs ...",
+        initramfs_suffix
     );
+    let mut decoder = CpioDecoder::new(reader);
+    let fs = FsResolver::new();
 
     loop {
         let Some(entry_result) = decoder.next() else {

--- a/osdk/src/bundle/bin.rs
+++ b/osdk/src/bundle/bin.rs
@@ -83,12 +83,11 @@ impl AsterBin {
         self.stripped
     }
 
-    /// Move the binary to the `base` directory and convert the path to a relative path.
-    pub fn move_to(self, base: impl AsRef<Path>) -> Self {
+    /// Copy the binary to the `base` directory and convert the path to a relative path.
+    pub fn copy_to(self, base: impl AsRef<Path>) -> Self {
         let file_name = self.path.file_name().unwrap();
         let copied_path = base.as_ref().join(file_name);
         fs::copy(&self.path, copied_path).unwrap();
-        fs::remove_file(&self.path).unwrap();
         Self {
             path: PathBuf::from(file_name),
             arch: self.arch,

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -286,21 +286,21 @@ impl Bundle {
         }
     }
 
-    /// Move the vm_image into the bundle.
+    /// Copy the vm_image into the bundle.
     pub fn consume_vm_image(&mut self, vm_image: AsterVmImage) {
         if self.manifest.vm_image.is_some() {
             panic!("vm_image already exists");
         }
-        self.manifest.vm_image = Some(vm_image.move_to(&self.path));
+        self.manifest.vm_image = Some(vm_image.copy_to(&self.path));
         self.write_manifest_to_fs();
     }
 
-    /// Move the aster_bin into the bundle.
+    /// Copy the aster_bin into the bundle.
     pub fn consume_aster_bin(&mut self, aster_bin: AsterBin) {
         if self.manifest.aster_bin.is_some() {
             panic!("aster_bin already exists");
         }
-        self.manifest.aster_bin = Some(aster_bin.move_to(&self.path));
+        self.manifest.aster_bin = Some(aster_bin.copy_to(&self.path));
         self.write_manifest_to_fs();
     }
 

--- a/osdk/src/bundle/vm_image.rs
+++ b/osdk/src/bundle/vm_image.rs
@@ -59,12 +59,11 @@ impl AsterVmImage {
         &self.typ
     }
 
-    /// Move the binary to the `base` directory and convert the path to a relative path.
-    pub fn move_to(self, base: impl AsRef<Path>) -> Self {
+    /// Copy the binary to the `base` directory and convert the path to a relative path.
+    pub fn copy_to(self, base: impl AsRef<Path>) -> Self {
         let file_name = self.path.file_name().unwrap();
         let copied_path = base.as_ref().join(file_name);
         fs::copy(&self.path, copied_path).unwrap();
-        fs::remove_file(&self.path).unwrap();
         Self {
             path: PathBuf::from(file_name),
             typ: self.typ,

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -32,7 +32,7 @@ pub fn main() {
     match osdk_subcommand {
         OsdkSubcommand::New(args) => execute_new_command(args),
         OsdkSubcommand::Build(build_args) => {
-            execute_build_command(&load_config(&build_args.common_args), build_args);
+            execute_build_command(&mut load_config(&build_args.common_args), build_args);
         }
         OsdkSubcommand::Run(run_args) => {
             execute_run_command(
@@ -476,4 +476,10 @@ pub struct CommonArgs {
         global = true
     )]
     pub encoding: Option<PayloadEncoding>,
+    #[arg(
+        long = "skip-build",
+        help = "Skip build phase to speed up QEMU execution",
+        global = true
+    )]
+    pub skip_build: bool,
 }

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -7,8 +7,9 @@ use clap::{crate_version, Args, Parser, ValueEnum};
 use crate::{
     arch::Arch,
     commands::{
-        execute_build_command, execute_debug_command, execute_forwarded_command,
-        execute_new_command, execute_profile_command, execute_run_command, execute_test_command,
+        execute_build_command, execute_debug_command, execute_fetch_command,
+        execute_forwarded_command, execute_new_command, execute_profile_command,
+        execute_run_command, execute_test_command,
     },
     config::{
         manifest::{ProjectType, TomlManifest},
@@ -58,6 +59,7 @@ pub fn main() {
         OsdkSubcommand::Check(args) => execute_forwarded_command("check", &args.args, true),
         OsdkSubcommand::Clippy(args) => execute_forwarded_command("clippy", &args.args, true),
         OsdkSubcommand::Doc(args) => execute_forwarded_command("doc", &args.args, false),
+        OsdkSubcommand::Fetch(_) => execute_fetch_command(),
     }
 }
 
@@ -95,6 +97,8 @@ pub enum OsdkSubcommand {
     Clippy(ForwardedArguments),
     #[command(about = "Build a package's documentation")]
     Doc(ForwardedArguments),
+    #[command(about = "Build all architectures to fetch and cache dependencies for offline use")]
+    Fetch(ForwardedArguments),
 }
 
 #[derive(Debug, Parser)]
@@ -482,4 +486,10 @@ pub struct CommonArgs {
         global = true
     )]
     pub skip_build: bool,
+    #[arg(
+        long = "offline",
+        help = "Run without accessing the network",
+        global = true
+    )]
+    pub offline: bool,
 }

--- a/osdk/src/commands/fetch.rs
+++ b/osdk/src/commands/fetch.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use clap::ValueEnum;
+
+use super::util;
+use crate::arch::Arch;
+
+/// Execute the build cargo command for each architecture without arguments.
+pub fn execute_fetch_command() {
+    let target_archs: Vec<&str> = Arch::value_variants()
+        .iter()
+        .map(|arch| arch.to_str())
+        .collect();
+
+    for current_arch in target_archs {
+        let mut cargo = util::cargo();
+        cargo
+            .arg("osdk")
+            .arg("build")
+            .arg(format!("--target-arch={}", current_arch));
+        cargo.status().expect("Failed to execute cargo");
+    }
+}

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 mod build;
 mod debug;
+mod fetch;
 mod new;
 mod profile;
 mod run;
@@ -11,8 +12,9 @@ mod test;
 mod util;
 
 pub use self::{
-    build::execute_build_command, debug::execute_debug_command, new::execute_new_command,
-    profile::execute_profile_command, run::execute_run_command, test::execute_test_command,
+    build::execute_build_command, debug::execute_debug_command, fetch::execute_fetch_command,
+    new::execute_new_command, profile::execute_profile_command, run::execute_run_command,
+    test::execute_test_command,
 };
 
 use crate::arch::get_default_arch;

--- a/osdk/src/config/scheme/action.rs
+++ b/osdk/src/config/scheme/action.rs
@@ -28,6 +28,8 @@ pub struct BuildScheme {
     pub encoding: Option<PayloadEncoding>,
     #[serde(default)]
     pub skip_build: bool,
+    #[serde(default)]
+    pub offline: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +48,8 @@ pub struct Build {
     pub encoding: PayloadEncoding,
     #[serde(default)]
     pub skip_build: bool,
+    #[serde(default)]
+    pub offline: bool,
 }
 
 impl Default for Build {
@@ -59,6 +63,7 @@ impl Default for Build {
             strip_elf: false,
             encoding: PayloadEncoding::default(),
             skip_build: false,
+            offline: false,
         }
     }
 }
@@ -86,6 +91,9 @@ impl Build {
         }
         if common_args.skip_build {
             self.skip_build = true;
+        }
+        if common_args.offline {
+            self.offline = true;
         }
     }
 }
@@ -122,6 +130,7 @@ impl BuildScheme {
             strip_elf: self.strip_elf,
             encoding: self.encoding.unwrap_or_default(),
             skip_build: self.skip_build,
+            offline: self.offline,
         }
     }
 }

--- a/osdk/src/config/scheme/action.rs
+++ b/osdk/src/config/scheme/action.rs
@@ -26,6 +26,8 @@ pub struct BuildScheme {
     #[serde(default)]
     pub strip_elf: bool,
     pub encoding: Option<PayloadEncoding>,
+    #[serde(default)]
+    pub skip_build: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,6 +44,8 @@ pub struct Build {
     #[serde(default)]
     pub strip_elf: bool,
     pub encoding: PayloadEncoding,
+    #[serde(default)]
+    pub skip_build: bool,
 }
 
 impl Default for Build {
@@ -54,6 +58,7 @@ impl Default for Build {
             linux_x86_legacy_boot: false,
             strip_elf: false,
             encoding: PayloadEncoding::default(),
+            skip_build: false,
         }
     }
 }
@@ -78,6 +83,9 @@ impl Build {
         }
         if let Some(encoding) = common_args.encoding.clone() {
             self.encoding.clone_from(&encoding);
+        }
+        if common_args.skip_build {
+            self.skip_build = true;
         }
     }
 }
@@ -113,6 +121,7 @@ impl BuildScheme {
             linux_x86_legacy_boot: self.linux_x86_legacy_boot,
             strip_elf: self.strip_elf,
             encoding: self.encoding.unwrap_or_default(),
+            skip_build: self.skip_build,
         }
     }
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,21 @@ ATOMIC_WGET := $(CUR_DIR)/../tools/atomic_wget.sh
 BUILD_DIR := $(CUR_DIR)/build
 INITRAMFS := $(BUILD_DIR)/initramfs
 INITRAMFS_FILELIST := $(BUILD_DIR)/initramfs.filelist
-INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio.gz
+# Supported encodings: `gzip` and `none`
+INITRAMFS_ENCODING ?= gzip
+# Determine the suffix and encoder command
+ifeq ($(INITRAMFS_ENCODING),gzip)
+	INITRAMFS_SUFFIX := .gz
+	INITRAMFS_ENCODER_CMD := gzip
+else ifeq ($(INITRAMFS_ENCODING),none)
+	INITRAMFS_SUFFIX :=
+	# Dummy encoder
+	INITRAMFS_ENCODER_CMD := cat
+else
+	$(error Unsupported INITRAMFS_ENCODING: $(INITRAMFS_ENCODING))
+endif
+INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio$(INITRAMFS_SUFFIX)
+INITRAMFS_PATH := $(BUILD_DIR)/initramfs_path.txt
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
 INITRAMFS_EMPTY_DIRS := \
@@ -104,7 +118,7 @@ $(INITRAMFS)/usr/local:
 
 .PHONY: $(INITRAMFS)/test
 $(INITRAMFS)/test:
-	@make --no-print-directory -C apps
+	@$(MAKE) --no-print-directory -C apps
 
 $(INITRAMFS)/benchmark: | $(INITRAMFS)/benchmark/bin
 	@cp -rf $(CUR_DIR)/benchmark/* $@
@@ -129,11 +143,11 @@ $(INITRAMFS_EMPTY_DIRS):
 
 .PHONY: $(SYSCALL_TEST_DIR)
 $(SYSCALL_TEST_DIR):
-	@make --no-print-directory -C syscall_test
+	@$(MAKE) --no-print-directory -C syscall_test
 
 .PHONY: $(INITRAMFS_IMAGE)
 $(INITRAMFS_IMAGE): $(INITRAMFS_FILELIST)
-	@if ! cmp -s $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous ; then \
+	@if ! cmp -s $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous || ! test -f $(INITRAMFS_IMAGE); then \
 		echo "Generating the initramfs image..."; \
 		cp -f $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous; \
 		( \
@@ -143,9 +157,10 @@ $(INITRAMFS_IMAGE): $(INITRAMFS_FILELIST)
 			# `$(INITRAMFS)` in the second column. This prunes the first \
 			# column and passes the second column to `cpio`. \
 			cut -d " " -f 2- $(INITRAMFS_FILELIST) | \
-				cpio -o -H newc | gzip \
+				cpio -o -H newc | $(INITRAMFS_ENCODER_CMD) \
 		) > $@; \
 	fi
+	@echo $(INITRAMFS_IMAGE) > $(INITRAMFS_PATH)
 
 .PHONY: $(INITRAMFS_FILELIST)
 # If the BUILD_SYSCALL_TEST variable is set, we should depend on the
@@ -170,11 +185,11 @@ build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE)
 
 .PHONY: format
 format:
-	@make --no-print-directory -C apps format
+	@$(MAKE) --no-print-directory -C apps format
 
 .PHONY: check
 check:
-	@make --no-print-directory -C apps check
+	@$(MAKE) --no-print-directory -C apps check
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Fixes #1663 (OSDK "dry-run" or "echo" not implemented).

**New make targets:**

- `make fetch`: Builds all architecture targets and tests to fetch dependencies.
  - Uses `cargo build` instead of `cargo fetch` since `cargo fetch` does not download all dependencies in my testing.

**New make variables:**

- `SKIP_BUILD=1`: Skips the build command execution if the target already exists. Ignored if OSDK subcommand is `build`.
- `OFFLINE=1`: Disables network access (requires `make fetch` to be run beforehand).
- `INITRAMFS_ENCODING=none`: Disables compression for `INITRAMFS`.
- `RERUN=1`: Enables all the above options.

You can add an alias to `~/.bashrc` for easier usage:

```bash
alias remake="make RERUN=1"
```

Then, use it as follows:

```
remake  # build (ignores `SKIP_BUILD=1`)
remake run
remake gdb_server
remake profile_server
remake test
remake ktest
```

When these features become stable, they can be leveraged to speed up CI by avoiding unnecessary recompilation and network access.

Performance comparison (system with 8 threads):

| Task                   | Make (secs) | Remake (secs) | Performance gain (%) |
|------------------------|-------------|---------------|----------------------|
| Build (excluding OSDK) | 37.99       | 32.13         | 15.43%               |
| Run (after build)      | 25.40       | 10.69         | 57.91%               |
| Run with tests update  | 29.15       | 11.64         | 60.07%               |
| Run with SMP=8         | 30.84       | 12.57         | 59.24%               |
| Ktest                  | 110.61      | 50.32         | 54.51%               |
