### PR TITLE
Add directory search permission check during path traversal on fs_res…

### DIFF
--- a/kernel/src/fs/fs_resolver.rs
+++ b/kernel/src/fs/fs_resolver.rs
@@ -2,6 +2,8 @@
 
 use alloc::str;
 
+use crate::fs::utils::Permission;
+
 use ostd::task::Task;
 
 use super::{
@@ -176,6 +178,13 @@ impl FsResolver {
 
         Ok(lookup_res)
     }
+        fn check_dir_search_permission(path: &Path) -> Result<()> {
+        let inode = path.inode();
+        if inode.type_() == InodeType::Dir {
+            inode.check_permission(Permission::MAY_EXEC)?;
+        }
+        Ok(())
+    }
 
     /// Lookups the target path according to the parent directory path.
     ///
@@ -212,6 +221,7 @@ impl FsResolver {
         let (mut current_path, mut relative_path) = (parent.clone(), relative_path);
 
         while !relative_path.is_empty() {
+            FsResolver::check_dir_search_permission(&current_path)?;
             let (next_name, path_remain, target_is_dir) =
                 if let Some((prefix, suffix)) = relative_path.split_once('/') {
                     let suffix = suffix.trim_start_matches('/');


### PR DESCRIPTION
This PR introduces directory execute/search permission (MAY_EXEC) checking during path lookup, aligning Asterinas with the Linux VFS behavior. 
Added `FsResolver::check_dir_search_permission()`
Inserted per-directory `MAY_EXEC` check in `lookup_from_parent()` 
Path traversal now fails with `EACCES` when execute/search permission is missing