### PR TITLE
Correct `{get,set}_option` for `NetlinkSocket`

### DIFF
--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -49,6 +49,7 @@ mod table;
 pub use addr::{GroupIdSet, NetlinkSocketAddr};
 pub use kobject_uevent::NetlinkUeventSocket;
 pub use options::{AddMembership, DropMembership};
+pub(super) use receiver::NETLINK_DEFAULT_BUF_SIZE;
 pub use route::NetlinkRouteSocket;
 pub use table::{is_valid_protocol, StandardNetlinkProtocol};
 

--- a/kernel/src/net/socket/netlink/receiver.rs
+++ b/kernel/src/net/socket/netlink/receiver.rs
@@ -112,4 +112,4 @@ impl<Message: QueueableMessage> MessageReceiver<Message> {
     }
 }
 
-const NETLINK_DEFAULT_BUF_SIZE: usize = 65536;
+pub(in crate::net) const NETLINK_DEFAULT_BUF_SIZE: usize = 65536;

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -10,6 +10,7 @@ use super::LingerOption;
 use crate::{
     match_sock_option_mut, match_sock_option_ref,
     net::socket::{
+        netlink::NETLINK_DEFAULT_BUF_SIZE,
         options::{
             AcceptConn, Broadcast, KeepAlive, Linger, PassCred, PeerCred, PeerGroups, Priority,
             RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,
@@ -88,11 +89,19 @@ impl SocketOptionSet {
         }
     }
 
+    /// Returns the default socket level options for netlink socket.
+    pub(in crate::net) fn new_netlink() -> Self {
+        Self {
+            send_buf: NETLINK_DEFAULT_BUF_SIZE as u32,
+            recv_buf: NETLINK_DEFAULT_BUF_SIZE as u32,
+            ..Default::default()
+        }
+    }
+
     /// Gets socket-level options.
     ///
-    /// Note that the socket error has to be handled separately, because it is automatically
-    /// cleared after reading. This method does not handle it. Instead,
-    /// [`Self::get_and_clear_socket_errors`] should be used.
+    /// Note that the socket error has to be handled separately. This method does not handle it
+    /// because it is automatically cleared after reading.
     pub fn get_option(
         &self,
         option: &mut dyn SocketOption,

--- a/test/src/apps/network/uevent_err.c
+++ b/test/src/apps/network/uevent_err.c
@@ -257,3 +257,39 @@ FN_TEST(add_and_drop_membership)
 	TEST_SUCC(close(sk_new));
 }
 END_TEST()
+
+FN_TEST(getsockopt_membership)
+{
+	int group;
+	socklen_t group_size = sizeof(group);
+
+	TEST_ERRNO(getsockopt(sk_unbound, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
+			      &group, &group_size),
+		   ENOPROTOOPT);
+	TEST_ERRNO(getsockopt(sk_unbound, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP,
+			      &group, &group_size),
+		   ENOPROTOOPT);
+
+	TEST_ERRNO(getsockopt(sk_bound, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
+			      &group, &group_size),
+		   ENOPROTOOPT);
+	TEST_ERRNO(getsockopt(sk_bound, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP,
+			      &group, &group_size),
+		   ENOPROTOOPT);
+
+	TEST_ERRNO(getsockopt(sk_connected, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
+			      &group, &group_size),
+		   ENOPROTOOPT);
+	TEST_ERRNO(getsockopt(sk_connected, SOL_NETLINK,
+			      NETLINK_DROP_MEMBERSHIP, &group, &group_size),
+		   ENOPROTOOPT);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(sk_unbound));
+	CHECK(close(sk_bound));
+	CHECK(close(sk_connected));
+}
+END_SETUP()


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/0b664a012e689b3f730cc4faa39bd03613f5b995/kernel/src/net/socket/netlink/common/mod.rs#L176-L180

This should be fixed so that we don't return an `Ok()` for all unrecognized socket options.

It seems that the test only needs to change the buffer size, which is already handled in the socket-level option set, although it does not take effect. So this PR adds `SocketOptionSet` for `NetlinkSocket`.