### PR TITLE
Drop incomplete `generic_const_exprs` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "ostd",
  "smoltcp",
  "spin",
- "static_assertions",
  "takeable",
 ]
 
@@ -100,7 +99,6 @@ dependencies = [
  "log",
  "ostd",
  "spin",
- "static_assertions",
 ]
 
 [[package]]
@@ -162,7 +160,6 @@ dependencies = [
  "ostd-pod",
  "postcard",
  "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -219,7 +216,6 @@ dependencies = [
  "rand",
  "riscv",
  "spin",
- "static_assertions",
  "takeable",
  "tdx-guest",
  "time",
@@ -1296,7 +1292,6 @@ dependencies = [
  "sbi-rt",
  "smallvec",
  "spin",
- "static_assertions",
  "tdx-guest",
  "unwinding",
  "volatile 0.6.1",
@@ -1631,12 +1626,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-assert"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8298db53081b3a951cadb6e0f4ebbe36def7bcb591a34676708d0d7ac87dd86"
-
-[[package]]
 name = "controlled"
 version = "0.1.0"
 dependencies = [
@@ -1282,7 +1276,6 @@ dependencies = [
  "bitflags 1.3.2",
  "buddy_system_allocator",
  "cfg-if",
- "const-assert",
  "fdt",
  "gimli 0.28.1",
  "iced-x86",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -52,7 +52,6 @@ rand = { version = "0.8.5", default-features = false, features = [
     "small_rng",
     "std_rng",
 ] }
-static_assertions = "1.1.0"
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e" }
 getset = "0.1.2"
 takeable = "0.2.2"

--- a/kernel/comps/block/Cargo.toml
+++ b/kernel/comps/block/Cargo.toml
@@ -12,7 +12,6 @@ align_ext = { path = "../../../ostd/libs/align_ext" }
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
-static_assertions = "1.1.0"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [lints]

--- a/kernel/comps/block/src/id.rs
+++ b/kernel/comps/block/src/id.rs
@@ -5,8 +5,7 @@ use core::{
     ops::{Add, Sub},
 };
 
-use ostd::Pod;
-use static_assertions::const_assert;
+use ostd::{const_assert, Pod};
 
 /// The block index used in the filesystem.
 pub type Bid = BlockId<BLOCK_SIZE>;

--- a/kernel/comps/mlsdisk/Cargo.toml
+++ b/kernel/comps/mlsdisk/Cargo.toml
@@ -26,7 +26,6 @@ log = "0.4"
 lru = "0.12.3"
 postcard = "1.0.6"
 serde = { version = "1.0.192", default-features = false, features = ["alloc", "derive"] }
-static_assertions = "1.1.0"
 
 [lints]
 workspace = true

--- a/kernel/comps/mlsdisk/src/layers/0-bio/mod.rs
+++ b/kernel/comps/mlsdisk/src/layers/0-bio/mod.rs
@@ -2,12 +2,12 @@
 
 //! The layer of untrusted block I/O.
 
-use static_assertions::assert_eq_size;
-
 mod block_buf;
 mod block_log;
 mod block_ring;
 mod block_set;
+
+use ostd::const_assert;
 
 pub use self::{
     block_buf::{Buf, BufMut, BufRef},
@@ -20,5 +20,5 @@ pub type BlockId = usize;
 pub const BLOCK_SIZE: usize = 0x1000;
 pub const BID_SIZE: usize = core::mem::size_of::<BlockId>();
 
-// This definition of BlockId assumes the target architecture is 64-bit
-assert_eq_size!(usize, u64);
+// This definition of `BlockId` assumes the target architecture is 64-bit.
+const_assert!(BID_SIZE == 8);

--- a/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_log.rs
+++ b/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_log.rs
@@ -3,9 +3,9 @@
 use alloc::vec;
 use core::{any::Any, mem::size_of};
 
+use ostd::const_assert;
 use ostd_pod::Pod;
 use serde::{Deserialize, Serialize};
-use static_assertions::const_assert;
 
 use super::{Iv, Key, Mac};
 use crate::{

--- a/kernel/comps/virtio/src/device/socket/config.rs
+++ b/kernel/comps/virtio/src/device/socket/config.rs
@@ -2,7 +2,7 @@
 
 use aster_util::safe_ptr::SafePtr;
 use bitflags::bitflags;
-use ostd::{io_mem::IoMem, Pod};
+use ostd::{io_mem::IoMem, mm::PodOnce, Pod};
 
 use crate::transport::VirtioTransport;
 
@@ -31,6 +31,8 @@ pub struct VirtioVsockConfig {
     pub guest_cid_low: u32,
     pub guest_cid_high: u32,
 }
+
+impl PodOnce for VirtioVsockConfig {}
 
 impl VirtioVsockConfig {
     pub(crate) fn new(transport: &dyn VirtioTransport) -> SafePtr<Self, IoMem> {

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -13,7 +13,7 @@ use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use log::debug;
 use ostd::{
-    mm::{DmaCoherent, FrameAllocOptions},
+    mm::{DmaCoherent, FrameAllocOptions, PodOnce},
     offset_of, Pod,
 };
 
@@ -445,6 +445,8 @@ bitflags! {
     }
 }
 
+impl PodOnce for DescFlags {}
+
 /// The driver uses the available ring to offer buffers to the device:
 /// each ring entry refers to the head of a descriptor chain.
 /// It is only written by the driver and read by the device.
@@ -487,3 +489,5 @@ bitflags! {
         const VIRTQ_AVAIL_F_NO_INTERRUPT = 1;
     }
 }
+
+impl PodOnce for AvailFlags {}

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -19,7 +19,6 @@ smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f0
     "socket-tcp",
 ] }
 spin = "0.9.4"
-static_assertions = "1.1.0"
 takeable = "0.2.2"
 
 [lints]

--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -7,8 +7,8 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::net::Ipv4Addr;
 
 use jhash::{jhash_1vals, jhash_3vals};
+use ostd::const_assert;
 use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
-use static_assertions::const_assert;
 
 use crate::{
     ext::Ext,

--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use id_alloc::IdAlloc;
-use ostd::mm::UntypedMem;
+use ostd::{const_assert, mm::UntypedMem};
 
 use super::{
     block_ptr::Ext2Bid,

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -7,7 +7,7 @@ use alloc::{borrow::ToOwned, rc::Rc};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use inherit_methods_macro::inherit_methods;
-use ostd::mm::UntypedMem;
+use ostd::{const_assert, mm::UntypedMem};
 
 use super::{
     block_ptr::{BidPath, BlockPtrs, Ext2Bid, BID_SIZE, MAX_BLOCK_PTRS},

--- a/kernel/src/fs/ext2/prelude.rs
+++ b/kernel/src/fs/ext2/prelude.rs
@@ -16,7 +16,6 @@ pub(super) use ostd::{
     mm::{Frame, FrameAllocOptions, Segment, USegment, VmIo},
     sync::{RwMutex, RwMutexReadGuard, RwMutexWriteGuard},
 };
-pub(super) use static_assertions::const_assert;
 
 pub(super) use super::utils::{Dirty, IsPowerOf};
 pub(super) use crate::{

--- a/kernel/src/fs/ext2/super_block.rs
+++ b/kernel/src/fs/ext2/super_block.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::const_assert;
+
 use super::{inode::RawInode, prelude::*};
 
 /// The magic number of Ext2.

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -20,7 +20,6 @@ bit_field = "0.10.1"
 buddy_system_allocator = { version = "0.10", default-features = false, features = ["alloc"] }
 bitflags = "1.3"
 cfg-if = "1.0"
-const-assert = "1.0"
 gimli = { version = "0.28", default-features = false, features = ["read-core"] }
 id-alloc = { path = "libs/id-alloc", version = "0.1.0" }
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e", version = "0.1.0" }

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -35,7 +35,6 @@ ostd-test = { version = "0.11.3", path = "libs/ostd-test" }
 ostd-pod = { git = "https://github.com/asterinas/ostd-pod", rev = "c4644be", version = "0.1.1" }
 spin = "0.9.4"
 smallvec = "1.13.2"
-static_assertions = "1.1.0"
 unwinding = { version = "0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = "0.6.1"
 xarray = { git = "https://github.com/asterinas/xarray", version = "0.1.0" }

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -8,7 +8,7 @@ use crate::{
     mm::{
         page_prop::{CachePolicy, PageFlags, PrivilegedPageFlags as PrivFlags},
         page_table::{PageTableEntryTrait, PageTableMode},
-        Paddr, PageProperty, PagingConstsTrait, PagingLevel, Vaddr,
+        Paddr, PageProperty, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
     },
     util::SameSizeAs,
     Pod,
@@ -77,6 +77,8 @@ impl PageTableEntry {
 
 // SAFETY: `PageTableEntry` has the same size as `usize` in our supported x86 architecture.
 unsafe impl SameSizeAs<usize> for PageTableEntry {}
+
+impl PodOnce for PageTableEntry {}
 
 impl PageTableEntryTrait for PageTableEntry {
     fn new_page(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     mm::{
         page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags as PrivFlags},
         page_table::PageTableEntryTrait,
-        Paddr, PagingConstsTrait, PagingLevel, Vaddr, PAGE_SIZE,
+        Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr, PAGE_SIZE,
     },
     util::SameSizeAs,
     Pod,
@@ -166,6 +166,8 @@ macro_rules! parse_flags {
 
 // SAFETY: `PageTableEntry` has the same size as `usize`
 unsafe impl SameSizeAs<usize> for PageTableEntry {}
+
+impl PodOnce for PageTableEntry {}
 
 impl PageTableEntryTrait for PageTableEntry {
     fn is_present(&self) -> bool {

--- a/ostd/src/cpu/set.rs
+++ b/ostd/src/cpu/set.rs
@@ -5,9 +5,9 @@
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use smallvec::SmallVec;
-use static_assertions::const_assert_eq;
 
 use super::{num_cpus, CpuId};
+use crate::const_assert;
 
 /// A subset of all CPUs in the system.
 #[derive(Clone, Debug, Default)]
@@ -159,7 +159,7 @@ pub struct AtomicCpuSet {
 }
 
 type AtomicInnerPart = AtomicU64;
-const_assert_eq!(core::mem::size_of::<AtomicInnerPart>() * 8, BITS_PER_PART);
+const_assert!(core::mem::size_of::<AtomicInnerPart>() * 8 == BITS_PER_PART);
 
 impl AtomicCpuSet {
     /// Creates a new `AtomicCpuSet` with an initial value.

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -24,7 +24,6 @@
 #![warn(missing_docs)]
 
 extern crate alloc;
-extern crate static_assertions;
 
 pub mod arch;
 pub mod boot;

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(core_intrinsics)]
 #![feature(coroutines)]
 #![feature(fn_traits)]
-#![feature(generic_const_exprs)]
 #![feature(iter_from_coroutine)]
 #![feature(let_chains)]
 #![feature(linkage)]
@@ -20,9 +19,6 @@
 #![feature(sync_unsafe_cell)]
 #![feature(trait_upcasting)]
 #![feature(iter_advance_by)]
-// The `generic_const_exprs` feature is incomplete however required for the page table
-// const generic implementation. We are using this feature in a conservative manner.
-#![expect(incomplete_features)]
 #![expect(internal_features)]
 #![no_std]
 #![warn(missing_docs)]

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -449,16 +449,8 @@ impl<M> Link<M> {
     }
 }
 
-// SAFETY: The size and alignment of `Link<M>` must be within the limits.
-// Also, if `M` is typed, `Link<M>` must not be untyped.
-//
-// FIXME: We would appreciate constant trait bounds very much, just like:
-// ```
-// Assert<{ core::mem::size_of::<Link<M>>() < FRAME_METADATA_MAX_SIZE }>: IsTrue,
-// Assert<{ core::mem::align_of::<Link<M>>() <= FRAME_METADATA_MAX_ALIGN }>: IsTrue,
-// ```
-// But due to the broken implementation of `generic_const_exprs` we can't do that.
-// It works for `M` that is declared inside OSTD but not for outside types.
+// SAFETY: If `M::on_drop` reads the page using the provided `VmReader`,
+// the safety is upheld by the one who implements `AnyFrameMeta` for `M`.
 unsafe impl<M> AnyFrameMeta for Link<M>
 where
     M: AnyFrameMeta,

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -49,11 +49,11 @@ use core::{
 
 use align_ext::AlignExt;
 use log::info;
-use static_assertions::const_assert_eq;
 
 use super::{allocator, Segment};
 use crate::{
     arch::mm::PagingConsts,
+    const_assert,
     mm::{
         kspace::LINEAR_MAPPING_BASE_VADDR, paddr_to_vaddr, page_size, page_table::boot_pt,
         CachePolicy, Infallible, Paddr, PageFlags, PageProperty, PrivilegedPageFlags, Vaddr,
@@ -124,8 +124,8 @@ pub(super) const REF_COUNT_MAX: u64 = i64::MAX as u64;
 
 type FrameMetaVtablePtr = core::ptr::DynMetadata<dyn AnyFrameMeta>;
 
-const_assert_eq!(PAGE_SIZE % META_SLOT_SIZE, 0);
-const_assert_eq!(size_of::<MetaSlot>(), META_SLOT_SIZE);
+const_assert!(PAGE_SIZE % META_SLOT_SIZE == 0);
+const_assert!(size_of::<MetaSlot>() == META_SLOT_SIZE);
 
 /// All frame metadata types must implement this trait.
 ///

--- a/ostd/src/mm/frame/untyped.rs
+++ b/ostd/src/mm/frame/untyped.rs
@@ -34,19 +34,12 @@ pub type UFrame = Frame<dyn AnyUFrameMeta>;
 
 /// Makes a structure usable as untyped frame metadata.
 ///
-/// Directly implementing [`AnyFrameMeta`] is not safe since the size and
-/// alignment must be checked. This macro provides a safe way to implement both
-/// [`AnyFrameMeta`] and [`AnyUFrameMeta`] with compile-time checks.
-///
 /// If this macro is used for built-in typed frame metadata, it won't compile.
 #[macro_export]
 macro_rules! impl_untyped_frame_meta_for {
     // Implement without specifying the drop behavior.
     ($t:ty) => {
-        use static_assertions::const_assert;
-        const_assert!(size_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_SIZE);
-        const_assert!(align_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_ALIGN);
-        // SAFETY: The size and alignment of the structure are checked.
+        // SAFETY: Untyped frames can be safely read.
         unsafe impl $crate::mm::frame::meta::AnyFrameMeta for $t {
             fn is_untyped(&self) -> bool {
                 true
@@ -56,12 +49,7 @@ macro_rules! impl_untyped_frame_meta_for {
     };
     // Implement with a customized drop function.
     ($t:ty, $body:expr) => {
-        use static_assertions::const_assert;
-        const_assert!(size_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_SIZE);
-        const_assert!(align_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_ALIGN);
-        // SAFETY: The size and alignment of the structure are checked.
-        // Outside OSTD the user cannot implement a `on_drop` method for typed
-        // frames. And untyped frames can be safely read.
+        // SAFETY: Untyped frames can be safely read.
         unsafe impl $crate::mm::frame::meta::AnyFrameMeta for $t {
             fn on_drop(&mut self, reader: &mut $crate::mm::VmReader<$crate::mm::Infallible>) {
                 $body

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -9,8 +9,8 @@ use core::{
 };
 
 use super::{
-    io::PodOnce, nr_subpage_per_huge, page_prop::PageProperty, page_size, Paddr, PagingConstsTrait,
-    PagingLevel, Vaddr,
+    nr_subpage_per_huge, page_prop::PageProperty, page_size, Paddr, PagingConstsTrait, PagingLevel,
+    PodOnce, Vaddr,
 };
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
@@ -84,9 +84,7 @@ pub struct PageTable<
     M: PageTableMode,
     E: PageTableEntryTrait = PageTableEntry,
     C: PagingConstsTrait = PagingConsts,
-> where
-    [(); C::NR_LEVELS as usize]:,
-{
+> {
     root: RawPageTableNode<E, C>,
     _phantom: PhantomData<M>,
 }
@@ -201,10 +199,7 @@ impl PageTable<KernelMode> {
     }
 }
 
-impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTable<M, E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTable<M, E, C> {
     /// Create a new empty page table. Useful for the kernel page table and IOMMU page tables only.
     pub fn empty() -> Self {
         PageTable {

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -23,9 +23,7 @@ use crate::{
 pub(in crate::mm) enum Child<
     E: PageTableEntryTrait = PageTableEntry,
     C: PagingConstsTrait = PagingConsts,
-> where
-    [(); C::NR_LEVELS as usize]:,
-{
+> {
     PageTable(RawPageTableNode<E, C>),
     Frame(Frame<dyn AnyFrameMeta>, PageProperty),
     /// Pages not tracked by handles.
@@ -33,10 +31,7 @@ pub(in crate::mm) enum Child<
     None,
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> Child<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> Child<E, C> {
     /// Returns whether the child does not map to anything.
     pub(in crate::mm) fn is_none(&self) -> bool {
         matches!(self, Child::None)

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -12,10 +12,7 @@ use crate::mm::{nr_subpage_per_huge, page_prop::PageProperty, page_size, PagingC
 /// This is a static reference to an entry in a node that does not account for
 /// a dynamic reference count to the child. It can be used to create a owned
 /// handle, which is a [`Child`].
-pub(in crate::mm) struct Entry<'a, E: PageTableEntryTrait, C: PagingConstsTrait>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+pub(in crate::mm) struct Entry<'a, E: PageTableEntryTrait, C: PagingConstsTrait> {
     /// The page table entry.
     ///
     /// We store the page table entry here to optimize the number of reads from
@@ -30,10 +27,7 @@ where
     node: &'a mut PageTableNode<E, C>,
 }
 
-impl<'a, E: PageTableEntryTrait, C: PagingConstsTrait> Entry<'a, E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<'a, E: PageTableEntryTrait, C: PagingConstsTrait> Entry<'a, E, C> {
     /// Returns if the entry does not map to anything.
     pub(in crate::mm) fn is_none(&self) -> bool {
         !self.pte.is_present()

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -56,19 +56,13 @@ use crate::{
 /// Only the CPU or a PTE can access a page table node using a raw handle. To access the page
 /// table node from the kernel code, use the handle [`PageTableNode`].
 #[derive(Debug)]
-pub(super) struct RawPageTableNode<E: PageTableEntryTrait, C: PagingConstsTrait>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+pub(super) struct RawPageTableNode<E: PageTableEntryTrait, C: PagingConstsTrait> {
     raw: Paddr,
     level: PagingLevel,
     _phantom: PhantomData<(E, C)>,
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> RawPageTableNode<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> RawPageTableNode<E, C> {
     pub(super) fn paddr(&self) -> Paddr {
         self.raw
     }
@@ -189,8 +183,6 @@ where
 
 impl<E: PageTableEntryTrait, C: PagingConstsTrait> From<RawPageTableNode<E, C>>
     for Frame<PageTablePageMeta<E, C>>
-where
-    [(); C::NR_LEVELS as usize]:,
 {
     fn from(raw: RawPageTableNode<E, C>) -> Self {
         let raw = ManuallyDrop::new(raw);
@@ -201,10 +193,7 @@ where
     }
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> Drop for RawPageTableNode<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> Drop for RawPageTableNode<E, C> {
     fn drop(&mut self) {
         // SAFETY: The physical address in the raw handle is valid. The restored
         // handle is dropped to decrement the reference count.
@@ -223,16 +212,11 @@ where
 pub(super) struct PageTableNode<
     E: PageTableEntryTrait = PageTableEntry,
     C: PagingConstsTrait = PagingConsts,
-> where
-    [(); C::NR_LEVELS as usize]:,
-{
+> {
     page: Frame<PageTablePageMeta<E, C>>,
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> PageTableNode<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> PageTableNode<E, C> {
     /// Borrows an entry in the node at a given index.
     ///
     /// # Panics
@@ -346,10 +330,7 @@ where
     }
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> Drop for PageTableNode<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> Drop for PageTableNode<E, C> {
     fn drop(&mut self) {
         // Release the lock.
         self.page.meta().lock.store(0, Ordering::Release);
@@ -362,9 +343,7 @@ where
 pub(in crate::mm) struct PageTablePageMeta<
     E: PageTableEntryTrait = PageTableEntry,
     C: PagingConstsTrait = PagingConsts,
-> where
-    [(); C::NR_LEVELS as usize]:,
-{
+> {
     /// The number of valid PTEs. It is mutable if the lock is held.
     pub nr_children: SyncUnsafeCell<u16>,
     /// The level of the page table page. A page table page cannot be
@@ -393,10 +372,7 @@ pub(in crate::mm) enum MapTrackingStatus {
     Tracked,
 }
 
-impl<E: PageTableEntryTrait, C: PagingConstsTrait> PageTablePageMeta<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<E: PageTableEntryTrait, C: PagingConstsTrait> PageTablePageMeta<E, C> {
     pub fn new_locked(level: PagingLevel, is_tracked: MapTrackingStatus) -> Self {
         Self {
             nr_children: SyncUnsafeCell::new(0),
@@ -410,10 +386,7 @@ where
 
 // SAFETY: The layout of the `PageTablePageMeta` is ensured to be the same for
 // all possible generic parameters. And the layout fits the requirements.
-unsafe impl<E: PageTableEntryTrait, C: PagingConstsTrait> AnyFrameMeta for PageTablePageMeta<E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+unsafe impl<E: PageTableEntryTrait, C: PagingConstsTrait> AnyFrameMeta for PageTablePageMeta<E, C> {
     fn on_drop(&mut self, reader: &mut VmReader<Infallible>) {
         let nr_children = self.nr_children.get_mut();
 

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -146,10 +146,7 @@ fn test_user_copy_on_write() {
     assert!(child_pt.query(from.start + 10).is_none());
 }
 
-impl<M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTable<M, E, C>
-where
-    [(); C::NR_LEVELS as usize]:,
-{
+impl<M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTable<M, E, C> {
     fn protect(&self, range: &Range<Vaddr>, mut op: impl FnMut(&mut PageProperty)) {
         let mut cursor = self.cursor_mut(range).unwrap();
         loop {

--- a/ostd/src/util.rs
+++ b/ostd/src/util.rs
@@ -1,5 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
+/// Asserts that a boolean expression is `true` at compile-time.
+///
+/// Rust provides [`const` blocks], which can be used flexibly within methods, but cannot be used
+/// directly at the top level. This macro serves as a helper to perform compile-time assertions
+/// outside of methods.
+///
+/// [`const` blocks]: https://doc.rust-lang.org/reference/expressions/block-expr.html#const-blocks
+//
+// TODO: Introduce `const_assert_eq!()` once `assert_eq!()` can be used in the `const` context.
+#[macro_export]
+macro_rules! const_assert {
+    ($cond:expr $(,)?) => { const _: () = assert!($cond); };
+    ($cond:expr, $($arg:tt)+) => { const _: () = assert!($cond, $($arg)*); };
+}
+
 /// A marker trait that represents a type has the same size as `T`.
 ///
 /// # Safety


### PR DESCRIPTION
The `generic_const_exprs` feature is incomplete, and using it will cause inline `const` blocks to fail the compilation ([playground link](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=4e61eda629157d8504d34e3840e2d9cc)):
```rust
// This won't compile if the feature is enabled!
// #![feature(generic_const_exprs)]

fn call_me<T>() {
    const { assert!(core::mem::size_of::<T>() <= 8) };
}

fn main() {
    call_me::<usize>();
}
```

As an alternative, we can try using [`const_assert`](https://docs.rs/const-assert/latest/const_assert/), which is only usable if the `generic_const_exprs` feature is available. However, this type of assertion is pre-monomorphic, and thus awkward to use:
```rust
#![feature(generic_const_exprs)]

use const_assert::{Assert, IsTrue};

fn call_me<T>()
where
    Assert<{ core::mem::size_of::<T>() <= 8 }>: IsTrue,
{
}

struct Foo<const N: usize>(u8);
impl<const N: usize> Foo<N> {
    fn bar() {
        call_me::<Self>();
    }
}

fn main() {}
```
The above cannot compile, due to:
```text
error: unconstrained generic constant
  --> src/main.rs:15:19
   |
15 |         call_me::<Self>();
   |                   ^^^^
   |
note: required by a bound in `call_me`
  --> src/main.rs:7:12
   |
5  | fn call_me<T>()
   |    ------- required by a bound in this function
6  | where
7  |     Assert<{ core::mem::size_of::<T>() <= 8 }>: IsTrue,
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_me`
help: try adding a `where` bound
   |
14 |     fn bar() where [(); { core::mem::size_of::<T>() <= 8 } as usize]: {
   |              ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

So I'm considering to remove the incomplete `generic_const_exprs` feature and try to use assertions in the `const` block instead.

**Change 1:** The major use of the `generic_const_exprs` is in the page table implementation:
https://github.com/asterinas/asterinas/blob/65f9363d7c8802428fbdc0a9ec8812413b2e3f77/ostd/src/mm/page_table/cursor.rs#L117-L128
I discussed this with @junyang-zh and @junyang-zh suggests just removing the type constraint and using `MAX_NR_LEVELS = 4` as the array size. I think that's reasonable enough.

**Change 2:** Another use of `generic_const_exprs` is to implement `PodOnce` for all `Pod` types of the desired length. By using `const { assert!(is_non_tearing::<T>()) };` the type `PodOnce` is not really needed. But I keep it as a hint type.

**Change 3:** Finally, I removed all uses of `static_assertions::const_assert!(cond)` to just `const _: () = assert!(cond)`.

Note that `assert_eq!` cannot be used in the `const` block, so I have to replace `static_assertions::const_assert_eq!(a, b)` with `const _: () = assert!(a == b)`. I can justify this because `static_assertions::const_assert_eq!` does not help as it gives a terrible error message:
```text
error[E0080]: evaluation of constant value failed
 --> src/main.rs:4:1
  |
4 | const_assert_eq!(core::mem::size_of::<usize>(), 4);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
  |
  = note: this error originates in the macro `const_assert` which comes from the expansion of the macro `const_assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
```

@junyang-zh Please also check how these commits interact with your current work. At least I manually applied the commits in #1789, and the compiler is still happy. There aren't any significant conflicts either, but just in case.

