### PR TITLE
Fix SMP boot for EFI handover

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -33,7 +33,7 @@
 use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot,
-    cpu::PinCurrentCpu,
+    cpu::{CpuId, CpuSet, PinCurrentCpu},
 };
 use process::Process;
 
@@ -81,8 +81,11 @@ pub fn main() {
     ostd::boot::smp::register_ap_entry(ap_init);
 
     // Spawn the first kernel thread on BSP.
+    let mut affinity = CpuSet::new_empty();
+    affinity.add(CpuId::bsp());
     ThreadOptions::new(init_thread)
         .priority(Priority::idle())
+        .cpu_affinity(affinity)
         .spawn();
 }
 

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -83,7 +83,13 @@ x2apic_mode:
     rdmsr
     jmp ap_protect
 
-.code32
+// This is a pointer to the page table used by the APs.
+// The BSP will fill this pointer before kicking the APs.
+.global __boot_page_table_pointer
+.align 4
+__boot_page_table_pointer:
+    .skip 4
+
 ap_protect:
     // Save the local APIC ID in an unused register.
     // We will calculate the stack pointer of this core 
@@ -103,7 +109,7 @@ ap_protect:
     // Set the page table. The application processors use
     // the same page table as the bootstrap processor's
     // boot phase page table.
-    lea eax, [boot_page_table_start]
+    mov eax, __boot_page_table_pointer
     mov cr3, eax
 
     // Enable long mode.
@@ -132,9 +138,9 @@ ap_long_mode_in_low_address:
     mov rax, offset ap_long_mode
     jmp rax
 
+.data
 // This is a pointer to be filled by the BSP when boot stacks
 // of all APs are allocated and initialized.
-.data
 .global __ap_boot_stack_array_pointer
 .align 8
 __ap_boot_stack_array_pointer:

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -57,7 +57,8 @@ pub(crate) fn get_num_processors() -> Option<u32> {
 /// Brings up all application processors.
 pub(crate) fn bringup_all_aps() {
     copy_ap_boot_code();
-    init_boot_stack_array();
+    fill_boot_stack_array_ptr();
+    fill_boot_pt_ptr();
     send_boot_ipis();
 }
 
@@ -85,7 +86,7 @@ fn copy_ap_boot_code() {
 }
 
 /// Initializes the boot stack array in the AP boot code with the given pages.
-fn init_boot_stack_array() {
+fn fill_boot_stack_array_ptr() {
     let pages = &crate::boot::smp::AP_BOOT_INFO
         .get()
         .unwrap()
@@ -97,13 +98,31 @@ fn init_boot_stack_array() {
     }
     let ap_boot_stack_arr_ptr: *mut u64 = __ap_boot_stack_array_pointer as usize as *mut u64;
     log::debug!(
-        "__ap_boot_stack_array_pointer: {:#x?}",
+        "Setting __ap_boot_stack_array_pointer={:#x?} for AP boot stacks",
         ap_boot_stack_arr_ptr
     );
 
     // SAFETY: this pointer points to a static variable defined in the `ap_boot.S`.
     unsafe {
         ap_boot_stack_arr_ptr.write_volatile(paddr_to_vaddr(pages.start_paddr()) as u64);
+    }
+}
+
+fn fill_boot_pt_ptr() {
+    // This is defined in the boot assembly code.
+    extern "C" {
+        fn __boot_page_table_pointer();
+    }
+    let boot_pt_ptr: *mut u32 = __boot_page_table_pointer as usize as *mut u32;
+    let boot_pt = crate::mm::page_table::boot_pt::with_borrow(|pt| pt.root_address()).unwrap();
+    log::debug!(
+        "Setting __boot_page_table_pointer={:#x?} for AP boot page tables",
+        boot_pt
+    );
+
+    // SAFETY: this pointer points to a static variable defined in the `ap_boot.S`.
+    unsafe {
+        boot_pt_ptr.write_volatile(boot_pt as u32);
     }
 }
 


### PR DESCRIPTION
Fix #1636 .

The boot page table was not initialized by the assembly during EFI boot. So APs don't get a proper page table. We let the BSP provide a boot page table address when starting APs.

After this fix SMP in EFI is still not ready. And I would start a issue tracking the problem that the GDT won't work with KVM and EFI handover boot.