### PR TITLE
Fix a potential race condition during PTE read/write operations

### DIFF
--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         page_table::PageTableEntryTrait,
         Paddr, PagingConstsTrait, PagingLevel, Vaddr, PAGE_SIZE,
     },
+    util::SameSizeAs,
     Pod,
 };
 
@@ -121,6 +122,9 @@ macro_rules! parse_flags {
         ($val as usize & $from.bits() as usize) >> $from.bits().ilog2() << $to.bits().ilog2()
     };
 }
+
+// SAFETY: `PageTableEntry` has the same size as `usize`
+unsafe impl SameSizeAs<usize> for PageTableEntry {}
 
 impl PageTableEntryTrait for PageTableEntry {
     fn is_present(&self) -> bool {

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -10,6 +10,7 @@ use crate::{
         page_table::{PageTableEntryTrait, PageTableMode},
         Paddr, PageProperty, PagingConstsTrait, PagingLevel, Vaddr,
     },
+    util::SameSizeAs,
     Pod,
 };
 
@@ -73,6 +74,9 @@ impl PageTableEntry {
     const PHYS_MASK: u64 = 0xFFFF_FFFF_F000;
     const PROP_MASK: u64 = !Self::PHYS_MASK & !PageTableFlags::LAST_PAGE.bits();
 }
+
+// SAFETY: `PageTableEntry` has the same size as `usize` in our supported x86 architecture.
+unsafe impl SameSizeAs<usize> for PageTableEntry {}
 
 impl PageTableEntryTrait for PageTableEntry {
     fn new_page(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         page_table::PageTableEntryTrait,
         Paddr, PagingConstsTrait, PagingLevel, Vaddr, PAGE_SIZE,
     },
+    util::SameSizeAs,
     Pod,
 };
 
@@ -162,6 +163,9 @@ macro_rules! parse_flags {
         ($val as usize & $from.bits() as usize) >> $from.bits().ilog2() << $to.bits().ilog2()
     };
 }
+
+// SAFETY: `PageTableEntry` has the same size as `usize`
+unsafe impl SameSizeAs<usize> for PageTableEntry {}
 
 impl PageTableEntryTrait for PageTableEntry {
     fn is_present(&self) -> bool {

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -47,6 +47,7 @@ pub mod task;
 pub mod timer;
 pub mod trap;
 pub mod user;
+mod util;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/ostd/src/util.rs
+++ b/ostd/src/util.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// A marker trait that represents a type has the same size as `T`.
+///
+/// # Safety
+///
+/// Types that implement `SameSizeAs<T>` must have the same size as `T`.
+pub unsafe trait SameSizeAs<T> {}


### PR DESCRIPTION
KernMiri reports a data race: when a `CursorMut` write to a PTE, there may be a concurrent read operation to the same PTE during the `Cursor::new()`. 

For the `read` operation in `Cursor::new()`, reading the PTE either before the write or after the write does not affect correct execution. However, if it reads a PTE that is halfway through being written, it may cause issues. Therefore, it is necessary to ensure that the `read`/`write` operations here are at least single instructions. This PR replaces the original `read`/`write` with the `read_once`/`write_once` API to strengthen this guarantee.