### PR TITLE
Allow specifying orderings when loading/storing `AtomicCpuSet`s

### DIFF
--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -3,7 +3,7 @@
 #![warn(unused)]
 
 use alloc::{boxed::Box, sync::Arc};
-use core::fmt;
+use core::{fmt, sync::atomic::Ordering};
 
 use ostd::{
     arch::read_tsc as sched_clock,
@@ -263,7 +263,7 @@ impl ClassScheduler {
         }
         debug_assert!(flags == EnqueueFlags::Spawn);
         let guard = disable_local();
-        let affinity = thread.atomic_cpu_affinity().load();
+        let affinity = thread.atomic_cpu_affinity().load(Ordering::Relaxed);
         let mut selected = guard.current_cpu();
         let mut minimum_load = u32::MAX;
         let last_chosen = match self.last_chosen_cpu.get() {

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -95,7 +95,7 @@ impl VmSpace {
             .try_write()
             .ok_or(VmSpaceClearError::CursorsAlive)?;
 
-        let cpus = self.cpus.load();
+        let cpus = self.cpus.load(Ordering::Relaxed);
         let cpu = preempt_guard.current_cpu();
         let cpus_set_is_empty = cpus.is_empty();
         let cpus_set_is_single_self = cpus.count() == 1 && cpus.contains(cpu);
@@ -142,7 +142,7 @@ impl VmSpace {
             CursorMut {
                 pt_cursor,
                 activation_lock,
-                flusher: TlbFlusher::new(self.cpus.load(), disable_preempt()),
+                flusher: TlbFlusher::new(self.cpus.load(Ordering::Relaxed), disable_preempt()),
             }
         })?)
     }

--- a/ostd/src/sync/rcu/monitor.rs
+++ b/ostd/src/sync/rcu/monitor.rs
@@ -129,7 +129,7 @@ impl GracePeriod {
     unsafe fn finish_grace_period(&mut self, this_cpu: CpuId) {
         self.cpu_mask.add(this_cpu, Ordering::Relaxed);
 
-        if self.cpu_mask.load().is_full() {
+        if self.cpu_mask.load(Ordering::Relaxed).is_full() {
             self.is_complete = true;
         }
     }
@@ -140,7 +140,7 @@ impl GracePeriod {
 
     pub fn restart(&mut self, callbacks: Callbacks) {
         self.is_complete = false;
-        self.cpu_mask.store(&CpuSet::new_empty());
+        self.cpu_mask.store(&CpuSet::new_empty(), Ordering::Relaxed);
         self.callbacks = callbacks;
     }
 }


### PR DESCRIPTION
This is needed by #1948 where we sync on the `AtomicCpuSet`s.