### PR TITLE
Trivial cleanups about type requirements for task `func`

### DIFF
--- a/kernel/src/thread/kernel_thread.rs
+++ b/kernel/src/thread/kernel_thread.rs
@@ -13,7 +13,7 @@ struct KernelThread;
 
 /// Options to create or spawn a new kernel thread.
 pub struct ThreadOptions {
-    func: Option<Box<dyn Fn() + Send + Sync>>,
+    func: Option<Box<dyn FnOnce() + Send>>,
     priority: Priority,
     cpu_affinity: CpuSet,
 }
@@ -22,7 +22,7 @@ impl ThreadOptions {
     /// Creates the thread options with the thread function.
     pub fn new<F>(func: F) -> Self
     where
-        F: Fn() + Send + Sync + 'static,
+        F: FnOnce() + Send + 'static,
     {
         let cpu_affinity = CpuSet::new_full();
         Self {

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -149,7 +149,7 @@ impl TaskOptions {
     /// Creates a set of options for a task.
     pub fn new<F>(func: F) -> Self
     where
-        F: FnOnce() + Send + Sync + 'static,
+        F: FnOnce() + Send + 'static,
     {
         Self {
             func: Some(Box::new(func)),


### PR DESCRIPTION
This PR unifies the type of task `func` to be `FnOnce() + Send + 'static`. We used to:
 - require `Fn()`, which is not necessary because it cannot be run twice;
 - require `Sync`, which is not necessary because it cannot be run in two threads.

This will help us resolve a FIXME in `kernel/src/fs/pipe.rs`.