### PR TITLE
Split some contents of root Makefile into kernel/Makefile and distro/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,19 +233,8 @@ test_osdk:
 		OSDK_LOCAL_DEV=1 cargo build && \
 		OSDK_LOCAL_DEV=1 cargo test
 
-.PHONY: check_vdso
-check_vdso:
-	@# Checking `VDSO_LIBRARY_DIR` environment variable
-	@if [ -z "$(VDSO_LIBRARY_DIR)" ]; then \
-		echo "Error: the VDSO_LIBRARY_DIR environment variable must be given."; \
-		echo "    This variable points to a directory that provides Linux's vDSO files,"; \
-		echo "    which is required to build Asterinas. Search for VDSO_LIBRARY_DIR"; \
-		echo "    in Asterinas's Dockerfile for more information."; \
-		exit 1; \
-	fi
-
 .PHONY: initramfs
-initramfs: check_vdso
+initramfs:
 	@$(MAKE) --no-print-directory -C test/initramfs
 
 # =========================== Kernel targets ===============================

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ book:
 
 .PHONY: format
 format:
-	@./tools/format_all.sh
+	@./tools/format_rust.sh
 	@$(MAKE) --no-print-directory -C distro format
 	@$(MAKE) --no-print-directory -C test/initramfs format
 	@$(MAKE) --no-print-directory -C test/nixos format
@@ -322,7 +322,7 @@ format:
 .PHONY: check
 check: initramfs $(CARGO_OSDK)
 	@# Check formatting issues of the Rust code
-	@./tools/format_all.sh --check
+	@./tools/format_rust.sh --check
 	@
 	@# Check compilation of the Rust code
 	@$(MAKE) --no-print-directory -C kernel check

--- a/distro/Makefile
+++ b/distro/Makefile
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MPL-2.0
+
+# This Makefile is responsible to build, run, test Asterinas NixOS.
+
+export OVMF := off
+export ENABLE_KVM ?= 1
+
+# NixOS settings
+export NIXOS_DISK_SIZE_IN_MB ?= 8192
+export NIXOS_DISABLE_SYSTEMD ?= false
+# The following option is only effective when NIXOS_DISABLE_SYSTEMD is set to 'true'.
+# Use a login shell to ensure that environment variables are initialized correctly.
+export NIXOS_STAGE_2_INIT ?= /bin/sh -l
+# End of NixOS settings
+
+# ISO installer settings
+export AUTO_INSTALL ?= true
+# End of ISO installer settings
+
+# Cachix binary cache settings
+export CACHIX_AUTH_TOKEN ?=
+export RELEASE_CACHIX_NAME ?= "aster-nixos-release"
+export RELEASE_SUBSTITUTER ?= https://aster-nixos-release.cachix.org
+export RELEASE_TRUSTED_PUBLIC_KEY ?= aster-nixos-release.cachix.org-1:xB6U/f5ck5vGDJZ04kPp3zGpZ4Nro9X4+TSSMAETVFE=
+export DEV_CACHIX_NAME ?= "aster-nixos-dev"
+export DEV_SUBSTITUTER ?= https://aster-nixos-dev.cachix.org
+export DEV_TRUSTED_PUBLIC_KEY ?= aster-nixos-dev.cachix.org-1:xrCbE2flfliFTQCY/2HeJoT2tCO+5kMTZeLIUH9lnIA=
+# End of Cachix binary cache settings
+
+SHELL := /bin/bash
+
+SRC_ROOT := $(abspath ..)
+NIX_SRC_DIRS := aster_nixos_installer cachix etc_nixos iso_image
+
+.PHONY: all
+all: nixos
+
+.PHONY: nixos
+nixos:
+	@if [ -n "$(NIXOS_TEST_SUITE)" ]; then \
+        $(MAKE) --no-print-directory -C $(SRC_ROOT)/test/nixos nixos; \
+    else \
+        $(SRC_ROOT)/tools/nixos/build_nixos.sh; \
+    fi
+
+.PHONY: run_nixos
+run_nixos:
+	@if [ -n "$(NIXOS_TEST_SUITE)" ]; then \
+        $(MAKE) --no-print-directory -C $(SRC_ROOT)/test/nixos run_nixos; \
+    else \
+        $(SRC_ROOT)/tools/nixos/run.sh nixos; \
+    fi
+
+.PHONY: iso
+iso: 
+	@if [ -n "$(NIXOS_TEST_SUITE)" ]; then \
+        $(MAKE) --no-print-directory -C $(SRC_ROOT)/test/nixos iso; \
+    else \
+        $(SRC_ROOT)/tools/nixos/build_iso.sh; \
+    fi
+
+.PHONY: run_iso
+run_iso:
+	@$(SRC_ROOT)/tools/nixos/run.sh iso
+
+.PHONY: cachix
+cachix:
+	@nix-build ./cachix \
+		--option extra-substituters "${RELEASE_SUBSTITUTER} ${DEV_SUBSTITUTER}" \
+		--option extra-trusted-public-keys "${RELEASE_TRUSTED_PUBLIC_KEY} ${DEV_TRUSTED_PUBLIC_KEY}" \
+		--out-link cachix.list
+
+.PHONY: push_cachix
+push_cachix: USE_RELEASE_CACHE ?= 0
+push_cachix: cachix
+ifeq ($(USE_RELEASE_CACHE), 1)
+	@cachix push $(RELEASE_CACHIX_NAME) < cachix.list
+else
+	@cachix push $(DEV_CACHIX_NAME) < cachix.list
+endif
+
+.PHONY: check
+check:
+	@for dir in $(NIX_SRC_DIRS); do \
+		echo "Checking $$dir"; \
+		nixfmt --check $$dir; \
+	done
+
+.PHONY: format
+format: 
+	@for dir in $(NIX_SRC_DIRS); do \
+		nixfmt $$dir; \
+	done
+
+.PHONY: clean
+clean: 
+	@rm -f result
+	@rm -rf $(SRC_ROOT)/target/nixos

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: MPL-2.0
+
+# This Makefile is responsible to build, run, test all kernel Rust crates.
+
+SRC_ROOT := $(abspath ..)
+SHELL := /bin/bash
+
+# All crates under kernel/libs, kernel/comps, osdk/deps, ostd/libs
+CRATE_DIRS := $(SRC_ROOT)/kernel/libs $(SRC_ROOT)/kernel/comps $(SRC_ROOT)/osdk/deps $(SRC_ROOT)/ostd/libs
+# Find all crate directories and remove trailing slashes
+ALL_CRATES := $(patsubst %/,%,$(sort $(foreach dir,$(CRATE_DIRS),\
+	$(dir $(shell find $(dir) -name Cargo.toml -type f 2>/dev/null)))))
+# Special OSDK crates do not directly rely on OSTD, but may depend on crates that do.
+SPECIAL_OSDK_CRATES := \
+	$(SRC_ROOT)/kernel/libs/device-id \
+	$(SRC_ROOT)/ostd/libs/linux-bzimage/setup
+# Exclude crates under kernel/libs/comp-sys/ and special OSDK crates
+ALL_CRATES := $(filter-out \
+	$(SRC_ROOT)/kernel/libs/comp-sys/% \
+	$(SPECIAL_OSDK_CRATES), \
+	$(ALL_CRATES))
+
+# Basically, non-OSDK crates do not depend on OSTD and can be checked
+# or tested without OSDK.
+NON_OSDK_CRATES := $(strip \
+	$(foreach crate,$(ALL_CRATES),\
+		$(if $(shell grep -q 'ostd\.workspace\s*=\s*true' $(crate)/Cargo.toml 2>/dev/null && echo yes),,\
+			$(crate))\
+	)\
+)
+
+# In contrast, OSDK crates depend on OSTD (or being `ostd` itself)
+# and need to be built or tested with OSDK.
+OSDK_CRATES := $(SRC_ROOT)/kernel $(SRC_ROOT)/ostd $(SPECIAL_OSDK_CRATES) $(strip \
+	$(foreach crate,$(ALL_CRATES),\
+		$(if $(shell grep -q 'ostd\.workspace\s*=\s*true' $(crate)/Cargo.toml 2>/dev/null && echo yes),\
+			$(crate),)\
+	)\
+)
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	@cargo osdk build $(CARGO_OSDK_BUILD_ARGS)
+
+.PHONY: run
+run:
+	@cargo osdk run $(CARGO_OSDK_BUILD_ARGS)
+
+.PHONY: check_crates_list
+check_crates_list:
+	@# Extract workspace members as relative paths (e.g., "kernel", "ostd/libs/foo")
+	@sed -n '/^\[workspace\]/,/^\[.*\]/{/members = \[/,/\]/p}' $(SRC_ROOT)/Cargo.toml | \
+		grep -v "members = \[" | tr -d '", \]' | \
+		sort > /tmp/all_members
+
+	@# Convert our absolute paths to relative paths (relative to SRC_ROOT)
+	@echo $(NON_OSDK_CRATES) $(OSDK_CRATES) | tr ' ' '\n' | \
+		sed 's|^$(SRC_ROOT)/||' | sort > /tmp/combined_members
+
+	@# Compare
+	@diff -B /tmp/all_members /tmp/combined_members || \
+		(echo "Error: The combination of OSDK_CRATES and NON_OSDK_CRATES" \
+			"is not the same as all workspace members" && exit 1)
+
+	@rm -f /tmp/all_members /tmp/combined_members
+
+.PHONY: check
+check: check_crates_list
+	@# Check if all workspace members enable workspace lints
+	@for dir in $(NON_OSDK_CRATES) $(OSDK_CRATES); do \
+		if [[ "$$(tail -2 $$dir/Cargo.toml)" != "[lints]"$$'\n'"workspace = true" ]]; then \
+			echo "Error: Workspace lints in $$dir are not enabled"; \
+			exit 1; \
+		fi \
+	done
+	@
+	@# Check compilation of the Rust code
+	@for dir in $(NON_OSDK_CRATES); do \
+		echo "Checking $$dir"; \
+		# Run clippy on each crate with and without the test configuration. \
+		(cd $$dir && cargo clippy --no-deps -- -D warnings) || exit 1; \
+		(cd $$dir && cargo clippy --tests --no-deps -- -D warnings) || exit 1; \
+	done
+	@for dir in $(OSDK_CRATES); do \
+		echo "Checking $$dir"; \
+		# Exclude linux-bzimage-setup since it only supports x86-64 currently and will panic \
+		# in other architectures. \
+ 		[ "$$dir" = "$(SRC_ROOT)/ostd/libs/linux-bzimage/setup" ] && [ "$(OSDK_TARGET_ARCH)" != "x86_64" ] && continue; \
+ 		# Run clippy on each crate with and without the ktest configuration. \
+ 		(cd $$dir && cargo osdk clippy -- --no-deps -- -D warnings) || exit 1; \
+ 		(cd $$dir && cargo osdk clippy --ktests -- --no-deps -- -D warnings) || exit 1; \
+	done
+
+.PHONY: test
+test:
+	@for dir in $(NON_OSDK_CRATES); do \
+		(cd $$dir && cargo test) || exit 1; \
+	done
+
+.PHONY: ktest
+ktest: 
+	@# Notes:
+	@# 1. linux-bzimage-setup is excluded from ktest since it's hard to be unit tested;
+	@# 2. Artifacts are removed after testing each crate to save the limited disk space
+	@#    available to free-tier Github runners.
+	@for dir in $(OSDK_CRATES); do \
+		[ $$dir = "$(SRC_ROOT)/ostd/libs/linux-bzimage/setup" ] && continue; \
+		echo "[make] Testing $$dir"; \
+		(cd $$dir && cargo osdk test $(CARGO_OSDK_TEST_ARGS)) || exit 1; \
+		tail --lines 10 $(SRC_ROOT)/qemu.log | grep -q "^\\[ktest runner\\] All crates tested." \
+			|| (echo "Test failed" && exit 1); \
+		rm -rf target/osdk/*; \
+	done
+
+.PHONY: docs
+docs: $(CARGO_OSDK)
+	@for dir in $(NON_OSDK_CRATES); do \
+		(cd $$dir && RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps) || exit 1; \
+	done
+	@for dir in $(OSDK_CRATES); do \
+		EXTRA_DOC_FLAGS=""; \
+		# The kernel crate is primarily composed of private items. \
+		# We include the --document-private-items flag \
+		# to ensure documentation of the internal items is fully checked. \
+		if [ "$$dir" = "$(SRC_ROOT)/kernel" ]; then \
+			EXTRA_DOC_FLAGS="--document-private-items -Arustdoc::private_intra_doc_links"; \
+		fi; \
+		(cd $$dir && RUSTDOCFLAGS="-Dwarnings $$EXTRA_DOC_FLAGS" cargo osdk doc --no-deps) || exit 1; \
+	done

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -51,9 +51,20 @@ endif
 .PHONY: all
 all: build
 
+.PHONY: check_vdso
+check_vdso:
+	@# Checking `VDSO_LIBRARY_DIR` environment variable
+	@if [ -z "$(VDSO_LIBRARY_DIR)" ]; then \
+		echo "Error: the VDSO_LIBRARY_DIR environment variable must be given."; \
+		echo "    This variable points to a directory that provides Linux's vDSO files,"; \
+		echo "    which is required to build Asterinas. Search for VDSO_LIBRARY_DIR"; \
+		echo "    in Asterinas's Dockerfile for more information."; \
+		exit 1; \
+	fi
+
 .PHONY: build
 ifeq ($(OSDK_TARGET_ARCH), loongarch64)
-build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
+build: check_vdso $(EXT2_IMAGE) $(EXFAT_IMAGE)
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
 else

--- a/tools/format_rust.sh
+++ b/tools/format_rust.sh
@@ -4,6 +4,24 @@
 
 set -e
 
+# --- Help message ---
+show_help() {
+    cat << EOF
+Usage: $0 [OPTION]
+
+Format all Rust code in the workspace, including excluded crates and special files.
+
+OPTIONS:
+    --check     Check if code is formatted (do not modify files)
+    --help      Display this help message and exit
+
+EXAMPLES:
+    $0                # Format all applicable Rust code
+    $0 --check        # Check formatting without modifying files
+
+EOF
+}
+
 WORKSPACE_ROOT="$(dirname "$(readlink -f "$0")")/.."
 
 EXCLUDED_CRATES=$(sed -n -e 's/#.*//; /^\s*$/d' -e '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
@@ -11,14 +29,23 @@ EXCLUDED_CRATES=$(sed -n -e 's/#.*//; /^\s*$/d' -e '/^\[workspace\]/,/^\[.*\]/{/
 CHECK_MODE=false
 
 if [ "$#" -eq 1 ]; then
-    if [ "$1" == "--check" ]; then
-        CHECK_MODE=true
-    else
-        echo "Error: Invalid argument. Only '--check' is allowed."
-        exit 1
-    fi
+    case "$1" in
+        --help)
+            show_help
+            exit 0
+            ;;
+        --check)
+            CHECK_MODE=true
+            ;;
+        *)
+            echo "Error: Invalid argument '$1'."
+            echo "Run '$0 --help' for usage."
+            exit 1
+            ;;
+    esac
 elif [ "$#" -gt 1 ]; then
-    echo "Error: Too many arguments. Only '--check' is allowed."
+    echo "Error: Too many arguments."
+    echo "Run '$0 --help' for usage."
     exit 1
 fi
 


### PR DESCRIPTION
This PR refactors the root Makefile by moving parts of its logic into `kernel/Makefile` and `distro/Makefile`.

Since we added support for the NixOS distribution, the root Makefile has become more complex. This change aims to simplify it by delegating responsibilities to more focused sub-Makefiles. This is purely a refactor—there are no functional changes.

The PR consists of four commits:

1. Move kernel-related build logic to `kernel/Makefile`.
The classification of crates into OSDK_CRATES and NON_OSDK_CRATES is now automated: instead of being manually listed, crates are identified by checking whether their `Cargo.toml` contains `ostd.workspace = true`.
Two special cases are handled explicitly:
- `device-id`: does not directly depend on OSTD, but depends on `aster-util`, which in turn depends on OSTD.
- `linux-bzimage-setup`: requires OSDK for checking despite lacking a direct OSTD dependency.
2. Move `check_vdso` to `test/initramfs/Makefile`
This target is an implementation detail of the initramfs test setup and doesn’t belong in the root Makefile.
3. Move distro-related logic to `distro/Makefile`
The `distro/result` directory (which stores artifacts from nix-build) is now excluded during formatting and linting checks, as it contains generated files that should not be formatted.
4. Rename `format_all.sh` to `format_rust.sh` and add `--help` support. Given that the script only formats Rust code, the new name better reflects its purpose. A helpful usage message is now displayed when --help is passed.

Environment variable handling remains unchanged due to its complexity. Two improvements are left for follow-up:
1. Explicit `export` declarations: All variables intended to be inherited by sub-Makefiles should be explicitly marked with `export` for clarity.
2. Deduplication of variable definitions: Some environment variables are currently defined both in the root Makefile and in sub-Makefiles. While this allows subdirectories to be built independently (e.g., via `cd distro && make`), it leads to redundancy and potential confusion. I'm not sure whether a single source of definition is preferable.