### PR TITLE
Temporarily disable scheduling class support

### DIFF
--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -9,6 +9,8 @@ mod stats;
 // Export the stats getter functions.
 pub use stats::{loadavg, nr_queued_and_running};
 
+// TODO: Use `sched_class::init` instead after the completion of #1676.
+pub use self::priority_scheduler::init;
 // There may be multiple scheduling policies in the system,
 // and subsequent schedulers can be placed under this module.
-pub use self::sched_class::{init, SchedAttr};
+pub use self::sched_class::SchedAttr;


### PR DESCRIPTION
This PR temporarily switches back to the legacy priority scheduler and disables the support of scheduling classes due to the performance regression that is unable to be solved in a relatively short time. The corresponding tracking issue is #1676.