### PR TITLE
Use iret instead of sysret if the context is not clean

### DIFF
--- a/ostd/src/arch/x86/trap/syscall.S
+++ b/ostd/src/arch/x86/trap/syscall.S
@@ -9,6 +9,7 @@
  *
  * We make the following new changes:
  * * Skip saving/restoring the fsgsbase registers.
+ * * Use new logic to determine whether to use sysret or iret.
  *
  * These changes are released under the following license:
  *
@@ -62,9 +63,27 @@ syscall_return:
     # trap_num
     # error_code
 
-    # determain sysret or iret
-    cmp dword ptr [rsp + 4*8], 0x100  # syscall?
+    # Determine whether to use sysret or iret.
+    # If returning to user space with a clean context,
+    # the fast sysret path can be used;
+    # otherwise, the slower iret path should be used.
+    # Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/arch/x86/entry/entry_64.S#L122>.
+
+    cmp qword ptr [rsp], rcx      # sysret requires rcx = rip
+    jne iret
+
+    cmp qword ptr [rsp + 8], r11  # sysret requires r11 = rflags
+    jne iret 
+
+    test r11, 0x10100             # sysret requires rflags not contain RF and TF flags
+    jnz iret
+
+    shl rcx, 64 - {ADDRESS_WIDTH}
+    sar rcx, 64 - {ADDRESS_WIDTH}
+    cmp qword ptr [rsp], rcx      # sysret requires rip be a canonical address
     je sysret
+    mov rcx, [rsp]
+
 iret:
     # construct trap frame
     push {USER_SS}          # push ss
@@ -76,9 +95,7 @@ iret:
     iretq
 
 sysret:
-    pop rcx                 # rcx = rip
-    pop r11                 # r11 = rflags
-    mov rsp, [rsp - 11*8]   # load rsp
+    mov rsp, [rsp - 9*8]    # load rsp
 
     sysretq
 

--- a/ostd/src/arch/x86/trap/syscall.rs
+++ b/ostd/src/arch/x86/trap/syscall.rs
@@ -29,11 +29,13 @@ use x86_64::{
 };
 
 use super::RawUserContext;
+use crate::mm::PagingConstsTrait;
 
 global_asm!(
     include_str!("syscall.S"),
     USER_CS = const super::gdt::USER_CS.0,
     USER_SS = const super::gdt::USER_SS.0,
+    ADDRESS_WIDTH = const crate::mm::kspace::KernelPtConfig::ADDRESS_WIDTH,
 );
 
 /// # Safety


### PR DESCRIPTION
This issue was identified when I attempted to run the Go runtime test for memmove. With the patch included in this PR, the test now runs successfully. First of all, thanks to @lrh2000 for helping to pinpoint the root cause during an offline discussion.

# Problem

I discovered that after a user-space preemption by the Go runtime, some register values become incorrect. The Go runtime preempts a goroutine by sending a SIGURG signal to the running thread. In the signal handler, it switches to another goroutine by modifying the general registers in the signal context and then calls the `rt_sigreturn` system call to return to kernel space. The `rt_sigreturn` restores all registers from the signal context, allowing the new goroutine to start running.

However, after `rt_sigreturn` returns to user space, I found that some register values are incorrect. Specifically, a local variable stored in the `rcx` register becomes the value of `rip`.

Currently, our syscall return path always uses the `sysret` instruction, regardless of the user context registers. This approach is incorrect in the case of `rt_sigreturn`. The sysret instruction does not restore certain registers, such as r11 and rcx (and possibly user_cs and user_ds, I'm not sure). Since `rt_sigreturn` requires restoring all registers from the signal context, we cannot use sysret here; instead, the iret instruction must be used.

# Solution

Following the Linux implementation, this PR adds checks to determine whether the user context is clean enough to use sysret. If not, the code will switch back to the slower iret path.

# Unresolved questions

Linux also checks [USER_CS](https://elixir.bootlin.com/linux/v6.0.9/source/arch/x86/entry/entry_64.S#L161) and [USER_DS](https://elixir.bootlin.com/linux/v6.0.9/source/arch/x86/entry/entry_64.S#L191) before using sysret, but I couldn’t find these fields in our current `UserContext` structure. Should we include checks for these values as well?