### PR TITLE
Enforce the suitable width of badge

### DIFF
--- a/.github/workflows/benchmark_x86.yml
+++ b/.github/workflows/benchmark_x86.yml
@@ -1,4 +1,4 @@
-name: Benchmark x86-64
+name: "Benchmark x86-64  "
 on:
   # In case of manual trigger, use workflow_dispatch
   workflow_dispatch:

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -1,4 +1,4 @@
-name: Test x86-64
+name: "Test x86-64  "
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes updating the names of the workflows to include additional spaces for better display of badges, 
 see [this](https://github.com/grief8/asterinas/actions/workflows/test_x86.yml/badge.svg?event=push).

Note that the workflow name is updated to "Test x86-64  " because the spaces at the end of `Test x86-64  ` will be trimmed while rendering.