### PR TITLE
Remove guard generics from `xarray::Cursor{,Mut}`

### DIFF
--- a/kernel/libs/xarray/src/mark.rs
+++ b/kernel/libs/xarray/src/mark.rs
@@ -16,17 +16,17 @@ pub(super) struct Mark {
 }
 
 impl Mark {
-    pub const fn new(inner: u64) -> Self {
+    pub(super) const fn new(inner: u64) -> Self {
         Self {
             inner: AtomicU64::new(inner),
         }
     }
 
-    pub const fn new_empty() -> Self {
+    pub(super) const fn new_empty() -> Self {
         Self::new(0)
     }
 
-    pub fn update(&self, _guard: XLockGuard, offset: u8, set: bool) -> bool {
+    pub(super) fn update(&self, _guard: XLockGuard, offset: u8, set: bool) -> bool {
         let old_val = self.inner.load(Ordering::Acquire);
         let new_val = if set {
             old_val | (1 << offset as u64)
@@ -39,11 +39,11 @@ impl Mark {
         old_val != new_val
     }
 
-    pub fn is_marked(&self, offset: u8) -> bool {
+    pub(super) fn is_marked(&self, offset: u8) -> bool {
         self.inner.load(Ordering::Acquire) & (1 << offset as u64) != 0
     }
 
-    pub fn is_clear(&self) -> bool {
+    pub(super) fn is_clear(&self) -> bool {
         self.inner.load(Ordering::Acquire) == 0
     }
 }
@@ -65,7 +65,7 @@ pub enum XMark {
     Mark2,
 }
 
-pub const NUM_MARKS: usize = 3;
+pub(super) const NUM_MARKS: usize = 3;
 
 impl XMark {
     /// Maps the `XMark` to an index in the range 0 to 2.

--- a/kernel/libs/xarray/src/mark.rs
+++ b/kernel/libs/xarray/src/mark.rs
@@ -2,8 +2,6 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use ostd::sync::SpinGuardian;
-
 use crate::XLockGuard;
 
 /// A mark used to indicate which slots in an [`XNode`] contain items that have been marked.
@@ -28,7 +26,7 @@ impl Mark {
         Self::new(0)
     }
 
-    pub fn update<G: SpinGuardian>(&self, offset: u8, set: bool, _guard: &XLockGuard<G>) -> bool {
+    pub fn update(&self, _guard: XLockGuard, offset: u8, set: bool) -> bool {
         let old_val = self.inner.load(Ordering::Acquire);
         let new_val = if set {
             old_val | (1 << offset as u64)

--- a/kernel/libs/xarray/src/range.rs
+++ b/kernel/libs/xarray/src/range.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{
-    sync::non_null::NonNullPtr,
-    task::{atomic_mode::AsAtomicModeGuard, DisabledPreemptGuard},
-};
+use ostd::sync::non_null::NonNullPtr;
 
 use crate::{cursor::Cursor, mark::NoneMark};
 
@@ -13,23 +10,21 @@ use crate::{cursor::Cursor, mark::NoneMark};
 ///
 /// [`XArray`]: super::XArray
 /// [`XArray::range`]: super::XArray::range
-pub struct Range<'a, P, M = NoneMark, G = DisabledPreemptGuard>
+pub struct Range<'a, P, M = NoneMark>
 where
     P: NonNullPtr + Send + Sync,
 {
-    cursor: Cursor<'a, P, M, G>,
+    cursor: Cursor<'a, P, M>,
     end: u64,
 }
 
-impl<'a, P: NonNullPtr + Send + Sync, M, G: AsAtomicModeGuard> Range<'a, P, M, G> {
-    pub(super) fn new(cursor: Cursor<'a, P, M, G>, end: u64) -> Self {
+impl<'a, P: NonNullPtr + Send + Sync, M> Range<'a, P, M> {
+    pub(super) fn new(cursor: Cursor<'a, P, M>, end: u64) -> Self {
         Range { cursor, end }
     }
 }
 
-impl<'a, P: NonNullPtr + Send + Sync, M, G: AsAtomicModeGuard> core::iter::Iterator
-    for Range<'a, P, M, G>
-{
+impl<'a, P: NonNullPtr + Send + Sync, M> core::iter::Iterator for Range<'a, P, M> {
     type Item = (u64, P::Ref<'a>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ostd/src/task/atomic_mode.rs
+++ b/ostd/src/task/atomic_mode.rs
@@ -73,3 +73,9 @@ impl<G: InAtomicMode> AsAtomicModeGuard for G {
         self
     }
 }
+
+impl AsAtomicModeGuard for dyn InAtomicMode + '_ {
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode {
+        self
+    }
+}


### PR DESCRIPTION
In general, I find the pattern `Cursor<..., G: AsAtomicModeGuard>` problematic. The intent of this pattern is to allow the caller to use different atomic mode guards (e.g., preemption guards, IRQ guards, or others) at their convenience. Thus, the caller can create `Cursor<..., DisabledPreemptGuard>`, `Cursor<..., DisabledLocalIrqGuard>`, etc.

This is all well and good, but the problem is that Rust is a language that tends to [monomorphize all generic types](https://rustc-dev-guide.rust-lang.org/backend/monomorph.html). So as long as I see both `Cursor<..., DisabledPreemptGuard>` and `Cursor<..., DisabledLocalIrqGuard>`, I feel like all the methods are being repeated twice, and repeated for no good reason _at all_ (the guard just helps with safety reasoning, and is not actually used).

While it can be argued that the compiler is smart enough to detect this and avoid generating the duplicate code, it's still not very ideal to me. This will remain true unless someone can give me a strong argument that the compiler must be able to do this as long as certain conditions are met, and we do meet those conditions. I have tried to find such rules, but have not been able to find any resources.

On the other hand, this problem can be solved by simply calling `AsAtomicModeGuard::as_atomic_mode_guard` before or on creating the cursor, and letting the cursor just maintain a `&dyn InAtomicMode`. This sounds very right to me, because it doesn't cause any performance overhead, solves the code explosion problem above, and even makes the code look better.

However, the current implementation of `Rcu::read_with` does not seem to accept a `&dyn InAtomicMode`, which is unexpected. I believe it's reasonable to do a `impl AsAtomicModeGuard for dyn InAtomicMode` to fix it.

I have to make `trait InAtomicMode: 'static {}` because otherwise there are some wired errors:
```
error[E0521]: borrowed data escapes outside of method
   --> /root/asterinas/kernel/libs/xarray/src/cursor.rs:139:26
    |
115 | impl<'a, P: NonNullPtr + Send + Sync, M> Cursor<'a, P, M> {
    |      -- lifetime `'a` defined here
...
134 |     fn traverse_to_target(&mut self) {
    |                           --------- `self` is a reference that is only valid in the method body
...
139 |         let Some(head) = self.xa.head.read_with(self.guard) else {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                          |
    |                          `self` escapes the method body here
    |                          argument requires that `'a` must outlive `'static`
```

Also fixing some visibility issues in the `xarray` crate and assigning code owners (@cchanging). Hopefully I'm doing it right?