### PR TITLE
Fix new_fd validation to use resource limits in `do_dup3`

### DIFF
--- a/kernel/src/syscall/dup.rs
+++ b/kernel/src/syscall/dup.rs
@@ -56,12 +56,12 @@ fn do_dup3(
         return_errno!(Errno::EINVAL);
     }
 
-    if new_fd
+    if new_fd.cast_unsigned() as u64
         >= ctx
             .process
             .resource_limits()
             .get_rlimit(ResourceType::RLIMIT_NOFILE)
-            .get_cur() as FileDesc
+            .get_cur()
     {
         return_errno!(Errno::EBADF);
     }


### PR DESCRIPTION
Fix #2905 

In Linux, the `new_fd` and `old_fd` is `unsigned int`, so we shall cast `new_fd` into `u64` instead of casting `rlimit` into `FileDesc` (i.e., `pub type FileDesc = i32;`)

refer: https://github.com/torvalds/linux/blob/24d479d26b25bce5faea3ddd9fa8f3a6c3129ea7/fs/file.c#L1419-L1432