### PR TITLE
Fix the typo CI failure

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ Inh  = "Inh"
 DELET = "DELET"
 wrk = "wrk"
 rto = "rto"
+typ = "typ"
 
 # Files with svg suffix are ignored to check. 
 [type.svg]


### PR DESCRIPTION
I suspect that due to the update of the typo checker, some recent CI runs failed. But locally it works. So I want to run CI for testing. Forgive me about the noise.