### PR TITLE
Add kernfs implementation

### DIFF
--- a/kernel/src/fs/kernfs/element.rs
+++ b/kernel/src/fs/kernfs/element.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+use core::fmt::{self, Formatter};
+
+use super::DataProvider;
+use crate::{fs::utils::Inode, prelude::*};
+
+/// Represents a pseudo directory.
+#[derive(Debug)]
+pub struct PseudoDir {
+    children: BTreeMap<String, Arc<dyn Inode>>,
+}
+
+/// Represents a pseudo symbolic link.
+#[derive(Debug)]
+pub struct PseudoSymlink {
+    target_path: String,
+}
+
+impl PseudoSymlink {
+    pub fn new(target_path: String) -> Self {
+        PseudoSymlink {
+            target_path: target_path,
+        }
+    }
+
+    /// Gets the target path of the symbolic link.
+    pub fn target_path(&self) -> String {
+        self.target_path.clone()
+    }
+
+    /// Sets the target path of the symbolic link.
+    pub fn set_target_path(&mut self, target_path: String) {
+        self.target_path = target_path;
+    }
+}
+
+/// Represents a pseudo file with data content.
+/// DataProvider should be implemented for reading and writing data.
+pub struct PseudoAttr {
+    data: Option<Box<dyn DataProvider>>,
+}
+
+impl PseudoAttr {
+    pub fn new(data: Option<Box<dyn DataProvider>>) -> Self {
+        PseudoAttr { data }
+    }
+
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) {
+        self.data = Some(data);
+    }
+
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        if let Some(data) = &self.data {
+            data.read_at(offset, buf)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        if let Some(data) = &mut self.data {
+            let new_size = data.write_at(offset, buf)?;
+            Ok(new_size)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn truncate(&mut self, new_size: usize) -> Result<()> {
+        if let Some(data) = &mut self.data {
+            data.truncate(new_size)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for PseudoAttr {
+    fn default() -> Self {
+        PseudoAttr::new(None)
+    }
+}
+
+impl fmt::Debug for PseudoAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "PseudoAttr")
+    }
+}
+
+/// The union of all pseudo elements.
+/// It can be a directory, a symbolic link, or a file with data content.
+#[derive(Debug)]
+pub enum PseudoElement {
+    Dir(PseudoDir),
+    Symlink(PseudoSymlink),
+    Attr(PseudoAttr),
+}
+
+impl PseudoElement {
+    /// Creates a new `PseudoDir`.
+    pub fn new_dir() -> Self {
+        PseudoElement::Dir(PseudoDir {
+            children: BTreeMap::new(),
+        })
+    }
+
+    /// Creates a new `PseudoSymlink` with the given target path.
+    pub fn new_symlink(target_path: &str) -> Self {
+        PseudoElement::Symlink(PseudoSymlink::new(target_path.to_string()))
+    }
+
+    /// Creates a new `PseudoAttr` with the given data provider.
+    pub fn new_attr(data: Option<Box<dyn DataProvider>>) -> Self {
+        PseudoElement::Attr(PseudoAttr::new(data))
+    }
+
+    /// Sets the data provider for the pseudo attribute.
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) -> Result<()> {
+        match self {
+            PseudoElement::Attr(ref mut attr) => {
+                attr.set_data(data);
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    /// Reads data from the pseudo attribute at the specified offset.
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        match self {
+            PseudoElement::Attr(attr) => attr.read_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    /// Writes data to the pseudo attribute at the specified offset.
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        match self {
+            PseudoElement::Attr(attr) => attr.write_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    /// Removes a child from the directory.
+    pub fn remove(&mut self, name: &str) -> Result<Arc<dyn Inode>> {
+        let node = match self {
+            PseudoElement::Dir(dir) => {
+                if let Some(node) = dir.children.remove(name) {
+                    node
+                } else {
+                    return_errno_with_message!(Errno::ENOENT, "no such file or directory");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        };
+        Ok(node)
+    }
+
+    /// Inserts a child into the directory.
+    pub fn insert(&mut self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        match self {
+            PseudoElement::Dir(dir) => {
+                if dir.children.contains_key(&name)
+                    || dir.children.insert(name.clone(), node.clone()).is_some()
+                {
+                    return_errno_with_message!(Errno::EEXIST, "file exists");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        }
+        Ok(())
+    }
+
+    /// Looks up a child by name in the directory.
+    pub fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        match self {
+            PseudoElement::Dir(dir) => match dir.children.get(name) {
+                Some(node) => Ok(node.clone() as Arc<dyn Inode>),
+                None => return_errno!(Errno::ENOENT),
+            },
+            _ => return_errno!(Errno::ENOTDIR),
+        }
+    }
+
+    /// Gets the children of the directory.
+    pub fn get_children(&self) -> Option<BTreeMap<String, Arc<dyn Inode>>> {
+        match self {
+            PseudoElement::Dir(dir) => Some(dir.children.clone()),
+            _ => None,
+        }
+    }
+
+    /// Reads the target path of the symbolic link.
+    pub fn read_link(&self) -> Result<String> {
+        match self {
+            PseudoElement::Symlink(link) => Ok(link.target_path()),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    /// Writes the target path to the symbolic link.
+    pub fn write_link(&mut self, target_path: &str) -> Result<()> {
+        match self {
+            PseudoElement::Symlink(link) => {
+                link.set_target_path(target_path.to_string());
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+}

--- a/kernel/src/fs/kernfs/inode.rs
+++ b/kernel/src/fs/kernfs/inode.rs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    string::String,
+    sync::{Arc, Weak},
+};
+use core::time::Duration;
+
+use ostd::sync::RwMutex;
+
+use super::{element::PseudoElement, DataProvider, PseudoExt, PseudoFileSystem, BLOCK_SIZE};
+use crate::{
+    fs::{
+        utils::{DirentVisitor, FileSystem, Inode, InodeMode, InodeType, Metadata, NAME_MAX},
+        Errno,
+    },
+    prelude::*,
+    process::{Gid, Uid},
+    time::clocks::RealTimeCoarseClock,
+};
+
+/// Represents a node in the kernel filesystem (kernfs).
+///
+/// This struct contains the core information and functionality for a inode in the pseudo filesystem,
+/// including its metadata, data, and relationship to other nodes.
+/// It is used to implement various types of filesystem entries like directories, regular files, and special files.
+/// The pseudo_extension field provides different abstractions for different pseudo-file system requirements.
+pub struct PseudoINode {
+    metadata: RwLock<Metadata>,                   // Inode attributes
+    elem: RwMutex<PseudoElement>,                 // Concrete node type
+    pseudo_extension: Option<Arc<dyn PseudoExt>>, // Extension hooks
+    fs: Weak<dyn PseudoFileSystem>,               // FS reference
+    parent: Option<Weak<PseudoINode>>,            // Parent directory
+    this: Weak<PseudoINode>,                      // Self reference
+}
+
+impl PseudoINode {
+    pub fn new_root(
+        fs: Weak<dyn PseudoFileSystem>,
+        root_ino: u64,
+        blk_size: usize,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            metadata: RwLock::new(Metadata::new_dir(
+                root_ino,
+                InodeMode::from_bits_truncate(0o555),
+                blk_size,
+            )),
+            elem: RwMutex::new(PseudoElement::new_dir()),
+            pseudo_extension,
+            fs,
+            parent: None,
+            this: weak_self.clone(),
+        })
+    }
+
+    pub fn new_attr(
+        name: &str,
+        mode: Option<InodeMode>,
+        data: Option<Box<dyn DataProvider>>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+        parent: Weak<PseudoINode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+
+        let mode = mode.unwrap_or_else(|| InodeMode::from_bits_truncate(0o777));
+        let metadata = Metadata::new_file(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwLock::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_attr(data)),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    pub fn new_dir(
+        name: &str,
+        mode: Option<InodeMode>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+        parent: Weak<PseudoINode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = mode.unwrap_or(arc_parent.metadata().mode);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwLock::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_dir()),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    pub fn new_symlink(
+        name: &str,
+        target: &str,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+        parent: Weak<PseudoINode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = InodeMode::from_bits_truncate(0o777);
+        let metadata = Metadata::new_symlink(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwLock::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_symlink(target)),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    /// Gets the current node.
+    pub fn this(&self) -> Arc<PseudoINode> {
+        self.this.upgrade().unwrap()
+    }
+
+    /// Gets the current node as a weak reference.
+    pub fn this_weak(&self) -> Weak<PseudoINode> {
+        self.this.clone()
+    }
+
+    /// Gets the parent of the current node.
+    fn parent(&self) -> Option<Arc<PseudoINode>> {
+        self.parent.as_ref().and_then(|p| p.upgrade())
+    }
+
+    /// Gets the pseudo filesystem of the current node.
+    fn pseudo_fs(&self) -> Arc<dyn PseudoFileSystem> {
+        self.fs.upgrade().unwrap()
+    }
+
+    /// Generates a new inode number for the current node.
+    fn generate_ino(&self) -> u64 {
+        self.pseudo_fs().alloc_unique_id()
+    }
+
+    /// Sets the data of the current node.
+    pub fn set_data(&self, data: Box<dyn DataProvider>) -> Result<()> {
+        self.elem.write().set_data(data)
+    }
+
+    /// Sets the pseudo_extension of the current node.
+    /// The pseudo_extension provides different abstractions for different pseudo-file system requirements.
+    pub fn set_pseudo_extension(&mut self, pseudo_extension: Arc<dyn PseudoExt>) {
+        self.pseudo_extension = Some(pseudo_extension);
+    }
+
+    /// Removes a child from the current node.
+    /// Returns Ok(Arc<dyn Inode>) if the child is removed successfully.
+    /// Current node should be a directory.
+    /// Triggers the pseudo_extension's `on_remove` method if the pseudo_extension exists.
+    fn remove(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(pseudo_extension) = self.pseudo_extension.as_ref() {
+            pseudo_extension.on_remove(name)?;
+        }
+        self.elem.write().remove(name)
+    }
+
+    /// Inserts a child to the current node.
+    /// Returns Ok(()) if the child is inserted successfully.
+    /// Current node should be a directory.
+    /// The child should not exist in the current node.
+    /// Triggers the pseudo_extension's `on_create` method if the pseudo_extension exists.
+    fn insert(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        if let Some(pseudo_extension) = self.pseudo_extension.as_ref() {
+            pseudo_extension.on_create(name.as_str(), node.clone())?;
+        }
+        self.elem.write().insert(name, node)
+    }
+
+    /// Reads data from the current node at the specified offset.
+    fn pseudo_read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.elem.read().read_at(offset, buf)
+    }
+
+    /// Writes data to the current node at the specified offset.
+    fn pseudo_write_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.elem.write().write_at(offset, buf)
+    }
+}
+
+impl Inode for PseudoINode {
+    fn type_(&self) -> InodeType {
+        self.metadata().type_
+    }
+
+    // File size in pseudo filesystem usually is equal to 0.
+    fn resize(&self, new_size: usize) -> Result<()> {
+        let mut elem = self.elem.write();
+        if let PseudoElement::Attr(attr) = &mut *elem {
+            attr.truncate(new_size)?;
+        }
+        Ok(())
+    }
+
+    fn metadata(&self) -> Metadata {
+        *self.metadata.read()
+    }
+
+    fn ino(&self) -> u64 {
+        self.metadata().ino
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.metadata().mode)
+    }
+
+    fn size(&self) -> usize {
+        self.metadata().size
+    }
+
+    fn atime(&self) -> Duration {
+        self.metadata().atime
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.metadata.write().atime = time;
+    }
+
+    fn mtime(&self) -> Duration {
+        self.metadata().mtime
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.metadata.write().mtime = time;
+    }
+
+    fn ctime(&self) -> Duration {
+        self.metadata().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs.upgrade().unwrap()
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.metadata.write().mode = mode;
+        Ok(())
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata().uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        self.metadata.write().uid = uid;
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.metadata().gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        self.metadata.write().gid = gid;
+        Ok(())
+    }
+
+    fn page_cache(&self) -> Option<crate::vm::vmo::Vmo<aster_rights::Full>> {
+        None
+    }
+
+    fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        let size = self.pseudo_read_at(offset, buf)?;
+        self.set_atime(RealTimeCoarseClock::get().read_time());
+        Ok(size)
+    }
+
+    fn read_direct_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.read_at(offset, buf)
+    }
+
+    fn write_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        let size = self.pseudo_write_at(offset, buf)?;
+        self.set_mtime(RealTimeCoarseClock::get().read_time());
+        self.set_ctime(RealTimeCoarseClock::get().read_time());
+        Ok(size)
+    }
+
+    fn write_direct_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.write_at(offset, buf)
+    }
+
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        if name.len() > NAME_MAX {
+            return_errno!(Errno::ENAMETOOLONG);
+        }
+        if self.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let new_node = match type_ {
+            InodeType::Dir => PseudoINode::new_dir(name, Some(mode), None, self.this_weak()),
+            InodeType::File => {
+                PseudoINode::new_attr(name, Some(mode), None, None, self.this_weak())
+            }
+            InodeType::SymLink => PseudoINode::new_symlink(name, "", None, self.this_weak()),
+            _ => return_errno!(Errno::EINVAL),
+        }?;
+        Ok(new_node)
+    }
+
+    fn readdir_at(&self, mut offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+            // Read the two special entries.
+            if *offset == 0 {
+                let this_inode = self.this();
+                visitor.visit(".", this_inode.ino(), this_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+            if *offset == 1 {
+                let parent_inode = self.parent().unwrap_or(self.this());
+                visitor.visit("..", parent_inode.ino(), parent_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+
+            // Read the normal child entries.
+            let cached_children = self.elem.read().get_children().unwrap_or_default();
+
+            for (name, inode) in cached_children.iter().skip(*offset - 2) {
+                visitor.visit(name, inode.ino(), inode.type_(), *offset - 2)?;
+                *offset += 1;
+            }
+
+            Ok(())
+        };
+        try_readdir(&mut offset, visitor)?;
+        Ok(offset)
+    }
+
+    fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "hard links not supported in kernfs");
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        // Removes a child from the current node.
+        // The child should be a regular file or a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() == InodeType::Dir {
+            return_errno!(Errno::EPERM);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        // Removes a child from the current node.
+        // The child should be a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode: Arc<dyn Inode> = match name {
+            "." => self.this(),
+            ".." => self.parent().unwrap_or(self.this()),
+            name => self.elem.read().lookup(name)?,
+        };
+        Ok(inode)
+    }
+
+    fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "rename is not supported in pseudo filesystem");
+    }
+
+    fn read_link(&self) -> Result<String> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.elem.read().read_link()
+    }
+
+    fn write_link(&self, target: &str) -> Result<()> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.elem.write().write_link(target)
+    }
+}

--- a/kernel/src/fs/kernfs/mod.rs
+++ b/kernel/src/fs/kernfs/mod.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod element;
+mod inode;
+
+pub use element::PseudoElement;
+pub use inode::PseudoINode;
+
+use super::utils::{FileSystem, Inode};
+use crate::prelude::*;
+
+/// Block size.
+const BLOCK_SIZE: usize = 1024;
+
+/// Provides interfaces for reading and writing to a pseudo file.
+/// It is used by the pseudo file system to read and write data.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::kernfs::DataProvider;
+/// use crate::prelude::*;
+///
+/// struct MyDataProvider {
+///    data: Vec<u8>,
+/// }
+///
+/// impl MyDataProvider {
+///   pub fn new(data: Vec<u8>) -> Self {
+///      Self { data }
+///  }
+/// }
+///
+/// impl DataProvider for MyDataProvider {
+///    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+///      let start = offset.min(self.data.len());
+///      let end = (offset + writer.avail()).min(self.data.len());
+///      let len = end - start;
+///      writer.write_all(&self.data[start..end])?;
+///      Ok(len)
+///     }
+///
+///   fn write_at(&mut self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+///      let write_len = reader.remain();
+///      let end = offset + write_len;
+///
+///      if self.data.len() < end {
+///         self.data.resize(end, 0);
+///         }
+///
+///      let mut writer = VmWriter::from(&mut self.data[offset..end]);
+///      let value = reader.read_fallible(&mut writer)?;
+///      if value != write_len {
+///         return_errno!(Errno::EINVAL);
+///         }
+///
+///      Ok(write_len)
+///     }
+///
+///  fn truncate(&mut self, new_size: usize) -> Result<()> {
+///     self.data.resize(new_size, 0);
+///     Ok(())
+///    }
+/// }
+/// ```
+pub trait DataProvider: Any + Sync + Send {
+    /// Reads data from the file at the given offset.
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize>;
+    /// Writes data to the file at the given offset.
+    fn write_at(&mut self, offset: usize, reader: &mut VmReader) -> Result<usize>;
+    /// Truncates the file to the given size.
+    fn truncate(&mut self, new_size: usize) -> Result<()>;
+}
+
+/// Provides different abstractions for different pseudo-file system requirements.
+/// It processes events and dynamic logic.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::{
+///     kernfs::PseudoExt,
+///     sysfs::Action,
+/// };
+///
+///
+/// struct MyPseudoExt {
+///     subject: Subject<Action>,
+/// }
+///
+/// impl PseudoExt for MyPseudoExt {
+///    fn on_create(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+///       // Implementation details...
+///       self.subject.notify_observers(Action::Add);
+///   }
+///
+///    fn on_remove(&self, name: String) -> Result<()> {
+///       // Implementation details...
+///       self.subject.notify_observers(Action::Remove);
+///   }
+/// }
+/// ```
+pub trait PseudoExt: Send + Sync {
+    /// Creates a new node.
+    fn on_create(&self, name: &str, node: Arc<dyn Inode>) -> Result<()>;
+    /// Removes a node.
+    fn on_remove(&self, name: &str) -> Result<()>;
+}
+
+/// A trait for the pseudo filesystem.
+///
+/// The pseudo filesystem is a virtual filesystem that is used to provide
+/// a consistent interface for the kernel to interact with the underlying
+/// hardware. It is typically mounted at a specific mount point (e.g., `/sys`)
+/// and provides a hierarchical view of system resources and configurations.
+///
+/// This trait defines the basic operations that a pseudo filesystem must
+/// implement, including allocating unique identifiers, initializing the
+/// filesystem, and providing access to the filesystem itself.
+///
+/// # Methods
+///
+/// - `alloc_unique_id(&self) -> u64`: Allocates and returns a unique identifier for
+///   inodes or other filesystem entities.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::PseudoFileSystem;
+///
+/// struct MyPseudoFS {
+///     // Implementation details...
+/// }
+///
+/// impl PseudoFileSystem for MyPseudoFS {
+///     fn alloc_unique_id(&self) -> u64 {
+///         // Allocate and return a unique ID
+///     }
+/// }
+/// ```
+pub trait PseudoFileSystem: FileSystem {
+    /// Allocates a unique ID for the inode.
+    fn alloc_unique_id(&self) -> u64;
+}
+
+/// A toy pseudo filesystem that is working as sysfs.
+/// It takes effect if you mount it to `/sys`.
+#[cfg(ktest)]
+mod tests {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    use ostd::{mm::VmWriter, prelude::ktest};
+
+    use crate::{
+        fs::{
+            kernfs::{DataProvider, PseudoFileSystem, PseudoINode},
+            utils::{FileSystem, FsFlags, Inode, SuperBlock},
+        },
+        prelude::*,
+    };
+
+    /// ToySysFS filesystem.
+    /// Root Inode ID.
+    const SYSFS_ROOT_INO: u64 = 1;
+    /// Block size.
+    const BLOCK_SIZE: usize = 1024;
+
+    pub struct ToySysFS {
+        root: Arc<dyn Inode>,
+        inode_allocator: AtomicU64,
+    }
+
+    impl ToySysFS {
+        pub fn new() -> Arc<Self> {
+            let fs = Arc::new_cyclic(|weak_fs| Self {
+                root: SysfsRoot::new_inode(weak_fs.clone()),
+                inode_allocator: AtomicU64::new(SYSFS_ROOT_INO + 1),
+            });
+            let root = fs.root_inode();
+            let root = root.downcast_ref::<PseudoINode>().unwrap();
+            let kernel = PseudoINode::new_dir("kernel", None, None, root.this_weak()).unwrap();
+            let _ = PseudoINode::new_attr(
+                "address_bits",
+                None,
+                Some(Box::new(AddressBits)),
+                None,
+                kernel.this_weak(),
+            )
+            .unwrap();
+            let _ = PseudoINode::new_attr(
+                "byteorder",
+                None,
+                Some(Box::new(CpuByteOrder::new())),
+                None,
+                kernel.this_weak(),
+            )
+            .unwrap();
+            fs
+        }
+    }
+
+    impl PseudoFileSystem for ToySysFS {
+        /// Allocates a unique ID for the inode.
+        fn alloc_unique_id(&self) -> u64 {
+            self.inode_allocator.fetch_add(1, Ordering::SeqCst)
+        }
+    }
+
+    impl FileSystem for ToySysFS {
+        fn sync(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn root_inode(&self) -> Arc<dyn Inode> {
+            self.root.clone()
+        }
+
+        fn sb(&self) -> SuperBlock {
+            unimplemented!()
+        }
+
+        fn flags(&self) -> FsFlags {
+            FsFlags::empty()
+        }
+    }
+
+    /// Represents the inode at `/sys`.
+    /// Root directory of the sysfs.
+    pub struct SysfsRoot;
+
+    impl SysfsRoot {
+        pub fn new_inode(fs: Weak<ToySysFS>) -> Arc<dyn Inode> {
+            PseudoINode::new_root(fs, SYSFS_ROOT_INO, BLOCK_SIZE, None)
+        }
+    }
+
+    pub struct AddressBits;
+
+    impl DataProvider for AddressBits {
+        fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+            let data = "64\n".as_bytes().to_vec();
+            let start = data.len().min(offset);
+            let end = data.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&data[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+            return_errno_with_message!(Errno::EINVAL, "cpuinfo is read-only");
+        }
+
+        fn truncate(&mut self, _new_size: usize) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    pub struct CpuByteOrder {
+        byte_order: Vec<u8>,
+    }
+
+    impl CpuByteOrder {
+        pub fn new() -> Self {
+            let byte_order = if cfg!(target_endian = "little") {
+                "little\n".as_bytes().to_vec()
+            } else {
+                "big\n".as_bytes().to_vec()
+            };
+            Self { byte_order }
+        }
+    }
+
+    impl Default for CpuByteOrder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl DataProvider for CpuByteOrder {
+        fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+            let start = self.byte_order.len().min(offset);
+            let end = self.byte_order.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&self.byte_order[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+            let write_len = reader.remain();
+            let end = offset + write_len;
+
+            if self.byte_order.len() < end {
+                self.byte_order.resize(end, 0);
+            }
+
+            let mut writer = VmWriter::from(&mut self.byte_order[offset..end]);
+            let value = reader.read_fallible(&mut writer)?;
+            if value != write_len {
+                return_errno!(Errno::EINVAL);
+            }
+
+            Ok(write_len)
+        }
+
+        fn truncate(&mut self, new_size: usize) -> Result<()> {
+            self.byte_order.resize(new_size, 0);
+            Ok(())
+        }
+    }
+
+    fn load_fs() -> Arc<ToySysFS> {
+        crate::time::clocks::init_for_ktest();
+        let fs: Arc<ToySysFS> = ToySysFS::new();
+        fs
+    }
+
+    #[ktest]
+    fn new_fs() {
+        let fs = load_fs();
+        assert_eq!(fs.alloc_unique_id(), SYSFS_ROOT_INO + 4);
+    }
+
+    #[ktest]
+    fn read_address_bits() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let ab = kernel.lookup("address_bits").unwrap();
+        let mut read_buf = vec![0u8; "64\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        ab.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "64\n".as_bytes());
+    }
+
+    #[ktest]
+    fn read_cpu_byteorder() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let mut read_buf = vec![0u8; "little\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "little\n".as_bytes());
+    }
+
+    #[ktest]
+    fn write_cpu_byteorder() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let write_buf = "big\n".as_bytes().to_vec();
+        let mut reader = VmReader::from(&write_buf as &[u8]).to_fallible();
+        let write_len = cpu_byteorder.write_at(0, &mut reader).unwrap();
+        assert_eq!(write_len, "big\n".as_bytes().len());
+        let mut read_buf = vec![0u8; "big\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "big\n".as_bytes());
+    }
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -8,6 +8,7 @@ pub mod file_handle;
 pub mod file_table;
 pub mod fs_resolver;
 pub mod inode_handle;
+pub mod kernfs;
 pub mod named_pipe;
 pub mod path;
 pub mod pipe;


### PR DESCRIPTION
## Overview  
**KernFS** is a modular in-kernel virtual filesystem framework designed to unify the implementation of pseudo filesystems such as sysfs, and cgroupfs. Its core architecture leverages abstractions for inode management, data operations, and event handling to support diverse requirements while maintaining high performance and low coupling. This document focuses on its compatibility design and extensibility.

---

## Core Components and Abstract Interfaces

### 1. **Inode Abstraction (`PseudoINode`)**  
- **Purpose**: Represents filesystem entries (directories, files, symlinks) and provides common operations (metadata management, child insertion/removal). We should provide it as the general `inode` implementation for other pseudo file systems, which means they do not need to implement `inode` trait any longer. 
- **Compatibility Features**:  
  - **Dynamic Type Handling**: Uses `PseudoElement` to distinguish between directory (`Dir`), symlink (`Symlink`), and attribute file (`Attr`), allowing flexible composition.  
  - **Event Hooks**: Integrates `EventHandler` for callbacks during node creation/removal (e.g., sysfs triggering `uevent`, cgroupfs updating control groups).  

### 2. **Data Operations Abstraction (`DataProvider`)**  
- **Purpose**: Defines read/write/truncate logic for file data, supporting heterogeneous storage backends. It leaves enough space for upper pseudo file systems to customize special files.
- **Key Methods**:  
```rust
pub trait DataProvider: Any + Sync + Send {
    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize>;
    fn write_at(&mut self, reader: &mut VmReader, offset: usize) -> Result<usize>;
    fn truncate(&mut self, new_size: usize) -> Result<()>;
}

// Example: /sys/devices/system/cpu/online
/// The data provider for the CPU online file.
/// It returns the online CPUs in the format of "0-<num_cpus>\n".
/// It is read-only.
struct CpuOnline;

impl DataProvider for CpuOnline {
    fn read_at(&self, writer: &mut ostd::mm::VmWriter, offset: usize) -> Result<usize> {
        let data = format!("0-{}\n", num_cpus() - 1).as_bytes().to_vec();
        let start = data.len().min(offset);
        let end = data.len().min(offset + writer.avail());
        let len = end - start;
        writer.write_fallible(&mut (&data[start..end]).into())?;
        Ok(len)
    }

    fn write_at(&mut self, reader: &mut ostd::mm::VmReader, offset: usize) -> Result<usize> {
        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
    }

    fn truncate(&mut self, _new_size: usize) -> Result<()> {
        return_errno!(Errno::EINVAL);
    }
}
```  

- **Compatibility Features**:  
  - **sysfs**: Implements read-only or dynamically generated attributes (e.g., `AddressBits` returning CPU address width).  
  - **cgroupfs**: Interacts with kernel control group APIs (e.g., updating process bindings when modifying `cgroup.procs`).  

### 3. **Filesystem Abstraction (`PseudoFileSystem`)**  
- **Purpose**: Manages global filesystem state (e.g., inode allocation, mount points).  
- **Key Method**:  
  ```rust
  pub trait PseudoFileSystem: FileSystem {
      fn alloc_id(&self) -> u64; // Allocates unique inode IDs
  }
  ```  
- **Compatibility Features**:  
  - **Inode Allocation**: Supports strategies like atomic counters (sysfs).  
  - **Mount Customization**: Initializes filesystem hierarchies via `FileSystem` trait (e.g., sysfs registering `/sys/kernel` on mount).  

### 4. **Extensible Event Handling (PseudoExt)**
- **Purpose**: Extends dynamic behavior of pseudo-file systems. It allows different pseudo-file systems (such as sysfs, cgroupfs) to inject custom logic when the following critical operations occur.
- **Key Method**:  
```rust
pub trait PseudoExt: Send + Sync {
    fn on_create(&self, name: String, node: Arc<dyn Inode>) -> Result<()>;
    fn on_remove(&self, name: String) -> Result<()>;
    // to be added...
}
```
- **Compatibility Features**:  
  - uevent notification for sysfs
  - Resource binding of cgroupfs
---

## Cross-Filesystem Compatibility Examples

### 1. **sysfs**  
- **Characteristics**: Static hierarchy, read-mostly attributes, kernel object (kobject) event propagation.  
- **Adaptation**:  
  - **Node Types**: Uses `PseudoElement::Attr` for attributes (e.g., `/sys/kernel/address_bits`).  
  - **Events**: Triggers `UEvent` via `EventHandler::on_create` for userspace notifications.  
  - **Hierarchy**: Dynamically constructs subsystems (e.g., `devices/`, `power/`) using `SysFS::create_kobject`.  

### 2. **cgroupfs**  
- **Characteristics**: Hierarchical control groups, resource limits, dynamic subgroup management.  
- **Adaptation**:  
  - **Node Types**: Extends `PseudoElement` with control group-specific files (e.g., `memory.limit_in_bytes`).  
  - **Data Interaction**: `DataProvider` writes invoke cgroup subsystem APIs (e.g., updating memory limits).  
  - **Hierarchy**: Builds control group trees via `PseudoINode` parent-child relationships.  


---

## Extensibility and Customization

### **Event Handling (`PseudoExt`)**  
- Example for cgroupfs:  
  ```rust
  struct CgroupHandler;

  impl PseudoExt for CgroupHandler {
      fn on_create(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
          cgroup_subsys_notify(&name); // Notify subsystem of new control group
          Ok(())
      }

      fn on_remove(&self, name: String) -> Result<()> {
          cgroup_subsys_cleanup(&name); // Cleanup subsystem resources
          Ok(())
      }
  }
  ```  
