### PR TITLE
Re-organize some code in `aster_systree` and fix some bugs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.9.0",
  "component",
+ "inherit-methods-macro",
  "ostd",
  "spin",
 ]

--- a/kernel/comps/systree/Cargo.toml
+++ b/kernel/comps/systree/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bitflags = "2.5"
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
+inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e"}
 spin = "0.9"
 
 [lints]

--- a/kernel/comps/systree/src/attr.rs
+++ b/kernel/comps/systree/src/attr.rs
@@ -37,9 +37,6 @@ pub struct SysAttr {
     name: SysStr,
     /// Flags defining the behavior and permissions of the attribute.
     flags: SysAttrFlags,
-    // Potentially add read/write handler functions or trait objects later
-    // read_handler: fn(...) -> Result<usize>,
-    // write_handler: fn(...) -> Result<usize>,
 }
 
 impl SysAttr {

--- a/kernel/comps/systree/src/lib.rs
+++ b/kernel/comps/systree/src/lib.rs
@@ -76,6 +76,8 @@ pub enum Error {
     PermissionDenied,
     /// Other internal error
     InternalError(&'static str),
+    /// Arithmetic overflow occurred
+    Overflow,
 }
 
 impl core::fmt::Display for Error {
@@ -88,6 +90,7 @@ impl core::fmt::Display for Error {
             Error::AttributeError => write!(f, "Attribute error"),
             Error::PermissionDenied => write!(f, "Permission denied for operation"),
             Error::InternalError(msg) => write!(f, "Internal error: {}", msg),
+            Error::Overflow => write!(f, "Numerical overflow occurred"),
         }
     }
 }

--- a/kernel/comps/systree/src/utils.rs
+++ b/kernel/comps/systree/src/utils.rs
@@ -3,7 +3,6 @@
 //! Utility definitions and helper structs for implementing `SysTree` nodes.
 
 use alloc::{collections::BTreeMap, string::String, sync::Arc};
-use core::ops::Deref;
 
 use ostd::sync::RwLock;
 
@@ -31,8 +30,8 @@ impl SysObjFields {
         &self.id
     }
 
-    pub fn name(&self) -> &str {
-        self.name.deref()
+    pub fn name(&self) -> &SysStr {
+        &self.name
     }
 }
 
@@ -54,7 +53,7 @@ impl SysNormalNodeFields {
         self.base.id()
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &SysStr {
         self.base.name()
     }
 
@@ -81,7 +80,7 @@ impl<C: SysObj + ?Sized> SysBranchNodeFields<C> {
         self.base.id()
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &SysStr {
         self.base.name()
     }
 
@@ -97,7 +96,7 @@ impl<C: SysObj + ?Sized> SysBranchNodeFields<C> {
     pub fn add_child(&self, new_child: Arc<C>) -> Result<()> {
         let mut children = self.children.write();
         let name = new_child.name();
-        if children.contains_key(name.deref()) {
+        if children.contains_key(name) {
             return Err(Error::PermissionDenied);
         }
         children.insert(name.clone(), new_child);
@@ -107,6 +106,29 @@ impl<C: SysObj + ?Sized> SysBranchNodeFields<C> {
     pub fn remove_child(&self, child_name: &str) -> Option<Arc<C>> {
         let mut children = self.children.write();
         children.remove(child_name)
+    }
+
+    pub fn visit_child_with(&self, name: &str, f: &mut dyn FnMut(Option<&Arc<C>>)) {
+        let children_guard = self.children.read();
+        f(children_guard.get(name))
+    }
+
+    pub fn visit_children_with(&self, min_id: u64, f: &mut dyn FnMut(&Arc<C>) -> Option<()>) {
+        let children_guard = self.children.read();
+        for child_arc in children_guard.values() {
+            if child_arc.id().as_u64() < min_id {
+                continue;
+            }
+
+            if f(child_arc).is_none() {
+                break;
+            }
+        }
+    }
+
+    pub fn child(&self, name: &str) -> Option<Arc<C>> {
+        let children = self.children.read();
+        children.get(name).cloned()
     }
 }
 
@@ -128,7 +150,7 @@ impl SymlinkNodeFields {
         self.base.id()
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &SysStr {
         self.base.name()
     }
 

--- a/kernel/comps/systree/src/utils.rs
+++ b/kernel/comps/systree/src/utils.rs
@@ -136,3 +136,76 @@ impl SymlinkNodeFields {
         &self.target_path
     }
 }
+
+/// A macro to automatically generate cast-related methods and `type_` method for `SysObj`
+/// trait implementation of `SysBranchNode` struct.
+///
+/// Users should make sure that the struct has a `weak_self: Weak<Self>` field.
+#[macro_export]
+macro_rules! impl_cast_methods_for_branch {
+    () => {
+        fn as_any(&self) -> &dyn core::any::Any {
+            self
+        }
+
+        fn cast_to_node(&self) -> Option<Arc<dyn SysNode>> {
+            self.weak_self.upgrade().map(|arc| arc as Arc<dyn SysNode>)
+        }
+
+        fn cast_to_branch(&self) -> Option<Arc<dyn SysBranchNode>> {
+            self.weak_self
+                .upgrade()
+                .map(|arc| arc as Arc<dyn SysBranchNode>)
+        }
+
+        fn type_(&self) -> SysNodeType {
+            SysNodeType::Branch
+        }
+    };
+}
+
+/// A macro to automatically generate cast-related methods and `type_` method for `SysObj`
+/// trait implementation of `SysNode` struct.
+///
+/// If the struct is also a branch node, use `impl_cast_methods_for_branch!()` instead.
+///
+/// Users should make sure that the struct has a `weak_self: Weak<Self>` field.
+#[macro_export]
+macro_rules! impl_cast_methods_for_node {
+    () => {
+        fn as_any(&self) -> &dyn core::any::Any {
+            self
+        }
+
+        fn cast_to_node(&self) -> Option<Arc<dyn SysNode>> {
+            self.weak_self.upgrade().map(|arc| arc as Arc<dyn SysNode>)
+        }
+
+        fn type_(&self) -> SysNodeType {
+            SysNodeType::Leaf
+        }
+    };
+}
+
+/// A macro to automatically generate cast-related methods and `type_` method for `SysObj`
+/// trait implementation of `SysSymlink` struct.
+///
+/// Users should make sure that the struct has a `weak_self: Weak<Self>` field.
+#[macro_export]
+macro_rules! impl_cast_methods_for_symlink {
+    () => {
+        fn as_any(&self) -> &dyn core::any::Any {
+            self
+        }
+
+        fn cast_to_symlink(&self) -> Option<Arc<dyn SysSymlink>> {
+            self.weak_self
+                .upgrade()
+                .map(|arc| arc as Arc<dyn SysSymlink>)
+        }
+
+        fn type_(&self) -> SysNodeType {
+            SysNodeType::Symlink
+        }
+    };
+}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -339,6 +339,7 @@ impl From<aster_systree::Error> for Error {
             AttributeError => Error::new(Errno::EIO),
             PermissionDenied => Error::new(Errno::EACCES),
             InternalError(msg) => Error::with_message(Errno::EIO, msg),
+            Overflow => Error::new(Errno::EOVERFLOW),
         }
     }
 }

--- a/kernel/src/fs/sysfs/inode.rs
+++ b/kernel/src/fs/sysfs/inode.rs
@@ -191,7 +191,7 @@ impl SysFsInode {
             match child_type {
                 SysNodeType::Branch => {
                     let child_branch = child_sysnode
-                        .arc_as_branch()
+                        .cast_to_branch()
                         .ok_or(Error::new(Errno::EIO))?;
                     let inode = Self::new_branch_dir(
                         self.systree,
@@ -202,7 +202,7 @@ impl SysFsInode {
                 }
                 SysNodeType::Leaf => {
                     let child_leaf_node =
-                        child_sysnode.arc_as_node().ok_or(Error::new(Errno::EIO))?;
+                        child_sysnode.cast_to_node().ok_or(Error::new(Errno::EIO))?;
                     let inode = Self::new_leaf_dir(
                         self.systree,
                         InnerNode::Leaf(child_leaf_node),
@@ -212,7 +212,7 @@ impl SysFsInode {
                 }
                 SysNodeType::Symlink => {
                     let child_symlink = child_sysnode
-                        .arc_as_symlink()
+                        .cast_to_symlink()
                         .ok_or(Error::new(Errno::EIO))?;
                     let inode = Self::new_symlink(
                         self.systree,
@@ -646,7 +646,7 @@ impl Iterator for NodeDentryIter {
                 };
                 return Some(Dentry {
                     ino: obj_ino,
-                    name: obj.name(),
+                    name: obj.name().clone(),
                     type_,
                 });
             }


### PR DESCRIPTION
This PR tries to enhance the `SysTree`. First, this PR aims to enable the `SysTree` system to provide read/write capabilities for attributes, which is required for @StevenJiang1110  uevent-related testing. Secondly, This PR proposes introducing `BasicSysNode` to `SysTree`, which will serve as a default node type to facilitate upper-layer `SysFs` in creating required directory nodes. 

This PR creates an `fs` subdirectory in `/sys` during sysfs initialization, which is a usage example for node creation. Additionally, here's an example for attribute operations:
```rust
pub fn test_attribute_init() {
    let sys_tree = aster_systree::singleton();

    let mut builder = SysAttrSetBuilder::new();
    builder.add(
        Cow::Borrowed("uevent"),
        SysAttrFlags::CAN_READ | SysAttrFlags::CAN_WRITE,
        |writer| {
            let context = "dummy value\n".as_bytes();
            writer
                .write_fallible(&mut VmReader::from(context))
                .map_err(|_| aster_systree::Error::AttributeError)
        },
        |_reader| {
            // do some operations
            Ok(0)
        },
    );
    let test_attribute = builder.build().unwrap();
    sys_tree
        .root()
        .create_normal_child(Cow::Borrowed("test"), test_attribute);
}
```
In this way, users can interact with `uevent` attribute through `sys/test/uevent`.

By the way, I'm still relatively new to this codebase...I may have overlooked some potential requirements. Any suggestions or feedback would be greatly appreciated!