### PR TITLE
Remove TLS-related stuffs from `LinuxABI`

### DIFF
--- a/kernel/src/arch/loongarch/cpu.rs
+++ b/kernel/src/arch/loongarch/cpu.rs
@@ -41,7 +41,8 @@ impl LinuxAbi for UserContext {
 
 /// Represents the context of a signal handler.
 ///
-/// This contains the context saved before a signal handler is invoked and restored by `sys_rt_sigreturn`.
+/// This contains the context saved before a signal handler is invoked; it will be restored by
+/// `sys_rt_sigreturn`.
 ///
 /// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/include/uapi/asm/sigcontext.h#L20>
 #[repr(C)]

--- a/kernel/src/arch/loongarch/cpu.rs
+++ b/kernel/src/arch/loongarch/cpu.rs
@@ -37,14 +37,6 @@ impl LinuxAbi for UserContext {
             self.a5(),
         ]
     }
-
-    fn set_tls_pointer(&mut self, tls: usize) {
-        self.set_tp(tls);
-    }
-
-    fn tls_pointer(&self) -> usize {
-        self.tp()
-    }
 }
 
 /// Represents the context of a signal handler.

--- a/kernel/src/arch/riscv/cpu.rs
+++ b/kernel/src/arch/riscv/cpu.rs
@@ -78,7 +78,10 @@ macro_rules! copy_gp_regs {
 
 /// Represents the context of a signal handler.
 ///
-/// This contains the context saved before a signal handler is invoked and restored by `sys_rt_sigreturn`.
+/// This contains the context saved before a signal handler is invoked; it will be restored by
+/// `sys_rt_sigreturn`.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/riscv/include/uapi/asm/sigcontext.h#L30>
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Clone, Copy, Debug, Default, Pod)]

--- a/kernel/src/arch/riscv/cpu.rs
+++ b/kernel/src/arch/riscv/cpu.rs
@@ -38,14 +38,6 @@ impl LinuxAbi for UserContext {
             self.a5(),
         ]
     }
-
-    fn set_tls_pointer(&mut self, tls: usize) {
-        self.set_tp(tls);
-    }
-
-    fn tls_pointer(&self) -> usize {
-        self.tp()
-    }
 }
 
 macro_rules! copy_gp_regs {

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -45,14 +45,6 @@ impl LinuxAbi for UserContext {
             self.r9(),
         ]
     }
-
-    fn set_tls_pointer(&mut self, tls: usize) {
-        self.set_fsbase(tls);
-    }
-
-    fn tls_pointer(&self) -> usize {
-        self.fsbase()
-    }
 }
 
 /// Represents the context of a signal handler.

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -49,7 +49,10 @@ impl LinuxAbi for UserContext {
 
 /// Represents the context of a signal handler.
 ///
-/// This contains the context saved before a signal handler is invoked and restored by `sys_rt_sigreturn`.
+/// This contains the context saved before a signal handler is invoked; it will be restored by
+/// `sys_rt_sigreturn`.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/x86/include/uapi/asm/sigcontext.h#L325>
 #[derive(Clone, Copy, Debug, Default, Pod)]
 #[repr(C)]
 pub struct SigContext {

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -1,24 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
+/// A trait that describes the Linux system call convention (ABI) for the user context.
 pub trait LinuxAbi {
-    /// Get number of syscall
+    /// Gets the system call number.
     fn syscall_num(&self) -> usize;
 
-    /// Get return value of syscall
+    /// Gets the return value of the system call.
     fn syscall_ret(&self) -> usize;
 
-    /// Set number of syscall
+    /// Sets the system call number.
     fn set_syscall_num(&mut self, num: usize);
 
-    /// Set return value of syscall
+    /// Sets the return value of the system call.
     fn set_syscall_ret(&mut self, ret: usize);
 
-    /// Get syscall args
+    /// Gets the arguments of the system call.
     fn syscall_args(&self) -> [usize; 6];
-
-    /// Set thread-local storage pointer
-    fn set_tls_pointer(&mut self, tls: usize);
-
-    /// Get thread-local storage pointer
-    fn tls_pointer(&self) -> usize;
 }

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -172,6 +172,7 @@ union siginfo_addr_bnd_t {
     upper: Vaddr, // *const c_void,
 }
 
+/// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/include/uapi/asm-generic/ucontext.h#L5>
 #[cfg(target_arch = "x86_64")]
 #[derive(Clone, Copy, Debug, Default, Pod)]
 #[repr(C)]


### PR DESCRIPTION
It does not seem necessary to have `set_tls_pointer`/`tls_pointer` methods in the `LinuxABI` trait:
https://github.com/asterinas/asterinas/blob/345cc9d0556eee0f680eb91d3355de7bd32181e8/kernel/src/arch/x86/cpu.rs#L49-L55

If we don't have these methods, the compiler will use the one from OSTD, which already makes much sense:
https://github.com/asterinas/asterinas/blob/345cc9d0556eee0f680eb91d3355de7bd32181e8/ostd/src/arch/x86/cpu/context/mod.rs#L241-L249

Conceptually, I don't understand why `LinuxABI` has anything to do with the TLS pointers. The TLS pointers are primarily defined by the architecture rather than the ABI. There may be some corner cases of which I am unaware, but they are not relevant to our current codebase.