### PR TITLE
Fix unwrap panic for invalid char of stack trace

### DIFF
--- a/osdk/src/util.rs
+++ b/osdk/src/util.rs
@@ -257,7 +257,7 @@ fn parse_package_id_string(package_id: &str) -> ParsedID {
 pub fn trace_panic_from_log(qemu_log: File, bin_path: PathBuf) {
     // We read last 500 lines since more than 100 layers of stack trace is unlikely.
     let reader = rev_buf_reader::RevBufReader::new(qemu_log);
-    let lines: Vec<String> = reader.lines().take(500).map(|l| l.unwrap()).collect();
+    let lines: Vec<String> = reader.lines().take(500).filter_map(|l| l.ok()).collect();
     let mut trace_exists = false;
     let mut stack_num = 0;
     let pc_matcher = regex::Regex::new(r" - pc (0x[0-9a-fA-F]+)").unwrap();


### PR DESCRIPTION
The `trace_panic_from_log` will panic if the stack trace contains invalid characters.

## Reproduce
Print invlid char before panic:
```C
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <sys/mman.h>
#include <unistd.h>
#include <string.h>
#include <errno.h>


int main() {
    char invalid_bytes[] = "\xff\n";
    printf("%s", invalid_bytes);
    madvise(0xf000, 0x1000, MADV_RANDOM);
    perror("madvise");
    return 0;
}
```

## Crash log
```
hread 'main' panicked at src/util.rs:260:65:
called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: "stream did not contain valid UTF-8" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```