### PR TITLE
Rustfmt socket option macros

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -10,13 +10,12 @@ use super::addr::UNSPECIFIED_LOCAL_ENDPOINT;
 use crate::{
     events::IoEvents,
     fs::utils::Inode,
-    match_sock_option_mut,
     net::{
         iface::is_broadcast_endpoint,
         socket::{
             ip::options::{IpOptionSet, SetIpLevelOption},
             new_pseudo_inode,
-            options::{Error as SocketError, SocketOption},
+            options::{macros::sock_option_mut, Error as SocketError, SocketOption},
             private::SocketPrivate,
             util::{
                 datagram_common::{select_remote_and_bind, Bound, Inner},
@@ -241,13 +240,13 @@ impl Socket for DatagramSocket {
     }
 
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
-        match_sock_option_mut!(option, {
-            socket_errors: SocketError => {
+        sock_option_mut!(match option {
+            socket_errors @ SocketError => {
                 // TODO: Support socket errors for UDP sockets
                 socket_errors.set(None);
                 return Ok(());
-            },
-            _ => ()
+            }
+            _ => (),
         });
 
         let inner = self.inner.read();

--- a/kernel/src/net/socket/ip/stream/options.rs
+++ b/kernel/src/net/socket/ip/stream/options.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{impl_socket_options, prelude::*};
+use crate::{net::socket::options::macros::impl_socket_options, prelude::*};
 
 impl_socket_options!(
     pub struct NoDelay(bool);

--- a/kernel/src/net/socket/netlink/options.rs
+++ b/kernel/src/net/socket/netlink/options.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::impl_socket_options;
+use crate::net::socket::options::macros::impl_socket_options;
 
 impl_socket_options!(
     pub struct AddMembership(u32);

--- a/kernel/src/net/socket/options/macros.rs
+++ b/kernel/src/net/socket/options/macros.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#[macro_export]
 macro_rules! impl_socket_options {
     ($(
         $(#[$outer:meta])*
@@ -43,13 +42,13 @@ macro_rules! impl_socket_options {
         )*
     };
 }
+pub(in crate::net) use impl_socket_options;
 
-#[macro_export]
-macro_rules! match_sock_option_ref {
+macro_rules! sock_option_ref {
     (
-        $option:expr, {
-            $( $bind: ident : $ty:ty => $arm:expr ),*,
-            _ => $default:expr
+        match $option:ident {
+            $( $bind:ident @ $ty:ty => $arm:block $(,)? )*
+            _ => $default:expr $(,)?
         }
     ) => {{
         let __option : &dyn SocketOption = $option;
@@ -63,13 +62,13 @@ macro_rules! match_sock_option_ref {
         }
     }};
 }
+pub(in crate::net) use sock_option_ref;
 
-#[macro_export]
-macro_rules! match_sock_option_mut {
+macro_rules! sock_option_mut {
     (
-        $option:expr, {
-            $( $bind: ident : $ty:ty => $arm:expr ),*,
-            _ => $default:expr
+        match $option:ident {
+            $( $bind:ident @ $ty:ty => $arm:block $(,)? )*
+            _ => $default:expr $(,)?
         }
     ) => {{
         let __option : &mut dyn SocketOption = $option;
@@ -83,3 +82,4 @@ macro_rules! match_sock_option_mut {
         }
     }};
 }
+pub(in crate::net) use sock_option_mut;

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::util::LingerOption;
-use crate::{impl_socket_options, net::socket::unix::CUserCred, prelude::*, process::Gid};
+use macros::impl_socket_options;
 
-mod macros;
+use super::util::LingerOption;
+use crate::{net::socket::unix::CUserCred, prelude::*, process::Gid};
+
+pub(in crate::net) mod macros;
 
 /// Socket options. This trait represents all options that can be set or got for a socket, including
 /// socket level options and options for specific socket type like tcp socket.

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -6,10 +6,9 @@ use super::message::{MessageQueue, MessageReceiver};
 use crate::{
     events::IoEvents,
     fs::utils::Inode,
-    match_sock_option_mut,
     net::socket::{
         new_pseudo_inode,
-        options::{Error as SocketError, SocketOption},
+        options::{macros::sock_option_mut, Error as SocketError, SocketOption},
         private::SocketPrivate,
         unix::{ctrl_msg::AuxiliaryData, UnixSocketAddr},
         util::{
@@ -200,13 +199,13 @@ impl Socket for UnixDatagramSocket {
     }
 
     fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
-        match_sock_option_mut!(option, {
-            socket_errors: SocketError => {
+        sock_option_mut!(match option {
+            socket_errors @ SocketError => {
                 // TODO: Support socket errors for UNIX sockets
                 socket_errors.set(None);
                 return Ok(());
-            },
-            _ => ()
+            }
+            _ => (),
         });
 
         let options = self.options.read();


### PR DESCRIPTION
See the second point in https://github.com/asterinas/asterinas/issues/2649#issuecomment-3604934414 (quoted below):
> One major downside is that the macro does not work with rustfmt. However, I just conducted some experiments and discovered a solution.
> 
> This version does not work with rustfmt:
> ```rust
>         match_sock_option_mut!(option, {
>             socket_errors: SocketError => {
>                 let a = Some(1i32);
>                 a.map(|val| val + 1).map(|val| val + 11231).map(|val| val + 23233).filter(|val| *val > 2333).expect("abcd");
>                 socket_errors.set(self.test_and_clear_error());
>                 return Ok(());
>             },
>             _ => ()
>         });
> ```
> But this version works:
> ```rust
>     sock_option_mut!(match option {
>         socket_errors @ SocketError => {
>             let a = Some(1i32);
>             a.map(|val| val + 1)
>                 .map(|val| val + 11231)
>                 .map(|val| val + 23233)
>                 .filter(|val| *val > 2333)
>                 .expect("abcd");
>             socket_errors.set(self.test_and_clear_error());
>             return Ok(());
>         }
>         _ => (),
>     });
> ```
> It seems that rustfmt only formats code that is written in valid Rust syntax. Otherwise it won't format anything inside the macro.

Note that this follows the [exact Rust syntax](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=4b1cd07f50768c2228a89c6d64726efe):
```rust
let val = 3;
match val {
    n @ 1..=9 => n + 1,
    () => 0,
}
```


The downside might be:
```
        match $option:ident {
```
 - This can only be an `ident`. If we use `$option:expr`, there is an error:
```
error: `$option:expr` is followed by `{`, which is not allowed for `expr` fragments
  --> kernel/src/net/socket/options/macros.rs:69:28
   |
69 |         match $option:expr {
   |                            ^ not allowed after `expr` fragments
   |
   = note: allowed there are: `=>`, `,` or `;`
```

And:
```
            $( $bind:ident @ $ty:ty => $arm:block $(,)? )*
```
This can only be a `block`. If we use `$arm:expr`, there is an error:
```
error: `$arm:expr` may be followed by `_`, which is not allowed for `expr` fragments
  --> kernel/src/net/socket/options/macros.rs:71:13
   |
71 |             _ => $default:expr $(,)?
   |             ^ not allowed after `expr` fragments
   |
   = note: allowed there are: `=>`, `,` or `;`
```

For now, I don't think these downsides are having a negative impact.