### PR TITLE
Use absolute time when setting up timer interrupt using SBI

### DIFF
--- a/ostd/src/arch/riscv/timer/mod.rs
+++ b/ostd/src/arch/riscv/timer/mod.rs
@@ -88,7 +88,7 @@ fn set_next_timer() {
 static mut SET_NEXT_TIMER_FN: fn() = set_next_timer_sbi;
 
 fn set_next_timer_sbi() {
-    sbi_rt::set_timer(TIMER_INTERVAL.load(Ordering::Relaxed));
+    sbi_rt::set_timer(get_next_when());
 }
 
 fn set_next_timer_sstc() {


### PR DESCRIPTION
We should use absolute value in sbi_set_timer invocation.

From SBI spec:
> 5.1. Extension: Set Timer (EID #0x00)
long sbi_set_timer(uint64_t stime_value)
Programs the clock for next event after stime_value time. This function also clears the pending timer
interrupt bit.