### PR TITLE
Automatically merge adjacent and compatible `VmMapping`s

### DIFF
--- a/kernel/src/vm/vmar/interval_set.rs
+++ b/kernel/src/vm/vmar/interval_set.rs
@@ -96,6 +96,26 @@ where
         }
     }
 
+    /// Finds the last interval item before the given point.
+    ///
+    /// If no such item exists, returns [`None`].
+    pub fn find_prev(&self, point: &K) -> Option<&V> {
+        self.btree
+            .upper_bound(core::ops::Bound::Excluded(point))
+            .peek_prev()
+            .map(|(_, v)| v)
+    }
+
+    /// Finds the first interval item after the given point.
+    ///
+    /// If no such item exists, returns [`None`].
+    pub fn find_next(&self, point: &K) -> Option<&V> {
+        self.btree
+            .lower_bound(core::ops::Bound::Excluded(point))
+            .peek_next()
+            .map(|(_, v)| v)
+    }
+
     /// Takes an interval item that contains the given point.
     ///
     /// If no such item exists, returns [`None`]. Otherwise, returns the item

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -208,6 +208,32 @@ impl VmarInner {
         self.vm_mappings.insert(vm_mapping);
     }
 
+    /// Inserts a modified `VmMapping` into the `Vmar`.
+    ///
+    /// This method will try to merge the `VmMapping` with surrounding mappings
+    /// that are adjacent and compatible, in order to reduce fragmentation.
+    ///
+    /// Make sure the insertion doesn't exceed address space limit.
+    fn insert_modified(&mut self, vm_mapping: VmMapping) {
+        self.total_vm += vm_mapping.map_size();
+        let mut vm_mapping = vm_mapping;
+        let addr = vm_mapping.map_to_addr();
+
+        if let Some(prev) = self.vm_mappings.find_prev(&addr) {
+            let (new_mapping, to_remove) = vm_mapping.try_merge_with(prev);
+            vm_mapping = new_mapping;
+            to_remove.map(|addr| self.vm_mappings.remove(&addr));
+        }
+
+        if let Some(next) = self.vm_mappings.find_next(&addr) {
+            let (new_mapping, to_remove) = vm_mapping.try_merge_with(next);
+            vm_mapping = new_mapping;
+            to_remove.map(|addr| self.vm_mappings.remove(&addr));
+        }
+
+        self.vm_mappings.insert(vm_mapping);
+    }
+
     /// Removes a `VmMapping` based on the provided key from the `Vmar`.
     fn remove(&mut self, key: &Vaddr) -> Option<VmMapping> {
         let vm_mapping = self.vm_mappings.remove(key)?;
@@ -378,7 +404,7 @@ impl VmarInner {
         self.check_extra_size_fits_rlimit(new_map_end - old_map_end)?;
         let last_mapping = self.remove(&last_mapping_addr).unwrap();
         let last_mapping = last_mapping.enlarge(new_map_end - old_map_end);
-        self.insert(last_mapping);
+        self.insert_modified(last_mapping);
         Ok(())
     }
 }
@@ -459,19 +485,19 @@ impl Vmar_ {
             let vm_mapping_range = vm_mapping.range();
             let intersected_range = get_intersected_range(&range, &vm_mapping_range);
 
-            // Protects part of the taken `VmMapping`.
             let (left, taken, right) = vm_mapping.split_range(&intersected_range)?;
 
-            let taken = taken.protect(vm_space.as_ref(), perms);
-            inner.insert(taken);
-
-            // And put the rest back.
+            // Puts the rest back.
             if let Some(left) = left {
                 inner.insert(left);
             }
             if let Some(right) = right {
                 inner.insert(right);
             }
+
+            // Protects part of the `VmMapping`.
+            let taken = taken.protect(vm_space.as_ref(), perms);
+            inner.insert_modified(taken);
         }
 
         Ok(())
@@ -605,7 +631,7 @@ impl Vmar_ {
         };
         // Now we can ensure that `new_size >= old_size`.
         let new_mapping = old_mapping.clone_for_remap_at(new_range.start)?;
-        inner.insert(new_mapping.enlarge(new_size - old_size));
+        inner.insert_modified(new_mapping.enlarge(new_size - old_size));
 
         // Move the mapping.
         let preempt_guard = disable_preempt();
@@ -1009,7 +1035,7 @@ where
         );
 
         // Add the mapping to the VMAR.
-        inner.insert(vm_mapping);
+        inner.insert_modified(vm_mapping);
 
         Ok(map_to_addr)
     }

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -22,6 +22,7 @@ use crate::{
     vm::{
         perms::VmPerms,
         util::duplicate_frame,
+        vmar::is_intersected,
         vmo::{CommitFlags, Vmo, VmoCommitError},
     },
 };
@@ -466,6 +467,28 @@ impl VmMapping {
         }
         panic!("The mapping does not contain the splitting range.");
     }
+
+    /// Attempts to merge `self` with the given `vm_mapping` if they are
+    /// adjacent and compatible.
+    ///
+    /// - Returns the merged mapping along with the address of the mapping
+    ///   to be removed if successful.
+    /// - Returns the original `self` and a `None` otherwise.
+    pub fn try_merge_with(self, vm_mapping: &VmMapping) -> (Self, Option<Vaddr>) {
+        debug_assert!(!is_intersected(&self.range(), &vm_mapping.range()));
+
+        let (left, right) = if self.map_to_addr < vm_mapping.map_to_addr {
+            (&self, vm_mapping)
+        } else {
+            (vm_mapping, &self)
+        };
+
+        if let Some(merged) = try_merge(left, right) {
+            (merged, Some(vm_mapping.map_to_addr))
+        } else {
+            (self, None)
+        }
+    }
 }
 
 /************************** VM Space operations ******************************/
@@ -579,4 +602,45 @@ impl MappedVmo {
             range: self.range.clone(),
         })
     }
+}
+
+/// Attempts to merge two [`VmMapping`]s into a single mapping if they are
+/// adjacent and compatible.
+///
+/// - Returns the merged [`VmMapping`] if successful. The caller should
+///   remove the original mappings before inserting the merged mapping
+///   into the [`Vmar`].
+/// - Returns `None` otherwise.
+fn try_merge(left: &VmMapping, right: &VmMapping) -> Option<VmMapping> {
+    if left.map_end() != right.map_to_addr()
+        || left.is_shared != right.is_shared
+        || left.handle_page_faults_around != right.handle_page_faults_around
+        || left.perms != right.perms
+    {
+        return None;
+    }
+    let vmo = match (&left.vmo, &right.vmo) {
+        (None, None) => None,
+        (Some(l_vmo), Some(r_vmo))
+            if Arc::ptr_eq(&l_vmo.vmo.0, &r_vmo.vmo.0)
+                && r_vmo.range.start - l_vmo.range.start == left.map_size()
+                && l_vmo.range.end - l_vmo.range.start >= left.map_size() =>
+        {
+            let range = l_vmo.range.start..l_vmo.range.end.max(r_vmo.range.end);
+            Some(MappedVmo::new(l_vmo.vmo.dup().ok()?, range))
+        }
+        _ => return None,
+    };
+
+    let map_size = NonZeroUsize::new(left.map_size() + right.map_size()).unwrap();
+
+    Some(VmMapping {
+        map_size,
+        map_to_addr: left.map_to_addr,
+        vmo,
+        inode: left.inode.clone(),
+        is_shared: left.is_shared,
+        handle_page_faults_around: left.handle_page_faults_around,
+        perms: left.perms,
+    })
 }

--- a/test/apps/mmap/mmap_and_mremap.c
+++ b/test/apps/mmap/mmap_and_mremap.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <fcntl.h>
 #include "../network/test.h"
 
 #define PAGE_SIZE 4096
@@ -76,5 +77,65 @@ FN_TEST(mmap_and_mremap_fixed)
 
 	TEST_RES(strcmp(new_addr, content), _ret == 0);
 	TEST_SUCC(munmap(new_addr, PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mmap_and_mremap_auto_merge_anon)
+{
+	char *addr = x_mmap(NULL, 6 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	TEST_SUCC(munmap(addr, 6 * PAGE_SIZE));
+
+	x_mmap(addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+	       MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+	strcpy(addr, content);
+	x_mmap(addr + 2 * PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE,
+	       MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+	x_mmap(addr + PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE,
+	       MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+
+	char *new_addr = mremap(addr, 3 * PAGE_SIZE, 3 * PAGE_SIZE,
+				MREMAP_MAYMOVE | MREMAP_FIXED,
+				addr + 3 * PAGE_SIZE);
+	if (new_addr == MAP_FAILED) {
+		perror("mremap");
+		exit(EXIT_FAILURE);
+	}
+
+	TEST_RES(strcmp(new_addr, content), _ret == 0);
+	TEST_SUCC(munmap(new_addr, 3 * PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mmap_and_mremap_auto_merge_file)
+{
+	const char *filename = "mremap_test_file";
+	int fd = TEST_SUCC(open(filename, O_CREAT | O_RDWR, 0600));
+	TEST_SUCC(ftruncate(fd, 6 * PAGE_SIZE));
+
+	char *addr = x_mmap(NULL, 6 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE, fd, 0);
+	TEST_SUCC(munmap(addr, 6 * PAGE_SIZE));
+
+	x_mmap(addr, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
+	       fd, 0);
+	strcpy(addr, content);
+	x_mmap(addr + 2 * PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE,
+	       MAP_PRIVATE | MAP_FIXED, fd, 2 * PAGE_SIZE);
+	x_mmap(addr + PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE,
+	       MAP_PRIVATE | MAP_FIXED, fd, PAGE_SIZE);
+
+	char *new_addr = mremap(addr, 3 * PAGE_SIZE, 3 * PAGE_SIZE,
+				MREMAP_MAYMOVE | MREMAP_FIXED,
+				addr + 3 * PAGE_SIZE);
+	if (new_addr == MAP_FAILED) {
+		perror("mremap");
+		exit(EXIT_FAILURE);
+	}
+
+	TEST_RES(strcmp(new_addr, content), _ret == 0);
+	TEST_SUCC(munmap(new_addr, 3 * PAGE_SIZE));
+	close(fd);
+	unlink(filename);
 }
 END_TEST()


### PR DESCRIPTION
We can merge two adjacent and compatible `VmMapping`s into a single one in order to reduce fragmentation. Linux also has this mechanism: https://github.com/torvalds/linux/blob/e04c78d86a9699d136910cfc0bdcf01087e3267e/mm/vma.c#L775-L806