### PR TITLE
Fix the bug in `is_mount_root` method

### DIFF
--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -140,11 +140,6 @@ impl Dentry {
         }
     }
 
-    /// Currently, the root `Dentry` of a fs is the root of a mount.
-    pub(super) fn is_mount_root(&self) -> bool {
-        self.name_and_parent.read().as_ref().is_none()
-    }
-
     /// Creates a `Dentry_` by creating a new inode of the `type_` with the `mode`.
     pub(super) fn create(
         &self,


### PR DESCRIPTION
This is a bug encountered during supporting Podman.

When bind the `src_path` to the `dst_path`, the `dentry` of the `src_path` becomes the root of the new mount node, but But it originally had a parent in the source mount. Hence the original logics of `is_mount_root` is wrong.