### PR TITLE
Add overflow check for given sigaltstack addr and size

### DIFF
--- a/kernel/src/syscall/sigaltstack.rs
+++ b/kernel/src/syscall/sigaltstack.rs
@@ -106,6 +106,9 @@ impl TryFrom<stack_t> for SigStack {
         if stack.size < MINSTKSZ {
             return_errno_with_message!(Errno::ENOMEM, "stack size is less than MINSTKSZ");
         }
+        if stack.sp.checked_add(stack.size).is_none() {
+            return_errno_with_message!(Errno::EINVAL, "overflow for given stack addr and size");
+        }
 
         if flags.is_empty() {
             flags.insert(SigStackFlags::SS_ONSTACK);


### PR DESCRIPTION
Fix #1392 

However, in Linux system call `sigaltstack` does not check the addr and size. 
Taking the PoC in the issue as the example, if we run it in Linux, the result is:
```
root@ps:~/asterinas# ./test/build/initramfs/root/sigstack.c 
sigaction: Success
Segmentation fault (core dumped)
```

Another possible fix is to add check in the panic point `process/signal/mod.rs:271`:

```
let stack_pointer = (sig_stack.base().checked_add(sig_stack.size())?).align_down(16); 
```