### PR TITLE
Fix osdk Docker image build failures

### DIFF
--- a/osdk/tools/docker/Dockerfile
+++ b/osdk/tools/docker/Dockerfile
@@ -157,10 +157,10 @@ RUN mkdir -p /github/home \
     && ln -s /root/.rustup /github/home/.rustup
 
 # Install cargo tools
-RUN cargo install \
+RUN cargo install --locked \
     cargo-binutils \
-    mdbook \
-    typos-cli
+    mdbook@0.4.52 \
+    typos-cli@1.39.0
 
 # Install QEMU built from the previous stages
 COPY --from=qemu /usr/local/qemu /usr/local/qemu


### PR DESCRIPTION
This PR fixes two issues in the osdk Docker image build:

1. [**GRUB build failure**](https://github.com/asterinas/asterinas/actions/runs/19570491196/job/56106388289#step:4:4764): The `gnulib` repository at `https://git.savannah.gnu.org/git/gnulib` is unstable. Replaced it with the GitHub mirror for better reliability.

2. **Cargo tools installation failure**: The current Rust toolchain (1.86) is incompatible with the latest versions of `mdbook` and `typos-cli` (which require 1.88+). Pinned both tools to compatible versions:
   - `mdbook@0.4.52` (supports Rust 1.82+)
   - `typos-cli@1.39.0` (supports Rust 1.80+)
