### PR TITLE
Add stage support for init_component macro

### DIFF
--- a/kernel/libs/comp-sys/component-macro/src/lib.rs
+++ b/kernel/libs/comp-sys/component-macro/src/lib.rs
@@ -11,11 +11,15 @@ mod priority;
 use init_comp::ComponentInitFunction;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::parse_macro_input;
+use syn::{parse_macro_input, LitStr};
 
 pub(crate) const COMPONENT_FILE_NAME: &str = "Components.toml";
 
 /// Register a function to be called when the component system is initialized. The function should not public.
+///
+/// You can specify the initialization stage:
+/// - `#[init_component]` - uses default "early" stage
+/// - `#[init_component("stage-name")]` - uses specified stage
 ///
 /// Example:
 /// ```rust
@@ -23,7 +27,6 @@ pub(crate) const COMPONENT_FILE_NAME: &str = "Components.toml";
 /// fn init() -> Result<(), component::ComponentInitError> {
 ///     Ok(())
 /// }
-///
 /// ```
 ///
 /// It will expand to
@@ -32,26 +35,23 @@ pub(crate) const COMPONENT_FILE_NAME: &str = "Components.toml";
 ///     Ok(())
 /// }
 ///
-/// const fn file() -> &'static str{
-///     file!()
-/// }
-///
-/// component::submit!(component::ComponentRegistry::new(&init,file()));
+/// component::submit!(component::ComponentRegistry::new("early", &init, file!()));
 /// ```
 /// The priority will calculate automatically
 ///
 #[proc_macro_attribute]
-pub fn init_component(_: TokenStream, input: TokenStream) -> proc_macro::TokenStream {
+pub fn init_component(args: TokenStream, input: TokenStream) -> proc_macro::TokenStream {
+    let stage = if args.is_empty() {
+        LitStr::new("early", proc_macro2::Span::call_site())
+    } else {
+        parse_macro_input!(args as LitStr)
+    };
     let function = parse_macro_input!(input as ComponentInitFunction);
     let function_name = &function.function_name;
     quote! {
         #function
 
-        const fn file() -> &'static str{
-            file!()
-        }
-
-        component::submit!(component::ComponentRegistry::new(&#function_name,file()));
+        component::submit!(component::ComponentRegistry::new(#stage, &#function_name, file!()));
     }
     .into()
 }
@@ -65,7 +65,7 @@ pub fn init_component(_: TokenStream, input: TokenStream) -> proc_macro::TokenSt
 /// Example:
 ///
 /// ```rust
-///     component::init_all(component::parse_metadata!());
+///     component::init_all("early", component::parse_metadata!());
 /// ```
 ///
 #[proc_macro]

--- a/kernel/libs/comp-sys/component/README.md
+++ b/kernel/libs/comp-sys/component/README.md
@@ -7,7 +7,12 @@ This crate is used for the initialization of the component system, which provide
 
 ### Register component
 
-Registering a crate as component by marking a function in the lib.rs with `#[init_component]` macro. The specific definition of the function can refer to the comments in the macro.
+Registering a crate as component by marking a function in the lib.rs with `#[init_component]` macro. You can specify initialization stage:
+
+- `#[init_component]` - uses default "early" stage
+- `#[init_component("stage-name")]` - uses specified stage
+
+The specific definition of the function can refer to the comments in the macro.
 
 ### Component initialization
 
@@ -45,7 +50,7 @@ fn init() -> Result<(), component::ComponentInitError> {
 }
 
 fn main(){
-    component::init_all(component::parse_metadata!()).unwrap();
+    component::init_all("early", component::parse_metadata!()).unwrap();
     assert_eq!(INIT_COUNT.load(Relaxed),2);
 }
 ```

--- a/kernel/libs/comp-sys/component/src/lib.rs
+++ b/kernel/libs/comp-sys/component/src/lib.rs
@@ -28,16 +28,22 @@ pub enum ComponentInitError {
 }
 
 pub struct ComponentRegistry {
+    stage: &'static str,
     function: &'static (dyn Fn() -> Result<(), ComponentInitError> + Sync),
     path: &'static str,
 }
 
 impl ComponentRegistry {
     pub const fn new(
+        stage: &'static str,
         function: &'static (dyn Fn() -> Result<(), ComponentInitError> + Sync),
         path: &'static str,
     ) -> Self {
-        Self { function, path }
+        Self {
+            stage,
+            function,
+            path,
+        }
     }
 }
 
@@ -46,6 +52,7 @@ inventory::collect!(ComponentRegistry);
 impl Debug for ComponentRegistry {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ComponentRegistry")
+            .field("stage", &self.stage)
             .field("path", &self.path)
             .finish()
     }
@@ -105,17 +112,22 @@ pub enum ComponentSystemInitError {
     NotIncludeAllComponent(String),
 }
 
-/// Component system initialization. It will collect invoke all functions that are marked by init_component based on dependencies between crates.
+/// Initialize the component system for a specific stage. It collects and invokes all
+/// functions marked with `#[init_component]` (or `#[init_component("stage-name")]`) that belong
+/// to the given stage, honoring dependencies/priority between crates.
 ///
 /// The collection of ComponentInfo usually generate by `parse_metadata` macro.
 ///
 /// ```rust
-///     component::init_all(component::parse_metadata!());
+///     component::init_all("early", component::parse_metadata!());
 /// ```
 ///
-pub fn init_all(components: Vec<ComponentInfo>) -> Result<(), ComponentSystemInitError> {
+pub fn init_all(
+    stage: &str,
+    components: Vec<ComponentInfo>,
+) -> Result<(), ComponentSystemInitError> {
     let components_info = parse_input(components);
-    match_and_call(components_info)?;
+    match_and_call(stage, components_info)?;
     Ok(())
 }
 
@@ -130,10 +142,15 @@ fn parse_input(components: Vec<ComponentInfo>) -> BTreeMap<String, ComponentInfo
 
 /// Match the ComponentInfo with ComponentRegistry. The key is the relative path of one component
 fn match_and_call(
+    stage: &str,
     mut components: BTreeMap<String, ComponentInfo>,
 ) -> Result<(), ComponentSystemInitError> {
     let mut infos = Vec::new();
     for registry in inventory::iter::<ComponentRegistry> {
+        if registry.stage != stage {
+            continue;
+        }
+
         // relative/path/to/comps/pci/src/lib.rs
         let mut str: String = registry.path.to_owned();
         str = str.replace('\\', "/");
@@ -169,7 +186,7 @@ fn match_and_call(
 
     infos.sort();
     debug!("component infos: {infos:?}");
-    info!("Components initializing...");
+    info!("Components {stage} initializing...");
 
     for i in infos {
         info!("Component initializing:{:?}", i);
@@ -179,6 +196,6 @@ fn match_and_call(
             info!("Component initialize complete");
         }
     }
-    info!("All components initialization completed");
+    info!("All components {stage} initialization completed");
     Ok(())
 }

--- a/kernel/libs/comp-sys/component/tests/init-order/second-init/tests/test.rs
+++ b/kernel/libs/comp-sys/component/tests/init-order/second-init/tests/test.rs
@@ -6,6 +6,6 @@ use std::sync::atomic::Ordering::Relaxed;
 #[test]
 fn test() {
     simple_logger::init_with_level(log::Level::Debug).unwrap();
-    component::init_all(component::parse_metadata!()).unwrap();
+    component::init_all("early", component::parse_metadata!()).unwrap();
     assert_eq!(HAS_INIT.load(Relaxed), true);
 }

--- a/kernel/libs/comp-sys/component/tests/init-order/src/main.rs
+++ b/kernel/libs/comp-sys/component/tests/init-order/src/main.rs
@@ -17,7 +17,7 @@ fn kernel_init() -> Result<(), component::ComponentInitError> {
 
 fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
-    component::init_all(component::parse_metadata!()).unwrap();
+    component::init_all("early", component::parse_metadata!()).unwrap();
     assert_eq!(first_init::HAS_INIT.load(Relaxed), true);
     assert_eq!(second_init::HAS_INIT.load(Relaxed), true);
     assert_eq!(HAS_INIT.load(Relaxed), true);

--- a/kernel/libs/comp-sys/component/tests/init-order/tests/test.rs
+++ b/kernel/libs/comp-sys/component/tests/init-order/tests/test.rs
@@ -12,6 +12,6 @@ fn kernel_init() -> Result<(), component::ComponentInitError> {
 #[test]
 fn test() {
     simple_logger::init_with_level(log::Level::Debug).unwrap();
-    component::init_all(component::parse_metadata!()).unwrap();
+    component::init_all("early", component::parse_metadata!()).unwrap();
     assert_eq!(HAS_INIT.load(Relaxed), true);
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -83,7 +83,7 @@ mod vm;
 #[controlled]
 fn main() {
     ostd::early_println!("[kernel] OSTD initialized. Preparing components.");
-    component::init_all(component::parse_metadata!()).unwrap();
+    component::init_all("early", component::parse_metadata!()).unwrap();
     init();
 
     // Spawn all AP idle threads.
@@ -118,12 +118,14 @@ fn init_in_first_kthread(fs_resolver: &FsResolver) {
     ipc::init_in_first_kthread();
     #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     vdso::init_in_first_kthread();
+    component::init_all("in_first_kthread", component::parse_metadata!()).unwrap();
 }
 
 fn init_in_first_process(ctx: &Context) {
     device::init_in_first_process(ctx).unwrap();
     fs::init_in_first_process(ctx);
     process::init_in_first_process(ctx);
+    component::init_all("in_first_process", component::parse_metadata!()).unwrap();
 }
 
 fn ap_init() {


### PR DESCRIPTION
This PR enhances the `#[init_component]` macro by adding stage specification support, allowing components to be initialized at different boot stages.
- `#[init_component]` - uses default "early" stage
- `#[init_component("stage-name")]` - uses specified stage

This change is needed to properly initialize block devices and their partitions during system boot:

Block components were being initialized in the "early" stage, but partition node recognition and initialization requires creating kernel threads for I/O operations, which cannot be done in the early boot stage.
 
By adding stage support, we can:
1. Initialize block device components in "early" stage (current behavior)
2. Defer partition node recognition and initialization to "first_kthread" stage where kthread creation is available

This allows for more flexible and correct initialization ordering of system components, particularly for storage subsystems that have complex initialization dependencies.
