### PR TITLE
Unify and optimize the comparison of special file names

### DIFF
--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -7,3 +7,30 @@ pub use mount::MountNode;
 
 mod dentry;
 mod mount;
+
+/// Checks if the file name is ".", indicating it's the current directory.
+pub const fn is_dot(filename: &str) -> bool {
+    let name_bytes = filename.as_bytes();
+    name_bytes.len() == 1 && name_bytes[0] == DOT_BYTE
+}
+
+/// Checks if the file name is "..", indicating it's the parent directory.
+pub const fn is_dotdot(filename: &str) -> bool {
+    let name_bytes = filename.as_bytes();
+    name_bytes.len() == 2 && name_bytes[0] == DOT_BYTE && name_bytes[1] == DOT_BYTE
+}
+
+/// Checks if the file name is "." or "..", indicating it's the current or parent directory.
+pub const fn is_dot_or_dotdot(filename: &str) -> bool {
+    let name_bytes = filename.as_bytes();
+    let name_len = name_bytes.len();
+    if name_len == 1 {
+        name_bytes[0] == DOT_BYTE
+    } else if name_len == 2 {
+        name_bytes[0] == DOT_BYTE && name_bytes[1] == DOT_BYTE
+    } else {
+        false
+    }
+}
+
+const DOT_BYTE: u8 = b'.';

--- a/kernel/src/fs/procfs/template/dir.rs
+++ b/kernel/src/fs/procfs/template/dir.rs
@@ -9,7 +9,10 @@ use inherit_methods_macro::inherit_methods;
 
 use super::{Common, ProcFS};
 use crate::{
-    fs::utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata, MknodType},
+    fs::{
+        path::{is_dot, is_dotdot},
+        utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata, MknodType},
+    },
     prelude::*,
     process::{Gid, Uid},
 };
@@ -152,21 +155,21 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
     }
 
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
-        let inode = match name {
-            "." => self.this(),
-            ".." => self.parent().unwrap_or(self.this()),
-            name => {
-                let mut cached_children = self.cached_children.write();
-                if let Some((_, inode)) = cached_children
-                    .iter()
-                    .find(|(child_name, inode)| child_name.as_str() == name)
-                {
-                    return Ok(inode.clone());
-                }
-                let inode = self.inner.lookup_child(self.this.clone(), name)?;
-                cached_children.put((String::from(name), inode.clone()));
-                inode
+        let inode = if is_dot(name) {
+            self.this()
+        } else if is_dotdot(name) {
+            self.parent().unwrap_or(self.this())
+        } else {
+            let mut cached_children = self.cached_children.write();
+            if let Some((_, inode)) = cached_children
+                .iter()
+                .find(|(child_name, inode)| child_name.as_str() == name)
+            {
+                return Ok(inode.clone());
             }
+            let inode = self.inner.lookup_child(self.this.clone(), name)?;
+            cached_children.put((String::from(name), inode.clone()));
+            inode
         };
         Ok(inode)
     }

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -12,7 +12,7 @@ use super::{
     ramfs::RamFS,
     utils::{FileSystem, InodeMode, InodeType},
 };
-use crate::prelude::*;
+use crate::{fs::path::is_dot, prelude::*};
 
 /// Unpack and prepare the rootfs from the initramfs CPIO buffer.
 pub fn init(initramfs_buf: &[u8]) -> Result<()> {
@@ -38,7 +38,7 @@ pub fn init(initramfs_buf: &[u8]) -> Result<()> {
         if entry_name.is_empty() {
             return_errno_with_message!(Errno::EINVAL, "invalid entry name");
         }
-        if entry_name == "." {
+        if is_dot(entry_name) {
             continue;
         }
 


### PR DESCRIPTION
This PR unifies and speeds up the comparison for special file names, which are the current directory name "." and the parent directory name "..".
This is a common technique learned from Linux filesystems' source codes. The new method can be up to 4 times faster according to a simple microbench case.