### PR TITLE
Fix minor issues of the CPU extension module

### DIFF
--- a/ostd/src/arch/riscv/cpu/extension.rs
+++ b/ostd/src/arch/riscv/cpu/extension.rs
@@ -7,7 +7,7 @@ use spin::Once;
 
 use crate::arch::boot::DEVICE_TREE;
 
-/// Detect available RISC-V ISA extensions.
+/// Detects available RISC-V ISA extensions.
 pub fn init() {
     let mut global_isa_extensions = IsaExtensions::all();
 
@@ -36,7 +36,7 @@ pub fn init() {
     GLOBAL_ISA_EXTENSIONS.call_once(|| global_isa_extensions);
 }
 
-/// Check if the specified set of ISA extensions are available.
+/// Checks if the specified set of ISA extensions are available.
 pub fn has_extensions(required: IsaExtensions) -> bool {
     GLOBAL_ISA_EXTENSIONS.get().unwrap().contains(required)
 }
@@ -99,7 +99,7 @@ fn parse_isa_extensions_list(isa_extensions: &fdt::node::NodeProperty) -> IsaExt
 
 static GLOBAL_ISA_EXTENSIONS: Once<IsaExtensions> = Once::new();
 
-/// Macro for RISC-V ISA extension definition and lookup table generation
+/// A macro for RISC-V ISA extension definition and lookup table generation.
 macro_rules! define_isa_extensions {
     (
         $(
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_string_with_basic() {
+    fn isa_string_with_basic() {
         let result = parse_isa_string_wrapper("rv64imafdc_zicsr_zifencei");
         assert!(result.contains(IsaExtensions::I));
         assert!(result.contains(IsaExtensions::M));
@@ -285,7 +285,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_string_edge_cases() {
+    fn isa_string_edge_cases() {
         // Empty string
         let result = parse_isa_string_wrapper("");
         assert!(result.is_empty());
@@ -308,7 +308,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_string_unknown_extensions() {
+    fn isa_string_unknown_extensions() {
         // Should ignore unknown extensions without crashing
         let result = parse_isa_string_wrapper("rv64imafdc_zunknown_zicsr_zifencei");
         assert!(result.contains(IsaExtensions::I));
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_extensions_list_basic() {
+    fn isa_extensions_list_basic() {
         let result =
             parse_isa_extensions_list_wrapper(&["i", "m", "a", "f", "d", "c", "zicsr", "zifencei"]);
         assert!(result.contains(IsaExtensions::I));
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_extensions_list_edge_cases() {
+    fn isa_extensions_list_edge_cases() {
         // Empty list
         let result = parse_isa_extensions_list_wrapper(&[]);
         assert!(result.is_empty());
@@ -354,7 +354,7 @@ mod tests {
     }
 
     #[ktest]
-    fn test_isa_extensions_list_unknown_extensions() {
+    fn isa_extensions_list_unknown_extensions() {
         // Should ignore unknown extensions without crashing
         let result = parse_isa_extensions_list_wrapper(&[
             "i", "m", "a", "f", "d", "c", "zunknown", "zicsr", "zifencei",

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -5,5 +5,3 @@
 pub mod context;
 pub mod extension;
 pub mod local;
-
-pub use extension::{has_extensions, IsaExtensions};

--- a/ostd/src/arch/riscv/timer/mod.rs
+++ b/ostd/src/arch/riscv/timer/mod.rs
@@ -9,7 +9,7 @@ use core::{
 
 use crate::{
     arch::{self, boot::DEVICE_TREE},
-    cpu::{CpuId, IsaExtensions, PinCurrentCpu},
+    cpu::{extension::IsaExtensions, CpuId, PinCurrentCpu},
     timer::INTERRUPT_CALLBACKS,
     trap,
 };
@@ -107,7 +107,7 @@ fn set_next_timer_sstc() {
 }
 
 fn is_sstc_enabled() -> bool {
-    arch::cpu::has_extensions(IsaExtensions::SSTC)
+    arch::cpu::extension::has_extensions(IsaExtensions::SSTC)
 }
 
 fn get_next_when() -> u64 {


### PR DESCRIPTION
Several minor issues:
 - [The summary line should be written in third person singular present indicative form. Basically, this means write “Returns” instead of “Return”.](https://rust-lang.github.io/rfcs/0505-api-comment-conventions.html#formatting)
 - [Don't add the `test_` prefix when naming unit tests.](https://github.com/asterinas/asterinas/issues/1762)
 - Avoid public re-exports from public modules, otherwise there will be two ways to name the same item.

A bigger issue that is not addressed in this PR is how to unify the two styles used in the RISC-V and x86-64 architectures, respectively.
https://github.com/asterinas/asterinas/blob/49ef0e9f7aa7606ab62387e231f679197572cf28/ostd/src/arch/x86/cpu/context/mod.rs#L466
https://github.com/asterinas/asterinas/blob/49ef0e9f7aa7606ab62387e231f679197572cf28/ostd/src/arch/riscv/timer/mod.rs#L110