### PR TITLE
Avoid inline comments in variable assignments in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ FEATURES ?=
 # End of auto test features.
 
 # Network settings
-NETDEV ?= user 		# Possible values are user,tap
+# NETDEV possible values are user,tap
+NETDEV ?= user
 VHOST ?= off
 # End of network settings
 
@@ -98,7 +99,8 @@ endif
 ifeq ($(BOOT_PROTOCOL), linux-efi-handover64)
 CARGO_OSDK_ARGS += --grub-mkrescue=/usr/bin/grub-mkrescue
 CARGO_OSDK_ARGS += --grub-boot-protocol="linux"
-CARGO_OSDK_ARGS += --encoding raw # FIXME: GZIP self-decompression triggers CPU faults
+# FIXME: GZIP self-decompression (--encoding gzip) triggers CPU faults
+CARGO_OSDK_ARGS += --encoding raw
 else ifeq ($(BOOT_PROTOCOL), linux-legacy32)
 CARGO_OSDK_ARGS += --linux-x86-legacy-boot
 CARGO_OSDK_ARGS += --grub-boot-protocol="linux"

--- a/test/apps/Makefile
+++ b/test/apps/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
-MAKEFLAGS += --no-builtin-rules # Prevent the implicit rules from compiling ".c" or ".s" files automatically.
+# Prevent the implicit rules from compiling ".c" or ".s" files automatically.
+MAKEFLAGS += --no-builtin-rules
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -28,11 +28,11 @@ LMBENCH_TCP_BW_RAND_PORT=${LMBENCH_TCP_BW_PORT:-$(shuf -i 1024-65535 -n 1)}
 # Optional QEMU arguments. Opt in them manually if needed.
 # QEMU_OPT_ARG_DUMP_PACKETS="-object filter-dump,id=filter0,netdev=net01,file=virtio-net.pcap"
 
-if [[ "$NETDEV" =~ "user" ]]; then
+if [ "$NETDEV" = "user" ]; then
     echo "[$1] Forwarded QEMU guest port: $SSH_RAND_PORT->22; $NGINX_RAND_PORT->8080 $REDIS_RAND_PORT->6379 $IPERF_RAND_PORT->5201 $LMBENCH_TCP_LAT_RAND_PORT->31234 $LMBENCH_TCP_BW_RAND_PORT->31236" 1>&2
     NETDEV_ARGS="-netdev user,id=net01,hostfwd=tcp::$SSH_RAND_PORT-:22,hostfwd=tcp::$NGINX_RAND_PORT-:8080,hostfwd=tcp::$REDIS_RAND_PORT-:6379,hostfwd=tcp::$IPERF_RAND_PORT-:5201,hostfwd=tcp::$LMBENCH_TCP_LAT_RAND_PORT-:31234,hostfwd=tcp::$LMBENCH_TCP_BW_RAND_PORT-:31236"
     VIRTIO_NET_FEATURES=",mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off"
-elif [[ "$NETDEV" =~ "tap" ]]; then 
+elif [ "$NETDEV" = "tap" ]; then
     THIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     QEMU_IFUP_SCRIPT_PATH=$THIS_SCRIPT_DIR/net/qemu-ifup.sh
     QEMU_IFDOWN_SCRIPT_PATH=$THIS_SCRIPT_DIR/net/qemu-ifdown.sh


### PR DESCRIPTION
This PR addresses the misuse of inline comments in Makefile variable assignments.

According to the [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html#tag_20_76_13_05:~:text=after%20the%20%3Cequals%2Dsign%3E%2C%20up%20to%20a%20comment%20character%20(%20%27%23%27%20)%20or%20an%20unescaped%20%3Cnewline%3E), any spaces before a comment character (`#`) are preserved as part of the value assigned. This can lead to unexpected behavior and make it hard to detect when variable values are used in subsequent commands.

Example: <https://stackoverflow.com/questions/9953825/trailing-comments-after-variable-assignment-subvert-comparison>.

Additionally, the `=~` operator in `qemu_args.sh` (`[[ "$NETDEV" =~ "user" ]]`) was replaced with `=` for equality comparison to avoid unintended matches caused by regex behavior. For example, with `=~`, "hello, user." would also match "user", which is not the desired behavior.