### PR TITLE
Synchronize `{pci,io}.rs` between architectures

### DIFF
--- a/ostd/src/arch/loongarch/mod.rs
+++ b/ostd/src/arch/loongarch/mod.rs
@@ -35,10 +35,10 @@ pub(crate) unsafe fn late_init_on_bsp() {
 
     // SAFETY:
     // 1. All the system device memory have been removed from the builder.
-    // 2. LoongArch platforms does not have port I/O.
+    // 2. LoongArch platforms do not have port I/O.
     unsafe { crate::io::init(io_mem_builder) };
 
-    let _ = pci::init();
+    pci::init();
 }
 
 pub(crate) unsafe fn init_on_ap() {

--- a/ostd/src/arch/loongarch/pci.rs
+++ b/ostd/src/arch/loongarch/pci.rs
@@ -6,6 +6,7 @@ use core::alloc::Layout;
 
 use align_ext::AlignExt;
 use fdt::node::FdtNode;
+use log::warn;
 use spin::Once;
 
 use super::boot::DEVICE_TREE;
@@ -13,21 +14,17 @@ use crate::{
     bus::pci::PciDeviceLocation, io::IoMem, mm::VmIoOnce, prelude::*, sync::SpinLock, Error,
 };
 
-static PCI_IO_MEM: Once<IoMem> = Once::new();
-
-pub(crate) fn has_pci_bus() -> bool {
-    PCI_IO_MEM.is_completed()
-}
+static PCI_ECAM_CFG_SPACE: Once<IoMem> = Once::new();
 
 pub(crate) fn write32(location: &PciDeviceLocation, offset: u32, value: u32) -> Result<()> {
-    PCI_IO_MEM.get().ok_or(Error::IoError)?.write_once(
+    PCI_ECAM_CFG_SPACE.get().ok_or(Error::IoError)?.write_once(
         (encode_as_address_offset(location) | (offset & 0xfc)) as usize,
         &value,
     )
 }
 
 pub(crate) fn read32(location: &PciDeviceLocation, offset: u32) -> Result<u32> {
-    PCI_IO_MEM
+    PCI_ECAM_CFG_SPACE
         .get()
         .ok_or(Error::IoError)?
         .read_once((encode_as_address_offset(location) | (offset & 0xfc)) as usize)
@@ -35,53 +32,55 @@ pub(crate) fn read32(location: &PciDeviceLocation, offset: u32) -> Result<u32> {
 
 /// Encodes the bus, device, and function into an address offset in the PCI MMIO region.
 fn encode_as_address_offset(location: &PciDeviceLocation) -> u32 {
-    ((location.bus as u32) << 16)
-        | ((location.device as u32) << 11)
-        | ((location.function as u32) << 8)
+    // We only support ECAM here for LoongArch platforms. Offsets are from
+    // <https://www.kernel.org/doc/Documentation/devicetree/bindings/pci/host-generic-pci.txt>.
+    ((location.bus as u32) << 20)
+        | ((location.device as u32) << 15)
+        | ((location.function as u32) << 12)
 }
 
-pub(crate) fn init() -> Result<()> {
-    let pci = DEVICE_TREE
+pub(crate) fn has_pci_bus() -> bool {
+    PCI_ECAM_CFG_SPACE.is_completed()
+}
+
+pub(crate) fn init() {
+    // We follow the Linux's PCI device tree to obtain the register information
+    // about the PCI bus. See also the specification at
+    // <https://www.kernel.org/doc/Documentation/devicetree/bindings/pci/host-generic-pci.txt>.
+    //
+    // TODO: Support multiple PCIe segment groups instead of assuming only one
+    // PCIe segment group is in use.
+    let Some(pci) = DEVICE_TREE
         .get()
         .unwrap()
-        .find_node("/pcie")
-        .ok_or(Error::IoError)?;
+        .find_compatible(&["pci-host-ecam-generic"])
+    else {
+        warn!("No generic PCI host controller node found in the device tree");
+        return;
+    };
 
-    if !pci
-        .compatible()
-        .ok_or(Error::IoError)?
-        .all()
-        .any(|c| c == "pci-host-ecam-generic")
-    {
-        return Err(Error::IoError);
-    }
-
-    let mut reg = pci.reg().ok_or(Error::IoError)?;
-
+    let Some(mut reg) = pci.reg() else {
+        warn!("PCI node should have exactly one `reg` property, but found zero `reg`s");
+        return;
+    };
     let Some(region) = reg.next() else {
-        log::warn!("PCI node should have exactly one `reg` property, but found zero `reg`s");
-        return Err(Error::IoError);
+        warn!("PCI node should have exactly one `reg` property, but found zero `reg`s");
+        return;
     };
     if reg.next().is_some() {
-        log::warn!(
+        warn!(
             "PCI node should have exactly one `reg` property, but found {} `reg`s",
             reg.count() + 2
         );
-        return Err(Error::IoError);
+        return;
     }
 
     // Initialize the MMIO allocator
     init_mmio_allocator_from_fdt(&pci);
 
-    PCI_IO_MEM.call_once(|| unsafe {
-        IoMem::acquire(
-            (region.starting_address as usize)
-                ..(region.starting_address as usize + region.size.unwrap()),
-        )
-        .unwrap()
-    });
-
-    Ok(())
+    let addr_start = region.starting_address as usize;
+    let addr_end = addr_start.checked_add(region.size.unwrap()).unwrap();
+    PCI_ECAM_CFG_SPACE.call_once(|| IoMem::acquire(addr_start..addr_end).unwrap());
 }
 
 pub(crate) const MSIX_DEFAULT_MSG_ADDR: u32 = 0x2ff0_0000;

--- a/ostd/src/arch/x86/pci.rs
+++ b/ostd/src/arch/x86/pci.rs
@@ -21,6 +21,15 @@ pub(crate) fn read32(location: &PciDeviceLocation, offset: u32) -> Result<u32> {
     Ok(PCI_DATA_PORT.read().to_le())
 }
 
+/// Encodes the bus, device, and function into a port address for use with the PCI I/O port.
+fn encode_as_port(location: &PciDeviceLocation) -> u32 {
+    // 1 << 31: Configuration enable
+    (1 << 31)
+        | ((location.bus as u32) << 16)
+        | (((location.device as u32) & 0b11111) << 11)
+        | (((location.function as u32) & 0b111) << 8)
+}
+
 pub(crate) fn has_pci_bus() -> bool {
     true
 }
@@ -36,13 +45,4 @@ pub(crate) fn construct_remappable_msix_address(remapping_index: u32) -> u32 {
     address |= (remapping_index & 0x8000) >> 13;
 
     address
-}
-
-/// Encodes the bus, device, and function into a port address for use with the PCI I/O port.
-fn encode_as_port(location: &PciDeviceLocation) -> u32 {
-    // 1 << 31: Configuration enable
-    (1 << 31)
-        | ((location.bus as u32) << 16)
-        | (((location.device as u32) & 0b11111) << 11)
-        | (((location.function as u32) & 0b111) << 8)
 }

--- a/ostd/src/bus/pci/device_info.rs
+++ b/ostd/src/bus/pci/device_info.rs
@@ -63,10 +63,18 @@ pub struct PciDeviceLocation {
 }
 
 impl PciDeviceLocation {
+    // TODO: Find a proper way to obtain the bus range. For example, if the PCI bus is identified
+    // from a device tree, this information can be obtained from the `bus-range` field (e.g.,
+    // `bus-range = <0x00 0x7f>`).
     const MIN_BUS: u8 = 0;
+    #[cfg(not(target_arch = "loongarch64"))]
     const MAX_BUS: u8 = 255;
+    #[cfg(target_arch = "loongarch64")]
+    const MAX_BUS: u8 = 127;
+
     const MIN_DEVICE: u8 = 0;
     const MAX_DEVICE: u8 = 31;
+
     const MIN_FUNCTION: u8 = 0;
     const MAX_FUNCTION: u8 = 7;
 


### PR DESCRIPTION
This PR applies RISC-V changes in https://github.com/asterinas/asterinas/pull/2045 to the LoongArch code.

The changes in `arch/*/io.rs` are non-functional. The code gets simplified due to the use of [`MemoryRegion::end`](https://github.com/asterinas/asterinas/blob/b20d8461fd02594f9d2f170ddeb334e9d0ee426c/ostd/src/boot/memory_region.rs#L112) method.

The changes in `arch/*/pci.rs` fix a BUG.
https://github.com/asterinas/asterinas/blob/b20d8461fd02594f9d2f170ddeb334e9d0ee426c/ostd/src/arch/riscv/pci.rs#L81-L86
https://github.com/asterinas/asterinas/blob/b20d8461fd02594f9d2f170ddeb334e9d0ee426c/ostd/src/arch/loongarch/pci.rs#L37-L40

The LoongArch implementation isn't correct because it tries to use the leagcy CAM offsets in the ECAM PCI bus:
https://github.com/asterinas/asterinas/blob/b20d8461fd02594f9d2f170ddeb334e9d0ee426c/ostd/src/arch/loongarch/pci.rs#L54

Before this PR, we locate these PCI devices:
```
PciDeviceId { vendor_id: 1b36, device_id: 8, revision_id: 0, prog_if: 0, subclass: 0, class: 6, subsystem_vendor_id: 1af4, subsystem_id: 1100 }	 	location: PciDeviceLocation { bus: 0, device: 0, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1000, revision_id: 0, prog_if: 0, subclass: 0, class: 2, subsystem_vendor_id: 1af4, subsystem_id: 1 }	 	location: PciDeviceLocation { bus: 0, device: 10, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1052, revision_id: 1, prog_if: 0, subclass: 0, class: 9, subsystem_vendor_id: 1af4, subsystem_id: 1100 }	 	location: PciDeviceLocation { bus: 1, device: 0, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1003, revision_id: 0, prog_if: 0, subclass: 80, class: 7, subsystem_vendor_id: 1af4, subsystem_id: 3 }	 	location: PciDeviceLocation { bus: 1, device: 10, function: 0 },
```

As you can see from the log, the locations of the four PCI devices are `bus={0,1}, device={0,10}`. They are odd and unlikely to be correct.

After this PR, we locate these PCI devices:
```
PciDeviceId { vendor_id: 1b36, device_id: 8, revision_id: 0, prog_if: 0, subclass: 0, class: 6, subsystem_vendor_id: 1af4, subsystem_id: 1100 }	 	location: PciDeviceLocation { bus: 0, device: 0, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1000, revision_id: 0, prog_if: 0, subclass: 0, class: 2, subsystem_vendor_id: 1af4, subsystem_id: 1 }	 	location: PciDeviceLocation { bus: 0, device: 1, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1052, revision_id: 1, prog_if: 0, subclass: 0, class: 9, subsystem_vendor_id: 1af4, subsystem_id: 1100 }	 	location: PciDeviceLocation { bus: 0, device: 2, function: 0 }, 
PciDeviceId { vendor_id: 1af4, device_id: 1003, revision_id: 0, prog_if: 0, subclass: 80, class: 7, subsystem_vendor_id: 1af4, subsystem_id: 3 }	 	location: PciDeviceLocation { bus: 0, device: 3, function: 0 }, 
```

Now the locations of the four PCI devices are `bus=0, device={0,1,2,3}`. They should be correct locations.