### PR TITLE
Revise the content of root field for the mountinfo file

### DIFF
--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -332,6 +332,27 @@ impl Dentry {
         }
         Ok(())
     }
+
+    /// Gets the absolute path name of this `Dentry` within the filesystem.
+    pub(super) fn path_name(&self) -> String {
+        let mut path_name = self.name().to_string();
+        let mut current_dir = self.this();
+
+        while let Some(parent_dir) = current_dir.parent() {
+            path_name = {
+                let parent_name = parent_dir.name();
+                if parent_name != "/" {
+                    parent_name + "/" + &path_name
+                } else {
+                    parent_name + &path_name
+                }
+            };
+            current_dir = parent_dir;
+        }
+
+        debug_assert!(path_name.starts_with('/'));
+        path_name
+    }
 }
 
 #[inherit_methods(from = "self.inode")]

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -102,6 +102,8 @@ impl Path {
     /// Gets the absolute path.
     ///
     /// It will resolve the mountpoint automatically.
+    //
+    // FIXME: This method needs to be aware of the current process's root path.
     pub fn abs_path(&self) -> String {
         let mut path_name = self.effective_name();
         let mut current_dir = self.this();
@@ -126,6 +128,8 @@ impl Path {
     ///
     /// If it is the root of a mount, it will go up to the mountpoint
     /// to get the name of the mountpoint recursively.
+    //
+    // FIXME: This method needs to be aware of the current process's root path.
     fn effective_name(&self) -> String {
         if !self.is_mount_root() {
             return self.dentry.name();

--- a/kernel/src/fs/path/mount.rs
+++ b/kernel/src/fs/path/mount.rs
@@ -534,7 +534,7 @@ impl Mount {
             let mount_id = mount.id();
             let parent = mount.parent().and_then(|parent| parent.upgrade());
             let parent_id = parent.as_ref().map_or(mount_id, |p| p.id());
-            let root = Path::new_fs_root(mount.clone()).abs_path();
+            let root = mount.root_dentry().path_name();
             let mount_point = if let Some(parent) = parent {
                 if let Some(mount_point_dentry) = mount.mountpoint() {
                     Path::new(parent, mount_point_dentry).abs_path()

--- a/test/src/syscall/gvisor/blocklists/proc_test
+++ b/test/src/syscall/gvisor/blocklists/proc_test
@@ -35,7 +35,6 @@ ProcSysVmMmapMinAddr.HasNumericValue
 ProcSysVmOvercommitMemory.HasNumericValue
 ProcFilesystems.PresenceOfShmMaxMniAll
 ProcMounts.IsSymlink
-ProcSelfMountinfo.RequiredFieldsArePresent
 ProcSelfMounts.RequiredFieldsArePresent
 Proc.GetdentsEnoent
 Proc.PidTidIOAccounting


### PR DESCRIPTION
Fix the bug mentioned in https://github.com/asterinas/asterinas/pull/2553#issuecomment-3495489473, that the root field should show the path name of the mount root within the filesystem instead of its `abs_path`.

I also find that our `abs_path` method and `effective_name` method does not be aware of the current process's root path. That is, the `effective_name` of the current process's root path should be `/` and the `abs_path` should be the path name relative to the process's root path.

Our current API doesn't seem to be able to pass the process root path into this method very elegantly (we can't pass `ctx` for all abs_path usages, we might have to use `current_thread!`). Maybe I need to find a better approach to solve this problem.

