### PR TITLE
Don't race between enabling IRQs and halting CPU

### DIFF
--- a/kernel/comps/softirq/src/lib.rs
+++ b/kernel/comps/softirq/src/lib.rs
@@ -13,7 +13,10 @@ use component::{init_component, ComponentInitError};
 use lock::is_softirq_enabled;
 use ostd::{
     cpu_local_cell,
-    trap::{disable_local, register_bottom_half_handler, DisabledLocalIrqGuard},
+    trap::{
+        irq::{disable_local, DisabledLocalIrqGuard},
+        register_bottom_half_handler,
+    },
 };
 use spin::Once;
 

--- a/kernel/comps/softirq/src/lock.rs
+++ b/kernel/comps/softirq/src/lock.rs
@@ -7,7 +7,7 @@ use ostd::{
         atomic_mode::{AsAtomicModeGuard, InAtomicMode},
         disable_preempt, DisabledPreemptGuard,
     },
-    trap::{disable_local, in_interrupt_context},
+    trap::{in_interrupt_context, irq::disable_local},
 };
 
 use crate::process_all_pending;

--- a/kernel/comps/softirq/src/taskless.rs
+++ b/kernel/comps/softirq/src/taskless.rs
@@ -131,7 +131,7 @@ fn do_schedule(
     {
         return;
     }
-    let irq_guard = trap::disable_local();
+    let irq_guard = trap::irq::disable_local();
     taskless_list
         .get_with(&irq_guard)
         .borrow_mut()
@@ -158,7 +158,7 @@ fn taskless_softirq_handler(
     softirq_id: u8,
 ) {
     let mut processing_list = {
-        let irq_guard = trap::disable_local();
+        let irq_guard = trap::irq::disable_local();
         let guard = taskless_list.get_with(&irq_guard);
         let mut list_mut = guard.borrow_mut();
         LinkedList::take(list_mut.deref_mut())
@@ -170,7 +170,7 @@ fn taskless_softirq_handler(
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
-            let irq_guard = trap::disable_local();
+            let irq_guard = trap::irq::disable_local();
             taskless_list
                 .get_with(&irq_guard)
                 .borrow_mut()

--- a/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
@@ -7,8 +7,8 @@ use log::info;
 #[cfg(target_arch = "x86_64")]
 use ostd::arch::kernel::MappedIrqLine;
 #[cfg(target_arch = "riscv64")] // TODO: Add `MappedIrqLine` support for RISC-V.
-use ostd::trap::IrqLine as MappedIrqLine;
-use ostd::{io::IoMem, mm::VmIoOnce, trap::IrqLine, Error, Result};
+use ostd::trap::irq::IrqLine as MappedIrqLine;
+use ostd::{io::IoMem, mm::VmIoOnce, trap::irq::IrqLine, Error, Result};
 
 /// A MMIO common device.
 #[derive(Debug)]

--- a/kernel/comps/virtio/src/transport/mmio/bus/mod.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/mod.rs
@@ -28,7 +28,7 @@ pub(super) fn init() {
 fn x86_probe() {
     use common_device::{mmio_check_magic, mmio_read_device_id, MmioCommonDevice};
     use log::debug;
-    use ostd::{arch::kernel::IRQ_CHIP, io::IoMem, trap::IrqLine};
+    use ostd::{arch::kernel::IRQ_CHIP, io::IoMem, trap::irq::IrqLine};
 
     // TODO: The correct method for detecting VirtIO-MMIO devices on x86_64 systems is to parse the
     // kernel command line if ACPI tables are absent [1], or the ACPI SSDT if ACPI tables are

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -11,7 +11,7 @@ use ostd::{
     io::IoMem,
     mm::{DmaCoherent, PAGE_SIZE},
     sync::RwLock,
-    trap::IrqCallbackFunction,
+    trap::irq::IrqCallbackFunction,
 };
 
 use super::{

--- a/kernel/comps/virtio/src/transport/mmio/multiplex.rs
+++ b/kernel/comps/virtio/src/transport/mmio/multiplex.rs
@@ -8,7 +8,10 @@ use aster_util::safe_ptr::SafePtr;
 use ostd::{
     io::IoMem,
     sync::RwLock,
-    trap::{IrqCallbackFunction, IrqLine, TrapFrame},
+    trap::{
+        irq::{IrqCallbackFunction, IrqLine},
+        TrapFrame,
+    },
 };
 
 /// Multiplexing Irqs. The two interrupt types (configuration space change and queue interrupt)

--- a/kernel/comps/virtio/src/transport/mod.rs
+++ b/kernel/comps/virtio/src/transport/mod.rs
@@ -9,7 +9,7 @@ use ostd::{
     bus::pci::cfg_space::Bar,
     io::IoMem,
     mm::{DmaCoherent, PodOnce},
-    trap::IrqCallbackFunction,
+    trap::irq::IrqCallbackFunction,
     Pod,
 };
 

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -15,7 +15,7 @@ use ostd::{
     },
     io::IoMem,
     mm::DmaCoherent,
-    trap::IrqCallbackFunction,
+    trap::irq::IrqCallbackFunction,
 };
 
 use super::{common_cfg::VirtioPciCommonCfg, msix::VirtioMsixManager};

--- a/kernel/comps/virtio/src/transport/pci/legacy.rs
+++ b/kernel/comps/virtio/src/transport/pci/legacy.rs
@@ -12,7 +12,7 @@ use ostd::{
     },
     io::IoMem,
     mm::{DmaCoherent, HasDaddr, PAGE_SIZE},
-    trap::IrqCallbackFunction,
+    trap::irq::IrqCallbackFunction,
 };
 
 use crate::{

--- a/kernel/comps/virtio/src/transport/pci/msix.rs
+++ b/kernel/comps/virtio/src/transport/pci/msix.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use ostd::{bus::pci::capability::msix::CapabilityMsixData, trap::IrqLine};
+use ostd::{bus::pci::capability::msix::CapabilityMsixData, trap::irq::IrqLine};
 
 pub struct VirtioMsixManager {
     config_msix_vector: u16,
@@ -20,7 +20,7 @@ impl VirtioMsixManager {
     pub fn new(mut msix: CapabilityMsixData) -> Self {
         let mut msix_vector_list: Vec<u16> = (0..msix.table_size()).collect();
         for i in msix_vector_list.iter() {
-            let irq = ostd::trap::IrqLine::alloc().unwrap();
+            let irq = IrqLine::alloc().unwrap();
             msix.set_interrupt_vector(irq, *i);
         }
         let config_msix_vector = msix_vector_list.pop().unwrap();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -111,8 +111,7 @@ fn ap_init() {
         );
 
         loop {
-            crate::thread::Thread::yield_now();
-            ostd::cpu::sleep_for_interrupt();
+            ostd::task::halt_cpu();
         }
     }
 
@@ -156,10 +155,10 @@ fn init_thread() {
         karg.get_initproc_envp().to_vec(),
     )
     .expect("Run init process failed.");
+
     // Wait till initproc become zombie.
     while !initproc.status().is_zombie() {
-        crate::thread::Thread::yield_now();
-        ostd::cpu::sleep_for_interrupt();
+        ostd::task::halt_cpu();
     }
 
     // TODO: exit via qemu isa debug device should not be the only way.

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -16,7 +16,7 @@ use ostd::{
         },
         AtomicCpuId, Task,
     },
-    trap::disable_local,
+    trap::irq::disable_local,
 };
 
 use super::{

--- a/osdk/deps/frame-allocator/src/cache.rs
+++ b/osdk/deps/frame-allocator/src/cache.rs
@@ -7,7 +7,7 @@ use core::{alloc::Layout, cell::RefCell};
 use ostd::{
     cpu_local,
     mm::{Paddr, PAGE_SIZE},
-    trap::DisabledLocalIrqGuard,
+    trap::irq::DisabledLocalIrqGuard,
 };
 
 cpu_local! {

--- a/osdk/deps/frame-allocator/src/lib.rs
+++ b/osdk/deps/frame-allocator/src/lib.rs
@@ -64,7 +64,7 @@ pub struct FrameAllocator;
 
 impl GlobalFrameAllocator for FrameAllocator {
     fn alloc(&self, layout: Layout) -> Option<Paddr> {
-        let guard = trap::disable_local();
+        let guard = trap::irq::disable_local();
         let res = cache::alloc(&guard, layout);
         if res.is_some() {
             TOTAL_FREE_SIZE.sub(guard.current_cpu(), layout.size());
@@ -73,13 +73,13 @@ impl GlobalFrameAllocator for FrameAllocator {
     }
 
     fn dealloc(&self, addr: Paddr, size: usize) {
-        let guard = trap::disable_local();
+        let guard = trap::irq::disable_local();
         TOTAL_FREE_SIZE.add(guard.current_cpu(), size);
         cache::dealloc(&guard, addr, size);
     }
 
     fn add_free_memory(&self, addr: Paddr, size: usize) {
-        let guard = trap::disable_local();
+        let guard = trap::irq::disable_local();
         TOTAL_FREE_SIZE.add(guard.current_cpu(), size);
         pools::add_free_memory(&guard, addr, size);
     }

--- a/osdk/deps/frame-allocator/src/pools/mod.rs
+++ b/osdk/deps/frame-allocator/src/pools/mod.rs
@@ -13,7 +13,7 @@ use ostd::{
     cpu_local,
     mm::Paddr,
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
-    trap::DisabledLocalIrqGuard,
+    trap::irq::DisabledLocalIrqGuard,
 };
 
 use crate::chunk::{greater_order_of, lesser_order_of, size_of_order, split_to_chunks, BuddyOrder};

--- a/osdk/deps/frame-allocator/src/smp_counter.rs
+++ b/osdk/deps/frame-allocator/src/smp_counter.rs
@@ -98,7 +98,7 @@ mod test {
             pub static FREE_SIZE_COUNTER: usize;
         }
 
-        let guard = trap::disable_local();
+        let guard = trap::irq::disable_local();
         let cur_cpu = guard.current_cpu();
         FREE_SIZE_COUNTER.add(cur_cpu, 10);
         assert_eq!(FREE_SIZE_COUNTER.get(), 10);

--- a/osdk/deps/heap-allocator/src/allocator.rs
+++ b/osdk/deps/heap-allocator/src/allocator.rs
@@ -296,7 +296,7 @@ impl GlobalHeapAllocator for HeapAllocator {
             return HeapSlot::alloc_large(layout.size().div_ceil(PAGE_SIZE) * PAGE_SIZE);
         };
 
-        let irq_guard = trap::disable_local();
+        let irq_guard = trap::irq::disable_local();
         let this_cache = LOCAL_POOL.get_with(&irq_guard);
         let mut local_cache = this_cache.borrow_mut();
 
@@ -309,7 +309,7 @@ impl GlobalHeapAllocator for HeapAllocator {
             return Ok(());
         };
 
-        let irq_guard = trap::disable_local();
+        let irq_guard = trap::irq::disable_local();
         let this_cache = LOCAL_POOL.get_with(&irq_guard);
         let mut local_cache = this_cache.borrow_mut();
 

--- a/osdk/deps/test-kernel/src/lib.rs
+++ b/osdk/deps/test-kernel/src/lib.rs
@@ -54,7 +54,7 @@ fn main() {
 
 #[ostd::ktest::panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    let _irq_guard = ostd::trap::disable_local();
+    let _irq_guard = ostd::trap::irq::disable_local();
 
     use alloc::{boxed::Box, string::ToString};
 

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -7,17 +7,3 @@ pub mod extension;
 pub mod local;
 
 pub use extension::{has_extensions, IsaExtensions};
-
-/// Halts the CPU.
-///
-/// This function halts the CPU until the next interrupt is received. By
-/// halting, the CPU might consume less power. Internally it is implemented
-/// using the `wfi` instruction.
-///
-/// Since the function sleeps the CPU, it should not be used within an atomic
-/// mode ([`crate::task::atomic_mode`]).
-#[track_caller]
-pub fn sleep_for_interrupt() {
-    crate::task::atomic_mode::might_sleep();
-    riscv::asm::wfi();
-}

--- a/ostd/src/arch/riscv/irq.rs
+++ b/ostd/src/arch/riscv/irq.rs
@@ -31,7 +31,31 @@ impl IrqRemapping {
     }
 }
 
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
 pub(crate) fn enable_local() {
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { riscv::interrupt::enable() }
+}
+
+/// Enables local IRQs and halts the CPU to wait for interrupts.
+///
+/// This method guarantees that no interrupts can occur in the middle. In other words, IRQs must
+/// either have been processed before this method is called, or they must wake the CPU up from the
+/// halting state.
+//
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+pub(crate) fn enable_local_and_halt() {
+    // RISC-V Instruction Set Manual, Machine-Level ISA, Version 1.13 says:
+    // "The WFI instruction can also be executed when interrupts are disabled. The operation of WFI
+    // must be unaffected by the global interrupt bits in `mstatus` (MIE and SIE) [..]"
+    //
+    // So we can use `wfi` even if IRQs are disabled. Pending IRQs can still wake up the CPU, but
+    // they will only occur later when we enable local IRQs.
+    riscv::asm::wfi();
+
+    // SAFETY: The safety is upheld by the caller.
     unsafe { riscv::interrupt::enable() }
 }
 

--- a/ostd/src/arch/riscv/timer/mod.rs
+++ b/ostd/src/arch/riscv/timer/mod.rs
@@ -67,7 +67,7 @@ pub(super) unsafe fn init() {
 }
 
 pub(super) fn handle_timer_interrupt() {
-    let irq_guard = trap::disable_local();
+    let irq_guard = trap::irq::disable_local();
     if irq_guard.current_cpu() == CpuId::bsp() {
         crate::timer::jiffies::ELAPSED.fetch_add(1, Ordering::Relaxed);
     }

--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -4,16 +4,3 @@
 
 pub mod context;
 pub mod local;
-
-/// Halts the CPU.
-///
-/// This function halts the CPU until the next interrupt is received. By
-/// halting, the CPU will enter the C-0 state and consume less power.
-///
-/// Since the function sleeps the CPU, it should not be used within an atomic
-/// mode ([`crate::task::atomic_mode`]).
-#[track_caller]
-pub fn sleep_for_interrupt() {
-    crate::task::atomic_mode::might_sleep();
-    x86_64::instructions::hlt();
-}

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -11,7 +11,7 @@ use volatile::{access::ReadWrite, VolatileRef};
 use super::registers::Capability;
 use crate::{
     sync::{LocalIrqDisabled, SpinLock},
-    trap::{IrqLine, TrapFrame},
+    trap::{irq::IrqLine, TrapFrame},
 };
 
 #[derive(Debug)]

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -50,12 +50,37 @@ impl IrqRemapping {
     }
 }
 
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
 pub(crate) fn enable_local() {
     x86_64::instructions::interrupts::enable();
     // When emulated with QEMU, interrupts may not be delivered if a STI instruction is immediately
     // followed by a RET instruction. It is a BUG of QEMU, see the following patch for details.
     // https://lore.kernel.org/qemu-devel/20231210190147.129734-2-lrh2000@pku.edu.cn/
     x86_64::instructions::nop();
+}
+
+/// Enables local IRQs and halts the CPU to wait for interrupts.
+///
+/// This method guarantees that no interrupts can occur in the middle. In other words, IRQs must
+/// either have been processed before this method is called, or they must wake the CPU up from the
+/// halting state.
+//
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+pub(crate) fn enable_local_and_halt() {
+    // SAFETY:
+    // 1. `sti` is safe to use because its safety requirement is upheld by the caller.
+    // 2. `hlt` is safe to use because it halts the CPU for interrupts.
+    unsafe {
+        // Intel(R) 64 and IA-32 Architectures Software Developer's Manual says:
+        // "If IF = 0, maskable hardware interrupts remain inhibited on the instruction boundary
+        // following an execution of STI."
+        //
+        // So interrupts will only occur at or after the HLT instruction, which guarantee that
+        // interrupts won't occur between enabling the local IRQs and halting the CPU.
+        core::arch::asm!("sti", "hlt", options(nomem, nostack, preserves_flags),)
+    };
 }
 
 pub(crate) fn disable_local() {

--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -76,7 +76,7 @@ impl super::Apic for X2Apic {
     }
 
     unsafe fn send_ipi(&self, icr: super::Icr) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         // SAFETY: These `rdmsr` and `wrmsr` instructions write the interrupt command to APIC and
         // wait for results. The caller guarantees it's safe to execute this interrupt command.
         unsafe {

--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -79,7 +79,7 @@ impl super::Apic for XApic {
     }
 
     unsafe fn send_ipi(&self, icr: super::Icr) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         self.write(xapic::XAPIC_ESR, 0);
         // The upper 32 bits of ICR must be written into XAPIC_ICR1 first,
         // because writing into XAPIC_ICR0 will trigger the action of

--- a/ostd/src/arch/x86/kernel/irq/ioapic.rs
+++ b/ostd/src/arch/x86/kernel/irq/ioapic.rs
@@ -11,7 +11,7 @@ use volatile::{
 };
 
 use crate::{
-    arch::if_tdx_enabled, io::IoMemAllocatorBuilder, mm::paddr_to_vaddr, trap::IrqLine, Error,
+    arch::if_tdx_enabled, io::IoMemAllocatorBuilder, mm::paddr_to_vaddr, trap::irq::IrqLine, Error,
     Result,
 };
 

--- a/ostd/src/arch/x86/kernel/irq/mod.rs
+++ b/ostd/src/arch/x86/kernel/irq/mod.rs
@@ -11,7 +11,7 @@ use log::info;
 use spin::Once;
 
 use super::acpi::get_acpi_tables;
-use crate::{io::IoMemAllocatorBuilder, sync::SpinLock, trap::IrqLine, Error, Result};
+use crate::{io::IoMemAllocatorBuilder, sync::SpinLock, trap::irq::IrqLine, Error, Result};
 
 mod ioapic;
 mod pic;

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -12,7 +12,7 @@ use crate::{
         pit::{self, OperatingMode},
         TIMER_FREQ,
     },
-    trap::{IrqLine, TrapFrame},
+    trap::{irq::IrqLine, TrapFrame},
 };
 
 /// The frequency of TSC(Hz)

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -12,7 +12,7 @@ use crate::{
         tsc_freq,
     },
     task::disable_preempt,
-    trap::{IrqLine, TrapFrame},
+    trap::{irq::IrqLine, TrapFrame},
 };
 
 /// Initializes APIC with TSC-deadline mode or periodic mode.

--- a/ostd/src/arch/x86/timer/hpet.rs
+++ b/ostd/src/arch/x86/timer/hpet.rs
@@ -13,7 +13,7 @@ use volatile::{
 use crate::{
     arch::kernel::{acpi::get_acpi_tables, MappedIrqLine, IRQ_CHIP},
     mm::paddr_to_vaddr,
-    trap::IrqLine,
+    trap::irq::IrqLine,
 };
 
 static HPET_INSTANCE: Once<Hpet> = Once::new();

--- a/ostd/src/arch/x86/timer/mod.rs
+++ b/ostd/src/arch/x86/timer/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     arch::kernel,
     cpu::{CpuId, PinCurrentCpu},
     timer::INTERRUPT_CALLBACKS,
-    trap::{self, IrqLine, TrapFrame},
+    trap::{self, irq::IrqLine, TrapFrame},
 };
 
 /// The timer frequency (Hz).
@@ -61,7 +61,7 @@ pub(super) fn init_ap() {
 }
 
 fn timer_callback(_: &TrapFrame) {
-    let irq_guard = trap::disable_local();
+    let irq_guard = trap::irq::disable_local();
     if irq_guard.current_cpu() == CpuId::bsp() {
         crate::timer::jiffies::ELAPSED.fetch_add(1, Ordering::SeqCst);
     }

--- a/ostd/src/arch/x86/timer/pit.rs
+++ b/ostd/src/arch/x86/timer/pit.rs
@@ -16,7 +16,7 @@ use crate::{
         timer::TIMER_FREQ,
     },
     io::{sensitive_io_port, IoPort},
-    trap::IrqLine,
+    trap::irq::IrqLine,
 };
 
 /// PIT Operating Mode.

--- a/ostd/src/bus/pci/capability/msix.rs
+++ b/ostd/src/bus/pci/capability/msix.rs
@@ -15,7 +15,7 @@ use crate::{
         device_info::PciDeviceLocation,
     },
     mm::VmIoOnce,
-    trap::IrqLine,
+    trap::irq::IrqLine,
 };
 
 /// MSI-X capability. It will set the BAR space it uses to be hidden.

--- a/ostd/src/cpu/local/cell.rs
+++ b/ostd/src/cpu/local/cell.rs
@@ -33,7 +33,7 @@ use crate::arch;
 ///     // You can avoid this by disabling interrupts (and preemption, if needed).
 ///     println!("BAR VAL: {:?}", BAR.load());
 ///
-///     let _irq_guard = ostd::trap::disable_local_irq();
+///     let _irq_guard = ostd::trap::irq::disable_local_irq();
 ///     println!("1st FOO VAL: {:?}", FOO.load());
 ///     // No surprises here, the two accesses must result in the same value.
 ///     println!("2nd FOO VAL: {:?}", FOO.load());

--- a/ostd/src/cpu/local/dyn_cpu_local.rs
+++ b/ostd/src/cpu/local/dyn_cpu_local.rs
@@ -10,7 +10,7 @@ use super::{AnyStorage, CpuLocal};
 use crate::{
     cpu::{all_cpus, num_cpus, CpuId, PinCurrentCpu},
     mm::{paddr_to_vaddr, FrameAllocOptions, Segment, Vaddr, PAGE_SIZE},
-    trap::DisabledLocalIrqGuard,
+    trap::irq::DisabledLocalIrqGuard,
     Result,
 };
 

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -56,7 +56,7 @@ use static_cpu_local::StaticStorage;
 use super::CpuId;
 use crate::{
     mm::{frame::allocator, paddr_to_vaddr, Paddr, PAGE_SIZE},
-    trap::DisabledLocalIrqGuard,
+    trap::irq::DisabledLocalIrqGuard,
 };
 
 /// Dynamically-allocated CPU-local objects.
@@ -324,7 +324,7 @@ mod test {
         crate::cpu_local! {
             static FOO: RefCell<usize> = RefCell::new(1);
         }
-        let irq_guard = crate::trap::disable_local();
+        let irq_guard = crate::trap::irq::disable_local();
         let foo_guard = FOO.get_with(&irq_guard);
         assert_eq!(*foo_guard.borrow(), 1);
         *foo_guard.borrow_mut() = 2;
@@ -337,7 +337,7 @@ mod test {
         crate::cpu_local_cell! {
             static BAR: usize = 3;
         }
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         assert_eq!(BAR.load(), 3);
         BAR.store(4);
         assert_eq!(BAR.load(), 4);

--- a/ostd/src/cpu/local/single_instr.rs
+++ b/ostd/src/cpu/local/single_instr.rs
@@ -41,7 +41,7 @@ pub trait SingleInstructionAddAssign<Rhs = Self> {
 
 impl<T: num_traits::WrappingAdd + Copy> SingleInstructionAddAssign<T> for T {
     default unsafe fn add_assign(offset: *mut Self, rhs: T) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
         // SAFETY:
@@ -67,7 +67,7 @@ pub trait SingleInstructionSubAssign<Rhs = Self> {
 
 impl<T: num_traits::WrappingSub + Copy> SingleInstructionSubAssign<T> for T {
     default unsafe fn sub_assign(offset: *mut Self, rhs: T) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
         // SAFETY: Same as `add_assign`.
@@ -87,7 +87,7 @@ pub trait SingleInstructionBitOrAssign<Rhs = Self> {
 
 impl<T: core::ops::BitOr<Output = T> + Copy> SingleInstructionBitOrAssign<T> for T {
     default unsafe fn bitor_assign(offset: *mut Self, rhs: T) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
         // SAFETY: Same as `add_assign`.
@@ -107,7 +107,7 @@ pub trait SingleInstructionBitAndAssign<Rhs = Self> {
 
 impl<T: core::ops::BitAnd<Output = T> + Copy> SingleInstructionBitAndAssign<T> for T {
     default unsafe fn bitand_assign(offset: *mut Self, rhs: T) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
         // SAFETY: Same as `add_assign`.
@@ -127,7 +127,7 @@ pub trait SingleInstructionBitXorAssign<Rhs = Self> {
 
 impl<T: core::ops::BitXor<Output = T> + Copy> SingleInstructionBitXorAssign<T> for T {
     default unsafe fn bitxor_assign(offset: *mut Self, rhs: T) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let addr = (base + offset as usize) as *mut Self;
         // SAFETY: Same as `add_assign`.
@@ -147,7 +147,7 @@ pub trait SingleInstructionLoad {
 
 impl<T: Copy> SingleInstructionLoad for T {
     default unsafe fn load(offset: *const Self) -> Self {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let ptr = (base + offset as usize) as *const Self;
         // SAFETY: Same as `add_assign`.
@@ -167,7 +167,7 @@ pub trait SingleInstructionStore {
 
 impl<T: Copy> SingleInstructionStore for T {
     default unsafe fn store(offset: *mut Self, val: Self) {
-        let _guard = crate::trap::disable_local();
+        let _guard = crate::trap::irq::disable_local();
         let base = crate::arch::cpu::local::get_base() as usize;
         let ptr = (base + offset as usize) as *mut Self;
         // SAFETY: Same as `add_assign`.

--- a/ostd/src/cpu/local/static_cpu_local.rs
+++ b/ostd/src/cpu/local/static_cpu_local.rs
@@ -5,7 +5,7 @@
 use core::marker::PhantomData;
 
 use super::{AnyStorage, CpuLocal, __cpu_local_end, __cpu_local_start};
-use crate::{arch, cpu::CpuId, trap::DisabledLocalIrqGuard};
+use crate::{arch, cpu::CpuId, trap::irq::DisabledLocalIrqGuard};
 
 /// Defines a statically-allocated CPU-local variable.
 ///
@@ -33,7 +33,7 @@ use crate::{arch, cpu::CpuId, trap::DisabledLocalIrqGuard};
 ///     let val_of_foo = ref_of_foo.load(Ordering::Relaxed);
 ///     println!("FOO VAL: {}", val_of_foo);
 ///
-///     let irq_guard = trap::disable_local();
+///     let irq_guard = trap::irq::disable_local();
 ///     let bar_guard = BAR.get_with(&irq_guard);
 ///     let val_of_bar = bar_guard.get();
 ///     println!("BAR VAL: {}", val_of_bar);

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -77,7 +77,7 @@ impl<'a, G: PinCurrentCpu> TlbFlusher<'a, G> {
     /// function. But it may not be synchronous. Upon the return of this
     /// function, the TLB entries may not be coherent.
     pub fn dispatch_tlb_flush(&mut self) {
-        let irq_guard = crate::trap::disable_local();
+        let irq_guard = crate::trap::irq::disable_local();
 
         if self.ops_stack.is_empty() {
             return;

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -28,7 +28,7 @@ use unwinding::abi::{
 #[linkage = "weak"]
 #[no_mangle]
 pub fn __ostd_panic_handler(info: &core::panic::PanicInfo) -> ! {
-    let _irq_guard = crate::trap::disable_local();
+    let _irq_guard = crate::trap::irq::disable_local();
 
     crate::cpu_local_cell! {
         static IN_PANIC: bool = false;

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -14,7 +14,7 @@ use crate::{
     cpu::{CpuSet, PinCurrentCpu},
     cpu_local,
     sync::SpinLock,
-    trap::{self, IrqLine, TrapFrame},
+    trap::{self, irq::IrqLine, TrapFrame},
 };
 
 /// Executes a function on other processors.
@@ -32,7 +32,7 @@ use crate::{
 /// The function `f` will be executed asynchronously on the target processors.
 /// However if called on the current processor, it will be synchronous.
 pub fn inter_processor_call(targets: &CpuSet, f: fn()) {
-    let irq_guard = trap::disable_local();
+    let irq_guard = trap::irq::disable_local();
     let this_cpu_id = irq_guard.current_cpu();
 
     let ipi_data = IPI_GLOBAL_DATA.get().unwrap();

--- a/ostd/src/sync/guard.rs
+++ b/ostd/src/sync/guard.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     task::{atomic_mode::AsAtomicModeGuard, disable_preempt, DisabledPreemptGuard},
-    trap::{disable_local, DisabledLocalIrqGuard},
+    trap::irq::{disable_local, DisabledLocalIrqGuard},
 };
 
 /// A guardian that denotes the guard behavior for holding a spin-based lock.

--- a/ostd/src/task/kernel_stack.rs
+++ b/ostd/src/task/kernel_stack.rs
@@ -12,7 +12,7 @@ use crate::{
         FrameAllocOptions, PAGE_SIZE,
     },
     prelude::*,
-    trap::DisabledLocalIrqGuard,
+    trap::irq::DisabledLocalIrqGuard,
 };
 
 /// The kernel stack size of a task, specified in pages.

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -24,7 +24,7 @@ use spin::Once;
 use utils::ForceSync;
 
 pub use self::{
-    preempt::{disable_preempt, DisabledPreemptGuard},
+    preempt::{disable_preempt, halt_cpu, DisabledPreemptGuard},
     scheduler::info::{AtomicCpuId, TaskScheduleInfo},
 };
 pub(crate) use crate::arch::task::{context_switch, TaskContext};

--- a/ostd/src/task/preempt/cpu_local.rs
+++ b/ostd/src/task/preempt/cpu_local.rs
@@ -27,7 +27,6 @@ pub(in crate::task) fn should_preempt() -> bool {
     PREEMPT_INFO.load() == 0
 }
 
-#[expect(dead_code)]
 pub(in crate::task) fn need_preempt() -> bool {
     PREEMPT_INFO.load() & NEED_PREEMPT_MASK == 0
 }

--- a/ostd/src/task/preempt/mod.rs
+++ b/ostd/src/task/preempt/mod.rs
@@ -4,3 +4,34 @@ pub(super) mod cpu_local;
 mod guard;
 
 pub use self::guard::{disable_preempt, DisabledPreemptGuard};
+
+/// Halts the CPU until interrupts if no preemption is required.
+///
+/// This function will return if:
+///  - preemption is required when calling this function,
+///  - preemption is required during halting the CPU, or
+///  - interrupts occur during halting the CPU.
+///
+/// This function will perform preemption before returning if
+/// preemption is required.
+///
+/// # Panics
+///
+/// This function will panic if it is called in the atomic mode
+/// ([`crate::task::atomic_mode`]).
+#[track_caller]
+pub fn halt_cpu() {
+    crate::task::atomic_mode::might_sleep();
+
+    let irq_guard = crate::trap::irq::disable_local();
+
+    if cpu_local::need_preempt() {
+        drop(irq_guard);
+    } else {
+        core::mem::forget(irq_guard);
+        // IRQs were previously enabled (checked by `might_sleep`). So we can re-enable them now.
+        crate::arch::irq::enable_local_and_halt();
+    }
+
+    super::scheduler::might_preempt();
+}

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -72,7 +72,7 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
     PREVIOUS_TASK_PTR.store(current_task_ptr);
 
     // We must disable IRQs when switching, see `after_switching_to`.
-    let _ = core::mem::ManuallyDrop::new(irq_guard);
+    core::mem::forget(irq_guard);
 
     // SAFETY:
     // 1. We have exclusive access to both the current context and the next context (see above).

--- a/ostd/src/task/processor.rs
+++ b/ostd/src/task/processor.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 use core::{ptr::NonNull, sync::atomic::Ordering};
 
 use super::{context_switch, Task, TaskContext, POST_SCHEDULE_HANDLER};
-use crate::{cpu_local_cell, trap::DisabledLocalIrqGuard};
+use crate::{cpu_local_cell, trap::irq::DisabledLocalIrqGuard};
 
 cpu_local_cell! {
     /// The `Arc<Task>` (casted by [`Arc::into_raw`]) that is the current task.
@@ -43,7 +43,7 @@ pub(super) fn switch_to_task(next_task: Arc<Task>) {
         crate::sync::finish_grace_period();
     }
 
-    let irq_guard = crate::trap::disable_local();
+    let irq_guard = crate::trap::irq::disable_local();
 
     let current_task_ptr = CURRENT_TASK_PTR.load();
     let current_task_ctx_ptr = if !current_task_ptr.is_null() {

--- a/ostd/src/timer/mod.rs
+++ b/ostd/src/timer/mod.rs
@@ -22,7 +22,7 @@ pub fn register_callback<F>(func: F)
 where
     F: Fn() + Sync + Send + 'static,
 {
-    let irq_guard = trap::disable_local();
+    let irq_guard = trap::irq::disable_local();
     INTERRUPT_CALLBACKS
         .get_with(&irq_guard)
         .borrow_mut()

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -2,7 +2,7 @@
 
 use spin::Once;
 
-use super::{disable_local, irq::process_top_half, DisabledLocalIrqGuard};
+use super::irq::{disable_local, process_top_half, DisabledLocalIrqGuard};
 use crate::{cpu_local_cell, task::disable_preempt, trap::TrapFrame};
 
 static BOTTOM_HALF_HANDLER: Once<fn(DisabledLocalIrqGuard) -> DisabledLocalIrqGuard> = Once::new();

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! IRQ line and IRQ guards.
+
 use core::{fmt::Debug, ops::Deref};
 
 use id_alloc::IdAlloc;
@@ -141,6 +143,7 @@ fn get_or_init_allocator() -> &'static SpinLock<IdAlloc> {
 /// A handle for an allocated IRQ line.
 ///
 /// When the handle is dropped, the IRQ line will be released automatically.
+#[must_use]
 #[derive(Debug)]
 struct InnerHandle {
     index: u8,
@@ -204,10 +207,10 @@ pub(super) fn process_top_half(trap_frame: &TrapFrame, irq_num: usize) {
 /// # Example
 ///
 /// ```rust
-/// use ostd::irq;
+/// use ostd::trap;
 ///
 /// {
-///     let _ = irq::disable_local();
+///     let _ = trap::irq::disable_local();
 ///     todo!("do something when irqs are disabled");
 /// }
 /// ```

--- a/ostd/src/trap/mod.rs
+++ b/ostd/src/trap/mod.rs
@@ -3,10 +3,9 @@
 //! Handles trap across kernel and user space.
 
 mod handler;
-mod irq;
+pub mod irq;
 
+pub(crate) use handler::call_irq_callback_functions;
 pub use handler::{in_interrupt_context, register_bottom_half_handler};
 
-pub(crate) use self::handler::call_irq_callback_functions;
-pub use self::irq::{disable_local, DisabledLocalIrqGuard, IrqCallbackFunction, IrqLine};
 pub use crate::arch::trap::TrapFrame;


### PR DESCRIPTION
> I wonder if this is caused by the race condition between checking the preemption and halting the CPU. If the interrupts come in between, we halt the CPU and miss an opportunity to schedule to a worker task.
> 
> We can try to fix this race condition instead. Will https://github.com/lrh2000/asterinas/commit/31033ea89330ba430d647c26794f010f697df32b help this problem?  

 _Originally posted by @lrh2000 in [#2023](https://github.com/asterinas/asterinas/issues/2023#issuecomment-2809534654)_

~I don't know if this PR helps #2023 or not, since the comment above didn't get a response.~ This PR is not related to #2023 per https://github.com/asterinas/asterinas/pull/2052#issuecomment-2854850965.

But regardless of whether it helps, fixing the race condition should not be controversial.