### PR TITLE
Fix panic in `add_posix_timer`

### DIFF
--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -175,18 +175,18 @@ impl PosixTimerManager {
     }
 
     /// Adds a POSIX timer to the managed `posix_timers`, and allocate a timer ID for this timer.
-    /// Return the timer ID.
-    pub fn add_posix_timer(&self, posix_timer: Arc<Timer>) -> usize {
+    /// Return the timer ID, or `None` if allocation failed.
+    pub fn add_posix_timer(&self, posix_timer: Arc<Timer>) -> Option<usize> {
         let mut timers = self.posix_timers.lock();
         // Holding the lock of `posix_timers` is required to operate the `id_allocator`.
-        let timer_id = self.id_allocator.lock().alloc().unwrap();
-        if timers.len() < timer_id + 1 {
+        let timer_id = self.id_allocator.lock().alloc()?;
+        if timers.len() <= timer_id {
             timers.resize(timer_id + 1, None);
         }
         // The ID allocated is not used by any other timers so this index in `timers`
         // must be `None`.
         timers[timer_id] = Some(posix_timer);
-        timer_id
+        Some(timer_id)
     }
 
     /// Finds a POSIX timer by the input `timer_id`.

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -108,7 +108,9 @@ pub fn sys_timer_create(
 
     let timer = create_timer(clockid, func, ctx)?;
 
-    let timer_id = current_process.timer_manager().add_posix_timer(timer);
+    let Some(timer_id) = current_process.timer_manager().add_posix_timer(timer) else {
+        return_errno_with_message!(Errno::EAGAIN, "timer IDs are exhausted");
+    };
     ctx.user_space().write_val(timer_id_addr, &timer_id)?;
     Ok(SyscallReturn::Return(0))
 }


### PR DESCRIPTION
Fix #2861 

refer
https://github.com/torvalds/linux/blob/623fb9912f6af600cda3b6bd166ac738c1115ef4/kernel/time/posix-timers.c#L487-L489

```C
        new_timer = alloc_posix_timer();
	if (unlikely(!new_timer))
		return -EAGAIN;
```