### PR TITLE
Remove `Arc` guards of locks

### DIFF
--- a/ostd/src/sync/mod.rs
+++ b/ostd/src/sync/mod.rs
@@ -14,18 +14,12 @@ mod wait;
 pub(crate) use self::rcu::finish_grace_period;
 pub use self::{
     guard::{GuardTransfer, LocalIrqDisabled, PreemptDisabled, SpinGuardian, WriteIrqDisabled},
-    mutex::{ArcMutexGuard, Mutex, MutexGuard},
+    mutex::{Mutex, MutexGuard},
     rcu::{non_null, Rcu, RcuDrop, RcuOption, RcuOptionReadGuard, RcuReadGuard},
     rwarc::{RoArc, RwArc},
-    rwlock::{
-        ArcRwLockReadGuard, ArcRwLockUpgradeableGuard, ArcRwLockWriteGuard, RwLock,
-        RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard,
-    },
-    rwmutex::{
-        ArcRwMutexReadGuard, ArcRwMutexUpgradeableGuard, ArcRwMutexWriteGuard, RwMutex,
-        RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard,
-    },
-    spin::{ArcSpinLockGuard, SpinLock, SpinLockGuard},
+    rwlock::{RwLock, RwLockReadGuard, RwLockUpgradeableGuard, RwLockWriteGuard},
+    rwmutex::{RwMutex, RwMutexReadGuard, RwMutexUpgradeableGuard, RwMutexWriteGuard},
+    spin::{SpinLock, SpinLockGuard},
     wait::{WaitQueue, Waiter, Waker},
 };
 

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -141,22 +140,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
         }
     }
 
-    /// Acquires a read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`read`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the read guard.
-    ///
-    /// [`read`]: Self::read
-    pub fn read_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<T, G> {
-        loop {
-            if let Some(readguard) = self.try_read_arc() {
-                return readguard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
     /// Acquires a write lock and spin-wait until it can be acquired.
     ///
     /// The calling thread will spin-wait until there are no other writers,
@@ -166,22 +149,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
     pub fn write(&self) -> RwLockWriteGuard<T, G> {
         loop {
             if let Some(writeguard) = self.try_write() {
-                return writeguard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
-    /// Acquires a write lock through an [`Arc`].
-    ///
-    /// The method is similar to [`write`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`write`]: Self::write
-    pub fn write_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<T, G> {
-        loop {
-            if let Some(writeguard) = self.try_write_arc() {
                 return writeguard;
             } else {
                 core::hint::spin_loop();
@@ -209,22 +176,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
         }
     }
 
-    /// Acquires an upgradeable read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`upread`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`upread`]: Self::upread
-    pub fn upread_arc(self: &Arc<Self>) -> ArcRwLockUpgradeableGuard<T, G> {
-        loop {
-            if let Some(guard) = self.try_upread_arc() {
-                return guard;
-            } else {
-                core::hint::spin_loop();
-            }
-        }
-    }
-
     /// Attempts to acquire a read lock.
     ///
     /// This function will never spin-wait and will return immediately.
@@ -233,26 +184,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
         let lock = self.lock.fetch_add(READER, Acquire);
         if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
             Some(RwLockReadGuard { inner: self, guard })
-        } else {
-            self.lock.fetch_sub(READER, Release);
-            None
-        }
-    }
-
-    /// Attempts to acquire an read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_read`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_read`]: Self::try_read
-    pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<T, G>> {
-        let guard = G::read_guard();
-        let lock = self.lock.fetch_add(READER, Acquire);
-        if lock & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
-            Some(ArcRwLockReadGuard {
-                inner: self.clone(),
-                guard,
-            })
         } else {
             self.lock.fetch_sub(READER, Release);
             None
@@ -275,28 +206,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
         }
     }
 
-    /// Attempts to acquire a write lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_write`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_write`]: Self::try_write
-    fn try_write_arc(self: &Arc<Self>) -> Option<ArcRwLockWriteGuard<T, G>> {
-        let guard = G::guard();
-        if self
-            .lock
-            .compare_exchange(0, WRITER, Acquire, Relaxed)
-            .is_ok()
-        {
-            Some(ArcRwLockWriteGuard {
-                inner: self.clone(),
-                guard,
-            })
-        } else {
-            None
-        }
-    }
-
     /// Attempts to acquire an upread lock.
     ///
     /// This function will never spin-wait and will return immediately.
@@ -305,26 +214,6 @@ impl<T: ?Sized, G: SpinGuardian> RwLock<T, G> {
         let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire) & (WRITER | UPGRADEABLE_READER);
         if lock == 0 {
             return Some(RwLockUpgradeableGuard { inner: self, guard });
-        } else if lock == WRITER {
-            self.lock.fetch_sub(UPGRADEABLE_READER, Release);
-        }
-        None
-    }
-
-    /// Attempts to acquire an upgradeable read lock through an [`Arc`].
-    ///
-    /// The method is similar to [`try_upread`], but it doesn't have the requirement
-    /// for compile-time checked lifetimes of the lock guard.
-    ///
-    /// [`try_upread`]: Self::try_upread
-    pub fn try_upread_arc(self: &Arc<Self>) -> Option<ArcRwLockUpgradeableGuard<T, G>> {
-        let guard = G::guard();
-        let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire) & (WRITER | UPGRADEABLE_READER);
-        if lock == 0 {
-            return Some(ArcRwLockUpgradeableGuard {
-                inner: self.clone(),
-                guard,
-            });
         } else if lock == WRITER {
             self.lock.fetch_sub(UPGRADEABLE_READER, Release);
         }
@@ -359,58 +248,30 @@ impl<T: ?Sized + fmt::Debug, G> fmt::Debug for RwLock<T, G> {
 unsafe impl<T: ?Sized + Send, G> Send for RwLock<T, G> {}
 unsafe impl<T: ?Sized + Send + Sync, G> Sync for RwLock<T, G> {}
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> !Send
-    for RwLockWriteGuard_<T, R, G>
-{
-}
-unsafe impl<T: ?Sized + Sync, R: Deref<Target = RwLock<T, G>> + Clone + Sync, G: SpinGuardian> Sync
-    for RwLockWriteGuard_<T, R, G>
-{
-}
+impl<T: ?Sized, G: SpinGuardian> !Send for RwLockWriteGuard<'_, T, G> {}
+unsafe impl<T: ?Sized + Sync, G: SpinGuardian> Sync for RwLockWriteGuard<'_, T, G> {}
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> !Send
-    for RwLockReadGuard_<T, R, G>
-{
-}
-unsafe impl<T: ?Sized + Sync, R: Deref<Target = RwLock<T, G>> + Clone + Sync, G: SpinGuardian> Sync
-    for RwLockReadGuard_<T, R, G>
-{
-}
+impl<T: ?Sized, G: SpinGuardian> !Send for RwLockReadGuard<'_, T, G> {}
+unsafe impl<T: ?Sized + Sync, G: SpinGuardian> Sync for RwLockReadGuard<'_, T, G> {}
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> !Send
-    for RwLockUpgradeableGuard_<T, R, G>
-{
-}
-unsafe impl<T: ?Sized + Sync, R: Deref<Target = RwLock<T, G>> + Clone + Sync, G: SpinGuardian> Sync
-    for RwLockUpgradeableGuard_<T, R, G>
-{
-}
+impl<T: ?Sized, G: SpinGuardian> !Send for RwLockUpgradeableGuard<'_, T, G> {}
+unsafe impl<T: ?Sized + Sync, G: SpinGuardian> Sync for RwLockUpgradeableGuard<'_, T, G> {}
 
 /// A guard that provides immutable data access.
 #[clippy::has_significant_drop]
 #[must_use]
-pub struct RwLockReadGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> {
+pub struct RwLockReadGuard<'a, T: ?Sized, G: SpinGuardian> {
     guard: G::ReadGuard,
-    inner: R,
+    inner: &'a RwLock<T, G>,
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> AsAtomicModeGuard
-    for RwLockReadGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> AsAtomicModeGuard for RwLockReadGuard<'_, T, G> {
     fn as_atomic_mode_guard(&self) -> &dyn crate::task::atomic_mode::InAtomicMode {
         self.guard.as_atomic_mode_guard()
     }
 }
 
-/// A guard that provides shared read access to the data protected by a [`RwLock`].
-pub type RwLockReadGuard<'a, T, G> = RwLockReadGuard_<T, &'a RwLock<T, G>, G>;
-
-/// A guard that provides shared read access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockReadGuard<T, G> = RwLockReadGuard_<T, Arc<RwLock<T, G>>, G>;
-
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
-    for RwLockReadGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Deref for RwLockReadGuard<'_, T, G> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -418,44 +279,31 @@ impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Drop
-    for RwLockReadGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Drop for RwLockReadGuard<'_, T, G> {
     fn drop(&mut self) {
         self.inner.lock.fetch_sub(READER, Release);
     }
 }
 
-impl<T: ?Sized + fmt::Debug, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> fmt::Debug
-    for RwLockReadGuard_<T, R, G>
-{
+impl<T: ?Sized + fmt::Debug, G: SpinGuardian> fmt::Debug for RwLockReadGuard<'_, T, G> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 /// A guard that provides mutable data access.
-pub struct RwLockWriteGuard_<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> {
+pub struct RwLockWriteGuard<'a, T: ?Sized, G: SpinGuardian> {
     guard: G::Guard,
-    inner: R,
+    inner: &'a RwLock<T, G>,
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> AsAtomicModeGuard
-    for RwLockWriteGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> AsAtomicModeGuard for RwLockWriteGuard<'_, T, G> {
     fn as_atomic_mode_guard(&self) -> &dyn crate::task::atomic_mode::InAtomicMode {
         self.guard.as_atomic_mode_guard()
     }
 }
 
-/// A guard that provides exclusive write access to the data protected by a [`RwLock`].
-pub type RwLockWriteGuard<'a, T, G> = RwLockWriteGuard_<T, &'a RwLock<T, G>, G>;
-/// A guard that provides exclusive write access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockWriteGuard<T, G> = RwLockWriteGuard_<T, Arc<RwLock<T, G>>, G>;
-
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
-    for RwLockWriteGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Deref for RwLockWriteGuard<'_, T, G> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -463,25 +311,19 @@ impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> DerefMut
-    for RwLockWriteGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> DerefMut for RwLockWriteGuard<'_, T, G> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.inner.val.get() }
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Drop
-    for RwLockWriteGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Drop for RwLockWriteGuard<'_, T, G> {
     fn drop(&mut self) {
         self.inner.lock.fetch_and(!WRITER, Release);
     }
 }
 
-impl<T: ?Sized + fmt::Debug, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> fmt::Debug
-    for RwLockWriteGuard_<T, R, G>
-{
+impl<T: ?Sized + fmt::Debug, G: SpinGuardian> fmt::Debug for RwLockWriteGuard<'_, T, G> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
@@ -489,37 +331,24 @@ impl<T: ?Sized + fmt::Debug, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGua
 
 /// A guard that provides immutable data access but can be atomically
 /// upgraded to `RwLockWriteGuard`.
-pub struct RwLockUpgradeableGuard_<
-    T: ?Sized,
-    R: Deref<Target = RwLock<T, G>> + Clone,
-    G: SpinGuardian,
-> {
+pub struct RwLockUpgradeableGuard<'a, T: ?Sized, G: SpinGuardian> {
     guard: G::Guard,
-    inner: R,
+    inner: &'a RwLock<T, G>,
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> AsAtomicModeGuard
-    for RwLockUpgradeableGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> AsAtomicModeGuard for RwLockUpgradeableGuard<'_, T, G> {
     fn as_atomic_mode_guard(&self) -> &dyn crate::task::atomic_mode::InAtomicMode {
         self.guard.as_atomic_mode_guard()
     }
 }
 
-/// A upgradable guard that provides read access to the data protected by a [`RwLock`].
-pub type RwLockUpgradeableGuard<'a, T, G> = RwLockUpgradeableGuard_<T, &'a RwLock<T, G>, G>;
-/// A upgradable guard that provides read access to the data protected by a `Arc<RwLock>`.
-pub type ArcRwLockUpgradeableGuard<T, G> = RwLockUpgradeableGuard_<T, Arc<RwLock<T, G>>, G>;
-
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian>
-    RwLockUpgradeableGuard_<T, R, G>
-{
+impl<'a, T: ?Sized, G: SpinGuardian> RwLockUpgradeableGuard<'a, T, G> {
     /// Upgrades this upread guard to a write guard atomically.
     ///
     /// After calling this method, subsequent readers will be blocked
     /// while previous readers remain unaffected. The calling thread
     /// will spin-wait until previous readers finish.
-    pub fn upgrade(mut self) -> RwLockWriteGuard_<T, R, G> {
+    pub fn upgrade(mut self) -> RwLockWriteGuard<'a, T, G> {
         self.inner.lock.fetch_or(BEING_UPGRADED, Acquire);
         loop {
             self = match self.try_upgrade() {
@@ -531,7 +360,7 @@ impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian>
     /// Attempts to upgrade this upread guard to a write guard atomically.
     ///
     /// This function will never spin-wait and will return immediately.
-    pub fn try_upgrade(mut self) -> Result<RwLockWriteGuard_<T, R, G>, Self> {
+    pub fn try_upgrade(mut self) -> Result<RwLockWriteGuard<'a, T, G>, Self> {
         let res = self.inner.lock.compare_exchange(
             UPGRADEABLE_READER | BEING_UPGRADED,
             WRITER | UPGRADEABLE_READER,
@@ -539,19 +368,17 @@ impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian>
             Relaxed,
         );
         if res.is_ok() {
-            let inner = self.inner.clone();
+            let inner = self.inner;
             let guard = self.guard.transfer_to();
             drop(self);
-            Ok(RwLockWriteGuard_ { inner, guard })
+            Ok(RwLockWriteGuard { inner, guard })
         } else {
             Err(self)
         }
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
-    for RwLockUpgradeableGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Deref for RwLockUpgradeableGuard<'_, T, G> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -559,17 +386,13 @@ impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Deref
     }
 }
 
-impl<T: ?Sized, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> Drop
-    for RwLockUpgradeableGuard_<T, R, G>
-{
+impl<T: ?Sized, G: SpinGuardian> Drop for RwLockUpgradeableGuard<'_, T, G> {
     fn drop(&mut self) {
         self.inner.lock.fetch_sub(UPGRADEABLE_READER, Release);
     }
 }
 
-impl<T: ?Sized + fmt::Debug, R: Deref<Target = RwLock<T, G>> + Clone, G: SpinGuardian> fmt::Debug
-    for RwLockUpgradeableGuard_<T, R, G>
-{
+impl<T: ?Sized + fmt::Debug, G: SpinGuardian> fmt::Debug for RwLockUpgradeableGuard<'_, T, G> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }


### PR DESCRIPTION
The `Arc` guard allows the user to borrow and acquire a lock with an `Arc` to the lock, instead of using the reference. This was introduced in #778 to support page table locking. However the locking rules have changed, and we no longer use `Arc`s for `Frame`s. So there were no users since then.

Beyond the lack of actual users, I argue that the `Arc` guard is not quite a good programming pattern because of
 1. the poor scalability of `Arc`. Creating an `Arc` guard will `clone` that `Arc`, which causes cache-line bouncing upon all the acquiring cores. And
 2. the chance of making the critical section undecidably long. Borrowing will make the critical section clear since the critical section is tied with a compile-time-known lifetime. But an `Arc` guard breaks this nice property.