### PR TITLE
Fix that `Cursor::take_next` reports the wrong address

### DIFF
--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -630,10 +630,7 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> CursorM
 
             // Unmap the current page and return it.
             let old = cur_entry.replace(Child::None);
-
-            self.0.move_forward();
-
-            return match old {
+            let item = match old {
                 Child::Frame(page, prop) => PageTableItem::Mapped {
                     va: self.0.va,
                     page,
@@ -650,6 +647,10 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> CursorM
                 }
                 Child::PageTable(_) | Child::None => unreachable!(),
             };
+
+            self.0.move_forward();
+
+            return item;
         }
 
         // If the loop exits, we did not find any mapped pages in the range.


### PR DESCRIPTION
My sincere apologies.

`Cursor::take_next` reports the wrong addresses since it firstly `move_forward` then reports the VA to the unmapper. The unmapper will flush TLB entries based on this VA. So TLB flushes are inaccurate.

Unit tests didn't catch it since they do not check the reported VAs, what a mistake.

PT unit tests should be further separated to make the tested properties clear. We should do it after #1781 . This PR doesn't include much changes so that #1781 could be better ported.

#1938 is not resolved by this PR. But it's one of the problems.