### PR TITLE
Implement vfork syscall

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -137,6 +137,14 @@ impl CloneArgs {
             ..Default::default()
         }
     }
+
+    pub fn for_vfork() -> Self {
+        Self {
+            flags: CloneFlags::CLONE_VFORK | CloneFlags::CLONE_VM,
+            exit_signal: Some(SIGCHLD),
+            ..Default::default()
+        }
+    }
 }
 
 impl From<u64> for CloneFlags {
@@ -158,7 +166,8 @@ impl CloneFlags {
             | CloneFlags::CLONE_SETTLS
             | CloneFlags::CLONE_PARENT_SETTID
             | CloneFlags::CLONE_CHILD_SETTID
-            | CloneFlags::CLONE_CHILD_CLEARTID;
+            | CloneFlags::CLONE_CHILD_CLEARTID
+            | CloneFlags::CLONE_VFORK;
         let unsupported_flags = *self - supported_flags;
         if !unsupported_flags.is_empty() {
             warn!("contains unsupported clone flags: {:?}", unsupported_flags);

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -14,6 +14,7 @@ use crate::{prelude::*, process::signal::signals::kernel::KernelSignal};
 /// [`do_exit_group`]: crate::process::posix_thread::do_exit_group
 pub(super) fn exit_process(thread_local: &ThreadLocal, current_process: &Process) {
     current_process.status().set_zombie();
+    current_process.status().set_vfork_child(false);
 
     // FIXME: This is obviously wrong in a number of ways, since different threads can have
     // different file tables, and different processes can share the same file table.
@@ -25,7 +26,7 @@ pub(super) fn exit_process(thread_local: &ThreadLocal, current_process: &Process
 
     send_child_death_signal(current_process);
 
-    current_process.lock_root_vmar().clear();
+    current_process.lock_root_vmar().set_vmar(None);
 }
 
 /// Sends parent-death signals to the children.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -26,8 +26,10 @@ pub use process::{
     ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, Session, Sid, Terminal,
 };
 pub use process_filter::ProcessFilter;
-pub use process_vm::{MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN};
-pub use program_loader::{check_executable_file, load_program_to_vm};
+pub use process_vm::{
+    renew_vm_and_map, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
+};
+pub use program_loader::{check_executable_file, ProgramToLoad};
 pub use rlimit::ResourceType;
 pub use term_status::TermStatus;
 pub use wait::{wait_child_exit, WaitOptions};

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -17,56 +17,89 @@ use crate::{
     prelude::*,
 };
 
-/// Load an executable to root vmar, including loading programme image, preparing heap and stack,
-/// initializing argv, envp and aux tables.
-/// About recursion_limit: recursion limit is used to limit th recursion depth of shebang executables.
-/// If the interpreter(the program behind #!) of shebang executable is also a shebang,
-/// then it will trigger recursion. We will try to setup root vmar for the interpreter.
-/// I guess for most cases, setting the recursion_limit as 1 should be enough.
-/// because the interpreter is usually an elf binary(e.g., /bin/bash)
-pub fn load_program_to_vm(
-    process_vm: &ProcessVm,
+/// Represents an executable file that is ready to be loaded into memory and executed.
+///
+/// This struct encapsulates the ELF file to be executed along with its header data,
+/// the `argv` and the `envp` which is required for the program execution.
+pub struct ProgramToLoad {
     elf_file: Dentry,
+    file_header: Box<[u8; PAGE_SIZE]>,
     argv: Vec<CString>,
     envp: Vec<CString>,
-    fs_resolver: &FsResolver,
-    recursion_limit: usize,
-) -> Result<(String, ElfLoadInfo)> {
-    let abs_path = elf_file.abs_path();
-    let inode = elf_file.inode();
-    let file_header = {
-        // read the first page of file header
-        let mut file_header_buffer = Box::new([0u8; PAGE_SIZE]);
-        inode.read_bytes_at(0, &mut *file_header_buffer)?;
-        file_header_buffer
-    };
-    if let Some(mut new_argv) = parse_shebang_line(&*file_header)? {
-        if recursion_limit == 0 {
-            return_errno_with_message!(Errno::ELOOP, "the recursieve limit is reached");
-        }
-        new_argv.extend_from_slice(&argv);
-        let interpreter = {
-            let filename = new_argv[0].to_str()?.to_string();
-            let fs_path = FsPath::new(AT_FDCWD, &filename)?;
-            fs_resolver.lookup(&fs_path)?
+}
+
+impl ProgramToLoad {
+    /// Constructs a new `ProgramToLoad` from a file, handling shebang interpretation if needed.
+    ///
+    /// About `recursion_limit`: recursion limit is used to limit th recursion depth of shebang executables.
+    /// If the interpreter(the program behind #!) of shebang executable is also a shebang,
+    /// then it will trigger recursion. We will try to setup root vmar for the interpreter.
+    /// I guess for most cases, setting the `recursion_limit` as 1 should be enough.
+    /// because the interpreter is usually an elf binary(e.g., /bin/bash)
+    pub fn build_from_file(
+        elf_file: Dentry,
+        fs_resolver: &FsResolver,
+        argv: Vec<CString>,
+        envp: Vec<CString>,
+        recursion_limit: usize,
+    ) -> Result<Self> {
+        let inode = elf_file.inode();
+        let file_header = {
+            // read the first page of file header
+            let mut file_header_buffer = Box::new([0u8; PAGE_SIZE]);
+            inode.read_bytes_at(0, &mut *file_header_buffer)?;
+            file_header_buffer
         };
-        check_executable_file(&interpreter)?;
-        return load_program_to_vm(
-            process_vm,
-            interpreter,
-            new_argv,
+        if let Some(mut new_argv) = parse_shebang_line(&*file_header)? {
+            if recursion_limit == 0 {
+                return_errno_with_message!(Errno::ELOOP, "the recursieve limit is reached");
+            }
+            new_argv.extend_from_slice(&argv);
+            let interpreter = {
+                let filename = new_argv[0].to_str()?.to_string();
+                let fs_path = FsPath::new(AT_FDCWD, &filename)?;
+                fs_resolver.lookup(&fs_path)?
+            };
+            check_executable_file(&interpreter)?;
+            return Self::build_from_file(
+                interpreter,
+                fs_resolver,
+                new_argv,
+                envp,
+                recursion_limit - 1,
+            );
+        }
+
+        Ok(Self {
+            elf_file,
+            file_header,
+            argv,
             envp,
-            fs_resolver,
-            recursion_limit - 1,
-        );
+        })
     }
 
-    process_vm.clear_and_map();
+    /// Loads the executable into the specified virtual memory space.
+    ///
+    /// Returns a tuple containing:
+    /// 1. The absolute path of the loaded executable.
+    /// 2. Information about the ELF loading process.
+    pub fn load_to_vm(
+        self,
+        process_vm: &ProcessVm,
+        fs_resolver: &FsResolver,
+    ) -> Result<(String, ElfLoadInfo)> {
+        let abs_path = self.elf_file.abs_path();
+        let elf_load_info = load_elf_to_vm(
+            process_vm,
+            &*self.file_header,
+            self.elf_file,
+            fs_resolver,
+            self.argv,
+            self.envp,
+        )?;
 
-    let elf_load_info =
-        load_elf_to_vm(process_vm, &*file_header, elf_file, fs_resolver, argv, envp)?;
-
-    Ok((abs_path, elf_load_info))
+        Ok((abs_path, elf_load_info))
+    }
 }
 
 pub fn check_executable_file(dentry: &Dentry) -> Result<()> {

--- a/kernel/src/process/status.rs
+++ b/kernel/src/process/status.rs
@@ -10,10 +10,13 @@ use super::ExitCode;
 ///
 /// This maintains:
 /// 1. Whether the process is a zombie (i.e., all its threads have exited);
-/// 2. The exit code of the process.
+/// 2. Whether the process is the vfork child, which shares the user-space virtual memory
+///    with its parent process;
+/// 3. The exit code of the process.
 #[derive(Debug)]
 pub struct ProcessStatus {
     is_zombie: AtomicBool,
+    is_vfork_child: AtomicBool,
     exit_code: AtomicU32,
 }
 
@@ -21,6 +24,7 @@ impl Default for ProcessStatus {
     fn default() -> Self {
         Self {
             is_zombie: AtomicBool::new(false),
+            is_vfork_child: AtomicBool::new(false),
             exit_code: AtomicU32::new(0),
         }
     }
@@ -41,6 +45,18 @@ impl ProcessStatus {
     pub(super) fn set_zombie(&self) {
         // Use the `Release` memory order to make the exit code visible.
         self.is_zombie.store(true, Ordering::Release);
+    }
+}
+
+impl ProcessStatus {
+    /// Returns whether the process is the vfork child.
+    pub fn is_vfork_child(&self) -> bool {
+        self.is_vfork_child.load(Ordering::Acquire)
+    }
+
+    /// Sets whether the process is the vfork child.
+    pub fn set_vfork_child(&self, is_vfork_child: bool) {
+        self.is_vfork_child.store(is_vfork_child, Ordering::Release);
     }
 }
 

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -26,7 +26,7 @@ use crate::syscall::{
     fallocate::sys_fallocate,
     fcntl::sys_fcntl,
     flock::sys_flock,
-    fork::sys_fork,
+    fork::{sys_fork, sys_vfork},
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
     get_priority::sys_get_priority,
@@ -205,6 +205,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETSOCKOPT = 55        => sys_getsockopt(args[..5]);
     SYS_CLONE = 56             => sys_clone(args[..5], &user_ctx);
     SYS_FORK = 57              => sys_fork(args[..0], &user_ctx);
+    SYS_VFORK = 58             => sys_vfork(args[..0], &user_ctx);
     SYS_EXECVE = 59            => sys_execve(args[..3], &mut user_ctx);
     SYS_EXIT = 60              => sys_exit(args[..1]);
     SYS_WAIT4 = 61             => sys_wait4(args[..4]);

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -15,8 +15,8 @@ use crate::{
     },
     prelude::*,
     process::{
-        check_executable_file, load_program_to_vm, posix_thread::ThreadName, Credentials, Process,
-        MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
+        check_executable_file, posix_thread::ThreadName, renew_vm_and_map, Credentials, Process,
+        ProgramToLoad, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
     },
 };
 
@@ -118,11 +118,27 @@ fn do_execve(
     drop(closed_files);
 
     debug!("load program to root vmar");
-    let (new_executable_path, elf_load_info) = {
-        let fs_resolver = &*posix_thread.fs().resolver().read();
-        let process_vm = process.vm();
-        load_program_to_vm(process_vm, elf_file.clone(), argv, envp, fs_resolver, 1)?
-    };
+    let fs_resolver = &*posix_thread.fs().resolver().read();
+    let program_to_load =
+        ProgramToLoad::build_from_file(elf_file.clone(), fs_resolver, argv, envp, 1)?;
+
+    let process_vm = process.vm();
+    if process.status().is_vfork_child() {
+        renew_vm_and_map(ctx);
+
+        // Resumes the parent process.
+        process.status().set_vfork_child(false);
+        let parent = process.parent().lock().process().upgrade().unwrap();
+        parent.children_wait_queue().wake_all();
+    } else {
+        // FIXME: Currently, the efficiency of replacing the VMAR is lower than that
+        // of directly clearing the VMAR. Therefore, if not in vfork case we will only
+        // clear the VMAR.
+        process_vm.clear_and_map();
+    }
+
+    let (new_executable_path, elf_load_info) =
+        program_to_load.load_to_vm(process_vm, fs_resolver)?;
 
     // After the program has been successfully loaded, the virtual memory of the current process
     // is initialized. Hence, it is necessary to clear the previously recorded robust list.

--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -13,3 +13,9 @@ pub fn sys_fork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallRe
     let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
     Ok(SyscallReturn::Return(child_pid as _))
 }
+
+pub fn sys_vfork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
+    let clone_args = CloneArgs::for_vfork();
+    let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
+    Ok(SyscallReturn::Return(child_pid as _))
+}

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -59,6 +59,7 @@ TESTS ?= \
 	unlink_test \
 	utimes_test \
 	vdso_clock_gettime_test \
+	vfork_test \
 	write_test \
 	xattr_test \
 	# The end of the list


### PR DESCRIPTION
The implementation of the vfork functionality in this PR is based on PR #1675 and is relatively complete. However, there are two potential issues that have not been addressed in this PR yet.
- The rights management for `Vmar`. `vfork` syscall will dup the `Vmar` and share the `Vmar_` with its parent. This `Vmar` should not be written until the vfork process doing `execve` or `exit`, so it is better to restrict the rights in the `Vmar` for `vfork`.  However, it is hard to perform such operations for `Vmar` with static rights. If change the `Vmar` to the dynamic rights, it will introduce runtime overhead.
- The redundancy of `Arc<VmSpace>` in `UserSpace`. Both the `UserSpace` in `Task` and the `Vmar` in `Process` store an `Arc<VmSpace>`. The `VmSpace` in these two locations needs to be consistent, which introduces additional maintenance and runtime overhead. For example, in ostd, when trying to access `VmSpace`, it currently cannot leverage data from `ThreadLocal` and instead must acquire it through a lock.

Currently I incline to solve these two issues in subsequent PRs.