### PR TITLE
Make stop runqueue per-CPU

### DIFF
--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -49,7 +49,7 @@ pub struct ClassScheduler {
 /// scheduling classes in its corresponding CPU core. The current task of this CPU
 /// core is also stored in this structure.
 struct PerCpuClassRqSet {
-    stop: Arc<stop::StopClassRq>,
+    stop: stop::StopClassRq,
     real_time: real_time::RealTimeClassRq,
     fair: fair::FairClassRq,
     idle: idle::IdleClassRq,
@@ -249,10 +249,9 @@ impl Scheduler for ClassScheduler {
 
 impl ClassScheduler {
     pub fn new() -> Self {
-        let stop = stop::StopClassRq::new();
         let class_rq = |cpu| {
             SpinLock::new(PerCpuClassRqSet {
-                stop: stop.clone(),
+                stop: stop::StopClassRq::new(),
                 real_time: real_time::RealTimeClassRq::new(cpu),
                 fair: fair::FairClassRq::new(cpu),
                 idle: idle::IdleClassRq::new(),

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -7,20 +7,18 @@ use super::*;
 /// This is a singleton class, meaning that only one thread can be in this class at a time.
 /// This is used for the most critical tasks, such as powering off and rebooting.
 pub(super) struct StopClassRq {
-    thread: SpinLock<Option<Arc<Thread>>>,
+    thread: Option<Arc<Thread>>,
 }
 
 impl StopClassRq {
-    pub fn new() -> Arc<Self> {
-        Arc::new(StopClassRq {
-            thread: SpinLock::new(None),
-        })
+    pub fn new() -> Self {
+        Self { thread: None }
     }
 }
 
 impl core::fmt::Debug for StopClassRq {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.thread.lock().is_some() {
+        if self.thread.is_some() {
             write!(f, "Stop: occupied")?;
         } else {
             write!(f, "Stop: empty")?;
@@ -29,9 +27,9 @@ impl core::fmt::Debug for StopClassRq {
     }
 }
 
-impl SchedClassRq for Arc<StopClassRq> {
+impl SchedClassRq for StopClassRq {
     fn enqueue(&mut self, thread: Arc<Thread>, _: Option<EnqueueFlags>) {
-        if self.thread.lock().replace(thread).is_some() {
+        if self.thread.replace(thread).is_some() {
             panic!("Multiple `stop` threads spawned")
         }
     }
@@ -41,11 +39,11 @@ impl SchedClassRq for Arc<StopClassRq> {
     }
 
     fn is_empty(&mut self) -> bool {
-        self.thread.lock().is_none()
+        self.thread.is_none()
     }
 
     fn pick_next(&mut self) -> Option<Arc<Thread>> {
-        self.thread.lock().take()
+        self.thread.take()
     }
 
     fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {


### PR DESCRIPTION
Stop thread is not universally unique. Every CPU should have one stop thread for other CPUs to stop itself to do some important task. In Linux they are per-CPU `migration/*` threads.

With this PR we make our behavior aligned with Linux and avoid a redundant spinlock while `pick_next_current` from scheduling class.