### PR TITLE
Miscellaneous `mm/io.rs` cleanups

### DIFF
--- a/kernel/comps/mlsdisk/src/lib.rs
+++ b/kernel/comps/mlsdisk/src/lib.rs
@@ -25,7 +25,10 @@ use aster_block::{
     BlockDevice, SECTOR_SIZE,
 };
 use component::{init_component, ComponentInitError};
-use ostd::{mm::VmIo, prelude::*};
+use ostd::{
+    mm::{io_util::HasVmReaderWriter, VmIo},
+    prelude::*,
+};
 
 pub use self::{
     error::{Errno, Error},

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -5,8 +5,8 @@ use alloc::{collections::linked_list::LinkedList, sync::Arc};
 use aster_softirq::BottomHalfDisabled;
 use ostd::{
     mm::{
-        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, Infallible, VmReader,
-        VmWriter, PAGE_SIZE,
+        io_util::HasVmReaderWriter, Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr,
+        Infallible, VmReader, VmWriter, PAGE_SIZE,
     },
     sync::SpinLock,
     Pod,

--- a/kernel/comps/network/src/dma_pool.rs
+++ b/kernel/comps/network/src/dma_pool.rs
@@ -12,8 +12,8 @@ use aster_softirq::BottomHalfDisabled;
 use bitvec::{array::BitArray, prelude::Lsb0};
 use ostd::{
     mm::{
-        Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr, Infallible, VmReader,
-        VmWriter, PAGE_SIZE,
+        io_util::HasVmReaderWriter, Daddr, DmaDirection, DmaStream, FrameAllocOptions, HasDaddr,
+        Infallible, VmReader, VmWriter, PAGE_SIZE,
     },
     sync::{RwLock, SpinLock},
 };

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -7,7 +7,10 @@ use aster_console::{AnyConsoleDevice, ConsoleCallback};
 use log::debug;
 use ostd::{
     arch::trap::TrapFrame,
-    mm::{DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions, VmReader},
+    mm::{
+        io_util::HasVmReaderWriter, DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions,
+        VmReader,
+    },
     sync::{Rcu, SpinLock},
 };
 

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -13,7 +13,7 @@ use aster_block::{
     BLOCK_SIZE,
 };
 use aster_rights::Full;
-use ostd::mm::{Segment, VmIo};
+use ostd::mm::{io_util::HasVmReaderWriter, Segment, VmIo};
 
 use super::{
     constants::*,

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -31,7 +31,7 @@ mod test {
         BlockDevice, BlockDeviceMeta,
     };
     use ostd::{
-        mm::{FrameAllocOptions, Segment, VmIo, PAGE_SIZE},
+        mm::{io_util::HasVmReaderWriter, FrameAllocOptions, Segment, VmIo, PAGE_SIZE},
         prelude::*,
     };
     use rand::{rngs::SmallRng, RngCore, SeedableRng};

--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use id_alloc::IdAlloc;
-use ostd::{const_assert, mm::UntypedMem};
+use ostd::{const_assert, mm::io_util::HasVmReaderWriter};
 
 use super::{
     block_ptr::Ext2Bid,

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -7,7 +7,7 @@ use alloc::{borrow::ToOwned, rc::Rc};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use inherit_methods_macro::inherit_methods;
-use ostd::{const_assert, mm::UntypedMem};
+use ostd::{const_assert, mm::io_util::HasVmReaderWriter};
 
 use super::{
     block_ptr::{BidPath, BlockPtrs, Ext2Bid, BID_SIZE, MAX_BLOCK_PTRS},

--- a/kernel/src/fs/ext2/xattr.rs
+++ b/kernel/src/fs/ext2/xattr.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::UntypedMem;
+use ostd::mm::io_util::HasVmReaderWriter;
 
 use super::{block_ptr::Ext2Bid, prelude::*, Ext2, Inode};
 use crate::fs::utils::{XattrName, XattrNamespace, XattrSetFlags, XATTR_NAME_MAX_LEN};

--- a/kernel/src/fs/ext2/xattr.rs
+++ b/kernel/src/fs/ext2/xattr.rs
@@ -314,10 +314,9 @@ impl Xattr {
         let len = entry.total_len();
         self.blocks_buf
             .writer()
-            .to_fallible()
             .skip(offset)
             .limit(len)
-            .fill_zeros(len)?;
+            .fill_zeros(len);
 
         let mut cache = cache.upgrade();
         let _ = cache.entries.remove(&offset);

--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -13,7 +13,7 @@ use aster_block::BLOCK_SIZE;
 use aster_rights::Full;
 use hashbrown::HashSet;
 use inherit_methods_macro::inherit_methods;
-use ostd::mm::{FrameAllocOptions, UntypedMem};
+use ostd::mm::{io_util::HasVmReaderWriter, FrameAllocOptions};
 
 use crate::{
     fs::{

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -497,11 +497,7 @@ impl RamInode {
 impl PageCacheBackend for RamInode {
     fn read_page_async(&self, _idx: usize, frame: &CachePage) -> Result<BioWaiter> {
         // Initially, any block/page in a RamFs inode contains all zeros
-        frame
-            .writer()
-            .to_fallible()
-            .fill_zeros(frame.size())
-            .unwrap();
+        frame.writer().fill_zeros(frame.size());
         Ok(BioWaiter::new())
     }
 

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -11,7 +11,7 @@ use aster_rights::Full;
 use aster_util::slot_vec::SlotVec;
 use hashbrown::HashMap;
 use ostd::{
-    mm::{UntypedMem, VmIo},
+    mm::{io_util::HasVmReaderWriter, VmIo},
     sync::{PreemptDisabled, RwLockWriteGuard},
 };
 

--- a/kernel/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/src/process/process_vm/init_stack/mod.rs
@@ -21,7 +21,7 @@ use core::{
 use align_ext::AlignExt;
 use aster_rights::Full;
 use ostd::{
-    mm::{UntypedMem, VmIo, MAX_USERSPACE_VADDR},
+    mm::{io_util::HasVmReaderWriter, VmIo, MAX_USERSPACE_VADDR},
     task::disable_preempt,
 };
 

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use inherit_methods_macro::inherit_methods;
-use ostd::mm::{FrameAllocOptions, Segment, UntypedMem, VmIo};
+use ostd::mm::{io_util::HasVmReaderWriter, FrameAllocOptions, Segment, VmIo};
 
 use super::{MultiRead, MultiWrite};
 use crate::prelude::*;

--- a/kernel/src/vm/util.rs
+++ b/kernel/src/vm/util.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::{Frame, FrameAllocOptions, UFrame, UntypedMem};
+use ostd::mm::{io_util::HasVmReaderWriter, Frame, FrameAllocOptions, UFrame};
 
 use crate::prelude::*;
 

--- a/kernel/src/vm/vmo/dyn_cap.rs
+++ b/kernel/src/vm/vmo/dyn_cap.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 
 use aster_rights::{Rights, TRights};
-use ostd::mm::{UFrame, VmIo};
+use ostd::mm::{UFrame, VmIo, VmIoFill};
 
 use super::{CommitFlags, Vmo, VmoCommitError, VmoRightsOp};
 use crate::prelude::*;
@@ -141,7 +141,23 @@ impl VmIo for Vmo<Rights> {
         self.0.write(offset, reader)?;
         Ok(())
     }
-    // TODO: Support efficient `write_vals()`
+}
+
+impl VmIoFill for Vmo<Rights> {
+    fn fill_zeros(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> core::result::Result<(), (ostd::Error, usize)> {
+        // TODO: Support efficient `fill_zeros()`.
+        for i in 0..len {
+            match self.write_slice(offset + i, &[0u8]) {
+                Ok(()) => continue,
+                Err(err) => return Err((err, i)),
+            }
+        }
+        Ok(())
+    }
 }
 
 impl VmoRightsOp for Vmo<Rights> {

--- a/kernel/src/vm/vmo/mod.rs
+++ b/kernel/src/vm/vmo/mod.rs
@@ -13,7 +13,7 @@ use core::{
 use align_ext::AlignExt;
 use aster_rights::Rights;
 use ostd::{
-    mm::{FrameAllocOptions, UFrame, UntypedMem, VmReader, VmWriter},
+    mm::{io_util::HasVmReaderWriter, FrameAllocOptions, UFrame, VmReader, VmWriter},
     task::disable_preempt,
 };
 use xarray::{Cursor, LockedXArray, XArray};

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
@@ -8,7 +8,7 @@ use int_to_c_enum::TryFromInt;
 
 use super::IrtEntryHandle;
 use crate::{
-    mm::{FrameAllocOptions, Segment, UntypedMem, PAGE_SIZE},
+    mm::{io_util::HasVmReaderWriter, FrameAllocOptions, Segment, PAGE_SIZE},
     sync::{LocalIrqDisabled, SpinLock},
 };
 

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -9,7 +9,8 @@ use crate::{
     error::Error,
     mm::{
         dma::{dma_type, Daddr, DmaType},
-        HasPaddr, Infallible, Paddr, USegment, UntypedMem, VmIo, VmReader, VmWriter, PAGE_SIZE,
+        io_util::{HasVmReaderWriter, VmReaderWriterResult},
+        HasPaddr, Infallible, Paddr, USegment, VmReader, VmWriter, PAGE_SIZE,
     },
 };
 
@@ -135,8 +136,8 @@ impl DmaStream {
     ///    (e.g., using [`write_bytes`]).
     ///    Before the CPU side notifies the device side to read, it must call the `sync` method first.
     ///
-    /// [`read_bytes`]: Self::read_bytes
-    /// [`write_bytes`]: Self::write_bytes
+    /// [`read_bytes`]: crate::mm::VmIo::read_bytes
+    /// [`write_bytes`]: crate::mm::VmIo::write_bytes
     pub fn sync(&self, _byte_range: Range<usize>) -> Result<(), Error> {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")]{
@@ -203,35 +204,17 @@ impl Drop for DmaStreamInner {
     }
 }
 
-impl VmIo for DmaStream {
-    /// Reads data into the buffer.
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<(), Error> {
-        if self.inner.direction == DmaDirection::ToDevice {
-            return Err(Error::AccessDenied);
-        }
-        self.inner.segment.read(offset, writer)
-    }
+impl HasVmReaderWriter for DmaStream {
+    type Types = VmReaderWriterResult;
 
-    /// Writes data from the buffer.
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<(), Error> {
-        if self.inner.direction == DmaDirection::FromDevice {
-            return Err(Error::AccessDenied);
-        }
-        self.inner.segment.write(offset, reader)
-    }
-}
-
-impl<'a> DmaStream {
-    /// Returns a reader to read data from it.
-    pub fn reader(&'a self) -> Result<VmReader<'a, Infallible>, Error> {
+    fn reader(&self) -> Result<VmReader<'_, Infallible>, Error> {
         if self.inner.direction == DmaDirection::ToDevice {
             return Err(Error::AccessDenied);
         }
         Ok(self.inner.segment.reader())
     }
 
-    /// Returns a writer to write data into it.
-    pub fn writer(&'a self) -> Result<VmWriter<'a, Infallible>, Error> {
+    fn writer(&self) -> Result<VmWriter<'_, Infallible>, Error> {
         if self.inner.direction == DmaDirection::FromDevice {
             return Err(Error::AccessDenied);
         }
@@ -300,35 +283,21 @@ impl<Dma: AsRef<DmaStream>> DmaStreamSlice<Dma> {
             .as_ref()
             .sync(self.offset..self.offset + self.len)
     }
+}
 
-    /// Returns a reader to read data from it.
-    pub fn reader(&self) -> Result<VmReader<Infallible>, Error> {
+impl<Dma: AsRef<DmaStream>> HasVmReaderWriter for DmaStreamSlice<Dma> {
+    type Types = VmReaderWriterResult;
+
+    fn reader(&self) -> Result<VmReader<'_, Infallible>, Error> {
         let mut stream_reader = self.stream.as_ref().reader()?;
         stream_reader.skip(self.offset).limit(self.len);
         Ok(stream_reader)
     }
 
-    /// Returns a writer to write data into it.
-    pub fn writer(&self) -> Result<VmWriter<Infallible>, Error> {
+    fn writer(&self) -> Result<VmWriter<'_, Infallible>, Error> {
         let mut stream_writer = self.stream.as_ref().writer()?;
         stream_writer.skip(self.offset).limit(self.len);
         Ok(stream_writer)
-    }
-}
-
-impl<Dma: AsRef<DmaStream> + Send + Sync> VmIo for DmaStreamSlice<Dma> {
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<(), Error> {
-        if writer.avail() + offset > self.len {
-            return Err(Error::InvalidArgs);
-        }
-        self.stream.as_ref().read(self.offset + offset, writer)
-    }
-
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<(), Error> {
-        if reader.remain() + offset > self.len {
-            return Err(Error::InvalidArgs);
-        }
-        self.stream.as_ref().write(self.offset + offset, reader)
     }
 }
 

--- a/ostd/src/mm/dma/test.rs
+++ b/ostd/src/mm/dma/test.rs
@@ -6,6 +6,7 @@ use crate::{
     mm::{
         dma::*,
         io::{VmIo, VmIoOnce},
+        io_util::HasVmReaderWriter,
         kspace::KERNEL_PAGE_TABLE,
         paddr_to_vaddr, CachePolicy, FrameAllocOptions, HasPaddr, VmReader, VmWriter, PAGE_SIZE,
     },

--- a/ostd/src/mm/frame/test.rs
+++ b/ostd/src/mm/frame/test.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{allocator::FrameAllocOptions, *};
-use crate::{impl_frame_meta_for, impl_untyped_frame_meta_for, prelude::*};
+use crate::{
+    impl_frame_meta_for, impl_untyped_frame_meta_for, mm::io_util::HasVmReaderWriter, prelude::*,
+};
 
 /// Typed mock metadata struct for testing
 #[derive(Debug, Default)]

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -610,11 +610,9 @@ impl VmReader<'_, Fallible> {
         let mut writer = VmWriter::from(val.as_bytes_mut());
         self.read_fallible(&mut writer)
             .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes read so far.
+                // The `copied_len` is the number of bytes read so far.
                 // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
+                self.cursor = self.cursor.wrapping_sub(copied_len);
                 err
             })?;
         Ok(val)
@@ -836,11 +834,9 @@ impl VmWriter<'_, Fallible> {
         let mut reader = VmReader::from(new_val.as_bytes());
         self.write_fallible(&mut reader)
             .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes written so far.
+                // The `copied_len` is the number of bytes written so far.
                 // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
+                self.cursor = self.cursor.wrapping_sub(copied_len);
                 err
             })?;
         Ok(())

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -754,36 +754,6 @@ impl<'a> VmWriter<'a, Infallible> {
         Ok(())
     }
 
-    /// Fills the available space by repeating `value`.
-    ///
-    /// Returns the number of values written.
-    ///
-    /// # Panics
-    ///
-    /// The size of the available space must be a multiple of the size of `value`.
-    /// Otherwise, the method would panic.
-    pub fn fill<T: Pod>(&mut self, value: T) -> usize {
-        let cursor = self.cursor.cast::<T>();
-        assert!(cursor.is_aligned());
-
-        let avail = self.avail();
-        assert!(avail % core::mem::size_of::<T>() == 0);
-        let written_num = avail / core::mem::size_of::<T>();
-
-        for i in 0..written_num {
-            let cursor_i = cursor.wrapping_add(i);
-            // SAFETY: `written_num` is calculated by the avail size and the size of the type `T`,
-            // so the `write` operation will only manipulate the memory managed by this writer.
-            // We've checked that the cursor is properly aligned with respect to the type `T`. All
-            // other safety requirements are the same as for `Self::write`.
-            unsafe { cursor_i.write_volatile(value) };
-        }
-
-        // The available space has been filled so this cursor can be moved to the end.
-        self.cursor = self.end;
-        written_num
-    }
-
     /// Converts to a fallible writer.
     pub fn to_fallible(self) -> VmWriter<'a, Fallible> {
         // It is safe to construct a fallible reader since an infallible reader covers the

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -40,7 +40,6 @@
 //! user space, making it impossible to avoid data races). However, they may produce erroneous
 //! results, such as unexpected bytes being copied, but do not cause soundness problems.
 
-use alloc::vec;
 use core::marker::PhantomData;
 
 use align_ext::AlignExt;
@@ -605,25 +604,6 @@ impl VmReader<'_, Fallible> {
                 err
             })?;
         Ok(val)
-    }
-
-    /// Collects all the remaining bytes into a `Vec<u8>`.
-    ///
-    /// If the memory read failed, this method will return `Err`
-    /// and the current reader's cursor remains pointing to
-    /// the original starting position.
-    pub fn collect(&mut self) -> Result<Vec<u8>> {
-        let mut buf = vec![0u8; self.remain()];
-        self.read_fallible(&mut buf.as_mut_slice().into())
-            .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes read so far.
-                // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
-                err
-            })?;
-        Ok(buf)
     }
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -43,7 +43,6 @@
 use core::{marker::PhantomData, mem::MaybeUninit};
 
 use align_ext::AlignExt;
-use inherit_methods_macro::inherit_methods;
 
 use crate::{
     arch::mm::{__memcpy_fallible, __memset_fallible},
@@ -255,42 +254,6 @@ pub trait VmIoOnce {
     /// [`VmWriter::write_once`].
     fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()>;
 }
-
-macro_rules! impl_vm_io_pointer {
-    ($typ:ty,$from:tt) => {
-        #[inherit_methods(from = $from)]
-        impl<T: VmIo> VmIo for $typ {
-            fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()>;
-            fn read_bytes(&self, offset: usize, buf: &mut [u8]) -> Result<()>;
-            fn read_val<F: Pod>(&self, offset: usize) -> Result<F>;
-            fn read_slice<F: Pod>(&self, offset: usize, slice: &mut [F]) -> Result<()>;
-            fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()>;
-            fn write_bytes(&self, offset: usize, buf: &[u8]) -> Result<()>;
-            fn write_val<F: Pod>(&self, offset: usize, new_val: &F) -> Result<()>;
-            fn write_slice<F: Pod>(&self, offset: usize, slice: &[F]) -> Result<()>;
-        }
-    };
-}
-
-impl_vm_io_pointer!(&T, "(**self)");
-impl_vm_io_pointer!(&mut T, "(**self)");
-impl_vm_io_pointer!(Box<T>, "(**self)");
-impl_vm_io_pointer!(Arc<T>, "(**self)");
-
-macro_rules! impl_vm_io_once_pointer {
-    ($typ:ty,$from:tt) => {
-        #[inherit_methods(from = $from)]
-        impl<T: VmIoOnce> VmIoOnce for $typ {
-            fn read_once<F: PodOnce>(&self, offset: usize) -> Result<F>;
-            fn write_once<F: PodOnce>(&self, offset: usize, new_val: &F) -> Result<()>;
-        }
-    };
-}
-
-impl_vm_io_once_pointer!(&T, "(**self)");
-impl_vm_io_once_pointer!(&mut T, "(**self)");
-impl_vm_io_once_pointer!(Box<T>, "(**self)");
-impl_vm_io_once_pointer!(Arc<T>, "(**self)");
 
 /// A marker type used for [`VmReader`] and [`VmWriter`],
 /// representing whether reads or writes on the underlying memory region are fallible.

--- a/ostd/src/mm/io_util.rs
+++ b/ostd/src/mm/io_util.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Utilities for types in [`super::io`].
+
+use inherit_methods_macro::inherit_methods;
+use ostd_pod::Pod;
+
+use super::{Infallible, PodOnce, VmIo, VmIoOnce, VmReader, VmWriter};
+use crate::{
+    mm::{FallibleVmRead, FallibleVmWrite},
+    prelude::*,
+    Error,
+};
+
+/// A helper trait that denotes types that can provide [`VmReader`]s and [`VmWriter`]s.
+///
+/// Having the reader and writer means that the type is capable of performing a range of VM
+/// operations. Thus, several traits will be automatically and efficiently implemented, such as
+/// [`VmIo`] and [`VmIoOnce`].
+pub trait HasVmReaderWriter {
+    /// A marker type that denotes the return types of [`Self::reader`] and [`Self::writer`].
+    ///
+    /// This can be either [`VmReaderWriterIdentity`] or [`VmReaderWriterResult`].
+    //
+    // TODO: This exists because `DmaStream` and related types track the DMA direction at runtime.
+    // The goal is to achieve this at compile time, which would eliminate the need for
+    // `VmReaderWriterTypes`. See the discussion at
+    // <https://github.com/asterinas/asterinas/pull/2289#discussion_r2261801694>.
+    type Types: VmReaderWriterTypes;
+
+    /// Returns a reader to read data from it.
+    fn reader(&self) -> <Self::Types as VmReaderWriterTypes>::Reader<'_>;
+    /// Returns a writer to write data to it.
+    fn writer(&self) -> <Self::Types as VmReaderWriterTypes>::Writer<'_>;
+}
+
+/// A marker trait that denotes the return types for [`HasVmReaderWriter`].
+pub trait VmReaderWriterTypes {
+    /// The return type of [`HasVmReaderWriter::reader`].
+    type Reader<'a>;
+    /// The return type of [`HasVmReaderWriter::writer`].
+    type Writer<'a>;
+
+    /// Converts [`Self::Reader`] to [`Result<VmReader<Infallible>>`].
+    fn to_reader_result(reader: Self::Reader<'_>) -> Result<VmReader<'_, Infallible>>;
+    /// Converts [`Self::Writer`] to [`Result<VmWriter<Infallible>>`].
+    fn to_writer_result(writer: Self::Writer<'_>) -> Result<VmWriter<'_, Infallible>>;
+}
+
+/// A marker type that denotes reader and writer identities as [`HasVmReaderWriter`] return types.
+pub enum VmReaderWriterIdentity {}
+impl VmReaderWriterTypes for VmReaderWriterIdentity {
+    type Reader<'a> = VmReader<'a, Infallible>;
+    type Writer<'a> = VmWriter<'a, Infallible>;
+    fn to_reader_result(reader: Self::Reader<'_>) -> Result<VmReader<'_, Infallible>> {
+        Ok(reader)
+    }
+    fn to_writer_result(writer: Self::Writer<'_>) -> Result<VmWriter<'_, Infallible>> {
+        Ok(writer)
+    }
+}
+
+/// A marker type that denotes reader and writer results as [`HasVmReaderWriter`] return types.
+pub enum VmReaderWriterResult {}
+impl VmReaderWriterTypes for VmReaderWriterResult {
+    type Reader<'a> = Result<VmReader<'a, Infallible>>;
+    type Writer<'a> = Result<VmWriter<'a, Infallible>>;
+    fn to_reader_result(reader: Self::Reader<'_>) -> Result<VmReader<'_, Infallible>> {
+        reader
+    }
+    fn to_writer_result(writer: Self::Writer<'_>) -> Result<VmWriter<'_, Infallible>> {
+        writer
+    }
+}
+
+impl<S: HasVmReaderWriter + Send + Sync> VmIo for S {
+    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
+        let mut reader = <Self as HasVmReaderWriter>::Types::to_reader_result(self.reader())?;
+
+        let limit = offset.checked_add(writer.avail()).ok_or(Error::Overflow)?;
+        if limit > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        reader.skip(offset);
+        let _len = reader
+            .to_fallible()
+            .read_fallible(writer)
+            .map_err(|(err, _)| err)?;
+        debug_assert!(!writer.has_avail());
+        Ok(())
+    }
+
+    fn read_bytes(&self, offset: usize, buf: &mut [u8]) -> Result<()> {
+        let mut reader = <Self as HasVmReaderWriter>::Types::to_reader_result(self.reader())?;
+
+        let limit = offset.checked_add(buf.len()).ok_or(Error::Overflow)?;
+        if limit > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let len = reader.skip(offset).read(&mut VmWriter::from(&mut *buf));
+        debug_assert_eq!(len, buf.len());
+        Ok(())
+    }
+
+    // No need to implement `read_slice`. Its default implementation is efficient enough by relying
+    // on `read_bytes`.
+
+    fn read_val<T: Pod>(&self, offset: usize) -> Result<T> {
+        let mut reader = <Self as HasVmReaderWriter>::Types::to_reader_result(self.reader())?;
+
+        if offset > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        reader.skip(offset).read_val()
+    }
+
+    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
+        let mut writer = <Self as HasVmReaderWriter>::Types::to_writer_result(self.writer())?;
+
+        let limit = offset.checked_add(reader.remain()).ok_or(Error::Overflow)?;
+        if limit > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        writer.skip(offset);
+        let _len = writer
+            .to_fallible()
+            .write_fallible(reader)
+            .map_err(|(err, _)| err)?;
+        debug_assert!(!reader.has_remain());
+        Ok(())
+    }
+
+    fn write_bytes(&self, offset: usize, buf: &[u8]) -> Result<()> {
+        let mut writer = <Self as HasVmReaderWriter>::Types::to_writer_result(self.writer())?;
+
+        let limit = offset.checked_add(buf.len()).ok_or(Error::Overflow)?;
+        if limit > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let len = writer.skip(offset).write(&mut VmReader::from(buf));
+        debug_assert_eq!(len, buf.len());
+        Ok(())
+    }
+
+    // No need to implement `write_slice`. Its default implementation is efficient enough by
+    // relying on `write_bytes`.
+
+    fn write_val<T: Pod>(&self, offset: usize, new_val: &T) -> Result<()> {
+        let mut writer = <Self as HasVmReaderWriter>::Types::to_writer_result(self.writer())?;
+
+        if offset > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        writer.skip(offset).write_val(new_val)
+    }
+}
+
+impl<S: HasVmReaderWriter> VmIoOnce for S {
+    fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T> {
+        let mut reader = <Self as HasVmReaderWriter>::Types::to_reader_result(self.reader())?;
+        reader.skip(offset).read_once()
+    }
+
+    fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()> {
+        let mut writer = <Self as HasVmReaderWriter>::Types::to_writer_result(self.writer())?;
+        writer.skip(offset).write_once(new_val)
+    }
+}
+
+// The pointer implementations below (i.e., `impl_vm_io_pointer`/`impl_vm_io_once_pointer`) should
+// apply to the `VmIo`/`VmIoOnce` traits themselves, instead of these helper traits.
+//
+// However, there are some unexpected compiler errors that complain that downstream crates can
+// implement `HasVmReaderWriter` to cause conflict implementations.
+
+macro_rules! impl_vm_io_pointer {
+    ($typ:ty,$from:tt) => {
+        #[inherit_methods(from = $from)]
+        impl<T: HasVmReaderWriter> HasVmReaderWriter for $typ {
+            type Types = T::Types;
+            fn reader(&self) -> <Self::Types as VmReaderWriterTypes>::Reader<'_>;
+            fn writer(&self) -> <Self::Types as VmReaderWriterTypes>::Writer<'_>;
+        }
+    };
+}
+
+impl_vm_io_pointer!(&T, "(**self)");
+impl_vm_io_pointer!(&mut T, "(**self)");
+impl_vm_io_pointer!(Box<T>, "(**self)");
+impl_vm_io_pointer!(Arc<T>, "(**self)");

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -34,8 +34,8 @@ pub use self::{
         Frame,
     },
     io::{
-        Fallible, FallibleVmRead, FallibleVmWrite, Infallible, PodOnce, VmIo, VmIoOnce, VmReader,
-        VmWriter,
+        Fallible, FallibleVmRead, FallibleVmWrite, Infallible, PodOnce, VmIo, VmIoFill, VmIoOnce,
+        VmReader, VmWriter,
     },
     page_prop::{CachePolicy, PageFlags, PageProperty},
     vm_space::VmSpace,

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod dma;
 pub mod frame;
 pub mod heap;
 pub mod io;
+pub mod io_util;
 pub(crate) mod kspace;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;
@@ -29,7 +30,7 @@ pub use self::{
         allocator::FrameAllocOptions,
         segment::{Segment, USegment},
         unique::UniqueFrame,
-        untyped::{AnyUFrameMeta, UFrame, UntypedMem},
+        untyped::{AnyUFrameMeta, UFrame},
         Frame,
     },
     io::{

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -118,21 +118,6 @@ mod io {
         writer_infallible.write_val(&val).unwrap();
     }
 
-    /// Tests the `fill` method in Infallible mode.
-    #[ktest]
-    fn fill_infallible() {
-        let mut buffer = vec![0u8; 8];
-        let mut writer_infallible = VmWriter::from(&mut buffer[..]);
-
-        // Fill with 0xFF
-        let filled = writer_infallible.fill(0xFFu8);
-        assert_eq!(filled, 8);
-        // Ensure the cursor is at the end
-        assert_eq!(writer_infallible.avail(), 0);
-
-        assert_eq!(buffer, vec![0xFF; 8]);
-    }
-
     /// Tests the `skip` method for reading in Infallible mode.
     #[ktest]
     fn skip_read_infallible() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -332,32 +332,6 @@ mod io {
         assert_eq!(val, read_val);
     }
 
-    /// Tests the `collect` method in Fallible mode.
-    #[ktest]
-    fn collect_fallible() {
-        let data = [5u8, 6, 7, 8, 9];
-        let reader = VmReader::from(&data[..]);
-        let mut reader_fallible = reader.to_fallible();
-
-        let collected = reader_fallible.collect().unwrap();
-        assert_eq!(collected, data);
-    }
-
-    /// Tests partial collection in Fallible mode.
-    #[ktest]
-    fn collect_partial_fallible() {
-        let data = [1u8, 2, 3, 4, 5];
-        let reader = VmReader::from(&data[..]);
-        let mut reader_fallible = reader.to_fallible();
-
-        // Limits the reader to 3 bytes
-        let limited_reader = reader_fallible.limit(3);
-
-        let result = limited_reader.collect();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), vec![1, 2, 3]);
-    }
-
     /// Tests the `fill_zeros` method in Fallible mode.
     #[ktest]
     fn fill_zeros_fallible() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -118,6 +118,21 @@ mod io {
         writer_infallible.write_val(&val).unwrap();
     }
 
+    /// Tests the `fill` method in Infallible mode.
+    #[ktest]
+    fn fill_infallible() {
+        let mut buffer = vec![0x7Fu8; 8];
+        let mut writer_infallible = VmWriter::from(&mut buffer[..]);
+
+        // Fill with zeros
+        let filled = writer_infallible.fill_zeros(10);
+        assert_eq!(filled, 8);
+        // Ensure the cursor is at the end
+        assert_eq!(writer_infallible.avail(), 0);
+
+        assert_eq!(buffer, vec![0; 8]);
+    }
+
     /// Tests the `skip` method for reading in Infallible mode.
     #[ktest]
     fn skip_read_infallible() {

--- a/ostd/src/prelude.rs
+++ b/ostd/src/prelude.rs
@@ -14,6 +14,6 @@ pub use ostd_macros::ktest;
 
 pub use crate::{
     early_print as print, early_println as println,
-    mm::{Paddr, UntypedMem, Vaddr},
+    mm::{Paddr, Vaddr},
     panic::abort,
 };


### PR DESCRIPTION
## Remove unsafe code in `mm/test.rs`

`mm/test.rs` contains a lot of unsafe `Vm{Reader,Writer}::from_kernel_space` usages, which is just not necessary. This commit removes them.

## Remove `VmReader::collect`

 - There are no users.
 - This method is vulnerable to do unbounded allocation.
 - The current implementation can be done safely outside OSTD.

## Remove `VmWriter::fill` & Add `VmWriter::fill_zeros`

I'd prefer to make every fallible operation has its infallible counterpart. The infallible `VmWriter` has a `fill` method that has no users (as shown in the first commit), but if an infallible `fill_zeros` is useful (as shown in the second commit).

## Retire missing `ptr::sub` in `mm/io.rs`

This is missed in https://github.com/asterinas/asterinas/pull/2081.
> I don't know how one could argue that the user space pointer belongs to an allocated object. I [asked](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/.60.7Bptr.7D.3A.3Aadd.60.20with.20a.20pointer.20outside.20the.20Rust.20world/near/516648519) the Rust people to explain this rule. They said there is no reason to take the risk of using `ptr::add` because it is not designed for that purpose. The underlying LLVM `getelementptr inbounds` "in spirit" requires an allocation. However, since there is no formal LLVM specification, it is unclear whether this use case constitutes undefined behavior (UB). Using `ptr::wrapping_add` is preferable. I made the switch accordingly.

## Avoid all `Pod::new_uninit`s in OSTD

This isn't sound due to https://github.com/asterinas/asterinas/issues/1060. We need to find ways to avoid it.

## Replace `write_vals` by `fill_zeros` in `VmIo` & Provide efficient `VmIo` with VM readers/writers

`VmIo` methods can be implemented in a more efficient way if the implementer can provide a `VmReader`/`VmWriter`. This is the case for all the `VmIo` implementations (`Frame`, `Segment`, `IoMem`, `DmaStream`, `DmaCoherent`) in OSTD.

Therefore, we can define a helper trait `io_util::VmIoByReaderWriter` to automatically derive `VmIo` implementations given methods that can produce a `VmReader`/`VmWriter`.