### PR TITLE
Add fields in `/proc/*/stat` and `/proc/*/status`

### DIFF
--- a/kernel/src/fs/device.rs
+++ b/kernel/src/fs/device.rs
@@ -64,6 +64,12 @@ impl DeviceId {
     pub fn minor(&self) -> u32 {
         ((self.0 >> 12) & 0xffff_ff00 | self.0 & 0x0000_00ff) as u32
     }
+
+    pub fn to_dev_t(&self) -> u32 {
+        let major = self.major();
+        let minor = self.minor();
+        ((major & 0xff) << 8) | (minor & 0xff)
+    }
 }
 
 impl Debug for DeviceId {

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use self::{
-    cmdline::CmdlineFileOps, comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps, task::TaskDirOps,
+    cmdline::CmdlineFileOps, comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps, stat::StatFileOps,
+    status::StatusFileOps, task::TaskDirOps,
 };
 use super::template::{DirOps, ProcDir, ProcDirBuilder};
 use crate::{
@@ -64,8 +65,12 @@ impl DirOps for PidDirOps {
             "comm" => CommFileOps::new_inode(self.0.clone(), this_ptr.clone()),
             "fd" => FdDirOps::new_inode(self.0.clone(), this_ptr.clone()),
             "cmdline" => CmdlineFileOps::new_inode(self.0.clone(), this_ptr.clone()),
-            "status" => status::StatusFileOps::new_inode(self.0.clone(), this_ptr.clone()),
-            "stat" => stat::StatFileOps::new_inode(self.0.clone(), this_ptr.clone()),
+            "status" => {
+                StatusFileOps::new_inode(self.0.clone(), self.0.main_thread(), this_ptr.clone())
+            }
+            "stat" => {
+                StatFileOps::new_inode(self.0.clone(), self.0.main_thread(), true, this_ptr.clone())
+            }
             "task" => TaskDirOps::new_inode(self.0.clone(), this_ptr.clone()),
             _ => return_errno!(Errno::ENOENT),
         };
@@ -91,10 +96,10 @@ impl DirOps for PidDirOps {
             CmdlineFileOps::new_inode(self.0.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("status", || {
-            status::StatusFileOps::new_inode(self.0.clone(), this_ptr.clone())
+            StatusFileOps::new_inode(self.0.clone(), self.0.main_thread(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("stat", || {
-            stat::StatFileOps::new_inode(self.0.clone(), this_ptr.clone())
+            StatFileOps::new_inode(self.0.clone(), self.0.main_thread(), true, this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("task", || {
             TaskDirOps::new_inode(self.0.clone(), this_ptr.clone())

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt::Write;
+use core::{fmt::Write, sync::atomic::Ordering};
 
 use crate::{
     fs::{
@@ -8,13 +8,21 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
+    process::posix_thread::{AsPosixThread, PosixThread},
+    thread::Thread,
+    vm::vmar::RssType,
     Process,
 };
 
-/// Represents the inode at `/proc/[pid]/stat`.
-/// The fields are the same as the ones in `/proc/[pid]/status`. But the format is different.
-/// See https://github.com/torvalds/linux/blob/ce1c54fdff7c4556b08f5b875a331d8952e8b6b7/fs/proc/array.c#L467
-/// FIXME: Some fields are not implemented yet.
+/// Represents the inode at either `/proc/[pid]/stat` or `/proc/[pid]/task/[tid]/stat`.
+///
+/// If `is_pid_stat` is true, it corresponds to the process-level `/proc/[pid]/stat`.
+/// Otherwise, it corresponds to the thread-level `/proc/[pid]/task/[tid]/stat`.
+///
+/// The fields are the same as the ones in `/proc/[pid]/status`, but the format is different.
+/// See <https://github.com/torvalds/linux/blob/ce1c54fdff7c4556b08f5b875a331d8952e8b6b7/fs/proc/array.c#L467>.
+///
+/// FIXME: Some fields are not implemented or contain placeholders yet.
 ///
 /// Fields:
 /// - pid              : Process ID.
@@ -68,36 +76,126 @@ use crate::{
 /// - env_start        : Start address of environment variables.
 /// - env_end          : End address of environment variables.
 /// - exit_code        : Process exit code as returned by waitpid(2).
-pub struct StatFileOps(Arc<Process>);
+pub struct StatFileOps {
+    process_ref: Arc<Process>,
+    thread_ref: Arc<Thread>,
+    is_pid_stat: bool,
+}
 
 impl StatFileOps {
-    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self(process_ref))
-            .parent(parent)
-            .build()
-            .unwrap()
+    pub fn new_inode(
+        process_ref: Arc<Process>,
+        thread_ref: Arc<Thread>,
+        is_pid_stat: bool,
+        parent: Weak<dyn Inode>,
+    ) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self {
+            process_ref,
+            thread_ref,
+            is_pid_stat,
+        })
+        .parent(parent)
+        .build()
+        .unwrap()
     }
 }
 
 impl FileOps for StatFileOps {
     fn data(&self) -> Result<Vec<u8>> {
-        let process = &self.0;
+        let process = &self.process_ref;
+        let thread = &self.thread_ref;
+        let posix_thread = thread.as_posix_thread().ok_or(Errno::ENOENT)?;
 
-        let pid = process.pid();
-        let comm = process.executable_path();
-        let state = if process.status().is_zombie() {
-            'Z'
-        } else {
-            'R'
-        };
+        let pid = posix_thread.tid();
+        let comm = posix_thread
+            .thread_name_as_string()
+            .unwrap_or_else(|| process.executable_path());
+        let state = if thread.is_exited() { 'Z' } else { 'R' };
         let ppid = process.parent().pid();
         let pgrp = process.pgid();
+        let session = process.sid();
+        let tty_nr = process.tty_id().map(|id| id.to_dev_t()).unwrap_or(0);
+        let tpgid = -1;
+        let flags = 0;
+        let min_flt = 0;
+        let cmin_flt = 0;
+        let maj_flt = 0;
+        let cmaj_flt = 0;
+
+        let (utime, stime) = {
+            let get_utime_and_stime = |posix_thread: &PosixThread| {
+                let prof_clock = posix_thread.prof_clock();
+                (
+                    prof_clock.user_clock().read_time_in_jiffies().as_u64(),
+                    prof_clock.kernel_clock().read_time_in_jiffies().as_u64(),
+                )
+            };
+            if self.is_pid_stat {
+                let tasks = process.tasks().lock();
+                let threads = tasks
+                    .as_slice()
+                    .iter()
+                    .map(|task| task.as_posix_thread().unwrap());
+                threads.map(get_utime_and_stime).fold(
+                    (0_u64, 0_u64),
+                    |(utime, stime), (thread_utime, thread_stime)| {
+                        (
+                            utime.checked_add(thread_utime).unwrap_or(u64::MAX),
+                            stime.checked_add(thread_stime).unwrap_or(u64::MAX),
+                        )
+                    },
+                )
+            } else {
+                get_utime_and_stime(posix_thread)
+            }
+        };
+
+        let cutime = 0;
+        let cstime = 0;
+        let priority = 0;
+        let nice = process.nice().load(Ordering::Relaxed).value().get();
+        let num_threads = process.tasks().lock().as_slice().len();
+        let itrealvalue = 0;
+        let starttime = 0;
+
+        let (vsize, rss) = if let Some(vmar_ref) = process.lock_root_vmar().as_ref() {
+            let vsize = vmar_ref.get_vsize();
+            let anon = vmar_ref.get_rss_counter(RssType::RSS_ANONPAGES);
+            let file = vmar_ref.get_rss_counter(RssType::RSS_FILEPAGES);
+            let rss = anon + file;
+            (vsize, rss)
+        } else {
+            (0, 0)
+        };
 
         let mut stat_output = String::new();
         writeln!(
             stat_output,
-            "{} ({}) {} {} {}",
-            pid, comm, state, ppid, pgrp
+            "{} ({}) {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
+            pid,
+            comm,
+            state,
+            ppid,
+            pgrp,
+            session,
+            tty_nr,
+            tpgid,
+            flags,
+            min_flt,
+            cmin_flt,
+            maj_flt,
+            cmaj_flt,
+            utime,
+            stime,
+            cutime,
+            cstime,
+            priority,
+            nice,
+            num_threads,
+            itrealvalue,
+            starttime,
+            vsize,
+            rss
         )
         .unwrap();
         Ok(stat_output.into_bytes())

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -9,11 +9,12 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
+    thread::Thread,
     vm::vmar::RssType,
     Process,
 };
 
-/// Represents the inode at `/proc/[pid]/status`.
+/// Represents the inode at either `/proc/[pid]/status` or `/proc/[pid]/task/[tid]/status`.
 /// See https://github.com/torvalds/linux/blob/ce1c54fdff7c4556b08f5b875a331d8952e8b6b7/fs/proc/array.c#L148
 /// FIXME: Some fields are not implemented yet.
 ///
@@ -59,54 +60,84 @@ use crate::{
 /// - Mems_allowed_list: List of memory nodes allowed for this process.
 /// - voluntary_ctxt_switches: Number of voluntary context switches.
 /// - nonvoluntary_ctxt_switches: Number of nonvoluntary context switches.
-pub struct StatusFileOps(Arc<Process>);
+pub struct StatusFileOps {
+    process_ref: Arc<Process>,
+    thread_ref: Arc<Thread>,
+}
 
 impl StatusFileOps {
-    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self(process_ref))
-            .parent(parent)
-            .build()
-            .unwrap()
+    pub fn new_inode(
+        process_ref: Arc<Process>,
+        thread_ref: Arc<Thread>,
+        parent: Weak<dyn Inode>,
+    ) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self {
+            process_ref,
+            thread_ref,
+        })
+        .parent(parent)
+        .build()
+        .unwrap()
     }
 }
 
 impl FileOps for StatusFileOps {
     fn data(&self) -> Result<Vec<u8>> {
-        let process = &self.0;
-        let main_thread = process.main_thread();
-        let file_table = main_thread.as_posix_thread().unwrap().file_table();
+        let process = &self.process_ref;
+        let thread = &self.thread_ref;
+        let posix_thread = thread.as_posix_thread().ok_or(Errno::ENOENT)?;
 
         let mut status_output = String::new();
-        writeln!(status_output, "Name:\t{}", process.executable_path()).unwrap();
+        writeln!(
+            status_output,
+            "Name:\t{}",
+            posix_thread
+                .thread_name_as_string()
+                .unwrap_or_else(|| process.executable_path())
+        )
+        .unwrap();
+
+        let state = if thread.is_exited() {
+            "Z (zombie)"
+        } else {
+            "R (running)"
+        };
+        writeln!(status_output, "State:\t{}", state).unwrap();
+
         writeln!(status_output, "Tgid:\t{}", process.pid()).unwrap();
-        writeln!(status_output, "Pid:\t{}", process.pid()).unwrap();
+        writeln!(status_output, "Pid:\t{}", posix_thread.tid()).unwrap();
         writeln!(status_output, "PPid:\t{}", process.parent().pid()).unwrap();
         writeln!(status_output, "TracerPid:\t{}", process.parent().pid()).unwrap(); // Assuming TracerPid is the same as PPid
         writeln!(
             status_output,
             "FDSize:\t{}",
-            file_table
+            posix_thread
+                .file_table()
                 .lock()
                 .as_ref()
                 .map(|file_table| file_table.read().len())
                 .unwrap_or(0)
         )
         .unwrap();
-        writeln!(
-            status_output,
-            "Threads:\t{}",
-            process.tasks().lock().as_slice().len()
-        )
-        .unwrap();
 
         if let Some(vmar_ref) = process.lock_root_vmar().as_ref() {
+            let vsize = vmar_ref.get_vsize();
             let anon = vmar_ref.get_rss_counter(RssType::RSS_ANONPAGES) * (PAGE_SIZE / 1024);
             let file = vmar_ref.get_rss_counter(RssType::RSS_FILEPAGES) * (PAGE_SIZE / 1024);
             let rss = anon + file;
             writeln!(
                 status_output,
-                "VmRSS:\t{} kB\nRssAnon:\t{} kB\nRssFile:\t{} kB",
-                rss, anon, file
+                "VmSize:\t{} kB\nVmRSS:\t{} kB\nRssAnon:\t{} kB\nRssFile:\t{} kB",
+                vsize, rss, anon, file
+            )
+            .unwrap();
+        }
+
+        if Arc::ptr_eq(thread, &process.main_thread()) {
+            writeln!(
+                status_output,
+                "Threads:\t{}",
+                process.tasks().lock().as_slice().len()
             )
             .unwrap();
         }

--- a/kernel/src/fs/procfs/pid/task.rs
+++ b/kernel/src/fs/procfs/pid/task.rs
@@ -9,6 +9,7 @@ use crate::{
         utils::{DirEntryVecExt, Inode},
     },
     process::posix_thread::AsPosixThread,
+    thread::{AsThread, Thread},
     Process,
 };
 
@@ -25,22 +26,44 @@ impl TaskDirOps {
 }
 
 /// Represents the inode at `/proc/[pid]/task/[tid]`.
-struct ThreadDirOps(Arc<Process>);
+struct TidDirOps {
+    process_ref: Arc<Process>,
+    thread_ref: Arc<Thread>,
+}
 
-impl ThreadDirOps {
-    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcDirBuilder::new(Self(process_ref))
-            .parent(parent)
-            .build()
-            .unwrap()
+impl TidDirOps {
+    pub fn new_inode(
+        process_ref: Arc<Process>,
+        thread_ref: Arc<Thread>,
+        parent: Weak<dyn Inode>,
+    ) -> Arc<dyn Inode> {
+        ProcDirBuilder::new(Self {
+            process_ref,
+            thread_ref,
+        })
+        .parent(parent)
+        .build()
+        .unwrap()
     }
 }
 
-impl DirOps for ThreadDirOps {
+impl DirOps for TidDirOps {
     fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
         let inode = match name {
-            "fd" => FdDirOps::new_inode(self.0.clone(), this_ptr.clone()),
-            "exe" => ExeSymOps::new_inode(self.0.clone(), this_ptr.clone()),
+            "fd" => FdDirOps::new_inode(self.process_ref.clone(), this_ptr.clone()),
+            "exe" => ExeSymOps::new_inode(self.process_ref.clone(), this_ptr.clone()),
+            "stat" => StatFileOps::new_inode(
+                self.process_ref.clone(),
+                self.thread_ref.clone(),
+                false,
+                this_ptr.clone(),
+            ),
+            "status" => StatusFileOps::new_inode(
+                self.process_ref.clone(),
+                self.thread_ref.clone(),
+                this_ptr.clone(),
+            ),
+
             _ => return_errno!(Errno::ENOENT),
         };
         Ok(inode)
@@ -49,14 +72,29 @@ impl DirOps for ThreadDirOps {
     fn populate_children(&self, this_ptr: Weak<dyn Inode>) {
         let this = {
             let this = this_ptr.upgrade().unwrap();
-            this.downcast_ref::<ProcDir<ThreadDirOps>>().unwrap().this()
+            this.downcast_ref::<ProcDir<TidDirOps>>().unwrap().this()
         };
         let mut cached_children = this.cached_children().write();
         cached_children.put_entry_if_not_found("fd", || {
-            FdDirOps::new_inode(self.0.clone(), this_ptr.clone())
+            FdDirOps::new_inode(self.process_ref.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("exe", || {
-            ExeSymOps::new_inode(self.0.clone(), this_ptr.clone())
+            ExeSymOps::new_inode(self.process_ref.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("stat", || {
+            StatFileOps::new_inode(
+                self.process_ref.clone(),
+                self.thread_ref.clone(),
+                false,
+                this_ptr.clone(),
+            )
+        });
+        cached_children.put_entry_if_not_found("status", || {
+            StatusFileOps::new_inode(
+                self.process_ref.clone(),
+                self.thread_ref.clone(),
+                this_ptr.clone(),
+            )
         });
     }
 }
@@ -68,10 +106,15 @@ impl DirOps for TaskDirOps {
         };
 
         for task in self.0.tasks().lock().as_slice() {
-            if task.as_posix_thread().unwrap().tid() != tid {
+            let thread = task.as_thread().unwrap();
+            if thread.as_posix_thread().unwrap().tid() != tid {
                 continue;
             }
-            return Ok(ThreadDirOps::new_inode(self.0.clone(), this_ptr));
+            return Ok(TidDirOps::new_inode(
+                self.0.clone(),
+                thread.clone(),
+                this_ptr,
+            ));
         }
         return_errno_with_message!(Errno::ENOENT, "No such thread")
     }
@@ -83,9 +126,10 @@ impl DirOps for TaskDirOps {
         };
         let mut cached_children = this.cached_children().write();
         for task in self.0.tasks().lock().as_slice() {
+            let thread = task.as_thread().unwrap();
             cached_children.put_entry_if_not_found(
                 &format!("{}", task.as_posix_thread().unwrap().tid()),
-                || ThreadDirOps::new_inode(self.0.clone(), this_ptr.clone()),
+                || TidDirOps::new_inode(self.0.clone(), thread.clone(), this_ptr.clone()),
             );
         }
     }

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -257,6 +257,9 @@ fn clone_child_task(
     // Inherit sigmask from current thread
     let sig_mask = posix_thread.sig_mask().load(Ordering::Relaxed).into();
 
+    // Inherit the thread name.
+    let thread_name = posix_thread.thread_name().lock().as_ref().cloned();
+
     let child_tid = allocate_posix_tid();
     let child_task = {
         let credentials = {
@@ -266,6 +269,7 @@ fn clone_child_task(
 
         let mut thread_builder = PosixThreadBuilder::new(child_tid, child_user_ctx, credentials)
             .process(posix_thread.weak_process())
+            .thread_name(thread_name)
             .sig_mask(sig_mask)
             .file_table(child_file_table)
             .fs(child_fs);

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::borrow::ToOwned;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_rights::{ReadDupOp, ReadOp, WriteOp};
@@ -94,6 +95,13 @@ impl PosixThread {
 
     pub fn thread_name(&self) -> &Mutex<Option<ThreadName>> {
         &self.name
+    }
+
+    pub fn thread_name_as_string(&self) -> Option<String> {
+        let thread_name = self.name.lock();
+        let name = thread_name.as_ref()?.name().ok()??;
+        let name = name.to_str().ok()?.to_owned();
+        Some(name)
     }
 
     pub fn file_table(&self) -> &Mutex<Option<RoArc<FileTable>>> {

--- a/kernel/src/process/posix_thread/name.rs
+++ b/kernel/src/process/posix_thread/name.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 
 pub const MAX_THREAD_NAME_LEN: usize = 16;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ThreadName {
     inner: [u8; MAX_THREAD_NAME_LEN],
     count: usize,

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -17,6 +17,7 @@ use super::{
     task_set::TaskSet,
 };
 use crate::{
+    fs::device::DeviceId,
     prelude::*,
     process::{status::StopWaitStatus, WaitOptions},
     sched::{AtomicNice, Nice},
@@ -95,7 +96,7 @@ pub struct Process {
 
     /// Whether the process has a subreaper that will reap it when the
     /// process becomes orphaned.
-    ///  
+    ///
     /// If `has_child_subreaper` is true in a `Process`, this attribute should
     /// also be true for all of its descendants.
     pub(super) has_child_subreaper: AtomicBool,
@@ -575,6 +576,16 @@ impl Process {
         session_inner.insert_process_group(new_process_group);
 
         Ok(())
+    }
+
+    /// Returns the device id of the controlling terminal, if present.
+    pub fn tty_id(&self) -> Option<DeviceId> {
+        let main_thread = self.main_thread();
+        let file_table = main_thread.as_posix_thread()?.file_table().lock();
+        let file_table_guard = file_table.as_ref()?.read();
+        let stdin = file_table_guard.get_file(0).ok()?;
+        let inode = stdin.as_inode_or_err().ok()?.dentry().inode();
+        inode.as_device().map(|dev| dev.id())
     }
 
     // ************** Virtual Memory *************

--- a/kernel/src/time/clocks/cpu_clock.rs
+++ b/kernel/src/time/clocks/cpu_clock.rs
@@ -3,7 +3,7 @@
 use alloc::sync::Arc;
 use core::time::Duration;
 
-use ostd::sync::SpinLock;
+use ostd::{sync::SpinLock, timer::Jiffies};
 
 use crate::time::Clock;
 
@@ -32,6 +32,12 @@ impl CpuClock {
     /// Adds `interval` to the original recorded time to update the `CpuClock`.
     pub fn add_time(&self, interval: Duration) {
         *self.time.disable_irq().lock() += interval;
+    }
+
+    /// Returns the current time of this clock in jiffies, or `Jiffies::MAX`
+    /// on overflow.
+    pub fn read_time_in_jiffies(&self) -> Jiffies {
+        self.read_time().into()
     }
 }
 

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -813,6 +813,11 @@ impl<R> Vmar<R> {
     pub fn get_rss_counter(&self, rss_type: RssType) -> usize {
         self.0.get_rss_counter(rss_type)
     }
+
+    /// Returns the virtual memory size in bytes.
+    pub fn get_vsize(&self) -> usize {
+        self.0.inner.read().total_vm
+    }
 }
 
 /// Options for creating a new mapping. The mapping is not allowed to overlap

--- a/ostd/src/timer/jiffies.rs
+++ b/ostd/src/timer/jiffies.rs
@@ -17,6 +17,9 @@ pub struct Jiffies(u64);
 pub(crate) static ELAPSED: AtomicU64 = AtomicU64::new(0);
 
 impl Jiffies {
+    /// The maximum value of [`Jiffies`].
+    pub const MAX: Self = Self(u64::MAX);
+
     /// Creates a new instance.
     pub fn new(value: u64) -> Self {
         Self(value)
@@ -36,10 +39,25 @@ impl Jiffies {
     pub fn as_duration(self) -> Duration {
         Duration::from_millis(self.0 * 1000 / TIMER_FREQ)
     }
+
+    /// Gets the jiffies counts calculated from the [`Duration`].
+    ///
+    /// Returns a `Jiffies::MAX` on overflow.
+    pub fn from_duration(duration: Duration) -> Self {
+        let millis = duration.as_millis();
+        let jiffies = (millis * TIMER_FREQ as u128).div_ceil(1000);
+        jiffies.try_into().map(Self::new).unwrap_or(Self::MAX)
+    }
 }
 
 impl From<Jiffies> for Duration {
     fn from(value: Jiffies) -> Self {
         value.as_duration()
+    }
+}
+
+impl From<Duration> for Jiffies {
+    fn from(duration: Duration) -> Self {
+        Self::from_duration(duration)
     }
 }


### PR DESCRIPTION
In order to support `busybox ps`, we need to add additional fields to `/proc/<pid>/stat`. The implementation of `busybox ps` is [here](https://github.com/mirror/busybox/blob/371fe9f71d445d18be28c82a2a6d82115c8af19d/libbb/procps.c#L390-L418). This PR adds the fields required by `busybox ps` and fills the unused fields with placeholders.

This PR also adds `/proc/<pid>/task/<tid>/stat` to support `ps -T`. For this file, I think we should stay consistent with the [Linux implementation](https://github.com/torvalds/linux/blob/ee88bddf7f2f5d1f1da87dd7bedc734048b70e88/fs/proc/array.c#L467-L681): a process's `/proc/<pid>/stat` should be almost identical to its main thread's `/proc/<pid>/task/<pid>/stat`, except for fields `exit_code`, `wchan`, `min_flt`, `maj_flt`, `gtime`, `utime`, and `stime`. For example, when the main thread has exited but other threads are still running, the `state` field of ` /proc/<pid>/stat` should be `Z` (zombie).

The `status` file behaves differently from `stat` slightly: a process’s `/proc/<pid>/status` is exactly the same as its main thread’s `/proc/<pid>/task/<pid>/status`. See the Linux implementation: [`/proc/<pid>/status`](https://github.com/torvalds/linux/blob/ee88bddf7f2f5d1f1da87dd7bedc734048b70e88/fs/proc/base.c#L3326) and [`/proc/<pid>/task/<pid>/status`](https://github.com/torvalds/linux/blob/ee88bddf7f2f5d1f1da87dd7bedc734048b70e88/fs/proc/base.c#L3675).


Now we can use `ps` to list process and `ps -T` to list threads. :)

```bash
~ # ps
PID   USER     TIME  COMMAND
    1 root      0:00 {busybox} sh -l
    4 root      0:00 ./test/pthread/rename
    6 root      0:00 {ps} sh -l
~ # ps -T
PID   USER     TIME  COMMAND
    1 root      0:00 {busybox} sh -l
    4 root      0:00 ./test/pthread/rename
    5 root      0:00 [renamed]
    7 root      0:00 {ps} sh -l
```

---

cc @TinaZhangZW