### PR TITLE
Add keepidle tcp option

### DIFF
--- a/kernel/src/net/socket/ip/stream/options.rs
+++ b/kernel/src/net/socket/ip/stream/options.rs
@@ -5,9 +5,10 @@ use crate::impl_socket_options;
 
 impl_socket_options!(
     pub struct NoDelay(bool);
-    pub struct Congestion(CongestionControl);
     pub struct MaxSegment(u32);
+    pub struct KeepIdle(u32);
     pub struct WindowClamp(u32);
+    pub struct Congestion(CongestionControl);
 );
 
 /// The keepalive interval.

--- a/kernel/src/net/socket/ip/stream/util.rs
+++ b/kernel/src/net/socket/ip/stream/util.rs
@@ -7,21 +7,24 @@ use crate::prelude::*;
 #[set = "pub"]
 pub struct TcpOptionSet {
     no_delay: bool,
-    congestion: CongestionControl,
     maxseg: u32,
+    keep_idle: u32,
     window_clamp: u32,
+    congestion: CongestionControl,
 }
 
 pub const DEFAULT_MAXSEG: u32 = 536;
+pub const DEFAULT_KEEP_IDLE: u32 = 7200;
 pub const DEFAULT_WINDOW_CLAMP: u32 = 0x8000_0000;
 
 impl TcpOptionSet {
     pub fn new() -> Self {
         Self {
             no_delay: false,
-            congestion: CongestionControl::Reno,
             maxseg: DEFAULT_MAXSEG,
+            keep_idle: DEFAULT_KEEP_IDLE,
             window_clamp: DEFAULT_WINDOW_CLAMP,
+            congestion: CongestionControl::Reno,
         }
     }
 }

--- a/kernel/src/syscall/getsockopt.rs
+++ b/kernel/src/syscall/getsockopt.rs
@@ -15,7 +15,7 @@ pub fn sys_getsockopt(
     optlen_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let level = CSocketOptionLevel::try_from(level)?;
+    let level = CSocketOptionLevel::try_from(level).map_err(|_| Errno::EOPNOTSUPP)?;
     if optval == 0 || optlen_addr == 0 {
         return_errno_with_message!(Errno::EINVAL, "optval or optlen_addr is null pointer");
     }

--- a/kernel/src/syscall/setsockopt.rs
+++ b/kernel/src/syscall/setsockopt.rs
@@ -15,7 +15,7 @@ pub fn sys_setsockopt(
     optlen: u32,
     _ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let level = CSocketOptionLevel::try_from(level)?;
+    let level = CSocketOptionLevel::try_from(level).map_err(|_| Errno::EOPNOTSUPP)?;
     if optval == 0 {
         return_errno_with_message!(Errno::EINVAL, "optval is null pointer");
     }

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -134,7 +134,7 @@ pub fn new_raw_socket_option(
     match level {
         CSocketOptionLevel::SOL_SOCKET => new_socket_option(name),
         CSocketOptionLevel::SOL_TCP => new_tcp_option(name),
-        _ => todo!(),
+        _ => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported option level"),
     }
 }
 

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -39,7 +39,7 @@ enum CSocketOptionName {
 }
 
 pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
-    let name = CSocketOptionName::try_from(name)?;
+    let name = CSocketOptionName::try_from(name).map_err(|_| Errno::ENOPROTOOPT)?;
     match name {
         CSocketOptionName::SNDBUF => Ok(Box::new(SendBuf::new())),
         CSocketOptionName::RCVBUF => Ok(Box::new(RecvBuf::new())),
@@ -48,7 +48,7 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
-        _ => todo!(),
+        _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported socket-level option"),
     }
 }
 

--- a/kernel/src/util/net/options/tcp.rs
+++ b/kernel/src/util/net/options/tcp.rs
@@ -3,7 +3,7 @@
 use super::RawSocketOption;
 use crate::{
     impl_raw_socket_option,
-    net::socket::ip::stream::options::{Congestion, MaxSegment, NoDelay, WindowClamp},
+    net::socket::ip::stream::options::{Congestion, KeepIdle, MaxSegment, NoDelay, WindowClamp},
     prelude::*,
     util::net::options::SocketOption,
 };
@@ -26,17 +26,19 @@ pub enum CTcpOptionName {
 }
 
 pub fn new_tcp_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
-    let name = CTcpOptionName::try_from(name)?;
+    let name = CTcpOptionName::try_from(name).map_err(|_| Errno::ENOPROTOOPT)?;
     match name {
         CTcpOptionName::NODELAY => Ok(Box::new(NoDelay::new())),
-        CTcpOptionName::CONGESTION => Ok(Box::new(Congestion::new())),
         CTcpOptionName::MAXSEG => Ok(Box::new(MaxSegment::new())),
+        CTcpOptionName::KEEPIDLE => Ok(Box::new(KeepIdle::new())),
         CTcpOptionName::WINDOW_CLAMP => Ok(Box::new(WindowClamp::new())),
-        _ => todo!(),
+        CTcpOptionName::CONGESTION => Ok(Box::new(Congestion::new())),
+        _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported tcp-level option"),
     }
 }
 
 impl_raw_socket_option!(NoDelay);
-impl_raw_socket_option!(Congestion);
 impl_raw_socket_option!(MaxSegment);
+impl_raw_socket_option!(KeepIdle);
 impl_raw_socket_option!(WindowClamp);
+impl_raw_socket_option!(Congestion);


### PR DESCRIPTION
Fix #1715.

The redis benchmark panics due to the keepidle tcp option is not supported.