### PR TITLE
Make bigtcp error wrappers consistent

### DIFF
--- a/kernel/libs/aster-bigtcp/src/errors.rs
+++ b/kernel/libs/aster-bigtcp/src/errors.rs
@@ -12,6 +12,9 @@ pub enum BindError {
 pub mod tcp {
     pub use smoltcp::socket::tcp::{RecvError, SendError};
 
+    /// An error returned by [`TcpListener::new_listen`].
+    ///
+    /// [`TcpListener::new_listen`]: crate::socket::TcpListener::new_listen
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub enum ListenError {
         InvalidState,
@@ -29,6 +32,9 @@ pub mod tcp {
         }
     }
 
+    /// An error returned by [`TcpConnection::new_connect`].
+    ///
+    /// [`TcpConnection::new_connect`]: crate::socket::TcpConnection::new_connect
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub enum ConnectError {
         InvalidState,
@@ -50,13 +56,23 @@ pub mod tcp {
 pub mod udp {
     pub use smoltcp::socket::udp::RecvError;
 
-    /// An error returned by [`BoundTcpSocket::recv`].
+    /// An error returned by [`UdpSocket::send`].
     ///
-    /// [`BoundTcpSocket::recv`]: crate::socket::BoundTcpSocket::recv
+    /// [`UdpSocket::send`]: crate::socket::UdpSocket::send
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub enum SendError {
-        TooLarge,
         Unaddressable,
         BufferFull,
+        /// The packet is too large.
+        TooLarge,
+    }
+
+    impl From<smoltcp::socket::udp::SendError> for SendError {
+        fn from(value: smoltcp::socket::udp::SendError) -> Self {
+            match value {
+                smoltcp::socket::udp::SendError::Unaddressable => Self::Unaddressable,
+                smoltcp::socket::udp::SendError::BufferFull => Self::BufferFull,
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR makes the error wrappers in bigtcp conform to the same style.

More specifically, it is the style introduced in https://github.com/asterinas/asterinas/pull/1750.
https://github.com/asterinas/asterinas/blob/39cc0dca26cb4340c1b69327357a622cfbd9ecef/kernel/libs/aster-bigtcp/src/errors.rs#L15-L30

The previous error wrapper `udp::SendError` does not conform to this (i.e., it does not implement the `From` trait), so it will be updated.
https://github.com/asterinas/asterinas/blob/39cc0dca26cb4340c1b69327357a622cfbd9ecef/kernel/libs/aster-bigtcp/src/errors.rs#L53-L61