### PR TITLE
Poll the correct iface in irq handler

### DIFF
--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -5,7 +5,7 @@ mod init;
 mod poll;
 mod sched;
 
-pub use init::{init, IFACES};
+pub use init::{init, iter_all_ifaces, loopback_iface, virtio_iface};
 pub use poll::lazy_init;
 
 pub type Iface = dyn aster_bigtcp::iface::Iface<ext::BigtcpExt>;

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use log::trace;
 use ostd::timer::Jiffies;
 
-use super::{Iface, IFACES};
+use super::{iter_all_ifaces, Iface};
 use crate::{
     sched::{Nice, SchedPolicy},
     thread::kernel_thread::ThreadOptions,
@@ -14,15 +14,13 @@ use crate::{
 };
 
 pub fn lazy_init() {
-    for iface in IFACES.get().unwrap() {
+    for iface in iter_all_ifaces() {
         spawn_background_poll_thread(iface.clone());
     }
 }
 
 pub(super) fn poll_ifaces() {
-    let ifaces = IFACES.get().unwrap();
-
-    for iface in ifaces.iter() {
+    for iface in iter_all_ifaces() {
         iface.poll();
     }
 }

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -7,7 +7,7 @@ use core::num::NonZeroU32;
 use super::util::finish_response;
 use crate::{
     net::{
-        iface::{Iface, IFACES},
+        iface::{iter_all_ifaces, Iface},
         socket::netlink::{
             message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
             route::message::{
@@ -28,9 +28,7 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
         return_errno_with_message!(Errno::EOPNOTSUPP, "GETADDR only supports dump requests");
     }
 
-    let ifaces = IFACES.get().unwrap();
-    let mut response_segments: Vec<RtnlSegment> = ifaces
-        .iter()
+    let mut response_segments: Vec<RtnlSegment> = iter_all_ifaces()
         // GETADDR only supports dump mode, so we're going to report all addresses.
         .filter_map(|iface| iface_to_new_addr(request_segment.header(), iface))
         .map(RtnlSegment::NewAddr)

--- a/kernel/src/net/socket/netlink/route/kernel/link.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/link.rs
@@ -9,7 +9,7 @@ use aster_bigtcp::iface::InterfaceType;
 use super::util::finish_response;
 use crate::{
     net::{
-        iface::{Iface, IFACES},
+        iface::{iter_all_ifaces, Iface},
         socket::netlink::{
             message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
             route::message::{LinkAttr, LinkSegment, LinkSegmentBody, RtnlSegment},
@@ -22,9 +22,7 @@ use crate::{
 pub(super) fn do_get_link(request_segment: &LinkSegment) -> Result<Vec<RtnlSegment>> {
     let filter_by = FilterBy::from_request(request_segment)?;
 
-    let ifaces = IFACES.get().unwrap();
-    let mut response_segments: Vec<RtnlSegment> = ifaces
-        .iter()
+    let mut response_segments: Vec<RtnlSegment> = iter_all_ifaces()
         // Filter to include only requested links.
         .filter(|iface| match &filter_by {
             FilterBy::Index(index) => *index == iface.index(),


### PR DESCRIPTION
Fixes #2033.

The issue was originally introduced in #1900, as we initialized the loopback interface before the virtio-net interface to ensure that the loopback interface index is consistently the smallest among all interfaces, mimicking Linux behavior. However, in the IRQ handler, we were still polling `IFACES[0]`, which corresponded to the loopback interface instead of virtio-net.

It’s important to note that #1981 permits the absence of virtio-net, meaning using `IFACES[1]` to access virtio-net may cause a panic. To resolve the issue, I've introduced several new methods such as `get_all_ifaces`, `get_loopback_iface`, and `get_virtio_iface`. Additionally, `IFACES` is now kept private within its module.