### PR TITLE
Use rust-analyzer for riscv64 and loongarch64 target

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,10 @@
         "kernel/Cargo.toml",
         "--target",
         "x86_64-unknown-none",
+        "--target",
+        "riscv64imac-unknown-none-elf",
+        "--target",
+        "loongarch64-unknown-none-softfloat",
         "-Zbuild-std=core,alloc,compiler_builtins",
         "-Zbuild-std-features=compiler-builtins-mem"
     ],

--- a/ostd/libs/linux-bzimage/setup/build.rs
+++ b/ostd/libs/linux-bzimage/setup/build.rs
@@ -7,23 +7,27 @@ fn main() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
     let target_arch = std::env::var("TARGET").unwrap();
-    let lds = source_dir.join("src/x86/linker.ld");
-    let def = match target_arch.as_str() {
-        "x86_64-unknown-none" => "-DCFG_TARGET_ARCH_X86_64=1",
-        "x86_64-i386_pm-none" => "-DCFG_TARGET_ARCH_X86_64=0",
-        other => panic!("unsupported target: {}", other),
-    };
+    if target_arch.starts_with("x86_64") {
+        let lds = source_dir.join("src/x86/linker.ld");
+        let def = match target_arch.as_str() {
+            "x86_64-unknown-none" => "-DCFG_TARGET_ARCH_X86_64=1",
+            "x86_64-i386_pm-none" => "-DCFG_TARGET_ARCH_X86_64=0",
+            other => panic!("unsupported x86_64 target: {}", other),
+        };
 
-    let out_lds = out_dir.join("linker.ld");
-    let status = Command::new("cpp")
-        .arg("-o")
-        .arg(&out_lds)
-        .arg(def)
-        .arg(&lds)
-        .status()
-        .expect("failed to run the preprocessor");
-    assert!(status.success(), "the preprocessor exits with failure");
+        let out_lds = out_dir.join("linker.ld");
+        let status = Command::new("cpp")
+            .arg("-o")
+            .arg(&out_lds)
+            .arg(def)
+            .arg(&lds)
+            .status()
+            .expect("failed to run the preprocessor");
+        assert!(status.success(), "the preprocessor exits with failure");
 
-    println!("cargo:rerun-if-changed={}", lds.display());
-    println!("cargo:rustc-link-arg=-T{}", out_lds.display());
+        println!("cargo:rerun-if-changed={}", lds.display());
+        println!("cargo:rustc-link-arg=-T{}", out_lds.display());
+    } else {
+        println!("cargo:warning=Unsupported target: {}", target_arch);
+    }
 }


### PR DESCRIPTION
This PR enables VSCode users to use rust-analyzer for our newly supported architectures (riscv64/loongarch64).

Now the rust-analyzer will run the check command on three targets and it will report if one of them is broken. However, users still need to manually change the `rust-analyzer.cargo.target` configuration to enable target-specific IDE features.