### PR TITLE
Add `/proc/mounts` support and expose mount sources in mountinfo

### DIFF
--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -36,7 +36,12 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
 
     // Mount devtmpfs.
     let dev_path = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
-    dev_path.mount(RamFs::new(), PerMountFlags::default(), ctx)?;
+    dev_path.mount(
+        RamFs::new(),
+        PerMountFlags::default(),
+        Some("ramfs".to_string()),
+        ctx,
+    )?;
 
     tty::init_in_first_process()?;
     pty::init_in_first_process(&path_resolver, ctx)?;

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -24,7 +24,12 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     let dev = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
     // Create the "pts" directory and mount devpts on it.
     let devpts_path = dev.new_fs_child("pts", InodeType::Dir, mkmod!(a+rx, u+w))?;
-    let devpts_mount = devpts_path.mount(DevPts::new(), PerMountFlags::default(), ctx)?;
+    let devpts_mount = devpts_path.mount(
+        DevPts::new(),
+        PerMountFlags::default(),
+        Some("devpts".to_string()),
+        ctx,
+    )?;
 
     DEV_PTS.call_once(|| Path::new_fs_root(devpts_mount));
 

--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -18,7 +18,12 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     // Create the "shm" directory under "/dev" and mount a ramfs on it.
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, chmod!(InodeMode::S_ISVTX, a+rwx))?;
-    shm_path.mount(RamFs::new(), PerMountFlags::default(), ctx)?;
+    shm_path.mount(
+        RamFs::new(),
+        PerMountFlags::default(),
+        Some("tmpfs".to_string()),
+        ctx,
+    )?;
     log::debug!("Mount RamFs at \"/dev/shm\"");
     Ok(())
 }

--- a/kernel/src/fs/path/dentry.rs
+++ b/kernel/src/fs/path/dentry.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// A `Dentry` represents a cached filesystem node in the VFS tree.
-pub(super) struct Dentry {
+pub(in crate::fs) struct Dentry {
     inode: Arc<dyn Inode>,
     type_: InodeType,
     name_and_parent: NameAndParent,
@@ -203,7 +203,7 @@ impl Dentry {
     }
 
     /// Gets the absolute path name of this `Dentry` within the filesystem.
-    pub(super) fn path_name(&self) -> String {
+    pub(in crate::fs) fn path_name(&self) -> String {
         let mut path_name = self.name().to_string();
         let mut current_dir = self.this();
 

--- a/kernel/src/fs/path/mod.rs
+++ b/kernel/src/fs/path/mod.rs
@@ -78,13 +78,18 @@ impl Path {
         Self::new(mount, dentry)
     }
 
-    fn new(mount: Arc<Mount>, dentry: Arc<Dentry>) -> Self {
+    pub(in crate::fs) fn new(mount: Arc<Mount>, dentry: Arc<Dentry>) -> Self {
         Self { mount, dentry }
     }
 
     /// Gets the mount node of current `Path`.
     pub fn mount_node(&self) -> &Arc<Mount> {
         &self.mount
+    }
+
+    /// Gets the dentry of current `Path`.
+    pub(in crate::fs) fn dentry(&self) -> &Arc<Dentry> {
+        &self.dentry
     }
 
     /// Returns true if the current `Path` is the root of its mount.
@@ -203,6 +208,7 @@ impl Path {
         &self,
         fs: Arc<dyn FileSystem>,
         flags: PerMountFlags,
+        source: Option<String>,
         ctx: &Context,
     ) -> Result<Arc<Mount>> {
         if self.type_() != InodeType::Dir {
@@ -222,7 +228,7 @@ impl Path {
             return_errno_with_message!(Errno::EINVAL, "the path is not in this mount namespace");
         }
 
-        let child_mount = self.mount.do_mount(fs, flags, &self.dentry)?;
+        let child_mount = self.mount.do_mount(fs, flags, &self.dentry, source)?;
 
         Ok(child_mount)
     }

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -11,6 +11,7 @@ use self::{
     cpuinfo::CpuInfoFileOps,
     loadavg::LoadAvgFileOps,
     meminfo::MemInfoFileOps,
+    mounts::MountsSymOps,
     pid::PidDirOps,
     self_::SelfSymOps,
     sys::SysDirOps,
@@ -41,6 +42,7 @@ mod cpuinfo;
 mod filesystems;
 mod loadavg;
 mod meminfo;
+mod mounts;
 mod pid;
 mod self_;
 mod stat;
@@ -159,6 +161,7 @@ impl RootDirOps {
         ("filesystems", FileSystemsFileOps::new_inode),
         ("loadavg", LoadAvgFileOps::new_inode),
         ("meminfo", MemInfoFileOps::new_inode),
+        ("mounts", MountsSymOps::new_inode),
         ("self", SelfSymOps::new_inode),
         ("stat", StatFileOps::new_inode),
         ("sys", SysDirOps::new_inode),

--- a/kernel/src/fs/procfs/mounts.rs
+++ b/kernel/src/fs/procfs/mounts.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::{
+        procfs::{ProcSymBuilder, SymOps},
+        utils::{Inode, SymbolicLink, mkmod},
+    },
+    prelude::*,
+};
+
+/// Represents the inode at `/proc/mounts`.
+pub struct MountsSymOps;
+
+impl MountsSymOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/root.c#L291>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L466>
+        ProcSymBuilder::new(Self, mkmod!(a+rwx))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl SymOps for MountsSymOps {
+    fn read_link(&self) -> Result<SymbolicLink> {
+        Ok(SymbolicLink::Plain("self/mounts".to_string()))
+    }
+}

--- a/kernel/src/fs/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/procfs/pid/task/mod.rs
@@ -12,8 +12,8 @@ use crate::{
                 cgroup::CgroupFileOps, cmdline::CmdlineFileOps, comm::CommFileOps,
                 environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps, gid_map::GidMapFileOps,
                 maps::MapsFileOps, mem::MemFileOps, mountinfo::MountInfoFileOps,
-                oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps, status::StatusFileOps,
-                uid_map::UidMapFileOps,
+                mounts::MountsFileOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
+                status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 DirOps, ProcDir, ProcDirBuilder, lookup_child_from_table,
@@ -37,6 +37,7 @@ mod gid_map;
 mod maps;
 mod mem;
 mod mountinfo;
+mod mounts;
 mod oom_score_adj;
 mod stat;
 mod status;
@@ -115,6 +116,7 @@ impl TidDirOps {
         ("status", StatusFileOps::new_inode),
         ("uid_map", UidMapFileOps::new_inode),
         ("maps", MapsFileOps::new_inode),
+        ("mounts", MountsFileOps::new_inode),
     ];
 }
 

--- a/kernel/src/fs/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/procfs/pid/task/mountinfo.rs
@@ -1,14 +1,83 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_util::printer::VmPrinter;
+
 use super::TidDirOps;
 use crate::{
     fs::{
+        path::{Mount, Path, PathResolver, PerMountFlags},
         procfs::template::{FileOps, ProcFileBuilder},
-        utils::{Inode, mkmod},
+        utils::{FsFlags, Inode, mkmod},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
 };
+
+/// A helper function to create the mount point path for a given mount (used by `mounts` and `mountinfo`).
+pub(super) fn make_mount_point_path(
+    is_resolver_root_mount: bool,
+    parent: Option<&Arc<Mount>>,
+    mount: &Mount,
+    path_resolver: &PathResolver,
+) -> String {
+    if is_resolver_root_mount {
+        "/".to_string()
+    } else if let Some(parent) = parent {
+        if let Some(mount_point_dentry) = mount.mountpoint() {
+            path_resolver
+                .make_abs_path(&Path::new(parent.clone(), mount_point_dentry))
+                .into_string()
+        } else {
+            "".to_string()
+        }
+    } else {
+        // No parent means it's the root of the namespace.
+        "/".to_string()
+    }
+}
+
+/// A single entry in the mountinfo file.
+struct MountInfoEntry<'a> {
+    /// A unique ID for the mount (but not guaranteed to be unique across reboots).
+    mount_id: usize,
+    /// The ID of the parent mount (or self if it has no parent).
+    parent_id: usize,
+    /// The major device ID of the filesystem.
+    major: u32,
+    /// The minor device ID of the filesystem.
+    minor: u32,
+    /// The root of the mount within the filesystem.
+    root: &'a str,
+    /// The mount point relative to the process's root directory.
+    mount_point: &'a str,
+    /// Per-mount flags.
+    mount_flags: PerMountFlags,
+    /// The type of the filesystem in the form "type[.subtype]".
+    fs_type: &'a str,
+    /// Filesystem-specific information or "none".
+    source: &'a str,
+    /// Per-filesystem flags.
+    fs_flags: FsFlags,
+}
+
+impl core::fmt::Display for MountInfoEntry<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} {} {}:{} {} {} {} - {} {} {}",
+            self.mount_id,
+            self.parent_id,
+            self.major,
+            self.minor,
+            &self.root,
+            &self.mount_point,
+            &self.mount_flags,
+            &self.fs_type,
+            &self.source,
+            &self.fs_flags,
+        )
+    }
+}
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/mountinfo` (and also `/proc/[pid]/mountinfo`).
 pub struct MountInfoFileOps(TidDirOps);
@@ -21,6 +90,62 @@ impl MountInfoFileOps {
             .build()
             .unwrap()
     }
+
+    /// Reads mount information for `/proc/[pid]/mountinfo`.
+    ///
+    /// Provides detailed mount information including mount IDs, parent relationships,
+    /// and device numbers.
+    fn read_mount_info(
+        &self,
+        path_resolver: &PathResolver,
+        offset: usize,
+        writer: &mut VmWriter,
+    ) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        for mount in path_resolver.collect_visible_mounts() {
+            let mount_id = mount.id();
+            let parent = mount.parent().and_then(|parent| parent.upgrade());
+            let parent_id = parent.as_ref().map_or(mount_id, |p| p.id());
+            let is_resolver_root_mount = Arc::ptr_eq(&mount, path_resolver.root().mount_node());
+            let root = if is_resolver_root_mount {
+                path_resolver.root().dentry().path_name()
+            } else {
+                mount.root_dentry().path_name()
+            };
+            let mount_point = make_mount_point_path(
+                is_resolver_root_mount,
+                parent.as_ref(),
+                mount.as_ref(),
+                path_resolver,
+            );
+            let mount_flags = mount.flags();
+            let fs_type = mount.fs().name();
+            let source = mount.source().unwrap_or("none");
+            let fs_flags = mount.fs().flags();
+
+            // The following fields are dummy for now.
+            let major = 0;
+            let minor = 0;
+
+            let entry = MountInfoEntry {
+                mount_id,
+                parent_id,
+                major,
+                minor,
+                root: &root,
+                mount_point: &mount_point,
+                mount_flags,
+                fs_type,
+                source,
+                fs_flags,
+            };
+
+            writeln!(printer, "{}", entry)?;
+        }
+
+        Ok(printer.bytes_written())
+    }
 }
 
 impl FileOps for MountInfoFileOps {
@@ -30,7 +155,6 @@ impl FileOps for MountInfoFileOps {
 
         let fs = posix_thread.read_fs();
         let path_resolver = fs.resolver().read();
-
-        path_resolver.read_mount_info(offset, writer)
+        self.read_mount_info(&path_resolver, offset, writer)
     }
 }

--- a/kernel/src/fs/procfs/pid/task/mounts.rs
+++ b/kernel/src/fs/procfs/pid/task/mounts.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        path::{PathResolver, PerMountFlags},
+        procfs::{
+            pid::task::mountinfo::make_mount_point_path,
+            template::{FileOps, ProcFileBuilder},
+        },
+        utils::{Inode, mkmod},
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+};
+
+/// A single entry in the mounts file.
+struct MountEntry<'a> {
+    /// Filesystem-specific information or "none".
+    source: &'a str,
+    /// Mount point relative to the process's root directory.
+    mount_point: &'a str,
+    /// The type of the filesystem in the form "type[.subtype]".
+    fs_type: &'a str,
+    /// Per-mount flags.
+    mount_flags: PerMountFlags,
+    /// The dump field is used by the dump(8) program to determine which
+    /// filesystems need to be dumped.
+    dump: u32,
+    /// The fsck(8) program uses this field.
+    pass: u32,
+}
+
+impl core::fmt::Display for MountEntry<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} {} {} {} {} {}",
+            &self.source,
+            &self.mount_point,
+            &self.fs_type,
+            &self.mount_flags,
+            &self.dump,
+            &self.pass,
+        )
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/mounts` (and also `/proc/[pid]/mounts`).
+pub struct MountsFileOps(TidDirOps);
+
+impl MountsFileOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3351>
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    /// Reads mount information for `/proc/[pid]/mounts` and `/proc/mounts`.
+    ///
+    /// Provides a simplified view of mounted filesystems in the traditional
+    /// `/etc/fstab` format.
+    fn read_mounts(
+        &self,
+        path_resolver: &PathResolver,
+        offset: usize,
+        writer: &mut VmWriter,
+    ) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        for mount in path_resolver.collect_visible_mounts() {
+            let parent = mount.parent().and_then(|parent| parent.upgrade());
+            let is_resolver_root_mount = Arc::ptr_eq(&mount, path_resolver.root().mount_node());
+            let mount_point = make_mount_point_path(
+                is_resolver_root_mount,
+                parent.as_ref(),
+                mount.as_ref(),
+                path_resolver,
+            );
+            let mount_flags = mount.flags();
+            let fs_type = mount.fs().name();
+            let source = mount.source().unwrap_or("none");
+
+            // The dump and pass fields are hardcoded to 0, because the kernel considers them
+            // userspace policy (managed by /etc/fstab) and does not store them in the VFS layer.
+            // This behavior is consistent with Linux.
+            //
+            // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc_namespace.c#L130>.
+            let dump = 0;
+            let pass = 0;
+
+            let entry = MountEntry {
+                source,
+                mount_point: &mount_point,
+                fs_type,
+                mount_flags,
+                dump,
+                pass,
+            };
+
+            writeln!(printer, "{}", entry)?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+}
+
+impl FileOps for MountsFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let thread = self.0.thread();
+        let posix_thread = thread.as_posix_thread().unwrap();
+
+        let fs = posix_thread.read_fs();
+        let path_resolver = fs.resolver().read();
+        self.read_mounts(&path_resolver, offset, writer)
+    }
+}

--- a/kernel/src/fs/utils/fs.rs
+++ b/kernel/src/fs/utils/fs.rs
@@ -150,6 +150,11 @@ pub trait FileSystem: Any + Sync + Send {
     /// Gets the name of this FS type such as `"ext4"` or `"sysfs"`.
     fn name(&self) -> &'static str;
 
+    /// Gets the source of this file system, e.g., the device name or user-provided source string.
+    fn source(&self) -> Option<&str> {
+        None
+    }
+
     /// Syncs the file system.
     fn sync(&self) -> Result<()>;
 

--- a/test/initramfs/src/syscall/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/proc_test
@@ -7,7 +7,6 @@ ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteNonRoot
 ProcFilesystems.OverflowID
 ProcFilesystems.PresenceOfShmMaxMniAll
-ProcMounts.IsSymlink
 ProcPid.AccessDeny
 ProcPidCwd.Subprocess
 ProcPidRoot.Subprocess
@@ -31,8 +30,6 @@ ProcSelfFdInfo.Flags
 # TODO: Mappings created with only `PROT_WRITE` should be shown as `-w-`.
 ProcSelfMaps.Map2
 ProcSelfMaps.MapUnmap
-ProcSelfMounts.ContainsProcfsEntry
-ProcSelfMounts.RequiredFieldsArePresent
 ProcSelfRoot.IsRoot
 ProcSelfStat.PopulateWriteRSS
 ProcSysKernelHostname.Exists


### PR DESCRIPTION
This PR implements `/proc/[pid]/mounts` and establishes `/proc/mounts` as a symlink, enabling support for standard tools like `findmnt` and `umount` by device.

In `xfstests` (#2856 ), test scripts rely on `findmnt` to check mount status and often perform unmount operations using the device path (e.g., `umount /dev/vdb`) rather than the mount point. Both actions require parsing `/proc/mounts` to retrieve the mapping between devices and mount points. Previously, the lack of mount source tracking and the missing `/proc/mounts` interface caused these tests to fail.

**Changes**
1.  Track Mount Source: Added a `Source` field to the `Mounts` struct to store the device path or filesystem name.
2.  Update `mountinfo`: The source string is now correctly exposed in `/proc/self/mountinfo`.
3.  Implement `mounts`:
    - Implemented `/proc/[pid]/mounts` (formatted according to Linux standards).
    - Created `/proc/mounts` as a symlink pointing to `/proc/self/mounts`.

With these changes, Asterinas can now:
- Correctly display source devices in `/proc/[pid]/mountinfo`.
- Support `findmnt` and `umount <device_path>` commands that are used in `xfstests` (#2856 ).


