### PR TITLE
Make the IRQ state within the trap correct

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ Inh  = "Inh"
 DELET = "DELET"
 wrk = "wrk"
 rto = "rto"
+typ = "typ"
 
 # Files with svg suffix are ignored to check. 
 [type.svg]


### PR DESCRIPTION
There is no need to disable the IRQ during handling the trap exception if the IRQ was enabled before entering the trap, like Linux: https://github.com/torvalds/linux/blob/dd83757f6e686a2188997cb58b5975f744bb7786/arch/x86/kernel/traps.c#L216C3-L216C24.