### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,31 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "aml"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f8cba7d4260ea05671dda81029f6f718b54402a4ec926a0d9a41bdbb96b415"
-dependencies = [
- "bit_field",
- "bitvec",
- "byteorder",
- "log",
- "spinning_top",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "aster-bigtcp"
 version = "0.1.0"
 dependencies = [
@@ -119,8 +94,6 @@ name = "aster-block"
 version = "0.1.0"
 dependencies = [
  "align_ext",
- "aster-util",
- "bitflags 1.3.2",
  "bitvec",
  "component",
  "int-to-c-enum",
@@ -134,10 +107,7 @@ dependencies = [
 name = "aster-console"
 version = "0.1.0"
 dependencies = [
- "aster-util",
- "bitflags 1.3.2",
  "component",
- "log",
  "ostd",
  "spin",
 ]
@@ -146,7 +116,6 @@ dependencies = [
 name = "aster-framebuffer"
 version = "0.1.0"
 dependencies = [
- "aster-logger",
  "component",
  "font8x8",
  "log",
@@ -158,13 +127,8 @@ dependencies = [
 name = "aster-input"
 version = "0.1.0"
 dependencies = [
- "ascii",
- "aster-rights",
- "aster-util",
- "bitflags 1.3.2",
  "component",
  "int-to-c-enum",
- "log",
  "ostd",
  "spin",
 ]
@@ -174,13 +138,10 @@ name = "aster-logger"
 version = "0.1.0"
 dependencies = [
  "aster-console",
- "aster-virtio",
- "cfg-if",
  "component",
  "log",
  "ostd",
  "owo-colors 3.5.0",
- "spin",
 ]
 
 [[package]]
@@ -207,15 +168,9 @@ dependencies = [
 name = "aster-network"
 version = "0.1.0"
 dependencies = [
- "align_ext",
  "aster-bigtcp",
- "aster-rights",
- "aster-util",
- "bitflags 1.3.2",
  "bitvec",
  "component",
- "int-to-c-enum",
- "log",
  "ostd",
  "spin",
 ]
@@ -225,11 +180,9 @@ name = "aster-nix"
 version = "0.1.0"
 dependencies = [
  "align_ext",
- "ascii",
  "aster-bigtcp",
  "aster-block",
  "aster-console",
- "aster-framebuffer",
  "aster-input",
  "aster-logger",
  "aster-mlsdisk",
@@ -271,7 +224,6 @@ dependencies = [
  "time",
  "typeflags",
  "typeflags-util",
- "vte",
  "xmas-elf 0.8.0",
 ]
 
@@ -298,7 +250,6 @@ dependencies = [
 name = "aster-softirq"
 version = "0.1.0"
 dependencies = [
- "aster-logger",
  "component",
  "intrusive-collections",
  "ostd",
@@ -309,7 +260,6 @@ dependencies = [
 name = "aster-time"
 version = "0.1.0"
 dependencies = [
- "aster-logger",
  "aster-util",
  "chrono",
  "component",
@@ -333,7 +283,6 @@ dependencies = [
 name = "aster-virtio"
 version = "0.1.0"
 dependencies = [
- "align_ext",
  "aster-bigtcp",
  "aster-block",
  "aster-console",
@@ -341,9 +290,7 @@ dependencies = [
  "aster-network",
  "aster-rights",
  "aster-util",
- "bit_field",
  "bitflags 1.3.2",
- "bytes",
  "component",
  "id-alloc",
  "int-to-c-enum",
@@ -450,12 +397,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"
@@ -1336,10 +1277,8 @@ version = "0.11.1"
 dependencies = [
  "acpi",
  "align_ext",
- "aml",
  "bit_field",
  "bitflags 1.3.2",
- "bitvec",
  "buddy_system_allocator",
  "cfg-if",
  "const-assert",
@@ -1694,15 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning_top"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,12 +1893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,27 +1903,6 @@ name = "volatile"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
-
-[[package]]
-name = "vte"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
-dependencies = [
- "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "wasi"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,7 +11,6 @@ aster-input = { path = "comps/input" }
 aster-block = { path = "comps/block" }
 aster-network = { path = "comps/network" }
 aster-console = { path = "comps/console" }
-aster-framebuffer = { path = "comps/framebuffer" }
 aster-softirq = { path = "comps/softirq" }
 aster-logger = { path = "comps/logger" }
 aster-mlsdisk = { path = "comps/mlsdisk" }
@@ -30,7 +29,6 @@ atomic-integer-wrapper = { path = "libs/atomic-integer-wrapper" }
 id-alloc = { path = "../ostd/libs/id-alloc" }
 int-to-c-enum = { path = "libs/int-to-c-enum" }
 cpio-decoder = { path = "libs/cpio-decoder" }
-ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 intrusive-collections = "0.9.5"
 paste = "1.0"
 time = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -46,7 +44,6 @@ libflate = { version = "2", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 lending-iterator = "0.1.7"
 spin = "0.9.4"
-vte = "0.10"
 lru = "0.12.3"
 log = "0.4"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/kernel/comps/block/Cargo.toml
+++ b/kernel/comps/block/Cargo.toml
@@ -6,11 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
 spin = "0.9.4"
 ostd = { path = "../../../ostd" }
 align_ext = { path = "../../../ostd/libs/align_ext" }
-aster-util = { path = "../../libs/aster-util" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"

--- a/kernel/comps/console/Cargo.toml
+++ b/kernel/comps/console/Cargo.toml
@@ -6,12 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
 spin = "0.9.4"
 ostd = { path = "../../../ostd" }
-aster-util = { path = "../../libs/aster-util" }
 component = { path = "../../libs/comp-sys/component" }
-log = "0.4"
 
 [lints]
 workspace = true

--- a/kernel/comps/framebuffer/Cargo.toml
+++ b/kernel/comps/framebuffer/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
-aster-logger = { path = "../logger" }
 log = "0.4"
 spin = "0.9.4"
 font8x8 = { version = "0.2.5", default-features = false, features = [

--- a/kernel/comps/input/Cargo.toml
+++ b/kernel/comps/input/Cargo.toml
@@ -6,15 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
 spin = "0.9.4"
 ostd = { path = "../../../ostd" }
-aster-util = { path = "../../libs/aster-util" }
-aster-rights = { path = "../../libs/aster-rights" }
 component = { path = "../../libs/comp-sys/component" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
-log = "0.4"
-ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 
 [lints]
 workspace = true

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -8,12 +8,9 @@ edition = "2021"
 [dependencies]
 component = { path = "../../libs/comp-sys/component" }
 aster-console = { path = "../console" }
-aster-virtio = { path = "../virtio" }
 log = "0.4"
 ostd = { path = "../../../ostd" }
-spin = "0.9.4"
 owo-colors = { version = "3", optional = true }
-cfg-if = "1.0"
 
 [features]
 default = ["log_color"]

--- a/kernel/comps/network/Cargo.toml
+++ b/kernel/comps/network/Cargo.toml
@@ -6,15 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-align_ext = { path = "../../../ostd/libs/align_ext" }
-aster-util = { path = "../../libs/aster-util" }
-aster-rights = { path = "../../libs/aster-rights" }
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
-bitflags = "1.3"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 component = { path = "../../libs/comp-sys/component" }
-int-to-c-enum = { path = "../../libs/int-to-c-enum" }
-log = "0.4"
 ostd = { path = "../../../ostd" }
 spin = "0.9.4"
 

--- a/kernel/comps/softirq/Cargo.toml
+++ b/kernel/comps/softirq/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
-aster-logger = { path = "../logger" }
 intrusive-collections = "0.9.5"
 spin = "0.9.4"
 

--- a/kernel/comps/time/Cargo.toml
+++ b/kernel/comps/time/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 ostd = { path = "../../../ostd" }
 aster-util = { path = "../../libs/aster-util" }
 component = { path = "../../libs/comp-sys/component" }
-aster-logger = { path = "../logger" }
 log = "0.4"
 spin = "0.9.4"
 

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 [dependencies]
 bitflags = "1.3"
 spin = "0.9.4"
-bytes = { version = "1.4.0", default-features = false }
-align_ext = { path = "../../../ostd/libs/align_ext" }
 aster-input = { path = "../input" }
 aster-block = { path = "../block" }
 aster-network = { path = "../network" }
@@ -22,7 +20,6 @@ typeflags-util = { path = "../../libs/typeflags-util" }
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
-bit_field = "0.10.1"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 
 [lints]

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -19,7 +19,6 @@ align_ext = { path = "libs/align_ext", version = "0.1.0" }
 bit_field = "0.10.1"
 buddy_system_allocator = { version = "0.10", default-features = false, features = ["alloc"] }
 bitflags = "1.3"
-bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 cfg-if = "1.0"
 const-assert = "1.0"
 gimli = { version = "0.28", default-features = false, features = ["read-core"] }
@@ -47,7 +46,6 @@ xarray = { git = "https://github.com/asterinas/xarray", version = "0.1.0" }
 x86_64 = "0.14.13"
 x86 = "0.52.0"
 acpi = "5.1.0"
-aml = "0.16.3"
 multiboot2 = "0.23.0"
 iced-x86 = { version = "1.21.0", default-features = false, features = [
     "no_std",


### PR DESCRIPTION
This PR removes all unused dependencies that were identified.

While working on #1623, I discovered cyclic dependencies caused by outdated dependencies. Therefore, this PR aims to eliminate these outdated dependencies.

The outdated dependencies were identified using `cargo shear`, [a Cargo subcommand](https://github.com/boshen/cargo-shear) designed to detect outdated dependencies. However, since it relies solely on pattern matching (without actual compilation), it may occasionally report false positives, particularly for crates that are only used in macros. As a result, this tool may _not_ be suitable for inclusion in CI.