### PR TITLE
Fix the implementation of prlimit64 syscall and the init process value of ResourceLimits

### DIFF
--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -17,7 +17,7 @@ use crate::{
         posix_thread::{PosixThreadBuilder, ThreadName, allocate_posix_tid},
         process_table,
         process_vm::new_vmar_and_map,
-        rlimit::ResourceLimits,
+        rlimit::new_resource_limits_for_init,
         signal::sig_disposition::SigDispositions,
     },
     sched::Nice,
@@ -56,7 +56,7 @@ fn create_init_process(
 
     let pid = allocate_posix_tid();
     let process_vm = new_vmar_and_map(PathOrInode::Path(elf_path.clone()));
-    let resource_limits = ResourceLimits::default();
+    let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
     let oom_score_adj = 0;
     let sig_dispositions = Arc::new(Mutex::new(SigDispositions::default()));

--- a/kernel/src/syscall/prlimit64.rs
+++ b/kernel/src/syscall/prlimit64.rs
@@ -5,7 +5,13 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Pid, ResourceType, rlimit::RawRLimit64},
+    process::{
+        Pid, Process, ResourceType,
+        credentials::capabilities::CapSet,
+        posix_thread::{AsPosixThread, PosixThread},
+        process_table,
+        rlimit::RawRLimit64,
+    },
 };
 
 pub fn sys_getrlimit(resource: u32, rlim_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
@@ -45,19 +51,74 @@ pub fn sys_prlimit64(
         "pid = {}, resource = {:?}, new_rlim_addr = 0x{:x}, old_rlim_addr = 0x{:x}",
         pid, resource, new_rlim_addr, old_rlim_addr
     );
-    let resource_limits = ctx.process.resource_limits();
-    if old_rlim_addr != 0 {
-        let rlimit = resource_limits.get_rlimit(resource);
-        let (cur, max) = rlimit.get_cur_and_max();
-        let rlimit_raw = RawRLimit64 { cur, max };
-        ctx.user_space().write_val(old_rlim_addr, &rlimit_raw)?;
-    }
-    if new_rlim_addr != 0 {
-        let new_raw: RawRLimit64 = ctx.user_space().read_val(new_rlim_addr)?;
-        debug!("new_rlimit = {:?}", new_raw);
-        resource_limits
-            .get_rlimit(resource)
-            .set_cur_and_max(new_raw.cur, new_raw.max)?;
+
+    let get_and_set_rlimit = |process: &Process| -> Result<()> {
+        let resource_limits = process.resource_limits();
+
+        if old_rlim_addr != 0 {
+            let rlimit = resource_limits.get_rlimit(resource);
+            let (cur, max) = rlimit.get_cur_and_max();
+            let rlimit_raw = RawRLimit64 { cur, max };
+            ctx.user_space().write_val(old_rlim_addr, &rlimit_raw)?;
+        }
+        if new_rlim_addr != 0 {
+            let new_raw: RawRLimit64 = ctx.user_space().read_val(new_rlim_addr)?;
+            debug!("new_rlimit = {:?}", new_raw);
+            resource_limits
+                .get_rlimit(resource)
+                .set_cur_and_max(new_raw.cur, new_raw.max)?;
+        }
+
+        Ok(())
+    };
+
+    if pid == 0 || pid == ctx.process.pid() {
+        get_and_set_rlimit(ctx.process.as_ref())?;
+    } else {
+        let target_process = process_table::get_process(pid).ok_or_else(|| {
+            Error::with_message(Errno::ESRCH, "the target process does not exist")
+        })?;
+
+        // Check permissions
+        check_rlimit_perm(target_process.main_thread().as_posix_thread().unwrap(), ctx)?;
+        get_and_set_rlimit(target_process.as_ref())?;
     }
     Ok(SyscallReturn::Return(0))
+}
+
+/// Checks whether the current process has permission to access
+/// the resource limits of the target process.
+// Reference: <https://man7.org/linux/man-pages/man2/prlimit.2.html>
+fn check_rlimit_perm(target: &PosixThread, ctx: &Context) -> Result<()> {
+    let target_process = target.process();
+
+    let current_cred = ctx.posix_thread.credentials();
+    let target_cred = target.credentials();
+
+    if target_process
+        .user_ns()
+        .lock()
+        .check_cap(CapSet::SYS_RESOURCE, ctx.posix_thread)
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    let current_ruid = current_cred.ruid();
+    let current_rgid = current_cred.rgid();
+
+    if current_ruid == target_cred.ruid()
+        && current_ruid == target_cred.euid()
+        && current_ruid == target_cred.suid()
+        && current_rgid == target_cred.rgid()
+        && current_rgid == target_cred.egid()
+        && current_rgid == target_cred.sgid()
+    {
+        return Ok(());
+    }
+
+    return_errno_with_message!(
+        Errno::EPERM,
+        "accessing the resource limits of the target process is not allowed"
+    )
 }


### PR DESCRIPTION
### Short description

Fix incorrect handling of the `pid` argument in the `prlimit64` syscall implementation. This patch updates the implementation to follow the correct behavior as documented in the [Linux manual page](https://man7.org/linux/man-pages/man2/prlimit.2.html).

According to the [Linux code](https://github.com/torvalds/linux/blob/cb015814f8b6eebcbb8e46e111d108892c5e6821/kernel/fork.c#L869C50-L870), this pr also correct the value of ResourceLimits for the init process.

### Review notes

When reviewing and merging this PR, please pay extra attention to the capability-related logic to make sure it remains correct and consistent with the existing design.