### PR TITLE
Fix a problem of using INITRAMFS_SKIP_GZIP=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 
 # Skip GZIP to make encoding and decoding of initramfs faster
 ifeq ($(INITRAMFS_SKIP_GZIP),1)
-CARGO_OSDK_INITRAMFS_OPTION := --initramfs=$(realpath test/build/initramfs.cpio)
+CARGO_OSDK_INITRAMFS_OPTION := --initramfs=$(abspath test/build/initramfs.cpio)
 CARGO_OSDK_COMMON_ARGS += $(CARGO_OSDK_INITRAMFS_OPTION)
 endif
 


### PR DESCRIPTION
This PR fixes an issue mentioned in #2452 that, when building Asterinas with `INITRAMFS_SKIP_GZIP=1` for the first time, it would fail due to not finding `test/build/initramfs.cpio`.