### PR TITLE
Fix three small issues when running Podman

### DIFF
--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -45,6 +45,9 @@ pub fn sys_madvise(
             warn!("MADV_DONTNEED isn't implemented, do nothing for now.");
         }
         MadviseBehavior::MADV_FREE => madv_free(start, end, ctx)?,
+        MadviseBehavior::MADV_NOHUGEPAGE => {
+            warn!("MADV_NOHUGEPAGE isn't implemented, do nothing for now");
+        }
         _ => todo!(),
     }
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -24,6 +24,10 @@ pub fn sys_openat(
         dirfd, path, flags, mode
     );
 
+    if path.is_empty() {
+        return_errno_with_message!(Errno::ENOENT, "openat fails with empty path");
+    }
+
     let file_handle = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::new(dirfd, path.as_ref())?;


### PR DESCRIPTION
This PR fixes three small issues when running Podman in #2214 .

1. The first commit warns on `MADV_NOHUGEPAGE` instead of panic. Since we don't support huge page now, we just print an warning message.
2. The second commit fixes the capget problem. When the user specifies an unsupported capability version, we should write the supported version to user space. In this case, if the `cap_user_data_addr` is 0, we should return success.
3. The third commit makes openat return ENOENT if the pathname is empty, this behavior is similar to other methods ending with `at` like `fstatat`.