### PR TITLE
frame: Add Reclaimable memory region to the `max_paddr` filter

### DIFF
--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -458,7 +458,12 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
         regions
             .iter()
-            .filter(|r| r.typ() == MemoryRegionType::Usable)
+            .filter(|r| {
+                matches!(
+                    r.typ(),
+                    MemoryRegionType::Usable | MemoryRegionType::Reclaimable
+                )
+            })
             .map(|r| r.base() + r.len())
             .max()
             .unwrap()


### PR DESCRIPTION
Sometimes, the reclaimable memory region (such as the initramfs) may exceed the usable memory region, causing the initramfs region to be ignored when establishing linear mappings. 

This issue had previously gone undetected because the usable memory in the QEMU virtual machine was set to a relatively large value, with the highest usable memory region exceeding 4GB. This allowed all lower regions to establish linear mappings, but it can cause problems in low-memory environments, such as microVMs.

In fact, I only discovered this issue in Firecracker, and here is the screenshot of the memory regions:

<img width="397" height="347" alt="image" src="https://github.com/user-attachments/assets/4ec45921-5e09-418c-90ad-c56f12b25e79" />

I think adding the Reclaimable region to the filter should make sense since these regions also bind with physical frames.

