### PR TITLE
Introduce NUMA-Aware Frame Allocator

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -11,8 +11,8 @@ inputs:
   release:
     description: 'Whether to run in release mode'
     required: false
-  
-  # Virtualization Settings  
+
+  # Virtualization Settings
   enable_kvm:
     description: 'Enable KVM acceleration'
     required: false
@@ -22,13 +22,16 @@ inputs:
   smp:
     description: 'Number of CPUs'
     required: false
+  numa:
+    description: 'Enable NUMA support'
+    required: false
   netdev:
     description: 'Network device type (user/tap)'
     required: false
   scheme:
     description: 'Test scheme (default/microvm/iommu)'
     required: false
-  
+
   # Test Parameters
   arch:
     description: 'Architecture (x86_64/riscv64/loongarch64)'
@@ -60,7 +63,7 @@ runs:
           echo "RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static" >> $GITHUB_ENV
           echo "RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup" >> $GITHUB_ENV
         fi
-        
+
     - name: Run basic tests
       if: ${{ inputs.auto_test == 'general' }}
       shell: bash
@@ -71,10 +74,10 @@ runs:
         [[ "${{ matrix.id }}" == "usermode_test" ]] && CMD+="make test"
         [[ "${{ matrix.id }}" == "ktest" ]] && CMD+="make ktest NETDEV=tap"
         [[ -n "${{ inputs.arch }}" ]] && CMD+=" OSDK_TARGET_ARCH=${{ inputs.arch }}"
-        
+
         echo "Executing: $CMD"
         eval $CMD
- 
+
     - name: Run integration test
       if: ${{ !(inputs.auto_test == 'general' || inputs.auto_test == 'osdk') }}
       shell: bash
@@ -83,6 +86,7 @@ runs:
         [[ "${{ inputs.intel_tdx }}" == "true" ]] && CMD+=" INTEL_TDX=1"
         [[ "${{ inputs.release }}" == "true" ]] && CMD+=" RELEASE=1"
         [[ "${{ inputs.enable_kvm }}" == "false" ]] && CMD+=" ENABLE_KVM=0"
+        [[ "${{ inputs.numa }}" == "true" ]] && CMD+=" NUMA=true"
         [[ -n "${{ inputs.smp }}" ]] && CMD+=" SMP=${{ inputs.smp }}"
         [[ -n "${{ inputs.netdev }}" ]] && CMD+=" NETDEV=${{ inputs.netdev }}"
         [[ -n "${{ inputs.scheme }}" ]] && CMD+=" SCHEME=${{ inputs.scheme }}"
@@ -91,7 +95,7 @@ runs:
         [[ -n "${{ inputs.syscall_test_suite }}" ]] && CMD+=" SYSCALL_TEST_SUITE=${{ inputs.syscall_test_suite }}"
         [[ -n "${{ inputs.syscall_test_workdir }}" ]] && CMD+=" SYSCALL_TEST_WORKDIR=${{ inputs.syscall_test_workdir }}"
         [[ -n "${{ inputs.boot_protocol }}" ]] && CMD+=" BOOT_PROTOCOL=${{ inputs.boot_protocol }}"
-        
+
         echo "Executing: $CMD"
         eval $CMD
 

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -67,6 +67,11 @@ jobs:
           - test_id: 'syscall-multiboot2-smp4'
             boot_protocol: 'multiboot2'
             smp: 4
+          # NUMA Syscall Test (Multiboot2)
+          - test_id: 'syscall-multiboot2-smp4-numa'
+            boot_protocol: 'multiboot2'
+            smp: 4
+            numa: true
 
           # General Test (Linux EFI Handover) (Debug Build)
           - test_id: 'general-handover64-debug'
@@ -86,6 +91,7 @@ jobs:
               (startsWith(matrix.test_id, 'syscall') && 'syscall') || 'test' }}
           release: ${{ !contains(matrix.release, 'false') }}
           enable_kvm: ${{ !contains(matrix.enable_kvm, 'false') }}
+          numa: ${{ contains(matrix.numa, 'true') }}
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}
@@ -101,6 +107,7 @@ jobs:
               (startsWith(matrix.test_id, 'syscall') && 'syscall') || 'test' }}
           release: ${{ !contains(matrix.release, 'false') }}
           enable_kvm: ${{ !contains(matrix.enable_kvm, 'false') }}
+          numa: ${{ contains(matrix.numa, 'true') }}
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "ostd-macros",
  "ostd-pod",
  "ostd-test",
+ "paste",
  "riscv",
  "sbi-rt",
  "smallvec",

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ RELEASE_LTO ?= 0
 LOG_LEVEL ?= error
 SCHEME ?= ""
 SMP ?= 1
+NUMA ?= false
 OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
 FEATURES ?=
 NO_DEFAULT_FEATURES ?= 0
@@ -139,6 +140,10 @@ endif
 
 ifeq ($(COVERAGE), 1)
 CARGO_OSDK_COMMON_ARGS += --coverage
+endif
+
+ifeq ($(NUMA), true)
+override FEATURES := $(FEATURES) numa
 endif
 
 ifdef FEATURES

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -80,6 +80,7 @@ cvm_guest = ["dep:tdx-guest", "ostd/cvm_guest", "aster-virtio/cvm_guest"]
 coverage = ["ostd/coverage"]
 # By default we use the Sv48 address translation mode.
 riscv_sv39_mode = ["ostd/riscv_sv39_mode"]
+numa = ["ostd/numa"]
 
 [lints]
 workspace = true

--- a/osdk/deps/frame-allocator/src/lib.rs
+++ b/osdk/deps/frame-allocator/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 #![deny(unsafe_code)]
+#![feature(let_chains)]
 
 //! An implementation of the global physical memory frame allocator for
 //! [OSTD](https://crates.io/crates/ostd) based kernels.
@@ -34,6 +35,7 @@ use ostd::{
     cpu::PinCurrentCpu,
     irq,
     mm::{frame::GlobalFrameAllocator, Paddr},
+    numa::NodeId,
 };
 
 mod cache;
@@ -72,10 +74,10 @@ impl GlobalFrameAllocator for FrameAllocator {
         res
     }
 
-    fn dealloc(&self, addr: Paddr, size: usize) {
+    fn dealloc(&self, addr: Paddr, size: usize, node_id: NodeId) {
         let guard = irq::disable_local();
         TOTAL_FREE_SIZE.add(guard.current_cpu(), size);
-        cache::dealloc(&guard, addr, size);
+        cache::dealloc(&guard, addr, size, node_id);
     }
 
     fn add_free_memory(&self, addr: Paddr, size: usize) {

--- a/osdk/deps/frame-allocator/src/pools/mod.rs
+++ b/osdk/deps/frame-allocator/src/pools/mod.rs
@@ -5,14 +5,17 @@ mod balancing;
 use core::{
     alloc::Layout,
     cell::RefCell,
-    ops::DerefMut,
+    ops::{DerefMut, Drop, Range},
     sync::atomic::{AtomicUsize, Ordering},
 };
 
 use ostd::{
+    cpu::{CpuId, PinCurrentCpu},
     cpu_local,
     irq::DisabledLocalIrqGuard,
+    leader_cpu_local,
     mm::Paddr,
+    numa::{leader_cpu_of, leader_cpu_of_node, memory_ranges, num_cpus_in_node, NodeId},
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
 };
 
@@ -20,14 +23,16 @@ use crate::chunk::{greater_order_of, lesser_order_of, size_of_order, split_to_ch
 
 use super::set::BuddySet;
 
-/// The global free buddies.
-static GLOBAL_POOL: SpinLock<BuddySet<MAX_BUDDY_ORDER>, LocalIrqDisabled> =
-    SpinLock::new(BuddySet::new_empty());
-/// A snapshot of the total size of the global free buddies, not precise.
-static GLOBAL_POOL_SIZE: AtomicUsize = AtomicUsize::new(0);
+// The NUMA node pools.
+leader_cpu_local! {
+    /// Free buddies in the NUMA node of the leader CPU.
+    static NODE_POOL: SpinLock<BuddySet<MAX_BUDDY_ORDER>, LocalIrqDisabled> = SpinLock::new(BuddySet::new_empty());
+    /// A snapshot of the total size of the free buddies in the NUMA node of the leader CPU, not precise.
+    static NODE_POOL_SIZE: AtomicUsize = AtomicUsize::new(0);
+}
 
-// CPU-local free buddies.
 cpu_local! {
+    /// CPU-local free buddies.
     static LOCAL_POOL: RefCell<BuddySet<MAX_LOCAL_BUDDY_ORDER>> = RefCell::new(BuddySet::new_empty());
 }
 
@@ -51,10 +56,11 @@ const MAX_BUDDY_ORDER: BuddyOrder = 32;
 /// chunks.
 const MAX_LOCAL_BUDDY_ORDER: BuddyOrder = 18;
 
+/// Allocates frames from the pools of the local NUMA node.
 pub(super) fn alloc(guard: &DisabledLocalIrqGuard, layout: Layout) -> Option<Paddr> {
     let local_pool_cell = LOCAL_POOL.get_with(guard);
     let mut local_pool = local_pool_cell.borrow_mut();
-    let mut global_pool = OnDemandGlobalLock::new();
+    let mut node_pool = OnDemandNodeLock::new(leader_cpu_of(guard.current_cpu()));
 
     let size_order = greater_order_of(layout.size());
     let align_order = greater_order_of(layout.align());
@@ -66,107 +72,178 @@ pub(super) fn alloc(guard: &DisabledLocalIrqGuard, layout: Layout) -> Option<Pad
         chunk_addr = local_pool.alloc_chunk(order);
     }
 
-    // Fall back to the global free lists if the local free lists are empty.
+    // Fall back to the NUMA node's free lists if the local free lists are empty.
     if chunk_addr.is_none() {
-        chunk_addr = global_pool.get().alloc_chunk(order);
+        chunk_addr = node_pool.get().alloc_chunk(order);
     }
-    // TODO: On memory pressure the global pool may be not enough. We may need
-    // to merge all buddy chunks from the local pools to the global pool and
+
+    // TODO: On memory pressure the NUMA node pool may be not enough. We may need
+    // to merge all buddy chunks from the local pools to the NUMA node pool and
     // try again.
+
+    // FIXME: Fall back to the other NUMA node's free lists if the current NUMA node's
+    // free lists are empty.
+
+    // TODO: On memory pressure all the NUMA node pools may be not enough. We may need
+    // to alloc across NUMA nodes.
 
     // If the alignment order is larger than the size order, we need to split
     // the chunk and return the rest part back to the free lists.
     let allocated_size = size_of_order(order);
-    if allocated_size > layout.size() {
-        if let Some(chunk_addr) = chunk_addr {
-            do_dealloc(
-                &mut local_pool,
-                &mut global_pool,
-                [(chunk_addr + layout.size(), allocated_size - layout.size())].into_iter(),
-            );
-        }
+    if allocated_size > layout.size()
+        && let Some(chunk_addr) = chunk_addr
+    {
+        do_dealloc(
+            Some(&mut local_pool),
+            &mut node_pool,
+            [(chunk_addr + layout.size(), allocated_size - layout.size())].into_iter(),
+        );
     }
 
-    balancing::balance(local_pool.deref_mut(), &mut global_pool);
+    balancing::balance(local_pool.deref_mut(), &mut node_pool);
 
     chunk_addr
 }
 
-pub(super) fn dealloc(
+/// Deallocates frames to the pools of the local NUMA node.
+pub(super) fn dealloc_to_local(
     guard: &DisabledLocalIrqGuard,
     segments: impl Iterator<Item = (Paddr, usize)>,
 ) {
     let local_pool_cell = LOCAL_POOL.get_with(guard);
     let mut local_pool = local_pool_cell.borrow_mut();
-    let mut global_pool = OnDemandGlobalLock::new();
+    let mut node_pool = OnDemandNodeLock::new(leader_cpu_of(guard.current_cpu()));
 
-    do_dealloc(&mut local_pool, &mut global_pool, segments);
+    do_dealloc(Some(&mut local_pool), &mut node_pool, segments);
 
-    balancing::balance(local_pool.deref_mut(), &mut global_pool);
+    balancing::balance(local_pool.deref_mut(), &mut node_pool);
+}
+
+/// Deallocates one frame to the pools of a remote NUMA node.
+pub(super) fn dealloc_to_remote(segments: impl Iterator<Item = (Paddr, usize)>, node_id: NodeId) {
+    let mut node_pool = OnDemandNodeLock::new(leader_cpu_of_node(node_id));
+
+    do_dealloc(None, &mut node_pool, segments);
 }
 
 pub(super) fn add_free_memory(_guard: &DisabledLocalIrqGuard, addr: Paddr, size: usize) {
-    let mut global_pool = OnDemandGlobalLock::new();
+    if size == 0 {
+        return;
+    }
+    let mut free_memory = addr..addr + size;
 
-    split_to_chunks(addr, size).for_each(|(addr, order)| {
-        global_pool.get().insert_chunk(addr, order);
-    });
+    let add_free_memory_to_node = |range: &Range<usize>, node_id: NodeId| {
+        let mut node_pool = OnDemandNodeLock::new(leader_cpu_of_node(node_id));
+
+        split_to_chunks(range.start, range.end - range.start).for_each(|(addr, order)| {
+            node_pool.get().insert_chunk(addr, order);
+        });
+    };
+
+    for mem_range in memory_ranges()
+        .iter()
+        .filter(|mem_range| mem_range.is_enabled && mem_range.proximity_domain.is_some())
+    {
+        let range =
+            mem_range.base_address as usize..(mem_range.base_address + mem_range.length) as usize;
+        if range.start >= free_memory.end {
+            break;
+        }
+        if range.end <= free_memory.start {
+            continue;
+        }
+
+        // If the free memory does not belong to any NUMA node, assign it to
+        // the default NUMA node (node 0).
+        if free_memory.start < range.start {
+            let non_overlap = free_memory.start..range.start.min(free_memory.end);
+            add_free_memory_to_node(&non_overlap, NodeId::new(0));
+            free_memory.start = non_overlap.end;
+            if free_memory.is_empty() {
+                break;
+            }
+        }
+
+        let overlap = free_memory.start.max(range.start)..free_memory.end.min(range.end);
+        let node_id = NodeId::new(mem_range.proximity_domain.unwrap());
+        add_free_memory_to_node(&overlap, node_id);
+        free_memory.start = overlap.end;
+        if free_memory.is_empty() {
+            break;
+        }
+    }
+
+    if !free_memory.is_empty() {
+        add_free_memory_to_node(&free_memory, NodeId::new(0));
+    }
 }
 
 fn do_dealloc(
-    local_pool: &mut BuddySet<MAX_LOCAL_BUDDY_ORDER>,
-    global_pool: &mut OnDemandGlobalLock,
+    mut local_pool: Option<&mut BuddySet<MAX_LOCAL_BUDDY_ORDER>>,
+    node_pool: &mut OnDemandNodeLock,
     segments: impl Iterator<Item = (Paddr, usize)>,
 ) {
     segments.for_each(|(addr, size)| {
         split_to_chunks(addr, size).for_each(|(addr, order)| {
-            if order >= MAX_LOCAL_BUDDY_ORDER {
-                global_pool.get().insert_chunk(addr, order);
-            } else {
+            if order < MAX_LOCAL_BUDDY_ORDER
+                && let Some(local_pool) = local_pool.as_mut()
+            {
                 local_pool.insert_chunk(addr, order);
+            } else {
+                node_pool.get().insert_chunk(addr, order);
             }
         });
     });
 }
 
-type GlobalLockGuard = SpinLockGuard<'static, BuddySet<MAX_BUDDY_ORDER>, LocalIrqDisabled>;
+type NodeLockGuard = SpinLockGuard<'static, BuddySet<MAX_BUDDY_ORDER>, LocalIrqDisabled>;
 
-/// An on-demand guard that locks the global pool when needed.
+/// An on-demand guard that locks the NUMA node pool when needed.
 ///
-/// It helps to avoid unnecessarily locking the global pool, and also avoids
-/// repeatedly locking the global pool when it is needed multiple times.
-struct OnDemandGlobalLock {
-    guard: Option<GlobalLockGuard>,
+/// It helps to avoid unnecessarily locking the node pool, and also avoids
+/// repeatedly locking the node pool when it is needed multiple times.
+struct OnDemandNodeLock {
+    leader_cpu: CpuId,
+    guard: Option<NodeLockGuard>,
 }
 
-impl OnDemandGlobalLock {
-    fn new() -> Self {
-        Self { guard: None }
+impl OnDemandNodeLock {
+    fn new(leader_cpu: CpuId) -> Self {
+        Self {
+            leader_cpu,
+            guard: None,
+        }
     }
 
-    fn get(&mut self) -> &mut GlobalLockGuard {
-        self.guard.get_or_insert_with(|| GLOBAL_POOL.lock())
+    fn get(&mut self) -> &mut NodeLockGuard {
+        self.guard
+            .get_or_insert_with(|| node_pool(self.leader_cpu).lock())
     }
 
-    /// Returns the size of the global pool.
+    /// Returns the size of the NUMA node pool.
     ///
-    /// If the global pool is locked, returns the actual size of the global pool.
-    /// Otherwise, returns the last snapshot of the global pool size by loading
-    /// [`GLOBAL_POOL_SIZE`].
-    fn get_global_size(&self) -> usize {
+    /// If the node pool is locked, returns the actual size of the node pool.
+    /// Otherwise, returns the last snapshot of the node pool size by loading
+    /// [`NODE_POOL_SIZE`].
+    fn get_node_size(&self) -> usize {
         if let Some(guard) = self.guard.as_ref() {
             guard.total_size()
         } else {
-            GLOBAL_POOL_SIZE.load(Ordering::Relaxed)
+            node_pool_size(self.leader_cpu).load(Ordering::Relaxed)
         }
+    }
+
+    /// Returns the number of CPUs in the NUMA node of the leader CPU.
+    fn get_num_cpus_in_node(&self) -> usize {
+        *num_cpus_in_node(self.leader_cpu).get().unwrap()
     }
 }
 
-impl Drop for OnDemandGlobalLock {
+impl Drop for OnDemandNodeLock {
     fn drop(&mut self) {
-        // Updates [`GLOBAL_POOL_SIZE`] if the global pool is locked.
+        // Updates the [`NODE_POOL_SIZE`] if the node pool is locked.
         if let Some(guard) = self.guard.as_ref() {
-            GLOBAL_POOL_SIZE.store(guard.total_size(), Ordering::Relaxed);
+            node_pool_size(self.leader_cpu).store(guard.total_size(), Ordering::Relaxed);
         }
     }
 }

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -35,6 +35,7 @@ spin = "0.9.4"
 smallvec = "1.13.2"
 volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
+paste = "1.0"
 
 minicov = { version = "0.3", optional = true }
 

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -76,6 +76,7 @@ default = ["cvm_guest"]
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
 coverage = ["minicov"]
 riscv_sv39_mode = []
+numa = []
 
 [lints]
 workspace = true

--- a/ostd/src/arch/x86/boot/mod.rs
+++ b/ostd/src/arch/x86/boot/mod.rs
@@ -22,6 +22,7 @@ mod linux_boot;
 mod multiboot;
 mod multiboot2;
 
+pub(crate) mod numa;
 pub(crate) mod smp;
 
 use core::arch::global_asm;

--- a/ostd/src/arch/x86/boot/numa.rs
+++ b/ostd/src/arch/x86/boot/numa.rs
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NUMA(Non Uniform Memory Access) boot support.
+
+use core::{
+    alloc::Layout,
+    marker::{PhantomData, PhantomPinned},
+    mem,
+    pin::Pin,
+};
+
+use acpi::{
+    sdt::{SdtHeader, Signature},
+    AcpiTable,
+};
+use bitflags::bitflags;
+use spin::Once;
+
+use crate::{
+    arch::kernel::acpi::get_acpi_tables,
+    cpu::CpuId,
+    mm::{frame::allocator, paddr_to_vaddr},
+};
+
+/// The processor affinity information for all CPUs.
+pub(crate) static PROCESSOR_AFFINITIES: Once<&'static [ProcessorAffinity]> = Once::new();
+/// The memory ranges associated with different proximity domains.
+pub(crate) static MEMORY_RANGES: Once<&'static [MemoryRange]> = Once::new();
+/// The NUMA distance matrix representing relative locality distances.
+pub(crate) static DISTANCE_MATRIX: Once<&'static [u8]> = Once::new();
+
+/// Initialize the NUMA topology, and returns the number of NUMA nodes, along with
+/// a `[CpuId; num_nodes()]` array to store the leader cpu of each NUMA node.
+pub(crate) fn init_numa_topology() -> (usize, &'static mut [CpuId]) {
+    let (num_nodes, processor_affinities, memory_ranges) =
+        parse_srat_table().unwrap_or((1, &mut [], &mut []));
+    PROCESSOR_AFFINITIES.call_once(|| processor_affinities);
+    MEMORY_RANGES.call_once(|| memory_ranges);
+
+    let (num_nodes, (distance_matrix, leader_cpu)) = parse_slit_table(num_nodes);
+    DISTANCE_MATRIX.call_once(|| distance_matrix);
+
+    (num_nodes, leader_cpu)
+}
+
+/// Default distance within the same NUMA node, if not specified by SLIT.
+const DEFAULT_LOCAL_DISTANCE: u8 = 10;
+/// Default distance between different NUMA nodes, if not specified by SLIT.
+const DEFAULT_REMOTE_DISTANCE: u8 = 20;
+
+/// Parses the SRAT table and returns the number of NUMA nodes, along with
+/// initialized processor affinity and memory range arrays.
+///
+/// Returns `None` if the SRAT table is missing.
+fn parse_srat_table() -> Option<(
+    usize,
+    &'static mut [ProcessorAffinity],
+    &'static mut [MemoryRange],
+)> {
+    let acpi_tables = get_acpi_tables()?;
+    let srat_table = acpi_tables.find_table::<Srat>().ok()?;
+
+    if srat_table
+        .get()
+        .entries()
+        .any(|e| matches!(e, SratEntry::Gicc(_) | SratEntry::GicIts(_)))
+    {
+        unimplemented!("ARM SRAT entries are not supported");
+    }
+
+    let mut processor_count = 0;
+    let mut memory_range_count = 0;
+    let mut num_nodes = 0;
+
+    for entry in srat_table.get().entries() {
+        match entry {
+            SratEntry::LocalApic(_) | SratEntry::LocalX2Apic(_) => processor_count += 1,
+            SratEntry::Memory(_) => memory_range_count += 1,
+            _ => (),
+        }
+    }
+
+    // Allocate a region to store the information of processor affinities and memory ranges.
+    let (processor_affinities, memory_ranges) = {
+        let (layout, processor_affinities_offset, memory_ranges_offset) = {
+            let processor_affinities_layout =
+                Layout::array::<ProcessorAffinity>(processor_count).unwrap();
+            let memory_ranges_layout = Layout::array::<MemoryRange>(memory_range_count).unwrap();
+            let (layout, memory_ranges_offset) = processor_affinities_layout
+                .extend(memory_ranges_layout)
+                .unwrap();
+            (layout, 0usize, memory_ranges_offset)
+        };
+
+        let paddr = allocator::early_alloc(layout).unwrap();
+        let addr = paddr_to_vaddr(paddr);
+        let processor_affinities_ptr =
+            (addr + processor_affinities_offset) as *mut ProcessorAffinity;
+        let memory_ranges_ptr = (addr + memory_ranges_offset) as *mut MemoryRange;
+
+        // SAFETY: The memory is properly allocated. We exclusively own it. So it's valid to write.
+        unsafe {
+            for i in 0..processor_count {
+                processor_affinities_ptr.add(i).write(ProcessorAffinity {
+                    local_apic_id: 0,
+                    proximity_domain: 0,
+                    is_enabled: false,
+                })
+            }
+            for i in 0..memory_range_count {
+                memory_ranges_ptr.add(i).write(MemoryRange {
+                    base_address: 0,
+                    length: 0,
+                    proximity_domain: None,
+                    hot_pluggable: false,
+                    non_volatile: false,
+                    is_enabled: false,
+                });
+            }
+        }
+
+        // SAFETY: The memory is properly allocated and initialized. We exclusively own it. We
+        // never deallocate it so it lives for `'static`. So we can create a mutable slice on it.
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(processor_affinities_ptr, processor_count),
+                core::slice::from_raw_parts_mut(memory_ranges_ptr, memory_range_count),
+            )
+        }
+    };
+
+    processor_count = 0;
+    memory_range_count = 0;
+
+    for entry in srat_table.get().entries() {
+        match entry {
+            SratEntry::LocalApic(entry) => {
+                let local_apic_id = entry.apic_id as u32;
+                let mut proximity_domain = entry.proximity_domain_low as u32;
+                for i in 0..3 {
+                    let shift = 8 * (3 - i);
+                    proximity_domain += (entry.proximity_domain_high[i] as u32) << shift;
+                }
+                let flags = entry.flags;
+                let is_enabled = flags.contains(LocalApicAffinityFlags::ENABLED);
+                let processor_affinity = ProcessorAffinity {
+                    local_apic_id,
+                    proximity_domain,
+                    is_enabled,
+                };
+                processor_affinities[processor_count] = processor_affinity;
+                processor_count += 1;
+                num_nodes = num_nodes.max((proximity_domain + 1) as usize);
+            }
+            SratEntry::LocalX2Apic(entry) => {
+                let local_apic_id = entry.x2apic_id;
+                let proximity_domain = entry.proximity_domain;
+                let flags = entry.flags;
+                let is_enabled = flags.contains(LocalX2ApicAffinityFlags::ENABLED);
+                let processor_affinity = ProcessorAffinity {
+                    local_apic_id,
+                    proximity_domain,
+                    is_enabled,
+                };
+                processor_affinities[processor_count] = processor_affinity;
+                processor_count += 1;
+                num_nodes = num_nodes.max((proximity_domain + 1) as usize);
+            }
+            SratEntry::Memory(entry) => {
+                let flags = entry.flags;
+                let base_address =
+                    entry.base_address_low as u64 + ((entry.base_address_high as u64) << 32);
+                let length = entry.length_low as u64 + ((entry.length_high as u64) << 32);
+                let proximity_domain = Some(entry.proximity_domain);
+                let hot_pluggable = flags.contains(MemoryAffinityFlags::HOT_PLUGGABLE);
+                let non_volatile = flags.contains(MemoryAffinityFlags::NON_VOLATILE);
+                let is_enabled = flags.contains(MemoryAffinityFlags::ENABLED);
+                let memory_range = MemoryRange {
+                    base_address,
+                    length,
+                    proximity_domain,
+                    hot_pluggable,
+                    non_volatile,
+                    is_enabled,
+                };
+                memory_ranges[memory_range_count] = memory_range;
+                memory_range_count += 1;
+                num_nodes = num_nodes.max((entry.proximity_domain + 1) as usize);
+            }
+            // TODO: parse information of generic initiators
+            SratEntry::GenericInitiator(_) => {}
+            _ => {}
+        }
+    }
+
+    // Sort the memory ranges by their base address.
+    memory_ranges.sort_by_key(|memory_range| memory_range.base_address);
+
+    // Remove overlapping memory ranges.
+    let mut max_end = 0;
+
+    for range in memory_ranges.iter_mut() {
+        if range.base_address < max_end {
+            log::warn!("Overlapping memory range detected: {:?}", range);
+            let overlap = max_end - range.base_address;
+            if overlap >= range.length {
+                range.length = 0;
+                range.is_enabled = false;
+            } else {
+                range.base_address += overlap;
+                range.length -= overlap;
+            }
+        }
+        let range_end = range.base_address.saturating_add(range.length);
+        range.length = range_end - range.base_address;
+        max_end = max_end.max(range_end);
+    }
+
+    Some((num_nodes, processor_affinities, memory_ranges))
+}
+
+/// Parses the SLIT table and returns the total number of NUMA nodes, along with the
+/// initialized NUMA distance matrix, and a `[CpuId; num_nodes()]` array to store the
+/// leader cpu of each NUMA node.
+///
+/// Falls back to default values if the SLIT table is missing.
+fn parse_slit_table(num_nodes: usize) -> (usize, (&'static mut [u8], &'static mut [CpuId])) {
+    let acpi_tables = get_acpi_tables().unwrap();
+    let Some(slit_table) = acpi_tables.find_table::<Slit>().ok() else {
+        return (num_nodes, default_distance_matrix(num_nodes));
+    };
+
+    let nr_system_localities = slit_table.get().nr_system_localities as usize;
+    let num_nodes = num_nodes.max(nr_system_localities);
+    let (distance_matrix, leader_cpu) = default_distance_matrix(num_nodes);
+
+    for (idx, entry) in slit_table.get().entries().enumerate() {
+        let (i, j) = (idx / nr_system_localities, idx % nr_system_localities);
+        distance_matrix[i * num_nodes + j] = entry;
+    }
+
+    (num_nodes, (distance_matrix, leader_cpu))
+}
+
+/// Allocates and initializes a default NUMA distance matrix, along with a
+/// `[CpuId; num_nodes()]` array to store the leader cpu of each NUMA node.
+fn default_distance_matrix(num_nodes: usize) -> (&'static mut [u8], &'static mut [CpuId]) {
+    let distance_count = num_nodes.checked_mul(num_nodes).unwrap();
+
+    // Allocate a region to store the distance matrix.
+    let (distance_matrix, leader_cpu) = {
+        let (layout, distance_matrix_offset, leader_cpu_offset) = {
+            let distance_matrix_layout = Layout::array::<u8>(distance_count).unwrap();
+            let leader_cpu_layout = Layout::array::<CpuId>(num_nodes).unwrap();
+            let (layout, leader_cpu_offset) =
+                distance_matrix_layout.extend(leader_cpu_layout).unwrap();
+            (layout, 0usize, leader_cpu_offset)
+        };
+
+        let paddr = allocator::early_alloc(layout).unwrap();
+        let addr = paddr_to_vaddr(paddr);
+        let distance_matrix_ptr = (addr + distance_matrix_offset) as *mut u8;
+        let leader_cpu_ptr = (addr + leader_cpu_offset) as *mut CpuId;
+
+        // SAFETY: The memory is properly allocated. We exclusively own it. So it's valid to write.
+        unsafe {
+            core::ptr::write_bytes(distance_matrix_ptr, 0, distance_count);
+            for i in 0..num_nodes {
+                leader_cpu_ptr.add(i).write(CpuId::bsp());
+            }
+        }
+
+        // SAFETY: The memory is properly allocated and initialized. We exclusively own it. We
+        // never deallocate it so it lives for `'static`. So we can create a mutable slice on it.
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(distance_matrix_ptr, distance_count),
+                core::slice::from_raw_parts_mut(leader_cpu_ptr, num_nodes),
+            )
+        }
+    };
+
+    for i in 0..num_nodes {
+        for j in 0..num_nodes {
+            distance_matrix[i * num_nodes + j] = if i == j {
+                DEFAULT_LOCAL_DISTANCE
+            } else {
+                DEFAULT_REMOTE_DISTANCE
+            };
+        }
+    }
+
+    (distance_matrix, leader_cpu)
+}
+
+// TODO: Switch to the official `acpi` crate API once the PRs
+// <https://github.com/rust-osdev/acpi/pull/241> and
+// <https://github.com/rust-osdev/acpi/pull/243> are merged.
+
+// *********** SRAT structures START ***********
+
+/// System Resource Affinity Table (SRAT).
+///
+/// This optional table provides information that allows OSPM to associate the following types of
+/// devices with system locality / proximity domains and clock domains:
+/// - processors,
+/// - memory ranges (including those provided by hot-added memory devices), and
+/// - generic initiators (e.g. heterogeneous processors and accelerators, GPUs, and I/O devices
+///   with integrated compute or DMA engines).
+#[repr(C, packed)]
+struct Srat {
+    header: SdtHeader,
+    _reserved_1: u32,
+    _reserved_2: u64,
+    _pinned: PhantomPinned,
+}
+
+/// ### Safety: Implementation properly represents a valid SRAT.
+unsafe impl AcpiTable for Srat {
+    const SIGNATURE: Signature = Signature::SRAT;
+
+    fn header(&self) -> &SdtHeader {
+        &self.header
+    }
+}
+
+impl Srat {
+    fn entries(self: Pin<&Self>) -> SratEntryIter {
+        let ptr = unsafe { Pin::into_inner_unchecked(self) as *const Srat as *const u8 };
+        SratEntryIter {
+            pointer: unsafe { ptr.add(mem::size_of::<Srat>()) },
+            remaining_length: self.header.length - mem::size_of::<Srat>() as u32,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+struct SratEntryIter<'a> {
+    pointer: *const u8,
+    remaining_length: u32,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> Iterator for SratEntryIter<'a> {
+    type Item = SratEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length > 0 {
+            let entry_pointer = self.pointer;
+            let entry_header = unsafe { *(self.pointer as *const AffinityEntryHeader) };
+
+            self.pointer = unsafe { self.pointer.offset(entry_header.length as isize) };
+            self.remaining_length -= entry_header.length as u32;
+
+            match entry_header.r#type {
+                AffinityEntryType::LocalApic => Some(SratEntry::LocalApic(unsafe {
+                    &*(entry_pointer as *const LocalApicAffinityEntry)
+                })),
+                AffinityEntryType::Memory => Some(SratEntry::Memory(unsafe {
+                    &*(entry_pointer as *const MemoryAffinityEntry)
+                })),
+                AffinityEntryType::LocalX2Apic => Some(SratEntry::LocalX2Apic(unsafe {
+                    &*(entry_pointer as *const LocalX2ApicAffinityEntry)
+                })),
+                AffinityEntryType::Gicc => Some(SratEntry::Gicc(unsafe {
+                    &*(entry_pointer as *const GiccAffinityEntry)
+                })),
+                AffinityEntryType::GicIts => Some(SratEntry::GicIts(unsafe {
+                    &*(entry_pointer as *const GicItsAffinityEntry)
+                })),
+                AffinityEntryType::GenericInitiator => Some(SratEntry::GenericInitiator(unsafe {
+                    &*(entry_pointer as *const GenericInitiatorAffinityEntry)
+                })),
+            }
+        } else {
+            None
+        }
+    }
+}
+
+enum SratEntry<'a> {
+    LocalApic(&'a LocalApicAffinityEntry),
+    Memory(&'a MemoryAffinityEntry),
+    LocalX2Apic(&'a LocalX2ApicAffinityEntry),
+    // TODO: remove the attributes after we can parse these entries.
+    #[expect(unused)]
+    Gicc(&'a GiccAffinityEntry),
+    #[expect(unused)]
+    GicIts(&'a GicItsAffinityEntry),
+    #[expect(unused)]
+    GenericInitiator(&'a GenericInitiatorAffinityEntry),
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct AffinityEntryHeader {
+    r#type: AffinityEntryType,
+    length: u8,
+}
+
+#[expect(unused)]
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum AffinityEntryType {
+    LocalApic = 0,
+    Memory = 1,
+    LocalX2Apic = 2,
+    Gicc = 3,
+    GicIts = 4,
+    GenericInitiator = 5,
+}
+
+#[repr(C, packed)]
+struct LocalApicAffinityEntry {
+    header: AffinityEntryHeader,
+    proximity_domain_low: u8,
+    apic_id: u8,
+    flags: LocalApicAffinityFlags,
+    local_sapic_eid: u8,
+    proximity_domain_high: [u8; 3],
+    clock_domain: u32,
+}
+
+bitflags! {
+    struct LocalApicAffinityFlags: u32 {
+        const ENABLED = 1;
+    }
+}
+
+#[repr(C, packed)]
+struct MemoryAffinityEntry {
+    header: AffinityEntryHeader,
+    proximity_domain: u32,
+    _reserved_1: u16,
+    base_address_low: u32,
+    base_address_high: u32,
+    length_low: u32,
+    length_high: u32,
+    _reserved_2: u32,
+    flags: MemoryAffinityFlags,
+    _reserved_3: u64,
+}
+
+bitflags! {
+    struct MemoryAffinityFlags: u32 {
+        const ENABLED = 1;
+        const HOT_PLUGGABLE = 1 << 1;
+        const NON_VOLATILE = 1 << 2;
+    }
+}
+
+#[repr(C, packed)]
+struct LocalX2ApicAffinityEntry {
+    header: AffinityEntryHeader,
+    _reserved_1: u16,
+    proximity_domain: u32,
+    x2apic_id: u32,
+    flags: LocalX2ApicAffinityFlags,
+    clock_domain: u32,
+    _reserved_2: u32,
+}
+
+type LocalX2ApicAffinityFlags = LocalApicAffinityFlags;
+
+#[repr(C, packed)]
+struct GiccAffinityEntry {
+    header: AffinityEntryHeader,
+    proximity_domain: u32,
+    acpi_processor_uid: u32,
+    flags: GiccAffinityFlags,
+    clock_domain: u32,
+}
+
+type GiccAffinityFlags = LocalApicAffinityFlags;
+
+#[repr(C, packed)]
+struct GicItsAffinityEntry {
+    header: AffinityEntryHeader,
+    proximity_domain: u32,
+    _reserved: u16,
+    its_id: u32,
+}
+
+#[repr(C, packed)]
+struct GenericInitiatorAffinityEntry {
+    header: AffinityEntryHeader,
+    _reserved_1: u8,
+    device_handle_type: DeviceHandleType,
+    proximity_domain: u32,
+    device_handle: DeviceHandle,
+    flags: GenericInitiatorAffinityFlags,
+    _reserved_2: u32,
+}
+
+#[expect(unused)]
+#[repr(u8)]
+#[non_exhaustive]
+enum DeviceHandleType {
+    Acpi = 0,
+    Pci = 1,
+}
+
+// TODO: remove this attribute after we can parse generic initiator affinity entry.
+#[expect(unused)]
+#[repr(C)]
+enum DeviceHandle {
+    Acpi(AcpiDeviceHandle),
+    Pci(PciDeviceHandle),
+}
+
+#[repr(C, packed)]
+struct AcpiDeviceHandle {
+    acpi_hid: u64,
+    acpi_uid: u32,
+    _reserved: u32,
+}
+
+#[repr(C, packed)]
+struct PciDeviceHandle {
+    pci_segment: u16,
+    pci_bdf_number: u16,
+    _reserved: [u32; 3],
+}
+
+bitflags! {
+    struct GenericInitiatorAffinityFlags: u32 {
+        const ENABLED = 1;
+        const ARCHITECTURAL_TRANSACTIONS = 1 << 1;
+    }
+}
+
+/// Processor affinity information.
+#[derive(Debug, Clone)]
+pub struct ProcessorAffinity {
+    /// The processor's APIC ID.
+    pub local_apic_id: u32,
+    /// The processor's proximity domain (NUMA node) ID.
+    pub proximity_domain: u32,
+    /// Whether the processor is enabled.
+    pub is_enabled: bool,
+}
+
+/// Memory range affinity information.
+#[derive(Debug, Clone)]
+pub struct MemoryRange {
+    /// The starting physical address.
+    pub base_address: u64,
+    /// The size in bytes.
+    pub length: u64,
+    /// The NUMA proximity domain (node).
+    pub proximity_domain: Option<u32>,
+    /// Whether the memory range supports hot-plugging.
+    pub hot_pluggable: bool,
+    /// Whether the memory range is non-volatile.
+    pub non_volatile: bool,
+    /// Whether the memory range is enabled.
+    pub is_enabled: bool,
+}
+
+// ************ SRAT structures END ************
+
+// *********** SLIT structures START ***********
+
+/// System Locality Information Table (SLIT)
+///
+/// This optional table provides a matrix that describes the relative distance
+/// (memory latency) between all System Localities, which are also referred to
+/// as Proximity Domains. The value of each Entry[i,j] in the SLIT table, where
+/// i represents a row of a matrix and j represents a column of a matrix,
+/// indicates the relative distances from System Locality / Proximity Domain i
+/// to every other System Locality j in the system (including itself).
+#[repr(C, packed)]
+pub struct Slit {
+    header: SdtHeader,
+    nr_system_localities: u64,
+    _pinned: PhantomPinned,
+}
+
+unsafe impl AcpiTable for Slit {
+    const SIGNATURE: Signature = Signature::SLIT;
+
+    fn header(&self) -> &SdtHeader {
+        &self.header
+    }
+}
+
+impl Slit {
+    fn entries(self: Pin<&Self>) -> SlitEntryIter {
+        let ptr = unsafe { Pin::into_inner_unchecked(self) as *const Slit as *const u8 };
+        SlitEntryIter {
+            pointer: unsafe { ptr.add(size_of::<Slit>()) },
+            remaining_length: self.header.length - size_of::<Slit>() as u32,
+        }
+    }
+}
+
+struct SlitEntryIter {
+    pointer: *const u8,
+    remaining_length: u32,
+}
+
+impl Iterator for SlitEntryIter {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length > 0 {
+            let entry_pointer = self.pointer;
+            let size_of_item = size_of::<Self::Item>();
+            self.pointer = unsafe { self.pointer.add(size_of_item) };
+            self.remaining_length -= size_of_item as u32;
+            Some(unsafe { *entry_pointer })
+        } else {
+            None
+        }
+    }
+}
+
+// ************ SLIT structures END ************

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -223,7 +223,7 @@ pub(crate) unsafe fn copy_bsp_for_ap(num_cpus: usize) {
             core::ptr::write_bytes(ptr as *mut u8, 0, size);
         }
         // SAFETY: The memory is properly allocated and initialized. We exclusively own it. We
-        // never deallocate it so it lives for '`static'. So we can create a mutable slice on it.
+        // never deallocate it so it lives for `'static`. So we can create a mutable slice on it.
         unsafe { core::slice::from_raw_parts_mut(ptr, num_aps) }
     };
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -37,6 +37,7 @@ pub mod io;
 pub mod irq;
 pub mod logger;
 pub mod mm;
+pub mod numa;
 pub mod panic;
 pub mod prelude;
 pub mod smp;
@@ -93,6 +94,8 @@ unsafe fn init() {
     //  2. The number of CPUs are available because ACPI has been initialized.
     //  3. CPU-local storage has NOT been used.
     unsafe { cpu::init_on_bsp() };
+
+    numa::init();
 
     // SAFETY: We are on the BSP and APs are not yet started.
     let meta_pages = unsafe { mm::frame::meta::init() };

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -12,6 +12,7 @@ use crate::{
     error::Error,
     impl_frame_meta_for,
     mm::{paddr_to_vaddr, Paddr, PAGE_SIZE},
+    numa::NodeId,
     prelude::*,
     util::ops::range_difference,
 };
@@ -153,7 +154,7 @@ pub trait GlobalFrameAllocator: Sync {
     /// allocated, they may be returned in any order with any number of calls.
     fn alloc(&self, layout: Layout) -> Option<Paddr>;
 
-    /// Deallocates a contiguous range of frames.
+    /// Deallocates a contiguous range of frames in the given NUMA node.
     ///
     /// The caller guarantees that `addr` and `size` are both aligned to
     /// [`PAGE_SIZE`]. The deallocated memory should always be allocated by
@@ -164,7 +165,7 @@ pub trait GlobalFrameAllocator: Sync {
     /// added, without being allocated in between.
     ///
     /// The deallocated memory can be uninitialized.
-    fn dealloc(&self, addr: Paddr, size: usize);
+    fn dealloc(&self, addr: Paddr, size: usize, node_id: NodeId);
 
     /// Adds a contiguous range of frames to the allocator.
     ///

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -60,15 +60,26 @@ use crate::{
         CachePolicy, Infallible, Paddr, PageFlags, PageProperty, PrivilegedPageFlags, Segment,
         Vaddr, VmReader, PAGE_SIZE,
     },
+    numa::{memory_ranges, num_nodes, NodeId},
     panic::abort,
     util::ops::range_difference,
 };
 
 /// The maximum number of bytes of the metadata of a frame.
 pub const FRAME_METADATA_MAX_SIZE: usize = META_SLOT_SIZE
+    - maybe_node_id_size()
     - size_of::<AtomicU64>()
     - size_of::<FrameMetaVtablePtr>()
     - size_of::<AtomicU64>();
+
+const fn maybe_node_id_size() -> usize {
+    if cfg!(feature = "numa") {
+        size_of::<u8>()
+    } else {
+        0
+    }
+}
+
 /// The maximum alignment in bytes of the metadata of a frame.
 pub const FRAME_METADATA_MAX_ALIGN: usize = META_SLOT_SIZE;
 
@@ -89,6 +100,9 @@ pub(in crate::mm) struct MetaSlot {
     /// Don't interpret this field as an array of bytes. It is a
     /// placeholder for the metadata of a frame.
     storage: UnsafeCell<[u8; FRAME_METADATA_MAX_SIZE]>,
+    /// The NUMA node ID that this frame belongs to.
+    #[cfg(feature = "numa")]
+    node_id: u8,
     /// The reference count of the page.
     ///
     /// Specifically, the reference count has the following meaning:
@@ -324,6 +338,19 @@ impl MetaSlot {
         mapping::meta_to_frame::<PagingConsts>(self as *const MetaSlot as Vaddr)
     }
 
+    /// Gets the NUMA node ID that this frame belongs to.
+    pub(super) fn node_id(&self) -> NodeId {
+        #[cfg(feature = "numa")]
+        {
+            NodeId::new(self.node_id as u32)
+        }
+
+        #[cfg(not(feature = "numa"))]
+        {
+            NodeId::new(0)
+        }
+    }
+
     /// Gets a dynamically typed pointer to the stored metadata.
     ///
     /// # Safety
@@ -544,8 +571,35 @@ fn alloc_meta_frames(tot_nr_frames: usize) -> (usize, Paddr) {
 
     let slots = paddr_to_vaddr(paddr) as *mut MetaSlot;
 
+    let mut memory_ranges = memory_ranges()
+        .iter()
+        .filter(|mem_range| mem_range.is_enabled && mem_range.proximity_domain.is_some())
+        .peekable();
+
     // Initialize the metadata slots.
     for i in 0..tot_nr_frames {
+        let paddr = (i * page_size::<PagingConsts>(1)) as u64;
+        while let Some(mem_range) = memory_ranges.peek() {
+            if mem_range.base_address + mem_range.length <= paddr {
+                memory_ranges.next();
+            } else {
+                break;
+            }
+        }
+
+        let node_id = memory_ranges
+            .peek()
+            .filter(|mem_range| mem_range.base_address <= paddr)
+            .and_then(|mem_range| mem_range.proximity_domain)
+            // If the frame does not belong to any NUMA node, assign it to the
+            // default NUMA node (node 0).
+            .unwrap_or(0);
+        assert!(node_id < num_nodes() as u32);
+        assert!(
+            node_id < u8::MAX as u32,
+            "the number of NUMA nodes exceeds 255"
+        );
+
         // SAFETY: The memory is successfully allocated with `tot_nr_frames`
         // slots so the index must be within the range.
         let slot = unsafe { slots.add(i) };
@@ -554,6 +608,8 @@ fn alloc_meta_frames(tot_nr_frames: usize) -> (usize, Paddr) {
         unsafe {
             slot.write(MetaSlot {
                 storage: UnsafeCell::new([0; FRAME_METADATA_MAX_SIZE]),
+                #[cfg(feature = "numa")]
+                node_id: node_id as u8,
                 ref_count: AtomicU64::new(REF_COUNT_UNUSED),
                 vtable_ptr: UnsafeCell::new(MaybeUninit::uninit()),
                 in_list: AtomicU64::new(0),

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -256,7 +256,11 @@ impl<M: AnyFrameMeta + ?Sized> Drop for Frame<M> {
             // SAFETY: this is the last reference and is about to be dropped.
             unsafe { self.slot().drop_last_in_place() };
 
-            allocator::get_global_frame_allocator().dealloc(self.paddr(), PAGE_SIZE);
+            allocator::get_global_frame_allocator().dealloc(
+                self.paddr(),
+                PAGE_SIZE,
+                self.slot().node_id(),
+            );
         }
     }
 }

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -164,7 +164,11 @@ impl<M: AnyFrameMeta + ?Sized> Drop for UniqueFrame<M> {
         // The slot is initialized.
         unsafe { self.slot().drop_last_in_place() };
 
-        super::allocator::get_global_frame_allocator().dealloc(self.paddr(), PAGE_SIZE);
+        super::allocator::get_global_frame_allocator().dealloc(
+            self.paddr(),
+            PAGE_SIZE,
+            self.slot().node_id(),
+        );
     }
 }
 

--- a/ostd/src/numa.rs
+++ b/ostd/src/numa.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! NUMA(Non Uniform Memory Access) support.
+
+use spin::Once;
+
+use crate::{
+    arch::boot::numa::{init_numa_topology, MemoryRange, MEMORY_RANGES, PROCESSOR_AFFINITIES},
+    cpu::{all_cpus, CpuId},
+    cpu_local,
+    util::id_set::Id,
+};
+
+/// The number of NUMA nodes.
+static mut NUM_NODES: usize = 0;
+
+/// Initializes the number of NUMA nodes.
+///
+/// # Safety
+///
+/// The caller must ensure that we're in the boot context, and this method is
+/// called only once.
+unsafe fn init_num_nodes(num_nodes: usize) {
+    assert!(num_nodes >= 1);
+
+    // SAFETY: It is safe to mutate this global variable because we
+    // are in the boot context.
+    unsafe { NUM_NODES = num_nodes };
+}
+
+/// Returns the number of NUMA nodes.
+pub fn num_nodes() -> usize {
+    // SAFETY: As far as the safe APIs are concerned, `NUM_NODES` is initialized
+    // and read-only, so it is always valid to read.
+    unsafe { NUM_NODES }
+}
+
+cpu_local! {
+    /// The NUMA node ID of the current CPU.
+    static NODE_ID: Once<NodeId> = Once::new();
+}
+
+/// Returns the NUMA node ID of the given CPU.
+///
+/// # Panics
+///
+/// This method panics if the NUMA topology is not initialized.
+pub fn node_id_of_cpu(cpu_id: CpuId) -> NodeId {
+    debug_assert!(NODE_ID.get_on_cpu(cpu_id).is_completed());
+
+    // SAFETY: As far as the safe APIs are concerned, `NODE_ID` has been initialized.
+    unsafe { *NODE_ID.get_on_cpu(cpu_id).get_unchecked() }
+}
+
+pub(super) fn init() {
+    let (num_nodes, leader_cpu) = init_numa_topology();
+    log::warn!("NUMA node(s): {}", num_nodes);
+
+    // SAFETY: We're in the boot context, calling the method only once.
+    unsafe { init_num_nodes(num_nodes) };
+
+    for affinity in PROCESSOR_AFFINITIES.get().unwrap().iter() {
+        if !affinity.is_enabled {
+            continue;
+        }
+        let node_id = affinity.proximity_domain;
+        let cpu_id = CpuId::try_from(affinity.local_apic_id as usize).unwrap();
+        NODE_ID
+            .get_on_cpu(cpu_id)
+            .call_once(|| NodeId::new(node_id));
+    }
+    for cpu_id in all_cpus() {
+        NODE_ID.get_on_cpu(cpu_id).call_once(|| NodeId::new(0));
+    }
+}
+
+/// The ID of a NUMA node in the system.
+///
+/// If converting from/to an integer, the integer must start from 0 and be less
+/// than the number of NUMA nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NodeId(u32);
+
+impl NodeId {
+    /// Creates a new instance.
+    ///
+    /// # Panics
+    ///
+    /// The given number must be smaller than the total number of NUMA nodes
+    /// (`ostd::numa::num_nodes()`).
+    pub fn new(raw_id: u32) -> Self {
+        assert!(raw_id < num_nodes() as u32);
+        // SAFETY: The raw ID is smaller than `num_nodes()`.
+        unsafe { Self::new_unchecked(raw_id) }
+    }
+}
+
+impl From<NodeId> for u32 {
+    fn from(node_id: NodeId) -> Self {
+        node_id.0
+    }
+}
+
+// SAFETY: `NodeId`s and the integers within 0 to `num_nodes` (exclusive) have 1:1 mapping.
+unsafe impl Id for NodeId {
+    unsafe fn new_unchecked(raw_id: u32) -> Self {
+        Self(raw_id)
+    }
+
+    fn cardinality() -> u32 {
+        num_nodes() as u32
+    }
+}
+
+/// Returns the memory ranges associated with different proximity domains.
+///
+/// The ranges are sorted by starting physical address and do not overlap.
+///
+/// # Panics
+///
+/// This method panics if the NUMA topology is not initialized.
+pub fn memory_ranges() -> &'static [MemoryRange] {
+    MEMORY_RANGES.get().unwrap()
+}

--- a/ostd/src/numa.rs
+++ b/ostd/src/numa.rs
@@ -38,6 +38,9 @@ pub fn num_nodes() -> usize {
 cpu_local! {
     /// The NUMA node ID of the current CPU.
     static NODE_ID: Once<NodeId> = Once::new();
+    /// The leader CPU of the current CPU, i.e., the CPU with the smallest ID
+    /// in the current CPU's NUMA node.
+    static LEADER_CPU: Once<CpuId> = Once::new();
 }
 
 /// Returns the NUMA node ID of the given CPU.
@@ -52,8 +55,87 @@ pub fn node_id_of_cpu(cpu_id: CpuId) -> NodeId {
     unsafe { *NODE_ID.get_on_cpu(cpu_id).get_unchecked() }
 }
 
+/// Returns the leader CPU of the NUMA node of the given CPU.
+///
+/// # Panics
+///
+/// This method panics if the NUMA topology is not initialized.
+pub fn leader_cpu_of(cpu_id: CpuId) -> CpuId {
+    debug_assert!(LEADER_CPU.get_on_cpu(cpu_id).is_completed());
+
+    // SAFETY: As far as the safe APIs are concerned, `LEADER_CPU` has been initialized.
+    unsafe { *LEADER_CPU.get_on_cpu(cpu_id).get_unchecked() }
+}
+/// Defines a statically-allocated CPU-local variable, which is only meaningful
+/// on leader CPUs, and automatically generates an accessor function for it.
+///
+/// # Examples
+///
+/// ```rust
+/// leader_cpu_local! {
+///     pub static FOO: AtomicU32 = AtomicU32::new(1);
+/// }
+/// ```
+///
+/// The code above will be expanded to:
+///
+/// ```rust
+/// cpu_local! {
+///     static FOO: AtomicU32 = AtomicU32::new(1);
+/// }
+///
+/// pub fn foo(leader_cpu: CpuId) -> &'static AtomicU32 {
+///   debug_assert!(is_leader_cpu(leader_cpu));
+///   FOO.get_on_cpu(leader_cpu)
+/// }
+/// ```
+///
+/// # Panics
+///
+/// The accessor functions panic if the given CPU is not a leader CPU.
+#[macro_export]
+macro_rules! leader_cpu_local {
+    ($( $(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr; )*) => {
+        cpu_local! {
+            $(
+                $(#[$attr])*
+                static $name: $t = $init;
+            )*
+        }
+
+        $(
+            paste::paste! {
+                $(#[$attr])*
+                $vis fn [<$name:lower>](leader_cpu: CpuId) -> &'static $t {
+                    debug_assert!(leader_cpu_of(leader_cpu) == leader_cpu);
+                    $name.get_on_cpu(leader_cpu)
+                }
+            }
+        )*
+    };
+}
+
+leader_cpu_local! {
+    /// The number of CPUs in the NUMA node of the leader CPU.
+    pub static NUM_CPUS_IN_NODE: Once<usize> = Once::new();
+}
+
+static LEADER_CPU_OF_NODE: Once<&'static [CpuId]> = Once::new();
+
+/// Returns the leader CPU of the given NUMA node.
+///
+/// # Panics
+///
+/// This method panics if the NUMA topology is not initialized.
+pub fn leader_cpu_of_node(node_id: NodeId) -> CpuId {
+    debug_assert!(LEADER_CPU_OF_NODE.is_completed());
+
+    // SAFETY: As far as the safe APIs are concerned, `LEADER_CPU_OF_NODE` has been initialized.
+    unsafe { LEADER_CPU_OF_NODE.get_unchecked()[node_id.as_usize()] }
+}
+
 pub(super) fn init() {
-    let (num_nodes, leader_cpu) = init_numa_topology();
+    let (num_nodes, leader_cpu_of_node) = init_numa_topology();
     log::warn!("NUMA node(s): {}", num_nodes);
 
     // SAFETY: We're in the boot context, calling the method only once.
@@ -72,6 +154,32 @@ pub(super) fn init() {
     for cpu_id in all_cpus() {
         NODE_ID.get_on_cpu(cpu_id).call_once(|| NodeId::new(0));
     }
+
+    // Initialize the leader CPU of each CPU. Since the number of CPUs won't be too large,
+    // and `alloc` is not allowed now, the O(n^2) approach is suitable here.
+    for cpu_id in all_cpus() {
+        let leader_cpu = LEADER_CPU.get_on_cpu(cpu_id);
+        if leader_cpu.is_completed() {
+            continue;
+        }
+        leader_cpu.call_once(|| cpu_id);
+        let node_id = node_id_of_cpu(cpu_id);
+        leader_cpu_of_node[node_id.as_usize()] = cpu_id;
+        let mut num_cpus_in_this_node = 1;
+
+        all_cpus()
+            .filter(|&id| id.as_usize() > cpu_id.as_usize() && node_id_of_cpu(id) == node_id)
+            .for_each(|non_leader_id| {
+                debug_assert!(!LEADER_CPU.get_on_cpu(non_leader_id).is_completed());
+                num_cpus_in_this_node += 1;
+                LEADER_CPU.get_on_cpu(non_leader_id).call_once(|| cpu_id);
+            });
+        num_cpus_in_node(cpu_id).call_once(|| num_cpus_in_this_node);
+    }
+
+    LEADER_CPU_OF_NODE.call_once(|| leader_cpu_of_node);
+
+    // FIXME: Add a fall back list for each NUMA node.
 }
 
 /// The ID of a NUMA node in the system.


### PR DESCRIPTION
This PR introduces a NUMA-aware frame allocator that follows a first-touch allocation strategy. Under this approach, physical pages are allocated from the NUMA node of the CPU that first accesses the memory.

---

# Non-NUMA-aware frame allocator

Our old frame allocator follows the following strategy:

 - Data Structure: Each CPU has a local cache and a local pool. All other memory resides in the global pool.

 - `alloc`: Allocation first tries the CPU’s local cache. If that fails, it tries the local pool, and if that also fails, it falls back to the global pool. After allocation, balance the sizes of the local pool and global pool.

 - `dealloc`: Deallocation first tries the CPU’s local cache. If that fails, it tries the local pool, and if that also fails, it falls back to the global pool. After deallocation, balance the sizes of the local pool and global pool.

 - `add_free_memory` (at boot stage): All free memory is added to the global pool.

# NUMA-aware frame allocator

The NUMA-aware frame allocator in this PR follows the following strategy:

 - Data Structure: Each CPU has a local cache and a local pool. Each NUMA node has its own pool.

 - `alloc`: Allocation first tries the CPU’s local cache. If that fails, it tries the local pool, and if that also fails, it falls back to the pool of the NUMA node that the current CPU belongs to. After allocation, balance the sizes of the local pool and node pool.

 - `dealloc`: 
   - If the current CPU and the memory deallocated belong to the same NUMA node, deallocation first tries the local cache. If that fails, it tries the local pool, and if that also fails, it falls back to the NUMA node’s pool. After deallocation, balance the sizes of the local pool and node pool.
   -  If the current CPU and the memory deallocated do not belong to the same NUMA node, the memory is directly deallocated to the pool of the NUMA node it belongs to.

 - `add_free_memory` (at boot stage): Free memory is added to the corresponding NUMA node’s pool based on its physical address.

# Performance

In short, the results are evaluated on a 2-socket AMD EPYC 9965 machine, each socket has a 192-core CPU and 512GB DRAM, showing a **7.88%** speedup.

For details, you can refer to [this branch](https://github.com/vvvvsv/asterinas/tree/parse_numa) in my own repository, and read the file `test_numa_readme.md`.

---

NOTE: @jellllly420 submitted two PRs to the `acpi` crate to add support for [SRAT](https://github.com/rust-osdev/acpi/pull/241) and [SLIT](https://github.com/rust-osdev/acpi/pull/243). This PR needs them to parse the NUMA topology at boot stage. However, it seems unlikely that these PRs will be merged in the near term, as the maintainer hasn’t responded for a long time.

Therefore, I directly used the code from those two PRs in the commit "Parse NUMA topology at boot stage" and co-authored it with @jellllly420. This approach may require further discussion. Perhaps we need to consider maintaining our own `acpi` crate?

UPDATE: Will go after https://github.com/rust-osdev/acpi/pull/264.

---

~NOTE: After https://github.com/asterinas/asterinas/pull/2643 is merged and the container version is bumped, I will update tools/qemu_args.sh according to [the comments](https://github.com/asterinas/asterinas/blob/1dd9a33f9823019c86acbecb90164bbd9a7da889/tools/qemu_args.sh#L126-L131) to fully support NUMA-aware. For now, NUMA binding is disabled so that the CI tests can pass.~

---

TODO:
 - [ ] Add dummy riscv and loongarch NUMA topology.
 - [ ] Add fall back lists.
 - [ ] Add syscalls `mbind`, `set_mempolicy`, `get_mempolicy`, `move_pages`.
 - [ ] Implement policies other than first-touch.