### PR TITLE
Specify SCHEME in Makefile for LoongArch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ endif
 
 ifeq ($(ARCH), riscv64)
 SCHEME = riscv
+else ifeq ($(ARCH), loongarch64)
+SCHEME = loongarch
 endif
 
 ifneq ($(SCHEME), "")


### PR DESCRIPTION
It looks like we need to manually specify the scheme for LoongArch. Otherwise, `make run ARCH=loongarch64` will fail with:
```
qemu-system-loongarch64: unsupported machine type: "q35"
Use -machine help to list supported machines
make: *** [Makefile:248: run] Error 2
```