### PR TITLE
Clarify the naming conventions under benchmark/schbench/

### DIFF
--- a/test/benchmark/schbench/smp1/bench_results/p50_rps_smp1.json
+++ b/test/benchmark/schbench/smp1/bench_results/p50_rps_smp1.json
@@ -9,7 +9,7 @@
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P50 RPS while max-loading the only CPU",
+        "title": "[Scheduler] P50 RPS while max-loading the only CPU (SMP=1)",
         "description": "schbench -F 256 -n 5 -r 90",
         "unit": "requests per second",
         "legend": "P50 RPS of schbench on {system}"

--- a/test/benchmark/schbench/smp1/bench_results/p99_request_latency_smp1.json
+++ b/test/benchmark/schbench/smp1/bench_results/p99_request_latency_smp1.json
@@ -9,7 +9,7 @@
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P99 request latency while max-loading the only CPU",
+        "title": "[Scheduler] P99 request latency while max-loading the only CPU (SMP=1)",
         "description": "schbench -F 256 -n 5 -r 90",
         "unit": "\u00b5s",
         "legend": "P99 request latency of schbench on {system}"

--- a/test/benchmark/schbench/smp1/bench_results/p99_wakeup_latency_smp1.json
+++ b/test/benchmark/schbench/smp1/bench_results/p99_wakeup_latency_smp1.json
@@ -9,7 +9,7 @@
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P99 wakeup latency while max-loading the only CPU",
+        "title": "[Scheduler] P99 wakeup latency while max-loading the only CPU (SMP=1)",
         "description": "schbench -F 256 -n 5 -r 90",
         "unit": "\u00b5s",
         "legend": "P99 wakeup latency of schbench on {system}"

--- a/test/benchmark/schbench/smp8/bench_results/p50_rps_smp8.json
+++ b/test/benchmark/schbench/smp8/bench_results/p50_rps_smp8.json
@@ -1,18 +1,18 @@
 {
     "alert": {
         "threshold": "130%",
-        "bigger_is_better": false
+        "bigger_is_better": true
     },
     "result_extraction": {
         "search_pattern": "\\*",
-        "nth_occurrence": 1,
+        "nth_occurrence": 3,
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P99 wakeup latency while max-loading the only CPU",
+        "title": "[Scheduler] P50 RPS while max-loading the only CPU (SMP=8)",
         "description": "schbench -F 256 -n 5 -r 90",
-        "unit": "\u00b5s",
-        "legend": "P99 wakeup latency of schbench on {system}"
+        "unit": "requests per second",
+        "legend": "P50 RPS of schbench on {system}"
     },
     "runtime_config": {
         "smp": 8

--- a/test/benchmark/schbench/smp8/bench_results/p99_request_latency_smp8.json
+++ b/test/benchmark/schbench/smp8/bench_results/p99_request_latency_smp8.json
@@ -1,18 +1,18 @@
 {
     "alert": {
         "threshold": "130%",
-        "bigger_is_better": true
+        "bigger_is_better": false
     },
     "result_extraction": {
         "search_pattern": "\\*",
-        "nth_occurrence": 3,
+        "nth_occurrence": 2,
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P50 RPS while max-loading the only CPU",
+        "title": "[Scheduler] P99 request latency while max-loading the only CPU (SMP=8)",
         "description": "schbench -F 256 -n 5 -r 90",
-        "unit": "requests per second",
-        "legend": "P50 RPS of schbench on {system}"
+        "unit": "\u00b5s",
+        "legend": "P99 request latency of schbench on {system}"
     },
     "runtime_config": {
         "smp": 8

--- a/test/benchmark/schbench/smp8/bench_results/p99_wakeup_latency_smp8.json
+++ b/test/benchmark/schbench/smp8/bench_results/p99_wakeup_latency_smp8.json
@@ -5,14 +5,14 @@
     },
     "result_extraction": {
         "search_pattern": "\\*",
-        "nth_occurrence": 2,
+        "nth_occurrence": 1,
         "result_index": 3
     },
     "chart": {
-        "title": "[Scheduler] P99 request latency while max-loading the only CPU",
+        "title": "[Scheduler] P99 wakeup latency while max-loading the only CPU (SMP=8)",
         "description": "schbench -F 256 -n 5 -r 90",
         "unit": "\u00b5s",
-        "legend": "P99 request latency of schbench on {system}"
+        "legend": "P99 wakeup latency of schbench on {system}"
     },
     "runtime_config": {
         "smp": 8


### PR DESCRIPTION
The current [benchmark page of schbench](https://asterinas.github.io/benchmark/schbench/) presents a confusing layout, as the results for `SMP=1` and `SMP=8` are intermingled. 

This PR addresses this issue by clarifying the naming conventions within the `smp8/` directory. For instance, files such as `smp8/bench_results/p99_request_latency_smp1.json` have been renamed to `smp8/bench_results/p99_request_latency_smp8.json` to accurately reflect their SMP configuration. Additionally, the titles have been updated to clearly indicate the SMP settings they correspond to.