### PR TITLE
Fix result extraction of SQLite benchmark

### DIFF
--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_between.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "10000 DELETEs, numeric BETWEEN, indexed....",
+        "search_pattern": "100000 DELETEs, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_individual.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "50000 DELETEs of individual rows....",
+        "search_pattern": "500000 DELETEs of individual rows....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_refill_replace.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_refill_replace.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Refill two 50000-row tables using REPLACE....",
+        "search_pattern": "Refill two 500000-row tables using REPLACE....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_ipk.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_ipk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "70000 SELECTS on an IPK....",
+        "search_pattern": "700000 SELECTS on an IPK....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_text_pk.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_text_pk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "70000 SELECTS on a TEXT PK....",
+        "search_pattern": "700000 SELECTS on a TEXT PK....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_between.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "10000 UPDATES, numeric BETWEEN, indexed....",
+        "search_pattern": "100000 UPDATES, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_big_one.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_big_one.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "One big UPDATE of the whole 50000-row table....",
+        "search_pattern": "One big UPDATE of the whole 500000-row table....",
         "result_index": 11
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_individual.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "50000 UPDATES of individual rows....",
+        "search_pattern": "500000 UPDATES of individual rows....",
         "result_index": 8
     },
     "chart": {


### PR DESCRIPTION
#1576 updates the SQLite benchmark command from `/benchmark/bin/sqlite-speedtest1 /ext2/test.db` to `/benchmark/bin/sqlite-speedtest1 --size 1000 /ext2/test.db` to ensure consistent benchmarking with a dataset size of 1000. However, the search pattern used for result extraction was not updated accordingly, leading to unexpected extraction failures for certain results.

This PR addresses this issue by updating the search pattern to align with the new benchmark command, ensuring accurate and consistent result extraction.