### PR TITLE
Fix the unit of meminfo

### DIFF
--- a/kernel/src/fs/procfs/meminfo.rs
+++ b/kernel/src/fs/procfs/meminfo.rs
@@ -40,9 +40,13 @@ fn mem_available() -> usize {
 
 impl FileOps for MemInfoFileOps {
     fn data(&self) -> Result<Vec<u8>> {
-        let total = mem_total();
-        let available = mem_available();
-        let output = format!("MemTotal:\t{}\nMemAvailable:\t{}\n", total, available);
+        let total = mem_total() / 1024;
+        let available = mem_available() / 1024;
+        let free = total - available;
+        let output = format!(
+            "MemTotal:\t{} kB\nMemFree:\t{} kB\nMemAvailable:\t{} kB\n",
+            total, free, available
+        );
         Ok(output.into_bytes())
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `kernel/src/fs/procfs/meminfo.rs` file to improve the memory information output format and add additional memory statistics to align with Linux. Now `/proc/meminfo` reports memory sizes in kilobytes.

Before:
```
~ # cat /proc/meminfo
MemTotal:	8536784896
MemAvailable:	8184336384
```

After:
```
~ # cat /proc/meminfo
MemTotal:	7984932 kB
MemFree:	1336080 kB
MemAvailable:	6648852 kB
```