### PR TITLE
Add `ThreadLocal`

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -11,7 +11,10 @@ use ostd::{
 
 use crate::{
     prelude::*,
-    process::{posix_thread::PosixThread, Process},
+    process::{
+        posix_thread::{PosixThread, ThreadLocal},
+        Process,
+    },
     thread::Thread,
 };
 
@@ -19,6 +22,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Context<'a> {
     pub process: &'a Process,
+    pub thread_local: &'a ThreadLocal,
     pub posix_thread: &'a PosixThread,
     pub thread: &'a Thread,
     pub task: &'a Task,

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::cell::{Cell, RefCell};
+
+use ostd::{mm::Vaddr, task::CurrentTask};
+
+use super::RobustListHead;
+use crate::process::signal::SigStack;
+
+/// Local data for a POSIX thread.
+pub struct ThreadLocal {
+    // TID pointers.
+    // https://man7.org/linux/man-pages/man2/set_tid_address.2.html
+    set_child_tid: Cell<Vaddr>,
+    clear_child_tid: Cell<Vaddr>,
+
+    // Robust futexes.
+    // https://man7.org/linux/man-pages/man2/get_robust_list.2.html
+    robust_list: RefCell<Option<RobustListHead>>,
+
+    // Signal.
+    /// `ucontext` address for the signal handler.
+    // FIXME: This field may be removed. For glibc applications with RESTORER flag set, the
+    // `sig_context` is always equals with RSP.
+    sig_context: Cell<Option<Vaddr>>,
+    /// Stack address, size, and flags for the signal handler.
+    sig_stack: RefCell<Option<SigStack>>,
+}
+
+impl ThreadLocal {
+    pub(super) fn new(set_child_tid: Vaddr, clear_child_tid: Vaddr) -> Self {
+        Self {
+            set_child_tid: Cell::new(set_child_tid),
+            clear_child_tid: Cell::new(clear_child_tid),
+            robust_list: RefCell::new(None),
+            sig_context: Cell::new(None),
+            sig_stack: RefCell::new(None),
+        }
+    }
+
+    pub fn set_child_tid(&self) -> &Cell<Vaddr> {
+        &self.set_child_tid
+    }
+
+    pub fn clear_child_tid(&self) -> &Cell<Vaddr> {
+        &self.clear_child_tid
+    }
+
+    pub fn robust_list(&self) -> &RefCell<Option<RobustListHead>> {
+        &self.robust_list
+    }
+
+    pub fn sig_context(&self) -> &Cell<Option<Vaddr>> {
+        &self.sig_context
+    }
+
+    pub fn sig_stack(&self) -> &RefCell<Option<SigStack>> {
+        &self.sig_stack
+    }
+}
+
+/// A trait to provide the `as_thread_local` method for tasks.
+pub trait AsThreadLocal {
+    /// Returns the associated [`ThreadLocal`].
+    fn as_thread_local(&self) -> Option<&ThreadLocal>;
+}
+
+impl AsThreadLocal for CurrentTask {
+    fn as_thread_local(&self) -> Option<&ThreadLocal> {
+        self.local_data().downcast_ref()
+    }
+}

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -26,7 +26,7 @@ use sig_mask::SigMask;
 use sig_num::SigNum;
 pub use sig_stack::{SigStack, SigStackFlags};
 
-use super::posix_thread::PosixThread;
+use super::posix_thread::ThreadLocal;
 use crate::{
     cpu::LinuxAbi,
     current_userspace,
@@ -165,7 +165,7 @@ pub fn handle_user_signal(
         .store(old_mask + mask, Ordering::Relaxed);
 
     // Set up signal stack.
-    let mut stack_pointer = if let Some(sp) = use_alternate_signal_stack(ctx.posix_thread) {
+    let mut stack_pointer = if let Some(sp) = use_alternate_signal_stack(ctx.thread_local) {
         sp as u64
     } else {
         // just use user stack
@@ -193,8 +193,8 @@ pub fn handle_user_signal(
         .inner
         .gp_regs
         .copy_from_raw(user_ctx.general_regs());
-    let mut sig_context = ctx.posix_thread.sig_context().lock();
-    if let Some(sig_context_addr) = *sig_context {
+    let sig_context = ctx.thread_local.sig_context().get();
+    if let Some(sig_context_addr) = sig_context {
         ucontext.uc_link = sig_context_addr;
     } else {
         ucontext.uc_link = 0;
@@ -203,7 +203,9 @@ pub fn handle_user_signal(
     user_space.write_val(stack_pointer as _, &ucontext)?;
     let ucontext_addr = stack_pointer;
     // Store the ucontext addr in sig context of current thread.
-    *sig_context = Some(ucontext_addr as Vaddr);
+    ctx.thread_local
+        .sig_context()
+        .set(Some(ucontext_addr as Vaddr));
 
     // 3. Set the address of the trampoline code.
     if flags.contains(SigActionFlags::SA_RESTORER) {
@@ -251,8 +253,8 @@ pub fn handle_user_signal(
 /// It the stack is already active, we just increase the handler counter and return None, since
 /// the stack pointer can be read from context.
 /// It the stack is not used by any handler, we will return the new sp in alternate signal stack.
-fn use_alternate_signal_stack(posix_thread: &PosixThread) -> Option<usize> {
-    let mut sig_stack = posix_thread.sig_stack().lock();
+fn use_alternate_signal_stack(thread_local: &ThreadLocal) -> Option<usize> {
+    let mut sig_stack = thread_local.sig_stack().borrow_mut();
     let sig_stack = (*sig_stack).as_mut()?;
 
     if sig_stack.is_disabled() {

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -90,9 +90,9 @@ fn do_execve(
 ) -> Result<()> {
     let Context {
         process,
+        thread_local,
         posix_thread,
-        thread: _,
-        task: _,
+        ..
     } = ctx;
 
     let executable_path = elf_file.abs_path();
@@ -107,7 +107,7 @@ fn do_execve(
         Some(ThreadName::new_from_executable_path(&executable_path)?);
     // clear ctid
     // FIXME: should we clear ctid when execve?
-    *posix_thread.clear_child_tid().lock() = 0;
+    thread_local.clear_child_tid().set(0);
 
     // Ensure that the file descriptors with the close-on-exec flag are closed.
     // FIXME: This is just wrong if the file table is shared with other processes.
@@ -123,10 +123,10 @@ fn do_execve(
 
     // After the program has been successfully loaded, the virtual memory of the current process
     // is initialized. Hence, it is necessary to clear the previously recorded robust list.
-    *posix_thread.robust_list().lock() = None;
+    *thread_local.robust_list().borrow_mut() = None;
     debug!("load elf in execve succeeds");
 
-    let credentials = ctx.posix_thread.credentials_mut();
+    let credentials = posix_thread.credentials_mut();
     set_uid_from_elf(process, &credentials, &elf_file)?;
     set_gid_from_elf(process, &credentials, &elf_file)?;
     credentials.set_keep_capabilities(false);

--- a/kernel/src/syscall/rt_sigreturn.rs
+++ b/kernel/src/syscall/rt_sigreturn.rs
@@ -9,16 +9,17 @@ use crate::{prelude::*, process::signal::c_types::ucontext_t};
 
 pub fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Result<SyscallReturn> {
     let Context {
-        process: _,
+        thread_local,
         posix_thread,
-        thread: _,
-        task: _,
+        ..
     } = ctx;
-    let mut sig_context = posix_thread.sig_context().lock();
-    if (*sig_context).is_none() {
-        return_errno_with_message!(Errno::EINVAL, "sigreturn should not been called");
-    }
-    let sig_context_addr = sig_context.unwrap();
+
+    let Some(sig_context_addr) = thread_local.sig_context().get() else {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "`sigreturn` cannot be called outside the signal context"
+        );
+    };
     // FIXME: This assertion is not always true, if RESTORER flag is not presented.
     // In this case, we will put restorer code on user stack, then the assertion will fail.
     // However, for most glibc applications, the restorer codes is provided by glibc and RESTORER flag is set.
@@ -27,7 +28,7 @@ pub fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Result<Sys
     let ucontext = ctx.user_space().read_val::<ucontext_t>(sig_context_addr)?;
 
     // If the sig stack is active and used by current handler, decrease handler counter.
-    if let Some(sig_stack) = posix_thread.sig_stack().lock().as_mut() {
+    if let Some(sig_stack) = &mut *thread_local.sig_stack().borrow_mut() {
         let rsp = user_ctx.stack_pointer();
         if rsp >= sig_stack.base() && rsp <= sig_stack.base() + sig_stack.size() {
             sig_stack.decrease_handler_counter();
@@ -36,15 +37,16 @@ pub fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Result<Sys
 
     // Set previous ucontext address
     if ucontext.uc_link == 0 {
-        *sig_context = None;
+        thread_local.sig_context().set(None);
     } else {
-        *sig_context = Some(ucontext.uc_link);
+        thread_local.sig_context().set(Some(ucontext.uc_link));
     };
     ucontext
         .uc_mcontext
         .inner
         .gp_regs
         .copy_to_raw(user_ctx.general_regs_mut());
+
     // unblock sig mask
     let sig_mask = ucontext.uc_sigmask;
     let old_mask = posix_thread.sig_mask().load(Ordering::Relaxed);

--- a/kernel/src/syscall/set_robust_list.rs
+++ b/kernel/src/syscall/set_robust_list.rs
@@ -12,15 +12,18 @@ pub fn sys_set_robust_list(
         "robust list head ptr: 0x{:x}, len = {}",
         robust_list_head_ptr, len
     );
+
     if len != core::mem::size_of::<RobustListHead>() {
         return_errno_with_message!(
             Errno::EINVAL,
-            "The len is not equal to the size of robust list head"
+            "the length is not equal to the size of the robust list head"
         );
     }
+
     let robust_list_head: RobustListHead = ctx.user_space().read_val(robust_list_head_ptr)?;
-    debug!("{:x?}", robust_list_head);
-    let mut robust_list = ctx.posix_thread.robust_list().lock();
-    *robust_list = Some(robust_list_head);
+    debug!("robust list head: {:x?}", robust_list_head);
+
+    *ctx.thread_local.robust_list().borrow_mut() = Some(robust_list_head);
+
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/set_tid_address.rs
+++ b/kernel/src/syscall/set_tid_address.rs
@@ -5,14 +5,16 @@ use crate::prelude::*;
 
 pub fn sys_set_tid_address(tidptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("tidptr = 0x{:x}", tidptr);
-    let mut clear_child_tid = ctx.posix_thread.clear_child_tid().lock();
-    if *clear_child_tid != 0 {
+
+    let clear_child_tid = ctx.thread_local.clear_child_tid().get();
+    if clear_child_tid != 0 {
         // According to manuals at https://man7.org/linux/man-pages/man2/set_tid_address.2.html
         // We need to write 0 to clear_child_tid and do futex wake
         todo!()
-    } else {
-        *clear_child_tid = tidptr;
     }
+
+    ctx.thread_local.set_child_tid().set(clear_child_tid);
+
     let tid = ctx.posix_thread.tid();
     Ok(SyscallReturn::Return(tid as _))
 }

--- a/kernel/src/syscall/sigaltstack.rs
+++ b/kernel/src/syscall/sigaltstack.rs
@@ -16,10 +16,7 @@ pub fn sys_sigaltstack(
         sig_stack_addr, old_sig_stack_addr
     );
 
-    let old_stack = {
-        let sig_stack = ctx.posix_thread.sig_stack().lock();
-        sig_stack.clone()
-    };
+    let old_stack = ctx.thread_local.sig_stack().borrow().clone();
 
     get_old_stack(old_sig_stack_addr, old_stack.as_ref(), ctx)?;
     set_new_stack(sig_stack_addr, old_stack.as_ref(), ctx)?;
@@ -73,7 +70,7 @@ fn set_new_stack(sig_stack_addr: Vaddr, old_stack: Option<&SigStack>, ctx: &Cont
 
     debug!("new_stack = {:?}", new_stack);
 
-    *ctx.posix_thread.sig_stack().lock() = Some(new_stack);
+    *ctx.thread_local.sig_stack().borrow_mut() = Some(new_stack);
 
     Ok(())
 }

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -10,19 +10,27 @@ use crate::{
     cpu::LinuxAbi,
     current_userspace,
     prelude::*,
-    process::{posix_thread::AsPosixThread, signal::handle_pending_signal},
+    process::{
+        posix_thread::{AsPosixThread, AsThreadLocal, ThreadLocal},
+        signal::handle_pending_signal,
+    },
     syscall::handle_syscall,
-    thread::exception::handle_exception,
+    thread::{exception::handle_exception, AsThread},
     vm::vmar::is_userspace_vaddr,
 };
 
 /// create new task with userspace and parent process
-pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>) -> Task {
+pub fn create_new_user_task(
+    user_space: Arc<UserSpace>,
+    thread_ref: Arc<Thread>,
+    thread_local: ThreadLocal,
+) -> Task {
     fn user_task_entry() {
-        let current_thread = current_thread!();
-        let current_posix_thread = current_thread.as_posix_thread().unwrap();
-        let current_process = current_posix_thread.process();
         let current_task = Task::current().unwrap();
+        let current_thread = current_task.as_thread().unwrap();
+        let current_posix_thread = current_thread.as_posix_thread().unwrap();
+        let current_thread_local = current_task.as_thread_local().unwrap();
+        let current_process = current_posix_thread.process();
 
         let user_space = current_task
             .user_space()
@@ -41,7 +49,7 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
             user_mode.context().syscall_ret()
         );
 
-        let child_tid_ptr = *current_posix_thread.set_child_tid().lock();
+        let child_tid_ptr = current_thread_local.set_child_tid().get();
 
         // The `clone` syscall may require child process to write the thread pid to the specified address.
         // Make sure the store operation completes before the clone call returns control to user space
@@ -56,6 +64,7 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
 
         let ctx = Context {
             process: current_process.as_ref(),
+            thread_local: current_thread_local,
             posix_thread: current_posix_thread,
             thread: current_thread.as_ref(),
             task: current_task.as_ref(),
@@ -99,6 +108,7 @@ pub fn create_new_user_task(user_space: Arc<UserSpace>, thread_ref: Arc<Thread>)
         let _ = oops::catch_panics_as_oops(user_task_entry);
     })
     .data(thread_ref)
+    .local_data(thread_local)
     .user_space(Some(user_space))
     .build()
     .expect("spawn task failed")

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -27,7 +27,7 @@ pub use self::{
     scheduler::info::{AtomicCpuId, TaskScheduleInfo},
 };
 pub(crate) use crate::arch::task::{context_switch, TaskContext};
-use crate::{prelude::*, user::UserSpace};
+use crate::{prelude::*, trap::in_interrupt_context, user::UserSpace};
 
 /// A task that executes a function to the end.
 ///
@@ -38,7 +38,10 @@ use crate::{prelude::*, user::UserSpace};
 pub struct Task {
     #[allow(clippy::type_complexity)]
     func: ForceSync<Cell<Option<Box<dyn FnOnce() + Send>>>>,
+
     data: Box<dyn Any + Send + Sync>,
+    local_data: ForceSync<Box<dyn Any + Send>>,
+
     user_space: Option<Arc<UserSpace>>,
     ctx: SyncUnsafeCell<TaskContext>,
     /// kernel stack, note that the top is SyscallFrame/TrapFrame
@@ -138,6 +141,7 @@ impl Task {
 pub struct TaskOptions {
     func: Option<Box<dyn FnOnce() + Send>>,
     data: Option<Box<dyn Any + Send + Sync>>,
+    local_data: Option<Box<dyn Any + Send>>,
     user_space: Option<Arc<UserSpace>>,
 }
 
@@ -150,6 +154,7 @@ impl TaskOptions {
         Self {
             func: Some(Box::new(func)),
             data: None,
+            local_data: None,
             user_space: None,
         }
     }
@@ -169,6 +174,15 @@ impl TaskOptions {
         T: Any + Send + Sync,
     {
         self.data = Some(Box::new(data));
+        self
+    }
+
+    /// Sets the local data associated with the task.
+    pub fn local_data<T>(mut self, data: T) -> Self
+    where
+        T: Any + Send,
+    {
+        self.local_data = Some(Box::new(data));
         self
     }
 
@@ -228,7 +242,8 @@ impl TaskOptions {
 
         let new_task = Task {
             func: ForceSync::new(Cell::new(self.func)),
-            data: self.data.unwrap(),
+            data: self.data.unwrap_or_else(|| Box::new(())),
+            local_data: ForceSync::new(self.local_data.unwrap_or_else(|| Box::new(()))),
             user_space: self.user_space,
             ctx,
             kstack,
@@ -252,12 +267,16 @@ impl TaskOptions {
 /// The current task.
 ///
 /// This type is not `Send`, so it cannot outlive the current task.
+///
+/// This type is also not `Sync`, so it can provide access to the local data of the current task.
 #[derive(Debug)]
 pub struct CurrentTask(NonNull<Task>);
 
-// The intern `NonNull<Task>` contained by `CurrentTask` implies that `CurrentTask` is `!Send`.
-// But it is still good to do this explicitly because this property is key for soundness.
+// The intern `NonNull<Task>` contained by `CurrentTask` implies that `CurrentTask` is `!Send` and
+// `!Sync`. But it is still good to do this explicitly because these properties are key for
+// soundness.
 impl !Send for CurrentTask {}
+impl !Sync for CurrentTask {}
 
 impl CurrentTask {
     /// # Safety
@@ -265,6 +284,25 @@ impl CurrentTask {
     /// The caller must ensure that `task` is the current task.
     unsafe fn new(task: NonNull<Task>) -> Self {
         Self(task)
+    }
+
+    /// Returns the local data of the current task.
+    ///
+    /// Note that the local data is only accessible in the task context. Although there is a
+    /// current task in the non-task context (e.g. IRQ handlers), access to the local data is
+    /// forbidden as it may cause soundness problems.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if called in a non-task context.
+    pub fn local_data(&self) -> &(dyn Any + Send) {
+        assert!(!in_interrupt_context());
+
+        let local_data = &self.local_data;
+
+        // SAFETY: The `local_data` field will only be accessed by the current task in the task
+        // context, so the data won't be accessed concurrently.
+        &**unsafe { local_data.get() }
     }
 
     /// Returns a cloned `Arc<Task>`.


### PR DESCRIPTION
This PR adds `ThreadLocal`, which currently includes the following fields:
```rust
/// Local data for a POSIX thread.
pub struct ThreadLocal {
    // TID pointers.
    // https://man7.org/linux/man-pages/man2/set_tid_address.2.html
    set_child_tid: Cell<Vaddr>,
    clear_child_tid: Cell<Vaddr>,

    // Robust futexes.
    // https://man7.org/linux/man-pages/man2/get_robust_list.2.html
    robust_list: RefCell<Option<RobustListHead>>,

    // Signal.
    /// `ucontext` address for the signal handler.
    // FIXME: This field may be removed. For glibc applications with RESTORER flag set, the
    // `sig_context` is always equals with RSP.
    sig_context: Cell<Option<Vaddr>>,
    /// Stack address, size, and flags for the signal handler.
    sig_stack: RefCell<Option<SigStack>>,
}
```

I think these fields should be thread-local data. Let's see if there is a consensus.

This PR does not touch any code related to the file table. If this PR is accepted, I can do another PR to use thread-local to make the file table lookup faster (in case the file table is not shared with anyone else). See https://github.com/asterinas/asterinas/issues/1550#issuecomment-2464107626.