### PR TITLE
Implement `getcpu` syscall and add corresponding test application

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -329,7 +329,7 @@ provided by Linux on x86-64 architecture.
 | 306	  | syncfs           | ❌              |
 | 307	  | sendmmsg         | ❌              |
 | 308	  | setns            | ❌              |
-| 309	  | getcpu	         | ❌              |
+| 309	  | getcpu	         | ✅              |
 | 310	  | process_vm_readv | ❌              |
 | 311	  | process_vm_writev | ❌              |
 | 312	  | kcmp             | ❌              |

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -26,6 +26,7 @@ use crate::syscall::{
     flock::sys_flock,
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
+    getcpu::sys_getcpu,
     getcwd::sys_getcwd,
     getdents64::sys_getdents64,
     getegid::sys_getegid,
@@ -225,6 +226,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRUSAGE = 165          => sys_getrusage(args[..2]);
     SYS_UMASK = 166              => sys_umask(args[..1]);
     SYS_PRCTL = 167              => sys_prctl(args[..5]);
+    SYS_GETCPU = 168             => sys_getcpu(args[..3]);
     SYS_GETTIMEOFDAY = 169       => sys_gettimeofday(args[..1]);
     SYS_GETPID = 172             => sys_getpid(args[..0]);
     SYS_GETPPID = 173            => sys_getppid(args[..0]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -29,6 +29,7 @@ use crate::syscall::{
     fork::sys_fork,
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
+    getcpu::sys_getcpu,
     getcwd::sys_getcwd,
     getdents64::{sys_getdents, sys_getdents64},
     getegid::sys_getegid,
@@ -314,6 +315,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PREADV = 295           => sys_preadv(args[..4]);
     SYS_PWRITEV = 296          => sys_pwritev(args[..4]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_GETCPU = 309           => sys_getcpu(args[..3]);
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
     SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut user_ctx);
     SYS_PREADV2 = 327          => sys_preadv2(args[..5]);

--- a/kernel/src/syscall/getcpu.rs
+++ b/kernel/src/syscall/getcpu.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{cpu::PinCurrentCpu, task::disable_preempt};
+
+use super::SyscallReturn;
+use crate::prelude::*;
+
+pub fn sys_getcpu(cpu: Vaddr, node: Vaddr, _tcache: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
+    // The third argument tcache is unused after Linux 2.6.24 so we ignore it
+    let preempt_guard = disable_preempt();
+    let cpuid = preempt_guard.current_cpu();
+    drop(preempt_guard);
+    debug!(
+        "getcpu: cpuid = {}, total_cpus = {}",
+        cpuid.as_usize(),
+        ostd::cpu::num_cpus()
+    );
+    // Since cpu and node can be NULL, we need to check them before writing
+    if cpu != 0 {
+        ctx.user_space()
+            .write_val::<usize>(cpu, &cpuid.as_usize())?;
+    }
+    if node != 0 {
+        ctx.user_space().write_val::<usize>(node, &0)?; // TODO: NUMA is not supported
+    }
+    Ok(SyscallReturn::Return(0))
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -37,6 +37,7 @@ mod flock;
 mod fork;
 mod fsync;
 mod futex;
+mod getcpu;
 mod getcwd;
 mod getdents64;
 mod getegid;

--- a/test/apps/Makefile
+++ b/test/apps/Makefile
@@ -23,6 +23,7 @@ TEST_APPS := \
 	file_io \
 	fork \
 	fork_c \
+	getcpu \
 	getpid \
 	hello_c \
 	hello_pie \

--- a/test/apps/getcpu/Makefile
+++ b/test/apps/getcpu/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/apps/getcpu/getcpu.c
+++ b/test/apps/getcpu/getcpu.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+int main()
+{
+	unsigned int cpu, node;
+
+	// Directly test the getcpu syscall because glibc's getcpu() may not
+	// use the getcpu syscall to retrieve CPU info
+	long ret = syscall(SYS_getcpu, &cpu, &node, NULL);
+	if (ret != 0) {
+		perror("syscall getcpu");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("getcpu syscall: cpu = %u, node = %u\n", cpu, node);
+
+	return 0;
+}


### PR DESCRIPTION
according to: https://man7.org/linux/man-pages/man2/getcpu.2.html

```c
int getcpu(unsigned int *cpu, unsigned int *node,
           struct getcpu_cache *tcache); // The tcache argument is unused since Linux 2.6.24
```

TODO: NUMA is not supported