### PR TITLE
Optimize inode lock usage and direntry lookup in ext2

### DIFF
--- a/kernel/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/ext2/impl_for_vfs/inode.rs
@@ -29,22 +29,7 @@ impl Inode for Ext2Inode {
     }
 
     fn metadata(&self) -> Metadata {
-        Metadata {
-            dev: 0, // TODO: ID of block device
-            ino: self.ino() as _,
-            size: self.file_size() as _,
-            blk_size: self.fs().super_block().block_size(),
-            blocks: self.blocks_count() as _,
-            atime: self.atime(),
-            mtime: self.mtime(),
-            ctime: self.ctime(),
-            type_: self.inode_type(),
-            mode: InodeMode::from(self.file_perm()),
-            nlinks: self.hard_links() as _,
-            uid: Uid::new(self.uid()),
-            gid: Gid::new(self.gid()),
-            rdev: self.device_id(),
-        }
+        self.metadata()
     }
 
     fn atime(&self) -> Duration {


### PR DESCRIPTION
This PR primarily includes:
1. Less locking in some inode micro-ops by: stripping the lock in `InodeImpl`, place fine-grained locks in a new struct `InodeBlockManager`, decoupled from `InodeDesc`.
2. Slightly improve the `DirEntry` lookup, leaving `DirEntry` updating as TODO which requires more work.

The benefit, taking benchmark `sqlite-speedtest1-ext2` as example:
| Case                 | old (latency) | New     |
| -------------------- | ------------- | ------- |
| SELECTS on an IPK    | 6.388s        | 5.190s  |
| SELECTS on a TEXT PK | 6.762s        | 5.560s  |
| ...                  |               |         |
| TOTAL                | 81.449s       | 75.440s |
