### PR TITLE
Clarify the safety conditions of `{,un}protect_gpa_range`

### DIFF
--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -77,10 +77,12 @@ impl DmaCoherent {
                 #[cfg(target_arch = "x86_64")]
                 crate::arch::if_tdx_enabled!({
                     // SAFETY:
-                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                    // The `check_and_insert_dma_mapping` function checks if the physical address range is already mapped.
-                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the 'unprotect_gpa_range' function.
+                    //  - The address of a `USegment` is always page aligned.
+                    //  - A `USegment` always points to normal physical memory, so the address
+                    //    range falls in the GPA limit.
+                    //  - A `USegment` always points to normal physical memory, so all the pages
+                    //    are contained in the linear mapping.
+                    //  - The pages belong to a `USegment`, so they're all untyped memory.
                     unsafe {
                         tdx_guest::unprotect_gpa_range(start_paddr, frame_count).unwrap();
                     }
@@ -137,10 +139,12 @@ impl Drop for DmaCoherentInner {
                 #[cfg(target_arch = "x86_64")]
                 crate::arch::if_tdx_enabled!({
                     // SAFETY:
-                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                    // The `start_paddr()` ensures the `start_paddr` is page-aligned.
-                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `protect_gpa_range` function.
+                    //  - The address of a `USegment` is always page aligned.
+                    //  - A `USegment` always points to normal physical memory, so the address
+                    //    range falls in the GPA limit.
+                    //  - A `USegment` always points to normal physical memory, so all the pages
+                    //    are contained in the linear mapping.
+                    //  - The pages belong to a `USegment`, so they're all untyped memory.
                     unsafe {
                         tdx_guest::protect_gpa_range(start_paddr, frame_count).unwrap();
                     }

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -66,10 +66,12 @@ impl DmaStream {
                 #[cfg(target_arch = "x86_64")]
                 crate::arch::if_tdx_enabled!({
                     // SAFETY:
-                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                    // The `check_and_insert_dma_mapping` function checks if the physical address range is already mapped.
-                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the 'unprotect_gpa_range' function.
+                    //  - The address of a `USegment` is always page aligned.
+                    //  - A `USegment` always points to normal physical memory, so the address
+                    //    range falls in the GPA limit.
+                    //  - A `USegment` always points to normal physical memory, so all the pages
+                    //    are contained in the linear mapping.
+                    //  - The pages belong to a `USegment`, so they're all untyped memory.
                     unsafe {
                         crate::arch::tdx_guest::unprotect_gpa_range(start_paddr, frame_count)
                             .unwrap();
@@ -177,10 +179,12 @@ impl Drop for DmaStreamInner {
                 #[cfg(target_arch = "x86_64")]
                 crate::arch::if_tdx_enabled!({
                     // SAFETY:
-                    // This is safe because we are ensuring that the physical address range specified by `start_paddr` and `frame_count` is valid before these operations.
-                    // The `start_paddr()` ensures the `start_paddr` is page-aligned.
-                    // We are also ensuring that we are only modifying the page table entries corresponding to the physical address range specified by `start_paddr` and `frame_count`.
-                    // Therefore, we are not causing any undefined behavior or violating any of the requirements of the `protect_gpa_range` function.
+                    //  - The address of a `USegment` is always page aligned.
+                    //  - A `USegment` always points to normal physical memory, so the address
+                    //    range falls in the GPA limit.
+                    //  - A `USegment` always points to normal physical memory, so all the pages
+                    //    are contained in the linear mapping.
+                    //  - The pages belong to a `USegment`, so they're all untyped memory.
                     unsafe {
                         crate::arch::tdx_guest::protect_gpa_range(start_paddr, frame_count)
                             .unwrap();


### PR DESCRIPTION
Currently, the safety conditions of `{,un}protect_gpa_range` are somehow ambiguous. More seriously, the SAFETY comments on the callers are even more ambiguous and claim something that won't hold.

For example, `IoMem::new` writes this:
https://github.com/asterinas/asterinas/blob/758c80c32170cd3cc6d62bd2d867a1c902843d0f/ostd/src/io/io_mem/mod.rs#L98-L102

But `unprotect_gpa_range` requires:
https://github.com/asterinas/asterinas/blob/758c80c32170cd3cc6d62bd2d867a1c902843d0f/ostd/src/arch/x86/tdx_guest.rs#L35

How to prove the safety comment is satisfied? Instead you cannot prove because there are counter examples: I/O memory can be at a high address so the pages may not be part of the linear mapping.

**This PR does not fix anything, just to make the current situation clear.** I've added some FIXMEs in the safety comments, which is really odd, but I don't think I can do better:
```rust
            // SAFETY:
            //  - The range `first_page_start..last_page_end` is always page aligned.
            //  - FIXME: We currently do not limit the I/O memory allocator with the GPA limit, so
            //    the address range may not fall in the GPA limit.
            //  - FIXME: The I/O memory can be at a high address, so it may not be contained in the
            //    linear mapping.
            //  - The caller guarantees that operations on the I/O memory do not have any side
            //    effects that may cause soundness problems, so the pages can safely be viewed as
            //    untyped memory.
            unsafe { crate::arch::tdx_guest::unprotect_gpa_range(first_page_start, pages).unwrap() };
```

I'm not familiar with the TDX code. In fact, I know very little about the TDX mechanism. Could you please confirm whether the modifications in this PR are correct, @Hsy-Intel? Thanks!