### PR TITLE
Move `ThreadFsInfo` from `PosixThread` to `ThreadLocal`

### DIFF
--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -1155,7 +1155,8 @@ impl FsType for OverlayFsType {
             }
         }
 
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
 
         let upper = fs.lookup(&FsPath::new(AT_FDCWD, upper)?)?;
         let lower = lower

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -255,7 +255,7 @@ fn clone_child_task(
     let child_file_table = clone_files(thread_local.borrow_file_table().unwrap(), clone_flags);
 
     // Clone fs
-    let child_fs = clone_fs(posix_thread.fs(), clone_flags);
+    let child_fs = clone_fs(&thread_local.borrow_fs(), clone_flags);
 
     // Clone FPU context
     let child_fpu_context = thread_local.fpu().clone_context();
@@ -339,7 +339,7 @@ fn clone_child_process(
     let child_file_table = clone_files(thread_local.borrow_file_table().unwrap(), clone_flags);
 
     // Clone the filesystem information
-    let child_fs = clone_fs(posix_thread.fs(), clone_flags);
+    let child_fs = clone_fs(&thread_local.borrow_fs(), clone_flags);
 
     // Clone signal dispositions
     let child_sig_dispositions = clone_sighand(process.sig_dispositions(), clone_flags);

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -145,7 +145,6 @@ impl PosixThreadBuilder {
                     name: Mutex::new(thread_name),
                     credentials,
                     file_table: Mutex::new(Some(file_table.clone_ro())),
-                    fs,
                     sig_mask,
                     sig_queues,
                     signalled_waker: SpinLock::new(None),
@@ -169,6 +168,7 @@ impl PosixThreadBuilder {
                 clear_child_tid,
                 root_vmar,
                 file_table,
+                fs,
                 fpu_context,
             );
 

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::{
     events::Observer,
-    fs::{file_table::FileTable, thread_info::ThreadFsInfo},
+    fs::file_table::FileTable,
     prelude::*,
     process::signal::constants::SIGCONT,
     thread::{Thread, Tid},
@@ -56,8 +56,6 @@ pub struct PosixThread {
     // Files
     /// File table
     file_table: Mutex<Option<RoArc<FileTable>>>,
-    /// File system
-    fs: Arc<ThreadFsInfo>,
 
     // Signal
     /// Blocked signals
@@ -101,10 +99,6 @@ impl PosixThread {
 
     pub fn file_table(&self) -> &Mutex<Option<RoArc<FileTable>>> {
         &self.file_table
-    }
-
-    pub fn fs(&self) -> &Arc<ThreadFsInfo> {
-        &self.fs
     }
 
     /// Get the reference to the signal mask of the thread.

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -88,7 +88,8 @@ pub fn do_faccessat(
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         if flags.contains(FaccessatFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -40,7 +40,11 @@ pub fn sys_fchmodat(
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
     dentry.set_mode(InodeMode::from_bits_truncate(mode))?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -78,7 +78,8 @@ pub fn sys_fchownat(
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         if flags.contains(ChownFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/chroot.rs
+++ b/kernel/src/syscall/chroot.rs
@@ -11,7 +11,8 @@ pub fn sys_chroot(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let path = ctx.user_space().read_cstring(path_ptr, MAX_FILENAME_LEN)?;
     debug!("path = {:?}", path);
 
-    let mut fs = ctx.posix_thread.fs().resolver().write();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let mut fs = fs_ref.resolver().write();
     let dentry = {
         let path = path.to_string_lossy();
         if path.is_empty() {

--- a/kernel/src/syscall/getcwd.rs
+++ b/kernel/src/syscall/getcwd.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 
 pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
-    let current = ctx.posix_thread;
-    let dirent = current
-        .fs()
+    let dirent = ctx
+        .thread_local
+        .borrow_fs()
         .resolver()
         .read()
         .lookup(&FsPath::new(AT_FDCWD, "").unwrap())

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -44,7 +44,8 @@ pub fn sys_linkat(
 
         let old_fs_path = FsPath::new(old_dirfd, old_path.as_ref())?;
         let new_fs_path = FsPath::new(new_dirfd, new_path.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         let old_dentry = if flags.contains(LinkFlags::AT_SYMLINK_FOLLOW) {
             fs.lookup(&old_fs_path)?
         } else {

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -39,7 +39,11 @@ pub fn sys_mount(
             return_errno_with_message!(Errno::ENOENT, "dirname is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, dirname.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
 
     if mount_flags.contains(MountFlags::MS_REMOUNT) && mount_flags.contains(MountFlags::MS_BIND) {
@@ -92,7 +96,11 @@ fn do_bind_mount(
             return_errno_with_message!(Errno::ENOENT, "src_name is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, src_name.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
 
     if src_dentry.type_() != InodeType::Dir {
@@ -115,7 +123,11 @@ fn do_move_mount_old(src_name: CString, dst_dentry: Dentry, ctx: &Context) -> Re
             return_errno_with_message!(Errno::ENOENT, "src_name is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, src_name.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
 
     if !src_dentry.is_root_of_mount() {

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -24,13 +24,12 @@ pub fn sys_openat(
         dirfd, path, flags, mode
     );
 
-    let current = ctx.posix_thread;
     let file_handle = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        let mask_mode = mode & !current.fs().umask().read().get();
-        let inode_handle = current
-            .fs()
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let mask_mode = mode & !fs_ref.umask().read().get();
+        let inode_handle = fs_ref
             .resolver()
             .read()
             .open(&fs_path, flags, mask_mode)

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -30,8 +30,8 @@ pub fn sys_readlinkat(
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.posix_thread
-            .fs()
+        ctx.thread_local
+            .borrow_fs()
             .resolver()
             .read()
             .lookup_no_follow(&fs_path)?

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -26,7 +26,8 @@ pub fn sys_renameat(
         old_dirfd, old_path, new_dirfd, new_path
     );
 
-    let fs = ctx.posix_thread.fs().resolver().read();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let fs = fs_ref.resolver().read();
 
     let (old_dir_dentry, old_name) = {
         let old_path = old_path.to_string_lossy();

--- a/kernel/src/syscall/rmdir.rs
+++ b/kernel/src/syscall/rmdir.rs
@@ -31,8 +31,8 @@ pub(super) fn sys_rmdirat(
             return_errno_with_message!(Errno::EBUSY, "is root directory");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.posix_thread
-            .fs()
+        ctx.thread_local
+            .borrow_fs()
             .resolver()
             .read()
             .lookup_dir_and_base_name(&fs_path)?

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -132,7 +132,8 @@ pub(super) fn lookup_dentry_for_xattr<'a>(
         |path: &CString, ctx: &Context, symlink_no_follow: bool| -> Result<Cow<'_, Dentry>> {
             let path = path.to_string_lossy();
             let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
-            let fs = ctx.posix_thread.fs().resolver().read();
+            let fs_ref = ctx.thread_local.borrow_fs();
+            let fs = fs_ref.resolver().read();
             let dentry = if symlink_no_follow {
                 fs.lookup_no_follow(&fs_path)?
             } else {

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -67,7 +67,8 @@ pub fn sys_fstatat(
     let dentry = {
         let filename = filename.to_string_lossy();
         let fs_path = FsPath::new(dirfd, filename.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         if flags.contains(StatFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -18,7 +18,11 @@ pub fn sys_statfs(path_ptr: Vaddr, statfs_buf_ptr: Vaddr, ctx: &Context) -> Resu
     let dentry = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::try_from(path.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
     let statfs = Statfs::from(dentry.fs().sb());
     user_space.write_val(statfs_buf_ptr, &statfs)?;

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -49,7 +49,8 @@ pub fn sys_statx(
     let dentry = {
         let filename = filename.to_string_lossy();
         let fs_path = FsPath::new(dirfd, filename.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         if flags.contains(StatxFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -35,8 +35,8 @@ pub fn sys_symlinkat(
             return_errno_with_message!(Errno::ENOENT, "linkpath is empty");
         }
         let fs_path = FsPath::new(dirfd, linkpath.as_ref())?;
-        ctx.posix_thread
-            .fs()
+        ctx.thread_local
+            .borrow_fs()
             .resolver()
             .read()
             .lookup_dir_and_new_basename(&fs_path, false)?

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -34,7 +34,11 @@ pub fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result<Syscal
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
         let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
     dir_dentry.resize(len as usize)?;
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/umask.rs
+++ b/kernel/src/syscall/umask.rs
@@ -5,6 +5,6 @@ use crate::prelude::*;
 
 pub fn sys_umask(mask: u16, ctx: &Context) -> Result<SyscallReturn> {
     debug!("mask = 0o{:o}", mask);
-    let old_mask = ctx.posix_thread.fs().umask().write().set(mask);
+    let old_mask = ctx.thread_local.borrow_fs().umask().write().set(mask);
     Ok(SyscallReturn::Return(old_mask as _))
 }

--- a/kernel/src/syscall/umount.rs
+++ b/kernel/src/syscall/umount.rs
@@ -21,13 +21,17 @@ pub fn sys_umount(path_addr: Vaddr, flags: u64, ctx: &Context) -> Result<Syscall
     let fs_path = FsPath::new(AT_FDCWD, path.as_ref())?;
 
     let target_dentry = if umount_flags.contains(UmountFlags::UMOUNT_NOFOLLOW) {
-        ctx.posix_thread
-            .fs()
+        ctx.thread_local
+            .borrow_fs()
             .resolver()
             .read()
             .lookup_no_follow(&fs_path)?
     } else {
-        ctx.posix_thread.fs().resolver().read().lookup(&fs_path)?
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup(&fs_path)?
     };
 
     target_dentry.unmount()?;

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -34,8 +34,8 @@ pub fn sys_unlinkat(
             return_errno_with_message!(Errno::EISDIR, "unlink on directory");
         }
         let fs_path = FsPath::new(dirfd, path.as_ref())?;
-        ctx.posix_thread
-            .fs()
+        ctx.thread_local
+            .borrow_fs()
             .resolver()
             .read()
             .lookup_dir_and_base_name(&fs_path)?

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -168,7 +168,8 @@ fn do_utimes(
     let dentry = {
         // Determine the file system path and the corresponding entry
         let fs_path = FsPath::new(dirfd, pathname.as_ref())?;
-        let fs = ctx.posix_thread.fs().resolver().read();
+        let fs_ref = ctx.thread_local.borrow_fs();
+        let fs = fs_ref.resolver().read();
         if flags.contains(UtimensFlags::AT_SYMLINK_NOFOLLOW) {
             fs.lookup_no_follow(&fs_path)?
         } else {


### PR DESCRIPTION
This commit originates from PR #2303. Since it is not related to namespaces and #2303 has become quite large, I propose to split this change into a separate PR for initial review.

This PR moves `ThreadFsInfo` from `PosixThread` to `ThreadLocal`. The main reason is that the unshare syscall allows a thread to isolate its `ThreadFsInfo` from other threads, which requires `ThreadFsInfo` to be mutable. The usage in unshare syscall in #2303 is like

```rust
fn unshare_fs(flags: CloneFlags, ctx: &Context) {
    if !flags.contains(CloneFlags::CLONE_FS) {
        return;
    }

    let mut fs_ref = ctx.thread_local.borrow_fs_mut();
    let new_fs = fs_ref.as_ref().clone();
    *fs_ref = Arc::new(new_fs);
}
```

However, in the current design, `PosixThread` holds a `Arc<ThreadFsInfo>`, which is effectively immutable. Simply wrapping this field with a lock (e.g., changing it to `RwMutex<Arc<ThreadFsInfo>>`) would introduce additional overhead and complexity, especially because the fields inside `ThreadFsInfo` already contain their own locks.

Fortunately, at present, we only need to access `ThreadFsInfo` for the current thread. This allows us to move `ThreadFsInfo` to `ThreadLocal`, making it mutable without sacrificing much efficiency. If in the future we need to access `ThreadFsInfo` from threads other than the current one, we may need to reconsider and refactor the structure of `ThreadFsInfo`.