### PR TITLE
Support `virtio-rng` and expose it as `/dev/hwrng`

### DIFF
--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -118,6 +118,7 @@ impl ConsoleDevice {
         // Register IRQ callbacks.
         let mut transport = device.transport.lock();
         let handle_console_input = {
+            // FIXME: This callback captures a strong `Arc`, creating a reference cycle.
             let device = device.clone();
             move |_: &TrapFrame| device.handle_recv_irq()
         };

--- a/kernel/comps/virtio/src/device/entropy/device.rs
+++ b/kernel/comps/virtio/src/device/entropy/device.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implements virtio-rng device instances.
+//!
+//! This module owns each device's virtqueue state, DMA buffer, IRQ-driven
+//! refill path, and user-visible entropy cache.
+
+use alloc::{boxed::Box, format, sync::Arc};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use ostd::{
+    Error,
+    arch::trap::TrapFrame,
+    mm::{
+        Fallible, FallibleVmRead, PAGE_SIZE, VmWriter,
+        dma::{DmaStream, FromDevice},
+        io::util::HasVmReaderWriter,
+    },
+    sync::{LocalIrqDisabled, Mutex, SpinLock, WaitQueue},
+};
+
+use crate::{
+    device::{VirtioDeviceError, entropy},
+    queue::VirtQueue,
+    transport::VirtioTransport,
+};
+
+static ENTROPY_DEVICE_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// The prefix of Linux-compatible device names (`virtio_rng.N`).
+//
+// TODO: Export the names in sysfs (`/sys/class/misc/hw_random/rng_available`)
+// and allow the user to select the current device.
+const ENTROPY_DEVICE_PREFIX: &str = "virtio_rng.";
+
+/// The queue size for in-flight entropy requests.
+///
+/// A ring depth of 1 is sufficient because `try_read` submits a new entropy
+/// request only when none is in flight.
+const ENTROPY_QUEUE_SIZE: u16 = 1;
+
+/// The buffer size of an entropy request.
+const ENTROPY_BUFFER_SIZE: usize = PAGE_SIZE;
+
+/// Entropy devices, which supply high-quality randomness for guest use.
+pub struct EntropyDevice {
+    transport: SpinLock<Box<dyn VirtioTransport>>,
+    inner: SpinLock<EntropyDeviceInner, LocalIrqDisabled>,
+    /// A filled DMA buffer drained by user-space reads.
+    cache: Mutex<EntropyCache>,
+    wait_queue: WaitQueue,
+}
+
+impl EntropyDevice {
+    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
+        let queue = VirtQueue::new(0, ENTROPY_QUEUE_SIZE, transport.as_mut())?;
+        let device = Arc::new(EntropyDevice {
+            transport: SpinLock::new(transport),
+            inner: SpinLock::new(EntropyDeviceInner::new(queue)?),
+            cache: Mutex::new(EntropyCache::new()?),
+            wait_queue: WaitQueue::new(),
+        });
+
+        let mut transport = device.transport.lock();
+
+        // Register IRQ callbacks.
+        transport.register_queue_callback(
+            0,
+            Box::new({
+                let device = Arc::downgrade(&device);
+                move |_: &TrapFrame| {
+                    if let Some(device) = device.upgrade() {
+                        device.handle_recv_irq()
+                    }
+                }
+            }),
+            false,
+        )?;
+        // Virtio-rng has no configuration fields, so config-space change interrupts
+        // are not expected and no config callback is registered.
+
+        transport.finish_init();
+        drop(transport);
+
+        let device_id = ENTROPY_DEVICE_ID.fetch_add(1, Ordering::Relaxed);
+        let name = format!("{ENTROPY_DEVICE_PREFIX}{device_id}");
+
+        entropy::register_device(name, device);
+
+        Ok(())
+    }
+
+    /// Attempts to read random data from cache into the given writer without blocking.
+    ///
+    /// Returns `Ok(Some(n))` with `n > 0` on success, `Ok(Some(0))` iff
+    /// `writer.avail() == 0`, and `Ok(None)` when no entropy is currently
+    /// available. The caller may block on [`Self::wait_queue`] and retry.
+    pub fn try_read(&self, writer: &mut VmWriter<'_, Fallible>) -> Result<Option<usize>, Error> {
+        let mut cache = self.cache.lock();
+
+        // Fast path: drain the cache under the mutex (`cache`) only.
+        if !cache.is_empty() {
+            return Ok(Some(cache.drain_into(writer)?));
+        }
+
+        // Slow path: under `inner`, lift a ready buffer into the cache (by
+        // handle swap — no memcpy), or submit a new request.
+        {
+            let mut inner = self.inner.lock();
+            if inner.ready_len > 0 {
+                let len = core::mem::replace(&mut inner.ready_len, 0);
+                cache.swap_in(&mut inner.dma_buf, len);
+                // Fall through to drain after releasing `inner`.
+            } else {
+                if !inner.in_flight {
+                    inner.submit();
+                }
+                return Ok(None);
+            }
+        }
+
+        // The user-space copy runs under the mutex (`cache`) only.
+        Ok(Some(cache.drain_into(writer)?))
+    }
+
+    /// Returns the wait queue callers can wait on; the device wakes it when
+    /// fresh entropy arrives.
+    pub fn wait_queue(&self) -> &WaitQueue {
+        &self.wait_queue
+    }
+
+    fn handle_recv_irq(&self) {
+        let mut inner = self.inner.lock();
+
+        let Ok((_, used_len)) = inner.queue.pop_used() else {
+            // No completed request was queued by the device, so the current
+            // in-flight request, if any, must remain pending.
+            return;
+        };
+
+        inner.ready_len = used_len as usize;
+        inner.in_flight = false;
+
+        drop(inner);
+
+        // Wake the waiters up so they can try again and see the new entropy.
+        self.wait_queue.wake_all();
+    }
+}
+
+struct EntropyDeviceInner {
+    queue: VirtQueue,
+    dma_buf: DmaStream<FromDevice>,
+    ready_len: usize,
+    in_flight: bool,
+}
+
+impl EntropyDeviceInner {
+    fn new(queue: VirtQueue) -> Result<Self, VirtioDeviceError> {
+        let dma_buf = DmaStream::<FromDevice>::alloc_uninit(ENTROPY_BUFFER_SIZE / PAGE_SIZE, false)
+            .map_err(VirtioDeviceError::ResourceAlloc)?;
+        Ok(Self {
+            queue,
+            dma_buf,
+            ready_len: 0,
+            in_flight: false,
+        })
+    }
+
+    fn submit(&mut self) {
+        let Self {
+            queue,
+            dma_buf,
+            in_flight,
+            ..
+        } = self;
+
+        queue.add_output_bufs(&[dma_buf]).unwrap();
+        if queue.should_notify() {
+            queue.notify();
+        }
+        *in_flight = true;
+    }
+}
+
+/// A filled DMA buffer waiting to be drained into user space.
+///
+/// Valid bytes live in `dma_buf[0..avail]` and are consumed from the tail.
+struct EntropyCache {
+    dma_buf: DmaStream<FromDevice>,
+    avail: usize,
+}
+
+impl EntropyCache {
+    fn new() -> Result<Self, VirtioDeviceError> {
+        let dma_buf = DmaStream::<FromDevice>::alloc_uninit(ENTROPY_BUFFER_SIZE / PAGE_SIZE, false)
+            .map_err(VirtioDeviceError::ResourceAlloc)?;
+        Ok(Self { dma_buf, avail: 0 })
+    }
+
+    fn is_empty(&self) -> bool {
+        self.avail == 0
+    }
+
+    /// Copies random data from the tail of the valid region
+    /// into `writer`, and marks those bytes as consumed.
+    fn drain_into(&mut self, writer: &mut VmWriter<'_, Fallible>) -> Result<usize, Error> {
+        let to_copy = writer.avail().min(self.avail);
+        let start = self.avail - to_copy;
+        let copied = self
+            .dma_buf
+            .reader()
+            .unwrap()
+            .skip(start)
+            .limit(to_copy)
+            .read_fallible(writer)
+            .map_err(|(err, _)| err)?;
+        self.avail = start;
+        Ok(copied)
+    }
+
+    /// Swaps the cache's drained buffer with the other DMA buffer.
+    ///
+    /// The incoming DMA buffer's first `len` bytes are treated as valid entropy.
+    /// The cache must be empty; otherwise unread entropy would be discarded.
+    fn swap_in(&mut self, other: &mut DmaStream<FromDevice>, len: usize) {
+        debug_assert!(self.is_empty());
+        other.sync_from_device(0..len).unwrap();
+        core::mem::swap(&mut self.dma_buf, other);
+        self.avail = len;
+    }
+}

--- a/kernel/comps/virtio/src/device/entropy/mod.rs
+++ b/kernel/comps/virtio/src/device/entropy/mod.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Manages virtio entropy devices.
+//!
+//! This module owns the global registry of discovered [`EntropyDevice`] instances.
+//! Virtio transport initialization creates devices in [`device`], then registers
+//! them here under stable names such as `virtio_rng.0`.
+
+use alloc::{collections::btree_map::BTreeMap, string::String, sync::Arc};
+
+use ostd::sync::SpinLock;
+use spin::Once;
+
+use crate::device::entropy::device::EntropyDevice;
+
+pub mod device;
+
+/// Registers an [`EntropyDevice`] under `name`.
+fn register_device(name: String, device: Arc<EntropyDevice>) {
+    let mut entropy_devs = ENTROPY_DEVICE_TABLE.get().unwrap().lock();
+
+    entropy_devs.insert(name, device);
+}
+
+/// Returns the first registered [`EntropyDevice`].
+pub fn first_device() -> Option<Arc<EntropyDevice>> {
+    let entropy_devs = ENTROPY_DEVICE_TABLE.get().unwrap().lock();
+
+    entropy_devs.values().next().cloned()
+}
+
+/// Initializes the entropy device registry.
+pub(crate) fn init() {
+    ENTROPY_DEVICE_TABLE.call_once(|| SpinLock::new(BTreeMap::new()));
+}
+
+static ENTROPY_DEVICE_TABLE: Once<SpinLock<BTreeMap<String, Arc<EntropyDevice>>>> = Once::new();

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -146,6 +146,7 @@ impl InputDevice {
 
         let mut transport = device.transport.lock();
         let handle_input = {
+            // FIXME: This callback captures a strong `Arc`, creating a reference cycle.
             let device = device.clone();
             move |_: &TrapFrame| device.handle_irq(&registered_device)
         };

--- a/kernel/comps/virtio/src/device/mod.rs
+++ b/kernel/comps/virtio/src/device/mod.rs
@@ -6,6 +6,7 @@ use crate::{queue, transport::VirtioTransportError};
 
 pub mod block;
 pub mod console;
+pub mod entropy;
 pub mod input;
 pub mod network;
 pub mod socket;

--- a/kernel/comps/virtio/src/device/socket/queue.rs
+++ b/kernel/comps/virtio/src/device/socket/queue.rs
@@ -89,7 +89,7 @@ impl TxQueue {
 
     /// Tries to submit `packet` to the inflight queue immediately, or returns a guard for
     /// submitting the packet to the pending queue.
-    pub fn try_send(&mut self, packet: TxPacket) -> core::result::Result<(), TxPendingGuard<'_>> {
+    pub fn try_send(&mut self, packet: TxPacket) -> Result<(), TxPendingGuard<'_>> {
         if !self.pending.is_empty() || self.queue.available_desc() == 0 {
             return Err(TxPendingGuard {
                 queue: self,

--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -18,7 +18,8 @@ use bitflags::bitflags;
 use component::{ComponentInitError, init_component};
 use device::{
     VirtioDeviceType, block::device::BlockDevice, console::device::ConsoleDevice,
-    input::device::InputDevice, network::device::NetworkDevice, socket::device::SocketDevice,
+    entropy::device::EntropyDevice, input::device::InputDevice, network::device::NetworkDevice,
+    socket::device::SocketDevice,
 };
 use ostd::{error, warn};
 use spin::Once;
@@ -48,6 +49,7 @@ fn virtio_component_init() -> Result<(), ComponentInitError> {
     // Find all devices and register them to the corresponding crate
     transport::init();
 
+    device::entropy::init();
     device::network::init();
     device::socket::init();
 
@@ -77,9 +79,10 @@ fn virtio_component_init() -> Result<(), ComponentInitError> {
         let device_type = transport.device_type();
         let res = match transport.device_type() {
             VirtioDeviceType::Block => BlockDevice::init(transport),
+            VirtioDeviceType::Console => ConsoleDevice::init(transport),
+            VirtioDeviceType::Entropy => EntropyDevice::init(transport),
             VirtioDeviceType::Input => InputDevice::init(transport),
             VirtioDeviceType::Network => NetworkDevice::init(transport),
-            VirtioDeviceType::Console => ConsoleDevice::init(transport),
             VirtioDeviceType::Socket => SocketDevice::init(transport),
             _ => {
                 warn!("Found unimplemented device:{:?}", device_type);

--- a/kernel/src/device/misc/hwrng.rs
+++ b/kernel/src/device/misc/hwrng.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Hardware RNG misc-device support.
+//!
+//! This module registers the `/dev/hwrng` character device and tracks the
+//! currently selected [`EntropyDevice`] backend.
+
+use alloc::{boxed::Box, sync::Arc};
+
+use aster_virtio::device::entropy::{self, device::EntropyDevice};
+use device_id::{DeviceId, MinorId};
+use ostd::mm::VmWriter;
+
+use crate::{
+    device::{Device, DeviceType, DevtmpfsInodeMeta, registry::char},
+    events::IoEvents,
+    fs::{
+        file::{FileIo, StatusFlags},
+        vfs::inode::InodeIo,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+};
+
+const HWRNG_MINOR: u32 = 183;
+
+/// The currently in-use hardware RNG device.
+//
+// TODO: Users can select a device by writing its name to `/sys/class/misc/hw_random/rng_current`,
+// which is not supported yet.
+static RNG_CURRENT: Mutex<Option<Arc<EntropyDevice>>> = Mutex::new(None);
+
+/// The `/dev/hwrng` device.
+#[derive(Debug)]
+struct HwRngDevice {
+    id: DeviceId,
+}
+
+impl HwRngDevice {
+    fn new() -> Arc<Self> {
+        let major = super::MISC_MAJOR.get().unwrap().get();
+        let minor = MinorId::new(HWRNG_MINOR);
+
+        let id = DeviceId::new(major, minor);
+        Arc::new(Self { id })
+    }
+}
+
+impl Device for HwRngDevice {
+    fn type_(&self) -> DeviceType {
+        DeviceType::Char
+    }
+
+    fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new("hwrng"))
+    }
+
+    fn open(&self) -> Result<Box<dyn FileIo>> {
+        // TODO: Reject non-read-only opens with `EINVAL`
+        // once device `open` callbacks receive `AccessMode`.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L169>.
+        Ok(Box::new(HwRngFile))
+    }
+}
+
+/// A file handle opened from `/dev/hwrng`.
+struct HwRngFile;
+
+impl Pollable for HwRngFile {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        // Linux's `/dev/hwrng` does not implement `.poll`, so userspace sees the VFS
+        // default ("always ready").
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L287-L292>.
+        mask & (IoEvents::IN | IoEvents::OUT)
+    }
+}
+
+impl InodeIo for HwRngFile {
+    fn read_at(
+        &self,
+        _offset: usize,
+        writer: &mut VmWriter,
+        status_flags: StatusFlags,
+    ) -> Result<usize> {
+        // Linux looks up the selected device at `read()`.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L215>.
+        let dev = current_device()?;
+        let is_nonblocking = status_flags.contains(StatusFlags::O_NONBLOCK);
+
+        let mut total_copied: usize = 0;
+        while writer.avail() > 0 {
+            // Clone the writer to keep the cursor at the correct position in case a page fault
+            // occurs later.
+            let mut new_writer = writer.clone_exclusive();
+
+            let res = if is_nonblocking {
+                match dev.try_read(&mut new_writer)? {
+                    Some(copied) => Ok(copied),
+                    None => return_errno_with_message!(Errno::EAGAIN, "no entropy is available"),
+                }
+            } else {
+                dev.wait_queue()
+                    .wait_until(|| match dev.try_read(&mut new_writer) {
+                        Ok(Some(copied)) => Some(Ok(copied)),
+                        Ok(None) => None,
+                        Err(err) => Some(Err(err)),
+                    })
+            };
+
+            match res {
+                Ok(copied) => {
+                    writer.skip(copied);
+                    total_copied += copied;
+                }
+                Err(err) => {
+                    if total_copied == 0 {
+                        return Err(err.into());
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(total_copied)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _reader: &mut VmReader,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        // FIXME: Opening this device with `O_WRONLY` or `O_RDWR` fails on Linux. Therefore, the
+        // write operation should never be reached. See the TODO in `HwRngDevice::open`.
+        return_errno_with_message!(
+            Errno::EBADF,
+            "the hardware RNG device does not support writing"
+        );
+    }
+}
+
+impl FileIo for HwRngFile {
+    fn check_seekable(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_offset_aware(&self) -> bool {
+        false
+    }
+}
+
+fn current_device() -> Result<Arc<EntropyDevice>> {
+    let Some(rng) = RNG_CURRENT.lock().clone() else {
+        return_errno_with_message!(Errno::ENODEV, "no current hardware RNG device is selected");
+    };
+    Ok(rng)
+}
+
+pub(super) fn init_in_first_kthread() {
+    if let Some(device) = entropy::first_device() {
+        *RNG_CURRENT.lock() = Some(device);
+    }
+
+    char::register(HwRngDevice::new()).unwrap();
+}

--- a/kernel/src/device/misc/mod.rs
+++ b/kernel/src/device/misc/mod.rs
@@ -9,6 +9,7 @@ use spin::Once;
 
 use super::registry::char::{MajorIdOwner, acquire_major};
 
+mod hwrng;
 #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
 pub mod tdxguest;
 
@@ -16,6 +17,8 @@ static MISC_MAJOR: Once<MajorIdOwner> = Once::new();
 
 pub(super) fn init_in_first_kthread() {
     MISC_MAJOR.call_once(|| acquire_major(MajorId::new(10)).unwrap());
+
+    hwrng::init_in_first_kthread();
 
     #[cfg(target_arch = "x86_64")]
     ostd::if_tdx_enabled!({

--- a/test/initramfs/src/regression/device/hwrng.c
+++ b/test/initramfs/src/regression/device/hwrng.c
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+ * Regression tests for `/dev/hwrng`.
+ *
+ * This test file covers device identity, open-mode behavior, blocking and
+ * nonblocking reads, writes, poll, and basic data sanity checks.
+ */
+
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define HWRNG_DEVICE "/dev/hwrng"
+#define HWRNG_MAJOR 10
+#define HWRNG_MINOR 183
+#define HWRNG_CONCURRENT_READERS 8
+#define HWRNG_CONCURRENT_READ_SIZE 256
+#define HWRNG_PRIME_READ_SIZE 1
+#define HWRNG_SHORT_READ_SIZE 64
+#define HWRNG_LARGE_READ_SIZE (16 * 1024)
+#define HWRNG_NONBLOCK_MAX_ATTEMPTS 128
+#define HWRNG_SMOKE_READ_SIZE 4096
+#define HWRNG_POLL_TIMEOUT_MS 1000
+
+static void exit_if_hwrng_is_unavailable(void);
+static void run_concurrent_reader(int pipe_fd);
+static bool is_all_zero(const uint8_t *buf, size_t len);
+static bool is_all_ff(const uint8_t *buf, size_t len);
+static bool is_repeating_u32_pattern(const uint8_t *buf, size_t len);
+static bool
+has_duplicate_buffer(const uint8_t bufs[][HWRNG_CONCURRENT_READ_SIZE],
+		     size_t buf_count);
+static size_t count_set_bits(const uint8_t *buf, size_t len);
+
+FN_SETUP(check_hwrng_availability)
+{
+	exit_if_hwrng_is_unavailable();
+}
+END_SETUP()
+
+FN_TEST(hwrng_has_correct_char_dev_id)
+{
+	struct stat st;
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(fstat(fd, &st), S_ISCHR(st.st_mode) &&
+					 major(st.st_rdev) == HWRNG_MAJOR &&
+					 minor(st.st_rdev) == HWRNG_MINOR);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_has_linux_compatible_mode)
+{
+	struct stat st;
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(fstat(fd, &st), (st.st_mode & 0777) == 0600);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_concurrent_readers_get_distinct_data)
+{
+	uint8_t bufs[HWRNG_CONCURRENT_READERS][HWRNG_CONCURRENT_READ_SIZE] = {
+		0
+	};
+	pid_t pids[HWRNG_CONCURRENT_READERS] = { 0 };
+	int pipe_fds[HWRNG_CONCURRENT_READERS][2];
+
+	for (size_t i = 0; i < HWRNG_CONCURRENT_READERS; ++i) {
+		TEST_SUCC(pipe(pipe_fds[i]));
+
+		pids[i] = TEST_SUCC(fork());
+		if (pids[i] == 0) {
+			CHECK(close(pipe_fds[i][0]));
+			run_concurrent_reader(pipe_fds[i][1]);
+		}
+
+		TEST_SUCC(close(pipe_fds[i][1]));
+	}
+
+	for (size_t i = 0; i < HWRNG_CONCURRENT_READERS; ++i) {
+		int status;
+
+		TEST_RES(read(pipe_fds[i][0], bufs[i], sizeof(bufs[i])),
+			 _ret == sizeof(bufs[i]));
+		TEST_SUCC(close(pipe_fds[i][0]));
+
+		TEST_RES(waitpid(pids[i], &status, 0),
+			 _ret == pids[i] && WIFEXITED(status) &&
+				 WEXITSTATUS(status) == EXIT_SUCCESS);
+		TEST_RES(is_all_zero(bufs[i], sizeof(bufs[i])), _ret == 0);
+		TEST_RES(is_all_ff(bufs[i], sizeof(bufs[i])), _ret == 0);
+		TEST_RES(is_repeating_u32_pattern(bufs[i], sizeof(bufs[i])),
+			 _ret == 0);
+	}
+
+	TEST_RES(has_duplicate_buffer(bufs, HWRNG_CONCURRENT_READERS),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(hwrng_short_read)
+{
+	uint8_t buf[HWRNG_SHORT_READ_SIZE] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_read_with_zero_count)
+{
+	uint8_t buf[1] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(read(fd, buf, 0), _ret == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+/* A large blocking read should span internal refills and still complete fully. */
+FN_TEST(hwrng_large_read)
+{
+	uint8_t buf[HWRNG_LARGE_READ_SIZE] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+	TEST_RES(is_all_zero(buf, sizeof(buf)), _ret == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_write_on_ro_ebadf)
+{
+	uint8_t buf[16] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_ERRNO(write(fd, buf, sizeof(buf)), EBADF);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_write_on_wo_einval)
+{
+	/*
+	 * FIXME: Linux rejects `O_WRONLY` and `O_RDWR` in `rng_dev_open()`
+	 * with `EINVAL`. Asterinas does not pass the access mode to
+	 * `Device::open()` yet, so the open succeeds and the later write fails
+	 * with `EBADF` instead.
+	 */
+#ifdef __asterinas__
+	uint8_t buf[16] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_WRONLY));
+
+	TEST_ERRNO(write(fd, buf, sizeof(buf)), EBADF);
+	TEST_SUCC(close(fd));
+#else
+	TEST_ERRNO(open(HWRNG_DEVICE, O_WRONLY), EINVAL);
+#endif
+}
+END_TEST()
+
+FN_TEST(hwrng_write_on_rw_einval)
+{
+	/* FIXME: See `hwrng_write_on_wo_einval`. */
+#ifdef __asterinas__
+	uint8_t buf[16] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDWR));
+
+	TEST_ERRNO(write(fd, buf, sizeof(buf)), EBADF);
+	TEST_SUCC(close(fd));
+#else
+	TEST_ERRNO(open(HWRNG_DEVICE, O_RDWR), EINVAL);
+#endif
+}
+END_TEST()
+
+/* Linux reports `/dev/hwrng` as always ready to `poll(2)`. */
+FN_TEST(hwrng_poll_reports_in_and_out)
+{
+	uint8_t buf[HWRNG_SHORT_READ_SIZE] = { 0 };
+	struct pollfd pfd;
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	pfd = (struct pollfd){
+		.fd = fd,
+		.events = POLLIN | POLLOUT,
+	};
+
+	TEST_RES(poll(&pfd, 1, HWRNG_POLL_TIMEOUT_MS), _ret == 1);
+	TEST_RES(pfd.revents, _ret == (POLLIN | POLLOUT));
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_lseek_is_noop_and_preserves_readability)
+{
+	uint8_t buf[HWRNG_SHORT_READ_SIZE] = { 0 };
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	/*
+	 * Linux binds `/dev/hwrng` to `noop_llseek`, so `lseek(2)` succeeds
+	 * without introducing offset-aware reads.
+	 * Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L287>.
+	 */
+	TEST_RES(lseek(fd, 0, SEEK_SET), _ret == 0);
+	TEST_RES(lseek(fd, 123, SEEK_CUR), _ret == 0);
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+/*
+ * `virtio-rng` cannot make the nonblocking outcome deterministic. Draining
+ * the cache immediately submits the next request, and a following
+ * nonblocking read races the completion IRQ. This test accepts either
+ * immediate data or `EAGAIN`.
+ */
+FN_TEST(hwrng_nonblock_eagain_or_immediate_data)
+{
+	uint8_t drain_buf[HWRNG_LARGE_READ_SIZE] = { 0 };
+	uint8_t nonblock_buf[HWRNG_LARGE_READ_SIZE] = { 0 };
+	bool saw_eagain = false;
+	bool saw_immediate_data = false;
+
+	for (size_t attempt = 0; attempt < HWRNG_NONBLOCK_MAX_ATTEMPTS;
+	     ++attempt) {
+		ssize_t nonblock_ret;
+		int fd;
+
+		fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+		TEST_RES(read(fd, drain_buf, sizeof(drain_buf)),
+			 _ret == sizeof(drain_buf));
+		TEST_SUCC(close(fd));
+
+		fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY | O_NONBLOCK));
+
+		errno = 0;
+		nonblock_ret = read(fd, nonblock_buf, sizeof(nonblock_buf));
+		if (nonblock_ret == -1 && errno == EAGAIN) {
+			saw_eagain = true;
+			TEST_SUCC(close(fd));
+			break;
+		}
+
+		TEST_RES(nonblock_ret, _ret > 0);
+		saw_immediate_data = true;
+
+		TEST_SUCC(close(fd));
+	}
+
+	TEST_RES(saw_eagain || saw_immediate_data, _ret);
+}
+END_TEST()
+
+FN_TEST(hwrng_nonblock_succeeds_after_cache_prime)
+{
+	uint8_t prime_buf[HWRNG_PRIME_READ_SIZE] = { 0 };
+	uint8_t buf[HWRNG_SHORT_READ_SIZE] = { 0 };
+	int fd;
+
+	fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+	TEST_RES(read(fd, prime_buf, sizeof(prime_buf)),
+		 _ret == sizeof(prime_buf));
+	TEST_SUCC(close(fd));
+
+	fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY | O_NONBLOCK));
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(hwrng_small_read_boundaries)
+{
+	const size_t sizes[] = { 1, 3, 7 };
+	uint8_t buf[7] = { 0 };
+	size_t total_read = 0;
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	while (total_read < HWRNG_LARGE_READ_SIZE) {
+		for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); ++i) {
+			memset(buf, 0, sizeof(buf));
+			TEST_RES(read(fd, buf, sizes[i]),
+				 _ret == (ssize_t)sizes[i]);
+			total_read += sizes[i];
+		}
+	}
+	TEST_RES(total_read, _ret >= HWRNG_LARGE_READ_SIZE);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+/*
+ * This is a smoke test for obvious DMA or cache-handling bugs. It is not a
+ * statistical randomness test.
+ */
+FN_TEST(hwrng_smoke_basic_content_checks)
+{
+	uint8_t buf[HWRNG_SMOKE_READ_SIZE] = { 0 };
+	size_t set_bits;
+	int fd = TEST_SUCC(open(HWRNG_DEVICE, O_RDONLY));
+
+	TEST_RES(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+	TEST_RES(is_all_zero(buf, sizeof(buf)), _ret == 0);
+	TEST_RES(is_all_ff(buf, sizeof(buf)), _ret == 0);
+	TEST_RES(is_repeating_u32_pattern(buf, sizeof(buf)), _ret == 0);
+
+	set_bits = count_set_bits(buf, sizeof(buf));
+	TEST_RES(set_bits, _ret >= sizeof(buf) * CHAR_BIT * 40 / 100 &&
+				   _ret <= sizeof(buf) * CHAR_BIT * 60 / 100);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+static void exit_if_hwrng_is_unavailable(void)
+{
+	int fd;
+	uint8_t buf[HWRNG_SHORT_READ_SIZE] = { 0 };
+
+	fd = open(HWRNG_DEVICE, O_RDONLY);
+	if (fd < 0) {
+		if (errno == ENOENT || errno == ENODEV || errno == ENXIO) {
+			fprintf(stderr, "hwrng tests skipped: %s (%s)\n",
+				HWRNG_DEVICE, strerror(errno));
+			exit(EXIT_SUCCESS);
+		}
+		fprintf(stderr, "fatal error: %s: open('%s') failed: %s\n",
+			__func__, HWRNG_DEVICE, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (read(fd, buf, sizeof(buf)) == -1) {
+		int saved_errno = errno;
+
+		if (saved_errno == ENODEV || saved_errno == EIO ||
+		    saved_errno == ENXIO) {
+			fprintf(stderr, "hwrng tests skipped: read('%s'): %s\n",
+				HWRNG_DEVICE, strerror(saved_errno));
+			CHECK(close(fd));
+			exit(EXIT_SUCCESS);
+		}
+
+		fprintf(stderr, "fatal error: %s: read('%s') failed: %s\n",
+			__func__, HWRNG_DEVICE, strerror(saved_errno));
+		CHECK(close(fd));
+		exit(EXIT_FAILURE);
+	}
+
+	CHECK(close(fd));
+}
+
+static void run_concurrent_reader(int pipe_fd)
+{
+	uint8_t buf[HWRNG_CONCURRENT_READ_SIZE] = { 0 };
+	int fd = CHECK(open(HWRNG_DEVICE, O_RDONLY));
+
+	CHECK_WITH(read(fd, buf, sizeof(buf)), _ret == sizeof(buf));
+	CHECK_WITH(write(pipe_fd, buf, sizeof(buf)), _ret == sizeof(buf));
+
+	CHECK(close(fd));
+	CHECK(close(pipe_fd));
+	_exit(EXIT_SUCCESS);
+}
+
+static bool is_all_zero(const uint8_t *buf, size_t len)
+{
+	for (size_t i = 0; i < len; ++i) {
+		if (buf[i] != 0) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool is_all_ff(const uint8_t *buf, size_t len)
+{
+	for (size_t i = 0; i < len; ++i) {
+		if (buf[i] != UINT8_MAX) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool is_repeating_u32_pattern(const uint8_t *buf, size_t len)
+{
+	if (len < sizeof(uint32_t) || len % sizeof(uint32_t) != 0) {
+		return false;
+	}
+
+	for (size_t i = sizeof(uint32_t); i < len; ++i) {
+		if (buf[i] != buf[i % sizeof(uint32_t)]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool
+has_duplicate_buffer(const uint8_t bufs[][HWRNG_CONCURRENT_READ_SIZE],
+		     size_t buf_count)
+{
+	for (size_t i = 0; i < buf_count; ++i) {
+		for (size_t j = i + 1; j < buf_count; ++j) {
+			if (memcmp(bufs[i], bufs[j],
+				   HWRNG_CONCURRENT_READ_SIZE) == 0) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static size_t count_set_bits(const uint8_t *buf, size_t len)
+{
+	size_t total = 0;
+
+	for (size_t i = 0; i < len; ++i) {
+		total += __builtin_popcount(buf[i]);
+	}
+
+	return total;
+}

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -14,4 +14,5 @@ set -e
 ./evdev
 ./framebuffer
 ./full
+./hwrng
 ./random

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -133,6 +133,8 @@ else
         -machine q35,kernel-irqchip=split \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -object rng-random,id=rng0,filename=/dev/urandom \
+        -device virtio-rng-pci,bus=pcie.0,addr=0x8,disable-legacy=on,disable-modern=off,rng=rng0,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
         -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
         $CONSOLE_ARGS \


### PR DESCRIPTION
## Changes in this PR
- Add configurations to include the `virtio-rng` device in qemu args.
- Detect `virtio-rng` devices and initialize.
- Expose `virtio-rng` device through `/dev/hwrng`, making it accessible for reading random numbers.
## Unsupported Feature
- Linux supports selecting the `hwrng` backend via `/sys/class/misc/hw_random/rng_current`. This feature was not implemented in this PR due to the need for **_locking_**, which could impact performance. The feature is noted but not currently included in the implementation.