### PR TITLE
Improve safety comments for `fill_boot_info_ptr` and `fill_boot_pt_ptr`

### DIFF
--- a/ostd/src/arch/riscv/boot/smp.rs
+++ b/ostd/src/arch/riscv/boot/smp.rs
@@ -115,7 +115,8 @@ unsafe fn bringup_ap(hart_id: u32) {
 ///
 /// # Safety
 ///
-/// The caller must ensure that `__ap_boot_info_array_pointer` is safe to write.
+/// This function writes to the static mutable variable `__ap_boot_info_array_pointer`.
+/// The caller must ensure exclusive access to this variable.
 unsafe fn fill_boot_info_ptr(info_ptr: *const PerApRawInfo) {
     unsafe extern "C" {
         static mut __ap_boot_info_array_pointer: *const PerApRawInfo;
@@ -131,7 +132,8 @@ unsafe fn fill_boot_info_ptr(info_ptr: *const PerApRawInfo) {
 ///
 /// # Safety
 ///
-/// The caller must ensure that `__ap_boot_page_table_pointer` is safe to write.
+/// This function writes to the static mutable variable `__ap_boot_page_table_pointer`.
+/// The caller must ensure exclusive access to this variable.
 unsafe fn fill_boot_page_table_ptr(pt_ptr: Paddr) {
     unsafe extern "C" {
         static mut __ap_boot_page_table_pointer: Paddr;

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -172,7 +172,8 @@ unsafe fn copy_ap_boot_code() {
 
 /// # Safety
 ///
-/// The caller must ensure the pointer to be filled is valid to write.
+/// This function writes to the static mutable variable `__ap_boot_info_array_pointer`.
+/// The caller must ensure exclusive access to this variable.
 unsafe fn fill_boot_info_ptr(info_ptr: *const PerApRawInfo) {
     unsafe extern "C" {
         static mut __ap_boot_info_array_pointer: *const PerApRawInfo;
@@ -186,7 +187,8 @@ unsafe fn fill_boot_info_ptr(info_ptr: *const PerApRawInfo) {
 
 /// # Safety
 ///
-/// The caller must ensure the pointer to be filled is valid to write.
+/// This function writes to the static mutable variable `__boot_page_table_pointer`.
+/// The caller must ensure exclusive access to this variable.
 unsafe fn fill_boot_pt_ptr(pt_ptr: Paddr) {
     unsafe extern "C" {
         static mut __boot_page_table_pointer: u32;


### PR DESCRIPTION
Resolves #2707
- Clarify safety contract for  `fill_boot_info_ptr`
- Clarify safety contract for `fill_boot_pt_ptr`