### PR TITLE
Fix a clippy error

### DIFF
--- a/kernel/src/device/tty/termio.rs
+++ b/kernel/src/device/tty/termio.rs
@@ -165,6 +165,7 @@ impl Default for C_LFLAGS {
 /* c_cc characters index*/
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
+#[expect(clippy::upper_case_acronyms)]
 pub enum CC_C_CHAR {
     VINTR = 0,
     VQUIT = 1,


### PR DESCRIPTION
The lint error fails the main branch.