### PR TITLE
Warn unsupported clone flags instead of panic

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -165,7 +165,7 @@ impl CloneFlags {
             | CloneFlags::CLONE_CHILD_CLEARTID;
         let unsupported_flags = *self - supported_flags;
         if !unsupported_flags.is_empty() {
-            panic!("contains unsupported clone flags: {:?}", unsupported_flags);
+            warn!("contains unsupported clone flags: {:?}", unsupported_flags);
         }
         Ok(())
     }


### PR DESCRIPTION
Throw a warn message instead of panic when Asterinas receive unsupported clone flags.