### PR TITLE
Update APICs' MMIO region sizes

### DIFF
--- a/ostd/src/arch/x86/irq/chip/ioapic.rs
+++ b/ostd/src/arch/x86/irq/chip/ioapic.rs
@@ -161,7 +161,11 @@ impl IoApicAccess {
     /// I/O Window (data).
     const MMIO_WIN: usize = 0x10;
     /// The size of the MMIO region.
-    const MMIO_SIZE: usize = 0x20;
+    ///
+    /// I/O APICs only have two MMIO registers, at offsets 0x00 and 0x10. Therefore, the size of
+    /// the MMIO region may be 0x20. However, we use a page here because (1) multiple I/O APICs
+    /// typically use different MMIO pages and (2) TD guests do not support sub-page MMIO regions.
+    const MMIO_SIZE: usize = crate::mm::PAGE_SIZE;
 
     /// IOAPIC ID.
     const IOAPICID: u8 = 0x00;

--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -145,4 +145,8 @@ pub(super) unsafe fn read_xapic_base_address() -> usize {
 }
 
 /// The size of the xAPIC MMIO region.
-pub(super) const XAPIC_MMIO_SIZE: usize = size_of::<[u32; 256]>();
+///
+/// Intel(R) 64 and IA-32 Architectures Software Developer's Manual, CHAPTER 11 ADVANCED
+/// PROGRAMMABLE INTERRUPT CONTROLLER (APIC) says "The local-APIC register-address space comprises
+/// the 4 KBytes at the physical address specified in the IA32_APIC_BASE MSR."
+pub(super) const XAPIC_MMIO_SIZE: usize = crate::mm::PAGE_SIZE;


### PR DESCRIPTION
Sorry. It seems that TDX guests are unable to boot after #2528.

Indeed, #2528 did not introduce a bug. TDX guests do not support sub-page MMIO regions, and #2528 uses non-page-aligned MMIO sizes for the I/O APIC, which was present in our codebase prior to #2528.
https://github.com/asterinas/asterinas/blob/43fc98dc77e4171035bb7e35c6100d577660acc1/ostd/src/io/io_mem/mod.rs#L87-L92
https://github.com/asterinas/asterinas/blob/43fc98dc77e4171035bb7e35c6100d577660acc1/ostd/src/arch/x86/irq/chip/ioapic.rs#L177
https://github.com/asterinas/asterinas/blob/43fc98dc77e4171035bb7e35c6100d577660acc1/ostd/src/arch/x86/irq/chip/ioapic.rs#L164

In fact, I believe the MMIO pages for I/O APICs and local APICs should occupy the whole page. So I correct them.