### PR TITLE
Place the heap after bss segment

### DIFF
--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -15,7 +15,7 @@ use crate::{
     process::{
         ContextUnshareAdminApi, Credentials, Process,
         posix_thread::{PosixThread, ThreadLocal, ThreadName, sigkill_other_threads, thread_table},
-        process_vm::{MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS, new_vmar_and_map},
+        process_vm::{MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS, ProcessVm},
         program_loader::{ProgramToLoad, elf::ElfLoadInfo},
         signal::{
             HandlePendingSignal, PauseReason, SigStack,
@@ -54,7 +54,7 @@ pub fn do_execve(
     let program_to_load =
         ProgramToLoad::build_from_inode(elf_inode.clone(), &fs_resolver, argv, envp)?;
 
-    let new_vmar = new_vmar_and_map(elf_file.clone());
+    let new_vmar = Vmar::new(ProcessVm::new(elf_file.clone()));
     let elf_load_info = program_to_load.load_to_vmar(new_vmar.as_ref(), &fs_resolver)?;
 
     // Ensure no other thread is concurrently performing exit_group or execve.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -38,7 +38,7 @@ pub use process::{
     Terminal, broadcast_signal_async, enqueue_signal_async, spawn_init_process,
 };
 pub use process_filter::ProcessFilter;
-pub use process_vm::ProcessVm;
+pub use process_vm::{INIT_STACK_SIZE, ProcessVm};
 pub use rlimit::ResourceType;
 pub use stats::collect_process_creation_count;
 pub use term_status::TermStatus;

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -13,16 +13,16 @@ use crate::{
     },
     prelude::*,
     process::{
-        Credentials, UserNamespace,
+        Credentials, ProcessVm, UserNamespace,
         posix_thread::{PosixThreadBuilder, ThreadName, allocate_posix_tid},
         process_table,
-        process_vm::new_vmar_and_map,
         program_loader::ProgramToLoad,
         rlimit::new_resource_limits_for_init,
         signal::sig_disposition::SigDispositions,
     },
     sched::Nice,
     thread::Tid,
+    vm::vmar::Vmar,
 };
 
 /// Creates and schedules the init process to run.
@@ -56,7 +56,7 @@ fn create_init_process(
     let elf_path = fs.resolver().read().lookup(&fs_path)?;
 
     let pid = allocate_posix_tid();
-    let process_vm = new_vmar_and_map(elf_path.clone());
+    let vmar = Vmar::new(ProcessVm::new(elf_path.clone()));
     let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
     let oom_score_adj = 0;
@@ -65,7 +65,7 @@ fn create_init_process(
 
     let init_proc = Process::new(
         pid,
-        process_vm,
+        vmar,
         resource_limits,
         nice,
         oom_score_adj,

--- a/kernel/src/process/program_loader/elf/elf_file.rs
+++ b/kernel/src/process/program_loader/elf/elf_file.rs
@@ -168,6 +168,14 @@ impl ElfHeaders {
             .reduce(|r1, r2| r1.start.min(r2.start)..r1.end.max(r2.end))
             .unwrap()
     }
+
+    /// Finds the last loadable segment and returns its virtual address bounds.
+    pub(super) fn find_last_vaddr_bound(&self) -> Option<Range<Vaddr>> {
+        self.loadable_phdrs
+            .iter()
+            .max_by_key(|phdr| phdr.virt_range().end)
+            .map(|phdr| phdr.virt_range().clone())
+    }
 }
 
 struct ElfHeader {

--- a/kernel/src/process/rlimit.rs
+++ b/kernel/src/process/rlimit.rs
@@ -6,7 +6,7 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use super::process_vm::{INIT_STACK_SIZE, USER_HEAP_SIZE_LIMIT};
+use super::process_vm::INIT_STACK_SIZE;
 use crate::{
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet},
@@ -48,8 +48,7 @@ impl Default for ResourceLimits {
         // Sets the resource limits with predefined values
         rlimits[ResourceType::RLIMIT_CPU as usize] = RLimit64::new(RLIM_INFINITY, RLIM_INFINITY);
         rlimits[ResourceType::RLIMIT_FSIZE as usize] = RLimit64::new(RLIM_INFINITY, RLIM_INFINITY);
-        rlimits[ResourceType::RLIMIT_DATA as usize] =
-            RLimit64::new(USER_HEAP_SIZE_LIMIT as u64, RLIM_INFINITY);
+        rlimits[ResourceType::RLIMIT_DATA as usize] = RLimit64::new(RLIM_INFINITY, RLIM_INFINITY);
         rlimits[ResourceType::RLIMIT_STACK as usize] =
             RLimit64::new(INIT_STACK_SIZE as u64, RLIM_INFINITY);
         rlimits[ResourceType::RLIMIT_CORE as usize] = RLimit64::new(0, RLIM_INFINITY);

--- a/kernel/src/syscall/brk.rs
+++ b/kernel/src/syscall/brk.rs
@@ -10,15 +10,16 @@ pub fn sys_brk(heap_end: u64, ctx: &Context) -> Result<SyscallReturn> {
         Some(heap_end as usize)
     };
     debug!("new heap end = {:x?}", heap_end);
+
     let user_space = ctx.user_space();
     let user_heap = user_space.vmar().process_vm().heap();
 
-    let syscall_ret = match new_heap_end {
+    let current_heap_end = match new_heap_end {
         Some(addr) => user_heap
-            .set_program_break(addr, ctx)
-            .unwrap_or_else(|current_break| current_break),
-        None => user_heap.program_break(),
+            .modify_heap_end(addr, ctx)
+            .unwrap_or_else(|cur_heap_end| cur_heap_end),
+        None => user_heap.heap_end(),
     };
 
-    Ok(SyscallReturn::Return(syscall_ret as _))
+    Ok(SyscallReturn::Return(current_heap_end as _))
 }


### PR DESCRIPTION
## Short description

This PR mainly focuses on the problem that origin heap is fixed and unaligned with Linux behavior.

The main changes are as follows:
1. Acquire the data segment and break info when loading the elf.
2. Add a new method of allocaling free region which starts from high address.
3. Reimplement the heap code.