### PR TITLE
Implement vfork syscall

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -142,6 +142,16 @@ impl CloneArgs {
             ..Default::default()
         }
     }
+
+    pub fn for_vfork() -> Self {
+        Self {
+            // FIXME: Should be CloneFlags::CLONE_VFORK | CloneFlags::Clone_VM, but that would
+            // require memory management to support.
+            flags: CloneFlags::CLONE_VFORK,
+            exit_signal: Some(SIGCHLD),
+            ..Default::default()
+        }
+    }
 }
 
 impl From<u64> for CloneFlags {
@@ -158,6 +168,7 @@ impl CloneFlags {
             | CloneFlags::CLONE_FS
             | CloneFlags::CLONE_FILES
             | CloneFlags::CLONE_SIGHAND
+            | CloneFlags::CLONE_VFORK
             | CloneFlags::CLONE_THREAD
             | CloneFlags::CLONE_SYSVSEM
             | CloneFlags::CLONE_SETTLS

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -22,6 +22,12 @@ pub(super) fn exit_process(thread_local: &ThreadLocal, current_process: &Process
     move_children_to_init(current_process);
 
     send_child_death_signal(current_process);
+
+    let _val = current_process
+        .vfork_done()
+        .lock()
+        .as_ref()
+        .is_some_and(|x| x.wake_up());
 }
 
 /// Sends parent-death signals to the children.

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -26,7 +26,7 @@ use crate::syscall::{
     fallocate::sys_fallocate,
     fcntl::sys_fcntl,
     flock::sys_flock,
-    fork::sys_fork,
+    fork::{sys_fork, sys_vfork},
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
     getcwd::sys_getcwd,
@@ -190,6 +190,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETSOCKOPT = 55        => sys_getsockopt(args[..5]);
     SYS_CLONE = 56             => sys_clone(args[..5], &user_ctx);
     SYS_FORK = 57              => sys_fork(args[..0], &user_ctx);
+    SYS_VFORK = 58             => sys_vfork(args[..0], &user_ctx);
     SYS_EXECVE = 59            => sys_execve(args[..3], &mut user_ctx);
     SYS_EXIT = 60              => sys_exit(args[..1]);
     SYS_WAIT4 = 61             => sys_wait4(args[..4]);

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -153,6 +153,15 @@ fn do_execve(
     // set new user stack top
     user_context.set_stack_pointer(elf_load_info.user_stack_top() as _);
     debug!("user stack top: 0x{:x}", elf_load_info.user_stack_top());
+
+    {
+        let _val = process
+            .vfork_done()
+            .lock()
+            .as_ref()
+            .is_some_and(|x| x.wake_up());
+    }
+    
     Ok(())
 }
 

--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -13,3 +13,9 @@ pub fn sys_fork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallRe
     let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
     Ok(SyscallReturn::Return(child_pid as _))
 }
+
+pub fn sys_vfork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
+    let clone_args = CloneArgs::for_vfork();
+    let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
+    Ok(SyscallReturn::Return(child_pid as _))
+}

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -54,6 +54,7 @@ TESTS ?= \
 	unlink_test \
 	utimes_test \
 	vdso_clock_gettime_test \
+	vfork_test \
 	write_test \
 	fallocate_test \
 	# The end of the list


### PR DESCRIPTION
Just a reopening of #1644 , having rebased the branch and cleared the commit history, sorry for the bothering. I am working on the rest part of the implementation.

This is a following up work of #1485 and #1429 ,to implement `vfork` syscall and support `init` process. The implementation of `vfork` syscall is primary for now. According to #1485 , the implementation should be divided into the following four steps.

- [x] flag handling
- [ ] parent process blocking
- [ ] memory management
- [ ] testing

At present, this PR deals with flag handling. It should be noticed that logically the flag for vfork syscall should contain CloneFlags::CLONE_VM, but the it is related to the following steps. Therefore, the change has not been applied.
Now the implementation simply uses `fork` as dummy(behaves the same as `fork`). It does not behaves strictly as the Linux `vfork`, since it does not block parent process and deals with the memory management problem. After the `vfork`, the parent process should be blocked until the child process calls `exec` or `_exit`. And the child process should carefully manage the memory space, since it shares the memory space with the parent process.

The following can be a reference.
[https://github.com/shadow/shadow/pull/3178](url)
