### PR TITLE
Refactor `procfs` with `VmPrinter`

### DIFF
--- a/kernel/src/fs/procfs/cmdline.rs
+++ b/kernel/src/fs/procfs/cmdline.rs
@@ -5,8 +5,7 @@
 //!
 //! Reference: <https://man7.org/linux/man-pages/man5/proc_cmdline.5.html>
 
-use alloc::format;
-
+use aster_util::printer::VmPrinter;
 use ostd::boot::boot_info;
 
 use crate::{
@@ -33,10 +32,13 @@ impl CmdLineFileOps {
 }
 
 impl FileOps for CmdLineFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
         // TODO: Parse additional kernel command line information with `bootconfig`.
         // See <https://docs.kernel.org/admin-guide/bootconfig.html> for details.
-        let cmdline = format!("{}\n", boot_info().kernel_cmdline);
-        Ok(cmdline.into_bytes())
+        writeln!(printer, "{}", boot_info().kernel_cmdline)?;
+
+        Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/fs/procfs/pid/task/cgroup.rs
+++ b/kernel/src/fs/procfs/pid/task/cgroup.rs
@@ -28,10 +28,6 @@ impl CgroupFileOps {
 }
 
 impl FileOps for CgroupFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
-        unreachable!()
-    }
-
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let path = self
             .0

--- a/kernel/src/fs/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/procfs/pid/task/cmdline.rs
@@ -25,16 +25,14 @@ impl CmdlineFileOps {
 }
 
 impl FileOps for CmdlineFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let vmar_guard = self.0.lock_vmar();
         let Some(init_stack_reader) = vmar_guard.init_stack_reader() else {
             // According to Linux behavior, return an empty string
             // if the process is a zombie process.
-            return Ok(Vec::new());
+            return Ok(0);
         };
-        Ok(init_stack_reader
-            .argv()
-            // Should we return an empty string if an error occurs?
-            .unwrap_or_else(|_| Vec::new()))
+
+        init_stack_reader.argv(offset, writer)
     }
 }

--- a/kernel/src/fs/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/procfs/pid/task/environ.rs
@@ -25,16 +25,13 @@ impl EnvironFileOps {
 }
 
 impl FileOps for EnvironFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let vmar_guard = self.0.lock_vmar();
         let Some(init_stack_reader) = vmar_guard.init_stack_reader() else {
             // According to Linux behavior, return an empty string
             // if the process is a zombie process.
-            return Ok(Vec::new());
+            return Ok(0);
         };
-        Ok(init_stack_reader
-            .envp()
-            // Should we return an empty string if an error occurs?
-            .unwrap_or_else(|_| Vec::new()))
+        init_stack_reader.envp(offset, writer)
     }
 }

--- a/kernel/src/fs/procfs/pid/task/gid_map.rs
+++ b/kernel/src/fs/procfs/pid/task/gid_map.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
+use aster_util::printer::VmPrinter;
 
 use super::TidDirOps;
 use crate::{
@@ -28,11 +28,20 @@ impl GidMapFileOps {
 }
 
 impl FileOps for GidMapFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
         // This is the default GID map for the initial user namespace.
         // TODO: Retrieve the GID map from the user namespace of the current process
         // instead of returning this hard-coded value.
-        let output = format!("{:>10} {:>10} {:>10}\n", 0, 0, u32::from(Gid::INVALID));
-        Ok(output.into_bytes())
+        writeln!(
+            printer,
+            "{:>10} {:>10} {:>10}",
+            0,
+            0,
+            u32::from(Gid::INVALID)
+        )?;
+
+        Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/fs/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/procfs/pid/task/mem.rs
@@ -25,10 +25,6 @@ impl MemFileOps {
 }
 
 impl FileOps for MemFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
-        unreachable!()
-    }
-
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let vmar_guard = self.0.lock_vmar();
         let Some(vmar) = vmar_guard.as_ref() else {

--- a/kernel/src/fs/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/procfs/pid/task/mountinfo.rs
@@ -24,10 +24,6 @@ impl MountInfoFileOps {
 }
 
 impl FileOps for MountInfoFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
-        unreachable!()
-    }
-
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let thread = self.0.thread();
         let posix_thread = thread.as_posix_thread().unwrap();

--- a/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{fmt::Write, sync::atomic::Ordering};
+use core::sync::atomic::Ordering;
+
+use aster_util::printer::VmPrinter;
 
 use super::TidDirOps;
 use crate::{
@@ -27,12 +29,13 @@ impl OomScoreAdjFileOps {
 }
 
 impl FileOps for OomScoreAdjFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
-        let oom_score_adj = self.0.oom_score_adj().load(Ordering::Relaxed);
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
 
-        let mut output = String::new();
-        writeln!(output, "{}", oom_score_adj).unwrap();
-        Ok(output.into_bytes())
+        let oom_score_adj = self.0.oom_score_adj().load(Ordering::Relaxed);
+        writeln!(printer, "{}", oom_score_adj)?;
+
+        Ok(printer.bytes_written())
     }
 
     fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {

--- a/kernel/src/fs/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/procfs/pid/task/stat.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{fmt::Write, sync::atomic::Ordering};
+use core::sync::atomic::Ordering;
+
+use aster_util::printer::VmPrinter;
 
 use super::TidDirOps;
 use crate::{
@@ -85,7 +87,7 @@ impl StatFileOps {
 }
 
 impl FileOps for StatFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let process = self.0.process_ref.as_ref();
         let thread = self.0.thread();
         let posix_thread = thread.as_posix_thread().unwrap();
@@ -158,9 +160,9 @@ impl FileOps for StatFileOps {
             (0, 0)
         };
 
-        let mut stat_output = String::new();
+        let mut printer = VmPrinter::new_skip(writer, offset);
         writeln!(
-            stat_output,
+            printer,
             "{} ({}) {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
             pid,
             comm,
@@ -186,8 +188,8 @@ impl FileOps for StatFileOps {
             starttime,
             vsize,
             rss
-        )
-        .unwrap();
-        Ok(stat_output.into_bytes())
+        )?;
+
+        Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/fs/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/procfs/pid/task/uid_map.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
+use aster_util::printer::VmPrinter;
 
 use super::TidDirOps;
 use crate::{
@@ -28,11 +28,20 @@ impl UidMapFileOps {
 }
 
 impl FileOps for UidMapFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
         // This is the default UID map for the initial user namespace.
         // TODO: Retrieve the UID map from the user namespace of the current process
         // instead of returning this hard-coded value.
-        let output = format!("{:>10} {:>10} {:>10}\n", 0, 0, u32::from(Uid::INVALID));
-        Ok(output.into_bytes())
+        writeln!(
+            printer,
+            "{:>10} {:>10} {:>10}",
+            0,
+            0,
+            u32::from(Uid::INVALID)
+        )?;
+
+        Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
+++ b/kernel/src/fs/procfs/sys/kernel/cap_last_cap.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
+use aster_util::printer::VmPrinter;
 
 use crate::{
     fs::{
@@ -25,9 +25,12 @@ impl CapLastCapFileOps {
 }
 
 impl FileOps for CapLastCapFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
         let cap_last_cap_value = CapSet::most_significant_bit();
-        let output = format!("{}\n", cap_last_cap_value);
-        Ok(output.into_bytes())
+        writeln!(printer, "{}", cap_last_cap_value)?;
+
+        Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/fs/procfs/sys/kernel/pid_max.rs
+++ b/kernel/src/fs/procfs/sys/kernel/pid_max.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
+use aster_util::printer::VmPrinter;
 
 use crate::{
     fs::{
@@ -25,9 +25,12 @@ impl PidMaxFileOps {
 }
 
 impl FileOps for PidMaxFileOps {
-    fn data(&self) -> Result<Vec<u8>> {
-        let output = format!("{}\n", PID_MAX);
-        Ok(output.into_bytes())
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", PID_MAX)?;
+
+        Ok(printer.bytes_written())
     }
 
     fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {

--- a/kernel/src/fs/procfs/template/file.rs
+++ b/kernel/src/fs/procfs/template/file.rs
@@ -97,17 +97,7 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
 }
 
 pub trait FileOps: Sync + Send {
-    fn data(&self) -> Result<Vec<u8>>;
-
-    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let data = self.data()?;
-        if offset >= data.len() {
-            return Ok(0);
-        }
-
-        let written_len = writer.write_fallible(&mut (&data[offset..]).into())?;
-        Ok(written_len)
-    }
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize>;
 
     fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
         return_errno_with_message!(Errno::EPERM, "the file is not writable");

--- a/kernel/src/fs/procfs/template/mod.rs
+++ b/kernel/src/fs/procfs/template/mod.rs
@@ -2,7 +2,7 @@
 
 use core::time::Duration;
 
-pub use self::{
+pub(super) use self::{
     builder::{ProcDirBuilder, ProcFileBuilder, ProcSymBuilder},
     dir::{lookup_child_from_table, populate_children_from_table, DirOps, ProcDir},
     file::FileOps,


### PR DESCRIPTION
Thanks to https://github.com/asterinas/asterinas/pull/2414 that introduced `VmPrinter`, we can use it to refactor `procfs` to avoid unnecessary heap allocations.

After the refactoring, I think we now have too much code following this pattern:

```rust
impl FileOps for SomeFileOps {
    fn data(&self) -> Result<Vec<u8>> {
        unreachable!()
    }

    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
        let mut printer = VmPrinter::new_skip(writer, offset);
        // Some writes
        Ok(printer.bytes_written())
    }
}
```

This is a bit ugly. We can enforce that **exactly** one of `fn data` and `fn read_at` is implemented at type level. The second commit achieves this by:

https://github.com/asterinas/asterinas/blob/bfec8061fa843c763786ac4e33d6f6301fe22e4e/kernel/src/fs/procfs/template/file.rs#L99-L130