### PR TITLE
Enable some security configurations in TDX environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,9 +1941,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tdx-guest"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3792a8dc443107e37c3804c655a4807605c8b275e986b0f08add336f01e49685"
+checksum = "15fda2de9c0a2fdcc22e802af4f7f1e8f609a206f34d30986e3cd974b04911f0"
 dependencies = [
  "bitflags 1.3.2",
  "iced-x86",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -66,7 +66,7 @@ takeable = "0.2.2"
 cfg-if = "1.0"
 
 [target.x86_64-unknown-none.dependencies]
-tdx-guest = { version = "0.2.1", optional = true }
+tdx-guest = { version = "0.2.2", optional = true }
 
 [target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.15.0", features = ["s-mode"] }

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 
 [target.x86_64-unknown-none.dependencies]
-tdx-guest = { version = "0.2.1", optional = true }
+tdx-guest = { version = "0.2.2", optional = true }
 
 [features]
 all = ["cvm_guest"]

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -57,7 +57,7 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [
     "decoder",
     "gas",
 ], optional = true }
-tdx-guest = { version = "0.2.1", optional = true }
+tdx-guest = { version = "0.2.2", optional = true }
 unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 
 [target.riscv64imac-unknown-none-elf.dependencies]

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -24,7 +24,7 @@ xmas-elf = "0.10.0"
 log = "0.4.20"
 uefi = { version = "0.32.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}
 uefi-raw = "0.8.0"
-tdx-guest = { version = "0.2.1", optional = true }
+tdx-guest = { version = "0.2.2", optional = true }
 
 [features]
 default = ["cvm_guest"]


### PR DESCRIPTION
This PR enable three security configurations in TDX environment:

1. Reduce #VE. When `VE_REDUCTION` is enabled, the TDX module obtains the static value of MSR/CPUID from the VMM when the TD starts and it significantly reduce the occurrence of #VE.
2. Disable SEPT #VE. Disable EPT violation conversion to `#VE(PENDING)` on guest TD access of PENDING pages. There is a known attack path could be leveraged for the MMIO emulation.
3. Enable notification for zero step attack detection in TDX environment.