### PR TITLE
Add CI to check documentation and publish API documentation to self-host website

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -1,0 +1,48 @@
+name: Publish API Docs
+
+on:
+  # Manally run
+  workflow_dispatch:
+  # Pull request events for checking API docs
+  pull_request:
+  # Scheduled events for nightly API docs
+  schedule:
+    # UTC 00:00 everyday
+    - cron: "0 0 * * *"
+  # Events for API docs of new release
+  push:
+    branches:
+      - main
+    paths:
+      - VERSION
+  
+jobs: 
+  check_api_docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container: asterinas/asterinas:0.15.2-20250613
+
+    steps: 
+      - uses: actions/checkout@v4
+
+      - name: Check API docs
+        if: github.event_name == 'pull_request'
+        run: ./tools/github_workflows/publish_api_docs.sh --dry-run
+
+      - name: Build & Upload Nightly API Docs
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          API_DOCS_NIGHTLY_PUBLISH_KEY: ${{ secrets.API_DOCS_NIGHTLY_PUBLISH_KEY }}
+        run: |
+          KEY_FILE=./api_docs_nightly_publish_key
+          echo "$API_DOCS_NIGHTLY_PUBLISH_KEY\n" > ${KEY_FILE}
+          ./tools/github_workflows/publish_api_docs.sh nightly ${KEY_FILE} 
+
+      - name: Build & Upload Release API Docs
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          API_DOCS_PUBLISH_KEY: ${{ secrets.API_DOCS_PUBLISH_KEY }}
+        run: |
+          KEY_FILE=./api_docs_publish_key
+          echo "$API_DOCS_PUBLISH_KEY\n" > ${KEY_FILE}
+          ./tools/github_workflows/publish_api_docs.sh release ${KEY_FILE} 

--- a/osdk/deps/frame-allocator/src/lib.rs
+++ b/osdk/deps/frame-allocator/src/lib.rs
@@ -19,7 +19,7 @@
 //! allocator based on the buddy system. It is by default shipped with OSDK
 //! for users that don't have special requirements on the frame allocator.
 //!
-//! [`GlobalFrameAllocator`]: ostd::mm::GlobalFrameAllocator
+//! [`GlobalFrameAllocator`]: ostd::mm::frame::GlobalFrameAllocator
 //! [`global_frame_allocator`]: ostd::global_frame_allocator
 
 // The heap allocator usually depends on frame allocation. If we depend on heap

--- a/osdk/deps/frame-allocator/src/smp_counter.rs
+++ b/osdk/deps/frame-allocator/src/smp_counter.rs
@@ -7,8 +7,8 @@ use ostd::cpu::{all_cpus, local::StaticCpuLocal, CpuId};
 use core::sync::atomic::{AtomicIsize, Ordering};
 
 /// Defines a static fast SMP counter.
-///
-/// See [`FastSmpCounter`] for more details.
+//
+// See `FastSmpCounter` for more details.
 #[macro_export]
 macro_rules! fast_smp_counter {
     ($(#[$attr:meta])* $vis:vis static $name:ident : usize;) => { paste::paste!{

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -42,6 +42,14 @@ pub fn execute_forwarded_command(subcommand: &str, args: &Vec<String>, cfg_ktest
 
     cargo.env("RUSTFLAGS", rustflags);
 
+    // When generating documentation via `cargo doc`, the `--check-cfg cfg(ktest)` flag
+    // must be specified in both `RUSTFLAGS` and `RUSTDOCFLAGS`.
+    if subcommand == "doc" {
+        let env_rustdocflags = std::env::var("RUSTDOCFLAGS").unwrap_or_default();
+        let rustdocflags = env_rustdocflags + " --check-cfg cfg(ktest)";
+        cargo.env("RUSTDOCFLAGS", rustdocflags);
+    }
+
     let status = cargo.status().expect("Failed to execute cargo");
     if !status.success() {
         error_msg!("Command {:?} failed with status: {:?}", cargo, status);

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -6,6 +6,7 @@ description = "Rust OS framework that facilitates the development of and innovat
 license = "MPL-2.0"
 readme = "README.md"
 repository = "https://github.com/asterinas/asterinas"
+documentation = "https://asterinas.github.io/api-docs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ostd/README.md
+++ b/ostd/README.md
@@ -18,4 +18,4 @@ Asterinas OSTD offers the following key values.
 
 ## OSTD APIs
 
-See [API docs](https://docs.rs/ostd/latest/ostd).
+See [API docs](https://asterinas.github.io/api-docs).

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -111,8 +111,8 @@ pub fn global_frame_allocator(_attr: TokenStream, item: TokenStream) -> TokenStr
 /// This attribute is not to be confused with Rust's built-in
 /// [`global_allocator`] attribute, which applies to a static variable
 /// implementing the unsafe `GlobalAlloc` trait. In contrast, the
-/// [`global_heap_allocator`] attribute does not require the heap allocator to
-/// implement an unsafe trait. [`global_heap_allocator`] eventually relies on
+/// [`macro@global_heap_allocator`] attribute does not require the heap allocator to
+/// implement an unsafe trait. [`macro@global_heap_allocator`] eventually relies on
 /// [`global_allocator`] to customize Rust's heap allocator.
 ///
 /// # Example

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -123,7 +123,7 @@ fn parse_memory_regions(mb1_info: &MultibootLegacyInfo) -> MemoryRegionArray {
 
 /// Representation of Multiboot Information according to specification.
 ///
-/// Ref:https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format
+/// Ref: <https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format>.
 ///
 ///```text
 ///         +-------------------+
@@ -203,7 +203,7 @@ struct MultibootLegacyInfo {
     /// ```
     mods_addr: u32,
 
-    /// If flags[4] = 1, then the field starting at byte 28 are valid:
+    /// If flags\[4\] = 1, then the field starting at byte 28 are valid:
     /// ```text
     ///         +-------------------+
     /// 28      | tabsize           |
@@ -214,7 +214,7 @@ struct MultibootLegacyInfo {
     /// ```
     /// These indicate where the symbol table from kernel image can be found.
     ///
-    /// If flags[5] = 1, then the field starting at byte 28 are valid:
+    /// If flags\[5\] = 1, then the field starting at byte 28 are valid:
     /// ```text
     ///         +-------------------+
     /// 28      | num               |

--- a/ostd/src/arch/x86/io.rs
+++ b/ostd/src/arch/x86/io.rs
@@ -57,5 +57,5 @@ pub(super) fn construct_io_mem_allocator_builder() -> IoMemAllocatorBuilder {
     unsafe { IoMemAllocatorBuilder::new(ranges) }
 }
 
-/// Port I/O definition reference: https://bochs.sourceforge.io/techspec/PORTS.LST
+/// Port I/O definition reference: <https://bochs.sourceforge.io/techspec/PORTS.LST>.
 pub const MAX_IO_PORT: u16 = u16::MAX;

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
@@ -194,10 +194,10 @@ impl IrtEntry {
     /// The format of this field in various Interrupt Remapping modes is as follows:
     /// - Intel xAPIC Mode (IRTA_REG.EIME=0):
     ///     - 63:48 - Reserved (0)
-    ///     - 47:40 - APIC DestinationID[7:0]
+    ///     - 47:40 - APIC DestinationID\[7:0\]
     ///     - 39:32 - Reserved (0)
     /// - Intel x2APIC Mode (IRTA_REG.EIME=1):
-    ///     - 63:32 - APIC DestinationID[31:0]
+    ///     - 63:32 - APIC DestinationID\[31:0\]
     pub const fn destination_id(&self) -> u32 {
         const DST_MASK: u128 = 0xFFFF_FFFF << 32;
         ((self.0 & DST_MASK) >> 32) as u32

--- a/ostd/src/arch/x86/kernel/apic/mod.rs
+++ b/ostd/src/arch/x86/kernel/apic/mod.rs
@@ -217,7 +217,7 @@ impl ApicId {
     ///
     /// In x2APIC mode, the 32-bit logical x2APIC ID, which can be read from
     /// LDR, is derived from the 32-bit local x2APIC ID:
-    /// Logical x2APIC ID = [(x2APIC ID[19:4] << 16) | (1 << x2APIC ID[3:0])]
+    /// Logical x2APIC ID = [(x2APIC ID\[19:4\] << 16) | (1 << x2APIC ID\[3:0\])]
     #[expect(unused)]
     pub fn x2apic_logical_id(&self) -> u32 {
         (self.x2apic_logical_cluster_id() << 16) | (1 << self.x2apic_logical_field_id())
@@ -225,7 +225,7 @@ impl ApicId {
 
     /// Returns the logical x2apic cluster ID.
     ///
-    /// Logical cluster ID = x2APIC ID[19:4]
+    /// Logical cluster ID = x2APIC ID\[19:4\]
     pub fn x2apic_logical_cluster_id(&self) -> u32 {
         let apic_id = match *self {
             ApicId::XApic(id) => id as u32,
@@ -238,7 +238,7 @@ impl ApicId {
     ///
     /// Specifically, the 16-bit logical ID sub-field is derived by the lowest
     /// 4 bits of the x2APIC ID, i.e.,
-    /// Logical field ID = x2APIC ID[3:0].
+    /// Logical field ID = x2APIC ID\[3:0\].
     pub fn x2apic_logical_field_id(&self) -> u32 {
         let apic_id = match *self {
             ApicId::XApic(id) => id as u32,

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -96,6 +96,8 @@ pub(crate) unsafe fn late_init_on_bsp() {
 ///
 /// This function must be called only once on each application processor.
 /// And it should be called after the BSP's call to [`init_on_bsp`].
+///
+/// [`init_on_bsp`]: crate::cpu::init_on_bsp
 pub(crate) unsafe fn init_on_ap() {
     timer::init_ap();
 }

--- a/ostd/src/arch/x86/timer/pit.rs
+++ b/ostd/src/arch/x86/timer/pit.rs
@@ -131,7 +131,7 @@ enum Channel {
     /// If bit 4 is clear, then for any/all PIT channels selected with bits 1 to 3,
     /// the next read of the corresponding data port will return a status byte.
     ///
-    /// Ref: https://wiki.osdev.org/Programmable_Interval_Timer#Read_Back_Command
+    /// Ref: <https://wiki.osdev.org/Programmable_Interval_Timer#Read_Back_Command>.
     ReadBackCommand = 0b11,
 }
 
@@ -150,7 +150,7 @@ sensitive_io_port! {
 
         /// The output from PIT channel 2 is connected to the PC speaker, so the frequency of the
         /// output determines the frequency of the sound produced by the speaker. For more information,
-        /// check https://wiki.osdev.org/PC_Speaker.
+        /// check <https://wiki.osdev.org/PC_Speaker>.
         static CHANNEL2_PORT: IoPort<u8, WriteOnlyAccess> = IoPort::new(0x42);
 
         /// PIT command port.

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -32,8 +32,8 @@ pub struct BootInfo {
 }
 
 /// Gets the boot information.
-///
-/// This function is usable after initialization with [`init_after_heap`].
+//
+// This function is usable after initialization with `init_after_heap`.
 pub fn boot_info() -> &'static BootInfo {
     INFO.get().unwrap()
 }

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -178,6 +178,8 @@ fn wait_for_all_aps_started(num_cpus: usize) {
 /// # Panics
 ///
 /// This method will panic if it is called either before all APs have booted or more than once.
+///
+/// [`CpuId`]: crate::cpu::CpuId
 pub(crate) fn construct_hw_cpu_id_mapping() -> Box<[HwCpuId]> {
     let mut hw_cpu_id_map = HW_CPU_ID_MAP.lock();
     assert_eq!(hw_cpu_id_map.len(), crate::cpu::num_cpus());

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -5,7 +5,7 @@
 //! This module provides a mechanism to define CPU-local objects. Users can
 //! define a statically-allocated CPU-local object by the macro
 //! [`crate::cpu_local!`], or allocate a dynamically-allocated CPU-local
-//! object with the function [`osdk_heap_allocator::alloc_cpu_local`].
+//! object with the function `osdk_heap_allocator::alloc_cpu_local`.
 //!
 //! The mechanism for statically-allocated CPU-local objects exploits the fact
 //! that constant values of non-[`Copy`] types can be bitwise copied. For

--- a/ostd/src/cpu/mod.rs
+++ b/ostd/src/cpu/mod.rs
@@ -138,6 +138,9 @@ unsafe fn set_this_cpu_id(id: u32) {
 ///
 /// The implementor must ensure that the current task is pinned to the current
 /// CPU while any one of the instances of the implemented structure exists.
+///
+/// [`DisabledLocalIrqGuard`]: crate::trap::irq::DisabledLocalIrqGuard
+/// [`DisabledPreemptGuard`]: crate::task::DisabledPreemptGuard
 pub unsafe trait PinCurrentCpu {
     /// Returns the ID of the current CPU.
     fn current_cpu(&self) -> CpuId {

--- a/ostd/src/io/io_port/mod.rs
+++ b/ostd/src/io/io_port/mod.rs
@@ -125,7 +125,7 @@ macro_rules! reserve_io_port_range {
 /// - The I/O port is used by the target system device driver.
 ///
 /// # Example
-/// ``` norun
+/// ```no_run
 /// sensitive_io_port! {
 ///     unsafe {
 ///         /// Master PIC command port

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -68,7 +68,7 @@ use crate::{
 /// assert_eq!(cursor.current_meta().unwrap().mark, 1);
 /// ```
 ///
-/// [`from_in_use`]: Frame::from_in_use
+/// [`from_in_use`]: super::Frame::from_in_use
 pub struct LinkedList<M>
 where
     Link<M>: AnyFrameMeta,

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -3,8 +3,9 @@
 //! Metadata management of frames.
 //!
 //! You can picture a globally shared, static, gigantic array of metadata
-//! initialized for each frame. An entry in the array is called a [`MetaSlot`],
-//! which contains the metadata of a frame. There would be a dedicated small
+//! initialized for each frame.
+//! Each entry in this array holds the metadata for a single frame.
+//! There would be a dedicated small
 //! "heap" space in each slot for dynamic metadata. You can store anything as
 //! the metadata of a frame as long as it's [`Sync`].
 //!
@@ -106,6 +107,7 @@ pub(in crate::mm) struct MetaSlot {
     ///
     /// [`Frame::from_unused`]: super::Frame::from_unused
     /// [`UniqueFrame`]: super::unique::UniqueFrame
+    /// [`drop_last_in_place`]: Self::drop_last_in_place
     //
     // Other than this field the fields should be `MaybeUninit`.
     // See initialization in `alloc_meta_frames`.

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -23,7 +23,7 @@
 //!    "alias XOR mutability" rule.
 //!
 //! The kind of a frame is determined by the type of its metadata. Untyped
-//! frames have its metadata type that implements the [`UntypedFrameMeta`]
+//! frames have its metadata type that implements the [`AnyUFrameMeta`]
 //! trait, while typed frames don't.
 //!
 //! Frames can have dedicated metadata, which is implemented in the [`meta`]

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -11,7 +11,7 @@ pub type Paddr = usize;
 pub(crate) mod dma;
 pub mod frame;
 pub mod heap;
-mod io;
+pub mod io;
 pub(crate) mod kspace;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -5,9 +5,8 @@
 //! The [`VmSpace`] struct is provided to manage the virtual memory space of a
 //! user. Cursors are used to traverse and modify over the virtual memory space
 //! concurrently. The VM space cursor [`self::Cursor`] is just a wrapper over
-//! the page table cursor [`super::page_table::Cursor`], providing efficient,
-//! powerful concurrent accesses to the page table, and suffers from the same
-//! validity concerns as described in [`super::page_table::cursor`].
+//! the page table cursor, providing efficient, powerful concurrent accesses
+//! to the page table.
 
 use core::{ops::Range, sync::atomic::Ordering};
 


### PR DESCRIPTION
Fixes #2174.
Fixes #2141.

This PR introduces two GitHub Actions workflows for documentation management and adds associated fixes:

1. The first commit implements a workflow to automatically publish OSTD API documentation to our self-hosted documentation site. The changes in this commit are mostly picked from #912.

2. The second commit implements a workflow that checks warning-free documentation builds. This is achieved by setting `RUSTDOCFLAGS="-Dwarnings"` to treat documentation warnings as errors.

3)  The third and fourth commits resolve several documentation generation issues.
