### PR TITLE
Add KDGETMODE and KDSETMODE ioctl support

### DIFF
--- a/kernel/comps/console/src/lib.rs
+++ b/kernel/comps/console/src/lib.rs
@@ -27,6 +27,12 @@ pub enum ConsoleSetFontError {
     InvalidFont,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ConsoleMode {
+    Text,
+    Graphics,
+}
+
 pub trait AnyConsoleDevice: Send + Sync + Any + Debug {
     /// Sends data to the console device.
     fn send(&self, buf: &[u8]);
@@ -39,6 +45,24 @@ pub trait AnyConsoleDevice: Send + Sync + Any + Debug {
     /// Sets the font of the console device.
     fn set_font(&self, _font: BitmapFont) -> Result<(), ConsoleSetFontError> {
         Err(ConsoleSetFontError::InappropriateDevice)
+    }
+
+    /// Sets the console mode (text or graphics)
+    ///
+    /// In text mode, the console will display text characters.
+    /// In graphics mode, the console will not display text and may be used
+    /// for graphical output (e.g., by X server).
+    ///
+    /// Returns true if the mode was changed, false if the mode is unsupported.
+    fn set_mode(&self, _mode: ConsoleMode) -> bool {
+        false
+    }
+
+    /// Gets the current console mode
+    ///
+    /// Returns the current console mode, or None if mode switching is not supported.
+    fn get_mode(&self) -> Option<ConsoleMode> {
+        None
     }
 }
 

--- a/kernel/src/device/pty/driver.rs
+++ b/kernel/src/device/pty/driver.rs
@@ -112,8 +112,4 @@ impl TtyDriver for PtyDriver {
     fn notify_input(&self) {
         self.pollee.notify(IoEvents::OUT);
     }
-
-    fn set_font(&self, _font: aster_console::BitmapFont) -> Result<()> {
-        return_errno_with_message!(Errno::ENOTTY, "the console has no support for font setting");
-    }
 }

--- a/kernel/src/device/tty/driver.rs
+++ b/kernel/src/device/tty/driver.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::{Errno, Error, Result};
+use aster_console::AnyConsoleDevice;
+
+use crate::prelude::{Errno, Error};
 
 /// An error indicating that no characters can be pushed because the buffer is full.
 #[derive(Debug, Clone, Copy)]
@@ -48,7 +50,14 @@ pub trait TtyDriver: Send + Sync + 'static {
     ///
     /// [`Tty::can_push`]: super::Tty::can_push
     fn notify_input(&self);
+}
 
-    /// Sets the TTY font.
-    fn set_font(&self, font: aster_console::BitmapFont) -> Result<()>;
+pub trait HasConsole {
+    fn console(&self) -> Option<&dyn AnyConsoleDevice>;
+}
+
+impl<D: TtyDriver> HasConsole for D {
+    default fn console(&self) -> Option<&dyn AnyConsoleDevice> {
+        None
+    }
 }

--- a/kernel/src/device/tty/n_tty.rs
+++ b/kernel/src/device/tty/n_tty.rs
@@ -6,11 +6,7 @@ use aster_console::AnyConsoleDevice;
 use ostd::mm::{Infallible, VmReader, VmWriter};
 use spin::Once;
 
-use super::{PushCharError, Tty, TtyDriver};
-use crate::{
-    error::Errno,
-    prelude::{return_errno_with_message, Result},
-};
+use super::{HasConsole, PushCharError, Tty, TtyDriver};
 
 pub struct ConsoleDriver {
     console: Arc<dyn AnyConsoleDevice>,
@@ -33,22 +29,11 @@ impl TtyDriver for ConsoleDriver {
     }
 
     fn notify_input(&self) {}
+}
 
-    fn set_font(&self, font: aster_console::BitmapFont) -> Result<()> {
-        use aster_console::ConsoleSetFontError;
-
-        match self.console.set_font(font) {
-            Ok(()) => Ok(()),
-            Err(ConsoleSetFontError::InappropriateDevice) => {
-                return_errno_with_message!(
-                    Errno::ENOTTY,
-                    "the console has no support for font setting"
-                )
-            }
-            Err(ConsoleSetFontError::InvalidFont) => {
-                return_errno_with_message!(Errno::EINVAL, "the font is invalid for the console")
-            }
-        }
+impl HasConsole for ConsoleDriver {
+    fn console(&self) -> Option<&dyn AnyConsoleDevice> {
+        Some(&*self.console)
     }
 }
 

--- a/kernel/src/fs/utils/ioctl.rs
+++ b/kernel/src/fs/utils/ioctl.rs
@@ -6,6 +6,10 @@ use crate::prelude::*;
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
 pub enum IoctlCmd {
+    /// Get console mode
+    KDGETMODE = 0x4B3B,
+    /// Set console mode
+    KDSETMODE = 0x4B3A,
     /// Get terminal attributes
     TCGETS = 0x5401,
     TCSETS = 0x5402,


### PR DESCRIPTION
# Add virtual console TTY mode management ioctls

## Description:
This PR adds support for essential virtual console ioctls required by display servers like Xorg and fixes a critical device major number assignment.

## Changes:

Fix: Correct the major number for /dev/tty1 to the Linux-hardcoded value of 4. This prevents failures in applications like Xorg that rely on this standard value.

Feature: Implement the KDGETMODE and KDSETMODE ioctls for virtual console mode management.

- Text Mode (KD_TEXT): The kernel manages the framebuffer, rendering text.
- Graphics Mode (KD_GRAPHICS): User space (e.g., Xorg) takes full control of the framebuffer.

## Purpose:
This implementation allows Xorg to successfully switch the console to graphics mode during initialization. This prevents rendering artifacts and system hangs caused by both the kernel and Xorg simultaneously writing to the framebuffer.


  
