### PR TITLE
Fix the GRUB build issue

### DIFF
--- a/tools/docker/Dockerfile.jinja
+++ b/tools/docker/Dockerfile.jinja
@@ -318,6 +318,7 @@ RUN wget -O unifont.pcf.gz https://unifoundry.com/pub/unifont/unifont-15.1.04/fo
     && rm unifont.pcf.gz
 WORKDIR /root/grub
 RUN echo depends bli part_gpt > grub-core/extra_deps.lst \ 
+    && ./bootstrap \
     && ./configure \ 
         --target=x86_64 \ 
         --disable-efiemu \ 


### PR DESCRIPTION
Sorry x2

```
 > [grub 5/7] RUN echo depends bli part_gpt > grub-core/extra_deps.lst     && ./configure         --target=x86_64         --disable-efiemu         --with-platform=efi         --enable-grub-mkfont         --prefix=/usr/local/grub         --disable-werror     && make -j     && make install:
0.195 /bin/bash: line 1: ./configure: No such file or directory
```

I once tested the build in the official GRUB tarball release, so I assumed it would work in the GRUB repository as well.

But it doesn't. In the repository, we have to additionally run `./boostrap` to generate `./configure` (which is already present in the tarball).

Really annoying...

I've tested (locally) the build process in the GRUB repository this time. Hopefully everything will work normally after this PR.