### PR TITLE
Fix a typo in i8042 `is_present_cmdline`

### DIFF
--- a/kernel/comps/i8042/src/controller.rs
+++ b/kernel/comps/i8042/src/controller.rs
@@ -175,7 +175,7 @@ impl I8042Controller {
 
     /// Checks if the kernel command line contains the "i8042.exist" option.
     fn is_present_cmdline() -> bool {
-        !KCMDLINE
+        KCMDLINE
             .get()
             .unwrap()
             .get_module_args("i8042")


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/f1a144b87658e856d82b5945a58f9461d9c33981/kernel/comps/i8042/src/controller.rs#L176-L186

This method does the opposite of what it is intended to do. The `!` operation should be removed.