### PR TITLE
Don't panic in LoongArch64 VirtIO MMIO probe

### DIFF
--- a/kernel/comps/virtio/src/transport/mmio/bus/arch/loongarch.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/arch/loongarch.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-// TODO: Add `MappedIrqLine` support for Loongarch.
+// TODO: Add `MappedIrqLine` support for LoongArch.
 pub(super) use ostd::irq::IrqLine as MappedIrqLine;
 
 pub(super) fn probe_for_device() {
-    unimplemented!()
+    // TODO: Probe virtio devices on the MMIO bus in LoongArch.
+    // Then, register them by calling `super::try_register_mmio_device`.
 }


### PR DESCRIPTION
I don't think we should panic just because the VirtIO MMIO device probe is not implemented for LoongArch64. Instead, we can ignore devices on an unsupported bus.

---

With #2823, #2351, and this PR, we should be able to boot the LoongArch64 kernel to the initramfs loading phase, i.e., something like:
```
[kernel] Spawn init thread
[     0.000] DEBUG: All component:[ComponentInfo { name: "aster-block", path: "/root/asterinas/kernel/comps/block", priority: 0 }, ComponentInfo { name: "aster-console", path: "/root/asterinas/kernel/comps/console", priority: 0 }, ComponentInfo { name: "aster-framebuffer", path: "/root/asterinas/kernel/comps/framebuffer", priority: 2 }, ComponentInfo { name: "aster-input", path: "/root/asterinas/kernel/comps/input", priority: 0 }, ComponentInfo { name: "aster-keyboard", path: "/root/asterinas/kernel/comps/keyboard", priority: 1 }, ComponentInfo { name: "aster-logger", path: "/root/asterinas/kernel/comps/logger", priority: 1 }, ComponentInfo { name: "aster-mlsdisk", path: "/root/asterinas/kernel/comps/mlsdisk", priority: 1 }, ComponentInfo { name: "aster-network", path: "/root/asterinas/kernel/comps/network", priority: 1 }, ComponentInfo { name: "aster-nix", path: "/root/asterinas/kernel", priority: 3 }, ComponentInfo { name: "aster-pci", path: "/root/asterinas/kernel/comps/pci", priority: 0 }, ComponentInfo { name: "aster-softirq", path: "/root/asterinas/kernel/comps/softirq", priority: 0 }, ComponentInfo { name: "aster-systree", path: "/root/asterinas/kernel/comps/systree", priority: 0 }, ComponentInfo { name: "aster-time", path: "/root/asterinas/kernel/comps/time", priority: 0 }, ComponentInfo { name: "aster-virtio", path: "/root/asterinas/kernel/comps/virtio", priority: 2 }]
[     0.000] DEBUG: Remain components:{"/root/asterinas/kernel": ComponentInfo { name: "aster-nix", path: "/root/asterinas/kernel", priority: 3 }, "/root/asterinas/kernel/comps/block": ComponentInfo { name: "aster-block", path: "/root/asterinas/kernel/comps/block", priority: 0 }, "/root/asterinas/kernel/comps/console": ComponentInfo { name: "aster-console", path: "/root/asterinas/kernel/comps/console", priority: 0 }, "/root/asterinas/kernel/comps/framebuffer": ComponentInfo { name: "aster-framebuffer", path: "/root/asterinas/kernel/comps/framebuffer", priority: 2 }, "/root/asterinas/kernel/comps/input": ComponentInfo { name: "aster-input", path: "/root/asterinas/kernel/comps/input", priority: 0 }, "/root/asterinas/kernel/comps/keyboard": ComponentInfo { name: "aster-keyboard", path: "/root/asterinas/kernel/comps/keyboard", priority: 1 }, "/root/asterinas/kernel/comps/logger": ComponentInfo { name: "aster-logger", path: "/root/asterinas/kernel/comps/logger", priority: 1 }, "/root/asterinas/kernel/comps/mlsdisk": ComponentInfo { name: "aster-mlsdisk", path: "/root/asterinas/kernel/comps/mlsdisk", priority: 1 }, "/root/asterinas/kernel/comps/network": ComponentInfo { name: "aster-network", path: "/root/asterinas/kernel/comps/network", priority: 1 }, "/root/asterinas/kernel/comps/pci": ComponentInfo { name: "aster-pci", path: "/root/asterinas/kernel/comps/pci", priority: 0 }, "/root/asterinas/kernel/comps/softirq": ComponentInfo { name: "aster-softirq", path: "/root/asterinas/kernel/comps/softirq", priority: 0 }, "/root/asterinas/kernel/comps/systree": ComponentInfo { name: "aster-systree", path: "/root/asterinas/kernel/comps/systree", priority: 0 }, "/root/asterinas/kernel/comps/time": ComponentInfo { name: "aster-time", path: "/root/asterinas/kernel/comps/time", priority: 0 }, "/root/asterinas/kernel/comps/virtio": ComponentInfo { name: "aster-virtio", path: "/root/asterinas/kernel/comps/virtio", priority: 2 }}
[     0.000] INFO : Exists components that are not initialized
[     0.000] DEBUG: component infos: []
[     0.000] INFO : Components initializing in Kthread stage...
[     0.000] INFO : All components initialization in Kthread stage completed
[     0.000] ERROR: Uncaught panic:
	No initramfs found!
	at /root/asterinas/kernel/src/fs/rootfs.rs:34
	on CPU 0 by thread Some(Thread { task: (Weak), data: Any { .. }, is_exited: false, cpu_affinity: AtomicCpuSet { bits: [1] }, sched_attr: SchedAttr { policy: SchedPolicyState { kind: AtomicSchedPolicyKind(3), policy: UnsafeCell { .. } }, last_cpu: AtomicCpuId(0), real_time: RealTimeAttr { prio: 99, time_slice: 1500000 }, fair: FairAttr { weight: 1024, pending_weight: 0, vruntime: 0 } } })
Printing stack trace:
[OSDK] The kernel seems panicked. Parsing stack trace for source lines:
```

