### PR TITLE
Fix some CPUID problems and add support for AMD cpus

### DIFF
--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -405,12 +405,7 @@ impl CpuInfo {
     }
 
     fn get_cpuid_level() -> u32 {
-        let cpuid = cpuid::CpuId::new();
-        if let Some(basic_info) = cpuid.get_tsc_info() {
-            basic_info.denominator()
-        } else {
-            0
-        }
+        cpuid::cpuid!(0x0).eax
     }
 
     fn get_cpu_flags() -> String {

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -514,7 +514,7 @@ impl CpuInfo {
 
     fn get_clflush_size() -> u8 {
         let cpuid = cpuid::CpuId::new();
-        cpuid.get_feature_info().unwrap().cflush_cache_line_size()
+        cpuid.get_feature_info().unwrap().cflush_cache_line_size() * 8
     }
 
     fn get_cache_alignment() -> u32 {


### PR DESCRIPTION
## Changes
1. Fixed `get_cpuid_level()` Implementation
Issue: The function was incorrectly returning TSC frequency denominator instead of the actual CPUID support level
Fix: Changed implementation to use `cpuid!(0x0).eax` which returns the highest supported basic CPUID function number
2. Fixed `get_clflush_size()` Implementation
Issue: it was returned line size directly, missing a 8x multiplyer
3.  add  `get_cache_size()` and` get_tlb_size()` support for amd cpus
4.  using RDTSC when TSC info not aviliable