### PR TITLE
Add `/proc/[pid]/environ` 、`/proc/[pid]/task/[tid]/environ` 

### DIFF
--- a/kernel/src/fs/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/procfs/pid/task/environ.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::Inode,
+    },
+    prelude::*,
+    Process,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/environ` (and also `/proc/[pid]/environ`).
+pub struct EnvironFileOps(Arc<Process>);
+
+impl EnvironFileOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self(process_ref))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for EnvironFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let envp_output = if self.0.status().is_zombie() {
+            // Returns 0 characters for zombie process.
+            Vec::new()
+        } else {
+            let Ok(envp_cstrs) = self.0.init_stack_reader().envp() else {
+                return Ok(Vec::new());
+            };
+            envp_cstrs
+                .into_iter()
+                .flat_map(|cstr| cstr.into_bytes_with_nul().into_iter())
+                .collect()
+        };
+        Ok(envp_output)
+    }
+}

--- a/kernel/src/fs/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/procfs/pid/task/mod.rs
@@ -11,8 +11,8 @@ use crate::{
             pid::{
                 stat::StatFileOps,
                 task::{
-                    cmdline::CmdlineFileOps, comm::CommFileOps, exe::ExeSymOps, fd::FdDirOps,
-                    status::StatusFileOps,
+                    cmdline::CmdlineFileOps, comm::CommFileOps, environ::EnvironFileOps,
+                    exe::ExeSymOps, fd::FdDirOps, status::StatusFileOps,
                 },
             },
             template::{DirOps, ProcDir, ProcDirBuilder},
@@ -26,6 +26,7 @@ use crate::{
 
 mod cmdline;
 mod comm;
+mod environ;
 mod exe;
 mod fd;
 mod status;
@@ -70,6 +71,7 @@ impl DirOps for TidDirOps {
         let inode = match name {
             "cmdline" => CmdlineFileOps::new_inode(self.process_ref.clone(), this_ptr),
             "comm" => CommFileOps::new_inode(self.process_ref.clone(), this_ptr),
+            "environ" => EnvironFileOps::new_inode(self.process_ref.clone(), this_ptr),
             "exe" => ExeSymOps::new_inode(self.process_ref.clone(), this_ptr),
             "fd" => FdDirOps::new_inode(self.thread_ref.clone(), this_ptr),
             "stat" => StatFileOps::new_inode(
@@ -109,6 +111,9 @@ impl TidDirOps {
         });
         cached_children.put_entry_if_not_found("comm", || {
             CommFileOps::new_inode(self.process_ref.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("environ", || {
+            EnvironFileOps::new_inode(self.process_ref.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("exe", || {
             ExeSymOps::new_inode(self.process_ref.clone(), this_ptr.clone())


### PR DESCRIPTION
This pull request adds support for the `/proc/[pid]/environ` and `/proc/[pid]/task/[tid]environ` file in the procfs filesystem and introduces the necessary file operations for reading environment variables , allowing users to access the environment variables of a process in a Linux-like manner. This PR also fix the missing of `/proc/[pid]/task/[tid]/cmdline`

**Process environment variable retrieval:**

* Added a new `envp` method to the `Process` struct to retrieve the process's environment variables.