### PR TITLE
Remove the dependency on initramfs for GDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ gdb_server: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk run $(CARGO_OSDK_BUILD_ARGS) --gdb-server wait-client,vscode,addr=:$(GDB_TCP_PORT)
 
 .PHONY: gdb_client
-gdb_client: initramfs $(CARGO_OSDK)
+gdb_client: $(CARGO_OSDK)
 	@cd kernel && cargo osdk debug $(CARGO_OSDK_BUILD_ARGS) --remote :$(GDB_TCP_PORT)
 
 .PHONY: profile_server
@@ -276,7 +276,7 @@ profile_server: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk run $(CARGO_OSDK_BUILD_ARGS) --gdb-server addr=:$(GDB_TCP_PORT)
 
 .PHONY: profile_client
-profile_client: initramfs $(CARGO_OSDK)
+profile_client: $(CARGO_OSDK)
 	@cd kernel && cargo osdk profile $(CARGO_OSDK_BUILD_ARGS) --remote :$(GDB_TCP_PORT) \
 		--samples $(GDB_PROFILE_COUNT) --interval $(GDB_PROFILE_INTERVAL) --format $(GDB_PROFILE_FORMAT)
 


### PR DESCRIPTION
Actually, the OSDK GDB client and OSDK gdb profile do not need to access the initramfs. Instead, it needs the kernel to be built. But the kernel is currently `.PHONY` in the `Makefile`, so it cannot be depended on.

The reason to remove it is that after nix is introduced, it is a little bit too slow (10s+) for nix to reuse the built image. So the experience using `make gdb_client` is rather painful.