### PR TITLE
Add `read_with` methods to RCU types

### DIFF
--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -61,6 +61,8 @@ pub use owner_ptr::OwnerPtr;
 pub struct Rcu<P: OwnerPtr>(RcuInner<P>);
 
 /// A guard that allows access to the pointed data protected by a [`Rcu`].
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct RcuReadGuard<'a, P: OwnerPtr>(RcuReadGuardInner<'a, P>);
 
 /// A Read-Copy Update (RCU) cell for sharing a _nullable_ pointer.  
@@ -99,6 +101,8 @@ pub struct RcuReadGuard<'a, P: OwnerPtr>(RcuReadGuardInner<'a, P>);
 pub struct RcuOption<P: OwnerPtr>(RcuInner<P>);
 
 /// A guard that allows access to the pointed data protected by a [`RcuOption`].
+#[clippy::has_significant_drop]
+#[must_use]
 pub struct RcuOptionReadGuard<'a, P: OwnerPtr>(RcuReadGuardInner<'a, P>);
 
 /// The inner implementation of both [`Rcu`] and [`RcuOption`].


### PR DESCRIPTION
This PR adds \`read_with\` methods to both `Rcu` and `RcuOption`, hoping to reduce the number of preemption disabling operations when multiple `Rcu` protected objects are read. Should be useful for #1898 