### PR TITLE
Remove IntervalSet::find_one unreachable code

### DIFF
--- a/kernel/src/vm/vmar/interval_set.rs
+++ b/kernel/src/vm/vmar/interval_set.rs
@@ -70,18 +70,11 @@ where
     /// that contains the point.
     pub fn find_one(&self, point: &K) -> Option<&V> {
         let cursor = self.btree.lower_bound(core::ops::Bound::Excluded(point));
-        // There's one previous element and one following element that may
-        // contain the point. If they don't, there's no other chances.
-        if let Some((_, v)) = cursor.peek_prev() {
-            if v.range().end > *point {
-                return Some(v);
-            }
-        } else if let Some((_, v)) = cursor.peek_next() {
-            if v.range().start <= *point {
-                return Some(v);
-            }
-        }
-        None
+        // There's only one previous element that may contain the point.
+        // If it doesn't, there's no other chances.
+        cursor
+            .peek_prev()
+            .and_then(|(_, v)| (v.range().end > *point).then_some(v))
     }
 
     /// Finds all interval items that intersect with the given range.


### PR DESCRIPTION
### Incorrect Logic in IntervalSet::find_one
The `cursor.peek_next().start` should be strictly greater than point due to the use of `Excluded(point)` in the `lower_bound` parameter. Therefore, the condition in the else branch appears to never be satisfied.
```rust
pub fn find_one(&self, point: &K) -> Option<&V> {
    let cursor = self.btree.lower_bound(core::ops::Bound::Excluded(point));
    // There's one previous element and one following element that may
    // contain the point. If they don't, there's no other chances.
    if let Some((_, v)) = cursor.peek_prev() {
        if v.range().end > *point {
            return Some(v);
        }
    } else if let Some((_, v)) = cursor.peek_next() {
        if v.range().start <= *point {
            return Some(v);
        }
    }
    None
}
```