### PR TITLE
Default to WUXGA resolution (1920x1200)

### DIFF
--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -105,6 +105,7 @@ fi
 QEMU_ARGS="\
     $COMMON_QEMU_ARGS \
     -machine q35,kernel-irqchip=split \
+    -device VGA,xres=1920,yres=1200 \
     -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \


### PR DESCRIPTION
Switch from 1280x800 to 1920x1200 to match productivity-focused displays commonly found on monitors and laptops, giving VMs more vertical workspace.