### PR TITLE
Fix integer overflow in futex wake

### DIFF
--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -195,7 +195,13 @@ impl FutexWakeOpEncode {
 
     fn calculate_new_val(&self, old_val: u32) -> u32 {
         let oparg = if self.is_oparg_shift {
-            1 << self.oparg
+            if self.oparg > 31 {
+                // Linux might return EINVAL in the future
+                // Reference: https://elixir.bootlin.com/linux/v6.15.2/source/kernel/futex/waitwake.c#L211-L222
+                warn!("futex_wake_op: program tries to shift op by {}", self.oparg);
+            }
+
+            1 << (self.oparg & 31)
         } else {
             self.oparg
         };


### PR DESCRIPTION
Fix #2188 

Linux currently outputs a warning message and `&= 31` to make the shift value valid.
However, according to the comment, we should return `EINVAL`?

https://elixir.bootlin.com/linux/v6.15.2/source/kernel/futex/waitwake.c#L211-L222

```C
	if (encoded_op & (FUTEX_OP_OPARG_SHIFT << 28)) {
		if (oparg < 0 || oparg > 31) {
			/*
			 * kill this print and return -EINVAL when userspace
			 * is sane again
			 */
			pr_info_ratelimited("futex_wake_op: %s tries to shift op by %d; fix this program\n",
					    current->comm, oparg);
			oparg &= 31;
		}
		oparg = 1 << oparg;
	}
```