### PR TITLE
Support `MS_REMOUNT` flag

### DIFF
--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-systems-and-mount-control.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/file-systems-and-mount-control.md
@@ -32,31 +32,29 @@ mount(
 // Create a bind mount
 mount(
     source, target, filesystemtype,
-    mountflags = MS_BIND | MS_REC | MS_MOVE,
+    mountflags = MS_BIND | MS_REC,
     data
 );
 ```
 
-Silently-ignored mount flags:
-* `MS_DIRSYNC`
-* `MS_LAZYTIME`
-* `MS_MANDLOCK`
-* `MS_NOATIME`
-* `MS_NODEV`
-* `MS_NODIRATIME`
-* `MS_NOEXEC`
-* `MS_NOSUID`
-* `MS_RDONLY`
-* `MS_RELATIME`
-* `MS_SILENT`
-* `MS_STRICTATIME`
-* `MS_SYNCHRONOUS`
-
 Partially supported mount flags:
 * `MS_REC` is only effective when used in conjunction with `MS_BIND`
+* `MS_REMOUNT` can be used, but the set options have no actual effect.
+* `MS_DIRSYNC` can be set but have no atual effect.
+* `MS_LAZYTIME` can be set but have no atual effect.
+* `MS_MANDLOCK` can be set but have no atual effect.
+* `MS_NOATIME` can be set but have no atual effect.
+* `MS_NODEV` can be set but have no atual effect.
+* `MS_NODIRATIME` can be set but have no atual effect.
+* `MS_NOEXEC` can be set but have no atual effect.
+* `MS_NOSUID` can be set but have no atual effect.
+* `MS_RDONLY` can be set but have no atual effect.
+* `MS_RELATIME` can be set but have no atual effect.
+* `MS_SILENT` can be set but have no atual effect.
+* `MS_STRICTATIME` can be set but have no atual effect.
+* `MS_SYNCHRONOUS` can be set but have no atual effect.
 
 Unsupported mount flags:
-* `MS_REMOUNT`
 * `MS_SHARED`
 * `MS_PRIVATE`
 * `MS_SLAVE`

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -5,7 +5,7 @@
 use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
-pub use mount::Mount;
+pub use mount::{AtimePolicy, Mount, MountOptions};
 
 use crate::{
     fs::{

--- a/kernel/src/fs/path/mount.rs
+++ b/kernel/src/fs/path/mount.rs
@@ -13,6 +13,85 @@ use crate::{
     prelude::*,
 };
 
+/// The options of a [`Mount`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MountOptions {
+    inner: MountOptionsInner,
+    atime_policy: AtimePolicy,
+}
+
+impl Default for MountOptions {
+    fn default() -> Self {
+        Self {
+            inner: MountOptionsInner::empty(),
+            atime_policy: AtimePolicy::Relatime,
+        }
+    }
+}
+
+impl MountOptions {
+    /// Sets nosuid attribute.
+    pub fn set_nosuid(&mut self) {
+        self.inner.set(MountOptionsInner::NOSUID, true);
+    }
+
+    /// Sets nodev attribute.
+    pub fn set_nodev(&mut self) {
+        self.inner.set(MountOptionsInner::NODEV, true);
+    }
+
+    /// Sets noexec attribute.
+    pub fn set_noexec(&mut self) {
+        self.inner.set(MountOptionsInner::NOEXEC, true);
+    }
+
+    /// Sets rdonly attribute.
+    pub fn set_rdonly(&mut self) {
+        self.inner.set(MountOptionsInner::RDONLY, true);
+    }
+
+    /// Sets nodiratime attribute.
+    pub fn set_nodiratime(&mut self) {
+        self.inner.set(MountOptionsInner::NODIRATIME, true);
+    }
+
+    /// Sets the atime policy.
+    pub fn set_atime_policy(&mut self, policy: AtimePolicy) {
+        self.atime_policy = policy;
+    }
+
+    /// Returns the atime policy.
+    pub fn atime_policy(&self) -> AtimePolicy {
+        self.atime_policy
+    }
+}
+
+bitflags! {
+    struct MountOptionsInner: u8 {
+        /// Ignore suid and sgid bits.
+        const NOSUID = 1 << 0;
+        /// Disallow access to device special files.
+        const NODEV = 1 << 1;
+        /// Disallow program execution.
+        const NOEXEC = 1 << 2;
+        /// Mount read-only.
+        const RDONLY = 1 << 3;
+        /// Do not update directory access times.
+        const NODIRATIME = 1 << 4;
+    }
+}
+
+/// The policy for updating access times (atime).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AtimePolicy {
+    /// Update atime relative to mtime/ctime.
+    Relatime,
+    /// Do not update access times.
+    Noatime,
+    /// Always perform atime updates.
+    Strictatime,
+}
+
 /// A `Mount` represents a mounted filesystem instance in the VFS.
 ///
 /// Each `Mount` can be viewed as a node in the mount tree, maintaining
@@ -29,6 +108,8 @@ pub struct Mount {
     parent: RwLock<Option<Weak<Mount>>>,
     /// Child mount nodes which are mounted on one dentry of self.
     children: RwLock<HashMap<DentryKey, Arc<Self>>>,
+    /// The options of this mount.
+    options: Mutex<MountOptions>,
     /// Reference to self.
     this: Weak<Self>,
 }
@@ -60,6 +141,7 @@ impl Mount {
             parent: RwLock::new(parent_mount),
             children: RwLock::new(HashMap::new()),
             fs,
+            options: Mutex::new(MountOptions::default()),
             this: weak_self.clone(),
         })
     }
@@ -118,6 +200,7 @@ impl Mount {
             parent: RwLock::new(None),
             children: RwLock::new(HashMap::new()),
             fs: self.fs.clone(),
+            options: Mutex::new(*self.options.lock()),
             this: weak_self.clone(),
         })
     }
@@ -248,6 +331,11 @@ impl Mount {
 
         self.fs.sync()?;
         Ok(())
+    }
+
+    /// Gets the locked mount options.
+    pub fn options(&self) -> MutexGuard<'_, MountOptions> {
+        self.options.lock()
     }
 
     /// Gets the parent mount node if any.

--- a/kernel/src/fs/utils/fs.rs
+++ b/kernel/src/fs/utils/fs.rs
@@ -43,6 +43,24 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Mount options for a filesystem.
+    pub struct FsMountOptions: u8 {
+        /// The filesystem is mounted read-only.
+        const READONLY      =   1 << 0;
+        /// Writes are synced at once.
+        const SYNCHRONOUS   =   1 << 1;
+        /// Allow mandatory locks on an FS.
+        const MANDLOCK      =   1 << 2;
+        /// Directory modifications are synchronous.
+        const DIRSYNC       =   1 << 3;
+        /// Suppress certain messages in kernel log.
+        const SILENT        =   1 << 4;
+        /// Update the on-disk [acm]times lazily.
+        const LAZYTIME      =   1 << 5;
+    }
+}
+
 pub trait FileSystem: Any + Sync + Send {
     fn sync(&self) -> Result<()>;
 
@@ -51,6 +69,18 @@ pub trait FileSystem: Any + Sync + Send {
     fn sb(&self) -> SuperBlock;
 
     fn flags(&self) -> FsFlags;
+
+    fn set_mount_options(
+        &self,
+        _options: FsMountOptions,
+        _data: Vaddr,
+        _ctx: &Context,
+    ) -> Result<()> {
+        // TODO: Currently we do not support any flags for filesystems.
+        // Remove the default empty implementation and add handling code
+        // for each filesystem in the future.
+        Ok(())
+    }
 }
 
 impl dyn FileSystem {

--- a/kernel/src/fs/utils/mod.rs
+++ b/kernel/src/fs/utils/mod.rs
@@ -10,7 +10,7 @@ pub use endpoint::{Endpoint, EndpointState};
 pub use falloc_mode::FallocMode;
 pub use file_creation_mask::FileCreationMask;
 pub use flock::{FlockItem, FlockList, FlockType};
-pub use fs::{FileSystem, FsFlags, SuperBlock};
+pub use fs::{FileSystem, FsFlags, FsMountOptions, SuperBlock};
 pub use inode::{Extension, Inode, InodeMode, InodeType, Metadata, MknodType, Permission};
 pub use ioctl::IoctlCmd;
 pub use page_cache::{CachePage, PageCache, PageCacheBackend};

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -4,9 +4,9 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         fs_resolver::{FsPath, AT_FDCWD},
-        path::Path,
+        path::{AtimePolicy, Mount, MountOptions, Path},
         registry::FsProperties,
-        utils::{FileSystem, InodeType},
+        utils::{FileSystem, FsMountOptions, InodeType},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -47,9 +47,10 @@ pub fn sys_mount(
     };
 
     if mount_flags.contains(MountFlags::MS_REMOUNT) && mount_flags.contains(MountFlags::MS_BIND) {
-        do_reconfigure_mnt()?;
+        do_remount_mnt(dst_path.mount_node(), mount_flags, ctx)?
     } else if mount_flags.contains(MountFlags::MS_REMOUNT) {
-        do_remount()?;
+        do_remount_mnt(dst_path.mount_node(), mount_flags, ctx)?;
+        do_remount_fs(&dst_path.fs(), mount_flags, data, ctx)?;
     } else if mount_flags.contains(MountFlags::MS_BIND) {
         do_bind_mount(
             devname,
@@ -66,18 +67,40 @@ pub fn sys_mount(
     } else if mount_flags.contains(MountFlags::MS_MOVE) {
         do_move_mount_old(devname, dst_path, ctx)?;
     } else {
-        do_new_mount(devname, fstype_addr, dst_path, data, ctx)?;
+        do_new_mount(devname, mount_flags, fstype_addr, dst_path, data, ctx)?;
     }
 
     Ok(SyscallReturn::Return(0))
 }
 
-fn do_reconfigure_mnt() -> Result<()> {
-    return_errno_with_message!(Errno::EINVAL, "do_reconfigure_mnt is not supported");
+/// Remount the mount with new flags.
+fn do_remount_mnt(mount: &Mount, flags: MountFlags, _ctx: &Context) -> Result<()> {
+    let mut new_options: MountOptions = flags.into();
+    let specified_atime_policy = flags.contains(MountFlags::MS_STRICTATIME)
+        || flags.contains(MountFlags::MS_NOATIME)
+        || flags.contains(MountFlags::MS_RELATIME);
+
+    let mut old_options = mount.options();
+    if !specified_atime_policy {
+        // Preserve the existing atime policy if none is specified in the flags
+        new_options.set_atime_policy(old_options.atime_policy());
+    }
+    *old_options = new_options;
+
+    Ok(())
 }
 
-fn do_remount() -> Result<()> {
-    return_errno_with_message!(Errno::EINVAL, "do_remount is not supported");
+/// Remount the filesystem with new flags and data.
+fn do_remount_fs(
+    fs: &Arc<dyn FileSystem>,
+    flags: MountFlags,
+    data: Vaddr,
+    ctx: &Context,
+) -> Result<()> {
+    let fs_mount_options: FsMountOptions = flags.into();
+    fs.set_mount_options(fs_mount_options, data, ctx)?;
+
+    Ok(())
 }
 
 /// Bind a mount to a dst location.
@@ -133,6 +156,7 @@ fn do_move_mount_old(src_name: CString, dst_path: Path, ctx: &Context) -> Result
 /// Mount a new filesystem.
 fn do_new_mount(
     devname: CString,
+    flags: MountFlags,
     fs_type: Vaddr,
     target_path: Path,
     data: Vaddr,
@@ -147,7 +171,12 @@ fn do_new_mount(
         return_errno_with_message!(Errno::EINVAL, "fs_type is empty");
     }
     let fs = get_fs(fs_type, devname, data, ctx)?;
-    target_path.mount(fs)?;
+    fs.set_mount_options(flags.into(), data, ctx)?;
+
+    let new_mount = target_path.mount(fs)?;
+    let new_mount_options: MountOptions = flags.into();
+    *new_mount.options() = new_mount_options;
+
     Ok(())
 }
 
@@ -207,5 +236,62 @@ bitflags! {
         const MS_SHARED        =   1 << 20;      // Change to shared.
         const MS_RELATIME      =   1 << 21; 	 // Update atime relative to mtime/ctime.
         const MS_KERNMOUNT     =   1 << 22;      // This is a kern_mount call.
+        const MS_STRICTATIME   =   1 << 24; 	 // Always perform atime updates.
+        const MS_LAZYTIME      =   1 << 25; 	 // Update the on-disk [acm]times lazily.
+    }
+}
+
+impl From<MountFlags> for MountOptions {
+    fn from(flags: MountFlags) -> Self {
+        let mut options = MountOptions::default();
+        if flags.contains(MountFlags::MS_NOSUID) {
+            options.set_nosuid();
+        }
+        if flags.contains(MountFlags::MS_NODEV) {
+            options.set_nodev();
+        }
+        if flags.contains(MountFlags::MS_NOEXEC) {
+            options.set_noexec();
+        }
+        if flags.contains(MountFlags::MS_RDONLY) {
+            options.set_rdonly();
+        }
+        if flags.contains(MountFlags::MS_NODIRATIME) {
+            options.set_nodiratime();
+        }
+
+        if flags.contains(MountFlags::MS_STRICTATIME) {
+            options.set_atime_policy(AtimePolicy::Strictatime);
+        } else if flags.contains(MountFlags::MS_NOATIME) {
+            options.set_atime_policy(AtimePolicy::Noatime);
+        }
+
+        options
+    }
+}
+
+impl From<MountFlags> for FsMountOptions {
+    fn from(flags: MountFlags) -> Self {
+        let mut options = FsMountOptions::empty();
+        if flags.contains(MountFlags::MS_RDONLY) {
+            options |= FsMountOptions::READONLY;
+        }
+        if flags.contains(MountFlags::MS_SYNCHRONOUS) {
+            options |= FsMountOptions::SYNCHRONOUS;
+        }
+        if flags.contains(MountFlags::MS_MANDLOCK) {
+            options |= FsMountOptions::MANDLOCK;
+        }
+        if flags.contains(MountFlags::MS_DIRSYNC) {
+            options |= FsMountOptions::DIRSYNC;
+        }
+        if flags.contains(MountFlags::MS_SILENT) {
+            options |= FsMountOptions::SILENT;
+        }
+        if flags.contains(MountFlags::MS_LAZYTIME) {
+            options |= FsMountOptions::LAZYTIME;
+        }
+
+        options
     }
 }


### PR DESCRIPTION
This PR adds the framework for per-mount options and per-filesystem options, and supports "dummy" `MS_REMOUNT` flag for mount syscall, which is required for Podman support.

The currently set mount options have no actual effect. The potential short-term user would be to output all configured options when generating the `mountinfo` file.