### PR TITLE
Fix the failure of device-related benchmarks

### DIFF
--- a/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
@@ -5,6 +5,7 @@
 use alloc::collections::BTreeMap;
 use core::mem::size_of;
 
+use log::trace;
 use ostd_pod::Pod;
 
 use super::second_stage::{DeviceMode, PageTableEntry, PagingConsts};
@@ -296,6 +297,12 @@ impl ContextTable {
         if device.device >= 32 || device.function >= 8 {
             return Err(ContextTableError::InvalidDeviceId);
         }
+        trace!(
+            "Mapping Daddr: {:x?} to Paddr: {:x?} for device: {:x?}",
+            daddr,
+            paddr,
+            device
+        );
         self.get_or_create_page_table(device)
             .map(
                 &(daddr..daddr + PAGE_SIZE),
@@ -314,6 +321,7 @@ impl ContextTable {
         if device.device >= 32 || device.function >= 8 {
             return Err(ContextTableError::InvalidDeviceId);
         }
+        trace!("Unmapping Daddr: {:x?} for device: {:x?}", daddr, device);
         let pt = self.get_or_create_page_table(device);
         let mut cursor = pt.cursor_mut(&(daddr..daddr + PAGE_SIZE)).unwrap();
         unsafe {

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -20,8 +20,8 @@ use crate::{
 pub struct DeviceMode {}
 
 impl PageTableMode for DeviceMode {
-    /// The device address space is 32-bit.
-    const VADDR_RANGE: Range<Vaddr> = 0..0x1_0000_0000;
+    /// The device address width we currently support is 39-bit.
+    const VADDR_RANGE: Range<Vaddr> = 0..0x80_0000_0000;
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
Fixes #1882.

See https://github.com/asterinas/asterinas/issues/1882#issuecomment-2746041436. In this PR, I set the `VADDR_RANGE` to `0..0x80_0000_0000` as a temporary fix for the failure of device-related benchmarks.