### PR TITLE
Introduce the mount namespace

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -328,7 +328,7 @@ provided by Linux on x86-64 architecture.
 | 305     | clock_adjtime          | ❌             |     |
 | 306     | syncfs                 | ❌             |     |
 | 307     | sendmmsg               | ❌             |     |
-| 308     | setns                  | ❌             |     |
+| 308     | setns                  | ✅             |     |
 | 309     | getcpu                 | ✅             |     |
 | 310     | process_vm_readv       | ❌             |     |
 | 311     | process_vm_writev      | ❌             |     |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -292,7 +292,7 @@ provided by Linux on x86-64 architecture.
 | 269     | faccessat              | ✅             |     |
 | 270     | pselect6               | ✅             |     |
 | 271     | ppoll                  | ✅             |     |
-| 272     | unshare                | ❌             |     |
+| 272     | unshare                | ✅             |     |
 | 273     | set_robust_list        | ✅             |     |
 | 274     | get_robust_list        | ❌             |     |
 | 275     | splice                 | ❌             |     |

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -18,7 +18,11 @@ pub use random::Random;
 pub use urandom::Urandom;
 
 use crate::{
-    fs::device::{add_node, Device, DeviceId, DeviceType},
+    fs::{
+        device::{add_node, Device, DeviceId, DeviceType},
+        fs_resolver::FsPath,
+        ramfs::RamFS,
+    },
     prelude::*,
 };
 
@@ -26,6 +30,10 @@ use crate::{
 pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     let fs = ctx.thread_local.borrow_fs();
     let fs_resolver = fs.resolver().read();
+
+    // Mount DevFS
+    let dev_path = fs_resolver.lookup(&FsPath::try_from("/dev")?)?;
+    dev_path.mount(RamFS::new(), ctx)?;
 
     let null = Arc::new(null::Null);
     add_node(null, "null", &fs_resolver)?;
@@ -56,9 +64,9 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     let urandom = Arc::new(urandom::Urandom);
     add_node(urandom, "urandom", &fs_resolver)?;
 
-    pty::init_in_first_process(&fs_resolver)?;
+    pty::init_in_first_process(&fs_resolver, ctx)?;
 
-    shm::init_in_first_process(&fs_resolver)?;
+    shm::init_in_first_process(&fs_resolver, ctx)?;
 
     Ok(())
 }

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -19,12 +19,12 @@ use spin::Once;
 
 static DEV_PTS: Once<Path> = Once::new();
 
-pub fn init_in_first_process(fs_resolver: &FsResolver) -> Result<()> {
+pub fn init_in_first_process(fs_resolver: &FsResolver, ctx: &Context) -> Result<()> {
     let dev = fs_resolver.lookup(&FsPath::try_from("/dev")?)?;
     // Create the "pts" directory and mount devpts on it.
     let devpts_path =
         dev.new_fs_child("pts", InodeType::Dir, InodeMode::from_bits_truncate(0o755))?;
-    let devpts_mount = devpts_path.mount(DevPts::new())?;
+    let devpts_mount = devpts_path.mount(DevPts::new(), ctx)?;
 
     DEV_PTS.call_once(|| Path::new_fs_root(devpts_mount));
 

--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 
 /// Initializes "/dev/shm" for POSIX shared memory usage.
-pub fn init_in_first_process(fs_resolver: &FsResolver) -> Result<()> {
+pub fn init_in_first_process(fs_resolver: &FsResolver, ctx: &Context) -> Result<()> {
     let dev_path = fs_resolver.lookup(&FsPath::try_from("/dev")?)?;
 
     // Create the "shm" directory under "/dev" and mount a ramfs on it.
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, InodeMode::from_bits_truncate(0o1777))?;
-    shm_path.mount(RamFS::new())?;
+    shm_path.mount(RamFS::new(), ctx)?;
     log::debug!("Mount RamFS at \"/dev/shm\"");
     Ok(())
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -65,8 +65,6 @@ pub fn init() {
     ext2::init();
     exfat::init();
     overlayfs::init();
-
-    rootfs::init();
 }
 
 pub fn init_in_first_kthread(fs_resolver: &FsResolver) {
@@ -85,14 +83,14 @@ pub fn init_in_first_process(ctx: &Context) {
         let ext2_fs = Ext2::open(block_device_ext2).unwrap();
         let target_path = FsPath::try_from("/ext2").unwrap();
         println!("[kernel] Mount Ext2 fs at {:?} ", target_path);
-        self::rootfs::mount_fs_at(ext2_fs, &target_path, &fs_resolver).unwrap();
+        self::rootfs::mount_fs_at(ext2_fs, &target_path, &fs_resolver, ctx).unwrap();
     }
 
     if let Ok(block_device_exfat) = start_block_device(exfat_device_name) {
         let exfat_fs = ExfatFS::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
         let target_path = FsPath::try_from("/exfat").unwrap();
         println!("[kernel] Mount ExFat fs at {:?} ", target_path);
-        self::rootfs::mount_fs_at(exfat_fs, &target_path, &fs_resolver).unwrap();
+        self::rootfs::mount_fs_at(exfat_fs, &target_path, &fs_resolver, ctx).unwrap();
     }
 
     // Initialize the file table for the first process.

--- a/kernel/src/fs/path/mount_namespace.rs
+++ b/kernel/src/fs/path/mount_namespace.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        fs_resolver::FsResolver,
+        path::{Mount, Path},
+        ramfs::RamFS,
+    },
+    namespace::UserNamespace,
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// Represents a mount namespace, which encapsulates a mount tree and provides
+/// isolation for filesystem views between different threads.
+///
+/// A `MountNamespace` only allows operations on [`Mount`]s that belong to that `MountNamespace`.
+/// If the operation target includes [`Mount`]s from other `MountNamespace`s, it will be directly
+/// rejected and return an `Err`.
+pub struct MountNamespace {
+    /// The root mount of this namespace.
+    root: Arc<Mount>,
+    /// The user namespace that owns this mount namespace.
+    owner: Arc<UserNamespace>,
+}
+
+impl MountNamespace {
+    /// Creates a new initial mount namespace with a RAM filesystem as root.
+    ///
+    /// Note that this method is intended for internal use only. It should only
+    /// be called during system setup when creating the initial process context.
+    #[doc(hidden)]
+    pub fn new_init(owner: Arc<UserNamespace>) -> Arc<Self> {
+        let rootfs = RamFS::new();
+
+        Arc::new_cyclic(|weak_self| {
+            let root = Mount::new_root(rootfs, weak_self.clone());
+            MountNamespace { root, owner }
+        })
+    }
+
+    /// Gets the root mount of this namespace.
+    pub fn root(&self) -> &Arc<Mount> {
+        &self.root
+    }
+
+    /// Creates a new filesystem resolver for this namespace.
+    ///
+    /// The resolver is initialized with the root and current working directory
+    /// both set to the root mount.
+    pub fn create_fs_resolver(&self) -> FsResolver {
+        let root = Path::new_fs_root(self.root.clone());
+        let cwd = Path::new_fs_root(self.root.clone());
+        FsResolver::new(root, cwd)
+    }
+
+    /// Creates a deep copy of this mount namespace, including the entire mount tree.
+    ///
+    /// This is typically used when creating a new namespace for a process or thread.
+    pub fn clone_new(
+        &self,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<MountNamespace>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+
+        let root_mount = &self.root;
+        let new_mnt_ns = Arc::new_cyclic(|weak_self| {
+            let new_root =
+                root_mount.clone_mount_tree(root_mount.root_dentry(), Some(weak_self), true);
+
+            MountNamespace {
+                root: new_root,
+                owner,
+            }
+        });
+
+        Ok(new_mnt_ns)
+    }
+
+    /// Returns the owner user namespace of the namespace.
+    pub fn owner(&self) -> &Arc<UserNamespace> {
+        &self.owner
+    }
+
+    /// Checks whether a given mount belongs to this mount namespace.
+    pub fn owns(self: &Arc<Self>, mount: &Mount) -> bool {
+        mount.mnt_ns().as_ptr() == Arc::as_ptr(self)
+    }
+}
+
+// When a mount namespace is dropped, it means that the corresponding mount
+// tree is no longer valid. Therefore, all mounts in its mount tree should be
+// detached from their parents and cleared of their mountpoints.
+impl Drop for MountNamespace {
+    fn drop(&mut self) {
+        let mut worklist = VecDeque::new();
+        worklist.push_back(self.root.clone());
+        while let Some(current_mount) = worklist.pop_front() {
+            let mut children = current_mount.children.write();
+            for (_, child) in children.drain() {
+                child.set_parent(None);
+                child.clear_mountpoint();
+                worklist.push_back(child);
+            }
+        }
+    }
+}

--- a/kernel/src/fs/thread_info.rs
+++ b/kernel/src/fs/thread_info.rs
@@ -11,6 +11,14 @@ pub struct ThreadFsInfo {
 }
 
 impl ThreadFsInfo {
+    /// Creates a new `ThreadFsInfo` with the given [`FsResolver`].
+    pub fn new(fs_resolver: FsResolver) -> Self {
+        Self {
+            resolver: RwMutex::new(fs_resolver),
+            umask: RwLock::new(FileCreationMask::default()),
+        }
+    }
+
     /// Returns the associated `FsResolver`.
     pub fn resolver(&self) -> &RwMutex<FsResolver> {
         &self.resolver
@@ -19,15 +27,6 @@ impl ThreadFsInfo {
     /// Returns the associated `FileCreationMask`.
     pub fn umask(&self) -> &RwLock<FileCreationMask> {
         &self.umask
-    }
-}
-
-impl Default for ThreadFsInfo {
-    fn default() -> Self {
-        Self {
-            resolver: RwMutex::new(FsResolver::default()),
-            umask: RwLock::new(FileCreationMask::default()),
-        }
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -65,6 +65,7 @@ pub mod events;
 pub mod fs;
 pub mod ipc;
 pub mod kcmdline;
+mod namespace;
 pub mod net;
 pub mod prelude;
 mod process;
@@ -108,6 +109,7 @@ pub fn init() {
     syscall::init();
     process::init();
     fs::init();
+    namespace::init();
 }
 
 fn init_in_first_kthread(fs_resolver: &FsResolver) {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,7 +38,10 @@ use ostd::{
 use process::{spawn_init_process, Process};
 use sched::SchedPolicy;
 
-use crate::{fs::fs_resolver::FsResolver, prelude::*, thread::kernel_thread::ThreadOptions};
+use crate::{
+    fs::fs_resolver::FsResolver, namespace::NsContext, prelude::*,
+    thread::kernel_thread::ThreadOptions,
+};
 
 extern crate alloc;
 extern crate lru;
@@ -106,7 +109,6 @@ pub fn init() {
     #[cfg(target_arch = "x86_64")]
     net::init();
     sched::init();
-    syscall::init();
     process::init();
     fs::init();
     namespace::init();
@@ -153,9 +155,8 @@ fn ap_init() {
 fn first_kthread() {
     println!("[kernel] Spawn init thread");
 
-    // TODO: After introducing the mount namespace, use an initial mount namespace to create
-    // the `FsResolver`, and the initial mount namespace should be passed to the first process.
-    let fs_resolver = FsResolver::new();
+    let init_ns_context = NsContext::new_init();
+    let fs_resolver = init_ns_context.mnt_ns().create_fs_resolver();
 
     init_in_first_kthread(&fs_resolver);
 
@@ -167,6 +168,7 @@ fn first_kthread() {
         karg.get_initproc_path().unwrap(),
         karg.get_initproc_argv().to_vec(),
         karg.get_initproc_envp().to_vec(),
+        init_ns_context,
     )
     .expect("Run init process failed.");
 

--- a/kernel/src/namespace/mod.rs
+++ b/kernel/src/namespace/mod.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    prelude::*,
+    process::{posix_thread::PosixThread, CloneFlags},
+};
+
+mod user;
+mod uts;
+
+pub use user::{UserNamespace, INIT_USER_NS};
+pub use uts::UtsNamespace;
+
+/// A set of namespaces to which a thread belongs.
+///
+/// This struct is immutable. To change a thread's namespaces (e.g., via the
+/// `clone` or `unshare` syscalls), a new `NsContext` instance must be created
+/// by selectively cloning fields from the existing context.
+///
+/// Note that the user and PID namespace are not managed by this struct.
+/// They are managed in separate places.
+pub struct NsContext {
+    uts: Arc<UtsNamespace>,
+}
+
+impl NsContext {
+    /// Creates a new `NsContext` in the initial state.
+    pub fn new_init() -> Self {
+        let owner = INIT_USER_NS.get().unwrap();
+        Self {
+            uts: UtsNamespace::new_init(owner.clone()),
+        }
+    }
+
+    /// Creates a new `NsContext` by cloning from an existing `context`.
+    ///
+    /// If no namespaces need to be cloned, this method simply clones self and returns.
+    /// Otherwise, a new `NsContext` will be created
+    /// by selectively cloning fields from the context and newly created namespaces.
+    //
+    // FIXME: This method is currently used by both `unshare()` and `clone()`.
+    // Once we support PID and time namespaces, their semantics diverge.
+    // We will need to refactor (or split) this method accordingly.
+    pub fn new_child(
+        self: &Arc<Self>,
+        user_ns: &Arc<UserNamespace>,
+        clone_flags: CloneFlags,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        let clone_ns_flags = (clone_flags & CLONE_NS_FLAGS) - CloneFlags::CLONE_NEWUSER;
+
+        // Fast path: If there are no new namespaces to clone,
+        // we can directly clone the context and return.
+        if clone_ns_flags.is_empty() {
+            return Ok(self.clone());
+        }
+
+        // Slow path: One or more namespaces need to be cloned,
+        // so a new `NsContext` must be created.
+
+        check_unsupported_ns_flags(clone_ns_flags)?;
+
+        let mut clone_builder = NsContextCloneBuilder::new(self);
+
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
+            let new_uts = self.uts.clone_new(user_ns.clone(), posix_thread)?;
+            clone_builder.new_uts(new_uts);
+        }
+
+        // TODO: Support other namespaces.
+
+        Ok(Arc::new(clone_builder.build()))
+    }
+
+    /// Returns the associated UTS namespace.
+    pub fn uts(&self) -> &Arc<UtsNamespace> {
+        &self.uts
+    }
+
+    /// Installs the namespace context to the thread specified by `ctx`.
+    pub fn install(self: Arc<Self>, ctx: &Context) {
+        let mut pthread_ns_context = ctx.posix_thread.ns_context().lock();
+        let mut thread_local_ns_context = ctx.thread_local.borrow_ns_context_mut();
+
+        // TODO: When installing a specific namespace,
+        // other dependent fields of a posix thread may also need to be updated.
+
+        *pthread_ns_context = Some(self.clone());
+        thread_local_ns_context.replace(Some(self));
+    }
+}
+
+/// A builder for creating a new `NsContext` by selectively cloning namespaces
+/// from an existing one.
+pub struct NsContextCloneBuilder<'a> {
+    old_context: &'a NsContext,
+
+    // Fields for new namespaces.
+    new_uts: Option<Arc<UtsNamespace>>,
+}
+
+impl<'a> NsContextCloneBuilder<'a> {
+    /// Creates a new builder based on an existing context.
+    pub fn new(old_context: &'a NsContext) -> Self {
+        Self {
+            old_context,
+            new_uts: None,
+        }
+    }
+
+    /// Sets the new UTS namespace.
+    pub fn new_uts(&mut self, new_uts: Arc<UtsNamespace>) -> &mut Self {
+        self.new_uts = Some(new_uts);
+        self
+    }
+
+    /// Builds the new `NsContext`.
+    pub fn build(self) -> NsContext {
+        let Self {
+            old_context,
+            new_uts,
+        } = self;
+
+        let new_uts = new_uts.unwrap_or_else(|| old_context.uts.clone());
+
+        NsContext { uts: new_uts }
+    }
+}
+
+/// Checks if the given `flags` contain any unsupported namespace-related flags.
+///
+/// This method does not check CLONE_NEWUSER since it's handled separately.
+pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
+    const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWUTS;
+
+    let unsupported_flags = (flags & CLONE_NS_FLAGS) - SUPPORTED_FLAGS - CloneFlags::CLONE_NEWUSER;
+    if unsupported_flags.is_empty() {
+        return Ok(());
+    }
+
+    warn!("unsupported clone ns flags: {:?}", unsupported_flags);
+    return_errno_with_message!(Errno::EINVAL, "unsupported clone namespace flags");
+}
+
+/// A bitmask of all `CloneFlags` related to namespace creation.
+pub const CLONE_NS_FLAGS: CloneFlags = CloneFlags::CLONE_NEWTIME
+    .union(CloneFlags::CLONE_NEWNS)
+    .union(CloneFlags::CLONE_NEWCGROUP)
+    .union(CloneFlags::CLONE_NEWUTS)
+    .union(CloneFlags::CLONE_NEWIPC)
+    .union(CloneFlags::CLONE_NEWUSER)
+    .union(CloneFlags::CLONE_NEWPID)
+    .union(CloneFlags::CLONE_NEWNET);
+
+pub(crate) fn init() {
+    INIT_USER_NS.call_once(UserNamespace::new_init);
+}

--- a/kernel/src/namespace/user.rs
+++ b/kernel/src/namespace/user.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use crate::{
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// The user namespace.
+pub struct UserNamespace {
+    _private: (),
+}
+
+impl UserNamespace {
+    /// Creates the initial user namespace.
+    pub(super) fn new_init() -> Arc<UserNamespace> {
+        Arc::new(UserNamespace { _private: () })
+    }
+
+    /// Checks whether the thread has the required capability in this user namespace.
+    pub fn check_cap(&self, required: CapSet, posix_thread: &PosixThread) -> Result<()> {
+        // Since creating new user namespaces is not supported at the moment,
+        // there is effectively only one user namespace in the entire system.
+        // Therefore, the thread has a single set of capabilities used for permission checks.
+        // FIXME: Once support for creating new user namespaces is added,
+        // we should verify the thread's capabilities within the relevant user namespace.
+        let cap_set = posix_thread.credentials().effective_capset();
+        if cap_set.contains(required) {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the thread does not have the required capability"
+        )
+    }
+}
+
+/// The init user namespace.
+pub static INIT_USER_NS: Once<Arc<UserNamespace>> = Once::new();

--- a/kernel/src/namespace/uts.rs
+++ b/kernel/src/namespace/uts.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    namespace::UserNamespace,
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// The UTS namespace.
+pub struct UtsNamespace {
+    uts_name: UtsName,
+    owner: Arc<UserNamespace>,
+}
+
+impl UtsNamespace {
+    /// Creates a new UTS namespace.
+    pub(super) fn new_init(owner: Arc<UserNamespace>) -> Arc<Self> {
+        let copy_slice = |src: &[u8], dst: &mut [u8]| {
+            let len = src.len().min(dst.len());
+            dst[..len].copy_from_slice(&src[..len]);
+        };
+
+        // We intentionally report Linux-like UTS values instead of this OS’s real
+        // name and version. These spoofed values satisfy glibc, which inspects
+        // uname fields (sysname, release, version, etc.) and expects Linux-compatible data.
+        let mut uts_name = UtsName::new();
+        copy_slice(b"Linux", &mut uts_name.sysname);
+        copy_slice(b"WHITLEY", &mut uts_name.nodename);
+        copy_slice(b"5.13.0", &mut uts_name.release);
+        copy_slice(b"5.13.0", &mut uts_name.version);
+        copy_slice(b"x86_64", &mut uts_name.machine);
+        copy_slice(b"", &mut uts_name.domainname);
+
+        Arc::new(Self { uts_name, owner })
+    }
+
+    /// Clones a new UTS namespace.
+    pub(super) fn clone_new(
+        &self,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        Ok(Arc::new(Self {
+            uts_name: self.uts_name,
+            owner,
+        }))
+    }
+
+    /// Returns the owner user namespace of the namespace.
+    pub fn owner(&self) -> &Arc<UserNamespace> {
+        &self.owner
+    }
+
+    /// Returns the UTS name.
+    pub fn uts_name(&self) -> &UtsName {
+        &self.uts_name
+    }
+}
+
+const UTS_FIELD_LEN: usize = 65;
+
+#[derive(Debug, Clone, Copy, Pod)]
+#[repr(C)]
+pub struct UtsName {
+    sysname: [u8; UTS_FIELD_LEN],
+    nodename: [u8; UTS_FIELD_LEN],
+    release: [u8; UTS_FIELD_LEN],
+    version: [u8; UTS_FIELD_LEN],
+    machine: [u8; UTS_FIELD_LEN],
+    domainname: [u8; UTS_FIELD_LEN],
+}
+
+impl UtsName {
+    const fn new() -> Self {
+        UtsName {
+            sysname: [0; UTS_FIELD_LEN],
+            nodename: [0; UTS_FIELD_LEN],
+            release: [0; UTS_FIELD_LEN],
+            version: [0; UTS_FIELD_LEN],
+            machine: [0; UTS_FIELD_LEN],
+            domainname: [0; UTS_FIELD_LEN],
+        }
+    }
+}

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -110,6 +110,11 @@ impl CloneArgs {
     ) -> Result<Self> {
         const FLAG_MASK: u64 = 0xff;
         let flags = CloneFlags::from(raw_flags & !FLAG_MASK);
+        if flags.contains(CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_FS)
+        {
+            return_errno_with_message!(Errno::EINVAL, "CLONE_NEWNS cannot be used with CLONE_FS for clone syscall");
+        }
+
         let exit_signal = raw_flags & FLAG_MASK;
         // Disambiguate the `parent_tid` parameter. The field is used
         // both for `CLONE_PIDFD` and `CLONE_PARENT_SETTID`, so at
@@ -178,7 +183,8 @@ impl CloneFlags {
             | CloneFlags::CLONE_PARENT_SETTID
             | CloneFlags::CLONE_CHILD_SETTID
             | CloneFlags::CLONE_CHILD_CLEARTID
-            | CloneFlags::CLONE_VFORK;
+            | CloneFlags::CLONE_VFORK
+            | CloneFlags::CLONE_NEWNS;
         let unsupported_flags = *self - supported_flags;
         if !unsupported_flags.is_empty() {
             warn!("contains unsupported clone flags: {:?}", unsupported_flags);
@@ -281,6 +287,13 @@ fn clone_child_task(
         posix_thread,
     )?;
 
+    if clone_flags.contains(CloneFlags::CLONE_NEWNS) {
+        child_fs
+            .resolver()
+            .write()
+            .switch_to_mnt_ns(child_ns_context.mnt_ns())?;
+    }
+
     let child_user_ctx = Box::new(clone_user_ctx(
         parent_context,
         clone_args.stack,
@@ -381,6 +394,13 @@ fn clone_child_process(
         clone_flags,
         posix_thread,
     )?;
+
+    if clone_flags.contains(CloneFlags::CLONE_NEWNS) {
+        child_fs
+            .resolver()
+            .write()
+            .switch_to_mnt_ns(child_ns_context.mnt_ns())?;
+    }
 
     // Inherit the parent's signal mask
     let child_sig_mask = posix_thread.sig_mask().load(Ordering::Relaxed).into();

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -57,7 +57,7 @@ impl PidFile {
         self.is_nonblocking.load(Ordering::Relaxed)
     }
 
-    pub(super) fn process(&self) -> &Arc<Process> {
+    pub fn process(&self) -> &Arc<Process> {
         &self.process
     }
 }

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -14,6 +14,7 @@ use ostd::{
 use super::{thread_table, PosixThread, ThreadLocal};
 use crate::{
     fs::{file_table::FileTable, thread_info::ThreadFsInfo},
+    namespace::{NsContext, UserNamespace, INIT_USER_NS},
     prelude::*,
     process::{
         posix_thread::name::ThreadName,
@@ -43,6 +44,8 @@ pub struct PosixThreadBuilder {
     sig_queues: SigQueues,
     sched_policy: SchedPolicy,
     fpu_context: FpuContext,
+    user_ns: Option<Arc<UserNamespace>>,
+    ns_context: Option<Arc<NsContext>>,
     is_init_process: bool,
 }
 
@@ -62,6 +65,8 @@ impl PosixThreadBuilder {
             sig_queues: SigQueues::new(),
             sched_policy: SchedPolicy::Fair(Nice::default()),
             fpu_context: FpuContext::new(),
+            user_ns: None,
+            ns_context: None,
             is_init_process: false,
         }
     }
@@ -106,6 +111,16 @@ impl PosixThreadBuilder {
         self
     }
 
+    pub fn user_ns(mut self, user_ns: Arc<UserNamespace>) -> Self {
+        self.user_ns = Some(user_ns);
+        self
+    }
+
+    pub fn ns_context(mut self, ns_context: Arc<NsContext>) -> Self {
+        self.ns_context = Some(ns_context);
+        self
+    }
+
     #[expect(clippy::wrong_self_convention)]
     pub(in crate::process) fn is_init_process(mut self) -> Self {
         self.is_init_process = true;
@@ -127,12 +142,21 @@ impl PosixThreadBuilder {
             sig_queues,
             sched_policy,
             fpu_context,
+            ns_context,
+            user_ns,
             is_init_process,
         } = self;
 
         let file_table = file_table.unwrap_or_else(|| RwArc::new(FileTable::new()));
 
         let fs = fs.unwrap_or_else(|| Arc::new(ThreadFsInfo::default()));
+
+        let user_ns = user_ns.unwrap_or_else(|| INIT_USER_NS.get().unwrap().clone());
+
+        let ns_context = ns_context.unwrap_or_else(|| {
+            assert!(Arc::ptr_eq(&user_ns, INIT_USER_NS.get().unwrap()));
+            Arc::new(NsContext::new_init())
+        });
 
         let root_vmar = process
             .upgrade()
@@ -161,6 +185,7 @@ impl PosixThreadBuilder {
                     virtual_timer_manager,
                     prof_timer_manager,
                     io_priority: AtomicU32::new(0),
+                    ns_context: Mutex::new(Some(ns_context.clone())),
                 }
             };
 
@@ -179,6 +204,8 @@ impl PosixThreadBuilder {
                 file_table,
                 fs,
                 fpu_context,
+                user_ns,
+                ns_context,
             );
 
             thread_table::add_thread(tid, thread.clone());

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -149,13 +149,15 @@ impl PosixThreadBuilder {
 
         let file_table = file_table.unwrap_or_else(|| RwArc::new(FileTable::new()));
 
-        let fs = fs.unwrap_or_else(|| Arc::new(ThreadFsInfo::default()));
-
         let user_ns = user_ns.unwrap_or_else(|| INIT_USER_NS.get().unwrap().clone());
 
         let ns_context = ns_context.unwrap_or_else(|| {
             assert!(Arc::ptr_eq(&user_ns, INIT_USER_NS.get().unwrap()));
-            Arc::new(NsContext::new_init())
+            NsContext::new_init()
+        });
+
+        let fs = fs.unwrap_or_else(|| {
+            Arc::new(ThreadFsInfo::new(ns_context.mnt_ns().create_fs_resolver()))
         });
 
         let root_vmar = process

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -81,10 +81,12 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
 
     // Drop fields in `PosixThread`.
     *posix_thread.file_table().lock() = None;
+    *posix_thread.ns_context().lock() = None;
 
     // Drop fields in `ThreadLocal`.
     *thread_local.root_vmar().borrow_mut() = None;
     thread_local.borrow_file_table_mut().remove();
+    thread_local.borrow_ns_context_mut().remove();
 
     if is_last_thread {
         exit_process(&posix_process);

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::{
     events::Observer,
     fs::file_table::FileTable,
+    namespace::NsContext,
     prelude::*,
     process::signal::constants::SIGCONT,
     thread::{Thread, Tid},
@@ -77,6 +78,9 @@ pub struct PosixThread {
 
     /// I/O Scheduling priority value
     io_priority: AtomicU32,
+
+    /// The namespaces that the thread belongs to.
+    ns_context: Mutex<Option<Arc<NsContext>>>,
 }
 
 impl PosixThread {
@@ -309,6 +313,11 @@ impl PosixThread {
     /// Returns the I/O priority value of the thread.
     pub fn io_priority(&self) -> &AtomicU32 {
         &self.io_priority
+    }
+
+    /// Returns the namespaces which the thread belongs to.
+    pub fn ns_context(&self) -> &Mutex<Option<Arc<NsContext>>> {
+        &self.ns_context
     }
 }
 

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -117,6 +117,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -326,6 +327,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -148,6 +148,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -232,6 +233,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1]);
     SYS_WAITID = 95                  => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96         => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97                 => sys_unshare(args[..1]);
     SYS_FUTEX = 98                   => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99         => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101              => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -117,6 +117,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -328,6 +329,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -148,6 +148,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::sys_unlinkat,
+    unshare::sys_unshare,
     utimens::sys_utimensat,
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -232,6 +233,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1]);
     SYS_WAITID = 95                  => sys_waitid(args[..5]);
     SYS_SET_TID_ADDRESS = 96         => sys_set_tid_address(args[..1]);
+    SYS_UNSHARE = 97                 => sys_unshare(args[..1]);
     SYS_FUTEX = 98                   => sys_futex(args[..6]);
     SYS_SET_ROBUST_LIST = 99         => sys_set_robust_list(args[..2]);
     SYS_NANOSLEEP = 101              => sys_nanosleep(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -161,6 +161,7 @@ use super::{
     umount::sys_umount,
     uname::sys_uname,
     unlink::{sys_unlink, sys_unlinkat},
+    unshare::sys_unshare,
     utimens::{sys_futimesat, sys_utime, sys_utimensat, sys_utimes},
     wait4::sys_wait4,
     waitid::sys_waitid,
@@ -356,6 +357,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FACCESSAT = 269        => sys_faccessat(args[..3]);
     SYS_PSELECT6 = 270         => sys_pselect6(args[..6]);
     SYS_PPOLL = 271            => sys_ppoll(args[..5]);
+    SYS_UNSHARE = 272          => sys_unshare(args[..1]);
     SYS_SET_ROBUST_LIST = 273  => sys_set_robust_list(args[..2]);
     SYS_UTIMENSAT = 280        => sys_utimensat(args[..4]);
     SYS_EPOLL_PWAIT = 281      => sys_epoll_pwait(args[..6]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -129,6 +129,7 @@ use super::{
     setgid::sys_setgid,
     setgroups::sys_setgroups,
     setitimer::{sys_getitimer, sys_setitimer},
+    setns::sys_setns,
     setpgid::sys_setpgid,
     setregid::sys_setregid,
     setresgid::sys_setresgid,
@@ -376,6 +377,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PREADV = 295           => sys_preadv(args[..4]);
     SYS_PWRITEV = 296          => sys_pwritev(args[..4]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_SETNS = 308            => sys_setns(args[..2]);
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);
     SYS_SCHED_SETATTR = 314    => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 315    => sys_sched_getattr(args[..4]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -401,7 +401,3 @@ macro_rules! log_syscall_entry {
         }
     };
 }
-
-pub(super) fn init() {
-    uname::init();
-}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -145,6 +145,7 @@ mod setfsuid;
 mod setgid;
 mod setgroups;
 mod setitimer;
+mod setns;
 mod setpgid;
 mod setregid;
 mod setresgid;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -177,6 +177,7 @@ mod umask;
 mod umount;
 mod uname;
 mod unlink;
+mod unshare;
 mod utimens;
 mod wait4;
 mod waitid;

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -102,7 +102,7 @@ fn do_bind_mount(src_name: CString, dst_path: Path, recursive: bool, ctx: &Conte
         return_errno_with_message!(Errno::ENOTDIR, "src_name must be directory");
     };
 
-    src_path.bind_mount_to(&dst_path, recursive)?;
+    src_path.bind_mount_to(&dst_path, recursive, ctx)?;
     Ok(())
 }
 
@@ -125,7 +125,7 @@ fn do_move_mount_old(src_name: CString, dst_path: Path, ctx: &Context) -> Result
             .lookup(&fs_path)?
     };
 
-    src_path.move_mount_to(&dst_path)?;
+    src_path.move_mount_to(&dst_path, ctx)?;
 
     Ok(())
 }
@@ -147,7 +147,7 @@ fn do_new_mount(
         return_errno_with_message!(Errno::EINVAL, "fs_type is empty");
     }
     let fs = get_fs(fs_type, devname, data, ctx)?;
-    target_path.mount(fs)?;
+    target_path.mount(fs, ctx)?;
     Ok(())
 }
 

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module implements the `setns` syscall.
+//!
+//! This syscall reassociates the calling thread with a namespace specified by a
+//! file descriptor. The `flags` argument determines which type of namespace can be
+//! joined.
+//!
+//! The file descriptor `fd` can refer to:
+//! 1. A namespace file from `/proc/[pid]/ns/`.
+//! 2. A `PidFile` opened by `pidfd_open` or by opening `/proc/[pid]` directory.
+
+use crate::{
+    fs::file_table::FileDesc,
+    namespace::{
+        check_unsupported_ns_flags, NsContext, NsContextCloneBuilder, UtsNamespace, CLONE_NS_FLAGS,
+    },
+    prelude::*,
+    process::{
+        credentials::capabilities::CapSet, posix_thread::AsPosixThread, CloneFlags, PidFile,
+    },
+    syscall::SyscallReturn,
+};
+
+pub fn sys_setns(fd: FileDesc, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let ns_type_flags = CloneFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid `setns` flags"))?;
+    debug!("flags = {:?}", ns_type_flags);
+
+    let file = {
+        let file_table = ctx.thread_local.borrow_file_table();
+        let file_table_locked = file_table.unwrap().read();
+        file_table_locked.get_file(fd)?.clone()
+    };
+
+    let new_ns_context = if let Some(pid_file) = file.downcast_ref::<PidFile>() {
+        build_context_from_pid_file(pid_file, ns_type_flags, ctx)?
+    }
+    // TODO: Support setting namespaces from `/proc/[pid]/ns`.
+    else {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the FD does not refer to a supported namespace file"
+        );
+    };
+
+    // Install the newly created namespace context.
+    Arc::new(new_ns_context).install(ctx);
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn build_context_from_pid_file(
+    pid_file: &PidFile,
+    flags: CloneFlags,
+    ctx: &Context,
+) -> Result<NsContext> {
+    if flags.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "flags must be specified with a PID file");
+    }
+
+    // Check for any flags that are not namespace-related.
+    if !(flags - CLONE_NS_FLAGS).is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "invalid flags are specified with a PID file");
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        return_errno_with_message!(Errno::EINVAL, "setting a user namespace is not supported");
+    }
+
+    check_unsupported_ns_flags(flags)?;
+
+    let target_thread = pid_file.process().main_thread();
+    let target_context = target_thread.as_posix_thread().unwrap().ns_context().lock();
+    let Some(target_context) = target_context.as_ref() else {
+        return_errno_with_message!(Errno::ESRCH, "the target process has exited");
+    };
+
+    let current_context = ctx.thread_local.borrow_ns_context();
+    let current_context = current_context.unwrap();
+
+    let mut clone_builder = NsContextCloneBuilder::new(current_context);
+
+    if flags.contains(CloneFlags::CLONE_NEWUTS) {
+        let target_ns = target_context.uts();
+        set_uts_ns(&mut clone_builder, target_ns, ctx)?;
+    }
+
+    // TODO: Support setting other namespaces from the target process.
+
+    Ok(clone_builder.build())
+}
+
+fn set_uts_ns(
+    clone_builder: &mut NsContextCloneBuilder,
+    target_ns: &Arc<UtsNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
+    // and the current user namespace.
+    target_ns
+        .owner()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    ctx.thread_local
+        .borrow_user_ns()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+
+    // TODO: Are the checks above sufficient?
+
+    clone_builder.new_uts(target_ns.clone());
+
+    Ok(())
+}

--- a/kernel/src/syscall/sync.rs
+++ b/kernel/src/syscall/sync.rs
@@ -3,7 +3,9 @@
 use super::SyscallReturn;
 use crate::prelude::*;
 
-pub fn sys_sync(_ctx: &Context) -> Result<SyscallReturn> {
-    crate::fs::rootfs::root_mount().sync()?;
+pub fn sys_sync(ctx: &Context) -> Result<SyscallReturn> {
+    let current_ns_context = ctx.thread_local.borrow_ns_context();
+    let current_mnt_ns = current_ns_context.unwrap().mnt_ns();
+    current_mnt_ns.root().sync()?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/umount.rs
+++ b/kernel/src/syscall/umount.rs
@@ -34,7 +34,7 @@ pub fn sys_umount(path_addr: Vaddr, flags: u64, ctx: &Context) -> Result<Syscall
             .lookup(&fs_path)?
     };
 
-    target_path.unmount()?;
+    target_path.unmount(ctx)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/uname.rs
+++ b/kernel/src/syscall/uname.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 pub fn sys_uname(old_uname_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("old uname addr = 0x{:x}", old_uname_addr);
     let ns_context = ctx.thread_local.borrow_ns_context();
-    let uts_name = ns_context.unwrap().uts().uts_name();
+    let uts_name = ns_context.unwrap().uts_ns().uts_name();
     ctx.user_space().write_val(old_uname_addr, uts_name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/uname.rs
+++ b/kernel/src/syscall/uname.rs
@@ -1,62 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
-
-use spin::Once;
-
 use super::SyscallReturn;
 use crate::prelude::*;
 
-// We don't use the real name and version of our os here. Instead, we pick up fake values witch is the same as the ones of linux.
-// The values are used to fool glibc since glibc will check the version and os name.
-static UTS_NAME: Once<UtsName> = Once::new();
-
-const UTS_FIELD_LEN: usize = 65;
-
-#[derive(Debug, Clone, Copy, Pod)]
-#[repr(C)]
-struct UtsName {
-    sysname: [u8; UTS_FIELD_LEN],
-    nodename: [u8; UTS_FIELD_LEN],
-    release: [u8; UTS_FIELD_LEN],
-    version: [u8; UTS_FIELD_LEN],
-    machine: [u8; UTS_FIELD_LEN],
-    domainname: [u8; UTS_FIELD_LEN],
-}
-
-impl UtsName {
-    const fn new() -> Self {
-        UtsName {
-            sysname: [0; UTS_FIELD_LEN],
-            nodename: [0; UTS_FIELD_LEN],
-            release: [0; UTS_FIELD_LEN],
-            version: [0; UTS_FIELD_LEN],
-            machine: [0; UTS_FIELD_LEN],
-            domainname: [0; UTS_FIELD_LEN],
-        }
-    }
-}
-
-pub(super) fn init() {
-    UTS_NAME.call_once(|| {
-        let copy_slice = |src: &[u8], dst: &mut [u8]| {
-            let len = src.len().min(dst.len());
-            dst[..len].copy_from_slice(&src[..len]);
-        };
-
-        let mut uts_name = UtsName::new();
-        copy_slice(b"Linux", &mut uts_name.sysname);
-        copy_slice(b"WHITLEY", &mut uts_name.nodename);
-        copy_slice(b"5.13.0", &mut uts_name.release);
-        copy_slice(b"5.13.0", &mut uts_name.version);
-        copy_slice(b"x86_64", &mut uts_name.machine);
-        copy_slice(b"", &mut uts_name.domainname);
-
-        uts_name
-    });
-}
-
 pub fn sys_uname(old_uname_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("old uname addr = 0x{:x}", old_uname_addr);
-    ctx.user_space()
-        .write_val(old_uname_addr, UTS_NAME.get().unwrap())?;
+    let ns_context = ctx.thread_local.borrow_ns_context();
+    let uts_name = ns_context.unwrap().uts().uts_name();
+    ctx.user_space().write_val(old_uname_addr, uts_name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -128,5 +128,14 @@ fn unshare_namespaces(flags: CloneFlags, ctx: &Context) -> Result<()> {
     *pthread_ns_context = Some(new_ns_context.clone());
     *thread_local_ns_context = new_ns_context;
 
+    if flags.contains(CloneFlags::CLONE_NEWNS) {
+        ctx.thread_local
+            .borrow_fs()
+            .resolver()
+            .write()
+            .switch_to_mnt_ns(thread_local_ns_context.mnt_ns())
+            .unwrap();
+    }
+
     Ok(())
 }

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::RwArc;
+
+use crate::{namespace::CLONE_NS_FLAGS, prelude::*, process::CloneFlags, syscall::SyscallReturn};
+
+pub fn sys_unshare(unshare_flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let mut flags = CloneFlags::from_bits(unshare_flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid `unshare` flags"))?;
+    debug!("unshare flags = {:?}", flags);
+
+    apply_implied_flags(&mut flags);
+    check_flags(flags, ctx)?;
+
+    unshare_files(flags, ctx);
+    unshare_fs(flags, ctx);
+    unshare_sysvsem(flags, ctx);
+    unshare_namespaces(flags, ctx)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn apply_implied_flags(flags: &mut CloneFlags) {
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        *flags |= CloneFlags::CLONE_THREAD | CloneFlags::CLONE_FS;
+    }
+
+    if flags.contains(CloneFlags::CLONE_SIGHAND) {
+        *flags |= CloneFlags::CLONE_THREAD;
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWNS) {
+        *flags |= CloneFlags::CLONE_FS;
+    }
+}
+
+fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
+    const VALID_FLAGS: CloneFlags = CLONE_NS_FLAGS
+        .union(CloneFlags::CLONE_FILES)
+        .union(CloneFlags::CLONE_FS)
+        .union(CloneFlags::CLONE_SYSVSEM)
+        .union(CloneFlags::CLONE_THREAD)
+        .union(CloneFlags::CLONE_VM)
+        .union(CloneFlags::CLONE_SIGHAND);
+
+    let invalid_flags = flags - VALID_FLAGS;
+    if !invalid_flags.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "unsupported `unshare` flags");
+    }
+
+    if flags.intersects(CloneFlags::CLONE_THREAD | CloneFlags::CLONE_VM | CloneFlags::CLONE_SIGHAND)
+        && ctx.process.tasks().lock().as_slice().len() != 1
+    {
+        return_errno_with_message!(Errno::EINVAL, "`CLONE_THREAD`, `CLONE_VM`, and `CLONE_SIGHAND` can be specified only if the process is single-threaded");
+    }
+
+    if flags.contains(CloneFlags::CLONE_VM) {
+        let vmar_ref = ctx.thread_local.root_vmar().borrow();
+        // If the VMAR is not shared, its reference count should be 2:
+        // one reference is held by `ThreadLocal` and the other by `ProcessVm` in `Process`.
+        if vmar_ref.as_ref().unwrap().reference_count() != 2 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "CLONE_VM can only be used when the VMAR is not shared"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn unshare_files(flags: CloneFlags, ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_FILES) {
+        return;
+    }
+
+    let mut pthread_file_table = ctx.posix_thread.file_table().lock();
+
+    let mut thread_local_file_table_ref = ctx.thread_local.borrow_file_table_mut();
+    let thread_local_file_table = thread_local_file_table_ref.unwrap();
+
+    let new_file_table = RwArc::new(thread_local_file_table.read().clone());
+
+    *pthread_file_table = Some(new_file_table.clone_ro());
+    *thread_local_file_table = new_file_table;
+}
+
+fn unshare_fs(flags: CloneFlags, ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_FS) {
+        return;
+    }
+
+    let mut fs_ref = ctx.thread_local.borrow_fs_mut();
+    let new_fs = fs_ref.as_ref().clone();
+    *fs_ref = Arc::new(new_fs);
+}
+
+fn unshare_sysvsem(flags: CloneFlags, _ctx: &Context) {
+    if !flags.contains(CloneFlags::CLONE_SYSVSEM) {
+        return;
+    }
+
+    warn!("unsharing System V semaphore is not supported");
+}
+
+fn unshare_namespaces(flags: CloneFlags, ctx: &Context) -> Result<()> {
+    if !flags.intersects(CLONE_NS_FLAGS) {
+        return Ok(());
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "cloning a new user namespace is not supported"
+        );
+    }
+
+    let user_ns_ref = ctx.thread_local.borrow_user_ns();
+
+    let mut pthread_ns_context = ctx.posix_thread.ns_context().lock();
+
+    let mut thread_local_ns_context = ctx.thread_local.borrow_ns_context_mut();
+    let thread_local_ns_context = thread_local_ns_context.unwrap();
+
+    let new_ns_context =
+        thread_local_ns_context.new_child(&user_ns_ref, flags, ctx.posix_thread)?;
+
+    *pthread_ns_context = Some(new_ns_context.clone());
+    *thread_local_ns_context = new_ns_context;
+
+    Ok(())
+}

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -69,7 +69,7 @@ fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
     Ok(())
 }
 
-fn unshare_files(flags: CloneFlags, ctx: &Context) {
+pub(super) fn unshare_files(flags: CloneFlags, ctx: &Context) {
     if !flags.contains(CloneFlags::CLONE_FILES) {
         return;
     }

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -129,6 +129,11 @@ impl<R> Vmar<R> {
     ) -> Result<Vaddr> {
         self.0.remap(old_addr, old_size, new_addr, new_size)
     }
+
+    /// Returns the reference count of the `Vmar`.
+    pub fn reference_count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
 }
 
 pub(super) struct Vmar_ {

--- a/test/src/apps/Makefile
+++ b/test/src/apps/Makefile
@@ -30,6 +30,7 @@ TEST_APPS := \
 	itimer \
 	mmap \
 	mongoose \
+	namespace \
 	network \
 	pipe \
 	prctl \

--- a/test/src/apps/namespace/Makefile
+++ b/test/src/apps/namespace/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=

--- a/test/src/apps/namespace/mnt_ns.c
+++ b/test/src/apps/namespace/mnt_ns.c
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/syscall.h>
+
+#include "../test.h"
+
+#define STACK_SIZE (1024 * 1024)
+
+// --- Test for unshare(CLONE_NEWNS) ---
+
+#define UNSHARE_MNT "/mnt/unshare_test"
+#define UNSHARE_FILE UNSHARE_MNT "/child.txt"
+
+static int unshare_child_fn(void)
+{
+	CHECK(unshare(CLONE_NEWNS));
+
+	// Mount a tmpfs in the new namespace. This should not be visible to the parent.
+	CHECK(mount("ramfs_child", UNSHARE_MNT, "ramfs", 0, ""));
+
+	int fd = CHECK(open(UNSHARE_FILE, O_CREAT | O_WRONLY, 0644));
+	CHECK(close(fd));
+	CHECK(access(UNSHARE_FILE, F_OK));
+
+	CHECK(umount(UNSHARE_MNT));
+
+	CHECK_WITH(access(UNSHARE_FILE, F_OK), errno == ENOENT);
+
+	return 0;
+}
+
+FN_TEST(unshare_newns)
+{
+	// Setup
+	CHECK_WITH(mkdir("/mnt", 0755), errno == 0 | errno == EEXIST);
+	CHECK_WITH(mkdir(UNSHARE_MNT, 0755), errno == 0 | errno == EEXIST);
+
+	TEST_ERRNO(access(UNSHARE_FILE, F_OK), ENOENT);
+
+	pid_t pid = TEST_SUCC(fork());
+
+	if (pid == 0) {
+		exit(unshare_child_fn());
+	} else {
+		int status;
+		TEST_SUCC(waitpid(pid, &status, 0));
+		TEST_RES(WIFEXITED(status) && WEXITSTATUS(status), _ret == 0);
+		// Verify that the child's mount operations were not visible to the parent.
+		TEST_ERRNO(access(UNSHARE_FILE, F_OK), ENOENT);
+	}
+
+	// Teardown
+	TEST_SUCC(rmdir(UNSHARE_MNT));
+}
+END_TEST()
+
+// --- Test for clone(CLONE_NEWNS) ---
+
+#define CLONE_PARENT_MNT "/mnt/clone_parent"
+#define CLONE_CHILD_MNT "/mnt/clone_child"
+#define PARENT_FILE CLONE_PARENT_MNT "/parent.txt"
+#define CHILD_FILE CLONE_CHILD_MNT "/child.txt"
+
+static int clone_child_fn(void *arg)
+{
+	CHECK(access(PARENT_FILE, F_OK));
+
+	CHECK(mount("ramfs_child", CLONE_CHILD_MNT, "ramfs", 0, ""));
+	int fd = CHECK(open(CHILD_FILE, O_CREAT | O_WRONLY, 0644));
+	CHECK(close(fd));
+
+	CHECK(umount(CLONE_PARENT_MNT));
+
+	// Verify parent's mount is gone from child's view.
+	CHECK_WITH(access(PARENT_FILE, F_OK), errno == ENOENT);
+
+	// Verify child's own mount is still present.
+	CHECK(access(CHILD_FILE, F_OK));
+
+	return 0;
+}
+
+FN_TEST(clone_newns)
+{
+	// Setup
+	CHECK_WITH(mkdir("/mnt", 0755), errno == 0 | errno == EEXIST);
+	CHECK_WITH(mkdir(CLONE_PARENT_MNT, 0755), errno == 0 | errno == EEXIST);
+	CHECK_WITH(mkdir(CLONE_CHILD_MNT, 0755), errno == 0 | errno == EEXIST);
+
+	TEST_SUCC(mount("ramfs_parent", CLONE_PARENT_MNT, "ramfs", 0, ""));
+	int fd = TEST_SUCC(open(PARENT_FILE, O_CREAT | O_WRONLY, 0644));
+	TEST_SUCC(close(fd));
+
+	char *stack = malloc(STACK_SIZE);
+	char *stack_top = stack + STACK_SIZE;
+
+	pid_t pid = TEST_SUCC(
+		clone(clone_child_fn, stack_top, CLONE_NEWNS | SIGCHLD, NULL));
+
+	int status;
+	TEST_SUCC(waitpid(pid, &status, 0));
+	TEST_RES(WIFEXITED(status) && WEXITSTATUS(status), _ret == 0);
+
+	// Parent's mount should be unaffected by child's umount.
+	TEST_SUCC(access(PARENT_FILE, F_OK));
+	// Child's mount should not be visible to the parent.
+	TEST_ERRNO(access(CHILD_FILE, F_OK), ENOENT);
+
+	// Teardown
+	free(stack);
+	TEST_SUCC(umount(CLONE_PARENT_MNT));
+	TEST_SUCC(rmdir(CLONE_PARENT_MNT));
+	TEST_SUCC(rmdir(CLONE_CHILD_MNT));
+}
+END_TEST()
+
+// --- Test for setns(CLONE_NEWNS) ---
+
+#define SETNS_MNT "/mnt/setns_target"
+#define SETNS_FILE SETNS_MNT "/target.txt"
+
+// This function runs in a child process to set up a target namespace.
+static int setns_target_fn(int pipe_write_fd)
+{
+	CHECK(unshare(CLONE_NEWNS));
+
+	CHECK(mount("ramfs_target", SETNS_MNT, "ramfs", 0, ""));
+
+	int fd = CHECK(open(SETNS_FILE, O_CREAT | O_WRONLY, 0644));
+	CHECK(close(fd));
+
+	// Signal to the parent that setup is complete.
+	char ok = 'K';
+	CHECK(write(pipe_write_fd, &ok, 1));
+	CHECK(close(pipe_write_fd));
+
+	// Wait to be killed by the parent.
+	pause();
+	return 0;
+}
+
+FN_TEST(setns_newns)
+{
+	// Setup
+	CHECK_WITH(mkdir("/mnt", 0755), errno == 0 | errno == EEXIST);
+	CHECK_WITH(mkdir(SETNS_MNT, 0755), errno == 0 | errno == EEXIST);
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t child_pid = TEST_SUCC(fork());
+
+	if (child_pid == 0) {
+		close(pipefd[0]);
+		exit(setns_target_fn(pipefd[1]));
+	}
+
+	close(pipefd[1]);
+
+	char buf;
+	TEST_SUCC(read(pipefd[0], &buf, 1));
+	close(pipefd[0]);
+
+	int pid_fd = TEST_SUCC(syscall(SYS_pidfd_open, child_pid, 0));
+
+	// Switch into the child's mount namespace using the pidfd.
+	TEST_SUCC(setns(pid_fd, CLONE_NEWNS));
+	TEST_SUCC(close(pid_fd));
+
+	// Check if we can see the file created by the child in its namespace.
+	TEST_SUCC(access(SETNS_FILE, F_OK));
+
+	// Teardown
+	TEST_SUCC(kill(child_pid, SIGKILL));
+	TEST_SUCC(waitpid(child_pid, NULL, 0));
+
+	TEST_SUCC(umount(SETNS_MNT));
+	TEST_SUCC(rmdir(SETNS_MNT));
+}
+END_TEST()

--- a/test/src/apps/namespace/setns.c
+++ b/test/src/apps/namespace/setns.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/syscall.h>
+
+#include "../test.h"
+
+FN_TEST(set_ns_empty_flags)
+{
+	// FIXME: The following test will fail on Asterinas
+	// because it currently does not support ns file.
+	// const char *ns_path = "/proc/self/ns/user";
+	// int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	// TEST_ERRNO(setns(fd_ns, 0), EINVAL);
+	// TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, 0), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_self_ns)
+{
+	// It is not permitted to use setns() to reenter the caller's
+	// current user namespace. This is different from other namespaces.
+	// FIXME: The following test will fail on Asterinas
+	// because it currently does not support ns file.
+	// const char *ns_path = "/proc/self/ns/user";
+	// int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	// TEST_ERRNO(setns(fd_ns, CLONE_NEWUSER), EINVAL);
+	// TEST_SUCC(close(fd_ns));
+
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_ERRNO(setns(pidfd, CLONE_NEWUSER), EINVAL);
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()

--- a/test/src/apps/namespace/unshare.c
+++ b/test/src/apps/namespace/unshare.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sched.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+
+#include "../test.h"
+
+FN_TEST(invalid_flags)
+{
+	TEST_ERRNO(unshare(CLONE_CHILD_CLEARTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_CHILD_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_DETACHED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_IO), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PARENT_SETTID), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PIDFD), EINVAL);
+	TEST_ERRNO(unshare(CLONE_PTRACE), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SETTLS), EINVAL);
+	TEST_ERRNO(unshare(CLONE_UNTRACED), EINVAL);
+	TEST_ERRNO(unshare(CLONE_VFORK), EINVAL);
+}
+END_TEST()
+
+void *sleep_1s_thread(void *arg)
+{
+	sleep(1);
+}
+
+FN_TEST(single_thread_flags)
+{
+	TEST_SUCC(unshare(CLONE_VM | CLONE_SIGHAND | CLONE_THREAD));
+
+	pthread_t thread_id;
+	TEST_SUCC(pthread_create(&thread_id, NULL, sleep_1s_thread, NULL));
+
+	TEST_ERRNO(unshare(CLONE_VM), EINVAL);
+	TEST_ERRNO(unshare(CLONE_SIGHAND), EINVAL);
+	TEST_ERRNO(unshare(CLONE_THREAD), EINVAL);
+
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_SUCC(unshare(CLONE_VM));
+	TEST_SUCC(unshare(CLONE_SIGHAND));
+	TEST_SUCC(unshare(CLONE_THREAD));
+}
+END_TEST()
+
+void *unshare_files_thread(void *arg)
+{
+	int test_fd = (int)(intptr_t)arg;
+
+	CHECK(unshare(CLONE_FILES));
+	CHECK(close(test_fd));
+}
+
+FN_TEST(unshare_files)
+{
+	struct stat old_stdin_stat, old_stdout_stat, old_stderr_stat;
+	struct stat new_stdin_stat, new_stdout_stat, new_stderr_stat;
+
+	TEST_SUCC(fstat(STDIN_FILENO, &old_stdin_stat));
+	TEST_SUCC(fstat(STDOUT_FILENO, &old_stdout_stat));
+	TEST_SUCC(fstat(STDERR_FILENO, &old_stderr_stat));
+
+	TEST_SUCC(unshare(CLONE_FILES));
+
+	TEST_RES(fstat(STDIN_FILENO, &new_stdin_stat),
+		 old_stdin_stat.st_ino == new_stdin_stat.st_ino);
+	TEST_RES(fstat(STDOUT_FILENO, &new_stdout_stat),
+		 old_stdout_stat.st_ino == new_stdout_stat.st_ino);
+	TEST_RES(fstat(STDERR_FILENO, &new_stderr_stat),
+		 old_stderr_stat.st_ino == new_stderr_stat.st_ino);
+
+	const char *TEST_FILENAME = "/tmp/unshare_files_test.txt";
+	pthread_t thread_id;
+	struct stat stat1, stat2;
+	int test_fd;
+
+	test_fd = TEST_SUCC(
+		open(TEST_FILENAME, O_CREAT | O_RDWR | O_TRUNC, 0644));
+	TEST_SUCC(fstat(test_fd, &stat1));
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_files_thread,
+				 (void *)(intptr_t)test_fd));
+	TEST_SUCC(pthread_join(thread_id, NULL));
+
+	TEST_RES(fstat(test_fd, &stat2), stat1.st_ino == stat2.st_ino);
+	TEST_SUCC(close(test_fd));
+	TEST_SUCC(unlink(TEST_FILENAME));
+}
+END_TEST()
+
+#define CWD_BUF_SIZE 1024
+#define THREAD_CWD "/tmp"
+
+void *unshare_fs_thread(void *arg)
+{
+	CHECK(unshare(CLONE_FS));
+
+	CHECK(chdir(THREAD_CWD));
+	CHECK(getcwd((char *)arg, CWD_BUF_SIZE));
+}
+
+FN_TEST(unshare_fs)
+{
+	char cwd_buf1[CWD_BUF_SIZE], cwd_buf2[CWD_BUF_SIZE];
+	pthread_t thread_id;
+
+	TEST_RES(getcwd(cwd_buf1, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, THREAD_CWD) != 0);
+
+	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_fs_thread,
+				 (void *)cwd_buf2));
+
+	TEST_RES(pthread_join(thread_id, NULL),
+		 strcmp(cwd_buf2, THREAD_CWD) == 0);
+
+	TEST_RES(getcwd(cwd_buf2, CWD_BUF_SIZE),
+		 strcmp(cwd_buf1, cwd_buf2) == 0);
+}
+END_TEST()

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,6 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
+namespace/unshare
 process/group_session
 process/job_control
 process/pidfd

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,6 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
+namespace/setns
 namespace/unshare
 process/group_session
 process/job_control


### PR DESCRIPTION
This PR implements the mount namespace designed in #2330, and is based on the PR #2312.

Explanation of some key issues:

### The lifetime of `Mount` and `MountNamespace`
- If no processes belong to a mount namespace, the mount namespace will be dropped.
- The dropping of a mount namespace means its corresponding mount tree ceases to exist. Therefore, when it is dropped, it will detach its associated `Mount`, triggering the `clear_mountpoint` logic.
- The mounts on the dropped mount tree may still exist but become orphaned mounts. Other processes can access them but cannot traverse them within their original mount tree.
- Such orphaned mounts require no special handling when they are dropped.

e.g.
```c
#define TEMP_DIR "/temp"
#define INNER_DIR "/temp/inner"

int main() {
    unshare(CLONE_NEWNS); // Create new mount namespace
    
    mkdir(TEMP_DIR, 0755); 
    mkdir(INNER_DIR, 0755); 
    mkdir("/temp/inner/old", 0755);
    mount("none", "/temp/inner", "tmpfs", 0, "size=10M"); // Mount tmpfs on `/temp/inner`
    mkdir("/temp/inner/new", 0755);
        
    pid_t pid = fork();

	if (pid == 0) {
        // In child process
		int fd_temp = open(TEMP_DIR, O_RDONLY | O_DIRECTORY);
        int fd_inner = open(INNER_DIR, O_RDONLY | O_DIRECTORY);

        unshare(CLONE_NEWNS); // Create new mount namespace
        sleep(2); // Wait for the parent to exit.

        // The tmpfs mount in the parent namespace still exists,
        // but it has been detached from the tree.
        fchdir(fd_temp);
        system("ls -l inner"); // Outputs `old`.
        fchdir(fd_inner);
        system("ls -l inner"); // Outputs `new`.
	} else {
        sleep(1);
        exit(0);
	}
}
```

### Mutability of Mount Namespace Root

Through research on Linux documentation and source code, the conclusion is that the root of a mount namespace in Linux is immutable. This PR chooses to follow Linux's behavior for the following reasons:

- The only system call that might potentially change the mount namespace root, pivot_root, explicitly states in its [manual](https://man7.org/linux/man-pages/man2/pivot_root.2.html):
  - "The rootfs (initial ramfs) cannot be pivot_root()ed. The recommended method of changing the root filesystem in this case is to delete everything in rootfs, overmount rootfs with the new root, attach stdin/stdout/stderr to the new /dev/console, and exec the new init(1)."
  - "EINVAL The current root is on the rootfs (initial ramfs) mount;"

Thus, for this system call, its semantics explicitly prohibit pivoting the rootfs, which is the root node of the mount namespace.

- [Linux documentation](https://github.com/torvalds/linux/blob/master/Documentation/filesystems/ramfs-rootfs-initramfs.rst) additionally explains the design decision behind why rootfs cannot be pivot_root'ed or unmounted:
  - "Rootfs is a special instance of ramfs (or tmpfs, if that's enabled), which is always present in 2.6 systems. You can't unmount rootfs for approximately the same reason you can't kill the init process; rather than having special code to check for and handle an empty list, it's smaller and simpler for the kernel to just make sure certain lists can't become empty."

Since the old root mount operated on by `pivot_root` is typically immediately unmounted afterward, if unmounting rootfs is not allowed, the corresponding pivot_root operation must also be disabled.
