### PR TITLE
Handle 8-bit/24-bit ANSI color codes for framebuffer

### DIFF
--- a/kernel/comps/framebuffer/src/ansi_escape.rs
+++ b/kernel/comps/framebuffer/src/ansi_escape.rs
@@ -152,25 +152,100 @@ impl EscapeFsm {
 
     /// Handles the "Select Graphic Rendition" sequence.
     fn handle_srg<T: EscapeOp>(&self, num_params: usize, op: &mut T) {
-        for param in &self.params[..num_params] {
-            match param {
+        let mut cursor = 0;
+        while cursor < num_params {
+            let op_code = self.params[cursor];
+            cursor += 1;
+
+            match op_code {
                 // Reset text attributes
                 0 => {
                     op.set_fg_color(Pixel::WHITE);
                     op.set_bg_color(Pixel::BLACK);
                 }
 
-                // Set foreground and background colors
-                // Reference: <https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit>
-                30..=37 => op.set_fg_color(COLORS[*param as usize - 30]),
-                90..=97 => op.set_fg_color(COLORS[*param as usize - 90 + 8]),
-                40..=47 => op.set_bg_color(COLORS[*param as usize - 40]),
-                100..=107 => op.set_bg_color(COLORS[*param as usize - 100 + 8]),
+                // Set foreground colors
+                // Reference: <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
+                30..=37 => op.set_fg_color(COLORS[op_code as usize - 30]),
+                38 if num_params - cursor >= 2 && self.params[cursor] == 5 => {
+                    op.set_fg_color(Self::get_256_color(self.params[cursor + 1] as u8));
+                    cursor += 2;
+                }
+                38 if num_params - cursor >= 4 && self.params[cursor] == 2 => {
+                    op.set_fg_color(Pixel {
+                        red: self.params[cursor + 1] as u8,
+                        green: self.params[cursor + 2] as u8,
+                        blue: self.params[cursor + 3] as u8,
+                    });
+                    cursor += 4;
+                }
+                // Reset to the default foreground color
+                39 => op.set_fg_color(Pixel::WHITE),
+                90..=97 => op.set_fg_color(COLORS[op_code as usize - 90 + 8]),
+
+                // Set background colors
+                // Reference: <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
+                40..=47 => op.set_bg_color(COLORS[op_code as usize - 40]),
+                48 if num_params - cursor >= 2 && self.params[cursor] == 5 => {
+                    op.set_bg_color(Self::get_256_color(self.params[cursor + 1] as u8));
+                    cursor += 2;
+                }
+                48 if num_params - cursor >= 4 && self.params[cursor] == 2 => {
+                    op.set_bg_color(Pixel {
+                        red: self.params[cursor + 1] as u8,
+                        green: self.params[cursor + 2] as u8,
+                        blue: self.params[cursor + 3] as u8,
+                    });
+                    cursor += 4;
+                }
+                // Reset to the default background color
+                49 => op.set_bg_color(Pixel::BLACK),
+                100..=107 => op.set_bg_color(COLORS[op_code as usize - 100 + 8]),
 
                 // Invalid or unsupported
-                _ => {}
+                _ => return,
             }
         }
+    }
+
+    /// Gets the 256-color used by Linux TTY.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.16.7/source/drivers/tty/vt/vt.c#L1599>
+    fn get_256_color(i: u8) -> Pixel {
+        // Arithmetic operations below won't overflow because `i` comes from a `u8`.
+        let mut i = i as u16;
+        let (red, green, blue) = match i {
+            // Standard colors.
+            0..=7 => {
+                let r = if i & 1 != 0 { 0xaa } else { 0x00 };
+                let g = if i & 2 != 0 { 0xaa } else { 0x00 };
+                let b = if i & 4 != 0 { 0xaa } else { 0x00 };
+                (r, g, b)
+            }
+            8..=15 => {
+                let r = if i & 1 != 0 { 0xff } else { 0x55 };
+                let g = if i & 2 != 0 { 0xff } else { 0x55 };
+                let b = if i & 4 != 0 { 0xff } else { 0x55 };
+                (r, g, b)
+            }
+            // 6x6x6 color cube.
+            16..=231 => {
+                i -= 16;
+                let b = i % 6 * 255 / 6;
+                i /= 6;
+                let g = i % 6 * 255 / 6;
+                i /= 6;
+                let r = i * 255 / 6;
+                (r as u8, g as u8, b as u8)
+            }
+            // Grayscale ramp.
+            _ => {
+                let g = (i * 10 - 2312) as u8;
+                (g, g, g)
+            }
+        };
+
+        Pixel { red, green, blue }
     }
 }
 
@@ -264,6 +339,51 @@ mod test {
         assert_eq!(state.fg, Pixel::WHITE);
         eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[107m");
         assert_eq!(state.bg, Pixel::WHITE);
+
+        assert!(!esc_fsm.eat(b'a', &mut state));
+
+        // Reset.
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[m");
+        assert_eq!(state.fg, Pixel::WHITE);
+        assert_eq!(state.bg, Pixel::BLACK);
+
+        assert!(!esc_fsm.eat(b'a', &mut state));
+
+        // Set the foreground color and background color using 8-bit/24-bit code.
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[38;5;0m");
+        assert_eq!(state.fg, Pixel::BLACK);
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[48;2;255;255;255m");
+        assert_eq!(state.bg, Pixel::WHITE);
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[38;5;8;48;5;16m");
+        assert_eq!(
+            state.fg,
+            Pixel {
+                red: 85,
+                green: 85,
+                blue: 85
+            }
+        );
+        assert_eq!(state.bg, Pixel::BLACK);
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[39;48;2;41;41;41m");
+        assert_eq!(state.fg, Pixel::WHITE);
+        assert_eq!(
+            state.bg,
+            Pixel {
+                red: 41,
+                green: 41,
+                blue: 41
+            }
+        );
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[38;5;255;49m");
+        assert_eq!(
+            state.fg,
+            Pixel {
+                red: 238,
+                green: 238,
+                blue: 238
+            }
+        );
+        assert_eq!(state.bg, Pixel::BLACK);
 
         assert!(!esc_fsm.eat(b'a', &mut state));
 


### PR DESCRIPTION
This PR enhances the framebuffer's ANSI escape sequence handling to support advanced color specifications including 8-bit (256-color) and 24-bit (true color) modes ~~, while also updating the standard 16-color palette to use xterm color values instead of VGA color values~~.

With this PR, the new logo (from #2427) will be rendered in the framebuffer as follows:
<img width="1078" height="560" alt="image" src="https://github.com/user-attachments/assets/ac01714e-2197-4ae4-9fd2-949de492d86f" />
