### PR TITLE
Enable RISC-V stack unwinding on panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ CARGO_OSDK_COMMON_ARGS += --profile release-lto
 OSTD_TASK_STACK_SIZE_IN_PAGES = 8
 else ifeq ($(RELEASE), 1)
 CARGO_OSDK_COMMON_ARGS += --release
-OSTD_TASK_STACK_SIZE_IN_PAGES = 8
+OSTD_TASK_STACK_SIZE_IN_PAGES = 16
 endif
 
 # If the BENCHMARK is set, we will run the benchmark in the kernel mode.

--- a/osdk/src/base_crate/riscv64.ld.template
+++ b/osdk/src/base_crate/riscv64.ld.template
@@ -34,10 +34,6 @@ SECTIONS
         *(.rodata .rodata.*)
     }
 
-    .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA_OFFSET) {
-        PROVIDE(__GNU_EH_FRAME_HDR = .);
-        KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
-    }
     . = ALIGN(8);
     .eh_frame               : AT(ADDR(.eh_frame) - KERNEL_VMA_OFFSET) {
         PROVIDE(__eh_frame = .);

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -65,7 +65,7 @@ unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu
 riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
-unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+unwinding = { version = "=0.2.5", default-features = false, features = ["fde-static", "hide-trace", "panic", "personality", "unwinder"] }
 
 [target.loongarch64-unknown-none-softfloat.dependencies]
 loongArch64 = "0.2.5"

--- a/ostd/src/arch/riscv/task/switch.S
+++ b/ostd/src/arch/riscv/task/switch.S
@@ -3,6 +3,7 @@
 .text
 .global context_switch
 .global first_context_switch
+.global kernel_task_entry_wrapper
 
 context_switch: # (nxt: *const TaskContext, cur: *mut TaskContext)
   # Save cur's register
@@ -39,3 +40,9 @@ first_context_switch: # (nxt: *const TaskContext)
   ld  s10, 0x58(a0)
   ld  s11, 0x60(a0)
   ret
+
+kernel_task_entry_wrapper:
+  .cfi_startproc
+  .cfi_undefined ra # mark return address as undefined to indicate end of call stack
+  call kernel_task_entry
+  .cfi_endproc

--- a/ostd/src/arch/x86/task/switch.S
+++ b/ostd/src/arch/x86/task/switch.S
@@ -31,6 +31,8 @@ first_context_switch: # (nxt: *const TaskContext)
   mov r13, [rdi + 32]
   mov r14, [rdi + 40]
   mov r15, [rdi + 48]
-  mov rax, [rdi + 56] # restore return address
-  mov [rsp], rax # for stack balance, must use mov instead of push
+  mov rax, [rdi + 56]
+  # for stack balance, we have to use mov instead of push here
+  mov qword ptr [rsp + 8], 0 # kernel_task_entry's return address
+  mov [rsp], rax             # first_context_switch's return address
   ret

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -161,8 +161,11 @@ impl TaskOptions {
 
     /// Builds a new task without running it immediately.
     pub fn build(self) -> Result<Task> {
-        /// all task will entering this function
-        /// this function is mean to executing the task_fn in Task
+        // All tasks will enter this function. It is meant to execute the `task_fn` in `Task`.
+        //
+        // RISC-V provides an assembly wrapper for this function as the end of call stack so
+        // we have to disable name mangling for it on RISC-V.
+        #[cfg_attr(target_arch = "riscv64", no_mangle)]
         extern "C" fn kernel_task_entry() -> ! {
             // SAFETY: The new task is switched on a CPU for the first time, `after_switching_to`
             // hasn't been called yet.
@@ -188,10 +191,18 @@ impl TaskOptions {
             scheduler::exit_current();
         }
 
+        #[cfg(target_arch = "riscv64")]
+        extern "C" {
+            fn kernel_task_entry_wrapper();
+        }
+
         let kstack = KernelStack::new_with_guard_page()?;
 
         let mut ctx = TaskContext::new();
+        #[cfg(not(target_arch = "riscv64"))]
         ctx.set_instruction_pointer(kernel_task_entry as usize);
+        #[cfg(target_arch = "riscv64")]
+        ctx.set_instruction_pointer(kernel_task_entry_wrapper as usize);
         // We should reserve space for the return address in the stack, otherwise
         // we will write across the page boundary due to the implementation of
         // the context switch.


### PR DESCRIPTION
This PR enables stack unwinding in panic handler for RISC-V.

It basically does three things:
- uses `unwinding` crate's `fde-static` feature for RISC-V instead of `fde-gnu-eh-frame-hdr` that x86 uses
    Rust's `riscv64imac-unknown-none-elf` target disables the generation of `.eh_frame_hdr` section on linking. So we have to linearly scan the `.eh_frame` section for FDE used in the unwinding.
- adds a wrapper for `kernel_task_entry` that serves as an explicit end of stack
    RISC-V unwinding takes `kernel_task_entry`'s saved return address. But that is set to `kernel_task_entry` itself before `ret` to `kernel_task_entry`. This will hurt the following stack unwinding (it doesn't terminate and eventually goes into unmapped memory in my case).
    x86 works well because it reads the 8-byte value right below stack bottom, which is some random garbage, as `kernel_task_entry`'s return address. This is why stack trace on x86 ends with a `??` function. The second commit also adds a explicit end of stack for x86.
- increases kernel stack size in release mode to 16 from 8
    This is to let the stack unwinding in release mode finish successfully and after that the whole process can exit. Otherwise it will stuck on page faults and we have to start a new shell.