### PR TITLE
Reconstruct benchmark workflow to support multiple architectures

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -1,0 +1,147 @@
+name: 'Benchmark'
+description: 'Run benchmarks for Asterinas'
+inputs:
+  task:
+    description: 'Task to run (benchmark, result)'
+    required: true
+  platform:
+    description: 'Platform to benchmark (x86-64, tdx)'
+    required: true
+  benchmark:
+    description: 'The benchmark to run'
+    required: false
+  benchmark-secret:
+    description: 'Secret token for benchmark action data submission'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up the environment
+      shell: bash
+      run: |
+        # If the task is 'benchmark', set up the environment for benchmarking
+        # If the task is 'result', set up the environment for result processing
+
+        if [[ "${{ inputs.task }}" == "benchmark" ]]; then
+          echo "Setting up environment for benchmarking..."
+          git config --global --add safe.directory /__w/asterinas/asterinas
+          git config --global http.sslVerify false
+          git config --global http.version HTTP/1.1
+        elif [[ "${{ inputs.task }}" == "result" ]]; then
+          echo "Setting up environment for result processing..."
+          sudo apt-get update && sudo apt-get install -y yq jq
+        else
+          echo "Unknown task: ${{ inputs.task }}"
+          exit 1
+        fi
+        
+    - name: Run benchmarks
+      if: ${{ inputs.task == 'benchmark' }}
+      shell: bash
+      run: |
+        make install_osdk
+        bash test/benchmark/bench_linux_and_aster.sh "${{ matrix.benchmarks }}" "${{ inputs.platform }}"
+        BENCHMARK_ARTIFACT=results_$(echo "${{ matrix.benchmarks }}" | tr '/' '-')
+        echo "BENCHMARK_ARTIFACT=$BENCHMARK_ARTIFACT" >> $GITHUB_ENV
+
+    - name: Store benchmark results
+      if: ${{ inputs.task == 'benchmark' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.BENCHMARK_ARTIFACT }}
+        if-no-files-found: error # Fail the benchmark job if no file is found.
+        path: |
+          result_*.json
+    
+    - name: Download Benchmark Results
+      if: ${{ inputs.task == 'result' }}
+      uses: actions/download-artifact@v4
+      with:
+        pattern: results_*
+        path: ./results
+        merge-multiple: true
+
+    - name: Generate all benchmark config files
+      if: ${{ inputs.task == 'result' }}
+      shell: bash
+      run: |
+        mkdir -p configs
+        BENCHMARK_LIST=$(ls results/result_*.json | sed 's/.*result_//' | sed 's/\.json//' | jq -R -s -c 'split("\n")[:-1]')
+        echo "Processing benchmarks: $BENCHMARK_LIST"
+
+        # Loop through the benchmark identifiers provided by the Matrix job
+        for benchmark_id in $(echo "$BENCHMARK_LIST" | jq -r '.[]'); do
+          echo "--- Processing $benchmark_id ---"
+          BENCHMARK_DIR=$(echo "$benchmark_id" | sed 's/-/\//g')
+          BENCHMARK_SUITE=$(echo "$BENCHMARK_DIR" | awk -F'/' '{print $1}')
+          BENCHMARK_NAME=$(echo "$BENCHMARK_DIR" | sed -E 's|^[^/]+/||; s|/bench_results||g; s|/|_|g')
+          BENCH_RESULT_YAML="test/benchmark/${BENCHMARK_DIR}/bench_result.yaml"
+          [ -f "$BENCH_RESULT_YAML" ] || BENCH_RESULT_YAML="test/benchmark/${BENCHMARK_DIR}.yaml"
+
+          if [ ! -f "$BENCH_RESULT_YAML" ]; then
+            echo "Warning: YAML file not found for $benchmark_id at $BENCH_RESULT_YAML. Skipping config generation."
+            continue
+          fi
+
+          # Extract data using yq
+          ALERT_THRESHOLD=$(yq -r '.alert.threshold // "130%"' "$BENCH_RESULT_YAML")
+          ALERT_TOOL=$(yq -r 'if (.alert.bigger_is_better == true) then "customBiggerIsBetter" else "customSmallerIsBetter" end' "$BENCH_RESULT_YAML")
+          TITLE=$(yq -r '.chart.title // "Undefined"' "$BENCH_RESULT_YAML")
+          DESCRIPTION=$(yq -r '.chart.description // "No description provided"' "$BENCH_RESULT_YAML")
+
+          # Generate summary JSON if needed (only once per suite)
+          SUMMARY_JSON="test/benchmark/$BENCHMARK_SUITE/summary.json"
+          if [ ! -f "$SUMMARY_JSON" ]; then
+              SUMMARY_YAML="test/benchmark/$BENCHMARK_SUITE/summary.yaml"
+              if [ -f "$SUMMARY_YAML" ]; then
+                yq . "$SUMMARY_YAML" > "$SUMMARY_JSON"
+                echo "Generated $SUMMARY_JSON"
+              else
+                echo "Warning: summary.yaml not found for suite $BENCHMARK_SUITE"
+              fi
+          fi
+
+          # Define file paths
+          CONFIG_FILE="configs/config_${benchmark_id}.json"
+          RESULT_FILE="results/result_${benchmark_id}.json"
+        
+          # Create JSON structure using jq
+          jq -n \
+            --arg title "$TITLE" \
+            --arg description "$DESCRIPTION" \
+            --arg suite "${{ inputs.platform }}/$BENCHMARK_SUITE" \
+            --arg name "$BENCHMARK_NAME" \
+            --arg threshold "$ALERT_THRESHOLD" \
+            --arg tool "$ALERT_TOOL" \
+            --arg result_path "$RESULT_FILE" \
+            --arg summary_path "$SUMMARY_JSON" \
+            '{
+              metadata: {
+                title: $title,
+                description: $description,
+                suite: $suite,
+                name: $name,
+                threshold: $threshold,
+                tool: $tool,
+                summary: $summary_path
+              },
+              result: $result_path
+            }' > "$CONFIG_FILE"
+
+          echo "Generated config file $CONFIG_FILE"
+        done
+
+    - name: Store benchmark results
+      if: ${{ inputs.task == 'result' }}
+      uses: asterinas/github-action-benchmark@v5
+      with:
+        # Use glob pattern to find all generated config files
+        output-file-path: "configs/config_*.json"
+        github-token: ${{ inputs.benchmark-secret }}
+        gh-repository: 'github.com/asterinas/benchmark'
+        auto-push: true
+        comment-on-alert: true
+        fail-on-alert: false
+        max-items-in-chart: 60
+        ref: ${{ github.sha }}

--- a/.github/workflows/benchmark_x86_tdx.yml
+++ b/.github/workflows/benchmark_x86_tdx.yml
@@ -1,10 +1,10 @@
-name: "Benchmark x86-64  "
+name: "Benchmark Intel TDX "
 on:
   # In case of manual trigger, use workflow_dispatch
   workflow_dispatch:
   schedule:
     # Schedule to run on every day at 20:00 UTC (04:00 Beijing Time)
-    - cron: '0 20 * * *'
+    - cron: '0 18 * * *'
 
 jobs:
   Benchmarks:
@@ -55,8 +55,9 @@ jobs:
           - lmbench/ext2_create_delete_files_0k_ops
           - lmbench/ext2_create_delete_files_10k_ops
           - lmbench/ext2_copy_files_bw
-          - fio/ext2_seq_write_bw
-          - fio/ext2_seq_read_bw
+          # FIXME: IOMMU are not supported in TDX now.
+          # - fio/ext2_seq_write_bw
+          # - fio/ext2_seq_read_bw
           - fio/ext2_seq_write_bw_no_iommu
           - fio/ext2_seq_read_bw_no_iommu
           # Loopback-related network benchmarks
@@ -107,7 +108,7 @@ jobs:
       max-parallel: 1
     timeout-minutes: 60
     container: 
-      image: asterinas/asterinas:0.14.1-20250326
+      image: asterinas/asterinas:0.14.1-20250326-tdx
       options: --device=/dev/kvm --privileged
 
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
     A secure, fast, and general-purpose OS kernel written in Rust and compatible with Linux<br/>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml/badge.svg?event=push" alt="Test x86-64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml/badge.svg" alt="Test Intel TDX" style="max-width: 100%;"></a>
-    <a href="https://asterinas.github.io/benchmark/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/x86-64/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/tdx/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_tdx.yml/badge.svg" alt="Benchmark Intel TDX" style="max-width: 100%;"></a>
     <br/>
 </p>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -3,7 +3,8 @@
     一个安全、快速、通用的操作系统内核，使用Rust编写，并与Linux兼容<br/>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml/badge.svg?event=push" alt="Test x86-64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml/badge.svg" alt="Test Intel TDX" style="max-width: 100%;"></a>
-    <a href="https://asterinas.github.io/benchmark/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/x86-64/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/tdx/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_tdx.yml/badge.svg" alt="Benchmark Intel TDX" style="max-width: 100%;"></a>
     <br/>
 </p>
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -3,7 +3,8 @@
     安全で高速、汎用的なOSカーネル。Rustで書かれ、Linuxと互換性があります<br/>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml/badge.svg?event=push" alt="Test x86-64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml/badge.svg" alt="Test Intel TDX" style="max-width: 100%;"></a>
-    <a href="https://asterinas.github.io/benchmark/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/x86-64/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_x86.yml/badge.svg" alt="Benchmark x86-64" style="max-width: 100%;"></a>
+    <a href="https://asterinas.github.io/benchmark/tdx/"><img src="https://github.com/asterinas/asterinas/actions/workflows/benchmark_tdx.yml/badge.svg" alt="Benchmark Intel TDX" style="max-width: 100%;"></a>
     <br/>
 </p>
 

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -2,7 +2,9 @@
 
 The Asterinas Benchmark Collection evaluates the performance of Asterinas in comparison to Linux across a range of benchmarking tools (e.g., LMbench, Sysbench, iPerf) and real-world applications (e.g., Nginx, Redis, SQLite, Memcached). These benchmarks are conducted under various configurations, such as within a single virtual machine (VM) or between a VM and its host.
 
-The benchmarks are run automatically on a nightly basis through continuous integration (CI) pipelines. Results, presented in clear and visually appealing figures and tables, are available [here](https://asterinas.github.io/benchmark/).
+The benchmarks are run automatically on a nightly basis through continuous integration (CI) pipelines. Results, presented in clear and visually appealing figures and tables, are available for all tier-1 supported platforms.
+1. [x86-64](https://asterinas.github.io/benchmark/x86-64/)
+2. [Intel TDX](https://asterinas.github.io/benchmark/tdx/)
 
 ## File Organization
 
@@ -19,7 +21,7 @@ The benchmark collection is organized into benchmark suites, each dedicated to a
 - [nginx](https://github.com/asterinas/asterinas/tree/main/test/benchmark/nginx)
 - [memcached](https://github.com/asterinas/asterinas/tree/main/test/benchmark/memcached)
 
-Each suite has a corresponding web page (e.g., [LMbench results](https://asterinas.github.io/benchmark/lmbench/)) that publishes the latest performance data. At the top of each page, a summary table showcases the most recent results, configured using the `summary.json` file in the suite's directory.
+Each suite has a corresponding web page (e.g., [LMbench results](https://asterinas.github.io/benchmark/x86-64/lmbench/)) that publishes the latest performance data. At the top of each page, a summary table showcases the most recent results, configured using the `summary.json` file in the suite's directory.
 
 ### Benchmark Jobs
 

--- a/test/benchmark/bench_linux_and_aster.sh
+++ b/test/benchmark/bench_linux_and_aster.sh
@@ -110,44 +110,76 @@ run_benchmark() {
          esac
      done <<< "$runtime_configs_str"
 
-    # Prepare commands for Asterinas and Linux
-    local asterinas_cmd="make run BENCHMARK=${benchmark} ${aster_scheme_cmd_part} SMP=${smp_val} MEM=${mem_val} ENABLE_KVM=1 RELEASE_LTO=1 NETDEV=tap VHOST=on 2>&1"
-    local linux_cmd="/usr/local/qemu/bin/qemu-system-x86_64 \
-        --no-reboot \
-        -smp ${smp_val} \
-        -m ${mem_val} \
-        -machine q35,kernel-irqchip=split \
-        -cpu Icelake-Server,-pcid,+x2apic \
-        --enable-kvm \
-        -kernel ${LINUX_KERNEL} \
-        -initrd ${BENCHMARK_ROOT}/../build/initramfs.cpio.gz \
-        -drive if=none,format=raw,id=x0,file=${BENCHMARK_ROOT}/../build/ext2.img \
-        -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
-        -append 'console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet' \
-        -netdev tap,id=net01,script=${BENCHMARK_ROOT}/../../tools/net/qemu-ifup.sh,downscript=${BENCHMARK_ROOT}/../../tools/net/qemu-ifdown.sh,vhost=on \
-        -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,csum=off,guest_csum=off,ctrl_guest_offloads=off,guest_tso4=off,guest_tso6=off,guest_ecn=off,guest_ufo=off,host_tso4=off,host_tso6=off,host_ecn=off,host_ufo=off,mrg_rxbuf=off,ctrl_vq=off,ctrl_rx=off,ctrl_vlan=off,ctrl_rx_extra=off,guest_announce=off,ctrl_mac_addr=off,host_ufo=off,guest_uso4=off,guest_uso6=off,host_uso=off \
-        -nographic \
-        2>&1"
+    # Prepare commands for Asterinas and Linux using arrays
+    local asterinas_cmd_arr=(make run "BENCHMARK=${benchmark}")
+    # Add scheme part only if it's not empty and the platform is not TDX (OSDK doesn't support multiple SCHEME)
+    [[ -n "$aster_scheme_cmd_part" && "$platform" != "tdx" ]] && asterinas_cmd_arr+=("$aster_scheme_cmd_part")
+    asterinas_cmd_arr+=(
+        "SMP=${smp_val}"
+        "MEM=${mem_val}"
+        ENABLE_KVM=1
+        RELEASE_LTO=1
+        NETDEV=tap
+        VHOST=on
+    )
+    if [[ "$platform" == "tdx" ]]; then
+        asterinas_cmd_arr+=(INTEL_TDX=1)
+    fi
 
-    # Trim leading/trailing whitespace from commands before eval
-    asterinas_cmd=$(echo "$asterinas_cmd" | sed 's/^ *//;s/ *$//;s/  */ /g')
-    linux_cmd=$(echo "$linux_cmd" | sed 's/^ *//;s/ *$//;s/  */ /g')
+    # TODO: 
+    #   1. Current linux kernel is not TDX compatible. Replace with TDX compatible version later.
+    #   2. `guest_uso4=off,guest_uso6=off,host_uso=off` is not supported by the QEMU of TDX development image.
+    local linux_cmd_arr=(
+        qemu-system-x86_64
+        --no-reboot
+        -smp "${smp_val}"
+        -m "${mem_val}"
+        -machine q35,kernel-irqchip=split
+        -cpu Icelake-Server,-pcid,+x2apic
+        --enable-kvm
+        -kernel "${LINUX_KERNEL}"
+        -initrd "${BENCHMARK_ROOT}/../build/initramfs.cpio.gz"
+        -drive "if=none,format=raw,id=x0,file=${BENCHMARK_ROOT}/../build/ext2.img"
+        -device "virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off"
+        -append "console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet"
+        -netdev "tap,id=net01,script=${BENCHMARK_ROOT}/../../tools/net/qemu-ifup.sh,downscript=${BENCHMARK_ROOT}/../../tools/net/qemu-ifdown.sh,vhost=on"
+        -nographic
+    )
+    if [[ "$platform" != "tdx" ]]; then
+        linux_cmd_arr+=(
+            -device "virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,csum=off,guest_csum=off,ctrl_guest_offloads=off,guest_tso4=off,guest_tso6=off,guest_ecn=off,guest_ufo=off,host_tso4=off,host_tso6=off,host_ecn=off,host_ufo=off,mrg_rxbuf=off,ctrl_vq=off,ctrl_rx=off,ctrl_vlan=off,ctrl_rx_extra=off,guest_announce=off,ctrl_mac_addr=off,host_ufo=off,guest_uso4=off,guest_uso6=off,host_uso=off"
+        )
+    else
+        linux_cmd_arr+=(
+            -device "virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off,csum=off,guest_csum=off,ctrl_guest_offloads=off,guest_tso4=off,guest_tso6=off,guest_ecn=off,guest_ufo=off,host_tso4=off,host_tso6=off,host_ecn=off,host_ufo=off,mrg_rxbuf=off,ctrl_vq=off,ctrl_rx=off,ctrl_vlan=off,ctrl_rx_extra=off,guest_announce=off,ctrl_mac_addr=off,host_ufo=off"
+        )
+    fi
 
     # Run the benchmark depending on the mode
     case "${run_mode}" in
         "guest_only")
             echo "Running benchmark ${benchmark} on Asterinas..."
-            eval "$asterinas_cmd" | tee ${ASTER_OUTPUT}
+            # Execute directly from array, redirect stderr to stdout, then tee
+            "${asterinas_cmd_arr[@]}" 2>&1 | tee "${ASTER_OUTPUT}"
             prepare_fs
             echo "Running benchmark ${benchmark} on Linux..."
-            eval "$linux_cmd" | tee ${LINUX_OUTPUT}
+            # Execute directly from array, redirect stderr to stdout, then tee
+            "${linux_cmd_arr[@]}" 2>&1 | tee "${LINUX_OUTPUT}"
             ;;
         "host_guest")
+            # Note: host_guest_bench_runner.sh expects commands as single strings.
+            # We need to reconstruct the string representation for compatibility.
+            # Use printf %q to quote arguments safely.
+            local asterinas_cmd_str
+            printf -v asterinas_cmd_str '%q ' "${asterinas_cmd_arr[@]}"
+            local linux_cmd_str
+            printf -v linux_cmd_str '%q ' "${linux_cmd_arr[@]}"
+
             echo "Running benchmark ${benchmark} on host and guest..."
             bash "${BENCHMARK_ROOT}/common/host_guest_bench_runner.sh" \
                 "${BENCHMARK_ROOT}/${benchmark}" \
-                "${asterinas_cmd}" \
-                "${linux_cmd}" \
+                "${asterinas_cmd_str}" \
+                "${linux_cmd_str}" \
                 "${ASTER_OUTPUT}" \
                 "${LINUX_OUTPUT}"
             ;;
@@ -181,6 +213,8 @@ cleanup() {
 # Main function to coordinate the benchmark run
 main() {
     local benchmark="$1"
+    local platform="$2"
+
     if [[ -z "${BENCHMARK_ROOT}/${benchmark}" ]]; then
         echo "Error: No benchmark specified" >&2
         exit 1


### PR DESCRIPTION
This pull request reconstructs the workflow for running benchmarks and updates the workflow to use this action. It also includes some minor documentation updates.

### Workflow Updates:
* Added a new composite action `.github/actions/benchmark/action.yml` to handle benchmark tasks, including environment setup, running benchmarks, and processing results.

* Updated `.github/workflows/benchmark_x86.yml` to use the new benchmark action, simplifying the workflow by removing redundant steps and delegating tasks to the action. 

* Refactored `test/benchmark/bench_linux_and_aster.sh` to use arrays for command construction, improving readability and maintainability. Also the parameter `architecture` is added for different architectures support. **Note that** the TDX benchmark is not introduced yet because I have no idea about booting a linux TD VM for our benchmark.

### Documentation Updates:
* Updated benchmark result links in `README.md`, `README_CN.md`, `README_JP.md`, and `test/benchmark/README.md` to point to the correct URLs. 
