### PR TITLE
Add cputime module and adds support for the `/proc/stat` and `/proc/uptime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
 name = "aster-softirq"
 version = "0.1.0"
 dependencies = [
+ "aster-util",
  "component",
  "intrusive-collections",
  "ostd",
@@ -325,6 +326,7 @@ dependencies = [
  "aster-rights",
  "aster-rights-proc",
  "inherit-methods-macro",
+ "osdk-heap-allocator",
  "ostd",
  "typeflags-util",
 ]

--- a/kernel/comps/softirq/Cargo.toml
+++ b/kernel/comps/softirq/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aster-util = { path = "../../libs/aster-util" }
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
 intrusive-collections = "0.9.5"

--- a/kernel/comps/softirq/src/stats.rs
+++ b/kernel/comps/softirq/src/stats.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::vec::Vec;
+
+use aster_util::per_cpu_counter::PerCpuCounter;
+use ostd::cpu::CpuId;
+use spin::Once;
+
+use super::SoftIrqLine;
+
+/// The maximum number of IRQ lines we track (256 should have covered most common hardware).
+pub(super) const NR_IRQ_LINES: usize = 256;
+
+/// Global interrupt counter.
+pub(super) static IRQ_COUNTERS: Once<[PerCpuCounter; NR_IRQ_LINES]> = Once::new();
+
+/// Iterates all IRQ lines for the number of executions across all CPUs.  
+pub fn iter_irq_counts_across_all_cpus() -> impl Iterator<Item = usize> {
+    let irq_counters = IRQ_COUNTERS.get().unwrap();
+    irq_counters.iter().map(|counter| counter.sum_all_cpus())
+}
+
+pub(super) fn process_statistic(irq_num: usize) {
+    if irq_num < NR_IRQ_LINES {
+        IRQ_COUNTERS.get().unwrap()[irq_num].add_on_cpu(CpuId::current_racy(), 1);
+    }
+}
+
+/// Iterates all softirq lines for the number of executions across all CPUs.
+pub fn iter_softirq_counts_across_all_cpus() -> impl Iterator<Item = usize> {
+    let softirq_counters: Vec<usize> = (0..SoftIrqLine::NR_LINES)
+        .map(|i| {
+            let soft_irq_line = SoftIrqLine::get(i);
+            if soft_irq_line.is_enabled() {
+                soft_irq_line.counter.get().unwrap().sum_all_cpus()
+            } else {
+                0
+            }
+        })
+        .collect::<Vec<usize>>();
+    softirq_counters.into_iter()
+}
+
+/// Iterates the softirq counters for a specific CPU.
+pub fn iter_softirq_counts_on_cpu(cpuid: CpuId) -> impl Iterator<Item = usize> {
+    let softirq_counters = (0..SoftIrqLine::NR_LINES)
+        .map(|i| {
+            let soft_irq_line = SoftIrqLine::get(i);
+            if soft_irq_line.is_enabled() {
+                soft_irq_line.counter.get().unwrap().get_on_cpu(cpuid)
+            } else {
+                0
+            }
+        })
+        .collect::<Vec<usize>>();
+    softirq_counters.into_iter()
+}

--- a/kernel/libs/aster-util/Cargo.toml
+++ b/kernel/libs/aster-util/Cargo.toml
@@ -11,6 +11,7 @@ typeflags-util = { path = "../typeflags-util" }
 aster-rights-proc = { path = "../aster-rights-proc" }
 aster-rights = { path = "../aster-rights" }
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e" }
+osdk-heap-allocator = { path = "../../../osdk/deps/heap-allocator" }
 
 [lints]
 workspace = true

--- a/kernel/libs/aster-util/src/lib.rs
+++ b/kernel/libs/aster-util/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 pub mod coeff;
 pub mod dup;
 pub mod mem_obj_slice;
+pub mod per_cpu_counter;
 pub mod printer;
 pub mod safe_ptr;
 pub mod slot_vec;

--- a/kernel/src/fs/procfs/stat.rs
+++ b/kernel/src/fs/procfs/stat.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module offers `/proc/stat` file support, which provides
+//! information about kernel system statistics.
+//!
+//! Reference: <https://man7.org/linux/man-pages/man5/proc_stat.5.html>
+
+use core::fmt::Write;
+
+use aster_softirq::{
+    iter_irq_counts_across_all_cpus, iter_softirq_counts_across_all_cpus, softirq_id::*,
+};
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{Inode, InodeMode},
+    },
+    prelude::*,
+    process::count_total_forks,
+    sched::nr_queued_and_running,
+    thread::collect_context_switch_count,
+    time::{cpu_time_stats::CpuTimeStatsManager, SystemTime, START_TIME},
+};
+
+/// Represents the inode at `/proc/stat`.  
+pub struct StatFileOps;
+
+impl StatFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn collect_stats() -> String {
+        let mut stat_output = String::new();
+        let stats_manager = CpuTimeStatsManager::singleton();
+
+        // Global CPU statistics:
+        // cpu <user> <nice> <system> <idle> <iowait> <irq> <softirq> <steal> <guest> <guest_nice>
+        let global_stats = stats_manager.collect_stats_on_all_cpus();
+        writeln!(
+            stat_output,
+            "cpu {} {} {} {} {} {} {} {} {} {}",
+            global_stats.user.as_u64(),
+            global_stats.nice.as_u64(),
+            global_stats.system.as_u64(),
+            global_stats.idle.as_u64(),
+            global_stats.iowait.as_u64(),
+            global_stats.irq.as_u64(),
+            global_stats.softirq.as_u64(),
+            global_stats.steal.as_u64(),
+            global_stats.guest.as_u64(),
+            global_stats.guest_nice.as_u64()
+        )
+        .unwrap();
+
+        // Per-CPU lines
+        for cpu_id in ostd::cpu::all_cpus() {
+            let cpu_stats = stats_manager.collect_stats_on_cpu(cpu_id);
+            writeln!(
+                stat_output,
+                "cpu{} {} {} {} {} {} {} {} {} {} {}",
+                cpu_id.as_usize(),
+                cpu_stats.user.as_u64(),
+                cpu_stats.nice.as_u64(),
+                cpu_stats.system.as_u64(),
+                cpu_stats.idle.as_u64(),
+                cpu_stats.iowait.as_u64(),
+                cpu_stats.irq.as_u64(),
+                cpu_stats.softirq.as_u64(),
+                cpu_stats.steal.as_u64(),
+                cpu_stats.guest.as_u64(),
+                cpu_stats.guest_nice.as_u64()
+            )
+            .unwrap();
+        }
+
+        // IRQ statistics: the total count followed by per-IRQ counts
+        let irq_stats = iter_irq_counts_across_all_cpus();
+        let mut total_irqs = 0usize;
+        let mut irq_counts = Vec::new();
+        for count in irq_stats {
+            total_irqs += count;
+            irq_counts.push(count);
+        }
+        write!(stat_output, "intr {}", total_irqs).unwrap();
+        for count in irq_counts {
+            write!(stat_output, " {}", count).unwrap();
+        }
+
+        writeln!(stat_output).unwrap();
+
+        // Context switch count
+        let context_switches: usize = collect_context_switch_count();
+        writeln!(stat_output, "ctxt {}", context_switches).unwrap();
+
+        // Boot time (seconds since UNIX epoch)
+        if let Some(start_time) = START_TIME.get() {
+            let boot_time = start_time
+                .duration_since(&SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            writeln!(stat_output, "btime {}", boot_time).unwrap();
+        } else {
+            writeln!(stat_output, "btime {}", 0).unwrap();
+        }
+
+        // Process count (number of forks since boot)
+        writeln!(stat_output, "processes {}", count_total_forks()).unwrap();
+
+        // Running and blocked processes
+        let (_, running_count) = nr_queued_and_running();
+        writeln!(stat_output, "procs_running {}", running_count).unwrap();
+
+        // TODO: Blocked processes
+        writeln!(stat_output, "procs_blocked {}", 0).unwrap();
+
+        // Softirq statistics
+        let softirq_stats = iter_softirq_counts_across_all_cpus();
+        let softirq_stats: Vec<usize> = softirq_stats.collect();
+        let total_softirqs: usize = softirq_stats.iter().sum();
+
+        // We only have 5 defined softirq types; the rest are reserved.
+        // Fill in zeros for the reserved types to match the expected output format.
+        writeln!(
+            stat_output,
+            "softirq {} {} {} {} {} {} {} {} {} {} {}",
+            total_softirqs,
+            softirq_stats[TASKLESS_URGENT_SOFTIRQ_ID as usize], // TASKLESS_URGENT
+            softirq_stats[TIMER_SOFTIRQ_ID as usize],           // TIMER
+            softirq_stats[TASKLESS_SOFTIRQ_ID as usize],        // TASKLESS
+            softirq_stats[NETWORK_TX_SOFTIRQ_ID as usize],      // NETWORK_TX
+            softirq_stats[NETWORK_RX_SOFTIRQ_ID as usize],      // NETWORK_RX
+            0usize,                                             // Reserved
+            0usize,                                             // Reserved
+            0usize,                                             // Reserved
+            0usize,                                             // Reserved
+            0usize,                                             // Reserved
+        )
+        .unwrap();
+        stat_output
+    }
+}
+
+impl FileOps for StatFileOps {
+    /// Retrieve the data for `/proc/stat`.
+    fn data(&self) -> Result<Vec<u8>> {
+        // Implementation to gather and format the statistics
+        let output = Self::collect_stats();
+        Ok(output.into_bytes())
+    }
+}

--- a/kernel/src/fs/procfs/uptime.rs
+++ b/kernel/src/fs/procfs/uptime.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module offers `/proc/uptime` file support, which provides
+//! information about the system uptime and idle time.
+//!
+//! Reference: <https://man7.org/linux/man-pages/man5/proc_uptime.5.html>
+
+use alloc::format;
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{Inode, InodeMode},
+    },
+    prelude::*,
+    time::cpu_time_stats::CpuTimeStatsManager,
+};
+
+/// Represents the inode at `/proc/uptime`.  
+pub struct UptimeFileOps;
+
+impl UptimeFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    pub fn collect_uptime() -> String {
+        let uptime = aster_time::read_monotonic_time().as_secs_f32();
+        let cpustat = CpuTimeStatsManager::singleton();
+        let idle_time = cpustat
+            .collect_stats_on_all_cpus()
+            .idle
+            .as_duration()
+            .as_secs_f32();
+        format!("{:.2} {:.2}\n", uptime, idle_time)
+    }
+}
+
+impl FileOps for UptimeFileOps {
+    /// Retrieve the data for `/proc/uptime`.
+    fn data(&self) -> Result<Vec<u8>> {
+        let output = Self::collect_uptime();
+        Ok(output.into_bytes())
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -113,6 +113,7 @@ fn init_on_each_cpu() {
     sched::init_on_each_cpu();
     process::init_on_each_cpu();
     fs::init_on_each_cpu();
+    time::init_on_each_cpu();
 }
 
 fn init_in_first_kthread(fs_resolver: &FsResolver) {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -15,12 +15,12 @@ mod process_vm;
 mod program_loader;
 pub mod rlimit;
 pub mod signal;
+mod stats;
 mod status;
 pub mod sync;
 mod task_set;
 mod term_status;
 mod wait;
-
 pub use clone::{clone_child, CloneArgs, CloneFlags};
 pub use credentials::{Credentials, Gid, Uid};
 pub use kill::{kill, kill_all, kill_group, tgkill};
@@ -38,6 +38,7 @@ pub use process_filter::ProcessFilter;
 pub use process_vm::{renew_vm_and_map, MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS};
 pub use program_loader::{check_executable_file, ProgramToLoad};
 pub use rlimit::ResourceType;
+pub use stats::count_total_forks;
 pub use term_status::TermStatus;
 pub use wait::{do_wait, WaitOptions, WaitStatus};
 
@@ -45,6 +46,7 @@ use crate::context::Context;
 
 pub(super) fn init() {
     posix_thread::futex::init();
+    clone::init();
 }
 
 pub(super) fn init_on_each_cpu() {

--- a/kernel/src/process/stats.rs
+++ b/kernel/src/process/stats.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::per_cpu_counter::PerCpuCounter;
+use spin::Once;
+
+/// The total number of fork, vfork and clone.
+pub(super) static FORKS_COUNTER: Once<PerCpuCounter> = Once::new();
+
+/// Returns the total number of fork, vfork and clone.
+pub fn count_total_forks() -> usize {
+    FORKS_COUNTER.get().unwrap().sum_all_cpus()
+}

--- a/kernel/src/thread/stats.rs
+++ b/kernel/src/thread/stats.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::per_cpu_counter::PerCpuCounter;
+use spin::Once;
+
+pub(super) static CONTEXT_SWITCH_COUNTER: Once<PerCpuCounter> = Once::new();
+
+/// Counts the number of context switches ever happened across all CPUs.
+pub fn collect_context_switch_count() -> usize {
+    CONTEXT_SWITCH_COUNTER.get().unwrap().sum_all_cpus()
+}

--- a/kernel/src/time/cpu_time_stats.rs
+++ b/kernel/src/time/cpu_time_stats.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+use aster_util::per_cpu_counter::PerCpuCounter;
+use ostd::{cpu::CpuId, timer::Jiffies};
+use spin::Once;
+
+use crate::{sched::SchedPolicy, thread::Thread};
+
+/// Represents CPU usage statistics for a system.
+///
+/// This structure contains various counters that track different types of CPU time.
+/// All values are measured in jiffies (clock ticks).
+///
+/// TODO: Implement proper accounting for CPU time
+#[derive(Debug, Clone, Copy)]
+pub struct CpuTimeStats {
+    /// Time spent in user mode.
+    pub user: Jiffies,
+    /// Time spent in user mode with low priority (nice).
+    pub nice: Jiffies,
+    /// Time spent in system/kernel mode.
+    pub system: Jiffies,
+    /// Time spent in the idle task.
+    pub idle: Jiffies,
+    /// Time spent waiting for I/O to complete.
+    /// TODO: track this statistic.
+    pub iowait: Jiffies,
+    /// Time spent servicing hardware interrupts.
+    pub irq: Jiffies,
+    /// Time spent servicing software interrupts.
+    pub softirq: Jiffies,
+    /// Time stolen by other operating systems running in a virtualized environment.
+    /// TODO: track this statistic.
+    pub steal: Jiffies,
+    /// Time spent running a virtual CPU for guest operating systems.
+    /// TODO: track this statistic.
+    pub guest: Jiffies,
+    /// Time spent running a low priority virtual CPU for guest operating systems.
+    /// TODO: track this statistic.
+    pub guest_nice: Jiffies,
+}
+
+pub struct CpuTimeStatsManager {
+    user: PerCpuCounter,
+    nice: PerCpuCounter,
+    system: PerCpuCounter,
+    idle: PerCpuCounter,
+    iowait: PerCpuCounter,
+    irq: PerCpuCounter,
+    softirq: PerCpuCounter,
+    steal: PerCpuCounter,
+    guest: PerCpuCounter,
+    guest_nice: PerCpuCounter,
+}
+
+static SINGLETON: Once<CpuTimeStatsManager> = Once::new();
+
+impl CpuTimeStatsManager {
+    /// Returns a reference to the singleton instance of `CpuTimeStatsManager`.
+    pub fn singleton() -> &'static CpuTimeStatsManager {
+        // It's fine to `unwrap` because `SINGLETON` must have been initialized in `init`.
+        SINGLETON.get().unwrap()
+    }
+
+    /// Collects the time statistics on the specific CPU.  
+    pub fn collect_stats_on_cpu(&self, cpu: CpuId) -> CpuTimeStats {
+        CpuTimeStats {
+            user: Jiffies::new(self.user.get_on_cpu(cpu) as u64),
+            nice: Jiffies::new(self.nice.get_on_cpu(cpu) as u64),
+            system: Jiffies::new(self.system.get_on_cpu(cpu) as u64),
+            idle: Jiffies::new(self.idle.get_on_cpu(cpu) as u64),
+            iowait: Jiffies::new(self.iowait.get_on_cpu(cpu) as u64),
+            irq: Jiffies::new(self.irq.get_on_cpu(cpu) as u64),
+            softirq: Jiffies::new(self.softirq.get_on_cpu(cpu) as u64),
+            steal: Jiffies::new(self.steal.get_on_cpu(cpu) as u64),
+            guest: Jiffies::new(self.guest.get_on_cpu(cpu) as u64),
+            guest_nice: Jiffies::new(self.guest_nice.get_on_cpu(cpu) as u64),
+        }
+    }
+
+    /// Collects the time statistics across all CPUs.
+    pub fn collect_stats_on_all_cpus(&self) -> CpuTimeStats {
+        CpuTimeStats {
+            user: Jiffies::new(self.user.sum_all_cpus() as u64),
+            nice: Jiffies::new(self.nice.sum_all_cpus() as u64),
+            system: Jiffies::new(self.system.sum_all_cpus() as u64),
+            idle: Jiffies::new(self.idle.sum_all_cpus() as u64),
+            iowait: Jiffies::new(self.iowait.sum_all_cpus() as u64),
+            irq: Jiffies::new(self.irq.sum_all_cpus() as u64),
+            softirq: Jiffies::new(self.softirq.sum_all_cpus() as u64),
+            steal: Jiffies::new(self.steal.sum_all_cpus() as u64),
+            guest: Jiffies::new(self.guest.sum_all_cpus() as u64),
+            guest_nice: Jiffies::new(self.guest_nice.sum_all_cpus() as u64),
+        }
+    }
+
+    fn inc_user_time(&self, cpu: CpuId) {
+        self.user.add_on_cpu(cpu, 1);
+    }
+
+    fn inc_system_time(&self, cpu: CpuId) {
+        self.system.add_on_cpu(cpu, 1);
+    }
+
+    fn inc_idle_time(&self, cpu: CpuId) {
+        self.idle.add_on_cpu(cpu, 1);
+    }
+
+    fn new() -> Self {
+        Self {
+            user: PerCpuCounter::new(),
+            nice: PerCpuCounter::new(),
+            system: PerCpuCounter::new(),
+            idle: PerCpuCounter::new(),
+            iowait: PerCpuCounter::new(),
+            irq: PerCpuCounter::new(),
+            softirq: PerCpuCounter::new(),
+            steal: PerCpuCounter::new(),
+            guest: PerCpuCounter::new(),
+            guest_nice: PerCpuCounter::new(),
+        }
+    }
+}
+
+fn update_cpu_statistics() {
+    let manager = CpuTimeStatsManager::singleton();
+    // No races because we are in IRQs.
+    let cpu_id = CpuId::current_racy();
+
+    // Idle time is not counted towards CPU usage.
+
+    // Non-idle time is counted as system time or user time.
+    let interrupt_level = ostd::irq::InterruptLevel::current();
+
+    match interrupt_level {
+        // In Level 1 interrupt context, check the privilege level of interrupted code
+        ostd::irq::InterruptLevel::L1(cpu_priv_at_irq) => match cpu_priv_at_irq {
+            ostd::cpu::PrivilegeLevel::Kernel => {
+                if is_idle() {
+                    manager.inc_idle_time(cpu_id);
+                    return;
+                }
+                manager.inc_system_time(cpu_id);
+            }
+            ostd::cpu::PrivilegeLevel::User => manager.inc_user_time(cpu_id),
+        },
+        // In Level 2 interrupt context (nested interrupt), always count as system time
+        ostd::irq::InterruptLevel::L2 => {
+            manager.inc_system_time(cpu_id);
+        }
+        // In task context, this shouldn't happen in timer interrupt handler
+        ostd::irq::InterruptLevel::L0 => {
+            unreachable!();
+        }
+    }
+}
+
+fn is_idle() -> bool {
+    if let Some(current_thread) = Thread::current() {
+        current_thread.sched_attr().policy() == SchedPolicy::Idle
+    } else {
+        false
+    }
+}
+
+pub fn init() {
+    SINGLETON.call_once(CpuTimeStatsManager::new);
+}
+
+pub fn init_on_each_cpu() {
+    ostd::timer::register_callback_on_cpu(update_cpu_statistics);
+}

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -5,15 +5,14 @@
 pub use core::{timer, Clock};
 
 use ::core::time::Duration;
-pub use system_time::SystemTime;
-#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))] // Now used for vDSO support only.
-pub use system_time::START_TIME;
+pub use system_time::{SystemTime, START_TIME};
 pub use timer::{Timer, TimerManager};
 
 use crate::prelude::*;
 
 pub mod clocks;
 mod core;
+pub mod cpu_time_stats;
 mod softirq;
 mod system_time;
 pub mod timerfd;
@@ -31,6 +30,11 @@ pub(super) fn init() {
     system_time::init();
     clocks::init();
     softirq::init();
+    cpu_time_stats::init();
+}
+
+pub(super) fn init_on_each_cpu() {
+    cpu_time_stats::init_on_each_cpu();
 }
 
 #[repr(C)]

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -3,7 +3,6 @@
 mod iovec;
 pub mod net;
 mod padded;
-pub mod per_cpu_counter;
 pub mod random;
 mod read_cstring;
 pub mod ring_buffer;

--- a/ostd/src/irq/mod.rs
+++ b/ostd/src/irq/mod.rs
@@ -91,7 +91,7 @@ pub(crate) fn call_irq_callback_functions(
     level::enter(
         move || {
             top_half::process(trap_frame, irq_num);
-            bottom_half::process();
+            bottom_half::process(irq_num);
         },
         cpu_priv_at_irq,
     );

--- a/test/src/syscall/gvisor/blocklists/proc_test
+++ b/test/src/syscall/gvisor/blocklists/proc_test
@@ -16,11 +16,7 @@ ProcSelfFdInfo.Flags
 ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteRoot
 ProcCpuinfo.DeniesWriteNonRoot
-ProcUptime.IsPresent
 ProcMeminfo.ContainsBasicFields
-ProcStat.ContainsBasicFields
-ProcStat.EndsWithNewline
-ProcStat.Fields
 ProcSelfStat.PopulateWriteRSS
 ProcSelfStat.PopulateNoneRSS
 ProcPidStatusTest.HasBasicFields


### PR DESCRIPTION
This pull request adds support for the `/proc/stat` and `/proc/uptime` files in the kernel's procfs, enabling reporting of system statistics and uptime information. It introduces new modules and file operations for these files, and implements a new CPU statistics tracking system to provide accurate data for these interfaces.

**New /proc/stat and /proc/uptime support:**

- Added `/proc/stat` and `/proc/uptime` file support to procfs, including their file operation handlers (`StatFileOps` and `UptimeFileOps`). These files now appear in the procfs root and provide system statistics and uptime/idle time, respectively. [[1]](diffhunk://#diff-ef4c7ad7803b981b000b99038edcee86cd4252c92cc34f15f0783bf09cd05865R14-R19) [[2]](diffhunk://#diff-ef4c7ad7803b981b000b99038edcee86cd4252c92cc34f15f0783bf09cd05865R36-R40) [[3]](diffhunk://#diff-ef4c7ad7803b981b000b99038edcee86cd4252c92cc34f15f0783bf09cd05865R156-R159) [[4]](diffhunk://#diff-ef4c7ad7803b981b000b99038edcee86cd4252c92cc34f15f0783bf09cd05865R190-R192) [[5]](diffhunk://#diff-e792bc66f192d0779385b975927c78b8a2268eb4f233e176594180393646e48eR1-R121) [[6]](diffhunk://#diff-a1f51b2933473a53488135d5af6fdbc457b456ebab185fa3073667242c612342R1-R38)

**CPU statistics infrastructure:**

- Implemented a new `cputime` module that tracks per-CPU and global CPU statistics (user, system, idle, etc.) and exposes this data via the new `/proc/stat` file. This includes periodic updates via a timer callback and integration into the kernel initialization sequence. [[1]](diffhunk://#diff-e0e9195d8a072f0d47ee55970de1a2a5f5b9c9bcf76209a166d2780962e44e70R1-R154) [[2]](diffhunk://#diff-e0ca88883fceb2d8ec9fa94a29a3ac27dc8d07102d023960004ea646f222748fR17) [[3]](diffhunk://#diff-e0ca88883fceb2d8ec9fa94a29a3ac27dc8d07102d023960004ea646f222748fR34)