### PR TITLE
Remove `tcp_loopback_connect_lat` from benchmark summary

### DIFF
--- a/test/benchmark/lmbench/summary.json
+++ b/test/benchmark/lmbench/summary.json
@@ -32,7 +32,6 @@
         "tcp_loopback_bw_4k",
         "tcp_loopback_bw_64k",
         "tcp_loopback_lat",
-        "tcp_loopback_connect_lat",
         "tcp_loopback_select_lat",
         "tcp_loopback_http_bw",
         "udp_loopback_lat",

--- a/test/benchmark/lmbench/tcp_loopback_connect_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_loopback_connect_lat/bench_result.json
@@ -8,7 +8,7 @@
         "result_index": 6
     },
     "chart": {
-        "title": "[TCP sockets] The latency of connect",
+        "title": "[TCP sockets] The latency of connect (loopback)",
         "description": "lat_connect",
         "unit": "\u00b5s",
         "legend": "Average TCP connection latency on {system}"

--- a/test/benchmark/lmbench/tcp_virtio_connect_lat/bench_result.json
+++ b/test/benchmark/lmbench/tcp_virtio_connect_lat/bench_result.json
@@ -8,7 +8,7 @@
         "result_index": 6
     },
     "chart": {
-        "title": "[TCP sockets] The latency of connect",
+        "title": "[TCP sockets] The latency of connect (virtio-net)",
         "description": "lat_connect",
         "unit": "\u00b5s",
         "legend": "Average TCP connection latency on {system}"


### PR DESCRIPTION
According to https://github.com/asterinas/asterinas/issues/1733#issuecomment-2574404540, `tcp_loopback_connect_lat` reveals a pitfall in the scheduling system.

While I agree that it indicates that something in the scheduling system needs to be fixed (perhaps we need a smarter preemptive strategy to fix this, e.g., CFS), I'm doubtful that it needs to be kept in the lmbench summary table. There are two points:
 - It does not benchmark what it is supposed to benchmark (i.e., the TCP connection latency of Linux and Asterinas).
 - The results are surprising, as Asterinas is shown to be orders of magnitude slower than Linux, which is not the case.

Meanwhile, `tcp_virtio_connect_lat` and `tcp_loopback_connect_lat` have exactly the same title, which is _very_ confusing. In fact, I think it's even more confusing because the summary table seems to merge items with the same title, I didn't figure out why this was happening for quite a while.