### PR TITLE
Add TSM-MR (measurement register) sysfs support

### DIFF
--- a/kernel/src/device/misc/mod.rs
+++ b/kernel/src/device/misc/mod.rs
@@ -19,6 +19,6 @@ pub(super) fn init_in_first_kthread() {
 
     #[cfg(target_arch = "x86_64")]
     ostd::if_tdx_enabled!({
-        super::registry::char::register(tdxguest::TdxGuest::new()).unwrap();
+        tdxguest::init().unwrap();
     });
 }

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -1,5 +1,43 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! Intel TDX guest device and measurement register API.
+//!
+//! This module provides two things:
+//!
+//! 1. **`/dev/tdx_guest` character device** — exposes the `TDX_CMD_GET_REPORT0`
+//!    ioctl, which lets userspace request a `TDREPORT_STRUCT` from the TDX module
+//!    (see [`TdxGuest`]).
+//!
+//! 2. **Measurement register API** — a set of public functions used by other
+//!    kernel subsystems (e.g. the TSM-MR sysfs layer) to interact with TDX
+//!    measurement registers.
+//!
+//! # Cached-report model
+//!
+//! A **TDX report** (`TDREPORT_STRUCT`) is a hardware-signed snapshot of the
+//! TD's current measurement state, produced by the `TDG.MR.REPORT` TDCALL.
+//! Throughout this module the word **"refresh"** always means issuing that
+//! TDCALL to regenerate the snapshot; it never refers to individual register
+//! reads.
+//!
+//! Because `TDG.MR.REPORT` is relatively expensive, the module keeps a single
+//! **global cached report** in `TDX_REPORT` and satisfies measurement-register
+//! reads from that cache.  The cache becomes **stale** after any
+//! [`extend_tdx_mr`] call, because extending an RTMR changes hardware state
+//! that is not reflected in the snapshot until the next refresh.
+//!
+//! # Measurement register API quick reference
+//!
+//! | Function | TDCALL? | Use when… |
+//! |---|---|---|
+//! | [`get_tdx_mr`] | No | Reading a register whose value is not expected to have changed since the last refresh (cheap). |
+//! | [`get_tdx_mr_refresh`] | Yes | Reading a register whose current hardware value is needed — e.g. immediately after [`extend_tdx_mr`]. The refresh and the register read are performed atomically under the write lock. |
+//! | [`refresh_tdx_report`] | Yes | Regenerating the report with a custom `report_data` blob (used by the `TDX_CMD_GET_REPORT0` ioctl and the quote path) without reading a specific register. |
+//! | [`extend_tdx_mr`] | Yes | Extending an RTMR. After extending, the cached report is stale; use [`get_tdx_mr_refresh`] (or [`refresh_tdx_report`] followed by [`get_tdx_mr`]) to observe the updated value. |
+//!
+//! For the TDX architecture specification see Intel's
+//! [TDX Module Specification](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-trust-domain-extensions.html).
+
 use alloc::sync::Arc;
 use core::{
     mem::{offset_of, size_of},
@@ -11,16 +49,17 @@ use device_id::{DeviceId, MinorId};
 use ostd::{
     const_assert,
     mm::{FrameAllocOptions, HasPaddr, HasSize, PAGE_SIZE, USegment, VmIo, dma::DmaCoherent},
-    sync::WaitQueue,
+    sync::{RwMutexWriteGuard, WaitQueue},
 };
+use spin::Once;
 use tdx_guest::{
     SHARED_MASK,
-    tdcall::{TdCallError, get_report},
-    tdvmcall::{TdVmcallError, get_quote},
+    tdcall::{self, TdCallError},
+    tdvmcall::{self, TdVmcallError},
 };
 
 use crate::{
-    device::{Device, DeviceType},
+    device::{Device, DeviceType, registry::char::register},
     events::IoEvents,
     fs::{
         file::{FileIo, StatusFlags},
@@ -160,9 +199,15 @@ impl FileIo for TdxGuestFile {
                         inblob_ptr.read()?
                     };
 
-                    let outblob = tdx_get_report(inblob.as_bytes())?;
+                    let report = TDX_REPORT
+                        .get()
+                        .ok_or_else(|| {
+                            Error::with_message(Errno::ENODEV, "TDX report not initialized")
+                        })?
+                        .write();
+                    refresh_tdx_report_locked(&report, Some(inblob.as_bytes()))?;
                     let outblob_ptr = field_ptr!(&data_ptr, TdxReportRequest, tdx_report);
-                    outblob_ptr.copy_from(&outblob)?;
+                    outblob_ptr.copy_from(&SafePtr::new(&*report, 0))?;
 
                     Ok(0)
                 })
@@ -172,28 +217,58 @@ impl FileIo for TdxGuestFile {
     }
 }
 
-pub fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
+static TDX_REPORT: Once<RwMutex<USegment>> = Once::new();
+
+/// Runtime Measurement Register (RTMR) index.
+///
+/// RTMRs are the only measurement registers that can be extended at runtime
+/// via [`extend_tdx_mr`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Rtmr {
+    Rtmr0,
+    Rtmr1,
+    Rtmr2,
+    Rtmr3,
+}
+
+/// TDX measurement register.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MeasurementReg {
+    MrConfigId,
+    MrOwner,
+    MrOwnerConfig,
+    MrTd,
+    Rtmr(Rtmr),
+}
+
+/// Gets the TDX quote given the specified data in `inblob`.
+pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
     const GET_QUOTE_IN_FLIGHT: u64 = 0xFFFF_FFFF_FFFF_FFFF;
     const GET_QUOTE_BUF_SIZE: usize = 8 * 1024;
 
-    let report = tdx_get_report(inblob)?;
-
-    let buf = alloc_dma_buf(GET_QUOTE_BUF_SIZE)?;
-    let report_ptr: SafePtr<TdxQuoteHdr, _, _> = SafePtr::new(&buf, 0);
+    let buf = DmaCoherent::alloc(GET_QUOTE_BUF_SIZE.div_ceil(PAGE_SIZE), false)?;
+    let header_ptr: SafePtr<TdxQuoteHdr, _, _> = SafePtr::new(&buf, 0);
     let payload_ptr: SafePtr<TdReport, _, _> = SafePtr::new(&buf, size_of::<TdxQuoteHdr>());
 
-    field_ptr!(&report_ptr, TdxQuoteHdr, version).write(&1u64)?;
-    field_ptr!(&report_ptr, TdxQuoteHdr, status).write(&0u64)?;
-    field_ptr!(&report_ptr, TdxQuoteHdr, in_len).write(&(size_of::<TdReport>() as u32))?;
-    field_ptr!(&report_ptr, TdxQuoteHdr, out_len).write(&0u32)?;
-    payload_ptr.copy_from(&report)?;
+    field_ptr!(&header_ptr, TdxQuoteHdr, version).write(&1u64)?;
+    field_ptr!(&header_ptr, TdxQuoteHdr, status).write(&0u64)?;
+    field_ptr!(&header_ptr, TdxQuoteHdr, in_len).write(&(size_of::<TdReport>() as u32))?;
+    field_ptr!(&header_ptr, TdxQuoteHdr, out_len).write(&0u32)?;
+
+    let report = TDX_REPORT
+        .get()
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
+        .write();
+    refresh_tdx_report_locked(&report, Some(inblob))?;
+    payload_ptr.copy_from(&SafePtr::new(&*report, 0))?;
+    drop(report);
 
     // FIXME: The `get_quote` API from the `tdx_guest` crate should have been marked `unsafe`
     // because it has no way to determine if the input physical address is safe or not.
-    get_quote((buf.paddr() as u64) | SHARED_MASK, buf.size() as u64)?;
+    tdvmcall::get_quote((buf.paddr() as u64) | SHARED_MASK, buf.size() as u64)?;
 
     // Poll for the quote to be ready.
-    let status_ptr = field_ptr!(&report_ptr, TdxQuoteHdr, status);
+    let status_ptr = field_ptr!(&header_ptr, TdxQuoteHdr, status);
     let sleep_queue = WaitQueue::new();
     let sleep_duration = Duration::from_millis(100);
     loop {
@@ -208,10 +283,141 @@ pub fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
     // to private memory in TDX, `TDG.MEM.PAGE.ACCEPT` will zero out all content.
     // TDX Module Specification - `TDG.MEM.PAGE.ACCEPT` Leaf:
     // "Accept a pending private page and initialize it to all-0 using the TD ephemeral private key."
-    let out_len = field_ptr!(&report_ptr, TdxQuoteHdr, out_len).read()?;
+    let out_len = field_ptr!(&header_ptr, TdxQuoteHdr, out_len).read()?;
     let mut outblob = vec![0u8; out_len as usize].into_boxed_slice();
     payload_ptr.cast().read_slice(outblob.as_mut())?;
     Ok(outblob)
+}
+
+/// Refreshes the global TDX report cache, issuing a `TDG.MR.REPORT` TDCALL.
+///
+/// If `inblob` is `Some`, it is written into the report's `REPORTDATA` field
+/// before the TDCALL; otherwise the field already present in the cached report
+/// is reused.
+///
+/// Most callers that only need to read a measurement register after an extend
+/// should use [`get_tdx_mr_refresh`] instead, which combines the refresh and
+/// the register read atomically.
+pub(crate) fn refresh_tdx_report(inblob: Option<&[u8]>) -> Result<()> {
+    let report = TDX_REPORT
+        .get()
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
+        .write();
+    refresh_tdx_report_locked(&report, inblob)
+}
+
+pub(crate) const SHA384_DIGEST_SIZE: usize = 48;
+
+/// Gets the measurement register value from the cached TDX report.
+///
+/// This is a cheap read — no TDCALL is issued. The value reflects the state of
+/// the report at the time of the last [`refresh_tdx_report`] or
+/// [`get_tdx_mr_refresh`] call. If the register may have been updated by a
+/// recent [`extend_tdx_mr`], use [`get_tdx_mr_refresh`] instead to obtain the
+/// current hardware value.
+pub(crate) fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
+    let report = TDX_REPORT
+        .get()
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
+        .read();
+
+    let mut blob = [0u8; SHA384_DIGEST_SIZE];
+    report
+        .read_bytes(TdReport::mr_offset(reg), blob.as_mut())
+        .unwrap();
+    Ok(blob)
+}
+
+/// Refreshes the TDX report and returns the requested measurement register value.
+///
+/// Issues a `TDG.MR.REPORT` TDCALL and then reads `reg` from the newly
+/// generated report. The refresh and the read are performed atomically under
+/// the write lock, so the returned value is guaranteed to reflect the hardware
+/// state at the time of the call.
+///
+/// Use this function after [`extend_tdx_mr`] to observe the updated RTMR
+/// value. If no extend has occurred and the cached report is still current,
+/// the cheaper [`get_tdx_mr`] can be used instead.
+pub(crate) fn get_tdx_mr_refresh(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
+    let report = TDX_REPORT
+        .get()
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
+        .write();
+
+    refresh_tdx_report_locked(&report, None)?;
+
+    let mut blob = [0u8; SHA384_DIGEST_SIZE];
+    report
+        .read_bytes(TdReport::mr_offset(reg), blob.as_mut())
+        .unwrap();
+    Ok(blob)
+}
+
+/// Extends an RTMR with the given SHA-384 digest, issuing a
+/// `TDG.MR.RTMR.EXTEND` TDCALL.
+///
+/// After this call the cached TDX report is stale with respect to the extended
+/// register. To read the updated value, use [`get_tdx_mr_refresh`], which
+/// atomically regenerates the report and reads the register. Alternatively,
+/// call [`refresh_tdx_report`] and then [`get_tdx_mr`] if you need to refresh
+/// once and read multiple registers.
+pub(crate) fn extend_tdx_mr(reg: Rtmr, data: &[u8; SHA384_DIGEST_SIZE]) -> Result<()> {
+    let index = match reg {
+        Rtmr::Rtmr0 => 0,
+        Rtmr::Rtmr1 => 1,
+        Rtmr::Rtmr2 => 2,
+        Rtmr::Rtmr3 => 3,
+    };
+
+    // `TDG.MR.RTMR.EXTEND` requires a 64B-aligned physical address; a
+    // page-aligned frame meets that requirement. RTMR extension is infrequent,
+    // so the per-call allocation overhead is negligible.
+    let buf: USegment = FrameAllocOptions::new().alloc_segment(1)?.into();
+    buf.write_bytes(0, data).unwrap();
+
+    tdcall::extend_rtmr(buf.paddr() as u64, index)?;
+    Ok(())
+}
+
+pub(super) fn init() -> Result<()> {
+    TDX_REPORT.call_once(|| {
+        let report = FrameAllocOptions::new()
+            .alloc_segment(size_of::<TdReport>().div_ceil(PAGE_SIZE))
+            .unwrap()
+            .into();
+        RwMutex::new(report)
+    });
+    refresh_tdx_report(None)?;
+    register(TdxGuest::new())?;
+    Ok(())
+}
+
+fn refresh_tdx_report_locked(
+    report: &RwMutexWriteGuard<'_, USegment>,
+    inblob: Option<&[u8]>,
+) -> Result<()> {
+    if let Some(inblob) = inblob {
+        if inblob.len() != size_of::<ReportData>() {
+            return_errno_with_message!(Errno::EINVAL, "Invalid inblob length");
+        }
+
+        // Use `inblob` as the data associated with the report.
+        report
+            .write_bytes(TdReport::report_data_offset(), inblob)
+            .unwrap();
+    }
+
+    // From TDX Module Specification, the report structure returned by TDX Module
+    // places the report data at offset 128, so using the same offset keeps the
+    // memory layout consistent with the TDX Modules's output format. And we can
+    // directly call `get_report` on the existing report structure without needing
+    // to rewrite the report data.
+    let report_data_ptr = report.paddr() + TdReport::report_data_offset();
+
+    // FIXME: The `get_report` API from the `tdx_guest` crate should have been marked `unsafe`
+    // because it has no way to determine if the input physical address is safe or not.
+    tdcall::get_report(report.paddr() as u64, report_data_ptr as u64)?;
+    Ok(())
 }
 
 #[repr(C)]
@@ -266,10 +472,10 @@ struct TdInfo {
     mrconfigid: [u8; 48],
     mrowner: [u8; 48],
     mrownerconfig: [u8; 48],
+    rtmr0: [u8; 48],
     rtmr1: [u8; 48],
     rtmr2: [u8; 48],
     rtmr3: [u8; 48],
-    rtmr4: [u8; 48],
     servtd_hash: [u8; 48],
     extension: [u8; 64],
 }
@@ -277,6 +483,20 @@ struct TdInfo {
 impl TdReport {
     const fn report_data_offset() -> usize {
         offset_of!(TdReport, report_mac) + offset_of!(ReportMac, report_data)
+    }
+
+    const fn mr_offset(reg: MeasurementReg) -> usize {
+        offset_of!(TdReport, td_info)
+            + match reg {
+                MeasurementReg::MrConfigId => offset_of!(TdInfo, mrconfigid),
+                MeasurementReg::MrOwner => offset_of!(TdInfo, mrowner),
+                MeasurementReg::MrOwnerConfig => offset_of!(TdInfo, mrownerconfig),
+                MeasurementReg::MrTd => offset_of!(TdInfo, mrtd),
+                MeasurementReg::Rtmr(Rtmr::Rtmr0) => offset_of!(TdInfo, rtmr0),
+                MeasurementReg::Rtmr(Rtmr::Rtmr1) => offset_of!(TdInfo, rtmr1),
+                MeasurementReg::Rtmr(Rtmr::Rtmr2) => offset_of!(TdInfo, rtmr2),
+                MeasurementReg::Rtmr(Rtmr::Rtmr3) => offset_of!(TdInfo, rtmr3),
+            }
     }
 }
 
@@ -288,41 +508,4 @@ mod ioctl_defs {
 
     pub(super) type GetTdxReport =
         ioc!(TDX_CMD_GET_REPORT0, b'T', 0x01, InOutData<TdxReportRequest>);
-}
-
-/// Gets the TDX report given the specified data in `inblob`.
-fn tdx_get_report(inblob: &[u8]) -> Result<SafePtr<TdReport, USegment>> {
-    if inblob.len() != size_of::<ReportData>() {
-        return_errno_with_message!(Errno::EINVAL, "Invalid inblob length");
-    }
-
-    let report: USegment = {
-        const REPORT_SIZE_IN_PAGES: usize = size_of::<TdReport>().div_ceil(PAGE_SIZE);
-        FrameAllocOptions::new()
-            .alloc_segment(REPORT_SIZE_IN_PAGES)?
-            .into()
-    };
-
-    // Use `inblob` as the data associated with the report.
-    let report_data_paddr = {
-        // From TDX Module Specification, the report structure returned by TDX Module
-        // places the report data at offset 128, so using the same offset keeps the
-        // memory layout consistent with the TDX Modules's output format. And we can
-        // directly call `get_report` on the existing report structure without needing
-        // to rewrite the report data.
-        report
-            .write_bytes(TdReport::report_data_offset(), inblob)
-            .unwrap();
-        report.paddr() + TdReport::report_data_offset()
-    };
-
-    // FIXME: The `get_report` API from the `tdx_guest` crate should have been marked `unsafe`
-    // because it has no way to determine if the input physical address is safe or not.
-    get_report(report.paddr() as u64, report_data_paddr as u64)?;
-    Ok(SafePtr::new(report, 0))
-}
-
-fn alloc_dma_buf(buf_len: usize) -> Result<DmaCoherent> {
-    let dma_buf = DmaCoherent::alloc(buf_len.div_ceil(PAGE_SIZE), false)?;
-    Ok(dma_buf)
 }

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -1,9 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-mod tsm;
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
+        mod tsm;
+        mod tsm_mr;
+    }
+}
 
 pub(super) fn init() {
-    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
-    tsm::init();
+    #[cfg(target_arch = "x86_64")]
+    ostd::if_tdx_enabled!({
+        tsm::init();
+        tsm_mr::init();
+    });
 }

--- a/kernel/src/security/tsm_mr.rs
+++ b/kernel/src/security/tsm_mr.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! TDX measurement registers (TSM-MR) sysfs interface.
+//!
+//! This module exposes Intel TDX measurement registers to userspace under
+//! `/sys/devices/virtual/misc/tdx_guest/measurements/`. Each file corresponds
+//! to one register:
+//!
+//! | Path | Register | Writable |
+//! |------|----------|----------|
+//! | `mrconfigid` | `MRCONFIGID` | No |
+//! | `mrowner` | `MROWNER` | No |
+//! | `mrownerconfig` | `MROWNERCONFIG` | No |
+//! | `mrtd:sha384` | `MRTD` | No |
+//! | `rtmr0:sha384` … `rtmr3:sha384` | `RTMR[0..3]` | Yes |
+//!
+//! For more information about the TSM-MR ABI, see the Linux kernel
+//! [documentation](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-virtual-misc-tdx_guest).
+
+use alloc::sync::Arc;
+
+use aster_systree::{
+    BranchNodeFields, Error, NormalNodeFields, Result, SysAttrSetBuilder, SysObj, SysPerms, SysStr,
+    inherit_sys_branch_node, inherit_sys_leaf_node,
+};
+use inherit_methods_macro::inherit_methods;
+use ostd::{
+    mm::{FallibleVmRead, FallibleVmWrite, VmReader, VmWriter},
+    sync::RwMutex,
+};
+
+use crate::device::misc::tdxguest::{self, MeasurementReg, Rtmr, SHA384_DIGEST_SIZE};
+
+pub(super) fn init() {
+    let node = {
+        let tdx_guest_node = TdxGuestSysNodeRoot::new();
+        let measurement = Measurement::new(SysStr::from("measurements"));
+        tdx_guest_node.add_child(measurement).unwrap();
+
+        // FIXME: Temporary folder node until we have a proper sysfs devices
+        // implementation.
+        let misc_node = FolderNode::new("misc");
+        misc_node.add_child(tdx_guest_node).unwrap();
+        let virtual_node = FolderNode::new("virtual");
+        virtual_node.add_child(misc_node).unwrap();
+        let devices_node = FolderNode::new("devices");
+        devices_node.add_child(virtual_node).unwrap();
+
+        devices_node
+    };
+
+    crate::fs::sysfs::systree_singleton()
+        .root()
+        .add_child(node.clone())
+        .unwrap();
+}
+
+/// A systree node representing the `/sys/devices/virtual/misc/tdx_guest`
+/// directory.
+#[derive(Debug)]
+struct TdxGuestSysNodeRoot {
+    fields: BranchNodeFields<dyn SysObj, Self>,
+}
+
+#[inherit_methods(from = "self.fields")]
+impl TdxGuestSysNodeRoot {
+    fn new() -> Arc<Self> {
+        let name = SysStr::from("tdx_guest");
+        let attrs = SysAttrSetBuilder::new().build().unwrap();
+        Arc::new_cyclic(|weak_self| {
+            let fields = BranchNodeFields::new(name, attrs, weak_self.clone());
+
+            TdxGuestSysNodeRoot { fields }
+        })
+    }
+
+    fn add_child(&self, new_child: Arc<dyn SysObj>) -> Result<()> {
+        self.fields.add_child(new_child)
+    }
+}
+
+inherit_sys_branch_node!(TdxGuestSysNodeRoot, fields, {
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RW_PERMS
+    }
+});
+
+#[derive(Debug)]
+struct Measurement {
+    fields: NormalNodeFields<Self>,
+    /// Whether the cached TDX report is in sync with current hardware state.
+    ///
+    /// Set to `false` by `write_attr` after a successful
+    /// [`tdxguest::extend_tdx_mr`] call, because the extend changes RTMR
+    /// hardware state that is not yet reflected in the cached
+    /// `TDREPORT_STRUCT`.  Set back to `true` by `read_attr_at` once it has
+    /// re-generated the report via [`tdxguest::get_tdx_mr_refresh`].
+    ///
+    /// Invariant: when `in_sync` is `true`, the cached report correctly
+    /// reflects the current value of every RTMR.  Static registers
+    /// (`MRCONFIGID`, `MROWNER`, `MROWNERCONFIG`, `MRTD`) are fixed at TD
+    /// creation time and are always in sync regardless of this flag.
+    in_sync: RwMutex<bool>,
+}
+
+#[derive(Debug)]
+struct MeasurementAttr {
+    name: &'static str,
+    perms: SysPerms,
+    reg: MeasurementReg,
+    /// Whether reading this attribute requires refreshing the cached TDX report
+    /// first.
+    ///
+    /// Static registers (`MRCONFIGID`, `MROWNER`, `MROWNERCONFIG`, `MRTD`) are
+    /// written by the TDX module at TD creation time and can never change at
+    /// runtime, so `false` is correct for them — the cached `TDREPORT_STRUCT`
+    /// is always authoritative.
+    ///
+    /// RTMRs can be extended at any time via [`tdxguest::extend_tdx_mr`], which
+    /// changes hardware state without updating the cache.  For these registers
+    /// `refresh_on_read` is `true`, and `read_attr_at` will conditionally
+    /// re-generate the report (via [`tdxguest::get_tdx_mr_refresh`]) whenever
+    /// [`Measurement::in_sync`] is `false`.
+    refresh_on_read: bool,
+}
+
+impl MeasurementAttr {
+    fn refresh_on_read(&self) -> bool {
+        self.refresh_on_read
+    }
+}
+
+const MEASUREMENT_ATTRS: &[MeasurementAttr] = &[
+    MeasurementAttr {
+        name: "mrconfigid",
+        perms: SysPerms::DEFAULT_RO_ATTR_PERMS,
+        reg: MeasurementReg::MrConfigId,
+        refresh_on_read: false,
+    },
+    MeasurementAttr {
+        name: "mrowner",
+        perms: SysPerms::DEFAULT_RO_ATTR_PERMS,
+        reg: MeasurementReg::MrOwner,
+        refresh_on_read: false,
+    },
+    MeasurementAttr {
+        name: "mrownerconfig",
+        perms: SysPerms::DEFAULT_RO_ATTR_PERMS,
+        reg: MeasurementReg::MrOwnerConfig,
+        refresh_on_read: false,
+    },
+    MeasurementAttr {
+        name: "mrtd:sha384",
+        perms: SysPerms::DEFAULT_RO_ATTR_PERMS,
+        reg: MeasurementReg::MrTd,
+        refresh_on_read: false,
+    },
+    MeasurementAttr {
+        name: "rtmr0:sha384",
+        perms: SysPerms::DEFAULT_RW_ATTR_PERMS,
+        reg: MeasurementReg::Rtmr(Rtmr::Rtmr0),
+        refresh_on_read: true,
+    },
+    MeasurementAttr {
+        name: "rtmr1:sha384",
+        perms: SysPerms::DEFAULT_RW_ATTR_PERMS,
+        reg: MeasurementReg::Rtmr(Rtmr::Rtmr1),
+        refresh_on_read: true,
+    },
+    MeasurementAttr {
+        name: "rtmr2:sha384",
+        perms: SysPerms::DEFAULT_RW_ATTR_PERMS,
+        reg: MeasurementReg::Rtmr(Rtmr::Rtmr2),
+        refresh_on_read: true,
+    },
+    MeasurementAttr {
+        name: "rtmr3:sha384",
+        perms: SysPerms::DEFAULT_RW_ATTR_PERMS,
+        reg: MeasurementReg::Rtmr(Rtmr::Rtmr3),
+        refresh_on_read: true,
+    },
+];
+
+impl Measurement {
+    fn new(name: SysStr) -> Arc<Self> {
+        let mut builder = SysAttrSetBuilder::new();
+        for attr in MEASUREMENT_ATTRS {
+            builder.add(SysStr::from(attr.name), attr.perms);
+        }
+        let attrs = builder.build().unwrap();
+
+        Arc::new_cyclic(|weak_self| {
+            let fields = NormalNodeFields::new(name, attrs, weak_self.clone());
+
+            Measurement {
+                fields,
+                in_sync: RwMutex::new(true),
+            }
+        })
+    }
+}
+
+inherit_sys_leaf_node!(Measurement, fields, {
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RW_PERMS
+    }
+
+    fn read_attr_at(&self, name: &str, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let attr = MEASUREMENT_ATTRS
+            .iter()
+            .find(|attr| attr.name == name)
+            .ok_or(Error::NotFound)?;
+
+        let mut in_sync = self.in_sync.upread();
+
+        let mr = (if attr.refresh_on_read() && !*in_sync {
+            let mut in_sync_write = in_sync.upgrade();
+            let mr = tdxguest::get_tdx_mr_refresh(attr.reg);
+            *in_sync_write = true;
+            in_sync = in_sync_write.downgrade();
+            mr
+        } else {
+            tdxguest::get_tdx_mr(attr.reg)
+        })
+        .map_err(|_| Error::AttributeError)?;
+
+        if offset >= mr.len() {
+            return Ok(0);
+        }
+        let mut reader = VmReader::from(&mr[offset..]);
+        writer
+            .write_fallible(&mut reader)
+            .map_err(|_| Error::AttributeError)
+    }
+
+    fn write_attr(&self, name: &str, reader: &mut VmReader) -> Result<usize> {
+        let attr = MEASUREMENT_ATTRS
+            .iter()
+            .find(|attr| attr.name == name)
+            .ok_or(Error::NotFound)?;
+
+        let MeasurementReg::Rtmr(rtmr) = attr.reg else {
+            return Err(Error::PermissionDenied);
+        };
+
+        let data = {
+            let mut buf = [0u8; SHA384_DIGEST_SIZE];
+            let mut writer = VmWriter::from(&mut buf[..]);
+            let bytes_read = reader
+                .read_fallible(&mut writer)
+                .map_err(|_| Error::AttributeError)?;
+            if bytes_read != buf.len() {
+                return Err(Error::InvalidOperation);
+            }
+
+            buf
+        };
+
+        let mut in_sync = self.in_sync.write();
+
+        tdxguest::extend_tdx_mr(rtmr, &data).map_err(|_| Error::AttributeError)?;
+
+        if attr.refresh_on_read() {
+            *in_sync = false;
+        }
+
+        Ok(data.len())
+    }
+});
+
+#[derive(Debug)]
+struct FolderNode {
+    fields: BranchNodeFields<dyn SysObj, Self>,
+}
+
+#[inherit_methods(from = "self.fields")]
+impl FolderNode {
+    fn new(name: &'static str) -> Arc<Self> {
+        let name = SysStr::from(name);
+        Arc::new_cyclic(|weak_self| {
+            let fields = BranchNodeFields::new(
+                name,
+                SysAttrSetBuilder::new().build().unwrap(),
+                weak_self.clone(),
+            );
+
+            FolderNode { fields }
+        })
+    }
+
+    fn add_child(&self, new_child: Arc<dyn SysObj>) -> Result<()> {
+        self.fields.add_child(new_child)
+    }
+}
+
+inherit_sys_branch_node!(FolderNode, fields, {
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RW_PERMS
+    }
+});

--- a/test/initramfs/src/regression/intel_tdx/Makefile
+++ b/test/initramfs/src/regression/intel_tdx/Makefile
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
-SUBDIRS := gen_quote
+SUBDIRS := \
+	gen_quote \
+	tsm_mr
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/intel_tdx/run_test.sh
+++ b/test/initramfs/src/regression/intel_tdx/run_test.sh
@@ -6,4 +6,5 @@ set -e
 
 if [ -e /dev/tdx_guest ]; then
     ./gen_quote/gen_quote
+    ./tsm_mr/tsm_mr.sh
 fi

--- a/test/initramfs/src/regression/intel_tdx/tsm_mr/Makefile
+++ b/test/initramfs/src/regression/intel_tdx/tsm_mr/Makefile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+
+CUR_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CUR_DIR_NAME := $(shell basename $(realpath $(CUR_DIR)))
+BUILD_DIR := $(CUR_DIR)/../../../../build
+OUTPUT_DIR ?= $(BUILD_DIR)/initramfs/test
+BIN_OUTPUT_DIR := $(OUTPUT_DIR)/intel_tdx/tsm_mr
+
+.PHONY: all
+
+all: $(BIN_OUTPUT_DIR) $(BIN_OUTPUT_DIR)/tsm_mr.sh
+
+$(BIN_OUTPUT_DIR):
+	@mkdir -p $(BIN_OUTPUT_DIR)
+
+$(BIN_OUTPUT_DIR)/tsm_mr.sh: $(CUR_DIR)/tsm_mr.sh
+	@cp $< $@
+	@chmod +x $@
+	@echo "COPY <= $@"

--- a/test/initramfs/src/regression/intel_tdx/tsm_mr/tsm_mr.sh
+++ b/test/initramfs/src/regression/intel_tdx/tsm_mr/tsm_mr.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+SYSFS_DIR="/sys/devices/virtual/misc/tdx_guest/measurements"
+
+# Check that a file is readable and returns exactly SHA384_DIGEST_SIZE (48) bytes.
+check_readable() {
+    name="$1"
+    path="$SYSFS_DIR/$name"
+    size=$(wc -c < "$path")
+    if [ "$size" -ne 48 ]; then
+        echo "FAIL: $name returned $size bytes, expected 48" >&2
+        exit 1
+    fi
+    echo "PASS: $name is readable (48 bytes)"
+}
+
+# Check that a file is readable and contains at least one non-zero byte.
+check_readable_nonzero() {
+    name="$1"
+    path="$SYSFS_DIR/$name"
+    # od -A n suppresses the address column, leaving only hex data bytes.
+    # Stripping spaces/newlines and then all '0' digits leaves a non-empty
+    # string iff at least one byte is non-zero.
+    nz=$(od -A n -t x1 < "$path" | tr -d ' \n')
+    if [ -z "$nz" ]; then
+        echo "FAIL: $name is empty" >&2
+        exit 1
+    fi
+    cleaned=$(echo "$nz" | tr -d '0')
+    if [ -z "$cleaned" ]; then
+        echo "FAIL: $name read back as all-zeros" >&2
+        exit 1
+    fi
+    echo "PASS: $name is readable and non-zero"
+}
+
+# Verify that writing to a read-only register is rejected (EACCES / EPERM).
+check_write_rejected() {
+    name="$1"
+    path="$SYSFS_DIR/$name"
+    if dd if=/dev/urandom bs=48 count=1 > "$path" 2>/dev/null; then
+        echo "FAIL: write to read-only register $name was not rejected" >&2
+        exit 1
+    fi
+    echo "PASS: write to read-only register $name was correctly rejected"
+}
+
+# Verify that writing a wrong-sized payload to an RTMR is rejected.
+check_wrong_size_rejected() {
+    name="$1"
+    size="$2"
+    path="$SYSFS_DIR/$name"
+    if dd if=/dev/urandom bs="$size" count=1 > "$path" 2>/dev/null; then
+        echo "FAIL: write of $size bytes to $name was not rejected" >&2
+        exit 1
+    fi
+    echo "PASS: write of $size bytes to $name was correctly rejected"
+}
+
+# --- 1. Read-only registers: smoke-test readability --------------------------
+
+echo "=== Read-only register smoke tests ==="
+# mrconfigid, mrowner, mrownerconfig may be all-zeros when not configured; only verify readability.
+for name in mrconfigid mrowner mrownerconfig; do
+    check_readable "$name"
+done
+# mrtd is set by the TDX module at TD creation time and must be non-zero.
+check_readable_nonzero "mrtd:sha384"
+
+# --- 2. RTMR extend: verify value changes after write ------------------------
+
+echo "=== RTMR extend before/after tests ==="
+i=0
+while [ $i -le 3 ]; do
+    name="rtmr${i}:sha384"
+    path="$SYSFS_DIR/$name"
+    echo "Testing RTMR${i}..."
+
+    before=$(hd "$path")
+    dd if=/dev/urandom bs=48 count=1 > "$path" 2>/dev/null
+    after=$(hd "$path")
+
+    if [ "$before" = "$after" ]; then
+        echo "FAIL: RTMR${i} value did not change after extend" >&2
+        exit 1
+    fi
+    echo "PASS: RTMR${i} value changed after extend"
+    i=$((i + 1))
+done
+
+# --- 3. Error paths ----------------------------------------------------------
+
+echo "=== Error path tests ==="
+
+# Writing to a read-only register must be rejected.
+for name in mrconfigid mrowner mrownerconfig "mrtd:sha384"; do
+    check_write_rejected "$name"
+done
+
+# Writing wrong-sized data to an RTMR must be rejected.
+for size in 32 64; do
+    i=0
+    while [ $i -le 3 ]; do
+        check_wrong_size_rejected "rtmr${i}:sha384" "$size"
+        i=$((i + 1))
+    done
+done
+
+echo "=== All TSM-MR tests completed successfully ==="


### PR DESCRIPTION
This PR introduces TSM-MR (Trusted Security Module - Measurement Register). It provides sysfs interface to read measurement registers from the TD report and to extend measurement registers. The interface is documented at 
[here](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-virtual-misc-tdx_guest).

The implementation largely follows Linux behavior. In particular, TSM and TSM-MR are treated as mostly independent subsystems. E.g.,
1. The TD report is cached so that RTMR values can be retrieved without generating a new report every time.
2. TSM-MR generates a report during initialization and before user-provided `inblob` is written, i.e. user can read RTMR without requesting a quote and the report is generated with an all-zero `inblob`.
3. Although the report is updated by `extend_rtmr`, the cached quote continues to reflect the previous report. I.e. the quote is regenerated only when new `inblob` is provided.