### PR TITLE
Implement controller framework for cgroup subsystem

### DIFF
--- a/kernel/comps/systree/src/lib.rs
+++ b/kernel/comps/systree/src/lib.rs
@@ -71,8 +71,10 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     /// Attempted to access a non-existent systree item
     NotFound,
-    /// Invalid operation for node type
-    InvalidNodeOperation(SysNodeType),
+    /// Invalid operation
+    InvalidOperation,
+    /// Resource is unavailable
+    ResourceUnavailable,
     /// Attribute operation failed
     AttributeError,
     /// Permission denied for operation
@@ -89,9 +91,8 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::NotFound => write!(f, "Attempted to access a non-existent systree item"),
-            Error::InvalidNodeOperation(ty) => {
-                write!(f, "Invalid operation for node type: {:?}", ty)
-            }
+            Error::InvalidOperation => write!(f, "Invalid operation"),
+            Error::ResourceUnavailable => write!(f, "Resource is unavailable"),
             Error::AttributeError => write!(f, "Attribute error"),
             Error::PermissionDenied => write!(f, "Permission denied for operation"),
             Error::InternalError(msg) => write!(f, "Internal error: {}", msg),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -333,7 +333,8 @@ impl From<aster_systree::Error> for Error {
         use aster_systree::Error::*;
         match err {
             NotFound => Error::new(Errno::ENOENT),
-            InvalidNodeOperation(_) => Error::new(Errno::EINVAL),
+            InvalidOperation => Error::new(Errno::EINVAL),
+            ResourceUnavailable => Error::new(Errno::EBUSY),
             AttributeError => Error::new(Errno::EIO),
             PermissionDenied => Error::new(Errno::EACCES),
             InternalError(msg) => Error::with_message(Errno::EIO, msg),

--- a/kernel/src/fs/cgroupfs/controller/cgroup.rs
+++ b/kernel/src/fs/cgroupfs/controller/cgroup.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+use core::sync::atomic::Ordering;
+
+use aster_systree::{Error, Result, SysAttrSet, SysAttrSetBuilder, SysPerms, SysStr};
+use ostd::mm::{VmReader, VmWriter};
+
+use crate::{
+    fs::cgroupfs::{
+        controller::{CgroupSysNode, SubCtrlState},
+        CgroupNode,
+    },
+    prelude::*,
+    process::{process_table, Pid},
+};
+
+/// The basic controller in cgroup subsystem.
+///
+/// Each cgroup in the hierarchy enables the controller by default and cannot deactivate it.
+/// The controller exposes the control interfaces for cgroup management operations.
+pub struct CgroupController {
+    attrs: SysAttrSet,
+}
+
+impl CgroupController {
+    pub(super) fn new(is_root: bool) -> Self {
+        let attrs = {
+            let mut builder = SysAttrSetBuilder::new();
+            if !is_root {
+                builder.add(
+                    SysStr::from("cgroup.events"),
+                    SysPerms::DEFAULT_RO_ATTR_PERMS,
+                );
+            }
+            builder.add(
+                SysStr::from("cgroup.controllers"),
+                SysPerms::DEFAULT_RO_ATTR_PERMS,
+            );
+            builder.add(
+                SysStr::from("cgroup.subtree_control"),
+                SysPerms::DEFAULT_RW_ATTR_PERMS,
+            );
+            builder.add(
+                SysStr::from("cgroup.max.depth"),
+                SysPerms::DEFAULT_RW_ATTR_PERMS,
+            );
+            builder.add(
+                SysStr::from("cgroup.procs"),
+                SysPerms::DEFAULT_RW_ATTR_PERMS,
+            );
+            builder.add(
+                SysStr::from("cgroup.threads"),
+                SysPerms::DEFAULT_RW_ATTR_PERMS,
+            );
+            builder.build().expect("Failed to build attribute set")
+        };
+
+        Self { attrs }
+    }
+}
+
+impl super::SubControl for CgroupController {
+    fn attr_set(&self) -> &SysAttrSet {
+        &self.attrs
+    }
+
+    fn read_attr(
+        &self,
+        name: &str,
+        writer: &mut VmWriter,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        if !self.attrs.contains(name) {
+            return Err(Error::NotFound);
+        }
+
+        match name {
+            "cgroup.controllers" => {
+                let context = cgroup_node.cgroup_parent().map_or_else(
+                    || SubCtrlState::all().show(),
+                    |parent| parent.controller().show_state(),
+                );
+
+                writer
+                    .write_fallible(&mut VmReader::from((context + "\n").as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            "cgroup.subtree_control" => {
+                let context = cgroup_node.controller().show_state();
+                writer
+                    .write_fallible(&mut VmReader::from((context + "\n").as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            "cgroup.procs" => {
+                let context =
+                    if let Some(cgroup_node) = cgroup_node.as_any().downcast_ref::<CgroupNode>() {
+                        cgroup_node.read_procs()
+                    } else {
+                        let process_table = process_table::process_table_mut();
+                        process_table
+                            .iter()
+                            .filter_map(|process| {
+                                if process.cgroup().is_none() {
+                                    Some(process.pid().to_string())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<String>>()
+                            .join("\n")
+                    };
+
+                writer
+                    .write_fallible(&mut VmReader::from((context + "\n").as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            "cgroup.events" => {
+                let cgroup_node = cgroup_node.as_any().downcast_ref::<CgroupNode>().unwrap();
+                let res = if cgroup_node.populated_count().load(Ordering::Acquire) > 0 {
+                    1
+                } else {
+                    0
+                };
+                // Currently we have not enabled the "frozen" attribute
+                // so the "frozen" field is always zero.
+                let output = format!("populated {}\nfrozen {}\n", res, 0);
+                writer
+                    .write_fallible(&mut VmReader::from(output.as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            _ => {
+                // TODO: Activate support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
+    }
+
+    fn write_attr(
+        &self,
+        name: &str,
+        reader: &mut VmReader,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        match name {
+            "cgroup.procs" => {
+                let (pid, pid_len) = read_pid_from_reader(reader)?;
+
+                // According to "no internal processes" rule of cgroupv2, if a non-root
+                // cgroup node has activated some sub-controls, it cannot bind any process.
+                //
+                // Ref: https://man7.org/linux/man-pages/man7/cgroups.7.html
+                if !cgroup_node.is_root()
+                    && !cgroup_node.controller().sub_ctrl_state.lock().is_empty()
+                {
+                    return Err(Error::ResourceUnavailable);
+                }
+
+                let process = if pid == 0 {
+                    current!()
+                } else {
+                    process_table::get_process(pid).ok_or(Error::AttributeError)?
+                };
+
+                if let Some(cgroup_node) = cgroup_node.as_any().downcast_ref::<CgroupNode>() {
+                    cgroup_node.move_process(process);
+                } else {
+                    let rcu_old_cgroup = process.cgroup();
+                    let old_cgroup = rcu_old_cgroup.get();
+                    if let Some(old_cgroup) = old_cgroup {
+                        old_cgroup.remove_process(&process);
+                    }
+                }
+
+                Ok(pid_len)
+            }
+            "cgroup.subtree_control" => {
+                let (actions, len) = read_subtree_control_from_reader(reader)?;
+
+                if let Some(cgroup_node) = cgroup_node.as_any().downcast_ref::<CgroupNode>() {
+                    // According to "no internal processes" rule of cgroupv2, if a non-root
+                    // cgroup node has bound processes, it cannot activate any sub-control.
+                    //
+                    // Ref: https://man7.org/linux/man-pages/man7/cgroups.7.html
+                    if cgroup_node.have_processes() {
+                        return Err(Error::ResourceUnavailable);
+                    }
+                }
+
+                let parent_node = cgroup_node.cgroup_parent();
+                let parent_ctrls_state = parent_node
+                    .as_ref()
+                    .map(|parent_node| parent_node.controller().sub_ctrl_state.lock());
+                for action in actions {
+                    match action {
+                        SubControlAction::Activate(name) => {
+                            // A cgroup can activate the sub-control only if this
+                            // sub-control has been activated in its parent cgroup.
+                            let can_activate =
+                                parent_ctrls_state
+                                    .as_ref()
+                                    .is_none_or(|parent_ctrls_state| {
+                                        parent_ctrls_state.is_enabled(&name).unwrap()
+                                    });
+
+                            if !can_activate {
+                                return Err(Error::NotFound);
+                            }
+
+                            cgroup_node.controller().activate(&name, cgroup_node)?;
+                        }
+                        SubControlAction::Deactivate(name) => {
+                            let mut can_deactivate = true;
+                            // If any child node has activated this sub-control,
+                            // the deactivation operation will be rejected.
+                            cgroup_node.visit_children_with(0, &mut |child| {
+                                let cgroup_child =
+                                    child.as_any().downcast_ref::<CgroupNode>().unwrap();
+                                if cgroup_child
+                                    .controller()
+                                    .sub_ctrl_state
+                                    .lock()
+                                    .is_enabled(&name)
+                                    .unwrap()
+                                {
+                                    can_deactivate = false;
+                                    None
+                                } else {
+                                    Some(())
+                                }
+                            });
+
+                            if !can_deactivate {
+                                return Err(Error::InvalidOperation);
+                            }
+
+                            cgroup_node.controller().deactivate(&name, cgroup_node)?;
+                        }
+                    }
+                }
+
+                Ok(len)
+            }
+            _ => {
+                // TODO: Activate support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
+    }
+}
+
+fn read_buffer_from_reader(reader: &mut VmReader) -> Result<(Vec<u8>, usize)> {
+    let mut buffer = alloc::vec![0; reader.remain()];
+    let len = reader
+        .read_fallible(&mut VmWriter::from(buffer.as_mut_slice()))
+        .map_err(|_| Error::AttributeError)?;
+
+    Ok((buffer, len))
+}
+
+/// Reads a PID from the given reader.
+///
+/// Returns a tuple containing the PID and the number of bytes read.
+fn read_pid_from_reader(reader: &mut VmReader) -> Result<(Pid, usize)> {
+    let (buffer, len) = read_buffer_from_reader(reader)?;
+
+    let pid = alloc::str::from_utf8(&buffer[..len])
+        .map_err(|_| Error::AttributeError)
+        .and_then(|string| {
+            let strip_string = string.trim();
+            strip_string
+                .parse::<u32>()
+                .map_err(|_| Error::AttributeError)
+        })?;
+
+    Ok((pid, len))
+}
+
+/// Reads the actions for sub-control from the given reader.
+///
+/// Returns a tuple containing vector of actions and the number of bytes read.
+fn read_subtree_control_from_reader(
+    reader: &mut VmReader,
+) -> Result<(Vec<SubControlAction>, usize)> {
+    let (buffer, len) = read_buffer_from_reader(reader)?;
+    let context = String::from_utf8_lossy_owned(buffer);
+
+    let mut actions_vec = Vec::new();
+    let actions = context.split_whitespace();
+    for action in actions {
+        if action.len() < 2 {
+            return Err(Error::AttributeError);
+        }
+
+        let action = match action.chars().next() {
+            Some('+') => {
+                let name = action[1..].to_string();
+                if SubCtrlState::control_bit(&name).is_none() {
+                    return Err(Error::InvalidOperation);
+                }
+
+                SubControlAction::Activate(name)
+            }
+            Some('-') => {
+                let name = action[1..].to_string();
+                if SubCtrlState::control_bit(&name).is_none() {
+                    return Err(Error::InvalidOperation);
+                }
+
+                SubControlAction::Deactivate(name)
+            }
+            _ => return Err(Error::AttributeError),
+        };
+        actions_vec.push(action);
+    }
+
+    Ok((actions_vec, len))
+}
+
+enum SubControlAction {
+    Activate(String),
+    Deactivate(String),
+}

--- a/kernel/src/fs/cgroupfs/controller/cpuset.rs
+++ b/kernel/src/fs/cgroupfs/controller/cpuset.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_systree::{Error, Result, SysAttrSet, SysAttrSetBuilder, SysPerms, SysStr};
+use ostd::mm::{VmReader, VmWriter};
+
+use crate::fs::cgroupfs::controller::CgroupSysNode;
+
+/// The controller responsible for cpuset in the cgroup subsystem.
+pub struct CpuSetController {
+    attrs: SysAttrSet,
+}
+
+impl CpuSetController {
+    pub(super) fn new(is_root: bool) -> Self {
+        let mut builder = SysAttrSetBuilder::new();
+
+        if !is_root {
+            builder.add(SysStr::from("cpuset.cpus"), SysPerms::DEFAULT_RW_ATTR_PERMS);
+            builder.add(SysStr::from("cpuset.mems"), SysPerms::DEFAULT_RW_ATTR_PERMS);
+        }
+
+        builder.add(
+            SysStr::from("cpuset.cpus.effective"),
+            SysPerms::DEFAULT_RO_ATTR_PERMS,
+        );
+        builder.add(
+            SysStr::from("cpuset.mems.effective"),
+            SysPerms::DEFAULT_RO_ATTR_PERMS,
+        );
+
+        let attrs = builder.build().expect("Failed to build attribute set");
+        Self { attrs }
+    }
+}
+
+impl super::SubControl for CpuSetController {
+    fn attr_set(&self) -> &SysAttrSet {
+        &self.attrs
+    }
+
+    fn read_attr(
+        &self,
+        _name: &str,
+        _writer: &mut VmWriter,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+
+    fn write_attr(
+        &self,
+        _name: &str,
+        _reader: &mut VmReader,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+}

--- a/kernel/src/fs/cgroupfs/controller/memory.rs
+++ b/kernel/src/fs/cgroupfs/controller/memory.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_systree::{Error, Result, SysAttrSet, SysAttrSetBuilder, SysPerms, SysStr};
+use ostd::mm::{VmReader, VmWriter};
+
+use crate::fs::cgroupfs::controller::CgroupSysNode;
+
+/// The controller responsible for memory management in the cgroup subsystem.
+///
+/// Note that even if the controller is inactive, it still provides some interfaces
+/// like "memory.pressure" for usage.
+pub struct MemoryController {
+    attrs: SysAttrSet,
+}
+
+impl MemoryController {
+    pub(super) fn new(is_active: bool, is_root: bool) -> Self {
+        let mut builder = SysAttrSetBuilder::new();
+        builder.add(
+            SysStr::from("memory.pressure"),
+            SysPerms::DEFAULT_RO_ATTR_PERMS,
+        );
+        if is_active {
+            builder.add(SysStr::from("memory.stat"), SysPerms::DEFAULT_RO_ATTR_PERMS);
+            if !is_root {
+                builder.add(SysStr::from("memory.max"), SysPerms::DEFAULT_RO_ATTR_PERMS);
+                builder.add(
+                    SysStr::from("memory.events"),
+                    SysPerms::DEFAULT_RO_ATTR_PERMS,
+                );
+            }
+        }
+
+        let attrs = builder.build().expect("Failed to build attribute set");
+        Self { attrs }
+    }
+}
+
+impl super::SubControl for MemoryController {
+    fn attr_set(&self) -> &SysAttrSet {
+        &self.attrs
+    }
+
+    fn read_attr(
+        &self,
+        _name: &str,
+        _writer: &mut VmWriter,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+
+    fn write_attr(
+        &self,
+        _name: &str,
+        _reader: &mut VmReader,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+}

--- a/kernel/src/fs/cgroupfs/controller/mod.rs
+++ b/kernel/src/fs/cgroupfs/controller/mod.rs
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{collections::btree_map::BTreeMap, string::String, sync::Arc, vec::Vec};
+
+use aster_systree::{Error, Result, SysAttr, SysAttrSet, SysAttrSetBuilder, SysBranchNode, SysStr};
+use bitflags::bitflags;
+use ostd::{
+    mm::{VmReader, VmWriter},
+    sync::{Mutex, MutexGuard, RcuOption},
+    task::disable_preempt,
+};
+
+use crate::fs::cgroupfs::{
+    controller::{
+        cgroup::CgroupController, cpuset::CpuSetController, memory::MemoryController,
+        pids::PidsController,
+    },
+    CgroupNode, CgroupSystem,
+};
+
+mod cgroup;
+mod cpuset;
+mod memory;
+mod pids;
+
+/// A trait to abstract all individual cgroup controllers.
+trait SubControl {
+    fn attr_set(&self) -> &SysAttrSet;
+
+    fn read_attr(
+        &self,
+        name: &str,
+        writer: &mut VmWriter,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize>;
+
+    fn write_attr(
+        &self,
+        name: &str,
+        reader: &mut VmReader,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize>;
+}
+
+/// An enum that wraps all possible cgroup sub-controller implementations.
+// TODO: Currently uses an enum type instead of trait objects because RCU doesn't support
+// `?Sized` objects in `Arc`. This may be changed to direct trait object usage in the future.
+pub(super) enum SubController {
+    Cgroup(CgroupController),
+    Memory(MemoryController),
+    CpuSet(CpuSetController),
+    Pids(PidsController),
+}
+
+impl SubController {
+    fn new(name: &str, ctrl_state: SubCtrlState, is_root: bool) -> Option<Arc<Self>> {
+        match name {
+            "cgroup" => Some(Self::Cgroup(CgroupController::new(is_root))),
+            "memory" => {
+                let is_active = ctrl_state.contains(SubCtrlState::MEMORY_CTRLS);
+                Some(Self::Memory(MemoryController::new(is_active, is_root)))
+            }
+            "cpuset" => {
+                let is_active = ctrl_state.contains(SubCtrlState::CPUSET_CTRLS);
+                is_active.then_some(Self::CpuSet(CpuSetController::new(is_root)))
+            }
+            "pids" => {
+                let is_active = ctrl_state.contains(SubCtrlState::PIDS_CTRLS);
+                (!is_root && is_active).then_some(Self::Pids(PidsController::new()))
+            }
+            _ => None,
+        }
+        .map(Arc::new)
+    }
+
+    fn as_subcontrol(&self) -> &dyn SubControl {
+        match self {
+            SubController::Cgroup(ctrl) => ctrl,
+            SubController::Memory(ctrl) => ctrl,
+            SubController::CpuSet(ctrl) => ctrl,
+            SubController::Pids(ctrl) => ctrl,
+        }
+    }
+
+    fn attr_set(&self) -> &SysAttrSet {
+        self.as_subcontrol().attr_set()
+    }
+
+    fn read_attr(
+        &self,
+        name: &str,
+        writer: &mut VmWriter,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        self.as_subcontrol().read_attr(name, writer, cgroup_node)
+    }
+
+    fn write_attr(
+        &self,
+        name: &str,
+        reader: &mut VmReader,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        self.as_subcontrol().write_attr(name, reader, cgroup_node)
+    }
+}
+
+bitflags! {
+    /// Bitflags representing enabled/disabled sub-control state.
+    pub(super) struct SubCtrlState: u8 {
+        const MEMORY_CTRLS = 1 << 0;
+        const CPUSET_CTRLS = 1 << 1;
+        const PIDS_CTRLS = 1 << 2;
+    }
+}
+
+impl SubCtrlState {
+    fn control_bit(name: &str) -> Option<Self> {
+        match name {
+            "memory" => Some(Self::MEMORY_CTRLS),
+            "cpuset" => Some(Self::CPUSET_CTRLS),
+            "pids" => Some(Self::PIDS_CTRLS),
+            _ => None,
+        }
+    }
+
+    /// Checks if a sub-control is enabled in the current state.
+    ///
+    /// If the given name does not represent a supported controller,
+    /// returns `None`.
+    fn is_enabled(&self, name: &str) -> Option<bool> {
+        Self::control_bit(name).map(|bit| self.contains(bit))
+    }
+
+    fn activate(&mut self, name: &str) {
+        if let Some(bit) = Self::control_bit(name) {
+            *self |= bit;
+        }
+    }
+
+    fn deactivate(&mut self, name: &str) {
+        if let Some(bit) = Self::control_bit(name) {
+            *self -= bit;
+        }
+    }
+
+    fn show(&self) -> String {
+        let mut controllers = Vec::new();
+
+        if self.contains(Self::MEMORY_CTRLS) {
+            controllers.push("memory");
+        }
+        if self.contains(Self::CPUSET_CTRLS) {
+            controllers.push("cpuset");
+        }
+        if self.contains(Self::PIDS_CTRLS) {
+            controllers.push("pids");
+        }
+
+        controllers.join(" ")
+    }
+}
+
+/// The main controller for a single cgroup.
+///
+/// This struct can manage the activation state of each sub-control, and dispatches read/write
+/// operations to the appropriate sub-controllers.
+///
+/// The following is an explanation of the activation for sub-controls and controllers.
+/// When a cgroup activates a specific sub-control (e.g., memory, io), it means this control
+/// capability is being delegated to its children. Consequently, the corresponding controller
+/// within the child nodes will be activated.
+///
+/// The root node serves as the origin for all these control capabilities, so the controllers
+/// it possesses are always active. For any other node, only if its parent node first enables
+/// a sub-control, its corresponding controller will be activated.
+///
+/// Among all nodes, the fundamental cgroup controller is always active.
+pub(super) struct Controller {
+    sub_ctrl_state: Mutex<SubCtrlState>,
+    controllers: BTreeMap<SysStr, RcuOption<Arc<SubController>>>,
+    /// All attributes within the current controller.
+    ///
+    /// This field must be updated whenever the state of active controllers changes.
+    all_attrs: Mutex<SysAttrSet>,
+}
+
+impl Controller {
+    /// Creates a new controller manager for a cgroup.
+    pub(super) fn new(ctrl_state: SubCtrlState, is_root: bool) -> Self {
+        let mut controllers = BTreeMap::new();
+
+        let cgroup_controller = SubController::new("cgroup", ctrl_state, is_root).unwrap();
+        controllers.insert(
+            SysStr::from("cgroup"),
+            RcuOption::new(Some(cgroup_controller)),
+        );
+
+        let memory_controller = SubController::new("memory", ctrl_state, is_root);
+        controllers.insert(SysStr::from("memory"), RcuOption::new(memory_controller));
+        let cpuset_controller = SubController::new("cpuset", ctrl_state, is_root);
+        controllers.insert(SysStr::from("cpuset"), RcuOption::new(cpuset_controller));
+        let pids_controller = SubController::new("pids", ctrl_state, is_root);
+        controllers.insert(SysStr::from("pids"), RcuOption::new(pids_controller));
+
+        let controller = Self {
+            sub_ctrl_state: Mutex::new(SubCtrlState::empty()),
+            controllers,
+            all_attrs: Mutex::new(SysAttrSet::new_empty()),
+        };
+        controller.update_attrs();
+
+        controller
+    }
+
+    pub(super) fn sub_ctrl_state(&self) -> MutexGuard<SubCtrlState> {
+        self.sub_ctrl_state.lock()
+    }
+
+    /// Returns a string representation of the current `subtree_control` state.
+    pub(super) fn show_state(&self) -> String {
+        self.sub_ctrl_state.lock().show()
+    }
+
+    /// Returns a specific attribute with given name.
+    pub(super) fn attr(&self, name: &str) -> Option<SysAttr> {
+        self.all_attrs.lock().get(name).cloned()
+    }
+
+    /// Returns a the entire attribute set of this node.
+    pub(super) fn node_attrs(&self) -> SysAttrSet {
+        self.all_attrs.lock().clone()
+    }
+
+    /// Rebuilds the `all_attrs` set.
+    ///
+    /// This should be called whenever the state of active controllers changes.
+    fn update_attrs(&self) {
+        let mut builder = SysAttrSetBuilder::new();
+        let guard = disable_preempt();
+        for controller in self.controllers.values() {
+            let rcu_controller = controller.read_with(&guard);
+            if let Some(controller) = rcu_controller {
+                for attr in controller.attr_set().iter() {
+                    builder.add(attr.name().clone(), attr.perms());
+                }
+            }
+        }
+
+        *self.all_attrs.lock() = builder.build().unwrap();
+    }
+
+    /// Activates a sub-control with given name.
+    pub(super) fn activate(&self, name: &str, current_node: &dyn CgroupSysNode) -> Result<()> {
+        let mut sub_ctrl_state = self.sub_ctrl_state.lock();
+        let Some(is_enabled) = sub_ctrl_state.is_enabled(name) else {
+            return Err(Error::InvalidOperation);
+        };
+
+        if is_enabled {
+            return Ok(());
+        }
+
+        sub_ctrl_state.activate(name);
+
+        current_node.visit_children_with(0, &mut |node| {
+            let cgroup_node = node.as_any().downcast_ref::<CgroupNode>().unwrap();
+            let rcu_controller = cgroup_node.controller().controllers.get(name).unwrap();
+            rcu_controller.update(SubController::new(name, *sub_ctrl_state, false));
+
+            cgroup_node.controller().update_attrs();
+
+            Some(())
+        });
+
+        Ok(())
+    }
+
+    /// Deactivates a sub-control with given name.
+    pub(super) fn deactivate(&self, name: &str, current_node: &dyn CgroupSysNode) -> Result<()> {
+        let mut sub_ctrl_state = self.sub_ctrl_state.lock();
+        let Some(is_enabled) = sub_ctrl_state.is_enabled(name) else {
+            return Err(Error::InvalidOperation);
+        };
+
+        if !is_enabled {
+            return Ok(());
+        }
+
+        sub_ctrl_state.deactivate(name);
+
+        current_node.visit_children_with(0, &mut |node| {
+            let cgroup_node = node.as_any().downcast_ref::<CgroupNode>().unwrap();
+            let rcu_controller = cgroup_node.controller().controllers.get(name).unwrap();
+            rcu_controller.update(SubController::new(name, *sub_ctrl_state, false));
+
+            cgroup_node.controller().update_attrs();
+
+            Some(())
+        });
+
+        Ok(())
+    }
+
+    pub(super) fn read_attr(
+        &self,
+        name: &str,
+        writer: &mut VmWriter,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        let Some((subsys, _)) = name.split_once('.') else {
+            return Err(Error::NotFound);
+        };
+
+        let Some(rcu_controller) = self
+            .controllers
+            .get(subsys)
+            .map(|controller| controller.read())
+        else {
+            return Err(Error::NotFound);
+        };
+
+        let Some(controller) = rcu_controller.get() else {
+            return Err(Error::NotFound);
+        };
+
+        controller.read_attr(name, writer, cgroup_node)
+    }
+
+    pub(super) fn write_attr(
+        &self,
+        name: &str,
+        reader: &mut VmReader,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        let Some((subsys, _)) = name.split_once('.') else {
+            return Err(Error::NotFound);
+        };
+
+        let Some(rcu_controller) = self
+            .controllers
+            .get(subsys)
+            .map(|controller| controller.read())
+        else {
+            return Err(Error::NotFound);
+        };
+
+        let Some(controller) = rcu_controller.get() else {
+            return Err(Error::NotFound);
+        };
+
+        controller.write_attr(name, reader, cgroup_node)
+    }
+}
+
+/// A trait that abstracts over different types of cgroup nodes (`CgroupNode`, `CgroupSystem`)
+/// to provide a common API for controller logics.
+pub(super) trait CgroupSysNode: SysBranchNode {
+    fn controller(&self) -> &Controller;
+
+    fn cgroup_parent(&self) -> Option<Arc<dyn CgroupSysNode>> {
+        let parent = self.parent()?;
+        if parent.is_root() {
+            Some(Arc::downcast::<CgroupSystem>(parent).unwrap())
+        } else {
+            Some(Arc::downcast::<CgroupNode>(parent).unwrap())
+        }
+    }
+}

--- a/kernel/src/fs/cgroupfs/controller/pids.rs
+++ b/kernel/src/fs/cgroupfs/controller/pids.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_systree::{Error, Result, SysAttrSet, SysAttrSetBuilder, SysPerms, SysStr};
+use ostd::mm::{VmReader, VmWriter};
+
+use crate::fs::cgroupfs::controller::CgroupSysNode;
+
+/// The controller responsible for PID in the cgroup subsystem.
+///
+/// This controller will only provide interfaces in non-root cgroup node.
+pub struct PidsController {
+    attrs: SysAttrSet,
+}
+
+impl PidsController {
+    pub(super) fn new() -> Self {
+        let mut builder = SysAttrSetBuilder::new();
+
+        builder.add(SysStr::from("pids.max"), SysPerms::DEFAULT_RW_ATTR_PERMS);
+
+        let attrs = builder.build().expect("Failed to build attribute set");
+        Self { attrs }
+    }
+}
+
+impl super::SubControl for PidsController {
+    fn attr_set(&self) -> &SysAttrSet {
+        &self.attrs
+    }
+
+    fn read_attr(
+        &self,
+        _name: &str,
+        _writer: &mut VmWriter,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+
+    fn write_attr(
+        &self,
+        _name: &str,
+        _reader: &mut VmReader,
+        _cgroup_node: &dyn CgroupSysNode,
+    ) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+}

--- a/kernel/src/fs/cgroupfs/fs.rs
+++ b/kernel/src/fs/cgroupfs/fs.rs
@@ -21,6 +21,7 @@ use crate::{
 pub struct CgroupFs {
     sb: SuperBlock,
     root: Arc<dyn Inode>,
+    systree_root: Arc<CgroupSystem>,
 }
 
 // Magic number for cgroupfs v2 (taken from Linux)
@@ -31,12 +32,18 @@ const NAME_MAX: usize = 255;
 impl CgroupFs {
     pub(super) fn new(root_node: Arc<CgroupSystem>) -> Arc<Self> {
         let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX);
-        let root_inode = CgroupInode::new_root(root_node);
+        let root_inode = CgroupInode::new_root(root_node.clone());
 
         Arc::new(Self {
             sb,
             root: root_inode,
+            systree_root: root_node,
         })
+    }
+
+    /// Returns the root node in the `SysTree`.
+    pub fn systree_root(&self) -> &Arc<CgroupSystem> {
+        &self.systree_root
     }
 }
 

--- a/kernel/src/fs/cgroupfs/inode.rs
+++ b/kernel/src/fs/cgroupfs/inode.rs
@@ -5,10 +5,15 @@ use alloc::sync::{Arc, Weak};
 use ostd::sync::RwLock;
 
 use crate::{
-    fs::utils::{
-        systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
-        FileSystem, Inode, InodeMode, Metadata,
+    fs::{
+        cgroupfs::CgroupNode,
+        path::{is_dot, is_dotdot},
+        utils::{
+            systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
+            FileSystem, Inode, InodeMode, Metadata,
+        },
     },
+    prelude::*,
     Result,
 };
 
@@ -74,5 +79,39 @@ impl SysTreeInodeTy for CgroupInode {
 impl Inode for CgroupInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         super::singleton().clone()
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        if is_dot(name) {
+            return_errno_with_message!(Errno::EINVAL, "rmdir on .");
+        }
+        if is_dotdot(name) {
+            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..");
+        }
+
+        let SysTreeNodeKind::Branch(branch_node) = self.node_kind() else {
+            return_errno_with_message!(Errno::ENOTDIR, "current node is not a branch node");
+        };
+
+        let target_node = branch_node
+            .child(name)
+            .ok_or(crate::Error::new(Errno::ENOENT))?;
+
+        let target_node = target_node.cast_to_branch().unwrap();
+        if target_node.count_children() != 0 {
+            return_errno_with_message!(
+                Errno::ENOTEMPTY,
+                "only an empty cgroup hierarchy can be removed"
+            );
+        }
+
+        let target_cgroup_node = Arc::downcast::<CgroupNode>(target_node).unwrap();
+        if target_cgroup_node.have_processes() {
+            return_errno_with_message!(Errno::EBUSY, "the cgroup hierarchy still has processes");
+        }
+
+        branch_node.remove_child(name)?;
+
+        Ok(())
     }
 }

--- a/kernel/src/fs/cgroupfs/inode.rs
+++ b/kernel/src/fs/cgroupfs/inode.rs
@@ -114,4 +114,8 @@ impl Inode for CgroupInode {
 
         Ok(())
     }
+
+    fn is_dentry_cacheable(&self) -> bool {
+        !matches!(self.node_kind, SysTreeNodeKind::Attr(..))
+    }
 }

--- a/kernel/src/fs/cgroupfs/mod.rs
+++ b/kernel/src/fs/cgroupfs/mod.rs
@@ -2,11 +2,10 @@
 
 use alloc::sync::Arc;
 
-use fs::CgroupFs;
+use fs::{CgroupFs, CgroupFsType};
 pub use inode::CgroupInode;
 use spin::Once;
-
-use crate::fs::cgroupfs::{fs::CgroupFsType, systree_node::CgroupSystem};
+pub use systree_node::{CgroupNode, CgroupSystem};
 
 mod fs;
 mod inode;

--- a/kernel/src/fs/cgroupfs/mod.rs
+++ b/kernel/src/fs/cgroupfs/mod.rs
@@ -7,6 +7,7 @@ pub use inode::CgroupInode;
 use spin::Once;
 pub use systree_node::{CgroupNode, CgroupSystem};
 
+mod controller;
 mod fs;
 mod inode;
 mod systree_node;

--- a/kernel/src/fs/cgroupfs/systree_node.rs
+++ b/kernel/src/fs/cgroupfs/systree_node.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{
+    format,
     string::ToString,
     sync::{Arc, Weak},
 };
-use core::fmt::Debug;
+use core::{
+    fmt::Debug,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use aster_systree::{
     inherit_sys_branch_node, BranchNodeFields, Error, Result, SysAttrSetBuilder, SysBranchNode,
@@ -12,6 +16,11 @@ use aster_systree::{
 };
 use inherit_methods_macro::inherit_methods;
 use ostd::mm::{VmReader, VmWriter};
+
+use crate::{
+    prelude::*,
+    process::{process_table, Pid, Process},
+};
 
 /// The root of a cgroup hierarchy, serving as the entry point to
 /// the entire cgroup control system.
@@ -28,9 +37,31 @@ pub struct CgroupSystem {
 /// Each node can bind a group of processes together for purpose of resource
 /// management. Except for the root node, all nodes in the cgroup tree are of
 /// this type.
-#[derive(Debug)]
 pub struct CgroupNode {
     fields: BranchNodeFields<CgroupNode, Self>,
+    /// Processes bound to this node.
+    processes: Mutex<BTreeMap<Pid, Weak<Process>>>,
+    /// The depth of the node in the cgroupfs [`SysTree`], where the child of
+    /// the root node has a depth of 1.
+    depth: usize,
+    /// Tracks the "populated" status of this node and its direct children.
+    ///
+    /// The count is the sum of:
+    /// - The number of its direct children that are populated.
+    /// - A value of 1 if this node itself contains processes.
+    ///
+    /// "populated": A node is considered populated if it has bound processes
+    /// either on itself or in any of its descendant nodes. Consequently,
+    /// a count > 0 indicates that this node is populated.
+    populated_count: AtomicUsize,
+}
+
+impl Debug for CgroupNode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CgroupNormalNode")
+            .field("fields", &self.fields)
+            .finish()
+    }
 }
 
 #[inherit_methods(from = "self.fields")]
@@ -60,6 +91,10 @@ impl CgroupSystem {
             SysPerms::DEFAULT_RW_ATTR_PERMS,
         );
         builder.add(
+            SysStr::from("cgroup.procs"),
+            SysPerms::DEFAULT_RW_ATTR_PERMS,
+        );
+        builder.add(
             SysStr::from("cgroup.threads"),
             SysPerms::DEFAULT_RW_ATTR_PERMS,
         );
@@ -78,7 +113,7 @@ impl CgroupSystem {
 }
 
 impl CgroupNode {
-    pub(super) fn new(name: SysStr) -> Arc<Self> {
+    pub(super) fn new(name: SysStr, depth: usize) -> Arc<Self> {
         let mut builder = SysAttrSetBuilder::new();
         // TODO: Add more attributes as needed. The normal cgroup node may have
         // more attributes than the unified one.
@@ -91,6 +126,10 @@ impl CgroupNode {
             SysPerms::DEFAULT_RW_ATTR_PERMS,
         );
         builder.add(
+            SysStr::from("cgroup.procs"),
+            SysPerms::DEFAULT_RW_ATTR_PERMS,
+        );
+        builder.add(
             SysStr::from("cgroup.threads"),
             SysPerms::DEFAULT_RW_ATTR_PERMS,
         );
@@ -99,12 +138,179 @@ impl CgroupNode {
             SysPerms::DEFAULT_RW_ATTR_PERMS,
         );
         builder.add(SysStr::from("cpu.stat"), SysPerms::DEFAULT_RO_ATTR_PERMS);
+        builder.add(
+            SysStr::from("cgroup.events"),
+            SysPerms::DEFAULT_RO_ATTR_PERMS,
+        );
 
         let attrs = builder.build().expect("Failed to build attribute set");
         Arc::new_cyclic(|weak_self| {
             let fields = BranchNodeFields::new(name, attrs, weak_self.clone());
-            CgroupNode { fields }
+            CgroupNode {
+                fields,
+                processes: Mutex::new(BTreeMap::new()),
+                depth,
+                populated_count: AtomicUsize::new(0),
+            }
         })
+    }
+}
+
+// For process management
+impl CgroupNode {
+    /// Moves a process to this cgroup node.
+    ///
+    /// A process can only belong to one cgroup at a time.
+    /// When moved to a new cgroup, it's automatically removed
+    /// from the previous one.
+    pub fn move_process(&self, process: Arc<Process>) {
+        let rcu_old_cgroup = process.cgroup();
+        let old_cgroup = rcu_old_cgroup.get();
+
+        let (mut current_process_set, old_cgroup_process_set) = {
+            if let Some(old_cgroup) = old_cgroup.as_ref() {
+                if self.id() == old_cgroup.id() {
+                    return;
+                }
+
+                if self.id() < old_cgroup.id() {
+                    let current_process_set = self.processes.lock();
+                    let old_cgroup_process_set = old_cgroup.processes.lock();
+                    (current_process_set, Some(old_cgroup_process_set))
+                } else {
+                    let old_cgroup_process_set = old_cgroup.processes.lock();
+                    let current_process_set = self.processes.lock();
+                    (current_process_set, Some(old_cgroup_process_set))
+                }
+            } else {
+                (self.processes.lock(), None)
+            }
+        };
+
+        if let Some(mut old_cgroup_process_set) = old_cgroup_process_set {
+            if old_cgroup_process_set.remove(&process.pid()).is_some()
+                && old_cgroup_process_set.is_empty()
+            {
+                let old_count = self.populated_count.fetch_sub(1, Ordering::AcqRel);
+                if old_count == 1 {
+                    self.propagate_sub_populated();
+                }
+            }
+        }
+
+        process.set_cgroup(Some(self.fields.weak_self().upgrade().unwrap()));
+
+        if current_process_set.is_empty() {
+            let old_count = self.populated_count.fetch_add(1, Ordering::AcqRel);
+            if old_count == 0 {
+                self.propagate_add_populated();
+            }
+        }
+
+        current_process_set.insert(process.pid(), Arc::downgrade(&process));
+    }
+
+    /// Removes a process from this cgroup node.
+    pub fn remove_process(&self, process: &Process) {
+        let mut processes = self.processes.lock();
+        if processes.remove(&process.pid()).is_none() {
+            return;
+        }
+
+        process.cgroup().compare_exchange(None).unwrap();
+
+        if processes.is_empty() {
+            let old_count = self.populated_count.fetch_sub(1, Ordering::AcqRel);
+            if old_count == 1 {
+                self.propagate_sub_populated();
+            }
+        }
+    }
+
+    fn propagate_add_populated(&self) {
+        if self.depth <= 1 {
+            return;
+        }
+
+        let mut current_parent = Arc::downcast::<CgroupNode>(self.parent().unwrap()).unwrap();
+        loop {
+            let old_count = current_parent
+                .populated_count
+                .fetch_add(1, Ordering::AcqRel);
+            if old_count > 0 {
+                break;
+            }
+
+            if current_parent.depth == 1 {
+                break;
+            }
+
+            current_parent = Arc::downcast::<CgroupNode>(current_parent.parent().unwrap()).unwrap();
+        }
+    }
+
+    fn propagate_sub_populated(&self) {
+        if self.depth <= 1 {
+            return;
+        }
+
+        let mut current_parent = Arc::downcast::<CgroupNode>(self.parent().unwrap()).unwrap();
+        loop {
+            let old_count = current_parent
+                .populated_count
+                .fetch_sub(1, Ordering::AcqRel);
+            if old_count != 1 {
+                break;
+            }
+
+            if current_parent.depth == 1 {
+                break;
+            }
+
+            current_parent = Arc::downcast::<CgroupNode>(current_parent.parent().unwrap()).unwrap();
+        }
+    }
+
+    /// Whether this cgroup node has any processes bound to it.
+    pub fn have_processes(&self) -> bool {
+        !self.processes.lock().is_empty()
+    }
+
+    /// Reads the PID of the processes bound to this cgroup node.
+    fn read_procs(&self, writer: &mut VmWriter) -> Result<usize> {
+        let context = self
+            .processes
+            .lock()
+            .keys()
+            .map(|pid| pid.to_string())
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        writer
+            .write_fallible(&mut VmReader::from((context + "\n").as_bytes()))
+            .map_err(|_| Error::AttributeError)
+    }
+
+    /// Writes the PID of a process to this cgroup node.
+    ///
+    /// The corresponding process will be bound to this cgroup.
+    /// The cgroup only allows binding one process at a time.
+    fn write_procs(&self, reader: &mut VmReader) -> Result<usize> {
+        // TODO: According to the "no internal processes" rule of cgroupv2
+        // (Ref: https://man7.org/linux/man-pages/man7/cgroups.7.html),
+        // if the cgroup node has enabled some controllers like "memory", "io",
+        // it is forbidden to bind a process to an internal cgroup node.
+        let (pid, pid_len) = read_pid_from_reader(reader)?;
+
+        let process = if pid == 0 {
+            current!()
+        } else {
+            process_table::get_process(pid).ok_or(Error::AttributeError)?
+        };
+
+        self.move_process(process);
+
+        Ok(pid_len)
     }
 }
 
@@ -117,14 +323,57 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
         // This method should be a no-op for `RootNode`.
     }
 
-    fn read_attr(&self, _name: &str, _writer: &mut VmWriter) -> Result<usize> {
-        // TODO: Add support for reading attributes.
-        Err(Error::AttributeError)
+    fn read_attr(&self, name: &str, writer: &mut VmWriter) -> Result<usize> {
+        match name {
+            "cgroup.procs" => {
+                let process_table = process_table::process_table_mut();
+                let context = process_table
+                    .iter()
+                    .filter_map(|process| {
+                        if process.cgroup().is_none() {
+                            Some(process.pid().to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<String>>()
+                    .join("\n");
+
+                writer
+                    .write_fallible(&mut VmReader::from((context + "\n").as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            _ => {
+                // TODO: Add support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
     }
 
-    fn write_attr(&self, _name: &str, _reader: &mut VmReader) -> Result<usize> {
-        // TODO: Add support for writing attributes.
-        Err(Error::AttributeError)
+    fn write_attr(&self, name: &str, reader: &mut VmReader) -> Result<usize> {
+        match name {
+            "cgroup.procs" => {
+                let (pid, pid_len) = read_pid_from_reader(reader)?;
+
+                let process = if pid == 0 {
+                    current!()
+                } else {
+                    process_table::get_process(pid).ok_or(Error::AttributeError)?
+                };
+
+                let rcu_old_cgroup = process.cgroup();
+                let old_cgroup = rcu_old_cgroup.get();
+                if let Some(old_cgroup) = old_cgroup {
+                    old_cgroup.remove_process(&process);
+                }
+
+                Ok(pid_len)
+            }
+            _ => {
+                // TODO: Add support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
     }
 
     fn perms(&self) -> SysPerms {
@@ -132,21 +381,44 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
     }
 
     fn create_child(&self, name: &str) -> Result<Arc<dyn SysObj>> {
-        let new_child = CgroupNode::new(name.to_string().into());
+        let new_child = CgroupNode::new(name.to_string().into(), 1);
         self.add_child(new_child.clone())?;
         Ok(new_child)
     }
 });
 
 inherit_sys_branch_node!(CgroupNode, fields, {
-    fn read_attr(&self, _name: &str, _writer: &mut VmWriter) -> Result<usize> {
-        // TODO: Add support for reading attributes.
-        Err(Error::AttributeError)
+    fn read_attr(&self, name: &str, writer: &mut VmWriter) -> Result<usize> {
+        match name {
+            "cgroup.procs" => self.read_procs(writer),
+            "cgroup.events" => {
+                let res = if self.populated_count.load(Ordering::Acquire) > 0 {
+                    1
+                } else {
+                    0
+                };
+                // Currently we have not enabled the "frozen" attribute
+                // so the "frozen" field is always zero.
+                let output = format!("populated {}\nfrozen {}\n", res, 0);
+                writer
+                    .write_fallible(&mut VmReader::from(output.as_bytes()))
+                    .map_err(|_| Error::AttributeError)
+            }
+            _ => {
+                // TODO: Add support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
     }
 
-    fn write_attr(&self, _name: &str, _reader: &mut VmReader) -> Result<usize> {
-        // TODO: Add support for writing attributes.
-        Err(Error::AttributeError)
+    fn write_attr(&self, name: &str, reader: &mut VmReader) -> Result<usize> {
+        match name {
+            "cgroup.procs" => self.write_procs(reader),
+            _ => {
+                // TODO: Add support for reading other attributes.
+                Err(Error::AttributeError)
+            }
+        }
     }
 
     fn perms(&self) -> SysPerms {
@@ -154,8 +426,29 @@ inherit_sys_branch_node!(CgroupNode, fields, {
     }
 
     fn create_child(&self, name: &str) -> Result<Arc<dyn SysObj>> {
-        let new_child = CgroupNode::new(name.to_string().into());
+        let new_child = CgroupNode::new(name.to_string().into(), self.depth + 1);
         self.add_child(new_child.clone())?;
         Ok(new_child)
     }
 });
+
+/// Reads a PID from the given reader.
+///
+/// Returns a tuple containing the PID and the number of bytes read.
+fn read_pid_from_reader(reader: &mut VmReader) -> Result<(Pid, usize)> {
+    let mut pid_buffer = alloc::vec![0; reader.remain()];
+    let pid_len = reader
+        .read_fallible(&mut VmWriter::from(pid_buffer.as_mut_slice()))
+        .map_err(|_| Error::AttributeError)?;
+
+    let pid = alloc::str::from_utf8(&pid_buffer[..pid_len])
+        .map_err(|_| Error::AttributeError)
+        .and_then(|string| {
+            let strip_string = string.trim();
+            strip_string
+                .parse::<u32>()
+                .map_err(|_| Error::AttributeError)
+        })?;
+
+    Ok((pid, pid_len))
+}

--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -179,15 +179,8 @@ impl Dentry_ {
     pub fn lookup_via_fs(&self, name: &str) -> Result<Arc<Dentry_>> {
         let children = self.children.upread();
 
-        let inode = match self.inode.lookup(name) {
-            Ok(inode) => inode,
-            Err(e) => {
-                if e.error() == Errno::ENOENT && self.is_dentry_cacheable() {
-                    children.upgrade().insert_negative(String::from(name));
-                }
-                return Err(e);
-            }
-        };
+        // TODO: Add a right implementation to cache negative dentry.
+        let inode = self.inode.lookup(name)?;
         let name = String::from(name);
         let target = Self::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
 

--- a/kernel/src/fs/procfs/pid/cgroup.rs
+++ b/kernel/src/fs/procfs/pid/cgroup.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use aster_systree::SysObj;
+
+use crate::{
+    fs::{
+        cgroupfs,
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::Inode,
+    },
+    prelude::*,
+    Process,
+};
+
+/// Represents the inode at `/proc/[pid]/cgroup`.
+pub struct CgroupOps(Arc<Process>);
+
+impl CgroupOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self(process_ref))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for CgroupOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let path = self
+            .0
+            .cgroup()
+            .get()
+            .map(|cgroup| cgroup.path())
+            .unwrap_or_else(|| cgroupfs::singleton().systree_root().path());
+
+        let data = format!("{}{}\n", "0::", path);
+        Ok(data.into_bytes())
+    }
+}

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -307,7 +307,9 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
     }
 
     default fn resize(&self, _new_size: usize) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
+        // The `resize` operation should be ignored by kernelfs inodes,
+        // and should not incur an error.
+        Ok(())
     }
 
     default fn atime(&self) -> Duration {
@@ -437,6 +439,10 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
     }
 
     default fn unlink(&self, _name: &str) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    default fn rmdir(&self, _name: &str) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -189,7 +189,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             }
         } else {
             // If no child node found, try finding an attribute of the current branch node
-            let Some(attr) = sysnode.node_attrs().get(name) else {
+            let Some(attr) = sysnode.attr(name) else {
                 return_errno_with_message!(Errno::ENOENT, "child node or attribute not found");
             };
 
@@ -204,7 +204,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                 }
             };
 
-            let inode = Self::new_attr(attr.clone(), parent_node_arc, Arc::downgrade(&self.this()));
+            let inode = Self::new_attr(attr, parent_node_arc, Arc::downgrade(&self.this()));
             Ok(inode)
         }
     }
@@ -214,7 +214,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         Self: Sized + 'static,
     {
         // This function is called when the current inode is a Leaf directory
-        let Some(attr) = sysnode.node_attrs().get(name) else {
+        let Some(attr) = sysnode.attr(name) else {
             return Err(Error::new(Errno::ENOENT));
         };
 
@@ -229,7 +229,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             }
         };
 
-        let inode = Self::new_attr(attr.clone(), leaf_node_arc, Arc::downgrade(&self.this()));
+        let inode = Self::new_attr(attr, leaf_node_arc, Arc::downgrade(&self.this()));
         Ok(inode)
     }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(register_tool)]
 #![feature(min_specialization)]
 #![feature(step_trait)]
+#![feature(string_from_utf8_lossy_owned)]
 #![feature(trait_alias)]
 #![feature(trait_upcasting)]
 #![feature(associated_type_defaults)]

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -197,6 +197,13 @@ pub fn clone_child(
         Ok(child_tid)
     } else {
         let child_process = clone_child_process(ctx, parent_context, clone_args)?;
+
+        let cgroup = ctx.process.cgroup();
+        if let Some(cgroup) = cgroup.get() {
+            cgroup.move_process(child_process.clone());
+        }
+        drop(cgroup);
+
         if clone_args.flags.contains(CloneFlags::CLONE_VFORK) {
             child_process.status().set_vfork_child(true);
         }

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -24,6 +24,12 @@ pub(super) fn exit_process(current_process: &Process) {
     move_children_to_reaper_process(current_process);
 
     send_child_death_signal(current_process);
+
+    let cgroup = current_process.cgroup();
+    if let Some(cgroup) = cgroup.get() {
+        // Remove the process from the cgroup.
+        cgroup.remove_process(current_process);
+    }
 }
 
 /// Sends parent-death signals to the children.

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -17,6 +17,7 @@ use super::{
     task_set::TaskSet,
 };
 use crate::{
+    fs::cgroupfs::CgroupNode,
     prelude::*,
     process::{status::StopWaitStatus, WaitOptions},
     sched::{AtomicNice, Nice},
@@ -34,7 +35,10 @@ mod timer_manager;
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 pub use init_proc::spawn_init_process;
 pub use job_control::JobControl;
-use ostd::{sync::WaitQueue, task::Task};
+use ostd::{
+    sync::{RcuOption, RcuOptionReadGuard, WaitQueue},
+    task::Task,
+};
 pub use process_group::ProcessGroup;
 pub use session::Session;
 pub use terminal::Terminal;
@@ -80,6 +84,10 @@ pub struct Process {
     pub(super) process_group: Mutex<Weak<ProcessGroup>>,
     /// resource limits
     resource_limits: ResourceLimits,
+    /// The bound cgroup of the process.
+    ///
+    /// If this field is `None`, the process is bound to the root cgroup.
+    cgroup: RcuOption<Arc<CgroupNode>>,
     /// Scheduling priority nice value
     /// According to POSIX.1, the nice value is a per-process attribute,
     /// the threads in a process should share a nice value.
@@ -215,6 +223,7 @@ impl Process {
             parent_death_signal: AtomicSigNum::new_empty(),
             exit_signal: AtomicSigNum::new_empty(),
             resource_limits,
+            cgroup: RcuOption::new(None),
             nice: AtomicNice::new(nice),
             timer_manager: PosixTimerManager::new(&prof_clock, process_ref),
             prof_clock,
@@ -754,6 +763,22 @@ impl Process {
                 }
             }
         }
+    }
+
+    // ******************* cgroup ********************
+
+    /// Returns a RCU read guard to the cgroup of the process.
+    pub fn cgroup(&self) -> RcuOptionReadGuard<Arc<CgroupNode>> {
+        self.cgroup.read()
+    }
+
+    /// Sets the cgroup for this process.
+    ///
+    /// Note: This function should only be called within the cgroup module.
+    /// Arbitrary calls may likely cause race conditions.
+    #[doc(hidden)]
+    pub fn set_cgroup(&self, cgroup: Option<Arc<CgroupNode>>) {
+        self.cgroup.update(cgroup);
     }
 }
 

--- a/test/src/apps/scripts/cgroup_test.sh
+++ b/test/src/apps/scripts/cgroup_test.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+CGROUP_ROOT="/sys/fs/cgroup"
+CGROUP_NAME="user"
+PROCESS_ID=1
+
+log_step() {
+    echo -e "\n==> $1"
+}
+
+verify() {
+    local description=$1
+    local command=$2
+    local expected=$3
+    
+    log_step "Verify: $description"
+    echo "Run: $command"
+    local result=$(eval "$command")
+    echo "Got: $result"
+    echo "Expected: $expected"
+    
+    if [ "$result" != "$expected" ]; then
+        echo -e "Error: Verification failed!"
+        exit 1
+    else
+        echo -e "Verified"
+    fi
+}
+
+cleanup() {
+    log_step "Cleaning up"
+    
+    if [ -f "$CGROUP_ROOT/cgroup.procs" ]; then
+        echo "Moving process $PROCESS_ID back to root cgroup"
+        echo $PROCESS_ID > "$CGROUP_ROOT/cgroup.procs" 2>/dev/null || true
+    fi
+    
+    if [ -d "$CGROUP_ROOT/$CGROUP_NAME" ]; then
+        echo "Removing test cgroup: $CGROUP_ROOT/$CGROUP_NAME"
+        rmdir "$CGROUP_ROOT/$CGROUP_NAME" 2>/dev/null || true
+    fi
+    
+    echo "Cleanup complete"
+}
+
+trap cleanup EXIT
+
+log_step "1. Change to cgroup root directory"
+cd "$CGROUP_ROOT"
+echo "Current directory: $(pwd)"
+
+log_step "2. Create user hierarchy"
+mkdir -p "$CGROUP_NAME"
+verify "user hierarchy exists" "ls -d $CGROUP_NAME" "$CGROUP_NAME"
+
+log_step "3. Enter user directory"
+cd "$CGROUP_NAME"
+echo "Current directory: $(pwd)"
+
+log_step "4. Check initial cgroup of process 1"
+verify "Process 1 initially in root cgroup" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/"
+
+log_step "4a. Check initial populated status"
+verify "Initial cgroup.events populated=0" "grep '^populated' cgroup.events" "populated 0"
+
+log_step "5. Bind process 1 to user hierarchy"
+echo $PROCESS_ID > cgroup.procs
+verify "Process 1 added to user hierarchy" "cat cgroup.procs | grep -w $PROCESS_ID" "$PROCESS_ID"
+
+log_step "5a. Check populated status after binding"
+verify "cgroup.events populated=1 after binding" "grep '^populated' cgroup.events" "populated 1"
+
+log_step "6. Check process 1 cgroup again"
+verify "Process 1 now in user hierarchy" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/$CGROUP_NAME"
+
+log_step "7. Return to parent directory"
+cd ..
+echo "Current directory: $(pwd)"
+
+log_step "8. Check parent cgroup.procs contents"
+echo "cgroup.procs contents:"
+cat cgroup.procs
+verify "cgroup.procs now does not contain process 1" "cat cgroup.procs | grep -w $PROCESS_ID" ""
+
+log_step "9. Move process 1 back to root cgroup"
+echo $PROCESS_ID > cgroup.procs
+verify "Process 1 back in root cgroup" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/"
+
+log_step "10. Remove user hierarchy"
+rmdir "$CGROUP_NAME"
+verify "user hierarchy removed" "ls -d $CGROUP_NAME 2>&1" "ls: $CGROUP_NAME: No such file or directory"
+
+echo -e "\nAll test steps completed successfully!"

--- a/test/src/apps/scripts/cgroup_test.sh
+++ b/test/src/apps/scripts/cgroup_test.sh
@@ -19,7 +19,7 @@ verify() {
     
     log_step "Verify: $description"
     echo "Run: $command"
-    local result=$(eval "$command")
+    local result=$(eval "$command" 2>&1)
     echo "Got: $result"
     echo "Expected: $expected"
     
@@ -53,6 +53,9 @@ log_step "1. Change to cgroup root directory"
 cd "$CGROUP_ROOT"
 echo "Current directory: $(pwd)"
 
+log_step "1a. Check initial controller attributes"
+verify "cpuset.cpus.effective exists in root" "ls cpuset.cpus.effective" "cpuset.cpus.effective"
+
 log_step "2. Create user hierarchy"
 mkdir -p "$CGROUP_NAME"
 verify "user hierarchy exists" "ls -d $CGROUP_NAME" "$CGROUP_NAME"
@@ -61,37 +64,71 @@ log_step "3. Enter user directory"
 cd "$CGROUP_NAME"
 echo "Current directory: $(pwd)"
 
+log_step "3a. Check initial memory.max in child"
+verify "memory.max doesn't exist initially" "ls memory.max" "ls: memory.max: No such file or directory"
+
+log_step "3b. Check memory.pressure exists in child"
+verify "memory.pressure exists" "ls memory.pressure" "memory.pressure"
+
 log_step "4. Check initial cgroup of process 1"
 verify "Process 1 initially in root cgroup" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/"
 
 log_step "4a. Check initial populated status"
 verify "Initial cgroup.events populated=0" "grep '^populated' cgroup.events" "populated 0"
 
-log_step "5. Bind process 1 to user hierarchy"
+log_step "5. Enable memory and pids in root"
+cd ..
+echo "+memory +pids" > cgroup.subtree_control
+verify "root subtree_control has memory and pids" "cat cgroup.subtree_control" "memory pids"
+
+log_step "5a. Check child now has memory.max and pids.max"
+cd "$CGROUP_NAME"
+echo "Current directory: $(pwd)"
+echo "Current directory lidt: $(ls)"
+verify "memory.max now exists" "ls memory.max" "memory.max"
+verify "pids.max now exists" "ls pids.max" "pids.max"
+
+log_step "5b. Check child cgroup.controllers"
+verify "child controllers are memory and pids" "cat cgroup.controllers" "memory pids"
+
+log_step "6. Disable memory in root"
+cd ..
+echo "-memory" > cgroup.subtree_control
+verify "root subtree_control removed memory" "cat cgroup.subtree_control" "pids"
+
+log_step "6a. Check child lost memory.max"
+cd "$CGROUP_NAME"
+verify "memory.max removed after disabling" "ls memory.max" "ls: memory.max: No such file or directory"
+
+log_step "7. Bind process 1 to user hierarchy"
 echo $PROCESS_ID > cgroup.procs
 verify "Process 1 added to user hierarchy" "cat cgroup.procs | grep -w $PROCESS_ID" "$PROCESS_ID"
 
-log_step "5a. Check populated status after binding"
-verify "cgroup.events populated=1 after binding" "grep '^populated' cgroup.events" "populated 1"
+log_step "7a. Try enabling pids in child (should fail with EBUSY)"
+verify "Cannot enable pids with process attached" "echo +pids > cgroup.subtree_control" "sh: write error: Device or resource busy"
 
-log_step "6. Check process 1 cgroup again"
-verify "Process 1 now in user hierarchy" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/$CGROUP_NAME"
-
-log_step "7. Return to parent directory"
+log_step "8. Remove process 1 from child"
 cd ..
-echo "Current directory: $(pwd)"
-
-log_step "8. Check parent cgroup.procs contents"
-echo "cgroup.procs contents:"
-cat cgroup.procs
-verify "cgroup.procs now does not contain process 1" "cat cgroup.procs | grep -w $PROCESS_ID" ""
-
-log_step "9. Move process 1 back to root cgroup"
 echo $PROCESS_ID > cgroup.procs
 verify "Process 1 back in root cgroup" "grep -a '0::' /proc/$PROCESS_ID/cgroup" "0::/"
 
-log_step "10. Remove user hierarchy"
+log_step "8a. Now enable pids in child (should succeed)"
+cd "$CGROUP_NAME"
+echo "+pids" > cgroup.subtree_control
+verify "pids enabled successfully" "cat cgroup.subtree_control" "pids"
+
+log_step "8b. Verify subtree_control is pids"
+verify "subtree_control is pids" "cat cgroup.subtree_control" "pids"
+
+log_step "9. Try binding process 1 again (should fail)"
+verify "Cannot bind process when pids enabled" "echo $PROCESS_ID > cgroup.procs" "sh: write error: Device or resource busy"
+
+log_step "10. Return to parent directory"
+cd ..
+echo "Current directory: $(pwd)"
+
+log_step "11. Remove user hierarchy"
 rmdir "$CGROUP_NAME"
-verify "user hierarchy removed" "ls -d $CGROUP_NAME 2>&1" "ls: $CGROUP_NAME: No such file or directory"
+verify "user hierarchy removed" "ls -d $CGROUP_NAME" "ls: $CGROUP_NAME: No such file or directory"
 
 echo -e "\nAll test steps completed successfully!"

--- a/test/src/apps/scripts/run_general_test.sh
+++ b/test/src/apps/scripts/run_general_test.sh
@@ -15,6 +15,7 @@ if [ -z $BLOCK_UNSUPPORTED_SMP_TESTS ]; then
     ./fs.sh # will hang
     ./process.sh # will randomly hang
     ./network.sh # will hang
+    ./cgroup_test.sh
 fi
 
 echo "All general tests passed."


### PR DESCRIPTION
Based on #2160.

This PR implements a controller framework for cgroup subsystem and add the dummy implementations of "memory", "cpuset" and "pids" controller.

With this PR, one can view the active controllers in current cgroup through "cgroup.controllers", and can delegate control functionality to the children of the cgroup through "cgroup.subtree_control".

Serves for #2214.

