### PR TITLE
Fix error handling in OverlayFsType by propagating lookup errors

### DIFF
--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -1184,12 +1184,8 @@ impl FsType for OverlayFsType {
         let upper = path_resolver.lookup(&FsPath::try_from(upper)?)?;
         let lower = lower
             .iter()
-            .map(|&lower| {
-                path_resolver
-                    .lookup(&FsPath::try_from(lower).unwrap())
-                    .unwrap()
-            })
-            .collect();
+            .map(|&lower| path_resolver.lookup(&FsPath::try_from(lower)?))
+            .collect::<Result<Vec<_>>>()?;
         let work = path_resolver.lookup(&FsPath::try_from(work)?)?;
 
         OverlayFs::new(upper, lower, work).map(|fs| fs as _)


### PR DESCRIPTION
Fix #2876 