### PR TITLE
Assign framebuffer code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,7 @@
 
 # Component code owners
 /kernel/comps/block/            @lucassong-mh
+/kernel/comps/framebuffer/      @cqs21 @lrh2000
 /kernel/comps/logger/           @cchanging
 /kernel/comps/mlsdisk/          @cqs21 @lucassong-mh
 /kernel/comps/network/          @StevenJiang1110 @lrh2000


### PR DESCRIPTION
As was demonstrated at last Friday's meeting at the Zhongguancun Laboratory. I have made some improvements to the TTY/framebuffer, resulting in a snake game demo over framebuffer TTY on my personal laptop:

_(the image was captured on a Linux system for reference only)_
![image](https://github.com/user-attachments/assets/382dc933-1bb6-4082-9dd5-125cb2ce0946)

I will submit the related changes later. Maybe I should assign the code owners first so that @cqs21 can receive a review request?
