### PR TITLE
Support reboot syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -15,7 +15,7 @@ support the loading of Linux kernel modules.
 ## System Calls
 
 At the time of writing,
-Asterinas supports over 220 Linux system calls for the x86-64 architecture,
+Asterinas supports over 225 Linux system calls for the x86-64 architecture,
 which are summarized in the table below.
 
 | Numbers | Names                  | Supported      | Feature Coverage |
@@ -189,7 +189,7 @@ which are summarized in the table below.
 | 166     | umount2                | ✅             | [⚠️](syscall-feature-coverage/file-systems-and-mount-control/#umount-and-umount2) |
 | 167     | swapon                 | ❌             | N/A |
 | 168     | swapoff                | ❌             | N/A |
-| 169     | reboot                 | ❌             | N/A |
+| 169     | reboot                 | ✅             | [⚠️](syscall-feature-coverage/system-information-and-misc/#reboot) |
 | 170     | sethostname            | ✅             | 💯 |
 | 171     | setdomainname          | ✅             | 💯 |
 | 172     | iopl                   | ❌             | N/A |

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/system-information-and-misc/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/system-information-and-misc/README.md
@@ -2,7 +2,7 @@
 
 <!--
 Put system calls such as
-uname, getrlimit, setrlimit, sysinfo, times, gettimeofday, clock_gettime,
+uname, getrlimit, reboot, setrlimit, sysinfo, times, gettimeofday, clock_gettime,
 clock_settime, getrusage, getdents, getdents64, personality, syslog,
 arch_prctl, set_tid_address, and getrandom
 under this category.
@@ -50,6 +50,25 @@ Silently-ignored flags:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/getrandom.2.html).
+
+### `reboot`
+
+Supported functionality in SCML:
+
+```c
+{{#include reboot.scml}}
+```
+
+Unsupported `op` flags:
+* `LINUX_REBOOT_CMD_CAD_OFF`
+* `LINUX_REBOOT_CMD_CAD_ON`
+* `LINUX_REBOOT_CMD_KEXEC`
+* `LINUX_REBOOT_CMD_RESTART`
+* `LINUX_REBOOT_CMD_RESTART2`
+* `LINUX_REBOOT_CMD_SW_SUSPEND`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/reboot.2.html).
 
 ## POSIX Clocks
 

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/system-information-and-misc/reboot.scml
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/system-information-and-misc/reboot.scml
@@ -1,0 +1,9 @@
+reboot_magic2 = LINUX_REBOOT_MAGIC2 | LINUX_REBOOT_MAGIC2A | LINUX_REBOOT_MAGIC2B | LINUX_REBOOT_MAGIC2C;
+
+// Stop the current system
+reboot(
+    magic  = LINUX_REBOOT_MAGIC1,
+    magic2 = <reboot_magic2>,
+    op     = LINUX_REBOOT_CMD_HALT | LINUX_REBOOT_CMD_POWER_OFF,
+    arg
+);

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -84,6 +84,7 @@ use super::{
     pwritev::{sys_pwritev, sys_pwritev2, sys_writev},
     read::sys_read,
     readlink::sys_readlinkat,
+    reboot::sys_reboot,
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
@@ -268,6 +269,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RT_SIGRETURN = 139           => sys_rt_sigreturn(args[..0], &mut user_ctx);
     SYS_SET_PRIORITY = 140           => sys_set_priority(args[..3]);
     SYS_GET_PRIORITY = 141           => sys_get_priority(args[..2]);
+    SYS_REBOOT = 142                 => sys_reboot(args[..4]);
     SYS_SETREGID = 143               => sys_setregid(args[..2]);
     SYS_SETGID = 144                 => sys_setgid(args[..1]);
     SYS_SETREUID = 145               => sys_setreuid(args[..2]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -84,6 +84,7 @@ use super::{
     pwritev::{sys_pwritev, sys_pwritev2, sys_writev},
     read::sys_read,
     readlink::sys_readlinkat,
+    reboot::sys_reboot,
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
@@ -268,6 +269,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RT_SIGRETURN = 139           => sys_rt_sigreturn(args[..0], &mut user_ctx);
     SYS_SET_PRIORITY = 140           => sys_set_priority(args[..3]);
     SYS_GET_PRIORITY = 141           => sys_get_priority(args[..2]);
+    SYS_REBOOT = 142                 => sys_reboot(args[..4]);
     SYS_SETREGID = 143               => sys_setregid(args[..2]);
     SYS_SETGID = 144                 => sys_setgid(args[..1]);
     SYS_SETREUID = 145               => sys_setreuid(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -93,6 +93,7 @@ use super::{
     pwritev::{sys_pwritev, sys_pwritev2, sys_writev},
     read::sys_read,
     readlink::{sys_readlink, sys_readlinkat},
+    reboot::sys_reboot,
     recvfrom::sys_recvfrom,
     recvmsg::sys_recvmsg,
     removexattr::{sys_fremovexattr, sys_lremovexattr, sys_removexattr},
@@ -309,6 +310,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SYNC = 162             => sys_sync(args[..0]);
     SYS_MOUNT = 165            => sys_mount(args[..5]);
     SYS_UMOUNT2 = 166          => sys_umount(args[..2]);
+    SYS_REBOOT = 169           => sys_reboot(args[..4]);
     SYS_SETHOSTNAME = 170      => sys_sethostname(args[..2]);
     SYS_SETDOMAINNAME = 171    => sys_setdomainname(args[..2]);
     SYS_GETTID = 186           => sys_gettid(args[..0]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -105,6 +105,7 @@ mod pwrite64;
 mod pwritev;
 mod read;
 mod readlink;
+mod reboot;
 mod recvfrom;
 mod recvmsg;
 mod removexattr;

--- a/kernel/src/syscall/reboot.rs
+++ b/kernel/src/syscall/reboot.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{prelude::*, process::credentials::capabilities::CapSet};
+
+// Linux reboot magic constants.
+const LINUX_REBOOT_MAGIC1: i32 = 0xfee1dead_u32 as i32;
+const LINUX_REBOOT_MAGIC2: i32 = 0x28121969;
+const LINUX_REBOOT_MAGIC2A: i32 = 0x05121996;
+const LINUX_REBOOT_MAGIC2B: i32 = 0x16041998;
+const LINUX_REBOOT_MAGIC2C: i32 = 0x20112000;
+
+/// Linux reboot commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+enum RebootCmd {
+    Restart = 0x01234567,
+    Halt = 0xcdef0123,
+    PowerOff = 0x4321fedc,
+    // TODO: Add more reboot sub-commands.
+}
+
+impl TryFrom<i32> for RebootCmd {
+    type Error = Error;
+
+    fn try_from(value: i32) -> Result<Self> {
+        match value {
+            0x01234567 => Ok(Self::Restart),
+            0xcdef0123 => Ok(Self::Halt),
+            0x4321fedc => Ok(Self::PowerOff),
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid reboot command"),
+        }
+    }
+}
+
+pub fn sys_reboot(
+    magic1: i32,
+    magic2: i32,
+    op: i32,
+    _arg: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    debug!(
+        "Reboot syscall invoked with magic1: {:#x}, magic2: {:#x}, op: {:#x}",
+        magic1, magic2, op
+    );
+
+    // Verify magic numbers
+    if magic1 != LINUX_REBOOT_MAGIC1 {
+        return_errno_with_message!(Errno::EINVAL, "invalid magic1");
+    }
+
+    if magic2 != LINUX_REBOOT_MAGIC2
+        && magic2 != LINUX_REBOOT_MAGIC2A
+        && magic2 != LINUX_REBOOT_MAGIC2B
+        && magic2 != LINUX_REBOOT_MAGIC2C
+    {
+        return_errno_with_message!(Errno::EINVAL, "invalid magic2");
+    }
+
+    if !ctx
+        .posix_thread
+        .credentials()
+        .effective_capset()
+        .contains(CapSet::SYS_BOOT)
+    {
+        return_errno_with_message!(Errno::EPERM, "insufficient capabilities for reboot");
+    }
+
+    let cmd = RebootCmd::try_from(op)?;
+
+    match cmd {
+        RebootCmd::Restart => {
+            // TODO: Implement restart functionality.
+            return_errno_with_message!(Errno::ENOSYS, "restart not implemented");
+        }
+        RebootCmd::Halt | RebootCmd::PowerOff => {
+            poweroff();
+        }
+    }
+}
+
+fn poweroff() -> ! {
+    use ostd::arch::cpu::poweroff::poweroff;
+
+    // TODO: Perform any necessary cleanup before powering off.
+    poweroff()
+}

--- a/ostd/src/arch/loongarch/cpu/mod.rs
+++ b/ostd/src/arch/loongarch/cpu/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod context;
 pub mod local;
+pub mod poweroff;

--- a/ostd/src/arch/loongarch/cpu/poweroff.rs
+++ b/ostd/src/arch/loongarch/cpu/poweroff.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Provides the implementation of the poweroff functionality.
+
+use crate::arch::qemu::{exit_qemu, QemuExitCode};
+
+/// Powers off the system.
+pub fn poweroff() -> ! {
+    // TODO: Implement the poweroff behavior on a real machine.
+    exit_qemu(QemuExitCode::Success);
+}

--- a/ostd/src/arch/riscv/cpu/mod.rs
+++ b/ostd/src/arch/riscv/cpu/mod.rs
@@ -5,3 +5,4 @@
 pub mod context;
 pub mod extension;
 pub mod local;
+pub mod poweroff;

--- a/ostd/src/arch/riscv/cpu/poweroff.rs
+++ b/ostd/src/arch/riscv/cpu/poweroff.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Provides the implementation of the poweroff functionality.
+
+use crate::arch::qemu::{exit_qemu, QemuExitCode};
+
+/// Powers off the system.
+pub fn poweroff() -> ! {
+    // TODO: Implement the poweroff behavior on a real machine.
+    exit_qemu(QemuExitCode::Success);
+}

--- a/ostd/src/arch/x86/cpu/mod.rs
+++ b/ostd/src/arch/x86/cpu/mod.rs
@@ -6,3 +6,4 @@ pub mod context;
 pub mod cpuid;
 pub mod extension;
 pub mod local;
+pub mod poweroff;

--- a/ostd/src/arch/x86/cpu/poweroff.rs
+++ b/ostd/src/arch/x86/cpu/poweroff.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Provides the implementation of the poweroff functionality.
+
+use crate::arch::{
+    cpu::cpuid::query_is_running_in_qemu,
+    qemu::{exit_qemu, QemuExitCode},
+};
+
+/// Powers off the system.
+pub fn poweroff() -> ! {
+    if query_is_running_in_qemu() {
+        exit_qemu(QemuExitCode::Success);
+    }
+
+    todo!("Implement ACPI shutdown");
+}


### PR DESCRIPTION
When using systemd as the init process, the original system `exit` only terminates the current shell and cannot shut down the entire system. Therefore, it is necessary to implement the `reboot` syscall to allow the system to shut down properly. 

With this PR, when systemd is not used, the `poweroff -f` command can be employed to invoke reboot for shutdown (without the `-f` option, the system may fail to shut down properly due to pre-shutdown service stopping operations and exit with an error like `ake: *** [Makefile:275: run] Error 1`, though it still exits...). When systemd is used, the `poweroff` command allows systemd to handle pre-shutdown cleanup and stopping operations before invoking `reboot` to exit.