### PR TITLE
Fix atomic violation on caps_lock

### DIFF
--- a/kernel/comps/framebuffer/src/console_input.rs
+++ b/kernel/comps/framebuffer/src/console_input.rs
@@ -213,8 +213,7 @@ impl FbConsoleHandler {
             }
             KeyCode::CapsLock => {
                 if key_status == KeyStatus::Pressed {
-                    let new_caps = !self.caps_lock.load(Ordering::Relaxed);
-                    self.caps_lock.store(new_caps, Ordering::Relaxed);
+                    self.caps_lock.fetch_xor(true, Ordering::Relaxed);
                 }
                 return;
             }


### PR DESCRIPTION
Updating the caps_lock state through a combination of load and store is an atomic violation, because individual atomic operations don't form an atomic sequence when executed consecutively.

The bug is detected by lockbud. cc https://github.com/os-checker/bugs-found/issues/3

Also see the Gemini's [explanation](https://aistudio.google.com/app/prompts?state=%7B%22ids%22:%5B%221JkqMQJccTq7rlYNusmovLl9krACM9aZd%22%5D,%22action%22:%22open%22,%22userId%22:%22107770117539303321065%22,%22resourceKeys%22:%7B%7D%7D&usp=sharing).