### PR TITLE
Add ktest cases for kernel memory space

### DIFF
--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -45,6 +45,8 @@ use core::ops::Range;
 use align_ext::AlignExt;
 use log::info;
 use spin::Once;
+#[cfg(ktest)]
+mod test;
 
 use super::{
     frame::{

--- a/ostd/src/mm/kspace/test.rs
+++ b/ostd/src/mm/kspace/test.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    mm::{
+        kspace::{
+            kvirt_area::{KVirtArea, Tracked, Untracked},
+            paddr_to_vaddr, should_map_as_tracked, LINEAR_MAPPING_BASE_VADDR,
+            TRACKED_MAPPED_PAGES_RANGE, VMALLOC_VADDR_RANGE,
+        },
+        page_prop::PageProperty,
+        FrameAllocOptions, Paddr, PAGE_SIZE,
+    },
+    prelude::*,
+};
+
+#[ktest]
+fn kvirt_area_tracked_alloc() {
+    let size = 2 * PAGE_SIZE;
+    let kvirt_area = KVirtArea::<Tracked>::new(size);
+
+    assert_eq!(kvirt_area.len(), size);
+    assert!(kvirt_area.start() >= TRACKED_MAPPED_PAGES_RANGE.start);
+    assert!(kvirt_area.end() <= TRACKED_MAPPED_PAGES_RANGE.end);
+}
+
+#[ktest]
+fn kvirt_area_untracked_alloc() {
+    let size = 2 * PAGE_SIZE;
+    let kvirt_area = KVirtArea::<Untracked>::new(size);
+
+    assert_eq!(kvirt_area.len(), size);
+    assert!(kvirt_area.start() >= VMALLOC_VADDR_RANGE.start);
+    assert!(kvirt_area.end() <= VMALLOC_VADDR_RANGE.end);
+}
+
+#[ktest]
+fn kvirt_area_tracked_map_pages() {
+    let size = 2 * PAGE_SIZE;
+    let mut kvirt_area = KVirtArea::<Tracked>::new(size);
+
+    let frames = FrameAllocOptions::default()
+        .alloc_segment_with(2, |_| ())
+        .unwrap();
+
+    let start_paddr = frames.start_paddr();
+    kvirt_area.map_pages(
+        kvirt_area.range(),
+        frames.into_iter(),
+        PageProperty::new_absent(),
+    );
+
+    for i in 0..2 {
+        let addr = kvirt_area.start() + i * PAGE_SIZE;
+        let page = kvirt_area.get_page(addr).unwrap();
+        assert_eq!(page.start_paddr(), start_paddr + (i * PAGE_SIZE));
+    }
+}
+
+#[ktest]
+fn kvirt_area_untracked_map_pages() {
+    let size = 2 * PAGE_SIZE;
+    let mut kvirt_area = KVirtArea::<Untracked>::new(size);
+
+    let va_range = kvirt_area.range();
+    let pa_range = 0..2 * PAGE_SIZE as Paddr;
+
+    unsafe {
+        kvirt_area.map_untracked_pages(va_range, pa_range, PageProperty::new_absent());
+    }
+
+    for i in 0..2 {
+        let addr = kvirt_area.start() + i * PAGE_SIZE;
+        let (pa, len) = kvirt_area.get_untracked_page(addr).unwrap();
+        assert_eq!(pa, (i * PAGE_SIZE) as Paddr);
+        assert_eq!(len, PAGE_SIZE);
+    }
+}
+
+#[ktest]
+fn kvirt_area_tracked_drop() {
+    let size = 2 * PAGE_SIZE;
+    let mut kvirt_area = KVirtArea::<Tracked>::new(size);
+
+    let frames = FrameAllocOptions::default().alloc_segment(2).unwrap();
+
+    kvirt_area.map_pages(
+        kvirt_area.range(),
+        frames.into_iter(),
+        PageProperty::new_absent(),
+    );
+
+    drop(kvirt_area);
+
+    // After dropping, the virtual address range should be freed and no longer mapped.
+    let kvirt_area = KVirtArea::<Tracked>::new(size);
+    assert!(kvirt_area.get_page(kvirt_area.start()).is_none());
+}
+
+#[ktest]
+fn kvirt_area_untracked_drop() {
+    let size = 2 * PAGE_SIZE;
+    let mut kvirt_area = KVirtArea::<Untracked>::new(size);
+
+    let va_range = kvirt_area.range();
+    let pa_range = 0..2 * PAGE_SIZE as Paddr;
+
+    unsafe {
+        kvirt_area.map_untracked_pages(va_range, pa_range, PageProperty::new_absent());
+    }
+
+    drop(kvirt_area);
+
+    // After dropping, the virtual address range should be freed and no longer mapped.
+    let kvirt_area = KVirtArea::<Untracked>::new(size);
+    assert!(kvirt_area.get_untracked_page(kvirt_area.start()).is_none());
+}
+
+#[ktest]
+fn manual_paddr_to_vaddr() {
+    let pa = 0x1000;
+    let va = paddr_to_vaddr(pa);
+
+    assert_eq!(va, LINEAR_MAPPING_BASE_VADDR + pa);
+}
+
+#[ktest]
+fn map_as_tracked() {
+    let tracked_addr = TRACKED_MAPPED_PAGES_RANGE.start;
+    let untracked_addr = VMALLOC_VADDR_RANGE.start;
+
+    assert!(should_map_as_tracked(tracked_addr));
+    assert!(!should_map_as_tracked(untracked_addr));
+}


### PR DESCRIPTION
This pull request introduces a new test module with multiple unit tests for the `KVirtArea` struct, covering both tracked and untracked memory allocations, page mappings, and proper cleanup after dropping. These changes enhance the test coverage for memory management functionalities.


Filename | Regions | Missed Regions | Cover | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
kspace/mod.rs | 25 | 1 | 96.00% | 8 | 0 | 100.00% | 110 | 0 | 100.00%
kspace/test.rs | 30 | 0 | 100.00% | 9 | 0 | 100.00% | 100 | 0 | 100.00%
kspace/kvirt_area.rs | 108 | 28 | 74.07% | 18 | 2 | 88.89% | 213 | 36 | 83.10%
Total | 163 | 29 | 82.21% | 35 | 2 | 94.29% | 423 | 36 | 91.49%

