### PR TITLE
Drop option lock before polling iface

### DIFF
--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -269,6 +269,7 @@ impl StreamSocket {
         });
 
         drop(state);
+        drop(options);
         self.pollee.invalidate();
         if let Some(iface) = iface_to_poll {
             iface.poll();


### PR DESCRIPTION
This PR fixes the CI failure in https://github.com/asterinas/asterinas/actions/runs/19613648923/job/56163086909?pr=2561.

The issue arises because iface.poll() is called while the option lock(which is a rwlock) is held. Polling the loopback device, however, requires acquiring a Mutex lock, which violates the atomic mode. Therefore, this PR releases the option lock before calling `iface.poll()`.

```rust
    struct Wrapper(Mutex<Loopback>);

    impl WithDevice for Wrapper {
        type Device = Loopback;

        fn with<F, R>(&self, f: F) -> R
        where
            F: FnOnce(&mut Self::Device) -> R,
        {
            let mut device = self.0.lock();
            f(&mut device)
        }
    }
```