### PR TITLE
Fix permission validation in mprotect and mmap

### DIFF
--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -22,7 +22,7 @@ pub fn sys_mmap(
     offset: u64,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let perms = VmPerms::from_bits_truncate(perms as u32);
+    let perms = VmPerms::from_user_bits_truncate(perms as u32);
     let option = MMapOptions::try_from(flags as u32)?;
     let res = do_sys_mmap(
         addr as usize,

--- a/kernel/src/syscall/mprotect.rs
+++ b/kernel/src/syscall/mprotect.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub fn sys_mprotect(addr: Vaddr, len: usize, perms: u64, ctx: &Context) -> Result<SyscallReturn> {
-    let vm_perms = VmPerms::from_bits_truncate(perms as u32);
+    let vm_perms = VmPerms::from_user_bits(perms as u32)?;
     debug!(
         "addr = 0x{:x}, len = 0x{:x}, perms = {:?}",
         addr, len, vm_perms

--- a/kernel/src/vm/perms.rs
+++ b/kernel/src/vm/perms.rs
@@ -42,6 +42,24 @@ impl VmPerms {
 
         Ok(())
     }
+
+    /// Parses `bits` as requested permissions from user programs and returns errors
+    /// if there are unknown permissions.
+    pub fn from_user_bits(bits: u32) -> Result<Self> {
+        if let Some(vm_perms) = VmPerms::from_bits(bits)
+            && Self::ALL_PERMS.contains(vm_perms)
+        {
+            Ok(vm_perms)
+        } else {
+            return_errno_with_message!(Errno::EINVAL, "invalid permissions");
+        }
+    }
+
+    /// Parses `bits` as requested permissions from user programs and ignores any
+    /// unknown permissions.
+    pub fn from_user_bits_truncate(bits: u32) -> Self {
+        VmPerms::from_bits_truncate(bits) & Self::ALL_PERMS
+    }
 }
 
 impl From<Rights> for VmPerms {

--- a/test/initramfs/src/apps/mmap/mmap_and_mprotect.c
+++ b/test/initramfs/src/apps/mmap/mmap_and_mprotect.c
@@ -22,10 +22,10 @@ FN_TEST(mprotect_shared_writable_mapping_on_read_only_file)
 	fd = TEST_SUCC(open(filename, O_RDONLY));
 
 	char *addr =
-		CHECK_WITH(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0),
-			   _ret != MAP_FAILED);
+		TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0));
 	TEST_ERRNO(mprotect(addr, PAGE_SIZE, PROT_READ | PROT_WRITE), EACCES);
 
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
 	TEST_SUCC(close(fd));
 	TEST_SUCC(unlink(filename));
 }
@@ -38,11 +38,9 @@ FN_TEST(mprotect_private_writable_mapping_copy_on_write)
 	TEST_SUCC(write(fd, "AAAA", 5));
 
 	char *addr1 =
-		CHECK_WITH(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0),
-			   _ret != MAP_FAILED);
+		TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0));
 	char *addr2 =
-		CHECK_WITH(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0),
-			   _ret != MAP_FAILED);
+		TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0));
 	TEST_RES(strcmp(addr1, "AAAA"), _ret == 0);
 	TEST_RES(strcmp(addr2, "AAAA"), _ret == 0);
 	TEST_SUCC(mprotect(addr1, PAGE_SIZE, PROT_READ | PROT_WRITE));
@@ -50,7 +48,24 @@ FN_TEST(mprotect_private_writable_mapping_copy_on_write)
 	TEST_RES(strcmp(addr1, "BBBB"), _ret == 0);
 	TEST_RES(strcmp(addr2, "AAAA"), _ret == 0);
 
+	TEST_SUCC(munmap(addr1, PAGE_SIZE));
+	TEST_SUCC(munmap(addr2, PAGE_SIZE));
 	TEST_SUCC(close(fd));
 	TEST_SUCC(unlink(filename));
+}
+END_TEST()
+
+FN_TEST(mprotect_invalid_permission)
+{
+#define PROT_INVALID 0x20
+
+	void *addr = TEST_SUCC(mmap(NULL, PAGE_SIZE,
+				    PROT_READ | PROT_WRITE | PROT_INVALID,
+				    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+
+	TEST_SUCC(mprotect(addr, PAGE_SIZE, PROT_READ | PROT_EXEC));
+	TEST_ERRNO(mprotect(addr, PAGE_SIZE, PROT_READ | PROT_INVALID), EINVAL);
+
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
 }
 END_TEST()


### PR DESCRIPTION
Add permission check in `mprotect` according to https://github.com/asterinas/asterinas/pull/2918#discussion_r2721470506

Refer:
https://github.com/torvalds/linux/blob/d91a46d6805af41e7f2286e0fc22d498f45a682b/include/linux/mman.h#L106-L109
```C
static inline bool arch_validate_prot(unsigned long prot, unsigned long addr)
{
	return (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC | PROT_SEM)) == 0;
}
```
https://github.com/torvalds/linux/blob/d91a46d6805af41e7f2286e0fc22d498f45a682b/mm/mprotect.c#L827-L828
```C
	if (!arch_validate_prot(prot, start))
		return -EINVAL;
```