### PR TITLE
Handle negative P(G)IDs via `cast_(un)signed`

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(int_roundings)]
+#![feature(integer_sign_cast)]
 #![feature(let_chains)]
 #![feature(linked_list_cursors)]
 #![feature(linked_list_remove)]

--- a/kernel/src/syscall/setpgid.rs
+++ b/kernel/src/syscall/setpgid.rs
@@ -12,6 +12,10 @@ pub fn sys_setpgid(pid: Pid, pgid: Pgid, ctx: &Context) -> Result<SyscallReturn>
     // The documentation quoted below is from
     // <https://www.man7.org/linux/man-pages/man2/setpgid.2.html>.
 
+    if pid.cast_signed() < 0 || pgid.cast_signed() < 0 {
+        return_errno_with_message!(Errno::EINVAL, "negative PIDs or PGIDs are not valid");
+    }
+
     // "If `pid` is zero, then the process ID of the calling process is used."
     let pid = if pid == 0 { current.pid() } else { pid };
     // "If `pgid` is zero, then the PGID of the process specified by `pid` is made the same as its

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -15,14 +15,16 @@ pub fn sys_waitid(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     // FIXME: what does infoq and rusage use for?
-    let process_filter = ProcessFilter::from_which_and_id(which, upid)?;
+    let process_filter = ProcessFilter::from_which_and_id(which, upid as _)?;
     let wait_options = WaitOptions::from_bits(options as u32)
         .ok_or(Error::with_message(Errno::EINVAL, "invalid options"))?;
+
     let waited_process =
         wait_child_exit(process_filter, wait_options, ctx).map_err(|err| match err.error() {
             Errno::EINTR => Error::new(Errno::ERESTARTSYS),
             _ => err,
         })?;
+
     let pid = waited_process.map_or(0, |process| process.pid());
     Ok(SyscallReturn::Return(pid as _))
 }

--- a/test/apps/process/group_session.c
+++ b/test/apps/process/group_session.c
@@ -32,6 +32,10 @@ END_SETUP()
 
 FN_TEST(setpgid_invalid)
 {
+	// Negative PIDs or PGIDs
+	TEST_ERRNO(setpgid(-1, current), EINVAL);
+	TEST_ERRNO(setpgid(current, -1), EINVAL);
+
 	// Non-present process groups
 	TEST_ERRNO(setpgid(child1, child2), EPERM);
 	TEST_ERRNO(setpgid(child2, child1), EPERM);
@@ -176,6 +180,9 @@ END_TEST()
 
 FN_TEST(getpgid_invalid)
 {
+	// Negative PIDs
+	TEST_ERRNO(getpgid(-1), ESRCH);
+
 	// Non-present processes
 	TEST_ERRNO(getpgid(0x3c3c3c3c), ESRCH);
 }
@@ -183,6 +190,9 @@ END_TEST()
 
 FN_TEST(getsid_invalid)
 {
+	// Negative PIDs
+	TEST_ERRNO(getsid(-1), ESRCH);
+
 	// Non-present processes
 	TEST_ERRNO(getsid(0x3c3c3c3c), ESRCH);
 }


### PR DESCRIPTION
[`u32::cast_signed`](https://doc.rust-lang.org/std/primitive.u32.html#method.cast_signed)/[`i32::cast_unsigned`](https://doc.rust-lang.org/std/primitive.i32.html#method.cast_unsigned) [will be stabilized in Rust 1.87](https://github.com/rust-lang/rust/commit/38fba8ca96f67abfd5334a366d18daa28760d823).  So it should not be controversial to use it, as long as the use itself makes sense.

In fact, we should prefer to use it instead of the `as` cast:
 - Converting a `u64` to `i32` with an `as` cast will succeed, but
 - doing so with `cast_signed` will fail.

The compilation failure can be useful as it reminds us to update the code if the type has changed (e.g. if we change `Pid` from `u32` to `u64`, we should update the `ProcessFilter` type as well).