### PR TITLE
Add support of sparse files for Ext2

### DIFF
--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -8,7 +8,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use device_id::DeviceId;
 use inherit_methods_macro::inherit_methods;
-use ostd::{const_assert, mm::io_util::HasVmReaderWriter};
+use ostd::{
+    const_assert,
+    mm::{HasSize, io_util::HasVmReaderWriter},
+};
 
 use super::{
     block_ptr::{BID_SIZE, BidPath, BlockPtrs, Ext2Bid, MAX_BLOCK_PTRS},
@@ -1862,16 +1865,51 @@ struct InodeBlockManager {
 
 impl InodeBlockManager {
     /// Reads one or multiple blocks to the segment start from `bid` asynchronously.
-    fn read_blocks_async(&self, bid: Ext2Bid, nblocks: usize) -> Result<BioWaiter> {
+    ///
+    /// This method handles sparse blocks by filling them with zeros directly,
+    /// and only initiates I/O for non-sparse blocks.
+    /// Reference: <https://elixir.bootlin.com/linux/v6.18/source/fs/iomap/direct-io.c#L505>
+    pub fn read_blocks_async(
+        &self,
+        bid: Ext2Bid,
+        nblocks: usize,
+        writer: &mut VmWriter,
+    ) -> Result<BioWaiter> {
+        debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
         let mut bio_waiter = BioWaiter::new();
+        let mut range_reader = DeviceRangeReader::new(self, bid..bid + nblocks as Ext2Bid)?;
+        let mut current_logical_idx = 0usize;
+        let start_bid = bid;
 
-        for dev_range in DeviceRangeReader::new(self, bid..bid + nblocks as Ext2Bid)? {
+        loop {
+            let pos_before = range_reader.pos();
+            let dev_range = match range_reader.read() {
+                Ok(Some(range)) => range,
+                Ok(None) => {
+                    // All remaining logical blocks are sparse (hole).
+                    let remaining = nblocks - current_logical_idx;
+                    writer.fill_zeros(remaining * BLOCK_SIZE)?;
+                    break;
+                }
+                Err(_) => return Err(Error::new(Errno::EIO)),
+            };
+
+            let range_logical_start = (pos_before - start_bid) as usize;
+
+            // Fill zeros for sparse blocks before this range.
+            while current_logical_idx < range_logical_start {
+                writer.fill_zeros(BLOCK_SIZE)?;
+                current_logical_idx += 1;
+            }
+
+            // Initiate async read for this non-sparse range.
             let start_bid = dev_range.start as Ext2Bid;
             let range_nblocks = dev_range.len();
-
             let bio_segment = BioSegment::alloc(range_nblocks, BioDirection::FromDevice);
             let waiter = self.fs().read_blocks_async(start_bid, bio_segment)?;
             bio_waiter.concat(waiter);
+
+            current_logical_idx += range_nblocks;
         }
 
         Ok(bio_waiter)
@@ -1879,7 +1917,7 @@ impl InodeBlockManager {
 
     pub fn read_blocks(&self, bid: Ext2Bid, nblocks: usize, writer: &mut VmWriter) -> Result<()> {
         debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
-        let bio_waiter = self.read_blocks_async(bid, nblocks)?;
+        let bio_waiter = self.read_blocks_async(bid, nblocks, writer)?;
         if Some(BioStatus::Complete) != bio_waiter.wait() {
             return_errno!(Errno::EIO);
         }
@@ -1896,8 +1934,13 @@ impl InodeBlockManager {
         Ok(())
     }
 
+    /// Reads one block to the frame start from `bid` asynchronously.
+    ///
+    /// This method handles sparse block by filling it with zeros directly.
+    /// Reference: <https://elixir.bootlin.com/linux/v6.18/source/fs/iomap/buffered-io.c#L389>
     pub fn read_block_async(&self, bid: Ext2Bid, frame: &CachePage) -> Result<BioWaiter> {
         let mut bio_waiter = BioWaiter::new();
+        let mut is_hole = true;
 
         for dev_range in DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)? {
             let start_bid = dev_range.start as Ext2Bid;
@@ -1909,6 +1952,11 @@ impl InodeBlockManager {
             );
             let waiter = self.fs().read_blocks_async(start_bid, bio_segment)?;
             bio_waiter.concat(waiter);
+            is_hole = false;
+        }
+
+        if is_hole {
+            frame.writer().fill_zeros(frame.size());
         }
 
         Ok(bio_waiter)
@@ -2017,6 +2065,11 @@ impl<'a> DeviceRangeReader<'a> {
         };
         reader.update_indirect_block()?;
         Ok(reader)
+    }
+
+    /// Gets the current logical block position.
+    pub fn pos(&self) -> Ext2Bid {
+        self.range.start
     }
 
     /// Reads the corresponding device block IDs for a specified range.

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1704,13 +1704,12 @@ impl InodeImpl {
         self.last_alloc_device_bid = if range.start == 0 {
             None
         } else {
-            Some(
+            let last_alloc_device_range =
                 DeviceRangeReader::new(&self.block_manager, (range.start - 1)..range.start)
                     .unwrap()
                     .read()
-                    .unwrap()
-                    .start,
-            )
+                    .unwrap();
+            last_alloc_device_range.map(|device_range| device_range.start)
         };
     }
 
@@ -2024,7 +2023,7 @@ impl<'a> DeviceRangeReader<'a> {
     ///
     /// Note that the returned device range size may be smaller than the requested range
     /// due to possible inconsecutive block allocation.
-    pub fn read(&mut self) -> Result<Range<Ext2Bid>> {
+    pub fn read(&mut self) -> Result<Option<Range<Ext2Bid>>> {
         let bid_path = BidPath::from(self.range.start);
         let max_cnt = self
             .range
@@ -2036,9 +2035,28 @@ impl<'a> DeviceRangeReader<'a> {
         let mut device_range: Option<Range<Ext2Bid>> = None;
         for i in start_idx..start_idx + max_cnt {
             let device_bid = match &self.indirect_block {
-                None => self.block_ptrs.direct(i),
+                None => match bid_path {
+                    BidPath::Direct(_) => self.block_ptrs.direct(i),
+                    _ => 0,
+                },
                 Some(indirect_block) => indirect_block.read_bid(i)?,
             };
+
+            // Skip sparse blocks which are not allocated
+            if device_bid == 0 {
+                match device_range {
+                    Some(ref mut range) => {
+                        // End the current range when hitting a sparse block
+                        break;
+                    }
+                    None => {
+                        // Skip leading sparse blocks, advance the logical range
+                        self.range.start += 1;
+                        continue;
+                    }
+                }
+            }
+
             match device_range {
                 Some(ref mut range) => {
                     if device_bid == range.end {
@@ -2052,7 +2070,16 @@ impl<'a> DeviceRangeReader<'a> {
                 }
             }
         }
-        let device_range = device_range.unwrap();
+
+        let device_range = match device_range {
+            Some(range) => range,
+            None => {
+                if !self.range.is_empty() {
+                    self.update_indirect_block()?;
+                }
+                return Ok(None);
+            }
+        };
 
         // Updates the range
         self.range.start += device_range.len() as Ext2Bid;
@@ -2061,7 +2088,7 @@ impl<'a> DeviceRangeReader<'a> {
             self.update_indirect_block()?;
         }
 
-        Ok(device_range)
+        Ok(Some(device_range))
     }
 
     fn update_indirect_block(&mut self) -> Result<()> {
@@ -2072,30 +2099,49 @@ impl<'a> DeviceRangeReader<'a> {
             }
             BidPath::Indirect(_) => {
                 let indirect_bid = self.block_ptrs.indirect();
-                let indirect_block = self.indirect_blocks.find(indirect_bid)?;
-                self.indirect_block = Some(indirect_block.clone());
+                if indirect_bid == 0 {
+                    self.indirect_block = None;
+                } else {
+                    let indirect_block = self.indirect_blocks.find(indirect_bid)?;
+                    self.indirect_block = Some(indirect_block.clone());
+                }
             }
             BidPath::DbIndirect(lvl1_idx, _) => {
-                let lvl1_indirect_bid = {
-                    let db_indirect_block =
-                        self.indirect_blocks.find(self.block_ptrs.db_indirect())?;
-                    db_indirect_block.read_bid(lvl1_idx as usize)?
-                };
-                let lvl1_indirect_block = self.indirect_blocks.find(lvl1_indirect_bid)?;
-                self.indirect_block = Some(lvl1_indirect_block.clone())
+                let db_indirect_bid = self.block_ptrs.db_indirect();
+                if db_indirect_bid == 0 {
+                    self.indirect_block = None;
+                } else {
+                    let db_indirect_block = self.indirect_blocks.find(db_indirect_bid)?;
+                    let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize)?;
+                    if lvl1_indirect_bid == 0 {
+                        self.indirect_block = None;
+                    } else {
+                        let lvl1_indirect_block = self.indirect_blocks.find(lvl1_indirect_bid)?;
+                        self.indirect_block = Some(lvl1_indirect_block.clone());
+                    }
+                }
             }
             BidPath::TbIndirect(lvl1_idx, lvl2_idx, _) => {
-                let lvl2_indirect_bid = {
-                    let lvl1_indirect_bid = {
-                        let tb_indirect_block =
-                            self.indirect_blocks.find(self.block_ptrs.tb_indirect())?;
-                        tb_indirect_block.read_bid(lvl1_idx as usize)?
-                    };
-                    let lvl1_indirect_block = self.indirect_blocks.find(lvl1_indirect_bid)?;
-                    lvl1_indirect_block.read_bid(lvl2_idx as usize)?
-                };
-                let lvl2_indirect_block = self.indirect_blocks.find(lvl2_indirect_bid)?;
-                self.indirect_block = Some(lvl2_indirect_block.clone())
+                let tb_indirect_bid = self.block_ptrs.tb_indirect();
+                if tb_indirect_bid == 0 {
+                    self.indirect_block = None;
+                } else {
+                    let tb_indirect_block = self.indirect_blocks.find(tb_indirect_bid)?;
+                    let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize)?;
+                    if lvl1_indirect_bid == 0 {
+                        self.indirect_block = None;
+                    } else {
+                        let lvl1_indirect_block = self.indirect_blocks.find(lvl1_indirect_bid)?;
+                        let lvl2_indirect_bid = lvl1_indirect_block.read_bid(lvl2_idx as usize)?;
+                        if lvl2_indirect_bid == 0 {
+                            self.indirect_block = None;
+                        } else {
+                            let lvl2_indirect_block =
+                                self.indirect_blocks.find(lvl2_indirect_bid)?;
+                            self.indirect_block = Some(lvl2_indirect_block.clone());
+                        }
+                    }
+                }
             }
         }
 
@@ -2112,7 +2158,10 @@ impl Iterator for DeviceRangeReader<'_> {
         }
 
         let range = self.read().unwrap();
-        Some(range)
+        match range {
+            Some(range) => Some(range),
+            None => self.next(),
+        }
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1562,18 +1562,8 @@ impl InodeImpl {
     /// After a successful expansion, the size will be enlarged to `new_size`,
     /// which may result in an increased block count.
     fn expand(&mut self, new_size: usize) -> Result<()> {
-        let new_blocks = self.desc.size_to_blocks(new_size);
-        let old_blocks = self.desc.size_in_blocks();
-
-        // Expands block count if necessary
-        if new_blocks > old_blocks {
-            if new_blocks - old_blocks > self.fs().super_block().free_blocks_count() {
-                return_errno_with_message!(Errno::ENOSPC, "not enough free blocks");
-            }
-            self.alloc_range_blocks(old_blocks..new_blocks)?;
-        }
-
-        // Expands the size
+        // Only update the size, creating sparse blocks.
+        // Actual disk blocks will be allocated on-demand during writes.
         self.update_size(new_size);
         Ok(())
     }

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1469,28 +1469,141 @@ impl InodeImpl {
 
     /// Ensures that blocks in the specified range are allocated.
     ///
-    /// This method checks each block in the range and allocates any sparse blocks.
+    /// This method scans the block mappings in the range and allocates any sparse blocks.
     pub fn ensure_blocks_allocated(&mut self, start_bid: Ext2Bid, nblocks: usize) -> Result<()> {
         let end_bid = start_bid + nblocks as Ext2Bid;
         let mut current_bid = start_bid;
 
-        while current_bid < end_bid {
-            let device_bid = self.get_device_bid(current_bid)?;
-            if device_bid == 0 {
-                let sparse_start = current_bid;
-                while current_bid < end_bid {
-                    if self.get_device_bid(current_bid)? != 0 {
-                        break;
-                    }
-                    current_bid += 1;
-                }
-                self.alloc_range_blocks(sparse_start..current_bid)?;
-            } else {
-                current_bid += 1;
-            }
+        while let Some(sparse_range) = self.find_next_sparse_range(current_bid..end_bid)? {
+            current_bid = sparse_range.end;
+            self.alloc_range_blocks(sparse_range)?;
         }
 
         Ok(())
+    }
+
+    fn find_next_sparse_range(&self, range: Range<Ext2Bid>) -> Result<Option<Range<Ext2Bid>>> {
+        let mut current_bid = range.start;
+
+        while current_bid < range.end {
+            let bid_path = BidPath::from(current_bid);
+            let window_end = (current_bid + bid_path.cnt_to_next_indirect()).min(range.end);
+            let range_in_window = current_bid..window_end;
+
+            let sparse_range = match bid_path {
+                BidPath::Direct(index) => {
+                    let block_ptrs = self.block_manager.block_ptrs.read();
+                    Self::find_sparse_range_in_window(
+                        range_in_window.clone(),
+                        index as usize,
+                        |entry_index| Ok(block_ptrs.direct(entry_index)),
+                    )?
+                }
+                BidPath::Indirect(index) => {
+                    let indirect_bid = self.block_manager.block_ptrs.read().indirect();
+                    if indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let indirect_block = indirect_blocks.find(indirect_bid)?;
+                    Self::find_sparse_range_in_window(
+                        range_in_window.clone(),
+                        index as usize,
+                        |entry_index| indirect_block.read_bid(entry_index),
+                    )?
+                }
+                BidPath::DbIndirect(level_one_index, level_two_index) => {
+                    let db_indirect_bid = self.block_manager.block_ptrs.read().db_indirect();
+                    if db_indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let level_one_indirect_bid = {
+                        let db_indirect_block = indirect_blocks.find(db_indirect_bid)?;
+                        db_indirect_block.read_bid(level_one_index as usize)?
+                    };
+                    if level_one_indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let level_one_indirect_block = indirect_blocks.find(level_one_indirect_bid)?;
+                    Self::find_sparse_range_in_window(
+                        range_in_window.clone(),
+                        level_two_index as usize,
+                        |entry_index| level_one_indirect_block.read_bid(entry_index),
+                    )?
+                }
+                BidPath::TbIndirect(level_one_index, level_two_index, level_three_index) => {
+                    let tb_indirect_bid = self.block_manager.block_ptrs.read().tb_indirect();
+                    if tb_indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let level_one_indirect_bid = {
+                        let tb_indirect_block = indirect_blocks.find(tb_indirect_bid)?;
+                        tb_indirect_block.read_bid(level_one_index as usize)?
+                    };
+                    if level_one_indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let level_two_indirect_bid = {
+                        let level_one_indirect_block =
+                            indirect_blocks.find(level_one_indirect_bid)?;
+                        level_one_indirect_block.read_bid(level_two_index as usize)?
+                    };
+                    if level_two_indirect_bid == 0 {
+                        return Ok(Some(range_in_window));
+                    }
+
+                    let level_two_indirect_block = indirect_blocks.find(level_two_indirect_bid)?;
+                    Self::find_sparse_range_in_window(
+                        range_in_window.clone(),
+                        level_three_index as usize,
+                        |entry_index| level_two_indirect_block.read_bid(entry_index),
+                    )?
+                }
+            };
+
+            if let Some(sparse_range) = sparse_range {
+                return Ok(Some(sparse_range));
+            }
+
+            current_bid = window_end;
+        }
+
+        Ok(None)
+    }
+
+    fn find_sparse_range_in_window(
+        logical_range: Range<Ext2Bid>,
+        start_index: usize,
+        mut read_bid_fn: impl FnMut(usize) -> Result<Ext2Bid>,
+    ) -> Result<Option<Range<Ext2Bid>>> {
+        let end_index = start_index + logical_range.len();
+        let mut current_index = start_index;
+
+        while current_index < end_index {
+            if read_bid_fn(current_index)? != 0 {
+                current_index += 1;
+                continue;
+            }
+
+            let sparse_start_index = current_index;
+            current_index += 1;
+            while current_index < end_index && read_bid_fn(current_index)? == 0 {
+                current_index += 1;
+            }
+
+            let sparse_start = logical_range.start + (sparse_start_index - start_index) as Ext2Bid;
+            let sparse_end = logical_range.start + (current_index - start_index) as Ext2Bid;
+            return Ok(Some(sparse_start..sparse_end));
+        }
+
+        Ok(None)
     }
 
     /// Punch a hole in the file by deallocating blocks in the specified range.
@@ -1501,60 +1614,6 @@ impl InodeImpl {
         self.dealloc_range_blocks(range);
 
         Ok(())
-    }
-
-    /// Gets the device block ID for a given file block ID.
-    ///
-    /// Returns 0 if the block is sparse (not allocated).
-    fn get_device_bid(&self, bid: Ext2Bid) -> Result<Ext2Bid> {
-        let bid_path = BidPath::from(bid);
-        let block_ptrs = self.block_manager.block_ptrs.read();
-
-        match bid_path {
-            BidPath::Direct(idx) => Ok(block_ptrs.direct(idx as usize)),
-            BidPath::Indirect(idx) => {
-                let indirect_bid = block_ptrs.indirect();
-                if indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                let indirect_block = indirect_blocks.find(indirect_bid)?;
-                indirect_block.read_bid(idx as usize)
-            }
-            BidPath::DbIndirect(lvl1_idx, lvl2_idx) => {
-                let db_indirect_bid = block_ptrs.db_indirect();
-                if db_indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                let db_indirect_block = indirect_blocks.find(db_indirect_bid)?;
-                let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize)?;
-                if lvl1_indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let lvl1_indirect_block = indirect_blocks.find(lvl1_indirect_bid)?;
-                lvl1_indirect_block.read_bid(lvl2_idx as usize)
-            }
-            BidPath::TbIndirect(lvl1_idx, lvl2_idx, lvl3_idx) => {
-                let tb_indirect_bid = block_ptrs.tb_indirect();
-                if tb_indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                let tb_indirect_block = indirect_blocks.find(tb_indirect_bid)?;
-                let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize)?;
-                if lvl1_indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let lvl1_indirect_block = indirect_blocks.find(lvl1_indirect_bid)?;
-                let lvl2_indirect_bid = lvl1_indirect_block.read_bid(lvl2_idx as usize)?;
-                if lvl2_indirect_bid == 0 {
-                    return Ok(0);
-                }
-                let lvl2_indirect_block = indirect_blocks.find(lvl2_indirect_bid)?;
-                lvl2_indirect_block.read_bid(lvl3_idx as usize)
-            }
-        }
     }
 
     /// Expands inode size.
@@ -1976,68 +2035,108 @@ impl InodeImpl {
             (range.end - max_cnt)..range.end
         };
 
+        let fs = self.fs();
+        let device_range_reader =
+            DeviceRangeReader::new(&self.block_manager, range.clone()).unwrap();
         let mut freed_blocks = 0u32;
-        for bid in range.clone() {
-            let bid_path = BidPath::from(bid);
-            let device_bid = self.get_device_bid(bid).unwrap();
-            if device_bid == 0 {
-                continue;
-            }
-
-            freed_blocks += 1;
-            self.fs().free_blocks(device_bid..device_bid + 1).unwrap();
-            match bid_path {
-                BidPath::Direct(idx) => {
-                    let mut block_ptrs = self.block_manager.block_ptrs.write();
-                    self.desc.block_ptrs.set_direct(idx as usize, 0);
-                    block_ptrs.set_direct(idx as usize, 0);
-                }
-                BidPath::Indirect(idx) => {
-                    let block_ptrs = self.block_manager.block_ptrs.write();
-                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                    let indirect_bid = block_ptrs.indirect();
-                    let indirect_block = indirect_blocks.find_mut(indirect_bid).unwrap();
-                    indirect_block.write_bid(idx as usize, &0).unwrap();
-                }
-                BidPath::DbIndirect(lvl1_idx, lvl2_idx) => {
-                    let block_ptrs = self.block_manager.block_ptrs.write();
-                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                    let db_indirect_bid = block_ptrs.db_indirect();
-                    let db_indirect_block = indirect_blocks.find_mut(db_indirect_bid).unwrap();
-                    let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize).unwrap();
-                    if lvl1_indirect_bid != 0 {
-                        let lvl1_indirect_block =
-                            indirect_blocks.find_mut(lvl1_indirect_bid).unwrap();
-                        lvl1_indirect_block
-                            .write_bid(lvl2_idx as usize, &0)
-                            .unwrap();
-                    }
-                }
-                BidPath::TbIndirect(lvl1_idx, lvl2_idx, lvl3_idx) => {
-                    let block_ptrs = self.block_manager.block_ptrs.write();
-                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
-                    let tb_indirect_bid = block_ptrs.tb_indirect();
-                    let tb_indirect_block = indirect_blocks.find_mut(tb_indirect_bid).unwrap();
-                    let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize).unwrap();
-                    if lvl1_indirect_bid != 0 {
-                        let lvl1_indirect_block =
-                            indirect_blocks.find_mut(lvl1_indirect_bid).unwrap();
-                        let lvl2_indirect_bid =
-                            lvl1_indirect_block.read_bid(lvl2_idx as usize).unwrap();
-                        if lvl2_indirect_bid != 0 {
-                            let lvl2_indirect_block =
-                                indirect_blocks.find_mut(lvl2_indirect_bid).unwrap();
-                            lvl2_indirect_block
-                                .write_bid(lvl3_idx as usize, &0)
-                                .unwrap();
-                        }
-                    }
-                }
-            }
+        for device_range in device_range_reader {
+            freed_blocks += device_range.len() as u32;
+            fs.free_blocks(device_range).unwrap();
         }
+
+        self.clear_range_block_mappings(range.clone());
         self.free_indirect_blocks_required_by(range.start).unwrap();
 
         (range.len() as Ext2Bid, freed_blocks)
+    }
+
+    /// Clears the block mappings for the specified range.
+    ///
+    /// It sets all block pointers within the range to 0, indicating that
+    /// these blocks are no longer mapped to the file.
+    fn clear_range_block_mappings(&mut self, range: Range<Ext2Bid>) {
+        let bid_path = BidPath::from(range.start);
+        let start_index = bid_path.last_lvl_idx();
+        let end_index = start_index + range.len();
+
+        match bid_path {
+            BidPath::Direct(_) => {
+                let mut block_ptrs = self.block_manager.block_ptrs.write();
+                for index in start_index..end_index {
+                    self.desc.block_ptrs.set_direct(index, 0);
+                    block_ptrs.set_direct(index, 0);
+                }
+            }
+            BidPath::Indirect(_) => {
+                let indirect_bid = self.desc.block_ptrs.indirect();
+                if indirect_bid == 0 {
+                    return;
+                }
+
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let indirect_block = indirect_blocks.find_mut(indirect_bid).unwrap();
+                for index in start_index..end_index {
+                    indirect_block.write_bid(index, &0).unwrap();
+                }
+            }
+            BidPath::DbIndirect(level_one_index, _) => {
+                let db_indirect_bid = self.desc.block_ptrs.db_indirect();
+                if db_indirect_bid == 0 {
+                    return;
+                }
+
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let level_one_indirect_bid = {
+                    let db_indirect_block = indirect_blocks.find(db_indirect_bid).unwrap();
+                    db_indirect_block
+                        .read_bid(level_one_index as usize)
+                        .unwrap()
+                };
+                if level_one_indirect_bid == 0 {
+                    return;
+                }
+
+                let level_one_indirect_block =
+                    indirect_blocks.find_mut(level_one_indirect_bid).unwrap();
+                for index in start_index..end_index {
+                    level_one_indirect_block.write_bid(index, &0).unwrap();
+                }
+            }
+            BidPath::TbIndirect(level_one_index, level_two_index, _) => {
+                let tb_indirect_bid = self.desc.block_ptrs.tb_indirect();
+                if tb_indirect_bid == 0 {
+                    return;
+                }
+
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let level_one_indirect_bid = {
+                    let tb_indirect_block = indirect_blocks.find(tb_indirect_bid).unwrap();
+                    tb_indirect_block
+                        .read_bid(level_one_index as usize)
+                        .unwrap()
+                };
+                if level_one_indirect_bid == 0 {
+                    return;
+                }
+
+                let level_two_indirect_bid = {
+                    let level_one_indirect_block =
+                        indirect_blocks.find(level_one_indirect_bid).unwrap();
+                    level_one_indirect_block
+                        .read_bid(level_two_index as usize)
+                        .unwrap()
+                };
+                if level_two_indirect_bid == 0 {
+                    return;
+                }
+
+                let level_two_indirect_block =
+                    indirect_blocks.find_mut(level_two_indirect_bid).unwrap();
+                for index in start_index..end_index {
+                    level_two_indirect_block.write_bid(index, &0).unwrap();
+                }
+            }
+        }
     }
 
     /// Frees the indirect blocks required by the specified block ID.

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -748,8 +748,9 @@ impl Inode {
             let len = inner.extend_write_at(offset, reader)?;
             (len, inner)
         } else {
+            let mut inner = inner.upgrade();
             let len = inner.write_at(offset, reader)?;
-            (len, inner.upgrade())
+            (len, inner)
         };
 
         let now = now();
@@ -1035,8 +1036,20 @@ impl InodeInner {
         Ok(read_len)
     }
 
-    pub fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+    pub fn write_at(&mut self, offset: usize, reader: &mut VmReader) -> Result<usize> {
         let write_len = reader.remain();
+        let end_offset = offset + write_len;
+
+        // Check if the write range contains sparse blocks.
+        // If so, allocate blocks for them before writing.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/fs/buffer.c#L2145>
+        assert!(end_offset <= self.file_size());
+        let start_bid = Bid::from_offset(offset).to_raw() as Ext2Bid;
+        let end_bid = Bid::from_offset(end_offset.align_up(BLOCK_SIZE)).to_raw() as Ext2Bid;
+        let nblocks = (end_bid - start_bid) as usize;
+        self.inode_impl
+            .ensure_blocks_allocated(start_bid, nblocks)?;
+
         self.page_cache.pages().write(offset, reader)?;
         Ok(write_len)
     }
@@ -1066,6 +1079,9 @@ impl InodeInner {
 
         let start_bid = Bid::from_offset(offset).to_raw() as Ext2Bid;
         let buf_nblocks = write_len / BLOCK_SIZE;
+        self.inode_impl
+            .ensure_blocks_allocated(start_bid, buf_nblocks)?;
+
         self.inode_impl
             .write_blocks(start_bid, buf_nblocks, reader)?;
 
@@ -1408,6 +1424,86 @@ impl InodeImpl {
             self.shrink(new_size);
         }
         Ok(())
+    }
+
+    /// Ensures that blocks in the specified range are allocated.
+    ///
+    /// This method checks each block in the range and allocates any sparse blocks.
+    pub fn ensure_blocks_allocated(&mut self, start_bid: Ext2Bid, nblocks: usize) -> Result<()> {
+        let end_bid = start_bid + nblocks as Ext2Bid;
+        let mut current_bid = start_bid;
+
+        while current_bid < end_bid {
+            let device_bid = self.get_device_bid(current_bid)?;
+            if device_bid == 0 {
+                let sparse_start = current_bid;
+                while current_bid < end_bid {
+                    if self.get_device_bid(current_bid)? != 0 {
+                        break;
+                    }
+                    current_bid += 1;
+                }
+                self.expand_blocks(sparse_start..current_bid)?;
+            } else {
+                current_bid += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Gets the device block ID for a given file block ID.
+    ///
+    /// Returns 0 if the block is sparse (not allocated).
+    fn get_device_bid(&self, bid: Ext2Bid) -> Result<Ext2Bid> {
+        let bid_path = BidPath::from(bid);
+        let block_ptrs = self.block_manager.block_ptrs.read();
+
+        match bid_path {
+            BidPath::Direct(idx) => Ok(block_ptrs.direct(idx as usize)),
+            BidPath::Indirect(idx) => {
+                let indirect_bid = block_ptrs.indirect();
+                if indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let indirect_block = indirect_blocks.find(indirect_bid)?;
+                indirect_block.read_bid(idx as usize)
+            }
+            BidPath::DbIndirect(lvl1_idx, lvl2_idx) => {
+                let db_indirect_bid = block_ptrs.db_indirect();
+                if db_indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let db_indirect_block = indirect_blocks.find(db_indirect_bid)?;
+                let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize)?;
+                if lvl1_indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let lvl1_indirect_block = indirect_blocks.find(lvl1_indirect_bid)?;
+                lvl1_indirect_block.read_bid(lvl2_idx as usize)
+            }
+            BidPath::TbIndirect(lvl1_idx, lvl2_idx, lvl3_idx) => {
+                let tb_indirect_bid = block_ptrs.tb_indirect();
+                if tb_indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let tb_indirect_block = indirect_blocks.find(tb_indirect_bid)?;
+                let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize)?;
+                if lvl1_indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let lvl1_indirect_block = indirect_blocks.find(lvl1_indirect_bid)?;
+                let lvl2_indirect_bid = lvl1_indirect_block.read_bid(lvl2_idx as usize)?;
+                if lvl2_indirect_bid == 0 {
+                    return Ok(0);
+                }
+                let lvl2_indirect_block = indirect_blocks.find(lvl2_indirect_bid)?;
+                lvl2_indirect_block.read_bid(lvl3_idx as usize)
+            }
+        }
     }
 
     /// Expands inode size.

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -893,7 +893,7 @@ impl Inode {
     pub fn gid(&self) -> u32;
     pub fn file_flags(&self) -> FileFlags;
     pub fn hard_links(&self) -> u16;
-    pub fn blocks_count(&self) -> Ext2Bid;
+    pub fn size_in_blocks(&self) -> Ext2Bid;
     pub fn acl(&self) -> Bid;
     pub fn atime(&self) -> Duration;
     pub fn mtime(&self) -> Duration;
@@ -1198,7 +1198,8 @@ impl InodeInner {
     pub fn nr_sectors_allocated(&self) -> usize;
     pub fn inc_hard_links(&mut self);
     pub fn dec_hard_links(&mut self);
-    pub fn blocks_count(&self) -> Ext2Bid;
+    pub fn size_in_blocks(&self) -> Ext2Bid;
+    pub fn occupied_sectors_count(&self) -> u32;
     pub fn acl(&self) -> Bid;
     pub fn set_acl(&mut self, bid: Bid);
     pub fn atime(&self) -> Duration;
@@ -1223,7 +1224,7 @@ struct InodeImpl {
 impl InodeImpl {
     pub fn new(desc: Dirty<InodeDesc>, weak_self: Weak<Inode>, fs: Weak<Ext2>) -> Self {
         let block_manager = InodeBlockManager {
-            nblocks: AtomicUsize::new(desc.blocks_count() as _),
+            nblocks: AtomicUsize::new(desc.size_in_blocks() as _),
             block_ptrs: RwMutex::new(desc.block_ptrs),
             indirect_blocks: RwMutex::new(IndirectBlockCache::new(fs.clone())),
             fs,
@@ -1286,7 +1287,7 @@ impl InodeImpl {
     }
 
     pub fn nr_sectors_allocated(&self) -> usize {
-        self.desc.sector_count as usize
+        self.desc.occupied_sectors_count as usize
     }
 
     pub fn inc_hard_links(&mut self) {
@@ -1298,8 +1299,12 @@ impl InodeImpl {
         self.desc.hard_links -= 1;
     }
 
-    pub fn blocks_count(&self) -> Ext2Bid {
-        self.desc.blocks_count()
+    pub fn size_in_blocks(&self) -> Ext2Bid {
+        self.desc.size_in_blocks()
+    }
+
+    pub fn occupied_sectors_count(&self) -> u32 {
+        self.desc.occupied_sectors_count
     }
 
     pub fn acl(&self) -> Bid {
@@ -1408,7 +1413,7 @@ impl InodeImpl {
     /// which may result in an increased block count.
     fn expand(&mut self, new_size: usize) -> Result<()> {
         let new_blocks = self.desc.size_to_blocks(new_size);
-        let old_blocks = self.desc.blocks_count();
+        let old_blocks = self.desc.size_in_blocks();
 
         // Expands block count if necessary
         if new_blocks > old_blocks {
@@ -1485,7 +1490,6 @@ impl InodeImpl {
                 self.fs().free_blocks(device_range).unwrap();
                 return Err(e);
             }
-
             self.last_alloc_device_bid = Some(device_range.end - 1);
             let nr_blocks = device_range.len() as Ext2Bid;
             self.desc.set_data_blocks(range.start + nr_blocks);
@@ -1668,7 +1672,7 @@ impl InodeImpl {
     /// which may result in an decreased block count.
     fn shrink(&mut self, new_size: usize) {
         let new_blocks = self.desc.size_to_blocks(new_size);
-        let old_blocks = self.desc.blocks_count();
+        let old_blocks = self.desc.size_in_blocks();
 
         // Shrinks block count if necessary
         if new_blocks < old_blocks {
@@ -1683,7 +1687,7 @@ impl InodeImpl {
         self.desc.size = new_size;
         self.block_manager
             .nblocks
-            .store(self.blocks_count() as _, Ordering::Release);
+            .store(self.size_in_blocks() as _, Ordering::Release);
     }
 
     /// Shrinks inode blocks.
@@ -2141,8 +2145,8 @@ pub(super) struct InodeDesc {
     dtime: Duration,
     /// Hard links count.
     hard_links: u16,
-    /// Number of sectors.
-    sector_count: u32,
+    /// Number of sectors occupied.
+    occupied_sectors_count: u32,
     /// File flags.
     flags: FileFlags,
     /// Pointers to blocks.
@@ -2171,7 +2175,7 @@ impl TryFrom<RawInode> for InodeDesc {
             mtime: Duration::from(inode.mtime),
             dtime: Duration::from(inode.dtime),
             hard_links: inode.hard_links,
-            sector_count: inode.sector_count,
+            occupied_sectors_count: inode.occupied_sectors_count,
             flags: FileFlags::from_bits(inode.flags)
                 .ok_or(Error::with_message(Errno::EINVAL, "invalid file flags"))?,
             block_ptrs: inode.block_ptrs,
@@ -2199,7 +2203,7 @@ impl InodeDesc {
             mtime: now,
             dtime: Duration::ZERO,
             hard_links: 1,
-            sector_count: 0,
+            occupied_sectors_count: 0,
             flags: FileFlags::empty(),
             block_ptrs: BlockPtrs::default(),
             acl: Bid::new(0),
@@ -2207,13 +2211,10 @@ impl InodeDesc {
     }
 
     pub fn num_page_bytes(&self) -> usize {
-        (self.blocks_count() as usize) * BLOCK_SIZE
+        (self.size_in_blocks() as usize) * BLOCK_SIZE
     }
 
-    /// Returns the actual number of blocks utilized, excluding the indirect blocks.
-    ///
-    /// Ext2 allows the `block_count` to exceed the actual number of blocks utilized.
-    pub fn blocks_count(&self) -> Ext2Bid {
+    pub fn size_in_blocks(&self) -> Ext2Bid {
         if self.is_fast_symlink() {
             return 0;
         }
@@ -2242,17 +2243,18 @@ impl InodeDesc {
         let old_acl_sectors = self.acl_sectors();
         self.acl = bid;
         let new_acl_sectors = self.acl_sectors();
-        self.sector_count = self.sector_count - old_acl_sectors + new_acl_sectors;
+        self.occupied_sectors_count =
+            self.occupied_sectors_count - old_acl_sectors + new_acl_sectors;
     }
 
     /// Returns the number of data sectors, including the indirect blocks.
     fn data_sectors(&self) -> u32 {
-        self.sector_count - self.acl_sectors()
+        self.occupied_sectors_count - self.acl_sectors()
     }
 
     /// Sets the number of data blocks, including the indirect blocks.
     fn set_data_blocks(&mut self, block_count: u32) {
-        self.sector_count = blocks_to_sectors(block_count) + self.acl_sectors();
+        self.occupied_sectors_count = blocks_to_sectors(block_count) + self.acl_sectors();
     }
 
     /// Returns whether the inode is a fast symlink.
@@ -2263,8 +2265,8 @@ impl InodeDesc {
     }
 }
 
-fn sectors_to_blocks(sector_count: u32) -> Ext2Bid {
-    sector_count.div_ceil((BLOCK_SIZE / SECTOR_SIZE) as u32)
+fn sectors_to_blocks(sectors_count: u32) -> Ext2Bid {
+    sectors_count.div_ceil((BLOCK_SIZE / SECTOR_SIZE) as u32)
 }
 
 fn blocks_to_sectors(block_count: u32) -> u32 {
@@ -2377,7 +2379,7 @@ pub(super) struct RawInode {
     /// Low 16 bits of Group Id.
     pub gid: u16,
     pub hard_links: u16,
-    pub sector_count: u32,
+    pub occupied_sectors_count: u32,
     /// File flags.
     pub flags: u32,
     /// OS dependent Value 1.
@@ -2411,7 +2413,7 @@ impl From<&InodeDesc> for RawInode {
             dtime: UnixTime::from(inode.dtime),
             gid: inode.gid as u16,
             hard_links: inode.hard_links,
-            sector_count: inode.sector_count,
+            occupied_sectors_count: inode.occupied_sectors_count,
             flags: inode.flags.bits(),
             block_ptrs: inode.block_ptrs,
             file_acl: if inode.type_ == InodeType::File {

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -813,9 +813,12 @@ impl Inode {
 
     pub fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
         match mode {
+            // Punch a hole in a file by releasing the blocks associated with
+            // the given offset and length.
+            // Reference: <https://elixir.bootlin.com/linux/v6.18/source/fs/ext4/inode.c#L4376-L4487>
             FallocMode::PunchHoleKeepSize => {
                 // Make the whole operation atomic
-                let inner = self.inner.write();
+                let mut inner = self.inner.write();
 
                 let file_size = inner.file_size();
                 if offset >= file_size {
@@ -823,8 +826,36 @@ impl Inode {
                 }
                 let end_offset = file_size.min(offset + len);
 
-                // TODO: Think of a more light-weight approach
-                inner.page_cache.fill_zeros(offset..end_offset)?;
+                // Fill the partial block at the start with zero, without deallocating block.
+                if !is_block_aligned(offset) {
+                    let block_end = offset.align_up(BLOCK_SIZE);
+                    let zero_end = end_offset.min(block_end);
+                    inner.page_cache.fill_zeros(offset..zero_end)?;
+                }
+
+                // Deallocating fully aligned blocks and drop their page cache.
+                let block_aligned_start = offset.align_up(BLOCK_SIZE);
+                let block_aligned_end = end_offset.align_down(BLOCK_SIZE);
+                if block_aligned_start < block_aligned_end {
+                    let start_bid = Bid::from_offset(block_aligned_start).to_raw() as Ext2Bid;
+                    let end_bid = Bid::from_offset(block_aligned_end).to_raw() as Ext2Bid;
+                    inner.punch_hole(start_bid..end_bid)?;
+                    inner
+                        .page_cache
+                        .discard_range(block_aligned_start..block_aligned_end);
+                    inner
+                        .page_cache
+                        .pages()
+                        .decommit(block_aligned_start..block_aligned_end)?;
+                }
+
+                // Fill the partial block at the end with zero, without deallocating block.
+                if !is_block_aligned(end_offset) && end_offset > block_aligned_start {
+                    let block_start = end_offset.align_down(BLOCK_SIZE);
+                    let zero_start = block_start.max(offset);
+                    inner.page_cache.fill_zeros(zero_start..end_offset)?;
+                }
+
                 Ok(())
             }
             // We extend the compatibility here since Ext2 in Linux
@@ -999,6 +1030,10 @@ impl InodeInner {
         self.page_cache.resize(new_size)?;
         self.inode_impl.resize(new_size)?;
         Ok(())
+    }
+
+    pub fn punch_hole(&mut self, range: Range<Ext2Bid>) -> Result<()> {
+        self.inode_impl.punch_hole(range)
     }
 
     pub fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
@@ -1452,6 +1487,16 @@ impl InodeImpl {
         Ok(())
     }
 
+    /// Punch a hole in the file by deallocating blocks in the specified range.
+    ///
+    /// This makes the blocks sparse (device block ID is 0) and frees the corresponding
+    /// device blocks. The file size remains unchanged.
+    pub fn punch_hole(&mut self, range: Range<Ext2Bid>) -> Result<()> {
+        self.dealloc_range_blocks(range);
+
+        Ok(())
+    }
+
     /// Gets the device block ID for a given file block ID.
     ///
     /// Returns 0 if the block is sparse (not allocated).
@@ -1534,7 +1579,7 @@ impl InodeImpl {
         let mut current_range = range.clone();
         while !current_range.is_empty() {
             let Ok(expand_cnt) = self.try_alloc_range_blocks(current_range.clone()) else {
-                self.shrink_blocks(range.start..current_range.start);
+                self.dealloc_range_blocks(range.start..current_range.start);
                 return_errno_with_message!(Errno::ENOSPC, "can not allocate blocks");
             };
             current_range.start += expand_cnt;
@@ -1856,6 +1901,7 @@ impl InodeImpl {
             current_range.end -= free_cnt;
         }
 
+        self.desc.occupied_sectors_count -= blocks_to_sectors(range.len() as u32);
         self.last_alloc_device_bid = if range.start == 0 {
             None
         } else {
@@ -1889,6 +1935,104 @@ impl InodeImpl {
         }
 
         self.free_indirect_blocks_required_by(range.start).unwrap();
+        range.len() as Ext2Bid
+    }
+
+    /// Deallocate inode blocks in a specified range.
+    ///
+    /// After the reduction, the block count will be decreased `range.len`.
+    fn dealloc_range_blocks(&mut self, range: Range<Ext2Bid>) {
+        let mut current_range = range.clone();
+        while !current_range.is_empty() {
+            let free_cnt = self.try_dealloc_range_blocks(current_range.clone());
+            current_range.end -= free_cnt;
+        }
+
+        self.desc.occupied_sectors_count -= blocks_to_sectors(range.len() as u32);
+        self.last_alloc_device_bid = if range.start == 0 {
+            None
+        } else {
+            let last_alloc_device_range =
+                DeviceRangeReader::new(&self.block_manager, (range.start - 1)..range.start)
+                    .unwrap()
+                    .read()
+                    .unwrap();
+            last_alloc_device_range.map(|device_range| device_range.start)
+        };
+    }
+
+    /// Attempts to deallocate a range of blocks and returns the number of blocks
+    /// successfully freed.
+    ///
+    /// Note that the returned number may be less than the requested range if needs
+    /// to free the indirect blocks that are no longer required.
+    fn try_dealloc_range_blocks(&mut self, range: Range<Ext2Bid>) -> Ext2Bid {
+        // Calculates the maximum range of blocks that can be freed in this round.
+        let range = {
+            let max_cnt = (range.len() as Ext2Bid)
+                .min(BidPath::from(range.end - 1).last_lvl_idx() as Ext2Bid + 1);
+            (range.end - max_cnt)..range.end
+        };
+
+        for bid in range.clone() {
+            let bid_path = BidPath::from(bid);
+            let device_bid = self.get_device_bid(bid).unwrap();
+            if device_bid == 0 {
+                continue;
+            }
+
+            self.fs().free_blocks(device_bid..device_bid + 1).unwrap();
+            match bid_path {
+                BidPath::Direct(idx) => {
+                    let mut block_ptrs = self.block_manager.block_ptrs.write();
+                    self.desc.block_ptrs.set_direct(idx as usize, 0);
+                    block_ptrs.set_direct(idx as usize, 0);
+                }
+                BidPath::Indirect(idx) => {
+                    let block_ptrs = self.block_manager.block_ptrs.write();
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let indirect_bid = block_ptrs.indirect();
+                    let indirect_block = indirect_blocks.find_mut(indirect_bid).unwrap();
+                    indirect_block.write_bid(idx as usize, &0).unwrap();
+                }
+                BidPath::DbIndirect(lvl1_idx, lvl2_idx) => {
+                    let block_ptrs = self.block_manager.block_ptrs.write();
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let db_indirect_bid = block_ptrs.db_indirect();
+                    let db_indirect_block = indirect_blocks.find_mut(db_indirect_bid).unwrap();
+                    let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize).unwrap();
+                    if lvl1_indirect_bid != 0 {
+                        let lvl1_indirect_block =
+                            indirect_blocks.find_mut(lvl1_indirect_bid).unwrap();
+                        lvl1_indirect_block
+                            .write_bid(lvl2_idx as usize, &0)
+                            .unwrap();
+                    }
+                }
+                BidPath::TbIndirect(lvl1_idx, lvl2_idx, lvl3_idx) => {
+                    let block_ptrs = self.block_manager.block_ptrs.write();
+                    let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                    let tb_indirect_bid = block_ptrs.tb_indirect();
+                    let tb_indirect_block = indirect_blocks.find_mut(tb_indirect_bid).unwrap();
+                    let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize).unwrap();
+                    if lvl1_indirect_bid != 0 {
+                        let lvl1_indirect_block =
+                            indirect_blocks.find_mut(lvl1_indirect_bid).unwrap();
+                        let lvl2_indirect_bid =
+                            lvl1_indirect_block.read_bid(lvl2_idx as usize).unwrap();
+                        if lvl2_indirect_bid != 0 {
+                            let lvl2_indirect_block =
+                                indirect_blocks.find_mut(lvl2_indirect_bid).unwrap();
+                            lvl2_indirect_block
+                                .write_bid(lvl3_idx as usize, &0)
+                                .unwrap();
+                        }
+                    }
+                }
+            }
+        }
+        self.free_indirect_blocks_required_by(range.start).unwrap();
+
         range.len() as Ext2Bid
     }
 

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1896,12 +1896,14 @@ impl InodeImpl {
     /// After the reduction, the block count will be decreased to `range.start`.
     fn shrink_blocks(&mut self, range: Range<Ext2Bid>) {
         let mut current_range = range.clone();
+        let mut total_freed_blocks = 0;
         while !current_range.is_empty() {
-            let free_cnt = self.try_shrink_blocks(current_range.clone());
+            let (free_cnt, freed_blocks) = self.try_shrink_blocks(current_range.clone());
+            total_freed_blocks += freed_blocks;
             current_range.end -= free_cnt;
         }
 
-        self.desc.occupied_sectors_count -= blocks_to_sectors(range.len() as u32);
+        self.desc.occupied_sectors_count -= blocks_to_sectors(total_freed_blocks);
         self.last_alloc_device_bid = if range.start == 0 {
             None
         } else {
@@ -1917,9 +1919,9 @@ impl InodeImpl {
     /// Attempts to shrink a range of blocks and returns the number of blocks
     /// successfully freed.
     ///
-    /// Note that the returned number may be less than the requested range if needs
+    /// Note that the first returned number may be less than the requested range if needs
     /// to free the indirect blocks that are no longer required.
-    fn try_shrink_blocks(&mut self, range: Range<Ext2Bid>) -> Ext2Bid {
+    fn try_shrink_blocks(&mut self, range: Range<Ext2Bid>) -> (Ext2Bid, u32) {
         // Calculates the maximum range of blocks that can be freed in this round.
         let range = {
             let max_cnt = (range.len() as Ext2Bid)
@@ -1930,12 +1932,14 @@ impl InodeImpl {
         let fs = self.fs();
         let device_range_reader =
             DeviceRangeReader::new(&self.block_manager, range.clone()).unwrap();
+        let mut freed_blocks = 0u32;
         for device_range in device_range_reader {
+            freed_blocks += device_range.len() as u32;
             fs.free_blocks(device_range.clone()).unwrap();
         }
 
         self.free_indirect_blocks_required_by(range.start).unwrap();
-        range.len() as Ext2Bid
+        (range.len() as Ext2Bid, freed_blocks)
     }
 
     /// Deallocate inode blocks in a specified range.
@@ -1943,12 +1947,14 @@ impl InodeImpl {
     /// After the reduction, the block count will be decreased `range.len`.
     fn dealloc_range_blocks(&mut self, range: Range<Ext2Bid>) {
         let mut current_range = range.clone();
+        let mut total_freed_blocks = 0;
         while !current_range.is_empty() {
-            let free_cnt = self.try_dealloc_range_blocks(current_range.clone());
+            let (free_cnt, freed_blocks) = self.try_dealloc_range_blocks(current_range.clone());
+            total_freed_blocks += freed_blocks;
             current_range.end -= free_cnt;
         }
 
-        self.desc.occupied_sectors_count -= blocks_to_sectors(range.len() as u32);
+        self.desc.occupied_sectors_count -= blocks_to_sectors(total_freed_blocks);
         self.last_alloc_device_bid = if range.start == 0 {
             None
         } else {
@@ -1966,7 +1972,7 @@ impl InodeImpl {
     ///
     /// Note that the returned number may be less than the requested range if needs
     /// to free the indirect blocks that are no longer required.
-    fn try_dealloc_range_blocks(&mut self, range: Range<Ext2Bid>) -> Ext2Bid {
+    fn try_dealloc_range_blocks(&mut self, range: Range<Ext2Bid>) -> (Ext2Bid, u32) {
         // Calculates the maximum range of blocks that can be freed in this round.
         let range = {
             let max_cnt = (range.len() as Ext2Bid)
@@ -1974,6 +1980,7 @@ impl InodeImpl {
             (range.end - max_cnt)..range.end
         };
 
+        let mut freed_blocks = 0u32;
         for bid in range.clone() {
             let bid_path = BidPath::from(bid);
             let device_bid = self.get_device_bid(bid).unwrap();
@@ -1981,6 +1988,7 @@ impl InodeImpl {
                 continue;
             }
 
+            freed_blocks += 1;
             self.fs().free_blocks(device_bid..device_bid + 1).unwrap();
             match bid_path {
                 BidPath::Direct(idx) => {
@@ -2033,7 +2041,7 @@ impl InodeImpl {
         }
         self.free_indirect_blocks_required_by(range.start).unwrap();
 
-        range.len() as Ext2Bid
+        (range.len() as Ext2Bid, freed_blocks)
     }
 
     /// Frees the indirect blocks required by the specified block ID.

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -2658,7 +2658,9 @@ impl InodeDesc {
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.18/source/fs/ext2/inode.c#L48-L55>.
     fn is_fast_symlink(&self) -> bool {
-        self.type_ == InodeType::SymLink && self.data_sectors() == 0
+        self.type_ == InodeType::SymLink
+            && self.data_sectors() == 0
+            && self.size <= MAX_FAST_SYMLINK_LEN
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1443,7 +1443,7 @@ impl InodeImpl {
                     }
                     current_bid += 1;
                 }
-                self.expand_blocks(sparse_start..current_bid)?;
+                self.alloc_range_blocks(sparse_start..current_bid)?;
             } else {
                 current_bid += 1;
             }
@@ -1519,7 +1519,7 @@ impl InodeImpl {
             if new_blocks - old_blocks > self.fs().super_block().free_blocks_count() {
                 return_errno_with_message!(Errno::ENOSPC, "not enough free blocks");
             }
-            self.expand_blocks(old_blocks..new_blocks)?;
+            self.alloc_range_blocks(old_blocks..new_blocks)?;
         }
 
         // Expands the size
@@ -1527,13 +1527,13 @@ impl InodeImpl {
         Ok(())
     }
 
-    /// Expands inode blocks.
+    /// Allocate inode blocks in a specified range.
     ///
-    /// After a successful expansion, the block count will be enlarged to `range.end`.
-    fn expand_blocks(&mut self, range: Range<Ext2Bid>) -> Result<()> {
+    /// After a successful allocation, the block count will be increase `range.len`.
+    fn alloc_range_blocks(&mut self, range: Range<Ext2Bid>) -> Result<()> {
         let mut current_range = range.clone();
         while !current_range.is_empty() {
-            let Ok(expand_cnt) = self.try_expand_blocks(current_range.clone()) else {
+            let Ok(expand_cnt) = self.try_alloc_range_blocks(current_range.clone()) else {
                 self.shrink_blocks(range.start..current_range.start);
                 return_errno_with_message!(Errno::ENOSPC, "can not allocate blocks");
             };
@@ -1543,31 +1543,61 @@ impl InodeImpl {
         Ok(())
     }
 
-    /// Attempts to expand a range of blocks and returns the number of consecutive
+    fn count_required_indirect_blocks(&self, bid: Ext2Bid) -> Result<u32> {
+        let bid_path = BidPath::from(bid);
+        let block_ptrs = self.block_manager.block_ptrs.read();
+
+        match bid_path {
+            BidPath::Direct(_) => Ok(0),
+            BidPath::Indirect(_) => {
+                if block_ptrs.indirect() == 0 {
+                    Ok(1)
+                } else {
+                    Ok(0)
+                }
+            }
+            BidPath::DbIndirect(lvl1_idx, _) => {
+                if block_ptrs.db_indirect() == 0 {
+                    return Ok(2);
+                }
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let db_indirect_block = indirect_blocks.find(block_ptrs.db_indirect())?;
+                let lvl1_indirect_bid = db_indirect_block.read_bid(lvl1_idx as usize).unwrap_or(0);
+                if lvl1_indirect_bid == 0 { Ok(1) } else { Ok(0) }
+            }
+            BidPath::TbIndirect(lvl1_idx, lvl2_idx, _) => {
+                if block_ptrs.tb_indirect() == 0 {
+                    return Ok(3);
+                }
+                let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+                let tb_indirect_block = indirect_blocks.find(block_ptrs.tb_indirect())?;
+                let lvl1_indirect_bid = tb_indirect_block.read_bid(lvl1_idx as usize).unwrap_or(0);
+                if lvl1_indirect_bid == 0 {
+                    return Ok(2);
+                }
+                let lvl2_indirect_bid = indirect_blocks
+                    .find(lvl1_indirect_bid)?
+                    .read_bid(lvl2_idx as usize)
+                    .unwrap_or(0);
+                if lvl2_indirect_bid == 0 { Ok(1) } else { Ok(0) }
+            }
+        }
+    }
+
+    /// Attempts to allocate a range of blocks and returns the number of consecutive
     /// blocks successfully allocated.
     ///
     /// Note that the returned number may be less than the requested range if there
     /// isn't enough consecutive space available or if there is a necessity to allocate
     /// indirect blocks.
-    fn try_expand_blocks(&mut self, range: Range<Ext2Bid>) -> Result<Ext2Bid> {
+    fn try_alloc_range_blocks(&mut self, range: Range<Ext2Bid>) -> Result<Ext2Bid> {
         // Calculates the maximum number of consecutive blocks that can be allocated in
         // this round, as well as the number of additional indirect blocks required for
         // the allocation.
         let (max_cnt, indirect_cnt) = {
             let bid_path = BidPath::from(range.start);
             let max_cnt = (range.len() as Ext2Bid).min(bid_path.cnt_to_next_indirect());
-            let indirect_cnt = match bid_path {
-                BidPath::Direct(_) => 0,
-                BidPath::Indirect(0) => 1,
-                BidPath::Indirect(_) => 0,
-                BidPath::DbIndirect(0, 0) => 2,
-                BidPath::DbIndirect(_, 0) => 1,
-                BidPath::DbIndirect(_, _) => 0,
-                BidPath::TbIndirect(0, 0, 0) => 3,
-                BidPath::TbIndirect(_, 0, 0) => 2,
-                BidPath::TbIndirect(_, _, 0) => 1,
-                BidPath::TbIndirect(_, _, _) => 0,
-            };
+            let indirect_cnt = self.count_required_indirect_blocks(range.start)?;
             (max_cnt, indirect_cnt)
         };
 
@@ -1589,9 +1619,9 @@ impl InodeImpl {
                 self.fs().free_blocks(device_range).unwrap();
                 return Err(e);
             }
+            self.desc.occupied_sectors_count += blocks_to_sectors(device_range.len() as u32);
             self.last_alloc_device_bid = Some(device_range.end - 1);
             let nr_blocks = device_range.len() as Ext2Bid;
-            self.desc.set_data_blocks(range.start + nr_blocks);
             return Ok(nr_blocks);
         }
 
@@ -1636,9 +1666,9 @@ impl InodeImpl {
             return Err(e);
         }
 
+        self.desc.occupied_sectors_count += blocks_to_sectors(device_range.len() as u32);
         self.last_alloc_device_bid = Some(device_range.end - 1);
         let nr_blocks = device_range.len() as Ext2Bid;
-        self.desc.set_data_blocks(range.start + nr_blocks);
         Ok(nr_blocks)
     }
 
@@ -1714,52 +1744,79 @@ impl InodeImpl {
         let bid_path = BidPath::from(bid);
         let mut block_ptrs = self.block_manager.block_ptrs.write();
         let mut indirect_blocks = self.block_manager.indirect_blocks.write();
+
         for indirect_bid in indirect_bids.iter() {
             let indirect_block = IndirectBlock::alloc()?;
             indirect_blocks.insert(*indirect_bid, indirect_block)?;
+        }
 
-            match bid_path {
-                BidPath::Indirect(idx) => {
-                    assert_eq!(idx, 0);
-                    self.desc.block_ptrs.set_indirect(*indirect_bid);
-                    block_ptrs.set_indirect(*indirect_bid);
-                }
-                BidPath::DbIndirect(lvl1_idx, lvl2_idx) => {
-                    assert_eq!(lvl2_idx, 0);
-                    if self.desc.block_ptrs.db_indirect() == 0 {
-                        self.desc.block_ptrs.set_db_indirect(*indirect_bid);
-                        block_ptrs.set_db_indirect(*indirect_bid);
-                    } else {
-                        let db_indirect_block =
-                            indirect_blocks.find_mut(self.desc.block_ptrs.db_indirect())?;
-                        db_indirect_block.write_bid(lvl1_idx as usize, indirect_bid)?;
-                    }
-                }
-                BidPath::TbIndirect(lvl1_idx, lvl2_idx, lvl3_idx) => {
-                    assert_eq!(lvl3_idx, 0);
-                    if self.desc.block_ptrs.tb_indirect() == 0 {
-                        self.desc.block_ptrs.set_tb_indirect(*indirect_bid);
-                        block_ptrs.set_tb_indirect(*indirect_bid);
-                    } else {
-                        let lvl1_indirect_bid = {
-                            let tb_indirect_block =
-                                indirect_blocks.find(self.desc.block_ptrs.tb_indirect())?;
-                            tb_indirect_block.read_bid(lvl1_idx as usize)?
-                        };
-
-                        if lvl1_indirect_bid == 0 {
-                            let tb_indirect_block =
-                                indirect_blocks.find_mut(self.desc.block_ptrs.tb_indirect())?;
-                            tb_indirect_block.write_bid(lvl1_idx as usize, indirect_bid)?;
-                        } else {
-                            let lvl1_indirect_block =
-                                indirect_blocks.find_mut(lvl1_indirect_bid)?;
-                            lvl1_indirect_block.write_bid(lvl2_idx as usize, indirect_bid)?;
-                        }
-                    }
-                }
-                BidPath::Direct(_) => panic!(),
+        match bid_path {
+            BidPath::Indirect(idx) => {
+                assert_eq!(indirect_bids.len(), 1);
+                self.desc.block_ptrs.set_indirect(indirect_bids[0]);
+                block_ptrs.set_indirect(indirect_bids[0]);
             }
+            BidPath::DbIndirect(lvl1_idx, _) => {
+                let mut bid_idx = 0;
+                if self.desc.block_ptrs.db_indirect() == 0 {
+                    self.desc.block_ptrs.set_db_indirect(indirect_bids[bid_idx]);
+                    block_ptrs.set_db_indirect(indirect_bids[bid_idx]);
+                    bid_idx += 1;
+                }
+
+                if bid_idx == 1 {
+                    assert!(indirect_bids.len() == 2);
+                } else {
+                    assert!(indirect_bids.len() == 1);
+                }
+
+                let db_indirect_block =
+                    indirect_blocks.find_mut(self.desc.block_ptrs.db_indirect())?;
+                db_indirect_block.write_bid(lvl1_idx as usize, &indirect_bids[bid_idx])?;
+            }
+            BidPath::TbIndirect(lvl1_idx, lvl2_idx, _) => {
+                let mut bid_idx = 0;
+                let tb_indirect_not_alloc = self.desc.block_ptrs.tb_indirect() == 0;
+                if tb_indirect_not_alloc {
+                    self.desc.block_ptrs.set_tb_indirect(indirect_bids[bid_idx]);
+                    block_ptrs.set_tb_indirect(indirect_bids[bid_idx]);
+                    bid_idx += 1;
+                }
+
+                if bid_idx == 1 {
+                    assert!(indirect_bids.len() == 3);
+                }
+
+                // If upper level indirect bid is zero, then the lower level
+                // one should be treated as zero (not allocated) as well.
+                let lvl1_indirect_bid = if tb_indirect_not_alloc {
+                    0
+                } else {
+                    let tb_indirect_block =
+                        indirect_blocks.find(self.desc.block_ptrs.tb_indirect())?;
+                    tb_indirect_block.read_bid(lvl1_idx as usize)?
+                };
+                let lvl1_indirect_bid = if lvl1_indirect_bid == 0 {
+                    let tb_indirect_block =
+                        indirect_blocks.find_mut(self.desc.block_ptrs.tb_indirect())?;
+                    tb_indirect_block.write_bid(lvl1_idx as usize, &indirect_bids[bid_idx])?;
+                    let bid = indirect_bids[bid_idx];
+                    bid_idx += 1;
+                    bid
+                } else {
+                    lvl1_indirect_bid
+                };
+
+                if bid_idx == 1 {
+                    assert!(indirect_bids.len() == 2);
+                } else {
+                    assert!(indirect_bids.len() == 1);
+                }
+
+                let lvl1_indirect_block = indirect_blocks.find_mut(lvl1_indirect_bid)?;
+                lvl1_indirect_block.write_bid(lvl2_idx as usize, &indirect_bids[bid_idx])?;
+            }
+            BidPath::Direct(_) => panic!(),
         }
 
         Ok(())
@@ -1799,7 +1856,6 @@ impl InodeImpl {
             current_range.end -= free_cnt;
         }
 
-        self.desc.set_data_blocks(range.start);
         self.last_alloc_device_bid = if range.start == 0 {
             None
         } else {
@@ -2448,11 +2504,6 @@ impl InodeDesc {
     /// Returns the number of data sectors, including the indirect blocks.
     fn data_sectors(&self) -> u32 {
         self.occupied_sectors_count - self.acl_sectors()
-    }
-
-    /// Sets the number of data blocks, including the indirect blocks.
-    fn set_data_blocks(&mut self, block_count: u32) {
-        self.occupied_sectors_count = blocks_to_sectors(block_count) + self.acl_sectors();
     }
 
     /// Returns whether the inode is a fast symlink.

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1093,8 +1093,14 @@ impl InodeInner {
         let write_len = reader.remain();
         let new_size = offset + write_len;
         self.page_cache.resize(new_size.align_up(BLOCK_SIZE))?;
+
+        // Only allocate blocks for the content being written, for creating sparse blocks
+        let start_bid = Bid::from_offset(offset).to_raw() as Ext2Bid;
+        let end_bid = Bid::from_offset(new_size.align_up(BLOCK_SIZE)).to_raw() as Ext2Bid;
+        self.inode_impl.alloc_range_blocks(start_bid..end_bid)?;
+
         self.page_cache.pages().write(offset, reader)?;
-        self.inode_impl.resize(new_size)?;
+        self.inode_impl.update_size(new_size);
         Ok(write_len)
     }
 

--- a/test/initramfs/src/apps/fs/ext2/sparse_file.c
+++ b/test/initramfs/src/apps/fs/ext2/sparse_file.c
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <linux/fs.h>
+#include <sys/stat.h>
+#include "../../common/test.h"
+
+#define TEST_FILE_PATH "/ext2/test_sparse_file"
+#define TEST_BLOCK_SIZE 4096
+
+static int check_all_pattern(const void *buf, size_t len, unsigned char pattern)
+{
+	const unsigned char *p = buf;
+	for (size_t i = 0; i < len; i++) {
+		if (p[i] != pattern) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static int check_all_zeros(const void *buf, size_t len)
+{
+	return check_all_pattern(buf, len, 0);
+}
+
+static off_t allocated_bytes(const struct stat *stat_buf)
+{
+	return stat_buf->st_blocks * 512;
+}
+
+// Create sparse blocks by lseek beyond EOF and read should return zeros
+FN_TEST(lseek_create_sparse_blocks)
+{
+	int fd = TEST_SUCC(
+		open(TEST_FILE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644));
+
+	// Write some data at the beginning
+	char write_buf[128] = "Hello, sparse file!";
+	TEST_RES(write(fd, write_buf, sizeof(write_buf)),
+		 _ret == sizeof(write_buf));
+
+	// Seek far beyond the current file size to create sparse blocks
+	off_t new_offset = 16 * 1024; // 16KB offset
+	off_t result = TEST_SUCC(lseek(fd, new_offset, SEEK_SET));
+	TEST_RES(result, _ret == new_offset);
+
+	// Write more data at the new position - this creates a sparse file
+	char write_buf2[64] = "Data after sparse area";
+	TEST_RES(write(fd, write_buf2, sizeof(write_buf2)),
+		 _ret == sizeof(write_buf2));
+	TEST_SUCC(fsync(fd));
+
+	// Get the file size
+	off_t file_size = TEST_SUCC(lseek(fd, 0, SEEK_END));
+	TEST_RES(file_size, _ret == new_offset + sizeof(write_buf2));
+	struct stat stat_buf;
+	TEST_SUCC(fstat(fd, &stat_buf));
+	TEST_RES(allocated_bytes(&stat_buf), _ret < stat_buf.st_size);
+
+	// Read from the beginning - should get original data
+	TEST_SUCC(lseek(fd, 0, SEEK_SET));
+	char read_buf[128] = { 0 };
+	TEST_RES(read(fd, read_buf, sizeof(read_buf)),
+		 _ret == sizeof(read_buf) &&
+			 memcmp(read_buf, write_buf, sizeof(write_buf)) == 0);
+
+	// Read from the sparse area - should get all zeros
+	TEST_SUCC(lseek(fd, 512, SEEK_SET)); // Position in the sparse area
+	char sparse_buf[512] = { 0 };
+	TEST_RES(read(fd, sparse_buf, sizeof(sparse_buf)),
+		 _ret == sizeof(sparse_buf) &&
+			 check_all_zeros(sparse_buf, sizeof(sparse_buf)));
+
+	// Read the data after the sparse area
+	TEST_SUCC(lseek(fd, new_offset, SEEK_SET));
+	char read_buf2[64] = { 0 };
+	TEST_RES(read(fd, read_buf2, sizeof(read_buf2)),
+		 _ret == sizeof(read_buf2) && memcmp(read_buf2, write_buf2,
+						     sizeof(write_buf2)) == 0);
+
+	// Clean up
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE_PATH));
+}
+END_TEST()
+
+// Punch hole with fallocate
+FN_TEST(fallocate_punch_hole)
+{
+	int fd = TEST_SUCC(
+		open(TEST_FILE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644));
+
+	// Write data to multiple blocks
+	char data[TEST_BLOCK_SIZE * 4];
+	memset(data, 'A', sizeof(data));
+	TEST_RES(write(fd, data, sizeof(data)), _ret == sizeof(data));
+
+	// Sync to ensure data is written
+	TEST_SUCC(fsync(fd));
+	struct stat stat_buf;
+	TEST_SUCC(fstat(fd, &stat_buf));
+	blkcnt_t blocks_before_punch = stat_buf.st_blocks;
+
+	// Punch a hole in the middle two blocks (offset 4096, length 8192)
+	off_t punch_offset = TEST_BLOCK_SIZE;
+	off_t punch_len = TEST_BLOCK_SIZE * 2;
+	TEST_SUCC(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+			    punch_offset, punch_len));
+	TEST_SUCC(fsync(fd));
+	TEST_SUCC(fstat(fd, &stat_buf));
+	TEST_RES(stat_buf.st_blocks,
+		 _ret < blocks_before_punch &&
+			 allocated_bytes(&stat_buf) + punch_len <=
+				 sizeof(data));
+
+	// File size should remain the same
+	off_t file_size = TEST_SUCC(lseek(fd, 0, SEEK_END));
+	TEST_RES(file_size, _ret == sizeof(data));
+
+	// Read from the punched hole area - should get zeros
+	TEST_SUCC(lseek(fd, punch_offset, SEEK_SET));
+	char hole_buf[punch_len];
+	TEST_RES(read(fd, hole_buf, sizeof(hole_buf)),
+		 _ret == sizeof(hole_buf) &&
+			 check_all_zeros(hole_buf, sizeof(hole_buf)));
+
+	// First block should still have data
+	TEST_SUCC(lseek(fd, 0, SEEK_SET));
+	char first_block[TEST_BLOCK_SIZE];
+	TEST_RES(read(fd, first_block, sizeof(first_block)),
+		 _ret == sizeof(first_block) &&
+			 check_all_pattern(first_block, sizeof(first_block),
+					   'A'));
+
+	// Last block should still have data
+	TEST_SUCC(lseek(fd, TEST_BLOCK_SIZE * 3, SEEK_SET));
+	char last_block[TEST_BLOCK_SIZE];
+	TEST_RES(read(fd, last_block, sizeof(last_block)),
+		 _ret == sizeof(last_block) &&
+			 check_all_pattern(last_block, sizeof(last_block),
+					   'A'));
+
+	// Clean up
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE_PATH));
+}
+END_TEST()
+
+// Write to sparse block should allocate and persist data
+FN_TEST(write_to_sparse_block)
+{
+	int fd = TEST_SUCC(
+		open(TEST_FILE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644));
+
+	// Create a sparse file by seeking beyond EOF
+	off_t sparse_offset = 32 * 1024; // 32KB
+	TEST_SUCC(lseek(fd, sparse_offset, SEEK_SET));
+
+	// Write data to the sparse area
+	char write_data[512] = "Data written to sparse block";
+	TEST_RES(write(fd, write_data, sizeof(write_data)),
+		 _ret == sizeof(write_data));
+
+	// Sync to ensure data is written
+	TEST_SUCC(fsync(fd));
+	struct stat stat_buf;
+	TEST_SUCC(fstat(fd, &stat_buf));
+	blkcnt_t blocks_before_reopen = stat_buf.st_blocks;
+	TEST_RES(allocated_bytes(&stat_buf), _ret < stat_buf.st_size);
+
+	// Read back the written data
+	TEST_SUCC(lseek(fd, sparse_offset, SEEK_SET));
+	char read_data[512] = { 0 };
+	TEST_RES(read(fd, read_data, sizeof(read_data)),
+		 _ret == sizeof(read_data) && memcmp(read_data, write_data,
+						     sizeof(write_data)) == 0);
+
+	// Read from the sparse area before the written data - should be zeros
+	TEST_SUCC(lseek(fd, TEST_BLOCK_SIZE, SEEK_SET));
+	char sparse_buf[512] = { 0 };
+	TEST_RES(read(fd, sparse_buf, sizeof(sparse_buf)),
+		 _ret == sizeof(sparse_buf) &&
+			 check_all_zeros(sparse_buf, sizeof(sparse_buf)));
+
+	// Close and reopen to verify persistence
+	TEST_SUCC(close(fd));
+	fd = TEST_SUCC(open(TEST_FILE_PATH, O_RDONLY, 0644));
+	TEST_SUCC(fstat(fd, &stat_buf));
+	TEST_RES(stat_buf.st_blocks,
+		 _ret == blocks_before_reopen &&
+			 allocated_bytes(&stat_buf) < stat_buf.st_size);
+
+	// Verify the data is still there after reopening
+	TEST_SUCC(lseek(fd, sparse_offset, SEEK_SET));
+	memset(read_data, 0, sizeof(read_data));
+	TEST_RES(read(fd, read_data, sizeof(read_data)),
+		 _ret == sizeof(read_data) && memcmp(read_data, write_data,
+						     sizeof(write_data)) == 0);
+
+	// Clean up
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE_PATH));
+}
+END_TEST()
+
+// Truncate sparse file
+FN_TEST(truncate_sparse_file)
+{
+	int fd = TEST_SUCC(
+		open(TEST_FILE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644));
+
+	// Create a sparse file
+	TEST_SUCC(lseek(fd, 64 * 1024, SEEK_SET)); // 64KB
+	char data[128] = "End of sparse file";
+	TEST_RES(write(fd, data, sizeof(data)), _ret == sizeof(data));
+	TEST_SUCC(fsync(fd));
+
+	off_t original_size = TEST_SUCC(lseek(fd, 0, SEEK_END));
+	TEST_RES(original_size, _ret == 64 * 1024 + sizeof(data));
+
+	// Truncate to smaller size (should cut off the end)
+	off_t new_size = 32 * 1024;
+	TEST_SUCC(ftruncate(fd, new_size));
+
+	off_t truncated_size = TEST_SUCC(lseek(fd, 0, SEEK_END));
+	TEST_RES(truncated_size, _ret == new_size);
+	struct stat stat_buf;
+	TEST_SUCC(fstat(fd, &stat_buf));
+	blkcnt_t blocks_after_shrink = stat_buf.st_blocks;
+	TEST_RES(allocated_bytes(&stat_buf), _ret < truncated_size);
+
+	// Read from truncated area - should get zeros (sparse)
+	TEST_SUCC(lseek(fd, new_size - 512, SEEK_SET));
+	char buf[512] = { 0 };
+	TEST_RES(read(fd, buf, sizeof(buf)),
+		 _ret == sizeof(buf) && check_all_zeros(buf, sizeof(buf)));
+
+	// Truncate to larger size (should extend with zeros)
+	new_size = 128 * 1024;
+	TEST_SUCC(ftruncate(fd, new_size));
+
+	truncated_size = TEST_SUCC(lseek(fd, 0, SEEK_END));
+	TEST_RES(truncated_size, _ret == new_size);
+	TEST_SUCC(fstat(fd, &stat_buf));
+	TEST_RES(stat_buf.st_blocks,
+		 _ret == blocks_after_shrink &&
+			 allocated_bytes(&stat_buf) < truncated_size);
+
+	// Read from newly extended sparse area - should be zeros
+	TEST_SUCC(lseek(fd, 100 * 1024, SEEK_SET));
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(read(fd, buf, sizeof(buf)),
+		 _ret == sizeof(buf) && check_all_zeros(buf, sizeof(buf)));
+
+	// Clean up
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE_PATH));
+}
+END_TEST()

--- a/test/initramfs/src/apps/fs/run_test.sh
+++ b/test/initramfs/src/apps/fs/run_test.sh
@@ -88,6 +88,7 @@ test_mount_bind_file() {
 echo "Start ext2 fs test......"
 test_ext2 "/ext2" "test_file.txt"
 ./ext2/mknod
+./ext2/sparse_file
 ./ext2/unix_socket
 echo "All ext2 fs test passed."
 


### PR DESCRIPTION
Closes #2776
Closes #2807 
Closes #2872
Closes #2871 

TODO list:
- [x] Fix issues caused by deleting sparse files.
- [x] Reading sparse block will return 0 directly.
- [x] Writing to sparse block will dynamically allocate disk blocks.
- [x] Support `fallocate`'s `PunchHoleKeepSize`(Current implementation just fill zeros, which will occupy disk spaces).
- [x] Support sparse block creation with `lseek`.
- [x] Expand a file size by `ftruncate` adds sparse blocks.
- [ ] ...