### PR TITLE
Revise the docs of the slab and remove an unused type

### DIFF
--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -31,7 +31,7 @@ static FRAME_ALLOCATOR: FrameAllocator = FrameAllocator;
 #[ostd::global_heap_allocator]
 static HEAP_ALLOCATOR: HeapAllocator = HeapAllocator;
 
-#[ostd::global_heap_allocator_slot_type_map]
+#[ostd::global_heap_allocator_slot_map]
 const fn slot_type_from_layout(layout: core::alloc::Layout) -> Option<ostd::mm::heap::SlotInfo> {
     type_from_layout(layout)
 }

--- a/osdk/deps/heap-allocator/src/allocator.rs
+++ b/osdk/deps/heap-allocator/src/allocator.rs
@@ -85,7 +85,7 @@ impl CommonSizeClass {
 
 /// Get the type of the slot from the layout.
 ///
-/// It should be used to define [`ostd::global_heap_allocator_slot_type_map`].
+/// It should be used to define [`ostd::global_heap_allocator_slot_map`].
 pub const fn type_from_layout(layout: Layout) -> Option<SlotInfo> {
     if let Some(class) = CommonSizeClass::from_layout(layout) {
         return Some(SlotInfo::SlabSlot(class as usize));

--- a/osdk/src/base_crate/main.rs.template
+++ b/osdk/src/base_crate/main.rs.template
@@ -37,7 +37,7 @@ mod default_heap_allocator {
     #[no_mangle]
     #[linkage = "weak"]
     #[expect(non_snake_case)]
-    fn __GLOBAL_HEAP_SLOT_SIZE_FROM_LAYOUT(layout: core::alloc::Layout) -> Option<ostd::mm::heap::SlotInfo> {
+    fn __GLOBAL_HEAP_SLOT_INFO_FROM_LAYOUT(layout: core::alloc::Layout) -> Option<ostd::mm::heap::SlotInfo> {
         type_from_layout(layout)
     }
 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -48,7 +48,7 @@ mod util;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use ostd_macros::{
-    global_frame_allocator, global_heap_allocator, global_heap_allocator_slot_type_map, main,
+    global_frame_allocator, global_heap_allocator, global_heap_allocator_slot_map, main,
     panic_handler,
 };
 pub use ostd_pod::Pod;

--- a/ostd/src/mm/heap/slab.rs
+++ b/ostd/src/mm/heap/slab.rs
@@ -7,28 +7,21 @@ use core::{alloc::AllocError, ptr::NonNull};
 use super::{slot::HeapSlot, slot_list::SlabSlotList};
 use crate::mm::{
     frame::{linked_list::Link, meta::AnyFrameMeta},
-    paddr_to_vaddr, Frame, FrameAllocOptions, UniqueFrame, PAGE_SIZE,
+    paddr_to_vaddr, FrameAllocOptions, UniqueFrame, PAGE_SIZE,
 };
 
 /// A slab.
 ///
-/// The slot size is the maximum size and alignment of the objects that can be
-/// allocated from the slab. The slab is divided into slots of this size.
+/// The slot size is the maximum size of objects that can be allocated from the
+/// slab. The slab is densely divided into slots of this size.
 ///
-/// The size of the slot cannot be smaller than the size of [`usize`] and must
-/// be a power of two. The size of the slab should be larger than the slot
-/// size and [`PAGE_SIZE`].
+/// The `SLOT_SIZE` is the size of the slots in bytes. The size of the slots
+/// cannot be smaller than the size of [`usize`]. It must be smaller than or
+/// equal to [`PAGE_SIZE`].
 ///
-/// The `SLOT_SIZE` is the size of the slot in bytes. It must be smaller than or
-/// equal to [`PAGE_SIZE`]. This restriction may be lifted in the future.
+/// A slab should have the size of one basic page. This restriction may be
+/// lifted in the future.
 pub type Slab<const SLOT_SIZE: usize> = UniqueFrame<Link<SlabMeta<SLOT_SIZE>>>;
-
-/// A shared pointer to a slab.
-///
-/// It is solely useful to point to a slab from a stray slot. When an object of
-/// this type exists no mutable references can be created to the slab. So don't
-/// hold it for long.
-pub type SharedSlab<const SLOT_SIZE: usize> = Frame<Link<SlabMeta<SLOT_SIZE>>>;
 
 /// Frame metadata of a slab.
 ///


### PR DESCRIPTION
Sorry. It seems that the slab allocator #1789 was merged too hastily, leaving some minor problems here.