### PR TITLE
Enhance the search pattern

### DIFF
--- a/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/bench_result.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_0k_ops/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "^0k",
+        "search_pattern": "^0k\t[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/bench_result.json
+++ b/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "10k",
+        "search_pattern": "^10k\t[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/bench_result.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "^0k",
+        "search_pattern": "^0k\t[0-9]+",
         "result_index": 2
     },
     "chart": {

--- a/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/bench_result.json
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/bench_result.json
@@ -4,7 +4,7 @@
         "bigger_is_better": true
     },
     "result_extraction": {
-        "search_pattern": "10k",
+        "search_pattern": "^10k\t[0-9]+",
         "result_index": 2
     },
     "chart": {


### PR DESCRIPTION
The current [benchmark](https://github.com/asterinas/asterinas/actions/runs/12485729109/job/34844919530#logs) for `lmbench/ramfs_create_delete_files_10k_ops` and `lmbench/ext2_create_delete_files_10k_ops` occasionally fails due to the insufficiently robust search pattern. This pull request aims to enhance the pattern by incorporating additional wildcards to improve its reliability. Potential issues are also fixed.