### PR TITLE
Avoid an `Arc::clone` in `mmap` to make it scale

### DIFF
--- a/kernel/src/vm/vmar/dyn_cap.rs
+++ b/kernel/src/vm/vmar/dyn_cap.rs
@@ -58,8 +58,7 @@ impl Vmar<Rights> {
     /// which ensures that any updated memory permissions do not go beyond
     /// the access rights of the underlying VMOs.
     pub fn new_map(&self, size: usize, perms: VmPerms) -> Result<VmarMapOptions<Rights, Rights>> {
-        let dup_self = self.dup()?;
-        Ok(VmarMapOptions::new(dup_self, size, perms))
+        Ok(VmarMapOptions::new(self, size, perms))
     }
 
     /// Changes the permissions of the memory mappings in the specified range.

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -480,8 +480,8 @@ impl<R> Vmar<R> {
 /// Options for creating a new mapping. The mapping is not allowed to overlap
 /// with any child VMARs. And unless specified otherwise, it is not allowed
 /// to overlap with any existing mapping, either.
-pub struct VmarMapOptions<R1, R2> {
-    parent: Vmar<R1>,
+pub struct VmarMapOptions<'a, R1, R2> {
+    parent: &'a Vmar<R1>,
     vmo: Option<Vmo<R2>>,
     perms: VmPerms,
     vmo_offset: usize,
@@ -496,14 +496,14 @@ pub struct VmarMapOptions<R1, R2> {
     handle_page_faults_around: bool,
 }
 
-impl<R1, R2> VmarMapOptions<R1, R2> {
+impl<'a, R1, R2> VmarMapOptions<'a, R1, R2> {
     /// Creates a default set of options with the VMO and the memory access
     /// permissions.
     ///
     /// The VMO must have access rights that correspond to the memory
     /// access permissions. For example, if `perms` contains `VmPerms::Write`,
     /// then `vmo.rights()` should contain `Rights::WRITE`.
-    pub fn new(parent: Vmar<R1>, size: usize, perms: VmPerms) -> Self {
+    pub fn new(parent: &'a Vmar<R1>, size: usize, perms: VmPerms) -> Self {
         Self {
             parent,
             vmo: None,

--- a/kernel/src/vm/vmar/static_cap.rs
+++ b/kernel/src/vm/vmar/static_cap.rs
@@ -68,8 +68,7 @@ impl<R: TRights> Vmar<TRightSet<R>> {
         size: usize,
         perms: VmPerms,
     ) -> Result<VmarMapOptions<TRightSet<R>, Rights>> {
-        let dup_self = self.dup()?;
-        Ok(VmarMapOptions::new(dup_self, size, perms))
+        Ok(VmarMapOptions::new(self, size, perms))
     }
 
     /// Change the permissions of the memory mappings in the specified range.


### PR DESCRIPTION
`Arc::clone` is not scalable. And we can avoid it in `VmarMapOptions`. Otherwise multiple threads `mmap`ping in the same address space would contend. Although it is not the only scalability issue in the current code base, it is the easiest one to address.