### PR TITLE
Fix several issues in IOMMU fault reporting

### DIFF
--- a/ostd/src/arch/x86/iommu/registers/capability.rs
+++ b/ostd/src/arch/x86/iommu/registers/capability.rs
@@ -71,7 +71,7 @@ impl Capability {
     /// If the register base address is X, and the value reported in this field
     /// is Y, the address for the first fault recording register is calculated as X+(16*Y).
     pub const fn fault_recording_register_offset(&self) -> u64 {
-        const FRO_MASK: u64 = 0x3FFF << 24;
+        const FRO_MASK: u64 = 0x3FF << 24;
         (self.0 & FRO_MASK) >> 24
     }
     /// Second Stage Large Page Support.

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(ptr_sub_ptr)]
 #![feature(sync_unsafe_cell)]
 #![feature(trait_upcasting)]
+#![feature(iter_advance_by)]
 // The `generic_const_exprs` feature is incomplete however required for the page table
 // const generic implementation. We are using this feature in a conservative manner.
 #![expect(incomplete_features)]


### PR DESCRIPTION
This PR fixes several issues in IOMMU fault reporting, including:
1. Activate the fault handler before enabling page fault interrupt, preventing the miss of the first fault event.
2. Correct the mask of the fault recording register offset in IOMMU.
3. Support handling multiple IOMMU faults, and improve the handling when multiple faults occur.
4. Clear the fault field in fault recording registers.