### PR TITLE
Move socket errors from `OptionSet` to `State`

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -362,7 +362,8 @@ impl Socket for DatagramSocket {
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
         match_sock_option_mut!(option, {
             socket_errors: SocketError => {
-                self.options.write().socket.get_and_clear_sock_errors(socket_errors);
+                // TODO: Support socket errors for UDP sockets
+                socket_errors.set(None);
                 return Ok(());
             },
             _ => ()

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -160,7 +160,7 @@ impl ConnectedStream {
         self.tcp_conn.iface()
     }
 
-    pub fn check_new(&mut self) -> Result<()> {
+    pub fn finish_last_connect(&mut self) -> Result<()> {
         if !self.is_new_connection {
             return_errno_with_message!(Errno::EISCONN, "the socket is already connected");
         }

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -82,7 +82,7 @@ impl ConnectingStream {
                 self.remote_endpoint,
                 true,
             )),
-            ConnectState::Refused => ConnResult::Refused(InitStream::new_bound(
+            ConnectState::Refused => ConnResult::Refused(InitStream::new_refused(
                 self.tcp_conn.into_bound_port().unwrap(),
             )),
         }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use aster_bigtcp::{socket::RawTcpOption, wire::IpEndpoint};
 
 use super::{connecting::ConnectingStream, listen::ListenStream, StreamObserver};
@@ -12,49 +14,62 @@ use crate::{
     prelude::*,
 };
 
-pub enum InitStream {
-    Unbound,
-    Bound(BoundPort),
+pub struct InitStream {
+    bound_port: Option<BoundPort>,
+    /// Indicates if the last `connect()` is considered to be done.
+    ///
+    /// If `connect()` is called but we're still in the `InitStream`, this means that the
+    /// connection is refused.
+    ///
+    ///  * If the connection is refused synchronously, the error code is returned by the
+    ///    `connect()` system call, and after that we always consider the `connect()` to be already
+    ///    done.
+    ///
+    ///  * If the connection is refused asynchronously (e.g., non-blocking sockets or interrupted
+    ///    `connect()`), the last `connect()` is not considered to have been done until another
+    ///    `connect()`, which checks and resets the boolean value and returns an appropriate error
+    ///    code.
+    is_connect_done: bool,
+    /// Indicates whether the socket error is `ECONNREFUSED`.
+    ///
+    /// This boolean value is set to true when the connection is refused and set to false when the
+    /// error code is reported via either `getsockopt(SOL_SOCKET, SO_ERROR)` or `connect()`.
+    is_conn_refused: AtomicBool,
 }
 
 impl InitStream {
     pub fn new() -> Self {
-        InitStream::Unbound
+        Self {
+            bound_port: None,
+            is_connect_done: true,
+            is_conn_refused: AtomicBool::new(false),
+        }
     }
 
     pub fn new_bound(bound_port: BoundPort) -> Self {
-        InitStream::Bound(bound_port)
+        Self {
+            bound_port: Some(bound_port),
+            is_connect_done: true,
+            is_conn_refused: AtomicBool::new(false),
+        }
     }
 
-    pub fn bind(
-        self,
-        endpoint: &IpEndpoint,
-        can_reuse: bool,
-    ) -> core::result::Result<BoundPort, (Error, Self)> {
-        match self {
-            InitStream::Unbound => (),
-            InitStream::Bound(bound_socket) => {
-                return Err((
-                    Error::with_message(Errno::EINVAL, "the socket is already bound to an address"),
-                    InitStream::Bound(bound_socket),
-                ));
-            }
-        };
-
-        let bound_port = match bind_port(endpoint, can_reuse) {
-            Ok(bound_port) => bound_port,
-            Err(err) => return Err((err, Self::Unbound)),
-        };
-
-        Ok(bound_port)
+    pub fn new_refused(bound_port: BoundPort) -> Self {
+        Self {
+            bound_port: Some(bound_port),
+            is_connect_done: false,
+            is_conn_refused: AtomicBool::new(true),
+        }
     }
 
-    fn bind_to_ephemeral_endpoint(
-        self,
-        remote_endpoint: &IpEndpoint,
-    ) -> core::result::Result<BoundPort, (Error, Self)> {
-        let endpoint = get_ephemeral_endpoint(remote_endpoint);
-        self.bind(&endpoint, false)
+    pub fn bind(&mut self, endpoint: &IpEndpoint, can_reuse: bool) -> Result<()> {
+        if self.bound_port.is_some() {
+            return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
+        }
+
+        self.bound_port = Some(bind_port(endpoint, can_reuse)?);
+
+        Ok(())
     }
 
     pub fn connect(
@@ -63,13 +78,49 @@ impl InitStream {
         option: &RawTcpOption,
         observer: StreamObserver,
     ) -> core::result::Result<ConnectingStream, (Error, Self)> {
-        let bound_port = match self {
-            InitStream::Bound(bound_port) => bound_port,
-            InitStream::Unbound => self.bind_to_ephemeral_endpoint(remote_endpoint)?,
+        debug_assert!(
+            self.is_connect_done,
+            "`finish_last_connect()` should be called before calling `connect()`"
+        );
+
+        let bound_port = if let Some(bound_port) = self.bound_port {
+            bound_port
+        } else {
+            let endpoint = get_ephemeral_endpoint(remote_endpoint);
+            match bind_port(&endpoint, false) {
+                Ok(bound_port) => bound_port,
+                Err(err) => return Err((err, self)),
+            }
         };
 
-        ConnectingStream::new(bound_port, *remote_endpoint, option, observer)
-            .map_err(|(err, bound_port)| (err, InitStream::Bound(bound_port)))
+        ConnectingStream::new(bound_port, *remote_endpoint, option, observer).map_err(
+            |(err, bound_port)| {
+                if err.error() == Errno::ECONNREFUSED {
+                    (err, InitStream::new_refused(bound_port))
+                } else {
+                    (err, InitStream::new_bound(bound_port))
+                }
+            },
+        )
+    }
+
+    pub fn finish_last_connect(&mut self) -> Result<()> {
+        if self.is_connect_done {
+            return Ok(());
+        }
+
+        self.is_connect_done = true;
+
+        let is_conn_refused = self.is_conn_refused.get_mut();
+        if *is_conn_refused {
+            *is_conn_refused = false;
+            return_errno_with_message!(Errno::ECONNREFUSED, "the connection is refused");
+        } else {
+            return_errno_with_message!(
+                Errno::ECONNABORTED,
+                "the error code for the connection failure is not available"
+            );
+        }
     }
 
     pub fn listen(
@@ -78,10 +129,22 @@ impl InitStream {
         option: &RawTcpOption,
         observer: StreamObserver,
     ) -> core::result::Result<ListenStream, (Error, Self)> {
-        let InitStream::Bound(bound_port) = self else {
+        if !self.is_connect_done {
+            // See the comments of `is_connect_done`.
+            // `listen()` is also not allowed until the second `connect()`.
+            return Err((
+                Error::with_message(
+                    Errno::EINVAL,
+                    "the connection is refused, but the connecting phase is not done",
+                ),
+                self,
+            ));
+        }
+
+        let Some(bound_port) = self.bound_port else {
             // FIXME: The socket should be bound to INADDR_ANY (i.e., 0.0.0.0) with an ephemeral
             // port. However, INADDR_ANY is not yet supported, so we need to return an error first.
-            debug_assert!(false, "listen() without bind() is not implemented");
+            warn!("listen() without bind() is not implemented");
             return Err((
                 Error::with_message(Errno::EINVAL, "listen() without bind() is not implemented"),
                 self,
@@ -90,19 +153,29 @@ impl InitStream {
 
         match ListenStream::new(bound_port, backlog, option, observer) {
             Ok(listen_stream) => Ok(listen_stream),
-            Err((bound_port, error)) => Err((error, Self::Bound(bound_port))),
+            Err((bound_port, error)) => Err((error, Self::new_bound(bound_port))),
         }
     }
 
     pub fn local_endpoint(&self) -> Option<IpEndpoint> {
-        match self {
-            InitStream::Unbound => None,
-            InitStream::Bound(bound_port) => Some(bound_port.endpoint().unwrap()),
-        }
+        self.bound_port
+            .as_ref()
+            .map(|bound_port| bound_port.endpoint().unwrap())
     }
 
     pub(super) fn check_io_events(&self) -> IoEvents {
         // Linux adds OUT and HUP events for a newly created socket
         IoEvents::OUT | IoEvents::HUP
+    }
+
+    pub(super) fn test_and_clear_error(&self) -> Option<Error> {
+        if self.is_conn_refused.swap(false, Ordering::Relaxed) {
+            Some(Error::with_message(
+                Errno::ECONNREFUSED,
+                "the connection is refused",
+            ))
+        } else {
+            None
+        }
     }
 }

--- a/kernel/src/net/socket/ip/stream/observer.rs
+++ b/kernel/src/net/socket/ip/stream/observer.rs
@@ -30,7 +30,8 @@ impl SocketEventObserver for StreamObserver {
         }
 
         if events.contains(SocketEvents::CLOSED) {
-            io_events |= IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP | IoEvents::HUP;
+            io_events |= IoEvents::IN | IoEvents::OUT;
+            io_events |= IoEvents::RDHUP | IoEvents::HUP | IoEvents::ERR;
         }
 
         self.0.notify(io_events);

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -9,8 +9,7 @@ use aster_bigtcp::socket::{
 use crate::{
     match_sock_option_mut, match_sock_option_ref,
     net::socket::options::{
-        Error as SocketError, KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf,
-        SocketOption,
+        KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
     },
     prelude::*,
 };
@@ -19,7 +18,6 @@ use crate::{
 #[get_copy = "pub"]
 #[set = "pub"]
 pub struct SocketOptionSet {
-    sock_errors: Option<Error>,
     reuse_addr: bool,
     reuse_port: bool,
     send_buf: u32,
@@ -32,7 +30,6 @@ impl SocketOptionSet {
     /// Return the default socket level options for tcp socket.
     pub fn new_tcp() -> Self {
         Self {
-            sock_errors: None,
             reuse_addr: false,
             reuse_port: false,
             send_buf: TCP_SEND_BUF_LEN as u32,
@@ -45,7 +42,6 @@ impl SocketOptionSet {
     /// Return the default socket level options for udp socket.
     pub fn new_udp() -> Self {
         Self {
-            sock_errors: None,
             reuse_addr: false,
             reuse_port: false,
             send_buf: UDP_SEND_PAYLOAD_LEN as u32,
@@ -53,15 +49,6 @@ impl SocketOptionSet {
             linger: LingerOption::default(),
             keep_alive: false,
         }
-    }
-
-    /// Gets and clears the socket error.
-    ///
-    /// When processing the `getsockopt` system call, the socket error is automatically cleared
-    /// after reading. This method should be called to provide this behavior.
-    pub fn get_and_clear_sock_errors(&mut self, option: &mut SocketError) {
-        option.set(self.sock_errors());
-        self.set_sock_errors(None);
     }
 
     /// Gets socket-level options.


### PR DESCRIPTION
Storing socket errors in `OptionSet` is not a good idea. The socket error can be accessed in `send`/`recv`/`poll`. More seriously, socket errors can also be set by network events (e.g. `ECONNRESET`).

By moving socket errors to `State`, we allow more flexible access to socket errors in `send`/`recv`/`poll` (as shown in this PR), and we can implement `ECONNRESET` by maintaining a flag in `TcpConnection` (to be done in a future PR).

The only socket error we currently support is `ECONNREFUSED`, which can be converted to a flag in `InitStream`. I have tested the Linux implementation and found that it is impossible to do a state transition (e.g. `InitStream` -> `ListenStream`/`ConnectingStream`) before clearing the socket error first. Some regression tests will be added for this to ensure that our behavior is consistent with Linux.