### PR TITLE
Fix the problem that OSDK picks the test kernel by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ initramfs:
 
 .PHONY: build
 build: initramfs $(CARGO_OSDK)
-	@cargo osdk build $(CARGO_OSDK_ARGS)
+	@cd kernel && cargo osdk build $(CARGO_OSDK_ARGS)
 
 .PHONY: tools
 tools:
@@ -205,7 +205,7 @@ tools:
 
 .PHONY: run
 run: initramfs $(CARGO_OSDK)
-	@cargo osdk run $(CARGO_OSDK_ARGS)
+	@cd kernel && cargo osdk run $(CARGO_OSDK_ARGS)
 # Check the running status of auto tests from the QEMU log
 ifeq ($(AUTO_TEST), syscall)
 	@tail --lines 100 qemu.log | grep -q "^.* of .* test cases passed." \
@@ -223,19 +223,19 @@ endif
 
 .PHONY: gdb_server
 gdb_server: initramfs $(CARGO_OSDK)
-	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server wait-client,vscode,addr=:$(GDB_TCP_PORT)
+	@cd kernel && cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server wait-client,vscode,addr=:$(GDB_TCP_PORT)
 
 .PHONY: gdb_client
 gdb_client: initramfs $(CARGO_OSDK)
-	@cargo osdk debug $(CARGO_OSDK_ARGS) --remote :$(GDB_TCP_PORT)
+	@cd kernel && cargo osdk debug $(CARGO_OSDK_ARGS) --remote :$(GDB_TCP_PORT)
 
 .PHONY: profile_server
 profile_server: initramfs $(CARGO_OSDK)
-	@cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server addr=:$(GDB_TCP_PORT)
+	@cd kernel && cargo osdk run $(CARGO_OSDK_ARGS) --gdb-server addr=:$(GDB_TCP_PORT)
 
 .PHONY: profile_client
 profile_client: initramfs $(CARGO_OSDK)
-	@cargo osdk profile $(CARGO_OSDK_ARGS) --remote :$(GDB_TCP_PORT) \
+	@cd kernel && cargo osdk profile $(CARGO_OSDK_ARGS) --remote :$(GDB_TCP_PORT) \
 		--samples $(GDB_PROFILE_COUNT) --interval $(GDB_PROFILE_INTERVAL) --format $(GDB_PROFILE_FORMAT)
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ ktest: initramfs $(CARGO_OSDK)
 	@# Exclude linux-bzimage-setup from ktest since it's hard to be unit tested
 	@for dir in $(OSDK_CRATES); do \
 		[ $$dir = "ostd/libs/linux-bzimage/setup" ] && continue; \
+		echo "[make] Testing $$dir"; \
 		(cd $$dir && OVMF=off cargo osdk test $(CARGO_OSDK_INITRAMFS_OPTION)) || exit 1; \
 		tail --lines 10 qemu.log | grep -q "^\\[ktest runner\\] All crates tested." \
 			|| (echo "Test failed" && exit 1); \

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -308,7 +308,7 @@ impl DebugProfileOutArgs {
                         .display()
                 )
             } else {
-                let crate_name = crate::util::get_current_crates().remove(0).name;
+                let crate_name = crate::util::get_kernel_crate().name;
                 let time_stamp = std::time::SystemTime::now();
                 let time_stamp: DateTime<Local> = time_stamp.into();
                 let time_stamp = time_stamp.format("%H%M%S");

--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -3,7 +3,7 @@
 use crate::{
     cli::DebugArgs,
     commands::util::bin_file_name,
-    util::{get_current_crates, get_target_directory},
+    util::{get_kernel_crate, get_target_directory},
 };
 use std::process::Command;
 
@@ -12,7 +12,7 @@ pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
 
     let file_path = get_target_directory()
         .join("osdk")
-        .join(get_current_crates().remove(0).name)
+        .join(get_kernel_crate().name)
         .join(bin_file_name());
     println!("Debugging {}", file_path.display());
 

--- a/osdk/src/commands/profile.rs
+++ b/osdk/src/commands/profile.rs
@@ -13,7 +13,7 @@ use inferno::flamegraph;
 use crate::{
     cli::{ProfileArgs, ProfileFormat},
     commands::util::bin_file_name,
-    util::{get_current_crates, get_target_directory},
+    util::{get_kernel_crate, get_target_directory},
 };
 use regex::Regex;
 use std::{
@@ -52,7 +52,7 @@ fn do_parse_stack_traces(target_file: &PathBuf, args: &ProfileArgs) {
 fn do_collect_stack_traces(args: &ProfileArgs) {
     let file_path = get_target_directory()
         .join("osdk")
-        .join(get_current_crates().remove(0).name)
+        .join(get_kernel_crate().name)
         .join(bin_file_name());
 
     let remote = &args.remote;

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -21,7 +21,13 @@ pub fn execute_test_command(config: &Config, args: &TestArgs) {
 }
 
 pub fn test_current_crate(config: &Config, args: &TestArgs) {
+    let current_crates = get_current_crates();
+    if current_crates.len() != 1 {
+        error_msg!("The current directory contains more than one crate");
+        std::process::exit(Errno::TooManyCrates as _);
+    }
     let current_crate = get_current_crates().remove(0);
+
     let cargo_target_directory = get_target_directory();
     let osdk_output_directory = cargo_target_directory.join(DEFAULT_TARGET_RELPATH);
 

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use crate::util::get_current_crates;
+use crate::util::get_kernel_crate;
 
 pub const COMMON_CARGO_ARGS: &[&str] = &[
     "-Zbuild-std=core,alloc,compiler_builtins",
@@ -23,7 +23,7 @@ pub fn profile_name_adapter(profile: &str) -> &str {
 }
 
 pub fn bin_file_name() -> String {
-    get_current_crates().remove(0).name + "-osdk-bin"
+    get_kernel_crate().name + "-osdk-bin"
 }
 
 pub(crate) fn is_tdx_enabled() -> bool {

--- a/osdk/src/error.rs
+++ b/osdk/src/error.rs
@@ -13,6 +13,7 @@ pub enum Errno {
     RunBundle = 8,
     BadCrateName = 9,
     NoKernelCrate = 10,
+    TooManyCrates = 11,
 }
 
 /// Print error message to console

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -144,6 +144,25 @@ pub fn get_current_crates() -> Vec<CrateInfo> {
     result
 }
 
+/// Get the kernel crate in the current directory.
+///
+/// If the current directory is a virtual workspace and no/multiple kernel
+/// crate is found, This function will print an error message and exit the
+/// process.
+pub fn get_kernel_crate() -> CrateInfo {
+    let crates = get_current_crates();
+    let kernel_crates: Vec<_> = crates.iter().filter(|c| c.is_kernel_crate).collect();
+    if kernel_crates.len() == 1 {
+        kernel_crates[0].clone()
+    } else if kernel_crates.is_empty() {
+        error_msg!("No kernel crate found in the current workspace");
+        std::process::exit(Errno::NoKernelCrate as _);
+    } else {
+        error_msg!("Multiple kernel crates found in the current workspace");
+        std::process::exit(Errno::TooManyCrates as _);
+    }
+}
+
 fn package_contains_ostd_main(package: &serde_json::Value) -> bool {
     let src_path = {
         let targets = package.get("targets").unwrap().as_array().unwrap();


### PR DESCRIPTION
Fix #1840 

Currently we have two kernel crates in the virtual workspace: the kernel and the test-kernel. In the past if we are in a virtual workspace, OSDK will pick a kernel crate in the workspace as the command target. But I think we shouldn't support such feature since typing `cargo build` in a Rust virtual workspace __with two binary crates__ will give you an error. In this PR I change `make ...` to call `cd kernel && cargo osdk ...` to ensure expected behaviors. ~~OSDK's ability to choose a crate still remains since we haven't discussed about it for a while.~~