### PR TITLE
Add the support for loongarch in osdk

### DIFF
--- a/osdk/src/base_crate/loongarch64.ld.template
+++ b/osdk/src/base_crate/loongarch64.ld.template
@@ -1,0 +1,85 @@
+OUTPUT_ARCH(loongarch)
+ENTRY(_start)
+
+# The physical address where the kernel will start to be loaded.
+KERNEL_LMA = 0x80000000;
+
+# The virtual memory of the kernel mapping.
+KERNEL_VMA = 0x9000000080000000;
+
+KERNEL_VMA_OFFSET = KERNEL_VMA - KERNEL_LMA;
+
+SECTIONS
+{
+    . = KERNEL_VMA;
+
+    PROVIDE(__executable_start = .);
+    __kernel_start = .;
+
+    .text : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
+        *(.text.entry)
+        *(.text .text.*)
+        PROVIDE(__etext = .);
+    }
+
+    .rodata : AT(ADDR(.rodata) - KERNEL_VMA_OFFSET) { *(.rodata .rodata.*) }
+
+    .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__GNU_EH_FRAME_HDR = .);
+        KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
+    }
+    . = ALIGN(8);
+    .eh_frame               : AT(ADDR(.eh_frame) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__eh_frame = .);
+        KEEP(*(.eh_frame .eh_frame.*))
+    }
+
+    # The list of unit test function symbols that should be executed while
+    # doing `cargo osdk test`.
+    .ktest_array            : AT(ADDR(.ktest_array) - KERNEL_VMA_OFFSET) {
+        __ktest_array = .;
+        KEEP(*(SORT(.ktest_array)))
+        __ktest_array_end = .;
+    }
+
+    .init_array             : AT(ADDR(.init_array) - KERNEL_VMA_OFFSET) {
+        __sinit_array = .;
+        KEEP(*(SORT(.init_array .init_array.*)))
+        __einit_array = .;
+    }
+    
+    # A list of the sensitive IoPort ranges in OSTD which will be used during
+    # the initialization of IoPortAllocator.
+    .sensitive_io_ports     : AT(ADDR(.sensitive_io_ports) - KERNEL_VMA_OFFSET) {
+        __sensitive_io_ports_start = .;
+        KEEP(*(.sensitive_io_ports))
+        __sensitive_io_ports_end = .;
+    }
+
+    . = DATA_SEGMENT_RELRO_END(0, .);
+
+    .data : AT(ADDR(.data) - KERNEL_VMA_OFFSET) { *(.data .data.*) }
+
+    # The CPU local data storage. It is readable and writable for the bootstrap
+    # processor, while it would be copied to other dynamically allocated memory
+    # areas for the application processors.
+    .cpu_local              : AT(ADDR(.cpu_local) - KERNEL_VMA_OFFSET) {
+        __cpu_local_start = .;
+        KEEP(*(SORT(.cpu_local)))
+        __cpu_local_end = .;
+    }
+
+    /* boot stack (in entry.S) */
+    .stack : AT(ADDR(.stack) - KERNEL_VMA_OFFSET) {
+        *(.bss.stack)
+    }
+
+    .bss : AT(ADDR(.bss) - KERNEL_VMA_OFFSET) {
+        __bss = .;
+        *(.bss .bss.*)
+        __bss_end = .;
+    }
+
+    . = DATA_SEGMENT_END(.);
+    __kernel_end = .;
+}

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -174,7 +174,7 @@ fn do_new_base_crate(
     }
     // TODO: currently just x86_64 works; add support for other architectures
     // here when OSTD is ready
-    include_linker_script!(["x86_64.ld", "riscv64.ld"]);
+    include_linker_script!(["x86_64.ld", "riscv64.ld", "loongarch64.ld"]);
 
     // Overwrite the main.rs file
     let main_rs = include_str!("main.rs.template");

--- a/osdk/src/commands/launch.json.template
+++ b/osdk/src/commands/launch.json.template
@@ -7,6 +7,18 @@
             "request": "custom",
             "targetCreateCommands": ["target create ${workspaceFolder}/target/osdk/#CRATE_NAME#/#BIN_NAME#"],
             "processCreateCommands": ["gdb-remote #ADDR_PORT#"]
+        },
+        {
+            "type": "gdb",
+            "request": "attach",
+            "name": "Debug Asterinas(#PROFILE#) for LoongArch",
+            "executable": "${workspaceFolder}/target/osdk/#CRATE_NAME#/#BIN_NAME#",
+            "target": ":#ADDR_PORT#",
+            "remote": true,
+            "cwd": "${workspaceRoot}",
+            "gdbpath": "loongarch64-linux-gnu-gdb",
+            "valuesFormatting": "parseText",
+            "stopAtConnect": true
         }
     ]
 }


### PR DESCRIPTION
首先在`osdk`中添加对`LoongArch`架构的支持。

我们在`osdk/src/base_crate/loongarch64.ld.template`中添加LoongArch的链接脚本。在该链接脚本中，我们主要关注如下部分

```plain
# The physical address where the kernel will start to be loaded.
KERNEL_LMA = 0x80000000;

# The virtual memory of the kernel mapping.
KERNEL_VMA = 0x9000000080000000;
```

它告诉我们内核被加载到物理地址为`0x80000000`的地方。但是代码中使用的地址为虚拟地址，起始为`0x9000000080000000`。这个虚拟地址之后在ostd中会设置为LoongArch中的直接映射窗口。

之前的插件不支持对LoongArch架构的调试。所以我们引入了另一个插件进行可视化调试。具体使用方法为：在`VSCode`中安装`Native Debug`插件，然后重启`VSCode`。