### PR TITLE
Fix random CI failures in network tests

### DIFF
--- a/test/apps/scripts/network.sh
+++ b/test/apps/scripts/network.sh
@@ -10,17 +10,25 @@ cd ${NETTEST_DIR}
 echo "Start network test......"
 
 ./tcp_server &
+sleep 0.2
 ./tcp_client
+
 ./udp_server &
+sleep 0.2
 ./udp_client
+
 ./unix_server &
+sleep 0.2
 ./unix_client
+
+./http_server &
+sleep 0.2
+./http_client
+
 ./socketpair
 ./sockoption
 ./listen_backlog
 ./send_buf_full
-./http_server &
-./http_client
 ./tcp_err
 ./tcp_poll
 ./udp_err


### PR DESCRIPTION
The [CI failures](https://github.com/asterinas/asterinas/actions/runs/12172909286/job/33952384565) [happen](https://github.com/asterinas/asterinas/actions/runs/12248401205/job/34167947586) [frequently](https://github.com/asterinas/asterinas/actions/runs/12222771131/job/34093470958).

https://github.com/asterinas/asterinas/blob/00e3688aa8945e09a48e85013ab73900490db7ad/test/apps/scripts/network.sh#L12-L13

It looks like `tcp_client` can run before `tcp_server` starts listening, so `connect` in `tcp_client` may fail. Let's add a `sleep` in between to prevent that from happening.