### PR TITLE
Fix timeout mechanism in `wait_events`

### DIFF
--- a/kernel/src/net/socket/vsock/stream/socket.rs
+++ b/kernel/src/net/socket/vsock/stream/socket.rs
@@ -171,12 +171,12 @@ impl Socket for VsockStreamSocket {
         vsockspace.request(&connecting.info()).unwrap();
         // wait for response from driver
         // TODO: Add timeout
-        let mut poller = Poller::new();
+        let mut poller = Poller::new(None);
         if !connecting
             .poll(IoEvents::IN, Some(poller.as_handle_mut()))
             .contains(IoEvents::IN)
         {
-            if let Err(e) = poller.wait(None) {
+            if let Err(e) = poller.wait() {
                 vsockspace
                     .remove_connecting_socket(&connecting.local_addr())
                     .unwrap();

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -73,7 +73,7 @@ pub fn futex_wait_bitset(
     // drop lock
     drop(futex_bucket);
 
-    let result = waiter.pause_timeout(timeout);
+    let result = waiter.pause_timeout(&timeout.into());
     match result {
         // FIXME: If the futex is woken up and a signal comes at the same time, we should succeed
         // instead of failing with `EINTR`. The code below is of course wrong, but was needed to

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -96,7 +96,7 @@ pub trait Pause: WaitTimeout {
     /// [`ETIME`]: crate::error::Errno::ETIME
     /// [`EINTR`]: crate::error::Errno::EINTR
     #[track_caller]
-    fn pause_timeout<'a>(&self, timeout: impl Into<TimeoutExt<'a>>) -> Result<()>;
+    fn pause_timeout<'a>(&self, timeout: &TimeoutExt<'a>) -> Result<()>;
 }
 
 impl Pause for Waiter {
@@ -136,8 +136,8 @@ impl Pause for Waiter {
         res
     }
 
-    fn pause_timeout<'a>(&self, timeout: impl Into<TimeoutExt<'a>>) -> Result<()> {
-        let timer = timeout.into().check_expired()?.map(|timeout| {
+    fn pause_timeout<'a>(&self, timeout: &TimeoutExt<'a>) -> Result<()> {
+        let timer = timeout.check_expired()?.map(|timeout| {
             let waker = self.waker();
             timeout.create_timer(move || {
                 waker.wake_up();
@@ -201,7 +201,7 @@ impl Pause for WaitQueue {
         waiter.pause_until_or_timeout_impl(cond, timeout)
     }
 
-    fn pause_timeout<'a>(&self, _timeout: impl Into<TimeoutExt<'a>>) -> Result<()> {
+    fn pause_timeout<'a>(&self, _timeout: &TimeoutExt<'a>) -> Result<()> {
         panic!("`pause_timeout` can only be used on `Waiter`");
     }
 }

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -89,11 +89,9 @@ pub trait Pause: WaitTimeout {
     ///
     /// # Errors
     ///
-    /// This method will return an error with [`ETIME`] if the timeout is reached.
-    ///
-    /// Unlike other methods in the trait, this method will _not_ return an error with [`EINTR`] if
-    /// a signal is received (FIXME: See <https://github.com/asterinas/asterinas/pull/1577> for why
-    /// we cannot fix this directly).
+    /// This method will return an error with
+    ///  - [`EINTR`] if a signal is received;
+    ///  - [`ETIME`] if the timeout is reached.
     ///
     /// [`ETIME`]: crate::error::Errno::ETIME
     /// [`EINTR`]: crate::error::Errno::EINTR
@@ -113,10 +111,9 @@ impl Pause for Waiter {
         // No fast paths for `Waiter`. If the caller wants a fast path, it should do so _before_
         // the waiter is created.
 
-        let current_thread = self.task().as_thread();
-
-        let Some(posix_thread) = current_thread
-            .as_ref()
+        let Some(posix_thread) = self
+            .task()
+            .as_thread()
             .and_then(|thread| thread.as_posix_thread())
         else {
             return self.wait_until_or_timeout_cancelled(cond, || Ok(()), timeout);
@@ -147,12 +144,12 @@ impl Pause for Waiter {
             })
         });
 
-        let current_thread = self.task().as_thread();
+        let posix_thread_opt = self
+            .task()
+            .as_thread()
+            .and_then(|thread| thread.as_posix_thread());
 
-        if let Some(posix_thread) = current_thread
-            .as_ref()
-            .and_then(|thread| thread.as_posix_thread())
-        {
+        if let Some(posix_thread) = posix_thread_opt {
             posix_thread.set_signalled_waker(self.waker());
             self.wait();
             posix_thread.clear_signalled_waker();
@@ -166,6 +163,16 @@ impl Pause for Waiter {
             }
             // If the timeout is not expired, cancel the timer manually.
             timer.cancel();
+        }
+
+        if posix_thread_opt
+            .as_ref()
+            .is_some_and(|posix_thread| posix_thread.has_pending())
+        {
+            return_errno_with_message!(
+                Errno::EINTR,
+                "the current thread is interrupted by a signal"
+            );
         }
 
         Ok(())

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::{
-    sync::atomic::{AtomicIsize, AtomicUsize, Ordering},
+    sync::atomic::{AtomicIsize, Ordering},
     time::Duration,
 };
 
@@ -13,6 +13,7 @@ use ostd::{
 use crate::{
     events::{IoEvents, Observer, Subject},
     prelude::*,
+    time::wait::TimeoutExt,
 };
 
 /// A pollee represents any I/O object (e.g., a file or socket) that can be polled.
@@ -255,6 +256,7 @@ impl<O: Observer<IoEvents> + 'static> PollAdaptor<O> {
 
 impl<O> PollAdaptor<O> {
     /// Gets a reference to the observer.
+    #[expect(dead_code, reason = "Keep this `Arc` to avoid dropping the observer")]
     pub fn observer(&self) -> &Arc<O> {
         &self.observer
     }
@@ -267,76 +269,50 @@ impl<O> PollAdaptor<O> {
 
 /// A poller that can be used to wait for some events.
 pub struct Poller {
-    poller: PollAdaptor<EventCounter>,
+    poller: PollHandle,
     waiter: Waiter,
+    timeout: TimeoutExt<'static>,
 }
 
 impl Poller {
     /// Constructs a new poller to wait for interesting events.
-    pub fn new() -> Self {
-        let (waiter, event_counter) = EventCounter::new_pair();
+    ///
+    /// If `timeout` is specified, [`Self::wait`] will fail with [`ETIME`] after the specified
+    /// timeout is expired.
+    ///
+    /// [`ETIME`]: crate::error::Errno::ETIME
+    pub fn new(timeout: Option<&Duration>) -> Self {
+        let (waiter, waker) = Waiter::new_pair();
+
+        let mut timeout_ext = TimeoutExt::from(timeout);
+        timeout_ext.freeze();
 
         Self {
-            poller: PollAdaptor::with_observer(event_counter),
+            poller: PollHandle::new(Arc::downgrade(&waker) as Weak<_>),
             waiter,
+            timeout: timeout_ext,
         }
     }
 
     /// Returns a mutable reference of [`PollHandle`].
     pub fn as_handle_mut(&mut self) -> &mut PollHandle {
-        self.poller.as_handle_mut()
+        &mut self.poller
     }
 
-    /// Waits until some interesting events happen since the last wait or until the timeout
-    /// expires.
+    /// Waits until some interesting events happen since the last wait.
     ///
-    /// The waiting process can be interrupted by a signal.
-    pub fn wait(&self, timeout: Option<&Duration>) -> Result<()> {
-        self.poller.observer().read(&self.waiter, timeout)?;
-        Ok(())
+    /// This method will fail with [`EINTR`] if interrupted by signals or [`ETIME`] on timeout.
+    ///
+    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ETIME`]: crate::error::Errno::ETIME
+    pub fn wait(&self) -> Result<()> {
+        self.waiter.pause_timeout(&self.timeout)
     }
 }
 
-struct EventCounter {
-    counter: AtomicUsize,
-    waker: Arc<Waker>,
-}
-
-impl EventCounter {
-    fn new_pair() -> (Waiter, Self) {
-        let (waiter, waker) = Waiter::new_pair();
-
-        (
-            waiter,
-            Self {
-                counter: AtomicUsize::new(0),
-                waker,
-            },
-        )
-    }
-
-    fn read(&self, waiter: &Waiter, timeout: Option<&Duration>) -> Result<usize> {
-        let cond = || {
-            let val = self.counter.swap(0, Ordering::Relaxed);
-            if val > 0 {
-                Some(val)
-            } else {
-                None
-            }
-        };
-
-        waiter.pause_until_or_timeout(cond, timeout)
-    }
-
-    fn write(&self) {
-        self.counter.fetch_add(1, Ordering::Relaxed);
-        self.waker.wake_up();
-    }
-}
-
-impl Observer<IoEvents> for EventCounter {
+impl Observer<IoEvents> for Waker {
     fn on_events(&self, _events: &IoEvents) {
-        self.write();
+        self.wake_up();
     }
 }
 
@@ -391,10 +367,10 @@ pub trait Pollable {
             return_errno_with_message!(Errno::ETIME, "the timeout expired");
         }
 
-        // Wait until the event happens.
-        let mut poller = Poller::new();
+        // Create the poller and register to wait for the events.
+        let mut poller = Poller::new(timeout);
         if self.poll(mask, Some(poller.as_handle_mut())).is_empty() {
-            poller.wait(timeout)?;
+            poller.wait()?;
         }
 
         loop {
@@ -405,9 +381,7 @@ pub trait Pollable {
             };
 
             // Wait until the next event happens.
-            //
-            // FIXME: We need to update `timeout` since we have waited for some time.
-            poller.wait(timeout)?;
+            poller.wait()?;
         }
     }
 }

--- a/kernel/src/time/core/timer.rs
+++ b/kernel/src/time/core/timer.rs
@@ -160,6 +160,11 @@ impl TimerManager {
         })
     }
 
+    /// Returns the clock associated with this timer manager.
+    pub fn clock(&self) -> &Arc<dyn Clock> {
+        &self.clock
+    }
+
     /// Returns whether a given `timeout` is expired.
     pub fn is_expired_timeout(&self, timeout: &Timeout) -> bool {
         match timeout {


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/c9e866626705c79509c2d6895318676d75bd075e/kernel/src/process/signal/poll.rs#L407-L410
https://github.com/asterinas/asterinas/blob/c9e866626705c79509c2d6895318676d75bd075e/kernel/src/syscall/poll.rs#L92

These two FIXMEs are caused by not exposing the standard `pause_until_or_timeout` API and instead creating the non-closure version of `Poller::wait`. We can fix them by replacing `Poller::wait` with `Poller::pause_until`. I believe this will also result in reasonable code overall.