### PR TITLE
Add RISC-V FPU support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "ostd-macros",
  "ostd-pod",
  "ostd-test",
+ "paste",
  "riscv",
  "sbi-rt",
  "smallvec",

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -66,6 +66,7 @@ riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+paste = "1.0.15"
 
 [target.loongarch64-unknown-none-softfloat.dependencies]
 loongArch64 = "0.2.5"

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -2,7 +2,7 @@
 
 //! CPU execution context control.
 
-use core::fmt::Debug;
+use core::{arch::global_asm, fmt::Debug};
 
 use riscv::register::scause::{Exception, Interrupt, Trap};
 
@@ -11,6 +11,7 @@ use crate::{
         timer::handle_timer_interrupt,
         trap::{RawUserContext, TrapFrame},
     },
+    cpu::extension::{has_extensions, IsaExtensions},
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 
@@ -139,6 +140,8 @@ impl UserContextApiInternal for UserContext {
     where
         F: FnMut() -> bool,
     {
+        // Sets FPU state to clean.
+        self.user_context.sstatus |= 2 << 13;
         let ret = loop {
             self.user_context.run();
             match riscv::register::scause::read().cause() {
@@ -265,30 +268,214 @@ pub type CpuException = Exception;
 
 /// The FPU context of user task.
 ///
-/// This could be used for saving both legacy and modern state format.
-// FIXME: Implement FPU context on RISC-V platforms.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct FpuContext;
+/// FIXME: refactor arch-agnostic FPU context management code in aster-nix.
+/// RISC-V provides two bits in `sstatus` indicating the FPU state:
+/// - FS=00: FPU state is OFF (FPU disabled, all FP instruction illegal).
+/// - FS=01`: FPU state is INITIAL (FPU enabled, FPU context assumed zeroed).
+/// - FS=10: FPU state is CLEAN (FPU enabled, FPU context unchanged since last
+///   load).
+/// - FS=11: FPU state is DIRTY (FPU enabled, FPU context modified since last
+///   load).
+/// This enable software to optimize FPU management by applying lazy strategy on
+/// FPU enable/load/store:
+/// - enable FPU after the first illegal instruction trap on FP instruction
+/// - load FPU context only if FS=01 or FS=10 (or just zero the FPU registers if
+///   FS=01)
+/// - store FPU context only if FS=11
+/// Currently aster-nix implements a similar but non-lazy software FPU
+/// management strategy. It is arch-agnostic so we cannot simply integrate
+/// RISC-V's design benefits into it. We should consider a more flexible generic
+/// FPU context management design which enables more arch-specific
+/// optimizations.
+#[allow(private_bounds)]
+#[derive(Clone, Debug)]
+pub enum FpuContext {
+    /// FPU context for F extension (32-bit floating point).
+    F(FFpuContext),
+    /// FPU context for D extension (64-bit floating point).
+    D(DFpuContext),
+    /// FPU context for Q extension (128-bit floating point).
+    Q(QFpuContext),
+}
 
 impl FpuContext {
     /// Creates a new FPU context.
     pub fn new() -> Self {
-        Self
+        if has_extensions(IsaExtensions::Q) {
+            Self::Q(QFpuContext::default())
+        } else if has_extensions(IsaExtensions::D) {
+            Self::D(DFpuContext::default())
+        } else if has_extensions(IsaExtensions::F) {
+            Self::F(FFpuContext::default())
+        } else {
+            panic!("No FPU extensions enabled");
+        }
     }
 
-    /// Saves CPU's current FPU context to this instance, if needed.
-    pub fn save(&mut self) {}
+    /// Saves CPU's current FPU context to this instance.
+    pub fn save(&mut self) {
+        match self {
+            Self::F(ctx) => ctx.save(),
+            Self::D(ctx) => ctx.save(),
+            Self::Q(ctx) => ctx.save(),
+        }
+    }
 
-    /// Loads CPU's FPU context from this instance, if needed.
-    pub fn load(&mut self) {}
+    /// Loads CPU's FPU context from this instance.
+    pub fn load(&mut self) {
+        match self {
+            Self::F(ctx) => ctx.load(),
+            Self::D(ctx) => ctx.load(),
+            Self::Q(ctx) => ctx.load(),
+        }
+    }
 
     /// Returns the FPU context as a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
-        &[]
+        match self {
+            Self::F(ctx) => ctx.as_bytes(),
+            Self::D(ctx) => ctx.as_bytes(),
+            Self::Q(ctx) => ctx.as_bytes(),
+        }
     }
 
     /// Returns the FPU context as a mutable byte slice.
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        &mut []
+        match self {
+            Self::F(ctx) => ctx.as_bytes_mut(),
+            Self::D(ctx) => ctx.as_bytes_mut(),
+            Self::Q(ctx) => ctx.as_bytes_mut(),
+        }
     }
+
+    // Linux uses a union of three kinds of FPU context here. We follow the same
+    // layout to be compatible with libraries that supports Linux.
+    const F_FPU_STATE_SIZE: usize = size_of::<u32>() * 32 + size_of::<u32>() * 1;
+    const D_FPU_STATE_SIZE: usize = size_of::<u64>() * 32 + size_of::<u32>() * 1;
+    const Q_FPU_STATE_SIZE: usize = size_of::<u64>() * 64 + size_of::<u32>() * 1;
+    const F_FPU_CONTEXT_RESERVED_LENGTH: usize =
+        (Self::FPU_CONTEXT_SIZE - Self::F_FPU_STATE_SIZE) / size_of::<u32>();
+    const D_FPU_CONTEXT_RESERVED_LENGTH: usize =
+        (Self::FPU_CONTEXT_SIZE - Self::D_FPU_STATE_SIZE) / size_of::<u32>();
+    const Q_FPU_CONTEXT_RESERVED_LENGTH: usize = 3;
+    const FPU_CONTEXT_SIZE: usize =
+        Self::Q_FPU_STATE_SIZE + size_of::<u32>() * Self::Q_FPU_CONTEXT_RESERVED_LENGTH;
+}
+
+/// FPU context for F extension (32-bit floating point).
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct FFpuContext {
+    f: [u32; 32],
+    fcsr: u32,
+    reserved: [u32; FpuContext::F_FPU_CONTEXT_RESERVED_LENGTH],
+}
+
+/// FPU context for D extension (64-bit floating point).
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct DFpuContext {
+    f: [u64; 32],
+    fcsr: u32,
+    reserved: [u32; FpuContext::D_FPU_CONTEXT_RESERVED_LENGTH],
+}
+
+/// FPU context for Q extension (128-bit floating point).
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Clone, Debug)]
+pub struct QFpuContext {
+    f: [u64; 64],
+    fcsr: u32,
+    reserved: [u32; FpuContext::Q_FPU_CONTEXT_RESERVED_LENGTH],
+}
+
+macro_rules! impl_fpu_context {
+    ($name:ident, $f_length:literal, $reserved_length:expr, $suffix:literal) => {
+        impl $name {
+            fn save(&mut self) {
+                unsafe {
+                    paste::paste! {
+                        [<save_fpu_context_$suffix>](self as *mut _);
+                    }
+                }
+            }
+
+            fn load(&self) {
+                unsafe {
+                    paste::paste! {
+                        [<load_fpu_context_$suffix>](self as *const _);
+                    }
+                }
+            }
+
+            fn as_bytes(&self) -> &[u8] {
+                unsafe {
+                    core::slice::from_raw_parts(
+                        self as *const Self as *const u8,
+                        core::mem::size_of::<Self>(),
+                    )
+                }
+            }
+
+            fn as_bytes_mut(&mut self) -> &mut [u8] {
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        self as *mut Self as *mut u8,
+                        core::mem::size_of::<Self>(),
+                    )
+                }
+            }
+
+            // Currently Rust generates array impls for every size up to 32
+            // manually and there is ongoing work on refactoring with const
+            // generics. We can remove the `new` method and just derive the
+            // `Default` implementation once that is done.
+            //
+            // See https://github.com/rust-lang/rust/issues/61415.
+            fn new() -> Self {
+                Self {
+                    f: [0; $f_length],
+                    fcsr: 0,
+                    reserved: [0; $reserved_length],
+                }
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
+impl_fpu_context!(
+    FFpuContext,
+    32,
+    FpuContext::F_FPU_CONTEXT_RESERVED_LENGTH,
+    "f"
+);
+impl_fpu_context!(
+    DFpuContext,
+    32,
+    FpuContext::D_FPU_CONTEXT_RESERVED_LENGTH,
+    "d"
+);
+impl_fpu_context!(
+    QFpuContext,
+    64,
+    FpuContext::Q_FPU_CONTEXT_RESERVED_LENGTH,
+    "q"
+);
+
+global_asm!(include_str!("fpu.S"));
+
+extern "C" {
+    fn save_fpu_context_f(ctx: *mut FFpuContext);
+    fn load_fpu_context_f(ctx: *const FFpuContext);
+    fn save_fpu_context_d(ctx: *mut DFpuContext);
+    fn load_fpu_context_d(ctx: *const DFpuContext);
+    fn save_fpu_context_q(ctx: *mut QFpuContext);
+    fn load_fpu_context_q(ctx: *const QFpuContext);
 }

--- a/ostd/src/arch/riscv/cpu/fpu.S
+++ b/ostd/src/arch/riscv/cpu/fpu.S
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+    .macro SAVE_FPU_CONTEXT base, store_insn, reg_size
+        .if \reg_size == 16
+            # Q extension - use manual encoding
+            FSQ 0, 0, 10    # a0 = register 10
+            FSQ 1, 16, 10
+            FSQ 2, 32, 10
+            FSQ 3, 48, 10
+            FSQ 4, 64, 10
+            FSQ 5, 80, 10
+            FSQ 6, 96, 10
+            FSQ 7, 112, 10
+            FSQ 8, 128, 10
+            FSQ 9, 144, 10
+            FSQ 10, 160, 10
+            FSQ 11, 176, 10
+            FSQ 12, 192, 10
+            FSQ 13, 208, 10
+            FSQ 14, 224, 10
+            FSQ 15, 240, 10
+            FSQ 16, 256, 10
+            FSQ 17, 272, 10
+            FSQ 18, 288, 10
+            FSQ 19, 304, 10
+            FSQ 20, 320, 10
+            FSQ 21, 336, 10
+            FSQ 22, 352, 10
+            FSQ 23, 368, 10
+            FSQ 24, 384, 10
+            FSQ 25, 400, 10
+            FSQ 26, 416, 10
+            FSQ 27, 432, 10
+            FSQ 28, 448, 10
+            FSQ 29, 464, 10
+            FSQ 30, 480, 10
+            FSQ 31, 496, 10
+        .else
+            # F/D extensions - use regular instructions
+            \store_insn f0, 0*\reg_size(\base)
+            \store_insn f1, 1*\reg_size(\base)
+            \store_insn f2, 2*\reg_size(\base)
+            \store_insn f3, 3*\reg_size(\base)
+            \store_insn f4, 4*\reg_size(\base)
+            \store_insn f5, 5*\reg_size(\base)
+            \store_insn f6, 6*\reg_size(\base)
+            \store_insn f7, 7*\reg_size(\base)
+            \store_insn f8, 8*\reg_size(\base)
+            \store_insn f9, 9*\reg_size(\base)
+            \store_insn f10, 10*\reg_size(\base)
+            \store_insn f11, 11*\reg_size(\base)
+            \store_insn f12, 12*\reg_size(\base)
+            \store_insn f13, 13*\reg_size(\base)
+            \store_insn f14, 14*\reg_size(\base)
+            \store_insn f15, 15*\reg_size(\base)
+            \store_insn f16, 16*\reg_size(\base)
+            \store_insn f17, 17*\reg_size(\base)
+            \store_insn f18, 18*\reg_size(\base)
+            \store_insn f19, 19*\reg_size(\base)
+            \store_insn f20, 20*\reg_size(\base)
+            \store_insn f21, 21*\reg_size(\base)
+            \store_insn f22, 22*\reg_size(\base)
+            \store_insn f23, 23*\reg_size(\base)
+            \store_insn f24, 24*\reg_size(\base)
+            \store_insn f25, 25*\reg_size(\base)
+            \store_insn f26, 26*\reg_size(\base)
+            \store_insn f27, 27*\reg_size(\base)
+            \store_insn f28, 28*\reg_size(\base)
+            \store_insn f29, 29*\reg_size(\base)
+            \store_insn f30, 30*\reg_size(\base)
+            \store_insn f31, 31*\reg_size(\base)
+        .endif
+
+        # Save fcsr
+        csrr t0, fcsr
+        sw t0, 32*\reg_size(\base)
+    .endm
+
+    .macro LOAD_FPU_CONTEXT base, load_insn, reg_size
+        .if \reg_size == 16
+            # Q extension - use manual encoding
+            FLQ 0, 0, 10    # a0 = register 10
+            FLQ 1, 16, 10
+            FLQ 2, 32, 10
+            FLQ 3, 48, 10
+            FLQ 4, 64, 10
+            FLQ 5, 80, 10
+            FLQ 6, 96, 10
+            FLQ 7, 112, 10
+            FLQ 8, 128, 10
+            FLQ 9, 144, 10
+            FLQ 10, 160, 10
+            FLQ 11, 176, 10
+            FLQ 12, 192, 10
+            FLQ 13, 208, 10
+            FLQ 14, 224, 10
+            FLQ 15, 240, 10
+            FLQ 16, 256, 10
+            FLQ 17, 272, 10
+            FLQ 18, 288, 10
+            FLQ 19, 304, 10
+            FLQ 20, 320, 10
+            FLQ 21, 336, 10
+            FLQ 22, 352, 10
+            FLQ 23, 368, 10
+            FLQ 24, 384, 10
+            FLQ 25, 400, 10
+            FLQ 26, 416, 10
+            FLQ 27, 432, 10
+            FLQ 28, 448, 10
+            FLQ 29, 464, 10
+            FLQ 30, 480, 10
+            FLQ 31, 496, 10
+        .else
+            # F/D extensions - use regular instructions
+            \load_insn f0, 0*\reg_size(\base)
+            \load_insn f1, 1*\reg_size(\base)
+            \load_insn f2, 2*\reg_size(\base)
+            \load_insn f3, 3*\reg_size(\base)
+            \load_insn f4, 4*\reg_size(\base)
+            \load_insn f5, 5*\reg_size(\base)
+            \load_insn f6, 6*\reg_size(\base)
+            \load_insn f7, 7*\reg_size(\base)
+            \load_insn f8, 8*\reg_size(\base)
+            \load_insn f9, 9*\reg_size(\base)
+            \load_insn f10, 10*\reg_size(\base)
+            \load_insn f11, 11*\reg_size(\base)
+            \load_insn f12, 12*\reg_size(\base)
+            \load_insn f13, 13*\reg_size(\base)
+            \load_insn f14, 14*\reg_size(\base)
+            \load_insn f15, 15*\reg_size(\base)
+            \load_insn f16, 16*\reg_size(\base)
+            \load_insn f17, 17*\reg_size(\base)
+            \load_insn f18, 18*\reg_size(\base)
+            \load_insn f19, 19*\reg_size(\base)
+            \load_insn f20, 20*\reg_size(\base)
+            \load_insn f21, 21*\reg_size(\base)
+            \load_insn f22, 22*\reg_size(\base)
+            \load_insn f23, 23*\reg_size(\base)
+            \load_insn f24, 24*\reg_size(\base)
+            \load_insn f25, 25*\reg_size(\base)
+            \load_insn f26, 26*\reg_size(\base)
+            \load_insn f27, 27*\reg_size(\base)
+            \load_insn f28, 28*\reg_size(\base)
+            \load_insn f29, 29*\reg_size(\base)
+            \load_insn f30, 30*\reg_size(\base)
+            \load_insn f31, 31*\reg_size(\base)
+        .endif
+
+        # Load fcsr
+        lw t0, 32*\reg_size(\base)
+        csrw fcsr, t0
+    .endm
+
+    # Currently LLVM assembler doesn't support Q extension, we manually
+    # encode the instructions here.
+    # FSQ: store freg to offset(basereg)
+    .macro FSQ freg, offset, basereg
+        .4byte (((\offset & 0xFE0) << 20) | (\freg << 20) | (\basereg << 15) | (0x4 << 12) | ((\offset & 0x1F) << 7) | 0x27)
+    .endm
+
+    # FLQ: load freg from offset(basereg)
+    .macro FLQ freg, offset, basereg
+        .4byte (((\offset & 0xFFF) << 20) | (\basereg << 15) | (0x4 << 12) | (\freg << 7) | 0x07)
+    .endm
+
+    .option push
+    .option arch, +f
+    .option arch, +d
+
+    .section .text
+    .global save_fpu_context_f
+    .type save_fpu_context_f, @function
+save_fpu_context_f:
+    SAVE_FPU_CONTEXT a0, fsw, 4
+    ret
+    .size save_fpu_context_f, .-save_fpu_context_f
+
+    .global load_fpu_context_f
+    .type load_fpu_context_f, @function
+load_fpu_context_f:
+    LOAD_FPU_CONTEXT a0, flw, 4
+    ret
+    .size load_fpu_context_f, .-load_fpu_context_f
+
+    .global save_fpu_context_d
+    .type save_fpu_context_d, @function
+save_fpu_context_d:
+    SAVE_FPU_CONTEXT a0, fsd, 8
+    ret
+    .size save_fpu_context_d, .-save_fpu_context_d
+
+    .global load_fpu_context_d
+    .type load_fpu_context_d, @function
+load_fpu_context_d:
+    LOAD_FPU_CONTEXT a0, fld, 8
+    ret
+    .size load_fpu_context_d, .-load_fpu_context_d
+
+    .global save_fpu_context_q
+    .type save_fpu_context_q, @function
+save_fpu_context_q:
+    SAVE_FPU_CONTEXT a0, fsq, 16
+    ret
+    .size save_fpu_context_q, .-save_fpu_context_q
+
+    .global load_fpu_context_q
+    .type load_fpu_context_q, @function
+load_fpu_context_q:
+    LOAD_FPU_CONTEXT a0, flq, 16
+    ret
+    .size load_fpu_context_q, .-load_fpu_context_q
+
+    .option pop

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -72,8 +72,8 @@ pub fn read_random() -> Option<u64> {
 pub(crate) fn enable_cpu_features() {
     cpu::extension::init();
     unsafe {
-        // We adopt a lazy approach to enable the floating-point unit; it's not
-        // enabled before the first FPU trap.
-        riscv::register::sstatus::set_fs(riscv::register::sstatus::FS::Off);
+        // Enables FPU in kernel so that we can use floating-point instructions
+        // to save/restore userspace FPU context in kernel code.
+        riscv::register::sstatus::set_fs(riscv::register::sstatus::FS::Initial);
     }
 }

--- a/ostd/src/arch/riscv/trap/trap.S
+++ b/ostd/src/arch/riscv/trap/trap.S
@@ -74,10 +74,6 @@ trap_from_user:
     STORE_SP t1, 32         # save sstatus
     STORE_SP t2, 33         # save sepc
 
-    li t0, 3 << 13
-    or t1, t1, t0           # sstatus.FS = Dirty (3)
-    csrw sstatus, t1
-
     andi t1, t1, 1 << 8     # sstatus.SPP == 1
     beqz t1, end_trap_from_user
 end_trap_from_kernel:


### PR DESCRIPTION
This PR adds RISC-V FPU support.

RISC-V's floating-point registers and instructions are gated by different extensions (F/D/Q). Different extensions provides FP registers of different sizes and different FP instructions. We implement the final `FpuContext` which we exposed to the users as a enum and choose variants based on runtime extension detection.
```rust
enum FpuContext {
    F(FFpuContext),
    D(DFpuContext),
    Q(QFpuContext),
}

struct FFpuContext { ... }

struct DFpuContext { ... }

struct QFpuContext { ... }
```

This PR respects `aster_nix::process::posix_thread::thread_local::ThreadFpu`'s FPU management strategy though RISC-V actually provides opportunities for a lazy strategy with hardware's help. I'd like to leave this as future work.