### PR TITLE
Support parsing shebang with multiple arguments in intepreter line

### DIFF
--- a/kernel/src/process/program_loader/shebang.rs
+++ b/kernel/src/process/program_loader/shebang.rs
@@ -16,21 +16,60 @@ pub fn parse_shebang_line(file_first_page: &[u8]) -> Result<Option<Vec<CString>>
         // The file is not a shebang.
         return Ok(None);
     }
+
     let Some(first_line_len) = file_first_page.iter().position(|&c| c == b'\n') else {
-        return_errno_with_message!(Errno::ENAMETOOLONG, "The shebang line is too long");
+        return_errno_with_message!(Errno::ENAMETOOLONG, "the shebang line is too long");
     };
+
     // Skip `#!`.
     let shebang_header = &file_first_page[2..first_line_len];
     let mut shebang_argv = Vec::new();
-    for arg in shebang_header.split(|&c| c == b' ') {
-        let arg = CString::new(arg)?;
+    for arg in shebang_header.split(|&c| c == b' ' || c == b'\t') {
+        if arg.is_empty() {
+            continue;
+        }
+
+        let arg = CString::new(arg).map_err(|_| {
+            Error::with_message(Errno::ENOEXEC, "unexpected nul terminator is found")
+        })?;
         shebang_argv.push(arg);
     }
-    if shebang_argv.len() != 1 {
-        return_errno_with_message!(
-            Errno::EINVAL,
-            "One and only one interpreter program should be specified"
+
+    if shebang_argv.is_empty() {
+        return_errno_with_message!(Errno::ENOEXEC, "no interpreter program is found");
+    }
+
+    Ok(Some(shebang_argv))
+}
+
+#[cfg(ktest)]
+mod test {
+    use alloc::{ffi::CString, vec};
+
+    use ostd::prelude::*;
+
+    use super::parse_shebang_line;
+
+    #[ktest]
+    fn parse_shebang_line_with_multiple_args() {
+        const LINE1: &str = "#! /bin/bash -e\n";
+        let res = parse_shebang_line(LINE1.as_bytes()).unwrap().unwrap();
+        assert_eq!(
+            res,
+            vec![
+                CString::new("/bin/bash").unwrap(),
+                CString::new("-e").unwrap()
+            ]
+        );
+
+        const LINE2: &str = "#!  /bin/env  python3  \n";
+        let res = parse_shebang_line(LINE2.as_bytes()).unwrap().unwrap();
+        assert_eq!(
+            res,
+            vec![
+                CString::new("/bin/env").unwrap(),
+                CString::new("python3").unwrap()
+            ]
         );
     }
-    Ok(Some(shebang_argv))
 }


### PR DESCRIPTION
This PR fixes two issues in shebang parsing when running podman on Asterinas:

1. Remove the check that incorrectly prevented the shebang interpreter line from having multiple arguments. An interpreter line may include multiple arguments—for example, `#!/usr/bin/env bash`.
2. Ignore empty arguments; otherwise the parser produces incorrect results when there are spaces after `#!`. For example, `#! /bin/bash` (note the space between `#!` and `/bin/bash`) was being parsed as [`""`, `"/bin/bash"`], which is incorrect.