### PR TITLE
Update outdated comments near `switch_to_task`

### DIFF
--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -210,7 +210,8 @@ impl TaskOptions {
         /// all task will entering this function
         /// this function is mean to executing the task_fn in Task
         extern "C" fn kernel_task_entry() -> ! {
-            // SAFETY: This is called only once when we are switched to a CPU.
+            // SAFETY: The new task is switched on a CPU for the first time, `after_switching_to`
+            // hasn't been called yet.
             unsafe { processor::after_switching_to() };
 
             let current_task = Task::current()

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -259,10 +259,12 @@ where
         };
     };
 
-    // FIXME: At this point, we need to prevent the current task from being scheduled on another
-    // CPU core. However, we currently have no way to ensure this. This is a soundness hole and
-    // should be fixed. See <https://github.com/asterinas/asterinas/issues/1471> for details.
-
+    // `switch_to_task` will spin if it finds that the next task is still running on some CPU core,
+    // which guarantees soundness regardless of the scheduler implementation.
+    //
+    // FIXME: The scheduler decision and context switching are not atomic, which can lead to some
+    // strange behavior even if the scheduler is implemented correctly. See "Problem 2" at
+    // <https://github.com/asterinas/asterinas/issues/1633> for details.
     cpu_local::clear_need_preempt();
     processor::switch_to_task(next_task);
 }


### PR DESCRIPTION
I noticed that some comments in `switch_to_task` were outdated, this PR updates those comments.

Thanks to #1930, we can now prove that the `context_switch` is safe. Our previous safety comments are just false claims, as the call to `context_switch` is not really safe, so the corresponding safety comments deserve updates as well.