### PR TITLE
Add ktest cases for heap allocator

### DIFF
--- a/ostd/src/mm/heap_allocator/mod.rs
+++ b/ostd/src/mm/heap_allocator/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod slab_allocator;
+#[cfg(ktest)]
+mod test;
 
 use core::alloc::{GlobalAlloc, Layout};
 

--- a/ostd/src/mm/heap_allocator/test.rs
+++ b/ostd/src/mm/heap_allocator/test.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::alloc::Layout;
+
+use super::{Heap, *};
+use crate::{mm::PAGE_SIZE, prelude::*};
+
+#[ktest]
+fn heap_initialization() {
+    unsafe {
+        init();
+
+        assert!(HEAP_ALLOCATOR.heap.get().is_some());
+    }
+}
+
+#[ktest]
+fn heap_allocator_new() {
+    let locked_heap = LockedHeapWithRescue::new();
+    assert!(locked_heap.heap.get().is_none());
+}
+
+#[ktest]
+fn heap_allocator_alloc() {
+    unsafe {
+        init();
+
+        let layout = Layout::from_size_align(16, 8).unwrap();
+        let ptr = HEAP_ALLOCATOR.alloc(layout);
+
+        assert!(!ptr.is_null());
+        HEAP_ALLOCATOR.dealloc(ptr, layout);
+    }
+}
+
+#[ktest]
+fn heap_allocator_dealloc() {
+    unsafe {
+        init();
+
+        let layout = Layout::from_size_align(16, 8).unwrap();
+        let ptr = HEAP_ALLOCATOR.alloc(layout);
+
+        HEAP_ALLOCATOR.dealloc(ptr, layout);
+
+        let ptr2 = HEAP_ALLOCATOR.alloc(layout);
+        assert!(!ptr2.is_null());
+
+        HEAP_ALLOCATOR.dealloc(ptr2, layout);
+    }
+}
+
+#[ktest]
+fn heap_allocator_large_layout() {
+    unsafe {
+        init();
+
+        let layout = Layout::from_size_align(PAGE_SIZE * 1024, PAGE_SIZE).unwrap();
+        let ptr = HEAP_ALLOCATOR.alloc(layout);
+
+        assert!(!ptr.is_null());
+
+        HEAP_ALLOCATOR.dealloc(ptr, layout);
+    }
+}
+
+#[ktest]
+fn heap_stat() {
+    #[repr(align(4096))]
+    struct MockHeapSpace([u8; PAGE_SIZE * 8]);
+
+    unsafe {
+        let mut buffer = MockHeapSpace([0u8; PAGE_SIZE * 8]);
+        let heap = Heap::new(buffer.0.as_mut_ptr() as usize, PAGE_SIZE * 8);
+
+        let layout: Layout = Layout::from_size_align(16, 8).unwrap();
+        let size = heap.usable_size(layout);
+        assert_eq!(size.0, 16);
+
+        let total_bytes = heap.total_bytes();
+        assert_eq!(total_bytes, PAGE_SIZE * 8);
+
+        let used_bytes = heap.used_bytes();
+        assert_eq!(used_bytes, 0);
+
+        let available_bytes = heap.available_bytes();
+        assert_eq!(available_bytes, PAGE_SIZE * 8);
+    }
+}


### PR DESCRIPTION
This pull request introduces unit tests for the `heap_allocator` module in the memory management subsystem. The changes include adding a new test module and implementing several test functions to ensure the correct behavior of the heap allocator.

### Added unit tests for `heap_allocator` module:

* [`ostd/src/mm/heap_allocator/test.rs`](diffhunk://#diff-16cf29a2abdda606e97daaa173583a103cc4a7a87b20a77e8088845c0f231b2eR1-R89): Implemented several test functions to verify the initialization, allocation, deallocation, and statistics of the heap allocator.

The latest coverage rate:

Filename | Regions | Missed Regions | Cover | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
slab_allocator/slab.rs | 30 | 2 | 93.33% | 14 | 1 | 92.86% | 82 | 4 | 95.12%
slab_allocator/mod.rs | 92 | 29 | 68.48% | 12 | 1 | 91.67% | 148 | 25 | 83.11%
mod.rs | 48 | 12 | 75.00% | 10 | 1 | 90.00% | 89 | 12 | 86.52%
Total | 170 | 43 | 74.71% | 36 | 3 | 91.67% | 319 | 41 | 87.15%
