### PR TITLE
Create `net/socket/util/datagram_common.rs`

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -3,11 +3,10 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_bigtcp::wire::IpEndpoint;
-use ostd::sync::PreemptDisabled;
-use takeable::Takeable;
+use unbound::BindOptions;
 
 use self::{bound::BoundDatagram, unbound::UnboundDatagram};
-use super::{common::get_ephemeral_endpoint, UNSPECIFIED_LOCAL_ENDPOINT};
+use super::UNSPECIFIED_LOCAL_ENDPOINT;
 use crate::{
     events::IoEvents,
     match_sock_option_mut,
@@ -15,6 +14,7 @@ use crate::{
         options::{Error as SocketError, SocketOption},
         private::SocketPrivate,
         util::{
+            datagram_common::{select_remote_and_bind, Bound, Inner},
             options::{SetSocketLevelOption, SocketOptionSet},
             send_recv_flags::SendRecvFlags,
             socket_addr::SocketAddr,
@@ -48,146 +48,22 @@ impl OptionSet {
 
 pub struct DatagramSocket {
     // Lock order: `inner` first, `options` second
-    inner: RwLock<Takeable<Inner>, PreemptDisabled>,
+    inner: RwMutex<Inner<UnboundDatagram, BoundDatagram>>,
     options: RwLock<OptionSet>,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
 }
 
-enum Inner {
-    Unbound(UnboundDatagram),
-    Bound(BoundDatagram),
-}
-
-impl Inner {
-    fn bind(
-        self,
-        endpoint: &IpEndpoint,
-        can_reuse: bool,
-        observer: DatagramObserver,
-    ) -> core::result::Result<BoundDatagram, (Error, Self)> {
-        let unbound_datagram = match self {
-            Inner::Unbound(unbound_datagram) => unbound_datagram,
-            Inner::Bound(bound_datagram) => {
-                return Err((
-                    Error::with_message(Errno::EINVAL, "the socket is already bound to an address"),
-                    Inner::Bound(bound_datagram),
-                ));
-            }
-        };
-
-        let bound_datagram = match unbound_datagram.bind(endpoint, can_reuse, observer) {
-            Ok(bound_datagram) => bound_datagram,
-            Err((err, unbound_datagram)) => return Err((err, Inner::Unbound(unbound_datagram))),
-        };
-        Ok(bound_datagram)
-    }
-
-    fn bind_to_ephemeral_endpoint(
-        self,
-        remote_endpoint: &IpEndpoint,
-        observer: DatagramObserver,
-    ) -> core::result::Result<BoundDatagram, (Error, Self)> {
-        if let Inner::Bound(bound_datagram) = self {
-            return Ok(bound_datagram);
-        }
-
-        let endpoint = get_ephemeral_endpoint(remote_endpoint);
-        self.bind(&endpoint, false, observer)
-    }
-}
-
 impl DatagramSocket {
     pub fn new(is_nonblocking: bool) -> Arc<Self> {
         let unbound_datagram = UnboundDatagram::new();
         Arc::new(Self {
-            inner: RwLock::new(Takeable::new(Inner::Unbound(unbound_datagram))),
+            inner: RwMutex::new(Inner::Unbound(unbound_datagram)),
             options: RwLock::new(OptionSet::new()),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
         })
-    }
-
-    fn try_bind_ephemeral(&self, remote_endpoint: &IpEndpoint) -> Result<()> {
-        // Fast path
-        if let Inner::Bound(_) = self.inner.read().as_ref() {
-            return Ok(());
-        }
-
-        // Slow path
-        let mut inner = self.inner.write();
-        inner.borrow_result(|owned_inner| {
-            let bound_datagram = match owned_inner.bind_to_ephemeral_endpoint(
-                remote_endpoint,
-                DatagramObserver::new(self.pollee.clone()),
-            ) {
-                Ok(bound_datagram) => bound_datagram,
-                Err((err, err_inner)) => {
-                    return (err_inner, Err(err));
-                }
-            };
-            (Inner::Bound(bound_datagram), Ok(()))
-        })
-    }
-
-    /// Selects the remote endpoint and binds if the socket is not bound.
-    ///
-    /// The remote endpoint specified in the system call (e.g., `sendto`) argument is preferred,
-    /// otherwise the connected endpoint of the socket is used. If there are no remote endpoints
-    /// available, this method will fail with [`EDESTADDRREQ`].
-    ///
-    /// If the remote endpoint is specified but the socket is not bound, this method will try to
-    /// bind the socket to an ephemeral endpoint.
-    ///
-    /// If the above steps succeed, `op` will be called with the bound socket and the selected
-    /// remote endpoint.
-    ///
-    /// [`EDESTADDRREQ`]: crate::error::Errno::EDESTADDRREQ
-    fn select_remote_and_bind<F, R>(&self, remote: Option<&IpEndpoint>, op: F) -> Result<R>
-    where
-        F: FnOnce(&BoundDatagram, &IpEndpoint) -> Result<R>,
-    {
-        let mut inner = self.inner.read();
-
-        // Not really a loop, since we always break on the first iteration. But we need to use
-        // `loop` here because we want to use `break` later.
-        #[expect(clippy::never_loop)]
-        let bound_datagram = loop {
-            // Fast path: The socket is already bound.
-            if let Inner::Bound(bound_datagram) = inner.as_ref() {
-                break bound_datagram;
-            }
-
-            // Slow path: Try to bind the socket to an ephemeral endpoint.
-            drop(inner);
-            if let Some(remote_endpoint) = remote {
-                self.try_bind_ephemeral(remote_endpoint)?;
-            } else {
-                return_errno_with_message!(
-                    Errno::EDESTADDRREQ,
-                    "the destination address is not specified"
-                );
-            }
-            inner = self.inner.read();
-
-            // Now the socket must be bound.
-            if let Inner::Bound(bound_datagram) = inner.as_ref() {
-                break bound_datagram;
-            }
-            unreachable!("`try_bind_ephemeral` succeeds so the socket cannot be unbound");
-        };
-
-        let remote_endpoint = remote
-            .or_else(|| bound_datagram.remote_endpoint())
-            .ok_or_else(|| {
-                Error::with_message(
-                    Errno::EDESTADDRREQ,
-                    "the destination address is not specified",
-                )
-            })?;
-
-        op(bound_datagram, remote_endpoint)
     }
 
     fn try_recv(
@@ -195,13 +71,9 @@ impl DatagramSocket {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, SocketAddr)> {
-        let inner = self.inner.read();
-
-        let Inner::Bound(bound_datagram) = inner.as_ref() else {
-            return_errno_with_message!(Errno::EAGAIN, "the socket is not bound");
-        };
-
-        let recv_bytes = bound_datagram
+        let recv_bytes = self
+            .inner
+            .read()
             .try_recv(writer, flags)
             .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
         self.pollee.invalidate();
@@ -215,33 +87,38 @@ impl DatagramSocket {
         remote: Option<&IpEndpoint>,
         flags: SendRecvFlags,
     ) -> Result<usize> {
-        let (sent_bytes, iface_to_poll) =
-            self.select_remote_and_bind(remote, |bound_datagram, remote_endpoint| {
+        let (sent_bytes, iface_to_poll) = select_remote_and_bind(
+            &self.inner,
+            remote,
+            || {
+                let remote_endpoint = remote.ok_or_else(|| {
+                    Error::with_message(
+                        Errno::EDESTADDRREQ,
+                        "the destination address is not specified",
+                    )
+                })?;
+                self.inner
+                    .write()
+                    .bind_ephemeral(remote_endpoint, &self.pollee)
+            },
+            |bound_datagram, remote_endpoint| {
                 let sent_bytes = bound_datagram.try_send(reader, remote_endpoint, flags)?;
                 let iface_to_poll = bound_datagram.iface().clone();
                 Ok((sent_bytes, iface_to_poll))
-            })?;
+            },
+        )?;
 
         self.pollee.invalidate();
         iface_to_poll.poll();
 
         Ok(sent_bytes)
     }
-
-    fn check_io_events(&self) -> IoEvents {
-        let inner = self.inner.read();
-
-        match inner.as_ref() {
-            Inner::Unbound(unbound_datagram) => unbound_datagram.check_io_events(),
-            Inner::Bound(bound_socket) => bound_socket.check_io_events(),
-        }
-    }
 }
 
 impl Pollable for DatagramSocket {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee
-            .poll_with(mask, poller, || self.check_io_events())
+            .poll_with(mask, poller, || self.inner.read().check_io_events())
     }
 }
 
@@ -258,57 +135,36 @@ impl SocketPrivate for DatagramSocket {
 impl Socket for DatagramSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
         let endpoint = socket_addr.try_into()?;
-
-        let mut inner = self.inner.write();
         let can_reuse = self.options.read().socket.reuse_addr();
-        inner.borrow_result(|owned_inner| {
-            let bound_datagram = match owned_inner.bind(
-                &endpoint,
-                can_reuse,
-                DatagramObserver::new(self.pollee.clone()),
-            ) {
-                Ok(bound_datagram) => bound_datagram,
-                Err((err, err_inner)) => {
-                    return (err_inner, Err(err));
-                }
-            };
-            (Inner::Bound(bound_datagram), Ok(()))
-        })
+
+        self.inner
+            .write()
+            .bind(&endpoint, &self.pollee, BindOptions { can_reuse })
     }
 
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
         let endpoint = socket_addr.try_into()?;
 
-        self.try_bind_ephemeral(&endpoint)?;
-
-        let mut inner = self.inner.write();
-        let Inner::Bound(bound_datagram) = inner.as_mut() else {
-            return_errno_with_message!(Errno::EINVAL, "the socket is not bound")
-        };
-        bound_datagram.set_remote_endpoint(&endpoint);
-
-        Ok(())
+        self.inner.write().connect(&endpoint, &self.pollee)
     }
 
     fn addr(&self) -> Result<SocketAddr> {
-        let inner = self.inner.read();
-        match inner.as_ref() {
-            Inner::Unbound(_) => Ok(UNSPECIFIED_LOCAL_ENDPOINT.into()),
-            Inner::Bound(bound_datagram) => Ok(bound_datagram.local_endpoint().into()),
-        }
+        let endpoint = self
+            .inner
+            .read()
+            .addr()
+            .unwrap_or(UNSPECIFIED_LOCAL_ENDPOINT);
+
+        Ok(endpoint.into())
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
-        let inner = self.inner.read();
+        let endpoint =
+            *self.inner.read().peer_addr().ok_or_else(|| {
+                Error::with_message(Errno::ENOTCONN, "the socket is not connected")
+            })?;
 
-        let remote_endpoint = match inner.as_ref() {
-            Inner::Unbound(_) => None,
-            Inner::Bound(bound_datagram) => bound_datagram.remote_endpoint(),
-        };
-
-        remote_endpoint
-            .map(|endpoint| (*endpoint).into())
-            .ok_or_else(|| Error::with_message(Errno::ENOTCONN, "the socket is not connected"))
+        Ok(endpoint.into())
     }
 
     fn sendmsg(
@@ -378,11 +234,11 @@ impl Socket for DatagramSocket {
         let inner = self.inner.read();
         let mut options = self.options.write();
 
-        match options.socket.set_option(option, inner.as_ref()) {
+        match options.socket.set_option(option, &*inner) {
             Err(e) => Err(e),
             Ok(need_iface_poll) => {
                 let iface_to_poll = need_iface_poll
-                    .then(|| match inner.as_ref() {
+                    .then(|| match &*inner {
                         Inner::Unbound(_) => None,
                         Inner::Bound(bound_datagram) => Some(bound_datagram.iface().clone()),
                     })
@@ -401,4 +257,4 @@ impl Socket for DatagramSocket {
     }
 }
 
-impl SetSocketLevelOption for Inner {}
+impl SetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {}

--- a/kernel/src/net/socket/ip/options.rs
+++ b/kernel/src/net/socket/ip/options.rs
@@ -54,7 +54,7 @@ impl IpOptionSet {
     pub(super) fn set_option(
         &mut self,
         option: &dyn SocketOption,
-        socket: &mut dyn SetIpLevelOption,
+        socket: &dyn SetIpLevelOption,
     ) -> Result<NeedIfacePoll> {
         match_sock_option_ref!(option, {
             ip_tos: Tos => {

--- a/kernel/src/net/socket/netlink/route/mod.rs
+++ b/kernel/src/net/socket/netlink/route/mod.rs
@@ -5,15 +5,16 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use bound::BoundNetlinkRoute;
-use takeable::Takeable;
 use unbound::UnboundNetlinkRoute;
 
 use super::NetlinkSocketAddr;
 use crate::{
     events::IoEvents,
     net::socket::{
-        options::SocketOption, private::SocketPrivate, MessageHeader, SendRecvFlags, Socket,
-        SocketAddr,
+        options::SocketOption,
+        private::SocketPrivate,
+        util::datagram_common::{select_remote_and_bind, Bound, Inner},
+        MessageHeader, SendRecvFlags, Socket, SocketAddr,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -26,43 +27,20 @@ mod message;
 mod unbound;
 
 pub struct NetlinkRouteSocket {
+    inner: RwMutex<Inner<UnboundNetlinkRoute, BoundNetlinkRoute>>,
+
     is_nonblocking: AtomicBool,
     pollee: Pollee,
-    inner: RwMutex<Takeable<Inner>>,
-}
-
-enum Inner {
-    Unbound(UnboundNetlinkRoute),
-    Bound(BoundNetlinkRoute),
 }
 
 impl NetlinkRouteSocket {
     pub fn new(is_nonblocking: bool) -> Self {
+        let unbound = UnboundNetlinkRoute::new();
         Self {
+            inner: RwMutex::new(Inner::Unbound(unbound)),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            inner: RwMutex::new(Takeable::new(Inner::Unbound(UnboundNetlinkRoute::new()))),
         }
-    }
-
-    fn try_receive(
-        &self,
-        writer: &mut dyn MultiWrite,
-        flags: SendRecvFlags,
-    ) -> Result<(usize, NetlinkSocketAddr)> {
-        let inner = self.inner.read();
-
-        let bound = match inner.as_ref() {
-            Inner::Unbound(_) => {
-                return_errno_with_message!(Errno::EAGAIN, "the socket is not bound")
-            }
-            Inner::Bound(bound_netlink_route) => bound_netlink_route,
-        };
-
-        let received = bound.try_receive(writer, flags)?;
-        self.pollee.invalidate();
-
-        Ok(received)
     }
 
     fn try_send(
@@ -71,51 +49,72 @@ impl NetlinkRouteSocket {
         remote: Option<&NetlinkSocketAddr>,
         flags: SendRecvFlags,
     ) -> Result<usize> {
-        let inner = self.inner.read();
-
-        let bound = match inner.as_ref() {
-            Inner::Unbound(_) => todo!(),
-            Inner::Bound(bound) => bound,
-        };
-
-        let sent_bytes = bound.try_send(reader, remote, flags)?;
+        let sent_bytes = select_remote_and_bind(
+            &self.inner,
+            remote,
+            || {
+                self.inner
+                    .write()
+                    .bind_ephemeral(&NetlinkSocketAddr::new_unspecified(), &self.pollee)
+            },
+            |bound, remote_endpoint| bound.try_send(reader, remote_endpoint, flags),
+        )?;
         self.pollee.notify(IoEvents::OUT | IoEvents::IN);
 
         Ok(sent_bytes)
     }
 
-    fn check_io_events(&self) -> IoEvents {
-        let inner = self.inner.read();
-        match inner.as_ref() {
-            Inner::Unbound(unbound) => unbound.check_io_events(),
-            Inner::Bound(bound) => bound.check_io_events(),
-        }
+    fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, SocketAddr)> {
+        let recv_bytes = self
+            .inner
+            .read()
+            .try_recv(writer, flags)
+            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
+        self.pollee.invalidate();
+
+        Ok(recv_bytes)
     }
 }
 
 impl Socket for NetlinkRouteSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
-        let SocketAddr::Netlink(netlink_addr) = socket_addr else {
-            return_errno_with_message!(
-                Errno::EAFNOSUPPORT,
-                "the provided address is not netlink address"
-            );
-        };
+        let endpoint = socket_addr.try_into()?;
 
-        let mut inner = self.inner.write();
-        inner.borrow_result(|owned_inner| match owned_inner.bind(&netlink_addr) {
-            Ok(bound_inner) => (bound_inner, Ok(())),
-            Err((err, err_inner)) => (err_inner, Err(err)),
-        })
+        // FIXME: We need to further check the Linux behavior
+        // whether we should return error if the socket is bound.
+        // The socket may call `bind` syscall to join new multicast groups.
+        self.inner.write().bind(&endpoint, &self.pollee, ())
+    }
+
+    fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
+        let endpoint = socket_addr.try_into()?;
+
+        self.inner.write().connect(&endpoint, &self.pollee)
     }
 
     fn addr(&self) -> Result<SocketAddr> {
-        let netlink_addr = match self.inner.read().as_ref() {
-            Inner::Unbound(_) => NetlinkSocketAddr::new_unspecified(),
-            Inner::Bound(bound) => bound.addr(),
-        };
+        let endpoint = self
+            .inner
+            .read()
+            .addr()
+            .unwrap_or(NetlinkSocketAddr::new_unspecified());
 
-        Ok(SocketAddr::Netlink(netlink_addr))
+        Ok(endpoint.into())
+    }
+
+    fn peer_addr(&self) -> Result<SocketAddr> {
+        let endpoint = self
+            .inner
+            .read()
+            .peer_addr()
+            .cloned()
+            .unwrap_or(NetlinkSocketAddr::new_unspecified());
+
+        Ok(endpoint.into())
     }
 
     fn sendmsg(
@@ -148,15 +147,11 @@ impl Socket for NetlinkRouteSocket {
         writers: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, MessageHeader)> {
-        let (received_len, addr) =
-            self.block_on(IoEvents::IN, || self.try_receive(writers, flags))?;
+        let (received_len, addr) = self.block_on(IoEvents::IN, || self.try_recv(writers, flags))?;
 
         // TODO: Receive control message
 
-        let message_header = {
-            let addr = SocketAddr::Netlink(addr);
-            MessageHeader::new(Some(addr), None)
-        };
+        let message_header = MessageHeader::new(Some(addr), None);
 
         Ok((received_len, message_header))
     }
@@ -180,28 +175,6 @@ impl SocketPrivate for NetlinkRouteSocket {
 impl Pollable for NetlinkRouteSocket {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee
-            .poll_with(mask, poller, || self.check_io_events())
-    }
-}
-
-impl Inner {
-    fn bind(self, addr: &NetlinkSocketAddr) -> core::result::Result<Self, (Error, Self)> {
-        let unbound = match self {
-            Inner::Unbound(unbound) => unbound,
-            Inner::Bound(bound) => {
-                // FIXME: We need to further check the Linux behavior
-                // whether we should return error if the socket is bound.
-                // The socket may call `bind` syscall to join new multicast groups.
-                return Err((
-                    Error::with_message(Errno::EINVAL, "the socket is already bound"),
-                    Self::Bound(bound),
-                ));
-            }
-        };
-
-        match unbound.bind(addr) {
-            Ok(bound) => Ok(Self::Bound(bound)),
-            Err((err, unbound)) => Err((err, Self::Unbound(unbound))),
-        }
+            .poll_with(mask, poller, || self.inner.read().check_io_events())
     }
 }

--- a/kernel/src/net/socket/netlink/route/unbound.rs
+++ b/kernel/src/net/socket/netlink/route/unbound.rs
@@ -3,10 +3,12 @@
 use super::bound::BoundNetlinkRoute;
 use crate::{
     events::IoEvents,
-    net::socket::netlink::{
-        table::NETLINK_SOCKET_TABLE, NetlinkSocketAddr, StandardNetlinkProtocol,
+    net::socket::{
+        netlink::{table::NETLINK_SOCKET_TABLE, NetlinkSocketAddr, StandardNetlinkProtocol},
+        util::datagram_common,
     },
     prelude::*,
+    process::signal::Pollee,
 };
 
 pub(super) struct UnboundNetlinkRoute {
@@ -17,19 +19,40 @@ impl UnboundNetlinkRoute {
     pub(super) const fn new() -> Self {
         Self { _private: () }
     }
+}
 
-    pub(super) fn bind(
-        self,
-        addr: &NetlinkSocketAddr,
-    ) -> core::result::Result<BoundNetlinkRoute, (Error, Self)> {
-        let bound_handle = NETLINK_SOCKET_TABLE
-            .bind(StandardNetlinkProtocol::ROUTE as _, addr)
-            .map_err(|err| (err, self))?;
+impl datagram_common::Unbound for UnboundNetlinkRoute {
+    type Endpoint = NetlinkSocketAddr;
+    type BindOptions = ();
+
+    type Bound = BoundNetlinkRoute;
+
+    fn bind(
+        &mut self,
+        endpoint: &Self::Endpoint,
+        _pollee: &Pollee,
+        _options: Self::BindOptions,
+    ) -> Result<BoundNetlinkRoute> {
+        let bound_handle =
+            NETLINK_SOCKET_TABLE.bind(StandardNetlinkProtocol::ROUTE as _, endpoint)?;
 
         Ok(BoundNetlinkRoute::new(bound_handle))
     }
 
-    pub(super) fn check_io_events(&self) -> IoEvents {
+    fn bind_ephemeral(
+        &mut self,
+        _remote_endpoint: &Self::Endpoint,
+        _pollee: &Pollee,
+    ) -> Result<Self::Bound> {
+        let bound_handle = NETLINK_SOCKET_TABLE.bind(
+            StandardNetlinkProtocol::ROUTE as _,
+            &NetlinkSocketAddr::new_unspecified(),
+        )?;
+
+        Ok(BoundNetlinkRoute::new(bound_handle))
+    }
+
+    fn check_io_events(&self) -> IoEvents {
         IoEvents::OUT
     }
 }

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -137,6 +137,10 @@ impl BoundHandle {
         }
     }
 
+    pub(super) const fn port(&self) -> PortNum {
+        self.port
+    }
+
     pub(super) const fn addr(&self) -> NetlinkSocketAddr {
         NetlinkSocketAddr::new(self.port, self.groups)
     }

--- a/kernel/src/net/socket/util/datagram_common.rs
+++ b/kernel/src/net/socket/util/datagram_common.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::RwMutex;
+
+use super::send_recv_flags::SendRecvFlags;
+use crate::{
+    events::IoEvents,
+    process::signal::Pollee,
+    return_errno_with_message,
+    util::{MultiRead, MultiWrite},
+    Errno, Error, Result,
+};
+
+pub trait Unbound {
+    type Endpoint;
+    type BindOptions;
+
+    type Bound;
+
+    fn bind(
+        &mut self,
+        endpoint: &Self::Endpoint,
+        pollee: &Pollee,
+        options: Self::BindOptions,
+    ) -> Result<Self::Bound>;
+    fn bind_ephemeral(
+        &mut self,
+        remote_endpoint: &Self::Endpoint,
+        pollee: &Pollee,
+    ) -> Result<Self::Bound>;
+
+    fn check_io_events(&self) -> IoEvents;
+}
+
+pub trait Bound {
+    type Endpoint;
+
+    fn local_endpoint(&self) -> Self::Endpoint;
+    fn remote_endpoint(&self) -> Option<&Self::Endpoint>;
+    fn set_remote_endpoint(&mut self, endpoint: &Self::Endpoint);
+
+    fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, Self::Endpoint)>;
+    fn try_send(
+        &self,
+        reader: &mut dyn MultiRead,
+        remote: &Self::Endpoint,
+        flags: SendRecvFlags,
+    ) -> Result<usize>;
+
+    fn check_io_events(&self) -> IoEvents;
+}
+
+pub enum Inner<UnboundSocket, BoundSocket> {
+    Unbound(UnboundSocket),
+    Bound(BoundSocket),
+}
+
+impl<UnboundSocket, BoundSocket> Inner<UnboundSocket, BoundSocket>
+where
+    UnboundSocket: Unbound<Endpoint = BoundSocket::Endpoint, Bound = BoundSocket>,
+    BoundSocket: Bound,
+{
+    pub fn bind(
+        &mut self,
+        endpoint: &UnboundSocket::Endpoint,
+        pollee: &Pollee,
+        options: UnboundSocket::BindOptions,
+    ) -> Result<()> {
+        let unbound_datagram = match self {
+            Inner::Unbound(unbound_datagram) => unbound_datagram,
+            Inner::Bound(_) => {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the socket is already bound to an address"
+                )
+            }
+        };
+
+        let bound_datagram = unbound_datagram.bind(endpoint, pollee, options)?;
+        *self = Inner::Bound(bound_datagram);
+
+        Ok(())
+    }
+
+    pub fn bind_ephemeral(
+        &mut self,
+        remote_endpoint: &UnboundSocket::Endpoint,
+        pollee: &Pollee,
+    ) -> Result<()> {
+        let unbound_datagram = match self {
+            Inner::Unbound(unbound_datagram) => unbound_datagram,
+            Inner::Bound(_) => return Ok(()),
+        };
+
+        let bound_datagram = unbound_datagram.bind_ephemeral(remote_endpoint, pollee)?;
+        *self = Inner::Bound(bound_datagram);
+
+        Ok(())
+    }
+
+    pub fn connect(
+        &mut self,
+        remote_endpoint: &UnboundSocket::Endpoint,
+        pollee: &Pollee,
+    ) -> Result<()> {
+        self.bind_ephemeral(remote_endpoint, pollee)?;
+
+        let bound_datagram = match self {
+            Inner::Unbound(_) => {
+                unreachable!(
+                    "`bind_to_ephemeral_endpoint` succeeds so the socket cannot be unbound"
+                );
+            }
+            Inner::Bound(bound_datagram) => bound_datagram,
+        };
+        bound_datagram.set_remote_endpoint(remote_endpoint);
+
+        Ok(())
+    }
+
+    pub fn addr(&self) -> Option<UnboundSocket::Endpoint> {
+        match self {
+            Inner::Unbound(_) => None,
+            Inner::Bound(bound_datagram) => Some(bound_datagram.local_endpoint()),
+        }
+    }
+
+    pub fn peer_addr(&self) -> Option<&UnboundSocket::Endpoint> {
+        match self {
+            Inner::Unbound(_) => None,
+            Inner::Bound(bound_datagram) => bound_datagram.remote_endpoint(),
+        }
+    }
+
+    pub fn try_recv(
+        &self,
+        writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
+    ) -> Result<(usize, UnboundSocket::Endpoint)> {
+        match self {
+            Inner::Unbound(_) => {
+                return_errno_with_message!(Errno::EAGAIN, "the socket is not bound");
+            }
+            Inner::Bound(bound_datagram) => bound_datagram.try_recv(writer, flags),
+        }
+    }
+
+    // If you're looking for `try_send`, there isn't one. Use `select_remote_and_bind` below and
+    // call `Bound::try_send` directly.
+
+    pub fn check_io_events(&self) -> IoEvents {
+        match self {
+            Inner::Unbound(unbound_datagram) => unbound_datagram.check_io_events(),
+            Inner::Bound(bound_datagram) => bound_datagram.check_io_events(),
+        }
+    }
+}
+
+/// Selects the remote endpoint and binds if the socket is not bound.
+///
+/// The remote endpoint specified in the system call (e.g., `sendto`) argument is preferred,
+/// otherwise the connected endpoint of the socket is used. If there are no remote endpoints
+/// available, this method will fail with [`EDESTADDRREQ`].
+///
+/// If the remote endpoint is specified but the socket is not bound, this method will try to
+/// bind the socket to an ephemeral endpoint.
+///
+/// If the above steps succeed, `op` will be called with the bound socket and the selected
+/// remote endpoint.
+///
+/// [`EDESTADDRREQ`]: crate::error::Errno::EDESTADDRREQ
+pub fn select_remote_and_bind<UnboundSocket, BoundSocket, B, F, R>(
+    inner_mutex: &RwMutex<Inner<UnboundSocket, BoundSocket>>,
+    remote: Option<&UnboundSocket::Endpoint>,
+    bind_ephemeral: B,
+    op: F,
+) -> Result<R>
+where
+    UnboundSocket: Unbound<Endpoint = BoundSocket::Endpoint, Bound = BoundSocket>,
+    BoundSocket: Bound,
+    B: FnOnce() -> Result<()>,
+    F: FnOnce(&BoundSocket, &UnboundSocket::Endpoint) -> Result<R>,
+{
+    let mut inner = inner_mutex.read();
+
+    // Not really a loop, since we always break on the first iteration. But we need to use
+    // `loop` here because we want to use `break` later.
+    #[expect(clippy::never_loop)]
+    let bound_datagram = loop {
+        // Fast path: The socket is already bound.
+        if let Inner::Bound(bound_datagram) = &*inner {
+            break bound_datagram;
+        }
+
+        // Slow path: Try to bind the socket to an ephemeral endpoint.
+        drop(inner);
+        bind_ephemeral()?;
+        inner = inner_mutex.read();
+
+        // Now the socket must be bound.
+        if let Inner::Bound(bound_datagram) = &*inner {
+            break bound_datagram;
+        }
+        unreachable!("`try_bind_ephemeral` succeeds so the socket cannot be unbound");
+    };
+
+    let remote_endpoint = remote
+        .or_else(|| bound_datagram.remote_endpoint())
+        .ok_or_else(|| {
+            Error::with_message(
+                Errno::EDESTADDRREQ,
+                "the destination address is not specified",
+            )
+        })?;
+
+    op(bound_datagram, remote_endpoint)
+}

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+pub mod datagram_common;
 mod message_header;
 pub mod options;
 pub mod send_recv_flags;

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -91,7 +91,7 @@ impl SocketOptionSet {
     pub fn set_option(
         &mut self,
         option: &dyn SocketOption,
-        socket: &mut dyn SetSocketLevelOption,
+        socket: &dyn SetSocketLevelOption,
     ) -> Result<NeedIfacePoll> {
         match_sock_option_ref!(option, {
             socket_recv_buf: RecvBuf => {

--- a/test/apps/network/netlink_route.c
+++ b/test/apps/network/netlink_route.c
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#include <netlink/netlink.h>
-#include <netlink/route/link.h>
-#include <netlink/route/addr.h>
 #include <net/if.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <netlink/route/addr.h>
 #include <unistd.h>
 
 #include "test.h"
@@ -223,5 +219,7 @@ FN_TEST(get_addr_error)
 			break;
 		}
 	}
+
+	TEST_SUCC(close(sock_fd));
 }
 END_TEST()

--- a/test/apps/network/rtnl_err.c
+++ b/test/apps/network/rtnl_err.c
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <netlink/netlink.h>
+#include <unistd.h>
+
+#include "test.h"
+
+static struct sockaddr_nl sk_addr = { .nl_family = AF_NETLINK };
+
+#define C_PORT 1001
+#define S_PORT 1002
+
+static int sk_unbound;
+static int sk_bound;
+static int sk_connected;
+
+FN_SETUP(unbound)
+{
+	sk_unbound = CHECK(
+		socket(PF_NETLINK, SOCK_DGRAM | SOCK_NONBLOCK, NETLINK_ROUTE));
+}
+END_SETUP()
+
+FN_SETUP(bound)
+{
+	sk_bound = CHECK(
+		socket(PF_NETLINK, SOCK_DGRAM | SOCK_NONBLOCK, NETLINK_ROUTE));
+
+	sk_addr.nl_pid = C_PORT;
+	CHECK(bind(sk_bound, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+}
+END_SETUP()
+
+FN_SETUP(connected)
+{
+	sk_connected = CHECK(
+		socket(PF_NETLINK, SOCK_DGRAM | SOCK_NONBLOCK, NETLINK_ROUTE));
+
+	sk_addr.nl_pid = S_PORT;
+	CHECK(connect(sk_connected, (struct sockaddr *)&sk_addr,
+		      sizeof(sk_addr)));
+}
+END_SETUP()
+
+FN_TEST(getsockname)
+{
+	struct sockaddr_nl saddr = { .nl_pid = 0xbeef };
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = 0;
+
+	TEST_RES(getsockname(sk_unbound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == 0xbeef);
+
+	TEST_RES(getsockname(sk_unbound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == 0);
+
+	TEST_RES(getsockname(sk_bound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == C_PORT);
+
+	TEST_RES(getsockname(sk_connected, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid != C_PORT);
+}
+END_TEST()
+
+FN_TEST(getpeername)
+{
+	struct sockaddr_nl saddr = { .nl_pid = 0xbeef };
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_RES(getpeername(sk_unbound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == 0);
+
+	TEST_RES(getpeername(sk_bound, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == 0);
+
+	TEST_RES(getpeername(sk_connected, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.nl_pid == S_PORT);
+}
+END_TEST()
+
+FN_TEST(send)
+{
+	char buf[1] = { 'z' };
+
+	TEST_RES(send(sk_bound, buf, 1, 0), 1);
+
+	TEST_ERRNO(send(sk_connected, buf, 1, 0), ECONNREFUSED);
+}
+END_TEST()
+
+FN_TEST(recv)
+{
+	char buf[1] = { 'z' };
+
+	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), EAGAIN);
+
+	TEST_ERRNO(recv(sk_bound, buf, 1, 0), EAGAIN);
+
+	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
+}
+END_TEST()
+
+FN_TEST(bind)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_ERRNO(bind(sk_unbound, psaddr, addrlen - 1), EINVAL);
+
+	TEST_ERRNO(bind(sk_bound, psaddr, addrlen), EINVAL);
+
+	TEST_ERRNO(bind(sk_connected, psaddr, addrlen), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listen)
+{
+	TEST_ERRNO(listen(sk_unbound, 2), EOPNOTSUPP);
+
+	TEST_ERRNO(listen(sk_bound, 2), EOPNOTSUPP);
+
+	TEST_ERRNO(listen(sk_connected, 2), EOPNOTSUPP);
+}
+END_TEST()
+
+FN_TEST(accept)
+{
+	struct sockaddr_nl saddr;
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_ERRNO(accept(sk_unbound, psaddr, &addrlen), EOPNOTSUPP);
+
+	TEST_ERRNO(accept(sk_bound, psaddr, &addrlen), EOPNOTSUPP);
+
+	TEST_ERRNO(accept(sk_connected, psaddr, &addrlen), EOPNOTSUPP);
+}
+END_TEST()
+
+FN_TEST(poll)
+{
+	struct pollfd pfd = { .events = POLLIN | POLLOUT };
+
+	pfd.fd = sk_unbound;
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+
+	pfd.fd = sk_bound;
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+
+	pfd.fd = sk_connected;
+	TEST_RES(poll(&pfd, 1, 0),
+		 (pfd.revents & (POLLIN | POLLOUT)) == POLLOUT);
+}
+END_TEST()
+
+FN_TEST(connect)
+{
+	struct sockaddr *psaddr = (struct sockaddr *)&sk_addr;
+	socklen_t addrlen = sizeof(sk_addr);
+
+	TEST_SUCC(connect(sk_connected, psaddr, addrlen));
+}
+END_TEST()

--- a/test/apps/scripts/network.sh
+++ b/test/apps/scripts/network.sh
@@ -34,4 +34,7 @@ sleep 0.2
 ./udp_err
 ./unix_err
 
+./netlink_route
+./rtnl_err
+
 echo "All network test passed"


### PR DESCRIPTION
This PR avoids duplicate code between `ip/datagram` and `netlink/route` by resolving https://github.com/asterinas/asterinas/pull/1900#discussion_r2022106859. See the comments for details on motivation and a high-level design.

The following TODO is also gone, I've added some regression tests to make sure the behavior matches Linux:
https://github.com/asterinas/asterinas/blob/1fe0fef41003c824b780b7b228f7b01a46497be0/kernel/src/net/socket/netlink/route/mod.rs#L77