### PR TITLE
Use `Pollee` as the socket observer

### DIFF
--- a/kernel/libs/aster-bigtcp/src/ext.rs
+++ b/kernel/libs/aster-bigtcp/src/ext.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::iface::ScheduleNextPoll;
+
+/// Extension to be implemented by users of this crate.
+///
+/// This should be implemented on an empty type that carries no data, since the type will never
+/// actually be instantiated.
+///
+/// The purpose of having this trait is to allow users of this crate to inject multiple types
+/// without the hassle of writing multiple trait bounds, which can be achieved by using the types
+/// associated with this trait.
+pub trait Ext {
+    /// The type for ifaces to schedule the next poll.
+    type ScheduleNextPoll: ScheduleNextPoll;
+}

--- a/kernel/libs/aster-bigtcp/src/ext.rs
+++ b/kernel/libs/aster-bigtcp/src/ext.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::iface::ScheduleNextPoll;
+use crate::{iface::ScheduleNextPoll, socket::SocketEventObserver};
 
 /// Extension to be implemented by users of this crate.
 ///
@@ -13,4 +13,10 @@ use crate::iface::ScheduleNextPoll;
 pub trait Ext {
     /// The type for ifaces to schedule the next poll.
     type ScheduleNextPoll: ScheduleNextPoll;
+
+    /// The type for TCP sockets to observe events.
+    type TcpEventObserver: SocketEventObserver;
+
+    /// The type for UDP sockets to observe events.
+    type UdpEventObserver: SocketEventObserver;
 }

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -11,7 +11,7 @@ use alloc::{
 };
 
 use keyable_arc::KeyableArc;
-use ostd::sync::{LocalIrqDisabled, PreemptDisabled, SpinLock, SpinLockGuard};
+use ostd::sync::{LocalIrqDisabled, SpinLock, SpinLockGuard};
 use smoltcp::{
     iface::{packet::Packet, Context},
     phy::Device,
@@ -36,7 +36,7 @@ use crate::{
 pub struct IfaceCommon<E: Ext> {
     name: String,
     interface: SpinLock<smoltcp::iface::Interface, LocalIrqDisabled>,
-    used_ports: SpinLock<BTreeMap<u16, usize>, PreemptDisabled>,
+    used_ports: SpinLock<BTreeMap<u16, usize>, LocalIrqDisabled>,
     tcp_sockets: SpinLock<BTreeSet<KeyableArc<BoundTcpSocketInner<E>>>, LocalIrqDisabled>,
     udp_sockets: SpinLock<BTreeSet<KeyableArc<BoundUdpSocketInner<E>>>, LocalIrqDisabled>,
     sched_poll: E::ScheduleNextPoll,

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -86,6 +86,7 @@ impl<E: Ext> IfaceCommon<E> {
         &self,
         iface: Arc<dyn Iface<E>>,
         socket: Box<UnboundTcpSocket>,
+        observer: E::TcpEventObserver,
         config: BindPortConfig,
     ) -> core::result::Result<BoundTcpSocket<E>, (BindError, Box<UnboundTcpSocket>)> {
         let port = match self.bind_port(config) {
@@ -93,7 +94,7 @@ impl<E: Ext> IfaceCommon<E> {
             Err(err) => return Err((err, socket)),
         };
 
-        let (raw_socket, observer) = socket.into_raw();
+        let raw_socket = socket.into_raw();
         let bound_socket = BoundTcpSocket::new(iface, port, raw_socket, observer);
 
         let inserted = self
@@ -109,6 +110,7 @@ impl<E: Ext> IfaceCommon<E> {
         &self,
         iface: Arc<dyn Iface<E>>,
         socket: Box<UnboundUdpSocket>,
+        observer: E::UdpEventObserver,
         config: BindPortConfig,
     ) -> core::result::Result<BoundUdpSocket<E>, (BindError, Box<UnboundUdpSocket>)> {
         let port = match self.bind_port(config) {
@@ -116,7 +118,7 @@ impl<E: Ext> IfaceCommon<E> {
             Err(err) => return Err((err, socket)),
         };
 
-        let (raw_socket, observer) = socket.into_raw();
+        let raw_socket = socket.into_raw();
         let bound_socket = BoundUdpSocket::new(iface, port, raw_socket, observer);
 
         let inserted = self

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -37,19 +37,21 @@ impl<E: Ext> dyn Iface<E> {
     pub fn bind_tcp(
         self: &Arc<Self>,
         socket: Box<UnboundTcpSocket>,
+        observer: E::TcpEventObserver,
         config: BindPortConfig,
     ) -> core::result::Result<BoundTcpSocket<E>, (BindError, Box<UnboundTcpSocket>)> {
         let common = self.common();
-        common.bind_tcp(self.clone(), socket, config)
+        common.bind_tcp(self.clone(), socket, observer, config)
     }
 
     pub fn bind_udp(
         self: &Arc<Self>,
         socket: Box<UnboundUdpSocket>,
+        observer: E::UdpEventObserver,
         config: BindPortConfig,
     ) -> core::result::Result<BoundUdpSocket<E>, (BindError, Box<UnboundUdpSocket>)> {
         let common = self.common();
-        common.bind_udp(self.clone(), socket, config)
+        common.bind_udp(self.clone(), socket, observer, config)
     }
 
     /// Gets the name of the iface.

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -6,8 +6,10 @@ mod iface;
 mod phy;
 mod poll;
 mod port;
+mod sched;
 mod time;
 
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub use port::BindPortConfig;
+pub use sched::ScheduleNextPoll;

--- a/kernel/libs/aster-bigtcp/src/iface/poll.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll.rs
@@ -16,15 +16,18 @@ use smoltcp::{
     },
 };
 
-use crate::socket::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult};
+use crate::{
+    ext::Ext,
+    socket::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult},
+};
 
-pub(super) struct PollContext<'a, E> {
+pub(super) struct PollContext<'a, E: Ext> {
     iface_cx: &'a mut Context,
     tcp_sockets: &'a BTreeSet<KeyableArc<BoundTcpSocketInner<E>>>,
     udp_sockets: &'a BTreeSet<KeyableArc<BoundUdpSocketInner<E>>>,
 }
 
-impl<'a, E> PollContext<'a, E> {
+impl<'a, E: Ext> PollContext<'a, E> {
     #[allow(clippy::mutable_key_type)]
     pub(super) fn new(
         iface_cx: &'a mut Context,
@@ -44,7 +47,7 @@ impl<'a, E> PollContext<'a, E> {
 pub(super) trait FnHelper<A, B, C, O>: FnMut(A, B, C) -> O {}
 impl<A, B, C, O, F> FnHelper<A, B, C, O> for F where F: FnMut(A, B, C) -> O {}
 
-impl<E> PollContext<'_, E> {
+impl<E: Ext> PollContext<'_, E> {
     pub(super) fn poll_ingress<D, P, Q>(
         &mut self,
         device: &mut D,
@@ -280,7 +283,7 @@ impl<E> PollContext<'_, E> {
     }
 }
 
-impl<E> PollContext<'_, E> {
+impl<E: Ext> PollContext<'_, E> {
     pub(super) fn poll_egress<D, Q>(&mut self, device: &mut D, mut dispatch_phy: Q)
     where
         D: Device + ?Sized,

--- a/kernel/libs/aster-bigtcp/src/iface/sched.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/sched.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// A trait to provide the `schedule_next_poll` method for ifaces.
+pub trait ScheduleNextPoll: Send + Sync {
+    /// Schedules the next poll at the specific time.
+    ///
+    /// This is invoked with the time at which the next poll should be performed, or `None` if no
+    /// next poll is required. It's up to the caller to determine the mechanism to ensure that the
+    /// next poll happens at the right time (e.g. by setting a timer).
+    fn schedule_next_poll(&self, ms: Option<u64>);
+}

--- a/kernel/libs/aster-bigtcp/src/lib.rs
+++ b/kernel/libs/aster-bigtcp/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod device;
 pub mod errors;
+pub mod ext;
 pub mod iface;
 pub mod socket;
 pub mod time;

--- a/kernel/src/net/iface/ext.rs
+++ b/kernel/src/net/iface/ext.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::sched::PollScheduler;
+use crate::net::socket::ip::{datagram::DatagramObserver, stream::StreamObserver};
 
 pub struct BigtcpExt;
 
 impl aster_bigtcp::ext::Ext for BigtcpExt {
     type ScheduleNextPoll = PollScheduler;
+
+    type TcpEventObserver = StreamObserver;
+    type UdpEventObserver = DatagramObserver;
 }

--- a/kernel/src/net/iface/ext.rs
+++ b/kernel/src/net/iface/ext.rs
@@ -1,78 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::string::String;
-use core::sync::atomic::{AtomicU64, Ordering};
+use super::sched::PollScheduler;
 
-use ostd::sync::WaitQueue;
+pub struct BigtcpExt;
 
-use super::Iface;
-
-/// The iface extension.
-pub struct IfaceExt {
-    /// The name of the iface.
-    name: String,
-    /// The time when we should do the next poll.
-    /// We store the total number of milliseconds since the system booted.
-    next_poll_at_ms: AtomicU64,
-    /// The wait queue that the background polling thread will sleep on.
-    polling_wait_queue: WaitQueue,
-}
-
-impl IfaceExt {
-    pub(super) fn new(name: String) -> Self {
-        Self {
-            name,
-            next_poll_at_ms: AtomicU64::new(0),
-            polling_wait_queue: WaitQueue::new(),
-        }
-    }
-
-    pub(super) fn next_poll_at_ms(&self) -> Option<u64> {
-        let millis = self.next_poll_at_ms.load(Ordering::Relaxed);
-        if millis == 0 {
-            None
-        } else {
-            Some(millis)
-        }
-    }
-
-    pub(super) fn polling_wait_queue(&self) -> &WaitQueue {
-        &self.polling_wait_queue
-    }
-
-    fn schedule_next_poll(&self, poll_at: Option<u64>) {
-        let Some(new_instant) = poll_at else {
-            self.next_poll_at_ms.store(0, Ordering::Relaxed);
-            return;
-        };
-
-        let old_instant = self.next_poll_at_ms.load(Ordering::Relaxed);
-        self.next_poll_at_ms.store(new_instant, Ordering::Relaxed);
-
-        if old_instant == 0 || new_instant < old_instant {
-            self.polling_wait_queue.wake_all();
-        }
-    }
-}
-
-pub trait IfaceEx {
-    /// Gets the name of the iface.
-    ///
-    /// In Linux, the name is usually the driver name followed by a unit number.
-    fn name(&self) -> &str;
-
-    /// Transmits or receives packets queued in the iface, and updates socket status accordingly.
-    ///
-    /// The background polling thread is woken up to perform the next poll if necessary.
-    fn poll(&self);
-}
-
-impl IfaceEx for Iface {
-    fn name(&self) -> &str {
-        &self.ext().name
-    }
-
-    fn poll(&self) {
-        self.raw_poll(&|next_poll| self.ext().schedule_next_poll(next_poll));
-    }
+impl aster_bigtcp::ext::Ext for BigtcpExt {
+    type ScheduleNextPoll = PollScheduler;
 }

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -7,10 +7,7 @@ use ostd::sync::LocalIrqDisabled;
 use spin::Once;
 
 use super::{poll::poll_ifaces, Iface};
-use crate::{
-    net::iface::ext::{IfaceEx, IfaceExt},
-    prelude::*,
-};
+use crate::{net::iface::sched::PollScheduler, prelude::*};
 
 pub static IFACES: Once<Vec<Arc<Iface>>> = Once::new();
 
@@ -69,7 +66,8 @@ fn new_virtio() -> Arc<Iface> {
         EthernetAddress(ether_addr),
         Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
         VIRTIO_GATEWAY,
-        IfaceExt::new("virtio".to_owned()),
+        "virtio".to_owned(),
+        PollScheduler::new(),
     )
 }
 
@@ -100,6 +98,7 @@ fn new_loopback() -> Arc<Iface> {
     IpIface::new(
         Wrapper(Mutex::new(Loopback::new(Medium::Ip))),
         Ipv4Cidr::new(LOOPBACK_ADDRESS, LOOPBACK_ADDRESS_PREFIX_LEN),
-        IfaceExt::new("lo".to_owned()),
+        "lo".to_owned(),
+        PollScheduler::new(),
     ) as _
 }

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -3,11 +3,11 @@
 mod ext;
 mod init;
 mod poll;
+mod sched;
 
-pub use ext::IfaceEx;
 pub use init::{init, IFACES};
 pub use poll::lazy_init;
 
-pub type Iface = dyn aster_bigtcp::iface::Iface<ext::IfaceExt>;
-pub type BoundTcpSocket = aster_bigtcp::socket::BoundTcpSocket<ext::IfaceExt>;
-pub type BoundUdpSocket = aster_bigtcp::socket::BoundUdpSocket<ext::IfaceExt>;
+pub type Iface = dyn aster_bigtcp::iface::Iface<ext::BigtcpExt>;
+pub type BoundTcpSocket = aster_bigtcp::socket::BoundTcpSocket<ext::BigtcpExt>;
+pub type BoundUdpSocket = aster_bigtcp::socket::BoundUdpSocket<ext::BigtcpExt>;

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use log::trace;
 use ostd::timer::Jiffies;
 
-use super::{ext::IfaceEx, Iface, IFACES};
+use super::{Iface, IFACES};
 use crate::{sched::priority::Priority, thread::kernel_thread::ThreadOptions, WaitTimeout};
 
 pub fn lazy_init() {
@@ -27,14 +27,14 @@ fn spawn_background_poll_thread(iface: Arc<Iface>) {
     let task_fn = move || {
         trace!("spawn background poll thread for {}", iface.name());
 
-        let iface_ext = iface.ext();
-        let wait_queue = iface_ext.polling_wait_queue();
+        let sched_poll = iface.sched_poll();
+        let wait_queue = sched_poll.polling_wait_queue();
 
         loop {
-            let next_poll_at_ms = if let Some(next_poll_at_ms) = iface_ext.next_poll_at_ms() {
+            let next_poll_at_ms = if let Some(next_poll_at_ms) = sched_poll.next_poll_at_ms() {
                 next_poll_at_ms
             } else {
-                wait_queue.wait_until(|| iface_ext.next_poll_at_ms())
+                wait_queue.wait_until(|| sched_poll.next_poll_at_ms())
             };
 
             let now_as_ms = Jiffies::elapsed().as_duration().as_millis() as u64;
@@ -54,9 +54,9 @@ fn spawn_background_poll_thread(iface: Arc<Iface>) {
 
             let duration = Duration::from_millis(next_poll_at_ms - now_as_ms);
             let _ = wait_queue.wait_until_or_timeout(
-                // If `iface_ext.next_poll_at_ms()` changes to an earlier time, we will end the
+                // If `sched_poll.next_poll_at_ms()` changes to an earlier time, we will end the
                 // waiting.
-                || (iface_ext.next_poll_at_ms()? < next_poll_at_ms).then_some(()),
+                || (sched_poll.next_poll_at_ms()? < next_poll_at_ms).then_some(()),
                 &duration,
             );
         }

--- a/kernel/src/net/iface/sched.rs
+++ b/kernel/src/net/iface/sched.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use aster_bigtcp::iface::ScheduleNextPoll;
+use ostd::sync::WaitQueue;
+
+pub struct PollScheduler {
+    /// The time when we should do the next poll.
+    /// We store the total number of milliseconds since the system booted.
+    next_poll_at_ms: AtomicU64,
+    /// The wait queue that the background polling thread will sleep on.
+    polling_wait_queue: WaitQueue,
+}
+
+impl PollScheduler {
+    pub(super) fn new() -> Self {
+        Self {
+            next_poll_at_ms: AtomicU64::new(0),
+            polling_wait_queue: WaitQueue::new(),
+        }
+    }
+
+    pub(super) fn next_poll_at_ms(&self) -> Option<u64> {
+        let millis = self.next_poll_at_ms.load(Ordering::Relaxed);
+        if millis == 0 {
+            None
+        } else {
+            Some(millis)
+        }
+    }
+
+    pub(super) fn polling_wait_queue(&self) -> &WaitQueue {
+        &self.polling_wait_queue
+    }
+}
+
+impl ScheduleNextPoll for PollScheduler {
+    fn schedule_next_poll(&self, poll_at: Option<u64>) {
+        let Some(new_instant) = poll_at else {
+            self.next_poll_at_ms.store(0, Ordering::Relaxed);
+            return;
+        };
+
+        let old_instant = self.next_poll_at_ms.load(Ordering::Relaxed);
+        self.next_poll_at_ms.store(new_instant, Ordering::Relaxed);
+
+        if old_instant == 0 || new_instant < old_instant {
+            self.polling_wait_queue.wake_all();
+        }
+    }
+}

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -3,7 +3,7 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_bigtcp::wire::IpEndpoint;
-use ostd::sync::WriteIrqDisabled;
+use ostd::sync::PreemptDisabled;
 use takeable::Takeable;
 
 use self::{bound::BoundDatagram, unbound::UnboundDatagram};
@@ -49,7 +49,7 @@ impl OptionSet {
 
 pub struct DatagramSocket {
     options: RwLock<OptionSet>,
-    inner: RwLock<Takeable<Inner>, WriteIrqDisabled>,
+    inner: RwLock<Takeable<Inner>, PreemptDisabled>,
     nonblocking: AtomicBool,
     pollee: Pollee,
 }

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -50,7 +50,7 @@ impl OptionSet {
 pub struct DatagramSocket {
     options: RwLock<OptionSet>,
     inner: RwLock<Takeable<Inner>, PreemptDisabled>,
-    nonblocking: AtomicBool,
+    is_nonblocking: AtomicBool,
     pollee: Pollee,
 }
 
@@ -98,22 +98,22 @@ impl Inner {
 }
 
 impl DatagramSocket {
-    pub fn new(nonblocking: bool) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool) -> Arc<Self> {
         let unbound_datagram = UnboundDatagram::new();
         Arc::new(Self {
             inner: RwLock::new(Takeable::new(Inner::Unbound(unbound_datagram))),
-            nonblocking: AtomicBool::new(nonblocking),
+            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             options: RwLock::new(OptionSet::new()),
         })
     }
 
     pub fn is_nonblocking(&self) -> bool {
-        self.nonblocking.load(Ordering::SeqCst)
+        self.is_nonblocking.load(Ordering::Relaxed)
     }
 
-    pub fn set_nonblocking(&self, nonblocking: bool) {
-        self.nonblocking.store(nonblocking, Ordering::SeqCst);
+    pub fn set_nonblocking(&self, is_nonblocking: bool) {
+        self.is_nonblocking.store(is_nonblocking, Ordering::Relaxed);
     }
 
     fn remote_endpoint(&self) -> Option<IpEndpoint> {

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -18,16 +18,13 @@ use crate::{
         utils::{InodeMode, Metadata, StatusFlags},
     },
     match_sock_option_mut,
-    net::{
-        iface::IfaceEx,
-        socket::{
-            options::{Error as SocketError, SocketOption},
-            util::{
-                options::SocketOptionSet, send_recv_flags::SendRecvFlags, socket_addr::SocketAddr,
-                MessageHeader,
-            },
-            Socket,
+    net::socket::{
+        options::{Error as SocketError, SocketOption},
+        util::{
+            options::SocketOptionSet, send_recv_flags::SendRecvFlags, socket_addr::SocketAddr,
+            MessageHeader,
         },
+        Socket,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -2,10 +2,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use aster_bigtcp::{
-    socket::{SocketEventObserver, SocketEvents},
-    wire::IpEndpoint,
-};
+use aster_bigtcp::wire::IpEndpoint;
 use ostd::sync::WriteIrqDisabled;
 use takeable::Takeable;
 
@@ -32,7 +29,10 @@ use crate::{
 };
 
 mod bound;
+mod observer;
 mod unbound;
+
+pub(in crate::net) use self::observer::DatagramObserver;
 
 #[derive(Debug, Clone)]
 struct OptionSet {
@@ -64,6 +64,7 @@ impl Inner {
         self,
         endpoint: &IpEndpoint,
         can_reuse: bool,
+        observer: DatagramObserver,
     ) -> core::result::Result<BoundDatagram, (Error, Self)> {
         let unbound_datagram = match self {
             Inner::Unbound(unbound_datagram) => unbound_datagram,
@@ -75,7 +76,7 @@ impl Inner {
             }
         };
 
-        let bound_datagram = match unbound_datagram.bind(endpoint, can_reuse) {
+        let bound_datagram = match unbound_datagram.bind(endpoint, can_reuse, observer) {
             Ok(bound_datagram) => bound_datagram,
             Err((err, unbound_datagram)) => return Err((err, Inner::Unbound(unbound_datagram))),
         };
@@ -85,26 +86,25 @@ impl Inner {
     fn bind_to_ephemeral_endpoint(
         self,
         remote_endpoint: &IpEndpoint,
+        observer: DatagramObserver,
     ) -> core::result::Result<BoundDatagram, (Error, Self)> {
         if let Inner::Bound(bound_datagram) = self {
             return Ok(bound_datagram);
         }
 
         let endpoint = get_ephemeral_endpoint(remote_endpoint);
-        self.bind(&endpoint, false)
+        self.bind(&endpoint, false, observer)
     }
 }
 
 impl DatagramSocket {
     pub fn new(nonblocking: bool) -> Arc<Self> {
-        Arc::new_cyclic(|me| {
-            let unbound_datagram = UnboundDatagram::new(me.clone() as _);
-            Self {
-                inner: RwLock::new(Takeable::new(Inner::Unbound(unbound_datagram))),
-                nonblocking: AtomicBool::new(nonblocking),
-                pollee: Pollee::new(),
-                options: RwLock::new(OptionSet::new()),
-            }
+        let unbound_datagram = UnboundDatagram::new();
+        Arc::new(Self {
+            inner: RwLock::new(Takeable::new(Inner::Unbound(unbound_datagram))),
+            nonblocking: AtomicBool::new(nonblocking),
+            pollee: Pollee::new(),
+            options: RwLock::new(OptionSet::new()),
         })
     }
 
@@ -134,7 +134,10 @@ impl DatagramSocket {
         // Slow path
         let mut inner = self.inner.write();
         inner.borrow_result(|owned_inner| {
-            let bound_datagram = match owned_inner.bind_to_ephemeral_endpoint(remote_endpoint) {
+            let bound_datagram = match owned_inner.bind_to_ephemeral_endpoint(
+                remote_endpoint,
+                DatagramObserver::new(self.pollee.clone()),
+            ) {
                 Ok(bound_datagram) => bound_datagram,
                 Err((err, err_inner)) => {
                     return (err_inner, Err(err));
@@ -277,7 +280,11 @@ impl Socket for DatagramSocket {
         let can_reuse = self.options.read().socket.reuse_addr();
         let mut inner = self.inner.write();
         inner.borrow_result(|owned_inner| {
-            let bound_datagram = match owned_inner.bind(&endpoint, can_reuse) {
+            let bound_datagram = match owned_inner.bind(
+                &endpoint,
+                can_reuse,
+                DatagramObserver::new(self.pollee.clone()),
+            ) {
                 Ok(bound_datagram) => bound_datagram,
                 Err((err, err_inner)) => {
                     return (err_inner, Err(err));
@@ -383,21 +390,5 @@ impl Socket for DatagramSocket {
 
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
         self.options.write().socket.set_option(option)
-    }
-}
-
-impl SocketEventObserver for DatagramSocket {
-    fn on_events(&self, events: SocketEvents) {
-        let mut io_events = IoEvents::empty();
-
-        if events.contains(SocketEvents::CAN_RECV) {
-            io_events |= IoEvents::IN;
-        }
-
-        if events.contains(SocketEvents::CAN_SEND) {
-            io_events |= IoEvents::OUT;
-        }
-
-        self.pollee.notify(io_events);
     }
 }

--- a/kernel/src/net/socket/ip/datagram/observer.rs
+++ b/kernel/src/net/socket/ip/datagram/observer.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_bigtcp::socket::{SocketEventObserver, SocketEvents};
+
+use crate::{events::IoEvents, process::signal::Pollee};
+
+pub struct DatagramObserver(Pollee);
+
+impl DatagramObserver {
+    pub(super) fn new(pollee: Pollee) -> Self {
+        Self(pollee)
+    }
+}
+
+impl SocketEventObserver for DatagramObserver {
+    fn on_events(&self, events: SocketEvents) {
+        let mut io_events = IoEvents::empty();
+
+        if events.contains(SocketEvents::CAN_RECV) {
+            io_events |= IoEvents::IN;
+        }
+
+        if events.contains(SocketEvents::CAN_SEND) {
+            io_events |= IoEvents::OUT;
+        }
+
+        self.0.notify(io_events);
+    }
+}

--- a/kernel/src/net/socket/ip/mod.rs
+++ b/kernel/src/net/socket/ip/mod.rs
@@ -2,9 +2,7 @@
 
 mod addr;
 mod common;
-mod datagram;
+pub mod datagram;
 pub mod stream;
 
 use addr::UNSPECIFIED_LOCAL_ENDPOINT;
-pub use datagram::DatagramSocket;
-pub use stream::StreamSocket;

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Weak;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_bigtcp::{
     errors::tcp::{RecvError, SendError},
-    socket::{NeedIfacePoll, SocketEventObserver, TcpStateCheck},
+    socket::{NeedIfacePoll, TcpStateCheck},
     wire::IpEndpoint,
 };
 
+use super::StreamObserver;
 use crate::{
     events::IoEvents,
     net::{
@@ -202,7 +202,7 @@ impl ConnectedStream {
         })
     }
 
-    pub(super) fn set_observer(&self, observer: Weak<dyn SocketEventObserver>) {
+    pub(super) fn set_observer(&self, observer: StreamObserver) {
         self.bound_socket.set_observer(observer)
     }
 }

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -3,7 +3,7 @@
 use aster_bigtcp::{
     errors::tcp::ListenError, iface::BindPortConfig, socket::UnboundTcpSocket, wire::IpEndpoint,
 };
-use ostd::sync::WriteIrqDisabled;
+use ostd::sync::PreemptDisabled;
 
 use super::{connected::ConnectedStream, StreamObserver};
 use crate::{
@@ -18,7 +18,7 @@ pub struct ListenStream {
     /// A bound socket held to ensure the TCP port cannot be released
     bound_socket: BoundTcpSocket,
     /// Backlog sockets listening at the local endpoint
-    backlog_sockets: RwLock<Vec<BacklogSocket>, WriteIrqDisabled>,
+    backlog_sockets: RwLock<Vec<BacklogSocket>, PreemptDisabled>,
 }
 
 impl ListenStream {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -77,12 +77,12 @@ impl OptionSet {
 }
 
 impl StreamSocket {
-    pub fn new(nonblocking: bool) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool) -> Arc<Self> {
         let init_stream = InitStream::new();
         Arc::new(Self {
             options: RwLock::new(OptionSet::new()),
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
-            is_nonblocking: AtomicBool::new(nonblocking),
+            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
         })
     }

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -23,16 +23,13 @@ use crate::{
         utils::{InodeMode, Metadata, StatusFlags},
     },
     match_sock_option_mut, match_sock_option_ref,
-    net::{
-        iface::IfaceEx,
-        socket::{
-            options::{Error as SocketError, SocketOption},
-            util::{
-                options::SocketOptionSet, send_recv_flags::SendRecvFlags,
-                shutdown_cmd::SockShutdownCmd, socket_addr::SocketAddr, MessageHeader,
-            },
-            Socket,
+    net::socket::{
+        options::{Error as SocketError, SocketOption},
+        util::{
+            options::SocketOptionSet, send_recv_flags::SendRecvFlags,
+            shutdown_cmd::SockShutdownCmd, socket_addr::SocketAddr, MessageHeader,
         },
+        Socket,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -8,7 +8,7 @@ use connecting::{ConnResult, ConnectingStream};
 use init::InitStream;
 use listen::ListenStream;
 use options::{Congestion, MaxSegment, NoDelay, WindowClamp};
-use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard, WriteIrqDisabled};
+use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 use takeable::Takeable;
 use util::TcpOptionSet;
 
@@ -46,7 +46,7 @@ pub use self::util::CongestionControl;
 
 pub struct StreamSocket {
     options: RwLock<OptionSet>,
-    state: RwLock<Takeable<State>, WriteIrqDisabled>,
+    state: RwLock<Takeable<State>, PreemptDisabled>,
     is_nonblocking: AtomicBool,
     pollee: Pollee,
 }
@@ -109,7 +109,7 @@ impl StreamSocket {
     /// Ensures that the socket state is up to date and obtains a read lock on it.
     ///
     /// For a description of what "up-to-date" means, see [`Self::update_connecting`].
-    fn read_updated_state(&self) -> RwLockReadGuard<Takeable<State>, WriteIrqDisabled> {
+    fn read_updated_state(&self) -> RwLockReadGuard<Takeable<State>, PreemptDisabled> {
         loop {
             let state = self.state.read();
             match state.as_ref() {
@@ -125,7 +125,7 @@ impl StreamSocket {
     /// Ensures that the socket state is up to date and obtains a write lock on it.
     ///
     /// For a description of what "up-to-date" means, see [`Self::update_connecting`].
-    fn write_updated_state(&self) -> RwLockWriteGuard<Takeable<State>, WriteIrqDisabled> {
+    fn write_updated_state(&self) -> RwLockWriteGuard<Takeable<State>, PreemptDisabled> {
         self.update_connecting().1
     }
 
@@ -142,7 +142,7 @@ impl StreamSocket {
         &self,
     ) -> (
         RwLockWriteGuard<OptionSet, PreemptDisabled>,
-        RwLockWriteGuard<Takeable<State>, WriteIrqDisabled>,
+        RwLockWriteGuard<Takeable<State>, PreemptDisabled>,
     ) {
         // Hold the lock in advance to avoid race conditions.
         let mut options = self.options.write();

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -2,10 +2,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use aster_bigtcp::{
-    socket::{SocketEventObserver, SocketEvents},
-    wire::IpEndpoint,
-};
+use aster_bigtcp::wire::IpEndpoint;
 use connected::ConnectedStream;
 use connecting::{ConnResult, ConnectingStream};
 use init::InitStream;
@@ -40,9 +37,11 @@ mod connected;
 mod connecting;
 mod init;
 mod listen;
+mod observer;
 pub mod options;
 mod util;
 
+pub(in crate::net) use self::observer::StreamObserver;
 pub use self::util::CongestionControl;
 
 pub struct StreamSocket {
@@ -79,26 +78,23 @@ impl OptionSet {
 
 impl StreamSocket {
     pub fn new(nonblocking: bool) -> Arc<Self> {
-        Arc::new_cyclic(|me| {
-            let init_stream = InitStream::new(me.clone() as _);
-            Self {
-                options: RwLock::new(OptionSet::new()),
-                state: RwLock::new(Takeable::new(State::Init(init_stream))),
-                is_nonblocking: AtomicBool::new(nonblocking),
-                pollee: Pollee::new(),
-            }
+        let init_stream = InitStream::new();
+        Arc::new(Self {
+            options: RwLock::new(OptionSet::new()),
+            state: RwLock::new(Takeable::new(State::Init(init_stream))),
+            is_nonblocking: AtomicBool::new(nonblocking),
+            pollee: Pollee::new(),
         })
     }
 
     fn new_connected(connected_stream: ConnectedStream) -> Arc<Self> {
-        Arc::new_cyclic(move |me| {
-            connected_stream.set_observer(me.clone() as _);
-            Self {
-                options: RwLock::new(OptionSet::new()),
-                state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
-                is_nonblocking: AtomicBool::new(false),
-                pollee: Pollee::new(),
-            }
+        let pollee = Pollee::new();
+        connected_stream.set_observer(StreamObserver::new(pollee.clone()));
+        Arc::new(Self {
+            options: RwLock::new(OptionSet::new()),
+            state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
+            is_nonblocking: AtomicBool::new(false),
+            pollee,
         })
     }
 
@@ -221,7 +217,7 @@ impl StreamSocket {
                 }
             };
 
-            let connecting_stream = match init_stream.connect(remote_endpoint) {
+            let connecting_stream = match init_stream.connect(remote_endpoint, &self.pollee) {
                 Ok(connecting_stream) => connecting_stream,
                 Err((err, init_stream)) => {
                     return (State::Init(init_stream), (Some(Err(err)), None));
@@ -276,11 +272,13 @@ impl StreamSocket {
             return_errno_with_message!(Errno::EINVAL, "the socket is not listening");
         };
 
-        let accepted = listen_stream.try_accept().map(|connected_stream| {
-            let remote_endpoint = connected_stream.remote_endpoint();
-            let accepted_socket = Self::new_connected(connected_stream);
-            (accepted_socket as _, remote_endpoint.into())
-        });
+        let accepted = listen_stream
+            .try_accept(&self.pollee)
+            .map(|connected_stream| {
+                let remote_endpoint = connected_stream.remote_endpoint();
+                let accepted_socket = Self::new_connected(connected_stream);
+                (accepted_socket as _, remote_endpoint.into())
+            });
         let iface_to_poll = listen_stream.iface().clone();
 
         drop(state);
@@ -451,7 +449,11 @@ impl Socket for StreamSocket {
                 );
             };
 
-            let bound_socket = match init_stream.bind(&endpoint, can_reuse) {
+            let bound_socket = match init_stream.bind(
+                &endpoint,
+                can_reuse,
+                StreamObserver::new(self.pollee.clone()),
+            ) {
                 Ok(bound_socket) => bound_socket,
                 Err((err, init_stream)) => {
                     return (State::Init(init_stream), Err(err));
@@ -492,7 +494,7 @@ impl Socket for StreamSocket {
                 }
             };
 
-            let listen_stream = match init_stream.listen(backlog) {
+            let listen_stream = match init_stream.listen(backlog, &self.pollee) {
                 Ok(listen_stream) => listen_stream,
                 Err((err, init_stream)) => {
                     return (State::Init(init_stream), Err(err));
@@ -685,30 +687,6 @@ impl Socket for StreamSocket {
         });
 
         Ok(())
-    }
-}
-
-impl SocketEventObserver for StreamSocket {
-    fn on_events(&self, events: SocketEvents) {
-        let mut io_events = IoEvents::empty();
-
-        if events.contains(SocketEvents::CAN_RECV) {
-            io_events |= IoEvents::IN;
-        }
-
-        if events.contains(SocketEvents::CAN_SEND) {
-            io_events |= IoEvents::OUT;
-        }
-
-        if events.contains(SocketEvents::PEER_CLOSED) {
-            io_events |= IoEvents::IN | IoEvents::RDHUP;
-        }
-
-        if events.contains(SocketEvents::CLOSED) {
-            io_events |= IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP | IoEvents::HUP;
-        }
-
-        self.pollee.notify(io_events);
     }
 }
 

--- a/kernel/src/net/socket/ip/stream/observer.rs
+++ b/kernel/src/net/socket/ip/stream/observer.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_bigtcp::socket::{SocketEventObserver, SocketEvents};
+
+use crate::{events::IoEvents, process::signal::Pollee};
+
+pub struct StreamObserver(Pollee);
+
+impl StreamObserver {
+    pub(super) fn new(pollee: Pollee) -> Self {
+        Self(pollee)
+    }
+}
+
+impl SocketEventObserver for StreamObserver {
+    fn on_events(&self, events: SocketEvents) {
+        let mut io_events = IoEvents::empty();
+
+        if events.contains(SocketEvents::CAN_RECV) {
+            io_events |= IoEvents::IN;
+        }
+
+        if events.contains(SocketEvents::CAN_SEND) {
+            io_events |= IoEvents::OUT;
+        }
+
+        if events.contains(SocketEvents::PEER_CLOSED) {
+            io_events |= IoEvents::IN | IoEvents::RDHUP;
+        }
+
+        if events.contains(SocketEvents::CLOSED) {
+            io_events |= IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP | IoEvents::HUP;
+        }
+
+        self.0.notify(io_events);
+    }
+}

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -28,6 +28,7 @@ use crate::{
 ///
 /// Then, [`Pollee::poll_with`] can allow you to register a [`Poller`] to wait for certain events,
 /// or register a [`PollAdaptor`] to be notified when certain events occur.
+#[derive(Clone)]
 pub struct Pollee {
     inner: Arc<PolleeInner>,
 }

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{file_handle::FileLike, file_table::FdFlags},
     net::socket::{
-        ip::{DatagramSocket, StreamSocket},
+        ip::{datagram::DatagramSocket, stream::StreamSocket},
         unix::UnixStreamSocket,
         vsock::VsockStreamSocket,
     },


### PR DESCRIPTION
The socket observer is currently the socket file, which needs to be upgraded to an `Arc` to report new network events.
https://github.com/asterinas/asterinas/blob/00e3688aa8945e09a48e85013ab73900490db7ad/kernel/src/net/socket/ip/stream/mod.rs#L694
https://github.com/asterinas/asterinas/blob/00e3688aa8945e09a48e85013ab73900490db7ad/kernel/libs/aster-bigtcp/src/socket/bound.rs#L465

This is problematic. Remember that the socket file may be closed at the same time by the user program, so the socket observer may be the last `Arc` to the socket file. So when we drop the `Arc`, we'll drop the socket file, which will immediately start an iface poll.
https://github.com/asterinas/asterinas/blob/00e3688aa8945e09a48e85013ab73900490db7ad/kernel/src/net/socket/ip/stream/mod.rs#L731

Then we get stuck because we are already in an iface poll and we cannot start another iface poll.

To solve this problem, I'm trying to use `Pollee` directly as a socket observer. This results in the first two commits.

The remaining three commits are some additional small fixes:
 1. Note that we can free ports in the iface poll (e.g. when a TCP socket exits its TIME-WAIT state). Since we're doing iface polling in IRQ handlers, `used_ports` must be protected with IRQ disabled.
 2. Since https://github.com/asterinas/asterinas/pull/1616, we don't access the socket states inside the IRQ handlers, so they can just be protected with `PreemptDisabled`.
 3. We should use `Ordering::Relaxed` to access `is_nonblocking` since we don't synchronize anything through this variable. It's already the case for TCP sockets, but the UDP side needs some fixes.