### PR TITLE
Improve user program relocation code

### DIFF
--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -118,8 +118,8 @@ fn create_init_task(
     };
 
     let mut user_ctx = UserContext::default();
-    user_ctx.set_instruction_pointer(elf_load_info.entry_point() as _);
-    user_ctx.set_stack_pointer(elf_load_info.user_stack_top() as _);
+    user_ctx.set_instruction_pointer(elf_load_info.entry_point as _);
+    user_ctx.set_stack_pointer(elf_load_info.user_stack_top as _);
     let thread_name = Some(ThreadName::new_from_executable_path(executable_path)?);
     let thread_builder = PosixThreadBuilder::new(tid, Arc::new(user_ctx), credentials)
         .thread_name(thread_name)

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -158,11 +158,11 @@ fn do_execve(
     // to the user-registered signal handlers.
     user_context.fpu_state().restore();
     // set new entry point
-    user_context.set_instruction_pointer(elf_load_info.entry_point() as _);
-    debug!("entry_point: 0x{:x}", elf_load_info.entry_point());
+    user_context.set_instruction_pointer(elf_load_info.entry_point as _);
+    debug!("entry_point: 0x{:x}", elf_load_info.entry_point);
     // set new user stack top
-    user_context.set_stack_pointer(elf_load_info.user_stack_top() as _);
-    debug!("user stack top: 0x{:x}", elf_load_info.user_stack_top());
+    user_context.set_stack_pointer(elf_load_info.user_stack_top as _);
+    debug!("user stack top: 0x{:x}", elf_load_info.user_stack_top);
     Ok(())
 }
 


### PR DESCRIPTION
This PR contains the first commit in #1999 . I haven't decided on the rest of the design (to refactor the user heap/stack handling) in that PR. But I think it should be less controversial to improve the user program relocation code first. There were some undocumented ad-hoc calculations that made the code not very readable. I hope this PR helps. 