### PR TITLE
Set hash buckets as 2 to work around performance bottleneck

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -147,9 +147,11 @@ pub(crate) struct SocketTable<E: Ext> {
 // On Linux, the number of buckets is determined at runtime based on the available memory.
 // For simplicity, we use fixed values here.
 // The bucket count should be a power of 2 to ensure efficient modulo calculations.
-const LISTENER_BUCKET_COUNT: u32 = 64;
+// FIXME: We have reduced the bucket count to 2 because iterating over all buckets has become a bottleneck.
+// Once we can avoid such iterations, we should set more meaningful bucket counts.
+const LISTENER_BUCKET_COUNT: u32 = 2;
 const LISTENER_BUCKET_MASK: u32 = LISTENER_BUCKET_COUNT - 1;
-const CONNECTION_BUCKET_COUNT: u32 = 8192;
+const CONNECTION_BUCKET_COUNT: u32 = 2;
 const CONNECTION_BUCKET_MASK: u32 = CONNECTION_BUCKET_COUNT - 1;
 
 const_assert!(LISTENER_BUCKET_COUNT.is_power_of_two());

--- a/test/benchmark/lmbench/tcp_virtio_bw_128/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_128/run.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Running lmbench TCP latency over virtio-net..."
+echo "Running lmbench TCP bandwidth test over virtio-net..."
 
 # Start the server
 /benchmark/bin/lmbench/bw_tcp -s 10.0.2.15 -b 1

--- a/test/benchmark/lmbench/tcp_virtio_bw_64k/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_bw_64k/run.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Running lmbench TCP latency over virtio-net..."
+echo "Running lmbench TCP bandwidth test over virtio-net..."
 
 # Start the server
 /benchmark/bin/lmbench/bw_tcp -s 10.0.2.15 -b 1

--- a/test/benchmark/lmbench/tcp_virtio_connect_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_connect_lat/run.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Running lmbench TCP latency over virtio-net..."
+echo "Running lmbench TCP connect latency test over virtio-net..."
 
 # Start the server
 benchmark/bin/lmbench/lat_connect -s 10.0.2.15 -b 1000

--- a/test/benchmark/lmbench/tcp_virtio_lat/run.sh
+++ b/test/benchmark/lmbench/tcp_virtio_lat/run.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Running lmbench TCP latency over virtio-net..."
+echo "Running lmbench TCP latency test over virtio-net..."
 
 # Start the server
 /benchmark/bin/lmbench/lat_tcp -s 10.0.2.15 -b 1

--- a/test/benchmark/lmbench/udp_virtio_lat/run.sh
+++ b/test/benchmark/lmbench/udp_virtio_lat/run.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Running lmbench UDP latency over virtio-net..."
+echo "Running lmbench UDP latency test over virtio-net..."
 
 # Start the server
 /benchmark/bin/lmbench/lat_udp -s 10.0.2.15


### PR DESCRIPTION
This PR workarounds the network performance problem introduced by #1750.

We still have much operations to iterate over all hash buckets in socket hashtable, it seems to become a bottleneck for most network benchmarks. So this PR temporarily sets the hash bucket count as 2 to work around the problem.