### PR TITLE
Minor improvements in unwinding builds and feature selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,12 @@ allow_attributes = "warn"
 # Cargo only looks at the profile settings 
 # in the Cargo.toml manifest at the root of the workspace
 
+[profile.dev]
+panic = "unwind"
+
 [profile.release]
 lto = "thin"
+panic = "unwind"
 
 # Release profile configuration with Link Time Optimization (LTO) enabled.
 #

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ LOG_LEVEL ?= error
 SCHEME ?= ""
 SMP ?= 1
 OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
+FEATURES ?=
+NO_DEFAULT_FEATURES ?= 0
 # End of global build options.
 
 # GDB debugging and profiling options.
@@ -33,7 +35,6 @@ GDB_PROFILE_INTERVAL ?= 0.1
 AUTO_TEST ?= none
 EXTRA_BLOCKLISTS_DIRS ?= ""
 SYSCALL_TEST_DIR ?= /tmp
-FEATURES ?=
 # End of auto test features.
 
 # Network settings
@@ -92,6 +93,9 @@ endif
 
 ifdef FEATURES
 CARGO_OSDK_ARGS += --features="$(FEATURES)"
+endif
+ifeq ($(NO_DEFAULT_FEATURES), 1)
+CARGO_OSDK_ARGS += --no-default-features
 endif
 
 # To test the linux-efi-handover64 boot protocol, we need to use Debian's

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -217,7 +217,7 @@ fn add_manifest_dependency(
     let dependencies = manifest.get_mut("dependencies").unwrap();
 
     let target_dep = toml::Table::from_str(&format!(
-        "{} = {{ path = \"{}\", default-features = false }}",
+        "{} = {{ path = \"{}\" }}",
         crate_name,
         crate_path.as_ref().display()
     ))

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -207,9 +207,8 @@ fn build_kernel_elf(
         &rustc_linker_script_arg,
         "-C relocation-model=static",
         "-C relro-level=off",
-        // We do not really allow unwinding except for kernel testing. However, we need to specify
-        // this to show backtraces when panicking.
-        "-C panic=unwind",
+        // Even if we disabled unwinding on panic, we need to specify this to show backtraces.
+        "-C force-unwind-tables=yes",
         // This is to let rustc know that "cfg(ktest)" is our well-known configuration.
         // See the [Rust Blog](https://blog.rust-lang.org/2024/05/06/check-cfg.html) for details.
         "--check-cfg cfg(ktest)",

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -98,7 +98,7 @@ pub static KTEST_CRATE_WHITELIST: Option<&[&str]> = Some(&{:#?});
         &cargo_target_directory,
         config,
         ActionChoice::Test,
-        &["--cfg ktest"],
+        &["--cfg ktest", "-C panic=unwind"],
     );
     std::env::remove_var("RUSTFLAGS");
     drop(dir_guard);


### PR DESCRIPTION
This PR:
 - ~~makes `unwind` a default feature for both OSTD and the kernel;~~
 - turn on `force-unwind-tables=yes` rather than `panic=unwind`, which makes our purpose clearer;
 - let feature selection in Makefile and OSDK make more sense.

It helps for supporting LoongArch64, which the `unwinding` crate does not support. LoongArch64 does not support `panic=unwind` too.