### PR TITLE
Workaround the missing process of a thread

### DIFF
--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -42,7 +42,11 @@ fn update_cpu_time() {
     let Some(posix_thread) = current_thread.as_posix_thread() else {
         return;
     };
-    let process = posix_thread.process();
+    let Some(process) = posix_thread.weak_process().upgrade() else {
+        // FIXME: A POSIX thread should have a process but we can have a
+        // `None` here.
+        return;
+    };
     let timer_manager = process.timer_manager();
     let jiffies_interval = Duration::from_millis(1000 / TIMER_FREQ);
     // Based on whether the timer interrupt occurs in kernel mode or user mode,


### PR DESCRIPTION
It actually happens when we launch a heavily multi-threaded workload. This PR is not a fix and we still should fix the root cause where we kill the process on a running thread without disabling interrupts.