### PR TITLE
Make some boot entry functions unsafe and document safety

### DIFF
--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -99,8 +99,17 @@ fn check_cpu_config() {
 /// The entry point of the Rust code portion of Asterinas.
 ///
 /// Reference: <https://docs.kernel.org/arch/loongarch/booting.html#information-passed-from-bootloader-to-kernel>
+///
+/// # Safety
+///
+/// - This function must be called only once through assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
-pub extern "C" fn loongarch_boot(_efi_boot: usize, cmdline_paddr: usize, systab_paddr: usize) -> ! {
+unsafe extern "C" fn loongarch_boot(
+    _efi_boot: usize,
+    cmdline_paddr: usize,
+    systab_paddr: usize,
+) -> ! {
     check_cpu_config();
 
     let systab_ptr = paddr_to_vaddr(systab_paddr) as *const EfiSystemTable;

--- a/ostd/src/arch/riscv/boot/bsp_boot.S
+++ b/ostd/src/arch/riscv/boot/bsp_boot.S
@@ -25,7 +25,7 @@ _start:
     # Arguments passed from SBI:
     #   a0 = hart id
     #   a1 = device tree paddr
-    # We do not touch them here. They are passed to the Rust entrypoint.
+    # We do not touch them here. They are passed to the Rust entrypoint `riscv_boot`.
 
     # Set up the Sv48 page table.
     #   sv48_boot_l4pt[511] = (PPN(sv48_boot_l3pt) << PTE_PPN_SHIFT) | PTE_V

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -107,8 +107,15 @@ fn parse_initramfs_range() -> Option<(usize, usize)> {
 static mut BOOTSTRAP_HART_ID: u32 = u32::MAX;
 
 /// The entry point of the Rust code portion of Asterinas.
+///
+/// `BOOTSTRAP_HART_ID` is initialized to be `hart_id` and accessible after calling this.
+///
+/// # Safety
+///
+/// - This function must be called only once through assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
-pub extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
+unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
     early_println!("Enter riscv_boot");
 
     // SAFETY: We only write it once this time. Other processors will only read

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -152,6 +152,7 @@ __ap_boot_cpu_id_tail:
 .code64
 
 ap_long_mode:
+    // Argument passed to ap_early_entry: rdi = cpu_id
     mov rdi, 1
     lock xadd [__ap_boot_cpu_id_tail], rdi
 

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -124,8 +124,14 @@ pub fn register_ap_entry(entry: fn()) {
     AP_LATE_ENTRY.call_once(|| entry);
 }
 
+/// Early boot entry of an AP.
+///
+/// # Safety
+///
+/// - This function must be called only once on each AP.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
-fn ap_early_entry(cpu_id: u32) -> ! {
+pub(crate) unsafe extern "C" fn ap_early_entry(cpu_id: u32) -> ! {
     // SAFETY:
     // 1. We're in the boot context of an AP.
     // 2. The CPU ID of the AP is correct.

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -165,8 +165,12 @@ impl TaskOptions {
         //
         // We provide an assembly wrapper for this function as the end of call stack so we
         // have to disable name mangling for it.
+        //
+        // # Safety
+        //
+        // This function must be called from `switch.S` when the context is prepared correctly.
         #[no_mangle]
-        extern "C" fn kernel_task_entry() -> ! {
+        unsafe extern "C" fn kernel_task_entry() -> ! {
             // SAFETY: The new task is switched on a CPU for the first time, `after_switching_to`
             // hasn't been called yet.
             unsafe { processor::after_switching_to() };


### PR DESCRIPTION
For consistency with boot entry functions being unsafe on x64, this PR makes more of such functions unsafe to prevent unsoundness of accidentally calling them from (safe) Rust. 

https://github.com/asterinas/asterinas/blob/9ad7c1855e3fcd19648b556db480d6a2cbee21a6/ostd/src/arch/x86/boot/linux_boot/mod.rs#L195-L197

https://github.com/asterinas/asterinas/blob/9ad7c1855e3fcd19648b556db480d6a2cbee21a6/ostd/src/arch/x86/boot/multiboot/mod.rs#L365-L367

https://github.com/asterinas/asterinas/blob/9ad7c1855e3fcd19648b556db480d6a2cbee21a6/ostd/src/arch/x86/boot/multiboot2/mod.rs#L140-L142

