### PR TITLE
Add several lmbench network benchmarks

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -59,16 +59,21 @@ jobs:
           - fio/ext2_seq_read_bw
           - fio/ext2_seq_write_bw_no_iommu
           - fio/ext2_seq_read_bw_no_iommu
-          # Network-related benchmarks
+          # Loopback-related network benchmarks
+          - lmbench/tcp_loopback_bw_128
           - lmbench/tcp_loopback_bw_4k
           - lmbench/tcp_loopback_bw_64k
           - lmbench/tcp_loopback_lat
           - lmbench/tcp_loopback_connect_lat
           - lmbench/tcp_loopback_select_lat
           - lmbench/tcp_loopback_http_bw
-          - lmbench/tcp_virtio_bw_64k
-          - lmbench/tcp_virtio_lat
           - lmbench/udp_loopback_lat
+          # VirtIO-net-related network benchmarks
+          - lmbench/tcp_virtio_bw_128
+          - lmbench/tcp_virtio_bw_64k
+          - lmbench/tcp_virtio_connect_lat
+          - lmbench/tcp_virtio_lat
+          - lmbench/udp_virtio_lat 
           - iperf3/tcp_virtio_bw
           # Scheduler-related benchmarks
           - hackbench/group8_smp1

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -129,7 +129,6 @@ pub(crate) unsafe fn init_on_ap() {
 
 pub(crate) fn interrupts_ack(irq_number: usize) {
     if !cpu::CpuException::is_cpu_exception(irq_number as u16) {
-        kernel::pic::ack();
         kernel::apic::with_borrow(|apic| {
             apic.eoi();
         });

--- a/test/benchmark/lmbench/summary.json
+++ b/test/benchmark/lmbench/summary.json
@@ -28,13 +28,18 @@
         "ramfs_create_delete_files_0k_ops",
         "ramfs_create_delete_files_10k_ops",
         "ext2_copy_files_bw",
+        "tcp_loopback_bw_128",
         "tcp_loopback_bw_4k",
         "tcp_loopback_bw_64k",
         "tcp_loopback_lat",
         "tcp_loopback_connect_lat",
         "tcp_loopback_select_lat",
         "tcp_loopback_http_bw",
+        "udp_loopback_lat",
+        "tcp_virtio_bw_128",
         "tcp_virtio_bw_64k",
-        "udp_loopback_lat"
+        "tcp_virtio_connect_lat",
+        "tcp_virtio_lat",
+        "udp_virtio_lat"
     ]
 }

--- a/test/benchmark/lmbench/tcp_loopback_bw_128/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_bw_128/bench_result.json
@@ -1,0 +1,16 @@
+{
+    "alert": {
+        "threshold": "125%",
+        "bigger_is_better": true
+    },
+    "result_extraction": {
+        "search_pattern": "0.000128 +[0-9.]+",
+        "result_index": 2
+    },
+    "chart": {
+        "title": "[TCP sockets] The bandwidth (localhost, 128B message)",
+        "description": "bw_tcp -l",
+        "unit": "MB/s",
+        "legend": "Average TCP bandwidth on {system}"
+    }
+}

--- a/test/benchmark/lmbench/tcp_loopback_bw_128/run.sh
+++ b/test/benchmark/lmbench/tcp_loopback_bw_128/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "*** Running lmbench TCP bandwidth test ***"
+
+/benchmark/bin/lmbench/bw_tcp -s 127.0.0.1 -b 1
+/benchmark/bin/lmbench/bw_tcp -m 128 -P 1 127.0.0.1
+/benchmark/bin/lmbench/bw_tcp -S 127.0.0.1

--- a/test/benchmark/lmbench/tcp_virtio_bw_128/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_bw_128/bench_result.json
@@ -1,0 +1,16 @@
+{
+    "alert": {
+        "threshold": "125%",
+        "bigger_is_better": true
+    },
+    "result_extraction": {
+        "search_pattern": "0.000128 +[0-9.]+ +MB",
+        "result_index": 2
+    },
+    "chart": {
+        "title": "[TCP sockets] The bandwidth (virtio-net, 128B message)",
+        "description": "bw_tcp -l",
+        "unit": "MB/sec",
+        "legend": "Average TCP bandwidth on {system}"
+    }
+}

--- a/test/benchmark/lmbench/tcp_virtio_bw_128/host.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_128/host.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run lmbench tcp client
+echo "Running lmbench tcp client connected to $GUEST_SERVER_IP_ADDRESS"
+# The -W parameter of bw_tcp refers to the number of bytes transferred during the warm-up phase.
+/usr/local/benchmark/lmbench/bw_tcp -m 128 -P 1 -W 50000000 -N 100 $GUEST_SERVER_IP_ADDRESS
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/lmbench/tcp_virtio_bw_128/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_128/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running lmbench TCP latency over virtio-net..."
+
+# Start the server
+/benchmark/bin/lmbench/bw_tcp -s 10.0.2.15 -b 1
+
+# Sleep for a long time to ensure VM won't exit
+sleep 200

--- a/test/benchmark/lmbench/tcp_virtio_connect_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_connect_lat/bench_result.json
@@ -1,0 +1,16 @@
+{
+    "alert": {
+        "threshold": "125%",
+        "bigger_is_better": false
+    },
+    "result_extraction": {
+        "search_pattern": "TCP\\/IP connection cost to [0-9.]+: +[0-9.]+",
+        "result_index": 6
+    },
+    "chart": {
+        "title": "[TCP sockets] The latency of connect",
+        "description": "lat_connect",
+        "unit": "\u00b5s",
+        "legend": "Average TCP connection latency on {system}"
+    }
+}

--- a/test/benchmark/lmbench/tcp_virtio_connect_lat/host.sh
+++ b/test/benchmark/lmbench/tcp_virtio_connect_lat/host.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run lmbench tcp client
+echo "Running lmbench tcp client connected to $GUEST_SERVER_IP_ADDRESS"
+/usr/local/benchmark/lmbench/lat_connect $GUEST_SERVER_IP_ADDRESS
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/lmbench/tcp_virtio_connect_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_connect_lat/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running lmbench TCP latency over virtio-net..."
+
+# Start the server
+benchmark/bin/lmbench/lat_connect -s 10.0.2.15 -b 1000
+
+# Sleep for a long time to ensure VM won't exit
+sleep 200

--- a/test/benchmark/lmbench/udp_virtio_lat/bench_result.json
+++ b/test/benchmark/lmbench/udp_virtio_lat/bench_result.json
@@ -1,0 +1,16 @@
+{
+    "alert": {
+        "threshold": "125%",
+        "bigger_is_better": false
+    },
+    "result_extraction": {
+        "search_pattern": "UDP latency using [0-9.]+: +[0-9.]+",
+        "result_index": 5
+    },
+    "chart": {
+        "title": "[UDP sockets] The latency of write+read (virtio-net)",
+        "description": "lat_udp",
+        "unit": "\u00b5s",
+        "legend": "Average UDP latency over virtio-net on {system}"
+    }
+}

--- a/test/benchmark/lmbench/udp_virtio_lat/host.sh
+++ b/test/benchmark/lmbench/udp_virtio_lat/host.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Warm up: We intentionally run another test for warmup here. 
+# Note that we can't use -W option for warmup here because it will fail due to receiving timeout.
+echo "Warm up......"
+/usr/local/benchmark/lmbench/lat_udp -P 1 -N 10 $GUEST_SERVER_IP_ADDRESS >/dev/null 2>&1
+# Run lmbench udp client
+echo "Running lmbench udp client connected to $GUEST_SERVER_IP_ADDRESS"
+/usr/local/benchmark/lmbench/lat_udp -P 1 -N 10 $GUEST_SERVER_IP_ADDRESS
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/lmbench/udp_virtio_lat/run.sh
+++ b/test/benchmark/lmbench/udp_virtio_lat/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running lmbench UDP latency over virtio-net..."
+
+# Start the server
+/benchmark/bin/lmbench/lat_udp -s 10.0.2.15
+
+# Sleep for a long time to ensure VM won't exit
+sleep 200


### PR DESCRIPTION
This PR introduces several new lmbench networks:

- tcp_virtio_connect_lat: Previously, we only had a benchmark for localhost.
- udp_virtio_lat: Previously, we only had a benchmark for localhost.
- tcp_virtio_bw_128 and tcp_loopback_bw_128: We aim to test bandwidth for both small and large packets. The large packet size is 64KB, while the small packet size is 128 bytes. Originally, I intended to use 64 bytes for the small packets, but Linux exhibited poor performance at that size (three times slower than Asterinas on the CI machine, possibly due to specific configurations on the CI machine). Hence, I opted for 128 bytes, where Linux's performance is significantly better, and Asterinas is only 1.5 times faster than Linux.

@sdww0, could you please take a look at this PR to see whether any benchmark will be covered in the paper is still missing and the PIC ACK changes in the first commit?