### PR TITLE
Resigning ownership of other Makefiles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,8 +80,8 @@
 /tools/                         @grief8
 /triagebot.toml                 @grief8
 
-Makefile                        @junyang-zh
-OSDK.toml                       @junyang-zh
+/Makefile                       @junyang-zh
+/OSDK.toml                      @junyang-zh
 
 # The following critical files are singled out
 /CODEOWNERS                     @tatetian


### PR DESCRIPTION
See https://github.com/asterinas/asterinas/pull/1841#issuecomment-2774363933

I think I shouldn't own other `Makefile`s and `OSDK.toml`s other than the root.