### PR TITLE
Add the basic namespace framework

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -328,7 +328,7 @@ provided by Linux on x86-64 architecture.
 | 305     | clock_adjtime          | ❌             |     |
 | 306     | syncfs                 | ❌             |     |
 | 307     | sendmmsg               | ❌             |     |
-| 308     | setns                  | ❌             |     |
+| 308     | setns                  | ✅             |     |
 | 309     | getcpu                 | ✅             |     |
 | 310     | process_vm_readv       | ❌             |     |
 | 311     | process_vm_writev      | ❌             |     |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -292,7 +292,7 @@ provided by Linux on x86-64 architecture.
 | 269     | faccessat              | ✅             |     |
 | 270     | pselect6               | ✅             |     |
 | 271     | ppoll                  | ✅             |     |
-| 272     | unshare                | ❌             |     |
+| 272     | unshare                | ✅             |     |
 | 273     | set_robust_list        | ✅             |     |
 | 274     | get_robust_list        | ❌             |     |
 | 275     | splice                 | ❌             |     |

--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -82,6 +82,13 @@ impl<'a> CurrentUserSpace<'a> {
         self.0.as_ref().unwrap()
     }
 
+    /// Returns whether the VMAR is shared with other processes or threads.
+    pub fn is_vmar_shared(&self) -> bool {
+        // If the VMAR is not shared, its reference count should be exactly 2:
+        // one reference is held by `ThreadLocal` and the other by `ProcessVm` in `Process`.
+        self.root_vmar().reference_count() != 2
+    }
+
     /// Creates a reader to read data from the user space of the current task.
     ///
     /// Returns `Err` if the `vaddr` and `len` do not represent a user space memory range.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -105,7 +105,6 @@ fn init() {
     time::init();
     net::init();
     sched::init();
-    syscall::init();
     process::init();
     fs::init();
 }

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -2,6 +2,9 @@
 
 pub mod iface;
 pub mod socket;
+mod uts_ns;
+
+pub use uts_ns::UtsNamespace;
 
 pub fn init() {
     iface::init();

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use crate::{
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread, UserNamespace},
+    util::padded,
+};
+
+/// The UTS namespace.
+pub struct UtsNamespace {
+    uts_name: UtsName,
+    owner: Arc<UserNamespace>,
+}
+
+impl UtsNamespace {
+    /// Returns a reference to the singleton initial UTS namespace.
+    pub fn get_init_singleton() -> &'static Arc<UtsNamespace> {
+        static INIT: Once<Arc<UtsNamespace>> = Once::new();
+
+        INIT.call_once(|| {
+            // We intentionally report Linux-like UTS values instead of Asterinas' real
+            // name and version. These spoofed values satisfy glibc, which inspects
+            // uname fields (sysname, release, version, etc.) and expects Linux-compatible data.
+            let uts_name = UtsName {
+                sysname: padded(b"Linux"),
+                nodename: padded(b"WHITLEY"),
+                release: padded(b"5.13.0"),
+                version: padded(b"5.13.0"),
+                machine: padded(b"x86_64"),
+                domainname: padded(b""),
+            };
+
+            let owner = UserNamespace::get_init_singleton().clone();
+
+            Arc::new(Self { uts_name, owner })
+        })
+    }
+
+    /// Clones a new UTS namespace from `self`.
+    pub fn new_clone(
+        &self,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        Ok(Arc::new(Self {
+            uts_name: self.uts_name,
+            owner,
+        }))
+    }
+
+    /// Returns the owner user namespace of the namespace.
+    pub fn owner_ns(&self) -> &Arc<UserNamespace> {
+        &self.owner
+    }
+
+    /// Returns the UTS name.
+    pub fn uts_name(&self) -> &UtsName {
+        &self.uts_name
+    }
+}
+
+const UTS_FIELD_LEN: usize = 65;
+
+#[derive(Debug, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct UtsName {
+    sysname: [u8; UTS_FIELD_LEN],
+    nodename: [u8; UTS_FIELD_LEN],
+    release: [u8; UTS_FIELD_LEN],
+    version: [u8; UTS_FIELD_LEN],
+    machine: [u8; UTS_FIELD_LEN],
+    domainname: [u8; UTS_FIELD_LEN],
+}

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -25,7 +25,7 @@ pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use namespace::{
-    nsproxy::{check_unsupported_ns_flags, ContextNsAdminApi, NsProxy, NsProxyBuilder},
+    nsproxy::{check_unsupported_ns_flags, ContextSetNsAdminApi, NsProxy, NsProxyBuilder},
     unshare::ContextUnshareAdminApi,
     user_ns::UserNamespace,
 };

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -26,6 +26,7 @@ pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use namespace::{
     nsproxy::{check_unsupported_ns_flags, ContextNsAdminApi, NsProxy, NsProxyBuilder},
+    unshare::ContextUnshareAdminApi,
     user_ns::UserNamespace,
 };
 pub use pid_file::PidFile;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -4,6 +4,7 @@ mod clone;
 pub mod credentials;
 mod exit;
 mod kill;
+mod namespace;
 mod pid_file;
 pub mod posix_thread;
 #[expect(clippy::module_inception)]
@@ -23,6 +24,10 @@ mod wait;
 pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
+pub use namespace::{
+    nsproxy::{check_unsupported_ns_flags, ContextNsAdminApi, NsProxy, NsProxyBuilder},
+    user_ns::UserNamespace,
+};
 pub use pid_file::PidFile;
 pub use process::{
     broadcast_signal_async, enqueue_signal_async, spawn_init_process, ExitCode, JobControl, Pgid,

--- a/kernel/src/process/namespace/mod.rs
+++ b/kernel/src/process/namespace/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub(super) mod nsproxy;
+pub(super) mod unshare;
 pub(super) mod user_ns;

--- a/kernel/src/process/namespace/mod.rs
+++ b/kernel/src/process/namespace/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(super) mod nsproxy;
+pub(super) mod user_ns;

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use crate::{
+    net::UtsNamespace,
+    prelude::*,
+    process::{posix_thread::PosixThread, CloneFlags, UserNamespace},
+};
+
+/// A struct that acts as a per-thread proxy to give access to most namespaces.
+///
+/// Each `PosixThread` owns an instance of `NsProxy`
+/// and keeps a local copy in `ThreadLocal` for fast access.
+/// `NsProxy` contains all types of namespaces except
+/// 1. The user namespace, which is included in the `Process` struct.
+/// 2. The PID namespace, which is included in the `Process` struct (TODO).
+pub struct NsProxy {
+    uts_ns: Arc<UtsNamespace>,
+}
+
+impl NsProxy {
+    /// Returns a reference to the singleton initial `NsProxy`.
+    pub(in crate::process) fn get_init_singleton() -> &'static Arc<Self> {
+        static INIT: Once<Arc<NsProxy>> = Once::new();
+        INIT.call_once(|| {
+            Arc::new(NsProxy {
+                uts_ns: UtsNamespace::get_init_singleton().clone(),
+            })
+        })
+    }
+
+    /// Creates a new `NsProxy` by cloning from an existing `NsProxy`.
+    ///
+    /// If no namespaces need to be cloned, this method simply clones `self` and returns.
+    /// Otherwise, a new `NsProxy` will be created
+    /// by selectively cloning fields from the proxy and newly created namespaces.
+    //
+    // FIXME: This method is currently used by both `unshare()` and `clone()`.
+    // Once we support PID and time namespaces, their semantics diverge.
+    // We will need to refactor (or split) this method accordingly.
+    pub(in crate::process) fn new_clone(
+        self: &Arc<Self>,
+        user_ns: &Arc<UserNamespace>,
+        clone_flags: CloneFlags,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        let clone_ns_flags = (clone_flags & CloneFlags::CLONE_NS_FLAGS) - CloneFlags::CLONE_NEWUSER;
+
+        // Fast path: If there are no new namespaces to clone,
+        // we can directly clone the proxy and return.
+        if clone_ns_flags.is_empty() {
+            return Ok(self.clone());
+        }
+
+        // Slow path: One or more namespaces need to be cloned,
+        // so a new `NsProxy` must be created.
+
+        check_unsupported_ns_flags(clone_ns_flags)?;
+
+        let mut builder = NsProxyBuilder::new(self);
+
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
+            let uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
+            builder.uts_ns(uts_ns);
+        }
+
+        // TODO: Support other namespaces.
+
+        Ok(Arc::new(builder.build()))
+    }
+
+    /// Returns the associated UTS namespace.
+    pub fn uts_ns(&self) -> &Arc<UtsNamespace> {
+        &self.uts_ns
+    }
+}
+
+/// A builder for creating a new `NsProxy` by selectively cloning namespaces
+/// from an existing one.
+pub struct NsProxyBuilder<'a> {
+    old_proxy: &'a NsProxy,
+
+    // Fields for new namespaces.
+    uts_ns: Option<Arc<UtsNamespace>>,
+}
+
+impl<'a> NsProxyBuilder<'a> {
+    /// Creates a builder based on an existing `NsProxy`.
+    pub fn new(old_proxy: &'a NsProxy) -> Self {
+        Self {
+            old_proxy,
+            uts_ns: None,
+        }
+    }
+
+    /// Sets the new UTS namespace.
+    pub fn uts_ns(&mut self, uts_ns: Arc<UtsNamespace>) -> &mut Self {
+        self.uts_ns = Some(uts_ns);
+        self
+    }
+
+    /// Builds the new `NsProxy`.
+    pub fn build(self) -> NsProxy {
+        let Self {
+            old_proxy,
+            uts_ns: new_uts,
+        } = self;
+
+        let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
+
+        NsProxy { uts_ns: new_uts }
+    }
+}
+
+/// Checks if the given `flags` contain any unsupported namespace-related flags.
+///
+/// This method does _not_ check CLONE_NEWUSER since it's handled separately.
+pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
+    const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWUTS;
+
+    let unsupported_flags =
+        (flags & CloneFlags::CLONE_NS_FLAGS) - SUPPORTED_FLAGS - CloneFlags::CLONE_NEWUSER;
+    if unsupported_flags.is_empty() {
+        return Ok(());
+    }
+
+    warn!("unsupported clone ns flags: {:?}", unsupported_flags);
+    return_errno_with_message!(Errno::EINVAL, "unsupported clone namespace flags");
+}

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::RwArc;
+
+use crate::{prelude::*, process::CloneFlags};
+
+/// Provides administrative APIs for disassociating execution contexts.
+pub trait ContextUnshareAdminApi {
+    /// Unshares the file table.
+    fn unshare_files(&self);
+    /// Unshares filesystem attributes.
+    fn unshare_fs(&self);
+    /// Unshares System V semaphore.
+    fn unshare_sysvsem(&self);
+    /// Creates and enters new namespaces as specified by the `flags` argument.
+    fn unshare_namespaces(&self, flags: CloneFlags) -> Result<()>;
+}
+
+impl ContextUnshareAdminApi for Context<'_> {
+    fn unshare_files(&self) {
+        let mut pthread_file_table = self.posix_thread.file_table().lock();
+
+        let mut thread_local_file_table_ref = self.thread_local.borrow_file_table_mut();
+        let thread_local_file_table = thread_local_file_table_ref.unwrap();
+
+        let new_file_table = RwArc::new(thread_local_file_table.read().clone());
+
+        *pthread_file_table = Some(new_file_table.clone_ro());
+        *thread_local_file_table = new_file_table;
+    }
+
+    fn unshare_fs(&self) {
+        let mut fs_ref = self.thread_local.borrow_fs_mut();
+        let new_fs = fs_ref.as_ref().clone();
+        *fs_ref = Arc::new(new_fs);
+    }
+
+    fn unshare_sysvsem(&self) {
+        // TODO: Support unsharing System V semaphore.
+        warn!("unsharing System V semaphore is not supported");
+    }
+
+    fn unshare_namespaces(&self, flags: CloneFlags) -> Result<()> {
+        if flags.contains(CloneFlags::CLONE_NEWUSER) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "cloning a new user namespace is not supported"
+            );
+        }
+
+        let user_ns_ref = self.thread_local.borrow_user_ns();
+
+        let mut pthread_ns_proxy = self.posix_thread.ns_proxy().lock();
+
+        let mut thread_local_ns_proxy_ref = self.thread_local.borrow_ns_proxy_mut();
+        let thread_local_ns_proxy = thread_local_ns_proxy_ref.unwrap();
+
+        let new_ns_proxy =
+            thread_local_ns_proxy.new_clone(&user_ns_ref, flags, self.posix_thread)?;
+
+        *pthread_ns_proxy = Some(new_ns_proxy.clone());
+        *thread_local_ns_proxy = new_ns_proxy;
+
+        Ok(())
+    }
+}

--- a/kernel/src/process/namespace/user_ns.rs
+++ b/kernel/src/process/namespace/user_ns.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use crate::{
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// The user namespace.
+pub struct UserNamespace {
+    _private: (),
+}
+
+impl UserNamespace {
+    /// Returns a reference to the singleton initial user namespace.
+    pub fn get_init_singleton() -> &'static Arc<UserNamespace> {
+        static INIT: Once<Arc<UserNamespace>> = Once::new();
+
+        INIT.call_once(|| Arc::new(UserNamespace { _private: () }))
+    }
+
+    /// Checks whether the thread has the required capability in this user namespace.
+    pub fn check_cap(&self, required: CapSet, posix_thread: &PosixThread) -> Result<()> {
+        // Since creating new user namespaces is not supported at the moment,
+        // there is effectively only one user namespace in the entire system.
+        // Therefore, the thread has a single set of capabilities used for permission checks.
+        // FIXME: Once support for creating new user namespaces is added,
+        // we should verify the thread's capabilities within the relevant user namespace.
+        let cap_set = posix_thread.credentials().effective_capset();
+        if cap_set.contains(required) {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the thread does not have the required capability"
+        )
+    }
+}

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -57,7 +57,7 @@ impl PidFile {
         self.is_nonblocking.load(Ordering::Relaxed)
     }
 
-    pub(super) fn process(&self) -> &Arc<Process> {
+    pub fn process(&self) -> &Arc<Process> {
         &self.process
     }
 }

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -81,10 +81,12 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
 
     // Drop fields in `PosixThread`.
     *posix_thread.file_table().lock() = None;
+    *posix_thread.ns_proxy().lock() = None;
 
     // Drop fields in `ThreadLocal`.
     *thread_local.root_vmar().borrow_mut() = None;
     thread_local.borrow_file_table_mut().remove();
+    thread_local.borrow_ns_proxy_mut().remove();
 
     if is_last_thread {
         exit_process(&posix_process);

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     events::Observer,
     fs::file_table::FileTable,
     prelude::*,
-    process::signal::constants::SIGCONT,
+    process::{namespace::nsproxy::NsProxy, signal::constants::SIGCONT},
     thread::{Thread, Tid},
     time::{clocks::ProfClock, Timer, TimerManager},
 };
@@ -77,6 +77,9 @@ pub struct PosixThread {
 
     /// I/O Scheduling priority value
     io_priority: AtomicU32,
+
+    /// The namespaces that the thread belongs to.
+    ns_proxy: Mutex<Option<Arc<NsProxy>>>,
 }
 
 impl PosixThread {
@@ -309,6 +312,11 @@ impl PosixThread {
     /// Returns the I/O priority value of the thread.
     pub fn io_priority(&self) -> &AtomicU32 {
         &self.io_priority
+    }
+
+    /// Returns the namespaces which the thread belongs to.
+    pub fn ns_proxy(&self) -> &Mutex<Option<Arc<NsProxy>>> {
+        &self.ns_proxy
     }
 }
 

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -9,7 +9,7 @@ use super::RobustListHead;
 use crate::{
     fs::{file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
-    process::signal::SigStack,
+    process::{signal::SigStack, NsProxy, UserNamespace},
     vm::vmar::Vmar,
 };
 
@@ -45,9 +45,14 @@ pub struct ThreadLocal {
     sig_context: Cell<Option<Vaddr>>,
     /// Stack address, size, and flags for the signal handler.
     sig_stack: RefCell<SigStack>,
+
+    // Namespaces.
+    user_ns: RefCell<Arc<UserNamespace>>,
+    ns_proxy: RefCell<Option<Arc<NsProxy>>>,
 }
 
 impl ThreadLocal {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         set_child_tid: Vaddr,
         clear_child_tid: Vaddr,
@@ -55,6 +60,8 @@ impl ThreadLocal {
         file_table: RwArc<FileTable>,
         fs: Arc<ThreadFsInfo>,
         fpu_context: FpuContext,
+        user_ns: Arc<UserNamespace>,
+        ns_proxy: Arc<NsProxy>,
     ) -> Self {
         Self {
             set_child_tid: Cell::new(set_child_tid),
@@ -68,6 +75,8 @@ impl ThreadLocal {
             sig_stack: RefCell::new(SigStack::default()),
             fpu_context: RefCell::new(fpu_context),
             fpu_state: Cell::new(FpuState::Unloaded),
+            user_ns: RefCell::new(user_ns),
+            ns_proxy: RefCell::new(Some(ns_proxy)),
         }
     }
 
@@ -127,19 +136,18 @@ impl ThreadLocal {
     }
 
     pub fn borrow_file_table(&self) -> FileTableRef {
-        FileTableRef(self.file_table.borrow())
+        ThreadLocalOptionRef(self.file_table.borrow())
     }
 
     pub fn borrow_file_table_mut(&self) -> FileTableRefMut {
-        FileTableRefMut(self.file_table.borrow_mut())
+        ThreadLocalOptionRefMut(self.file_table.borrow_mut())
     }
 
     pub fn borrow_fs(&self) -> Ref<'_, Arc<ThreadFsInfo>> {
         self.fs.borrow()
     }
 
-    #[expect(dead_code)]
-    pub fn borrow_fs_mut(&self) -> RefMut<'_, Arc<ThreadFsInfo>> {
+    pub(in crate::process) fn borrow_fs_mut(&self) -> RefMut<'_, Arc<ThreadFsInfo>> {
         self.fs.borrow_mut()
     }
 
@@ -153,6 +161,18 @@ impl ThreadLocal {
 
     pub fn fpu(&self) -> ThreadFpu<'_> {
         ThreadFpu(self)
+    }
+
+    pub fn borrow_user_ns(&self) -> Ref<'_, Arc<UserNamespace>> {
+        self.user_ns.borrow()
+    }
+
+    pub fn borrow_ns_proxy(&self) -> NsProxyRef {
+        ThreadLocalOptionRef(self.ns_proxy.borrow())
+    }
+
+    pub(in crate::process) fn borrow_ns_proxy_mut(&self) -> NsProxyRefMut {
+        ThreadLocalOptionRefMut(self.ns_proxy.borrow_mut())
     }
 }
 
@@ -243,40 +263,52 @@ impl ThreadFpu<'_> {
 }
 
 /// An immutable, shared reference to the file table in [`ThreadLocal`].
-pub struct FileTableRef<'a>(Ref<'a, Option<RwArc<FileTable>>>);
+pub type FileTableRef<'a> = ThreadLocalOptionRef<'a, RwArc<FileTable>>;
 
-impl FileTableRef<'_> {
-    /// Unwraps and returns a reference to the file table.
+/// An immutable, shared reference to the `NsProxy` in [`ThreadLocal`].
+pub type NsProxyRef<'a> = ThreadLocalOptionRef<'a, Arc<NsProxy>>;
+
+/// An immutable, shared reference to thread-local data contained within a `RefCell<Option<..>>`.
+pub struct ThreadLocalOptionRef<'a, T>(Ref<'a, Option<T>>);
+
+impl<T> ThreadLocalOptionRef<'_, T> {
+    /// Unwraps and returns a reference to the data.
     ///
     /// # Panics
     ///
-    /// This method will panic if the thread has exited and the file table has been dropped.
-    pub fn unwrap(&self) -> &RwArc<FileTable> {
+    /// This method will panic if the thread has exited and the data has been dropped.
+    pub fn unwrap(&self) -> &T {
         self.0.as_ref().unwrap()
     }
 }
 
 /// A mutable, exclusive reference to the file table in [`ThreadLocal`].
-pub struct FileTableRefMut<'a>(RefMut<'a, Option<RwArc<FileTable>>>);
+pub type FileTableRefMut<'a> = ThreadLocalOptionRefMut<'a, RwArc<FileTable>>;
 
-impl FileTableRefMut<'_> {
-    /// Unwraps and returns a reference to the file table.
+/// A mutable, exclusive reference to the `NsProxy` in [`ThreadLocal`].
+pub(in crate::process) type NsProxyRefMut<'a> = ThreadLocalOptionRefMut<'a, Arc<NsProxy>>;
+
+/// A mutable, exclusive reference to thread-local data contained within a `RefCell<Option<..>>`.
+pub struct ThreadLocalOptionRefMut<'a, T>(RefMut<'a, Option<T>>);
+
+impl<T> ThreadLocalOptionRefMut<'_, T> {
+    /// Unwraps and returns a reference to the data.
     ///
     /// # Panics
     ///
-    /// This method will panic if the thread has exited and the file table has been dropped.
-    pub fn unwrap(&mut self) -> &mut RwArc<FileTable> {
+    /// This method will panic if the thread has exited and the data has been dropped.
+    pub fn unwrap(&mut self) -> &mut T {
         self.0.as_mut().unwrap()
     }
 
-    /// Removes the file table and drops it.
+    /// Removes the data and drops it.
     pub(super) fn remove(&mut self) {
         *self.0 = None;
     }
 
-    /// Replaces the file table with a new one, returning the old one.
-    pub fn replace(&mut self, new_table: Option<RwArc<FileTable>>) -> Option<RwArc<FileTable>> {
-        core::mem::replace(&mut *self.0, new_table)
+    /// Replaces the data with a new one, returning the old one.
+    pub(in crate::process) fn replace(&mut self, new: Option<T>) -> Option<T> {
+        core::mem::replace(&mut *self.0, new)
     }
 }
 

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -17,7 +17,7 @@ use crate::{
         process_vm::ProcessVm,
         rlimit::ResourceLimits,
         signal::sig_disposition::SigDispositions,
-        Credentials, ProgramToLoad,
+        Credentials, ProgramToLoad, UserNamespace,
     },
     sched::Nice,
     thread::Tid,
@@ -52,6 +52,7 @@ fn create_init_process(
     let resource_limits = ResourceLimits::default();
     let nice = Nice::default();
     let sig_dispositions = Arc::new(Mutex::new(SigDispositions::default()));
+    let user_ns = UserNamespace::get_init_singleton().clone();
 
     let init_proc = Process::new(
         pid,
@@ -61,6 +62,7 @@ fn create_init_process(
         resource_limits,
         nice,
         sig_dispositions,
+        user_ns,
     );
 
     let init_task = create_init_task(

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -117,6 +117,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -326,6 +327,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -148,6 +148,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -232,6 +233,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1]);
     SYS_WAITID = 95                  => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96         => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97                 => sys_unshare(args[..1]);
     SYS_FUTEX = 98                   => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99         => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101              => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -117,6 +117,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -328,6 +329,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -148,6 +148,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -232,6 +233,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1]);
     SYS_WAITID = 95                  => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96         => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97                 => sys_unshare(args[..1]);
     SYS_FUTEX = 98                   => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99         => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101              => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -161,6 +161,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
+    unshare::sys_unshare,
     utimens::{sys_futimesat, sys_utime, sys_utimensat, sys_utimes},
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -356,6 +357,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FACCESSAT = 269        => sys_faccessat(args[..3]);
     SYS_PSELECT6 = 270         => sys_pselect6(args[..6]);
     SYS_PPOLL = 271            => sys_ppoll(args[..5]);
+    SYS_UNSHARE = 272          => sys_unshare(args[..1]);
     SYS_SET_ROBUST_LIST = 273  => sys_set_robust_list(args[..2]);
     SYS_UTIMENSAT = 280        => sys_utimensat(args[..4]);
     SYS_EPOLL_PWAIT = 281      => sys_epoll_pwait(args[..6]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -129,6 +129,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -376,6 +377,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PREADV = 295           => sys_preadv(args[..4]);
     SYS_PWRITEV = 296          => sys_pwritev(args[..4]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_SETNS = 308            => sys_setns(args[..2]);
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);
     SYS_SCHED_SETATTR = 314    => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 315    => sys_sched_getattr(args[..4]);

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use bitflags::bitflags;
-use ostd::sync::RwArc;
 
 use super::SyscallReturn;
 use crate::{
     fs::file_table::{FdFlags, FileDesc},
     prelude::*,
+    process::ContextUnshareAdminApi,
 };
 
 bitflags! {
@@ -57,23 +57,21 @@ pub fn sys_close_range(
 
     let flags = CloseRangeFlags::from_bits(raw_flags).ok_or_else(|| Error::new(Errno::EINVAL))?;
 
-    let original_table = ctx.thread_local.borrow_file_table().unwrap().clone();
+    if flags.contains(CloseRangeFlags::UNSHARE) {
+        // FIXME: While directly invoking `unshare_files` is logically correct,
+        // it might not be the most efficient approach.
+        // `unshare_files` clones the entire file table by duplicating all its entries.
+        // However, in the context of `close_range`,
+        // cloning files that are about to be closed is unnecessary overhead.
+        ctx.unshare_files();
+    }
 
-    let file_table = if flags.contains(CloseRangeFlags::UNSHARE) {
-        let new_table = RwArc::new(original_table.get_cloned());
-        let _ = ctx
-            .thread_local
-            .borrow_file_table_mut()
-            .replace(Some(new_table.clone()));
-        new_table
-    } else {
-        original_table
-    };
+    let file_table = ctx.thread_local.borrow_file_table();
 
     let mut files_to_drop = Vec::new();
 
     {
-        let mut file_table_locked = file_table.write();
+        let mut file_table_locked = file_table.unwrap().write();
 
         let table_len = file_table_locked.len() as u32;
         if first >= table_len {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -401,7 +401,3 @@ macro_rules! log_syscall_entry {
         }
     };
 }
-
-pub(super) fn init() {
-    uname::init();
-}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -145,6 +145,7 @@ mod setfsuid;
 mod setgid;
 mod setgroups;
 mod setitimer;
+mod setns;
 mod setpgid;
 mod setregid;
 mod setresgid;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -177,6 +177,7 @@ mod umask;
 mod umount;
 mod uname;
 mod unlink;
+mod unshare;
 mod utimens;
 mod wait4;
 mod waitid;

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module implements the `setns` syscall.
+//!
+//! This syscall reassociates the calling thread with a namespace specified by a
+//! file descriptor. The `flags` argument determines which type of namespace can be
+//! joined.
+//!
+//! The file descriptor `fd` can refer to:
+//! 1. A namespace file from `/proc/[pid]/ns/`.
+//! 2. A `PidFile` opened by `pidfd_open` or by opening `/proc/[pid]` directory.
+
+use crate::{
+    fs::file_table::FileDesc,
+    net::UtsNamespace,
+    prelude::*,
+    process::{
+        check_unsupported_ns_flags, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
+        CloneFlags, ContextSetNsAdminApi, NsProxy, NsProxyBuilder, PidFile,
+    },
+    syscall::SyscallReturn,
+};
+
+pub fn sys_setns(fd: FileDesc, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let ns_type_flags = CloneFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid `setns` flags"))?;
+    debug!("setns flags = {:?}", ns_type_flags);
+
+    let file = {
+        let file_table = ctx.thread_local.borrow_file_table();
+        let file_table_locked = file_table.unwrap().read();
+        file_table_locked.get_file(fd)?.clone()
+    };
+
+    let new_ns_proxy = if let Some(pid_file) = file.downcast_ref::<PidFile>() {
+        build_proxy_from_pid_file(pid_file, ns_type_flags, ctx)?
+    }
+    // TODO: Support setting namespaces from `/proc/[pid]/ns`.
+    else {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the FD does not refer to a supported namespace file"
+        );
+    };
+
+    // Install the newly created `NsProxy`.
+    ctx.set_ns_proxy(Arc::new(new_ns_proxy));
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn build_proxy_from_pid_file(
+    pid_file: &PidFile,
+    flags: CloneFlags,
+    ctx: &Context,
+) -> Result<NsProxy> {
+    if flags.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "flags must be specified with a PID file");
+    }
+
+    // Check for any flags that are not namespace-related.
+    if !(flags - CloneFlags::CLONE_NS_FLAGS).is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "invalid flags are specified with a PID file");
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        return_errno_with_message!(Errno::EINVAL, "setting a user namespace is not supported");
+    }
+
+    check_unsupported_ns_flags(flags)?;
+
+    let target_thread = pid_file.process().main_thread();
+    let target_proxy = target_thread.as_posix_thread().unwrap().ns_proxy().lock();
+    let Some(target_proxy) = target_proxy.as_ref() else {
+        return_errno_with_message!(Errno::ESRCH, "the target process has exited");
+    };
+
+    let current_proxy = ctx.thread_local.borrow_ns_proxy();
+    let current_proxy = current_proxy.unwrap();
+
+    let mut builder = NsProxyBuilder::new(current_proxy);
+
+    if flags.contains(CloneFlags::CLONE_NEWUTS) {
+        let target_ns = target_proxy.uts_ns();
+        set_uts_ns(&mut builder, target_ns, ctx)?;
+    }
+
+    // TODO: Support setting other namespaces from the target process.
+
+    Ok(builder.build())
+}
+
+fn set_uts_ns(
+    builder: &mut NsProxyBuilder,
+    target_ns: &Arc<UtsNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
+    // and the current user namespace.
+    target_ns
+        .owner_ns()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    ctx.thread_local
+        .borrow_user_ns()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+
+    // TODO: Are the checks above sufficient?
+
+    builder.uts_ns(target_ns.clone());
+
+    Ok(())
+}

--- a/kernel/src/syscall/uname.rs
+++ b/kernel/src/syscall/uname.rs
@@ -1,62 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
-
-use spin::Once;
-
 use super::SyscallReturn;
 use crate::prelude::*;
 
-// We don't use the real name and version of our os here. Instead, we pick up fake values witch is the same as the ones of linux.
-// The values are used to fool glibc since glibc will check the version and os name.
-static UTS_NAME: Once<UtsName> = Once::new();
-
-const UTS_FIELD_LEN: usize = 65;
-
-#[derive(Debug, Clone, Copy, Pod)]
-#[repr(C)]
-struct UtsName {
-    sysname: [u8; UTS_FIELD_LEN],
-    nodename: [u8; UTS_FIELD_LEN],
-    release: [u8; UTS_FIELD_LEN],
-    version: [u8; UTS_FIELD_LEN],
-    machine: [u8; UTS_FIELD_LEN],
-    domainname: [u8; UTS_FIELD_LEN],
-}
-
-impl UtsName {
-    const fn new() -> Self {
-        UtsName {
-            sysname: [0; UTS_FIELD_LEN],
-            nodename: [0; UTS_FIELD_LEN],
-            release: [0; UTS_FIELD_LEN],
-            version: [0; UTS_FIELD_LEN],
-            machine: [0; UTS_FIELD_LEN],
-            domainname: [0; UTS_FIELD_LEN],
-        }
-    }
-}
-
-pub(super) fn init() {
-    UTS_NAME.call_once(|| {
-        let copy_slice = |src: &[u8], dst: &mut [u8]| {
-            let len = src.len().min(dst.len());
-            dst[..len].copy_from_slice(&src[..len]);
-        };
-
-        let mut uts_name = UtsName::new();
-        copy_slice(b"Linux", &mut uts_name.sysname);
-        copy_slice(b"WHITLEY", &mut uts_name.nodename);
-        copy_slice(b"5.13.0", &mut uts_name.release);
-        copy_slice(b"5.13.0", &mut uts_name.version);
-        copy_slice(b"x86_64", &mut uts_name.machine);
-        copy_slice(b"", &mut uts_name.domainname);
-
-        uts_name
-    });
-}
-
 pub fn sys_uname(old_uname_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("old uname addr = 0x{:x}", old_uname_addr);
-    ctx.user_space()
-        .write_val(old_uname_addr, UTS_NAME.get().unwrap())?;
+    let ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let uts_name = ns_proxy.unwrap().uts_ns().uts_name();
+    ctx.user_space().write_val(old_uname_addr, uts_name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    prelude::*,
+    process::{CloneFlags, ContextUnshareAdminApi},
+    syscall::SyscallReturn,
+};
+
+pub fn sys_unshare(unshare_flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let mut flags = CloneFlags::from_bits(unshare_flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid `unshare` flags"))?;
+    debug!("unshare flags = {:?}", flags);
+
+    apply_implied_flags(&mut flags);
+    check_flags(flags, ctx)?;
+
+    if flags.contains(CloneFlags::CLONE_FILES) {
+        ctx.unshare_files();
+    }
+
+    if flags.contains(CloneFlags::CLONE_FS) {
+        ctx.unshare_fs();
+    }
+
+    if flags.contains(CloneFlags::CLONE_SYSVSEM) {
+        ctx.unshare_sysvsem();
+    }
+
+    let ns_flags = flags.intersection(CloneFlags::CLONE_NS_FLAGS);
+    if !ns_flags.is_empty() {
+        ctx.unshare_namespaces(ns_flags)?;
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn apply_implied_flags(flags: &mut CloneFlags) {
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        *flags |= CloneFlags::CLONE_THREAD | CloneFlags::CLONE_FS;
+    }
+
+    if flags.contains(CloneFlags::CLONE_SIGHAND) {
+        *flags |= CloneFlags::CLONE_THREAD;
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWNS) {
+        *flags |= CloneFlags::CLONE_FS;
+    }
+}
+
+fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
+    const VALID_FLAGS: CloneFlags = CloneFlags::CLONE_NS_FLAGS
+        .union(CloneFlags::CLONE_FILES)
+        .union(CloneFlags::CLONE_FS)
+        .union(CloneFlags::CLONE_SYSVSEM)
+        .union(CloneFlags::CLONE_THREAD)
+        .union(CloneFlags::CLONE_VM)
+        .union(CloneFlags::CLONE_SIGHAND);
+
+    let invalid_flags = flags - VALID_FLAGS;
+    if !invalid_flags.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "unsupported `unshare` flags");
+    }
+
+    if flags.intersects(CloneFlags::CLONE_THREAD | CloneFlags::CLONE_VM | CloneFlags::CLONE_SIGHAND)
+        && ctx.process.tasks().lock().as_slice().len() != 1
+    {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "`CLONE_THREAD`, `CLONE_VM`, and `CLONE_SIGHAND` can be specified only if the process is single-threaded"
+        );
+    }
+
+    if flags.contains(CloneFlags::CLONE_VM) && ctx.user_space().is_vmar_shared() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "`CLONE_VM` can only be used when the VMAR is not shared"
+        );
+    }
+
+    Ok(())
+}

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -2,8 +2,10 @@
 
 mod iovec;
 pub mod net;
+mod padded;
 pub mod per_cpu_counter;
 pub mod random;
 pub mod ring_buffer;
 
 pub use iovec::{MultiRead, MultiWrite, VmReaderArray, VmWriterArray};
+pub use padded::padded;

--- a/kernel/src/util/padded.rs
+++ b/kernel/src/util/padded.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// Creates a fixed-size byte array out of a byte slice.
+///
+/// # Example
+///
+/// ```
+/// let fixed_size_text: [u8; 128] = padded(b"Hello World");
+/// ```
+///
+/// Without this `padded` utility function,
+/// one would have to write a more lengthy but less efficient version.
+///
+/// ```
+/// let fixed_size_text: [u8; 128] = {
+///    const HELLO: &[u8] = b"Hello World";
+///    let mut buf = [0u8; 128];
+///    buf[..HELLO.len()].copy_from_slice(HELLO);
+///    buf
+/// };
+/// ```
+pub const fn padded<const N: usize>(s: &[u8]) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut i = 0;
+    while i < s.len() && i < N {
+        out[i] = s[i];
+        i += 1;
+    }
+    out
+}

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -129,6 +129,11 @@ impl<R> Vmar<R> {
     ) -> Result<Vaddr> {
         self.0.remap(old_addr, old_size, new_addr, new_size)
     }
+
+    /// Returns the reference count of the VMAR.
+    pub fn reference_count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
 }
 
 pub(super) struct Vmar_ {

--- a/test/src/apps/Makefile
+++ b/test/src/apps/Makefile
@@ -30,6 +30,7 @@ TEST_APPS := \
 	itimer \
 	mmap \
 	mongoose \
+	namespace \
 	network \
 	pipe \
 	prctl \

--- a/test/src/apps/namespace/Makefile
+++ b/test/src/apps/namespace/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/src/apps/namespace/setns.c
+++ b/test/src/apps/namespace/setns.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/syscall.h>
+
+#include "../test.h"
+
+FN_TEST(set_ns_empty_flags)
+{
+	// FIXME: The following test will fail on Asterinas
+	// because it currently does not support ns file.
+	// const char *ns_path = "/proc/self/ns/user";
+	// int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	// TEST_ERRNO(setns(fd_ns, 0), EINVAL);
+	// TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, 0), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_self_ns)
+{
+	// It is not permitted to use setns() to reenter the caller's
+	// current user namespace. This is different from other namespaces.
+	// FIXME: The following test will fail on Asterinas
+	// because it currently does not support ns file.
+	// const char *ns_path = "/proc/self/ns/user";
+	// int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	// TEST_ERRNO(setns(fd_ns, CLONE_NEWUSER), EINVAL);
+	// TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, CLONE_NEWUSER), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()

--- a/test/src/apps/namespace/unshare.c
+++ b/test/src/apps/namespace/unshare.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sched.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+
+#include "../test.h"
+
+FN_TEST(invalid_flags)
+{
+	TEST_ERRNO(unshare(CLONE_CHILD_CLEARTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_CHILD_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_DETACHED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_IO), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PIDFD), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PTRACE), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SETTLS), EINVAL);
+	TEST_ERRNO(unshare(CLONE_UNTRACED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_VFORK), EINVAL);
+}
+END_TEST()
+
+void *sleep_1s_thread(void *arg)
+{
+	sleep(1);
+}
+
+FN_TEST(single_thread_flags)
+{
+	TEST_SUCC(unshare(CLONE_VM | CLONE_SIGHAND | CLONE_THREAD));
+
+	pthread_t thread_id;
+	TEST_SUCC(pthread_create(&thread_id, NULL, sleep_1s_thread, NULL));
+
+	TEST_ERRNO(unshare(CLONE_VM), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SIGHAND), EINVAL);
+	TEST_ERRNO(unshare(CLONE_THREAD), EINVAL);
+
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_SUCC(unshare(CLONE_VM));
+	TEST_SUCC(unshare(CLONE_SIGHAND));
+	TEST_SUCC(unshare(CLONE_THREAD));
+}
+END_TEST()
+
+void *unshare_files_thread(void *arg)
+{
+	int test_fd = (int)(intptr_t)arg;
+
+	CHECK(unshare(CLONE_FILES));
+	CHECK(close(test_fd));
+}
+
+FN_TEST(unshare_files)
+{
+	struct stat old_stdin_stat, old_stdout_stat, old_stderr_stat;
+	struct stat new_stdin_stat, new_stdout_stat, new_stderr_stat;
+
+	TEST_SUCC(fstat(STDIN_FILENO, &old_stdin_stat));
+	TEST_SUCC(fstat(STDOUT_FILENO, &old_stdout_stat));
+	TEST_SUCC(fstat(STDERR_FILENO, &old_stderr_stat));
+
+	TEST_SUCC(unshare(CLONE_FILES));
+
+	TEST_RES(fstat(STDIN_FILENO, &new_stdin_stat),
+		 old_stdin_stat.st_ino == new_stdin_stat.st_ino);
+	TEST_RES(fstat(STDOUT_FILENO, &new_stdout_stat),
+		 old_stdout_stat.st_ino == new_stdout_stat.st_ino);
+	TEST_RES(fstat(STDERR_FILENO, &new_stderr_stat),
+		 old_stderr_stat.st_ino == new_stderr_stat.st_ino);
+
+	const char *TEST_FILENAME = "/tmp/unshare_files_test.txt";
+	pthread_t thread_id;
+	struct stat stat1, stat2;
+	int test_fd;
+
+	test_fd = TEST_SUCC(
+		open(TEST_FILENAME, O_CREAT | O_RDWR | O_TRUNC, 0644));
+	TEST_SUCC(fstat(test_fd, &stat1));
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_files_thread,
+				 (void *)(intptr_t)test_fd));
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_RES(fstat(test_fd, &stat2), stat1.st_ino == stat2.st_ino);
+	TEST_SUCC(close(test_fd));
+	TEST_SUCC(unlink(TEST_FILENAME));
+}
+END_TEST()
+
+#define CWD_BUF_SIZE 1024
+#define THREAD_CWD "/tmp"
+
+void *unshare_fs_thread(void *arg)
+{
+	CHECK(unshare(CLONE_FS));
+
+	CHECK(chdir(THREAD_CWD));
+	CHECK(getcwd((char *)arg, CWD_BUF_SIZE));
+}
+
+FN_TEST(unshare_fs)
+{
+	char cwd_buf1[CWD_BUF_SIZE], cwd_buf2[CWD_BUF_SIZE];
+	pthread_t thread_id;
+
+	TEST_RES(getcwd(cwd_buf1, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, THREAD_CWD) != 0);
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_fs_thread,
+				 (void *)cwd_buf2));
+
+	TEST_RES(pthread_join(thread_id, NULL),
+		 strcmp(cwd_buf2, THREAD_CWD) == 0);
+
+	TEST_RES(getcwd(cwd_buf2, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, cwd_buf2) == 0);
+}
+END_TEST()

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,6 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
+namespace/unshare
 process/group_session
 process/job_control
 process/pidfd

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,6 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
+namespace/setns
 namespace/unshare
 process/group_session
 process/job_control


### PR DESCRIPTION
This PR originates from #2303, but I remove the procfs related parts. The procfs entries still have some problems and need more design to make it work correctly.

The design part about this PR is in #2313.

This PR introduces the fundamental structures and interfaces related to namespaces. Before implementing any concrete namespaces, we first need to decide where namespaces should be placed and how they will be accessed.

Also two syscalls which are used to operate on namespaces, `unshare` and `setns` are added.

Additionally, this PR includes a dummy user namespace to demonstrate the usage of these APIs. Since it is a placeholder implementation, all operations on the user namespace currently return `EINVAL`. 

The PR consists of 6 commits now:

1. The first commit adds the basic namespace framework and a dummy user namespace. 
An question about the user namespace is that how capability check APIs should look like? Will the check only use credentials from posix thread or will it interact with user namespace? From [the manual](https://man7.org/linux/man-pages/man7/user_namespaces.7.html): 
> - A process has a capability inside a user namespace if it is a
>          member of that namespace and it has the capability in its
>         effective capability set.
> - If a process has a capability in a user namespace, then it has
>          that capability in all child (and further removed descendant)
>         namespaces as well.
> - When a user namespace is created, the kernel records the
>          effective user ID of the creating process as being the "owner"
>          of the namespace.  A process that resides in the parent of the
>          user namespace and whose effective user ID matches the owner of
>          the namespace has all capabilities in the namespace.

So I think the current API should be reasonable: All capability check must consider the user namespace, instead of only considering the capability set in posix thread.

2. The second commit adds the unshare syscall.
3. The third commit adds the setns syscall.
4. The fourth commit fixes the unshare file table logic in the `close_range` syscall, which is a trivial fix.