### PR TITLE
Refactor the implementation of prlimit64

### DIFF
--- a/test/src/syscall/ltp/testcases/all.txt
+++ b/test/src/syscall/ltp/testcases/all.txt
@@ -1446,8 +1446,8 @@ setreuid06
 # setreuid07_16
 
 # setrlimit01
-# setrlimit02
-# setrlimit03
+setrlimit02
+setrlimit03
 setrlimit04
 setrlimit05
 # setrlimit06


### PR DESCRIPTION
This PR refactors the implementation of setrlimit, getrlimit, and prlimit64.

The primary goal of this refactoring is to reuse common logic across these three syscalls. Additionally, this PR introduces a missing permission check: if the new `rlim_max` exceeds the current maximum, the calling thread must have CAP_SYS_RESOURCE in the initial user namespace ([referencing](https://elixir.bootlin.com/linux/v6.18/source/kernel/sys.c#L1526)).

With this change, the setrlimit02 LTP test now passes. (setrlimit03 was already passing prior to this PR).