### PR TITLE
Pass virtual address to TDX `unprotect_gpa_range`

### DIFF
--- a/ostd/src/arch/x86/irq/chip/ioapic.rs
+++ b/ostd/src/arch/x86/irq/chip/ioapic.rs
@@ -1,21 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use bit_field::BitField;
-use cfg_if::cfg_if;
 use log::info;
 
 use crate::{
-    arch::if_tdx_enabled,
     io::{IoMem, IoMemAllocatorBuilder, Sensitive},
     irq::IrqLine,
     Error, Result,
 };
-
-cfg_if! {
-    if #[cfg(feature = "cvm_guest")] {
-        use crate::arch::tdx_guest;
-    }
-}
 
 /// I/O Advanced Programmable Interrupt Controller (APIC).
 ///
@@ -182,26 +174,6 @@ impl IoApicAccess {
             base_address..(base_address + Self::MMIO_SIZE),
             crate::mm::CachePolicy::Uncacheable,
         );
-
-        if_tdx_enabled!({
-            assert_eq!(
-                base_address % crate::mm::PAGE_SIZE,
-                0,
-                "[IOAPIC]: I/O memory is not page aligned, which cannot be unprotected in TDX: {:#x}",
-                base_address,
-            );
-            // SAFETY:
-            //  - The address range is page aligned, as we've checked above.
-            //  - The caller guarantees that the address range represents the MMIO region for I/O
-            //    APICs, so the address range must fall in the GPA limit.
-            //  - FIXME: The I/O memory can be at a high address, so it may not be contained in the
-            //    linear mapping.
-            //  - Operations on the I/O memory can have side effects that may cause soundness
-            //    problems, so the pages are not trivially untyped memory. However, since
-            //    `io_mem_builder.remove()` ensures exclusive ownership, it's still fine to
-            //    unprotect only once, before the I/O memory is used.
-            unsafe { tdx_guest::unprotect_gpa_range(base_address, 1).unwrap() };
-        });
 
         Self { io_mem }
     }

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -1,76 +1,40 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use log::warn;
 use tdx_guest::{tdcall::accept_page, tdvmcall::map_gpa, TdxTrapFrame};
 
 use super::trap::TrapFrame;
-use crate::{
-    mm::{
-        kspace::KERNEL_PAGE_TABLE,
-        paddr_to_vaddr,
-        page_prop::{PageProperty, PrivilegedPageFlags as PrivFlags},
-        page_table::boot_pt,
-        PAGE_SIZE,
-    },
-    prelude::Paddr,
-};
+use crate::{mm::PAGE_SIZE, prelude::Paddr};
 
 const SHARED_BIT: u8 = 51;
 const SHARED_MASK: u64 = 1u64 << SHARED_BIT;
 
 #[derive(Debug)]
 pub enum PageConvertError {
-    PageTable,
+    InvalidAddress,
     TdCall,
     TdVmcall,
 }
 
 /// Converts physical pages to Intel TDX shared pages.
 ///
-/// This function sets the [`PrivFlags::SHARED`] bit in the linear mapping of physical pages. Then,
-/// it invokes the [`map_gpa`] TDVMCALL to convert those pages into Intel TDX shared pages. Due to
+/// Invokes the [`map_gpa`] TDVMCALL to convert those pages into Intel TDX shared pages. Due to
 /// the conversion, any existing data on the pages will be erased.
 ///
 /// # Safety
 ///
 /// The caller must ensure that:
-///  - The provided physical address is page aligned.
 ///  - The provided physical address range is in bounds, i.e., it should fall within the maximum
 ///    Guest Physical Address (GPA) limit.
-///  - The provided physical address range is part of the linear mapping.
 ///  - All of the physical pages are untyped memory. Therefore, converting and erasing the data
 ///    will not cause memory safety issues.
 pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), PageConvertError> {
     const PAGE_MASK: usize = PAGE_SIZE - 1;
     if gpa & PAGE_MASK != 0 {
-        warn!("Misaligned address: {:x}", gpa);
+        return Err(PageConvertError::InvalidAddress);
     }
 
-    // Protect the page in the boot page table if in the boot phase.
-    let protect_op = |prop: &mut PageProperty| {
-        *prop = PageProperty {
-            flags: prop.flags,
-            cache: prop.cache,
-            priv_flags: prop.priv_flags | PrivFlags::SHARED,
-        }
-    };
-    let _ = boot_pt::with_borrow(|boot_pt| {
-        for i in 0..page_num {
-            let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
-            // SAFETY: The caller ensures that the address range exists in the linear mapping and
-            // can be mapped as shared pages.
-            unsafe { boot_pt.protect_base_page(vaddr, protect_op) };
-        }
-    });
-
-    // Protect the page in the kernel page table.
-    let pt = KERNEL_PAGE_TABLE.get().unwrap();
-    let vaddr = paddr_to_vaddr(gpa);
-    // SAFETY: The caller ensures that the address range exists in the linear mapping and can be
-    // mapped as shared pages.
-    unsafe { pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op) }
-        .map_err(|_| PageConvertError::PageTable)?;
-
+    // FIXME: The `map_gpa` API from the `tdx_guest` crate should have been marked `unsafe`
+    // because it has no way to determine if the input physical address is safe or not.
     map_gpa(
         (gpa & (!PAGE_MASK)) as u64 | SHARED_MASK,
         (page_num * PAGE_SIZE) as u64,
@@ -80,50 +44,28 @@ pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), Pag
 
 /// Converts physical pages to Intel TDX private pages.
 ///
-/// This function clears the [`PrivFlags::SHARED`] bit in the linear mapping of physical pages.
-/// Then, it invokes the [`map_gpa`] TDVMCALL and the [`accept_page`] TDCALL to convert those pages
+/// Invokes the [`map_gpa`] TDVMCALL and the [`accept_page`] TDCALL to convert those pages
 /// into Intel TDX private pages. Due to the conversion, any existing data on the pages will be
 /// erased.
 ///
 /// # Safety
 ///
 /// The caller must ensure that:
-///  - The provided physical address is page aligned.
 ///  - The provided physical address range is in bounds, i.e., it should fall within the maximum
 ///    Guest Physical Address (GPA) limit.
-///  - The provided physical address range is part of the linear mapping.
 ///  - All of the physical pages are untyped memory. Therefore, converting and erasing the data
 ///    will not cause memory safety issues.
 pub unsafe fn protect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), PageConvertError> {
     const PAGE_MASK: usize = PAGE_SIZE - 1;
     if gpa & !PAGE_MASK == 0 {
-        warn!("Misaligned address: {:x}", gpa);
+        return Err(PageConvertError::InvalidAddress);
     }
 
-    // Protect the page in the boot page table if in the boot phase.
-    let protect_op = |prop: &mut PageProperty| {
-        *prop = PageProperty {
-            flags: prop.flags,
-            cache: prop.cache,
-            priv_flags: prop.priv_flags - PrivFlags::SHARED,
-        }
-    };
-    let _ = boot_pt::with_borrow(|boot_pt| {
-        for i in 0..page_num {
-            let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
-            // SAFETY: The caller ensures that the address range exists in the linear mapping and
-            // can be mapped as non-shared pages.
-            unsafe { boot_pt.protect_base_page(vaddr, protect_op) };
-        }
-    });
-
-    // Protect the page in the kernel page table.
-    let pt = KERNEL_PAGE_TABLE.get().unwrap();
-    let vaddr = paddr_to_vaddr(gpa);
-    // SAFETY: The caller ensures that the address range exists in the linear mapping and can be
-    // mapped as non-shared pages.
-    unsafe { pt.protect_flush_tlb(&(vaddr..vaddr + page_num * PAGE_SIZE), protect_op) }
-        .map_err(|_| PageConvertError::PageTable)?;
+    // GPA outside the physical frame range cannot be converted to private pages.
+    // This limitation can be removed when supporting private I/O pages in the future.
+    if gpa + page_num * PAGE_SIZE > crate::mm::frame::max_paddr() {
+        return Err(PageConvertError::InvalidAddress);
+    }
 
     map_gpa((gpa & PAGE_MASK) as u64, (page_num * PAGE_SIZE) as u64)
         .map_err(|_| PageConvertError::TdVmcall)?;

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -60,7 +60,7 @@ use crate::mm::{HasPaddr, HasSize, Paddr, PagingConsts, PagingLevel, Vaddr, PAGE
 static MAX_PADDR: AtomicUsize = AtomicUsize::new(0);
 
 /// Returns the maximum physical address that is tracked by frame metadata.
-pub(in crate::mm) fn max_paddr() -> Paddr {
+pub(crate) fn max_paddr() -> Paddr {
     let max_paddr = MAX_PADDR.load(Ordering::Relaxed) as Paddr;
     debug_assert_ne!(max_paddr, 0);
     max_paddr


### PR DESCRIPTION
Since `IoMem` ranges are not in linear mapping and should be shared, this PR passes actual mapped virtual addresses to `unprotect_gpa_range`, instead of assuming linear mapping.

Key changes:
- Add `gva` parameter to `unprotect_gpa_range()` to accept mapped virtual addresses
- Remove boot page table operations as they're no longer used when invoking `protect_gpa_range` and `unprotect_gpa_range`
- Update all callers (IoApic, DMA coherent, DMA stream, IO memory) to pass 
  the correct virtual addresses
- For linear-mapped memory (USegment), use `paddr_to_vaddr()`
- For IO memory, use the actual `KVirtArea` mapping