### PR TITLE
Support Python on Asterinas

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -33,6 +33,7 @@ INITRAMFS_ALL_DIRS := \
 	$(INITRAMFS)/sbin \
 	$(INITRAMFS)/usr/bin \
 	$(INITRAMFS)/usr/local \
+	$(INITRAMFS)/usr/lib \
 	$(INITRAMFS)/test \
 	$(INITRAMFS)/benchmark \
 	$(INITRAMFS_EMPTY_DIRS)
@@ -48,6 +49,7 @@ $(INITRAMFS)/lib/x86_64-linux-gnu: | $(VDSO_LIB)
 	@cp -L /lib/x86_64-linux-gnu/libm.so.6 $@
 	@cp -L /lib/x86_64-linux-gnu/libgcc_s.so.1 $@
 	@cp -L /lib/x86_64-linux-gnu/libpthread.so.0 $@
+	@cp -L /lib/x86_64-linux-gnu/libexpat.so.1 $@
 	@# required for benchmarks
 	@cp -L /lib/x86_64-linux-gnu/libcrypto.so.3 $@
 	@cp -L /lib/x86_64-linux-gnu/libcrypt.so.1 $@
@@ -94,6 +96,9 @@ $(INITRAMFS)/etc:
 $(INITRAMFS)/bin:
 	@mkdir -p $@
 	@/bin/busybox --install -s $@
+	@cp /bin/python $@
+	@cp /bin/python3 $@
+	@cp /bin/python3.10 $@
 
 $(INITRAMFS)/sbin:
 	@mkdir -p $@
@@ -109,6 +114,10 @@ $(INITRAMFS)/usr/local:
 	@cp -r /usr/local/nginx $@
 	@cp -r /usr/local/redis $@
 	@cp -r /usr/local/memcached $@
+
+$(INITRAMFS)/usr/lib:
+	@mkdir -p $@
+	@cp -r /usr/lib/python3.10 $@
 
 .PHONY: $(INITRAMFS)/test
 $(INITRAMFS)/test:


### PR DESCRIPTION
Hello. This PR supports Python on Asterinas. 


![image](https://github.com/user-attachments/assets/68b89ca1-8924-48b2-9e07-799b25d0ce3a)


After moving Python related files into Asterinas initramfs, the compressed image `initramfs.cpio.gz` size goes to 45Mb from 34Mb. 

Some interesting things I did on Asterinas with Python:
- Run AI models, including large language models:

![_cgi-bin_mmwebwx-bin_webwxgetmsgimg__ MsgID=4554705081775239534 skey=@crypt_c1f457cc_76e07c38ae3aa64954a8652fb907387e mmweb_appid=wx_webfilehelper](https://github.com/user-attachments/assets/4f237b58-9618-4132-bacc-38c8ad9b3775)
![_cgi-bin_mmwebwx-bin_webwxgetmsgimg__ MsgID=8689406359348736282 skey=@crypt_c1f457cc_76e07c38ae3aa64954a8652fb907387e mmweb_appid=wx_webfilehelper](https://github.com/user-attachments/assets/68a7c73a-8fee-451b-a4a1-201c8bfcfe16)

The screenshots above are running GPT2 and Bert on Asterinas. 

- Run a Pytorch benchmark. I did not run the full benchmark and only had two metrics here: 

![_cgi-bin_mmwebwx-bin_webwxgetmsgimg__ MsgID=3387510302915346832 skey=@crypt_c1f457cc_76e07c38ae3aa64954a8652fb907387e mmweb_appid=wx_webfilehelper](https://github.com/user-attachments/assets/898d5854-18ec-4f77-84a7-70e76aa4b894)

Do you think the PyTorch benchmark can be integrated into Asterinas' auto benchmark? The benchmark I ran is: https://github.com/pytorch/benchmark

Thanks.

