### PR TITLE
Support missing socket options for UNIX stream socket

### DIFF
--- a/kernel/libs/aster-rights/src/lib.rs
+++ b/kernel/libs/aster-rights/src/lib.rs
@@ -52,6 +52,7 @@ typeflags::typeflags! {
 pub type Full = TRightSet<TRights![Dup, Read, Write, Exec, Signal]>;
 pub type ReadOp = TRights![Read];
 pub type WriteOp = TRights![Write];
+pub type ReadDupOp = TRights![Read, Dup];
 pub type FullOp = TRights![Read, Write, Dup];
 
 /// Wrapper for TRights, used to bypass an error message from the Rust compiler,

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         private::SocketPrivate,
         util::{
             datagram_common::{select_remote_and_bind, Bound, Inner},
-            options::{SetSocketLevelOption, SocketOptionSet},
+            options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
             MessageHeader, SendRecvFlags, SocketAddr,
         },
         Socket,
@@ -223,7 +223,8 @@ impl Socket for DatagramSocket {
             _ => ()
         });
 
-        self.options.read().socket.get_option(option)
+        let inner = self.inner.read();
+        self.options.read().socket.get_option(option, &*inner)
     }
 
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
@@ -250,6 +251,12 @@ impl Socket for DatagramSocket {
                 Ok(())
             }
         }
+    }
+}
+
+impl GetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
+    fn is_listening(&self) -> bool {
+        false
     }
 }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -33,7 +33,7 @@ use crate::{
             options::{Error as SocketError, SocketOption},
             private::SocketPrivate,
             util::{
-                options::{SetSocketLevelOption, SocketOptionSet},
+                options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
                 MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr,
             },
             Socket,
@@ -588,10 +588,11 @@ impl Socket for StreamSocket {
             _ => ()
         });
 
+        let state = self.read_updated_state();
         let options = self.options.read();
 
         // Deal with socket-level options
-        match options.socket.get_option(option) {
+        match options.socket.get_option(option, state.as_ref()) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -665,10 +666,10 @@ impl Socket for StreamSocket {
         let mut options = self.options.write();
 
         // Deal with socket-level options
-        let need_iface_poll = match options.socket.set_option(option, state.as_mut()) {
+        let need_iface_poll = match options.socket.set_option(option, state.as_ref()) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // Deal with IP-level options
-                match options.ip.set_option(option, state.as_mut()) {
+                match options.ip.set_option(option, state.as_ref()) {
                     Err(err) if err.error() == Errno::ENOPROTOOPT => {
                         // Deal with TCP-level options
                         do_tcp_setsockopt(option, &mut options, state.as_mut())?
@@ -797,6 +798,12 @@ impl State {
             State::Connected(ref connected_stream) => Some(connected_stream.iface()),
             State::Listen(ref listen_stream) => Some(listen_stream.iface()),
         }
+    }
+}
+
+impl GetSocketLevelOption for State {
+    fn is_listening(&self) -> bool {
+        matches!(self, Self::Listen(_))
     }
 }
 

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -20,4 +20,6 @@ impl_socket_options!(
     pub struct Error(Option<crate::error::Error>);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
+    pub struct SendBufForce(u32);
+    pub struct RecvBufForce(u32);
 );

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -18,6 +18,7 @@ impl_socket_options!(
     pub struct SendBuf(u32);
     pub struct RecvBuf(u32);
     pub struct Error(Option<crate::error::Error>);
+    pub struct Priority(i32);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
     pub struct SendBufForce(u32);

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -21,6 +21,7 @@ impl_socket_options!(
     pub struct Priority(i32);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
+    pub struct AcceptConn(bool);
     pub struct SendBufForce(u32);
     pub struct RecvBufForce(u32);
 );

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::util::LingerOption;
-use crate::{impl_socket_options, prelude::*};
+use crate::{impl_socket_options, net::socket::unix::CUserCred, prelude::*, process::Gid};
 
 mod macros;
 
@@ -21,7 +21,9 @@ impl_socket_options!(
     pub struct Priority(i32);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
+    pub struct PeerCred(CUserCred);
     pub struct AcceptConn(bool);
     pub struct SendBufForce(u32);
     pub struct RecvBufForce(u32);
+    pub struct PeerGroups(Arc<[Gid]>);
 );

--- a/kernel/src/net/socket/unix/cred.rs
+++ b/kernel/src/net/socket/unix/cred.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_rights::{Dup, Read, ReadDupOp, ReadOp, TRights};
+use aster_rights_proc::require;
+
+use crate::{
+    prelude::*,
+    process::{posix_thread::AsPosixThread, Credentials, Gid, Pid, Uid},
+};
+
+pub(super) struct SocketCred<R = ReadOp> {
+    pid: Pid,
+    cred: Credentials<R>,
+}
+
+impl SocketCred<ReadOp> {
+    pub(super) fn new_current() -> Self {
+        let pid = current!().pid();
+        let cred = current_thread!().as_posix_thread().unwrap().credentials();
+
+        Self { pid, cred }
+    }
+}
+
+impl SocketCred<ReadDupOp> {
+    pub(super) fn new_current() -> Self {
+        let pid = current!().pid();
+        let cred = current_thread!()
+            .as_posix_thread()
+            .unwrap()
+            .credentials_dup();
+
+        Self { pid, cred }
+    }
+}
+
+impl<R: TRights> SocketCred<R> {
+    #[require(R > Read)]
+    pub(super) fn to_c_user_cred(&self) -> CUserCred {
+        CUserCred {
+            pid: self.pid,
+            uid: self.cred.euid(),
+            gid: self.cred.egid(),
+        }
+    }
+
+    #[require(R > Read)]
+    pub(super) fn groups(&self) -> Arc<[Gid]> {
+        self.cred.groups().iter().cloned().collect()
+    }
+
+    #[require(R > R1)]
+    pub(super) fn restrict<R1: TRights>(self) -> SocketCred<R1> {
+        let Self { pid, cred } = self;
+        SocketCred {
+            pid,
+            cred: cred.restrict(),
+        }
+    }
+
+    #[require(R > Dup)]
+    pub(super) fn dup(&self) -> Self {
+        Self {
+            pid: self.pid,
+            cred: self.cred.dup(),
+        }
+    }
+}
+
+/// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/socket.h#L183>.
+#[derive(Debug, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct CUserCred {
+    pid: Pid,
+    uid: Uid,
+    gid: Gid,
+}
+
+impl CUserCred {
+    pub(in crate::net) const fn new_unknown() -> Self {
+        Self {
+            pid: 0,
+            uid: Uid::INVALID,
+            gid: Gid::INVALID,
+        }
+    }
+}

--- a/kernel/src/net/socket/unix/mod.rs
+++ b/kernel/src/net/socket/unix/mod.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod addr;
+mod cred;
 mod ns;
 mod stream;
 
 pub use addr::UnixSocketAddr;
+pub use cred::CUserCred;
 pub use stream::UnixStreamSocket;
 pub(super) use stream::UNIX_STREAM_DEFAULT_BUF_SIZE;

--- a/kernel/src/net/socket/unix/mod.rs
+++ b/kernel/src/net/socket/unix/mod.rs
@@ -6,3 +6,4 @@ mod stream;
 
 pub use addr::UnixSocketAddr;
 pub use stream::UnixStreamSocket;
+pub(super) use stream::UNIX_STREAM_DEFAULT_BUF_SIZE;

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -28,8 +28,8 @@ impl Connected {
         state: EndpointState,
         peer_state: EndpointState,
     ) -> (Connected, Connected) {
-        let (this_writer, peer_reader) = RingBuffer::new(DEFAULT_BUF_SIZE).split();
-        let (peer_writer, this_reader) = RingBuffer::new(DEFAULT_BUF_SIZE).split();
+        let (this_writer, peer_reader) = RingBuffer::new(UNIX_STREAM_DEFAULT_BUF_SIZE).split();
+        let (peer_writer, this_reader) = RingBuffer::new(UNIX_STREAM_DEFAULT_BUF_SIZE).split();
 
         let this_inner = Inner {
             addr: SpinLock::new(addr),
@@ -164,4 +164,4 @@ impl AsRef<EndpointState> for Inner {
     }
 }
 
-const DEFAULT_BUF_SIZE: usize = 65536;
+pub(in crate::net) const UNIX_STREAM_DEFAULT_BUF_SIZE: usize = 65536;

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -14,7 +14,10 @@ use crate::{
     events::IoEvents,
     fs::file_handle::FileLike,
     net::socket::{
-        unix::addr::{UnixSocketAddrBound, UnixSocketAddrKey},
+        unix::{
+            addr::{UnixSocketAddrBound, UnixSocketAddrKey},
+            stream::socket::OptionSet,
+        },
         util::{SockShutdownCmd, SocketAddr},
     },
     prelude::*,
@@ -52,7 +55,9 @@ impl Listener {
         let connected = self.backlog.pop_incoming()?;
         let peer_addr = connected.peer_addr().into();
 
-        let socket = UnixStreamSocket::new_connected(connected, false);
+        // TODO: Update options for a newly-accepted socket
+        let options = OptionSet::new();
+        let socket = UnixStreamSocket::new_connected(connected, options, false);
         Ok((socket, peer_addr))
     }
 

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -5,4 +5,5 @@ mod init;
 mod listener;
 mod socket;
 
+pub(in crate::net) use connected::UNIX_STREAM_DEFAULT_BUF_SIZE;
 pub use socket::UnixStreamSocket;

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -17,7 +17,7 @@ use crate::{
         private::SocketPrivate,
         unix::UnixSocketAddr,
         util::{
-            options::{SetSocketLevelOption, SocketOptionSet},
+            options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
             MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr,
         },
         Socket,
@@ -375,10 +375,11 @@ impl Socket for UnixStreamSocket {
     }
 
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+        let state = self.state.read();
         let options = self.options.read();
 
         // Deal with socket-level options
-        match options.socket.get_option(option) {
+        match options.socket.get_option(option, state.as_ref()) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -405,6 +406,12 @@ impl Socket for UnixStreamSocket {
             }
             Err(e) => Err(e),
         }
+    }
+}
+
+impl GetSocketLevelOption for State {
+    fn is_listening(&self) -> bool {
+        matches!(self, Self::Listen(_))
     }
 }
 

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -11,8 +11,8 @@ use crate::{
     match_sock_option_mut, match_sock_option_ref,
     net::socket::{
         options::{
-            KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf,
-            SendBufForce, SocketOption,
+            AcceptConn, KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr, ReusePort,
+            SendBuf, SendBufForce, SocketOption,
         },
         unix::UNIX_STREAM_DEFAULT_BUF_SIZE,
     },
@@ -80,7 +80,11 @@ impl SocketOptionSet {
     /// Note that the socket error has to be handled separately, because it is automatically
     /// cleared after reading. This method does not handle it. Instead,
     /// [`Self::get_and_clear_socket_errors`] should be used.
-    pub fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+    pub fn get_option(
+        &self,
+        option: &mut dyn SocketOption,
+        socket: &dyn GetSocketLevelOption,
+    ) -> Result<()> {
         match_sock_option_mut!(option, {
             socket_reuse_addr: ReuseAddr => {
                 let reuse_addr = self.reuse_addr();
@@ -109,6 +113,10 @@ impl SocketOptionSet {
             socket_keepalive: KeepAlive => {
                 let keep_alive = self.keep_alive();
                 socket_keepalive.set(keep_alive);
+            },
+            socket_accept_conn: AcceptConn => {
+                let is_listening = socket.is_listening();
+                socket_accept_conn.set(is_listening);
             },
             socket_sendbuf_force: SendBufForce => {
                 check_current_privileged()?;
@@ -221,6 +229,12 @@ fn check_priority(priority: i32) -> Result<()> {
 
 pub const MIN_SENDBUF: u32 = 2304;
 pub const MIN_RECVBUF: u32 = 2304;
+
+/// A trait used for getting socket level options on actual sockets.
+pub(in crate::net) trait GetSocketLevelOption {
+    /// Returns whether the socket is in listening state.
+    fn is_listening(&self) -> bool;
+}
 
 /// A trait used for setting socket level options on actual sockets.
 pub(in crate::net) trait SetSocketLevelOption {

--- a/kernel/src/process/credentials/group.rs
+++ b/kernel/src/process/credentials/group.rs
@@ -11,6 +11,11 @@ use crate::prelude::*;
 pub struct Gid(u32);
 
 impl Gid {
+    /// The invalid GID, typically used to indicate that no valid GID is found when returning to user space.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L51>.
+    pub const INVALID: Gid = Gid(u32::MAX);
+
     pub const fn new(gid: u32) -> Self {
         Self(gid)
     }

--- a/kernel/src/process/credentials/user.rs
+++ b/kernel/src/process/credentials/user.rs
@@ -13,6 +13,11 @@ pub struct Uid(u32);
 const ROOT_UID: u32 = 0;
 
 impl Uid {
+    /// The invalid UID, typically used to indicate that no valid UID is found when returning to user space.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L50>.
+    pub const INVALID: Uid = Self::new(u32::MAX);
+
     pub const fn new_root() -> Self {
         Self(ROOT_UID)
     }

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -2,7 +2,7 @@
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use aster_rights::{ReadOp, WriteOp};
+use aster_rights::{ReadDupOp, ReadOp, WriteOp};
 use ostd::sync::{RoArc, Waker};
 
 use super::{
@@ -288,6 +288,11 @@ impl PosixThread {
 
     /// Gets the read-only credentials of the thread.
     pub fn credentials(&self) -> Credentials<ReadOp> {
+        self.credentials.dup().restrict()
+    }
+
+    /// Gets the duplicatable read-only credentials of the thread.
+    pub fn credentials_dup(&self) -> Credentials<ReadDupOp> {
         self.credentials.dup().restrict()
     }
 

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -67,7 +67,7 @@ use self::{socket::new_socket_option, tcp::new_tcp_option};
 pub trait RawSocketOption: SocketOption {
     fn read_from_user(&mut self, addr: Vaddr, max_len: u32) -> Result<()>;
 
-    fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize>;
+    fn write_to_user(&self, addr: Vaddr, max_len: &mut u32) -> Result<usize>;
 
     fn as_sock_option_mut(&mut self) -> &mut dyn SocketOption;
 
@@ -87,11 +87,11 @@ macro_rules! impl_raw_socket_option {
                 Ok(())
             }
 
-            fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
+            fn write_to_user(&self, addr: Vaddr, max_len: &mut u32) -> Result<usize> {
                 use $crate::util::net::options::utils::WriteToUser;
 
                 let output = self.get().unwrap();
-                output.write_to_user(addr, max_len)
+                output.write_to_user(addr, *max_len)
             }
 
             fn as_sock_option_mut(&mut self) -> &mut dyn SocketOption {
@@ -114,11 +114,11 @@ macro_rules! impl_raw_sock_option_get_only {
                 return_errno_with_message!(Errno::ENOPROTOOPT, "the option is getter-only");
             }
 
-            fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
+            fn write_to_user(&self, addr: Vaddr, max_len: &mut u32) -> Result<usize> {
                 use $crate::util::net::options::utils::WriteToUser;
 
                 let output = self.get().unwrap();
-                output.write_to_user(addr, max_len)
+                output.write_to_user(addr, *max_len)
             }
 
             fn as_sock_option_mut(&mut self) -> &mut dyn SocketOption {
@@ -145,7 +145,7 @@ macro_rules! impl_raw_sock_option_set_only {
                 Ok(())
             }
 
-            fn write_to_user(&self, _addr: Vaddr, _max_len: u32) -> Result<usize> {
+            fn write_to_user(&self, _addr: Vaddr, _max_len: &mut u32) -> Result<usize> {
                 return_errno_with_message!(Errno::ENOPROTOOPT, "the option is setter-only");
             }
 

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -4,7 +4,8 @@ use super::RawSocketOption;
 use crate::{
     impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        Error, KeepAlive, Linger, RecvBuf, ReuseAddr, ReusePort, SendBuf, SocketOption,
+        Error, KeepAlive, Linger, RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf,
+        SendBufForce, SocketOption,
     },
     prelude::*,
 };
@@ -25,8 +26,6 @@ enum CSocketOptionName {
     BROADCAST = 6,
     SNDBUF = 7,
     RCVBUF = 8,
-    SNDBUFFORCE = 32,
-    RCVBUFFORCE = 33,
     KEEPALIVE = 9,
     OOBINLINE = 10,
     NO_CHECK = 11,
@@ -34,6 +33,8 @@ enum CSocketOptionName {
     LINGER = 13,
     BSDCOMPAT = 14,
     REUSEPORT = 15,
+    SNDBUFFORCE = 32,
+    RCVBUFFORCE = 33,
     RCVTIMEO_NEW = 66,
     SNDTIMEO_NEW = 67,
 }
@@ -48,6 +49,8 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
+        CSocketOptionName::SNDBUFFORCE => Ok(Box::new(SendBufForce::new())),
+        CSocketOptionName::RCVBUFFORCE => Ok(Box::new(RecvBufForce::new())),
         _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported socket-level option"),
     }
 }
@@ -59,3 +62,5 @@ impl_raw_sock_option_get_only!(Error);
 impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
+impl_raw_socket_option!(SendBufForce);
+impl_raw_socket_option!(RecvBufForce);

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -2,12 +2,13 @@
 
 use super::RawSocketOption;
 use crate::{
-    impl_raw_sock_option_get_only, impl_raw_socket_option,
+    current_userspace, impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        AcceptConn, Error, KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr,
-        ReusePort, SendBuf, SendBufForce, SocketOption,
+        AcceptConn, Error, KeepAlive, Linger, PeerCred, PeerGroups, Priority, RecvBuf,
+        RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,
     },
     prelude::*,
+    process::Gid,
 };
 
 /// Socket level options.
@@ -33,9 +34,15 @@ enum CSocketOptionName {
     LINGER = 13,
     BSDCOMPAT = 14,
     REUSEPORT = 15,
+    PASSCRED = 16,
+    PEERCRED = 17,
+    ATTACH_FILTER = 26,
+    DETACH_FILTER = 27,
     ACCPETCONN = 30,
+    PEERSEC = 31,
     SNDBUFFORCE = 32,
     RCVBUFFORCE = 33,
+    PEERGROUPS = 59,
     RCVTIMEO_NEW = 66,
     SNDTIMEO_NEW = 67,
 }
@@ -51,9 +58,11 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::PRIORITY => Ok(Box::new(Priority::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
+        CSocketOptionName::PEERCRED => Ok(Box::new(PeerCred::new())),
         CSocketOptionName::ACCPETCONN => Ok(Box::new(AcceptConn::new())),
         CSocketOptionName::SNDBUFFORCE => Ok(Box::new(SendBufForce::new())),
         CSocketOptionName::RCVBUFFORCE => Ok(Box::new(RecvBufForce::new())),
+        CSocketOptionName::PEERGROUPS => Ok(Box::new(PeerGroups::new())),
         _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported socket-level option"),
     }
 }
@@ -66,6 +75,40 @@ impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(Priority);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
+impl_raw_sock_option_get_only!(PeerCred);
 impl_raw_sock_option_get_only!(AcceptConn);
 impl_raw_socket_option!(SendBufForce);
 impl_raw_socket_option!(RecvBufForce);
+
+// SO_PEERGROUPS is a read-only option. However, calling setsockopt on SO_PEERGROUPS will return EINVAL
+// instead of ENOPROTOOPT like other options. Therefore, we manually implement `RawSocketOption` for it.
+impl RawSocketOption for PeerGroups {
+    fn read_from_user(&mut self, _addr: Vaddr, _max_len: u32) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "the option is getter-only");
+    }
+
+    fn write_to_user(&self, addr: Vaddr, buffer_len: &mut u32) -> Result<usize> {
+        let groups = self.get().unwrap();
+
+        let old_len = *buffer_len;
+        *buffer_len = (groups.len() * core::mem::size_of::<Gid>()) as u32;
+        if old_len < *buffer_len {
+            return_errno_with_message!(Errno::ERANGE, "the buffer is too small");
+        }
+
+        for (i, gid) in groups.iter().enumerate() {
+            let dst = addr + i * core::mem::size_of::<Gid>();
+            current_userspace!().write_val(dst, gid)?;
+        }
+
+        Ok(*buffer_len as usize)
+    }
+
+    fn as_sock_option_mut(&mut self) -> &mut dyn SocketOption {
+        self
+    }
+
+    fn as_sock_option(&self) -> &dyn SocketOption {
+        self
+    }
+}

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -4,8 +4,8 @@ use super::RawSocketOption;
 use crate::{
     impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        Error, KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf,
-        SendBufForce, SocketOption,
+        AcceptConn, Error, KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr,
+        ReusePort, SendBuf, SendBufForce, SocketOption,
     },
     prelude::*,
 };
@@ -33,6 +33,7 @@ enum CSocketOptionName {
     LINGER = 13,
     BSDCOMPAT = 14,
     REUSEPORT = 15,
+    ACCPETCONN = 30,
     SNDBUFFORCE = 32,
     RCVBUFFORCE = 33,
     RCVTIMEO_NEW = 66,
@@ -50,6 +51,7 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::PRIORITY => Ok(Box::new(Priority::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
+        CSocketOptionName::ACCPETCONN => Ok(Box::new(AcceptConn::new())),
         CSocketOptionName::SNDBUFFORCE => Ok(Box::new(SendBufForce::new())),
         CSocketOptionName::RCVBUFFORCE => Ok(Box::new(RecvBufForce::new())),
         _ => return_errno_with_message!(Errno::ENOPROTOOPT, "unsupported socket-level option"),
@@ -64,5 +66,6 @@ impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(Priority);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
+impl_raw_sock_option_get_only!(AcceptConn);
 impl_raw_socket_option!(SendBufForce);
 impl_raw_socket_option!(RecvBufForce);

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -4,7 +4,7 @@ use super::RawSocketOption;
 use crate::{
     impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        Error, KeepAlive, Linger, RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf,
+        Error, KeepAlive, Linger, Priority, RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf,
         SendBufForce, SocketOption,
     },
     prelude::*,
@@ -47,6 +47,7 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::REUSEADDR => Ok(Box::new(ReuseAddr::new())),
         CSocketOptionName::ERROR => Ok(Box::new(Error::new())),
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
+        CSocketOptionName::PRIORITY => Ok(Box::new(Priority::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
         CSocketOptionName::SNDBUFFORCE => Ok(Box::new(SendBufForce::new())),
@@ -60,6 +61,7 @@ impl_raw_socket_option!(RecvBuf);
 impl_raw_socket_option!(ReuseAddr);
 impl_raw_sock_option_get_only!(Error);
 impl_raw_socket_option!(ReusePort);
+impl_raw_socket_option!(Priority);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
 impl_raw_socket_option!(SendBufForce);

--- a/test/apps/network/sockoption_unix.c
+++ b/test/apps/network/sockoption_unix.c
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+ * UNIX stream socket-related socket options.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <stdbool.h>
+#include <sys/wait.h>
+#include "../test.h"
+
+static int sk_unbound;
+static int sk_listen;
+static int sk_connected;
+static int sk_accepted;
+static int sk_tcp;
+static struct sockaddr_un addr = { .sun_family = AF_UNIX,
+				   .sun_path = "/tmp/sock_option_test" };
+
+FN_SETUP(create_sockets)
+{
+	sk_unbound = CHECK(socket(PF_UNIX, SOCK_STREAM, 0));
+
+	sk_listen = CHECK(socket(PF_UNIX, SOCK_STREAM, 0));
+	CHECK(bind(sk_listen, (struct sockaddr *)&addr, sizeof(addr)));
+	CHECK(listen(sk_listen, 3));
+
+	sk_connected = CHECK(socket(PF_UNIX, SOCK_STREAM, 0));
+	CHECK(connect(sk_connected, (struct sockaddr *)&addr, sizeof(addr)));
+
+	sk_accepted = CHECK(accept(sk_listen, NULL, NULL));
+
+	sk_tcp = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+}
+END_SETUP()
+
+FN_TEST(priority)
+{
+	int val = 0;
+	socklen_t len = sizeof(val);
+
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_PRIORITY, &val, &len),
+		 val == 0);
+
+	val = -1;
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_PRIORITY, &val, len));
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_PRIORITY, &val, &len),
+		 val == -1);
+
+	val = 100;
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_PRIORITY, &val, len));
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_PRIORITY, &val, &len),
+		 val == 100);
+}
+END_TEST()
+
+FN_TEST(acceptconn)
+{
+	int val = 0;
+	socklen_t len = sizeof(val);
+
+	TEST_ERRNO(setsockopt(sk_unbound, SOL_SOCKET, SO_ACCEPTCONN, &val, len),
+		   ENOPROTOOPT);
+
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_ACCEPTCONN, &val, &len),
+		 val == 0 && len == 4);
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_ACCEPTCONN, &val, &len),
+		 val == 1 && len == 4);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_ACCEPTCONN, &val, &len),
+		 val == 0 && len == 4);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_ACCEPTCONN, &val,
+			    &len),
+		 val == 0 && len == 4);
+	TEST_RES(getsockopt(sk_tcp, SOL_SOCKET, SO_ACCEPTCONN, &val, &len),
+		 val == 0 && len == 4);
+}
+END_TEST()
+
+FN_TEST(peer_cred)
+{
+	struct cred {
+		pid_t pid;
+		uid_t uid;
+		gid_t gid;
+	};
+
+	struct cred ucred = {};
+	socklen_t len = sizeof(ucred);
+
+	TEST_ERRNO(setsockopt(sk_unbound, SOL_SOCKET, SO_PEERCRED, &ucred, len),
+		   ENOPROTOOPT);
+	TEST_RES(getsockopt(sk_tcp, SOL_SOCKET, SO_PEERCRED, &ucred, &len),
+		 ucred.pid == 0 && ucred.uid == -1 && ucred.gid == -1);
+
+	TEST_ERRNO(setsockopt(sk_unbound, SOL_SOCKET, SO_PEERCRED, &ucred, len),
+		   ENOPROTOOPT);
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_PEERCRED, &ucred, &len),
+		 ucred.pid == 0 && ucred.uid == -1 && ucred.gid == -1);
+
+	pid_t pid = getpid();
+	uid_t uid = geteuid();
+	gid_t gid = getegid();
+
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_PEERCRED, &ucred, &len),
+		 ucred.pid == pid && ucred.uid == uid && ucred.gid == gid);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_PEERCRED, &ucred, &len),
+		 ucred.pid == pid && ucred.uid == uid && ucred.gid == gid);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_PEERCRED, &ucred,
+			    &len),
+		 ucred.pid == pid && ucred.uid == uid && ucred.gid == gid);
+
+	// Test listen socket
+	int child_pid = TEST_SUCC(fork());
+	if (child_pid == 0) {
+		// Child process
+		int sk_connect_new = CHECK(socket(AF_UNIX, SOCK_STREAM, 0));
+		CHECK(connect(sk_connect_new, (struct sockaddr *)&addr,
+			      sizeof(addr)));
+		CHECK_WITH(getsockopt(sk_connect_new, SOL_SOCKET, SO_PEERCRED,
+				      &ucred, &len),
+			   ucred.pid == pid && ucred.uid == uid &&
+				   ucred.gid == gid);
+		CHECK(close(sk_connect_new));
+		exit(0);
+	}
+
+	int sk_accepted_new = TEST_SUCC(accept(sk_listen, NULL, NULL));
+	TEST_RES(getsockopt(sk_accepted_new, SOL_SOCKET, SO_PEERCRED, &ucred,
+			    &len),
+		 ucred.pid == child_pid && ucred.uid == uid &&
+			 ucred.gid == gid);
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_PEERCRED, &ucred, &len),
+		 ucred.pid == pid && ucred.uid == uid && ucred.gid == gid);
+
+	int status = 0;
+	TEST_RES(wait4(child_pid, &status, 0, NULL),
+		 _ret == child_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+	TEST_SUCC(close(sk_accepted_new));
+}
+END_TEST()
+
+bool is_groups_equal(gid_t *g1, gid_t *g2, int groups)
+{
+	for (int i = 0; i < groups; i++) {
+		if (g1[i] != g2[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+FN_TEST(peer_groups)
+{
+	int groups = TEST_SUCC(getgroups(0, NULL));
+	gid_t *buffer = (gid_t *)malloc(groups * sizeof(gid_t));
+	TEST_SUCC(getgroups(groups, buffer));
+
+	TEST_ERRNO(setsockopt(sk_unbound, SOL_SOCKET, SO_PEERGROUPS, buffer,
+			      groups),
+		   EINVAL);
+
+	gid_t small_buffer[1];
+	socklen_t buffer_len = 1;
+
+	TEST_ERRNO(getsockopt(sk_tcp, SOL_SOCKET, SO_PEERGROUPS, small_buffer,
+			      &buffer_len),
+		   ENODATA);
+	TEST_ERRNO(getsockopt(sk_unbound, SOL_SOCKET, SO_PEERGROUPS,
+			      small_buffer, &buffer_len),
+		   ENODATA);
+	buffer_len = 1;
+	TEST_ERRNO(getsockopt(sk_listen, SOL_SOCKET, SO_PEERGROUPS,
+			      small_buffer, &buffer_len),
+		   ERANGE);
+	buffer_len = 1;
+	TEST_ERRNO(getsockopt(sk_accepted, SOL_SOCKET, SO_PEERGROUPS,
+			      small_buffer, &buffer_len),
+		   ERANGE);
+
+	gid_t big_buffer[100];
+
+	buffer_len = sizeof(big_buffer);
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_PEERGROUPS, big_buffer,
+			    &buffer_len),
+		 buffer_len == groups * sizeof(gid_t) &&
+			 is_groups_equal(big_buffer, buffer, groups));
+
+	buffer_len = sizeof(big_buffer);
+	TEST_ERRNO(getsockopt(sk_connected, SOL_SOCKET, SO_PEERGROUPS, NULL,
+			      &buffer_len),
+		   EFAULT);
+
+	buffer_len = sizeof(big_buffer);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_PEERGROUPS, big_buffer,
+			    &buffer_len),
+		 buffer_len == groups * sizeof(gid_t) &&
+			 is_groups_equal(big_buffer, buffer, groups));
+
+	int fildes[2];
+
+	buffer_len = sizeof(big_buffer);
+	TEST_SUCC(socketpair(PF_UNIX, SOCK_STREAM, 0, fildes));
+	TEST_RES(getsockopt(fildes[0], SOL_SOCKET, SO_PEERGROUPS, big_buffer,
+			    &buffer_len),
+		 buffer_len == groups * sizeof(gid_t) &&
+			 is_groups_equal(big_buffer, buffer, groups));
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+	free(buffer);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(sk_unbound));
+	CHECK(close(sk_listen));
+	CHECK(close(sk_accepted));
+	CHECK(close(sk_connected));
+	CHECK(close(sk_tcp));
+	CHECK(unlink(addr.sun_path));
+}
+END_SETUP()

--- a/test/apps/scripts/network.sh
+++ b/test/apps/scripts/network.sh
@@ -27,6 +27,7 @@ sleep 0.2
 
 ./socketpair
 ./sockoption
+./sockoption_unix
 ./listen_backlog
 ./send_buf_full
 ./tcp_err


### PR DESCRIPTION
This PR is part of the work in PR #2158.

It adds basic support for socket options for UNIX stream sockets and introduces 6 new socket options.

However, this PR does not include the dummy implementations of IP_RECVERR and SO_ATTACH_FILTER mentioned in #2158. We may need to further investigate whether these dummy implementations could negatively impact user applications.