### PR TITLE
Allow non-leaders to operate jobs

### DIFF
--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -316,27 +316,6 @@ impl Process {
             .map_or(0, |session| session.sid())
     }
 
-    /// Returns the process group and the session if the process is a session leader.
-    ///
-    /// Note that once a process becomes a session leader, it remains a session leader forever.
-    /// Specifically, it can no longer be moved to a new process group or a new session. So this
-    /// method is race-free.
-    //
-    // FIXME: If we call this method on a non-current process without holding the process table
-    // lock, the session may be dead if the process is reaped at the same time.
-    fn leading_session(&self) -> Option<(Arc<ProcessGroup>, Arc<Session>)> {
-        let process_group_mut = self.process_group.lock();
-
-        let process_group = process_group_mut.upgrade().unwrap();
-        let session = process_group.session().unwrap();
-
-        if session.is_leader(self) {
-            Some((process_group, session))
-        } else {
-            None
-        }
-    }
-
     /// Returns the controlling terminal of the process, if any.
     pub fn terminal(&self) -> Option<Arc<dyn Terminal>> {
         self.process_group

--- a/test/syscall_test/blocklists/pty_test
+++ b/test/syscall_test/blocklists/pty_test
@@ -24,9 +24,5 @@ PtyTest.SwitchTwiceMultiline
 JobControlTest.SetTTYBadArg
 JobControlTest.SetTTYDifferentSession
 JobControlTest.ReleaseTTYSignals
-# FIXME: `ReleaseTTYNonLeader` does pass in Linux, but is disabled because we
-# cannot mimic the exact Linux behavior due to some design differences.
-# See <https://github.com/asterinas/asterinas/pull/2066#issuecomment-2865177068>.
-JobControlTest.ReleaseTTYNonLeader
 JobControlTest.SetForegroundProcessGroup
 JobControlTest.SetForegroundProcessGroupEmptyProcessGroup


### PR DESCRIPTION
https://github.com/asterinas/asterinas/pull/2066 introduces a severe regression (sorry):
```
~ # ls
sh: can't set tty process group: Inappropriate ioctl for device
~ # cat
sh: can't set tty process group: Inappropriate ioctl for device
~ # chmod
sh: can't set tty process group: Inappropriate ioctl for device
```

This only affects the interaction shell, so it cannot be detected by the regression tests (i.e., our CI).

The statement claimed in https://github.com/asterinas/asterinas/pull/2066#issuecomment-2865177068 is basically correct, but the decision made there is to allow the second code snippet, which is problematic because it can cause the shell to fail in certain situations.

To be clear, why I preferred to allow the second code snippet in https://github.com/asterinas/asterinas/pull/2066#issuecomment-2865177068 is because allowing the first code snippet will complicate the regression tests. But now I think we have no other choice but to accept the complication. This PR fixes the problem, and also makes the regression tests conform to our code. A few more TODOs are added, since our behavior is still different from Linux.

```c
// TODO: Next we do `kill_child` and `run_child_with_tty` because the
// Linux kernel keeps track of the controlling terminal of each process
// in `current->signal->tty`. So without killing and restarting the
// child, the controlling terminal won't be visible to it in Linux, but
// will be visible in Asterinas. We may want to fix this behavioral
// difference later.
```

---

~https://github.com/asterinas/asterinas/issues/2072 reports a race in regression testing. The SIGCHLD triggered by the child exit can interrupt the sleep process and cause it to fail. A workaround is to add an extra sleep, but ignore the result. (Note that this won't happen in Linux because ignored singals won't cause `EINTR` in Linux).~ This workaround has been removed per the discussion below.

```c
	// In Asterinas, SIGCHLD can cause a previous sleep to
	// fail with an `EINTR`. So we insert another sleep here
	// and ignore the result to work around the problem.
	usleep(100 * 1000);
```