### PR TITLE
Add `/proc/pid/oom_score_adj`

### DIFF
--- a/kernel/src/fs/procfs/cmdline.rs
+++ b/kernel/src/fs/procfs/cmdline.rs
@@ -12,7 +12,7 @@ use ostd::boot::boot_info;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -23,7 +23,13 @@ pub struct CmdLineFileOps;
 impl CmdLineFileOps {
     /// Create a new inode for `/proc/cmdline`.
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/cmdline.c#L19>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L549-L550>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/cpuinfo.rs
+++ b/kernel/src/fs/procfs/cpuinfo.rs
@@ -16,7 +16,7 @@ use crate::{
     arch::cpu::CpuInformation,
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -27,7 +27,13 @@ pub struct CpuInfoFileOps;
 impl CpuInfoFileOps {
     /// Creates a new inode for `/proc/cpuinfo`.
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/cpuinfo.c#L25>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L549-L550>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/filesystems.rs
+++ b/kernel/src/fs/procfs/filesystems.rs
@@ -6,7 +6,7 @@ use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
         registry::FsProperties,
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -16,7 +16,13 @@ pub struct FileSystemsFileOps;
 
 impl FileSystemsFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/filesystems.c#L259>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L549-L550>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/loadavg.rs
+++ b/kernel/src/fs/procfs/loadavg.rs
@@ -10,7 +10,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread,
@@ -22,7 +22,13 @@ pub struct LoadAvgFileOps;
 
 impl LoadAvgFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/loadavg.c#L33>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L549-L550>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/meminfo.rs
+++ b/kernel/src/fs/procfs/meminfo.rs
@@ -11,7 +11,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -21,7 +21,13 @@ pub struct MemInfoFileOps;
 
 impl MemInfoFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/meminfo.c#L178>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L549-L550>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     fs::{
         procfs::filesystems::FileSystemsFileOps,
         registry::{FsProperties, FsType},
-        utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, SuperBlock, NAME_MAX},
+        utils::{DirEntryVecExt, FileSystem, FsFlags, Inode, InodeMode, SuperBlock, NAME_MAX},
     },
     prelude::*,
     process::{
@@ -120,7 +120,8 @@ struct RootDirOps;
 
 impl RootDirOps {
     pub fn new_inode(fs: Weak<ProcFs>) -> Arc<dyn Inode> {
-        let root_inode = ProcDirBuilder::new(Self)
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/root.c#L368>
+        let root_inode = ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
             .fs(fs)
             .ino(PROC_ROOT_INO)
             .build()

--- a/kernel/src/fs/procfs/pid/mod.rs
+++ b/kernel/src/fs/procfs/pid/mod.rs
@@ -9,7 +9,7 @@ use crate::{
             stat::StatFileOps,
             task::{TaskDirOps, TidDirOps},
         },
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
     process::{posix_thread::AsPosixThread, Process},
@@ -41,12 +41,17 @@ impl PidDirOps {
             .unwrap()
             .file_table();
 
-        let pid_inode = ProcDirBuilder::new(Self(tid_dir_ops.clone()))
-            .parent(parent)
-            // The pid directories must be volatile, because it is just associated with one process.
-            .volatile()
-            .build()
-            .unwrap();
+        let pid_inode = ProcDirBuilder::new(
+            Self(tid_dir_ops.clone()),
+            // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3493>
+            InodeMode::from_bits_truncate(0o555),
+        )
+        .parent(parent)
+        // The pid directories must be volatile, because it is just associated with one process.
+        .volatile()
+        .build()
+        .unwrap();
+
         // This is for an exiting process that has not yet been reaped by its parent,
         // whose file table may have already been released.
         if let Some(file_table_ref) = file_table.lock().as_ref() {

--- a/kernel/src/fs/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/task/cmdline.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::Process,
@@ -14,7 +14,8 @@ pub struct CmdlineFileOps(Arc<Process>);
 
 impl CmdlineFileOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self(process_ref))
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3340>
+        ProcFileBuilder::new(Self(process_ref), InodeMode::from_bits_truncate(0o444))
             .parent(parent)
             .build()
             .unwrap()

--- a/kernel/src/fs/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/procfs/pid/task/environ.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     Process,
@@ -14,7 +14,8 @@ pub struct EnvironFileOps(Arc<Process>);
 
 impl EnvironFileOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self(process_ref))
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3324>
+        ProcFileBuilder::new(Self(process_ref), InodeMode::from_bits_truncate(0o400))
             .parent(parent)
             .build()
             .unwrap()

--- a/kernel/src/fs/procfs/pid/task/exe.rs
+++ b/kernel/src/fs/procfs/pid/task/exe.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::Process,
@@ -14,7 +14,10 @@ pub struct ExeSymOps(Arc<Process>);
 
 impl ExeSymOps {
     pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcSymBuilder::new(Self(process_ref))
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3350>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L174-L175>
+        ProcSymBuilder::new(Self(process_ref), InodeMode::from_bits_truncate(0o777))
             .parent(parent)
             .build()
             .unwrap()

--- a/kernel/src/fs/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/procfs/pid/task/mod.rs
@@ -12,7 +12,8 @@ use crate::{
                 stat::StatFileOps,
                 task::{
                     cmdline::CmdlineFileOps, comm::CommFileOps, environ::EnvironFileOps,
-                    exe::ExeSymOps, fd::FdDirOps, status::StatusFileOps,
+                    exe::ExeSymOps, fd::FdDirOps, oom_score_adj::OomScoreAdjFileOps,
+                    status::StatusFileOps,
                 },
             },
             template::{DirOps, ProcDir, ProcDirBuilder},
@@ -29,6 +30,7 @@ mod comm;
 mod environ;
 mod exe;
 mod fd;
+mod oom_score_adj;
 mod status;
 
 /// Represents the inode at `/proc/[pid]/task`.
@@ -79,6 +81,7 @@ impl DirOps for TidDirOps {
             "environ" => EnvironFileOps::new_inode(self.process_ref.clone(), this_ptr),
             "exe" => ExeSymOps::new_inode(self.process_ref.clone(), this_ptr),
             "fd" => FdDirOps::new_inode(self.thread_ref.clone(), this_ptr),
+            "oom_score_adj" => OomScoreAdjFileOps::new_inode(self.process_ref.clone(), this_ptr),
             "stat" => StatFileOps::new_inode(
                 self.process_ref.clone(),
                 self.thread_ref.clone(),
@@ -125,6 +128,9 @@ impl TidDirOps {
         });
         cached_children.put_entry_if_not_found("fd", || {
             FdDirOps::new_inode(self.thread_ref.clone(), this_ptr.clone())
+        });
+        cached_children.put_entry_if_not_found("oom_score_adj", || {
+            OomScoreAdjFileOps::new_inode(self.process_ref.clone(), this_ptr.clone())
         });
         cached_children.put_entry_if_not_found("stat", || {
             StatFileOps::new_inode(

--- a/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{fmt::Write, sync::atomic::Ordering};
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{Inode, InodeMode},
+    },
+    prelude::*,
+    process::Process,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/oom_score_adj` (and also `/proc/[pid]/oom_score_adj`).
+pub struct OomScoreAdjFileOps(Arc<Process>);
+
+impl OomScoreAdjFileOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3386>
+        ProcFileBuilder::new(Self(process_ref), InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for OomScoreAdjFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let oom_score_adj = self.0.oom_score_adj().load(Ordering::Relaxed);
+
+        let mut output = String::new();
+        writeln!(output, "{}", oom_score_adj).unwrap();
+        Ok(output.into_bytes())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        // TODO: Extend the `ReadCString` trait to read a C string without
+        // requiring the nul terminator.
+        let (val, read_bytes) = read_i32_from(reader)?;
+        if !(OOM_SCORE_ADJ_MIN..=OOM_SCORE_ADJ_MAX).contains(&val) {
+            return_errno_with_message!(Errno::EINVAL, "the OOM score adjustment is out of range");
+        }
+
+        // TODO: If the new adjustment value is smaller than the smallest
+        // adjustment value that the process has ever reached and the writer
+        // does not have the `SYS_RESOURCE` capability, we should fail with
+        // `EACCES`. See
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L1152>.
+        self.0.oom_score_adj().store(val as i16, Ordering::Relaxed);
+
+        Ok(read_bytes)
+    }
+}
+
+/// Reads an `i32` from the given `VmReader`.
+///
+/// Returns the read value and the number of bytes read from the given `VmReader`.
+fn read_i32_from(reader: &mut VmReader) -> Result<(i32, usize)> {
+    let mut buf = [0u8; BUF_SIZE_I32];
+
+    let read_bytes = reader.read_fallible(&mut (&mut buf[..BUF_SIZE_I32 - 1]).into())?;
+    let val = CStr::from_bytes_until_nul(&buf)
+        .unwrap()
+        .to_str()
+        .ok()
+        .and_then(|str| str.parse::<i32>().ok())
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the value is not a valid integer"))?;
+    Ok((val, read_bytes))
+}
+
+/// Worst case buffer size needed for holding an integer.
+// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/internal.h#L163>.
+const BUF_SIZE_I32: usize = 13;
+
+// FIXME: Support OOM killer and move these constants to a more appropriate place.
+const OOM_SCORE_ADJ_MIN: i32 = -1000;
+const OOM_SCORE_ADJ_MAX: i32 = 1000;

--- a/kernel/src/fs/procfs/self_.rs
+++ b/kernel/src/fs/procfs/self_.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
 };
@@ -13,7 +13,11 @@ pub struct SelfSymOps;
 
 impl SelfSymOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcSymBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/self.c#L50>
+        ProcSymBuilder::new(Self, InodeMode::from_bits_truncate(0o777))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
+++ b/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::credentials::capabilities::CapSet,
@@ -16,7 +16,11 @@ pub struct CapLastCapFileOps;
 
 impl CapLastCapFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/sysctl.c#L1701>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o444))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/procfs/sys/kernel/mod.rs
@@ -7,7 +7,7 @@ use crate::{
             template::{DirOps, ProcDirBuilder},
             ProcDir,
         },
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
 };
@@ -20,7 +20,13 @@ pub struct KernelDirOps;
 
 impl KernelDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/sysctl.c#L1765>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L978>
+        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/sys/kernel/pid_max.rs
+++ b/kernel/src/fs/procfs/sys/kernel/pid_max.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread::PID_MAX,
@@ -16,7 +16,11 @@ pub struct PidMaxFileOps;
 
 impl PidMaxFileOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcFileBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/pid.c#L721>
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 
@@ -24,5 +28,13 @@ impl FileOps for PidMaxFileOps {
     fn data(&self) -> Result<Vec<u8>> {
         let output = format!("{}\n", PID_MAX);
         Ok(output.into_bytes())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!("writing to `/proc/sys/kernel/pid_max` is not supported");
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to `/proc/sys/kernel/pid_max` is not supported"
+        );
     }
 }

--- a/kernel/src/fs/procfs/sys/mod.rs
+++ b/kernel/src/fs/procfs/sys/mod.rs
@@ -4,7 +4,7 @@ use self::kernel::KernelDirOps;
 use crate::{
     fs::{
         procfs::template::{DirOps, ProcDir, ProcDirBuilder},
-        utils::{DirEntryVecExt, Inode},
+        utils::{DirEntryVecExt, Inode, InodeMode},
     },
     prelude::*,
 };
@@ -16,7 +16,13 @@ pub struct SysDirOps;
 
 impl SysDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcDirBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L1566>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L488-L489>
+        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/fs/procfs/template/dir.rs
+++ b/kernel/src/fs/procfs/template/dir.rs
@@ -32,6 +32,7 @@ impl<D: DirOps> ProcDir<D> {
         parent: Option<Weak<dyn Inode>>,
         ino: Option<u64>,
         is_volatile: bool,
+        mode: InodeMode,
     ) -> Arc<Self> {
         let common = {
             let ino = ino.unwrap_or_else(|| {
@@ -40,8 +41,7 @@ impl<D: DirOps> ProcDir<D> {
                 procfs.alloc_id()
             });
 
-            let metadata =
-                Metadata::new_dir(ino, InodeMode::from_bits_truncate(0o555), super::BLOCK_SIZE);
+            let metadata = Metadata::new_dir(ino, mode, super::BLOCK_SIZE);
             Common::new(metadata, fs, is_volatile)
         };
         Arc::new_cyclic(|weak_self| Self {

--- a/kernel/src/fs/procfs/template/sym.rs
+++ b/kernel/src/fs/procfs/template/sym.rs
@@ -17,15 +17,11 @@ pub struct ProcSym<S: SymOps> {
 }
 
 impl<S: SymOps> ProcSym<S> {
-    pub fn new(sym: S, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Arc<Self> {
+    pub fn new(sym: S, fs: Weak<dyn FileSystem>, is_volatile: bool, mode: InodeMode) -> Arc<Self> {
         let common = {
             let arc_fs = fs.upgrade().unwrap();
             let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
-            let metadata = Metadata::new_symlink(
-                procfs.alloc_id(),
-                InodeMode::from_bits_truncate(0o777),
-                super::BLOCK_SIZE,
-            );
+            let metadata = Metadata::new_symlink(procfs.alloc_id(), mode, super::BLOCK_SIZE);
             Common::new(metadata, fs, is_volatile)
         };
         Arc::new(Self { inner: sym, common })

--- a/kernel/src/fs/procfs/thread_self.rs
+++ b/kernel/src/fs/procfs/thread_self.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         procfs::{ProcSymBuilder, SymOps},
-        utils::Inode,
+        utils::{Inode, InodeMode},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -16,7 +16,11 @@ pub struct ThreadSelfSymOps;
 
 impl ThreadSelfSymOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        ProcSymBuilder::new(Self).parent(parent).build().unwrap()
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/thread_self.c#L50>
+        ProcSymBuilder::new(Self, InodeMode::from_bits_truncate(0o777))
+            .parent(parent)
+            .build()
+            .unwrap()
     }
 }
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -401,6 +401,9 @@ fn clone_child_process(
     // Inherit the parent's nice value
     let child_nice = process.nice().load(Ordering::Relaxed);
 
+    // Inherit the parent's OOM score adjustment
+    let child_oom_score_adj = process.oom_score_adj().load(Ordering::Relaxed);
+
     let child_tid = allocate_posix_tid();
 
     let child = {
@@ -437,6 +440,7 @@ fn clone_child_process(
             child_process_vm,
             child_resource_limits,
             child_nice,
+            child_oom_score_adj,
             child_sig_dispositions,
             child_user_ns,
             child_thread_builder,
@@ -644,6 +648,7 @@ fn create_child_process(
     process_vm: ProcessVm,
     resource_limits: ResourceLimits,
     nice: Nice,
+    oom_score_adj: i16,
     sig_dispositions: Arc<Mutex<SigDispositions>>,
     user_ns: Arc<UserNamespace>,
     thread_builder: PosixThreadBuilder,
@@ -655,6 +660,7 @@ fn create_child_process(
         process_vm,
         resource_limits,
         nice,
+        oom_score_adj,
         sig_dispositions,
         user_ns,
     );

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -51,6 +51,7 @@ fn create_init_process(
     let process_vm = ProcessVm::alloc();
     let resource_limits = ResourceLimits::default();
     let nice = Nice::default();
+    let oom_score_adj = 0;
     let sig_dispositions = Arc::new(Mutex::new(SigDispositions::default()));
     let user_ns = UserNamespace::get_init_singleton().clone();
 
@@ -61,6 +62,7 @@ fn create_init_process(
         process_vm,
         resource_limits,
         nice,
+        oom_score_adj,
         sig_dispositions,
         user_ns,
     );

--- a/test/src/syscall/gvisor/Makefile
+++ b/test/src/syscall/gvisor/Makefile
@@ -34,6 +34,7 @@ TESTS ?= \
 	prctl_setuid_test \
 	pread64_test \
 	preadv2_test \
+	proc_pid_oomscore_test \
 	proc_test \
 	pselect_test \
 	pty_test \

--- a/test/src/syscall/gvisor/blocklists/proc_pid_oomscore_test
+++ b/test/src/syscall/gvisor/blocklists/proc_pid_oomscore_test
@@ -1,0 +1,2 @@
+# TODO: Support `/proc/[pid]/oom_score`
+ProcPidOomscoreTest.BasicRead


### PR DESCRIPTION
This PR is required for https://github.com/asterinas/asterinas/issues/2214.

The first commit in this PR makes the file modes in procfs configurable and modifies the modes of some files to conform with the Linux interface.

The second commit adds `/proc/<pid>/oom_score_adj` and `/proc/<pid>/task/<tid>/oom_score_adj`, and supports reading / writing these files.