### PR TITLE
Add fallback for RTC device

### DIFF
--- a/kernel/comps/time/src/lib.rs
+++ b/kernel/comps/time/src/lib.rs
@@ -28,7 +28,7 @@ static RTC_DRIVER: Once<Arc<dyn Driver + Send + Sync>> = Once::new();
 
 #[init_component]
 fn time_init() -> Result<(), ComponentInitError> {
-    let rtc = rtc::init_rtc_driver().ok_or(ComponentInitError::Unknown)?;
+    let rtc = rtc::init_rtc_driver();
     RTC_DRIVER.call_once(|| rtc);
     tsc::init();
     Ok(())

--- a/kernel/comps/time/src/rtc/goldfish.rs
+++ b/kernel/comps/time/src/rtc/goldfish.rs
@@ -1,40 +1,61 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce};
 use chrono::{DateTime, Datelike, Timelike};
+use log::warn;
+use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce};
 
-use crate::{SystemTime, rtc::Driver};
+use crate::{rtc::Driver, SystemTime};
 
 pub struct RtcGoldfish {
     io_mem: IoMem,
 }
 
 impl Driver for RtcGoldfish {
-    fn try_new() -> Option<RtcGoldfish> {
-        let chosen = DEVICE_TREE.get().unwrap().find_node("/soc/rtc").unwrap();
-        if let Some(compatible) = chosen.compatible()
-            && compatible.all().any(|c| c == "google,goldfish-rtc")
-        {
-            let region = chosen.reg().unwrap().next().unwrap();
-            let io_mem = IoMem::acquire(
-                region.starting_address as usize
-                    ..region.starting_address as usize + region.size.unwrap(),
-            )
-            .unwrap();
-            Some(RtcGoldfish { io_mem })
-        } else {
-            None
+    fn try_new() -> Option<Self> {
+        const FDT_COMPATIBLE: &str = "google,goldfish-rtc";
+
+        let node = DEVICE_TREE
+            .get()
+            .unwrap()
+            .find_compatible(&[FDT_COMPATIBLE])?;
+
+        let Some(mut reg) = node.reg() else {
+            warn!("Goldfish node should have exactly one `reg` property, but found zero `reg`s");
+            return None;
+        };
+        let Some(region) = reg.next() else {
+            warn!("Goldfish node should have exactly one `reg` property, but found zero `reg`s");
+            return None;
+        };
+        if reg.next().is_some() {
+            warn!(
+                "Goldfish node should have exactly one `reg` property, but found {} `reg`s",
+                reg.count() + 2
+            );
+            return None;
         }
+
+        let addr_start = region.starting_address as usize;
+        let Some(addr_end) = addr_start.checked_add(region.size.unwrap()) else {
+            warn!("Goldfish RTC register region size overflows");
+            return None;
+        };
+        let Ok(io_mem) = IoMem::acquire(addr_start..addr_end) else {
+            warn!("Failed to acquire Goldfish RTC MMIO region");
+            return None;
+        };
+
+        Some(Self { io_mem })
     }
 
     fn read_rtc(&self) -> SystemTime {
-        const TIME_LOW: usize = 0;
-        const TIME_HIGH: usize = 4;
+        const LOWER_HALF_OFFSET: usize = 0;
+        const HIGHER_HALF_OFFSET: usize = 4;
 
-        let mut last_time_high = self.io_mem.read_once(TIME_HIGH).unwrap();
+        let mut last_time_high = self.io_mem.read_once(HIGHER_HALF_OFFSET).unwrap();
         let timestamp = loop {
-            let time_low: u32 = self.io_mem.read_once(TIME_LOW).unwrap();
-            let time_high: u32 = self.io_mem.read_once(TIME_HIGH).unwrap();
+            let time_low: u32 = self.io_mem.read_once(LOWER_HALF_OFFSET).unwrap();
+            let time_high: u32 = self.io_mem.read_once(HIGHER_HALF_OFFSET).unwrap();
             if last_time_high == time_high {
                 break ((time_high as u64) << 32) | time_low as u64;
             }


### PR DESCRIPTION
Add a fallback RTC device that keeps returning the UNIX epoch (1970-01-01 00:00:00) when there is no RTC devices. This is as if our kernel boots up right after that moment.