### PR TITLE
Block a setuid ltp test for exfat test

### DIFF
--- a/test/src/syscall/ltp/testcases/blocked/exfat.txt
+++ b/test/src/syscall/ltp/testcases/blocked/exfat.txt
@@ -68,6 +68,7 @@ sendfile06
 sendfile06_64
 sendfile08
 sendfile08_64
+setuid04
 stat02
 stat02_64
 symlink02


### PR DESCRIPTION
setuid04 ltp test will fail with exFAT due to some bugs of `InodeMode` maintaining in exFAT, which will cause CI failure after #2458 merged.  