### PR TITLE
Support the system call `mremap`

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -15,7 +15,7 @@ support the loading of Linux kernel modules.
 ## System Calls
 
 At the time of writing,
-Asterinas implements 213 out of the 336 system calls
+Asterinas implements 214 out of the 336 system calls
 provided by Linux on x86-64 architecture.
 
 | Numbers | Names            | Is Implemented  |
@@ -45,7 +45,7 @@ provided by Linux on x86-64 architecture.
 | 22      | pipe             | ✅              |
 | 23      | select           | ✅              |
 | 24      | sched_yield      | ✅              |
-| 25      | mremap           | ❌              |
+| 25      | mremap           | ✅              |
 | 26      | msync            | ✅              |
 | 27      | mincore          | ❌              |
 | 28      | madvise          | ✅              |
@@ -321,10 +321,10 @@ provided by Linux on x86-64 architecture.
 | 298     | perf_event_open  | ❌              |
 | 299     | recvmmsg         | ❌              |
 | 300     | fanotify_init    | ❌              |
-| 301     | fanotify_mark    | ❌              | 
+| 301     | fanotify_mark    | ❌              |
 | 302	  | prlimit64        | ✅              |
 | 303	  | name_to_handle_at | ❌              |
-| 304	  | open_by_handle_at | ❌              |	
+| 304	  | open_by_handle_at | ❌              |
 | 305	  | clock_adjtime    | ❌              |
 | 306	  | syncfs           | ❌              |
 | 307	  | sendmmsg         | ❌              |

--- a/kernel/src/process/process_vm/heap.rs
+++ b/kernel/src/process/process_vm/heap.rs
@@ -91,7 +91,7 @@ impl Heap {
                 let new_size = new_heap_end - self.base;
 
                 // Expand the heap.
-                root_vmar.resize_mapping(self.base, old_size, new_size)?;
+                root_vmar.resize_mapping(self.base, old_size, new_size, false)?;
 
                 self.current_heap_end.store(new_heap_end, Ordering::Release);
                 Ok(new_heap_end)

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -60,6 +60,7 @@ use crate::syscall::{
     mmap::sys_mmap,
     mount::sys_mount,
     mprotect::sys_mprotect,
+    mremap::sys_mremap,
     msync::sys_msync,
     munmap::sys_munmap,
     nanosleep::{sys_clock_nanosleep, sys_nanosleep},
@@ -277,6 +278,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RECVMSG = 212            => sys_recvmsg(args[..3]);
     SYS_BRK = 214                => sys_brk(args[..1]);
     SYS_MUNMAP = 215             => sys_munmap(args[..2]);
+    SYS_MREMAP = 216           => sys_mremap(args[..5]);
     SYS_CLONE = 220              => sys_clone(args[..5], &user_ctx);
     SYS_EXECVE = 221             => sys_execve(args[..3], &mut user_ctx);
     SYS_MMAP = 222               => sys_mmap(args[..6]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -69,6 +69,7 @@ use crate::syscall::{
     mmap::sys_mmap,
     mount::sys_mount,
     mprotect::sys_mprotect,
+    mremap::sys_mremap,
     msync::sys_msync,
     munmap::sys_munmap,
     nanosleep::{sys_clock_nanosleep, sys_nanosleep},
@@ -184,6 +185,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCESS = 21            => sys_access(args[..2]);
     SYS_PIPE = 22              => sys_pipe(args[..1]);
     SYS_SELECT = 23            => sys_select(args[..5]);
+    SYS_MREMAP = 25            => sys_mremap(args[..5]);
     SYS_MSYNC = 26             => sys_msync(args[..3]);
     SYS_SCHED_YIELD = 24       => sys_sched_yield(args[..0]);
     SYS_MADVISE = 28           => sys_madvise(args[..3]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -74,6 +74,7 @@ mod mknod;
 mod mmap;
 mod mount;
 mod mprotect;
+mod mremap;
 mod msync;
 mod munmap;
 mod nanosleep;

--- a/kernel/src/syscall/mremap.rs
+++ b/kernel/src/syscall/mremap.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use align_ext::AlignExt;
+
+use super::SyscallReturn;
+use crate::prelude::*;
+
+pub fn sys_mremap(
+    old_addr: Vaddr,
+    old_size: usize,
+    new_size: usize,
+    flags: i32,
+    new_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let flags = MremapFlags::from_bits(flags).ok_or(Errno::EINVAL)?;
+    let new_addr = do_sys_mremap(old_addr, old_size, new_size, flags, new_addr, ctx)?;
+    Ok(SyscallReturn::Return(new_addr as _))
+}
+
+fn do_sys_mremap(
+    old_addr: Vaddr,
+    old_size: usize,
+    new_size: usize,
+    flags: MremapFlags,
+    new_addr: Vaddr,
+    ctx: &Context,
+) -> Result<Vaddr> {
+    debug!(
+        "mremap: old_addr = 0x{:x}, old_size = {}, new_size = {}, flags = {:?}, new_addr = 0x{:x}",
+        old_addr, old_size, new_size, flags, new_addr,
+    );
+
+    if old_addr % PAGE_SIZE != 0 {
+        return_errno_with_message!(Errno::EINVAL, "mremap: `old_addr` must be page-aligned");
+    }
+    if new_size == 0 {
+        return_errno_with_message!(Errno::EINVAL, "mremap: `new_size` cannot be zero");
+    }
+    if old_size == 0 {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "mremap: copying shareable mapping is not supported"
+        );
+    }
+
+    let old_size = old_size.align_up(PAGE_SIZE);
+    let new_size = new_size.align_up(PAGE_SIZE);
+
+    let user_space = ctx.user_space();
+    let root_vmar = user_space.root_vmar();
+
+    if !flags.contains(MremapFlags::MREMAP_FIXED) && new_size <= old_size {
+        if new_size < old_size {
+            // We can shrink a old range which spans multiple mappings. See
+            // <https://github.com/google/gvisor/blob/95d875276806484f974ce9e95556a561331f8e22/test/syscalls/linux/mremap.cc#L100-L117>.
+            root_vmar.resize_mapping(old_addr, old_size, new_size, false)?;
+        }
+        return Ok(old_addr);
+    }
+
+    if flags.contains(MremapFlags::MREMAP_MAYMOVE) {
+        if flags.contains(MremapFlags::MREMAP_FIXED) {
+            root_vmar.remap(old_addr, old_size, Some(new_addr), new_size)
+        } else {
+            root_vmar.remap(old_addr, old_size, None, new_size)
+        }
+    } else {
+        if flags.contains(MremapFlags::MREMAP_FIXED) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "mremap: `MREMAP_FIXED` specified without also specifying `MREMAP_MAYMOVE`"
+            );
+        }
+        // We can ensure that `new_size > old_size` here. Since we are enlarging
+        // the old mapping, it is necessary to check whether the old range lies
+        // in a single mapping.
+        //
+        // FIXME: According to <https://man7.org/linux/man-pages/man2/mremap.2.html>,
+        // if the `MREMAP_MAYMOVE` flag is not set, and the mapping cannot
+        // be expanded at the current `Vaddr`, we should return an `ENOMEM`.
+        // However, `resize_mapping` returns a `EACCES` in this case.
+        root_vmar.resize_mapping(old_addr, old_size, new_size, true)?;
+        Ok(old_addr)
+    }
+}
+
+bitflags! {
+    struct MremapFlags: i32 {
+        const MREMAP_MAYMOVE = 1 << 0;
+        const MREMAP_FIXED = 1 << 1;
+        // TODO: Add support for this flag, which exists since Linux 5.7.
+        // const MREMAP_DONTUNMAP = 1 << 2;
+    }
+}

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -14,7 +14,7 @@ use ostd::{
     task::disable_preempt,
 };
 
-use super::{interval_set::Interval, RssType};
+use super::{interval_set::Interval, RssDelta, RssType};
 use crate::{
     fs::utils::Inode,
     prelude::*,
@@ -151,12 +151,13 @@ impl VmMapping {
 /****************************** Page faults **********************************/
 
 impl VmMapping {
-    /// Handles a page fault and returns the number of pages mapped.
-    pub fn handle_page_fault(
+    /// Handles a page fault.
+    pub(super) fn handle_page_fault(
         &self,
         vm_space: &VmSpace,
         page_fault_info: &PageFaultInfo,
-    ) -> Result<usize> {
+        rss_delta: &mut RssDelta,
+    ) -> Result<()> {
         if !self.perms.contains(page_fault_info.required_perms) {
             trace!(
                 "self.perms {:?}, page_fault_info.required_perms {:?}, self.range {:?}",
@@ -173,7 +174,7 @@ impl VmMapping {
         let is_write = page_fault_info.required_perms.contains(VmPerms::WRITE);
 
         if !is_write && self.vmo.is_some() && self.handle_page_faults_around {
-            let (rss_increment, res) = self.handle_page_faults_around(vm_space, address);
+            let res = self.handle_page_faults_around(vm_space, address, rss_delta);
 
             // Errors caused by the "around" pages should be ignored, so here we
             // only return the error if the faulting page is still not mapped.
@@ -184,14 +185,13 @@ impl VmMapping {
                     &(page_aligned_addr..page_aligned_addr + PAGE_SIZE),
                 )?;
                 if let (_, Some((_, _))) = cursor.query().unwrap() {
-                    return Ok(rss_increment);
+                    return Ok(());
                 }
             }
 
-            return res.map(|_| rss_increment);
+            return res;
         }
 
-        let mut rss_increment: usize = 0;
         'retry: loop {
             let preempt_guard = disable_preempt();
             let mut cursor = vm_space.cursor_mut(
@@ -206,14 +206,14 @@ impl VmMapping {
                         // The page fault is already handled maybe by other threads.
                         // Just flush the TLB and return.
                         TlbFlushOp::Range(va).perform_on_current();
-                        return Ok(0);
+                        return Ok(());
                     }
                     assert!(is_write);
                     // Perform COW if it is a write access to a shared mapping.
 
                     // Skip if the page fault is already handled.
                     if prop.flags.contains(PageFlags::W) {
-                        return Ok(0);
+                        return Ok(());
                     }
 
                     // If the forked child or parent immediately unmaps the page after
@@ -233,7 +233,7 @@ impl VmMapping {
                         let new_frame = duplicate_frame(&frame)?;
                         prop.flags |= new_flags;
                         cursor.map(new_frame.into(), prop);
-                        rss_increment += 1;
+                        rss_delta.add(self.rss_type(), 1);
                     }
                     cursor.flusher().sync_tlb_flush();
                 }
@@ -270,13 +270,13 @@ impl VmMapping {
                     let map_prop = PageProperty::new_user(page_flags, CachePolicy::Writeback);
 
                     cursor.map(frame, map_prop);
-                    rss_increment += 1;
+                    rss_delta.add(self.rss_type(), 1);
                 }
             }
             break 'retry;
         }
 
-        Ok(rss_increment)
+        Ok(())
     }
 
     fn prepare_page(
@@ -310,14 +310,12 @@ impl VmMapping {
     }
 
     /// Handles a page fault and maps additional surrounding pages.
-    ///
-    /// Returns a tuple `(mapped_pages, result)`, where `mapped_pages` is the number
-    /// of pages mapped successfully, even if the `result` is some error.
     fn handle_page_faults_around(
         &self,
         vm_space: &VmSpace,
         page_fault_addr: Vaddr,
-    ) -> (usize, Result<()>) {
+        mut rss_delta: &mut RssDelta,
+    ) -> Result<()> {
         const SURROUNDING_PAGE_NUM: usize = 16;
         const SURROUNDING_PAGE_ADDR_MASK: usize = !(SURROUNDING_PAGE_NUM * PAGE_SIZE - 1);
 
@@ -332,19 +330,12 @@ impl VmMapping {
         );
 
         let vm_perms = self.perms - VmPerms::WRITE;
-        let mut rss_increment: usize = 0;
 
         'retry: loop {
             let preempt_guard = disable_preempt();
+            let mut cursor = vm_space.cursor_mut(&preempt_guard, &(start_addr..end_addr))?;
 
-            let mut cursor = match vm_space.cursor_mut(&preempt_guard, &(start_addr..end_addr)) {
-                Ok(cursor) => cursor,
-                Err(e) => {
-                    return (rss_increment, Err(e.into()));
-                }
-            };
-
-            let rss_increment_ref = &mut rss_increment;
+            let rss_delta_ref = &mut rss_delta;
             let operate =
                 move |commit_fn: &mut dyn FnMut()
                     -> core::result::Result<UFrame, VmoCommitError>| {
@@ -356,7 +347,7 @@ impl VmMapping {
                         let page_prop = PageProperty::new_user(page_flags, CachePolicy::Writeback);
                         let frame = commit_fn()?;
                         cursor.map(frame, page_prop);
-                        *rss_increment_ref += 1;
+                        rss_delta_ref.add(self.rss_type(), 1);
                     } else {
                         let next_addr = cursor.virt_addr() + PAGE_SIZE;
                         if next_addr < end_addr {
@@ -369,16 +360,14 @@ impl VmMapping {
             let start_offset = start_addr - self.map_to_addr;
             let end_offset = end_addr - self.map_to_addr;
             match vmo.try_operate_on_range(&(start_offset..end_offset), operate) {
-                Ok(_) => return (rss_increment, Ok(())),
+                Ok(_) => return Ok(()),
                 Err(VmoCommitError::NeedIo(index)) => {
                     drop(preempt_guard);
-                    if let Err(e) = vmo.commit_on(index, CommitFlags::empty()) {
-                        return (rss_increment, Err(e));
-                    }
+                    vmo.commit_on(index, CommitFlags::empty())?;
                     start_addr = index * PAGE_SIZE + self.map_to_addr;
                     continue 'retry;
                 }
-                Err(VmoCommitError::Err(e)) => return (rss_increment, Err(e)),
+                Err(VmoCommitError::Err(e)) => return Err(e),
             }
         }
     }

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -113,6 +113,12 @@ impl VmMapping {
         })
     }
 
+    pub(super) fn clone_for_remap_at(&self, va: Vaddr) -> Result<VmMapping> {
+        let mut vm_mapping = self.new_fork()?;
+        vm_mapping.map_to_addr = va;
+        Ok(vm_mapping)
+    }
+
     /// Returns the mapping's start address.
     pub fn map_to_addr(&self) -> Vaddr {
         self.map_to_addr
@@ -388,7 +394,7 @@ impl VmMapping {
     ///
     /// The address must be within the mapping and page-aligned. The address
     /// must not be either the start or the end of the mapping.
-    fn split(self, at: Vaddr) -> Result<(Self, Self)> {
+    pub fn split(self, at: Vaddr) -> Result<(Self, Self)> {
         debug_assert!(self.map_to_addr < at && at < self.map_end());
         debug_assert!(at % PAGE_SIZE == 0);
 

--- a/test/apps/mmap/mmap_and_mremap.c
+++ b/test/apps/mmap/mmap_and_mremap.c
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include "../network/test.h"
+
+#define PAGE_SIZE 4096
+
+const char *content = "kjfkljk*wigo&h";
+
+void *x_mmap(void *addr, size_t length, int prot, int flags, int fd,
+	     off_t offset)
+{
+	void *result = mmap(addr, length, prot, flags, fd, offset);
+	if (result == MAP_FAILED) {
+		perror("mmap");
+		exit(EXIT_FAILURE);
+	}
+	return result;
+}
+
+FN_TEST(mmap_and_mremap)
+{
+	char *addr = x_mmap(NULL, 3 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	TEST_SUCC(munmap(addr, 3 * PAGE_SIZE));
+
+	addr = x_mmap(addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+	strcpy(addr, content);
+
+	char *addr2 = x_mmap(addr + 2 * PAGE_SIZE, PAGE_SIZE,
+			     PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+
+	char *new_addr = mremap(addr, PAGE_SIZE, 3 * PAGE_SIZE, MREMAP_MAYMOVE);
+	if (new_addr == MAP_FAILED) {
+		perror("mremap");
+		exit(EXIT_FAILURE);
+	}
+
+	// The following operation (if uncommented) would cause a segmentation fault.
+	// strcpy(addr, "Writing to old address");
+
+	TEST_RES(strcmp(new_addr, content), _ret == 0);
+	strcpy(new_addr + PAGE_SIZE, "Writing to page 2 (new)");
+	strcpy(new_addr + 2 * PAGE_SIZE, "Writing to page 3 (new)");
+
+	TEST_SUCC(munmap(new_addr, 3 * PAGE_SIZE));
+	TEST_SUCC(munmap(addr2, PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mmap_and_mremap_fixed)
+{
+	char *addr = x_mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	strcpy(addr, content);
+
+	// Map and unmap a target region to ensure we know it's free
+	char *fixed_addr = x_mmap(NULL, PAGE_SIZE, PROT_NONE,
+				  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	TEST_SUCC(munmap(fixed_addr, PAGE_SIZE)); // free it for mremap
+
+	char *new_addr = mremap(addr, PAGE_SIZE, PAGE_SIZE,
+				MREMAP_MAYMOVE | MREMAP_FIXED, fixed_addr);
+	if (new_addr != fixed_addr) {
+		perror("mremap");
+		exit(EXIT_FAILURE);
+	}
+
+	TEST_RES(strcmp(new_addr, content), _ret == 0);
+	TEST_SUCC(munmap(new_addr, PAGE_SIZE));
+}
+END_TEST()

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -28,6 +28,7 @@ hello_world/hello_world
 itimer/setitimer
 itimer/timer_create
 mmap/mmap_and_fork
+mmap/mmap_and_mremap
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss

--- a/test/syscall_test/gvisor/Makefile
+++ b/test/syscall_test/gvisor/Makefile
@@ -25,6 +25,7 @@ TESTS ?= \
 	mknod_test \
 	mmap_test \
 	mount_test \
+	mremap_test \
 	msync_test \
 	open_create_test \
 	open_test \

--- a/test/syscall_test/gvisor/blocklists/mremap_test
+++ b/test/syscall_test/gvisor/blocklists/mremap_test
@@ -1,0 +1,6 @@
+MremapDeathTest.SharedAnon
+MremapTest.InPlace_Copy
+MremapTest.MayMove_Copy
+MremapTest.MustMove_Copy
+PrivateShared/MremapParamTest.InPlace_ExpansionFailure/*
+PrivateShared/MremapParamTest.Fixed_ShrinkingAcrossVMAs/*

--- a/test/syscall_test/ltp/testcases/all.txt
+++ b/test/syscall_test/ltp/testcases/all.txt
@@ -883,11 +883,11 @@ mprotect05
 # mq_timedsend01
 # mq_unlink01
 
-# mremap01
-# mremap02
-# mremap03
+mremap01
+mremap02
+mremap03
 # mremap04
-# mremap05
+mremap05
 # mremap06
 
 # mseal01


### PR DESCRIPTION
The PR adds support for the syscall `mremap` required in the tracking issue https://github.com/asterinas/asterinas/issues/2112 .

EDIT: The current usage of `RssDelta` has an issue — users may return early without calling `add_rss_delta`, or simply forget to call it. To fix this issue, we should update the RSS count when a `RssDelta` is dropped. The first commit fixes the `RssDelta` issue, and the second commit adds support for `mremap`.

