### PR TITLE
Update SCML for resource limit and scheduler syscalls

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -160,14 +160,14 @@ which are summarized in the table below.
 | 137     | statfs                 | ✅             | 💯 |
 | 138     | fstatfs                | ✅             | 💯 |
 | 139     | sysfs                  | ❌             | N/A |
-| 140     | getpriority            | ✅             | ❓ |
-| 141     | setpriority            | ✅             | ❓ |
-| 142     | sched_setparam         | ✅             | ❓ |
-| 143     | sched_getparam         | ✅             | ❓ |
-| 144     | sched_setscheduler     | ✅             | ❓ |
-| 145     | sched_getscheduler     | ✅             | ❓ |
-| 146     | sched_get_priority_max | ✅             | ❓ |
-| 147     | sched_get_priority_min | ✅             | ❓ |
+| 140     | getpriority            | ✅             | 💯 |
+| 141     | setpriority            | ✅             | 💯 |
+| 142     | sched_setparam         | ✅             | 💯 |
+| 143     | sched_getparam         | ✅             | 💯 |
+| 144     | sched_setscheduler     | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#sched_setscheduler) |
+| 145     | sched_getscheduler     | ✅             | 💯 |
+| 146     | sched_get_priority_max | ✅             | 💯 |
+| 147     | sched_get_priority_min | ✅             | 💯 |
 | 148     | sched_rr_get_interval  | ❌             | N/A |
 | 149     | mlock                  | ❌             | N/A |
 | 150     | munlock                | ❌             | N/A |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
@@ -52,3 +52,17 @@ Supported functionality in SCML:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/clone.2.html).
+
+### `sched_setscheduler`
+
+Supported functionality in SCML:
+
+```c
+{{#include sched_setscheduler.scml}}
+```
+
+Unsupported policies or flags:
+* `SCHED_RESET_ON_FORK`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/sched_setscheduler.2.html).

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/fully_covered.scml
@@ -79,3 +79,21 @@ setfsgid(fsgid);
 
 // Determine CPU and NUMA node on which the calling thread is running
 getcpu(cpu, node);
+
+// Get/set program scheduling priority
+getpriority(which = PRIO_PROCESS | PRIO_PGRP | PRIO_USER, who);
+setpriority(which = PRIO_PROCESS | PRIO_PGRP | PRIO_USER, who, prio);
+
+sched_policies = SCHED_FIFO | SCHED_RR | SCHED_OTHER | SCHED_BATCH |
+                 SCHED_IDLE | SCHED_DEADLINE;
+
+// Get static priority range
+sched_get_priority_max(policy = <sched_policies>);
+sched_get_priority_min(policy = <sched_policies>);
+
+// Get/set scheduling parameters
+sched_setparam(pid, param);
+sched_getparam(pid, param);
+
+// Get scheduling policy
+sched_getscheduler(pid);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/sched_setscheduler.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/sched_setscheduler.scml
@@ -1,0 +1,2 @@
+// Set scheduling policy
+sched_setscheduler(pid, policy = SCHED_OTHER | SCHED_BATCH | SCHED_IDLE | SCHED_FIFO | SCHED_RR, param);


### PR DESCRIPTION
This PR is required for #2630.

Mark `getrlimit`, `setrlimit`, and most scheduler-related syscalls as fully supported in SCML documentation. Although these syscalls are added to `fully_supported.scml`, all flags in the syscalls are still explicitly listed. Because:
- Detection of flag definition errors (inconsistencies with `strace`).
- Quick feedback from `sctrace` when Linux introduces new flags.

`sched_setscheduler` is marked as partially supported due to missing `SCHED_RESET_ON_FORK` flag support.