### PR TITLE
Make VirtioConsolesPrinter heapless

### DIFF
--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -13,7 +13,7 @@ use core::any::Any;
 use component::{init_component, ComponentInitError};
 use ostd::{
     mm::{Infallible, VmReader},
-    sync::SpinLock,
+    sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
 };
 use spin::Once;
 
@@ -50,6 +50,16 @@ pub fn all_devices() -> Vec<(String, Arc<dyn AnyConsoleDevice>)> {
         .iter()
         .map(|(name, device)| (name.clone(), device.clone()))
         .collect()
+}
+
+pub fn all_devices_lock<'a>(
+) -> SpinLockGuard<'a, BTreeMap<String, Arc<dyn AnyConsoleDevice>>, LocalIrqDisabled> {
+    COMPONENT
+        .get()
+        .unwrap()
+        .console_device_table
+        .disable_irq()
+        .lock()
 }
 
 static COMPONENT: Once<Component> = Once::new();


### PR DESCRIPTION
Recently, I encountered a deadlock issue: When `LOG_LEVEL` is set to debug, the system gets stuck during `unpacking the initramfs.cpio.gz to rootfs`. After further investigation, I found that the deadlock is triggered within the `rescue_if_low_memory` function in the heap allocator. This function outputs debug information and is required to do heap allocation. However, at this point, the remaining bytes are still less than `PAGE_SIZE * 4`, triggering the `debug!()` again, causing a deadlock in the `RECORD_LOCK` of `aster_logger`.

This PR addresses the issue by introducing `IS_RESCUING`. This flag is set to true when performing rescue, preventing the deadlock. The remaining `PAGE_SIZE * 4` space is sufficient to handle the memory required for debug output.