### PR TITLE
Support `/proc/<pid>/mem`

### DIFF
--- a/kernel/src/fs/procfs/cpuinfo.rs
+++ b/kernel/src/fs/procfs/cpuinfo.rs
@@ -11,7 +11,7 @@ use crate::{
     arch::cpu::CpuInfo,
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -22,7 +22,11 @@ pub struct CpuInfoFileOps;
 impl CpuInfoFileOps {
     /// Create a new inode for `/proc/cpuinfo`.
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        ProcFileBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .build()
+            .unwrap()
     }
 
     /// Collect and format CPU information for all cores.

--- a/kernel/src/fs/procfs/filesystems.rs
+++ b/kernel/src/fs/procfs/filesystems.rs
@@ -6,7 +6,7 @@ use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
         registry::FsProperties,
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -16,7 +16,11 @@ pub struct FileSystemsFileOps;
 
 impl FileSystemsFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        ProcFileBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/loadavg.rs
+++ b/kernel/src/fs/procfs/loadavg.rs
@@ -10,7 +10,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread,
@@ -22,7 +22,11 @@ pub struct LoadAvgFileOps;
 
 impl LoadAvgFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        ProcFileBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/meminfo.rs
+++ b/kernel/src/fs/procfs/meminfo.rs
@@ -11,7 +11,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -21,7 +21,11 @@ pub struct MemInfoFileOps;
 
 impl MemInfoFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        ProcFileBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     fs::{
         procfs::filesystems::FileSystemsFileOps,
         registry::{FsProperties, FsType},
-        utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+        utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, InodeMode, SuperBlock, NAME_MAX},
     },
     prelude::*,
     process::{
@@ -119,6 +119,7 @@ impl RootDirOps {
         let root_inode = ProcDirBuilder::new(Self)
             .fs(fs)
             .ino(PROC_ROOT_INO)
+            .mode(InodeMode::from_bits_truncate(0o555))
             .build()
             .unwrap();
         let weak_ptr = Arc::downgrade(&root_inode);

--- a/kernel/src/fs/procfs/pid/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/cmdline.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     Process,
@@ -16,6 +16,7 @@ impl CmdlineFileOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         ProcFileBuilder::new(Self(process_ref))
             .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
             .build()
             .unwrap()
     }

--- a/kernel/src/fs/procfs/pid/exe.rs
+++ b/kernel/src/fs/procfs/pid/exe.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     Process,
@@ -16,6 +16,10 @@ impl ExeSymOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         ProcSymBuilder::new(Self(process_ref))
             .parent(parent)
+            // Reference:
+            // <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/proc/base.c#L174-L175>
+            // <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/proc/base.c#L3344>
+            .mode(InodeMode::from_bits_truncate(0o777))
             .build()
             .unwrap()
     }

--- a/kernel/src/fs/procfs/pid/mem.rs
+++ b/kernel/src/fs/procfs/pid/mem.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use align_ext::AlignExt;
+use ostd::{
+    mm::{io_util::HasVmReaderWriter, UFrame},
+    task::disable_preempt,
+};
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{Inode, InodeMode},
+    },
+    prelude::*,
+    Process,
+};
+
+/// Represents the inode at either `/proc/[pid]/mem` or `/proc/[pid]/task/[tid]/mem`.
+pub struct MemFileOps(Arc<Process>);
+
+impl MemFileOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self(process_ref))
+            .parent(parent)
+            // Reference: <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/proc/base.c#L3341>
+            .mode(InodeMode::from_bits_truncate(0o600))
+            .build()
+            .unwrap()
+    }
+
+    fn access_at<F>(&self, offset: usize, len: usize, mut op: F) -> Result<usize>
+    where
+        F: FnMut(UFrame, usize) -> Result<()>,
+    {
+        let range = offset.align_down(PAGE_SIZE)..(offset + len).align_up(PAGE_SIZE);
+
+        let vmar_guard = self.0.lock_root_vmar();
+        let vmar = vmar_guard.as_ref().ok_or(Error::new(Errno::ENOENT))?;
+        let preempt_guard = disable_preempt();
+        let mut cursor = vmar.vm_space().cursor(&preempt_guard, &range)?;
+        let mut current_va = range.start;
+
+        while current_va < range.end {
+            cursor.jump(current_va)?;
+            let (_, Some((frame, _))) = cursor.query()? else {
+                return_errno_with_message!(Errno::EIO, "Page not accessible");
+            };
+
+            let skip_offset = if current_va == range.start {
+                offset - range.start
+            } else {
+                0
+            };
+
+            op(frame, skip_offset)?;
+
+            current_va += PAGE_SIZE;
+        }
+
+        Ok(len)
+    }
+}
+
+impl FileOps for MemFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let read_len = writer.avail();
+
+        self.access_at(offset, read_len, |frame, skip_offset| {
+            frame.reader().skip(skip_offset).read_fallible(writer)?;
+            Ok(())
+        })
+    }
+
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let write_len = reader.remain();
+
+        self.access_at(offset, write_len, |frame, skip_offset| {
+            frame.writer().skip(skip_offset).write_fallible(reader)?;
+            Ok(())
+        })
+    }
+}

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     events::Observer,
     fs::{
         file_table::FdEvents,
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
     process::{posix_thread::AsPosixThread, Process},
@@ -35,6 +35,7 @@ impl PidDirOps {
             .parent(parent)
             // The pid directories must be volatile, because it is just associated with one process.
             .volatile()
+            .mode(InodeMode::from_bits_truncate(0o555))
             .build()
             .unwrap();
         // This is for an exiting process that has not yet been reaped by its parent,

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use self::{
-    cmdline::CmdlineFileOps, comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps, stat::StatFileOps,
-    status::StatusFileOps, task::TaskDirOps,
+    cmdline::CmdlineFileOps, comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps, mem::MemFileOps,
+    stat::StatFileOps, status::StatusFileOps, task::TaskDirOps,
 };
 use super::template::{DirOps, ProcDir, ProcDirBuilder};
 use crate::{
@@ -19,6 +19,7 @@ mod cmdline;
 mod comm;
 mod exe;
 mod fd;
+mod mem;
 mod stat;
 mod status;
 mod task;
@@ -66,6 +67,7 @@ impl DirOps for PidDirOps {
             "comm" => CommFileOps::new_inode(self.0.clone(), this_ptr.clone()),
             "fd" => FdDirOps::new_inode(self.0.clone(), this_ptr.clone()),
             "cmdline" => CmdlineFileOps::new_inode(self.0.clone(), this_ptr.clone()),
+            "mem" => MemFileOps::new_inode(self.0.clone(), this_ptr.clone()),
             "status" => {
                 StatusFileOps::new_inode(self.0.clone(), self.0.main_thread(), this_ptr.clone())
             }
@@ -95,6 +97,9 @@ impl DirOps for PidDirOps {
         });
         cached_children.put_entry_if_not_found("cmdline", || {
             CmdlineFileOps::new_inode(self.0.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("mem", || {
+            MemFileOps::new_inode(self.0.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("status", || {
             StatusFileOps::new_inode(self.0.clone(), self.0.main_thread(), this_ptr.clone())

--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -5,7 +5,7 @@ use core::{fmt::Write, sync::atomic::Ordering};
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -94,6 +94,7 @@ impl StatFileOps {
             is_pid_stat,
         })
         .parent(parent)
+        .mode(InodeMode::from_bits_truncate(0o444))
         .build()
         .unwrap()
     }

--- a/kernel/src/fs/procfs/pid/status.rs
+++ b/kernel/src/fs/procfs/pid/status.rs
@@ -5,7 +5,7 @@ use core::fmt::Write;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -76,6 +76,7 @@ impl StatusFileOps {
             thread_ref,
         })
         .parent(parent)
+        .mode(InodeMode::from_bits_truncate(0o444))
         .build()
         .unwrap()
     }

--- a/kernel/src/fs/procfs/pid/task.rs
+++ b/kernel/src/fs/procfs/pid/task.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::{
     fs::{
         procfs::template::{DirOps, ProcDir, ProcDirBuilder},
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     process::posix_thread::AsPosixThread,
     thread::{AsThread, Thread},
@@ -20,6 +20,7 @@ impl TaskDirOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         ProcDirBuilder::new(Self(process_ref))
             .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o555))
             .build()
             .unwrap()
     }
@@ -42,6 +43,7 @@ impl TidDirOps {
             thread_ref,
         })
         .parent(parent)
+        .mode(InodeMode::from_bits_truncate(0o555))
         .build()
         .unwrap()
     }

--- a/kernel/src/fs/procfs/pid/task.rs
+++ b/kernel/src/fs/procfs/pid/task.rs
@@ -54,6 +54,7 @@ impl DirOps for TidDirOps {
         let inode = match name {
             "fd" => FdDirOps::new_inode(self.process_ref.clone(), this_ptr.clone()),
             "exe" => ExeSymOps::new_inode(self.process_ref.clone(), this_ptr.clone()),
+            "mem" => MemFileOps::new_inode(self.process_ref.clone(), this_ptr.clone()),
             "stat" => StatFileOps::new_inode(
                 self.process_ref.clone(),
                 self.thread_ref.clone(),
@@ -81,6 +82,9 @@ impl DirOps for TidDirOps {
         });
         cached_children.put_entry_if_not_found("exe", || {
             ExeSymOps::new_inode(self.process_ref.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("mem", || {
+            MemFileOps::new_inode(self.process_ref.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("stat", || {
             StatFileOps::new_inode(

--- a/kernel/src/fs/procfs/self_.rs
+++ b/kernel/src/fs/procfs/self_.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -13,7 +13,12 @@ pub struct SelfSymOps;
 
 impl SelfSymOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcSymBuilder::new(Self).parent(parent).build().unwrap()
+        ProcSymBuilder::new(Self)
+            .parent(parent)
+            // Reference: <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/proc/self.c#L50>
+            .mode(InodeMode::from_bits_truncate(0o777))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
+++ b/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::credentials::capabilities::CapSet,
@@ -16,7 +16,11 @@ pub struct CapLastCapFileOps;
 
 impl CapLastCapFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        ProcFileBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/procfs/sys/kernel/mod.rs
@@ -7,7 +7,7 @@ use crate::{
             template::{DirOps, ProcDirBuilder},
             ProcDir,
         },
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
 };
@@ -20,7 +20,11 @@ pub struct KernelDirOps;
 
 impl KernelDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+        ProcDirBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o555))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/mod.rs
+++ b/kernel/src/fs/procfs/sys/mod.rs
@@ -4,7 +4,7 @@ use self::kernel::KernelDirOps;
 use crate::{
     fs::{
         procfs::template::{DirOps, ProcDir, ProcDirBuilder},
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
 };
@@ -16,7 +16,11 @@ pub struct SysDirOps;
 
 impl SysDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+        ProcDirBuilder::new(Self)
+            .parent(parent)
+            .mode(InodeMode::from_bits_truncate(0o555))
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/template/dir.rs
+++ b/kernel/src/fs/procfs/template/dir.rs
@@ -32,6 +32,7 @@ impl<D: DirOps> ProcDir<D> {
         parent: Option<Weak<dyn Inode>>,
         ino: Option<u64>,
         is_volatile: bool,
+        mode: InodeMode,
     ) -> Arc<Self> {
         let common = {
             let ino = ino.unwrap_or_else(|| {
@@ -40,8 +41,7 @@ impl<D: DirOps> ProcDir<D> {
                 procfs.alloc_id()
             });
 
-            let metadata =
-                Metadata::new_dir(ino, InodeMode::from_bits_truncate(0o555), super::BLOCK_SIZE);
+            let metadata = Metadata::new_dir(ino, mode, super::BLOCK_SIZE);
             Common::new(metadata, fs, is_volatile)
         };
         Arc::new_cyclic(|weak_self| Self {

--- a/kernel/src/fs/procfs/template/file.rs
+++ b/kernel/src/fs/procfs/template/file.rs
@@ -17,15 +17,11 @@ pub struct ProcFile<F: FileOps> {
 }
 
 impl<F: FileOps> ProcFile<F> {
-    pub fn new(file: F, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Arc<Self> {
+    pub fn new(file: F, fs: Weak<dyn FileSystem>, is_volatile: bool, mode: InodeMode) -> Arc<Self> {
         let common = {
             let arc_fs = fs.upgrade().unwrap();
             let procfs = arc_fs.downcast_ref::<ProcFS>().unwrap();
-            let metadata = Metadata::new_file(
-                procfs.alloc_id(),
-                InodeMode::from_bits_truncate(0o444),
-                super::BLOCK_SIZE,
-            );
+            let metadata = Metadata::new_file(procfs.alloc_id(), mode, super::BLOCK_SIZE);
             Common::new(metadata, fs, is_volatile)
         };
         Arc::new(Self {
@@ -63,24 +59,19 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
     }
 
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let data = self.inner.data()?;
-        let start = data.len().min(offset);
-        let end = data.len().min(offset + writer.avail());
-        let len = end - start;
-        writer.write_fallible(&mut (&data[start..end]).into())?;
-        Ok(len)
+        self.inner.read_at(offset, writer)
     }
 
     fn read_direct_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         self.read_at(offset, writer)
     }
 
-    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
-        Err(Error::new(Errno::EPERM))
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        self.inner.write_at(offset, reader)
     }
 
-    fn write_direct_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
-        Err(Error::new(Errno::EPERM))
+    fn write_direct_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        self.write_at(offset, reader)
     }
 
     fn read_link(&self) -> Result<String> {
@@ -101,5 +92,20 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
 }
 
 pub trait FileOps: Sync + Send {
-    fn data(&self) -> Result<Vec<u8>>;
+    fn data(&self) -> Result<Vec<u8>> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let data = self.data()?;
+        let start = data.len().min(offset);
+        let end = data.len().min(offset + writer.avail());
+        let len = end - start;
+        writer.write_fallible(&mut (&data[start..end]).into())?;
+        Ok(len)
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        Err(Error::new(Errno::EPERM))
+    }
 }

--- a/kernel/src/fs/procfs/template/sym.rs
+++ b/kernel/src/fs/procfs/template/sym.rs
@@ -17,15 +17,11 @@ pub struct ProcSym<S: SymOps> {
 }
 
 impl<S: SymOps> ProcSym<S> {
-    pub fn new(sym: S, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Arc<Self> {
+    pub fn new(sym: S, fs: Weak<dyn FileSystem>, is_volatile: bool, mode: InodeMode) -> Arc<Self> {
         let common = {
             let arc_fs = fs.upgrade().unwrap();
             let procfs = arc_fs.downcast_ref::<ProcFS>().unwrap();
-            let metadata = Metadata::new_symlink(
-                procfs.alloc_id(),
-                InodeMode::from_bits_truncate(0o777),
-                super::BLOCK_SIZE,
-            );
+            let metadata = Metadata::new_symlink(procfs.alloc_id(), mode, super::BLOCK_SIZE);
             Common::new(metadata, fs, is_volatile)
         };
         Arc::new(Self { inner: sym, common })

--- a/kernel/src/fs/procfs/thread_self.rs
+++ b/kernel/src/fs/procfs/thread_self.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -16,7 +16,12 @@ pub struct ThreadSelfSymOps;
 
 impl ThreadSelfSymOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcSymBuilder::new(Self).parent(parent).build().unwrap()
+        ProcSymBuilder::new(Self)
+            .parent(parent)
+            // Reference: <https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/proc/thread_self.c#L50>
+            .mode(InodeMode::from_bits_truncate(0o777))
+            .build()
+            .unwrap()
     }
 }
 

--- a/test/src/apps/Makefile
+++ b/test/src/apps/Makefile
@@ -34,6 +34,7 @@ TEST_APPS := \
 	pipe \
 	prctl \
 	process \
+	procfs \
 	pthread \
 	pty \
 	sched \

--- a/test/src/apps/procfs/Makefile
+++ b/test/src/apps/procfs/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/src/apps/procfs/pid_mem.c
+++ b/test/src/apps/procfs/pid_mem.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <string.h>
+#include <errno.h>
+
+#define BUF_SIZE 256
+
+FN_TEST(pid_mem)
+{
+	const char *old_text = "Hello#1, /proc/pid/mem!";
+	const char *new_text = "Hello#2, /proc/pid/mem!";
+	static volatile char addr[BUF_SIZE] = { 0 };
+
+	pid_t pid = TEST_SUCC(fork());
+
+	if (pid == 0) {
+		// Child
+		strncpy(addr, old_text, strlen(old_text) + 1);
+
+		sleep(2); // Ensure parent has read and written
+		CHECK_WITH(strcmp(addr, new_text), _ret == 0);
+
+		exit(EXIT_SUCCESS);
+	} else {
+		// Parent
+		char mem_path[64];
+		snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", pid);
+		int fd = TEST_SUCC(open(mem_path, O_RDWR));
+
+		sleep(1); // Ensure child has written
+		char buf[BUF_SIZE] = { 0 };
+
+		TEST_SUCC(lseek(fd, (off_t)addr, SEEK_SET));
+		TEST_SUCC(read(fd, buf, sizeof(buf) - 1));
+		TEST_RES(strcmp(buf, old_text), _ret == 0);
+
+		TEST_SUCC(lseek(fd, (off_t)addr, SEEK_SET));
+		TEST_SUCC(write(fd, new_text, strlen(new_text)));
+		close(fd);
+
+		int status;
+		TEST_RES(wait4(pid, &status, 0, NULL),
+			 _ret == pid && WIFEXITED(status) &&
+				 WEXITSTATUS(status) == EXIT_SUCCESS);
+	}
+}
+END_TEST()

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -37,6 +37,7 @@ process/group_session
 process/job_control
 process/pidfd
 process/wait4
+procfs/pid_mem
 pthread/pthread_test
 pty/open_pty
 pty/pty_blocking


### PR DESCRIPTION
The first commit in this PR makes the file modes in procfs configurable and modifies the modes of some files to conform with the Linux interface.
The second commit adds `/proc/<pid>/mem` and `/proc/<pid>/task/<tid>/mem`, which are required to support GDB (Tracking issue: https://github.com/asterinas/asterinas/issues/2323).

