### PR TITLE
Update inotify-related SCML

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -273,9 +273,9 @@ which are summarized in the table below.
 | 250     | keyctl                 | ❌             | N/A |
 | 251     | ioprio_set             | ✅             | ❓ |
 | 252     | ioprio_get             | ✅             | ❓ |
-| 253     | inotify_init           | ❌             | N/A |
-| 254     | inotify_add_watch      | ❌             | N/A |
-| 255     | inotify_rm_watch       | ❌             | N/A |
+| 253     | inotify_init           | ✅             | 💯 |
+| 254     | inotify_add_watch      | ✅             | [⚠️](syscall-feature-coverage/file-systems-and-mount-control/#inotify_add_watch) |
+| 255     | inotify_rm_watch       | ✅             | 💯 |
 | 256     | migrate_pages          | ❌             | N/A |
 | 257     | openat                 | ✅             | [⚠️](syscall-feature-coverage/file-and-directory-operations/#open-and-openat) |
 | 258     | mkdirat                | ✅             | 💯 |
@@ -314,7 +314,7 @@ which are summarized in the table below.
 | 291     | epoll_create1          | ✅             | ❓ |
 | 292     | dup3                   | ✅             | 💯 |
 | 293     | pipe2                  | ✅             | [⚠️](syscall-feature-coverage/file-descriptor-and-io-control/#pipe-and-pipe2) |
-| 294     | inotify_init1          | ❌             | N/A |
+| 294     | inotify_init1          | ✅             | [⚠️](syscall-feature-coverage/file-systems-and-mount-control/#inotify_init-and-inotify_init1) |
 | 295     | preadv                 | ✅             | 💯 |
 | 296     | pwritev                | ✅             | 💯 |
 | 297     | rt_tgsigqueueinfo      | ❌             | N/A |

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/README.md
@@ -94,14 +94,3 @@ Unsupported control flags:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man7/inotify.7.html).
-
-### `inotify_rm_watch`
-
-Supported functionality in SCML:
-
-```c
-{{#include inotify_rm_watch.scml}}
-```
-
-For more information,
-see [the man page](https://man7.org/linux/man-pages/man2/inotify_rm_watch.2.html).

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/fully_supported.scml
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/fully_supported.scml
@@ -7,3 +7,6 @@ sync();
 
 // Change root directory
 chroot(path);
+
+// Remove a watch from an inotify instance
+inotify_rm_watch(fd, wd);

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_add_watch.scml
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_add_watch.scml
@@ -6,5 +6,4 @@ inotify_controls = IN_ONLYDIR | IN_DONT_FOLLOW | IN_MASK_CREATE |
                    IN_MASK_ADD | IN_ISDIR;
 
 // Add a watch to an initialized inotify instance
-inotify_add_watch(fd, pathname = <PATH>, mask = <inotify_events> | <inotify_controls>);
-
+inotify_add_watch(fd, pathname, mask = <inotify_events> | <inotify_controls>);

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_init_and_init1.scml
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_init_and_init1.scml
@@ -3,4 +3,3 @@ inotify_init();
 
 // Create an inotify instance with enhanced behavior control
 inotify_init1(flags = IN_CLOEXEC | IN_NONBLOCK);
-

--- a/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_rm_watch.scml
+++ b/book/src/kernel/linux-compatibility/syscall-feature-coverage/file-systems-and-mount-control/inotify_rm_watch.scml
@@ -1,3 +1,0 @@
-// Remove a watch from an inotify instance
-inotify_rm_watch(fd, wd);
-


### PR DESCRIPTION
- Mark inotify-related syscalls as implemented in the Linux compatibility documentation.
- Move `inotify_rm_watch` to fully supported list as it doesn't require specific documentation.
- Remove `pathname` limitation in `inotify_add_watch` (filesystem coverage not implemented yet).