### PR TITLE
Resolve lints in the TTY module

### DIFF
--- a/kernel/src/device/tty/device.rs
+++ b/kernel/src/device/tty/device.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(unused_variables)]
-
 use crate::{
     events::IoEvents,
     fs::{
@@ -41,17 +39,17 @@ impl Device for TtyDevice {
 }
 
 impl Pollable for TtyDevice {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
         IoEvents::empty()
     }
 }
 
 impl FileIo for TtyDevice {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot read tty device");
     }
 
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "cannot write tty device");
     }
 }

--- a/kernel/src/device/tty/driver.rs
+++ b/kernel/src/device/tty/driver.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(dead_code)]
-
 use ostd::mm::{Infallible, VmReader};
 use spin::Once;
 
@@ -84,11 +82,6 @@ fn console_input_callback(mut reader: VmReader<Infallible>) {
         let ch = reader.read_val().unwrap();
         tty_driver.push_char(ch);
     }
-}
-
-fn serial_input_callback(item: u8) {
-    let tty_driver = get_tty_driver();
-    tty_driver.push_char(item);
 }
 
 fn get_tty_driver() -> &'static TtyDriver {

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(unused_variables)]
-
 use alloc::format;
 
 use ostd::{
@@ -235,7 +233,7 @@ impl LineDiscipline {
                 let ctrl_char = format!("^{}", get_printable_char(ch));
                 echo_callback(&ctrl_char);
             }
-            item => {}
+            _ => {}
         }
     }
 
@@ -254,8 +252,6 @@ impl LineDiscipline {
             (vmin, vtime)
         };
         let read_len = {
-            let len = self.read_buffer.lock().len();
-            let max_read_len = len.min(dst.len());
             if vmin == 0 && vtime == 0 {
                 // poll read
                 self.poll_read(dst)
@@ -400,11 +396,6 @@ fn is_ctrl_char(ch: u8) -> bool {
 fn get_printable_char(ctrl_char: u8) -> char {
     debug_assert!(is_ctrl_char(ctrl_char));
     char::from_u32((ctrl_char + b'A' - 1) as u32).unwrap()
-}
-
-enum PolleeType {
-    Add,
-    Del,
 }
 
 struct LineDisciplineWorkPara {

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(dead_code)]
-
 use ostd::early_print;
 use spin::Once;
 
@@ -39,6 +37,7 @@ pub(super) fn init() {
 
 pub struct Tty {
     /// tty_name
+    #[expect(unused)]
     name: CString,
     /// line discipline
     ldisc: Arc<LineDiscipline>,


### PR DESCRIPTION
The TTY module needs some refactoring to properly support the coexistence of the virtio console and the framebuffer console. Most of the work is still in progress, but fixing the lints first should not be controversial.

The story behind is:
 1. try to refactor the TTY code
 2. found many race conditions in the job control code
 3. try to refactor the job control code
 4. found many race conditions in the process group/session code
 5. try to refactor the process group/session code
 6. submitted https://github.com/asterinas/asterinas/pull/2051

which is _really not flexible_.