### PR TITLE
Introduce the semantics of the atomic-mode guard

### DIFF
--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -10,6 +10,7 @@ use crate::{
     cpu::{AtomicCpuSet, CpuId, CpuSet, PinCurrentCpu},
     prelude::*,
     sync::SpinLock,
+    task::atomic_mode::AsAtomicModeGuard,
 };
 
 /// A RCU monitor ensures the completion of _grace periods_ by keeping track
@@ -42,7 +43,7 @@ impl RcuMonitor {
         // GP.
         let callbacks = {
             let mut state = self.state.disable_irq().lock();
-            let cpu = state.guard().current_cpu();
+            let cpu = state.as_atomic_mode_guard().current_cpu();
             if state.current_gp.is_complete() {
                 return;
             }

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -9,7 +9,8 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use super::{guard::Guardian, LocalIrqDisabled, PreemptDisabled};
+use super::{guard::SpinGuardian, LocalIrqDisabled, PreemptDisabled};
+use crate::task::atomic_mode::AsAtomicModeGuard;
 
 /// A spin lock.
 ///
@@ -67,7 +68,7 @@ impl<T: ?Sized> SpinLock<T, PreemptDisabled> {
     }
 }
 
-impl<T: ?Sized, G: Guardian> SpinLock<T, G> {
+impl<T: ?Sized, G: SpinGuardian> SpinLock<T, G> {
     /// Acquires the spin lock.
     pub fn lock(&self) -> SpinLockGuard<T, G> {
         // Notice the guard must be created before acquiring the lock.
@@ -152,19 +153,22 @@ pub type ArcSpinLockGuard<T, G> = SpinLockGuard_<T, Arc<SpinLock<T, G>>, G>;
 /// The guard of a spin lock.
 #[clippy::has_significant_drop]
 #[must_use]
-pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> {
+pub struct SpinLockGuard_<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> {
     guard: G::Guard,
     lock: R,
 }
 
-impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> SpinLockGuard_<T, R, G> {
-    /// Returns a reference to the guard.
-    pub fn guard(&self) -> &G::Guard {
-        &self.guard
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> AsAtomicModeGuard
+    for SpinLockGuard_<T, R, G>
+{
+    fn as_atomic_mode_guard(&self) -> &dyn crate::task::atomic_mode::InAtomicMode {
+        self.guard.as_atomic_mode_guard()
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> Deref for SpinLockGuard_<T, R, G> {
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> Deref
+    for SpinLockGuard_<T, R, G>
+{
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -172,7 +176,7 @@ impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> Deref for SpinLo
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> DerefMut
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> DerefMut
     for SpinLockGuard_<T, R, G>
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -180,13 +184,15 @@ impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> DerefMut
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> Drop for SpinLockGuard_<T, R, G> {
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> Drop
+    for SpinLockGuard_<T, R, G>
+{
     fn drop(&mut self) {
         self.lock.release_lock();
     }
 }
 
-impl<T: ?Sized + fmt::Debug, R: Deref<Target = SpinLock<T, G>>, G: Guardian> fmt::Debug
+impl<T: ?Sized + fmt::Debug, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> fmt::Debug
     for SpinLockGuard_<T, R, G>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -194,11 +200,14 @@ impl<T: ?Sized + fmt::Debug, R: Deref<Target = SpinLock<T, G>>, G: Guardian> fmt
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: Guardian> !Send for SpinLockGuard_<T, R, G> {}
+impl<T: ?Sized, R: Deref<Target = SpinLock<T, G>>, G: SpinGuardian> !Send
+    for SpinLockGuard_<T, R, G>
+{
+}
 
 // SAFETY: `SpinLockGuard_` can be shared between tasks/threads in same CPU.
 // As `lock()` is only called when there are no race conditions caused by interrupts.
-unsafe impl<T: ?Sized + Sync, R: Deref<Target = SpinLock<T, G>> + Sync, G: Guardian> Sync
+unsafe impl<T: ?Sized + Sync, R: Deref<Target = SpinLock<T, G>> + Sync, G: SpinGuardian> Sync
     for SpinLockGuard_<T, R, G>
 {
 }

--- a/ostd/src/task/atomic_mode.rs
+++ b/ostd/src/task/atomic_mode.rs
@@ -45,3 +45,31 @@ pub fn might_sleep() {
         );
     }
 }
+
+/// A marker trait for guard types that enforce the atomic mode.
+///
+/// Key kernel primitives such as `SpinLock` and `Rcu` rely on
+/// [the atomic mode](crate::task::atomic_mode) for correctness or soundness.
+/// The existence of such a guard guarantees that
+/// the current task is executing in the atomic mode.
+///
+/// # Safety
+///
+/// The implementer must ensure that the atomic mode is maintained while
+/// the guard type is alive.
+///
+/// [`DisabledLocalIrqGuard`]: crate::task::DisabledPreemptGuard
+/// [`DisabledPreemptGuard`]: crate::trap::DisabledLocalIrqGuard
+pub unsafe trait InAtomicMode {}
+
+/// Abstracts any type from which one can obtain a reference to an atomic-mode guard.
+pub trait AsAtomicModeGuard {
+    /// Returns a guard for the atomic mode.
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode;
+}
+
+impl<G: InAtomicMode> AsAtomicModeGuard for G {
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode {
+        self
+    }
+}

--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::sync::GuardTransfer;
+use crate::{sync::GuardTransfer, task::atomic_mode::InAtomicMode};
 
 /// A guard for disable preempt.
 #[clippy::has_significant_drop]
@@ -12,6 +12,10 @@ pub struct DisabledPreemptGuard {
 }
 
 impl !Send for DisabledPreemptGuard {}
+
+// SAFETY: The guard disables preemptions, which meets the second
+// sufficient condition for atomic mode.
+unsafe impl InAtomicMode for DisabledPreemptGuard {}
 
 impl DisabledPreemptGuard {
     fn new() -> Self {

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -6,6 +6,7 @@ use crate::{
     arch::irq::{self, IrqCallbackHandle, IRQ_ALLOCATOR},
     prelude::*,
     sync::GuardTransfer,
+    task::atomic_mode::InAtomicMode,
     trap::TrapFrame,
     Error,
 };
@@ -139,6 +140,10 @@ pub struct DisabledLocalIrqGuard {
 }
 
 impl !Send for DisabledLocalIrqGuard {}
+
+// SAFETY: The guard disables local IRQs, which meets the first
+// sufficient condition for atomic mode.
+unsafe impl InAtomicMode for DisabledLocalIrqGuard {}
 
 impl DisabledLocalIrqGuard {
     fn new() -> Self {


### PR DESCRIPTION
This PR lets the Guardian ensures that preemption is disabled while the lock is held. This can allow RCU read with both `DisabledPreemptGuard` and `DisabledLocalIrqGuard`.