### PR TITLE
Stop sharing kernel boot PDPTs and linear boot PDPTs

### DIFF
--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -56,7 +56,7 @@ __linux64_boot:
 
     // Set up the page table and load it.
     call page_table_setup_64
-    lea rdx, [rip + boot_pml4]
+    lea rdx, [rip + boot_l4pt]
     mov cr3, rdx
 
     // Prepare far return. The default operation size of
@@ -126,7 +126,7 @@ protected_mode:
     mov cr4, eax
 
     // Set the page table address.
-    lea eax, [boot_pml4]
+    lea eax, [boot_l4pt]
     mov cr3, eax
 
     // Enable long mode.
@@ -163,78 +163,77 @@ PTE_WRITE       = (1 << 1)
 PTE_HUGE        = (1 << 7)
 PTE_GLOBAL      = (1 << 8)
 
-    // PML4: 0x00000000_00000000 ~ 0x00000000_3fffffff
+    // L4PT: 0x00000000_00000000 ~ 0x00000000_3fffffff
     //       0x00000000_40000000 ~ 0x00000000_7fffffff
     //       0x00000000_80000000 ~ 0x00000000_bfffffff
     //       0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pml4]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_l4pt]
+    lea eax, [boot_l3pt_linear_id + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PML4: 0xffff8000_00000000 ~ 0xffff8000_3fffffff
+    // L4PT: 0xffff8000_00000000 ~ 0xffff8000_3fffffff
     //       0xffff8000_40000000 ~ 0xffff8000_7fffffff
     //       0xffff8000_80000000 ~ 0xffff8000_bfffffff
     //       0xffff8000_c0000000 ~ 0xffff8000_ffffffff
-    //       0xffff8008_00000000 ~ 0xffff8008_3fffffff
-    lea edi, [boot_pml4 + 0x100 * 8]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_l4pt + 0x100 * 8]
+    lea eax, [boot_l3pt_linear_id + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PML4: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
+    // L4PT: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
     //       0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pml4 + 0x1ff * 8]
-    lea eax, [boot_pdpt + (PTE_PRESENT | PTE_WRITE)]
+    lea edi, [boot_l4pt + 0x1ff * 8]
+    lea eax, [boot_l3pt_kernel + (PTE_PRESENT | PTE_WRITE)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0x00000000_00000000 ~ 0x00000000_3fffffff
-    lea edi, [boot_pdpt]
-    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0x00000000_00000000 ~ 0x00000000_3fffffff
+    lea edi, [boot_l3pt_linear_id]
+    lea eax, [boot_l2pt_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0x00000000_40000000 ~ 0x00000000_7fffffff
-    lea edi, [boot_pdpt + 0x1 * 8]
-    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0x00000000_40000000 ~ 0x00000000_7fffffff
+    lea edi, [boot_l3pt_linear_id + 0x1 * 8]
+    lea eax, [boot_l2pt_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0x00000000_80000000 ~ 0x00000000_bfffffff
-    lea edi, [boot_pdpt + 0x2 * 8]
-    lea eax, [boot_pd_2g_3g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0x00000000_80000000 ~ 0x00000000_bfffffff
+    lea edi, [boot_l3pt_linear_id + 0x2 * 8]
+    lea eax, [boot_l2pt_2g_3g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0x00000000_c0000000 ~ 0x00000000_ffffffff
-    lea edi, [boot_pdpt + 0x3 * 8]
-    lea eax, [boot_pd_3g_4g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0x00000000_c0000000 ~ 0x00000000_ffffffff
+    lea edi, [boot_l3pt_linear_id + 0x3 * 8]
+    lea eax, [boot_l2pt_3g_4g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
-    lea edi, [boot_pdpt + 0x1fe * 8]
-    lea eax, [boot_pd_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0xffffffff_80000000 ~ 0xffffffff_bfffffff
+    lea edi, [boot_l3pt_kernel + 0x1fe * 8]
+    lea eax, [boot_l2pt_0g_1g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // PDPT: 0xffffffff_c0000000 ~ 0xffffffff_ffffffff
-    lea edi, [boot_pdpt + 0x1ff * 8]
-    lea eax, [boot_pd_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
+    // L3PT: 0xffffffff_c0000000 ~ 0xffffffff_ffffffff
+    lea edi, [boot_l3pt_kernel + 0x1ff * 8]
+    lea eax, [boot_l2pt_1g_2g + (PTE_PRESENT | PTE_WRITE | PTE_GLOBAL)]
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
-    // Page Directory: map to low 1 GiB * 4 space
-    lea edi, [boot_pd]
+    // L2PT: map to low 1 GiB * 4 space
+    lea edi, [boot_l2pt]
     mov eax, PTE_PRESENT | PTE_WRITE | PTE_GLOBAL | PTE_HUGE
     mov ecx, 512 * 4 // (of entries in PD) * (number of PD)
-write_pd_entry_\bits:
+write_l2pt_entry_\bits:
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
     add eax, 0x200000 // +2MiB
     add edi, 8
-    loop write_pd_entry_\bits
+    loop write_l2pt_entry_\bits
 
     ret
 .endm
@@ -263,18 +262,26 @@ gdt_end:
 
 .global boot_page_table_start
 boot_page_table_start:
-boot_pml4:
+boot_l4pt:
     .skip 4096
-boot_pdpt:
+// This L3PT is used for both identity mapping and linear mapping. Four lower
+// entries point to `boot_l2pt`s so that it maps to low 4G physical memory.
+boot_l3pt_linear_id:
     .skip 4096
-boot_pd:
-boot_pd_0g_1g:
+// This L3PT is used for kernel mapping, which is at highest 2G space. Two
+// higher entries point to `boot_l2pt`s so it maps to low 2G physical memory.
+boot_l3pt_kernel:
     .skip 4096
-boot_pd_1g_2g:
+// These L2PTs are used for identity mapping, linear mapping and kernel mapping.
+// They map to low 4G physical memory in 2MB huge pages.
+boot_l2pt:
+boot_l2pt_0g_1g:
     .skip 4096
-boot_pd_2g_3g:
+boot_l2pt_1g_2g:
     .skip 4096
-boot_pd_3g_4g:
+boot_l2pt_2g_3g:
+    .skip 4096
+boot_l2pt_3g_4g:
     .skip 4096
 boot_page_table_end:
 


### PR DESCRIPTION
I was being too clever. Don't be clever.

In the boot page table, originally, all the identity mapping (`0x0->0x0`), linear mapping (`0xffff8000_00000000->0x0`), and kernel mapping (`0xfffffff8_00000000->0x0`) share the same level-3 page table page. So that it can save some memory.

In order to make it work, the L3 PT entries at index 0, 1, 2, 3, 510, and 511 are written, so they respectively match the mapping purposes (identity mapping and linear mapping need 0, 1, 2, 3, while kernel mapping needs 510 and 511).

The result is that, the addresses `0xffff807f_80000000` and `0x000007f_80000000` are unexpectedly mapped to `0x0`! (the reason is left as your exercise :) ). `7f_80000000` happens to be 510G. The direct result is that we fail to boot machines with > 510G memory. Another implication is that it may lead to the kernel surprisingly reading the 0x0 page when accessing the 510G linear mapping, in the boot phase.

This PR fixes it and allows booting with > 510G memory.
