### PR TITLE
Clarify the code for a long shebang

### DIFF
--- a/kernel/src/process/program_loader/shebang.rs
+++ b/kernel/src/process/program_loader/shebang.rs
@@ -12,13 +12,13 @@ use crate::prelude::*;
 /// file, then `Err(_)` is returned. If the buffer does not start with `#!`,
 /// then `Ok(None)` is returned.
 pub fn parse_shebang_line(file_first_page: &[u8]) -> Result<Option<Vec<CString>>> {
-    if !file_first_page.starts_with(b"#!") || !file_first_page.contains(&b'\n') {
+    if !file_first_page.starts_with(b"#!") {
         // The file is not a shebang.
         return Ok(None);
     }
 
     let Some(first_line_len) = file_first_page.iter().position(|&c| c == b'\n') else {
-        return_errno_with_message!(Errno::ENAMETOOLONG, "the shebang line is too long");
+        return_errno_with_message!(Errno::ENOEXEC, "the shebang line is too long");
     };
 
     // Skip `#!`.


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/ecd0ac96626dc2ab7c9251a61b45fcb0b4f44f0c/kernel/src/process/program_loader/shebang.rs#L15-L22

I'm confused about this. `!file_first_page.contains("\n")` is checked twice in different ways (lines 15 and 20) and corresponds to two different actions (lines 16 and 21). We should remove one check of the two?

As far as Linux is concerned, it [returns `ENOEXEC` if the interpreter is  truncated](https://elixir.bootlin.com/linux/v6.18.1/source/fs/binfmt_script.c#L64-L69), but it [allows the argument to be truncated](https://elixir.bootlin.com/linux/v6.18.1/source/fs/binfmt_script.c#L54-L56). I think we should return `ENOEXEC` for both cases because we don't support the Linux behavior of second one (yet).