### PR TITLE
Always move zombie children to init

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -82,8 +82,10 @@ fn move_process_children(
 ) -> core::result::Result<(), ()> {
     // Take the lock first to avoid the race when the `reaper_process` is exiting concurrently.
     let mut reaper_process_children = reaper_process.children().lock();
+
+    let is_init = is_init_process(&reaper_process);
     let is_zombie = reaper_process.status().is_zombie();
-    if is_zombie {
+    if !is_init && is_zombie {
         return Err(());
     }
 


### PR DESCRIPTION
Fixes #1975
Fixes #1987

#1975 and #1987 are caused by infinite loop in:
https://github.com/asterinas/asterinas/blob/5ed5647d421cd7b38cd1d3f10018d6b7e4029dd6/kernel/src/process/exit.rs#L104-L108

`find_reaper_process` says that the reaper process is the init process, but `move_process_children` refuses to do anything because it finds out that the init process is a zombie process.