### PR TITLE
Clean up boot sections (`.boot`/`.bsp_boot`) and reduce the kernel size by 256 KiB

### DIFF
--- a/osdk/src/base_crate/riscv64.ld.template
+++ b/osdk/src/base_crate/riscv64.ld.template
@@ -1,23 +1,38 @@
-OUTPUT_ARCH(riscv)
 ENTRY(_start)
+OUTPUT_ARCH(riscv)
+
 KERNEL_LMA = 0x80200000;
 KERNEL_VMA = 0xffffffff80200000;
 KERNEL_VMA_OFFSET = KERNEL_VMA - KERNEL_LMA;
 
 SECTIONS
 {
-    . = KERNEL_VMA;
+    # First, we use physical addresses for the boot sections.
+    . = KERNEL_LMA;
 
-    PROVIDE(__executable_start = .);
-    __kernel_start = .;
+    __kernel_start = . + KERNEL_VMA_OFFSET;
 
-    .text : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
-        *(.text.entry)
+    .boot                   : AT(ADDR(.boot)) {
+        KEEP(*(.boot))
+        # FIXME: We want to create a separate .boot.stack section so that the
+        # executable doesn't contain the boot stack (which is just hundreds of
+        # kilobytes of zeros). But it is currently in the .boot section because
+        # the linker will otherwise complain unexpected relocation failures.
+        KEEP(*(.boot.stack))
+        . = ALIGN(4096);
+    }
+
+    # Then, we switch to virtual addresses for all the other sections.
+    . += KERNEL_VMA_OFFSET;
+
+    .text                   : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
         *(.text .text.*)
         PROVIDE(__etext = .);
     }
 
-    .rodata : AT(ADDR(.rodata) - KERNEL_VMA_OFFSET) { *(.rodata .rodata.*) }
+    .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA_OFFSET) {
+        *(.rodata .rodata.*)
+    }
 
     .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA_OFFSET) {
         PROVIDE(__GNU_EH_FRAME_HDR = .);
@@ -51,9 +66,9 @@ SECTIONS
         __sensitive_io_ports_end = .;
     }
 
-    . = DATA_SEGMENT_RELRO_END(0, .);
-
-    .data : AT(ADDR(.data) - KERNEL_VMA_OFFSET) { *(.data .data.*) }
+    .data                   : AT(ADDR(.data) - KERNEL_VMA_OFFSET) {
+        *(.data .data.*)
+    }
 
     # The CPU local data storage. It is readable and writable for the bootstrap
     # processor, while it would be copied to other dynamically allocated memory
@@ -64,17 +79,11 @@ SECTIONS
         __cpu_local_end = .;
     }
 
-    /* boot stack (in entry.S) */
-    .stack : AT(ADDR(.stack) - KERNEL_VMA_OFFSET) {
-        *(.bss.stack)
-    }
-
-    .bss : AT(ADDR(.bss) - KERNEL_VMA_OFFSET) {
+    .bss                    : AT(ADDR(.bss) - KERNEL_VMA_OFFSET) {
         __bss = .;
         *(.bss .bss.*)
         __bss_end = .;
     }
 
-    . = DATA_SEGMENT_END(.);
     __kernel_end = .;
 }

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -61,16 +61,21 @@ SECTIONS
 # --------------------------------------------------------------------------- #
     . = BSP_BOOT_LMA;
 
-    .bsp_boot               : AT(BSP_BOOT_LMA) {
-        KEEP(*(.bsp_boot .bsp_boot.*))
+    .bsp_boot               : AT(ADDR(.bsp_boot)) {
+        KEEP(*(.bsp_boot))
+    } : bsp_boot
+    # Create a separate .bsp_boot.stack section so that the executable doesn't
+    # contain the boot stack (which is just hundreds of kilobytes of zeros).
+    .bsp_boot.stack         : AT(ADDR(.bsp_boot.stack)) {
+        KEEP(*(.bsp_boot.stack))
         . = ALIGN(4096);
     } : bsp_boot
 
     . = AP_EXEC_MA;
 
-    .ap_boot                : AT(BSP_BOOT_LMA + SIZEOF(.bsp_boot)) {
-        __ap_boot_start = BSP_BOOT_LMA + SIZEOF(.bsp_boot) + KERNEL_VMA;
-        KEEP(*(.ap_boot .ap_boot.*))
+    .ap_boot                : AT(LOADADDR(.bsp_boot.stack) + SIZEOF(.bsp_boot.stack)) {
+        __ap_boot_start = LOADADDR(.ap_boot) + KERNEL_VMA;
+        KEEP(*(.ap_boot))
         __ap_boot_end = __ap_boot_start + (. - AP_EXEC_MA);
         . = ALIGN(4096);
     } : ap_boot
@@ -78,7 +83,7 @@ SECTIONS
 # --------------------------------------------------------------------------- #
 # Here are the rest of the virtual memory sections which can be relocated.    #
 # --------------------------------------------------------------------------- #
-    . = BSP_BOOT_LMA + KERNEL_VMA + SIZEOF(.bsp_boot) + SIZEOF(.ap_boot);
+    . = LOADADDR(.ap_boot) + SIZEOF(.ap_boot) + KERNEL_VMA;
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
         *(.text .text.*)

--- a/ostd/src/arch/riscv/boot/boot.S
+++ b/ostd/src/arch/riscv/boot/boot.S
@@ -1,66 +1,83 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
-.section .text.entry
+SATP_MODE_SV48         = 9 << 60
+SATP_PPN_SHIFT         = 0
+
+PTE_V                  = 0x01
+PTE_R                  = 0x02
+PTE_W                  = 0x04
+PTE_X                  = 0x08
+PTE_PPN_SHIFT          = 10
+PTE_SIZE               = 8
+
+PAGE_SHIFT             = 12
+
+KERNEL_VMA             = 0xffffffff00000000
+
+.section ".boot", "awx", @progbits
 .globl _start
 _start:
     # Arguments passed from SBI:
     #   a0 = hart id
     #   a1 = device tree paddr (not touched)
 
-    # 1. enable paging
-    # setting up 1st pagetable
-    #   entry = (PPN(boot_pagetable_2nd) << 10) | 0x01 # V
-    la     t1, boot_pagetable
-    li     t0, 8 * 511
+    # Set up the page table.
+    #   boot_l4pt[511] = (PPN(boot_l3pt) << PTE_PPN_SHIFT) | PTE_V
+    la     t1, boot_l4pt
+    li     t0, 511 * PTE_SIZE
     add    t1, t1, t0
-    la     t0, boot_pagetable_2nd
-    srli   t0, t0, 2
-    ori    t0, t0, 0x01
+    la     t0, boot_l3pt
+    srli   t0, t0, PAGE_SHIFT - PTE_PPN_SHIFT
+    ori    t0, t0, PTE_V
     sd     t0, 0(t1)
 
-    la     t0, boot_pagetable
-    li     t1, 9 << 60
-    srli   t0, t0, 12
+    # Load the page table.
+    la     t0, boot_l4pt
+    li     t1, SATP_MODE_SV48
+    srli   t0, t0, PAGE_SHIFT - SATP_PPN_SHIFT
     or     t0, t0, t1
     csrw   satp, t0
     sfence.vma
 
-    # 2. set sp (BSP only)
-    lga    sp, boot_stack_top
-
-    # 3. set gp (CPU-local address)
-.extern __cpu_local_start
-    lga    gp, __cpu_local_start
-
-    # 4. jump to rust riscv_boot
-    lga    t0, riscv_boot
+    # Update SP/PC to use the virtual address.
+    li     t1, KERNEL_VMA
+    la     sp, boot_stack_top
+    or     sp, sp, t1
+    la     t0, _start_virt - KERNEL_VMA
+    or     t0, t0, t1
     jr     t0
 
+PTE_VRWX = PTE_V | PTE_R | PTE_W | PTE_X
 
-.section .bss.stack
+.balign 4096
+boot_l4pt:
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # identity 0~512 GiB
+    .zero 255 * PTE_SIZE
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # linear 0~512 GiB
+    .zero 254 * PTE_SIZE
+    .quad 0                                      # TBA (-> boot_l3pt)
+boot_l3pt:  # 0xffff_ffff_0000_0000 -> 0x0000_0000_0000_0000
+    .zero 508 * PTE_SIZE
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB
+    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 1~2 GiB
+    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 2~3 GiB
+    .quad 0
 
-.globl boot_stack_bottom
-boot_stack_bottom:
-    .space 0x40000 # 64 KiB
-
+.section ".boot.stack", "aw", @nobits
 .globl boot_stack_top
+boot_stack_bottom:
+    .balign 4096
+    .skip 0x40000  # 256 KiB
 boot_stack_top:
 
+# From here, we're in the .text section: we no longer use physical address.
+.text
+.globl _start_virt
+_start_virt:
+    # Initialize GP to the CPU-local start address.
+.extern __cpu_local_start
+    la     gp, __cpu_local_start
 
-.section .data
-
-.align 12
-boot_pagetable:
-    .quad (0x00000 << 10) | 0xcf # VRWXAD
-    .zero 8 * 255
-    .quad (0x00000 << 10) | 0xcf # VRWXAD
-    .zero 8 * 254
-    .quad 0  # To-Be-Assign
-
-boot_pagetable_2nd:
-    # 0x0000_00ff_8000_0000 -> 0x0000_0000_8000_0000
-    .zero 8 * 508
-    .quad (0x00000 << 10) | 0xcf # VRWXAD
-    .quad (0x40000 << 10) | 0xcf # VRWXAD
-    .quad (0x80000 << 10) | 0xcf # VRWXAD
-    .quad 0
+    # Jump into Rust code.
+    la     t0, riscv_boot
+    jr     t0

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -5,7 +5,7 @@
 .global ap_boot_from_real_mode
 .global ap_boot_from_long_mode
 
-.section ".ap_boot", "awx"
+.section ".ap_boot", "awx", @progbits
 .align 4096
 
 IA32_EFER_MSR     = 0xC0000080

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -5,7 +5,7 @@
 // The boot header, initial boot setup code, temporary GDT and page tables are
 // in the boot section. The boot section is mapped writable since kernel may
 // modify the initial page table.
-.section ".bsp_boot", "awx"
+.section ".bsp_boot", "awx", @progbits
 .code32
 
 // With every entry types we could go through common paging or machine
@@ -285,11 +285,6 @@ boot_l2pt_3g_4g:
     .skip 4096
 boot_page_table_end:
 
-.global boot_stack_top
-boot_stack_bottom:
-    .skip 0x40000
-boot_stack_top:
-
 .code64
 long_mode_in_low_address:
     mov ax, 0
@@ -304,6 +299,13 @@ long_mode_in_low_address:
     or  rsp, rbx
     mov rax, offset long_mode
     jmp rax
+
+.section ".bsp_boot.stack", "aw", @nobits
+.global boot_stack_top
+boot_stack_bottom:
+    .align 4096
+    .skip 0x40000  # 256 KiB
+boot_stack_top:
 
 // From here, we're in the .text section: we no longer use physical address.
 .text


### PR DESCRIPTION
This PR performs the following things.

### Reduce the x86-64 kernel size by 256 KiB

The 256 KiB boot stack was previously included in the `.bsp_boot` section. This resulted in the final executable file containing 256 KB of zeros:
```
root@localhost:~/asterinas# ls -al ./target/osdk/iso_root/boot/aster-nix-osdk-bin 
-rwxr-xr-x 4 root root 5525352 Jul 20 14:30 ./target/osdk/iso_root/boot/aster-nix-osdk-bin
root@localhost:~/asterinas# readelf -l ./target/osdk/iso_root/boot/aster-nix-osdk-bin 
[..]
  LOAD           0x0000000000002000 0x0000000008001000 0x0000000008001000
                 0x0000000000049000 0x0000000000049000  RWE    0x1000
[..]
```

This is unnecessary. By creating a separate `.bsp_boot.stack` section marked with `@nobits`, we no longer need 256 KiB of zeros in the kernel binary:
```
root@localhost:~/asterinas# ls -al ./target/osdk/iso_root/boot/aster-nix-osdk-bin 
-rwxr-xr-x 4 root root 5263416 Jul 20 14:33 ./target/osdk/iso_root/boot/aster-nix-osdk-bin
root@localhost:~/asterinas# readelf -l ./target/osdk/iso_root/boot/aster-nix-osdk-bin 
[..]
  LOAD           0x0000000000002000 0x0000000008001000 0x0000000008001000
                 0x0000000000008026 0x0000000000049000  RWE    0x1000
[..]
```

### Make the RISC-V boot section arrangement consistent with the x86 one

I'm trying to do the same thing for RISC-V, but it fails due to reallocation errors. I haven't figured out why they occur yet.
```
          rust-lld: error: /root/asterinas/target/riscv64gc-unknown-none-elf/release/deps/aster_nix_osdk_bin-a0e3c46ec3afd727.aster_block-baaa08daa3ba389c.aster_block.dce70232c02ed8ac-cgu.2.rcgu.o.rcgu.o:(function alloc::raw_vec::finish_grow::h2345c0b1dfcbbd6f (.llvm.14587855533345345400): .text.unlikely._ZN5alloc7raw_vec11finish_grow17h2345c0b1dfcbbd6fE.llvm.14587855533345345400+0x5c): relocation R_RISCV_PCREL_HI20 out of range: 1048506 is not in [-524288, 524287]; references '__rust_no_alloc_shim_is_unstable'
          >>> referenced by aster_block.dce70232c02ed8ac-cgu.2
          >>> defined in /root/asterinas/target/riscv64gc-unknown-none-elf/release/deps/aster_nix_osdk_bin-a0e3c46ec3afd727.3vajh8smyodg45fm4oypceasy.rcgu.o
          
          rust-lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
```

I can only add a FIXME for it. In any case, this PR attempts to unify the boot section arrangement of RISC-V and x86. I think it still has some benefits. For example, positioning the boot trompline and boot stack at the beginning of the kernel load region allows for easier reclaimation once they become obsolete.

### Clean up the RISC-V boot assembly

Since this PR touches `ostd/src/arch/riscv/boot/boot.S`, it makes some cleanup. It mostly just adds some comments and defines some page table constants. Hopefully it makes sense to improve the code readability:
```
SATP_MODE_SV48         = 9 << 60
SATP_PPN_SHIFT         = 0

PTE_V                  = 0x01
PTE_R                  = 0x02
PTE_W                  = 0x04
PTE_X                  = 0x08
PTE_PPN_SHIFT          = 10
PTE_SIZE               = 8
```

---

The correctness of the RISC-V code will not be tested in CI, but I manually checked the result of `make run ARCH=riscv64` before and after this PR to ensure this PR does not introduce any functional changes.