### PR TITLE
Bypass system dbus in `switch-to-configuration-ng`

### DIFF
--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -33,12 +33,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use nix-env to install and run the hello package
         run: |
-          make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=4096 NIXOS_TEST_COMMAND='nix-env -iA nixos.hello && hello' || true
+          make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=6144 NIXOS_TEST_COMMAND='nix-env -iA nixos.hello && hello' || true
           tail --lines 10 qemu.log | grep -q "^Hello, world!" || (echo "Test nix-env failed" && exit 1)
           echo "Test nix-env succeeds!"
       - name: Use nix-shell to install and run the hello package
         run: |
-          make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=4096 NIXOS_TEST_COMMAND='nix-shell -p hello --command hello' || true
+          make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=6144 NIXOS_TEST_COMMAND='nix-shell -p hello --command hello' || true
           tail --lines 10 qemu.log | grep -q "^Hello, world!" || (echo "Test nix-shell failed" && exit 1)
           echo "Test nix-shell succeeds!"
 

--- a/.github/workflows/test_nixos_minimal.yml
+++ b/.github/workflows/test_nixos_minimal.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           image: asterinas/asterinas:0.16.2-20251209
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
-          run: make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=4096 NIXOS_TEST_COMMAND='hello-asterinas' || true
+          run: make run NIXOS=1 NIXOS_DISK_SIZE_IN_MB=6144 NIXOS_TEST_COMMAND='hello-asterinas' || true
       - name: Check results
         run: |
           tail --lines 10 ${{ github.workspace }}/qemu.log | grep -q "^Hello Asterinas!" || (echo "Test NixOS failed" && exit 1)

--- a/distro/aster_configuration.nix
+++ b/distro/aster_configuration.nix
@@ -3,18 +3,18 @@
 { config, lib, pkgs, ... }: {
   # Imports all Nix files located under the 'modules' directory.
   #
-  # Each Nix file within the 'modules' directory contributes a specific part to the overall 'configuration.nix'. 
-  # For instance, 'core.nix' typically handles configurations 
+  # Each Nix file within the 'modules' directory contributes a specific part to the overall 'configuration.nix'.
+  # For instance, 'core.nix' typically handles configurations
   # related to the system's core functionalities and boot process.
-  # 
-  # To maintain modularity, 
-  # distinct aspects of the system's configuration 
-  # should be organized into separate Nix files under the 'modules' directory and subsequently imported here. 
-  # 
-  # If a module's content is optional, 
+  #
+  # To maintain modularity,
+  # distinct aspects of the system's configuration
+  # should be organized into separate Nix files under the 'modules' directory and subsequently imported here.
+  #
+  # If a module's content is optional,
   # its activation should be controlled by an enable/disable switch defined in the top-level 'configuration.nix'.
   #
-  # The content defined in these module files must adhere to the options permissible within 'configuration.nix'. 
+  # The content defined in these module files must adhere to the options permissible within 'configuration.nix'.
   # For a comprehensive list of available options,
   # please refer to https://search.nixos.org/options.
   imports = [
@@ -25,12 +25,13 @@
   ];
 
   # Overlays provide patches to 'nixpkgs' that enable these packages to run effectively on AsterNixOS.
-  # For details on the overlay file definition format, 
+  # For details on the overlay file definition format,
   # please refer to https://nixos.org/manual/nixpkgs/stable/#sec-overlays-definition.
   nixpkgs.overlays = [
     (import ./overlays/hello-asterinas/default.nix)
     (import ./overlays/desktop/default.nix)
     (import ./overlays/podman/default.nix)
     (import ./overlays/systemd/default.nix)
+    (import ./overlays/switch-to-configuration-ng/default.nix)
   ];
 }

--- a/distro/overlays/switch-to-configuration-ng/0001-Bypass-system-dbus.patch
+++ b/distro/overlays/switch-to-configuration-ng/0001-Bypass-system-dbus.patch
@@ -1,0 +1,78 @@
+From 5ae18b1b7c670208c1b44f16bcf77ac3148ae355 Mon Sep 17 00:00:00 2001
+From: vvsv <vvsv_7169@163.com>
+Date: Wed, 10 Dec 2025 17:54:18 +0800
+Subject: [PATCH] Bypass system dbus
+
+The commented-out code connects to the system DBus, reading systemd state via DBus,
+computes the unit diff, and then reports activation results back over DBus.
+
+TODO: Remove this patch once system DBus support is implemented.
+---
+ src/main.rs        | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/main.rs b/src/main.rs
+index 8baf5924a7db..bb1a60fd69f6 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,6 +1,9 @@
+ #![deny(clippy::all)]
+ #![allow(clippy::too_many_arguments)]
+ #![allow(clippy::type_complexity)]
++#![allow(dead_code)]
++#![allow(unused_imports)]
++#![allow(unused_variables)]
+
+ use std::{
+     cell::RefCell,
+@@ -932,6 +935,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
+         die();
+     }
+
++/*
+     let dbus_conn = LocalConnection::new_session().context("Failed to open dbus connection")?;
+     let (systemd, _) = new_dbus_proxies(&dbus_conn);
+
+@@ -968,6 +972,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
+     dbus_conn
+         .remove_match(jobs_token)
+         .context("Failed to remove jobs token")?;
++*/
+
+     Ok(())
+ }
+@@ -1106,6 +1111,7 @@ won't take effect until you reboot the system.
+     let handler = SigHandler::Handler(handle_sigpipe);
+     unsafe { signal::signal(Signal::SIGPIPE, handler) }.context("Failed to set SIGPIPE handler")?;
+
++/*
+     let mut units_to_stop = HashMap::new();
+     let mut units_to_skip = HashMap::new();
+     let mut units_to_filter = HashMap::new(); // units not shown
+@@ -1539,6 +1545,7 @@ won't take effect until you reboot the system.
+
+     // Wait for all stop jobs to finish
+     block_on_jobs(&dbus_conn, &submitted_jobs);
++*/
+
+     let mut exit_code = 0;
+
+@@ -1558,6 +1565,7 @@ won't take effect until you reboot the system.
+             exit_code = 2;
+         }
+     }
++/*
+
+     // Handle the activation script requesting the restart or reload of a unit.
+     for unit in std::fs::read_to_string(RESTART_BY_ACTIVATION_LIST_FILE)
+@@ -1934,6 +1942,7 @@ won't take effect until you reboot the system.
+
+         exit_code = 4;
+     }
++*/
+
+     if exit_code == 0 {
+         log::info!(
+--
+2.39.5
+

--- a/distro/overlays/switch-to-configuration-ng/default.nix
+++ b/distro/overlays/switch-to-configuration-ng/default.nix
@@ -1,0 +1,9 @@
+self: super:
+
+{
+  switch-to-configuration-ng = super.switch-to-configuration-ng.overrideAttrs
+    (oldAttrs: {
+      patches = (oldAttrs.patches or [ ])
+        ++ [ ./0001-Bypass-system-dbus.patch ];
+    });
+}


### PR DESCRIPTION
Bypass system dbus in `switch-to-configuration-ng` since we do not support `/run/dbus/system_bus_socket` currently.

Required for https://github.com/asterinas/asterinas/issues/2672.