### PR TITLE
Avoid excessive heap allocations in `sys_futex`

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(btree_extract_if)]
 #![feature(debug_closure_helpers)]
 #![feature(extend_one)]
+#![feature(extract_if)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(int_roundings)]


### PR DESCRIPTION
This PR just removes the need of extra`Arc`s and `Box`es when doing futexes. Also, changes the futex bucket locks to be spinlocks, the same as Linux's. The critical section isn't long.

It introduces the `extract_if` Rust feature for better code. I am looking forward to feedback if anyone isn't pleased about introducing new unstable features. If not using `extract_if`, we may need to clone `FutexItem`s (which contains `Arc`s), or wrap the items with `Option`s, or continue to use the linked list instead of `Vec`.