### PR TITLE
Add GitHub workflow to publish ISO image and package cache

### DIFF
--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -1,0 +1,105 @@
+name: Publish AsterNixOS
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push-cachix:
+    runs-on: ubuntu-4-cores-150GB-ssd
+    container:
+      image: asterinas/asterinas:0.16.2-20251209
+      options: -v /dev:/dev --privileged
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Asterinas NixOS patched packages and push to release cache
+        run: |
+          make kernel BOOT_PROTOCOL=linux-efi-handover64
+          export CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN_FOR_RELEASE_CACHE }}
+          make push_cachix USE_RELEASE_CACHE=1
+          echo "Push cachix succeeds!"
+
+  create-github-release:
+    runs-on: ubuntu-latest
+    needs: [ push-cachix ]
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Asterinas version
+        id: tag
+        run: |
+          ASTER_VERSION=$(cat ./VERSION)
+          echo "ASTER_VERSION=${ASTER_VERSION}"
+          echo "tag=${ASTER_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          body="TODO: Write the release notes for version $tag"
+          echo "tag=$tag"
+          echo "body=$body"
+          if gh release view "$tag" > /dev/null 2>&1; then
+            echo "Release with tag $tag already exists. Skipping creation."
+          else
+            gh release create --draft "$tag" --title "$tag" --notes "$body"
+          fi
+
+  build-iso:
+    runs-on: ubuntu-latest
+    needs: [ create-github-release ]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ 'x86_64' ]
+    timeout-minutes: 60
+    steps:
+      - uses: endersonmenezes/free-disk-space@v3
+        with:
+          rm_cmd: "rmz"
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+      - uses: actions/checkout@v4
+
+      - name: Build ISO
+        uses: addnab/docker-run-action@v3
+        with:
+          image: asterinas/asterinas:0.16.2-20251209
+          options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
+          run: |
+            make iso RELEASE=1 AUTO_INSTALL=false ARCH=${{ matrix.arch }}
+            iso_path=$(realpath ./target/nixos/iso_image/iso/*.iso)
+            echo "iso_path=$iso_path"
+            cp $iso_path ./asterinas-nixos.iso
+            echo "Building ISO succeeds"
+      - name: Upload ISO
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          tag="${{ needs.create-github-release.outputs.tag }}"
+          echo "upload asterinas-nixos-$tag-${{ matrix.arch }}.iso"
+          cd ${{ github.workspace }}
+          mv ./asterinas-nixos.iso asterinas-nixos-$tag-${{ matrix.arch }}.iso
+          gh release upload "$tag" "asterinas-nixos-$tag-${{ matrix.arch }}.iso"
+
+  publish-github-release:
+    runs-on: ubuntu-latest
+    needs: [ create-github-release, build-iso ]
+    steps:
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release edit "${{ needs.create-github-release.outputs.tag }}" --draft=false


### PR DESCRIPTION
This PR adds a workflow to publish release for ISO image.

The created release can be viewed in my own forked repo at [here](https://github.com/StevenJiang1110/asterinas/releases/tag/0.16.2).

This workflow uses the GitHub CLI (gh command) to manage releases, and largely follows the approach used by [Ruby](https://github.com/ruby/ruby-dev-builder/blob/b0bf59a17c17985d4692243d4689c273f6348fa5/.github/workflows/build.yml). The GitHub release is managed in three steps:
1. Create a draft release in the create-release job.
2. Upload artifacts (the ISO installer in our case) in the build-iso job.
3. Mark the release as ready (in the publish-release job).

I don't have permissions to create release in this repository, see [this run](https://github.com/asterinas/asterinas/actions/runs/20131914425/job/57775230087?pr=2735#step:4:12). So it's better to manually trigger this workflow once to check whether this repository can create release.