### PR TITLE
Make common timer code architecture-agnostic

### DIFF
--- a/kernel/comps/time/src/tsc.rs
+++ b/kernel/comps/time/src/tsc.rs
@@ -85,5 +85,5 @@ fn init_timer() {
     };
 
     // TODO: re-organize the code structure and use the `Timer` to achieve the updating.
-    timer::register_callback(update);
+    timer::register_callback_on_cpu(update);
 }

--- a/kernel/comps/time/src/tsc.rs
+++ b/kernel/comps/time/src/tsc.rs
@@ -7,8 +7,8 @@ use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use ostd::{
-    arch::{read_tsc, timer::TIMER_FREQ, tsc_freq},
-    timer,
+    arch::{read_tsc, tsc_freq},
+    timer::{self, TIMER_FREQ},
 };
 use spin::Once;
 

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -81,7 +81,7 @@ fn update_cpu_time() {
 /// Registers a function to update the CPU clock in processes and
 /// threads during the system timer interrupt.
 pub(super) fn init_on_each_cpu() {
-    timer::register_callback(update_cpu_time);
+    timer::register_callback_on_cpu(update_cpu_time);
 }
 
 /// Represents timer resources and utilities for a POSIX process.

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -14,7 +14,7 @@ use ostd::{
     sync::SpinLock,
     task::{
         scheduler::{
-            enable_preemption, info::CommonSchedInfo, inject_scheduler, EnqueueFlags,
+            enable_preemption_on_cpu, info::CommonSchedInfo, inject_scheduler, EnqueueFlags,
             LocalRunQueue, Scheduler, UpdateFlags,
         },
         AtomicCpuId, Task,
@@ -56,7 +56,7 @@ pub fn init() {
 }
 
 pub fn init_on_each_cpu() {
-    enable_preemption();
+    enable_preemption_on_cpu();
 }
 
 /// Represents the middle layer between scheduling classes and generic scheduler

--- a/kernel/src/sched/stats/loadavg.rs
+++ b/kernel/src/sched/stats/loadavg.rs
@@ -6,7 +6,10 @@
 
 use core::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
-use ostd::{arch::timer::TIMER_FREQ, sync::RwLock, timer};
+use ostd::{
+    sync::RwLock,
+    timer::{self, TIMER_FREQ},
+};
 
 /// Fixed-point representation of the load average.
 ///

--- a/kernel/src/sched/stats/scheduler_stats.rs
+++ b/kernel/src/sched/stats/scheduler_stats.rs
@@ -17,7 +17,7 @@ pub fn set_stats_from_scheduler(scheduler: &'static dyn SchedulerStats) {
     SCHEDULER_STATS.call_once(|| scheduler);
 
     // Register a callback to update the load average periodically
-    timer::register_callback(|| {
+    timer::register_callback_on_cpu(|| {
         loadavg::update_loadavg(|| nr_queued_and_running().0);
     });
 }

--- a/kernel/src/time/softirq.rs
+++ b/kernel/src/time/softirq.rs
@@ -11,7 +11,7 @@ static TIMER_SOFTIRQ_CALLBACKS: RcuOption<Box<Vec<fn()>>> = RcuOption::new_none(
 pub(super) fn init() {
     SoftIrqLine::get(TIMER_SOFTIRQ_ID).enable(timer_softirq_handler);
 
-    timer::register_callback(|| {
+    timer::register_callback_on_cpu(|| {
         SoftIrqLine::get(TIMER_SOFTIRQ_ID).raise();
     });
 }

--- a/ostd/src/arch/loongarch/mod.rs
+++ b/ostd/src/arch/loongarch/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod pci;
 pub mod qemu;
 pub(crate) mod serial;
 pub(crate) mod task;
-pub mod timer;
+mod timer;
 pub mod trap;
 
 #[cfg(feature = "cvm_guest")]

--- a/ostd/src/arch/loongarch/timer/mod.rs
+++ b/ostd/src/arch/loongarch/timer/mod.rs
@@ -2,10 +2,10 @@
 
 //! The timer support.
 
-/// The timer frequency (Hz). Here we choose 1000Hz since 1000Hz is easier for
-/// unit conversion and convenient for timer. What's more, the frequency cannot
-/// be set too high or too low, 1000Hz is a modest choice.
-///
-/// For system performance reasons, this rate cannot be set too high, otherwise
-/// most of the time is spent executing timer code.
-pub const TIMER_FREQ: u64 = 1000;
+use super::trap::TrapFrame;
+
+// TODO: Add LoongArch timer support and call this method.
+#[expect(dead_code)]
+fn timer_callback(trapframe: &TrapFrame) {
+    crate::timer::call_timer_callback_functions(trapframe);
+}

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod pci;
 pub mod qemu;
 pub(crate) mod serial;
 pub(crate) mod task;
-pub mod timer;
+mod timer;
 pub mod trap;
 
 use core::sync::atomic::Ordering;

--- a/ostd/src/arch/x86/kernel/apic/mod.rs
+++ b/ostd/src/arch/x86/kernel/apic/mod.rs
@@ -363,7 +363,3 @@ pub fn init(io_mem_builder: &IoMemAllocatorBuilder) -> Result<(), ApicInitError>
         Err(ApicInitError::NoApic)
     }
 }
-
-pub fn exists() -> bool {
-    APIC_TYPE.is_completed()
-}

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -6,13 +6,11 @@ use log::info;
 
 use crate::{
     arch::{
-        timer::{
-            pit::{self, OperatingMode},
-            TIMER_FREQ,
-        },
+        timer::pit::{self, OperatingMode},
         trap::TrapFrame,
     },
     irq::IrqLine,
+    timer::TIMER_FREQ,
 };
 
 /// The frequency in Hz of the Time Stamp Counter (TSC).

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -60,7 +60,7 @@ pub(crate) unsafe fn late_init_on_bsp() {
     kernel::irq::init(&io_mem_builder);
 
     kernel::tsc::init_tsc_freq();
-    timer::init_bsp();
+    timer::init_on_bsp();
 
     // SAFETY: We're on the BSP and we're ready to boot all APs.
     unsafe { crate::boot::smp::boot_all_aps() };
@@ -89,7 +89,7 @@ pub(crate) unsafe fn late_init_on_bsp() {
 ///
 /// [`init_on_bsp`]: crate::cpu::init_on_bsp
 pub(crate) unsafe fn init_on_ap() {
-    timer::init_ap();
+    timer::init_on_ap();
 }
 
 pub(crate) fn interrupts_ack(irq_number: usize) {

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod pci;
 pub mod qemu;
 pub(crate) mod serial;
 pub(crate) mod task;
-pub mod timer;
+mod timer;
 pub mod trap;
 
 #[cfg(feature = "cvm_guest")]

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Initializes APIC with TSC-deadline mode or periodic mode.
 ///
 /// Return the corresponding [`IrqLine`] for the system timer.
-pub(super) fn init_bsp() -> IrqLine {
+pub(super) fn init_on_bsp() -> IrqLine {
     if is_tsc_deadline_mode_supported() {
         init_deadline_mode_config();
     } else {
@@ -34,7 +34,7 @@ pub(super) fn init_bsp() -> IrqLine {
 /// Initializes APIC timer on AP.
 ///
 /// The caller should provide the [`IrqLine`] for the system timer.
-pub(super) fn init_ap(timer_irq: &IrqLine) {
+pub(super) fn init_on_ap(timer_irq: &IrqLine) {
     init_timer(timer_irq);
 }
 

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -4,7 +4,6 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use log::info;
 
-use super::TIMER_FREQ;
 use crate::{
     arch::{
         kernel::apic::{self, Apic, DivideConfig},
@@ -14,6 +13,7 @@ use crate::{
     },
     irq::IrqLine,
     task::disable_preempt,
+    timer::TIMER_FREQ,
 };
 
 /// Initializes APIC with TSC-deadline mode or periodic mode.

--- a/ostd/src/arch/x86/timer/pit.rs
+++ b/ostd/src/arch/x86/timer/pit.rs
@@ -13,10 +13,10 @@ use crate::{
     arch::{
         device::io_port::WriteOnlyAccess,
         kernel::{MappedIrqLine, IRQ_CHIP},
-        timer::TIMER_FREQ,
     },
     io::{sensitive_io_port, IoPort},
     irq::IrqLine,
+    timer::TIMER_FREQ,
 };
 
 /// PIT Operating Mode.

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -150,7 +150,7 @@ pub trait Scheduler<T = Task>: Sync + Send {
 ///   or any synchronization primitive built upon it (e.g., [`crate::sync::WaitQueue`], [`crate::sync::Mutex`]),
 ///   which blocks the current task until a wake-up event occurs.
 /// - **Ticking**, triggered periodically by the system timer
-///   (see [`crate::arch::timer::TIMER_FREQ`]),
+///   (see [`crate::timer::TIMER_FREQ`]),
 ///   which provides an opportunity to do time accounting and consider preemption.
 /// - **Exiting**, triggered when the execution logic of a task has come to an end,
 ///   which informs the scheduler that the task is exiting and will never be enqueued again.

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -86,7 +86,7 @@ pub fn inject_scheduler(scheduler: &'static dyn Scheduler<Task>) {
     SCHEDULER.call_once(|| scheduler);
 }
 
-/// Enables preemptive scheduling.
+/// Enables preemptive scheduling on the current CPU.
 ///
 /// After calling this function on a CPU,
 /// a task that is executing in the user mode may get preempted
@@ -97,8 +97,8 @@ pub fn inject_scheduler(scheduler: &'static dyn Scheduler<Task>) {
 /// Thus, this function should be called _once_ on every CPU
 /// by an OSTD-based kernel during its initialization phase,
 /// after it has injected its scheduler via [`inject_scheduler`].
-pub fn enable_preemption() {
-    timer::register_callback(|| {
+pub fn enable_preemption_on_cpu() {
+    timer::register_callback_on_cpu(|| {
         SCHEDULER.get().unwrap().mut_local_rq_with(&mut |local_rq| {
             let should_pick_next = local_rq.update_current(UpdateFlags::Tick);
             if should_pick_next {

--- a/ostd/src/timer/jiffies.rs
+++ b/ostd/src/timer/jiffies.rs
@@ -5,7 +5,7 @@ use core::{
     time::Duration,
 };
 
-use crate::arch::timer::TIMER_FREQ;
+use super::TIMER_FREQ;
 
 /// Jiffies is a term used to denote the units of time measurement by the kernel.
 ///

--- a/ostd/src/timer/mod.rs
+++ b/ostd/src/timer/mod.rs
@@ -30,8 +30,8 @@ cpu_local! {
     static INTERRUPT_CALLBACKS: RefCell<Vec<InterruptCallback>> = RefCell::new(Vec::new());
 }
 
-/// Register a function that will be executed during the system timer interruption.
-pub fn register_callback<F>(func: F)
+/// Registers a function that will be executed during the timer interrupt on the current CPU.
+pub fn register_callback_on_cpu<F>(func: F)
 where
     F: Fn() + Sync + Send + 'static,
 {


### PR DESCRIPTION
The following code snippets are architecture-agnostic, so they can be moved out from `ostd::arch`.

https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/x86/timer/mod.rs#L33
https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/loongarch/timer/mod.rs#L11
https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/riscv/timer/mod.rs#L25

https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/x86/timer/mod.rs#L64-L74
https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/riscv/timer/mod.rs#L82-L92

Additionally, we don't support cases where APIC is not present. Therefore, legacy support has been removed.
https://github.com/asterinas/asterinas/blob/4b87dab86e8c9940f7713369edcbe74cc9d9bad9/ostd/src/arch/x86/mod.rs#L59

Finally, I think we should make it more explicit in `timer::register_callback` that it only registers a timer callback for the current CPU. I renamed it to `timer::register_callback_on_cpu`.
```patch
-/// Register a function that will be executed during the system timer interruption.
-pub fn register_callback<F>(func: F)
+/// Registers a function that will be executed during the timer interrupt on the current CPU.
+pub fn register_callback_on_cpu<F>(func: F)
```
