### PR TITLE
Avoid iterating over all sockets to remove dead sockets

### DIFF
--- a/kernel/libs/aster-bigtcp/src/boolean_value.rs
+++ b/kernel/libs/aster-bigtcp/src/boolean_value.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// Defines a struct representing a boolean value.
+///
+/// In some cases, it is beneficial to use a struct instead of
+/// a plain boolean value to clarify the semantics.
+/// This macro provides a convenient way to define a struct
+/// that represents a boolean value.
+#[macro_export]
+macro_rules! define_boolean_value {
+    (
+        $(#[$attr:meta])*
+        $name: ident
+    ) => {
+        $(#[$attr])*
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name(bool);
+
+        impl $name {
+            pub const TRUE: Self = Self(true);
+            pub const FALSE: Self = Self(false);
+        }
+
+        impl core::ops::Deref for $name {
+            type Target = bool;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}

--- a/kernel/libs/aster-bigtcp/src/lib.rs
+++ b/kernel/libs/aster-bigtcp/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(unsafe_code)]
 #![feature(extract_if)]
 
+pub mod boolean_value;
 pub mod device;
 pub mod errors;
 pub mod ext;


### PR DESCRIPTION
To enhance scalability, we need to avoid iterating over all sockets. This PR addresses the initial step by eliminating the iteration for moving dead sockets.

Additionally, some minor cleanup has been included.