### PR TITLE
Minor improvements on scheduling class

### DIFF
--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -35,12 +35,11 @@ impl core::fmt::Debug for IdleClassRq {
 
 impl SchedClassRq for IdleClassRq {
     fn enqueue(&mut self, entity: Arc<Task>, _: Option<EnqueueFlags>) {
-        let ptr = Arc::as_ptr(&entity);
-        if let Some(t) = self.entity.replace(entity)
-            && ptr != Arc::as_ptr(&t)
-        {
-            panic!("Multiple `idle` entities spawned")
-        }
+        let old = self.entity.replace(entity);
+        debug_assert!(
+            old.is_none(),
+            "the length of the idle queue should be no larger than 1"
+        );
     }
 
     fn len(&self) -> usize {
@@ -52,7 +51,7 @@ impl SchedClassRq for IdleClassRq {
     }
 
     fn pick_next(&mut self) -> Option<Arc<Task>> {
-        self.entity.clone()
+        self.entity.take()
     }
 
     fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -295,11 +295,9 @@ impl LocalRunQueue for PerCpuClassRqSet {
 
     fn pick_next_current(&mut self) -> Option<&Arc<Task>> {
         self.pick_next_entity().and_then(|next| {
-            let next_ptr = Arc::as_ptr(&next.0);
+            // We guarantee that a task can appear at once in a `PerCpuClassRqSet`. So, the `next` cannot be the same
+            // as the current task here.
             if let Some((old, _)) = self.current.replace((next, CurrentRuntime::new())) {
-                if Arc::as_ptr(&old.0) == next_ptr {
-                    return None;
-                }
                 self.enqueue_entity(old, None);
             }
             self.current.as_ref().map(|((task, _), _)| task)

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -14,18 +14,18 @@ use super::{CurrentRuntime, SchedAttr, SchedClassRq};
 /// This is a singleton class, meaning that only one thread can be in this class at a time.
 /// This is used for the most critical tasks, such as powering off and rebooting.
 pub(super) struct StopClassRq {
-    thread: Option<Arc<Task>>,
+    entity: Option<Arc<Task>>,
 }
 
 impl StopClassRq {
     pub fn new() -> Self {
-        Self { thread: None }
+        Self { entity: None }
     }
 }
 
 impl core::fmt::Debug for StopClassRq {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.thread.is_some() {
+        if self.entity.is_some() {
             write!(f, "Stop: occupied")?;
         } else {
             write!(f, "Stop: empty")?;
@@ -35,10 +35,12 @@ impl core::fmt::Debug for StopClassRq {
 }
 
 impl SchedClassRq for StopClassRq {
-    fn enqueue(&mut self, thread: Arc<Task>, _: Option<EnqueueFlags>) {
-        if self.thread.replace(thread).is_some() {
-            panic!("Multiple `stop` threads spawned")
-        }
+    fn enqueue(&mut self, entity: Arc<Task>, _: Option<EnqueueFlags>) {
+        let old = self.entity.replace(entity);
+        debug_assert!(
+            old.is_none(),
+            "the length of the stop queue should be no larger than 1"
+        );
     }
 
     fn len(&self) -> usize {
@@ -46,15 +48,15 @@ impl SchedClassRq for StopClassRq {
     }
 
     fn is_empty(&self) -> bool {
-        self.thread.is_none()
+        self.entity.is_none()
     }
 
     fn pick_next(&mut self) -> Option<Arc<Task>> {
-        self.thread.take()
+        self.entity.take()
     }
 
     fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {
-        // Stop threads has the lowest priority value. They should never be preempted.
+        // Stop entities has the lowest priority value. They should never be preempted.
         false
     }
 }


### PR DESCRIPTION
## Changes
- rewrite `Idle` logics like `Stop`, eliminating redundant `Clone`
- remove useless check since a task cannot be in the runqueue while being the `current`