### PR TITLE
Move `current_cpu_racy` to `CpuId` & Fix bad types in `getcpu` syscall

### DIFF
--- a/kernel/src/syscall/getcpu.rs
+++ b/kernel/src/syscall/getcpu.rs
@@ -1,27 +1,32 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{cpu::PinCurrentCpu, task::disable_preempt};
+use ostd::cpu::CpuId;
 
 use super::SyscallReturn;
 use crate::prelude::*;
 
 pub fn sys_getcpu(cpu: Vaddr, node: Vaddr, _tcache: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    // The third argument tcache is unused after Linux 2.6.24 so we ignore it
-    let preempt_guard = disable_preempt();
-    let cpuid = preempt_guard.current_cpu();
-    drop(preempt_guard);
+    // The third argument `tcache` is unused since Linux 2.6.24, so we ignore it.
+
+    // The system call itself is inherently racy, so using `current_racy` here should be fine.
+    let current_cpu = CpuId::current_racy().as_usize() as u32;
+    // TODO: Support NUMA.
+    let current_node = 0u32;
+
     debug!(
-        "getcpu: cpuid = {}, total_cpus = {}",
-        cpuid.as_usize(),
-        ostd::cpu::num_cpus()
+        "[sys_getcpu]: cpu = {} (total {}), node = {}",
+        current_cpu,
+        ostd::cpu::num_cpus(),
+        current_node,
     );
-    // Since cpu and node can be NULL, we need to check them before writing
+
+    // `cpu` and `node` can be NULL, so we need to check before writing.
     if cpu != 0 {
-        ctx.user_space()
-            .write_val::<usize>(cpu, &cpuid.as_usize())?;
+        ctx.user_space().write_val(cpu, &current_cpu)?;
     }
     if node != 0 {
-        ctx.user_space().write_val::<usize>(node, &0)?; // TODO: NUMA is not supported
+        ctx.user_space().write_val(node, &current_node)?;
     }
+
     Ok(SyscallReturn::Return(0))
 }

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -210,7 +210,8 @@ cpu_local! {
 }
 
 fn do_remote_flush() {
-    let current_cpu = crate::cpu::current_cpu_racy(); // Safe because we are in IRQs.
+    // No races because we are in IRQs or have disabled preemption.
+    let current_cpu = crate::cpu::CpuId::current_racy();
 
     let mut op_queue = FLUSH_OPS.get_on_cpu(current_cpu).lock();
     op_queue.flush_all();

--- a/test/apps/getcpu/getcpu.c
+++ b/test/apps/getcpu/getcpu.c
@@ -1,24 +1,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#define _GNU_SOURCE
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include "../network/test.h"
+
 #include <sys/syscall.h>
+#include <unistd.h>
 
-int main()
+FN_TEST(getcpu)
 {
-	unsigned int cpu, node;
+	struct int_pair {
+		unsigned int first;
+		unsigned int second;
+	};
 
-	// Directly test the getcpu syscall because glibc's getcpu() may not
-	// use the getcpu syscall to retrieve CPU info
-	long ret = syscall(SYS_getcpu, &cpu, &node, NULL);
-	if (ret != 0) {
-		perror("syscall getcpu");
-		exit(EXIT_FAILURE);
-	}
+	struct int_pair cpu = { .first = 0xdeadbeef, .second = 0xbeefdead };
+	struct int_pair node = { .first = 0xbeefdead, .second = 0xdeadbeef };
 
-	printf("getcpu syscall: cpu = %u, node = %u\n", cpu, node);
+	// Use `syscall()` here because `getcpu()` from glibc may not use
+	// the system call to retrieve CPU information.
+	TEST_SUCC(syscall(SYS_getcpu, NULL, NULL));
 
-	return 0;
+	// Our CI has a maximum of 16 CPUs, and NUMA support is not yet
+	// available. Update these conditions if we have more than 16 CPUs
+	// or if NUMA support is added.
+	TEST_RES(syscall(SYS_getcpu, &cpu, &node),
+		 cpu.first < 16 && cpu.second == 0xbeefdead &&
+			 node.first == 0 && node.second == 0xdeadbeef);
 }
+END_TEST()

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -21,6 +21,7 @@ exit/exit_procfs
 eventfd2/eventfd2
 fork/fork
 fork_c/fork
+getcpu/getcpu
 getpid/getpid
 hello_pie/hello
 hello_world/hello_world


### PR DESCRIPTION
I'm wondering if it would be better to make `current_cpu_racy` a method of `CpuId`. After all, we have [`Task::current`](https://github.com/asterinas/asterinas/blob/d4872af3c78769ed5ea7a1a1bbbe310fcd6d2908/ostd/src/task/mod.rs#L71). Therefore, we may want `CpuId::current` as well. However, it's racy, so it becomes `CpuId::current_racy`.

I found some use cases for the `current_racy` method, so I'm converting the code. However, it appears that the `getcpu` system call is incorrectly implemented. It should write two `u32`s to user space, not two `usize`s. This issue has been resolved in the second commit, which includes proper regression tests.