### PR TITLE
Temporary fix of benchmark workflow

### DIFF
--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -218,7 +218,7 @@ jobs:
           auto-push: true
           alert-threshold: ${{ env.ALERT_THRESHOLD }}
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: false
           chart-title: ${{ env.TITLE }}
           chart-description: ${{ env.DESCRIPTION }}
           summary-json-path: test/benchmark/${{ env.BENCHMARK_SUITE }}/summary.json

--- a/.github/workflows/benchmark_asterinas.yml
+++ b/.github/workflows/benchmark_asterinas.yml
@@ -103,6 +103,8 @@ jobs:
           - memcached/t8_conc32_window20k
           - memcached/t16_conc64_window10k
       fail-fast: false
+      # FIXME: Remove the following line after fixing the parallel execution of network benchmarks.
+      max-parallel: 1
     timeout-minutes: 60
     container: 
       image: asterinas/asterinas:0.14.1-20250322


### PR DESCRIPTION
This PR helps improve the stability and display of benchmarks.

1. Now, the benchmarks are enforced to executed serially, because any virtio net tests relying on the TAP backend should not be run in parallel for performance benchmark. See https://github.com/asterinas/asterinas/issues/1929#issuecomment-2749933804
2. Performance alerts also cause the failure status of benchmark workflow, which is quite strict. Therefore, alert comments are retained, but workflow no longer fails because of it.