### PR TITLE
Fix device id of ext2 inode

### DIFF
--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -88,8 +88,9 @@ impl Inode {
 
     pub fn metadata(&self) -> Metadata {
         let inner = self.inner.read();
+        let id = self.fs.upgrade().unwrap().block_device().id();
         Metadata {
-            dev: 0, // TODO: ID of block device
+            dev: id.as_encoded_u64(),
             ino: self.ino() as _,
             size: inner.file_size() as _,
             blk_size: BLOCK_SIZE,


### PR DESCRIPTION
The `switch_root` checks this field using `xstat`, requiring the new root directory to be a separate mount point. Due to the field being hardcoded to 0, `switch_root` cannot properly identify different filesystems, causing the check to fail.