### PR TITLE
Make ELF segments explicit and aligned

### DIFF
--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -30,11 +30,11 @@ PHDRS
     # segment to prevent this from happening.
     header PT_LOAD FLAGS(4);      # R__
 
-    # Boot segments.
+    # Boot segments. Addresses are physical.
     bsp_boot PT_LOAD FLAGS(7);    # RWE
     ap_boot PT_LOAD FLAGS(7);     # RWE
 
-    # Normal segments.
+    # Normal segments. Addresses are virtual.
     text PT_LOAD FLAGS(5);        # R_E
     rodata PT_LOAD FLAGS(4);      # R__
     data PT_LOAD FLAGS(6);        # RW_
@@ -57,22 +57,21 @@ SECTIONS
     } : header
 
 # --------------------------------------------------------------------------- #
-# These are 2 boot sections that need specific physical addresses. But they   #
-# should use virtual symbols.                                                 #
+# These are 2 boot sections that need specific physical addresses.            #
 # --------------------------------------------------------------------------- #
-    . = BSP_BOOT_LMA + KERNEL_VMA;
+    . = BSP_BOOT_LMA;
 
     .bsp_boot               : AT(BSP_BOOT_LMA) {
         KEEP(*(.bsp_boot .bsp_boot.*))
         . = ALIGN(4096);
     } : bsp_boot
 
-    . = AP_EXEC_MA + KERNEL_VMA;
+    . = AP_EXEC_MA;
 
     .ap_boot                : AT(BSP_BOOT_LMA + SIZEOF(.bsp_boot)) {
-        __ap_boot_start = . - AP_EXEC_MA + BSP_BOOT_LMA + SIZEOF(.bsp_boot);
+        __ap_boot_start = BSP_BOOT_LMA + SIZEOF(.bsp_boot) + KERNEL_VMA;
         KEEP(*(.ap_boot .ap_boot.*))
-        __ap_boot_end = . - AP_EXEC_MA + BSP_BOOT_LMA + SIZEOF(.bsp_boot);
+        __ap_boot_end = __ap_boot_start + (. - AP_EXEC_MA);
         . = ALIGN(4096);
     } : ap_boot
 

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -51,12 +51,11 @@ SECTIONS
     }
     PROVIDE(__ap_boot_end = __ap_boot_start + SIZEOF(.ap_boot));
 
-    . = BSP_BOOT_LMA + KERNEL_VMA + SIZEOF(.bsp_boot) + SIZEOF(.ap_boot);
-    . = ALIGN(4096);
-
 # --------------------------------------------------------------------------- #
 # Here are the rest of the virtual memory sections which can be relocated.    #
 # --------------------------------------------------------------------------- #
+    . = BSP_BOOT_LMA + KERNEL_VMA + SIZEOF(.bsp_boot) + SIZEOF(.ap_boot);
+    . = ALIGN(4096);
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
         *(.text .text.*)
@@ -95,22 +94,14 @@ SECTIONS
         PROVIDE(__GNU_EH_FRAME_HDR = .);
         KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
     }
-    . = ALIGN(8);
     .eh_frame               : AT(ADDR(.eh_frame) - KERNEL_VMA) {
         PROVIDE(__eh_frame = .);
         KEEP(*(.eh_frame .eh_frame.*))
     }
+    .gcc_except_table       : AT(ADDR(.gcc_except_table) - KERNEL_VMA) {
+        *(.gcc_except_table .gcc_except_table.*)
+    }
 
-    .gcc_except_table       : AT(ADDR(.gcc_except_table) - KERNEL_VMA) { *(.gcc_except_table .gcc_except_table.*) }
-
-    .data.rel.ro            : AT(ADDR(.data.rel.ro) - KERNEL_VMA) { *(.data.rel.ro .data.rel.ro.*) }
-    .dynamic                : AT(ADDR(.dynamic) - KERNEL_VMA) { *(.dynamic) }
-    
-    .got                    : AT(ADDR(.got) - KERNEL_VMA)  { *(.got .got.*) }
-    .got.plt                : AT(ADDR(.got.plt) - KERNEL_VMA)  { *(.got.plt .got.plt.*) }
-
-    . = DATA_SEGMENT_RELRO_END(0, .);
-    
     .data                   : AT(ADDR(.data) - KERNEL_VMA) { *(.data .data.*) }
 
     # The CPU local data storage. It is readable and writable for the bootstrap
@@ -134,11 +125,6 @@ SECTIONS
         *(.bss .bss.*) *(COMMON)
         __bss_end = .;
     }
-
-    .tdata                  : AT(ADDR(.tdata) - KERNEL_VMA) { *(.tdata .tdata.*) }
-    .tbss                   : AT(ADDR(.tbss) - KERNEL_VMA) { *(.tbss .tbss.*) }
-
-    . = DATA_SEGMENT_END(.);
 
     __kernel_end = .;
 }

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -17,6 +17,29 @@ AP_EXEC_MA = 0x8000;
 # The virtual memory offset of the kernel mapping.
 KERNEL_VMA = 0xffffffff80000000;
 
+PHDRS
+{
+    # Make sure that the start address of each segment is aligned with a page
+    # boundary. GRUB is known to misbehave (at least under certain conditions)
+    # if the segments are not aligned to pages.
+    # See also: https://github.com/asterinas/asterinas/pull/1689
+
+    # Headers.
+    # This may not be necessary, but llvm-strip will move sections that are not
+    # part of a segment to the end of the file. We need to have headers as a
+    # segment to prevent this from happening.
+    header PT_LOAD FLAGS(4);      # R__
+
+    # Boot segments.
+    bsp_boot PT_LOAD FLAGS(7);    # RWE
+    ap_boot PT_LOAD FLAGS(7);     # RWE
+
+    # Normal segments.
+    text PT_LOAD FLAGS(5);        # R_E
+    rodata PT_LOAD FLAGS(4);      # R__
+    data PT_LOAD FLAGS(6);        # RW_
+}
+
 SECTIONS
 {
 # --------------------------------------------------------------------------- #
@@ -28,10 +51,10 @@ SECTIONS
 
     .multiboot_header       : AT(ADDR(.multiboot_header) - KERNEL_VMA) {
         KEEP(*(.multiboot_header))
-    }
+    } : header
     .multiboot2_header      : AT(ADDR(.multiboot2_header) - KERNEL_VMA) {
         KEEP(*(.multiboot2_header))
-    }
+    } : header
 
 # --------------------------------------------------------------------------- #
 # These are 2 boot sections that need specific physical addresses. But they   #
@@ -41,26 +64,29 @@ SECTIONS
 
     .bsp_boot               : AT(BSP_BOOT_LMA) {
         KEEP(*(.bsp_boot .bsp_boot.*))
-    }
+        . = ALIGN(4096);
+    } : bsp_boot
 
     . = AP_EXEC_MA + KERNEL_VMA;
 
-    PROVIDE(__ap_boot_start = BSP_BOOT_LMA + SIZEOF(.bsp_boot) + KERNEL_VMA);
     .ap_boot                : AT(BSP_BOOT_LMA + SIZEOF(.bsp_boot)) {
+        __ap_boot_start = . - AP_EXEC_MA + BSP_BOOT_LMA + SIZEOF(.bsp_boot);
         KEEP(*(.ap_boot .ap_boot.*))
-    }
-    PROVIDE(__ap_boot_end = __ap_boot_start + SIZEOF(.ap_boot));
+        __ap_boot_end = . - AP_EXEC_MA + BSP_BOOT_LMA + SIZEOF(.bsp_boot);
+        . = ALIGN(4096);
+    } : ap_boot
 
 # --------------------------------------------------------------------------- #
 # Here are the rest of the virtual memory sections which can be relocated.    #
 # --------------------------------------------------------------------------- #
     . = BSP_BOOT_LMA + KERNEL_VMA + SIZEOF(.bsp_boot) + SIZEOF(.ap_boot);
-    . = ALIGN(4096);
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
         *(.text .text.*)
         PROVIDE(__etext = .);
-    }
+    } : text
+
+    . = ALIGN(4096);
 
     # The section to store exception table (ExTable).
     # This table is used for recovering from specific exception handling faults
@@ -70,7 +96,7 @@ SECTIONS
         __ex_table = .;
         KEEP(*(SORT(.ex_table)))
         __ex_table_end = .;
-    }
+    } : rodata
 
     # The list of unit test function symbols that should be executed while
     # doing `cargo osdk test`.
@@ -78,7 +104,7 @@ SECTIONS
         __ktest_array = .;
         KEEP(*(SORT(.ktest_array)))
         __ktest_array_end = .;
-    }
+    } : rodata
 
     # A list of initialization function symbols. They will be called on OSTD
     # initialization.
@@ -86,23 +112,29 @@ SECTIONS
         __sinit_array = .;
         KEEP(*(SORT(.init_array .init_array.*)))
         __einit_array = .;
-    }
+    } : rodata
 
-    .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA) { *(.rodata .rodata.*) }
+    .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA) {
+        *(.rodata .rodata.*)
+    } : rodata
 
     .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA) {
         PROVIDE(__GNU_EH_FRAME_HDR = .);
         KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
-    }
+    } : rodata
     .eh_frame               : AT(ADDR(.eh_frame) - KERNEL_VMA) {
         PROVIDE(__eh_frame = .);
         KEEP(*(.eh_frame .eh_frame.*))
-    }
+    } : rodata
     .gcc_except_table       : AT(ADDR(.gcc_except_table) - KERNEL_VMA) {
         *(.gcc_except_table .gcc_except_table.*)
-    }
+    } : rodata
 
-    .data                   : AT(ADDR(.data) - KERNEL_VMA) { *(.data .data.*) }
+    . = ALIGN(4096);
+
+    .data                   : AT(ADDR(.data) - KERNEL_VMA) {
+        *(.data .data.*)
+    } : data
 
     # The CPU local data storage. It is readable and writable for the bootstrap
     # processor, while it would be copied to other dynamically allocated memory
@@ -114,17 +146,17 @@ SECTIONS
     # when trap from ring3 to ring0, CPU can switch stack correctly.
     .cpu_local_tss          : AT(ADDR(.cpu_local_tss) - KERNEL_VMA) {
         *(.cpu_local_tss)
-    }
+    } : data
     .cpu_local              : AT(ADDR(.cpu_local) - KERNEL_VMA) {
         KEEP(*(SORT(.cpu_local)))
-    }
+    } : data
     __cpu_local_end = .;
 
     .bss                    : AT(ADDR(.bss) - KERNEL_VMA) {
         __bss = .;
         *(.bss .bss.*) *(COMMON)
         __bss_end = .;
-    }
+    } : data
 
     __kernel_end = .;
 }

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -6,8 +6,6 @@
 .extern boot_page_table_start
 .extern ap_early_entry
 
-KERNEL_VMA              = 0xffffffff80000000
-
 .section ".ap_boot", "awx"
 .align 4096
 .code16
@@ -23,13 +21,13 @@ ap_real_mode_boot:
     xor ax, ax  // clear ax
     mov ds, ax  // clear ds
 
-    lgdt [ap_gdtr - KERNEL_VMA] // load gdt
+    lgdt [ap_gdtr] // load gdt
 
     mov eax, cr0
     or eax, 1
     mov cr0, eax // enable protected mode
 
-    ljmp 0x8, offset ap_protect_entry - KERNEL_VMA
+    ljmp 0x8, offset ap_protect_entry
 
 // 32-bit AP GDT.
 .align 16
@@ -44,7 +42,7 @@ ap_gdt_end:
 .align 16
 ap_gdtr:
     .word ap_gdt_end - ap_gdt - 1
-    .quad ap_gdt - KERNEL_VMA
+    .quad ap_gdt
 
 .align 4
 .code32
@@ -95,7 +93,7 @@ ap_protect:
     // Now we try getting into long mode.
 
     // Use the 64-bit GDT.
-    lgdt [boot_gdtr - KERNEL_VMA]
+    lgdt [boot_gdtr]
 
     // Enable PAE and PGE.
     mov eax, cr4
@@ -105,7 +103,7 @@ ap_protect:
     // Set the page table. The application processors use
     // the same page table as the bootstrap processor's
     // boot phase page table.
-    lea eax, [boot_page_table_start - KERNEL_VMA]
+    lea eax, [boot_page_table_start]
     mov cr3, eax
 
     // Enable long mode.
@@ -119,10 +117,9 @@ ap_protect:
     or eax, 1 << 31
     mov cr0, eax
 
-    ljmp 0x8, offset ap_long_mode_in_low_address - KERNEL_VMA
+    ljmp 0x8, offset ap_long_mode_in_low_address
 
 .code64
-
 ap_long_mode_in_low_address:
     mov ax, 0
     mov ds, ax
@@ -132,18 +129,19 @@ ap_long_mode_in_low_address:
     mov gs, ax
 
     // Update RIP to use the virtual address.
-    mov rbx, KERNEL_VMA
-    lea rax, [ap_long_mode - KERNEL_VMA]
-    or  rax, rbx
+    mov rax, offset ap_long_mode
     jmp rax
 
 // This is a pointer to be filled by the BSP when boot stacks
 // of all APs are allocated and initialized.
+.data
 .global __ap_boot_stack_array_pointer
 .align 8
 __ap_boot_stack_array_pointer:
     .skip 8
 
+.text
+.code64
 ap_long_mode:
     // The local APIC ID is in the RDI.
     mov rax, rdi
@@ -158,4 +156,5 @@ ap_long_mode:
     mov rax, offset ap_early_entry
     call rax
 
-    hlt
+.extern halt # bsp_boot.S
+    jmp halt

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -31,7 +31,7 @@ __linux32_boot:
     cld
 
     // Set the kernel call stack.
-    mov esp, offset boot_stack_top - KERNEL_VMA
+    mov esp, offset boot_stack_top
 
     push 0      // upper 32-bits
     push esi    // boot_params ptr
@@ -47,7 +47,7 @@ __linux32_boot:
 .global __linux64_boot_tag
 __linux64_boot_tag:
     // Set the kernel call stack.
-    lea rsp, [boot_stack_top - KERNEL_VMA]
+    lea rsp, [boot_stack_top]
     push rsi    // boot_params ptr from the loader
     push ENTRYTYPE_LINUX_64
 
@@ -62,7 +62,7 @@ __multiboot_boot:
     cld
 
     // Set the kernel call stack.
-    mov esp, offset boot_stack_top - KERNEL_VMA
+    mov esp, offset boot_stack_top
 
     push 0      // Upper 32-bits.
     push eax    // multiboot magic ptr
@@ -87,11 +87,11 @@ initial_boot_setup:
     // Prepare for far return. We use a far return as a fence after setting GDT.
     mov eax, 24
     push eax
-    lea edx, [protected_mode - KERNEL_VMA]
+    lea edx, [protected_mode]
     push edx
 
     // Switch to our own temporary GDT.
-    lgdt [boot_gdtr - KERNEL_VMA]
+    lgdt [boot_gdtr]
     retf
 
 protected_mode:
@@ -105,8 +105,8 @@ protected_mode:
 page_table_setup:
     // Zero out the page table.
     mov al, 0x00
-    lea edi, [boot_page_table_start - KERNEL_VMA]
-    lea ecx, [boot_page_table_end - KERNEL_VMA]
+    lea edi, [boot_page_table_start]
+    lea ecx, [boot_page_table_end]
     sub ecx, edi
     cld
     rep stosb
@@ -121,8 +121,8 @@ PTE_GLOBAL      = (1 << 8)
     //       0x00000000_40000000 ~ 0x00000000_7fffffff
     //       0x00000000_80000000 ~ 0x00000000_bfffffff
     //       0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pml4 - KERNEL_VMA]
-    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_pml4]
+    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
@@ -131,56 +131,56 @@ PTE_GLOBAL      = (1 << 8)
     //       0xffff8000_80000000 ~ 0xffff8000_bfffffff
     //       0xffff8000_c0000000 ~ 0xffff8000_ffffffff
     //       0xffff8008_00000000 ~ 0xffff8008_3fffffff
-    lea edi, [boot_pml4 - KERNEL_VMA + 0x100 * 8]
-    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_pml4 + 0x100 * 8]
+    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PML4: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
     //       0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pml4 - KERNEL_VMA + 0x1ff * 8]
-    lea eax, [boot_pdpt - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_pml4 + 0x1ff * 8]
+    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_00000000 ~ 0x00000000_3fffffff
-    lea edi, [boot_pdpt - KERNEL_VMA]
-    lea eax, [boot_pd_0g_1g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt]
+    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_40000000 ~ 0x00000000_7fffffff
-    lea edi, [boot_pdpt - KERNEL_VMA + 0x1 * 8]
-    lea eax, [boot_pd_1g_2g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt + 0x1 * 8]
+    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_80000000 ~ 0x00000000_bfffffff
-    lea edi, [boot_pdpt - KERNEL_VMA + 0x2 * 8]
-    lea eax, [boot_pd_2g_3g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt + 0x2 * 8]
+    lea eax, [boot_pd_2g_3g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pdpt - KERNEL_VMA + 0x3 * 8]
-    lea eax, [boot_pd_3g_4g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt + 0x3 * 8]
+    lea eax, [boot_pd_3g_4g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
-    lea edi, [boot_pdpt - KERNEL_VMA + 0x1fe * 8]
-    lea eax, [boot_pd_0g_1g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt + 0x1fe * 8]
+    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT: 0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pdpt - KERNEL_VMA + 0x1ff * 8]
-    lea eax, [boot_pd_1g_2g - KERNEL_VMA + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    lea edi, [boot_pdpt + 0x1ff * 8]
+    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // Page Directory: map to low 1 GiB * 4 space
-    lea edi, [boot_pd - KERNEL_VMA]
+    lea edi, [boot_pd]
     mov eax, PTE_PRESENT | PTE_WRITE | PTE_GLOBAL | PTE_HUGE
     mov ecx, 512 * 4 // (of entries in PD) * (number of PD)
 write_pd_entry:
@@ -199,7 +199,7 @@ enable_long_mode:
     mov cr4, eax
 
     // Set the page table address.
-    lea eax, [boot_pml4 - KERNEL_VMA]
+    lea eax, [boot_pml4]
     mov cr3, eax
 
     // Enable long mode.
@@ -211,7 +211,7 @@ enable_long_mode:
     // Prepare for far return.
     mov  eax, 8
     push eax
-    lea  edx, [long_mode_in_low_address - KERNEL_VMA]
+    lea  edx, [long_mode_in_low_address]
     push edx
 
     // Enable paging.
@@ -227,7 +227,7 @@ enable_long_mode:
 .global boot_gdtr
 boot_gdtr:
     .word gdt_end - gdt - 1
-    .quad gdt - KERNEL_VMA
+    .quad gdt
 
 .align 16
 gdt:
@@ -274,13 +274,12 @@ long_mode_in_low_address:
     // Update RSP/RIP to use the virtual address.
     mov rbx, KERNEL_VMA
     or  rsp, rbx
-    lea rax, [long_mode - KERNEL_VMA]
-    or  rax, rbx
+    mov rax, offset long_mode
     jmp rax
 
-//  From here, we're in the .text section: we no longer use physical address.
-.code64
+// From here, we're in the .text section: we no longer use physical address.
 .text
+.code64
 long_mode:
     // Clear .bss section.
     mov al, 0x00

--- a/ostd/src/arch/x86/boot/multiboot2/header.S
+++ b/ostd/src/arch/x86/boot/multiboot2/header.S
@@ -10,7 +10,6 @@ MB2_MAGIC = 0xE85250D6
 MB2_ARCHITECTURE = 0 // 32-bit (protected) mode of i386
 MB2_HEADERLEN = header_end - header_start
 MB2_CHECKSUM = -(MB2_MAGIC + MB2_ARCHITECTURE + MB2_HEADERLEN)
-KERNEL_VMA = 0xffffffff80000000
 
 header_start:
     .align 8
@@ -26,7 +25,7 @@ entry_address_tag_start:
     .short 1                // Optional
     .long  entry_address_tag_end - entry_address_tag_start
 .extern __multiboot_boot
-    .long __multiboot_boot - KERNEL_VMA // entry_addr
+    .long __multiboot_boot  // entry_addr
 entry_address_tag_end:
 
     // Tag: information request


### PR DESCRIPTION
I happened to reproduce the CI failure in https://github.com/asterinas/asterinas/pull/1647 on my local machine (but I don't know why it can't be reproduced earlier)... So I had a chance to debug it.

My conclusion is:

 - Our `aster-nix-osdk-bin` (as an ELF file) has non-page-aligned segments in its program headers:
```
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000001000 0xffffffff88000000 0x0000000008000000
                 0x000000000000000c 0x000000000000000c  R      0x1000
  LOAD           0x0000000000001010 0xffffffff88000010 0x0000000008000010
                 0x0000000000000038 0x0000000000000038  R      0x1000
  LOAD           0x0000000000002000 0xffffffff88001000 0x0000000008001000
                 0x000000000004702a 0x000000000004702a  RWE    0x1000
[ .. ]
```
 - GRUB does a poor job of handling such non-page-aligned segments:
```
loader/multiboot.c:165:multiboot_loader: segment 0: paddr=0x8000000, memsz=0xc,
vaddr=0xffffffff88000000
[..]
lib/relocator.c:1201:relocator: allocated: 0x8000000+0xc
lib/relocator.c:1290:relocator: allocated 0x8000000/0x8000000
[..]
loader/multiboot.c:165:multiboot_loader: segment 1: paddr=0x8000010,
memsz=0x38, vaddr=0xffffffff88000010
[..]
lib/relocator.c:1201:relocator: allocated: 0x8001000+0x38
lib/relocator.c:1290:relocator: allocated 0x8001000/0x8000010
[..]
loader/multiboot.c:165:multiboot_loader: segment 2: paddr=0x8001000,
memsz=0x4702a, vaddr=0xffffffff88001000
[..]
lib/relocator.c:1201:relocator: allocated: 0x8002000+0x4702a
lib/relocator.c:1290:relocator: allocated 0x8002000/0x8001000
```

Note that
 - the second segment should be put at 0x8000010, but is actually put at 0x8001000;
 - the third segment should be put at 0x8001000, but is actually put at 0x8002000.

As a result, the address of the entry point is wrong:
 - This is what the ELF says:
```
  Entry point address:               0xffffffff88001210
```
```
ffffffff88001210 <__multiboot_boot>:
ffffffff88001210:       fa                      cli
ffffffff88001211:       fc                      cld
ffffffff88001212:       bc 00 80 04 08          mov    $0x8048000,%esp
```
 - But this is what the code in the memory actually looks like:
```
(gdb) x/3i 0x8001210
   0x8001210:	add    %al,(%rax)
   0x8001212:	add    %al,(%rax)
   0x8001214:	add    %al,(%rax)
(gdb) x/3i 0x8002210
   0x8002210:	cli
   0x8002211:	cld
   0x8002212:	mov    $0x8048000,%esp
```

I believe this is undesirable and will cause problems.

I strongly suspect that the root cause in the GRUB code is [this line](https://elixir.bootlin.com/grub/grub-2.12/source/grub-core/lib/relocator.c#L848), which aligns the start and end addresses of each segment with the page boundaries.

So,
- This PR makes segments explicit in the link script and ensures that they're aligned with page boundaries.
- This PR also includes an additional commit to make the boot segments use physical addresses. I don't really have a strong opinion on this change, but it does result in simpler code from my perspective.