### PR TITLE
Add `wait4` and `clone` syscall limitation to the book

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -76,12 +76,12 @@ which are summarized in the table below.
 | 53      | socketpair             | ✅             | [⚠️](limitations-on-system-calls/networking-and-sockets.html#socketpair) |
 | 54      | setsockopt             | ✅             | [⚠️](limitations-on-system-calls/networking-and-sockets.html#getsockopt-and-setsockopt) |
 | 55      | getsockopt             | ✅             | [⚠️](limitations-on-system-calls/networking-and-sockets.html#getsockopt-and-setsockopt) |
-| 56      | clone                  | ✅             |     |
+| 56      | clone                  | ✅             | [⚠️](limitations-on-system-calls/process-and-thread-management.md#clone) |
 | 57      | fork                   | ✅             |     |
 | 58      | vfork                  | ❌             |     |
 | 59      | execve                 | ✅             |     |
 | 60      | exit                   | ✅             |     |
-| 61      | wait4                  | ✅             |     |
+| 61      | wait4                  | ✅             | [⚠️](limitations-on-system-calls/process-and-thread-management.md#wait4) |
 | 62      | kill                   | ✅             |     |
 | 63      | uname                  | ✅             |     |
 | 64      | semget                 | ✅             |     |

--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/process-and-thread-management.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/process-and-thread-management.md
@@ -64,3 +64,82 @@ Unsupported scheduling flags:
 * `SCHED_FLAG_DL_OVERRUN`
 * `SCHED_FLAG_UTIL_CLAMP_MIN`
 * `SCHED_FLAG_UTIL_CLAMP_MAX`
+
+## `wait4`
+
+Supported functionality in SCML:
+
+```c
+// Wait until a specified child process undergoes a state change (termination, stopping and resumption)
+wait4(
+    pid, wstatus,
+    options = WNOHANG | WSTOPPED | WCONTINUED | WNOWAIT,
+    rusage
+);
+```
+
+Ignored options:
+* `WEXITED`
+* `WNOTHREAD`
+* `WALL`
+* `WCLONE`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/wait4.2.html).
+
+## `clone`
+
+Supported functionality in SCML:
+
+```c
+signal_flags = SIGHUP | SIGINT | SIGQUIT | SIGILL |
+               SIGTRAP | SIGABRT | SIGSTKFLT | SIGFPE |
+               SIGKILL | SIGBUS | SIGSEGV | SIGXCPU |
+               SIGPIPE | SIGALRM | SIGTERM | SIGUSR1 |
+               SIGUSR2 | SIGCHLD | SIGPWR | SIGVTALRM |
+               SIGPROF | SIGIO | SIGWINCH | SIGSTOP |
+               SIGTSTP | SIGCONT | SIGTTIN | SIGTTOU |
+               SIGURG | SIGXFSZ | SIGSYS | SIGRTMIN;
+
+opt_flags =
+    // Optional flags
+    //
+    // Share the parent's virtual memory
+    CLONE_VM |
+    // Share the parent's filesystem
+    CLONE_FS |
+    // Share the parent's file descriptor table
+    CLONE_FILES |
+    // Share the parent's signal handlers
+    CLONE_SIGHAND |
+    // Place child in the same thread group as parent
+    CLONE_THREAD |
+    // Share the parent's System V semaphore adjustments
+    CLONE_SYSVSEM |
+    // Suspend parent until the child exits or calls `execve`
+    CLONE_VFORK |
+    // Create a new mount namespace for the child
+    CLONE_NEWNS |
+    // Write child `TID` to parent's memory
+    CLONE_PARENT_SETTID |
+    // Allocate a `PID` file descriptor for the child
+    CLONE_PIDFD |
+    // Set thread-local storage for the child
+    CLONE_SETTLS |
+    // Write child `TID` to child's memory
+    CLONE_CHILD_SETTID |
+    // Clear child `TID` in child's memory on exit
+    CLONE_CHILD_CLEARTID |
+    // Make the child's parent the same as the caller's parent
+    CLONE_PARENT;
+
+// Create a thread or process
+clone(
+    fn, stack,
+    flags = <opt_flags> | <signal_flags>,
+    func_arg, ..
+);
+```
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/clone.2.html).

--- a/book/src/kernel/linux-compatibility/limitations-on-system-calls/system-call-matching-language.md
+++ b/book/src/kernel/linux-compatibility/limitations-on-system-calls/system-call-matching-language.md
@@ -88,6 +88,21 @@ open(path, flags = O_PATH | O_CLOEXEC);
 SCML rules constrain only the flagged arguments;
 other parameters (like `path` and `mode`) accept any value.
 
+In many system calls, the number of arguments may vary depending on the flags provided.
+To accommodate this, SCML allows you to use the `..` wildcard in the parameter list.
+This indicates that any additional arguments are accepted, regardless of their value or count.
+
+For example:
+
+```c
+open(path, flags = O_RDONLY | O_WRONLY | O_RDWR | O_CLOEXEC, ..);
+```
+
+Here, the `..` wildcard makes the rule flexible enough to match invocations of `open` with extra parameters,
+such as when the `O_CREAT` flag is present and a `mode` argument is required.
+This approach makes it easy to write concise rules that only constrain the arguments of interest,
+while allowing other parameters to vary as needed.
+
 ### C-Style Comments
 
 SCML also supports C‑style comments:
@@ -259,7 +274,8 @@ Non‑terminals are in angle brackets, terminals in quotes.
                    | <bitflags-rule> ';'
 
 <syscall-rule>   ::= <identifier> '(' [ <param-list> ] ')'
-<param-list>     ::= <param> { ',' <param> }
+<param-list>     ::= '..'
+                   | <param> { ',' <param> } [ ',' '..' ]
 <param>          ::= <identifier> '=' <expr>
                    | <identifier>
 


### PR DESCRIPTION
This PR introduces documentation for syscall limitations using the System Call Matching Language (SCML), specifically covering the `wait4` and `clone` system calls.

Additionally, wildcard support has been incorporated into SCML's parameter list syntax. This enhancement simplifies the description of system calls that accept a variable number of arguments, such as `clone`.