### PR TITLE
Check capabilities instead of the root user

### DIFF
--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -254,9 +254,7 @@ impl AuxiliaryData {
             warn!("UNIX sockets in SCM_RIGHTS messages can leak kernel resource");
 
             let credentials = current_thread!().as_posix_thread().unwrap().credentials();
-            if !credentials.euid().is_root()
-                && !credentials.effective_capset().contains(CapSet::SYS_ADMIN)
-            {
+            if !credentials.effective_capset().contains(CapSet::SYS_ADMIN) {
                 return_errno_with_message!(
                     Errno::EPERM,
                     "UNIX sockets in SCM_RIGHTS messages can leak kernel resource"

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -242,7 +242,7 @@ fn check_current_privileged() -> Result<()> {
         posix_thread.credentials()
     };
 
-    if credentials.euid().is_root() || credentials.effective_capset().contains(CapSet::NET_ADMIN) {
+    if credentials.effective_capset().contains(CapSet::NET_ADMIN) {
         return Ok(());
     }
 


### PR DESCRIPTION
It seems that we should always check the capabilities. We should never check whether the user is root or not.

See the Linux implementation here:
https://elixir.bootlin.com/linux/v6.17.1/source/security/commoncap.c#L80-L82

The modified code in `kernel/src/net/socket/util/options.rs` was originally added by @StevenJiang1110. I followed his approach to add another capability check in `kernel/src/net/socket/unix/ctrl_msg.rs`. I'd like to know if I missed anything? 