### PR TITLE
Fix a typo in Dockerfile

### DIFF
--- a/tools/docker/Dockerfile.jinja
+++ b/tools/docker/Dockerfile.jinja
@@ -309,7 +309,7 @@ FROM build-grub as grub
 # EFI handover boot, which is deprecated. So we have to build GRUB from source.
 WORKDIR /root
 # See also: https://github.com/asterinas/asterinas/pull/1710
-RUN git clone --single-branch -b asterinas/2.12 https://github.com/asterinas/grub.git
+RUN git clone --single-branch -b asterinas/2.12 https://github.com/asterinas/grub.git \
     && git -C grub checkout 0633bc8
 # Fetch and install the Unicode font data for grub.
 RUN wget -O unifont.pcf.gz https://unifoundry.com/pub/unifont/unifont-15.1.04/font-builds/unifont-15.1.04.pcf.gz \ 


### PR DESCRIPTION
Sorry...

```
#1 DONE 0.0s
Dockerfile:312
--------------------
 310 |     # See also: https://github.com/***/***/pull/1710
 311 |     RUN git clone --single-branch -b ***/2.12 https://github.com/***/grub.git
 312 | >>>     && git -C grub checkout 0633bc8
 313 |     # Fetch and install the Unicode font data for grub.
 314 |     RUN wget -O unifont.pcf.gz https://unifoundry.com/pub/unifont/unifont-15.1.04/font-builds/unifont-15.1.04.pcf.gz \ 
--------------------
ERROR: failed to solve: dockerfile parse error on line 312: unknown instruction: &&
```