### PR TITLE
Move `Pipe` from `InodeImpl` to `Inode`

### DIFF
--- a/kernel/src/fs/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/ext2/impl_for_vfs/inode.rs
@@ -148,7 +148,11 @@ impl Inode for Ext2Inode {
 
                 Some(device.open())
             }
-            InodeType::NamedPipe => Some(self.open_named_pipe(access_mode, status_flags)),
+            InodeType::NamedPipe => {
+                let pipe = self.named_pipe().unwrap();
+
+                Some(pipe.open_named(access_mode, status_flags))
+            }
             _ => None,
         }
     }

--- a/test/src/syscall/gvisor/blocklists.ext2/pipe_test
+++ b/test/src/syscall/gvisor/blocklists.ext2/pipe_test
@@ -1,2 +1,4 @@
-# TODO: Support pipe file in ext2 filesystem.
-*
+# Nothing here. Pipe files are supported by the ext2 file system.
+#
+# This file is kept to ensure that the `blocklists.ext2` directory
+# is not empty, as it may become useful in the future.


### PR DESCRIPTION
I am not sure why we need to take a lock before accessing the `named_pipe` field. It does not seem to make sense.

The `named_pipe` field should be with the `type_` field because it is completely determined by the `type_` field.

Additionally, it should be in a `Box`, as almost all inodes are not named pipes.

Meanwhile, the gvisor block list is also outdated.