### PR TITLE
Fix the memory leak on large heap deallocation

### DIFF
--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -116,6 +116,8 @@ impl<M: AnyFrameMeta> Segment<M> {
     /// It could be manually forgotten by [`core::mem::forget`],
     /// [`ManuallyDrop`], or [`Self::into_raw`].
     pub(crate) unsafe fn from_raw(range: Range<Paddr>) -> Self {
+        debug_assert_eq!(range.start % PAGE_SIZE, 0);
+        debug_assert_eq!(range.end % PAGE_SIZE, 0);
         Self {
             range,
             _marker: core::marker::PhantomData,

--- a/ostd/src/mm/heap/slot.rs
+++ b/ostd/src/mm/heap/slot.rs
@@ -116,8 +116,7 @@ impl HeapSlot {
 
         debug_assert_eq!(size % PAGE_SIZE, 0);
         debug_assert_eq!(self.paddr() % PAGE_SIZE, 0);
-        let nframes = size / PAGE_SIZE;
-        let range = self.paddr()..self.paddr() + nframes;
+        let range = self.paddr()..self.paddr() + size;
 
         // SAFETY: The segment was once forgotten when allocated.
         drop(unsafe { Segment::<LargeAllocFrameMeta>::from_raw(range) });


### PR DESCRIPTION
The bug is obvious. When deallocating a large heap slot that was served using the frame allocator, many of the tail pages are leaked. Because the range to be deallocated is calculated in the wrong way.

Now I can do `ab -n 200000 -c 1 http://10.0.2.15:8080/4096bytes.html` (Nginx benchmark) under 8G memory.