### PR TITLE
Debug for try_from impl for Duration

### DIFF
--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -65,8 +65,8 @@ impl TryFrom<timespec_t> for Duration {
             return_errno_with_message!(Errno::EINVAL, "timesepc_t cannot be negative");
         }
 
-        if value.nsec > NSEC_PER_SEC {
-            // The value of nanoseconds cannot exceed 10^9,
+        if value.nsec >= NSEC_PER_SEC {
+            // The value of nanoseconds must be strictly less than 10^9,
             // otherwise the value for seconds should be set.
             return_errno_with_message!(Errno::EINVAL, "nsec is not normalized");
         }


### PR DESCRIPTION
When I use `Duration::try_from(ts)` in the implementation of sys_epoll_pwait2, I notice there is a bug in it, resulting failure in LTP test.
In the examination for `value: timespec_t`, `value.nsec` shoule be strictly smaller than NSEC_PER_SEC, but we did not consider equal case before. Therefore, when LTP test passes an invalid value with `value.nsec` NSEC_PER_SEC, it should have caused error but not.