### PR TITLE
Fix parameter passing of `preadv/pwritev`-family syscalls

### DIFF
--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -213,8 +213,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_WRITEV = 66                  => sys_writev(args[..3]);
     SYS_PREAD64 = 67                 => sys_pread64(args[..4]);
     SYS_PWRITE64 = 68                => sys_pwrite64(args[..4]);
-    SYS_PREADV = 69                  => sys_preadv(args[..4]);
-    SYS_PWRITEV = 70                 => sys_pwritev(args[..4]);
+    SYS_PREADV = 69                  => sys_preadv(args[..5]);
+    SYS_PWRITEV = 70                 => sys_pwritev(args[..5]);
     SYS_SENDFILE64 = 71              => sys_sendfile(args[..4]);
     SYS_PSELECT6 = 72                => sys_pselect6(args[..6]);
     SYS_PPOLL = 73                   => sys_ppoll(args[..5]);
@@ -335,8 +335,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);
-    SYS_PREADV2 = 286                => sys_preadv2(args[..5]);
-    SYS_PWRITEV2 = 287               => sys_pwritev2(args[..5]);
+    SYS_PREADV2 = 286                => sys_preadv2(args[..6]);
+    SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
     SYS_STATX = 291                  => sys_statx(args[..5]);
     SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -213,8 +213,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_WRITEV = 66                  => sys_writev(args[..3]);
     SYS_PREAD64 = 67                 => sys_pread64(args[..4]);
     SYS_PWRITE64 = 68                => sys_pwrite64(args[..4]);
-    SYS_PREADV = 69                  => sys_preadv(args[..4]);
-    SYS_PWRITEV = 70                 => sys_pwritev(args[..4]);
+    SYS_PREADV = 69                  => sys_preadv(args[..5]);
+    SYS_PWRITEV = 70                 => sys_pwritev(args[..5]);
     SYS_SENDFILE64 = 71              => sys_sendfile(args[..4]);
     SYS_PSELECT6 = 72                => sys_pselect6(args[..6]);
     SYS_PPOLL = 73                   => sys_ppoll(args[..5]);
@@ -337,8 +337,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);
-    SYS_PREADV2 = 286                => sys_preadv2(args[..5]);
-    SYS_PWRITEV2 = 287               => sys_pwritev2(args[..5]);
+    SYS_PREADV2 = 286                => sys_preadv2(args[..6]);
+    SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
     SYS_STATX = 291                  => sys_statx(args[..5]);
     SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -374,8 +374,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_EPOLL_CREATE1 = 291    => sys_epoll_create1(args[..1]);
     SYS_DUP3 = 292             => sys_dup3(args[..3]);
     SYS_PIPE2 = 293            => sys_pipe2(args[..2]);
-    SYS_PREADV = 295           => sys_preadv(args[..4]);
-    SYS_PWRITEV = 296          => sys_pwritev(args[..4]);
+    SYS_PREADV = 295           => sys_preadv(args[..5]);
+    SYS_PWRITEV = 296          => sys_pwritev(args[..5]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
     SYS_SETNS = 308            => sys_setns(args[..2]);
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);
@@ -385,8 +385,8 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 319     => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut user_ctx);
-    SYS_PREADV2 = 327          => sys_preadv2(args[..5]);
-    SYS_PWRITEV2 = 328         => sys_pwritev2(args[..5]);
+    SYS_PREADV2 = 327          => sys_preadv2(args[..6]);
+    SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);

--- a/kernel/src/syscall/preadv.rs
+++ b/kernel/src/syscall/preadv.rs
@@ -21,9 +21,14 @@ pub fn sys_preadv(
     fd: FileDesc,
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
-    offset: i64,
+    offset_low: u64,
+    _offset_high: u64,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
+    // On 64-bit platforms, Linux assumes the `offset_low` contains the full
+    // 64-bit offset.
+    // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/read_write.c#L1114-L1118>.
+    let offset = offset_low.cast_signed();
     let res = do_sys_preadv(fd, io_vec_ptr, io_vec_count, offset, RWFFlag::empty(), ctx)?;
     Ok(SyscallReturn::Return(res as _))
 }
@@ -32,10 +37,15 @@ pub fn sys_preadv2(
     fd: FileDesc,
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
-    offset: i64,
+    offset_low: u64,
+    _offset_high: u64,
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
+    // On 64-bit platforms, Linux assumes the `offset_low` contains the full
+    // 64-bit offset.
+    // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/read_write.c#L1114-L1118>.
+    let offset = offset_low.cast_signed();
     let flags = match RWFFlag::from_bits(flags) {
         Some(flags) => flags,
         None => return_errno_with_message!(Errno::EINVAL, "invalid flags"),


### PR DESCRIPTION
Linux splits the `offset` parameter of `preadv`/`pwritev`-family syscalls to two separate parameters, representing the lower half and the higher half. Our current implementation doesn't follow this ABI and the previous success of syscall test are just out of luck.

This PR fixes this problem. For more details on how glibc and Linux interact with each other across this ABI, one may want to check https://elixir.bootlin.com/glibc/glibc-2.42.9000/source/sysdeps/unix/sysv/linux/preadv2.c and https://elixir.bootlin.com/linux/v6.16.9/source/fs/read_write.c.