### PR TITLE
Alloc-free booting

### DIFF
--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -15,7 +15,7 @@ use core::{
 use component::{init_component, ComponentInitError};
 use font8x8::UnicodeFonts;
 use ostd::{
-    boot::{self, memory_region::MemoryRegionType, memory_regions},
+    boot::{boot_info, memory_region::MemoryRegionType},
     io_mem::IoMem,
     mm::{VmIo, PAGE_SIZE},
     sync::SpinLock,
@@ -36,9 +36,11 @@ pub(crate) static WRITER: Once<SpinLock<Writer>> = Once::new();
 #[allow(clippy::diverging_sub_expression)]
 pub(crate) fn init() {
     let mut writer = {
-        let framebuffer = boot::framebuffer_arg();
+        let Some(framebuffer) = boot_info().framebuffer_arg else {
+            return;
+        };
         let mut size = 0;
-        for region in memory_regions().iter() {
+        for region in boot_info().memory_regions.iter() {
             if region.typ() == MemoryRegionType::Framebuffer {
                 size = region.len();
             }
@@ -56,9 +58,9 @@ pub(crate) fn init() {
             io_mem,
             x_pos: 0,
             y_pos: 0,
-            bytes_per_pixel: (framebuffer.bpp / 8) as usize,
-            width: framebuffer.width as usize,
-            height: framebuffer.height as usize,
+            bytes_per_pixel: (framebuffer.bpp / 8),
+            width: framebuffer.width,
+            height: framebuffer.height,
             buffer: buffer.leak(),
         }
     };

--- a/kernel/comps/framebuffer/src/lib.rs
+++ b/kernel/comps/framebuffer/src/lib.rs
@@ -38,7 +38,7 @@ pub(crate) fn init() {
     let mut writer = {
         let framebuffer = boot::framebuffer_arg();
         let mut size = 0;
-        for region in memory_regions() {
+        for region in memory_regions().iter() {
             if region.typ() == MemoryRegionType::Framebuffer {
                 size = region.len();
             }

--- a/kernel/src/kcmdline.rs
+++ b/kernel/src/kcmdline.rs
@@ -18,8 +18,6 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::early_println;
-
 #[derive(PartialEq, Debug)]
 struct InitprocArgs {
     path: Option<String>,
@@ -116,7 +114,7 @@ impl From<&str> for KCmdlineArg {
                 1 => (arg_pattern[0], None),
                 2 => (arg_pattern[0], Some(arg_pattern[1])),
                 _ => {
-                    early_println!(
+                    log::warn!(
                         "[KCmdline] Unable to parse kernel argument {}, skip for now",
                         arg
                     );
@@ -129,7 +127,7 @@ impl From<&str> for KCmdlineArg {
                 1 => (None, entry_pattern[0]),
                 2 => (Some(entry_pattern[0]), entry_pattern[1]),
                 _ => {
-                    early_println!(
+                    log::warn!(
                         "[KCmdline] Unable to parse entry {} in argument {}, skip for now",
                         entry,
                         arg

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -32,7 +32,7 @@
 
 use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
-    boot,
+    boot::boot_info,
     cpu::{CpuId, CpuSet, PinCurrentCpu},
 };
 use process::Process;
@@ -96,7 +96,7 @@ pub fn init() {
     #[cfg(target_arch = "x86_64")]
     net::init();
     sched::init();
-    fs::rootfs::init(boot::initramfs()).unwrap();
+    fs::rootfs::init(boot_info().initramfs.expect("No initramfs found!")).unwrap();
     device::init().unwrap();
     syscall::init();
     vdso::init();
@@ -141,7 +141,7 @@ fn init_thread() {
 
     print_banner();
 
-    let karg = boot::kernel_cmdline();
+    let karg = &boot_info().kernel_cmdline;
 
     let initproc = Process::spawn_user_process(
         karg.get_initproc_path().unwrap(),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(trait_upcasting)]
 #![register_tool(component_access_control)]
 
+use kcmdline::KCmdlineArg;
 use ostd::{
     arch::qemu::{exit_qemu, QemuExitCode},
     boot::boot_info,
@@ -59,6 +60,7 @@ pub mod error;
 pub mod events;
 pub mod fs;
 pub mod ipc;
+pub mod kcmdline;
 pub mod net;
 pub mod prelude;
 mod process;
@@ -141,7 +143,7 @@ fn init_thread() {
 
     print_banner();
 
-    let karg = &boot_info().kernel_cmdline;
+    let karg: KCmdlineArg = boot_info().kernel_cmdline.as_str().into();
 
     let initproc = Process::spawn_user_process(
         karg.get_initproc_path().unwrap(),

--- a/osdk/src/commands/new/lib.template
+++ b/osdk/src/commands/new/lib.template
@@ -7,7 +7,7 @@ mod tests {
 
     #[ktest]
     fn it_works() {
-        let memory_regions = ostd::boot::memory_regions();
+        let memory_regions = &ostd::boot::boot_info().memory_regions;
         assert!(!memory_regions.is_empty());
     }
 }

--- a/osdk/tests/examples_in_book/work_in_workspace_templates/mylib/src/lib.rs
+++ b/osdk/tests/examples_in_book/work_in_workspace_templates/mylib/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub fn available_memory() -> usize {
-    let regions = ostd::boot::memory_regions();
+    let regions = &ostd::boot::boot_info().memory_regions;
     regions.iter().map(|region| region.len()).sum()
 }

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -4,7 +4,6 @@
 
 pub mod smp;
 
-use alloc::string::String;
 use core::arch::global_asm;
 
 use fdt::Fdt;
@@ -12,11 +11,7 @@ use spin::Once;
 
 use crate::{
     boot::{
-        kcmdline::KCmdlineArg,
-        memory_region::{
-            non_overlapping_regions_from, MemoryRegion, MemoryRegionArray, MemoryRegionType,
-            MAX_REGIONS,
-        },
+        memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
         BootloaderAcpiArg, BootloaderFramebufferArg,
     },
     early_println,
@@ -28,32 +23,33 @@ global_asm!(include_str!("boot.S"));
 /// The Flattened Device Tree of the platform.
 pub static DEVICE_TREE: Once<Fdt> = Once::new();
 
-fn init_bootloader_name(bootloader_name: &'static Once<String>) {
-    bootloader_name.call_once(|| "Unknown".into());
+fn parse_bootloader_name() -> &'static str {
+    "Unknown"
 }
 
-fn init_kernel_commandline(kernel_cmdline: &'static Once<KCmdlineArg>) {
-    let bootargs = DEVICE_TREE.get().unwrap().chosen().bootargs().unwrap_or("");
-    kernel_cmdline.call_once(|| bootargs.into());
+fn parse_kernel_commandline() -> &'static str {
+    DEVICE_TREE.get().unwrap().chosen().bootargs().unwrap_or("")
 }
 
-fn init_initramfs(initramfs: &'static Once<&'static [u8]>) {
+fn parse_initramfs() -> Option<&'static [u8]> {
     let Some((start, end)) = parse_initramfs_range() else {
-        return;
+        return None;
     };
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;
-    initramfs.call_once(|| unsafe { core::slice::from_raw_parts(base_va as *const u8, length) });
+    Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
-fn init_acpi_arg(acpi: &'static Once<BootloaderAcpiArg>) {
-    acpi.call_once(|| BootloaderAcpiArg::NotProvided);
+fn parse_acpi_arg() -> BootloaderAcpiArg {
+    BootloaderAcpiArg::NotProvided
 }
 
-fn init_framebuffer_info(_framebuffer_arg: &'static Once<BootloaderFramebufferArg>) {}
+fn parse_framebuffer_info() -> Option<BootloaderFramebufferArg> {
+    None
+}
 
-fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
+fn parse_memory_regions() -> MemoryRegionArray {
     let mut regions = MemoryRegionArray::new();
 
     for region in DEVICE_TREE.get().unwrap().memory().regions() {
@@ -92,7 +88,7 @@ fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
         ));
     }
 
-    memory_regions.call_once(|| regions.into_non_overlapping());
+    regions.into_non_overlapping()
 }
 
 fn parse_initramfs_range() -> Option<(usize, usize)> {
@@ -111,14 +107,16 @@ pub extern "C" fn riscv_boot(_hart_id: usize, device_tree_paddr: usize) -> ! {
     let fdt = unsafe { fdt::Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 
-    crate::boot::register_boot_init_callbacks(
-        init_bootloader_name,
-        init_kernel_commandline,
-        init_initramfs,
-        init_acpi_arg,
-        init_framebuffer_info,
-        init_memory_regions,
-    );
+    use crate::boot::{call_ostd_main, EarlyBootInfo, EARLY_INFO};
 
-    crate::boot::call_ostd_main();
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: parse_bootloader_name(),
+        kernel_cmdline: parse_kernel_commandline(),
+        initramfs: parse_initramfs(),
+        acpi_arg: parse_acpi_arg(),
+        framebuffer_arg: parse_framebuffer_info(),
+        memory_regions: parse_memory_regions(),
+    });
+
+    call_ostd_main();
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -47,6 +47,12 @@ bitflags::bitflags! {
         const ACCESSED =        1 << 6;
         /// Whether the memory area represented by this entry is modified.
         const DIRTY =           1 << 7;
+
+        // First bit ignored by MMU.
+        const RSV1 =            1 << 8;
+        // Second bit ignored by MMU.
+        const RSV2 =            1 << 9;
+
         // PBMT: Non-cacheable, idempotent, weakly-ordered (RVWMO), main memory
         const PBMT_NC =         1 << 61;
         // PBMT: Non-cacheable, non-idempotent, strongly-ordered (I/O ordering), I/O
@@ -144,7 +150,9 @@ impl PageTableEntryTrait for PageTableEntry {
             | parse_flags!(self.0, PageTableFlags::WRITABLE, PageFlags::W)
             | parse_flags!(self.0, PageTableFlags::EXECUTABLE, PageFlags::X)
             | parse_flags!(self.0, PageTableFlags::ACCESSED, PageFlags::ACCESSED)
-            | parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY);
+            | parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY)
+            | parse_flags!(self.0, PageTableFlags::RSV1, PageFlags::AVAIL1)
+            | parse_flags!(self.0, PageTableFlags::RSV2, PageFlags::AVAIL2);
         let priv_flags = parse_flags!(self.0, PageTableFlags::USER, PrivFlags::USER)
             | parse_flags!(self.0, PageTableFlags::GLOBAL, PrivFlags::GLOBAL);
 
@@ -175,6 +183,16 @@ impl PageTableEntryTrait for PageTableEntry {
                 prop.priv_flags.bits(),
                 PrivFlags::GLOBAL,
                 PageTableFlags::GLOBAL
+            )
+            | parse_flags!(
+                prop.flags.AVAIL1.bits(),
+                PageFlags::AVAIL1,
+                PageTableFlags::RSV1
+            )
+            | parse_flags!(
+                prop.flags.AVAIL2.bits(),
+                PageFlags::AVAIL2,
+                PageTableFlags::RSV2
             );
 
         match prop.cache {

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -3,30 +3,24 @@
 //! The Linux 64-bit Boot Protocol supporting module.
 //!
 
-use alloc::{borrow::ToOwned, format, string::String};
 use core::ffi::CStr;
 
 use linux_boot_params::{BootParams, E820Type, LINUX_BOOT_HEADER_MAGIC};
-use spin::Once;
 
 use crate::{
     boot::{
-        kcmdline::KCmdlineArg,
         memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
         BootloaderAcpiArg, BootloaderFramebufferArg,
     },
     mm::kspace::{paddr_to_vaddr, LINEAR_MAPPING_BASE_VADDR},
 };
 
-static BOOT_PARAMS: Once<BootParams> = Once::new();
-
-fn init_bootloader_name(bootloader_name: &'static Once<String>) {
-    let hdr = &BOOT_PARAMS.get().unwrap().hdr;
+fn parse_bootloader_name(boot_params: &BootParams) -> &str {
+    let hdr = &boot_params.hdr;
     // The bootloaders have assigned IDs in Linux, see
     // https://www.kernel.org/doc/Documentation/x86/boot.txt
     // for details.
-    let ext_str: String;
-    let name = match hdr.type_of_loader {
+    match hdr.type_of_loader {
         0x0 => "LILO", // (0x00 reserved for pre-2.00 bootloader)
         0x1 => "Loadlin",
         0x2 => "bootsect-loader", // (0x20, all other values reserved)
@@ -40,37 +34,27 @@ fn init_bootloader_name(bootloader_name: &'static Once<String>) {
         0xB => "Qemu",
         0xC => "Arcturus Networks uCbootloader",
         0xD => "kexec-tools",
-        0xE => {
-            // Extended
-            ext_str = format!(
-                "Extended bootloader {}, version {}",
-                (hdr.ext_loader_type + 0x10),
-                (hdr.type_of_loader & 0x0f) + (hdr.ext_loader_ver << 4)
-            );
-            &ext_str
-        }
+        0xE => "Extended loader",
         0xF => "Special", // (0xFF = undefined)
         0x10 => "Reserved",
         0x11 => "Minimal Linux Bootloader <http://sebastian-plotz.blogspot.de>",
         0x12 => "OVMF UEFI virtualization stack",
         _ => "Unknown bootloader type!",
     }
-    .to_owned();
-    bootloader_name.call_once(|| name);
 }
 
-fn init_kernel_commandline(kernel_cmdline: &'static Once<KCmdlineArg>) {
-    let cmdline_c_str: &CStr =
-        unsafe { CStr::from_ptr(BOOT_PARAMS.get().unwrap().hdr.cmd_line_ptr as *const i8) };
+fn parse_kernel_commandline(boot_params: &BootParams) -> &str {
+    // SAFETY: The pointer in the header points to a valid C string.
+    let cmdline_c_str: &CStr = unsafe { CStr::from_ptr(boot_params.hdr.cmd_line_ptr as *const i8) };
     let cmdline_str = cmdline_c_str.to_str().unwrap();
-    kernel_cmdline.call_once(|| cmdline_str.into());
+    cmdline_str
 }
 
-fn init_initramfs(initramfs: &'static Once<&'static [u8]>) {
-    let hdr = &BOOT_PARAMS.get().unwrap().hdr;
+fn parse_initramfs(boot_params: &BootParams) -> Option<&[u8]> {
+    let hdr = &boot_params.hdr;
     let ptr = hdr.ramdisk_image as usize;
     if ptr == 0 {
-        return;
+        return None;
     }
     // We must return a slice composed by VA since kernel should read everything in VA.
     let base_va = if ptr < LINEAR_MAPPING_BASE_VADDR {
@@ -80,30 +64,32 @@ fn init_initramfs(initramfs: &'static Once<&'static [u8]>) {
     };
     let length = hdr.ramdisk_size as usize;
     if length == 0 {
-        return;
+        return None;
     }
-    initramfs.call_once(|| unsafe { core::slice::from_raw_parts(base_va as *const u8, length) });
+    // SAFETY: The regions is reported as initramfs by the bootloader, so it should be valid.
+    Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
-fn init_acpi_arg(acpi: &'static Once<BootloaderAcpiArg>) {
-    let rsdp = BOOT_PARAMS.get().unwrap().acpi_rsdp_addr;
+fn parse_acpi_arg(boot_params: &BootParams) -> BootloaderAcpiArg {
+    let rsdp = boot_params.acpi_rsdp_addr;
     if rsdp == 0 {
-        acpi.call_once(|| BootloaderAcpiArg::NotProvided);
+        BootloaderAcpiArg::NotProvided
     } else {
-        acpi.call_once(|| {
-            BootloaderAcpiArg::Rsdp(rsdp.try_into().expect("RSDP address overflowed!"))
-        });
+        BootloaderAcpiArg::Rsdp(rsdp.try_into().expect("RSDP address overflowed!"))
     }
 }
 
-fn init_framebuffer_info(framebuffer_arg: &'static Once<BootloaderFramebufferArg>) {
-    let screen_info = &BOOT_PARAMS.get().unwrap().screen_info;
-    framebuffer_arg.call_once(|| BootloaderFramebufferArg {
+fn parse_framebuffer_info(boot_params: &BootParams) -> Option<BootloaderFramebufferArg> {
+    let screen_info = boot_params.screen_info;
+    if screen_info.lfb_base == 0 {
+        return None;
+    }
+    Some(BootloaderFramebufferArg {
         address: screen_info.lfb_base as usize,
         width: screen_info.lfb_width as usize,
         height: screen_info.lfb_height as usize,
         bpp: screen_info.lfb_depth as usize,
-    });
+    })
 }
 
 impl From<E820Type> for MemoryRegionType {
@@ -118,10 +104,8 @@ impl From<E820Type> for MemoryRegionType {
     }
 }
 
-fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
+fn parse_memory_regions(boot_params: &BootParams) -> MemoryRegionArray {
     let mut regions = MemoryRegionArray::new();
-
-    let boot_params = BOOT_PARAMS.get().unwrap();
 
     // Add regions from E820.
     let num_entries = boot_params.e820_entries as usize;
@@ -156,22 +140,25 @@ fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
         ))
         .unwrap();
 
-    memory_regions.call_once(|| regions.into_non_overlapping());
+    regions.into_non_overlapping()
 }
 
 /// The entry point of the Rust code portion of Asterinas.
 #[no_mangle]
 unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
-    let params = *params_ptr;
+    let params = unsafe { &*params_ptr };
     assert_eq!({ params.hdr.header }, LINUX_BOOT_HEADER_MAGIC);
-    BOOT_PARAMS.call_once(|| params);
-    crate::boot::register_boot_init_callbacks(
-        init_bootloader_name,
-        init_kernel_commandline,
-        init_initramfs,
-        init_acpi_arg,
-        init_framebuffer_info,
-        init_memory_regions,
-    );
-    crate::boot::call_ostd_main();
+
+    use crate::boot::{call_ostd_main, EarlyBootInfo, EARLY_INFO};
+
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: parse_bootloader_name(params),
+        kernel_cmdline: parse_kernel_commandline(params),
+        initramfs: parse_initramfs(params),
+        acpi_arg: parse_acpi_arg(params),
+        framebuffer_arg: parse_framebuffer_info(params),
+        memory_regions: parse_memory_regions(params),
+    });
+
+    call_ostd_main();
 }

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -38,13 +38,10 @@ fn parse_bootloader_name(mb1_info: &MultibootLegacyInfo) -> &str {
 fn parse_kernel_commandline(mb1_info: &MultibootLegacyInfo) -> &str {
     let mut cmdline = "";
     if mb1_info.cmdline != 0 {
+        let ptr = paddr_to_vaddr(mb1_info.cmdline as usize) as *const i8;
         // SAFETY: the command line is C-style zero-terminated string.
-        unsafe {
-            let cstr = paddr_to_vaddr(mb1_info.cmdline as usize) as *const i8;
-            let cstr = core::ffi::CStr::from_ptr(cstr);
-
-            cmdline = cstr.to_str().unwrap();
-        }
+        let cstr = unsafe { core::ffi::CStr::from_ptr(ptr) };
+        cmdline = cstr.to_str().unwrap();
     }
     cmdline
 }

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::string::String;
 use core::arch::global_asm;
-
-use spin::Once;
 
 use crate::{
     boot::{
-        kcmdline::KCmdlineArg,
         memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
         BootloaderAcpiArg, BootloaderFramebufferArg,
     },
@@ -21,55 +17,48 @@ global_asm!(include_str!("header.S"));
 
 pub(super) const MULTIBOOT_ENTRY_MAGIC: u32 = 0x2BADB002;
 
-fn init_bootloader_name(bootloader_name: &'static Once<String>) {
-    bootloader_name.call_once(|| {
-        let mut name = "";
-        let info = MB1_INFO.get().unwrap();
-        if info.boot_loader_name != 0 {
-            // SAFETY: the bootloader name is C-style zero-terminated string.
-            unsafe {
-                let cstr = paddr_to_vaddr(info.boot_loader_name as usize) as *const u8;
-                let mut len = 0;
-                while cstr.add(len).read() != 0 {
-                    len += 1;
-                }
-
-                name = core::str::from_utf8(core::slice::from_raw_parts(cstr, len))
-                    .expect("cmdline is not a utf-8 string");
+fn parse_bootloader_name(mb1_info: &MultibootLegacyInfo) -> &str {
+    let mut name = "Unknown Multiboot loader";
+    if mb1_info.boot_loader_name != 0 {
+        // SAFETY: the bootloader name is C-style zero-terminated string.
+        unsafe {
+            let cstr = paddr_to_vaddr(mb1_info.boot_loader_name as usize) as *const u8;
+            let mut len = 0;
+            while cstr.add(len).read() != 0 {
+                len += 1;
             }
+
+            name = core::str::from_utf8(core::slice::from_raw_parts(cstr, len))
+                .expect("cmdline is not a utf-8 string");
         }
-        name.into()
-    });
-}
-
-fn init_kernel_commandline(kernel_cmdline: &'static Once<KCmdlineArg>) {
-    kernel_cmdline.call_once(|| {
-        let mut cmdline = "";
-        let info = MB1_INFO.get().unwrap();
-        if info.cmdline != 0 {
-            // SAFETY: the command line is C-style zero-terminated string.
-            unsafe {
-                let cstr = paddr_to_vaddr(info.cmdline as usize) as *const u8;
-                let mut len = 0;
-                while cstr.add(len).read() != 0 {
-                    len += 1;
-                }
-
-                cmdline = core::str::from_utf8(core::slice::from_raw_parts(cstr, len))
-                    .expect("cmdline is not a utf-8 string");
-            }
-        }
-        cmdline.into()
-    });
-}
-
-fn init_initramfs(initramfs: &'static Once<&'static [u8]>) {
-    let info = MB1_INFO.get().unwrap();
-    // FIXME: We think all modules are initramfs, can this cause problems?
-    if info.mods_count == 0 {
-        return;
     }
-    let modules_addr = info.mods_addr as usize;
+    name
+}
+
+fn parse_kernel_commandline(mb1_info: &MultibootLegacyInfo) -> &str {
+    let mut cmdline = "";
+    if mb1_info.cmdline != 0 {
+        // SAFETY: the command line is C-style zero-terminated string.
+        unsafe {
+            let cstr = paddr_to_vaddr(mb1_info.cmdline as usize) as *const u8;
+            let mut len = 0;
+            while cstr.add(len).read() != 0 {
+                len += 1;
+            }
+
+            cmdline = core::str::from_utf8(core::slice::from_raw_parts(cstr, len))
+                .expect("cmdline is not a utf-8 string");
+        }
+    }
+    cmdline
+}
+
+fn parse_initramfs(mb1_info: &MultibootLegacyInfo) -> Option<&[u8]> {
+    // FIXME: We think all modules are initramfs, can this cause problems?
+    if mb1_info.mods_count == 0 {
+        return None;
+    }
+    let modules_addr = mb1_info.mods_addr as usize;
     // We only use one module
     let (start, end) = unsafe {
         (
@@ -84,32 +73,33 @@ fn init_initramfs(initramfs: &'static Once<&'static [u8]>) {
         start
     };
     let length = end - start;
-    initramfs.call_once(|| unsafe { core::slice::from_raw_parts(base_va as *const u8, length) });
+
+    Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
-fn init_acpi_arg(acpi: &'static Once<BootloaderAcpiArg>) {
+fn parse_acpi_arg(_mb1_info: &MultibootLegacyInfo) -> BootloaderAcpiArg {
     // The multiboot protocol does not contain RSDP address.
     // TODO: What about UEFI?
-    acpi.call_once(|| BootloaderAcpiArg::NotProvided);
+    BootloaderAcpiArg::NotProvided
 }
 
-fn init_framebuffer_info(framebuffer_arg: &'static Once<BootloaderFramebufferArg>) {
-    let info = MB1_INFO.get().unwrap();
-    framebuffer_arg.call_once(|| BootloaderFramebufferArg {
-        address: info.framebuffer_table.addr as usize,
-        width: info.framebuffer_table.width as usize,
-        height: info.framebuffer_table.height as usize,
-        bpp: info.framebuffer_table.bpp as usize,
-    });
+fn parse_framebuffer_info(mb1_info: &MultibootLegacyInfo) -> Option<BootloaderFramebufferArg> {
+    if mb1_info.framebuffer_table.addr == 0 {
+        return None;
+    }
+    Some(BootloaderFramebufferArg {
+        address: mb1_info.framebuffer_table.addr as usize,
+        width: mb1_info.framebuffer_table.width as usize,
+        height: mb1_info.framebuffer_table.height as usize,
+        bpp: mb1_info.framebuffer_table.bpp as usize,
+    })
 }
 
-fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
+fn parse_memory_regions(mb1_info: &MultibootLegacyInfo) -> MemoryRegionArray {
     let mut regions = MemoryRegionArray::new();
 
-    let info = MB1_INFO.get().unwrap();
-
     // Add the regions in the multiboot protocol.
-    for entry in info.get_memory_map() {
+    for entry in mb1_info.get_memory_map() {
         let start = entry.base_addr();
         let region = MemoryRegion::new(
             start.try_into().unwrap(),
@@ -121,10 +111,10 @@ fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
 
     // Add the framebuffer region.
     let fb = BootloaderFramebufferArg {
-        address: info.framebuffer_table.addr as usize,
-        width: info.framebuffer_table.width as usize,
-        height: info.framebuffer_table.height as usize,
-        bpp: info.framebuffer_table.bpp as usize,
+        address: mb1_info.framebuffer_table.addr as usize,
+        width: mb1_info.framebuffer_table.width as usize,
+        height: mb1_info.framebuffer_table.height as usize,
+        bpp: mb1_info.framebuffer_table.bpp as usize,
     };
     regions
         .push(MemoryRegion::new(
@@ -138,8 +128,8 @@ fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
     regions.push(MemoryRegion::kernel()).unwrap();
 
     // Add the initramfs area.
-    if info.mods_count != 0 {
-        let modules_addr = info.mods_addr as usize;
+    if mb1_info.mods_count != 0 {
+        let modules_addr = mb1_info.mods_addr as usize;
         // We only use one module
         let (start, end) = unsafe {
             (
@@ -165,8 +155,7 @@ fn init_memory_regions(memory_regions: &'static Once<MemoryRegionArray>) {
         ))
         .unwrap();
 
-    // Initialize with non-overlapping regions.
-    memory_regions.call_once(move || regions.into_non_overlapping());
+    regions.into_non_overlapping()
 }
 
 /// Representation of Multiboot Information according to specification.
@@ -402,20 +391,23 @@ impl Iterator for MemoryEntryIter {
     }
 }
 
-static MB1_INFO: Once<&'static MultibootLegacyInfo> = Once::new();
-
 /// The entry point of Rust code called by inline asm.
 #[no_mangle]
 unsafe extern "sysv64" fn __multiboot_entry(boot_magic: u32, boot_params: u64) -> ! {
     assert_eq!(boot_magic, MULTIBOOT_ENTRY_MAGIC);
-    MB1_INFO.call_once(|| &*(paddr_to_vaddr(boot_params as usize) as *const MultibootLegacyInfo));
-    crate::boot::register_boot_init_callbacks(
-        init_bootloader_name,
-        init_kernel_commandline,
-        init_initramfs,
-        init_acpi_arg,
-        init_framebuffer_info,
-        init_memory_regions,
-    );
-    crate::boot::call_ostd_main();
+    let mb1_info =
+        unsafe { &*(paddr_to_vaddr(boot_params as usize) as *const MultibootLegacyInfo) };
+
+    use crate::boot::{call_ostd_main, EarlyBootInfo, EARLY_INFO};
+
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: parse_bootloader_name(mb1_info),
+        kernel_cmdline: parse_kernel_commandline(mb1_info),
+        initramfs: parse_initramfs(mb1_info),
+        acpi_arg: parse_acpi_arg(mb1_info),
+        framebuffer_arg: parse_framebuffer_info(mb1_info),
+        memory_regions: parse_memory_regions(mb1_info),
+    });
+
+    call_ostd_main();
 }

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -40,14 +40,10 @@ fn parse_kernel_commandline(mb1_info: &MultibootLegacyInfo) -> &str {
     if mb1_info.cmdline != 0 {
         // SAFETY: the command line is C-style zero-terminated string.
         unsafe {
-            let cstr = paddr_to_vaddr(mb1_info.cmdline as usize) as *const u8;
-            let mut len = 0;
-            while cstr.add(len).read() != 0 {
-                len += 1;
-            }
+            let cstr = paddr_to_vaddr(mb1_info.cmdline as usize) as *const i8;
+            let cstr = core::ffi::CStr::from_ptr(cstr);
 
-            cmdline = core::str::from_utf8(core::slice::from_raw_parts(cstr, len))
-                .expect("cmdline is not a utf-8 string");
+            cmdline = cstr.to_str().unwrap();
         }
     }
     cmdline

--- a/ostd/src/arch/x86/kernel/acpi/mod.rs
+++ b/ostd/src/arch/x86/kernel/acpi/mod.rs
@@ -5,7 +5,6 @@
 pub mod dmar;
 pub mod remapping;
 
-use alloc::borrow::ToOwned;
 use core::ptr::NonNull;
 
 use acpi::{rsdp::Rsdp, AcpiHandler, AcpiTables};
@@ -43,7 +42,7 @@ impl AcpiHandler for AcpiMemoryHandler {
 }
 
 pub fn init() {
-    let acpi_tables = match boot::acpi_arg().to_owned() {
+    let acpi_tables = match boot::EARLY_INFO.get().unwrap().acpi_arg {
         BootloaderAcpiArg::Rsdp(addr) => unsafe {
             AcpiTables::from_rsdp(AcpiMemoryHandler {}, addr).unwrap()
         },

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -6,7 +6,6 @@
 //!  2. the routine booting into the actual kernel;
 //!  3. the routine booting the other processors in the SMP context.
 
-pub mod kcmdline;
 pub mod memory_region;
 pub mod smp;
 
@@ -15,7 +14,6 @@ use alloc::{
     vec::Vec,
 };
 
-use kcmdline::KCmdlineArg;
 use memory_region::{MemoryRegion, MemoryRegionArray};
 use spin::Once;
 
@@ -24,7 +22,7 @@ pub struct BootInfo {
     /// The name of the bootloader.
     pub bootloader_name: String,
     /// The kernel command line arguments.
-    pub kernel_cmdline: KCmdlineArg,
+    pub kernel_cmdline: String,
     /// The initial ramfs raw bytes.
     pub initramfs: Option<&'static [u8]>,
     /// The framebuffer arguments.
@@ -100,7 +98,7 @@ pub(crate) fn init() {
 
     INFO.call_once(|| BootInfo {
         bootloader_name: boot_time_info.bootloader_name.to_string(),
-        kernel_cmdline: boot_time_info.kernel_cmdline.into(),
+        kernel_cmdline: boot_time_info.kernel_cmdline.to_string(),
         initramfs: boot_time_info.initramfs,
         framebuffer_arg: boot_time_info.framebuffer_arg,
         memory_regions: boot_time_info.memory_regions.to_vec(),

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![allow(dead_code)]
-
 //! The architecture-independent boot module, which provides
 //!  1. a universal information getter interface from the bootloader to the
 //!     rest of OSTD;
@@ -12,12 +10,35 @@ pub mod kcmdline;
 pub mod memory_region;
 pub mod smp;
 
-use alloc::string::String;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use kcmdline::KCmdlineArg;
+use memory_region::{MemoryRegion, MemoryRegionArray};
 use spin::Once;
 
-use self::memory_region::MemoryRegionArray;
+/// The boot information provided by the bootloader.
+pub struct BootInfo {
+    /// The name of the bootloader.
+    pub bootloader_name: String,
+    /// The kernel command line arguments.
+    pub kernel_cmdline: KCmdlineArg,
+    /// The initial ramfs raw bytes.
+    pub initramfs: Option<&'static [u8]>,
+    /// The framebuffer arguments.
+    pub framebuffer_arg: Option<BootloaderFramebufferArg>,
+    /// The memory regions provided by the bootloader.
+    pub memory_regions: Vec<MemoryRegion>,
+}
+
+/// Gets the boot information.
+pub fn boot_info() -> &'static BootInfo {
+    INFO.get().unwrap()
+}
+
+static INFO: Once<BootInfo> = Once::new();
 
 /// ACPI information from the bootloader.
 ///
@@ -49,66 +70,41 @@ pub struct BootloaderFramebufferArg {
     pub bpp: usize,
 }
 
-macro_rules! define_global_static_boot_arguments {
-    ( $( $lower:ident, $upper:ident, $typ:ty; )* ) => {
-        // Define statics and corresponding public getter APIs.
-        $(
-            static $upper: Once<$typ> = Once::new();
-            /// Macro generated public getter API.
-            pub fn $lower() -> &'static $typ {
-                $upper.get().unwrap()
-            }
-        )*
+/*************************** Boot-time information ***************************/
 
-        struct BootInitCallBacks {
-            $( $lower: fn(&'static Once<$typ>) -> (), )*
-        }
-
-        static BOOT_INIT_CALLBACKS: Once<BootInitCallBacks> = Once::new();
-
-        /// The macro generated boot init callbacks registering interface.
-        ///
-        /// For the introduction of a new boot protocol, the entry point could be a novel
-        /// one. The entry point function should register all the boot initialization
-        /// methods before `ostd::main` is called. A boot initialization method takes a
-        /// reference of the global static boot information variable and initialize it,
-        /// so that the boot information it represents could be accessed in the kernel
-        /// anywhere.
-        ///
-        /// The reason why the entry point function is not designed to directly initialize
-        /// the boot information variables is simply that the heap is not initialized at
-        /// that moment.
-        pub fn register_boot_init_callbacks($( $lower: fn(&'static Once<$typ>) -> (), )* ) {
-            BOOT_INIT_CALLBACKS.call_once(|| {
-                BootInitCallBacks { $( $lower, )* }
-            });
-        }
-
-        fn call_all_boot_init_callbacks() {
-            let callbacks = &BOOT_INIT_CALLBACKS.get().unwrap();
-            $( (callbacks.$lower)(&$upper); )*
-        }
-    };
+/// The boot-time boot information.
+///
+/// When supporting multiple boot protocols with a single build, the entrypoint
+/// and boot information getters are dynamically decided. The entry point
+/// function should initializer all arguments at [`EARLY_INFO`].
+///
+/// All the references in this structure should be valid in the boot context.
+/// After the kernel is booted, users should use [`BootInfo`] instead.
+pub(crate) struct EarlyBootInfo {
+    pub(crate) bootloader_name: &'static str,
+    pub(crate) kernel_cmdline: &'static str,
+    pub(crate) initramfs: Option<&'static [u8]>,
+    pub(crate) acpi_arg: BootloaderAcpiArg,
+    pub(crate) framebuffer_arg: Option<BootloaderFramebufferArg>,
+    pub(crate) memory_regions: MemoryRegionArray,
 }
 
-// Define a series of static variables and their getter APIs.
-define_global_static_boot_arguments!(
-    //  Getter Names     |  Static Variables  | Variable Types
-    bootloader_name,        BOOTLOADER_NAME,    String;
-    kernel_cmdline,         KERNEL_CMDLINE,     KCmdlineArg;
-    initramfs,              INITRAMFS,          &'static [u8];
-    acpi_arg,               ACPI_ARG,           BootloaderAcpiArg;
-    framebuffer_arg,        FRAMEBUFFER_ARG,    BootloaderFramebufferArg;
-    memory_regions,         MEMORY_REGIONS,     MemoryRegionArray;
-);
+/// The boot-time information.
+pub(crate) static EARLY_INFO: Once<EarlyBootInfo> = Once::new();
 
-/// The initialization method of the boot module.
+/// Initializes the runtime information.
 ///
-/// After initializing the boot module, the get functions could be called.
-/// The initialization must be done after the heap is set and before physical
-/// mappings are cancelled.
-pub fn init() {
-    call_all_boot_init_callbacks();
+/// This function allows the run-time getters to work properly.
+pub(crate) fn init() {
+    let boot_time_info = EARLY_INFO.get().unwrap();
+
+    INFO.call_once(|| BootInfo {
+        bootloader_name: boot_time_info.bootloader_name.to_string(),
+        kernel_cmdline: boot_time_info.kernel_cmdline.into(),
+        initramfs: boot_time_info.initramfs,
+        framebuffer_arg: boot_time_info.framebuffer_arg,
+        memory_regions: boot_time_info.memory_regions.to_vec(),
+    });
 }
 
 /// Calls the OSTD-user defined entrypoint of the actual kernel.

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -12,12 +12,12 @@ pub mod kcmdline;
 pub mod memory_region;
 pub mod smp;
 
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 
 use kcmdline::KCmdlineArg;
 use spin::Once;
 
-use self::memory_region::MemoryRegion;
+use self::memory_region::MemoryRegionArray;
 
 /// ACPI information from the bootloader.
 ///
@@ -99,7 +99,7 @@ define_global_static_boot_arguments!(
     initramfs,              INITRAMFS,          &'static [u8];
     acpi_arg,               ACPI_ARG,           BootloaderAcpiArg;
     framebuffer_arg,        FRAMEBUFFER_ARG,    BootloaderFramebufferArg;
-    memory_regions,         MEMORY_REGIONS,     Vec<MemoryRegion>;
+    memory_regions,         MEMORY_REGIONS,     MemoryRegionArray;
 );
 
 /// The initialization method of the boot module.

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -32,6 +32,8 @@ pub struct BootInfo {
 }
 
 /// Gets the boot information.
+///
+/// This function is usable after initialization with [`init_after_heap`].
 pub fn boot_info() -> &'static BootInfo {
     INFO.get().unwrap()
 }
@@ -90,10 +92,11 @@ pub(crate) struct EarlyBootInfo {
 /// The boot-time information.
 pub(crate) static EARLY_INFO: Once<EarlyBootInfo> = Once::new();
 
-/// Initializes the runtime information.
+/// Initializes the boot information.
 ///
-/// This function allows the run-time getters to work properly.
-pub(crate) fn init() {
+/// This function copies the boot-time accessible information to the heap to
+/// allow [`boot_info`] to work properly.
+pub(crate) fn init_after_heap() {
     let boot_time_info = EARLY_INFO.get().unwrap();
 
     INFO.call_once(|| BootInfo {

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -31,6 +31,7 @@ struct PerApInfo {
     // no longer be used, and the `Segment` can be deallocated (this problem also
     // exists in the boot processor, but the memory it occupies should be returned
     // to the frame allocator).
+    #[allow(dead_code)]
     boot_stack_pages: Segment<KernelMeta>,
 }
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -75,14 +75,15 @@ unsafe fn init() {
     #[cfg(feature = "cvm_guest")]
     arch::init_cvm_guest();
 
+    logger::init();
+
     // SAFETY: This function is called only once and only on the BSP.
     unsafe { cpu::local::early_init_bsp_local_base() };
 
     // SAFETY: This function is called only once and only on the BSP.
     unsafe { mm::heap_allocator::init() };
 
-    boot::init();
-    logger::init();
+    boot::init_after_heap();
 
     mm::frame::allocator::init();
     mm::kspace::init_kernel_page_table(mm::init_page_meta());

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use log::{LevelFilter, Metadata, Record};
 use spin::Once;
 
-use crate::boot::{boot_info, kcmdline::ModuleArg};
+use crate::boot::BOOT_TIME_INFO;
 
 static LOGGER: Logger = Logger::new();
 
@@ -82,16 +82,15 @@ pub(crate) fn init() {
 }
 
 fn get_log_level() -> Option<LevelFilter> {
-    let module_args = boot_info().kernel_cmdline.get_module_args("ostd")?;
+    let kcmdline = BOOT_TIME_INFO.get().unwrap().kernel_cmdline;
 
-    let value = {
-        let value = module_args.iter().find_map(|arg| match arg {
-            ModuleArg::KeyVal(name, value) if name.as_bytes() == "log_level".as_bytes() => {
-                Some(value)
-            }
-            _ => None,
-        })?;
-        value.as_c_str().to_str().ok()?
-    };
+    // Although OSTD is agnostic of the parsing of the kernel command line,
+    // the logger assumes that it follows the Linux kernel command line format.
+    // We search for the `ostd.log_level=ARGUMENT` pattern in string.
+    let value = kcmdline
+        .split(' ')
+        .find(|arg| arg.starts_with("ostd.log_level="))
+        .map(|arg| arg.split('=').last().unwrap_or_default())?;
+
     LevelFilter::from_str(value).ok()
 }

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use log::{LevelFilter, Metadata, Record};
 use spin::Once;
 
-use crate::boot::BOOT_TIME_INFO;
+use crate::boot::EARLY_INFO;
 
 static LOGGER: Logger = Logger::new();
 
@@ -82,7 +82,7 @@ pub(crate) fn init() {
 }
 
 fn get_log_level() -> Option<LevelFilter> {
-    let kcmdline = BOOT_TIME_INFO.get().unwrap().kernel_cmdline;
+    let kcmdline = EARLY_INFO.get().unwrap().kernel_cmdline;
 
     // Although OSTD is agnostic of the parsing of the kernel command line,
     // the logger assumes that it follows the Linux kernel command line format.

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use log::{LevelFilter, Metadata, Record};
 use spin::Once;
 
-use crate::boot::{kcmdline::ModuleArg, kernel_cmdline};
+use crate::boot::{boot_info, kcmdline::ModuleArg};
 
 static LOGGER: Logger = Logger::new();
 
@@ -82,7 +82,7 @@ pub(crate) fn init() {
 }
 
 fn get_log_level() -> Option<LevelFilter> {
-    let module_args = kernel_cmdline().get_module_args("ostd")?;
+    let module_args = boot_info().kernel_cmdline.get_module_args("ostd")?;
 
     let value = {
         let value = module_args.iter().find_map(|arg| match arg {

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -184,7 +184,7 @@ impl CountingFrameAllocator {
 pub(in crate::mm) static FRAME_ALLOCATOR: Once<SpinLock<CountingFrameAllocator>> = Once::new();
 
 pub(crate) fn init() {
-    let regions = crate::boot::memory_regions();
+    let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
     let mut total: usize = 0;
     let mut allocator = FrameAllocator::<32>::new();
     for region in regions.iter() {

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -246,7 +246,7 @@ impl_frame_meta_for!(MetaPageMeta);
 /// The function returns a list of `Frame`s containing the metadata.
 pub(crate) fn init() -> Segment<MetaPageMeta> {
     let max_paddr = {
-        let regions = crate::boot::memory_regions();
+        let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
         regions.iter().map(|r| r.base() + r.len()).max().unwrap()
     };
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -134,7 +134,7 @@ pub static KERNEL_PAGE_TABLE: Once<PageTable<KernelMode, PageTableEntry, PagingC
 pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
     info!("Initializing the kernel page table");
 
-    let regions = crate::boot::memory_regions();
+    let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
     let phys_mem_cap = regions.iter().map(|r| r.base() + r.len()).max().unwrap();
 
     // Start to initialize the kernel page table.

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -115,6 +115,11 @@ bitflags! {
         const ACCESSED  = 0b00001000;
         /// Has the memory page been written.
         const DIRTY     = 0b00010000;
+
+        /// The first bit available for software use.
+        const AVAIL1    = 0b01000000;
+        /// The second bit available for software use.
+        const AVAIL2    = 0b10000000;
     }
 }
 


### PR DESCRIPTION
This is the first PR to achieve `alloc`-free booting. This PR eliminates
 1. the need of heap-allocated boot parameters during booting, so the copying of boot-context only boot parameters can be done late.
 2. the need of a `Vec` remembering the frames allocated for the boot page table. This is achieved by using an unused bit in PTEs that marks firmware PTs and boot PTs.

This PR also makes kernel commandline parsing out of OSTD, as it is convenient here.

Subsequent PRs to make the frame allocator `alloc`-free would finally enable #1555 