### PR TITLE
Add TFDSetTimeFlags and fix reachable panic

### DIFF
--- a/kernel/src/syscall/timer_settime.rs
+++ b/kernel/src/syscall/timer_settime.rs
@@ -43,12 +43,10 @@ pub fn sys_timer_settime(
         // Clear previous timer
         timer.cancel();
     } else {
-        let timeout = if flags == 0 {
+        let timeout = if (flags & TIMER_ABSTIME) == 0 {
             Timeout::After(expire_time)
-        } else if flags == TIMER_ABSTIME {
-            Timeout::When(expire_time)
         } else {
-            unreachable!()
+            Timeout::When(expire_time)
         };
         timer.set_timeout(timeout);
     }

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -27,10 +27,18 @@ pub struct TimerfdFile {
 }
 
 bitflags! {
-    /// The flags useds for timerfd-related operations.
+    /// The flags used for timerfd-related operations.
     pub struct TFDFlags: u32 {
         const TFD_CLOEXEC = CreationFlags::O_CLOEXEC.bits();
         const TFD_NONBLOCK = StatusFlags::O_NONBLOCK.bits();
+    }
+}
+
+bitflags! {
+    /// The flags used for timerfd settime operations.
+    pub struct TFDSetTimeFlags: u32 {
+        const TFD_TIMER_ABSTIME = 0x1;
+        const TFD_TIMER_CANCEL_ON_SET = 0x2;
     }
 }
 


### PR DESCRIPTION
Fix #2142 

Linux checks flags by 
https://elixir.bootlin.com/linux/v6.15.1/source/fs/timerfd.c#L461
```
if ((flags & ~TFD_SETTIME_FLAGS) ||
		 !itimerspec64_valid(new))
		return -EINVAL;
```

where
```
#define TFD_SETTIME_FLAGS (TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET)
```

So the `flag` could be [0, 3]
