### PR TITLE
Support /proc/pid/uid_map and /proc/pid/gid_map

### DIFF
--- a/kernel/src/fs/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/procfs/pid/task/uid_map.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::format;
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{mkmod, Inode},
+    },
+    prelude::*,
+    process::Process,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/uid_map` (and also `/proc/[pid]/uid_map`).
+#[expect(dead_code)]
+pub struct UidMapFileOps(Arc<Process>);
+
+impl UidMapFileOps {
+    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3386>
+        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r, u+w))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for UidMapFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        // This is the default UID map for the initial user namespace.
+        // TODO: Retrieve the UID map from the user namespace of the current process
+        // instead of returning this hard-coded value.
+        const INVALID_UID: u32 = u32::MAX;
+        let res = format!("{:>10}{:>10}{:>10}", 0, 0, INVALID_UID);
+        Ok(res.into_bytes())
+    }
+}


### PR DESCRIPTION
This PR adds support for `/proc/pid/uid_map` and `/proc/pid/gid_map`, which is required by #2214.

These two files are used to show the UID and GID mappings between the user namespace and its parent user namesspace, since we don't actually support user namespace at this time, so here we only hardcoded the values for the initial user namesace.

From [the maunal](https://man7.org/linux/man-pages/man7/user_namespaces.7.html): 

```plain
       The initial user namespace has no parent namespace, but, for
       consistency, the kernel provides dummy user and group ID mapping
       files for this namespace.  Looking at the uid_map file (gid_map is
       the same) from a shell in the initial namespace shows:

           $ cat /proc/$$/uid_map;
                    0          0 4294967295
```