### PR TITLE
Unify the implementation of /proc/[pid] and /proc/[pid]/task/[tid]

### DIFF
--- a/kernel/src/fs/procfs/pid/stat.rs
+++ b/kernel/src/fs/procfs/pid/stat.rs
@@ -8,10 +8,9 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    process::posix_thread::AsPosixThread,
+    process::{posix_thread::AsPosixThread, Process},
     thread::Thread,
     vm::vmar::RssType,
-    Process,
 };
 
 /// Represents the inode at either `/proc/[pid]/stat` or `/proc/[pid]/task/[tid]/stat`.

--- a/kernel/src/fs/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/task/cmdline.rs
@@ -6,10 +6,10 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    Process,
+    process::Process,
 };
 
-/// Represents the inode at `/proc/[pid]/cmdline`.
+/// Represents the inode at `/proc/[pid]/task/[tid]/cmdline` (and also `/proc/[pid]/cmdline`).
 pub struct CmdlineFileOps(Arc<Process>);
 
 impl CmdlineFileOps {

--- a/kernel/src/fs/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/procfs/pid/task/comm.rs
@@ -6,10 +6,10 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    Process,
+    process::Process,
 };
 
-/// Represents the inode at `/proc/[pid]/comm`.
+/// Represents the inode at `/proc/[pid]/task/[tid]/comm` (and also `/proc/[pid]/comm`).
 pub struct CommFileOps(Arc<Process>);
 
 impl CommFileOps {

--- a/kernel/src/fs/procfs/pid/task/exe.rs
+++ b/kernel/src/fs/procfs/pid/task/exe.rs
@@ -6,10 +6,10 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    Process,
+    process::Process,
 };
 
-/// Represents the inode at `/proc/[pid]/exe`.
+/// Represents the inode at `/proc/[pid]/task/[tid]/exe` (and also `/proc/[pid]/exe`).
 pub struct ExeSymOps(Arc<Process>);
 
 impl ExeSymOps {

--- a/kernel/src/fs/procfs/pid/task/status.rs
+++ b/kernel/src/fs/procfs/pid/task/status.rs
@@ -8,13 +8,12 @@ use crate::{
         utils::Inode,
     },
     prelude::*,
-    process::posix_thread::AsPosixThread,
+    process::{posix_thread::AsPosixThread, Process},
     thread::Thread,
     vm::vmar::RssType,
-    Process,
 };
 
-/// Represents the inode at either `/proc/[pid]/status` or `/proc/[pid]/task/[tid]/status`.
+/// Represents the inode at `/proc/[pid]/task/[tid]/status` (and also `/proc/[pid]/status`).
 /// See https://github.com/torvalds/linux/blob/ce1c54fdff7c4556b08f5b875a331d8952e8b6b7/fs/proc/array.c#L148
 /// FIXME: Some fields are not implemented yet.
 ///


### PR DESCRIPTION
This PR unifies the implementation of entries under `/proc/[pid]` and `/proc/[pid]/task/[tid]`.

When working on procfs namespace entries, I found these entries should appear in both `/proc/[pid]` and `/proc/[pid]/task/[tid]`, representing process-level and thread-level views, respectively. Today those two directories are managed separately, so adding a new entry requires duplicating the work for both locations, which leads to redundant code and occasional inconsistencies. For example, `/proc/[pid]/fd` exists while `/proc/[pid]/task/[tid]/fd` does not.

To address this, the PR introduces a `PidOrTid` enum to indicate whether an inode lives under the pid directory or the tid directory. This lets us unify the interface and implement the shared logic for both directories in one place.

```rust
/// Represents an inode is under `/proc/[pid]` or `/proc/[pid]/task/[tid]`.
#[derive(Clone)]
pub enum PidOrTid {
    Pid {
        process: Arc<Process>,
        main_thread: Arc<Thread>,
    },
    Tid {
        process: Arc<Process>,
        thread: Arc<Thread>,
    },
}
```