### PR TITLE
Simplify `fill_zeros_remote` and `check_extra_size_fits_rlimit`

### DIFF
--- a/kernel/src/vm/vmar/vmar_impls/access_remote.rs
+++ b/kernel/src/vm/vmar/vmar_impls/access_remote.rs
@@ -4,9 +4,7 @@ use core::ops::Range;
 
 use align_ext::AlignExt;
 use ostd::{
-    mm::{
-        HasSize, PAGE_SIZE, PageFlags, UFrame, io_util::HasVmReaderWriter, vm_space::VmQueriedItem,
-    },
+    mm::{PAGE_SIZE, PageFlags, UFrame, io_util::HasVmReaderWriter, vm_space::VmQueriedItem},
     task::disable_preempt,
 };
 
@@ -78,14 +76,11 @@ impl Vmar {
     ) -> core::result::Result<usize, (Error, usize)> {
         let mut remain = len;
         let write = |frame: UFrame, skip_offset: usize| {
-            let frame_size = frame.size();
-            let mut writer = frame.writer().to_fallible();
+            let mut writer = frame.writer();
             writer.skip(skip_offset);
-            let to_write = remain.min(frame_size - skip_offset);
-            let res = writer.fill_zeros(to_write);
-            let (Ok(n) | Err((_, n))) = &res;
-            remain -= *n;
-            res
+            let res = writer.fill_zeros(remain);
+            remain -= res;
+            Ok(res)
         };
 
         self.access_remote(vaddr, len, PageFlags::W, write)

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -156,17 +156,13 @@ impl VmarInner {
             return Ok(());
         };
 
-        let rlimt_as = process
+        let rlimit_as = process
             .resource_limits()
             .get_rlimit(ResourceType::RLIMIT_AS)
             .get_cur();
 
-        let new_total_vm = self
-            .total_vm
-            .checked_add(expand_size)
-            .ok_or(Errno::ENOMEM)?;
-        if new_total_vm > rlimt_as as usize {
-            return_errno_with_message!(Errno::ENOMEM, "address space limit overflow");
+        if rlimit_as.saturating_sub(self.total_vm as u64) < expand_size as u64 {
+            return_errno_with_message!(Errno::ENOMEM, "the address space size limit is reached");
         }
         Ok(())
     }


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/2c80e0c3a4bfcd3b877790e50b4f27d52613629b/kernel/src/vm/vmar/vmar_impls/access_remote.rs#L80-L89

This seems unnecessarily complex. Using the infallible `VmWriter` and [infallible `fill_zeros`](https://github.com/asterinas/asterinas/blob/2c80e0c3a4bfcd3b877790e50b4f27d52613629b/ostd/src/mm/io.rs#L784-L801) would be much simpler.
```rust
            let mut writer = frame.writer();
            writer.skip(skip_offset);
            let res = writer.fill_zeros(remain);
            remain -= res;
            Ok(res)
```

---

`check_extra_size_fits_rlimit` can also be simplified by using `saturating_sub`. In addition, this PR fixes a typo in the variable name `rlimt_as` (which should be `rlimit_as`).

