### PR TITLE
Ignore unusable regions for `max_paddr`

### DIFF
--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -53,6 +53,7 @@ use log::info;
 
 use crate::{
     arch::mm::PagingConsts,
+    boot::memory_region::MemoryRegionType,
     const_assert,
     mm::{
         frame::allocator::{self, EarlyAllocatedFrameMeta},
@@ -451,7 +452,12 @@ impl_frame_meta_for!(MetaPageMeta);
 pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
     let max_paddr = {
         let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
-        regions.iter().map(|r| r.base() + r.len()).max().unwrap()
+        regions
+            .iter()
+            .filter(|r| r.typ() == MemoryRegionType::Usable)
+            .map(|r| r.base() + r.len())
+            .max()
+            .unwrap()
     };
 
     info!(
@@ -567,8 +573,11 @@ macro_rules! mark_ranges {
 fn mark_unusable_ranges() {
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
 
-    for region in regions.iter() {
-        use crate::boot::memory_region::MemoryRegionType;
+    for region in regions
+        .iter()
+        .rev()
+        .skip_while(|r| r.typ() != MemoryRegionType::Usable)
+    {
         match region.typ() {
             MemoryRegionType::BadMemory => mark_ranges!(region, UnusableMemoryMeta),
             MemoryRegionType::Unknown => mark_ranges!(region, UnusableMemoryMeta),


### PR DESCRIPTION
This PR fixes the memory problem in #1963.
> The size of physical memory is incorrectly [detected](https://github.com/asterinas/asterinas/blob/0078c18068f148618ff0d25624c747edbcbf5964/ostd/src/mm/frame/meta.rs#L447) when there is a framebuffer region at a high address (e.g. 0x40_0000_0000). This can cause an unexpectedly large page metadata region to be allocated, wasting memory.

We should ignore unusable regions of memory when calculating the maximum physical address.