### PR TITLE
Clean up visibility and re-exports of `trapframe` types under `arch::trap`

### DIFF
--- a/kernel/comps/keyboard/src/i8042_chip/keyboard.rs
+++ b/kernel/comps/keyboard/src/i8042_chip/keyboard.rs
@@ -5,8 +5,11 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use ostd::{
-    arch::kernel::{MappedIrqLine, IRQ_CHIP},
-    trap::{irq::IrqLine, TrapFrame},
+    arch::{
+        kernel::{MappedIrqLine, IRQ_CHIP},
+        trap::TrapFrame,
+    },
+    trap::irq::IrqLine,
 };
 use spin::Once;
 

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -18,9 +18,9 @@ use aster_block::{
 use id_alloc::IdAlloc;
 use log::{debug, info};
 use ostd::{
+    arch::trap::TrapFrame,
     mm::{DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions, VmIo},
     sync::SpinLock,
-    trap::TrapFrame,
     Pod,
 };
 

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -6,9 +6,9 @@ use core::hint::spin_loop;
 use aster_console::{AnyConsoleDevice, ConsoleCallback};
 use log::debug;
 use ostd::{
+    arch::trap::TrapFrame,
     mm::{DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions, VmReader},
     sync::{Rcu, SpinLock},
-    trap::TrapFrame,
 };
 
 use super::{config::VirtioConsoleConfig, DEVICE_NAME};

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -16,10 +16,10 @@ use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use log::{debug, info};
 use ostd::{
+    arch::trap::TrapFrame,
     io::IoMem,
     mm::{DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, VmIo, PAGE_SIZE},
     sync::{LocalIrqDisabled, RwLock, SpinLock},
-    trap::TrapFrame,
 };
 
 use super::{InputConfigSelect, VirtioInputConfig, VirtioInputEvent, QUEUE_EVENT, QUEUE_STATUS};

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -12,7 +12,7 @@ use aster_network::{
 use aster_softirq::BottomHalfDisabled;
 use aster_util::slot_vec::SlotVec;
 use log::{debug, warn};
-use ostd::{mm::DmaStream, sync::SpinLock, trap::TrapFrame};
+use ostd::{arch::trap::TrapFrame, mm::DmaStream, sync::SpinLock};
 
 use super::{config::VirtioNetConfig, header::VirtioNetHdr};
 use crate::{

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -6,7 +6,7 @@ use core::{fmt::Debug, hint::spin_loop, mem::size_of};
 use aster_network::{RxBuffer, TxBuffer};
 use aster_util::{field_ptr, slot_vec::SlotVec};
 use log::debug;
-use ostd::{mm::VmWriter, sync::SpinLock, trap::TrapFrame, Pod};
+use ostd::{arch::trap::TrapFrame, mm::VmWriter, sync::SpinLock, Pod};
 
 use super::{
     config::{VirtioVsockConfig, VsockFeatures},

--- a/kernel/comps/virtio/src/transport/mmio/multiplex.rs
+++ b/kernel/comps/virtio/src/transport/mmio/multiplex.rs
@@ -6,12 +6,10 @@ use core::fmt::Debug;
 use aster_rights::{ReadOp, TRightSet, WriteOp};
 use aster_util::safe_ptr::SafePtr;
 use ostd::{
+    arch::trap::TrapFrame,
     io::IoMem,
     sync::RwLock,
-    trap::{
-        irq::{IrqCallbackFunction, IrqLine},
-        TrapFrame,
-    },
+    trap::irq::{IrqCallbackFunction, IrqLine},
 };
 
 /// Multiplexing Irqs. The two interrupt types (configuration space change and queue interrupt)

--- a/kernel/src/arch/riscv/cpu.rs
+++ b/kernel/src/arch/riscv/cpu.rs
@@ -3,7 +3,7 @@
 use alloc::{format, string::String};
 
 use ostd::{
-    cpu::context::{CpuExceptionInfo, RawGeneralRegs, UserContext},
+    cpu::context::{CpuExceptionInfo, GeneralRegs, UserContext},
     Pod,
 };
 
@@ -122,11 +122,11 @@ macro_rules! copy_gp_regs {
 }
 
 impl GpRegs {
-    pub fn copy_to_raw(&self, dst: &mut RawGeneralRegs) {
+    pub fn copy_to_raw(&self, dst: &mut GeneralRegs) {
         copy_gp_regs!(self, dst);
     }
 
-    pub fn copy_from_raw(&mut self, src: &RawGeneralRegs) {
+    pub fn copy_from_raw(&mut self, src: &GeneralRegs) {
         copy_gp_regs!(src, self);
     }
 }

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -7,7 +7,7 @@ use alloc::{
 };
 
 use ostd::{
-    cpu::context::{cpuid, CpuException, CpuExceptionInfo, RawGeneralRegs, UserContext},
+    cpu::context::{cpuid, CpuException, CpuExceptionInfo, GeneralRegs, UserContext},
     Pod,
 };
 
@@ -102,11 +102,11 @@ macro_rules! copy_gp_regs {
 }
 
 impl GpRegs {
-    pub fn copy_to_raw(&self, dst: &mut RawGeneralRegs) {
+    pub fn copy_to_raw(&self, dst: &mut GeneralRegs) {
         copy_gp_regs!(self, dst);
     }
 
-    pub fn copy_from_raw(&mut self, src: &RawGeneralRegs) {
+    pub fn copy_from_raw(&mut self, src: &GeneralRegs) {
         copy_gp_regs!(src, self);
     }
 }

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -2,7 +2,7 @@
 
 use aster_rights::WriteOp;
 use ostd::{
-    cpu::context::{FpuState, RawGeneralRegs, UserContext},
+    cpu::context::{FpuState, GeneralRegs, UserContext},
     user::UserContextApi,
 };
 
@@ -149,7 +149,7 @@ fn do_execve(
     // set signal disposition to default
     process.sig_dispositions().lock().inherit();
     // set cpu context to default
-    *user_context.general_regs_mut() = RawGeneralRegs::default();
+    *user_context.general_regs_mut() = GeneralRegs::default();
     user_context.set_tls_pointer(0);
     *user_context.fpu_state_mut() = FpuState::default();
     // FIXME: how to reset the FPU state correctly? Before returning to the user space,

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -6,16 +6,15 @@ use core::fmt::Debug;
 
 use riscv::register::scause::{Exception, Interrupt, Trap};
 
-pub use crate::arch::trap::GeneralRegs as RawGeneralRegs;
 use crate::{
     arch::{
         timer::handle_timer_interrupt,
-        trap::{TrapFrame, UserContext as RawUserContext},
+        trap::{RawUserContext, TrapFrame},
     },
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 
-/// Cpu context, including both general-purpose registers and FPU state.
+/// Userspace CPU context, including both general-purpose registers and FPU state.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct UserContext {
@@ -23,6 +22,45 @@ pub struct UserContext {
     trap: Trap,
     fpu_state: FpuState,
     cpu_exception_info: CpuExceptionInfo,
+}
+
+/// General registers.
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct GeneralRegs {
+    pub zero: usize,
+    pub ra: usize,
+    pub sp: usize,
+    pub gp: usize,
+    pub tp: usize,
+    pub t0: usize,
+    pub t1: usize,
+    pub t2: usize,
+    pub s0: usize,
+    pub s1: usize,
+    pub a0: usize,
+    pub a1: usize,
+    pub a2: usize,
+    pub a3: usize,
+    pub a4: usize,
+    pub a5: usize,
+    pub a6: usize,
+    pub a7: usize,
+    pub s2: usize,
+    pub s3: usize,
+    pub s4: usize,
+    pub s5: usize,
+    pub s6: usize,
+    pub s7: usize,
+    pub s8: usize,
+    pub s9: usize,
+    pub s10: usize,
+    pub s11: usize,
+    pub t3: usize,
+    pub t4: usize,
+    pub t5: usize,
+    pub t6: usize,
 }
 
 /// CPU exception information.
@@ -66,12 +104,12 @@ impl CpuExceptionInfo {
 
 impl UserContext {
     /// Returns a reference to the general registers.
-    pub fn general_regs(&self) -> &RawGeneralRegs {
+    pub fn general_regs(&self) -> &GeneralRegs {
         &self.user_context.general
     }
 
     /// Returns a mutable reference to the general registers
-    pub fn general_regs_mut(&mut self) -> &mut RawGeneralRegs {
+    pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
         &mut self.user_context.general
     }
 
@@ -166,15 +204,15 @@ impl UserContextApi for UserContext {
     }
 
     fn set_instruction_pointer(&mut self, ip: usize) {
-        self.user_context.set_ip(ip);
+        self.user_context.sepc = ip;
     }
 
     fn stack_pointer(&self) -> usize {
-        self.user_context.get_sp()
+        self.sp()
     }
 
     fn set_stack_pointer(&mut self, sp: usize) {
-        self.user_context.set_sp(sp);
+        self.set_sp(sp);
     }
 }
 

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -6,7 +6,8 @@ mod trap;
 
 use riscv::register::scause::Interrupt;
 use spin::Once;
-pub use trap::{GeneralRegs, TrapFrame, UserContext};
+pub(super) use trap::RawUserContext;
+pub use trap::TrapFrame;
 
 use super::cpu::context::CpuExceptionInfo;
 use crate::cpu_local_cell;
@@ -15,8 +16,8 @@ cpu_local_cell! {
     static IS_KERNEL_INTERRUPTED: bool = false;
 }
 
-/// Initialize interrupt handling on RISC-V.
-pub unsafe fn init() {
+/// Initializes interrupt handling on RISC-V.
+pub(crate) unsafe fn init() {
     self::trap::init();
 }
 

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -16,7 +16,7 @@
 
 use core::arch::{asm, global_asm};
 
-use crate::Pod;
+use crate::arch::cpu::context::GeneralRegs;
 
 #[cfg(target_arch = "riscv32")]
 global_asm!(
@@ -86,136 +86,29 @@ pub struct TrapFrame {
 }
 
 /// Saved registers on a trap.
-#[derive(Debug, Default, Clone, Copy, Pod)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
-pub struct UserContext {
+pub(in crate::arch) struct RawUserContext {
     /// General registers
-    pub general: GeneralRegs,
+    pub(in crate::arch) general: GeneralRegs,
     /// Supervisor Status
-    pub sstatus: usize,
+    pub(in crate::arch) sstatus: usize,
     /// Supervisor Exception Program Counter
-    pub sepc: usize,
+    pub(in crate::arch) sepc: usize,
 }
 
-impl UserContext {
-    /// Go to user space with the context, and come back when a trap occurs.
+impl RawUserContext {
+    /// Goes to user space with the context, and comes back when a trap occurs.
     ///
     /// On return, the context will be reset to the status before the trap.
-    /// Trap reason and error code will be returned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use trapframe::{UserContext, GeneralRegs};
-    ///
-    /// // init user space context
-    /// let mut context = UserContext {
-    ///     general: GeneralRegs {
-    ///         sp: 0x10000,
-    ///         ..Default::default()
-    ///     },
-    ///     sepc: 0x1000,
-    ///     ..Default::default()
-    /// };
-    /// // go to user
-    /// context.run();
-    /// // back from user
-    /// println!("back from user: {:#x?}", context);
-    /// ```
-    pub fn run(&mut self) {
+    /// Trap reason and error code will be placed at `scause` and `stval`.
+    pub(in crate::arch) fn run(&mut self) {
         unsafe { run_user(self) }
-    }
-}
-
-/// General registers
-#[derive(Debug, Default, Clone, Copy, Pod)]
-#[repr(C)]
-#[expect(missing_docs)]
-pub struct GeneralRegs {
-    pub zero: usize,
-    pub ra: usize,
-    pub sp: usize,
-    pub gp: usize,
-    pub tp: usize,
-    pub t0: usize,
-    pub t1: usize,
-    pub t2: usize,
-    pub s0: usize,
-    pub s1: usize,
-    pub a0: usize,
-    pub a1: usize,
-    pub a2: usize,
-    pub a3: usize,
-    pub a4: usize,
-    pub a5: usize,
-    pub a6: usize,
-    pub a7: usize,
-    pub s2: usize,
-    pub s3: usize,
-    pub s4: usize,
-    pub s5: usize,
-    pub s6: usize,
-    pub s7: usize,
-    pub s8: usize,
-    pub s9: usize,
-    pub s10: usize,
-    pub s11: usize,
-    pub t3: usize,
-    pub t4: usize,
-    pub t5: usize,
-    pub t6: usize,
-}
-
-impl UserContext {
-    /// Get number of syscall
-    pub fn get_syscall_num(&self) -> usize {
-        self.general.a7
-    }
-
-    /// Get return value of syscall
-    pub fn get_syscall_ret(&self) -> usize {
-        self.general.a0
-    }
-
-    /// Set return value of syscall
-    pub fn set_syscall_ret(&mut self, ret: usize) {
-        self.general.a0 = ret;
-    }
-
-    /// Get syscall args
-    pub fn get_syscall_args(&self) -> [usize; 6] {
-        [
-            self.general.a0,
-            self.general.a1,
-            self.general.a2,
-            self.general.a3,
-            self.general.a4,
-            self.general.a5,
-        ]
-    }
-
-    /// Set instruction pointer
-    pub fn set_ip(&mut self, ip: usize) {
-        self.sepc = ip;
-    }
-
-    /// Set stack pointer
-    pub fn set_sp(&mut self, sp: usize) {
-        self.general.sp = sp;
-    }
-
-    /// Get stack pointer
-    pub fn get_sp(&self) -> usize {
-        self.general.sp
-    }
-
-    /// Set tls pointer
-    pub fn set_tls(&mut self, tls: usize) {
-        self.general.gp = tls;
     }
 }
 
 #[expect(improper_ctypes)]
 extern "C" {
     fn trap_entry();
-    fn run_user(regs: &mut UserContext);
+    fn run_user(regs: &mut RawUserContext);
 }

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -22,7 +22,10 @@ use x86_64::registers::{
 };
 
 use crate::{
-    arch::CPU_FEATURES,
+    arch::{
+        trap::{RawUserContext, TrapFrame},
+        CPU_FEATURES,
+    },
     task::scheduler,
     trap::call_irq_callback_functions,
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
@@ -38,17 +41,40 @@ cfg_if! {
 
 pub use x86::cpuid;
 
-pub use crate::arch::trap::{
-    GeneralRegs as RawGeneralRegs, TrapFrame, UserContext as RawUserContext,
-};
-
-/// Cpu context, including both general-purpose registers and FPU state.
+/// Userspace CPU context, including both general-purpose registers and FPU state.
 #[derive(Clone, Default, Debug)]
 #[repr(C)]
 pub struct UserContext {
     user_context: RawUserContext,
     fpu_state: FpuState,
     cpu_exception_info: CpuExceptionInfo,
+}
+
+/// General registers.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct GeneralRegs {
+    pub rax: usize,
+    pub rbx: usize,
+    pub rcx: usize,
+    pub rdx: usize,
+    pub rsi: usize,
+    pub rdi: usize,
+    pub rbp: usize,
+    pub rsp: usize,
+    pub r8: usize,
+    pub r9: usize,
+    pub r10: usize,
+    pub r11: usize,
+    pub r12: usize,
+    pub r13: usize,
+    pub r14: usize,
+    pub r15: usize,
+    pub rip: usize,
+    pub rflags: usize,
+    pub fsbase: usize,
+    pub gsbase: usize,
 }
 
 /// CPU exception information.
@@ -65,12 +91,12 @@ pub struct CpuExceptionInfo {
 
 impl UserContext {
     /// Returns a reference to the general registers.
-    pub fn general_regs(&self) -> &RawGeneralRegs {
+    pub fn general_regs(&self) -> &GeneralRegs {
         &self.user_context.general
     }
 
     /// Returns a mutable reference to the general registers
-    pub fn general_regs_mut(&mut self) -> &mut RawGeneralRegs {
+    pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
         &mut self.user_context.general
     }
 

--- a/ostd/src/arch/x86/cpu/context/tdx.rs
+++ b/ostd/src/arch/x86/cpu/context/tdx.rs
@@ -4,7 +4,7 @@ use tdx_guest::{
     handle_virtual_exception as do_handle_virtual_exception, tdcall, TdgVeInfo, TdxTrapFrame,
 };
 
-use crate::cpu::context::{RawGeneralRegs, UserContext};
+use super::{GeneralRegs, UserContext};
 
 pub(crate) struct VirtualizationExceptionHandler {
     ve_info: TdgVeInfo,
@@ -34,7 +34,7 @@ impl VirtualizationExceptionHandler {
     }
 }
 
-struct GeneralRegsWrapper<'a>(&'a mut RawGeneralRegs);
+struct GeneralRegsWrapper<'a>(&'a mut GeneralRegs);
 
 impl TdxTrapFrame for GeneralRegsWrapper<'_> {
     fn rax(&self) -> usize {

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -10,8 +10,9 @@ use volatile::{access::ReadWrite, VolatileRef};
 
 use super::registers::Capability;
 use crate::{
+    arch::trap::TrapFrame,
     sync::{LocalIrqDisabled, SpinLock},
-    trap::{irq::IrqLine, TrapFrame},
+    trap::irq::IrqLine,
 };
 
 #[derive(Debug)]

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -8,11 +8,14 @@ use log::info;
 use x86::cpuid::cpuid;
 
 use crate::{
-    arch::timer::{
-        pit::{self, OperatingMode},
-        TIMER_FREQ,
+    arch::{
+        timer::{
+            pit::{self, OperatingMode},
+            TIMER_FREQ,
+        },
+        trap::TrapFrame,
     },
-    trap::{irq::IrqLine, TrapFrame},
+    trap::irq::IrqLine,
 };
 
 /// The frequency of TSC(Hz)

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -3,6 +3,7 @@
 use log::warn;
 use tdx_guest::{tdcall::accept_page, tdvmcall::map_gpa, TdxTrapFrame};
 
+use super::trap::TrapFrame;
 use crate::{
     mm::{
         kspace::KERNEL_PAGE_TABLE,
@@ -12,7 +13,6 @@ use crate::{
         PAGE_SIZE,
     },
     prelude::Paddr,
-    trap::TrapFrame,
 };
 
 const SHARED_BIT: u8 = 51;

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -9,10 +9,11 @@ use crate::{
     arch::{
         kernel::apic::{self, Apic, DivideConfig},
         timer::pit::OperatingMode,
+        trap::TrapFrame,
         tsc_freq,
     },
     task::disable_preempt,
-    trap::{irq::IrqLine, TrapFrame},
+    trap::irq::IrqLine,
 };
 
 /// Initializes APIC with TSC-deadline mode or periodic mode.

--- a/ostd/src/arch/x86/timer/mod.rs
+++ b/ostd/src/arch/x86/timer/mod.rs
@@ -10,11 +10,12 @@ use core::sync::atomic::Ordering;
 
 use spin::Once;
 
+use super::trap::TrapFrame;
 use crate::{
     arch::kernel,
     cpu::{CpuId, PinCurrentCpu},
     timer::INTERRUPT_CALLBACKS,
-    trap::{self, irq::IrqLine, TrapFrame},
+    trap::{self, irq::IrqLine},
 };
 
 /// The timer frequency (Hz).

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -10,11 +10,14 @@ use alloc::{boxed::Box, collections::VecDeque};
 use spin::Once;
 
 use crate::{
-    arch::irq::{send_ipi, HwCpuId},
+    arch::{
+        irq::{send_ipi, HwCpuId},
+        trap::TrapFrame,
+    },
     cpu::{CpuSet, PinCurrentCpu},
     cpu_local,
     sync::SpinLock,
-    trap::{self, irq::IrqLine, TrapFrame},
+    trap::{self, irq::IrqLine},
 };
 
 /// Executes a function on other processors.

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -3,7 +3,7 @@
 use spin::Once;
 
 use super::irq::{disable_local, process_top_half, DisabledLocalIrqGuard};
-use crate::{cpu_local_cell, task::disable_preempt, trap::TrapFrame};
+use crate::{arch::trap::TrapFrame, cpu_local_cell, task::disable_preempt};
 
 static BOTTOM_HALF_HANDLER: Once<fn(DisabledLocalIrqGuard) -> DisabledLocalIrqGuard> = Once::new();
 

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -8,11 +8,13 @@ use id_alloc::IdAlloc;
 use spin::Once;
 
 use crate::{
-    arch::irq::{self, IrqRemapping, IRQ_NUM_MAX, IRQ_NUM_MIN},
+    arch::{
+        irq::{self, IrqRemapping, IRQ_NUM_MAX, IRQ_NUM_MIN},
+        trap::TrapFrame,
+    },
     prelude::*,
     sync::{GuardTransfer, RwLock, SpinLock, WriteIrqDisabled},
     task::atomic_mode::InAtomicMode,
-    trap::TrapFrame,
     Error,
 };
 

--- a/ostd/src/trap/mod.rs
+++ b/ostd/src/trap/mod.rs
@@ -7,5 +7,3 @@ pub mod irq;
 
 pub(crate) use handler::call_irq_callback_functions;
 pub use handler::{in_interrupt_context, register_bottom_half_handler};
-
-pub use crate::arch::trap::TrapFrame;

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -2,7 +2,7 @@
 
 //! User mode.
 
-use crate::{cpu::context::UserContext, trap::TrapFrame};
+use crate::{arch::trap::TrapFrame, cpu::context::UserContext};
 
 /// Specific architectures need to implement this trait. This should only used in [`UserMode`]
 ///


### PR DESCRIPTION
I believe that the types in `arch/*/trap/*` are mostly copied from `trapframe`. Their visibility and re-exports are a real mess. The PR proposes the following three changes to improve the current situation.

Change 1 (in the first commit):
 * Before this PR: public items, `arch::trap::GeneralRegs` == `arch::cpu::context::RawGeneralRegs`
 * After this PR: public item `arch::cpu::context::GeneralRegs`
   - Note that https://github.com/asterinas/asterinas/pull/2219 plans to rename [`GpRegs`](https://github.com/asterinas/asterinas/blob/49ef0e9f7aa7606ab62387e231f679197572cf28/kernel/src/arch/x86/cpu.rs#L56) to `SigContext`, so we may not need to worry about the name conflict between the `GeneralRegs` in OSTD and [the `GpRegs` in the Asterinas kernel](https://github.com/asterinas/asterinas/blob/49ef0e9f7aa7606ab62387e231f679197572cf28/kernel/src/arch/x86/cpu.rs#L56).

Change 2 (also in the first commit):
 * Before this PR: public items, `arch::trap::UserContext` == `arch::cpu::context::RawUserContext`
 * After this PR: private item `arch::trap::RawUserContext`

Change 3 (in the second commit):
 * Before this PR: public items, `arch::trap::TrapFrame` == `trap::TrapFrame`
 * After this PR: public item `arch::trap::TrapFrame`