### PR TITLE
feat: Support /proc/kallsyms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,10 +973,6 @@ version = "0.1.0"
 [[package]]
 name = "ksym-bin"
 version = "0.1.0"
-dependencies = [
- "log",
- "rustc-demangle",
-]
 
 [[package]]
 name = "lazy_static"
@@ -1549,12 +1545,6 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,14 @@ name = "keyable-arc"
 version = "0.1.0"
 
 [[package]]
+name = "ksym-bin"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1283,7 @@ dependencies = [
  "inherit-methods-macro",
  "int-to-c-enum",
  "intrusive-collections",
+ "ksym-bin",
  "linux-boot-params",
  "log",
  "loongArch64",
@@ -1540,6 +1549,12 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "kernel/libs/typeflags-util",
     "kernel/libs/atomic-integer-wrapper",
     "kernel/libs/xarray",
+    "kernel/libs/ksym-bin",
 ]
 exclude = [
     "kernel/libs/comp-sys/cargo-component",

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ KALLSYMS_PATH := ./target/osdk/aster-nix/kallsyms
 KALLSYMS_DST := ./test/src/proc/kallsyms
 
 .PHONY: build
-build: initramfs $(CARGO_OSDK) ksym
+build: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk build $(CARGO_OSDK_BUILD_ARGS)
 	@if [ -f "$(KALLSYMS_PATH)" ]; then \
 		cp "$(KALLSYMS_PATH)" "$(KALLSYMS_DST)"; \
@@ -271,15 +271,6 @@ build: initramfs $(CARGO_OSDK) ksym
 # 	remake initramfs to include the updated kallsyms
 	@make initramfs
 	@echo "// dummy kallsyms" > ./test/src/proc/kallsyms
-
-.PHONY: ksym
-ksym:
-	@if ! command -v gen_ksym >/dev/null 2>&1; then \
-		echo "Installing gen_ksym..."; \
-		cargo install --path kernel/libs/ksym-bin --features=demangle; \
-	else \
-		echo "gen_ksym already installed."; \
-	fi
 
 .PHONY: tools
 tools:

--- a/Makefile
+++ b/Makefile
@@ -257,16 +257,36 @@ check_vdso:
 initramfs: check_vdso
 	@$(MAKE) --no-print-directory -C test
 
+KALLSYMS_PATH := ./target/osdk/aster-nix/kallsyms
+KALLSYMS_DST := ./test/src/proc/kallsyms
+
 .PHONY: build
-build: initramfs $(CARGO_OSDK)
+build: initramfs $(CARGO_OSDK) ksym
 	@cd kernel && cargo osdk build $(CARGO_OSDK_BUILD_ARGS)
+	@if [ -f "$(KALLSYMS_PATH)" ]; then \
+		cp "$(KALLSYMS_PATH)" "$(KALLSYMS_DST)"; \
+	else \
+		echo "Warning: kallsyms not generated, skipping copy."; \
+	fi
+# 	remake initramfs to include the updated kallsyms
+	@make initramfs
+	@echo "// dummy kallsyms" > ./test/src/proc/kallsyms
+
+.PHONY: ksym
+ksym:
+	@if ! command -v gen_ksym >/dev/null 2>&1; then \
+		echo "Installing gen_ksym..."; \
+		cargo install --path kernel/libs/ksym-bin --features=demangle; \
+	else \
+		echo "gen_ksym already installed."; \
+	fi
 
 .PHONY: tools
 tools:
 	@cd kernel/libs/comp-sys && cargo install --path cargo-component
 
 .PHONY: run
-run: initramfs $(CARGO_OSDK)
+run: build
 	@cd kernel && cargo osdk run $(CARGO_OSDK_BUILD_ARGS)
 # Check the running status of auto tests from the QEMU log
 ifeq ($(AUTO_TEST), syscall)

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,8 @@ OSDK_CRATES := \
 	kernel/comps/pci \
 	kernel/libs/aster-util \
 	kernel/libs/aster-bigtcp \
-	kernel/libs/xarray
+	kernel/libs/xarray \
+	kernel/libs/ksym-bin
 
 # OSDK dependencies
 OSDK_SRC_FILES := \

--- a/kernel/libs/ksym-bin/Cargo.toml
+++ b/kernel/libs/ksym-bin/Cargo.toml
@@ -4,15 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 description = "A Rust crate for generating kernel symbol tables (ksyms) from kernel binaries."
-
-[dependencies]
-rustc-demangle = { version = "0.1", optional = true }
-log = "0.4"
-
-[features]
-demangle = ["dep:rustc-demangle"]
-assembly = []
-
-[[bin]]
-name = "gen_ksym"
-required-features = ["demangle"]

--- a/kernel/libs/ksym-bin/Cargo.toml
+++ b/kernel/libs/ksym-bin/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 description = "A Rust crate for generating kernel symbol tables (ksyms) from kernel binaries."
+
+[lints]
+workspace = true

--- a/kernel/libs/ksym-bin/Cargo.toml
+++ b/kernel/libs/ksym-bin/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ksym-bin"
+version = "0.1.0"
+edition = "2021"
+
+description = "A Rust crate for generating kernel symbol tables (ksyms) from kernel binaries."
+
+[dependencies]
+rustc-demangle = { version = "0.1", optional = true }
+log = "0.4"
+
+[features]
+demangle = ["dep:rustc-demangle"]
+assembly = []
+
+[[bin]]
+name = "gen_ksym"
+required-features = ["demangle"]

--- a/kernel/libs/ksym-bin/README.en.md
+++ b/kernel/libs/ksym-bin/README.en.md
@@ -1,0 +1,135 @@
+# ksym-bin Guide
+
+This directory provides a tool that reads kallsyms-like symbol lists (e.g., from /proc/kallsyms) from stdin and produces a compressed binary blob, along with a zero-copy reading convention for consumers.
+
+This document covers:
+- Relationships among KallsymsBlob metadata
+- Compression and token selection rules
+- Symbol ordering and lookup
+- Binary layout and alignment (for zero-copy)
+- Limitations and notes
+
+## KallsymsBlob metadata
+
+KallsymsBlob is a build-time container used to collect symbols, compress them, and serialize the result. Key fields:
+
+- token_table: Vec<u8>
+  - Concatenated bytes of all token strings.
+- token_index: Vec<u32>
+  - Start byte offsets for each token in token_table; indices match token ids (0..N-1).
+- token_map: HashMap<String, u16>
+  - Build-time dictionary (not serialized) mapping token text to its id.
+- kallsyms_names: Vec<u8>
+  - Concatenated compressed bytes of all symbol names.
+- kallsyms_offsets: Vec<u32>
+  - For each address-ordered symbol, the start byte offset into `kallsyms_names`.
+- kallsyms_seqs_of_names: Vec<u32>
+  - Mapping from name-order to address-order indices (used for binary search by name).
+- kallsyms_addresses: Vec<u64>
+  - Symbol virtual addresses in ascending order (address order).
+- kallsyms_num_syms: usize
+  - Number of symbols (also written as a u64 header in the blob).
+
+Relationship:
+- For the i-th symbol in address order:
+  - Address = `kallsyms_addresses[i]`
+  - Name record begins at `kallsyms_offsets[i]`. Each name record starts with a 1-byte type prefix `TY_LEN=1` and a 2-byte length prefix `LENGTH_BYTES=2` (little-endian), followed by `entry_len` bytes of payload. The actual slice is:
+    `kallsyms_names[kallsyms_offsets[i] + PREFIX_LEN .. kallsyms_offsets[i] + PREFIX_LEN + entry_len] (PREFIX_LEN = TY_LEN + LENGTH_BYTES)`.
+- Name search: binary search over `kallsyms_seqs_of_names`; once `mid` is found, retrieve the address-order index `seq = kallsyms_seqs_of_names[mid]`.
+
+## Compression and token selection
+
+- Token candidates are collected via a fixed-prefix heuristic: only prefixes of each name are considered. The length set is implementation-configured (currently several discrete lengths such as 10, 24, 31, …, 2000).
+  - If a name is shorter than the smallest length (currently 10), the whole name is also counted as a candidate (for position 0 only).
+  - Candidates are ranked by a weighted score (frequency × length), and up to 512 tokens are selected. Tokens that are prefixes of already-selected tokens are skipped to reduce redundancy.
+- Name compression uses “single-prefix token + raw remainder”:
+  - Try only one token at the beginning of the name (longer candidates first);
+  - If matched, emit the token code and then append the remaining raw bytes; otherwise, write the whole name as raw bytes.
+- Each name record is encoded as a “fixed-size prefix + payload”:
+  - A 1-byte type prefix;
+  - A 2-byte little-endian length prefix specifies the size of the payload;
+  - If a token is used, the payload starts with `0xFF <id> 0xFF` (1-byte id) or `0xFF <id_hi> <id_lo> 0xFF` (2-byte id), followed by the remaining raw bytes;
+  - If no token is used, the payload is simply the raw name bytes.
+- Token marker constant: `TOKEN_MARKER = 0xFF`.
+
+Note: Only text symbols (T/t) are kept from the input, and Rust demangling is applied. During encoding, the symbol type character (T/t) is prefixed to the compressed name.
+
+## Symbol ordering and lookup
+
+- Storage order is by address. During build:
+  - `kallsyms_addresses` and `kallsyms_offsets` are sorted ascending by address;
+  - A name-order → address-order mapping `kallsyms_seqs_of_names` is built for name binary search.
+- Lookup:
+  - Address → symbol: binary-search `kallsyms_addresses` to get index i. To handle aliasing (multiple symbols at the same address), search backward to the first symbol at that address, then search forward to the next symbol with a different address to determine the size. If none is found, use the end of the text section as the upper bound. Name decoding uses the length prefix at `kallsyms_offsets[i]` to slice the record, then expand.
+  - Name → address: binary-search in name space. Each step, use `kallsyms_seqs_of_names[mid]` to fetch the address-order index, decode the name record using the length prefix, and compare. On match, return the corresponding address.
+
+## Binary layout and alignment
+
+All fields are serialized in little-endian. To support zero-copy reading with proper alignment (u64 aligned to 8 bytes, u32 aligned to 4 bytes), padding is inserted before each segment as needed. The loader maps the blob at a 4K-aligned address. With this guarantee, zero-copy casting via `from_raw_parts` is safe.
+
+Segment order (alignment in parentheses):
+
+1) num_syms: u64
+2) addresses[num_syms]: u64[]  (align 8)
+3) offsets[num_syms]: u32[]    (align 4)
+4) seqs[num_syms]: u32[]       (align 4)
+5) names:                      (align 8)
+   - names_len: u64
+   - names_bytes[names_len]: u8[]
+     - repeated name records: `[[type: u8] [len: u16(le)] [payload: u8[len]]`
+6) token_table:                (align 8)
+   - token_table_len: u64
+   - token_table_bytes[token_table_len]: u8[]
+7) token_index:                (align 8 for len, then align 4 for array)
+   - token_index_len: u64
+   - token_index[token_index_len]: u32[] (align 4)
+
+Notes:
+- Alignment is ensured by padding the output buffer before each segment.
+- `kallsyms_offsets` uses u32; thus `kallsyms_names.len()` must be < 4 GiB.
+
+## Zero-copy reading (KallsymsMapped)
+
+- `from_blob(&blob, stext, etext)` interprets the segments directly as slices while remembering the text section bounds for address lookup:
+  - `&[u64]` for addresses,
+  - `&[u32]` for offsets, seqs, and token_index,
+  - `&[u8]`  for names and token_table.
+- Because each segment begins at an 8/4-byte boundary and the overall mapping is 4K-aligned, `from_raw_parts` alignment is satisfied.
+
+## Limitations and notes
+
+- Up to 512 tokens; token id is u16.
+- Each name record has a 2-byte little-endian length; maximum payload per record is 65535 bytes.
+- `kallsyms_offsets` is u32, limiting the total size of `kallsyms_names` to < 4 GiB.
+- All top-level integers (num_syms, addresses, offsets, seqs, names_len, token_table_len, token_index_len, and token_index contents) are little-endian; name record length is also little-endian.
+- Compression applies at most one token at the beginning; the rest remains raw bytes. Heavier compression strategies can be added in the future if needed.
+
+## Usage
+
+- Generation:
+  - Pipe `nm -n -C {ELF}` (keeping T/t only) into the generator, e.g.:
+    - `nm -n -C {ELF} | cargo run -p ksym-bin --bin gen_ksym --features demangle > kallsyms.bin`
+- Reading (consumer):
+  - Use `ksym_bin::KallsymsMapped::from_blob(&blob, stext, etext)` for zero-copy parsing;
+  - Use `lookup_address`, `lookup_name`, or `dump_all_symbols()` (dump line format: `<addr_hex> <type_char> <name>`).
+
+## Tests
+
+```
+cargo test --bin gen_ksym --features="demangle"
+```
+
+## Example
+
+Example with three simplified symbols:
+- Input:
+  - 0000000000001000 T _start
+  - 0000000000001100 T do_fork
+  - 0000000000001200 T cpu_startup_entry
+- In the resulting blob:
+  - addresses = [0x1000, 0x1100, 0x1200]
+  - offsets point to the beginning of each compressed name record in `kallsyms_names`;
+  - seqs reflect the mapping from name order to address order;
+  - names/token_table/token_index are serialized with the alignment described above.
+
+That summarizes the metadata relationships and binary layout for the current implementation.

--- a/kernel/libs/ksym-bin/README.md
+++ b/kernel/libs/ksym-bin/README.md
@@ -1,0 +1,134 @@
+# ksym-bin 说明
+
+本目录提供从标准输入读取的 kallsyms 风格符号列表（例如 /proc/kallsyms）生成压缩二进制 blob 的工具，以及对应的零拷贝读取格式约定。
+
+本文档描述：
+- KallsymsBlob 元数据之间的关系
+- 压缩与 token 选择规则
+- 符号排序与查找
+- 二进制文件布局与对齐（适配零拷贝读取）
+- 限制与注意事项
+
+## KallsymsBlob 元数据关系
+
+KallsymsBlob 是构建期的数据容器，用于收集符号并压缩、序列化。关键字段：
+
+- token_table: Vec<u8>
+  - 所有 token 字符串的拼接字节。
+- token_index: Vec<u32>
+  - 每个 token 在 token_table 中的起始偏移（按字节），与 token 的 id 一一对应。
+- token_map: HashMap<String, u16>
+  - 构建期使用的字典（不会写入 blob），用于从 token 文本得到 token id（0..N-1）。
+- kallsyms_names: Vec<u8>
+  - 压缩后的所有符号名字节串，顺序拼接。
+- kallsyms_offsets: Vec<u32>
+  - 每个符号在 `kallsyms_names` 中的起始偏移（按字节），与地址序下的符号一一对应。
+- kallsyms_seqs_of_names: Vec<u32>
+  - “名字序 → 地址序”的索引映射。用于对名字做二分时，定位到地址序下的具体条目。
+- kallsyms_addresses: Vec<u64>
+  - 每个符号的虚拟地址，按升序排列（即“地址序”）。
+- kallsyms_num_syms: usize
+  - 符号数量（同时也会以 u64 形式写入 blob 头）。
+
+关系示意：
+- 地址序下的第 i 个符号：
+  - 地址 = `kallsyms_addresses[i]`
+  - 名称压缩片段起始 = `kallsyms_offsets[i]`，每条名称均以类型和前缀长度字段开头，长度为 `TY_LEN=1`、`LENGTH_BYTES=2`（小端，低字节在前），即PREFIX_LEN = TY_LEN + LENGTH_BYTES，
+    实际片段范围 = `kallsyms_names[kallsyms_offsets[i] + PREFIX_LEN .. kallsyms_offsets[i] + PREFIX_LEN + entry_len]`，其中 `entry_len` 来自该条目前置的 2 字节小端长度。
+- 名字序查找：在 `kallsyms_seqs_of_names` 上二分比较（通过展开名称），命中 `mid` 后得到地址序索引 `seq = kallsyms_seqs_of_names[mid]`。
+
+## 压缩与 token 选择规则
+
+- Token 候选采用“固定前缀启发式”：只统计每个符号名的前缀，长度集合由实现配置（当前默认包含若干离散长度，如 10、24、31、…、2000）。
+  - 若符号长度短于集合中的最小长度（当前为 10），会把“整名”也计入候选（仅用于名字开头）。
+  - 候选排序采用加权策略，按 频次×长度 由高到低选取，最多保留 512 个 token；并避免选择是已选 token 前缀的候选（减少冗余）。
+- 符号压缩采用“单前缀 token + 原始剩余”：
+  - 仅在名称开头尝试匹配一个 token（按候选长度从长到短）；
+  - 命中后写入 token 编码，剩余部分以原始字节追加；若未命中，则整名以原始字节写入。
+- 名称条目为“定长前缀 + 负载”的记录格式：
+  - 每个名称条目1字节类型 + 2 字节长度（小端，低字节在前）作为前缀，表示“负载”的总字节数；
+  - 若使用 token，负载以 `0xFF <id> 0xFF`（1 字节 id）或 `0xFF <id_hi> <id_lo> 0xFF`（2 字节 id）开头，随后跟随名称剩余原始字节；
+  - 若未使用 token，负载即为整名的原始字节。
+- Token 编码中使用的分隔符常量：`TOKEN_MARKER = 0xFF`。
+
+备注：读取输入时仅保留文本符号类型 T/t，并进行 Rust demangle。编码阶段会把符号类型字符（T/t）作为前缀放在压缩名称的最前面。
+
+## 符号排序与查找
+
+- 存储顺序为“地址序”。构建过程中：
+  - `kallsyms_addresses` 与 `kallsyms_offsets` 按地址升序排列；
+  - 另外构建一个“名字序 → 地址序”的 `kallsyms_seqs_of_names` 用于名字二分。
+- 查找：
+  - 地址 → 符号：在 `kallsyms_addresses` 上二分得到 i；为处理“同址符号别名（alias）”，会向前回溯到该地址的第一个符号，然后向后搜索下一个“地址不同”的符号以确定大小；若找不到则以文本段结束地址作为上界。名称解码基于 `kallsyms_offsets[i]` 与记录内的长度前缀来截取片段再展开。
+  - 名称 → 地址：在名字序空间二分，每步根据 `kallsyms_seqs_of_names[mid]` 取回地址序索引，再用长度前缀解码对应名称进行比较；命中后返回对应地址。 
+
+## 二进制文件布局与对齐
+
+所有数值均为小端序列化。为满足零拷贝读取时的对齐要求（u64 按 8 字节对齐，u32 按 4 字节对齐），在写入各段之前会插入适当的 padding。内核加载该 bin 时会将其映射到 4K 对齐的页起始地址；在此前提下，下面的对齐能保证 `from_raw_parts` 的对齐安全。
+
+布局顺序（括号中为对齐要求）：
+
+1) num_syms: u64
+2) addresses[num_syms]: u64[]  (align 8)
+3) offsets[num_syms]: u32[]    (align 4)
+4) seqs[num_syms]: u32[]       (align 4)
+5) names:                      (align 8)
+   - names_len: u64
+   - names_bytes[names_len]: u8[]
+     - 重复的“名称条目记录”：`[type: u8] [len: u16(le)] [payload: u8[len]]`
+6) token_table:                (align 8)
+   - token_table_len: u64
+   - token_table_bytes[token_table_len]: u8[]
+7) token_index:                (align 8 for len, then align 4 for array)
+   - token_index_len: u64
+   - token_index[token_index_len]: u32[] (align 4)
+
+说明：
+- 对齐通过在写入每个段前对 `Vec<u8>` 进行 padding 实现。
+- `kallsyms_offsets` 使用 u32 存储，要求 `kallsyms_names.len() < 4GiB`。
+
+## 零拷贝读取（KallsymsMapped）
+
+- 零拷贝视图通过 `from_blob(&blob, stext, etext)` 直接把上述各段解释为切片，同时记住文本段边界用于地址查找：
+  - `&[u64]` 对应 addresses，
+  - `&[u32]` 对应 offsets、seqs、token_index，
+  - `&[u8]`  对应 names、token_table。
+- 由于段起始已按 8/4 字节对齐，再加上整体 4K 页对齐映射，`from_raw_parts` 的对齐要求满足，避免拷贝。
+
+## 限制与注意事项
+
+- token 数量上限 512；token id 为 u16。
+- 每个名称条目的压缩后长度字段为 u16（小端），单条记录最大 65535 字节。
+- `kallsyms_offsets` 为 u32，限制 `kallsyms_names` 总长度 < 4GiB。
+- 顶层整数（num_syms、addresses、offsets、seqs、names_len、token_table_len、token_index_len 和 token_index 内容）均以小端写入；名称条目长度同为小端。
+- 压缩仅在名称开头使用一个 token，其余部分为原始字节；若需要更高压缩比，可扩展为混合策略（前缀+后缀等）。
+
+## 生成与使用
+
+- 生成：
+  - 将 nm -n -C {ELF} 作为标准输入（仅保留 T/t），执行本工具二进制，例如：
+    - `nm -n -C {ELF} | cargo run -p ksym-bin --bin gen_ksym --features demangle > kallsyms.bin`
+- 读取（消费者侧）：
+  - 使用 `ksym_bin::KallsymsMapped::from_blob(&blob, stext, etext)` 零拷贝解析；
+  - 可调用 `lookup_address`、`lookup_name`、或 `dump_all_symbols()` 获取数据（dump 输出形如：`<addr_hex> <type_char> <name>`）。
+
+
+## Tests
+```
+cargo test --bin gen_ksym --features="demangle"
+```
+
+## 示例
+
+示例（简化三条符号）：
+- 输入：
+  - 0000000000001000 T _start
+  - 0000000000001100 T do_fork
+  - 0000000000001200 T cpu_startup_entry
+- 生成的 blob 中：
+  - addresses = [0x1000, 0x1100, 0x1200]
+  - offsets 指向 `kallsyms_names` 中三段压缩名称的起始位置；
+  - seqs 反映名字序到地址序的对应关系；
+  - names/token_table/token_index 按上述布局与对齐写入。
+
+以上即当前实现对应的元数据关系与二进制布局说明。

--- a/kernel/libs/ksym-bin/src/bin/gen_ksym.rs
+++ b/kernel/libs/ksym-bin/src/bin/gen_ksym.rs
@@ -1,0 +1,386 @@
+use std::{collections::HashMap, fmt::Debug, io::Write, u64};
+
+use ksym_bin::TOKEN_MARKER;
+
+/// Candidate prefix lengths for heuristic tokenization
+// const PREFIX_CANDIDATE_LENS: &[usize] = &[8, 16, 24, 32, 64, 96, 128, 512, 1024, 2048];
+const PREFIX_CANDIDATE_LENS: &[usize] = &[
+    10, 24, 31, 40, 56, 60, 70, 80, 90, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900,
+    1000, 1200, 1400, 1600, 1800, 2000,
+];
+
+/// Maximum number of tokens
+const MAX_TOKEN: usize = 512;
+
+/// The structure for compressed symbol data
+pub struct KallsymsBlob {
+    pub token_table: Vec<u8>,
+    /// The start index of each token in token_table
+    pub token_index: Vec<u32>,
+    pub token_map: HashMap<String, u16>,
+    /// Compressed symbol data
+    pub kallsyms_names: Vec<u8>,
+    /// The offsets of each symbol in kallsyms_names
+    pub kallsyms_offsets: Vec<u32>,
+    /// The sequence numbers of each symbol
+    pub kallsyms_seqs_of_names: Vec<u32>,
+    /// The addresses of each symbol
+    pub kallsyms_addresses: Vec<u64>,
+    pub kallsyms_num_syms: usize,
+}
+
+impl Debug for KallsymsBlob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KallsymsBlob")
+            .field("token_table size", &(self.token_table.len()))
+            .field("token_index size", &(self.token_index.len() * 4))
+            .field("kallsyms_names size", &(self.kallsyms_names.len()))
+            .field("kallsyms_offsets size", &(self.kallsyms_offsets.len() * 4))
+            .field(
+                "kallsyms_seqs_of_names size",
+                &(self.kallsyms_seqs_of_names.len() * 4),
+            )
+            .field(
+                "kallsyms_addresses size",
+                &(self.kallsyms_addresses.len() * 8),
+            )
+            .field("kallsyms_num_syms", &self.kallsyms_num_syms)
+            .finish()
+    }
+}
+
+impl KallsymsBlob {
+    pub fn new() -> Self {
+        Self {
+            token_table: Vec::new(),
+            token_index: Vec::new(),
+            token_map: HashMap::new(),
+            kallsyms_names: Vec::new(),
+            kallsyms_offsets: Vec::new(),
+            kallsyms_seqs_of_names: Vec::new(),
+            kallsyms_addresses: Vec::new(),
+            kallsyms_num_syms: 0,
+        }
+    }
+
+    /// Add a token to the token table
+    fn add_token(&mut self, token: String) -> Option<u16> {
+        if let Some(&id) = self.token_map.get(&token) {
+            return Some(id);
+        }
+        let id = self.token_map.len() as u16;
+        self.token_index.push(self.token_table.len() as u32);
+        self.token_table.extend_from_slice(token.as_bytes());
+        self.token_map.insert(token, id);
+        Some(id)
+    }
+
+    /// Compress all symbol names, auto-generating tokens.
+    /// Storage order: address order, with a name-order to address-order mapping.
+    pub fn compress_symbols(&mut self, symbols: &[(String, u64, char)]) {
+        // 0) Build indices for name order and address order.
+        let n = symbols.len();
+        if n == 0 {
+            return;
+        }
+        let mut idx_by_addr: Vec<usize> = (0..n).collect();
+        idx_by_addr.sort_by_key(|&i| symbols[i].1);
+        let mut idx_by_name: Vec<usize> = (0..n).collect();
+        idx_by_name.sort_by(|&i, &j| symbols[i].0.cmp(&symbols[j].0));
+
+        // map original index -> address-order index
+        let mut orig_to_addr_idx = vec![0usize; n];
+        for (addr_pos, &orig_idx) in idx_by_addr.iter().enumerate() {
+            orig_to_addr_idx[orig_idx] = addr_pos;
+        }
+
+        // 1) Count possible tokens using prefix-based heuristic.
+        // For each symbol, consider only prefixes of specific lengths.
+        let mut token_count: HashMap<String, usize> = HashMap::new();
+        for (name, _, _) in symbols.iter() {
+            let bytes = name.as_bytes();
+            for &len in PREFIX_CANDIDATE_LENS {
+                if bytes.len() >= len {
+                    let token = std::str::from_utf8(&bytes[..len]).unwrap();
+                    *token_count.entry(token.to_string()).or_insert(0) += 1;
+                } else if !bytes.is_empty() && len == PREFIX_CANDIDATE_LENS[0] {
+                    // Edge case: name shorter than the smallest candidate length; include full name to avoid missing short common prefixes
+                    let token = name;
+                    *token_count.entry(token.to_string()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        // 2) Select high-frequency tokens (cap at MAX_TOKEN), prefer longer tokens on tie
+        let mut tokens: Vec<(String, usize)> = token_count.into_iter().collect();
+        tokens.sort_by(|a, b| {
+            // primary: frequency desc; secondary: length desc;
+            // b.1.cmp(&a.1).then_with(|| b.0.len().cmp(&a.0.len()))
+            (b.1 * b.0.len()).cmp(&(a.1 * a.0.len())) // weighted by length(more effective)
+        });
+        let mut final_token_list: Vec<String> = Vec::new();
+        for (tok, _) in tokens.into_iter() {
+            if final_token_list.len() >= MAX_TOKEN {
+                break;
+            }
+            // Avoid tokens that are prefixes of existing tokens
+            let mut is_prefix = false;
+            for existing in &final_token_list {
+                if existing.starts_with(&tok) {
+                    is_prefix = true;
+                    break;
+                }
+            }
+            if !is_prefix {
+                final_token_list.push(tok);
+            }
+        }
+        for tok in final_token_list.into_iter() {
+            self.add_token(tok);
+        }
+
+        // 3) Compress symbols in address order and build offsets/addresses.
+        for &orig_idx in &idx_by_addr {
+            let (ref sym, addr, ty) = symbols[orig_idx];
+            self.kallsyms_offsets.push(self.kallsyms_names.len() as u32);
+            self.kallsyms_addresses.push(addr);
+
+            let sym_bytes = sym.as_bytes();
+            // Only allow a single token at the beginning (prefix) according to heuristic.
+            let rem = sym_bytes.len();
+            let mut consumed = 0usize;
+            for &l in PREFIX_CANDIDATE_LENS.iter().rev() {
+                if l > rem {
+                    // if the candidate length exceeds the remaining length, skip
+                    continue;
+                }
+                let candidate = &sym[..l];
+                if let Some(&id) = self.token_map.get(candidate) {
+                    // 1. [type] [length] (0xff  token             0xff) [remaining bytes]
+                    // 2. [type] [length] (0xff  token_hi token_lo 0xff) [remaining bytes]
+                    //    [1byte][2bytes] (1byte 1byte    1byte   1byte) [remaining bytes]
+                    let mut length: u16 = if id < 256 { 3 } else { 4 };
+                    length += (rem - l) as u16;
+                    // Emit type char
+                    self.kallsyms_names.push(ty as u8);
+
+                    // Emit length (little-endian: lo, hi)
+                    self.kallsyms_names.push((length & 0xFF) as u8);
+                    self.kallsyms_names.push((length >> 8) as u8);
+
+                    // Emit token
+                    self.kallsyms_names.push(TOKEN_MARKER);
+                    if id < 256 {
+                        self.kallsyms_names.push(id as u8);
+                    } else {
+                        self.kallsyms_names.push((id >> 8) as u8);
+                        self.kallsyms_names.push((id & 0xFF) as u8);
+                    }
+                    self.kallsyms_names.push(TOKEN_MARKER);
+                    consumed = l;
+                    break;
+                }
+            }
+
+            if consumed == 0 {
+                // No token matched; emit full symbol as raw bytes
+                // Emit type char
+                self.kallsyms_names.push(ty as u8);
+                // Emit length
+                let length = rem as u16;
+                // little-endian: lo, hi
+                self.kallsyms_names.push((length & 0xFF) as u8);
+                self.kallsyms_names.push((length >> 8) as u8);
+            }
+
+            // Emit remaining bytes raw
+            self.kallsyms_names
+                .extend_from_slice(&sym_bytes[consumed..]);
+        }
+
+        // 4) Build name-order -> address-order sequence mapping.
+        self.kallsyms_seqs_of_names.reserve(n);
+        for &orig_idx in &idx_by_name {
+            let addr_idx = orig_to_addr_idx[orig_idx] as u32;
+            self.kallsyms_seqs_of_names.push(addr_idx);
+        }
+
+        self.kallsyms_num_syms = n;
+    }
+
+    /// Serialize blob into bytes
+    /// Convert the blob into binary data
+    pub fn to_blob(&self) -> Vec<u8> {
+        let mut blob = Vec::new();
+
+        #[inline]
+        fn pad(vec: &mut Vec<u8>, align: usize) {
+            let rem = vec.len() % align;
+            if rem != 0 {
+                vec.resize(vec.len() + (align - rem), 0);
+            }
+        }
+
+        blob.extend_from_slice(&(self.kallsyms_num_syms as u64).to_le_bytes());
+
+        // addresses [u64]
+        pad(&mut blob, 8);
+        for &addr in &self.kallsyms_addresses {
+            blob.extend_from_slice(&addr.to_le_bytes());
+        }
+        // offsets [u32]
+        pad(&mut blob, 4);
+        for &off in &self.kallsyms_offsets {
+            blob.extend_from_slice(&(off as u32).to_le_bytes());
+        }
+        // seqs [u32]
+        pad(&mut blob, 4);
+        for &seq in &self.kallsyms_seqs_of_names {
+            blob.extend_from_slice(&seq.to_le_bytes());
+        }
+
+        // names bytes (len u64 + bytes)
+        pad(&mut blob, 8);
+        blob.extend_from_slice(&(self.kallsyms_names.len() as u64).to_le_bytes());
+        blob.extend_from_slice(&self.kallsyms_names);
+
+        // token table bytes (len u64 + bytes)
+        pad(&mut blob, 8);
+        blob.extend_from_slice(&(self.token_table.len() as u64).to_le_bytes());
+        blob.extend_from_slice(&self.token_table);
+
+        // token index [u32] (len u64 + array)
+        pad(&mut blob, 8);
+        blob.extend_from_slice(&(self.token_index.len() as u64).to_le_bytes());
+        pad(&mut blob, 4);
+        for &idx in &self.token_index {
+            blob.extend_from_slice(&idx.to_le_bytes());
+        }
+
+        blob
+    }
+}
+
+fn read_symbol(line: &str) -> Option<(String, u64, char)> {
+    if line.len() > 4096 {
+        panic!("The kernel symbol is too long: {}", line);
+    }
+    let mut parts = line.split_whitespace();
+    let vaddr = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let symbol_type = parts.next()?.chars().next()?;
+    let mut symbol = parts.collect::<Vec<_>>().join(" ");
+    // local symbol or global symbol in text section
+    if symbol_type != 'T' && symbol_type != 't' {
+        return None;
+    }
+    // skip $x symbol
+    if symbol.contains("$x") {
+        return None;
+    }
+    if symbol.starts_with("_ZN") {
+        symbol = format!("{:#}", rustc_demangle::demangle(&symbol));
+    } else {
+        symbol = format!("{}", symbol);
+    }
+    Some((symbol, vaddr, symbol_type))
+}
+
+fn read_map() -> Vec<(String, u64, char)> {
+    let mut symbol_table = Vec::new();
+    let mut line = String::new();
+    loop {
+        let size = std::io::stdin().read_line(&mut line).unwrap();
+        if size == 0 {
+            break;
+        }
+        line = line.trim().to_string();
+        if let Some(entry) = read_symbol(&line) {
+            symbol_table.push(entry);
+        }
+        line.clear();
+    }
+    symbol_table
+}
+
+fn main() {
+    let symbol_table = read_map();
+    let mut blob = KallsymsBlob::new();
+    blob.compress_symbols(&symbol_table);
+    let binary_blob = blob.to_blob();
+    // Output to stdout
+    std::io::stdout()
+        .write_all(&binary_blob)
+        .expect("Failed to write blob");
+}
+
+#[cfg(test)]
+mod tests {
+    use ksym_bin::KSYM_NAME_LEN;
+
+    use crate::KallsymsBlob;
+    #[test]
+    fn test() {
+        let symbols = r#"
+        0000000000001000 T do_mkdir
+        0000000000001300 T alias_do_fork
+        0000000000001300 T do_fork
+        0000000000001300 T do_fork_2
+        0000000000001200 T cpu_startup_entry
+        0000000000001400 T cpu_startup_entry
+    "#;
+        let symbols: Vec<(String, u64, char)> = symbols
+            .lines()
+            .filter_map(|line| super::read_symbol(line.trim()))
+            .collect();
+
+        println!("Original symbols: {:?}", symbols);
+
+        let mut blob = KallsymsBlob::new();
+        blob.compress_symbols(&symbols);
+
+        let binary_blob = blob.to_blob();
+        println!("Binary blob size: {} bytes", binary_blob.len());
+
+        let mapped =
+            ksym_bin::KallsymsMapped::from_blob(&binary_blob, 0x1000, 0x1500).expect("parse blob");
+
+        assert_eq!(mapped.lookup_address(100, &mut [0; KSYM_NAME_LEN]), None);
+        assert_eq!(
+            mapped.lookup_address(0x1200, &mut [0; KSYM_NAME_LEN]),
+            Some(("cpu_startup_entry", 0x100, 0, 'T'))
+        );
+        // Test aliased symbols
+        assert_eq!(
+            mapped.lookup_address(0x1300, &mut [0; KSYM_NAME_LEN]),
+            Some(("alias_do_fork", 0x100, 0, 'T'))
+        );
+        assert_eq!(
+            mapped.lookup_address(0x1250, &mut [0; KSYM_NAME_LEN]),
+            Some(("cpu_startup_entry", 0x100, 0x50, 'T'))
+        );
+        assert_eq!(
+            mapped.lookup_address(0x1450, &mut [0; KSYM_NAME_LEN]),
+            Some(("cpu_startup_entry", 0x100, 0x50, 'T'))
+        );
+        assert_eq!(
+            mapped.lookup_name("cpu_startup_entry"),
+            Some(0x1200),
+            "The address of cpu_startup_entry should be 0x1200 instead of 0x1400"
+        );
+        assert_eq!(mapped.lookup_name("do_fork_2"), Some(0x1300));
+
+        println!("All tests passed.");
+        let dumped = mapped.dump_all_symbols();
+        println!("Dumped all symbols:\n{}", dumped);
+    }
+
+    fn trans<'b>(buf: &'b mut [u8; 10]) -> &'b str {
+        buf.copy_from_slice(b"abcdabcdab");
+        std::str::from_utf8(buf).unwrap()
+    }
+    #[test]
+    fn k() {
+        let mut buf = [0u8; 10];
+        assert_eq!(trans(&mut buf), "abcdabcdab");
+    }
+}

--- a/kernel/libs/ksym-bin/src/lib.rs
+++ b/kernel/libs/ksym-bin/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 #![no_std]
 
 use alloc::string::String;
@@ -150,7 +152,7 @@ impl<'a> KallsymsMapped<'a> {
             let name =
                 self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
             use core::fmt::Write as _;
-            let _ = writeln!(out, "{:016x} {} {}", addr, ty as char, name);
+            let _ = writeln!(out, "{:016x} {ty} {}", addr, name);
         }
         out
     }
@@ -207,7 +209,7 @@ impl<'a> KallsymsMapped<'a> {
         }
         // little-endian: lo first, then hi
         // we skip the type byte
-        let len_lo = bytes[0 + TY_LEN] as u16;
+        let len_lo = bytes[TY_LEN] as u16;
         let len_hi = bytes[1 + TY_LEN] as u16;
         ((len_hi << 8) | len_lo, bytes[0] as char)
     }
@@ -300,7 +302,7 @@ impl<'a> KallsymsMapped<'a> {
             let end = start + PREFIX_LEN + len as usize;
             let mid_name =
                 self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
-            match name.cmp(&mid_name) {
+            match name.cmp(mid_name) {
                 core::cmp::Ordering::Equal => break,
                 core::cmp::Ordering::Less => high = mid - 1,
                 core::cmp::Ordering::Greater => low = mid + 1,
@@ -342,6 +344,6 @@ impl<'a> KallsymsMapped<'a> {
             }
         }
 
-        return Some((low, high));
+        Some((low, high))
     }
 }

--- a/kernel/libs/ksym-bin/src/lib.rs
+++ b/kernel/libs/ksym-bin/src/lib.rs
@@ -1,0 +1,347 @@
+#![no_std]
+
+use alloc::string::String;
+extern crate alloc;
+
+/// Token delimiter marker
+pub const TOKEN_MARKER: u8 = 0xFF;
+/// Length bytes for compressed symbol
+pub(crate) const LENGTH_BYTES: usize = 2;
+
+pub const KSYM_NAME_LEN: usize = 1024;
+/// Length bytes for symbol type
+const TY_LEN: usize = 1;
+
+const PREFIX_LEN: usize = LENGTH_BYTES + TY_LEN;
+/// Mapped kallsyms structure from binary blob
+pub struct KallsymsMapped<'a> {
+    token_table: &'a [u8],
+    token_index: &'a [u32],
+    kallsyms_names: &'a [u8],
+    kallsyms_offsets: &'a [u32],
+    kallsyms_seqs_of_names: &'a [u32],
+    kallsyms_addresses: &'a [u64],
+    kallsyms_num_syms: usize,
+    stext: u64,
+    etext: u64,
+}
+
+impl<'a> KallsymsMapped<'a> {
+    /// Convert binary data into the blob structure and return KallsymsMapped.
+    /// # Safety
+    /// The input blob must be well-formed and valid.
+    /// Undefined behavior may occur if the blob is malformed.
+    /// # WARNING
+    /// The blob is expected to be page-aligned in memory.
+    pub fn from_blob(blob: &'a [u8], stext: u64, etext: u64) -> Result<Self, &'static str> {
+        // page-aligned by loader (4K)
+        let base = blob.as_ptr() as usize;
+        let mut off = 0usize;
+
+        let align_off = |align: usize, off: usize| {
+            let addr = base + off;
+            let addr = (addr + align - 1) & !(align - 1);
+            addr - base
+        };
+
+        // read num_syms (u64)
+        if off + 8 > blob.len() {
+            return Err("The number of symbols is missing");
+        }
+        let num_syms = u64::from_le_bytes(blob[off..off + 8].try_into().unwrap()) as usize;
+        off += 8;
+
+        // addresses [u64], align 8
+        off = align_off(8, off);
+        let need = num_syms * core::mem::size_of::<u64>();
+        if off + need > blob.len() {
+            return Err("The addresses array is missing");
+        }
+        let addresses =
+            unsafe { core::slice::from_raw_parts(blob[off..].as_ptr() as *const u64, num_syms) };
+        off += need;
+
+        // offsets [u32], align 4
+        off = align_off(4, off);
+        let need = num_syms * core::mem::size_of::<u32>();
+        if off + need > blob.len() {
+            return Err("The offsets array is missing");
+        }
+        let offsets =
+            unsafe { core::slice::from_raw_parts(blob[off..].as_ptr() as *const u32, num_syms) };
+        off += need;
+
+        // seqs [u32], align 4
+        off = align_off(4, off);
+        let need = num_syms * core::mem::size_of::<u32>();
+        if off + need > blob.len() {
+            return Err("The seqs array is missing");
+        }
+        let seqs =
+            unsafe { core::slice::from_raw_parts(blob[off..].as_ptr() as *const u32, num_syms) };
+        off += need;
+
+        // names (len u64 + bytes), align 8
+        off = align_off(8, off);
+        if off + 8 > blob.len() {
+            return Err("The names length is missing");
+        }
+        let names_len = u64::from_le_bytes(blob[off..off + 8].try_into().unwrap()) as usize;
+        off += 8;
+        if off + names_len > blob.len() {
+            return Err("The names array is missing");
+        }
+        let names = &blob[off..off + names_len];
+        off += names_len;
+
+        // token table (len u64 + bytes), align 8
+        off = align_off(8, off);
+        if off + 8 > blob.len() {
+            return Err("The token table length is missing");
+        }
+        let token_table_len = u64::from_le_bytes(blob[off..off + 8].try_into().unwrap()) as usize;
+        off += 8;
+        if off + token_table_len > blob.len() {
+            return Err("The token table array is missing");
+        }
+        let token_table = &blob[off..off + token_table_len];
+        off += token_table_len;
+
+        // token index [u32] (len u64 + array), align 8 then 4
+        off = align_off(8, off);
+        if off + 8 > blob.len() {
+            return Err("The token index length is missing");
+        }
+        let token_index_len = u64::from_le_bytes(blob[off..off + 8].try_into().unwrap()) as usize;
+        off += 8;
+        off = align_off(4, off);
+        let need = token_index_len * core::mem::size_of::<u32>();
+        if off + need > blob.len() {
+            return Err("The token index array is missing");
+        }
+        let token_index = unsafe {
+            core::slice::from_raw_parts(blob[off..].as_ptr() as *const u32, token_index_len)
+        };
+        // off += need;
+        Ok(Self {
+            token_table,
+            token_index,
+            kallsyms_names: names,
+            kallsyms_offsets: offsets,
+            kallsyms_seqs_of_names: seqs,
+            kallsyms_addresses: addresses,
+            kallsyms_num_syms: num_syms,
+            stext,
+            etext,
+        })
+    }
+
+    /// Dump all symbols in address order and return as a string.
+    /// Each line: 16-digit hex address + type + name.
+    pub fn dump_all_symbols(&self) -> String {
+        let mut out = String::new();
+        let mut name_buf = [0u8; KSYM_NAME_LEN];
+
+        for i in 0..self.kallsyms_num_syms {
+            let addr = self.kallsyms_addresses[i];
+            let start = self.kallsyms_offsets[i] as usize;
+            let (len, ty) = Self::read_compressed_len_and_type(&self.kallsyms_names[start..]);
+            let end = start + PREFIX_LEN + len as usize;
+            let name =
+                self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
+            use core::fmt::Write as _;
+            let _ = writeln!(out, "{:016x} {} {}", addr, ty as char, name);
+        }
+        out
+    }
+
+    /// Expand a compressed symbol data into the resulting uncompressed string,
+    /// if uncompressed string is too long (>= maxlen), it will be truncated,
+    /// given the offset to where the symbol is in the compressed stream.
+    fn expand_symbol<'b>(&self, bytes: &[u8], name_buf: &'b mut [u8; KSYM_NAME_LEN]) -> &'b str {
+        let mut i = 0;
+        let mut offset = 0;
+        if bytes[i] == TOKEN_MARKER {
+            let mut token_id = None;
+            // Try to parse 0xFF <id> 0xFF (1-byte) or 0xFF <id_hi> <id_lo> 0xFF (2-byte)
+            if i + 2 < bytes.len() && bytes[i + 2] == TOKEN_MARKER {
+                let id = bytes[i + 1] as u16;
+                token_id = Some(id);
+                i += 3;
+            } else if i + 3 < bytes.len() && bytes[i + 3] == TOKEN_MARKER {
+                let id = ((bytes[i + 1] as u16) << 8) | (bytes[i + 2] as u16);
+                token_id = Some(id);
+                i += 4;
+            }
+            if let Some(id) = token_id {
+                if (id as usize) < self.token_index.len() {
+                    let start = self.token_index[id as usize] as usize;
+                    let end = if (id as usize) + 1 < self.token_index.len() {
+                        self.token_index[(id as usize) + 1] as usize
+                    } else {
+                        self.token_table.len()
+                    };
+                    let token_str = &self.token_table[start..end];
+                    let need_copy = (KSYM_NAME_LEN - offset).min(token_str.len());
+                    name_buf[offset..offset + need_copy].copy_from_slice(&token_str[..need_copy]);
+                    offset += need_copy;
+                }
+            }
+            // Append the rest as raw bytes
+            let need_copy = (KSYM_NAME_LEN - offset).min(bytes.len() - i);
+            name_buf[offset..offset + need_copy].copy_from_slice(&bytes[i..i + need_copy]);
+            offset += need_copy;
+        } else {
+            // Not a token; treat as raw bytes
+            let need_copy = (KSYM_NAME_LEN - offset).min(bytes.len() - i);
+            name_buf[offset..offset + need_copy].copy_from_slice(&bytes[i..i + need_copy]);
+            offset += need_copy;
+        }
+        let name = core::str::from_utf8(&name_buf[..offset]).unwrap_or_default();
+        name
+    }
+
+    fn read_compressed_len_and_type(bytes: &[u8]) -> (u16, char) {
+        if bytes.len() < PREFIX_LEN {
+            return (0, ' ');
+        }
+        // little-endian: lo first, then hi
+        // we skip the type byte
+        let len_lo = bytes[0 + TY_LEN] as u16;
+        let len_hi = bytes[1 + TY_LEN] as u16;
+        ((len_hi << 8) | len_lo, bytes[0] as char)
+    }
+
+    /// Address → Symbol lookup. Returns (symbol name, symbol size, offset within symbol, type) if found.
+    ///
+    /// See <https://elixir.bootlin.com/linux/v6.6/source/kernel/kallsyms.c#L446>
+    pub fn lookup_address<'b>(
+        &self,
+        addr: u64,
+        name_buf: &'b mut [u8; KSYM_NAME_LEN],
+    ) -> Option<(&'b str, u64, u64, char)> {
+        // Quick check: address within text section and symbols exist
+        if addr < self.stext || addr >= self.etext || self.kallsyms_num_syms == 0 {
+            return None;
+        }
+        let mut low = 0usize;
+        let mut high = self.kallsyms_num_syms;
+
+        while high - low > 1 {
+            let mid = low + (high - low) / 2;
+            if self.kallsyms_addresses[mid] <= addr {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+
+        if low >= self.kallsyms_num_syms {
+            return None;
+        }
+
+        // Search for the first aliased symbol. Aliased
+        // symbols are symbols with the same address.
+        while low > 0 && self.kallsyms_addresses[low - 1] == addr {
+            low -= 1;
+        }
+        let symbol_start = self.kallsyms_addresses[low];
+
+        let mut symbol_end = None;
+        // Search for next non-aliased symbol.
+        for high in (low + 1)..self.kallsyms_num_syms {
+            if self.kallsyms_addresses[high] > symbol_start {
+                symbol_end = Some(self.kallsyms_addresses[high]);
+                break;
+            }
+        }
+        // If we found no next symbol, we use the end of the section.
+        let symbol_end = symbol_end.unwrap_or(self.etext);
+
+        let start = self.kallsyms_offsets[low] as usize;
+        let (len, ty) = Self::read_compressed_len_and_type(&self.kallsyms_names[start..]);
+        let end = start + PREFIX_LEN + len as usize;
+        Some((
+            self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], name_buf),
+            symbol_end - symbol_start,
+            addr - symbol_start,
+            ty,
+        ))
+    }
+
+    /// Lookup the address for this symbol. Returns 0 if not found.
+    ///
+    /// See <https://elixir.bootlin.com/linux/v6.6/source/kernel/kallsyms.c#L265>
+    pub fn lookup_name(&self, name: &str) -> Option<u64> {
+        let (start_idx, _end_idx) = self.lookup_names(name, false)?;
+        let seq = self.kallsyms_seqs_of_names[start_idx] as usize;
+        Some(self.kallsyms_addresses[seq])
+    }
+
+    /// Symbol name → Address lookup (binary search on name order). It returns the first and last
+    /// name index (need_end) if there are multiple symbols with the same name. If need_end is false,
+    /// only the first index is valid.
+    ///
+    /// See <https://elixir.bootlin.com/linux/v6.6/source/kernel/kallsyms.c#L208>
+    pub fn lookup_names(&self, name: &str, need_end: bool) -> Option<(usize, usize)> {
+        let mut name_buf = [0u8; KSYM_NAME_LEN];
+        if self.kallsyms_num_syms == 0 {
+            return None;
+        }
+        let mut low = 0usize;
+        let mut high = self.kallsyms_num_syms - 1;
+        let mut mid = 0usize;
+        while low <= high {
+            mid = low + (high - low) / 2;
+            // address-order index
+            let seq = self.kallsyms_seqs_of_names[mid] as usize;
+            let start = self.kallsyms_offsets[seq] as usize;
+            let (len, _ty) = Self::read_compressed_len_and_type(&self.kallsyms_names[start..]);
+            let end = start + PREFIX_LEN + len as usize;
+            let mid_name =
+                self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
+            match name.cmp(&mid_name) {
+                core::cmp::Ordering::Equal => break,
+                core::cmp::Ordering::Less => high = mid - 1,
+                core::cmp::Ordering::Greater => low = mid + 1,
+            }
+        }
+        if low > high {
+            return None;
+        }
+        low = mid;
+        // Check for earlier matches in case of duplicates
+        while low > 0 {
+            let seq = self.kallsyms_seqs_of_names[low - 1] as usize;
+            let start = self.kallsyms_offsets[seq] as usize;
+            let (len, _ty) = Self::read_compressed_len_and_type(&self.kallsyms_names[start..]);
+            let end = start + PREFIX_LEN + len as usize;
+            let mid_name =
+                self.expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
+            if mid_name != name {
+                break;
+            }
+            low -= 1;
+        }
+
+        high = 0;
+        if need_end {
+            // Check for later matches in case of duplicates
+            high = mid;
+            while high < self.kallsyms_num_syms - 1 {
+                let seq = self.kallsyms_seqs_of_names[high + 1] as usize;
+                let start = self.kallsyms_offsets[seq] as usize;
+                let (len, _ty) = Self::read_compressed_len_and_type(&self.kallsyms_names[start..]);
+                let end = start + PREFIX_LEN + len as usize;
+                let mid_name = self
+                    .expand_symbol(&self.kallsyms_names[start + PREFIX_LEN..end], &mut name_buf);
+                if mid_name != name {
+                    break;
+                }
+                high += 1;
+            }
+        }
+
+        return Some((low, high));
+    }
+}

--- a/kernel/src/fs/procfs/kallsyms.rs
+++ b/kernel/src/fs/procfs/kallsyms.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module offers `/proc/kallsyms` file support, which provides
+//! information about kernel symbols.
+//!
+//! https://man7.org/linux/man-pages/man5/proc_kallsyms.5.html
+
+use crate::{
+    fs::{
+        procfs::template::{FileOps, ProcFileBuilder},
+        utils::{mkmod, Inode},
+    },
+    prelude::*,
+};
+
+/// File operations for `/proc/kallsyms`.
+pub struct KallsymsFileOps;
+
+impl KallsymsFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFileBuilder::new(Self, mkmod!(a+r))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for KallsymsFileOps {
+    fn data(&self) -> Result<Vec<u8>> {
+        let data = ostd::ksym::dump_ksyms()
+            .map(|sym| sym.into_bytes())
+            .unwrap_or(Vec::new());
+        Ok(data)
+    }
+}

--- a/kernel/src/fs/procfs/kallsyms.rs
+++ b/kernel/src/fs/procfs/kallsyms.rs
@@ -29,7 +29,7 @@ impl FileOps for KallsymsFileOps {
     fn data(&self) -> Result<Vec<u8>> {
         let data = ostd::ksym::dump_ksyms()
             .map(|sym| sym.into_bytes())
-            .unwrap_or(Vec::new());
+            .unwrap_or_default();
         Ok(data)
     }
 }

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use self::{
     cmdline::CmdLineFileOps,
     cpuinfo::CpuInfoFileOps,
+    kallsyms::KallsymsFileOps,
     loadavg::LoadAvgFileOps,
     meminfo::MemInfoFileOps,
     pid::PidDirOps,
@@ -31,6 +32,7 @@ use crate::{
 mod cmdline;
 mod cpuinfo;
 mod filesystems;
+mod kallsyms;
 mod loadavg;
 mod meminfo;
 mod pid;
@@ -165,6 +167,8 @@ impl DirOps for RootDirOps {
             StatFileOps::new_inode(this_ptr.clone())
         } else if name == "cmdline" {
             CmdLineFileOps::new_inode(this_ptr.clone())
+        } else if name == "kallsyms" {
+            KallsymsFileOps::new_inode(this_ptr.clone())
         } else if let Ok(pid) = name.parse::<Pid>() {
             let process_ref =
                 process_table::get_process(pid).ok_or_else(|| Error::new(Errno::ENOENT))?;
@@ -200,6 +204,8 @@ impl DirOps for RootDirOps {
         cached_children.put_entry_if_not_found("stat", || StatFileOps::new_inode(this_ptr.clone()));
         cached_children
             .put_entry_if_not_found("cmdline", || CmdLineFileOps::new_inode(this_ptr.clone()));
+        cached_children
+            .put_entry_if_not_found("kallsyms", || KallsymsFileOps::new_inode(this_ptr.clone()));
         for process in process_table::process_table_mut().iter() {
             let pid = process.pid().to_string();
             cached_children.put_entry_if_not_found(&pid, || {

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -595,9 +595,6 @@ dependencies = [
 [[package]]
 name = "ksym-bin"
 version = "0.1.0"
-dependencies = [
- "log",
-]
 
 [[package]]
 name = "libc"

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -193,11 +193,13 @@ dependencies = [
  "indexmap",
  "indicatif",
  "inferno",
+ "ksym-bin",
  "linux-bzimage-builder",
  "log",
  "quote",
  "regex",
  "rev_buf_reader",
+ "rustc-demangle",
  "serde",
  "serde_json",
  "shlex",
@@ -591,6 +593,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksym-bin"
+version = "0.1.0"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +855,12 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -28,6 +28,8 @@ syn = { version = "2.0.52", features = ["extra-traits", "full", "parsing", "prin
 tempfile = "3.14.0"
 toml = { version = "0.8.8", features = ["preserve_order"] }
 which = "8.0.0"
+rustc-demangle = { version = "0.1" }
+ksym-bin = { path = "../kernel/libs/ksym-bin" }
 
 [dev-dependencies]
 assert_cmd = "2.0.13"

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -29,7 +29,8 @@ tempfile = "3.14.0"
 toml = { version = "0.8.8", features = ["preserve_order"] }
 which = "8.0.0"
 rustc-demangle = { version = "0.1" }
-ksym-bin = { path = "../kernel/libs/ksym-bin" }
+# TODO: update it
+ksym-bin = { path = "../kernel/libs/ksym-bin", version = "0.1" }
 
 [dev-dependencies]
 assert_cmd = "2.0.13"

--- a/osdk/src/base_crate/loongarch64.ld.template
+++ b/osdk/src/base_crate/loongarch64.ld.template
@@ -30,6 +30,7 @@ SECTIONS
     . += KERNEL_VMA_OFFSET;
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__stext = .);
         *(.text .text.*)
         PROVIDE(__etext = .);
     }

--- a/osdk/src/base_crate/riscv64.ld.template
+++ b/osdk/src/base_crate/riscv64.ld.template
@@ -26,6 +26,7 @@ SECTIONS
     . += KERNEL_VMA_OFFSET;
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__stext = .);
         *(.text .text.*)
         PROVIDE(__etext = .);
     }

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -86,6 +86,7 @@ SECTIONS
     . = LOADADDR(.ap_boot) + SIZEOF(.ap_boot) + KERNEL_VMA;
 
     .text                   : AT(ADDR(.text) - KERNEL_VMA) {
+        PROVIDE(__stext = .);
         *(.text .text.*)
         PROVIDE(__etext = .);
     } : text

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -83,6 +83,14 @@ impl Bundle {
         created
     }
 
+    /// Get the absolute path of the kernel binary inside the bundle directory, if present.
+    pub fn aster_bin_abs_path(&self) -> Option<PathBuf> {
+        self.manifest
+            .aster_bin
+            .as_ref()
+            .map(|bin| self.path.join(bin.path()))
+    }
+
     // Load the bundle from the file system. If the bundle does not exist or have inconsistencies,
     // it will return `None`.
     pub fn load(path: impl AsRef<Path>) -> Option<Self> {

--- a/osdk/src/commands/build/gen_ksym.rs
+++ b/osdk/src/commands/build/gen_ksym.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, fmt::Debug, u64};
+// SPDX-License-Identifier: MPL-2.0
+
+use std::{collections::HashMap, fmt::Debug};
 
 const TOKEN_MARKER: u8 = 0xFF;
 
@@ -231,7 +233,7 @@ impl KallsymsBlob {
         // offsets [u32]
         pad(&mut blob, 4);
         for &off in &self.kallsyms_offsets {
-            blob.extend_from_slice(&(off as u32).to_le_bytes());
+            blob.extend_from_slice(&(off).to_le_bytes());
         }
         // seqs [u32]
         pad(&mut blob, 4);
@@ -272,7 +274,7 @@ pub fn symbol_info(line: &str) -> Option<(String, u64, char)> {
     if symbol.starts_with("_ZN") {
         symbol = format!("{:#}", rustc_demangle::demangle(&symbol));
     } else {
-        symbol = format!("{}", symbol);
+        symbol = symbol.to_string();
     }
     Some((symbol, vaddr, symbol_type))
 }

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -37,7 +37,7 @@ volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
 minicov = { version = "0.3", optional = true }
-
+ksym-bin = { path = "../kernel/libs/ksym-bin", version = "0.1" }
 # The targets are chosen to prevent the generated machine code from using any
 # vector or floating-point registers.
 #
@@ -59,7 +59,6 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [
 ], optional = true }
 tdx-guest = { version = "0.2.1", optional = true }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
-ksym-bin = { path = "../kernel/libs/ksym-bin" }
 
 [target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.11.1", features = ["s-mode"] }

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -59,6 +59,7 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [
 ], optional = true }
 tdx-guest = { version = "0.2.1", optional = true }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+ksym-bin = { path = "../kernel/libs/ksym-bin" }
 
 [target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.11.1", features = ["s-mode"] }

--- a/ostd/src/ksym.rs
+++ b/ostd/src/ksym.rs
@@ -1,0 +1,50 @@
+// ! Kernel symbol table support.
+//!
+//! This module provides functionality to initialize and dump the kernel symbol table
+//! using the `ksym-bin` crate.
+
+use alloc::string::String;
+
+use ksym_bin::KallsymsMapped;
+pub use ksym_bin::KSYM_NAME_LEN;
+use spin::Once;
+
+pub(crate) static KSYM: Once<KallsymsMapped<'static>> = Once::new();
+extern "C" {
+    fn __stext();
+    fn __etext();
+}
+
+/// Initialize the kernel symbol table from the given ksym data blob.
+pub fn init_ksym(ksym_data: &'static [u8]) {
+    let kallsyms = KallsymsMapped::from_blob(ksym_data, __stext as u64, __etext as u64)
+        .expect("Failed to parse ksym data");
+    KSYM.call_once(|| kallsyms);
+}
+
+/// Dumps all kernel symbols as a string.
+pub fn dump_ksyms() -> Option<String> {
+    if let Some(ksym) = KSYM.get() {
+        return Some(ksym.dump_all_symbols());
+    }
+    None
+}
+
+/// Looks up a kernel symbol by its address.
+pub fn lookup_address(
+    addr: u64,
+    name_buf: &mut [u8; KSYM_NAME_LEN],
+) -> Option<(&str, u64, u64, char)> {
+    if let Some(ksym) = KSYM.get() {
+        return ksym.lookup_address(addr, name_buf);
+    }
+    None
+}
+
+/// Looks up the address of a kernel symbol by its name.
+pub fn lookup_name(name: &str) -> Option<u64> {
+    if let Some(ksym) = KSYM.get() {
+        return ksym.lookup_name(name);
+    }
+    None
+}

--- a/ostd/src/ksym.rs
+++ b/ostd/src/ksym.rs
@@ -1,4 +1,6 @@
-// ! Kernel symbol table support.
+// SPDX-License-Identifier: MPL-2.0
+
+//! Kernel symbol table support.
 //!
 //! This module provides functionality to initialize and dump the kernel symbol table
 //! using the `ksym-bin` crate.
@@ -17,8 +19,9 @@ extern "C" {
 
 /// Initialize the kernel symbol table from the given ksym data blob.
 pub fn init_ksym(ksym_data: &'static [u8]) {
-    let kallsyms = KallsymsMapped::from_blob(ksym_data, __stext as u64, __etext as u64)
-        .expect("Failed to parse ksym data");
+    let kallsyms =
+        KallsymsMapped::from_blob(ksym_data, __stext as usize as u64, __etext as usize as u64)
+            .expect("Failed to parse ksym data");
     KSYM.call_once(|| kallsyms);
 }
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -39,6 +39,7 @@ pub mod cpu;
 mod error;
 pub mod io;
 pub mod irq;
+pub mod ksym;
 pub mod logger;
 pub mod mm;
 pub mod panic;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,1 @@
 build/
-src/proc/*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,2 @@
 build/
+src/proc/*

--- a/test/nix/benchmark/hackbench.nix
+++ b/test/nix/benchmark/hackbench.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, }:
+{ stdenv, fetchurl }:
 stdenv.mkDerivation rec {
   pname = "hackbench";
   version = "0.92";

--- a/test/nix/benchmark/schbench.nix
+++ b/test/nix/benchmark/schbench.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, }:
+{ stdenv, fetchgit }:
 stdenv.mkDerivation rec {
   pname = "schbench";
   version = "v1.0";

--- a/test/nix/initramfs.nix
+++ b/test/nix/initramfs.nix
@@ -5,11 +5,16 @@ let
     root = ./../src/etc;
     fileset = ./../src/etc;
   };
+  proc = lib.fileset.toSource {
+    root = ./../src/proc;
+    fileset = ./../src/proc;
+  };
   gvisor_libs = builtins.path {
     name = "gvisor-libs";
     path = "/lib/x86_64-linux-gnu";
   };
-  all_pkgs = [ busybox etc ] ++ lib.optionals (apps != null) [ apps.package ]
+  all_pkgs = [ busybox etc proc ]
+    ++ lib.optionals (apps != null) [ apps.package ]
     ++ lib.optionals (benchmark != null) [ benchmark.package ]
     ++ lib.optionals (syscall != null) [ syscall.package ];
 in stdenvNoCC.mkDerivation {
@@ -25,6 +30,7 @@ in stdenvNoCC.mkDerivation {
     cp -r ${busybox}/bin/* $out/bin/
 
     cp -r ${etc}/* $out/etc/
+    cp -r ${proc}/* $out/proc/
 
     ${lib.optionalString (apps != null) ''
       cp -r ${apps.package}/* $out/test/

--- a/test/src/proc/kallsyms
+++ b/test/src/proc/kallsyms
@@ -1,0 +1,1 @@
+// dummy kallsyms


### PR DESCRIPTION
This PR introduces support for /proc/kallsyms.

To generate this file, we need to use the `nm` tool after kernel compilation to generate kernel symbols and then filter and demangle the symbols using a simple tool I wrote. I place this file in `initramfs` so that it can be read during kernel initialization and stored in some global variables.

With this kernel symbol information, we can extend the functionality of `print_stack_trace` to print the function names on the stack.
For example:
<img width="767" height="315" alt="image" src="https://github.com/user-attachments/assets/892a31e3-e6e0-4f59-98c5-45407c3a9f91" />

This is my first PR to Asterinas, so I’d appreciate your help in reviewing it and letting me know if any changes are needed. Thank you!