### PR TITLE
Support netlink route socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ version = "0.1.0"
 dependencies = [
  "aster-softirq",
  "bitflags 1.3.2",
+ "int-to-c-enum",
  "jhash",
  "ostd",
  "smoltcp",

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 aster-softirq = { path = "../../comps/softirq" }
 bitflags = "1.3"
+int-to-c-enum = { path = "../int-to-c-enum" }
 jhash = { path = "../jhash" }
 ostd = { path = "../../../ostd" }
 smoltcp = { git = "https://github.com/asterinas/smoltcp", tag = "r_2024-11-08_f07e5b5", default-features = false, features = [

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -6,8 +6,11 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_softirq::BottomHalfDisabled;
+use bitflags::bitflags;
+use int_to_c_enum::TryFromInt;
 use ostd::sync::{SpinLock, SpinLockGuard};
 use smoltcp::{
     iface::{packet::Packet, Context},
@@ -30,7 +33,11 @@ use crate::{
 };
 
 pub struct IfaceCommon<E: Ext> {
+    index: u32,
     name: String,
+    type_: InterfaceType,
+    flags: InterfaceFlags,
+
     interface: SpinLock<PollableIface<E>, BottomHalfDisabled>,
     used_ports: SpinLock<BTreeMap<u16, usize>, BottomHalfDisabled>,
     sockets: SpinLock<SocketTable<E>, BottomHalfDisabled>,
@@ -40,11 +47,18 @@ pub struct IfaceCommon<E: Ext> {
 impl<E: Ext> IfaceCommon<E> {
     pub(super) fn new(
         name: String,
+        type_: InterfaceType,
+        flags: InterfaceFlags,
         interface: smoltcp::iface::Interface,
         sched_poll: E::ScheduleNextPoll,
     ) -> Self {
+        let index = INTERFACE_INDEX_ALLOCATOR.fetch_add(1, Ordering::Relaxed);
+
         Self {
+            index,
             name,
+            type_,
+            flags,
             interface: SpinLock::new(PollableIface::new(interface)),
             used_ports: SpinLock::new(BTreeMap::new()),
             sockets: SpinLock::new(SocketTable::new()),
@@ -52,18 +66,39 @@ impl<E: Ext> IfaceCommon<E> {
         }
     }
 
+    pub(super) fn index(&self) -> u32 {
+        self.index
+    }
+
     pub(super) fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(super) fn type_(&self) -> InterfaceType {
+        self.type_
+    }
+
+    pub(super) fn flags(&self) -> InterfaceFlags {
+        self.flags
     }
 
     pub(super) fn ipv4_addr(&self) -> Option<Ipv4Address> {
         self.interface.lock().ipv4_addr()
     }
 
+    pub(super) fn prefix_len(&self) -> Option<u8> {
+        self.interface.lock().prefix_len()
+    }
+
     pub(super) fn sched_poll(&self) -> &E::ScheduleNextPoll {
         &self.sched_poll
     }
 }
+
+/// An allocator that allocates a unique index for each interface.
+//
+// FIXME: This allocator is specific to each network namespace.
+pub static INTERFACE_INDEX_ALLOCATOR: AtomicU32 = AtomicU32::new(1);
 
 // Lock order: `interface` -> `sockets`
 impl<E: Ext> IfaceCommon<E> {
@@ -243,5 +278,81 @@ impl<E: Ext> BoundPort<E> {
 impl<E: Ext> Drop for BoundPort<E> {
     fn drop(&mut self) {
         self.iface.common().release_port(self.port);
+    }
+}
+
+/// Interface type.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.18/source/include/uapi/linux/if_arp.h#L30>
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, TryFromInt, PartialEq, Eq)]
+pub enum InterfaceType {
+    // Arp protocol hardware identifiers
+    /// from KA9Q: NET/ROM pseudo
+    NETROM = 0,
+    /// Ethernet 10Mbps
+    ETHER = 1,
+    /// Experimental Ethernet
+    EETHER = 2,
+
+    // Dummy types for non ARP hardware
+    /// IPIP tunnel
+    TUNNEL = 768,
+    /// IP6IP6 tunnel
+    TUNNEL6 = 769,
+    /// Frame Relay Access Device
+    FRAD = 770,
+    /// SKIP vif
+    SKIP = 771,
+    /// Loopback device
+    LOOPBACK = 772,
+    /// Localtalk device
+    LOCALTALK = 773,
+    // TODO: This enum is not exhaustive
+}
+
+bitflags! {
+    /// Interface flags.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.0.18/source/include/uapi/linux/if.h#L82>
+    pub struct InterfaceFlags: u32 {
+        /// Interface is up
+        const UP				= 1<<0;
+        /// Broadcast address valid
+        const BROADCAST			= 1<<1;
+        /// Turn on debugging
+        const DEBUG			    = 1<<2;
+        /// Loopback net
+        const LOOPBACK			= 1<<3;
+        /// Interface is has p-p link
+        const POINTOPOINT		= 1<<4;
+        /// Avoid use of trailers
+        const NOTRAILERS		= 1<<5;
+        /// Interface RFC2863 OPER_UP
+        const RUNNING			= 1<<6;
+        /// No ARP protocol
+        const NOARP			    = 1<<7;
+        /// Receive all packets
+        const PROMISC			= 1<<8;
+        /// Receive all multicast packets
+        const ALLMULTI			= 1<<9;
+        /// Master of a load balancer
+        const MASTER			= 1<<10;
+        /// Slave of a load balancer
+        const SLAVE			    = 1<<11;
+        /// Supports multicast
+        const MULTICAST			= 1<<12;
+        /// Can set media type
+        const PORTSEL			= 1<<13;
+        /// Auto media select active
+        const AUTOMEDIA			= 1<<14;
+        /// Dialup device with changing addresses
+        const DYNAMIC			= 1<<15;
+        /// Driver signals L1 up
+        const LOWER_UP			= 1<<16;
+        /// Driver signals dormant
+        const DORMANT			= 1<<17;
+        /// Echo sent packets
+        const ECHO			    = 1<<18;
     }
 }

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -10,7 +10,7 @@ mod port;
 mod sched;
 mod time;
 
-pub use common::BoundPort;
+pub use common::{BoundPort, InterfaceFlags, InterfaceType};
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -39,6 +39,13 @@ impl<E: Ext> PollableIface<E> {
         self.interface.ipv4_addr()
     }
 
+    pub(super) fn prefix_len(&self) -> Option<u8> {
+        self.interface
+            .ip_addrs()
+            .first()
+            .map(|ip_addr| ip_addr.prefix_len())
+    }
+
     /// Returns the next poll time.
     pub(super) fn next_poll_at_ms(&self) -> Option<u64> {
         self.pending_conns.next_poll_at_ms()

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(step_trait)]
 #![feature(trait_alias)]
 #![feature(trait_upcasting)]
+#![feature(associated_type_defaults)]
 #![register_tool(component_access_control)]
 
 use kcmdline::KCmdlineArg;

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -5,6 +5,7 @@ pub mod socket;
 
 pub fn init() {
     iface::init();
+    socket::netlink::init();
     socket::vsock::init();
 }
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 pub mod ip;
+pub mod netlink;
 pub mod options;
 pub mod unix;
 mod util;

--- a/kernel/src/net/socket/netlink/addr/mod.rs
+++ b/kernel/src/net/socket/netlink/addr/mod.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod multicast;
+
+pub use multicast::{GroupIdSet, MAX_GROUPS};
+
+use crate::{net::socket::SocketAddr, prelude::*};
+
+/// The socket address of a netlink socket.
+///
+/// The address contains the port number for unicast
+/// and the group IDs for multicast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetlinkSocketAddr {
+    port: PortNum,
+    groups: GroupIdSet,
+}
+
+impl NetlinkSocketAddr {
+    /// Creates a new netlink address.
+    pub const fn new(port: PortNum, groups: GroupIdSet) -> Self {
+        Self { port, groups }
+    }
+
+    /// Creates a new unspecified address.
+    ///
+    /// Both the port ID and group numbers are left unspecified.
+    ///
+    /// Note that an unspecified address can also represent the kernel socket address.
+    pub const fn new_unspecified() -> Self {
+        Self {
+            port: UNSPECIFIED_PORT,
+            groups: GroupIdSet::new_empty(),
+        }
+    }
+
+    /// Returns the port number.
+    pub const fn port(&self) -> PortNum {
+        self.port
+    }
+
+    /// Returns the group ID set.
+    pub const fn groups(&self) -> GroupIdSet {
+        self.groups
+    }
+}
+
+impl TryFrom<SocketAddr> for NetlinkSocketAddr {
+    type Error = Error;
+
+    fn try_from(value: SocketAddr) -> Result<Self> {
+        match value {
+            SocketAddr::Netlink(addr) => Ok(addr),
+            _ => return_errno_with_message!(
+                Errno::EAFNOSUPPORT,
+                "the address is in an unsupported address family"
+            ),
+        }
+    }
+}
+
+impl From<NetlinkSocketAddr> for SocketAddr {
+    fn from(value: NetlinkSocketAddr) -> Self {
+        SocketAddr::Netlink(value)
+    }
+}
+
+pub type NetlinkProtocolId = u32;
+pub type PortNum = u32;
+
+pub const UNSPECIFIED_PORT: PortNum = 0;

--- a/kernel/src/net/socket/netlink/addr/multicast.rs
+++ b/kernel/src/net/socket/netlink/addr/multicast.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+/// A set of group IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GroupIdSet(u32);
+
+impl GroupIdSet {
+    /// Creates a new empty `GroupIdSet`.
+    pub const fn new_empty() -> Self {
+        Self(0)
+    }
+
+    /// Creates a new `GroupIdSet` with multiple groups.
+    ///
+    /// Each 1 bit in `groups` represent a group.
+    pub const fn new(groups: u32) -> Self {
+        Self(groups)
+    }
+
+    /// Creates an iterator over all group IDs.
+    pub const fn ids_iter(&self) -> GroupIdIter {
+        GroupIdIter::new(self)
+    }
+
+    /// Adds a new group.
+    ///
+    /// If the group already exists, this method will return an error.
+    pub fn add_group(&mut self, group_id: GroupId) -> Result<()> {
+        if group_id >= 32 {
+            return_errno_with_message!(Errno::EINVAL, "the group ID is invalid");
+        }
+
+        let mask = 1u32 << group_id;
+        if self.0 & mask != 0 {
+            return_errno_with_message!(Errno::EINVAL, "the group ID already exists");
+        }
+        self.0 |= mask;
+
+        Ok(())
+    }
+
+    /// Sets new groups.
+    pub fn set_groups(&mut self, new_groups: u32) {
+        self.0 = new_groups;
+    }
+
+    /// Clears all groups.
+    pub fn clear(&mut self) {
+        self.0 = 0;
+    }
+
+    /// Checks if the set of group IDs is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns the group IDs as a u32.
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Iterator over a set of group IDs.
+pub struct GroupIdIter {
+    groups: u32,
+}
+
+impl GroupIdIter {
+    const fn new(groups: &GroupIdSet) -> Self {
+        Self { groups: groups.0 }
+    }
+}
+
+impl Iterator for GroupIdIter {
+    type Item = GroupId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.groups > 0 {
+            let group_id = self.groups.trailing_zeros();
+            self.groups &= self.groups - 1;
+            return Some(group_id);
+        }
+
+        None
+    }
+}
+
+pub const MAX_GROUPS: u32 = 32;
+pub type GroupId = u32;

--- a/kernel/src/net/socket/netlink/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/message/attr/mod.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Netlink attributes.
+//!
+//! Netlink attributes provide additional information for each [`segment`].
+//! Each netlink attribute consists of two components:
+//! 1. Header: The attribute header is of type [`CNlAttrHeader`],
+//!    which specifies the type and length of the attribute. The attribute
+//!    type belongs to different classes, which rely on the segment type.
+//! 2. Payload: The attribute's payload, which can vary in type.
+//!    Currently, payload types include primitive types, C string, and binary.
+//!    The payload can also include one or multiple other attributes,
+//!    known as nested attributes.
+//!
+//! Similar to [`super::segment::NlSegment`], attributes have alignment requirements;
+//! both the header and payload must be aligned to [`super::NLMSG_ALIGN`]
+//! when being transferred to and from user space.
+//!
+//! The layout of a netlink attribute is depicted as follows:
+//!
+//! ┌────────┬─────────┬─────────┬─────────┐
+//! │ Header │ Padding │ Payload │ Padding │
+//! └────────┴─────────┴─────────┴─────────┘
+//!
+//! [`segment`]: super::segment
+
+use align_ext::AlignExt;
+
+use super::NLMSG_ALIGN;
+use crate::{
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+pub mod noattr;
+
+/// Netlink attribute header.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L229>.
+//
+// The layout of the `type_` field is structured as follows:
+// ┌────────┬───────────────┬──────────┐
+// │ Nested │ Net Byteorder │ Payload  │
+// └────────┴───────────────┴──────────┘
+//   bit 15      bit 14       bits 13-0
+#[derive(Debug, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct CAttrHeader {
+    len: u16,
+    type_: u16,
+}
+
+impl CAttrHeader {
+    pub fn type_(&self) -> u16 {
+        self.type_ & ATTRIBUTE_TYPE_MASK
+    }
+}
+
+const IS_NESTED_MASK: u16 = 1u16 << 15;
+const IS_NET_BYTEORDER_MASK: u16 = 1u16 << 14;
+const ATTRIBUTE_TYPE_MASK: u16 = !(IS_NESTED_MASK | IS_NET_BYTEORDER_MASK);
+
+/// Netlink Attribute.
+pub trait Attribute: Debug + Send + Sync {
+    /// Returns the type of the attribute.
+    fn type_(&self) -> u16;
+
+    /// Returns the byte representation of the payload.
+    fn payload_as_bytes(&self) -> &[u8];
+
+    /// Returns the payload length (excluding padding).
+    fn payload_len(&self) -> usize {
+        self.payload_as_bytes().len()
+    }
+
+    /// Returns the total length of the attribute (header + payload, excluding padding).
+    fn total_len(&self) -> usize {
+        core::mem::size_of::<CAttrHeader>() + self.payload_len()
+    }
+
+    /// Returns the total length of the attribute (header + payload, including padding).
+    fn total_len_with_padding(&self) -> usize {
+        self.total_len().align_up(NLMSG_ALIGN)
+    }
+
+    /// Returns the length of the padding bytes.
+    fn padding_len(&self) -> usize {
+        self.total_len_with_padding() - self.total_len()
+    }
+
+    /// Reads the attribute from the `reader`.
+    fn read_from(reader: &mut dyn MultiRead) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Reads all attributes from the reader.
+    ///
+    /// The cumulative length of the read attributes must not exceed total_len.
+    fn read_all_from(reader: &mut dyn MultiRead, mut total_len: usize) -> Result<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        let mut res = Vec::new();
+
+        while total_len > 0 {
+            let attr = Self::read_from(reader)?;
+            total_len -= attr.total_len();
+
+            let padding_len = attr.padding_len().min(total_len);
+            reader.skip(padding_len);
+            total_len -= padding_len;
+
+            res.push(attr);
+        }
+
+        Ok(res)
+    }
+
+    /// Writes the attribute to the `writer`.
+    fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()> {
+        let header = CAttrHeader {
+            type_: self.type_(),
+            len: self.total_len() as u16,
+        };
+
+        writer.write_val(&header)?;
+        writer.write(&mut VmReader::from(self.payload_as_bytes()))?;
+
+        let padding_len = self.padding_len();
+        writer.skip(padding_len);
+
+        Ok(())
+    }
+}

--- a/kernel/src/net/socket/netlink/message/attr/noattr.rs
+++ b/kernel/src/net/socket/netlink/message/attr/noattr.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::Attribute;
+use crate::{prelude::*, util::MultiRead};
+
+/// A special type indicates that a segment cannot have attributes.
+#[derive(Debug)]
+pub enum NoAttr {}
+
+impl Attribute for NoAttr {
+    fn type_(&self) -> u16 {
+        match *self {}
+    }
+
+    fn payload_as_bytes(&self) -> &[u8] {
+        match *self {}
+    }
+
+    fn read_from(_reader: &mut dyn MultiRead) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        return_errno_with_message!(Errno::EINVAL, "`NoAttr` cannot be read");
+    }
+
+    fn read_all_from(_reader: &mut dyn MultiRead, _total_len: usize) -> Result<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(Vec::new())
+    }
+}

--- a/kernel/src/net/socket/netlink/message/mod.rs
+++ b/kernel/src/net/socket/netlink/message/mod.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Netlink message types for all netlink protocols.
+//!
+//! This module defines how to interpret messages sent from user space and how to write
+//! kernel messages back to user space.
+
+mod attr;
+mod segment;
+
+pub(super) use attr::{noattr::NoAttr, Attribute, CAttrHeader};
+pub(super) use segment::{
+    ack::{DoneSegment, ErrorSegment},
+    common::SegmentCommon,
+    header::{CMsgSegHdr, GetRequestFlags, SegHdrCommonFlags},
+    CSegmentType, SegmentBody,
+};
+
+use crate::{
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+/// A netlink message.
+///
+/// A netlink message can be transmitted to and from user space using a single send/receive syscall.
+/// It consists of one or more [`ProtocolSegment`]s.
+#[derive(Debug)]
+pub(super) struct Message<T: ProtocolSegment> {
+    segments: Vec<T>,
+}
+
+impl<T: ProtocolSegment> Message<T> {
+    pub(super) const fn new(segments: Vec<T>) -> Self {
+        Self { segments }
+    }
+
+    pub(super) fn segments(&self) -> &[T] {
+        &self.segments
+    }
+
+    pub(super) fn segments_mut(&mut self) -> &mut [T] {
+        &mut self.segments
+    }
+
+    pub(super) fn read_from(reader: &mut dyn MultiRead) -> Result<Self> {
+        // FIXME: Does a request contain only one segment? We need to investigate further.
+        let segments = {
+            let segment = T::read_from(reader)?;
+            vec![segment]
+        };
+
+        Ok(Self { segments })
+    }
+
+    pub(super) fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()> {
+        for segment in self.segments.iter() {
+            segment.write_to(writer)?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn total_len(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.header().len as usize)
+            .sum()
+    }
+}
+
+pub(super) trait ProtocolSegment: Sized {
+    fn header(&self) -> &CMsgSegHdr;
+    fn header_mut(&mut self) -> &mut CMsgSegHdr;
+    fn read_from(reader: &mut dyn MultiRead) -> Result<Self>;
+    fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()>;
+}
+
+pub(super) const NLMSG_ALIGN: usize = 4;

--- a/kernel/src/net/socket/netlink/message/segment/ack.rs
+++ b/kernel/src/net/socket/netlink/message/segment/ack.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module defines segments that only appear in acknowledgment messages.
+//!
+//! An acknowledgment segment appears as the final segment in a response message from the kernel.
+//! Netlink utilizes two classes of acknowledgment segments:
+//! 1. Done Segment: Indicates the conclusion of a message comprised of multiple segments.
+//! 2. Error Segment: Indicates that an error occurred while the kernel processed the user space request.
+//!
+
+use super::{
+    common::SegmentCommon,
+    header::{CMsgSegHdr, SegHdrCommonFlags},
+    CSegmentType, SegmentBody,
+};
+use crate::{net::socket::netlink::message::NoAttr, prelude::*};
+
+pub type DoneSegment = SegmentCommon<DoneSegmentBody, NoAttr>;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+pub struct DoneSegmentBody {
+    error_code: i32,
+}
+
+impl SegmentBody for DoneSegmentBody {
+    type CType = DoneSegmentBody;
+}
+
+impl DoneSegment {
+    pub fn new_from_request(request_header: &CMsgSegHdr, error: Option<Error>) -> Self {
+        let header = CMsgSegHdr {
+            len: 0,
+            type_: CSegmentType::DONE as _,
+            flags: SegHdrCommonFlags::empty().bits(),
+            seq: request_header.seq,
+            pid: request_header.pid,
+        };
+
+        let body = {
+            let error_code = error_to_error_code(error);
+            DoneSegmentBody { error_code }
+        };
+
+        Self::new(header, body, Vec::new())
+    }
+}
+
+pub type ErrorSegment = SegmentCommon<ErrorSegmentBody, NoAttr>;
+
+#[derive(Debug, Pod, Clone, Copy)]
+#[repr(C)]
+pub struct ErrorSegmentBody {
+    error_code: i32,
+    request_header: CMsgSegHdr,
+}
+
+impl SegmentBody for ErrorSegmentBody {
+    type CType = ErrorSegmentBody;
+}
+
+impl ErrorSegment {
+    pub fn new_from_request(request_header: &CMsgSegHdr, error: Option<Error>) -> Self {
+        let header = CMsgSegHdr {
+            len: 0,
+            type_: CSegmentType::ERROR as _,
+            flags: SegHdrCommonFlags::empty().bits(),
+            seq: request_header.seq,
+            pid: request_header.pid,
+        };
+
+        let body = {
+            let error_code = error_to_error_code(error);
+            ErrorSegmentBody {
+                error_code,
+                request_header: *request_header,
+            }
+        };
+
+        Self::new(header, body, Vec::new())
+    }
+}
+
+const fn error_to_error_code(error: Option<Error>) -> i32 {
+    if let Some(error) = error {
+        -(error.error() as i32)
+    } else {
+        0
+    }
+}

--- a/kernel/src/net/socket/netlink/message/segment/common.rs
+++ b/kernel/src/net/socket/netlink/message/segment/common.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use align_ext::AlignExt;
+
+use super::{header::CMsgSegHdr, SegmentBody};
+use crate::{
+    net::socket::netlink::message::{attr::Attribute, NLMSG_ALIGN},
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+#[derive(Debug)]
+pub struct SegmentCommon<Body, Attr> {
+    header: CMsgSegHdr,
+    body: Body,
+    attrs: Vec<Attr>,
+}
+
+impl<Body, Attr> SegmentCommon<Body, Attr> {
+    pub const HEADER_LEN: usize = size_of::<CMsgSegHdr>();
+
+    pub fn header(&self) -> &CMsgSegHdr {
+        &self.header
+    }
+
+    pub fn header_mut(&mut self) -> &mut CMsgSegHdr {
+        &mut self.header
+    }
+
+    pub fn body(&self) -> &Body {
+        &self.body
+    }
+
+    pub fn attrs(&self) -> &Vec<Attr> {
+        &self.attrs
+    }
+}
+
+impl<Body: SegmentBody, Attr: Attribute> SegmentCommon<Body, Attr> {
+    pub const BODY_LEN: usize = size_of::<Body::CType>();
+
+    pub fn new(header: CMsgSegHdr, body: Body, attrs: Vec<Attr>) -> Self {
+        let mut res = Self {
+            header,
+            body,
+            attrs,
+        };
+        res.header.len = res.total_len() as u32;
+        res
+    }
+
+    pub fn read_from(header: CMsgSegHdr, reader: &mut dyn MultiRead) -> Result<Self>
+    where
+        Error: From<<Body::CType as TryInto<Body>>::Error>,
+    {
+        let (body, remain_len) = Body::read_from(&header, reader).unwrap();
+
+        let attrs = Attr::read_all_from(reader, remain_len)?;
+
+        Ok(Self {
+            header,
+            body,
+            attrs,
+        })
+    }
+
+    pub fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()> {
+        // FIXME: If the message can be truncated, we should avoid returning an error.
+        // Furthermore, we need to check the Linux behavior to determine whether to return an error
+        // if the writer is not large enough to accommodate the final padding bytes.
+        if writer.sum_lens() < (self.header.len as usize).align_up(NLMSG_ALIGN) {
+            return_errno_with_message!(Errno::EFAULT, "the writer length is too small");
+        }
+
+        writer.write_val(&self.header)?;
+        self.body.write_to(writer)?;
+        for attr in self.attrs.iter() {
+            attr.write_to(writer)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn total_len(&self) -> usize {
+        Self::HEADER_LEN + Self::BODY_LEN + self.attrs_len()
+    }
+}
+
+impl<Body, Attr: Attribute> SegmentCommon<Body, Attr> {
+    pub fn attrs_len(&self) -> usize {
+        self.attrs
+            .iter()
+            .map(|attr| attr.total_len_with_padding())
+            .sum()
+    }
+}

--- a/kernel/src/net/socket/netlink/message/segment/header.rs
+++ b/kernel/src/net/socket/netlink/message/segment/header.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! General netlink message types for all netlink protocols.
+
+use crate::prelude::*;
+
+/// `nlmsghdr` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L52>.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+pub struct CMsgSegHdr {
+    /// Length of the message, including the header
+    pub len: u32,
+    /// Type of message content
+    pub type_: u16,
+    /// Additional flags
+    pub flags: u16,
+    /// Sequence number
+    pub seq: u32,
+    /// Sending process port ID
+    pub pid: u32,
+}
+
+bitflags! {
+    /// Common flags used in [`CMsgSegmentHdr`].
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L62>.
+    pub struct SegHdrCommonFlags: u16 {
+        /// Indicates a request message
+        const REQUEST = 0x01;
+        /// Multipart message, terminated by NLMSG_DONE
+        const MULTI = 0x02;
+        /// Reply with an acknowledgment, with zero or an error code
+        const ACK = 0x04;
+        /// Echo this request
+        const ECHO = 0x08;
+        /// Dump was inconsistent due to sequence change
+        const DUMP_INTR = 0x10;
+        /// Dump was filtered as requested
+        const DUMP_FILTERED = 0x20;
+    }
+}
+
+bitflags! {
+    /// Modifiers for GET requests.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L70>.
+    pub struct GetRequestFlags: u16 {
+        /// Specify the tree root
+        const ROOT = 0x100;
+        /// Return all matching results
+        const MATCH = 0x200;
+        /// Atomic get request
+        const ATOMIC = 0x400;
+        /// Combination flag for root and match
+        const DUMP = Self::ROOT.bits | Self::MATCH.bits;
+    }
+}
+
+bitflags! {
+    /// Modifiers for NEW requests.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L76>.
+    pub struct NewRequestFlags: u16 {
+        /// Override existing entries
+        const REPLACE = 0x100;
+        /// Do not modify if it exists
+        const EXCL = 0x200;
+        /// Create if it does not exist
+        const CREATE = 0x400;
+        /// Add to the end of the list
+        const APPEND = 0x800;
+    }
+}
+
+bitflags! {
+    /// Modifiers for DELETE requests.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L82>.
+    pub struct DeleteRequestFlags: u16 {
+        /// Do not delete recursively
+        const NONREC = 0x100;
+        /// Delete multiple objects
+        const BULK = 0x200;
+    }
+}
+
+bitflags! {
+    /// Flags for ACK messages.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/netlink.h#L86>.
+    pub struct AckFlags: u16 {
+        const CAPPED = 0x100;
+        const ACK_TLVS = 0x100;
+    }
+}

--- a/kernel/src/net/socket/netlink/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/message/segment/mod.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use align_ext::AlignExt;
+use header::CMsgSegHdr;
+
+use super::NLMSG_ALIGN;
+use crate::{
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+pub mod ack;
+pub mod common;
+pub mod header;
+
+pub trait SegmentBody: Sized + Clone + Copy {
+    // The actual message body should be `Self::CType`,
+    // but older versions of Linux use a legacy type (usually `CRtGenMsg` here).
+    // Additionally, some software, like iproute2, also uses this legacy type.
+    // Therefore, we need to handle both cases.
+    // Reference: <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2393>.
+    // FIXME: Verify whether the legacy type includes any types other than `CRtGenMsg`.
+    type CLegacyType: Pod = Self::CType;
+    type CType: Pod + From<Self::CLegacyType> + TryInto<Self> + From<Self>;
+
+    /// Reads the segment body from the `reader`.
+    ///
+    /// This method returns the body and the remaining length to be read from the `reader`.
+    fn read_from(header: &CMsgSegHdr, reader: &mut dyn MultiRead) -> Result<(Self, usize)>
+    where
+        Error: From<<Self::CType as TryInto<Self>>::Error>,
+    {
+        let mut remaining_len = (header.len as usize)
+            .checked_sub(size_of_val(header))
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the message length is too small"))?;
+
+        // Align `remaining_len` up to `NLMSG_ALIGN`.
+        let reader_len = reader.sum_lens();
+        if reader_len < remaining_len {
+            return_errno_with_message!(Errno::EINVAL, "the reader length is too small");
+        }
+        remaining_len = remaining_len.align_up(NLMSG_ALIGN).min(reader_len);
+
+        // Read the body.
+        let (c_type, padding_len) = if remaining_len >= size_of::<Self::CType>() {
+            let c_type = reader.read_val::<Self::CType>()?;
+            remaining_len -= size_of_val(&c_type);
+
+            (c_type, Self::padding_len())
+        } else if remaining_len >= size_of::<Self::CLegacyType>() {
+            let legacy = reader.read_val::<Self::CLegacyType>()?;
+            remaining_len -= size_of_val(&legacy);
+
+            (Self::CType::from(legacy), Self::lecacy_padding_len())
+        } else {
+            return_errno_with_message!(Errno::EINVAL, "the message length is too small");
+        };
+
+        // Skip the padding bytes.
+        let padding_len = padding_len.min(remaining_len);
+        reader.skip(padding_len);
+        remaining_len -= padding_len;
+
+        let body = c_type.try_into()?;
+        Ok((body, remaining_len))
+    }
+
+    fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()> {
+        // Write the body.
+        let c_body = Self::CType::from(*self);
+        writer.write_val(&c_body)?;
+
+        // Skip the padding bytes.
+        let padding_len = Self::padding_len();
+        writer.skip(padding_len);
+        Ok(())
+    }
+
+    fn padding_len() -> usize {
+        let payload_len = size_of::<Self::CType>();
+        payload_len.align_up(NLMSG_ALIGN) - payload_len
+    }
+
+    fn lecacy_padding_len() -> usize {
+        let payload_len = size_of::<Self::CLegacyType>();
+        payload_len.align_up(NLMSG_ALIGN) - payload_len
+    }
+}
+
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, TryFromInt, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CSegmentType {
+    // Standard netlink message types
+    NOOP = 1,
+    ERROR = 2,
+    DONE = 3,
+    OVERRUN = 4,
+
+    // protocol-level types
+    NEWLINK = 16,
+    DELLINK = 17,
+    GETLINK = 18,
+    SETLINK = 19,
+
+    NEWADDR = 20,
+    DELADDR = 21,
+    GETADDR = 22,
+
+    NEWROUTE = 24,
+    DELROUTE = 25,
+    GETROUTE = 26,
+    // TODO: The list is not exhaustive.
+}

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module defines netlink sockets.
+//!
+//! Netlink provides a standardized, socket-based interface,
+//! typically used for communication between user space and kernel space.
+//! It can also be used for interaction between two user processes.
+//!
+//! Each netlink socket corresponds to
+//! a netlink protocol identified by a protocol ID (u32).
+//! Protocols are generally defined to serve specific functions.
+//! For instance, the NETLINK_ROUTE protocol is employed
+//! to retrieve or modify network device settings.
+//! Only sockets associated with the same protocol can communicate with each other.
+//! Some protocols are pre-defined by the kernel and serve fixed purposes,
+//! but users can also establish custom protocols by specifying new protocol IDs.
+//!
+//! Before initiating communication,
+//! a netlink socket must be bound to an address,
+//! which consists of a port number and a multicast group number.
+//!
+//! The port number is used for unicast communication,
+//! whereas the multicast group number is meant for multicast communication.
+//!
+//! In terms of unicast communication within each protocol,
+//! a port number can only be bound to one socket.
+//! However, the same port number can be utilized across different protocols.
+//! Typically, the port number corresponds to the process ID of the running process.
+//!
+//! Multicast communication allows a message
+//! to be sent to one or multiple multicast groups simultaneously.
+//! Each protocol can support up to 32 multicast groups,
+//! and a socket can belong to zero or multiple multicast groups.
+//!
+//! Netlink communication is akin to UDP in that
+//! it does not require a connection to be established before sending messages.
+//! The destination address must be specified when dispatching a message.
+//!
+
+mod addr;
+mod message;
+mod route;
+mod table;
+
+pub use addr::{GroupIdSet, NetlinkSocketAddr};
+pub use route::NetlinkRouteSocket;
+pub use table::{is_valid_protocol, StandardNetlinkProtocol};
+
+pub(in crate::net) fn init() {
+    table::init();
+}

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Sub;
+
+use super::message::RtnlMessage;
+use crate::{
+    events::IoEvents,
+    net::socket::{
+        netlink::{
+            message::ProtocolSegment, route::kernel::get_netlink_route_kernel, table::BoundHandle,
+            NetlinkSocketAddr,
+        },
+        SendRecvFlags,
+    },
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+pub(super) struct BoundNetlinkRoute {
+    handle: BoundHandle,
+    receive_queue: Mutex<VecDeque<RtnlMessage>>,
+}
+
+impl BoundNetlinkRoute {
+    pub(super) const fn new(handle: BoundHandle) -> Self {
+        Self {
+            handle,
+            receive_queue: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub(super) const fn addr(&self) -> NetlinkSocketAddr {
+        self.handle.addr()
+    }
+
+    pub(super) fn try_send(
+        &self,
+        reader: &mut dyn MultiRead,
+        remote: Option<&NetlinkSocketAddr>,
+        flags: SendRecvFlags,
+    ) -> Result<usize> {
+        // TODO: Deal with flags
+        if !flags.is_all_supported() {
+            warn!("unsupported flags: {:?}", flags);
+        }
+
+        if let Some(remote) = remote {
+            // TODO: Further check whether other socket address can be supported.
+            if *remote != NetlinkSocketAddr::new_unspecified() {
+                return_errno_with_message!(
+                    Errno::ECONNREFUSED,
+                    "sending netlink route messages to user space is not supported"
+                );
+            }
+        } else {
+            // TODO: We should use the connected remote address, if any.
+        }
+
+        let mut nlmsg = {
+            let sum_lens = reader.sum_lens();
+
+            match RtnlMessage::read_from(reader) {
+                Ok(nlmsg) => nlmsg,
+                Err(e) if e.error() == Errno::EFAULT => {
+                    // EFAULT indicates an error occurred while copying data from user space,
+                    // and this error should be returned back to user space.
+                    return Err(e);
+                }
+                Err(e) => {
+                    // Errors other than EFAULT indicate a failure in parsing the netlink message.
+                    // These errors should be silently ignored.
+                    warn!("failed to send netlink message: {:?}", e);
+                    return Ok(sum_lens);
+                }
+            }
+        };
+
+        let local_port = self.addr().port();
+        for segment in nlmsg.segments_mut() {
+            // The header's PID should be the sender's port ID.
+            // However, the sender can also leave it unspecified.
+            // In such cases, we will manually set the PID to the sender's port ID.
+            let header = segment.header_mut();
+            if header.pid == 0 {
+                header.pid = local_port;
+            }
+        }
+
+        get_netlink_route_kernel().request(&nlmsg, |response| {
+            self.receive_queue.lock().push_back(response);
+        });
+
+        Ok(nlmsg.total_len())
+    }
+
+    pub(super) fn try_receive(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, NetlinkSocketAddr)> {
+        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
+        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+            warn!("unsupported flags: {:?}", flags);
+        }
+
+        let mut receive_queue = self.receive_queue.lock();
+
+        let Some(response) = receive_queue.front() else {
+            return_errno_with_message!(Errno::EAGAIN, "nothing to receive");
+        };
+
+        let len = {
+            let max_len = writer.sum_lens();
+            response.total_len().min(max_len)
+        };
+
+        response.write_to(writer)?;
+
+        if !flags.contains(SendRecvFlags::MSG_PEEK) {
+            receive_queue.pop_front().unwrap();
+        }
+
+        // TODO: The message can only come from kernel socket currently.
+        let remote = NetlinkSocketAddr::new_unspecified();
+
+        Ok((len, remote))
+    }
+
+    pub(super) fn check_io_events(&self) -> IoEvents {
+        let mut events = IoEvents::OUT;
+
+        let receive_queue = self.receive_queue.lock();
+        if !receive_queue.is_empty() {
+            events |= IoEvents::IN;
+        }
+
+        events
+    }
+}

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Handle address-related requests.
+
+use core::num::NonZeroU32;
+
+use super::util::finish_response;
+use crate::{
+    net::{
+        iface::{Iface, IFACES},
+        socket::netlink::{
+            message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
+            route::message::{
+                AddrAttr, AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope, RtnlSegment,
+            },
+        },
+    },
+    prelude::*,
+    util::net::CSocketAddrFamily,
+};
+
+pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegment>> {
+    let dump_all = {
+        let flags = GetRequestFlags::from_bits_truncate(request_segment.header().flags);
+        flags.contains(GetRequestFlags::DUMP)
+    };
+    if !dump_all {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "GETADDR only supports dump requests");
+    }
+
+    let ifaces = IFACES.get().unwrap();
+    let mut response_segments: Vec<RtnlSegment> = ifaces
+        .iter()
+        // GETADDR only supports dump mode, so we're going to report all addresses.
+        .filter_map(|iface| iface_to_new_addr(request_segment.header(), iface))
+        .map(RtnlSegment::NewAddr)
+        .collect();
+
+    finish_response(request_segment.header(), dump_all, &mut response_segments);
+
+    Ok(response_segments)
+}
+
+fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<AddrSegment> {
+    let ipv4_addr = iface.ipv4_addr()?;
+
+    let header = CMsgSegHdr {
+        len: 0,
+        type_: CSegmentType::NEWADDR as _,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: request_header.seq,
+        pid: request_header.pid,
+    };
+
+    let addr_message = AddrSegmentBody {
+        family: CSocketAddrFamily::AF_INET as _,
+        prefix_len: iface.prefix_len().unwrap(),
+        flags: AddrMessageFlags::PERMANENT,
+        scope: RtScope::HOST,
+        index: NonZeroU32::new(iface.index()),
+    };
+
+    let attrs = vec![
+        AddrAttr::Address(ipv4_addr.octets()),
+        AddrAttr::Label(CString::new(iface.name()).unwrap()),
+        AddrAttr::Local(ipv4_addr.octets()),
+    ];
+
+    Some(AddrSegment::new(header, addr_message, attrs))
+}

--- a/kernel/src/net/socket/netlink/route/kernel/link.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/link.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Handle link-related requests.
+
+use core::num::NonZero;
+
+use aster_bigtcp::iface::InterfaceType;
+
+use super::util::finish_response;
+use crate::{
+    net::{
+        iface::{Iface, IFACES},
+        socket::netlink::{
+            message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
+            route::message::{LinkAttr, LinkSegment, LinkSegmentBody, RtnlSegment},
+        },
+    },
+    prelude::*,
+    util::net::CSocketAddrFamily,
+};
+
+pub(super) fn do_get_link(request_segment: &LinkSegment) -> Result<Vec<RtnlSegment>> {
+    let filter_by = FilterBy::from_request(request_segment)?;
+
+    let ifaces = IFACES.get().unwrap();
+    let mut response_segments: Vec<RtnlSegment> = ifaces
+        .iter()
+        // Filter to include only requested links.
+        .filter(|iface| match &filter_by {
+            FilterBy::Index(index) => *index == iface.index(),
+            FilterBy::Name(name) => *name == iface.name(),
+            FilterBy::Dump => true,
+        })
+        .map(|iface| iface_to_new_link(request_segment.header(), iface))
+        .map(RtnlSegment::NewLink)
+        .collect();
+
+    let dump_all = matches!(filter_by, FilterBy::Dump);
+
+    if !dump_all && response_segments.is_empty() {
+        return_errno_with_message!(Errno::ENODEV, "no link found");
+    }
+
+    finish_response(request_segment.header(), dump_all, &mut response_segments);
+
+    Ok(response_segments)
+}
+
+enum FilterBy<'a> {
+    Index(u32),
+    Name(&'a str),
+    Dump,
+}
+
+impl<'a> FilterBy<'a> {
+    fn from_request(request_segment: &'a LinkSegment) -> Result<Self> {
+        let dump_all = {
+            let flags = GetRequestFlags::from_bits_truncate(request_segment.header().flags);
+            flags.contains(GetRequestFlags::DUMP)
+        };
+        if dump_all {
+            validate_dumplink_request(request_segment.body())?;
+            return Ok(Self::Dump);
+        }
+
+        validate_getlink_request(request_segment.body())?;
+
+        // `index` takes precedence over `required_name`.
+
+        if let Some(required_index) = request_segment.body().index {
+            return Ok(Self::Index(required_index.get()));
+        }
+
+        let required_name = request_segment.attrs().iter().find_map(|attr| {
+            if let LinkAttr::Name(name) = attr {
+                Some(name.to_str().unwrap())
+            } else {
+                None
+            }
+        });
+        if let Some(required_name) = required_name {
+            return Ok(Self::Name(required_name));
+        }
+
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "either interface name or index should be specified for non-dump mode"
+        );
+    }
+}
+
+// The below functions starting with `validate_` should only be enabled in strict mode.
+// Reference: <https://docs.kernel.org/userspace-api/netlink/intro.html#strict-checking>.
+
+fn validate_getlink_request(body: &LinkSegmentBody) -> Result<()> {
+    // FIXME: The Linux implementation also checks the `padding` and `change` fields,
+    // but these fields are lost during the conversion of a `CIfInfoMsg` to `LinkSegmentBody`.
+    // We should consider including the `change` field in `LinkSegmentBody`.
+    // Reference: <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L4043>.
+    if !body.flags.is_empty() || body.type_ != InterfaceType::NETROM {
+        return_errno_with_message!(Errno::EINVAL, "the flags or the type is not valid");
+    }
+
+    Ok(())
+}
+
+fn validate_dumplink_request(body: &LinkSegmentBody) -> Result<()> {
+    // FIXME: The Linux implementation also checks the `padding` and `change` fields.
+    // Reference: <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2378>.
+    if !body.flags.is_empty() || body.type_ != InterfaceType::NETROM {
+        return_errno_with_message!(Errno::EINVAL, "the flags or the type is not valid");
+    }
+
+    // The check is from <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2383>.
+    if body.index.is_some() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "filtering by interface index is not valid for link dumps"
+        );
+    }
+
+    Ok(())
+}
+
+fn iface_to_new_link(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> LinkSegment {
+    let header = CMsgSegHdr {
+        len: 0,
+        type_: CSegmentType::NEWLINK as _,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: request_header.seq,
+        pid: request_header.pid,
+    };
+
+    let link_message = LinkSegmentBody {
+        family: CSocketAddrFamily::AF_UNSPEC,
+        type_: iface.type_(),
+        index: NonZero::new(iface.index()),
+        flags: iface.flags(),
+    };
+
+    let attrs = vec![
+        LinkAttr::Name(CString::new(iface.name()).unwrap()),
+        LinkAttr::Mtu(iface.mtu() as u32),
+    ];
+
+    LinkSegment::new(header, link_message, attrs)
+}

--- a/kernel/src/net/socket/netlink/route/kernel/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/mod.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module defines the kernel socket,
+//! which is responsible for handling requests from user space.
+
+use core::marker::PhantomData;
+
+use super::message::{RtnlMessage, RtnlSegment};
+use crate::{
+    net::socket::netlink::message::{CSegmentType, ErrorSegment, ProtocolSegment},
+    prelude::*,
+};
+
+mod addr;
+mod link;
+mod util;
+
+pub(super) struct NetlinkRouteKernelSocket {
+    _private: PhantomData<()>,
+}
+
+impl NetlinkRouteKernelSocket {
+    const fn new() -> Self {
+        Self {
+            _private: PhantomData,
+        }
+    }
+
+    pub(super) fn request<F: FnMut(RtnlMessage)>(
+        &self,
+        request: &RtnlMessage,
+        mut consume_response: F,
+    ) {
+        debug!("netlink route request: {:?}", request);
+
+        for segment in request.segments() {
+            let request_header = segment.header();
+
+            let segment_type = CSegmentType::try_from(request_header.type_).unwrap();
+
+            let response_segments = match segment {
+                RtnlSegment::GetLink(request_segment) => link::do_get_link(request_segment),
+                RtnlSegment::GetAddr(request_segment) => addr::do_get_addr(request_segment),
+                _ => {
+                    // FIXME: The error is currently silently ignored.
+                    warn!("unsupported request type: {:?}", segment_type);
+                    return;
+                }
+            };
+
+            let response = match response_segments {
+                Ok(segments) => RtnlMessage::new(segments),
+                Err(error) => {
+                    // TODO: Deal with the `NetlinkMessageCommonFlags::ACK` flag.
+                    // Should we return `ErrorSegment` if ACK flag does not exist?
+                    // Reference: <https://docs.kernel.org/userspace-api/netlink/intro.html#netlink-message-types>.
+                    let err_segment = ErrorSegment::new_from_request(request_header, Some(error));
+                    RtnlMessage::new(vec![RtnlSegment::Error(err_segment)])
+                }
+            };
+
+            debug!("netlink route response: {:?}", response);
+
+            consume_response(response);
+        }
+    }
+}
+
+/// FIXME: NETLINK_ROUTE_KERNEL should be a per-network namespace socket
+static NETLINK_ROUTE_KERNEL: NetlinkRouteKernelSocket = NetlinkRouteKernelSocket::new();
+
+pub(super) fn get_netlink_route_kernel() -> &'static NetlinkRouteKernelSocket {
+    &NETLINK_ROUTE_KERNEL
+}

--- a/kernel/src/net/socket/netlink/route/kernel/util.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/util.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    net::socket::netlink::{
+        message::{CMsgSegHdr, DoneSegment, ProtocolSegment, SegHdrCommonFlags},
+        route::message::RtnlSegment,
+    },
+    prelude::*,
+};
+
+/// Finishes a response message.
+pub fn finish_response(
+    request_header: &CMsgSegHdr,
+    dump_all: bool,
+    response_segments: &mut Vec<RtnlSegment>,
+) {
+    if !dump_all {
+        assert_eq!(response_segments.len(), 1);
+        return;
+    }
+    append_done_segment(request_header, response_segments);
+    add_multi_flag(response_segments);
+}
+
+/// Appends a done segment as the last segment of the provided segments.
+fn append_done_segment(request_header: &CMsgSegHdr, response_segments: &mut Vec<RtnlSegment>) {
+    let done_segment = DoneSegment::new_from_request(request_header, None);
+    response_segments.push(RtnlSegment::Done(done_segment));
+}
+
+/// Adds the `MULTI` flag to all segments in `segments`.
+fn add_multi_flag(response_segments: &mut Vec<RtnlSegment>) {
+    for segment in response_segments.iter_mut() {
+        let header = segment.header_mut();
+        let mut flags = SegHdrCommonFlags::from_bits_truncate(header.flags);
+        flags |= SegHdrCommonFlags::MULTI;
+        header.flags = flags.bits();
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::IFNAME_SIZE;
+use crate::{
+    net::socket::netlink::message::{Attribute, CAttrHeader},
+    prelude::*,
+    util::MultiRead,
+};
+
+/// Address-related attributes.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_addr.h#L26>.
+#[derive(Debug, Clone, Copy, TryFromInt)]
+#[repr(u16)]
+#[expect(non_camel_case_types)]
+enum AddrAttrClass {
+    UNSPEC = 0,
+    ADDRESS = 1,
+    LOCAL = 2,
+    LABEL = 3,
+    BROADCAST = 4,
+    ANYCAST = 5,
+    CACHEINFO = 6,
+    MULTICAST = 7,
+    FLAGS = 8,
+    RT_PRIORITY = 9,
+    TARGET_NETNSID = 10,
+}
+
+#[derive(Debug)]
+pub enum AddrAttr {
+    Address([u8; 4]),
+    Local([u8; 4]),
+    Label(CString),
+}
+
+impl AddrAttr {
+    fn class(&self) -> AddrAttrClass {
+        match self {
+            AddrAttr::Address(_) => AddrAttrClass::ADDRESS,
+            AddrAttr::Local(_) => AddrAttrClass::LOCAL,
+            AddrAttr::Label(_) => AddrAttrClass::LABEL,
+        }
+    }
+}
+
+impl Attribute for AddrAttr {
+    fn type_(&self) -> u16 {
+        self.class() as u16
+    }
+
+    fn payload_as_bytes(&self) -> &[u8] {
+        match self {
+            AddrAttr::Address(address) => address,
+            AddrAttr::Local(local) => local,
+            AddrAttr::Label(label) => label.as_bytes_with_nul(),
+        }
+    }
+
+    fn read_from(reader: &mut dyn MultiRead) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let header = reader.read_val::<CAttrHeader>()?;
+        // TODO: Currently, `IS_NET_BYTEORDER_MASK` and `IS_NESTED_MASK` are ignored.
+        let res = match AddrAttrClass::try_from(header.type_())? {
+            AddrAttrClass::ADDRESS => Self::Address(reader.read_val()?),
+            AddrAttrClass::LOCAL => Self::Local(reader.read_val()?),
+            AddrAttrClass::LABEL => Self::Label(reader.read_cstring_with_max_len(IFNAME_SIZE)?),
+            class => {
+                // FIXME: Netlink should ignore all unknown attributes.
+                // See the reference in `LinkAttr::read_from`.
+                warn!("address attribute `{:?}` is not supported", class);
+                return_errno_with_message!(Errno::EINVAL, "unsupported address attribute");
+            }
+        };
+
+        Ok(res)
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/attr/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/link.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::IFNAME_SIZE;
+use crate::{
+    net::socket::netlink::message::{Attribute, CAttrHeader},
+    prelude::*,
+    util::MultiRead,
+};
+
+/// Link-level attributes.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_link.h#L297>.
+#[derive(Debug, Clone, Copy, TryFromInt)]
+#[repr(u16)]
+#[allow(non_camel_case_types)]
+enum LinkAttrClass {
+    UNSPEC = 0,
+    ADDRESS = 1,
+    BROADCAST = 2,
+    IFNAME = 3,
+    MTU = 4,
+    LINK = 5,
+    QDISC = 6,
+    STATS = 7,
+    COST = 8,
+    PRIORITY = 9,
+    MASTER = 10,
+    /// Wireless Extension event
+    WIRELESS = 11,
+    /// Protocol specific information for a link
+    PROTINFO = 12,
+    TXQLEN = 13,
+    MAP = 14,
+    WEIGHT = 15,
+    OPERSTATE = 16,
+    LINKMODE = 17,
+    LINKINFO = 18,
+    NET_NS_PID = 19,
+    IFALIAS = 20,
+    /// Number of VFs if device is SR-IOV PF
+    NUM_VF = 21,
+    VFINFO_LIST = 22,
+    STATS64 = 23,
+    VF_PORTS = 24,
+    PORT_SELF = 25,
+    AF_SPEC = 26,
+    /// Group the device belongs to
+    GROUP = 27,
+    NET_NS_FD = 28,
+    /// Extended info mask, VFs, etc.
+    EXT_MASK = 29,
+    /// Promiscuity count: > 0 means acts PROMISC
+    PROMISCUITY = 30,
+    NUM_TX_QUEUES = 31,
+    NUM_RX_QUEUES = 32,
+    CARRIER = 33,
+    PHYS_PORT_ID = 34,
+    CARRIER_CHANGES = 35,
+    PHYS_SWITCH_ID = 36,
+    LINK_NETNSID = 37,
+    PHYS_PORT_NAME = 38,
+    PROTO_DOWN = 39,
+    GSO_MAX_SEGS = 40,
+    GSO_MAX_SIZE = 41,
+    PAD = 42,
+    XDP = 43,
+    EVENT = 44,
+    NEW_NETNSID = 45,
+    IF_NETNSID = 46,
+    CARRIER_UP_COUNT = 47,
+    CARRIER_DOWN_COUNT = 48,
+    NEW_IFINDEX = 49,
+    MIN_MTU = 50,
+    MAX_MTU = 51,
+    PROP_LIST = 52,
+    /// Alternative ifname
+    ALT_IFNAME = 53,
+    PERM_ADDRESS = 54,
+    PROTO_DOWN_REASON = 55,
+    PARENT_DEV_NAME = 56,
+    PARENT_DEV_BUS_NAME = 57,
+}
+
+#[derive(Debug)]
+pub enum LinkAttr {
+    Name(CString),
+    Mtu(u32),
+    TxqLen(u32),
+    LinkMode(u8),
+    ExtMask(RtExtFilter),
+}
+
+impl LinkAttr {
+    fn class(&self) -> LinkAttrClass {
+        match self {
+            LinkAttr::Name(_) => LinkAttrClass::IFNAME,
+            LinkAttr::Mtu(_) => LinkAttrClass::MTU,
+            LinkAttr::TxqLen(_) => LinkAttrClass::TXQLEN,
+            LinkAttr::LinkMode(_) => LinkAttrClass::LINKMODE,
+            LinkAttr::ExtMask(_) => LinkAttrClass::EXT_MASK,
+        }
+    }
+}
+
+impl Attribute for LinkAttr {
+    fn type_(&self) -> u16 {
+        self.class() as u16
+    }
+
+    fn payload_as_bytes(&self) -> &[u8] {
+        match self {
+            LinkAttr::Name(name) => name.as_bytes_with_nul(),
+            LinkAttr::Mtu(mtu) => mtu.as_bytes(),
+            LinkAttr::TxqLen(txq_len) => txq_len.as_bytes(),
+            LinkAttr::LinkMode(link_mode) => link_mode.as_bytes(),
+            LinkAttr::ExtMask(ext_filter) => ext_filter.as_bytes(),
+        }
+    }
+
+    fn read_from(reader: &mut dyn MultiRead) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let header = reader.read_val::<CAttrHeader>()?;
+        // TODO: Currently, `IS_NET_BYTEORDER_MASK` and `IS_NESTED_MASK` are ignored.
+        let res = match LinkAttrClass::try_from(header.type_())? {
+            LinkAttrClass::IFNAME => Self::Name(reader.read_cstring_with_max_len(IFNAME_SIZE)?),
+            LinkAttrClass::MTU => Self::Mtu(reader.read_val()?),
+            LinkAttrClass::TXQLEN => Self::TxqLen(reader.read_val()?),
+            LinkAttrClass::LINKMODE => Self::LinkMode(reader.read_val()?),
+            LinkAttrClass::EXT_MASK => Self::ExtMask(reader.read_val()?),
+            class => {
+                // FIXME: Netlink should ignore all unknown attributes.
+                // But how to decide the payload type if the class is unknown?
+                // Reference: https://docs.kernel.org/userspace-api/netlink/intro.html#unknown-attributes
+                warn!("link attribute `{:?}` is not supported", class);
+                return_errno_with_message!(Errno::EINVAL, "unsupported link attribute");
+            }
+        };
+
+        Ok(res)
+    }
+}
+
+bitflags! {
+    /// New extended info filters for [`NlLinkAttr::ExtMask`].
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L819>.
+    #[repr(C)]
+    #[derive(Pod)]
+    pub struct RtExtFilter: u32 {
+        const VF = 1 << 0;
+        const BRVLAN = 1 << 1;
+        const BRVLAN_COMPRESSED = 1 << 2;
+        const SKIP_STATS = 1 << 3;
+        const MRP = 1 << 4;
+        const CFM_CONFIG = 1 << 5;
+        const CFM_STATUS = 1 << 6;
+        const MST = 1 << 7;
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub mod addr;
+pub mod link;
+
+/// The size limit for interface names.
+const IFNAME_SIZE: usize = 16;

--- a/kernel/src/net/socket/netlink/route/message/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Netlink message types for the netlink route protocol.
+//!
+//! This module defines how to interpret messages sent from user space and how to write
+//! kernel messages back to user space.
+
+mod attr;
+mod segment;
+
+pub(super) use attr::{addr::AddrAttr, link::LinkAttr};
+pub(super) use segment::{
+    addr::{AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope},
+    link::{LinkSegment, LinkSegmentBody},
+    RtnlSegment,
+};
+
+use crate::net::socket::netlink::message::Message;
+
+/// A netlink route message.
+pub(super) type RtnlMessage = Message<RtnlSegment>;

--- a/kernel/src/net/socket/netlink/route/message/segment/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/addr.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZeroU32;
+
+use super::legacy::CRtGenMsg;
+use crate::{
+    net::socket::netlink::{
+        message::{SegmentBody, SegmentCommon},
+        route::message::attr::addr::AddrAttr,
+    },
+    prelude::*,
+};
+
+pub type AddrSegment = SegmentCommon<AddrSegmentBody, AddrAttr>;
+
+impl SegmentBody for AddrSegmentBody {
+    type CLegacyType = CRtGenMsg;
+    type CType = CIfaddrMsg;
+}
+
+/// `ifaddrmsg` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_addr.h#L8>.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+pub struct CIfaddrMsg {
+    pub family: u8,
+    /// The prefix length
+    pub prefix_len: u8,
+    /// Flags
+    pub flags: u8,
+    /// Address scope
+    pub scope: u8,
+    /// Link index
+    pub index: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AddrSegmentBody {
+    pub family: i32,
+    pub prefix_len: u8,
+    pub flags: AddrMessageFlags,
+    pub scope: RtScope,
+    pub index: Option<NonZeroU32>,
+}
+
+impl TryFrom<CIfaddrMsg> for AddrSegmentBody {
+    type Error = Error;
+
+    fn try_from(value: CIfaddrMsg) -> Result<Self> {
+        // TODO: If the attribute IFA_FLAGS exists, the flags in header should be ignored.
+        let flags = AddrMessageFlags::from_bits_truncate(value.flags as u32);
+        let scope = RtScope::try_from(value.scope)?;
+        let index = NonZeroU32::new(value.index);
+
+        Ok(Self {
+            family: value.family as i32,
+            prefix_len: value.prefix_len,
+            flags,
+            scope,
+            index,
+        })
+    }
+}
+
+impl From<AddrSegmentBody> for CIfaddrMsg {
+    fn from(value: AddrSegmentBody) -> Self {
+        let index = if let Some(index) = value.index {
+            index.get()
+        } else {
+            0
+        };
+        CIfaddrMsg {
+            family: value.family as u8,
+            prefix_len: value.prefix_len,
+            flags: value.flags.bits() as u8,
+            scope: value.scope as _,
+            index,
+        }
+    }
+}
+
+bitflags! {
+    /// Flags in [`CIfaddrMsg`].
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_addr.h#L45>.
+    pub struct AddrMessageFlags: u32 {
+        const SECONDARY      = 0x01;
+        const NODAD          = 0x02;
+        const OPTIMISTIC     = 0x04;
+        const DADFAILED      = 0x08;
+        const HOMEADDRESS    = 0x10;
+        const DEPRECATED	 = 0x20;
+        const TENTATIVE		 = 0x40;
+        const PERMANENT		 = 0x80;
+        const MANAGETEMPADDR = 0x100;
+        const NOPREFIXROUTE	 = 0x200;
+        const MCAUTOJOIN	 = 0x400;
+        const STABLE_PRIVACY = 0x800;
+    }
+}
+
+/// `rt_scope_t` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L320>.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+pub enum RtScope {
+    UNIVERSE = 0,
+    // User defined values
+    SITE = 200,
+    LINK = 253,
+    HOST = 254,
+    NOWHERE = 255,
+}

--- a/kernel/src/net/socket/netlink/route/message/segment/legacy.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/legacy.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{addr::CIfaddrMsg, link::CIfinfoMsg};
+use crate::prelude::*;
+
+/// `rtgenmsg` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L548>.
+#[derive(Debug, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct CRtGenMsg {
+    pub family: u8,
+}
+
+impl From<CRtGenMsg> for CIfinfoMsg {
+    fn from(value: CRtGenMsg) -> Self {
+        Self {
+            family: value.family,
+            _pad: 0,
+            type_: 0,
+            index: 0,
+            flags: 0,
+            change: 0,
+        }
+    }
+}
+
+impl From<CRtGenMsg> for CIfaddrMsg {
+    fn from(value: CRtGenMsg) -> Self {
+        Self {
+            family: value.family,
+            prefix_len: 0,
+            flags: 0,
+            scope: 0,
+            index: 0,
+        }
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/segment/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/link.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZeroU32;
+
+use aster_bigtcp::iface::{InterfaceFlags, InterfaceType};
+
+use super::legacy::CRtGenMsg;
+use crate::{
+    net::socket::netlink::{
+        message::{SegmentBody, SegmentCommon},
+        route::message::attr::link::LinkAttr,
+    },
+    prelude::*,
+    util::net::CSocketAddrFamily,
+};
+
+pub type LinkSegment = SegmentCommon<LinkSegmentBody, LinkAttr>;
+
+impl SegmentBody for LinkSegmentBody {
+    type CLegacyType = CRtGenMsg;
+    type CType = CIfinfoMsg;
+}
+
+/// `ifinfomsg` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L561>.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+pub struct CIfinfoMsg {
+    /// AF_UNSPEC
+    pub family: u8,
+    /// Padding byte
+    pub _pad: u8,
+    /// Device type
+    pub type_: u16,
+    /// Interface index
+    pub index: u32,
+    /// Device flags
+    pub flags: u32,
+    /// Change mask
+    pub change: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LinkSegmentBody {
+    pub family: CSocketAddrFamily,
+    pub type_: InterfaceType,
+    pub index: Option<NonZeroU32>,
+    pub flags: InterfaceFlags,
+}
+
+impl TryFrom<CIfinfoMsg> for LinkSegmentBody {
+    type Error = Error;
+
+    fn try_from(value: CIfinfoMsg) -> Result<Self> {
+        let family = CSocketAddrFamily::try_from(value.family as i32)?;
+        let type_ = InterfaceType::try_from(value.type_)?;
+        let index = NonZeroU32::new(value.index);
+        let flags = InterfaceFlags::from_bits_truncate(value.flags);
+
+        Ok(Self {
+            family,
+            type_,
+            index,
+            flags,
+        })
+    }
+}
+
+impl From<LinkSegmentBody> for CIfinfoMsg {
+    fn from(value: LinkSegmentBody) -> Self {
+        CIfinfoMsg {
+            family: value.family as _,
+            _pad: 0,
+            type_: value.type_ as _,
+            index: value.index.map(NonZeroU32::get).unwrap_or(0),
+            flags: value.flags.bits(),
+            change: 0,
+        }
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/mod.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module defines the message segment,
+//! which is the basic unit of a netlink message.
+//!
+//! Typically, a segment will consist of three parts:
+//!
+//! 1. Header: The headers of all segments are of type [`CMessageSegmentHeader`],
+//! which indicate the type and total length of the segment.
+//!
+//! 2. Body: The body is the main component of a segment.
+//! Each segment will have one and only one body.
+//! The body type is defined by the `type_` field of the header.
+//!
+//! 3. Attributes: Attributes are optional.
+//! A segment can have zero or multiple attributes.
+//! Attributes belong to different classes,
+//! with the class defined by the `type_` field of the header.
+//! The total number of attributes is controlled by the `len` field of the header.
+//!
+//! Note that all headers, bodies, and attributes require
+//! their starting address in memory to be aligned to [`super::NLMSG_ALIGN`]
+//! when copying to and from user space.
+//! Therefore, necessary padding must be added to ensure alignment.
+//!
+//! The layout of a segment in memory is shown below:
+//!
+//! ┌────────┬─────────┬──────┬─────────┬──────┬──────┬──────┐
+//! │ Header │ Padding │ Body │ Padding │ Attr │ Attr │ Attr │
+//! └────────┴─────────┴──────┴─────────┴──────┴──────┴──────┘
+
+pub mod addr;
+mod legacy;
+pub mod link;
+pub mod route;
+
+use addr::AddrSegment;
+use link::LinkSegment;
+
+use crate::{
+    net::socket::netlink::message::{
+        CMsgSegHdr, CSegmentType, DoneSegment, ErrorSegment, ProtocolSegment,
+    },
+    prelude::*,
+    util::{MultiRead, MultiWrite},
+};
+
+/// The netlink route segment, which is the basic unit of a netlink route message.
+#[derive(Debug)]
+pub enum RtnlSegment {
+    NewLink(LinkSegment),
+    GetLink(LinkSegment),
+    NewAddr(AddrSegment),
+    GetAddr(AddrSegment),
+    Done(DoneSegment),
+    Error(ErrorSegment),
+}
+
+impl ProtocolSegment for RtnlSegment {
+    fn header(&self) -> &CMsgSegHdr {
+        match self {
+            RtnlSegment::NewLink(link_segment) | RtnlSegment::GetLink(link_segment) => {
+                link_segment.header()
+            }
+            RtnlSegment::NewAddr(addr_segment) | RtnlSegment::GetAddr(addr_segment) => {
+                addr_segment.header()
+            }
+            RtnlSegment::Done(done_segment) => done_segment.header(),
+            RtnlSegment::Error(error_segment) => error_segment.header(),
+        }
+    }
+
+    fn header_mut(&mut self) -> &mut CMsgSegHdr {
+        match self {
+            RtnlSegment::NewLink(link_segment) | RtnlSegment::GetLink(link_segment) => {
+                link_segment.header_mut()
+            }
+            RtnlSegment::NewAddr(addr_segment) | RtnlSegment::GetAddr(addr_segment) => {
+                addr_segment.header_mut()
+            }
+            RtnlSegment::Done(done_segment) => done_segment.header_mut(),
+            RtnlSegment::Error(error_segment) => error_segment.header_mut(),
+        }
+    }
+
+    fn read_from(reader: &mut dyn MultiRead) -> Result<Self> {
+        let header = reader.read_val::<CMsgSegHdr>()?;
+
+        let segment = match CSegmentType::try_from(header.type_)? {
+            CSegmentType::GETLINK => RtnlSegment::GetLink(LinkSegment::read_from(header, reader)?),
+            CSegmentType::GETADDR => RtnlSegment::GetAddr(AddrSegment::read_from(header, reader)?),
+            _ => return_errno_with_message!(Errno::EINVAL, "unsupported segment type"),
+        };
+
+        Ok(segment)
+    }
+
+    fn write_to(&self, writer: &mut dyn MultiWrite) -> Result<()> {
+        match self {
+            RtnlSegment::NewLink(link_segment) => link_segment.write_to(writer)?,
+            RtnlSegment::NewAddr(addr_segment) => addr_segment.write_to(writer)?,
+            RtnlSegment::Done(done_segment) => done_segment.write_to(writer)?,
+            RtnlSegment::Error(error_segment) => error_segment.write_to(writer)?,
+            RtnlSegment::GetAddr(_) | RtnlSegment::GetLink(_) => {
+                unreachable!("kernel should not write get requests to user space");
+            }
+        }
+        Ok(())
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/segment/route.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/route.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+/// `rtmsg` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L237>.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+#[expect(unused)]
+pub(super) struct CRtMsg {
+    family: u8,
+    dst_len: u8,
+    src_len: u8,
+    tos: u8,
+    table: u8,
+    protocol: u8,
+    scope: u8,
+    type_: u8,
+    flags: u32,
+}

--- a/kernel/src/net/socket/netlink/route/mod.rs
+++ b/kernel/src/net/socket/netlink/route/mod.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Netlink Route Socket.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use bound::BoundNetlinkRoute;
+use takeable::Takeable;
+use unbound::UnboundNetlinkRoute;
+
+use super::NetlinkSocketAddr;
+use crate::{
+    events::IoEvents,
+    net::socket::{
+        options::SocketOption, private::SocketPrivate, MessageHeader, SendRecvFlags, Socket,
+        SocketAddr,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable, Pollee},
+    util::{MultiRead, MultiWrite},
+};
+
+mod bound;
+mod kernel;
+mod message;
+mod unbound;
+
+pub struct NetlinkRouteSocket {
+    is_nonblocking: AtomicBool,
+    pollee: Pollee,
+    inner: RwMutex<Takeable<Inner>>,
+}
+
+enum Inner {
+    Unbound(UnboundNetlinkRoute),
+    Bound(BoundNetlinkRoute),
+}
+
+impl NetlinkRouteSocket {
+    pub fn new(is_nonblocking: bool) -> Self {
+        Self {
+            is_nonblocking: AtomicBool::new(is_nonblocking),
+            pollee: Pollee::new(),
+            inner: RwMutex::new(Takeable::new(Inner::Unbound(UnboundNetlinkRoute::new()))),
+        }
+    }
+
+    fn try_receive(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, NetlinkSocketAddr)> {
+        let inner = self.inner.read();
+
+        let bound = match inner.as_ref() {
+            Inner::Unbound(_) => {
+                return_errno_with_message!(Errno::EAGAIN, "the socket is not bound")
+            }
+            Inner::Bound(bound_netlink_route) => bound_netlink_route,
+        };
+
+        let received = bound.try_receive(writer, flags)?;
+        self.pollee.invalidate();
+
+        Ok(received)
+    }
+
+    fn try_send(
+        &self,
+        reader: &mut dyn MultiRead,
+        remote: Option<&NetlinkSocketAddr>,
+        flags: SendRecvFlags,
+    ) -> Result<usize> {
+        let inner = self.inner.read();
+
+        let bound = match inner.as_ref() {
+            Inner::Unbound(_) => todo!(),
+            Inner::Bound(bound) => bound,
+        };
+
+        let sent_bytes = bound.try_send(reader, remote, flags)?;
+        self.pollee.notify(IoEvents::OUT | IoEvents::IN);
+
+        Ok(sent_bytes)
+    }
+
+    fn check_io_events(&self) -> IoEvents {
+        let inner = self.inner.read();
+        match inner.as_ref() {
+            Inner::Unbound(unbound) => unbound.check_io_events(),
+            Inner::Bound(bound) => bound.check_io_events(),
+        }
+    }
+}
+
+impl Socket for NetlinkRouteSocket {
+    fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
+        let SocketAddr::Netlink(netlink_addr) = socket_addr else {
+            return_errno_with_message!(
+                Errno::EAFNOSUPPORT,
+                "the provided address is not netlink address"
+            );
+        };
+
+        let mut inner = self.inner.write();
+        inner.borrow_result(|owned_inner| match owned_inner.bind(&netlink_addr) {
+            Ok(bound_inner) => (bound_inner, Ok(())),
+            Err((err, err_inner)) => (err_inner, Err(err)),
+        })
+    }
+
+    fn addr(&self) -> Result<SocketAddr> {
+        let netlink_addr = match self.inner.read().as_ref() {
+            Inner::Unbound(_) => NetlinkSocketAddr::new_unspecified(),
+            Inner::Bound(bound) => bound.addr(),
+        };
+
+        Ok(SocketAddr::Netlink(netlink_addr))
+    }
+
+    fn sendmsg(
+        &self,
+        reader: &mut dyn MultiRead,
+        message_header: MessageHeader,
+        flags: SendRecvFlags,
+    ) -> Result<usize> {
+        let MessageHeader {
+            addr,
+            control_message,
+        } = message_header;
+
+        let remote = match addr {
+            None => None,
+            Some(addr) => Some(addr.try_into()?),
+        };
+
+        if control_message.is_some() {
+            // TODO: Support sending control message
+            warn!("sending control message is not supported");
+        }
+
+        // TODO: Make sure our blocking behavior matches that of Linux
+        self.try_send(reader, remote.as_ref(), flags)
+    }
+
+    fn recvmsg(
+        &self,
+        writers: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, MessageHeader)> {
+        let (received_len, addr) =
+            self.block_on(IoEvents::IN, || self.try_receive(writers, flags))?;
+
+        // TODO: Receive control message
+
+        let message_header = {
+            let addr = SocketAddr::Netlink(addr);
+            MessageHeader::new(Some(addr), None)
+        };
+
+        Ok((received_len, message_header))
+    }
+
+    fn set_option(&self, _option: &dyn SocketOption) -> Result<()> {
+        // TODO: This dummy option is added to pass the libnl test
+        Ok(())
+    }
+}
+
+impl SocketPrivate for NetlinkRouteSocket {
+    fn is_nonblocking(&self) -> bool {
+        self.is_nonblocking.load(Ordering::Relaxed)
+    }
+
+    fn set_nonblocking(&self, nonblocking: bool) {
+        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+    }
+}
+
+impl Pollable for NetlinkRouteSocket {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+        self.pollee
+            .poll_with(mask, poller, || self.check_io_events())
+    }
+}
+
+impl Inner {
+    fn bind(self, addr: &NetlinkSocketAddr) -> core::result::Result<Self, (Error, Self)> {
+        let unbound = match self {
+            Inner::Unbound(unbound) => unbound,
+            Inner::Bound(bound) => {
+                // FIXME: We need to further check the Linux behavior
+                // whether we should return error if the socket is bound.
+                // The socket may call `bind` syscall to join new multicast groups.
+                return Err((
+                    Error::with_message(Errno::EINVAL, "the socket is already bound"),
+                    Self::Bound(bound),
+                ));
+            }
+        };
+
+        match unbound.bind(addr) {
+            Ok(bound) => Ok(Self::Bound(bound)),
+            Err((err, unbound)) => Err((err, Self::Unbound(unbound))),
+        }
+    }
+}

--- a/kernel/src/net/socket/netlink/route/unbound.rs
+++ b/kernel/src/net/socket/netlink/route/unbound.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::bound::BoundNetlinkRoute;
+use crate::{
+    events::IoEvents,
+    net::socket::netlink::{
+        table::NETLINK_SOCKET_TABLE, NetlinkSocketAddr, StandardNetlinkProtocol,
+    },
+    prelude::*,
+};
+
+pub(super) struct UnboundNetlinkRoute {
+    _private: (),
+}
+
+impl UnboundNetlinkRoute {
+    pub(super) const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    pub(super) fn bind(
+        self,
+        addr: &NetlinkSocketAddr,
+    ) -> core::result::Result<BoundNetlinkRoute, (Error, Self)> {
+        let bound_handle = NETLINK_SOCKET_TABLE
+            .bind(StandardNetlinkProtocol::ROUTE as _, addr)
+            .map_err(|err| (err, self))?;
+
+        Ok(BoundNetlinkRoute::new(bound_handle))
+    }
+
+    pub(super) fn check_io_events(&self) -> IoEvents {
+        IoEvents::OUT
+    }
+}

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use multicast::MulticastGroup;
+
+use super::addr::{GroupIdSet, NetlinkProtocolId, NetlinkSocketAddr, PortNum, MAX_GROUPS};
+use crate::{net::socket::netlink::addr::UNSPECIFIED_PORT, prelude::*, util::random::getrandom};
+
+mod multicast;
+
+pub(super) static NETLINK_SOCKET_TABLE: NetlinkSocketTable = NetlinkSocketTable::new();
+
+/// All bound netlink sockets.
+pub(super) struct NetlinkSocketTable {
+    protocols: [Mutex<Option<ProtocolSocketTable>>; MAX_ALLOWED_PROTOCOL_ID as usize],
+}
+
+impl NetlinkSocketTable {
+    pub(super) const fn new() -> Self {
+        Self {
+            protocols: [const { Mutex::new(None) }; MAX_ALLOWED_PROTOCOL_ID as usize],
+        }
+    }
+
+    /// Adds a new netlink protocol.
+    fn add_new_protocol(&self, protocol_id: NetlinkProtocolId) {
+        if protocol_id >= MAX_ALLOWED_PROTOCOL_ID {
+            return;
+        }
+
+        let mut protocol = self.protocols[protocol_id as usize].lock();
+        if protocol.is_some() {
+            return;
+        }
+
+        let new_protocol = ProtocolSocketTable::new(protocol_id);
+        *protocol = Some(new_protocol);
+    }
+
+    pub(super) fn bind(
+        &self,
+        protocol: NetlinkProtocolId,
+        addr: &NetlinkSocketAddr,
+    ) -> Result<BoundHandle> {
+        if protocol >= MAX_ALLOWED_PROTOCOL_ID {
+            return_errno_with_message!(Errno::EINVAL, "the netlink protocol does not exist");
+        }
+
+        let mut protocol = self.protocols[protocol as usize].lock();
+
+        let Some(protocol_sockets) = protocol.as_mut() else {
+            return_errno_with_message!(Errno::EINVAL, "the netlink protocol does not exist")
+        };
+
+        protocol_sockets.bind(addr)
+    }
+}
+
+/// Bound socket table of a single netlink protocol.
+///
+/// Each table can have bound sockets for unicast
+/// and at most 32 groups for multicast.
+struct ProtocolSocketTable {
+    id: NetlinkProtocolId,
+    // TODO: This table should maintain the port number-to-socket relationship
+    // to support both unicast and multicast effectively.
+    unicast_sockets: BTreeSet<PortNum>,
+    multicast_groups: Box<[MulticastGroup]>,
+}
+
+impl ProtocolSocketTable {
+    /// Creates a new table.
+    fn new(id: NetlinkProtocolId) -> Self {
+        let multicast_groups = (0u32..MAX_GROUPS).map(|_| MulticastGroup::new()).collect();
+        Self {
+            id,
+            unicast_sockets: BTreeSet::new(),
+            multicast_groups,
+        }
+    }
+
+    /// Binds a socket to the table.
+    /// Returns the bound handle.
+    ///
+    /// The socket will be bound to a port specified by `addr.port()`.
+    /// If `addr.port()` is zero, the kernel will assign a port,
+    /// typically corresponding to the process ID of the current process.
+    /// If the assigned port is already in use,
+    /// this function will try to allocate a random unused port.
+    ///
+    /// Additionally, this socket can join one or more multicast groups,
+    /// as specified in `addr.groups()`.
+    fn bind(&mut self, addr: &NetlinkSocketAddr) -> Result<BoundHandle> {
+        let port = if addr.port() != UNSPECIFIED_PORT {
+            addr.port()
+        } else {
+            let mut random_port = current!().pid();
+            while random_port == UNSPECIFIED_PORT || self.unicast_sockets.contains(&random_port) {
+                getrandom(random_port.as_bytes_mut()).unwrap();
+            }
+            random_port
+        };
+
+        if self.unicast_sockets.contains(&port) {
+            return_errno_with_message!(Errno::EADDRINUSE, "the netlink port is already in use");
+        }
+
+        self.unicast_sockets.insert(port);
+
+        for group_id in addr.groups().ids_iter() {
+            let group = &mut self.multicast_groups[group_id as usize];
+            group.add_member(port);
+        }
+
+        Ok(BoundHandle::new(self.id, port, addr.groups()))
+    }
+}
+
+/// A bound netlink socket address.
+///
+/// When dropping a `BoundHandle`,
+/// the port will be automatically released.
+#[derive(Debug)]
+pub(super) struct BoundHandle {
+    protocol: NetlinkProtocolId,
+    port: PortNum,
+    groups: GroupIdSet,
+}
+
+impl BoundHandle {
+    fn new(protocol: NetlinkProtocolId, port: PortNum, groups: GroupIdSet) -> Self {
+        debug_assert_ne!(port, UNSPECIFIED_PORT);
+
+        Self {
+            protocol,
+            port,
+            groups,
+        }
+    }
+
+    pub(super) const fn addr(&self) -> NetlinkSocketAddr {
+        NetlinkSocketAddr::new(self.port, self.groups)
+    }
+}
+
+impl Drop for BoundHandle {
+    fn drop(&mut self) {
+        let mut protocol_sockets = NETLINK_SOCKET_TABLE.protocols[self.protocol as usize].lock();
+
+        let Some(protocol_sockets) = protocol_sockets.as_mut() else {
+            return;
+        };
+
+        protocol_sockets.unicast_sockets.remove(&self.port);
+
+        for group_id in self.groups.ids_iter() {
+            let group = &mut protocol_sockets.multicast_groups[group_id as usize];
+            group.remove_member(self.port);
+        }
+    }
+}
+
+pub(super) fn init() {
+    for protocol in 0..MAX_ALLOWED_PROTOCOL_ID {
+        if is_standard_protocol(protocol) {
+            NETLINK_SOCKET_TABLE.add_new_protocol(protocol);
+        }
+    }
+}
+
+/// Returns whether the `protocol` is valid.
+pub fn is_valid_protocol(protocol: NetlinkProtocolId) -> bool {
+    protocol < MAX_ALLOWED_PROTOCOL_ID
+}
+
+/// Returns whether the `protocol` is reserved for system use.
+fn is_standard_protocol(protocol: NetlinkProtocolId) -> bool {
+    StandardNetlinkProtocol::try_from(protocol).is_ok()
+}
+
+/// Netlink protocols that are assigned for specific usage.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/include/uapi/linux/netlink.h#L9>.
+#[allow(non_camel_case_types)]
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+pub enum StandardNetlinkProtocol {
+    /// Routing/device hook
+    ROUTE = 0,
+    /// Unused number
+    UNUSED = 1,
+    /// Reserved for user mode socket protocols
+    USERSOCK = 2,
+    /// Unused number, formerly ip_queue
+    FIREWALL = 3,
+    /// Socket monitoring
+    SOCK_DIAG = 4,
+    /// Netfilter/iptables ULOG
+    NFLOG = 5,
+    /// IPsec
+    XFRM = 6,
+    /// SELinux event notifications
+    SELINUX = 7,
+    /// Open-iSCSI
+    ISCSI = 8,
+    /// Auditing
+    AUDIT = 9,
+    FIB_LOOKUP = 10,
+    CONNECTOR = 11,
+    /// Netfilter subsystem
+    NETFILTER = 12,
+    IP6_FW = 13,
+    /// DECnet routing messages
+    DNRTMSG = 14,
+    /// Kernel messages to userspace
+    KOBJECT_UEVENT = 15,
+    GENERIC = 16,
+    /// Leave room for NETLINK_DM (DM Events)
+    /// SCSI Transports
+    SCSITRANSPORT = 18,
+    ECRYPTFS = 19,
+    RDMA = 20,
+    /// Crypto layer
+    CRYPTO = 21,
+    /// SMC monitoring
+    SMC = 22,
+}
+
+const MAX_ALLOWED_PROTOCOL_ID: NetlinkProtocolId = 32;

--- a/kernel/src/net/socket/netlink/table/multicast.rs
+++ b/kernel/src/net/socket/netlink/table/multicast.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{net::socket::netlink::addr::PortNum, prelude::*};
+
+/// A netlink multicast group.
+///
+/// A group can contain multiple sockets,
+/// each identified by its bound port number.
+pub struct MulticastGroup {
+    members: BTreeSet<PortNum>,
+}
+
+impl MulticastGroup {
+    /// Creates a new multicast group.
+    pub const fn new() -> Self {
+        Self {
+            members: BTreeSet::new(),
+        }
+    }
+
+    /// Returns whether the group contains a member.
+    #[expect(unused)]
+    pub fn contains_member(&self, port_num: PortNum) -> bool {
+        self.members.contains(&port_num)
+    }
+
+    /// Adds a new member to the multicast group.
+    pub fn add_member(&mut self, port_num: PortNum) {
+        debug_assert!(!self.members.contains(&port_num));
+        self.members.insert(port_num);
+    }
+
+    /// Removes a member from the multicast group.
+    pub fn remove_member(&mut self, port_num: PortNum) {
+        debug_assert!(self.members.contains(&port_num));
+        self.members.remove(&port_num);
+    }
+}

--- a/kernel/src/net/socket/util/socket_addr.rs
+++ b/kernel/src/net/socket/util/socket_addr.rs
@@ -3,7 +3,7 @@
 use aster_bigtcp::wire::{Ipv4Address, PortNum};
 
 use crate::{
-    net::socket::{unix::UnixSocketAddr, vsock::addr::VsockSocketAddr},
+    net::socket::{netlink::NetlinkSocketAddr, unix::UnixSocketAddr, vsock::addr::VsockSocketAddr},
     prelude::*,
 };
 
@@ -11,5 +11,6 @@ use crate::{
 pub enum SocketAddr {
     Unix(UnixSocketAddr),
     IPv4(Ipv4Address, PortNum),
+    Netlink(NetlinkSocketAddr),
     Vsock(VsockSocketAddr),
 }

--- a/kernel/src/net/socket/vsock/mod.rs
+++ b/kernel/src/net/socket/vsock/mod.rs
@@ -15,7 +15,7 @@ pub use stream::VsockStreamSocket;
 // init static driver
 pub static VSOCK_GLOBAL: Once<Arc<VsockSpace>> = Once::new();
 
-pub fn init() {
+pub(in crate::net) fn init() {
     if let Some(driver) = get_device(DEVICE_NAME) {
         VSOCK_GLOBAL.call_once(|| Arc::new(VsockSpace::new(driver)));
         register_recv_callback(DEVICE_NAME, || {

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -5,6 +5,7 @@ use crate::{
     fs::{file_handle::FileLike, file_table::FdFlags},
     net::socket::{
         ip::{datagram::DatagramSocket, stream::StreamSocket},
+        netlink::{is_valid_protocol, NetlinkRouteSocket, StandardNetlinkProtocol},
         unix::UnixStreamSocket,
         vsock::VsockStreamSocket,
     },
@@ -16,29 +17,62 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
     let domain = CSocketAddrFamily::try_from(domain)?;
     let sock_type = SockType::try_from(type_ & SOCK_TYPE_MASK)?;
     let sock_flags = SockFlags::from_bits_truncate(type_ & !SOCK_TYPE_MASK);
-    let protocol = Protocol::try_from(protocol)?;
     debug!(
-        "domain = {:?}, sock_type = {:?}, sock_flags = {:?}, protocol = {:?}",
-        domain, sock_type, sock_flags, protocol
+        "domain = {:?}, sock_type = {:?}, sock_flags = {:?}",
+        domain, sock_type, sock_flags
     );
-    let nonblocking = sock_flags.contains(SockFlags::SOCK_NONBLOCK);
-    let file_like = match (domain, sock_type, protocol) {
+    let is_nonblocking = sock_flags.contains(SockFlags::SOCK_NONBLOCK);
+    let file_like = match (domain, sock_type) {
         // FIXME: SOCK_SEQPACKET is added to run fcntl_test, not supported yet.
-        (CSocketAddrFamily::AF_UNIX, SockType::SOCK_STREAM | SockType::SOCK_SEQPACKET, _) => {
-            UnixStreamSocket::new(nonblocking) as Arc<dyn FileLike>
+        (CSocketAddrFamily::AF_UNIX, SockType::SOCK_STREAM | SockType::SOCK_SEQPACKET) => {
+            UnixStreamSocket::new(is_nonblocking) as Arc<dyn FileLike>
         }
-        (
-            CSocketAddrFamily::AF_INET,
-            SockType::SOCK_STREAM,
-            Protocol::IPPROTO_IP | Protocol::IPPROTO_TCP,
-        ) => StreamSocket::new(nonblocking) as Arc<dyn FileLike>,
-        (
-            CSocketAddrFamily::AF_INET,
-            SockType::SOCK_DGRAM,
-            Protocol::IPPROTO_IP | Protocol::IPPROTO_UDP,
-        ) => DatagramSocket::new(nonblocking) as Arc<dyn FileLike>,
-        (CSocketAddrFamily::AF_VSOCK, SockType::SOCK_STREAM, _) => {
-            Arc::new(VsockStreamSocket::new(nonblocking)) as Arc<dyn FileLike>
+        (CSocketAddrFamily::AF_INET, SockType::SOCK_STREAM) => {
+            let protocol = Protocol::try_from(protocol)?;
+            debug!("protocol = {:?}", protocol);
+            match protocol {
+                Protocol::IPPROTO_IP | Protocol::IPPROTO_TCP => {
+                    StreamSocket::new(is_nonblocking) as Arc<dyn FileLike>
+                }
+                _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
+            }
+        }
+        (CSocketAddrFamily::AF_INET, SockType::SOCK_DGRAM) => {
+            let protocol = Protocol::try_from(protocol)?;
+            debug!("protocol = {:?}", protocol);
+            match protocol {
+                Protocol::IPPROTO_IP | Protocol::IPPROTO_UDP => {
+                    DatagramSocket::new(is_nonblocking) as Arc<dyn FileLike>
+                }
+                _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
+            }
+        }
+        (CSocketAddrFamily::AF_NETLINK, SockType::SOCK_RAW | SockType::SOCK_DGRAM) => {
+            let netlink_family = StandardNetlinkProtocol::try_from(protocol as u32);
+            debug!("netlink family = {:?}", netlink_family);
+            match netlink_family {
+                Ok(StandardNetlinkProtocol::ROUTE) => {
+                    Arc::new(NetlinkRouteSocket::new(is_nonblocking))
+                }
+                Ok(_) => {
+                    return_errno_with_message!(
+                        Errno::EAFNOSUPPORT,
+                        "some standard netlink families are not supported yet"
+                    );
+                }
+                Err(_) => {
+                    if is_valid_protocol(protocol as u32) {
+                        return_errno_with_message!(
+                            Errno::EAFNOSUPPORT,
+                            "user-provided netlink family is not supported"
+                        )
+                    }
+                    return_errno_with_message!(Errno::EAFNOSUPPORT, "invalid netlink family");
+                }
+            }
+        }
+        (CSocketAddrFamily::AF_VSOCK, SockType::SOCK_STREAM) => {
+            Arc::new(VsockStreamSocket::new(is_nonblocking)) as Arc<dyn FileLike>
         }
         _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported domain"),
     };

--- a/kernel/src/util/net/addr/ip.rs
+++ b/kernel/src/util/net/addr/ip.rs
@@ -38,6 +38,7 @@ impl From<(Ipv4Address, PortNum)> for CSocketAddrInet {
 
 impl From<CSocketAddrInet> for (Ipv4Address, PortNum) {
     fn from(value: CSocketAddrInet) -> Self {
+        debug_assert_eq!(value.sin_family, CSocketAddrFamily::AF_INET as u16);
         (value.sin_addr.into(), value.sin_port.into())
     }
 }

--- a/kernel/src/util/net/addr/mod.rs
+++ b/kernel/src/util/net/addr/mod.rs
@@ -7,5 +7,6 @@ pub use family::{
 
 mod family;
 mod ip;
+mod netlink;
 mod unix;
 mod vsock;

--- a/kernel/src/util/net/addr/netlink.rs
+++ b/kernel/src/util/net/addr/netlink.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::CSocketAddrFamily;
+use crate::{
+    net::socket::netlink::{GroupIdSet, NetlinkSocketAddr},
+    prelude::*,
+};
+
+/// Netlink socket address.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod)]
+pub struct CSocketAddrNetlink {
+    /// Address family (AF_NETLINK).
+    nl_family: u16,
+    /// Pad bytes (always zero).
+    nl_pad: u16,
+    /// Port ID.
+    nl_pid: u32,
+    /// Multicast groups mask.
+    nl_groups: u32,
+}
+
+impl From<NetlinkSocketAddr> for CSocketAddrNetlink {
+    fn from(value: NetlinkSocketAddr) -> Self {
+        Self {
+            nl_family: CSocketAddrFamily::AF_NETLINK as _,
+            nl_pad: 0,
+            nl_pid: value.port(),
+            nl_groups: value.groups().as_u32(),
+        }
+    }
+}
+
+impl From<CSocketAddrNetlink> for NetlinkSocketAddr {
+    fn from(value: CSocketAddrNetlink) -> Self {
+        debug_assert_eq!(value.nl_family, CSocketAddrFamily::AF_NETLINK as u16);
+        let port = value.nl_pid;
+        let groups = GroupIdSet::new(value.nl_groups);
+        NetlinkSocketAddr::new(port, groups)
+    }
+}

--- a/kernel/src/util/net/addr/vsock.rs
+++ b/kernel/src/util/net/addr/vsock.rs
@@ -33,6 +33,7 @@ impl From<VsockSocketAddr> for CSocketAddrVm {
 
 impl From<CSocketAddrVm> for VsockSocketAddr {
     fn from(value: CSocketAddrVm) -> Self {
+        debug_assert_eq!(value.svm_family, CSocketAddrFamily::AF_VSOCK as u16);
         Self {
             cid: value.svm_cid,
             port: value.svm_port,

--- a/test/Makefile
+++ b/test/Makefile
@@ -70,6 +70,9 @@ $(INITRAMFS)/lib/x86_64-linux-gnu: | $(VDSO_LIB)
 	@cp -L /lib/x86_64-linux-gnu/libevent-2.1.so.7 $@
 	@# required for VDSO
 	@cp -L $(VDSO_LIB) $@
+	@# required for netlink test
+	@cp -L /lib/x86_64-linux-gnu/libnl-3.so.200 $@
+	@cp -L /lib/x86_64-linux-gnu/libnl-route-3.so.200 $@
 
 $(VDSO_LIB): | $(VDSO_DIR) $(BINARY_CACHE_DIR)/vdso64.so
 	@# TODO: use a custom compiled vdso.so file in the future.

--- a/test/apps/network/Makefile
+++ b/test/apps/network/Makefile
@@ -2,4 +2,4 @@
 
 include ../test_common.mk
 
-EXTRA_C_FLAGS :=
+EXTRA_C_FLAGS := -I/usr/include/libnl3 -lnl-3 -lnl-route-3

--- a/test/apps/network/netlink_route.c
+++ b/test/apps/network/netlink_route.c
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <netlink/netlink.h>
+#include <netlink/route/link.h>
+#include <netlink/route/addr.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "test.h"
+
+#define ETHER_NAME "eth0"
+#define LOOPBACK_NAME "lo"
+
+#define SUCC(expr) ((expr), 0)
+
+int find_lo_and_eth0_by_libc(struct if_nameindex *if_ni)
+{
+	int found_links = 0;
+
+	for (struct if_nameindex *i = if_ni;
+	     !(i->if_index == 0 && i->if_name == NULL); i++) {
+		if (strcmp(i->if_name, LOOPBACK_NAME) == 0) {
+			found_links++;
+		}
+
+		if (strcmp(i->if_name, ETHER_NAME) == 0) {
+			found_links++;
+		}
+	}
+
+	return found_links;
+}
+
+FN_TEST(if_nameindex)
+{
+	struct if_nameindex *if_ni;
+
+	CHECK_WITH(SUCC(if_ni = if_nameindex()), if_ni != NULL);
+
+	TEST_RES(find_lo_and_eth0_by_libc(if_ni), _ret == 2);
+
+	if_freenameindex(if_ni);
+}
+END_TEST()
+
+void find_lo_and_eth0_by_libnl(struct nl_object *obj, void *arg)
+{
+	int *found_links = (int *)arg;
+	struct rtnl_link *link = (struct rtnl_link *)obj;
+
+	if (strcmp(rtnl_link_get_name(link), LOOPBACK_NAME) == 0) {
+		*found_links += 1;
+	}
+
+	if (strcmp(rtnl_link_get_name(link), ETHER_NAME) == 0) {
+		*found_links += 1;
+	}
+}
+
+FN_TEST(get_link_by_libnl)
+{
+	struct nl_sock *sock;
+	struct nl_cache *link_cache;
+
+	// 1. Create netlink socket and connect
+	sock = nl_socket_alloc();
+	TEST_RES(nl_connect(sock, NETLINK_ROUTE), _ret >= 0);
+
+	// 2. Allocate and retrieve link cache
+	TEST_RES(rtnl_link_alloc_cache(sock, AF_UNSPEC, &link_cache),
+		 _ret >= 0);
+
+	// 3. Iterate over all links to find lo and eth0
+	int found_links = 0;
+	TEST_RES(SUCC(nl_cache_foreach(link_cache, find_lo_and_eth0_by_libnl,
+				       &found_links)),
+		 found_links == 2);
+
+	// 4. Cleanup
+	nl_cache_free(link_cache);
+	nl_close(sock);
+	nl_socket_free(sock);
+}
+END_TEST()
+
+void find_loopback_address(struct nl_object *obj, void *arg)
+{
+	int *found_loopback = (int *)arg;
+	struct rtnl_addr *addr = (struct rtnl_addr *)obj;
+	struct nl_addr *local;
+	char buf[INET_ADDRSTRLEN];
+
+	int family = rtnl_addr_get_family(addr);
+	if (family != AF_INET) {
+		return;
+	}
+
+	local = rtnl_addr_get_local(addr);
+	if (local) {
+		nl_addr2str(local, buf, sizeof(buf));
+		if (strcmp(buf, "127.0.0.1/8") == 0) {
+			*found_loopback = 1;
+		}
+	}
+}
+
+FN_TEST(get_loopback_address)
+{
+	struct nl_sock *sock;
+	struct nl_cache *addr_cache;
+
+	// 1. Create netlink socket and connect
+	sock = nl_socket_alloc();
+	TEST_RES(nl_connect(sock, NETLINK_ROUTE), _ret >= 0);
+
+	// 2. Allocate and retrieve address cache
+	TEST_RES(rtnl_addr_alloc_cache(sock, &addr_cache), _ret >= 0);
+
+	// 3. Iterate over all addresses to find loopback address
+	int found_loopback = 0;
+	TEST_RES(SUCC(nl_cache_foreach(addr_cache, find_loopback_address,
+				       &found_loopback)),
+		 found_loopback == 1);
+
+	// 4. Cleanup
+	nl_cache_free(addr_cache);
+	nl_close(sock);
+	nl_socket_free(sock);
+}
+END_TEST()
+
+int find_new_addr_until_done(char *buffer, size_t len, int *found_new_addr)
+{
+	struct nlmsghdr *nlh = (struct nlmsghdr *)buffer;
+
+	for (; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
+		if (nlh->nlmsg_type == NLMSG_DONE) {
+			return *found_new_addr ? 1 : -1;
+		}
+
+		if (nlh->nlmsg_type == RTM_NEWADDR) {
+			*found_new_addr += 1;
+		} else {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+FN_TEST(get_addr_error)
+{
+#define BUFFER_SIZE 8192
+
+	struct nl_req {
+		struct nlmsghdr hdr;
+		struct ifaddrmsg ifa;
+	};
+
+	int sock_fd;
+	struct sockaddr_nl sa;
+	char buffer[BUFFER_SIZE];
+
+	sock_fd = TEST_SUCC(socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE));
+
+	memset(&sa, 0, sizeof(sa));
+	sa.nl_family = AF_NETLINK;
+
+	TEST_SUCC(bind(sock_fd, (struct sockaddr *)&sa, sizeof(sa)));
+
+	// 1. Without NLM_F_DUMP flag
+	struct nl_req req;
+	memset(&req, 0, sizeof(req));
+	req.hdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
+	req.hdr.nlmsg_type = RTM_GETADDR;
+	req.hdr.nlmsg_flags = NLM_F_REQUEST;
+	req.hdr.nlmsg_seq = 1;
+	req.ifa.ifa_family = AF_UNSPEC;
+
+	struct iovec iov = { &req, req.hdr.nlmsg_len };
+	struct msghdr msg = { &sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
+
+	TEST_SUCC(sendmsg(sock_fd, &msg, 0));
+	TEST_RES(recv(sock_fd, buffer, BUFFER_SIZE, 0),
+		 ((struct nlmsghdr *)buffer)->nlmsg_type == NLMSG_ERROR &&
+			 ((struct nlmsgerr *)NLMSG_DATA(buffer))->error ==
+				 -EOPNOTSUPP);
+
+	// 2. Invalid required index
+	req.hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP | NLM_F_ACK;
+	req.ifa.ifa_index = 9999;
+	TEST_SUCC(sendmsg(sock_fd, &msg, 0));
+
+	int found_new_addr = 0;
+	while (1) {
+		size_t recv_len =
+			TEST_SUCC(recv(sock_fd, buffer, BUFFER_SIZE, 0));
+
+		int found_done = TEST_SUCC(find_new_addr_until_done(
+			buffer, recv_len, &found_new_addr));
+
+		if (found_done != 0) {
+			break;
+		}
+	}
+
+	// 3. Invalid required family
+	req.ifa.ifa_family = 255;
+	req.ifa.ifa_index = 0;
+	TEST_SUCC(sendmsg(sock_fd, &msg, 0));
+
+	found_new_addr = 0;
+	while (1) {
+		size_t recv_len =
+			TEST_SUCC(recv(sock_fd, buffer, BUFFER_SIZE, 0));
+
+		int found_done = TEST_SUCC(find_new_addr_until_done(
+			buffer, recv_len, &found_new_addr));
+
+		if (found_done != 0) {
+			break;
+		}
+	}
+}
+END_TEST()

--- a/test/apps/test_common.mk
+++ b/test/apps/test_common.mk
@@ -22,7 +22,7 @@ $(OBJ_OUTPUT_DIR) $(DEP_OUTPUT_DIR):
 	@mkdir -p $@
 
 $(OBJ_OUTPUT_DIR)/%: %.c | $(OBJ_OUTPUT_DIR) $(DEP_OUTPUT_DIR)
-	@$(CC) $(C_FLAGS) $(EXTRA_C_FLAGS) $< -o $@ \
+	@$(CC) $(C_FLAGS) $< -o $@ $(EXTRA_C_FLAGS) \
 		-MMD -MF $(DEP_OUTPUT_DIR)/$*.d
 	@echo "CC <= $@"
 

--- a/test/syscall_test/Makefile
+++ b/test/syscall_test/Makefile
@@ -46,6 +46,7 @@ TESTS ?= \
 	sigaction_test \
 	sigaltstack_test \
 	signalfd_test \
+	socket_netlink_route_test \
 	stat_test \
 	stat_times_test \
 	statfs_test \

--- a/test/syscall_test/blocklists/socket_netlink_route_test
+++ b/test/syscall_test/blocklists/socket_netlink_route_test
@@ -1,0 +1,12 @@
+NetlinkRouteTest.MsgHdrMsgUnsuppType
+NetlinkRouteTest.MsgHdrMsgTrunc
+NetlinkRouteTest.MsgTruncMsgHdrMsgTrunc
+NetlinkRouteTest.ControlMessageIgnored
+NetlinkRouteTest.AddAddr
+NetlinkRouteTest.GetRouteDump
+NetlinkRouteTest.GetRouteRequest
+NetlinkRouteTest.RecvmsgTrunc
+NetlinkRouteTest.RecvmsgTruncPeek
+NetlinkRouteTest.NoPasscredNoCreds
+NetlinkRouteTest.PasscredCreds
+NetlinkRouteTest/SockOptTest.GetSockOpt/*


### PR DESCRIPTION
This PR implements Netlink route sockets for managing network interfaces.

The main work in this PR is to add the general Netlink route framework. I also implement two Netlink route commands: GETLINK and GETADDR, which are used to acquire interface and address information.

Netlink route is a protocol within Netlink. Generally, Netlink sockets are similar to datagram sockets, not requiring an initial connection. However, Netlink route sockets differ somewhat from typical Netlink sockets: users always utilize the socket to communicate with the kernel, rather than with other user Netlink sockets. Therefore, we maintain a mock kernel socket to facilitate communication with user sockets.

There are currently six commits in this PR. I did not split these commits in line level; they are mostly split at the file level.

1. The first commit adds tests. Currently, only a few tests are included, and they are aimed at covering the _correct_ path. The _error_ paths are largely _not_ covered.

2. ~The second commit refines the interfaces of `VmReader` and `MultiRead`. The main issue was that I wanted to implement `ReadCString` for `dyn MultiRead`, but the current interface was not suitable for this. Additionally, I added the `align_to` method to `MultiRead`, as Netlink usually requires reads from aligned addresses.~

3. The third commit adds the `ConfigurableIface`, which is a wrapper around `Arc<Iface>`. This structure is intended to provide device-specific information for Netlink requests. Currently, I mostly use hard-coded values, not the real values from device. As its name suggests, the device should also support being configured by Netlink requests, although this PR does not yet support that behavior. 

4. The fourth commit introduces the basic structures for Netlink, including changes to the syscall interface and support for binding, and some general concepts(like multicast group, alghouth multicast is not covered in this PR).

5. The fifth commit adds message support, including how to parse Netlink request messages from users into Rust types and vice versa.

6. The sixth commit covers the kernel logic for responding to user requests.

Considering the size of this PR is already quite large, some work remains unfinished. These areas should be marked with FIXME or TODO.