### PR TITLE
Extract ring buffer into kernel/libs/ring-buffer (prep for syslog work)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "ostd-pod",
  "paste",
  "rand",
+ "ring-buffer",
  "riscv",
  "spin",
  "takeable",
@@ -1584,6 +1585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ring-buffer"
+version = "0.1.0"
+dependencies = [
+ "inherit-methods-macro",
+ "ostd",
+ "ostd-pod",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "kernel/libs/jhash",
     "kernel/libs/keyable-arc",
     "kernel/libs/logo-ascii-art",
+    "kernel/libs/ring-buffer",
     "kernel/libs/typeflags",
     "kernel/libs/typeflags-util",
     "kernel/libs/xarray",
@@ -88,6 +89,7 @@ default-members = [
     "kernel/libs/aster-bigtcp",
     "kernel/libs/aster-util",
     "kernel/libs/device-id",
+    "kernel/libs/ring-buffer",
     "kernel/libs/xarray",
 ]
 # All user-space or host-native crates.
@@ -164,6 +166,7 @@ device-id = { path = "kernel/libs/device-id" }
 jhash = { path = "kernel/libs/jhash" }
 keyable-arc = { path = "kernel/libs/keyable-arc" }
 logo-ascii-art = { path = "kernel/libs/logo-ascii-art" }
+ring-buffer = { path = "kernel/libs/ring-buffer" }
 typeflags = { path = "kernel/libs/typeflags" }
 typeflags-util = { path = "kernel/libs/typeflags-util" }
 xarray = { path = "kernel/libs/xarray" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -56,6 +56,7 @@ rand = { workspace = true, features = [
     "small_rng",
     "std_rng",
 ] }
+ring-buffer.workspace = true
 spin.workspace = true
 takeable.workspace = true
 time.workspace = true

--- a/kernel/libs/ring-buffer/Cargo.toml
+++ b/kernel/libs/ring-buffer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ring-buffer"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+inherit-methods-macro.workspace = true
+ostd.workspace = true
+ostd-pod.workspace = true
+
+[lints]
+workspace = true

--- a/kernel/libs/ring-buffer/src/lib.rs
+++ b/kernel/libs/ring-buffer/src/lib.rs
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::{
+    marker::PhantomData,
+    mem::size_of,
+    num::Wrapping,
+    ops::Deref,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use inherit_methods_macro::inherit_methods;
+use ostd::mm::{FrameAllocOptions, PAGE_SIZE, Segment, VmIo, io::util::HasVmReaderWriter};
+use ostd_pod::Pod;
+
+/// A lock-free single-producer single-consumer (SPSC) FIFO ring buffer.
+///
+/// This ring buffer is backed by a [`Segment<()>`] and provides non-blocking
+/// `push`/`pop` and `push_slice`/`pop_slice` operations for `T: Pod` items.
+/// It is designed for concurrent use where one thread produces items and
+/// another consumes them without requiring locks.
+///
+/// # Constraints
+///
+/// - The capacity must be a power of two.
+/// - Items must implement the [`Pod`] trait for safe memory operations.
+///
+/// # Usage Patterns
+///
+/// For concurrent SPSC usage, call [`split`](Self::split) to obtain a
+/// [`Producer`] and [`Consumer`] pair that can be safely used from
+/// different threads. For single-threaded usage, the `push`/`pop` methods
+/// can be called directly on a mutable reference.
+///
+/// # Example
+///
+/// ```ignore
+/// use ring_buffer::RingBuffer;
+///
+/// let rb = RingBuffer::<u8>::new(16);
+/// let (mut producer, mut consumer) = rb.split();
+///
+/// producer.push(42).unwrap();
+/// assert_eq!(consumer.pop(), Some(42));
+/// ```
+pub struct RingBuffer<T> {
+    segment: Segment<()>,
+    capacity: usize,
+    tail: AtomicUsize,
+    head: AtomicUsize,
+    phantom: PhantomData<T>,
+}
+
+/// The producer half of a [`RingBuffer`].
+///
+/// A `Producer` has exclusive rights to push items into the ring buffer.
+/// It can be safely used from one thread while a [`Consumer`] operates
+/// on the same ring buffer from another thread.
+pub struct Producer<T, R: Deref<Target = RingBuffer<T>>> {
+    rb: R,
+    phantom: PhantomData<T>,
+}
+
+/// The consumer half of a [`RingBuffer`].
+///
+/// A `Consumer` has exclusive rights to pop items from the ring buffer.
+/// It can be safely used from one thread while a [`Producer`] operates
+/// on the same ring buffer from another thread.
+pub struct Consumer<T, R: Deref<Target = RingBuffer<T>>> {
+    rb: R,
+    phantom: PhantomData<T>,
+}
+
+/// A producer backed by an `Arc<RingBuffer<T>>`.
+pub type RbProducer<T> = Producer<T, Arc<RingBuffer<T>>>;
+
+/// A consumer backed by an `Arc<RingBuffer<T>>`.
+pub type RbConsumer<T> = Consumer<T, Arc<RingBuffer<T>>>;
+
+impl<T> RingBuffer<T> {
+    const T_SIZE: usize = size_of::<T>();
+
+    /// Creates a new ring buffer with the specified capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is not a power of two.
+    pub fn new(capacity: usize) -> Self {
+        assert!(
+            capacity.is_power_of_two(),
+            "capacity must be a power of two"
+        );
+
+        let nframes = capacity
+            .checked_mul(Self::T_SIZE)
+            .unwrap()
+            .div_ceil(PAGE_SIZE);
+        let segment = FrameAllocOptions::new()
+            .zeroed(false)
+            .alloc_segment(nframes)
+            .unwrap();
+
+        Self {
+            segment,
+            capacity,
+            tail: AtomicUsize::new(0),
+            head: AtomicUsize::new(0),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Splits the ring buffer into a producer and consumer pair.
+    ///
+    /// The returned [`RbProducer`] and [`RbConsumer`] share ownership of the
+    /// underlying buffer via `Arc` and can be used concurrently from different threads.
+    pub fn split(self) -> (RbProducer<T>, RbConsumer<T>) {
+        let producer = Producer {
+            rb: Arc::new(self),
+            phantom: PhantomData,
+        };
+        let consumer = Consumer {
+            rb: Arc::clone(&producer.rb),
+            phantom: PhantomData,
+        };
+        (producer, consumer)
+    }
+
+    /// Returns the capacity of the ring buffer in number of items.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns a reference to the underlying memory segment.
+    ///
+    /// This is intended for advanced use cases that require direct memory access.
+    pub fn segment(&self) -> &Segment<()> {
+        &self.segment
+    }
+
+    /// Returns `true` if the ring buffer contains no items.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `true` if the ring buffer is at full capacity.
+    pub fn is_full(&self) -> bool {
+        self.free_len() == 0
+    }
+
+    /// Returns the number of items currently in the ring buffer.
+    pub fn len(&self) -> usize {
+        // Implementation notes: This subtraction only makes sense if either the head or the tail
+        // is considered frozen; if both are volatile, the number of the items may become negative
+        // due to race conditions. This is always true with a `RingBuffer` or a pair of
+        // `RbProducer` and `RbConsumer`.
+        (self.tail() - self.head()).0
+    }
+
+    /// Returns the number of items that can be pushed before the buffer is full.
+    pub fn free_len(&self) -> usize {
+        self.capacity - self.len()
+    }
+
+    /// Returns the head counter value.
+    ///
+    /// This represents the cumulative number of items that have been read from
+    /// the ring buffer since creation. The value wraps on overflow.
+    pub fn head(&self) -> Wrapping<usize> {
+        Wrapping(self.head.load(Ordering::Acquire))
+    }
+
+    /// Returns the tail counter value.
+    ///
+    /// This represents the cumulative number of items that have been written to
+    /// the ring buffer since creation. The value wraps on overflow.
+    pub fn tail(&self) -> Wrapping<usize> {
+        Wrapping(self.tail.load(Ordering::Acquire))
+    }
+
+    /// Advances the tail by `len` items starting from `tail`.
+    ///
+    /// This is an internal method. External users should use the safe
+    /// `commit_write` method on `Producer` instead.
+    pub(crate) fn advance_tail(&self, mut tail: Wrapping<usize>, len: usize) {
+        tail += len;
+        self.tail.store(tail.0, Ordering::Release);
+    }
+
+    /// Advances the head by `len` items starting from `head`.
+    ///
+    /// This is an internal method. External users should use the safe
+    /// `commit_read` method on `Consumer` instead.
+    pub(crate) fn advance_head(&self, mut head: Wrapping<usize>, len: usize) {
+        head += len;
+        self.head.store(head.0, Ordering::Release);
+    }
+
+    /// Resets the head to the current tail, effectively draining the buffer.
+    ///
+    /// This is an internal method. External users should use `Consumer::clear` instead.
+    pub(crate) fn reset_head(&self) {
+        let new_head = self.tail();
+        self.head.store(new_head.0, Ordering::Release);
+    }
+
+    /// Resets the ring buffer to an empty state.
+    ///
+    /// This method requires exclusive access (`&mut self`) and should only be
+    /// called when no concurrent producers or consumers are operating on the buffer.
+    pub fn clear(&mut self) {
+        self.tail.store(0, Ordering::Release);
+        self.head.store(0, Ordering::Release);
+    }
+}
+
+impl RingBuffer<u8> {
+    /// Commits a read operation by advancing the head pointer.
+    ///
+    /// This method is intended for advanced use cases where the caller reads
+    /// data directly from the backing segment and needs to update the head.
+    /// For normal use, prefer `Consumer::pop` or `Consumer::pop_slice`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds the number of available items in the buffer.
+    pub fn commit_read(&mut self, len: usize) {
+        assert!(
+            len <= self.len(),
+            "commit_read: len exceeds available items"
+        );
+        let head = self.head();
+        self.advance_head(head, len);
+    }
+}
+
+impl<T: Pod> RingBuffer<T> {
+    /// Pushes a single item into the ring buffer.
+    ///
+    /// Returns `Some(())` on success, or `None` if the buffer is full.
+    pub fn push(&mut self, item: T) -> Option<()> {
+        let mut producer = Producer {
+            rb: self,
+            phantom: PhantomData,
+        };
+        producer.push(item)
+    }
+
+    /// Pushes all items from the slice into the ring buffer.
+    ///
+    /// Returns `Some(())` if all items were successfully pushed, or `None` if
+    /// there is not enough free space to fit all items. This is an all-or-nothing
+    /// operation; no items are pushed if the slice cannot fit entirely.
+    pub fn push_slice(&mut self, items: &[T]) -> Option<()> {
+        let mut producer = Producer {
+            rb: self,
+            phantom: PhantomData,
+        };
+        producer.push_slice(items)
+    }
+
+    /// Pops a single item from the ring buffer.
+    ///
+    /// Returns `Some(item)` on success, or `None` if the buffer is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        let mut consumer = Consumer {
+            rb: self,
+            phantom: PhantomData,
+        };
+        consumer.pop()
+    }
+
+    /// Pops items from the ring buffer into the provided slice.
+    ///
+    /// Returns `Some(())` if all slots in the slice were filled, or `None` if
+    /// there are not enough items available. This is an all-or-nothing operation;
+    /// no items are popped if the slice cannot be filled entirely.
+    pub fn pop_slice(&mut self, items: &mut [T]) -> Option<()> {
+        let mut consumer = Consumer {
+            rb: self,
+            phantom: PhantomData,
+        };
+        consumer.pop_slice(items)
+    }
+}
+
+impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
+    const T_SIZE: usize = size_of::<T>();
+
+    /// Pushes a single item into the ring buffer.
+    ///
+    /// Returns `Some(())` on success, or `None` if the buffer is full.
+    pub fn push(&mut self, item: T) -> Option<()> {
+        let rb = &self.rb;
+        if rb.is_full() {
+            return None;
+        }
+
+        let tail = rb.tail();
+        let offset = tail.0 & (rb.capacity - 1);
+        let byte_offset = offset * Self::T_SIZE;
+
+        let mut writer = rb.segment.writer();
+        writer.skip(byte_offset);
+        writer.write_val(&item).unwrap();
+
+        rb.advance_tail(tail, 1);
+        Some(())
+    }
+
+    /// Pushes all items from the slice into the ring buffer.
+    ///
+    /// Returns `Some(())` if all items were successfully pushed, or `None` if
+    /// there is not enough free space. This is an all-or-nothing operation;
+    /// no items are pushed if the slice cannot fit entirely.
+    pub fn push_slice(&mut self, items: &[T]) -> Option<()> {
+        let rb = &self.rb;
+        let nitems = items.len();
+        if rb.free_len() < nitems {
+            return None;
+        }
+
+        let tail = rb.tail();
+        let offset = tail.0 & (rb.capacity - 1);
+        let byte_offset = offset * Self::T_SIZE;
+
+        if offset + nitems > rb.capacity {
+            // Write into two separate parts due to wraparound.
+            rb.segment
+                .write_slice(byte_offset, &items[..rb.capacity - offset])
+                .unwrap();
+            rb.segment
+                .write_slice(0, &items[rb.capacity - offset..])
+                .unwrap();
+        } else {
+            rb.segment.write_slice(byte_offset, items).unwrap();
+        }
+
+        rb.advance_tail(tail, nitems);
+        Some(())
+    }
+}
+
+#[inherit_methods(from = "self.rb")]
+impl<T, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
+    pub fn capacity(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn is_full(&self) -> bool;
+    pub fn len(&self) -> usize;
+    pub fn free_len(&self) -> usize;
+    pub fn head(&self) -> Wrapping<usize>;
+    pub fn tail(&self) -> Wrapping<usize>;
+    pub fn segment(&self) -> &Segment<()>;
+}
+
+impl<T, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
+    /// Commits a write operation by advancing the tail pointer.
+    ///
+    /// This method is intended for advanced use cases where the caller writes
+    /// data directly to the backing segment and needs to update the tail.
+    /// For normal use, prefer `Producer::push` or `Producer::push_slice`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds the available free space in the buffer.
+    pub fn commit_write(&self, len: usize) {
+        assert!(
+            len <= self.free_len(),
+            "commit_write: len exceeds free space"
+        );
+        let tail = self.tail();
+        self.rb.advance_tail(tail, len);
+    }
+}
+
+impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
+    const T_SIZE: usize = size_of::<T>();
+
+    /// Pops a single item from the ring buffer.
+    ///
+    /// Returns `Some(item)` on success, or `None` if the buffer is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        let rb = &self.rb;
+        if rb.is_empty() {
+            return None;
+        }
+
+        let head = rb.head();
+        let offset = head.0 & (rb.capacity - 1);
+        let byte_offset = offset * Self::T_SIZE;
+
+        let mut reader = rb.segment.reader();
+        reader.skip(byte_offset);
+        let item = reader.read_val::<T>().unwrap();
+
+        rb.advance_head(head, 1);
+        Some(item)
+    }
+
+    /// Pops items from the ring buffer into the provided slice.
+    ///
+    /// Returns `Some(())` if all slots in the slice were filled, or `None` if
+    /// there are not enough items available. This is an all-or-nothing operation;
+    /// no items are popped if the slice cannot be filled entirely.
+    pub fn pop_slice(&mut self, items: &mut [T]) -> Option<()> {
+        let rb = &self.rb;
+        let nitems = items.len();
+        if rb.len() < nitems {
+            return None;
+        }
+
+        let head = rb.head();
+        let offset = head.0 & (rb.capacity - 1);
+        let byte_offset = offset * Self::T_SIZE;
+
+        if offset + nitems > rb.capacity {
+            // Read from two separate parts due to wraparound.
+            rb.segment
+                .read_slice(byte_offset, &mut items[..rb.capacity - offset])
+                .unwrap();
+            rb.segment
+                .read_slice(0, &mut items[rb.capacity - offset..])
+                .unwrap();
+        } else {
+            rb.segment.read_slice(byte_offset, items).unwrap();
+        }
+
+        rb.advance_head(head, nitems);
+        Some(())
+    }
+
+    /// Discards `count` items from the ring buffer without reading them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `count` exceeds the number of available items in the buffer.
+    pub fn skip(&mut self, count: usize) {
+        let rb = &self.rb;
+        let len = rb.len();
+        assert!(len >= count, "skip: count exceeds available items");
+
+        let head = rb.head();
+        rb.advance_head(head, count);
+    }
+
+    /// Discards all items from the ring buffer.
+    ///
+    /// After this call, the buffer will be empty from the consumer's perspective.
+    pub fn clear(&mut self) {
+        self.rb.reset_head();
+    }
+}
+
+#[inherit_methods(from = "self.rb")]
+impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
+    pub fn capacity(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn is_full(&self) -> bool;
+    pub fn len(&self) -> usize;
+    pub fn free_len(&self) -> usize;
+    pub fn head(&self) -> Wrapping<usize>;
+    pub fn tail(&self) -> Wrapping<usize>;
+    pub fn segment(&self) -> &Segment<()>;
+}
+
+impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
+    /// Commits a read operation by advancing the head pointer.
+    ///
+    /// This method is intended for advanced use cases where the caller reads
+    /// data directly from the backing segment and needs to update the head.
+    /// For normal use, prefer `Consumer::pop` or `Consumer::pop_slice`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds the number of available items in the buffer.
+    pub fn commit_read(&self, len: usize) {
+        assert!(
+            len <= self.len(),
+            "commit_read: len exceeds available items"
+        );
+        let head = self.head();
+        self.rb.advance_head(head, len);
+    }
+}
+
+#[cfg(ktest)]
+mod test;

--- a/kernel/libs/ring-buffer/src/test.rs
+++ b/kernel/libs/ring-buffer/src/test.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::prelude::ktest;
+
+use super::*;
+
+#[ktest]
+fn rb_basics() {
+    let mut rb = RingBuffer::<i32>::new(4);
+    rb.push(-100).unwrap();
+    rb.push_slice(&[-1]).unwrap();
+    assert_eq!(rb.len(), 2);
+
+    let mut popped = [0i32; 2];
+    rb.pop_slice(&mut popped).unwrap();
+    assert_eq!(popped, [-100i32, -1]);
+    assert!(rb.is_empty());
+
+    rb.push_slice(&[i32::MAX, 1, -2, 100]).unwrap();
+    assert!(rb.is_full());
+
+    let popped = rb.pop();
+    assert_eq!(popped, Some(i32::MAX));
+    assert_eq!(rb.free_len(), 1);
+
+    let mut popped = [0i32; 3];
+    rb.pop_slice(&mut popped).unwrap();
+    assert_eq!(popped, [1i32, -2, 100]);
+    assert_eq!(rb.free_len(), 4);
+}
+
+#[ktest]
+fn rb_write_read_one() {
+    let rb = RingBuffer::<u8>::new(1);
+
+    let (mut prod, mut cons) = rb.split();
+    assert_eq!(prod.capacity(), 1);
+    assert_eq!(cons.capacity(), 1);
+
+    assert!(cons.pop().is_none());
+    assert!(prod.push(1).is_some());
+    assert!(prod.is_full());
+
+    assert!(prod.push(2).is_none());
+    assert!(prod.push_slice(&[2]).is_none());
+    assert_eq!(cons.pop().unwrap(), 1u8);
+    assert!(cons.is_empty());
+}
+
+#[ktest]
+fn rb_write_read_all() {
+    use ostd::mm::PAGE_SIZE;
+
+    let rb = RingBuffer::<u8>::new(4 * PAGE_SIZE);
+    assert_eq!(rb.capacity(), 4 * PAGE_SIZE);
+
+    let (mut prod, mut cons) = rb.split();
+    prod.push(u8::MIN).unwrap();
+    assert_eq!(cons.pop().unwrap(), u8::MIN);
+
+    prod.push_slice(&[u8::MAX]).unwrap();
+    let mut popped = [0u8];
+    cons.pop_slice(&mut popped).unwrap();
+    assert_eq!(popped, [u8::MAX]);
+
+    let step = 128;
+    let mut input = alloc::vec![0u8; step];
+    for i in (0..4 * PAGE_SIZE).step_by(step) {
+        input.fill(i as _);
+        prod.push_slice(&input).unwrap();
+    }
+    assert!(cons.is_full());
+
+    let mut output = alloc::vec![0u8; step];
+    for i in (0..4 * PAGE_SIZE).step_by(step) {
+        cons.pop_slice(&mut output).unwrap();
+        assert_eq!(output[0], i as u8);
+        assert_eq!(output[step - 1], i as u8);
+    }
+    assert!(prod.is_empty());
+}

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     util::{
         ioctl::{RawIoctl, dispatch_ioctl},
-        ring_buffer::{RbConsumer, RbProducer, RingBuffer},
+        ring_buffer::{ConsumerU8Ext, ProducerU8Ext, RbConsumer, RbProducer, RingBuffer},
     },
 };
 

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -20,7 +20,7 @@ use crate::{
     process::signal::Pollee,
     util::{
         MultiRead, MultiWrite,
-        ring_buffer::{RbConsumer, RbProducer, RingBuffer},
+        ring_buffer::{ConsumerU8Ext, ProducerU8Ext, RbConsumer, RbProducer, RingBuffer},
     },
 };
 

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -1,557 +1,141 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{
-    marker::PhantomData,
-    num::Wrapping,
-    ops::Deref,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::ops::Deref;
 
-use inherit_methods_macro::inherit_methods;
-use ostd::mm::{FrameAllocOptions, Segment, VmIo, io::util::HasVmReaderWriter};
+use ostd::mm::io::util::HasVmReaderWriter;
+pub use ring_buffer::{Consumer, Producer, RbConsumer, RbProducer, RingBuffer};
 
 use super::{MultiRead, MultiWrite};
 use crate::prelude::*;
 
-/// A lock-free SPSC FIFO ring buffer backed by a [`Segment<()>`].
-///
-/// The ring buffer supports `push`/`pop` any `T: Pod` items, also
-/// supports `write`/`read` any bytes data based on [`VmReader`]/[`VmWriter`].
-///
-/// The ring buffer returns immediately after processing without any blocking.
-/// The ring buffer can be shared between threads.
-///
-/// # Example
-///
-/// ```
-/// use ostd_pod::Pod;
-/// use ring_buffer::RingBuffer;
-///
-/// #[derive(Pod)]
-/// struct Item {
-///     a: u32,
-///     b: u32,
-/// }
-///
-/// let rb = RingBuffer::<Item>::new(10);
-/// let (producer, consumer) = rb.split();
-///
-/// for i in 0..10 {
-///     producer.push(Item { a: i, b: i }).unwrap();
-/// }
-///
-/// for _ in 0..10 {
-///     let item = consumer.pop().unwrap();
-///     assert_eq!(item.a, item.b);
-/// }
-/// ```
-pub struct RingBuffer<T> {
-    segment: Segment<()>,
-    capacity: usize,
-    tail: AtomicUsize,
-    head: AtomicUsize,
-    phantom: PhantomData<T>,
-}
-
-/// A producer of a [`RingBuffer`].
-pub struct Producer<T, R: Deref<Target = RingBuffer<T>>> {
-    rb: R,
-    phantom: PhantomData<T>,
-}
-/// A consumer of a [`RingBuffer`].
-pub struct Consumer<T, R: Deref<Target = RingBuffer<T>>> {
-    rb: R,
-    phantom: PhantomData<T>,
-}
-
-pub type RbProducer<T> = Producer<T, Arc<RingBuffer<T>>>;
-pub type RbConsumer<T> = Consumer<T, Arc<RingBuffer<T>>>;
-
-impl<T> RingBuffer<T> {
-    const T_SIZE: usize = size_of::<T>();
-
-    /// Creates a new [`RingBuffer`] with the given capacity.
-    pub fn new(capacity: usize) -> Self {
-        assert!(
-            capacity.is_power_of_two(),
-            "capacity must be a power of two"
-        );
-
-        let nframes = capacity
-            .checked_mul(Self::T_SIZE)
-            .unwrap()
-            .div_ceil(PAGE_SIZE);
-        let segment = FrameAllocOptions::new()
-            .zeroed(false)
-            .alloc_segment(nframes)
-            .unwrap();
-
-        Self {
-            segment,
-            capacity,
-            tail: AtomicUsize::new(0),
-            head: AtomicUsize::new(0),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Splits the [`RingBuffer`] into a producer and a consumer.
-    pub fn split(self) -> (RbProducer<T>, RbConsumer<T>) {
-        let producer = Producer {
-            rb: Arc::new(self),
-            phantom: PhantomData,
-        };
-        let consumer = Consumer {
-            rb: Arc::clone(&producer.rb),
-            phantom: PhantomData,
-        };
-        (producer, consumer)
-    }
-
-    /// Gets the capacity of the `RingBuffer`.
-    pub fn capacity(&self) -> usize {
-        self.capacity
-    }
-
-    /// Checks if the `RingBuffer` is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Checks if the `RingBuffer` is full.
-    pub fn is_full(&self) -> bool {
-        self.free_len() == 0
-    }
-
-    /// Gets the number of items in the `RingBuffer`.
-    pub fn len(&self) -> usize {
-        // Implementation notes: This subtraction only makes sense if either the head or the tail
-        // is considered frozen; if both are volatile, the number of the items may become negative
-        // due to race conditions. This is always true with a `RingBuffer` or a pair of
-        // `RbProducer` and `RbConsumer`.
-        (self.tail() - self.head()).0
-    }
-
-    /// Gets the number of free items in the `RingBuffer`.
-    pub fn free_len(&self) -> usize {
-        self.capacity - self.len()
-    }
-
-    /// Gets the head number of the `RingBuffer`.
-    ///
-    /// This is the number of items read from the ring buffer. The number wraps when crossing
-    /// [`usize`] boundaries.
-    pub fn head(&self) -> Wrapping<usize> {
-        Wrapping(self.head.load(Ordering::Acquire))
-    }
-
-    /// Gets the tail number of the `RingBuffer`.
-    ///
-    /// This is the number of items written into the ring buffer. The number wraps when crossing
-    /// [`usize`] boundaries.
-    pub fn tail(&self) -> Wrapping<usize> {
-        Wrapping(self.tail.load(Ordering::Acquire))
-    }
-
-    /// Clears the `RingBuffer`.
-    pub fn clear(&mut self) {
-        self.tail.store(0, Ordering::Release);
-        self.head.store(0, Ordering::Release);
-    }
-}
-
-impl<T: Pod> RingBuffer<T> {
-    /// Pushes an item to the `RingBuffer`.
-    ///
-    /// Returns `Some` on success. Returns `None` if
-    /// the ring buffer is full.
-    pub fn push(&mut self, item: T) -> Option<()> {
-        let mut producer = Producer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        producer.push(item)
-    }
-
-    /// Pushes a slice of items to the `RingBuffer`.
-    ///
-    /// Returns `Some` on success, all items are pushed to the ring buffer.
-    /// Returns `None` if the ring buffer is full or cannot fit all items.
-    pub fn push_slice(&mut self, items: &[T]) -> Option<()> {
-        let mut producer = Producer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        producer.push_slice(items)
-    }
-
-    /// Pops an item from the `RingBuffer`.
-    ///
-    /// Returns `Some` with the popped item on success.
-    /// Returns `None` if the ring buffer is empty.
-    pub fn pop(&mut self) -> Option<T> {
-        let mut consumer = Consumer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        consumer.pop()
-    }
-
-    /// Pops a slice of items from the `RingBuffer`.
-    ///
-    /// Returns `Some` on success, all items are popped from the ring buffer.
-    /// Returns `None` if the ring buffer is empty or cannot fill all items.
-    pub fn pop_slice(&mut self, items: &mut [T]) -> Option<()> {
-        let mut consumer = Consumer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        consumer.pop_slice(items)
-    }
-
-    pub(self) fn advance_tail(&self, mut tail: Wrapping<usize>, len: usize) {
-        tail += len;
-        self.tail.store(tail.0, Ordering::Release);
-    }
-
-    pub(self) fn advance_head(&self, mut head: Wrapping<usize>, len: usize) {
-        head += len;
-        self.head.store(head.0, Ordering::Release);
-    }
-
-    pub(self) fn reset_head(&self) {
-        let new_head = self.tail();
-        self.head.store(new_head.0, Ordering::Release);
-    }
-}
-
-impl RingBuffer<u8> {
-    /// Writes data from the `reader` to the `RingBuffer`.
+/// Extension methods for writing bytes to a [`Producer<u8, _>`].
+pub trait ProducerU8Ext {
+    /// Writes data from `reader` to the ring buffer.
     ///
     /// Returns the number of bytes written.
-    #[expect(unused)]
-    pub fn write_fallible(&mut self, reader: &mut dyn MultiRead) -> Result<usize> {
-        let mut producer = Producer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        producer.write_fallible(reader)
-    }
+    fn write_fallible(&mut self, reader: &mut dyn MultiRead) -> Result<usize>;
 
-    /// Reads data from the `writer` to the `RingBuffer`.
-    ///
-    /// Returns the number of bytes read.
-    #[expect(unused)]
-    pub fn read_fallible(&mut self, writer: &mut dyn MultiWrite) -> Result<usize> {
-        let mut consumer = Consumer {
-            rb: self,
-            phantom: PhantomData,
-        };
-        consumer.read_fallible(writer)
-    }
-}
-
-impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
-    const T_SIZE: usize = size_of::<T>();
-
-    /// Pushes an item to the `RingBuffer`.
-    ///
-    /// Returns `Some` on success. Returns `None` if
-    /// the ring buffer is full.
-    pub fn push(&mut self, item: T) -> Option<()> {
-        let rb = &self.rb;
-        if rb.is_full() {
-            return None;
-        }
-
-        let tail = rb.tail();
-        let offset = tail.0 & (rb.capacity - 1);
-        let byte_offset = offset * Self::T_SIZE;
-
-        let mut writer = rb.segment.writer();
-        writer.skip(byte_offset);
-        writer.write_val(&item).unwrap();
-
-        rb.advance_tail(tail, 1);
-        Some(())
-    }
-
-    /// Pushes a slice of items to the `RingBuffer`.
-    ///
-    /// Returns `Some` on success, all items are pushed to the ring buffer.
-    /// Returns `None` if the ring buffer is full or cannot fit all items.
-    pub fn push_slice(&mut self, items: &[T]) -> Option<()> {
-        let rb = &self.rb;
-        let nitems = items.len();
-        if rb.free_len() < nitems {
-            return None;
-        }
-
-        let tail = rb.tail();
-        let offset = tail.0 & (rb.capacity - 1);
-        let byte_offset = offset * Self::T_SIZE;
-
-        if offset + nitems > rb.capacity {
-            // Write into two separate parts
-            rb.segment
-                .write_slice(byte_offset, &items[..rb.capacity - offset])
-                .unwrap();
-            rb.segment
-                .write_slice(0, &items[rb.capacity - offset..])
-                .unwrap();
-        } else {
-            rb.segment.write_slice(byte_offset, items).unwrap();
-        }
-
-        rb.advance_tail(tail, nitems);
-        Some(())
-    }
-
-    // There is no counterpart to `Consumer::skip` and `Consumer::clear`. They do not make sense
-    // for the producer.
-}
-
-impl<R: Deref<Target = RingBuffer<u8>>> Producer<u8, R> {
-    /// Writes data from the `VmReader` to the `RingBuffer`.
+    /// Writes up to `max_len` bytes from `reader` to the ring buffer.
     ///
     /// Returns the number of bytes written.
-    pub fn write_fallible(&mut self, reader: &mut dyn MultiRead) -> Result<usize> {
+    fn write_fallible_with_max_len(
+        &mut self,
+        reader: &mut dyn MultiRead,
+        max_len: usize,
+    ) -> Result<usize>;
+}
+
+impl<R: Deref<Target = RingBuffer<u8>>> ProducerU8Ext for Producer<u8, R> {
+    fn write_fallible(&mut self, reader: &mut dyn MultiRead) -> Result<usize> {
         self.write_fallible_with_max_len(reader, usize::MAX)
     }
 
-    /// Writes data from the `VmReader` to the `RingBuffer` with the maximum length.
-    ///
-    /// Returns the number of bytes written.
-    pub fn write_fallible_with_max_len(
+    fn write_fallible_with_max_len(
         &mut self,
         reader: &mut dyn MultiRead,
         max_len: usize,
     ) -> Result<usize> {
-        let rb = &self.rb;
-        let free_len = rb.free_len().min(max_len);
+        let free_len = self.free_len().min(max_len);
 
-        let tail = rb.tail();
-        let offset = tail.0 & (rb.capacity - 1);
+        let tail = self.tail();
+        let offset = tail.0 & (self.capacity() - 1);
 
-        let write_len = if offset + free_len > rb.capacity {
+        let write_len = if offset + free_len > self.capacity() {
             // Write into two separate parts
             let mut write_len = 0;
 
-            let mut writer = rb.segment.writer();
-            writer.skip(offset).limit(rb.capacity - offset);
+            let mut writer = self.segment().writer();
+            writer.skip(offset).limit(self.capacity() - offset);
             write_len += reader.read(&mut writer)?;
 
-            let mut writer = rb.segment.writer();
-            writer.limit(free_len - (rb.capacity - offset));
+            let mut writer = self.segment().writer();
+            writer.limit(free_len - (self.capacity() - offset));
             write_len += reader.read(&mut writer)?;
 
             write_len
         } else {
-            let mut writer = rb.segment.writer();
+            let mut writer = self.segment().writer();
             writer.skip(offset).limit(free_len);
             reader.read(&mut writer)?
         };
 
-        rb.advance_tail(tail, write_len);
+        self.commit_write(write_len);
         Ok(write_len)
     }
 }
 
-#[inherit_methods(from = "self.rb")]
-impl<T, R: Deref<Target = RingBuffer<T>>> Producer<T, R> {
-    pub fn capacity(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn is_full(&self) -> bool;
-    pub fn len(&self) -> usize;
-    pub fn free_len(&self) -> usize;
-    pub fn head(&self) -> Wrapping<usize>;
-    pub fn tail(&self) -> Wrapping<usize>;
-}
-
-impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
-    const T_SIZE: usize = size_of::<T>();
-
-    /// Pops an item from the `RingBuffer`.
-    ///
-    /// Returns `Some` with the popped item on success.
-    /// Returns `None` if the ring buffer is empty.
-    pub fn pop(&mut self) -> Option<T> {
-        let rb = &self.rb;
-        if rb.is_empty() {
-            return None;
-        }
-
-        let head = rb.head();
-        let offset = head.0 & (rb.capacity - 1);
-        let byte_offset = offset * Self::T_SIZE;
-
-        let mut reader = rb.segment.reader();
-        reader.skip(byte_offset);
-        let item = reader.read_val::<T>().unwrap();
-
-        rb.advance_head(head, 1);
-        Some(item)
-    }
-
-    /// Pops a slice of items from the `RingBuffer`.
-    ///
-    /// Returns `Some` on success, all items are popped from the ring buffer.
-    /// Returns `None` if the ring buffer is empty or cannot fill all items.
-    pub fn pop_slice(&mut self, items: &mut [T]) -> Option<()> {
-        let rb = &self.rb;
-        let nitems = items.len();
-        if rb.len() < nitems {
-            return None;
-        }
-
-        let head = rb.head();
-        let offset = head.0 & (rb.capacity - 1);
-        let byte_offset = offset * Self::T_SIZE;
-
-        if offset + nitems > rb.capacity {
-            // Read from two separate parts
-            rb.segment
-                .read_slice(byte_offset, &mut items[..rb.capacity - offset])
-                .unwrap();
-            rb.segment
-                .read_slice(0, &mut items[rb.capacity - offset..])
-                .unwrap();
-        } else {
-            rb.segment.read_slice(byte_offset, items).unwrap();
-        }
-
-        rb.advance_head(head, nitems);
-        Some(())
-    }
-
-    /// Skips `count` items in the `RingBuffer`.
-    ///
-    /// In other words, `count` items are popped from the `RingBuffer` and discarded.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the number of the available items to pop is less than `count`.
-    pub fn skip(&mut self, count: usize) {
-        let rb = &self.rb;
-        let len = rb.len();
-        assert!(len >= count);
-
-        let head = rb.head();
-        rb.advance_head(head, count);
-    }
-
-    /// Clears the `RingBuffer`.
-    ///
-    /// In other words, all items are popped from the `RingBuffer` and discarded.
-    pub fn clear(&mut self) {
-        self.rb.reset_head();
-    }
-}
-
-impl<R: Deref<Target = RingBuffer<u8>>> Consumer<u8, R> {
-    /// Reads data from the `VmWriter` to the `RingBuffer`.
+/// Extension methods for reading bytes from a [`Consumer<u8, _>`].
+pub trait ConsumerU8Ext {
+    /// Reads data from the ring buffer into `writer`.
     ///
     /// Returns the number of bytes read.
-    pub fn read_fallible(&mut self, writer: &mut dyn MultiWrite) -> Result<usize> {
+    fn read_fallible(&mut self, writer: &mut dyn MultiWrite) -> Result<usize>;
+
+    /// Reads up to `max_len` bytes from the ring buffer into `writer`.
+    ///
+    /// Returns the number of bytes read.
+    fn read_fallible_with_max_len(
+        &mut self,
+        writer: &mut dyn MultiWrite,
+        max_len: usize,
+    ) -> Result<usize>;
+}
+
+impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
+    fn read_fallible(&mut self, writer: &mut dyn MultiWrite) -> Result<usize> {
         self.read_fallible_with_max_len(writer, usize::MAX)
     }
 
-    /// Reads data from the `VmWriter` to the `RingBuffer` with the maximum length.
-    ///
-    /// Returns the number of bytes read.
-    pub fn read_fallible_with_max_len(
+    fn read_fallible_with_max_len(
         &mut self,
         writer: &mut dyn MultiWrite,
         max_len: usize,
     ) -> Result<usize> {
-        let rb = &self.rb;
-        let len = rb.len().min(max_len);
+        let len = self.len().min(max_len);
 
-        let head = rb.head();
-        let offset = head.0 & (rb.capacity - 1);
+        let head = self.head();
+        let offset = head.0 & (self.capacity() - 1);
 
-        let read_len = if offset + len > rb.capacity {
+        let read_len = if offset + len > self.capacity() {
             // Read from two separate parts
             let mut read_len = 0;
 
-            let mut reader = rb.segment.reader();
-            reader.skip(offset).limit(rb.capacity - offset);
+            let mut reader = self.segment().reader();
+            reader.skip(offset).limit(self.capacity() - offset);
             read_len += writer.write(&mut reader)?;
 
-            let mut reader = rb.segment.reader();
-            reader.limit(len - (rb.capacity - offset));
+            let mut reader = self.segment().reader();
+            reader.limit(len - (self.capacity() - offset));
             read_len += writer.write(&mut reader)?;
 
             read_len
         } else {
-            let mut reader = rb.segment.reader();
+            let mut reader = self.segment().reader();
             reader.skip(offset).limit(len);
             writer.write(&mut reader)?
         };
 
-        rb.advance_head(head, read_len);
+        self.commit_read(read_len);
         Ok(read_len)
     }
 }
 
-#[inherit_methods(from = "self.rb")]
-impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
-    pub fn capacity(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn is_full(&self) -> bool;
-    pub fn len(&self) -> usize;
-    pub fn free_len(&self) -> usize;
-    pub fn head(&self) -> Wrapping<usize>;
-    pub fn tail(&self) -> Wrapping<usize>;
-}
-
 #[cfg(ktest)]
 mod test {
-    use ostd::prelude::*;
+    use alloc::vec;
+
+    use ostd::{
+        mm::{PAGE_SIZE, VmReader, VmWriter},
+        prelude::*,
+    };
 
     use super::*;
 
     #[ktest]
-    fn basics() {
-        let mut rb = RingBuffer::<i32>::new(4);
-        rb.push(-100).unwrap();
-        rb.push_slice(&[-1]).unwrap();
-        assert_eq!(rb.len(), 2);
-
-        let mut popped = [0i32; 2];
-        rb.pop_slice(&mut popped).unwrap();
-        assert_eq!(popped, [-100i32, -1]);
-        assert!(rb.is_empty());
-
-        rb.push_slice(&[i32::MAX, 1, -2, 100]).unwrap();
-        assert!(rb.is_full());
-
-        let popped = rb.pop();
-        assert_eq!(popped, Some(i32::MAX));
-        assert_eq!(rb.free_len(), 1);
-
-        let mut popped = [0i32; 3];
-        rb.pop_slice(&mut popped).unwrap();
-        assert_eq!(popped, [1i32, -2, 100]);
-        assert_eq!(rb.free_len(), 4);
-    }
-
-    #[ktest]
-    fn write_read_one() {
+    fn rb_write_read_one_with_ext() {
         let rb = RingBuffer::<u8>::new(1);
 
         let (mut prod, mut cons) = rb.split();
-        assert_eq!(prod.capacity(), 1);
-        assert_eq!(cons.capacity(), 1);
-
-        assert!(cons.pop().is_none());
-        assert!(prod.push(1).is_some());
-        assert!(prod.is_full());
-
-        assert!(prod.push(2).is_none());
-        assert!(prod.push_slice(&[2]).is_none());
-        assert_eq!(cons.pop().unwrap(), 1u8);
-        assert!(cons.is_empty());
 
         let input = [u8::MAX];
         assert_eq!(
@@ -583,18 +167,11 @@ mod test {
     }
 
     #[ktest]
-    fn write_read_all() {
+    fn rb_write_read_all_with_ext() {
         let rb = RingBuffer::<u8>::new(4 * PAGE_SIZE);
         assert_eq!(rb.capacity(), 4 * PAGE_SIZE);
 
         let (mut prod, mut cons) = rb.split();
-        prod.push(u8::MIN).unwrap();
-        assert_eq!(cons.pop().unwrap(), u8::MIN);
-
-        prod.push_slice(&[u8::MAX]).unwrap();
-        let mut popped = [0u8];
-        cons.pop_slice(&mut popped).unwrap();
-        assert_eq!(popped, [u8::MAX]);
 
         let step = 128;
         let mut input = vec![0u8; step];


### PR DESCRIPTION
This PR extracts the lock-free SPSC FIFO ring buffer from `kernel::util` into a reusable crate `kernel/libs/ring-buffer`, as suggested in #2265.

* Add new `ring-buffer` crate providing `RingBuffer<T>` + `Producer/Consumer` for `T: Pod`.
* Keep `kernel::util::ring_buffer` as a thin re-export + `u8` I/O extension traits (`ProducerU8Ext`/`ConsumerU8Ext`/`RingBufferU8Ext`) for existing users.
* Update pipe/unix/vsock call sites to import the extension traits.
* Wire the crate into workspace/OSDK and add kernel dependency.

No intended functional change; this is a refactor to unblock upcoming syslog work.