### PR TITLE
Triage some gvisor tests (mostly related to the UNIX sockets)

### DIFF
--- a/test/initramfs/src/syscall/gvisor/blocklists/inotify_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/inotify_test
@@ -1,7 +1,5 @@
-# TODO: Generate `DELETE_SELF`/`IGNORED` after closing the last FD.
+# TODO: Generate `CLOSE`/`CLOSE_NOWRITE` after closing the last FD.
 Inotify.DupFD
-Inotify.IncludeUnlinkedFile
-Inotify.IncludeUnlinkedFile_NoRandomSave
 
 # Symbolic links to the busybox binary does not work:
 # "gvisor_test_temp_1103_1767603858010282988: applet not found"
@@ -16,6 +14,10 @@ Inotify.ExcludeUnlinkInodeEvents
 Inotify.ExcludeUnlinkInodeEvents_NoRandomSave
 Inotify.ExcludeUnlinkMultipleChildren
 Inotify.ExcludeUnlinkMultipleChildren_NoRandomSave
+
+# TODO: Generate `DELETE_SELF`/`IGNORED` after closing the last FD.
+Inotify.IncludeUnlinkedFile
+Inotify.IncludeUnlinkedFile_NoRandomSave
 
 # TODO: Report `MOVE_*` events at the `rename()` system call.
 Inotify.MoveGeneratesEvents

--- a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_dgram_local_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_dgram_local_test
@@ -12,4 +12,5 @@ DgramUnixSockets/NonStreamSocketPairTest.MsgTruncTruncationRecvmsgMsghdrFlagMsgT
 DgramUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncZeroLen/*
 DgramUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncMsgPeekZeroLen/*
 
+# TODO: Implement `SO_SNDBUF` behavior
 DgramUnixSockets/DgramUnixSocketPairTest.IncreasedSocketSendBufUnblocksWrites/*

--- a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_pair_test
@@ -6,9 +6,6 @@ AllUnixDomainSockets/UnixSocketPairTest.TIOCINQSucceeds/*
 AllUnixDomainSockets/UnixSocketPairTest.TIOCOUTQSucceeds/*
 AllUnixDomainSockets/UnixSocketPairTest.NetdeviceIoctlsSucceed/*
 
-# TODO: Fix operations on `/proc/*/fd/*`
-AllUnixDomainSockets/UnixSocketPairTest.SocketReopenFromProcfs/*
-
 # TODO: Report `MSG_(C)TRUNC` after truncating the (control) message
 AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicFDPassNoSpaceMsgCtrunc/*
 AllUnixDomainSockets/UnixSocketPairCmsgTest.BasicFDPassNullControlMsgCtrunc/*

--- a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_seqpacket_local_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_seqpacket_local_test
@@ -12,4 +12,5 @@ SeqpacketUnixSockets/NonStreamSocketPairTest.MsgTruncTruncationRecvmsgMsghdrFlag
 SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncZeroLen/*
 SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgMsgTruncMsgPeekZeroLen/*
 
+# TODO: Implement `SO_SNDBUF` behavior
 SeqpacketUnixSockets/SeqpacketUnixSocketPairTest.IncreasedSocketSendBufUnblocksWrites/*

--- a/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_stream_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/socket_unix_stream_test
@@ -4,8 +4,7 @@ AllUnixDomainSockets/StreamUnixSocketPairTest.RecvmsgOneSideClosed/*
 # TODO: Support `ECONNRESET` errors on UNIX sockets
 AllUnixDomainSockets/StreamUnixSocketPairTest.ReadOneSideClosedWithUnreadData/*
 
+# TODO: Implement `SO_SNDBUF` behavior
 AllUnixDomainSockets/StreamUnixSocketPairTest.IncreasedSocketSendBufUnblocksWrites/*
-
 AllUnixDomainSockets/StreamUnixSocketPairTest.SendBufferOverflow/*
-
 AllUnixDomainSockets/StreamUnixSocketPairTest.SetSocketSendBuf/*


### PR DESCRIPTION
In https://github.com/asterinas/asterinas/pull/2903 and https://github.com/asterinas/asterinas/pull/2901, I fixed some incorrect behavior discovered by the newly added gvisor test cases in `test/initramfs/src/syscall/gvisor/blocklists/socket_unix_*`.

The rest is related to the `SO_SNDBUF` option. We have a dummy implementation, but the option never takes effect. The corresponding gvior tests then won't pass. I added a TODO comment to align the style with the existing tests:
```
# TODO: Implement `SO_SNDBUF` behavior
AllUnixDomainSockets/StreamUnixSocketPairTest.IncreasedSocketSendBufUnblocksWrites/*
AllUnixDomainSockets/StreamUnixSocketPairTest.SendBufferOverflow/*
AllUnixDomainSockets/StreamUnixSocketPairTest.SetSocketSendBuf/*
```

---

In addition, two small adjustments:
 - `SocketReopenFromProcfs` now passes. So I remove it.
 - [`Inotify.DupFD` tests `CLOSE`/`CLOSE_NOWRITE`](https://github.com/google/gvisor/blob/509480e9286157ca77b3610b4573265a23fd357e/test/syscalls/linux/inotify.cc#L820-L822) instead of `DELETE_SELF`/`IGNORED`. I added the wrong comment in https://github.com/asterinas/asterinas/pull/2859. I discovered this later and fixed it.