### PR TITLE
Drop the file table at the correct time

### DIFF
--- a/kernel/src/device/pty/pty.rs
+++ b/kernel/src/device/pty/pty.rs
@@ -217,8 +217,8 @@ impl FileIo for PtyMaster {
                 };
 
                 let fd = {
-                    let file_table = thread_local.file_table().borrow();
-                    let mut file_table_locked = file_table.write();
+                    let file_table = thread_local.borrow_file_table();
+                    let mut file_table_locked = file_table.unwrap().write();
                     // TODO: deal with the O_CLOEXEC flag
                     file_table_locked.insert(slave, FdFlags::empty())
                 };

--- a/kernel/src/fs/epoll/file.rs
+++ b/kernel/src/fs/epoll/file.rs
@@ -63,7 +63,7 @@ impl EpollFile {
             EpollCtl::Mod(fd, ..) => *fd,
         };
 
-        let mut file_table = thread_local.file_table().borrow_mut();
+        let mut file_table = thread_local.borrow_file_table_mut();
         let file = get_file_fast!(&mut file_table, fd).into_owned();
         drop(file_table);
 

--- a/kernel/src/fs/file_table.rs
+++ b/kernel/src/fs/file_table.rs
@@ -3,7 +3,6 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwArc;
 
 use super::{
     file_handle::FileLike,
@@ -15,6 +14,7 @@ use crate::{
     fs::utils::StatusFlags,
     prelude::*,
     process::{
+        posix_thread::FileTableRefMut,
         signal::{constants::SIGIO, signals::kernel::KernelSignal, PollAdaptor},
         Pid, Process,
     },
@@ -130,24 +130,20 @@ impl FileTable {
         Some(removed_entry.file)
     }
 
-    pub fn close_all(&mut self) -> Vec<Arc<dyn FileLike>> {
-        self.close_files(|_, _| true)
-    }
-
     pub fn close_files_on_exec(&mut self) -> Vec<Arc<dyn FileLike>> {
-        self.close_files(|_, entry| entry.flags().contains(FdFlags::CLOEXEC))
+        self.close_files(|entry| entry.flags().contains(FdFlags::CLOEXEC))
     }
 
     fn close_files<F>(&mut self, should_close: F) -> Vec<Arc<dyn FileLike>>
     where
-        F: Fn(FileDesc, &FileTableEntry) -> bool,
+        F: Fn(&FileTableEntry) -> bool,
     {
         let mut closed_files = Vec::new();
         let closed_fds: Vec<FileDesc> = self
             .table
             .idxes_and_items()
             .filter_map(|(idx, entry)| {
-                if should_close(idx as FileDesc, entry) {
+                if should_close(entry) {
                     Some(idx as FileDesc)
                 } else {
                     None
@@ -221,6 +217,9 @@ impl Clone for FileTable {
 
 impl Drop for FileTable {
     fn drop(&mut self) {
+        // Closes all files first.
+        self.close_files(|_| true);
+
         let events = FdEvents::DropFileTable;
         self.subject.notify_observers(&events);
     }
@@ -235,12 +234,14 @@ pub trait WithFileTable {
     fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R;
 }
 
-impl WithFileTable for RwArc<FileTable> {
+impl WithFileTable for FileTableRefMut<'_> {
     fn read_with<R>(&mut self, f: impl FnOnce(&FileTable) -> R) -> R {
-        if let Some(inner) = self.get() {
+        let file_table = self.unwrap();
+
+        if let Some(inner) = file_table.get() {
             f(inner)
         } else {
-            f(&self.read())
+            f(&file_table.read())
         }
     }
 }
@@ -269,10 +270,13 @@ macro_rules! get_file_fast {
         use alloc::borrow::Cow;
 
         use ostd::sync::RwArc;
+        use $crate::{
+            fs::file_table::{FileDesc, FileTable},
+            process::posix_thread::FileTableRefMut,
+        };
 
-        use crate::fs::file_table::{FileDesc, FileTable};
-
-        let file_table: &mut RwArc<FileTable> = $file_table;
+        let file_table: &mut FileTableRefMut<'_> = $file_table;
+        let file_table: &mut RwArc<FileTable> = file_table.unwrap();
         let file_desc: FileDesc = $file_desc;
 
         if let Some(inner) = file_table.get() {

--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -169,13 +169,13 @@ impl FsResolver {
             FsPathInner::Cwd => self.cwd.clone(),
             FsPathInner::FdRelative(fd, path) => {
                 let task = Task::current().unwrap();
-                let mut file_table = task.as_thread_local().unwrap().file_table().borrow_mut();
+                let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
                 let file = get_file_fast!(&mut file_table, fd);
                 self.lookup_from_parent(file.as_inode_or_err()?.dentry(), path, lookup_ctx)?
             }
             FsPathInner::Fd(fd) => {
                 let task = Task::current().unwrap();
-                let mut file_table = task.as_thread_local().unwrap().file_table().borrow_mut();
+                let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
                 let file = get_file_fast!(&mut file_table, fd);
                 file.as_inode_or_err()?.dentry().clone()
             }

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -387,6 +387,7 @@ impl<R> InodeHandle<R> {
 
 impl<R> Drop for InodeHandle<R> {
     fn drop(&mut self) {
+        self.release_range_locks();
         self.unlock_flock();
     }
 }

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -81,7 +81,16 @@ impl FileOps for StatusFileOps {
         writeln!(status_output, "Pid:\t{}", process.pid()).unwrap();
         writeln!(status_output, "PPid:\t{}", process.parent().pid()).unwrap();
         writeln!(status_output, "TracerPid:\t{}", process.parent().pid()).unwrap(); // Assuming TracerPid is the same as PPid
-        writeln!(status_output, "FDSize:\t{}", file_table.read().len()).unwrap();
+        writeln!(
+            status_output,
+            "FDSize:\t{}",
+            file_table
+                .lock()
+                .as_ref()
+                .map(|file_table| file_table.read().len())
+                .unwrap_or(0)
+        )
+        .unwrap();
         writeln!(
             status_output,
             "Threads:\t{}",

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -239,7 +239,7 @@ fn clone_child_task(
     clone_sysvsem(clone_flags)?;
 
     // clone file table
-    let child_file_table = clone_files(&thread_local.file_table().borrow(), clone_flags);
+    let child_file_table = clone_files(thread_local.borrow_file_table().unwrap(), clone_flags);
 
     // clone fs
     let child_fs = clone_fs(posix_thread.fs(), clone_flags);
@@ -315,7 +315,7 @@ fn clone_child_process(
     ));
 
     // clone file table
-    let child_file_table = clone_files(&thread_local.file_table().borrow(), clone_flags);
+    let child_file_table = clone_files(thread_local.borrow_file_table().unwrap(), clone_flags);
 
     // clone fs
     let child_fs = clone_fs(posix_thread.fs(), clone_flags);

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -2,7 +2,7 @@
 
 use core::sync::atomic::Ordering;
 
-use super::{posix_thread::ThreadLocal, process_table, Pid, Process};
+use super::{process_table, Pid, Process};
 use crate::{prelude::*, process::signal::signals::kernel::KernelSignal};
 
 /// Exits the current POSIX process.
@@ -12,21 +12,18 @@ use crate::{prelude::*, process::signal::signals::kernel::KernelSignal};
 ///
 /// [`do_exit`]: crate::process::posix_thread::do_exit
 /// [`do_exit_group`]: crate::process::posix_thread::do_exit_group
-pub(super) fn exit_process(thread_local: &ThreadLocal, current_process: &Process) {
+pub(super) fn exit_process(current_process: &Process) {
     current_process.status().set_zombie();
     current_process.status().set_vfork_child(false);
 
-    // FIXME: This is obviously wrong in a number of ways, since different threads can have
-    // different file tables, and different processes can share the same file table.
-    thread_local.file_table().borrow().write().close_all();
+    // Drop fields in `Process`.
+    current_process.lock_root_vmar().set_vmar(None);
 
     send_parent_death_signal(current_process);
 
     move_children_to_reaper_process(current_process);
 
     send_child_death_signal(current_process);
-
-    current_process.lock_root_vmar().set_vmar(None);
 }
 
 /// Sends parent-death signals to the children.

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -122,7 +122,7 @@ impl PosixThreadBuilder {
         Arc::new_cyclic(|weak_task| {
             let root_vmar = process
                 .upgrade()
-                .map(|process| process.lock_root_vmar().get().dup().unwrap());
+                .map(|process| process.lock_root_vmar().unwrap().dup().unwrap());
 
             let posix_thread = {
                 let prof_clock = ProfClock::new();

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -119,11 +119,15 @@ impl PosixThreadBuilder {
 
         let fs = fs.unwrap_or_else(|| Arc::new(ThreadFsInfo::default()));
 
-        Arc::new_cyclic(|weak_task| {
-            let root_vmar = process
-                .upgrade()
-                .map(|process| process.lock_root_vmar().unwrap().dup().unwrap());
+        let root_vmar = process
+            .upgrade()
+            .unwrap()
+            .lock_root_vmar()
+            .unwrap()
+            .dup()
+            .unwrap();
 
+        Arc::new_cyclic(|weak_task| {
             let posix_thread = {
                 let prof_clock = ProfClock::new();
                 let virtual_timer_manager = TimerManager::new(prof_clock.user_clock().clone());
@@ -134,7 +138,7 @@ impl PosixThreadBuilder {
                     tid,
                     name: Mutex::new(thread_name),
                     credentials,
-                    file_table: file_table.clone_ro(),
+                    file_table: Mutex::new(Some(file_table.clone_ro())),
                     fs,
                     sig_mask,
                     sig_queues,

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -79,10 +79,15 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
         thread_table::remove_thread(posix_thread.tid());
     }
 
+    // Drop fields in `PosixThread`.
+    *posix_thread.file_table().lock() = None;
+
+    // Drop fields in `ThreadLocal`.
     *thread_local.root_vmar().borrow_mut() = None;
+    thread_local.borrow_file_table_mut().remove();
 
     if is_last_thread {
-        exit_process(thread_local, &posix_process);
+        exit_process(&posix_process);
     }
 }
 

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -40,7 +40,7 @@ pub use exit::{do_exit, do_exit_group};
 pub use name::{ThreadName, MAX_THREAD_NAME_LEN};
 pub use posix_thread_ext::{create_posix_task_from_executable, AsPosixThread};
 pub use robust_list::RobustListHead;
-pub use thread_local::{AsThreadLocal, ThreadLocal};
+pub use thread_local::{AsThreadLocal, FileTableRefMut, ThreadLocal};
 
 pub struct PosixThread {
     // Immutable part
@@ -55,7 +55,7 @@ pub struct PosixThread {
 
     // Files
     /// File table
-    file_table: RoArc<FileTable>,
+    file_table: Mutex<Option<RoArc<FileTable>>>,
     /// File system
     fs: Arc<ThreadFsInfo>,
 
@@ -96,7 +96,7 @@ impl PosixThread {
         &self.name
     }
 
-    pub fn file_table(&self) -> &RoArc<FileTable> {
+    pub fn file_table(&self) -> &Mutex<Option<RoArc<FileTable>>> {
         &self.file_table
     }
 

--- a/kernel/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/src/process/process_vm/init_stack/mod.rs
@@ -385,7 +385,7 @@ impl InitStackReader<'_> {
         let stack_base = self.init_stack_bottom();
         let page_base_addr = stack_base.align_down(PAGE_SIZE);
 
-        let vm_space = self.vmar.get().vm_space();
+        let vm_space = self.vmar.unwrap().vm_space();
         let mut cursor = vm_space.cursor(&(page_base_addr..page_base_addr + PAGE_SIZE))?;
         let VmItem::Mapped { frame, .. } = cursor.query()? else {
             return_errno_with_message!(Errno::EACCES, "Page not accessible");
@@ -409,7 +409,7 @@ impl InitStackReader<'_> {
         let mut argv = Vec::with_capacity(argc);
         let page_base_addr = read_offset.align_down(PAGE_SIZE);
 
-        let vm_space = self.vmar.get().vm_space();
+        let vm_space = self.vmar.unwrap().vm_space();
         let mut cursor = vm_space.cursor(&(page_base_addr..page_base_addr + PAGE_SIZE))?;
         let VmItem::Mapped { frame, .. } = cursor.query()? else {
             return_errno_with_message!(Errno::EACCES, "Page not accessible");
@@ -449,7 +449,7 @@ impl InitStackReader<'_> {
         let mut envp = Vec::new();
         let page_base_addr = read_offset.align_down(PAGE_SIZE);
 
-        let vm_space = self.vmar.get().vm_space();
+        let vm_space = self.vmar.unwrap().vm_space();
         let mut cursor = vm_space.cursor(&(page_base_addr..page_base_addr + PAGE_SIZE))?;
         let VmItem::Mapped { frame, .. } = cursor.query()? else {
             return_errno_with_message!(Errno::EACCES, "Page not accessible");

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -66,7 +66,7 @@ pub fn load_elf_to_vm(
             // the process cannot return to user space again,
             // so `Vmar::clear` and `do_exit_group` are called here.
             // FIXME: sending a fault signal is an alternative approach.
-            process_vm.lock_root_vmar().get().clear().unwrap();
+            process_vm.lock_root_vmar().unwrap().clear().unwrap();
 
             // FIXME: `current` macro will be used in `do_exit_group`.
             // if the macro is used when creating the init process,
@@ -116,7 +116,7 @@ fn init_and_map_vmos(
     elf_file: &Dentry,
 ) -> Result<(Vaddr, AuxVec)> {
     let process_vmar = process_vm.lock_root_vmar();
-    let root_vmar = process_vmar.get();
+    let root_vmar = process_vmar.unwrap();
 
     // After we clear process vm, if any error happens, we must call exit_group instead of return to user space.
     let ldso_load_info = if let Some((ldso_file, ldso_elf)) = ldso {
@@ -409,7 +409,7 @@ pub fn init_aux_vec(elf: &Elf, elf_map_addr: Vaddr, ldso_base: Option<Vaddr>) ->
 /// Maps the VDSO VMO to the corresponding virtual memory address.
 fn map_vdso_to_vm(process_vm: &ProcessVm) -> Option<Vaddr> {
     let process_vmar = process_vm.lock_root_vmar();
-    let root_vmar = process_vmar.get();
+    let root_vmar = process_vmar.unwrap();
     let vdso_vmo = vdso_vmo()?;
 
     let options = root_vmar

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -47,7 +47,7 @@ fn do_accept(
     flags: Flags,
     ctx: &Context,
 ) -> Result<FileDesc> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 
@@ -74,7 +74,7 @@ fn do_accept(
     }
 
     let fd = {
-        let mut file_table_locked = file_table.write();
+        let mut file_table_locked = file_table.unwrap().write();
         file_table_locked.insert(connected_socket, fd_flags)
     };
 

--- a/kernel/src/syscall/bind.rs
+++ b/kernel/src/syscall/bind.rs
@@ -16,7 +16,7 @@ pub fn sys_bind(
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addrlen as usize)?;
     debug!("sockfd = {sockfd}, socket_addr = {socket_addr:?}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/chdir.rs
+++ b/kernel/src/syscall/chdir.rs
@@ -35,7 +35,7 @@ pub fn sys_fchdir(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let dentry = {
-        let mut file_table = ctx.thread_local.file_table().borrow_mut();
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
         let file = get_file_fast!(&mut file_table, fd);
         file.as_inode_or_err()?.dentry().clone()
     };

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -13,7 +13,7 @@ use crate::{
 pub fn sys_fchmod(fd: FileDesc, mode: u16, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}, mode = 0o{:o}", fd, mode);
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     file.set_mode(InodeMode::from_bits_truncate(mode))?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -20,7 +20,7 @@ pub fn sys_fchown(fd: FileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<Sys
         return Ok(SyscallReturn::Return(0));
     }
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     if let Some(uid) = uid {
         file.set_owner(uid)?;

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -7,8 +7,8 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
     let file = {
-        let file_table = ctx.thread_local.file_table().borrow();
-        let mut file_table_locked = file_table.write();
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
         let _ = file_table_locked.get_file(fd)?;
         file_table_locked.close_file(fd).unwrap()
     };

--- a/kernel/src/syscall/connect.rs
+++ b/kernel/src/syscall/connect.rs
@@ -16,7 +16,7 @@ pub fn sys_connect(
     let socket_addr = read_socket_addr_from_user(sockaddr_ptr, addr_len as _)?;
     debug!("fd = {sockfd}, socket_addr = {socket_addr:?}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -54,8 +54,8 @@ pub fn sys_eventfd2(init_val: u64, flags: u32, ctx: &Context) -> Result<SyscallR
 fn do_sys_eventfd2(init_val: u64, flags: Flags, ctx: &Context) -> FileDesc {
     let event_file = EventFile::new(init_val, flags);
     let fd = {
-        let file_table = ctx.thread_local.file_table().borrow();
-        let mut file_table_locked = file_table.write();
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
         let fd_flags = if flags.contains(Flags::EFD_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -62,7 +62,7 @@ fn lookup_executable_file(
     ctx: &Context,
 ) -> Result<Dentry> {
     let dentry = if flags.contains(OpenFlags::AT_EMPTY_PATH) && filename.is_empty() {
-        let mut file_table = ctx.thread_local.file_table().borrow_mut();
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
         let file = get_file_fast!(&mut file_table, dfd);
         file.as_inode_or_err()?.dentry().clone()
     } else {
@@ -111,8 +111,8 @@ fn do_execve(
     // Ensure that the file descriptors with the close-on-exec flag are closed.
     // FIXME: This is just wrong if the file table is shared with other processes.
     let closed_files = thread_local
-        .file_table()
-        .borrow()
+        .borrow_file_table()
+        .unwrap()
         .write()
         .close_files_on_exec();
     drop(closed_files);

--- a/kernel/src/syscall/fallocate.rs
+++ b/kernel/src/syscall/fallocate.rs
@@ -24,7 +24,7 @@ pub fn sys_fallocate(
 
     check_offset_and_len(offset, len, ctx)?;
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let falloc_mode = FallocMode::try_from(

--- a/kernel/src/syscall/flock.rs
+++ b/kernel/src/syscall/flock.rs
@@ -12,7 +12,7 @@ use crate::{
 pub fn sys_flock(fd: FileDesc, ops: i32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("flock: fd: {}, ops: {:?}", fd, ops);
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let inode_file = file.as_inode_or_err()?;
     let ops: FlockOps = FlockOps::from_i32(ops)?;

--- a/kernel/src/syscall/fsync.rs
+++ b/kernel/src/syscall/fsync.rs
@@ -9,7 +9,7 @@ use crate::{
 pub fn sys_fsync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let dentry = file.as_inode_or_err()?.dentry();
     dentry.sync_all()?;
@@ -19,7 +19,7 @@ pub fn sys_fsync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 pub fn sys_fdatasync(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}", fd);
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let dentry = file.as_inode_or_err()?.dentry();
     dentry.sync_data()?;

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -22,7 +22,7 @@ pub fn sys_getdents(
         fd, buf_addr, buf_len
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let inode_handle = file.as_inode_or_err()?;
     if inode_handle.dentry().type_() != InodeType::Dir {
@@ -48,7 +48,7 @@ pub fn sys_getdents64(
         fd, buf_addr, buf_len
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let inode_handle = file.as_inode_or_err()?;
     if inode_handle.dentry().type_() != InodeType::Dir {

--- a/kernel/src/syscall/getpeername.rs
+++ b/kernel/src/syscall/getpeername.rs
@@ -15,7 +15,7 @@ pub fn sys_getpeername(
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/getsockname.rs
+++ b/kernel/src/syscall/getsockname.rs
@@ -15,7 +15,7 @@ pub fn sys_getsockname(
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, addr = 0x{addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/getsockopt.rs
+++ b/kernel/src/syscall/getsockopt.rs
@@ -25,7 +25,7 @@ pub fn sys_getsockopt(
 
     debug!("level = {level:?}, sockfd = {sockfd}, optname = {optname:?}, optlen = {optlen}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/getxattr.rs
+++ b/kernel/src/syscall/getxattr.rs
@@ -67,7 +67,7 @@ pub fn sys_fgetxattr(
     value_len: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let user_space = ctx.user_space();

--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -16,7 +16,7 @@ pub fn sys_ioctl(fd: FileDesc, cmd: u32, arg: Vaddr, ctx: &Context) -> Result<Sy
         fd, ioctl_cmd, arg
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let res = match ioctl_cmd {
         IoctlCmd::FIONBIO => {

--- a/kernel/src/syscall/listen.rs
+++ b/kernel/src/syscall/listen.rs
@@ -9,7 +9,7 @@ use crate::{
 pub fn sys_listen(sockfd: FileDesc, backlog: i32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, backlog = {backlog}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/listxattr.rs
+++ b/kernel/src/syscall/listxattr.rs
@@ -60,7 +60,7 @@ pub fn sys_flistxattr(
     list_len: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let user_space = ctx.user_space();

--- a/kernel/src/syscall/lseek.rs
+++ b/kernel/src/syscall/lseek.rs
@@ -23,7 +23,7 @@ pub fn sys_lseek(fd: FileDesc, offset: isize, whence: u32, ctx: &Context) -> Res
         2 => SeekFrom::End(offset),
         _ => return_errno!(Errno::EINVAL),
     };
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let offset = file.seek(seek_from)?;

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -125,7 +125,7 @@ fn do_sys_mmap(
             }
         } else {
             let vmo = {
-                let mut file_table = ctx.thread_local.file_table().borrow_mut();
+                let mut file_table = ctx.thread_local.borrow_file_table_mut();
                 let file = get_file_fast!(&mut file_table, fd);
                 let inode_handle = file.as_inode_or_err()?;
 

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -42,8 +42,8 @@ pub fn sys_openat(
     };
 
     let fd = {
-        let file_table = ctx.thread_local.file_table().borrow();
-        let mut file_table_locked = file_table.write();
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
         let fd_flags =
             if CreationFlags::from_bits_truncate(flags).contains(CreationFlags::O_CLOEXEC) {
                 FdFlags::CLOEXEC

--- a/kernel/src/syscall/pipe.rs
+++ b/kernel/src/syscall/pipe.rs
@@ -21,8 +21,8 @@ pub fn sys_pipe2(fds: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn>
         FdFlags::empty()
     };
 
-    let file_table = ctx.thread_local.file_table().borrow();
-    let mut file_table_locked = file_table.write();
+    let file_table = ctx.thread_local.borrow_file_table();
+    let mut file_table_locked = file_table.unwrap().write();
 
     let pipe_fds = PipeFds {
         reader_fd: file_table_locked.insert(pipe_reader, fd_flags),

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -59,7 +59,8 @@ pub fn sys_poll(fds: Vaddr, nfds: u64, timeout: i32, ctx: &Context) -> Result<Sy
 }
 
 pub fn do_poll(poll_fds: &[PollFd], timeout: Option<&Duration>, ctx: &Context) -> Result<usize> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file_table = file_table.unwrap();
 
     let poll_files = if let Some(file_table_inner) = file_table.get() {
         PollFiles::new_borrowed(poll_fds, file_table_inner)

--- a/kernel/src/syscall/pread64.rs
+++ b/kernel/src/syscall/pread64.rs
@@ -22,7 +22,7 @@ pub fn sys_pread64(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait

--- a/kernel/src/syscall/preadv.rs
+++ b/kernel/src/syscall/preadv.rs
@@ -65,7 +65,7 @@ fn do_sys_preadv(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     if io_vec_count == 0 {
@@ -126,7 +126,7 @@ fn do_sys_readv(
         fd, io_vec_ptr, io_vec_count
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     if io_vec_count == 0 {

--- a/kernel/src/syscall/pwrite64.rs
+++ b/kernel/src/syscall/pwrite64.rs
@@ -22,7 +22,7 @@ pub fn sys_pwrite64(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     // TODO: Check (f.file->f_mode & FMODE_PWRITE); We don't have f_mode in our FileLike trait

--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -66,7 +66,7 @@ fn do_sys_pwritev(
         return_errno_with_message!(Errno::EINVAL, "offset cannot be negative");
     }
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     // TODO: Check (f.file->f_mode & FMODE_PREAD); We don't have f_mode in our FileLike trait
@@ -123,7 +123,7 @@ fn do_sys_writev(
         fd, io_vec_ptr, io_vec_count
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let mut total_len = 0;

--- a/kernel/src/syscall/read.rs
+++ b/kernel/src/syscall/read.rs
@@ -17,7 +17,7 @@ pub fn sys_read(
         fd, user_buf_addr, buf_len
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     // According to <https://man7.org/linux/man-pages/man2/read.2.html>, if

--- a/kernel/src/syscall/recvfrom.rs
+++ b/kernel/src/syscall/recvfrom.rs
@@ -20,7 +20,7 @@ pub fn sys_recvfrom(
     let flags = SendRecvFlags::from_bits_truncate(flags);
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = {len}, flags = {flags:?}, src_addr = 0x{src_addr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -22,7 +22,7 @@ pub fn sys_recvmsg(
         sockfd, c_user_msghdr, flags
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/removexattr.rs
+++ b/kernel/src/syscall/removexattr.rs
@@ -32,7 +32,7 @@ pub fn sys_lremovexattr(path_ptr: Vaddr, name_ptr: Vaddr, ctx: &Context) -> Resu
 }
 
 pub fn sys_fremovexattr(fd: FileDesc, name_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let user_space = ctx.user_space();

--- a/kernel/src/syscall/sendfile.rs
+++ b/kernel/src/syscall/sendfile.rs
@@ -38,8 +38,7 @@ pub fn sys_sendfile(
 
     let (out_file, in_file) = ctx
         .thread_local
-        .file_table()
-        .borrow_mut()
+        .borrow_file_table_mut()
         .read_with(|inner| {
             let out_file = inner.get_file(out_fd)?.clone();
             // FIXME: the in_file must support mmap-like operations (i.e., it cannot be a socket).

--- a/kernel/src/syscall/sendmsg.rs
+++ b/kernel/src/syscall/sendmsg.rs
@@ -22,7 +22,7 @@ pub fn sys_sendmsg(
         sockfd, c_user_msghdr, flags
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/sendto.rs
+++ b/kernel/src/syscall/sendto.rs
@@ -26,7 +26,7 @@ pub fn sys_sendto(
     };
     debug!("sockfd = {sockfd}, buf = 0x{buf:x}, len = 0x{len:x}, flags = {flags:?}, socket_addr = {socket_addr:?}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/setsockopt.rs
+++ b/kernel/src/syscall/setsockopt.rs
@@ -25,7 +25,7 @@ pub fn sys_setsockopt(
         level, sockfd, optname, optlen
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -74,7 +74,7 @@ pub fn sys_fsetxattr(
     flags: i32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let user_space = ctx.user_space();

--- a/kernel/src/syscall/shutdown.rs
+++ b/kernel/src/syscall/shutdown.rs
@@ -11,7 +11,7 @@ pub fn sys_shutdown(sockfd: FileDesc, how: i32, ctx: &Context) -> Result<Syscall
     let shutdown_cmd = SockShutdownCmd::try_from(how)?;
     debug!("sockfd = {sockfd}, cmd = {shutdown_cmd:?}");
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd);
     let socket = file.as_socket_or_err()?;
 

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -94,8 +94,8 @@ fn create_new_signalfd(
 
     register_observer(ctx, &signal_file, mask)?;
 
-    let file_table = ctx.thread_local.file_table().borrow();
-    let fd = file_table.write().insert(signal_file, fd_flags);
+    let file_table = ctx.thread_local.borrow_file_table();
+    let fd = file_table.unwrap().write().insert(signal_file, fd_flags);
     Ok(fd)
 }
 
@@ -105,7 +105,7 @@ fn update_existing_signalfd(
     new_mask: SigMask,
     non_blocking: bool,
 ) -> Result<FileDesc> {
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     let signal_file = file
         .downcast_ref::<SignalFile>()

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -43,8 +43,8 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
         _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported domain"),
     };
     let fd = {
-        let file_table = ctx.thread_local.file_table().borrow();
-        let mut file_table_locked = file_table.write();
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -37,8 +37,8 @@ pub fn sys_socketpair(
     };
 
     let socket_fds = {
-        let file_table = ctx.thread_local.file_table().borrow();
-        let mut file_table_locked = file_table.write();
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
         let fd_flags = if sock_flags.contains(SockFlags::SOCK_CLOEXEC) {
             FdFlags::CLOEXEC
         } else {

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -15,7 +15,7 @@ use crate::{
 pub fn sys_fstat(fd: FileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("fd = {}, stat_buf_addr = 0x{:x}", fd, stat_buf_ptr);
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     let stat = Stat::from(file.metadata());

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -29,7 +29,7 @@ pub fn sys_fstatfs(fd: FileDesc, statfs_buf_ptr: Vaddr, ctx: &Context) -> Result
     debug!("fd = {}, statfs_buf_addr = 0x{:x}", fd, statfs_buf_ptr);
 
     let fs = {
-        let mut file_table = ctx.thread_local.file_table().borrow_mut();
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
         let file = get_file_fast!(&mut file_table, fd);
         file.as_inode_or_err()?.dentry().fs()
     };

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -16,7 +16,7 @@ pub fn sys_ftruncate(fd: FileDesc, len: isize, ctx: &Context) -> Result<SyscallR
 
     check_length(len, ctx)?;
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     file.resize(len as usize)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/write.rs
+++ b/kernel/src/syscall/write.rs
@@ -17,7 +17,7 @@ pub fn sys_write(
         fd, user_buf_ptr, user_buf_len
     );
 
-    let mut file_table = ctx.thread_local.file_table().borrow_mut();
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
     // According to <https://man7.org/linux/man-pages/man2/write.2.html>, if

--- a/test/apps/clone3/clone_files.c
+++ b/test/apps/clone3/clone_files.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../network/test.h"
+
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static char child_stack[4096];
+#define CHILD_STACK_TOP \
+	(child_stack + sizeof(child_stack) / sizeof(child_stack[0]))
+
+static int fd1, fd2;
+
+static int child_close(void *arg)
+{
+	CHECK(close(fd2));
+
+	_exit(0);
+}
+
+FN_TEST(clone_files_and_close)
+{
+	pid_t pid;
+	int status;
+
+	fd1 = TEST_SUCC(open("/dev/null", O_RDONLY));
+	fd2 = TEST_SUCC(open("/dev/null", O_RDONLY));
+
+	pid = TEST_SUCC(clone(&child_close, CHILD_STACK_TOP,
+			      CLONE_FILES | SIGCHLD, NULL, NULL, NULL, NULL));
+
+	TEST_RES(wait(&status),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(close(fd1));
+	TEST_ERRNO(close(fd2), EBADF);
+}
+END_TEST()

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -11,6 +11,7 @@ echo "Start process test......"
 # These test programs are sorted by name.
 tests="
 clone3/clone_exit_signal
+clone3/clone_files
 clone3/clone_no_exit_signal
 clone3/clone_process
 cpu_affinity/cpu_affinity


### PR DESCRIPTION
This follows #1832 to make the file table in `ThreadLocal` and `PosixThread` an `Option<FileTable>` so that the file table can be properly dropped when the process or thread exits.

https://github.com/asterinas/asterinas/blob/3c2c31ceb0af7bfe0f8ec63fd04fbb92e7233b9c/kernel/src/process/exit.rs#L19-L21

This PR looks quite large because it touches so many files, but it's just an API change in `ThreadLocal` and the file table is accessed in so many system calls. The actual changes that need to be reviewed should be quite small.

```rust
impl ThreadLocal {
    pub fn borrow_file_table(&self) -> FileTableRef;

    pub fn borrow_file_table_mut(&self) -> FileTableRefMut;
}

/// An immutable, shared reference to the file table in [`ThreadLocal`].
pub struct FileTableRef<'a>;

impl FileTableRef<'_> {
    /// Unwraps and returns a reference to the file table.
    ///
    /// # Panics
    ///
    /// This method will panic if the thread has exited and the file table has been dropped.
    pub fn unwrap(&self) -> &RwArc<FileTable>;
}

/// A mutable, exclusive reference to the file table in [`ThreadLocal`].
pub struct FileTableRefMut<'a>;

impl FileTableRefMut<'_> {
    /// Unwraps and returns a reference to the file table.
    ///
    /// # Panics
    ///
    /// This method will panic if the thread has exited and the file table has been dropped.
    pub fn unwrap(&mut self) -> &mut RwArc<FileTable>;

    /// Removes the file table and drops it.
    pub(super) fn remove(&mut self);
}
```