### PR TITLE
Add `futex`, `lseek` and `newfstatat` syscall limitation to the book

### DIFF
--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-and-directory-operations.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-and-directory-operations.md
@@ -97,3 +97,40 @@ Unsupported flags:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/rename.2.html).
+
+## `lseek`
+
+Supported functionality in SCML:
+
+```c
+// Set file offset
+lseek(
+    fd, offset,
+    whence = SEEK_SET | SEEK_CUR | SEEK_END
+);
+```
+
+Unsupported flags:
+* `SEEK_DATA`
+* `SEEK_HOLE`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/lseek.2.html).
+
+## `newfstatat`
+
+Supported functionality in SCML:
+
+```c
+// Retrieve file status by file descriptor
+newfstatat(
+    dirfd, path, statbuf,
+    flags = AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW
+);
+```
+
+Silently-ignored flags:
+* `AT_NO_AUTOMOUNT`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/newfstatat.2.html).

--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/inter-process-communication.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/inter-process-communication.md
@@ -100,3 +100,67 @@ Unsupported commands:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/semctl.2.html).
+
+### `futex`
+
+Supported functionality in SCML:
+
+```c
+opt_flags = FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME;
+
+// Block current thread if target value at `uaddr` matches `val`, and wait up to `timeout`.
+futex(
+    uaddr,
+    futex_op = FUTEX_WAIT | <opt_flags>,
+    val, timeout
+);
+
+// Block current thread with bitmask condition if target value at `uaddr` matches `val`,
+// and wait up to `timeout`.
+futex(
+    uaddr,
+    futex_op = FUTEX_WAIT_BITSET | <opt_flags>,
+    val, timeout, unused = NULL, bitmask
+);
+
+// Unblock up to `max_waiters` threads waiting on `uaddr`
+futex(
+    uaddr,
+    futex_op = FUTEX_WAKE | <opt_flags>,
+    max_waiters
+);
+
+// Unblock up to `max_waiters` threads on `uaddr`, if the value on `uaddr` matches `bitmask`
+futex(
+    uaddr,
+    futex_op = FUTEX_WAKE_BITSET | <opt_flags>,
+    max_waiters, unused0 = NULL, unused1 = NULL, bitmask
+);
+
+// Unblock up to `max_waiters` threads waiting on `uaddr`, and requeue up to
+// `max_requeue_waiters` of the remaining waiters to the target futex at `uaddr2`.
+futex(
+    uaddr,
+    futex_op = FUTEX_REQUEUE | <opt_flags>,
+    max_waiters, max_requeue_waiters, uaddr2
+);
+
+// Perform atomic operation encoded in `operation` on `uaddr2`. Unblock up to `max_waiters`
+// threads waiting on `uaddr`, and conditionally unblock up to `max_waiters2` threads
+// waiting on `uaddr2` based on the result of the atomic operation.
+futex(
+    uaddr,
+    futex_op = FUTEX_WAKE_OP | <opt_flags>,
+    max_waiters, max_waiters2, uaddr2, operation
+);
+```
+
+Unsupported operations:
+* `FUTEX_FD`
+* `FUTEX_CMP_REQUEUE`
+* `FUTEX_LOCK_PI`
+* `FUTEX_UNLOCK_PI`
+* `FUTEX_TRYLOCK_PI`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/futex.2.html).


### PR DESCRIPTION
This PR adds syscall limitations documentation via System Call Matching Language (SCML) for: `futex`, `lseek` and `newfstatat`.