### PR TITLE
Set softfloat targets for ARM/LoongArch/RISC-V

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -68,10 +68,10 @@ fixed = "1.28.0"
 [target.x86_64-unknown-none.dependencies]
 tdx-guest = { version = "0.2.1", optional = true }
 
-[target.riscv64gc-unknown-none-elf.dependencies]
+[target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.11.1", features = ["s-mode"] }
 
-[target.loongarch64-unknown-none.dependencies]
+[target.loongarch64-unknown-none-softfloat.dependencies]
 loongArch64 = "0.2.5"
 
 [features]

--- a/kernel/comps/time/Cargo.toml
+++ b/kernel/comps/time/Cargo.toml
@@ -12,7 +12,7 @@ component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
 spin = "0.9.4"
 
-[target.riscv64gc-unknown-none-elf.dependencies]
+[target.riscv64imac-unknown-none-elf.dependencies]
 chrono = { version = "0.4.38", default-features = false }
 
 [lints]

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -418,6 +418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +631,12 @@ dependencies = [
  "serde",
  "xmas-elf",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -837,6 +849,19 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -844,7 +869,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys",
 ]
 
@@ -951,7 +976,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys",
 ]
 
@@ -1120,7 +1145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix",
+ "rustix 1.0.7",
  "winsafe",
 ]
 

--- a/osdk/src/arch.rs
+++ b/osdk/src/arch.rs
@@ -46,10 +46,10 @@ impl Arch {
     /// Get the target triple for the architecture.
     pub fn triple(&self) -> &'static str {
         match self {
-            Arch::Aarch64 => "aarch64-unknown-none",
-            Arch::RiscV64 => "riscv64gc-unknown-none-elf",
+            Arch::Aarch64 => "aarch64-unknown-none-softfloat",
+            Arch::RiscV64 => "riscv64imac-unknown-none-elf",
             Arch::X86_64 => "x86_64-unknown-none",
-            Arch::LoongArch64 => "loongarch64-unknown-none",
+            Arch::LoongArch64 => "loongarch64-unknown-none-softfloat",
         }
     }
 

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -39,6 +39,15 @@ bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
 minicov = { version = "0.3", optional = true }
 
+# The targets are chosen to prevent the generated machine code from using any
+# vector or floating-point registers.
+#
+# - `x86_64-unknown-none` satisfies this property, as explained by [the
+#   official documentation](https://doc.rust-lang.org/rustc/platform-support/x86_64-unknown-none.html).
+# - `riscv64imac-unknown-none-elf` denotes a RISC-V ISA with only basic
+#   extensions (`imac`) and no floating-point-related extensions.
+# - `loongarch64-unknown-none-softfloat` is rather self-explaining.
+
 [target.x86_64-unknown-none.dependencies]
 x86_64 = "0.14.13"
 x86 = "0.52.0"
@@ -52,13 +61,13 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [
 tdx-guest = { version = "0.2.1", optional = true }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 
-[target.riscv64gc-unknown-none-elf.dependencies]
+[target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 
-[target.loongarch64-unknown-none.dependencies]
+[target.loongarch64-unknown-none-softfloat.dependencies]
 loongArch64 = "0.2.5"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 


### PR DESCRIPTION
We should avoid using floats in the kernel. Specifically, we should instruct the compiler to avoid generating floating-point instructions. Otherwise, even if we don't explicitly use floating-point types, the compiler may still try to use them for optimization purposes.

We're doing this manually for the x86-64 architecture:
https://github.com/asterinas/asterinas/blob/345cc9d0556eee0f680eb91d3355de7bd32181e8/osdk/src/commands/build/bin.rs#L183-L198

We can also do this manually for other architectures. However:
 - for ARM and LoongArch, it's more conventional to just change the target triples to the `*-softfloat` variants, i.e., [`aarch64-unknown-none-softfloat` and `loongarch64-unknown-none-softfloat`](https://doc.rust-lang.org/rustc/platform-support.html);
 - for RISC-V, we perhaps want `riscv64imac-unknown-none-elf`.