### PR TITLE
update statx scml documentation

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -342,7 +342,7 @@ which are summarized in the table below.
 | 322     | execveat               | ✅             | 💯 |
 | 327     | preadv2                | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#preadv2-and-pwritev2) |
 | 328     | pwritev2               | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#preadv2-and-pwritev2) |
-| 332     | statx                  | ✅             | ❓ |
+| 332     | statx                  | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#statx) |
 | 434     | pidfd_open             | ✅             | 💯 |
 | 435     | clone3                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#clone-and-clone3) |
 | 436     | close_range            | ✅             | ❓ |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -117,3 +117,26 @@ Silently-ignored flags:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/faccessat2.2.html).
+
+### `statx`
+
+Supported functionality in SCML:
+
+```c
+{{#include statx.scml}}
+```
+
+Silently-ignored flags:
+* `AT_NO_AUTOMOUNT`
+* `AT_STATX_FORCE_SYNC`
+* `AT_STATX_DONT_SYNC`
+
+Silently-ignored masks:
+* `STATX_DIOALIGN`
+* `STATX_MNT_ID_UNIQUE`
+* `STATX_SUBVOL`
+* `STATX_WRITE_ATOMIC`
+* `STATX_DIO_READ_ALIGN`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/statx.2.html).

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/statx.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/statx.scml
@@ -1,0 +1,15 @@
+statx_flags = AT_EMPTY_PATH | AT_NO_AUTOMOUNT | AT_STATX_FORCE_SYNC |
+              AT_STATX_DONT_SYNC | AT_STATX_SYNC_AS_STAT | AT_SYMLINK_NOFOLLOW;
+statx_mask = STATX_TYPE | STATX_MODE | STATX_NLINK | STATX_UID | STATX_GID |
+             STATX_ATIME | STATX_MTIME | STATX_CTIME | STATX_INO | STATX_SIZE |
+             STATX_BLOCKS | STATX_BASIC_STATS | STATX_BTIME | STATX_ALL |
+             STATX_MNT_ID | STATX_DIOALIGN | STATX_MNT_ID_UNIQUE | STATX_SUBVOL |
+             STATX_WRITE_ATOMIC | STATX_DIO_READ_ALIGN;
+
+// Get file status (extended)
+statx(
+    dirfd, pathname,
+    flags = <statx_flags>,
+    mask = <statx_mask>,
+    statxbuf
+);

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -243,15 +243,21 @@ bitflags! {
         const STATX_BASIC_STATS     = 0x000007ff;
         /// Want stx_btime
         const STATX_BTIME           = 0x00000800;
-        /// Deprecated: The same as STATX_BASIC_STATS | STATX_BTIME
-        const STATX_ALL             = 0x00000fff;
         /// Want stx_mnt_id
         const STATX_MNT_ID          = 0x00001000;
         /// Want stx_dio_mem_align and stx_dio_offset_align
         const STATX_DIOALIGN        = 0x00002000;
+        /// Want extended stx_mount_id
+        const STATX_MNT_ID_UNIQUE   = 0x00004000;
+        /// Want stx_subvol
+        const STATX_SUBVOL          = 0x00008000;
+        /// Want stx_write_atomic
+        const STATX_WRITE_ATOMIC    = 0x00010000;
+        /// Wand dio read alignment info
+        const STATX_DIO_READ_ALIGN  = 0x00020000;
         /// Reserved for future struct statx expansion
         const STATX_RESERVED		= 0x80000000;
-        /// Want/got stx_change_attr
-        const STATX_CHANGE_COOKIE   = 0x40000000;
+        /// Deprecated: The same as STATX_BASIC_STATS | STATX_BTIME
+        const STATX_ALL             = 0x00000fff;
     }
 }


### PR DESCRIPTION
This PR is required for #2630 .
- Add statx syscall scml documtation
- Refer to latest statx mannual and linux source code to update statx masks

Since a lot of information in statx is 0 and some information has corresponding implementations. I write the mask corresponding to filed 0 as silently-ignored masks.

