### PR TITLE
Implement fallible atomics and fix atomic mode breaks for futex operations (e.g., `FUTEX_WAKE_OP`)

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -7,7 +7,7 @@ use core::{cell::Ref, mem};
 use aster_rights::Full;
 use ostd::{
     mm::{Fallible, Infallible, VmReader, VmWriter, MAX_USERSPACE_VADDR},
-    task::{CurrentTask, Task},
+    task::Task,
 };
 
 use crate::{
@@ -50,8 +50,13 @@ pub struct CurrentUserSpace<'a>(Ref<'a, Option<Vmar<Full>>>);
 #[macro_export]
 macro_rules! current_userspace {
     () => {{
-        use $crate::context::CurrentUserSpace;
-        CurrentUserSpace::new(&ostd::task::Task::current().unwrap())
+        use $crate::{context::CurrentUserSpace, process::posix_thread::AsThreadLocal};
+        CurrentUserSpace::new(
+            ostd::task::Task::current()
+                .unwrap()
+                .as_thread_local()
+                .unwrap(),
+        )
     }};
 }
 
@@ -62,8 +67,7 @@ impl<'a> CurrentUserSpace<'a> {
     ///
     /// Otherwise, you can use the `current_userspace` macro
     /// to obtain an instance of `CurrentUserSpace` if it will only be used once.
-    pub fn new(current_task: &'a CurrentTask) -> Self {
-        let thread_local = current_task.as_thread_local().unwrap();
+    pub fn new(thread_local: &'a ThreadLocal) -> Self {
         let vmar_ref = thread_local.root_vmar().borrow();
         Self(vmar_ref)
     }

--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -153,6 +153,42 @@ impl<'a> CurrentUserSpace<'a> {
         Ok(user_writer.write_val(val)?)
     }
 
+    /// Atomically loads a 32-bit unsigned integer.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vaddr` is not aligned on a 4-byte boundary.
+    pub fn atomic_load(&self, vaddr: Vaddr) -> Result<u32> {
+        check_vaddr(vaddr)?;
+
+        let user_reader = self.reader(vaddr, core::mem::size_of::<u32>())?;
+        Ok(user_reader.atomic_load()?)
+    }
+
+    /// Atomically updates a 32-bit unsigned integer.
+    ///
+    /// This method internally uses an atomic compare-and-exchange operation.If the value changes
+    /// concurrently, this method will retry so the operation may be performed multiple times.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `vaddr` is not aligned on a 4-byte boundary.
+    pub fn atomic_update<F>(&self, vaddr: Vaddr, op: F) -> Result<u32>
+    where
+        F: Fn(u32) -> u32,
+    {
+        check_vaddr(vaddr)?;
+
+        let user_reader = self.reader(vaddr, core::mem::size_of::<u32>())?;
+        let mut user_writer = self.writer(vaddr, core::mem::size_of::<u32>())?;
+        loop {
+            match user_writer.atomic_update(&user_reader, &op)? {
+                (old_val, true) => return Ok(old_val),
+                (_, false) => continue,
+            }
+        }
+    }
+
     /// Reads a C string from the user space of the current process.
     /// The length of the string should not exceed `max_len`,
     /// including the final `\0` byte.
@@ -320,7 +356,7 @@ fn check_vaddr(va: Vaddr) -> Result<()> {
     if va < crate::vm::vmar::ROOT_VMAR_LOWEST_ADDR {
         Err(Error::with_message(
             Errno::EFAULT,
-            "Bad user space pointer specified",
+            "the userspace address is too small",
         ))
     } else {
         Ok(())

--- a/kernel/src/fs/ext2/xattr.rs
+++ b/kernel/src/fs/ext2/xattr.rs
@@ -314,10 +314,9 @@ impl Xattr {
         let len = entry.total_len();
         self.blocks_buf
             .writer()
-            .to_fallible()
             .skip(offset)
             .limit(len)
-            .fill_zeros(len)?;
+            .fill_zeros(len);
 
         let mut cache = cache.upgrade();
         let _ = cache.entries.remove(&offset);

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -497,11 +497,7 @@ impl RamInode {
 impl PageCacheBackend for RamInode {
     fn read_page_async(&self, _idx: usize, frame: &CachePage) -> Result<BioWaiter> {
         // Initially, any block/page in a RamFs inode contains all zeros
-        frame
-            .writer()
-            .to_fallible()
-            .fill_zeros(frame.size())
-            .unwrap();
+        frame.writer().fill_zeros(frame.size());
         Ok(BioWaiter::new())
     }
 

--- a/kernel/src/fs/utils/page_cache.rs
+++ b/kernel/src/fs/utils/page_cache.rs
@@ -3,7 +3,6 @@
 #![expect(dead_code)]
 
 use core::{
-    iter,
     ops::Range,
     sync::atomic::{AtomicU8, Ordering},
 };
@@ -101,21 +100,18 @@ impl PageCache {
         let first_page_end = start.align_up(PAGE_SIZE);
         if first_page_end > start {
             let zero_len = first_page_end.min(end) - start;
-            self.pages()
-                .write_vals(start, iter::repeat_n(&0, zero_len), 0)?;
+            self.pages().fill_zeros(start, zero_len)?;
         }
 
         // Write zeros to the last partial page if any
         let last_page_start = end.align_down(PAGE_SIZE);
         if last_page_start < end && last_page_start >= start {
             let zero_len = end - last_page_start;
-            self.pages()
-                .write_vals(last_page_start, iter::repeat_n(&0, zero_len), 0)?;
+            self.pages().fill_zeros(last_page_start, zero_len)?;
         }
 
         for offset in (first_page_end..last_page_start).step_by(PAGE_SIZE) {
-            self.pages()
-                .write_vals(offset, iter::repeat_n(&0, PAGE_SIZE), 0)?;
+            self.pages().fill_zeros(offset, PAGE_SIZE)?;
         }
         Ok(())
     }

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -7,7 +7,13 @@ use ostd::{
 };
 use spin::Once;
 
-use crate::{prelude::*, process::Pid, time::wait::ManagedTimeout};
+use crate::{
+    prelude::*,
+    process::Pid,
+    thread::exception::PageFaultInfo,
+    time::wait::ManagedTimeout,
+    vm::{page_fault_handler::PageFaultHandler, perms::VmPerms},
+};
 
 type FutexBitSet = u32;
 
@@ -55,19 +61,49 @@ pub fn futex_wait_bitset(
     let (futex_item, waiter) = FutexItem::create(futex_key);
 
     let (_, futex_bucket_ref) = get_futex_bucket(futex_key);
-    // lock futex bucket ref here to avoid data race
-    let mut futex_bucket = futex_bucket_ref.lock();
 
-    if !futex_key.load_val(ctx).is_ok_and(|val| val == futex_val) {
+    let user_space = ctx.user_space();
+
+    let (mut futex_bucket, val) = loop {
+        // Lock the futex bucket first to avoid race conditions.
+        let futex_bucket = futex_bucket_ref.lock();
+
+        let guard = ctx.thread_local.disable_page_fault();
+        let result = user_space.atomic_load(futex_key.addr());
+        drop(guard);
+
+        match result {
+            Err(err) if err.error() == Errno::EFAULT => (),
+            _ => break (futex_bucket, result?),
+        }
+
+        drop(futex_bucket);
+
+        // The futex word is aligned on a 4-byte boundary, so it cannot cross the page boundary.
+        user_space
+            .root_vmar()
+            .handle_page_fault(&PageFaultInfo {
+                address: futex_key.addr(),
+                required_perms: VmPerms::READ,
+            })
+            .map_err(|_| {
+                Error::with_message(
+                    Errno::EFAULT,
+                    "the page fault of the futex word cannot be resolved",
+                )
+            })?;
+    };
+
+    if val != futex_val.cast_unsigned() {
         return_errno_with_message!(
             Errno::EAGAIN,
-            "futex value does not match or load_val failed"
+            "the futex word does not contain the expected value"
         );
     }
 
     futex_bucket.add_item(futex_item);
 
-    // drop lock
+    // Release the lock.
     drop(futex_bucket);
 
     let result = waiter.pause_timeout(&timeout.into());
@@ -243,24 +279,50 @@ pub fn futex_wake_op(
     let (index_1, futex_bucket_ref_1) = get_futex_bucket(futex_key_1);
     let (index_2, futex_bucket_ref_2) = get_futex_bucket(futex_key_2);
 
-    let (mut futex_bucket_1, mut futex_bucket_2) = if index_1 == index_2 {
-        (futex_bucket_ref_1.lock(), None)
-    } else {
-        // Ensure that we always lock the buckets in a consistent order to avoid deadlocks.
-        if index_1 < index_2 {
-            let bucket_1 = futex_bucket_ref_1.lock();
-            let bucket_2 = futex_bucket_ref_2.lock();
-            (bucket_1, Some(bucket_2))
-        } else {
-            let bucket_2 = futex_bucket_ref_2.lock();
-            let bucket_1 = futex_bucket_ref_1.lock();
-            (bucket_1, Some(bucket_2))
-        }
-    };
+    let user_space = ctx.user_space();
 
-    let old_val = ctx
-        .user_space()
-        .atomic_update(futex_addr_2, |val| wake_op.calculate_new_val(val))?;
+    let (mut futex_bucket_1, mut futex_bucket_2, old_val) = loop {
+        let (futex_bucket_1, futex_bucket_2) = if index_1 == index_2 {
+            (futex_bucket_ref_1.lock(), None)
+        } else {
+            // Ensure that we always lock the buckets in a consistent order to avoid deadlocks.
+            if index_1 < index_2 {
+                let bucket_1 = futex_bucket_ref_1.lock();
+                let bucket_2 = futex_bucket_ref_2.lock();
+                (bucket_1, Some(bucket_2))
+            } else {
+                let bucket_2 = futex_bucket_ref_2.lock();
+                let bucket_1 = futex_bucket_ref_1.lock();
+                (bucket_1, Some(bucket_2))
+            }
+        };
+
+        let guard = ctx.thread_local.disable_page_fault();
+        let result = user_space.atomic_update(futex_addr_2, |val| wake_op.calculate_new_val(val));
+        drop(guard);
+
+        match result {
+            Err(err) if err.error() == Errno::EFAULT => (),
+            _ => break (futex_bucket_1, futex_bucket_2, result?),
+        }
+
+        drop(futex_bucket_1);
+        drop(futex_bucket_2);
+
+        // The futex word is aligned on a 4-byte boundary, so it cannot cross the page boundary.
+        user_space
+            .root_vmar()
+            .handle_page_fault(&PageFaultInfo {
+                address: futex_addr_2,
+                required_perms: VmPerms::READ | VmPerms::WRITE,
+            })
+            .map_err(|_| {
+                Error::with_message(
+                    Errno::EFAULT,
+                    "the page fault of the futex word cannot be resolved",
+                )
+            })?;
+    };
 
     let mut res = futex_bucket_1.remove_and_wake_items(futex_key_1, max_count_1);
     if wake_op.should_wake(old_val) {
@@ -483,10 +545,6 @@ impl FutexKey {
         }
 
         Ok(Self { addr, bitset, pid })
-    }
-
-    pub fn load_val(&self, ctx: &Context) -> Result<i32> {
-        Ok(ctx.user_space().atomic_load(self.addr)?.cast_signed())
     }
 
     pub fn addr(&self) -> Vaddr {

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -51,7 +51,7 @@ pub fn futex_wait_bitset(
         return_errno_with_message!(Errno::EINVAL, "at least one bit should be set");
     }
 
-    let futex_key = FutexKey::new(futex_addr, bitset, pid);
+    let futex_key = FutexKey::new(futex_addr, bitset, pid)?;
     let (futex_item, waiter) = FutexItem::create(futex_key);
 
     let (_, futex_bucket_ref) = get_futex_bucket(futex_key);
@@ -110,7 +110,7 @@ pub fn futex_wake_bitset(
         return_errno_with_message!(Errno::EINVAL, "at least one bit should be set");
     }
 
-    let futex_key = FutexKey::new(futex_addr, bitset, pid);
+    let futex_key = FutexKey::new(futex_addr, bitset, pid)?;
     let (_, futex_bucket_ref) = get_futex_bucket(futex_key);
     let mut futex_bucket = futex_bucket_ref.lock();
     let res = futex_bucket.remove_and_wake_items(futex_key, max_count);
@@ -238,8 +238,8 @@ pub fn futex_wake_op(
 ) -> Result<usize> {
     let wake_op = FutexWakeOpEncode::from_u32(wake_op_bits)?;
 
-    let futex_key_1 = FutexKey::new(futex_addr_1, FUTEX_BITSET_MATCH_ANY, pid);
-    let futex_key_2 = FutexKey::new(futex_addr_2, FUTEX_BITSET_MATCH_ANY, pid);
+    let futex_key_1 = FutexKey::new(futex_addr_1, FUTEX_BITSET_MATCH_ANY, pid)?;
+    let futex_key_2 = FutexKey::new(futex_addr_2, FUTEX_BITSET_MATCH_ANY, pid)?;
     let (index_1, futex_bucket_ref_1) = get_futex_bucket(futex_key_1);
     let (index_2, futex_bucket_ref_2) = get_futex_bucket(futex_key_2);
 
@@ -258,10 +258,9 @@ pub fn futex_wake_op(
         }
     };
 
-    // FIXME: This should be an atomic read-modify-write memory access here.
-    let old_val = ctx.user_space().read_val(futex_addr_2)?;
-    let new_val = wake_op.calculate_new_val(old_val);
-    ctx.user_space().write_val(futex_addr_2, &new_val)?;
+    let old_val = ctx
+        .user_space()
+        .atomic_update(futex_addr_2, |val| wake_op.calculate_new_val(val))?;
 
     let mut res = futex_bucket_1.remove_and_wake_items(futex_key_1, max_count_1);
     if wake_op.should_wake(old_val) {
@@ -284,8 +283,8 @@ pub fn futex_requeue(
         return futex_wake(futex_addr, max_nwakes, pid);
     }
 
-    let futex_key = FutexKey::new(futex_addr, FUTEX_BITSET_MATCH_ANY, pid);
-    let futex_new_key = FutexKey::new(futex_new_addr, FUTEX_BITSET_MATCH_ANY, pid);
+    let futex_key = FutexKey::new(futex_addr, FUTEX_BITSET_MATCH_ANY, pid)?;
+    let futex_new_key = FutexKey::new(futex_new_addr, FUTEX_BITSET_MATCH_ANY, pid)?;
     let (bucket_idx, futex_bucket_ref) = get_futex_bucket(futex_key);
     let (new_bucket_idx, futex_new_bucket_ref) = get_futex_bucket(futex_new_key);
 
@@ -472,14 +471,22 @@ struct FutexKey {
 }
 
 impl FutexKey {
-    pub fn new(addr: Vaddr, bitset: FutexBitSet, pid: Option<Pid>) -> Self {
-        Self { addr, bitset, pid }
+    pub fn new(addr: Vaddr, bitset: FutexBitSet, pid: Option<Pid>) -> Result<Self> {
+        // "On all platforms, futexes are four-byte integers that must be aligned on a four-byte
+        // boundary."
+        // Reference: <https://man7.org/linux/man-pages/man2/futex.2.html>.
+        if addr % core::mem::align_of::<u32>() != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the futex word is not aligend on a four-byte boundary"
+            );
+        }
+
+        Ok(Self { addr, bitset, pid })
     }
 
     pub fn load_val(&self, ctx: &Context) -> Result<i32> {
-        // FIXME: how to implement a atomic load?
-        warn!("implement an atomic load");
-        ctx.user_space().read_val(self.addr)
+        Ok(ctx.user_space().atomic_load(self.addr)?.cast_signed())
     }
 
     pub fn addr(&self) -> Vaddr {

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -128,7 +128,7 @@ const FUTEX_TID_MASK: u32 = 0x3FFF_FFFF;
 /// FIXME: requires atomic operations here
 pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
     let task = Task::current().unwrap();
-    let user_space = CurrentUserSpace::new(&task);
+    let user_space = CurrentUserSpace::new(task.as_thread_local().unwrap());
 
     let futex_val = {
         if futex_addr == 0 {

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -17,6 +17,7 @@ pub struct ThreadLocal {
 
     // Virtual memory address regions.
     root_vmar: RefCell<Option<Vmar<Full>>>,
+    page_fault_disabled: Cell<u32>,
 
     // Robust futexes.
     // https://man7.org/linux/man-pages/man2/get_robust_list.2.html
@@ -50,6 +51,7 @@ impl ThreadLocal {
             set_child_tid: Cell::new(set_child_tid),
             clear_child_tid: Cell::new(clear_child_tid),
             root_vmar: RefCell::new(Some(root_vmar)),
+            page_fault_disabled: Cell::new(0),
             robust_list: RefCell::new(None),
             file_table: RefCell::new(Some(file_table)),
             sig_context: Cell::new(None),
@@ -69,6 +71,16 @@ impl ThreadLocal {
 
     pub fn root_vmar(&self) -> &RefCell<Option<Vmar<Full>>> {
         &self.root_vmar
+    }
+
+    pub fn disable_page_fault(&self) -> DisabledPageFaultGuard {
+        self.page_fault_disabled
+            .set(self.page_fault_disabled.get() + 1);
+        DisabledPageFaultGuard(self)
+    }
+
+    pub fn is_page_fault_disabled(&self) -> bool {
+        self.page_fault_disabled.get() != 0
     }
 
     pub fn robust_list(&self) -> &RefCell<Option<RobustListHead>> {
@@ -93,6 +105,30 @@ impl ThreadLocal {
 
     pub fn fpu(&self) -> ThreadFpu<'_> {
         ThreadFpu(self)
+    }
+}
+
+/// A guard that disables the page fault handler.
+///
+/// When page faults occur, the handler may attempt to load the page from the disk, which can break
+/// the atomic mode. By holding this guard, the page fault handler will fail immediately, so
+/// fallible memory operation will return [`Errno::EFAULT`] once it triggers a page fault.
+///
+/// Usually, we should _not_ try to access the userspace memory while being in the atomic mode
+/// (e.g., when holding a spin lock). If we must do so, this guard is a last resort that disables
+/// the handler instead. Note that this guard alters the semantics of the fallible memory
+/// operation. This means that it is the caller's responsibility to exit the atomic mode, handle
+/// the page fault, and retry when encountering a [`Errno::EFAULT`]. Do _not_ use this guard
+/// without adding code that explicitly handles the page fault!
+///
+/// This guard can be obtained from [`ThreadLocal::disable_page_fault`].
+pub struct DisabledPageFaultGuard<'a>(&'a ThreadLocal);
+
+impl Drop for DisabledPageFaultGuard<'_> {
+    fn drop(&mut self) {
+        self.0
+            .page_fault_disabled
+            .set(self.0.page_fault_disabled.get() - 1);
     }
 }
 

--- a/kernel/src/thread/exception.rs
+++ b/kernel/src/thread/exception.rs
@@ -9,10 +9,9 @@ use ostd::cpu::context::CpuException;
 use ostd::cpu::context::CpuExceptionInfo as CpuException;
 #[cfg(target_arch = "loongarch64")]
 use ostd::cpu::context::CpuExceptionInfo as CpuException;
-use ostd::cpu::context::UserContext;
+use ostd::{cpu::context::UserContext, task::Task};
 
 use crate::{
-    current_userspace,
     prelude::*,
     process::signal::signals::fault::FaultSignal,
     vm::{page_fault_handler::PageFaultHandler, perms::VmPerms, vmar::Vmar},
@@ -69,5 +68,15 @@ fn generate_fault_signal(exception: CpuException, ctx: &Context) {
 }
 
 pub(super) fn page_fault_handler(info: &CpuException) -> core::result::Result<(), ()> {
-    handle_page_fault_from_vmar(current_userspace!().root_vmar(), &info.try_into().unwrap())
+    let task = Task::current().unwrap();
+    let thread_local = task.as_thread_local().unwrap();
+
+    if thread_local.is_page_fault_disabled() {
+        // Do nothing if the page fault handler is disabled. This will typically cause the fallible
+        // memory operation to report `EFAULT` errors immediately.
+        return Err(());
+    }
+
+    let user_space = CurrentUserSpace::new(thread_local);
+    handle_page_fault_from_vmar(user_space.root_vmar(), &info.try_into().unwrap())
 }

--- a/kernel/src/util/net/addr/family.rs
+++ b/kernel/src/util/net/addr/family.rs
@@ -209,7 +209,7 @@ pub fn write_socket_addr_to_user(
     max_len_ptr: Vaddr,
 ) -> Result<()> {
     let current_task = Task::current().unwrap();
-    let user_space = CurrentUserSpace::new(&current_task);
+    let user_space = CurrentUserSpace::new(current_task.as_thread_local().unwrap());
 
     let max_len = user_space.read_val::<i32>(max_len_ptr)?;
 

--- a/kernel/src/vm/vmo/dyn_cap.rs
+++ b/kernel/src/vm/vmo/dyn_cap.rs
@@ -141,7 +141,7 @@ impl VmIo for Vmo<Rights> {
         self.0.write(offset, reader)?;
         Ok(())
     }
-    // TODO: Support efficient `write_vals()`
+    // TODO: Support efficient `fill_zeros()`
 }
 
 impl VmoRightsOp for Vmo<Rights> {

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -302,13 +302,25 @@ pub(in crate::arch) fn paddr_to_daddr(pa: Paddr) -> usize {
 }
 
 pub(crate) unsafe fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize {
-    // TODO: implement fallible
+    // TODO: Implement this fallible operation.
     unsafe { core::ptr::copy(src, dst, size) };
     0
 }
 
 pub(crate) unsafe fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize {
-    // TODO: implement fallible
+    // TODO: Implement this fallible operation.
     unsafe { core::ptr::write_bytes(dst, value, size) };
     0
+}
+
+pub(crate) unsafe fn __atomic_load_fallible(ptr: *const u32) -> u64 {
+    // TODO: Implement this fallible operation.
+    // TODO: How to choose the correct memory order here?
+    unsafe { core::intrinsics::atomic_load_seqcst(ptr) as u64 }
+}
+
+pub(crate) unsafe fn __atomic_cmpxchg_fallible(ptr: *mut u32, old_val: u32, new_val: u32) -> u64 {
+    // TODO: Implement this fallible operation.
+    // TODO: How to choose the correct memory order here?
+    unsafe { core::intrinsics::atomic_cxchg_seqcst_seqcst(ptr, old_val, new_val).0 as u64 }
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -54,7 +54,7 @@ bitflags::bitflags! {
         // Second bit ignored by MMU.
         const RSV2 =            1 << 9;
 
-        // PBMT: Non-cacheable, idempotent, weakly-ordered (RVWMO), main memory
+        // PBMT: Non-cacheable, idempotent, ly-ordered (RVWMO), main memory
         const PBMT_NC =         1 << 61;
         // PBMT: Non-cacheable, non-idempotent, strongly-ordered (I/O ordering), I/O
         const PBMT_IO =         1 << 62;
@@ -223,20 +223,30 @@ impl fmt::Debug for PageTableEntry {
     }
 }
 
-pub(crate) fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize {
-    // TODO: implement fallible
-    unsafe {
-        riscv::register::sstatus::set_sum();
-    }
+pub(crate) unsafe fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize {
+    // TODO: Implement this fallible operation.
+    unsafe { riscv::register::sstatus::set_sum() };
     unsafe { core::ptr::copy(src, dst, size) };
     0
 }
 
-pub(crate) fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize {
-    // TODO: implement fallible
-    unsafe {
-        riscv::register::sstatus::set_sum();
-    }
+pub(crate) unsafe fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize {
+    // TODO: Implement this fallible operation.
+    unsafe { riscv::register::sstatus::set_sum() };
     unsafe { core::ptr::write_bytes(dst, value, size) };
     0
+}
+
+pub(crate) unsafe fn __atomic_load_fallible(ptr: *const u32) -> u64 {
+    // TODO: Implement this fallible operation.
+    unsafe { riscv::register::sstatus::set_sum() };
+    // TODO: How to choose the correct memory order here?
+    unsafe { core::intrinsics::atomic_load_seqcst(ptr) as u64 }
+}
+
+pub(crate) unsafe fn __atomic_cmpxchg_fallible(ptr: *mut u32, old_val: u32, new_val: u32) -> u64 {
+    // TODO: Implement this fallible operation.
+    unsafe { riscv::register::sstatus::set_sum() };
+    // TODO: How to choose the correct memory order here?
+    unsafe { core::intrinsics::atomic_cxchg_seqcst_seqcst(ptr, old_val, new_val).0 as u64 }
 }

--- a/ostd/src/arch/x86/mm/atomic_cmpxchg_fallible.S
+++ b/ostd/src/arch/x86/mm/atomic_cmpxchg_fallible.S
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/// Atomically compares and exchanges a 32-bit integer value. This function works with
+/// exception handling and can recover from a page fault.
+///
+/// Returns the previous value or `!0` if failed to update.
+.text
+.global __atomic_cmpxchg_fallible
+.code64
+__atomic_cmpxchg_fallible: # (ptr: *mut u32, old_val: u32, new_val: u32) -> u64
+    mov eax, esi
+.cmpxchg:
+    lock; cmpxchg [rdi], edx
+    ret
+.cmpxchg_fault:
+    mov rax, -1
+    ret
+
+.pushsection .ex_table, "a"
+    .align 8
+    .quad [.cmpxchg]
+    .quad [.cmpxchg_fault]
+.popsection

--- a/ostd/src/arch/x86/mm/atomic_load_fallible.S
+++ b/ostd/src/arch/x86/mm/atomic_load_fallible.S
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/// Atomically loads a 32-bit integer value. This function works with exception handling
+/// and can recover from a page fault.
+///
+/// Returns the loaded value or `!0` if failed to load.
+.text
+.global __atomic_load_fallible
+.code64
+__atomic_load_fallible: # (ptr: *const u32) -> u64;
+.load:
+    mov eax, [rdi]
+    ret
+.load_fault:
+    mov rax, -1
+    ret
+
+.pushsection .ex_table, "a"
+    .align 8
+    .quad [.load]
+    .quad [.load_fault]
+.popsection

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -6,7 +6,9 @@ use alloc::fmt;
 use core::ops::Range;
 
 use cfg_if::cfg_if;
-pub(crate) use util::{__memcpy_fallible, __memset_fallible};
+pub(crate) use util::{
+    __atomic_cmpxchg_fallible, __atomic_load_fallible, __memcpy_fallible, __memset_fallible,
+};
 use x86_64::{instructions::tlb, structures::paging::PhysFrame, VirtAddr};
 
 use crate::{

--- a/ostd/src/arch/x86/mm/util.rs
+++ b/ostd/src/arch/x86/mm/util.rs
@@ -3,6 +3,9 @@
 core::arch::global_asm!(include_str!("memcpy_fallible.S"));
 core::arch::global_asm!(include_str!("memset_fallible.S"));
 
+core::arch::global_asm!(include_str!("atomic_load_fallible.S"));
+core::arch::global_asm!(include_str!("atomic_cmpxchg_fallible.S"));
+
 extern "C" {
     /// Copies `size` bytes from `src` to `dst`. This function works with exception handling
     /// and can recover from page fault.
@@ -12,4 +15,13 @@ extern "C" {
     /// This function works with exception handling and can recover from page fault.
     /// Returns number of bytes that failed to set.
     pub(crate) fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize;
+
+    /// Atomically loads a 32-bit integer value. This function works with exception handling
+    /// and can recover from page fault.
+    /// Returns the loaded value or `!0` if failed to load.
+    pub(crate) fn __atomic_load_fallible(ptr: *const u32) -> u64;
+    /// Atomically compares and exchanges a 32-bit integer value. This function works with
+    /// exception handling and can recover from page fault.
+    /// Returns the previous value or `!0` if failed to update.
+    pub(crate) fn __atomic_cmpxchg_fallible(ptr: *mut u32, old_val: u32, new_val: u32) -> u64;
 }

--- a/ostd/src/io/io_mem/mod.rs
+++ b/ostd/src/io/io_mem/mod.rs
@@ -12,10 +12,10 @@ pub(super) use self::allocator::init;
 pub(crate) use self::allocator::IoMemAllocatorBuilder;
 use crate::{
     mm::{
+        io_util,
         kspace::kvirt_area::KVirtArea,
         page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
-        FallibleVmRead, FallibleVmWrite, HasPaddr, Infallible, Paddr, PodOnce, VmIo, VmIoOnce,
-        VmReader, VmWriter, PAGE_SIZE,
+        HasPaddr, Infallible, Paddr, VmReader, VmWriter, PAGE_SIZE,
     },
     prelude::*,
     Error,
@@ -167,55 +167,17 @@ impl IoMem {
     }
 }
 
-impl VmIo for IoMem {
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
-        let offset = offset + self.offset;
-        if self
-            .limit
-            .checked_sub(offset)
-            .is_none_or(|remain| remain < writer.avail())
-        {
-            return Err(Error::InvalidArgs);
-        }
-
-        self.reader()
-            .skip(offset)
-            .read_fallible(writer)
-            .map_err(|(e, _)| e)?;
-        debug_assert!(!writer.has_avail());
-
-        Ok(())
+impl io_util::VmIoByReaderWriter for IoMem {
+    fn io_reader(&self) -> Result<VmReader<Infallible>> {
+        Ok(self.reader())
     }
 
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
-        let offset = offset + self.offset;
-        if self
-            .limit
-            .checked_sub(offset)
-            .is_none_or(|remain| remain < reader.remain())
-        {
-            return Err(Error::InvalidArgs);
-        }
-
-        self.writer()
-            .skip(offset)
-            .write_fallible(reader)
-            .map_err(|(e, _)| e)?;
-        debug_assert!(!reader.has_remain());
-
-        Ok(())
+    fn io_writer(&self) -> Result<VmWriter<Infallible>> {
+        Ok(self.writer())
     }
 }
 
-impl VmIoOnce for IoMem {
-    fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T> {
-        self.reader().skip(offset).read_once()
-    }
-
-    fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()> {
-        self.writer().skip(offset).write_once(new_val)
-    }
-}
+impl io_util::VmIoOnceByReaderWriter for IoMem {}
 
 impl Drop for IoMem {
     fn drop(&mut self) {

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -10,11 +10,10 @@ use crate::{
     arch::iommu,
     mm::{
         dma::{dma_type, Daddr, DmaType},
-        io::VmIoOnce,
+        io_util,
         kspace::{paddr_to_vaddr, KERNEL_PAGE_TABLE},
         page_prop::CachePolicy,
-        HasPaddr, Infallible, Paddr, PodOnce, USegment, UntypedMem, VmIo, VmReader, VmWriter,
-        PAGE_SIZE,
+        HasPaddr, Infallible, Paddr, USegment, UntypedMem, VmReader, VmWriter, PAGE_SIZE,
     },
     prelude::*,
 };
@@ -176,25 +175,17 @@ impl Drop for DmaCoherentInner {
     }
 }
 
-impl VmIo for DmaCoherent {
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
-        self.inner.segment.read(offset, writer)
+impl io_util::VmIoByReaderWriter for DmaCoherent {
+    fn io_reader(&self) -> Result<VmReader<Infallible>> {
+        Ok(self.inner.segment.reader())
     }
 
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
-        self.inner.segment.write(offset, reader)
+    fn io_writer(&self) -> Result<VmWriter<Infallible>> {
+        Ok(self.inner.segment.writer())
     }
 }
 
-impl VmIoOnce for DmaCoherent {
-    fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T> {
-        self.inner.segment.reader().skip(offset).read_once()
-    }
-
-    fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()> {
-        self.inner.segment.writer().skip(offset).write_once(new_val)
-    }
-}
+impl io_util::VmIoOnceByReaderWriter for DmaCoherent {}
 
 impl<'a> DmaCoherent {
     /// Returns a reader to read data from it.

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -9,7 +9,7 @@ use crate::{
     error::Error,
     mm::{
         dma::{dma_type, Daddr, DmaType},
-        HasPaddr, Infallible, Paddr, USegment, UntypedMem, VmIo, VmReader, VmWriter, PAGE_SIZE,
+        io_util, HasPaddr, Infallible, Paddr, USegment, UntypedMem, VmReader, VmWriter, PAGE_SIZE,
     },
 };
 
@@ -135,8 +135,8 @@ impl DmaStream {
     ///    (e.g., using [`write_bytes`]).
     ///    Before the CPU side notifies the device side to read, it must call the `sync` method first.
     ///
-    /// [`read_bytes`]: Self::read_bytes
-    /// [`write_bytes`]: Self::write_bytes
+    /// [`read_bytes`]: crate::mm::VmIo::read_bytes
+    /// [`write_bytes`]: crate::mm::VmIo::write_bytes
     pub fn sync(&self, _byte_range: Range<usize>) -> Result<(), Error> {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")]{
@@ -203,21 +203,13 @@ impl Drop for DmaStreamInner {
     }
 }
 
-impl VmIo for DmaStream {
-    /// Reads data into the buffer.
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<(), Error> {
-        if self.inner.direction == DmaDirection::ToDevice {
-            return Err(Error::AccessDenied);
-        }
-        self.inner.segment.read(offset, writer)
+impl io_util::VmIoByReaderWriter for DmaStream {
+    fn io_reader(&self) -> Result<VmReader<Infallible>, Error> {
+        self.reader()
     }
 
-    /// Writes data from the buffer.
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<(), Error> {
-        if self.inner.direction == DmaDirection::FromDevice {
-            return Err(Error::AccessDenied);
-        }
-        self.inner.segment.write(offset, reader)
+    fn io_writer(&self) -> Result<VmWriter<Infallible>, Error> {
+        self.writer()
     }
 }
 
@@ -316,19 +308,13 @@ impl<Dma: AsRef<DmaStream>> DmaStreamSlice<Dma> {
     }
 }
 
-impl<Dma: AsRef<DmaStream> + Send + Sync> VmIo for DmaStreamSlice<Dma> {
-    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<(), Error> {
-        if writer.avail() + offset > self.len {
-            return Err(Error::InvalidArgs);
-        }
-        self.stream.as_ref().read(self.offset + offset, writer)
+impl<Dma: AsRef<DmaStream> + Send + Sync> io_util::VmIoByReaderWriter for DmaStreamSlice<Dma> {
+    fn io_reader(&self) -> Result<VmReader<Infallible>, Error> {
+        self.reader()
     }
 
-    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<(), Error> {
-        if reader.remain() + offset > self.len {
-            return Err(Error::InvalidArgs);
-        }
-        self.stream.as_ref().write(self.offset + offset, reader)
+    fn io_writer(&self) -> Result<VmWriter<Infallible>, Error> {
+        self.writer()
     }
 }
 

--- a/ostd/src/mm/frame/untyped.rs
+++ b/ostd/src/mm/frame/untyped.rs
@@ -6,14 +6,16 @@
 //! relaxed rules but we cannot create references to them. This module provides
 //! the declaration of untyped frames and segments, and the implementation of
 //! extra functionalities (such as [`VmIo`]) for them.
+//!
+//! [`VmIo`]: crate::mm::VmIo
 
 use super::{meta::AnyFrameMeta, Frame, Segment};
 use crate::{
     mm::{
-        io::{FallibleVmRead, FallibleVmWrite, VmIo, VmReader, VmWriter},
-        paddr_to_vaddr, Infallible,
+        io::{VmReader, VmWriter},
+        io_util, paddr_to_vaddr, Infallible,
     },
-    Error, Result,
+    Result,
 };
 
 /// The metadata of untyped frame.
@@ -82,48 +84,30 @@ macro_rules! impl_untyped_for {
         impl<UM: AnyUFrameMeta + ?Sized> UntypedMem for $t<UM> {
             fn reader(&self) -> VmReader<'_, Infallible> {
                 let ptr = paddr_to_vaddr(self.start_paddr()) as *const u8;
-                // SAFETY: Only untyped frames are allowed to be read.
+                // SAFETY:
+                // - The memory range points to untyped memory.
+                // - The frame/segment is alive during the lifetime `'_`.
+                // - Using `VmReader` and `VmWriter` is the only way to access the frame/segment.
                 unsafe { VmReader::from_kernel_space(ptr, self.size()) }
             }
 
             fn writer(&self) -> VmWriter<'_, Infallible> {
                 let ptr = paddr_to_vaddr(self.start_paddr()) as *mut u8;
-                // SAFETY: Only untyped frames are allowed to be written.
+                // SAFETY:
+                // - The memory range points to untyped memory.
+                // - The frame/segment is alive during the lifetime `'_`.
+                // - Using `VmReader` and `VmWriter` is the only way to access the frame/segment.
                 unsafe { VmWriter::from_kernel_space(ptr, self.size()) }
             }
         }
 
-        impl<UM: AnyUFrameMeta + ?Sized> VmIo for $t<UM> {
-            fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
-                let read_len = writer.avail().min(self.size().saturating_sub(offset));
-                // Do bound check with potential integer overflow in mind
-                let max_offset = offset.checked_add(read_len).ok_or(Error::Overflow)?;
-                if max_offset > self.size() {
-                    return Err(Error::InvalidArgs);
-                }
-                let len = self
-                    .reader()
-                    .skip(offset)
-                    .read_fallible(writer)
-                    .map_err(|(e, _)| e)?;
-                debug_assert!(len == read_len);
-                Ok(())
+        impl<UM: AnyUFrameMeta + ?Sized> io_util::VmIoByReaderWriter for $t<UM> {
+            fn io_reader(&self) -> Result<VmReader<Infallible>> {
+                Ok(self.reader())
             }
 
-            fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
-                let write_len = reader.remain().min(self.size().saturating_sub(offset));
-                // Do bound check with potential integer overflow in mind
-                let max_offset = offset.checked_add(write_len).ok_or(Error::Overflow)?;
-                if max_offset > self.size() {
-                    return Err(Error::InvalidArgs);
-                }
-                let len = self
-                    .writer()
-                    .skip(offset)
-                    .write_fallible(reader)
-                    .map_err(|(e, _)| e)?;
-                debug_assert!(len == write_len);
-                Ok(())
+            fn io_writer(&self) -> Result<VmWriter<Infallible>> {
+                Ok(self.writer())
             }
         }
     };

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -610,11 +610,9 @@ impl VmReader<'_, Fallible> {
         let mut writer = VmWriter::from(val.as_bytes_mut());
         self.read_fallible(&mut writer)
             .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes read so far.
+                // The `copied_len` is the number of bytes read so far.
                 // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
+                self.cursor = self.cursor.wrapping_sub(copied_len);
                 err
             })?;
         Ok(val)
@@ -836,11 +834,9 @@ impl VmWriter<'_, Fallible> {
         let mut reader = VmReader::from(new_val.as_bytes());
         self.write_fallible(&mut reader)
             .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes written so far.
+                // The `copied_len` is the number of bytes written so far.
                 // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
+                self.cursor = self.cursor.wrapping_sub(copied_len);
                 err
             })?;
         Ok(())

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -754,36 +754,6 @@ impl<'a> VmWriter<'a, Infallible> {
         Ok(())
     }
 
-    /// Fills the available space by repeating `value`.
-    ///
-    /// Returns the number of values written.
-    ///
-    /// # Panics
-    ///
-    /// The size of the available space must be a multiple of the size of `value`.
-    /// Otherwise, the method would panic.
-    pub fn fill<T: Pod>(&mut self, value: T) -> usize {
-        let cursor = self.cursor.cast::<T>();
-        assert!(cursor.is_aligned());
-
-        let avail = self.avail();
-        assert!(avail % core::mem::size_of::<T>() == 0);
-        let written_num = avail / core::mem::size_of::<T>();
-
-        for i in 0..written_num {
-            let cursor_i = cursor.wrapping_add(i);
-            // SAFETY: `written_num` is calculated by the avail size and the size of the type `T`,
-            // so the `write` operation will only manipulate the memory managed by this writer.
-            // We've checked that the cursor is properly aligned with respect to the type `T`. All
-            // other safety requirements are the same as for `Self::write`.
-            unsafe { cursor_i.write_volatile(value) };
-        }
-
-        // The available space has been filled so this cursor can be moved to the end.
-        self.cursor = self.end;
-        written_num
-    }
-
     /// Converts to a fallible writer.
     pub fn to_fallible(self) -> VmWriter<'a, Fallible> {
         // It is safe to construct a fallible reader since an infallible reader covers the

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -40,7 +40,6 @@
 //! user space, making it impossible to avoid data races). However, they may produce erroneous
 //! results, such as unexpected bytes being copied, but do not cause soundness problems.
 
-use alloc::vec;
 use core::marker::PhantomData;
 
 use align_ext::AlignExt;
@@ -605,25 +604,6 @@ impl VmReader<'_, Fallible> {
                 err
             })?;
         Ok(val)
-    }
-
-    /// Collects all the remaining bytes into a `Vec<u8>`.
-    ///
-    /// If the memory read failed, this method will return `Err`
-    /// and the current reader's cursor remains pointing to
-    /// the original starting position.
-    pub fn collect(&mut self) -> Result<Vec<u8>> {
-        let mut buf = vec![0u8; self.remain()];
-        self.read_fallible(&mut buf.as_mut_slice().into())
-            .map_err(|(err, copied_len)| {
-                // SAFETY: The `copied_len` is the number of bytes read so far.
-                // So the `cursor` can be moved back to the original position.
-                unsafe {
-                    self.cursor = self.cursor.sub(copied_len);
-                }
-                err
-            })?;
-        Ok(buf)
     }
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -40,7 +40,7 @@
 //! user space, making it impossible to avoid data races). However, they may produce erroneous
 //! results, such as unexpected bytes being copied, but do not cause soundness problems.
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem::MaybeUninit};
 
 use align_ext::AlignExt;
 use inherit_methods_macro::inherit_methods;
@@ -91,7 +91,7 @@ pub trait VmIo: Send + Sync {
 
     /// Reads a value of a specified type at a specified offset.
     fn read_val<T: Pod>(&self, offset: usize) -> Result<T> {
-        let mut val = T::new_uninit();
+        let mut val = T::new_zeroed();
         self.read_bytes(offset, val.as_bytes_mut())?;
         Ok(val)
     }
@@ -526,11 +526,25 @@ impl<'a> VmReader<'a, Infallible> {
             return Err(Error::InvalidArgs);
         }
 
-        let mut val = T::new_uninit();
-        let mut writer = VmWriter::from(val.as_bytes_mut());
+        let mut val = MaybeUninit::<T>::uninit();
 
+        // SAFETY:
+        // - The memory range points to typed memory.
+        // - The validity requirements for write accesses are met because the pointer is converted
+        //   from a mutable pointer where the underlying storage outlives the temporary lifetime
+        //   and no other Rust references to the same storage exist during the lifetime.
+        // - The type, i.e., `T`, is plain-old-data.
+        let mut writer = unsafe {
+            VmWriter::from_kernel_space(val.as_mut_ptr().cast(), core::mem::size_of::<T>())
+        };
         self.read(&mut writer);
-        Ok(val)
+        debug_assert!(!writer.has_avail());
+
+        // SAFETY:
+        // - `self.read` has initialized all the bytes in `val`.
+        // - The type is plain-old-data.
+        let val_inited = unsafe { val.assume_init() };
+        Ok(val_inited)
     }
 
     /// Reads a value of the `PodOnce` type using one non-tearing memory load.
@@ -606,8 +620,17 @@ impl VmReader<'_, Fallible> {
             return Err(Error::InvalidArgs);
         }
 
-        let mut val = T::new_uninit();
-        let mut writer = VmWriter::from(val.as_bytes_mut());
+        let mut val = MaybeUninit::<T>::uninit();
+
+        // SAFETY:
+        // - The memory range points to typed memory.
+        // - The validity requirements for write accesses are met because the pointer is converted
+        //   from a mutable pointer where the underlying storage outlives the temporary lifetime
+        //   and no other Rust references to the same storage exist during the lifetime.
+        // - The type, i.e., `T`, is plain-old-data.
+        let mut writer = unsafe {
+            VmWriter::from_kernel_space(val.as_mut_ptr().cast(), core::mem::size_of::<T>())
+        };
         self.read_fallible(&mut writer)
             .map_err(|(err, copied_len)| {
                 // The `copied_len` is the number of bytes read so far.
@@ -615,7 +638,13 @@ impl VmReader<'_, Fallible> {
                 self.cursor = self.cursor.wrapping_sub(copied_len);
                 err
             })?;
-        Ok(val)
+        debug_assert!(!writer.has_avail());
+
+        // SAFETY:
+        // - `self.read_fallible` has initialized all the bytes in `val`.
+        // - The type is plain-old-data.
+        let val_inited = unsafe { val.assume_init() };
+        Ok(val_inited)
     }
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -43,7 +43,9 @@
 use core::{marker::PhantomData, mem::MaybeUninit};
 
 use crate::{
-    arch::mm::{__memcpy_fallible, __memset_fallible},
+    arch::mm::{
+        __atomic_cmpxchg_fallible, __atomic_load_fallible, __memcpy_fallible, __memset_fallible,
+    },
     mm::{
         kspace::{KERNEL_BASE_VADDR, KERNEL_END_VADDR},
         MAX_USERSPACE_VADDR,
@@ -274,6 +276,45 @@ unsafe fn memset_fallible(dst: *mut u8, value: u8, len: usize) -> usize {
     len - failed_bytes
 }
 
+/// Atomically loads a 32-bit integer value.
+/// This function will return errors if encountering an unresolvable page fault.
+///
+/// Returns the loaded value.
+///
+/// # Safety
+///
+/// - `ptr` must either be [valid] for writes of 4 bytes or be in user space for 4 bytes.
+/// - `ptr` must be aligned on a 4-byte boundary.
+unsafe fn atomic_load_fallible(ptr: *const u32) -> Result<u32> {
+    // SAFETY: The safety is upheld by the caller.
+    let result = unsafe { __atomic_load_fallible(ptr) };
+    if result == !0 {
+        Err(Error::PageFault)
+    } else {
+        Ok(result as u32)
+    }
+}
+
+/// Atomically compares and exchanges a 32-bit integer value.
+/// This function will return errors if encountering an unresolvable page fault.
+///
+/// Returns the previous value.
+/// `new_val` will be written if and only if the previous value is equal to `old_val`.
+///
+/// # Safety
+///
+/// - `ptr` must either be [valid] for reads and writes of 4 bytes or be in user space for 4 bytes.
+/// - `ptr` must be aligned on a 4-byte boundary.
+unsafe fn atomic_cmpxchg_fallible(ptr: *mut u32, old_val: u32, new_val: u32) -> Result<u32> {
+    // SAFETY: The safety is upheld by the caller.
+    let result = unsafe { __atomic_cmpxchg_fallible(ptr, old_val, new_val) };
+    if result == !0 {
+        Err(Error::PageFault)
+    } else {
+        Ok(result as u32)
+    }
+}
+
 /// Fallible memory read from a `VmWriter`.
 pub trait FallibleVmRead<F> {
     /// Reads all data into the writer until one of the three conditions is met:
@@ -493,6 +534,9 @@ impl<'a> VmReader<'a, Infallible> {
         Ok(val)
     }
 
+    // Currently, there are no volatile atomic operations in `core::intrinsics`. Therefore, we do
+    // not provide an infallible implementation of `VmReader::atomic_load`.
+
     /// Converts to a fallible reader.
     pub fn to_fallible(self) -> VmReader<'a, Fallible> {
         // It is safe to construct a fallible reader since an infallible reader covers the
@@ -561,6 +605,32 @@ impl VmReader<'_, Fallible> {
         // - The type is plain-old-data.
         let val_inited = unsafe { val.assume_init() };
         Ok(val_inited)
+    }
+
+    /// Atomically loads a 32-bit integer value.
+    ///
+    /// Regardless of whether it is successful, the cursor of the reader and writer will not move.
+    ///
+    /// This method will fail with errors if
+    ///  1. the remaining space of the reader is less than 4 bytes (`size_of::<u32>()`), or
+    ///  2. the memory operation fails due to an unresolvable page fault.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the memory location is not aligned on a 4-byte boundary
+    /// (`align_of::<u32>()`).
+    pub fn atomic_load(&self) -> Result<u32> {
+        if self.remain() < core::mem::size_of::<u32>() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let cursor = self.cursor.cast::<u32>();
+        assert!(cursor.is_aligned());
+
+        // SAFETY:
+        // 1. The cursor is either valid for reading or in user space for 4 bytes.
+        // 2. The cursor is aligned on a 4-byte boundary.
+        unsafe { atomic_load_fallible(cursor) }
     }
 }
 
@@ -711,6 +781,9 @@ impl<'a> VmWriter<'a, Infallible> {
         Ok(())
     }
 
+    // Currently, there are no volatile atomic operations in `core::intrinsics`. Therefore, we do
+    // not provide an infallible implementation of `VmWriter::atomic_update`.
+
     /// Writes `len` zeros to the target memory.
     ///
     /// This method attempts to fill up to `len` bytes with zeros. If the available
@@ -785,6 +858,59 @@ impl VmWriter<'_, Fallible> {
                 err
             })?;
         Ok(())
+    }
+
+    /// Atomically updates a 32-bit integer value.
+    ///
+    /// This is implemented by performing an atomic load, applying the operation, and performing an
+    /// atomic compare-and-exchange. So this cannot prevent the ABA problem.
+    ///
+    /// The caller is required to provide a reader which points to the exactly same memory location
+    /// to ensure that reading from the memory is allowed.
+    ///
+    /// On success, the previous value will be returned with a boolean value denoting whether the
+    /// compare-and-exchange succeeds. The caller usually wants to retry if the flag is false.
+    ///
+    /// Regardless of whether it is successful, the cursor of the reader and writer will not move.
+    ///
+    /// This method will fail with errors if:
+    ///  1. the remaining (avail) space of the reader (writer) is less than 4 bytes
+    ///     (`size_of::<u32>()`), or
+    ///  2. the memory operation fails due to an unresolvable page fault.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if:
+    ///  1. the reader and the writer does not point to the same memory location, or
+    ///  2. the memory location is not aligned on a 4-byte boundary (`align_of::<u32>()`).
+    pub fn atomic_update<F>(&mut self, reader: &VmReader, op: F) -> Result<(u32, bool)>
+    where
+        F: FnOnce(u32) -> u32,
+    {
+        if self.avail() < core::mem::size_of::<u32>()
+            || reader.remain() < core::mem::size_of::<u32>()
+        {
+            return Err(Error::InvalidArgs);
+        }
+
+        assert_eq!(self.cursor.cast_const(), reader.cursor);
+
+        let cursor = self.cursor.cast::<u32>();
+        assert!(cursor.is_aligned());
+
+        // SAFETY:
+        // 1. The cursor is either valid for reading or in user space for 4 bytes.
+        // 2. The cursor is aligned on a 4-byte boundary.
+        let old_val = unsafe { atomic_load_fallible(cursor)? };
+
+        let new_val = op(old_val);
+
+        // SAFETY:
+        // 1. The cursor is either valid for reading and writing or in user space for 4 bytes.
+        // 2. The cursor is aligned on a 4-byte boundary.
+        let cur_val = unsafe { atomic_cmpxchg_fallible(cursor, old_val, new_val)? };
+
+        Ok((old_val, old_val == cur_val))
     }
 
     /// Writes `len` zeros to the target memory.

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -42,7 +42,6 @@
 
 use core::{marker::PhantomData, mem::MaybeUninit};
 
-use align_ext::AlignExt;
 use inherit_methods_macro::inherit_methods;
 
 use crate::{
@@ -155,65 +154,20 @@ pub trait VmIo: Send + Sync {
         self.write_bytes(offset, buf)
     }
 
-    /// Writes a sequence of values given by an iterator (`iter`) from the specified offset (`offset`).
+    /// Writes `len` zeros at a specified offset.
     ///
-    /// The write process stops until the VM object does not have enough remaining space
-    /// or the iterator returns `None`. If any value is written, the function returns `Ok(nr_written)`,
-    /// where `nr_written` is the number of the written values.
-    ///
-    /// The offset of every value written by this method is aligned to the `align`-byte boundary.
-    /// Naturally, when `align` equals to `0` or `1`, then the argument takes no effect:
-    /// the values will be written in the most compact way.
-    ///
-    /// # Example
-    ///
-    /// Initializes an VM object with the same value can be done easily with `write_values`.
-    ///
-    /// ```
-    /// use core::iter::self;
-    ///
-    /// let _nr_values = vm_obj.write_vals(0, iter::repeat(0_u32), 0).unwrap();
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This method panics if `align` is greater than two,
-    /// but not a power of two, in release mode.
-    fn write_vals<'a, T: Pod + 'a, I: Iterator<Item = &'a T>>(
-        &self,
-        offset: usize,
-        iter: I,
-        align: usize,
-    ) -> Result<usize> {
-        let mut nr_written = 0;
-
-        let (mut offset, item_size) = if (align >> 1) == 0 {
-            // align is 0 or 1
-            (offset, core::mem::size_of::<T>())
-        } else {
-            // align is more than 2
-            (
-                offset.align_up(align),
-                core::mem::size_of::<T>().align_up(align),
-            )
-        };
-
-        for item in iter {
-            match self.write_val(offset, item) {
-                Ok(_) => {
-                    offset += item_size;
-                    nr_written += 1;
-                }
-                Err(e) => {
-                    if nr_written > 0 {
-                        return Ok(nr_written);
-                    }
-                    return Err(e);
-                }
+    /// Unlike the other methods above, this method allows for short writes because `len` can be
+    /// effectively unbounded. However, if not all bytes can be written successfully, an `Err(_)`
+    /// will be returned with the error and the number of zeros that have been written thus far.
+    fn fill_zeros(&self, offset: usize, len: usize) -> core::result::Result<(), (Error, usize)> {
+        // TODO: Optimize this default implementation by writing in chunks.
+        for i in 0..len {
+            match self.write_slice(offset + i, &[0u8]) {
+                Ok(()) => continue,
+                Err(err) => return Err((err, i)),
             }
         }
-
-        Ok(nr_written)
+        Ok(())
     }
 }
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -42,8 +42,6 @@
 
 use core::{marker::PhantomData, mem::MaybeUninit};
 
-use inherit_methods_macro::inherit_methods;
-
 use crate::{
     arch::mm::{__memcpy_fallible, __memset_fallible},
     mm::{
@@ -191,42 +189,6 @@ pub trait VmIoOnce {
     /// [`VmWriter::write_once`].
     fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()>;
 }
-
-macro_rules! impl_vm_io_pointer {
-    ($typ:ty,$from:tt) => {
-        #[inherit_methods(from = $from)]
-        impl<T: VmIo> VmIo for $typ {
-            fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()>;
-            fn read_bytes(&self, offset: usize, buf: &mut [u8]) -> Result<()>;
-            fn read_val<F: Pod>(&self, offset: usize) -> Result<F>;
-            fn read_slice<F: Pod>(&self, offset: usize, slice: &mut [F]) -> Result<()>;
-            fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()>;
-            fn write_bytes(&self, offset: usize, buf: &[u8]) -> Result<()>;
-            fn write_val<F: Pod>(&self, offset: usize, new_val: &F) -> Result<()>;
-            fn write_slice<F: Pod>(&self, offset: usize, slice: &[F]) -> Result<()>;
-        }
-    };
-}
-
-impl_vm_io_pointer!(&T, "(**self)");
-impl_vm_io_pointer!(&mut T, "(**self)");
-impl_vm_io_pointer!(Box<T>, "(**self)");
-impl_vm_io_pointer!(Arc<T>, "(**self)");
-
-macro_rules! impl_vm_io_once_pointer {
-    ($typ:ty,$from:tt) => {
-        #[inherit_methods(from = $from)]
-        impl<T: VmIoOnce> VmIoOnce for $typ {
-            fn read_once<F: PodOnce>(&self, offset: usize) -> Result<F>;
-            fn write_once<F: PodOnce>(&self, offset: usize, new_val: &F) -> Result<()>;
-        }
-    };
-}
-
-impl_vm_io_once_pointer!(&T, "(**self)");
-impl_vm_io_once_pointer!(&mut T, "(**self)");
-impl_vm_io_once_pointer!(Box<T>, "(**self)");
-impl_vm_io_once_pointer!(Arc<T>, "(**self)");
 
 /// A marker type used for [`VmReader`] and [`VmWriter`],
 /// representing whether reads or writes on the underlying memory region are fallible.

--- a/ostd/src/mm/io_util.rs
+++ b/ostd/src/mm/io_util.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use inherit_methods_macro::inherit_methods;
+use ostd_pod::Pod;
+
+use super::{Infallible, PodOnce, VmIo, VmIoOnce, VmReader, VmWriter};
+use crate::{
+    mm::{FallibleVmRead, FallibleVmWrite},
+    prelude::*,
+    Error,
+};
+
+/// A helper trait that provides efficient [`VmIo`] implementation for types that can provide
+/// [`VmReader`]s and [`VmWriter`]s.
+pub(crate) trait VmIoByReaderWriter: Send + Sync {
+    fn io_reader(&self) -> Result<VmReader<Infallible>>;
+    fn io_writer(&self) -> Result<VmWriter<Infallible>>;
+}
+
+impl<S: VmIoByReaderWriter> VmIo for S {
+    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
+        let mut reader = self.io_reader()?;
+
+        let limit = offset.checked_add(writer.avail()).ok_or(Error::Overflow)?;
+        if limit > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        reader.skip(offset);
+        let _len = reader
+            .to_fallible()
+            .read_fallible(writer)
+            .map_err(|(err, _)| err)?;
+        debug_assert!(!writer.has_avail());
+        Ok(())
+    }
+
+    fn read_bytes(&self, offset: usize, buf: &mut [u8]) -> Result<()> {
+        let mut reader = self.io_reader()?;
+
+        let limit = offset.checked_add(buf.len()).ok_or(Error::Overflow)?;
+        if limit > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let len = reader.skip(offset).read(&mut VmWriter::from(&mut *buf));
+        debug_assert_eq!(len, buf.len());
+        Ok(())
+    }
+
+    // No need to implement `read_slice`. Its default implementation is efficient enough by relying
+    // on `read_bytes`.
+
+    fn read_val<T: Pod>(&self, offset: usize) -> Result<T> {
+        let mut reader = self.io_reader()?;
+
+        if offset > reader.remain() {
+            return Err(Error::InvalidArgs);
+        }
+
+        reader.skip(offset).read_val()
+    }
+
+    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
+        let mut writer = self.io_writer()?;
+
+        let limit = offset.checked_add(reader.remain()).ok_or(Error::Overflow)?;
+        if limit > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        writer.skip(offset);
+        let _len = writer
+            .to_fallible()
+            .write_fallible(reader)
+            .map_err(|(err, _)| err)?;
+        debug_assert!(!reader.has_remain());
+        Ok(())
+    }
+
+    fn write_bytes(&self, offset: usize, buf: &[u8]) -> Result<()> {
+        let mut writer = self.io_writer()?;
+
+        let limit = offset.checked_add(buf.len()).ok_or(Error::Overflow)?;
+        if limit > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        let len = writer.skip(offset).write(&mut VmReader::from(buf));
+        debug_assert_eq!(len, buf.len());
+        Ok(())
+    }
+
+    // No need to implement `write_slice`. Its default implementation is efficient enough by
+    // relying on `write_bytes`.
+
+    fn write_val<T: Pod>(&self, offset: usize, new_val: &T) -> Result<()> {
+        let mut writer = self.io_writer()?;
+
+        if offset > writer.avail() {
+            return Err(Error::InvalidArgs);
+        }
+
+        writer.skip(offset).write_val(new_val)
+    }
+
+    fn fill_zeros(&self, offset: usize, len: usize) -> core::result::Result<(), (Error, usize)> {
+        let mut writer = self.io_writer().map_err(|err| (err, 0))?;
+
+        if offset > writer.avail() {
+            return Err((Error::InvalidArgs, 0));
+        }
+
+        let filled_len = writer.skip(offset).fill_zeros(len);
+        if filled_len == len {
+            Ok(())
+        } else {
+            Err((Error::InvalidArgs, filled_len))
+        }
+    }
+}
+
+/// A helper trait that provides [`VmIoOnce`] implementation for types that can provide
+/// [`VmReader`]s and [`VmWriter`]s.
+pub(crate) trait VmIoOnceByReaderWriter: VmIoByReaderWriter {}
+
+impl<S: VmIoOnceByReaderWriter> VmIoOnce for S {
+    fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T> {
+        self.io_reader()?.skip(offset).read_once()
+    }
+
+    fn write_once<T: PodOnce>(&self, offset: usize, new_val: &T) -> Result<()> {
+        self.io_writer()?.skip(offset).write_once(new_val)
+    }
+}
+
+// The pointer implementations below (i.e., `impl_vm_io_pointer`/`impl_vm_io_once_pointer`) should
+// apply to the `VmIo`/`VmIoOnce` traits themselves, instead of these helper traits.
+//
+// However, there are some unexpected compiler errors that complain that downstream crates can
+// implement `VmIoByReaderWriter`/`VmIoOnceByReaderWriter` to cause conflict implementations --
+// which isn't really possible because `VmIoByReaderWriter`/`VmIoOnceByReaderWriter` isn't supposed
+// to be public.
+
+macro_rules! impl_vm_io_pointer {
+    ($typ:ty,$from:tt) => {
+        #[inherit_methods(from = $from)]
+        impl<T: VmIoByReaderWriter> VmIoByReaderWriter for $typ {
+            fn io_reader(&self) -> Result<VmReader<Infallible>>;
+            fn io_writer(&self) -> Result<VmWriter<Infallible>>;
+        }
+    };
+}
+
+impl_vm_io_pointer!(&T, "(**self)");
+impl_vm_io_pointer!(&mut T, "(**self)");
+impl_vm_io_pointer!(Box<T>, "(**self)");
+impl_vm_io_pointer!(Arc<T>, "(**self)");
+
+macro_rules! impl_vm_io_once_pointer {
+    ($typ:ty,$from:tt) => {
+        #[inherit_methods(from = $from)]
+        impl<T: VmIoOnceByReaderWriter> VmIoOnceByReaderWriter for $typ {}
+    };
+}
+
+impl_vm_io_once_pointer!(&T, "(**self)");
+impl_vm_io_once_pointer!(&mut T, "(**self)");
+impl_vm_io_once_pointer!(Box<T>, "(**self)");
+impl_vm_io_once_pointer!(Arc<T>, "(**self)");

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod dma;
 pub mod frame;
 pub mod heap;
 pub mod io;
+pub(crate) mod io_util;
 pub(crate) mod kspace;
 pub(crate) mod page_prop;
 pub(crate) mod page_table;

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -118,21 +118,6 @@ mod io {
         writer_infallible.write_val(&val).unwrap();
     }
 
-    /// Tests the `fill` method in Infallible mode.
-    #[ktest]
-    fn fill_infallible() {
-        let mut buffer = vec![0u8; 8];
-        let mut writer_infallible = VmWriter::from(&mut buffer[..]);
-
-        // Fill with 0xFF
-        let filled = writer_infallible.fill(0xFFu8);
-        assert_eq!(filled, 8);
-        // Ensure the cursor is at the end
-        assert_eq!(writer_infallible.avail(), 0);
-
-        assert_eq!(buffer, vec![0xFF; 8]);
-    }
-
     /// Tests the `skip` method for reading in Infallible mode.
     #[ktest]
     fn skip_read_infallible() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -332,32 +332,6 @@ mod io {
         assert_eq!(val, read_val);
     }
 
-    /// Tests the `collect` method in Fallible mode.
-    #[ktest]
-    fn collect_fallible() {
-        let data = [5u8, 6, 7, 8, 9];
-        let reader = VmReader::from(&data[..]);
-        let mut reader_fallible = reader.to_fallible();
-
-        let collected = reader_fallible.collect().unwrap();
-        assert_eq!(collected, data);
-    }
-
-    /// Tests partial collection in Fallible mode.
-    #[ktest]
-    fn collect_partial_fallible() {
-        let data = [1u8, 2, 3, 4, 5];
-        let reader = VmReader::from(&data[..]);
-        let mut reader_fallible = reader.to_fallible();
-
-        // Limits the reader to 3 bytes
-        let limited_reader = reader_fallible.limit(3);
-
-        let result = limited_reader.collect();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), vec![1, 2, 3]);
-    }
-
     /// Tests the `fill_zeros` method in Fallible mode.
     #[ktest]
     fn fill_zeros_fallible() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -118,6 +118,21 @@ mod io {
         writer_infallible.write_val(&val).unwrap();
     }
 
+    /// Tests the `fill` method in Infallible mode.
+    #[ktest]
+    fn fill_infallible() {
+        let mut buffer = vec![0x7Fu8; 8];
+        let mut writer_infallible = VmWriter::from(&mut buffer[..]);
+
+        // Fill with zeros
+        let filled = writer_infallible.fill_zeros(10);
+        assert_eq!(filled, 8);
+        // Ensure the cursor is at the end
+        assert_eq!(writer_infallible.avail(), 0);
+
+        assert_eq!(buffer, vec![0; 8]);
+    }
+
     /// Tests the `skip` method for reading in Infallible mode.
     #[ktest]
     fn skip_read_infallible() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -381,19 +381,19 @@ mod io {
         assert_eq!(result, Err(Error::InvalidArgs));
     }
 
-    /// Tests the `write_vals` method in VmIO.
+    /// Tests the `fill_zeros` method in VmIO.
     #[ktest]
-    fn write_vals_segment() {
-        let mut buffer = [0u8; 12];
+    fn fill_zeros_segment() {
+        let mut buffer = [0u8; 5];
         let segment = FrameAllocOptions::new().alloc_segment(1).unwrap();
-        let values = [1u32, 2, 3];
-        let nr_written = segment.write_vals(0, values.iter(), 4).unwrap();
-        assert_eq!(nr_written, 3);
+        let values = [1u8, 2, 3, 4, 5];
+        segment.write_slice(0, &values).unwrap();
+        segment.fill_zeros(1, 3).unwrap();
         segment.read_bytes(0, &mut buffer[..]).unwrap();
-        assert_eq!(buffer, [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
+        assert_eq!(buffer, [1, 0, 0, 0, 5]);
         // Writes with error offset
-        let result = segment.write_vals(8192, values.iter(), 4);
-        assert_eq!(result, Err(Error::InvalidArgs));
+        let result = segment.fill_zeros(8192, 3);
+        assert_eq!(result, Err((Error::InvalidArgs, 0)));
     }
 
     /// Tests the `write_slice` method in VmIO.
@@ -412,7 +412,7 @@ mod io {
     fn read_val_segment() {
         let segment = FrameAllocOptions::new().alloc_segment(1).unwrap();
         let values = [1u32, 2, 3];
-        segment.write_vals(0, values.iter(), 4).unwrap();
+        segment.write_slice(0, &values).unwrap();
         let val: u32 = segment.read_val(0).unwrap();
         assert_eq!(val, 1);
     }
@@ -422,7 +422,7 @@ mod io {
     fn read_slice_segment() {
         let segment = FrameAllocOptions::new().alloc_segment(1).unwrap();
         let values = [1u32, 2, 3];
-        segment.write_vals(0, values.iter(), 4).unwrap();
+        segment.write_slice(0, &values).unwrap();
         let mut read_buffer = [0u8; 12];
         segment.read_slice(0, &mut read_buffer[..]).unwrap();
         assert_eq!(read_buffer, [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -332,6 +332,57 @@ mod io {
         assert_eq!(val, read_val);
     }
 
+    /// Tests the `atomic_load` method in Fallible mode.
+    #[ktest]
+    fn atomic_load_fallible() {
+        let buffer = [1u8, 1, 1, 1, 2, 2, 2, 2];
+        let reader = VmReader::from(&buffer[..]);
+        let mut reader_fallible = reader.to_fallible();
+
+        assert_eq!(reader_fallible.atomic_load().unwrap(), 0x01010101);
+        reader_fallible.skip(4);
+        assert_eq!(reader_fallible.atomic_load().unwrap(), 0x02020202);
+    }
+
+    /// Tests the `atomic_update` method in Fallible mode.
+    #[ktest]
+    fn atomic_update_fallible() {
+        type Segment = crate::mm::Segment<()>;
+
+        fn update(segment: &Segment, old_val: u32, new_val: u32, f: fn(segment: &Segment)) -> bool {
+            let (val, is_succ) = segment
+                .writer()
+                .to_fallible()
+                .skip(4)
+                .atomic_update(segment.reader().to_fallible().skip(4), |val| {
+                    assert_eq!(val, old_val);
+                    f(segment);
+                    new_val
+                })
+                .unwrap();
+            assert_eq!(val, old_val);
+            is_succ
+        }
+
+        let segment = FrameAllocOptions::new()
+            .zeroed(true)
+            .alloc_segment(1)
+            .unwrap();
+
+        assert!(update(&segment, 0, 100, |_| ()));
+        assert!(update(&segment, 100, 200, |_| ()));
+
+        let is_succ = update(&segment, 200, 400, |segment| {
+            assert!(update(segment, 200, 300, |_| ()))
+        });
+        assert!(!is_succ);
+
+        let mut reader = segment.reader().to_fallible();
+        reader.skip(4);
+        assert_eq!(reader.atomic_load().unwrap(), 300);
+        assert_eq!(reader.read_val::<u32>().unwrap(), 300);
+    }
+
     /// Tests the `fill_zeros` method in Fallible mode.
     #[ktest]
     fn fill_zeros_fallible() {


### PR DESCRIPTION
**Note:** This PR is based on https://github.com/asterinas/asterinas/pull/2289. While it is possible to rebase this PR against the main branch, I would prefer to let the cleanup PR go ahead. Please consider reviewing #2289 first. Thanks!

Alternatively, you can also review the last two commits in this PR, i.e., "Add atomic operations for VM readers/writers" and "Add atomic operations for VM readers/writers".

---

In the driver reuse project, I need to add atomic operations to the `VmReader` and `VmWriter` to safely and efficiently communicate with the Linux kernel. The mainline kernel also requires these operations because futex operations cannot otherwise be implemented correctly.

#### Add atomic operations for VM readers/writers

The current APIs are designed to take an arbitrary closure and are implemented with the atomic compare-and-exchange operation. It largely [aligns to the Linux kernel implementation](https://elixir.bootlin.com/linux/v6.16/source/arch/x86/include/asm/futex.h#L35), but we should be aware of an alternative: we can hardcode the supported operations in OSTD to use more efficient instructions, such as "xchg" and "lock; xadd".

Additionally, the type is currently hardcoded as `u32`. I cannot easily support all possible types (`u8`, `u16`, `u32`, and `u64`).

```rust
impl VmReader<'_, Fallible> {
    pub fn atomic_load(&self) -> Result<u32>;
}
impl VmWriter<'_, Fallible> {
    pub fn atomic_update<F>(&mut self, reader: &VmReader, op: F) -> Result<(u32, bool)>
    where
        F: FnOnce(u32) -> u32;
}
```

#### Add atomic operations for VM readers/writers

Besides, the userspace futex word needs to be operated after locking the futex bucket, which can break the atomic mode because the lock is a spin lock. Linux [disables the page fault handler temporarily](https://elixir.bootlin.com/linux/v6.16/source/kernel/futex/waitwake.c#L223) and [addresses the page fault manually after exiting the atomic mode](https://elixir.bootlin.com/linux/v6.16/source/kernel/futex/waitwake.c#L287). I think we should do something similar.

