### PR TITLE
Call `check_vaddr` in `CurrentUserSpace::reader/writer`

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -85,9 +85,7 @@ impl<'a> CurrentUserSpace<'a> {
     ///
     /// Returns `Err` if the `vaddr` and `len` do not represent a user space memory range.
     pub fn reader(&self, vaddr: Vaddr, len: usize) -> Result<VmReader<'_, Fallible>> {
-        if len > 0 {
-            check_vaddr(vaddr)?;
-        }
+        check_vaddr(vaddr)?;
         Ok(self.root_vmar().vm_space().reader(vaddr, len)?)
     }
 
@@ -95,9 +93,7 @@ impl<'a> CurrentUserSpace<'a> {
     ///
     /// Returns `Err` if the `vaddr` and `len` do not represent a user space memory range.
     pub fn writer(&self, vaddr: Vaddr, len: usize) -> Result<VmWriter<'_, Fallible>> {
-        if len > 0 {
-            check_vaddr(vaddr)?;
-        }
+        check_vaddr(vaddr)?;
         Ok(self.root_vmar().vm_space().writer(vaddr, len)?)
     }
 
@@ -113,9 +109,7 @@ impl<'a> CurrentUserSpace<'a> {
         vaddr: Vaddr,
         len: usize,
     ) -> Result<(VmReader<'_, Fallible>, VmWriter<'_, Fallible>)> {
-        if len > 0 {
-            check_vaddr(vaddr)?;
-        }
+        check_vaddr(vaddr)?;
         Ok(self.root_vmar().vm_space().reader_writer(vaddr, len)?)
     }
 

--- a/kernel/src/syscall/listxattr.rs
+++ b/kernel/src/syscall/listxattr.rs
@@ -87,7 +87,12 @@ fn listxattr(
     }
 
     let namespace = get_current_xattr_namespace(ctx);
-    let mut list_writer = user_space.writer(list_ptr, list_len)?;
+    let mut list_writer = if list_ptr != 0 && list_len != 0 {
+        user_space.writer(list_ptr, list_len)?
+    } else {
+        // A dummy writer that won't be used to write anything.
+        VmWriter::from([].as_mut_slice()).to_fallible()
+    };
 
     let path = lookup_path_for_xattr(&file_ctx, ctx)?;
     path.list_xattr(namespace, &mut list_writer)

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -144,7 +144,7 @@ impl VmSpace {
 
     /// Creates a reader to read data from the user space of the current task.
     ///
-    /// Returns `Err` if this `VmSpace` is not belonged to the user space of the current task
+    /// Returns `Err` if this `VmSpace` does not belong to the user space of the current task
     /// or the `vaddr` and `len` do not represent a user space memory range.
     ///
     /// Users must ensure that no other page table is activated in the current task during the
@@ -164,7 +164,7 @@ impl VmSpace {
 
     /// Creates a writer to write data into the user space.
     ///
-    /// Returns `Err` if this `VmSpace` is not belonged to the user space of the current task
+    /// Returns `Err` if this `VmSpace` does not belong to the user space of the current task
     /// or the `vaddr` and `len` do not represent a user space memory range.
     ///
     /// Users must ensure that no other page table is activated in the current task during the
@@ -184,6 +184,43 @@ impl VmSpace {
         //
         // SAFETY: The memory range is in user space, as checked above.
         Ok(unsafe { VmWriter::<Fallible>::from_user_space(vaddr as *mut u8, len) })
+    }
+
+    /// Creates a reader/writer pair to read data from and write data into the user space.
+    ///
+    /// Returns `Err` if this `VmSpace` does not belong to the user space of the current task
+    /// or the `vaddr` and `len` do not represent a user space memory range.
+    ///
+    /// Users must ensure that no other page table is activated in the current task during the
+    /// lifetime of the created `VmReader` and `VmWriter`. This guarantees that the `VmReader`
+    /// and the `VmWriter` can operate correctly.
+    ///
+    /// This method is semantically equivalent to calling [`Self::reader`] and [`Self::writer`]
+    /// separately, but it avoids double checking the validity of the memory region.
+    pub fn reader_writer(
+        &self,
+        vaddr: Vaddr,
+        len: usize,
+    ) -> Result<(VmReader<'_, Fallible>, VmWriter<'_, Fallible>)> {
+        if current_page_table_paddr() != self.pt.root_paddr() {
+            return Err(Error::AccessDenied);
+        }
+
+        if vaddr.checked_add(len).unwrap_or(usize::MAX) > MAX_USERSPACE_VADDR {
+            return Err(Error::AccessDenied);
+        }
+
+        // SAFETY: The memory range is in user space, as checked above.
+        let reader = unsafe { VmReader::<Fallible>::from_user_space(vaddr as *const u8, len) };
+
+        // `VmWriter` is neither `Sync` nor `Send`, so it will not live longer than the current
+        // task. This ensures that the correct page table is activated during the usage period of
+        // the `VmWriter`.
+        //
+        // SAFETY: The memory range is in user space, as checked above.
+        let writer = unsafe { VmWriter::<Fallible>::from_user_space(vaddr as *mut u8, len) };
+
+        Ok((reader, writer))
     }
 }
 


### PR DESCRIPTION
This PR addresses a point raised in https://github.com/asterinas/asterinas/pull/2343#discussion_r2284280895.

This patch guarantees that all consumers of `CurrentUserSpace::reader` and `CurrentUserSpace::writer` won't access memory regions that go below the lowest user space address allowed.

It also creates `VmSpace::reader_writer` and `CurrentUserSpace::reader_writer` for ergonimically returning a reader/writer pair guaranteed to access the same memory region while avoiding double checking the validity of such addresses.