### PR TITLE
Add dummy implementation of renameat2 system call

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -336,6 +336,7 @@ provided by Linux on x86-64 architecture.
 | 313     | finit_module           | ❌             |     |
 | 314     | sched_setattr          | ✅             | [⚠️](limitations-on-system-calls/process-and-thread-management.md#sched_getattr-and-sched_setattr) |
 | 315     | sched_getattr          | ✅             | [⚠️](limitations-on-system-calls/process-and-thread-management.md#sched_getattr-and-sched_setattr) |
+| 316     | renameat2              | ✅             | [⚠️](limitations-on-system-calls/file-and-directory-operations.md#renameat2) |
 | 318     | getrandom              | ✅             | [⚠️](limitations-on-system-calls/system-information-and-misc.md#getrandom) |
 | 319     | memfd_create           | ✅             |     |
 | 322     | execveat               | ✅             |     |

--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-and-directory-operations.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-and-directory-operations.md
@@ -80,3 +80,20 @@ The SCML rules are omitted for brevity.
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/openat.2.html).
+
+## `renameat2`
+
+Supported functionality in SCML:
+
+```c
+// Rename a file, moving it between directories if required.
+renameat2(olddirfd, oldpath, newdirfd, newpath, 0);
+```
+
+Unsupported flags:
+* `RENAME_EXCHANGE`
+* `RENAME_NOREPLACE`
+* `RENAME_WHITEOUT`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/rename.2.html).

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -87,6 +87,7 @@ use super::{
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
+    rename::sys_renameat2,
     rt_sigaction::sys_rt_sigaction,
     rt_sigpending::sys_rt_sigpending,
     rt_sigprocmask::sys_rt_sigprocmask,
@@ -330,6 +331,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
+    SYS_RENAMEAT2 = 276              => sys_renameat2(args[..5]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -87,6 +87,7 @@ use super::{
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
+    rename::sys_renameat2,
     rt_sigaction::sys_rt_sigaction,
     rt_sigpending::sys_rt_sigpending,
     rt_sigprocmask::sys_rt_sigprocmask,
@@ -332,6 +333,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
+    SYS_RENAMEAT2 = 276              => sys_renameat2(args[..5]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -96,7 +96,7 @@ use super::{
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
-    rename::{sys_rename, sys_renameat},
+    rename::{sys_rename, sys_renameat, sys_renameat2},
     rmdir::sys_rmdir,
     rt_sigaction::sys_rt_sigaction,
     rt_sigpending::sys_rt_sigpending,
@@ -381,6 +381,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);
     SYS_SCHED_SETATTR = 314    => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 315    => sys_sched_getattr(args[..4]);
+    SYS_RENAMEAT2 = 316        => sys_renameat2(args[..5]);
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 319     => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut user_ctx);

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -11,11 +11,12 @@ use crate::{
     syscall::constants::MAX_FILENAME_LEN,
 };
 
-pub fn sys_renameat(
+pub fn sys_renameat2(
     old_dirfd: FileDesc,
     old_path_addr: Vaddr,
     new_dirfd: FileDesc,
     new_path_addr: Vaddr,
+    flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let user_space = ctx.user_space();
@@ -25,6 +26,14 @@ pub fn sys_renameat(
         "old_dirfd = {}, old_path = {:?}, new_dirfd = {}, new_path = {:?}",
         old_dirfd, old_path_name, new_dirfd, new_path_name
     );
+    let Some(flags) = Flags::from_bits(flags) else {
+        return_errno_with_message!(Errno::EINVAL, "invalid flags");
+    };
+    // TODO: Add support for handling the `NOREPLACE`, `EXCHANGE`, and `WHITEOUT` flags.
+    if !flags.is_empty() {
+        warn!("unsupported flags: {:?}", flags);
+        return_errno_with_message!(Errno::EINVAL, "unsupported flags");
+    }
 
     let fs_ref = ctx.thread_local.borrow_fs();
     let fs = fs_ref.resolver().read();
@@ -70,10 +79,31 @@ pub fn sys_renameat(
     Ok(SyscallReturn::Return(0))
 }
 
+pub fn sys_renameat(
+    old_dirfd: FileDesc,
+    old_path_addr: Vaddr,
+    new_dirfd: FileDesc,
+    new_path_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    self::sys_renameat2(old_dirfd, old_path_addr, new_dirfd, new_path_addr, 0, ctx)
+}
+
 pub fn sys_rename(
     old_path_addr: Vaddr,
     new_path_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    self::sys_renameat(AT_FDCWD, old_path_addr, AT_FDCWD, new_path_addr, ctx)
+    self::sys_renameat2(AT_FDCWD, old_path_addr, AT_FDCWD, new_path_addr, 0, ctx)
+}
+
+bitflags! {
+    /// Flags used in the `renameat2` system call.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.16.3/source/include/uapi/linux/fcntl.h#L140-L143>.
+    struct Flags: u32 {
+        const NOREPLACE = 1 << 0;
+        const EXCHANGE  = 1 << 1;
+        const WHITEOUT  = 1 << 2;
+    }
 }


### PR DESCRIPTION
This PR adds a dummy implementation of the `renameat2` syscall. It's needed on newer architectures (like riscv64/loongarch64) since they don't have legacy `rename` and `renameat`.

Below is from the [man page](https://man7.org/linux/man-pages/man2/rename.2.html),

> renameat2() has an additional flags argument.  A renameat2() call with a zero flags argument is equivalent to renameat().

The implementation here now rejects all non-zero flags and immediately panics.