### PR TITLE
Don't panic when allocating the last page

### DIFF
--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -85,7 +85,7 @@ impl<M: AnyFrameMeta> Segment<M> {
         if range.start % PAGE_SIZE != 0 || range.end % PAGE_SIZE != 0 {
             return Err(GetFrameError::NotAligned);
         }
-        if range.end >= super::MAX_PADDR.load(Ordering::Relaxed) {
+        if range.end > super::MAX_PADDR.load(Ordering::Relaxed) {
             return Err(GetFrameError::OutOfBound);
         }
         assert!(range.start < range.end);


### PR DESCRIPTION
[This CI](https://github.com/asterinas/asterinas/actions/runs/13511949213/job/37753715867?pr=1854) fails:
```
 ERROR: Uncaught panic:
	called `Result::unwrap()` on an `Err` value: OutOfBound
	at /__w/asterinas/asterinas/ostd/src/mm/frame/allocator.rs:107
	on CPU 0 by thread None
```

https://github.com/asterinas/asterinas/blob/18e0eae33104fbeecf8ebde63abbdcb7cdf7cfef/ostd/src/mm/frame/allocator.rs#L103-L107

This seems to be caused by allocating the last page so we have `range.end` and `MAX_PADDR` exactly the same.

https://github.com/asterinas/asterinas/blob/18e0eae33104fbeecf8ebde63abbdcb7cdf7cfef/ostd/src/mm/frame/segment.rs#L88-L90

```
range.end 2146373632, MAX_PADDR 2146373632
```