### PR TITLE
Assign some library code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,10 @@
 /kernel/comps/time/             @cchanging
 /kernel/comps/virtio/           @sdww0
 
+# Library code owners
+/kernel/libs/aster-bigtcp/      @StevenJiang1110 @lrh2000
+/kernel/libs/xarray/            @cchanging @lrh2000
+
 #=============================================================================
 # The Asterinas OSDK
 #=============================================================================


### PR DESCRIPTION
As suggested by https://github.com/asterinas/asterinas/pull/2078#issuecomment-2879341853, splitting the CODEOWNERS changes from #2078.

This PR assigns the code owners for `/kernel/libs/aster-bigtcp/` and `/kernel/libs/xarray/`.