### PR TITLE
Add `Sized` trait bound to `NonNullPtr`

### DIFF
--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 /// raw pointers.
 ///
 /// [`Rcu`]: super::Rcu
-pub unsafe trait NonNullPtr: 'static {
+pub unsafe trait NonNullPtr: Sized + 'static {
     /// The target type that this pointer refers to.
     // TODO: Support `Target: ?Sized`.
     type Target;


### PR DESCRIPTION
This PR adds the `Self: Sized` trait bound to `NonNullPtr::from_raw` and `NonNullPtr::into_raw` as their arguments require a size known at compile-time. Adding this trait bound does not change the code behavior, as the Rust compiler will reject attempts to implement it with an unsized type. 

The main reason for this change is that the formal verification tool [Verus](https://github.com/asterinas/vostd/pull/253) will reject it earlier, when checking the trait definition. I also believe that this modification makes the trait bound requirement a bit more explicit.