### PR TITLE
Fail immediately if publishing fails

### DIFF
--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -65,11 +65,7 @@ do_publish_for() {
         RUSTFLAGS=$RF cargo publish --dry-run --allow-dirty $ADDITIONAL_ARGS
         RUSTFLAGS=$RF cargo doc $ADDITIONAL_ARGS
     else
-        # Continue if the publish fails, as we may be re-triggering the
-        # workflow and the package may have already been published.
-        if ! RUSTFLAGS=$RF cargo publish --token $TOKEN $ADDITIONAL_ARGS; then
-            echo "Warning: Failed to publish $1"
-        fi
+        RUSTFLAGS=$RF cargo publish --token $TOKEN $ADDITIONAL_ARGS
     fi
 
     popd


### PR DESCRIPTION
#1918 added the failure-resume policy since we published some of the crates and failed the rest. We wanted to re-trigger the workflow to publish the rest. @tatetian suggests a removal since it is dangerous. This PR removes the policy. 

An alternative way, which I like, is to fail at the end of the workflow if there is a failed publish. So that when we fail to publish some crates in the future due to, e.g., a network outage, we can just do a re-trigger.