### PR TITLE
Set socket options to underlying sockets

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -2,13 +2,15 @@
 
 mod bound;
 mod event;
+mod option;
 mod state;
 mod unbound;
 
 pub use bound::{BoundTcpSocket, BoundUdpSocket, ConnectState, NeedIfacePoll};
 pub(crate) use bound::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult};
 pub use event::{SocketEventObserver, SocketEvents};
-pub use state::TcpStateCheck;
+pub use option::RawTcpSetOption;
+pub use state::{TcpState, TcpStateCheck};
 pub use unbound::{
     UnboundTcpSocket, UnboundUdpSocket, TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN,
     UDP_SEND_PAYLOAD_LEN,

--- a/kernel/libs/aster-bigtcp/src/socket/option.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/option.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use smoltcp::time::Duration;
+
+use super::NeedIfacePoll;
+
+/// A trait defines setting socket options on a raw socket.
+///
+/// TODO: When `UnboundSocket` is removed, all methods in this trait can accept
+/// `&self` instead of `&mut self` as parameter.
+pub trait RawTcpSetOption {
+    /// Sets the keep alive interval.
+    ///
+    /// Polling the iface _may_ be required after this method succeeds.
+    fn set_keep_alive(&mut self, interval: Option<Duration>) -> NeedIfacePoll;
+
+    /// Enables or disables Nagle’s Algorithm.
+    ///
+    /// Polling the iface is not required after this method succeeds.
+    fn set_nagle_enabled(&mut self, enabled: bool);
+}

--- a/kernel/libs/aster-bigtcp/src/socket/state.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/state.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use smoltcp::socket::tcp::State as TcpState;
+pub use smoltcp::socket::tcp::State as TcpState;
 
 use super::RawTcpSocket;
 

--- a/kernel/libs/aster-bigtcp/src/socket/unbound.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/unbound.rs
@@ -2,7 +2,7 @@
 
 use alloc::{boxed::Box, vec};
 
-use super::{RawTcpSocket, RawUdpSocket};
+use super::{option::RawTcpSetOption, NeedIfacePoll, RawTcpSocket, RawUdpSocket};
 
 pub struct UnboundSocket<T> {
     socket: Box<T>,
@@ -27,6 +27,17 @@ impl UnboundTcpSocket {
 impl Default for UnboundTcpSocket {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl RawTcpSetOption for UnboundTcpSocket {
+    fn set_keep_alive(&mut self, interval: Option<smoltcp::time::Duration>) -> NeedIfacePoll {
+        self.socket.set_keep_alive(interval);
+        NeedIfacePoll::FALSE
+    }
+
+    fn set_nagle_enabled(&mut self, enabled: bool) {
+        self.socket.set_nagle_enabled(enabled);
     }
 }
 

--- a/kernel/libs/aster-bigtcp/src/time.rs
+++ b/kernel/libs/aster-bigtcp/src/time.rs
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub use smoltcp::time::Instant;
+pub use smoltcp::time::{Duration, Instant};

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_bigtcp::{
     errors::tcp::{RecvError, SendError},
-    socket::{NeedIfacePoll, TcpStateCheck},
+    socket::{NeedIfacePoll, RawTcpSetOption, RawTcpSocket, TcpStateCheck},
     wire::IpEndpoint,
 };
 
@@ -204,5 +204,16 @@ impl ConnectedStream {
 
     pub(super) fn set_observer(&self, observer: StreamObserver) {
         self.bound_socket.set_observer(observer)
+    }
+
+    pub(super) fn set_raw_option<R>(
+        &mut self,
+        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
+    ) -> R {
+        set_option(&mut self.bound_socket)
+    }
+
+    pub(super) fn raw_with<R>(&self, f: impl FnOnce(&RawTcpSocket) -> R) -> R {
+        self.bound_socket.raw_with(f)
     }
 }

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_bigtcp::{socket::ConnectState, wire::IpEndpoint};
+use aster_bigtcp::{
+    socket::{ConnectState, RawTcpSetOption},
+    wire::IpEndpoint,
+};
 
 use super::{connected::ConnectedStream, init::InitStream};
 use crate::{
@@ -82,5 +85,12 @@ impl ConnectingStream {
 
     pub(super) fn check_io_events(&self) -> IoEvents {
         IoEvents::empty()
+    }
+
+    pub(super) fn set_raw_option<R>(
+        &mut self,
+        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
+    ) -> R {
+        set_option(&mut self.bound_socket)
     }
 }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_bigtcp::{socket::UnboundTcpSocket, wire::IpEndpoint};
+use aster_bigtcp::{
+    socket::{RawTcpSetOption, UnboundTcpSocket},
+    wire::IpEndpoint,
+};
 
 use super::{connecting::ConnectingStream, listen::ListenStream, StreamObserver};
 use crate::{
@@ -107,5 +110,15 @@ impl InitStream {
     pub(super) fn check_io_events(&self) -> IoEvents {
         // Linux adds OUT and HUP events for a newly created socket
         IoEvents::OUT | IoEvents::HUP
+    }
+
+    pub(super) fn set_raw_option<R>(
+        &mut self,
+        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
+    ) -> R {
+        match self {
+            InitStream::Unbound(unbound_socket) => set_option(unbound_socket.as_mut()),
+            InitStream::Bound(bound_socket) => set_option(bound_socket),
+        }
     }
 }

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -2,7 +2,10 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use aster_bigtcp::wire::IpEndpoint;
+use aster_bigtcp::{
+    socket::{NeedIfacePoll, RawTcpSetOption},
+    wire::IpEndpoint,
+};
 use connected::ConnectedStream;
 use connecting::{ConnResult, ConnectingStream};
 use init::InitStream;
@@ -20,13 +23,19 @@ use crate::{
         utils::{InodeMode, Metadata, StatusFlags},
     },
     match_sock_option_mut, match_sock_option_ref,
-    net::socket::{
-        options::{Error as SocketError, SocketOption},
-        util::{
-            options::SocketOptionSet, send_recv_flags::SendRecvFlags,
-            shutdown_cmd::SockShutdownCmd, socket_addr::SocketAddr, MessageHeader,
+    net::{
+        iface::Iface,
+        socket::{
+            options::{Error as SocketError, SocketOption},
+            util::{
+                options::{SetSocketLevelOption, SocketOptionSet},
+                send_recv_flags::SendRecvFlags,
+                shutdown_cmd::SockShutdownCmd,
+                socket_addr::SocketAddr,
+                MessageHeader,
+            },
+            Socket,
         },
-        Socket,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -87,11 +96,28 @@ impl StreamSocket {
         })
     }
 
-    fn new_connected(connected_stream: ConnectedStream) -> Arc<Self> {
+    fn new_accepted(connected_stream: ConnectedStream) -> Arc<Self> {
+        let options = connected_stream.raw_with(|raw_tcp_socket| {
+            let mut options = OptionSet::new();
+
+            if raw_tcp_socket.keep_alive().is_some() {
+                options.socket.set_keep_alive(true);
+            }
+
+            if !raw_tcp_socket.nagle_enabled() {
+                options.tcp.set_no_delay(true);
+            }
+
+            // TODO: Update other options for a newly-accepted socket
+
+            options
+        });
+
         let pollee = Pollee::new();
         connected_stream.set_observer(StreamObserver::new(pollee.clone()));
+
         Arc::new(Self {
-            options: RwLock::new(OptionSet::new()),
+            options: RwLock::new(options),
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             is_nonblocking: AtomicBool::new(false),
             pollee,
@@ -276,7 +302,7 @@ impl StreamSocket {
             .try_accept(&self.pollee)
             .map(|connected_stream| {
                 let remote_endpoint = connected_stream.remote_endpoint();
-                let accepted_socket = Self::new_connected(connected_stream);
+                let accepted_socket = Self::new_accepted(connected_stream);
                 (accepted_socket as _, remote_endpoint.into())
             });
         let iface_to_poll = listen_stream.iface().clone();
@@ -650,11 +676,23 @@ impl Socket for StreamSocket {
     }
 
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
-        let mut options = self.options.write();
+        let (mut options, mut state) = self.update_connecting();
 
-        match options.socket.set_option(option) {
+        match options.socket.set_option(option, state.as_mut()) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
-            res => return res,
+            Err(err) => return Err(err),
+            Ok(need_iface_poll) => {
+                let iface_to_poll = need_iface_poll.then(|| state.iface().cloned()).flatten();
+
+                drop(state);
+                drop(options);
+
+                if let Some(iface) = iface_to_poll {
+                    iface.poll();
+                }
+
+                return Ok(());
+            }
         }
 
         // FIXME: Here we have only set the value of the option, without actually
@@ -663,6 +701,7 @@ impl Socket for StreamSocket {
             tcp_no_delay: NoDelay => {
                 let no_delay = tcp_no_delay.get().unwrap();
                 options.tcp.set_no_delay(*no_delay);
+                state.set_raw_option(|raw_socket: &mut dyn RawTcpSetOption| raw_socket.set_nagle_enabled(!no_delay));
             },
             tcp_congestion: Congestion => {
                 let congestion = tcp_congestion.get().unwrap();
@@ -694,18 +733,62 @@ impl Socket for StreamSocket {
     }
 }
 
+impl State {
+    /// Calls `f` to set raw socket option.
+    ///
+    /// Note that for listening socket, `f` is called on all backlog sockets in `Listen` State.
+    /// That is to say, `f` won't be called on backlog sockets in `SynReceived` or `Established` state.
+    fn set_raw_option<R>(&mut self, set_option: impl Fn(&mut dyn RawTcpSetOption) -> R) -> R {
+        match self {
+            State::Init(init_stream) => init_stream.set_raw_option(set_option),
+            State::Connecting(connecting_stream) => connecting_stream.set_raw_option(set_option),
+            State::Connected(connected_stream) => connected_stream.set_raw_option(set_option),
+            State::Listen(listen_stream) => listen_stream.set_raw_option(set_option),
+        }
+    }
+
+    fn iface(&self) -> Option<&Arc<Iface>> {
+        match self {
+            State::Init(_) => None,
+            State::Connecting(ref connecting_stream) => Some(connecting_stream.iface()),
+            State::Connected(ref connected_stream) => Some(connected_stream.iface()),
+            State::Listen(ref listen_stream) => Some(listen_stream.iface()),
+        }
+    }
+}
+
+impl SetSocketLevelOption for State {
+    fn set_keep_alive(&mut self, keep_alive: bool) -> NeedIfacePoll {
+        /// The keepalive interval.
+        ///
+        /// The linux value can be found at `/proc/sys/net/ipv4/tcp_keepalive_intvl`,
+        /// which is by default 75 seconds for most Linux distributions.
+        const KEEPALIVE_INTERVAL: aster_bigtcp::time::Duration =
+            aster_bigtcp::time::Duration::from_secs(75);
+
+        let interval = if keep_alive {
+            Some(KEEPALIVE_INTERVAL)
+        } else {
+            None
+        };
+
+        let set_keepalive =
+            |raw_socket: &mut dyn RawTcpSetOption| raw_socket.set_keep_alive(interval);
+
+        self.set_raw_option(set_keepalive)
+    }
+}
+
 impl Drop for StreamSocket {
     fn drop(&mut self) {
         let state = self.state.write().take();
 
-        let iface_to_poll = match state {
-            State::Init(_) => None,
-            State::Connecting(ref connecting_stream) => Some(connecting_stream.iface().clone()),
-            State::Connected(ref connected_stream) => Some(connected_stream.iface().clone()),
-            State::Listen(ref listen_stream) => Some(listen_stream.iface().clone()),
-        };
+        let iface_to_poll = state.iface().cloned();
 
+        // Dropping the state will drop the sockets. This will trigger the socket close process (if
+        // needed) and require immediate iface polling afterwards.
         drop(state);
+
         if let Some(iface) = iface_to_poll {
             iface.poll();
         }

--- a/test/apps/network/sockoption.c
+++ b/test/apps/network/sockoption.c
@@ -6,22 +6,58 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
+#include <arpa/inet.h>
 #include "test.h"
 
-int sockfd;
-int option;
+int sk_unbound;
+int sk_listen;
+int sk_connected;
+int sk_accepted;
+
+struct sockaddr_in listen_addr;
+#define LISTEN_PORT htons(0x1242)
 
 FN_SETUP(general)
 {
-	sockfd = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	sk_unbound = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+
+	listen_addr.sin_family = AF_INET;
+	listen_addr.sin_port = LISTEN_PORT;
+	CHECK(inet_aton("127.0.0.1", &listen_addr.sin_addr));
+
+	sk_listen = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	CHECK(bind(sk_listen, (struct sockaddr *)&listen_addr,
+		   sizeof(listen_addr)));
+	CHECK(listen(sk_listen, 3));
+
+	sk_connected = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	CHECK(connect(sk_connected, (struct sockaddr *)&listen_addr,
+		      sizeof(listen_addr)));
+
+	sk_accepted = CHECK(accept(sk_listen, NULL, NULL));
 }
 END_SETUP()
+
+int refresh_connection()
+{
+	close(sk_connected);
+	close(sk_accepted);
+
+	sk_connected = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	CHECK(connect(sk_connected, (struct sockaddr *)&listen_addr,
+		      sizeof(listen_addr)));
+
+	sk_accepted = CHECK(accept(sk_listen, NULL, NULL));
+
+	return 0;
+}
 
 FN_TEST(buffer_size)
 {
 	int sendbuf;
 	socklen_t sendbuf_len = sizeof(sendbuf);
-	TEST_RES(getsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, &sendbuf,
+
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_SNDBUF, &sendbuf,
 			    &sendbuf_len),
 		 sendbuf_len == sizeof(sendbuf));
 }
@@ -31,39 +67,166 @@ FN_TEST(socket_error)
 {
 	int error;
 	socklen_t error_len = sizeof(error);
-	TEST_RES(getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &error, &error_len),
+
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_ERROR, &error,
+			    &error_len),
 		 error_len == sizeof(error) && error == 0);
 }
 END_TEST()
 
 FN_TEST(nagle)
 {
-	// Disable Nagle algorithm
-	option = 1;
-	CHECK(setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &option,
-			 sizeof(option)));
-
-	// Get new value
+	int option = 1;
 	int nagle;
 	socklen_t nagle_len = sizeof(nagle);
-	TEST_RES(getsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nagle,
+
+	// 1. Check default values
+	refresh_connection();
+	TEST_RES(getsockopt(sk_connected, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 0);
+	TEST_RES(getsockopt(sk_accepted, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 0);
+
+	// 2. Disable Nagle algorithm on unbound socket
+	CHECK(setsockopt(sk_unbound, IPPROTO_TCP, TCP_NODELAY, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_unbound, IPPROTO_TCP, TCP_NODELAY, &nagle,
 			    &nagle_len),
 		 nagle == 1);
+
+	// 3. Disable Nagle algorithm on connected socket
+	CHECK(setsockopt(sk_connected, IPPROTO_TCP, TCP_NODELAY, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_connected, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 1);
+
+	// 4. Disable Nagle algorithm on listening socket before connection
+	CHECK(setsockopt(sk_listen, IPPROTO_TCP, TCP_NODELAY, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_listen, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 1);
+
+	refresh_connection();
+	TEST_RES(getsockopt(sk_connected, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 0);
+	TEST_RES(getsockopt(sk_accepted, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 1);
+
+	// 5. Disable Nagle algorithm on listening socket after connection
+	option = 0;
+	CHECK(setsockopt(sk_listen, IPPROTO_TCP, TCP_NODELAY, &option,
+			 sizeof(option)));
+
+	close(sk_connected);
+	close(sk_accepted);
+
+	sk_connected = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	CHECK(connect(sk_connected, (struct sockaddr *)&listen_addr,
+		      sizeof(listen_addr)));
+
+	option = 1;
+	CHECK(setsockopt(sk_listen, IPPROTO_TCP, TCP_NODELAY, &option,
+			 sizeof(option)));
+
+	sk_accepted = CHECK(accept(sk_listen, NULL, NULL));
+
+	TEST_RES(getsockopt(sk_connected, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 0);
+	TEST_RES(getsockopt(sk_accepted, IPPROTO_TCP, TCP_NODELAY, &nagle,
+			    &nagle_len),
+		 nagle == 0);
 }
 END_TEST()
 
 FN_TEST(reuseaddr)
 {
-	// Enable reuse address
-	option = 1;
-	CHECK(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &option,
+	int option = 1;
+	CHECK(setsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, &option,
 			 sizeof(option)));
 
-	// Get new value
 	int reuseaddr;
 	socklen_t reuseaddr_len = sizeof(reuseaddr);
-	TEST_RES(getsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
+
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
 			    &reuseaddr_len),
 		 reuseaddr == 1);
+}
+END_TEST()
+
+FN_TEST(keepalive)
+{
+	int option = 1;
+	int keepalive;
+	socklen_t keepalive_len = sizeof(keepalive);
+
+	// 1. Check default values
+	refresh_connection();
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 0);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 0);
+
+	// 2. Enable keepalive on unbound socket
+	CHECK(setsockopt(sk_unbound, SOL_SOCKET, SO_KEEPALIVE, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 1);
+
+	// 3. Enable keepalive on connected socket
+	CHECK(setsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 1);
+
+	// 4. Enable keepalive on listening socket
+	CHECK(setsockopt(sk_listen, SOL_SOCKET, SO_KEEPALIVE, &option,
+			 sizeof(option)));
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 1);
+
+	refresh_connection();
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 0);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 1);
+
+	// 5. Setting keepalive after connection comes
+	option = 0;
+	CHECK(setsockopt(sk_listen, SOL_SOCKET, SO_KEEPALIVE, &option,
+			 sizeof(option)));
+
+	close(sk_connected);
+	close(sk_accepted);
+
+	sk_connected = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	CHECK(connect(sk_connected, (struct sockaddr *)&listen_addr,
+		      sizeof(listen_addr)));
+
+	option = 1;
+	CHECK(setsockopt(sk_listen, SOL_SOCKET, SO_KEEPALIVE, &option,
+			 sizeof(option)));
+
+	sk_accepted = CHECK(accept(sk_listen, NULL, NULL));
+
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 0);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_KEEPALIVE, &keepalive,
+			    &keepalive_len),
+		 keepalive == 0);
 }
 END_TEST()


### PR DESCRIPTION
Previously, socket options did not modify the underlying socket; they merely set the option values. This could lead to misleading results in some benchmarks, such as those for the Apache web server.

This PR introduces actual changes to the underlying sockets. Since smoltcp provides only limited interfaces for setting socket options, a few options can currently be supported. In this PR, the options included are `TCP_NODELAY` and `SO_KEEPALIVE`.

The most complex scenario involves listening sockets; specifically, whether the options set on a listening socket will affect the accepted sockets. 

This PR is a superset of #1582.

More details are available in the code.