### PR TITLE
Add a nixos channel in container

### DIFF
--- a/tools/docker/nix/Dockerfile
+++ b/tools/docker/nix/Dockerfile
@@ -12,6 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN sh <(curl -L https://nixos.org/nix/install) --daemon --yes \
     && . /etc/profile.d/nix.sh \
     && nix-channel --add https://nixos.org/channels/nixos-25.05 nixpkgs \
+    && nix-channel --add https://nixos.org/channels/nixos-25.05 nixos \
     && nix-channel --update \
     && nix-env -iA nixpkgs.nixfmt \
     && nix-env -iA nixpkgs.nixos-install-tools \


### PR DESCRIPTION
This pull request ensures that nixos-install can correctly set up the default channel within the newly installed NixOS system.

To achieve this, a channel named `nixos` is added to the build container. Its URL is pinned to the NixOS 25.05 release, aligning with the default channel expected by the target system.

Since PR #2632 will update the Docker version, this PR does not bump it. Please merge this PR before #2632. Thanks!