### PR TITLE
Notify virtqueue in a batch manner

### DIFF
--- a/kernel/comps/network/src/driver.rs
+++ b/kernel/comps/network/src/driver.rs
@@ -2,7 +2,10 @@
 
 use alloc::vec;
 
-use aster_bigtcp::{device, time::Instant};
+use aster_bigtcp::{
+    device::{self, NotifyDevice},
+    time::Instant,
+};
 use ostd::mm::VmWriter;
 
 use crate::{buffer::RxBuffer, AnyNetworkDevice};
@@ -32,6 +35,13 @@ impl device::Device for dyn AnyNetworkDevice {
         self.capabilities()
     }
 }
+
+impl NotifyDevice for dyn AnyNetworkDevice {
+    fn notify_poll_end(&mut self) {
+        self.notify_poll_end();
+    }
+}
+
 pub struct RxToken(RxBuffer);
 
 impl device::RxToken for RxToken {

--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -47,12 +47,23 @@ pub trait AnyNetworkDevice: Send + Sync + Any + Debug {
 
     fn can_receive(&self) -> bool;
     fn can_send(&self) -> bool;
-    /// Receive a packet from network. If packet is ready, returns a RxBuffer containing the packet.
-    /// Otherwise, return NotReady error.
+
+    /// Receives a packet from network. If packet is ready, returns a `RxBuffer` containing the packet.
+    /// Otherwise, return [`VirtioNetError::NotReady`].
     fn receive(&mut self) -> Result<RxBuffer, VirtioNetError>;
-    /// Send a packet to network. Return until the request completes.
+
+    /// Sends a packet to network.
     fn send(&mut self, packet: &[u8]) -> Result<(), VirtioNetError>;
+
+    /// Frees processes tx buffers.
     fn free_processed_tx_buffers(&mut self);
+
+    /// Notifies the device driver that a polling operation has ended.
+    ///
+    /// The driver can assume that the device remains protected by acquiring a poll lock
+    /// for the entire duration of the polling process.
+    /// Thus two polling process cannot happen simultaneously.
+    fn notify_poll_end(&mut self);
 }
 
 pub trait NetDeviceIrqHandler = Fn() + Send + Sync + 'static;

--- a/kernel/libs/aster-bigtcp/src/device.rs
+++ b/kernel/libs/aster-bigtcp/src/device.rs
@@ -18,3 +18,9 @@ pub trait WithDevice: Send + Sync {
     where
         F: FnOnce(&mut Self::Device) -> R;
 }
+
+/// A trait for notifying device drivers about the polling process.
+pub trait NotifyDevice {
+    /// Notifies the device driver that polling has ended.
+    fn notify_poll_end(&mut self);
+}


### PR DESCRIPTION
This PR is to optimize the `lmbench/tcp_virtio_bw_64k` by optimzing most `vq.notify` away.

Originally, whenever a packet is sent to the virtqueue in virtio-net, we notify the virtqueue of the new buffer by invoking `vq.notify`. This notification process is resource-intensive, as it results in a VM-EXIT. For example, when sending a 64KB TCP message, we need to split it into packets, resulting in 44 packets (based on 64K/1516). Consequently, `vq.notify` is called 44 times, which can be quite time-consuming.

As suggest by `2.7.13 Supplying Buffers to The Device` in virtio spec, we should add multiple buffers if possible before notification:
```plain
The driver offers buffers to one of the device’s virtqueues as follows:
1. The driver places the buffer into free descriptor(s) in the descriptor table, chaining as necessary (see
2.7.5 The Virtqueue Descriptor Table).
2. The driver places the index of the head of the descriptor chain into the next ring entry of the available
ring.
3. Steps 1 and 2 MAY be performed repeatedly if batching is possible.
.........
7. The driver sends an available buffer notification to the device if such notifications are not suppressed.
```

In this PR, we attempt to invoke `vq.notify` at most once per device poll. The device driver will keep track of the number of packets sent and received during a single polling session. After the polling completes, the device driver will notify the virtqueue if any packets were sent or received. Since the device driver lock is consistently held throughout the device polling process, race conditions are effectively prevented.

# Experiment results

After this PR, the results of the benchmark are in the following table, the experiments are done on our CI machine: 

We can conclude that except for some outliers, Asterinas can achieve performance comparable to Linux.

IOMMU off | Tries 1 | Tries 2 | Tries 3 | Tries 4 | Tries 5
-- | -- | -- | -- | -- | --
Asteirnas(MB/sec) | **834** | 749 | **786** | **540** | 469
Linux(MB/src) | 751 | **770** | 783 | 488 | **734**

IOMMU on | Tries 1 | Tries 2 | Tries 3 | Tries 4 | Tries 5
-- | -- | -- | -- | -- | --
Asteirnas(MB/sec) | 507 | 502 | **789** | **771** | **768**
Linux(MB/src) | **693** | **507** | 739 | 726 | 738

</div>

## About Outliers

When running experiments on the CI machine, the results are either around 500 or around 800. This is true for both Linux and Asterinas, and this result appears in different experiments, suggesting it may be related to certain properties of the machine. When both Asterinas and Linux show a lower result (around 500) or both show a higher result (around 800), the results for Asterinas and Linux are quite similar. Otherwise we view it as an outlier.
