### PR TITLE
Add per-class preemption strategy

### DIFF
--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -58,4 +58,8 @@ impl SchedClassRq for IdleClassRq {
         // Idle entities has the greatest priority value. They should always be preempted.
         true
     }
+
+    fn check_preempt_current(_: &SchedAttr, _: &SchedAttr) -> bool {
+        unreachable!("There should be only one unique idle entity.")
+    }
 }

--- a/kernel/src/sched/sched_class/real_time.rs
+++ b/kernel/src/sched/sched_class/real_time.rs
@@ -220,6 +220,13 @@ impl SchedClassRq for RealTimeClassRq {
                 ts => ts <= rt.period_delta,
             },
             UpdateFlags::Yield => true,
+            UpdateFlags::CheckPreempt => {
+                unreachable!("Real-time task preemption involves only priority.")
+            }
         }
+    }
+
+    fn check_preempt_current(attr: &SchedAttr, current_attr: &SchedAttr) -> bool {
+        attr.real_time.prio.load(Relaxed) < current_attr.real_time.prio.load(Relaxed)
     }
 }

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -59,4 +59,8 @@ impl SchedClassRq for StopClassRq {
         // Stop entities has the lowest priority value. They should never be preempted.
         false
     }
+
+    fn check_preempt_current(_: &SchedAttr, _: &SchedAttr) -> bool {
+        unreachable!("There should be only one unique stop entity.")
+    }
 }

--- a/kernel/src/sched/sched_class/time.rs
+++ b/kernel/src/sched/sched_class/time.rs
@@ -34,11 +34,18 @@ pub const BASE_SLICE_NS: u64 = 750_000;
 /// The minimum scheduling period, measured in nanoseconds.
 pub const MIN_PERIOD_NS: u64 = 6_000_000;
 
-fn consts() -> (u64, u64) {
-    static CONSTS: Once<(u64, u64)> = Once::new();
+/// The penalty for new task in preemption check, measured in nanoseconds.
+pub const PREEMPT_PENALTY: u64 = 1_000_000;
+
+fn consts() -> (u64, u64, u64) {
+    static CONSTS: Once<(u64, u64, u64)> = Once::new();
     *CONSTS.call_once(|| {
         let (a, b) = tsc_factors();
-        (BASE_SLICE_NS * b / a, MIN_PERIOD_NS * b / a)
+        (
+            BASE_SLICE_NS * b / a,
+            MIN_PERIOD_NS * b / a,
+            PREEMPT_PENALTY * b / a,
+        )
     })
 }
 
@@ -50,4 +57,9 @@ pub fn base_slice_clocks() -> u64 {
 /// Returns the minimum scheduling period, measured in TSC clock units.
 pub fn min_period_clocks() -> u64 {
     consts().1
+}
+
+/// Returns the penalty for new task in preemption check, measured in TSC clock units.
+pub fn preempt_penalty_clocks() -> u64 {
+    consts().2
 }

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -102,6 +102,8 @@ pub enum UpdateFlags {
     Wait,
     /// Task yielding.
     Yield,
+    /// Preemption checking.
+    CheckPreempt,
 }
 
 /// Preempts the current task.


### PR DESCRIPTION
Currently enqueued thread preempts current thread only when it's of a more favored scheduling class. This PR adds preemption check when both threads are of a same scheduling class.