### PR TITLE
Enable syscall tests for UNIX sockets

### DIFF
--- a/kernel/src/fs/utils/endpoint.rs
+++ b/kernel/src/fs/utils/endpoint.rs
@@ -15,7 +15,7 @@ use crate::{
 /// users to access the local and remote `T`s from both endpoints.
 pub struct Endpoint<T> {
     inner: Arc<Inner<T>>,
-    endpoint: Location,
+    location: Location,
 }
 
 enum Location {
@@ -42,11 +42,11 @@ impl<T> Endpoint<T> {
 
         let client = Endpoint {
             inner: inner.clone(),
-            endpoint: Location::Client,
+            location: Location::Client,
         };
         let server = Endpoint {
             inner,
-            endpoint: Location::Server,
+            location: Location::Server,
         };
 
         (client, server)
@@ -54,7 +54,7 @@ impl<T> Endpoint<T> {
 
     /// Returns a reference to the `T` on the local endpoint.
     pub fn this_end(&self) -> &T {
-        match self.endpoint {
+        match self.location {
             Location::Client => &self.inner.client,
             Location::Server => &self.inner.server,
         }
@@ -62,14 +62,14 @@ impl<T> Endpoint<T> {
 
     /// Returns a reference to the `T` on the remote endpoint.
     pub fn peer_end(&self) -> &T {
-        match self.endpoint {
+        match self.location {
             Location::Client => &self.inner.server,
             Location::Server => &self.inner.client,
         }
     }
 }
 
-/// A [`Endpoint`] state that helps end-to-end data communication.
+/// An [`Endpoint`] state that helps end-to-end data communication.
 ///
 /// The state contains a [`Pollee`] that will be notified when new data or the buffer becomes
 /// available. Additionally, this state tracks whether communication has been shut down, i.e.,

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -89,6 +89,7 @@ impl Init {
         };
 
         pollee.invalidate();
+
         Ok(Listener::new(
             addr,
             backlog,

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -55,11 +55,12 @@ impl Listener {
 
     pub(super) fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         let connected = self.backlog.pop_incoming()?;
-        let peer_addr = connected.peer_addr().into();
 
+        let peer_addr = connected.peer_addr().into();
         // TODO: Update options for a newly-accepted socket
         let options = OptionSet::new();
         let socket = UnixStreamSocket::new_connected(connected, options, false);
+
         Ok((socket, peer_addr))
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -452,7 +452,10 @@ fn do_unix_getsockopt(option: &mut dyn SocketOption, state: &State) -> Result<()
             let groups = state.peer_groups()?;
             socket_peer_groups.set(groups);
         },
-        _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option to get is not unix socket specific")
+        _ => return_errno_with_message!(
+            Errno::ENOPROTOOPT,
+            "the socket option to get is not UNIX-socket-specific"
+        )
     });
 
     Ok(())

--- a/test/apps/network/unix_err.c
+++ b/test/apps/network/unix_err.c
@@ -340,6 +340,16 @@ FN_TEST(send)
 	TEST_ERRNO(send(sk_listen, buf, 0, 0), ENOTCONN);
 	TEST_ERRNO(write(sk_listen, buf, 1), ENOTCONN);
 	TEST_ERRNO(write(sk_listen, buf, 0), ENOTCONN);
+
+	TEST_ERRNO(sendto(sk_unbound, buf, 1, 0, &LISTEN_ADDR, LISTEN_ADDRLEN),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_bound, buf, 1, 0, &LISTEN_ADDR2, LISTEN_ADDRLEN2),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_listen, buf, 1, 0, &BOUND_ADDR, BOUND_ADDRLEN),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_accepted, buf, 1, 0, &UNNAMED_ADDR,
+			  UNNAMED_ADDRLEN),
+		   EISCONN);
 }
 END_TEST()
 

--- a/test/syscall_test/gvisor/Makefile
+++ b/test/syscall_test/gvisor/Makefile
@@ -50,6 +50,8 @@ TESTS ?= \
 	sigaltstack_test \
 	signalfd_test \
 	socket_netlink_route_test \
+	socket_unix_pair_test \
+	socket_unix_stream_test \
 	stat_test \
 	stat_times_test \
 	statfs_test \

--- a/test/syscall_test/gvisor/blocklists/socket_unix_pair_test
+++ b/test/syscall_test/gvisor/blocklists/socket_unix_pair_test
@@ -1,0 +1,27 @@
+# TODO: Support `SOCK_SEQPACKET` sockets
+AllUnixDomainSockets/UnixSocketPairTest.BindToBadName/*
+AllUnixDomainSockets/UnixSocketPairTest.BindToBadFamily/*
+AllUnixDomainSockets/*/4
+AllUnixDomainSockets/*/5
+AllUnixDomainSockets/*/10
+AllUnixDomainSockets/*/11
+
+# TODO: Support `SOCK_DGRAM` sockets
+AllUnixDomainSockets/*/2
+AllUnixDomainSockets/*/3
+AllUnixDomainSockets/*/8
+AllUnixDomainSockets/*/9
+
+# TODO: Support the `recvmmsg` system call
+AllUnixDomainSockets/UnixSocketPairTest.RecvmmsgTimeoutAfterRecv/*
+
+# TODO: Support `ioctl` operations on sockets
+AllUnixDomainSockets/UnixSocketPairTest.TIOCINQSucceeds/*
+AllUnixDomainSockets/UnixSocketPairTest.TIOCOUTQSucceeds/*
+AllUnixDomainSockets/UnixSocketPairTest.NetdeviceIoctlsSucceed/*
+
+# TODO: Fix operations on `/proc/*/fd/*`
+AllUnixDomainSockets/UnixSocketPairTest.SocketReopenFromProcfs/*
+
+# TODO: Support control messages
+AllUnixDomainSockets/UnixSocketPairCmsgTest.*

--- a/test/syscall_test/gvisor/blocklists/socket_unix_stream_test
+++ b/test/syscall_test/gvisor/blocklists/socket_unix_stream_test
@@ -1,0 +1,5 @@
+# TODO: Support the `SO_RCVTIMEO` socket option
+AllUnixDomainSockets/StreamUnixSocketPairTest.RecvmsgOneSideClosed/*
+
+# TODO: Support `ECONNRESET` errors on UNIX sockets
+AllUnixDomainSockets/StreamUnixSocketPairTest.ReadOneSideClosedWithUnreadData/*


### PR DESCRIPTION
There appear to be some well-written gVisor tests for sending and receiving UNIX control messages. #2176 may benefit from them.

However, it seems that we have not yet enabled any gVisor tests for UNIX sockets. That's unfortunate. Let's enable them.