### PR TITLE
Remove `read*_to_end` methods

### DIFF
--- a/kernel/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/src/fs/inode_handle/dyn_cap.rs
@@ -47,14 +47,6 @@ impl InodeHandle<Rights> {
         Ok(InodeHandle(self.0.clone(), R1::new()))
     }
 
-    pub fn read_to_end(&self, buf: &mut Vec<u8>) -> Result<usize> {
-        if !self.1.contains(Rights::READ) {
-            return_errno_with_message!(Errno::EBADF, "file is not readable");
-        }
-
-        self.0.read_to_end(buf)
-    }
-
     pub fn readdir(&self, visitor: &mut dyn DirentVisitor) -> Result<usize> {
         if !self.1.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "file is not readable");

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -113,19 +113,6 @@ impl InodeHandle_ {
         }
     }
 
-    pub fn read_to_end(&self, buf: &mut Vec<u8>) -> Result<usize> {
-        if self.file_io.is_some() {
-            return_errno_with_message!(Errno::EINVAL, "file io does not support read to end");
-        }
-
-        let len = if self.status_flags().contains(StatusFlags::O_DIRECT) {
-            self.dentry.inode().read_direct_to_end(buf)?
-        } else {
-            self.dentry.inode().read_to_end(buf)?
-        };
-        Ok(len)
-    }
-
     pub fn seek(&self, pos: SeekFrom) -> Result<usize> {
         let mut offset = self.offset.lock();
         let new_offset: isize = match pos {

--- a/kernel/src/fs/inode_handle/static_cap.rs
+++ b/kernel/src/fs/inode_handle/static_cap.rs
@@ -12,11 +12,6 @@ impl<R: TRights> InodeHandle<TRightSet<R>> {
         self.0.read(writer)
     }
 
-    #[require(R > Read)]
-    pub fn read_to_end(&self, buf: &mut Vec<u8>) -> Result<usize> {
-        self.0.read_to_end(buf)
-    }
-
     #[require(R > Write)]
     pub fn write(&self, reader: &mut VmReader) -> Result<usize> {
         self.0.write(reader)

--- a/kernel/src/fs/utils/inode.rs
+++ b/kernel/src/fs/utils/inode.rs
@@ -569,34 +569,6 @@ impl dyn Inode {
         (self as &dyn Any).downcast_ref::<T>()
     }
 
-    pub fn read_to_end(&self, buf: &mut Vec<u8>) -> Result<usize> {
-        if !self.type_().support_read() {
-            return_errno!(Errno::EISDIR);
-        }
-
-        let file_size = self.size();
-        if buf.len() < file_size {
-            buf.resize(file_size, 0);
-        }
-
-        let mut writer = VmWriter::from(&mut buf[..file_size]).to_fallible();
-        self.read_at(0, &mut writer)
-    }
-
-    pub fn read_direct_to_end(&self, buf: &mut Vec<u8>) -> Result<usize> {
-        if !self.type_().support_read() {
-            return_errno!(Errno::EISDIR);
-        }
-
-        let file_size = self.size();
-        if buf.len() < file_size {
-            buf.resize(file_size, 0);
-        }
-
-        let mut writer = VmWriter::from(&mut buf[..file_size]).to_fallible();
-        self.read_direct_at(0, &mut writer)
-    }
-
     pub fn writer(&self, from_offset: usize) -> InodeWriter {
         InodeWriter {
             inner: self,


### PR DESCRIPTION
These methods have a number of problems:
 - `file.size()` can be uncontrollably large. We should never allocate a buffer according to `file.size()` without first checking that `file.size()` is a reasonable value. Otherwise, the kernel may panic due to insufficient memory.
 - There may be race conditions between checking `file.size()` and reading the file. The result of the `read*_to_end` methods may be wrong if race conditions occur.

I cannot figure out when the kernel should use such a method, not to mention that the implementation also suffers from race conditions, so it's wrong. Fortunately, these methods have no existing users, so I suggest just removing them.