### PR TITLE
Provide `mem_unit` and `procs` in `sysinfo`

### DIFF
--- a/kernel/src/process/process_table.rs
+++ b/kernel/src/process/process_table.rs
@@ -28,6 +28,11 @@ pub fn process_table_mut() -> MutexGuard<'static, ProcessTable> {
     PROCESS_TABLE.lock()
 }
 
+/// Returns the number of current processes.
+pub fn process_num() -> usize {
+    PROCESS_TABLE.lock().inner.len()
+}
+
 /// Process Table.
 pub struct ProcessTable {
     inner: BTreeMap<Pid, Arc<Process>>,

--- a/test/src/syscall/gvisor/blocklists/sysinfo_test
+++ b/test/src/syscall/gvisor/blocklists/sysinfo_test
@@ -1,2 +1,0 @@
-SysinfoTest.MemunitSet
-SysinfoTest.NumProcsSaneValue


### PR DESCRIPTION
This PR enables `sysinfo` to provide more information, which is required by systemd (#2251).