### PR TITLE
Refactor the implementation of `Dentry`, `Dentry_` and `MountNode`

### DIFF
--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     fs::{
         devpts::DevPts,
         fs_resolver::{FsPath, FsResolver},
-        path::Dentry,
+        path::Path,
         utils::{Inode, InodeMode, InodeType},
     },
     prelude::*,
@@ -17,7 +17,7 @@ pub use driver::PtySlave;
 pub use master::PtyMaster;
 use spin::Once;
 
-static DEV_PTS: Once<Dentry> = Once::new();
+static DEV_PTS: Once<Path> = Once::new();
 
 pub fn init() -> Result<()> {
     let fs = FsResolver::new();
@@ -27,7 +27,7 @@ pub fn init() -> Result<()> {
     let devpts_dentry =
         dev.new_fs_child("pts", InodeType::Dir, InodeMode::from_bits_truncate(0o755))?;
     let devpts_mount_node = devpts_dentry.mount(DevPts::new())?;
-    let devpts = Dentry::new_fs_root(devpts_mount_node.clone());
+    let devpts = Path::new_fs_root(devpts_mount_node.clone());
 
     DEV_PTS.call_once(|| devpts);
 

--- a/kernel/src/fs/device.rs
+++ b/kernel/src/fs/device.rs
@@ -4,7 +4,7 @@ use super::inode_handle::FileIo;
 use crate::{
     fs::{
         fs_resolver::{FsPath, FsResolver},
-        path::Dentry,
+        path::Path,
         utils::{InodeMode, InodeType},
     },
     prelude::*,
@@ -102,8 +102,8 @@ impl DeviceId {
 ///
 /// If the parent path is not existing, `mkdir -p` the parent path.
 /// This function is used in registering device.
-pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Dentry> {
-    let mut dentry = {
+pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Path> {
+    let mut dev_path = {
         let fs_resolver = FsResolver::new();
         fs_resolver.lookup(&FsPath::try_from("/dev").unwrap())?
     };
@@ -123,24 +123,24 @@ pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Dentry> {
             (relative_path, "")
         };
 
-        match dentry.lookup(next_name) {
-            Ok(next_dentry) => {
+        match dev_path.lookup(next_name) {
+            Ok(next_path) => {
                 if path_remain.is_empty() {
                     return_errno_with_message!(Errno::EEXIST, "device node is existing");
                 }
-                dentry = next_dentry;
+                dev_path = next_path;
             }
             Err(_) => {
                 if path_remain.is_empty() {
                     // Create the device node
-                    dentry = dentry.mknod(
+                    dev_path = dev_path.mknod(
                         next_name,
                         InodeMode::from_bits_truncate(0o666),
                         device.clone().into(),
                     )?;
                 } else {
                     // Mkdir parent path
-                    dentry = dentry.new_fs_child(
+                    dev_path = dev_path.new_fs_child(
                         next_name,
                         InodeType::Dir,
                         InodeMode::from_bits_truncate(0o755),
@@ -151,7 +151,7 @@ pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Dentry> {
         relative_path = path_remain;
     }
 
-    Ok(dentry)
+    Ok(dev_path)
 }
 
 /// Delete the device node from FS for the device.

--- a/kernel/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/src/fs/inode_handle/dyn_cap.rs
@@ -7,14 +7,14 @@ use super::*;
 use crate::{prelude::*, process::signal::Pollable};
 
 impl InodeHandle<Rights> {
-    pub fn new(dentry: Dentry, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Self> {
+    pub fn new(dentry: Path, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Self> {
         let inode = dentry.inode();
         inode.check_permission(access_mode.into())?;
         Self::new_unchecked_access(dentry, access_mode, status_flags)
     }
 
     pub fn new_unchecked_access(
-        dentry: Dentry,
+        dentry: Path,
         access_mode: AccessMode,
         status_flags: StatusFlags,
     ) -> Result<Self> {

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file_handle::FileLike,
-        path::Dentry,
+        path::Path,
         utils::{
             AccessMode, DirentVisitor, FallocMode, FileRange, FlockItem, FlockList, InodeMode,
             InodeType, IoctlCmd, Metadata, RangeLockItem, RangeLockItemBuilder, RangeLockList,
@@ -34,7 +34,7 @@ use crate::{
 pub struct InodeHandle<R = Rights>(Arc<InodeHandle_>, R);
 
 struct InodeHandle_ {
-    dentry: Dentry,
+    dentry: Path,
     /// `file_io` is Similar to `file_private` field in `file` structure in linux. If
     /// `file_io` is Some, typical file operations including `read`, `write`, `poll`,
     /// `ioctl` will be provided by `file_io`, instead of `dentry`.
@@ -343,7 +343,7 @@ impl Debug for InodeHandle_ {
 
 /// Methods for both dyn and static
 impl<R> InodeHandle<R> {
-    pub fn dentry(&self) -> &Dentry {
+    pub fn dentry(&self) -> &Path {
         &self.0.dentry
     }
 

--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -19,7 +19,7 @@ use crate::{
     fs::{
         device::Device,
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Dentry,
+        path::Path,
         registry::{FsProperties, FsType},
         utils::{
             DirentCounter, DirentVisitor, FallocMode, FileSystem, FsFlags, Inode, InodeMode,
@@ -56,21 +56,21 @@ pub struct OverlayFS {
 
 /// The mutable upper layer of an `OverlayFS`.
 struct OverlayUpper {
-    dentry: Dentry,
+    dentry: Path,
 }
 
 /// The immutable lower layer of an `OverlayFS`.
-/// A lower layer may contain multiple `Dentry`s with different mount points.
+/// A lower layer may contain multiple `Path`s with different mount points.
 struct OverlayLower {
     /// Layered dentries from top to bottom.
-    dentries: Vec<Dentry>,
+    dentries: Vec<Path>,
     // TODO: Support data-only lower layers.
 }
 
 /// The work directory. Must reside in
 /// the same file system as the upper layer.
 struct OverlayWork {
-    dentry: Dentry,
+    dentry: Path,
     // TODO: Align the work directory's behavior with Linux.
 }
 
@@ -113,7 +113,7 @@ impl OverlayFS {
     /// # Errors
     /// * `EINVAL` - If work and upper are on different filesystems
     /// * `EINVAL` - If work is not empty
-    pub fn new(upper: Dentry, lower: Vec<Dentry>, work: Dentry) -> Result<Arc<Self>> {
+    pub fn new(upper: Path, lower: Vec<Path>, work: Path) -> Result<Arc<Self>> {
         Self::validate_work_and_upper(&work, &upper)?;
         Self::validate_work_empty(&work)?;
 
@@ -129,7 +129,7 @@ impl OverlayFS {
     }
 
     /// Validates that work is on the same filesystem as upper.
-    fn validate_work_and_upper(work: &Dentry, upper: &Dentry) -> Result<()> {
+    fn validate_work_and_upper(work: &Path, upper: &Path) -> Result<()> {
         if !Arc::ptr_eq(upper.mount_node(), work.mount_node()) {
             return_errno_with_message!(
                 Errno::EINVAL,
@@ -140,7 +140,7 @@ impl OverlayFS {
     }
 
     /// Validates that work is empty.
-    fn validate_work_empty(work: &Dentry) -> Result<()> {
+    fn validate_work_empty(work: &Path) -> Result<()> {
         let mut counter = DirentCounter::new();
         let _ = work.inode().readdir_at(0, &mut counter);
         if counter.count() > 0 {
@@ -1190,18 +1190,18 @@ mod tests {
         let mode = InodeMode::all();
         let upper = {
             let root_mount = MountNode::new_root(RamFS::new());
-            Dentry::new_fs_root(root_mount)
+            Path::new_fs_root(root_mount)
         };
         let lower = {
             let r1 = MountNode::new_root(RamFS::new());
             let r2 = MountNode::new_root(RamFS::new());
 
-            let l1 = Dentry::new_fs_root(r1);
+            let l1 = Path::new_fs_root(r1);
             l1.new_fs_child("f1", InodeType::File, mode).unwrap();
             let d1 = l1.new_fs_child("d1", InodeType::Dir, mode).unwrap();
             d1.new_fs_child("f11", InodeType::File, mode).unwrap();
 
-            let l2 = Dentry::new_fs_root(r2);
+            let l2 = Path::new_fs_root(r2);
             let f2 = l2.new_fs_child("f2", InodeType::File, mode).unwrap();
             let f2_inode = f2.inode();
             f2_inode
@@ -1232,9 +1232,9 @@ mod tests {
     fn work_and_upper_should_be_in_same_mount() {
         crate::time::clocks::init_for_ktest();
 
-        let upper = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
-        let lower = vec![Dentry::new_fs_root(MountNode::new_root(RamFS::new()))];
-        let work = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
+        let upper = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+        let lower = vec![Path::new_fs_root(MountNode::new_root(RamFS::new()))];
+        let work = Path::new_fs_root(MountNode::new_root(RamFS::new()));
 
         let Err(e) = OverlayFS::new(upper, lower, work) else {
             panic!("OverlayFS::new should fail when work and upper are not in the same mount");
@@ -1248,11 +1248,11 @@ mod tests {
 
         let mode = InodeMode::all();
         let upper = {
-            let root = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
+            let root = Path::new_fs_root(MountNode::new_root(RamFS::new()));
             root.new_fs_child("file", InodeType::File, mode).unwrap();
             root
         };
-        let lower = vec![Dentry::new_fs_root(MountNode::new_root(RamFS::new()))];
+        let lower = vec![Path::new_fs_root(MountNode::new_root(RamFS::new()))];
         let work = upper.clone();
 
         let Err(e) = OverlayFS::new(upper, lower, work) else {
@@ -1266,7 +1266,7 @@ mod tests {
         crate::time::clocks::init_for_ktest();
 
         let mode = InodeMode::all();
-        let root = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
+        let root = Path::new_fs_root(MountNode::new_root(RamFS::new()));
         let upper = {
             let dir = root.new_fs_child("upper", InodeType::Dir, mode).unwrap();
             dir.new_fs_child("f1", InodeType::File, mode).unwrap();
@@ -1278,7 +1278,7 @@ mod tests {
         };
         let lower = {
             let l1 = {
-                let r1 = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
+                let r1 = Path::new_fs_root(MountNode::new_root(RamFS::new()));
                 r1.new_fs_child("f1", InodeType::Dir, mode).unwrap();
                 r1.new_fs_child("f2", InodeType::File, mode).unwrap();
                 let d1 = r1.new_fs_child("d1", InodeType::Dir, mode).unwrap();
@@ -1293,7 +1293,7 @@ mod tests {
                 r1
             };
             let l2 = {
-                let r2 = Dentry::new_fs_root(MountNode::new_root(RamFS::new()));
+                let r2 = Path::new_fs_root(MountNode::new_root(RamFS::new()));
                 r2.new_fs_child("f1", InodeType::File, mode).unwrap();
                 r2.new_fs_child("d1", InodeType::Dir, mode).unwrap();
                 r2.new_fs_child("d2", InodeType::Dir, mode).unwrap();

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -2,11 +2,249 @@
 
 //! Form file paths within and across FSes with dentries and mount points.
 
-pub use dentry::{Dentry, DentryKey};
+use core::time::Duration;
+
+use inherit_methods_macro::inherit_methods;
 pub use mount::MountNode;
+use ostd::sync::{PreemptDisabled, RwMutexReadGuard, RwMutexWriteGuard};
+
+use crate::{
+    fs::{
+        path::dentry::Dentry,
+        utils::{
+            FileSystem, Inode, InodeMode, InodeType, Metadata, MknodType, Permission, XattrName,
+            XattrNamespace, XattrSetFlags, NAME_MAX,
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
+};
 
 mod dentry;
 mod mount;
+
+/// A `Path` is used to represent an exact location in the VFS tree.
+#[derive(Debug, Clone)]
+pub struct Path {
+    mount_node: Arc<MountNode>,
+    dentry: Arc<Dentry>,
+}
+
+impl Path {
+    /// Creates a new `Path` to represent the root directory of a file system.
+    pub fn new_fs_root(mount_node: Arc<MountNode>) -> Self {
+        let inner = mount_node.root_dentry().clone();
+        Self::new(mount_node, inner)
+    }
+
+    /// Creates a new `Path` to represent the child directory of a file system.
+    pub fn new_fs_child(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Self> {
+        if self
+            .inode()
+            .check_permission(Permission::MAY_WRITE)
+            .is_err()
+        {
+            return_errno!(Errno::EACCES);
+        }
+        let new_child_dentry = self.dentry.create(name, type_, mode)?;
+        Ok(Self::new(self.mount_node.clone(), new_child_dentry))
+    }
+
+    fn new(mount_node: Arc<MountNode>, dentry: Arc<Dentry>) -> Self {
+        Self { mount_node, dentry }
+    }
+
+    /// Lookups the target `Path` given the `name`.
+    pub fn lookup(&self, name: &str) -> Result<Self> {
+        if self.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        if self.inode().check_permission(Permission::MAY_EXEC).is_err() {
+            return_errno!(Errno::EACCES);
+        }
+        if name.len() > NAME_MAX {
+            return_errno!(Errno::ENAMETOOLONG);
+        }
+
+        let _read_guard = begin_mount_tree_read();
+
+        let target_path = if is_dot(name) {
+            self.this()
+        } else if is_dotdot(name) {
+            self.effective_parent().unwrap_or_else(|| self.this())
+        } else {
+            let target_inner_opt = self.dentry.lookup_via_cache(name)?;
+            match target_inner_opt {
+                Some(target_inner) => Self::new(self.mount_node.clone(), target_inner),
+                None => {
+                    let target_inner = self.dentry.lookup_via_fs(name)?;
+                    Self::new(self.mount_node.clone(), target_inner)
+                }
+            }
+        };
+
+        Ok(target_path.top_path())
+    }
+
+    /// Gets the absolute path.
+    ///
+    /// It will resolve the mountpoint automatically.
+    pub fn abs_path(&self) -> String {
+        let mut path = self.effective_name();
+        let mut current_dir = self.this();
+
+        while let Some(parent_dir) = current_dir.effective_parent() {
+            path = {
+                let parent_name = parent_dir.effective_name();
+                if parent_name != "/" {
+                    parent_name + "/" + &path
+                } else {
+                    parent_name + &path
+                }
+            };
+            current_dir = parent_dir;
+        }
+
+        debug_assert!(path.starts_with('/'));
+        path
+    }
+
+    /// Gets the effective name of the `Path`.
+    ///
+    /// If it is the root of a mount, it will go up to the mountpoint
+    /// to get the name of the mountpoint recursively.
+    fn effective_name(&self) -> String {
+        if !self.dentry.is_mount_root() {
+            return self.dentry.name();
+        }
+
+        let Some(parent) = self.mount_node.parent() else {
+            return self.dentry.name();
+        };
+        let Some(mountpoint) = self.mount_node.mountpoint() else {
+            return self.dentry.name();
+        };
+
+        let mount_parent = Self::new(parent.upgrade().unwrap(), mountpoint);
+        mount_parent.effective_name()
+    }
+
+    /// Gets the effective parent of the `Path`.
+    ///
+    /// If it is the root of a mount, it will go up to the mountpoint
+    /// to get the parent of the mountpoint recursively.
+    fn effective_parent(&self) -> Option<Self> {
+        if !self.dentry.is_mount_root() {
+            return Some(Self::new(
+                self.mount_node.clone(),
+                self.dentry.parent().unwrap(),
+            ));
+        }
+
+        let parent = self.mount_node.parent()?;
+        let mountpoint = self.mount_node.mountpoint()?;
+
+        let mount_parent = Self::new(parent.upgrade().unwrap(), mountpoint);
+        mount_parent.effective_parent()
+    }
+
+
+    /// Creates a `Path` by making an inode of the `type_` with the `mode`.
+    pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Self> {
+        let inner = self.dentry.mknod(name, mode, type_)?;
+        Ok(Self::new(self.mount_node.clone(), inner))
+    }
+
+    /// Links a new name for the `Path`.
+    pub fn link(&self, old: &Self, name: &str) -> Result<()> {
+        if !Arc::ptr_eq(&old.mount_node, &self.mount_node) {
+            return_errno_with_message!(Errno::EXDEV, "cannot cross mount");
+        }
+
+        self.dentry.link(&old.dentry, name)
+    }
+
+    /// Deletes a `Path`.
+    pub fn unlink(&self, name: &str) -> Result<()> {
+        self.dentry.unlink(name)
+    }
+
+    /// Deletes a directory `Path`.
+    pub fn rmdir(&self, name: &str) -> Result<()> {
+        self.dentry.rmdir(name)
+    }
+
+    /// Renames a `Path` to the new `Path` by `rename()` the inner inode.
+    pub fn rename(&self, old_name: &str, new_dir: &Self, new_name: &str) -> Result<()> {
+        if !Arc::ptr_eq(&self.mount_node, &new_dir.mount_node) {
+            return_errno_with_message!(Errno::EXDEV, "cannot cross mount");
+        }
+
+        self.dentry.rename(old_name, &new_dir.dentry, new_name)
+    }
+
+    /// Binds mount the `Path` to the destination `Path`.
+    ///
+    /// If `recursive` is true, it will bind mount the whole mount tree
+    /// to the destination `Path`. Otherwise, it will only bind mount
+    /// the root mount node.
+    pub fn bind_mount_to(&self, dst_dentry: &Self, recursive: bool) -> Result<()> {
+        let _write_guard = begin_mount_tree_write();
+        let new_mount = self
+            .mount_node
+            .clone_mount_node_tree(&self.dentry, recursive);
+        new_mount.graft_mount_node_tree(dst_dentry)?;
+        Ok(())
+    }
+
+    fn this(&self) -> Self {
+        self.clone()
+    }
+
+    /// Gets the mount node of current `Path`.
+    pub fn mount_node(&self) -> &Arc<MountNode> {
+        &self.mount_node
+    }
+}
+
+#[inherit_methods(from = "self.dentry")]
+impl Path {
+    pub fn fs(&self) -> Arc<dyn FileSystem>;
+    pub fn sync_all(&self) -> Result<()>;
+    pub fn sync_data(&self) -> Result<()>;
+    pub fn metadata(&self) -> Metadata;
+    pub fn type_(&self) -> InodeType;
+    pub fn mode(&self) -> Result<InodeMode>;
+    pub fn set_mode(&self, mode: InodeMode) -> Result<()>;
+    pub fn size(&self) -> usize;
+    pub fn resize(&self, size: usize) -> Result<()>;
+    pub fn owner(&self) -> Result<Uid>;
+    pub fn set_owner(&self, uid: Uid) -> Result<()>;
+    pub fn group(&self) -> Result<Gid>;
+    pub fn set_group(&self, gid: Gid) -> Result<()>;
+    pub fn atime(&self) -> Duration;
+    pub fn set_atime(&self, time: Duration);
+    pub fn mtime(&self) -> Duration;
+    pub fn set_mtime(&self, time: Duration);
+    pub fn ctime(&self) -> Duration;
+    pub fn set_ctime(&self, time: Duration);
+    pub fn inode(&self) -> &Arc<dyn Inode>;
+    pub fn is_mount_root(&self) -> bool;
+    pub fn is_mountpoint(&self) -> bool;
+    pub fn set_xattr(
+        &self,
+        name: XattrName,
+        value_reader: &mut VmReader,
+        flags: XattrSetFlags,
+    ) -> Result<()>;
+    pub fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
+    pub fn list_xattr(
+        &self,
+        namespace: XattrNamespace,
+        list_writer: &mut VmWriter,
+    ) -> Result<usize>;
+    pub fn remove_xattr(&self, name: XattrName) -> Result<()>;
+}
 
 /// Checks if the file name is ".", indicating it's the current directory.
 pub const fn is_dot(filename: &str) -> bool {

--- a/kernel/src/net/socket/unix/addr.rs
+++ b/kernel/src/net/socket/unix/addr.rs
@@ -4,7 +4,7 @@ use keyable_arc::KeyableArc;
 
 use super::ns::{self, AbstractHandle};
 use crate::{
-    fs::{path::Dentry, utils::Inode},
+    fs::{path::Path, utils::Inode},
     net::socket::util::SocketAddr,
     prelude::*,
 };
@@ -72,7 +72,7 @@ impl TryFrom<SocketAddr> for UnixSocketAddr {
 
 #[derive(Clone, Debug)]
 pub(super) enum UnixSocketAddrBound {
-    Path(Arc<str>, Dentry),
+    Path(Arc<str>, Path),
     Abstract(Arc<AbstractHandle>),
 }
 

--- a/kernel/src/net/socket/unix/ns/path.rs
+++ b/kernel/src/net/socket/unix/ns/path.rs
@@ -3,14 +3,14 @@
 use crate::{
     fs::{
         fs_resolver::{split_path, FsPath},
-        path::Dentry,
+        path::Path,
         utils::{InodeMode, InodeType, Permission},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
 };
 
-pub fn lookup_socket_file(path: &str) -> Result<Dentry> {
+pub fn lookup_socket_file(path: &str) -> Result<Path> {
     let dentry = {
         let current = current_thread!();
         let current = current.as_posix_thread().unwrap();
@@ -37,7 +37,7 @@ pub fn lookup_socket_file(path: &str) -> Result<Dentry> {
     Ok(dentry)
 }
 
-pub fn create_socket_file(path: &str) -> Result<Dentry> {
+pub fn create_socket_file(path: &str) -> Result<Path> {
     let (parent_pathname, file_name) = split_path(path);
 
     let parent = {

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -11,7 +11,7 @@ use super::process_vm::ProcessVm;
 use crate::{
     fs::{
         fs_resolver::{FsPath, FsResolver, AT_FDCWD},
-        path::Dentry,
+        path::Path,
         utils::{InodeType, Permission},
     },
     prelude::*,
@@ -22,7 +22,7 @@ use crate::{
 /// This struct encapsulates the ELF file to be executed along with its header data,
 /// the `argv` and the `envp` which is required for the program execution.
 pub struct ProgramToLoad {
-    elf_file: Dentry,
+    elf_file: Path,
     file_header: Box<[u8; PAGE_SIZE]>,
     argv: Vec<CString>,
     envp: Vec<CString>,
@@ -37,7 +37,7 @@ impl ProgramToLoad {
     /// I guess for most cases, setting the `recursion_limit` as 1 should be enough.
     /// because the interpreter is usually an elf binary(e.g., /bin/bash)
     pub fn build_from_file(
-        elf_file: Dentry,
+        elf_file: Path,
         fs_resolver: &FsResolver,
         argv: Vec<CString>,
         envp: Vec<CString>,
@@ -102,7 +102,7 @@ impl ProgramToLoad {
     }
 }
 
-pub fn check_executable_file(dentry: &Dentry) -> Result<()> {
+pub fn check_executable_file(dentry: &Path) -> Result<()> {
     if dentry.type_().is_directory() {
         return_errno_with_message!(Errno::EISDIR, "the file is a directory");
     }

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -11,7 +11,7 @@ use crate::{
     fs::{
         file_table::{get_file_fast, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Dentry,
+        path::Path,
     },
     prelude::*,
     process::{
@@ -60,7 +60,7 @@ fn lookup_executable_file(
     filename: String,
     flags: OpenFlags,
     ctx: &Context,
-) -> Result<Dentry> {
+) -> Result<Path> {
     let dentry = if flags.contains(OpenFlags::AT_EMPTY_PATH) && filename.is_empty() {
         let mut file_table = ctx.thread_local.borrow_file_table_mut();
         let file = get_file_fast!(&mut file_table, dfd);
@@ -81,7 +81,7 @@ fn lookup_executable_file(
 }
 
 fn do_execve(
-    elf_file: Dentry,
+    elf_file: Path,
     argv_ptr_ptr: Vaddr,
     envp_ptr_ptr: Vaddr,
     ctx: &Context,
@@ -217,7 +217,7 @@ fn read_cstring_vec(
 fn set_uid_from_elf(
     current: &Process,
     credentials: &Credentials<WriteOp>,
-    elf_file: &Dentry,
+    elf_file: &Path,
 ) -> Result<()> {
     if elf_file.mode()?.has_set_uid() {
         let uid = elf_file.owner()?;
@@ -235,7 +235,7 @@ fn set_uid_from_elf(
 fn set_gid_from_elf(
     current: &Process,
     credentials: &Credentials<WriteOp>,
-    elf_file: &Dentry,
+    elf_file: &Path,
 ) -> Result<()> {
     if elf_file.mode()?.has_set_gid() {
         let gid = elf_file.group()?;

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Dentry,
+        path::Path,
         registry::FsProperties,
         utils::{FileSystem, InodeType},
     },
@@ -82,7 +82,7 @@ fn do_remount() -> Result<()> {
 /// Such as use user command `mount --rbind src dst`.
 fn do_bind_mount(
     src_name: CString,
-    dst_dentry: Dentry,
+    dst_dentry: Path,
     recursive: bool,
     ctx: &Context,
 ) -> Result<()> {
@@ -108,7 +108,7 @@ fn do_change_type() -> Result<()> {
 }
 
 /// Move a mount from src location to dst location.
-fn do_move_mount_old(src_name: CString, dst_dentry: Dentry, ctx: &Context) -> Result<()> {
+fn do_move_mount_old(src_name: CString, dst_dentry: Path, ctx: &Context) -> Result<()> {
     let src_dentry = {
         let src_name = src_name.to_string_lossy();
         if src_name.is_empty() {
@@ -118,7 +118,7 @@ fn do_move_mount_old(src_name: CString, dst_dentry: Dentry, ctx: &Context) -> Re
         ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
     };
 
-    if !src_dentry.is_root_of_mount() {
+    if !src_dentry.is_mount_root() {
         return_errno_with_message!(Errno::EINVAL, "src_name can not be moved");
     };
     if src_dentry.mount_node().parent().is_none() {
@@ -134,7 +134,7 @@ fn do_move_mount_old(src_name: CString, dst_dentry: Dentry, ctx: &Context) -> Re
 fn do_new_mount(
     devname: CString,
     fs_type: Vaddr,
-    target_dentry: Dentry,
+    target_dentry: Path,
     data: Vaddr,
     ctx: &Context,
 ) -> Result<()> {

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -8,7 +8,7 @@ use crate::{
         file_handle::FileLike,
         file_table::{get_file_fast, FileDesc},
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Dentry,
+        path::Path,
         utils::{
             XattrName, XattrNamespace, XattrSetFlags, XATTR_NAME_MAX_LEN, XATTR_VALUE_MAX_LEN,
         },
@@ -127,9 +127,9 @@ pub(super) enum XattrFileCtx<'a> {
 pub(super) fn lookup_dentry_for_xattr<'a>(
     file_ctx: &'a XattrFileCtx<'a>,
     ctx: &'a Context,
-) -> Result<Cow<'a, Dentry>> {
+) -> Result<Cow<'a, Path>> {
     let lookup_dentry_from_fs =
-        |path: &CString, ctx: &Context, symlink_no_follow: bool| -> Result<Cow<'_, Dentry>> {
+        |path: &CString, ctx: &Context, symlink_no_follow: bool| -> Result<Cow<'_, Path>> {
             let path = path.to_string_lossy();
             let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
             let fs = ctx.posix_thread.fs().resolver().read();

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -7,7 +7,7 @@ use crate::{
     fs::{
         file_table::FileDesc,
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Dentry,
+        path::Path,
     },
     prelude::*,
     time::{clocks::RealTimeCoarseClock, timespec_t, timeval_t},
@@ -109,7 +109,7 @@ struct Utimbuf {
     modtime: i64,
 }
 
-fn vfs_utimes(dentry: &Dentry, times: Option<TimeSpecPair>) -> Result<SyscallReturn> {
+fn vfs_utimes(dentry: &Path, times: Option<TimeSpecPair>) -> Result<SyscallReturn> {
     let (atime, mtime, ctime) = match times {
         Some(times) => {
             if !times.atime.is_valid() || !times.mtime.is_valid() {

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -4,6 +4,7 @@ mod iovec;
 pub mod net;
 pub mod per_cpu_counter;
 pub mod random;
+pub mod rcu_linked_list;
 pub mod ring_buffer;
 
 pub use iovec::{MultiRead, MultiWrite, VmReaderArray, VmWriterArray};

--- a/kernel/src/util/rcu_linked_list.rs
+++ b/kernel/src/util/rcu_linked_list.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! A linked list implementation using RCU synchronization.
+//!
+//! This module provides an RCU-based doubly-linked list ([`RcuList`]) designed for high-performance
+//! concurrent access scenarios where reads vastly outnumber writes.
+
+use ostd::{
+    sync::{non_null::ArcRef, RcuOption},
+    task::{atomic_mode::AsAtomicModeGuard, disable_preempt},
+};
+
+use crate::prelude::*;
+
+/// A linked list implementation using RCU (Read-Copy-Update) synchronization.
+pub struct RcuList<T: 'static + Send + Sync> {
+    head: RcuOption<Arc<T>>,
+    obtain_link: fn(&T) -> &RcuListLink<T>,
+}
+
+/// The link fields for a node in the RCU linked list.
+pub struct RcuListLink<T: 'static + Send + Sync> {
+    next: RcuOption<Arc<T>>,
+    prev: RcuOption<Arc<T>>,
+}
+
+impl<T: 'static + Send + Sync> RcuList<T> {
+    /// Creates a new empty RCU linked list
+    ///
+    /// # Example
+    /// ```
+    /// struct Node {
+    ///     value: usize,
+    ///     link: RcuListLink<Self>
+    /// }
+    ///
+    /// let node_list = RcuLinkedList::new(|node| &node.link);
+    /// ```
+    pub fn new(obtain_link: fn(&T) -> &RcuListLink<T>) -> Self {
+        RcuList {
+            head: RcuOption::new_none(),
+            obtain_link,
+        }
+    }
+
+    /// Checks if the list is empty
+    pub fn is_empty(&self, guard: &dyn AsAtomicModeGuard) -> bool {
+        self.head.read_with(guard).is_none()
+    }
+
+    /// Returns a reference to the front node in the list.
+    pub fn front<'a>(&'a self, guard: &'a dyn AsAtomicModeGuard) -> Option<ArcRef<'a, T>> {
+        self.head.read_with(guard)
+    }
+
+    /// Pushes a new node to the front of the list
+    pub fn push_front(&self, new_head: Arc<T>, guard: &dyn AsAtomicModeGuard) {
+        let _guard = guard.as_atomic_mode_guard();
+
+        let head = self.head.read_with(guard);
+        let new_link = (self.obtain_link)(&new_head);
+
+        new_link.prev.update(None);
+        if let Some(head) = head {
+            let head_link = (self.obtain_link)(&head);
+
+            new_link.next.update(Some(head.clone()));
+            head_link.prev.update(Some(new_head.clone()));
+        } else {
+            new_link.next.update(None);
+        }
+
+        self.head.update(Some(new_head));
+    }
+
+    /// Pushes a new node to the front of the list
+    pub fn pop_front(&self, guard: &dyn AsAtomicModeGuard) -> Option<Arc<T>> {
+        let _guard = guard.as_atomic_mode_guard();
+
+        let head = self.head.read_with(guard)?.clone();
+
+        let head_link = (self.obtain_link)(&head);
+        let new_head = head_link.next.read_with(guard);
+        if let Some(new_head) = &new_head {
+            let new_head_link = (self.obtain_link)(new_head);
+            new_head_link.prev.update(None);
+        }
+
+        self.head.update(new_head.as_deref().cloned());
+
+        Some(head)
+    }
+
+    /// Removes a node from the list
+    pub fn remove(&self, node: &T, guard: &dyn AsAtomicModeGuard) {
+        let _guard = guard.as_atomic_mode_guard();
+
+        let links = (self.obtain_link)(node);
+
+        let prev = links.prev.read_with(guard);
+        let next = links.next.read_with(guard);
+
+        if let Some(prev_node) = &prev {
+            let prev_links = (self.obtain_link)(prev_node);
+            prev_links.next.update(next.as_deref().cloned());
+        } else {
+            self.head.update(next.as_deref().cloned());
+        }
+
+        if let Some(next_node) = next {
+            let next_links = (self.obtain_link)(&next_node);
+            next_links.prev.update(prev.as_deref().cloned());
+        }
+
+        links.next.update(None);
+        links.prev.update(None);
+    }
+
+    /// Returns a iterator over the list.
+    pub fn iter<'a>(&'a self, guard: &'a dyn AsAtomicModeGuard) -> RcuListIter<'a, T> {
+        RcuListIter {
+            list: self,
+            guard,
+            current: self.head.read_with(guard).as_deref().cloned(),
+        }
+    }
+}
+
+impl<T: 'static + Send + Sync> Default for RcuListLink<T> {
+    fn default() -> Self {
+        Self {
+            next: RcuOption::new_none(),
+            prev: RcuOption::new_none(),
+        }
+    }
+}
+
+/// An iterator over the nodes of an `RcuList`.
+pub struct RcuListIter<'a, T: 'static + Send + Sync> {
+    list: &'a RcuList<T>,
+    guard: &'a dyn AsAtomicModeGuard,
+    current: Option<Arc<T>>,
+}
+
+impl<T: 'static + Send + Sync> Iterator for RcuListIter<'_, T> {
+    type Item = Arc<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current_node = self.current.take()?;
+
+        let link = (self.list.obtain_link)(&current_node);
+        self.current = link.next.read_with(self.guard).as_deref().cloned();
+
+        Some(current_node)
+    }
+}
+
+impl<T: 'static + Send + Sync> Drop for RcuList<T> {
+    fn drop(&mut self) {
+        let current_rcu = core::mem::replace(&mut self.head, RcuOption::new_none());
+
+        let guard = disable_preempt();
+
+        let mut head_node = current_rcu.read_with(&guard).as_deref().cloned();
+        while let Some(node) = head_node {
+            let current_link = (self.obtain_link)(&node);
+            let next_node = current_link.next.read_with(&guard).as_deref().cloned();
+
+            current_link.next.update(None);
+            current_link.prev.update(None);
+
+            head_node = next_node;
+        }
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::{prelude::*, task::disable_preempt};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestNode {
+        id: u32,
+        link: RcuListLink<Self>,
+    }
+
+    #[ktest]
+    fn test_empty_list() {
+        let list = RcuList::<TestNode>::new(|n| &n.link);
+        let guard = disable_preempt();
+
+        assert!(list.is_empty(&guard));
+        assert!(list.front(&guard).is_none());
+        assert!(list.pop_front(&guard).is_none());
+    }
+
+    #[ktest]
+    fn test_push_pop_front() {
+        let list = RcuList::<TestNode>::new(|n| &n.link);
+        let guard = disable_preempt();
+
+        let node1 = Arc::new(TestNode {
+            id: 1,
+            ..Default::default()
+        });
+        let node2 = Arc::new(TestNode {
+            id: 2,
+            ..Default::default()
+        });
+
+        list.push_front(node1.clone(), &guard);
+        assert_eq!(list.front(&guard).unwrap().id, 1);
+
+        list.push_front(node2.clone(), &guard);
+        assert_eq!(list.front(&guard).unwrap().id, 2);
+
+        assert_eq!(list.pop_front(&guard).unwrap().id, 2);
+        assert_eq!(list.pop_front(&guard).unwrap().id, 1);
+        assert!(list.is_empty(&guard));
+    }
+
+    #[ktest]
+    fn test_remove_middle() {
+        let list = RcuList::<TestNode>::new(|n| &n.link);
+        let guard = disable_preempt();
+
+        let nodes = vec![
+            Arc::new(TestNode {
+                id: 1,
+                ..Default::default()
+            }),
+            Arc::new(TestNode {
+                id: 2,
+                ..Default::default()
+            }),
+            Arc::new(TestNode {
+                id: 3,
+                ..Default::default()
+            }),
+        ];
+
+        for node in &nodes {
+            list.push_front(node.clone(), &guard);
+        }
+
+        // Remove middle node (id=2)
+        list.remove(&nodes[1], &guard);
+
+        let mut iter = list.iter(&guard);
+        assert_eq!(iter.next().unwrap().id, 3);
+        assert_eq!(iter.next().unwrap().id, 1);
+        assert!(iter.next().is_none());
+    }
+
+    #[ktest]
+    fn test_drop_cleanup() {
+        let list = RcuList::<TestNode>::new(|n| &n.link);
+        let guard = disable_preempt();
+
+        let node = Arc::new(TestNode {
+            id: 1,
+            ..Default::default()
+        });
+        list.push_front(node.clone(), &guard);
+
+        drop(list);
+
+        // Verify node links were cleared
+        assert!(node.link.next.read_with(&guard).is_none());
+        assert!(node.link.prev.read_with(&guard).is_none());
+    }
+}


### PR DESCRIPTION
This PR first renames `Dentry` and `Dentry_` to `Path` and `Dentry`, respectively, to align with Linux's terminology and avoid conceptual confusion. 

```rust
/// A `Path` is used to represent an exact location in the VFS tree.
#[derive(Debug, Clone)]
pub struct Path {
    mount_node: Arc<MountNode>,
    inner: Arc<Dentry>,
}

/// A `Dentry` represents a cached filesystem node in the VFS layer.
pub(super) struct Dentry {
    inode: Arc<dyn Inode>,
    type_: InodeType,
    name_and_parent: RwLock<Option<(String, Arc<Dentry>)>>,
    children: RwMutex<DentryChildren>,
    flags: AtomicU32,
    this: Weak<Dentry>,
}
```
Then, it refactors the Mount-related implementation by introducing RCU (Read-Copy-Update) usage, while ensuring the current mount management approach can accommodate future mount namespace mechanism extensions.
## Motivation
Currently, we use the following abstraction `MountNode`:

```rust
/// The `MountNode` is used to form a mount tree to maintain the mount information.
pub struct MountNode {
    /// Root dentry.
    root_dentry: Arc<Dentry_>,
    /// Mountpoint dentry. A mount node can be mounted on one dentry of another mount node,
    /// which makes the mount being the child of the mount node.
    mountpoint_dentry: RwLock<Option<Arc<Dentry_>>>,
    /// The associated FS.
    fs: Arc<dyn FileSystem>,
    /// The parent mount node.
    parent: RwLock<Option<Weak<MountNode>>>,
    /// Child mount nodes which are mounted on one dentry of self.
    children: RwLock<HashMap<DentryKey, Arc<Self>>>,
    /// Reference to self.
    this: Weak<Self>,
}
```

The current implementation has two main issues:

1. **Path Lookup Inefficiency**: During path `lookup`, if the current `Dentry` is a mount point, the system must recursively call `Path::get_top_dentry` to traverse the child mount nodes until the last non-mount-point `Dentry` is found. 
```rust
    /// Gets the top `Dentry` of the current.
    ///
    /// Used when different file systems are mounted on the same mount point.
    ///
    /// For example, first `mount /dev/sda1 /mnt` and then `mount /dev/sda2 /mnt`.
    /// After the second mount is completed, the content of the first mount will be overridden.
    /// We need to recursively obtain the top `Dentry`.
    fn get_top_dentry(self) -> Self {
        if !self.inner.is_mountpoint() {
            return self;
        }

        match self.mount_node.get(&self) {
            Some(child_mount) => {
                let inner = child_mount.root_dentry().clone();
                Self::new(child_mount, inner).get_top_dentry()
            }
            None => self,
        }
    }
```
This process requires frequent lock acquisition, significantly reducing efficiency. Since `lookup` is a highly frequent operation, this becomes a performance bottleneck.
    
2. **Mount Tree Modification Constraints**: Modifications to the mount tree rely on the **`children`** field of each `MountNode`, which is protected by an individual lock. However, with future features like **_mount peer groups_**, a single mount operation might propagate to other nodes, modifying `MountNode`s across different mount namespaces. To ensure atomicity and consistent, all relevant locks must be acquired at once, but the current design makes this nearly impossible, potentially leading to deadlocks.
    
### Proposed Solution:

The goal of this new design is to address the problems above:
- Achieve **efficient** reading (close to lockless lookup)
- Achieve **atomic modifications to the mount tree** within a transaction

The new design adopt some methods from Linux, such as:

- **RCU**  for managing `MountNode` fields to enable lock-free reads.
- **Global Locks** for mount operations. When a transaction modifies the mount tree structure, it must first acquire this global lock to ensure atomicity.
    

```rust
/// The `MountNode` is used to form a mount tree to maintain the mount information.
pub struct MountNode {
    /// Root dentry.
    root_dentry: Arc<Dentry>,
    /// Mountpoint dentry. A mount node can be mounted on one dentry of another mount node,
    /// which makes the mount being the child of the mount node.
    mountpoint: RcuOption<Arc<Dentry>>,
    /// The associated FS.
    fs: Arc<dyn FileSystem>,
    /// The parent mount node.
    parent: RcuOption<Weak<MountNode>>,
    /// Child mount nodes which are mounted on one dentry of self.
    children: RcuList<MountNode>,
    /// The link used when the is added to the children list.
    children_list_link: RcuListLink<MountNode>,
    /// Reference to self.
    this: Weak<Self>,
}

/// The global mount lock, protecting the atomicity and consistency of mount-related
/// operations across different mount namespace.
/// 
/// FIXME: This lock doesn't actually serve any purpose in a single mount namespace scenario. In a multi-namespace environment, it can be replaced with a SeqLock (sequence lock) consistent with Linux's implementation to achieve truly lock-free reads.
pub(super) type MountLock = RwLock<()>;
/// The global instance of the mount lock.
pub(super) static MOUNT_LOCK: MountLock = MountLock::new(());

/// A mutex lock that protects the mount tree topology of a mount namespace.
///
/// # TODO: Maintains per-namespace instantiation after mount namespace mechanism
/// achieved.
pub(super) static NAMESPACE_LOCK: RwMutex<()> = RwMutex::new(());
```

Here, an **RCU-based linked list** is used to manage the `children` list and the `mounts` of a `dentry`. This design ensures **lock-free reads while maintaining scalability**, which also aligns with Linux's implementation.

```rust
/// A linked list implementation using RCU (Read-Copy-Update) synchronization.
pub struct RcuList<T: 'static + Send + Sync> {
    head: RcuOption<Arc<T>>,
    obtain_link: fn(&T) -> &RcuListLink<T>
}

/// The link fields for a node in the RCU linked list.
pub struct RcuListLink<T: 'static + Send + Sync> {
    next: RcuOption<Arc<T>>,
    prev: RcuOption<Arc<T>>,
}

impl<T: 'static + Send + Sync> RcuList<T> {
    /// Creates a new empty RCU linked list
    /// 
    /// # Example
    /// ```
    /// struct Node {
    ///     value: usize,
    ///     link: RcuListLink<Self>
    /// }
    /// 
    /// let node_list = RcuLinkedList::new(|node| &node.link);
    /// ```
    pub fn new(obtain_link: fn(&T) -> &RcuListLink<T>) -> Self {
        RcuList {
            head: RcuOption::new_none(),
            obtain_link,
        }
    }

    /// Checks if the list is empty
    pub fn is_empty(&self) -> bool;

    /// Returns a reference to the front node in the list.
    pub fn front<'a>(&'a self, guard: &'a dyn AsAtomicModeGuard) -> Option<ArcRef<'a, T>>;

    /// Pushes a new node to the front of the list.
    pub fn push_front(&self, new_head: Arc<T>, guard: &dyn AsAtomicModeGuard);

    /// Pushes a new node to the front of the list.
    pub fn pop_front(&self, guard: &dyn AsAtomicModeGuard) -> Option<Arc<T>>;

    /// Removes a node from the list.
    ///
    /// Users must ensure the given `node` is in the current list.
    pub fn remove(&self, node: &T, guard: &dyn AsAtomicModeGuard);

    /// Returns a iterator over the list.
    pub fn iter<'a>(&'a self, guard: &'a dyn AsAtomicModeGuard) -> RcuListIter<'a, T>;
}

impl<T: 'static + Send + Sync> Drop for RcuList<T> {...}
```

For read operations within a mount namespace, a read lock is acquired, while write operations require a write lock. Since these operations can sometimes take a long time, using a **Mutex** helps prevent excessive waiting.

For actual modifications to the Mount Tree, the `MountLock`'s write lock must be held to ensure the consistency of the mount topology.