### PR TITLE
Add socket hashtable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,10 +71,11 @@ name = "aster-bigtcp"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
- "keyable-arc",
+ "jhash",
  "ostd",
  "smoltcp",
  "spin 0.9.8",
+ "static_assertions",
  "takeable",
 ]
 
@@ -838,6 +839,10 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "jhash"
+version = "0.1.0"
 
 [[package]]
 name = "json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "kernel/libs/aster-rights-proc",
     "kernel/libs/aster-util",
     "kernel/libs/aster-bigtcp",
+    "kernel/libs/jhash",
     "kernel/libs/keyable-arc",
     "kernel/libs/typeflags",
     "kernel/libs/typeflags-util",

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ NON_OSDK_CRATES := \
 	kernel/libs/int-to-c-enum/derive \
 	kernel/libs/aster-rights \
 	kernel/libs/aster-rights-proc \
+	kernel/libs/jhash \
 	kernel/libs/keyable-arc \
 	kernel/libs/typeflags \
 	kernel/libs/typeflags-util \

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.3"
-keyable-arc = { path = "../keyable-arc" }
+jhash = { path = "../jhash" }
 ostd = { path = "../../../ostd" }
 smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f07e5b5", default-features = false, features = [
     "alloc",
@@ -19,4 +19,5 @@ smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f0
     "socket-tcp",
 ] }
 spin = "0.9.4"
+static_assertions = "1.1.0"
 takeable = "0.2.2"

--- a/kernel/libs/aster-bigtcp/src/errors.rs
+++ b/kernel/libs/aster-bigtcp/src/errors.rs
@@ -10,7 +10,41 @@ pub enum BindError {
 }
 
 pub mod tcp {
-    pub use smoltcp::socket::tcp::{ConnectError, ListenError, RecvError, SendError};
+    pub use smoltcp::socket::tcp::{RecvError, SendError};
+
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub enum ListenError {
+        InvalidState,
+        Unaddressable,
+        /// The specified address is in use.
+        AddressInUse,
+    }
+
+    impl From<smoltcp::socket::tcp::ListenError> for ListenError {
+        fn from(value: smoltcp::socket::tcp::ListenError) -> Self {
+            match value {
+                smoltcp::socket::tcp::ListenError::InvalidState => Self::InvalidState,
+                smoltcp::socket::tcp::ListenError::Unaddressable => Self::Unaddressable,
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub enum ConnectError {
+        InvalidState,
+        Unaddressable,
+        /// The specified address is in use.
+        AddressInUse,
+    }
+
+    impl From<smoltcp::socket::tcp::ConnectError> for ConnectError {
+        fn from(value: smoltcp::socket::tcp::ConnectError) -> Self {
+            match value {
+                smoltcp::socket::tcp::ConnectError::InvalidState => Self::InvalidState,
+                smoltcp::socket::tcp::ConnectError::Unaddressable => Self::Unaddressable,
+            }
+        }
+    }
 }
 
 pub mod udp {

--- a/kernel/libs/aster-bigtcp/src/lib.rs
+++ b/kernel/libs/aster-bigtcp/src/lib.rs
@@ -12,13 +12,14 @@
 
 #![no_std]
 #![deny(unsafe_code)]
-#![feature(btree_extract_if)]
+#![feature(extract_if)]
 
 pub mod device;
 pub mod errors;
 pub mod ext;
 pub mod iface;
 pub mod socket;
+pub mod socket_table;
 pub mod time;
 pub mod wire;
 

--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module defines the socket table, which manages all TCP and UDP sockets,
+//! for efficiently inserting, looking up, and removing sockets.
+
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::net::Ipv4Addr;
+
+use jhash::{jhash_1vals, jhash_3vals};
+use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
+use static_assertions::const_assert;
+
+use crate::{
+    ext::Ext,
+    socket::{TcpConnectionBg, TcpListenerBg, UdpSocketBg},
+    wire::PortNum,
+};
+
+pub type SocketHash = u32;
+
+/// A unique key for identifying a `TcpListener`.
+///
+/// Note that two `TcpListener`s cannot listen on the same address
+/// even if both sockets set SO_REUSEADDR to true,
+/// so there cannot be multiple listeners with the same `ListenerKey`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ListenerKey {
+    addr: IpAddress,
+    port: PortNum,
+    hash: SocketHash,
+}
+
+impl ListenerKey {
+    pub(crate) const fn new(addr: IpAddress, port: PortNum) -> Self {
+        // FIXME: If the socket is listening on an unspecified address (0.0.0.0),
+        // Linux will get the hash value by port only.
+        let hash = hash_addr_port(addr, port);
+        Self { addr, port, hash }
+    }
+
+    pub(crate) const fn hash(&self) -> SocketHash {
+        self.hash
+    }
+}
+
+impl From<IpListenEndpoint> for ListenerKey {
+    fn from(listen_endpoint: IpListenEndpoint) -> Self {
+        let addr = listen_endpoint
+            .addr
+            .unwrap_or(IpAddress::Ipv4(Ipv4Addr::UNSPECIFIED));
+        let port = listen_endpoint.port;
+        Self::new(addr, port)
+    }
+}
+
+/// A unique key for identifying a `TcpConnection`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ConnectionKey {
+    local_addr: IpAddress,
+    local_port: PortNum,
+    remote_addr: IpAddress,
+    remote_port: PortNum,
+    hash: SocketHash,
+}
+
+impl ConnectionKey {
+    pub(crate) const fn new(
+        local_addr: IpAddress,
+        local_port: PortNum,
+        remote_addr: IpAddress,
+        remote_port: PortNum,
+    ) -> Self {
+        let hash = hash_local_remote(local_addr, local_port, remote_addr, remote_port);
+        Self {
+            local_addr,
+            local_port,
+            remote_addr,
+            remote_port,
+            hash,
+        }
+    }
+
+    pub(crate) const fn hash(&self) -> SocketHash {
+        self.hash
+    }
+}
+
+impl From<(IpEndpoint, IpEndpoint)> for ConnectionKey {
+    fn from(value: (IpEndpoint, IpEndpoint)) -> Self {
+        Self::new(value.0.addr, value.0.port, value.1.addr, value.1.port)
+    }
+}
+
+// FIXME: The following two constants should be randomly-generated at runtime
+const HASH_SECRET: u32 = 0xdeadbeef;
+
+// FIXME: This constant should be a per-net-namespace value
+const NET_HASHMIX: u32 = 0xbeefdead;
+
+const fn hash_local_remote(
+    local_addr: IpAddress,
+    local_port: PortNum,
+    remote_addr: IpAddress,
+    remote_port: PortNum,
+) -> SocketHash {
+    // FIXME: Deal with IPv6 addresses once IPv6 is supported.
+    let IpAddress::Ipv4(local_ipv4) = local_addr;
+    let IpAddress::Ipv4(remote_ipv4) = remote_addr;
+
+    jhash_3vals(
+        local_ipv4.to_bits(),
+        remote_ipv4.to_bits(),
+        (local_port as u32).wrapping_shl(16) | remote_port as u32,
+        HASH_SECRET.wrapping_add(NET_HASHMIX),
+    )
+}
+
+const fn hash_addr_port(addr: IpAddress, port: PortNum) -> SocketHash {
+    // FIXME: Deal with IPv6 addresses once IPv6 is supported.
+    let IpAddress::Ipv4(ipv4_addr) = addr;
+
+    jhash_1vals(ipv4_addr.to_bits(), NET_HASHMIX) ^ (port as u32)
+}
+
+/// The socket table manages TCP and UDP sockets.
+///
+/// Unlike the Linux inet hashtable, which is shared across a single network namespace,
+/// this table is currently limited to a single interface.
+///
+// TODO: Modify the table to be shared across a single network namespace
+// to support INADDR_ANY (0.0.0.0).
+pub(crate) struct SocketTable<E: Ext> {
+    // TODO: Linux has two hashtables for listeners:
+    // the first is hashed by local address and port,
+    // the second is hashed by local port only.
+    // The second table is the only place where sockets listening on INADDR_ANY (0.0.0.0) can exist.
+    // Since we do not yet support INADDR_ANY, we only have the first table here.
+    listener_buckets: Box<[ListenerHashBucket<E>]>,
+    connection_buckets: Box<[ConnectionHashBucket<E>]>,
+    // Linux does not include UDP sockets in the inet hashtable.
+    // Here we include UDP sockets in the socket table for simplicity.
+    // Note that multiple UDP sockets can be bound to the same address,
+    // so we cannot use (addr, port) as a _unique_ key for UDP sockets.
+    udp_sockets: Vec<Arc<UdpSocketBg<E>>>,
+}
+
+// On Linux, the number of buckets is determined at runtime based on the available memory.
+// For simplicity, we use fixed values here.
+// The bucket count should be a power of 2 to ensure efficient modulo calculations.
+const LISTENER_BUCKET_COUNT: u32 = 64;
+const LISTENER_BUCKET_MASK: u32 = LISTENER_BUCKET_COUNT - 1;
+const CONNECTION_BUCKET_COUNT: u32 = 8192;
+const CONNECTION_BUCKET_MASK: u32 = CONNECTION_BUCKET_COUNT - 1;
+
+const_assert!(LISTENER_BUCKET_COUNT.is_power_of_two());
+const_assert!(CONNECTION_BUCKET_COUNT.is_power_of_two());
+
+impl<E: Ext> SocketTable<E> {
+    pub(crate) fn new() -> Self {
+        let listener_buckets = (0..LISTENER_BUCKET_COUNT)
+            .map(|_| ListenerHashBucket::new())
+            .collect();
+
+        let connection_buckets = (0..CONNECTION_BUCKET_COUNT)
+            .map(|_| ConnectionHashBucket::new())
+            .collect();
+
+        let udp_sockets = Vec::new();
+
+        Self {
+            listener_buckets,
+            connection_buckets,
+            udp_sockets,
+        }
+    }
+
+    /// Inserts a TCP listener into the table.
+    ///
+    /// If a socket with the same [`ListenerKey`] has already been inserted,
+    /// this method will return an error and the listener will not be inserted.
+    pub(crate) fn insert_listener(
+        &mut self,
+        listener: Arc<TcpListenerBg<E>>,
+    ) -> Result<(), Arc<TcpListenerBg<E>>> {
+        let key = listener.listener_key();
+
+        let bucket = {
+            let hash = key.hash();
+            let bucket_index = hash & LISTENER_BUCKET_MASK;
+            &mut self.listener_buckets[bucket_index as usize]
+        };
+
+        if bucket
+            .listeners
+            .iter()
+            .any(|tcp_listener| tcp_listener.listener_key() == listener.listener_key())
+        {
+            return Err(listener);
+        }
+
+        bucket.listeners.push(listener);
+        Ok(())
+    }
+
+    pub(crate) fn insert_connection(
+        &mut self,
+        connection: Arc<TcpConnectionBg<E>>,
+    ) -> Result<(), Arc<TcpConnectionBg<E>>> {
+        let key = connection.connection_key();
+
+        let bucket = {
+            let hash = key.hash();
+            let bucket_index = hash & CONNECTION_BUCKET_MASK;
+            &mut self.connection_buckets[bucket_index as usize]
+        };
+
+        if bucket
+            .connections
+            .iter()
+            .any(|tcp_connection| tcp_connection.connection_key() == connection.connection_key())
+        {
+            return Err(connection);
+        }
+
+        bucket.connections.push(connection);
+        Ok(())
+    }
+
+    pub(crate) fn insert_udp_socket(&mut self, udp_socket: Arc<UdpSocketBg<E>>) {
+        debug_assert!(!self
+            .udp_sockets
+            .iter()
+            .any(|socket| Arc::ptr_eq(socket, &udp_socket)));
+        self.udp_sockets.push(udp_socket);
+    }
+
+    pub(crate) fn lookup_listener(&self, key: &ListenerKey) -> Option<&Arc<TcpListenerBg<E>>> {
+        let bucket = {
+            let hash = key.hash();
+            let bucket_index = hash & LISTENER_BUCKET_MASK;
+            &self.listener_buckets[bucket_index as usize]
+        };
+
+        bucket
+            .listeners
+            .iter()
+            .find(|listener| listener.listener_key() == key)
+    }
+
+    pub(crate) fn lookup_connection(
+        &self,
+        key: &ConnectionKey,
+    ) -> Option<&Arc<TcpConnectionBg<E>>> {
+        let bucket = {
+            let hash = key.hash();
+            let bucket_index = hash & CONNECTION_BUCKET_MASK;
+            &self.connection_buckets[bucket_index as usize]
+        };
+
+        bucket
+            .connections
+            .iter()
+            .find(|connection| connection.connection_key() == key)
+    }
+
+    pub(crate) fn remove_listener(
+        &mut self,
+        listener: &TcpListenerBg<E>,
+    ) -> Option<Arc<TcpListenerBg<E>>> {
+        let key = listener.listener_key();
+
+        let bucket = {
+            let hash = key.hash();
+            let bucket_index = hash & LISTENER_BUCKET_MASK;
+            &mut self.listener_buckets[bucket_index as usize]
+        };
+
+        let index = bucket
+            .listeners
+            .iter()
+            .position(|tcp_listener| tcp_listener.listener_key() == listener.listener_key())?;
+        Some(bucket.listeners.swap_remove(index))
+    }
+
+    pub(crate) fn remove_udp_socket(
+        &mut self,
+        socket: &Arc<UdpSocketBg<E>>,
+    ) -> Option<Arc<UdpSocketBg<E>>> {
+        let index = self
+            .udp_sockets
+            .iter()
+            .position(|udp_socket| Arc::ptr_eq(udp_socket, socket))?;
+        Some(self.udp_sockets.swap_remove(index))
+    }
+
+    pub(crate) fn remove_dead_tcp_connections(&mut self) {
+        for connection_bucket in self.connection_buckets.iter_mut() {
+            for tcp_conn in connection_bucket
+                .connections
+                .extract_if(|connection| connection.is_dead())
+            {
+                tcp_conn.on_dead_events();
+            }
+        }
+    }
+
+    pub(crate) fn tcp_listener_iter(&self) -> impl Iterator<Item = &Arc<TcpListenerBg<E>>> {
+        self.listener_buckets
+            .iter()
+            .flat_map(|bucket| bucket.listeners.iter())
+    }
+
+    pub(crate) fn tcp_conn_iter(&self) -> impl Iterator<Item = &Arc<TcpConnectionBg<E>>> {
+        self.connection_buckets
+            .iter()
+            .flat_map(|bucket| bucket.connections.iter())
+    }
+
+    pub(crate) fn udp_socket_iter(&self) -> impl Iterator<Item = &Arc<UdpSocketBg<E>>> {
+        self.udp_sockets.iter()
+    }
+}
+
+impl<E: Ext> Default for SocketTable<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct ListenerHashBucket<E: Ext> {
+    listeners: Vec<Arc<TcpListenerBg<E>>>,
+}
+
+impl<E: Ext> ListenerHashBucket<E> {
+    const fn new() -> Self {
+        Self {
+            listeners: Vec::new(),
+        }
+    }
+}
+
+struct ConnectionHashBucket<E: Ext> {
+    connections: Vec<Arc<TcpConnectionBg<E>>>,
+}
+
+impl<E: Ext> ConnectionHashBucket<E> {
+    const fn new() -> Self {
+        Self {
+            connections: Vec::new(),
+        }
+    }
+}

--- a/kernel/libs/jhash/Cargo.toml
+++ b/kernel/libs/jhash/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "jhash"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/kernel/libs/jhash/src/lib.rs
+++ b/kernel/libs/jhash/src/lib.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module implements hash algorithms developed by Bob Jenkins.
+//!
+//! For further information, visit: www.burtleburtle.net/bob/hash/doobs.html
+//!
+//! The hash functions in this module facilitate the production of 32-bit values for hash table lookups.
+//! Although the [Linux kernel's jhash](https://github.com/torvalds/linux/blob/master/include/linux/jhash.h)
+//! slightly differs from the original version, this module reimplements the Linux kernel's version.
+//!
+
+#![no_std]
+#![deny(unsafe_code)]
+
+/// A randomly chosen initial value
+const JHASH_INITVAL: u32 = 0xdeadbeef;
+
+/// Hashes an arbitrary u8 slices.
+///
+/// # Example
+///
+/// If you are hashing n slices, do it like this:
+/// ```rust
+/// use jhash::jhash_slice;
+///
+/// fn hash_slices(slices: &[&[u8]]) -> u32 {
+///     let mut hash: u32 = 0;
+///     for slice in slices {
+///         hash = jhash_slice(slice, hash);
+///     }
+///     hash
+/// }
+/// ```
+pub const fn jhash_slice(slice: &[u8], initval: u32) -> u32 {
+    let mut length = slice.len() as u32;
+    let mut index: usize = 0;
+
+    // Init the internal state
+    let mut a: u32 = JHASH_INITVAL.wrapping_add(length).wrapping_add(initval);
+    let mut b: u32 = a;
+    let mut c: u32 = a;
+
+    // Handle the most bytes except last 12 bytes
+    while length > 12 {
+        // FIXME: The Linux version uses `u32::from_ne_bytes`.
+        // Here, we use `from_le_bytes` to ensure consistency
+        // in results across multiple runs on all machines.
+        a = a.wrapping_add(u32::from_le_bytes([
+            slice[index],
+            slice[index + 1],
+            slice[index + 2],
+            slice[index + 3],
+        ]));
+        b = b.wrapping_add(u32::from_le_bytes([
+            slice[index + 4],
+            slice[index + 5],
+            slice[index + 6],
+            slice[index + 7],
+        ]));
+        c = c.wrapping_add(u32::from_le_bytes([
+            slice[index + 8],
+            slice[index + 9],
+            slice[index + 10],
+            slice[index + 11],
+        ]));
+        (a, b, c) = jhash_mix(a, b, c);
+
+        index += 12;
+        length -= 12;
+    }
+
+    // Handle the last 12 bytes
+    if length == 12 {
+        c = c.wrapping_add((slice[index + 11] as u32) << 24);
+    }
+
+    if length >= 11 {
+        c = c.wrapping_add((slice[index + 10] as u32) << 16);
+    }
+
+    if length >= 10 {
+        c = c.wrapping_add((slice[index + 9] as u32) << 8);
+    }
+
+    if length >= 9 {
+        c = c.wrapping_add(slice[index + 8] as u32);
+    }
+
+    if length >= 8 {
+        b = b.wrapping_add((slice[index + 7] as u32) << 24);
+    }
+
+    if length >= 7 {
+        b = b.wrapping_add((slice[index + 6] as u32) << 16);
+    }
+
+    if length >= 6 {
+        b = b.wrapping_add((slice[index + 5] as u32) << 8);
+    }
+
+    if length >= 5 {
+        b = b.wrapping_add(slice[index + 4] as u32);
+    }
+
+    if length >= 4 {
+        a = a.wrapping_add((slice[index + 3] as u32) << 24);
+    }
+
+    if length >= 3 {
+        a = a.wrapping_add((slice[index + 2] as u32) << 16);
+    }
+
+    if length >= 2 {
+        a = a.wrapping_add((slice[index + 1] as u32) << 8);
+    }
+
+    if length >= 1 {
+        a = a.wrapping_add(slice[index] as u32);
+        return jhash_final(a, b, c);
+    }
+
+    c
+}
+
+/// Hashes exactly three u32 values
+pub const fn jhash_3vals(a: u32, b: u32, c: u32, initval: u32) -> u32 {
+    jhash_3vals_inner(
+        a,
+        b,
+        c,
+        initval.wrapping_add(JHASH_INITVAL).wrapping_add(3 << 2),
+    )
+}
+
+/// Hashes exactly two u32 values
+pub const fn jhash_2vals(a: u32, b: u32, initval: u32) -> u32 {
+    jhash_3vals_inner(
+        a,
+        b,
+        0,
+        initval.wrapping_add(JHASH_INITVAL).wrapping_add(2 << 2),
+    )
+}
+
+/// Hashes exactly one u32 value
+pub const fn jhash_1vals(a: u32, initval: u32) -> u32 {
+    jhash_3vals_inner(
+        a,
+        0,
+        0,
+        initval.wrapping_add(JHASH_INITVAL).wrapping_add(1 << 2),
+    )
+}
+
+/// Hashes an array of u32 values.
+pub const fn jhash_u32_array(array: &[u32], initval: u32) -> u32 {
+    let mut length = array.len() as u32;
+    let mut index = 0;
+
+    // Initialize values a, b, and c
+    let mut a: u32 = JHASH_INITVAL
+        .wrapping_add(length << 2)
+        .wrapping_add(initval);
+    let mut b: u32 = a;
+    let mut c: u32 = a;
+
+    // Process most values except the last three
+    while length > 3 {
+        a = a.wrapping_add(array[index]);
+        b = b.wrapping_add(array[index + 1]);
+        c = c.wrapping_add(array[index + 2]);
+        (a, b, c) = jhash_mix(a, b, c);
+
+        length -= 3;
+        index += 3;
+    }
+
+    if length == 3 {
+        c = c.wrapping_add(array[index + 2]);
+    }
+
+    if length >= 2 {
+        b = b.wrapping_add(array[index + 1]);
+    }
+
+    if length >= 1 {
+        a = a.wrapping_add(array[index]);
+        return jhash_final(a, b, c);
+    }
+
+    c
+}
+
+/// An internal function that handles hashing for 3 u32 values
+const fn jhash_3vals_inner(mut a: u32, mut b: u32, mut c: u32, initval: u32) -> u32 {
+    a = a.wrapping_add(initval);
+    b = b.wrapping_add(initval);
+    c = c.wrapping_add(initval);
+
+    jhash_final(a, b, c)
+}
+
+/// Finalizes the mix of three 32-bit values into a single u32 value
+const fn jhash_final(mut a: u32, mut b: u32, mut c: u32) -> u32 {
+    c ^= b;
+    c = c.wrapping_sub(b.rotate_left(14));
+
+    a ^= c;
+    a = a.wrapping_sub(c.rotate_left(11));
+
+    b ^= a;
+    b = b.wrapping_sub(a.rotate_left(25));
+
+    c ^= b;
+    c = c.wrapping_sub(b.rotate_left(16));
+
+    a ^= c;
+    a = a.wrapping_sub(c.rotate_left(4));
+
+    b ^= a;
+    b = b.wrapping_sub(a.rotate_left(14));
+
+    c ^= b;
+    c.wrapping_sub(b.rotate_left(24))
+}
+
+/// Mixes three 32-bit values in a reversible manner
+const fn jhash_mix(mut a: u32, mut b: u32, mut c: u32) -> (u32, u32, u32) {
+    a = a.wrapping_sub(c);
+    a ^= c.rotate_left(4);
+    c = c.wrapping_add(b);
+
+    b = b.wrapping_sub(a);
+    b ^= a.rotate_left(6);
+    a = a.wrapping_add(c);
+
+    c = c.wrapping_sub(b);
+    c ^= b.rotate_left(8);
+    b = b.wrapping_add(a);
+
+    a = a.wrapping_sub(c);
+    a ^= c.rotate_left(16);
+    c = c.wrapping_add(b);
+
+    b = b.wrapping_sub(a);
+    b ^= a.rotate_left(19);
+    a = a.wrapping_add(c);
+
+    c = c.wrapping_sub(b);
+    c ^= b.rotate_left(4);
+    b = b.wrapping_add(a);
+
+    (a, b, c)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const JHASH_INITVAL: u32 = 0;
+
+    #[test]
+    fn test_jhash_3vals() {
+        assert_eq!(jhash_3vals(1, 2, 3, JHASH_INITVAL), 2757843189);
+        assert_eq!(jhash_3vals(4, 5, 6, JHASH_INITVAL), 3701334656);
+
+        assert_eq!(jhash_3vals(0, 0, 0, JHASH_INITVAL), 459859287);
+        assert_eq!(
+            jhash_3vals(u32::MAX, u32::MAX, u32::MAX, JHASH_INITVAL),
+            1846109353
+        );
+
+        assert_eq!(jhash_3vals(1, 2, 3, 10), 453614296);
+        assert_eq!(jhash_3vals(10, 20, 30, 5), 1448556389);
+    }
+
+    #[test]
+    fn test_jhash_2vals() {
+        assert_eq!(jhash_2vals(1, 2, JHASH_INITVAL), 2337044857);
+        assert_eq!(jhash_2vals(3, 4, JHASH_INITVAL), 3842257880);
+        assert_eq!(jhash_2vals(0, 0, JHASH_INITVAL), 1489077439);
+        assert_eq!(jhash_2vals(u32::MAX, u32::MAX, JHASH_INITVAL), 1382321797);
+        assert_eq!(jhash_2vals(1, 2, 10), 1474913524);
+        assert_eq!(jhash_2vals(10, 20, 5), 1368945286);
+    }
+
+    #[test]
+    fn test_jhash_1vals() {
+        assert_eq!(jhash_1vals(1, JHASH_INITVAL), 1923623579);
+        assert_eq!(jhash_1vals(5, JHASH_INITVAL), 4121471414);
+        assert_eq!(jhash_1vals(0, JHASH_INITVAL), 76781240);
+        assert_eq!(jhash_1vals(u32::MAX, JHASH_INITVAL), 2601633627);
+        assert_eq!(jhash_1vals(1, 10), 1508237099);
+        assert_eq!(jhash_1vals(10, 5), 2141486731);
+    }
+
+    #[test]
+    fn test_jhash_u32_array() {
+        assert_eq!(jhash_u32_array(&[1, 2, 3], JHASH_INITVAL), 2757843189);
+        assert_eq!(jhash_u32_array(&[4, 5, 6, 7, 8], JHASH_INITVAL), 581654130);
+        assert_eq!(jhash_u32_array(&[], JHASH_INITVAL), 3735928559);
+        assert_eq!(jhash_u32_array(&[10], JHASH_INITVAL), 1030482289);
+        assert_eq!(jhash_u32_array(&[10, 20], JHASH_INITVAL), 363923158);
+        assert_eq!(
+            jhash_u32_array(&[0, 1, 2, u32::MAX], JHASH_INITVAL),
+            3019125658
+        );
+        assert_eq!(jhash_u32_array(&[1, 2, 3], 10), 453614296);
+    }
+
+    #[test]
+    fn test_jhash_slice() {
+        assert_eq!(jhash_slice(b"hello world", JHASH_INITVAL), 1252609637);
+        assert_eq!(jhash_slice(b"12345", JHASH_INITVAL), 729031446);
+        assert_eq!(jhash_slice(b"\n\t\r", JHASH_INITVAL), 483925400);
+        assert_eq!(jhash_slice(b"", JHASH_INITVAL), 3735928559);
+
+        let test_slices = &[
+            b"12345".as_slice(),
+            b"hello world hello world",
+            b"\n",
+            b"",
+            b"\t\r\n",
+        ];
+        fn hash_slices(slices: &[&[u8]]) -> u32 {
+            let mut hash: u32 = 0;
+            for slice in slices {
+                hash = jhash_slice(slice, hash);
+            }
+            hash
+        }
+        assert_eq!(hash_slices(test_slices), 3662697720);
+        assert_eq!(hash_slices(&test_slices[0..4]), 230550114);
+        assert_eq!(hash_slices(&test_slices[0..3]), 789588851);
+        assert_eq!(hash_slices(&test_slices[0..2]), 1101610926);
+        assert_eq!(hash_slices(&test_slices[0..1]), 729031446);
+        assert_eq!(hash_slices(&[]), 0);
+    }
+}

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -88,7 +88,10 @@ impl InitStream {
             ));
         };
 
-        Ok(ListenStream::new(bound_port, backlog, option, observer))
+        match ListenStream::new(bound_port, backlog, option, observer) {
+            Ok(listen_stream) => Ok(listen_stream),
+            Err((bound_port, error)) => Err((error, Self::Bound(bound_port))),
+        }
     }
 
     pub fn local_endpoint(&self) -> Option<IpEndpoint> {

--- a/tools/format_all.sh
+++ b/tools/format_all.sh
@@ -32,9 +32,9 @@ fi
 # Format the 100-line kernel demo as well
 KERNEL_DEMO_FILE="$WORKSPACE_ROOT/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs"
 if [ "$CHECK_MODE" = true ]; then
-    cargo fmt --check -- $KERNEL_DEMO_FILE
+    rustfmt --check $KERNEL_DEMO_FILE
 else
-    cargo fmt -- $KERNEL_DEMO_FILE
+    rustfmt $KERNEL_DEMO_FILE
 fi
 
 for CRATE in $EXCLUDED_CRATES; do


### PR DESCRIPTION
Fixes #1561.

This PR introduces `SocketTable` as a replacement for `SocketSet` to enhance the efficiency of processing incoming TCP packets. The new design aims to reduce complexity, especially when dealing with a large number of sockets.

However, this PR in imcomplete in several areas compared to the Linux inet hashtable:

1. The Linux inet hashtable employs fine-grained, per-bucket locking, which is crucial for achieving good scalability. In contrast, our implementation still uses a single lock for the entire hash table. This approach is due to the presence of numerous operations that require iterating over the entire hashtable (including dispatching TCP, updating dead sockets, handling socket events, and calculating the next poll in milliseconds). Adopting fine-grained locking would necessitate locking each bucket for all these operations, which is inefficient. Once we eliminate these operations that iterate over all TCP connections, we can transition to fine-grained locking.

**Note**: This PR alone may not resolve the performance issues when the number of sockets increases, as we still have operations that iterate over all sockets.

2. The Linux inet hashtable is system-wide, whereas the current `SocketTable` implementation functions per interface. To support `INADDR_ANY (0.0.0.0)` in the future, we might need to make it system-wide.
3. The socket hash table is responsible for port reuse check(managed by bound socket buckets), which has not been implemented. 
4. UDP sockets are not addressed in this PR. Instead, UDP sockets have been simply moved from `SocketSet` to `SocketTable`.