### PR TITLE
Pooling some cached block writes in ext2

### DIFF
--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use id_alloc::IdAlloc;
+use ostd::mm::UntypedMem;
 
 use super::{
     block_ptr::Ext2Bid,
@@ -320,6 +321,8 @@ impl Debug for BlockGroup {
 impl PageCacheBackend for BlockGroupImpl {
     fn read_page_async(&self, idx: usize, frame: &CachePage) -> Result<BioWaiter> {
         let bid = self.inode_table_bid + idx as Ext2Bid;
+        // TODO: Should we allocate the bio segment from the pool on reads?
+        // This may require an additional copy to the requested frame in the completion callback.
         let bio_segment = BioSegment::new_from_segment(
             Segment::from(frame.clone()).into(),
             BioDirection::FromDevice,
@@ -332,10 +335,12 @@ impl PageCacheBackend for BlockGroupImpl {
 
     fn write_page_async(&self, idx: usize, frame: &CachePage) -> Result<BioWaiter> {
         let bid = self.inode_table_bid + idx as Ext2Bid;
-        let bio_segment = BioSegment::new_from_segment(
-            Segment::from(frame.clone()).into(),
-            BioDirection::ToDevice,
-        );
+        let bio_segment = BioSegment::alloc(1, BioDirection::ToDevice);
+        // This requires an additional copy to the pooled bio segment.
+        bio_segment
+            .writer()
+            .unwrap()
+            .write_fallible(&mut frame.reader().to_fallible())?;
         self.fs
             .upgrade()
             .unwrap()

--- a/kernel/src/fs/ext2/indirect_block_cache.rs
+++ b/kernel/src/fs/ext2/indirect_block_cache.rs
@@ -19,6 +19,7 @@ pub struct IndirectBlockCache {
     fs: Weak<Ext2>,
 }
 
+// TODO: Should we allocate the bio segments from the pool for the I/O on indirect blocks?
 impl IndirectBlockCache {
     /// The upper bound on the size of the cache.
     ///

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -7,6 +7,7 @@ use alloc::{borrow::ToOwned, rc::Rc};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use inherit_methods_macro::inherit_methods;
+use ostd::mm::UntypedMem;
 
 use super::{
     block_ptr::{BidPath, BlockPtrs, Ext2Bid, BID_SIZE, MAX_BLOCK_PTRS},
@@ -1812,6 +1813,8 @@ impl InodeBlockManager {
 
         for dev_range in DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)? {
             let start_bid = dev_range.start as Ext2Bid;
+            // TODO: Should we allocate the bio segment from the pool on reads?
+            // This may require an additional copy to the requested frame in the completion callback.
             let bio_segment = BioSegment::new_from_segment(
                 Segment::from(frame.clone()).into(),
                 BioDirection::FromDevice,
@@ -1859,10 +1862,12 @@ impl InodeBlockManager {
 
         for dev_range in DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)? {
             let start_bid = dev_range.start as Ext2Bid;
-            let bio_segment = BioSegment::new_from_segment(
-                Segment::from(frame.clone()).into(),
-                BioDirection::ToDevice,
-            );
+            let bio_segment = BioSegment::alloc(1, BioDirection::ToDevice);
+            // This requires an additional copy to the pooled bio segment.
+            bio_segment
+                .writer()
+                .unwrap()
+                .write_fallible(&mut frame.reader().to_fallible())?;
             let waiter = self.fs().write_blocks_async(start_bid, bio_segment)?;
             bio_waiter.concat(waiter);
         }


### PR DESCRIPTION
This PR poolings some cached (with page cache enabled) block writes (not all of them). This measure will bring benefits when the cost behind `BioSegment::new_from_segment()` becomes heavy, which points to the `DmaStream::map/unmap` after we correct the IOTLB behaviors.

Pooling the cached block reads requires more work and is marked as `TODO` here. This is because the block reads are mostly asynchronous and we need to perform the final copy from the pool to the requested buffer in the completion callback.