### PR TITLE
Fail the benchmark job if no result file is found

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BENCHMARK_ARTIFACT }}
+          if-no-files-found: error # Fail the benchmark job if no file is found.
           path: |
             result_*.json
 


### PR DESCRIPTION
The current benchmark setup does not throw errors when a benchmark job fails, as demonstrated in [this GitHub Actions run](https://github.com/asterinas/asterinas/actions/runs/12283970310/job/34278692723). While this behavior does not affect the `Results` job, it can create a misleading impression that the benchmarks executed successfully. To address this, we should implement a mechanism to enforce error reporting via `actions/upload-artifact@v4` in cases where no result file is detected.