### PR TITLE
Make the mount-related fields in statx effective

### DIFF
--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -65,7 +65,7 @@ impl Path {
     }
 
     /// Returns true if the current `Path` is the root of its mount.
-    pub(super) fn is_mount_root(&self) -> bool {
+    pub fn is_mount_root(&self) -> bool {
         Arc::ptr_eq(&self.dentry, self.mount.root_dentry())
     }
 


### PR DESCRIPTION
When debugging systemd in nixos, I found that after entering the shell, the `/run/current-system` symlink we prepared in the initialization script could no longer be found, which prevented the `$PATH` environment variable from correctly locating `/run/current-system/sw/bin`. The underlying reason is that systemd automatically mounts a tmpfs at `/run`, overwriting the original contents. In fact, before mounting, systemd will use the `statx` syscall to check if the current path is already a mount root. If it is, it skips the corresponding operation.

In our current `statx` implementation, the `stx_attributes_mask` includes `STATX_ATTR_MOUNT_ROOT`, which implies that the current `stx_attributes` supports the `STATX_ATTR_MOUNT_ROOT` flag. But in reality, we don't actually support this feature, which caused systemd to mistakenly believe that the current path was not a mount root. This PR fixes that issue.