### PR TITLE
Set `build-users-group` following official usage

### DIFF
--- a/distro/modules/core.nix
+++ b/distro/modules/core.nix
@@ -69,6 +69,6 @@ in {
     sandbox = false;
     # FIXME: Support Nix build users (nixbld*) and remove this setting. For detailed gaps, see
     # <https://github.com/asterinas/asterinas/issues/2672>.
-    build-users-group = [ ];
+    build-users-group = "";
   };
 }


### PR DESCRIPTION
Discussed in https://github.com/asterinas/asterinas/pull/2710#discussion_r2602191634.

Reference: 
https://nix.dev/manual/nix/2.32/command-ref/conf-file#conf-build-users-group
https://github.com/NixOS/nix/blob/7448aedd74e28174bfa33aad0d148c0070c86dfb/src/libstore/include/nix/store/globals.hh#L477-L515