### PR TITLE
Fix a misuse of `CommonSizeClass::from_size` in CPU local allocator

### DIFF
--- a/ostd/src/cpu/local/dyn_cpu_local.rs
+++ b/ostd/src/cpu/local/dyn_cpu_local.rs
@@ -157,11 +157,9 @@ impl<const ITEM_SIZE: usize> DynCpuLocalChunk<ITEM_SIZE> {
         &mut self,
         init_values: &mut impl FnMut(CpuId) -> T,
     ) -> Option<CpuLocal<T, DynamicStorage<T>>> {
-        const {
-            assert!(ITEM_SIZE.is_power_of_two());
-            assert!(size_of::<T>() <= ITEM_SIZE);
-            assert!(align_of::<T>() <= ITEM_SIZE);
-        }
+        assert!(ITEM_SIZE.is_power_of_two());
+        assert!(size_of::<T>() <= ITEM_SIZE);
+        assert!(align_of::<T>() <= ITEM_SIZE);
 
         let index = self.bitmap.first_zero()?;
         self.bitmap.set(index, true);


### PR DESCRIPTION
This is a small fix. Originally, types that don't have exactly the size 8, 16, or 32 cannot be allocated from the CPU local allocator. We use counters with size 8 only, so the bug went unnoticed.


The layout checks in can't be in `const` blocks since incompatible methods, e.g., `DynCpuLocalChunk::<2>::alloc::<usize>()` will be instantiated even if never actually called. 

<details><summary>Compiler Error</summary>
<p>


```
error[E0080]: evaluation of `ostd::cpu::local::DynCpuLocalChunk::<8>::alloc::<cpu_local_allocator::test::Aligned16, fn(ostd::cpu::CpuId) -> cpu_local_allocator::test::Aligned16>::{constant#0}` failed
   --> /root/asterinas/ostd/src/cpu/local/dyn_cpu_local.rs:162:13
    |
162 |             assert!(size_of::<T>() <= ITEM_SIZE);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: size_of::<T>() <= ITEM_SIZE', /root/asterinas/ostd/src/cpu/local/dyn_cpu_local.rs:162:13
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant encountered
   --> /root/asterinas/ostd/src/cpu/local/dyn_cpu_local.rs:160:9
    |
160 | /         const {
161 | |             assert!(ITEM_SIZE.is_power_of_two());
162 | |             assert!(size_of::<T>() <= ITEM_SIZE);
163 | |             assert!(align_of::<T>() <= ITEM_SIZE);
164 | |         }
    | |_________^

note: the above error was encountered while instantiating `fn ostd::cpu::local::DynCpuLocalChunk::<8>::alloc::<cpu_local_allocator::test::Aligned16, fn(ostd::cpu::CpuId) -> cpu_local_allocator::test::Aligned16>`
  --> /root/asterinas/osdk/deps/heap-allocator/src/cpu_local_allocator.rs:38:33
   |
38 |                 let cpu_local = chunk.alloc::<T>(init_values).unwrap();
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

</p>
</details> 
