### PR TITLE
Clean up TDX SMP code

### DIFF
--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -2,89 +2,75 @@
 
 // The boot routine executed by the application processor.
 
+.global ap_boot_from_real_mode
+.global ap_boot_from_long_mode
+
 .extern boot_gdtr
 .extern boot_page_table_start
 .extern ap_early_entry
 
 .section ".ap_boot", "awx"
 .align 4096
-.code16
 
 IA32_APIC_BASE = 0x1B
 IA32_X2APIC_APICID = 0x802
 MMIO_XAPIC_APICID = 0xFEE00020
 
-start:
-    cli // disable interrupts
-    cld
-
-    xor ax, ax  // clear ax
-    mov ds, ax  // clear ds
-
-    // In the Intel Trust Domain, the APs awakened by the operating system are in long mode.
-    // We can determine this using the value of the CS register.
-    // FIXME: This method will not affect the booting of linux-efi-handover64,
-    // multiboot and multiboot2 in non-TDX environments.
-    // However, it cannot guarantee the impact on other booting methods added in the future.
-    mov ax, cs
-    cmp ax, 0x38
-    jne ap_real_mode_boot
-
-.code64
-ap_long_mode_tdx:
-    // The Local APIC ID information is stored in r8d by Intel TDX Virtual Firmware.
-    mov edi, r8d
-
+.macro setup_64bit_gdt_and_page_table eax
+    // Use the 64-bit GDT.
     lgdt [boot_gdtr]
 
     // Enable PAE and PGE.
-    mov rax, cr4
-    or  rax, 0xa0
-    mov cr4, rax
+    mov \eax, cr4
+    or  \eax, 0xa0
+    mov cr4, \eax
 
     // Set the page table. The application processors use
     // the same page table as the bootstrap processor's
     // boot phase page table.
-    mov rax, 0
-    mov rax, __boot_page_table_pointer
-    mov cr3, rax
-
-    push 0x8
-    mov rax, offset ap_long_mode_in_low_address
-    push rax
-    retfq
-
-ap_long_mode_in_low_address:
-    mov ax, 0
-    mov ds, ax
-    mov ss, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-
-    // Update RIP to use the virtual address.
-    mov rax, offset ap_long_mode
-    jmp rax
-
-ap_long_mode:
-    // The local APIC ID is in the RDI.
-    mov rax, rdi
-    shl rax, 3
-
-    // Setup the stack.
-    mov rbx, [__ap_boot_stack_array_pointer]
-    mov rsp, [rbx + rax]
-    xor rbp, rbp
-
-    // Go to Rust code.
-    mov rax, offset ap_early_entry
-    call rax
-
-.extern halt # bsp_boot.S
-    jmp halt
+    mov eax, __boot_page_table_pointer // 32-bit load
+    mov cr3, \eax
+.endm
 
 .code16
-ap_real_mode_boot:
+ap_boot_from_real_mode:
+    cli // disable interrupts
+    cld
+
+    jmp ap_real_mode
+
+.code64
+ap_boot_from_long_mode:
+    cli // disable interrupts
+    cld
+
+    // The firmware stores the local APIC ID in R8D, see:
+    // <https://github.com/tianocore/edk2/blob/14b730cde8bfd56bba10cf78b24338b6a59b989f/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm#L67-L73>.
+    // FIXME: This is an implementation detail of the specific firmware. We
+    // should NOT rely on it. We should NOT even try to rely on the local APIC
+    // ID, because the APIC IDs on real hardware may NOT be contiguous (i.e.,
+    // there may be holes where the holes do not represent logical processors).
+    // We should compute the CPU ID ourselves using atomic operations.
+    mov edi, r8d
+
+    setup_64bit_gdt_and_page_table rax
+
+    // Some firmware seems to provide per-AP stacks that we can use. However,
+    // the ACPI specification does not promise that the stack is usable. It is
+    // better not to rely on such implementation details.
+    lea rsp, [rip + retf_stack_bottom]
+    retf // 32-bit far return
+.align 8
+retf_stack_bottom:
+.long ap_long_mode
+.long 0x8
+retf_stack_top:
+
+.code16
+ap_real_mode:
+    xor ax, ax  // clear ax
+    mov ds, ax  // clear ds
+
     lgdt [ap_gdtr] // load gdt
 
     mov eax, cr0
@@ -150,9 +136,9 @@ x2apic_mode:
 // This is a pointer to the page table used by the APs.
 // The BSP will fill this pointer before kicking the APs.
 .global __boot_page_table_pointer
-.align 8
+.align 4
 __boot_page_table_pointer:
-    .skip 8
+    .skip 4
 
 ap_protect:
     // Save the local APIC ID in an unused register.
@@ -162,19 +148,7 @@ ap_protect:
 
     // Now we try getting into long mode.
 
-    // Use the 64-bit GDT.
-    lgdt [boot_gdtr]
-
-    // Enable PAE and PGE.
-    mov eax, cr4
-    or  eax, 0xa0
-    mov cr4, eax
-
-    // Set the page table. The application processors use
-    // the same page table as the bootstrap processor's
-    // boot phase page table.
-    mov eax, __boot_page_table_pointer
-    mov cr3, eax
+    setup_64bit_gdt_and_page_table eax
 
     // Enable long mode.
     mov ecx, 0xc0000080 
@@ -187,7 +161,32 @@ ap_protect:
     or eax, 1 << 31
     mov cr0, eax
 
-    ljmp 0x8, offset ap_long_mode_in_low_address
+    ljmp 0x8, offset ap_long_mode
+
+.code64
+ap_long_mode:
+    mov ax, 0
+    mov ds, ax
+    mov ss, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
+    // The local APIC ID is in the RDI.
+    mov rax, rdi
+    shl rax, 3
+
+    // Setup the stack.
+    mov rbx, [__ap_boot_stack_array_pointer]
+    mov rsp, [rbx + rax]
+    xor rbp, rbp
+
+    // Go to Rust code.
+    mov rax, offset ap_early_entry
+    call rax
+
+.extern halt # bsp_boot.S
+    jmp halt
 
 .data
 // This is a pointer to be filled by the BSP when boot stacks

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -116,22 +116,10 @@ fn parse_memory_regions(boot_params: &BootParams) -> MemoryRegionArray {
     // Add regions from E820.
     let num_entries = boot_params.e820_entries as usize;
     for e820_entry in &boot_params.e820_table[0..num_entries] {
-        if_tdx_enabled!({
-            if (e820_entry.addr..(e820_entry.addr + e820_entry.size)).contains(&0x800000) {
-                regions
-                    .push(MemoryRegion::new(
-                        e820_entry.addr as usize,
-                        e820_entry.size as usize,
-                        MemoryRegionType::Reclaimable,
-                    ))
-                    .unwrap();
-                continue;
-            }
-        });
         regions
             .push(MemoryRegion::new(
-                e820_entry.addr as usize,
-                e820_entry.size as usize,
+                e820_entry.addr.try_into().unwrap(),
+                e820_entry.size.try_into().unwrap(),
                 e820_entry.typ.into(),
             ))
             .unwrap();
@@ -167,6 +155,27 @@ fn parse_memory_regions(boot_params: &BootParams) -> MemoryRegionArray {
             MemoryRegionType::Reclaimable,
         ))
         .unwrap();
+
+    // FIXME: Early versions of TDVF did not correctly report the location of AP's page tables as
+    // EfiACPIMemoryNVS. We need to manually reserve this memory region to prevent them from being
+    // corrupted. TDVF has now been upstreamed to OVMF, and this issue has been fixed in OVMF
+    // stable-202411 or later. See the commit for details:
+    // <https://github.com/tianocore/edk2/commit/383f729ac096b8deb279933fce86e83a5f7f5ec7>.
+    if_tdx_enabled!({
+        // The definition of these constants can be found in:
+        // <https://github.com/tianocore/edk2/blob/a7ab45ace25c4b987994158687d04de07ed20a96/OvmfPkg/IntelTdx/IntelTdxX64.fdf#L64-L71>
+        // <https://github.com/tianocore/edk2/blob/a7ab45ace25c4b987994158687d04de07ed20a96/OvmfPkg/Include/Fdf/OvmfPkgDefines.fdf.inc#L106>
+        regions
+            .push(MemoryRegion::new(
+                // PcdOvmfSecPageTablesBase = $(MEMFD_BASE_ADDRESS) + 0x000000 = 0x800000
+                0x800000,
+                // PcdOvmfSecPageTablesSize = 0x006000
+                0x006000,
+                // EfiACPIMemoryNVS
+                MemoryRegionType::NonVolatileSleep,
+            ))
+            .unwrap();
+    });
 
     regions.into_non_overlapping()
 }


### PR DESCRIPTION
Cleaning up the code added in https://github.com/asterinas/asterinas/pull/1651.

---

First, 0x80000 (see #1628 and #1942) is truly magical and deserves a detailed explanation.

```rust
    // FIXME: Early versions of TDVF did not correctly report the location of AP's page tables as
    // EfiACPIMemoryNVS. We need to manually reserve this memory region to prevent them from being
    // corrupted. TDVF has now been upstreamed to OVMF, and this issue has been fixed in OVMF
    // stable-202411 or later. See the commit for details:
    // <https://github.com/tianocore/edk2/commit/383f729ac096b8deb279933fce86e83a5f7f5ec7>.
    if_tdx_enabled!({
        // The definition of these constants can be found in:
        // <https://github.com/tianocore/edk2/blob/a7ab45ace25c4b987994158687d04de07ed20a96/OvmfPkg/IntelTdx/IntelTdxX64.fdf#L64-L71>
        // <https://github.com/tianocore/edk2/blob/a7ab45ace25c4b987994158687d04de07ed20a96/OvmfPkg/Include/Fdf/OvmfPkgDefines.fdf.inc#L106>
        regions
            .push(MemoryRegion::new(
                // PcdOvmfSecPageTablesBase = $(MEMFD_BASE_ADDRESS) + 0x000000 = 0x800000
                0x800000,
                // PcdOvmfSecPageTablesSize = 0x006000
                0x006000,
                // EfiACPIMemoryNVS
                MemoryRegionType::NonVolatileSleep,
            ))
            .unwrap();
    });
```
I think comments like the one above explain both:
 1. why we need to do this (we confirmed it's a bug in the firmware) and
 2. where the magic numbers come from (we found how they're defined as the constants in the firmware code).

Also, the changes are minimal, as it only reserves a small amount of memory (instead of reserving the entire memory region containing 0x80000).

---

The second commit fixes several problems in `ap_boot.S` (or at least adds proper FIXMEs for them):

https://github.com/asterinas/asterinas/blob/7d3b49c4d616b0e59ed68a239e3844577856c914/ostd/src/arch/x86/boot/ap_boot.S#L24-L31

This is really wired because it makes the CPU run 16-bit code in long mode. Let's avoid this by specifying the entry address using the ACPI wakeup mailbox protocol.

https://github.com/asterinas/asterinas/blob/7d3b49c4d616b0e59ed68a239e3844577856c914/ostd/src/arch/x86/boot/ap_boot.S#L35-L36

I read the ACPI specification and the wakeup mailbox protocol never claims to pass the ACPI ID using the R8D register. I'm afraid this is mostly an implementation detail of a specific firmware. I have added a FIXME for this, as we should soon refactor the related code to avoid treating the local APIC ID as the CPU ID.

https://github.com/asterinas/asterinas/blob/7d3b49c4d616b0e59ed68a239e3844577856c914/ostd/src/arch/x86/boot/ap_boot.S#L65-L69

This is just a false claim as the `ap_long_mode` method is still in the low address.

---

The changes have been tested in our TDX machine and the following command succeeds:
```
make run AUTO_TEST=test INTEL_TDX=1 RELEASE=1 SMP=4 NETDEV=tap
```