### PR TITLE
Fix `format_all.sh` treating comments as directories

### DIFF
--- a/tools/format_all.sh
+++ b/tools/format_all.sh
@@ -6,7 +6,7 @@ set -e
 
 WORKSPACE_ROOT="$(dirname "$(readlink -f "$0")")/.."
 
-EXCLUDED_CRATES=$(sed -n '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
+EXCLUDED_CRATES=$(sed -n -e 's/#.*//; /^\s*$/d' -e '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
 
 CHECK_MODE=false
 


### PR DESCRIPTION
The script `format_all.sh` incorrectly treats comments as directories. This PR fixes this issue.

https://github.com/asterinas/asterinas/blob/cd22854f59d90095c9fdac75d194b46b643092de/Cargo.toml#L41-L42

```txt
$ ./tools/format_all.sh
Directory for crate #The`base`and`test-base`cratesareauto-generatedbyOSDKandultimatelybuiltbyCargo does not exist
Directory for crate #during`cargoosdkrun`and`cargoosdktest`commands does not exist
```
