### PR TITLE
Add ktest cases for vmspace

### DIFF
--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -8,7 +8,10 @@ use ostd_pod::Pod;
 use crate::{
     mm::{
         io::{VmIo, VmReader, VmWriter},
-        FallibleVmRead, FallibleVmWrite, FrameAllocOptions,
+        tlb::TlbFlushOp,
+        vm_space::{get_activated_vm_space, VmItem, VmSpaceClearError},
+        CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PageFlags, PageProperty,
+        UFrame, VmSpace,
     },
     prelude::*,
     Error,
@@ -487,5 +490,441 @@ mod io {
         let mut read_buffer = [0u8; 12];
         segment.read_slice(0, &mut read_buffer[..]).unwrap();
         assert_eq!(read_buffer, [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
+    }
+}
+
+mod vmspace {
+    use super::*;
+
+    /// Helper function to create a dummy `UFrame`.
+    fn create_dummy_frame() -> UFrame {
+        let frame = FrameAllocOptions::new().alloc_frame().unwrap();
+        let uframe: UFrame = frame.into();
+        uframe
+    }
+
+    /// Creates a new `VmSpace` and verifies its initial state.
+    #[ktest]
+    fn vmspace_creation() {
+        let vmspace = VmSpace::new();
+        let range = 0x0..0x1000;
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.next(),
+            Some(VmItem::NotMapped { va: 0, len: 0x1000 })
+        );
+    }
+
+    /// Maps and unmaps a single page using `CursorMut`.
+    #[ktest]
+    fn vmspace_map_unmap() {
+        let vmspace = VmSpace::default();
+        let range = 0x1000..0x2000;
+        let frame = create_dummy_frame();
+        let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            // Initially, the page should not be mapped.
+            assert_eq!(
+                cursor_mut.query().unwrap(),
+                VmItem::NotMapped {
+                    va: range.start,
+                    len: range.start + 0x1000
+                }
+            );
+            // Maps a frame.
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        // Queries the mapping.
+        {
+            let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+            assert_eq!(cursor.virt_addr(), range.start);
+            assert_eq!(
+                cursor.query().unwrap(),
+                VmItem::Mapped {
+                    va: range.start,
+                    frame,
+                    prop
+                }
+            );
+        }
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            // Unmaps the frame.
+            cursor_mut.unmap(range.start);
+        }
+
+        // Queries to ensure it's unmapped.
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.query().unwrap(),
+            VmItem::NotMapped {
+                va: range.start,
+                len: range.start + 0x1000
+            }
+        );
+    }
+
+    /// Maps a page twice and unmaps twice using `CursorMut`.
+    #[ktest]
+    fn vmspace_map_twice() {
+        let vmspace = VmSpace::default();
+        let range = 0x1000..0x2000;
+        let frame = create_dummy_frame();
+        let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        {
+            let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+            assert_eq!(
+                cursor.query().unwrap(),
+                VmItem::Mapped {
+                    va: range.start,
+                    frame: frame.clone(),
+                    prop
+                }
+            );
+        }
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        {
+            let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+            assert_eq!(
+                cursor.query().unwrap(),
+                VmItem::Mapped {
+                    va: range.start,
+                    frame,
+                    prop
+                }
+            );
+        }
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.unmap(range.start);
+        }
+
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.query().unwrap(),
+            VmItem::NotMapped {
+                va: range.start,
+                len: range.start + 0x1000
+            }
+        );
+    }
+
+    /// Unmaps twice using `CursorMut`.
+    #[ktest]
+    fn vmspace_unmap_twice() {
+        let vmspace = VmSpace::default();
+        let range = 0x1000..0x2000;
+        let frame = create_dummy_frame();
+        let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.unmap(range.start);
+        }
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.unmap(range.start);
+        }
+
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.query().unwrap(),
+            VmItem::NotMapped {
+                va: range.start,
+                len: range.start + 0x1000
+            }
+        );
+    }
+
+    /// Clears the `VmSpace`.
+    #[ktest]
+    fn vmspace_clear() {
+        let vmspace = VmSpace::new();
+        let range = 0x2000..0x3000;
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            let frame = create_dummy_frame();
+            let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+            cursor_mut.map(frame, prop);
+        }
+
+        // Clears the VmSpace.
+        assert!(vmspace.clear().is_ok());
+
+        // Verifies that the mapping is cleared.
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.next(),
+            Some(VmItem::NotMapped {
+                va: range.start,
+                len: range.start + 0x1000
+            })
+        );
+    }
+
+    /// Verifies that `VmSpace::clear` returns an error when cursors are active.
+    #[ktest]
+    fn vmspace_clear_with_alive_cursors() {
+        let vmspace = VmSpace::new();
+        let range = 0x3000..0x4000;
+        let _cursor_mut = vmspace
+            .cursor_mut(&range)
+            .expect("Failed to create mutable cursor");
+
+        // Attempts to clear the VmSpace while a cursor is active.
+        let result = vmspace.clear();
+        assert!(matches!(result, Err(VmSpaceClearError::CursorsAlive)));
+    }
+
+    /// Activates and deactivates the `VmSpace` in single-CPU scenarios.
+    #[ktest]
+    fn vmspace_activate() {
+        let vmspace = Arc::new(VmSpace::new());
+
+        // Activates the VmSpace.
+        vmspace.activate();
+        assert_eq!(get_activated_vm_space().unwrap(), Arc::as_ptr(&vmspace));
+
+        // Deactivates the VmSpace.
+        let vmspace2 = Arc::new(VmSpace::new());
+        vmspace2.activate();
+        assert_eq!(get_activated_vm_space().unwrap(), Arc::as_ptr(&vmspace2));
+    }
+
+    /// Tests the `flusher` method of `CursorMut`.
+    #[ktest]
+    fn cursor_mut_flusher() {
+        let vmspace = VmSpace::new();
+        let range = 0x4000..0x5000;
+        let frame = create_dummy_frame();
+        let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        {
+            // Verifies that the mapping exists.
+            let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+            assert_eq!(
+                cursor.next(),
+                Some(VmItem::Mapped {
+                    va: 0x4000,
+                    frame: frame.clone(),
+                    prop: PageProperty::new(PageFlags::R, CachePolicy::Writeback),
+                })
+            );
+        }
+
+        {
+            // Flushes the TLB using a mutable cursor.
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            cursor_mut.flusher().issue_tlb_flush(TlbFlushOp::All);
+            cursor_mut.flusher().dispatch_tlb_flush();
+        }
+
+        {
+            // Verifies that the mapping still exists.
+            let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+            assert_eq!(
+                cursor.next(),
+                Some(VmItem::Mapped {
+                    va: 0x4000,
+                    frame,
+                    prop: PageProperty::new(PageFlags::R, CachePolicy::Writeback),
+                })
+            );
+        }
+    }
+
+    /// Verifies the `VmReader` and `VmWriter` interfaces.
+    #[ktest]
+    fn vmspace_reader_writer() {
+        let vmspace = Arc::new(VmSpace::new());
+        let range = 0x4000..0x5000;
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            let frame = create_dummy_frame();
+            let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+            cursor_mut.map(frame, prop);
+        }
+
+        // Mocks the current page table paddr to match the VmSpace's root paddr.
+        // Fails if the VmSpace is not the current task's user space.
+
+        // Attempts to create a reader.
+        let reader_result = vmspace.reader(0x4000, 0x1000);
+        // Expects failure in a test environment.
+        assert!(reader_result.is_err());
+
+        // Attempts to create a writer.
+        let writer_result = vmspace.writer(0x4000, 0x1000);
+        assert!(writer_result.is_err());
+
+        // Activates the VmSpace.
+        vmspace.activate();
+
+        // Attempts to create a reader.
+        let reader_result = vmspace.reader(0x4000, 0x1000);
+        assert!(reader_result.is_ok());
+        // Attempts to create a writer.
+        let writer_result = vmspace.writer(0x4000, 0x1000);
+        assert!(writer_result.is_ok());
+
+        // Attempts to create a reader with an out-of-range address.
+        let reader_result = vmspace.reader(0x4000, usize::MAX);
+        assert!(reader_result.is_err());
+        // Attempts to create a writer with an out-of-range address.
+        let writer_result = vmspace.writer(0x4000, usize::MAX);
+        assert!(writer_result.is_err());
+    }
+
+    /// Creates overlapping cursors and verifies handling.
+    #[ktest]
+    fn overlapping_cursors() {
+        let vmspace = VmSpace::new();
+        let range1 = 0x5000..0x6000;
+        let range2 = 0x5800..0x6800; // Overlaps with range1.
+
+        // Creates the first cursor.
+        let _cursor1 = vmspace
+            .cursor(&range1)
+            .expect("Failed to create first cursor");
+
+        // Attempts to create the second overlapping cursor.
+        let cursor2_result = vmspace.cursor(&range2);
+        assert!(cursor2_result.is_err());
+    }
+
+    /// Iterates over the `Cursor` using the `Iterator` trait.
+    #[ktest]
+    fn cursor_iterator() {
+        let vmspace = VmSpace::new();
+        let range = 0x6000..0x7000;
+        let frame = create_dummy_frame();
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            let prop = PageProperty::new(PageFlags::R, CachePolicy::Writeback);
+            cursor_mut.map(frame.clone(), prop);
+        }
+
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert!(cursor.jump(range.start).is_ok());
+        let item = cursor.next();
+        assert_eq!(
+            item,
+            Some(VmItem::Mapped {
+                va: 0x6000,
+                frame,
+                prop: PageProperty::new(PageFlags::R, CachePolicy::Writeback),
+            })
+        );
+
+        // Confirms no additional items.
+        assert!(cursor.next().is_none());
+    }
+
+    /// Protects a range of pages.
+    #[ktest]
+    fn protect_next() {
+        let vmspace = VmSpace::new();
+        let range = 0x7000..0x8000;
+        let frame = create_dummy_frame();
+        {
+            let mut cursor_mut = vmspace
+                .cursor_mut(&range)
+                .expect("Failed to create mutable cursor");
+            let prop = PageProperty::new(PageFlags::RW, CachePolicy::Writeback);
+            cursor_mut.map(frame.clone(), prop);
+            cursor_mut.jump(range.start).expect("Failed to jump cursor");
+            let protected_range = cursor_mut.protect_next(0x1000, |prop| {
+                prop.flags = PageFlags::R;
+            });
+
+            assert_eq!(protected_range, Some(0x7000..0x8000));
+        }
+        // Confirms that the property was updated.
+        let mut cursor = vmspace.cursor(&range).expect("Failed to create cursor");
+        assert_eq!(
+            cursor.next(),
+            Some(VmItem::Mapped {
+                va: 0x7000,
+                frame,
+                prop: PageProperty::new(PageFlags::R, CachePolicy::Writeback),
+            })
+        );
+    }
+
+    /// Attempts to map unaligned lengths and expects a panic.
+    #[ktest]
+    #[should_panic(expected = "assertion failed: len % super::PAGE_SIZE == 0")]
+    fn unaligned_unmap_panics() {
+        let vmspace = VmSpace::new();
+        let range = 0xA000..0xB000;
+        let mut cursor_mut = vmspace
+            .cursor_mut(&range)
+            .expect("Failed to create mutable cursor");
+        cursor_mut.unmap(0x800); // Not page-aligned.
+    }
+
+    /// Attempts to protect a partial page and expects a panic.
+    #[ktest]
+    #[should_panic]
+    fn protect_out_range_page() {
+        let vmspace = VmSpace::new();
+        let range = 0xB000..0xC000;
+        let mut cursor_mut = vmspace
+            .cursor_mut(&range)
+            .expect("Failed to create mutable cursor");
+        cursor_mut.protect_next(0x2000, |_| {}); // Not page-aligned.
     }
 }


### PR DESCRIPTION
This pull request introduces ktest cases for vmpace, which significantly enhance coverage rate as follows:

| Filename                     | Regions | Missed Regions | Cover   | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover   |
|------------------------------|---------|----------------|---------|-----------|------------------|----------|-------|--------------|---------|
| ostd/src/mm/vm_space.rs | 119     | 17             | 85.71%  | 29        | 1                | 96.55%   | 236   | 12           | 94.92%  |

There are other changes to enable the test cases.

**Enhancement to ktest context:**

* [`osdk/test-kernel/src/lib.rs`](diffhunk://#diff-a583a536b47f1350c477b0a92c1a56b09cf324d95b8765e6e73fa569c3ec3694L52-R62): Modified the `ktest::main` function to include user-space context initialization when spawning tasks.

**Test configuration and utility functions:**

* `ostd/src/mm/vm_space.rs`: 

1. [Added](diffhunk://#diff-8623a039ddbd4bbb55ce46e569ad68ced2a6e141afd0e3d4c46e3ddc70b24b45R463-R473) a new function `get_activated_vm_space` to retrieve the currently activated VM space pointer, conditionally compiled with `#[cfg(ktest)]`.
2. [Implemented](diffhunk://#diff-8623a039ddbd4bbb55ce46e569ad68ced2a6e141afd0e3d4c46e3ddc70b24b45R495-R518) the `PartialEq` trait for the `VmItem` enum to allow for proper equality comparisons of VM items.

**Bug fix:**

* [`ostd/src/mm/page_table/cursor.rs`](diffhunk://#diff-9704569fd22cfc337d748b642212ffeb7db6081948ef0d65c85b3f32a816c902L813-R814): Fixed a bug in the `jump` method to correctly calculate the target address with offset when jumping to a source address.
