### PR TITLE
Revise some names and comments in `ostd::arch`

### DIFF
--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -114,14 +114,14 @@ pub(crate) unsafe fn sync_dma_range(_range: Range<Vaddr>, _direction: DmaDirecti
 #[repr(C)]
 pub(crate) struct PageTableEntry(usize);
 
-/// Activates the given level 4 page table.
+/// Activates the given root-level page table.
 ///
 /// "pgdl" or "pgdh" register doesn't have a field that encodes the cache policy,
 /// so `_root_pt_cache` is ignored.
 ///
 /// # Safety
 ///
-/// Changing the level 4 page table is unsafe, because it's possible to violate memory safety by
+/// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
 pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
     assert!(root_paddr % PagingConsts::BASE_PAGE_SIZE == 0);

--- a/ostd/src/arch/loongarch/mod.rs
+++ b/ostd/src/arch/loongarch/mod.rs
@@ -60,14 +60,14 @@ pub fn tsc_freq() -> u64 {
     loongArch64::time::get_timer_freq() as _
 }
 
-/// Reads the current value of the processor’s time-stamp counter (TSC).
+/// Reads the current value of the processor's time-stamp counter (TSC).
 pub fn read_tsc() -> u64 {
     loongArch64::time::Time::read() as _
 }
 
 /// Reads a hardware generated 64-bit random value.
 ///
-/// Returns None if no random value was generated.
+/// Returns `None` if no random value was generated.
 pub fn read_random() -> Option<u64> {
     // FIXME: Implement a hardware random number generator on LoongArch platforms.
     None

--- a/ostd/src/arch/loongarch/trap/mod.rs
+++ b/ostd/src/arch/loongarch/trap/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     mm::MAX_USERSPACE_VADDR,
 };
 
-/// Initialize trap handling on LoongArch.
+/// Initializes trap handling on LoongArch.
 pub(crate) unsafe fn init() {
     unsafe {
         self::trap::init();

--- a/ostd/src/arch/loongarch/trap/trap.S
+++ b/ostd/src/arch/loongarch/trap/trap.S
@@ -21,13 +21,13 @@ trap_entry:
     # the kernel stack pointer. If we came from the kernel, SAVE_SCRATCH
     # will contain 0, and we should continue on the current stack.
     csrwr   $sp, SAVE_SCRATCH
-    bnez    $sp, trap_from_user
+    bnez    $sp, _trap_from_user
 
-trap_from_kernel:
+_trap_from_kernel:
     csrrd   $sp, SAVE_SCRATCH
     addi.d  $sp, $sp, -35 * XLENB
 
-trap_from_user:
+_trap_from_user:
     # save general registers except $sp($r3)
     STORE_SP $r1, 1
     STORE_SP $r2, 2
@@ -72,16 +72,16 @@ trap_from_user:
     STORE_SP $t3, 34         # save euen
 
     andi    $t1, $t1, 0x3
-    bnez    $t1, end_trap_from_user
+    bnez    $t1, _end_trap_from_user
 
-end_trap_from_kernel:
+_end_trap_from_kernel:
     move    $a0, $sp           # first arg is TrapFrame
-    la.local   $ra, trap_return
+    la.local   $ra, _trap_return
 .extern trap_handler
     la.local   $t0, trap_handler
     jr      $t0
 
-end_trap_from_user:
+_end_trap_from_user:
     # load kernel-sp in UserContext.general.zero
     LOAD_SP $sp, 0
     # load callee-saved registers
@@ -129,7 +129,7 @@ run_user: # (regs: &mut RawUserContext)
     move    $t0, $sp
     csrwr   $t0, SAVE_SCRATCH   # SAVE_SCRATCH = bottom of TrapFrame/UserContext       
 
-trap_return:
+_trap_return:
     LOAD_SP $t0, 32         # t0 = prmd
     LOAD_SP $t1, 33         # t1 = era
     LOAD_SP $t2, 34         # t2 = euen

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -14,7 +14,7 @@ global_asm!(include_str!("trap.S"));
 /// - Set `eentry` to `trap_entry`
 ///
 /// You **MUST NOT** modify these registers later.
-pub unsafe fn init() {
+pub(super) unsafe fn init() {
     // When VS=0, the entry address for all exceptions and interrupts is the same
     loongArch64::register::ecfg::set_vs(0);
     // Configure the entry address for normal exceptions and interrupts

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -155,14 +155,14 @@ pub(crate) unsafe fn sync_dma_range(range: Range<Vaddr>, direction: DmaDirection
 #[repr(C)]
 pub(crate) struct PageTableEntry(usize);
 
-/// Activate the given level 4 page table.
+/// Activates the given root-level page table.
 ///
 /// "satp" register doesn't have a field that encodes the cache policy,
 /// so `_root_pt_cache` is ignored.
 ///
 /// # Safety
 ///
-/// Changing the level 4 page table is unsafe, because it's possible to violate memory safety by
+/// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
 pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
     assert!(root_paddr % PagingConsts::BASE_PAGE_SIZE == 0);

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -63,19 +63,19 @@ pub(crate) unsafe fn init_on_ap() {
     unimplemented!();
 }
 
-/// Return the frequency of TSC. The unit is Hz.
+/// Returns the frequency of TSC. The unit is Hz.
 pub fn tsc_freq() -> u64 {
     timer::get_timebase_freq()
 }
 
-/// Reads the current value of the processor’s time-stamp counter (TSC).
+/// Reads the current value of the processor's time-stamp counter (TSC).
 pub fn read_tsc() -> u64 {
     riscv::register::time::read64()
 }
 
 /// Reads a hardware generated 64-bit random value.
 ///
-/// Returns None if no random value was generated.
+/// Returns `None` if no random value was generated.
 pub fn read_random() -> Option<u64> {
     // FIXME: Implement a hardware random number generator on RISC-V platforms.
     None

--- a/ostd/src/arch/riscv/trap/trap.S
+++ b/ostd/src/arch/riscv/trap/trap.S
@@ -8,7 +8,8 @@
  * Copyright (c) 2020 - 2024 Runji Wang
  *
  * We make the following new changes:
- * * Add the `trap_handler_table`.
+ * * Adjust some symbol names.
+ * * Disable FPU and U-mode memory access on traps.
  *
  * These changes are released under the following license:
  *
@@ -29,12 +30,15 @@ trap_entry:
     # the kernel stack pointer. If we came from the kernel, sscratch
     # will contain 0, and we should continue on the current stack.
     csrrw sp, sscratch, sp
-    bnez sp, trap_from_user
-trap_from_kernel:
+    bnez sp, _trap_from_user
+
+_trap_from_kernel:
     csrr sp, sscratch
     addi sp, sp, -34 * XLENB
     # sscratch = previous-sp, sp = kernel-sp
-trap_from_user:
+    # fallthrough
+
+_trap_from_user:
     # save general registers except sp(x2)
     STORE_SP x1, 1
     STORE_SP x3, 3
@@ -78,14 +82,15 @@ trap_from_user:
     STORE_SP t2, 33                          # save sepc
 
     andi t1, t1, 1 << 8                      # sstatus.SPP == 1
-    beqz t1, end_trap_from_user
-end_trap_from_kernel:
+    beqz t1, _end_trap_from_user
+
+_end_trap_from_kernel:
     mv a0, sp                                # first arg is TrapFrame
-    lla ra, trap_return                      # set return address
+    lla ra, _trap_return                     # set return address
 .extern trap_handler
     j trap_handler
 
-end_trap_from_user:
+_end_trap_from_user:
     # load callee-saved registers
     LOAD_SP sp, 0
     LOAD_SP s0, 0
@@ -132,7 +137,7 @@ run_user: # (regs: &mut RawUserContext)
     STORE_SP t0, 0          # save kernel-sp
     csrw sscratch, sp       # sscratch = bottom of trap frame
 
-trap_return:
+_trap_return:
     LOAD_SP t0, 32          # t0 = sstatus
     LOAD_SP t1, 33          # t1 = sepc
     csrw sstatus, t0        # load sstatus

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -64,7 +64,7 @@ global_asm!(include_str!("trap.S"), SSTATUS_FS_MASK = const SSTATUS_FS_MASK, SST
 /// - Set `stvec` to internal exception vector.
 ///
 /// You **MUST NOT** modify these registers later.
-pub unsafe fn init() {
+pub(super) unsafe fn init() {
     unsafe {
         // Set sscratch register to 0, indicating to exception vector that we are
         // presently executing in the kernel

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -124,12 +124,13 @@ pub(crate) unsafe fn sync_dma_range(_range: Range<Vaddr>, _direction: DmaDirecti
 #[repr(C)]
 pub(crate) struct PageTableEntry(usize);
 
-/// Activates the given level 4 page table.
+/// Activates the given root-level page table.
+///
 /// The cache policy of the root page table node is controlled by `root_pt_cache`.
 ///
 /// # Safety
 ///
-/// Changing the level 4 page table is unsafe, because it's possible to violate memory safety by
+/// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
 pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, root_pt_cache: CachePolicy) {
     let addr = PhysFrame::from_start_address(x86_64::PhysAddr::new(root_paddr as u64)).unwrap();

--- a/ostd/src/arch/x86/mod.rs
+++ b/ostd/src/arch/x86/mod.rs
@@ -101,7 +101,7 @@ pub fn tsc_freq() -> u64 {
     kernel::tsc::TSC_FREQ.load(Ordering::Acquire)
 }
 
-/// Reads the current value of the processor’s time-stamp counter (TSC).
+/// Reads the current value of the processor's time-stamp counter (TSC).
 pub fn read_tsc() -> u64 {
     use core::arch::x86_64::_rdtsc;
 

--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -60,9 +60,8 @@ trap_handler_table:
 .text
 .code64
 
-.global trap_common
 trap_common:
-    cld                     # clear DF before calling/returning to any C function to conform to x86-64 calling convention
+    cld                     # clear DF before going to Rust to conform to x86-64 calling convention
     push rax
     mov ax, [rsp + 4*8]     # load cs
     and ax, 0x3             # test
@@ -96,6 +95,7 @@ _trap_from_user:
     push [rax - 3*8]        # push rflags
     push [rax - 5*8]        # push rip
     mov rax, [rax - 8*8]    # pop rax
+.extern trap_syscall_entry
     jmp trap_syscall_entry
 
 _trap_from_kernel:
@@ -130,8 +130,6 @@ _trap_from_kernel:
     mov rdi, rsp
     call trap_handler
 
-.global trap_return
-trap_return:
     pop rax
     pop rbx
     pop rcx


### PR DESCRIPTION
 - Fix some minor comment issues, like:
```patch
-/// Activates the given level 4 page table.
+/// Activates the given root-level page table.
```

 - https://github.com/asterinas/asterinas/pull/2508 adjusts some symbol names under `arch/x86/trap/`, leaving other architectures' symbol names in an inconsistent state. This PR fixes them.