### PR TITLE
Fix broken clippy lint check

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -50,7 +50,7 @@ pub struct CurrentUserSpace<'a>(Ref<'a, Option<Vmar<Full>>>);
 #[macro_export]
 macro_rules! current_userspace {
     () => {{
-        use crate::context::CurrentUserSpace;
+        use $crate::context::CurrentUserSpace;
         CurrentUserSpace::new(&ostd::task::Task::current().unwrap())
     }};
 }

--- a/kernel/src/events/events.rs
+++ b/kernel/src/events/events.rs
@@ -39,6 +39,6 @@ impl<E: Events> EventsFilter<E> for () {
 
 impl<E: Events, F: EventsFilter<E>> EventsFilter<E> for Option<F> {
     fn filter(&self, events: &E) -> bool {
-        self.as_ref().map_or(true, |f| f.filter(events))
+        self.as_ref().is_none_or(|f| f.filter(events))
     }
 }

--- a/kernel/src/fs/device.rs
+++ b/kernel/src/fs/device.rs
@@ -50,9 +50,9 @@ impl DeviceId {
         let major = major as u64;
         let minor = minor as u64;
         Self(
-            (major & 0xffff_f000) << 32
-                | (major & 0x0000_0fff) << 8
-                | (minor & 0xffff_ff00) << 12
+            ((major & 0xffff_f000) << 32)
+                | ((major & 0x0000_0fff) << 8)
+                | ((minor & 0xffff_ff00) << 12)
                 | (minor & 0x0000_00ff),
         )
     }

--- a/kernel/src/fs/epoll/entry.rs
+++ b/kernel/src/fs/epoll/entry.rs
@@ -368,7 +368,7 @@ impl Iterator for ReadySetPopIter<'_> {
             let weak_entry = entries.pop_front().unwrap();
 
             // Clear the epoll file's events if there are no ready entries.
-            if entries.len() == 0 {
+            if entries.is_empty() {
                 self.ready_set.pollee.invalidate();
             }
 

--- a/kernel/src/fs/exfat/dentry.rs
+++ b/kernel/src/fs/exfat/dentry.rs
@@ -89,6 +89,8 @@ impl TryFrom<RawExfatDentry> for ExfatDentry {
     type Error = crate::error::Error;
     fn try_from(dentry: RawExfatDentry) -> Result<Self> {
         let dentry_bytes = dentry.as_bytes();
+        #[expect(clippy::match_overlapping_arm)]
+        // FIXME: `EXFAT_STREAM` and `0xC0..=0xFF` overlap. Is the overlapping case expected?
         match dentry.dentry_type {
             EXFAT_FILE => Ok(ExfatDentry::File(ExfatFileDentry::from_bytes(dentry_bytes))),
             EXFAT_STREAM => Ok(ExfatDentry::Stream(ExfatStreamDentry::from_bytes(

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -85,7 +85,7 @@ mod test {
                     BioType::Read => seg
                         .inner_segment()
                         .writer()
-                        .write(&mut self.queue.0.reader().skip(cur_device_ofs)),
+                        .write(self.queue.0.reader().skip(cur_device_ofs)),
                     BioType::Write => self
                         .queue
                         .0

--- a/kernel/src/fs/exfat/utils.rs
+++ b/kernel/src/fs/exfat/utils.rs
@@ -8,7 +8,7 @@ use super::fat::ClusterID;
 use crate::prelude::*;
 
 pub fn make_hash_index(cluster: ClusterID, offset: u32) -> usize {
-    (cluster as usize) << 32usize | (offset as usize & 0xffffffffusize)
+    ((cluster as usize) << 32usize) | (offset as usize & 0xffffffffusize)
 }
 
 pub fn calc_checksum_32(data: &[u8]) -> u32 {

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -2133,10 +2133,10 @@ impl TryFrom<RawInode> for InodeDesc {
         Ok(Self {
             type_: inode_type,
             perm: FilePerm::from_raw_mode(inode.mode)?,
-            uid: (inode.os_dependent_2.uid_high as u32) << 16 | inode.uid as u32,
-            gid: (inode.os_dependent_2.gid_high as u32) << 16 | inode.gid as u32,
+            uid: ((inode.os_dependent_2.uid_high as u32) << 16) | inode.uid as u32,
+            gid: ((inode.os_dependent_2.gid_high as u32) << 16) | inode.gid as u32,
             size: if inode_type == InodeType::File {
-                (inode.size_high as usize) << 32 | inode.size_low as usize
+                ((inode.size_high as usize) << 32) | inode.size_low as usize
             } else {
                 inode.size_low as usize
             },

--- a/kernel/src/fs/ext2/xattr.rs
+++ b/kernel/src/fs/ext2/xattr.rs
@@ -247,8 +247,7 @@ impl Xattr {
         }
 
         value_writer.write_fallible(
-            &mut self
-                .blocks_buf
+            self.blocks_buf
                 .reader()
                 .to_fallible()
                 .skip(entry.value_offset as usize)

--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -510,7 +510,7 @@ pub fn split_path(path: &str) -> (&str, &str) {
     let file_name = path
         .split_inclusive('/')
         .filter(|&x| x != "/")
-        .last()
+        .next_back()
         .unwrap_or(".");
 
     let mut split = path.trim_end_matches('/').rsplitn(2, '/');

--- a/kernel/src/fs/sysfs/inode.rs
+++ b/kernel/src/fs/sysfs/inode.rs
@@ -198,7 +198,7 @@ impl SysFsInode {
                         InnerNode::Branch(child_branch),
                         Arc::downgrade(&self.this()),
                     );
-                    return Ok(inode);
+                    Ok(inode)
                 }
                 SysNodeType::Leaf => {
                     let child_leaf_node =
@@ -208,7 +208,7 @@ impl SysFsInode {
                         InnerNode::Leaf(child_leaf_node),
                         Arc::downgrade(&self.this()),
                     );
-                    return Ok(inode);
+                    Ok(inode)
                 }
                 SysNodeType::Symlink => {
                     let child_symlink = child_sysnode
@@ -219,7 +219,7 @@ impl SysFsInode {
                         child_symlink,
                         Arc::downgrade(&self.this()),
                     );
-                    return Ok(inode);
+                    Ok(inode)
                 }
             }
         } else {
@@ -245,7 +245,7 @@ impl SysFsInode {
                 parent_node_arc,
                 Arc::downgrade(&self.this()),
             );
-            return Ok(inode);
+            Ok(inode)
         }
     }
 
@@ -481,9 +481,9 @@ impl Inode for SysFsInode {
         let mut count = 0;
         let mut last_ino = start_ino;
 
-        let mut iter = self.new_dentry_iter(start_ino + 1);
+        let iter = self.new_dentry_iter(start_ino + 1);
 
-        while let Some(dentry) = iter.next() {
+        for dentry in iter {
             // The offset reported back to the caller should be the absolute position
             let next_offset = (dentry.ino + 1) as usize;
             let res = visitor.visit(&dentry.name, dentry.ino, dentry.type_, next_offset);
@@ -657,7 +657,7 @@ impl<'a> ThisAndParentDentryIter<'a> {
     }
 }
 
-impl<'a> Iterator for ThisAndParentDentryIter<'a> {
+impl Iterator for ThisAndParentDentryIter<'_> {
     type Item = Dentry;
 
     fn next(&mut self) -> Option<Dentry> {

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -23,5 +23,5 @@ pub fn singleton() -> &'static Arc<SysFs> {
 /// Should be called during kernel filesystem initialization, *after* aster_systree::init().
 pub fn init() {
     // Ensure systree is initialized first. This should be handled by the kernel's init order.
-    SYSFS_SINGLETON.call_once(|| SysFs::new());
+    SYSFS_SINGLETON.call_once(SysFs::new);
 }

--- a/kernel/src/fs/sysfs/test.rs
+++ b/kernel/src/fs/sysfs/test.rs
@@ -110,7 +110,7 @@ impl SysNode for MockLeafNode {
         let value = data.get(name).ok_or(SysTreeError::AttributeError)?; // Should exist if in attrs
         let bytes = value.as_bytes();
         writer
-            .write_fallible(&mut (&bytes[..]).into())
+            .write_fallible(&mut bytes.into())
             .map_err(|_| SysTreeError::AttributeError)
     }
 
@@ -214,7 +214,7 @@ impl SysNode for MockBranchNode {
         };
         let bytes = value.as_bytes();
         writer
-            .write_fallible(&mut (&bytes[..]).into())
+            .write_fallible(&mut bytes.into())
             .map_err(|_| SysTreeError::AttributeError)
     }
 
@@ -329,7 +329,7 @@ fn create_mock_systree_instance() -> &'static Arc<SysTree> {
     let symlink1 = MockSymlinkNode::new("link1", "../branch1/leaf1");
 
     // Build hierarchy - ignore Result since this is test setup
-    let _ = branch1.add_child(leaf1.clone() as Arc<dyn SysObj>);
+    branch1.add_child(leaf1.clone() as Arc<dyn SysObj>);
     let _ = root.add_child(branch1.clone() as Arc<dyn SysObj>);
     let _ = root.add_child(leaf2.clone() as Arc<dyn SysObj>);
     let _ = root.add_child(symlink1.clone() as Arc<dyn SysObj>);

--- a/kernel/src/net/socket/netlink/common/unbound.rs
+++ b/kernel/src/net/socket/netlink/common/unbound.rs
@@ -59,7 +59,7 @@ impl<P: SupportedNetlinkProtocol> datagram_common::Unbound for UnboundNetlink<P>
 
         let bound_handle = {
             let endpoint = {
-                let mut endpoint = endpoint.clone();
+                let mut endpoint = *endpoint;
                 endpoint.add_groups(self.groups);
                 endpoint
             };

--- a/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
@@ -81,7 +81,7 @@ impl datagram_common::Bound for BoundNetlinkUevent {
 
         response.write_to(writer)?;
 
-        let remote = response.src_addr().clone();
+        let remote = *response.src_addr();
 
         if !flags.contains(SendRecvFlags::MSG_PEEK) {
             receive_queue.pop_front().unwrap();

--- a/kernel/src/net/socket/netlink/kobject_uevent/message/syn_uevent.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/message/syn_uevent.rs
@@ -40,7 +40,7 @@ impl FromStr for SyntheticUevent {
         };
 
         let mut envs = Vec::new();
-        for env_str in split.into_iter() {
+        for env_str in split {
             let (key, value) = {
                 // Each string should be in the `KEY=VALUE` format.
                 match env_str.split_once('=') {
@@ -87,10 +87,9 @@ impl FromStr for Uuid {
             return_errno_with_message!(Errno::EINVAL, "the UUID length is invalid");
         }
 
-        for (byte, pattern) in bytes.into_iter().zip(UUID_PATTERN.as_bytes()) {
-            if *pattern == b'x' && byte.is_ascii_hexdigit() {
-                continue;
-            } else if *pattern == b'-' && *byte == b'-' {
+        for (byte, pattern) in bytes.iter().zip(UUID_PATTERN.as_bytes()) {
+            if (*pattern == b'x' && byte.is_ascii_hexdigit()) || (*pattern == b'-' && *byte == b'-')
+            {
                 continue;
             } else {
                 return_errno_with_message!(Errno::EINVAL, "the UUID content is invalid");

--- a/kernel/src/net/socket/netlink/kobject_uevent/message/uevent.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/message/uevent.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
 use core::{
+    fmt::Display,
     str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -142,8 +142,8 @@ impl Uevent {
     }
 }
 
-impl ToString for Uevent {
-    fn to_string(&self) -> String {
+impl Display for Uevent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut env_string = {
             let len = self
                 .envs
@@ -160,7 +160,8 @@ impl ToString for Uevent {
             env_string.push('\0');
         }
 
-        format!(
+        write!(
+            f,
             "{}@{}\0ACTION={}\0DEVPATH={}\0SUBSYSTEM={}\0{}SEQNUM={}\0",
             self.action.as_str(),
             self.devpath,

--- a/kernel/src/net/socket/netlink/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/message/segment/mod.rs
@@ -89,6 +89,7 @@ pub trait SegmentBody: Sized + Clone + Copy {
 
 #[repr(u16)]
 #[derive(Debug, Clone, Copy, TryFromInt, PartialEq, Eq, PartialOrd, Ord)]
+#[expect(clippy::upper_case_acronyms)]
 pub enum CSegmentType {
     // Standard netlink message types
     NOOP = 1,

--- a/kernel/src/net/socket/netlink/route/kernel/util.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/util.rs
@@ -29,7 +29,7 @@ fn append_done_segment(request_header: &CMsgSegHdr, response_segments: &mut Vec<
 }
 
 /// Adds the `MULTI` flag to all segments in `segments`.
-fn add_multi_flag(response_segments: &mut Vec<RtnlSegment>) {
+fn add_multi_flag(response_segments: &mut [RtnlSegment]) {
     for segment in response_segments.iter_mut() {
         let header = segment.header_mut();
         let mut flags = SegHdrCommonFlags::from_bits_truncate(header.flags);

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, TryFromInt)]
 #[repr(u16)]
 #[expect(non_camel_case_types)]
+#[expect(clippy::upper_case_acronyms)]
 enum AddrAttrClass {
     UNSPEC = 0,
     ADDRESS = 1,

--- a/kernel/src/net/socket/netlink/route/message/attr/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/link.rs
@@ -12,7 +12,8 @@ use crate::{
 /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_link.h#L297>.
 #[derive(Debug, Clone, Copy, TryFromInt)]
 #[repr(u16)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
+#[expect(clippy::upper_case_acronyms)]
 enum LinkAttrClass {
     UNSPEC = 0,
     ADDRESS = 1,

--- a/kernel/src/net/socket/netlink/route/message/segment/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/addr.rs
@@ -105,6 +105,7 @@ bitflags! {
 /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L320>.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
+#[expect(clippy::upper_case_acronyms)]
 pub enum RtScope {
     UNIVERSE = 0,
     // User defined values

--- a/kernel/src/net/socket/netlink/route/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/mod.rs
@@ -5,18 +5,18 @@
 //!
 //! Typically, a segment will consist of three parts:
 //!
-//! 1. Header: The headers of all segments are of type [`CMessageSegmentHeader`],
-//! which indicate the type and total length of the segment.
+//! 1. Header: The headers of all segments are of type [`CMegSegHdr`],
+//!    which indicate the type and total length of the segment.
 //!
 //! 2. Body: The body is the main component of a segment.
-//! Each segment will have one and only one body.
-//! The body type is defined by the `type_` field of the header.
+//!    Each segment will have one and only one body.
+//!    The body type is defined by the `type_` field of the header.
 //!
 //! 3. Attributes: Attributes are optional.
-//! A segment can have zero or multiple attributes.
-//! Attributes belong to different classes,
-//! with the class defined by the `type_` field of the header.
-//! The total number of attributes is controlled by the `len` field of the header.
+//!    A segment can have zero or multiple attributes.
+//!    Attributes belong to different classes,
+//!    with the class defined by the `type_` field of the header.
+//!    The total number of attributes is controlled by the `len` field of the header.
 //!
 //! Note that all headers, bodies, and attributes require
 //! their starting address in memory to be aligned to [`super::NLMSG_ALIGN`]

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -259,7 +259,7 @@ impl<Message: 'static> Drop for BoundHandle<Message> {
 }
 
 pub(super) fn init() {
-    NETLINK_SOCKET_TABLE.call_once(|| NetlinkSocketTable::new());
+    NETLINK_SOCKET_TABLE.call_once(NetlinkSocketTable::new);
 }
 
 /// Returns whether the `protocol` is valid.
@@ -270,7 +270,7 @@ pub fn is_valid_protocol(protocol: NetlinkProtocolId) -> bool {
 /// Netlink protocols that are assigned for specific usage.
 ///
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/include/uapi/linux/netlink.h#L9>.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
 pub enum StandardNetlinkProtocol {

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -515,6 +515,7 @@ fn clone_sysvsem(clone_flags: CloneFlags) -> Result<()> {
     Ok(())
 }
 
+#[expect(clippy::too_many_arguments)]
 fn create_child_process(
     pid: Pid,
     parent: Weak<Process>,

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -80,7 +80,7 @@ fn move_process_children(
     // Take the lock first to avoid the race when the `reaper_process` is exiting concurrently.
     let mut reaper_process_children = reaper_process.children().lock();
 
-    let is_init = is_init_process(&reaper_process);
+    let is_init = is_init_process(reaper_process);
     let is_zombie = reaper_process.status().is_zombie();
     if !is_init && is_zombie {
         return Err(());

--- a/kernel/src/process/posix_thread/name.rs
+++ b/kernel/src/process/posix_thread/name.rs
@@ -28,7 +28,7 @@ impl ThreadName {
         let mut thread_name = ThreadName::new();
         let executable_file_name = executable_path
             .split('/')
-            .last()
+            .next_back()
             .ok_or(Error::with_message(Errno::EINVAL, "invalid elf path"))?;
         let name = CString::new(executable_file_name)?;
         thread_name.set_name(&name)?;

--- a/kernel/src/process/process/terminal.rs
+++ b/kernel/src/process/process/terminal.rs
@@ -108,7 +108,7 @@ impl dyn Terminal {
         let mut session_inner = session.lock();
 
         if let Some(session_terminal) = session_inner.terminal() {
-            if Arc::ptr_eq(&session_terminal, &self) {
+            if Arc::ptr_eq(session_terminal, &self) {
                 return Ok(());
             }
             return_errno_with_message!(
@@ -195,7 +195,7 @@ impl dyn Terminal {
 
         if !session_inner
             .terminal()
-            .is_some_and(|session_terminal| Arc::ptr_eq(session_terminal, &self))
+            .is_some_and(|session_terminal| Arc::ptr_eq(session_terminal, self))
         {
             return_errno_with_message!(
                 Errno::ENOTTY,

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -171,7 +171,7 @@ impl ProcessVm {
     pub fn clear_and_map(&self) {
         let root_vmar = self.lock_root_vmar();
         root_vmar.unwrap().clear().unwrap();
-        self.heap.alloc_and_map_vm(&root_vmar.unwrap()).unwrap();
+        self.heap.alloc_and_map_vm(root_vmar.unwrap()).unwrap();
     }
 }
 

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -96,7 +96,7 @@ pub trait Pause: WaitTimeout {
     /// [`ETIME`]: crate::error::Errno::ETIME
     /// [`EINTR`]: crate::error::Errno::EINTR
     #[track_caller]
-    fn pause_timeout<'a>(&self, timeout: &TimeoutExt<'a>) -> Result<()>;
+    fn pause_timeout(&self, timeout: &TimeoutExt<'_>) -> Result<()>;
 }
 
 impl Pause for Waiter {
@@ -136,7 +136,7 @@ impl Pause for Waiter {
         res
     }
 
-    fn pause_timeout<'a>(&self, timeout: &TimeoutExt<'a>) -> Result<()> {
+    fn pause_timeout(&self, timeout: &TimeoutExt<'_>) -> Result<()> {
         let timer = timeout.check_expired()?.map(|timeout| {
             let waker = self.waker();
             timeout.create_timer(move || {
@@ -201,7 +201,7 @@ impl Pause for WaitQueue {
         waiter.pause_until_or_timeout_impl(cond, timeout)
     }
 
-    fn pause_timeout<'a>(&self, _timeout: &TimeoutExt<'a>) -> Result<()> {
+    fn pause_timeout(&self, _timeout: &TimeoutExt<'_>) -> Result<()> {
         panic!("`pause_timeout` can only be used on `Waiter`");
     }
 }

--- a/kernel/src/sched/sched_class/policy.rs
+++ b/kernel/src/sched/sched_class/policy.rs
@@ -103,6 +103,6 @@ impl SchedPolicyState {
     }
 
     pub fn update<T>(&self, update: impl FnOnce(&mut SchedPolicy) -> T) -> T {
-        update(&mut *self.policy.disable_irq().lock())
+        update(&mut self.policy.disable_irq().lock())
     }
 }

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -113,7 +113,7 @@ struct Dirent {
     name: CString,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Debug, Clone, Copy)]
 struct DirentInner {
     d_ino: u64,
@@ -172,7 +172,7 @@ struct Dirent64 {
     name: CString,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Debug, Clone, Copy)]
 struct Dirent64Inner {
     d_ino: u64,

--- a/kernel/src/syscall/sched_getattr.rs
+++ b/kernel/src/syscall/sched_getattr.rs
@@ -183,9 +183,9 @@ pub(super) fn access_sched_attr_with<T>(
     f: impl FnOnce(&SchedAttr) -> Result<T>,
 ) -> Result<T> {
     match tid {
-        0 => f(&ctx.thread.sched_attr()),
+        0 => f(ctx.thread.sched_attr()),
         _ if tid > (i32::MAX as u32) => Err(Error::with_message(Errno::EINVAL, "invalid tid")),
-        _ => f(&thread_table::get_thread(tid)
+        _ => f(thread_table::get_thread(tid)
             .ok_or_else(|| Error::with_message(Errno::ESRCH, "thread does not exist"))?
             .sched_attr()),
     }

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -151,7 +151,7 @@ pub(super) fn lookup_dentry_for_xattr<'a>(
     }
 }
 
-pub(super) fn read_xattr_name_cstr_from_user<'a>(
+pub(super) fn read_xattr_name_cstr_from_user(
     name_ptr: Vaddr,
     user_space: &CurrentUserSpace,
 ) -> Result<CString> {
@@ -170,9 +170,10 @@ pub(super) fn parse_xattr_name(name_str: &str) -> Result<XattrName> {
         return_errno_with_message!(Errno::ERANGE, "xattr name empty or too long");
     }
 
-    let xattr_name = XattrName::try_from_full_name(name_str.as_ref()).ok_or(
-        Error::with_message(Errno::EOPNOTSUPP, "invalid xattr namespace"),
-    )?;
+    let xattr_name = XattrName::try_from_full_name(name_str).ok_or(Error::with_message(
+        Errno::EOPNOTSUPP,
+        "invalid xattr namespace",
+    ))?;
     Ok(xattr_name)
 }
 
@@ -181,18 +182,14 @@ pub(super) fn check_xattr_namespace(namespace: XattrNamespace, ctx: &Context) ->
     let permitted_capset = credentials.permitted_capset();
     let effective_capset = credentials.effective_capset();
 
-    match namespace {
-        XattrNamespace::Trusted => {
-            if !permitted_capset.contains(CapSet::SYS_ADMIN)
-                || !effective_capset.contains(CapSet::SYS_ADMIN)
-            {
-                return_errno_with_message!(
-                    Errno::EPERM,
-                    "try to access trusted xattr without CAP_SYS_ADMIN"
-                );
-            }
-        }
-        _ => {}
+    if namespace == XattrNamespace::Trusted
+        && (!permitted_capset.contains(CapSet::SYS_ADMIN)
+            || !effective_capset.contains(CapSet::SYS_ADMIN))
+    {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "try to access trusted xattr without CAP_SYS_ADMIN"
+        );
     }
     Ok(())
 }

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -184,7 +184,7 @@ impl From<Duration> for StatxTimestamp {
     fn from(duration: Duration) -> Self {
         Self {
             tv_sec: duration.as_secs() as i64,
-            tv_nsec: duration.subsec_nanos() as u32,
+            tv_nsec: duration.subsec_nanos(),
             __reserved: 0,
         }
     }

--- a/kernel/src/time/core/timer.rs
+++ b/kernel/src/time/core/timer.rs
@@ -188,7 +188,7 @@ impl TimerManager {
     pub fn process_expired_timers(&self) {
         let callbacks = {
             let mut timeout_list = self.timer_callbacks.disable_irq().lock();
-            if timeout_list.len() == 0 {
+            if timeout_list.is_empty() {
                 return;
             }
 

--- a/kernel/src/time/softirq.rs
+++ b/kernel/src/time/softirq.rs
@@ -5,8 +5,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use aster_softirq::{softirq_id::TIMER_SOFTIRQ_ID, SoftIrqLine};
 use ostd::{sync::RcuOption, timer};
 
-#[allow(clippy::type_complexity)]
-#[allow(clippy::box_collection)]
+#[expect(clippy::type_complexity)]
 static TIMER_SOFTIRQ_CALLBACKS: RcuOption<Box<Vec<fn()>>> = RcuOption::new_none();
 
 pub(super) fn init() {

--- a/kernel/src/util/net/addr/family.rs
+++ b/kernel/src/util/net/addr/family.rs
@@ -268,13 +268,13 @@ pub fn write_socket_addr_with_max_len(
 }
 
 // Utility function to write a C socket address to user space.
-fn write_c_socket_address_util<TCSockAddr: Pod, TSockAddr>(
+fn write_c_socket_address_util<TCSockAddr, TSockAddr>(
     addr: TSockAddr,
     dest: Vaddr,
     max_len: usize,
 ) -> Result<usize>
 where
-    TCSockAddr: From<TSockAddr>,
+    TCSockAddr: Pod + From<TSockAddr>,
 {
     let c_socket_addr = TCSockAddr::from(addr);
     let actual_len = size_of::<TCSockAddr>();

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -673,7 +673,7 @@ impl<'a, R1, R2> VmarMapOptions<'a, R1, R2> {
     }
 }
 
-impl<'a, R1, R2> VmarMapOptions<'a, R1, R2>
+impl<R1, R2> VmarMapOptions<'_, R1, R2>
 where
     Vmo<R2>: VmoRightsOp,
 {

--- a/kernel/src/vm/vmo/mod.rs
+++ b/kernel/src/vm/vmo/mod.rs
@@ -459,7 +459,6 @@ impl Vmo_ {
             cursor.next();
         }
 
-        drop(cursor);
         drop(locked_pages);
 
         for page_idx in removed_page_idx {

--- a/kernel/src/vm/vmo/options.rs
+++ b/kernel/src/vm/vmo/options.rs
@@ -143,7 +143,6 @@ fn committed_pages_if_continuous(flags: VmoFlags, size: usize) -> Result<XArray<
             cursor.store(frame);
             cursor.next();
         }
-        drop(cursor);
         drop(locked_pages);
         Ok(committed_pages)
     } else {

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -51,6 +51,7 @@ pub enum BaseCrateType {
     /// The base crate is for testing the target crate.
     Test,
     /// The base crate is for other actions using Cargo.
+    #[expect(unused)]
     Other,
 }
 

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -10,8 +10,6 @@ mod run;
 mod test;
 mod util;
 
-use util::DEFAULT_TARGET_RELPATH;
-
 pub use self::{
     build::execute_build_command, debug::execute_debug_command, new::execute_new_command,
     profile::execute_profile_command, run::execute_run_command, test::execute_test_command,
@@ -19,9 +17,8 @@ pub use self::{
 
 use crate::{
     arch::get_default_arch,
-    base_crate::{new_base_crate, BaseCrateType},
     error_msg,
-    util::{get_current_crates, get_target_directory, DirGuard},
+    util::{get_current_crates, DirGuard},
 };
 
 /// Execute the forwarded cargo command with arguments.
@@ -65,24 +62,9 @@ pub fn execute_forwarded_command_on_each_crate(
     args: &Vec<String>,
     cfg_ktest: bool,
 ) {
-    let cargo_target_directory = get_target_directory();
-    let osdk_output_directory = cargo_target_directory.join(DEFAULT_TARGET_RELPATH);
-
     let target_crates = get_current_crates();
     for target in target_crates {
-        if !target.is_kernel_crate {
-            let _dir_guard = DirGuard::change_dir(target.path);
-            execute_forwarded_command(subcommand, args, cfg_ktest);
-        } else {
-            let base_crate_path = new_base_crate(
-                BaseCrateType::Other,
-                osdk_output_directory.join(&target.name),
-                &target.name,
-                target.path,
-                false,
-            );
-            let _dir_guard = DirGuard::change_dir(&base_crate_path);
-            execute_forwarded_command(subcommand, args, cfg_ktest);
-        }
+        let _dir_guard = DirGuard::change_dir(target.path);
+        execute_forwarded_command(subcommand, args, cfg_ktest);
     }
 }

--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -50,17 +50,6 @@ do_publish_for() {
     RF="$RUSTFLAGS --check-cfg cfg(ktest)"
 
     if [ -n "$DRY_RUN" ]; then
-        # Temporarily change the crate version to the next patched version.
-        #
-        # `cargo publish --dry-run` requires that 
-        # the crate version is not already published on crates.io,
-        # otherwise, the check will fail.
-        # Therefore, we modify the crate version to ensure it is not published.
-        current_version=$(cat $ASTER_SRC_DIR/VERSION)
-        next_patched_version=$(echo "$current_version" | awk -F. '{printf "%d.%d.%d\n", $1, $2, $3 + 1}')
-        pattern="^version = \"[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\"$"
-        sed -i "0,/${pattern}/s/${pattern}/version = \"${next_patched_version}\"/1" Cargo.toml
-        
         # Perform checks
         RUSTFLAGS=$RF cargo publish --dry-run --allow-dirty $ADDITIONAL_ARGS
         RUSTFLAGS=$RF cargo doc $ADDITIONAL_ARGS


### PR DESCRIPTION
This issue was identified by @lrh2000 in [this comment](https://github.com/asterinas/asterinas/pull/2109#issuecomment-2947956459). Currently, the clippy check in CI is not functioning correctly.

The problem arises because OSDK runs `cargo clippy -- -D warnings` in the base crate instead of in the kernel crate. As a result, clippy does not perform link check in the kernel crate and can only report warnings generated by `cargo build`.

The first commit resolves this issue by executing the forwarded command in the kernel crate rather than in the base crate. However, I am uncertain whether this fix is appropriate and would appreciate @junyang-zh's confirmation.

The second commit resolves all clippy warnings. Since the clippy check has not been enabled for quite some time, there are numerous warnings that need to be addressed before we can re-enable clippy.