### PR TITLE
Fix benchmark CI errors

### DIFF
--- a/test/nix/default.nix
+++ b/test/nix/default.nix
@@ -9,7 +9,9 @@ let
   else
     throw "Target arch ${target} not yet supported.";
 
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-25.05";
+  # Pinned nixpkgs (nix version: 2.29.1, channel: nixos-25.05, release date: 2025-07-01)
+  nixpkgs = fetchTarball
+    "https://github.com/NixOS/nixpkgs/archive/c0bebd16e69e631ac6e52d6eb439daba28ac50cd.tar.gz";
   pkgs = import nixpkgs {
     config = { };
     overlays = [ ];

--- a/test/nix/initramfs.nix
+++ b/test/nix/initramfs.nix
@@ -57,13 +57,13 @@ in stdenv.mkDerivation {
     # This will generate a text file containing the complete closure of the packages,
     # including the packages themselves.
     # The output of `writeClosure` is equivalent to `nix-store -q --requisites`.
+    mkdir -p $out/nix/store
     pkg_path=${lib.strings.concatStringsSep ":" all_pkgs}
     while IFS= read -r dep_path; do
       if [[ "$pkg_path" == *"$dep_path"* ]]; then
         continue
       fi
-      mkdir -p $out/$dep_path
-      cp -r $dep_path/* $out/$dep_path/
+      cp -r $dep_path $out/nix/store/
     done < ${writeClosure all_pkgs}
   '';
 }

--- a/test/src/benchmark/bench_linux_and_aster.sh
+++ b/test/src/benchmark/bench_linux_and_aster.sh
@@ -145,11 +145,11 @@ run_benchmark() {
         -cpu Icelake-Server,-pcid,+x2apic
         --enable-kvm
         -kernel "${LINUX_KERNEL}"
-        -initrd "${BENCHMARK_ROOT}/../build/initramfs.cpio.gz"
-        -drive "if=none,format=raw,id=x0,file=${BENCHMARK_ROOT}/../build/ext2.img"
+        -initrd "${BENCHMARK_ROOT}/../../build/initramfs.cpio.gz"
+        -drive "if=none,format=raw,id=x0,file=${BENCHMARK_ROOT}/../../build/ext2.img"
         -device "virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off"
         -append "console=ttyS0 rdinit=/benchmark/common/bench_runner.sh ${benchmark} linux mitigations=off hugepages=0 transparent_hugepage=never quiet"
-        -netdev "tap,id=net01,script=${BENCHMARK_ROOT}/../../tools/net/qemu-ifup.sh,downscript=${BENCHMARK_ROOT}/../../tools/net/qemu-ifdown.sh,vhost=on"
+        -netdev "tap,id=net01,script=${BENCHMARK_ROOT}/../../../tools/net/qemu-ifup.sh,downscript=${BENCHMARK_ROOT}/../../../tools/net/qemu-ifdown.sh,vhost=on"
         -nographic
     )
     if [[ "$platform" != "tdx" ]]; then

--- a/test/src/benchmark/common/prepare_host.sh
+++ b/test/src/benchmark/common/prepare_host.sh
@@ -15,7 +15,7 @@ LINUX_DEPENDENCIES_DIR="/opt/linux_binary_cache"
 LINUX_KERNEL="${LINUX_DEPENDENCIES_DIR}/vmlinuz"
 LINUX_KERNEL_VERSION="5.15.0-105"
 LINUX_MODULES_DIR="${BENCHMARK_ROOT}/../build/initramfs/lib/modules/${LINUX_KERNEL_VERSION}/kernel"
-WGET_SCRIPT="${BENCHMARK_ROOT}/../../tools/atomic_wget.sh"
+WGET_SCRIPT="${BENCHMARK_ROOT}/../../../tools/atomic_wget.sh"
 
 # Prepare Linux kernel and modules
 prepare_libs() {
@@ -42,6 +42,6 @@ prepare_libs() {
 # Prepare fs for Linux
 prepare_fs() {
     # Disable unsupported ext2 features of Asterinas on Linux to ensure fairness
-    mke2fs -F -O ^ext_attr -O ^resize_inode -O ^dir_index ${BENCHMARK_ROOT}/../build/ext2.img
+    mke2fs -F -O ^ext_attr -O ^resize_inode -O ^dir_index ${BENCHMARK_ROOT}/../../build/ext2.img
     make initramfs BENCHMARK=${benchmark}
 }


### PR DESCRIPTION
- Fix errors introduced by the nix channel update by pinning to commit `c0bebd1`
- Fix file path errors