### PR TITLE
Add sysfs implementation and export some kernel infomation

### DIFF
--- a/kernel/src/device/tty/export_sys.rs
+++ b/kernel/src/device/tty/export_sys.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, format};
+
+use super::Tty;
+use crate::{
+    fs::{
+        device::{Device, DeviceId},
+        kernfs::DataProvider,
+        sysfs::{SysFS, SYSFS_REF},
+    },
+    prelude::*,
+};
+
+/// Register the tty device in the SysFS.
+pub(super) fn register_tty(tty_device: Arc<Tty>) -> Result<()> {
+    let tty_subsystem = SYSFS_REF
+        .get()
+        .ok_or(Errno::ENOENT)?
+        .init_parent_dirs("/sys/devices/virtual/tty/")?;
+    let tty_template = SysFS::create_dir(&tty_device.name(), 0o755, tty_subsystem, None)?;
+    let _ = SysFS::create_attribute(
+        "dev",
+        0o444,
+        tty_template.clone(),
+        Box::new(TtyDevID::new(tty_device.id())),
+        None,
+    )?;
+    let _ = SysFS::create_attribute(
+        "uevent",
+        0o644,
+        tty_template.clone(),
+        Box::new(TtyUEvent::new(tty_device.id(), tty_device.name())),
+        None,
+    )?;
+    // Exports `/sys/class/tty/<tty>/` as a symlink to `/sys/devices/virtual/tty/<tty>/`
+    let tty_class = SYSFS_REF
+        .get()
+        .ok_or(Errno::ENOENT)?
+        .init_parent_dirs("/sys/class/tty/")?;
+    let _ = SysFS::create_symlink(
+        &tty_device.name(),
+        tty_class,
+        &format!("../../devices/virtual/tty/{}", tty_device.name()),
+        None,
+    )?;
+    Ok(())
+}
+
+/// Represents `/sys/class/tty/<tty>/dev`, e.g., `/sys/class/tty/tty0/dev`
+struct TtyDevID {
+    id: DeviceId,
+}
+
+impl TtyDevID {
+    pub fn new(id: DeviceId) -> Self {
+        Self { id }
+    }
+}
+
+impl DataProvider for TtyDevID {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+        let data = format!("{}:{}\n", self.id.major(), self.id.minor())
+            .as_bytes()
+            .to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+
+    fn truncate(&mut self, _new_size: usize) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+}
+
+/// Represents `/sys/class/tty/<tty>/uevent`, e.g., `/sys/class/tty/tty0/uevent`
+struct TtyUEvent {
+    id: DeviceId,
+    name: String,
+}
+
+impl TtyUEvent {
+    pub fn new(id: DeviceId, name: String) -> Self {
+        Self { id, name }
+    }
+}
+
+impl DataProvider for TtyUEvent {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+        let data = format!(
+            "MAJOR={}\nMINOR={}\nDEVNAME={}\n",
+            self.id.major(),
+            self.id.minor(),
+            self.name
+        )
+        .as_bytes()
+        .to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+
+    fn truncate(&mut self, _new_size: usize) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+}

--- a/kernel/src/fs/kernfs/element.rs
+++ b/kernel/src/fs/kernfs/element.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+use core::fmt::{self, Formatter};
+
+use super::DataProvider;
+use crate::{fs::utils::Inode, prelude::*};
+
+#[derive(Debug)]
+pub struct PseudoDir {
+    children: BTreeMap<String, Arc<dyn Inode>>,
+}
+
+#[derive(Debug)]
+pub struct PseudoSymlink {
+    target_path: String,
+}
+
+impl PseudoSymlink {
+    pub fn new(target_kn: String) -> Self {
+        PseudoSymlink {
+            target_path: target_kn,
+        }
+    }
+
+    pub fn target_path(&self) -> String {
+        self.target_path.clone()
+    }
+
+    pub fn set_target_path(&mut self, target_kn: String) {
+        self.target_path = target_kn;
+    }
+}
+
+pub struct PseudoAttr {
+    data: Option<Box<dyn DataProvider>>,
+}
+
+impl PseudoAttr {
+    pub fn new() -> Self {
+        PseudoAttr { data: None }
+    }
+
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) {
+        self.data = Some(data);
+    }
+
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        if let Some(data) = &self.data {
+            data.read_at(buf, offset)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        if let Some(data) = &mut self.data {
+            let new_size = data.write_at(buf, offset)?;
+            Ok(new_size)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn truncate(&mut self, new_size: usize) -> Result<()> {
+        if let Some(data) = &mut self.data {
+            data.truncate(new_size)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for PseudoAttr {
+    fn default() -> Self {
+        PseudoAttr::new()
+    }
+}
+
+impl fmt::Debug for PseudoAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "PseudoAttr")
+    }
+}
+
+#[derive(Debug)]
+pub enum PseudoElement {
+    Dir(PseudoDir),         // Directory node
+    Symlink(PseudoSymlink), // Symbolic link
+    Attr(PseudoAttr),       // File with data content
+}
+
+impl PseudoElement {
+    pub fn new_dir() -> Self {
+        PseudoElement::Dir(PseudoDir {
+            children: BTreeMap::new(),
+        })
+    }
+
+    pub fn new_symlink(target_kn: &str) -> Self {
+        PseudoElement::Symlink(PseudoSymlink::new(target_kn.to_string()))
+    }
+
+    pub fn new_attr() -> Self {
+        PseudoElement::Attr(PseudoAttr::new())
+    }
+
+    pub fn set_data(&mut self, data: Box<dyn DataProvider>) -> Result<()> {
+        match self {
+            PseudoElement::Attr(ref mut attr) => {
+                attr.set_data(data);
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        match self {
+            PseudoElement::Attr(attr) => attr.read_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn write_at(&mut self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        match self {
+            PseudoElement::Attr(attr) => attr.write_at(offset, buf),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn remove(&mut self, name: &str) -> Result<Arc<dyn Inode>> {
+        let node = match self {
+            PseudoElement::Dir(dir) => {
+                if let Some(node) = dir.children.remove(name) {
+                    node
+                } else {
+                    return_errno_with_message!(Errno::ENOENT, "no such file or directory");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        };
+        Ok(node)
+    }
+
+    pub fn insert(&mut self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        match self {
+            PseudoElement::Dir(dir) => {
+                if dir.children.contains_key(&name)
+                    || dir.children.insert(name.clone(), node.clone()).is_some()
+                {
+                    return_errno_with_message!(Errno::EEXIST, "file exists");
+                }
+            }
+            _ => return_errno_with_message!(Errno::ENOTDIR, "not a directory"),
+        }
+        Ok(())
+    }
+
+    pub fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        match self {
+            PseudoElement::Dir(dir) => match dir.children.get(name) {
+                Some(node) => Ok(node.clone() as Arc<dyn Inode>),
+                None => return_errno!(Errno::ENOENT),
+            },
+            _ => return_errno!(Errno::ENOTDIR),
+        }
+    }
+
+    pub fn get_children(&self) -> Option<BTreeMap<String, Arc<dyn Inode>>> {
+        match self {
+            PseudoElement::Dir(dir) => Some(dir.children.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn read_link(&self) -> Result<String> {
+        match self {
+            PseudoElement::Symlink(link) => Ok(link.target_path()),
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+
+    pub fn write_link(&mut self, target_kn: &str) -> Result<()> {
+        match self {
+            PseudoElement::Symlink(link) => {
+                link.set_target_path(target_kn.to_string());
+                Ok(())
+            }
+            _ => return_errno!(Errno::EINVAL),
+        }
+    }
+}

--- a/kernel/src/fs/kernfs/inode.rs
+++ b/kernel/src/fs/kernfs/inode.rs
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    string::String,
+    sync::{Arc, Weak},
+};
+use core::time::Duration;
+
+use ostd::sync::RwMutex;
+
+use super::{element::PseudoElement, DataProvider, PseudoExt, PseudoFileSystem, BLOCK_SIZE};
+use crate::{
+    events::IoEvents,
+    fs::{
+        device::Device,
+        utils::{
+            DirentVisitor, FallocMode, FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
+            MknodType, NAME_MAX,
+        },
+        Errno,
+    },
+    prelude::*,
+    process::{signal::PollHandle, Gid, Uid},
+    time::clocks::RealTimeCoarseClock,
+};
+
+/// Represents a node in the kernel filesystem (kernfs).
+///
+/// This struct contains the core information and functionality for a inode in the pseudo filesystem,
+/// including its metadata, data, and relationship to other nodes.
+/// It is used to implement various types of filesystem entries like directories, regular files, and special files.
+/// The pseudo_extension field provides different abstractions for different pseudo-file system requirements.
+pub struct PseudoINode {
+    metadata: RwMutex<Metadata>,                  // Inode attributes
+    elem: RwMutex<PseudoElement>,                 // Concrete node type
+    pseudo_extension: Option<Arc<dyn PseudoExt>>, // Extension hooks
+    fs: Weak<dyn PseudoFileSystem>,               // FS reference
+    parent: Option<Weak<PseudoINode>>,            // Parent directory
+    this: Weak<PseudoINode>,                      // Self reference
+}
+
+impl PseudoINode {
+    pub fn new_root(
+        fs: Weak<dyn PseudoFileSystem>,
+        root_ino: u64,
+        blk_size: usize,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            metadata: RwMutex::new(Metadata::new_dir(
+                root_ino,
+                InodeMode::from_bits_truncate(0o555),
+                blk_size,
+            )),
+            elem: RwMutex::new(PseudoElement::new_dir()),
+            pseudo_extension,
+            fs,
+            parent: None,
+            this: weak_self.clone(),
+        })
+    }
+
+    pub fn new_attr(
+        name: &str,
+        mode: Option<InodeMode>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+        parent: Weak<PseudoINode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+
+        let mode = mode.unwrap_or_else(|| InodeMode::from_bits_truncate(0o777));
+        let metadata = Metadata::new_file(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwMutex::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_attr()),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    pub fn new_dir(
+        name: &str,
+        mode: Option<InodeMode>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+        parent: Weak<PseudoINode>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = mode.unwrap_or(arc_parent.metadata().mode);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwMutex::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_dir()),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    pub fn new_symlink(
+        name: &str,
+        target: &str,
+        parent: Weak<PseudoINode>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Result<Arc<Self>> {
+        let arc_parent = parent.upgrade().unwrap();
+        let ino = arc_parent.generate_ino();
+        let mode = InodeMode::from_bits_truncate(0o777);
+        let metadata = Metadata::new_symlink(ino, mode, BLOCK_SIZE);
+
+        let new_inode = Arc::new_cyclic(|weak_self| Self {
+            metadata: RwMutex::new(metadata),
+            elem: RwMutex::new(PseudoElement::new_symlink(target)),
+            pseudo_extension,
+            fs: Arc::downgrade(&arc_parent.pseudo_fs()),
+            parent: Some(parent),
+            this: weak_self.clone(),
+        });
+        arc_parent.insert(name.to_string(), new_inode.clone())?;
+        Ok(new_inode)
+    }
+
+    /// Get the current node.
+    pub fn this(&self) -> Arc<PseudoINode> {
+        self.this.upgrade().unwrap()
+    }
+
+    /// Get the current node as a weak reference.
+    pub fn this_weak(&self) -> Weak<PseudoINode> {
+        self.this.clone()
+    }
+
+    /// Get the parent of the current node.
+    fn parent(&self) -> Option<Arc<PseudoINode>> {
+        self.parent.as_ref().and_then(|p| p.upgrade())
+    }
+
+    /// Get the pseudo filesystem of the current node.
+    fn pseudo_fs(&self) -> Arc<dyn PseudoFileSystem> {
+        self.fs.upgrade().unwrap()
+    }
+
+    /// Generate a new inode number for the current node.
+    fn generate_ino(&self) -> u64 {
+        self.pseudo_fs().alloc_id()
+    }
+
+    /// Set the data of the current node.
+    pub fn set_data(&self, data: Box<dyn DataProvider>) -> Result<()> {
+        self.elem.write().set_data(data)
+    }
+
+    /// Set the pseudo_extension of the current node.
+    /// The pseudo_extension provides different abstractions for different pseudo-file system requirements.
+    pub fn set_pseudo_extension(&mut self, pseudo_extension: Arc<dyn PseudoExt>) {
+        self.pseudo_extension = Some(pseudo_extension);
+    }
+
+    /// Remove a child from the current node.
+    /// Return Ok(Arc<dyn Inode>) if the child is removed successfully.
+    /// Current node should be a directory.
+    /// Trigger the pseudo_extension's on_remove method if the pseudo_extension exists.
+    fn remove(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(pseudo_extension) = self.pseudo_extension.as_ref() {
+            pseudo_extension.on_remove(name.to_string())?;
+        }
+        self.elem.write().remove(name)
+    }
+
+    /// Insert a child to the current node.
+    /// Return Ok(()) if the child is inserted successfully.
+    /// Current node should be a directory.
+    /// The child should not exist in the current node.
+    /// Trigger the pseudo_extension's on_create method if the pseudo_extension exists.
+    fn insert(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+        if let Some(pseudo_extension) = self.pseudo_extension.as_ref() {
+            pseudo_extension.on_create(name.clone(), node.clone())?;
+        }
+        self.elem.write().insert(name, node)
+    }
+
+    /// Read data from the current node at the specified offset.
+    fn pseudo_read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.elem.read().read_at(offset, buf)
+    }
+
+    /// Write data to the current node at the specified offset.
+    fn pseudo_write_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.elem.write().write_at(offset, buf)
+    }
+}
+
+impl Inode for PseudoINode {
+    fn type_(&self) -> InodeType {
+        self.metadata().type_
+    }
+
+    // File size in pseudo filesystem usually is equal to 0.
+    fn resize(&self, new_size: usize) -> Result<()> {
+        let mut elem = self.elem.write();
+        if let PseudoElement::Attr(attr) = &mut *elem {
+            attr.truncate(new_size)?;
+        }
+        Ok(())
+    }
+
+    fn metadata(&self) -> Metadata {
+        *self.metadata.read()
+    }
+
+    fn ino(&self) -> u64 {
+        self.metadata().ino
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.metadata().mode)
+    }
+
+    fn size(&self) -> usize {
+        self.metadata().size
+    }
+
+    fn atime(&self) -> Duration {
+        self.metadata().atime
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.metadata.write().atime = time;
+    }
+
+    fn mtime(&self) -> Duration {
+        self.metadata().mtime
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.metadata.write().mtime = time;
+    }
+
+    fn ctime(&self) -> Duration {
+        self.metadata().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().ctime = time;
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs.upgrade().unwrap()
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.metadata.write().mode = mode;
+        Ok(())
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata().uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        self.metadata.write().uid = uid;
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.metadata().gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        self.metadata.write().gid = gid;
+        Ok(())
+    }
+
+    fn page_cache(&self) -> Option<crate::vm::vmo::Vmo<aster_rights::Full>> {
+        None
+    }
+
+    fn read_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        let size = self.pseudo_read_at(offset, buf)?;
+        self.set_atime(RealTimeCoarseClock::get().read_time());
+        Ok(size)
+    }
+
+    fn read_direct_at(&self, offset: usize, buf: &mut VmWriter) -> Result<usize> {
+        self.read_at(offset, buf)
+    }
+
+    fn write_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        let size = self.pseudo_write_at(offset, buf)?;
+        self.set_mtime(RealTimeCoarseClock::get().read_time());
+        self.set_ctime(RealTimeCoarseClock::get().read_time());
+        Ok(size)
+    }
+
+    fn write_direct_at(&self, offset: usize, buf: &mut VmReader) -> Result<usize> {
+        self.write_at(offset, buf)
+    }
+
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        if name.len() > NAME_MAX {
+            return_errno!(Errno::ENAMETOOLONG);
+        }
+        if self.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        if self.lookup(name).is_ok() {
+            return_errno!(Errno::EEXIST);
+        }
+        let new_node = match type_ {
+            InodeType::Dir => PseudoINode::new_dir(name, Some(mode), None, self.this_weak()),
+            InodeType::File => PseudoINode::new_attr(name, Some(mode), None, self.this_weak()),
+            InodeType::SymLink => PseudoINode::new_symlink(name, "", self.this_weak(), None),
+            _ => return_errno!(Errno::EINVAL),
+        }?;
+        Ok(new_node)
+    }
+
+    fn mknod(&self, _name: &str, _mode: InodeMode, _dev: MknodType) -> Result<Arc<dyn Inode>> {
+        Err(Error::new(Errno::ENOTDIR))
+    }
+
+    fn as_device(&self) -> Option<Arc<dyn Device>> {
+        None
+    }
+
+    fn readdir_at(&self, mut offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+            // Read the two special entries.
+            if *offset == 0 {
+                let this_inode = self.this();
+                visitor.visit(".", this_inode.ino(), this_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+            if *offset == 1 {
+                let parent_inode = self.parent().unwrap_or(self.this());
+                visitor.visit("..", parent_inode.ino(), parent_inode.type_(), *offset)?;
+                *offset += 1;
+            }
+
+            // Read the normal child entries.
+            let cached_children = self.elem.read().get_children().unwrap_or_default();
+
+            for (name, inode) in cached_children.iter().skip(*offset - 2) {
+                visitor.visit(name, inode.ino(), inode.type_(), *offset - 2)?;
+                *offset += 1;
+            }
+
+            Ok(())
+        };
+        try_readdir(&mut offset, visitor)?;
+        Ok(offset)
+    }
+
+    fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "hard links not supported in kernfs");
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        // Remove a child from the current node.
+        // The child should be a regular file or a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() == InodeType::Dir {
+            return_errno!(Errno::EPERM);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        // Remove a child from the current node.
+        // The child should be a directory.
+        // The child should not be "." or "..".
+        if name == "." || name == ".." {
+            return_errno!(Errno::EPERM);
+        }
+        if self.lookup(name)?.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        self.remove(name)?;
+        Ok(())
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode: Arc<dyn Inode> = match name {
+            "." => self.this(),
+            ".." => self.parent().unwrap_or(self.this()),
+            name => self.elem.read().lookup(name)?,
+        };
+        Ok(inode)
+    }
+
+    fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "rename is not supported in pseudo filesystem");
+    }
+
+    fn read_link(&self) -> Result<String> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.elem.read().read_link()
+    }
+
+    fn write_link(&self, target: &str) -> Result<()> {
+        if self.type_() != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.elem.write().write_link(target)
+    }
+
+    fn ioctl(&self, _cmd: IoctlCmd, _arg: usize) -> Result<i32> {
+        Err(Error::new(Errno::EISDIR))
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn sync_data(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP);
+    }
+
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        let events = IoEvents::IN | IoEvents::OUT;
+        events & mask
+    }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        true
+    }
+}

--- a/kernel/src/fs/kernfs/mod.rs
+++ b/kernel/src/fs/kernfs/mod.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod element;
+mod inode;
+
+pub use element::PseudoElement;
+pub use inode::PseudoINode;
+
+use super::utils::{FileSystem, Inode};
+use crate::prelude::*;
+
+/// Block size.
+const BLOCK_SIZE: usize = 1024;
+
+/// Provides interfaces for reading and writing to a pseudo file.
+pub trait DataProvider: Any + Sync + Send {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize>;
+    fn write_at(&mut self, reader: &mut VmReader, offset: usize) -> Result<usize>;
+    fn truncate(&mut self, new_size: usize) -> Result<()>;
+}
+
+/// Provides different abstractions for different pseudo-file system requirements.
+/// Processing events and dynamic logic.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::{
+///     kernfs::PseudoExt,
+///     sysfs::Action,
+/// };
+///
+///
+/// struct MyPseudoExt {
+///     subject: Subject<Action>,
+/// }
+///
+/// impl PseudoExt for MyPseudoExt {
+///    fn on_create(&self, name: String, node: Arc<dyn Inode>) -> Result<()> {
+///       // Implementation details...
+///       self.subject.notify_observers(Action::Add);
+///   }
+///
+///    fn on_remove(&self, name: String) -> Result<()> {
+///       // Implementation details...
+///       self.subject.notify_observers(Action::Remove);
+///   }
+/// }
+///
+pub trait PseudoExt: Send + Sync {
+    fn on_create(&self, name: String, node: Arc<dyn Inode>) -> Result<()>;
+    fn on_remove(&self, name: String) -> Result<()>;
+}
+
+/// A trait for the pseudo filesystem.
+///
+/// The pseudo filesystem is a virtual filesystem that is used to provide
+/// a consistent interface for the kernel to interact with the underlying
+/// hardware. It is typically mounted at a specific mount point (e.g., `/sys`)
+/// and provides a hierarchical view of system resources and configurations.
+///
+/// This trait defines the basic operations that a pseudo filesystem must
+/// implement, including allocating unique identifiers, initializing the
+/// filesystem, and providing access to the filesystem itself.
+///
+/// # Methods
+///
+/// - `alloc_id(&self) -> u64`: Allocates and returns a unique identifier for
+///   inodes or other filesystem entities.
+///
+/// # Example
+///
+/// ```rust
+/// use crate::fs::PseudoFileSystem;
+///
+/// struct MyPseudoFS {
+///     // Implementation details...
+/// }
+///
+/// impl PseudoFileSystem for MyPseudoFS {
+///     fn alloc_id(&self) -> u64 {
+///         // Allocate and return a unique ID
+///     }
+/// }
+/// ```
+pub trait PseudoFileSystem: FileSystem {
+    fn alloc_id(&self) -> u64;
+}
+
+/// A toy pseudo filesystem that is working as sysfs.
+/// It takes effect if you mount it to `/sys`.
+#[cfg(ktest)]
+mod tests {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    use ostd::{mm::VmWriter, prelude::ktest};
+
+    use crate::{
+        fs::{
+            kernfs::{DataProvider, PseudoFileSystem, PseudoINode},
+            utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+        },
+        prelude::*,
+    };
+
+    /// ToySysFS filesystem.
+    /// Magic number.
+    const SYSFS_MAGIC: u64 = 0x9fa0;
+    /// Root Inode ID.
+    const SYSFS_ROOT_INO: u64 = 1;
+    /// Block size.
+    const BLOCK_SIZE: usize = 1024;
+
+    pub struct ToySysFS {
+        sb: SuperBlock,
+        root: Arc<dyn Inode>,
+        inode_allocator: AtomicU64,
+    }
+
+    impl ToySysFS {
+        pub fn new() -> Arc<Self> {
+            let fs = Arc::new_cyclic(|weak_fs| Self {
+                sb: SuperBlock::new(SYSFS_MAGIC, BLOCK_SIZE, NAME_MAX),
+                root: SysfsRoot::new_inode(weak_fs.clone()),
+                inode_allocator: AtomicU64::new(SYSFS_ROOT_INO + 1),
+            });
+            let root = fs.root_inode();
+            let root = root.downcast_ref::<PseudoINode>().unwrap();
+            let kernel = PseudoINode::new_dir("kernel", None, None, root.this_weak()).unwrap();
+            let ab = PseudoINode::new_attr("address_bits", None, None, kernel.this_weak()).unwrap();
+            ab.set_data(Box::new(AddressBits)).unwrap();
+            let cpu_byteorder =
+                PseudoINode::new_attr("byteorder", None, None, kernel.this_weak()).unwrap();
+            cpu_byteorder
+                .set_data(Box::new(CpuByteOrder::new()))
+                .unwrap();
+            fs
+        }
+    }
+
+    impl PseudoFileSystem for ToySysFS {
+        fn alloc_id(&self) -> u64 {
+            self.inode_allocator.fetch_add(1, Ordering::SeqCst)
+        }
+    }
+
+    impl FileSystem for ToySysFS {
+        fn sync(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn root_inode(&self) -> Arc<dyn Inode> {
+            self.root.clone()
+        }
+
+        fn sb(&self) -> SuperBlock {
+            self.sb.clone()
+        }
+
+        fn flags(&self) -> FsFlags {
+            FsFlags::empty()
+        }
+    }
+
+    /// Represents the inode at `/sys`.
+    /// Root directory of the sysfs.
+    pub struct SysfsRoot;
+
+    impl SysfsRoot {
+        pub fn new_inode(fs: Weak<ToySysFS>) -> Arc<dyn Inode> {
+            PseudoINode::new_root(fs, SYSFS_ROOT_INO, BLOCK_SIZE, None)
+        }
+    }
+
+    pub struct AddressBits;
+
+    impl DataProvider for AddressBits {
+        fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+            let data = "64\n".as_bytes().to_vec();
+            let start = data.len().min(offset);
+            let end = data.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&data[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+            return_errno_with_message!(Errno::EINVAL, "cpuinfo is read-only");
+        }
+
+        fn truncate(&mut self, _new_size: usize) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    pub struct CpuByteOrder {
+        byte_order: Vec<u8>,
+    }
+
+    impl CpuByteOrder {
+        pub fn new() -> Self {
+            let byte_order = if cfg!(target_endian = "little") {
+                "little\n".as_bytes().to_vec()
+            } else {
+                "big\n".as_bytes().to_vec()
+            };
+            Self { byte_order }
+        }
+    }
+
+    impl Default for CpuByteOrder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl DataProvider for CpuByteOrder {
+        fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+            let start = self.byte_order.len().min(offset);
+            let end = self.byte_order.len().min(offset + writer.avail());
+            let len = end - start;
+            writer.write_fallible(&mut (&self.byte_order[start..end]).into())?;
+            Ok(len)
+        }
+
+        fn write_at(&mut self, reader: &mut VmReader, offset: usize) -> Result<usize> {
+            let write_len = reader.remain();
+            let end = offset + write_len;
+
+            if self.byte_order.len() < end {
+                self.byte_order.resize(end, 0);
+            }
+
+            let mut writer = VmWriter::from(&mut self.byte_order[offset..end]);
+            let value = reader.read_fallible(&mut writer)?;
+            if value != write_len {
+                return_errno!(Errno::EINVAL);
+            }
+
+            Ok(write_len)
+        }
+
+        fn truncate(&mut self, new_size: usize) -> Result<()> {
+            self.byte_order.resize(new_size, 0);
+            Ok(())
+        }
+    }
+
+    fn load_fs() -> Arc<ToySysFS> {
+        crate::time::clocks::init_for_ktest();
+        let fs: Arc<ToySysFS> = ToySysFS::new();
+        fs
+    }
+
+    #[ktest]
+    fn new_fs() {
+        let fs = load_fs();
+        assert_eq!(fs.alloc_id(), SYSFS_ROOT_INO + 4);
+    }
+
+    #[ktest]
+    fn read_address_bits() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let ab = kernel.lookup("address_bits").unwrap();
+        let mut read_buf = vec![0u8; "64\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        ab.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "64\n".as_bytes());
+    }
+
+    #[ktest]
+    fn read_cpu_byteorder() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let mut read_buf = vec![0u8; "little\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "little\n".as_bytes());
+    }
+
+    #[ktest]
+    fn write_cpu_byteorder() {
+        let fs = load_fs();
+        let root = fs.root_inode();
+        let kernel = root.lookup("kernel").unwrap();
+        let cpu_byteorder = kernel.lookup("byteorder").unwrap();
+        let write_buf = "big\n".as_bytes().to_vec();
+        let mut reader = VmReader::from(&write_buf as &[u8]).to_fallible();
+        let write_len = cpu_byteorder.write_at(0, &mut reader).unwrap();
+        assert_eq!(write_len, "big\n".as_bytes().len());
+        let mut read_buf = vec![0u8; "big\n".as_bytes().len()];
+        let mut writer = VmWriter::from(&mut read_buf as &mut [u8]).to_fallible();
+        cpu_byteorder.read_at(0, &mut writer).unwrap();
+        assert_eq!(read_buf, "big\n".as_bytes());
+    }
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -15,6 +15,7 @@ pub mod pipe;
 pub mod procfs;
 pub mod ramfs;
 pub mod rootfs;
+pub mod sysfs;
 pub mod thread_info;
 pub mod utils;
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -8,6 +8,7 @@ pub mod file_handle;
 pub mod file_table;
 pub mod fs_resolver;
 pub mod inode_handle;
+pub mod kernfs;
 pub mod named_pipe;
 pub mod path;
 pub mod pipe;

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -11,6 +11,7 @@ use super::{
     path::MountNode,
     procfs::{self, ProcFS},
     ramfs::RamFS,
+    sysfs::SysFS,
     utils::{FileSystem, InodeMode, InodeType},
 };
 use crate::{fs::path::is_dot, prelude::*};
@@ -113,6 +114,10 @@ pub fn init(initramfs_buf: &[u8]) -> Result<()> {
     // Mount DevFS
     let dev_dentry = fs.lookup(&FsPath::try_from("/dev")?)?;
     dev_dentry.mount(RamFS::new())?;
+    // Mount SysFS
+    let sys_dentry = fs.lookup(&FsPath::try_from("/sys")?)?;
+    let sysfs: Arc<SysFS> = SysFS::new();
+    sys_dentry.mount(sysfs.clone())?;
 
     println!("[kernel] rootfs is ready");
 

--- a/kernel/src/fs/sysfs/devices/mod.rs
+++ b/kernel/src/fs/sysfs/devices/mod.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use ostd::cpu::num_cpus;
+
+use super::{KObject, SysFS, SYSFS_REF};
+use crate::{fs::kernfs::DataProvider, prelude::*};
+
+/// Registers `/sys/devices/system/cpu/online` in the SysFS.
+pub(super) fn register_cpu_online() -> Result<()> {
+    let cpu_kobject = SYSFS_REF
+        .get()
+        .ok_or(Errno::ENOENT)?
+        .init_parent_dirs("/sys/devices/system/cpu/")?;
+    let _ = SysFS::create_attribute("online", 0o444, cpu_kobject, Box::new(CpuOnline), None)?;
+    Ok(())
+}
+
+/// The data provider for the CPU online file.
+/// It returns the online CPUs in the format of "0-<num_cpus>\n".
+/// It is read-only.
+struct CpuOnline;
+
+impl DataProvider for CpuOnline {
+    fn read_at(&self, writer: &mut ostd::mm::VmWriter, offset: usize) -> Result<usize> {
+        let data = format!("0-{}\n", num_cpus() - 1).as_bytes().to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, reader: &mut ostd::mm::VmReader, offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "This file is read-only");
+    }
+
+    fn truncate(&mut self, _new_size: usize) -> Result<()> {
+        return_errno!(Errno::EINVAL);
+    }
+}

--- a/kernel/src/fs/sysfs/event.rs
+++ b/kernel/src/fs/sysfs/event.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    events::{Events, EventsFilter, Observer, Subject},
+    prelude::*,
+};
+
+/// Represents possible actions for a UEvent
+#[derive(Debug, Clone, Copy)]
+pub enum Action {
+    Add,
+    Remove,
+    Offline,
+    Online,
+    Change,
+    Move,
+}
+
+/// Represents a kernel event that can be exported to userspace.
+/// FIXME: Currently, this is a stub implementation, because we don't support UEvent now.
+/// It should be used with the trait `PseudoExt`.
+#[derive(Debug, Clone, Copy)]
+pub struct UEvent {
+    action: Action,
+}
+
+impl UEvent {
+    pub fn new(action: Action) -> Self {
+        Self { action }
+    }
+
+    pub fn export(&self) -> String {
+        match self.action {
+            Action::Add => "ACTION=add\n",
+            Action::Remove => "ACTION=remove\n",
+            Action::Offline => "ACTION=offline\n",
+            Action::Online => "ACTION=online\n",
+            Action::Change => "ACTION=change\n",
+            Action::Move => "ACTION=move\n",
+        }
+        .to_string()
+    }
+}
+
+impl Events for UEvent {}
+
+/// Filter for UEvents (currently filters out all events)
+#[derive(Debug, Clone, Copy)]
+pub struct UEventFilter;
+
+impl EventsFilter<UEvent> for UEventFilter {
+    fn filter(&self, event: &UEvent) -> bool {
+        false
+    }
+}

--- a/kernel/src/fs/sysfs/kernel/mod.rs
+++ b/kernel/src/fs/sysfs/kernel/mod.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::boxed::Box;
+
+use super::{KObject, SysFS, SYSFS_REF};
+use crate::{fs::kernfs::DataProvider, prelude::*};
+
+/// Registers `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size` in the SysFS.
+pub(super) fn register_huge_page() -> Result<()> {
+    let transparent_hugepage_kobject = SYSFS_REF
+        .get()
+        .ok_or(Errno::ENOENT)?
+        .init_parent_dirs("/sys/kernel/mm/transparent_hugepage")?;
+    let _ = SysFS::create_attribute(
+        "hpage_pmd_size",
+        0o444,
+        transparent_hugepage_kobject,
+        Box::new(HugepagePmdSize),
+        None,
+    )?;
+    Ok(())
+}
+
+// FIXME: we don't support transparent_hugepage now, so we just return 0.
+pub struct HugepagePmdSize;
+
+impl DataProvider for HugepagePmdSize {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+        let data = "0\n".as_bytes().to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, _reader: &mut VmReader, _offset: usize) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "HugepagePmdSize is read-only");
+    }
+
+    fn truncate(&mut self, _new_size: usize) -> Result<()> {
+        return_errno!(Errno::EINVAL);
+    }
+}

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+#![allow(unused)]
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use devices::register_cpu_online;
+use event::UEvent;
+use kernel::register_huge_page;
+use power::register_power_state;
+use spin::Once;
+
+use super::{
+    kernfs::{PseudoExt, PseudoINode},
+    utils::InodeMode,
+};
+use crate::{
+    fs::{
+        kernfs::{DataProvider, PseudoFileSystem},
+        utils::{FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+    },
+    prelude::*,
+};
+
+mod devices;
+mod event;
+mod kernel;
+mod power;
+
+/// Magic number.
+const SYSFS_MAGIC: u64 = 0x62656572;
+/// Root Inode ID.
+const SYSFS_ROOT_INO: u64 = 1;
+/// Block size.
+const BLOCK_SIZE: usize = 1024;
+
+pub type KObject = PseudoINode;
+
+/// The reference to the SysFS filesystem.
+/// The devices can use this reference to register their attributes.
+pub static SYSFS_REF: Once<Arc<SysFS>> = Once::new();
+
+/// Represents the SysFS filesystem.
+pub struct SysFS {
+    sb: SuperBlock,
+    root: Arc<dyn Inode>,
+    inode_allocator: AtomicU64,
+    this: Weak<Self>,
+}
+
+impl SysFS {
+    pub fn new() -> Arc<Self> {
+        let fs = Arc::new_cyclic(|weak_fs| Self {
+            sb: SuperBlock::new(SYSFS_MAGIC, BLOCK_SIZE, NAME_MAX),
+            root: SysfsRoot::new_inode(weak_fs.clone()),
+            inode_allocator: AtomicU64::new(SYSFS_ROOT_INO + 1),
+            this: weak_fs.clone(),
+        });
+        SYSFS_REF.call_once(|| fs.clone());
+        register_huge_page().unwrap();
+        register_cpu_online().unwrap();
+        register_power_state().unwrap();
+        fs
+    }
+
+    pub fn create_attribute(
+        name: &str,
+        mode: u16,
+        parent: Arc<KObject>,
+        attribute: Box<dyn DataProvider>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Result<Arc<KObject>> {
+        let mode = InodeMode::from_bits_truncate(mode);
+        let attr = KObject::new_attr(name, Some(mode), pseudo_extension, parent.this_weak())?;
+        attr.set_data(attribute).unwrap();
+        Ok(attr)
+    }
+
+    pub fn create_dir(
+        name: &str,
+        mode: u16,
+        parent: Arc<KObject>,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Result<Arc<KObject>> {
+        let mode = InodeMode::from_bits_truncate(mode);
+        KObject::new_dir(name, Some(mode), pseudo_extension, parent.this_weak())
+    }
+
+    pub fn create_symlink(
+        name: &str,
+        parent: Arc<KObject>,
+        target: &str,
+        pseudo_extension: Option<Arc<dyn PseudoExt>>,
+    ) -> Result<Arc<KObject>> {
+        KObject::new_symlink(name, target, parent.this_weak(), pseudo_extension)
+    }
+
+    /// Initialize the parent directories of the given path.
+    /// If the parent directories do not exist, create them.
+    /// Return the KObject reference of the last directory.
+    /// The extensions are not set. The caller should set them by `KObject::set_pseudo_extensions` if needed.
+    pub fn init_parent_dirs(&self, parent: &str) -> Result<Arc<KObject>> {
+        let mut parent_node = self.root_inode().downcast_ref::<KObject>().unwrap().this();
+        for dir in parent.split('/') {
+            if dir.is_empty() || dir == "sys" {
+                continue;
+            }
+            if let Ok(next) = parent_node.lookup(dir) {
+                parent_node = next.downcast_ref::<KObject>().unwrap().this();
+            } else {
+                parent_node = SysFS::create_dir(dir, 0o755, parent_node.clone(), None)?;
+            }
+        }
+        Ok(parent_node)
+    }
+}
+
+impl PseudoFileSystem for SysFS {
+    fn alloc_id(&self) -> u64 {
+        self.inode_allocator.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+impl FileSystem for SysFS {
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root.clone()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.sb.clone()
+    }
+
+    fn flags(&self) -> FsFlags {
+        FsFlags::empty()
+    }
+}
+
+/// Represents the root directory of the sysfs filesystem
+pub struct SysfsRoot;
+
+impl SysfsRoot {
+    pub fn new_inode(fs: Weak<SysFS>) -> Arc<dyn Inode> {
+        KObject::new_root(fs, SYSFS_ROOT_INO, BLOCK_SIZE, None)
+    }
+}

--- a/kernel/src/fs/sysfs/power/mod.rs
+++ b/kernel/src/fs/sysfs/power/mod.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::boxed::Box;
+
+use ostd::arch::qemu::{exit_qemu, QemuExitCode};
+
+use super::{KObject, SysFS, UEvent, SYSFS_REF};
+use crate::{
+    fs::kernfs::{DataProvider, PseudoExt},
+    prelude::*,
+    util::MultiRead,
+};
+
+/// Registers `/sys/power/state` in the SysFS.
+pub(super) fn register_power_state() -> Result<()> {
+    let power_kobj = SYSFS_REF
+        .get()
+        .ok_or(Errno::ENOENT)?
+        .init_parent_dirs("/sys/power/")?;
+    let _ = SysFS::create_attribute("state", 0o644, power_kobj, Box::new(State), None)?;
+    Ok(())
+}
+
+/// Represents the power state attribute in sysfs
+pub struct State;
+
+impl DataProvider for State {
+    fn read_at(&self, writer: &mut VmWriter, offset: usize) -> Result<usize> {
+        let data = "freeze mem disk\n".as_bytes().to_vec();
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&mut self, reader: &mut VmReader, _offset: usize) -> Result<usize> {
+        let mut buffer = vec![0u8; reader.remain()];
+        reader.read(&mut buffer.as_mut_slice().into())?;
+        let buffer = core::str::from_utf8(&buffer)?;
+        // FIXME: Implement the power state transition
+        match buffer {
+            "poweroff\n" => {
+                exit_qemu(QemuExitCode::Success);
+            }
+            "reboot\n" => {
+                todo!();
+            }
+            "mem\n" => {
+                todo!();
+            }
+            "disk\n" => {
+                todo!();
+            }
+            "freeze\n" => {
+                todo!();
+            }
+            _ => {}
+        }
+        Ok(buffer.len())
+    }
+
+    fn truncate(&mut self, _new_size: usize) -> Result<()> {
+        Ok(())
+    }
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ INITRAMFS_EMPTY_DIRS := \
 	$(INITRAMFS)/tmp \
 	$(INITRAMFS)/opt \
 	$(INITRAMFS)/proc \
+	$(INITRAMFS)/sys \
 	$(INITRAMFS)/dev \
 	$(INITRAMFS)/ext2 \
 	$(INITRAMFS)/exfat


### PR DESCRIPTION
This PR should be merged after #1884. It introduces the integration of the **SysFS (System File System)** into the kernel, enabling userspace access to kernel and device information through a hierarchical file structure. The implementation follows Linux conventions, exposing devices, kernel parameters, and power management controls via `/sys`.

#### Key Changes:
1. **SysFS Core Infrastructure**:
   - **Hierarchy Management**: Supports directories, symlinks, and attribute files via `KObject` abstractions.
   - **Dynamic Inode Allocation**: Uses an atomic counter to assign unique inode IDs.
   - **Data Providers**: Implemented `DataProvider` trait for dynamic file content (e.g., CPU online status, TTY device IDs).

2. **Device Exposure**:
   - **TTY SysFS Integration**:
     - Created `export_sys.rs` to register TTYs under `/sys/devices/virtual/tty/` and symlinks in `/sys/class/tty/`.
     - Added `dev` (major:minor ID) and `uevent` (device metadata) attributes for each TTY.
   - **CPU Information**:
     - Exposed CPU online status via `/sys/devices/system/cpu/online`.
   - **Power Management**:
     - Added `/sys/power/state` for basic power control (stub implementation).

3. **Kernel Parameters**:
   - Added `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size` (currently returns 0).

4. **Initialization**:
   - Mounted SysFS at `/sys` during root filesystem setup.
   - Auto-created parent directories for device entries (e.g., `/sys/devices/virtual/tty`).

#### Implementation Highlights:
- **Extensible Structure**: `SysFS` uses `KObject` nodes to represent directories/files, with `DataProvider` handling read/write operations.
- **Standard Compliance**: Follows Linux SysFS layout (e.g., devices under `/sys/devices`, class symlinks in `/sys/class`).
- **Stub Foundations**: Placeholders for future work (e.g., `UEvent` support, full power state handling).

#### Example SysFS Tree:
```
/sys/
├── class/
│   └── tty/ -> ../../devices/virtual/tty/
├── devices/
│   ├── system/
│   │   └── cpu/
│   │       └── online (ro: "0-N")
│   └── virtual/
│       └── tty/
│           └── console/
│               ├── dev (ro: "major:minor")
│               └── uevent (ro: "MAJOR=X...")
├── kernel/
│   └── mm/.../hpage_pmd_size (ro: "0")
└── power/
    └── state (rw: "freeze mem disk")
```

#### Future Work:
- Implement full `UEvent` propagation for device hotplug notifications.
- Add more kernel subsystems to SysFS (e.g., module parameters, buses).
