### PR TITLE
Add memory size configuration to benchmarks

### DIFF
--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -244,6 +244,8 @@ chart:                        # Chart configuration
 
 runtime_config:              # Runtime configuration
   aster_scheme: "null"       # Corresponds to Makefile parameters, IOMMU is enabled by default (SCHEME=iommu)
+  smp: 1                     # Number of CPUs to allocate to the VM
+  mem: 8G                  # Memory size in GB to allocate to the VM
 ```
 
 By adhering to this format, we ensure clarity and consistency in benchmarking workflows and reporting systems.

--- a/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/bench_result.yaml
+++ b/test/benchmark/lmbench/ramfs_create_delete_files_0k_ops/bench_result.yaml
@@ -9,3 +9,5 @@ chart:
 result_extraction:
   result_index: 2
   search_pattern: ^0k
+runtime_config:
+  mem: 32G


### PR DESCRIPTION
Fixes #1947 

This PR add a new configurable field `mem` to `bench_result.yaml` which align with the `MEM` field on the `Makefile`. And it set the memory size of `lmbench/ramfs_create_delete_files_0k_ops` to 32 GB.

To be honest, I think this is a temporary solution. We have too many default values on our Makefile. Benchmark also need a place to store the default values, e.g., smp, mem, scheme, arch. And the unified entry `test/benchmark/bench_linux_and_aster.sh` may not be a good place. Furthermore, using `make run` to run Asterinas while using QEMU to start Linux seems weird. We would better take the same QEMU arguments but the different kernel to execute benchmarks over two different VMs.