### PR TITLE
Use vDSO for fallback of user-provided sa_restorer on RISC-V platforms

### DIFF
--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -58,6 +58,8 @@ pub fn load_elf_to_vm(
             // the vDSO is mapped after the ELF file, heap, and stack.
             #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
             if let Some(vdso_text_base) = map_vdso_to_vm(process_vm) {
+                #[cfg(target_arch = "riscv64")]
+                process_vm.set_vdso_base(vdso_text_base);
                 aux_vec
                     .set(AuxKey::AT_SYSINFO_EHDR, vdso_text_base as u64)
                     .unwrap();

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -295,6 +295,9 @@ pub fn handle_user_signal(
             "After writing restorer addr: user_rsp = 0x{:x}",
             stack_pointer
         );
+    } else {
+        #[cfg(target_arch = "riscv64")]
+        user_ctx.set_ra(ctx.process.vm().vdso_base() + crate::vdso::__VDSO_RT_SIGRETURN_OFFSET);
     }
 
     // 4. Set correct register values

--- a/kernel/src/process/signal/sig_disposition.rs
+++ b/kernel/src/process/signal/sig_disposition.rs
@@ -79,11 +79,15 @@ fn check_sigaction(sig_action: &SigAction) -> Result<()> {
             // On x86-64, `SA_RESTORER` is mandatory and cannot be omitted.
             // Ref: <https://elixir.bootlin.com/linux/v6.13/source/arch/x86/kernel/signal_64.c#L172>
             return_errno_with_message!(Errno::EINVAL, "x86-64 should always use SA_RESTORER");
+        } else if #[cfg(target_arch = "riscv64")] {
+            // On RISC-V, if `SA_RESTORER` is not specified, `__vdso_rt_sigreturn` will be used as a fallback.
+            Ok(())
         } else {
             // FIXME: The support for user-provided signal handlers
             // without `SA_RESTORER` is arch-dependent.
             // Other archs may need to handle scenarios where `SA_RESTORER` is omitted.
-            return_errno_with_message!(Errno::EINVAL, "TODO: properly deal with SA_RESTORER");
+            warn!("SA_RESTORER fallback mechanism not implemented for this architecture");
+            return_errno_with_message!(Errno::EINVAL, "this architecture currently requires SA_RESTORER");
         }
     }
 }

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -224,6 +224,13 @@ const PREBUILT_VDSO_LIB: &[u8] =
 const PREBUILT_VDSO_LIB: &[u8] =
     include_bytes!(concat!(env!("VDSO_LIBRARY_DIR"), "/vdso_riscv64.so"));
 
+/// The offset from the vDSO base to the `__vdso_rt_sigreturn` function.
+///
+/// This constant is specific to the prebuilt vDSO library and can be obtained from
+/// `readelf -s vdso_riscv64.so | grep '__vdso_rt_sigreturn'`.
+#[cfg(target_arch = "riscv64")]
+pub(crate) const __VDSO_RT_SIGRETURN_OFFSET: usize = 0x5b0;
+
 impl Vdso {
     /// Constructs a new `Vdso`, including an initialized `VdsoData` and a VMO of the vDSO.
     fn new() -> Self {


### PR DESCRIPTION
x86 Linux typically ask s`rt_sigaction`'s callers to provide `sa_restorer` that helps invoking `rt_sigreturn` after processing the signal handler. However, RISC-V Linux provides the fallback stub in its vDSO code, `__vdso_rt_sigreturn`, and the kernel can set the return address to this symbol before entering signal handler if there isn't any valid user-provided `sa_restorer`.
https://elixir.bootlin.com/linux/v6.16.3/source/arch/riscv/kernel/signal.c#L338-L341

This PR implements the idea described above.