### PR TITLE
Support `SO_PASSCRED` & `SCM_CREDENTIALS` & `SOCK_SEQPACKET`

### DIFF
--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -21,6 +21,7 @@ impl_socket_options!(
     pub struct Priority(i32);
     pub struct Linger(LingerOption);
     pub struct KeepAlive(bool);
+    pub struct PassCred(bool);
     pub struct PeerCred(CUserCred);
     pub struct AcceptConn(bool);
     pub struct SendBufForce(u32);

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -17,7 +17,7 @@ use crate::{
             addr::{UnixSocketAddr, UnixSocketAddrBound},
             cred::SocketCred,
         },
-        util::SockShutdownCmd,
+        util::{options::SocketOptionSet, SockShutdownCmd},
     },
     prelude::*,
     process::signal::Pollee,
@@ -54,6 +54,7 @@ impl Init {
         peer_addr: UnixSocketAddrBound,
         pollee: Pollee,
         peer_cred: SocketCred,
+        options: &SocketOptionSet,
     ) -> (Connected, Connected) {
         let Init {
             addr,
@@ -71,6 +72,7 @@ impl Init {
             EndpointState::new(Pollee::new(), is_write_shutdown.into_inner()),
             cred,
             peer_cred,
+            options,
         );
 
         (this_conn, peer_conn)

--- a/kernel/src/net/socket/unix/stream/init.rs
+++ b/kernel/src/net/socket/unix/stream/init.rs
@@ -82,6 +82,7 @@ impl Init {
         self,
         backlog: usize,
         pollee: Pollee,
+        is_seqpacket: bool,
     ) -> core::result::Result<Listener, (Error, Self)> {
         let Some(addr) = self.addr else {
             return Err((
@@ -98,6 +99,7 @@ impl Init {
             self.is_read_shutdown.into_inner(),
             self.is_write_shutdown.into_inner(),
             pollee,
+            is_seqpacket,
         ))
     }
 

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -20,7 +20,7 @@ use crate::{
             cred::SocketCred,
             stream::socket::OptionSet,
         },
-        util::{SockShutdownCmd, SocketAddr},
+        util::{options::SocketOptionSet, SockShutdownCmd, SocketAddr},
     },
     prelude::*,
     process::signal::Pollee,
@@ -234,6 +234,7 @@ impl Backlog {
         &self,
         init: Init,
         pollee: Pollee,
+        options: &SocketOptionSet,
     ) -> core::result::Result<Connected, (Error, Init)> {
         let mut locked_incoming_conns = self.incoming_conns.lock();
 
@@ -261,6 +262,7 @@ impl Backlog {
             self.addr.clone(),
             pollee,
             self.listener_cred.dup().restrict(),
+            options,
         );
 
         incoming_conns.push_back(server_conn);

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -38,9 +38,10 @@ impl Listener {
         is_read_shutdown: bool,
         is_write_shutdown: bool,
         pollee: Pollee,
+        is_seqpacket: bool,
     ) -> Self {
         let backlog = BACKLOG_TABLE
-            .add_backlog(addr, pollee, backlog, is_read_shutdown)
+            .add_backlog(addr, pollee, backlog, is_read_shutdown, is_seqpacket)
             .unwrap();
 
         Self {
@@ -53,13 +54,13 @@ impl Listener {
         self.backlog.addr()
     }
 
-    pub(super) fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    pub(super) fn try_accept(&self, is_seqpacket: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         let connected = self.backlog.pop_incoming()?;
 
         let peer_addr = connected.peer_addr().into();
         // TODO: Update options for a newly-accepted socket
         let options = OptionSet::new();
-        let socket = UnixStreamSocket::new_connected(connected, options, false);
+        let socket = UnixStreamSocket::new_connected(connected, options, false, is_seqpacket);
 
         Ok((socket, peer_addr))
     }
@@ -123,6 +124,7 @@ impl BacklogTable {
         pollee: Pollee,
         backlog: usize,
         is_shutdown: bool,
+        is_seqpacket: bool,
     ) -> Option<Arc<Backlog>> {
         let addr_key = addr.to_key();
 
@@ -132,7 +134,13 @@ impl BacklogTable {
             return None;
         }
 
-        let new_backlog = Arc::new(Backlog::new(addr, pollee, backlog, is_shutdown));
+        let new_backlog = Arc::new(Backlog::new(
+            addr,
+            pollee,
+            backlog,
+            is_shutdown,
+            is_seqpacket,
+        ));
         backlog_sockets.insert(addr_key, new_backlog.clone());
 
         Some(new_backlog)
@@ -154,10 +162,17 @@ pub(super) struct Backlog {
     incoming_conns: SpinLock<Option<VecDeque<Connected>>>,
     wait_queue: WaitQueue,
     listener_cred: SocketCred<ReadDupOp>,
+    is_seqpacket: bool,
 }
 
 impl Backlog {
-    fn new(addr: UnixSocketAddrBound, pollee: Pollee, backlog: usize, is_shutdown: bool) -> Self {
+    fn new(
+        addr: UnixSocketAddrBound,
+        pollee: Pollee,
+        backlog: usize,
+        is_shutdown: bool,
+        is_seqpacket: bool,
+    ) -> Self {
         let incoming_sockets = if is_shutdown {
             None
         } else {
@@ -171,6 +186,7 @@ impl Backlog {
             incoming_conns: SpinLock::new(incoming_sockets),
             wait_queue: WaitQueue::new(),
             listener_cred: SocketCred::<ReadDupOp>::new_current(),
+            is_seqpacket,
         }
     }
 
@@ -235,7 +251,21 @@ impl Backlog {
         init: Init,
         pollee: Pollee,
         options: &SocketOptionSet,
+        is_seqpacket: bool,
     ) -> core::result::Result<Connected, (Error, Init)> {
+        if is_seqpacket != self.is_seqpacket {
+            // FIXME: According to the Linux implementation, we should avoid this error by
+            // maintaining two socket tables for SOCK_STREAM sockets and SOCK_SEQPACKET sockets
+            // separately.
+            return Err((
+                Error::with_message(
+                    Errno::ECONNREFUSED,
+                    "the listening socket has a different socket type",
+                ),
+                init,
+            ));
+        }
+
         let mut locked_incoming_conns = self.incoming_conns.lock();
 
         let Some(incoming_conns) = &mut *locked_incoming_conns else {

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -123,7 +123,7 @@ impl SocketOptionSet {
                 socket_pass_cred.set(pass_cred);
             },
             socket_peer_cred: PeerCred => {
-                let peer_cred = CUserCred::new_unknown();
+                let peer_cred = CUserCred::new_invalid();
                 socket_peer_cred.set(peer_cred);
             },
             socket_accept_conn: AcceptConn => {
@@ -198,6 +198,7 @@ impl SocketOptionSet {
                 // sockets for setting and getting.
                 let pass_cred = socket_pass_cred.get().unwrap();
                 self.set_pass_cred(*pass_cred);
+                socket.set_pass_cred(*pass_cred);
             },
             socket_sendbuf_force: SendBufForce => {
                 check_current_privileged()?;
@@ -263,4 +264,6 @@ pub(in crate::net) trait SetSocketLevelOption {
     fn set_keep_alive(&self, _keep_alive: bool) -> NeedIfacePoll {
         NeedIfacePoll::FALSE
     }
+    /// Sets whether receipt of the credentials of the sending process is enabled.
+    fn set_pass_cred(&self, _pass_cred: bool) {}
 }

--- a/kernel/src/process/credentials/group.rs
+++ b/kernel/src/process/credentials/group.rs
@@ -16,6 +16,14 @@ impl Gid {
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L51>.
     pub const INVALID: Gid = Gid(u32::MAX);
 
+    /// The overflow GID, typically used to indicate that group mappings between namespaces fail.
+    ///
+    /// This is currently a constant (65534 is usually the "nobody" group), but it should be
+    /// configured via `/proc/sys/kernel/overflowgid`.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/kernel/sys.c#L167>.
+    pub const OVERFLOW: Gid = Self::new(65534);
+
     pub const fn new(gid: u32) -> Self {
         Self(gid)
     }

--- a/kernel/src/process/credentials/user.rs
+++ b/kernel/src/process/credentials/user.rs
@@ -18,6 +18,14 @@ impl Uid {
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L50>.
     pub const INVALID: Uid = Self::new(u32::MAX);
 
+    /// The overflow UID, typically used to indicate that user mappings between namespaces fail.
+    ///
+    /// This is currently a constant (65534 is usually the "nobody" user), but it should be
+    /// configured via `/proc/sys/kernel/overflowuid`.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/kernel/sys.c#L166>.
+    pub const OVERFLOW: Uid = Self::new(65534);
+
     pub const fn new_root() -> Self {
         Self(ROOT_UID)
     }

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -4,7 +4,7 @@ use super::RawSocketOption;
 use crate::{
     current_userspace, impl_raw_sock_option_get_only, impl_raw_socket_option,
     net::socket::options::{
-        AcceptConn, Error, KeepAlive, Linger, PeerCred, PeerGroups, Priority, RecvBuf,
+        AcceptConn, Error, KeepAlive, Linger, PassCred, PeerCred, PeerGroups, Priority, RecvBuf,
         RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,
     },
     prelude::*,
@@ -57,6 +57,7 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
         CSocketOptionName::PRIORITY => Ok(Box::new(Priority::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
+        CSocketOptionName::PASSCRED => Ok(Box::new(PassCred::new())),
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
         CSocketOptionName::PEERCRED => Ok(Box::new(PeerCred::new())),
         CSocketOptionName::ACCPETCONN => Ok(Box::new(AcceptConn::new())),
@@ -75,6 +76,7 @@ impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(Priority);
 impl_raw_socket_option!(Linger);
 impl_raw_socket_option!(KeepAlive);
+impl_raw_socket_option!(PassCred);
 impl_raw_sock_option_get_only!(PeerCred);
 impl_raw_sock_option_get_only!(AcceptConn);
 impl_raw_socket_option!(SendBufForce);

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -346,6 +346,8 @@ impl<R: Deref<Target = RingBuffer<u8>>> Producer<u8, R> {
         rb.advance_tail(tail, write_len);
         Ok(write_len)
     }
+
+    // There is no counterpart to `Consumer::skip`. It does not make sense for the producer.
 }
 
 #[inherit_methods(from = "self.rb")]
@@ -459,6 +461,22 @@ impl<R: Deref<Target = RingBuffer<u8>>> Consumer<u8, R> {
 
         rb.advance_head(head, read_len);
         Ok(read_len)
+    }
+
+    /// Skips `count` bytes in the `RingBuffer`.
+    ///
+    /// In other words, `count` bytes are read from the `RingBuffer` and discarded.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the number of the available bytes to read is less than `count`.
+    pub fn skip(&mut self, count: usize) {
+        let rb = &self.rb;
+        let len = rb.len();
+        assert!(len >= count);
+
+        let head = rb.head();
+        rb.advance_head(head, count);
     }
 }
 

--- a/test/src/apps/network/unix_seqpacket_err.c
+++ b/test/src/apps/network/unix_seqpacket_err.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define SOCK_TYPE SOCK_SEQPACKET
+#include "unix_streamlike_prologue.h"
+
+FN_TEST(sendto)
+{
+	char buf[1] = { 'z' };
+
+	TEST_ERRNO(sendto(sk_unbound, buf, 1, 0, &LISTEN_ADDR, LISTEN_ADDRLEN),
+		   ENOTCONN);
+	TEST_ERRNO(sendto(sk_bound, buf, 1, 0, &LISTEN_ADDR2, LISTEN_ADDRLEN2),
+		   ENOTCONN);
+	TEST_ERRNO(sendto(sk_listen, buf, 1, 0, &BOUND_ADDR, BOUND_ADDRLEN),
+		   ENOTCONN);
+}
+END_TEST()
+
+FN_TEST(send_recv_trunc)
+{
+	int fildes[2];
+	char buf[1];
+
+	TEST_SUCC(
+		socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, fildes));
+
+	TEST_SUCC(send(fildes[0], "abc", 3, 0));
+	TEST_SUCC(send(fildes[0], "def", 3, 0));
+	TEST_SUCC(send(fildes[0], "hij", 3, 0));
+
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 1 && buf[0] == 'a');
+	TEST_RES(recv(fildes[1], buf, 0, 0), _ret == 0);
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 1 && buf[0] == 'h');
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+FN_TEST(send_recv_zero)
+{
+	int fildes[2];
+	char buf[1];
+
+	TEST_SUCC(
+		socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, fildes));
+
+	buf[0] = 'a';
+	TEST_SUCC(send(fildes[0], buf, 1, 0));
+	buf[0] = 'b';
+	TEST_SUCC(send(fildes[0], buf, 0, 0));
+	buf[0] = 'c';
+	TEST_SUCC(send(fildes[0], buf, 0, 0));
+	buf[0] = 'd';
+	TEST_SUCC(send(fildes[0], buf, 1, 0));
+
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 1 && buf[0] == 'a');
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 0 && buf[0] == 'a');
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 0 && buf[0] == 'a');
+	TEST_RES(recv(fildes[1], buf, 1, 0), _ret == 1 && buf[0] == 'd');
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+#include "unix_streamlike_epilogue.h"

--- a/test/src/apps/network/unix_stream_err.c
+++ b/test/src/apps/network/unix_stream_err.c
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define SOCK_TYPE SOCK_STREAM
+#include "unix_streamlike_prologue.h"
+
+FN_TEST(sendto)
+{
+	char buf[1] = { 'z' };
+
+	TEST_ERRNO(sendto(sk_unbound, buf, 1, 0, &LISTEN_ADDR, LISTEN_ADDRLEN),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_bound, buf, 1, 0, &LISTEN_ADDR2, LISTEN_ADDRLEN2),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_listen, buf, 1, 0, &BOUND_ADDR, BOUND_ADDRLEN),
+		   EOPNOTSUPP);
+	TEST_ERRNO(sendto(sk_accepted, buf, 1, 0, &UNNAMED_ADDR,
+			  UNNAMED_ADDRLEN),
+		   EISCONN);
+}
+END_TEST()
+
+FN_TEST(scm_rights)
+{
+	int fildes[2];
+	char buf[20] = "abcdefg";
+	char cbuf[CMSG_SPACE(sizeof(int) * 3)];
+	struct iovec iov;
+	struct msghdr mhdr;
+	struct cmsghdr *chdr;
+	int *cdata;
+	int cfds[2];
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fildes));
+
+	memset(&mhdr, 0, sizeof(mhdr));
+	mhdr.msg_iov = &iov;
+	mhdr.msg_iovlen = 1;
+	mhdr.msg_control = cbuf;
+	mhdr.msg_controllen = CMSG_SPACE(sizeof(int) * 3);
+
+	iov.iov_base = buf;
+	iov.iov_len = 1;
+
+	chdr = CMSG_FIRSTHDR(&mhdr);
+	chdr->cmsg_level = SOL_SOCKET;
+	chdr->cmsg_type = SCM_RIGHTS;
+	chdr->cmsg_len = CMSG_SPACE(sizeof(int) * 3);
+
+	cdata = (int *)CMSG_DATA(chdr);
+	TEST_SUCC(pipe(cfds));
+	cdata[0] = cfds[0];
+	cdata[1] = cfds[0];
+	cdata[2] = cfds[1];
+
+	// Sending control messages with zero bytes to a stream socket
+	// seems to "succeed". However, no data or control messages can
+	// be transmitted.
+	mhdr.msg_iovlen = 0;
+	TEST_SUCC(sendmsg(fildes[0], &mhdr, 0));
+	mhdr.msg_iovlen = 1;
+
+	// > (1)  sendmsg(2) of four bytes, with no ancillary data.
+	// > (2)  sendmsg(2) of one byte, with ancillary data.
+	// > (3)  sendmsg(2) of four bytes, with no ancillary data.
+	//  -- https://man7.org/linux/man-pages/man7/unix.7.html
+	TEST_RES(send(fildes[0], buf, 4, 0), _ret == 4);
+	TEST_RES(sendmsg(fildes[0], &mhdr, 0), _ret == 1);
+	TEST_RES(send(fildes[0], buf, 4, 0), _ret == 4);
+
+	memset(&mhdr, 0, sizeof(mhdr));
+	mhdr.msg_iov = &iov;
+	mhdr.msg_iovlen = 1;
+	mhdr.msg_control = cbuf;
+	mhdr.msg_controllen = CMSG_SPACE(sizeof(int));
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(cbuf, 0, sizeof(cbuf));
+
+	// > Suppose that the receiver now performs recvmsg(2) calls each with
+	// > a buffer size of 20 bytes.  The first call will receive five bytes
+	// > of data, along with the ancillary data sent by the second
+	// > sendmsg(2) call.
+	TEST_RES(recvmsg(fildes[1], &mhdr, 0),
+		 _ret == 5 &&
+			 mhdr.msg_controllen == CMSG_SPACE(sizeof(int) * 2) &&
+			 (chdr = CMSG_FIRSTHDR(&mhdr)) &&
+			 chdr->cmsg_level == SOL_SOCKET &&
+			 chdr->cmsg_type == SCM_RIGHTS &&
+			 chdr->cmsg_len == CMSG_SPACE(sizeof(int) * 2) &&
+			 (cdata = (int *)CMSG_DATA(chdr)) &&
+			 cdata[0] == cfds[1] + 1 && cdata[1] == cfds[1] + 2);
+	// > The next call will receive the remaining four
+	// > bytes of data.
+	TEST_RES(recv(fildes[1], buf, sizeof(buf), 0), _ret == 4);
+
+	// The purpose of the tests below is to verify that the received file
+	// descriptors are functional.
+	TEST_RES(write(cfds[1], "x", 1), _ret == 1);
+	TEST_RES(read(cdata[0], buf, 1), _ret == 1 && buf[0] == 'x');
+	TEST_RES(write(cfds[1], "y", 1), _ret == 1);
+	TEST_RES(read(cdata[1], buf, 1), _ret == 1 && buf[0] == 'y');
+
+	TEST_SUCC(close(cdata[0]));
+	TEST_SUCC(close(cdata[1]));
+	TEST_SUCC(close(cfds[0]));
+
+	TEST_ERRNO(write(cfds[1], "y", 1), EPIPE);
+	TEST_SUCC(close(cfds[1]));
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+#include "unix_streamlike_epilogue.h"

--- a/test/src/apps/network/unix_streamlike_epilogue.h
+++ b/test/src/apps/network/unix_streamlike_epilogue.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(sk_unbound));
+
+	CHECK(close(sk_bound));
+
+	CHECK(close(sk_listen));
+
+	CHECK(close(sk_connected));
+
+	CHECK(close(sk_accepted));
+
+	CHECK(unlink(BOUND_ADDR.sun_path));
+
+	CHECK(unlink(LISTEN_ADDR.sun_path));
+}
+END_SETUP()

--- a/test/src/apps/scripts/network.sh
+++ b/test/src/apps/scripts/network.sh
@@ -33,7 +33,8 @@ sleep 0.2
 ./tcp_err
 ./tcp_poll
 ./udp_err
-./unix_err
+./unix_stream_err
+./unix_seqpacket_err
 
 ./netlink_route
 ./rtnl_err

--- a/test/src/apps/test.h
+++ b/test/src/apps/test.h
@@ -37,10 +37,11 @@
 #include <string.h>
 
 /** Starts the definition of a setup function. */
-#define FN_SETUP(name)                                                        \
-	void setup_##name(void) __attribute__((constructor(__LINE__ + 200))); \
-                                                                              \
-	void setup_##name(void)                                               \
+#define FN_SETUP(name)                                           \
+	void setup_##name(void)                                  \
+		__attribute__((constructor(__COUNTER__ + 200))); \
+                                                                 \
+	void setup_##name(void)                                  \
 	{
 /** Ends the definition of a setup function. */
 #define END_SETUP() }
@@ -84,11 +85,12 @@
 static int __total_failures;
 
 /** Starts the definition of a test function. */
-#define FN_TEST(name)                                                        \
-	void test_##name(void) __attribute__((constructor(__LINE__ + 200))); \
-                                                                             \
-	void test_##name(void)                                               \
-	{                                                                    \
+#define FN_TEST(name)                                            \
+	void test_##name(void)                                   \
+		__attribute__((constructor(__COUNTER__ + 200))); \
+                                                                 \
+	void test_##name(void)                                   \
+	{                                                        \
 		int __tests_passed = 0, __tests_failed = 0;
 
 /** Ends the definition of a test function. */

--- a/test/src/syscall/gvisor/Makefile
+++ b/test/src/syscall/gvisor/Makefile
@@ -51,7 +51,10 @@ TESTS ?= \
 	signalfd_test \
 	socket_netlink_route_test \
 	socket_unix_pair_test \
+	socket_unix_seqpacket_local_test \
 	socket_unix_stream_test \
+	socket_unix_unbound_seqpacket_test \
+	socket_unix_unbound_stream_test \
 	stat_test \
 	stat_times_test \
 	statfs_test \

--- a/test/src/syscall/gvisor/blocklists/socket_unix_pair_test
+++ b/test/src/syscall/gvisor/blocklists/socket_unix_pair_test
@@ -1,11 +1,3 @@
-# TODO: Support `SOCK_SEQPACKET` sockets
-AllUnixDomainSockets/UnixSocketPairTest.BindToBadName/*
-AllUnixDomainSockets/UnixSocketPairTest.BindToBadFamily/*
-AllUnixDomainSockets/*/4
-AllUnixDomainSockets/*/5
-AllUnixDomainSockets/*/10
-AllUnixDomainSockets/*/11
-
 # TODO: Support `SOCK_DGRAM` sockets
 AllUnixDomainSockets/*/2
 AllUnixDomainSockets/*/3
@@ -23,5 +15,17 @@ AllUnixDomainSockets/UnixSocketPairTest.NetdeviceIoctlsSucceed/*
 # TODO: Fix operations on `/proc/*/fd/*`
 AllUnixDomainSockets/UnixSocketPairTest.SocketReopenFromProcfs/*
 
-# TODO: Support control messages
-AllUnixDomainSockets/UnixSocketPairCmsgTest.*
+# TODO: Report `MSG_(C)TRUNC` after truncating the (control) message
+AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicFDPassNoSpaceMsgCtrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicFDPassNullControlMsgCtrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicFDPassNotEnoughSpaceMsgCtrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicThreeFDPassTruncationMsgCtrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicTwoFDPassUnalignedRecvTruncationMsgTrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.CredPassNoSpaceMsgCtrunc/*
+AllUnixDomainSockets/UnixSocketPairCmsgTest.CredPassTruncatedMsgCtrunc/*
+
+# TODO: Support `MSG_CMSG_CLOEXEC`
+AllUnixDomainSockets/UnixSocketPairCmsgTest.CloexecRecvFDPass/*
+
+# TODO: Support `MSG_PEEK`
+AllUnixDomainSockets/UnixSocketPairCmsgTest.FDPassPeek/*

--- a/test/src/syscall/gvisor/blocklists/socket_unix_seqpacket_local_test
+++ b/test/src/syscall/gvisor/blocklists/socket_unix_seqpacket_local_test
@@ -1,0 +1,13 @@
+# TODO: Support `MSG_DONTWAIT` and `MSG_PEEK`
+SeqpacketUnixSockets/NonStreamSocketPairTest.SplitRecv/*
+SeqpacketUnixSockets/NonStreamSocketPairTest.SinglePeek/*
+SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgTruncPeekDontwaitZeroLen/*
+
+# TODO: Support `SO_SNDTIMEO`
+SeqpacketUnixSockets/UnixNonStreamSocketPairTest.SendTimeout/*
+
+# TODO: Support `MSG_TRUNC`
+SeqpacketUnixSockets/NonStreamSocketPairTest.MsgTruncTruncation/*
+SeqpacketUnixSockets/NonStreamSocketPairTest.MsgTruncTruncationRecvmsgMsghdrFlagMsgTrunc/*
+SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncZeroLen/*
+SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncMsgPeekZeroLen/*


### PR DESCRIPTION
~*Based on https://github.com/asterinas/asterinas/pull/2176. Please review https://github.com/asterinas/asterinas/pull/2176 first*.~

---

The socket option `SO_PASSCRED` controls the behavior of the `SCM_CREDENTIALS` control message, so they should be implemented together.

More details:
 - If `SO_PASSCRED` is disabled, `SCM_CREDENTIALS` will never be delivered to the receiver, even if the sender specifies it.
 - If `SO_PASSCRED` is on, `SCM_CREDENTIALS` will always be delivered, regardless of whether the sender specifies it.
   - If `SO_PASSCRED` is off when the message is sent but on when it is received, `SCM_CREDENTIALS` will be delivered. However, it will not contain the sender's credentials because they are not recorded. Instead, placeholder values will be used.

The third commit adds support for `SOCK_SEQPACKET` sockets using some control message tricks. The only purpose of the third commit is to enable a number of gVisor tests. As I said in https://github.com/asterinas/asterinas/pull/2176,
> [Many FD-passing tests use SOCK_SEQPACKET sockets](https://github.com/google/gvisor/blob/128211909518e94a57659411be3aac4140d29fc6/test/syscalls/linux/socket_unix_cmsg.cc#L100) and will therefore fail due to the lack of support for this socket type.
