### PR TITLE
Remove some variants in `ostd::Error`

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -200,8 +200,6 @@ impl From<ostd::Error> for Error {
             ostd::Error::NotEnoughResources => Error::new(Errno::EBUSY),
             ostd::Error::PageFault => Error::new(Errno::EFAULT),
             ostd::Error::Overflow => Error::new(Errno::EOVERFLOW),
-            ostd::Error::MapAlreadyMappedVaddr => Error::new(Errno::EINVAL),
-            ostd::Error::KVirtAreaAllocError => Error::new(Errno::ENOMEM),
         }
     }
 }

--- a/ostd/src/error.rs
+++ b/ostd/src/error.rs
@@ -19,10 +19,6 @@ pub enum Error {
     NotEnoughResources,
     /// Arithmetic Overflow occurred.
     Overflow,
-    /// Memory mapping already exists for the given virtual address.
-    MapAlreadyMappedVaddr,
-    /// Error when allocating kernel virtual memory.
-    KVirtAreaAllocError,
 }
 
 impl From<PageTableError> for Error {

--- a/ostd/src/util/range_alloc.rs
+++ b/ostd/src/util/range_alloc.rs
@@ -3,16 +3,16 @@
 use alloc::collections::btree_map::BTreeMap;
 use core::ops::Range;
 
-use crate::{
-    prelude::*,
-    sync::{PreemptDisabled, SpinLock, SpinLockGuard},
-    Error,
-};
+use crate::sync::{PreemptDisabled, SpinLock, SpinLockGuard};
 
 pub struct RangeAllocator {
     fullrange: Range<usize>,
     freelist: SpinLock<Option<BTreeMap<usize, FreeRange>>>,
 }
+
+/// An error returned when allocating from a [`RangeAllocator`].
+#[derive(Debug)]
+pub struct RangeAllocError;
 
 impl RangeAllocator {
     pub const fn new(fullrange: Range<usize>) -> Self {
@@ -27,7 +27,7 @@ impl RangeAllocator {
     }
 
     /// Allocates a specific kernel virtual area.
-    pub fn alloc_specific(&self, allocate_range: &Range<usize>) -> Result<()> {
+    pub fn alloc_specific(&self, allocate_range: &Range<usize>) -> Result<(), RangeAllocError> {
         debug_assert!(allocate_range.start < allocate_range.end);
 
         let mut lock_guard = self.get_freelist_guard();
@@ -63,14 +63,14 @@ impl RangeAllocator {
         if target_node.is_some() {
             Ok(())
         } else {
-            Err(Error::KVirtAreaAllocError)
+            Err(RangeAllocError)
         }
     }
 
     /// Allocates a range specific by the `size`.
     ///
     /// This is currently implemented with a simple FIRST-FIT algorithm.
-    pub fn alloc(&self, size: usize) -> Result<Range<usize>> {
+    pub fn alloc(&self, size: usize) -> Result<Range<usize>, RangeAllocError> {
         let mut lock_guard = self.get_freelist_guard();
         let freelist = lock_guard.as_mut().unwrap();
         let mut allocate_range = None;
@@ -97,7 +97,7 @@ impl RangeAllocator {
         if let Some(range) = allocate_range {
             Ok(range)
         } else {
-            Err(Error::KVirtAreaAllocError)
+            Err(RangeAllocError)
         }
     }
 


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/e5c5bc79921ae89e9b574d69640b9f9f96b2f86f/ostd/src/error.rs#L22-L25

I think these two errors are too specific to belong to the `ostd::Error` type.

 - I just removed `MapAlreadyMappedVaddr` because it isn't used anywhere.
 - `KVirtAreaAllocError` is [used](https://github.com/asterinas/asterinas/blob/e5c5bc79921ae89e9b574d69640b9f9f96b2f86f/ostd/src/util/range_alloc.rs#L66) in [`RangeAllocator`](https://github.com/asterinas/asterinas/blob/e5c5bc79921ae89e9b574d69640b9f9f96b2f86f/ostd/src/util/range_alloc.rs#L12), so the name is inaccurate. I moved the definition of the error type to `range_alloc.rs`.