### PR TITLE
Remove `PageProperty::new_absent`

### DIFF
--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -25,15 +25,6 @@ impl PageProperty {
             priv_flags: PrivilegedPageFlags::USER,
         }
     }
-
-    /// Creates a page property that implies an invalid page without mappings.
-    pub fn new_absent() -> Self {
-        Self {
-            flags: PageFlags::empty(),
-            cache: CachePolicy::Writeback,
-            priv_flags: PrivilegedPageFlags::empty(),
-        }
-    }
 }
 
 // TODO: Make it more abstract when supporting other architectures.


### PR DESCRIPTION
```rust
impl PageProperty {
    /// Creates a page property that implies an invalid page without mappings.
    pub fn new_absent() -> Self {
```

This is clearly problematic because it contradicts:

https://github.com/asterinas/asterinas/blob/eff4daf3ace4640a701f78e72e78fe2a89c68ea9/ostd/src/mm/page_prop.rs#L9-L11

Fortunately, I do not find any use cases, so no code seems to be doing it wrong. Unfortunately, the linter doesn't recognize it as dead code, and I don't know why.