### PR TITLE
Ignore invalid APIC entries

### DIFF
--- a/ostd/src/arch/riscv/boot/smp.rs
+++ b/ostd/src/arch/riscv/boot/smp.rs
@@ -2,7 +2,7 @@
 
 //! Multiprocessor Boot Support
 
-pub(crate) fn get_num_processors() -> Option<u32> {
+pub(crate) fn count_processors() -> Option<u32> {
     Some(1)
 }
 

--- a/ostd/src/cpu/mod.rs
+++ b/ostd/src/cpu/mod.rs
@@ -16,7 +16,7 @@ cfg_if::cfg_if! {
 pub use set::{AtomicCpuSet, CpuSet};
 use spin::Once;
 
-use crate::{arch::boot::smp::get_num_processors, cpu_local_cell, task::atomic_mode::InAtomicMode};
+use crate::{arch::boot::smp::count_processors, cpu_local_cell, task::atomic_mode::InAtomicMode};
 
 /// The ID of a CPU in the system.
 ///
@@ -59,7 +59,7 @@ static NUM_CPUS: Once<u32> = Once::new();
 /// The caller must ensure that this function is called only once on the BSP
 /// at the correct time when the number of CPUs is available from the platform.
 pub(crate) unsafe fn init_num_cpus() {
-    let num_processors = get_num_processors().unwrap_or(1);
+    let num_processors = count_processors().unwrap_or(1);
     NUM_CPUS.call_once(|| num_processors);
 }
 


### PR DESCRIPTION
This PR fixes the first SMP problem in #1963.
> Find a correct way to get the number of processors: The current implementation of [get_num_processors](https://github.com/asterinas/asterinas/blob/7a8afd8c484b5bc8b1edb9206eb73b6d4ce709c8/ostd/src/arch/x86/boot/smp.rs#L45) is wrong, as it reports that my laptop has 32 processors, when in fact it has only 16.

We should ignore APIC entries whose flags do not indicate that they are enabled.