### PR TITLE
Initial pointer for kernel heap must be `*mut u8`

### DIFF
--- a/ostd/src/mm/heap_allocator/mod.rs
+++ b/ostd/src/mm/heap_allocator/mod.rs
@@ -41,7 +41,7 @@ pub unsafe fn init() {
     // SAFETY: The HEAP_SPACE is a static memory range, so it's always valid.
     unsafe {
         #[allow(static_mut_refs)]
-        HEAP_ALLOCATOR.init(HEAP_SPACE.0.as_ptr(), INIT_KERNEL_HEAP_SIZE);
+        HEAP_ALLOCATOR.init(HEAP_SPACE.0.as_mut_ptr(), INIT_KERNEL_HEAP_SIZE);
     }
 }
 
@@ -56,7 +56,7 @@ impl LockedHeapWithRescue {
     }
 
     /// SAFETY: The range [start, start + size) must be a valid memory region.
-    pub unsafe fn init(&self, start: *const u8, size: usize) {
+    pub unsafe fn init(&self, start: *mut u8, size: usize) {
         self.heap
             .call_once(|| SpinLock::new(Heap::new(start as usize, size)));
     }


### PR DESCRIPTION
`*const T` and `*mut T` are "mostly" the same (i.e., `const`/`mut` is just lint, and we're free to do `cast_mut()`/`cast_const()` whenever we want). However, it's "mostly" with one explicit exception: any pointers originally created as `*const T` can _never_ mutate the underlying data (except interior mutability), even if they are later casted to `*mut T`, and even if the storage (e.g., `static mut`) and Rust aliasing rules allow it.
 - For more details, please refer to https://github.com/rust-lang/unsafe-code-guidelines/issues/257. I'm quoting the most important sentence below:
> If that initial transition is a *const, then the entire "domain" gets marked as read-only (modulo UnsafeCell). The raw ptrs basically "remember" the way that the first raw ptr got created.

So, the following code is unsound, because the heap memory will be mutated later but we get `*const u8` as the initially created pointer:
https://github.com/asterinas/asterinas/blob/87ee88da8c5e6297838a86b395cee3c56807df60/ostd/src/mm/heap_allocator/mod.rs#L40-L44

Indeed, KernMiri complains UB when we create a mutable reference inside the heap storage (credit @cchanging):
https://github.com/asterinas/asterinas/blob/87ee88da8c5e6297838a86b395cee3c56807df60/ostd/src/mm/heap_allocator/slab_allocator/slab.rs#L110-L111

```
error: Undefined Behavior: trying to retag from <wildcard> for Unique permission at alloc164[0xfffc0], but no exposed tags have suitable permission in the borrow stack for this location
  --> src/main.rs:10:29
    |
111 |            new_list.push(&mut *new_block);
    |                          ^^^^^^^^^^^^^^^
    |                          |
    |                          trying to retag from <wildcard> for Unique permission at alloc164[0xfffc0], but no exposed tags have suitable permission in the borrow stack for this location
    |                          this error occurs as part of retag at alloc164[0xfffc0..0xfffc8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
```

Credits: @cchanging found this UB via KernMiri. We had some offline discussions about this UB, and then @cchanging and I did some experiments to finally figure out what was happening.