### PR TITLE
Fix wrong container image tag

### DIFF
--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: asterinas/asterinas:$(cat asterinas/DOCKER_IMAGE_VERSION)
+    container: asterinas/asterinas:0.14.0
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#1911 introduces a wrong container image tag `asterinas/asterinas:$(cat asterinas/DOCKER_IMAGE_VERSION)`, which causes [errors](https://github.com/asterinas/asterinas/actions/runs/13971317313) on osdk publishing.