### PR TITLE
Enable arch-aware `make check`

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -70,7 +70,7 @@ runs:
         [[ "${{ matrix.id }}" == "compile" ]] && CMD+="make build FEATURES=all"
         [[ "${{ matrix.id }}" == "usermode_test" ]] && CMD+="make test"
         [[ "${{ matrix.id }}" == "ktest" ]] && CMD+="make ktest NETDEV=tap"
-        [[ -n "${{ inputs.arch }}" ]] && CMD+=" ARCH=${{ inputs.arch }}"
+        [[ -n "${{ inputs.arch }}" ]] && CMD+=" OSDK_TARGET_ARCH=${{ inputs.arch }}"
         
         echo "Executing: $CMD"
         eval $CMD
@@ -86,7 +86,7 @@ runs:
         [[ -n "${{ inputs.smp }}" ]] && CMD+=" SMP=${{ inputs.smp }}"
         [[ -n "${{ inputs.netdev }}" ]] && CMD+=" NETDEV=${{ inputs.netdev }}"
         [[ -n "${{ inputs.scheme }}" ]] && CMD+=" SCHEME=${{ inputs.scheme }}"
-        [[ -n "${{ inputs.arch }}" ]] && CMD+=" ARCH=${{ inputs.arch }}"
+        [[ -n "${{ inputs.arch }}" ]] && CMD+=" OSDK_TARGET_ARCH=${{ inputs.arch }}"
         [[ -n "${{ inputs.extra_blocklists }}" ]] && CMD+=" EXTRA_BLOCKLISTS_DIRS=${{ inputs.extra_blocklists }}"
         [[ -n "${{ inputs.syscall_test_suite }}" ]] && CMD+=" SYSCALL_TEST_SUITE=${{ inputs.syscall_test_suite }}"
         [[ -n "${{ inputs.syscall_test_workdir }}" ]] && CMD+=" SYSCALL_TEST_WORKDIR=${{ inputs.syscall_test_workdir }}"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -49,6 +49,7 @@
         * [cargo osdk debug](osdk/reference/commands/debug.md)
         * [cargo osdk profile](osdk/reference/commands/profile.md)
     * [Manifest](osdk/reference/manifest.md)
+    * [Environment Variables](osdk/reference/environment-variables.md)
 
 # How to Contribute
 

--- a/docs/src/osdk/reference/environment-variables.md
+++ b/docs/src/osdk/reference/environment-variables.md
@@ -1,0 +1,7 @@
+# Environment Variables
+
+The OSDK tool uses the following environment variables to customize compilation and target behavior. 
+
+## OSDK-Specific Variables
+- `OSDK_TARGET_ARCH`: If set, OSDK will use the specified value as its default target architecture (e.g., x86_64, riscv64). 
+If not set, OSDK will default to the host architecture.

--- a/kernel/comps/time/src/rtc/loongson.rs
+++ b/kernel/comps/time/src/rtc/loongson.rs
@@ -25,8 +25,8 @@ impl Driver for RtcLoongson {
             const SYS_TOYTRIM: usize = 0x20;
             // Initialize the RTC unit
             // Reference: <https://loongson.github.io/LoongArch-Documentation/Loongson-7A1000-usermanual-EN.html#rtc>
-            io_mem.write_once(SYS_TOYTRIM, &0x0u32);
-            io_mem.write_once(SYS_RTCCTRL, &0x2900u32);
+            io_mem.write_once(SYS_TOYTRIM, &0x0u32).unwrap();
+            io_mem.write_once(SYS_RTCCTRL, &0x2900u32).unwrap();
 
             Some(Self { io_mem })
         } else {

--- a/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! MMIO bus.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use alloc::{collections::VecDeque, fmt::Debug, sync::Arc, vec::Vec};
 

--- a/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! MMIO bus.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use alloc::{collections::VecDeque, fmt::Debug, sync::Arc, vec::Vec};
 

--- a/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! MMIO device common definitions or functions.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use int_to_c_enum::TryFromInt;
 use log::info;

--- a/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! MMIO device common definitions or functions.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use int_to_c_enum::TryFromInt;
 use log::info;

--- a/kernel/src/arch/loongarch/cpu.rs
+++ b/kernel/src/arch/loongarch/cpu.rs
@@ -3,7 +3,7 @@
 use alloc::{format, string::String};
 
 use ostd::{
-    cpu::context::{CpuExceptionInfo, GeneralRegs, UserContext},
+    cpu::context::{CpuExceptionInfo, UserContext},
     user::UserContextApi,
     Pod,
 };

--- a/kernel/src/arch/loongarch/signal.rs
+++ b/kernel/src/arch/loongarch/signal.rs
@@ -13,7 +13,7 @@ impl SignalContext for UserContext {
 }
 
 impl From<&CpuExceptionInfo> for FaultSignal {
-    fn from(trap_info: &CpuExceptionInfo) -> Self {
+    fn from(_trap_info: &CpuExceptionInfo) -> Self {
         unimplemented!()
     }
 }

--- a/kernel/src/arch/riscv/cpu.rs
+++ b/kernel/src/arch/riscv/cpu.rs
@@ -3,8 +3,7 @@
 use alloc::{format, string::String};
 
 use ostd::{
-    cpu::context::{CpuExceptionInfo, GeneralRegs, UserContext},
-    mm::Vaddr,
+    cpu::context::{CpuExceptionInfo, UserContext},
     user::UserContextApi,
     Pod,
 };

--- a/kernel/src/arch/riscv/signal.rs
+++ b/kernel/src/arch/riscv/signal.rs
@@ -13,7 +13,7 @@ impl SignalContext for UserContext {
 }
 
 impl From<&CpuExceptionInfo> for FaultSignal {
-    fn from(trap_info: &CpuExceptionInfo) -> Self {
+    fn from(_trap_info: &CpuExceptionInfo) -> Self {
         unimplemented!()
     }
 }

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -202,8 +202,12 @@ pub struct ucontext_t {
 impl Default for ucontext_t {
     fn default() -> Self {
         Self {
+            uc_flags: 0,
+            uc_link: Default::default(),
+            uc_stack: Default::default(),
+            uc_sigmask: Default::default(),
             __unused: [0; 120],
-            ..Default::default()
+            uc_mcontext: Default::default(),
         }
     }
 }

--- a/kernel/src/process/signal/signals/fault.rs
+++ b/kernel/src/process/signal/signals/fault.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
 use super::Signal;
 use crate::{
     prelude::*,

--- a/kernel/src/process/signal/signals/fault.rs
+++ b/kernel/src/process/signal/signals/fault.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use super::Signal;
 use crate::{

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! System call handlers.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 pub use clock_gettime::ClockId;
 use ostd::cpu::context::UserContext;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! System call handlers.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 pub use clock_gettime::ClockId;
 use ostd::cpu::context::UserContext;

--- a/osdk/src/arch.rs
+++ b/osdk/src/arch.rs
@@ -79,7 +79,22 @@ impl Display for Arch {
 }
 
 /// Get the default architecture implied by the host rustc's default architecture.
+///
+/// If the environment variable `OSDK_TARGET_ARCH` is set, use it to determine the default
+/// architecture directly.
 pub fn get_default_arch() -> Arch {
+    if let Ok(arch) = std::env::var("OSDK_TARGET_ARCH") {
+        return match arch.as_str() {
+            "aarch64" => Arch::Aarch64,
+            "riscv64" => Arch::RiscV64,
+            "x86_64" => Arch::X86_64,
+            "loongarch64" => Arch::LoongArch64,
+            _ => panic!(
+                "The environment variable `OSDK_TARGET_ARCH` specifies an unsupported native architecture"
+            ),
+        };
+    };
+
     let output = crate::util::new_command_checked_exists("rustc")
         .arg("-vV")
         .output()

--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -30,9 +30,7 @@ fn parse_bootloader_name() -> &'static str {
 }
 
 fn parse_initramfs() -> Option<&'static [u8]> {
-    let Some((start, end)) = parse_initramfs_range() else {
-        return None;
-    };
+    let (start, end) = parse_initramfs_range()?;
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;

--- a/ostd/src/arch/loongarch/boot/smp.rs
+++ b/ostd/src/arch/loongarch/boot/smp.rs
@@ -8,6 +8,10 @@ pub(crate) fn count_processors() -> Option<u32> {
     Some(1)
 }
 
-pub(crate) fn bringup_all_aps(_info_ptr: *const PerApRawInfo, _pr_ptr: Paddr, _num_cpus: u32) {
+pub(crate) unsafe fn bringup_all_aps(
+    _info_ptr: *const PerApRawInfo,
+    _pr_ptr: Paddr,
+    _num_cpus: u32,
+) {
     unimplemented!()
 }

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -2,9 +2,9 @@
 
 //! CPU execution context control.
 
-use core::{arch::asm, fmt::Debug};
+use core::fmt::Debug;
 
-use loongArch64::register::estat::{self, Exception, Interrupt, Trap};
+use loongArch64::register::estat::{Exception, Interrupt, Trap};
 
 use crate::{
     arch::{
@@ -86,7 +86,7 @@ impl CpuExceptionInfo {
 }
 
 /// Userspace CPU context, including general-purpose registers and exception information.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct UserContext {
     user_context: RawUserContext,
@@ -339,7 +339,7 @@ pub type CpuException = Exception;
 /// The FPU context of user task.
 /// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/include/uapi/asm/sigcontext.h#L37>
 // FIXME: Implement FPU context on LoongArch64 platforms.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FpuContext;
 
 impl FpuContext {

--- a/ostd/src/arch/loongarch/device/io_port.rs
+++ b/ostd/src/arch/loongarch/device/io_port.rs
@@ -2,25 +2,41 @@
 
 //! I/O port access.
 
-use core::marker::PhantomData;
-
+/// An access marker type indicating that a port is only allowed to write values.
 pub struct WriteOnlyAccess;
+/// An access marker type indicating that a port is allowed to read or write values.
 pub struct ReadWriteAccess;
 
+/// A marker trait for access types which allow writing port values.
 pub trait IoPortWriteAccess {}
+/// A marker trait for access types which allow reading port values.
 pub trait IoPortReadAccess {}
 
 impl IoPortWriteAccess for WriteOnlyAccess {}
 impl IoPortWriteAccess for ReadWriteAccess {}
 impl IoPortReadAccess for ReadWriteAccess {}
 
+/// A helper trait that implements the read port operation.
 pub trait PortRead: Sized {
+    /// Reads a `Self` value from the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
     unsafe fn read_from_port(_port: u16) -> Self {
         unimplemented!()
     }
 }
 
+/// A helper trait that implements the write port operation.
 pub trait PortWrite: Sized {
+    /// Writes a `Self` value to the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
     unsafe fn write_to_port(_port: u16, _value: Self) {
         unimplemented!()
     }

--- a/ostd/src/arch/loongarch/io.rs
+++ b/ostd/src/arch/loongarch/io.rs
@@ -11,7 +11,7 @@ use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
 /// address space as MMIO regions.
 pub(super) fn construct_io_mem_allocator_builder() -> IoMemAllocatorBuilder {
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
-    let mut reserved_filter = regions.iter().filter(|r| {
+    let reserved_filter = regions.iter().filter(|r| {
         r.typ() != MemoryRegionType::Unknown
             && r.typ() != MemoryRegionType::Reserved
             && r.typ() != MemoryRegionType::Framebuffer

--- a/ostd/src/arch/loongarch/irq.rs
+++ b/ostd/src/arch/loongarch/irq.rs
@@ -20,7 +20,7 @@ impl IrqRemapping {
     ///
     /// This will do nothing if the entry is already initialized or interrupt
     /// remapping is disabled or not supported by the architecture.
-    pub(crate) fn init(&self, irq_num: u8) {}
+    pub(crate) fn init(&self, _irq_num: u8) {}
 
     /// Gets the remapping index of the IRQ line.
     ///
@@ -66,7 +66,7 @@ pub(crate) fn is_local_enabled() -> bool {
 pub(crate) struct HwCpuId(u32);
 
 impl HwCpuId {
-    pub(crate) fn read_current(guard: &dyn PinCurrentCpu) -> Self {
+    pub(crate) fn read_current(_guard: &dyn PinCurrentCpu) -> Self {
         // TODO: Support SMP in LoongArch.
         Self(0)
     }
@@ -79,6 +79,6 @@ impl HwCpuId {
 /// The caller must ensure that the interrupt number is valid and that
 /// the corresponding handler is configured correctly on the remote CPU.
 /// Furthermore, invoking the interrupt handler must also be safe.
-pub(crate) unsafe fn send_ipi(hw_cpu_id: HwCpuId, irq_num: u8, guard: &dyn PinCurrentCpu) {
+pub(crate) unsafe fn send_ipi(_hw_cpu_id: HwCpuId, _irq_num: u8, _guard: &dyn PinCurrentCpu) {
     unimplemented!()
 }

--- a/ostd/src/arch/loongarch/kernel/irq/eiointc.rs
+++ b/ostd/src/arch/loongarch/kernel/irq/eiointc.rs
@@ -89,10 +89,7 @@ impl Eiointc {
 
         // Set the interrupt to bounce on the cores on node 0
         for i in 0..Self::MAX_INTERRUPT_NUM {
-            iocsr_write_b(
-                Self::EXT_IOI_MAP_CORE_BASE + i as usize,
-                (1 << core_num) - 1,
-            );
+            iocsr_write_b(Self::EXT_IOI_MAP_CORE_BASE + i, (1 << core_num) - 1);
         }
 
         // Set the node type0 to node 0

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -142,17 +142,17 @@ impl PageTableEntry {
 
     fn is_huge(&self) -> bool {
         if self.0 & PageTableFlags::IS_BASIC.bits() != 0 {
-            return false;
+            false
         } else {
-            return self.0 & PageTableFlags::GLOBAL_OR_HUGE.bits() != 0;
+            self.0 & PageTableFlags::GLOBAL_OR_HUGE.bits() != 0
         }
     }
 
     fn is_global(&self) -> bool {
         if self.0 & PageTableFlags::IS_BASIC.bits() != 0 {
-            return self.0 & PageTableFlags::GLOBAL_OR_HUGE.bits() != 0;
+            self.0 & PageTableFlags::GLOBAL_OR_HUGE.bits() != 0
         } else {
-            return self.0 & PageTableFlags::GLOBAL_IN_HUGE.bits() != 0;
+            self.0 & PageTableFlags::GLOBAL_IN_HUGE.bits() != 0
         }
     }
 }
@@ -226,10 +226,11 @@ impl PageTableEntryTrait for PageTableEntry {
         PageProperty {
             flags: PageFlags::from_bits(flags as u8).unwrap(),
             cache,
-            priv_flags: PrivFlags::from_bits(priv_flags as u8).unwrap(),
+            priv_flags: PrivFlags::from_bits(priv_flags).unwrap(),
         }
     }
 
+    #[expect(clippy::precedence)]
     fn set_prop(&mut self, prop: PageProperty) {
         let mut flags = PageTableFlags::VALID.bits()
             // FIXME: To avoid the PageModifyFault exception,

--- a/ostd/src/arch/loongarch/mod.rs
+++ b/ostd/src/arch/loongarch/mod.rs
@@ -2,6 +2,8 @@
 
 //! Platform-specific code for the LoongArch platform.
 
+#![expect(dead_code)]
+
 pub mod boot;
 pub(crate) mod cpu;
 pub mod device;

--- a/ostd/src/arch/loongarch/pci.rs
+++ b/ostd/src/arch/loongarch/pci.rs
@@ -85,7 +85,7 @@ pub(crate) fn init() {
 
 pub(crate) const MSIX_DEFAULT_MSG_ADDR: u32 = 0x2ff0_0000;
 
-pub(crate) fn construct_remappable_msix_address(remapping_index: u32) -> u32 {
+pub(crate) fn construct_remappable_msix_address(_remapping_index: u32) -> u32 {
     unimplemented!()
 }
 
@@ -140,7 +140,7 @@ fn init_mmio_allocator_from_fdt(node: &FdtNode) {
 
     while i + entry_size <= data.len() {
         let pci_space = u32::from_be_bytes(data[i..i + 4].try_into().unwrap());
-        let pci_addr = u64::from_be_bytes(data[i + 4..i + 12].try_into().unwrap());
+        let _pci_addr = u64::from_be_bytes(data[i + 4..i + 12].try_into().unwrap());
         let cpu_addr = u64::from_be_bytes(data[i + 12..i + 20].try_into().unwrap());
         let size = u64::from_be_bytes(data[i + 20..i + 28].try_into().unwrap());
 

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::arch::{asm, global_asm};
+use core::arch::global_asm;
 
 use crate::arch::cpu::context::GeneralRegs;
 

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -32,9 +32,7 @@ fn parse_kernel_commandline() -> &'static str {
 }
 
 fn parse_initramfs() -> Option<&'static [u8]> {
-    let Some((start, end)) = parse_initramfs_range() else {
-        return None;
-    };
+    let (start, end) = parse_initramfs_range()?;
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;

--- a/ostd/src/arch/riscv/boot/smp.rs
+++ b/ostd/src/arch/riscv/boot/smp.rs
@@ -8,6 +8,10 @@ pub(crate) fn count_processors() -> Option<u32> {
     Some(1)
 }
 
-pub(crate) fn bringup_all_aps(_info_ptr: *const PerApRawInfo, _pr_ptr: Paddr, _num_cpus: u32) {
+pub(crate) unsafe fn bringup_all_aps(
+    _info_ptr: *const PerApRawInfo,
+    _pr_ptr: Paddr,
+    _num_cpus: u32,
+) {
     unimplemented!()
 }

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Userspace CPU context, including general-purpose registers and exception information.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct UserContext {
     user_context: RawUserContext,
@@ -65,6 +65,7 @@ pub struct GeneralRegs {
 /// CPU exception information.
 //
 // TODO: Refactor the struct into an enum (similar to x86's `CpuException`).
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct CpuExceptionInfo {
@@ -268,7 +269,7 @@ pub type CpuException = Exception;
 ///
 /// This could be used for saving both legacy and modern state format.
 // FIXME: Implement FPU context on RISC-V platforms.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FpuContext;
 
 impl FpuContext {

--- a/ostd/src/arch/riscv/cpu/extension.rs
+++ b/ostd/src/arch/riscv/cpu/extension.rs
@@ -62,7 +62,7 @@ fn parse_isa_string(isa: &fdt::node::NodeProperty) -> IsaExtensions {
         for ch in first_part.chars() {
             if let Some(ext_data) = EXTENSION_TABLE
                 .iter()
-                .find(|e| e.name.len() == 1 && e.name.chars().next() == Some(ch))
+                .find(|e| e.name.len() == 1 && e.name.starts_with(ch))
             {
                 extensions |= ext_data.flag;
             }

--- a/ostd/src/arch/riscv/device/io_port.rs
+++ b/ostd/src/arch/riscv/device/io_port.rs
@@ -2,25 +2,41 @@
 
 //! I/O port access.
 
-use core::marker::PhantomData;
-
+/// An access marker type indicating that a port is only allowed to write values.
 pub struct WriteOnlyAccess;
+/// An access marker type indicating that a port is allowed to read or write values.
 pub struct ReadWriteAccess;
 
+/// A marker trait for access types which allow writing port values.
 pub trait IoPortWriteAccess {}
+/// A marker trait for access types which allow reading port values.
 pub trait IoPortReadAccess {}
 
 impl IoPortWriteAccess for WriteOnlyAccess {}
 impl IoPortWriteAccess for ReadWriteAccess {}
 impl IoPortReadAccess for ReadWriteAccess {}
 
+/// A helper trait that implements the read port operation.
 pub trait PortRead: Sized {
+    /// Reads a `Self` value from the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
     unsafe fn read_from_port(_port: u16) -> Self {
         unimplemented!()
     }
 }
 
+/// A helper trait that implements the write port operation.
 pub trait PortWrite: Sized {
+    /// Writes a `Self` value to the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
     unsafe fn write_to_port(_port: u16, _value: Self) {
         unimplemented!()
     }

--- a/ostd/src/arch/riscv/io.rs
+++ b/ostd/src/arch/riscv/io.rs
@@ -11,7 +11,7 @@ use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
 /// address space as MMIO regions.
 pub(super) fn construct_io_mem_allocator_builder() -> IoMemAllocatorBuilder {
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
-    let mut reserved_filter = regions.iter().filter(|r| {
+    let reserved_filter = regions.iter().filter(|r| {
         r.typ() != MemoryRegionType::Unknown
             && r.typ() != MemoryRegionType::Reserved
             && r.typ() != MemoryRegionType::Framebuffer

--- a/ostd/src/arch/riscv/irq.rs
+++ b/ostd/src/arch/riscv/irq.rs
@@ -20,7 +20,7 @@ impl IrqRemapping {
     ///
     /// This will do nothing if the entry is already initialized or interrupt
     /// remapping is disabled or not supported by the architecture.
-    pub(crate) fn init(&self, irq_num: u8) {}
+    pub(crate) fn init(&self, _irq_num: u8) {}
 
     /// Gets the remapping index of the IRQ line.
     ///
@@ -74,7 +74,7 @@ pub(crate) fn is_local_enabled() -> bool {
 pub(crate) struct HwCpuId(u32);
 
 impl HwCpuId {
-    pub(crate) fn read_current(guard: &dyn PinCurrentCpu) -> Self {
+    pub(crate) fn read_current(_guard: &dyn PinCurrentCpu) -> Self {
         // TODO: Support SMP in RISC-V.
         Self(0)
     }
@@ -87,6 +87,6 @@ impl HwCpuId {
 /// The caller must ensure that the interrupt number is valid and that
 /// the corresponding handler is configured correctly on the remote CPU.
 /// Furthermore, invoking the interrupt handler must also be safe.
-pub(crate) unsafe fn send_ipi(hw_cpu_id: HwCpuId, irq_num: u8, guard: &dyn PinCurrentCpu) {
+pub(crate) unsafe fn send_ipi(_hw_cpu_id: HwCpuId, _irq_num: u8, _guard: &dyn PinCurrentCpu) {
     unimplemented!()
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -101,7 +101,9 @@ pub struct PageTableEntry(usize);
 pub unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
     assert!(root_paddr % PagingConsts::BASE_PAGE_SIZE == 0);
     let ppn = root_paddr >> 12;
-    riscv::register::satp::set(riscv::register::satp::Mode::Sv48, 0, ppn);
+    unsafe {
+        riscv::register::satp::set(riscv::register::satp::Mode::Sv48, 0, ppn);
+    }
 }
 
 pub fn current_page_table_paddr() -> Paddr {
@@ -173,6 +175,7 @@ impl PageTableEntryTrait for PageTableEntry {
         }
     }
 
+    #[expect(clippy::precedence)]
     fn set_prop(&mut self, prop: PageProperty) {
         let mut flags = PageTableFlags::VALID.bits()
             | parse_flags!(prop.flags.bits(), PageFlags::R, PageTableFlags::READABLE)

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -2,6 +2,8 @@
 
 //! Platform-specific code for the RISC-V platform.
 
+#![expect(dead_code)]
+
 pub mod boot;
 pub(crate) mod cpu;
 pub mod device;
@@ -47,7 +49,7 @@ pub(crate) unsafe fn init_on_ap() {
     unimplemented!()
 }
 
-pub(crate) fn interrupts_ack(irq_number: usize) {
+pub(crate) fn interrupts_ack(_irq_number: usize) {
     unimplemented!()
 }
 

--- a/ostd/src/arch/riscv/pci.rs
+++ b/ostd/src/arch/riscv/pci.rs
@@ -76,6 +76,6 @@ pub(crate) fn init() {
 
 pub(crate) const MSIX_DEFAULT_MSG_ADDR: u32 = 0x2400_0000;
 
-pub(crate) fn construct_remappable_msix_address(remapping_index: u32) -> u32 {
+pub(crate) fn construct_remappable_msix_address(_remapping_index: u32) -> u32 {
     unimplemented!()
 }

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -2,6 +2,8 @@
 
 //! Handles trap.
 
+#[expect(clippy::module_inception)]
+
 mod trap;
 
 use riscv::register::scause::Interrupt;
@@ -18,7 +20,9 @@ cpu_local_cell! {
 
 /// Initializes interrupt handling on RISC-V.
 pub(crate) unsafe fn init() {
-    self::trap::init();
+    unsafe {
+        self::trap::init();
+    }
 }
 
 /// Returns true if this function is called within the context of an IRQ handler

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -3,7 +3,6 @@
 //! Handles trap.
 
 #[expect(clippy::module_inception)]
-
 mod trap;
 
 use riscv::register::scause::Interrupt;

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(unfulfilled_lint_expectations)]
+
 use core::arch::{asm, global_asm};
 
 use crate::arch::cpu::context::GeneralRegs;
@@ -55,11 +57,13 @@ global_asm!(include_str!("trap.S"));
 ///
 /// You **MUST NOT** modify these registers later.
 pub unsafe fn init() {
-    // Set sscratch register to 0, indicating to exception vector that we are
-    // presently executing in the kernel
-    asm!("csrw sscratch, zero");
-    // Set the exception vector address
-    asm!("csrw stvec, {}", in(reg) trap_entry as usize);
+    unsafe {
+        // Set sscratch register to 0, indicating to exception vector that we are
+        // presently executing in the kernel
+        asm!("csrw sscratch, zero");
+        // Set the exception vector address
+        asm!("csrw stvec, {}", in(reg) trap_entry as usize);
+    }
 }
 
 /// Trap frame of kernel interrupt

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -5,7 +5,11 @@
 //!     rest of OSTD;
 //!  2. the routine booting into the actual kernel;
 //!  3. the routine booting the other processors in the SMP context.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 pub mod memory_region;
 pub mod smp;

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -5,6 +5,7 @@
 //!     rest of OSTD;
 //!  2. the routine booting into the actual kernel;
 //!  3. the routine booting the other processors in the SMP context.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 pub mod memory_region;
 pub mod smp;

--- a/ostd/src/bus/pci/cfg_space.rs
+++ b/ostd/src/bus/pci/cfg_space.rs
@@ -270,6 +270,7 @@ impl MemoryBar {
         // 32 bit register is considered an extension of the first (i.e., bits 63:32). Software
         // writes a value of all 1's to both registers, reads them back, and combines the result
         // into a 64-bit value."
+        #[cfg_attr(target_arch = "loongarch64", expect(unused_variables))]
         let (raw64, size_encoded64) = match address_length {
             AddrLen::Bits32 => (raw as u64, size_encoded as u64 | ((u32::MAX as u64) << 32)),
             AddrLen::Bits64 => {

--- a/ostd/src/cpu/local/static_cpu_local.rs
+++ b/ostd/src/cpu/local/static_cpu_local.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Statically-allocated CPU-local objects.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use core::marker::PhantomData;
 

--- a/ostd/src/cpu/local/static_cpu_local.rs
+++ b/ostd/src/cpu/local/static_cpu_local.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Statically-allocated CPU-local objects.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use core::marker::PhantomData;
 

--- a/ostd/src/io/io_mem/allocator.rs
+++ b/ostd/src/io/io_mem/allocator.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! I/O Memory allocator.
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use alloc::vec::Vec;
 use core::ops::Range;

--- a/ostd/src/io/io_mem/allocator.rs
+++ b/ostd/src/io/io_mem/allocator.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! I/O Memory allocator.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use alloc::vec::Vec;
 use core::ops::Range;

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![cfg_attr(target_arch = "riscv64", allow(unfulfilled_lint_expectations))]
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    allow(unfulfilled_lint_expectations)
+)]
 
 use alloc::sync::Arc;
 use core::ops::Range;

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg_attr(target_arch = "riscv64", allow(unfulfilled_lint_expectations))]
+
 use alloc::sync::Arc;
 use core::ops::Range;
 
@@ -151,9 +153,9 @@ impl DmaStream {
                 if self.inner.is_cache_coherent {
                     return Ok(());
                 }
-                let start_va = crate::mm::paddr_to_vaddr(self.inner.segment.start_paddr()) as *const u8;
+                let _start_va = crate::mm::paddr_to_vaddr(self.inner.segment.start_paddr()) as *const u8;
                 // TODO: Query the CPU for the cache line size via CPUID, we use 64 bytes as the cache line size here.
-                for i in _byte_range.step_by(64) {
+                for _i in _byte_range.step_by(64) {
                     // TODO: Call the cache line flush command in the corresponding architecture.
                     todo!()
                 }

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -49,7 +49,6 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use align_ext::AlignExt;
 use log::info;
 
 use crate::{
@@ -58,7 +57,6 @@ use crate::{
     const_assert,
     mm::{
         frame::allocator::{self, EarlyAllocatedFrameMeta},
-        kspace::LINEAR_MAPPING_BASE_VADDR,
         paddr_to_vaddr, page_size,
         page_table::boot_pt,
         CachePolicy, Infallible, Paddr, PageFlags, PageProperty, PrivilegedPageFlags, Segment,
@@ -611,6 +609,10 @@ fn mark_unusable_ranges() {
 /// initializing metadata.
 #[cfg(target_arch = "x86_64")]
 fn add_temp_linear_mapping(max_paddr: Paddr) {
+    use align_ext::AlignExt;
+
+    use crate::mm::kspace::LINEAR_MAPPING_BASE_VADDR;
+
     const PADDR4G: Paddr = 0x1_0000_0000;
 
     if max_paddr <= PADDR4G {

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -34,6 +34,8 @@
 //! If the address width is (according to [`crate::arch::mm::PagingConsts`])
 //! 39 bits or 57 bits, the memory space just adjust proportionally.
 
+#![cfg_attr(target_arch = "loongarch64", expect(unused_imports))]
+
 pub(crate) mod kvirt_area;
 
 use core::ops::Range;

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Virtual memory (VM).
-#![cfg_attr(target_arch = "riscv64", expect(unused_imports))]
+
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(unused_imports)
+)]
 
 /// Virtual addresses.
 pub type Vaddr = usize;

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Virtual memory (VM).
+#![cfg_attr(target_arch = "riscv64", expect(unused_imports))]
 
 /// Virtual addresses.
 pub type Vaddr = usize;

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
 use core::{
     fmt::Debug,
     intrinsics::transmute_unchecked,

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+#![cfg_attr(
+    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    expect(dead_code)
+)]
 
 use core::{
     fmt::Debug,

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -2,6 +2,8 @@
 
 //! Panic support.
 
+#![cfg_attr(target_arch = "loongarch64", expect(unused_imports))]
+
 use core::ffi::c_void;
 
 use crate::{
@@ -110,6 +112,7 @@ pub fn print_stack_trace() {
     _Unwind_Backtrace(callback, &mut data as *mut _ as _);
 }
 
+/// Catches unwinding panics.
 #[cfg(target_arch = "loongarch64")]
 pub fn catch_unwind<R, F: FnOnce() -> R>(
     f: F,
@@ -118,11 +121,13 @@ pub fn catch_unwind<R, F: FnOnce() -> R>(
     Ok(f())
 }
 
+/// Begins panic handling
 #[cfg(target_arch = "loongarch64")]
 pub fn begin_panic<R>(_: alloc::boxed::Box<R>) {
     // TODO: Support panic context in LoongArch.
 }
 
+/// Prints the stack trace of the current thread to the console.
 #[cfg(target_arch = "loongarch64")]
 pub fn print_stack_trace() {
     // TODO: Support stack trace print in LoongArch.

--- a/ostd/src/trap/handler.rs
+++ b/ostd/src/trap/handler.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
+
 use spin::Once;
 
 use super::irq::{disable_local, process_top_half, DisabledLocalIrqGuard};

--- a/ostd/src/trap/mod.rs
+++ b/ostd/src/trap/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Handles trap across kernel and user space.
+
 #![cfg_attr(target_arch = "riscv64", expect(unused_imports))]
 
 mod handler;

--- a/ostd/src/trap/mod.rs
+++ b/ostd/src/trap/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Handles trap across kernel and user space.
+#![cfg_attr(target_arch = "riscv64", expect(unused_imports))]
 
 mod handler;
 pub mod irq;

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! User mode.
+
 #![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use crate::{arch::trap::TrapFrame, cpu::context::UserContext};

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! User mode.
+#![cfg_attr(target_arch = "riscv64", expect(dead_code))]
 
 use crate::{arch::trap::TrapFrame, cpu::context::UserContext};
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
-ARCH ?= x86_64
+OSDK_TARGET_ARCH ?= x86_64
 SMP ?= 1
 VERBOSE ?= 1
 SYSCALL_TEST_SUITE ?= ltp
@@ -47,7 +47,7 @@ endif
 all: build
 
 .PHONY: build
-ifeq ($(ARCH), loongarch64)
+ifeq ($(OSDK_TARGET_ARCH), loongarch64)
 build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
@@ -59,7 +59,7 @@ endif
 $(INITRAMFS_IMAGE): $(INITRAMFS)
 	@nix-build \
 		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(ARCH) \
+		--argstr target $(OSDK_TARGET_ARCH) \
 		--arg enableBasicTest $(ENABLE_BASIC_TEST) \
 		--arg enableBenchmark $(ENABLE_BENCHMARK) \
 		--arg enableSyscallTest $(ENABLE_SYSCALL_TEST) \
@@ -74,7 +74,7 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 $(INITRAMFS):
 	@nix-build \
 		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(ARCH) \
+		--argstr target $(OSDK_TARGET_ARCH) \
 		--arg enableBasicTest $(ENABLE_BASIC_TEST) \
 		--arg enableBenchmark $(ENABLE_BENCHMARK) \
 		--arg enableSyscallTest $(ENABLE_SYSCALL_TEST) \

--- a/test/README.md
+++ b/test/README.md
@@ -38,9 +38,9 @@ While most tests rely on `Nix` for compilation, the `gvisor` syscall test suite 
 The test suite supports building for multiple architectures, including `x86_64` and `riscv64`. You can specify the desired architecture by running:
 
 ```bash
-make build ARCH=x86_64
+make build OSDK_TARGET_ARCH=x86_64
 # or
-make build ARCH=riscv64
+make build OSDK_TARGET_ARCH=riscv64
 ```
 
 The build artifacts (initramfs) can be found in the `test/build` directory after the compilation.


### PR DESCRIPTION
In OSDK, the target arch detection logic does not read the `ARCH` environment variable, which causes `make check` to always check the x86 architecture code even when `ARCH` is explicitly specified. This PR addresses that issue.

However, since the RISC-V and LoongArch implementations currently contain many dummy placeholders, the enabled Clippy checks exclude `dead_code`, `unused_imports`, and `unfulfilled_lint_expectations` to avoid requiring extensive modifications to non-architecture-specific code.