### PR TITLE
Handle the listener in `State::set_pass_cred`

### DIFF
--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -553,7 +553,7 @@ impl SetSocketLevelOption for State {
                 // automatically." See <https://man7.org/linux/man-pages/man7/unix.7.html> for
                 // details.
             }
-            Self::Listen(_) => {}
+            Self::Listen(listener) => listener.set_pass_cred(pass_cred),
             Self::Connected(connected) => connected.set_pass_cred(pass_cred),
         }
     }


### PR DESCRIPTION
I am sorry that https://github.com/asterinas/asterinas/pull/2903 forgets to update the code in `State::set_pass_cred`.... 

Hopefully, this won't cause too much noise. It's a one-line fix PR with an 83-line regression test.