### PR TITLE
Add validation for msg_iovlen in recvmsg syscall

### DIFF
--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -22,6 +22,12 @@ pub fn sys_recvmsg(
         sockfd, c_user_msghdr, flags
     );
 
+    const MAX_IOVEC_ENTRIES: usize = 1024;
+    let msg_iovlen = c_user_msghdr.msg_iovlen as usize;
+    if msg_iovlen > MAX_IOVEC_ENTRIES {
+        return_errno_with_message!(Errno::EMSGSIZE, "message too long");
+    }
+
     let mut file_table = ctx.thread_local.file_table().borrow_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;


### PR DESCRIPTION
A problem found by Trinity, a fuzz tool.
![image](https://github.com/user-attachments/assets/a80c1bb9-86cf-421e-bec0-35ec84c451d3)
![image](https://github.com/user-attachments/assets/cbe14e8f-3697-4a74-9287-22674f575122)

I tried to reproduce the error message, but I was not successful. However, I found that if I add a size limit to msg_iovlen, the error disappears.

A simple poc:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/socket.h>
#include <unistd.h>
#include <errno.h>

#define BUFFER_SIZE 1024  // 每个缓冲区的大小
#define IOV_COUNT 1025555555  // iov 数组的数量，linux上，大于1024会报message too long

int main() {
    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
    if (sockfd < 0) {
        perror("socket");
        return 1;
    }

    // 创建一个包含大量 iovec 结构的数组
    struct iovec *iov_array = malloc(IOV_COUNT * sizeof(struct iovec));
    if (!iov_array) {
        perror("malloc for iov_array");
        close(sockfd);
        return 1;
    }

    // 初始化每个 iovec 结构
    for (int i = 0; i < IOV_COUNT; i++) {
        char *buffer = malloc(BUFFER_SIZE);
        if (!buffer) {
            perror("malloc for buffer");
            free(iov_array);
            close(sockfd);
            return 1;
        }
        iov_array[i].iov_base = buffer;
        iov_array[i].iov_len = BUFFER_SIZE;
    }

    // 设置 msghdr 结构
    struct msghdr msg;
    memset(&msg, 0, sizeof(msg));
    msg.msg_iov = iov_array;
    msg.msg_iovlen = IOV_COUNT;

    // 调用 recvmsg 并检查结果
    ssize_t received = recvmsg(sockfd, &msg, 0);

    if (received < 0) {
        perror("recvmsg");
        printf("Error number: %d\n", errno);
    } else {
        printf("Received %zd bytes\n", received);
    }

    // 清理资源
    for (int i = 0; i < IOV_COUNT; i++) {
        free(iov_array[i].iov_base);
    }
    free(iov_array);
    close(sockfd);

    return 0;
}
```
In the current implementation, there is no check on the length of `msg_iovlen` in the `recvmsg` system call. This can lead to potential issues such as excessive memory allocation or buffer overflow when `msg_iovlen` is set to an unreasonably large value.

To address this, we now validate the length of `msg_iovlen`:
- If `msg_iovlen` exceeds a predefined maximum limit, the system call will return `-EMSGSIZE`.
- The maximum limit is set to a reasonable value based on Linux.

This change ensures that the system remains stable and secure even when handling large numbers of iovec structures.
