### PR TITLE
Rename `atomic_update` to `atomic_fetch_update`

### DIFF
--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -295,7 +295,8 @@ pub fn futex_wake_op(
         };
 
         let pf_result = ctx.thread_local.with_page_fault_disabled(|| {
-            user_space.atomic_update::<u32>(futex_addr_2, |val| wake_op.calculate_new_val(val))
+            user_space
+                .atomic_fetch_update::<u32>(futex_addr_2, |val| wake_op.calculate_new_val(val))
         });
         if let Some(result) = pf_result {
             break (futex_bucket_1, futex_bucket_2, result?);

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -910,8 +910,9 @@ impl VmWriter<'_, Fallible> {
         assert!(cursor.is_aligned());
 
         // SAFETY:
-        // 1. The cursor is either valid for reading and writing or in user space for 4 bytes.
-        // 2. The cursor is aligned on a 4-byte boundary.
+        // 1. The cursor is either valid for reading and writing or in user space for
+        //    `size_of::<T>()` bytes.
+        // 2. The cursor is aligned on a `align_of::<T>()`-byte boundary.
         let cur_val = unsafe { T::atomic_cmpxchg_fallible(cursor, old_val, new_val)? };
 
         Ok((cur_val, old_val == cur_val))


### PR DESCRIPTION
This addresses https://github.com/asterinas/asterinas/pull/2343#discussion_r2284400177.

Besides, I found there are typos introduced in `ostd/src/mm/io.rs` by https://github.com/asterinas/asterinas/pull/2306. The typos have been fixed together in this PR.