### PR TITLE
RISC-V `ktest`--the OSDK support

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -25,9 +25,6 @@ init_args = ["sh", "-l"]
 initramfs = "test/build/initramfs.cpio.gz"
 
 # Special options for testing
-[test.boot]
-method = "qemu-direct"
-
 [test.qemu]
 args = "$(./tools/qemu_args.sh test)"
 

--- a/docs/src/osdk/reference/manifest.md
+++ b/docs/src/osdk/reference/manifest.md
@@ -28,7 +28,7 @@ the available configurations in the manifest.
 ```toml
 project_type = "kernel"                     # <1> 
 
-# --------------------------- the default schema settings -------------------------------
+# --------------------------- the default scheme settings -------------------------------
 supported_archs = ["x86_64", "riscv64"]     # <2>
 
 # The common options for all build, run and test subcommands 
@@ -63,13 +63,13 @@ args = "-machine q35 -m 2G"                 # <19>
 [test.boot]                                 # <8>
 [test.grub]                                 # <13>
 [test.qemu]                                 # <17>
-# ----------------------- end of the default schema settings ----------------------------
+# ----------------------- end of the default scheme settings ----------------------------
 
-# A customized schema settings
-[schema."custom"]                           # <22>
-[schema."custom".build]                     # <3>
-[schema."custom".run]                       # <20>
-[schema."custom".test]                      # <21>
+# A customized scheme settings
+[scheme."custom"]                           # <22>
+[scheme."custom".build]                     # <3>
+[scheme."custom".run]                       # <20>
+[scheme."custom".test]                      # <21>
 ```
 
 Here are some additional notes for the fields:
@@ -201,10 +201,10 @@ can include any POSIX shell compliant separators.
 
     Similar to `20`, but only take effect when running `cargo osdk test`.
 
-22. The definition of customized schema. 
+22. The definition of customized scheme. 
 
-    A customized schema has the same fields as the default schema. 
-    By default, a customized schema will inherit all options from the default schema,
+    A customized scheme has the same fields as the default scheme. 
+    By default, a customized scheme will inherit all options from the default scheme,
     unless overridden by new options.
 
 ### Example
@@ -221,10 +221,20 @@ used to determine the actual set of qemu arguments.
 
 ### Scheme
 
-Scheme is an advanced feature to create multiple profiles for
-the same actions under different scenarios. Scheme allows any
-user-defined keys and can be selected by the `--scheme` CLI
-argument. The key `scheme` can be used to create special settings
-(especially special QEMU configurations). If a scheme action is
-matched, unspecified and required arguments will be inherited
-from the default scheme.
+Scheme is an advanced feature that allows you to create multiple profiles for
+the same action (`build`, `run`, or `test`) under different scenarios (e.g.,
+x86 vs. RISC-V). Schemes support any user-defined keys (see the 22nd
+configuration) and can be selected using the `--scheme` CLI argument.
+
+If a scheme `<s>` is selected for an action (such as `test`), the value of an
+unspecified but required configuration `key` will be determined by the
+following rules:
+ - If the general config (`scheme.<s>.key`) exists for the selected scheme, use
+   this value.
+ - Otherwise, if the default scheme has this configuration for the action
+   (`test.key`), use this value.
+ - Otherwise, if the default scheme has this configuration (`key`), use this
+   value.
+
+If the value is still not found, either the default value for the key will be
+used or an error will be thrown.

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "shlex",
  "syn",
  "toml",
+ "which",
 ]
 
 [[package]]
@@ -381,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +405,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "getrandom"
@@ -609,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +833,19 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1064,6 +1100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1250,12 @@ checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.111"
 shlex = "1.3.0"
 syn = { version = "2.0.52", features = ["extra-traits", "full", "parsing", "printing"] }
 toml = { version = "0.8.8", features = ["preserve_order"] }
+which = "8.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.13"

--- a/osdk/src/arch.rs
+++ b/osdk/src/arch.rs
@@ -80,7 +80,7 @@ impl Display for Arch {
 
 /// Get the default architecture implied by the host rustc's default architecture.
 pub fn get_default_arch() -> Arch {
-    let output = std::process::Command::new("rustc")
+    let output = crate::util::new_command_checked_exists("rustc")
         .arg("-vV")
         .output()
         .expect("Failed to run rustc to get the host target");

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -11,7 +11,6 @@ use vm_image::{AsterVmImage, AsterVmImageType};
 
 use std::{
     path::{Path, PathBuf},
-    process::Command,
     time::SystemTime,
 };
 
@@ -22,7 +21,7 @@ use crate::{
     },
     error::Errno,
     error_msg,
-    util::DirGuard,
+    util::{new_command_checked_exists, DirGuard},
 };
 
 /// The osdk bundle artifact that stores as `bundle` directory.
@@ -199,8 +198,8 @@ impl Bundle {
             ActionChoice::Run => &config.run,
             ActionChoice::Test => &config.test,
         };
-        let mut qemu_cmd = Command::new(&action.qemu.path);
 
+        let mut qemu_cmd = new_command_checked_exists(&action.qemu.path);
         qemu_cmd.current_dir(&config.work_dir);
 
         match action.boot.method {

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -4,7 +4,6 @@ use std::{
     fs::{File, OpenOptions},
     io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use linux_bzimage_builder::{
@@ -17,7 +16,7 @@ use crate::{
         bin::{AsterBin, AsterBinType, AsterBzImageMeta, AsterElfMeta},
         file::BundleFile,
     },
-    util::{get_current_crates, hard_link_or_copy},
+    util::{get_current_crates, hard_link_or_copy, new_command_checked_exists},
 };
 
 pub fn make_install_bzimage(
@@ -95,7 +94,7 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
 
     if strip {
         // We use rust-strip to reduce the kernel image size.
-        let status = Command::new("rust-strip")
+        let status = new_command_checked_exists("rust-strip")
             .arg(elf.path())
             .arg("-o")
             .arg(result_elf_path.as_os_str())
@@ -170,7 +169,7 @@ fn install_setup_with_arch(
     }
     let target_dir = std::fs::canonicalize(target_dir).unwrap();
 
-    let mut cmd = Command::new("cargo");
+    let mut cmd = new_command_checked_exists("cargo");
     let mut rustflags = vec![
         "-Cdebuginfo=2",
         "-Ccode-model=kernel",

--- a/osdk/src/commands/build/grub.rs
+++ b/osdk/src/commands/build/grub.rs
@@ -16,7 +16,7 @@ use crate::{
         scheme::{ActionChoice, BootProtocol},
         Config,
     },
-    util::{get_current_crates, hard_link_or_copy},
+    util::{get_current_crates, hard_link_or_copy, new_command_checked_exists},
 };
 
 pub fn create_bootdev_image(
@@ -84,7 +84,7 @@ pub fn create_bootdev_image(
 
     // Make the boot device CDROM image using `grub-mkrescue`.
     let iso_path = &target_dir.as_ref().join(target_name.to_string() + ".iso");
-    let mut grub_mkrescue_cmd = std::process::Command::new(action.grub.grub_mkrescue.as_os_str());
+    let mut grub_mkrescue_cmd = new_command_checked_exists(action.grub.grub_mkrescue.as_os_str());
     grub_mkrescue_cmd
         .arg(iso_root.as_os_str())
         .arg("-o")
@@ -166,7 +166,7 @@ fn generate_grub_cfg(
 }
 
 fn get_grub_mkrescue_version(grub_mkrescue: &PathBuf) -> String {
-    let mut cmd = std::process::Command::new(grub_mkrescue);
+    let mut cmd = new_command_checked_exists(grub_mkrescue);
     cmd.arg("--version");
     let output = cmd.output().unwrap();
     String::from_utf8(output.stdout).unwrap()

--- a/osdk/src/commands/build/qcow2.rs
+++ b/osdk/src/commands/build/qcow2.rs
@@ -8,6 +8,7 @@ use crate::{
         vm_image::{AsterQcow2ImageMeta, AsterVmImage, AsterVmImageType},
     },
     error_msg,
+    util::new_command_checked_exists,
 };
 
 pub fn convert_iso_to_qcow2(iso: AsterVmImage) -> AsterVmImage {
@@ -17,7 +18,7 @@ pub fn convert_iso_to_qcow2(iso: AsterVmImage) -> AsterVmImage {
     let iso_path = iso.path();
     let qcow2_path = iso_path.with_extension("qcow2");
     // Convert the ISO to QCOW2 using `qemu-img`.
-    let mut qemu_img = process::Command::new("qemu-img");
+    let mut qemu_img = new_command_checked_exists("qemu-img");
     qemu_img.args([
         "convert",
         "-O",

--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -3,9 +3,8 @@
 use crate::{
     cli::DebugArgs,
     commands::util::bin_file_name,
-    util::{get_kernel_crate, get_target_directory},
+    util::{get_kernel_crate, get_target_directory, new_command_checked_exists},
 };
-use std::process::Command;
 
 pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
     let remote = &args.remote;
@@ -16,7 +15,7 @@ pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
         .join(bin_file_name());
     println!("Debugging {}", file_path.display());
 
-    let mut gdb = Command::new("gdb");
+    let mut gdb = new_command_checked_exists("gdb");
     gdb.args([
         format!("{}", file_path.display()).as_str(),
         "-ex",
@@ -27,7 +26,7 @@ pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
 
 #[test]
 fn have_gdb_installed() {
-    let output = Command::new("gdb").arg("--version").output();
+    let output = new_command_checked_exists("gdb").arg("--version").output();
     assert!(output.is_ok(), "Failed to run gdb");
     let stdout = String::from_utf8_lossy(&output.unwrap().stdout).to_string();
     assert!(stdout.contains("GNU gdb"));

--- a/osdk/src/commands/profile.rs
+++ b/osdk/src/commands/profile.rs
@@ -13,7 +13,7 @@ use inferno::flamegraph;
 use crate::{
     cli::{ProfileArgs, ProfileFormat},
     commands::util::bin_file_name,
-    util::{get_kernel_crate, get_target_directory},
+    util::{get_kernel_crate, get_target_directory, new_command_checked_exists},
 };
 use regex::Regex;
 use std::{
@@ -21,7 +21,7 @@ use std::{
     fs::File,
     io::{BufRead, Write},
     path::PathBuf,
-    process::{Command, Stdio},
+    process::Stdio,
     thread, time,
 };
 
@@ -92,7 +92,7 @@ fn do_collect_stack_traces(args: &ProfileArgs) {
         ];
         gdb_args.append(&mut vec![backtrace_cmd_seq; *samples].concat());
 
-        Command::new("gdb")
+        new_command_checked_exists("gdb")
             .args(gdb_args)
             .stdout(Stdio::piped())
             .spawn()
@@ -119,7 +119,7 @@ fn do_collect_stack_traces(args: &ProfileArgs) {
         }
         gdb_output.clear();
         thread::sleep(time::Duration::from_secs_f64(*interval));
-        let _ = Command::new("kill")
+        let _ = new_command_checked_exists("kill")
             .args(["-INT", &format!("{}", gdb_process.id())])
             .output();
     }

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use crate::util::get_kernel_crate;
+use crate::util::{get_kernel_crate, new_command_checked_exists};
 
 pub const COMMON_CARGO_ARGS: &[&str] = &[
     "-Zbuild-std=core,alloc,compiler_builtins",
@@ -12,7 +12,7 @@ pub const COMMON_CARGO_ARGS: &[&str] = &[
 pub const DEFAULT_TARGET_RELPATH: &str = "osdk";
 
 pub fn cargo() -> Command {
-    Command::new("cargo")
+    new_command_checked_exists("cargo")
 }
 
 pub fn profile_name_adapter(profile: &str) -> &str {

--- a/osdk/src/config/mod.rs
+++ b/osdk/src/config/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     config::unix_args::apply_kv_array,
     error::Errno,
     error_msg,
+    util::new_command_checked_exists,
 };
 
 /// The global configuration for the OSDK actions.
@@ -155,7 +156,7 @@ fn canonicalize_and_eval(action_scheme: &mut ActionScheme, workdir: &PathBuf) {
 /// This function is used to evaluate the string using the host's shell recursively
 /// in order.
 pub fn eval(cwd: impl AsRef<Path>, s: &String) -> io::Result<String> {
-    let mut eval = process::Command::new("bash");
+    let mut eval = new_command_checked_exists("bash");
     eval.arg("-c");
     eval.arg(format!("echo \"{}\"", s));
     eval.current_dir(cwd.as_ref());

--- a/osdk/src/error.rs
+++ b/osdk/src/error.rs
@@ -14,6 +14,7 @@ pub enum Errno {
     BadCrateName = 9,
     NoKernelCrate = 10,
     TooManyCrates = 11,
+    ExecutableNotFound = 12,
 }
 
 /// Print error message to console

--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -23,7 +23,7 @@ pub fn ostd_dep() -> String {
 }
 
 fn cargo() -> Command {
-    Command::new("cargo")
+    new_command_checked_exists("cargo")
 }
 
 /// Create a new library crate with cargo
@@ -163,6 +163,22 @@ pub fn get_kernel_crate() -> CrateInfo {
     }
 }
 
+/// Check if an OSDK dependent executable (e.g. QEMU) exists.
+///
+/// If it exists, create a command. If not, print an error message and exit the
+/// process.
+pub fn new_command_checked_exists(executable: impl AsRef<Path>) -> Command {
+    let executable = executable.as_ref();
+    if which::which(executable).is_err() {
+        error_msg!(
+            "Executable {:?} cannot be found in PATH, please install the corresponding package",
+            executable
+        );
+        std::process::exit(Errno::ExecutableNotFound as _);
+    }
+    Command::new(executable)
+}
+
 fn package_contains_ostd_main(package: &serde_json::Value) -> bool {
     let src_path = {
         let targets = package.get("targets").unwrap().as_array().unwrap();
@@ -262,13 +278,15 @@ pub fn trace_panic_from_log(qemu_log: File, bin_path: PathBuf) {
     let mut stack_num = 0;
     let pc_matcher = regex::Regex::new(r" - pc (0x[0-9a-fA-F]+)").unwrap();
     let exe = bin_path.to_string_lossy();
-    let mut addr2line = Command::new("addr2line");
+
+    let mut addr2line = new_command_checked_exists("addr2line");
     addr2line.args(["-e", &exe]);
     let mut addr2line_proc = addr2line
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .spawn()
         .unwrap();
+
     for line in lines.into_iter().rev() {
         if line.contains("Printing stack trace:") {
             println!("[OSDK] The kernel seems panicked. Parsing stack trace for source lines:");

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -4,14 +4,15 @@
 
 # This script is used to generate QEMU arguments for OSDK.
 # Usage: `qemu_args.sh [scheme]`
-#  - scheme: "normal", "microvm" or "iommu";
+#  - scheme: "normal", "test", "microvm" or "iommu";
 # Other arguments are configured via environmental variables:
 #  - OVMF: "on" or "off";
+#  - BOOT_METHOD: "qemu-direct", "grub-rescue-iso", "linux-efi-pe64" or "linux-efi-handover64";
 #  - NETDEV: "user" or "tap";
 #  - VHOST: "off" or "on";
 #  - VSOCK: "off" or "on";
 #  - SMP: number of CPUs;
-#  - MEM: amount of memory, e.g. "8G".
+#  - MEM: amount of memory, e.g. "8G";
 #  - VNC_PORT: VNC port, default is "42".
 
 OVMF=${OVMF:-"on"}
@@ -153,8 +154,8 @@ if [ "$1" = "microvm" ]; then
 fi
 
 if [ "$OVMF" = "on" ]; then
-    if [ "$1" = "test" ]; then
-        echo "We use QEMU direct boot for testing, which does not support OVMF, ignoring OVMF" 1>&2
+    if [ "$BOOT_METHOD" = "qemu-direct" ]; then
+        echo "QEMU direct boot is not compatible with OVMF, ignoring OVMF" 1>&2
     else
         OVMF_PATH="/root/ovmf/release"
         QEMU_ARGS="${QEMU_ARGS} \


### PR DESCRIPTION
This PR refines the OSDK scheme inheritance rules and adds arguments in the Makefile to make ktest work. After this PR, we can boot QEMU RISC-V with the correct arguments. But the OSTD is currently broken:

```
# make ktest

OpenSBI v1.5.1
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

Platform Name             : riscv-virtio,qemu
Platform Features         : medeleg
Platform HART Count       : 1
Platform IPI Device       : aclint-mswi
Platform Timer Device     : aclint-mtimer @ 10000000Hz
Platform Console Device   : uart8250
Platform HSM Device       : ---
Platform PMU Device       : ---
Platform Reboot Device    : syscon-reboot
Platform Shutdown Device  : syscon-poweroff
Platform Suspend Device   : ---
Platform CPPC Device      : ---
Firmware Base             : 0x80000000
Firmware Size             : 327 KB
Firmware RW Offset        : 0x40000
Firmware RW Size          : 71 KB
Firmware Heap Offset      : 0x49000
Firmware Heap Size        : 35 KB (total), 2 KB (reserved), 11 KB (used), 21 KB (free)
Firmware Scratch Size     : 4096 B (total), 416 B (used), 3680 B (free)
Runtime SBI Version       : 2.0

Domain0 Name              : root
Domain0 Boot HART         : 0
Domain0 HARTs             : 0*
Domain0 Region00          : 0x0000000000100000-0x0000000000100fff M: (I,R,W) S/U: (R,W)
Domain0 Region01          : 0x0000000010000000-0x0000000010000fff M: (I,R,W) S/U: (R,W)
Domain0 Region02          : 0x0000000002000000-0x000000000200ffff M: (I,R,W) S/U: ()
Domain0 Region03          : 0x0000000080040000-0x000000008005ffff M: (R,W) S/U: ()
Domain0 Region04          : 0x0000000080000000-0x000000008003ffff M: (R,X) S/U: ()
Domain0 Region05          : 0x000000000c400000-0x000000000c5fffff M: (I,R,W) S/U: (R,W)
Domain0 Region06          : 0x000000000c000000-0x000000000c3fffff M: (I,R,W) S/U: (R,W)
Domain0 Region07          : 0x0000000000000000-0xffffffffffffffff M: () S/U: (R,W,X)
Domain0 Next Address      : 0x0000000080200000
Domain0 Next Arg1         : 0x000000027fe00000
Domain0 Next Mode         : S-mode
Domain0 SysReset          : yes
Domain0 SysSuspend        : yes

Boot HART ID              : 0
Boot HART Domain          : root
Boot HART Priv Version    : v1.12
Boot HART Base ISA        : rv64imafdch
Boot HART ISA Extensions  : sstc,zicntr,zihpm,zicboz,zicbom,sdtrig,svadu
Boot HART PMP Count       : 16
Boot HART PMP Granularity : 2 bits
Boot HART PMP Address Bits: 54
Boot HART MHPM Info       : 16 (0x0007fff8)
Boot HART Debug Triggers  : 2 triggers
Boot HART MIDELEG         : 0x0000000000001666
Boot HART MEDELEG         : 0x0000000000f0b509
Enter riscv_boot
Test failed
```

Subsequent PRs should fix this before enabling RISC-V ktest CI.

Depends on #2167 