### PR TITLE
Assign keyboard code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,7 @@
 # Component code owners
 /kernel/comps/block/            @lucassong-mh
 /kernel/comps/framebuffer/      @cqs21 @lrh2000
+/kernel/comps/keyboard/         @cqs21 @lrh2000
 /kernel/comps/logger/           @cchanging
 /kernel/comps/mlsdisk/          @cqs21 @lucassong-mh
 /kernel/comps/network/          @StevenJiang1110 @lrh2000


### PR DESCRIPTION
Maybe I'll fix a bug that occasionally occurs on my laptop later. In any case, let's make sure that future PRs can tag the correct code owners first.