### PR TITLE
Fix the issue of `InodeBlockManager::read_blocks`

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -204,6 +204,11 @@ impl BioWaiter {
         self.bios.append(&mut other.bios);
     }
 
+    /// Returns an iterator for the `Bio` requests associated with `self`.
+    pub fn reqs(&self) -> impl Iterator<Item = Bio> {
+        self.bios.iter().map(|bio_inner| Bio(bio_inner.clone()))
+    }
+
     /// Waits for the completion of all `Bio` requests.
     ///
     /// This method iterates through each `Bio` in the list, waiting for their

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -1817,12 +1817,6 @@ impl InodeImpl {
 
 #[inherit_methods(from = "self.block_manager")]
 impl InodeImpl {
-    pub fn read_blocks_async(
-        &self,
-        bid: Ext2Bid,
-        nblocks: usize,
-        writer: &mut VmWriter,
-    ) -> Result<BioWaiter>;
     pub fn read_blocks(&self, bid: Ext2Bid, nblocks: usize, writer: &mut VmWriter) -> Result<()>;
     pub fn read_block_async(&self, bid: Ext2Bid, frame: &CachePage) -> Result<BioWaiter>;
     pub fn write_blocks_async(
@@ -1850,13 +1844,7 @@ struct InodeBlockManager {
 
 impl InodeBlockManager {
     /// Reads one or multiple blocks to the segment start from `bid` asynchronously.
-    pub fn read_blocks_async(
-        &self,
-        bid: Ext2Bid,
-        nblocks: usize,
-        writer: &mut VmWriter,
-    ) -> Result<BioWaiter> {
-        debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
+    fn read_blocks_async(&self, bid: Ext2Bid, nblocks: usize) -> Result<BioWaiter> {
         let mut bio_waiter = BioWaiter::new();
 
         for dev_range in DeviceRangeReader::new(self, bid..bid + nblocks as Ext2Bid)? {
@@ -1864,8 +1852,6 @@ impl InodeBlockManager {
             let range_nblocks = dev_range.len();
 
             let bio_segment = BioSegment::alloc(range_nblocks, BioDirection::FromDevice);
-            bio_segment.reader().unwrap().read_fallible(writer)?;
-
             let waiter = self.fs().read_blocks_async(start_bid, bio_segment)?;
             bio_waiter.concat(waiter);
         }
@@ -1874,10 +1860,22 @@ impl InodeBlockManager {
     }
 
     pub fn read_blocks(&self, bid: Ext2Bid, nblocks: usize, writer: &mut VmWriter) -> Result<()> {
-        match self.read_blocks_async(bid, nblocks, writer)?.wait() {
-            Some(BioStatus::Complete) => Ok(()),
-            _ => return_errno!(Errno::EIO),
+        debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
+        let bio_waiter = self.read_blocks_async(bid, nblocks)?;
+        if Some(BioStatus::Complete) != bio_waiter.wait() {
+            return_errno!(Errno::EIO);
         }
+
+        for bio in bio_waiter.reqs() {
+            for segment in bio.segments() {
+                segment
+                    .reader()?
+                    .read_fallible(writer)
+                    .map_err(|(e, _)| Error::from(e))?;
+            }
+        }
+
+        Ok(())
     }
 
     pub fn read_block_async(&self, bid: Ext2Bid, frame: &CachePage) -> Result<BioWaiter> {


### PR DESCRIPTION
Closes #2835 

This PR resolves the issue aforementioned, and I wrote a simple C program with the help of LLM to test it:
``` c
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <fcntl.h>
#include <errno.h>
#include <sys/stat.h>
#include <sys/types.h>

#define BLOCK_SIZE 4096
#define TEST_PATTERN 0xAA

/* Fill buffer with known pattern */
static void fill_pattern(void *buf, size_t size, unsigned char pattern)
{
    memset(buf, pattern, size);
}

/* Verify buffer contains the expected pattern */
static int verify_pattern(const void *buf, size_t size, unsigned char pattern)
{
    const unsigned char *ptr = buf;
    for (size_t i = 0; i < size; i++) {
        if (ptr[i] != pattern) {
            fprintf(stderr, "Pattern mismatch at offset %zu: expected 0x%02X, got 0x%02X\n",
                    i, pattern, ptr[i]);
            return -1;
        }
    }
    return 0;
}

/* Print hex dump of buffer for debugging */
static void hexdump(const void *buf, size_t size, const char *prefix)
{
    const unsigned char *ptr = buf;
    size_t i;

    printf("%s (first %zu bytes):\n", prefix, size < 64 ? size : 64);
    for (i = 0; i < size && i < 64; i++) {
        if (i % 16 == 0) {
            printf("%s%04zx: ", prefix ? "  " : "", i);
        }
        printf("%02x ", ptr[i]);
        if (i % 16 == 15) {
            printf("\n");
        }
    }
    if (i % 16 != 0) {
        printf("\n");
    }
}

static int test_basic_oadirect(const char *filename)
{
    int fd;
    void *write_buf = NULL;
    void *read_buf = NULL;
    int ret = -1;

    printf("=== Test 1: Basic O_DIRECT Read ===\n");

    /* Allocate aligned buffers for O_DIRECT */
    if (posix_memalign(&write_buf, BLOCK_SIZE, BLOCK_SIZE) != 0) {
        perror("posix_memalign for write_buf");
        goto out;
    }
    if (posix_memalign(&read_buf, BLOCK_SIZE, BLOCK_SIZE) != 0) {
        perror("posix_memalign for read_buf");
        goto out;
    }

    /* Open file with O_DIRECT */
    fd = open(filename, O_RDWR | O_DIRECT | O_CREAT, 0644);
    if (fd < 0) {
        /* O_DIRECT might not be supported, try without it */
        printf("Warning: O_DIRECT not supported, testing without it\n");
        fd = open(filename, O_RDWR | O_CREAT, 0644);
        if (fd < 0) {
            perror("open");
            goto out;
        }
    }

    /* Write known pattern */
    fill_pattern(write_buf, BLOCK_SIZE, TEST_PATTERN);
    if (write(fd, write_buf, BLOCK_SIZE) != BLOCK_SIZE) {
        perror("write");
        close(fd);
        goto out;
    }
    fsync(fd);

    /* Reset file position */
    lseek(fd, 0, SEEK_SET);

    /* Clear read buffer to detect uninitialized reads */
    memset(read_buf, 0x00, BLOCK_SIZE);

    /* Read back the data */
    ssize_t nread = read(fd, read_buf, BLOCK_SIZE);
    if (nread != BLOCK_SIZE) {
        perror("read");
        close(fd);
        goto out;
    }

    /* Verify the pattern */
    if (verify_pattern(read_buf, BLOCK_SIZE, TEST_PATTERN) != 0) {
        fprintf(stderr, "FAIL: Read data does not match written pattern!\n");
        hexdump(read_buf, BLOCK_SIZE, "Read data");
        hexdump(write_buf, BLOCK_SIZE, "Expected data");
        close(fd);
        goto out;
    }

    printf("PASS: O_DIRECT read test succeeded\n");
    close(fd);
    ret = 0;

out:
    free(write_buf);
    free(read_buf);
    return ret;
}

int main(int argc, char *argv[])
{
    const char *filename;
    int failed = 0;

    if (argc < 2) {
        fprintf(stderr, "Usage: %s <test_file_path>\n", argv[0]);
        return 1;
    }

    filename = argv[1];

    /* Run all tests */
    if (test_basic_oadirect(filename) != 0) {
        failed++;
    }

    if (failed == 0) {
        printf("ALL TESTS PASSED\n");
    } else {
        printf("%d TEST(S) FAILED\n", failed);
    }

    /* Clean up test file */
    unlink(filename);

    return failed > 0 ? 1 : 0;
}

```

- Before fix:
<img width="1268" height="609" alt="issue" src="https://github.com/user-attachments/assets/d0491802-1570-4897-aaa2-6ff4aa954b6d" />

- After fix: 
<img width="1107" height="218" alt="fix" src="https://github.com/user-attachments/assets/ff64e97b-ad0c-4706-9e30-2b5b5804603e" />
