### PR TITLE
Implement `apic::with_borrow` using `Once`

### DIFF
--- a/ostd/src/arch/riscv/irq.rs
+++ b/ostd/src/arch/riscv/irq.rs
@@ -8,7 +8,7 @@ use id_alloc::IdAlloc;
 use spin::Once;
 
 use crate::{
-    cpu::CpuId,
+    cpu::PinCurrentCpu,
     sync::{Mutex, PreemptDisabled, SpinLock, SpinLockGuard},
     trap::TrapFrame,
 };
@@ -147,7 +147,7 @@ impl Drop for IrqCallbackHandle {
 pub(crate) struct HwCpuId(u32);
 
 impl HwCpuId {
-    pub(crate) fn read_current() -> Self {
+    pub(crate) fn read_current(guard: &dyn PinCurrentCpu) -> Self {
         // TODO: Support SMP in RISC-V.
         Self(0)
     }
@@ -160,6 +160,6 @@ impl HwCpuId {
 /// The caller must ensure that the interrupt number is valid and that
 /// the corresponding handler is configured correctly on the remote CPU.
 /// Furthermore, invoking the interrupt handler must also be safe.
-pub(crate) unsafe fn send_ipi(hw_cpu_id: HwCpuId, irq_num: u8) {
+pub(crate) unsafe fn send_ipi(hw_cpu_id: HwCpuId, irq_num: u8, guard: &dyn PinCurrentCpu) {
     unimplemented!()
 }

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -343,13 +343,8 @@ fn spin_wait_cycles(c: u64) {
         }
     }
 
-    use core::arch::x86_64::_rdtsc;
-
-    // SAFETY: Reading CPU cycles is always safe.
-    let start = unsafe { _rdtsc() };
-
-    // SAFETY: Reading CPU cycles is always safe.
-    while duration(start, unsafe { _rdtsc() }) < c {
+    let start = crate::arch::read_tsc();
+    while duration(start, crate::arch::read_tsc()) < c {
         core::hint::spin_loop();
     }
 }

--- a/ostd/src/arch/x86/kernel/apic/mod.rs
+++ b/ostd/src/arch/x86/kernel/apic/mod.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::boxed::Box;
-use core::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicBool, Ordering},
-};
 
 use bit_field::BitField;
 use spin::Once;
@@ -18,90 +14,93 @@ pub mod xapic;
 
 static APIC_TYPE: Once<ApicType> = Once::new();
 
-/// Do something over the APIC instance for the current CPU.
+/// Returns a reference to the local APIC instance of the current CPU.
 ///
-/// You should provide a closure operating on the given mutable borrow of the
-/// local APIC instance. During the execution of the closure, the interrupts
-/// are guaranteed to be disabled.
+/// The reference to the APIC instance will not outlive the given
+/// [`PinCurrentCpu`] guard and the APIC instance does not implement
+/// [`Sync`], so it is safe to assume that the APIC instance belongs
+/// to the current CPU. Note that interrupts are not disabled, so the
+/// APIC instance may be accessed concurrently by interrupt handlers.
 ///
-/// This function also lazily initializes the Local APIC instance. It does
-/// enable the Local APIC if it is not enabled.
+/// At the first time the function is called, the local APIC instance
+/// is initialized and enabled if it was not enabled beforehand.
 ///
-/// Example:
+/// # Examples
+///
 /// ```rust
-/// use ostd::arch::x86::kernel::apic;
+/// use ostd::{
+///     arch::x86::kernel::apic,
+///     task::disable_preempt,
+/// };
 ///
-/// let ticks = apic::with_borrow(|apic| {
-///     let ticks = apic.timer_current_count();
-///     apic.set_timer_init_count(0);
-///     ticks
-/// });
+/// let preempt_guard = disable_preempt();
+/// let apic = apic::get_or_init(&preempt_guard as _);
+///
+/// let ticks = apic.timer_current_count();
+/// apic.set_timer_init_count(0);
 /// ```
-pub fn with_borrow<R>(f: impl FnOnce(&(dyn Apic + 'static)) -> R) -> R {
-    cpu_local! {
-        static APIC_INSTANCE: UnsafeCell<Option<Box<dyn Apic + 'static>>> = UnsafeCell::new(None);
-        static IS_INITIALIZED: AtomicBool = AtomicBool::new(false);
-    }
+pub fn get_or_init(guard: &dyn PinCurrentCpu) -> &(dyn Apic + 'static) {
+    struct ForceSyncSend<T>(T);
 
-    let preempt_guard = crate::task::disable_preempt();
+    // SAFETY: `ForceSyncSend` is `Sync + Send`, but accessing its contained value is unsafe.
+    unsafe impl<T> Sync for ForceSyncSend<T> {}
+    unsafe impl<T> Send for ForceSyncSend<T> {}
 
-    // SAFETY: Preemption is disabled, so we can safely access the CPU-local variable.
-    let apic_ptr = unsafe {
-        let ptr = APIC_INSTANCE.as_ptr();
-        (*ptr).get()
-    };
-
-    // If it is not initialized, lazily initialize it.
-    if IS_INITIALIZED
-        .get_on_cpu(preempt_guard.current_cpu())
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
-        .is_ok()
-    {
-        let apic: Option<Box<dyn Apic>> = Some(match APIC_TYPE.get().unwrap() {
-            ApicType::XApic => {
-                let mut xapic = xapic::XApic::new().unwrap();
-                xapic.enable();
-                let version = xapic.version();
-                log::info!(
-                    "xAPIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
-                    xapic.id(),
-                    version & 0xff,
-                    (version >> 16) & 0xff
-                );
-                Box::new(xapic)
-            }
-            ApicType::X2Apic => {
-                let mut x2apic = x2apic::X2Apic::new().unwrap();
-                x2apic.enable();
-                let version = x2apic.version();
-                log::info!(
-                    "x2APIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
-                    x2apic.id(),
-                    version & 0xff,
-                    (version >> 16) & 0xff
-                );
-                Box::new(x2apic)
-            }
-        });
-        // SAFETY: It will be only written once and no other read or write can
-        // happen concurrently for the synchronization with `IS_INITIALIZED`.
-        //
-        // If interrupts happen during the initialization, it can be written
-        // twice. But it should not happen since we must call this function
-        // when interrupts are disabled during the initialization of OSTD.
-        unsafe {
-            debug_assert!(apic_ptr.read().is_none());
-            apic_ptr.write(apic);
+    impl<T> ForceSyncSend<T> {
+        /// # Safety
+        ///
+        /// The caller must ensure that its context allows for safe access to `&T`.
+        unsafe fn get(&self) -> &T {
+            &self.0
         }
     }
 
-    // SAFETY: The APIC pointer is not accessed by other CPUs. It should point
-    // to initialized data and there will not be any write-during-read problem
-    // since there would be no write after `IS_INITIALIZED` is set to true.
-    let apic_ref = unsafe { &*apic_ptr };
-    let apic_ref = apic_ref.as_ref().unwrap().as_ref();
+    cpu_local! {
+        static APIC_INSTANCE: Once<ForceSyncSend<Box<dyn Apic + 'static>>> = Once::new();
+    }
 
-    f.call_once((apic_ref,))
+    let apic_instance = APIC_INSTANCE.get_on_cpu(guard.current_cpu());
+
+    // The APIC instance has already been initialized.
+    if let Some(apic) = apic_instance.get() {
+        // SAFETY: Accessing `&dyn Apic` is safe as long as we're running on the same CPU on which
+        // the APIC instance was created. The `get_on_cpu` method above ensures this.
+        return &**unsafe { apic.get() };
+    }
+
+    // Initialize the APIC instance now.
+    apic_instance.call_once(|| match APIC_TYPE.get().unwrap() {
+        ApicType::XApic => {
+            let mut xapic = xapic::XApic::new().unwrap();
+            xapic.enable();
+            let version = xapic.version();
+            log::info!(
+                "xAPIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
+                xapic.id(),
+                version & 0xff,
+                (version >> 16) & 0xff
+            );
+            ForceSyncSend(Box::new(xapic))
+        }
+        ApicType::X2Apic => {
+            let mut x2apic = x2apic::X2Apic::new().unwrap();
+            x2apic.enable();
+            let version = x2apic.version();
+            log::info!(
+                "x2APIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
+                x2apic.id(),
+                version & 0xff,
+                (version >> 16) & 0xff
+            );
+            ForceSyncSend(Box::new(x2apic))
+        }
+    });
+
+    // We've initialized the APIC instance, so this `unwrap` cannot fail.
+    let apic = apic_instance.get().unwrap();
+    // SAFETY: Accessing `&dyn Apic` is safe as long as we're running on the same CPU on which the
+    // APIC instance was created. The initialization above ensures this.
+    &**unsafe { apic.get() }
 }
 
 pub trait Apic: ApicTimer {

--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -8,14 +8,22 @@ use x86::msr::{
 
 use super::ApicTimer;
 
-pub struct X2Apic {}
+#[derive(Debug)]
+pub struct X2Apic {
+    _private: (),
+}
+
+// The APIC instance can be shared among threads running on the same CPU, but not among those
+// running on different CPUs. Therefore, it is not `Send`/`Sync`.
+impl !Send for X2Apic {}
+impl !Sync for X2Apic {}
 
 impl X2Apic {
     pub(crate) fn new() -> Option<Self> {
         if !Self::has_x2apic() {
             return None;
         }
-        Some(Self {})
+        Some(Self { _private: () })
     }
 
     pub(super) fn has_x2apic() -> bool {

--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -18,6 +18,11 @@ pub struct XApic {
     mmio_start: *mut u32,
 }
 
+// The APIC instance can be shared among threads running on the same CPU, but not among those
+// running on different CPUs. Therefore, it is not `Send`/`Sync`.
+impl !Send for XApic {}
+impl !Sync for XApic {}
+
 impl XApic {
     pub fn new() -> Option<Self> {
         if !Self::has_xapic() {

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -25,10 +25,7 @@ use x86::cpuid::{CpuId, FeatureInfo};
 #[cfg(feature = "cvm_guest")]
 pub(crate) mod tdx_guest;
 
-use core::{
-    arch::x86_64::{_rdrand64_step, _rdtsc},
-    sync::atomic::Ordering,
-};
+use core::sync::atomic::Ordering;
 
 use kernel::apic::ioapic;
 use log::{info, warn};
@@ -132,6 +129,8 @@ pub fn tsc_freq() -> u64 {
 
 /// Reads the current value of the processor’s time-stamp counter (TSC).
 pub fn read_tsc() -> u64 {
+    use core::arch::x86_64::_rdtsc;
+
     // SAFETY: It is safe to read a time-related counter.
     unsafe { _rdtsc() }
 }
@@ -140,6 +139,8 @@ pub fn read_tsc() -> u64 {
 ///
 /// Returns None if no random value was generated.
 pub fn read_random() -> Option<u64> {
+    use core::arch::x86_64::_rdrand64_step;
+
     // Recommendation from "Intel® Digital Random Number Generator (DRNG) Software
     // Implementation Guide" - Section 5.2.1 and "Intel® 64 and IA-32 Architectures
     // Software Developer’s Manual" - Volume 1 - Section 7.3.17.1.

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -119,9 +119,9 @@ pub(crate) unsafe fn init_on_ap() {
 
 pub(crate) fn interrupts_ack(irq_number: usize) {
     if !cpu::context::CpuException::is_cpu_exception(irq_number as u16) {
-        kernel::apic::with_borrow(|apic| {
-            apic.eoi();
-        });
+        // TODO: We're in the interrupt context, so `disable_preempt()` is not
+        // really necessary here.
+        kernel::apic::get_or_init(&crate::task::disable_preempt() as _).eoi();
     }
 }
 

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{
-    arch::x86_64::_rdtsc,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use log::info;
 
@@ -46,7 +43,7 @@ pub(super) fn timer_callback() {
 
     match CONFIG.get().expect("ACPI timer config is not initialized") {
         Config::DeadlineMode { tsc_interval } => {
-            let tsc_value = unsafe { _rdtsc() };
+            let tsc_value = crate::arch::read_tsc();
             let next_tsc_value = tsc_interval + tsc_value;
             unsafe { wrmsr(IA32_TSC_DEADLINE, next_tsc_value) };
         }

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -155,7 +155,11 @@ fn ap_early_entry(cpu_id: u32) -> ! {
 }
 
 fn report_online_and_hw_cpu_id(cpu_id: u32) {
-    let old_val = HW_CPU_ID_MAP.lock().insert(cpu_id, HwCpuId::read_current());
+    // There are no races because this method will only be called in the boot
+    // context, where preemption won't occur.
+    let hw_cpu_id = HwCpuId::read_current(&crate::task::disable_preempt());
+
+    let old_val = HW_CPU_ID_MAP.lock().insert(cpu_id, hw_cpu_id);
     assert!(old_val.is_none());
 }
 

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -52,7 +52,13 @@ pub fn inter_processor_call(targets: &CpuSet, f: fn()) {
         }
         // SAFETY: The value of `irq_num` corresponds to a valid IRQ line and
         // triggering it will not cause any safety issues.
-        unsafe { send_ipi(ipi_data.hw_cpu_ids[cpu_id.as_usize()], irq_num) };
+        unsafe {
+            send_ipi(
+                ipi_data.hw_cpu_ids[cpu_id.as_usize()],
+                irq_num,
+                &irq_guard as _,
+            )
+        };
     }
     if call_on_self {
         // Execute the function synchronously.


### PR DESCRIPTION
The current implementation of `apic::with_borrow` is quite odd:
 - It claims that it will disable IRQs, but indeed it will only disable preemption.
https://github.com/asterinas/asterinas/blob/12d693d7b4618b12f1617fa03dc2ce514226cc43/ostd/src/arch/x86/kernel/apic/mod.rs#L23-L25
 - The `IS_INITIALIZED` variable is used similarly to the `Once` implementation, which results in duplicated logic.
https://github.com/asterinas/asterinas/blob/12d693d7b4618b12f1617fa03dc2ce514226cc43/ostd/src/arch/x86/kernel/apic/mod.rs#L43
 - It is difficult to argue how we can create a Rust reference to the APIC instance without first checking the `IS_INITIALIZED` boolean. This is not sound if initialization is done concurrently.
https://github.com/asterinas/asterinas/blob/12d693d7b4618b12f1617fa03dc2ce514226cc43/ostd/src/arch/x86/kernel/apic/mod.rs#L48-L52
 - We have the "INITIALIZED" state and "UNINITIALIZED" state but do not correctly implement the "INITIALIZING" state, so it's also hard to argue why the APIC instance won't be written concurrently.
https://github.com/asterinas/asterinas/blob/12d693d7b4618b12f1617fa03dc2ce514226cc43/ostd/src/arch/x86/kernel/apic/mod.rs#L89-L95

I originally tried to convert the preemption guard to an IRQ guard, which aligns with the doc comments. However, I later discovered that the removal of the IRQ guard was intentional, as seen in https://github.com/asterinas/asterinas/pull/1473. I doubt the performance difference is observable here, though. But anyway, this PR keeps the preemption guard and uses `Once` to fix the safety reasoning.

I noticed that we don't want to implement `Send`/`Sync` for `dyn Apic`, which is why `Once` cannot be used directly. This can be made explicit by creating a `ForceSyncSend` type (similar to [`ForceSync`](https://github.com/asterinas/asterinas/blob/12d693d7b4618b12f1617fa03dc2ce514226cc43/ostd/src/task/utils.rs#L5-L6)).