### PR TITLE
Add INITRAMFS_SKIP_GZIP option to make initramfs encoding/decoding faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ ifeq ($(ENABLE_KVM), 1)
 CARGO_OSDK_ARGS += --qemu-args="-accel kvm"
 endif
 
+# Skip GZIP to make encoding and decoding of initramfs faster
+ifeq ($(INITRAMFS_SKIP_GZIP),1)
+CARGO_OSDK_INITRAMFS_OPTION := --initramfs=$(realpath test/build/initramfs.cpio)
+CARGO_OSDK_ARGS += $(CARGO_OSDK_INITRAMFS_OPTION)
+endif
+
 # Pass make variables to all subdirectory makes
 export
 
@@ -243,7 +249,7 @@ ktest: initramfs $(CARGO_OSDK)
 	@# Exclude linux-bzimage-setup from ktest since it's hard to be unit tested
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "ostd/libs/linux-bzimage/setup" ] && continue; \
-		(cd $$dir && OVMF=off cargo osdk test) || exit 1; \
+		(cd $$dir && OVMF=off cargo osdk test $(CARGO_OSDK_INITRAMFS_OPTION)) || exit 1; \
 		tail --lines 10 qemu.log | grep -q "^\\[ktest runner\\] All crates tested." \
 			|| (echo "Test failed" && exit 1); \
 	done

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,12 @@ ATOMIC_WGET := $(CUR_DIR)/../tools/atomic_wget.sh
 BUILD_DIR := $(CUR_DIR)/build
 INITRAMFS := $(BUILD_DIR)/initramfs
 INITRAMFS_FILELIST := $(BUILD_DIR)/initramfs.filelist
+INITRAMFS_SKIP_GZIP ?= 0
+ifeq ($(INITRAMFS_SKIP_GZIP),1)
+INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio
+else
 INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio.gz
+endif
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
 INITRAMFS_EMPTY_DIRS := \
@@ -107,7 +112,7 @@ $(INITRAMFS)/usr/local:
 
 .PHONY: $(INITRAMFS)/test
 $(INITRAMFS)/test:
-	@make --no-print-directory -C apps
+	@$(MAKE) --no-print-directory -C apps
 
 $(INITRAMFS)/benchmark: | $(INITRAMFS)/benchmark/bin
 	@cp -rf $(CUR_DIR)/benchmark/* $@
@@ -134,11 +139,11 @@ $(INITRAMFS_EMPTY_DIRS):
 
 .PHONY: $(SYSCALL_TEST_DIR)
 $(SYSCALL_TEST_DIR):
-	@make --no-print-directory -C syscall_test
+	@$(MAKE) --no-print-directory -C syscall_test
 
 .PHONY: $(INITRAMFS_IMAGE)
 $(INITRAMFS_IMAGE): $(INITRAMFS_FILELIST)
-	@if ! cmp -s $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous ; then \
+	@if ! cmp -s $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous || ! test -f $@; then \
 		echo "Generating the initramfs image..."; \
 		cp -f $(INITRAMFS_FILELIST) $(INITRAMFS_FILELIST).previous; \
 		( \
@@ -148,7 +153,12 @@ $(INITRAMFS_IMAGE): $(INITRAMFS_FILELIST)
 			# `$(INITRAMFS)` in the second column. This prunes the first \
 			# column and passes the second column to `cpio`. \
 			cut -d " " -f 2- $(INITRAMFS_FILELIST) | \
-				cpio -o -H newc | gzip \
+				cpio -o -H newc | \
+					if [ "$(INITRAMFS_SKIP_GZIP)" != 1 ]; then \
+						gzip; \
+					else \
+						cat; \
+					fi \
 		) > $@; \
 	fi
 
@@ -175,11 +185,11 @@ build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE)
 
 .PHONY: format
 format:
-	@make --no-print-directory -C apps format
+	@$(MAKE) --no-print-directory -C apps format
 
 .PHONY: check
 check:
-	@make --no-print-directory -C apps check
+	@$(MAKE) --no-print-directory -C apps check
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Usage:

```
# Disable GZIP compression to speed up boot
make INITRAMFS_SKIP_GZIP=1
```

GZIP is (painfully) slower than no compression, but `INITRAMFS_ENCODING=none` is not enabled by default to keep backwards compatibility (#212).

~~Other encodings like `zstd` (both fast and high compression) or `lz4` (super-fast but lower compression) are possible to add but not added due to dependencies issues (they depend on `std` or `libc`).~~

~~This PR depends on the improvements in #1684 and #1685, so it should be rebased on them.~~