### PR TITLE
Fix lint errors 

### DIFF
--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -146,7 +146,7 @@ impl ConfigManager<VirtioBlockConfig> {
         let cap_high = self
             .read_once::<u32>(offset_of!(VirtioBlockConfig, capacity) + 4)
             .unwrap() as u64;
-        blk_config.capacity = cap_high << 32 | cap_low;
+        blk_config.capacity = (cap_high << 32) | cap_low;
         blk_config.size_max = self
             .read_once::<u32>(offset_of!(VirtioBlockConfig, size_max))
             .unwrap();
@@ -193,7 +193,7 @@ impl ConfigManager<VirtioBlockConfig> {
             .read_once::<u32>(offset_of!(VirtioBlockConfig, capacity) + 4)
             .unwrap() as usize;
 
-        cap_high << 32 | cap_low
+        (cap_high << 32) | cap_low
     }
 }
 

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -264,7 +264,7 @@ impl EventTable {
         let segment = FrameAllocOptions::new().alloc_segment(1).unwrap();
 
         let default_event = VirtioInputEvent::default();
-        let iter = iter::repeat(&default_event).take(EVENT_SIZE);
+        let iter = iter::repeat_n(&default_event, EVENT_SIZE);
         let nr_written = segment.write_vals(0, iter, 0).unwrap();
         assert_eq!(nr_written, EVENT_SIZE);
 

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -53,10 +53,10 @@ impl SocketDevice {
         let guest_cid = field_ptr!(&virtio_vsock_config, VirtioVsockConfig, guest_cid_low)
             .read_once()
             .unwrap() as u64
-            | (field_ptr!(&virtio_vsock_config, VirtioVsockConfig, guest_cid_high)
+            | ((field_ptr!(&virtio_vsock_config, VirtioVsockConfig, guest_cid_high)
                 .read_once()
                 .unwrap() as u64)
-                << 32;
+                << 32);
 
         let mut recv_queue = VirtQueue::new(QUEUE_RECV, QUEUE_SIZE, transport.as_mut())
             .expect("creating recv queue fails");

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -225,7 +225,7 @@ impl VirtioTransport for VirtioMmioTransport {
         let device_feature_high = field_ptr!(&self.layout, VirtioMmioLayout, device_features)
             .read_once()
             .unwrap() as u64;
-        device_feature_high << 32 | device_feature_low as u64
+        (device_feature_high << 32) | device_feature_low as u64
     }
 
     fn write_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -163,7 +163,7 @@ impl VirtioTransport for VirtioPciModernTransport {
         let device_feature_high = field_ptr!(&self.common_cfg, VirtioPciCommonCfg, device_features)
             .read_once()
             .unwrap() as u64;
-        device_feature_high << 32 | device_feature_low as u64
+        (device_feature_high << 32) | device_feature_low as u64
     }
 
     fn write_driver_features(&mut self, features: u64) -> Result<(), VirtioTransportError> {

--- a/kernel/libs/comp-sys/cargo-component/analysis/src/conf.rs
+++ b/kernel/libs/comp-sys/cargo-component/analysis/src/conf.rs
@@ -70,8 +70,8 @@ impl Config {
 
     /// ensure the config to be valid. We will check three things.
     /// 1. The component ident and library name(The last segment of component path) cannot be duplicate.
-    /// 2. The controlled type in whilelist should be in one of defined components.
-    /// 3. The components in whilelist should be defined.
+    /// 2. The controlled type in whitelist should be in one of defined components.
+    /// 3. The components in whitelist should be defined.
     pub fn check_config(&self) {
         let mut component_idents = HashSet::new();
         let mut lib_names = HashSet::new();
@@ -89,14 +89,14 @@ impl Config {
             lib_names.insert(lib_name);
         }
 
-        for (type_, whilelist) in &self.whitelists {
+        for (type_, whitelist) in &self.whitelists {
             // check 2
             let component_ident = type_.iter().nth(0).unwrap();
             if !component_idents.contains(component_ident) {
                 panic!("The controlled type is not in any component.");
             }
             // check 3
-            for (component_name, _) in whilelist.iter() {
+            for (component_name, _) in whitelist.iter() {
                 if !component_idents.contains(component_name) {
                     panic!("The component in whitelist is not defined");
                 }

--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -27,7 +27,7 @@ use crate::{
 
 const BUFFER_CAPACITY: usize = 4096;
 
-/// Pesudo terminal master.
+/// Pseudo terminal master.
 /// Internally, it has two buffers.
 /// One is inside ldisc, which is written by master and read by slave,
 /// the other is a ring buffer, which is written by slave and read by master.

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -1067,8 +1067,8 @@ impl ExfatInode {
     }
 }
 
-struct EmptyVistor;
-impl DirentVisitor for EmptyVistor {
+struct EmptyVisitor;
+impl DirentVisitor for EmptyVisitor {
     fn visit(&mut self, name: &str, ino: u64, type_: InodeType, offset: usize) -> Result<()> {
         Ok(())
     }
@@ -1458,7 +1458,7 @@ impl Inode for ExfatInode {
             return Ok(0);
         }
 
-        let mut empty_visitor = EmptyVistor;
+        let mut empty_visitor = EmptyVisitor;
 
         let dir_read = {
             let fs = inner.fs();

--- a/kernel/src/fs/utils/range_lock/mod.rs
+++ b/kernel/src/fs/utils/range_lock/mod.rs
@@ -182,7 +182,7 @@ impl Clone for RangeLockItem {
 /// Rule of ordering:
 /// Locks are sorted by owner process, then by the starting offset.
 ///
-/// Rule of mergeing:
+/// Rule of merging:
 /// Adjacent and overlapping locks with same owner and type will be merged.
 ///
 /// Rule of updating:

--- a/osdk/src/commands/new/rust-toolchain.toml.template
+++ b/osdk/src/commands/new/rust-toolchain.toml.template
@@ -1,5 +1,5 @@
 # One should also update asterinas/rust-toolchain.toml when updating this.
 # The first two lines will be deleted when generating the user's toolchain file.
 [toolchain]
-channel = "nightly-2024-11-29"
+channel = "nightly-2025-02-01"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/osdk/src/commands/run.rs
+++ b/osdk/src/commands/run.rs
@@ -139,7 +139,7 @@ mod gdb {
         Tcp,  // IP_ADDR:PORT
     }
     pub fn stub_type_of(stub: &str) -> StubAddrType {
-        if stub.split(':').last().unwrap().parse::<u16>().is_ok() {
+        if stub.split(':').next_back().unwrap().parse::<u16>().is_ok() {
             return StubAddrType::Tcp;
         }
         StubAddrType::Unix

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/paging.rs
@@ -185,7 +185,7 @@ impl PageTableCreator {
 impl Ia32eTable {
     fn index(&mut self, level: usize, va: u64) -> &mut Ia32eEntry {
         debug_assert!((1..=5).contains(&level));
-        let index = va as usize >> (12 + 9 * (level - 1)) & (TABLE_ENTRY_COUNT - 1);
+        let index = (va as usize >> (12 + 9 * (level - 1))) & (TABLE_ENTRY_COUNT - 1);
         &mut self.0[index]
     }
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -150,15 +150,15 @@ impl PageTableEntryTrait for PageTableEntry {
     }
 
     fn prop(&self) -> PageProperty {
-        let flags = parse_flags!(self.0, PageTableFlags::READABLE, PageFlags::R)
-            | parse_flags!(self.0, PageTableFlags::WRITABLE, PageFlags::W)
-            | parse_flags!(self.0, PageTableFlags::EXECUTABLE, PageFlags::X)
-            | parse_flags!(self.0, PageTableFlags::ACCESSED, PageFlags::ACCESSED)
-            | parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY)
-            | parse_flags!(self.0, PageTableFlags::RSV1, PageFlags::AVAIL1)
-            | parse_flags!(self.0, PageTableFlags::RSV2, PageFlags::AVAIL2);
-        let priv_flags = parse_flags!(self.0, PageTableFlags::USER, PrivFlags::USER)
-            | parse_flags!(self.0, PageTableFlags::GLOBAL, PrivFlags::GLOBAL);
+        let flags = (parse_flags!(self.0, PageTableFlags::READABLE, PageFlags::R))
+            | (parse_flags!(self.0, PageTableFlags::WRITABLE, PageFlags::W))
+            | (parse_flags!(self.0, PageTableFlags::EXECUTABLE, PageFlags::X))
+            | (parse_flags!(self.0, PageTableFlags::ACCESSED, PageFlags::ACCESSED))
+            | (parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY))
+            | (parse_flags!(self.0, PageTableFlags::RSV1, PageFlags::AVAIL1))
+            | (parse_flags!(self.0, PageTableFlags::RSV2, PageFlags::AVAIL2));
+        let priv_flags = (parse_flags!(self.0, PageTableFlags::USER, PrivFlags::USER))
+            | (parse_flags!(self.0, PageTableFlags::GLOBAL, PrivFlags::GLOBAL));
 
         let cache = if self.0 & PageTableFlags::PBMT_IO.bits() != 0 {
             CachePolicy::Uncacheable

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -112,7 +112,7 @@ fn parse_memory_regions(mb1_info: &MultibootLegacyInfo) -> MemoryRegionArray {
     regions
         .push(MemoryRegion::new(
             fb.address,
-            (fb.width * fb.height * fb.bpp + 7) / 8, // round up when divide with 8 (bits/Byte)
+            (fb.width * fb.height * fb.bpp).div_ceil(8), // round up when divide with 8 (bits/Byte)
             MemoryRegionType::Framebuffer,
         ))
         .unwrap();

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -116,7 +116,7 @@ fn parse_memory_regions() -> MemoryRegionArray {
         regions
             .push(MemoryRegion::new(
                 fb.address,
-                (fb.width * fb.height * fb.bpp + 7) / 8, // round up when divide with 8 (bits/Byte)
+                (fb.width * fb.height * fb.bpp).div_ceil(8), // round up when divide with 8 (bits/Byte)
                 MemoryRegionType::Framebuffer,
             ))
             .unwrap();

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
@@ -159,7 +159,7 @@ impl IrtEntry {
     /// Enables this entry with no validation,
     /// DST = 0, IM = 0, DLM = 0, TM = 0, RH = 0, DM = 0, FPD = 1, P = 1
     pub fn enable_default(&mut self, vector: u32) {
-        self.0 = 0b11 | (vector as u128) << 16;
+        self.0 = 0b11 | ((vector as u128) << 16);
     }
 
     pub fn source_validation_type(&self) -> SourceValidationType {

--- a/ostd/src/arch/x86/kernel/apic/mod.rs
+++ b/ostd/src/arch/x86/kernel/apic/mod.rs
@@ -183,12 +183,12 @@ impl Icr {
             ApicId::X2Apic(d) => (d as u64) << 32,
         };
         Icr(dest
-            | (destination_shorthand as u64) << 18
-            | (trigger_mode as u64) << 15
-            | (level as u64) << 14
-            | (delivery_status as u64) << 12
-            | (destination_mode as u64) << 11
-            | (delivery_mode as u64) << 8
+            | ((destination_shorthand as u64) << 18)
+            | ((trigger_mode as u64) << 15)
+            | ((level as u64) << 14)
+            | ((delivery_status as u64) << 12)
+            | ((destination_mode as u64) << 11)
+            | ((delivery_mode as u64) << 8)
             | (vector as u64))
     }
 
@@ -219,7 +219,7 @@ impl ApicId {
     /// Logical x2APIC ID = [(x2APIC ID[19:4] << 16) | (1 << x2APIC ID[3:0])]
     #[expect(unused)]
     pub fn x2apic_logical_id(&self) -> u32 {
-        self.x2apic_logical_cluster_id() << 16 | 1 << self.x2apic_logical_field_id()
+        (self.x2apic_logical_cluster_id() << 16) | (1 << self.x2apic_logical_field_id())
     }
 
     /// Returns the logical x2apic cluster ID.

--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -46,7 +46,7 @@ impl X2Apic {
             }
 
             // Set SVR, Enable APIC and set Spurious Vector to 15 (Reserved irq number)
-            let svr: u64 = 1 << 8 | 15;
+            let svr: u64 = (1 << 8) | 15;
             wrmsr(IA32_X2APIC_SIVR, svr);
         }
     }
@@ -73,7 +73,7 @@ impl super::Apic for X2Apic {
         wrmsr(IA32_X2APIC_ICR, icr.0);
         loop {
             let icr = rdmsr(IA32_X2APIC_ICR);
-            if (icr >> 12 & 0x1) == 0 {
+            if ((icr >> 12) & 0x1) == 0 {
                 break;
             }
             if rdmsr(IA32_X2APIC_ESR) > 0 {

--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -50,7 +50,7 @@ impl XApic {
         set_apic_base_address(get_apic_base_address());
 
         // Set SVR, Enable APIC and set Spurious Vector to 15 (Reserved irq number)
-        let svr: u32 = 1 << 8 | 15;
+        let svr: u32 = (1 << 8) | 15;
         self.write(xapic::XAPIC_SVR, svr);
     }
 
@@ -83,7 +83,7 @@ impl super::Apic for XApic {
         self.write(xapic::XAPIC_ICR0, icr.lower());
         loop {
             let icr = self.read(xapic::XAPIC_ICR0);
-            if (icr >> 12 & 0x1) == 0 {
+            if ((icr >> 12) & 0x1) == 0 {
                 break;
             }
             if self.read(xapic::XAPIC_ESR) > 0 {

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -198,18 +198,18 @@ impl PageTableEntryTrait for PageTableEntry {
     }
 
     fn prop(&self) -> PageProperty {
-        let flags = parse_flags!(self.0, PageTableFlags::PRESENT, PageFlags::R)
-            | parse_flags!(self.0, PageTableFlags::WRITABLE, PageFlags::W)
-            | parse_flags!(!self.0, PageTableFlags::NO_EXECUTE, PageFlags::X)
-            | parse_flags!(self.0, PageTableFlags::ACCESSED, PageFlags::ACCESSED)
-            | parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY)
-            | parse_flags!(self.0, PageTableFlags::HIGH_IGN1, PageFlags::AVAIL1)
-            | parse_flags!(self.0, PageTableFlags::HIGH_IGN2, PageFlags::AVAIL2);
-        let priv_flags = parse_flags!(self.0, PageTableFlags::USER, PrivFlags::USER)
-            | parse_flags!(self.0, PageTableFlags::GLOBAL, PrivFlags::GLOBAL);
+        let flags = (parse_flags!(self.0, PageTableFlags::PRESENT, PageFlags::R))
+            | (parse_flags!(self.0, PageTableFlags::WRITABLE, PageFlags::W))
+            | (parse_flags!(!self.0, PageTableFlags::NO_EXECUTE, PageFlags::X))
+            | (parse_flags!(self.0, PageTableFlags::ACCESSED, PageFlags::ACCESSED))
+            | (parse_flags!(self.0, PageTableFlags::DIRTY, PageFlags::DIRTY))
+            | (parse_flags!(self.0, PageTableFlags::HIGH_IGN1, PageFlags::AVAIL1))
+            | (parse_flags!(self.0, PageTableFlags::HIGH_IGN2, PageFlags::AVAIL2));
+        let priv_flags = (parse_flags!(self.0, PageTableFlags::USER, PrivFlags::USER))
+            | (parse_flags!(self.0, PageTableFlags::GLOBAL, PrivFlags::GLOBAL));
         #[cfg(feature = "cvm_guest")]
         let priv_flags =
-            priv_flags | parse_flags!(self.0, PageTableFlags::SHARED, PrivFlags::SHARED);
+            priv_flags | (parse_flags!(self.0, PageTableFlags::SHARED, PrivFlags::SHARED));
         let cache = if self.0 & PageTableFlags::NO_CACHE.bits() != 0 {
             CachePolicy::Uncacheable
         } else if self.0 & PageTableFlags::WRITE_THROUGH.bits() != 0 {
@@ -229,35 +229,35 @@ impl PageTableEntryTrait for PageTableEntry {
             return;
         }
         let mut flags = PageTableFlags::empty().bits();
-        flags |= parse_flags!(prop.flags.bits(), PageFlags::R, PageTableFlags::PRESENT)
-            | parse_flags!(prop.flags.bits(), PageFlags::W, PageTableFlags::WRITABLE)
-            | parse_flags!(!prop.flags.bits(), PageFlags::X, PageTableFlags::NO_EXECUTE)
-            | parse_flags!(
+        flags |= (parse_flags!(prop.flags.bits(), PageFlags::R, PageTableFlags::PRESENT))
+            | (parse_flags!(prop.flags.bits(), PageFlags::W, PageTableFlags::WRITABLE))
+            | (parse_flags!(!prop.flags.bits(), PageFlags::X, PageTableFlags::NO_EXECUTE))
+            | (parse_flags!(
                 prop.flags.bits(),
                 PageFlags::ACCESSED,
                 PageTableFlags::ACCESSED
-            )
-            | parse_flags!(prop.flags.bits(), PageFlags::DIRTY, PageTableFlags::DIRTY)
-            | parse_flags!(
+            ))
+            | (parse_flags!(prop.flags.bits(), PageFlags::DIRTY, PageTableFlags::DIRTY))
+            | (parse_flags!(
                 prop.flags.bits(),
                 PageFlags::AVAIL1,
                 PageTableFlags::HIGH_IGN1
-            )
-            | parse_flags!(
+            ))
+            | (parse_flags!(
                 prop.flags.bits(),
                 PageFlags::AVAIL2,
                 PageTableFlags::HIGH_IGN2
-            )
-            | parse_flags!(
+            ))
+            | (parse_flags!(
                 prop.priv_flags.bits(),
                 PrivFlags::USER,
                 PageTableFlags::USER
-            )
-            | parse_flags!(
+            ))
+            | (parse_flags!(
                 prop.priv_flags.bits(),
                 PrivFlags::GLOBAL,
                 PageTableFlags::GLOBAL
-            );
+            ));
         #[cfg(feature = "cvm_guest")]
         {
             flags |= parse_flags!(

--- a/ostd/src/arch/x86/timer/hpet.rs
+++ b/ostd/src/arch/x86/timer/hpet.rs
@@ -31,7 +31,7 @@ const HPET_FREQ: usize = 1_000_000_000_000_000;
 #[repr(C)]
 struct HpetTimerRegister {
     configuration_and_capabilities_register: u32,
-    timer_compartor_value_register: u32,
+    timer_comparator_value_register: u32,
     fsb_interrupt_route_register: u32,
 }
 

--- a/ostd/src/arch/x86/timer/pit.rs
+++ b/ostd/src/arch/x86/timer/pit.rs
@@ -168,8 +168,8 @@ pub(crate) fn init(operating_mode: OperatingMode) {
     // Bit 0 is BCD/binary mode, which is always set to binary mode(value: 0)
     MODE_COMMAND_PORT.write(
         ((operating_mode as u8) << 1)
-            | (AccessMode::LowAndHighByte as u8) << 4
-            | (Channel::Channel0 as u8) << 6,
+            | ((AccessMode::LowAndHighByte as u8) << 4)
+            | ((Channel::Channel0 as u8) << 6),
     );
 
     // Set timer frequency

--- a/ostd/src/bus/pci/device_info.rs
+++ b/ostd/src/bus/pci/device_info.rs
@@ -141,7 +141,7 @@ impl PciDeviceLocation {
         let mask = (0xFF << dest) as u32;
         self.write32(
             offset & Self::BIT32_ALIGN_MASK,
-            ((val as u32) << dest | (old & !mask)).to_le(),
+            (((val as u32) << dest) | (old & !mask)).to_le(),
         );
     }
 
@@ -151,7 +151,7 @@ impl PciDeviceLocation {
         let mask = (0xFFFF << dest) as u32;
         self.write32(
             offset & Self::BIT32_ALIGN_MASK,
-            ((val as u32) << dest | (old & !mask)).to_le(),
+            (((val as u32) << dest) | (old & !mask)).to_le(),
         );
     }
 

--- a/ostd/src/logger.rs
+++ b/ostd/src/logger.rs
@@ -90,7 +90,7 @@ fn get_log_level() -> Option<LevelFilter> {
     let value = kcmdline
         .split(' ')
         .find(|arg| arg.starts_with("ostd.log_level="))
-        .map(|arg| arg.split('=').last().unwrap_or_default())?;
+        .map(|arg| arg.split('=').next_back().unwrap_or_default())?;
 
     LevelFilter::from_str(value).ok()
 }

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -73,7 +73,7 @@ const fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize {
 
 /// The index of a VA's PTE in a page table node at the given level.
 const fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> usize {
-    va >> (C::BASE_PAGE_SIZE.ilog2() as usize + nr_pte_index_bits::<C>() * (level as usize - 1))
+    (va >> (C::BASE_PAGE_SIZE.ilog2() as usize + nr_pte_index_bits::<C>() * (level as usize - 1)))
         & (nr_subpage_per_huge::<C>() - 1)
 }
 


### PR DESCRIPTION
This PR fixes the lint [failure](https://github.com/asterinas/asterinas/actions/runs/13556607484/job/37894488112). The clippy tool is stricter now.

This pull request includes several changes to improve code readability and fix minor errors in various files. The most important changes include adding parentheses for clarity in bitwise operations, correcting typographical errors, and updating method calls for consistency.

1. Code readability improvements: Added parentheses around bitwise operations to ensure clarity.
2. Typographical corrections.
3. Method call updates:
* [`kernel/comps/virtio/src/device/input/device.rs`](diffhunk://#diff-b10c9beaa6f40bf9e226f8e0bbd5ed3fd60dca5cb4f384bf5c7a2ba7f86ece4fL267-R267): Replaced `iter::repeat` with `iter::repeat_n` for creating repeated elements in `EventTable`.
* `ostd/src/arch/x86/boot/multiboot/mod.rs` and `ostd/src/arch/x86/boot/multiboot2/mod.rs`: Replaced manual division and rounding with `div_ceil` method for calculating framebuffer size. 