### PR TITLE
Fix improper handling of O_TRUNC for non-regular files

### DIFF
--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -112,7 +112,7 @@ impl FsResolver {
             );
         }
 
-        if creation_flags.contains(CreationFlags::O_TRUNC) {
+        if inode_type.is_regular_file() && creation_flags.contains(CreationFlags::O_TRUNC) {
             target_dentry.resize(0)?;
         }
         InodeHandle::new(target_dentry, open_args.access_mode, open_args.status_flags)


### PR DESCRIPTION
Fixes an issue where the `O_TRUNC` operation was incorrectly applied to non-regular files, such as `/dev/null`. This caused errors like:
```
~ # echo > /dev/null
sh: can't create /dev/null: Is a directory
```