### PR TITLE
Add the doc of `cargo osdk profile` to the book

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -34,6 +34,7 @@
         * [cargo osdk run](osdk/reference/commands/run.md)
         * [cargo osdk test](osdk/reference/commands/test.md)
         * [cargo osdk debug](osdk/reference/commands/debug.md)
+        * [cargo osdk profile](osdk/reference/commands/profile.md)
     * [Manifest](osdk/reference/manifest.md)
 
 # How to Contribute


### PR DESCRIPTION
Sorry that @tatetian find out the section "`cargo osdk profile`" does not appear in the book. Here's a fix and I tested with `mdbook serve` and it looks OK now.