### PR TITLE
Define `ASTER_SCML` in `validate_scmls` workflow

### DIFF
--- a/.github/workflows/validate_scmls.yml
+++ b/.github/workflows/validate_scmls.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - tools/sctrace/**
       - book/src/kernel/linux-compatibility/syscall-flag-coverage/**
+      - .github/workflows/validate_scmls.yml
   push:
     branches:
       - main
     paths:
       - tools/sctrace/**
       - book/src/kernel/linux-compatibility/syscall-flag-coverage/**
+      - .github/workflows/validate_scmls.yml
 
 jobs:
   validate_scmls:
@@ -21,4 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate SCML files with sctrace
-        run: ./tools/sctrace.sh $ASTER_SCML -- echo "Asterinas"
+        run: |
+          export ASTER_SCML=$(find ./book/src/kernel/linux-compatibility/ -name "*.scml")
+          ./tools/sctrace.sh $ASTER_SCML -- echo "Asterinas"


### PR DESCRIPTION
GitHub Actions doesn't load `~/.bashrc`, so `ASTER_SCML` was undefined. This PR explicitly sets it by finding all `.scml` files before running `sctrace`.