### PR TITLE
Support `RUSAGE_CHILDREN` option for `getrusage`

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -32,7 +32,7 @@ pub use namespace::{
 pub use pid_file::PidFile;
 pub use process::{
     broadcast_signal_async, enqueue_signal_async, spawn_init_process, ExitCode, JobControl, Pgid,
-    Pid, Process, ProcessGroup, Session, Sid, Terminal,
+    Pid, Process, ProcessGroup, ReapedChildrenStats, Session, Sid, Terminal,
 };
 pub use process_filter::ProcessFilter;
 pub use process_vm::{renew_vm_and_map, MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS};

--- a/test/src/syscall/ltp/testcases/all.txt
+++ b/test/src/syscall/ltp/testcases/all.txt
@@ -537,7 +537,7 @@ getrlimit03
 # get_mempolicy02
 # get_robust_list01
 
-# getrusage01
+getrusage01
 getrusage02
 # getrusage03
 # getrusage04


### PR DESCRIPTION
This PR is required for https://github.com/asterinas/asterinas/issues/2214.

This PR supports the options `RUSAGE_CHILDREN` for the syscall [`getrusage`](https://man7.org/linux/man-pages/man2/getrusage.2.html). 

>        RUSAGE_CHILDREN
>              Return resource usage statistics for all children of the
>              calling process that have terminated and been waited for.
>              These statistics will include the resources used by
>              grandchildren, and further removed descendants, if all of
>              the intervening descendants waited on their terminated
>              children.

The `RUSAGE_BOTH` option is a glibc-specific extension and is not directly supported by the Linux `getrusage` system call. Therefore, it is removed in this PR. See:
https://elixir.bootlin.com/linux/v6.16.5/source/kernel/sys.c#L1891-L1893
https://github.com/linux-test-project/ltp/blob/bf9589d5bdeef15b3dbb03f896793306552d0d0f/testcases/kernel/syscalls/getrusage/getrusage02.c#L37