### PR TITLE
Implement driver for "sifive,uart0" device on SiFive FU540-C000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,15 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "ctor"
-version = "0.1.25"
-source = "git+https://github.com/asterinas/rust-ctor#e30a5d960a3eccf79a7caddfa4de43b5dce424a0"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,17 +792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8661f18e73000bcea2f0d68262eb8ac1b1e951e10eb936d3f95b36201c136d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,11 +937,11 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.3"
-source = "git+https://github.com/asterinas/inventory?rev=9dce587#9dce58712d1cd1e51ff067634d42b5c5fea29f48"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
- "ctor",
- "ghost",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "jhash",
  "ostd",
  "smoltcp",
- "spin",
+ "spin 0.9.8",
  "takeable",
 ]
 
@@ -101,7 +101,7 @@ dependencies = [
  "int-to-c-enum",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ dependencies = [
  "font8x8",
  "int-to-c-enum",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ dependencies = [
  "component",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ dependencies = [
  "component",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ dependencies = [
  "component",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -156,6 +156,9 @@ name = "aster-logger"
 version = "0.1.0"
 dependencies = [
  "aster-console",
+ "aster-framebuffer",
+ "aster-uart",
+ "aster-virtio",
  "component",
  "log",
  "ostd",
@@ -191,7 +194,7 @@ dependencies = [
  "bitvec",
  "component",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -213,6 +216,7 @@ dependencies = [
  "aster-softirq",
  "aster-systree",
  "aster-time",
+ "aster-uart",
  "aster-util",
  "aster-virtio",
  "atomic-integer-wrapper",
@@ -243,7 +247,7 @@ dependencies = [
  "paste",
  "rand",
  "riscv",
- "spin",
+ "spin 0.9.8",
  "takeable",
  "tdx-guest",
  "time",
@@ -264,7 +268,7 @@ dependencies = [
  "fdt",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -294,7 +298,7 @@ dependencies = [
  "component",
  "intrusive-collections",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -306,7 +310,7 @@ dependencies = [
  "component",
  "inherit-methods-macro",
  "ostd",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -318,7 +322,17 @@ dependencies = [
  "component",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "aster-uart"
+version = "0.1.0"
+dependencies = [
+ "aster-console",
+ "component",
+ "ostd",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -353,7 +367,7 @@ dependencies = [
  "int-to-c-enum",
  "log",
  "ostd",
- "spin",
+ "spin 0.9.8",
  "tdx-guest",
  "typeflags-util",
 ]
@@ -859,7 +873,7 @@ dependencies = [
  "hash32 0.2.1",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -979,7 +993,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1290,7 +1304,7 @@ dependencies = [
  "riscv",
  "sbi-rt",
  "smallvec",
- "spin",
+ "spin 0.9.8",
  "tdx-guest",
  "unwinding",
  "volatile 0.6.1",
@@ -1655,6 +1669,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "kernel/comps/time",
     "kernel/comps/virtio",
     "kernel/comps/pci",
+    "kernel/comps/uart",
     "kernel/libs/cpio-decoder",
     "kernel/libs/int-to-c-enum",
     "kernel/libs/int-to-c-enum/derive",

--- a/Components.toml
+++ b/Components.toml
@@ -14,6 +14,7 @@ mlsdisk = { name = "aster-mlsdisk" }
 systree = { name = "aster-systree" }
 keyboard = { name = "aster-keyboard" }
 pci = { name = "aster-pci" }
+uart = { name = "aster-uart" }
 
 [whitelist]
 [whitelist.nix.main]

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ OSDK_CRATES := \
 	kernel/comps/time \
 	kernel/comps/virtio \
 	kernel/comps/pci \
+	kernel/comps/uart \
 	kernel/libs/aster-util \
 	kernel/libs/aster-bigtcp \
 	kernel/libs/xarray

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,6 +20,7 @@ aster-virtio = { path = "comps/virtio" }
 aster-rights = { path = "libs/aster-rights" }
 aster-systree = { path = "comps/systree" }
 aster-keyboard = { path = "comps/keyboard" }
+aster-uart = { path = "comps/uart" }
 component = { path = "libs/comp-sys/component" }
 controlled = { path = "libs/comp-sys/controlled" }
 logo-ascii-art = { path = "libs/logo-ascii-art" }

--- a/kernel/comps/logger/Cargo.toml
+++ b/kernel/comps/logger/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [dependencies]
 component = { path = "../../libs/comp-sys/component" }
 aster-console = { path = "../console" }
+aster-framebuffer = { path = "../framebuffer" }
+aster-uart = { path = "../uart" }
+aster-virtio = { path = "../virtio" }
 log = "0.4"
 ostd = { path = "../../../ostd" }
 owo-colors = { version = "3", optional = true }

--- a/kernel/comps/uart/Cargo.toml
+++ b/kernel/comps/uart/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aster-uart"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ostd = { path = "../../../ostd" }
+component = { path = "../../libs/comp-sys/component" }
+aster-console = { path = "../console" }
+spin = "0.10.0"
+
+[lints]
+workspace = true

--- a/kernel/comps/uart/src/lib.rs
+++ b/kernel/comps/uart/src/lib.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![no_std]
+#![deny(unsafe_code)]
+#![feature(let_chains)]
+
+use component::{init_component, ComponentInitError};
+
+#[cfg(target_arch = "riscv64")]
+mod sifive;
+
+#[init_component]
+fn uart_init() -> Result<(), ComponentInitError> {
+    #[cfg(target_arch = "riscv64")]
+    sifive::init();
+
+    Ok(())
+}
+
+#[cfg_attr(not(target_arch = "riscv64"), expect(unused))]
+trait Uart {
+    fn init(&self, clock_hz: u32);
+
+    fn transmit(&self, byte: u8) -> ostd::Result<()>;
+
+    fn receive(&self) -> Option<u8>;
+}

--- a/kernel/comps/uart/src/sifive.rs
+++ b/kernel/comps/uart/src/sifive.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MPL-2.0
+
+extern crate alloc;
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
+use core::{hint::spin_loop, mem::offset_of};
+
+use aster_console::{AnyConsoleDevice, ConsoleCallback};
+use ostd::{
+    arch::{
+        boot::DEVICE_TREE,
+        irq::{InterruptSourceInFdt, MappedIrqLine, IRQ_CHIP},
+    },
+    io::IoMem,
+    irq::IrqLine,
+    mm::{VmIoOnce, VmReader},
+    sync::{LocalIrqDisabled, Rcu, SpinLock},
+};
+use spin::Once;
+
+use crate::Uart;
+
+pub fn init() {
+    let fdt = DEVICE_TREE.get().unwrap();
+    let uart_nodes = fdt.all_nodes().filter(|n| {
+        n.compatible()
+            .is_some_and(|c| c.all().any(|s| s == SifiveUart::FDT_COMPATIBLE))
+    });
+
+    let stdout = fdt.chosen().stdout().map(|node| node.name);
+
+    let mut mapped_irq_lines: Vec<MappedIrqLine> = Vec::new();
+    uart_nodes.for_each(|uart_node| {
+        let reg = uart_node.reg().unwrap().next().unwrap();
+        let io_mem = IoMem::acquire(
+            reg.starting_address as usize..reg.starting_address as usize + reg.size.unwrap(),
+        )
+        .unwrap();
+
+        let interrupt_source_in_fdt = InterruptSourceInFdt {
+            interrupt: uart_node.interrupts().unwrap().next().unwrap() as u32,
+            interrupt_parent: uart_node
+                .property("interrupt-parent")
+                .and_then(|prop| prop.as_usize())
+                .unwrap() as u32,
+        };
+        let mut mapped_irq_line = IrqLine::alloc()
+            .and_then(|irq_line| {
+                IRQ_CHIP
+                    .get()
+                    .unwrap()
+                    .map_fdt_pin_to(interrupt_source_in_fdt, irq_line)
+            })
+            .unwrap();
+
+        let uart = Arc::new(SifiveUart {
+            io_mem,
+            callbacks: Rcu::new(Box::new(Vec::new())),
+            tx_lock: SpinLock::new(()),
+        });
+        uart.init(SifiveUart::CLOCK_HZ);
+
+        if let Some(stdout_path) = stdout
+            && stdout_path == uart_node.name
+        {
+            aster_console::register_device(
+                format_args!("SIFIVE_UART_{}_CONSOLE", mapped_irq_lines.len()).to_string(),
+                uart.clone(),
+            );
+        }
+
+        mapped_irq_line.on_active(move |_trapframe| {
+            uart.handle_rx_irq();
+        });
+        mapped_irq_lines.push(mapped_irq_line);
+    });
+
+    SIFIVE_UART_MAPPED_IRQ_LINES.call_once(|| mapped_irq_lines);
+}
+
+static SIFIVE_UART_MAPPED_IRQ_LINES: Once<Vec<MappedIrqLine>> = Once::new();
+
+pub struct SifiveUart {
+    io_mem: IoMem,
+    #[expect(clippy::box_collection)]
+    callbacks: Rcu<Box<Vec<&'static ConsoleCallback>>>,
+    // We need to lock transmit operations to ensure that multiple threads
+    // do not interleave their writes.
+    tx_lock: SpinLock<(), LocalIrqDisabled>,
+}
+
+impl Uart for SifiveUart {
+    fn init(&self, clock_hz: u32) {
+        let div = ((clock_hz as u64 + (Self::TARGET_BAUD as u64 / 2)) / (Self::TARGET_BAUD as u64)
+            - 1) as u32;
+        self.io_mem
+            .write_once(offset_of!(Registers, div), &div)
+            .unwrap();
+        self.io_mem
+            .write_once(offset_of!(Registers, txctrl), &Self::TXCTRL_TXEN)
+            .unwrap();
+        self.io_mem
+            .write_once(
+                offset_of!(Registers, rxctrl),
+                &(Self::RXCTRL_RXEN | (0 << Self::RXCTRL_RXCNT_SHIFT)),
+            )
+            .unwrap();
+        self.io_mem
+            .write_once(offset_of!(Registers, ie), &Self::IE_RXWM)
+            .unwrap();
+    }
+
+    fn transmit(&self, byte: u8) -> ostd::Result<()> {
+        let offset = offset_of!(Registers, txdata);
+        let txdata = self.io_mem.read_once::<u32>(offset).unwrap();
+        if txdata & Self::TXDATA_FULL != 0 {
+            Err(ostd::Error::NotEnoughResources)
+        } else {
+            self.io_mem
+                .write_once(offset, &(byte as u32 & Self::TXDATA_DATA_MASK))
+                .unwrap();
+            Ok(())
+        }
+    }
+
+    fn receive(&self) -> Option<u8> {
+        let offset = offset_of!(Registers, rxdata);
+        let rxdata = self.io_mem.read_once::<u32>(offset).unwrap();
+        if rxdata & Self::RXDATA_EMPTY != 0 {
+            None
+        } else {
+            Some((rxdata & Self::RXDATA_DATA_MASK) as u8)
+        }
+    }
+}
+
+impl AnyConsoleDevice for SifiveUart {
+    fn send(&self, bytes: &[u8]) {
+        let _tx_lock = self.tx_lock.lock();
+        for &byte in bytes {
+            self.transmit_blocking(byte);
+        }
+    }
+
+    fn register_callback(&self, callback: &'static ConsoleCallback) {
+        loop {
+            let callbacks = self.callbacks.read();
+            let mut callbacks_cloned = callbacks.get().clone();
+            callbacks_cloned.push(callback);
+            if callbacks.compare_exchange(callbacks_cloned).is_ok() {
+                break;
+            }
+            // Contention on pushing, retry.
+            core::hint::spin_loop();
+        }
+    }
+}
+
+impl SifiveUart {
+    fn transmit_blocking(&self, byte: u8) {
+        while self.transmit(byte).is_err() {
+            spin_loop();
+        }
+    }
+
+    fn handle_rx_irq(&self) {
+        let mut buffer = [0u8; 128];
+        loop {
+            let mut count = 0;
+            while let Some(byte) = self.receive() {
+                buffer[count] = byte;
+                count += 1;
+                if count >= buffer.len() {
+                    break;
+                }
+            }
+
+            if count == 0 {
+                break;
+            }
+
+            let callbacks = self.callbacks.read();
+            for callback in callbacks.get().iter() {
+                let reader = VmReader::from(&buffer[..count]);
+                callback(reader);
+            }
+            drop(callbacks);
+        }
+    }
+}
+
+impl SifiveUart {
+    const FDT_COMPATIBLE: &'static str = "sifive,uart0";
+
+    const TARGET_BAUD: u32 = 115200;
+    // FIXME: We should query the clock frequency from the device tree. Here we
+    // hardcode it to 500MHz for SiFive Hifive Unleashed board.
+    const CLOCK_HZ: u32 = 500_000_000;
+
+    const TXDATA_FULL: u32 = 0b1 << 31;
+    const TXDATA_DATA_MASK: u32 = 0xff;
+    const RXDATA_EMPTY: u32 = 0b1 << 31;
+    const RXDATA_DATA_MASK: u32 = 0xff;
+    const TXCTRL_TXEN: u32 = 0b1;
+    const RXCTRL_RXEN: u32 = 0b1;
+    const RXCTRL_RXCNT_SHIFT: u32 = 16;
+    const IE_RXWM: u32 = 0b1 << 1;
+}
+
+impl core::fmt::Debug for SifiveUart {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SifiveUart").finish_non_exhaustive()
+    }
+}
+
+#[repr(C)]
+struct Registers {
+    txdata: u32,
+    rxdata: u32,
+    txctrl: u32,
+    rxctrl: u32,
+    ie: u32,
+    _ip: u32,
+    div: u32,
+}

--- a/kernel/libs/comp-sys/component/Cargo.toml
+++ b/kernel/libs/comp-sys/component/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-inventory = { git = "https://github.com/asterinas/inventory", rev = "9dce587" }
 log = "0.4"
 component-macro = { path = "../component-macro" }
+inventory = "0.3.21"
 
 [build-dependencies]
 json = "0.12.4"

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -48,6 +48,15 @@ extern crate controlled;
 #[macro_use]
 extern crate getset;
 
+// We should declare components that are not explicitly used by others here to
+// ensure they are linked into the final binary. Otherwise,
+// `inventory::submit`ted `init` functions in those components will be discarded
+// by the linker.
+//
+// See <https://github.com/dtolnay/inventory/issues/50>.
+extern crate aster_mlsdisk;
+extern crate aster_uart;
+
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv/mod.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]


### PR DESCRIPTION
On SiFive HiFive Unleashed board, we have to use UART as console device.  This PR adds a `aster_uart` component that abstracts UART utilities to an `Uart` trait and implements a driver for "sifive,uart0" device on SiFive FU540-C000.
```rust
trait Uart {
    fn init(&self, clock_hz: u32);

    fn transmit(&self, byte: u8) -> ostd::Result<()>;

    fn receive(&self) -> Option<u8>;
}
```

The initialization and rx/tx logics follows the official specification and is tested to work. The specification can be found in Chapter 13 of https://pdos.csail.mit.edu/6.828/2025/readings/FU540-C000-v1.0.pdf.

Besides, this PR also involves some refinements on our `component` crate:
- uses mainline `inventory` instead of out out-of-tree version since the problem has been fixed upstream (I believe https://github.com/asterinas/inventory and https://github.com/asterinas/rust-ctor are no longer needed),
- explicitly declares "unused" components in `aster-nix` crate, otherwise their `inventory::submit`ted `init` functions will be discarded from the binary and never get invoked.