### PR TITLE
Implement sethostname and setdomainname syscalls

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -191,7 +191,7 @@ provided by Linux on x86-64 architecture.
 | 168     | swapoff                | ❌             |     |
 | 169     | reboot                 | ❌             |     |
 | 170     | sethostname            | ✅             |     |
-| 171     | setdomainname          | ❌             |     |
+| 171     | setdomainname          | ✅             |     |
 | 172     | iopl                   | ❌             |     |
 | 173     | ioperm                 | ❌             |     |
 | 174     | create_module          | ❌             |     |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -190,7 +190,7 @@ provided by Linux on x86-64 architecture.
 | 167     | swapon                 | ❌             |     |
 | 168     | swapoff                | ❌             |     |
 | 169     | reboot                 | ❌             |     |
-| 170     | sethostname            | ❌             |     |
+| 170     | sethostname            | ✅             |     |
 | 171     | setdomainname          | ❌             |     |
 | 172     | iopl                   | ❌             |     |
 | 173     | ioperm                 | ❌             |     |

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -30,7 +30,8 @@ impl UtsNamespace {
                 release: padded(b"5.13.0"),
                 version: padded(b"5.13.0"),
                 machine: padded(b"x86_64"),
-                domainname: padded(b""),
+                // Reference: <https://elixir.bootlin.com/linux/v6.16/source/include/linux/uts.h#L17>.
+                domainname: padded(b"(none)"),
             };
 
             let owner = UserNamespace::get_init_singleton().clone();

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -80,6 +80,22 @@ impl UtsNamespace {
         self.uts_name.write().nodename = new_host_name;
         Ok(())
     }
+
+    /// Sets a new domain name for the UTS namespace.
+    ///
+    /// This method will fail with `EPERM` if the caller does not have the SYS_ADMIN capability
+    /// in the owner user namespace.
+    pub fn set_domainname(&self, addr: Vaddr, len: usize, ctx: &Context) -> Result<()> {
+        self.owner.check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+
+        let new_domain_name = copy_uts_field_from_user(addr, len as _, ctx)?;
+        debug!(
+            "set domain name: {:?}",
+            CStr::from_bytes_until_nul(new_domain_name.as_bytes()).unwrap()
+        );
+        self.uts_name.write().domainname = new_domain_name;
+        Ok(())
+    }
 }
 
 const UTS_FIELD_LEN: usize = 65;

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -117,6 +117,7 @@ use super::{
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
     setgroups::sys_setgroups,
+    sethostname::sys_sethostname,
     setitimer::{sys_getitimer, sys_setitimer},
     setns::sys_setns,
     setpgid::sys_setpgid,
@@ -283,6 +284,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETGROUPS = 158              => sys_getgroups(args[..2]);
     SYS_SETGROUPS = 159              => sys_setgroups(args[..2]);
     SYS_NEWUNAME = 160               => sys_uname(args[..1]);
+    SYS_SETHOSTNAME = 161            => sys_sethostname(args[..2]);
     SYS_GETRUSAGE = 165              => sys_getrusage(args[..2]);
     SYS_UMASK = 166                  => sys_umask(args[..1]);
     SYS_PRCTL = 167                  => sys_prctl(args[..5]);

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -113,6 +113,7 @@ use super::{
     set_priority::sys_set_priority,
     set_robust_list::sys_set_robust_list,
     set_tid_address::sys_set_tid_address,
+    setdomainname::sys_setdomainname,
     setfsgid::sys_setfsgid,
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
@@ -285,6 +286,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SETGROUPS = 159              => sys_setgroups(args[..2]);
     SYS_NEWUNAME = 160               => sys_uname(args[..1]);
     SYS_SETHOSTNAME = 161            => sys_sethostname(args[..2]);
+    SYS_SETDOMAINNAME = 162          => sys_setdomainname(args[..2]);
     SYS_GETRUSAGE = 165              => sys_getrusage(args[..2]);
     SYS_UMASK = 166                  => sys_umask(args[..1]);
     SYS_PRCTL = 167                  => sys_prctl(args[..5]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -117,6 +117,7 @@ use super::{
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
     setgroups::sys_setgroups,
+    sethostname::sys_sethostname,
     setitimer::{sys_getitimer, sys_setitimer},
     setns::sys_setns,
     setpgid::sys_setpgid,
@@ -283,6 +284,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETGROUPS = 158              => sys_getgroups(args[..2]);
     SYS_SETGROUPS = 159              => sys_setgroups(args[..2]);
     SYS_NEWUNAME = 160               => sys_uname(args[..1]);
+    SYS_SETHOSTNAME = 161            => sys_sethostname(args[..2]);
     SYS_GETRLIMIT = 163              => sys_getrlimit(args[..2]);
     SYS_SETRLIMIT = 164              => sys_setrlimit(args[..2]);
     SYS_GETRUSAGE = 165              => sys_getrusage(args[..2]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -113,6 +113,7 @@ use super::{
     set_priority::sys_set_priority,
     set_robust_list::sys_set_robust_list,
     set_tid_address::sys_set_tid_address,
+    setdomainname::sys_setdomainname,
     setfsgid::sys_setfsgid,
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
@@ -285,6 +286,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SETGROUPS = 159              => sys_setgroups(args[..2]);
     SYS_NEWUNAME = 160               => sys_uname(args[..1]);
     SYS_SETHOSTNAME = 161            => sys_sethostname(args[..2]);
+    SYS_SETDOMAINNAME = 162          => sys_setdomainname(args[..2]);
     SYS_GETRLIMIT = 163              => sys_getrlimit(args[..2]);
     SYS_SETRLIMIT = 164              => sys_setrlimit(args[..2]);
     SYS_GETRUSAGE = 165              => sys_getrusage(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -124,6 +124,7 @@ use super::{
     set_priority::sys_set_priority,
     set_robust_list::sys_set_robust_list,
     set_tid_address::sys_set_tid_address,
+    setdomainname::sys_setdomainname,
     setfsgid::sys_setfsgid,
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
@@ -309,6 +310,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_MOUNT = 165            => sys_mount(args[..5]);
     SYS_UMOUNT2 = 166          => sys_umount(args[..2]);
     SYS_SETHOSTNAME = 170      => sys_sethostname(args[..2]);
+    SYS_SETDOMAINNAME = 171    => sys_setdomainname(args[..2]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);
     SYS_SETXATTR = 188         => sys_setxattr(args[..5]);
     SYS_LSETXATTR = 189        => sys_lsetxattr(args[..5]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -128,6 +128,7 @@ use super::{
     setfsuid::sys_setfsuid,
     setgid::sys_setgid,
     setgroups::sys_setgroups,
+    sethostname::sys_sethostname,
     setitimer::{sys_getitimer, sys_setitimer},
     setns::sys_setns,
     setpgid::sys_setpgid,
@@ -306,7 +307,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_CHROOT = 161           => sys_chroot(args[..1]);
     SYS_SYNC = 162             => sys_sync(args[..0]);
     SYS_MOUNT = 165            => sys_mount(args[..5]);
-    SYS_UMOUNT2 = 166           => sys_umount(args[..2]);
+    SYS_UMOUNT2 = 166          => sys_umount(args[..2]);
+    SYS_SETHOSTNAME = 170      => sys_sethostname(args[..2]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);
     SYS_SETXATTR = 188         => sys_setxattr(args[..5]);
     SYS_LSETXATTR = 189        => sys_lsetxattr(args[..5]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -140,6 +140,7 @@ mod set_ioprio;
 mod set_priority;
 mod set_robust_list;
 mod set_tid_address;
+mod setdomainname;
 mod setfsgid;
 mod setfsuid;
 mod setgid;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -144,6 +144,7 @@ mod setfsgid;
 mod setfsuid;
 mod setgid;
 mod setgroups;
+mod sethostname;
 mod setitimer;
 mod setns;
 mod setpgid;

--- a/kernel/src/syscall/setdomainname.rs
+++ b/kernel/src/syscall/setdomainname.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{prelude::*, syscall::SyscallReturn};
+
+pub fn sys_setdomainname(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let ns_proxy_ref = ctx.thread_local.borrow_ns_proxy();
+    let ns_proxy = ns_proxy_ref.unwrap();
+    ns_proxy.uts_ns().set_domainname(addr, len, ctx)?;
+    Ok(SyscallReturn::Return(0))
+}

--- a/kernel/src/syscall/sethostname.rs
+++ b/kernel/src/syscall/sethostname.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{prelude::*, syscall::SyscallReturn};
+
+pub fn sys_sethostname(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let ns_proxy_ref = ctx.thread_local.borrow_ns_proxy();
+    let ns_proxy = ns_proxy_ref.unwrap();
+    ns_proxy.uts_ns().set_hostname(addr, len, ctx)?;
+    Ok(SyscallReturn::Return(0))
+}

--- a/kernel/src/syscall/uname.rs
+++ b/kernel/src/syscall/uname.rs
@@ -6,6 +6,6 @@ pub fn sys_uname(old_uname_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> 
     debug!("old uname addr = 0x{:x}", old_uname_addr);
     let ns_proxy = ctx.thread_local.borrow_ns_proxy();
     let uts_name = ns_proxy.unwrap().uts_ns().uts_name();
-    ctx.user_space().write_val(old_uname_addr, uts_name)?;
+    ctx.user_space().write_val(old_uname_addr, &*uts_name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/test/src/syscall/gvisor/Makefile
+++ b/test/src/syscall/gvisor/Makefile
@@ -70,6 +70,7 @@ TESTS ?= \
 	timerfd_test \
 	timers_test \
 	truncate_test \
+	uname_test \
 	uidgid_test \
 	unlink_test \
 	utimes_test \

--- a/test/src/syscall/ltp/testcases/all.txt
+++ b/test/src/syscall/ltp/testcases/all.txt
@@ -1340,8 +1340,9 @@ set_robust_list01
 # set_thread_area01
 # set_tid_address01
 
-# setdomainname01
-# setdomainname02
+setdomainname01
+setdomainname02
+# TODO: Drop capabilities on UID changes, so that setdomainname() will fail with EPERM.
 # setdomainname03
 
 # setfsgid01

--- a/test/src/syscall/ltp/testcases/all.txt
+++ b/test/src/syscall/ltp/testcases/all.txt
@@ -1379,8 +1379,9 @@ setgroups02
 # setgroups03
 # setgroups03_16
 
-# sethostname01
-# sethostname02
+sethostname01
+sethostname02
+# TODO: Drop capabilities on UID changes, so that sethostname() will fail with EPERM. 
 # sethostname03
 
 # setitimer01


### PR DESCRIPTION
This PR implements the sethostname and setdomainname syscalls. The sethostname syscall is required by Podman in #2214. The setdomainname syscall is added as well due to the similarity in their implementations.

The first two commits introduce these syscalls along with their LTP tests. The sethostname3 and setdomainname3 tests currently fail because LTP expects an EPERM error when a non-root user invokes these syscalls. However, in our current implementation, the capability set is not updated when the UID changes, so these permission checks are not yet enforced.

The third commit addresses a minor issue in the gVisor uname test by ensuring that the domain name is never empty. We adopt the same default value `(none)` used by Linux.