### PR TITLE
Add signal & timer related syscall limitations to the book

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -33,7 +33,7 @@ provided by Linux on x86-64 architecture.
 | 10      | mprotect               | ✅             | [⚠️](limitations-on-system-calls/memory-management.md#mprotect) |
 | 11      | munmap                 | ✅             |     |
 | 12      | brk                    | ✅             |     |
-| 13      | rt_sigaction           | ✅             |     |
+| 13      | rt_sigaction           | ✅             | [⚠️](limitations-on-system-calls/signals-and-timers.md#rt_sigaction) |
 | 14      | rt_sigprocmask         | ✅             |     |
 | 15      | rt_sigreturn           | ✅             |     |
 | 16      | ioctl                  | ✅             |     |
@@ -242,7 +242,7 @@ provided by Linux on x86-64 architecture.
 | 219     | restart_syscall        | ❌             |     |
 | 220     | semtimedop             | ✅             | [⚠️](limitations-on-system-calls/inter-process-communication.md#semop-and-semtimedop) |
 | 221     | fadvise64              | ✅             |     |
-| 222     | timer_create           | ✅             |     |
+| 222     | timer_create           | ✅             | [⚠️](limitations-on-system-calls/signals-and-timers.md#timer_create) |
 | 223     | timer_settime          | ✅             |     |
 | 224     | timer_gettime          | ✅             |     |
 | 225     | timer_getoverrun       | ❌             |     |

--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/signals-and-timers.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/signals-and-timers.md
@@ -8,3 +8,77 @@ rt_sigreturn, kill, tkill, tgkill, alarm, setitimer, getitimer, nanosleep,
 timer_create, timer_settime, timer_gettime, and timer_delete
 under this category.
 -->
+
+## Signals
+
+### `rt_sigaction`
+
+Supported functionality in SCML:
+
+```c
+// Change and/or retrieve a signal action
+rt_sigaction(
+    signum,
+    act = {
+        sa_flags = SA_ONSTACK | SA_RESTART | SA_NODEFER | SA_RESTORER | SA_SIGINFO | SA_RESETHAND,
+        ..
+    },
+    oldact, sigsetsize
+);
+```
+
+Unsupported `sigaction` flags:
+* `SA_NOCLDSTOP`
+* `SA_NOCLDWAIT`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/sigaction.2.html).
+
+### `rt_sigprocmask`
+
+Supported functionality in SCML:
+
+```c
+// Change and/or retrieve blocked signals
+rt_sigprocmask(
+    how = SIG_BLOCK | SIG_UNBLOCK | SIG_SETMASK, set, oldset, sigsetsize
+);
+```
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/sigprocmask.2.html).
+
+## POSIX Interval Timers
+
+### `timer_create`
+
+Supported functionality in SCML:
+
+```c
+opt_notify_methods = SIGEV_NONE | SIGEV_SIGNAL | SIGEV_THREAD_ID;
+
+// Create a timer with predefined clock source
+timer_create(
+    clockid = CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID | CLOCK_REALTIME | CLOCK_MONOTONIC | CLOCK_BOOTTIME,
+    sevp = <opt_notify_methods>,
+    timerid
+);
+
+// Create a timer based on a per-process or per-thread clock
+timer_create(
+    clockid = <INTEGER>,
+    sevp = <opt_notify_methods>,
+    timerid
+);
+```
+
+Unsupported predefined clock IDs:
+* `CLOCK_REALTIME_ALARM`
+* `CLOCK_BOOTTIME_ALARM`
+* `CLOCK_TAI`
+
+Unsupported notification methods:
+* `SIGEV_THREAD`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/timer_create.2.html).


### PR DESCRIPTION
This PR adds syscall limitations documentation via System Call Matching Language (SCML) for:
- Signals: `rt_sigaction` and `rt_sigprocmask`
- POSIX Interval Timers: `timer_create`

In addition, add matching rules for built-in flags: `<PATH>` and `<NUMBER>`.