### PR TITLE
Revise safety comments of entry points

### DIFF
--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -102,7 +102,7 @@ fn check_cpu_config() {
 ///
 /// # Safety
 ///
-/// - This function must be called only once through assembly code.
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
 /// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "C" fn loongarch_boot(

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -112,14 +112,15 @@ static mut BOOTSTRAP_HART_ID: u32 = u32::MAX;
 ///
 /// # Safety
 ///
-/// - This function must be called only once through assembly code.
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
 /// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
     early_println!("Enter riscv_boot");
 
-    // SAFETY: We only write it once this time. Other processors will only read
-    // it. And other processors are not booted yet so there's no races.
+    // We will only write it once. Other processors will only read it.
+    // SAFETY: We don't create Rust references, so there are no aliasing problems. Other processors
+    // have not been booted yet, so there are no data races.
     unsafe { BOOTSTRAP_HART_ID = hart_id as u32 };
 
     let device_tree_ptr = paddr_to_vaddr(device_tree_paddr) as *const u8;

--- a/ostd/src/arch/riscv/boot/smp.rs
+++ b/ostd/src/arch/riscv/boot/smp.rs
@@ -190,7 +190,8 @@ cpu_local_cell! {
 //
 /// # Safety
 ///
-/// - This function must be called only once on each AP through assembly code.
+/// - This function must be called only once on each AP at a proper timing in the AP's boot
+///   assembly code.
 /// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "C" fn riscv_ap_early_entry(cpu_id: u32, hart_id: u32) -> ! {
@@ -199,7 +200,9 @@ unsafe extern "C" fn riscv_ap_early_entry(cpu_id: u32, hart_id: u32) -> ! {
     AP_CURRENT_HART_ID.store(hart_id);
 
     // SAFETY: This is valid to call, because
-    // - the caller guarantees being called only once on each AP.
-    // - the compiler guarantees the C calling conventions on this call.
+    // - The caller is the AP's boot assembly code. It also guarantees that this method will be
+    //   called only once on each AP. No uninitialized AP states are accessed by the code above.
+    // - The compiler guarantees the C calling conventions for this call, and the caller guarantees
+    //   the correctness of the arguments.
     unsafe { ap_early_entry(cpu_id) }
 }

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -192,7 +192,12 @@ fn parse_memory_regions(boot_params: &BootParams) -> MemoryRegionArray {
     regions.into_non_overlapping()
 }
 
-/// The entry point of the Rust code portion of Asterinas.
+/// The entry point of the Rust code portion of Asterinas (with Linux boot parameters).
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
     let params = unsafe { &*params_ptr };

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -362,7 +362,12 @@ impl Iterator for MemoryEntryIter {
     }
 }
 
-/// The entry point of Rust code called by inline asm.
+/// The entry point of the Rust code portion of Asterinas (with multiboot parameters).
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "sysv64" fn __multiboot_entry(boot_magic: u32, boot_params: u64) -> ! {
     assert_eq!(boot_magic, MULTIBOOT_ENTRY_MAGIC);

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -137,7 +137,12 @@ fn parse_memory_regions(mb2_info: &BootInformation) -> MemoryRegionArray {
     regions.into_non_overlapping()
 }
 
-/// The entry point of Rust code called by inline asm.
+/// The entry point of the Rust code portion of Asterinas (with multiboot2 parameters).
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 unsafe extern "sysv64" fn __multiboot2_entry(boot_magic: u32, boot_params: u64) -> ! {
     assert_eq!(boot_magic, multiboot2::MAGIC);

--- a/ostd/src/boot/smp.rs
+++ b/ostd/src/boot/smp.rs
@@ -124,11 +124,12 @@ pub fn register_ap_entry(entry: fn()) {
     AP_LATE_ENTRY.call_once(|| entry);
 }
 
-/// Early boot entry of an AP.
+/// The AP's entry point of the Rust code portion of Asterinas.
 ///
 /// # Safety
 ///
-/// - This function must be called only once on each AP.
+/// - This function must be called only once on each AP at a proper timing in the AP's boot
+///   assembly code, or via a thin Rust wrapper that does not access uninitialized AP states.
 /// - The caller must follow C calling conventions and put the right arguments in registers.
 #[no_mangle]
 pub(crate) unsafe extern "C" fn ap_early_entry(cpu_id: u32) -> ! {


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/4f71f4bbe6456849929d7035ec5f23bb04200279/ostd/src/boot/smp.rs#L129-L134

I don't think this is enough. It needs to guarantee the following:
https://github.com/asterinas/asterinas/blob/4f71f4bbe6456849929d7035ec5f23bb04200279/ostd/src/arch/riscv/mod.rs#L74-L77
More specifically:
https://github.com/asterinas/asterinas/blob/4f71f4bbe6456849929d7035ec5f23bb04200279/ostd/src/arch/riscv/irq/chip/mod.rs#L57-L59

However, the current safety requirements cannot. `riscv_ap_early_entry` can call many (safe) methods without violating the safety condition of `ap_early_entry`. However, it can violate the safety condition of `arch::riscv::init_on_ap`/`arch::riscv::irq::chip::init`.

The safety comments for the `ap_early_entry` method need to be more specific than just stating that the method can only be called once. I propose:
```rust
/// - This function must be called only once on each AP at a proper timing in the AP's boot
///   assembly code, or via a thin Rust wrapper that does not access uninitialized AP states.
```

Then,
 - If it is called from the AP's boot assembly code, we know that no Rust methods have been called yet.
 - If it is called via a thin Rust wrapper, we must also state that the Rust wrapper will not access uninitialized AP states. This means it cannot call methods inside `arch::riscv::irq::chip`, which would violate the safety conditions of `arch::riscv::irq::chip::init`.

In addition, I use "at a proper timing" to mean that this method must be called after the AP's boot assembly code prepares all the necessary resources. It is not safe to call it in the middle of the boot assembly code, for example. It is similar to:
https://github.com/asterinas/asterinas/blob/4f71f4bbe6456849929d7035ec5f23bb04200279/ostd/src/arch/riscv/timer/mod.rs#L28