### PR TITLE
Clean up the code for the VFS path module

### DIFF
--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -28,7 +28,7 @@ pub fn init() -> Result<()> {
         let devpts_path =
             dev.new_fs_child("pts", InodeType::Dir, InodeMode::from_bits_truncate(0o755))?;
         let devpts_mount_node = devpts_path.mount(DevPts::new())?;
-        Path::new_fs_root(devpts_mount_node.clone())
+        Path::new_fs_root(devpts_mount_node)
     };
 
     DEV_PTS.call_once(|| devpts_path);

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -27,8 +27,8 @@ pub fn init() -> Result<()> {
         // Create the "pts" directory and mount devpts on it.
         let devpts_path =
             dev.new_fs_child("pts", InodeType::Dir, InodeMode::from_bits_truncate(0o755))?;
-        let devpts_mount_node = devpts_path.mount(DevPts::new())?;
-        Path::new_fs_root(devpts_mount_node)
+        let devpts_mount = devpts_path.mount(DevPts::new())?;
+        Path::new_fs_root(devpts_mount)
     };
 
     DEV_PTS.call_once(|| devpts_path);

--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -1183,19 +1183,19 @@ mod tests {
     use ostd::{mm::VmIo, prelude::ktest};
 
     use super::*;
-    use crate::fs::{path::MountNode, ramfs::RamFS};
+    use crate::fs::{path::Mount, ramfs::RamFS};
 
     fn create_overlay_fs() -> Arc<dyn FileSystem> {
         crate::time::clocks::init_for_ktest();
 
         let mode = InodeMode::all();
         let upper = {
-            let root_mount = MountNode::new_root(RamFS::new());
+            let root_mount = Mount::new_root(RamFS::new());
             Path::new_fs_root(root_mount)
         };
         let lower = {
-            let r1 = MountNode::new_root(RamFS::new());
-            let r2 = MountNode::new_root(RamFS::new());
+            let r1 = Mount::new_root(RamFS::new());
+            let r2 = Mount::new_root(RamFS::new());
 
             let l1 = Path::new_fs_root(r1);
             l1.new_fs_child("f1", InodeType::File, mode).unwrap();
@@ -1233,9 +1233,9 @@ mod tests {
     fn work_and_upper_should_be_in_same_mount() {
         crate::time::clocks::init_for_ktest();
 
-        let upper = Path::new_fs_root(MountNode::new_root(RamFS::new()));
-        let lower = vec![Path::new_fs_root(MountNode::new_root(RamFS::new()))];
-        let work = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+        let upper = Path::new_fs_root(Mount::new_root(RamFS::new()));
+        let lower = vec![Path::new_fs_root(Mount::new_root(RamFS::new()))];
+        let work = Path::new_fs_root(Mount::new_root(RamFS::new()));
 
         let Err(e) = OverlayFS::new(upper, lower, work) else {
             panic!("OverlayFS::new should fail when work and upper are not in the same mount");
@@ -1249,11 +1249,11 @@ mod tests {
 
         let mode = InodeMode::all();
         let upper = {
-            let root = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+            let root = Path::new_fs_root(Mount::new_root(RamFS::new()));
             root.new_fs_child("file", InodeType::File, mode).unwrap();
             root
         };
-        let lower = vec![Path::new_fs_root(MountNode::new_root(RamFS::new()))];
+        let lower = vec![Path::new_fs_root(Mount::new_root(RamFS::new()))];
         let work = upper.clone();
 
         let Err(e) = OverlayFS::new(upper, lower, work) else {
@@ -1267,7 +1267,7 @@ mod tests {
         crate::time::clocks::init_for_ktest();
 
         let mode = InodeMode::all();
-        let root = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+        let root = Path::new_fs_root(Mount::new_root(RamFS::new()));
         let upper = {
             let dir = root.new_fs_child("upper", InodeType::Dir, mode).unwrap();
             dir.new_fs_child("f1", InodeType::File, mode).unwrap();
@@ -1279,7 +1279,7 @@ mod tests {
         };
         let lower = {
             let l1 = {
-                let r1 = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+                let r1 = Path::new_fs_root(Mount::new_root(RamFS::new()));
                 r1.new_fs_child("f1", InodeType::Dir, mode).unwrap();
                 r1.new_fs_child("f2", InodeType::File, mode).unwrap();
                 let d1 = r1.new_fs_child("d1", InodeType::Dir, mode).unwrap();
@@ -1294,7 +1294,7 @@ mod tests {
                 r1
             };
             let l2 = {
-                let r2 = Path::new_fs_root(MountNode::new_root(RamFS::new()));
+                let r2 = Path::new_fs_root(Mount::new_root(RamFS::new()));
                 r2.new_fs_child("f1", InodeType::File, mode).unwrap();
                 r2.new_fs_child("d1", InodeType::Dir, mode).unwrap();
                 r2.new_fs_child("d2", InodeType::Dir, mode).unwrap();

--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -35,8 +35,8 @@ pub(super) struct Dentry {
 impl Dentry {
     /// Creates a new root `Dentry` with the given inode.
     ///
-    /// It is been created during the construction of the `MountNode`.
-    /// The `MountNode` holds an arc reference to this root `Dentry`.
+    /// It is been created during the construction of the `Mount`.
+    /// The `Mount` holds an arc reference to this root `Dentry`.
     pub(super) fn new_root(inode: Arc<dyn Inode>) -> Arc<Self> {
         Self::new(inode, DentryOptions::Root)
     }

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -169,12 +169,7 @@ impl Path {
         }
     }
 
-    /// Makes current `Dentry` to be a mountpoint,
-    /// sets it as the mountpoint of the child mount.
-    pub(super) fn set_mountpoint(&self, child_mount: Arc<MountNode>) {
-        child_mount.set_mountpoint(&self.dentry);
-        self.dentry.set_mounted_bit();
-    }
+}
 
     /// Mounts the fs on current `Dentry` as a mountpoint.
     ///
@@ -192,7 +187,7 @@ impl Path {
         }
 
         let child_mount = self.mount_node.mount(fs, &self.dentry)?;
-        self.set_mountpoint(child_mount.clone());
+
         Ok(child_mount)
     }
 
@@ -212,8 +207,6 @@ impl Path {
 
         let child_mount = parent_mount_node.unmount(&mountpoint)?;
 
-        let child_mount = mountpoint_mount_node.unmount(&parent_mount_path)?;
-        mountpoint.clear_mounted_bit();
         Ok(child_mount)
     }
 

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -5,7 +5,7 @@
 use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
-pub use mount::MountNode;
+pub use mount::Mount;
 
 use crate::{
     fs::{
@@ -28,15 +28,15 @@ mod mount;
 /// may have multiple `Path` instances referencing it due to mount operations.
 #[derive(Debug, Clone)]
 pub struct Path {
-    mount_node: Arc<MountNode>,
+    mount: Arc<Mount>,
     dentry: Arc<Dentry>,
 }
 
 impl Path {
     /// Creates a new `Path` to represent the root directory of a file system.
-    pub fn new_fs_root(mount_node: Arc<MountNode>) -> Self {
-        let inner = mount_node.root_dentry().clone();
-        Self::new(mount_node, inner)
+    pub fn new_fs_root(mount: Arc<Mount>) -> Self {
+        let inner = mount.root_dentry().clone();
+        Self::new(mount, inner)
     }
 
     /// Creates a new `Path` to represent the child directory of a file system.
@@ -49,16 +49,16 @@ impl Path {
             return_errno!(Errno::EACCES);
         }
         let new_child_dentry = self.dentry.create(name, type_, mode)?;
-        Ok(Self::new(self.mount_node.clone(), new_child_dentry))
+        Ok(Self::new(self.mount.clone(), new_child_dentry))
     }
 
-    fn new(mount_node: Arc<MountNode>, dentry: Arc<Dentry>) -> Self {
-        Self { mount_node, dentry }
+    fn new(mount: Arc<Mount>, dentry: Arc<Dentry>) -> Self {
+        Self { mount, dentry }
     }
 
     /// Gets the mount node of current `Path`.
-    pub fn mount_node(&self) -> &Arc<MountNode> {
-        &self.mount_node
+    pub fn mount_node(&self) -> &Arc<Mount> {
+        &self.mount
     }
 
     /// Lookups the target `Path` given the `name`.
@@ -80,10 +80,10 @@ impl Path {
         } else {
             let target_inner_opt = self.dentry.lookup_via_cache(name)?;
             match target_inner_opt {
-                Some(target_inner) => Self::new(self.mount_node.clone(), target_inner),
+                Some(target_inner) => Self::new(self.mount.clone(), target_inner),
                 None => {
                     let target_inner = self.dentry.lookup_via_fs(name)?;
-                    Self::new(self.mount_node.clone(), target_inner)
+                    Self::new(self.mount.clone(), target_inner)
                 }
             }
         };
@@ -123,10 +123,10 @@ impl Path {
             return self.dentry.name();
         }
 
-        let Some(parent) = self.mount_node.parent() else {
+        let Some(parent) = self.mount.parent() else {
             return self.dentry.name();
         };
-        let Some(mountpoint) = self.mount_node.mountpoint() else {
+        let Some(mountpoint) = self.mount.mountpoint() else {
             return self.dentry.name();
         };
 
@@ -140,14 +140,11 @@ impl Path {
     /// to get the parent of the mountpoint recursively.
     fn effective_parent(&self) -> Option<Self> {
         if !self.dentry.is_mount_root() {
-            return Some(Self::new(
-                self.mount_node.clone(),
-                self.dentry.parent().unwrap(),
-            ));
+            return Some(Self::new(self.mount.clone(), self.dentry.parent().unwrap()));
         }
 
-        let parent = self.mount_node.parent()?;
-        let mountpoint = self.mount_node.mountpoint()?;
+        let parent = self.mount.parent()?;
+        let mountpoint = self.mount.mountpoint()?;
 
         let mount_parent = Self::new(parent.upgrade().unwrap(), mountpoint);
         mount_parent.effective_parent()
@@ -165,7 +162,7 @@ impl Path {
             return self;
         }
 
-        match self.mount_node.get(&self.dentry) {
+        match self.mount.get(&self.dentry) {
             Some(child_mount) => {
                 let inner = child_mount.root_dentry().clone();
                 Self::new(child_mount, inner).get_top_path()
@@ -187,7 +184,7 @@ impl Path {
     /// The root Dentry cannot be mounted.
     ///
     /// Returns the mounted child mount.
-    pub fn mount(&self, fs: Arc<dyn FileSystem>) -> Result<Arc<MountNode>> {
+    pub fn mount(&self, fs: Arc<dyn FileSystem>) -> Result<Arc<Mount>> {
         if self.type_() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
@@ -195,7 +192,7 @@ impl Path {
             return_errno_with_message!(Errno::EINVAL, "can not mount on root");
         }
 
-        let child_mount = self.mount_node.mount(fs, &self.dentry)?;
+        let child_mount = self.mount.do_mount(fs, &self.dentry)?;
 
         Ok(child_mount)
     }
@@ -203,18 +200,18 @@ impl Path {
     /// Unmounts and returns the mounted child mount.
     ///
     /// Note that the root mount cannot be unmounted.
-    pub fn unmount(&self) -> Result<Arc<MountNode>> {
+    pub fn unmount(&self) -> Result<Arc<Mount>> {
         if !self.dentry.is_mount_root() {
             return_errno_with_message!(Errno::EINVAL, "not mounted");
         }
 
-        let Some(mountpoint) = self.mount_node.mountpoint() else {
+        let Some(mountpoint) = self.mount.mountpoint() else {
             return_errno_with_message!(Errno::EINVAL, "cannot umount root mount");
         };
 
-        let parent_mount_node = self.mount_node.parent().unwrap().upgrade().unwrap();
+        let parent_mount = self.mount.parent().unwrap().upgrade().unwrap();
 
-        let child_mount = parent_mount_node.unmount(&mountpoint)?;
+        let child_mount = parent_mount.do_unmount(&mountpoint)?;
 
         Ok(child_mount)
     }
@@ -225,10 +222,8 @@ impl Path {
     /// just the root (non-recursive) or the entire mount subtree (recursive),
     /// and grafts it to the destination `Path`.
     pub fn bind_mount_to(&self, dst_path: &Self, recursive: bool) -> Result<()> {
-        let new_mount = self
-            .mount_node
-            .clone_mount_node_tree(&self.dentry, recursive);
-        new_mount.graft_mount_node_tree(dst_path)?;
+        let new_mount = self.mount.clone_mount_tree(&self.dentry, recursive);
+        new_mount.graft_mount_tree(dst_path)?;
         Ok(())
     }
 
@@ -243,18 +238,18 @@ impl Path {
             return_errno_with_message!(Errno::EINVAL, "The root mount can not be moved");
         }
 
-        self.mount_node.graft_mount_node_tree(dst_path)
+        self.mount.graft_mount_tree(dst_path)
     }
 
     /// Creates a `Path` by making an inode of the `type_` with the `mode`.
     pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Self> {
         let inner = self.dentry.mknod(name, mode, type_)?;
-        Ok(Self::new(self.mount_node.clone(), inner))
+        Ok(Self::new(self.mount.clone(), inner))
     }
 
     /// Links a new name for the `Path`.
     pub fn link(&self, old: &Self, name: &str) -> Result<()> {
-        if !Arc::ptr_eq(&old.mount_node, &self.mount_node) {
+        if !Arc::ptr_eq(&old.mount, &self.mount) {
             return_errno_with_message!(Errno::EXDEV, "cannot cross mount");
         }
 
@@ -263,7 +258,7 @@ impl Path {
 
     /// Renames a `Path` to the new `Path` by `rename()` the inner inode.
     pub fn rename(&self, old_name: &str, new_dir: &Self, new_name: &str) -> Result<()> {
-        if !Arc::ptr_eq(&self.mount_node, &new_dir.mount_node) {
+        if !Arc::ptr_eq(&self.mount, &new_dir.mount) {
             return_errno_with_message!(Errno::EXDEV, "cannot cross mount");
         }
 

--- a/kernel/src/fs/path/mount.rs
+++ b/kernel/src/fs/path/mount.rs
@@ -192,7 +192,7 @@ impl MountNode {
     }
 
     /// Grafts the mount node tree to the mountpoint.
-    pub fn graft_mount_node_tree(&self, target_path: &Path) -> Result<()> {
+    pub(super) fn graft_mount_node_tree(&self, target_path: &Path) -> Result<()> {
         if target_path.type_() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }

--- a/kernel/src/fs/path/mount.rs
+++ b/kernel/src/fs/path/mount.rs
@@ -253,7 +253,7 @@ impl MountNode {
     }
 
     /// Gets the parent mount node if any.
-    pub fn parent(&self) -> Option<Weak<Self>> {
+    pub(super) fn parent(&self) -> Option<Weak<Self>> {
         self.parent.read().as_ref().cloned()
     }
 
@@ -261,18 +261,13 @@ impl MountNode {
     ///
     /// In some cases we may need to reset the parent of
     /// the created MountNode, such as move mount.
-    pub fn set_parent(&self, mount_node: &Arc<MountNode>) {
+    fn set_parent(&self, mount_node: &Arc<MountNode>) {
         let mut parent = self.parent.write();
         *parent = Some(Arc::downgrade(mount_node));
     }
 
     fn this(&self) -> Arc<Self> {
         self.this.upgrade().unwrap()
-    }
-
-    /// Gets the associated fs.
-    pub fn fs(&self) -> &Arc<dyn FileSystem> {
-        &self.fs
     }
 }
 

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -8,7 +8,7 @@ use spin::Once;
 
 use super::{
     fs_resolver::{FsPath, FsResolver},
-    path::MountNode,
+    path::Mount,
     ramfs::RamFS,
     utils::{FileSystem, InodeMode, InodeType},
 };
@@ -119,15 +119,15 @@ pub fn mount_fs_at(fs: Arc<dyn FileSystem>, fs_path: &FsPath) -> Result<()> {
     Ok(())
 }
 
-static ROOT_MOUNT: Once<Arc<MountNode>> = Once::new();
+static ROOT_MOUNT: Once<Arc<Mount>> = Once::new();
 
 pub fn init_root_mount() {
-    ROOT_MOUNT.call_once(|| -> Arc<MountNode> {
+    ROOT_MOUNT.call_once(|| -> Arc<Mount> {
         let rootfs = RamFS::new();
-        MountNode::new_root(rootfs)
+        Mount::new_root(rootfs)
     });
 }
 
-pub fn root_mount() -> &'static Arc<MountNode> {
+pub fn root_mount() -> &'static Arc<Mount> {
     ROOT_MOUNT.get().unwrap()
 }

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -75,19 +75,19 @@ pub fn do_faccessat(
     let flags = FaccessatFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "Invalid flags"))?;
 
-    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
+    let path_name = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
     debug!(
-        "dirfd = {}, path = {:?}, mode = {:o}, flags = {:?}",
-        dirfd, path, mode, flags
+        "dirfd = {}, path_name = {:?}, mode = {:o}, flags = {:?}",
+        dirfd, path_name, mode, flags
     );
 
-    if path.is_empty() && !flags.contains(FaccessatFlags::AT_EMPTY_PATH) {
+    if path_name.is_empty() && !flags.contains(FaccessatFlags::AT_EMPTY_PATH) {
         return_errno_with_message!(Errno::ENOENT, "path is empty");
     }
 
-    let dentry = {
-        let path = path.to_string_lossy();
-        let fs_path = FsPath::new(dirfd, path.as_ref())?;
+    let path = {
+        let path_name = path_name.to_string_lossy();
+        let fs_path = FsPath::new(dirfd, path_name.as_ref())?;
         let fs_ref = ctx.thread_local.borrow_fs();
         let fs = fs_ref.resolver().read();
         if flags.contains(FaccessatFlags::AT_SYMLINK_NOFOLLOW) {
@@ -96,12 +96,13 @@ pub fn do_faccessat(
             fs.lookup(&fs_path)?
         }
     };
+
     // AccessMode::empty() means F_OK and no more permission check needed.
     if mode.is_empty() {
         return Ok(SyscallReturn::Return(0));
     }
 
-    let inode = dentry.inode();
+    let inode = path.inode();
 
     // FIXME: The current implementation is dummy
     if mode.contains(AccessMode::R_OK) {

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -31,21 +31,25 @@ pub fn sys_fchmodat(
     /* flags: u32, */
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let path = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
-    debug!("dirfd = {}, path = {:?}, mode = 0o{:o}", dirfd, path, mode,);
+    let path_name = ctx.user_space().read_cstring(path_ptr, PATH_MAX)?;
+    debug!(
+        "dirfd = {}, path_name = {:?}, mode = 0o{:o}",
+        dirfd, path_name, mode,
+    );
 
-    let dentry = {
-        let path = path.to_string_lossy();
-        if path.is_empty() {
+    let path = {
+        let path_name = path_name.to_string_lossy();
+        if path_name.is_empty() {
             return_errno_with_message!(Errno::ENOENT, "path is empty");
         }
-        let fs_path = FsPath::new(dirfd, path.as_ref())?;
+        let fs_path = FsPath::new(dirfd, path_name.as_ref())?;
         ctx.thread_local
             .borrow_fs()
             .resolver()
             .read()
             .lookup(&fs_path)?
     };
-    dentry.set_mode(InodeMode::from_bits_truncate(mode))?;
+
+    path.set_mode(InodeMode::from_bits_truncate(mode))?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -125,14 +125,7 @@ fn do_move_mount_old(src_name: CString, dst_path: Path, ctx: &Context) -> Result
             .lookup(&fs_path)?
     };
 
-    if !src_path.is_mount_root() {
-        return_errno_with_message!(Errno::EINVAL, "src_name can not be moved");
-    };
-    if src_path.mount_node().parent().is_none() {
-        return_errno_with_message!(Errno::EINVAL, "src_name can not be moved");
-    }
-
-    src_path.mount_node().graft_mount_node_tree(&dst_path)?;
+    src_path.move_mount_to(&dst_path)?;
 
     Ok(())
 }

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -64,7 +64,7 @@ pub fn sys_fstatat(
         return self::sys_fstat(dirfd, stat_buf_ptr, ctx);
     }
 
-    let dentry = {
+    let path = {
         let filename = filename.to_string_lossy();
         let fs_path = FsPath::new(dirfd, filename.as_ref())?;
         let fs_ref = ctx.thread_local.borrow_fs();
@@ -75,7 +75,8 @@ pub fn sys_fstatat(
             fs.lookup(&fs_path)?
         }
     };
-    let stat = Stat::from(dentry.metadata());
+
+    let stat = Stat::from(path.metadata());
     user_space.write_val(stat_buf_ptr, &stat)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -46,7 +46,7 @@ pub fn sys_statx(
         );
     }
 
-    let dentry = {
+    let path = {
         let filename = filename.to_string_lossy();
         let fs_path = FsPath::new(dirfd, filename.as_ref())?;
         let fs_ref = ctx.thread_local.borrow_fs();
@@ -58,7 +58,7 @@ pub fn sys_statx(
         }
     };
 
-    let statx = Statx::from(dentry.metadata());
+    let statx = Statx::from(path.metadata());
 
     user_space.write_val(statx_buf_ptr, &statx)?;
     Ok(SyscallReturn::Return(0))


### PR DESCRIPTION
### Complete some remaining rename tasks

This commit completes some remaining renaming work from #2301.

### Avoid passing `self` when calling internal mount-related methods within `Path`

Originally, when the `Path` struct invoked certain internal methods of `Mount`, it would pass `self` to `Mount`; however, `self` contained `Mount`'s own information, which was entirely unnecessary.

### Fix the mountpoint state maintaining for `Dentry`

The original logic for determining whether a `Dentry` is a mountpoint was flawed, as a single `Dentry` could correspond to multiple `Mount` instances, making it incorrect to directly clear the mount bit during unmount. Additionally, the previous implementation missed updating mount flags in certain cases, such as during `detach_mount_node` or when updating a mount point, where the mount flags of the old mount point were not properly updated.

This commit introduces the `mount_count` to address issues arising from multiple mounts. It also binds the update of the `mount_count` with the update of the `mountpoint` inside `Mount`, ensuring consistent behavior and avoiding missed operations.

### Move all mount operation interfaces to `Path`

This commit moves public mount interface to the `Path` abstraction, making `Path` the initiator of mount operations, thereby unifying the interface.

### Refine visibility

This commit refines method visibilities, removing unnecessary `public` declarations, and deletes a function that were never used.

### Rename `MountNode` to `Mount`

This commit rename `MountNode` to `Mount`, and updates several related variable names, which is align with Linux conventions and can improve clarity.

---

Currently, race conditions still exist in mount-related operations; these will be addressed in future work along with optimization of the internal function implementation logic.