### PR TITLE
Support syscall `syncfs`

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -326,7 +326,7 @@ which are summarized in the table below.
 | 303     | name_to_handle_at      | ❌             | N/A |
 | 304     | open_by_handle_at      | ❌             | N/A |
 | 305     | clock_adjtime          | ❌             | N/A |
-| 306     | syncfs                 | ❌             | N/A |
+| 306     | syncfs                 | ✅             | 💯 |
 | 307     | sendmmsg               | ✅             | [⚠️](syscall-flag-coverage/networking-and-sockets/#sendto-and-sendmsg) |
 | 308     | setns                  | ✅             | ❓ |
 | 309     | getcpu                 | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fully_covered.scml
@@ -5,6 +5,10 @@ fstatfs(fd, buf);
 // Commit filesystem caches to disk
 sync();
 
+// Commit caches of the filesystem containing the file referred to
+// by the file descriptor `fd` to disk
+syncfs(fd);
+
 // Change root directory
 chroot(path);
 

--- a/kernel/src/syscall/arch/loongarch.rs
+++ b/kernel/src/syscall/arch/loongarch.rs
@@ -142,7 +142,7 @@ use super::{
     statfs::{sys_fstatfs, sys_statfs},
     statx::sys_statx,
     symlink::sys_symlinkat,
-    sync::sys_sync,
+    sync::{sys_sync, sys_syncfs},
     sysinfo::sys_sysinfo,
     tgkill::sys_tgkill,
     timer_create::{sys_timer_create, sys_timer_delete},
@@ -339,6 +339,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SYNCFS = 267                 => sys_syncfs(args[..1]);
     SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SENDMMSG = 269               => sys_sendmmsg(args[..4]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);

--- a/kernel/src/syscall/arch/riscv.rs
+++ b/kernel/src/syscall/arch/riscv.rs
@@ -142,7 +142,7 @@ use super::{
     statfs::{sys_fstatfs, sys_statfs},
     statx::sys_statx,
     symlink::sys_symlinkat,
-    sync::sys_sync,
+    sync::{sys_sync, sys_syncfs},
     sysinfo::sys_sysinfo,
     tgkill::sys_tgkill,
     timer_create::{sys_timer_create, sys_timer_delete},
@@ -341,6 +341,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
     SYS_WAIT4 = 260                  => sys_wait4(args[..4]);
     SYS_PRLIMIT64 = 261              => sys_prlimit64(args[..4]);
+    SYS_SYNCFS = 267                 => sys_syncfs(args[..1]);
     SYS_SETNS = 268                  => sys_setns(args[..2]);
     SYS_SENDMMSG = 269               => sys_sendmmsg(args[..4]);
     SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -153,7 +153,7 @@ use super::{
     statfs::{sys_fstatfs, sys_statfs},
     statx::sys_statx,
     symlink::{sys_symlink, sys_symlinkat},
-    sync::sys_sync,
+    sync::{sys_sync, sys_syncfs},
     sysinfo::sys_sysinfo,
     tgkill::sys_tgkill,
     time::sys_time,
@@ -389,6 +389,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PREADV = 295           => sys_preadv(args[..5]);
     SYS_PWRITEV = 296          => sys_pwritev(args[..5]);
     SYS_PRLIMIT64 = 302        => sys_prlimit64(args[..4]);
+    SYS_SYNCFS = 306           => sys_syncfs(args[..1]);
     SYS_SENDMMSG = 307         => sys_sendmmsg(args[..4]);
     SYS_SETNS = 308            => sys_setns(args[..2]);
     SYS_GETCPU = 309           => sys_getcpu(args[..3]);

--- a/kernel/src/syscall/sync.rs
+++ b/kernel/src/syscall/sync.rs
@@ -1,11 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::prelude::*;
+use crate::{
+    fs::file_table::{get_file_fast, FileDesc},
+    prelude::*,
+};
 
 pub fn sys_sync(ctx: &Context) -> Result<SyscallReturn> {
     let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
     let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
     current_mnt_ns.sync()?;
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_syncfs(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
+    debug!("fd = {}", fd);
+
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+    file.inode().fs().sync()?;
     Ok(SyscallReturn::Return(0))
 }


### PR DESCRIPTION
This is required for supporting `nixos-rebuild` in Asterinas NixOS. https://github.com/asterinas/asterinas/issues/2672

Reference: https://man7.org/linux/man-pages/man2/syncfs.2.html