### PR TITLE
Add xfce nix overlay

### DIFF
--- a/distro/aster_configuration.nix
+++ b/distro/aster_configuration.nix
@@ -17,10 +17,16 @@
   # The content defined in these module files must adhere to the options permissible within 'configuration.nix'. 
   # For a comprehensive list of available options,
   # please refer to https://search.nixos.org/options.
-  imports = [ ./modules/core.nix ];
+  imports = [
+    ./modules/core.nix
+    ./modules/xfce/default.nix
+  ];
 
   # Overlays provide patches to 'nixpkgs' that enable these packages to run effectively on AsterNixOS.
   # For details on the overlay file definition format, 
   # please refer to https://nixos.org/manual/nixpkgs/stable/#sec-overlays-definition.
-  nixpkgs.overlays = [ (import ./overlays/hello-asterinas/default.nix) ];
+  nixpkgs.overlays = [
+    (import ./overlays/hello-asterinas/default.nix)
+    (import ./overlays/de/default.nix)
+  ];
 }

--- a/distro/configuration.nix
+++ b/distro/configuration.nix
@@ -11,6 +11,10 @@
 
   networking.hostName = "asterinas"; # Define your hostname.
 
+  # Uncomment the two options below to enable the X11 (X.Org) desktop (XFCE).
+  # services.xserver.enable = true;
+  # services.xserver.desktopManager.xfce.enable = true;
+
   # List packages installed in system profile.
   # You can use https://search.nixos.org/ to find more packages (and options).
   environment.systemPackages = with pkgs; [ hello-asterinas ];

--- a/distro/modules/xfce/default.nix
+++ b/distro/modules/xfce/default.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+let
+  runAsXfce = pkgs.writeScriptBin "run_as_xfce" (builtins.readFile ./run_as_xfce.sh);
+in
+{
+  environment.systemPackages =
+    (lib.optionals (config.services.xserver.enable &&
+      config.services.xserver.desktopManager.xfce.enable)
+      [ runAsXfce ])
+    ++ (lib.optionals config.services.xserver.enable
+      [ pkgs.xorg.xf86videofbdev ])
+    ++ [ pkgs.vim ];
+
+  systemd.services."xfce-desktop" = lib.mkIf
+    (config.services.xserver.enable && config.services.xserver.desktopManager.xfce.enable)
+    {
+      description = "XFCE Desktop Environment";
+      after = [ "multi-user.target" ];
+      wantedBy = [ "graphical.target" ];
+      serviceConfig = {
+        Environment = "DISPLAY=:0";
+        ExecStart = "${runAsXfce}/bin/run_as_xfce";
+        StandardOutput = "tty";
+        StandardError = "tty";
+        KillMode = "process";
+        Delegate = "yes";
+        Restart = "no";
+        Type = "simple";
+      };
+    };
+}

--- a/distro/modules/xfce/run_as_xfce.sh
+++ b/distro/modules/xfce/run_as_xfce.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Step 1: run dbus
+mkdir -p /var/lib/dbus /usr/share/X11/xorg.conf.d
+[ -f /var/lib/dbus/machine-id ] || echo "52e0ad0e9794402c90315dd6af205511" > /var/lib/dbus/machine-id
+
+if command -v dbus-launch >/dev/null 2>&1; then
+  eval "$(dbus-launch --sh-syntax)"
+fi
+
+# Step 2:run Xorg
+XKB_DATA="/run/current-system/sw/share/X11/xkb"
+MODULE_PATH="/run/current-system/sw/lib/xorg/modules"
+
+nohup Xorg :0 \
+  -modulepath "$MODULE_PATH" \
+  -xkbdir "$XKB_DATA" \
+  -logverbose 0 \
+  -logfile /var/log/xorg_debug.log \
+  -novtswitch \
+  -keeptty \
+  -keyboard keyboard \
+  -pointer mouse0 \
+  > /var/log/xorg.log 2>&1 &
+
+
+# Step 3: run xfce4
+export DISPLAY=:0
+LOG=/var/log/xfce-session.log
+mkdir -p "$(dirname "$LOG")"
+: > "$LOG"                 # truncate/create
+chmod 600 "$LOG"
+nohup xfce4-session >>"$LOG" 2>&1 &

--- a/distro/overlays/de/default.nix
+++ b/distro/overlays/de/default.nix
@@ -1,0 +1,57 @@
+self: super:
+
+{
+  xorg = super.xorg // {
+    xorgserver = super.xorg.xorgserver.overrideAttrs (oldAttrs: {
+      version = "21.1.4";
+      src = oldAttrs.src;
+      patches = (oldAttrs.patches or []) ++ [
+        ./patches/xorgServer/0001-Skip-checking-graphics-under-sys.patch
+        ./patches/xorgServer/0002-hardcode-tty1-usage-due-to-Asterinas-limitations.patch
+      ];
+      nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [
+        self.meson
+        self.ninja
+        self.pkg-config
+      ];
+      buildInputs = (oldAttrs.buildInputs or []) ++ [
+        self.dri-pkgconfig-stub
+        self.libudev-zero
+        self.xorg.fontutil
+        self.libtirpc
+      ];
+      configurePhase = ''
+        meson setup builddir \
+          --prefix=$out \
+          --libdir=lib \
+          -Dxorg=true \
+          -Dglamor=true \
+          -Dxkb_output_dir=$out/share/X11/xkb \
+          -Doptimization=0 \
+          -Ddebug=true \
+          -Dudev=false \
+          -Dxkb_bin_dir=${self.xorg.xkbcomp}/bin \
+          -Dudev_kms=false
+      '';
+      buildPhase = ''
+        meson compile -C builddir
+      '';
+      installPhase = ''
+        meson install -C builddir
+        mkdir -p $out/share/X11/xorg.conf.d
+        cp ${./patches/xorgServer/10-fbdev.conf} $out/share/X11/xorg.conf.d/10-fbdev.conf
+      '';
+    });
+  };
+
+  xfce = super.xfce // {
+    xfwm4 = super.xfce.xfwm4.overrideAttrs (oldAttrs: {
+      version = "4.16.1";
+    });
+
+    xfdesktop = super.xfce.xfdesktop.overrideAttrs (oldAttrs: {
+      version = "4.16.0";
+    });
+  };
+}
+

--- a/distro/overlays/de/patches/xorgServer/0001-Skip-checking-graphics-under-sys.patch
+++ b/distro/overlays/de/patches/xorgServer/0001-Skip-checking-graphics-under-sys.patch
@@ -1,0 +1,38 @@
+From 6e3a7b461bbf96d0e81ec36981b34605dbf4d8d7 Mon Sep 17 00:00:00 2001
+From: Wei Zhang <ruoyuan.zw@antgroup.com>
+Date: Wed, 7 May 2025 05:34:47 +0000
+Subject: [PATCH] Skip checking graphics under sys
+
+The sys filesystem support is on the way. Right now, we skip the checking
+to avoid fbdev driver failing to work.
+
+Signed-off-by: Wei Zhang <ruoyuan.zw@antgroup.com>
+---
+ hw/xfree86/fbdevhw/fbdevhw.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/xfree86/fbdevhw/fbdevhw.c b/hw/xfree86/fbdevhw/fbdevhw.c
+index 9c30f00..27253a7 100644
+--- a/hw/xfree86/fbdevhw/fbdevhw.c
++++ b/hw/xfree86/fbdevhw/fbdevhw.c
+@@ -328,7 +328,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
+         xf86DrvMsg(scrnIndex, X_ERROR, "open %s: %s\n", dev, strerror(errno));
+         return -1;
+     }
+-
++#if 0
+     /* only touch non-PCI devices on this path */
+     {
+         char buf[PATH_MAX] = {0};
+@@ -344,7 +344,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
+         }
+         free(sysfs_path);
+     }
+-
++#endif
+     if (namep) {
+         if (-1 == ioctl(fd, FBIOGET_FSCREENINFO, (void *) (&fix))) {
+             *namep = NULL;
+--
+2.43.0
+

--- a/distro/overlays/de/patches/xorgServer/0002-hardcode-tty1-usage-due-to-Asterinas-limitations.patch
+++ b/distro/overlays/de/patches/xorgServer/0002-hardcode-tty1-usage-due-to-Asterinas-limitations.patch
@@ -1,0 +1,101 @@
+From 16f92eda2d20d675fd5bab24771e78350fc75b8e Mon Sep 17 00:00:00 2001
+From: Wei Zhang <ruoyuan.zw@antgroup.com>
+Date: Wed, 17 Sep 2025 16:05:54 +0800
+Subject: [PATCH] hardcode tty1 usage due to Asterinas limitations
+
+Asterinas currently only supports /dev/tty1 and lacks multi-tty device
+support. This patch:
+
+- Forces Xorg to use exclusively /dev/tty1
+- Skips ioctl calls intended for tty device switching
+- Maintains functionality while avoiding unsupported operations
+
+The changes ensure Xorg remains operational on Asterinas without
+attempting to access non-existent tty devices or perform unsupported
+tty switching operations.
+
+Signed-off-by: Wei Zhang <ruoyuan.zw@antgroup.com>
+---
+ hw/xfree86/os-support/linux/lnx_init.c | 26 ++++++++++++++++++++++----
+ 1 file changed, 22 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/os-support/linux/lnx_init.c b/hw/xfree86/os-support/linux/lnx_init.c
+index 111b3b4..22163ce 100644
+--- a/hw/xfree86/os-support/linux/lnx_init.c
++++ b/hw/xfree86/os-support/linux/lnx_init.c
+@@ -106,6 +106,15 @@ linux_parse_vt_settings(int may_fail)
+         from = X_CMDLINE;
+     }
+     else {
++        /*
++         * NOTE: In Asterinas, the number of TTYs is hardcoded, because the
++	 * current implementation of Asterinas does not support multiple TTYs.
++	 * Currently, only /dev/tty1 is supported.
++	 *
++	 * Todo: Update this logic if multi-TTY support is added in the future.
++         */
++        xf86Info.vtno = 1;
++#if 0
+         fd = open("/dev/tty0", O_WRONLY, 0);
+         if (fd < 0) {
+             if (may_fail)
+@@ -139,6 +148,7 @@ linux_parse_vt_settings(int may_fail)
+             }
+         }
+         close(fd);
++#endif
+     }
+
+     xf86Msg(from, "using VT number %d\n\n", xf86Info.vtno);
+@@ -204,15 +214,13 @@ xf86OpenConsole(void)
+         i = 0;
+         while (vcs[i] != NULL) {
+             snprintf(vtname, sizeof(vtname), vcs[i], xf86Info.vtno);    /* /dev/tty1-64 */
++            xf86Msg(X_WARNING, "[DEBUG]xf86OpenConsole: trying to open %s\n", vtname);
+             if ((xf86Info.consoleFd = open(vtname, O_RDWR | O_NDELAY, 0)) >= 0)
+                 break;
+             i++;
+         }
+
+-        if (xf86Info.consoleFd < 0)
+-            FatalError("xf86OpenConsole: Cannot open virtual console"
+-                       " %d (%s)\n", xf86Info.vtno, strerror(errno));
+-
++#if 0
+         /*
+          * Linux doesn't switch to an active vt after the last close of a vt,
+          * so we do this ourselves by remembering which is active now.
+@@ -223,10 +231,17 @@ xf86OpenConsole(void)
+                     strerror(errno));
+         else
+             activeVT = vts.v_active;
++#endif
+
+         if (!xf86Info.ShareVTs) {
+             struct termios nTty;
+
++	    SYSCALL(ret = ioctl(xf86Info.consoleFd, KDSETMODE, KD_GRAPHICS));
++            if (ret < 0)
++                FatalError("xf86OpenConsole: KDSETMODE KD_GRAPHICS failed %s\n",
++                           strerror(errno));
++	    xf86Msg(X_WARNING, "[DEBUG] xf86OpenConsole: KDSETMODE to KD_GRAPHICS\n");
++#if 0
+             /*
+              * now get the VT.  This _must_ succeed, or else fail completely.
+              */
+@@ -282,9 +297,12 @@ xf86OpenConsole(void)
+             cfsetispeed(&nTty, 9600);
+             cfsetospeed(&nTty, 9600);
+             tcsetattr(xf86Info.consoleFd, TCSANOW, &nTty);
++#endif
+         }
+     }
+     else {                      /* serverGeneration != 1 */
++        xf86Msg(X_WARNING, "[DEBUG] xf86Info.ShareVTs %d, xf86Info.autoVTSwitch %d\n",
++                xf86Info.ShareVTs, xf86Info.autoVTSwitch);
+         if (!xf86Info.ShareVTs && xf86Info.autoVTSwitch) {
+             /* now get the VT */
+             if (!switch_to(xf86Info.vtno, "xf86OpenConsole"))
+--
+2.43.0
+

--- a/distro/overlays/de/patches/xorgServer/10-fbdev.conf
+++ b/distro/overlays/de/patches/xorgServer/10-fbdev.conf
@@ -1,0 +1,40 @@
+Section "Device"
+    Identifier  "FBDev"
+    Driver      "fbdev"
+    Option      "fbdev" "/dev/fb0"
+EndSection
+
+Section "Screen"
+    Identifier  "Screen0"
+    Device      "FBDev"
+    DefaultDepth 24
+    SubSection "Display"
+        Depth     24
+        Modes     "1280x800"   # Must match the EFI framebuffer resolution
+    EndSubSection
+EndSection
+
+Section "ServerFlags"
+    Option      "AutoAddDevices" "on"  # Prevent input device autodetection issues
+    Option      "DontVTSwitch" "true"    # Disable VT switching (avoid hangs)
+    Option      "AutoEnableDevices" "on"
+EndSection
+
+Section "InputDevice"
+    Identifier "Keyboard"
+    Driver "evdev"
+    Option "Device" "/dev/input/event0"
+EndSection
+
+Section "InputDevice"
+    Identifier "Mouse0"
+    Driver "evdev"
+    Option "Device" "/dev/input/event1"
+EndSection
+
+Section "ServerLayout"
+    Identifier "DefaultLayout"
+    InputDevice "Keyboard" "CoreKeyboard"
+    InputDevice "Mouse0" "CorePointer"
+EndSection
+


### PR DESCRIPTION
Add XFCE Nix overlay

Add a distro/modules/xfce module and distro/overlays/de overlay that provide XFCE desktop configuration and the run_as_xfce helper script. Wire the module into aster_configuration.nix.

Motivation: enable XFCE on Asterinas with reproducible packaging.