### PR TITLE
Add ktest cases for io.rs

### DIFF
--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -19,6 +19,9 @@ pub(crate) mod page_table;
 pub mod tlb;
 pub mod vm_space;
 
+#[cfg(ktest)]
+mod test;
+
 use core::{fmt::Debug, ops::Range};
 
 pub use self::{


### PR DESCRIPTION
This pull request introduces ktest cases for `io.rs` under memory management, which enhance the code coverage as follows:

| Filename                     | Regions | Missed Regions | Cover   | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover   |
|------------------------------|---------|----------------|---------|-----------|------------------|----------|-------|--------------|---------|
| ostd/src/mm/io.rs | 141     | 16             | 88.65%  | 45        | 1                | 97.78%   | 371   | 13           | 96.50%  |

**Note that** this PR also need user-space context, so it should go after #1793.