### PR TITLE
Re-enable several debug runs in CI 

### DIFF
--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -66,8 +66,9 @@ jobs:
             boot_protocol: 'multiboot2'
             smp: 4
 
-          # General Test (Linux EFI Handover)
-          - test_id: 'general-handover64'
+          # General Test (Linux EFI Handover) (Debug Build)
+          - test_id: 'general-handover64-debug'
+            release: false
             boot_protocol: 'linux-efi-handover64'
           # SMP General Test (Multiboot2)
           - test_id: 'general-multiboot2-smp4'
@@ -81,8 +82,8 @@ jobs:
         with:
           auto_test: ${{ (startsWith(matrix.test_id, 'boot') && 'boot') ||
               (startsWith(matrix.test_id, 'syscall') && 'syscall') || 'test' }}
-          release: ${{ matrix.release || true }}
-          enable_kvm: ${{ matrix.enable_kvm || true }}
+          release: ${{ !contains(matrix.release, 'false') }}
+          enable_kvm: ${{ !contains(matrix.enable_kvm, 'false') }}
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}
@@ -96,8 +97,8 @@ jobs:
         with:
           auto_test: ${{ (startsWith(matrix.test_id, 'boot') && 'boot') ||
               (startsWith(matrix.test_id, 'syscall') && 'syscall') || 'test' }}
-          release: ${{ matrix.release || true }}
-          enable_kvm: ${{ matrix.enable_kvm || true }}
+          release: ${{ !contains(matrix.release, 'false') }}
+          enable_kvm: ${{ !contains(matrix.enable_kvm, 'false') }}
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -199,7 +199,7 @@ impl Connected {
         drop(reader);
 
         let ctrl_msgs = aux_data.generate_control(is_pass_cred);
-        debug_assert!(is_empty || read_tot_len != 0);
+        debug_assert!(is_seqpacket || read_tot_len != 0);
         peer_end
             .has_aux
             .store(!all_aux.is_empty(), Ordering::Relaxed);


### PR DESCRIPTION
Debug runs in CI aren't working properly. The following statements always set `release`/`enable_kvm` to true.
https://github.com/asterinas/asterinas/blob/659f079c2d41c2cecb3fc06ec62cbece1f67f86e/.github/workflows/test_x86.yml#L84-L85

This PR fixes the bug. Additionally, I found we don't have debug runs for regression tests, so this PR sets one of the two regression tests to debug mode to improve our test coverage.

https://github.com/asterinas/asterinas/blob/659f079c2d41c2cecb3fc06ec62cbece1f67f86e/.github/workflows/test_x86.yml#L69-L75

In order to make CI pass, this PR fixes two bugs:

#### Allow to receive empty SEQPACKET packets 

https://github.com/asterinas/asterinas/blob/659f079c2d41c2cecb3fc06ec62cbece1f67f86e/test/src/apps/network/unix_seqpacket_err.c#L58

```
test_send_recv_zero: `socketpair(1, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, fildes)` passed [got Success]
test_send_recv_zero: `send(fildes[0], buf, 1, 0)` passed [got Success]
test_send_recv_zero: `send(fildes[0], buf, 0, 0)` passed [got Success]
test_send_recv_zero: `send(fildes[0], buf, 0, 0)` passed [got Success]
test_send_recv_zero: `send(fildes[0], buf, 1, 0)` passed [got Success]
test_send_recv_zero: `recv(fildes[1], buf, 1, 0)` passed [got Success]
[    61.209] ERROR: Uncaught panic:
	assertion failed: is_empty || read_tot_len != 0
	at /root/asterinas/kernel/src/net/socket/unix/stream/connected.rs:202
```

#### Fix race conditions in `pause_timeout`

https://github.com/asterinas/ltp/blob/c3c7e0303a7649411ee4a5cf0d2d882dcf47ddaf/testcases/kernel/syscalls/ppoll/ppoll01.c#L128-L139

This test case first sends a SIGINT and then starts `ppoll`. If SIGINT comes before `ppoll` starts to wait, our current implementation will miss the signal.
https://github.com/asterinas/asterinas/blob/c6a6e66aaca9635e36d99e47ed87edd6d4b69f87/kernel/src/process/signal/pause.rs#L153-L155

As shown in the commit, we should check if there are pending signals after setting up the waker.

This commit fixes https://github.com/asterinas/asterinas/issues/2122.