### PR TITLE
Add tmpfs support by wrapping ramfs

### DIFF
--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -20,6 +20,7 @@ pub mod registry;
 pub mod rootfs;
 pub mod sysfs;
 pub mod thread_info;
+pub mod tmpfs;
 pub mod utils;
 
 use aster_block::BlockDevice;
@@ -60,6 +61,7 @@ pub fn init() {
     procfs::init();
     cgroupfs::init();
     ramfs::init();
+    tmpfs::init();
     devpts::init();
 
     ext2::init();

--- a/kernel/src/fs/ramfs/mod.rs
+++ b/kernel/src/fs/ramfs/mod.rs
@@ -11,7 +11,7 @@ use crate::fs::ramfs::fs::RamFsType;
 mod fs;
 mod xattr;
 
-const RAMFS_MAGIC: u64 = 0x0102_1994;
+const RAMFS_MAGIC: u64 = 0x8584_58f6;
 const BLOCK_SIZE: usize = 4096;
 const ROOT_INO: u64 = 1;
 const NAME_MAX: usize = 255;

--- a/kernel/src/fs/tmpfs/fs.rs
+++ b/kernel/src/fs/tmpfs/fs.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        ramfs::RamFS,
+        registry::{FsProperties, FsType},
+        utils::{FileSystem, FsFlags, Inode, SuperBlock},
+    },
+    prelude::*,
+};
+
+/// The temporary file system (tmpfs) structure.
+//
+// TODO: Currently, tmpfs is implemented as a thin wrapper around RamFS.
+// In the future we need to implement tmpfs-specific features such as
+// memory limits and swap support.
+pub struct TmpFs {
+    inner: Arc<RamFS>,
+}
+
+impl FileSystem for TmpFs {
+    fn sync(&self) -> Result<()> {
+        // do nothing
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.inner.root_inode()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.inner.sb()
+    }
+
+    fn flags(&self) -> FsFlags {
+        FsFlags::DENTRY_UNEVICTABLE
+    }
+}
+
+pub(super) struct TmpFsType;
+
+impl FsType for TmpFsType {
+    fn name(&self) -> &'static str {
+        "tmpfs"
+    }
+
+    fn create(
+        &self,
+        _args: Option<CString>,
+        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
+        _ctx: &Context,
+    ) -> Result<Arc<dyn FileSystem>> {
+        Ok(Arc::new(TmpFs {
+            inner: RamFS::new(),
+        }))
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::empty()
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+        None
+    }
+}

--- a/kernel/src/fs/tmpfs/mod.rs
+++ b/kernel/src/fs/tmpfs/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Temporary file system (tmpfs) based on RamFS.
+
+use alloc::sync::Arc;
+
+mod fs;
+
+#[expect(dead_code)]
+const TMPFS_MAGIC: u64 = 0x0102_1994;
+
+pub(super) fn init() {
+    let ramfs_type = Arc::new(fs::TmpFsType);
+    super::registry::register(ramfs_type).unwrap();
+}


### PR DESCRIPTION
This PR provides a "dummy" `tmpfs` implementation by wrapping `ramfs`, which is required by Podman (#2214).

If this implementation is not considered suitable for a direct merge into the main branch, I think the initial version of `tmpfs` could support at least a size limit feature. This would likely require additional time, as implementing a `tmpfs` that is genuinely distinct from `ramfs` might involve extra work to refactor some of the existing `ramfs` interfaces to achieve good code reusability.

