### PR TITLE
Add some IOCTLs for evdev

### DIFF
--- a/kernel/comps/input/src/event_type_codes.rs
+++ b/kernel/comps/input/src/event_type_codes.rs
@@ -151,6 +151,11 @@ impl RelCodeSet {
         let index = rel_code as usize;
         self.0.get(index).map(|b| *b).unwrap()
     }
+
+    /// Returns the bitmap as a byte slice.
+    pub fn as_raw_slice(&self) -> &[u8] {
+        self.0.as_raw_slice()
+    }
 }
 
 /// A set of [`KeyCode`] represented as a bitmap.
@@ -195,6 +200,11 @@ impl KeyCodeSet {
     pub fn contain_any(&self, range: core::ops::Range<usize>) -> bool {
         assert!(range.is_empty() || range.end <= KEY_COUNT);
         range.into_iter().any(|i| *self.0.get(i).unwrap())
+    }
+
+    /// Returns the bitmap as a byte slice.
+    pub fn as_raw_slice(&self) -> &[u8] {
+        self.0.as_raw_slice()
     }
 }
 

--- a/kernel/comps/input/src/input_dev.rs
+++ b/kernel/comps/input/src/input_dev.rs
@@ -225,6 +225,21 @@ impl InputCapability {
     pub fn clear_supported_relative_axis(&mut self, rel_code: RelCode) {
         self.supported_relative_axes.clear(rel_code);
     }
+
+    /// Returns the supported event types as a bitmap.
+    pub fn event_types_bits(&self) -> u32 {
+        self.supported_event_types.bits()
+    }
+
+    /// Returns the supported key code bitmap as bytes.
+    pub fn supported_keys_bitmap(&self) -> &[u8] {
+        self.supported_keys.as_raw_slice()
+    }
+
+    /// Returns the supported relative axes bitmap as bytes.
+    pub fn supported_relative_axes_bitmap(&self) -> &[u8] {
+        self.supported_relative_axes.as_raw_slice()
+    }
 }
 
 pub trait InputDevice: Send + Sync + Any + Debug {

--- a/kernel/src/util/ioctl/mod.rs
+++ b/kernel/src/util/ioctl/mod.rs
@@ -364,7 +364,6 @@ impl<const MAGIC: u8, const NR: u8, const IS_MODERN: bool>
     /// Obtains a [`VmWriter`] that can write the dynamically-sized ioctl argument to userspace.
     ///
     /// The size of the ioctl argument is specified in [`VmWriter::avail`].
-    #[expect(dead_code)]
     pub fn with_writer<F, R>(&self, f: F) -> Result<R>
     where
         F: for<'a> FnOnce(VmWriter<'a>) -> Result<R>,


### PR DESCRIPTION
This PR is to add some IOCTLs for `evdev`, which are necessary for `xorg server`.

Actually the first commit is from evdev (PR https://github.com/asterinas/asterinas/pull/2561/), and the second commit is for IOCTLs. Since evdev has not been merged yet, I mark this PR as _draft_. After evdev has final version, I would modify this PR and mark it _open_. 


