### PR TITLE
Make `UniqueFrame::repurpose` sound

### DIFF
--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -86,12 +86,14 @@ impl<M: AnyFrameMeta + ?Sized> UniqueFrame<M> {
 
     /// Repurposes the frame with a new metadata.
     pub fn repurpose<M1: AnyFrameMeta>(self, metadata: M1) -> UniqueFrame<M1> {
+        let this = ManuallyDrop::new(self);
+
         // SAFETY: We are the sole owner and the metadata is initialized.
-        unsafe { self.slot().drop_meta_in_place() };
+        unsafe { this.slot().drop_meta_in_place() };
         // SAFETY: We are the sole owner.
-        unsafe { self.slot().write_meta(metadata) };
+        unsafe { this.slot().write_meta(metadata) };
         // SAFETY: The metadata is initialized with type `M1`.
-        unsafe { core::mem::transmute(self) }
+        unsafe { core::mem::transmute(ManuallyDrop::into_inner(this)) }
     }
 
     /// Resets the frame to unused without up-calling the allocator.

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -41,16 +41,6 @@ impl<M: AnyFrameMeta> UniqueFrame<M> {
         })
     }
 
-    /// Repurposes the frame with a new metadata.
-    pub fn repurpose<M1: AnyFrameMeta>(self, metadata: M1) -> UniqueFrame<M1> {
-        // SAFETY: We are the sole owner and the metadata is initialized.
-        unsafe { self.slot().drop_meta_in_place() };
-        // SAFETY: We are the sole owner.
-        unsafe { self.slot().write_meta(metadata) };
-        // SAFETY: The metadata is initialized with type `M1`.
-        unsafe { core::mem::transmute(self) }
-    }
-
     /// Gets the metadata of this page.
     pub fn meta(&self) -> &M {
         // SAFETY: The type is tracked by the type system.
@@ -92,6 +82,16 @@ impl<M: AnyFrameMeta + ?Sized> UniqueFrame<M> {
         // SAFETY: The metadata is initialized and valid. We have the exclusive
         // access to the frame.
         unsafe { &mut *self.slot().dyn_meta_ptr() }
+    }
+
+    /// Repurposes the frame with a new metadata.
+    pub fn repurpose<M1: AnyFrameMeta>(self, metadata: M1) -> UniqueFrame<M1> {
+        // SAFETY: We are the sole owner and the metadata is initialized.
+        unsafe { self.slot().drop_meta_in_place() };
+        // SAFETY: We are the sole owner.
+        unsafe { self.slot().write_meta(metadata) };
+        // SAFETY: The metadata is initialized with type `M1`.
+        unsafe { core::mem::transmute(self) }
     }
 
     /// Resets the frame to unused without up-calling the allocator.


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/70b26f824d8beddcfd559fe3cac26ecc5caa6c88/ostd/src/mm/frame/unique.rs#L44-L52

This is not sound. If `drop_meta_in_place` panics, we'll drop the metadata twice:
https://github.com/asterinas/asterinas/blob/70b26f824d8beddcfd559fe3cac26ecc5caa6c88/ostd/src/mm/frame/unique.rs#L158-L167

We should do something similar to `reset_as_unused`, i.e., wraps the frame in a `ManuallyDrop` because dropping the frame metadata:
https://github.com/asterinas/asterinas/blob/70b26f824d8beddcfd559fe3cac26ecc5caa6c88/ostd/src/mm/frame/unique.rs#L108-L115

Besides, I can't see why `repurpose` won't work for `?Sized` metadata, so I make it work.