### PR TITLE
Ensure `bzImage` is rebuilt on kernel payload changes

### DIFF
--- a/ostd/libs/linux-bzimage/setup/build.rs
+++ b/ostd/libs/linux-bzimage/setup/build.rs
@@ -5,6 +5,7 @@ use std::{path::PathBuf, process::Command};
 fn main() {
     let source_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let payload_file = PathBuf::from(std::env::var("PAYLOAD_FILE").unwrap());
 
     let target_arch = std::env::var("TARGET").unwrap();
     if target_arch.starts_with("x86_64") {
@@ -25,6 +26,7 @@ fn main() {
             .expect("failed to run the preprocessor");
         assert!(status.success(), "the preprocessor exits with failure");
 
+        println!("cargo:rerun-if-changed={}", payload_file.display());
         println!("cargo:rerun-if-changed={}", lds.display());
         println!("cargo:rustc-link-arg=-T{}", out_lds.display());
     } else {


### PR DESCRIPTION
This patch fixes #2413 by ensuring the `linux-bzimage-setup` is properly rebuilt when the kernel payload it processes changes.

Currently, launching a TD guest (or any guest using the Linux boot method) requires generating a `bzImage`. The build process uses `cargo install --force` to (re)install the `linux-bzimage-setup` tool. However, the `--force` flag alone does not trigger a recompilation without reason. Crucially, the build system does not track changes to the compressed kernel binary (the payload) that `linux-bzimage-setup` consumes. Therefore, modifications to the kernel are not reflected in the final `bzImage` unless one manually cleans the Cargo cache, leading to an outdated guest kernel boot image.

This fix ensures Cargo's dependency tracking includes the payload file, triggering a necessary rebuild of `linux-bzimage-setup` whenever the payload itself is updated, thus guaranteeing the `bzImage` is always generated from the latest kernel.