### PR TITLE
Add ip level socket option

### DIFF
--- a/kernel/src/net/socket/ip/mod.rs
+++ b/kernel/src/net/socket/ip/mod.rs
@@ -3,6 +3,7 @@
 mod addr;
 mod common;
 pub mod datagram;
+pub mod options;
 pub mod stream;
 
 use addr::UNSPECIFIED_LOCAL_ENDPOINT;

--- a/kernel/src/net/socket/ip/options.rs
+++ b/kernel/src/net/socket/ip/options.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZeroU8;
+
+use aster_bigtcp::socket::NeedIfacePoll;
+
+use crate::{
+    impl_socket_options, match_sock_option_mut, match_sock_option_ref,
+    net::socket::options::SocketOption, prelude::*,
+};
+
+/// IP-level socket options.
+#[derive(Debug, Clone, Copy, CopyGetters, Setters)]
+#[get_copy = "pub"]
+#[set = "pub"]
+pub(super) struct IpOptionSet {
+    tos: u8,
+    ttl: IpTtl,
+    hdrincl: bool,
+}
+
+const DEFAULT_TTL: u8 = 64;
+pub(super) const INET_ECN_MASK: u8 = 3;
+
+impl IpOptionSet {
+    pub(super) const fn new_tcp() -> Self {
+        Self {
+            tos: 0,
+            ttl: IpTtl(None),
+            hdrincl: false,
+        }
+    }
+
+    pub(super) fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+        match_sock_option_mut!(option, {
+            ip_tos: Tos => {
+                let tos = self.tos();
+                ip_tos.set(tos as _);
+            },
+            ip_ttl: Ttl => {
+                let ttl = self.ttl();
+                ip_ttl.set(ttl);
+            },
+            ip_hdrincl: Hdrincl => {
+                let hdrincl = self.hdrincl();
+                ip_hdrincl.set(hdrincl);
+            },
+            _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option is unknown")
+        });
+
+        Ok(())
+    }
+
+    pub(super) fn set_option(
+        &mut self,
+        option: &dyn SocketOption,
+        socket: &mut dyn SetIpLevelOption,
+    ) -> Result<NeedIfacePoll> {
+        match_sock_option_ref!(option, {
+            ip_tos: Tos => {
+                let old_value = self.tos();
+                let mut val = *ip_tos.get().unwrap() as u8;
+                val &= !INET_ECN_MASK;
+                val |= old_value & INET_ECN_MASK;
+                self.set_tos(val);
+            },
+            ip_ttl: Ttl => {
+                let ttl = ip_ttl.get().unwrap();
+                self.set_ttl(*ttl);
+            },
+            ip_hdrincl: Hdrincl => {
+                let hdrincl = ip_hdrincl.get().unwrap();
+                socket.set_hdrincl(*hdrincl)?;
+                self.set_hdrincl(*hdrincl);
+            },
+            _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option to be set is unknown")
+        });
+
+        Ok(NeedIfacePoll::FALSE)
+    }
+}
+
+impl_socket_options!(
+    pub struct Tos(i32);
+    pub struct Ttl(IpTtl);
+    pub struct Hdrincl(bool);
+);
+
+#[derive(Debug, Clone, Copy)]
+pub struct IpTtl(Option<NonZeroU8>);
+
+impl IpTtl {
+    pub const fn new(val: Option<NonZeroU8>) -> Self {
+        Self(val)
+    }
+
+    pub const fn get(&self) -> u8 {
+        if let Some(val) = self.0 {
+            val.get()
+        } else {
+            DEFAULT_TTL
+        }
+    }
+}
+
+pub trait SetIpLevelOption {
+    fn set_hdrincl(&self, _hdrincl: bool) -> Result<()>;
+}

--- a/kernel/src/util/net/options/ip.rs
+++ b/kernel/src/util/net/options/ip.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use int_to_c_enum::TryFromInt;
+
+use super::RawSocketOption;
+use crate::{
+    impl_raw_socket_option,
+    net::socket::ip::options::{Hdrincl, Tos, Ttl},
+    prelude::*,
+    util::net::options::SocketOption,
+};
+
+/// Socket options for IP socket.
+///
+/// The raw definitions can be found at:
+/// https://elixir.bootlin.com/linux/v6.0.19/source/include/uapi/linux/in.h#L94
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+#[expect(non_camel_case_types)]
+#[expect(clippy::upper_case_acronyms)]
+pub enum CIpOptionName {
+    TOS = 1,
+    TTL = 2,
+    HDRINCL = 3,
+    OPTIONS = 4,
+    ROUTER_ALERT = 5,
+    RECVOPTS = 6,
+    RETOPTS = 7,
+    PKTINFO = 8,
+    PKTOPTIONS = 9,
+    MTU_DISCOVER = 10,
+    RECVERR = 11,
+    RECVTTL = 12,
+    RECVTOS = 13,
+    MTU = 14,
+    FREEBIND = 15,
+    IPSEC_POLICY = 16,
+    XFRM_POLICY = 17,
+    PASSSEC = 18,
+    TRANSPARENT = 19,
+    ORIGDSTADDR = 20,
+    MINTTL = 21,
+    NODEFRAG = 22,
+    CHECKSUM = 23,
+    BIND_ADDRESS_NO_PORT = 24,
+    RECVFRAGSIZE = 25,
+    RECVERR_RFC4884 = 26,
+    MULTICAST_IF = 32,
+    MULTICAST_TTL = 33,
+    MULTICAST_LOOP = 34,
+    ADD_MEMBERSHIP = 35,
+    DROP_MEMBERSHIP = 36,
+    UNBLOCK_SOURCE = 37,
+    BLOCK_SOURCE = 38,
+    ADD_SOURCE_MEMBERSHIP = 39,
+    DROP_SOURCE_MEMBERSHIP = 40,
+    MSFILTER = 41,
+    MCAST_JOIN_GROUP = 42,
+    MCAST_BLOCK_SOURCE = 43,
+    MCAST_UNBLOCK_SOURCE = 44,
+    MCAST_LEAVE_GROUP = 45,
+    MCAST_JOIN_SOURCE_GROUP = 46,
+    MCAST_LEAVE_SOURCE_GROUP = 47,
+    MCAST_MSFILTER = 48,
+    MULTICAST_ALL = 49,
+    UNICAST_IF = 50,
+}
+
+pub fn new_ip_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
+    let name = CIpOptionName::try_from(name).map_err(|_| Errno::ENOPROTOOPT)?;
+    match name {
+        CIpOptionName::TOS => Ok(Box::new(Tos::new())),
+        CIpOptionName::TTL => Ok(Box::new(Ttl::new())),
+        CIpOptionName::HDRINCL => Ok(Box::new(Hdrincl::new())),
+        _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported ip level option"),
+    }
+}
+
+impl_raw_socket_option!(Ttl);
+impl_raw_socket_option!(Tos);
+impl_raw_socket_option!(Hdrincl);

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -51,8 +51,11 @@
 //! At the syscall level, the interface is unified for all options and does not need to be modified.
 //!
 
+use ip::new_ip_option;
+
 use crate::{net::socket::options::SocketOption, prelude::*};
 
+mod ip;
 mod socket;
 mod tcp;
 mod utils;
@@ -133,6 +136,7 @@ pub fn new_raw_socket_option(
 ) -> Result<Box<dyn RawSocketOption>> {
     match level {
         CSocketOptionLevel::SOL_SOCKET => new_socket_option(name),
+        CSocketOptionLevel::SOL_IP => new_ip_option(name),
         CSocketOptionLevel::SOL_TCP => new_tcp_option(name),
         _ => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported option level"),
     }


### PR DESCRIPTION
This PR introduces IP level options, as requested in issues #1681 and #1683.

Given that IP level options encompass a broad range, and neither issue specifies which exact options are missing, this PR includes only three specific IP options.