### PR TITLE
Align execve argument limits with Linux

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -27,9 +27,7 @@ pub use process::{
     Pid, Process, ProcessGroup, Session, Sid, Terminal,
 };
 pub use process_filter::ProcessFilter;
-pub use process_vm::{
-    renew_vm_and_map, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
-};
+pub use process_vm::{renew_vm_and_map, MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS};
 pub use program_loader::{check_executable_file, ProgramToLoad};
 pub use rlimit::ResourceType;
 pub use term_status::TermStatus;

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -20,8 +20,7 @@ pub use self::{
     heap::USER_HEAP_SIZE_LIMIT,
     init_stack::{
         aux_vec::{AuxKey, AuxVec},
-        InitStack, InitStackReader, INIT_STACK_SIZE, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER,
-        MAX_ENV_LEN,
+        InitStack, InitStackReader, INIT_STACK_SIZE, MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS,
     },
 };
 use crate::{prelude::*, vm::vmar::Vmar};

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -16,7 +16,7 @@ use crate::{
     prelude::*,
     process::{
         check_executable_file, posix_thread::ThreadName, renew_vm_and_map, Credentials, Process,
-        ProgramToLoad, MAX_ARGV_NUMBER, MAX_ARG_LEN, MAX_ENVP_NUMBER, MAX_ENV_LEN,
+        ProgramToLoad, MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS,
     },
 };
 
@@ -95,8 +95,13 @@ fn do_execve(
     } = ctx;
 
     let executable_path = elf_file.abs_path();
-    let argv = read_cstring_vec(argv_ptr_ptr, MAX_ARGV_NUMBER, MAX_ARG_LEN, ctx)?;
-    let envp = read_cstring_vec(envp_ptr_ptr, MAX_ENVP_NUMBER, MAX_ENV_LEN, ctx)?;
+    // FIXME: A malicious user could cause a kernel panic by exhausting available memory.
+    // Currently, the implementation reads up to `MAX_NR_STRING_ARGS` arguments, each up to
+    // `MAX_LEN_STRING_ARG` in length, without first verifying the total combined size.
+    // To prevent excessive memory allocation, a preliminary check should sum the lengths
+    // of all strings to enforce a sensible overall limit.
+    let argv = read_cstring_vec(argv_ptr_ptr, MAX_NR_STRING_ARGS, MAX_LEN_STRING_ARG, ctx)?;
+    let envp = read_cstring_vec(envp_ptr_ptr, MAX_NR_STRING_ARGS, MAX_LEN_STRING_ARG, ctx)?;
     debug!(
         "filename: {:?}, argv = {:?}, envp = {:?}",
         executable_path, argv, envp


### PR DESCRIPTION
The current argument limit of execve syscall is too small compared with Linux, which causes many test fail when tesing Go runtime in #2229. 

So just align these limits with Linux.