### PR TITLE
Improve CPU selection algorithm

### DIFF
--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -298,9 +298,11 @@ impl ClassScheduler {
                     .iter()
                     .filter(|&cpu| cpu.as_usize() as isize <= last_chosen),
             );
+        let policy = thread.sched_attr().policy_kind();
         for candidate in affinity_iter {
             let rq = self.rqs[candidate.as_usize()].lock();
-            let (load, _) = rq.nr_queued_and_running();
+            let (queued, running) = rq.nr_queued_and_running_for_policy(policy);
+            let load = queued + running;
             if load < minimum_load {
                 minimum_load = load;
                 selected = candidate;
@@ -334,8 +336,19 @@ impl PerCpuClassRqSet {
 
     fn nr_queued_and_running(&self) -> (u32, u32) {
         let queued = self.stop.len() + self.real_time.len() + self.fair.len() + self.idle.len();
-        let running = usize::from(self.current.is_some());
-        (queued as u32, running as u32)
+        let running = u32::from(self.current.is_some());
+        (queued as u32, running)
+    }
+
+    fn nr_queued_and_running_for_policy(&self, policy: SchedPolicyKind) -> (u32, u32) {
+        let queued = match policy {
+            SchedPolicyKind::Stop => self.stop.len(),
+            SchedPolicyKind::RealTime => self.real_time.len(),
+            SchedPolicyKind::Fair => self.fair.len(),
+            SchedPolicyKind::Idle => self.idle.len(),
+        };
+        let running = u32::from(self.current.is_some());
+        (queued as u32, running)
     }
 }
 


### PR DESCRIPTION
When selecting a CPU for a thread, compare loads of run queues compatible with the thread's policy.

This change significantly improves tail latency on higher SMPs.

### On `main`

```
~ # ./benchmark/schbench/smp8/run.sh
setting worker threads to 8
warmup done, zeroing stats
Wakeup Latencies percentiles (usec) runtime 90 (s) (26050 total samples)
	  50.0th: 20         (7876 samples)
	  90.0th: 37         (9749 samples)
	* 99.0th: 42688      (2347 samples)
	  99.9th: 121472     (232 samples)
	  min=1, max=211585
Request Latencies percentiles (usec) runtime 90 (s) (26056 total samples)
	  50.0th: 13008      (7790 samples)
	  90.0th: 59712      (10440 samples)
	* 99.0th: 157952     (2328 samples)
	  99.9th: 282112     (234 samples)
	  min=5829, max=546047
RPS percentiles (requests) runtime 90 (s) (0 total samples)
	  20.0th: 0          (0 samples)
	* 50.0th: 0          (0 samples)
	  90.0th: 0          (0 samples)
	  min=0, max=0
average rps: 308.38
```

### On my branch

```
~ # ./benchmark/schbench/smp8/run.sh 
setting worker threads to 8
warmup done, zeroing stats
Wakeup Latencies percentiles (usec) runtime 90 (s) (26592 total samples)
	  50.0th: 44         (8419 samples)
	  90.0th: 70         (10004 samples)
	* 99.0th: 89         (2397 samples)
	  99.9th: 105        (211 samples)
	  min=1, max=541
Request Latencies percentiles (usec) runtime 90 (s) (26735 total samples)
	  50.0th: 16176      (8058 samples)
	  90.0th: 33216      (10660 samples)
	* 99.0th: 70528      (2406 samples)
	  99.9th: 115072     (235 samples)
	  min=3071, max=204847
RPS percentiles (requests) runtime 90 (s) (0 total samples)
	  20.0th: 0          (0 samples)
	* 50.0th: 0          (0 samples)
	  90.0th: 0          (0 samples)
	  min=0, max=0
average rps: 314.64
```