### PR TITLE
Fix error setting bid in `InodeImpl::free_indirect_blocks_required_by`

### DIFF
--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -1741,8 +1741,8 @@ impl InodeImpl {
                     return Ok(());
                 }
 
-                self.desc.block_ptrs.set_indirect(bid);
-                block_ptrs.set_indirect(bid);
+                self.desc.block_ptrs.set_indirect(0);
+                block_ptrs.set_indirect(0);
                 indirect_blocks.remove(indirect_bid);
                 self.fs()
                     .free_blocks(indirect_bid..indirect_bid + 1)


### PR DESCRIPTION
When debugging `InodeImpl::free_indirect_blocks_required_by`, I found this little bug.
<img width="2537" height="1293" alt="indirect" src="https://github.com/user-attachments/assets/f0f9ba5d-8794-42cd-a972-414220cc391e" />
The purpose of `block_ptrs.set_indirect` should be to set the indirect block to 0, indicating that it is freed, rather than setting it to `bid`, a file block ID.