### PR TITLE
Fix dependency issue between components `logger` and `virtio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ name = "aster-block"
 version = "0.1.0"
 dependencies = [
  "align_ext",
- "aster-logger",
  "aster-util",
  "bitflags 1.3.2",
  "bitvec",
@@ -122,7 +121,6 @@ name = "aster-input"
 version = "0.1.0"
 dependencies = [
  "ascii",
- "aster-logger",
  "aster-rights",
  "aster-util",
  "bitflags 1.3.2",
@@ -138,6 +136,7 @@ name = "aster-logger"
 version = "0.1.0"
 dependencies = [
  "aster-console",
+ "aster-virtio",
  "cfg-if",
  "component",
  "log",
@@ -152,7 +151,6 @@ version = "0.1.0"
 dependencies = [
  "align_ext",
  "aster-bigtcp",
- "aster-logger",
  "aster-rights",
  "aster-util",
  "bitflags 1.3.2",
@@ -281,7 +279,6 @@ dependencies = [
  "aster-block",
  "aster-console",
  "aster-input",
- "aster-logger",
  "aster-network",
  "aster-rights",
  "aster-util",

--- a/kernel/comps/block/Cargo.toml
+++ b/kernel/comps/block/Cargo.toml
@@ -11,7 +11,6 @@ spin = "0.9.4"
 ostd = { path = "../../../ostd" }
 align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-util = { path = "../../libs/aster-util" }
-aster-logger = { path = "../logger" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"

--- a/kernel/comps/input/Cargo.toml
+++ b/kernel/comps/input/Cargo.toml
@@ -11,7 +11,6 @@ spin = "0.9.4"
 ostd = { path = "../../../ostd" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
-aster-logger = { path = "../logger" }
 component = { path = "../../libs/comp-sys/component" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 log = "0.4"

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 component = { path = "../../libs/comp-sys/component" }
 aster-console = { path = "../console" }
+aster-virtio = { path = "../virtio" }
 log = "0.4"
 ostd = { path = "../../../ostd" }
 spin = "0.9.4"

--- a/kernel/comps/network/Cargo.toml
+++ b/kernel/comps/network/Cargo.toml
@@ -10,7 +10,6 @@ align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
-aster-logger = { path = "../logger" }
 bitflags = "1.3"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 component = { path = "../../libs/comp-sys/component" }

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -12,7 +12,6 @@ bytes = { version = "1.4.0", default-features = false }
 align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-input = { path = "../input" }
 aster-block = { path = "../block" }
-aster-logger = { path = "../logger" }
 aster-network = { path = "../network" }
 aster-console = { path = "../console" }
 aster-util = { path = "../../libs/aster-util" }


### PR DESCRIPTION
Recently, I noticed that some debug logs related to virtio were missing.

After investigating the cause, I discovered a timing issue that occurs after the injection of `AsterLogger` and before the virtio `ConsoleDevice` is ready (registered in the `console_device_table` within the component `aster-console`). During this period, all logs, possibly from other virtio devices, are lost.

This seems to be a dependency inversion issue, as the `aster-logger` component should depend on the `aster-virtio` component to ensure the device `virtio-console` is initialized at first.