### PR TITLE
Optimize the benchmark workflow

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -33,9 +33,14 @@ INITRAMFS_ALL_DIRS := \
 	$(INITRAMFS)/sbin \
 	$(INITRAMFS)/usr/bin \
 	$(INITRAMFS)/usr/local \
-	$(INITRAMFS)/test \
 	$(INITRAMFS)/benchmark \
 	$(INITRAMFS_EMPTY_DIRS)
+
+# Include test as target if BENCHMARK is not set.
+ifeq ($(BENCHMARK), none)
+INITRAMFS_ALL_DIRS += $(INITRAMFS)/test
+endif
+
 SYSCALL_TEST_DIR := $(INITRAMFS)/opt/syscall_test
 
 .PHONY: all

--- a/test/benchmark/common/prepare_host.sh
+++ b/test/benchmark/common/prepare_host.sh
@@ -43,5 +43,5 @@ prepare_libs() {
 prepare_fs() {
     # Disable unsupported ext2 features of Asterinas on Linux to ensure fairness
     mke2fs -F -O ^ext_attr -O ^resize_inode -O ^dir_index ${BENCHMARK_ROOT}/../build/ext2.img
-    make initramfs
+    make initramfs BENCHMARK=${benchmark}
 }


### PR DESCRIPTION
This pull request includes changes to the `test/Makefile` and `test/benchmark/common/prepare_host.sh` files to improve the initialization and preparation processes for benchmarks. 

Improvements to initialization and preparation processes:

* [`test/Makefile`](diffhunk://#diff-740cb5a1689091cb894445e46683c255e39689ccba1c6c63d8a8841c8df8817dL28-R45): Modified the `INITRAMFS_ALL_DIRS` definition to conditionally include the test directory based on the `BENCHMARK` variable. The `apps` is no longer compiled and packed when we do the benchmarks.
* [`test/benchmark/common/prepare_host.sh`](diffhunk://#diff-bb76958e6a2d3a9cb54b58113057b18cd1f338d4a685e3c4258d80bdb0af7523R46-R49): Added a check to ensure the `initramfs.cpio.gz` file does not exist before running the `make initramfs` command.