### PR TITLE
Cleanup dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,73 +1188,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1323,8 +1260,6 @@ dependencies = [
  "linux-boot-params",
  "log",
  "multiboot2",
- "num",
- "num-derive",
  "num-traits",
  "ostd-macros",
  "ostd-pod",

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -27,8 +27,6 @@ int-to-c-enum = { path = "../kernel/libs/int-to-c-enum", version = "0.1.0" }
 intrusive-collections = { version = "0.9.6", features = ["nightly"] }
 linux-boot-params = { version = "0.15.2", path = "libs/linux-bzimage/boot-params" }
 log = "0.4"
-num = { version = "0.4", default-features = false }
-num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 ostd-macros = { version = "0.15.2", path = "libs/ostd-macros" }
 ostd-test = { version = "0.15.2", path = "libs/ostd-test" }

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -11,9 +11,8 @@ use core::{
 
 use bitflags::bitflags;
 use cfg_if::cfg_if;
+use int_to_c_enum::TryFromInt;
 use log::debug;
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use spin::Once;
 use x86::bits64::segmentation::wrfsbase;
 use x86_64::registers::{
@@ -250,7 +249,8 @@ macro_rules! define_cpu_exception {
     ( $([ $name: ident = $exception_id:tt, $exception_type:tt]),* ) => {
         /// CPU exception.
         #[expect(non_camel_case_types)]
-        #[derive(Debug, Copy, Clone, Eq, PartialEq, FromPrimitive)]
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, TryFromInt)]
+        #[repr(u16)]
         pub enum CpuException {
             $(
                 #[doc = concat!("The ", stringify!($name), " exception")]
@@ -340,7 +340,7 @@ impl CpuException {
 
     /// Maps a `trap_num` to its corresponding CPU exception.
     pub fn to_cpu_exception(trap_num: u16) -> Option<CpuException> {
-        FromPrimitive::from_u16(trap_num)
+        CpuException::try_from(trap_num).ok()
     }
 }
 


### PR DESCRIPTION
This PR cleans up the project dependencies. 

1.**The first commit removes the num crate dependency from OSTD**, as the int-to-c-enum crate can fulfill the same purpose. This helps reduce the TCB.

~2. **The second commit moves the align_ext, id_alloc, and int-to-c-enum crates to separate repositories under the Asterinas organization**. These crates also need to be published to crates.io because they serve as dependencies for OSTD. However, our current publishing workflow does not include these crates. If anyone modifies them, there is currently no mechanism in place to notify us that a new version should be published. By moving these crates to their own repositories, contributors can submit pull requests directly to those projects. Once a new version is published on crates.io, the main repository can then update its dependencies accordingly.~