### PR TITLE
Fix the #VE irq issue causing TDX CI failure

### DIFF
--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -40,7 +40,7 @@ cfg_if! {
     if #[cfg(feature = "cvm_guest")] {
         mod tdx;
 
-        use tdx::handle_virtualization_exception;
+        use tdx::VirtualizationExceptionHandler;
     }
 }
 
@@ -132,8 +132,11 @@ impl UserContextApiInternal for UserContext {
             match CpuException::to_cpu_exception(self.user_context.trap_num as u16) {
                 #[cfg(feature = "cvm_guest")]
                 Some(CpuException::VIRTUALIZATION_EXCEPTION) => {
+                    let ve_handler = VirtualizationExceptionHandler::new();
+                    // Check out the doc of `VirtualizationExceptionHandler::new` to
+                    // see why IRQs must enabled _after_ instantiating a `VirtualizationExceptionHandler`.
                     crate::arch::irq::enable_local();
-                    handle_virtualization_exception(self);
+                    ve_handler.handle(self);
                 }
                 Some(exception) if exception.typ().is_fatal_or_trap() => {
                     crate::arch::irq::enable_local();


### PR DESCRIPTION
The PR #1668 added the irq enablement when handing #VE. However, if a guest kernel action which would normally cause a #VE occurs in the interrupt-disabled region before TDGETVEINFO, a #DF (fault exception) is delivered to the guest which will result in an oops. Therefore, we should put the irq enable after TDGETVEINFO.

After verification, the local syscall test can pass.