### PR TITLE
Work around the compile error caused by crate "unwinding"

### DIFF
--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -38,7 +38,8 @@ ostd-pod = { git = "https://github.com/asterinas/ostd-pod", rev = "c4644be", ver
 spin = "0.9.4"
 smallvec = "1.13.2"
 static_assertions = "1.1.0"
-unwinding = { version = "0.2.3", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+# The version is pinned to "0.2.3" due to a compilation error with version "0.2.5". Unpin it once the issue is resolved.
+unwinding = { version = "=0.2.3", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = { version = "0.4.5", features = ["unstable"] }
 xarray = { git = "https://github.com/asterinas/xarray", version = "0.1.0" }
 


### PR DESCRIPTION
Background: https://github.com/asterinas/asterinas/issues/1765.

This is a temporary workaround.