### PR TITLE
Avoid unrelated network callbacks and type names

### DIFF
--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -29,7 +29,7 @@ use spin::Once;
 pub struct EthernetAddr(pub [u8; 6]);
 
 #[derive(Debug, Clone, Copy)]
-pub enum VirtioNetError {
+pub enum NetError {
     NotReady,
     WrongToken,
     Busy,
@@ -48,11 +48,11 @@ pub trait AnyNetworkDevice: Send + Sync + Any + Debug {
     fn can_send(&self) -> bool;
 
     /// Receives a packet from network. If packet is ready, returns a `RxBuffer` containing the packet.
-    /// Otherwise, return [`VirtioNetError::NotReady`].
-    fn receive(&mut self) -> Result<RxBuffer, VirtioNetError>;
+    /// Otherwise, return [`NetError::NotReady`].
+    fn receive(&mut self) -> Result<RxBuffer, NetError>;
 
     /// Sends a packet to network.
-    fn send(&mut self, packet: &[u8]) -> Result<(), VirtioNetError>;
+    fn send(&mut self, packet: &[u8]) -> Result<(), NetError>;
 
     /// Frees processes tx buffers.
     fn free_processed_tx_buffers(&mut self);


### PR DESCRIPTION
The code seems a bit odd. First, we create the VirtIO interface for the VirtIO network device. Then, we register the VirtIO callback on *all* network devices:
https://github.com/asterinas/asterinas/blob/384e5bc70da4fcc7d150140a0ae3706b6a33a91a/kernel/src/net/iface/init.rs#L69
https://github.com/asterinas/asterinas/blob/384e5bc70da4fcc7d150140a0ae3706b6a33a91a/kernel/src/net/iface/init.rs#L46

This PR makes a slight adjustment to the code to prevent the callback from being registered on unrelated network devices.

Besides, `VirtioNetError` lives in `comps/network`, which has nothing to do with VirtIO. For this reason, I also renamed it.
https://github.com/asterinas/asterinas/blob/384e5bc70da4fcc7d150140a0ae3706b6a33a91a/kernel/comps/network/src/lib.rs#L32

---

Note that the first commit reorders the `new_loopback` and `new_virtio` methods with no other modifications. Unfortunately, the Git diff is very unreadable. I'm sorry for that, but I cannot figure out a way to make it readable?