### PR TITLE
Fix reachable unwrap in sys_arch_prctl by using the `?` operator

### DIFF
--- a/kernel/src/syscall/arch_prctl.rs
+++ b/kernel/src/syscall/arch_prctl.rs
@@ -26,7 +26,7 @@ pub fn sys_arch_prctl(
         "arch_prctl_code: {:?}, addr = 0x{:x}",
         arch_prctl_code, addr
     );
-    let res = do_arch_prctl(arch_prctl_code, addr, user_ctx).unwrap();
+    let res = do_arch_prctl(arch_prctl_code, addr, user_ctx)?;
     Ok(SyscallReturn::Return(res as _))
 }
 


### PR DESCRIPTION
Fix #2780 