### PR TITLE
Clarify the `DeviceId` encoding

### DIFF
--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -64,12 +64,7 @@ pub fn init() -> Result<()> {
 // Instead of hardcoding every device numbers in this function,
 // a registration mechanism should be used to allow each driver to
 // allocate device IDs either statically or dynamically.
-pub fn get_device(dev: usize) -> Result<Arc<dyn Device>> {
-    if dev == 0 {
-        return_errno_with_message!(Errno::EPERM, "whiteout device")
-    }
-
-    let devid = DeviceId::from(dev as u64);
+pub fn get_device(devid: DeviceId) -> Result<Arc<dyn Device>> {
     let major = devid.major();
     let minor = devid.minor();
 
@@ -79,6 +74,6 @@ pub fn get_device(dev: usize) -> Result<Arc<dyn Device>> {
         (5, 0) => Ok(Arc::new(tty::TtyDevice)),
         (1, 8) => Ok(Arc::new(random::Random)),
         (1, 9) => Ok(Arc::new(urandom::Urandom)),
-        _ => return_errno_with_message!(Errno::EINVAL, "unsupported device"),
+        _ => return_errno_with_message!(Errno::EINVAL, "the device ID is invalid or unsupported"),
     }
 }

--- a/kernel/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/ext2/impl_for_vfs/inode.rs
@@ -120,7 +120,7 @@ impl Inode for Ext2Inode {
         let inode = match type_ {
             MknodType::CharDeviceNode(dev) | MknodType::BlockDeviceNode(dev) => {
                 let inode = self.create(name, inode_type, mode.into())?;
-                inode.set_device_id(dev.id().into()).unwrap();
+                inode.set_device_id(dev.id().as_encoded_u64()).unwrap();
                 inode
             }
             _ => todo!(),

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -125,7 +125,7 @@ impl FileOps for StatFileOps {
 
         let (tty_nr, tpgid) = if let Some(terminal) = process.terminal() {
             (
-                terminal.id().as_encoded_u32(),
+                terminal.id().as_encoded_u64(),
                 terminal
                     .job_control()
                     .foreground()

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -1109,7 +1109,7 @@ impl Inode for RamInode {
         let rdev = self
             .inner
             .as_device()
-            .map(|device| device.id().into())
+            .map(|device| device.id().as_encoded_u64())
             .unwrap_or(0);
         let inode_metadata = self.metadata.lock();
         Metadata {

--- a/kernel/src/fs/utils/inode.rs
+++ b/kernel/src/fs/utils/inode.rs
@@ -294,7 +294,7 @@ impl Metadata {
             nlinks: 1,
             uid: Uid::new_root(),
             gid: Gid::new_root(),
-            rdev: device.id().into(),
+            rdev: device.id().as_encoded_u64(),
         }
     }
 

--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -4,6 +4,7 @@ use super::SyscallReturn;
 use crate::{
     device::get_device,
     fs::{
+        device::DeviceId,
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
         utils::{InodeMode, InodeType, MknodType},
@@ -49,7 +50,7 @@ pub fn sys_mknodat(
             let _ = dir_dentry.new_fs_child(&name, InodeType::File, inode_mode)?;
         }
         InodeType::CharDevice | InodeType::BlockDevice => {
-            let device_inode = get_device(dev)?;
+            let device_inode = get_device(DeviceId::from_encoded_u64(dev as u64))?;
             let _ = dir_dentry.mknod(&name, inode_mode, device_inode.into())?;
         }
         InodeType::NamedPipe => {

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -118,8 +118,8 @@ pub struct Statx {
 
 impl From<Metadata> for Statx {
     fn from(info: Metadata) -> Self {
-        let devid = DeviceId::from(info.dev);
-        let rdevid = DeviceId::from(info.rdev);
+        let devid = DeviceId::from_encoded_u64(info.dev);
+        let rdevid = DeviceId::from_encoded_u64(info.rdev);
 
         // FIXME: We assume it is always not mount_root.
         let stx_attributes = 0;

--- a/test/syscall_test/gvisor/blocklists/mknod_test
+++ b/test/syscall_test/gvisor/blocklists/mknod_test
@@ -1,6 +1,13 @@
-MknodTest.MknodAtFIFO
-MknodTest.MknodOnExistingPathFails
+# Broken support or no support at all.
 MknodTest.Socket
 MknodTest.Fifo
 MknodTest.FifoOtrunc
 MknodTest.FifoTruncNoOp
+
+# Buggy or unimplemented in exfat and ext2.
+MknodTest.MknodAtFIFO
+MknodTest.MknodOnExistingPathFails
+
+# This test cannot pass in Linux when run as root, and
+# it has been removed from the latest version of gVisor.
+MknodTest.UnimplementedTypesReturnError


### PR DESCRIPTION
As mentioned in the discussion at https://github.com/asterinas/asterinas/pull/2215#discussion_r2179302975, the current implementation of `DeviceId` is not ideal.

I have no idea how the `u64` encodings are derived, as I cannot find any clues in the Linux kernel:
https://github.com/asterinas/asterinas/blob/a13297ae4c0b445ae5e9fed8ed7ffa8c7d334621/kernel/src/fs/device.rs#L75-L83

After some investigation, I discovered that it's actually... [from glibc](https://github.com/bminor/glibc/blob/632d895f3e5d98162f77b9c3c1da4ec19968b671/bits/sysmacros.h#L26-L34)?

Anyway, let's at least ensure this knowledge persists by adding comments to the code:
```rust
    /// Encodes the device ID as a `u64` value.
    ///
    /// The lower 32 bits use the same encoding strategy as Linux. See the Linux implementation at:
    /// <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/include/linux/kdev_t.h#L39-L44>
    ///
    /// If the major or minor device number is too large, the additional bits will be recorded
    /// using the higher 32 bits. Note that as of 2025, the Linux kernel still has no support for
    /// 64-bit device IDs, so this encoding follows the implementation in glibc:
    /// <https://github.com/bminor/glibc/blob/632d895f3e5d98162f77b9c3c1da4ec19968b671/bits/sysmacros.h#L26-L34>
    pub fn as_encoded_u64(&self) -> u64;
```
