### PR TITLE
Retire incomplete features

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,7 +6,6 @@
 #![no_std]
 #![no_main]
 #![deny(unsafe_code)]
-#![expect(incomplete_features)]
 #![feature(btree_cursors)]
 #![feature(btree_extract_if)]
 #![feature(debug_closure_helpers)]
@@ -22,10 +21,6 @@
 #![feature(negative_impls)]
 #![feature(panic_can_unwind)]
 #![feature(register_tool)]
-// FIXME: This feature is used to support vm capbility now as a work around.
-// Since this is an incomplete feature, use this feature is unsafe.
-// We should find a proper method to replace this feature with min_specialization, which is a sound feature.
-#![feature(specialization)]
 #![feature(step_trait)]
 #![feature(trait_alias)]
 #![feature(trait_upcasting)]

--- a/kernel/src/vm/vmar/dyn_cap.rs
+++ b/kernel/src/vm/vmar/dyn_cap.rs
@@ -109,7 +109,7 @@ impl Vmar<Rights> {
     /// # Access rights
     ///
     /// The method requires the Read right.
-    pub fn fork_from(vmar: &Vmar) -> Result<Self> {
+    pub fn fork_from(vmar: &Self) -> Result<Self> {
         vmar.check_rights(Rights::READ)?;
         let vmar_ = vmar.0.new_fork_root()?;
         Ok(Vmar(vmar_, Rights::all()))

--- a/kernel/src/vm/vmar/static_cap.rs
+++ b/kernel/src/vm/vmar/static_cap.rs
@@ -2,7 +2,7 @@
 
 use core::ops::Range;
 
-use aster_rights::{Dup, Rights, TRightSet, TRights, Write};
+use aster_rights::{Dup, Read, Rights, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 
 use super::{VmPerms, Vmar, VmarMapOptions, VmarRightsOp, Vmar_};
@@ -120,8 +120,8 @@ impl<R: TRights> Vmar<TRightSet<R>> {
     /// # Access rights
     ///
     /// The method requires the Read right.
-    pub fn fork_from<R1>(vmar: &Vmar<R1>) -> Result<Self> {
-        vmar.check_rights(Rights::READ)?;
+    #[require(R > Read)]
+    pub fn fork_from(vmar: &Self) -> Result<Self> {
         let vmar_ = vmar.0.new_fork_root()?;
         Ok(Vmar(vmar_, TRightSet(R::new())))
     }

--- a/kernel/src/vm/vmo/mod.rs
+++ b/kernel/src/vm/vmo/mod.rs
@@ -78,12 +78,12 @@ pub trait VmoRightsOp {
     /// Returns the access rights.
     fn rights(&self) -> Rights;
 
-    /// Check whether rights is included in self
+    /// Checks whether current rights meet the input `rights`.
     fn check_rights(&self, rights: Rights) -> Result<()> {
         if self.rights().contains(rights) {
             Ok(())
         } else {
-            return_errno_with_message!(Errno::EINVAL, "vmo rights check failed");
+            return_errno_with_message!(Errno::EACCES, "VMO rights are insufficient");
         }
     }
 
@@ -91,21 +91,6 @@ pub trait VmoRightsOp {
     fn to_dyn(self) -> Vmo<Rights>
     where
         Self: Sized;
-}
-
-// We implement this trait for VMO, so we can use functions on type like Vmo<R> without trait bounds.
-// FIXME: This requires the incomplete feature specialization, which should be fixed further.
-impl<R> VmoRightsOp for Vmo<R> {
-    default fn rights(&self) -> Rights {
-        unimplemented!()
-    }
-
-    default fn to_dyn(self) -> Vmo<Rights>
-    where
-        Self: Sized,
-    {
-        unimplemented!()
-    }
 }
 
 bitflags! {


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/54bd64269bd688b149b7f48f063f0e8cf2704a01/kernel/src/lib.rs#L25-L28

The incomplete `generic_const_exprs` feature in OSTD has been removed in https://github.com/asterinas/asterinas/pull/1875. Another incomplete `specialization` feature in the kernel is relatively easy to remove. Generally speaking, incomplete features do not have any soundness guarantee, so we should avoid it whenever possible.