### PR TITLE
Optimize page faults

### DIFF
--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -739,7 +739,7 @@ impl Vmar_ {
                 rss_delta.add(vm_mapping.rss_type(), num_copied as isize);
             }
 
-            cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::All);
+            cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::for_all());
             cur_cursor.flusher().dispatch_tlb_flush();
             cur_cursor.flusher().sync_tlb_flush();
         }

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -688,7 +688,7 @@ mod vmspace {
             let mut cursor_mut = vmspace
                 .cursor_mut(&preempt_guard, &range)
                 .expect("Failed to create mutable cursor");
-            cursor_mut.flusher().issue_tlb_flush(TlbFlushOp::All);
+            cursor_mut.flusher().issue_tlb_flush(TlbFlushOp::for_all());
             cursor_mut.flusher().dispatch_tlb_flush();
         }
 

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -309,7 +309,7 @@ impl<'a> CursorMut<'a> {
                 debug_assert_eq!(va, start_va);
                 let (old_frame, _) = item;
                 self.flusher
-                    .issue_tlb_flush_with(TlbFlushOp::Address(start_va), old_frame.into());
+                    .issue_tlb_flush_with(TlbFlushOp::for_single(start_va), old_frame.into());
                 self.flusher.dispatch_tlb_flush();
             }
             PageTableFrag::StrayPageTable { .. } => {
@@ -351,7 +351,7 @@ impl<'a> CursorMut<'a> {
                     let (frame, _) = item;
                     num_unmapped += 1;
                     self.flusher
-                        .issue_tlb_flush_with(TlbFlushOp::Address(va), frame.into());
+                        .issue_tlb_flush_with(TlbFlushOp::for_single(va), frame.into());
                 }
                 PageTableFrag::StrayPageTable {
                     pt,
@@ -361,7 +361,7 @@ impl<'a> CursorMut<'a> {
                 } => {
                     num_unmapped += num_frames;
                     self.flusher
-                        .issue_tlb_flush_with(TlbFlushOp::Range(va..va + len), pt);
+                        .issue_tlb_flush_with(TlbFlushOp::for_range(va..va + len), pt);
                 }
             }
         }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -90,7 +90,7 @@ impl VmSpace {
         guard: &'a G,
         va: &Range<Vaddr>,
     ) -> Result<Cursor<'a>> {
-        Ok(self.pt.cursor(guard, va).map(Cursor)?)
+        Ok(Cursor(self.pt.cursor(guard, va)?))
     }
 
     /// Gets an mutable cursor in the virtual address range.
@@ -108,10 +108,10 @@ impl VmSpace {
         guard: &'a G,
         va: &Range<Vaddr>,
     ) -> Result<CursorMut<'a>> {
-        Ok(self.pt.cursor_mut(guard, va).map(|pt_cursor| CursorMut {
-            pt_cursor,
+        Ok(CursorMut {
+            pt_cursor: self.pt.cursor_mut(guard, va)?,
             flusher: TlbFlusher::new(&self.cpus, disable_preempt()),
-        })?)
+        })
     }
 
     /// Activates the page table on the current CPU.


### PR DESCRIPTION
This is an optimization done during early CortenMM development. Cherry picking to contribute here.

There are three weird memory copies:

![389312018c16f1761738f9f5b990e9c7](https://github.com/user-attachments/assets/fc7581ba-3a28-42b6-9574-8c65d7b0cc54)

It is shocking that `return Ok(some_fn().map(|res| Wrapper { f1: res, f2: large_struct() })?)` leads to an extra memory copy than `return Ok(Wrapper { f1: some_fn()?, f2: large_struct() })`. In our case, the `TlbFlusher::new()` who initializes an array of `TlbFlushOp`s is the `large_struct()`. This is optimized in the first commit.

After that, `Result::unwrap` still causes two memory copies. I don't know why the compiler isn't able to optimize this. In our prototype, I changed the API to the panicking style instead of returning an error, but I think this is too intrusive. Maybe fix the compiler instead.

Nevertheless, we can optimize the amount of memory to be copied. The second commit compresses the three qword `Option<TlbFlushOps>` into one qword.

