### PR TITLE
Add overlay and configuration files for Podman

### DIFF
--- a/distro/aster_configuration.nix
+++ b/distro/aster_configuration.nix
@@ -17,7 +17,8 @@
   # The content defined in these module files must adhere to the options permissible within 'configuration.nix'. 
   # For a comprehensive list of available options,
   # please refer to https://search.nixos.org/options.
-  imports = [ ./modules/core.nix ./modules/xfce/default.nix ];
+  imports =
+    [ ./modules/core.nix ./modules/xfce/default.nix ./modules/container.nix ];
 
   # Overlays provide patches to 'nixpkgs' that enable these packages to run effectively on AsterNixOS.
   # For details on the overlay file definition format, 
@@ -25,5 +26,6 @@
   nixpkgs.overlays = [
     (import ./overlays/hello-asterinas/default.nix)
     (import ./overlays/desktop/default.nix)
+    (import ./overlays/podman/default.nix)
   ];
 }

--- a/distro/configuration.nix
+++ b/distro/configuration.nix
@@ -19,6 +19,10 @@
   # You can use https://search.nixos.org/ to find more packages (and options).
   environment.systemPackages = with pkgs; [ hello-asterinas ];
 
+  # Uncomment the following two lines to enable Podman.
+  # virtualisation.podman.enable = true;
+  # virtualisation.containers.enable = true;
+
   system.nixos.distroName = "Asterinas NixOS";
 
   # This option defines the first version of NixOS you have installed on this particular machine,

--- a/distro/modules/container.nix
+++ b/distro/modules/container.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }: {
+  virtualisation.containers.storage.settings = {
+    storage = {
+      driver = "vfs";
+      runroot = "/run/containers/storage";
+      graphroot = "/var/lib/containers/storage";
+    };
+  };
+
+  virtualisation.containers.policy = {
+    default = [{ type = "insecureAcceptAnything"; }];
+  };
+
+  virtualisation.containers.containersConf.settings = {
+    containers = {
+      cgroupns = "host";
+      cgroups = "enabled";
+      default_sysctls = [ ];
+      ipcns = "host";
+      keyring = false;
+      netns = "host";
+      pidns = "host";
+      privileged = true;
+      seccomp_profile = "unconfined";
+      userns = "host";
+      devices = [ ];
+    };
+
+    secrets = { };
+    network = { };
+    engine = {
+      cgroup_manager = "cgroupfs";
+      events_logger = "none";
+      no_pivot_root = true;
+      runtime = "runc";
+    };
+  };
+}

--- a/distro/overlays/podman/Podman-Disable-etc-hosts-and-etc-resolv-conf-injection.patch
+++ b/distro/overlays/podman/Podman-Disable-etc-hosts-and-etc-resolv-conf-injection.patch
@@ -1,0 +1,42 @@
+From b16b6eb174407a34fbbd1a2d8c566ecfbc1b3af0 Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Wed, 17 Sep 2025 12:02:50 +0000
+Subject: [PATCH] Podman: Disable /etc/hosts and /etc/resolv.conf injection
+
+---
+ libpod/container_internal.go | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/libpod/container_internal.go b/libpod/container_internal.go
+index 1d879d06cb..3c4c1ed921 100644
+--- a/libpod/container_internal.go
++++ b/libpod/container_internal.go
+@@ -1013,7 +1013,8 @@ func (c *Container) completeNetworkSetup() error {
+ 	}
+ 	if netDisabled {
+ 		// with net=none we still want to set up /etc/hosts
+-		return c.addHosts()
++		// return c.addHosts()
++		return nil
+ 	}
+ 	if c.config.NetNsCtr != "" {
+ 		return nil
+@@ -1030,11 +1031,12 @@ func (c *Container) completeNetworkSetup() error {
+ 		}
+ 	}
+ 	// add /etc/hosts entries
+-	if err := c.addHosts(); err != nil {
+-		return err
+-	}
++	// if err := c.addHosts(); err != nil {
++	// 	return err
++	// }
+ 
+-	return c.addResolvConf()
++	// return c.addResolvConf()
++	return nil
+ }
+ 
+ // Initialize a container, creating it in the runtime
+-- 
+2.34.1

--- a/distro/overlays/podman/default.nix
+++ b/distro/overlays/podman/default.nix
@@ -1,0 +1,15 @@
+final: prev: {
+  runc = prev.runc.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or [ ]) ++ [
+      ./runc-Disable-container-state-check.patch
+      ./runc-Disable-creating-dev-mqueue.patch
+      ./runc-Disable-eBPF-for-device-filtering.patch
+      ./runc-Disable-user-and-capability-setup-checks.patch
+      ./runc-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+    ];
+  });
+  podman = (prev.podman.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or [ ])
+      ++ [ ./Podman-Disable-etc-hosts-and-etc-resolv-conf-injection.patch ];
+  })).override { runc = final.runc; };
+}

--- a/distro/overlays/podman/runc-Disable-container-state-check.patch
+++ b/distro/overlays/podman/runc-Disable-container-state-check.patch
@@ -1,0 +1,24 @@
+From 1eedcce83f03e0627411f082340f776781a27628 Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Fri, 5 Dec 2025 09:09:14 +0000
+Subject: [PATCH] runc: Disable container state check
+
+---
+ libcontainer/state_linux.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libcontainer/state_linux.go b/libcontainer/state_linux.go
+index aa6259b1..52615b93 100644
+--- a/libcontainer/state_linux.go
++++ b/libcontainer/state_linux.go
+@@ -94,6 +94,8 @@ func (b *stoppedState) transition(s containerState) error {
+ 		return nil
+ 	case *stoppedState:
+ 		return nil
++	case *createdState:
++		return nil
+ 	}
+ 	return newStateTransitionError(b, s)
+ }
+-- 
+2.34.1

--- a/distro/overlays/podman/runc-Disable-creating-dev-mqueue.patch
+++ b/distro/overlays/podman/runc-Disable-creating-dev-mqueue.patch
@@ -1,0 +1,40 @@
+From fd4389860594a0bab956a5a51647f3818a279c69 Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Fri, 5 Dec 2025 09:14:57 +0000
+Subject: [PATCH] runc: Disable creating /dev/mqueue
+
+---
+ libcontainer/rootfs_linux.go | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/rootfs_linux.go b/libcontainer/rootfs_linux.go
+index 930bc34f..18f8b7d1 100644
+--- a/libcontainer/rootfs_linux.go
++++ b/libcontainer/rootfs_linux.go
+@@ -482,7 +482,7 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
+ 	}
+ 
+ 	mountFd := c.fd
+-	dest, err := createMountpoint(rootfs, m, mountFd, m.Source)
++	_, err := createMountpoint(rootfs, m, mountFd, m.Source)
+ 	if err != nil {
+ 		return fmt.Errorf("create mount destination for %s mount: %w", m.Destination, err)
+ 	}
+@@ -490,10 +490,11 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
+ 
+ 	switch m.Device {
+ 	case "mqueue":
+-		if err := mountPropagate(m, rootfs, "", nil); err != nil {
+-			return err
+-		}
+-		return label.SetFileLabel(dest, mountLabel)
++		// if err := mountPropagate(m, rootfs, "", nil); err != nil {
++		// 	return err
++		// }
++		// return label.SetFileLabel(dest, mountLabel)
++		return nil
+ 	case "tmpfs":
+ 		if m.Extensions&configs.EXT_COPYUP == configs.EXT_COPYUP {
+ 			err = doTmpfsCopyUp(m, rootfs, mountLabel)
+-- 
+2.34.1

--- a/distro/overlays/podman/runc-Disable-eBPF-for-device-filtering.patch
+++ b/distro/overlays/podman/runc-Disable-eBPF-for-device-filtering.patch
@@ -1,0 +1,48 @@
+From f988afe0f4440ee4195c7aa7d968fcc3f397d55f Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Fri, 5 Dec 2025 09:07:15 +0000
+Subject: [PATCH] runc: Disable eBPF for device filtering
+
+---
+ libcontainer/cgroups/fs2/devices.go | 13 ++++++-------
+ 1 file changed, 6 insertions(+), 7 deletions(-)
+
+diff --git a/libcontainer/cgroups/fs2/devices.go b/libcontainer/cgroups/fs2/devices.go
+index 0d234560..5b16fb9b 100644
+--- a/libcontainer/cgroups/fs2/devices.go
++++ b/libcontainer/cgroups/fs2/devices.go
+@@ -5,7 +5,6 @@ import (
+ 
+ 	"golang.org/x/sys/unix"
+ 
+-	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf"
+ 	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf/devicefilter"
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ 	"github.com/opencontainers/runc/libcontainer/devices"
+@@ -57,7 +56,7 @@ func setDevices(dirPath string, r *configs.Resources) error {
+ 	if r.SkipDevices {
+ 		return nil
+ 	}
+-	insts, license, err := devicefilter.DeviceFilter(r.Devices)
++	_, _, err := devicefilter.DeviceFilter(r.Devices)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -66,10 +65,10 @@ func setDevices(dirPath string, r *configs.Resources) error {
+ 		return fmt.Errorf("cannot get dir FD for %s", dirPath)
+ 	}
+ 	defer unix.Close(dirFD)
+-	if _, err := ebpf.LoadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {
+-		if !canSkipEBPFError(r) {
+-			return err
+-		}
+-	}
++	// if _, err := ebpf.LoadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {
++	// 	if !canSkipEBPFError(r) {
++	// 		return err
++	// 	}
++	// }
+ 	return nil
+ }
+-- 
+2.34.1

--- a/distro/overlays/podman/runc-Disable-user-and-capability-setup-checks.patch
+++ b/distro/overlays/podman/runc-Disable-user-and-capability-setup-checks.patch
@@ -1,0 +1,33 @@
+From cac64a82434caaf91df7cbc3d567442ee5e27fec Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Fri, 5 Dec 2025 09:18:05 +0000
+Subject: [PATCH] runc: Disable user and capability setup checks
+
+---
+ libcontainer/init_linux.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libcontainer/init_linux.go b/libcontainer/init_linux.go
+index c849ec6b..9de25d5c 100644
+--- a/libcontainer/init_linux.go
++++ b/libcontainer/init_linux.go
+@@ -218,7 +218,7 @@ func finalizeNamespace(config *initConfig) error {
+ 		return fmt.Errorf("unable to set keep caps: %w", err)
+ 	}
+ 	if err := setupUser(config); err != nil {
+-		return fmt.Errorf("unable to setup user: %w", err)
++		// return fmt.Errorf("unable to setup user: %w", err)
+ 	}
+ 	// Change working directory AFTER the user has been set up, if we haven't done it yet.
+ 	if doChdir {
+@@ -234,7 +234,7 @@ func finalizeNamespace(config *initConfig) error {
+ 		return fmt.Errorf("unable to clear keep caps: %w", err)
+ 	}
+ 	if err := w.ApplyCaps(); err != nil {
+-		return fmt.Errorf("unable to apply caps: %w", err)
++		// return fmt.Errorf("unable to apply caps: %w", err)
+ 	}
+ 	return nil
+ }
+-- 
+2.34.1

--- a/distro/overlays/podman/runc-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+++ b/distro/overlays/podman/runc-Switch-MS_SLAVE-to-MS_PRIVATE.patch
@@ -1,0 +1,42 @@
+From a4e533f9fee4e3ae57c802ffd7073026a8417b84 Mon Sep 17 00:00:00 2001
+From: jiangjianfeng <jiangjianfeng.jjf@antgroup.com>
+Date: Fri, 5 Dec 2025 08:07:46 +0000
+Subject: [PATCH] runc: Switch MS_SLAVE to MS_PRIVATE.
+
+---
+ libcontainer/rootfs_linux.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libcontainer/rootfs_linux.go b/libcontainer/rootfs_linux.go
+index 1c2ea07a..18f8b7d1 100644
+--- a/libcontainer/rootfs_linux.go
++++ b/libcontainer/rootfs_linux.go
+@@ -832,7 +832,7 @@ func rootfsParentMountPrivate(path string) error {
+ }
+ 
+ func prepareRoot(config *configs.Config) error {
+-	flag := unix.MS_SLAVE | unix.MS_REC
++	flag := unix.MS_PRIVATE | unix.MS_REC
+ 	if config.RootPropagation != 0 {
+ 		flag = config.RootPropagation
+ 	}
+@@ -917,7 +917,7 @@ func pivotRoot(rootfs string) error {
+ 	// known to cause issues due to races where we still have a reference to a
+ 	// mount while a process in the host namespace are trying to operate on
+ 	// something they think has no mounts (devicemapper in particular).
+-	if err := mount("", ".", "", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
++	if err := mount("", ".", "", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+ 		return err
+ 	}
+ 	// Perform the unmount. MNT_DETACH allows us to unmount /proc/self/cwd.
+@@ -966,7 +966,7 @@ func msMoveRoot(rootfs string) error {
+ 	for _, info := range mountinfos {
+ 		p := info.Mountpoint
+ 		// Be sure umount events are not propagated to the host.
+-		if err := mount("", p, "", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
++		if err := mount("", p, "", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+ 			if errors.Is(err, unix.ENOENT) {
+ 				// If the mountpoint doesn't exist that means that we've
+ 				// already blasted away some parent directory of the mountpoint
+-- 
+2.34.1


### PR DESCRIPTION
This PR introduces the necessary configuration and overlay files for Podman. However, two additional PRs should be merged before Podman can be fully operational: #2592 (for cgroup controller support) and another one addressing systemd support for mounting special filesystems like cgroupfs. Consequently, this PR does not include any tests for Podman at this stage.