### PR TITLE
Distribute tasks among all the CPUs (in CFS)

### DIFF
--- a/kernel/src/sched/sched_class/fair.rs
+++ b/kernel/src/sched/sched_class/fair.rs
@@ -235,11 +235,11 @@ impl SchedClassRq for FairClassRq {
         self.entities.push(Reverse(FairQueueItem(entity, vruntime)));
     }
 
-    fn len(&mut self) -> usize {
+    fn len(&self) -> usize {
         self.entities.len()
     }
 
-    fn is_empty(&mut self) -> bool {
+    fn is_empty(&self) -> bool {
         self.entities.is_empty()
     }
 

--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -43,11 +43,11 @@ impl SchedClassRq for IdleClassRq {
         }
     }
 
-    fn len(&mut self) -> usize {
+    fn len(&self) -> usize {
         usize::from(!self.is_empty())
     }
 
-    fn is_empty(&mut self) -> bool {
+    fn is_empty(&self) -> bool {
         self.entity.is_none()
     }
 

--- a/kernel/src/sched/sched_class/real_time.rs
+++ b/kernel/src/sched/sched_class/real_time.rs
@@ -184,11 +184,11 @@ impl SchedClassRq for RealTimeClassRq {
         self.nr_running += 1;
     }
 
-    fn len(&mut self) -> usize {
+    fn len(&self) -> usize {
         self.nr_running
     }
 
-    fn is_empty(&mut self) -> bool {
+    fn is_empty(&self) -> bool {
         self.nr_running == 0
     }
 

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -41,11 +41,11 @@ impl SchedClassRq for StopClassRq {
         }
     }
 
-    fn len(&mut self) -> usize {
+    fn len(&self) -> usize {
         usize::from(!self.is_empty())
     }
 
-    fn is_empty(&mut self) -> bool {
+    fn is_empty(&self) -> bool {
         self.thread.is_none()
     }
 

--- a/ostd/src/task/scheduler/info.rs
+++ b/ostd/src/task/scheduler/info.rs
@@ -48,6 +48,11 @@ impl AtomicCpuId {
             .map_err(|prev| (prev as usize).try_into().unwrap())
     }
 
+    /// Sets the inner value of an `AtomicCpuId` anyway.
+    pub fn set_anyway(&self, cpu_id: CpuId) {
+        self.0.store(cpu_id.as_usize() as u32, Ordering::Relaxed);
+    }
+
     /// Sets the inner value of an `AtomicCpuId` to `AtomicCpuId::NONE`, i.e. makes
     /// an `AtomicCpuId` empty.
     pub fn set_to_none(&self) {


### PR DESCRIPTION
This PR adds basic multi-core support for current CFS implementation.

We select the CPU with minimum number of tasks as the target for a newly enqueued task. It's basically the same with what we do in current priority scheduler. This can be vulnerable with too many tasks, each with its own priority. However, it should be OK for our simple workloads now (or, at least no worse than the trivial priority scheduler).

Here are profile results of the CFS and our current priority scheduler on schbench (SMP = 8). We can see the overhead of CFS is much smaller.

- CFS ([interactive](https://github.com/user-attachments/assets/231bf945-a624-4684-a7fd-1c3db84d0d70))
    ![aster-nix-profile-082943](https://github.com/user-attachments/assets/231bf945-a624-4684-a7fd-1c3db84d0d70)

- priority scheduler ([interactive](https://github.com/user-attachments/assets/20050e6c-ea75-4f0c-9974-d7c176f4b9e9))
    ![aster-nix-profile-090806](https://github.com/user-attachments/assets/20050e6c-ea75-4f0c-9974-d7c176f4b9e9)

I didn't implement more complicated solutions like scheduler domain here since we currently don't involve much SMT or NUMA stuff and I'd like the CFS to be enabled first before we get everything perfect.
