### PR TITLE
Clarify how `Path` inherits methods from `Dentry` and `Inode`

### DIFF
--- a/kernel/src/fs/inode_handle/dyn_cap.rs
+++ b/kernel/src/fs/inode_handle/dyn_cap.rs
@@ -204,7 +204,7 @@ impl FileLike for InodeHandle {
     }
 
     fn inode(&self) -> &Arc<dyn Inode> {
-        self.0.inode()
+        self.0.path.inode()
     }
 }
 

--- a/kernel/src/fs/inode_handle/mod.rs
+++ b/kernel/src/fs/inode_handle/mod.rs
@@ -7,7 +7,6 @@ mod dyn_cap;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 pub use dyn_cap::InodeHandle;
-use inherit_methods_macro::inherit_methods;
 
 use crate::{
     events::IoEvents,
@@ -250,12 +249,6 @@ impl HandleInner {
             flock_list.unlock(req_owner);
         }
     }
-}
-
-#[inherit_methods(from = "self.path")]
-impl HandleInner {
-    pub(self) fn size(&self) -> usize;
-    pub(self) fn inode(&self) -> &Arc<dyn Inode>;
 }
 
 impl Debug for HandleInner {

--- a/kernel/src/fs/path/mount.rs
+++ b/kernel/src/fs/path/mount.rs
@@ -371,7 +371,7 @@ impl Mount {
 
     /// Attaches the mount node to the mountpoint.
     fn attach_to_path(&self, target_path: &Path) {
-        let key = target_path.key();
+        let key = target_path.dentry.key();
         target_path
             .mount_node()
             .children


### PR DESCRIPTION
I am quite confused when seeing:
https://github.com/asterinas/asterinas/blob/35ab40057a50c587fcfca9a13110e2db55178b45/kernel/src/fs/path/dentry.rs#L358-L392
https://github.com/asterinas/asterinas/blob/35ab40057a50c587fcfca9a13110e2db55178b45/kernel/src/fs/path/mod.rs#L467-L506


It's unclear whether the `Path` methods were inherited from `Inode` or `Dentry`. Most of `Dentry`'s methods inherited from `Inode` are redundant because they only serve to make `Path`'s methods, which are inherited from `Dentry`, work.

I believe that the version in this PR is better:
```rust
// Methods inherited from `Dentry`.
#[inherit_methods(from = "self.dentry")]
impl Path {
    pub fn unlink(&self, name: &str) -> Result<()>;
    pub fn rmdir(&self, name: &str) -> Result<()>;
    // ...
}


// Methods inherited from `Inode`.
#[inherit_methods(from = "self.inode()")]
impl Path {
    pub fn fs(&self) -> Arc<dyn FileSystem>;
    pub fn sync_all(&self) -> Result<()>;
    // ...
}
```