### PR TITLE
Add NVMe driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "aster-logger",
  "aster-mlsdisk",
  "aster-network",
+ "aster-nvme",
  "aster-rights",
  "aster-rights-proc",
  "aster-softirq",
@@ -272,6 +273,22 @@ dependencies = [
  "aster-softirq",
  "bitvec",
  "component",
+ "ostd",
+ "ostd-pod",
+ "spin",
+ "zerocopy",
+]
+
+[[package]]
+name = "aster-nvme"
+version = "0.1.0"
+dependencies = [
+ "aster-block",
+ "aster-pci",
+ "aster-util",
+ "component",
+ "device-id",
+ "io-util",
  "ostd",
  "ostd-pod",
  "spin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "kernel/comps/logger",
     "kernel/comps/mlsdisk",
     "kernel/comps/network",
+    "kernel/comps/nvme",
     "kernel/comps/pci",
     "kernel/comps/softirq",
     "kernel/comps/systree",
@@ -81,6 +82,7 @@ default-members = [
     "kernel/comps/logger",
     "kernel/comps/mlsdisk",
     "kernel/comps/network",
+    "kernel/comps/nvme",
     "kernel/comps/pci",
     "kernel/comps/softirq",
     "kernel/comps/systree",
@@ -151,6 +153,7 @@ aster-input = { path = "kernel/comps/input" }
 aster-logger = { path = "kernel/comps/logger" }
 aster-mlsdisk = { path = "kernel/comps/mlsdisk" }
 aster-network = { path = "kernel/comps/network" }
+aster-nvme = { path = "kernel/comps/nvme" }
 aster-pci = { path = "kernel/comps/pci" }
 aster-softirq = { path = "kernel/comps/softirq" }
 aster-systree = { path = "kernel/comps/systree" }

--- a/Components.toml
+++ b/Components.toml
@@ -10,6 +10,7 @@ kernel = { name = "aster-kernel" }
 logger = { name = "aster-logger" }
 mlsdisk = { name = "aster-mlsdisk" }
 network = { name = "aster-network" }
+nvme = { name = "aster-nvme" }
 pci = { name = "aster-pci" }
 softirq = { name = "aster-softirq" }
 systree = { name = "aster-systree" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -17,6 +17,7 @@ aster-input.workspace = true
 aster-logger.workspace = true
 aster-mlsdisk.workspace = true
 aster-network.workspace = true
+aster-nvme.workspace = true
 aster-rights.workspace = true
 aster-rights-proc.workspace = true
 aster-softirq.workspace = true

--- a/kernel/comps/nvme/Cargo.toml
+++ b/kernel/comps/nvme/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "aster-nvme"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+aster-block.workspace = true
+aster-pci.workspace = true
+aster-util.workspace = true
+component.workspace = true
+device-id.workspace = true
+io-util.workspace = true
+ostd.workspace = true
+ostd-pod.workspace = true
+spin.workspace = true
+zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/kernel/comps/nvme/src/device/block_device.rs
+++ b/kernel/comps/nvme/src/device/block_device.rs
@@ -1,0 +1,933 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe Block Device implementation.
+//!
+//! Implements the [`aster_block::BlockDevice`] trait on top of the NVMe transport.
+//! BIOs are staged in [`BioRequestSingleQueue`] and drained by repeated calls to
+//! [`NvmeBlockDevice::handle_requests`] from the kernel registry's per-device
+//! kthread (see `kernel/src/device/registry/block.rs`). Reads, writes, and flushes
+//! issue synchronously to I/O queue [`IO_QID`] and wait on a per-queue `WaitQueue` driven
+//! by the MSI-X completion interrupt.
+//!
+//! Concurrency invariant: at most one in-flight NVMe command per queue at a time.
+//! Supporting more would require redesigning how commands are submitted and completions waited on.
+
+use alloc::{borrow::ToOwned, format, string::String, sync::Arc, vec::Vec};
+use core::{
+    ffi::CStr,
+    hint::spin_loop,
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
+
+use aster_block::{
+    BlockDeviceMeta, SECTOR_SIZE,
+    bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio, bio_segment_pool_init},
+    request_queue::{BioRequest, BioRequestSingleQueue},
+};
+use aster_util::safe_ptr::SafePtr;
+use device_id::DeviceId;
+use ostd::{
+    debug, error, info,
+    mm::{HasDaddr, HasSize, PAGE_SIZE, dma::DmaStream},
+    sync::{LocalIrqDisabled, SpinLock, SpinLockGuard, WaitQueue},
+    timer::Jiffies,
+};
+
+use super::{
+    namespace::{LBA_SIZE, NvmeNamespace},
+    stat::NvmeStats,
+};
+use crate::{
+    NVME_BLOCK_MAJOR_ID,
+    device::{MAX_NS_NUM, NvmeDeviceError},
+    nvme_cmd,
+    nvme_queue::{
+        NvmeCompletionQueue, NvmeCompletionQueueAccess, NvmeSubmissionQueue,
+        NvmeSubmissionQueueAccess, QUEUE_DEPTH, QUEUE_NUM,
+    },
+    nvme_regs::{NvmeRegs32, NvmeRegs64},
+    nvme_spec::{NvmeCommand, NvmeCompletion},
+    transport::pci::transport::{NvmePciTransport, NvmePciTransportLock},
+};
+
+/// Admin submission and completion queue pair (NVMe queue ID 0).
+const ADMIN_QID: usize = 0;
+/// I/O submission and completion queue pair (NVMe queue ID 1).
+const IO_QID: usize = 1;
+// TODO: Support multiple I/O submission and completion queue pairs.
+ostd::const_assert!(IO_QID + 1 == QUEUE_NUM);
+
+#[derive(Debug)]
+pub struct NvmeBlockDevice {
+    device: NvmeDeviceInner,
+    queue: BioRequestSingleQueue,
+    name: String,
+    id: DeviceId,
+}
+
+impl aster_block::BlockDevice for NvmeBlockDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+        self.queue.enqueue(bio)
+    }
+
+    fn metadata(&self) -> BlockDeviceMeta {
+        const { assert!(LBA_SIZE == SECTOR_SIZE) };
+        let sectors = self.device.namespace.nsze;
+
+        BlockDeviceMeta {
+            max_nr_segments_per_bio: self.queue.max_nr_segments_per_bio(),
+            nr_sectors: sectors as usize,
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn id(&self) -> DeviceId {
+        self.id
+    }
+}
+
+static NR_NVME_DEVICE: AtomicU32 = AtomicU32::new(0);
+
+impl NvmeBlockDevice {
+    pub(crate) fn init(transport: NvmePciTransport) -> Result<(), NvmeDeviceError> {
+        let (device, io_msix_vectors) = NvmeDeviceInner::init(transport)?;
+
+        let index = NR_NVME_DEVICE.fetch_add(1, Ordering::Relaxed);
+        let name = formatted_device_name(index, device.namespace.id);
+        let id = {
+            // Use the allocated major ID for the NVMe device
+            let major_id = NVME_BLOCK_MAJOR_ID.get().unwrap().get();
+            DeviceId::new(major_id, device_id::MinorId::new(index))
+        };
+
+        let block_device = Arc::new(Self {
+            device,
+            queue: BioRequestSingleQueue::new(),
+            name,
+            id,
+        });
+
+        block_device
+            .device
+            .setup_msix_handlers(&block_device, io_msix_vectors);
+
+        aster_block::register(block_device)
+            .map_err(|_| NvmeDeviceError::BlockDeviceRegisterFailed)?;
+
+        bio_segment_pool_init();
+        Ok(())
+    }
+
+    /// Dequeues a `BioRequest` from the software staging queue and
+    /// processes the request.
+    pub fn handle_requests(&self) {
+        let request = self.queue.dequeue();
+        debug!("Handle Request: {:?}", request);
+        match request.type_() {
+            BioType::Read => self.device.read(request),
+            BioType::Write => self.device.write(request),
+            BioType::Flush => self.device.flush(request),
+        }
+    }
+}
+
+fn formatted_device_name(index: u32, nsid: u32) -> String {
+    format!("nvme{}n{}", index, nsid)
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct IdentifyControllerData {
+    _reserved: [u8; 4],
+    serial: [u8; 20],
+    model: [u8; 40],
+    firmware: [u8; 8],
+    _rest: [u8; 56],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct IdentifyNamespaceListData {
+    nsids: [u32; MAX_NS_NUM],
+}
+
+/// Identify Namespace data structure returned for CNS 00h
+/// (NVM Command Set Specification Figure 114).
+///
+/// Only the fields needed to determine the active LBA format are captured here;
+/// the remaining bytes of the 4096-byte response are not used.
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct IdentifyNamespaceData {
+    /// NSZE: total number of logical blocks.
+    nsze: u64,
+    /// NCAP: namespace capacity in logical blocks.
+    _ncap: u64,
+    /// NUSE: namespace utilization in logical blocks.
+    _nuse: u64,
+    /// NSFEAT (byte 24).
+    _nsfeat: u8,
+    /// NLBAF: number of LBA formats supported minus one (byte 25).
+    _nlbaf: u8,
+    /// FLBAS: formatted LBA size; bits[3:0] index into `lbaf[]` (byte 26).
+    flbas: u8,
+    /// RESERVED: bytes 27–127.
+    _reserved: [u8; 101],
+    /// LBAF[0..15]: LBA format support descriptors (bytes 128–191).
+    ///
+    /// Each entry is a u32: bits[23:16] = LBADS (LBA data-size exponent,
+    /// so actual size = 2^LBADS bytes).
+    lbaf: [u32; 16],
+}
+
+struct InitContext {
+    submission_queues: [NvmeSubmissionQueue; QUEUE_NUM],
+    completion_queues: [NvmeCompletionQueue; QUEUE_NUM],
+    transport: NvmePciTransport,
+    dstrd: u16,
+    cc_mps_value: u32,
+    controller_ready_timeout: Duration,
+}
+
+struct IoMsixVectors([u16; QUEUE_NUM - 1]);
+
+struct NvmeDeviceInner {
+    submission_queues: [SpinLock<NvmeSubmissionQueue, LocalIrqDisabled>; QUEUE_NUM],
+    completion_queues: [SpinLock<NvmeCompletionQueue, LocalIrqDisabled>; QUEUE_NUM],
+    completion_wait_queues: [WaitQueue; QUEUE_NUM],
+    transport: NvmePciTransportLock,
+    namespace: NvmeNamespace,
+    dstrd: u16,
+    stats: NvmeStats,
+}
+
+#[derive(Clone, Copy)]
+enum IoOp {
+    Read,
+    Write,
+}
+
+impl core::fmt::Debug for NvmeDeviceInner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NvmeDeviceInner")
+            .field("namespace", &self.namespace)
+            .field("dstrd", &self.dstrd)
+            .field("stats", &self.stats)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NvmeDeviceInner {
+    const CAP_TO_UNIT_MILLIS: u64 = 500;
+    const MPS_BASE_PAGE_SHIFT: u32 = 12;
+
+    fn init(mut transport: NvmePciTransport) -> Result<(Self, IoMsixVectors), NvmeDeviceError> {
+        let cap = transport.regs().read64(NvmeRegs64::Cap);
+
+        let dstrd = ((cap >> NvmeRegs64::CAP_DSTRD_SHIFT) & NvmeRegs64::CAP_DSTRD_MASK) as u16;
+
+        let cap_mpsmin =
+            ((cap >> NvmeRegs64::CAP_MPSMIN_SHIFT) & NvmeRegs64::CAP_MPSMIN_MASK) as u32;
+        let cap_mpsmax =
+            ((cap >> NvmeRegs64::CAP_MPSMAX_SHIFT) & NvmeRegs64::CAP_MPSMAX_MASK) as u32;
+        let cc_mps_value =
+            const { PAGE_SIZE.trailing_zeros() - NvmeDeviceInner::MPS_BASE_PAGE_SHIFT };
+        if cc_mps_value < cap_mpsmin || cc_mps_value > cap_mpsmax {
+            error!(
+                "Host page size not supported by controller: host MPS={}, CAP.MPSMIN={}, CAP.MPSMAX={}",
+                cc_mps_value, cap_mpsmin, cap_mpsmax
+            );
+            return Err(NvmeDeviceError::InvalidControllerConfig);
+        }
+
+        let timeout_units = (cap >> NvmeRegs64::CAP_TO_SHIFT) & NvmeRegs64::CAP_TO_MASK;
+        // CAP.TO is defined in 500 ms units; treat zero as one unit so we still
+        // have a bounded wait on devices that report 0.
+        let timeout_millis = timeout_units.max(1) * Self::CAP_TO_UNIT_MILLIS;
+        let controller_ready_timeout = Duration::from_millis(timeout_millis);
+
+        let mut init_ctx =
+            InitContext::new(transport, dstrd, cc_mps_value, controller_ready_timeout)?;
+
+        // NVMe controller initialization sequence.
+        //
+        // See NVMe Spec 2.0, Section 3.5 (Controller Initialization).
+        //   1. Wait for CSTS.RDY to become '0' (controller ready to be reset)
+        //   2. Configure Admin Queue by setting AQA, ASQ, and ACQ
+        //   3. Set I/O queue entry sizes (CC.IOSQES and CC.IOCQES)
+        //   4. Enable the controller by setting CC.EN to '1'
+        //   5. Wait for CSTS.RDY to become '1' (controller ready to process commands)
+        //   6. Configure MSI-X interrupts for the Admin Queue
+        init_ctx.reset_controller()?;
+        init_ctx.configure_admin_queue();
+        init_ctx.set_entry_size();
+        init_ctx.enable_controller()?;
+        init_ctx.identify_controller()?;
+
+        let nsids = init_ctx.identify_ns_list()?;
+        if nsids.is_empty() {
+            return Err(NvmeDeviceError::NoNamespace);
+        }
+
+        // TODO: Support exposing multiple namespaces per controller instead of only the first one.
+        let namespace = init_ctx.identify_ns(nsids[0])?;
+
+        let io_msix_vectors = init_ctx.create_io_queues()?;
+        let device = NvmeDeviceInner {
+            submission_queues: init_ctx.submission_queues.map(SpinLock::new),
+            completion_queues: init_ctx.completion_queues.map(SpinLock::new),
+            completion_wait_queues: [WaitQueue::new(), WaitQueue::new()],
+            transport: NvmePciTransportLock::new(init_ctx.transport),
+            namespace,
+            dstrd: init_ctx.dstrd,
+            stats: NvmeStats::new(),
+        };
+        Ok((device, io_msix_vectors))
+    }
+
+    /// Registers MSI-X handlers that wake completion wait queues for admin and I/O queues.
+    fn setup_msix_handlers(
+        &self,
+        block_device: &Arc<NvmeBlockDevice>,
+        io_msix_vectors: IoMsixVectors,
+    ) {
+        let mut transport = self.transport.lock();
+        let msix_manager = transport.msix_manager_mut();
+
+        // Admin queue interrupt (vector 0)
+        let (_admin_vec, admin_irq) = msix_manager.admin_irq();
+        let device_weak = Arc::downgrade(block_device);
+        admin_irq.on_active(move |_| {
+            if let Some(block_device) = device_weak.upgrade() {
+                block_device.device.completion_wait_queues[0].wake_all();
+            }
+        });
+
+        // I/O queues
+        for io_qid in 1..QUEUE_NUM {
+            let io_irq = msix_manager
+                .irq_for_vector_mut(io_msix_vectors.0[io_qid - 1])
+                .unwrap();
+            let device_weak = Arc::downgrade(block_device);
+            io_irq.on_active(move |_| {
+                if let Some(block_device) = device_weak.upgrade() {
+                    block_device.device.completion_wait_queues[io_qid].wake_all();
+                }
+            });
+        }
+    }
+}
+
+impl InitContext {
+    /// Controller Configuration Enable bit.
+    const CC_ENABLE: u32 = 0x1;
+    /// Controller Configuration I/O Submission Queue Entry Size shift.
+    const IOSQES_SHIFT: u32 = 16;
+    /// Controller Configuration I/O Submission Queue Entry Size value.
+    const IOSQES_VALUE: u32 = 6;
+    /// Controller Configuration I/O Completion Queue Entry Size shift.
+    const IOCQES_SHIFT: u32 = 20;
+    /// Controller Configuration I/O Completion Queue Entry Size value.
+    const IOCQES_VALUE: u32 = 4;
+    /// Controller Configuration memory page size shift.
+    const MPS_SHIFT: u32 = 7;
+    /// Controller Configuration command set selection shift.
+    const CSS_SHIFT: u32 = 4;
+    /// Controller Configuration arbitration mechanism shift.
+    const AMS_SHIFT: u32 = 11;
+    /// Controller Configuration memory page size mask.
+    const MPS_MASK: u32 = 0b1111 << Self::MPS_SHIFT;
+    /// Controller Configuration command set selection mask.
+    const CSS_MASK: u32 = 0b111 << Self::CSS_SHIFT;
+    /// Controller Configuration arbitration mechanism mask.
+    const AMS_MASK: u32 = 0b111 << Self::AMS_SHIFT;
+    /// Controller Configuration IOSQES field mask.
+    const IOSQES_MASK: u32 = 0b1111 << Self::IOSQES_SHIFT;
+    /// Controller Configuration IOCQES field mask.
+    const IOCQES_MASK: u32 = 0b1111 << Self::IOCQES_SHIFT;
+    /// Controller Status Ready bit.
+    const CSTS_RDY: u32 = 0x1;
+    /// Controller Fatal Status bit.
+    const CSTS_CFS: u32 = 0x2;
+
+    fn new(
+        transport: NvmePciTransport,
+        dstrd: u16,
+        cc_mps_value: u32,
+        controller_ready_timeout: Duration,
+    ) -> Result<Self, NvmeDeviceError> {
+        let sq0 = NvmeSubmissionQueue::new().ok_or(NvmeDeviceError::QueueAllocationFailed)?;
+        let sq1 = NvmeSubmissionQueue::new().ok_or(NvmeDeviceError::QueueAllocationFailed)?;
+        let cq0 = NvmeCompletionQueue::new().ok_or(NvmeDeviceError::QueueAllocationFailed)?;
+        let cq1 = NvmeCompletionQueue::new().ok_or(NvmeDeviceError::QueueAllocationFailed)?;
+        Ok(Self {
+            submission_queues: [sq0, sq1],
+            completion_queues: [cq0, cq1],
+            transport,
+            dstrd,
+            cc_mps_value,
+            controller_ready_timeout,
+        })
+    }
+
+    fn sq_mut(&mut self, qid: usize) -> NvmeSubmissionQueueAccess<'_, &mut NvmeSubmissionQueue> {
+        NvmeSubmissionQueueAccess::new(
+            qid as u16,
+            self.dstrd,
+            &mut self.submission_queues[qid],
+            self.transport.dbregs(),
+        )
+    }
+
+    fn cq_mut(&mut self, qid: usize) -> NvmeCompletionQueueAccess<'_, &mut NvmeCompletionQueue> {
+        NvmeCompletionQueueAccess::new(
+            qid as u16,
+            self.dstrd,
+            &mut self.completion_queues[qid],
+            self.transport.dbregs(),
+        )
+    }
+
+    fn wait_controller_ready(&mut self, expected_ready: bool) -> Result<(), NvmeDeviceError> {
+        let start = Jiffies::elapsed().as_duration();
+        let deadline = start
+            .checked_add(self.controller_ready_timeout)
+            .unwrap_or(Duration::MAX);
+
+        loop {
+            let csts = self.transport.regs().read32(NvmeRegs32::Csts);
+            if (csts & Self::CSTS_CFS) != 0 {
+                error!(
+                    "Controller reports fatal status during reset/enable: CSTS={:#x}",
+                    csts
+                );
+                return Err(NvmeDeviceError::ControllerEnableTimeout);
+            }
+            let ready = (csts & Self::CSTS_RDY) != 0;
+            if ready == expected_ready {
+                return Ok(());
+            }
+            if Jiffies::elapsed().as_duration() >= deadline {
+                error!(
+                    "Controller ready transition timed out: expected RDY={}, CSTS={:#x}",
+                    expected_ready as u8, csts
+                );
+                return Err(NvmeDeviceError::ControllerEnableTimeout);
+            }
+            spin_loop();
+        }
+    }
+
+    fn reset_controller(&mut self) -> Result<(), NvmeDeviceError> {
+        let mut cc = self.transport.regs().read32(NvmeRegs32::Cc);
+        if (cc & Self::CC_ENABLE) != 0 {
+            self.wait_controller_ready(true)?;
+            cc &= !Self::CC_ENABLE;
+            self.transport.regs().write32(NvmeRegs32::Cc, cc);
+        }
+        self.wait_controller_ready(false)
+    }
+
+    fn configure_admin_queue(&mut self) {
+        let acq = &self.completion_queues[0];
+        let asq = &self.submission_queues[0];
+
+        self.transport.regs().write32(
+            NvmeRegs32::Aqa,
+            (((QUEUE_DEPTH - 1) as u32) << 16) | ((QUEUE_DEPTH - 1) as u32),
+        );
+        self.transport
+            .regs()
+            .write64(NvmeRegs64::Asq, asq.sq_daddr() as u64);
+        self.transport
+            .regs()
+            .write64(NvmeRegs64::Acq, acq.cq_daddr() as u64);
+    }
+
+    fn set_entry_size(&mut self) {
+        let mut cc = self.transport.regs().read32(NvmeRegs32::Cc);
+        cc &= !(Self::MPS_MASK
+            | Self::CSS_MASK
+            | Self::AMS_MASK
+            | Self::IOSQES_MASK
+            | Self::IOCQES_MASK);
+        cc |= self.cc_mps_value << Self::MPS_SHIFT;
+        cc |= Self::IOSQES_VALUE << Self::IOSQES_SHIFT;
+        cc |= Self::IOCQES_VALUE << Self::IOCQES_SHIFT;
+        self.transport.regs().write32(NvmeRegs32::Cc, cc);
+    }
+
+    fn enable_controller(&mut self) -> Result<(), NvmeDeviceError> {
+        let mut cc = self.transport.regs().read32(NvmeRegs32::Cc);
+        cc |= Self::CC_ENABLE;
+        self.transport.regs().write32(NvmeRegs32::Cc, cc);
+        self.wait_controller_ready(true)
+    }
+
+    fn submit_and_wait_polling(
+        &mut self,
+        qid: usize,
+        entry: NvmeCommand,
+    ) -> Result<(), NvmeDeviceError> {
+        let expected_cid = self
+            .sq_mut(qid)
+            .submit(entry)
+            .ok_or(NvmeDeviceError::SubmissionQueueFull)?;
+
+        loop {
+            let Some(cqe) = self.cq_mut(qid).complete() else {
+                spin_loop();
+                continue;
+            };
+
+            self.submission_queues[qid].update_sq_head(&cqe);
+
+            if cqe.cid() != expected_cid {
+                debug!(
+                    "Ignore unexpected completion in polling path: expected CID {}, got {} on QID {}",
+                    expected_cid,
+                    cqe.cid(),
+                    qid
+                );
+                continue;
+            }
+
+            if cqe.has_error() {
+                return Err(NvmeDeviceError::CommandFailed);
+            }
+
+            return Ok(());
+        }
+    }
+
+    fn identify_controller(&mut self) -> Result<(), NvmeDeviceError> {
+        let stream =
+            DmaStream::alloc(1, false).map_err(|_| NvmeDeviceError::DmaAllocationFailed)?;
+        let data: SafePtr<IdentifyControllerData, DmaStream> = SafePtr::new(stream, 0);
+
+        let entry = nvme_cmd::identify_controller(data.daddr());
+        self.submit_and_wait_polling(ADMIN_QID, entry)?;
+
+        let result = data.read().unwrap();
+
+        let serial = bytes_to_cstr_string(&result.serial);
+        let model = bytes_to_cstr_string(&result.model);
+        let firmware = bytes_to_cstr_string(&result.firmware);
+
+        info!(
+            "Controller identified - Serial: {}, Model: {}, Firmware: {}",
+            serial, model, firmware
+        );
+        Ok(())
+    }
+
+    fn identify_ns_list(&mut self) -> Result<Vec<u32>, NvmeDeviceError> {
+        let stream =
+            DmaStream::alloc(1, false).map_err(|_| NvmeDeviceError::DmaAllocationFailed)?;
+        let data: SafePtr<IdentifyNamespaceListData, DmaStream> = SafePtr::new(stream, 0);
+
+        let entry = nvme_cmd::identify_namespace_list(data.daddr(), 0);
+        self.submit_and_wait_polling(ADMIN_QID, entry)?;
+
+        let result = data.read().unwrap();
+
+        let nsids = result
+            .nsids
+            .iter()
+            .copied()
+            .take_while(|&nsid| nsid != 0)
+            .collect();
+        Ok(nsids)
+    }
+
+    fn identify_ns(&mut self, nsid: u32) -> Result<NvmeNamespace, NvmeDeviceError> {
+        let stream =
+            DmaStream::alloc(1, false).map_err(|_| NvmeDeviceError::DmaAllocationFailed)?;
+        let data: SafePtr<IdentifyNamespaceData, DmaStream> = SafePtr::new(stream, 0);
+
+        let entry = nvme_cmd::identify_namespace(data.daddr(), nsid);
+        self.submit_and_wait_polling(ADMIN_QID, entry)?;
+
+        let result = data.read().unwrap();
+
+        // Parse the active LBA format to obtain the logical block size.
+        // FLBAS bits[3:0] select the current format entry in `lbaf[]`.
+        // This driver currently supports only the lower 16 LBAF entries.
+        // LBADS (bits[23:16] of that entry) is the base-2 exponent of the block size.
+        if result.flbas & 0x60 != 0 {
+            error!(
+                "Namespace {}: FLBAS uses an extended active format index (unsupported)",
+                nsid
+            );
+            return Err(NvmeDeviceError::InvalidControllerConfig);
+        }
+        let fmt_idx = (result.flbas & 0x0f) as usize;
+        let lbads = (result.lbaf[fmt_idx] >> 16) & 0xff;
+        let reported_lba_size = 1u64 << lbads;
+        if reported_lba_size != LBA_SIZE as u64 {
+            error!(
+                "Namespace {}: LBA size is {} bytes (LBADS={}), but driver requires {}",
+                nsid, reported_lba_size, lbads, LBA_SIZE
+            );
+            return Err(NvmeDeviceError::InvalidControllerConfig);
+        }
+
+        info!(
+            "Namespace {}: NSZE={}, LBA size={} bytes",
+            nsid, result.nsze, LBA_SIZE
+        );
+        Ok(NvmeNamespace {
+            id: nsid,
+            nsze: result.nsze,
+        })
+    }
+
+    fn create_io_queues(&mut self) -> Result<IoMsixVectors, NvmeDeviceError> {
+        // Pre-allocate MSI-X vectors for I/O queues
+        let io_msix_vectors = {
+            let mut io_msix_vectors = [0; QUEUE_NUM - 1];
+            let msix_manager = self.transport.msix_manager_mut();
+            for io_qid in 1..QUEUE_NUM {
+                let (vector, _io_irq) = msix_manager
+                    .alloc_io_queue_irq()
+                    .ok_or(NvmeDeviceError::MsixAllocationFailed)?;
+                io_msix_vectors[io_qid - 1] = vector;
+            }
+            io_msix_vectors
+        };
+
+        for io_qid in 1..QUEUE_NUM {
+            let cptr = self.completion_queues[io_qid].cq_daddr();
+
+            let msix_vector = io_msix_vectors[io_qid - 1];
+
+            let entry = nvme_cmd::create_io_completion_queue(
+                io_qid as u16,
+                cptr,
+                (QUEUE_DEPTH - 1) as u16,
+                Some(msix_vector),
+            );
+            self.submit_and_wait_polling(ADMIN_QID, entry)?;
+
+            let sptr = self.submission_queues[io_qid].sq_daddr();
+
+            let entry = nvme_cmd::create_io_submission_queue(
+                io_qid as u16,
+                sptr,
+                (QUEUE_DEPTH - 1) as u16,
+                io_qid as u16,
+            );
+            self.submit_and_wait_polling(ADMIN_QID, entry)?;
+        }
+
+        Ok(IoMsixVectors(io_msix_vectors))
+    }
+}
+
+impl NvmeDeviceInner {
+    fn lock_sq(
+        &self,
+        qid: usize,
+    ) -> NvmeSubmissionQueueAccess<'_, SpinLockGuard<'_, NvmeSubmissionQueue, LocalIrqDisabled>>
+    {
+        NvmeSubmissionQueueAccess::new(
+            qid as u16,
+            self.dstrd,
+            self.submission_queues[qid].lock(),
+            self.transport.dbregs(),
+        )
+    }
+
+    fn lock_cq(
+        &self,
+        qid: usize,
+    ) -> NvmeCompletionQueueAccess<'_, SpinLockGuard<'_, NvmeCompletionQueue, LocalIrqDisabled>>
+    {
+        NvmeCompletionQueueAccess::new(
+            qid as u16,
+            self.dstrd,
+            self.completion_queues[qid].lock(),
+            self.transport.dbregs(),
+        )
+    }
+
+    /// Submits a command to the submission queue and waits for its completion.
+    ///
+    /// This helper assumes that only a single thread calls `submit_and_wait`
+    /// for a given `qid` at a time. Calling it concurrently on the same queue
+    /// is not supported now.
+    ///
+    /// Returns `Ok(())` if the command completed successfully,
+    /// `Err(NvmeDeviceError::SubmissionQueueFull)` if the SQ has no free slots, or
+    /// `Err(NvmeDeviceError::CommandFailed)` if the device reported a non-zero status.
+    fn submit_and_wait(&self, qid: usize, entry: NvmeCommand) -> Result<(), NvmeDeviceError> {
+        let wait_queue = &self.completion_wait_queues[qid];
+
+        let cid = self
+            .lock_sq(qid)
+            .submit(entry)
+            .ok_or(NvmeDeviceError::SubmissionQueueFull)?;
+        if qid == IO_QID {
+            self.stats.increment_submitted();
+        }
+
+        wait_queue.wait_until(|| {
+            let completion = self.lock_cq(qid).complete()?;
+
+            self.submission_queues[qid]
+                .lock()
+                .update_sq_head(&completion);
+
+            self.process_completion(qid, completion, cid)
+        })
+    }
+
+    /// Interprets a completion queue entry for the command identified by `expected_cid`.
+    ///
+    /// Returns `None` if the completion does not match `expected_cid` (not our command),
+    /// `Some(Ok(()))` if it matches and the device reports success, or
+    /// `Some(Err(NvmeDeviceError::CommandFailed))` if it matches but the device reports an error.
+    fn process_completion(
+        &self,
+        qid: usize,
+        completion: NvmeCompletion,
+        expected_cid: u16,
+    ) -> Option<Result<(), NvmeDeviceError>> {
+        if qid == IO_QID {
+            self.stats.increment_completed();
+        }
+
+        let is_target = completion.cid() == expected_cid;
+        if !is_target {
+            debug!(
+                "Ignore unexpected completion: expected CID {}, got {} on QID {}",
+                expected_cid,
+                completion.cid(),
+                qid
+            );
+            return None;
+        }
+
+        if completion.has_error() {
+            Some(Err(NvmeDeviceError::CommandFailed))
+        } else {
+            Some(Ok(()))
+        }
+    }
+
+    /// Performs read or write I/O for a `BioRequest` on I/O queue [`IO_QID`].
+    ///
+    /// Splits work into chunks; each chunk is built from `io_op` and submitted synchronously.
+    fn io_rw_request(&self, request: BioRequest, io_op: IoOp) {
+        const { assert!(LBA_SIZE == SECTOR_SIZE) };
+
+        let nsid = self.namespace.id;
+        let mut lba = request.sid_range().start.to_raw();
+
+        for bio in request.into_bios() {
+            let mut status = BioStatus::Complete;
+            for segment in bio.segments() {
+                let dma_slice = segment.inner_dma_slice();
+                // `BioSegment` should guarantee that the segment's address and the size is
+                // aligned to sectors.
+                debug_assert!(dma_slice.daddr().is_multiple_of(SECTOR_SIZE));
+                debug_assert!(dma_slice.size().is_multiple_of(SECTOR_SIZE));
+
+                let seg_sectors = (dma_slice.size() / SECTOR_SIZE) as u64;
+                let mut remaining = seg_sectors;
+                let mut ptr0 = dma_slice.daddr() as u64;
+
+                while remaining > 0 {
+                    // TODO: Support PRP lists / `ptr1`. For now we only use `ptr0` and keep
+                    // `ptr1` at 0, so each command is limited to a page.
+                    let sectors_to_io = {
+                        let bytes_in_page = (PAGE_SIZE as u64) - (ptr0 & (PAGE_SIZE as u64 - 1));
+                        let sectors_in_page = bytes_in_page / (SECTOR_SIZE as u64);
+                        sectors_in_page.min(remaining)
+                    };
+
+                    let entry = match io_op {
+                        IoOp::Read => {
+                            nvme_cmd::io_read(nsid, lba, (sectors_to_io - 1) as u16, ptr0, 0u64)
+                        }
+                        IoOp::Write => {
+                            nvme_cmd::io_write(nsid, lba, (sectors_to_io - 1) as u16, ptr0, 0u64)
+                        }
+                    };
+                    // TODO: This path submits and waits synchronously, which may block.
+                    if self.submit_and_wait(IO_QID, entry).is_err() {
+                        status = BioStatus::IoError;
+                    }
+
+                    lba += sectors_to_io;
+                    remaining -= sectors_to_io;
+                    ptr0 += (SECTOR_SIZE as u64) * sectors_to_io;
+                }
+            }
+            bio.complete(status);
+        }
+    }
+
+    fn read(&self, request: BioRequest) {
+        self.io_rw_request(request, IoOp::Read);
+    }
+
+    fn write(&self, request: BioRequest) {
+        self.io_rw_request(request, IoOp::Write);
+    }
+
+    fn flush(&self, request: BioRequest) {
+        let nsid = self.namespace.id;
+
+        let entry = nvme_cmd::io_flush(nsid);
+        // TODO: This path submits and waits synchronously, which may block.
+        let status = self
+            .submit_and_wait(IO_QID, entry)
+            .map_or(BioStatus::IoError, |_| BioStatus::Complete);
+        for bio in request.into_bios() {
+            bio.complete(status);
+        }
+    }
+}
+
+fn bytes_to_cstr_string(bytes: &[u8]) -> String {
+    if let Ok(cstr) = CStr::from_bytes_until_nul(bytes) {
+        let s = cstr.to_string_lossy();
+        s.trim_end().to_owned()
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use alloc::{sync::Arc, vec};
+
+    use aster_block::{
+        BLOCK_SIZE,
+        bio::{Bio, BioDirection, BioSegment},
+        id::{Bid, Sid},
+    };
+    use io_util::batch::IoBatch;
+    use ostd::{
+        info,
+        mm::{FrameAllocOptions, VmIo, VmReader, io::util::HasVmReaderWriter},
+        prelude::ktest,
+    };
+
+    use super::{BioType, IoOp, NvmeBlockDevice};
+    use crate::nvme_init;
+
+    const TEST_CHAR: u8 = b'B';
+    const TEST_BUF_LENGTH: usize = 8192;
+
+    #[ktest]
+    fn initialize() {
+        ensure_initialized();
+    }
+
+    fn ensure_initialized() {
+        if aster_block::collect_all().is_empty() {
+            component::init_all(
+                component::InitStage::Bootstrap,
+                component::parse_metadata!(),
+            )
+            .unwrap();
+
+            nvme_init().expect("`nvme_init` returned an error");
+        }
+    }
+
+    #[ktest]
+    fn write_then_read() {
+        ensure_initialized();
+
+        let device = match aster_block::collect_all()
+            .into_iter()
+            .find(|d| d.name() == "nvme0n1")
+        {
+            Some(device) => device,
+            None => {
+                info!("Skip nvme ktest: NVMe device not found");
+                return;
+            }
+        };
+        let device_arc = Arc::clone(&device);
+
+        let nvme_block_device = device_arc
+            .downcast_ref::<NvmeBlockDevice>()
+            .expect("Failed to downcast device");
+
+        let mut write_batch = IoBatch::with_capacity(1);
+        create_and_submit_bio_request(
+            nvme_block_device,
+            &mut write_batch,
+            IoOp::Write,
+            TEST_BUF_LENGTH,
+            TEST_CHAR,
+        );
+        nvme_block_device.handle_requests();
+        write_batch.wait_all().unwrap();
+
+        let mut read_batch = IoBatch::with_capacity(1);
+        let read_bio_segment = create_and_submit_bio_request(
+            nvme_block_device,
+            &mut read_batch,
+            IoOp::Read,
+            TEST_BUF_LENGTH,
+            TEST_CHAR,
+        );
+        nvme_block_device.handle_requests();
+        read_batch.wait_all().unwrap();
+
+        let mut read_buf = [0u8; TEST_BUF_LENGTH];
+        read_bio_segment
+            .inner_dma_slice()
+            .read_bytes(0, &mut read_buf)
+            .unwrap();
+        assert!(read_buf.iter().all(|&x| x == TEST_CHAR));
+    }
+
+    fn create_and_submit_bio_request(
+        device: &NvmeBlockDevice,
+        io_batch: &mut IoBatch,
+        req_type: IoOp,
+        buf_len: usize,
+        val: u8,
+    ) -> BioSegment {
+        let buf_nblocks = buf_len / BLOCK_SIZE;
+        let segment = FrameAllocOptions::new()
+            .zeroed(false)
+            .alloc_segment(buf_nblocks)
+            .unwrap();
+
+        if matches!(req_type, IoOp::Write) {
+            let mut writer = segment.writer();
+            let fill_buf = [val; BLOCK_SIZE];
+            for _ in 0..buf_nblocks {
+                let mut reader = VmReader::from(fill_buf.as_slice());
+                writer.write(&mut reader);
+            }
+        }
+
+        let (bio_type, direction) = match req_type {
+            IoOp::Write => (BioType::Write, BioDirection::ToDevice),
+            IoOp::Read => (BioType::Read, BioDirection::FromDevice),
+        };
+        let bio_segment = BioSegment::new_from_segment(segment.into(), direction);
+
+        let bio = Bio::new(
+            bio_type,
+            Sid::from(Bid::from_offset(0)),
+            vec![bio_segment.clone()],
+            None,
+        );
+        bio.submit(device, io_batch).unwrap();
+
+        bio_segment
+    }
+}

--- a/kernel/comps/nvme/src/device/mod.rs
+++ b/kernel/comps/nvme/src/device/mod.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod block_device;
+mod namespace;
+mod stat;
+
+pub(crate) const MAX_NS_NUM: usize = 1024;
+
+#[derive(Debug)]
+pub(crate) enum NvmeDeviceError {
+    BlockDeviceRegisterFailed,
+    CommandFailed,
+    ControllerEnableTimeout,
+    InvalidControllerConfig,
+    MsixAllocationFailed,
+    NoNamespace,
+    QueueAllocationFailed,
+    SubmissionQueueFull,
+    DmaAllocationFailed,
+}

--- a/kernel/comps/nvme/src/device/namespace.rs
+++ b/kernel/comps/nvme/src/device/namespace.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_block::SECTOR_SIZE;
+
+#[derive(Debug)]
+pub(super) struct NvmeNamespace {
+    /// Namespace ID reported by the controller.
+    pub id: u32,
+    /// Total number of logical blocks (NSZE).
+    pub nsze: u64,
+}
+
+/// Logical block size in bytes (`2^LBADS` from the active LBA format).
+///
+/// For now this must match [`SECTOR_SIZE`] so the block layer and NVMe LBAs align.
+pub(super) const LBA_SIZE: usize = SECTOR_SIZE;

--- a/kernel/comps/nvme/src/device/stat.rs
+++ b/kernel/comps/nvme/src/device/stat.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[derive(Debug)]
+pub(super) struct NvmeStats {
+    completed: AtomicU64,
+    submitted: AtomicU64,
+}
+
+impl NvmeStats {
+    pub(super) fn new() -> Self {
+        Self {
+            completed: AtomicU64::new(0),
+            submitted: AtomicU64::new(0),
+        }
+    }
+
+    #[expect(dead_code)]
+    pub(super) fn get_stats(&self) -> (u64, u64) {
+        (
+            self.submitted.load(Ordering::Relaxed),
+            self.completed.load(Ordering::Relaxed),
+        )
+    }
+
+    #[expect(dead_code)]
+    pub(super) fn reset_stats(&self) {
+        self.submitted.store(0, Ordering::Relaxed);
+        self.completed.store(0, Ordering::Relaxed);
+    }
+
+    pub(super) fn increment_submitted(&self) {
+        self.submitted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn increment_completed(&self) {
+        self.completed.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl fmt::Display for NvmeStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "submitted {} completed {}",
+            self.submitted.load(Ordering::Relaxed),
+            self.completed.load(Ordering::Relaxed)
+        )
+    }
+}

--- a/kernel/comps/nvme/src/lib.rs
+++ b/kernel/comps/nvme/src/lib.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe (Non-Volatile Memory Express) driver for Asterinas.
+//!
+//! This driver implements support for NVMe storage devices following the
+//! NVM Express Base Specification Revision 2.0.
+//!
+//! Reference: NVM Express Base Specification Revision 2.0
+
+#![no_std]
+
+extern crate alloc;
+#[macro_use]
+extern crate ostd_pod;
+
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "nvme: "
+    };
+}
+
+use aster_block::MajorIdOwner;
+use component::{ComponentInitError, init_component};
+use spin::Once;
+use transport::pci::NVME_PCI_DRIVER;
+
+pub use self::device::block_device::NvmeBlockDevice;
+
+mod device;
+mod msix;
+mod nvme_cmd;
+mod nvme_queue;
+mod nvme_regs;
+mod nvme_spec;
+mod transport;
+
+static NVME_BLOCK_MAJOR_ID: Once<MajorIdOwner> = Once::new();
+
+#[init_component]
+fn nvme_init() -> Result<(), ComponentInitError> {
+    let major = aster_block::allocate_major().map_err(|_| ComponentInitError::Unknown)?;
+    NVME_BLOCK_MAJOR_ID.call_once(|| major);
+
+    transport::init();
+
+    while let Some(transport) = NVME_PCI_DRIVER.get().unwrap().pop_device_transport() {
+        let res = NvmeBlockDevice::init(transport);
+        if res.is_err() {
+            ostd::error!("Device initialization error: {:?}", res);
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/comps/nvme/src/msix.rs
+++ b/kernel/comps/nvme/src/msix.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! MSI-X interrupt management for NVMe devices.
+//!
+//! This module provides MSI-X interrupt vector allocation and management
+//! for NVMe controllers, allowing per-queue interrupt handling for better
+//! performance and scalability.
+
+use alloc::vec::Vec;
+
+use aster_pci::capability::msix::CapabilityMsixData;
+use ostd::irq::IrqLine;
+
+/// MSI-X interrupt manager for NVMe devices.
+///
+/// NVMe devices can use multiple MSI-X vectors for improved interrupt handling:
+/// - Admin queue vector: Used for admin command completions.
+/// - I/O queue vectors: Each I/O queue can have its own interrupt vector.
+pub(crate) struct NvmeMsixManager {
+    /// MSI-X vector for admin queue (queue 0).
+    admin_vector: u16,
+    /// Available MSI-X vectors for I/O queues.
+    unused_vectors: Vec<u16>,
+    /// MSI-X vectors currently assigned to I/O queues.
+    used_vectors: Vec<u16>,
+    /// MSI-X capability data.
+    msix: CapabilityMsixData,
+}
+
+impl NvmeMsixManager {
+    /// Creates a new MSI-X manager and initializes all available interrupt vectors.
+    ///
+    /// # Arguments
+    ///
+    /// * `msix` - The MSI-X capability data from PCI configuration space
+    ///
+    /// # Returns
+    ///
+    /// A new `NvmeMsixManager` with all vectors allocated and initialized, or `None` if allocating
+    /// an IRQ line for any vector fails.
+    pub(crate) fn new(mut msix: CapabilityMsixData) -> Option<Self> {
+        let table_size = msix.table_size();
+        if table_size == 0 {
+            return None;
+        }
+        let n = usize::from(table_size);
+
+        let mut irqs = Vec::with_capacity(n);
+        for _ in 0..n {
+            irqs.push(IrqLine::alloc().ok()?);
+        }
+
+        for (i, irq) in irqs.into_iter().enumerate() {
+            msix.set_interrupt_vector(irq, i as u16);
+        }
+
+        // Reserve the first vector for admin queue
+        let mut vector_list: Vec<u16> = (0..table_size).collect();
+        let admin_vector = vector_list.remove(0);
+
+        Some(Self {
+            admin_vector,
+            unused_vectors: vector_list,
+            used_vectors: Vec::new(),
+            msix,
+        })
+    }
+
+    /// Returns the admin queue MSI-X vector and its IRQ line.
+    pub(crate) fn admin_irq(&mut self) -> (u16, &mut IrqLine) {
+        (
+            self.admin_vector,
+            self.msix.irq_mut(self.admin_vector as usize).unwrap(),
+        )
+    }
+
+    /// Allocates an MSI-X vector for an I/O queue.
+    ///
+    /// Returns `Some((vector_id, irq_line))` if a vector is available, or `None` otherwise.
+    pub(crate) fn alloc_io_queue_irq(&mut self) -> Option<(u16, &mut IrqLine)> {
+        let vector = self.unused_vectors.pop()?;
+        self.used_vectors.push(vector);
+        Some((vector, self.msix.irq_mut(vector as usize).unwrap()))
+    }
+
+    /// Returns the total number of MSI-X vectors available.
+    pub(crate) fn table_size(&self) -> u16 {
+        self.msix.table_size()
+    }
+
+    /// Returns a mutable reference to the IRQ line for the given vector if any.
+    pub(crate) fn irq_for_vector_mut(&mut self, vector: u16) -> Option<&mut IrqLine> {
+        self.msix.irq_mut(vector as usize)
+    }
+}

--- a/kernel/comps/nvme/src/nvme_cmd.rs
+++ b/kernel/comps/nvme/src/nvme_cmd.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe command builders.
+//!
+//! Refer to NVM Express Base Specification Revision 2.0:
+//! - Section 5: Admin Command Set
+//! - Section 6: NVM Command Set
+
+use crate::nvme_spec::NvmeCommand;
+
+/// Admin Command Set opcodes.
+///
+/// See NVMe Spec 2.0, Section 5 (Admin Command Set).
+#[repr(u8)]
+enum AdminCommandSet {
+    /// Delete I/O Submission Queue command. See Section 5.7.
+    DeleteIosq = 0x00,
+    /// Create I/O Submission Queue command. See Section 5.5.
+    CreateIosq = 0x01,
+    /// Delete I/O Completion Queue command. See Section 5.6.
+    DeleteIocq = 0x04,
+    /// Create I/O Completion Queue command. See Section 5.4.
+    CreateIocq = 0x05,
+    /// Identify command. See Section 5.17.
+    IdentifyCommand = 0x06,
+}
+
+/// I/O Command Set opcodes (NVM Command Set).
+///
+/// See NVMe Spec 2.0, Section 7 (I/O Commands).
+#[repr(u8)]
+enum IoCommandSet {
+    /// Flush command. See Section 7.1.
+    Flush = 0x00,
+    /// Write command. See Section 7.
+    Write = 0x01,
+    /// Read command. See Section 7.
+    Read = 0x02,
+}
+
+/// Bit position for the FUSE (Fused Operation) field in the command flags byte.
+///
+/// The FUSE field (bits 6:7) indicates whether this command is part of a fused operation:
+/// - 00b: Normal command (not part of a fused operation)
+/// - 01b: First command of a fused operation
+/// - 10b: Second command of a fused operation
+/// - 11b: Reserved
+const IO_CMD_NOT_FUSED_BITS: u8 = 6;
+
+// Admin command builders for queue lifecycle.
+
+/// Builds a Create I/O Completion Queue admin command. See Section 5.4.
+pub(crate) fn create_io_completion_queue(
+    qid: u16,
+    ptr: usize,
+    size: u16,
+    iv: Option<u16>,
+) -> NvmeCommand {
+    let cdw11 = if let Some(vector) = iv {
+        ((vector as u32) << 16) | 0b11
+    } else {
+        0b1
+    };
+
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::CreateIocq as u8,
+        0,
+        0,
+        [ptr as u64, 0],
+        [((size as u32) << 16) | (qid as u32), cdw11],
+    )
+}
+
+/// Builds a Create I/O Submission Queue admin command. See Section 5.5.
+pub(crate) fn create_io_submission_queue(
+    qid: u16,
+    ptr: usize,
+    size: u16,
+    cqid: u16,
+) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::CreateIosq as u8,
+        0,
+        0,
+        [ptr as u64, 0],
+        [
+            ((size as u32) << 16) | (qid as u32),
+            ((cqid as u32) << 16) | 1,
+        ],
+    )
+}
+
+/// Builds a Delete I/O Completion Queue admin command. See Section 5.6.
+#[expect(dead_code)]
+pub(crate) fn delete_io_completion_queue(qid: u16) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::DeleteIocq as u8,
+        0,
+        0,
+        [0, 0],
+        [qid as u32],
+    )
+}
+
+/// Builds a Delete I/O Submission Queue admin command. See Section 5.7.
+#[expect(dead_code)]
+pub(crate) fn delete_io_submission_queue(qid: u16) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::DeleteIosq as u8,
+        0,
+        0,
+        [0, 0],
+        [qid as u32],
+    )
+}
+
+// Admin command builders for identify operations.
+
+/// Builds an Identify command for a single namespace (CNS 00h). See Section 5.17.
+pub(crate) fn identify_namespace(ptr: usize, nsid: u32) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::IdentifyCommand as u8,
+        0,
+        nsid,
+        [ptr as u64, 0],
+        [],
+    )
+}
+
+/// Builds an Identify command for the controller (CNS 01h). See Section 5.17.
+pub(crate) fn identify_controller(ptr: usize) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::IdentifyCommand as u8,
+        0,
+        0,
+        [ptr as u64, 0],
+        [1],
+    )
+}
+
+/// Builds an Identify command for the active namespace ID list (CNS 02h). See Section 5.17.
+pub(crate) fn identify_namespace_list(ptr: usize, base: u32) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        AdminCommandSet::IdentifyCommand as u8,
+        0,
+        base,
+        [ptr as u64, 0],
+        [2],
+    )
+}
+
+// I/O command builders.
+
+/// Builds a Read command. See Section 7.
+pub(crate) fn io_read(nsid: u32, lba: u64, nlb: u16, ptr0: u64, ptr1: u64) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        IoCommandSet::Read as u8,
+        0 << IO_CMD_NOT_FUSED_BITS,
+        nsid,
+        [ptr0, ptr1],
+        [
+            lba as u32,
+            (lba >> 32) as u32,
+            // `nlb` is the Number of Logical Blocks field encoded as "block count minus one"
+            nlb as u32,
+        ],
+    )
+}
+
+/// Builds a Write command. See Section 7.
+pub(crate) fn io_write(nsid: u32, lba: u64, nlb: u16, ptr0: u64, ptr1: u64) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        IoCommandSet::Write as u8,
+        0 << IO_CMD_NOT_FUSED_BITS,
+        nsid,
+        [ptr0, ptr1],
+        [
+            lba as u32,
+            (lba >> 32) as u32,
+            // `nlb` is the Number of Logical Blocks field encoded as "block count minus one"
+            nlb as u32,
+        ],
+    )
+}
+
+/// Builds a Flush command. See Section 7.1.
+pub(crate) fn io_flush(nsid: u32) -> NvmeCommand {
+    NvmeCommand::from_raw_fields(
+        IoCommandSet::Flush as u8,
+        0 << IO_CMD_NOT_FUSED_BITS,
+        nsid,
+        [0, 0],
+        [],
+    )
+}

--- a/kernel/comps/nvme/src/nvme_queue.rs
+++ b/kernel/comps/nvme/src/nvme_queue.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe Submission and Completion Queue implementation.
+//!
+//! Refer to NVM Express Base Specification Revision 2.0, Section 3.3 (Queue Mechanism).
+
+use core::{
+    ops::DerefMut,
+    sync::atomic::{Ordering, fence},
+};
+
+use aster_util::{field_ptr, safe_ptr::SafePtr};
+use ostd::{
+    mm::{HasDaddr, dma::DmaCoherent},
+    warn,
+};
+
+use crate::{
+    nvme_regs::NvmeDoorbellRegs,
+    nvme_spec::{NvmeCommand, NvmeCompletion},
+    transport::pci::transport::DbregAccess,
+};
+
+/// Number of entries in each submission and completion ring.
+pub(crate) const QUEUE_DEPTH: usize = 64;
+
+/// Number of queue pairs the driver allocates (admin plus I/O).
+//
+// TODO: This value should be changed when supporting more than 1 I/O queue pairs.
+pub(crate) const QUEUE_NUM: usize = 2;
+
+/// Completion Queue.
+#[derive(Debug)]
+pub(crate) struct NvmeCompletionQueue {
+    cqueue: SafePtr<Cqring, DmaCoherent>,
+    head: u16,
+    phase: bool,
+}
+
+struct Cqring {
+    ring: [NvmeCompletion; QUEUE_DEPTH],
+}
+
+impl NvmeCompletionQueue {
+    /// Creates a new completion ring.
+    ///
+    /// Returns `None` if DMA memory for the completion ring cannot be allocated.
+    pub(crate) fn new() -> Option<Self> {
+        let dma = DmaCoherent::alloc(1, true).ok()?;
+        Some(Self {
+            cqueue: SafePtr::new(dma, 0),
+            head: 0,
+            phase: true,
+        })
+    }
+
+    /// Returns the DMA physical address of the completion ring.
+    pub(crate) fn cq_daddr(&self) -> usize {
+        self.cqueue.daddr()
+    }
+
+    /// Consumes the next completion entry if its phase tag matches the expected phase.
+    ///
+    /// Returns the new head index (for the CQ head doorbell) and the completion, or `None` if no
+    /// entry is ready.
+    fn complete(&mut self) -> Option<(u16, NvmeCompletion)> {
+        let ring_ptr: SafePtr<[NvmeCompletion; QUEUE_DEPTH], &DmaCoherent> =
+            field_ptr!(&self.cqueue, Cqring, ring);
+        let mut ring_slot_ptr = ring_ptr.cast::<NvmeCompletion>();
+        ring_slot_ptr.add(self.head as usize);
+
+        let phase_tag = NvmeCompletion::read_phase_tag(&ring_slot_ptr);
+        if phase_tag != self.phase {
+            return None;
+        }
+
+        // Read barrier.
+        fence(Ordering::SeqCst);
+
+        let entry = ring_slot_ptr
+            .read()
+            .expect("CQ slot pointer must be valid within allocated DMA ring");
+        self.head = (self.head + 1) % (QUEUE_DEPTH as u16);
+        if self.head == 0 {
+            self.phase = !self.phase;
+        }
+        Some((self.head, entry))
+    }
+}
+
+/// Submission Queue.
+#[derive(Debug)]
+pub(crate) struct NvmeSubmissionQueue {
+    squeue: SafePtr<Sqring, DmaCoherent>,
+    tail: u16,
+    head: u16,
+}
+
+struct Sqring {
+    ring: [NvmeCommand; QUEUE_DEPTH],
+}
+
+impl NvmeSubmissionQueue {
+    /// Creates a new submission ring.
+    ///
+    /// Returns `None` if DMA memory for the submission ring cannot be allocated.
+    pub(crate) fn new() -> Option<Self> {
+        let dma = DmaCoherent::alloc(1, true).ok()?;
+        Some(Self {
+            squeue: SafePtr::new(dma, 0),
+            tail: 0,
+            head: 0,
+        })
+    }
+
+    /// Updates the mirrored SQ head from the SQ head pointer in `completion`.
+    pub(crate) fn update_sq_head(&mut self, completion: &NvmeCompletion) {
+        self.head = completion.sq_head() % (QUEUE_DEPTH as u16);
+    }
+
+    /// Returns the DMA physical address of the submission ring.
+    pub(crate) fn sq_daddr(&self) -> usize {
+        self.squeue.daddr()
+    }
+
+    /// Enqueues a command into the submission ring.
+    ///
+    /// Does nothing when the queue is full (`(tail + 1) % size == head`).
+    ///
+    /// Returns the new tail index for the SQ Tail doorbell, or `None` if full.
+    fn submit(&mut self, entry: NvmeCommand) -> Option<u16> {
+        let next_tail = (self.tail + 1) % (QUEUE_DEPTH as u16);
+        if next_tail == self.head {
+            return None;
+        }
+
+        let ring_ptr: SafePtr<[NvmeCommand; QUEUE_DEPTH], &DmaCoherent> =
+            field_ptr!(&self.squeue, Sqring, ring);
+        let mut ring_slot_ptr = ring_ptr.cast::<NvmeCommand>();
+        ring_slot_ptr.add(self.tail as usize);
+        ring_slot_ptr
+            .write(&entry)
+            .expect("SQ slot pointer must be valid within allocated DMA ring");
+
+        self.tail = next_tail;
+        Some(self.tail)
+    }
+}
+
+pub(crate) struct NvmeCompletionQueueAccess<'a, Q> {
+    qid: u16,
+    dstrd: u16,
+    queue: Q,
+    dbregs: DbregAccess<'a>,
+}
+
+impl<'a, Q> NvmeCompletionQueueAccess<'a, Q>
+where
+    Q: DerefMut<Target = NvmeCompletionQueue>,
+{
+    /// Binds queue `qid` and doorbell stride `dstrd` to `queue` and `dbregs` for locked poll.
+    pub(crate) fn new(qid: u16, dstrd: u16, queue: Q, dbregs: DbregAccess<'a>) -> Self {
+        Self {
+            qid,
+            dstrd,
+            queue,
+            dbregs,
+        }
+    }
+
+    /// Polls for a completion and updates the CQ head doorbell when an entry is consumed.
+    pub(crate) fn complete(&mut self) -> Option<NvmeCompletion> {
+        let (new_head, entry) = self.queue.complete()?;
+        // Full barrier: do not update the doorbell until the completion entry read finishes.
+        fence(Ordering::SeqCst);
+        self.dbregs.write_racy(
+            NvmeDoorbellRegs::Cqhdbl,
+            self.qid,
+            self.dstrd,
+            new_head as u32,
+        );
+        if entry.has_error() {
+            warn!(
+                "completion queue {}: command failed (CID={}, status={:04X}, SC={:#04x}, SQID={})",
+                self.qid,
+                entry.cid(),
+                entry.status(),
+                entry.status_code(),
+                entry.sq_id(),
+            );
+        }
+        Some(entry)
+    }
+}
+
+pub(crate) struct NvmeSubmissionQueueAccess<'a, Q> {
+    qid: u16,
+    dstrd: u16,
+    queue: Q,
+    dbregs: DbregAccess<'a>,
+}
+
+impl<'a, Q> NvmeSubmissionQueueAccess<'a, Q>
+where
+    Q: DerefMut<Target = NvmeSubmissionQueue>,
+{
+    /// Binds queue `qid` and doorbell stride `dstrd` to `queue` and `dbregs` for locked submit.
+    pub(crate) fn new(qid: u16, dstrd: u16, queue: Q, dbregs: DbregAccess<'a>) -> Self {
+        Self {
+            qid,
+            dstrd,
+            queue,
+            dbregs,
+        }
+    }
+
+    /// Submits a command and rings the SQ tail doorbell.
+    ///
+    /// Writes at the current tail, sets the command identifier to that slot index, advances the
+    /// tail, then updates the doorbell.
+    ///
+    /// Returns the command identifier used (same as the tail before enqueue), or `None` if the
+    /// queue is full.
+    pub(crate) fn submit(&mut self, mut entry: NvmeCommand) -> Option<u16> {
+        let cid = self.queue.tail;
+        entry.set_cid(cid);
+        let new_tail = match self.queue.submit(entry) {
+            Some(tail) => tail,
+            None => {
+                warn!("submission queue {} is full", self.qid);
+                return None;
+            }
+        };
+        // Write barrier: do not update the doorbell until the submit entry write finishes.
+        fence(Ordering::SeqCst);
+        self.dbregs.write_racy(
+            NvmeDoorbellRegs::Sqtdbl,
+            self.qid,
+            self.dstrd,
+            new_tail as u32,
+        );
+        Some(cid)
+    }
+}

--- a/kernel/comps/nvme/src/nvme_regs.rs
+++ b/kernel/comps/nvme/src/nvme_regs.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe Controller Register definitions.
+//!
+//! Refer to NVM Express Base Specification Revision 2.0, Section 3.1.
+
+/// 32-bit Controller Registers.
+#[repr(usize)]
+#[derive(Clone, Copy, Debug)]
+#[expect(dead_code)]
+pub(crate) enum NvmeRegs32 {
+    /// Version (VS): Indicates the NVMe specification version.
+    Vs = 0x8,
+    /// Interrupt Mask Set (INTMS): Used to set interrupt mask bits.
+    Intms = 0xC,
+    /// Interrupt Mask Clear (INTMC): Used to clear interrupt mask bits.
+    Intmc = 0x10,
+    /// Controller Configuration (CC): Used to configure the controller.
+    Cc = 0x14,
+    /// Controller Status (CSTS): Reports status of the controller.
+    Csts = 0x1C,
+    /// NVM Subsystem Reset (NSSR): Used to reset the NVM subsystem.
+    Nssr = 0x20,
+    /// Admin Queue Attributes (AQA): Defines the size of Admin Queues.
+    Aqa = 0x24,
+    /// Controller Memory Buffer Location (CMBLOC): Indicates the location of the Controller Memory Buffer.
+    Cmbloc = 0x38,
+    /// Controller Memory Buffer Size (CMBSZ): Indicates the size of the Controller Memory Buffer.
+    Cmbsz = 0x3C,
+    /// Boot Partition Information (BPINFO): Provides information about boot partitions.
+    Bpinfo = 0x40,
+    /// Boot Partition Read Select (BPRSEL): Selects which boot partition to read from.
+    Bprsel = 0x44,
+    /// Boot Partition Memory Buffer Location (BPMBL): Indicates the location of the boot partition memory buffer.
+    Bpmbl = 0x48,
+    /// Controller Memory Buffer Status (CMBSTS): Reports the status of the Controller Memory Buffer.
+    Cmbsts = 0x58,
+    /// Persistent Memory Region Capabilities (PMRCAP): Reports Persistent Memory Region capabilities.
+    Pmrcap = 0xE00,
+    /// Persistent Memory Region Control (PMRCTL): Controls the Persistent Memory Region.
+    Pmrctl = 0xE04,
+    /// Persistent Memory Region Status (PMRSTS): Reports the status of the Persistent Memory Region.
+    Pmrsts = 0xE08,
+    /// Persistent Memory Region Elasticity Buffer Size (PMREBS): Reports the size of the elasticity buffer.
+    Pmrebs = 0xE0C,
+    /// Persistent Memory Region Sustained Write Throughput (PMRSWTP): Reports sustained write throughput.
+    Pmrswtp = 0xE10,
+}
+
+/// 64-bit Controller Registers.
+#[repr(usize)]
+#[derive(Clone, Copy, Debug)]
+#[expect(dead_code)]
+pub(crate) enum NvmeRegs64 {
+    /// Controller Capabilities (CAP): Identifies basic capabilities.
+    Cap = 0x0,
+    /// Admin Submission Queue Base Address (ASQ): Base address of the Admin Submission Queue.
+    Asq = 0x28,
+    /// Admin Completion Queue Base Address (ACQ): Base address of the Admin Completion Queue.
+    Acq = 0x30,
+    /// Controller Memory Buffer Memory Space Control (CMBMSC): Controls the Controller Memory Buffer memory space.
+    Cmbmsc = 0x50,
+    /// Persistent Memory Region Memory Space Control (PMRMSC): Controls the Persistent Memory Region memory space.
+    Pmrmsc = 0xE14,
+}
+
+/// Exclusive end offset of fixed 32/64-bit registers this driver accesses.
+pub(crate) const NVME_BAR0_FIXED_REGS_END: u64 = NvmeRegs64::Pmrmsc as u64 + 8;
+
+impl NvmeRegs64 {
+    /// CAP.DSTRD bit shift.
+    pub(crate) const CAP_DSTRD_SHIFT: u32 = 32;
+    /// CAP.DSTRD bit mask.
+    pub(crate) const CAP_DSTRD_MASK: u64 = 0b1111;
+    /// CAP.TO bit shift.
+    pub(crate) const CAP_TO_SHIFT: u32 = 24;
+    /// CAP.TO bit mask.
+    pub(crate) const CAP_TO_MASK: u64 = 0xff;
+    /// CAP.MPSMIN bit shift.
+    pub(crate) const CAP_MPSMIN_SHIFT: u32 = 48;
+    /// CAP.MPSMIN bit mask.
+    pub(crate) const CAP_MPSMIN_MASK: u64 = 0b1111;
+    /// CAP.MPSMAX bit shift.
+    pub(crate) const CAP_MPSMAX_SHIFT: u32 = 52;
+    /// CAP.MPSMAX bit mask.
+    pub(crate) const CAP_MPSMAX_MASK: u64 = 0b1111;
+}
+
+/// Doorbell Registers.
+///
+/// Doorbell registers are used to notify the controller of updates to submission
+/// and completion queues. Each queue pair has two doorbell registers:
+/// - Submission Queue y Tail Doorbell (SQyTDBL): offset 0x1000 + (2y * (4 << DSTRD))
+/// - Completion Queue y Head Doorbell (CQyHDBL): offset 0x1000 + ((2y+1) * (4 << DSTRD))
+///
+/// Where 'y' is the queue identifier (queue ID).
+#[repr(usize)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum NvmeDoorbellRegs {
+    /// Submission Queue y Tail Doorbell (SQyTDBL).
+    Sqtdbl,
+    /// Completion Queue y Head Doorbell (CQyHDBL).
+    Cqhdbl,
+}
+
+impl NvmeDoorbellRegs {
+    /// Calculates the offset for this doorbell register.
+    ///
+    /// # Arguments
+    ///
+    /// * `qid` - Queue identifier (queue ID)
+    /// * `dstrd` - Doorbell Stride value from the CAP register
+    ///
+    /// # Returns
+    ///
+    /// The offset, in bytes, from the base of the controller registers.
+    pub(crate) fn offset(&self, qid: u16, dstrd: u16) -> usize {
+        const DOORBELL_BASE: usize = 0x1000;
+        let stride = 4usize << usize::from(dstrd);
+
+        match self {
+            NvmeDoorbellRegs::Sqtdbl => DOORBELL_BASE + (2 * usize::from(qid)) * stride,
+            NvmeDoorbellRegs::Cqhdbl => DOORBELL_BASE + ((2 * usize::from(qid)) + 1) * stride,
+        }
+    }
+}

--- a/kernel/comps/nvme/src/nvme_spec.rs
+++ b/kernel/comps/nvme/src/nvme_spec.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NVMe protocol data structures.
+//!
+//! Refer to NVM Express Base Specification Revision 2.0, Section 3.3.3
+
+use aster_util::{field_ptr, safe_ptr::SafePtr};
+use ostd::mm::dma::DmaCoherent;
+
+/// Submission Queue Entry (SQE).
+///
+/// See NVMe Spec 2.0, Section 3.3.1 (Submission Queue Entry).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(crate) struct NvmeCommand {
+    /// Opcode.
+    opcode: u8,
+    /// Flags.
+    flags: u8,
+    /// Command ID.
+    cid: u16,
+    /// Namespace identifier.
+    nsid: u32,
+    /// Reserved.
+    _rsvd: u64,
+    /// Metadata pointer.
+    mptr: u64,
+    /// Data pointer.
+    dptr: [u64; 2],
+    /// Command dword 10.
+    cdw10: u32,
+    /// Command dword 11.
+    cdw11: u32,
+    /// Command dword 12.
+    cdw12: u32,
+    /// Command dword 13.
+    cdw13: u32,
+    /// Command dword 14.
+    cdw14: u32,
+    /// Command dword 15.
+    cdw15: u32,
+}
+
+/// Completion Queue Entry (CQE).
+///
+/// See NVMe Spec 2.0, Section 3.3.3.2 (Common Completion Queue Entry), Figure 89.
+/// Layout by dword (offsets0–15 in the entry):
+/// - **Dword 0**: Command specific.
+/// - **Dword 1**: Command specific.
+/// - **Dword 2**: SQ Head Pointer (bits 15:0) | SQ Identifier (bits 31:16).
+/// - **Dword 3**: Command Identifier (bits 15:0) | Phase Tag (bit 16) | Status Field (bits 31:17, 15 bits).
+///
+/// The Status bits are further defined in Figure 92 (DNR, M, CRD, SCT, SC, etc.).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(crate) struct NvmeCompletion {
+    /// Dword 0: Command Specific (32 bits).
+    dword0: u32,
+
+    /// Dword 1: Command Specific (32 bits).
+    dword1: u32,
+
+    /// Dword 2, bits 0-15: SQ Head Pointer (16 bits).
+    ///
+    /// The head pointer of the corresponding Submission Queue that is updated
+    /// by the controller when this entry is placed into the Completion Queue.
+    sq_head: u16,
+
+    /// Dword 2, bits 16-31: SQ Identifier (16 bits).
+    ///
+    /// The Submission Queue identifier that is associated with this completion.
+    sq_id: u16,
+
+    /// Dword 3, bits 0-15: Command Identifier (16 bits).
+    ///
+    /// The Command Identifier (CID) of the command that this completion is associated with.
+    cid: u16,
+
+    /// Dword 3, bits 16-31: Status Field (16 bits).
+    status: u16,
+}
+
+impl NvmeCommand {
+    /// Creates a command entry from fully encoded command fields.
+    ///
+    /// `cdw` supplies command dwords starting at CDW10; any of CDW11–CDW15 not included are zero.
+    /// There can be at most six command dwords (i.e., `N <= 6`).
+    pub(crate) fn from_raw_fields<const N: usize>(
+        opcode: u8,
+        flags: u8,
+        nsid: u32,
+        dptr: [u64; 2],
+        cdw: [u32; N],
+    ) -> Self {
+        const { assert!(N <= 6) };
+        Self {
+            opcode,
+            flags,
+            cid: 0,
+            nsid,
+            _rsvd: 0,
+            mptr: 0,
+            dptr,
+            cdw10: cdw.first().copied().unwrap_or(0),
+            cdw11: cdw.get(1).copied().unwrap_or(0),
+            cdw12: cdw.get(2).copied().unwrap_or(0),
+            cdw13: cdw.get(3).copied().unwrap_or(0),
+            cdw14: cdw.get(4).copied().unwrap_or(0),
+            cdw15: cdw.get(5).copied().unwrap_or(0),
+        }
+    }
+
+    /// Sets the Command Identifier (CID) for this submission queue entry.
+    pub(crate) fn set_cid(&mut self, cid: u16) {
+        self.cid = cid;
+    }
+}
+
+impl NvmeCompletion {
+    /// Reads the phase tag (P) from a completion queue slot.
+    pub(crate) fn read_phase_tag(ring_slot_ptr: &SafePtr<NvmeCompletion, &DmaCoherent>) -> bool {
+        let status = field_ptr!(ring_slot_ptr, NvmeCompletion, status)
+            .read_once()
+            .expect("CQ status field must be valid within allocated DMA ring");
+        (status & 1) != 0
+    }
+
+    /// Returns the completion entry SQ head pointer.
+    pub(crate) fn sq_head(&self) -> u16 {
+        self.sq_head
+    }
+
+    /// Returns the completion entry SQ identifier.
+    pub(crate) fn sq_id(&self) -> u16 {
+        self.sq_id
+    }
+
+    /// Returns the completion entry command identifier.
+    pub(crate) fn cid(&self) -> u16 {
+        self.cid
+    }
+
+    /// Returns the raw completion status bits.
+    pub(crate) fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// Masks Status Code (SC), DW3 bits 24:17, in bits 8:1 of `status`.
+    const STATUS_SC_MASK: u16 = 0x01FE;
+
+    /// Checks if the completion indicates an error.
+    ///
+    /// Returns `true` if the Status Code is non-zero.
+    pub(crate) fn has_error(&self) -> bool {
+        self.status_code() != 0
+    }
+
+    /// Gets the Status Code from the completion status field.
+    ///
+    /// Returns the Status Code (SC).
+    pub(crate) fn status_code(&self) -> u8 {
+        ((self.status & Self::STATUS_SC_MASK) >> 1) as u8
+    }
+}

--- a/kernel/comps/nvme/src/transport/mod.rs
+++ b/kernel/comps/nvme/src/transport/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod pci;
+
+pub(crate) fn init() {
+    pci::nvme_pci_init();
+}

--- a/kernel/comps/nvme/src/transport/pci/driver.rs
+++ b/kernel/comps/nvme/src/transport/pci/driver.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{sync::Arc, vec::Vec};
+
+use aster_pci::{
+    PciDeviceId,
+    bus::{PciDevice, PciDriver},
+    common_device::PciCommonDevice,
+};
+use ostd::{bus::BusProbeError, sync::SpinLock};
+
+use super::transport::NvmePciTransport;
+
+#[derive(Debug)]
+struct NvmePciDevice {
+    device_id: PciDeviceId,
+}
+
+impl NvmePciDevice {
+    fn new(device_id: PciDeviceId) -> Self {
+        Self { device_id }
+    }
+}
+
+impl PciDevice for NvmePciDevice {
+    fn device_id(&self) -> PciDeviceId {
+        self.device_id
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct NvmePciDriver {
+    devices: SpinLock<Vec<NvmePciTransport>>,
+}
+
+impl NvmePciDriver {
+    pub(crate) fn pop_device_transport(&self) -> Option<NvmePciTransport> {
+        self.devices.lock().pop()
+    }
+
+    pub(super) fn new() -> Self {
+        NvmePciDriver {
+            devices: SpinLock::new(Vec::new()),
+        }
+    }
+}
+
+impl PciDriver for NvmePciDriver {
+    fn probe(
+        &self,
+        device: PciCommonDevice,
+    ) -> Result<Arc<dyn PciDevice>, (BusProbeError, PciCommonDevice)> {
+        const NVME_DEVICE_CLASS: u8 = 0x01;
+        const NVME_DEVICE_SUBCLASS: u8 = 0x08;
+        const NVME_DEVICE_PROG_IF: u8 = 0x02;
+
+        if device.device_id().class != NVME_DEVICE_CLASS
+            || device.device_id().subclass != NVME_DEVICE_SUBCLASS
+            || device.device_id().prog_if != NVME_DEVICE_PROG_IF
+        {
+            return Err((BusProbeError::DeviceNotMatch, device));
+        }
+
+        let device_id = *device.device_id();
+        let transport = NvmePciTransport::new(device)?;
+
+        self.devices.lock().push(transport);
+
+        Ok(Arc::new(NvmePciDevice::new(device_id)))
+    }
+}

--- a/kernel/comps/nvme/src/transport/pci/mod.rs
+++ b/kernel/comps/nvme/src/transport/pci/mod.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod driver;
+pub(crate) mod transport;
+
+use alloc::sync::Arc;
+
+use aster_pci::PCI_BUS;
+use spin::Once;
+
+use self::driver::NvmePciDriver;
+
+pub(crate) static NVME_PCI_DRIVER: Once<Arc<NvmePciDriver>> = Once::new();
+
+pub(crate) fn nvme_pci_init() {
+    NVME_PCI_DRIVER.call_once(|| Arc::new(NvmePciDriver::new()));
+    PCI_BUS
+        .lock()
+        .register_driver(NVME_PCI_DRIVER.get().unwrap().clone());
+}

--- a/kernel/comps/nvme/src/transport/pci/transport.rs
+++ b/kernel/comps/nvme/src/transport/pci/transport.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use aster_pci::{
+    cfg_space::{Bar, BarAccess},
+    common_device::PciCommonDevice,
+};
+use ostd::{
+    bus::BusProbeError,
+    error, info,
+    sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
+};
+
+use crate::{
+    msix::NvmeMsixManager,
+    nvme_queue::QUEUE_NUM,
+    nvme_regs::{NVME_BAR0_FIXED_REGS_END, NvmeDoorbellRegs, NvmeRegs32, NvmeRegs64},
+};
+
+pub(crate) struct NvmePciTransport {
+    inner: NvmePciTransportInner,
+    config_bar: BarAccess,
+}
+
+pub(crate) struct NvmePciTransportInner {
+    common_device: PciCommonDevice,
+    msix_manager: NvmeMsixManager,
+}
+
+impl Debug for NvmePciTransport {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NvmePciTransport")
+            .field("common_device", &self.inner.common_device)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NvmePciTransport {
+    /// Creates a PCI NVMe transport for `common_device`.
+    ///
+    /// Returns `Err` with the device if BAR0 is unusable, too small, cannot be mapped, or MSI-X
+    /// setup fails.
+    #[expect(clippy::result_large_err)]
+    pub(super) fn new(
+        mut common_device: PciCommonDevice,
+    ) -> Result<Self, (BusProbeError, PciCommonDevice)> {
+        let Some(config_bar) = Self::check_and_acquire_bar0(&mut common_device) else {
+            error!("BAR0 is unusable: missing, not MMIO, map failed, or too small");
+            return Err((BusProbeError::ConfigurationSpaceError, common_device));
+        };
+
+        let Some(msix_manager) = Self::init_msix(&mut common_device) else {
+            error!("MSI-X capability missing or MSI-X setup failed");
+            return Err((BusProbeError::ConfigurationSpaceError, common_device));
+        };
+
+        Ok(Self {
+            inner: NvmePciTransportInner {
+                common_device,
+                msix_manager,
+            },
+            config_bar,
+        })
+    }
+
+    /// Validates BAR0, maps it, and checks its size against the fixed layout and
+    /// [`Self::required_bar0_size_bytes`].
+    fn check_and_acquire_bar0(device: &mut PciCommonDevice) -> Option<BarAccess> {
+        let bar0 = device.bar_manager_mut().bar_mut(0)?;
+        let bar_size = match bar0 {
+            Bar::Memory(mem) => mem.size(),
+            Bar::Io(_) => return None,
+        };
+
+        if bar_size < NVME_BAR0_FIXED_REGS_END {
+            return None;
+        }
+
+        let config_bar = bar0.acquire().ok()?;
+        let cap = RegAccess(&config_bar).read64(NvmeRegs64::Cap);
+        let required_bar = Self::required_bar0_size_bytes(cap);
+        if bar_size < required_bar {
+            return None;
+        }
+
+        Some(config_bar)
+    }
+
+    /// Returns the minimum BAR0 size in bytes required for the controller register block and the
+    /// doorbell array for all queue pairs used by this driver.
+    fn required_bar0_size_bytes(cap: u64) -> u64 {
+        let dstrd = ((cap >> NvmeRegs64::CAP_DSTRD_SHIFT) & NvmeRegs64::CAP_DSTRD_MASK) as u16;
+        NVME_BAR0_FIXED_REGS_END
+            .max(NvmeDoorbellRegs::Sqtdbl.offset(QUEUE_NUM as u16, dstrd) as u64)
+    }
+
+    /// Initializes MSI-X capability if available.
+    fn init_msix(common_device: &mut PciCommonDevice) -> Option<NvmeMsixManager> {
+        let msix_opt = common_device.acquire_msix_capability().ok()?;
+        let msix_data = msix_opt?;
+        let manager = NvmeMsixManager::new(msix_data)?;
+        info!("MSI-X enabled with {} vectors", manager.table_size());
+        Some(manager)
+    }
+
+    /// Returns a mutable reference to the MSI-X manager.
+    pub(crate) fn msix_manager_mut(&mut self) -> &mut NvmeMsixManager {
+        self.inner.msix_manager_mut()
+    }
+
+    /// Returns access to the NVMe registers.
+    pub(crate) fn regs(&mut self) -> RegAccess<'_> {
+        RegAccess(&self.config_bar)
+    }
+
+    /// Returns access to the doorbell registers.
+    pub(crate) fn dbregs(&self) -> DbregAccess<'_> {
+        DbregAccess(&self.config_bar)
+    }
+}
+
+impl NvmePciTransportInner {
+    /// Returns a mutable reference to the MSI-X manager.
+    pub(crate) fn msix_manager_mut(&mut self) -> &mut NvmeMsixManager {
+        &mut self.msix_manager
+    }
+}
+
+pub(crate) struct NvmePciTransportLock {
+    inner: SpinLock<NvmePciTransportInner, LocalIrqDisabled>,
+    config_bar: BarAccess,
+}
+
+pub(crate) struct NvmePciTransportGuard<'a> {
+    inner: SpinLockGuard<'a, NvmePciTransportInner, LocalIrqDisabled>,
+}
+
+impl Deref for NvmePciTransportGuard<'_> {
+    type Target = NvmePciTransportInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for NvmePciTransportGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl NvmePciTransportLock {
+    /// Wraps a probed [`NvmePciTransport`] for concurrent access.
+    pub(crate) fn new(inner: NvmePciTransport) -> Self {
+        Self {
+            inner: SpinLock::new(inner.inner),
+            config_bar: inner.config_bar,
+        }
+    }
+
+    /// Locks the inner transport and returns a guard for register and MSI-X access.
+    pub(crate) fn lock(&self) -> NvmePciTransportGuard<'_> {
+        NvmePciTransportGuard {
+            inner: self.inner.lock(),
+        }
+    }
+
+    /// Returns doorbell access without taking the transport lock.
+    pub(crate) fn dbregs(&self) -> DbregAccess<'_> {
+        DbregAccess(&self.config_bar)
+    }
+}
+
+/// Access to NVMe registers (i.e., [`NvmeRegs32`] and [`NvmeRegs64`]).
+///
+/// These NVMe registers are protected by the spin lock on [`NvmePciTransportInner`].
+/// `RegAccess` can only be constructed from
+/// a mutable reference of [`NvmePciTransport`] or [`NvmePciTransportGuard`],
+/// so reading/writing the registers are race-free.
+pub(crate) struct RegAccess<'a>(&'a BarAccess);
+
+impl RegAccess<'_> {
+    /// Reads a 32-bit controller register.
+    pub(crate) fn read32(&self, reg: NvmeRegs32) -> u32 {
+        self.0.read_once(reg as usize).unwrap()
+    }
+
+    /// Reads a 64-bit controller register.
+    pub(crate) fn read64(&self, reg: NvmeRegs64) -> u64 {
+        let base = reg as usize;
+        let reg_low: u32 = self.0.read_once(base).unwrap();
+        let reg_high: u32 = self.0.read_once(base + 4).unwrap();
+        ((reg_high as u64) << 32) | (reg_low as u64)
+    }
+
+    /// Writes a 32-bit controller register.
+    pub(crate) fn write32(&self, reg: NvmeRegs32, val: u32) {
+        self.0.write_once(reg as usize, val).unwrap();
+    }
+
+    /// Writes a 64-bit controller register.
+    pub(crate) fn write64(&self, reg: NvmeRegs64, val: u64) {
+        let base = reg as usize;
+        let val_low = (val & 0xFFFF_FFFF) as u32;
+        let val_high = (val >> 32) as u32;
+        self.0.write_once(base, val_low).unwrap();
+        self.0.write_once(base + 4, val_high).unwrap();
+    }
+}
+
+/// Access to doorbell registers (i.e., [`NvmeDoorbellRegs`]).
+///
+/// These doorbell registers are protected by the queue's spin lock.
+/// From the perspective of the NVMe transport,
+/// we can only provide racy APIs.
+/// This is reflected by the fact that `DbregAccess` can be constructed
+/// from an immutable reference of [`NvmePciTransportLock`].
+/// The caller should call these APIs after locking the queue.
+///
+/// We only expose write access here. Doorbell registers are used by the host to
+/// notify the controller of queue updates; reading them is not relied upon.
+pub(crate) struct DbregAccess<'a>(&'a BarAccess);
+
+impl DbregAccess<'_> {
+    /// Writes a queue doorbell.
+    ///
+    /// This API is intentionally racy: `DbregAccess` can be obtained from shared transport
+    /// references, so multiple writers may exist at once. Callers must hold the corresponding
+    /// queue lock to keep doorbell updates ordered with queue memory updates.
+    pub(crate) fn write_racy(&self, reg: NvmeDoorbellRegs, qid: u16, dstrd: u16, val: u32) {
+        let offset = reg.offset(qid, dstrd);
+        self.0.write_once(offset, val).unwrap();
+    }
+}

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_block::{BlockDevice, SECTOR_SIZE};
+use aster_nvme::NvmeBlockDevice;
 use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 use device_id::DeviceId;
 use ostd::mm::VmIo;
@@ -24,14 +25,30 @@ pub(super) fn init_in_first_kthread() {
             continue;
         }
 
-        let task_fn = move || {
-            info!("spawn the virt-io-block thread");
-            let virtio_block_device = device.downcast_ref::<VirtIoBlockDevice>().unwrap();
-            loop {
-                virtio_block_device.handle_requests();
-            }
-        };
-        ThreadOptions::new(task_fn).spawn();
+        // Spawn threads for virtio block devices
+        if device.downcast_ref::<VirtIoBlockDevice>().is_some() {
+            let device_clone = device.clone();
+            let task_fn = move || {
+                info!("spawn the virtio-block thread");
+                let virtio_block_device = device_clone.downcast_ref::<VirtIoBlockDevice>().unwrap();
+                loop {
+                    virtio_block_device.handle_requests();
+                }
+            };
+            ThreadOptions::new(task_fn).spawn();
+        }
+        // Spawn threads for NVMe block devices
+        else if device.downcast_ref::<NvmeBlockDevice>().is_some() {
+            let device_clone = device.clone();
+            let task_fn = move || {
+                info!("spawn the nvme-block thread");
+                let nvme_block_device = device_clone.downcast_ref::<NvmeBlockDevice>().unwrap();
+                loop {
+                    nvme_block_device.handle_requests();
+                }
+            };
+            ThreadOptions::new(task_fn).spawn();
+        }
     }
 }
 

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -29,6 +29,7 @@ INITRAMFS_COMPRESSED := true
 endif
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
+SSD_IMAGE := $(BUILD_DIR)/nvme0n1.img
 XFSTESTS_TEST_IMAGE := $(BUILD_DIR)/xfstests_test.img
 XFSTESTS_SCRATCH_IMAGE := $(BUILD_DIR)/xfstests_scratch.img
 XFSTESTS_DISK_SIZE ?= 12G
@@ -61,9 +62,9 @@ build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
 else ifeq ($(BUILD_XFSTESTS_IMAGES), true)
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
+build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(SSD_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
 else
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE)
+build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(SSD_IMAGE)
 endif
 
 .PHONY: $(INITRAMFS_IMAGE)
@@ -174,6 +175,11 @@ $(EXFAT_IMAGE):
 	@mkdir -p $(BUILD_DIR)
 	@fallocate -l 512M $(EXFAT_IMAGE)
 	@mkfs.exfat $(EXFAT_IMAGE)
+
+$(SSD_IMAGE):
+	@mkdir -p $(BUILD_DIR)
+	@dd if=/dev/zero of=$(SSD_IMAGE) bs=256M count=1
+	@mke2fs -t ext2 -F $(SSD_IMAGE)
 
 $(XFSTESTS_TEST_IMAGE):
 	@mkdir -p $(BUILD_DIR)

--- a/test/initramfs/src/regression/device/nvme.c
+++ b/test/initramfs/src/regression/device/nvme.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define DEVICE_PATH "/dev/nvme0n1"
+#define MOUNT_POINT "/nvme"
+#define TEST_FILE "/nvme/nvme_test"
+#define BUFFER_SIZE 65536
+#define ALIGNMENT 4096
+
+#ifndef O_DIRECT
+#define O_DIRECT 040000
+#endif
+
+static char *nvme_write_buf;
+static char *nvme_read_buf;
+
+FN_SETUP(mount_nvme_ext2)
+{
+	if (mkdir(MOUNT_POINT, 0755) != 0 && errno != EEXIST) {
+		fprintf(stderr,
+			"fatal error: setup_mount_nvme_ext2: mkdir('%s') failed: %s\n",
+			MOUNT_POINT, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (mount(DEVICE_PATH, MOUNT_POINT, "ext2", 0, "") != 0) {
+		if (errno == ENOENT || errno == ENODEV || errno == ENXIO) {
+			fprintf(stderr,
+				"nvme tests skipped: mount('%s') failed: %s\n",
+				DEVICE_PATH, strerror(errno));
+			exit(EXIT_SUCCESS);
+		}
+		fprintf(stderr,
+			"fatal error: setup_mount_nvme_ext2: mount('%s') failed: %s\n",
+			DEVICE_PATH, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+END_SETUP()
+
+FN_SETUP(alloc_nvme_buffers)
+{
+	CHECK_WITH(posix_memalign((void **)&nvme_write_buf, ALIGNMENT,
+				  BUFFER_SIZE),
+		   _ret == 0);
+	CHECK_WITH(posix_memalign((void **)&nvme_read_buf, ALIGNMENT,
+				  BUFFER_SIZE),
+		   _ret == 0);
+}
+END_SETUP()
+
+FN_TEST(rw_direct_verify)
+{
+	srand((unsigned int)time(NULL));
+	for (size_t i = 0; i < BUFFER_SIZE; i++) {
+		nvme_write_buf[i] = (char)(rand() % 256);
+	}
+
+	int fd = TEST_SUCC(
+		open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR | O_DIRECT, 0644));
+	TEST_RES(write(fd, nvme_write_buf, BUFFER_SIZE), _ret == BUFFER_SIZE);
+	TEST_SUCC(lseek(fd, 0, SEEK_SET));
+	TEST_RES(read(fd, nvme_read_buf, BUFFER_SIZE), _ret == BUFFER_SIZE);
+	TEST_RES(memcmp(nvme_write_buf, nvme_read_buf, BUFFER_SIZE), _ret == 0);
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_SETUP(teardown_nvme)
+{
+	free(nvme_read_buf);
+	nvme_read_buf = NULL;
+	free(nvme_write_buf);
+	nvme_write_buf = NULL;
+	CHECK(umount(MOUNT_POINT));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -15,4 +15,5 @@ set -e
 ./framebuffer
 ./full
 ./hwrng
+./nvme
 ./random

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -178,6 +178,8 @@ else
         -device virtio-rng-pci,bus=pcie.0,addr=0x8,disable-legacy=on,disable-modern=off,rng=rng0,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
         -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
+        -drive if=none,format=raw,id=nvme0n1,file=./test/initramfs/build/nvme0n1.img \
+        -device nvme,drive=nvme0n1,serial=nvme0n1 \
         $CONSOLE_ARGS \
         $IOMMU_EXTRA_ARGS \
     "


### PR DESCRIPTION
This is the first PR to add NVMe driver. It could support several basic Admin and I/O commands, including identify_namespace, read, write, flush, etc. For details, please check `kernel/comps/nvme/src/nvme_cmd.rs`.

In order to prove the correctness, this PR includes two ktests. One is to check the initialization, and the other is to write and then read to prove the correctness of read and write commands. There is also a userspace microbenchmark to prove this driver could handle requests with SSD device.

Now it could be used for basic I/O requests. In the future, we would add more features and commands to make this driver stronger and higher-performance.