### PR TITLE
Improve futex code and log clarity

### DIFF
--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -143,7 +143,7 @@ fn wake_robust_list(thread_local: &ThreadLocal, tid: Tid) {
     for futex_addr in list_head.futexes() {
         if let Err(err) = wake_robust_futex(futex_addr, tid) {
             debug!(
-                "exit: cannot wake robust futex at {:?}: {:?}",
+                "exit: cannot wake the robust futex at {:#x}: {:?}",
                 futex_addr, err
             );
             return;

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -140,7 +140,7 @@ pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
     let task = Task::current().unwrap();
     let user_space = CurrentUserSpace::new(task.as_thread_local().unwrap());
 
-    // Instantiate reader and writer pointing at the same `futex_addr`, set up
+    // Instantiate a reader and a writer pointing at the same `futex_addr`, set up
     // for the same length: the length of an `u32`.
     let (reader, writer) = user_space.reader_writer(futex_addr, size_of::<u32>())?;
 
@@ -157,12 +157,13 @@ pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
             (_, true) => {
                 // Wake up one waiter and break out from the loop.
                 if new_val & FUTEX_WAITERS != 0 {
-                    debug!("wake robust futex addr: {:?}", futex_addr);
+                    debug!("wake the robust futex at {:#x}", futex_addr);
                     futex_wake(futex_addr, 1, None)?;
                 }
                 break;
             }
         }
     }
+
     Ok(())
 }


### PR DESCRIPTION
Some trivial changes.

Summary:
 - Use `{:#x}` to print futex addresses.
 - Use `TryFromInt` instead of manually repeating the enum variant.
 - Remove the unnecessary indentation at `futex_requeue`.