### PR TITLE
Add ktest cases for page property

### DIFF
--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -19,6 +19,9 @@ pub(crate) mod page_table;
 pub mod tlb;
 pub mod vm_space;
 
+#[cfg(ktest)]
+mod test;
+
 use core::{fmt::Debug, ops::Range};
 
 pub use self::{

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    mm::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
+    prelude::*,
+};
+
+mod page_prop {
+    use super::*;
+
+    /// Verifies all functionality of `PageProperty`.
+    #[ktest]
+    fn page_property() {
+        let flags = PageFlags::RWX;
+        let cache = CachePolicy::Writeback;
+        let priv_flags = PrivilegedPageFlags::USER;
+
+        let prop = PageProperty {
+            flags,
+            cache,
+            priv_flags,
+        };
+
+        assert_eq!(prop.flags, flags);
+        assert_eq!(prop.cache, cache);
+        assert_eq!(prop.priv_flags, priv_flags);
+
+        let new_prop = PageProperty::new(flags, cache);
+        assert_eq!(new_prop.flags, flags);
+        assert_eq!(new_prop.cache, cache);
+        assert_eq!(new_prop.priv_flags, PrivilegedPageFlags::USER);
+
+        let absent_prop = PageProperty::new_absent();
+        assert_eq!(absent_prop.flags, PageFlags::empty());
+        assert_eq!(absent_prop.cache, CachePolicy::Writeback);
+        assert_eq!(absent_prop.priv_flags, PrivilegedPageFlags::empty());
+    }
+
+    /// Verifies our custom PageFlags behavior.
+    #[ktest]
+    fn page_flags() {
+        // Test our specific flag combinations
+        assert!(PageFlags::RWX.contains(PageFlags::R | PageFlags::W | PageFlags::X));
+        assert!((PageFlags::ACCESSED | PageFlags::DIRTY)
+            .contains(PageFlags::ACCESSED | PageFlags::DIRTY));
+        assert!(
+            (PageFlags::AVAIL1 | PageFlags::AVAIL2).contains(PageFlags::AVAIL1 | PageFlags::AVAIL2)
+        );
+    }
+
+    /// Verifies our custom PrivilegedPageFlags behavior.
+    #[ktest]
+    fn privileged_page_flags() {
+        assert!((PrivilegedPageFlags::USER | PrivilegedPageFlags::GLOBAL)
+            .contains(PrivilegedPageFlags::USER | PrivilegedPageFlags::GLOBAL));
+
+        #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+        {
+            assert!(PrivilegedPageFlags::SHARED.contains(PrivilegedPageFlags::SHARED));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test module for the memory management (`mm`) component and includes various tests for `PageProperty`, `CachePolicy`, `PageFlags`, and `PrivilegedPageFlags` in the `ostd` crate. The coverage rates are increased as follows:

| Filename                     | Regions | Missed Regions | Cover   | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover   |
|------------------------------|---------|----------------|---------|-----------|------------------|----------|-------|--------------|---------|
| ostd/src/mm/page_prop.rs | 2       | 0              | 100.00% | 2         | 0                | 100.00%  | 14    | 0            | 100.00% |

