### PR TITLE
Fix futex awakening reason detection

### DIFF
--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -164,7 +164,7 @@ pub fn sem_op(
 
     // Prepare to wait
     let status = pending_op.status.clone();
-    let (waiter, waker) = Waiter::new_pair();
+    let (waiter, waker) = Waiter::new_pair_default();
 
     // Check if timeout exists to avoid calling `Arc::clone()`
     if let Some(timeout) = timeout {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -74,6 +74,7 @@ mod syscall;
 mod thread;
 mod time;
 mod util;
+mod wait;
 // TODO: Add vDSO support for other architectures.
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 mod vdso;

--- a/kernel/src/net/iface/sched.rs
+++ b/kernel/src/net/iface/sched.rs
@@ -5,12 +5,14 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use aster_bigtcp::iface::ScheduleNextPoll;
 use ostd::sync::WaitQueue;
 
+use crate::wait::SigTimeoutWaitQueue;
+
 pub struct PollScheduler {
     /// The time when we should do the next poll.
     /// We store the total number of milliseconds since the system booted.
     next_poll_at_ms: AtomicU64,
     /// The wait queue that the background polling thread will sleep on.
-    polling_wait_queue: WaitQueue,
+    polling_wait_queue: SigTimeoutWaitQueue,
 }
 
 impl PollScheduler {
@@ -30,7 +32,7 @@ impl PollScheduler {
         }
     }
 
-    pub(super) fn polling_wait_queue(&self) -> &WaitQueue {
+    pub(super) fn polling_wait_queue(&self) -> &SigTimeoutWaitQueue {
         &self.polling_wait_queue
     }
 }

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     prelude::*,
     process::signal::Pollee,
+    wait::SigTimeoutWaitQueue,
 };
 
 pub(super) struct Listener {
@@ -160,7 +161,7 @@ pub(super) struct Backlog {
     pollee: Pollee,
     backlog: AtomicUsize,
     incoming_conns: SpinLock<Option<VecDeque<Connected>>>,
-    wait_queue: WaitQueue,
+    wait_queue: SigTimeoutWaitQueue,
     listener_cred: SocketCred<ReadDupOp>,
     is_seqpacket: bool,
 }

--- a/kernel/src/process/process/job_control.rs
+++ b/kernel/src/process/process/job_control.rs
@@ -3,7 +3,7 @@
 use ostd::sync::{LocalIrqDisabled, WaitQueue};
 
 use super::{ProcessGroup, Session};
-use crate::prelude::*;
+use crate::{prelude::*, wait::SigTimeoutWaitQueue};
 
 /// The job control for terminals like TTY and PTY.
 ///
@@ -13,7 +13,7 @@ use crate::prelude::*;
 /// for a terminal.
 pub struct JobControl {
     inner: SpinLock<Inner, LocalIrqDisabled>,
-    wait_queue: WaitQueue,
+    wait_queue: SigTimeoutWaitQueue,
 }
 
 #[derive(Default)]

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     sched::{AtomicNice, Nice},
     thread::{AsThread, Thread},
     time::clocks::ProfClock,
+    wait::SigTimeoutWaitQueue,
 };
 
 mod init_proc;
@@ -70,7 +71,7 @@ pub struct Process {
 
     process_vm: ProcessVm,
     /// Wait for child status changed
-    children_wait_queue: WaitQueue,
+    children_wait_queue: SigTimeoutWaitQueue,
     pub(super) pidfile_pollee: Pollee,
 
     // Mutable Part
@@ -301,7 +302,7 @@ impl Process {
         &self.children
     }
 
-    pub fn children_wait_queue(&self) -> &WaitQueue {
+    pub fn children_wait_queue(&self) -> &SigTimeoutWaitQueue {
         &self.children_wait_queue
     }
 

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -5,15 +5,13 @@ use core::{
     time::Duration,
 };
 
-use ostd::{
-    sync::{Waiter, Waker},
-    task::Task,
-};
+use ostd::{sync::Waiter, task::Task};
 
 use crate::{
     events::{IoEvents, Observer, Subject},
     prelude::*,
     time::wait::TimeoutExt,
+    wait::{SigTimeoutWaiter, SigTimeoutWaker},
 };
 
 /// A pollee represents any I/O object (e.g., a file or socket) that can be polled.
@@ -275,7 +273,7 @@ impl<O> PollAdaptor<O> {
 /// A poller that can be used to wait for some events.
 pub struct Poller {
     poller: PollHandle,
-    waiter: Waiter,
+    waiter: SigTimeoutWaiter,
     timeout: TimeoutExt<'static>,
 }
 
@@ -315,7 +313,7 @@ impl Poller {
     }
 }
 
-impl Observer<IoEvents> for Waker {
+impl Observer<IoEvents> for SigTimeoutWaker {
     fn on_events(&self, _events: &IoEvents) {
         self.wake_up();
     }

--- a/kernel/src/process/sync/condvar.rs
+++ b/kernel/src/process/sync/condvar.rs
@@ -8,7 +8,7 @@ use core::time::Duration;
 
 use ostd::sync::{MutexGuard, SpinLock, WaitQueue};
 
-use crate::time::wait::WaitTimeout;
+use crate::{time::wait::WaitTimeout, wait::SigTimeoutWaitQueue};
 
 /// Represents potential errors during lock operations on synchronization primitives,
 /// specifically for operations associated with a `Condvar` (Condition Variable).
@@ -83,7 +83,7 @@ impl<Guard> LockErr<Guard> {
 /// The main thread waits for the flag to be set to `true`,
 /// utilizing the `Condvar` to sleep efficiently until the condition is met.
 pub struct Condvar {
-    waitqueue: Arc<WaitQueue>,
+    waitqueue: Arc<SigTimeoutWaitQueue>,
     counter: SpinLock<Inner>,
 }
 

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -30,6 +30,7 @@ use crate::{
         Gid, Uid,
     },
     time::clocks::RealTimeClock,
+    wait::SigTimeoutWaitQueue,
 };
 
 pub fn sys_eventfd(init_val: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -78,7 +79,7 @@ struct EventFile {
     counter: Mutex<u64>,
     pollee: Pollee,
     flags: Mutex<Flags>,
-    write_wait_queue: WaitQueue,
+    write_wait_queue: SigTimeoutWaitQueue,
 }
 
 impl EventFile {

--- a/kernel/src/wait.rs
+++ b/kernel/src/wait.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::sync::{WaitQueue, Waiter, Waker};
+
+/// Reason for waking from a signal or timeout capable wait.
+pub enum SigTimeoutWake {
+    /// Woken by signal delivery.
+    Signal,
+    /// Woken by timeout expiration.
+    Timeout,
+}
+
+/// Waker for signal/timeout waits.
+pub type SigTimeoutWaker = Waker<SigTimeoutWake>;
+
+/// Waiter for signal/timeout waits.
+pub type SigTimeoutWaiter = Waiter<SigTimeoutWake>;
+
+/// Wait queue for signal/timeout scenarios.
+pub type SigTimeoutWaitQueue = WaitQueue<SigTimeoutWake>;


### PR DESCRIPTION
This patch enhances `Waiter` and `Waker` with the possibility of waking up with an associated "wake up reason".

With this change, it becomes easy to return appropriate errors in Asterinas. In particular, this patch focuses on resolving the return of `futex_wait_bitset`.

Closes #2393