### PR TITLE
Make zero reads/writes' behavior right

### DIFF
--- a/kernel/src/fs/utils/channel.rs
+++ b/kernel/src/fs/utils/channel.rs
@@ -95,6 +95,14 @@ macro_rules! impl_common_methods_for_channel {
             self.0.common.is_shutdown()
         }
 
+        pub fn is_full(&self) -> bool {
+            self.this_end().rb().is_full()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.this_end().rb().is_empty()
+        }
+
         pub fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
             self.this_end()
                 .pollee
@@ -134,11 +142,10 @@ impl Producer<u8> {
     /// - Returns `Ok(_)` with the number of bytes written if successful.
     /// - Returns `Err(EPIPE)` if the channel is shut down.
     /// - Returns `Err(EAGAIN)` if the channel is full.
+    ///
+    /// The caller should not pass an empty `reader` to this method.
     pub fn try_write(&self, reader: &mut dyn MultiRead) -> Result<usize> {
-        if reader.is_empty() {
-            // Even after shutdown, writing an empty buffer is still fine.
-            return Ok(0);
-        }
+        debug_assert!(!reader.is_empty());
 
         if self.is_shutdown() {
             return_errno_with_message!(Errno::EPIPE, "the channel is shut down");
@@ -215,10 +222,10 @@ impl Consumer<u8> {
     /// - Returns `Ok(_)` with the number of bytes read if successful.
     /// - Returns `Ok(0)` if the channel is shut down and there is no data left.
     /// - Returns `Err(EAGAIN)` if the channel is empty.
+    ///
+    /// The caller should not pass an empty `writer` to this method.
     pub fn try_read(&self, writer: &mut dyn MultiWrite) -> Result<usize> {
-        if writer.is_empty() {
-            return Ok(0);
-        }
+        debug_assert!(!writer.is_empty());
 
         // This must be recorded before the actual operation to avoid race conditions.
         let is_shutdown = self.is_shutdown();

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -125,6 +125,11 @@ pub trait Socket: private::SocketPrivate + Send + Sync {
 
 impl<T: Socket + 'static> FileLike for T {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+        if !writer.has_avail() {
+            // Linux always returns `Ok(0)` in this case, so we follow it.
+            return Ok(0);
+        }
+
         // TODO: Set correct flags
         self.recvmsg(writer, SendRecvFlags::empty())
             .map(|(len, _)| len)

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -142,6 +142,11 @@ where
             warn!("sending control message is not supported");
         }
 
+        if reader.is_empty() {
+            // Based on how Linux behaves, zero-sized messages are not allowed for netlink sockets.
+            return_errno_with_message!(Errno::ENODATA, "there are no data to send");
+        }
+
         // TODO: Make sure our blocking behavior matches that of Linux
         self.try_send(reader, remote.as_ref(), flags)
     }

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -72,10 +72,24 @@ impl Connected {
     }
 
     pub(super) fn try_read(&self, writer: &mut dyn MultiWrite) -> Result<usize> {
+        if writer.is_empty() {
+            if self.reader.is_empty() {
+                return_errno_with_message!(Errno::EAGAIN, "the channel is empty");
+            }
+            return Ok(0);
+        }
+
         self.reader.try_read(writer)
     }
 
     pub(super) fn try_write(&self, reader: &mut dyn MultiRead) -> Result<usize> {
+        if reader.is_empty() {
+            if self.writer.is_shutdown() {
+                return_errno_with_message!(Errno::EPIPE, "the channel is shut down");
+            }
+            return Ok(0);
+        }
+
         self.writer.try_write(reader)
     }
 

--- a/test/apps/network/rtnl_err.c
+++ b/test/apps/network/rtnl_err.c
@@ -83,9 +83,15 @@ FN_TEST(send)
 {
 	char buf[1] = { 'z' };
 
-	TEST_RES(send(sk_bound, buf, 1, 0), 1);
+	TEST_SUCC(send(sk_bound, buf, 1, 0));
+	TEST_ERRNO(send(sk_bound, buf, 0, 0), ENODATA);
+	TEST_SUCC(write(sk_bound, buf, 1));
+	TEST_ERRNO(write(sk_bound, buf, 0), ENODATA);
 
 	TEST_ERRNO(send(sk_connected, buf, 1, 0), ECONNREFUSED);
+	TEST_ERRNO(send(sk_connected, buf, 0, 0), ENODATA);
+	TEST_ERRNO(write(sk_connected, buf, 1), ECONNREFUSED);
+	TEST_ERRNO(write(sk_connected, buf, 0), ENODATA);
 }
 END_TEST()
 
@@ -94,10 +100,19 @@ FN_TEST(recv)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_unbound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_unbound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_unbound, buf, 0));
 
 	TEST_ERRNO(recv(sk_bound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_bound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_bound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_bound, buf, 0));
 
 	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_connected, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_connected, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_connected, buf, 0));
 }
 END_TEST()
 

--- a/test/apps/network/tcp_err.c
+++ b/test/apps/network/tcp_err.c
@@ -148,10 +148,19 @@ FN_TEST(send)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(send(sk_unbound, buf, 1, 0), EPIPE);
+	TEST_ERRNO(send(sk_unbound, buf, 0, 0), EPIPE);
+	TEST_ERRNO(write(sk_unbound, buf, 1), EPIPE);
+	TEST_ERRNO(write(sk_unbound, buf, 0), EPIPE);
 
 	TEST_ERRNO(send(sk_bound, buf, 1, 0), EPIPE);
+	TEST_ERRNO(send(sk_bound, buf, 0, 0), EPIPE);
+	TEST_ERRNO(write(sk_bound, buf, 1), EPIPE);
+	TEST_ERRNO(write(sk_bound, buf, 0), EPIPE);
 
 	TEST_ERRNO(send(sk_listen, buf, 1, 0), EPIPE);
+	TEST_ERRNO(send(sk_listen, buf, 0, 0), EPIPE);
+	TEST_ERRNO(write(sk_listen, buf, 1), EPIPE);
+	TEST_ERRNO(write(sk_listen, buf, 0), EPIPE);
 }
 END_TEST()
 
@@ -160,10 +169,24 @@ FN_TEST(recv)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), ENOTCONN);
+	TEST_ERRNO(recv(sk_unbound, buf, 0, 0), ENOTCONN);
+	TEST_ERRNO(read(sk_unbound, buf, 1), ENOTCONN);
+	TEST_SUCC(read(sk_unbound, buf, 0));
 
 	TEST_ERRNO(recv(sk_bound, buf, 1, 0), ENOTCONN);
+	TEST_ERRNO(recv(sk_bound, buf, 0, 0), ENOTCONN);
+	TEST_ERRNO(read(sk_bound, buf, 1), ENOTCONN);
+	TEST_SUCC(read(sk_bound, buf, 0));
 
 	TEST_ERRNO(recv(sk_listen, buf, 1, 0), ENOTCONN);
+	TEST_ERRNO(recv(sk_listen, buf, 0, 0), ENOTCONN);
+	TEST_ERRNO(read(sk_listen, buf, 1), ENOTCONN);
+	TEST_SUCC(read(sk_listen, buf, 0));
+
+	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_connected, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_connected, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_connected, buf, 0));
 }
 END_TEST()
 

--- a/test/apps/network/udp_err.c
+++ b/test/apps/network/udp_err.c
@@ -93,8 +93,14 @@ FN_TEST(send)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(send(sk_unbound, buf, 1, 0), EDESTADDRREQ);
+	TEST_ERRNO(send(sk_unbound, buf, 0, 0), EDESTADDRREQ);
+	TEST_ERRNO(write(sk_unbound, buf, 1), EDESTADDRREQ);
+	TEST_ERRNO(write(sk_unbound, buf, 0), EDESTADDRREQ);
 
 	TEST_ERRNO(send(sk_bound, buf, 1, 0), EDESTADDRREQ);
+	TEST_ERRNO(send(sk_bound, buf, 0, 0), EDESTADDRREQ);
+	TEST_ERRNO(write(sk_bound, buf, 1), EDESTADDRREQ);
+	TEST_ERRNO(write(sk_bound, buf, 0), EDESTADDRREQ);
 }
 END_TEST()
 
@@ -103,10 +109,19 @@ FN_TEST(recv)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_unbound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_unbound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_unbound, buf, 0));
 
 	TEST_ERRNO(recv(sk_bound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_bound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_bound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_bound, buf, 0));
 
 	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_connected, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_connected, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_connected, buf, 0));
 }
 END_TEST()
 

--- a/test/apps/network/uevent_err.c
+++ b/test/apps/network/uevent_err.c
@@ -84,9 +84,15 @@ FN_TEST(send)
 {
 	char buf[1] = { 'z' };
 
-	TEST_RES(send(sk_bound, buf, 1, 0), 1);
+	TEST_SUCC(send(sk_bound, buf, 1, 0));
+	TEST_ERRNO(send(sk_bound, buf, 0, 0), ENODATA);
+	TEST_SUCC(write(sk_bound, buf, 1));
+	TEST_ERRNO(write(sk_bound, buf, 0), ENODATA);
 
 	TEST_ERRNO(send(sk_connected, buf, 1, 0), ECONNREFUSED);
+	TEST_ERRNO(send(sk_connected, buf, 0, 0), ENODATA);
+	TEST_ERRNO(write(sk_connected, buf, 1), ECONNREFUSED);
+	TEST_ERRNO(write(sk_connected, buf, 0), ENODATA);
 }
 END_TEST()
 
@@ -95,10 +101,19 @@ FN_TEST(recv)
 	char buf[1] = { 'z' };
 
 	TEST_ERRNO(recv(sk_unbound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_unbound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_unbound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_unbound, buf, 0));
 
 	TEST_ERRNO(recv(sk_bound, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_bound, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_bound, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_bound, buf, 0));
 
 	TEST_ERRNO(recv(sk_connected, buf, 1, 0), EAGAIN);
+	TEST_ERRNO(recv(sk_connected, buf, 0, 0), EAGAIN);
+	TEST_ERRNO(read(sk_connected, buf, 1), EAGAIN);
+	TEST_SUCC(read(sk_connected, buf, 0));
 }
 END_TEST()
 

--- a/test/apps/pipe/pipe_err.c
+++ b/test/apps/pipe/pipe_err.c
@@ -176,3 +176,37 @@ FN_TEST(close_second_then_poll)
 	TEST_SUCC(close(fildes[0]));
 }
 END_TEST()
+
+// See also `zero_recvs_may_fail` in `unix_err.c`
+FN_TEST(zero_reads_always_succeed)
+{
+	int fildes[2];
+	char buf[1] = { 'z' };
+
+	CHECK(pipe(fildes));
+
+	TEST_SUCC(read(fildes[0], buf, 0));
+
+	TEST_RES(write(fildes[1], buf, 1), _ret == 1);
+	TEST_SUCC(read(fildes[0], buf, 0));
+
+	TEST_SUCC(close(fildes[0]));
+}
+END_TEST()
+
+// See also `zero_sends_may_fail` in `unix_err.c`
+FN_TEST(zero_writes_always_succeed)
+{
+	int fildes[2];
+	char buf[1] = { 'z' };
+
+	CHECK(pipe(fildes));
+
+	TEST_SUCC(write(fildes[1], buf, 0));
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(write(fildes[1], buf, 0));
+
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()


### PR DESCRIPTION
Part of #2176.

This PR adds lots of regression tests to ensure our zero-byte `read`/`write`/`send`/`recv` behavior is consistent with that of Linux:
 - Zero-byte `read`/`write` from/into **pipes** always succeeds.
 - Zero-byte `read` from **sockets** always succeeds, but zero-byte `write` into sockets may fail.
 - Zero-byte `send`/`recv` from/into **sockets** may fail.
   - Zero-byte `send`/`write` into **netlink sockets** always fails with a special error code `ENODATA`.