### PR TITLE
Make syscall restart mechanism work across all architectures

### DIFF
--- a/kernel/src/arch/loongarch/cpu.rs
+++ b/kernel/src/arch/loongarch/cpu.rs
@@ -17,10 +17,6 @@ impl LinuxAbi for UserContext {
         self.a7()
     }
 
-    fn set_syscall_num(&mut self, num: usize) {
-        self.set_a7(num);
-    }
-
     fn syscall_ret(&self) -> usize {
         self.a0()
     }

--- a/kernel/src/arch/riscv/cpu.rs
+++ b/kernel/src/arch/riscv/cpu.rs
@@ -17,10 +17,6 @@ impl LinuxAbi for UserContext {
         self.a7()
     }
 
-    fn set_syscall_num(&mut self, num: usize) {
-        self.set_a7(num);
-    }
-
     fn syscall_ret(&self) -> usize {
         self.a0()
     }

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -29,10 +29,6 @@ impl LinuxAbi for UserContext {
         self.rax()
     }
 
-    fn set_syscall_num(&mut self, num: usize) {
-        self.set_rax(num);
-    }
-
     fn set_syscall_ret(&mut self, ret: usize) {
         self.set_rax(ret);
     }

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -8,9 +8,6 @@ pub trait LinuxAbi {
     /// Gets the return value of the system call.
     fn syscall_ret(&self) -> usize;
 
-    /// Sets the system call number.
-    fn set_syscall_num(&mut self, num: usize);
-
     /// Sets the return value of the system call.
     fn set_syscall_ret(&mut self, ret: usize);
 

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -83,14 +83,14 @@ pub fn create_new_user_task(
 
             // Handle user events
             let user_ctx = user_mode.context_mut();
-            let mut syscall_number = None;
+            let mut pre_syscall_ret = None;
             match return_reason {
                 ReturnReason::UserException => {
                     let exception = user_ctx.take_exception().unwrap();
                     handle_exception(&ctx, user_ctx, exception)
                 }
                 ReturnReason::UserSyscall => {
-                    syscall_number = Some(user_ctx.syscall_num());
+                    pre_syscall_ret = Some(user_ctx.syscall_ret());
                     handle_syscall(&ctx, user_ctx);
                 }
                 ReturnReason::KernelEvent => {}
@@ -102,7 +102,7 @@ pub fn create_new_user_task(
             }
 
             // Handle signals
-            handle_pending_signal(user_ctx, &ctx, syscall_number);
+            handle_pending_signal(user_ctx, &ctx, pre_syscall_ret);
 
             // Handle signals while the thread is stopped
             // FIXME: Currently, we handle all signals when the process is stopped.


### PR DESCRIPTION
Currently we save syscall number before handling syscall to avoid losing it when setting syscall return value. This works on x86_64 because x86_64's syscall number and syscall return value share exactly the same register. However, it's not the case on other architectures. For example, on riscv64, the syscall return value shares the same register as the first syscall argument (instead of the syscall number).

A safe solution across all architectures is to always restore the initial value of the syscall return value register.