### PR TITLE
Fix schbench benchmark result extraction pattern

### DIFF
--- a/test/src/benchmark/schbench/smp1/bench_results/p50_rps.yaml
+++ b/test/src/benchmark/schbench/smp1/bench_results/p50_rps.yaml
@@ -9,4 +9,4 @@ chart:
 result_extraction:
   nth_occurrence: 3
   result_index: 3
-  search_pattern: \*
+  search_pattern: '50.0th:'

--- a/test/src/benchmark/schbench/smp1/bench_results/p99_request_latency.yaml
+++ b/test/src/benchmark/schbench/smp1/bench_results/p99_request_latency.yaml
@@ -9,4 +9,4 @@ chart:
 result_extraction:
   nth_occurrence: 2
   result_index: 3
-  search_pattern: \*
+  search_pattern: '99.0th:'

--- a/test/src/benchmark/schbench/smp1/bench_results/p99_wakeup_latency.yaml
+++ b/test/src/benchmark/schbench/smp1/bench_results/p99_wakeup_latency.yaml
@@ -9,4 +9,4 @@ chart:
 result_extraction:
   nth_occurrence: 1
   result_index: 3
-  search_pattern: \*
+  search_pattern: '99.0th:'

--- a/test/src/benchmark/schbench/smp8/bench_results/p50_rps.yaml
+++ b/test/src/benchmark/schbench/smp8/bench_results/p50_rps.yaml
@@ -9,6 +9,6 @@ chart:
 result_extraction:
   nth_occurrence: 3
   result_index: 3
-  search_pattern: \*
+  search_pattern: '50.0th:'
 runtime_config:
   smp: 8

--- a/test/src/benchmark/schbench/smp8/bench_results/p99_request_latency.yaml
+++ b/test/src/benchmark/schbench/smp8/bench_results/p99_request_latency.yaml
@@ -9,6 +9,6 @@ chart:
 result_extraction:
   nth_occurrence: 2
   result_index: 3
-  search_pattern: \*
+  search_pattern: '99.0th:'
 runtime_config:
   smp: 8

--- a/test/src/benchmark/schbench/smp8/bench_results/p99_wakeup_latency.yaml
+++ b/test/src/benchmark/schbench/smp8/bench_results/p99_wakeup_latency.yaml
@@ -9,6 +9,6 @@ chart:
 result_extraction:
   nth_occurrence: 1
   result_index: 3
-  search_pattern: \*
+  search_pattern: '99.0th:'
 runtime_config:
   smp: 8


### PR DESCRIPTION
The new logo contains "*" character, which causes the original schbench benchmark result extraction pattern to fail. 