### PR TITLE
Add `get_mut` methods for locks

### DIFF
--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -721,7 +721,7 @@ impl SocketEventObserver for StreamSocket {
 
 impl Drop for StreamSocket {
     fn drop(&mut self) {
-        let state = self.state.write().take();
+        let state = self.state.get_mut().take();
 
         let iface_to_poll = match state {
             State::Init(_) => None,

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -365,8 +365,8 @@ impl Socket for VsockStreamSocket {
 impl Drop for VsockStreamSocket {
     fn drop(&mut self) {
         let vsockspace = VSOCK_GLOBAL.get().unwrap();
-        let inner = self.status.read();
-        match &*inner {
+        let inner = self.status.get_mut();
+        match inner {
             Status::Init(init) => {
                 if let Some(addr) = init.bound_addr() {
                     vsockspace.recycle_port(&addr.port);

--- a/ostd/src/sync/mutex.rs
+++ b/ostd/src/sync/mutex.rs
@@ -43,6 +43,7 @@ impl<T: ?Sized> Mutex<T> {
     /// for compile-time checked lifetimes of the mutex guard.
     ///
     /// [`lock`]: Self::lock
+    #[track_caller]
     pub fn lock_arc(self: &Arc<Self>) -> ArcMutexGuard<T> {
         self.queue.wait_until(|| self.try_lock_arc())
     }

--- a/ostd/src/sync/mutex.rs
+++ b/ostd/src/sync/mutex.rs
@@ -69,6 +69,14 @@ impl<T: ?Sized> Mutex<T> {
         })
     }
 
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This method is zero-cost: By holding a mutable reference to the lock, the compiler has
+    /// already statically guaranteed that access to the data is exclusive.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.val.get_mut()
+    }
+
     /// Releases the mutex and wake up one thread which is blocked on this mutex.
     fn unlock(&self) {
         self.release_lock();

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -331,6 +331,14 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
         }
         None
     }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This method is zero-cost: By holding a mutable reference to the lock, the compiler has
+    /// already statically guaranteed that access to the data is exclusive.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.val.get_mut()
+    }
 }
 
 impl<T: ?Sized + fmt::Debug, G> fmt::Debug for RwLock<T, G> {

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -192,6 +192,14 @@ impl<T: ?Sized> RwMutex<T> {
         }
         None
     }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This method is zero-cost: By holding a mutable reference to the lock, the compiler has
+    /// already statically guaranteed that access to the data is exclusive.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.val.get_mut()
+    }
 }
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for RwMutex<T> {

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -109,6 +109,14 @@ impl<T: ?Sized, G: Guardian> SpinLock<T, G> {
         None
     }
 
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This method is zero-cost: By holding a mutable reference to the lock, the compiler has
+    /// already statically guaranteed that access to the data is exclusive.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.val.get_mut()
+    }
+
     /// Acquires the spin lock, otherwise busy waiting
     fn acquire_lock(&self) {
         while !self.try_acquire_lock() {


### PR DESCRIPTION
 - [`Mutex::get_mut` in the Rust standard library](https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.get_mut)
 - [`Mutex::get_mut` in `parking_lot`](https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html#method.get_mut)

This can be implemented using [`UnsafeCell::get_mut`](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html#method.get_mut) without using a single line of unsafe code.

This can be useful when we already have a mutable reference, perhaps because:
 1. The trait (e.g., `Drop`) gives us:
https://github.com/asterinas/asterinas/blob/18d5eb1f02825ce80cefc8a9c09e6931a0c2ac9e/kernel/src/net/socket/ip/stream/mod.rs#L697-L699
 2. The lock is behind another `RwLock`/`RwMutex` which has already been exclusively locked.

For exactly the same principle, we should also add [`Mutex::into_inner`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.into_inner) by using [`UnsafeCell::into_inner`](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html#method.into_inner). (They were [added together](https://github.com/rust-lang/rust/pull/29031) to the Rust standard library and [tracked together](https://github.com/rust-lang/rust/issues/28968) for stabilization). However, I'm not aware of any concrete use cases in our current codebase. Are there any?