### PR TITLE
Make the file lookup faster

### DIFF
--- a/kernel/src/fs/file_handle.rs
+++ b/kernel/src/fs/file_handle.rs
@@ -5,10 +5,7 @@
 //! Opened File Handle
 
 use crate::{
-    fs::{
-        device::Device,
-        utils::{AccessMode, FallocMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags},
-    },
+    fs::utils::{AccessMode, FallocMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags},
     net::socket::Socket,
     prelude::*,
     process::{signal::Pollable, Gid, Uid},
@@ -101,10 +98,6 @@ pub trait FileLike: Pollable + Send + Sync + Any {
     }
 
     fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
-        None
-    }
-
-    fn as_device(&self) -> Option<Arc<dyn Device>> {
         None
     }
 }

--- a/kernel/src/fs/file_handle.rs
+++ b/kernel/src/fs/file_handle.rs
@@ -4,6 +4,7 @@
 
 //! Opened File Handle
 
+use super::inode_handle::InodeHandle;
 use crate::{
     fs::utils::{AccessMode, FallocMode, InodeMode, IoctlCmd, Metadata, SeekFrom, StatusFlags},
     net::socket::Socket,
@@ -130,5 +131,11 @@ impl dyn FileLike {
     pub fn as_socket_or_err(&self) -> Result<&dyn Socket> {
         self.as_socket()
             .ok_or_else(|| Error::with_message(Errno::ENOTSOCK, "the file is not a socket"))
+    }
+
+    pub fn as_inode_or_err(&self) -> Result<&InodeHandle> {
+        self.downcast_ref().ok_or_else(|| {
+            Error::with_message(Errno::EINVAL, "the file is not related to an inode")
+        })
     }
 }

--- a/kernel/src/fs/file_handle.rs
+++ b/kernel/src/fs/file_handle.rs
@@ -97,7 +97,7 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::EOPNOTSUPP, "fallocate is not supported");
     }
 
-    fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
+    fn as_socket(&self) -> Option<&dyn Socket> {
         None
     }
 }
@@ -125,5 +125,10 @@ impl dyn FileLike {
     pub fn write_bytes_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
         self.write_at(offset, &mut reader)
+    }
+
+    pub fn as_socket_or_err(&self) -> Result<&dyn Socket> {
+        self.as_socket()
+            .ok_or_else(|| Error::with_message(Errno::ENOTSOCK, "the file is not a socket"))
     }
 }

--- a/kernel/src/fs/file_table.rs
+++ b/kernel/src/fs/file_table.rs
@@ -15,7 +15,6 @@ use super::{
 use crate::{
     events::{Events, IoEvents, Observer, Subject},
     fs::utils::StatusFlags,
-    net::socket::Socket,
     prelude::*,
     process::{
         signal::{constants::SIGIO, signals::kernel::KernelSignal, PollAdaptor},
@@ -183,13 +182,6 @@ impl FileTable {
             .get(fd as usize)
             .map(|entry| &entry.file)
             .ok_or(Error::with_message(Errno::EBADF, "fd not exits"))
-    }
-
-    pub fn get_socket(&self, sockfd: FileDesc) -> Result<Arc<dyn Socket>> {
-        let file_like = self.get_file(sockfd)?.clone();
-        file_like
-            .as_socket()
-            .ok_or_else(|| Error::with_message(Errno::ENOTSOCK, "the fd is not a socket"))
     }
 
     pub fn get_entry(&self, fd: FileDesc) -> Result<&FileTableEntry> {

--- a/kernel/src/fs/file_table.rs
+++ b/kernel/src/fs/file_table.rs
@@ -5,6 +5,7 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::slot_vec::SlotVec;
+use ostd::sync::RwArc;
 
 use super::{
     file_handle::FileLike,
@@ -236,6 +237,67 @@ impl Drop for FileTable {
         self.subject.notify_observers(&events);
     }
 }
+
+/// A helper trait that provides methods to operate the file table.
+pub trait WithFileTable {
+    /// Calls `f` with the file table.
+    ///
+    /// This method is lockless if the file table is not shared. Otherwise, `f` is called while
+    /// holding the read lock on the file table.
+    fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R;
+}
+
+impl WithFileTable for RwArc<FileTable> {
+    fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R {
+        if let Some(inner) = self.get() {
+            f(inner)
+        } else {
+            f(&self.read())
+        }
+    }
+}
+
+/// Gets a file from a file descriptor as fast as possible.
+///
+/// `file_table` should be a mutable borrow of the file table contained in the `file_table` field
+/// (which is a [`RefCell`]) in [`ThreadLocal`]. A mutable borrow is required because its
+/// exclusivity can be useful for achieving lockless file lookups.
+///
+/// If the file table is not shared with another thread, this macro will be free of locks
+/// ([`RwArc::read`]) and free of reference counting ([`Arc::clone`]).
+///
+/// If the file table is shared, the read lock is taken, the file is cloned, and then the read lock
+/// is released. Cloning and releasing the lock is necessary because we cannot hold such locks when
+/// operating on files, since many operations on files can block.
+///
+/// Note: This has to be a macro due to a limitation in the Rust borrow check implementation. Once
+/// <https://github.com/rust-lang/rust/issues/58910> is fixed, we can try to convert this macro to
+/// a function.
+///
+/// [`RefCell`]: core::cell::RefCell
+/// [`ThreadLocal`]: crate::process::posix_thread::ThreadLocal
+macro_rules! get_file_fast {
+    ($file_table:expr, $file_desc:expr) => {{
+        use alloc::borrow::Cow;
+
+        use ostd::sync::RwArc;
+
+        use crate::fs::file_table::{FileDesc, FileTable};
+
+        let file_table: &mut RwArc<FileTable> = $file_table;
+        let file_desc: FileDesc = $file_desc;
+
+        if let Some(inner) = file_table.get() {
+            // Fast path: The file table is not shared, we can get the file in a lockless way.
+            Cow::Borrowed(inner.get_file(file_desc)?)
+        } else {
+            // Slow path: The file table is shared, we need to hold the lock and clone the file.
+            Cow::Owned(file_table.read().get_file(file_desc)?.clone())
+        }
+    }};
+}
+
+pub(crate) use get_file_fast;
 
 #[derive(Copy, Clone, Debug)]
 pub enum FdEvents {

--- a/kernel/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/src/fs/inode_handle/dyn_cap.rs
@@ -134,8 +134,4 @@ impl FileLike for InodeHandle<Rights> {
         }
         self.0.fallocate(mode, offset, len)
     }
-
-    fn as_device(&self) -> Option<Arc<dyn Device>> {
-        self.dentry().inode().as_device()
-    }
 }

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -15,7 +15,6 @@ use inherit_methods_macro::inherit_methods;
 use crate::{
     events::IoEvents,
     fs::{
-        device::Device,
         file_handle::FileLike,
         path::Dentry,
         utils::{

--- a/kernel/src/fs/procfs/pid/fd.rs
+++ b/kernel/src/fs/procfs/pid/fd.rs
@@ -25,7 +25,7 @@ impl FdDirOps {
             .build()
             .unwrap();
         let main_thread = process_ref.main_thread();
-        let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
+        let file_table = main_thread.as_posix_thread().unwrap().file_table().read();
         let weak_ptr = Arc::downgrade(&fd_inode);
         file_table.register_observer(weak_ptr);
         fd_inode
@@ -52,7 +52,7 @@ impl DirOps for FdDirOps {
                 .parse::<FileDesc>()
                 .map_err(|_| Error::new(Errno::ENOENT))?;
             let main_thread = self.0.main_thread();
-            let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
+            let file_table = main_thread.as_posix_thread().unwrap().file_table().read();
             file_table
                 .get_file(fd)
                 .map_err(|_| Error::new(Errno::ENOENT))?
@@ -68,7 +68,7 @@ impl DirOps for FdDirOps {
         };
         let mut cached_children = this.cached_children().write();
         let main_thread = self.0.main_thread();
-        let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
+        let file_table = main_thread.as_posix_thread().unwrap().file_table().read();
         for (fd, file) in file_table.fds_and_files() {
             cached_children.put_entry_if_not_found(&fd.to_string(), || {
                 FileSymOps::new_inode(file.clone(), this_ptr.clone())

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -34,7 +34,7 @@ impl PidDirOps {
             .build()
             .unwrap();
         let main_thread = process_ref.main_thread();
-        let file_table = main_thread.as_posix_thread().unwrap().file_table().lock();
+        let file_table = main_thread.as_posix_thread().unwrap().file_table().read();
         let weak_ptr = Arc::downgrade(&pid_inode);
         file_table.register_observer(weak_ptr);
         pid_inode

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -81,7 +81,7 @@ impl FileOps for StatusFileOps {
         writeln!(status_output, "Pid:\t{}", process.pid()).unwrap();
         writeln!(status_output, "PPid:\t{}", process.parent().pid()).unwrap();
         writeln!(status_output, "TracerPid:\t{}", process.parent().pid()).unwrap(); // Assuming TracerPid is the same as PPid
-        writeln!(status_output, "FDSize:\t{}", file_table.lock().len()).unwrap();
+        writeln!(status_output, "FDSize:\t{}", file_table.read().len()).unwrap();
         writeln!(
             status_output,
             "Threads:\t{}",

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -242,7 +242,7 @@ impl FileLike for DatagramSocket {
         self.try_send(reader, &remote, flags)
     }
 
-    fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
+    fn as_socket(&self) -> Option<&dyn Socket> {
         Some(self)
     }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -453,7 +453,7 @@ impl FileLike for StreamSocket {
         Ok(())
     }
 
-    fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
+    fn as_socket(&self) -> Option<&dyn Socket> {
         Some(self)
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -164,7 +164,7 @@ impl Pollable for UnixStreamSocket {
 }
 
 impl FileLike for UnixStreamSocket {
-    fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
+    fn as_socket(&self) -> Option<&dyn Socket> {
         Some(self)
     }
 

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -139,7 +139,7 @@ impl Pollable for VsockStreamSocket {
 }
 
 impl FileLike for VsockStreamSocket {
-    fn as_socket(self: Arc<Self>) -> Option<Arc<dyn Socket>> {
+    fn as_socket(&self) -> Option<&dyn Socket> {
         Some(self)
     }
 

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -80,7 +80,7 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
     }
 
     if is_last_thread {
-        exit_process(posix_thread, &posix_process);
+        exit_process(thread_local, &posix_process);
     }
 }
 

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -5,7 +5,7 @@
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_rights::{ReadOp, WriteOp};
-use ostd::sync::Waker;
+use ostd::sync::{RoArc, Waker};
 
 use super::{
     kill::SignalSenderIds,
@@ -57,7 +57,7 @@ pub struct PosixThread {
 
     // Files
     /// File table
-    file_table: Arc<SpinLock<FileTable>>,
+    file_table: RoArc<FileTable>,
     /// File system
     fs: Arc<ThreadFsInfo>,
 
@@ -98,7 +98,7 @@ impl PosixThread {
         &self.name
     }
 
-    pub fn file_table(&self) -> &Arc<SpinLock<FileTable>> {
+    pub fn file_table(&self) -> &RoArc<FileTable> {
         &self.file_table
     }
 

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     fs::{
         fs_resolver::{FsPath, FsResolver, AT_FDCWD},
         path::Dentry,
-        utils::Permission,
+        utils::{InodeType, Permission},
     },
     prelude::*,
 };
@@ -72,6 +72,10 @@ pub fn load_program_to_vm(
 pub fn check_executable_file(dentry: &Dentry) -> Result<()> {
     if dentry.type_().is_directory() {
         return_errno_with_message!(Errno::EISDIR, "the file is a directory");
+    }
+
+    if dentry.type_() == InodeType::SymLink {
+        return_errno_with_message!(Errno::ELOOP, "the file is a symbolic link");
     }
 
     if !dentry.type_().is_regular_file() {

--- a/kernel/src/syscall/bind.rs
+++ b/kernel/src/syscall/bind.rs
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc,
-    prelude::*,
-    util::net::{get_socket_from_fd, read_socket_addr_from_user},
-};
+use crate::{fs::file_table::FileDesc, prelude::*, util::net::read_socket_addr_from_user};
 
 pub fn sys_bind(
     sockfd: FileDesc,
     sockaddr_ptr: Vaddr,
     addrlen: u32,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addrlen as usize)?;
     debug!("sockfd = {sockfd}, socket_addr = {socket_addr:?}");
 
-    let socket = get_socket_from_fd(sockfd)?;
+    let file = {
+        let file_table = ctx.posix_thread.file_table().lock();
+        file_table.get_file(sockfd)?.clone()
+    };
+    let socket = file.as_socket_or_err()?;
+
     socket.bind(socket_addr)?;
+
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -3,7 +3,7 @@
 use super::SyscallReturn;
 use crate::{
     fs::{
-        file_table::FileDesc,
+        file_table::{get_file_fast, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
         utils::PATH_MAX,
     },
@@ -20,10 +20,8 @@ pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<Sys
         return Ok(SyscallReturn::Return(0));
     }
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
     if let Some(uid) = uid {
         file.set_owner(uid)?;
     }

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -7,9 +7,10 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let file = {
-        let mut file_table = ctx.posix_thread.file_table().lock();
-        let _ = file_table.get_file(fd)?;
-        file_table.close_file(fd).unwrap()
+        let file_table = ctx.thread_local.file_table().borrow();
+        let mut file_table_locked = file_table.write();
+        let _ = file_table_locked.get_file(fd)?;
+        file_table_locked.close_file(fd).unwrap()
     };
 
     // Cleanup work needs to be done in the `Drop` impl.

--- a/kernel/src/syscall/connect.rs
+++ b/kernel/src/syscall/connect.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::net::read_socket_addr_from_user};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+    util::net::read_socket_addr_from_user,
+};
 
 pub fn sys_connect(
     sockfd: FileDesc,
@@ -12,10 +16,8 @@ pub fn sys_connect(
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addr_len as _)?;
     debug!("fd = {sockfd}, socket_addr = {socket_addr:?}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     socket

--- a/kernel/src/syscall/dup.rs
+++ b/kernel/src/syscall/dup.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::{FdFlags, FileDesc},
+    fs::file_table::{get_file_fast, FdFlags, FileDesc},
     prelude::*,
     process::ResourceType,
 };
@@ -10,8 +10,9 @@ use crate::{
 pub fn sys_dup(old_fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("old_fd = {}", old_fd);
 
-    let mut file_table = ctx.posix_thread.file_table().lock();
-    let new_fd = file_table.dup(old_fd, 0, FdFlags::empty())?;
+    let file_table = ctx.thread_local.file_table().borrow();
+    let mut file_table_locked = file_table.write();
+    let new_fd = file_table_locked.dup(old_fd, 0, FdFlags::empty())?;
 
     Ok(SyscallReturn::Return(new_fd as _))
 }
@@ -20,8 +21,8 @@ pub fn sys_dup2(old_fd: FileDesc, new_fd: FileDesc, ctx: &Context) -> Result<Sys
     debug!("old_fd = {}, new_fd = {}", old_fd, new_fd);
 
     if old_fd == new_fd {
-        let file_table = ctx.posix_thread.file_table().lock();
-        let _ = file_table.get_file(old_fd)?;
+        let mut file_table = ctx.thread_local.file_table().borrow_mut();
+        let _file = get_file_fast!(&mut file_table, old_fd);
         return Ok(SyscallReturn::Return(new_fd as _));
     }
 
@@ -66,9 +67,10 @@ fn do_dup3(
         return_errno!(Errno::EBADF);
     }
 
-    let mut file_table = ctx.posix_thread.file_table().lock();
-    let _ = file_table.close_file(new_fd);
-    let new_fd = file_table.dup(old_fd, new_fd, flags)?;
+    let file_table = ctx.thread_local.file_table().borrow();
+    let mut file_table_locked = file_table.write();
+    let _ = file_table_locked.close_file(new_fd);
+    let new_fd = file_table_locked.dup(old_fd, new_fd, flags)?;
 
     Ok(SyscallReturn::Return(new_fd as _))
 }

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -9,10 +9,9 @@ use ostd::{
 use super::{constants::*, SyscallReturn};
 use crate::{
     fs::{
-        file_table::FileDesc,
+        file_table::{get_file_fast, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
         path::Dentry,
-        utils::InodeType,
     },
     prelude::*,
     process::{
@@ -62,22 +61,22 @@ fn lookup_executable_file(
     flags: OpenFlags,
     ctx: &Context,
 ) -> Result<Dentry> {
-    let fs_resolver = ctx.posix_thread.fs().resolver().read();
     let dentry = if flags.contains(OpenFlags::AT_EMPTY_PATH) && filename.is_empty() {
-        fs_resolver.lookup_from_fd(dfd)
+        let mut file_table = ctx.thread_local.file_table().borrow_mut();
+        let file = get_file_fast!(&mut file_table, dfd);
+        file.as_inode_or_err()?.dentry().clone()
     } else {
+        let fs_resolver = ctx.posix_thread.fs().resolver().read();
         let fs_path = FsPath::new(dfd, &filename)?;
         if flags.contains(OpenFlags::AT_SYMLINK_NOFOLLOW) {
-            let dentry = fs_resolver.lookup_no_follow(&fs_path)?;
-            if dentry.type_() == InodeType::SymLink {
-                return_errno_with_message!(Errno::ELOOP, "the executable file is a symlink");
-            }
-            Ok(dentry)
+            fs_resolver.lookup_no_follow(&fs_path)?
         } else {
-            fs_resolver.lookup(&fs_path)
+            fs_resolver.lookup(&fs_path)?
         }
-    }?;
+    };
+
     check_executable_file(&dentry)?;
+
     Ok(dentry)
 }
 
@@ -111,7 +110,11 @@ fn do_execve(
 
     // Ensure that the file descriptors with the close-on-exec flag are closed.
     // FIXME: This is just wrong if the file table is shared with other processes.
-    let closed_files = posix_thread.file_table().lock().close_files_on_exec();
+    let closed_files = thread_local
+        .file_table()
+        .borrow()
+        .write()
+        .close_files_on_exec();
     drop(closed_files);
 
     debug!("load program to root vmar");

--- a/kernel/src/syscall/fallocate.rs
+++ b/kernel/src/syscall/fallocate.rs
@@ -2,7 +2,10 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::{file_table::FileDesc, utils::FallocMode},
+    fs::{
+        file_table::{get_file_fast, FileDesc},
+        utils::FallocMode,
+    },
     prelude::*,
     process::ResourceType,
 };
@@ -21,10 +24,8 @@ pub fn sys_fallocate(
 
     check_offset_and_len(offset, len, ctx)?;
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
 
     let falloc_mode = FallocMode::try_from(
         RawFallocMode::from_bits(mode as _)

--- a/kernel/src/syscall/getpeername.rs
+++ b/kernel/src/syscall/getpeername.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc,
-    prelude::*,
-    util::net::{get_socket_from_fd, write_socket_addr_to_user},
-};
+use crate::{fs::file_table::FileDesc, prelude::*, util::net::write_socket_addr_to_user};
 
 pub fn sys_getpeername(
     sockfd: FileDesc,
     addr: Vaddr,
     addrlen_ptr: Vaddr,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let peer_addr = {
-        let socket = get_socket_from_fd(sockfd)?;
-        socket.peer_addr()?
+    let file = {
+        let file_table = ctx.posix_thread.file_table().lock();
+        file_table.get_file(sockfd)?.clone()
     };
+    let socket = file.as_socket_or_err()?;
+
+    let peer_addr = socket.peer_addr()?;
     // FIXME: trunscate write len if addrlen is not big enough
     write_socket_addr_to_user(&peer_addr, addr, addrlen_ptr)?;
+
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/getpeername.rs
+++ b/kernel/src/syscall/getpeername.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::net::write_socket_addr_to_user};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+    util::net::write_socket_addr_to_user,
+};
 
 pub fn sys_getpeername(
     sockfd: FileDesc,
@@ -11,10 +15,8 @@ pub fn sys_getpeername(
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     let peer_addr = socket.peer_addr()?;

--- a/kernel/src/syscall/getsockname.rs
+++ b/kernel/src/syscall/getsockname.rs
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc,
-    prelude::*,
-    util::net::{get_socket_from_fd, write_socket_addr_to_user},
-};
+use crate::{fs::file_table::FileDesc, prelude::*, util::net::write_socket_addr_to_user};
 
 pub fn sys_getsockname(
     sockfd: FileDesc,
     addr: Vaddr,
     addrlen_ptr: Vaddr,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let socket_addr = {
-        let socket = get_socket_from_fd(sockfd)?;
-        socket.addr()?
+    let file = {
+        let file_table = ctx.posix_thread.file_table().lock();
+        file_table.get_file(sockfd)?.clone()
     };
+    let socket = file.as_socket_or_err()?;
 
+    let socket_addr = socket.addr()?;
     // FIXME: trunscate write len if addrlen is not big enough
     write_socket_addr_to_user(&socket_addr, addr, addrlen_ptr)?;
+
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/getsockopt.rs
+++ b/kernel/src/syscall/getsockopt.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDesc,
+    fs::file_table::{get_file_fast, FileDesc},
     prelude::*,
     util::net::{new_raw_socket_option, CSocketOptionLevel},
 };
@@ -25,10 +25,8 @@ pub fn sys_getsockopt(
 
     debug!("level = {level:?}, sockfd = {sockfd}, optname = {optname:?}, optlen = {optlen}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     let mut raw_option = new_raw_socket_option(level, optname)?;

--- a/kernel/src/syscall/listen.rs
+++ b/kernel/src/syscall/listen.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+};
 
 pub fn sys_listen(sockfd: FileDesc, backlog: i32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, backlog = {backlog}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     socket.listen(backlog as usize)?;

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -40,16 +40,19 @@ pub fn sys_openat(
             })?;
         Arc::new(inode_handle)
     };
-    let mut file_table = current.file_table().lock();
+
     let fd = {
+        let file_table = ctx.thread_local.file_table().borrow();
+        let mut file_table_locked = file_table.write();
         let fd_flags =
             if CreationFlags::from_bits_truncate(flags).contains(CreationFlags::O_CLOEXEC) {
                 FdFlags::CLOEXEC
             } else {
                 FdFlags::empty()
             };
-        file_table.insert(file_handle, fd_flags)
+        file_table_locked.insert(file_handle, fd_flags)
     };
+
     Ok(SyscallReturn::Return(fd as _))
 }
 

--- a/kernel/src/syscall/pread64.rs
+++ b/kernel/src/syscall/pread64.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+};
 
 pub fn sys_pread64(
     fd: FileDesc,
@@ -18,10 +21,10 @@ pub fn sys_pread64(
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.posix_thread.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
     if user_buf_len == 0 {
         return Ok(SyscallReturn::Return(0));

--- a/kernel/src/syscall/pwrite64.rs
+++ b/kernel/src/syscall/pwrite64.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+};
 
 pub fn sys_pwrite64(
     fd: FileDesc,
@@ -14,13 +17,14 @@ pub fn sys_pwrite64(
         "fd = {}, user_buf_ptr = 0x{:x}, user_buf_len = 0x{:x}, offset = 0x{:x}",
         fd, user_buf_ptr, user_buf_len, offset
     );
+
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.posix_thread.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+
     // TODO: Check (f.file->f_mode & FMODE_PWRITE); We don't have f_mode in our FileLike trait
     if user_buf_len == 0 {
         return Ok(SyscallReturn::Return(0));

--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*, util::VmReaderArray};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+    util::VmReaderArray,
+};
 
 pub fn sys_writev(
     fd: FileDesc,
@@ -57,13 +61,14 @@ fn do_sys_pwritev(
         "fd = {}, io_vec_ptr = 0x{:x}, io_vec_counter = 0x{:x}, offset = 0x{:x}",
         fd, io_vec_ptr, io_vec_count, offset
     );
+
     if offset < 0 {
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
-    let file = {
-        let filetable = ctx.posix_thread.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
     if io_vec_count == 0 {
         return Ok(0);
@@ -116,10 +121,10 @@ fn do_sys_writev(
         "fd = {}, io_vec_ptr = 0x{:x}, io_vec_counter = 0x{:x}",
         fd, io_vec_ptr, io_vec_count
     );
-    let file = {
-        let filetable = ctx.posix_thread.file_table().lock();
-        filetable.get_file(fd)?.clone()
-    };
+
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+
     let mut total_len = 0;
 
     let mut reader_array = VmReaderArray::from_user_io_vecs(ctx, io_vec_ptr, io_vec_count)?;

--- a/kernel/src/syscall/recvfrom.rs
+++ b/kernel/src/syscall/recvfrom.rs
@@ -2,7 +2,9 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDesc, net::socket::SendRecvFlags, prelude::*,
+    fs::file_table::{get_file_fast, FileDesc},
+    net::socket::SendRecvFlags,
+    prelude::*,
     util::net::write_socket_addr_to_user,
 };
 
@@ -18,10 +20,8 @@ pub fn sys_recvfrom(
     let flags = SendRecvFlags::from_bits_truncate(flags);
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = {len}, flags = {flags:?}, src_addr = 0x{src_addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     let mut writers = {

--- a/kernel/src/syscall/sendto.rs
+++ b/kernel/src/syscall/sendto.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDesc,
+    fs::file_table::{get_file_fast, FileDesc},
     net::socket::{MessageHeader, SendRecvFlags},
     prelude::*,
     util::net::read_socket_addr_from_user,
@@ -26,10 +26,8 @@ pub fn sys_sendto(
     };
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = 0x{len:x}, flags = {flags:?}, socket_addr = {socket_addr:?}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     let message_header = MessageHeader::new(socket_addr, None);

--- a/kernel/src/syscall/setsockopt.rs
+++ b/kernel/src/syscall/setsockopt.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file_table::FileDesc,
+    fs::file_table::{get_file_fast, FileDesc},
     prelude::*,
     util::net::{new_raw_socket_option, CSocketOptionLevel},
 };
@@ -25,10 +25,8 @@ pub fn sys_setsockopt(
         level, sockfd, optname, optlen
     );
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     let raw_option = {

--- a/kernel/src/syscall/setsockopt.rs
+++ b/kernel/src/syscall/setsockopt.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::file_table::FileDesc,
     prelude::*,
-    util::net::{get_socket_from_fd, new_raw_socket_option, CSocketOptionLevel},
+    util::net::{new_raw_socket_option, CSocketOptionLevel},
 };
 
 pub fn sys_setsockopt(
@@ -13,7 +13,7 @@ pub fn sys_setsockopt(
     optname: i32,
     optval: Vaddr,
     optlen: u32,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<SyscallReturn> {
     let level = CSocketOptionLevel::try_from(level).map_err(|_| Errno::EOPNOTSUPP)?;
     if optval == 0 {
@@ -25,16 +25,17 @@ pub fn sys_setsockopt(
         level, sockfd, optname, optlen
     );
 
-    let socket = get_socket_from_fd(sockfd)?;
+    let file = {
+        let file_table = ctx.posix_thread.file_table().lock();
+        file_table.get_file(sockfd)?.clone()
+    };
+    let socket = file.as_socket_or_err()?;
 
     let raw_option = {
         let mut option = new_raw_socket_option(level, optname)?;
-
         option.read_from_user(optval, optlen)?;
-
         option
     };
-
     debug!("raw option: {:?}", raw_option);
 
     socket.set_option(raw_option.as_sock_option())?;

--- a/kernel/src/syscall/shutdown.rs
+++ b/kernel/src/syscall/shutdown.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    fs::file_table::FileDesc, net::socket::SockShutdownCmd, prelude::*,
-    util::net::get_socket_from_fd,
-};
+use crate::{fs::file_table::FileDesc, net::socket::SockShutdownCmd, prelude::*};
 
-pub fn sys_shutdown(sockfd: FileDesc, how: i32, _ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_shutdown(sockfd: FileDesc, how: i32, ctx: &Context) -> Result<SyscallReturn> {
     let shutdown_cmd = SockShutdownCmd::try_from(how)?;
     debug!("sockfd = {sockfd}, cmd = {shutdown_cmd:?}");
 
-    let socket = get_socket_from_fd(sockfd)?;
+    let file = {
+        let file_table = ctx.posix_thread.file_table().lock();
+        file_table.get_file(sockfd)?.clone()
+    };
+    let socket = file.as_socket_or_err()?;
+
     socket.shutdown(shutdown_cmd)?;
+
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/shutdown.rs
+++ b/kernel/src/syscall/shutdown.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, net::socket::SockShutdownCmd, prelude::*};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    net::socket::SockShutdownCmd,
+    prelude::*,
+};
 
 pub fn sys_shutdown(sockfd: FileDesc, how: i32, ctx: &Context) -> Result<SyscallReturn> {
     let shutdown_cmd = SockShutdownCmd::try_from(how)?;
     debug!("sockfd = {sockfd}, cmd = {shutdown_cmd:?}");
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(sockfd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
     socket.shutdown(shutdown_cmd)?;

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -43,13 +43,14 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
         _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported domain"),
     };
     let fd = {
-        let mut file_table = ctx.posix_thread.file_table().lock();
+        let file_table = ctx.thread_local.file_table().borrow();
+        let mut file_table_locked = file_table.write();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {
             FdFlags::empty()
         };
-        file_table.insert(file_like, fd_flags)
+        file_table_locked.insert(file_like, fd_flags)
     };
     Ok(SyscallReturn::Return(fd as _))
 }

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -37,14 +37,15 @@ pub fn sys_socketpair(
     };
 
     let socket_fds = {
-        let mut file_table = ctx.posix_thread.file_table().lock();
+        let file_table = ctx.thread_local.file_table().borrow();
+        let mut file_table_locked = file_table.write();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {
             FdFlags::empty()
         };
-        let fd_a = file_table.insert(socket_a, fd_flags);
-        let fd_b = file_table.insert(socket_b, fd_flags);
+        let fd_a = file_table_locked.insert(socket_a, fd_flags);
+        let fd_b = file_table_locked.insert(socket_b, fd_flags);
         SocketFds(fd_a, fd_b)
     };
 

--- a/kernel/src/syscall/write.rs
+++ b/kernel/src/syscall/write.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{fs::file_table::FileDesc, prelude::*};
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+};
 
 pub fn sys_write(
     fd: FileDesc,
@@ -14,10 +17,8 @@ pub fn sys_write(
         fd, user_buf_ptr, user_buf_len
     );
 
-    let file = {
-        let file_table = ctx.posix_thread.file_table().lock();
-        file_table.get_file(fd)?.clone()
-    };
+    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let file = get_file_fast!(&mut file_table, fd);
 
     // According to <https://man7.org/linux/man-pages/man2/write.2.html>, if
     // the user specified an empty buffer, we should detect errors by checking

--- a/kernel/src/util/net/mod.rs
+++ b/kernel/src/util/net/mod.rs
@@ -10,14 +10,3 @@ pub use addr::{
 };
 pub use options::{new_raw_socket_option, CSocketOptionLevel};
 pub use socket::{CUserMsgHdr, Protocol, SockFlags, SockType, SOCK_TYPE_MASK};
-
-use crate::{
-    fs::file_table::FileDesc, net::socket::Socket, prelude::*, process::posix_thread::AsPosixThread,
-};
-
-pub fn get_socket_from_fd(sockfd: FileDesc) -> Result<Arc<dyn Socket>> {
-    let current = current_thread!();
-    let current = current.as_posix_thread().unwrap();
-    let file_table = current.file_table().lock();
-    file_table.get_socket(sockfd)
-}

--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -7,6 +7,7 @@ mod mutex;
 // TODO: refactor this rcu implementation
 // Comment out this module since it raises lint error
 // mod rcu;
+mod rwarc;
 mod rwlock;
 mod rwmutex;
 mod spin;
@@ -17,6 +18,7 @@ pub(crate) use self::guard::GuardTransfer;
 pub use self::{
     guard::{LocalIrqDisabled, PreemptDisabled, WriteIrqDisabled},
     mutex::{ArcMutexGuard, Mutex, MutexGuard},
+    rwarc::{RoArc, RwArc},
     rwlock::{
         ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
         RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,

--- a/ostd/src/sync/rwarc.rs
+++ b/ostd/src/sync/rwarc.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::Arc;
+use core::sync::atomic::{fence, AtomicUsize, Ordering};
+
+use super::{PreemptDisabled, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// A reference-counting pointer with read-write capabilities.
+///
+/// This is essentially `Arc<RwLock<T>>`, so it can provide read-write capabilities through
+/// [`RwArc::read`] and [`RwArc::write`].
+///
+/// In addition, this allows to derive another reference-counting pointer with read-only
+/// capabilities ([`RoArc`]) via [`RwArc::clone_ro`].
+///
+/// The purpose of having this type is to allow lockless (read) access to the underlying data when
+/// there is only one [`RwArc`] instance for the particular allocation (note that there can be any
+/// number of [`RoArc`] instances for that allocation). See the [`RwArc::get`] method for more
+/// details.
+pub struct RwArc<T>(Arc<Inner<T>>);
+
+/// A reference-counting pointer with read-only capabilities.
+///
+/// This type can be created from an existing [`RwArc`] using its [`RwArc::clone_ro`] method. See
+/// the type and method documentation for more details.
+pub struct RoArc<T>(Arc<Inner<T>>);
+
+struct Inner<T> {
+    data: RwLock<T>,
+    num_rw: AtomicUsize,
+}
+
+impl<T> RwArc<T> {
+    /// Creates a new `RwArc<T>`.
+    pub fn new(data: T) -> Self {
+        let inner = Inner {
+            data: RwLock::new(data),
+            num_rw: AtomicUsize::new(1),
+        };
+        Self(Arc::new(inner))
+    }
+
+    /// Acquires the read lock for immutable access.
+    pub fn read(&self) -> RwLockReadGuard<T, PreemptDisabled> {
+        self.0.data.read()
+    }
+
+    /// Acquires the write lock for mutable access.
+    pub fn write(&self) -> RwLockWriteGuard<T, PreemptDisabled> {
+        self.0.data.write()
+    }
+
+    /// Returns an immutable reference if no other `RwArc` points to the same allocation.
+    ///
+    /// This method is cheap because it does not acquire a lock.
+    ///
+    /// It's still sound because:
+    /// - The mutable reference to `self` and the condition ensure that we are exclusively
+    ///   accessing the unique `RwArc` instance for the particular allocation.
+    /// - There may be any number of [`RoArc`]s pointing to the same allocation, but they may only
+    ///   produce immutable references to the underlying data.
+    pub fn get(&mut self) -> Option<&T> {
+        if self.0.num_rw.load(Ordering::Relaxed) > 1 {
+            return None;
+        }
+
+        // This will synchronize with `RwArc::drop` to make sure its changes are visible to us.
+        fence(Ordering::Acquire);
+
+        let data_ptr = self.0.data.as_ptr();
+
+        // SAFETY: The data is valid. During the lifetime, no one will be able to create a mutable
+        // reference to the data, so it's okay to create an immutable reference like the one below.
+        Some(unsafe { &*data_ptr })
+    }
+
+    /// Clones a [`RoArc`] that points to the same allocation.
+    pub fn clone_ro(&self) -> RoArc<T> {
+        RoArc(self.0.clone())
+    }
+}
+
+impl<T> Clone for RwArc<T> {
+    fn clone(&self) -> Self {
+        let inner = self.0.clone();
+
+        // Note that overflowing the counter will make it unsound. But not to worry: the above
+        // `Arc::clone` must have already aborted the kernel before this happens.
+        inner.num_rw.fetch_add(1, Ordering::Relaxed);
+
+        Self(inner)
+    }
+}
+
+impl<T> Drop for RwArc<T> {
+    fn drop(&mut self) {
+        self.0.num_rw.fetch_sub(1, Ordering::Release);
+    }
+}
+
+impl<T> RoArc<T> {
+    /// Acquires the read lock for immutable access.
+    pub fn read(&self) -> RwLockReadGuard<T, PreemptDisabled> {
+        self.0.data.read()
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use super::*;
+    use crate::prelude::*;
+
+    #[ktest]
+    fn lockless_get() {
+        let mut rw1 = RwArc::new(1u32);
+        assert_eq!(rw1.get(), Some(1).as_ref());
+
+        let _ro = rw1.clone_ro();
+        assert_eq!(rw1.get(), Some(1).as_ref());
+
+        let rw2 = rw1.clone();
+        assert_eq!(rw1.get(), None);
+
+        drop(rw2);
+        assert_eq!(rw1.get(), Some(1).as_ref());
+    }
+}

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -339,6 +339,14 @@ impl<T: ?Sized, G: Guardian> RwLock<T, G> {
     pub fn get_mut(&mut self) -> &mut T {
         self.val.get_mut()
     }
+
+    /// Returns a raw pointer to the underlying data.
+    ///
+    /// This method is safe, but it's up to the caller to ensure that access to the data behind it
+    /// is still safe.
+    pub(super) fn as_ptr(&self) -> *mut T {
+        self.val.get()
+    }
 }
 
 impl<T: ?Sized + fmt::Debug, G> fmt::Debug for RwLock<T, G> {


### PR DESCRIPTION
This introduces `WithFileTable` and `get_file_fast` which allow lock-free operation on the file table and atomic-free file lookup respectively (if the file table is not shared, see #1550).
```rust
/// A helper trait that provides methods to operate the file table.
pub trait WithFileTable {
    /// Calls `f` with the file table.
    ///
    /// This method is lockless if the file table is not shared. Otherwise, `f` is called while
    /// holding the read lock on the file table.
    fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R;
}

impl WithFileTable for RwArc<FileTable> {
    fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R {
        if let Some(inner) = self.get() {
            f(inner)
        } else {
            f(&self.read())
        }
    }
}
```
Example:
https://github.com/lrh2000/asterinas/blob/a8f79962cf73b8645ea3a204f3b39f24fb5de6f9/kernel/src/syscall/ioctl.rs#L43-L47

```rust
/// Gets a file from a file descriptor as fast as possible.
///
/// If the file table is not shared with another thread, this macro will be free of locks
/// ([`RwArc::read`]) and free of reference counting ([`Arc::clone`]).
///
/// If the file table is shared, the read lock is taken, the file is cloned, and then the read lock
/// is released. This is because many operations on files can block, so we cannot hold such locks
/// when operating on files.
///
/// # Panics
///
/// This macro will cause an immediate panic if the [`RefCell`] that stores the file table in
/// [`ThreadLocal`] is already borrowed. Note that this also means that calling this macro twice
/// without releasing the [`RefMut`] of the file table will cause a panic.
///
/// [`RefCell`]: core::cell::RefCell
/// [`RefMut`]: core::cell::RefMut
/// [`ThreadLocal`]: crate::process::posix_thread::ThreadLocal
macro_rules! get_file_fast {
    { let ($file_table:ident, $file:ident) = $file_desc:ident @ $thread_local:expr } => {
        use alloc::borrow::Cow;

        let mut $file_table = $thread_local.file_table().borrow_mut();
        let $file = if let Some(file_table) = $file_table.get() {
            Cow::Borrowed(file_table.get_file($file_desc)?)
        } else {
            Cow::Owned($file_table.read().get_file($file_desc)?.clone())
        };
    };
}
```
Example:
https://github.com/lrh2000/asterinas/blob/a8f79962cf73b8645ea3a204f3b39f24fb5de6f9/kernel/src/syscall/accept.rs#L50-L51