### PR TITLE
Rewrite `trap/gdt.rs` and `trap/idt.rs`

### DIFF
--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -23,13 +23,11 @@ pub(crate) fn init_cvm_guest() {
 }
 
 pub(crate) unsafe fn late_init_on_bsp() {
-    // SAFETY: this function is only called once on BSP.
-    unsafe {
-        trap::init(true);
-    }
+    // SAFETY: This function is only called once on BSP.
+    unsafe { trap::init(true) };
     irq::init();
 
-    // SAFETY: we're on the BSP and we're ready to boot all APs.
+    // SAFETY: We're on the BSP and we're ready to boot all APs.
     unsafe { crate::boot::smp::boot_all_aps() };
 
     timer::init();

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -23,8 +23,8 @@ pub(crate) fn init_cvm_guest() {
 }
 
 pub(crate) unsafe fn late_init_on_bsp() {
-    // SAFETY: This function is only called once on BSP.
-    unsafe { trap::init(true) };
+    // SAFETY: This function is called in the boot context of the BSP.
+    unsafe { trap::init() };
     irq::init();
 
     // SAFETY: We're on the BSP and we're ready to boot all APs.

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -15,7 +15,7 @@ cpu_local_cell! {
 }
 
 /// Initialize interrupt handling on RISC-V.
-pub unsafe fn init(_on_bsp: bool) {
+pub unsafe fn init() {
     self::trap::init();
 }
 

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -251,10 +251,10 @@ boot_gdtr:
 
 .align 16
 gdt:
-    .quad 0x0000000000000000 // 0:  null descriptor
-    .quad 0x00af9a000000ffff // 8:  64-bit code segment (kernel)
-    .quad 0x00cf92000000ffff // 16: 64-bit data segment (kernel)
-    .quad 0x00cf9a000000ffff // 24: 32-bit code segment (kernel)
+    .quad 0          // 0:  null descriptor
+    .quad {KCODE64}  // 8:  code segment (kernel, 64-bit)
+    .quad {KDATA}    // 16: data segment (kernel)
+    .quad {KCODE32}  // 24: code segment (kernel, 32-bit)
 gdt_end:
 
 // The page tables and the stack

--- a/ostd/src/arch/x86/boot/mod.rs
+++ b/ostd/src/arch/x86/boot/mod.rs
@@ -26,5 +26,10 @@ pub mod smp;
 
 use core::arch::global_asm;
 
-global_asm!(include_str!("bsp_boot.S"));
+global_asm!(
+    include_str!("bsp_boot.S"),
+    KCODE64 = const super::trap::gdt::KCODE64,
+    KDATA = const super::trap::gdt::KDATA,
+    KCODE32 = const super::trap::gdt::KCODE32,
+);
 global_asm!(include_str!("ap_boot.S"));

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -62,10 +62,11 @@ static CPU_FEATURES: Once<FeatureInfo> = Once::new();
 ///
 /// # Safety
 ///
-/// This function must be called only once on the bootstrapping processor.
+/// This function must be called only once in the boot context of the
+/// bootstrapping processor.
 pub(crate) unsafe fn late_init_on_bsp() {
     // SAFETY: This function is only called once on BSP.
-    unsafe { trap::init(true) };
+    unsafe { trap::init() };
     irq::init();
 
     kernel::acpi::init();

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -64,10 +64,8 @@ static CPU_FEATURES: Once<FeatureInfo> = Once::new();
 ///
 /// This function must be called only once on the bootstrapping processor.
 pub(crate) unsafe fn late_init_on_bsp() {
-    // SAFETY: this function is only called once on BSP.
-    unsafe {
-        trap::init(true);
-    }
+    // SAFETY: This function is only called once on BSP.
+    unsafe { trap::init(true) };
     irq::init();
 
     kernel::acpi::init();
@@ -87,7 +85,7 @@ pub(crate) unsafe fn late_init_on_bsp() {
     kernel::tsc::init_tsc_freq();
     timer::init_bsp();
 
-    // SAFETY: we're on the BSP and we're ready to boot all APs.
+    // SAFETY: We're on the BSP and we're ready to boot all APs.
     unsafe { crate::boot::smp::boot_all_aps() };
 
     if_tdx_enabled!({
@@ -105,9 +103,7 @@ pub(crate) unsafe fn late_init_on_bsp() {
     // 1. All the system device memory have been removed from the builder.
     // 2. All the port I/O regions belonging to the system device are defined using the macros.
     // 3. `MAX_IO_PORT` defined in `crate::arch::io` is the maximum value specified by x86-64.
-    unsafe {
-        crate::io::init(io_mem_builder);
-    }
+    unsafe { crate::io::init(io_mem_builder) };
 }
 
 /// Architecture-specific initialization on the application processor.

--- a/ostd/src/arch/x86/trap/idt.rs
+++ b/ostd/src/arch/x86/trap/idt.rs
@@ -1,47 +1,66 @@
-// SPDX-License-Identifier: MPL-2.0 OR MIT
-//
-// The original source code is from [trapframe-rs](https://github.com/rcore-os/trapframe-rs),
-// which is released under the following license:
-//
-// SPDX-License-Identifier: MIT
-//
-// Copyright (c) 2020 - 2024 Runji Wang
-//
-// We make the following new changes:
-// * Include `trap.S` in this file and remove unused function `sidt`.
-// * Link `VECTORS` to `trap_handler_table` defined in `trap.S`.
-//
-// These changes are released under the following license:
-//
 // SPDX-License-Identifier: MPL-2.0
 
-//! Configure Interrupt Descriptor Table (GDT).
+//! Configure the Interrupt Descriptor Table (IDT).
 
 use alloc::boxed::Box;
 use core::arch::global_asm;
 
+use spin::Once;
 use x86_64::{
-    structures::idt::{Entry, HandlerFunc, InterruptDescriptorTable},
-    PrivilegeLevel,
+    instructions::tables::lidt,
+    structures::{idt::Entry, DescriptorTablePointer},
+    PrivilegeLevel, VirtAddr,
 };
 
 global_asm!(include_str!("trap.S"));
 
-pub fn init() {
-    extern "C" {
-        #[link_name = "trap_handler_table"]
-        static VECTORS: [HandlerFunc; 256];
-    }
+const NUM_INTERRUPTS: usize = 256;
 
-    let idt = Box::leak(Box::new(InterruptDescriptorTable::new()));
-    let entries: &'static mut [Entry<HandlerFunc>; 256] =
-        unsafe { core::mem::transmute_copy(&idt) };
-    for i in 0..256 {
-        let opt = unsafe { entries[i].set_handler_fn(VECTORS[i]) };
-        // Enable user space `int3` and `into`.
-        if i == 3 || i == 4 {
-            opt.set_privilege_level(PrivilegeLevel::Ring3);
+extern "C" {
+    #[link_name = "trap_handler_table"]
+    static VECTORS: [usize; NUM_INTERRUPTS];
+}
+
+static GLOBAL_IDT: Once<&'static [Entry<()>]> = Once::new();
+
+/// Initializes and loads the IDT.
+///
+/// The caller should only call this method once in the boot context for each available processor.
+/// This is not a safety requirement, however, because calling this method again will do nothing
+/// more than load the same IDT.
+pub(super) fn init() {
+    let idt = *GLOBAL_IDT.call_once(|| {
+        let idt = Box::leak(Box::new([const { Entry::missing() }; NUM_INTERRUPTS]));
+
+        // SAFETY: The vector array is properly initialized, lives for `'static`, and will never be
+        // mutated. So it's always fine to create an immutable borrow to it.
+        let vectors = unsafe { &VECTORS };
+
+        // Initialize the IDT entries.
+        for (intr_no, &handler) in vectors.iter().enumerate() {
+            let handler = VirtAddr::new(handler as u64);
+
+            let entry = &mut idt[intr_no];
+            // SAFETY: The handler defined in `trap.S` has a correct signature to handle the
+            // corresponding exception or interrupt.
+            let opt = unsafe { entry.set_handler_addr(handler) };
+
+            // Enable `int3` and `into` in the userspace.
+            if intr_no == 3 || intr_no == 4 {
+                opt.set_privilege_level(PrivilegeLevel::Ring3);
+            }
         }
-    }
-    idt.load();
+
+        idt
+    });
+
+    let idtr = DescriptorTablePointer {
+        limit: (core::mem::size_of_val(idt) - 1) as u16,
+        base: VirtAddr::new(idt.as_ptr().addr() as u64),
+    };
+    // SAFETY: The IDT is valid to load because:
+    //  - It lives for `'static`.
+    //  - It contains correct entries at correct indexes: all handlers are defined in `trap.S` with
+    //    correct handler signatures.
+    unsafe { lidt(&idtr) };
 }

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -107,7 +107,7 @@ pub struct TrapFrame {
 /// This function will:
 /// - Switch to a new, CPU-local [GDT].
 /// - Switch to a new, CPU-local [TSS].
-/// - Switch to a new, CPU-local [IDT].
+/// - Switch to a new, global [IDT].
 /// - Enable the [`syscall`] instruction.
 ///
 /// [GDT]: https://wiki.osdev.org/GDT

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -123,7 +123,9 @@ pub unsafe fn init() {
     unsafe { gdt::init() };
 
     idt::init();
-    syscall::init();
+
+    // SAFETY: `gdt::init` has been called before.
+    unsafe { syscall::init() };
 }
 
 /// User space context.

--- a/ostd/src/arch/x86/trap/syscall.S
+++ b/ostd/src/arch/x86/trap/syscall.S
@@ -67,10 +67,10 @@ syscall_return:
     je sysret
 iret:
     # construct trap frame
-    push [USER_SS]          # push ss
+    push {USER_SS}          # push ss
     push [rsp - 8*8]        # push rsp
     push [rsp + 3*8]        # push rflags
-    push [USER_CS]          # push cs
+    push {USER_CS}          # push cs
     push [rsp + 4*8]        # push rip
 
     iretq

--- a/ostd/src/arch/x86/trap/syscall.rs
+++ b/ostd/src/arch/x86/trap/syscall.rs
@@ -36,31 +36,46 @@ global_asm!(
     USER_SS = const super::gdt::USER_SS.0,
 );
 
-pub(super) fn init() {
+/// # Safety
+///
+/// The caller needs to ensure that `gdt::init` has been called before, so the segment selectors
+/// used in the `syscall` and `sysret` instructions have been properly initialized.
+pub(super) unsafe fn init() {
     let cpuid = CpuId::new();
+
+    assert!(cpuid
+        .get_extended_processor_and_feature_identifiers()
+        .unwrap()
+        .has_syscall_sysret());
+    assert!(cpuid.get_extended_feature_info().unwrap().has_fsgsbase());
+
+    // Flags to clear on syscall.
+    //
+    // Linux 5.0 uses TF|DF|IF|IOPL|AC|NT. Reference:
+    // <https://github.com/torvalds/linux/blob/v5.0/arch/x86/kernel/cpu/common.c#L1559-L1562>
+    const RFLAGS_MASK: u64 = 0x47700;
+
+    // SAFETY: The segment selectors are correctly initialized (as upheld by the caller), and the
+    // entry point and flags to clear are also correctly set, so enabling the `syscall` and
+    // `sysret` instructions is safe.
     unsafe {
-        // Enable `syscall` instruction.
-        assert!(cpuid
-            .get_extended_processor_and_feature_identifiers()
-            .unwrap()
-            .has_syscall_sysret());
+        LStar::write(VirtAddr::new(syscall_entry as usize as u64));
+        SFMask::write(RFlags::from_bits(RFLAGS_MASK).unwrap());
+
+        // Enable the `syscall` and `sysret` instructions.
         Efer::update(|efer| {
             efer.insert(EferFlags::SYSTEM_CALL_EXTENSIONS);
         });
+    }
 
-        // Enable `FSGSBASE` instructions.
-        assert!(cpuid.get_extended_feature_info().unwrap().has_fsgsbase());
+    // SAFETY: Enabling the `rdfsbase`, `wrfsbase`, `rdgsbase`, and `wrgsbase` instructions is safe
+    // as long as the kernel properly deals with the arbitrary base values set by the userspace
+    // program. (FIXME: Do we really need to unconditionally enable them?)
+    unsafe {
         Cr4::update(|cr4| {
             cr4.insert(Cr4Flags::FSGSBASE);
-        });
-
-        // Flags to clear on syscall.
-        // Copy from Linux 5.0, TF|DF|IF|IOPL|AC|NT
-        const RFLAGS_MASK: u64 = 0x47700;
-
-        LStar::write(VirtAddr::new(syscall_entry as usize as u64));
-        SFMask::write(RFlags::from_bits(RFLAGS_MASK).unwrap());
-    }
+        })
+    };
 }
 
 extern "sysv64" {

--- a/ostd/src/arch/x86/trap/syscall.rs
+++ b/ostd/src/arch/x86/trap/syscall.rs
@@ -30,9 +30,13 @@ use x86_64::{
 
 use super::UserContext;
 
-global_asm!(include_str!("syscall.S"));
+global_asm!(
+    include_str!("syscall.S"),
+    USER_CS = const super::gdt::USER_CS.0,
+    USER_SS = const super::gdt::USER_SS.0,
+);
 
-pub fn init() {
+pub(super) fn init() {
     let cpuid = CpuId::new();
     unsafe {
         // Enable `syscall` instruction.

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -142,29 +142,21 @@ pub fn register_ap_entry(entry: fn()) {
 #[no_mangle]
 fn ap_early_entry(cpu_id: u32) -> ! {
     // SAFETY: `cpu_id` is the correct value of the CPU ID.
-    unsafe {
-        cpu::init_on_ap(cpu_id);
-    }
+    unsafe { cpu::init_on_ap(cpu_id) };
 
     crate::arch::enable_cpu_features();
 
-    // SAFETY: this function is only called once on this AP.
-    unsafe {
-        crate::arch::trap::init(false);
-    }
+    // SAFETY: This function is only called once on this AP.
+    unsafe { crate::arch::trap::init(false) };
 
-    // SAFETY: this function is only called once on this AP, after the BSP has
+    // SAFETY: This function is only called once on this AP, after the BSP has
     // done the architecture-specific initialization.
-    unsafe {
-        crate::arch::init_on_ap();
-    }
+    unsafe { crate::arch::init_on_ap() };
 
     crate::arch::irq::enable_local();
 
-    // SAFETY: this function is only called once on this AP.
-    unsafe {
-        crate::mm::kspace::activate_kernel_page_table();
-    }
+    // SAFETY: This function is only called once on this AP.
+    unsafe { crate::mm::kspace::activate_kernel_page_table() };
 
     // Mark the AP as started.
     let ap_boot_info = AP_BOOT_INFO.get().unwrap();

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -146,8 +146,8 @@ fn ap_early_entry(cpu_id: u32) -> ! {
 
     crate::arch::enable_cpu_features();
 
-    // SAFETY: This function is only called once on this AP.
-    unsafe { crate::arch::trap::init(false) };
+    // SAFETY: This function is called in the boot context of the AP.
+    unsafe { crate::arch::trap::init() };
 
     // SAFETY: This function is only called once on this AP, after the BSP has
     // done the architecture-specific initialization.

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -78,9 +78,8 @@ unsafe fn init() {
 
     // SAFETY: This function is called only once, before `allocator::init`
     // and after memory regions are initialized.
-    unsafe {
-        mm::frame::allocator::init_early_allocator();
-    }
+    unsafe { mm::frame::allocator::init_early_allocator() };
+
     #[cfg(target_arch = "x86_64")]
     arch::if_tdx_enabled!({
     } else {


### PR DESCRIPTION
Part of the work to enable `unsafe_op_in_unsafe_fn` lint.

---

There is some unnecessary unsafe code in `trap/gdt.rs`.

For example, `USER_CS` and `USER_SS` can be set by multiple processors at the same time. I cannot write proper safety comments to justify why there are no data races:
https://github.com/asterinas/asterinas/blob/81b79dacc651c24848407b2774455fbe086d5ec8/ostd/src/arch/x86/trap/gdt.rs#L74-L75

Also, this TSS initialization is unnecessary because the privileged kernel stack is filled with a value just before we return to userspace:
https://github.com/asterinas/asterinas/blob/81b79dacc651c24848407b2774455fbe086d5ec8/ostd/src/arch/x86/trap/gdt.rs#L88

This PR rewrites `trap/gdt.rs` and `trap/idt.rs` to improve the code and properly document each unsafe block of code.

Since this is a complete rewrite for these two files, I have removed the unnecessary copyright headers:
https://github.com/asterinas/asterinas/blob/81b79dacc651c24848407b2774455fbe086d5ec8/ostd/src/arch/x86/trap/gdt.rs#L3-L14