### PR TITLE
Make TDX accept the same virtio-net parameters as the normal setting

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -47,30 +47,7 @@ supported_archs = ["x86_64"]
 build.features = ["cvm_guest"]
 boot.method = "grub-qcow2"
 grub.boot_protocol = "linux"
-qemu.args = """\
-    -name process=tdxvm,debug-threads=on \
-    -m ${MEM:-8G} \
-    -smp ${SMP:-1} \
-    -vga none \
-    -nographic \
-    -monitor pty \
-    -no-hpet \
-    -nodefaults \
-    -bios /usr/share/qemu/OVMF.fd \
-    -object tdx-guest,sept-ve-disable=on,id=tdx,quote-generation-service=vsock:2:4050 \
-    -cpu host,-kvm-steal-time,pmu=off \
-    -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=ram1 \
-    -object memory-backend-memfd-private,id=ram1,size=${MEM:-8G} \
-    -device virtio-net-pci,netdev=mynet0 \
-    -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off \
-    -netdev user,id=mynet0,hostfwd=tcp::10027-:22 \
-    -chardev stdio,id=mux,mux=on,logfile=qemu.log \
-    -device virtio-serial,romfile= \
-    -device virtconsole,chardev=mux \
-    -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
-    -monitor chardev:mux \
-    -serial chardev:mux \
-"""
+qemu.args = "$(./tools/qemu_args.sh tdx)"
 
 [scheme."riscv"]
 boot.method = "qemu-direct"


### PR DESCRIPTION
Fixes #2009.

This PR moves TDX settings from `OSDK.toml` to `tools/qemu_args.sh` so TDX can accept the same virtio-net parameters as the normal setting