### PR TITLE
Implementing `FileLike` for all `Socket`s

### DIFF
--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -32,8 +32,8 @@ impl BoundDatagram {
         self.bound_socket.local_endpoint().unwrap()
     }
 
-    pub fn remote_endpoint(&self) -> Option<IpEndpoint> {
-        self.remote_endpoint
+    pub fn remote_endpoint(&self) -> Option<&IpEndpoint> {
+        self.remote_endpoint.as_ref()
     }
 
     pub fn set_remote_endpoint(&mut self, endpoint: &IpEndpoint) {

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -19,53 +19,54 @@ pub mod vsock;
 
 /// Operations defined on a socket.
 pub trait Socket: FileLike + Send + Sync {
-    /// Assign the address specified by socket_addr to the socket
+    /// Assigns the specified address to the socket.
     fn bind(&self, _socket_addr: SocketAddr) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "bind() is not supported");
     }
 
-    /// Build connection for a given address
+    /// Builds a connection for the given address
     fn connect(&self, _socket_addr: SocketAddr) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "connect() is not supported");
     }
 
-    /// Listen for connections on a socket
+    /// Listens for connections on the socket.
     fn listen(&self, _backlog: usize) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "listen() is not supported");
     }
 
-    /// Accept a connection on a socket
+    /// Accepts a connection on the socket.
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "accept() is not supported");
     }
 
-    /// Shut down part of a full-duplex connection
+    /// Shuts down part of a full-duplex connection.
     fn shutdown(&self, _cmd: SockShutdownCmd) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "shutdown() is not supported");
     }
 
-    /// Get address of this socket.
+    /// Gets the address of this socket.
     fn addr(&self) -> Result<SocketAddr> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "getsockname() is not supported");
     }
 
-    /// Get address of peer socket
+    /// Gets the address of the peer socket.
     fn peer_addr(&self) -> Result<SocketAddr> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "getpeername() is not supported");
     }
 
-    /// Get options on the socket. The resulted option will put in the `option` parameter, if
-    /// this method returns success.
+    /// Gets options on the socket.
+    ///
+    /// If the method succeeds, the result will be stored in the `option` parameter.
     fn get_option(&self, _option: &mut dyn SocketOption) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "getsockopt() is not supported");
     }
 
-    /// Set options on the socket.
+    /// Sets options on the socket.
     fn set_option(&self, _option: &dyn SocketOption) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "setsockopt() is not supported");
     }
 
-    /// Sends a message on a socket.
+    /// Sends a message on the socket.
     fn sendmsg(
         &self,
         reader: &mut dyn MultiRead,
@@ -73,7 +74,7 @@ pub trait Socket: FileLike + Send + Sync {
         flags: SendRecvFlags,
     ) -> Result<usize>;
 
-    /// Receives a message from a socket.
+    /// Receives a message from the socket.
     ///
     /// If successful, the `io_vecs` buffer will be filled with the received content.
     /// This method returns the length of the received message,

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -6,7 +6,10 @@ pub use self::util::{
     socket_addr::SocketAddr, MessageHeader,
 };
 use crate::{
-    fs::file_handle::FileLike,
+    fs::{
+        file_handle::FileLike,
+        utils::{InodeMode, Metadata, StatusFlags},
+    },
     prelude::*,
     util::{MultiRead, MultiWrite},
 };
@@ -17,8 +20,43 @@ pub mod unix;
 mod util;
 pub mod vsock;
 
+mod private {
+    use crate::{events::IoEvents, prelude::*, process::signal::Pollable};
+
+    /// Common methods for sockets, but private to the network module.
+    ///
+    /// These are implementation details of sockets, so shouldn't be accessed outside the network
+    /// module. Therefore, the whole trait is sealed.
+    pub trait SocketPrivate: Pollable {
+        /// Returns whether the socket is in non-blocking mode.
+        fn is_nonblocking(&self) -> bool;
+
+        /// Sets whether the socket is in non-blocking mode.
+        fn set_nonblocking(&self, nonblocking: bool);
+
+        /// Blocks until some events occur to complete I/O operations.
+        ///
+        /// If the socket is in non-blocking mode and the I/O operations cannot be completed
+        /// immediately, this method will fail with [`EAGAIN`] instead of blocking.
+        ///
+        /// [`EAGAIN`]: crate::error::Errno::EAGAIN
+        #[track_caller]
+        fn block_on<F, R>(&self, events: IoEvents, mut try_op: F) -> Result<R>
+        where
+            Self: Sized,
+            F: FnMut() -> Result<R>,
+        {
+            if self.is_nonblocking() {
+                try_op()
+            } else {
+                self.wait_events(events, None, try_op)
+            }
+        }
+    }
+}
+
 /// Operations defined on a socket.
-pub trait Socket: FileLike + Send + Sync {
+pub trait Socket: private::SocketPrivate + Send + Sync {
     /// Assigns the specified address to the socket.
     fn bind(&self, _socket_addr: SocketAddr) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "bind() is not supported");
@@ -84,4 +122,57 @@ pub trait Socket: FileLike + Send + Sync {
         writers: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, MessageHeader)>;
+}
+
+impl<T: Socket + 'static> FileLike for T {
+    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+        // TODO: Set correct flags
+        self.recvmsg(writer, SendRecvFlags::empty())
+            .map(|(len, _)| len)
+    }
+
+    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+        // TODO: Set correct flags
+        self.sendmsg(
+            reader,
+            MessageHeader {
+                addr: None,
+                control_message: None,
+            },
+            SendRecvFlags::empty(),
+        )
+    }
+
+    fn status_flags(&self) -> StatusFlags {
+        // TODO: Support other flags (e.g., `O_ASYNC`)
+        if self.is_nonblocking() {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        }
+    }
+
+    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
+        // TODO: Support other flags (e.g., `O_ASYNC`)
+        if new_flags.contains(StatusFlags::O_NONBLOCK) {
+            self.set_nonblocking(true);
+        } else {
+            self.set_nonblocking(false);
+        }
+        Ok(())
+    }
+
+    fn as_socket(&self) -> Option<&dyn Socket> {
+        Some(self)
+    }
+
+    fn metadata(&self) -> Metadata {
+        // This is a dummy implementation.
+        // TODO: Add "SockFS" and link `Socket` to it.
+        Metadata::new_socket(
+            0,
+            InodeMode::from_bits_truncate(0o140777),
+            aster_block::BLOCK_SIZE,
+        )
+    }
 }

--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -5,11 +5,9 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use super::{connected::Connected, connecting::Connecting, init::Init, listen::Listen};
 use crate::{
     events::IoEvents,
-    fs::{
-        file_handle::FileLike,
-        utils::{InodeMode, Metadata, StatusFlags},
-    },
+    fs::file_handle::FileLike,
     net::socket::{
+        private::SocketPrivate,
         vsock::{addr::VsockSocketAddr, VSOCK_GLOBAL},
         MessageHeader, SendRecvFlags, SockShutdownCmd, Socket, SocketAddr,
     },
@@ -43,14 +41,6 @@ impl VsockStreamSocket {
             status: RwLock::new(Status::Connected(connected)),
             is_nonblocking: AtomicBool::new(false),
         }
-    }
-
-    fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
     }
 
     fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
@@ -114,18 +104,6 @@ impl VsockStreamSocket {
         }
         Ok((read_size, peer_addr))
     }
-
-    fn recv(
-        &self,
-        writer: &mut dyn MultiWrite,
-        flags: SendRecvFlags,
-    ) -> Result<(usize, SocketAddr)> {
-        if self.is_nonblocking() {
-            self.try_recv(writer, flags)
-        } else {
-            self.wait_events(IoEvents::IN, None, || self.try_recv(writer, flags))
-        }
-    }
 }
 
 impl Pollable for VsockStreamSocket {
@@ -138,49 +116,13 @@ impl Pollable for VsockStreamSocket {
     }
 }
 
-impl FileLike for VsockStreamSocket {
-    fn as_socket(&self) -> Option<&dyn Socket> {
-        Some(self)
+impl SocketPrivate for VsockStreamSocket {
+    fn is_nonblocking(&self) -> bool {
+        self.is_nonblocking.load(Ordering::Relaxed)
     }
 
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        // TODO: Set correct flags
-        let read_len = self
-            .recv(writer, SendRecvFlags::empty())
-            .map(|(len, _)| len)?;
-        Ok(read_len)
-    }
-
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
-        // TODO: Set correct flags
-        self.send(reader, SendRecvFlags::empty())
-    }
-
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_nonblocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        if new_flags.contains(StatusFlags::O_NONBLOCK) {
-            self.set_nonblocking(true);
-        } else {
-            self.set_nonblocking(false);
-        }
-        Ok(())
-    }
-
-    fn metadata(&self) -> Metadata {
-        // This is a dummy implementation.
-        // TODO: Add "SockFS" and link `VsockStreamSocket` to it.
-        Metadata::new_socket(
-            0,
-            InodeMode::from_bits_truncate(0o140777),
-            aster_block::BLOCK_SIZE,
-        )
+    fn set_nonblocking(&self, nonblocking: bool) {
+        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
     }
 }
 
@@ -280,11 +222,7 @@ impl Socket for VsockStreamSocket {
     }
 
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        if self.is_nonblocking() {
-            self.try_accept()
-        } else {
-            self.wait_events(IoEvents::IN, None, || self.try_accept())
-        }
+        self.block_on(IoEvents::IN, || self.try_accept())
     }
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
@@ -329,7 +267,7 @@ impl Socket for VsockStreamSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let (received_bytes, _) = self.recv(writer, flags)?;
+        let (received_bytes, _) = self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
 
         // TODO: Receive control message
 


### PR DESCRIPTION
We've repeated to implement `FileLike` for each `Socket` type:
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/vsock/stream/socket.rs#L141
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/ip/datagram/mod.rs#L222
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/ip/stream/mod.rs#L425
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/unix/stream/socket.rs#L166

However, the implementations are exactly the same. Having duplicate code is really bad practice, so let's add a blanket implementation for them:
```rust
impl<T: Socket + 'static> FileLike for T {
    // ...
}
```

Meanwhile, I notice that our implementation of UDP `send` locks the socket twice if the remote endpoint is not supplied: the first lock for querying the remote endpoint, and the second lock for sending the message. It is an inefficient implementation. The last commit fixes this problem.
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/ip/datagram/mod.rs#L349
https://github.com/asterinas/asterinas/blob/c4229e3c2f10108ba964de8be8087cc103ede216/kernel/src/net/socket/ip/datagram/mod.rs#L363