### PR TITLE
Fix result extraction of some benchmarks

### DIFF
--- a/test/benchmark/lmbench/tcp_virtio_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "TCP latency using 127.0.0.1:",
+        "search_pattern": "TCP latency using 10.0.2.15:",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/sysbench/cpu_lat/bench_result.json
+++ b/test/benchmark/sysbench/cpu_lat/bench_result.json
@@ -1,10 +1,16 @@
 {
-    "alert_threshold": "130%",
-    "alert_tool": "customSmallerIsBetter",
-    "search_pattern": "avg:",
-    "result_index": "NF",
-    "description": "sysbench cpu",
-    "title": "[CPU] CPU performance",
-    "unit": "ms",
-    "legend": "Average Execution Time per CPU on {system}"
+    "alert": {
+        "threshold": "130%",
+        "bigger_is_better": false
+    },
+    "result_extraction": {
+        "search_pattern": "avg:",
+        "result_index": "NF"
+    },
+    "chart": {
+        "title": "[CPU] CPU performance",
+        "description": "sysbench cpu",
+        "unit": "ms",
+        "legend": "Average Execution Time per CPU on {system}"
+    }
 }

--- a/test/benchmark/sysbench/thread_lat/bench_result.json
+++ b/test/benchmark/sysbench/thread_lat/bench_result.json
@@ -1,10 +1,16 @@
 {
-    "alert_threshold": "130%",
-    "alert_tool": "customSmallerIsBetter",
-    "search_pattern": "avg:",
-    "result_index": "NF",
-    "description": "sysbench threads",
-    "title": "[Threads] Threads performance",
-    "unit": "ms",
-    "legend": "Average Execution Time per Thread on {system}"
+    "alert": {
+        "threshold": "130%",
+        "bigger_is_better": false
+    },
+    "result_extraction": {
+        "search_pattern": "avg:",
+        "result_index": "NF"
+    },
+    "chart": {
+        "title": "[Threads] Threads performance",
+        "description": "sysbench threads",
+        "unit": "ms",
+        "legend": "Average Execution Time per Thread on {system}"
+    }
 }


### PR DESCRIPTION
[The most recent run of benchmark CI](https://github.com/asterinas/asterinas/actions/runs/12303877199) shows that four tests don't generate results:
- sysbench/cpu_lat
- sysbench/thread_lat
- lmbench/tcp_virtio_lat
- lmbench/tcp_loopback_http_bw

The first three are fixed in this PR and tested locally. The last failure is occasional.