### PR TITLE
Support syslog(2): add syscall(2), logger integration and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "component",
  "ostd",
  "owo-colors",
+ "ring-buffer",
 ]
 
 [[package]]
@@ -525,11 +526,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -687,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -791,14 +793,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
+ "wasi",
 ]
 
 [[package]]
@@ -1017,6 +1019,21 @@ name = "keyable-arc"
 version = "0.1.0"
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -1234,9 +1251,9 @@ checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -1834,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1847,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "toml"
@@ -2031,6 +2048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,18 +2218,18 @@ checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "ostd",
  "owo-colors",
  "ring-buffer",
+ "spin",
 ]
 
 [[package]]

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -10,6 +10,7 @@ aster-console.workspace = true
 component.workspace = true
 ostd.workspace = true
 owo-colors = { workspace = true, optional = true }
+ring-buffer.workspace = true
 
 [features]
 default = ["log_color"]

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -11,6 +11,7 @@ component.workspace = true
 ostd.workspace = true
 owo-colors = { workspace = true, optional = true }
 ring-buffer.workspace = true
+spin.workspace = true
 
 [features]
 default = ["log_color"]

--- a/kernel/comps/logger/src/aster_logger.rs
+++ b/kernel/comps/logger/src/aster_logger.rs
@@ -15,8 +15,9 @@ static LOGGER: AsterLogger = AsterLogger;
 impl ostd::log::Log for AsterLogger {
     fn log(&self, record: &Record) {
         let timestamp = Jiffies::elapsed().as_duration();
+        let klog = super::klog::klog();
         super::append_log(record, &timestamp);
-        if super::klog::should_print(record.level()) {
+        if klog.should_print(record.level()) {
             print_logs(record, &timestamp);
         }
     }

--- a/kernel/comps/logger/src/aster_logger.rs
+++ b/kernel/comps/logger/src/aster_logger.rs
@@ -15,7 +15,10 @@ static LOGGER: AsterLogger = AsterLogger;
 impl ostd::log::Log for AsterLogger {
     fn log(&self, record: &Record) {
         let timestamp = Jiffies::elapsed().as_duration();
-        print_logs(record, &timestamp);
+        super::append_log(record, &timestamp);
+        if super::klog::should_print(record.level()) {
+            print_logs(record, &timestamp);
+        }
     }
 }
 
@@ -62,5 +65,6 @@ fn print_logs(record: &Record, timestamp: &Duration) {
 }
 
 pub(super) fn init() {
+    super::klog::init_klog();
     ostd::log::inject_logger(&LOGGER);
 }

--- a/kernel/comps/logger/src/klog.rs
+++ b/kernel/comps/logger/src/klog.rs
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::Arc;
+use core::{
+    fmt::{self, Write},
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+    time::Duration,
+};
+
+use ostd::{
+    log::{Level, Record},
+    mm::VmIo,
+    sync::{SpinLock, WaitQueue},
+};
+use ring_buffer::RingBuffer;
+
+/// Size of the kernel log ring buffer (64 KB).
+///
+/// This matches the default `CONFIG_LOG_BUF_SHIFT=16` in Linux.
+/// The buffer stores formatted log messages including timestamps.
+const LOG_BUFFER_CAPACITY: usize = 64 * 1024;
+
+/// Maximum size of a single formatted log message.
+///
+/// Log messages longer than this will be truncated. This is a stack-allocated
+/// scratch buffer used to format messages without heap allocation, which is
+/// important for logging in low-memory or allocator-internal contexts.
+const FORMAT_BUF_CAPACITY: usize = 512;
+
+/// Chunk size for copying data to/from user space.
+///
+/// Reading and writing are done in chunks to avoid holding locks for too long
+/// and to limit stack usage.
+const COPY_CHUNK: usize = 512;
+
+/// Linux console log level.
+///
+/// Controls which log messages are broadcast to the console. Only messages
+/// with a priority level less than the console log level will be displayed.
+/// For example, setting the console level to `Error` (4) will display messages
+/// of levels `Emerg`, `Alert`, `Crit`, and `Error`.
+///
+/// These values correspond to Linux's console log level as documented in
+/// `man 2 syslog` and used by the `SYSLOG_ACTION_CONSOLE_LEVEL` action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum LinuxConsoleLogLevel {
+    /// Suppress all console output.
+    Off = 0,
+    /// Allow messages with priority `KERN_EMERG` (0) or higher.
+    Emerg = 1,
+    /// Allow messages with priority `KERN_ALERT` (1) or higher.
+    Alert = 2,
+    /// Allow messages with priority `KERN_CRIT` (2) or higher.
+    Crit = 3,
+    /// Allow messages with priority `KERN_ERR` (3) or higher.
+    Error = 4,
+    /// Allow messages with priority `KERN_WARNING` (4) or higher.
+    Warn = 5,
+    /// Allow messages with priority `KERN_NOTICE` (5) or higher.
+    Notice = 6,
+    /// Allow messages with priority `KERN_INFO` (6) or higher.
+    Info = 7,
+    /// Allow messages with priority `KERN_DEBUG` (7) or higher (all messages).
+    Debug = 8,
+}
+
+impl LinuxConsoleLogLevel {
+    /// Creates a console log level from a raw integer value.
+    ///
+    /// Returns `None` if the value is out of the valid range (0-8).
+    pub fn from_raw(raw: i32) -> Option<Self> {
+        match raw {
+            0 => Some(Self::Off),
+            1 => Some(Self::Emerg),
+            2 => Some(Self::Alert),
+            3 => Some(Self::Crit),
+            4 => Some(Self::Error),
+            5 => Some(Self::Warn),
+            6 => Some(Self::Notice),
+            7 => Some(Self::Info),
+            8 => Some(Self::Debug),
+            _ => None,
+        }
+    }
+
+    /// Checks if a log level should be printed at this console log level.
+    fn should_print(self, level: Level) -> bool {
+        (level as u8) < (self as u8)
+    }
+}
+
+static KLOG: SpinLock<Option<Arc<KernelLog>>> = SpinLock::new(None);
+
+/// Initializes the kernel log buffer.
+///
+/// This function must be called before any logging operations.
+pub fn init_klog() {
+    let mut guard = KLOG.lock();
+    if guard.is_none() {
+        *guard = Some(Arc::new(KernelLog::new()));
+    }
+}
+
+fn klog() -> Arc<KernelLog> {
+    let mut guard = KLOG.lock();
+    if guard.is_none() {
+        *guard = Some(Arc::new(KernelLog::new()));
+    }
+    guard.as_ref().unwrap().clone()
+}
+
+/// Appends a log record to the kernel log buffer.
+///
+/// The record is formatted with a timestamp prefix before being stored.
+/// This function does not allocate memory and uses a fixed-size scratch buffer.
+pub fn append_log(record: &Record, timestamp: &Duration) {
+    let mut scratch = [0u8; FORMAT_BUF_CAPACITY];
+    let mut writer = FixedBuf::new(&mut scratch);
+
+    let secs = timestamp.as_secs();
+    let millis = timestamp.subsec_millis();
+    let _ = writeln!(
+        writer,
+        "[{:>6}.{:03}] {:<6}: {}{}",
+        secs,
+        millis,
+        record.level(),
+        record.prefix(),
+        record.args()
+    );
+
+    if !writer.is_empty() {
+        klog().append(writer.as_bytes());
+    }
+}
+
+/// Checks if a log message at the given level should be printed to console.
+pub fn should_print(level: Level) -> bool {
+    klog().should_print(level)
+}
+
+/// Returns the current console log level.
+pub fn console_level() -> LinuxConsoleLogLevel {
+    klog().get_console_level()
+}
+
+/// Sets the console log level.
+///
+/// Returns the previous console log level.
+pub fn console_set_level(level: LinuxConsoleLogLevel) -> LinuxConsoleLogLevel {
+    klog().set_console_level(level, false)
+}
+
+/// Disables console output by setting the log level to `Off`.
+///
+/// The previous log level is saved and can be restored with `console_on()`.
+/// Returns the previous console log level.
+pub fn console_off() -> LinuxConsoleLogLevel {
+    klog().set_console_level(LinuxConsoleLogLevel::Off, true)
+}
+
+/// Restores the console log level that was saved by `console_off()`.
+///
+/// Returns the restored console log level.
+pub fn console_on() -> LinuxConsoleLogLevel {
+    klog().restore_console_level()
+}
+
+/// Reads log messages from the kernel log buffer (destructive).
+///
+/// This is a blocking read that removes data from the buffer as it is read.
+/// Returns the number of bytes read into `dst`.
+pub fn klog_read(dst: &mut [u8]) -> usize {
+    klog().read(dst)
+}
+
+/// Reads log messages from the kernel log buffer (non-destructive).
+///
+/// Reads up to `window_len` bytes starting at `offset` within the available
+/// log data. The data remains in the buffer after reading.
+/// Returns the number of bytes read into `dst`.
+pub fn klog_read_all(dst: &mut [u8], offset: usize, window_len: usize) -> usize {
+    klog().read_all(dst, offset, window_len)
+}
+
+/// Marks the current buffer position as cleared.
+///
+/// After this call, `klog_read_all` will only return messages logged after
+/// the clear operation, but the data is not actually removed from the buffer.
+pub fn mark_clear() {
+    klog().mark_clear();
+}
+
+/// Returns the number of unread bytes in the kernel log buffer.
+pub fn klog_size_unread() -> usize {
+    klog().size_unread()
+}
+
+/// Returns the total capacity of the kernel log buffer in bytes.
+pub fn klog_capacity() -> usize {
+    LOG_BUFFER_CAPACITY
+}
+
+/// Checks if reading all log messages requires `CAP_SYSLOG` or `CAP_SYS_ADMIN`.
+///
+/// When `dmesg_restrict` is enabled, unprivileged users cannot read the
+/// kernel log buffer via `SYSLOG_ACTION_READ_ALL`.
+pub fn read_all_requires_cap() -> bool {
+    klog().dmesg_restrict()
+}
+
+/// Gets the current value of the `dmesg_restrict` flag.
+pub fn dmesg_restrict_get() -> bool {
+    klog().dmesg_restrict.load(Ordering::Relaxed)
+}
+
+/// Sets the `dmesg_restrict` flag.
+///
+/// When enabled, reading all log messages requires `CAP_SYSLOG` or `CAP_SYS_ADMIN`.
+pub fn dmesg_restrict_set(val: bool) {
+    klog().dmesg_restrict.store(val, Ordering::Relaxed);
+}
+
+struct KernelLog {
+    buffer: SpinLock<RingBuffer<u8>>,
+    clear_tail: SpinLock<usize>,
+    dmesg_restrict: AtomicBool,
+    /// Current console log level (stored as raw u8 for atomic access).
+    console_level: AtomicU8,
+    /// Saved console log level for restore after console_off/console_on.
+    saved_console_level: SpinLock<Option<LinuxConsoleLogLevel>>,
+    waitq: WaitQueue,
+}
+
+impl KernelLog {
+    fn new() -> Self {
+        Self {
+            buffer: SpinLock::new(RingBuffer::new(LOG_BUFFER_CAPACITY)),
+            clear_tail: SpinLock::new(0),
+            dmesg_restrict: AtomicBool::new(false),
+            console_level: AtomicU8::new(LinuxConsoleLogLevel::Info as u8),
+            saved_console_level: SpinLock::new(None),
+            waitq: WaitQueue::new(),
+        }
+    }
+
+    fn append(&self, mut bytes: &[u8]) {
+        {
+            let mut buf = self.buffer.lock();
+            let cap = buf.capacity();
+
+            if bytes.len() > cap {
+                bytes = &bytes[bytes.len() - cap..];
+                buf.clear();
+            }
+
+            // Drop oldest data if needed.
+            let free = buf.free_len();
+            let need_drop = bytes.len().saturating_sub(free);
+            if need_drop > 0 {
+                buf.commit_read(need_drop);
+                self.bump_clear_tail(&mut buf);
+            }
+
+            buf.push_slice(bytes)
+                .expect("push_slice must succeed after drop");
+        }
+
+        // Wake up blocked readers once new data arrives.
+        self.waitq.wake_all();
+    }
+
+    fn bump_clear_tail(&self, buf: &mut RingBuffer<u8>) {
+        let mut clear_tail = self.clear_tail.lock();
+        let head = buf.head().0;
+        if *clear_tail < head {
+            *clear_tail = head;
+        }
+    }
+
+    fn read(&self, dst: &mut [u8]) -> usize {
+        let mut copied = 0;
+        while copied < dst.len() {
+            let chunk = {
+                let mut buf = self.buffer.lock();
+                let available = buf.len();
+                if available == 0 {
+                    break;
+                }
+                let take =
+                    core::cmp::min(core::cmp::min(dst.len() - copied, COPY_CHUNK), available);
+                copy_from(&buf, buf.head().0, &mut dst[copied..copied + take]);
+                buf.commit_read(take);
+                self.bump_clear_tail(&mut buf);
+                take
+            };
+            copied += chunk;
+        }
+        copied
+    }
+
+    fn read_all(&self, dst: &mut [u8], offset: usize, window_len: usize) -> usize {
+        let mut copied = 0;
+        while copied < dst.len() {
+            let buf = self.buffer.lock();
+            let head = buf.head().0;
+            let tail = buf.tail().0;
+            let base = core::cmp::max(head, *self.clear_tail.lock());
+            let available = tail.saturating_sub(base);
+            if available == 0 {
+                return copied;
+            }
+            let window = core::cmp::min(available, window_len);
+            if offset + copied >= window {
+                return copied;
+            }
+            let remain = window - (offset + copied);
+            let take = core::cmp::min(core::cmp::min(dst.len() - copied, COPY_CHUNK), remain);
+            let start = (tail - window) + offset + copied;
+
+            // Copy while holding the lock to prevent data from being overwritten.
+            copy_from(&buf, start, &mut dst[copied..copied + take]);
+            drop(buf);
+
+            copied += take;
+        }
+        copied
+    }
+
+    fn mark_clear(&self) {
+        let buf = self.buffer.lock();
+        let mut clear_tail = self.clear_tail.lock();
+        *clear_tail = buf.tail().0;
+    }
+
+    fn size_unread(&self) -> usize {
+        self.buffer.lock().len()
+    }
+
+    fn dmesg_restrict(&self) -> bool {
+        self.dmesg_restrict.load(Ordering::Relaxed)
+    }
+
+    fn set_console_level(
+        &self,
+        level: LinuxConsoleLogLevel,
+        save_old: bool,
+    ) -> LinuxConsoleLogLevel {
+        let mut saved = self.saved_console_level.lock();
+        let old_raw = self.console_level.swap(level as u8, Ordering::SeqCst);
+        // SAFETY: We only store valid LinuxConsoleLogLevel values.
+        let old =
+            LinuxConsoleLogLevel::from_raw(old_raw as i32).unwrap_or(LinuxConsoleLogLevel::Info);
+        if save_old && saved.is_none() {
+            *saved = Some(old);
+        }
+        old
+    }
+
+    fn restore_console_level(&self) -> LinuxConsoleLogLevel {
+        let mut saved = self.saved_console_level.lock();
+        if let Some(prev) = saved.take() {
+            self.console_level.store(prev as u8, Ordering::SeqCst);
+            prev
+        } else {
+            self.get_console_level()
+        }
+    }
+
+    fn get_console_level(&self) -> LinuxConsoleLogLevel {
+        let raw = self.console_level.load(Ordering::SeqCst);
+        LinuxConsoleLogLevel::from_raw(raw as i32).unwrap_or(LinuxConsoleLogLevel::Info)
+    }
+
+    fn should_print(&self, level: Level) -> bool {
+        self.get_console_level().should_print(level)
+    }
+
+    fn wait_nonempty(&self) {
+        self.waitq
+            .wait_until(|| (!self.buffer.lock().is_empty()).then_some(()));
+    }
+}
+
+/// Blocks until the kernel log buffer is non-empty.
+///
+/// This is used by `SYSLOG_ACTION_READ` to wait for new log messages.
+pub fn klog_wait_nonempty() {
+    klog().wait_nonempty();
+}
+
+fn copy_from(rb: &RingBuffer<u8>, start: usize, dst: &mut [u8]) {
+    let cap = rb.capacity();
+    let offset = start & (cap - 1);
+    if offset + dst.len() > cap {
+        let first = cap - offset;
+        rb.segment().read_slice(offset, &mut dst[..first]).unwrap();
+        rb.segment().read_slice(0, &mut dst[first..]).unwrap();
+    } else {
+        rb.segment().read_slice(offset, dst).unwrap();
+    }
+}
+
+struct FixedBuf<'a> {
+    buf: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> FixedBuf<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, len: 0 }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Write for FixedBuf<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let space = self.buf.len().saturating_sub(self.len);
+        if space == 0 {
+            return Ok(());
+        }
+
+        let bytes = s.as_bytes();
+        let copy_len = bytes.len().min(space);
+        self.buf[self.len..self.len + copy_len].copy_from_slice(&bytes[..copy_len]);
+        self.len += copy_len;
+        Ok(())
+    }
+}

--- a/kernel/comps/logger/src/klog.rs
+++ b/kernel/comps/logger/src/klog.rs
@@ -1,6 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
+//! Kernel log buffer (`klog`) backing `dmesg(1)` and `syslog(2)`.
+//!
+//! `KernelLog` stores formatted records in a fixed-capacity ring buffer; the
+//! oldest records are evicted on overflow. Console output is gated by a
+//! configurable level independent of buffer retention.
+//!
+//! # Locking
+//!
+//! Lock order on `KernelLog`: `buffer` -> `clear_tail`. `saved_console_level`
+//! is independent. All locks are IRQ-safe because the logger fires from
+//! interrupt context.
+//!
+//! # Invariants
+//!
+//! - `clear_tail` is monotonic and always satisfies `head <= clear_tail <= tail`
+//!   (modulo wraparound of the cumulative `usize` counters).
+//! - `console_level` is always a valid `LinuxConsoleLogLevel` discriminant.
+
 use core::{
     fmt::{self, Write},
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
@@ -10,15 +27,16 @@ use core::{
 use ostd::{
     log::{Level, Record},
     mm::VmIo,
-    sync::{SpinLock, WaitQueue},
+    sync::{LocalIrqDisabled, SpinLock, WaitQueue},
 };
 use ring_buffer::RingBuffer;
+use spin::Once;
 
 /// Size of the kernel log ring buffer (64 KB).
 ///
 /// This matches the default `CONFIG_LOG_BUF_SHIFT=16` in Linux.
 /// The buffer stores formatted log messages including timestamps.
-const LOG_BUFFER_CAPACITY: usize = 64 * 1024;
+pub const LOG_BUFFER_CAPACITY: usize = 64 * 1024;
 
 /// Maximum size of a single formatted log message.
 ///
@@ -26,12 +44,6 @@ const LOG_BUFFER_CAPACITY: usize = 64 * 1024;
 /// scratch buffer used to format messages without heap allocation, which is
 /// important for logging in low-memory or allocator-internal contexts.
 const FORMAT_BUF_CAPACITY: usize = 512;
-
-/// Chunk size for copying data to/from user space.
-///
-/// Reading and writing are done in chunks to avoid holding locks for too long
-/// and to limit stack usage.
-const COPY_CHUNK: usize = 512;
 
 /// Linux console log level.
 ///
@@ -90,24 +102,20 @@ impl LinuxConsoleLogLevel {
     }
 }
 
-static KLOG: SpinLock<Option<Arc<KernelLog>>> = SpinLock::new(None);
+static KLOG: Once<KernelLog> = Once::new();
+
+/// Returns a reference to the global [`KernelLog`].
+///
+/// Initializes the kernel log buffer on first call.
+pub fn klog() -> &'static KernelLog {
+    KLOG.call_once(KernelLog::new)
+}
 
 /// Initializes the kernel log buffer.
 ///
 /// This function must be called before any logging operations.
 pub fn init_klog() {
-    let mut guard = KLOG.lock();
-    if guard.is_none() {
-        *guard = Some(Arc::new(KernelLog::new()));
-    }
-}
-
-fn klog() -> Arc<KernelLog> {
-    let mut guard = KLOG.lock();
-    if guard.is_none() {
-        *guard = Some(Arc::new(KernelLog::new()));
-    }
-    guard.as_ref().unwrap().clone()
+    KLOG.call_once(KernelLog::new);
 }
 
 /// Appends a log record to the kernel log buffer.
@@ -135,101 +143,18 @@ pub fn append_log(record: &Record, timestamp: &Duration) {
     }
 }
 
-/// Checks if a log message at the given level should be printed to console.
-pub fn should_print(level: Level) -> bool {
-    klog().should_print(level)
-}
-
-/// Returns the current console log level.
-pub fn console_level() -> LinuxConsoleLogLevel {
-    klog().get_console_level()
-}
-
-/// Sets the console log level.
+/// The kernel log buffer.
 ///
-/// Returns the previous console log level.
-pub fn console_set_level(level: LinuxConsoleLogLevel) -> LinuxConsoleLogLevel {
-    klog().set_console_level(level, false)
-}
-
-/// Disables console output by setting the log level to `Off`.
-///
-/// The previous log level is saved and can be restored with `console_on()`.
-/// Returns the previous console log level.
-pub fn console_off() -> LinuxConsoleLogLevel {
-    klog().set_console_level(LinuxConsoleLogLevel::Off, true)
-}
-
-/// Restores the console log level that was saved by `console_off()`.
-///
-/// Returns the restored console log level.
-pub fn console_on() -> LinuxConsoleLogLevel {
-    klog().restore_console_level()
-}
-
-/// Reads log messages from the kernel log buffer (destructive).
-///
-/// This is a blocking read that removes data from the buffer as it is read.
-/// Returns the number of bytes read into `dst`.
-pub fn klog_read(dst: &mut [u8]) -> usize {
-    klog().read(dst)
-}
-
-/// Reads log messages from the kernel log buffer (non-destructive).
-///
-/// Reads up to `window_len` bytes starting at `offset` within the available
-/// log data. The data remains in the buffer after reading.
-/// Returns the number of bytes read into `dst`.
-pub fn klog_read_all(dst: &mut [u8], offset: usize, window_len: usize) -> usize {
-    klog().read_all(dst, offset, window_len)
-}
-
-/// Marks the current buffer position as cleared.
-///
-/// After this call, `klog_read_all` will only return messages logged after
-/// the clear operation, but the data is not actually removed from the buffer.
-pub fn mark_clear() {
-    klog().mark_clear();
-}
-
-/// Returns the number of unread bytes in the kernel log buffer.
-pub fn klog_size_unread() -> usize {
-    klog().size_unread()
-}
-
-/// Returns the total capacity of the kernel log buffer in bytes.
-pub fn klog_capacity() -> usize {
-    LOG_BUFFER_CAPACITY
-}
-
-/// Checks if reading all log messages requires `CAP_SYSLOG` or `CAP_SYS_ADMIN`.
-///
-/// When `dmesg_restrict` is enabled, unprivileged users cannot read the
-/// kernel log buffer via `SYSLOG_ACTION_READ_ALL`.
-pub fn read_all_requires_cap() -> bool {
-    klog().dmesg_restrict()
-}
-
-/// Gets the current value of the `dmesg_restrict` flag.
-pub fn dmesg_restrict_get() -> bool {
-    klog().dmesg_restrict.load(Ordering::Relaxed)
-}
-
-/// Sets the `dmesg_restrict` flag.
-///
-/// When enabled, reading all log messages requires `CAP_SYSLOG` or `CAP_SYS_ADMIN`.
-pub fn dmesg_restrict_set(val: bool) {
-    klog().dmesg_restrict.store(val, Ordering::Relaxed);
-}
-
-struct KernelLog {
-    buffer: SpinLock<RingBuffer<u8>>,
-    clear_tail: SpinLock<usize>,
+/// Stores formatted log records in a fixed-capacity ring buffer, manages
+/// console log levels, and provides read access for `syslog(2)` and `/proc/sys/kernel/dmesg_restrict`.
+pub struct KernelLog {
+    buffer: SpinLock<RingBuffer<u8>, LocalIrqDisabled>,
+    clear_tail: SpinLock<usize, LocalIrqDisabled>,
     dmesg_restrict: AtomicBool,
     /// Current console log level (stored as raw u8 for atomic access).
     console_level: AtomicU8,
     /// Saved console log level for restore after console_off/console_on.
-    saved_console_level: SpinLock<Option<LinuxConsoleLogLevel>>,
+    saved_console_level: SpinLock<Option<LinuxConsoleLogLevel>, LocalIrqDisabled>,
     waitq: WaitQueue,
 }
 
@@ -253,6 +178,7 @@ impl KernelLog {
             if bytes.len() > cap {
                 bytes = &bytes[bytes.len() - cap..];
                 buf.clear();
+                *self.clear_tail.lock() = 0;
             }
 
             // Drop oldest data if needed.
@@ -260,18 +186,19 @@ impl KernelLog {
             let need_drop = bytes.len().saturating_sub(free);
             if need_drop > 0 {
                 buf.commit_read(need_drop);
-                self.bump_clear_tail(&mut buf);
+                self.bump_clear_tail(&buf);
             }
 
             buf.push_slice(bytes)
                 .expect("push_slice must succeed after drop");
         }
 
-        // Wake up blocked readers once new data arrives.
+        // The `buffer` lock must be dropped before waking — the waiters' re-check
+        // in `wait_nonempty` re-acquires it.
         self.waitq.wake_all();
     }
 
-    fn bump_clear_tail(&self, buf: &mut RingBuffer<u8>) {
+    fn bump_clear_tail(&self, buf: &RingBuffer<u8>) {
         let mut clear_tail = self.clear_tail.lock();
         let head = buf.head().0;
         if *clear_tail < head {
@@ -279,7 +206,10 @@ impl KernelLog {
         }
     }
 
-    fn read(&self, dst: &mut [u8]) -> usize {
+    /// Reads and removes log messages from the buffer (destructive).
+    ///
+    /// Returns the number of bytes read into `dst`.
+    pub fn read(&self, dst: &mut [u8]) -> usize {
         let mut copied = 0;
         while copied < dst.len() {
             let chunk = {
@@ -292,7 +222,7 @@ impl KernelLog {
                     core::cmp::min(core::cmp::min(dst.len() - copied, COPY_CHUNK), available);
                 copy_from(&buf, buf.head().0, &mut dst[copied..copied + take]);
                 buf.commit_read(take);
-                self.bump_clear_tail(&mut buf);
+                self.bump_clear_tail(&buf);
                 take
             };
             copied += chunk;
@@ -300,65 +230,93 @@ impl KernelLog {
         copied
     }
 
-    fn read_all(&self, dst: &mut [u8], offset: usize, window_len: usize) -> usize {
-        let mut copied = 0;
-        while copied < dst.len() {
-            let buf = self.buffer.lock();
-            let head = buf.head().0;
-            let tail = buf.tail().0;
-            let base = core::cmp::max(head, *self.clear_tail.lock());
-            let available = tail.saturating_sub(base);
-            if available == 0 {
-                return copied;
-            }
-            let window = core::cmp::min(available, window_len);
-            if offset + copied >= window {
-                return copied;
-            }
-            let remain = window - (offset + copied);
-            let take = core::cmp::min(core::cmp::min(dst.len() - copied, COPY_CHUNK), remain);
-            let start = (tail - window) + offset + copied;
-
-            // Copy while holding the lock to prevent data from being overwritten.
-            copy_from(&buf, start, &mut dst[copied..copied + take]);
-            drop(buf);
-
-            copied += take;
+    /// Reads log messages without removing them (non-destructive).
+    ///
+    /// Reads up to `window_len` bytes starting at `offset` within the available
+    /// log data, pinned to the snapshot `at_tail` for cross-chunk consistency.
+    /// Returns the number of bytes read into `dst`.
+    pub fn read_all(&self, dst: &mut [u8], offset: usize, window_len: usize, at_tail: usize) -> usize {
+        let buf = self.buffer.lock();
+        let base = core::cmp::max(buf.head().0, *self.clear_tail.lock());
+        let available = at_tail.saturating_sub(base);
+        let window = core::cmp::min(available, window_len);
+        if offset >= window {
+            return 0;
         }
-        copied
+        let take = core::cmp::min(dst.len(), window - offset);
+        let start = (at_tail - window) + offset;
+        copy_from(&buf, start, &mut dst[..take]);
+        take
     }
 
-    fn mark_clear(&self) {
+    /// Returns the current tail position for snapshot-based reads.
+    ///
+    /// The returned value can be passed to [`read_all`](Self::read_all) to
+    /// ensure all chunks within a single syscall observe a consistent view.
+    pub fn snapshot_tail(&self) -> usize {
+        self.buffer.lock().tail().0
+    }
+
+    /// Marks the current buffer position as cleared.
+    ///
+    /// After this call, [`read_all`](Self::read_all) will only return messages
+    /// logged after the clear operation.
+    pub fn mark_clear(&self) {
         let buf = self.buffer.lock();
         let mut clear_tail = self.clear_tail.lock();
         *clear_tail = buf.tail().0;
     }
 
-    fn size_unread(&self) -> usize {
-        self.buffer.lock().len()
+    /// Returns the number of unread bytes in the kernel log buffer.
+    pub fn size_unread(&self) -> usize {
+        let buf = self.buffer.lock();
+        let base = core::cmp::max(buf.head().0, *self.clear_tail.lock());
+        buf.tail().0.saturating_sub(base)
     }
 
-    fn dmesg_restrict(&self) -> bool {
+    /// Returns whether `dmesg_restrict` is enabled.
+    pub fn dmesg_restrict(&self) -> bool {
         self.dmesg_restrict.load(Ordering::Relaxed)
     }
 
-    fn set_console_level(
-        &self,
-        level: LinuxConsoleLogLevel,
-        save_old: bool,
-    ) -> LinuxConsoleLogLevel {
-        let mut saved = self.saved_console_level.lock();
+    /// Sets the `dmesg_restrict` flag.
+    ///
+    /// When enabled, reading all log messages requires `CAP_SYSLOG` or `CAP_SYS_ADMIN`.
+    pub fn set_dmesg_restrict(&self, val: bool) {
+        self.dmesg_restrict.store(val, Ordering::Relaxed);
+    }
+
+    /// Sets the console log level.
+    ///
+    /// Returns the previous console log level.
+    pub fn set_console_level(&self, level: LinuxConsoleLogLevel) -> LinuxConsoleLogLevel {
         let old_raw = self.console_level.swap(level as u8, Ordering::SeqCst);
-        // SAFETY: We only store valid LinuxConsoleLogLevel values.
+        // `console_level` is only ever written from `LinuxConsoleLogLevel as u8`,
+        // so `from_raw` never fails; `unwrap_or(Info)` is defensive.
+        LinuxConsoleLogLevel::from_raw(old_raw as i32).unwrap_or(LinuxConsoleLogLevel::Info)
+    }
+
+    /// Disables console output by setting the log level to `Off`.
+    ///
+    /// The previous log level is saved and can be restored with
+    /// [`restore_console_level`](Self::restore_console_level).
+    /// Returns the previous console log level.
+    pub fn disable_console(&self) -> LinuxConsoleLogLevel {
+        let mut saved = self.saved_console_level.lock();
+        let old_raw = self.console_level.swap(LinuxConsoleLogLevel::Off as u8, Ordering::SeqCst);
         let old =
             LinuxConsoleLogLevel::from_raw(old_raw as i32).unwrap_or(LinuxConsoleLogLevel::Info);
-        if save_old && saved.is_none() {
+        if saved.is_none() {
             *saved = Some(old);
         }
         old
     }
 
-    fn restore_console_level(&self) -> LinuxConsoleLogLevel {
+    /// Restores the console log level saved by
+    /// [`disable_console`](Self::disable_console).
+    ///
+    /// Returns the restored console log level.
+    pub fn restore_console_level(&self) -> LinuxConsoleLogLevel {
         let mut saved = self.saved_console_level.lock();
         if let Some(prev) = saved.take() {
             self.console_level.store(prev as u8, Ordering::SeqCst);
@@ -373,22 +331,23 @@ impl KernelLog {
         LinuxConsoleLogLevel::from_raw(raw as i32).unwrap_or(LinuxConsoleLogLevel::Info)
     }
 
-    fn should_print(&self, level: Level) -> bool {
+    /// Checks if a log message at the given level should be printed to console.
+    pub fn should_print(&self, level: Level) -> bool {
         self.get_console_level().should_print(level)
     }
 
-    fn wait_nonempty(&self) {
+    /// Blocks until the kernel log buffer is non-empty.
+    pub fn wait_nonempty(&self) {
         self.waitq
             .wait_until(|| (!self.buffer.lock().is_empty()).then_some(()));
     }
 }
 
-/// Blocks until the kernel log buffer is non-empty.
+/// Chunk size for copying data between kernel and user space.
 ///
-/// This is used by `SYSLOG_ACTION_READ` to wait for new log messages.
-pub fn klog_wait_nonempty() {
-    klog().wait_nonempty();
-}
+/// Reading is done in chunks to limit stack usage and avoid holding
+/// locks for too long.
+const COPY_CHUNK: usize = 512;
 
 fn copy_from(rb: &RingBuffer<u8>, start: usize, dst: &mut [u8]) {
     let cap = rb.capacity();

--- a/kernel/comps/logger/src/klog.rs
+++ b/kernel/comps/logger/src/klog.rs
@@ -45,6 +45,12 @@ pub const LOG_BUFFER_CAPACITY: usize = 64 * 1024;
 /// important for logging in low-memory or allocator-internal contexts.
 const FORMAT_BUF_CAPACITY: usize = 512;
 
+/// Chunk size for copying data between kernel and user space.
+///
+/// Reading is done in chunks to limit stack usage and avoid holding
+/// locks for too long.
+const COPY_CHUNK: usize = 512;
+
 /// Linux console log level.
 ///
 /// Controls which log messages are broadcast to the console. Only messages
@@ -116,6 +122,40 @@ pub fn klog() -> &'static KernelLog {
 /// This function must be called before any logging operations.
 pub fn init_klog() {
     KLOG.call_once(KernelLog::new);
+}
+
+struct FixedBuf<'a> {
+    buf: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> FixedBuf<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, len: 0 }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Write for FixedBuf<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let space = self.buf.len().saturating_sub(self.len);
+        if space == 0 {
+            return Ok(());
+        }
+
+        let bytes = s.as_bytes();
+        let copy_len = bytes.len().min(space);
+        self.buf[self.len..self.len + copy_len].copy_from_slice(&bytes[..copy_len]);
+        self.len += copy_len;
+        Ok(())
+    }
 }
 
 /// Appends a log record to the kernel log buffer.
@@ -343,12 +383,6 @@ impl KernelLog {
     }
 }
 
-/// Chunk size for copying data between kernel and user space.
-///
-/// Reading is done in chunks to limit stack usage and avoid holding
-/// locks for too long.
-const COPY_CHUNK: usize = 512;
-
 fn copy_from(rb: &RingBuffer<u8>, start: usize, dst: &mut [u8]) {
     let cap = rb.capacity();
     let offset = start & (cap - 1);
@@ -358,39 +392,5 @@ fn copy_from(rb: &RingBuffer<u8>, start: usize, dst: &mut [u8]) {
         rb.segment().read_slice(0, &mut dst[first..]).unwrap();
     } else {
         rb.segment().read_slice(offset, dst).unwrap();
-    }
-}
-
-struct FixedBuf<'a> {
-    buf: &'a mut [u8],
-    len: usize,
-}
-
-impl<'a> FixedBuf<'a> {
-    fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, len: 0 }
-    }
-
-    fn as_bytes(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-}
-
-impl Write for FixedBuf<'_> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        let space = self.buf.len().saturating_sub(self.len);
-        if space == 0 {
-            return Ok(());
-        }
-
-        let bytes = s.as_bytes();
-        let copy_len = bytes.len().min(space);
-        self.buf[self.len..self.len + copy_len].copy_from_slice(&bytes[..copy_len]);
-        self.len += copy_len;
-        Ok(())
     }
 }

--- a/kernel/comps/logger/src/lib.rs
+++ b/kernel/comps/logger/src/lib.rs
@@ -27,8 +27,14 @@ macro_rules! __log_prefix {
 
 mod aster_logger;
 mod console;
+mod klog;
 
 pub use console::_print;
+pub use klog::{
+    LinuxConsoleLogLevel, append_log, console_level, console_off, console_on, console_set_level,
+    dmesg_restrict_get, dmesg_restrict_set, init_klog, klog_capacity, klog_read, klog_read_all,
+    klog_size_unread, klog_wait_nonempty, mark_clear, read_all_requires_cap,
+};
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {

--- a/kernel/comps/logger/src/lib.rs
+++ b/kernel/comps/logger/src/lib.rs
@@ -31,9 +31,7 @@ mod klog;
 
 pub use console::_print;
 pub use klog::{
-    LinuxConsoleLogLevel, append_log, console_level, console_off, console_on, console_set_level,
-    dmesg_restrict_get, dmesg_restrict_set, init_klog, klog_capacity, klog_read, klog_read_all,
-    klog_size_unread, klog_wait_nonempty, mark_clear, read_all_requires_cap,
+    LinuxConsoleLogLevel, append_log, init_klog, klog, LOG_BUFFER_CAPACITY,
 };
 
 #[init_component]

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_logger::{dmesg_restrict_get, dmesg_restrict_set};
+use aster_logger;
 use aster_util::printer::VmPrinter;
 
 use crate::{
@@ -11,6 +11,8 @@ use crate::{
     },
     prelude::*,
 };
+
+const DMESG_RESTRICT_MAX_INPUT: usize = 16;
 
 /// Represents the inode at `/proc/sys/kernel/dmesg_restrict`.
 pub struct DmesgRestrictFileOps;
@@ -24,7 +26,11 @@ impl DmesgRestrictFileOps {
 impl FileOps for DmesgRestrictFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
-        writeln!(printer, "{}", if dmesg_restrict_get() { 1 } else { 0 })?;
+        writeln!(
+            printer,
+            "{}",
+            if aster_logger::klog().dmesg_restrict() { 1 } else { 0 }
+        )?;
         Ok(printer.bytes_written())
     }
 
@@ -59,9 +65,7 @@ impl FileOps for DmesgRestrictFileOps {
             _ => return_errno_with_message!(Errno::EINVAL, "expected 0 or 1"),
         };
 
-        dmesg_restrict_set(val);
+        aster_logger::klog().set_dmesg_restrict(val);
         Ok(read_len)
     }
 }
-
-const DMESG_RESTRICT_MAX_INPUT: usize = 16;

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
@@ -66,6 +66,6 @@ impl FileOps for DmesgRestrictFileOps {
         };
 
         aster_logger::klog().set_dmesg_restrict(val);
-        Ok(read_len)
+        Ok(input_len)
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/dmesg_restrict.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_logger::{dmesg_restrict_get, dmesg_restrict_set};
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{FileOps, ProcFile},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+};
+
+/// Represents the inode at `/proc/sys/kernel/dmesg_restrict`.
+pub struct DmesgRestrictFileOps;
+
+impl DmesgRestrictFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl FileOps for DmesgRestrictFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        writeln!(printer, "{}", if dmesg_restrict_get() { 1 } else { 0 })?;
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        if offset != 0 {
+            return_errno_with_message!(Errno::EINVAL, "writes must start at offset 0");
+        }
+
+        let input_len = reader.remain();
+        if input_len == 0 {
+            return Ok(0);
+        }
+        if input_len > DMESG_RESTRICT_MAX_INPUT {
+            return_errno_with_message!(Errno::EINVAL, "input is too long");
+        }
+
+        let mut buf = [0u8; DMESG_RESTRICT_MAX_INPUT];
+        let mut writer = VmWriter::from(&mut buf[..input_len]).to_fallible();
+        let read_len = match reader.read_fallible(&mut writer) {
+            Ok(len) => len,
+            Err((err, 0)) => return Err(err.into()),
+            Err((err, _written)) => return Err(err.into()),
+        };
+
+        let input = core::str::from_utf8(&buf[..read_len])
+            .map_err(|_| Error::new(Errno::EINVAL))?
+            .trim();
+
+        let val = match input {
+            "0" => false,
+            "1" => true,
+            _ => return_errno_with_message!(Errno::EINVAL, "expected 0 or 1"),
+        };
+
+        dmesg_restrict_set(val);
+        Ok(read_len)
+    }
+}
+
+const DMESG_RESTRICT_MAX_INPUT: usize = 16;

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,8 @@ use crate::{
         procfs::{
             ProcDir,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps, dmesg_restrict::DmesgRestrictFileOps,
+                pid_max::PidMaxFileOps, yama::YamaDirOps,
             },
             template::{
                 DirOps, ReaddirEntry, StaticDirEntry, listed_entries_from_table,
@@ -19,6 +20,7 @@ use crate::{
 };
 
 mod cap_last_cap;
+mod dmesg_restrict;
 mod pid_max;
 mod yama;
 
@@ -39,6 +41,11 @@ impl KernelDirOps {
             "cap_last_cap",
             InodeType::File,
             CapLastCapFileOps::new_inode,
+        ),
+        (
+            "dmesg_restrict",
+            InodeType::File,
+            DmesgRestrictFileOps::new_inode,
         ),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
         ("yama", InodeType::Dir, YamaDirOps::new_inode),

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -156,6 +156,7 @@ macro_rules! import_generic_syscall_entries {
             symlink::sys_symlinkat,
             sync::{sys_sync, sys_syncfs},
             sysinfo::sys_sysinfo,
+            syslog::sys_syslog,
             tgkill::{sys_tgkill, sys_tkill},
             timer_create::{sys_timer_create, sys_timer_delete},
             timer_settime::{sys_timer_gettime, sys_timer_settime},
@@ -295,6 +296,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_TIMER_DELETE = 111           => sys_timer_delete(args[..1]);
             SYS_CLOCK_GETTIME = 113          => sys_clock_gettime(args[..2]);
             SYS_CLOCK_NANOSLEEP = 115        => sys_clock_nanosleep(args[..4]);
+            SYS_SYSLOG = 116                 => sys_syslog(args[..3]);
             SYS_PTRACE = 117                 => sys_ptrace(args[..4]);
             SYS_SCHED_SETPARAM = 118         => sys_sched_setparam(args[..2]);
             SYS_SCHED_SETSCHEDULER = 119     => sys_sched_setscheduler(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -160,6 +160,7 @@ use super::{
     symlink::{sys_symlink, sys_symlinkat},
     sync::{sys_sync, sys_syncfs},
     sysinfo::sys_sysinfo,
+    syslog::sys_syslog,
     tgkill::{sys_tgkill, sys_tkill},
     time::sys_time,
     timer_create::{sys_timer_create, sys_timer_delete},
@@ -270,6 +271,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETTIMEOFDAY = 96      => sys_gettimeofday(args[..1]);
     SYS_GETRLIMIT = 97         => sys_getrlimit(args[..2]);
     SYS_GETRUSAGE = 98         => sys_getrusage(args[..2]);
+    SYS_SYSLOG = 103           => sys_syslog(args[..3]);
     SYS_SYSINFO = 99           => sys_sysinfo(args[..1]);
     SYS_PTRACE = 101           => sys_ptrace(args[..4]);
     SYS_GETUID = 102           => sys_getuid(args[..0]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -172,6 +172,7 @@ mod statx;
 mod symlink;
 mod sync;
 mod sysinfo;
+pub(crate) mod syslog;
 mod tgkill;
 mod time;
 mod timer_create;

--- a/kernel/src/syscall/syslog.rs
+++ b/kernel/src/syscall/syslog.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_logger::{
+    LinuxConsoleLogLevel, console_off, console_on, console_set_level, klog_capacity, klog_read,
+    klog_read_all, klog_size_unread, klog_wait_nonempty, mark_clear, read_all_requires_cap,
+};
+use int_to_c_enum::TryFromInt;
+use ostd::mm::VmReader;
+
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials::capabilities::CapSet, util::MultiWrite};
+
+/// Actions for the syslog system call.
+///
+/// These actions control how the kernel log buffer is accessed and managed.
+/// See `man 2 syslog` for detailed documentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromInt)]
+#[repr(i32)]
+enum SysLogAction {
+    /// Close the log (currently a no-op).
+    Close = 0,
+    /// Open the log (currently a no-op).
+    Open = 1,
+    /// Read from the log (blocking, destructive).
+    Read = 2,
+    /// Read all messages remaining in the ring buffer (non-destructive).
+    ReadAll = 3,
+    /// Read and clear all messages remaining in the ring buffer.
+    ReadClear = 4,
+    /// Clear the ring buffer.
+    Clear = 5,
+    /// Disable printk to console.
+    ConsoleOff = 6,
+    /// Enable printk to console.
+    ConsoleOn = 7,
+    /// Set the console log level.
+    ConsoleLevel = 8,
+    /// Return number of unread characters in the log buffer.
+    SizeUnread = 9,
+    /// Return the size of the log buffer.
+    SizeBuffer = 10,
+}
+
+/// Temporary buffer size for copying data between kernel and user space.
+const TMP_BUF: usize = 512;
+
+pub fn sys_syslog(action: i32, buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let action = SysLogAction::try_from(action)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "unknown syslog action"))?;
+
+    match action {
+        SysLogAction::Close | SysLogAction::Open => Ok(SyscallReturn::Return(0)),
+        SysLogAction::Read => {
+            ensure_cap(ctx)?;
+            Ok(SyscallReturn::Return(
+                read_destructive(buf, len, ctx)? as isize
+            ))
+        }
+        SysLogAction::ReadAll => {
+            if read_all_requires_cap() {
+                ensure_cap(ctx)?;
+            }
+            Ok(SyscallReturn::Return(
+                read_all(buf, len, ctx, false)? as isize
+            ))
+        }
+        SysLogAction::ReadClear => {
+            ensure_cap(ctx)?;
+            let copied = read_all(buf, len, ctx, true)?;
+            Ok(SyscallReturn::Return(copied as isize))
+        }
+        SysLogAction::Clear => {
+            ensure_cap(ctx)?;
+            mark_clear();
+            Ok(SyscallReturn::Return(0))
+        }
+        SysLogAction::ConsoleOff => {
+            ensure_cap(ctx)?;
+            console_off();
+            Ok(SyscallReturn::Return(0))
+        }
+        SysLogAction::ConsoleOn => {
+            ensure_cap(ctx)?;
+            console_on();
+            Ok(SyscallReturn::Return(0))
+        }
+        SysLogAction::ConsoleLevel => {
+            ensure_cap(ctx)?;
+            let new_level = LinuxConsoleLogLevel::from_raw(len as i32)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid console level"))?;
+            let _old = console_set_level(new_level);
+            Ok(SyscallReturn::Return(0))
+        }
+        SysLogAction::SizeUnread => {
+            ensure_cap(ctx)?;
+            Ok(SyscallReturn::Return(klog_size_unread() as isize))
+        }
+        SysLogAction::SizeBuffer => {
+            if read_all_requires_cap() {
+                ensure_cap(ctx)?;
+            }
+            Ok(SyscallReturn::Return(klog_capacity() as isize))
+        }
+    }
+}
+
+fn ensure_cap(ctx: &Context) -> Result<()> {
+    let credentials = ctx.posix_thread.credentials();
+    if credentials
+        .effective_capset()
+        .intersects(CapSet::SYS_ADMIN | CapSet::SYSLOG)
+    {
+        return Ok(());
+    }
+    return_errno_with_message!(Errno::EPERM, "operation not permitted")
+}
+
+fn read_destructive(buf: Vaddr, len: usize, ctx: &Context) -> Result<usize> {
+    if len == 0 {
+        return Ok(0);
+    }
+    let mut tmp = [0u8; TMP_BUF];
+    let mut copied = 0;
+    let user_space = ctx.user_space();
+    let mut writer = user_space.writer(buf, len)?;
+
+    while copied < len {
+        // Block until at least one byte is available, then drain non-blocking.
+        if copied == 0 {
+            klog_wait_nonempty();
+        }
+        let to_take = core::cmp::min(len - copied, tmp.len());
+        let n = klog_read(&mut tmp[..to_take]);
+        if n == 0 {
+            // If we raced with another reader after waiting, wait again for the first byte.
+            if copied == 0 {
+                // Retry waiting for data.
+                continue;
+            }
+            break;
+        }
+        let mut reader = VmReader::from(&tmp[..n]);
+        writer.write(&mut reader)?;
+        copied += n;
+    }
+    Ok(copied)
+}
+
+fn read_all(buf: Vaddr, len: usize, ctx: &Context, clear_after: bool) -> Result<usize> {
+    if len == 0 {
+        return Ok(0);
+    }
+    let mut tmp = [0u8; TMP_BUF];
+    let mut copied = 0;
+    let mut offset = 0;
+    let user_space = ctx.user_space();
+    let mut writer = user_space.writer(buf, len)?;
+
+    while copied < len {
+        let to_take = core::cmp::min(len - copied, tmp.len());
+        let n = klog_read_all(&mut tmp[..to_take], offset, len);
+        if n == 0 {
+            break;
+        }
+        let mut reader = VmReader::from(&tmp[..n]);
+        writer.write(&mut reader)?;
+        copied += n;
+        offset += n;
+    }
+
+    if clear_after {
+        mark_clear();
+    }
+
+    Ok(copied)
+}

--- a/kernel/src/syscall/syslog.rs
+++ b/kernel/src/syscall/syslog.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_logger::{
-    LinuxConsoleLogLevel, console_off, console_on, console_set_level, klog_capacity, klog_read,
-    klog_read_all, klog_size_unread, klog_wait_nonempty, mark_clear, read_all_requires_cap,
-};
+use aster_logger::{self, LinuxConsoleLogLevel, LOG_BUFFER_CAPACITY};
 use int_to_c_enum::TryFromInt;
 use ostd::mm::VmReader;
 
@@ -57,7 +54,7 @@ pub fn sys_syslog(action: i32, buf: Vaddr, len: usize, ctx: &Context) -> Result<
             ))
         }
         SysLogAction::ReadAll => {
-            if read_all_requires_cap() {
+            if aster_logger::klog().dmesg_restrict() {
                 ensure_cap(ctx)?;
             }
             Ok(SyscallReturn::Return(
@@ -71,35 +68,43 @@ pub fn sys_syslog(action: i32, buf: Vaddr, len: usize, ctx: &Context) -> Result<
         }
         SysLogAction::Clear => {
             ensure_cap(ctx)?;
-            mark_clear();
+            aster_logger::klog().mark_clear();
             Ok(SyscallReturn::Return(0))
         }
         SysLogAction::ConsoleOff => {
             ensure_cap(ctx)?;
-            console_off();
+            aster_logger::klog().disable_console();
             Ok(SyscallReturn::Return(0))
         }
         SysLogAction::ConsoleOn => {
             ensure_cap(ctx)?;
-            console_on();
+            aster_logger::klog().restore_console_level();
             Ok(SyscallReturn::Return(0))
         }
         SysLogAction::ConsoleLevel => {
             ensure_cap(ctx)?;
-            let new_level = LinuxConsoleLogLevel::from_raw(len as i32)
+            let raw = len as i32;
+            if !(1..=8).contains(&raw) {
+                return_errno_with_message!(Errno::EINVAL, "console level out of range");
+            }
+            let new_level = LinuxConsoleLogLevel::from_raw(raw)
                 .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid console level"))?;
-            let _old = console_set_level(new_level);
+            aster_logger::klog().set_console_level(new_level);
             Ok(SyscallReturn::Return(0))
         }
         SysLogAction::SizeUnread => {
-            ensure_cap(ctx)?;
-            Ok(SyscallReturn::Return(klog_size_unread() as isize))
-        }
-        SysLogAction::SizeBuffer => {
-            if read_all_requires_cap() {
+            if aster_logger::klog().dmesg_restrict() {
                 ensure_cap(ctx)?;
             }
-            Ok(SyscallReturn::Return(klog_capacity() as isize))
+            Ok(SyscallReturn::Return(
+                aster_logger::klog().size_unread() as isize
+            ))
+        }
+        SysLogAction::SizeBuffer => {
+            if aster_logger::klog().dmesg_restrict() {
+                ensure_cap(ctx)?;
+            }
+            Ok(SyscallReturn::Return(LOG_BUFFER_CAPACITY as isize))
         }
     }
 }
@@ -127,10 +132,10 @@ fn read_destructive(buf: Vaddr, len: usize, ctx: &Context) -> Result<usize> {
     while copied < len {
         // Block until at least one byte is available, then drain non-blocking.
         if copied == 0 {
-            klog_wait_nonempty();
+            aster_logger::klog().wait_nonempty();
         }
         let to_take = core::cmp::min(len - copied, tmp.len());
-        let n = klog_read(&mut tmp[..to_take]);
+        let n = aster_logger::klog().read(&mut tmp[..to_take]);
         if n == 0 {
             // If we raced with another reader after waiting, wait again for the first byte.
             if copied == 0 {
@@ -155,10 +160,12 @@ fn read_all(buf: Vaddr, len: usize, ctx: &Context, clear_after: bool) -> Result<
     let mut offset = 0;
     let user_space = ctx.user_space();
     let mut writer = user_space.writer(buf, len)?;
+    let klog = aster_logger::klog();
+    let at_tail = klog.snapshot_tail();
 
     while copied < len {
         let to_take = core::cmp::min(len - copied, tmp.len());
-        let n = klog_read_all(&mut tmp[..to_take], offset, len);
+        let n = klog.read_all(&mut tmp[..to_take], offset, len, at_tail);
         if n == 0 {
             break;
         }
@@ -169,7 +176,7 @@ fn read_all(buf: Vaddr, len: usize, ctx: &Context, clear_after: bool) -> Result<
     }
 
     if clear_after {
-        mark_clear();
+        klog.mark_clear();
     }
 
     Ok(copied)


### PR DESCRIPTION
- Add `sys_syslog` module with circular 64 KB kernel log buffer and `dmesg_restrict`.
- Extend `AsterLogger` to push logs into the buffer and honor console log levels.
- Register callback in syscall init, dispatch on x86/RISCV (`SYS_SYSLOG`).