### PR TITLE
Replace proc_macro APIs with proc_macro2 APIs in ostd_macros

### DIFF
--- a/ostd/libs/ostd-macros/Cargo.toml
+++ b/ostd/libs/ostd-macros/Cargo.toml
@@ -12,7 +12,7 @@ repository ="https://github.com/asterinas/asterinas"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.78"
+proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
 quote = "1.0.35"
 rand = "0.8.5"
 syn = { version = "2.0.48", features = ["full"] }

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -320,11 +320,9 @@ pub fn ktest(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let package_name = std::env::var("CARGO_PKG_NAME").unwrap();
-    let span = proc_macro::Span::call_site();
-    let source = span.source_file().path();
-    let source = source.to_str().unwrap();
-    let line = span.line();
-    let col = span.column();
+    let span = proc_macro2::Span::call_site();
+    let line = span.start().line;
+    let col = span.start().column;
 
     let register_ktest_item = if package_name.as_str() == "ostd" {
         quote! {
@@ -338,7 +336,7 @@ pub fn ktest(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     module_path: module_path!(),
                     fn_name: stringify!(#fn_name),
                     package: #package_name,
-                    source: #source,
+                    source: file!(),
                     line: #line,
                     col: #col,
                 },
@@ -356,7 +354,7 @@ pub fn ktest(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     module_path: module_path!(),
                     fn_name: stringify!(#fn_name),
                     package: #package_name,
-                    source: #source,
+                    source: file!(),
                     line: #line,
                     col: #col,
                 },


### PR DESCRIPTION
Fixes #2133.

The documentation build for OSTD version 0.15.0 fails because `ostd_macros` uses the deprecated API `proc_macro::Span::source_file`.

This PR replaces the use of `proc_macro::Span::source_file` with the `file!` macro and swaps out `proc_macro` APIs for `proc_macro2` APIs, which are more stable.

Details about the bug and other possible solutions are discussed in #2133. You can refer to that issue for more information.