### PR TITLE
Reduce the held time of scheduling policy lock

### DIFF
--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -6,7 +6,7 @@ use super::*;
 ///
 /// This run queue is used for the per-cpu idle entity, if any.
 pub(super) struct IdleClassRq {
-    entity: Option<SchedEntity>,
+    entity: Option<Arc<Task>>,
 }
 
 impl IdleClassRq {
@@ -27,10 +27,10 @@ impl core::fmt::Debug for IdleClassRq {
 }
 
 impl SchedClassRq for IdleClassRq {
-    fn enqueue(&mut self, entity: SchedEntity, _: Option<EnqueueFlags>) {
-        let ptr = Arc::as_ptr(&entity.0);
+    fn enqueue(&mut self, entity: Arc<Task>, _: Option<EnqueueFlags>) {
+        let ptr = Arc::as_ptr(&entity);
         if let Some(t) = self.entity.replace(entity)
-            && ptr != Arc::as_ptr(&t.0)
+            && ptr != Arc::as_ptr(&t)
         {
             panic!("Multiple `idle` entities spawned")
         }
@@ -44,7 +44,7 @@ impl SchedClassRq for IdleClassRq {
         self.entity.is_none()
     }
 
-    fn pick_next(&mut self) -> Option<SchedEntity> {
+    fn pick_next(&mut self) -> Option<Arc<Task>> {
         self.entity.clone()
     }
 

--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -4,20 +4,20 @@ use super::*;
 
 /// The per-cpu run queue for the IDLE scheduling class.
 ///
-/// This run queue is used for the per-cpu idle thread, if any.
+/// This run queue is used for the per-cpu idle entity, if any.
 pub(super) struct IdleClassRq {
-    thread: Option<Arc<Thread>>,
+    entity: Option<SchedEntity>,
 }
 
 impl IdleClassRq {
     pub fn new() -> Self {
-        Self { thread: None }
+        Self { entity: None }
     }
 }
 
 impl core::fmt::Debug for IdleClassRq {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.thread.is_some() {
+        if self.entity.is_some() {
             write!(f, "Idle: occupied")?;
         } else {
             write!(f, "Idle: empty")?;
@@ -27,12 +27,12 @@ impl core::fmt::Debug for IdleClassRq {
 }
 
 impl SchedClassRq for IdleClassRq {
-    fn enqueue(&mut self, thread: Arc<Thread>, _: Option<EnqueueFlags>) {
-        let ptr = Arc::as_ptr(&thread);
-        if let Some(t) = self.thread.replace(thread)
-            && ptr != Arc::as_ptr(&t)
+    fn enqueue(&mut self, entity: SchedEntity, _: Option<EnqueueFlags>) {
+        let ptr = Arc::as_ptr(&entity.0);
+        if let Some(t) = self.entity.replace(entity)
+            && ptr != Arc::as_ptr(&t.0)
         {
-            panic!("Multiple `idle` threads spawned")
+            panic!("Multiple `idle` entities spawned")
         }
     }
 
@@ -41,15 +41,15 @@ impl SchedClassRq for IdleClassRq {
     }
 
     fn is_empty(&mut self) -> bool {
-        self.thread.is_none()
+        self.entity.is_none()
     }
 
-    fn pick_next(&mut self) -> Option<Arc<Thread>> {
-        self.thread.clone()
+    fn pick_next(&mut self) -> Option<SchedEntity> {
+        self.entity.clone()
     }
 
     fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {
-        // Idle threads has the greatest priority value. They should always be preempted.
+        // Idle entities has the greatest priority value. They should always be preempted.
         true
     }
 }

--- a/kernel/src/sched/sched_class/policy.rs
+++ b/kernel/src/sched/sched_class/policy.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZero;
+
+use super::real_time::RealTimePolicy;
+use crate::sched::priority::{Nice, NiceRange, Priority, RangedU8};
+
+/// The User-chosen scheduling policy.
+///
+/// The scheduling policies are specified by the user, usually through its priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SchedPolicy {
+    Stop,
+    RealTime {
+        rt_prio: super::real_time::RtPrio,
+        rt_policy: RealTimePolicy,
+    },
+    Fair(Nice),
+    Idle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum SchedPolicyKind {
+    Stop,
+    RealTime,
+    Fair,
+    Idle,
+}
+
+impl From<Priority> for SchedPolicy {
+    fn from(priority: Priority) -> Self {
+        match priority.range().get() {
+            0 => SchedPolicy::Stop,
+            rt @ 1..=99 => SchedPolicy::RealTime {
+                rt_prio: RangedU8::new(rt),
+                rt_policy: Default::default(),
+            },
+            100..=139 => SchedPolicy::Fair(priority.into()),
+            _ => SchedPolicy::Idle,
+        }
+    }
+}
+
+const TYPE_MASK: u64 = 0x0000_0000_0000_ffff;
+const TYPE_SHIFT: u32 = 0;
+
+const TYPE_STOP: u64 = 0;
+const TYPE_REAL_TIME: u64 = 1;
+const TYPE_FAIR: u64 = 2;
+const TYPE_IDLE: u64 = 3;
+
+const SUBTYPE_MASK: u64 = 0x0000_0000_00ff_0000;
+const SUBTYPE_SHIFT: u32 = 16;
+
+const RT_PRIO_MASK: u64 = SUBTYPE_MASK;
+const RT_PRIO_SHIFT: u32 = SUBTYPE_SHIFT;
+
+const FAIR_NICE_MASK: u64 = SUBTYPE_MASK;
+const FAIR_NICE_SHIFT: u32 = SUBTYPE_SHIFT;
+
+const RT_TYPE_MASK: u64 = 0x0000_0000_ff00_0000;
+const RT_TYPE_SHIFT: u32 = 24;
+
+const RT_TYPE_FIFO: u64 = 0;
+const RT_TYPE_RR: u64 = 1;
+
+const RT_FACTOR_MASK: u64 = 0xffff_ffff_0000_0000;
+const RT_FACTOR_SHIFT: u32 = 32;
+
+fn get(raw: u64, mask: u64, shift: u32) -> u64 {
+    (raw & mask) >> shift
+}
+
+fn set(value: u64, mask: u64, shift: u32) -> u64 {
+    (value << shift) & mask
+}
+
+impl SchedPolicy {
+    pub(super) fn from_raw(raw: u64) -> Self {
+        match get(raw, TYPE_MASK, TYPE_SHIFT) {
+            TYPE_STOP => SchedPolicy::Stop,
+            TYPE_REAL_TIME => SchedPolicy::RealTime {
+                rt_prio: RangedU8::new(get(raw, RT_PRIO_MASK, RT_PRIO_SHIFT) as u8),
+                rt_policy: match get(raw, RT_TYPE_MASK, RT_TYPE_SHIFT) {
+                    RT_TYPE_FIFO => RealTimePolicy::Fifo,
+                    RT_TYPE_RR => RealTimePolicy::RoundRobin {
+                        base_slice_factor: NonZero::new(
+                            get(raw, RT_FACTOR_MASK, RT_FACTOR_SHIFT) as u32
+                        ),
+                    },
+                    _ => unreachable!(),
+                },
+            },
+            TYPE_FAIR => {
+                SchedPolicy::Fair(Nice::new(NiceRange::new(
+                    get(raw, FAIR_NICE_MASK, FAIR_NICE_SHIFT) as i8,
+                )))
+            }
+            TYPE_IDLE => SchedPolicy::Idle,
+            _ => unreachable!(),
+        }
+    }
+
+    pub(super) fn into_raw(this: Self) -> u64 {
+        match this {
+            SchedPolicy::Stop => set(TYPE_STOP, TYPE_MASK, TYPE_SHIFT),
+            SchedPolicy::RealTime { rt_prio, rt_policy } => {
+                let ty = set(TYPE_REAL_TIME, TYPE_MASK, TYPE_SHIFT);
+                let rt_prio = set(rt_prio.get() as u64, RT_PRIO_MASK, RT_PRIO_SHIFT);
+                let rt_policy = match rt_policy {
+                    RealTimePolicy::Fifo => set(RT_TYPE_FIFO, RT_TYPE_MASK, RT_TYPE_SHIFT),
+                    RealTimePolicy::RoundRobin { base_slice_factor } => {
+                        let rt_type = set(RT_TYPE_RR, RT_TYPE_MASK, RT_TYPE_SHIFT);
+                        let rt_factor = set(
+                            base_slice_factor.map_or(0, NonZero::get) as u64,
+                            RT_FACTOR_MASK,
+                            RT_FACTOR_SHIFT,
+                        );
+                        rt_type | rt_factor
+                    }
+                };
+                ty | rt_prio | rt_policy
+            }
+            SchedPolicy::Fair(nice) => {
+                let ty = set(TYPE_FAIR, TYPE_MASK, TYPE_SHIFT);
+                let nice = set(nice.range().get() as u64, FAIR_NICE_MASK, FAIR_NICE_SHIFT);
+                ty | nice
+            }
+            SchedPolicy::Idle => set(TYPE_IDLE, TYPE_MASK, TYPE_SHIFT),
+        }
+    }
+}
+
+impl SchedPolicyKind {
+    pub fn from_raw(raw: u64) -> Self {
+        match get(raw, TYPE_MASK, TYPE_SHIFT) {
+            TYPE_STOP => SchedPolicyKind::Stop,
+            TYPE_REAL_TIME => SchedPolicyKind::RealTime,
+            TYPE_FAIR => SchedPolicyKind::Fair,
+            TYPE_IDLE => SchedPolicyKind::Idle,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/kernel/src/sched/sched_class/policy.rs
+++ b/kernel/src/sched/sched_class/policy.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::num::NonZero;
+use core::sync::atomic::{AtomicU8, Ordering::Relaxed};
 
-use super::real_time::RealTimePolicy;
-use crate::sched::priority::{Nice, NiceRange, Priority, RangedU8};
+use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
+use int_to_c_enum::TryFromInt;
+use ostd::sync::SpinLock;
+
+pub use super::real_time::RealTimePolicy;
+use crate::sched::priority::{Nice, Priority, RangedU8};
 
 /// The User-chosen scheduling policy.
 ///
@@ -19,12 +23,13 @@ pub enum SchedPolicy {
     Idle,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, TryFromInt)]
+#[repr(u8)]
 pub(super) enum SchedPolicyKind {
-    Stop,
-    RealTime,
-    Fair,
-    Idle,
+    Stop = 0,
+    RealTime = 1,
+    Fair = 2,
+    Idle = 3,
 }
 
 impl From<Priority> for SchedPolicy {
@@ -41,104 +46,73 @@ impl From<Priority> for SchedPolicy {
     }
 }
 
-const TYPE_MASK: u64 = 0x0000_0000_0000_ffff;
-const TYPE_SHIFT: u32 = 0;
-
-const TYPE_STOP: u64 = 0;
-const TYPE_REAL_TIME: u64 = 1;
-const TYPE_FAIR: u64 = 2;
-const TYPE_IDLE: u64 = 3;
-
-const SUBTYPE_MASK: u64 = 0x0000_0000_00ff_0000;
-const SUBTYPE_SHIFT: u32 = 16;
-
-const RT_PRIO_MASK: u64 = SUBTYPE_MASK;
-const RT_PRIO_SHIFT: u32 = SUBTYPE_SHIFT;
-
-const FAIR_NICE_MASK: u64 = SUBTYPE_MASK;
-const FAIR_NICE_SHIFT: u32 = SUBTYPE_SHIFT;
-
-const RT_TYPE_MASK: u64 = 0x0000_0000_ff00_0000;
-const RT_TYPE_SHIFT: u32 = 24;
-
-const RT_TYPE_FIFO: u64 = 0;
-const RT_TYPE_RR: u64 = 1;
-
-const RT_FACTOR_MASK: u64 = 0xffff_ffff_0000_0000;
-const RT_FACTOR_SHIFT: u32 = 32;
-
-fn get(raw: u64, mask: u64, shift: u32) -> u64 {
-    (raw & mask) >> shift
-}
-
-fn set(value: u64, mask: u64, shift: u32) -> u64 {
-    (value << shift) & mask
-}
-
 impl SchedPolicy {
-    pub(super) fn from_raw(raw: u64) -> Self {
-        match get(raw, TYPE_MASK, TYPE_SHIFT) {
-            TYPE_STOP => SchedPolicy::Stop,
-            TYPE_REAL_TIME => SchedPolicy::RealTime {
-                rt_prio: RangedU8::new(get(raw, RT_PRIO_MASK, RT_PRIO_SHIFT) as u8),
-                rt_policy: match get(raw, RT_TYPE_MASK, RT_TYPE_SHIFT) {
-                    RT_TYPE_FIFO => RealTimePolicy::Fifo,
-                    RT_TYPE_RR => RealTimePolicy::RoundRobin {
-                        base_slice_factor: NonZero::new(
-                            get(raw, RT_FACTOR_MASK, RT_FACTOR_SHIFT) as u32
-                        ),
-                    },
-                    _ => unreachable!(),
-                },
-            },
-            TYPE_FAIR => {
-                SchedPolicy::Fair(Nice::new(NiceRange::new(
-                    get(raw, FAIR_NICE_MASK, FAIR_NICE_SHIFT) as i8,
-                )))
-            }
-            TYPE_IDLE => SchedPolicy::Idle,
-            _ => unreachable!(),
-        }
-    }
-
-    pub(super) fn into_raw(this: Self) -> u64 {
-        match this {
-            SchedPolicy::Stop => set(TYPE_STOP, TYPE_MASK, TYPE_SHIFT),
-            SchedPolicy::RealTime { rt_prio, rt_policy } => {
-                let ty = set(TYPE_REAL_TIME, TYPE_MASK, TYPE_SHIFT);
-                let rt_prio = set(rt_prio.get() as u64, RT_PRIO_MASK, RT_PRIO_SHIFT);
-                let rt_policy = match rt_policy {
-                    RealTimePolicy::Fifo => set(RT_TYPE_FIFO, RT_TYPE_MASK, RT_TYPE_SHIFT),
-                    RealTimePolicy::RoundRobin { base_slice_factor } => {
-                        let rt_type = set(RT_TYPE_RR, RT_TYPE_MASK, RT_TYPE_SHIFT);
-                        let rt_factor = set(
-                            base_slice_factor.map_or(0, NonZero::get) as u64,
-                            RT_FACTOR_MASK,
-                            RT_FACTOR_SHIFT,
-                        );
-                        rt_type | rt_factor
-                    }
-                };
-                ty | rt_prio | rt_policy
-            }
-            SchedPolicy::Fair(nice) => {
-                let ty = set(TYPE_FAIR, TYPE_MASK, TYPE_SHIFT);
-                let nice = set(nice.range().get() as u64, FAIR_NICE_MASK, FAIR_NICE_SHIFT);
-                ty | nice
-            }
-            SchedPolicy::Idle => set(TYPE_IDLE, TYPE_MASK, TYPE_SHIFT),
+    pub(super) fn kind(&self) -> SchedPolicyKind {
+        match self {
+            SchedPolicy::Stop => SchedPolicyKind::Stop,
+            SchedPolicy::RealTime { .. } => SchedPolicyKind::RealTime,
+            SchedPolicy::Fair(_) => SchedPolicyKind::Fair,
+            SchedPolicy::Idle => SchedPolicyKind::Idle,
         }
     }
 }
 
-impl SchedPolicyKind {
-    pub fn from_raw(raw: u64) -> Self {
-        match get(raw, TYPE_MASK, TYPE_SHIFT) {
-            TYPE_STOP => SchedPolicyKind::Stop,
-            TYPE_REAL_TIME => SchedPolicyKind::RealTime,
-            TYPE_FAIR => SchedPolicyKind::Fair,
-            TYPE_IDLE => SchedPolicyKind::Idle,
-            _ => unreachable!(),
+define_atomic_version_of_integer_like_type!(SchedPolicyKind, try_from = true, {
+    #[derive(Debug)]
+    pub struct AtomicSchedPolicyKind(AtomicU8);
+});
+
+impl From<SchedPolicyKind> for u8 {
+    fn from(value: SchedPolicyKind) -> Self {
+        value as _
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SchedPolicyState {
+    kind: AtomicSchedPolicyKind,
+    policy: SpinLock<SchedPolicy>,
+}
+
+impl SchedPolicyState {
+    pub fn new(policy: SchedPolicy) -> Self {
+        Self {
+            kind: AtomicSchedPolicyKind::new(policy.kind()),
+            policy: SpinLock::new(policy),
         }
+    }
+
+    pub fn kind(&self) -> SchedPolicyKind {
+        self.kind.load(Relaxed)
+    }
+
+    pub fn get(&self) -> SchedPolicy {
+        *self.policy.disable_irq().lock()
+    }
+
+    pub fn set(&self, mut policy: SchedPolicy, update: impl FnOnce(SchedPolicy)) {
+        let mut this = self.policy.disable_irq().lock();
+
+        // Keep the old base slice factor if the new policy doesn't specify one.
+        if let (
+            SchedPolicy::RealTime {
+                rt_policy:
+                    RealTimePolicy::RoundRobin {
+                        base_slice_factor: slot,
+                    },
+                ..
+            },
+            SchedPolicy::RealTime {
+                rt_policy: RealTimePolicy::RoundRobin { base_slice_factor },
+                ..
+            },
+        ) = (*this, &mut policy)
+        {
+            *base_slice_factor = slot.or(*base_slice_factor);
+        }
+
+        update(policy);
+        self.kind.store(policy.kind(), Relaxed);
+        *this = policy;
     }
 }

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::sync::atomic::AtomicBool;
+
 use super::*;
 
 /// The per-cpu run queue for the STOP scheduling class.
@@ -32,6 +34,7 @@ impl SchedClassRq for StopClassRq {
         if self.thread.replace(thread).is_some() {
             panic!("Multiple `stop` threads spawned")
         }
+        self.has_value.store(true, Relaxed);
     }
 
     fn len(&mut self) -> usize {

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::AtomicBool;
-
 use super::*;
 
 /// The per-cpu run queue for the STOP scheduling class.
@@ -9,7 +7,7 @@ use super::*;
 /// This is a singleton class, meaning that only one thread can be in this class at a time.
 /// This is used for the most critical tasks, such as powering off and rebooting.
 pub(super) struct StopClassRq {
-    thread: Option<Arc<Thread>>,
+    thread: Option<Arc<Task>>,
 }
 
 impl StopClassRq {
@@ -30,11 +28,10 @@ impl core::fmt::Debug for StopClassRq {
 }
 
 impl SchedClassRq for StopClassRq {
-    fn enqueue(&mut self, thread: Arc<Thread>, _: Option<EnqueueFlags>) {
+    fn enqueue(&mut self, thread: Arc<Task>, _: Option<EnqueueFlags>) {
         if self.thread.replace(thread).is_some() {
             panic!("Multiple `stop` threads spawned")
         }
-        self.has_value.store(true, Relaxed);
     }
 
     fn len(&mut self) -> usize {
@@ -45,7 +42,7 @@ impl SchedClassRq for StopClassRq {
         self.thread.is_none()
     }
 
-    fn pick_next(&mut self) -> Option<Arc<Thread>> {
+    fn pick_next(&mut self) -> Option<Arc<Task>> {
         self.thread.take()
     }
 


### PR DESCRIPTION
The current scheduling class implementation holds the lock of the thread-wise scheduling policy for the whole time of updating and enqueuing threads, which takes up most of the elapsed time and causes severe performance regression regarding context switching.

This PR fixes this by releasing the lock before executing the updating/enqueuing process.

# Potential Drawbacks

The policy might be changed by the user when the scheduling data is updated/enqueued, resulting in the lag of the thread migration between different run queues and the potential logical (not concerning memory safety) data races.