### PR TITLE
Use accurate build time only when publishing

### DIFF
--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -98,6 +98,7 @@ jobs:
           image: asterinas/asterinas:0.17.0-20251228
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
+            export ASTER_BUILD_TIMESTAMP=`date '+%a %b %e %H:%M:%S %Z %Y'`
             make iso RELEASE=1 AUTO_INSTALL=false ARCH=${{ matrix.arch }}
             iso_path=$(realpath ./target/nixos/iso_image/iso/*.iso)
             echo "iso_path=$iso_path"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "component",
+ "const_format",
  "controlled",
  "core2",
  "cpio-decoder",
@@ -520,6 +521,26 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "toml",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1925,6 +1946,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ volatile = "0.6.1"
 # a capability it currently lacks.
 aes-gcm = { version = "0.9.4", features = ["force-soft"] }
 bittle = "0.5.6"
+const_format = "0.2.35"
 ctr = "0.8.0"
 font8x8 = { version = "0.2.5", default-features = false, features = [ "unicode" ] }
 getset = "0.1.2"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -29,6 +29,7 @@ bitflags.workspace = true
 bitvec.workspace = true
 cfg-if.workspace = true
 component.workspace = true
+const_format.workspace = true
 controlled.workspace = true
 core2.workspace = true
 cpio-decoder.workspace = true

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -250,19 +250,7 @@ fn build_kernel_elf(
                 .unwrap_or_else(|_| "unknown".to_string())
         ),
     );
-    // Use system date command to get the formatted time string
-    let date_output = std::process::Command::new("date")
-        // Reference: <https://man7.org/linux/man-pages/man1/date.1.html>
-        .arg("+%a %b %e %H:%M:%S %Z %Y")
-        .output()
-        .ok()
-        .and_then(|output| {
-            String::from_utf8(output.stdout)
-                .ok()
-                .map(|s| s.trim().to_string())
-        })
-        .unwrap_or_else(|| "Thu Jan  1 00:00:00 UTC 1970".to_string());
-    command.env("OSDK_BUILD_TIMESTAMP", format!("#1 {}", date_output));
+
     command.env("RUSTFLAGS", rustflags.join(" "));
     command.arg("build");
     command.arg("--features").arg(features.join(" "));


### PR DESCRIPTION
While refactoring the Makefile, I discovered that OSDK's cache build mechanism is currently broken. The issue stems from the fact that every `cargo osdk build` command passes the current system time as an environment variable to the kernel, which is then used to generate the contents of `/proc/version`.

While the impact on `make kernel` is negligible due to its short build time, it becomes highly problematic for `make nixos` or `make iso`. Since the kernel's binary content changes with every build, it triggers a full, redundant rebuild of the NixOS system or the ISO image, which is quite frustrating.

To resolve this, this PR introduces a new environment variable to toggle the use of the current timestamp. In most scenarios, the build will now default to a fixed timestamp (1970-01-01 00:00:00). The actual system time will only be used for official release builds, effectively minimizing unnecessary rebuilds.