### PR TITLE
Make Results always be triggered

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -143,6 +143,7 @@ jobs:
   Results:
     runs-on: ubuntu-latest
     needs: Matrix
+    if: always() # Always run regardless of whether the previous job was successful or not.
     strategy:
       matrix:
         benchmark: ${{ fromJson(needs.Matrix.outputs.benchmarks) }}


### PR DESCRIPTION
I have identified that the [Benchmark workflow](https://github.com/asterinas/asterinas/actions/runs/12341838143/job/34440964283#logs) experienced a failure due to a timeout issue. This timeout event led to the cancellation of the jobs, including the `Results` uploading job. I reproduce it on [here](https://github.com/grief8/asterinas/actions/runs/12347534305) and fix it [here](https://github.com/grief8/asterinas/actions/runs/12348071275).
To guarantee the successful execution of the `Results` job, it is advisable to incorporate `if: always()` in a manner similar to the `Matrix` job.