### PR TITLE
Publish the heap allocator after updating the version

### DIFF
--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -86,6 +86,7 @@ for TARGET in $TARGETS; do
     do_publish_for ostd/libs/ostd-test --target $TARGET
     do_publish_for ostd --target $TARGET
     do_publish_for osdk/deps/frame-allocator --target $TARGET
+    do_publish_for osdk/deps/heap-allocator --target $TARGET
     do_publish_for osdk/deps/test-kernel --target $TARGET
 
     # For actual publishing, we should only publish once. Using any target that


### PR DESCRIPTION
The heap allocator was missed when publishing OSTD, so I've added it to the publish script.

I've manually published heap allocator version 0.15.0 to crates.io.

We might need to perform a version bump soon, as the documentation for OSTD 0.15.0 on `docs.rs` has failed to build. Only a version bump can trigger a rebuild of the documentation on `docs.rs`.