### PR TITLE
Optimize TLB flush implementation (a bit)

### DIFF
--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -136,8 +136,6 @@ fn ap_early_entry(local_apic_id: u32) -> ! {
 
     crate::arch::irq::enable_local();
 
-    crate::mm::tlb::register_timer_callbacks_this_cpu();
-
     // SAFETY: this function is only called once on this AP.
     unsafe {
         crate::mm::kspace::activate_kernel_page_table();

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -106,7 +106,6 @@ unsafe fn init() {
     boot::init_after_heap();
 
     mm::dma::init();
-    mm::tlb::register_timer_callbacks_this_cpu();
 
     unsafe { arch::late_init_on_bsp() };
 

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -205,17 +205,6 @@ impl TlbFlushOp {
     }
 }
 
-/// Registers the timer callbacks for the TLB flush operations.
-///
-/// We check if there's pending TLB flush requests on each CPU in the timer
-/// callback. This is to ensure that the TLB flush requests are processed
-/// ultimately in case the IPIs are not received.
-///
-/// This function should be done once for each CPU during the initialization.
-pub(crate) fn register_timer_callbacks_this_cpu() {
-    crate::timer::register_callback(do_remote_flush);
-}
-
 // The queues of pending requests on each CPU.
 //
 // Lock ordering: lock FLUSH_OPS before PAGE_KEEPER.


### PR DESCRIPTION
The last commit in https://github.com/asterinas/asterinas/pull/1877 makes the time interrupt flush TLBs, and claims the reason as the IPI may be lost:
https://github.com/asterinas/asterinas/blob/c85986caedf1bb42ade917038590f2e91fb5d175/ostd/src/mm/tlb.rs#L211-L212

I don't think it will occur unless our IPI implementation contains bugs.

As a concrete evident, if the IPI could be lost, Linux would not have [an API](https://github.com/torvalds/linux/blob/586de92313fcab8ed84ac5f78f4d2aae2db92c59/kernel/smp.c#L622-L631) that allows the caller to wait until all other processors have received and processed the IPI.

So this PR proposes to remove the timer callback.

---

Also, the pages to be flushed used to be managed by two locks, which is no longer necessary because all usage sites lock both locks. Having two locks is inefficient and prone to race conditions or deadlocks, which can also confuse the code reader.
https://github.com/asterinas/asterinas/blob/c85986caedf1bb42ade917038590f2e91fb5d175/ostd/src/mm/tlb.rs#L223-L224

This PR also proposes to merge them into one lock.