### PR TITLE
Add sem-related syscall limitations to the book

### DIFF
--- a/docs/src/kernel/linux-compatibility/README.md
+++ b/docs/src/kernel/linux-compatibility/README.md
@@ -85,8 +85,8 @@ provided by Linux on x86-64 architecture.
 | 62      | kill                   | ✅             |     |
 | 63      | uname                  | ✅             |     |
 | 64      | semget                 | ✅             |     |
-| 65      | semop                  | ✅             |     |
-| 66      | semctl                 | ✅             |     |
+| 65      | semop                  | ✅             | [⚠️](limitations-on-system-calls/inter-process-communication.md#semop-and-semtimedop) |
+| 66      | semctl                 | ✅             | [⚠️](limitations-on-system-calls/inter-process-communication.md#semctl) |
 | 67      | shmdt                  | ❌             |     |
 | 68      | msgget                 | ❌             |     |
 | 69      | msgsnd                 | ❌             |     |
@@ -240,7 +240,7 @@ provided by Linux on x86-64 architecture.
 | 217     | getdents64             | ✅             |     |
 | 218     | set_tid_address        | ✅             |     |
 | 219     | restart_syscall        | ❌             |     |
-| 220     | semtimedop             | ✅             |     |
+| 220     | semtimedop             | ✅             | [⚠️](limitations-on-system-calls/inter-process-communication.md#semop-and-semtimedop) |
 | 221     | fadvise64              | ✅             |     |
 | 222     | timer_create           | ✅             |     |
 | 223     | timer_settime          | ✅             |     |

--- a/docs/src/kernel/linux-compatibility/limitations-on-system-calls/inter-process-communication.md
+++ b/docs/src/kernel/linux-compatibility/limitations-on-system-calls/inter-process-communication.md
@@ -6,3 +6,90 @@ msgget, msgsnd, msgrcv, msgctl, semget, semop, semctl, shmget, shmat, shmctl
 futex, set_robust_list, and get_robust_list
 under this category.
 -->
+
+## `System V semaphore`
+
+### `semget`
+
+Supported functionality in SCML:
+
+```c
+// Creat or open a semaphore set
+semget(
+    key,
+    nsems,
+    semflg = IPC_CREAT | IPC_EXCL
+);
+```
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/semget.2.html).
+
+### `semop` and `semtimedop`
+
+Supported functionality in SCML:
+
+```c
+struct sembuf = {
+    sem_flg = IPC_NOWAIT,
+    ..
+};
+
+// Semaphore operations without blocking
+semop(
+    semid,
+    sops = [ <sembuf> ],
+    nsops
+);
+```
+
+Unsupported semaphore flags:
+* `SEM_UNDO`
+
+Supported and unsupported functionality of `semtimedop` are the same as `semop`.
+The SCML rules are omitted for brevity.
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/semop.2.html).
+
+### `semctl`
+
+Supported functionality in SCML:
+
+```c
+// Remove the semaphore set
+semctl(
+    semid,
+    semnum,
+    cmd = IPC_RMID
+);
+
+// Initialize the value of the semnum-th semaphore
+semctl(
+    semid,
+    semnum,
+    cmd = SETVAL,
+    arg
+);
+
+// Return the current value (GETVAL), last operating process's PID (GETPID),
+// count of processes awaiting increment (GETNCNT) or count of processes awaiting
+// zero (GETZCNT) of the semnum-th semaphore
+semctl(
+    semid,
+    semnum,
+    cmd = GETVAL | GETPID | GETNCNT | GETZCNT
+);
+```
+
+Unsupported commands:
+* `IPC_STAT`
+* `IPC_INFO`
+* `SEM_INFO`
+* `SEM_STAT`
+* `SEM_STAT_ANY`
+* `GETALL`
+* `SETALL`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/semctl.2.html).


### PR DESCRIPTION
Based on #2314, this PR introduces semaphore-related syscall limitations to the documentation via System Call Matching Language (SCML).

The targeted syscalls—semget, semop, semctl, and semtimedop—exemplify SCML's matching rules for Bitflags, Structs, and Arrays, enabling precise description.