### PR TITLE
Fix mapping between `sched_attr` and `SchedPolicy`

### DIFF
--- a/test/apps/sched/sched_attr_idle.c
+++ b/test/apps/sched/sched_attr_idle.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define SCHED_IDLE 5
+
+void *test(void *__arg)
+{
+	struct sched_param param = { .sched_priority = 0 };
+	assert(sched_setscheduler(0, SCHED_IDLE, &param) == 0);
+	sleep(1);
+	return NULL;
+}
+
+int main()
+{
+	pthread_t thread;
+	assert(pthread_create(&thread, NULL, test, NULL) == 0);
+	test(NULL);
+
+	pthread_join(thread, NULL);
+	printf("Test completed\n");
+
+	return 0;
+}

--- a/test/apps/scripts/process.sh
+++ b/test/apps/scripts/process.sh
@@ -37,6 +37,7 @@ pthread/pthread_test
 pty/open_pty
 pty/pty_blocking
 sched/sched_attr
+sched/sched_attr_idle
 shm/posix_shm
 signal_c/parent_death_signal
 signal_c/signal_test


### PR DESCRIPTION
Fixes #2153.

Mapping between `sched_attr` and `SchedPolicy`:

- Before:
  - `SCHED_NORMAL` <-> `SchedPolicy::Fair`
  - `SCHED_IDLE` <-> `SchedPolicy::Idle`

- After:
  - `SCHED_NORMAL` -> `SchedPolicy::Fair`
  - `SCHED_IDLE` <-> `SchedPolicy::Fair(Nice::MAX)`
  - <n/a> <- `SchedPolicy::Idle`
