### PR TITLE
Skip management hart when detecting available extensions

### DIFF
--- a/ostd/src/arch/riscv/cpu/extension.rs
+++ b/ostd/src/arch/riscv/cpu/extension.rs
@@ -15,6 +15,13 @@ pub(in crate::arch) fn init() {
     let mut cpu_count = 0;
 
     for cpu in device_tree.cpus() {
+        // FIXME: We should find a robust method to identify the management
+        // harts. Here we simply skip those harts without MMU, which is supposed
+        // to work in most cases.
+        if cpu.property("mmu-type").is_none() {
+            continue;
+        }
+
         cpu_count += 1;
 
         let cpu_isa_extensions = if let Some(isa_extensions) = cpu.property("riscv,isa-extensions")


### PR DESCRIPTION
On some RISC-V boards, there will be one or more small management harts that supports less extensions than other application harts. Firmwares and some system services can run on those management harts.

Currently we naively intersect all harts' supported extensions to get the supported extensions on the platform. Therefore some extensions will be seen as unsupported even if all application harts support them. We should skip those management harts when detecting available extensions.

However, I haven't found a robust way to identify management harts at runtime. Here I just skip all harts that don't have a "mmu-type" property in its FDT node, which should work on most cases AFAIK. But this is an undocumented workaround so I left a FIXME there.