### PR TITLE
Partiall implementation of `sysinfo` syscall (`uptime` calculation)

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -119,7 +119,7 @@ provided by Linux on x86-64 architecture.
 | 96      | gettimeofday     | ✅              |
 | 97      | getrlimit        | ✅              |
 | 98      | getrusage        | ✅              |
-| 99      | sysinfo          | ❌              |
+| 99      | sysinfo          | ✅              |
 | 100     | times            | ❌              |
 | 101     | ptrace           | ❌              |
 | 102     | getuid           | ✅              |

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -120,6 +120,7 @@ use crate::syscall::{
     statfs::{sys_fstatfs, sys_statfs},
     symlink::{sys_symlink, sys_symlinkat},
     sync::sys_sync,
+    sysinfo::sys_sysinfo,
     tgkill::sys_tgkill,
     time::sys_time,
     timer_create::{sys_timer_create, sys_timer_delete},
@@ -224,6 +225,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETTIMEOFDAY = 96      => sys_gettimeofday(args[..1]);
     SYS_GETRLIMIT = 97         => sys_getrlimit(args[..2]);
     SYS_GETRUSAGE = 98         => sys_getrusage(args[..2]);
+    SYS_SYSINFO = 99           => sys_sysinfo(args[..1]);
     SYS_GETUID = 102           => sys_getuid(args[..0]);
     SYS_GETGID = 104           => sys_getgid(args[..0]);
     SYS_SETUID = 105           => sys_setuid(args[..1]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -127,6 +127,7 @@ mod stat;
 mod statfs;
 mod symlink;
 mod sync;
+mod sysinfo;
 mod tgkill;
 mod time;
 mod timer_create;

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,11 +1,34 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
+use crate::prelude::*;
+use aster_time::read_monotonic_time;
+
+#[derive(Debug, Default, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct sysinfo {
+    uptime: i64,
+    loads: [u64; 3],
+    totalram: u64,
+    freeram: u64,
+    sharedram: u64,
+    bufferram: u64,
+    totalswap: u64,
+    freeswap: u64,
+    procs: u16,
+    totalhigh: u64,
+    freehigh: u64,
+    mem_unit: u32
+}
 
 pub fn sys_sysinfo(
     sysinfo_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    unimplemented!("sysinfo implementation in process");
-    Ok(SyscallReturn::Return(-1))
+    let info = sysinfo {
+        uptime: read_monotonic_time().as_secs() as i64,
+        ..Default::default() // TODO: add other system information
+    };
+    ctx.user_space().write_val(sysinfo_addr, &info)?;
+    Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_time::read_monotonic_time;
+use ostd::mm::stat::{mem_total, mem_available};
 
 use super::SyscallReturn;
 use crate::prelude::*;
@@ -8,23 +9,25 @@ use crate::prelude::*;
 #[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
 pub struct sysinfo {
-    uptime: i64,
-    loads: [u64; 3],
-    totalram: u64,
-    freeram: u64,
-    sharedram: u64,
-    bufferram: u64,
-    totalswap: u64,
-    freeswap: u64,
-    procs: u16,
-    totalhigh: u64,
-    freehigh: u64,
-    mem_unit: u32,
+    uptime: i64,     /* Seconds since boot */
+    loads: [u64; 3], /* 1, 5, and 15 minute load averages */
+    totalram: u64,   /* Total usable main memory size */
+    freeram: u64,    /* Available memory size */
+    sharedram: u64,  /* Amount of shared memory */
+    bufferram: u64,  /* Memory used by buffers */
+    totalswap: u64,  /* Total swap space size */
+    freeswap: u64,   /* swap space still available */
+    procs: u16,      /* Number of current processes */
+    totalhigh: u64,  /* Total high memory size */
+    freehigh: u64,   /* Available high memory size */
+    mem_unit: u32,   /* Memory unit size in bytes */
 }
 
 pub fn sys_sysinfo(sysinfo_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let info = sysinfo {
         uptime: read_monotonic_time().as_secs() as i64,
+        totalram: mem_total() as u64,
+        freeram: mem_available() as u64,
         ..Default::default() // TODO: add other system information
     };
     ctx.user_space().write_val(sysinfo_addr, &info)?;

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_time::read_monotonic_time;
-use ostd::mm::stat::{mem_total, mem_available};
+use ostd::mm::stat::{mem_available, mem_total};
 
 use super::SyscallReturn;
 use crate::prelude::*;

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+
+pub fn sys_sysinfo(
+    sysinfo_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    unimplemented!("sysinfo implementation in process");
+    Ok(SyscallReturn::Return(-1))
+}

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_time::read_monotonic_time;
+
 use super::SyscallReturn;
 use crate::prelude::*;
-use aster_time::read_monotonic_time;
 
 #[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
@@ -18,13 +19,10 @@ pub struct sysinfo {
     procs: u16,
     totalhigh: u64,
     freehigh: u64,
-    mem_unit: u32
+    mem_unit: u32,
 }
 
-pub fn sys_sysinfo(
-    sysinfo_addr: Vaddr,
-    ctx: &Context,
-) -> Result<SyscallReturn> {
+pub fn sys_sysinfo(sysinfo_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let info = sysinfo {
         uptime: read_monotonic_time().as_secs() as i64,
         ..Default::default() // TODO: add other system information

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -47,6 +47,7 @@ TESTS ?= \
 	statfs_test \
 	symlink_test \
 	sync_test \
+	sysinfo_test \
 	timers_test \
 	truncate_test \
 	uidgid_test \

--- a/test/syscall_test/blocklists/sysinfo_test
+++ b/test/syscall_test/blocklists/sysinfo_test
@@ -1,0 +1,4 @@
+SysinfoTest.TotalRamSaneValue
+SysinfoTest.MemunitSet
+SysinfoTest.FreeRamSaneValue
+SysinfoTest.NumProcsSaneValue

--- a/test/syscall_test/blocklists/sysinfo_test
+++ b/test/syscall_test/blocklists/sysinfo_test
@@ -1,4 +1,2 @@
-SysinfoTest.TotalRamSaneValue
 SysinfoTest.MemunitSet
-SysinfoTest.FreeRamSaneValue
 SysinfoTest.NumProcsSaneValue


### PR DESCRIPTION
This PR partially implements `sysinfo` syscall with `sysinfo` struct. Only `uptime` calculation was implemented. This fixes the `uptime` tool, which previously printed random information.

- before:
![Screenshot from 2024-12-11 23-45-32](https://github.com/user-attachments/assets/66a3e6c8-f8a7-478b-9d52-b201731a789e)

- after
![Screenshot from 2024-12-11 23-32-01](https://github.com/user-attachments/assets/c2c6e89f-0307-4f71-b83b-1de47abb1cfa)

Many thanks to @levBagryansky