### PR TITLE
Enhance the robustness of search pattern (lmbench)

### DIFF
--- a/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/bench_result.yaml
+++ b/test/benchmark/lmbench/ext2_create_delete_files_10k_ops/bench_result.yaml
@@ -8,4 +8,4 @@ chart:
   unit: number
 result_extraction:
   result_index: 2
-  search_pattern: ^0k\t[0-9]+
+  search_pattern: ^10k\t[0-9]+

--- a/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/bench_result.yaml
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/bench_result.yaml
@@ -8,4 +8,4 @@ chart:
   unit: number
 result_extraction:
   result_index: 2
-  search_pattern: 10k
+  search_pattern: ^10k\t[0-9]+


### PR DESCRIPTION
This pull request includes changes in two benchmark result YAML files to correct the `search_pattern` for extracting results.   Current patterns are not robust enough, see [1](https://github.com/asterinas/asterinas/actions/runs/13639528806/job/38126037733#step:6:16) and [2](https://github.com/asterinas/asterinas/actions/runs/13639528806/job/38126036664#step:6:16). 

Benchmark result YAML file updates:

* [`test/benchmark/lmbench/ext2_create_delete_files_10k_ops/bench_result.yaml`](diffhunk://#diff-afea088b44010b850beff3f958b1ba53e527746365356a7dc87296bffb218527L11-R11): Updated `search_pattern` from `^0k\t[0-9]+` to `^10k\t[0-9]+` to correctly match the expected pattern.
* [`test/benchmark/lmbench/ramfs_create_delete_files_10k_ops/bench_result.yaml`](diffhunk://#diff-86620cda4d353c4217642d757ca8be66fd6af4e75cb67019ea488745e12b1e10L11-R11): Updated `search_pattern` from `10k` to `^10k\t[0-9]+` to ensure accurate pattern matching.