### PR TITLE
Add the basic namespace framework (with procfs entries)

### DIFF
--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -292,7 +292,7 @@ provided by Linux on x86-64 architecture.
 | 269     | faccessat        | ✅              |
 | 270     | pselect6         | ✅              |
 | 271     | ppoll            | ✅              |
-| 272     | unshare          | ❌              |
+| 272     | unshare          | ✅              |
 | 273     | set_robust_list  | ✅              |
 | 274     | get_robust_list  | ❌              |
 | 275     | splice           | ❌              |

--- a/docs/src/kernel/linux-compatibility.md
+++ b/docs/src/kernel/linux-compatibility.md
@@ -328,7 +328,7 @@ provided by Linux on x86-64 architecture.
 | 305	  | clock_adjtime    | ❌              |
 | 306	  | syncfs           | ❌              |
 | 307	  | sendmmsg         | ❌              |
-| 308	  | setns            | ❌              |
+| 308	  | setns            | ✅              |
 | 309	  | getcpu	         | ✅              |
 | 310	  | process_vm_readv | ❌              |
 | 311	  | process_vm_writev | ❌              |

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     events::Observer,
     fs::{
         file_table::FdEvents,
+        procfs::pid::ns::NsDirOps,
         utils::{DirEntryVecExt, Inode},
     },
     prelude::*,
@@ -19,6 +20,7 @@ mod cmdline;
 mod comm;
 mod exe;
 mod fd;
+mod ns;
 mod stat;
 mod status;
 mod task;
@@ -72,6 +74,7 @@ impl DirOps for PidDirOps {
                 StatFileOps::new_inode(self.0.clone(), self.0.main_thread(), true, this_ptr.clone())
             }
             "task" => TaskDirOps::new_inode(self.0.clone(), this_ptr.clone()),
+            "ns" => NsDirOps::new_inode(self.0.clone(), this_ptr.clone()),
             _ => return_errno!(Errno::ENOENT),
         };
         Ok(inode)
@@ -103,6 +106,9 @@ impl DirOps for PidDirOps {
         });
         cached_children.put_entry_if_not_found("task", || {
             TaskDirOps::new_inode(self.0.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("ns", || {
+            NsDirOps::new_inode(self.0.clone(), this_ptr.clone())
         });
     }
 }

--- a/kernel/src/fs/procfs/pid/ns.rs
+++ b/kernel/src/fs/procfs/pid/ns.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        procfs::template::{DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
+        utils::{DirEntryVecExt, Inode},
+    },
+    namespace::{NameSpace, NsFile},
+    prelude::*,
+    process::{posix_thread::AsPosixThread, Process},
+};
+
+/// Represents the inode at `/proc/[pid]/ns`.
+pub struct NsDirOps(Arc<Process>);
+
+impl NsDirOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDirBuilder::new(Self(process_ref.clone()))
+            .parent(parent)
+            .volatile()
+            .build()
+            .unwrap()
+    }
+}
+
+impl DirOps for NsDirOps {
+    fn lookup_child(&self, this_ptr: Weak<dyn Inode>, name: &str) -> Result<Arc<dyn Inode>> {
+        let main_thread = self.0.main_thread();
+
+        let ns_context = {
+            let posix_thread = main_thread.as_posix_thread().unwrap();
+            posix_thread.ns_context().lock()
+        };
+
+        let ns_context_locked = ns_context
+            .as_ref()
+            .ok_or_else(|| {
+                Error::with_message(Errno::ENOENT, "the process does not have namespaces")
+            })?
+            .read();
+
+        // Mode 1: Look up by namespace name (e.g., "user").
+        // This returns a symbolic link to the namespace.
+        if let Some(ns) = ns_context_locked.iter_ns().find_map(|ns| {
+            if ns.name() == name {
+                ns.weak_self().upgrade()
+            } else {
+                None
+            }
+        }) {
+            return Ok(NsSymOps::new_inode(ns, this_ptr));
+        };
+
+        // Mode 2: Look up by symlink content.
+        // This returns an `NsFile` directly, as if the symlink had been resolved.
+        //
+        // FIXME: The following lookup mode implements non-standard behavior.
+        // It allows resolving a namespace by its symlink content (e.g., "user:[4026531837]")
+        // in a single lookup. This is necessary for internal kernel operations that
+        // resolve a link and open the file in one step. This should ideally be disallowed
+        // for direct userspace lookups, but we currently lack the mechanism to
+        // differentiate the caller.
+        if let Some(ns) = ns_context_locked.iter_ns().find_map(|ns| {
+            if ns.proc_symlink().as_str() == name {
+                ns.weak_self().upgrade()
+            } else {
+                None
+            }
+        }) {
+            return Ok(Arc::new(NsFile::new(ns)));
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the process does not have namespaces");
+    }
+
+    fn populate_children(&self, this_ptr: Weak<dyn Inode>) {
+        let main_thread = self.0.main_thread();
+
+        let ns_context = {
+            let posix_thread = main_thread.as_posix_thread().unwrap();
+            posix_thread.ns_context().lock()
+        };
+
+        let Some(ns_context) = ns_context.as_ref() else {
+            return;
+        };
+
+        let this = {
+            let this = this_ptr.upgrade().unwrap();
+            this.downcast_ref::<ProcDir<NsDirOps>>().unwrap().this()
+        };
+
+        let mut cached_children = this.cached_children().write();
+        ns_context.read().iter_ns().for_each(|ns| {
+            let Some(ns) = ns.weak_self().upgrade() else {
+                return;
+            };
+            cached_children.put_entry_if_not_found(ns.name(), || {
+                NsSymOps::new_inode(ns.clone(), this_ptr.clone())
+            });
+        });
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/ns/N`.
+struct NsSymOps(Arc<dyn NameSpace>);
+
+impl NsSymOps {
+    pub fn new_inode(ns: Arc<dyn NameSpace>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcSymBuilder::new(Self(ns))
+            .parent(parent)
+            .volatile()
+            .build()
+            .unwrap()
+    }
+}
+
+impl SymOps for NsSymOps {
+    fn read_link(&self) -> Result<String> {
+        Ok(self.0.proc_symlink())
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -65,6 +65,7 @@ pub mod events;
 pub mod fs;
 pub mod ipc;
 pub mod kcmdline;
+mod namespace;
 pub mod net;
 pub mod prelude;
 mod process;

--- a/kernel/src/namespace/mod.rs
+++ b/kernel/src/namespace/mod.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use ostd::sync::RwArc;
+
+use crate::{
+    fs::utils::Inode,
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread, CloneFlags},
+};
+
+mod user;
+
+pub use user::UserNamespace;
+
+/// Represents the set of namespaces to which a thread belongs.
+///
+/// This struct is immutable. To change a thread's namespaces (e.g., via the
+/// `clone` or `unshare` syscalls), a new `NsContext` instance must be created
+/// by selectively cloning fields from the existing context.
+pub struct NsContext {
+    user: Arc<UserNamespace>,
+}
+
+impl NsContext {
+    /// Creates a new `NsContext` in the initial state.
+    pub fn new_init() -> Self {
+        Self {
+            user: UserNamespace::new_init(),
+        }
+    }
+
+    /// Creates a new `NsContext` by cloning from an existing `context`,
+    /// based on the provided `clone_flags`.
+    pub fn clone_from(
+        context: &RwArc<Self>,
+        clone_flags: CloneFlags,
+        posix_thread: &PosixThread,
+    ) -> Result<RwArc<Self>> {
+        let clone_ns_flags = clone_flags & CLONE_NS_FLAGS;
+
+        // Fast path: If there are no new namespaces to clone,
+        // we can directly clone the context and return.
+        if clone_ns_flags.is_empty() {
+            return Ok(context.clone());
+        }
+
+        // Slow path
+
+        check_unsupported_ns_flags(clone_ns_flags)?;
+
+        let context_locked = context.read();
+        let mut clone_builder = NsContextCloneBuilder::new(&context_locked);
+
+        // The user namespace must be cloned first, as the new user namespace is
+        // used for privilege checks when cloning other namespaces.
+        // This allows a user who is unprivileged in the old user namespace
+        // to gain privileges in the new one.
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWUSER) {
+            let new_user = context_locked.user().new_child()?;
+            clone_builder.set_user(new_user);
+        }
+
+        let new_user = clone_builder.user();
+
+        // Clone namespaces other than the user namespace require the SYS_ADMIN capability.
+        if !(clone_ns_flags - CloneFlags::CLONE_NEWUSER).is_empty() {
+            new_user.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        }
+
+        // TODO: Support other namespaces.
+
+        Ok(clone_builder.build())
+    }
+
+    /// Returns the associated user namespace.
+    pub fn user(&self) -> &Arc<UserNamespace> {
+        &self.user
+    }
+
+    /// Installs the given namespace `context` for the thread specified by `ctx`.
+    pub fn install(context: RwArc<Self>, ctx: &Context) {
+        let mut pthread_ns_context = ctx.posix_thread.ns_context().lock();
+        let mut thread_local_ns_context = ctx.thread_local.borrow_ns_context_mut();
+
+        *pthread_ns_context = Some(context.clone_ro());
+        thread_local_ns_context.replace(Some(context));
+    }
+
+    /// Returns an iterator over all namespaces in this `NsContext`.
+    pub fn iter_ns(&self) -> impl Iterator<Item = &dyn NameSpace> {
+        [self.user.as_ref() as _].into_iter()
+    }
+}
+
+/// A builder for creating a new `NsContext` by selectively cloning namespaces
+/// from an existing one.
+pub struct NsContextCloneBuilder<'a> {
+    old_context: &'a NsContext,
+
+    // Fields for new namespaces.
+    new_user: Option<Arc<UserNamespace>>,
+}
+
+impl<'a> NsContextCloneBuilder<'a> {
+    /// Creates a new builder based on an existing context.
+    pub fn new(old_context: &'a NsContext) -> Self {
+        Self {
+            old_context,
+            new_user: None,
+        }
+    }
+
+    /// Sets the new user namespace for the context being built.
+    pub fn set_user(&mut self, user: Arc<UserNamespace>) -> &mut Self {
+        self.new_user = Some(user);
+        self
+    }
+
+    /// Returns the new user namespace.
+    pub(self) fn user(&self) -> &Arc<UserNamespace> {
+        self.new_user.as_ref().unwrap_or(&self.old_context.user)
+    }
+
+    /// Builds the new `NsContext`.
+    pub fn build(self) -> RwArc<NsContext> {
+        let Self {
+            old_context,
+            new_user,
+        } = self;
+
+        let new_user = new_user.unwrap_or_else(|| old_context.user.clone());
+
+        RwArc::new(NsContext { user: new_user })
+    }
+}
+
+/// Checks if the given `flags` contain any unsupported namespace-related flags.
+pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
+    const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWUSER;
+
+    let unsupported_flags = (flags & CLONE_NS_FLAGS) - SUPPORTED_FLAGS;
+    if unsupported_flags.is_empty() {
+        return Ok(());
+    }
+
+    warn!("unsupported clone ns flags: {:?}", unsupported_flags);
+    return_errno_with_message!(Errno::EINVAL, "unsupported clone ns flags");
+}
+
+/// A bitmask of all `CloneFlags` related to namespace creation.
+pub const CLONE_NS_FLAGS: CloneFlags = CloneFlags::CLONE_NEWTIME
+    .union(CloneFlags::CLONE_NEWNS)
+    .union(CloneFlags::CLONE_NEWCGROUP)
+    .union(CloneFlags::CLONE_NEWUTS)
+    .union(CloneFlags::CLONE_NEWIPC)
+    .union(CloneFlags::CLONE_NEWUSER)
+    .union(CloneFlags::CLONE_NEWPID)
+    .union(CloneFlags::CLONE_NEWNET);
+
+/// Defines the common interface for all namespace types.
+pub trait NameSpace: Send + Sync + Any + 'static {
+    /// Returns a reference to the underlying inode that represents this namespace.
+    fn inode(&self) -> &Arc<dyn Inode>;
+
+    /// Returns the symbolic name of the namespace type (e.g., "user", "pid").
+    fn name(&self) -> &'static str;
+
+    /// Returns the `NsType` enum variant for this namespace.
+    fn type_(&self) -> NsType;
+
+    /// Returns the string representation of the namespace as it would appear in `/proc/[pid]/ns/`.
+    fn proc_symlink(&self) -> String {
+        format!("{}:[{}]", self.name(), self.inode().ino())
+    }
+
+    /// Returns the owning user namespace.
+    ///
+    /// All namespaces, except for a user namespace itself, are owned by a user namespace.
+    fn owner(&self) -> Option<&UserNamespace>;
+
+    /// Returns a weak reference to this namespace.
+    fn weak_self(&self) -> &Weak<dyn NameSpace>;
+}
+
+/// The different types of namespaces.
+#[derive(Debug, Clone, Copy)]
+pub enum NsType {
+    Mount,
+    User,
+    Pid,
+    Cgroup,
+    Time,
+    Uts,
+    Ipc,
+    Net,
+}
+
+impl From<NsType> for CloneFlags {
+    fn from(value: NsType) -> Self {
+        match value {
+            NsType::Mount => Self::CLONE_NEWNS,
+            NsType::User => Self::CLONE_NEWUSER,
+            NsType::Pid => Self::CLONE_NEWPID,
+            NsType::Cgroup => Self::CLONE_NEWCGROUP,
+            NsType::Time => Self::CLONE_NEWTIME,
+            NsType::Uts => Self::CLONE_NEWUTS,
+            NsType::Ipc => Self::CLONE_NEWIPC,
+            NsType::Net => Self::CLONE_NEWNET,
+        }
+    }
+}

--- a/kernel/src/namespace/mod.rs
+++ b/kernel/src/namespace/mod.rs
@@ -10,8 +10,10 @@ use crate::{
     process::{credentials::capabilities::CapSet, posix_thread::PosixThread, CloneFlags},
 };
 
+mod ns_file;
 mod user;
 
+pub use ns_file::NsFile;
 pub use user::UserNamespace;
 
 /// Represents the set of namespaces to which a thread belongs.

--- a/kernel/src/namespace/ns_file.rs
+++ b/kernel/src/namespace/ns_file.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::time::Duration;
+
+use inherit_methods_macro::inherit_methods;
+
+use crate::{
+    fs::utils::{FileSystem, Inode, InodeMode, InodeType, Metadata},
+    namespace::NameSpace,
+    prelude::*,
+    process::{Gid, Uid},
+};
+
+/// Represents an open file handle to a specific namespace.
+///
+/// The `NsFile` correspond to the special files found in
+/// `/proc/[pid]/ns/`, such as `/proc/self/ns/user`.
+pub struct NsFile(Arc<dyn NameSpace>);
+
+impl NsFile {
+    pub const fn new(ns: Arc<dyn NameSpace>) -> Self {
+        Self(ns)
+    }
+
+    pub fn ns(&self) -> &Arc<dyn NameSpace> {
+        &self.0
+    }
+}
+
+#[inherit_methods(from = "self.0.inode()")]
+impl Inode for NsFile {
+    fn size(&self) -> usize;
+    fn resize(&self, new_size: usize) -> Result<()>;
+    fn metadata(&self) -> Metadata;
+    fn ino(&self) -> u64;
+    fn type_(&self) -> InodeType;
+    fn mode(&self) -> Result<InodeMode>;
+    fn set_mode(&self, mode: InodeMode) -> Result<()>;
+    fn owner(&self) -> Result<Uid>;
+    fn set_owner(&self, uid: Uid) -> Result<()>;
+    fn group(&self) -> Result<Gid>;
+    fn set_group(&self, gid: Gid) -> Result<()>;
+    fn atime(&self) -> Duration;
+    fn set_atime(&self, time: Duration);
+    fn mtime(&self) -> Duration;
+    fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
+    fn fs(&self) -> Arc<dyn FileSystem>;
+}

--- a/kernel/src/namespace/user.rs
+++ b/kernel/src/namespace/user.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        ramfs::new_detached_inode,
+        utils::{Inode, InodeMode},
+    },
+    namespace::{NameSpace, NsType},
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread, Gid, Uid},
+};
+
+/// The user namespace.
+pub struct UserNamespace {
+    inode: Arc<dyn Inode>,
+    weak_self: Weak<dyn NameSpace>,
+}
+
+impl UserNamespace {
+    /// Creates the initial user namespace.
+    pub(super) fn new_init() -> Arc<UserNamespace> {
+        let inode = new_detached_inode(
+            InodeMode::from_bits_truncate(0o777),
+            Uid::new_root(),
+            Gid::new_root(),
+        );
+        Arc::new_cyclic(|weak_ref| Self {
+            inode,
+            weak_self: weak_ref.clone() as Weak<dyn NameSpace>,
+        })
+    }
+
+    /// Creates a new child user namespace.
+    pub(super) fn new_child(self: &Arc<Self>) -> Result<Arc<UserNamespace>> {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "creating child user namespace is not supported"
+        );
+    }
+
+    /// Checks whether the thread has the required capability in this user namespace.
+    pub fn check_cap(&self, _required: CapSet, _posix_thread: &PosixThread) -> Result<()> {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "checking capability in user namespace is not supported"
+        )
+    }
+}
+
+impl NameSpace for UserNamespace {
+    fn inode(&self) -> &Arc<dyn Inode> {
+        &self.inode
+    }
+
+    fn name(&self) -> &'static str {
+        "user"
+    }
+
+    fn type_(&self) -> NsType {
+        NsType::User
+    }
+
+    fn owner(&self) -> Option<&UserNamespace> {
+        None
+    }
+
+    fn weak_self(&self) -> &Weak<dyn NameSpace> {
+        &self.weak_self
+    }
+}

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -57,7 +57,7 @@ impl PidFile {
         self.is_nonblocking.load(Ordering::Relaxed)
     }
 
-    pub(super) fn process(&self) -> &Arc<Process> {
+    pub fn process(&self) -> &Arc<Process> {
         &self.process
     }
 }

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -81,10 +81,12 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
 
     // Drop fields in `PosixThread`.
     *posix_thread.file_table().lock() = None;
+    *posix_thread.ns_context().lock() = None;
 
     // Drop fields in `ThreadLocal`.
     *thread_local.root_vmar().borrow_mut() = None;
     thread_local.borrow_file_table_mut().remove();
+    thread_local.borrow_ns_context_mut().remove();
 
     if is_last_thread {
         exit_process(&posix_process);

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::{
     events::Observer,
     fs::file_table::FileTable,
+    namespace::NsContext,
     prelude::*,
     process::signal::constants::SIGCONT,
     thread::{Thread, Tid},
@@ -77,6 +78,9 @@ pub struct PosixThread {
 
     /// I/O Scheduling priority value
     io_priority: AtomicU32,
+
+    /// The namespaces that the thread belongs to.
+    ns_context: Mutex<Option<RoArc<NsContext>>>,
 }
 
 impl PosixThread {
@@ -309,6 +313,11 @@ impl PosixThread {
     /// Returns the I/O priority value of the thread.
     pub fn io_priority(&self) -> &AtomicU32 {
         &self.io_priority
+    }
+
+    /// Returns the namespaces which the thread belongs to.
+    pub fn ns_context(&self) -> &Mutex<Option<RoArc<NsContext>>> {
+        &self.ns_context
     }
 }
 

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -8,6 +8,7 @@ use ostd::{cpu::context::FpuContext, mm::Vaddr, sync::RwArc, task::CurrentTask};
 use super::RobustListHead;
 use crate::{
     fs::{file_table::FileTable, thread_info::ThreadFsInfo},
+    namespace::NsContext,
     prelude::*,
     process::signal::SigStack,
     vm::vmar::Vmar,
@@ -44,6 +45,9 @@ pub struct ThreadLocal {
     sig_context: Cell<Option<Vaddr>>,
     /// Stack address, size, and flags for the signal handler.
     sig_stack: RefCell<Option<SigStack>>,
+
+    // Namespaces.
+    ns_context: RefCell<Option<RwArc<NsContext>>>,
 }
 
 impl ThreadLocal {
@@ -54,6 +58,7 @@ impl ThreadLocal {
         file_table: RwArc<FileTable>,
         fs: Arc<ThreadFsInfo>,
         fpu_context: FpuContext,
+        ns_context: RwArc<NsContext>,
     ) -> Self {
         Self {
             set_child_tid: Cell::new(set_child_tid),
@@ -66,6 +71,7 @@ impl ThreadLocal {
             sig_stack: RefCell::new(None),
             fpu_context: RefCell::new(fpu_context),
             fpu_state: Cell::new(FpuState::Unloaded),
+            ns_context: RefCell::new(Some(ns_context)),
         }
     }
 
@@ -86,11 +92,11 @@ impl ThreadLocal {
     }
 
     pub fn borrow_file_table(&self) -> FileTableRef {
-        FileTableRef(self.file_table.borrow())
+        ThreadLocalOptionRef(self.file_table.borrow())
     }
 
     pub fn borrow_file_table_mut(&self) -> FileTableRefMut {
-        FileTableRefMut(self.file_table.borrow_mut())
+        ThreadLocalOptionRefMut(self.file_table.borrow_mut())
     }
 
     pub fn borrow_fs(&self) -> Ref<'_, Arc<ThreadFsInfo>> {
@@ -111,6 +117,14 @@ impl ThreadLocal {
 
     pub fn fpu(&self) -> ThreadFpu<'_> {
         ThreadFpu(self)
+    }
+
+    pub fn borrow_ns_context(&self) -> NsContextRef {
+        ThreadLocalOptionRef(self.ns_context.borrow())
+    }
+
+    pub fn borrow_ns_context_mut(&self) -> NsContextRefMut {
+        ThreadLocalOptionRefMut(self.ns_context.borrow_mut())
     }
 }
 
@@ -201,40 +215,51 @@ impl ThreadFpu<'_> {
 }
 
 /// An immutable, shared reference to the file table in [`ThreadLocal`].
-pub struct FileTableRef<'a>(Ref<'a, Option<RwArc<FileTable>>>);
+pub type FileTableRef<'a> = ThreadLocalOptionRef<'a, RwArc<FileTable>>;
 
-impl FileTableRef<'_> {
-    /// Unwraps and returns a reference to the file table.
+/// An immutable, shared reference to the namespaces in [`ThreadLocal`].
+pub type NsContextRef<'a> = ThreadLocalOptionRef<'a, RwArc<NsContext>>;
+
+/// An immutable, shared reference to thread-local data contained within a `RefCell<Option<..>>`.
+pub struct ThreadLocalOptionRef<'a, T>(Ref<'a, Option<T>>);
+
+impl<T> ThreadLocalOptionRef<'_, T> {
+    /// Unwraps and returns a reference to the data.
     ///
     /// # Panics
     ///
-    /// This method will panic if the thread has exited and the file table has been dropped.
-    pub fn unwrap(&self) -> &RwArc<FileTable> {
+    /// This method will panic if the thread has exited and the data has been dropped.
+    pub fn unwrap(&self) -> &T {
         self.0.as_ref().unwrap()
     }
 }
 
 /// A mutable, exclusive reference to the file table in [`ThreadLocal`].
-pub struct FileTableRefMut<'a>(RefMut<'a, Option<RwArc<FileTable>>>);
+pub type FileTableRefMut<'a> = ThreadLocalOptionRefMut<'a, RwArc<FileTable>>;
 
-impl FileTableRefMut<'_> {
-    /// Unwraps and returns a reference to the file table.
+pub type NsContextRefMut<'a> = ThreadLocalOptionRefMut<'a, RwArc<NsContext>>;
+
+/// A mutable, exclusive reference to thread-local data contained within a `RefCell<Option<..>>`.
+pub struct ThreadLocalOptionRefMut<'a, T>(RefMut<'a, Option<T>>);
+
+impl<T> ThreadLocalOptionRefMut<'_, T> {
+    /// Unwraps and returns a reference to the data.
     ///
     /// # Panics
     ///
-    /// This method will panic if the thread has exited and the file table has been dropped.
-    pub fn unwrap(&mut self) -> &mut RwArc<FileTable> {
+    /// This method will panic if the thread has exited and the data has been dropped.
+    pub fn unwrap(&mut self) -> &mut T {
         self.0.as_mut().unwrap()
     }
 
-    /// Removes the file table and drops it.
+    /// Removes the data and drops it.
     pub(super) fn remove(&mut self) {
         *self.0 = None;
     }
 
-    /// Replaces the file table with a new one, returning the old one.
-    pub fn replace(&mut self, new_table: Option<RwArc<FileTable>>) -> Option<RwArc<FileTable>> {
-        core::mem::replace(&mut *self.0, new_table)
+    /// Replaces the data with a new one, returning the old one.
+    pub fn replace(&mut self, new: Option<T>) -> Option<T> {
+        core::mem::replace(&mut *self.0, new)
     }
 }
 

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -138,6 +138,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -205,6 +206,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94          => sys_exit_group(args[..1]);
     SYS_WAITID = 95              => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96     => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97             => sys_unshare(args[..1]);
     SYS_FUTEX = 98               => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99     => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101          => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -109,6 +109,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -293,6 +294,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242            => sys_accept4(args[..4]);
     SYS_WAIT4 = 260              => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261          => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268              => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274      => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275      => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278          => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -113,6 +113,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -300,6 +301,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242            => sys_accept4(args[..4]);
     SYS_WAIT4 = 260              => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261          => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268              => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274      => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275      => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278          => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -142,6 +142,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -211,6 +212,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94          => sys_exit_group(args[..1]);
     SYS_WAITID = 95              => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96     => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97             => sys_unshare(args[..1]);
     SYS_FUTEX = 98               => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99     => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101          => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -161,6 +161,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
+    unshare::sys_unshare,
     utimens::{sys_futimesat, sys_utime, sys_utimensat, sys_utimes},
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -356,6 +357,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FACCESSAT = 269        => sys_faccessat(args[..3]);
     SYS_PSELECT6 = 270         => sys_pselect6(args[..6]);
     SYS_PPOLL = 271            => sys_ppoll(args[..5]);
+    SYS_UNSHARE = 272          => sys_unshare(args[..1]);
     SYS_SET_ROBUST_LIST = 273  => sys_set_robust_list(args[..2]);
     SYS_UTIMENSAT = 280        => sys_utimensat(args[..4]);
     SYS_EPOLL_PWAIT = 281      => sys_epoll_pwait(args[..6]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -129,6 +129,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -376,6 +377,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PREADV = 295           => sys_preadv(args[..4]);
     SYS_PWRITEV = 296          => sys_pwritev(args[..4]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_SETNS = 308            => sys_setns(args[..2]);
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);
     SYS_SCHED_SETATTR = 314    => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 315    => sys_sched_getattr(args[..4]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -140,6 +140,7 @@ mod setfsuid;
 mod setgid;
 mod setgroups;
 mod setitimer;
+mod setns;
 mod setpgid;
 mod setregid;
 mod setresgid;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -172,6 +172,7 @@ mod umask;
 mod umount;
 mod uname;
 mod unlink;
+mod unshare;
 mod utimens;
 mod wait4;
 mod waitid;

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module implements the `setns` syscall.
+//!
+//! This syscall reassociates the calling thread with a namespace specified by a
+//! file descriptor. The `flags` argument determines which type of namespace can be
+//! joined.
+//!
+//! The file descriptor `fd` can refer to:
+//! 1. A namespace file from `/proc/[pid]/ns/`.
+//! 2. A `PidFile` opened by `pidfd_open` or open `/proc/[pid]` directory.
+
+use ostd::sync::RwArc;
+
+use crate::{
+    fs::{file_handle::FileLike, file_table::FileDesc},
+    namespace::{
+        check_unsupported_ns_flags, NsContext, NsContextCloneBuilder, NsFile, NsType,
+        UserNamespace, CLONE_NS_FLAGS,
+    },
+    prelude::*,
+    process::{
+        credentials::capabilities::CapSet, posix_thread::AsPosixThread, CloneFlags, PidFile,
+    },
+    syscall::SyscallReturn,
+};
+
+pub fn sys_setns(fd: FileDesc, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let ns_type_flags = CloneFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid setns flags"))?;
+
+    let file = {
+        let file_table = ctx.thread_local.borrow_file_table();
+        let file_table_locked = file_table.unwrap().read();
+        file_table_locked.get_file(fd)?.clone()
+    };
+
+    let new_ns_context = if let Some(ns_file) = as_ns_file(file.as_ref()) {
+        build_context_from_ns_file(ns_file, ns_type_flags, ctx)?
+    } else if let Some(pid_file) = file.downcast_ref::<PidFile>() {
+        build_context_from_pid_file(pid_file, ns_type_flags, ctx)?
+    } else {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "fd does not refer to a supported namespace file type"
+        );
+    };
+
+    // Install the newly created namespace context.
+    NsContext::install(new_ns_context, ctx);
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn as_ns_file(file: &dyn FileLike) -> Option<&NsFile> {
+    file.inode()?.downcast_ref::<NsFile>()
+}
+
+fn build_context_from_ns_file(
+    ns_file: &NsFile,
+    flags: CloneFlags,
+    ctx: &Context,
+) -> Result<RwArc<NsContext>> {
+    let target_ns = ns_file.ns();
+    let target_ns_type_flag = CloneFlags::from(target_ns.type_());
+
+    // The flags mush be specified and they must match the type of the target namespace file.
+    if flags.is_empty() || flags != target_ns_type_flag {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "setns flags do not match the type of the namespace file"
+        );
+    }
+
+    check_unsupported_ns_flags(target_ns_type_flag)?;
+
+    let current_context = ctx.thread_local.borrow_ns_context();
+    let current_context_locked = current_context.unwrap().read();
+    let mut clone_builder = NsContextCloneBuilder::new(&current_context_locked);
+
+    // Based on the namespace type, add it to the builder.
+    match target_ns.type_() {
+        NsType::User => {
+            let target_ns = Arc::downcast(target_ns.clone()).unwrap();
+            set_user_ns(
+                &mut clone_builder,
+                target_ns,
+                current_context_locked.user(),
+                ctx,
+            )?;
+        }
+        // TODO: Support other namespace types.
+        _ => return_errno_with_message!(Errno::EINVAL, "the namespace to set is unsupported"),
+    }
+
+    Ok(clone_builder.build())
+}
+
+fn build_context_from_pid_file(
+    pid_file: &PidFile,
+    flags: CloneFlags,
+    ctx: &Context,
+) -> Result<RwArc<NsContext>> {
+    if flags.is_empty() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "flags must be specified when using a pid file"
+        );
+    }
+
+    // Check for any flags that are not namespace-related.
+    if !(flags - CLONE_NS_FLAGS).is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "invalid flags specified for pid file mode");
+    }
+
+    check_unsupported_ns_flags(flags)?;
+
+    // Lock target context and the current context.
+    // Since we acquire only read locks for both, the lock order doesn't matter.
+
+    let target_thread = pid_file.process().main_thread();
+    let target_context = target_thread.as_posix_thread().unwrap().ns_context().lock();
+    let Some(target_context) = target_context.as_ref() else {
+        return_errno_with_message!(Errno::ESRCH, "target process has exited");
+    };
+    let target_context_locked = target_context.read();
+
+    let current_context = ctx.thread_local.borrow_ns_context();
+    let current_context_locked = current_context.unwrap().read();
+
+    let mut clone_builder = NsContextCloneBuilder::new(&current_context_locked);
+
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        let target_ns = target_context_locked.user().clone();
+        set_user_ns(
+            &mut clone_builder,
+            target_ns,
+            current_context_locked.user(),
+            ctx,
+        )?;
+    }
+
+    // TODO: Support setting other namespaces from the target process.
+
+    Ok(clone_builder.build())
+}
+
+fn set_user_ns(
+    clone_builder: &mut NsContextCloneBuilder,
+    target_ns: Arc<UserNamespace>,
+    current_ns: &Arc<UserNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    // Prevent a thread from re-entering the same user namespace
+    if Arc::ptr_eq(&target_ns, current_ns) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "a thread cannot re-enter the same user namespace"
+        );
+    }
+
+    // Disallow joining a new user namespace in multithreaded processes
+    if !is_single_threaded(ctx) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "multithreaded processes cannot join a new user namespace"
+        );
+    }
+
+    // Verify the thread has SYS_ADMIN capability in the target namespace
+    target_ns.check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+
+    let fs = ctx.thread_local.borrow_fs();
+    // Prevent joining the new namespace if the thread's filesystem state is shared
+    if Arc::strong_count(&fs) != 1 {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "cannot join a new namespace when the thread shares filesystem state with other threads"
+        )
+    }
+
+    // TODO: Are the checks above sufficient?
+
+    clone_builder.set_user(target_ns);
+
+    Ok(())
+}
+
+fn is_single_threaded(ctx: &Context) -> bool {
+    ctx.process.tasks().lock().as_slice().len() == 1
+}

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::RwArc;
+
+use crate::{
+    namespace::{NsContext, CLONE_NS_FLAGS},
+    prelude::*,
+    process::CloneFlags,
+    syscall::SyscallReturn,
+};
+
+pub fn sys_unshare(unshare_flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let flags = {
+        let mut flags = CloneFlags::from_bits(unshare_flags)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid unshare flags"))?;
+        apply_implied_flags(&mut flags);
+        flags
+    };
+
+    debug!("unshare flags = {:?}", flags);
+
+    check_flags(flags, ctx)?;
+
+    unshare_files(flags, ctx);
+    unshare_fs(flags, ctx);
+    unshare_sysvsem(flags, ctx);
+    unshare_namespaces(flags, ctx)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn apply_implied_flags(flags: &mut CloneFlags) {
+    // Specifying CLONE_NEWIPC automatically implies CLONE_SYSVSEM.
+    if flags.contains(CloneFlags::CLONE_NEWIPC) {
+        *flags |= CloneFlags::CLONE_SYSVSEM;
+    }
+
+    // Specifying CLONE_NEWNS automatically implies CLONE_FS.
+    if flags.contains(CloneFlags::CLONE_NEWNS) {
+        *flags |= CloneFlags::CLONE_FS;
+    }
+
+    // Specifying CLONE_NEWPID automatically implies CLONE_THREAD.
+    if flags.contains(CloneFlags::CLONE_NEWPID) {
+        *flags |= CloneFlags::CLONE_THREAD;
+    }
+
+    // Specifying CLONE_NEWUSER automatically implies both CLONE_THREAD and CLONE_FS.
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        *flags |= CloneFlags::CLONE_THREAD | CloneFlags::CLONE_FS;
+    }
+}
+
+fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
+    const VALID_FLAGS: CloneFlags = CLONE_NS_FLAGS
+        .union(CloneFlags::CLONE_FILES)
+        .union(CloneFlags::CLONE_FS)
+        .union(CloneFlags::CLONE_SYSVSEM)
+        .union(CloneFlags::CLONE_THREAD)
+        .union(CloneFlags::CLONE_VM)
+        .union(CloneFlags::CLONE_SIGHAND);
+
+    let invalid_flags = flags - VALID_FLAGS;
+    if !invalid_flags.is_empty() {
+        debug!("invalid flags: {:?}", invalid_flags);
+        return_errno_with_message!(Errno::EINVAL, "unsupported unshare flags");
+    }
+
+    if flags.intersects(CloneFlags::CLONE_THREAD | CloneFlags::CLONE_VM | CloneFlags::CLONE_SIGHAND)
+    {
+        let is_single_threaded = ctx.process.tasks().lock().as_slice().len() == 1;
+        if !is_single_threaded {
+            return_errno_with_message!(Errno::EINVAL, "CLONE_THREAD, CLONE_VM, CLONE_SIGHAND can only be specified for single threaded process");
+        }
+    }
+
+    Ok(())
+}
+
+fn unshare_files(flags: CloneFlags, ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_FILES) {
+        return;
+    }
+
+    let mut pthread_file_table = ctx.posix_thread.file_table().lock();
+
+    let mut thread_local_file_table_ref = ctx.thread_local.borrow_file_table_mut();
+    let thread_local_file_table = thread_local_file_table_ref.unwrap();
+
+    let new_file_table = RwArc::new(thread_local_file_table.read().clone());
+
+    *pthread_file_table = Some(new_file_table.clone_ro());
+    *thread_local_file_table = new_file_table;
+}
+
+fn unshare_fs(flags: CloneFlags, ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_FS) {
+        return;
+    }
+
+    let mut fs_ref = ctx.thread_local.borrow_fs_mut();
+    let new_fs = fs_ref.as_ref().clone();
+    *fs_ref = Arc::new(new_fs);
+}
+
+fn unshare_sysvsem(flags: CloneFlags, _ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_SYSVSEM) {
+        return;
+    }
+
+    warn!("unsharing System V semaphore is not supported");
+}
+
+fn unshare_namespaces(flags: CloneFlags, ctx: &Context) -> Result<()> {
+    if !flags.intersects(CLONE_NS_FLAGS) {
+        return Ok(());
+    }
+
+    let mut pthread_ns_context = ctx.posix_thread.ns_context().lock();
+
+    let mut thread_local_ns_context = ctx.thread_local.borrow_ns_context_mut();
+    let thread_local_ns_context = thread_local_ns_context.unwrap();
+
+    let new_ns_context = NsContext::clone_from(thread_local_ns_context, flags, ctx.posix_thread)?;
+
+    *pthread_ns_context = Some(new_ns_context.clone_ro());
+    *thread_local_ns_context = new_ns_context;
+
+    Ok(())
+}

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -77,7 +77,7 @@ fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
     Ok(())
 }
 
-fn unshare_files(flags: CloneFlags, ctx: &Context) {
+pub(super) fn unshare_files(flags: CloneFlags, ctx: &Context) {
     if !flags.contains(CloneFlags::CLONE_FILES) {
         return;
     }

--- a/test/src/apps/Makefile
+++ b/test/src/apps/Makefile
@@ -30,6 +30,7 @@ TEST_APPS := \
 	itimer \
 	mmap \
 	mongoose \
+	namespace \
 	network \
 	pipe \
 	prctl \

--- a/test/src/apps/namespace/Makefile
+++ b/test/src/apps/namespace/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/src/apps/namespace/setns.c
+++ b/test/src/apps/namespace/setns.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/syscall.h>
+
+#include "../test.h"
+
+FN_TEST(ns_file)
+{
+	const char *ns_path = "/proc/self/ns/user";
+	int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	TEST_SUCC(close(fd_ns));
+
+	char buf[128];
+	ssize_t len;
+	strcpy(buf, "/proc/self/ns/");
+	ssize_t prefix_len = strlen(buf);
+	len = TEST_RES(readlink(ns_path, buf + prefix_len,
+				sizeof(buf) - prefix_len - 1),
+		       strncmp("user:[", buf + prefix_len, 5) == 0);
+	buf[prefix_len + len] = '\0';
+
+	// The following test will fail on Asterinas because it currently permits
+	// lookup of paths intended only for internal kernel use.
+	// TEST_ERRNO(open(buf, O_RDONLY), ENOENT);
+}
+END_TEST()
+
+FN_TEST(set_ns_empty_flags)
+{
+	const char *ns_path = "/proc/self/ns/user";
+	int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	TEST_ERRNO(setns(fd_ns, 0), EINVAL);
+	TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, 0), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_self_ns)
+{
+	// It is not permitted to use setns() to reenter the caller's
+	// current user namespace. This is different from other namespaces.
+	const char *ns_path = "/proc/self/ns/user";
+	int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	TEST_ERRNO(setns(fd_ns, CLONE_NEWUSER), EINVAL);
+	TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, CLONE_NEWUSER), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()

--- a/test/src/apps/namespace/unshare.c
+++ b/test/src/apps/namespace/unshare.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sched.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+
+#include "../test.h"
+
+FN_TEST(invalid_flags)
+{
+	TEST_ERRNO(unshare(CLONE_CHILD_CLEARTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_CHILD_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_DETACHED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_IO), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PIDFD), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PTRACE), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SETTLS), EINVAL);
+	TEST_ERRNO(unshare(CLONE_UNTRACED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_VFORK), EINVAL);
+}
+END_TEST()
+
+void *sleep_1s_thread(void *arg)
+{
+	sleep(1);
+}
+
+FN_TEST(single_thread_flags)
+{
+	TEST_SUCC(unshare(CLONE_VM | CLONE_SIGHAND | CLONE_THREAD));
+
+	pthread_t thread_id;
+	TEST_SUCC(pthread_create(&thread_id, NULL, sleep_1s_thread, NULL));
+
+	TEST_ERRNO(unshare(CLONE_VM), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SIGHAND), EINVAL);
+	TEST_ERRNO(unshare(CLONE_THREAD), EINVAL);
+
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_SUCC(unshare(CLONE_VM));
+	TEST_SUCC(unshare(CLONE_SIGHAND));
+	TEST_SUCC(unshare(CLONE_THREAD));
+}
+END_TEST()
+
+void *unshare_files_thread(void *arg)
+{
+	int test_fd = (int)(intptr_t)arg;
+
+	CHECK(unshare(CLONE_FILES));
+	CHECK(close(test_fd));
+}
+
+FN_TEST(unshare_files)
+{
+	struct stat old_stdin_stat, old_stdout_stat, old_stderr_stat;
+	struct stat new_stdin_stat, new_stdout_stat, new_stderr_stat;
+
+	TEST_SUCC(fstat(STDIN_FILENO, &old_stdin_stat));
+	TEST_SUCC(fstat(STDOUT_FILENO, &old_stdout_stat));
+	TEST_SUCC(fstat(STDERR_FILENO, &old_stderr_stat));
+
+	TEST_SUCC(unshare(CLONE_FILES));
+
+	TEST_RES(fstat(STDIN_FILENO, &new_stdin_stat),
+		 old_stdin_stat.st_ino == new_stdin_stat.st_ino);
+	TEST_RES(fstat(STDOUT_FILENO, &new_stdout_stat),
+		 old_stdout_stat.st_ino == new_stdout_stat.st_ino);
+	TEST_RES(fstat(STDERR_FILENO, &new_stderr_stat),
+		 old_stderr_stat.st_ino == new_stderr_stat.st_ino);
+
+	const char *TEST_FILENAME = "/tmp/unshare_files_test.txt";
+	pthread_t thread_id;
+	struct stat stat1, stat2;
+	int test_fd;
+
+	test_fd = TEST_SUCC(
+		open(TEST_FILENAME, O_CREAT | O_RDWR | O_TRUNC, 0644));
+	TEST_SUCC(fstat(test_fd, &stat1));
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_files_thread,
+				 (void *)(intptr_t)test_fd));
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_RES(fstat(test_fd, &stat2), stat1.st_ino == stat2.st_ino);
+	TEST_SUCC(close(test_fd));
+	TEST_SUCC(unlink(TEST_FILENAME));
+}
+END_TEST()
+
+#define CWD_BUF_SIZE 1024
+#define THREAD_CWD "/tmp"
+
+void *unshare_fs_thread(void *arg)
+{
+	CHECK(unshare(CLONE_FS));
+
+	CHECK(chdir(THREAD_CWD));
+	CHECK(getcwd((char *)arg, CWD_BUF_SIZE));
+}
+
+FN_TEST(unshare_fs)
+{
+	char cwd_buf1[CWD_BUF_SIZE], cwd_buf2[CWD_BUF_SIZE];
+	pthread_t thread_id;
+
+	TEST_RES(getcwd(cwd_buf1, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, THREAD_CWD) != 0);
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_fs_thread,
+				 (void *)cwd_buf2));
+
+	TEST_RES(pthread_join(thread_id, NULL),
+		 strcmp(cwd_buf2, THREAD_CWD) == 0);
+
+	TEST_RES(getcwd(cwd_buf2, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, cwd_buf2) == 0);
+}
+END_TEST()

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,6 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
+namespace/unshare
 process/group_session
 process/job_control
 process/pidfd


### PR DESCRIPTION
This PR introduces the fundamental structures and interfaces related to namespaces. Before implementing any concrete namespaces, we first need to decide where namespaces should be placed and how they will be accessed.

Additionally, this PR includes a dummy user namespace to demonstrate the usage of these APIs. Since it is a placeholder implementation, all operations on the user namespace currently return `EINVAL`. 

The PR consists of 6 commits now:

1. The first commit adds the basic namespace framework.
2. The second commit adds the procfs entries for namespaces.
~3. The third commit moves ThreadFsInfo from PosixThread to ThreadLocal; a separate PR (#2304) has been opened for this change.~
3. The fourth commit adds the unshare syscall.
4. The fifth commit adds the setns syscall.
5. The sixth commit fixes the unshare file table logic in the `close_range` syscall.