### PR TITLE
Move some overflow checks from `{read,write}v.rs` to `iovec.rs`

### DIFF
--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -80,24 +80,7 @@ fn do_sys_pwritev(
     let user_space = ctx.user_space();
     let mut reader_array = VmReaderArray::from_user_io_vecs(&user_space, io_vec_ptr, io_vec_count)?;
     for reader in reader_array.readers_mut() {
-        if !reader.has_remain() {
-            continue;
-        }
-
-        let reader_len = reader.remain();
-        if total_len.checked_add(reader_len).is_none()
-            || total_len
-                .checked_add(reader_len)
-                .and_then(|sum| sum.checked_add(cur_offset))
-                .is_none()
-            || total_len
-                .checked_add(reader_len)
-                .and_then(|sum| sum.checked_add(cur_offset))
-                .map(|sum| sum > isize::MAX as usize)
-                .unwrap_or(false)
-        {
-            return_errno_with_message!(Errno::EINVAL, "Total length overflow");
-        }
+        debug_assert!(reader.has_remain());
 
         // TODO: According to the man page
         // at <https://man7.org/linux/man-pages/man2/readv.2.html>,
@@ -140,9 +123,7 @@ fn do_sys_writev(
     let user_space = ctx.user_space();
     let mut reader_array = VmReaderArray::from_user_io_vecs(&user_space, io_vec_ptr, io_vec_count)?;
     for reader in reader_array.readers_mut() {
-        if !reader.has_remain() {
-            continue;
-        }
+        debug_assert!(reader.has_remain());
 
         // TODO: According to the man page
         // at <https://man7.org/linux/man-pages/man2/readv.2.html>,

--- a/test/src/apps/file_io/iovec_err.c
+++ b/test/src/apps/file_io/iovec_err.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdint.h>
+#include <sys/fcntl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include "../test.h"
+
+static char buf[16];
+static struct iovec iov_long[UIO_MAXIOV + 2];
+static struct iovec iov_inv[2];
+
+FN_SETUP(iov)
+{
+	int i;
+
+	for (i = 0; i <= UIO_MAXIOV + 1; ++i)
+		iov_long[i] = (struct iovec){ .iov_base = buf,
+					      .iov_len = sizeof(buf) };
+
+	iov_inv[0] = (struct iovec){ .iov_base = buf, .iov_len = sizeof(buf) };
+	iov_inv[1] = (struct iovec){ .iov_base = buf, .iov_len = -1234 };
+}
+END_SETUP()
+
+FN_TEST(readv)
+{
+	int fd;
+
+	fd = TEST_SUCC(open("/dev/zero", O_RDONLY));
+
+	TEST_SUCC(readv(fd, iov_long, UIO_MAXIOV - 1));
+	TEST_SUCC(readv(fd, iov_long, UIO_MAXIOV));
+	TEST_ERRNO(readv(fd, iov_long, UIO_MAXIOV + 1), EINVAL);
+
+	TEST_SUCC(readv(fd, iov_inv, 1));
+	TEST_ERRNO(readv(fd, iov_inv, 2), EINVAL);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(writev)
+{
+	int fd;
+
+	fd = TEST_SUCC(open("/dev/null", O_WRONLY));
+
+	TEST_SUCC(writev(fd, iov_long, UIO_MAXIOV - 1));
+	TEST_SUCC(writev(fd, iov_long, UIO_MAXIOV));
+	TEST_ERRNO(writev(fd, iov_long, UIO_MAXIOV + 1), EINVAL);
+
+	TEST_SUCC(writev(fd, iov_inv, 1));
+	TEST_ERRNO(writev(fd, iov_inv, 2), EINVAL);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(sendmsg_recvmsg)
+{
+	int fds[2];
+	struct msghdr msgh;
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fds));
+
+	memset(&msgh, 0, sizeof(msgh));
+#define sendv(fd, iov, iovcnt)            \
+	({                                \
+		msgh.msg_iov = iov;       \
+		msgh.msg_iovlen = iovcnt; \
+		sendmsg(fd, &msgh, 0);    \
+	})
+#define recvv(fd, iov, iovcnt)            \
+	({                                \
+		msgh.msg_iov = iov;       \
+		msgh.msg_iovlen = iovcnt; \
+		recvmsg(fd, &msgh, 0);    \
+	})
+
+	TEST_SUCC(sendv(fds[0], iov_long, UIO_MAXIOV - 1));
+	TEST_SUCC(sendv(fds[0], iov_long, UIO_MAXIOV));
+	TEST_ERRNO(sendv(fds[0], iov_long, UIO_MAXIOV + 1), EMSGSIZE);
+
+	TEST_SUCC(recvv(fds[1], iov_long, UIO_MAXIOV - 1));
+	TEST_SUCC(recvv(fds[1], iov_long, UIO_MAXIOV));
+	TEST_ERRNO(recvv(fds[1], iov_long, UIO_MAXIOV + 1), EMSGSIZE);
+
+	TEST_SUCC(sendv(fds[0], iov_inv, 1));
+	TEST_ERRNO(sendv(fds[0], iov_inv, 2), EINVAL);
+
+	TEST_SUCC(recvv(fds[1], iov_inv, 1));
+	TEST_ERRNO(recvv(fds[1], iov_inv, 2), EINVAL);
+
+#undef sendv
+#undef recvv
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()

--- a/test/src/apps/scripts/fs.sh
+++ b/test/src/apps/scripts/fs.sh
@@ -65,3 +65,4 @@ pipe/pipe_err
 pipe/short_rw
 epoll/epoll_err
 epoll/poll_err
+file_io/iovec_err


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/f56d2f3bad8ff769b50507356c0306488926d1cb/kernel/src/syscall/preadv.rs#L85-L98

This checks:
 - The total length of the buffers in `writer_array` won't overflow. This is a basic property of `VmWriterArray` and we should perform the check in `copy_iovs_and_convert`:
https://github.com/asterinas/asterinas/blob/f56d2f3bad8ff769b50507356c0306488926d1cb/kernel/src/util/iovec.rs#L120-L128
 - The offset won't overflow. This should be guaranteed by `file.read_at` instead. Otherwise, I believe that we'll encounter problems in other code as well, e.g.,:
https://github.com/asterinas/asterinas/blob/f56d2f3bad8ff769b50507356c0306488926d1cb/kernel/src/fs/inode_handle/mod.rs#L59-L62