### PR TITLE
Bypass `texinfo/install-info` in `nixos-rebuild`

### DIFF
--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -108,4 +108,7 @@ in {
     # <https://github.com/asterinas/asterinas/issues/2672>.
     build-users-group = "";
   };
+
+  # FIXME: Currently, during `nixos-rebuild`, `texinfo/install-info` encounters a `SIGBUS`.
+  documentation.info.enable = false;
 }


### PR DESCRIPTION
Required for https://github.com/asterinas/asterinas/issues/2672.