### PR TITLE
Create backlog sockets on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,8 @@ dependencies = [
  "keyable-arc",
  "ostd",
  "smoltcp",
+ "spin 0.9.8",
+ "takeable",
 ]
 
 [[package]]

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -18,3 +18,5 @@ smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f0
     "socket-udp",
     "socket-tcp",
 ] }
+spin = "0.9.4"
+takeable = "0.2.2"

--- a/kernel/libs/aster-bigtcp/src/ext.rs
+++ b/kernel/libs/aster-bigtcp/src/ext.rs
@@ -15,7 +15,7 @@ pub trait Ext {
     type ScheduleNextPoll: ScheduleNextPoll;
 
     /// The type for TCP sockets to observe events.
-    type TcpEventObserver: SocketEventObserver;
+    type TcpEventObserver: SocketEventObserver + Clone;
 
     /// The type for UDP sockets to observe events.
     type UdpEventObserver: SocketEventObserver;

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, sync::Arc};
+use alloc::sync::Arc;
 
 use smoltcp::wire::Ipv4Address;
 
-use super::port::BindPortConfig;
-use crate::{
-    errors::BindError,
-    ext::Ext,
-    socket::{BoundTcpSocket, BoundUdpSocket, UnboundTcpSocket, UnboundUdpSocket},
-};
+use super::{port::BindPortConfig, BoundPort};
+use crate::{errors::BindError, ext::Ext};
 
 /// A network interface.
 ///
@@ -34,24 +30,12 @@ impl<E: Ext> dyn Iface<E> {
     /// FIXME: The reason for binding the socket and the iface together is because there are
     /// limitations inside smoltcp. See discussion at
     /// <https://github.com/smoltcp-rs/smoltcp/issues/779>.
-    pub fn bind_tcp(
+    pub fn bind(
         self: &Arc<Self>,
-        socket: Box<UnboundTcpSocket>,
-        observer: E::TcpEventObserver,
         config: BindPortConfig,
-    ) -> core::result::Result<BoundTcpSocket<E>, (BindError, Box<UnboundTcpSocket>)> {
+    ) -> core::result::Result<BoundPort<E>, BindError> {
         let common = self.common();
-        common.bind_tcp(self.clone(), socket, observer, config)
-    }
-
-    pub fn bind_udp(
-        self: &Arc<Self>,
-        socket: Box<UnboundUdpSocket>,
-        observer: E::UdpEventObserver,
-        config: BindPortConfig,
-    ) -> core::result::Result<BoundUdpSocket<E>, (BindError, Box<UnboundUdpSocket>)> {
-        let common = self.common();
-        common.bind_udp(self.clone(), socket, observer, config)
+        common.bind(self.clone(), config)
     }
 
     /// Gets the name of the iface.

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -9,6 +9,7 @@ mod port;
 mod sched;
 mod time;
 
+pub use common::BoundPort;
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub use port::BindPortConfig;

--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -6,15 +6,12 @@ mod option;
 mod state;
 mod unbound;
 
-pub use bound::{BoundTcpSocket, BoundUdpSocket, ConnectState, NeedIfacePoll};
-pub(crate) use bound::{BoundTcpSocketInner, BoundUdpSocketInner, TcpProcessResult};
+pub use bound::{ConnectState, NeedIfacePoll, TcpConnection, TcpListener, UdpSocket};
+pub(crate) use bound::{TcpConnectionBg, TcpListenerBg, TcpProcessResult, UdpSocketBg};
 pub use event::{SocketEventObserver, SocketEvents};
-pub use option::RawTcpSetOption;
-pub use state::{TcpState, TcpStateCheck};
-pub use unbound::{
-    UnboundTcpSocket, UnboundUdpSocket, TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN,
-    UDP_SEND_PAYLOAD_LEN,
-};
+pub use option::{RawTcpOption, RawTcpSetOption};
+pub use state::TcpStateCheck;
+pub use unbound::{TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN, UDP_SEND_PAYLOAD_LEN};
 
 pub type RawTcpSocket = smoltcp::socket::tcp::Socket<'static>;
 pub type RawUdpSocket = smoltcp::socket::udp::Socket<'static>;

--- a/kernel/libs/keyable-arc/src/lib.rs
+++ b/kernel/libs/keyable-arc/src/lib.rs
@@ -138,8 +138,21 @@ impl<T: ?Sized> KeyableArc<T> {
     }
 
     /// Creates a new `KeyableWeak` pointer to this allocation.
+    #[inline]
     pub fn downgrade(this: &Self) -> KeyableWeak<T> {
         Arc::downgrade(&this.0).into()
+    }
+
+    /// Gets the number of strong pointers pointing to this allocation.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        Arc::strong_count(&this.0)
+    }
+
+    /// Gets the number of weak pointers pointing to this allocation.
+    #[inline]
+    pub fn weak_count(this: &Self) -> usize {
+        Arc::weak_count(&this.0)
     }
 }
 

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -9,5 +9,8 @@ pub use init::{init, IFACES};
 pub use poll::lazy_init;
 
 pub type Iface = dyn aster_bigtcp::iface::Iface<ext::BigtcpExt>;
-pub type BoundTcpSocket = aster_bigtcp::socket::BoundTcpSocket<ext::BigtcpExt>;
-pub type BoundUdpSocket = aster_bigtcp::socket::BoundUdpSocket<ext::BigtcpExt>;
+pub type BoundPort = aster_bigtcp::iface::BoundPort<ext::BigtcpExt>;
+
+pub type TcpConnection = aster_bigtcp::socket::TcpConnection<ext::BigtcpExt>;
+pub type TcpListener = aster_bigtcp::socket::TcpListener<ext::BigtcpExt>;
+pub type UdpSocket = aster_bigtcp::socket::UdpSocket<ext::BigtcpExt>;

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -8,7 +8,7 @@ use aster_bigtcp::{
 use crate::{
     events::IoEvents,
     net::{
-        iface::{BoundUdpSocket, Iface},
+        iface::{Iface, UdpSocket},
         socket::util::send_recv_flags::SendRecvFlags,
     },
     prelude::*,
@@ -16,12 +16,12 @@ use crate::{
 };
 
 pub struct BoundDatagram {
-    bound_socket: BoundUdpSocket,
+    bound_socket: UdpSocket,
     remote_endpoint: Option<IpEndpoint>,
 }
 
 impl BoundDatagram {
-    pub fn new(bound_socket: BoundUdpSocket) -> Self {
+    pub fn new(bound_socket: UdpSocket) -> Self {
         Self {
             bound_socket,
             remote_endpoint: None,

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_bigtcp::{
-    socket::{ConnectState, RawTcpSetOption},
+    socket::{ConnectState, RawTcpOption, RawTcpSetOption},
     wire::IpEndpoint,
 };
 
-use super::{connected::ConnectedStream, init::InitStream};
+use super::{connected::ConnectedStream, init::InitStream, StreamObserver};
 use crate::{
     events::IoEvents,
-    net::iface::{BoundTcpSocket, Iface},
+    net::iface::{BoundPort, Iface, TcpConnection},
     prelude::*,
 };
 
 pub struct ConnectingStream {
-    bound_socket: BoundTcpSocket,
+    tcp_conn: TcpConnection,
     remote_endpoint: IpEndpoint,
 }
 
@@ -25,32 +25,38 @@ pub enum ConnResult {
 
 impl ConnectingStream {
     pub fn new(
-        bound_socket: BoundTcpSocket,
+        bound_port: BoundPort,
         remote_endpoint: IpEndpoint,
-    ) -> core::result::Result<Self, (Error, BoundTcpSocket)> {
+        option: &RawTcpOption,
+        observer: StreamObserver,
+    ) -> core::result::Result<Self, (Error, BoundPort)> {
         // The only reason this method might fail is because we're trying to connect to an
         // unspecified address (i.e. 0.0.0.0). We currently have no support for binding to,
         // listening on, or connecting to the unspecified address.
         //
         // We assume the remote will just refuse to connect, so we return `ECONNREFUSED`.
-        if bound_socket.connect(remote_endpoint).is_err() {
-            return Err((
-                Error::with_message(
-                    Errno::ECONNREFUSED,
-                    "connecting to an unspecified address is not supported",
-                ),
-                bound_socket,
-            ));
-        }
+        let tcp_conn =
+            match TcpConnection::new_connect(bound_port, remote_endpoint, option, observer) {
+                Ok(tcp_conn) => tcp_conn,
+                Err((bound_port, _)) => {
+                    return Err((
+                        Error::with_message(
+                            Errno::ECONNREFUSED,
+                            "connecting to an unspecified address is not supported",
+                        ),
+                        bound_port,
+                    ))
+                }
+            };
 
         Ok(Self {
-            bound_socket,
+            tcp_conn,
             remote_endpoint,
         })
     }
 
     pub fn has_result(&self) -> bool {
-        match self.bound_socket.connect_state() {
+        match self.tcp_conn.connect_state() {
             ConnectState::Connecting => false,
             ConnectState::Connected => true,
             ConnectState::Refused => true,
@@ -58,21 +64,23 @@ impl ConnectingStream {
     }
 
     pub fn into_result(self) -> ConnResult {
-        let next_state = self.bound_socket.connect_state();
+        let next_state = self.tcp_conn.connect_state();
 
         match next_state {
             ConnectState::Connecting => ConnResult::Connecting(self),
             ConnectState::Connected => ConnResult::Connected(ConnectedStream::new(
-                self.bound_socket,
+                self.tcp_conn,
                 self.remote_endpoint,
                 true,
             )),
-            ConnectState::Refused => ConnResult::Refused(InitStream::new_bound(self.bound_socket)),
+            ConnectState::Refused => ConnResult::Refused(InitStream::new_bound(
+                self.tcp_conn.into_bound_port().unwrap(),
+            )),
         }
     }
 
     pub fn local_endpoint(&self) -> IpEndpoint {
-        self.bound_socket.local_endpoint().unwrap()
+        self.tcp_conn.local_endpoint().unwrap()
     }
 
     pub fn remote_endpoint(&self) -> IpEndpoint {
@@ -80,7 +88,7 @@ impl ConnectingStream {
     }
 
     pub fn iface(&self) -> &Arc<Iface> {
-        self.bound_socket.iface()
+        self.tcp_conn.iface()
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {
@@ -88,9 +96,9 @@ impl ConnectingStream {
     }
 
     pub(super) fn set_raw_option<R>(
-        &mut self,
-        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
+        &self,
+        set_option: impl FnOnce(&dyn RawTcpSetOption) -> R,
     ) -> R {
-        set_option(&mut self.bound_socket)
+        set_option(&self.tcp_conn)
     }
 }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -1,43 +1,38 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_bigtcp::{
-    socket::{RawTcpSetOption, UnboundTcpSocket},
-    wire::IpEndpoint,
-};
+use aster_bigtcp::{socket::RawTcpOption, wire::IpEndpoint};
 
 use super::{connecting::ConnectingStream, listen::ListenStream, StreamObserver};
 use crate::{
     events::IoEvents,
     net::{
-        iface::BoundTcpSocket,
-        socket::ip::common::{bind_socket, get_ephemeral_endpoint},
+        iface::BoundPort,
+        socket::ip::common::{bind_port, get_ephemeral_endpoint},
     },
     prelude::*,
-    process::signal::Pollee,
 };
 
 pub enum InitStream {
-    Unbound(Box<UnboundTcpSocket>),
-    Bound(BoundTcpSocket),
+    Unbound,
+    Bound(BoundPort),
 }
 
 impl InitStream {
     pub fn new() -> Self {
-        InitStream::Unbound(Box::new(UnboundTcpSocket::new()))
+        InitStream::Unbound
     }
 
-    pub fn new_bound(bound_socket: BoundTcpSocket) -> Self {
-        InitStream::Bound(bound_socket)
+    pub fn new_bound(bound_port: BoundPort) -> Self {
+        InitStream::Bound(bound_port)
     }
 
     pub fn bind(
         self,
         endpoint: &IpEndpoint,
         can_reuse: bool,
-        observer: StreamObserver,
-    ) -> core::result::Result<BoundTcpSocket, (Error, Self)> {
-        let unbound_socket = match self {
-            InitStream::Unbound(unbound_socket) => unbound_socket,
+    ) -> core::result::Result<BoundPort, (Error, Self)> {
+        match self {
+            InitStream::Unbound => (),
             InitStream::Bound(bound_socket) => {
                 return Err((
                     Error::with_message(Errno::EINVAL, "the socket is already bound to an address"),
@@ -45,48 +40,45 @@ impl InitStream {
                 ));
             }
         };
-        let bound_socket = match bind_socket(
-            unbound_socket,
-            endpoint,
-            can_reuse,
-            |iface, socket, config| iface.bind_tcp(socket, observer, config),
-        ) {
-            Ok(bound_socket) => bound_socket,
-            Err((err, unbound_socket)) => return Err((err, InitStream::Unbound(unbound_socket))),
+
+        let bound_port = match bind_port(endpoint, can_reuse) {
+            Ok(bound_port) => bound_port,
+            Err(err) => return Err((err, Self::Unbound)),
         };
-        Ok(bound_socket)
+
+        Ok(bound_port)
     }
 
     fn bind_to_ephemeral_endpoint(
         self,
         remote_endpoint: &IpEndpoint,
-        observer: StreamObserver,
-    ) -> core::result::Result<BoundTcpSocket, (Error, Self)> {
+    ) -> core::result::Result<BoundPort, (Error, Self)> {
         let endpoint = get_ephemeral_endpoint(remote_endpoint);
-        self.bind(&endpoint, false, observer)
+        self.bind(&endpoint, false)
     }
 
     pub fn connect(
         self,
         remote_endpoint: &IpEndpoint,
-        pollee: &Pollee,
+        option: &RawTcpOption,
+        observer: StreamObserver,
     ) -> core::result::Result<ConnectingStream, (Error, Self)> {
-        let bound_socket = match self {
-            InitStream::Bound(bound_socket) => bound_socket,
-            InitStream::Unbound(_) => self
-                .bind_to_ephemeral_endpoint(remote_endpoint, StreamObserver::new(pollee.clone()))?,
+        let bound_port = match self {
+            InitStream::Bound(bound_port) => bound_port,
+            InitStream::Unbound => self.bind_to_ephemeral_endpoint(remote_endpoint)?,
         };
 
-        ConnectingStream::new(bound_socket, *remote_endpoint)
-            .map_err(|(err, bound_socket)| (err, InitStream::Bound(bound_socket)))
+        ConnectingStream::new(bound_port, *remote_endpoint, option, observer)
+            .map_err(|(err, bound_port)| (err, InitStream::Bound(bound_port)))
     }
 
     pub fn listen(
         self,
         backlog: usize,
-        pollee: &Pollee,
+        option: &RawTcpOption,
+        observer: StreamObserver,
     ) -> core::result::Result<ListenStream, (Error, Self)> {
-        let InitStream::Bound(bound_socket) = self else {
+        let InitStream::Bound(bound_port) = self else {
             // FIXME: The socket should be bound to INADDR_ANY (i.e., 0.0.0.0) with an ephemeral
             // port. However, INADDR_ANY is not yet supported, so we need to return an error first.
             debug_assert!(false, "listen() without bind() is not implemented");
@@ -96,29 +88,18 @@ impl InitStream {
             ));
         };
 
-        ListenStream::new(bound_socket, backlog, pollee)
-            .map_err(|(err, bound_socket)| (err, InitStream::Bound(bound_socket)))
+        Ok(ListenStream::new(bound_port, backlog, option, observer))
     }
 
     pub fn local_endpoint(&self) -> Option<IpEndpoint> {
         match self {
-            InitStream::Unbound(_) => None,
-            InitStream::Bound(bound_socket) => Some(bound_socket.local_endpoint().unwrap()),
+            InitStream::Unbound => None,
+            InitStream::Bound(bound_port) => Some(bound_port.endpoint().unwrap()),
         }
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {
         // Linux adds OUT and HUP events for a newly created socket
         IoEvents::OUT | IoEvents::HUP
-    }
-
-    pub(super) fn set_raw_option<R>(
-        &mut self,
-        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
-    ) -> R {
-        match self {
-            InitStream::Unbound(unbound_socket) => set_option(unbound_socket.as_mut()),
-            InitStream::Bound(bound_socket) => set_option(bound_socket),
-        }
     }
 }

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -1,103 +1,59 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_bigtcp::{
-    errors::tcp::ListenError,
-    iface::BindPortConfig,
-    socket::{RawTcpSetOption, TcpState, UnboundTcpSocket},
+    socket::{RawTcpOption, RawTcpSetOption},
     wire::IpEndpoint,
 };
-use ostd::sync::PreemptDisabled;
 
 use super::{connected::ConnectedStream, StreamObserver};
 use crate::{
     events::IoEvents,
-    net::iface::{BoundTcpSocket, Iface},
+    net::iface::{BoundPort, Iface, TcpListener},
     prelude::*,
-    process::signal::Pollee,
 };
 
 pub struct ListenStream {
-    backlog: usize,
-    /// A bound socket held to ensure the TCP port cannot be released
-    bound_socket: BoundTcpSocket,
-    /// Backlog sockets listening at the local endpoint
-    backlog_sockets: RwLock<Vec<BacklogSocket>, PreemptDisabled>,
+    tcp_listener: TcpListener,
 }
 
 impl ListenStream {
     pub fn new(
-        bound_socket: BoundTcpSocket,
+        bound_port: BoundPort,
         backlog: usize,
-        pollee: &Pollee,
-    ) -> core::result::Result<Self, (Error, BoundTcpSocket)> {
+        option: &RawTcpOption,
+        observer: StreamObserver,
+    ) -> Self {
         const SOMAXCONN: usize = 4096;
-        let somaxconn = SOMAXCONN.min(backlog);
+        let max_conn = SOMAXCONN.min(backlog);
 
-        let listen_stream = Self {
-            backlog: somaxconn,
-            bound_socket,
-            backlog_sockets: RwLock::new(Vec::new()),
+        let tcp_listener = match TcpListener::new_listen(bound_port, max_conn, option, observer) {
+            Ok(tcp_listener) => tcp_listener,
+            Err((_, err)) => {
+                unreachable!("`new_listen` fails with {:?}, which should not happen", err)
+            }
         };
-        if let Err(err) = listen_stream.fill_backlog_sockets(pollee) {
-            return Err((err, listen_stream.bound_socket));
-        }
-        Ok(listen_stream)
+
+        Self { tcp_listener }
     }
 
-    /// Append sockets listening at LocalEndPoint to support backlog
-    fn fill_backlog_sockets(&self, pollee: &Pollee) -> Result<()> {
-        let mut backlog_sockets = self.backlog_sockets.write();
+    pub fn try_accept(&self) -> Result<ConnectedStream> {
+        let (new_conn, remote_endpoint) = self.tcp_listener.accept().ok_or_else(|| {
+            Error::with_message(Errno::EAGAIN, "no pending connection is available")
+        })?;
 
-        let backlog = self.backlog;
-        let current_backlog_len = backlog_sockets.len();
-        debug_assert!(backlog >= current_backlog_len);
-        if backlog == current_backlog_len {
-            return Ok(());
-        }
-
-        for _ in current_backlog_len..backlog {
-            let backlog_socket = BacklogSocket::new(&self.bound_socket, pollee)?;
-            backlog_sockets.push(backlog_socket);
-        }
-
-        Ok(())
-    }
-
-    pub fn try_accept(&self, pollee: &Pollee) -> Result<ConnectedStream> {
-        let mut backlog_sockets = self.backlog_sockets.write();
-
-        let index = backlog_sockets
-            .iter()
-            .position(|backlog_socket| backlog_socket.can_accept())
-            .ok_or_else(|| {
-                Error::with_message(Errno::EAGAIN, "no pending connection is available")
-            })?;
-        let active_backlog_socket = backlog_sockets.remove(index);
-
-        if let Ok(backlog_socket) = BacklogSocket::new(&self.bound_socket, pollee) {
-            backlog_sockets.push(backlog_socket);
-        }
-
-        let remote_endpoint = active_backlog_socket.remote_endpoint().unwrap();
-        Ok(ConnectedStream::new(
-            active_backlog_socket.into_bound_socket(),
-            remote_endpoint,
-            false,
-        ))
+        Ok(ConnectedStream::new(new_conn, remote_endpoint, false))
     }
 
     pub fn local_endpoint(&self) -> IpEndpoint {
-        self.bound_socket.local_endpoint().unwrap()
+        self.tcp_listener.local_endpoint().unwrap()
     }
 
     pub fn iface(&self) -> &Arc<Iface> {
-        self.bound_socket.iface()
+        self.tcp_listener.iface()
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {
-        let backlog_sockets = self.backlog_sockets.read();
-
-        let can_accept = backlog_sockets.iter().any(|socket| socket.can_accept());
+        let can_accept = self.tcp_listener.can_accept();
 
         // If network packets come in simultaneously, the socket state may change in the middle.
         // However, the current pollee implementation should be able to handle this race condition.
@@ -108,97 +64,10 @@ impl ListenStream {
         }
     }
 
-    /// Calls `f` to set socket option on raw socket.
-    ///
-    /// This method will call `f` on the bound socket and each backlog socket that is in `Listen` state  .
     pub(super) fn set_raw_option<R>(
-        &mut self,
-        set_option: impl Fn(&mut dyn RawTcpSetOption) -> R,
+        &self,
+        set_option: impl FnOnce(&dyn RawTcpSetOption) -> R,
     ) -> R {
-        self.backlog_sockets.write().iter_mut().for_each(|socket| {
-            if socket
-                .bound_socket
-                .raw_with(|raw_tcp_socket| raw_tcp_socket.state() != TcpState::Listen)
-            {
-                return;
-            }
-
-            // If the socket receives SYN after above check,
-            // we will also set keep alive on the socket that is not in `Listen` state.
-            // But such a race doesn't matter, we just let it happen.
-            set_option(&mut socket.bound_socket);
-        });
-
-        set_option(&mut self.bound_socket)
-    }
-}
-
-struct BacklogSocket {
-    bound_socket: BoundTcpSocket,
-}
-
-impl BacklogSocket {
-    // FIXME: All of the error codes below seem to have no Linux equivalents, and I see no reason
-    // why the error may occur. Perhaps it is better to call `unwrap()` directly?
-    fn new(bound_socket: &BoundTcpSocket, pollee: &Pollee) -> Result<Self> {
-        let local_endpoint = bound_socket.local_endpoint().ok_or(Error::with_message(
-            Errno::EINVAL,
-            "the socket is not bound",
-        ))?;
-
-        let unbound_socket = {
-            let mut unbound = UnboundTcpSocket::new();
-            unbound.set_keep_alive(bound_socket.raw_with(|socket| socket.keep_alive()));
-            unbound.set_nagle_enabled(bound_socket.raw_with(|socket| socket.nagle_enabled()));
-
-            // TODO: Inherit other options that can be set via `setsockopt` from bound socket
-
-            Box::new(unbound)
-        };
-        let bound_socket = {
-            let iface = bound_socket.iface();
-            let bind_port_config = BindPortConfig::new(local_endpoint.port, true);
-            iface
-                .bind_tcp(
-                    unbound_socket,
-                    StreamObserver::new(pollee.clone()),
-                    bind_port_config,
-                )
-                .map_err(|(err, _)| err)?
-        };
-
-        match bound_socket.listen(local_endpoint) {
-            Ok(()) => Ok(Self { bound_socket }),
-            Err(ListenError::Unaddressable) => {
-                return_errno_with_message!(Errno::EINVAL, "the listening address is invalid")
-            }
-            Err(ListenError::InvalidState) => {
-                return_errno_with_message!(Errno::EINVAL, "the listening socket is invalid")
-            }
-        }
-    }
-
-    /// Returns whether the backlog socket can be `accept`ed.
-    ///
-    /// According to the Linux implementation, assuming the TCP Fast Open mechanism is off, a
-    /// backlog socket becomes ready to be returned in the `accept` system call when the 3-way
-    /// handshake is complete (i.e., when it enters the ESTABLISHED state).
-    ///
-    /// The Linux kernel implementation can be found at
-    /// <https://elixir.bootlin.com/linux/v6.11.8/source/net/ipv4/tcp_input.c#L7304>.
-    //
-    // FIMXE: Some sockets may be dead (e.g., RSTed), and such sockets can never become alive
-    // again. We need to remove them from the backlog sockets.
-    fn can_accept(&self) -> bool {
-        self.bound_socket.raw_with(|socket| socket.may_send())
-    }
-
-    fn remote_endpoint(&self) -> Option<IpEndpoint> {
-        self.bound_socket
-            .raw_with(|socket| socket.remote_endpoint())
-    }
-
-    fn into_bound_socket(self) -> BoundTcpSocket {
-        self.bound_socket
+        set_option(&self.tcp_listener)
     }
 }

--- a/kernel/src/net/socket/ip/stream/observer.rs
+++ b/kernel/src/net/socket/ip/stream/observer.rs
@@ -4,6 +4,7 @@ use aster_bigtcp::socket::{SocketEventObserver, SocketEvents};
 
 use crate::{events::IoEvents, process::signal::Pollee};
 
+#[derive(Clone)]
 pub struct StreamObserver(Pollee);
 
 impl StreamObserver {

--- a/kernel/src/net/socket/ip/stream/options.rs
+++ b/kernel/src/net/socket/ip/stream/options.rs
@@ -9,3 +9,10 @@ impl_socket_options!(
     pub struct MaxSegment(u32);
     pub struct WindowClamp(u32);
 );
+
+/// The keepalive interval.
+///
+/// The linux value can be found at `/proc/sys/net/ipv4/tcp_keepalive_intvl`,
+/// which is by default 75 seconds for most Linux distributions.
+pub(super) const KEEPALIVE_INTERVAL: aster_bigtcp::time::Duration =
+    aster_bigtcp::time::Duration::from_secs(75);

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -173,7 +173,7 @@ impl LingerOption {
 /// A trait used for setting socket level options on actual sockets.
 pub(in crate::net) trait SetSocketLevelOption {
     /// Sets whether keepalive messages are enabled.
-    fn set_keep_alive(&mut self, _keep_alive: bool) -> NeedIfacePoll {
+    fn set_keep_alive(&self, _keep_alive: bool) -> NeedIfacePoll {
         NeedIfacePoll::FALSE
     }
 }


### PR DESCRIPTION
~*Depends on https://github.com/asterinas/asterinas/pull/1688 to avoid merge conflicts*~

This PR splits `BoundTcpSocket` into `TcpListener` and `TcpConnection`.

`TcpListener` is implemented to create a `TcpConnection` when it sees a SYN packet and the number of backlogged connections does not exceed the limit. This avoids creating `backlog` sockets when a listening socket is created, which can significantly degrade performance.

Fixes https://github.com/asterinas/asterinas/issues/457 (See https://github.com/asterinas/asterinas/issues/457#issuecomment-2540818228 and https://github.com/asterinas/asterinas/issues/457#issuecomment-2540832410)