### PR TITLE
Remove unnecessary `#[inline]` attributes

### DIFF
--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -421,7 +421,6 @@ pub struct Descriptor {
 
 type DescriptorPtr<'a> = SafePtr<Descriptor, &'a DmaCoherent, TRightSet<TRights![Dup, Write]>>;
 
-#[inline]
 fn set_dma_buf<T: DmaBuf>(desc_ptr: &DescriptorPtr, buf: &T) {
     // TODO: skip the empty dma buffer or just return error?
     debug_assert_ne!(buf.len(), 0);

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -410,7 +410,6 @@ impl Ext2 {
         Ok(())
     }
 
-    #[inline]
     fn block_group_of_bid(&self, bid: Ext2Bid) -> Result<(usize, &BlockGroup)> {
         let block_group_idx = (bid / self.blocks_per_group) as usize;
         if block_group_idx >= self.block_groups.len() {
@@ -419,7 +418,6 @@ impl Ext2 {
         Ok((block_group_idx, &self.block_groups[block_group_idx]))
     }
 
-    #[inline]
     fn block_group_of_ino(&self, ino: u32) -> Result<(usize, &BlockGroup)> {
         let block_group_idx = ((ino - 1) / self.inodes_per_group) as usize;
         if block_group_idx >= self.block_groups.len() {
@@ -428,12 +426,10 @@ impl Ext2 {
         Ok((block_group_idx, &self.block_groups[block_group_idx]))
     }
 
-    #[inline]
     fn inode_idx(&self, ino: u32) -> u32 {
         (ino - 1) % self.inodes_per_group
     }
 
-    #[inline]
     fn block_idx(&self, bid: Ext2Bid) -> Ext2Bid {
         bid % self.blocks_per_group
     }

--- a/kernel/src/fs/ext2/indirect_block_cache.rs
+++ b/kernel/src/fs/ext2/indirect_block_cache.rs
@@ -128,7 +128,6 @@ impl IndirectBlockCache {
         Ok(())
     }
 
-    #[inline]
     fn fs(&self) -> Arc<Ext2> {
         self.fs.upgrade().unwrap()
     }

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -2196,7 +2196,6 @@ impl InodeDesc {
         blocks
     }
 
-    #[inline]
     fn size_to_blocks(&self, size: usize) -> Ext2Bid {
         if self.type_ == InodeType::SymLink && size <= MAX_FAST_SYMLINK_LEN {
             return 0;

--- a/ostd/src/arch/x86/kernel/pic.rs
+++ b/ostd/src/arch/x86/kernel/pic.rs
@@ -112,7 +112,6 @@ pub fn set_mask(master_mask: u8, slave_mask: u8) {
     SLAVE_DATA.write(slave_mask);
 }
 
-#[inline(always)]
 pub(crate) fn ack() {
     MASTER_CMD.write(0x20);
 }

--- a/ostd/src/bus/pci/capability/vendor.rs
+++ b/ostd/src/bus/pci/capability/vendor.rs
@@ -70,7 +70,6 @@ impl CapabilityVndrData {
         Ok(())
     }
 
-    #[inline]
     fn check_range(&self, offset: u16) -> Result<()> {
         if self.length < offset {
             return Err(Error::InvalidArgs);


### PR DESCRIPTION
This PR removes unnecessary `#[inline]` attribute annotations from private functions. In general, within a crate, the compiler makes effective inline decisions on its own (https://matklad.github.io/2021/07/09/inline-in-rust.html).

The detection was performed automatically using a predicate in the RPL-Toolchain (https://github.com/RPL-Toolchain/RPL).

Additionally, RPL-Toolchain can detect `#[inline]` annotations on functions that require monomorphization. If this detection is needed, it can be added to this PR later or handled in a separate PR.

cc @jellllly420.
