### PR TITLE
[sched] Fix the missing of preemption check in RISC-V & loongarch

### DIFF
--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -149,6 +149,7 @@ impl UserContextApiInternal for UserContext {
         F: FnMut() -> bool,
     {
         let ret = loop {
+            crate::task::scheduler::might_preempt();
             self.user_context.run();
 
             let cause = loongArch64::register::estat::read().cause();

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -144,7 +144,9 @@ impl UserContextApiInternal for UserContext {
         F: FnMut() -> bool,
     {
         let ret = loop {
+            crate::task::scheduler::might_preempt();
             self.user_context.run();
+
             match riscv::register::scause::read().cause() {
                 Trap::Interrupt(Interrupt::SupervisorTimer) => {
                     call_irq_callback_functions(

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -22,7 +22,6 @@ use crate::{
     cpu::PrivilegeLevel,
     irq::call_irq_callback_functions,
     mm::Vaddr,
-    task::scheduler,
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 
@@ -271,7 +270,7 @@ impl UserContextApiInternal for UserContext {
 
         // Return when it is syscall or cpu exception type is Fault or Trap.
         loop {
-            scheduler::might_preempt();
+            crate::task::scheduler::might_preempt();
             self.user_context.run();
 
             let exception =


### PR DESCRIPTION
The UserContext in RISC-V and LoongArch forgot to call `ostd::task::scheduler::might_preempt`.

In `ostd/src/arch/x86/cpu/context/mod.rs::UserContext` it has:

```rust
impl UserContextApiInternal for UserContext {
    fn execute<F>(&mut self, mut has_kernel_event: F) -> ReturnReason
    where
        F: FnMut() -> bool,
    {
        ....
        loop {
            scheduler::might_preempt();
            self.user_context.run();
            ....
        }
    }
}
``