### PR TITLE
Add free-disk-space action to Docker publish workflows

### DIFF
--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -12,6 +12,7 @@ jobs:
   publish_osdk_image:
     runs-on: ubuntu-latest
     steps:
+      - uses: BRAINSia/free-disk-space@v2
       - uses: actions/checkout@v4
       - name: Prepare for Docker build and push
         id: prepare-for-docker-build-and-push
@@ -34,6 +35,7 @@ jobs:
     needs: publish_osdk_image
     runs-on: ubuntu-latest
     steps:
+      - uses: BRAINSia/free-disk-space@v2
       - uses: actions/checkout@v4
       - name: Prepare for Docker build and push
         id: prepare-for-docker-build-and-push
@@ -56,6 +58,7 @@ jobs:
     needs: publish_nix_image
     runs-on: ubuntu-latest
     steps:
+      - uses: BRAINSia/free-disk-space@v2
       - uses: actions/checkout@v4
       - name: Prepare for Docker build and push
         id: prepare-for-docker-build-and-push


### PR DESCRIPTION
The runner runs out of disk space when publish docker images, as seen in https://github.com/asterinas/asterinas/actions/runs/20987019219/job/60325606482.
This PR adds the `BRAINSia/free-disk-space@v2` action to Docker publish workflow, which frees up approximately 28GB of disk space before building, preventing potential disk space exhaustion during the build process.