### PR TITLE
Test SMP LTP CI

### DIFF
--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -694,3 +694,5 @@ fn try_merge(left: &VmMapping, right: &VmMapping) -> Option<VmMapping> {
         ..*left
     })
 }
+
+// Please ignore this PR.


### PR DESCRIPTION
This PR is used to check what CI failures in https://github.com/asterinas/asterinas/issues/2217 still exist.

**Please just ignore this PR.**