### PR TITLE
Add various device and other supports for RISC-V

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -77,7 +77,7 @@ boot.method = "qemu-direct"
 build.strip_elf = false
 
 qemu.args = """\
-    -cpu rv64,zba=true,zbb=true \
+    -cpu rv64,zba=true,zbb=true,svpbmt=true \
     -machine virt \
     -m 8G \
     --no-reboot \

--- a/kernel/src/arch/riscv/mod.rs
+++ b/kernel/src/arch/riscv/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod cpu;
 pub mod signal;
+pub mod stat;

--- a/kernel/src/arch/riscv/stat.rs
+++ b/kernel/src/arch/riscv/stat.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{fs::utils::Metadata, prelude::*, time::timespec_t};
+
+#[derive(Debug, Clone, Copy, Pod, Default)]
+#[repr(C)]
+pub struct Stat {
+    /// ID of device containing file
+    st_dev: u64,
+    /// Inode number
+    st_ino: u64,
+    /// File type and mode
+    st_mode: u32,
+    /// Number of hard links
+    st_nlink: u32,
+    /// User ID of owner
+    st_uid: u32,
+    /// Group ID of owner
+    st_gid: u32,
+    /// Device ID (if special file)
+    st_rdev: u64,
+    /// Padding bytes
+    __pad0: u64,
+    /// Total size, in bytes
+    st_size: isize,
+    /// Block size for filesystem I/O
+    st_blksize: isize,
+    /// Number of 512-byte blocks allocated
+    st_blocks: isize,
+    /// Time of last access
+    st_atime: timespec_t,
+    /// Time of last modification
+    st_mtime: timespec_t,
+    /// Time of last status change
+    st_ctime: timespec_t,
+    /// Unused field
+    __unused: [u32; 2],
+}
+
+impl From<Metadata> for Stat {
+    fn from(info: Metadata) -> Self {
+        Self {
+            st_dev: info.dev,
+            st_ino: info.ino,
+            st_nlink: info.nlinks as u32,
+            st_mode: info.type_ as u32 | info.mode.bits() as u32,
+            st_uid: info.uid.into(),
+            st_gid: info.gid.into(),
+            __pad0: 0,
+            st_rdev: info.rdev,
+            st_size: info.size as isize,
+            st_blksize: info.blk_size as isize,
+            st_blocks: (info.blocks * (info.blk_size / 512)) as isize, // Number of 512B blocks
+            st_atime: info.atime.into(),
+            st_mtime: info.mtime.into(),
+            st_ctime: info.ctime.into(),
+            __unused: [0; 2],
+        }
+    }
+}

--- a/kernel/src/arch/x86/mod.rs
+++ b/kernel/src/arch/x86/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod cpu;
 pub mod signal;
+pub mod stat;

--- a/kernel/src/arch/x86/stat.rs
+++ b/kernel/src/arch/x86/stat.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{fs::utils::Metadata, prelude::*, time::timespec_t};
+
+/// File Stat
+#[derive(Debug, Clone, Copy, Pod, Default)]
+#[repr(C)]
+pub struct Stat {
+    /// ID of device containing file
+    st_dev: u64,
+    /// Inode number
+    st_ino: u64,
+    /// Number of hard links
+    st_nlink: usize,
+    /// File type and mode
+    st_mode: u32,
+    /// User ID of owner
+    st_uid: u32,
+    /// Group ID of owner
+    st_gid: u32,
+    /// Padding bytes
+    __pad0: u32,
+    /// Device ID (if special file)
+    st_rdev: u64,
+    /// Total size, in bytes
+    st_size: isize,
+    /// Block size for filesystem I/O
+    st_blksize: isize,
+    /// Number of 512-byte blocks allocated
+    st_blocks: isize,
+    /// Time of last access
+    st_atime: timespec_t,
+    /// Time of last modification
+    st_mtime: timespec_t,
+    /// Time of last status change
+    st_ctime: timespec_t,
+    /// Unused field
+    __unused: [i64; 3],
+}
+
+impl From<Metadata> for Stat {
+    fn from(info: Metadata) -> Self {
+        Self {
+            st_dev: info.dev,
+            st_ino: info.ino,
+            st_nlink: info.nlinks,
+            st_mode: info.type_ as u32 | info.mode.bits() as u32,
+            st_uid: info.uid.into(),
+            st_gid: info.gid.into(),
+            __pad0: 0,
+            st_rdev: info.rdev,
+            st_size: info.size as isize,
+            st_blksize: info.blk_size as isize,
+            st_blocks: (info.blocks * (info.blk_size / 512)) as isize, // Number of 512B blocks
+            st_atime: info.atime.into(),
+            st_mtime: info.mtime.into(),
+            st_ctime: info.ctime.into(),
+            __unused: [0; 3],
+        }
+    }
+}

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -2,14 +2,13 @@
 
 use super::SyscallReturn;
 use crate::{
+    arch::stat::Stat,
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
-        utils::Metadata,
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
-    time::timespec_t,
 };
 
 pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
@@ -76,64 +75,6 @@ pub fn sys_fstatat(
     let stat = Stat::from(dentry.metadata());
     user_space.write_val(stat_buf_ptr, &stat)?;
     Ok(SyscallReturn::Return(0))
-}
-
-/// File Stat
-#[derive(Debug, Clone, Copy, Pod, Default)]
-#[repr(C)]
-pub struct Stat {
-    /// ID of device containing file
-    st_dev: u64,
-    /// Inode number
-    st_ino: u64,
-    /// Number of hard links
-    st_nlink: usize,
-    /// File type and mode
-    st_mode: u32,
-    /// User ID of owner
-    st_uid: u32,
-    /// Group ID of owner
-    st_gid: u32,
-    /// Padding bytes
-    __pad0: u32,
-    /// Device ID (if special file)
-    st_rdev: u64,
-    /// Total size, in bytes
-    st_size: isize,
-    /// Block size for filesystem I/O
-    st_blksize: isize,
-    /// Number of 512-byte blocks allocated
-    st_blocks: isize,
-    /// Time of last access
-    st_atime: timespec_t,
-    /// Time of last modification
-    st_mtime: timespec_t,
-    /// Time of last status change
-    st_ctime: timespec_t,
-    /// Unused field
-    __unused: [i64; 3],
-}
-
-impl From<Metadata> for Stat {
-    fn from(info: Metadata) -> Self {
-        Self {
-            st_dev: info.dev,
-            st_ino: info.ino,
-            st_nlink: info.nlinks,
-            st_mode: info.type_ as u32 | info.mode.bits() as u32,
-            st_uid: info.uid.into(),
-            st_gid: info.gid.into(),
-            __pad0: 0,
-            st_rdev: info.rdev,
-            st_size: info.size as isize,
-            st_blksize: info.blk_size as isize,
-            st_blocks: (info.blocks * (info.blk_size / 512)) as isize, // Number of 512B blocks
-            st_atime: info.atime.into(),
-            st_mtime: info.mtime.into(),
-            st_ctime: info.ctime.into(),
-            __unused: [0; 3],
-        }
-    }
 }
 
 bitflags::bitflags! {

--- a/osdk/src/base_crate/riscv64.ld.template
+++ b/osdk/src/base_crate/riscv64.ld.template
@@ -17,6 +17,16 @@ SECTIONS
         PROVIDE(__etext = .);
     }
 
+    # The section to store exception table (ExTable).
+    # This table is used for recovering from specific exception handling faults
+    # occurring at known points in the code.
+    # Ref: /ostd/src/arch/riscv/ex_table.rs
+    .ex_table               : AT(ADDR(.ex_table) - KERNEL_VMA_OFFSET) {
+        __ex_table = .;
+        KEEP(*(SORT(.ex_table)))
+        __ex_table_end = .;
+    }
+
     .rodata : AT(ADDR(.rodata) - KERNEL_VMA_OFFSET) { *(.rodata .rodata.*) }
 
     .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA_OFFSET) {

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -11,7 +11,7 @@ use riscv::register::scause::{Exception, Interrupt, Trap};
 pub use super::trap::GeneralRegs as RawGeneralRegs;
 use super::{
     irq::TIMER_IRQ_LINE,
-    trap::{TrapFrame, UserContext as RawUserContext},
+    trap::{handle_external_interrupts, TrapFrame, UserContext as RawUserContext},
 };
 use crate::{
     task::scheduler,
@@ -125,6 +125,9 @@ impl UserContextApiInternal for UserContext {
             match riscv::register::scause::read().cause() {
                 Trap::Interrupt(Interrupt::SupervisorTimer) => {
                     call_irq_callback_functions(&self.as_trap_frame(), TIMER_IRQ_LINE)
+                }
+                Trap::Interrupt(Interrupt::SupervisorExternal) => {
+                    handle_external_interrupts(&self.as_trap_frame())
                 }
                 Trap::Interrupt(_) => todo!(),
                 Trap::Exception(Exception::UserEnvCall) => {

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -6,11 +6,18 @@ pub mod local;
 
 use core::fmt::Debug;
 
-use riscv::register::scause::{Exception, Trap};
+use riscv::register::scause::{Exception, Interrupt, Trap};
 
 pub use super::trap::GeneralRegs as RawGeneralRegs;
-use super::trap::{TrapFrame, UserContext as RawUserContext};
-use crate::user::{ReturnReason, UserContextApi, UserContextApiInternal};
+use super::{
+    irq::TIMER_IRQ_LINE,
+    trap::{TrapFrame, UserContext as RawUserContext},
+};
+use crate::{
+    task::scheduler,
+    trap::call_irq_callback_functions,
+    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+};
 
 /// Cpu context, including both general-purpose registers and floating-point registers.
 #[derive(Clone, Copy, Debug)]
@@ -113,8 +120,12 @@ impl UserContextApiInternal for UserContext {
         F: FnMut() -> bool,
     {
         let ret = loop {
+            scheduler::might_preempt();
             self.user_context.run();
             match riscv::register::scause::read().cause() {
+                Trap::Interrupt(Interrupt::SupervisorTimer) => {
+                    call_irq_callback_functions(&self.as_trap_frame(), TIMER_IRQ_LINE)
+                }
                 Trap::Interrupt(_) => todo!(),
                 Trap::Exception(Exception::UserEnvCall) => {
                     self.user_context.sepc += 4;

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -35,8 +35,12 @@ pub struct CpuExceptionInfo {
 
 impl Default for UserContext {
     fn default() -> Self {
+        let mut user_context = RawUserContext::default();
+        user_context.sstatus |= (riscv::register::sstatus::FS::Clean as usize) << 13;
+        // TODO: save floating registers on context/task switch
+
         UserContext {
-            user_context: RawUserContext::default(),
+            user_context,
             trap: Trap::Exception(Exception::Unknown),
             fp_regs: (),
             cpu_exception_info: CpuExceptionInfo::default(),

--- a/ostd/src/arch/riscv/device/mod.rs
+++ b/ostd/src/arch/riscv/device/mod.rs
@@ -4,3 +4,21 @@
 //! This module mainly contains the APIs that should exposed to the device driver like PCI, RTC
 
 pub mod io_port;
+pub(crate) mod plic;
+
+use crate::{
+    io_mem::IoMem,
+    mm::page_prop::{CachePolicy, PageFlags},
+};
+
+pub(crate) fn init() {
+    plic::init();
+}
+
+pub(self) unsafe fn create_device_io_mem(starting_address: *const u8, size: usize) -> IoMem {
+    IoMem::new(
+        (starting_address as usize)..(starting_address as usize) + size,
+        PageFlags::RW,
+        CachePolicy::Uncacheable,
+    )
+}

--- a/ostd/src/arch/riscv/device/plic.rs
+++ b/ostd/src/arch/riscv/device/plic.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZeroU16;
+
+use bit_field::BitField;
+use fdt::{node::FdtNode, Fdt};
+use riscv::register::scause::Interrupt;
+use spin::Once;
+
+use crate::{
+    arch::boot::DEVICE_TREE, cpu::CpuId, cpu_local, io_mem::IoMem, mm::VmIoOnce, sync::SpinLock,
+    trap,
+};
+
+const PRIORITY_BASE: usize = 0x000000;
+const PRIORITY_PER_SOURCE: usize = 0x000004;
+const ENABLE_BASE: usize = 0x002000;
+const ENABLE_PER_HART: usize = 0x000080;
+const CONTEXT_BASE: usize = 0x200000;
+const CONTEXT_PER_HART: usize = 0x001000;
+const THRESHOLD_OFFSET: usize = 0x000000;
+const CLAIM_OFFSET: usize = 0x000004;
+
+cpu_local! {
+    static PLIC_HANDLER: Once<PlicHandler> = Once::new();
+}
+
+static PLIC_IOMEM: Once<IoMem> = Once::new();
+
+pub struct PlicHandler {
+    pub context_id: usize,
+    pub hart_base: usize,
+    pub enable_base: usize,
+}
+
+pub fn set_priority(id: u16, priority: u32) {
+    let io_mem = PLIC_IOMEM.get().unwrap();
+    let offset = PRIORITY_BASE + id as usize * PRIORITY_PER_SOURCE;
+    io_mem.write_once(offset, &priority).unwrap();
+}
+
+pub fn set_interrupt_enabled_on(cpu: CpuId, id: u16, enabled: bool) {
+    let handler = PLIC_HANDLER.get_on_cpu(cpu).get().unwrap();
+    let io_mem = PLIC_IOMEM.get().unwrap();
+
+    let offset = handler.enable_base + (id as usize / 32) * 4;
+    let mut value: u32 = io_mem.read_once(offset).unwrap();
+    value.set_bit(id as usize % 32, enabled);
+    io_mem.write_once(offset, &value).unwrap();
+}
+
+pub fn claim_interrupt() -> Option<NonZeroU16> {
+    let io_mem = PLIC_IOMEM.get().unwrap();
+    let irq_guard = trap::disable_local();
+
+    let offset = PLIC_HANDLER.get_with(&irq_guard).get().unwrap().hart_base + CLAIM_OFFSET;
+    NonZeroU16::new(io_mem.read_once::<u32>(offset).unwrap() as u16)
+}
+
+pub fn complete_interrupt(id: u16) {
+    let io_mem = PLIC_IOMEM.get().unwrap();
+    let irq_guard = trap::disable_local();
+
+    let offset = PLIC_HANDLER.get_with(&irq_guard).get().unwrap().hart_base + CLAIM_OFFSET;
+    io_mem.write_once(offset, &(id as u32)).unwrap();
+}
+
+pub fn set_priority_threshold_on(cpu: CpuId, threshold: u32) {
+    let handler = PLIC_HANDLER.get_on_cpu(cpu).get().unwrap();
+    let io_mem = PLIC_IOMEM.get().unwrap();
+
+    let offset = handler.hart_base + THRESHOLD_OFFSET;
+    io_mem.write_once(offset, &threshold).unwrap();
+}
+
+/// Enable target external interrupt
+pub fn enable_external_interrupt(id: u16) {
+    // we only enable for cpu 0 for now.
+    set_interrupt_enabled_on(CpuId::bsp(), id, true);
+    set_priority(id, 1);
+    set_priority_threshold_on(CpuId::bsp(), 0);
+}
+
+pub(super) fn init() {
+    let fdt = DEVICE_TREE.get().unwrap();
+    let plic = fdt.find_node("/soc/plic").unwrap();
+    let region = plic.reg().unwrap().next().unwrap();
+    PLIC_IOMEM.call_once(|| unsafe {
+        super::create_device_io_mem(region.starting_address, region.size.unwrap())
+    });
+
+    log::debug!("PLIC is found on {:#x?}", region.starting_address);
+
+    let interrupts_ext = plic.property("interrupts-extended").unwrap().value;
+    let mut cell_iter = interrupts_ext
+        .chunks_exact(4)
+        .map(|b| u32::from_be_bytes(b.try_into().unwrap()));
+
+    for context_id in 0.. {
+        let Some(phandle) = cell_iter.next() else {
+            break;
+        };
+        if phandle == 0 {
+            continue;
+        }
+
+        let (cpu, intc) = find_cpu_with_intc_phandle(&fdt, phandle).unwrap();
+
+        let cell_count = intc.interrupt_cells().unwrap();
+        assert!(cell_count >= 1);
+        let cause = cell_iter.next().unwrap();
+        // consume remaining cells
+        for _ in 1..cell_count {
+            cell_iter.next().unwrap();
+        }
+
+        if cause != Interrupt::SupervisorExternal as u32 {
+            continue;
+        }
+
+        let hartid = cpu.property("reg").unwrap().as_usize().unwrap() as usize;
+        log::debug!("Register PLIC context {context_id} on CPU {hartid}, with interrupt {cause}");
+
+        let mut handler = PLIC_HANDLER.get_on_cpu(hartid.try_into().unwrap());
+        handler.call_once(|| PlicHandler {
+            context_id,
+            hart_base: CONTEXT_BASE + CONTEXT_PER_HART * context_id,
+            enable_base: ENABLE_BASE + ENABLE_PER_HART * context_id,
+        });
+    }
+
+    unsafe {
+        riscv::register::sie::set_sext();
+    }
+}
+
+fn find_cpu_with_intc_phandle<'b, 'a: 'b>(
+    fdt: &'b Fdt<'a>,
+    phandle: u32,
+) -> Option<(FdtNode<'b, 'a>, FdtNode<'b, 'a>)> {
+    for cpu in fdt.find_all_nodes("/cpus/cpu") {
+        if let Some(intc) = cpu.children().find(|node| {
+            node.compatible()
+                .is_some_and(|compat| compat.all().any(|c| c == "riscv,cpu-intc"))
+        }) && intc
+            .property("phandle")
+            .is_some_and(|p| p.as_usize().unwrap() as u32 == phandle)
+        {
+            return Some((cpu, intc));
+        }
+    }
+    None
+}

--- a/ostd/src/arch/riscv/ex_table.rs
+++ b/ostd/src/arch/riscv/ex_table.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::Vaddr;
+
+#[repr(C)]
+struct ExTableItem {
+    inst_addr: Vaddr,
+    recovery_inst_addr: Vaddr,
+}
+
+extern "C" {
+    fn __ex_table();
+    fn __ex_table_end();
+}
+
+/// A structure representing the usage of exception table (ExTable).
+/// This table is used for recovering from specific exception handling faults
+/// occurring at known points in the code.
+///
+/// To add a recovery instruction for a target assembly instruction, one should add
+/// the following statements:
+///
+/// ```
+/// .pushsection .ex_table, "a"
+/// .align 8
+/// .quad [.target_label],
+/// .quad [.recovery_label],
+/// .popsection
+/// ```
+///
+/// where the `target_label` and `recovery_label` are the labels of the target instruction
+/// and the label of recovery instruction respectively.
+///
+/// For example, we have the following assembly code snippets in an input file:
+/// ```
+/// .label1:
+///     sb     a1, t0(a0)
+///     addi   t0, t0, 1
+///     bltu   t0, a2, label1
+/// .label2:
+///     ret
+/// ```
+///
+/// We can add the following statements in the same file (`label1` and `label2` are local
+/// labels):
+///
+/// ```
+/// .pushsection .ex_table, "a"
+/// .align 8
+/// .quad [.label1],
+/// .quad [.label2],
+/// .popsection
+/// ```
+///
+/// After that, we can use the API of `ExTable` to resume execution when handling
+/// exceptions caused by `rep movsb` (which `label1` point to) failing.
+pub(crate) struct ExTable;
+
+impl ExTable {
+    /// Finds the recovery instruction address for a given instruction address.
+    ///
+    /// This function is generally used when an exception (such as a page fault) occurs.
+    /// if the exception handling fails and there is a predefined recovery action,
+    /// then the found recovery action will be taken.
+    pub fn find_recovery_inst_addr(inst_addr: Vaddr) -> Option<Vaddr> {
+        let table_size =
+            (__ex_table_end as usize - __ex_table as usize) / core::mem::size_of::<ExTableItem>();
+        // SAFETY: `__ex_table` is a static section consisting of `ExTableItem`.
+        let ex_table =
+            unsafe { core::slice::from_raw_parts(__ex_table as *const ExTableItem, table_size) };
+        for item in ex_table {
+            if item.inst_addr == inst_addr {
+                return Some(item.recovery_inst_addr);
+            }
+        }
+        None
+    }
+}

--- a/ostd/src/arch/riscv/iommu/mod.rs
+++ b/ostd/src/arch/riscv/iommu/mod.rs
@@ -28,6 +28,10 @@ pub(crate) fn init() -> Result<(), IommuError> {
     Err(IommuError::NoIommu)
 }
 
+pub fn has_interrupt_remapping() -> bool {
+    false
+}
+
 pub(crate) fn has_dma_remapping() -> bool {
     false
 }

--- a/ostd/src/arch/riscv/irq.rs
+++ b/ostd/src/arch/riscv/irq.rs
@@ -9,9 +9,34 @@ use spin::Once;
 
 use crate::{
     cpu::CpuId,
-    sync::{Mutex, PreemptDisabled, SpinLock, SpinLockGuard},
+    prelude::*,
+    sync::{LocalIrqDisabled, Mutex, PreemptDisabled, SpinLock, SpinLockGuard},
     trap::TrapFrame,
 };
+
+pub struct IrtEntry;
+
+impl IrtEntry {
+    pub fn enable_default(&mut self, vector: u32) {
+        unimplemented!()
+    }
+}
+
+pub struct IrtEntryHandle;
+
+impl IrtEntryHandle {
+    pub fn index(&self) -> u16 {
+        unimplemented!()
+    }
+
+    pub fn irt_entry(&self) -> Option<&IrtEntry> {
+        unimplemented!()
+    }
+
+    pub fn irt_entry_mut(&mut self) -> Option<&mut IrtEntry> {
+        unimplemented!()
+    }
+}
 
 /// The global allocator for software defined IRQ lines.
 pub(crate) static IRQ_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
@@ -84,6 +109,10 @@ impl IrqLine {
     #[allow(clippy::redundant_allocation)]
     pub unsafe fn acquire(irq_num: u8) -> Arc<&'static Self> {
         Arc::new(IRQ_LIST.get().unwrap().get(irq_num as usize).unwrap())
+    }
+
+    pub fn bind_remapping_entry(&self) -> Option<&Arc<SpinLock<IrtEntryHandle, LocalIrqDisabled>>> {
+        None
     }
 
     /// Get the IRQ number.

--- a/ostd/src/arch/riscv/irq.rs
+++ b/ostd/src/arch/riscv/irq.rs
@@ -18,6 +18,9 @@ pub(crate) static IRQ_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
 
 pub(crate) static IRQ_LIST: Once<Vec<IrqLine>> = Once::new();
 
+// FIXME: use properly managed irq number
+pub(crate) const TIMER_IRQ_LINE: usize = 128;
+
 pub(crate) fn init() {
     let mut list: Vec<IrqLine> = Vec::new();
     for i in 0..256 {

--- a/ostd/src/arch/riscv/mm/memcpy_fallible.S
+++ b/ostd/src/arch/riscv/mm/memcpy_fallible.S
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// Status register flags
+SR_SUM = 0x00040000
+
+// Sets `size` bytes of memory at `dst` to the byte value given by `value`.
+// This function works with exception handling and can recover from a page fault.
+//
+// Returns number of bytes that failed to set.
+.text
+.global __memcpy_fallible
+__memcpy_fallible: # (dst: *mut u8, src: *const u8, size: usize) -> usize
+    // Enable user memory access
+    li     t2, SR_SUM
+    csrs   sstatus, t2
+
+    add    t0, a0, a2      # Mark the end of the region
+
+1:
+    bgeu   a0, t0, memcpy_exit
+load:
+    lbu    t1, 0(a1)
+store:
+    sb     t1, 0(a0)
+    addi   a0, a0, 1
+    addi   a1, a1, 1
+    j      1b
+
+memcpy_exit:
+    csrc   sstatus, t2
+    sub    a0, t0, a0
+    ret
+
+.pushsection .ex_table, "a"
+    .align 8
+    .quad load, memcpy_exit
+    .quad store, memcpy_exit
+.popsection

--- a/ostd/src/arch/riscv/mm/memset_fallible.S
+++ b/ostd/src/arch/riscv/mm/memset_fallible.S
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// Status register flags
+SR_SUM = 0x00040000
+
+// Sets `size` bytes of memory at `dst` to the byte value given by `value`.
+// This function works with exception handling and can recover from a page fault.
+//
+// Returns number of bytes that failed to set.
+.text
+.global __memset_fallible
+__memset_fallible: # (dst: *mut u8, value: u8, size: usize) -> usize
+    // Enable user memory access
+    li     t2, SR_SUM
+    csrs   sstatus, t2
+
+    add    t0, a0, a2      # Mark the end of the region
+
+1:
+    bgeu   a0, t0, memset_exit
+set:
+    sb     a1, (a0)
+    addi   a0, a0, 1
+    j      1b
+
+memset_exit:
+    csrc   sstatus, t2
+    sub    a0, t0, a0
+    ret
+
+.pushsection .ex_table, "a"
+    .align 8
+    .quad set, memset_exit
+.popsection

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -3,6 +3,8 @@
 use alloc::fmt;
 use core::ops::Range;
 
+pub(crate) use util::{__memcpy_fallible, __memset_fallible};
+
 use crate::{
     mm::{
         page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags as PrivFlags},
@@ -11,6 +13,8 @@ use crate::{
     },
     Pod,
 };
+
+mod util;
 
 pub(crate) const NR_ENTRIES_PER_PAGE: usize = 512;
 
@@ -208,22 +212,4 @@ impl fmt::Debug for PageTableEntry {
             .field("prop", &self.prop())
             .finish()
     }
-}
-
-pub(crate) fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize {
-    // TODO: implement fallible
-    unsafe {
-        riscv::register::sstatus::set_sum();
-    }
-    unsafe { core::ptr::copy(src, dst, size) };
-    0
-}
-
-pub(crate) fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize {
-    // TODO: implement fallible
-    unsafe {
-        riscv::register::sstatus::set_sum();
-    }
-    unsafe { core::ptr::write_bytes(dst, value, size) };
-    0
 }

--- a/ostd/src/arch/riscv/mm/util.rs
+++ b/ostd/src/arch/riscv/mm/util.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+core::arch::global_asm!(include_str!("memcpy_fallible.S"));
+core::arch::global_asm!(include_str!("memset_fallible.S"));
+
+extern "C" {
+    /// Copies `size` bytes from `src` to `dst`. This function works with exception handling
+    /// and can recover from page fault.
+    /// Returns number of bytes that failed to copy.
+    pub(crate) fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize;
+    /// Fills `size` bytes in the memory pointed to by `dst` with the value `value`.
+    /// This function works with exception handling and can recover from page fault.
+    /// Returns number of bytes that failed to set.
+    pub(crate) fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize;
+}

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -40,6 +40,8 @@ pub(crate) fn init_on_bsp() {
     // we are on the BSP.
     unsafe { crate::cpu::local::init_on_bsp() };
 
+    device::init();
+
     crate::boot::smp::boot_all_aps();
 
     timer::init();
@@ -51,7 +53,7 @@ pub(crate) unsafe fn init_on_ap() {
 
 pub(crate) fn interrupts_ack(irq_number: usize) {
     if irq_number != irq::TIMER_IRQ_LINE {
-        unimplemented!()
+        device::plic::complete_interrupt(irq_number as u16);
     }
 }
 

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -50,7 +50,9 @@ pub(crate) unsafe fn init_on_ap() {
 }
 
 pub(crate) fn interrupts_ack(irq_number: usize) {
-    unimplemented!()
+    if irq_number != irq::TIMER_IRQ_LINE {
+        unimplemented!()
+    }
 }
 
 /// Return the frequency of TSC. The unit is Hz.

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -5,6 +5,7 @@
 pub mod boot;
 pub(crate) mod cpu;
 pub mod device;
+pub(crate) mod ex_table;
 pub mod iommu;
 pub(crate) mod irq;
 pub(crate) mod mm;

--- a/ostd/src/arch/riscv/timer/mod.rs
+++ b/ostd/src/arch/riscv/timer/mod.rs
@@ -6,7 +6,11 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use spin::Once;
 
-use crate::{arch::boot::DEVICE_TREE, io_mem::IoMem};
+use crate::{
+    arch::boot::DEVICE_TREE,
+    io_mem::IoMem,
+    mm::page_prop::{CachePolicy, PageFlags},
+};
 
 /// The timer frequency (Hz). Here we choose 1000Hz since 1000Hz is easier for unit conversion and
 /// convenient for timer. What's more, the frequency cannot be set too high or too low, 1000Hz is
@@ -40,6 +44,8 @@ pub(super) fn init() {
             IoMem::new(
                 (region.starting_address as usize)
                     ..(region.starting_address as usize) + region.size.unwrap(),
+                PageFlags::RW,
+                CachePolicy::Uncacheable,
             )
         };
         GOLDFISH_IO_MEM.call_once(|| io_mem);

--- a/ostd/src/arch/riscv/timer/mod.rs
+++ b/ostd/src/arch/riscv/timer/mod.rs
@@ -7,9 +7,11 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Once;
 
 use crate::{
-    arch::boot::DEVICE_TREE,
+    arch::{boot::DEVICE_TREE, irq::TIMER_IRQ_LINE},
     io_mem::IoMem,
     mm::page_prop::{CachePolicy, PageFlags},
+    timer::INTERRUPT_CALLBACKS,
+    trap::{self, IrqLine, TrapFrame},
 };
 
 /// The timer frequency (Hz). Here we choose 1000Hz since 1000Hz is easier for unit conversion and
@@ -21,11 +23,18 @@ use crate::{
 pub const TIMER_FREQ: u64 = 1000;
 
 pub(crate) static TIMEBASE_FREQ: AtomicU64 = AtomicU64::new(1);
+static TIMER_STEP: AtomicU64 = AtomicU64::new(1);
+static TIMER_IRQ: Once<IrqLine> = Once::new();
 
 /// [`IoMem`] of goldfish RTC, which will be used by `aster-time`.
 pub static GOLDFISH_IO_MEM: Once<IoMem> = Once::new();
 
 pub(super) fn init() {
+    init_timer();
+    init_rtc();
+}
+
+fn init_timer() {
     let timer_freq = DEVICE_TREE
         .get()
         .unwrap()
@@ -33,8 +42,42 @@ pub(super) fn init() {
         .next()
         .unwrap()
         .timebase_frequency() as u64;
+    let timer_step = timer_freq / TIMER_FREQ;
     TIMEBASE_FREQ.store(timer_freq, Ordering::Relaxed);
+    TIMER_STEP.store(timer_step, Ordering::Relaxed);
 
+    set_next_timer();
+    unsafe {
+        riscv::register::sie::set_stimer();
+    }
+
+    let mut irq = IrqLine::alloc_specific(TIMER_IRQ_LINE as u8).unwrap();
+    irq.on_active(timer_callback);
+    TIMER_IRQ.call_once(|| irq);
+
+    log::debug!("Timer initialized with frequency: {timer_freq} Hz, timer step: {timer_step} Hz",);
+}
+
+fn set_next_timer() {
+    let timer_step = TIMER_STEP.load(Ordering::Relaxed);
+    let now = riscv::register::time::read64();
+    sbi_rt::set_timer(now + timer_step);
+}
+
+pub(crate) fn timer_callback(_: &TrapFrame) {
+    crate::timer::jiffies::ELAPSED.fetch_add(1, Ordering::SeqCst);
+
+    let irq_guard = trap::disable_local();
+    let callbacks_guard = INTERRUPT_CALLBACKS.get_with(&irq_guard);
+    for callback in callbacks_guard.borrow().iter() {
+        (callback)();
+    }
+    drop(callbacks_guard);
+
+    set_next_timer();
+}
+
+fn init_rtc() {
     let chosen = DEVICE_TREE.get().unwrap().find_node("/soc/rtc").unwrap();
     if let Some(compatible) = chosen.compatible()
         && compatible.all().any(|c| c == "google,goldfish-rtc")

--- a/ostd/src/arch/riscv/trap/trap.S
+++ b/ostd/src/arch/riscv/trap/trap.S
@@ -74,6 +74,7 @@ trap_from_user:
     STORE_SP t1, 32         # save sstatus
     STORE_SP t2, 33         # save sepc
 
+    # FIXME: remove kernel floating support once related usage is dropped
     li t0, 3 << 13
     or t1, t1, t0           # sstatus.FS = Dirty (3)
     csrw sstatus, t1

--- a/ostd/src/bus/mmio/mod.rs
+++ b/ostd/src/bus/mmio/mod.rs
@@ -53,7 +53,7 @@ pub(crate) fn init() {
 
 #[cfg(target_arch = "riscv64")]
 fn riscv64_mmio_probe() {
-    use crate::arch::boot::DEVICE_TREE;
+    use crate::arch::{boot::DEVICE_TREE, device::plic::enable_external_interrupt};
 
     let mut lock = MMIO_BUS.lock();
     for node in DEVICE_TREE
@@ -69,6 +69,7 @@ fn riscv64_mmio_probe() {
             region.starting_address,
             interrupt
         );
+        enable_external_interrupt(interrupt as u16);
 
         let device = MmioCommonDevice::new(region.starting_address as usize, handle);
         lock.register_mmio_device(device);

--- a/ostd/src/bus/mmio/mod.rs
+++ b/ostd/src/bus/mmio/mod.rs
@@ -46,6 +46,33 @@ pub(crate) fn init() {
     // FIXME: The address 0xFEB0_0000 is obtained from an instance of microvm, and it may not work in other architecture.
     #[cfg(target_arch = "x86_64")]
     iter_range(0xFEB0_0000..0xFEB0_4000);
+
+    #[cfg(target_arch = "riscv64")]
+    riscv64_mmio_probe();
+}
+
+#[cfg(target_arch = "riscv64")]
+fn riscv64_mmio_probe() {
+    use crate::arch::boot::DEVICE_TREE;
+
+    let mut lock = MMIO_BUS.lock();
+    for node in DEVICE_TREE
+        .get()
+        .unwrap()
+        .find_all_nodes("/soc/virtio_mmio")
+    {
+        let region = node.reg().unwrap().next().unwrap();
+        let interrupt = node.interrupts().unwrap().next().unwrap();
+        let handle = IrqLine::alloc_specific(interrupt as u8).unwrap();
+        log::debug!(
+            "Initialize Virtio MMIO at {:#x?}, interrupt: {}",
+            region.starting_address,
+            interrupt
+        );
+
+        let device = MmioCommonDevice::new(region.starting_address as usize, handle);
+        lock.register_mmio_device(device);
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/ostd/src/bus/pci/capability/msix.rs
+++ b/ostd/src/bus/pci/capability/msix.rs
@@ -62,6 +62,8 @@ impl Clone for CapabilityMsixData {
 
 #[cfg(target_arch = "x86_64")]
 const MSIX_DEFAULT_MSG_ADDR: u32 = 0xFEE0_0000;
+#[cfg(target_arch = "riscv64")]
+const MSIX_DEFAULT_MSG_ADDR: u32 = 0x0000_0000;
 
 impl CapabilityMsixData {
     pub(super) fn new(dev: &mut PciCommonDevice, cap_ptr: u16) -> Self {

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -155,6 +155,11 @@ impl DmaStream {
                 // TODO: Query the CPU for the cache line size via CPUID, we use 64 bytes as the cache line size here.
                 for i in _byte_range.step_by(64) {
                     // TODO: Call the cache line flush command in the corresponding architecture.
+                    #[cfg(target_arch="riscv64")]
+                    {
+                        log::trace!("Cache line flush in RISC-V is not supported for now.");
+                        return Ok(());
+                    }
                     todo!()
                 }
                 Ok(())


### PR DESCRIPTION
New:
1. Enable user-space floating mode
2. Add exception table mechanism
3. Add Virtio-mmio bus support
4. Add RISC-V timer support
5. Add RISC-V PLIC support

Fix:
1. Fix RISC-V `sys_fstat` (the layout of `Stat` is different from x86's)
2. Fix RISC-V goldfish IoMem compilation error
3. Add dummy implementtation for interrupt remapping to make it compile
