### PR TITLE
Fix ELF loading when shebang/loader path is too long/far

### DIFF
--- a/kernel/src/process/program_loader/elf/mod.rs
+++ b/kernel/src/process/program_loader/elf/mod.rs
@@ -3,4 +3,5 @@
 mod elf_file;
 mod load_elf;
 
+pub use elf_file::ElfHeaders;
 pub use load_elf::{load_elf_to_vm, ElfLoadInfo};

--- a/kernel/src/process/program_loader/shebang.rs
+++ b/kernel/src/process/program_loader/shebang.rs
@@ -2,22 +2,25 @@
 
 use crate::prelude::*;
 
-/// Try to parse a buffer as a shebang line.
+/// Tries to parse a buffer as a shebang line.
 ///
 /// If the buffer starts with `#!` and its header is a valid shebang sequence,
-/// then the function returns `Ok(Some(parts))`,
-/// where `parts` is a `Vec` that contains the path of and the arguments for the interpreter.
-/// If the buffer starts with `#!` but some error occurs while parsing the file,
-/// then `Err(_)` is returned.
-/// If the buffer does not start with `#!`, then `Ok(None)` is returned.
-pub fn parse_shebang_line(file_header_buffer: &[u8]) -> Result<Option<Vec<CString>>> {
-    if !file_header_buffer.starts_with(b"#!") || !file_header_buffer.contains(&b'\n') {
-        // the file is not a shebang
+/// then the function returns `Ok(Some(parts))`, where `parts` is a `Vec` that
+/// contains the path of and the arguments for the interpreter.
+///
+/// If the buffer starts with `#!` but some error occurs while parsing the
+/// file, then `Err(_)` is returned. If the buffer does not start with `#!`,
+/// then `Ok(None)` is returned.
+pub fn parse_shebang_line(file_first_page: &[u8]) -> Result<Option<Vec<CString>>> {
+    if !file_first_page.starts_with(b"#!") || !file_first_page.contains(&b'\n') {
+        // The file is not a shebang.
         return Ok(None);
     }
-    let first_line_len = file_header_buffer.iter().position(|&c| c == b'\n').unwrap();
-    // skip #!
-    let shebang_header = &file_header_buffer[2..first_line_len];
+    let Some(first_line_len) = file_first_page.iter().position(|&c| c == b'\n') else {
+        return_errno_with_message!(Errno::ENAMETOOLONG, "The shebang line is too long");
+    };
+    // Skip `#!`.
+    let shebang_header = &file_first_page[2..first_line_len];
     let mut shebang_argv = Vec::new();
     for arg in shebang_header.split(|&c| c == b' ') {
         let arg = CString::new(arg)?;


### PR DESCRIPTION
I hit the `debug_assert` when I try to run the JVM from the nix package. That `java` binary has its `PT_INTERP` program outside the first page. So the kernel panicked.

There should be many other places where the kernel simply panics when the ELF format is not expected. I didn't fix all of them I spotted. However, I included some fixes for shebang parsing.