### PR TITLE
Install clang into the docker image

### DIFF
--- a/osdk/tools/docker/Dockerfile
+++ b/osdk/tools/docker/Dockerfile
@@ -125,6 +125,7 @@ FROM build-base AS rust
 # Install all OSDK dependent packages
 RUN apt update \
     && apt install -y \
+    clang \
     curl \
     gdb \
     grub-efi-amd64 \


### PR DESCRIPTION
Install clang into the docker image for coverage feature in #2203 , since `minicov` requires clang to compile.

Clang is introduced in #1857 and removed in #2231.