### PR TITLE
`context.rs` enhancements

### DIFF
--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -139,9 +139,7 @@ pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
 
     // Instantiate reader and writer pointing at the same `futex_addr`, set up
     // for the same length: the length of an `u32`.
-    const U32_LEN: usize = size_of::<u32>();
-    let writer = user_space.writer(futex_addr, U32_LEN)?;
-    let reader = user_space.reader(futex_addr, U32_LEN)?;
+    let (reader, writer) = user_space.reader_writer(futex_addr, size_of::<u32>())?;
 
     let mut old_val: u32 = reader.atomic_load()?;
     loop {


### PR DESCRIPTION
* Improve the phrasing of some docstrings and comments
* Add warning comments about attempts to validate memory addresses at reader/writer instantiation time
* Create the `reader_writer` method for ergonomically instantiate a reader/writer pair covering the same memory region. This method is also slightly more efficient than calling `reader` and `writer` separately
* Clean up `check_vaddr` for clarity and rename it to `check_vaddr_lowerbound` for explicity
* Include the data length check before calling `check_vaddr_lowerbound` in `atomic_load` and `atomic_fetch_update` for further consistency with the delayed buffer validation