### PR TITLE
Test more podman commands in CI

### DIFF
--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test nix commands
         run: |
-          make nixos NIXOS_DISK_SIZE_IN_MB=6144 NIXOS_TEST_COMMAND='test-nix-commands' || true
+          make nixos NIXOS_DISK_SIZE_IN_MB=6144 NIXOS_TEST_COMMAND='test-nix-commands'
           make run_nixos || true
 
       - name: Check results
@@ -58,7 +58,7 @@ jobs:
     container:
       image: asterinas/asterinas:0.16.2-20251211
       options: -v /dev:/dev --privileged
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Modify configuration.nix to include test-asterinas and podman
@@ -70,10 +70,10 @@ jobs:
 
       - name: Run podman commands
         run: |
-          make nixos NIXOS_DISK_SIZE_IN_MB=8192 NIXOS_TEST_COMMAND='test-podman' || true
+          make nixos NIXOS_DISK_SIZE_IN_MB=8192 NIXOS_TEST_COMMAND='test-podman'
           make run_nixos || true
 
       - name: Check results
         run: |
-          tail --lines 50 qemu.log | grep -q "alpine-release" || (echo "Test podman failed" && exit 1)
+          tail --lines 50 qemu.log | grep -q "^Test podman succeeds" || (echo "Test podman failed" && exit 1)
           echo "Test podman succeeds!"

--- a/distro/etc_nixos/overlays/test-asterinas/test-podman.sh
+++ b/distro/etc_nixos/overlays/test-asterinas/test-podman.sh
@@ -4,4 +4,18 @@
 
 set -e
 
-podman run docker.io/library/alpine:latest ls /etc
+CONTAINER_NAME=c1
+IMAGE_NAME=docker.io/library/alpine
+
+podman run --name=${CONTAINER_NAME} ${IMAGE_NAME} ls /etc \
+    | grep -q "^alpine-release" \
+    || (echo "Test 'podman run' failed" && exit 1)
+podman image ls \
+    | grep -q ${IMAGE_NAME} \
+    || (echo "Test 'podman image ls' failed" && exit 1)
+podman ps -a \
+    | grep -q "Exited (0)" \
+    || (echo "Test 'podman ps -a' failed" && exit 1)
+podman rm ${CONTAINER_NAME} || (echo "Test 'podman rm' failed" && exit 1)
+
+echo "Test podman succeeds"


### PR DESCRIPTION
Except `podman run`, this PR also add `podman image ls`, `podman ps -a` and `podman rm` commands into CI.