### PR TITLE
Cache negative dentries for faster negative lookups

### DIFF
--- a/kernel/src/fs/devpts/mod.rs
+++ b/kernel/src/fs/devpts/mod.rs
@@ -299,4 +299,8 @@ impl Inode for RootInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         self.fs.upgrade().unwrap()
     }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        false
+    }
 }

--- a/kernel/src/fs/devpts/ptmx.rs
+++ b/kernel/src/fs/devpts/ptmx.rs
@@ -163,6 +163,10 @@ impl Inode for Ptmx {
     fn as_device(&self) -> Option<Arc<dyn Device>> {
         Some(Arc::new(self.inner.clone()))
     }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        false
+    }
 }
 
 impl Device for Inner {


### PR DESCRIPTION
This PR introduces "negative dentry", learned from [Linux](https://github.com/torvalds/linux/blob/v6.13-rc6/Documentation/filesystems/vfs.rst?plain=1#L1460), which reflects failed filename lookups, saving potential repeated and costly lookups in the future.

Below shows the benefit on benchmark `sqlite-speedtest1-ext2`, which issues a lot of negative lookup on files "sqlite.db-journal" and "sqlite.db-wal" in its pattern:

| Case                 | Old (latency) | New     |
| -------------------- | ------------- | ------- |
| SELECTS on an IPK    | 4.403s        | 3.328s  |
| SELECTS on a TEXT PK | 4.704s        | 3.662s  |
| ...                  |               |         |
| TOTAL                | 78.303s       | 72.276s |




