### PR TITLE
Add iago attack prevention comments for untrusted interfaces

### DIFF
--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -53,6 +53,13 @@ use crate::{
 /// This function needs to be called after the OS initializes the ACPI table.
 pub(crate) fn count_processors() -> Option<u32> {
     let acpi_tables = get_acpi_tables()?;
+    // TODO: Prevent Iago attack: Validate MADT table integrity and sanity check processor counts in Intel TDX environment.
+    // The untrusted input could provide a malicious ACPI table with:
+    // - Corrupted table structure to trigger parsing vulnerabilities
+    // - Modified checksums or signatures to bypass integrity checks
+    // - Inconsistent processor counts across multiple calls (TOCTOU attack affecting kernel state)
+    // Consider implementing: checksum verification, table structure validation to prevent parser exploits,
+    // and caching/consistency checks to detect TOCTOU attacks.
     let madt_table = acpi_tables.find_table::<acpi::madt::Madt>().ok()?;
 
     // According to ACPI spec [1], "If this bit [the Enabled bit] is set the processor is ready for

--- a/ostd/src/arch/x86/irq/chip/ioapic.rs
+++ b/ostd/src/arch/x86/irq/chip/ioapic.rs
@@ -200,6 +200,10 @@ impl IoApicAccess {
             //    problems, so the pages are not trivially untyped memory. However, since
             //    `io_mem_builder.remove()` ensures exclusive ownership, it's still fine to
             //    unprotect only once, before the I/O memory is used.
+            // TODO: Prevent Iago attack: unprotect_gpa_range() exposes I/O APIC registers to untrusted VMM manipulation.
+            // Critical risks: interrupt routing tampering, register access monitoring, and
+            // side-channel attacks through MMIO access patterns. All subsequent MMIO operations
+            // (read/write) are vulnerable to VMM interference and require validation.
             unsafe { tdx_guest::unprotect_gpa_range(base_address, 1).unwrap() };
         });
 

--- a/ostd/src/arch/x86/irq/chip/mod.rs
+++ b/ostd/src/arch/x86/irq/chip/mod.rs
@@ -169,6 +169,15 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     // correctly and reliably (e.g., by parsing the MultiProcessor Specification, which has
     // been deprecated for a long time and may not even exist in modern hardware).
     let acpi_tables = get_acpi_tables().unwrap();
+    // TODO: Prevent Iago attack: Validate MADT table integrity and I/O APIC configuration data in Intel TDX environment.
+    // The untrusted input could provide a malicious ACPI table with:
+    // - Invalid I/O APIC base addresses that could cause memory access violations or overlap with critical memory regions
+    // - Malicious interrupt source overrides that redirect critical interrupts (e.g., timer, keyboard)
+    // - Corrupted MADT structure or inconsistent entry counts
+    // - Invalid bus types or inconsistent entry structures.
+    // Consider implementing: MADT structure validation to prevent parser exploits,
+    // checksum verification, validate I/O APIC addresses against known memory maps,
+    // and validation of critical interrupt mappings (timer, system interrupts).
     let madt_table = acpi_tables.find_table::<Madt>().unwrap();
 
     // "A one indicates that the system also has a PC-AT-compatible dual-8259 setup. The 8259

--- a/ostd/src/arch/x86/kernel/acpi/mod.rs
+++ b/ostd/src/arch/x86/kernel/acpi/mod.rs
@@ -97,6 +97,14 @@ pub(in crate::arch) fn init() {
         reset_port_and_val: None,
     };
 
+    // TODO: Prevent Iago attack: Validate FADT table integrity and century register value in Intel TDX environment.
+    // The untrusted input could provide a malicious ACPI table with:
+    // - Invalid century register address that could cause hardware access violations
+    // - Out-of-range century register indices/offsets
+    // - Corrupted FADT structure to trigger parsing vulnerabilities
+    // - Inconsistent century register values across multiple calls (TOCTOU attacks)
+    // Consider implementing: checksum verification, validate century register against
+    // known valid CMOS RTC century register addresses, and caching to detect modifications.
     if let Some(acpi_tables) = get_acpi_tables()
         && let Ok(fadt) = acpi_tables.find_table::<Fadt>()
     {

--- a/ostd/src/arch/x86/kernel/apic/x2apic.rs
+++ b/ostd/src/arch/x86/kernel/apic/x2apic.rs
@@ -47,6 +47,13 @@ impl X2Apic {
         // constructed if x2APIC is known to be present.
         unsafe {
             // Enable x2APIC and xAPIC if they are not enabled by default.
+            // TODO: Prevent Iago attack: Avoid accessing this register in Intel TDX environment.
+            // This RDMSR triggers #VE exception, and in Intel TDX, x2APIC is enabled by default.
+            // Malicious VMM/Host could exploit this access to:
+            // - Invalid APIC base address pointing to critical memory regions or device MMIO
+            // - Corrupted enable bits that could cause undefined processor behavior
+            // Consider implementing: In Intel TDX environments, X2APIC is enabled by default,
+            // so avoid accessing this register.
             let mut base = rdmsr(IA32_APIC_BASE);
             if base & X2APIC_ENABLE_BITS != X2APIC_ENABLE_BITS {
                 base |= X2APIC_ENABLE_BITS;
@@ -54,6 +61,14 @@ impl X2Apic {
             }
 
             // Set SVR. Enable APIC and set Spurious Vector to 15 (reserved IRQ number).
+            // TODO: Prevent Iago attack: Verify SVR write operation succeeded in Intel TDX environment.
+            // This WRMSR triggers #VE exception, delegating SVR configuration to untrusted VMM.
+            // A malicious VMM/Host could exploit this to:
+            // - Silently ignore or modify the written value
+            // - Return false success while blocking the actual configuration
+            // - Partially tamper with written values (e.g., disable APIC while keeping vector number)
+            // Consider implementing: immediate readback verification and functional verification
+            // to ensure APIC is actually enabled.
             let svr: u64 = (1 << 8) | 15;
             wrmsr(IA32_X2APIC_SIVR, svr);
         }
@@ -79,6 +94,16 @@ impl super::Apic for X2Apic {
         // SAFETY: These operations write the interrupt command to APIC and wait for results. The
         // caller guarantees it's safe to execute this interrupt command.
         unsafe {
+            // TODO: Prevent Iago attack: Verify IPI delivery and detect VMM/Host interference in Intel TDX environment.
+            // These two WRMSRs trigger #VE exceptions, delegating IPI delivery to untrusted VMM.
+            // Malicious VMM/Host can interfere with IPI delivery:
+            // - IPIs may be silently dropped or delayed by malicious hypervisor control
+            // - ESR values could be manipulated to hide delivery failures
+            // - ICR delivery status bit may be controlled to fake successful delivery
+            // - Infinite loops possible if VMM prevents delivery status from clearing
+            // Consider implementing: timeout-based delivery verification, ESR validation against
+            // known error patterns, delivery status cross-validation, and fail-fast mechanisms
+            // when IPI delivery is compromised to prevent system hangs or security violations.
             wrmsr(IA32_X2APIC_ESR, 0);
             wrmsr(IA32_X2APIC_ICR, icr.0);
             loop {
@@ -96,18 +121,64 @@ impl super::Apic for X2Apic {
 
 impl ApicTimer for X2Apic {
     fn set_timer_init_count(&self, value: u64) {
+        // TODO: Prevent Iago attack: Validate timer initial count in TDX environment.
+        // This WRMSR triggers #VE exception, allowing untrusted VMM to intercept timer setup.
+        // Malicious VMM/Host can exploit this to:
+        // - Silently modify the initial count value to alter timer frequency/duration
+        // - Set extremely large values causing timer overflow or unexpected behavior
+        // - Set zero or very small values leading to rapid timer expiration and system instability
+        // - Inject inconsistent values across multiple timer configurations
+        // Timer count manipulation can result in: incorrect time measurements, scheduling
+        // anomalies, performance degradation, or timing-based security vulnerabilities.
+        // Consider implementing: value range validation, and cross-validation with
+        // expected timer behavior patterns.
         unsafe { wrmsr(IA32_X2APIC_INIT_COUNT, value) };
     }
 
     fn timer_current_count(&self) -> u64 {
+        // TODO: Prevent Iago attack: Validate timer current count readback in TDX environment.
+        // This RDMSR triggers #VE exception, delegating timer state access to untrusted VMM.
+        // Malicious VMM/Host can exploit this to:
+        // - Return fabricated count values that don't reflect actual timer state
+        // - Provide inconsistent readings across multiple calls breaking time monotonicity
+        // - Return values that suggest timer stopped/frozen when it's actually running
+        // - Inject timing information that enables side-channel attacks or fingerprinting
+        // - Manipulate count progression to affect time-based algorithms and scheduling
+        // Compromised timer readings can result in: incorrect time calculations, broken
+        // timeout mechanisms, scheduling failures, or security bypass through timing manipulation.
+        // Consider implementing: consistency checks across timer reads.
         unsafe { rdmsr(IA32_X2APIC_CUR_COUNT) }
     }
 
     fn set_lvt_timer(&self, value: u64) {
+        // TODO: Prevent Iago attack: Validate LVT Timer configuration in TDX environment.
+        // This WRMSR triggers #VE exception, delegating timer configuration to untrusted VMM.
+        // It can be exploited by malicious VMM/Host to tamper with timer configuration:
+        // - Silently block or modify timer mode bits (periodic/deadline)
+        // - Tamper with interrupt vector numbers causing timer interrupts to be misrouted
+        // - Manipulate mask bit to disable timer interrupts leading to system hangs
+        // - Modify delivery mode causing timer to use wrong interrupt delivery mechanism
+        // - Set reserved bits violating APIC specification and causing undefined behavior
+        // Timer compromise can result in: scheduling failures, system hangs, security bypass
+        // through timing attacks, or complete system unresponsiveness.
+        // Consider implementing: readback verification to detect write tampering, timer
+        // functionality testing, and fail-fast mechanisms when timer integrity is compromised.
         unsafe { wrmsr(IA32_X2APIC_LVT_TIMER, value) };
     }
 
     fn set_timer_div_config(&self, div_config: super::DivideConfig) {
+        // TODO: Prevent Iago attack: Validate timer divide configuration in TDX environment.
+        // This WRMSR triggers #VE exception, allowing untrusted VMM to intercept divider setup.
+        // Malicious VMM/Host can exploit this to:
+        // - Silently modify divide configuration affecting timer frequency calculations
+        // - Set invalid divide values causing timer to operate at unexpected frequencies
+        // - Change divider settings inconsistently across timer reconfigurations
+        // - Force divide-by-1 when higher division expected, causing timer to run too fast
+        // - Set maximum division when minimal expected, causing timer to run too slow
+        // Divider manipulation can result in: incorrect timer frequencies, system timing
+        // drift, performance issues, or timing-based security vulnerabilities.
+        // Consider implementing: readback verification of divide configuration and frequency
+        // validation against expected values.
         unsafe { wrmsr(IA32_X2APIC_DIV_CONF, div_config as u64) };
     }
 }

--- a/ostd/src/io/io_port/mod.rs
+++ b/ostd/src/io/io_port/mod.rs
@@ -95,6 +95,13 @@ impl<T, A> IoPort<T, A> {
 
 impl<T: PortRead, A: IoPortReadAccess> IoPort<T, A> {
     /// Reads from the I/O port
+    // TODO: Prevent Iago attack: Validate read values from sensitive I/O ports in Intel TDX environment.
+    // The untrusted host/VMM could return malicious values that may cause:
+    // - Out-of-range values leading to undefined behavior in device drivers
+    // - Inconsistent values across multiple reads (TOCTOU attacks)
+    // - Values designed to exploit vulnerabilities in device driver logic
+    // Consider implementing: range validation, caching to detect modifications,
+    // and safe error handling to prevent driver vulnerabilities.
     pub fn read(&self) -> T {
         unsafe { PortRead::read_from_port(self.port) }
     }
@@ -102,6 +109,13 @@ impl<T: PortRead, A: IoPortReadAccess> IoPort<T, A> {
 
 impl<T: PortWrite, A: IoPortWriteAccess> IoPort<T, A> {
     /// Writes to the I/O port
+    // TODO: Prevent Iago attack: Validate written values to sensitive I/O ports in Intel TDX environment.
+    // The untrusted host/VMM could exploit write operations to:
+    // - Device misconfiguration leading to security bypass
+    // - Silent write failures causing system instability
+    // - Modify written values, causing device misbehavior or security vulnerabilities
+    // - Partially tamper with written values, leading to inconsistent device states
+    // Consider implementing: immediate readback verification and functional verification.
     pub fn write(&self, value: T) {
         unsafe { PortWrite::write_to_port(self.port, value) }
     }


### PR DESCRIPTION
# Iago attacks prevention in Intel TDX Asterinas guest kernel

## Introduction

In modern cloud computing environments, Intel TDX (Trust Domain Extensions) technology provides hardware-level confidential computing protection for virtual machines. However, even with such powerful hardware protection, we still need to be vigilant against a threat called the "Iago attack."

*Iago attacks definition: Attacks in which a malicious kernel induces a protected process to act against its interests by manipulating system call return values.*

Consider a simple file read operation: When the guest kernel requests to read a file, it sends the request to the VMM through the hypercall interface. A malicious VMM can return a false number of bytes read or inject malicious content into the buffer. If the guest kernel does not adequately validate these return values, buffer overflows or other security vulnerabilities can result.

The core advantage of Intel TDX technology lies in its hardware-level memory protection. The TDX module and Intel platform ensure that the memory and registers of TDX guest virtual machines are fully protected, preventing even privileged VMMs (virtual machine monitors) from directly accessing this sensitive data. This protection mechanism lays a solid foundation for confidential computing in cloud environments.

However, just as any secure system has its boundaries, TDX's protection capabilities also have limitations. The most critical limitation is that TDX cannot protect the security of guest virtual machines interacting with the host/VMM through existing communication interfaces. These interfaces become potential weak points in the overall security architecture and are the primary targets of Iago attacks.

**In a TDX environment, there are two primary communication interfaces, both of which can serve as vectors for Iago attacks. The first is the TDVMCALL hypercalls interface, which is the primary channel through which the guest kernel requests services from the VMM via the TDX module**. When a guest needs to perform privileged operations or access hardware resources, it must communicate with the VMM through this interface. The problem is that the VMM has complete control over the return values ​​of these calls and can return arbitrary malicious data.

**Another key interface is shared memory for I/O operations.** To enable efficient device access and data exchange, a shared memory region is established between the guest and the VMM. However, this also means that the VMM can modify the contents of this shared memory at any time, injecting malicious data into the guest or tampering with expected responses.

The threat model includes:
- Protecting the TDX Asterinas guest kernel (ring 0) from hypervisor attacks through TDVMCALL hypercalls and shared memory IO interfaces
- Preventing privilege escalation attacks from untrusted VMM targeting the guest kernel
- Maintaining kernel data confidentiality and integrity against VMM-based attacks
- Ensuring no new attack vectors are introduced from TDX guest userspace (ring 3) to the guest kernel (ring 0)

The threat model excludes:
- Denial-of-service (DoS) attacks towards the TDX guest kernel (since VMM controls guest resources by default)
- TDX guest userspace (ring 3) security threats and protections
- Attacks where TDX guest userspace directly uses untrusted interfaces (TDVMCALL, shared memory) without proper validation
- Security issues from guest userspace debug/test tools performing MMIO or PCI config space operations with unvalidated VMM input
- Attacks exploiting kernel printout and debug routines that accept parameters directly from untrusted host/VMM
- General userspace application security within the TDX guest environment

Based on the above information, this PR adds comments about the protection against Iago attack from the above untrusted interfaces. All comments start with ***"TODO: Prevent Iago attack:"*** for subsequent fixes.

This PR primarily analyzes ACPI tables and IO port access, MMIO access, and MSR and CPUID that can trigger #VE.

1. ACPI tables.
  The description in the TDX Linux Guest Kernel Security Specification:
  
  > ACPI tables are (mostly) controlled by the host and only passed through the TDVF (see TDX guest virtual firmware for more information). They are measured into TDX attestation registers, and therefore can be remotely attested and therefore can be considered trusted. However, we cannot expect that an attesting entity fully understands what causes the Linux kernel to open security holes based on some particular AML. Then a malicious hypervisor might be able to attack the guest based on attack surfaces exposed by the non-malicious and attested ACPI tables.
  
  Therefore, we should treat ACPI tables as untrusted. The list of ACPI tables currently pass to Asterinas TDX is as follows:
  
  | Name(signature) | Description | Used |
  |---------|---------|---------|
  | FADT(FACP) | Fixed ACPI Description Table (FADT) | Yes |
  | CCEL | Confidential Computing Event Log | Future use |
  | HPET(HPET) | IA-PC High Precision Event Timer Table | Yes |
  | MCFG(MCFG) | PCI Express Memory-mapped Configuration Space base address description table | No |
  | WAET(WAET) | Windows ACPI Emulated Devices Table | No |
  | MADT(APIC) | Multiple APIC Description Table (MADT) | Yes |

2. IO port accesses. 
  The current interfaces for accessing the IO port in Asterinas are as follows:
  https://github.com/asterinas/asterinas/blob/43fc98dc77e4171035bb7e35c6100d577660acc1/ostd/src/io/io_port/mod.rs#L66-L78
  All kernel modules that call this interface should consider measures to deal with malicious input or exposure of sensitive kernel information.

3. Shared memory accesses.
  The current interfaces for accessing the shared memory in Asterinas are `IoMem::new`,`DmaCoherent::map`, `DmaStream::map`. All kernel modules that call these interfaces should consider measures to deal with malicious input or exposure of sensitive kernel information.

4. MSR accesses that trigger #VE
  The list of MSR accesses that trigger #VE currently during Asterinas TDX boot time is as follows:
  
  | MSRs range | MSR Name | Description | access |
  |---------|---------|---------|---------|
  | 0x1b | IA32_APIC_BASE | Controls the enable state and base address configuration of the local APIC | Read |
  | 0x80f | IA32_X2APIC_SIVR | Spurious Interrupt Vector | Write |
  | 0x803 | IA32_X2APIC_VERSION | APIC Version | Read |
  | 0x828 | IA32_X2APIC_ESR | Error Status Register | Read/Write |
  | 0x830 | IA32_X2APIC_ICR | x2APIC Interrupt Command register | Read/Write |
  | 0x832 | IA32_X2APIC_LVT_TIMER | Local Vector Table | Write |
  | 0x838 | IA32_X2APIC_INIT_COUNT | x2APIC Initial Count register | Write |
  | 0x839 | IA32_X2APIC_CUR_COUNT | x2APIC Current Count register | Write |
  | 0x83e | IA32_X2APIC_DIV_CONF | x2APIC Divide Configuration register | Write |

  The `IA32_X2APIC_VERSION` MSR is used only for kernel log printing and is not considered in our threat model.

5. CPUID accesses that trigger #VE
  The list of CPUID accesses that trigger #VE currently during Asterinas TDX boot time is as follows:  

  | CPUID Leaf | Purpose |
  |---------|---------|
  | 0x40000000 | Queries if the system is running in QEMU |

  This CPUID access is used only for detecting the QEMU hypervisor signature and no new security risks are introduced.

## Limitation

1. Sustaining.
  - A whitelist access mechanism should be established for ACPI tables, MSR, CPUID, and Port IO.
  - Port IO and shared memory accesses involve a significant amount of code and will continue to grow, so a suitable method should be considered to monitor these code snippets for further code audit.
2. Fuzzing
  - Develop comprehensive fuzzing frameworks specifically targeting Iago attack vectors.

## References

For information about Intel TDX Linux guest security strategy, please refer [this guide](https://intel.github.io/ccc-linux-guest-hardening-docs/security-spec.html).

For more TEE-based OS hardening project, please refer [gramine-tdx](https://github.com/gramineproject/gramine-tdx/tree/intel_tdx).