### PR TITLE
Fix ext2 block groups count

### DIFF
--- a/kernel/src/fs/ext2/block_group.rs
+++ b/kernel/src/fs/ext2/block_group.rs
@@ -58,10 +58,15 @@ impl BlockGroup {
                     Ok(IdAlloc::from_bytes_with_capacity(&buf, capacity))
                 };
 
-                let block_bitmap = get_bitmap(
-                    descriptor.block_bitmap_bid,
-                    super_block.blocks_per_group() as usize,
-                )?;
+                let block_bitmap = {
+                    let num_blocks = if (idx as u32) < super_block.block_groups_count() - 1 {
+                        super_block.blocks_per_group()
+                    } else {
+                        // The last block group may have less blocks than others.
+                        super_block.total_blocks() - super_block.blocks_per_group() * idx as u32
+                    };
+                    get_bitmap(descriptor.block_bitmap_bid, num_blocks as usize)?
+                };
                 let inode_bitmap = get_bitmap(
                     descriptor.inode_bitmap_bid,
                     super_block.inodes_per_group() as usize,

--- a/kernel/src/fs/ext2/super_block.rs
+++ b/kernel/src/fs/ext2/super_block.rs
@@ -216,7 +216,7 @@ impl SuperBlock {
 
     /// Returns the number of block groups.
     pub fn block_groups_count(&self) -> u32 {
-        self.blocks_count / self.blocks_per_group
+        self.blocks_count.div_ceil(self.blocks_per_group)
     }
 
     /// Returns the filesystem state.


### PR DESCRIPTION
Ext2 block groups count was calculated using integer division, causing inaccessible blocks in the final partial group, which leads to premature "No space left on device" errors. For example:
```
~ # dd if=/dev/zero of=/ext2/test.file bs=1M count=2000
dd: error writing '/ext2/test.file': No space left on device
```
