### PR TITLE
Fail the CI if workspace lints are not enabled 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "aster-rights",
  "aster-rights-proc",
  "aster-softirq",
+ "aster-systree",
  "aster-time",
  "aster-util",
  "aster-virtio",
@@ -221,7 +222,6 @@ dependencies = [
  "rand",
  "riscv",
  "spin",
- "systree",
  "takeable",
  "tdx-guest",
  "time",
@@ -261,6 +261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aster-systree"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.6.0",
+ "component",
+ "ostd",
+ "spin",
+]
+
+[[package]]
 name = "aster-time"
 version = "0.1.0"
 dependencies = [
@@ -294,6 +304,7 @@ dependencies = [
  "aster-network",
  "aster-rights",
  "aster-softirq",
+ "aster-systree",
  "aster-util",
  "bitflags 1.3.2",
  "component",
@@ -302,7 +313,6 @@ dependencies = [
  "log",
  "ostd",
  "spin",
- "systree",
  "typeflags-util",
 ]
 
@@ -1684,16 +1694,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "systree"
-version = "0.1.0"
-dependencies = [
- "bitflags 2.6.0",
- "component",
- "ostd",
- "spin",
 ]
 
 [[package]]

--- a/Components.toml
+++ b/Components.toml
@@ -11,7 +11,7 @@ time = { name = "aster-time" }
 framebuffer = { name = "aster-framebuffer" }
 network = { name = "aster-network" }
 mlsdisk = { name = "aster-mlsdisk" }
-systree = { name = "systree" }
+systree = { name = "aster-systree" }
 
 [whitelist]
 [whitelist.nix.main]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -17,6 +17,7 @@ aster-mlsdisk = { path = "comps/mlsdisk" }
 aster-time = { path = "comps/time" }
 aster-virtio = { path = "comps/virtio" }
 aster-rights = { path = "libs/aster-rights" }
+aster-systree = { path = "comps/systree" }
 component = { path = "libs/comp-sys/component" }
 controlled = { path = "libs/comp-sys/controlled" }
 osdk-frame-allocator = { path = "../osdk/deps/frame-allocator" }
@@ -58,7 +59,6 @@ inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-ma
 getset = "0.1.2"
 takeable = "0.2.2"
 cfg-if = "1.0"
-systree = { path = "comps/systree" }
 # Fixed point numbers
 # TODO: fork this crate to rewrite all the (unnecessary) unsafe usage
 fixed = "1.28.0"

--- a/kernel/comps/systree/Cargo.toml
+++ b/kernel/comps/systree/Cargo.toml
@@ -3,8 +3,13 @@ name = "systree"
 version = "0.1.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 bitflags = "2.5"
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
 spin = "0.9"
+
+[lints]
+workspace = true

--- a/kernel/comps/systree/Cargo.toml
+++ b/kernel/comps/systree/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "systree"
+name = "aster-systree"
 version = "0.1.0"
 edition = "2021"
 

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -16,13 +16,13 @@ aster-util = { path = "../../libs/aster-util" }
 aster-rights = { path = "../../libs/aster-rights" }
 aster-bigtcp = { path = "../../libs/aster-bigtcp" }
 aster-softirq = { path = "../softirq"}
+aster-systree = { path = "../systree" }
 id-alloc = { path = "../../../ostd/libs/id-alloc" }
 typeflags-util = { path = "../../libs/typeflags-util" }
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
-systree = { path = "../systree" }
 
 [lints]
 workspace = true

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -330,9 +330,9 @@ impl From<int_to_c_enum::TryFromIntError> for Error {
     }
 }
 
-impl From<systree::Error> for Error {
-    fn from(err: systree::Error) -> Self {
-        use systree::Error::*;
+impl From<aster_systree::Error> for Error {
+    fn from(err: aster_systree::Error) -> Self {
+        use aster_systree::Error::*;
         match err {
             NodeNotFound(_) => Error::new(Errno::ENOENT),
             InvalidNodeOperation(_) => Error::new(Errno::EINVAL),

--- a/kernel/src/fs/sysfs/fs.rs
+++ b/kernel/src/fs/sysfs/fs.rs
@@ -2,7 +2,7 @@
 
 use alloc::sync::Arc;
 
-use systree::singleton as systree_singleton;
+use aster_systree::singleton as systree_singleton;
 
 use crate::fs::{
     sysfs::inode::SysFsInode,

--- a/kernel/src/fs/sysfs/inode.rs
+++ b/kernel/src/fs/sysfs/inode.rs
@@ -8,11 +8,11 @@ use alloc::{
 };
 use core::time::Duration;
 
-use ostd::sync::RwLock;
-use systree::{
+use aster_systree::{
     SysAttr, SysAttrFlags, SysBranchNode, SysNode, SysNodeId, SysNodeType, SysObj, SysStr,
     SysSymlink, SysTree,
 };
+use ostd::sync::RwLock;
 
 use crate::{
     events::IoEvents,

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -20,7 +20,7 @@ pub fn singleton() -> &'static Arc<SysFs> {
 
 /// Initializes the SysFs singleton.
 /// Ensures that the singleton is created by calling it.
-/// Should be called during kernel filesystem initialization, *after* systree::init().
+/// Should be called during kernel filesystem initialization, *after* aster_systree::init().
 pub fn init() {
     // Ensure systree is initialized first. This should be handled by the kernel's init order.
     SYSFS_SINGLETON.call_once(|| SysFs::new());

--- a/kernel/src/fs/sysfs/test.rs
+++ b/kernel/src/fs/sysfs/test.rs
@@ -11,15 +11,15 @@ use alloc::{
 };
 use core::{any::Any, fmt::Debug};
 
+use aster_systree::{
+    init_for_ktest, singleton as systree_singleton, Error as SysTreeError, Result as SysTreeResult,
+    SysAttrFlags, SysAttrSet, SysAttrSetBuilder, SysBranchNode, SysBranchNodeFields, SysNode,
+    SysNodeId, SysNodeType, SysNormalNodeFields, SysObj, SysStr, SysSymlink, SysTree,
+};
 use ostd::{
     mm::{FallibleVmRead, FallibleVmWrite, VmReader, VmWriter},
     prelude::ktest,
     sync::RwLock,
-};
-use systree::{
-    init_for_ktest, singleton as systree_singleton, Error as SysTreeError, Result as SysTreeResult,
-    SysAttrFlags, SysAttrSet, SysAttrSetBuilder, SysBranchNode, SysBranchNodeFields, SysNode,
-    SysNodeId, SysNodeType, SysNormalNodeFields, SysObj, SysStr, SysSymlink, SysTree,
 };
 
 use crate::{


### PR DESCRIPTION
PRs like https://github.com/asterinas/asterinas/pull/2054, https://github.com/asterinas/asterinas/pull/2012, and https://github.com/asterinas/asterinas/pull/1984 consistently forget to enable workspace lints, which is bad.

After this PR, the CI will fail if workspace lints are not enabled.

Also, `systree` is the only component whose name does not have an `aster-` prefix, is this desired? If not, let's fix it.