### PR TITLE
Init vDSO singleton in the first kthread

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -117,14 +117,14 @@ fn init_in_first_kthread(fs_resolver: &FsResolver) {
     net::init_in_first_kthread();
     fs::init_in_first_kthread(fs_resolver);
     ipc::init_in_first_kthread();
+    #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+    vdso::init_in_first_kthread();
 }
 
 fn init_in_first_process(ctx: &Context) {
     device::init_in_first_process(ctx).unwrap();
     fs::init_in_first_process(ctx);
     process::init_in_first_process(ctx);
-    #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
-    vdso::init_in_first_process();
 }
 
 fn ap_init() {

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -358,7 +358,7 @@ fn init_vdso() {
     VDSO.call_once(|| Arc::new(vdso));
 }
 
-pub(super) fn init_in_first_process() {
+pub(super) fn init_in_first_kthread() {
     init_start_secs_count();
     init_vdso();
 


### PR DESCRIPTION
Every userspace process needs to map the vDSO data/text into its own address space so we have to prepare vDSO singleton BEFORE spawning the first process. This PR fixes this problem.