### PR TITLE
Better safety reasoning about CPU-local variables

### DIFF
--- a/ostd/src/arch/riscv/boot/boot.S
+++ b/ostd/src/arch/riscv/boot/boot.S
@@ -28,7 +28,11 @@ _start:
     # 2. set sp (BSP only)
     lga    sp, boot_stack_top
 
-    # 3. jump to rust riscv_boot
+    # 3. set gp (CPU-local address)
+.extern __cpu_local_start
+    lga    gp, __cpu_local_start
+
+    # 4. jump to rust riscv_boot
     lga    t0, riscv_boot
     jr     t0
 

--- a/ostd/src/arch/riscv/cpu/local.rs
+++ b/ostd/src/arch/riscv/cpu/local.rs
@@ -2,14 +2,6 @@
 
 //! Architecture dependent CPU-local information utilities.
 
-pub(crate) unsafe fn set_base(addr: u64) {
-    core::arch::asm!(
-        "mv gp, {addr}",
-        addr = in(reg) addr,
-        options(preserves_flags, nostack)
-    );
-}
-
 pub(crate) fn get_base() -> u64 {
     let mut gp;
     unsafe {

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -29,7 +29,8 @@ pub(crate) unsafe fn late_init_on_bsp() {
     }
     irq::init();
 
-    crate::boot::smp::boot_all_aps();
+    // SAFETY: we're on the BSP and we're ready to boot all APs.
+    unsafe { crate::boot::smp::boot_all_aps() };
 
     timer::init();
     let _ = pci::init();

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -5,10 +5,6 @@
 .global ap_boot_from_real_mode
 .global ap_boot_from_long_mode
 
-.extern boot_gdtr
-.extern boot_page_table_start
-.extern ap_early_entry
-
 .section ".ap_boot", "awx"
 .align 4096
 
@@ -18,6 +14,7 @@ MMIO_XAPIC_APICID = 0xFEE00020
 
 .macro setup_64bit_gdt_and_page_table eax
     // Use the 64-bit GDT.
+.extern boot_gdtr
     lgdt [boot_gdtr]
 
     // Enable PAE and PGE.
@@ -62,7 +59,7 @@ ap_boot_from_long_mode:
     retf // 32-bit far return
 .align 8
 retf_stack_bottom:
-.long ap_long_mode
+.long ap_long_mode_in_low_address
 .long 0x8
 retf_stack_top:
 
@@ -161,10 +158,10 @@ ap_protect:
     or eax, 1 << 31
     mov cr0, eax
 
-    ljmp 0x8, offset ap_long_mode
+    ljmp 0x8, offset ap_long_mode_in_low_address
 
 .code64
-ap_long_mode:
+ap_long_mode_in_low_address:
     mov ax, 0
     mov ds, ax
     mov ss, ax
@@ -172,26 +169,40 @@ ap_long_mode:
     mov fs, ax
     mov gs, ax
 
+    // Update RIP to use the virtual address.
+    mov rax, offset ap_long_mode
+    jmp rax
+
+.data
+// This is a pointer to be filled by the BSP when boot information
+// of all APs are allocated and initialized.
+.global __ap_boot_info_array_pointer
+.align 8
+__ap_boot_info_array_pointer:
+    .skip 8
+
+.text
+.code64
+ap_long_mode:
     // The local APIC ID is in the RDI.
     mov rax, rdi
-    shl rax, 3
+    shl rax, 4                   // 16-byte `PerApRawInfo`
 
+    mov rbx, [rip + __ap_boot_info_array_pointer]
     // Setup the stack.
-    mov rbx, [__ap_boot_stack_array_pointer]
-    mov rsp, [rbx + rax]
-    xor rbp, rbp
+    mov rsp, [rbx + rax - 16]    // raw_info[cpu_id - 1].stack_top
+    // Setup the GS base (the CPU-local address).
+    mov rax, [rbx + rax - 8]     // raw_info[cpu_id - 1].cpu_local
+    mov rdx, rax
+    shr rdx, 32          // EDX:EAX = raw_info.cpu_local
+    mov ecx, 0xC0000101  // ECX = GS.base
+    wrmsr
 
     // Go to Rust code.
+.extern ap_early_entry
+    xor rbp, rbp
     mov rax, offset ap_early_entry
     call rax
 
 .extern halt # bsp_boot.S
     jmp halt
-
-.data
-// This is a pointer to be filled by the BSP when boot stacks
-// of all APs are allocated and initialized.
-.global __ap_boot_stack_array_pointer
-.align 8
-__ap_boot_stack_array_pointer:
-    .skip 8

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -309,7 +309,18 @@ long_mode:
     sub rcx, rdi
     rep stosb
 
-    // Call the corresponding Rust entrypoint according to the boot entrypoint
+    // Clear RBP to stop the backtrace.
+    xor rbp, rbp
+
+    // Initialize the GS base to the CPU-local start address.
+.extern __cpu_local_start
+    lea rax, [rip + __cpu_local_start]
+    mov rdx, rax
+    shr rdx, 32          // EDX:EAX = __cpu_local_start
+    mov ecx, 0xC0000101  // ECX = GS.base
+    wrmsr
+
+    // Call the corresponding Rust entrypoint according to the boot entrypoint.
     pop rax
     cmp rax, ENTRYTYPE_MULTIBOOT
     je entry_type_multiboot
@@ -329,8 +340,6 @@ long_mode:
 entry_type_linux:
     pop rdi // boot_params ptr
 
-    xor rbp, rbp
-
     lea  rax, [rip + __linux_boot]  // jump into Rust code
     call rax
     jmp halt
@@ -339,8 +348,6 @@ entry_type_multiboot:
     pop rsi // the address of multiboot info
     pop rdi // multiboot magic
 
-    xor rbp, rbp
-
     lea  rax, [rip + __multiboot_entry]  // jump into Rust code
     call rax
     jmp halt
@@ -348,8 +355,6 @@ entry_type_multiboot:
 entry_type_multiboot2:
     pop rsi // the address of multiboot info
     pop rdi // multiboot magic
-
-    xor rbp, rbp
 
     lea  rax, [rip + __multiboot2_entry]  // jump into Rust code
     call rax

--- a/ostd/src/arch/x86/cpu/local.rs
+++ b/ostd/src/arch/x86/cpu/local.rs
@@ -15,111 +15,113 @@ use crate::cpu::local::single_instr::{
     SingleInstructionSubAssign,
 };
 
-/// The GDT ensures that the GS segment is initialized to zero on boot.
-/// This assertion checks that the base address has been set.
-macro_rules! debug_assert_initialized {
-    () => {
-        // The compiler may think that [`super::get_base`] has side effects
-        // so it may not be optimized out. We make sure that it will be
-        // conditionally compiled only in debug builds.
-        #[cfg(debug_assertions)]
-        debug_assert_ne!(get_base(), 0);
-    };
-}
-
 macro_rules! impl_numeric_single_instruction_for {
     ($([$typ: ty, $inout_type: ident, $register_format: expr])*) => {$(
 
         impl SingleInstructionAddAssign<$typ> for $typ {
             unsafe fn add_assign(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("add gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY:
+                // 1. `gs` points to the CPU-local region (global invariant).
+                // 2. `offset` represents the offset of a CPU-local variable
+                //    (upheld by the caller).
+                // 3. The variable is only accessible in the current CPU, is
+                //    a scalar, and is never borrowed, so it is valid to
+                //    read/write using a single instruction (upheld by the
+                //    caller).
+                unsafe {
+                    core::arch::asm!(
+                        concat!("add gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
         impl SingleInstructionSubAssign<$typ> for $typ {
             unsafe fn sub_assign(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("sub gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("sub gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
         impl SingleInstructionBitAndAssign<$typ> for $typ {
             unsafe fn bitand_assign(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("and gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("and gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
         impl SingleInstructionBitOrAssign<$typ> for $typ {
             unsafe fn bitor_assign(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("or gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("or gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
         impl SingleInstructionBitXorAssign<$typ> for $typ {
             unsafe fn bitxor_assign(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("xor gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("xor gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
         impl SingleInstructionLoad for $typ {
             unsafe fn load(offset: *const Self) -> Self {
-                debug_assert_initialized!();
-
                 let val: Self;
-                core::arch::asm!(
-                    concat!("mov {0", $register_format, "}, gs:[{1}]"),
-                    out($inout_type) val,
-                    in(reg) offset,
-                    options(nostack, readonly),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("mov {0", $register_format, "}, gs:[{1}]"),
+                        out($inout_type) val,
+                        in(reg) offset,
+                        options(nostack, readonly),
+                    );
+                }
                 val
             }
         }
 
         impl SingleInstructionStore for $typ {
             unsafe fn store(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("mov gs:[{0}], {1", $register_format, "}"),
-                    in(reg) offset,
-                    in($inout_type) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("mov gs:[{0}], {1", $register_format, "}"),
+                        in(reg) offset,
+                        in($inout_type) val,
+                        options(nostack),
+                    );
+                }
             }
         }
 
@@ -144,29 +146,31 @@ macro_rules! impl_generic_single_instruction_for {
 
         impl<$gen_type $(, $more_gen_type)*> SingleInstructionLoad for $typ {
             unsafe fn load(offset: *const Self) -> Self {
-                debug_assert_initialized!();
-
                 let val: Self;
-                core::arch::asm!(
-                    concat!("mov {0}, gs:[{1}]"),
-                    out(reg) val,
-                    in(reg) offset,
-                    options(nostack, readonly),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("mov {0}, gs:[{1}]"),
+                        out(reg) val,
+                        in(reg) offset,
+                        options(nostack, readonly),
+                    );
+                }
                 val
             }
         }
 
         impl<$gen_type $(, $more_gen_type)*> SingleInstructionStore for $typ {
             unsafe fn store(offset: *mut Self, val: Self) {
-                debug_assert_initialized!();
-
-                core::arch::asm!(
-                    concat!("mov gs:[{0}], {1}"),
-                    in(reg) offset,
-                    in(reg) val,
-                    options(nostack),
-                );
+                // SAFETY: Same as `add_assign`.
+                unsafe {
+                    core::arch::asm!(
+                        concat!("mov gs:[{0}], {1}"),
+                        in(reg) offset,
+                        in(reg) val,
+                        options(nostack),
+                    );
+                }
             }
         }
     )*}
@@ -184,15 +188,16 @@ impl_generic_single_instruction_for!(
 
 impl SingleInstructionLoad for bool {
     unsafe fn load(offset: *const Self) -> Self {
-        debug_assert_initialized!();
-
         let val: u8;
-        core::arch::asm!(
-            "mov {0}, gs:[{1}]",
-            out(reg_byte) val,
-            in(reg) offset,
-            options(nostack, readonly),
-        );
+        // SAFETY: Same as `add_assign`.
+        unsafe {
+            core::arch::asm!(
+                "mov {0}, gs:[{1}]",
+                out(reg_byte) val,
+                in(reg) offset,
+                options(nostack, readonly),
+            );
+        }
         debug_assert!(val == 1 || val == 0);
         val == 1
     }
@@ -200,14 +205,15 @@ impl SingleInstructionLoad for bool {
 
 impl SingleInstructionStore for bool {
     unsafe fn store(offset: *mut Self, val: Self) {
-        debug_assert_initialized!();
-
         let val: u8 = if val { 1 } else { 0 };
-        core::arch::asm!(
-            "mov gs:[{0}], {1}",
-            in(reg) offset,
-            in(reg_byte) val,
-            options(nostack),
-        );
+        // SAFETY: Same as `add_assign`.
+        unsafe {
+            core::arch::asm!(
+                "mov gs:[{0}], {1}",
+                in(reg) offset,
+                in(reg_byte) val,
+                options(nostack),
+            );
+        }
     }
 }

--- a/ostd/src/arch/x86/cpu/local.rs
+++ b/ostd/src/arch/x86/cpu/local.rs
@@ -4,20 +4,6 @@
 
 use x86_64::registers::segmentation::{Segment64, GS};
 
-/// Sets the base address for the CPU local storage by writing to the GS base model-specific register.
-/// This operation is marked as `unsafe` because it directly interfaces with low-level CPU registers.
-///
-/// # Safety
-///
-///  - This function is safe to call provided that the GS register is dedicated entirely for CPU local storage
-///    and is not concurrently accessed for other purposes.
-///  - The caller must ensure that `addr` is a valid address and properly aligned, as required by the CPU.
-///  - This function should only be called in contexts where the CPU is in a state to accept such changes,
-///    such as during processor initialization.
-pub(crate) unsafe fn set_base(addr: u64) {
-    GS::write_base(x86_64::addr::VirtAddr::new(addr));
-}
-
 /// Gets the base address for the CPU local storage by reading the GS base model-specific register.
 pub(crate) fn get_base() -> u64 {
     GS::read_base().as_u64()

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -95,7 +95,8 @@ pub(crate) unsafe fn late_init_on_bsp() {
     kernel::tsc::init_tsc_freq();
     timer::init_bsp();
 
-    crate::boot::smp::boot_all_aps();
+    // SAFETY: we're on the BSP and we're ready to boot all APs.
+    unsafe { crate::boot::smp::boot_all_aps() };
 
     if_tdx_enabled!({
     } else {

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -40,14 +40,16 @@ struct PerApInfo {
 
 static AP_LATE_ENTRY: Once<fn()> = Once::new();
 
-/// Boot all application processors.
+/// Boots all application processors.
 ///
 /// This function should be called late in the system startup. The system must at
 /// least ensure that the scheduler, ACPI table, memory allocation, and IPI module
 /// have been initialized.
 ///
-/// However, the function need to be called before any `cpu_local!` variables are
-/// accessed, including the APIC instance.
+/// # Safety
+///
+/// This function can only be called in the boot context of the BSP where APs have
+/// not yet been booted.
 pub fn boot_all_aps() {
     let num_cpus = num_cpus() as u32;
     if num_cpus == 1 {
@@ -97,7 +99,8 @@ pub fn boot_all_aps() {
 
     log::info!("Booting all application processors...");
 
-    bringup_all_aps(num_cpus);
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { bringup_all_aps(num_cpus) };
     wait_for_all_aps_started();
 
     log::info!("All application processors started. The BSP continues to run.");

--- a/ostd/src/cpu/local/cell.rs
+++ b/ostd/src/cpu/local/cell.rs
@@ -110,7 +110,7 @@ impl<T: 'static> CpuLocalCell<T> {
     ///   must be taken to ensure that the borrowing rules are correctly
     ///   enforced, since the interrupts may come asynchronously.
     pub fn as_mut_ptr(&'static self) -> *mut T {
-        super::has_init::assert_true();
+        super::is_used::debug_set_true();
 
         let offset = {
             let bsp_va = self as *const _ as usize;

--- a/ostd/src/cpu/local/cpu_local.rs
+++ b/ostd/src/cpu/local/cpu_local.rs
@@ -84,7 +84,7 @@ impl<T: 'static> CpuLocal<T> {
         Self(val)
     }
 
-    /// Get access to the underlying value on the current CPU with a
+    /// Gets access to the underlying value on the current CPU with a
     /// provided IRQ guard.
     ///
     /// By this method, you can borrow a reference to the underlying value
@@ -100,15 +100,10 @@ impl<T: 'static> CpuLocal<T> {
         }
     }
 
-    /// Get access to the underlying value through a raw pointer.
+    /// Gets access to the underlying value through a raw pointer.
     ///
-    /// This function calculates the virtual address of the CPU-local object
-    /// based on the CPU-local base address and the offset in the BSP.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the reference to `self` is static.
-    pub(crate) unsafe fn as_ptr(&'static self) -> *const T {
+    /// This method is safe, but using the returned pointer will be unsafe.
+    pub(crate) fn as_ptr(&'static self) -> *const T {
         super::is_used::debug_set_true();
 
         let offset = self.get_offset();
@@ -122,7 +117,7 @@ impl<T: 'static> CpuLocal<T> {
         local_va as *mut T
     }
 
-    /// Get the offset of the CPU-local object in the CPU-local area.
+    /// Gets the offset of the CPU-local object in the CPU-local area.
     fn get_offset(&'static self) -> usize {
         let bsp_va = self as *const _ as usize;
         let bsp_base = __cpu_local_start as usize;
@@ -134,11 +129,10 @@ impl<T: 'static> CpuLocal<T> {
 }
 
 impl<T: 'static + Sync> CpuLocal<T> {
-    /// Get access to the copy of value on a specific CPU.
+    /// Gets access to the CPU-local value on a specific CPU.
     ///
-    /// # Panics
-    ///
-    /// Panics if the CPU ID is out of range.
+    /// This allows the caller to access CPU-local data from a remote CPU,
+    /// so the data type must be `Sync`.
     pub fn get_on_cpu(&'static self, cpu_id: CpuId) -> &'static T {
         super::is_used::debug_set_true();
 
@@ -149,21 +143,22 @@ impl<T: 'static + Sync> CpuLocal<T> {
             return &self.0;
         }
 
-        // SAFETY: Here we use `Once::get_unchecked` to make getting the CPU-
-        // local base faster. The storages must be initialized here (since this
-        // is not the BSP) so it is safe to do so.
-        let base = unsafe {
-            *super::CPU_LOCAL_STORAGES
-                .get_unchecked()
-                .get_unchecked(cpu_id - 1)
-        };
-        let base = crate::mm::paddr_to_vaddr(base);
+        // SAFETY: At this time we have a non-BSP `CpuId`, which means that
+        // `init_cpu_nums` must have been called, so `copy_bsp_for_ap` must
+        // also have been called (see the implementation of `cpu::init_on_bsp`),
+        // so `CPU_LOCAL_STORAGES` must already be initialized.
+        let storages = unsafe { super::CPU_LOCAL_STORAGES.get_unchecked() };
+        // SAFETY: `cpu_id` is guaranteed to be in range because the type
+        // invariant of `CpuId`.
+        let storage = unsafe { *storages.get_unchecked(cpu_id - 1) };
+        let base = crate::mm::paddr_to_vaddr(storage);
 
         let offset = self.get_offset();
-
         let ptr = (base + offset) as *const T;
 
-        // SAFETY: The pointer is valid since the initialization is completed.
+        // SAFETY: `ptr` represents CPU-local data on a remote CPU. It
+        // contains valid data, the type is `Sync`, and no one will mutably
+        // borrow it, so creating an immutable borrow here is valid.
         unsafe { &*ptr }
     }
 }

--- a/ostd/src/cpu/local/cpu_local.rs
+++ b/ostd/src/cpu/local/cpu_local.rs
@@ -109,7 +109,7 @@ impl<T: 'static> CpuLocal<T> {
     ///
     /// The caller must ensure that the reference to `self` is static.
     pub(crate) unsafe fn as_ptr(&'static self) -> *const T {
-        super::has_init::assert_true();
+        super::is_used::debug_set_true();
 
         let offset = self.get_offset();
 
@@ -140,16 +140,23 @@ impl<T: 'static + Sync> CpuLocal<T> {
     ///
     /// Panics if the CPU ID is out of range.
     pub fn get_on_cpu(&'static self, cpu_id: CpuId) -> &'static T {
-        super::has_init::assert_true();
+        super::is_used::debug_set_true();
+
+        let cpu_id = cpu_id.as_usize();
+
         // If on the BSP, just use the statically linked storage.
-        if cpu_id.as_usize() == 0 {
+        if cpu_id == 0 {
             return &self.0;
         }
 
         // SAFETY: Here we use `Once::get_unchecked` to make getting the CPU-
         // local base faster. The storages must be initialized here (since this
         // is not the BSP) so it is safe to do so.
-        let base = unsafe { super::CPU_LOCAL_STORAGES.get_unchecked().get(cpu_id) };
+        let base = unsafe {
+            *super::CPU_LOCAL_STORAGES
+                .get_unchecked()
+                .get_unchecked(cpu_id - 1)
+        };
         let base = crate::mm::paddr_to_vaddr(base);
 
         let offset = self.get_offset();

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -65,8 +65,11 @@ static CPU_LOCAL_STORAGES: Once<&'static [Paddr]> = Once::new();
 /// function to copy it for the APs. Otherwise, the copied data will
 /// contain non-constant (also non-`Copy`) data, resulting in undefined
 /// behavior when it's loaded on the APs.
-pub(crate) unsafe fn copy_bsp_for_ap() {
-    let num_aps = super::num_cpus() - 1; // BSP does not need allocated storage.
+///
+/// The caller must ensure that the `num_cpus` matches the number of all
+/// CPUs that will access the CPU-local storage.
+pub(crate) unsafe fn copy_bsp_for_ap(num_cpus: usize) {
+    let num_aps = num_cpus - 1; // BSP does not need allocated storage.
     if num_aps == 0 {
         return;
     }

--- a/ostd/src/cpu/local/single_instr.rs
+++ b/ostd/src/cpu/local/single_instr.rs
@@ -35,7 +35,7 @@ pub trait SingleInstructionAddAssign<Rhs = Self> {
     ///
     /// # Safety
     ///
-    ///
+    /// Please refer to the module-level documentation of [`self`].
     unsafe fn add_assign(offset: *mut Self, rhs: Rhs);
 }
 
@@ -44,7 +44,12 @@ impl<T: num_traits::WrappingAdd + Copy> SingleInstructionAddAssign<T> for T {
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
-        addr.write(addr.read().wrapping_add(&rhs));
+        // SAFETY:
+        // 1. `addr` represents the address of a CPU-local variable.
+        // 2. The variable is only accessible in the current CPU, is
+        //    `Copy`, and is is never borrowed, so it is valid to
+        //    read/write.
+        unsafe { addr.write(addr.read().wrapping_add(&rhs)) };
     }
 }
 
@@ -65,7 +70,8 @@ impl<T: num_traits::WrappingSub + Copy> SingleInstructionSubAssign<T> for T {
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
-        addr.write(addr.read().wrapping_sub(&rhs));
+        // SAFETY: Same as `add_assign`.
+        unsafe { addr.write(addr.read().wrapping_sub(&rhs)) };
     }
 }
 
@@ -84,7 +90,8 @@ impl<T: core::ops::BitOr<Output = T> + Copy> SingleInstructionBitOrAssign<T> for
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
-        addr.write(addr.read() | rhs);
+        // SAFETY: Same as `add_assign`.
+        unsafe { addr.write(addr.read() | rhs) };
     }
 }
 
@@ -103,7 +110,8 @@ impl<T: core::ops::BitAnd<Output = T> + Copy> SingleInstructionBitAndAssign<T> f
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
-        addr.write(addr.read() & rhs);
+        // SAFETY: Same as `add_assign`.
+        unsafe { addr.write(addr.read() & rhs) };
     }
 }
 
@@ -122,7 +130,8 @@ impl<T: core::ops::BitXor<Output = T> + Copy> SingleInstructionBitXorAssign<T> f
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
-        addr.write(addr.read() ^ rhs);
+        // SAFETY: Same as `add_assign`.
+        unsafe { addr.write(addr.read() ^ rhs) };
     }
 }
 
@@ -141,7 +150,8 @@ impl<T: Copy> SingleInstructionLoad for T {
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let ptr = (base + offset as usize) as *const Self;
-        ptr.read()
+        // SAFETY: Same as `add_assign`.
+        unsafe { ptr.read() }
     }
 }
 
@@ -160,6 +170,7 @@ impl<T: Copy> SingleInstructionStore for T {
         let _guard = crate::trap::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let ptr = (base + offset as usize) as *mut Self;
-        ptr.write(val);
+        // SAFETY: Same as `add_assign`.
+        unsafe { ptr.write(val) };
     }
 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -84,11 +84,13 @@ unsafe fn init() {
 
     logger::init();
 
-    // SAFETY: They are only called once on BSP and ACPI has been initialized.
-    // No CPU local objects have been accessed by this far.
+    // SAFETY:
+    // 1. They are only called once in the boot context of the BSP.
+    // 2. The number of CPUs are available because ACPI has been initialized.
+    // 3. No CPU-local objects have been accessed yet.
     unsafe {
         cpu::init_num_cpus();
-        cpu::local::init_on_bsp();
+        cpu::local::copy_bsp_for_ap();
         cpu::set_this_cpu_id(0);
     }
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -88,11 +88,7 @@ unsafe fn init() {
     // 1. They are only called once in the boot context of the BSP.
     // 2. The number of CPUs are available because ACPI has been initialized.
     // 3. No CPU-local objects have been accessed yet.
-    unsafe {
-        cpu::init_num_cpus();
-        cpu::local::copy_bsp_for_ap();
-        cpu::set_this_cpu_id(0);
-    }
+    unsafe { cpu::init_on_bsp() };
 
     // SAFETY: We are on the BSP and APs are not yet started.
     let meta_pages = unsafe { mm::frame::meta::init() };


### PR DESCRIPTION
I'm trying to get avoid of some "fake" safety reasoning. For example:
https://github.com/asterinas/asterinas/blob/b9ce3e64ad57f336b22ae39daaae618ad12c343c/ostd/src/arch/x86/cpu/local.rs#L49-L52
- `SAFETY: GS has a valid base`, but why? **(Problem 1)**

https://github.com/asterinas/asterinas/blob/b9ce3e64ad57f336b22ae39daaae618ad12c343c/ostd/src/cpu/local/cpu_local.rs#L152-L157
- `SAFETY: The storage is initialized`, but why? **(Problem 2)**

https://github.com/asterinas/asterinas/blob/b9ce3e64ad57f336b22ae39daaae618ad12c343c/ostd/src/cpu/mod.rs#L85-L87
- `SAFETY: The number of CPUs is initialized`, but why? **(Problem 3)**

I found myself unable to reasonably answer the above "but why" questions. Of course, I know that these safety conditions are perfectly met _after our kernel has successfully booted_, but the problem is _who ensures that these methods can't be called during boot time?_ They're exposed to safe APIs, so it's just too easy to call them at boot time without realizing that it introduces UB.

This got me thinking about whether it would be possible to fix the problems. In fact, I found that all three problems are fixable: some tricks are involved, but overall I think that fixing them results in a better state for doing proper safety reasoning.

- To fix **Problem 1**, we can simply introduce a new global invariant: the GS base address points to CPU-local memory. Saying it's a global invariant means that the initialization should be done before entering the Rust code. This seems reasonable for the following reasons:
  - Setting up the base address is highly architecture dependent, so using assembly code to initialize it before entering the Rust code seems fine.
  - We have already used `early_init_bsp_local_base` to set the base address early in the boot process. So moving the initialization to an even earlier stage of the boot process seems to be fine as well.
https://github.com/asterinas/asterinas/blob/b9ce3e64ad57f336b22ae39daaae618ad12c343c/ostd/src/lib.rs#L80-L81

For details, see commit "Turn `GS.base` validity into a global invariant".

- To fix **Problem 3**, we notice at the point of doing `CPU_LOCAL_STORAGES.get_unchecked()` that we must have a non-BSP `CpuId`. We can do the following to ensure that if a non-BSP `CpuId` can be constructed, then `CPU_LOCAL_STORAGES` must have been initialized.
  - First, we initialize `NUM_CPUS` to one at the beginning of the boot process, so that a non-BSP `CpuId` cannot be constructed.
  - Second, we initialize `CPU_LOCAL_STORAGES` (according to the actual number of CPUs).
  - Third, we update `NUM_CPUS` to the actual number of CPUs. Now a non-BSP `CpuId` can be constructed.

For details, see commit "Fix safety reasoning about `get_on_cpu`" (Note that it also fixes **Problem 2**).

(Looks like #1783 also touches the related code. This PR may need to be rebase after it is merged).