### PR TITLE
Fix/clarify problems about mount namespaces

### DIFF
--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -56,6 +56,9 @@ impl FsResolver {
     ///
     /// Otherwise, the method will change both the `cwd` and `root` to their corresponding
     /// `Path`s within the new `MountNamespace`.
+    //
+    // FIXME: This cannot fail if we clone mount namespaces and update resolvers in an atomic way.
+    // We currently leak this error to userspace, which is not a correct behavior.
     pub fn switch_to_mnt_ns(&mut self, mnt_ns: &Arc<MountNamespace>) -> Result<()> {
         if mnt_ns.owns(self.root.mount_node()) && mnt_ns.owns(self.cwd.mount_node()) {
             return Ok(());

--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -64,14 +64,18 @@ impl FsResolver {
             return Ok(());
         }
 
-        let new_root = self
-            .root
-            .find_corresponding_mount(mnt_ns)
-            .ok_or(Error::new(Errno::EINVAL))?;
-        let new_cwd = self
-            .cwd
-            .find_corresponding_mount(mnt_ns)
-            .ok_or(Error::new(Errno::EINVAL))?;
+        let new_root = self.root.find_corresponding_mount(mnt_ns).ok_or_else(|| {
+            Error::with_message(
+                Errno::EINVAL,
+                "the root directory does not exist in the target mount namespace",
+            )
+        })?;
+        let new_cwd = self.cwd.find_corresponding_mount(mnt_ns).ok_or_else(|| {
+            Error::with_message(
+                Errno::EINVAL,
+                "the current working directory does not exist in the target mount namespace",
+            )
+        })?;
 
         self.root = new_root;
         self.cwd = new_cwd;

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -169,7 +169,9 @@ impl ContextSetNsAdminApi for Context<'_> {
         // TODO: When setting a specific namespace,
         // other dependent fields of a posix thread may also need to be updated.
 
-        *self.thread_local.borrow_fs().resolver().write() = ns_proxy.mnt_ns.new_fs_resolver();
+        if !Arc::ptr_eq(&thread_local_ns_proxy.unwrap().mnt_ns, &ns_proxy.mnt_ns) {
+            *self.thread_local.borrow_fs().resolver().write() = ns_proxy.mnt_ns.new_fs_resolver();
+        }
 
         *pthread_ns_proxy = Some(ns_proxy.clone());
         thread_local_ns_proxy.replace(Some(ns_proxy));

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -63,8 +63,7 @@ impl ContextUnshareAdminApi for Context<'_> {
                 .borrow_fs()
                 .resolver()
                 .write()
-                .switch_to_mnt_ns(new_ns_proxy.mnt_ns())
-                .unwrap();
+                .switch_to_mnt_ns(new_ns_proxy.mnt_ns())?;
         }
 
         *pthread_ns_proxy = Some(new_ns_proxy.clone());

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -89,7 +89,7 @@ fn build_proxy_from_pid_file(
         if ctx.thread_local.is_fs_shared() {
             return_errno_with_message!(
                 Errno::EINVAL,
-                "cannot change mount namespace with shared filesystem"
+                "setting a mount namespace is not allowed with shared filesystem information"
             );
         }
 

--- a/test/src/apps/scripts/process.sh
+++ b/test/src/apps/scripts/process.sh
@@ -33,7 +33,7 @@ mmap/mmap_beyond_the_file
 mmap/mmap_shared_filebacked
 mmap/mmap_readahead
 mmap/mmap_vmrss
-namepsace/mnt_ns
+namespace/mnt_ns
 namespace/setns
 namespace/unshare
 process/group_session


### PR DESCRIPTION
There are some problems with the merged PR https://github.com/asterinas/asterinas/pull/2379:

 - First, there is a trivial typo that will lead to CI failures:
<img width="1206" height="444" alt="image" src="https://github.com/user-attachments/assets/4e892ca7-0128-4977-9134-91972d2f3102" />

 - Second, the implementation of `FsResolver::switch_to_mnt_ns` is problematic. I see no ideas why it should fail with `EINVAL`. [According to the Linux implementation](https://elixir.bootlin.com/linux/v6.16.8/source/fs/namespace.c#L4338-L4386), it should never fail. The problem is that cloning the mount tree and updating the FS resolver should be combined into a single, atomic operation. However, we can't do that because we don't have a global mount lock.
https://github.com/asterinas/asterinas/blob/57d3d9ded1fea80ab3c8736e03fd4d9248e4b676/kernel/src/fs/fs_resolver.rs#L64-L71

 - Third, which I haven't fully confirmed, is that the implementation of many other mount operations is problematic. It's hard to believe that the current implementation is free of race conditions without a global mount lock. For example, why is cloning the mount tree okay without taking a global lock?

 - Fourth, this is just wrong. Why setting non-mount namespaces reset the FS resolver?
https://github.com/asterinas/asterinas/blob/57d3d9ded1fea80ab3c8736e03fd4d9248e4b676/kernel/src/process/namespace/nsproxy.rs#L172

I couldn't do anything about the third problem, but I tried to fix or at least clarify several others.