### PR TITLE
Optimize the usage of `FsResolver` during initialization

### DIFF
--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -10,11 +10,8 @@ use crate::{
 };
 
 /// Initializes "/dev/shm" for POSIX shared memory usage.
-pub fn init() -> Result<()> {
-    let dev_path = {
-        let fs = FsResolver::new();
-        fs.lookup(&FsPath::try_from("/dev")?)?
-    };
+pub fn init_in_first_process(fs_resolver: &FsResolver) -> Result<()> {
+    let dev_path = fs_resolver.lookup(&FsPath::try_from("/dev")?)?;
 
     // Create the "shm" directory under "/dev" and mount a ramfs on it.
     let shm_path =

--- a/kernel/src/fs/device.rs
+++ b/kernel/src/fs/device.rs
@@ -102,11 +102,8 @@ impl DeviceId {
 ///
 /// If the parent path is not existing, `mkdir -p` the parent path.
 /// This function is used in registering device.
-pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Path> {
-    let mut dev_path = {
-        let fs_resolver = FsResolver::new();
-        fs_resolver.lookup(&FsPath::try_from("/dev").unwrap())?
-    };
+pub fn add_node(device: Arc<dyn Device>, path: &str, fs_resolver: &FsResolver) -> Result<Path> {
+    let mut dev_path = fs_resolver.lookup(&FsPath::try_from("/dev").unwrap())?;
     let mut relative_path = {
         let relative_path = path.trim_start_matches('/');
         if relative_path.is_empty() {
@@ -157,7 +154,7 @@ pub fn add_node(device: Arc<dyn Device>, path: &str) -> Result<Path> {
 /// Delete the device node from FS for the device.
 ///
 /// This function is used in unregistering device.
-pub fn delete_node(path: &str) -> Result<()> {
+pub fn delete_node(path: &str, fs_resolver: &FsResolver) -> Result<()> {
     let abs_path = {
         let device_path = path.trim_start_matches('/');
         if device_path.is_empty() {
@@ -166,10 +163,8 @@ pub fn delete_node(path: &str) -> Result<()> {
         String::from("/dev") + "/" + device_path
     };
 
-    let (parent_path, name) = {
-        let fs_resolver = FsResolver::new();
-        fs_resolver.lookup_dir_and_base_name(&FsPath::try_from(abs_path.as_str()).unwrap())?
-    };
+    let (parent_path, name) =
+        fs_resolver.lookup_dir_and_base_name(&FsPath::try_from(abs_path.as_str()).unwrap())?;
 
     parent_path.unlink(&name)?;
     Ok(())

--- a/kernel/src/fs/file_table.rs
+++ b/kernel/src/fs/file_table.rs
@@ -4,11 +4,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::slot_vec::SlotVec;
 
-use super::{
-    file_handle::FileLike,
-    fs_resolver::{FsPath, FsResolver, AT_FDCWD},
-    utils::{AccessMode, InodeMode},
-};
+use super::file_handle::FileLike;
 use crate::{
     events::{Events, IoEvents, Observer, Subject},
     fs::utils::StatusFlags,
@@ -31,34 +27,6 @@ impl FileTable {
     pub const fn new() -> Self {
         Self {
             table: SlotVec::new(),
-            subject: Subject::new(),
-        }
-    }
-
-    pub fn new_with_stdio() -> Self {
-        let mut table = SlotVec::new();
-        let fs_resolver = FsResolver::new();
-        let tty_path = FsPath::new(AT_FDCWD, "/dev/console").expect("cannot find tty");
-        let stdin = {
-            let flags = AccessMode::O_RDONLY as u32;
-            let mode = InodeMode::S_IRUSR;
-            fs_resolver.open(&tty_path, flags, mode.bits()).unwrap()
-        };
-        let stdout = {
-            let flags = AccessMode::O_WRONLY as u32;
-            let mode = InodeMode::S_IWUSR;
-            fs_resolver.open(&tty_path, flags, mode.bits()).unwrap()
-        };
-        let stderr = {
-            let flags = AccessMode::O_WRONLY as u32;
-            let mode = InodeMode::S_IWUSR;
-            fs_resolver.open(&tty_path, flags, mode.bits()).unwrap()
-        };
-        table.put(FileTableEntry::new(Arc::new(stdin), FdFlags::empty()));
-        table.put(FileTableEntry::new(Arc::new(stdout), FdFlags::empty()));
-        table.put(FileTableEntry::new(Arc::new(stderr), FdFlags::empty()));
-        Self {
-            table,
             subject: Subject::new(),
         }
     }

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -97,6 +97,6 @@ impl IpcPermission {
     }
 }
 
-pub(super) fn init() {
-    semaphore::init();
+pub(super) fn init_in_first_kthread() {
+    semaphore::init_in_first_kthread();
 }

--- a/kernel/src/ipc/semaphore/mod.rs
+++ b/kernel/src/ipc/semaphore/mod.rs
@@ -6,6 +6,6 @@
 pub mod posix;
 pub mod system_v;
 
-pub(super) fn init() {
-    system_v::init();
+pub(super) fn init_in_first_kthread() {
+    system_v::init_in_first_kthread();
 }

--- a/kernel/src/ipc/semaphore/system_v/mod.rs
+++ b/kernel/src/ipc/semaphore/system_v/mod.rs
@@ -15,6 +15,6 @@ bitflags! {
     }
 }
 
-pub(super) fn init() {
-    sem_set::init();
+pub(super) fn init_in_first_kthread() {
+    sem_set::init_in_first_kthread();
 }

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -354,7 +354,7 @@ static ID_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
 /// Semaphore sets in system
 static SEMAPHORE_SETS: RwLock<BTreeMap<key_t, SemaphoreSet>> = RwLock::new(BTreeMap::new());
 
-pub(super) fn init() {
+pub(super) fn init_in_first_kthread() {
     ID_ALLOCATOR.call_once(|| {
         let mut id_alloc = IdAlloc::with_capacity(SEMMNI + 1);
         // Remove the first index 0

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -6,7 +6,7 @@ mod poll;
 mod sched;
 
 pub use init::{init, iter_all_ifaces, loopback_iface, virtio_iface};
-pub use poll::lazy_init;
+pub(super) use poll::init_in_first_kthread;
 
 pub type Iface = dyn aster_bigtcp::iface::Iface<ext::BigtcpExt>;
 pub type BoundPort = aster_bigtcp::iface::BoundPort<ext::BigtcpExt>;

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -13,7 +13,7 @@ use crate::{
     WaitTimeout,
 };
 
-pub fn lazy_init() {
+pub fn init_in_first_kthread() {
     for iface in iter_all_ifaces() {
         spawn_background_poll_thread(iface.clone());
     }

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -10,6 +10,6 @@ pub fn init() {
 }
 
 /// Lazy init should be called after spawning init thread.
-pub fn lazy_init() {
-    iface::lazy_init();
+pub fn init_in_first_kthread() {
+    iface::init_in_first_kthread();
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -35,7 +35,13 @@ pub use rlimit::ResourceType;
 pub use term_status::TermStatus;
 pub use wait::{do_wait, WaitOptions, WaitStatus};
 
+use crate::context::Context;
+
 pub(super) fn init() {
     process::init();
     posix_thread::futex::init();
+}
+
+pub(super) fn init_in_first_process(ctx: &Context) {
+    process::init_in_first_process(ctx);
 }

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -4,7 +4,7 @@
 
 use ostd::{cpu::context::UserContext, task::Task, user::UserContextApi};
 
-use super::{Process, Terminal};
+use super::Process;
 use crate::{
     fs::{
         fs_resolver::{FsPath, AT_FDCWD},
@@ -35,9 +35,6 @@ pub fn spawn_init_process(
     let process = create_init_process(executable_path, argv, envp)?;
 
     set_session_and_group(&process);
-
-    // FIXME: This should be done by the userspace init process.
-    (crate::device::tty::system_console().clone() as Arc<dyn Terminal>).set_control(&process)?;
 
     process.run();
 
@@ -124,6 +121,7 @@ fn create_init_task(
     let thread_builder = PosixThreadBuilder::new(tid, Box::new(user_ctx), credentials)
         .thread_name(thread_name)
         .process(process)
-        .fs(Arc::new(fs));
+        .fs(Arc::new(fs))
+        .is_init_process();
     Ok(thread_builder.build())
 }

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -56,6 +56,13 @@ pub(super) fn init() {
     timer_manager::init();
 }
 
+pub(super) fn init_in_first_process(ctx: &Context) {
+    // FIXME: This should be done by the userspace init process.
+    (crate::device::tty::system_console().clone() as Arc<dyn Terminal>)
+        .set_control(ctx.process)
+        .unwrap();
+}
+
 /// Process stands for a set of threads that shares the same userspace.
 pub struct Process {
     // Immutable Part

--- a/kernel/src/thread/work_queue/mod.rs
+++ b/kernel/src/thread/work_queue/mod.rs
@@ -174,7 +174,7 @@ impl WorkQueue {
 }
 
 /// Initialize global worker pools and work queues.
-pub fn init() {
+pub fn init_in_first_kthread() {
     WORKERPOOL_NORMAL.call_once(|| {
         let cpu_set = CpuSet::new_full();
         WorkerPool::new(WorkPriority::Normal, cpu_set)

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -351,7 +351,7 @@ fn init_vdso() {
     VDSO.call_once(|| Arc::new(vdso));
 }
 
-pub(super) fn init() {
+pub(super) fn init_in_first_process() {
     init_start_secs_count();
     init_vdso();
 


### PR DESCRIPTION
This PR is to pave the way for future mount namespace support.

## Include the VDSO library directly

This commit embeds the VDSO library directly into the kernel using include_bytes!. However, since the VDSO library is currently cloned from github during initramfs creation, the current implementation is somewhat inelegant—I'm unsure if this is acceptable as a temporary solution.

**Alternative**: Like the next commit, move the initialization of VDSO to the init task and remain the `FsResolver` usage.

The CI failure is due to the arch-unaware `make check`, #2349 will fix this problem.

## Optimize the `FsResolver` acquisitions during the initialization phase

This commit removes the `ext2` and `exfat` mount operations during kernel boot, delegating them to userspace. It also relocates the logic for building the initramfs file tree and mounting `/dev` into the init task.

The reason for not fully offloading `/dev` mounting to userspace is that the current operations here are relatively complex, and Linux also supports kernel-managed `/dev` mounting and initialization (by enabling `CONFIG_DEVTMPFS_MOUNT`). Hence retaining these operations remains reasonable.