### PR TITLE
Disallow masking SIGKILL and SIGSTOP in user space

### DIFF
--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -57,7 +57,11 @@ fn do_rt_sigprocmask(
             MaskOp::Unblock => {
                 sig_mask_ref.store(old_sig_mask_value - read_mask, Ordering::Relaxed)
             }
-            MaskOp::SetMask => sig_mask_ref.store(read_mask, Ordering::Relaxed),
+            MaskOp::SetMask => {
+                read_mask -= SIGKILL; // Cannot block SIGKILL
+                read_mask -= SIGSTOP; // Cannot block SIGSTOP
+                sig_mask_ref.store(read_mask, Ordering::Relaxed);
+            }
         }
     }
     debug!("new set = {:x?}", sig_mask_ref.load(Ordering::Relaxed));


### PR DESCRIPTION
According to the Linux man pages[1], "It is not possible to block SIGKILL or SIGSTOP. Attempts to do so are silently ignored." This patch ensures compliance by explicitly removing SIGKILL and SIGSTOP from the signal mask in the `MaskOp::SetMask` operation of the `rt_sigprocmask` syscall.

[1]: https://www.man7.org/linux/man-pages/man2/sigprocmask.2.html