### PR TITLE
Warn `unsafe_op_in_unsafe_fn` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ exclude = [
     "osdk",
 ]
 
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+
 [workspace.lints.clippy]
 allow_attributes = "warn"
 

--- a/ostd/src/arch/x86/device/serial.rs
+++ b/ostd/src/arch/x86/device/serial.rs
@@ -36,21 +36,18 @@ impl SerialPort {
     ///
     /// User must ensure the `port` is valid serial port.
     pub const unsafe fn new(port: u16) -> Self {
-        let data = IoPort::new(port);
-        let int_en = IoPort::new(port + 1);
-        let fifo_ctrl = IoPort::new(port + 2);
-        let line_ctrl = IoPort::new(port + 3);
-        let modem_ctrl = IoPort::new(port + 4);
-        let line_status = IoPort::new(port + 5);
-        let modem_status = IoPort::new(port + 6);
-        Self {
-            data,
-            int_en,
-            fifo_ctrl,
-            line_ctrl,
-            modem_ctrl,
-            line_status,
-            modem_status,
+        // SAFETY: The caller guarantees that these ports are serial ports, so the `IoPort`s can be
+        // created safely.
+        unsafe {
+            Self {
+                data: IoPort::new(port),
+                int_en: IoPort::new(port + 1),
+                fifo_ctrl: IoPort::new(port + 2),
+                line_ctrl: IoPort::new(port + 3),
+                modem_ctrl: IoPort::new(port + 4),
+                line_status: IoPort::new(port + 5),
+                modem_status: IoPort::new(port + 6),
+            }
         }
     }
 

--- a/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
@@ -77,8 +77,9 @@ impl RootTable {
             return Err(ContextTableError::InvalidDeviceId);
         }
 
-        self.get_or_create_context_table(device)
-            .map(device, daddr, paddr)?;
+        let context_table = self.get_or_create_context_table(device);
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { context_table.map(device, daddr, paddr)? };
 
         Ok(())
     }
@@ -92,8 +93,8 @@ impl RootTable {
             return Err(ContextTableError::InvalidDeviceId);
         }
 
-        self.get_or_create_context_table(device)
-            .unmap(device, daddr)?;
+        let context_table = self.get_or_create_context_table(device);
+        context_table.unmap(device, daddr)?;
 
         Ok(())
     }
@@ -297,23 +298,26 @@ impl ContextTable {
         if device.device >= 32 || device.function >= 8 {
             return Err(ContextTableError::InvalidDeviceId);
         }
+
         trace!(
             "Mapping Daddr: {:x?} to Paddr: {:x?} for device: {:x?}",
             daddr,
             paddr,
             device
         );
-        self.get_or_create_page_table(device)
-            .map(
-                &(daddr..daddr + PAGE_SIZE),
-                &(paddr..paddr + PAGE_SIZE),
-                PageProperty {
-                    flags: PageFlags::RW,
-                    cache: CachePolicy::Uncacheable,
-                    priv_flags: PrivFlags::empty(),
-                },
-            )
-            .unwrap();
+
+        let from = daddr..daddr + PAGE_SIZE;
+        let to = paddr..paddr + PAGE_SIZE;
+        let prop = PageProperty {
+            flags: PageFlags::RW,
+            cache: CachePolicy::Uncacheable,
+            priv_flags: PrivFlags::empty(),
+        };
+
+        let pt = self.get_or_create_page_table(device);
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { pt.map(&from, &to, prop).unwrap() };
+
         Ok(())
     }
 
@@ -321,13 +325,16 @@ impl ContextTable {
         if device.device >= 32 || device.function >= 8 {
             return Err(ContextTableError::InvalidDeviceId);
         }
+
         trace!("Unmapping Daddr: {:x?} for device: {:x?}", daddr, device);
+
         let pt = self.get_or_create_page_table(device);
         let mut cursor = pt.cursor_mut(&(daddr..daddr + PAGE_SIZE)).unwrap();
-        unsafe {
-            let result = cursor.take_next(PAGE_SIZE);
-            debug_assert!(matches!(result, PageTableItem::MappedUntracked { .. }));
-        }
+
+        // SAFETY: This unmaps a page from the context table, which is always safe.
+        let item = unsafe { cursor.take_next(PAGE_SIZE) };
+        debug_assert!(matches!(item, PageTableItem::MappedUntracked { .. }));
+
         Ok(())
     }
 }

--- a/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
@@ -122,7 +122,7 @@ impl RootTable {
         }
 
         // Activate page table.
-        let address = unsafe { page_table.root_paddr() };
+        let address = page_table.root_paddr();
         context_table.page_tables.insert(address, page_table);
         let entry = ContextEntry(address as u128 | 1 | 0x1_0000_0000_0000_0000);
         context_table
@@ -267,7 +267,7 @@ impl ContextTable {
 
         if !bus_entry.is_present() {
             let table = PageTable::<DeviceMode, PageTableEntry, PagingConsts>::empty();
-            let address = unsafe { table.root_paddr() };
+            let address = table.root_paddr();
             self.page_tables.insert(address, table);
             let entry = ContextEntry(address as u128 | 3 | 0x1_0000_0000_0000_0000);
             self.entries_frame

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -233,7 +233,10 @@ pub(super) static FAULT_EVENT_REGS: Once<SpinLock<FaultEventRegisters, LocalIrqD
 ///
 /// User must ensure the base_register_vaddr is read from DRHD
 pub(super) unsafe fn init(base_register_vaddr: NonNull<u8>) {
-    FAULT_EVENT_REGS.call_once(|| SpinLock::new(FaultEventRegisters::new(base_register_vaddr)));
+    FAULT_EVENT_REGS
+        // SAFETY: The caller guarantees that the memory contain IOMMU registers, so
+        // the `FaultEventRegisters` can be created safely.
+        .call_once(|| SpinLock::new(unsafe { FaultEventRegisters::new(base_register_vaddr) }));
 }
 
 fn iommu_fault_handler(_frame: &TrapFrame) {

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/mod.rs
@@ -45,6 +45,7 @@ impl IrtEntryHandle {
     /// # Safety
     ///
     /// User must ensure the target address is **always** valid and point to `IrtEntry`.
+    #[expect(unsafe_op_in_unsafe_fn)]
     pub(self) unsafe fn new(table_vaddr: Vaddr, index: u16) -> Self {
         Self {
             index,

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -191,6 +191,8 @@ pub(crate) unsafe fn send_ipi(cpu_id: CpuId, irq_num: u8) {
         irq_num,
     );
     apic::with_borrow(|apic| {
-        apic.send_ipi(icr);
+        // SAFETY: The ICR is valid to generate the request IPI. Generating the request IPI is safe
+        // as guaranteed by the caller.
+        unsafe { apic.send_ipi(icr) };
     });
 }

--- a/ostd/src/arch/x86/kernel/apic/ioapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/ioapic.rs
@@ -144,9 +144,17 @@ impl IoApicAccess {
     /// User must ensure the base address is valid.
     unsafe fn new(base_address: usize, io_mem_builder: &IoMemAllocatorBuilder) -> Self {
         io_mem_builder.remove(base_address..(base_address + 0x20));
-        let base = NonNull::new(paddr_to_vaddr(base_address) as *mut u8).unwrap();
-        let register = VolatileRef::new_restricted(WriteOnly, base.cast::<u32>());
-        let data = VolatileRef::new(base.add(0x10).cast::<u32>());
+
+        let register_addr = NonNull::new(paddr_to_vaddr(base_address) as *mut u32).unwrap();
+        // SAFETY: The caller guarantees that the memory is an I/O ACPI register, so the
+        // `VolatileRef` can be created safely.
+        let register = unsafe { VolatileRef::new_restricted(WriteOnly, register_addr) };
+
+        let data_addr = NonNull::new(paddr_to_vaddr(base_address + 0x10) as *mut u32).unwrap();
+        // SAFETY: The caller guarantees that the memory is an I/O ACPI register, so the
+        // `VolatileRef` can be created safely.
+        let data = unsafe { VolatileRef::new(data_addr) };
+
         Self { register, data }
     }
 

--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -69,15 +69,19 @@ impl super::Apic for X2Apic {
 
     unsafe fn send_ipi(&self, icr: super::Icr) {
         let _guard = crate::trap::disable_local();
-        wrmsr(IA32_X2APIC_ESR, 0);
-        wrmsr(IA32_X2APIC_ICR, icr.0);
-        loop {
-            let icr = rdmsr(IA32_X2APIC_ICR);
-            if ((icr >> 12) & 0x1) == 0 {
-                break;
-            }
-            if rdmsr(IA32_X2APIC_ESR) > 0 {
-                break;
+        // SAFETY: These `rdmsr` and `wrmsr` instructions write the interrupt command to APIC and
+        // wait for results. The caller guarantees it's safe to execute this interrupt command.
+        unsafe {
+            wrmsr(IA32_X2APIC_ESR, 0);
+            wrmsr(IA32_X2APIC_ICR, icr.0);
+            loop {
+                let icr = rdmsr(IA32_X2APIC_ICR);
+                if ((icr >> 12) & 0x1) == 0 {
+                    break;
+                }
+                if rdmsr(IA32_X2APIC_ESR) > 0 {
+                    break;
+                }
             }
         }
     }

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -52,13 +52,18 @@ pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), Pag
     let _ = boot_pt::with_borrow(|boot_pt| {
         for i in 0..page_num {
             let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
-            boot_pt.protect_base_page(vaddr, protect_op);
+            // SAFETY: The caller ensures that the address range exists in the linear mapping and
+            // can be mapped as shared pages.
+            unsafe { boot_pt.protect_base_page(vaddr, protect_op) };
         }
     });
+
     // Protect the page in the kernel page table.
     let pt = KERNEL_PAGE_TABLE.get().unwrap();
     let vaddr = paddr_to_vaddr(gpa);
-    pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
+    // SAFETY: The caller ensures that the address range exists in the linear mapping and can be
+    // mapped as shared pages.
+    unsafe { pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op) }
         .map_err(|_| PageConvertError::PageTable)?;
 
     map_gpa(
@@ -94,21 +99,28 @@ pub unsafe fn protect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), PageC
     let _ = boot_pt::with_borrow(|boot_pt| {
         for i in 0..page_num {
             let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
-            boot_pt.protect_base_page(vaddr, protect_op);
+            // SAFETY: The caller ensures that the address range exists in the linear mapping and
+            // can be mapped as non-shared pages.
+            unsafe { boot_pt.protect_base_page(vaddr, protect_op) };
         }
     });
+
     // Protect the page in the kernel page table.
     let pt = KERNEL_PAGE_TABLE.get().unwrap();
     let vaddr = paddr_to_vaddr(gpa);
-    pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op)
+    // SAFETY: The caller ensures that the address range exists in the linear mapping and can be
+    // mapped as non-shared pages.
+    unsafe { pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op) }
         .map_err(|_| PageConvertError::PageTable)?;
 
     map_gpa((gpa & PAGE_MASK) as u64, (page_num * PAGE_SIZE) as u64)
         .map_err(|_| PageConvertError::TdVmcall)?;
     for i in 0..page_num {
+        // SAFETY: The caller ensures that the address range represents physical memory so the
+        // memory can be accepted.
         unsafe {
-            accept_page(0, (gpa + i * PAGE_SIZE) as u64).map_err(|_| PageConvertError::TdCall)?;
-        }
+            accept_page(0, (gpa + i * PAGE_SIZE) as u64).map_err(|_| PageConvertError::TdCall)?
+        };
     }
     Ok(())
 }

--- a/ostd/src/io/io_mem/allocator.rs
+++ b/ostd/src/io/io_mem/allocator.rs
@@ -114,7 +114,8 @@ pub static IO_MEM_ALLOCATOR: Once<IoMemAllocator> = Once::new();
 /// User must ensure all the memory I/O regions that belong to the system device have been removed by calling the
 /// `remove` function.
 pub(crate) unsafe fn init(io_mem_builder: IoMemAllocatorBuilder) {
-    IO_MEM_ALLOCATOR.call_once(|| IoMemAllocator::new(io_mem_builder.allocators));
+    // SAFETY: The safety is upheld by the caller.
+    IO_MEM_ALLOCATOR.call_once(|| unsafe { IoMemAllocator::new(io_mem_builder.allocators) });
 }
 
 fn find_allocator<'a>(

--- a/ostd/src/io/mod.rs
+++ b/ostd/src/io/mod.rs
@@ -37,7 +37,12 @@ cfg_if!(
 /// 3. `MAX_IO_PORT` defined in `crate::arch::io` is guaranteed not to
 ///    exceed the maximum value specified by architecture.
 pub(crate) unsafe fn init(io_mem_builder: IoMemAllocatorBuilder) {
-    self::io_mem::init(io_mem_builder);
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { self::io_mem::init(io_mem_builder) };
+
+    // SAFETY: The safety is upheld by the caller.
     #[cfg(target_arch = "x86_64")]
-    self::io_port::init();
+    unsafe {
+        self::io_port::init()
+    };
 }

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -302,7 +302,9 @@ unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
     //
     // For more details and future possibilities, see
     // <https://github.com/asterinas/asterinas/pull/1001#discussion_r1667317406>.
-    core::intrinsics::volatile_copy_memory(dst, src, len);
+
+    // SAFETY: The safety is guaranteed by the safety preconditions and the explanation above.
+    unsafe { core::intrinsics::volatile_copy_memory(dst, src, len) };
 }
 
 /// Copies `len` bytes from `src` to `dst`.
@@ -322,7 +324,8 @@ unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
 ///
 /// [valid]: crate::mm::io#safety
 unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
-    let failed_bytes = __memcpy_fallible(dst, src, len);
+    // SAFETY: The safety is upheld by the caller.
+    let failed_bytes = unsafe { __memcpy_fallible(dst, src, len) };
     len - failed_bytes
 }
 
@@ -337,7 +340,8 @@ unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
 ///
 /// [valid]: crate::mm::io#safety
 unsafe fn memset_fallible(dst: *mut u8, value: u8, len: usize) -> usize {
-    let failed_bytes = __memset_fallible(dst, value, len);
+    // SAFETY: The safety is upheld by the caller.
+    let failed_bytes = unsafe { __memset_fallible(dst, value, len) };
     len - failed_bytes
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -548,10 +548,13 @@ impl<'a> VmReader<'a, Infallible> {
 
     /// Converts to a fallible reader.
     pub fn to_fallible(self) -> VmReader<'a, Fallible> {
-        // SAFETY: It is safe to transmute to a fallible reader since
-        // 1. the fallibility is a zero-sized marker type,
-        // 2. an infallible reader covers the capabilities of a fallible reader.
-        unsafe { core::mem::transmute(self) }
+        // It is safe to construct a fallible reader since an infallible reader covers the
+        // capabilities of a fallible reader.
+        VmReader {
+            cursor: self.cursor,
+            end: self.end,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -799,10 +802,13 @@ impl<'a> VmWriter<'a, Infallible> {
 
     /// Converts to a fallible writer.
     pub fn to_fallible(self) -> VmWriter<'a, Fallible> {
-        // SAFETY: It is safe to transmute to a fallible writer since
-        // 1. the fallibility is a zero-sized marker type,
-        // 2. an infallible reader covers the capabilities of a fallible reader.
-        unsafe { core::mem::transmute(self) }
+        // It is safe to construct a fallible reader since an infallible reader covers the
+        // capabilities of a fallible reader.
+        VmWriter {
+            cursor: self.cursor,
+            end: self.end,
+            phantom: PhantomData,
+        }
     }
 }
 

--- a/ostd/src/mm/page_table/cursor.rs
+++ b/ostd/src/mm/page_table/cursor.rs
@@ -809,7 +809,8 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> CursorM
                     // Do copy.
                     op(&mut prop);
                     self.jump(src_va).unwrap();
-                    let original = self.map(page, prop);
+                    // SAFETY: The safety is upheld by the caller.
+                    let original = unsafe { self.map(page, prop) };
                     assert!(original.is_none());
 
                     // Only move the source cursor forward since `Self::map` will do it.

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -215,9 +215,10 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTab
 
     /// The physical address of the root page table.
     ///
-    /// It is dangerous to directly provide the physical address of the root page table to the
-    /// hardware since the page table node may be dropped, resulting in UAF.
-    pub unsafe fn root_paddr(&self) -> Paddr {
+    /// Obtaining the physical address of the root page table is safe, however, using it or
+    /// providing it to the hardware will be unsafe since the page table node may be dropped,
+    /// resulting in UAF.
+    pub fn root_paddr(&self) -> Paddr {
         self.root.paddr()
     }
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -192,7 +192,10 @@ impl PageTable<KernelMode> {
         mut op: impl FnMut(&mut PageProperty),
     ) -> Result<(), PageTableError> {
         let mut cursor = CursorMut::new(self, vaddr)?;
-        while let Some(range) = cursor.protect_next(vaddr.end - cursor.virt_addr(), &mut op) {
+        // SAFETY: The safety is upheld by the caller.
+        while let Some(range) =
+            unsafe { cursor.protect_next(vaddr.end - cursor.virt_addr(), &mut op) }
+        {
             crate::arch::mm::tlb_flush_addr(range.start);
         }
         Ok(())
@@ -210,7 +213,8 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTab
     }
 
     pub(in crate::mm) unsafe fn first_activate_unchecked(&self) {
-        self.root.first_activate();
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { self.root.first_activate() };
     }
 
     /// The physical address of the root page table.
@@ -228,7 +232,9 @@ impl<'a, M: PageTableMode, E: PageTableEntryTrait, C: PagingConstsTrait> PageTab
         paddr: &Range<Paddr>,
         prop: PageProperty,
     ) -> Result<(), PageTableError> {
-        self.cursor_mut(vaddr)?.map_pa(paddr, prop);
+        let mut cursor = self.cursor_mut(vaddr)?;
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { cursor.map_pa(paddr, prop) };
         Ok(())
     }
 

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -132,7 +132,8 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> RawPageTableNode<E, C> {
             return;
         }
 
-        activate_page_table(self.raw, CachePolicy::Writeback);
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { activate_page_table(self.raw, CachePolicy::Writeback) };
 
         // Increment the reference count of the current page table.
         self.inc_ref_count();
@@ -154,7 +155,8 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> RawPageTableNode<E, C> {
 
         self.inc_ref_count();
 
-        activate_page_table(self.raw, CachePolicy::Writeback);
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { activate_page_table(self.raw, CachePolicy::Writeback) };
     }
 
     fn inc_ref_count(&self) {

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -185,7 +185,7 @@ impl VmSpace {
     /// Users must ensure that no other page table is activated in the current task during the
     /// lifetime of the created `VmReader`. This guarantees that the `VmReader` can operate correctly.
     pub fn reader(&self, vaddr: Vaddr, len: usize) -> Result<VmReader<'_, Fallible>> {
-        if current_page_table_paddr() != unsafe { self.pt.root_paddr() } {
+        if current_page_table_paddr() != self.pt.root_paddr() {
             return Err(Error::AccessDenied);
         }
 
@@ -205,7 +205,7 @@ impl VmSpace {
     /// Users must ensure that no other page table is activated in the current task during the
     /// lifetime of the created `VmWriter`. This guarantees that the `VmWriter` can operate correctly.
     pub fn writer(&self, vaddr: Vaddr, len: usize) -> Result<VmWriter<'_, Fallible>> {
-        if current_page_table_paddr() != unsafe { self.pt.root_paddr() } {
+        if current_page_table_paddr() != self.pt.root_paddr() {
             return Err(Error::AccessDenied);
         }
 


### PR DESCRIPTION
This PR concludes a series of efforts to enable the `unsafe_op_in_unsafe_fn` lint. This lint will be warned by default in Rust 2024. This lint is really good lint that I think deserves to be handled carefully rather than just suppressed.

If we have carefully written all the unsafe code, this lint should not cause much trouble, because we just need to add some `unsafe` blocks!

But the problem is that in some cases I have found that I cannot write proper safety comments for the newly added unsafe block, which means that the original code is buggy and requires some refactoring to fix the underlying unsoundness.

So the refactoring has to be done over several months:
 - https://github.com/asterinas/asterinas/pull/1836
 - https://github.com/asterinas/asterinas/pull/1866
 - https://github.com/asterinas/asterinas/pull/1786
 - https://github.com/asterinas/asterinas/pull/2030
 - https://github.com/asterinas/asterinas/pull/2068

So this PR finally enables the lint, with all newly added `unsafe` blocks properly documented.

---

This PR contains 9 commits, which sounds very awful. This PR touches many modules in the OSTD, and most of the changes are fairly trivial, so I'm not sure what the best way to create commits is. I'm currently grouping similar changes into one commit, rather than grouping changes to a specific module into one commit. If you're more interested in changes to a specific module, you can just check the whole diff and locate the module you're interested in.

Again, almost all the changes are trivial. `` Use `wrapping_add` to add userspace pointers `` can be an exception which needs some more explanation. We previously use `ptr::add` to operate userspace pointers, however, the safety requirements of `ptr::add` [claim](https://doc.rust-lang.org/std/primitive.pointer.html#safety-7) that:
> If the computed offset is non-zero, then self must be [derived from](https://doc.rust-lang.org/std/ptr/index.html#provenance) a pointer to some [allocated object](https://doc.rust-lang.org/std/ptr/index.html#allocated-object)

I don't know how one could argue that the user space pointer belongs to an allocated object. I [asked](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/.60.7Bptr.7D.3A.3Aadd.60.20with.20a.20pointer.20outside.20the.20Rust.20world/near/516648519) the Rust people to explain this rule. They said there is no reason to take the risk of using `ptr::add` because it is not designed for that purpose. The underlying LLVM `getelementptr inbounds` "in spirit" requires an allocation. However, since there is no formal LLVM specification, it is unclear whether this use case constitutes undefined behavior (UB). Using `ptr::wrapping_add` is preferable. I made the switch accordingly.