### PR TITLE
Improve input parsing in `OomScoreAdjFileOps` by trimming whitespace

### DIFF
--- a/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/procfs/pid/task/oom_score_adj.rs
@@ -43,6 +43,7 @@ impl FileOps for OomScoreAdjFileOps {
         let val = cstr
             .to_str()
             .ok()
+            .map(|str| str.trim())
             .and_then(|str| str.parse::<i32>().ok())
             .ok_or_else(|| {
                 Error::with_message(Errno::EINVAL, "the value is not a valid integer")


### PR DESCRIPTION
This PR fixes Asterinas failing to write to `/proc/[pid]/oom_score_adj` via `echo`. Currently, running:

```bash
~ # echo 1 > /proc/self/oom_score_adj
sh: write error: Invalid argument
```
fails because `echo` appends a trailing `\n`, which Asterinas does not parse correctly. This PR trims the input before parsing, aligning the behavior with Linux.