### PR TITLE
Don't enable DMA remapping if 3-level page tables are not supported

### DIFF
--- a/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
@@ -74,6 +74,11 @@ pub fn init() {
     // Create a Root Table instance.
     let mut root_table = RootTable::new();
     // For all PCI devices, use the same page table.
+    //
+    // TODO: The BIOS reserves some memory regions as DMA targets and lists them in the Reserved
+    // Memory Region Reporting (RMRR) structures. These regions must be mapped for the hardware or
+    // firmware to function properly. For more details, see Intel(R) Virtualization Technology for
+    // Directed I/O (Revision 5.0), 3.16 Handling Requests to Reserved System Memory.
     let page_table = PageTable::<DeviceMode, PageTableEntry, PagingConsts>::empty();
     for table in PciDeviceLocation::all() {
         root_table.specify_device_page_table(table, unsafe { page_table.shallow_copy() })

--- a/ostd/src/arch/x86/iommu/registers/capability.rs
+++ b/ostd/src/arch/x86/iommu/registers/capability.rs
@@ -38,7 +38,7 @@ impl Capability {
 
     /// Number of domain support.
     ///
-    /// ```norun
+    /// ```text
     /// 0 => 4-bit domain-ids with support for up to 16 domains.
     /// 1 => 6-bit domain-ids with support for up to 64 domains.
     /// 2 => 8-bit domain-ids with support for up to 256 domains.
@@ -54,15 +54,8 @@ impl Capability {
     }
 
     /// Supported Adjusted Guest Address Widths.
-    /// ```norun
-    /// 0/4 => Reserved
-    /// 1   => 39-bit AGAW (3-level page-table)
-    /// 2   => 48-bit AGAW (4-level page-table)
-    /// 3   => 57-bit AGAW (5-level page-table)
-    /// ```
-    pub const fn supported_adjusted_guest_address_widths(&self) -> u64 {
-        const SAGAW_MASK: u64 = 0x1F << 8;
-        (self.0 & SAGAW_MASK) >> 8
+    pub const fn supported_adjusted_guest_address_widths(&self) -> CapabilitySagaw {
+        CapabilitySagaw::from_bits_truncate(self.0 >> 8)
     }
 
     /// Fault-recording Register offset, specifies the offset of the first fault recording
@@ -74,15 +67,10 @@ impl Capability {
         const FRO_MASK: u64 = 0x3FF << 24;
         (self.0 & FRO_MASK) >> 24
     }
+
     /// Second Stage Large Page Support.
-    /// ```norun
-    /// 2/3 => Reserved
-    /// 0   => 21-bit offset to page frame(2MB)
-    /// 1   => 30-bit offset to page frame(1GB)
-    /// ```
-    pub const fn second_stage_large_page_support(&self) -> u64 {
-        const SSLPS_MASK: u64 = 0xF << 34;
-        (self.0 & SSLPS_MASK) >> 34
+    pub const fn second_stage_large_page_support(&self) -> CapabilitySslps {
+        CapabilitySslps::from_bits_truncate(self.0 >> 34)
     }
 
     /// Maximum Guest Address Width. The maximum guest physical address width supported
@@ -127,7 +115,7 @@ impl Debug for Capability {
 
 bitflags! {
     /// Capability flags in IOMMU.
-    pub struct CapabilityFlags: u64{
+    pub struct CapabilityFlags: u64 {
         /// Required Write-Buffer Flushing.
         const RWBF =        1 << 4;
         /// Protected Low-Memory Region
@@ -158,5 +146,29 @@ bitflags! {
         const ESIRTPS =     1 << 62;
         /// Enhanced Set Root Table Pointer Support.
         const ESRTPS =      1 << 63;
+    }
+}
+
+bitflags! {
+    /// Supported Adjusted Guest Address Widths (SAGAW) in IOMMU.
+    pub struct CapabilitySagaw: u64 {
+        /// 39-bit AGAW (3-level page-table).
+        const AGAW_39BIT_3LP = 1 << 1;
+        /// 48-bit AGAW (4-level page-table).
+        const AGAW_48BIT_4LP = 1 << 2;
+        /// 57-bit AGAW (5-level page-table).
+        const AGAW_57BIT_5LP = 1 << 3;
+        // 0th and 4th bits are reserved.
+    }
+}
+
+bitflags! {
+    /// Second Stage Large Page Support (SSLPS) in IOMMU.
+    pub struct CapabilitySslps: u64 {
+        /// 21-bit offset to page frame (2MB).
+        const PAGE_21BIT_2MB = 1 << 0;
+        /// 30-bit offset to page frame (1GB).
+        const PAGE_30BIT_1GB = 1 << 1;
+        // 2nd and 3rd bits are reserved.
     }
 }

--- a/ostd/src/arch/x86/iommu/registers/mod.rs
+++ b/ostd/src/arch/x86/iommu/registers/mod.rs
@@ -11,7 +11,7 @@ mod status;
 use core::ptr::NonNull;
 
 use bit_field::BitField;
-pub use capability::Capability;
+pub use capability::{Capability, CapabilitySagaw};
 use command::GlobalCommand;
 use extended_cap::ExtendedCapability;
 pub use extended_cap::ExtendedCapabilityFlags;

--- a/ostd/src/arch/x86/iommu/registers/mod.rs
+++ b/ostd/src/arch/x86/iommu/registers/mod.rs
@@ -258,6 +258,15 @@ impl IommuRegisters {
 
         let base_address = dmar
             .remapping_iter()
+            // TODO: Add support for multiple DMA remapping hardware unit definitions (DRHDs). Note
+            // that we use `rev()` here to select the last one, since DRHDs that control specific
+            // devices tend to be reported first.
+            //
+            // For example, Intel(R) Virtualization Technology for Directed I/O (Revision 5.0), 8.4
+            // DMA Remapping Hardware Unit Definition Structure says "If a DRHD structure with
+            // INCLUDE_PCI_ALL flag Set is reported for a Segment, it must be enumerated by BIOS
+            // after all other DRHD structures for the same Segment".
+            .rev()
             .find_map(|remapping| match remapping {
                 Remapping::Drhd(drhd) => Some(drhd.register_base_addr()),
                 _ => None,


### PR DESCRIPTION
This PR works around the IOMMU problem in #1963:
> **IOMMU:** IOMMU is broken on my laptop. 
> - The screen goes black after calling [dma_remapping::init](https://github.com/asterinas/asterinas/blob/7a8afd8c484b5bc8b1edb9206eb73b6d4ce709c8/ostd/src/arch/x86/iommu/mod.rs#L28).

There are three underlying problems.
 - First, my laptop's capability register shows that the IOMMU only supports four-level page tables, not three-level. Therefore, enabling the DMA remapping with three-level page tables is impossible.
 - Second, the memory regions specified in Reserved Memory Region Reporting (RMRR) must be mapped as DMA targets. Currently, we don't do this.
> Reserved system memory regions are typically allocated by BIOS at boot time and reported to OS as reserved address ranges in the system memory map. Requests to these reserved regions may either occur as a result of operations performed by the system software driver (for example in the case of DMA from unified memory access (UMA) graphics controllers to graphics reserved memory), or may be initiated by non system software (for example in case of DMA performed by a USB controller under BIOS SMM control for legacy keyboard emulation). For proper functioning of these legacy reserved memory usages, when system software enables DMA remapping, the second-stage translation structures for the respective devices are expected to be set up to provide identity mapping for the specified reserved memory regions with read and write permissions.
 - Third, we need to support multiple the DMA remapping hardware unit definitions (DRHDs). On my laptop, the first DRHD contains only the graphics card, while the second DRHD contains all the other PCI devices.

Following the changes made to this PR, DMA remapping will remain disabled if the IOMMU does not support three-level page tables. Therefore, none of the three issues will arise. However, these issues may need to be addressed in the future. I add some TODOs in the code.