### PR TITLE
Introduce `VmPrinter` to write formatted output to the user space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
 name = "aster-systree"
 version = "0.1.0"
 dependencies = [
+ "aster-util",
  "bitflags 2.9.1",
  "component",
  "inherit-methods-macro",

--- a/kernel/comps/systree/Cargo.toml
+++ b/kernel/comps/systree/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bitflags = "2.5"
 ostd = { path = "../../../ostd" }
 component = { path = "../../libs/comp-sys/component" }
+aster-util = { path = "../../libs/aster-util" }
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e"}
 spin = "0.9"
 

--- a/kernel/comps/systree/src/lib.rs
+++ b/kernel/comps/systree/src/lib.rs
@@ -31,6 +31,7 @@ mod utils;
 
 use alloc::{borrow::Cow, sync::Arc};
 
+use aster_util::printer::VmPrinterError;
 use component::{init_component, ComponentInitError};
 use spin::Once;
 
@@ -98,6 +99,14 @@ impl core::fmt::Display for Error {
             Error::AlreadyExists => write!(f, "The systree item already exists"),
             Error::Overflow => write!(f, "Numerical overflow occurred"),
             Error::PageFault => write!(f, "Page fault occurred during memory access"),
+        }
+    }
+}
+
+impl From<VmPrinterError> for Error {
+    fn from(value: VmPrinterError) -> Self {
+        match value {
+            VmPrinterError::PageFault => Error::PageFault,
         }
     }
 }

--- a/kernel/comps/systree/src/lib.rs
+++ b/kernel/comps/systree/src/lib.rs
@@ -71,8 +71,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     /// Attempted to access a non-existent systree item
     NotFound,
-    /// Invalid operation for node type
-    InvalidNodeOperation(SysNodeType),
+    /// Invalid operation occurred
+    InvalidOperation,
     /// Attribute operation failed
     AttributeError,
     /// Permission denied for operation
@@ -83,20 +83,21 @@ pub enum Error {
     AlreadyExists,
     /// Arithmetic overflow occurred
     Overflow,
+    /// Page fault occurred during memory access
+    PageFault,
 }
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::NotFound => write!(f, "Attempted to access a non-existent systree item"),
-            Error::InvalidNodeOperation(ty) => {
-                write!(f, "Invalid operation for node type: {:?}", ty)
-            }
+            Error::InvalidOperation => write!(f, "Invalid operation occurred"),
             Error::AttributeError => write!(f, "Attribute error"),
             Error::PermissionDenied => write!(f, "Permission denied for operation"),
             Error::InternalError(msg) => write!(f, "Internal error: {}", msg),
             Error::AlreadyExists => write!(f, "The systree item already exists"),
             Error::Overflow => write!(f, "Numerical overflow occurred"),
+            Error::PageFault => write!(f, "Page fault occurred during memory access"),
         }
     }
 }

--- a/kernel/comps/systree/src/node.rs
+++ b/kernel/comps/systree/src/node.rs
@@ -155,7 +155,7 @@ pub trait SysNode: SysObj {
         let read_len = self.read_attr(name, &mut writer)?;
         // Use from_utf8_lossy or handle error properly if strict UTF-8 is needed
         let attr_val =
-            String::from_utf8(buf[..read_len].to_vec()).map_err(|_| Error::AttributeError)?;
+            String::from_utf8(buf[..read_len].to_vec()).map_err(|_| Error::InvalidOperation)?;
         Ok(attr_val)
     }
 

--- a/kernel/comps/systree/src/test.rs
+++ b/kernel/comps/systree/src/test.rs
@@ -81,7 +81,7 @@ inherit_sys_branch_node!(DeviceNode, fields, {
         let mut writer = VmWriter::from(&mut buffer[..]);
         let read_len = reader
             .read_fallible(&mut writer)
-            .map_err(|_| Error::AttributeError)?;
+            .map_err(|_| Error::PageFault)?;
 
         Ok(read_len)
     }

--- a/kernel/libs/aster-util/src/lib.rs
+++ b/kernel/libs/aster-util/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 pub mod coeff;
 pub mod dup;
 pub mod mem_obj_slice;
+pub mod printer;
 pub mod safe_ptr;
 pub mod slot_vec;
 pub mod union_read_ptr;

--- a/kernel/libs/aster-util/src/printer.rs
+++ b/kernel/libs/aster-util/src/printer.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::fmt::{Arguments, Write};
+
+use ostd::mm::{FallibleVmWrite, VmReader, VmWriter};
+
+/// A specialized printer for formatted text output.
+///
+/// `VmPrinter` is designed to handle the common pattern in kernel where kernel
+/// code needs to generate formatted text output (like status information, statistics,
+/// or configuration data) and write it to user space with proper offset handling.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use aster_util::printer::VmPrinter;
+/// use ostd::{mm::VmWriter, Pod};
+///
+/// let mut buf = [0u8; 3];
+/// let mut writer = VmWriter::from(buf.as_bytes_mut()).to_fallible();
+/// let mut printer = VmPrinter::new_skip(&mut writer, 3);
+///
+/// let res = writeln!(printer, "val: {}", 123);
+/// assert!(res.is_ok());
+///
+/// assert_eq!(printer.bytes_written(), 3);
+/// assert_eq!(&buf, b": 1");
+/// ```
+pub struct VmPrinter<'a, 'b> {
+    /// The underlying [`VmWriter`] to write the final output.
+    writer: &'a mut VmWriter<'b>,
+    /// Number of bytes to skip from the beginning of the output.
+    ///
+    /// When content is written through this writer, the first `bytes_to_skip`
+    /// bytes will be discarded, and only subsequent bytes will be written
+    /// to the underlying `VmWriter`.
+    bytes_to_skip: usize,
+    /// Total number of bytes written to the underlying writer.
+    bytes_written: usize,
+}
+
+impl<'a, 'b> VmPrinter<'a, 'b> {
+    /// Creates a new `VmPrinter` that prints to `writer`.
+    fn new(writer: &'a mut VmWriter<'b>) -> Self {
+        Self {
+            writer,
+            bytes_to_skip: 0,
+            bytes_written: 0,
+        }
+    }
+
+    /// Creates a new `VmPrinter` that skips the first `bytes_to_skip` bytes and prints the
+    /// remaining bytes to `writer`.
+    pub fn new_skip(writer: &'a mut VmWriter<'b>, bytes_to_skip: usize) -> Self {
+        Self {
+            writer,
+            bytes_to_skip,
+            bytes_written: 0,
+        }
+    }
+
+    /// Returns the total number of bytes written to the underlying writer.
+    pub fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+
+    /// Writes formatted content to the underlying writer.
+    pub fn write_fmt(&mut self, args: Arguments<'_>) -> Result<(), VmPrinterError> {
+        Write::write_fmt(self, args).map_err(|_| VmPrinterError::PageFault)
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> core::fmt::Result {
+        if self.bytes_to_skip >= bytes.len() {
+            self.bytes_to_skip -= bytes.len();
+            return Ok(());
+        }
+
+        let bytes_to_write = &bytes[self.bytes_to_skip..];
+        if self.bytes_to_skip > 0 {
+            self.bytes_to_skip = 0;
+        }
+
+        let mut reader = VmReader::from(bytes_to_write);
+        let written_len = self
+            .writer
+            .write_fallible(&mut reader)
+            .map_err(|_| core::fmt::Error)?;
+
+        self.bytes_written += written_len;
+
+        Ok(())
+    }
+}
+
+impl Write for VmPrinter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write_bytes(s.as_bytes())
+    }
+}
+
+impl<'a, 'b> From<&'a mut VmWriter<'b>> for VmPrinter<'a, 'b> {
+    fn from(writer: &'a mut VmWriter<'b>) -> Self {
+        Self::new(writer)
+    }
+}
+
+/// An error returned by [`VmPrinter::write_fmt`].
+pub enum VmPrinterError {
+    /// Page fault occurred.
+    PageFault,
+}
+
+#[cfg(ktest)]
+mod test {
+    use ostd::{mm::VmWriter, prelude::*, Pod};
+
+    use super::*;
+
+    #[ktest]
+    fn basic_write() {
+        let mut buf = [0u8; 64];
+        let mut writer = VmWriter::from(buf.as_bytes_mut()).to_fallible();
+        let mut printer = VmPrinter::from(&mut writer);
+
+        let res = writeln!(printer, "test");
+        assert!(res.is_ok());
+
+        assert_eq!(printer.bytes_written(), 5);
+        assert_eq!(&buf[..5], b"test\n");
+    }
+
+    #[ktest]
+    fn write_with_skip() {
+        let mut buf = [0u8; 3];
+        let mut writer = VmWriter::from(buf.as_bytes_mut()).to_fallible();
+        let mut printer = VmPrinter::new_skip(&mut writer, 3);
+
+        let res = writeln!(printer, "val: {}", 123);
+        assert!(res.is_ok());
+
+        assert_eq!(printer.bytes_written(), 3);
+        assert_eq!(&buf, b": 1");
+    }
+
+    #[ktest]
+    fn skip_all_content() {
+        let mut buf = [0u8; 64];
+        let mut writer = VmWriter::from(buf.as_bytes_mut()).to_fallible();
+        let mut printer = VmPrinter::new_skip(&mut writer, 100);
+
+        let res = writeln!(printer, "short message");
+        assert!(res.is_ok());
+
+        // Nothing should be written
+        assert_eq!(printer.bytes_written(), 0);
+        assert_eq!(buf[0], 0);
+    }
+}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -333,12 +333,13 @@ impl From<aster_systree::Error> for Error {
         use aster_systree::Error::*;
         match err {
             NotFound => Error::new(Errno::ENOENT),
-            InvalidNodeOperation(_) => Error::new(Errno::EINVAL),
+            InvalidOperation => Error::new(Errno::EINVAL),
             AttributeError => Error::new(Errno::EIO),
             PermissionDenied => Error::new(Errno::EACCES),
             InternalError(msg) => Error::with_message(Errno::EIO, msg),
             AlreadyExists => Error::new(Errno::EEXIST),
             Overflow => Error::new(Errno::EOVERFLOW),
+            PageFault => Error::new(Errno::EFAULT),
         }
     }
 }

--- a/kernel/src/fs/cgroupfs/systree_node.rs
+++ b/kernel/src/fs/cgroupfs/systree_node.rs
@@ -125,7 +125,7 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
         // This method should be a no-op for `RootNode`.
     }
 
-    fn read_attr(&self, _name: &str, _writer: &mut VmWriter) -> Result<usize> {
+    fn read_attr_at(&self, _name: &str, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
         // TODO: Add support for reading attributes.
         Err(Error::AttributeError)
     }
@@ -147,7 +147,7 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
 });
 
 inherit_sys_branch_node!(CgroupNode, fields, {
-    fn read_attr(&self, _name: &str, _writer: &mut VmWriter) -> Result<usize> {
+    fn read_attr_at(&self, _name: &str, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
         // TODO: Add support for reading attributes.
         Err(Error::AttributeError)
     }

--- a/kernel/src/fs/sysfs/test.rs
+++ b/kernel/src/fs/sysfs/test.rs
@@ -85,11 +85,7 @@ inherit_sys_leaf_node!(MockLeafNode, fields, {
             return Err(SysTreeError::PermissionDenied);
         }
         let data = self.data.read();
-        let value = data.get(name).ok_or(SysTreeError::AttributeError)?; // Should exist if in attrs
-        let bytes = value.as_bytes();
-        writer
-            .write_fallible(&mut bytes.into())
-            .map_err(|_| SysTreeError::AttributeError)
+        let value = data.get(name).ok_or(SysTreeError::NotFound)?; // Should exist if in attrs
     }
 
     fn write_attr(&self, name: &str, reader: &mut VmReader) -> SysTreeResult<usize> {
@@ -163,7 +159,7 @@ inherit_sys_branch_node!(MockBranchNode, fields, {
         }
         let value = match name {
             "branch_attr" => "branch_value",
-            _ => return Err(SysTreeError::AttributeError),
+            _ => return Err(SysTreeError::NotFound),
         };
         let bytes = value.as_bytes();
         writer

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -361,13 +361,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
             return Err(Error::new(Errno::EINVAL));
         };
 
-        let len = if offset == 0 {
-            leaf.read_attr(attr.name(), buf)?
-        } else {
-            // The `read_attr_at` method is more general than `read_attr`,
-            // but it could be less efficient. So we only use the more general form when necessary.
-            leaf.read_attr_at(attr.name(), offset, buf)?
-        };
+        let len = leaf.read_attr_at(attr.name(), offset, buf)?;
 
         Ok(len)
     }


### PR DESCRIPTION
A implemenation for the design of @lrh2000 in the [comment](https://github.com/asterinas/asterinas/pull/2160#discussion_r2322555452).

This PR can give the code that generates output to user-space data and writes to the writer a better shape. It can also benefit the code in `ProcFs`.

One thing I'm not entirely sure about is the location of the implementation. Currently, since this writer serves kernel-generated data and is somewhat aligned with `SysTree`, and the primary users are methods related to `SysTree`, I've placed it in the corresponding crate. However, I'm not certain if this would still be appropriate if there are future users, such as those related to `ProcFs`.