### PR TITLE
Fix the wrong behavior of TCSETSW flag

### DIFF
--- a/kernel/src/device/pty/driver.rs
+++ b/kernel/src/device/pty/driver.rs
@@ -146,11 +146,6 @@ impl TtyDriver for PtyDriver {
         Ok(len)
     }
 
-    fn drain_output(&self) {
-        self.output.lock().clear();
-        self.pollee.invalidate();
-    }
-
     fn echo_callback(&self) -> impl FnMut(&[u8]) + '_ {
         let mut output = self.output.lock();
         let mut has_notified = false;

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -170,7 +170,7 @@ impl FileIo for PtyMaster {
         use crate::{device::tty::ioctl_defs::*, fs::utils::ioctl_defs::GetNumBytesToRead};
 
         dispatch_ioctl!(match raw_ioctl {
-            GetTermios | SetTermios | SetTermiosDrain | SetTermiosFlush | GetWinSize
+            GetTermios | SetTermios | SetTermiosWait | SetTermiosFlush | GetWinSize
             | SetWinSize | GetPtyNumber => {
                 return self.slave.ioctl(raw_ioctl);
             }

--- a/kernel/src/device/tty/driver.rs
+++ b/kernel/src/device/tty/driver.rs
@@ -36,9 +36,6 @@ pub trait TtyDriver: Send + Sync + 'static {
     /// pushed.
     fn push_output(&self, chs: &[u8]) -> Result<usize>;
 
-    /// Drains the output buffer.
-    fn drain_output(&self);
-
     /// Returns a callback function that echoes input characters to the output buffer.
     ///
     /// Note that the implementation may choose to hold a lock during the life of the callback.

--- a/kernel/src/device/tty/ioctl_defs.rs
+++ b/kernel/src/device/tty/ioctl_defs.rs
@@ -10,7 +10,7 @@ use crate::util::ioctl::{InData, OutData, PassByVal, ioc};
 
 pub type GetTermios      = ioc!(TCGETS,     0x5401,     OutData<CTermios>);
 pub type SetTermios      = ioc!(TCSETS,     0x5402,     InData<CTermios>);
-pub type SetTermiosDrain = ioc!(TCSETSW,    0x5403,     InData<CTermios>);
+pub type SetTermiosWait  = ioc!(TCSETSW,    0x5403,     InData<CTermios>);
 pub type SetTermiosFlush = ioc!(TCSETSF,    0x5404,     InData<CTermios>);
 
 pub type GetWinSize      = ioc!(TIOCGWINSZ, 0x5413,     OutData<CWinSize>);

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -320,24 +320,29 @@ impl<D: TtyDriver> Tty<D> {
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
             }
-            cmd @ SetTermiosDrain => {
+            cmd @ SetTermiosWait => {
                 let termios = cmd.read()?;
 
+                // TODO: If applicable, wait for the output buffer to drain. For now, we don't need
+                // to do anything here because:
+                //  - Linux does not consider a pty to have an output buffer, so it does not drain
+                //    it. See
+                //    <https://elixir.bootlin.com/linux/v5.10.247/source/drivers/tty/pty.c#L137-L148>.
+                //  - We don't currently have an output buffer for other TTYs.
                 let mut ldisc = self.ldisc.lock();
                 let old_termios = ldisc.termios();
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
-                self.driver.drain_output();
             }
             cmd @ SetTermiosFlush => {
                 let termios = cmd.read()?;
 
+                // TODO: If applicable, wait for the output buffer to drain. (See comments above.)
                 let mut ldisc = self.ldisc.lock();
                 let old_termios = ldisc.termios();
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
                 ldisc.drain_input();
-                self.driver.drain_output();
 
                 self.pollee.invalidate();
             }

--- a/kernel/src/device/tty/n_tty.rs
+++ b/kernel/src/device/tty/n_tty.rs
@@ -46,8 +46,6 @@ impl TtyDriver for VtDriver {
         Ok(chs.len())
     }
 
-    fn drain_output(&self) {}
-
     fn echo_callback(&self) -> impl FnMut(&[u8]) + '_ {
         |chs| self.console.send(chs)
     }
@@ -87,8 +85,6 @@ impl TtyDriver for HvcDriver {
         self.console.send(chs);
         Ok(chs.len())
     }
-
-    fn drain_output(&self) {}
 
     fn echo_callback(&self) -> impl FnMut(&[u8]) + '_ {
         |chs| self.console.send(chs)


### PR DESCRIPTION
We currently call flag TCSETSW `SetTermiosDrain` in Asterinas, but this makes no sense. Flag TCSETSW in Linux has a wait semantic, not a drain semantic. This misuse is the root cause of the current pty output issues. 

Since we currently lack related mechanisms to support wait, this fix does not introduce additional behavior for this flag.