### PR TITLE
Move some fields from `Process` to the new structure `ProcessState`.

### DIFF
--- a/kernel/src/fs/procfs/self_.rs
+++ b/kernel/src/fs/procfs/self_.rs
@@ -6,6 +6,7 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
+    process::ProcessState,
 };
 
 /// Represents the inode at `/proc/self`.
@@ -19,6 +20,10 @@ impl SelfSymOps {
 
 impl SymOps for SelfSymOps {
     fn read_link(&self) -> Result<String> {
-        Ok(current!().pid().to_string())
+        Ok(
+            ProcessState::with_current_task(|process_state| process_state.pid())
+                .unwrap()
+                .to_string(),
+        )
     }
 }

--- a/kernel/src/fs/procfs/thread_self.rs
+++ b/kernel/src/fs/procfs/thread_self.rs
@@ -8,7 +8,7 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    process::posix_thread::AsPosixThread,
+    process::{posix_thread::AsPosixThread, ProcessState},
 };
 
 /// Represents the inode at `/proc/self-thread`.
@@ -22,7 +22,8 @@ impl ThreadSelfSymOps {
 
 impl SymOps for ThreadSelfSymOps {
     fn read_link(&self) -> Result<String> {
-        let pid = current!().pid();
+        let pid = ProcessState::with_current_task(|process_state| process_state.pid()).unwrap();
+
         let tid = current_thread!().as_posix_thread().unwrap().tid();
         Ok(format!("{}/task/{}", pid, tid))
     }

--- a/kernel/src/fs/utils/range_lock/builder.rs
+++ b/kernel/src/fs/utils/range_lock/builder.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::*;
-use crate::process::Pid;
+use crate::process::{Pid, ProcessState};
 
 /// Builder for `RangeLockItem`.
 ///
@@ -59,7 +59,9 @@ impl RangeLockItemBuilder {
     }
 
     pub fn build(self) -> Result<RangeLockItem> {
-        let owner = self.owner.unwrap_or_else(|| current!().pid());
+        let owner = self.owner.unwrap_or_else(|| {
+            ProcessState::with_current_task(|process_state| process_state.pid()).unwrap()
+        });
         let type_ = if let Some(type_) = self.type_ {
             type_
         } else {

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -13,7 +13,7 @@ use super::sem_set::{SemSetInner, SEMVMX};
 use crate::{
     ipc::{key_t, semaphore::system_v::sem_set::sem_sets, IpcFlags},
     prelude::*,
-    process::Pid,
+    process::{Pid, ProcessState},
     time::{clocks::JIFFIES_TIMER_MANAGER, timer::Timeout},
 };
 
@@ -123,7 +123,10 @@ impl Semaphore {
     pub(super) fn new(val: i32) -> Self {
         Self {
             val,
-            latest_modified_pid: current!().pid(),
+            latest_modified_pid: ProcessState::with_current_task(|process_state| {
+                process_state.pid()
+            })
+            .unwrap(),
         }
     }
 }

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -78,7 +78,7 @@ pub fn tgkill(tid: Tid, tgid: Pid, signal: Option<UserSignal>, ctx: &Context) ->
     let posix_thread = thread.as_posix_thread().unwrap();
 
     // Check tgid
-    let pid = posix_thread.process().pid();
+    let pid = posix_thread.process_state().unwrap().pid();
     if pid != tgid {
         return_errno_with_message!(
             Errno::EINVAL,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -23,7 +23,8 @@ pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use process::{
-    ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, Session, Sid, Terminal,
+    ExitCode, JobControl, Pgid, Pid, Process, ProcessBuilder, ProcessGroup, ProcessState, Session,
+    Sid, Terminal,
 };
 pub use process_filter::ProcessFilter;
 pub use process_vm::{MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN};

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -128,9 +128,13 @@ impl PosixThreadBuilder {
                 let prof_clock = ProfClock::new();
                 let virtual_timer_manager = TimerManager::new(prof_clock.user_clock().clone());
                 let prof_timer_manager = TimerManager::new(prof_clock.clone());
+                let process_state = process
+                    .upgrade()
+                    .map(|process| process.process_state().clone());
 
                 PosixThread {
                     process,
+                    process_state,
                     tid,
                     name: Mutex::new(thread_name),
                     credentials,

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -7,6 +7,7 @@ use ostd::sync::{RoArc, Waker};
 
 use super::{
     kill::SignalSenderIds,
+    process::ProcessState,
     signal::{
         sig_action::SigAction,
         sig_mask::{AtomicSigMask, SigMask, SigSet},
@@ -45,6 +46,7 @@ pub use thread_local::{AsThreadLocal, ThreadLocal};
 pub struct PosixThread {
     // Immutable part
     process: Weak<Process>,
+    process_state: Option<Arc<ProcessState>>,
     tid: Tid,
 
     // Mutable part
@@ -81,6 +83,10 @@ pub struct PosixThread {
 impl PosixThread {
     pub fn process(&self) -> Arc<Process> {
         self.process.upgrade().unwrap()
+    }
+
+    pub fn process_state(&self) -> Option<&Arc<ProcessState>> {
+        self.process_state.as_ref()
     }
 
     pub fn weak_process(&self) -> Weak<Process> {

--- a/kernel/src/process/process/job_control.rs
+++ b/kernel/src/process/process/job_control.rs
@@ -11,7 +11,7 @@ use crate::{
             constants::{SIGCONT, SIGHUP},
             signals::kernel::KernelSignal,
         },
-        ProcessGroup, Session,
+        ProcessGroup, ProcessState, Session,
     },
 };
 
@@ -161,7 +161,9 @@ impl JobControl {
             return true;
         };
 
-        foreground.contains_process(current!().pid())
+        foreground.contains_process(
+            ProcessState::with_current_task(|process_state| process_state.pid()).unwrap(),
+        )
     }
 }
 

--- a/kernel/src/process/status.rs
+++ b/kernel/src/process/status.rs
@@ -8,7 +8,7 @@ use super::ExitCode;
 
 /// The status of a process.
 ///
-/// This maintains:
+/// It contains the external conditions of the process. This maintains:
 /// 1. Whether the process is a zombie (i.e., all its threads have exited);
 /// 2. The exit code of the process.
 #[derive(Debug)]

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -77,7 +77,7 @@ pub fn sys_timer_create(
                         Error::with_message(Errno::EINVAL, "target thread does not exist")
                     })?;
                     let posix_thread = thread.as_posix_thread().unwrap();
-                    if posix_thread.process().pid() != current_process.pid() {
+                    if posix_thread.process_state().unwrap().pid() != current_process.pid() {
                         return_errno_with_message!(
                             Errno::EINVAL,
                             "target thread should belong to current process"


### PR DESCRIPTION
The current pointer relationship between `Process` and `Task` is as follows: `Process` owns an `Arc<Task>`, while `Task` holds a `Weak<Process>` through `PosixThread`. This makes sense but introduces some issues:

1. For example, two different tasks within the same process may need to access the process for different reasons: one to get the process's pid and another to get its resource limits. Both operations require calling `upgrade()` on `Weak<Process>`, which increases the reference count of `Process`, leading to contention.
2. More critically, I plan to introduce a dynamically allocated per-CPU counter in Asterinas to track the Resident Set Size (RSS) for each process. It is a basic ability of process resource usage monitoring, and is required by techniques such as OOM. If the current design remains unchanged, every page fault would require incrementing the cpu-local RSS counter. Since this involves upgrading `Weak<Process>` to locate the current process from the current task, it will cause contention, and prevent the per-CPU counter from achieving its intended performance benefits.

A better design might be to introduce a new structure, ProcessState, and move the PID, resource limits, and future per-CPU counters from Process into ProcessState. The pointer relationships would be as follows:

![图片1](https://github.com/user-attachments/assets/922ff783-81a2-446f-b4ca-d470d59a3d32)

With this design, tasks can access certain fields of the process without contention. This PR implements the design, copies pid to `ProcessState`, and moves resource limits to `ProcessState`. To pass Rust's safety checks without increasing the reference count of `ProcessState`, users need to use the marco `with_current_task!` to access the current `ProcessState` while holding `Task::current()` not dropped. This may seem a bit complex, but it ensures contention-free access to `ProcessState` across tasks, which is particularly important for per-CPU counters required by the processes.



