### PR TITLE
Fix some missing or redundant pollee invalidation

### DIFF
--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -146,6 +146,7 @@ impl Producer<u8> {
 
         let written_len = self.0.write(reader)?;
         self.peer_end().pollee.notify(IoEvents::IN);
+        self.this_end().pollee.invalidate();
 
         if written_len > 0 {
             Ok(written_len)
@@ -172,6 +173,7 @@ impl<T: Pod> Producer<T> {
             (err, item)
         })?;
         self.peer_end().pollee.notify(IoEvents::IN);
+        self.this_end().pollee.invalidate();
 
         Ok(())
     }

--- a/kernel/src/net/socket/ip/options.rs
+++ b/kernel/src/net/socket/ip/options.rs
@@ -103,6 +103,6 @@ impl IpTtl {
     }
 }
 
-pub trait SetIpLevelOption {
+pub(super) trait SetIpLevelOption {
     fn set_hdrincl(&self, _hdrincl: bool) -> Result<()>;
 }

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -336,7 +336,6 @@ impl StreamSocket {
         let remote_endpoint = connected_stream.remote_endpoint();
 
         drop(state);
-        self.pollee.invalidate();
         if let Some(iface) = iface_to_poll {
             iface.poll();
         }

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -188,6 +188,7 @@ impl Backlog {
         drop(locked_incoming_conns);
 
         if conn.is_some() {
+            self.pollee.invalidate();
             self.wait_queue.wake_one();
         }
 
@@ -203,13 +204,9 @@ impl Backlog {
     }
 
     fn shutdown(&self) {
-        let mut incoming_conns = self.incoming_conns.lock();
+        *self.incoming_conns.lock() = None;
 
-        *incoming_conns = None;
         self.pollee.notify(IoEvents::HUP);
-
-        drop(incoming_conns);
-
         self.wait_queue.wake_all();
     }
 


### PR DESCRIPTION
Part of #2176.

We should call `Pollee::invalidate` to invalidate old I/O events if the input or output buffer may become empty or full. It seems that we forgot to do so in a few places, so let's fix it.

Additionally, there are currently two `Pollee::invalidate` calls in `try_recv` at `kernel/src/net/socket/ip/stream/mod.rs`. The latter is redundant and should be removed.