### PR TITLE
Don't force console printer to use `if_tdx_enabled`

### DIFF
--- a/ostd/src/arch/riscv/serial.rs
+++ b/ostd/src/arch/riscv/serial.rs
@@ -33,6 +33,8 @@ impl Write for Stdout {
 /// Initializes the serial port.
 pub(crate) fn init() {}
 
+pub(crate) fn callback_init() {}
+
 /// Sends a byte on the serial port.
 pub fn send(data: u8) {
     sbi_rt::console_write_byte(data);

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -41,11 +41,9 @@ use log::{info, warn};
 
 #[cfg(feature = "cvm_guest")]
 pub(crate) fn init_cvm_guest() {
-    use ::tdx_guest::serial_println;
-
     match init_tdx() {
         Ok(td_info) => {
-            serial_println!(
+            crate::early_println!(
                 "[kernel] Intel TDX initialized\n[kernel] td gpaw: {}, td attributes: {:?}",
                 td_info.gpaw,
                 td_info.attributes
@@ -89,7 +87,6 @@ pub(crate) unsafe fn late_init_on_bsp() {
             kernel::pic::enable();
         }
     }
-    serial::callback_init();
 
     kernel::tsc::init_tsc_freq();
     timer::init_bsp();

--- a/ostd/src/arch/x86/serial.rs
+++ b/ostd/src/arch/x86/serial.rs
@@ -2,9 +2,6 @@
 
 //! The console I/O.
 
-#![expect(dead_code)]
-#![expect(unused_variables)]
-
 use alloc::{fmt, sync::Arc, vec::Vec};
 use core::fmt::Write;
 
@@ -84,20 +81,7 @@ pub(crate) fn callback_init() {
     CONSOLE_IRQ_CALLBACK.call_once(|| SpinLock::new(irq));
 }
 
-pub(crate) fn register_console_callback<F>(callback: F)
-where
-    F: Fn(&TrapFrame) + Sync + Send + 'static,
-{
-    CONSOLE_IRQ_CALLBACK
-        .get()
-        .unwrap()
-        .disable_irq()
-        .lock()
-        .on_active(callback);
-}
-
-fn handle_serial_input(trap_frame: &TrapFrame) {
-    // debug!("keyboard interrupt was met");
+fn handle_serial_input(_trap_frame: &TrapFrame) {
     let lock = if let Some(lock) = SERIAL_INPUT_CALLBACKS.try_lock() {
         lock
     } else {
@@ -133,7 +117,7 @@ pub fn send(data: u8) {
 }
 
 /// Receives a byte on the serial port. non-blocking
-pub fn receive_char() -> Option<u8> {
+fn receive_char() -> Option<u8> {
     if line_sts().contains(LineSts::INPUT_FULL) {
         Some(CONSOLE_COM1_PORT.recv())
     } else {

--- a/ostd/src/console.rs
+++ b/ostd/src/console.rs
@@ -4,9 +4,15 @@
 
 use core::fmt::Arguments;
 
+use crate::if_tdx_enabled;
+
 /// Prints formatted arguments to the console.
 pub fn early_print(args: Arguments) {
-    crate::arch::serial::print(args);
+    if_tdx_enabled!({
+        tdx_guest::print(args);
+    } else {
+        crate::arch::serial::print(args);
+    });
 }
 
 /// Prints to the console.

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -113,6 +113,7 @@ unsafe fn init() {
     if_tdx_enabled!({
         arch::serial::init();
     });
+    arch::serial::callback_init();
 
     smp::init();
 

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -10,7 +10,7 @@ use super::{meta::AnyFrameMeta, segment::Segment, Frame};
 use crate::{
     boot::memory_region::MemoryRegionType,
     error::Error,
-    if_tdx_enabled, impl_frame_meta_for,
+    impl_frame_meta_for,
     mm::{paddr_to_vaddr, Paddr, PAGE_SIZE},
     prelude::*,
     util::range_difference,
@@ -212,13 +212,7 @@ pub(crate) unsafe fn init() {
             // Truncate the early allocated frames if there is an overlap.
             for r1 in range_difference(&(region.base()..region.end()), &range_1) {
                 for r2 in range_difference(&r1, &range_2) {
-                    if_tdx_enabled!({
-                        use tdx_guest::serial_println;
-
-                        serial_println!("Adding free frames to the allocator: {:x?}", r2);
-                    } else {
-                        log::info!("Adding free frames to the allocator: {:x?}", r2);
-                    });
+                    log::info!("Adding free frames to the allocator: {:x?}", r2);
                     get_global_frame_allocator().add_free_memory(r2.start, r2.len());
                 }
             }

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -53,7 +53,7 @@ use log::info;
 
 use crate::{
     arch::mm::PagingConsts,
-    const_assert, if_tdx_enabled,
+    const_assert,
     mm::{
         frame::allocator::{self, EarlyAllocatedFrameMeta},
         kspace::LINEAR_MAPPING_BASE_VADDR,
@@ -447,15 +447,10 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         regions.iter().map(|r| r.base() + r.len()).max().unwrap()
     };
 
-    if_tdx_enabled!({
-        use tdx_guest::serial_println;
-
-        serial_println!("Initializing frame metadata for physical memory up to {:x}",
-            max_paddr)
-    } else {
-        info!("Initializing frame metadata for physical memory up to {:x}",
-            max_paddr);
-    });
+    info!(
+        "Initializing frame metadata for physical memory up to {:x}",
+        max_paddr
+    );
 
     add_temp_linear_mapping(max_paddr);
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -59,7 +59,6 @@ use super::{
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
     boot::memory_region::MemoryRegionType,
-    if_tdx_enabled,
 };
 
 /// The shortest supported address width is 39 bits. And the literal
@@ -133,13 +132,7 @@ pub static KERNEL_PAGE_TABLE: Once<PageTable<KernelMode, PageTableEntry, PagingC
 /// This function should be called before:
 ///  - any initializer that modifies the kernel page table.
 pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
-    if_tdx_enabled!({
-        use tdx_guest::serial_println;
-
-        serial_println!("Initializing the kernel page table");
-    } else {
-        info!("Initializing the kernel page table");
-    });
+    info!("Initializing the kernel page table");
 
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
     let phys_mem_cap = regions.iter().map(|r| r.base() + r.len()).max().unwrap();


### PR DESCRIPTION
I don't think we want to have things like these..
https://github.com/asterinas/asterinas/blob/4f0acddfd45e617460e32cf49e423410a7f712a6/ostd/src/mm/frame/allocator.rs#L215-L221
https://github.com/asterinas/asterinas/blob/4f0acddfd45e617460e32cf49e423410a7f712a6/ostd/src/mm/frame/meta.rs#L450-L458
https://github.com/asterinas/asterinas/blob/4f0acddfd45e617460e32cf49e423410a7f712a6/ostd/src/mm/kspace/mod.rs#L136-L142

That's simply too ugly.

I want to change `early_print` to call `tdx_guest::print` directly instead, which should be more efficient when TDX is active since it won't throw #VE exceptions.

This PR has been tested in TDX environments and everything seems to work normally.