### PR TITLE
Validate futex address alignment before waking robust futexes

### DIFF
--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -540,7 +540,7 @@ impl FutexKey {
         if !addr.is_multiple_of(align_of::<u32>()) {
             return_errno_with_message!(
                 Errno::EINVAL,
-                "the futex word is not aligend on a four-byte boundary"
+                "the futex word is not aligned on a four-byte boundary"
             );
         }
 

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -130,8 +130,11 @@ const FUTEX_TID_MASK: u32 = 0x3FFF_FFFF;
 /// `FUTEX_OWNER_DIED` and one waiter (if any) is woken.  
 /// If the futex is owned by another thread, the operation is canceled.
 pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
-    if futex_addr == 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid futext addr");
+    if !futex_addr.is_multiple_of(align_of::<u32>()) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the futex word is not aligned on a four-byte boundary"
+        );
     }
 
     let task = Task::current().unwrap();


### PR DESCRIPTION
Fix #2805

Refer to the alignment check in `handle_futex_death` in Linux, which is called by `exit_robust_list`.
https://github.com/torvalds/linux/blob/04688d6128b7c8b4ccec2913e7f2ff1c4437da96/kernel/futex/core.c#L1022-L1024

And `wake_robust_list` in Asterinas 
> corresponds to Linux's `exit_robust_list`. Errors are silently ignored.