### PR TITLE
Allow empty UNIX control messages

### DIFF
--- a/kernel/src/net/socket/util/message_header.rs
+++ b/kernel/src/net/socket/util/message_header.rs
@@ -49,7 +49,7 @@ impl ControlMessage {
 
         while reader.has_remain() && msgs.len() < MAX_NR_MSGS {
             let header = reader.read_val::<CControlHeader>()?;
-            if header.len <= size_of::<CControlHeader>() || header.payload_len() > reader.remain() {
+            if header.len < size_of::<CControlHeader>() || header.payload_len() > reader.remain() {
                 return_errno_with_message!(
                     Errno::EINVAL,
                     "the size of the control message is invalid"

--- a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test
@@ -26,10 +26,6 @@ AllUnixDomainSockets/UnixSocketPairCmsgTest.FDPassPeek/*
 
 AllUnixDomainSockets/UnixSocketPairCmsgTest.InheritPasscred/*
 
-AllUnixDomainSockets/UnixSocketPairCmsgTest.ZeroFDPass/*
-AllUnixDomainSockets/UnixSocketPairCmsgTest.ZeroFDPassCoalesceData/0
-AllUnixDomainSockets/UnixSocketPairCmsgTest.ZeroFDPassCoalesceData/6
-
 AllUnixDomainSockets/UnixSocketPeerCredTest.GetPeerCred/2
 AllUnixDomainSockets/UnixSocketPeerCredTest.GetPeerCred/3
 AllUnixDomainSockets/UnixSocketPeerCredTest.GetPeerCred/8


### PR DESCRIPTION
So we can fix:
https://github.com/asterinas/asterinas/blob/bdc1c797701a677f3f77e2d1ed73a7f1133a9b4a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test#L29-L31

---

The following tests are also relatively easy to fix and should be fixed. I will do them later in separate PRs.
https://github.com/asterinas/asterinas/blob/bdc1c797701a677f3f77e2d1ed73a7f1133a9b4a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test#L27
https://github.com/asterinas/asterinas/blob/bdc1c797701a677f3f77e2d1ed73a7f1133a9b4a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test#L33-L36