### PR TITLE
Align `PidFile` semantics with `POSIX` standards

### DIFF
--- a/kernel/src/fs/pipe/anon_pipe.rs
+++ b/kernel/src/fs/pipe/anon_pipe.rs
@@ -8,7 +8,7 @@ use crate::{
     fs::{
         inode_handle::{FileIo, InodeHandle},
         pipe::Pipe,
-        pseudofs::{PipeFs, PseudoInode},
+        pseudofs::{PipeFs, PseudoInode, PseudoInodeType},
         utils::{
             AccessMode, Extension, FileSystem, Inode, InodeIo, InodeMode, InodeType, Metadata,
             StatusFlags, mkmod,
@@ -46,7 +46,7 @@ impl AnonPipeInode {
         let pipe = Pipe::new();
 
         let pseudo_inode = PipeFs::singleton().alloc_inode(
-            InodeType::NamedPipe,
+            PseudoInodeType::Pipe,
             mkmod!(u+rw),
             Uid::new_root(),
             Gid::new_root(),

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -20,6 +20,7 @@ use super::{
     task_set::TaskSet,
 };
 use crate::{
+    events::IoEvents,
     fs::cgroupfs::CgroupNode,
     prelude::*,
     process::{
@@ -149,6 +150,12 @@ pub struct Process {
     // Namespaces
     /// The user namespace
     user_ns: Mutex<Arc<UserNamespace>>,
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        self.pidfile_pollee.notify(IoEvents::HUP);
+    }
 }
 
 /// Representing a parent process by holding a weak reference to it and its PID.

--- a/test/initramfs/src/apps/pseudofs/pseudo_inode.c
+++ b/test/initramfs/src/apps/pseudofs/pseudo_inode.c
@@ -54,19 +54,17 @@ FN_TEST(anon_inodefs_share_inode)
 {
 	struct fd_mode {
 		int fd;
-		mode_t modes[2];
+		mode_t mode;
 	};
 
 	struct fd_mode fds[] = {
-		{ epoll_fd, { 0600, 0000 } },	{ event_fd, { 0000, 0111 } },
-		{ timer_fd, { 0111, 0222 } },	{ signal_fd, { 0222, 0333 } },
-		{ inotify_fd, { 0333, 0444 } }, { pid_fd, { 0444, 0600 } },
+		{ epoll_fd, 0600 },  { event_fd, 0600 },   { timer_fd, 0600 },
+		{ signal_fd, 0600 }, { inotify_fd, 0600 }, { pid_fd, 0700 },
 	};
 
 	for (size_t i = 0; i < sizeof(fds) / sizeof(fds[0]); i++) {
-		TEST_RES(get_mode(fds[i].fd), _ret == fds[i].modes[0]);
-		TEST_SUCC(set_mode(fds[i].fd, fds[i].modes[1]));
-		TEST_RES(get_mode(fds[i].fd), _ret == fds[i].modes[1]);
+		TEST_RES(get_mode(fds[i].fd), _ret == fds[i].mode);
+		TEST_ERRNO(set_mode(fds[i].fd, 0600), EOPNOTSUPP);
 	}
 }
 END_TEST()

--- a/test/initramfs/src/apps/pseudofs/pseudo_mount.c
+++ b/test/initramfs/src/apps/pseudofs/pseudo_mount.c
@@ -24,8 +24,7 @@ static int read_fdinfo_mnt_id(int fd)
 
 FN_TEST(pseudo_mount)
 {
-	int anon[] = { epoll_fd,  event_fd,   timer_fd,
-		       signal_fd, inotify_fd, pid_fd };
+	int anon[] = { epoll_fd, event_fd, timer_fd, signal_fd, inotify_fd };
 
 	struct fd_group {
 		int *fds;
@@ -34,13 +33,11 @@ FN_TEST(pseudo_mount)
 	};
 
 	struct fd_group groups[] = {
-		{ pipe_1, 2, -1 },
-		{ sock, 2, -1 },
-		{ anon, 6, -1 },
-		{ &mem_fd, 1, -1 },
+		{ pipe_1, 2, -1 },  { sock, 2, -1 },	{ anon, 5, -1 },
+		{ &mem_fd, 1, -1 }, { &pid_fd, 1, -1 },
 	};
 
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < 5; i++) {
 		int base = TEST_SUCC(read_fdinfo_mnt_id(groups[i].fds[0]));
 		for (int j = 1; j < groups[i].nr; j++) {
 			TEST_RES(read_fdinfo_mnt_id(groups[i].fds[j]),
@@ -49,8 +46,8 @@ FN_TEST(pseudo_mount)
 		groups[i].mnt_id = base;
 	}
 
-	for (int i = 0; i < 4; i++) {
-		for (int j = i + 1; j < 4; j++) {
+	for (int i = 0; i < 5; i++) {
+		for (int j = i + 1; j < 5; j++) {
 			TEST_RES(0, groups[i].mnt_id != groups[j].mnt_id);
 		}
 	}


### PR DESCRIPTION
## Changes in this PR
- Fix `pseudo_mount.c` and `pidfd.c` testcases to pass under linux.
- Fix `pidfd` part in `pseudo_inode.c` to pass under linux by adding `PidfdFs` and `PseudoInodeType`
- Fix `epoll` for `PidFile` to fit description in [man7](https://man7.org/linux/man-pages/man2/pidfd_open.2.html).
>  When the task that it refers to terminates and becomes a zombie, these interfaces indicate the file descriptor as readable (EPOLLIN).  When the task is reaped, these interfaces produce a hangup event (EPOLLHUP).
- When read or write at pidfd file with offset, return EINVAL instead of ESPIPE.