### PR TITLE
Add buffer size validation to prevent overflow in syscall getdents

### DIFF
--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -28,6 +28,11 @@ pub fn sys_getdents(
     if inode_handle.dentry().type_() != InodeType::Dir {
         return_errno!(Errno::ENOTDIR);
     }
+
+    const MAX_GETDENTS_BUF_SIZE: usize = ((i32::MAX as usize) & !(0xFFF)) >> 1;
+    if buf_len > MAX_GETDENTS_BUF_SIZE {
+        return_errno_with_message!(Errno::EINVAL, "count is too large");
+    }
     let mut buffer = vec![0u8; buf_len];
     let mut reader = DirentBufferReader::<Dirent>::new(&mut buffer); // Use the non-64-bit reader
     let _ = inode_handle.readdir(&mut reader)?;
@@ -53,6 +58,11 @@ pub fn sys_getdents64(
     let inode_handle = file.as_inode_or_err()?;
     if inode_handle.dentry().type_() != InodeType::Dir {
         return_errno!(Errno::ENOTDIR);
+    }
+
+    const MAX_GETDENTS_BUF_SIZE: usize = ((i32::MAX as usize) & !(0xFFF)) >> 1;
+    if buf_len > MAX_GETDENTS_BUF_SIZE {
+        return_errno_with_message!(Errno::EINVAL, "count is too large");
     }
     let mut buffer = vec![0u8; buf_len];
     let mut reader = DirentBufferReader::<Dirent64>::new(&mut buffer);


### PR DESCRIPTION
A problem found by Trinity.
```
================
[    22.067] ERROR: Uncaught panic:
	Heap allocation error, layout = Layout { size: 2147479551, align: 1 (1 << 0) }
	at /root/asterinas/ostd/src/mm/heap_allocator/mod.rs:26
	on CPU 0 by thread Some(Thread { task: (Weak), data: Any { .. }, status: AtomicThreadStatus(1), cpu_affinity: AtomicCpuSet { bits: [1] }, sched_attr: SchedAttr { policy: SchedPolicyState { kind: AtomicSchedPolicyKind(2), policy: UnsafeCell { .. } }, last_cpu: AtomicCpuId(0), real_time: RealTimeAttr { prio: 99, time_slice: 31698980 }, fair: FairAttr { weight: 1024, vruntime: 123897735 } } })
Printing stack trace:
   1: fn 0xffffffff88808eb0 - pc 0xffffffff88808f1a / registers:

     rax                0x1; rdx                0x8; rcx                0x0; rbx                0x0;
     rsi 0xffffffff887a2006; rdi 0xffffffff88839da7; rbp                0x0; rsp 0xffffdfffffd7fca0;

   2: fn 0xffffffff8804bcc0 - pc 0xffffffff8804cc49 / registers:


```
Related to [issue 1605](https://github.com/asterinas/asterinas/issues/1605)

Poc of the error:
```
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/syscall.h>
#include <unistd.h>
#include <fcntl.h>
#include <errno.h>
#include <dirent.h>  // 提供 DT_REG, DT_DIR, DT_LNK 等定义
#include <errno.h>

// 手动定义 linux_dirent 结构
struct linux_dirent {
    unsigned long  d_ino;     // inode 号
    off_t          d_off;     // 偏移量
    unsigned short d_reclen;  // 记录长度
    char           d_name[];  // 文件名 (null-terminated)
};

// 定义缓冲区大小
#define BUF_SIZE 102400000

int main(int argc, char *argv[]) {
    int fd;
    long nread;
    char buf[1024];
    struct linux_dirent *d;
    char d_type;
    
    // 检查命令行参数
    if (argc != 2) {
        printf("用法: %s <目录路径>\n", argv[0]);
        exit(EXIT_FAILURE);
    }

    // 打开目录
    fd = open(argv[1], O_RDONLY | O_DIRECTORY);
    if (fd == -1) {
        perror("打开目录失败");
        exit(EXIT_FAILURE);
    }

    printf("目录内容:\n");
    printf("================\n");

    // 使用 getdents 系统调用读取目录项
    while (1) {
        nread = syscall(SYS_getdents, fd, buf, BUF_SIZE);

        if (nread == -1) {
            perror("getdents 调用失败");
            exit(EXIT_FAILURE);
        }

        // 当 nread 为 0 时表示读取完毕
        if (nread == 0)
            break;

        // 处理读取到的目录项
        for (long bpos = 0; bpos < nread;) {
            d = (struct linux_dirent *)(buf + bpos);
            
            // 获取文件类型
            d_type = *(buf + bpos + d->d_reclen - 1);
            
            // 打印目录项信息
            printf("文件名: %-20s | inode: %ld | 类型: ", 
                   d->d_name, 
                   (long)d->d_ino);
            
            // 根据文件类型打印
            switch (d_type) {
                case DT_REG: printf("普通文件\n"); break;
                case DT_DIR: printf("目录\n"); break;
                case DT_LNK: printf("符号链接\n"); break;
                default: printf("其他类型\n"); break;
            }
            
            bpos += d->d_reclen;
        }
    }

    // 关闭目录
    close(fd);
    printf("================\n");
    printf("读取完成\n");

    return 0;
}
```