### PR TITLE
Some adjustments to FS APIs and behavior

### DIFF
--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         fs_resolver::{FsPath, FsResolver},
-        ramfs::RamFS,
+        ramfs::RamFs,
         utils::{InodeMode, InodeType},
     },
     prelude::*,
@@ -16,7 +16,7 @@ pub fn init_in_first_process(fs_resolver: &FsResolver) -> Result<()> {
     // Create the "shm" directory under "/dev" and mount a ramfs on it.
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, InodeMode::from_bits_truncate(0o1777))?;
-    shm_path.mount(RamFS::new())?;
-    log::debug!("Mount RamFS at \"/dev/shm\"");
+    shm_path.mount(RamFs::new())?;
+    log::debug!("Mount RamFs at \"/dev/shm\"");
     Ok(())
 }

--- a/kernel/src/fs/cgroupfs/inode.rs
+++ b/kernel/src/fs/cgroupfs/inode.rs
@@ -4,6 +4,7 @@ use alloc::sync::{Arc, Weak};
 
 use ostd::sync::RwLock;
 
+use super::fs::CgroupFs;
 use crate::{
     fs::utils::{
         systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
@@ -13,7 +14,7 @@ use crate::{
 };
 
 /// An inode abstraction used in the cgroup file system.
-pub struct CgroupInode {
+pub(super) struct CgroupInode {
     /// The corresponding node in the SysTree.
     node_kind: SysTreeNodeKind,
     /// The metadata of this inode.
@@ -67,12 +68,14 @@ impl SysTreeInodeTy for CgroupInode {
     }
 
     fn this(&self) -> Arc<Self> {
-        self.this.upgrade().expect("Weak ref invalid")
+        self.this
+            .upgrade()
+            .expect("invalid weak reference to `self`")
     }
 }
 
 impl Inode for CgroupInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
-        super::singleton().clone()
+        CgroupFs::singleton().clone()
     }
 }

--- a/kernel/src/fs/cgroupfs/mod.rs
+++ b/kernel/src/fs/cgroupfs/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
-use crate::fs::cgroupfs::fs::CgroupFsType;
+use fs::CgroupFsType;
 
 mod fs;
 mod inode;
@@ -11,6 +9,5 @@ mod systree_node;
 // This method should be called during kernel file system initialization,
 // _after_ `aster_systree::init`.
 pub(super) fn init() {
-    let cgroupfs_type = Arc::new(CgroupFsType);
-    super::registry::register(cgroupfs_type).unwrap();
+    super::registry::register(&CgroupFsType).unwrap();
 }

--- a/kernel/src/fs/cgroupfs/mod.rs
+++ b/kernel/src/fs/cgroupfs/mod.rs
@@ -2,27 +2,15 @@
 
 use alloc::sync::Arc;
 
-use fs::CgroupFs;
-use spin::Once;
-
-use crate::fs::cgroupfs::{fs::CgroupFsType, systree_node::CgroupSystem};
+use crate::fs::cgroupfs::fs::CgroupFsType;
 
 mod fs;
 mod inode;
 mod systree_node;
 
-static CGROUP_SINGLETON: Once<Arc<CgroupFs>> = Once::new();
-
-/// Returns a reference to the global CgroupFs instance. Panics if not initialized.
-pub fn singleton() -> &'static Arc<CgroupFs> {
-    CGROUP_SINGLETON.get().expect("CgroupFs is not initialized")
-}
-
-/// Initializes the CgroupFs singleton.
-/// Ensures that the singleton is created by calling it.
-/// Should be called during kernel file system initialization, *after* aster_systree::init().
-pub fn init() {
-    let cgroup_root = CgroupSystem::new();
-    let cgroup_fs_type = CgroupFsType::new(cgroup_root);
-    super::registry::register(cgroup_fs_type).unwrap();
+// This method should be called during kernel file system initialization,
+// _after_ `aster_systree::init`.
+pub(super) fn init() {
+    let cgroupfs_type = Arc::new(CgroupFsType);
+    super::registry::register(cgroupfs_type).unwrap();
 }

--- a/kernel/src/fs/devpts/mod.rs
+++ b/kernel/src/fs/devpts/mod.rs
@@ -130,8 +130,7 @@ impl FsType for DevPtsType {
 }
 
 pub(super) fn init() {
-    let devpts_type = Arc::new(DevPtsType);
-    super::registry::register(devpts_type).unwrap();
+    super::registry::register(&DevPtsType).unwrap();
 }
 
 struct RootInode {

--- a/kernel/src/fs/devpts/mod.rs
+++ b/kernel/src/fs/devpts/mod.rs
@@ -112,20 +112,19 @@ impl FsType for DevPtsType {
         "devpts"
     }
 
-    fn create(
-        &self,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-        _ctx: &Context,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(DevPts::new())
-    }
-
     fn properties(&self) -> FsProperties {
         FsProperties::empty()
     }
 
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn create(
+        &self,
+        _args: Option<CString>,
+        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
+    ) -> Result<Arc<dyn FileSystem>> {
+        Ok(DevPts::new())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/exfat/bitmap.rs
+++ b/kernel/src/fs/exfat/bitmap.rs
@@ -13,7 +13,7 @@ use super::{
     constants::EXFAT_RESERVED_CLUSTERS,
     dentry::{ExfatBitmapDentry, ExfatDentry, ExfatDentryIterator},
     fat::{ClusterID, ExfatChain},
-    fs::ExfatFS,
+    fs::ExfatFs,
 };
 use crate::{fs::exfat::fat::FatChainFlags, prelude::*, vm::vmo::Vmo};
 
@@ -31,12 +31,12 @@ pub(super) struct ExfatBitmap {
 
     // Used to track the number of free clusters.
     num_free_cluster: u32,
-    fs: Weak<ExfatFS>,
+    fs: Weak<ExfatFs>,
 }
 
 impl ExfatBitmap {
     pub(super) fn load(
-        fs_weak: Weak<ExfatFS>,
+        fs_weak: Weak<ExfatFs>,
         root_page_cache: Vmo<Full>,
         root_chain: ExfatChain,
     ) -> Result<Self> {
@@ -55,7 +55,7 @@ impl ExfatBitmap {
         return_errno_with_message!(Errno::EINVAL, "bitmap not found")
     }
 
-    fn load_bitmap_from_dentry(fs_weak: Weak<ExfatFS>, dentry: &ExfatBitmapDentry) -> Result<Self> {
+    fn load_bitmap_from_dentry(fs_weak: Weak<ExfatFs>, dentry: &ExfatBitmapDentry) -> Result<Self> {
         let fs = fs_weak.upgrade().unwrap();
         let num_clusters = (dentry.size as usize).align_up(fs.cluster_size()) / fs.cluster_size();
 
@@ -83,7 +83,7 @@ impl ExfatBitmap {
         })
     }
 
-    fn fs(&self) -> Arc<ExfatFS> {
+    fn fs(&self) -> Arc<ExfatFs> {
         self.fs.upgrade().unwrap()
     }
 

--- a/kernel/src/fs/exfat/dentry.rs
+++ b/kernel/src/fs/exfat/dentry.rs
@@ -8,7 +8,7 @@ use ostd::mm::VmIo;
 use super::{
     constants::{EXFAT_FILE_NAME_LEN, MAX_NAME_LENGTH},
     fat::FatChainFlags,
-    fs::ExfatFS,
+    fs::ExfatFs,
     inode::FatAttr,
     upcase_table::ExfatUpcaseTable,
     utils::{calc_checksum_16, DosTimestamp},
@@ -219,7 +219,7 @@ impl ExfatDentrySet {
     }
 
     pub(super) fn from(
-        fs: Arc<ExfatFS>,
+        fs: Arc<ExfatFs>,
         name: &str,
         inode_type: InodeType,
         _mode: InodeMode,

--- a/kernel/src/fs/exfat/fat.rs
+++ b/kernel/src/fs/exfat/fat.rs
@@ -3,7 +3,7 @@
 use super::{
     bitmap::ExfatBitmap,
     constants::{EXFAT_FIRST_CLUSTER, EXFAT_RESERVED_CLUSTERS},
-    fs::ExfatFS,
+    fs::ExfatFs,
 };
 use crate::prelude::*;
 
@@ -61,7 +61,7 @@ pub struct ExfatChain {
     num_clusters: u32,
     // use FAT or not
     flags: FatChainFlags,
-    fs: Weak<ExfatFS>,
+    fs: Weak<ExfatFs>,
 }
 
 // A position by the chain and relative offset in the cluster.
@@ -69,7 +69,7 @@ pub type ExfatChainPosition = (ExfatChain, usize);
 
 impl ExfatChain {
     pub(super) fn new(
-        fs: Weak<ExfatFS>,
+        fs: Weak<ExfatFs>,
         current: ClusterID,
         num_clusters: Option<u32>,
         flags: FatChainFlags,
@@ -118,7 +118,7 @@ impl ExfatChain {
         self.flags = flags;
     }
 
-    fn fs(&self) -> Arc<ExfatFS> {
+    fn fs(&self) -> Arc<ExfatFs> {
         self.fs.upgrade().unwrap()
     }
 

--- a/kernel/src/fs/exfat/fs.rs
+++ b/kernel/src/fs/exfat/fs.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct ExfatFS {
+pub struct ExfatFs {
     block_device: Arc<dyn BlockDevice>,
     super_block: ExfatSuperBlock,
 
@@ -59,7 +59,7 @@ const FAT_LRU_CACHE_SIZE: usize = 1024;
 
 pub(super) const EXFAT_ROOT_INO: Ino = 1;
 
-impl ExfatFS {
+impl ExfatFs {
     pub fn open(
         block_device: Arc<dyn BlockDevice>,
         mount_option: ExfatMountOptions,
@@ -67,7 +67,7 @@ impl ExfatFS {
         // Load the super_block
         let super_block = Self::read_super_block(block_device.as_ref())?;
         let fs_size = super_block.num_clusters as usize * super_block.cluster_size as usize;
-        let exfat_fs = Arc::new_cyclic(|weak_self| ExfatFS {
+        let exfat_fs = Arc::new_cyclic(|weak_self| ExfatFs {
             block_device,
             super_block,
             bitmap: Arc::new(Mutex::new(ExfatBitmap::default())),
@@ -368,7 +368,7 @@ impl ExfatFS {
     }
 }
 
-impl PageCacheBackend for ExfatFS {
+impl PageCacheBackend for ExfatFs {
     fn read_page_async(&self, idx: usize, frame: &CachePage) -> Result<BioWaiter> {
         if self.fs_size() < idx * PAGE_SIZE {
             return_errno_with_message!(Errno::EINVAL, "invalid read size")
@@ -402,7 +402,7 @@ impl PageCacheBackend for ExfatFS {
     }
 }
 
-impl FileSystem for ExfatFS {
+impl FileSystem for ExfatFs {
     fn sync(&self) -> Result<()> {
         for inode in self.inodes.read().values() {
             inode.sync_all()?;
@@ -467,7 +467,7 @@ impl FsType for ExfatType {
         _args: Option<CString>,
         disk: Option<Arc<dyn BlockDevice>>,
     ) -> Result<Arc<dyn FileSystem>> {
-        ExfatFS::open(disk.unwrap(), ExfatMountOptions::default()).map(|fs| fs as _)
+        ExfatFs::open(disk.unwrap(), ExfatMountOptions::default()).map(|fs| fs as _)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/exfat/fs.rs
+++ b/kernel/src/fs/exfat/fs.rs
@@ -458,20 +458,19 @@ impl FsType for ExfatType {
         "exfat"
     }
 
-    fn create(
-        &self,
-        _args: Option<CString>,
-        disk: Option<Arc<dyn BlockDevice>>,
-        ctx: &Context,
-    ) -> Result<Arc<dyn FileSystem>> {
-        ExfatFS::open(disk.unwrap(), ExfatMountOptions::default()).map(|fs| fs as _)
-    }
-
     fn properties(&self) -> FsProperties {
         FsProperties::NEED_DISK
     }
 
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn create(
+        &self,
+        _args: Option<CString>,
+        disk: Option<Arc<dyn BlockDevice>>,
+    ) -> Result<Arc<dyn FileSystem>> {
+        ExfatFS::open(disk.unwrap(), ExfatMountOptions::default()).map(|fs| fs as _)
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/exfat/inode.rs
+++ b/kernel/src/fs/exfat/inode.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::{
-        exfat::{dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFS},
+        exfat::{dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs},
         path::{is_dot, is_dot_or_dotdot, is_dotdot},
         utils::{
             CachePage, DirentVisitor, Extension, Inode, InodeMode, InodeType, IoctlCmd, Metadata,
@@ -128,7 +128,7 @@ struct ExfatInodeInner {
     parent_hash: usize,
 
     /// A pointer to exFAT fs.
-    fs: Weak<ExfatFS>,
+    fs: Weak<ExfatFs>,
 
     /// Important: To enlarge the page_cache, we need to update the page_cache size before we update the size of inode, to avoid extra data read.
     /// To shrink the page_cache, we need to update the page_cache size after we update the size of inode, to avoid extra data write.
@@ -225,7 +225,7 @@ impl ExfatInodeInner {
         false
     }
 
-    fn fs(&self) -> Arc<ExfatFS> {
+    fn fs(&self) -> Arc<ExfatFs> {
         self.fs.upgrade().unwrap()
     }
 
@@ -635,7 +635,7 @@ impl ExfatInode {
     }
 
     pub(super) fn build_root_inode(
-        fs_weak: Weak<ExfatFS>,
+        fs_weak: Weak<ExfatFs>,
         root_chain: ExfatChain,
     ) -> Result<Arc<ExfatInode>> {
         let sb = fs_weak.upgrade().unwrap().super_block();
@@ -694,7 +694,7 @@ impl ExfatInode {
     }
 
     fn build_from_dentry_set(
-        fs: Arc<ExfatFS>,
+        fs: Arc<ExfatFs>,
         dentry_set: &ExfatDentrySet,
         dentry_set_position: ExfatChainPosition,
         dentry_entry: u32,
@@ -804,7 +804,7 @@ impl ExfatInode {
 
     /// The caller of the function should give a unique ino to assign to the inode.
     pub(super) fn read_from_iterator(
-        fs: Arc<ExfatFS>,
+        fs: Arc<ExfatFs>,
         dentry_entry: usize,
         chain_pos: ExfatChainPosition,
         file_dentry: &ExfatFileDentry,

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -12,7 +12,7 @@ mod utils;
 
 use alloc::sync::Arc;
 
-pub use fs::{ExfatFS, ExfatMountOptions};
+pub use fs::{ExfatFs, ExfatMountOptions};
 
 use crate::fs::exfat::fs::ExfatType;
 
@@ -39,7 +39,7 @@ mod test {
         fs::{
             exfat::{
                 constants::{EXFAT_RESERVED_CLUSTERS, MAX_NAME_LENGTH},
-                ExfatFS, ExfatMountOptions,
+                ExfatFs, ExfatMountOptions,
             },
             utils::{generate_random_operation, new_fs_in_memory, Inode, InodeMode, InodeType},
         },
@@ -130,11 +130,11 @@ mod test {
     }
 
     // Generate a simulated exfat file system
-    fn load_exfat() -> Arc<ExfatFS> {
+    fn load_exfat() -> Arc<ExfatFs> {
         let segment = new_vm_segment_from_image();
         let disk = ExfatMemoryDisk::new(segment);
         let mount_option = ExfatMountOptions::default();
-        let fs = ExfatFS::open(Arc::new(disk), mount_option);
+        let fs = ExfatFs::open(Arc::new(disk), mount_option);
         assert!(fs.is_ok(), "Fs failed to init:{:?}", fs.unwrap_err());
         fs.unwrap()
     }

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -10,15 +10,12 @@ mod super_block;
 mod upcase_table;
 mod utils;
 
-use alloc::sync::Arc;
-
 pub use fs::{ExfatFs, ExfatMountOptions};
 
 use crate::fs::exfat::fs::ExfatType;
 
 pub(super) fn init() {
-    let exfat_type = Arc::new(ExfatType);
-    super::registry::register(exfat_type).unwrap();
+    super::registry::register(&ExfatType).unwrap();
 }
 
 #[cfg(ktest)]

--- a/kernel/src/fs/exfat/upcase_table.rs
+++ b/kernel/src/fs/exfat/upcase_table.rs
@@ -10,7 +10,7 @@ use super::{
     constants::UNICODE_SIZE,
     dentry::{ExfatDentry, ExfatDentryIterator, ExfatUpcaseDentry, UTF16Char},
     fat::ExfatChain,
-    fs::ExfatFS,
+    fs::ExfatFs,
     utils::calc_checksum_32,
 };
 use crate::{fs::exfat::fat::FatChainFlags, prelude::*, vm::vmo::Vmo};
@@ -20,7 +20,7 @@ const UPCASE_MANDATORY_SIZE: usize = 128;
 #[derive(Debug)]
 pub(super) struct ExfatUpcaseTable {
     upcase_table: [u16; UPCASE_MANDATORY_SIZE],
-    fs: Weak<ExfatFS>,
+    fs: Weak<ExfatFs>,
 }
 
 impl ExfatUpcaseTable {
@@ -32,7 +32,7 @@ impl ExfatUpcaseTable {
     }
 
     pub(super) fn load(
-        fs_weak: Weak<ExfatFS>,
+        fs_weak: Weak<ExfatFs>,
         root_page_cache: Vmo<Full>,
         root_chain: ExfatChain,
     ) -> Result<Self> {
@@ -48,7 +48,7 @@ impl ExfatUpcaseTable {
         return_errno_with_message!(Errno::EINVAL, "Upcase table not found")
     }
 
-    fn load_table_from_dentry(fs_weak: Weak<ExfatFS>, dentry: &ExfatUpcaseDentry) -> Result<Self> {
+    fn load_table_from_dentry(fs_weak: Weak<ExfatFs>, dentry: &ExfatUpcaseDentry) -> Result<Self> {
         if (dentry.size as usize) < UPCASE_MANDATORY_SIZE * UNICODE_SIZE {
             return_errno_with_message!(Errno::EINVAL, "Upcase table too small")
         }

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -446,20 +446,19 @@ impl FsType for Ext2Type {
         "ext2"
     }
 
-    fn create(
-        &self,
-        _args: Option<CString>,
-        disk: Option<Arc<dyn BlockDevice>>,
-        _ctx: &Context,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ext2::open(disk.unwrap()).map(|fs| fs as _)
-    }
-
     fn properties(&self) -> FsProperties {
         FsProperties::NEED_DISK
     }
 
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn create(
+        &self,
+        _args: Option<CString>,
+        disk: Option<Arc<dyn BlockDevice>>,
+    ) -> Result<Arc<dyn FileSystem>> {
+        Ext2::open(disk.unwrap()).map(|fs| fs as _)
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -36,8 +36,6 @@
 //! 1. Supports merging small read/write operations.
 //! 2. Handles the intermediate failure status correctly.
 
-use alloc::sync::Arc;
-
 pub use fs::Ext2;
 pub use inode::{FilePerm, Inode};
 pub use super_block::{SuperBlock, MAGIC_NUM};
@@ -57,6 +55,5 @@ mod utils;
 mod xattr;
 
 pub(super) fn init() {
-    let ext2_type = Arc::new(Ext2Type);
-    super::registry::register(ext2_type).unwrap();
+    super::registry::register(&Ext2Type).unwrap();
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -28,7 +28,7 @@ use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 
 use crate::{
     fs::{
-        exfat::{ExfatFS, ExfatMountOptions},
+        exfat::{ExfatFs, ExfatMountOptions},
         ext2::Ext2,
         file_table::FdFlags,
         fs_resolver::{FsPath, FsResolver},
@@ -91,7 +91,7 @@ pub fn init_in_first_process(ctx: &Context) {
     }
 
     if let Ok(block_device_exfat) = start_block_device(exfat_device_name) {
-        let exfat_fs = ExfatFS::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
+        let exfat_fs = ExfatFs::open(block_device_exfat, ExfatMountOptions::default()).unwrap();
         let target_path = FsPath::try_from("/exfat").unwrap();
         println!("[kernel] Mount ExFat fs at {:?} ", target_path);
         self::rootfs::mount_fs_at(exfat_fs, &target_path, &fs_resolver).unwrap();

--- a/kernel/src/fs/overlayfs/mod.rs
+++ b/kernel/src/fs/overlayfs/mod.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use fs::OverlayFsType;
+
 mod fs;
 
-use alloc::sync::Arc;
-
-use crate::fs::overlayfs::fs::OverlayFsType;
-
 pub(super) fn init() {
-    let overlay_type = Arc::new(OverlayFsType);
-    super::registry::register(overlay_type).unwrap();
+    super::registry::register(&OverlayFsType).unwrap();
 }

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -48,13 +48,13 @@ const PROC_ROOT_INO: u64 = 1;
 /// Block size.
 const BLOCK_SIZE: usize = 1024;
 
-pub struct ProcFS {
+pub struct ProcFs {
     sb: SuperBlock,
     root: Arc<dyn Inode>,
     inode_allocator: AtomicU64,
 }
 
-impl ProcFS {
+impl ProcFs {
     pub fn new() -> Arc<Self> {
         Arc::new_cyclic(|weak_fs| Self {
             sb: SuperBlock::new(PROC_MAGIC, BLOCK_SIZE, NAME_MAX),
@@ -68,7 +68,7 @@ impl ProcFS {
     }
 }
 
-impl FileSystem for ProcFS {
+impl FileSystem for ProcFs {
     fn sync(&self) -> Result<()> {
         Ok(())
     }
@@ -102,7 +102,7 @@ impl FsType for ProcFsType {
         _args: Option<CString>,
         _disk: Option<Arc<dyn aster_block::BlockDevice>>,
     ) -> Result<Arc<dyn FileSystem>> {
-        Ok(ProcFS::new())
+        Ok(ProcFs::new())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -114,7 +114,7 @@ impl FsType for ProcFsType {
 struct RootDirOps;
 
 impl RootDirOps {
-    pub fn new_inode(fs: Weak<ProcFS>) -> Arc<dyn Inode> {
+    pub fn new_inode(fs: Weak<ProcFs>) -> Arc<dyn Inode> {
         let root_inode = ProcDirBuilder::new(Self)
             .fs(fs)
             .ino(PROC_ROOT_INO)

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -93,20 +93,19 @@ impl FsType for ProcFsType {
         "proc"
     }
 
-    fn create(
-        &self,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-        _ctx: &Context,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(ProcFS::new())
-    }
-
     fn properties(&self) -> FsProperties {
         FsProperties::empty()
     }
 
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn create(
+        &self,
+        _args: Option<CString>,
+        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
+    ) -> Result<Arc<dyn FileSystem>> {
+        Ok(ProcFS::new())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -37,8 +37,7 @@ mod template;
 mod thread_self;
 
 pub(super) fn init() {
-    let procfs_type = Arc::new(ProcFsType);
-    super::registry::register(procfs_type).unwrap();
+    super::registry::register(&ProcFsType).unwrap();
 }
 
 /// Magic number.

--- a/kernel/src/fs/procfs/template/dir.rs
+++ b/kernel/src/fs/procfs/template/dir.rs
@@ -7,7 +7,7 @@ use core::time::Duration;
 use aster_util::slot_vec::SlotVec;
 use inherit_methods_macro::inherit_methods;
 
-use super::{Common, ProcFS};
+use super::{Common, ProcFs};
 use crate::{
     fs::{
         path::{is_dot, is_dotdot},
@@ -36,7 +36,7 @@ impl<D: DirOps> ProcDir<D> {
         let common = {
             let ino = ino.unwrap_or_else(|| {
                 let arc_fs = fs.upgrade().unwrap();
-                let procfs = arc_fs.downcast_ref::<ProcFS>().unwrap();
+                let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
                 procfs.alloc_id()
             });
 

--- a/kernel/src/fs/procfs/template/file.rs
+++ b/kernel/src/fs/procfs/template/file.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
 
-use super::{Common, ProcFS};
+use super::{Common, ProcFs};
 use crate::{
     fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata},
     prelude::*,
@@ -20,7 +20,7 @@ impl<F: FileOps> ProcFile<F> {
     pub fn new(file: F, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Arc<Self> {
         let common = {
             let arc_fs = fs.upgrade().unwrap();
-            let procfs = arc_fs.downcast_ref::<ProcFS>().unwrap();
+            let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
             let metadata = Metadata::new_file(
                 procfs.alloc_id(),
                 InodeMode::from_bits_truncate(0o444),

--- a/kernel/src/fs/procfs/template/mod.rs
+++ b/kernel/src/fs/procfs/template/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
     file::FileOps,
     sym::SymOps,
 };
-use super::{ProcFS, BLOCK_SIZE};
+use super::{ProcFs, BLOCK_SIZE};
 use crate::{
     fs::utils::{FileSystem, InodeMode, InodeType, Metadata},
     prelude::*,

--- a/kernel/src/fs/procfs/template/sym.rs
+++ b/kernel/src/fs/procfs/template/sym.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
 
-use super::{Common, ProcFS};
+use super::{Common, ProcFs};
 use crate::{
     fs::utils::{FileSystem, Inode, InodeMode, InodeType, IoctlCmd, Metadata},
     prelude::*,
@@ -20,7 +20,7 @@ impl<S: SymOps> ProcSym<S> {
     pub fn new(sym: S, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Arc<Self> {
         let common = {
             let arc_fs = fs.upgrade().unwrap();
-            let procfs = arc_fs.downcast_ref::<ProcFS>().unwrap();
+            let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
             let metadata = Metadata::new_symlink(
                 procfs.alloc_id(),
                 InodeMode::from_bits_truncate(0o777),

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -1279,20 +1279,19 @@ impl FsType for RamFsType {
         "ramfs"
     }
 
-    fn create(
-        &self,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-        _ctx: &Context,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(RamFS::new())
-    }
-
     fn properties(&self) -> FsProperties {
         FsProperties::empty()
     }
 
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn create(
+        &self,
+        _args: Option<CString>,
+        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
+    ) -> Result<Arc<dyn FileSystem>> {
+        Ok(RamFS::new())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/ramfs/fs.rs
+++ b/kernel/src/fs/ramfs/fs.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 /// A volatile file system whose data and metadata exists only in memory.
-pub struct RamFS {
+pub struct RamFs {
     /// The super block
     sb: SuperBlock,
     /// Root inode
@@ -46,7 +46,7 @@ pub struct RamFS {
     inode_allocator: AtomicU64,
 }
 
-impl RamFS {
+impl RamFs {
     pub fn new() -> Arc<Self> {
         Arc::new_cyclic(|weak_fs| Self {
             sb: SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX),
@@ -73,7 +73,7 @@ impl RamFS {
     }
 }
 
-impl FileSystem for RamFS {
+impl FileSystem for RamFs {
     fn sync(&self) -> Result<()> {
         // do nothing
         Ok(())
@@ -105,7 +105,7 @@ struct RamInode {
     /// Reference to self
     this: Weak<RamInode>,
     /// Reference to fs
-    fs: Weak<RamFS>,
+    fs: Weak<RamFs>,
     /// Extensions
     extension: Extension,
     /// Extended attributes
@@ -389,7 +389,7 @@ impl DirEntry {
 
 impl RamInode {
     fn new_dir(
-        fs: &Arc<RamFS>,
+        fs: &Arc<RamFs>,
         mode: InodeMode,
         uid: Uid,
         gid: Gid,
@@ -407,7 +407,7 @@ impl RamInode {
         })
     }
 
-    fn new_file(fs: &Arc<RamFS>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
+    fn new_file(fs: &Arc<RamFs>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| RamInode {
             inner: Inner::new_file(weak_self.clone()),
             metadata: SpinLock::new(InodeMeta::new(mode, uid, gid)),
@@ -433,7 +433,7 @@ impl RamInode {
         })
     }
 
-    fn new_symlink(fs: &Arc<RamFS>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
+    fn new_symlink(fs: &Arc<RamFs>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| RamInode {
             inner: Inner::new_symlink(),
             metadata: SpinLock::new(InodeMeta::new(mode, uid, gid)),
@@ -447,7 +447,7 @@ impl RamInode {
     }
 
     fn new_device(
-        fs: &Arc<RamFS>,
+        fs: &Arc<RamFs>,
         mode: InodeMode,
         uid: Uid,
         gid: Gid,
@@ -465,7 +465,7 @@ impl RamInode {
         })
     }
 
-    fn new_socket(fs: &Arc<RamFS>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
+    fn new_socket(fs: &Arc<RamFs>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| RamInode {
             inner: Inner::new_socket(),
             metadata: SpinLock::new(InodeMeta::new(mode, uid, gid)),
@@ -478,7 +478,7 @@ impl RamInode {
         })
     }
 
-    fn new_named_pipe(fs: &Arc<RamFS>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
+    fn new_named_pipe(fs: &Arc<RamFs>, mode: InodeMode, uid: Uid, gid: Gid) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| RamInode {
             inner: Inner::new_named_pipe(),
             metadata: SpinLock::new(InodeMeta::new(mode, uid, gid)),
@@ -1243,7 +1243,7 @@ impl Inode for RamInode {
     }
 }
 
-/// Creates a RAM inode that is detached from any `RamFS`.
+/// Creates a RAM inode that is detached from any `RamFs`.
 ///
 // TODO: Add "anonymous inode fs" and link the inode to it.
 pub fn new_detached_inode(mode: InodeMode, uid: Uid, gid: Gid) -> Arc<dyn Inode> {
@@ -1288,7 +1288,7 @@ impl FsType for RamFsType {
         _args: Option<CString>,
         _disk: Option<Arc<dyn aster_block::BlockDevice>>,
     ) -> Result<Arc<dyn FileSystem>> {
-        Ok(RamFS::new())
+        Ok(RamFs::new())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/ramfs/mod.rs
+++ b/kernel/src/fs/ramfs/mod.rs
@@ -2,11 +2,8 @@
 
 //! Ramfs based on PageCache
 
-use alloc::sync::Arc;
-
+use fs::RamFsType;
 pub use fs::{new_detached_inode, RamFs};
-
-use crate::fs::ramfs::fs::RamFsType;
 
 mod fs;
 mod xattr;
@@ -17,6 +14,5 @@ const ROOT_INO: u64 = 1;
 const NAME_MAX: usize = 255;
 
 pub(super) fn init() {
-    let ramfs_type = Arc::new(RamFsType);
-    super::registry::register(ramfs_type).unwrap();
+    super::registry::register(&RamFsType).unwrap();
 }

--- a/kernel/src/fs/ramfs/mod.rs
+++ b/kernel/src/fs/ramfs/mod.rs
@@ -4,7 +4,7 @@
 
 use alloc::sync::Arc;
 
-pub use fs::{new_detached_inode, RamFS};
+pub use fs::{new_detached_inode, RamFs};
 
 use crate::fs::ramfs::fs::RamFsType;
 

--- a/kernel/src/fs/registry.rs
+++ b/kernel/src/fs/registry.rs
@@ -44,7 +44,7 @@ bitflags! {
         /// Whether a FS needs to be backed by a disk.
         ///
         /// Most persistent FSes such as Ext2 require disks.
-        /// But a volatile FS such as RamFS or
+        /// But a volatile FS such as RamFs or
         /// a pseudo FS such as SysFS does not.
         const NEED_DISK = 1 << 1;
     }

--- a/kernel/src/fs/registry.rs
+++ b/kernel/src/fs/registry.rs
@@ -4,7 +4,7 @@ use alloc::borrow::ToOwned;
 
 use aster_block::BlockDevice;
 use aster_systree::{
-    inherit_sys_branch_node, AttrLessBranchNodeFields, SysBranchNode, SysObj, SysPerms, SysStr,
+    inherit_sys_branch_node, AttrLessBranchNodeFields, SysNode, SysObj, SysPerms, SysStr,
 };
 use spin::Once;
 
@@ -26,7 +26,6 @@ pub trait FsType: Send + Sync + 'static {
         &self,
         args: Option<CString>,
         disk: Option<Arc<dyn BlockDevice>>,
-        ctx: &Context,
     ) -> Result<Arc<dyn FileSystem>>;
 
     /// Returns a `SysTree` node that represents the FS type.
@@ -36,7 +35,7 @@ pub trait FsType: Send + Sync + 'static {
     ///
     /// The same result will be returned by this method
     /// when it is called multiple times.
-    fn sysnode(&self) -> Option<Arc<dyn SysBranchNode>>;
+    fn sysnode(&self) -> Option<Arc<dyn SysNode>>;
 }
 
 bitflags! {

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -10,7 +10,7 @@ use spin::Once;
 use super::{
     fs_resolver::{FsPath, FsResolver},
     path::Mount,
-    ramfs::RamFS,
+    ramfs::RamFs,
     utils::{FileSystem, InodeMode, InodeType},
 };
 use crate::{fs::path::is_dot, prelude::*};
@@ -107,7 +107,7 @@ pub fn init_in_first_kthread(fs_resolver: &FsResolver) -> Result<()> {
     }
     // Mount DevFS
     let dev_path = fs_resolver.lookup(&FsPath::try_from("/dev")?)?;
-    dev_path.mount(RamFS::new())?;
+    dev_path.mount(RamFs::new())?;
 
     println!("[kernel] rootfs is ready");
     Ok(())
@@ -127,7 +127,7 @@ static ROOT_MOUNT: Once<Arc<Mount>> = Once::new();
 
 pub(super) fn init() {
     ROOT_MOUNT.call_once(|| -> Arc<Mount> {
-        let rootfs = RamFS::new();
+        let rootfs = RamFs::new();
         Mount::new_root(rootfs)
     });
 }

--- a/kernel/src/fs/sysfs/fs.rs
+++ b/kernel/src/fs/sysfs/fs.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_systree::singleton as systree_singleton;
 use spin::Once;
 

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -7,21 +7,10 @@ mod test;
 
 use alloc::sync::Arc;
 
-use spin::Once;
-
-pub use self::fs::SysFs;
 use crate::fs::sysfs::fs::SysFsType;
 
-static SYSFS_SINGLETON: Once<Arc<SysFs>> = Once::new();
-
-/// Returns a reference to the global [`SysFs`] instance. Panics if not initialized.
-pub fn singleton() -> &'static Arc<SysFs> {
-    SYSFS_SINGLETON.get().expect("SysFs not initialized")
-}
-
-/// Initializes the SysFs singleton.
-/// Ensures that the singleton is created by calling it.
-/// Should be called during kernel file system initialization, *after* aster_systree::init().
+// This method should be called during kernel file system initialization,
+// _after_ `aster_systree::init`.
 pub fn init() {
     let sysfs_type = Arc::new(SysFsType);
     super::registry::register(sysfs_type).unwrap();

--- a/kernel/src/fs/sysfs/mod.rs
+++ b/kernel/src/fs/sysfs/mod.rs
@@ -5,13 +5,10 @@ mod inode;
 #[cfg(ktest)]
 mod test;
 
-use alloc::sync::Arc;
-
-use crate::fs::sysfs::fs::SysFsType;
+use fs::SysFsType;
 
 // This method should be called during kernel file system initialization,
 // _after_ `aster_systree::init`.
 pub fn init() {
-    let sysfs_type = Arc::new(SysFsType);
-    super::registry::register(sysfs_type).unwrap();
+    super::registry::register(&SysFsType).unwrap();
 }

--- a/kernel/src/fs/sysfs/test.rs
+++ b/kernel/src/fs/sysfs/test.rs
@@ -231,7 +231,7 @@ fn create_mock_systree_instance() -> &'static Arc<SysTree> {
 // Initialize a SysFs instance using the mock systree.
 fn init_sysfs_with_mock_tree() -> Arc<SysFs> {
     let _ = create_mock_systree_instance();
-    SysFs::new()
+    SysFs::new_for_ktest()
 }
 
 #[ktest]

--- a/kernel/src/fs/tmpfs/fs.rs
+++ b/kernel/src/fs/tmpfs/fs.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     fs::{
-        ramfs::RamFS,
+        ramfs::RamFs,
         registry::{FsProperties, FsType},
         utils::{FileSystem, FsFlags, Inode, SuperBlock},
     },
@@ -11,11 +11,11 @@ use crate::{
 
 /// The temporary file system (tmpfs) structure.
 //
-// TODO: Currently, tmpfs is implemented as a thin wrapper around RamFS.
+// TODO: Currently, tmpfs is implemented as a thin wrapper around RamFs.
 // In the future we need to implement tmpfs-specific features such as
 // memory limits and swap support.
 pub struct TmpFs {
-    inner: Arc<RamFS>,
+    inner: Arc<RamFs>,
 }
 
 impl FileSystem for TmpFs {
@@ -54,7 +54,7 @@ impl FsType for TmpFsType {
         _disk: Option<Arc<dyn aster_block::BlockDevice>>,
     ) -> Result<Arc<dyn FileSystem>> {
         Ok(Arc::new(TmpFs {
-            inner: RamFS::new(),
+            inner: RamFs::new(),
         }))
     }
 

--- a/kernel/src/fs/tmpfs/fs.rs
+++ b/kernel/src/fs/tmpfs/fs.rs
@@ -44,22 +44,21 @@ impl FsType for TmpFsType {
         "tmpfs"
     }
 
+    fn properties(&self) -> FsProperties {
+        FsProperties::empty()
+    }
+
     fn create(
         &self,
         _args: Option<CString>,
         _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-        _ctx: &Context,
     ) -> Result<Arc<dyn FileSystem>> {
         Ok(Arc::new(TmpFs {
             inner: RamFS::new(),
         }))
     }
 
-    fn properties(&self) -> FsProperties {
-        FsProperties::empty()
-    }
-
-    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysBranchNode>> {
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
         None
     }
 }

--- a/kernel/src/fs/tmpfs/mod.rs
+++ b/kernel/src/fs/tmpfs/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Temporary file system (tmpfs) based on RamFS.
+//! Temporary file system (tmpfs) based on RamFs.
 
 use alloc::sync::Arc;
 

--- a/kernel/src/fs/tmpfs/mod.rs
+++ b/kernel/src/fs/tmpfs/mod.rs
@@ -2,7 +2,7 @@
 
 //! Temporary file system (tmpfs) based on RamFs.
 
-use alloc::sync::Arc;
+use fs::TmpFsType;
 
 mod fs;
 
@@ -10,6 +10,5 @@ mod fs;
 const TMPFS_MAGIC: u64 = 0x0102_1994;
 
 pub(super) fn init() {
-    let ramfs_type = Arc::new(fs::TmpFsType);
-    super::registry::register(ramfs_type).unwrap();
+    super::registry::register(&TmpFsType).unwrap();
 }

--- a/kernel/src/fs/utils/page_cache.rs
+++ b/kernel/src/fs/utils/page_cache.rs
@@ -312,7 +312,7 @@ impl ReadaheadState {
             if pg_waiter.nreqs() > 0 {
                 self.waiter.concat(pg_waiter);
             } else {
-                // Some backends (e.g. RamFS) do not issue requests, but fill the page directly.
+                // Some backends (e.g. RamFs) do not issue requests, but fill the page directly.
                 async_page.store_state(PageState::UpToDate);
             }
             pages.put(async_idx, async_page);

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -180,7 +180,7 @@ fn get_fs(
         None
     };
 
-    fs_type.create(data, disk, ctx)
+    fs_type.create(data, disk)
 }
 
 bitflags! {


### PR DESCRIPTION
This PR removes `FsType::sysnode` and change the signature of `registery::register` to:
```rust
pub fn register(
    new_type: &'static dyn FsType,
    sysnode: Option<Arc<dyn SysBranchNode>>,
) -> Result<()>;
```

I think it makes more sense?

Meanwhile, there are some minor other cleanups and bug-fixes.

For example, I have no idea why we previously reject to mount the sysfs/cgroupfs twice. This behavior is basically wrong:
https://github.com/asterinas/asterinas/blob/d4d84f18b7288f7251c779aad5749de9ffbe368f/kernel/src/fs/sysfs/fs.rs#L77-L79