### PR TITLE
Correct the reuseaddr behavior

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/port.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/port.rs
@@ -7,36 +7,29 @@ pub enum BindPortConfig {
     /// Binds to the specified reusable port.
     Specified(u16),
     /// Allocates an ephemeral port to bind.
-    Ephemeral,
+    Ephemeral(bool),
+    /// Reuses the port of the listening socket.
+    Backlog(u16),
 }
 
 impl BindPortConfig {
     /// Creates new configuration using for bind to a TCP/UDP port.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if `port` is zero (indicating that an ephemeral port should be
-    /// allocated) and `can_use` is true. This makes no sense because new ephemeral ports are
-    /// always not reused.
     pub fn new(port: u16, can_reuse: bool) -> Self {
         match (port, can_reuse) {
-            (0, _) => {
-                assert!(!can_reuse);
-                Self::Ephemeral
-            }
+            (0, can_reuse) => Self::Ephemeral(can_reuse),
             (_, true) => Self::CanReuse(port),
             (_, false) => Self::Specified(port),
         }
     }
 
     pub(super) fn can_reuse(&self) -> bool {
-        matches!(self, Self::CanReuse(_))
+        matches!(self, Self::CanReuse(_)) || matches!(self, Self::Ephemeral(true))
     }
 
     pub(super) fn port(&self) -> Option<u16> {
         match self {
-            Self::CanReuse(port) | Self::Specified(port) => Some(*port),
-            Self::Ephemeral => None,
+            Self::CanReuse(port) | Self::Specified(port) | Self::Backlog(port) => Some(*port),
+            Self::Ephemeral(_) => None,
         }
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -98,6 +98,10 @@ impl<T: Inner<E>, E: Ext> Socket<T, E> {
     pub fn iface(&self) -> &Arc<dyn Iface<E>> {
         self.0.bound.iface()
     }
+
+    pub fn bound_port(&self) -> &BoundPort<E> {
+        &self.0.bound
+    }
 }
 
 define_boolean_value!(

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -236,7 +236,7 @@ impl<E: Ext> TcpListenerBg<E> {
         let conn = TcpConnection::new_cyclic(
             self.bound
                 .iface()
-                .bind(BindPortConfig::CanReuse(self.bound.port()))
+                .bind(BindPortConfig::Backlog(self.bound.port()))
                 .unwrap(),
             |weak| {
                 TcpConnectionInner::new(

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -8,7 +8,7 @@ use aster_bigtcp::{
 use crate::{
     events::IoEvents,
     net::{
-        iface::{Iface, UdpSocket},
+        iface::{BoundPort, Iface, UdpSocket},
         socket::util::{datagram_common, SendRecvFlags},
     },
     prelude::*,
@@ -30,6 +30,10 @@ impl BoundDatagram {
 
     pub(super) fn iface(&self) -> &Arc<Iface> {
         self.bound_socket.iface()
+    }
+
+    pub(super) fn bound_port(&self) -> &BoundPort {
+        self.bound_socket.bound_port()
     }
 }
 

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -260,4 +260,12 @@ impl GetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
     }
 }
 
-impl SetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {}
+impl SetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
+    fn set_reuse_addr(&self, reuse_addr: bool) {
+        let Inner::Bound(bound) = self else {
+            return;
+        };
+
+        bound.bound_port().set_can_reuse(reuse_addr);
+    }
+}

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -10,7 +10,7 @@ use super::observer::StreamObserver;
 use crate::{
     events::IoEvents,
     net::{
-        iface::{Iface, RawTcpSocketExt, TcpConnection},
+        iface::{BoundPort, Iface, RawTcpSocketExt, TcpConnection},
         socket::util::{LingerOption, SendRecvFlags, SockShutdownCmd},
     },
     prelude::*,
@@ -143,6 +143,10 @@ impl ConnectedStream {
 
     pub(super) fn iface(&self) -> &Arc<Iface> {
         self.tcp_conn.iface()
+    }
+
+    pub(super) fn bound_port(&self) -> &BoundPort {
+        self.tcp_conn.bound_port()
     }
 
     pub(super) fn finish_last_connect(&mut self) -> Result<()> {

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -100,6 +100,10 @@ impl ConnectingStream {
         self.tcp_conn.iface()
     }
 
+    pub(super) fn bound_port(&self) -> &BoundPort {
+        self.tcp_conn.bound_port()
+    }
+
     pub(super) fn check_io_events(&self) -> IoEvents {
         IoEvents::empty()
     }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -79,10 +79,15 @@ impl InitStream {
         Ok(())
     }
 
+    pub(super) fn bound_port(&self) -> Option<&BoundPort> {
+        self.bound_port.as_ref()
+    }
+
     pub(super) fn connect(
         self,
         remote_endpoint: &IpEndpoint,
         option: &RawTcpOption,
+        can_reuse: bool,
         observer: StreamObserver,
     ) -> core::result::Result<ConnectingStream, (Error, Self)> {
         debug_assert!(
@@ -94,7 +99,7 @@ impl InitStream {
             bound_port
         } else {
             let endpoint = get_ephemeral_endpoint(remote_endpoint);
-            match bind_port(&endpoint, false) {
+            match bind_port(&endpoint, can_reuse) {
                 Ok(bound_port) => bound_port,
                 Err(err) => return Err((err, self)),
             }

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -174,6 +174,7 @@ impl SocketOptionSet {
             socket_reuse_addr: ReuseAddr => {
                 let reuse_addr = socket_reuse_addr.get().unwrap();
                 self.set_reuse_addr(*reuse_addr);
+                socket.set_reuse_addr(*reuse_addr);
             },
             socket_reuse_port: ReusePort => {
                 let reuse_port = socket_reuse_port.get().unwrap();
@@ -260,6 +261,9 @@ pub(in crate::net) trait GetSocketLevelOption {
 
 /// A trait used for setting socket level options on actual sockets.
 pub(in crate::net) trait SetSocketLevelOption {
+    /// Sets whether the socket address can be reused.
+    fn set_reuse_addr(&self, _reuse_addr: bool) {}
+
     /// Sets whether keepalive messages are enabled.
     fn set_keep_alive(&self, _keep_alive: bool) -> NeedIfacePoll {
         NeedIfacePoll::FALSE

--- a/test/src/apps/network/tcp_reuseaddr.c
+++ b/test/src/apps/network/tcp_reuseaddr.c
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <unistd.h>
+#include <sys/signal.h>
+#include <sys/socket.h>
+#include <sys/poll.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+
+#include "../test.h"
+
+int sock1;
+int sock2;
+int sock3;
+
+struct sockaddr_in addr;
+socklen_t addrlen;
+
+FN_SETUP(init)
+{
+	sock1 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	sock2 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	sock3 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	addr.sin_family = AF_INET;
+	CHECK(inet_aton("127.0.0.1", &addr.sin_addr));
+	addrlen = sizeof(addr);
+}
+END_SETUP()
+
+FN_TEST(bind_to_ephemeral)
+{
+	int option = 1;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	TEST_ERRNO(bind(sock2, (struct sockaddr *)&addr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_SUCC(bind(sock2, (struct sockaddr *)&addr, addrlen));
+}
+END_TEST()
+
+void renew_socks()
+{
+	CHECK(close(sock1));
+	CHECK(close(sock2));
+	CHECK(close(sock3));
+	sock1 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	sock2 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	sock3 = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+}
+
+FN_TEST(bind_to_listening_port)
+{
+	renew_socks();
+
+	int option = 1;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(listen(sock1, 1));
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	TEST_ERRNO(bind(sock2, (struct sockaddr *)&addr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+
+	// Currently, Asterinas does not check whether the port is already in use
+	// by a listening socket when binding, so this test will fail.
+	// TEST_ERRNO(bind(sock2, (struct sockaddr *)&addr, addrlen), EADDRINUSE);
+}
+END_TEST()
+
+FN_TEST(listen_on_the_same_port)
+{
+	renew_socks();
+
+	int option = 1;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_SUCC(bind(sock2, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(listen(sock1, 1));
+	TEST_ERRNO(listen(sock2, 1), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sock3, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+
+	// Currently, Asterinas does not check whether the port is already in use
+	// by a listening socket when binding, so this test will fail.
+	// TEST_ERRNO(bind(sock3, (struct sockaddr *)&addr, addrlen), EADDRINUSE);
+}
+END_TEST()
+
+FN_TEST(bind_to_connected_port)
+{
+	renew_socks();
+
+	int option = 1;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(listen(sock1, 3));
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_SUCC(connect(sock2, (struct sockaddr *)&addr, addrlen));
+
+	struct sockaddr_in sock2_addr;
+	TEST_SUCC(getsockname(sock2, (struct sockaddr *)&sock2_addr, &addrlen));
+
+	int sock3 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+
+	TEST_ERRNO(bind(sock3, (struct sockaddr *)&sock2_addr, addrlen),
+		   EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sock3, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_SUCC(bind(sock3, (struct sockaddr *)&sock2_addr, addrlen));
+
+	TEST_ERRNO(connect(sock2, (struct sockaddr *)&addr, addrlen), EISCONN);
+
+	TEST_SUCC(close(sock3));
+}
+END_TEST()
+
+FN_TEST(enable_reuse_after_bound)
+{
+	renew_socks();
+
+	int option = 0;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	option = 1;
+	TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_ERRNO(bind(sock2, (struct sockaddr *)&addr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	TEST_SUCC(bind(sock2, (struct sockaddr *)&addr, addrlen));
+}
+END_TEST()
+
+FN_TEST(disable_reuse_after_bound)
+{
+	renew_socks();
+
+	int option = 1;
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     sizeof(option)));
+	addr.sin_port = 0;
+	TEST_SUCC(bind(sock1, (struct sockaddr *)&addr, addrlen));
+
+	option = 0;
+	socklen_t option_len = sizeof(option);
+	TEST_SUCC(setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			     option_len));
+	TEST_RES(getsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &option,
+			    &option_len),
+		 option == 0 && option_len == 4);
+
+	TEST_SUCC(getsockname(sock1, (struct sockaddr *)&addr, &addrlen));
+
+	// The following test succeeds on Linux because Linux does not allow disabling
+	// SO_REUSEADDR for TCP sockets once the socket is bound. In contrast, Asterinas
+	// enforces a stricter rule: the port can be reused only if all sockets bound to it
+	// have port reuse enabled.
+	// See the discussion at <https://github.com/asterinas/asterinas/pull/2277#discussion_r2230139244>.
+	//
+	// option = 1;
+	// TEST_SUCC(setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &option,
+	// 		     sizeof(option)));
+	// TEST_SUCC(bind(sock2, (struct sockaddr *)&addr, addrlen));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(sock1));
+	CHECK(close(sock2));
+	CHECK(close(sock3));
+}
+END_SETUP()

--- a/test/src/apps/network/udp_err.c
+++ b/test/src/apps/network/udp_err.c
@@ -184,19 +184,22 @@ FN_TEST(bind_reuseaddr)
 
 	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
 
-	// FIXME: The test will fail in Asterinas since it doesn't check
-	// if the previous socket was bound with `SO_REUSEADDR`
-	//
-	// TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &disable,
-	// 		     sizeof(disable)));
-	// TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &enable,
-	// 		     sizeof(enable)));
-	// TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
+	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &disable,
+			     sizeof(disable)));
+	TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &enable,
+			     sizeof(enable)));
+	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
 
 	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &enable,
 			     sizeof(enable)));
 	TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &disable,
 			     sizeof(disable)));
+	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
+
+	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &disable,
+			     sizeof(disable)));
+	TEST_SUCC(setsockopt(sk2, SOL_SOCKET, SO_REUSEADDR, &enable,
+			     sizeof(enable)));
 	TEST_ERRNO(bind(sk2, psaddr, addrlen), EADDRINUSE);
 
 	TEST_SUCC(setsockopt(sk1, SOL_SOCKET, SO_REUSEADDR, &enable,

--- a/test/src/apps/scripts/network.sh
+++ b/test/src/apps/scripts/network.sh
@@ -32,6 +32,7 @@ sleep 0.2
 ./send_buf_full
 ./tcp_err
 ./tcp_poll
+./tcp_reuseaddr
 ./udp_err
 ./unix_stream_err
 ./unix_seqpacket_err


### PR DESCRIPTION
This PR addresses a panic issue that occurs when running network tests from the Go standard library.

See the relevant code here:

https://github.com/asterinas/asterinas/blob/e86f7584a3c4d395c8ea9e72ce8738cd2039d0b0/kernel/libs/aster-bigtcp/src/iface/port.rs#L21-L30.

The assertion in the above code fails in several network tests. In fact, we should allow the `can_reuse` flag to be set even when binding to an ephemeral port.

If `can_reuse` is set to true:
1. When ephemeral ports are still available, we can select a random unused port. This port can then be reused by subsequent sockets.
2. When ephemeral ports are exhausted, we can select a port already in use that is marked as reusable(This behavior is not supported by this PR yet. In fact, additional checks are required, but they are not included in this PR. [Reference](https://elixir.bootlin.com/linux/v6.0.9/source/tools/testing/selftests/net/reuseaddr_ports_exhausted.c#L8))