### PR TITLE
Remove redundant "sqlite/" prefix

### DIFF
--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -192,10 +192,10 @@ To include a new benchmark in the suite's summary table, we need to update the `
 // sqlite/summary.json
 {
     "benchmarks": [
-        "sqlite/ext2_deletes_between",
-        "sqlite/ext2_deletes_individual",
-        "sqlite/ext2_refill_replace",
-        "sqlite/ext2_selects_ipk"
+        "ext2_deletes_between",
+        "ext2_deletes_individual",
+        "ext2_refill_replace",
+        "ext2_selects_ipk"
     ]
 }
 ```


### PR DESCRIPTION
This pull request includes changes to update the benchmark names in the suite's summary table. The changes ensure consistency by removing the `sqlite/` prefix from the benchmark names. It is redundant to specify `sqlite/` because `summary.json` is already under `sqlite/`.
