### PR TITLE
Dynamically get the Commit SHA that triggers the workflow

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -220,3 +220,4 @@ jobs:
           chart-title: ${{ env.TITLE }}
           chart-description: ${{ env.DESCRIPTION }}
           summary-json-path: test/benchmark/${{ env.BENCHMARK_SUITE }}/summary.json
+          ref: ${{ github.sha }}


### PR DESCRIPTION
A workflow run ([#13618885402](https://github.com/asterinas/asterinas/actions/runs/13618885402)) triggered by commit [3025196](https://github.com/asterinas/asterinas/commit/30251964ee3d193dfb78cb00d8658d42d38f7fbf) generated a performance regression alert. However, the alert comment was incorrectly posted to an unrelated commit ([55ee4bd](https://github.com/asterinas/asterinas/commit/55ee4bda2c8bd31c2142d1b05f7e8098170ddb40#comments)). [Workflow logs](https://github.com/asterinas/asterinas/actions/runs/13618885402/job/38070692019#step:6:102) reveal the benchmark action failed to properly propagate the triggering commit SHA.

### Root Cause
 The workflow configuration lacked explicit commit SHA tracking when triggering subsequent benchmark actions, causing comment misplacement.

### Solution
 Add the field `ref` to `benchmark_asterinas.yaml` and explicitly pass the triggering commit SHA by:
```yaml
ref: ${{ github.sha }}
```

### Verification
 After implementing the fix:

- Triggered benchmark action with ref parameter
- Committed new changes to the branch
- Observed alert comment correctly posted on the original triggering commit ([Validation Run](https://github.com/grief8/asterinas/actions/runs/13626076594/job/38084343419#step:6:105))