### PR TITLE
Add support for `Rcu` to store an `Either`

### DIFF
--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -43,7 +43,7 @@ pub mod task;
 pub mod timer;
 pub mod trap;
 pub mod user;
-pub(crate) mod util;
+pub mod util;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{marker::PhantomData, ptr::NonNull};
+
+use super::NonNullPtr;
+use crate::util::Either;
+
+// If both `L` and `R` have at least one alignment bit (i.e., their alignments are at least 2), we
+// can use the alignment bit to indicate whether a pointer is `L` or `R`, so it's possible to
+// implement `NonNullPtr` for `Either<L, R>`.
+unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
+    type Target = PhantomData<Self>;
+
+    type Ref<'a>
+        = Either<L::Ref<'a>, R::Ref<'a>>
+    where
+        Self: 'a;
+
+    const ALIGN_BITS: u32 = min(L::ALIGN_BITS, R::ALIGN_BITS)
+        .checked_sub(1)
+        .expect("`L` and `R` alignments should be at least 2 to pack `Either` into one pointer");
+
+    fn into_raw(self) -> NonNull<Self::Target> {
+        match self {
+            Self::Left(left) => left.into_raw().cast(),
+            Self::Right(right) => right
+                .into_raw()
+                .map_addr(|addr| addr | (1 << Self::ALIGN_BITS))
+                .cast(),
+        }
+    }
+
+    unsafe fn from_raw(ptr: NonNull<Self::Target>) -> Self {
+        // SAFETY: The caller ensures that the pointer comes from `Self::into_raw`, which
+        // guarantees that `real_ptr` is a non-null pointer.
+        let (is_right, real_ptr) = unsafe { remove_bits(ptr, 1 << Self::ALIGN_BITS) };
+
+        if is_right == 0 {
+            // SAFETY: `Self::into_raw` guarantees that `real_ptr` comes from `L::into_raw`. Other
+            // safety requirements are upheld by the caller.
+            Either::Left(unsafe { L::from_raw(real_ptr.cast()) })
+        } else {
+            // SAFETY: `Self::into_raw` guarantees that `real_ptr` comes from `R::into_raw`. Other
+            // safety requirements are upheld by the caller.
+            Either::Right(unsafe { R::from_raw(real_ptr.cast()) })
+        }
+    }
+
+    unsafe fn raw_as_ref<'a>(raw: NonNull<Self::Target>) -> Self::Ref<'a> {
+        // SAFETY: The caller ensures that the pointer comes from `Self::into_raw`, which
+        // guarantees that `real_ptr` is a non-null pointer.
+        let (is_right, real_ptr) = unsafe { remove_bits(raw, 1 << Self::ALIGN_BITS) };
+
+        if is_right == 0 {
+            // SAFETY: `Self::into_raw` guarantees that `real_ptr` comes from `L::into_raw`. Other
+            // safety requirements are upheld by the caller.
+            Either::Left(unsafe { L::raw_as_ref(real_ptr.cast()) })
+        } else {
+            // SAFETY: `Self::into_raw` guarantees that `real_ptr` comes from `R::into_raw`. Other
+            // safety requirements are upheld by the caller.
+            Either::Right(unsafe { R::raw_as_ref(real_ptr.cast()) })
+        }
+    }
+
+    fn ref_as_raw(ptr_ref: Self::Ref<'_>) -> NonNull<Self::Target> {
+        match ptr_ref {
+            Either::Left(left) => L::ref_as_raw(left).cast(),
+            Either::Right(right) => R::ref_as_raw(right)
+                .map_addr(|addr| addr | (1 << Self::ALIGN_BITS))
+                .cast(),
+        }
+    }
+}
+
+// A `min` implementation for use in constant evaluation.
+const fn min(a: u32, b: u32) -> u32 {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+/// # Safety
+///
+/// The caller must ensure that removing the bits from the non-null pointer will result in another
+/// non-null pointer.
+unsafe fn remove_bits<T>(ptr: NonNull<T>, bits: usize) -> (usize, NonNull<T>) {
+    use core::num::NonZeroUsize;
+
+    let removed_bits = ptr.addr().get() & bits;
+    let result_ptr = ptr.map_addr(|addr|
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { NonZeroUsize::new_unchecked(addr.get() & !bits) });
+
+    (removed_bits, result_ptr)
+}
+
+#[cfg(ktest)]
+mod test {
+    use alloc::{boxed::Box, sync::Arc};
+
+    use super::*;
+    use crate::{prelude::ktest, sync::RcuOption};
+
+    type Either32 = Either<Arc<u32>, Box<u32>>;
+    type Either16 = Either<Arc<u32>, Box<u16>>;
+
+    #[ktest]
+    fn alignment() {
+        assert_eq!(<Either32 as NonNullPtr>::ALIGN_BITS, 1);
+        assert_eq!(<Either16 as NonNullPtr>::ALIGN_BITS, 0);
+    }
+
+    #[ktest]
+    fn left_pointer() {
+        let val: Either16 = Either::Left(Arc::new(123));
+
+        let ptr = NonNullPtr::into_raw(val);
+        assert_eq!(ptr.addr().get() & 1, 0);
+
+        let ref_ = unsafe { <Either16 as NonNullPtr>::raw_as_ref(ptr) };
+        assert!(matches!(ref_, Either::Left(ref r) if ***r == 123));
+
+        let ptr2 = <Either16 as NonNullPtr>::ref_as_raw(ref_);
+        assert_eq!(ptr, ptr2);
+
+        let val = unsafe { <Either16 as NonNullPtr>::from_raw(ptr) };
+        assert!(matches!(val, Either::Left(ref r) if **r == 123));
+        drop(val);
+    }
+
+    #[ktest]
+    fn right_pointer() {
+        let val: Either16 = Either::Right(Box::new(456));
+
+        let ptr = NonNullPtr::into_raw(val);
+        assert_eq!(ptr.addr().get() & 1, 1);
+
+        let ref_ = unsafe { <Either16 as NonNullPtr>::raw_as_ref(ptr) };
+        assert!(matches!(ref_, Either::Right(ref r) if ***r == 456));
+
+        let ptr2 = <Either16 as NonNullPtr>::ref_as_raw(ref_);
+        assert_eq!(ptr, ptr2);
+
+        let val = unsafe { <Either16 as NonNullPtr>::from_raw(ptr) };
+        assert!(matches!(val, Either::Right(ref r) if **r == 456));
+        drop(val);
+    }
+
+    #[ktest]
+    fn rcu_store_load() {
+        let rcu: RcuOption<Either32> = RcuOption::new_none();
+        assert!(rcu.read().get().is_none());
+
+        rcu.update(Some(Either::Left(Arc::new(888))));
+        assert!(matches!(rcu.read().get().unwrap(), Either::Left(r) if **r == 888));
+
+        rcu.update(Some(Either::Right(Box::new(999))));
+        assert!(matches!(rcu.read().get().unwrap(), Either::Right(r) if **r == 999));
+    }
+}

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 /// raw pointers.
 ///
 /// [`Rcu`]: super::Rcu
-pub unsafe trait NonNullPtr: Send + 'static {
+pub unsafe trait NonNullPtr: 'static {
     /// The target type that this pointer refers to.
     // TODO: Support `Target: ?Sized`.
     type Target;
@@ -102,7 +102,7 @@ impl<'a, T> BoxRef<'a, T> {
     }
 }
 
-unsafe impl<T: Send + 'static> NonNullPtr for Box<T> {
+unsafe impl<T: 'static> NonNullPtr for Box<T> {
     type Target = T;
 
     type Ref<'a>
@@ -164,7 +164,7 @@ impl<'a, T> ArcRef<'a, T> {
     }
 }
 
-unsafe impl<T: Send + Sync + 'static> NonNullPtr for Arc<T> {
+unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     type Target = T;
 
     type Ref<'a>
@@ -218,7 +218,7 @@ impl<T> Deref for WeakRef<'_, T> {
     }
 }
 
-unsafe impl<T: Send + Sync + 'static> NonNullPtr for Weak<T> {
+unsafe impl<T: 'static> NonNullPtr for Weak<T> {
     type Target = T;
 
     type Ref<'a>

--- a/ostd/src/util/either.rs
+++ b/ostd/src/util/either.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// A type containing either a [`Left`] value `L` or a [`Right`] value `R`.
+///
+/// [`Left`]: Self::Left
+/// [`Right`]: Self::Right
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Either<L, R> {
+    /// Contains the left value
+    Left(L),
+    /// Contains the right value
+    Right(R),
+}
+
+impl<L, R> Either<L, R> {
+    /// Converts to the left value, if any.
+    pub fn left(self) -> Option<L> {
+        match self {
+            Self::Left(left) => Some(left),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Converts to the right value, if any.
+    pub fn right(self) -> Option<R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(right) => Some(right),
+        }
+    }
+
+    /// Returns true if the left value is present.
+    pub fn is_left(&self) -> bool {
+        matches!(self, Self::Left(_))
+    }
+
+    /// Returns true if the right value is present.
+    pub fn is_right(&self) -> bool {
+        matches!(self, Self::Right(_))
+    }
+
+    // TODO: Add other utility methods (e.g. `as_ref`, `as_mut`) as needed.
+    // As a good reference, check what methods `Result` provides.
+}

--- a/ostd/src/util/mod.rs
+++ b/ostd/src/util/mod.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! Utility types and methods.
+
+mod either;
 mod macros;
-pub mod marker;
-pub mod ops;
-pub mod range_alloc;
+pub(crate) mod marker;
+pub(crate) mod ops;
+pub(crate) mod range_alloc;
+
+pub use either::Either;


### PR DESCRIPTION
This allows RCU to store an `Either` type, provided that both `L` and `R` are `NonNullPtr` and the alignments of `L` and `R` are both greater than or equal to `2`.

```rust
pub enum Either<L, R> {
    Left(L),
    Right(R),
}
```

This is done by tracking the number of the alignment bits in `NonNullPtr` so that the following trait implementation is possible:
```rust
unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
    const ALIGN_BITS: u32 = min(L::ALIGN_BITS, R::ALIGN_BITS).checked_sub(1).unwrap();
    // ..
}
```

In the future, we can also add the following trait implementation to allow RCU to store a pointer with some tags, provided the tags can be stored in the alignment bits:
```rust
unsafe impl<const BITS: u32, T: NonNullPtr> NonNullPtr for (T, Tag<BITS>) {
    const ALIGN_BITS: u32 = T::ALIGN_BITS.checked_sub(BITS).unwrap();
    // ..
}
```

Based on this PR, #1976 can implement `XArray` completely outside of OSTD. @cchanging should have verified this, leaving only a minor issue which I assume is eventually fixable (see #1976 for details).

I don't know where to define the `Either` type. It is currently exposed via `ostd::utils::Either`, so I will make `ostd::utils` public and make all its submodules `pub(crate)`.

The third commit `` Remove `Send` trait bound from `NonNullPtr` `` is added because otherwise the `XArray` will fail to compile due to (see [the example code in the playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=11e538dd201d44ff074f2585b0686979)):
```
   Compiling playground v0.0.1 (/playground)
error[E0275]: overflow evaluating the requirement `RcuInner<std::sync::Weak<XNode<P>>>: Send`
  --> src/lib.rs:18:13
   |
18 |     parent: RcuInner<Weak<XNode<P>>>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: required because it appears within the type `XNode<P>`
  --> src/lib.rs:17:8
   |
17 | struct XNode<P: NonNullPtr + Sync> {
   |        ^^^^^
note: required for `std::sync::Weak<XNode<P>>` to implement `NonNullPtr`
  --> src/lib.rs:6:39
   |
6  | unsafe impl<T: Send + Sync + 'static> NonNullPtr for Weak<T> {}
   |                ----                   ^^^^^^^^^^     ^^^^^^^
   |                |
   |                unsatisfied trait bound introduced here
note: required by a bound in `RcuInner`
  --> src/lib.rs:8:20
   |
8  | struct RcuInner<P: NonNullPtr> {
   |                    ^^^^^^^^^^ required by this bound in `RcuInner`

For more information about this error, try `rustc --explain E0275`.
error: could not compile `playground` (lib) due to 1 previous error
```