### PR TITLE
Enhance search pattern with regex

### DIFF
--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -164,7 +164,7 @@ Below are the contents of these files for the sample benchmark:
 // sqlite/ext2_benchmarks/bench_results/ext2_deletes_between.json
 {
     "result_extraction": {
-        "search_pattern": "10000 DELETEs, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ DELETEs, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {
@@ -174,7 +174,7 @@ Below are the contents of these files for the sample benchmark:
 // sqlite/ext2_benchmarks/bench_results/ext2_updates_between.json
 {
     "result_extraction": {
-        "search_pattern": "10000 UPDATES, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ UPDATES, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/fio/ext2_iommu_seq_read_bw/bench_result.json
+++ b/test/benchmark/fio/ext2_iommu_seq_read_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "bw=",
+        "search_pattern": "bw=[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/fio/ext2_iommu_seq_write_bw/bench_result.json
+++ b/test/benchmark/fio/ext2_iommu_seq_write_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "bw=",
+        "search_pattern": "bw=[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/fio/ext2_seq_read_bw/bench_result.json
+++ b/test/benchmark/fio/ext2_seq_read_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "bw=",
+        "search_pattern": "bw=[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/fio/ext2_seq_write_bw/bench_result.json
+++ b/test/benchmark/fio/ext2_seq_write_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "bw=",
+        "search_pattern": "bw=[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/ext2_copy_files_bw/bench_result.json
+++ b/test/benchmark/lmbench/ext2_copy_files_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "lmdd result:",
+        "search_pattern": "lmdd result: +[0-9.]+",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/lmbench/fifo_lat/bench_result.json
+++ b/test/benchmark/lmbench/fifo_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Fifo latency",
+        "search_pattern": "Fifo latency: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_copy_bw/bench_result.json
+++ b/test/benchmark/lmbench/mem_copy_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "536.87",
+        "search_pattern": "536.87 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_mmap_bw/bench_result.json
+++ b/test/benchmark/lmbench/mem_mmap_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "268.44",
+        "search_pattern": "268.44 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_mmap_lat/bench_result.json
+++ b/test/benchmark/lmbench/mem_mmap_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "4.194304",
+        "search_pattern": "4.194304 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_pagefault_lat/bench_result.json
+++ b/test/benchmark/lmbench/mem_pagefault_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Pagefaults on ",
+        "search_pattern": "Pagefaults on [^:]+: +[0-9.]+",
         "result_index": 4
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_read_bw/bench_result.json
+++ b/test/benchmark/lmbench/mem_read_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "536.87",
+        "search_pattern": "536.87 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/mem_write_bw/bench_result.json
+++ b/test/benchmark/lmbench/mem_write_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "536.87",
+        "search_pattern": "536.87 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/pipe_bw/bench_result.json
+++ b/test/benchmark/lmbench/pipe_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "Pipe bandwidth",
+        "search_pattern": "Pipe bandwidth: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/pipe_lat/bench_result.json
+++ b/test/benchmark/lmbench/pipe_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Pipe latency",
+        "search_pattern": "Pipe latency: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/process_ctx_lat/bench_result.json
+++ b/test/benchmark/lmbench/process_ctx_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "18 ",
+        "search_pattern": "18 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/process_exec_lat/bench_result.json
+++ b/test/benchmark/lmbench/process_exec_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Process fork\\+execve",
+        "search_pattern": "Process fork\\+execve: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/process_fork_lat/bench_result.json
+++ b/test/benchmark/lmbench/process_fork_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Process fork",
+        "search_pattern": "Process fork\\+exit: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/process_getppid_lat/bench_result.json
+++ b/test/benchmark/lmbench/process_getppid_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple syscall:",
+        "search_pattern": "Simple syscall: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/semaphore_lat/bench_result.json
+++ b/test/benchmark/lmbench/semaphore_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Semaphore latency:",
+        "search_pattern": "Semaphore latency: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/signal_catch_lat/bench_result.json
+++ b/test/benchmark/lmbench/signal_catch_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Signal handler overhead:",
+        "search_pattern": "Signal handler overhead: +[0-9.]+",
         "result_index": 4
     },
     "chart": {

--- a/test/benchmark/lmbench/signal_install_lat/bench_result.json
+++ b/test/benchmark/lmbench/signal_install_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Signal handler installation:",
+        "search_pattern": "Signal handler installation: +[0-9.]+",
         "result_index": 4
     },
     "chart": {

--- a/test/benchmark/lmbench/signal_prot_lat/bench_result.json
+++ b/test/benchmark/lmbench/signal_prot_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Protection fault:",
+        "search_pattern": "Protection fault: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_bw_4k/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_bw_4k/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "0.004096 ",
+        "search_pattern": "0.004096 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_bw_64k/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_bw_64k/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "0.065536 ",
+        "search_pattern": "0.065536 +[0-9.]+ +MB",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_connect_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_connect_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "TCP\\/IP connection cost to 127.0.0.1:",
+        "search_pattern": "TCP\\/IP connection cost to [0-9.]+: +[0-9.]+",
         "result_index": 6
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_http_bw/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_http_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "Avg xfer: ",
+        "search_pattern": "Avg xfer: +([0-9.]+|inf)",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "TCP latency using 127.0.0.1:",
+        "search_pattern": "TCP latency using [0-9.]+: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_loopback_select_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_select_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Select on 200 tcp fd's:",
+        "search_pattern": "Select on [0-9.]+ tcp fd's: +[0-9.]+",
         "result_index": 6
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "0.065536 ",
+        "search_pattern": "0.065536 +[0-9.]+ +MB",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/tcp_virtio_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "TCP latency using 10.0.2.15:",
+        "search_pattern": "TCP latency using [0-9.]+: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/udp_loopback_lat/bench_result.json
+++ b/test/benchmark/lmbench/udp_loopback_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "UDP latency using 127.0.0.1:",
+        "search_pattern": "UDP latency using [0-9.]+: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/unix_bw/bench_result.json
+++ b/test/benchmark/lmbench/unix_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "sock stream bandwidth",
+        "search_pattern": "sock stream bandwidth: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/unix_connect_lat/bench_result.json
+++ b/test/benchmark/lmbench/unix_connect_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "UNIX connection cost:",
+        "search_pattern": "UNIX connection cost: +[0-9.]+",
         "result_index": 4
     },
     "chart": {

--- a/test/benchmark/lmbench/unix_lat/bench_result.json
+++ b/test/benchmark/lmbench/unix_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "sock stream latency",
+        "search_pattern": "sock stream latency: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_fcntl_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_fcntl_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Fcntl lock latency:",
+        "search_pattern": "Fcntl lock latency: +[0-9.]+",
         "result_index": 4
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_fstat_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_fstat_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple fstat",
+        "search_pattern": "Simple fstat: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_open_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_open_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple open\\/close",
+        "search_pattern": "Simple open\\/close: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_read_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_read_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple read:",
+        "search_pattern": "Simple read: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_read_pagecache_bw/bench_result.json
+++ b/test/benchmark/lmbench/vfs_read_pagecache_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "536.87",
+        "search_pattern": "536.87 +[0-9.]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_select_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_select_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Select on ",
+        "search_pattern": "Select on [0-9]+ fd's: +[0-9.]+",
         "result_index": 5
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_stat_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_stat_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple stat",
+        "search_pattern": "Simple stat: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/lmbench/vfs_write_lat/bench_result.json
+++ b/test/benchmark/lmbench/vfs_write_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Simple write:",
+        "search_pattern": "Simple write: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/nginx/http_req10k_conc1_bw/bench_result.json
+++ b/test/benchmark/nginx/http_req10k_conc1_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "Transfer rate:",
+        "search_pattern": "Transfer rate: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/nginx/http_req10k_conc20_bw/bench_result.json
+++ b/test/benchmark/nginx/http_req10k_conc20_bw/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "Transfer rate:",
+        "search_pattern": "Transfer rate: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/redis/get_100k_conc20_rps/bench_result.json
+++ b/test/benchmark/redis/get_100k_conc20_rps/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "throughput summary:",
+        "search_pattern": "throughput summary: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/redis/ping_inline_100k_conc20_rps/bench_result.json
+++ b/test/benchmark/redis/ping_inline_100k_conc20_rps/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "throughput summary:",
+        "search_pattern": "throughput summary: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/redis/ping_mbulk_100k_conc20_rps/bench_result.json
+++ b/test/benchmark/redis/ping_mbulk_100k_conc20_rps/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "throughput summary:",
+        "search_pattern": "throughput summary: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/redis/set_100k_conc20_rps/bench_result.json
+++ b/test/benchmark/redis/set_100k_conc20_rps/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "throughput summary:",
+        "search_pattern": "throughput summary: +[0-9.]+",
         "result_index": 3
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_between.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "100000 DELETEs, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ DELETEs, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_individual.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_deletes_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "500000 DELETEs of individual rows....",
+        "search_pattern": "[0-9]+ DELETEs of individual rows....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_refill_replace.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_refill_replace.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Refill two 500000-row tables using REPLACE....",
+        "search_pattern": "Refill two [0-9]+-row tables using REPLACE....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_ipk.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_ipk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "700000 SELECTS on an IPK....",
+        "search_pattern": "[0-9]+ SELECTS on an IPK....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_text_pk.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_selects_text_pk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "700000 SELECTS on a TEXT PK....",
+        "search_pattern": "[0-9]+ SELECTS on a TEXT PK....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_between.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "100000 UPDATES, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ UPDATES, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_big_one.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_big_one.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "One big UPDATE of the whole 500000-row table....",
+        "search_pattern": "One big UPDATE of the whole [0-9]+-row table....",
         "result_index": 11
     },
     "chart": {

--- a/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_individual.json
+++ b/test/benchmark/sqlite/ext2_benchmarks/bench_results/ext2_updates_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "500000 UPDATES of individual rows....",
+        "search_pattern": "[0-9]+ UPDATES of individual rows....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_deletes_between.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_deletes_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "100000 DELETEs, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ DELETEs, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_deletes_individual.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_deletes_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "500000 DELETEs of individual rows....",
+        "search_pattern": "[0-9]+ DELETEs of individual rows....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_refill_replace.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_refill_replace.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "Refill two 500000-row tables using REPLACE....",
+        "search_pattern": "Refill two [0-9]+-row tables using REPLACE....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_selects_ipk.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_selects_ipk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "700000 SELECTS on an IPK....",
+        "search_pattern": "[0-9]+ SELECTS on an IPK....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_selects_text_pk.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_selects_text_pk.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "700000 SELECTS on a TEXT PK....",
+        "search_pattern": "[0-9]+ SELECTS on a TEXT PK....",
         "result_index": 9
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_between.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_between.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "100000 UPDATES, numeric BETWEEN, indexed....",
+        "search_pattern": "[0-9]+ UPDATES, numeric BETWEEN, indexed....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_big_one.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_big_one.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "One big UPDATE of the whole 500000-row table....",
+        "search_pattern": "One big UPDATE of the whole [0-9]+-row table....",
         "result_index": 11
     },
     "chart": {

--- a/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_individual.json
+++ b/test/benchmark/sqlite/ramfs_benchmarks/bench_results/ramfs_updates_individual.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "500000 UPDATES of individual rows....",
+        "search_pattern": "[0-9]+ UPDATES of individual rows....",
         "result_index": 8
     },
     "chart": {

--- a/test/benchmark/sysbench/cpu_lat/bench_result.json
+++ b/test/benchmark/sysbench/cpu_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "avg:",
+        "search_pattern": "avg: +[0-9.]+",
         "result_index": "NF"
     },
     "chart": {

--- a/test/benchmark/sysbench/thread_lat/bench_result.json
+++ b/test/benchmark/sysbench/thread_lat/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": false
     },
     "result_extraction": {
-        "search_pattern": "avg:",
+        "search_pattern": "avg: +[0-9.]+",
         "result_index": "NF"
     },
     "chart": {


### PR DESCRIPTION
This pull request enhances the flexibility and accuracy of search patterns within various benchmark configurations. The primary modifications involve updating the `search_pattern` values by incorporating regular expressions. These regex improvements increase robustness by:

- Broader Numeric Matching: Accommodating a wider range of numeric values.
- Data Precision: Ensuring that only relevant data from raw outputs is captured, minimizing the inclusion of miscellaneous or unintended data.

The verification can be seen [here](https://github.com/grief8/asterinas/actions/runs/12368190782).