### PR TITLE
Miscellaneous page table cleanups

### DIFF
--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -63,8 +63,10 @@ pub(super) fn unlock_range<C: PageTableConfig>(cursor: &mut Cursor<'_, C>) {
         }
     }
     let guard_node = cursor.path[cursor.guard_level as usize - 1].take().unwrap();
-    let cur_node_va = cursor.barrier_va.start / page_size::<C>(cursor.guard_level + 1)
-        * page_size::<C>(cursor.guard_level + 1);
+    let cur_node_va = cursor
+        .barrier_va
+        .start
+        .align_down(page_size::<C>(cursor.guard_level + 1));
 
     // SAFETY: A cursor maintains that its corresponding sub-tree is locked.
     unsafe {


### PR DESCRIPTION
Just minor and miscellaneous cleanups. Some were noticed while reviewing #2042. I didn't leave comments there because they are not related to the changes in #2042.

I squashed them into one commit because they're all minor issues, and most of the changes are non-functional, such as comment adjustments. Creating too many small commits is probably not worth it. Hope this won't make the review difficult, as the changes in this PR are still relatively minor.