### PR TITLE
Use `size_of`/`align_of` in the prelude

### DIFF
--- a/kernel/comps/mlsdisk/src/layers/0-bio/mod.rs
+++ b/kernel/comps/mlsdisk/src/layers/0-bio/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
 
 pub type BlockId = usize;
 pub const BLOCK_SIZE: usize = 0x1000;
-pub const BID_SIZE: usize = core::mem::size_of::<BlockId>();
+pub const BID_SIZE: usize = size_of::<BlockId>();
 
 // This definition of `BlockId` assumes the target architecture is 64-bit.
 const_assert!(BID_SIZE == 8);

--- a/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_blob.rs
+++ b/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_blob.rs
@@ -64,7 +64,7 @@ struct Header {
 
 impl<B: BlockSet> CryptoBlob<B> {
     /// The size of the header of a crypto blob in bytes.
-    pub const HEADER_NBYTES: usize = core::mem::size_of::<Header>();
+    pub const HEADER_NBYTES: usize = size_of::<Header>();
 
     /// Opens an existing `CryptoBlob`.
     ///

--- a/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_chain.rs
+++ b/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_chain.rs
@@ -76,7 +76,7 @@ struct Footer {
 impl<L: BlockLog> CryptoChain<L> {
     /// The available size in each chained block is smaller than that of
     /// the block size.
-    pub const AVAIL_BLOCK_SIZE: usize = BLOCK_SIZE - core::mem::size_of::<Footer>();
+    pub const AVAIL_BLOCK_SIZE: usize = BLOCK_SIZE - size_of::<Footer>();
 
     /// Construct a new `CryptoChain` using `block_log: L` as the storage.
     pub fn new(block_log: L) -> Self {

--- a/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_log.rs
+++ b/kernel/comps/mlsdisk/src/layers/1-crypto/crypto_log.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::vec;
-use core::{any::Any, mem::size_of};
+use core::any::Any;
 
 use ostd::const_assert;
 use ostd_pod::Pod;

--- a/kernel/comps/mlsdisk/src/layers/2-edit/journal.rs
+++ b/kernel/comps/mlsdisk/src/layers/2-edit/journal.rs
@@ -330,7 +330,7 @@ impl<S> Snapshot<S> {
 
     /// Return the length of metadata.
     pub fn meta_len() -> usize {
-        core::mem::size_of::<BlockId>()
+        size_of::<BlockId>()
     }
 }
 
@@ -966,7 +966,7 @@ mod tests {
         let mut journal = EditJournal::format(
             disk.subset(0..16).unwrap(),
             XState { sum: 0 },
-            core::mem::size_of::<XState>() * 2,
+            size_of::<XState>() * 2,
             ThresholdPolicy::new(threshold),
         )
         .unwrap();
@@ -1031,7 +1031,7 @@ mod tests {
         let disk = MemDisk::create(16).unwrap();
 
         let journal_disk = disk.subset(0..12).unwrap();
-        let state_max_nbytes = core::mem::size_of::<XState>() * 2;
+        let state_max_nbytes = size_of::<XState>() * 2;
         let compact_policy =
             DefaultCompactPolicy::new::<MemDisk>(journal_disk.nblocks(), state_max_nbytes);
         let mut journal: EditJournal<XEdit, XState, MemDisk, DefaultCompactPolicy> =

--- a/kernel/comps/mlsdisk/src/layers/3-log/tx_log.rs
+++ b/kernel/comps/mlsdisk/src/layers/3-log/tx_log.rs
@@ -720,7 +720,7 @@ impl<D: BlockSet + 'static> Debug for TxLogStore<D> {
 }
 
 impl Superblock {
-    const SUPERBLOCK_SIZE: usize = core::mem::size_of::<Superblock>();
+    const SUPERBLOCK_SIZE: usize = size_of::<Superblock>();
 
     /// Returns the total number of blocks occupied by the `TxLogStore`.
     pub fn total_nblocks(&self) -> usize {

--- a/kernel/comps/mlsdisk/src/layers/4-lsm/sstable.rs
+++ b/kernel/comps/mlsdisk/src/layers/4-lsm/sstable.rs
@@ -2,7 +2,7 @@
 
 //! Sorted String Table.
 use alloc::vec;
-use core::{marker::PhantomData, mem::size_of, num::NonZeroUsize, ops::RangeInclusive};
+use core::{marker::PhantomData, num::NonZeroUsize, ops::RangeInclusive};
 
 use lru::LruCache;
 use ostd_pod::Pod;

--- a/kernel/comps/mlsdisk/src/layers/4-lsm/wal.rs
+++ b/kernel/comps/mlsdisk/src/layers/4-lsm/wal.rs
@@ -2,7 +2,7 @@
 
 //! Transactions in WriteAhead Log.
 use alloc::vec;
-use core::{fmt::Debug, mem::size_of};
+use core::fmt::Debug;
 
 use ostd_pod::Pod;
 

--- a/kernel/comps/mlsdisk/src/layers/5-disk/block_alloc.rs
+++ b/kernel/comps/mlsdisk/src/layers/5-disk/block_alloc.rs
@@ -3,7 +3,6 @@
 //! Block allocation.
 use alloc::vec;
 use core::{
-    mem::size_of,
     num::NonZeroUsize,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -8,7 +8,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use core::{fmt::Debug, hint::spin_loop, mem::size_of};
+use core::{fmt::Debug, hint::spin_loop};
 
 use aster_block::{
     bio::{bio_segment_pool_init, BioEnqueueError, BioStatus, BioType, SubmittedBio},

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -6,7 +6,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{fmt::Debug, mem};
+use core::fmt::Debug;
 
 use aster_input::{
     key::{Key, KeyStatus},
@@ -259,7 +259,7 @@ struct EventTable {
 
 impl EventTable {
     fn new(num_events: usize) -> Self {
-        assert!(num_events * mem::size_of::<VirtioInputEvent>() <= PAGE_SIZE);
+        assert!(num_events * size_of::<VirtioInputEvent>() <= PAGE_SIZE);
 
         let segment = FrameAllocOptions::new()
             .zeroed(true)
@@ -287,12 +287,12 @@ impl EventTable {
     }
 }
 
-const EVENT_SIZE: usize = core::mem::size_of::<VirtioInputEvent>();
+const EVENT_SIZE: usize = size_of::<VirtioInputEvent>();
 type EventBuf<'a> = SafePtr<VirtioInputEvent, &'a DmaStream>;
 
 impl<T, M: HasDaddr> DmaBuf for SafePtr<T, M> {
     fn len(&self) -> usize {
-        core::mem::size_of::<T>()
+        size_of::<T>()
     }
 }
 

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -3,7 +3,7 @@
 use alloc::{
     boxed::Box, collections::linked_list::LinkedList, string::ToString, sync::Arc, vec::Vec,
 };
-use core::{fmt::Debug, mem::size_of};
+use core::fmt::Debug;
 
 use aster_bigtcp::device::{Checksum, DeviceCapabilities, Medium};
 use aster_network::{

--- a/kernel/comps/virtio/src/device/network/header.rs
+++ b/kernel/comps/virtio/src/device/network/header.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 use int_to_c_enum::TryFromInt;
 use ostd::Pod;
 
-pub const VIRTIO_NET_HDR_LEN: usize = core::mem::size_of::<VirtioNetHdr>();
+pub const VIRTIO_NET_HDR_LEN: usize = size_of::<VirtioNetHdr>();
 
 /// VirtioNet header precedes each packet
 #[repr(C)]

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec};
-use core::{fmt::Debug, hint::spin_loop, mem::size_of};
+use core::{fmt::Debug, hint::spin_loop};
 
 use aster_network::{RxBuffer, TxBuffer};
 use aster_util::{field_ptr, slot_vec::SlotVec};

--- a/kernel/comps/virtio/src/device/socket/header.rs
+++ b/kernel/comps/virtio/src/device/socket/header.rs
@@ -31,7 +31,7 @@ use ostd::Pod;
 
 use super::error::{self, SocketError};
 
-pub const VIRTIO_VSOCK_HDR_LEN: usize = core::mem::size_of::<VirtioVsockHdr>();
+pub const VIRTIO_VSOCK_HDR_LEN: usize = size_of::<VirtioVsockHdr>();
 
 /// Socket address.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{boxed::Box, sync::Arc};
-use core::mem::{offset_of, size_of};
+use core::mem::offset_of;
 
 use aster_rights::{ReadOp, WriteOp};
 use aster_util::{field_ptr, safe_ptr::SafePtr};

--- a/kernel/libs/aster-util/src/safe_ptr.rs
+++ b/kernel/libs/aster-util/src/safe_ptr.rs
@@ -247,18 +247,18 @@ impl<T: PodOnce, M: VmIoOnce, R: TRights> SafePtr<T, M, TRightSet<R>> {
 // =============== Address-related methods ==============
 impl<T, M, R> SafePtr<T, M, R> {
     pub const fn is_aligned(&self) -> bool {
-        self.offset % core::mem::align_of::<T>() == 0
+        self.offset % align_of::<T>() == 0
     }
 
     /// Increase the address in units of bytes occupied by the generic T.
     pub fn add(&mut self, count: usize) {
-        let offset = count * core::mem::size_of::<T>();
+        let offset = count * size_of::<T>();
         self.offset += offset;
     }
 
     /// Increase or decrease the address in units of bytes occupied by the generic T.
     pub fn offset(&mut self, count: isize) {
-        let offset = count * core::mem::size_of::<T>() as isize;
+        let offset = count * size_of::<T>() as isize;
         if count >= 0 {
             self.offset += offset as usize;
         } else {
@@ -362,8 +362,7 @@ impl<T, M: HasDaddr, R> HasDaddr for SafePtr<T, M, R> {
 impl<T, R> SafePtr<T, DmaStream, R> {
     /// Synchronize the object in the streaming DMA mapping
     pub fn sync(&self) -> Result<()> {
-        self.vm_obj
-            .sync(self.offset..self.offset + core::mem::size_of::<T>())
+        self.vm_obj.sync(self.offset..self.offset + size_of::<T>())
     }
 }
 

--- a/kernel/libs/cpio-decoder/src/lib.rs
+++ b/kernel/libs/cpio-decoder/src/lib.rs
@@ -330,7 +330,7 @@ impl Header {
     where
         R: Read,
     {
-        let mut buf = vec![0u8; core::mem::size_of::<Self>()];
+        let mut buf = vec![0u8; size_of::<Self>()];
         reader.read_exact(&mut buf)?;
 
         let header = Self {
@@ -356,7 +356,7 @@ impl Header {
     }
 
     fn len(&self) -> usize {
-        core::mem::size_of::<Self>()
+        size_of::<Self>()
     }
 }
 

--- a/kernel/src/fs/exfat/bitmap.rs
+++ b/kernel/src/fs/exfat/bitmap.rs
@@ -181,7 +181,7 @@ impl ExfatBitmap {
         mut cur_unit_offset: u32,
         total_cluster_num: u32,
     ) -> (u32, u32) {
-        let unit_size: u32 = (BITS_PER_BYTE * core::mem::size_of::<BitStore>()) as u32;
+        let unit_size: u32 = (BITS_PER_BYTE * size_of::<BitStore>()) as u32;
         while cur_unit_index < total_cluster_num {
             let leading_zeros = bytes[cur_unit_index as usize].leading_zeros();
             let head_cluster_num = unit_size - cur_unit_offset;
@@ -241,7 +241,7 @@ impl ExfatBitmap {
         cur_unit_offset: u32,
         num_clusters: u32,
     ) -> Range<ClusterID> {
-        let unit_size: u32 = (BITS_PER_BYTE * core::mem::size_of::<BitStore>()) as u32;
+        let unit_size: u32 = (BITS_PER_BYTE * size_of::<BitStore>()) as u32;
         let result_bit_index = cur_unit_index * unit_size + cur_unit_offset;
         result_bit_index + EXFAT_RESERVED_CLUSTERS
             ..result_bit_index + EXFAT_RESERVED_CLUSTERS + num_clusters
@@ -261,7 +261,7 @@ impl ExfatBitmap {
         }
 
         let bytes: &[BitStore] = self.bitvec.as_raw_slice();
-        let unit_size: u32 = (BITS_PER_BYTE * core::mem::size_of::<BitStore>()) as u32;
+        let unit_size: u32 = (BITS_PER_BYTE * size_of::<BitStore>()) as u32;
         let start_cluster_index = search_start_cluster - EXFAT_RESERVED_CLUSTERS;
         let mut cur_unit_index = start_cluster_index / unit_size;
         let mut cur_unit_offset = start_cluster_index % unit_size;
@@ -354,7 +354,7 @@ impl ExfatBitmap {
     }
 
     fn write_to_disk(&mut self, clusters: Range<ClusterID>, sync: bool) -> Result<()> {
-        let unit_size = core::mem::size_of::<BitStore>() * BITS_PER_BYTE;
+        let unit_size = size_of::<BitStore>() * BITS_PER_BYTE;
         let start_byte_off: usize = (clusters.start - EXFAT_RESERVED_CLUSTERS) as usize / unit_size;
         let end_byte_off: usize =
             ((clusters.end - EXFAT_RESERVED_CLUSTERS) as usize).align_up(unit_size) / unit_size;

--- a/kernel/src/fs/exfat/fat.rs
+++ b/kernel/src/fs/exfat/fat.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::mem::size_of;
-
 use super::{
     bitmap::ExfatBitmap,
     constants::{EXFAT_FIRST_CLUSTER, EXFAT_RESERVED_CLUSTERS},

--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -42,7 +42,7 @@ impl BlockGroup {
                 let descriptor = {
                     // Read the block group descriptor
                     // TODO: if the main is corrupted, should we load the backup?
-                    let offset = idx * core::mem::size_of::<RawGroupDescriptor>();
+                    let offset = idx * size_of::<RawGroupDescriptor>();
                     let raw_descriptor = group_descriptors_segment
                         .read_val::<RawGroupDescriptor>(offset)
                         .unwrap();
@@ -487,7 +487,7 @@ impl From<RawGroupDescriptor> for GroupDescriptor {
     }
 }
 
-const_assert!(core::mem::size_of::<RawGroupDescriptor>() == 32);
+const_assert!(size_of::<RawGroupDescriptor>() == 32);
 
 /// The raw block group descriptor.
 ///

--- a/kernel/src/fs/ext2/block_ptr.rs
+++ b/kernel/src/fs/ext2/block_ptr.rs
@@ -176,4 +176,4 @@ pub const MAX_TB_INDIRECT_BLOCKS: Ext2Bid = MAX_INDIRECT_BLOCKS * MAX_DB_INDIREC
 pub const MAX_BLOCK_PTRS: usize = TB_INDIRECT + 1;
 
 /// The size of of the block id.
-pub const BID_SIZE: usize = core::mem::size_of::<Ext2Bid>();
+pub const BID_SIZE: usize = size_of::<Ext2Bid>();

--- a/kernel/src/fs/ext2/dir.rs
+++ b/kernel/src/fs/ext2/dir.rs
@@ -18,7 +18,7 @@ pub struct DirEntry {
 
 impl DirEntry {
     const ALIGN: usize = 4;
-    const HEADER_LEN: usize = core::mem::size_of::<DirEntryHeader>();
+    const HEADER_LEN: usize = size_of::<DirEntryHeader>();
     const PARENT_OFFSET: usize = Self::HEADER_LEN + Self::ALIGN;
 
     /// Constructs a new `DirEntry` object with the specified inode (`ino`),

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -48,7 +48,7 @@ impl Ext2 {
 
         let group_descriptors_segment: USegment = {
             let npages = ((super_block.block_groups_count() as usize)
-                * core::mem::size_of::<RawGroupDescriptor>())
+                * size_of::<RawGroupDescriptor>())
             .div_ceil(BLOCK_SIZE);
             let segment = FrameAllocOptions::new()
                 .zeroed(false)
@@ -214,7 +214,7 @@ impl Ext2 {
         block_group_idx: usize,
         raw_descriptor: &RawGroupDescriptor,
     ) -> Result<()> {
-        let offset = block_group_idx * core::mem::size_of::<RawGroupDescriptor>();
+        let offset = block_group_idx * size_of::<RawGroupDescriptor>();
         self.group_descriptors_segment
             .write_val(offset, raw_descriptor)?;
         Ok(())

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -1308,9 +1308,9 @@ impl InodeImpl {
     }
 
     pub fn set_device_id(&mut self, device_id: u64) {
-        self.desc.block_ptrs.as_bytes_mut()[..core::mem::size_of::<u64>()]
+        self.desc.block_ptrs.as_bytes_mut()[..size_of::<u64>()]
             .copy_from_slice(device_id.as_bytes());
-        self.block_manager.block_ptrs.write().as_bytes_mut()[..core::mem::size_of::<u64>()]
+        self.block_manager.block_ptrs.write().as_bytes_mut()[..size_of::<u64>()]
             .copy_from_slice(device_id.as_bytes());
     }
 
@@ -1318,7 +1318,7 @@ impl InodeImpl {
         let mut device_id: u64 = 0;
         device_id
             .as_bytes_mut()
-            .copy_from_slice(&self.desc.block_ptrs.as_bytes()[..core::mem::size_of::<u64>()]);
+            .copy_from_slice(&self.desc.block_ptrs.as_bytes()[..size_of::<u64>()]);
         device_id
     }
 
@@ -2284,7 +2284,7 @@ bitflags! {
     }
 }
 
-const_assert!(core::mem::size_of::<RawInode>() == 128);
+const_assert!(size_of::<RawInode>() == 128);
 
 /// The raw inode on device.
 #[repr(C)]

--- a/kernel/src/fs/ext2/super_block.rs
+++ b/kernel/src/fs/ext2/super_block.rs
@@ -154,7 +154,7 @@ impl TryFrom<RawSuperBlock> for SuperBlock {
             first_ino: sb.first_ino,
             inode_size: {
                 let inode_size = sb.inode_size as _;
-                if inode_size < core::mem::size_of::<RawInode>() {
+                if inode_size < size_of::<RawInode>() {
                     return_errno_with_message!(Errno::EINVAL, "inode size is too small");
                 }
                 inode_size
@@ -422,7 +422,7 @@ pub enum RevLevel {
     Dynamic = 1,
 }
 
-const_assert!(core::mem::size_of::<RawSuperBlock>() == SUPER_BLOCK_SIZE);
+const_assert!(size_of::<RawSuperBlock>() == SUPER_BLOCK_SIZE);
 
 /// The raw superblock, it must be exactly 1024 bytes in length.
 #[repr(C)]

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -547,7 +547,7 @@ impl FutexKey {
         // "On all platforms, futexes are four-byte integers that must be aligned on a four-byte
         // boundary."
         // Reference: <https://man7.org/linux/man-pages/man2/futex.2.html>.
-        if addr % core::mem::align_of::<u32>() != 0 {
+        if addr % align_of::<u32>() != 0 {
             return_errno_with_message!(
                 Errno::EINVAL,
                 "the futex word is not aligend on a four-byte boundary"

--- a/kernel/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/src/process/process_vm/init_stack/mod.rs
@@ -13,10 +13,7 @@
 //! so the content reading from init stack may not be the same as the process init status.
 //!
 
-use core::{
-    mem,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use align_ext::AlignExt;
 use aster_rights::Full;
@@ -289,10 +286,10 @@ impl InitStackWriter {
     fn adjust_stack_alignment(&self, envp_pointers: &[u64], argv_pointers: &[u64]) -> Result<()> {
         // Ensure 8-byte alignment
         self.write_u64(0)?;
-        let auxvec_size = (self.auxvec.table().len() + 1) * (mem::size_of::<u64>() * 2);
-        let envp_pointers_size = (envp_pointers.len() + 1) * mem::size_of::<u64>();
-        let argv_pointers_size = (argv_pointers.len() + 1) * mem::size_of::<u64>();
-        let argc_size = mem::size_of::<u64>();
+        let auxvec_size = (self.auxvec.table().len() + 1) * (size_of::<u64>() * 2);
+        let envp_pointers_size = (envp_pointers.len() + 1) * size_of::<u64>();
+        let argv_pointers_size = (argv_pointers.len() + 1) * size_of::<u64>();
+        let argc_size = size_of::<u64>();
         let to_write_size = auxvec_size + envp_pointers_size + argv_pointers_size + argc_size;
         if (self.pos() - to_write_size) % 16 != 0 {
             self.write_u64(0)?;

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -3,8 +3,6 @@
 #![expect(dead_code)]
 #![expect(non_camel_case_types)]
 
-use core::mem::{self, size_of};
-
 use aster_util::read_union_field;
 use inherit_methods_macro::inherit_methods;
 use ostd::cpu::context::UserContext;
@@ -77,7 +75,7 @@ impl siginfo_t {
 #[derive(Clone, Copy, Pod)]
 #[repr(C)]
 union siginfo_fields_t {
-    bytes: [u8; 128 - mem::size_of::<i32>() * 4],
+    bytes: [u8; 128 - size_of::<i32>() * 4],
     common: siginfo_common_t,
     sigfault: siginfo_sigfault_t,
 }
@@ -85,7 +83,7 @@ union siginfo_fields_t {
 impl siginfo_fields_t {
     fn zero_fields() -> Self {
         Self {
-            bytes: [0; 128 - mem::size_of::<i32>() * 4],
+            bytes: [0; 128 - size_of::<i32>() * 4],
         }
     }
 }

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -13,7 +13,7 @@ pub mod sig_queues;
 mod sig_stack;
 pub mod signals;
 
-use core::{mem, sync::atomic::Ordering};
+use core::sync::atomic::Ordering;
 
 use align_ext::AlignExt;
 use c_types::{siginfo_t, ucontext_t};
@@ -199,7 +199,7 @@ pub fn handle_user_signal(
     let user_space = ctx.user_space();
 
     // 1. Write siginfo_t
-    stack_pointer -= mem::size_of::<siginfo_t>() as u64;
+    stack_pointer -= size_of::<siginfo_t>() as u64;
     user_space.write_val(stack_pointer as _, &sig_info)?;
     let siginfo_addr = stack_pointer;
 

--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -38,7 +38,7 @@ pub fn sys_clone3(
         clong_args_addr,
         size
     );
-    if size != core::mem::size_of::<Clone3Args>() {
+    if size != size_of::<Clone3Args>() {
         return_errno_with_message!(Errno::EINVAL, "invalid size");
     }
 

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 // See: https://elixir.bootlin.com/linux/v6.11.5/source/fs/eventpoll.c#L2437
-const EP_MAX_EVENTS: usize = i32::MAX as usize / core::mem::size_of::<c_epoll_event>();
+const EP_MAX_EVENTS: usize = i32::MAX as usize / size_of::<c_epoll_event>();
 
 pub fn sys_epoll_create(size: i32, ctx: &Context) -> Result<SyscallReturn> {
     if size <= 0 {
@@ -152,7 +152,7 @@ fn do_epoll_pwait2(
     for epoll_event in epoll_events.iter() {
         let c_epoll_event = c_epoll_event::from(epoll_event);
         user_space.write_val(write_addr, &c_epoll_event)?;
-        write_addr += core::mem::size_of::<c_epoll_event>();
+        write_addr += size_of::<c_epoll_event>();
     }
 
     Ok(epoll_events.len())

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -173,7 +173,7 @@ impl Pollable for EventFile {
 
 impl FileLike for EventFile {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        let read_len = core::mem::size_of::<u64>();
+        let read_len = size_of::<u64>();
 
         if writer.avail() < read_len {
             return_errno_with_message!(Errno::EINVAL, "buf len is less len u64 size");
@@ -189,7 +189,7 @@ impl FileLike for EventFile {
     }
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
-        let write_len = core::mem::size_of::<u64>();
+        let write_len = size_of::<u64>();
         if reader.remain() < write_len {
             return_errno_with_message!(Errno::EINVAL, "buf len is less than the size of u64");
         }

--- a/kernel/src/syscall/getdents64.rs
+++ b/kernel/src/syscall/getdents64.rs
@@ -124,8 +124,7 @@ struct DirentInner {
 impl DirentSerializer for Dirent {
     fn new(ino: u64, offset: u64, _type_: InodeType, name: CString) -> Self {
         let d_reclen = {
-            let len =
-                core::mem::size_of::<Dirent64Inner>() + name.as_c_str().to_bytes_with_nul().len();
+            let len = size_of::<Dirent64Inner>() + name.as_c_str().to_bytes_with_nul().len();
             align_up(len, 8) as u16
         };
         Self {
@@ -184,8 +183,7 @@ struct Dirent64Inner {
 impl DirentSerializer for Dirent64 {
     fn new(ino: u64, offset: u64, type_: InodeType, name: CString) -> Self {
         let d_reclen = {
-            let len =
-                core::mem::size_of::<Dirent64Inner>() + name.as_c_str().to_bytes_with_nul().len();
+            let len = size_of::<Dirent64Inner>() + name.as_c_str().to_bytes_with_nul().len();
             align_up(len, 8) as u16
         };
         let d_type = DirentType::from(type_) as u8;

--- a/kernel/src/syscall/getgroups.rs
+++ b/kernel/src/syscall/getgroups.rs
@@ -26,7 +26,7 @@ pub fn sys_getgroups(size: i32, group_list_addr: Vaddr, ctx: &Context) -> Result
 
     let user_space = ctx.user_space();
     for (idx, gid) in groups.iter().enumerate() {
-        let addr = group_list_addr + idx * core::mem::size_of_val(gid);
+        let addr = group_list_addr + idx * size_of_val(gid);
         user_space.write_val(addr, gid)?;
     }
 

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -50,7 +50,7 @@ pub fn do_sys_poll(
 
         for _ in 0..nfds {
             let c_poll_fd = user_space.read_val::<c_pollfd>(read_addr)?;
-            read_addr += core::mem::size_of::<c_pollfd>();
+            read_addr += size_of::<c_pollfd>();
 
             let poll_fd = PollFd::from(c_poll_fd);
             // Always clear the revents fields first
@@ -74,7 +74,7 @@ pub fn do_sys_poll(
         let c_poll_fd = c_pollfd::from(pollfd);
 
         user_space.write_val(write_addr, &c_poll_fd)?;
-        write_addr += core::mem::size_of::<c_pollfd>();
+        write_addr += size_of::<c_pollfd>();
     }
 
     Ok(SyscallReturn::Return(num_revents as _))

--- a/kernel/src/syscall/rt_sigsuspend.rs
+++ b/kernel/src/syscall/rt_sigsuspend.rs
@@ -22,7 +22,7 @@ pub fn sys_rt_sigsuspend(
         sigmask_addr, sigmask_size
     );
 
-    if sigmask_size != core::mem::size_of::<SigMask>() {
+    if sigmask_size != size_of::<SigMask>() {
         return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
     }
 

--- a/kernel/src/syscall/sched_affinity.rs
+++ b/kernel/src/syscall/sched_affinity.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{cmp, mem, sync::atomic::Ordering};
+use core::{cmp, sync::atomic::Ordering};
 
 use ostd::cpu::{num_cpus, CpuId, CpuSet};
 
@@ -59,7 +59,7 @@ pub fn sys_sched_setaffinity(
 // Linux uses `DECLARE_BITMAP` for `cpu_set_t`, inside which each part is a
 // `long`. We use the same scheme to ensure byte endianness compatibility.
 type Part = u64;
-const SIZE_OF_PART: usize = mem::size_of::<Part>();
+const SIZE_OF_PART: usize = size_of::<Part>();
 const CPUS_IN_PART: usize = SIZE_OF_PART * 8;
 
 fn read_cpu_set_from(

--- a/kernel/src/syscall/sched_getattr.rs
+++ b/kernel/src/syscall/sched_getattr.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::mem;
-
 use super::{
     sched_get_priority_max::{rt_to_static, static_to_rt, SCHED_PRIORITY_RANGE},
     SyscallReturn,
@@ -141,7 +139,7 @@ pub(super) fn read_linux_sched_attr_from_user(
     addr: Vaddr,
     ctx: &Context,
 ) -> Result<LinuxSchedAttr> {
-    let type_size = mem::size_of::<LinuxSchedAttr>();
+    let type_size = size_of::<LinuxSchedAttr>();
 
     let space = ctx.user_space();
 
@@ -149,7 +147,7 @@ pub(super) fn read_linux_sched_attr_from_user(
 
     space.read_bytes(
         addr,
-        &mut VmWriter::from(&mut attr.as_bytes_mut()[..mem::size_of::<u32>()]),
+        &mut VmWriter::from(&mut attr.as_bytes_mut()[..size_of::<u32>()]),
     )?;
 
     let size = type_size.min(attr.size as usize);
@@ -175,7 +173,7 @@ pub(super) fn write_linux_sched_attr_to_user(
 ) -> Result<()> {
     let space = ctx.user_space();
 
-    attr.size = (mem::size_of::<LinuxSchedAttr>() as u32).min(user_size);
+    attr.size = (size_of::<LinuxSchedAttr>() as u32).min(user_size);
 
     let range = SCHED_PRIORITY_RANGE
         .get(attr.sched_policy as usize)

--- a/kernel/src/syscall/select.rs
+++ b/kernel/src/syscall/select.rs
@@ -199,7 +199,7 @@ fn convert_events_to_rwe(events: IoEvents) -> Result<(bool, bool, bool)> {
 }
 
 const FD_SETSIZE: usize = 1024;
-const USIZE_BITS: usize = core::mem::size_of::<usize>() * 8;
+const USIZE_BITS: usize = usize::BITS as usize;
 
 #[derive(Debug, Clone, Copy, Pod)]
 #[repr(C)]

--- a/kernel/src/syscall/set_robust_list.rs
+++ b/kernel/src/syscall/set_robust_list.rs
@@ -13,7 +13,7 @@ pub fn sys_set_robust_list(
         robust_list_head_ptr, len
     );
 
-    if len != core::mem::size_of::<RobustListHead>() {
+    if len != size_of::<RobustListHead>() {
         return_errno_with_message!(
             Errno::EINVAL,
             "the length is not equal to the size of the robust list head"

--- a/kernel/src/syscall/setgroups.rs
+++ b/kernel/src/syscall/setgroups.rs
@@ -14,7 +14,7 @@ pub fn sys_setgroups(size: usize, group_list_addr: Vaddr, ctx: &Context) -> Resu
 
     let mut new_groups = BTreeSet::new();
     for idx in 0..size {
-        let addr = group_list_addr + idx * core::mem::size_of::<Gid>();
+        let addr = group_list_addr + idx * size_of::<Gid>();
         let gid = ctx.user_space().read_val(addr)?;
         new_groups.insert(gid);
     }

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -55,7 +55,7 @@ pub fn sys_signalfd4(
         fd, mask_ptr, sizemask, flags
     );
 
-    if sizemask != core::mem::size_of::<SigMask>() {
+    if sizemask != size_of::<SigMask>() {
         return Err(Error::with_message(Errno::EINVAL, "invalid mask size"));
     }
 
@@ -216,7 +216,7 @@ impl SignalFile {
 
         // Mask is inverted to get the signals that are not blocked
         let mask = !self.signals_mask.load(Ordering::Relaxed);
-        let max_signals = writer.avail() / core::mem::size_of::<SignalfdSiginfo>();
+        let max_signals = writer.avail() / size_of::<SignalfdSiginfo>();
         let mut count = 0;
 
         for _ in 0..max_signals {
@@ -233,7 +233,7 @@ impl SignalFile {
         if count == 0 {
             return_errno!(Errno::EAGAIN);
         }
-        Ok(count * core::mem::size_of::<SignalfdSiginfo>())
+        Ok(count * size_of::<SignalfdSiginfo>())
     }
 }
 
@@ -261,7 +261,7 @@ impl Pollable for SignalFile {
 
 impl FileLike for SignalFile {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        if writer.avail() < core::mem::size_of::<SignalfdSiginfo>() {
+        if writer.avail() < size_of::<SignalfdSiginfo>() {
             return_errno_with_message!(Errno::EINVAL, "Buffer too small for siginfo structure");
         }
 

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -214,7 +214,7 @@ fn read_time_from_user<T: Pod>(time_ptr: Vaddr, ctx: &Context) -> Result<(T, T)>
     let mut time_addr = time_ptr;
     let user_space = ctx.user_space();
     let autime = user_space.read_val::<T>(time_addr)?;
-    time_addr += core::mem::size_of::<T>();
+    time_addr += size_of::<T>();
     let mutime = user_space.read_val::<T>(time_addr)?;
     Ok((autime, mutime))
 }

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -113,7 +113,7 @@ impl Pollable for TimerfdFile {
 
 impl FileLike for TimerfdFile {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        let read_len = core::mem::size_of::<u64>();
+        let read_len = size_of::<u64>();
 
         if writer.avail() < read_len {
             return_errno_with_message!(Errno::EINVAL, "buf len is less len u64 size");

--- a/kernel/src/util/iovec.rs
+++ b/kernel/src/util/iovec.rs
@@ -90,10 +90,8 @@ fn copy_iovs_and_convert<'a, T: 'a>(
 
     for idx in 0..count {
         let mut iov = {
-            let addr = start_addr + idx * core::mem::size_of::<UserIoVec>();
-            let uiov: UserIoVec = vm_space
-                .reader(addr, core::mem::size_of::<UserIoVec>())?
-                .read_val()?;
+            let addr = start_addr + idx * size_of::<UserIoVec>();
+            let uiov: UserIoVec = vm_space.reader(addr, size_of::<UserIoVec>())?.read_val()?;
             IoVec::try_from(uiov)?
         };
 

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -93,13 +93,13 @@ impl RawSocketOption for PeerGroups {
         let groups = self.get().unwrap();
 
         let old_len = *buffer_len;
-        *buffer_len = (groups.len() * core::mem::size_of::<Gid>()) as u32;
+        *buffer_len = (groups.len() * size_of::<Gid>()) as u32;
         if old_len < *buffer_len {
             return_errno_with_message!(Errno::ERANGE, "the buffer is too small");
         }
 
         for (i, gid) in groups.iter().enumerate() {
-            let dst = addr + i * core::mem::size_of::<Gid>();
+            let dst = addr + i * size_of::<Gid>();
             current_userspace!().write_val(dst, gid)?;
         }
 

--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -41,7 +41,7 @@ macro_rules! impl_read_write_for_32bit_type {
     ($pod_ty: ty) => {
         impl ReadFromUser for $pod_ty {
             fn read_from_user(addr: Vaddr, max_len: u32) -> Result<Self> {
-                if (max_len as usize) < core::mem::size_of::<$pod_ty>() {
+                if (max_len as usize) < size_of::<$pod_ty>() {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
                 }
                 crate::current_userspace!().read_val::<$pod_ty>(addr)
@@ -50,7 +50,7 @@ macro_rules! impl_read_write_for_32bit_type {
 
         impl WriteToUser for $pod_ty {
             fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-                let write_len = core::mem::size_of::<$pod_ty>();
+                let write_len = size_of::<$pod_ty>();
 
                 if (max_len as usize) < write_len {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
@@ -121,7 +121,7 @@ impl WriteToUser for IpTtl {
 
 impl WriteToUser for Option<Error> {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = core::mem::size_of::<i32>();
+        let write_len = size_of::<i32>();
 
         if (max_len as usize) < write_len {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
@@ -139,7 +139,7 @@ impl WriteToUser for Option<Error> {
 
 impl ReadFromUser for LingerOption {
     fn read_from_user(addr: Vaddr, max_len: u32) -> Result<Self> {
-        if (max_len as usize) < core::mem::size_of::<CLinger>() {
+        if (max_len as usize) < size_of::<CLinger>() {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
         }
 
@@ -151,7 +151,7 @@ impl ReadFromUser for LingerOption {
 
 impl WriteToUser for LingerOption {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = core::mem::size_of::<CLinger>();
+        let write_len = size_of::<CLinger>();
 
         if (max_len as usize) < write_len {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");
@@ -229,7 +229,7 @@ impl From<CLinger> for LingerOption {
 
 impl WriteToUser for CUserCred {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = core::mem::size_of::<CUserCred>();
+        let write_len = size_of::<CUserCred>();
 
         if (max_len as usize) < write_len {
             return_errno_with_message!(Errno::EINVAL, "max_len is too short");

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -68,7 +68,7 @@ pub type RbProducer<T> = Producer<T, Arc<RingBuffer<T>>>;
 pub type RbConsumer<T> = Consumer<T, Arc<RingBuffer<T>>>;
 
 impl<T> RingBuffer<T> {
-    const T_SIZE: usize = core::mem::size_of::<T>();
+    const T_SIZE: usize = size_of::<T>();
 
     /// Creates a new [`RingBuffer`] with the given capacity.
     pub fn new(capacity: usize) -> Self {
@@ -246,7 +246,7 @@ impl RingBuffer<u8> {
 }
 
 impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
-    const T_SIZE: usize = core::mem::size_of::<T>();
+    const T_SIZE: usize = size_of::<T>();
 
     /// Pushes an item to the `RingBuffer`.
     ///
@@ -362,7 +362,7 @@ impl<T, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
 }
 
 impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
-    const T_SIZE: usize = core::mem::size_of::<T>();
+    const T_SIZE: usize = size_of::<T>();
 
     /// Pops an item from the `RingBuffer`.
     ///

--- a/osdk/deps/heap-allocator/src/cpu_local_allocator.rs
+++ b/osdk/deps/heap-allocator/src/cpu_local_allocator.rs
@@ -98,7 +98,7 @@ static ALLOCATOR_32: CpuLocalAllocator<32> = CpuLocalAllocator::new();
 ///
 /// Currently, the size of `T` must be no larger than 32 bytes.
 pub fn alloc_cpu_local<T>(mut init_values: impl FnMut(CpuId) -> T) -> Result<CpuLocalBox<T>> {
-    let size = core::mem::size_of::<T>();
+    let size = size_of::<T>();
     let class = CommonSizeClass::from_size(size).ok_or(Error::InvalidArgs)?;
     let cpu_local = match class {
         CommonSizeClass::Bytes8 => ALLOCATOR_8.alloc::<T>(&mut init_values),
@@ -115,7 +115,7 @@ pub fn alloc_cpu_local<T>(mut init_values: impl FnMut(CpuId) -> T) -> Result<Cpu
 
 /// Deallocates a dynamically-allocated CPU-local object of type `T`.
 fn dealloc_cpu_local<T>(cpu_local: DynamicCpuLocal<T>) {
-    let size = core::mem::size_of::<T>();
+    let size = size_of::<T>();
     let class = CommonSizeClass::from_size(size).unwrap();
     match class {
         CommonSizeClass::Bytes8 => ALLOCATOR_8.dealloc(cpu_local),

--- a/ostd/libs/linux-bzimage/boot-params/src/lib.rs
+++ b/ostd/libs/linux-bzimage/boot-params/src/lib.rs
@@ -49,7 +49,7 @@ pub struct BootParams {
     pub sentinel: u8,                   /* 0x1ef */
     pub _pad6: [u8; 1],                 /* 0x1f0 */
     pub hdr: SetupHeader,               /* setup header 0x1f1 */
-    pub _pad7: [u8; 0x290 - 0x1f1 - core::mem::size_of::<SetupHeader>()],
+    pub _pad7: [u8; 0x290 - 0x1f1 - size_of::<SetupHeader>()],
     pub edd_mbr_sig_buffer: [u32; EDD_MBR_SIG_MAX], /* 0x290 */
     pub e820_table: [BootE820Entry; E820_MAX_ENTRIES_ZEROPAGE], /* 0x2d0 */
     pub _pad8: [u8; 48],                            /* 0xcd0 */

--- a/ostd/libs/linux-bzimage/builder/src/pe_header.rs
+++ b/ostd/libs/linux-bzimage/builder/src/pe_header.rs
@@ -8,7 +8,7 @@
 //! The reference to the Linux PE header definition:
 //! <https://github.com/torvalds/linux/blob/master/include/linux/pe.h>
 
-use std::{mem::size_of, vec};
+use std::vec;
 
 use align_ext::AlignExt;
 use bytemuck::{Pod, Zeroable};

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -45,7 +45,7 @@ extern "sysv64" fn main_efi_common64(
 
 fn allocate_boot_params() -> &'static mut BootParams {
     let boot_params = {
-        let bytes = alloc_pages(AllocateType::AnyPages, core::mem::size_of::<BootParams>());
+        let bytes = alloc_pages(AllocateType::AnyPages, size_of::<BootParams>());
         MaybeUninit::fill(bytes, 0);
         // SAFETY: Zero initialization gives a valid representation for `BootParams`.
         unsafe { &mut *bytes.as_mut_ptr().cast::<BootParams>() }

--- a/ostd/libs/linux-bzimage/setup/src/x86/legacy_i386/alloc.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/legacy_i386/alloc.rs
@@ -37,7 +37,7 @@ pub(super) unsafe fn init(boot_params: &'static linux_boot_params::BootParams) {
 
     used[1] = range_from_start_and_len(
         core::ptr::from_ref(boot_params).addr(),
-        core::mem::size_of::<linux_boot_params::BootParams>(),
+        size_of::<linux_boot_params::BootParams>(),
     );
     // No need to worry about `ext_*` addresses/sizes since we're 32-bit.
     used[2] = range_from_start_and_len(

--- a/ostd/libs/ostd-test/src/lib.rs
+++ b/ostd/libs/ostd-test/src/lib.rs
@@ -185,7 +185,7 @@ macro_rules! ktest_array {
             fn __ktest_array();
             fn __ktest_array_end();
         }
-        let item_size = core::mem::size_of::<KtestItem>();
+        let item_size = size_of::<KtestItem>();
         let l = (__ktest_array_end as usize - __ktest_array as usize) / item_size;
         // SAFETY: __ktest_array is a static section consisting of KtestItem.
         unsafe { core::slice::from_raw_parts(__ktest_array as *const KtestItem, l) }

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -24,7 +24,7 @@ impl PagingConstsTrait for PagingConsts {
     const VA_SIGN_EXT: bool = true;
     // TODO: Support huge page
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 1;
-    const PTE_SIZE: usize = core::mem::size_of::<PageTableEntry>();
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -24,7 +24,7 @@ impl PagingConstsTrait for PagingConsts {
     const ADDRESS_WIDTH: usize = 48;
     const VA_SIGN_EXT: bool = true;
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 4;
-    const PTE_SIZE: usize = core::mem::size_of::<PageTableEntry>();
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {

--- a/ostd/src/arch/x86/ex_table.rs
+++ b/ostd/src/arch/x86/ex_table.rs
@@ -62,8 +62,7 @@ impl ExTable {
     /// if the exception handling fails and there is a predefined recovery action,
     /// then the found recovery action will be taken.
     pub fn find_recovery_inst_addr(inst_addr: Vaddr) -> Option<Vaddr> {
-        let table_size =
-            (__ex_table_end as usize - __ex_table as usize) / core::mem::size_of::<ExTableItem>();
+        let table_size = (__ex_table_end as usize - __ex_table as usize) / size_of::<ExTableItem>();
         // SAFETY: `__ex_table` is a static section consisting of `ExTableItem`.
         let ex_table =
             unsafe { core::slice::from_raw_parts(__ex_table as *const ExTableItem, table_size) };

--- a/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
@@ -3,7 +3,6 @@
 #![expect(dead_code)]
 
 use alloc::collections::BTreeMap;
-use core::mem::size_of;
 
 use log::trace;
 use ostd_pod::Pod;

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -48,7 +48,7 @@ impl PagingConstsTrait for PagingConsts {
     const ADDRESS_WIDTH: usize = 39;
     const VA_SIGN_EXT: bool = true;
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 1;
-    const PTE_SIZE: usize = core::mem::size_of::<PageTableEntry>();
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{fmt::Debug, mem::size_of};
+use core::fmt::Debug;
 
 use bitflags::bitflags;
 use id_alloc::IdAlloc;

--- a/ostd/src/arch/x86/iommu/invalidate/queue.rs
+++ b/ostd/src/arch/x86/iommu/invalidate/queue.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::mem::size_of;
-
 use crate::{
     mm::{FrameAllocOptions, Segment, VmIo, PAGE_SIZE},
     prelude::*,

--- a/ostd/src/arch/x86/kernel/acpi/dmar.rs
+++ b/ostd/src/arch/x86/kernel/acpi/dmar.rs
@@ -93,7 +93,7 @@ impl Dmar {
             )
         };
 
-        let mut index = core::mem::size_of::<DmarHeader>();
+        let mut index = size_of::<DmarHeader>();
         let mut remapping_structures = Vec::new();
         while index != (header.header.length as usize) {
             // CommonHeader { type: u16, length: u16 }

--- a/ostd/src/arch/x86/kernel/acpi/remapping.rs
+++ b/ostd/src/arch/x86/kernel/acpi/remapping.rs
@@ -193,7 +193,7 @@ macro_rules! impl_from_bytes {
                 let header = $header_struct::from_bytes(bytes);
                 debug_assert_eq!(header.length as usize, bytes.len());
 
-                let mut index = core::mem::size_of::<$header_struct>();
+                let mut index = size_of::<$header_struct>();
                 let mut device_scopes = Vec::new();
                 while index != (header.length as usize) {
                     let val = DeviceScope::from_bytes_prefix(&bytes[index..]);
@@ -228,7 +228,7 @@ impl DeviceScope {
         let header = DeviceScopeHeader::from_bytes(bytes);
         debug_assert!((header.length as usize) <= bytes.len());
 
-        let mut index = core::mem::size_of::<DeviceScopeHeader>();
+        let mut index = size_of::<DeviceScopeHeader>();
         debug_assert!((header.length as usize) >= index);
 
         let mut path = Vec::new();
@@ -266,7 +266,7 @@ impl Andd {
         let header = AnddHeader::from_bytes(bytes);
         debug_assert_eq!(header.length as usize, bytes.len());
 
-        let header_len = core::mem::size_of::<AnddHeader>();
+        let header_len = size_of::<AnddHeader>();
         let acpi_object_name = core::str::from_utf8(&bytes[header_len..])
             .unwrap()
             .to_owned();

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -33,7 +33,7 @@ impl PagingConstsTrait for PagingConsts {
     const ADDRESS_WIDTH: usize = 48;
     const VA_SIGN_EXT: bool = true;
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 2;
-    const PTE_SIZE: usize = core::mem::size_of::<PageTableEntry>();
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {

--- a/ostd/src/arch/x86/trap/gdt.rs
+++ b/ostd/src/arch/x86/trap/gdt.rs
@@ -59,7 +59,7 @@ pub(super) unsafe fn init() {
 
     // Load the new GDT.
     let gdtr = DescriptorTablePointer {
-        limit: (core::mem::size_of_val(gdt) - 1) as u16,
+        limit: (size_of_val(gdt) - 1) as u16,
         base: VirtAddr::new(gdt.as_ptr().addr() as u64),
     };
     // SAFETY: The GDT is valid to load because:

--- a/ostd/src/arch/x86/trap/idt.rs
+++ b/ostd/src/arch/x86/trap/idt.rs
@@ -55,7 +55,7 @@ pub(super) fn init() {
     });
 
     let idtr = DescriptorTablePointer {
-        limit: (core::mem::size_of_val(idt) - 1) as u16,
+        limit: (size_of_val(idt) - 1) as u16,
         base: VirtAddr::new(idt.as_ptr().addr() as u64),
     };
     // SAFETY: The IDT is valid to load because:

--- a/ostd/src/bus/pci/cfg_space.rs
+++ b/ostd/src/bus/pci/cfg_space.rs
@@ -5,7 +5,6 @@
 //! Reference: <https://wiki.osdev.org/PCI>
 
 use alloc::sync::Arc;
-use core::mem::size_of;
 
 use bitflags::bitflags;
 

--- a/ostd/src/cpu/local/cell.rs
+++ b/ostd/src/cpu/local/cell.rs
@@ -116,7 +116,7 @@ impl<T: 'static> CpuLocalCell<T> {
             let bsp_va = self as *const _ as usize;
             let bsp_base = __cpu_local_start as usize;
             // The implementation should ensure that the CPU-local object resides in the `.cpu_local`.
-            debug_assert!(bsp_va + core::mem::size_of::<T>() <= __cpu_local_end as usize);
+            debug_assert!(bsp_va + size_of::<T>() <= __cpu_local_end as usize);
 
             bsp_va - bsp_base as usize
         };
@@ -125,7 +125,7 @@ impl<T: 'static> CpuLocalCell<T> {
         let local_va = local_base + offset;
 
         // A sanity check about the alignment.
-        debug_assert_eq!(local_va % core::mem::align_of::<T>(), 0);
+        debug_assert_eq!(local_va % align_of::<T>(), 0);
 
         local_va as *mut T
     }

--- a/ostd/src/cpu/local/dyn_cpu_local.rs
+++ b/ostd/src/cpu/local/dyn_cpu_local.rs
@@ -158,8 +158,8 @@ impl<const ITEM_SIZE: usize> DynCpuLocalChunk<ITEM_SIZE> {
     ) -> Option<CpuLocal<T, DynamicStorage<T>>> {
         const {
             assert!(ITEM_SIZE.is_power_of_two());
-            assert!(core::mem::size_of::<T>() <= ITEM_SIZE);
-            assert!(core::mem::align_of::<T>() <= ITEM_SIZE);
+            assert!(size_of::<T>() <= ITEM_SIZE);
+            assert!(align_of::<T>() <= ITEM_SIZE);
         }
 
         let index = self.bitmap.first_zero()?;

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -209,7 +209,7 @@ pub(crate) unsafe fn copy_bsp_for_ap(num_cpus: usize) {
 
     // Allocate a region to store the pointers to the CPU-local storage segments.
     let res = {
-        let size = core::mem::size_of::<Paddr>()
+        let size = size_of::<Paddr>()
             .checked_mul(num_aps)
             .unwrap()
             .align_up(PAGE_SIZE);

--- a/ostd/src/cpu/local/static_cpu_local.rs
+++ b/ostd/src/cpu/local/static_cpu_local.rs
@@ -80,7 +80,7 @@ impl<T: 'static> StaticStorage<T> {
         let local_va = local_base + offset;
 
         // A sanity check about the alignment.
-        debug_assert_eq!(local_va % core::mem::align_of::<T>(), 0);
+        debug_assert_eq!(local_va % align_of::<T>(), 0);
 
         local_va as *const T
     }
@@ -90,7 +90,7 @@ impl<T: 'static> StaticStorage<T> {
         let bsp_va = self as *const _ as usize;
         let bsp_base = __cpu_local_start as usize;
         // The implementation should ensure that the CPU-local object resides in the `.cpu_local`.
-        debug_assert!(bsp_va + core::mem::size_of::<T>() <= __cpu_local_end as usize);
+        debug_assert!(bsp_va + size_of::<T>() <= __cpu_local_end as usize);
 
         bsp_va - bsp_base
     }

--- a/ostd/src/cpu/set.rs
+++ b/ostd/src/cpu/set.rs
@@ -18,7 +18,7 @@ pub struct CpuSet {
 
 type InnerPart = u64;
 
-const BITS_PER_PART: usize = core::mem::size_of::<InnerPart>() * 8;
+const BITS_PER_PART: usize = InnerPart::BITS as usize;
 const NR_PARTS_NO_ALLOC: usize = 2;
 
 const fn part_idx(cpu_id: CpuId) -> usize {
@@ -159,7 +159,7 @@ pub struct AtomicCpuSet {
 }
 
 type AtomicInnerPart = AtomicU64;
-const_assert!(core::mem::size_of::<AtomicInnerPart>() * 8 == BITS_PER_PART);
+const_assert!(size_of::<AtomicInnerPart>() * 8 == BITS_PER_PART);
 
 impl AtomicCpuSet {
     /// Creates a new `AtomicCpuSet` with an initial value.

--- a/ostd/src/io/io_port/mod.rs
+++ b/ostd/src/io/io_port/mod.rs
@@ -5,7 +5,7 @@
 use crate::arch::device::io_port::{IoPortReadAccess, IoPortWriteAccess, PortRead, PortWrite};
 mod allocator;
 
-use core::{marker::PhantomData, mem::size_of};
+use core::marker::PhantomData;
 
 pub(super) use self::allocator::init;
 use crate::{prelude::*, Error};

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -51,7 +51,7 @@ unsafe impl<M: AnyFrameMeta + ?Sized> NonNullPtr for Frame<M> {
     where
         Self: 'a;
 
-    const ALIGN_BITS: u32 = core::mem::align_of::<MetaSlot>().trailing_zeros();
+    const ALIGN_BITS: u32 = align_of::<MetaSlot>().trailing_zeros();
 
     fn into_raw(self) -> NonNull<Self::Target> {
         let ptr = NonNull::new(self.ptr.cast_mut()).unwrap();

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -19,8 +19,6 @@ pub(crate) mod mapping {
     //! The metadata of each physical page is linear mapped to fixed virtual addresses
     //! in [`FRAME_METADATA_RANGE`].
 
-    use core::mem::size_of;
-
     use super::MetaSlot;
     use crate::mm::{kspace::FRAME_METADATA_RANGE, Paddr, PagingConstsTrait, Vaddr, PAGE_SIZE};
 
@@ -171,11 +169,9 @@ macro_rules! impl_frame_meta_for {
         // SAFETY: `on_drop` won't read the page.
         unsafe impl $crate::mm::frame::meta::AnyFrameMeta for $t {}
 
+        $crate::const_assert!(size_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_SIZE);
         $crate::const_assert!(
-            core::mem::size_of::<$t>() <= $crate::mm::frame::meta::FRAME_METADATA_MAX_SIZE
-        );
-        $crate::const_assert!(
-            $crate::mm::frame::meta::FRAME_METADATA_MAX_ALIGN % core::mem::align_of::<$t>() == 0
+            $crate::mm::frame::meta::FRAME_METADATA_MAX_ALIGN % align_of::<$t>() == 0
         );
     };
 }

--- a/ostd/src/mm/heap/slab.rs
+++ b/ostd/src/mm/heap/slab.rs
@@ -87,7 +87,7 @@ impl<const SLOT_SIZE: usize> Slab<SLOT_SIZE> {
     pub fn new() -> crate::prelude::Result<Self> {
         const { assert!(SLOT_SIZE <= PAGE_SIZE) };
         // To ensure we can store a pointer in each slot.
-        const { assert!(SLOT_SIZE >= core::mem::size_of::<usize>()) };
+        const { assert!(SLOT_SIZE >= size_of::<usize>()) };
         // To ensure `nr_allocated` can be stored in a `u16`.
         const { assert!(PAGE_SIZE / SLOT_SIZE <= u16::MAX as usize) };
 

--- a/ostd/src/mm/heap/slot_list.rs
+++ b/ostd/src/mm/heap/slot_list.rs
@@ -50,7 +50,7 @@ impl<const SLOT_SIZE: usize> SlabSlotList<SLOT_SIZE> {
         };
 
         assert_eq!(slot_size, SLOT_SIZE);
-        const { assert!(SLOT_SIZE >= core::mem::size_of::<usize>()) };
+        const { assert!(SLOT_SIZE >= size_of::<usize>()) };
 
         let original_head = self.head;
 

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -83,7 +83,7 @@ mod test_utils {
         const ADDRESS_WIDTH: usize = 48;
         const VA_SIGN_EXT: bool = true;
         const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 3;
-        const PTE_SIZE: usize = core::mem::size_of::<PageTableEntry>();
+        const PTE_SIZE: usize = size_of::<PageTableEntry>();
     }
 
     #[derive(Clone, Debug)]

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::vec;
-use core::mem::size_of;
 
 use ostd_pod::Pod;
 

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -110,7 +110,7 @@ unsafe impl<T: 'static> NonNullPtr for Box<T> {
     where
         Self: 'a;
 
-    const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
+    const ALIGN_BITS: u32 = align_of::<T>().trailing_zeros();
 
     fn into_raw(self) -> NonNull<Self::Target> {
         let ptr = Box::into_raw(self);
@@ -172,7 +172,7 @@ unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     where
         Self: 'a;
 
-    const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
+    const ALIGN_BITS: u32 = align_of::<T>().trailing_zeros();
 
     fn into_raw(self) -> NonNull<Self::Target> {
         let ptr = Arc::into_raw(self).cast_mut();


### PR DESCRIPTION
[`size_of` and `align_of` are in the prelude since Rust 1.80](https://github.com/rust-lang/rust/releases/tag/1.80.0)

This PR contains changes that are generated from
```
sed -i 's|core::mem::align_of|align_of|g' **/*.rs
sed -i 's|core::mem::size_of|size_of|g' **/*.rs
sed -i 's|mem::align_of|align_of|g' **/*.rs
sed -i 's|mem::size_of|size_of|g' **/*.rs
```
with some fixes to make the compiler happy (e.g., remove some unused imports).

