### PR TITLE
Adjust the lint check to recognize "wrk" as a valid word.

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ ND   = "ND"
 Fo   = "Fo"
 Inh  = "Inh"
 DELET = "DELET"
+wrk = "wrk"
 
 # Files with svg suffix are ignored to check. 
 [type.svg]


### PR DESCRIPTION
Fix the CI failure shown at https://github.com/asterinas/asterinas/actions/runs/12547375744/job/34984727819