### PR TITLE
Workaround unrecognized input event types by writing all zeros

### DIFF
--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -334,6 +334,19 @@ fn handle_get_bit(evdev: &Arc<EvdevDevice>, event_type: u8, writer: &mut VmWrite
             let bitmap = capability.supported_relative_axes_bitmap();
             write_bytes_and_zeros_to_userspace(writer, bitmap)?;
         }
+        t if t == EventTypes::ABS.as_index()
+            || t == EventTypes::LED.as_index()
+            || t == EventTypes::SW.as_index()
+            || t == EventTypes::MSC.as_index()
+            || t == EventTypes::FF.as_index()
+            || t == EventTypes::SND.as_index() =>
+        {
+            // TODO: We do not support these uncommon event types yet, but
+            // returning an error would cause `libevdev` to crash. So we report
+            // a zeroed bitmap here. See
+            // <https://cgit.freedesktop.org/libevdev/tree/libevdev/libevdev.c?h=libevdev-1.13.6#n459>.
+            writer.fill_zeros(writer.avail())?;
+        }
         _ => {
             return_errno_with_message!(Errno::EINVAL, "the event type is not supported yet");
         }


### PR DESCRIPTION
This PR serves as a debug patch for PR [#2582](https://github.com/asterinas/asterinas/pull/2582). While that PR successfully passed `evtest`, we discovered that it would crash when running XFCE due to additional calls of  other discriminants of `GetEventBits`. Although it doesn't utilize these uncommon event types, the ioctl would crash if it returned an error. This patch ensures that those calls return Ok instead of errors, preventing the crash.