### PR TITLE
Make `mremap` behavior consistent with Linux

### DIFF
--- a/kernel/src/syscall/mremap.rs
+++ b/kernel/src/syscall/mremap.rs
@@ -51,11 +51,9 @@ fn do_sys_mremap(
     let root_vmar = user_space.root_vmar();
 
     if !flags.contains(MremapFlags::MREMAP_FIXED) && new_size <= old_size {
-        if new_size < old_size {
-            // We can shrink a old range which spans multiple mappings. See
-            // <https://github.com/google/gvisor/blob/95d875276806484f974ce9e95556a561331f8e22/test/syscalls/linux/mremap.cc#L100-L117>.
-            root_vmar.resize_mapping(old_addr, old_size, new_size, false)?;
-        }
+        // We can shrink a old range which spans multiple mappings. See
+        // <https://github.com/google/gvisor/blob/95d875276806484f974ce9e95556a561331f8e22/test/syscalls/linux/mremap.cc#L100-L117>.
+        root_vmar.resize_mapping(old_addr, old_size, new_size, false)?;
         return Ok(old_addr);
     }
 


### PR DESCRIPTION
As pointed out in https://github.com/asterinas/asterinas/pull/2199#pullrequestreview-2948055023 by @vvvvsv, the behavior of our `mremap` implementation is not consistent with Linux:
> I just checked that on Linux, if `mremap` fails (e.g., because the old range spans multiple VMAs), and `new_size < old_size`, the old mapping will still be shrunk. Also, if `mremap(MREMAP_FIXED)` fails, the existing VMA in the new range (if some) will still be unmapped.

So we may want to refactor the `mremap` implementation as follows:
> To be consistent with Linux, maybe we should refactor the `remap` method as:
> 
> ```rust
>     fn remap() {
>         // Shrinks the old mapping first if new_size < old_size.
>         if new_size < old_size {
>             inner.alloc_free_region_exact_truncate(
>                 &self.vm_space,
>                 old_addr + new_size,
>                 old_size - new_size,
>                 &mut rss_delta,
>             )?;
>             old_size = new_size;
>         }
> 
>         // Alloc free region for new range. We can use `?` here to return early. 
> 
>         let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
> 
>         // The others. After `inner.remove(&old_mapping_addr)`, we shouldn't use any `?`s.
>     }
> ```

In this PR, I've added a new test to verify the exact Linux behavior. It should now pass in both Linux and Asterinas.
```c
	// Shared, Anonymous, Anonymous, Anonymous, Anonymous
	// [ Page 1-3: source         ] [ Page 4-5: target  ]
	//
	// This `mremap()` will fail because Page 1 and Page 2 are of different
	// types. However, it still shrinks the source mapping and clears the
	// target mapping, so Page 3, 4, and 5 will be unmapped.

	TEST_ERRNO(mremap(addr, 3 * PAGE_SIZE, 2 * PAGE_SIZE,
			  MREMAP_MAYMOVE | MREMAP_FIXED, addr + 3 * PAGE_SIZE),
		   EFAULT);
```