### PR TITLE
Replace the use of `read_volatile` and `write_volatile` with assembly code

### DIFF
--- a/kernel/libs/aster-util/src/safe_ptr.rs
+++ b/kernel/libs/aster-util/src/safe_ptr.rs
@@ -5,12 +5,8 @@ use core::{fmt::Debug, marker::PhantomData};
 use aster_rights::{Dup, Exec, Full, Read, Signal, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 use ostd::{
-    Error, Result,
-    mm::{
-        Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
-        dma::DmaDirection,
-        io::util::{HasVmReaderWriter, VmReaderWriterTypes},
-    },
+    Result,
+    mm::{Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce, dma::DmaDirection},
 };
 use ostd_pod::Pod;
 
@@ -239,18 +235,12 @@ impl<T: Pod, M: VmIo, R: TRights> SafePtr<T, M, TRightSet<R>> {
     ///  - the Read right for another pointer.
     #[require(R > Write)]
     #[require(R1 > Read)]
-    pub fn copy_from<M1: HasVmReaderWriter, R1: TRights>(
+    pub fn copy_from<M1: VmIo, R1: TRights>(
         &self,
         ptr: &SafePtr<T, M1, TRightSet<R1>>,
     ) -> Result<()> {
-        let mut reader = M1::Types::to_reader_result(ptr.vm_obj.reader())?.to_fallible();
-
-        if reader.remain() < size_of::<T>() {
-            return Err(Error::InvalidArgs);
-        }
-        reader.limit(size_of::<T>());
-
-        self.vm_obj.write(self.offset, &mut reader)
+        let val = ptr.vm_obj.read_val::<T>(ptr.offset)?;
+        self.vm_obj.write_val(self.offset, &val)
     }
 }
 

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 
 use aster_framebuffer::{ColorMapEntry, FRAMEBUFFER, FrameBuffer, MAX_CMAP_SIZE, PixelFormat};
 use device_id::{DeviceId, MajorId, MinorId};
-use ostd::mm::{HasPaddr, HasSize, VmIo, io::util::HasVmReaderWriter};
+use ostd::mm::{HasPaddr, HasSize, VmIo, VmReader, VmWriter};
 
 use super::{Device, DeviceType, registry::char};
 use crate::{
@@ -410,21 +410,34 @@ impl InodeIo for FbHandle {
             return Ok(0);
         }
 
-        let mut reader = self.framebuffer.io_mem().reader();
-
-        if offset >= reader.remain() {
+        let io_mem = self.framebuffer.io_mem();
+        let size = io_mem.size();
+        if offset >= size {
             return Ok(0);
         }
-        reader.skip(offset);
 
-        let mut reader = reader.to_fallible();
-        let len = match reader.read_fallible(writer) {
-            Ok(len) => len,
-            Err((err, 0)) => return Err(err.into()),
-            Err((_err, len)) => len,
+        let len = writer.avail().min(size - offset);
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let mut new_writer = writer.clone_exclusive();
+        new_writer.limit(len);
+
+        let result = io_mem.read_fallible(offset, &mut new_writer);
+        let copied = match result {
+            Ok(copied) => copied,
+            Err((err, copied)) => {
+                if copied > 0 {
+                    copied
+                } else {
+                    return Err(err.into());
+                }
+            }
         };
 
-        Ok(len)
+        writer.skip(copied);
+        Ok(copied)
     }
 
     fn write_at(
@@ -437,23 +450,37 @@ impl InodeIo for FbHandle {
             return Ok(0);
         }
 
-        let mut writer = self.framebuffer.io_mem().writer();
-        if offset >= writer.avail() {
+        let io_mem = self.framebuffer.io_mem();
+        let size = io_mem.size();
+        if offset >= size {
             return_errno_with_message!(
                 Errno::ENOSPC,
                 "the write offset is beyond the framebuffer size"
             );
         }
-        writer.skip(offset);
 
-        let mut writer = writer.to_fallible();
-        let len = match writer.write_fallible(reader) {
-            Ok(len) => len,
-            Err((err, 0)) => return Err(err.into()),
-            Err((_err, len)) => len,
+        let len = reader.remain().min(size - offset);
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let mut new_reader = reader.clone();
+        new_reader.limit(len);
+
+        let result = io_mem.write_fallible(offset, &mut new_reader);
+        let copied = match result {
+            Ok(copied) => copied,
+            Err((err, copied)) => {
+                if copied > 0 {
+                    copied
+                } else {
+                    return Err(err.into());
+                }
+            }
         };
 
-        Ok(len)
+        reader.skip(copied);
+        Ok(copied)
     }
 }
 

--- a/ostd/src/arch/loongarch/io/io_mem.rs
+++ b/ostd/src/arch/loongarch/io/io_mem.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities.
+
+use crate::{
+    arch::mm::__memcpy_fallible,
+    io::io_mem::util::{copy_from_mmio_val, copy_to_mmio_val, for_aligned_chunks, memset_mmio_val},
+    mm::PodOnce,
+};
+
+/// Reads from a pointer with a non-tearing memory load.
+///
+/// This function is semantically equivalent to `core::ptr::read_volatile`
+/// but is manually implemented with a single memory load instruction.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::read_volatile`.
+///
+/// # Guarantee
+///
+/// The single-memory-load-instruction guarantee is particularly useful for
+/// Confidential VMs (CVMs),
+/// where the memory loads may cause CPU exceptions
+/// and the kernel has to handle such exceptions
+/// by decoding the faulting CPU instruction.
+/// As such, the kernel must be compiled to emit simple load/store CPU instructions.
+pub(crate) unsafe fn read_once<T: PodOnce>(ptr: *const T) -> T {
+    // TODO: Use arch-specific single-instruction load for LoongArch.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `read_volatile`.
+    unsafe { core::ptr::read_volatile(ptr) }
+}
+
+/// Writes to a pointer with a non-tearing memory store.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::write_volatile`.
+///
+/// # Guarantee
+///
+/// Refer to the "Guarantee" section of [`read_once`].
+pub(crate) unsafe fn write_once<T: PodOnce>(ptr: *mut T, val: T) {
+    // TODO: Use arch-specific single-instruction store for LoongArch.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `write_volatile`.
+    unsafe { core::ptr::write_volatile(ptr, val) }
+}
+
+/// Copies from MMIO to regular memory.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio(mut dst_ptr: *mut u8, mut src_io_ptr: *const u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `src_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        src_io_ptr.addr(),
+        count,
+        8,
+        copy_from_mmio_val(&mut dst_ptr, &mut src_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from regular memory to MMIO.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio(mut src_ptr: *const u8, mut dst_io_ptr: *mut u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        copy_to_mmio_val(&mut src_ptr, &mut dst_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from MMIO to fallible memory and returns bytes copied.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio_fallible(
+    dst_ptr: *mut u8,
+    src_io_ptr: *const u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_ptr, src_io_ptr, count) };
+    count - failed_bytes
+}
+
+/// Copies from fallible memory to MMIO and returns bytes copied.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid or in user space for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio_fallible(
+    src_ptr: *const u8,
+    dst_io_ptr: *mut u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_io_ptr, src_ptr, count) };
+    count - failed_bytes
+}
+
+/// Fills MMIO with `value` for `count` bytes.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn memset_mmio(mut dst_io_ptr: *mut u8, value: u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let written = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        memset_mmio_val(&mut dst_io_ptr, value)
+    );
+    debug_assert_eq!(written, count);
+}

--- a/ostd/src/arch/loongarch/io/mod.rs
+++ b/ostd/src/arch/loongarch/io/mod.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! I/O memory utilities.
+
 use alloc::vec::Vec;
 
 use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
 
-/// Initializes the allocatable MMIO area based on the RISC-V memory
+pub(crate) mod io_mem;
+
+/// Initializes the allocatable MMIO area based on the LoongArch memory
 /// distribution map.
 ///
 /// Here we consider all the holes (filtering usable RAM) in the physical

--- a/ostd/src/arch/loongarch/mod.rs
+++ b/ostd/src/arch/loongarch/mod.rs
@@ -7,7 +7,7 @@
 pub mod boot;
 pub mod cpu;
 pub mod device;
-mod io;
+pub(crate) mod io;
 pub(crate) mod iommu;
 pub(crate) mod irq;
 pub(crate) mod mm;

--- a/ostd/src/arch/loongarch/serial.rs
+++ b/ostd/src/arch/loongarch/serial.rs
@@ -5,7 +5,11 @@
 use spin::Once;
 
 use crate::{
-    arch::{boot::DEVICE_TREE, mm::paddr_to_daddr},
+    arch::{
+        boot::DEVICE_TREE,
+        io::io_mem::{read_once, write_once},
+        mm::paddr_to_daddr,
+    },
     console::uart_ns16650a::{Ns16550aAccess, Ns16550aRegister, Ns16550aUart},
     sync::{LocalIrqDisabled, SpinLock},
 };
@@ -34,12 +38,12 @@ impl SerialAccess {
 impl Ns16550aAccess for SerialAccess {
     fn read(&self, reg: Ns16550aRegister) -> u8 {
         // SAFETY: `self.base + reg` is a valid register of the serial port.
-        unsafe { core::ptr::read_volatile(self.base.add(reg as u8 as usize)) }
+        unsafe { read_once(self.base.add(reg as usize)) }
     }
 
     fn write(&mut self, reg: Ns16550aRegister, val: u8) {
         // SAFETY: `self.base + reg` is a valid register of the serial port.
-        unsafe { core::ptr::write_volatile(self.base.add(reg as u8 as usize), val) };
+        unsafe { write_once(self.base.add(reg as usize), val) }
     }
 }
 

--- a/ostd/src/arch/riscv/io/io_mem.rs
+++ b/ostd/src/arch/riscv/io/io_mem.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities.
+
+use crate::{
+    arch::mm::__memcpy_fallible,
+    io::io_mem::util::{copy_from_mmio_val, copy_to_mmio_val, for_aligned_chunks, memset_mmio_val},
+    mm::PodOnce,
+};
+
+/// Reads from a pointer with a non-tearing memory load.
+///
+/// This function is semantically equivalent to `core::ptr::read_volatile`
+/// but is manually implemented with a single memory load instruction.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::read_volatile`.
+///
+/// # Guarantee
+///
+/// The single-memory-load-instruction guarantee is particularly useful for
+/// Confidential VMs (CVMs),
+/// where the memory loads may cause CPU exceptions
+/// and the kernel has to handle such exceptions
+/// by decoding the faulting CPU instruction.
+/// As such, the kernel must be compiled to emit simple load/store CPU instructions.
+pub(crate) unsafe fn read_once<T: PodOnce>(ptr: *const T) -> T {
+    // TODO: Use arch-specific single-instruction load for RISC-V.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `read_volatile`.
+    unsafe { core::ptr::read_volatile(ptr) }
+}
+
+/// Writes to a pointer with a non-tearing memory store.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::write_volatile`.
+///
+/// # Guarantee
+///
+/// Refer to the "Guarantee" section of [`read_once`].
+pub(crate) unsafe fn write_once<T: PodOnce>(ptr: *mut T, val: T) {
+    // TODO: Use arch-specific single-instruction store for RISC-V.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `write_volatile`.
+    unsafe { core::ptr::write_volatile(ptr, val) }
+}
+
+/// Copies from MMIO to regular memory.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio(mut dst_ptr: *mut u8, mut src_io_ptr: *const u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `src_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        src_io_ptr.addr(),
+        count,
+        8,
+        copy_from_mmio_val(&mut dst_ptr, &mut src_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from regular memory to MMIO.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio(mut src_ptr: *const u8, mut dst_io_ptr: *mut u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        copy_to_mmio_val(&mut src_ptr, &mut dst_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from MMIO to fallible memory and returns bytes copied.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio_fallible(
+    dst_ptr: *mut u8,
+    src_io_ptr: *const u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_ptr, src_io_ptr, count) };
+    count - failed_bytes
+}
+
+/// Copies from fallible memory to MMIO and returns bytes copied.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid or in user space for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio_fallible(
+    src_ptr: *const u8,
+    dst_io_ptr: *mut u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_io_ptr, src_ptr, count) };
+    count - failed_bytes
+}
+
+/// Fills MMIO with `value` for `count` bytes.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn memset_mmio(mut dst_io_ptr: *mut u8, value: u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let written = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        memset_mmio_val(&mut dst_io_ptr, value)
+    );
+    debug_assert_eq!(written, count);
+}

--- a/ostd/src/arch/riscv/io/mod.rs
+++ b/ostd/src/arch/riscv/io/mod.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! I/O memory utilities.
+
 use alloc::vec::Vec;
 
 use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
 
-/// Initializes the allocatable MMIO area based on the LoongArch memory
+pub(crate) mod io_mem;
+
+/// Initializes the allocatable MMIO area based on the RISC-V memory
 /// distribution map.
 ///
 /// Here we consider all the holes (filtering usable RAM) in the physical

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -7,7 +7,7 @@
 pub mod boot;
 pub mod cpu;
 pub mod device;
-mod io;
+pub(crate) mod io;
 pub(crate) mod iommu;
 pub mod irq;
 pub(crate) mod mm;

--- a/ostd/src/arch/x86/io/cvm.rs
+++ b/ostd/src/arch/x86/io/cvm.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities for confidential VMs.
+
+use super::io_mem::read_once;
+use crate::{
+    arch::mm::__memcpy_fallible,
+    io::io_mem::util::{copy_from_mmio_val, copy_to_mmio_val, for_aligned_chunks, memset_mmio_val},
+    mm::PodOnce,
+};
+
+/// Copies from MMIO to regular memory with CVM-safe access granularity.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(super) unsafe fn copy_from_mmio(mut dst_ptr: *mut u8, mut src_io_ptr: *const u8, count: usize) {
+    if count == 0 {
+        return;
+    }
+
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `src_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        src_io_ptr.addr(),
+        count,
+        8,
+        copy_from_mmio_val(&mut dst_ptr, &mut src_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from regular memory to MMIO with CVM-safe access granularity.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(super) unsafe fn copy_to_mmio(mut src_ptr: *const u8, mut dst_io_ptr: *mut u8, count: usize) {
+    if count == 0 {
+        return;
+    }
+
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        copy_to_mmio_val(&mut src_ptr, &mut dst_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from MMIO to fallible memory with CVM-safe access granularity.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(super) unsafe fn copy_from_mmio_fallible(
+    mut dst_ptr: *mut u8,
+    mut src_io_ptr: *const u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees MMIO source validity for `count` bytes.
+    // The callee handles partial completion when the fallible destination faults.
+    for_aligned_chunks!(
+        src_io_ptr.addr(),
+        count,
+        8,
+        copy_from_mmio_val_fallible(&mut dst_ptr, &mut src_io_ptr)
+    )
+}
+
+/// Copies from fallible memory to MMIO with CVM-safe access granularity.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+/// - `src_ptr` must be valid or in user space for reads of `count` bytes.
+pub(super) unsafe fn copy_to_mmio_fallible(
+    mut src_ptr: *const u8,
+    mut dst_io_ptr: *mut u8,
+    mut count: usize,
+) -> usize {
+    const BUF_SIZE: usize = 256;
+    let mut buf = [0u8; BUF_SIZE];
+    let mut copied_total = 0;
+
+    while count > 0 {
+        let chunk = core::cmp::min(count, BUF_SIZE);
+
+        // SAFETY: The caller ensures `src_ptr` is valid or in user space for reads.
+        let failed = unsafe { __memcpy_fallible(buf.as_mut_ptr(), src_ptr, chunk) };
+        let copied = chunk - failed;
+
+        if copied < chunk {
+            // For MMIO safety, avoid issuing a partial chunk write when source fault occurs.
+            return copied_total;
+        }
+
+        // SAFETY: The caller ensures destination MMIO range is valid for `chunk` bytes.
+        unsafe { copy_to_mmio(buf.as_ptr(), dst_io_ptr, chunk) };
+        dst_io_ptr = dst_io_ptr.wrapping_add(chunk);
+        src_ptr = src_ptr.wrapping_add(chunk);
+        copied_total += chunk;
+        count -= chunk;
+    }
+
+    copied_total
+}
+
+/// Fills MMIO with `value` for `count` bytes with CVM-safe access granularity.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(super) unsafe fn memset_mmio(mut dst_io_ptr: *mut u8, value: u8, count: usize) {
+    if count == 0 {
+        return;
+    }
+
+    // SAFETY: The caller guarantees destination MMIO pointer is valid for `count` bytes.
+    let written = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        memset_mmio_val(&mut dst_io_ptr, value)
+    );
+    debug_assert_eq!(written, count);
+}
+
+/// Copies from MMIO to fallible memory for a single value and returns bytes copied.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `size_of::<T>()` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `size_of::<T>()` bytes.
+unsafe fn copy_from_mmio_val_fallible<T: PodOnce>(
+    dst_ptr: &mut *mut u8,
+    src_io_ptr: &mut *const u8,
+) -> usize {
+    // SAFETY: The caller ensures MMIO source range is valid for reads.
+    let value = unsafe { read_once::<T>((*src_io_ptr).cast::<T>()) };
+    let size = size_of::<T>();
+    // SAFETY: The caller ensures destination range is valid or in user space for writes.
+    let failed =
+        unsafe { __memcpy_fallible(*dst_ptr, core::ptr::addr_of!(value).cast::<u8>(), size) };
+    let copied = size - failed;
+
+    *dst_ptr = (*dst_ptr).wrapping_add(copied);
+    *src_io_ptr = (*src_io_ptr).wrapping_add(copied);
+    copied
+}

--- a/ostd/src/arch/x86/io/io_mem.rs
+++ b/ostd/src/arch/x86/io/io_mem.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities.
+
+use core::arch::asm;
+
+use super::cvm;
+use crate::{
+    arch::{if_tdx_enabled, mm::__memcpy_fallible},
+    mm::PodOnce,
+};
+
+/// Reads from a pointer with a non-tearing memory load.
+///
+/// This function is semantically equivalent to `core::ptr::read_volatile`
+/// but is manually implemented with a single memory load instruction.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::read_volatile`.
+///
+/// # Guarantee
+///
+/// The single-memory-load-instruction guarantee is particularly useful for
+/// Confidential VMs (CVMs) such as Intel TDX and AMD SEV,
+/// where memory loads may cause CPU exceptions (#VE and #VC, respectively)
+/// and the kernel has to handle such exceptions
+/// by decoding the faulting CPU instruction.
+/// As such, the kernel must be compiled to emit simple load/store CPU instructions.
+pub(crate) unsafe fn read_once<T: PodOnce>(ptr: *const T) -> T {
+    debug_assert!(ptr.is_aligned());
+    let mut val: u64 = 0;
+
+    // SAFETY: The caller guarantees `ptr` is valid for reads.
+    unsafe {
+        // EFFICIENCY: The match should be optimized out for release builds.
+        //
+        // This match is resolved at compile-time via monomorphization.
+        // Since `size_of::<T>()` is a constant for each concrete instance of this
+        // function, the compiler eliminates the branch and only emits the
+        // `MOV` instruction for the matching size.
+        match size_of::<T>() {
+            1 => {
+                asm!("mov {0:l}, [{1}]", out(reg) val, in(reg) ptr, options(nostack, readonly, preserves_flags))
+            }
+            2 => {
+                asm!("mov {0:x}, [{1}]", out(reg) val, in(reg) ptr, options(nostack, readonly, preserves_flags))
+            }
+            4 => {
+                asm!("mov {0:e}, [{1}]", out(reg) val, in(reg) ptr, options(nostack, readonly, preserves_flags))
+            }
+            8 => {
+                asm!("mov {0}, [{1}]", out(reg) val, in(reg) ptr, options(nostack, readonly, preserves_flags))
+            }
+            _ => core::hint::unreachable_unchecked(),
+        }
+        // EFFICIENCY: This should compile to a no-op for release builds.
+        // This is because both the source and destination locations fit in a register.
+        // So it only _re-interprets_ bits and no copying is needed.
+        core::ptr::read((&val as *const u64).cast::<T>())
+    }
+}
+
+/// Writes to a pointer with a non-tearing memory store.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::write_volatile`.
+///
+/// # Guarantee
+///
+/// Refer to the "Guarantee" section of [`read_once`].
+pub(crate) unsafe fn write_once<T: PodOnce>(ptr: *mut T, val: T) {
+    debug_assert!(ptr.is_aligned());
+    let mut tmp: u64 = 0;
+
+    // SAFETY: The caller guarantees `ptr` is valid for writes.
+    unsafe {
+        // EFFICIENCY: This should be a no-op for release build.
+        // This is because both the source and destination locations fit in a register.
+        // So it only _re-interprets_ bits and no copying is needed.
+        core::ptr::write((&mut tmp as *mut u64).cast::<T>(), val);
+
+        // EFFICIENCY: The match here has no overhead for release build.
+        //
+        // This match is resolved at compile-time via monomorphization.
+        // Since `size_of::<T>()` is a constant for each concrete instance of this
+        // function, the compiler eliminates the branch and only emits the
+        // `MOV` instruction for the matching size.
+        match size_of::<T>() {
+            1 => {
+                asm!("mov [{0}], {1:l}", in(reg) ptr, in(reg) tmp, options(nostack, preserves_flags))
+            }
+            2 => {
+                asm!("mov [{0}], {1:x}", in(reg) ptr, in(reg) tmp, options(nostack, preserves_flags))
+            }
+            4 => {
+                asm!("mov [{0}], {1:e}", in(reg) ptr, in(reg) tmp, options(nostack, preserves_flags))
+            }
+            8 => {
+                asm!("mov [{0}], {1}", in(reg) ptr, in(reg) tmp, options(nostack, preserves_flags))
+            }
+            _ => core::hint::unreachable_unchecked(),
+        }
+    }
+}
+
+macro_rules! do_copy_mmio_impl {
+    (dst: $dst:ident, src: $src:ident, count: $count:ident) => {{
+        if $count == 0 { return; }
+
+        // SAFETY: The caller guarantees source and destination are valid for `count` bytes.
+        unsafe {
+            asm!(
+                "rep movsb",
+                inout("rdi") $dst => _,
+                inout("rsi") $src => _,
+                inout("rcx") $count => _,
+                options(nostack, preserves_flags)
+            );
+        }
+    }};
+}
+
+macro_rules! do_memset_mmio_impl {
+    (dst: $dst:ident, value: $value:ident, count: $count:ident) => {{
+        if $count == 0 { return; }
+
+        // SAFETY: The caller guarantees destination pointer is valid for `count` bytes.
+        unsafe {
+            asm!(
+                "rep stosb",
+                inout("rdi") $dst => _,
+                inout("rcx") $count => _,
+                in("al") $value,
+                options(nostack, preserves_flags)
+            );
+        }
+    }};
+}
+
+/// Copies from MMIO to regular memory.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio(dst_ptr: *mut u8, src_io_ptr: *const u8, count: usize) {
+    if_tdx_enabled!({
+        // SAFETY: The caller guarantees both pointers are valid for `count` bytes.
+        return unsafe { cvm::copy_from_mmio(dst_ptr, src_io_ptr, count) };
+    });
+
+    do_copy_mmio_impl!(dst: dst_ptr, src: src_io_ptr, count: count);
+}
+
+/// Copies from regular memory to MMIO.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio(src_ptr: *const u8, dst_io_ptr: *mut u8, count: usize) {
+    if_tdx_enabled!({
+        // SAFETY: The caller guarantees both pointers are valid for `count` bytes.
+        return unsafe { cvm::copy_to_mmio(src_ptr, dst_io_ptr, count) };
+    });
+
+    do_copy_mmio_impl!(dst: dst_io_ptr, src: src_ptr, count: count);
+}
+
+/// Copies from MMIO to fallible memory and returns bytes copied.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio_fallible(
+    dst_ptr: *mut u8,
+    src_io_ptr: *const u8,
+    count: usize,
+) -> usize {
+    if_tdx_enabled!({
+        // SAFETY: The caller guarantees both pointers are valid for `count` bytes.
+        return unsafe { cvm::copy_from_mmio_fallible(dst_ptr, src_io_ptr, count) };
+    });
+
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_ptr, src_io_ptr, count) };
+    count - failed_bytes
+}
+
+/// Copies from fallible memory to MMIO and returns bytes copied.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid or in user space for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio_fallible(
+    src_ptr: *const u8,
+    dst_io_ptr: *mut u8,
+    count: usize,
+) -> usize {
+    if_tdx_enabled!({
+        // SAFETY: The caller guarantees both pointers are valid for `count` bytes.
+        return unsafe { cvm::copy_to_mmio_fallible(src_ptr, dst_io_ptr, count) };
+    });
+
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_io_ptr, src_ptr, count) };
+    count - failed_bytes
+}
+
+/// Fills MMIO with `value` for `count` bytes.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn memset_mmio(dst_io_ptr: *mut u8, value: u8, count: usize) {
+    if_tdx_enabled!({
+        // SAFETY: The caller guarantees the destination pointer is valid for `count` bytes.
+        return unsafe { cvm::memset_mmio(dst_io_ptr, value, count) };
+    });
+
+    do_memset_mmio_impl!(dst: dst_io_ptr, value: value, count: count);
+}

--- a/ostd/src/arch/x86/io/mod.rs
+++ b/ostd/src/arch/x86/io/mod.rs
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! I/O memory utilities and port-I/O limit definitions.
+
 use alloc::vec::Vec;
 
 use align_ext::AlignExt;
 
 use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
+
+pub(crate) mod io_mem;
+
+#[cfg(feature = "cvm_guest")]
+pub(crate) mod cvm;
 
 /// Initializes the allocatable MMIO area based on the x86-64 memory distribution map.
 ///

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -64,7 +64,6 @@ pub unsafe fn protect_gpa_tdvm_call(gpa: Paddr, size: usize) -> Result<(), PageC
 
 pub struct TrapFrameWrapper<'a>(pub &'a mut TrapFrame);
 
-#[cfg(feature = "cvm_guest")]
 impl TdxTrapFrame for TrapFrameWrapper<'_> {
     fn rax(&self) -> usize {
         self.0.rax

--- a/ostd/src/io/io_mem/mod.rs
+++ b/ostd/src/io/io_mem/mod.rs
@@ -3,6 +3,7 @@
 //! I/O memory and its allocator that allocates memory I/O (MMIO) to device drivers.
 
 mod allocator;
+pub(crate) mod util;
 
 use core::{
     marker::PhantomData,
@@ -10,15 +11,23 @@ use core::{
 };
 
 use align_ext::AlignExt;
+use inherit_methods_macro::inherit_methods;
 
 pub(crate) use self::allocator::IoMemAllocatorBuilder;
 pub(super) use self::allocator::init;
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+use crate::arch::{if_tdx_enabled, tdx_guest::unprotect_gpa_tdvm_call};
 use crate::{
     Error,
+    arch::io::io_mem::{read_once, write_once},
     cpu::{AtomicCpuSet, CpuSet},
     mm::{
-        HasPaddr, HasSize, Infallible, PAGE_SIZE, Paddr, PodOnce, VmReader, VmWriter,
-        io::util::{HasVmReaderWriter, VmReaderWriterIdentity},
+        Fallible, HasPaddr, HasSize, Infallible, PAGE_SIZE, Paddr, PodOnce, VmIo, VmIoFill,
+        VmIoOnce, VmReader, VmWriter,
+        io::{
+            Io,
+            copy::{memcpy, memset},
+        },
         kspace::kvirt_area::KVirtArea,
         page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
         tlb::{TlbFlushOp, TlbFlusher},
@@ -88,7 +97,7 @@ impl<SecuritySensitivity> IoMem<SecuritySensitivity> {
         let area_size = frames_range.len();
 
         #[cfg(target_arch = "x86_64")]
-        let priv_flags = crate::arch::if_tdx_enabled!({
+        let priv_flags = if_tdx_enabled!({
             assert!(
                 first_page_start == range.start && last_page_end == range.end,
                 "I/O memory is not page aligned, which cannot be unprotected in TDX: {:#x?}..{:#x?}",
@@ -103,7 +112,7 @@ impl<SecuritySensitivity> IoMem<SecuritySensitivity> {
             //  - The caller guarantees that operations on the I/O memory do not have any side
             //    effects that may cause soundness problems, so the pages can safely be viewed as
             //    untyped memory.
-            unsafe { crate::arch::tdx_guest::unprotect_gpa_tdvm_call(first_page_start, area_size).unwrap() };
+            unsafe { unprotect_gpa_tdvm_call(first_page_start, area_size).unwrap() };
 
             PrivilegedPageFlags::SHARED
         } else {
@@ -146,6 +155,19 @@ impl<SecuritySensitivity> IoMem<SecuritySensitivity> {
     pub fn cache_policy(&self) -> CachePolicy {
         self.cache_policy
     }
+
+    /// Returns the base virtual address of the MMIO range.
+    fn base(&self) -> usize {
+        self.kvirt_area.deref().start() + self.offset
+    }
+
+    /// Validates that the offset range lies within the MMIO window.
+    fn check_range(&self, offset: usize, len: usize) -> Result<()> {
+        if offset.checked_add(len).is_none_or(|end| end > self.limit) {
+            return Err(Error::InvalidArgs);
+        }
+        Ok(())
+    }
 }
 
 #[cfg_attr(target_arch = "loongarch64", expect(unused))]
@@ -163,10 +185,10 @@ impl IoMem<Sensitive> {
     /// not cause any out-of-bounds access, and does not cause unsound side
     /// effects (e.g., corrupting the kernel memory).
     pub(crate) unsafe fn read_once<T: PodOnce>(&self, offset: usize) -> T {
-        debug_assert!(offset + size_of::<T>() < self.limit);
+        debug_assert!(offset + size_of::<T>() <= self.limit);
         let ptr = (self.kvirt_area.deref().start() + self.offset + offset) as *const T;
         // SAFETY: The safety of the read operation's semantics is upheld by the caller.
-        unsafe { core::ptr::read_volatile(ptr) }
+        unsafe { read_once(ptr) }
     }
 
     /// Writes a value of the `PodOnce` type at the specified offset using one
@@ -182,10 +204,10 @@ impl IoMem<Sensitive> {
     /// not cause any out-of-bounds access, and does not cause unsound side
     /// effects (e.g., corrupting the kernel memory).
     pub(crate) unsafe fn write_once<T: PodOnce>(&self, offset: usize, value: &T) {
-        debug_assert!(offset + size_of::<T>() < self.limit);
+        debug_assert!(offset + size_of::<T>() <= self.limit);
         let ptr = (self.kvirt_area.deref().start() + self.offset + offset) as *mut T;
         // SAFETY: The safety of the write operation's semantics is upheld by the caller.
-        unsafe { core::ptr::write_volatile(ptr, *value) };
+        unsafe { write_once(ptr, *value) };
     }
 }
 
@@ -208,40 +230,195 @@ impl IoMem<Insensitive> {
             .acquire(range, cache_policy)
             .ok_or(Error::AccessDenied)
     }
-}
 
-// For now, we reuse `VmReader` and `VmWriter` to access I/O memory.
-//
-// Note that I/O memory is not normal typed or untyped memory. Strictly speaking, it is not
-// "memory", but rather I/O ports that communicate directly with the hardware. However, this code
-// is in OSTD, so we can rely on the implementation details of `VmReader` and `VmWriter`, which we
-// know are also suitable for accessing I/O memory.
+    /// Reads from MMIO into fallible memory and returns the copied length.
+    ///
+    /// This method performs the same low-level copy primitive as [`VmIo::read`],
+    /// but exposes partial progress instead of enforcing no-short-read semantics.
+    pub fn read_fallible(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+    ) -> core::result::Result<usize, (Error, usize)> {
+        let len = writer.avail();
+        self.check_range(offset, len).map_err(|err| (err, 0))?;
 
-impl HasVmReaderWriter for IoMem<Insensitive> {
-    type Types = VmReaderWriterIdentity;
+        let src = (self.base() + offset) as *const u8;
+        // SAFETY: `src` points to a validated MMIO range and `writer.cursor()` points to
+        // fallible destination memory tracked by `writer`.
+        let copied = unsafe { memcpy::<Fallible, Io>(writer.cursor(), src, len) };
+        writer.skip(copied);
 
-    fn reader(&self) -> VmReader<'_, Infallible> {
-        // SAFETY: The constructor of the `IoMem` structure has already ensured the
-        // safety of reading from the mapped physical address, and the mapping is valid.
-        unsafe {
-            VmReader::from_kernel_space(
-                (self.kvirt_area.deref().start() + self.offset) as *mut u8,
-                self.limit,
-            )
+        if copied < len {
+            Err((Error::PageFault, copied))
+        } else {
+            Ok(copied)
         }
     }
 
-    fn writer(&self) -> VmWriter<'_, Infallible> {
-        // SAFETY: The constructor of the `IoMem` structure has already ensured the
-        // safety of writing to the mapped physical address, and the mapping is valid.
-        unsafe {
-            VmWriter::from_kernel_space(
-                (self.kvirt_area.deref().start() + self.offset) as *mut u8,
-                self.limit,
-            )
+    /// Writes from fallible memory to MMIO and returns the copied length.
+    ///
+    /// This method performs the same low-level copy primitive as [`VmIo::write`],
+    /// but exposes partial progress instead of enforcing no-short-write semantics.
+    pub fn write_fallible(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+    ) -> core::result::Result<usize, (Error, usize)> {
+        let len = reader.remain();
+        self.check_range(offset, len).map_err(|err| (err, 0))?;
+
+        let dst = (self.base() + offset) as *mut u8;
+        // SAFETY: `dst` points to a validated MMIO range and `reader.cursor()` points to
+        // fallible source memory tracked by `reader`.
+        let copied = unsafe { memcpy::<Io, Fallible>(dst, reader.cursor(), len) };
+        reader.skip(copied);
+
+        if copied < len {
+            Err((Error::PageFault, copied))
+        } else {
+            Ok(copied)
         }
     }
 }
+
+impl VmIoOnce for IoMem<Insensitive> {
+    fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T> {
+        self.check_range(offset, size_of::<T>())?;
+        let ptr = (self.base() + offset) as *const T;
+        if !ptr.is_aligned() {
+            return Err(Error::InvalidArgs);
+        }
+
+        // SAFETY: The pointer is properly aligned and within the validated range.
+        let val = unsafe { read_once(ptr) };
+        Ok(val)
+    }
+
+    fn write_once<T: PodOnce>(&self, offset: usize, value: &T) -> Result<()> {
+        self.check_range(offset, size_of::<T>())?;
+        let ptr = (self.base() + offset) as *mut T;
+        if !ptr.is_aligned() {
+            return Err(Error::InvalidArgs);
+        }
+
+        // SAFETY: The pointer is properly aligned and within the validated range.
+        unsafe { write_once(ptr, *value) };
+        Ok(())
+    }
+}
+
+impl VmIo for IoMem<Insensitive> {
+    fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
+        let len = writer.avail();
+        self.check_range(offset, len)?;
+
+        let src = (self.base() + offset) as *const u8;
+        // SAFETY: `src` points to a validated MMIO range and `writer.cursor()` points to
+        // fallible destination memory tracked by `writer`.
+        let copied = unsafe { memcpy::<Fallible, Io>(writer.cursor(), src, len) };
+        if copied < len {
+            return Err(Error::PageFault);
+        }
+
+        writer.skip(copied);
+        Ok(())
+    }
+
+    fn read_bytes(&self, offset: usize, buf: &mut [u8]) -> Result<()> {
+        let len = buf.len();
+        self.check_range(offset, len)?;
+        let src = (self.base() + offset) as *const u8;
+        let dst = buf.as_mut_ptr();
+
+        // SAFETY: The `dst` and `src` buffers are valid to write and read for `len` bytes.
+        unsafe { memcpy::<Infallible, Io>(dst, src, len) };
+        Ok(())
+    }
+
+    fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()> {
+        let len = reader.remain();
+        self.check_range(offset, len)?;
+
+        let dst = (self.base() + offset) as *mut u8;
+        // SAFETY: `dst` points to a validated MMIO range and `reader.cursor()` points to
+        // fallible source memory tracked by `reader`.
+        let copied = unsafe { memcpy::<Io, Fallible>(dst, reader.cursor(), len) };
+        if copied < len {
+            return Err(Error::PageFault);
+        }
+
+        reader.skip(copied);
+        Ok(())
+    }
+
+    fn write_bytes(&self, offset: usize, buf: &[u8]) -> Result<()> {
+        let len = buf.len();
+        self.check_range(offset, len)?;
+        let src = buf.as_ptr();
+        let dst = (self.base() + offset) as *mut u8;
+
+        // SAFETY: The `dst` and `src` buffers are valid to write and read for `len` bytes.
+        unsafe { memcpy::<Io, Infallible>(dst, src, len) };
+        Ok(())
+    }
+}
+
+impl VmIoFill for IoMem<Insensitive> {
+    fn fill_zeros(&self, offset: usize, len: usize) -> core::result::Result<(), (Error, usize)> {
+        if len == 0 {
+            return Ok(());
+        }
+
+        if offset > self.limit {
+            return Err((Error::InvalidArgs, 0));
+        }
+
+        let available = self.limit - offset;
+        let write_len = core::cmp::min(len, available);
+        if write_len == 0 {
+            return Err((Error::InvalidArgs, 0));
+        }
+
+        let dst = (self.base() + offset) as *mut u8;
+        // SAFETY: `dst` points to the validated MMIO subrange of `write_len` bytes.
+        unsafe { memset::<Io>(dst, 0u8, write_len) };
+
+        if write_len == len {
+            Ok(())
+        } else {
+            Err((Error::InvalidArgs, write_len))
+        }
+    }
+}
+
+macro_rules! impl_vm_io_pointer {
+    ($ty:ty, $from:tt) => {
+        #[inherit_methods(from = $from)]
+        impl VmIo for $ty {
+            fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()>;
+            fn write(&self, offset: usize, reader: &mut VmReader) -> Result<()>;
+        }
+
+        #[inherit_methods(from = $from)]
+        impl VmIoOnce for $ty {
+            fn read_once<T: PodOnce>(&self, offset: usize) -> Result<T>;
+            fn write_once<T: PodOnce>(&self, offset: usize, value: &T) -> Result<()>;
+        }
+
+        #[inherit_methods(from = $from)]
+        impl VmIoFill for $ty {
+            fn fill_zeros(
+                &self,
+                offset: usize,
+                len: usize,
+            ) -> core::result::Result<(), (Error, usize)>;
+        }
+    };
+}
+
+impl_vm_io_pointer!(&IoMem<Insensitive>, "(**self)");
+impl_vm_io_pointer!(&mut IoMem<Insensitive>, "(**self)");
 
 impl<SecuritySensitivity> HasPaddr for IoMem<SecuritySensitivity> {
     fn paddr(&self) -> Paddr {
@@ -260,5 +437,161 @@ impl<SecuritySensitivity> Drop for IoMem<SecuritySensitivity> {
         // TODO: Multiple `IoMem` instances should not overlap, we should refactor the driver code and
         // remove the `Clone` and `IoMem::slice`. After refactoring, the `Drop` can be implemented to recycle
         // the `IoMem`.
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use core::mem::size_of;
+
+    use crate::{
+        arch::io::io_mem::{copy_from_mmio, copy_to_mmio, read_once, write_once},
+        prelude::ktest,
+    };
+
+    #[ktest]
+    fn read_write_u8() {
+        let mut data: u8 = 0;
+        // SAFETY: `data` is valid for a single MMIO read/write.
+        unsafe {
+            write_once(&mut data, 42u8);
+            assert_eq!(read_once(&data), 42u8);
+        }
+    }
+
+    #[ktest]
+    fn read_write_u16() {
+        let mut data: u16 = 0;
+        let val: u16 = 0x1234;
+        // SAFETY: `data` is valid for a single MMIO read/write.
+        unsafe {
+            write_once(&mut data, val);
+            assert_eq!(read_once(&data), val);
+        }
+    }
+
+    #[ktest]
+    fn read_write_u32() {
+        let mut data: u32 = 0;
+        let val: u32 = 0x12345678;
+        // SAFETY: `data` is valid for a single MMIO read/write.
+        unsafe {
+            write_once(&mut data, val);
+            assert_eq!(read_once(&data), val);
+        }
+    }
+
+    #[ktest]
+    fn read_write_u64() {
+        let mut data: u64 = 0;
+        let val: u64 = 0xDEADBEEFCAFEBABE;
+        // SAFETY: `data` is valid for a single MMIO read/write.
+        unsafe {
+            write_once(&mut data, val);
+            assert_eq!(read_once(&data), val);
+        }
+    }
+
+    #[ktest]
+    fn boundary_overlap() {
+        let mut data: [u8; 2] = [0xAA, 0xBB];
+        // SAFETY: `data` is valid for a single MMIO read/write.
+        unsafe {
+            write_once(&mut data[0], 0x11u8);
+            assert_eq!(data[0], 0x11);
+            assert_eq!(data[1], 0xBB);
+        }
+    }
+
+    fn fill_pattern(buf: &mut [u8]) {
+        for (idx, byte) in buf.iter_mut().enumerate() {
+            *byte = (idx as u8).wrapping_mul(3).wrapping_add(1);
+        }
+    }
+
+    fn run_copy_from_case(src_offset: usize, dst_offset: usize, len: usize) {
+        let mut src = [0u8; 64];
+        let mut dst = [0u8; 64];
+        fill_pattern(&mut src);
+
+        // SAFETY: Offsets are validated by callers before this helper is invoked.
+        let src_ptr = unsafe { src.as_ptr().add(src_offset) };
+        // SAFETY: Offsets are validated by callers before this helper is invoked.
+        let dst_ptr = unsafe { dst.as_mut_ptr().add(dst_offset) };
+
+        // SAFETY: The test buffers are valid for the requested range.
+        unsafe { copy_from_mmio(dst_ptr, src_ptr, len) };
+
+        assert_eq!(
+            &dst[dst_offset..dst_offset + len],
+            &src[src_offset..src_offset + len]
+        );
+    }
+
+    fn run_copy_to_case(src_offset: usize, dst_offset: usize, len: usize) {
+        let mut src = [0u8; 64];
+        let mut dst = [0u8; 64];
+        fill_pattern(&mut src);
+
+        // SAFETY: Offsets are validated by callers before this helper is invoked.
+        let src_ptr = unsafe { src.as_ptr().add(src_offset) };
+        // SAFETY: Offsets are validated by callers before this helper is invoked.
+        let dst_ptr = unsafe { dst.as_mut_ptr().add(dst_offset) };
+
+        // SAFETY: The test buffers are valid for the requested range.
+        unsafe { copy_to_mmio(src_ptr, dst_ptr, len) };
+
+        assert_eq!(
+            &dst[dst_offset..dst_offset + len],
+            &src[src_offset..src_offset + len]
+        );
+    }
+
+    #[ktest]
+    fn copy_from_alignment_and_sizes() {
+        let word_size = size_of::<usize>();
+        let sizes = [
+            0,
+            1,
+            word_size.saturating_sub(1),
+            word_size,
+            word_size + 1,
+            word_size * 2 + 3,
+        ];
+        let offsets = [0, 1, 2];
+
+        for &len in &sizes {
+            for &src_offset in &offsets {
+                for &dst_offset in &offsets {
+                    if src_offset + len <= 64 && dst_offset + len <= 64 {
+                        run_copy_from_case(src_offset, dst_offset, len);
+                    }
+                }
+            }
+        }
+    }
+
+    #[ktest]
+    fn copy_to_alignment_and_sizes() {
+        let word_size = size_of::<usize>();
+        let sizes = [
+            0,
+            1,
+            word_size.saturating_sub(1),
+            word_size,
+            word_size + 1,
+            word_size * 2 + 3,
+        ];
+        let offsets = [0, 1, 2];
+
+        for &len in &sizes {
+            for &src_offset in &offsets {
+                for &dst_offset in &offsets {
+                    if src_offset + len <= 64 && dst_offset + len <= 64 {
+                        run_copy_to_case(src_offset, dst_offset, len);
+                    }
+                }
+            }
+        }
     }
 }

--- a/ostd/src/io/io_mem/util.rs
+++ b/ostd/src/io/io_mem/util.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Alignment-aware utilities for MMIO copy and fill operations.
+
+use crate::{
+    arch::io::io_mem::{read_once, write_once},
+    mm::PodOnce,
+};
+
+/// Iterates over aligned chunk sizes and dispatches to typed MMIO operations.
+///
+/// This macro intentionally keeps the required `unsafe` operation centralized,
+/// so call sites only need to justify one high-level safety argument.
+///
+/// # Arguments
+///
+/// - `$io_addr`: Base I/O address used to derive alignment for each chunk.
+/// - `$count`: Total bytes to process.
+/// - `$max_chunk`: Maximum chunk width in bytes. Must be a power of two in `1..=8`.
+/// - `$op($args...)`: Typed operation called as `$op::<T>($args...)` for each selected chunk,
+///   where `T` is one of `u8`, `u16`, `u32`, or `u64`.
+///
+/// # Safety
+///
+/// - The enclosing function must ensure that each invocation of `$op::<T>(...)`
+///   is valid for every chunk type selected by this macro (`u8`, `u16`, `u32`, `u64`).
+/// - In particular, pointer validity and alignment for the selected chunk sizes
+///   must hold for the full `$count` range.
+/// - For MMIO, the caller must also ensure the target range supports accesses
+///   at all selected widths. Some devices require fixed-width accesses and may
+///   fault or behave unexpectedly when split into smaller operations.
+/// - `$op` must advance any pointer arguments consistently with the returned
+///   byte count so that chunk iteration stays synchronized.
+macro_rules! for_aligned_chunks {
+    ($io_addr:expr, $count:expr, $max_chunk:expr, $op:ident ( $($arg:expr),* $(,)? )) => {{
+        crate::io::io_mem::util::for_each_chunk_with_max($io_addr, $count, $max_chunk, |chunk_size| {
+            match chunk_size {
+                1 => {
+                    // SAFETY: The caller of the enclosing function guarantees pointer validity
+                    // and alignment requirements for this chunk size.
+                    unsafe { $op::<u8>($($arg),*) }
+                }
+                2 => {
+                    // SAFETY: The caller of the enclosing function guarantees pointer validity
+                    // and alignment requirements for this chunk size.
+                    unsafe { $op::<u16>($($arg),*) }
+                }
+                4 => {
+                    // SAFETY: The caller of the enclosing function guarantees pointer validity
+                    // and alignment requirements for this chunk size.
+                    unsafe { $op::<u32>($($arg),*) }
+                }
+                8 => {
+                    // SAFETY: The caller of the enclosing function guarantees pointer validity
+                    // and alignment requirements for this chunk size.
+                    unsafe { $op::<u64>($($arg),*) }
+                }
+                _ => unreachable!("unexpected chunk size: {}", chunk_size),
+            }
+        })
+    }};
+}
+
+pub(crate) use for_aligned_chunks;
+
+#[doc(hidden)]
+pub(crate) fn for_each_chunk_with_max(
+    mut io_addr: usize,
+    count: usize,
+    max_chunk: usize,
+    mut copy_chunk_fn: impl FnMut(usize) -> usize,
+) -> usize {
+    debug_assert!(max_chunk.is_power_of_two());
+    debug_assert!((1..=8).contains(&max_chunk));
+
+    let mut copied_total = 0;
+    let mut remaining = count;
+    let max_log2 = max_chunk.trailing_zeros();
+
+    while remaining > 0 {
+        let addr_align_log2 = io_addr.trailing_zeros();
+        let mut chunk_size = 1 << addr_align_log2.min(max_log2);
+
+        if chunk_size > remaining {
+            chunk_size = 1 << (usize::BITS - 1 - remaining.leading_zeros());
+        }
+
+        let copied = copy_chunk_fn(chunk_size);
+        debug_assert!(copied <= chunk_size);
+        copied_total += copied;
+        if copied < chunk_size {
+            return copied_total;
+        }
+
+        remaining -= chunk_size;
+        io_addr += chunk_size;
+    }
+
+    copied_total
+}
+
+/// Copies from MMIO to regular memory for a single value of type `T`.
+///
+/// # Safety
+///
+/// - `src_io_ptr` must be valid for MMIO reads of `size_of::<T>()` bytes and properly aligned.
+/// - `dst_ptr` must be valid for writes of `size_of::<T>()` bytes.
+pub(crate) unsafe fn copy_from_mmio_val<T: PodOnce>(
+    dst_ptr: &mut *mut u8,
+    src_io_ptr: &mut *const u8,
+) -> usize {
+    debug_assert!((*src_io_ptr).addr().is_multiple_of(align_of::<T>()));
+    // SAFETY: The caller guarantees the MMIO and regular memory pointers are valid.
+    unsafe {
+        let val: T = read_once((*src_io_ptr).cast::<T>());
+        let dst = *dst_ptr;
+        let align_mask = size_of::<T>() - 1;
+        if dst.addr() & align_mask == 0 {
+            core::ptr::write(dst.cast::<T>(), val);
+        } else {
+            core::ptr::write_unaligned(dst.cast::<T>(), val);
+        }
+    }
+
+    *src_io_ptr = (*src_io_ptr).wrapping_add(size_of::<T>());
+    *dst_ptr = (*dst_ptr).wrapping_add(size_of::<T>());
+    size_of::<T>()
+}
+
+/// Copies from regular memory to MMIO for a single value of type `T`.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `size_of::<T>()` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `size_of::<T>()` bytes and
+///   must be aligned to `align_of::<T>()`.
+pub(crate) unsafe fn copy_to_mmio_val<T: PodOnce>(
+    src_ptr: &mut *const u8,
+    dst_io_ptr: &mut *mut u8,
+) -> usize {
+    debug_assert!((*dst_io_ptr).addr().is_multiple_of(align_of::<T>()));
+    // SAFETY: The caller guarantees the regular memory and MMIO pointers are valid.
+    unsafe {
+        let src = *src_ptr;
+        let align_mask = size_of::<T>() - 1;
+        let val: T = if src.addr() & align_mask != 0 {
+            core::ptr::read_unaligned(src.cast::<T>())
+        } else {
+            core::ptr::read(src.cast::<T>())
+        };
+        write_once((*dst_io_ptr).cast::<T>(), val);
+    }
+
+    *src_ptr = (*src_ptr).wrapping_add(size_of::<T>());
+    *dst_io_ptr = (*dst_io_ptr).wrapping_add(size_of::<T>());
+    size_of::<T>()
+}
+
+/// Writes one typed repeated-byte value into MMIO destination.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `size_of::<T>()` bytes and aligned to `align_of::<T>()`.
+pub(crate) unsafe fn memset_mmio_val<T: PodOnce>(dst_io_ptr: &mut *mut u8, value: u8) -> usize {
+    debug_assert!((*dst_io_ptr).addr().is_multiple_of(align_of::<T>()));
+
+    let repeated = u64::from_ne_bytes([value; 8]);
+    // SAFETY: The caller guarantees destination pointer is valid and aligned for `T`.
+    unsafe {
+        match size_of::<T>() {
+            1 => write_once((*dst_io_ptr).cast::<u8>(), repeated as u8),
+            2 => write_once((*dst_io_ptr).cast::<u16>(), repeated as u16),
+            4 => write_once((*dst_io_ptr).cast::<u32>(), repeated as u32),
+            8 => write_once((*dst_io_ptr).cast::<u64>(), repeated),
+            _ => core::hint::unreachable_unchecked(),
+        }
+    }
+
+    *dst_io_ptr = (*dst_io_ptr).wrapping_add(size_of::<T>());
+    size_of::<T>()
+}

--- a/ostd/src/io/mod.rs
+++ b/ostd/src/io/mod.rs
@@ -7,7 +7,7 @@
 //!  - `IoMem` for memory I/O (MMIO).
 //!  - `IoPort` for port I/O (PIO).
 
-mod io_mem;
+pub(crate) mod io_mem;
 
 pub use self::io_mem::IoMem;
 #[cfg_attr(target_arch = "loongarch64", expect(unused_imports))]

--- a/ostd/src/mm/io/copy.rs
+++ b/ostd/src/mm/io/copy.rs
@@ -4,7 +4,7 @@
 //!
 //! This module provides [`Memcpy`] and [`Memset`] traits that generalize
 //! the classic C `memcpy` and `memset` for typed memory categories
-//! ([`Infallible`], [`Fallible`]).
+//! ([`Infallible`], [`Fallible`], [`Io`]).
 //!
 //! # Examples
 //!
@@ -34,9 +34,22 @@
 //!     // A page fault occurred after `filled` bytes.
 //! }
 //! ```
+//!
+//! Kernel buffer to MMIO data-region copy (for example, framebuffer upload):
+//!
+//! ```ignore
+//! // SAFETY: `src_kbuf` points to valid kernel bytes,
+//! // and `dst_io` points to a valid MMIO data region for `len` bytes.
+//! unsafe { memcpy::<Io, Infallible>(dst_io, src_kbuf, len) };
+//! ```
 
-use super::{Fallible, Infallible};
-use crate::arch::mm::{__memcpy_fallible, __memset_fallible};
+use super::{Fallible, Infallible, Io};
+use crate::arch::{
+    io::io_mem::{
+        copy_from_mmio, copy_from_mmio_fallible, copy_to_mmio, copy_to_mmio_fallible, memset_mmio,
+    },
+    mm::{__memcpy_fallible, __memset_fallible},
+};
 
 /// Copies `len` bytes from `src` to `dst`.
 ///
@@ -165,6 +178,17 @@ unsafe impl Memcpy<Fallible> for Infallible {
     }
 }
 
+// SAFETY: Delegates to `copy_from_mmio`, which correctly copies from MMIO
+// to kernel memory using MMIO-safe load/store operations.
+unsafe impl Memcpy<Io> for Infallible {
+    type Result = ();
+
+    unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { copy_from_mmio(dst, src, len) };
+    }
+}
+
 // SAFETY: Delegates to `__memcpy_fallible`,
 // which handles page faults when copying from infallible to fallible memory.
 unsafe impl Memcpy<Infallible> for Fallible {
@@ -189,6 +213,39 @@ unsafe impl Memcpy<Fallible> for Fallible {
     }
 }
 
+// SAFETY: Delegates to `copy_from_mmio_fallible`,
+// which preserves fallible semantics and handles CVM/non-CVM differences.
+unsafe impl Memcpy<Io> for Fallible {
+    type Result = usize;
+
+    unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) -> usize {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { copy_from_mmio_fallible(dst, src, len) }
+    }
+}
+
+// SAFETY: Delegates to `copy_to_mmio`, which copies from kernel memory
+// to MMIO using MMIO-safe load/store operations.
+unsafe impl Memcpy<Infallible> for Io {
+    type Result = ();
+
+    unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { copy_to_mmio(src, dst, len) };
+    }
+}
+
+// SAFETY: Delegates to `copy_to_mmio_fallible`,
+// which preserves fallible semantics and handles CVM/non-CVM differences.
+unsafe impl Memcpy<Fallible> for Io {
+    type Result = usize;
+
+    unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) -> usize {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { copy_to_mmio_fallible(src, dst, len) }
+    }
+}
+
 // SAFETY: Delegates to `volatile_set_memory`,
 // which correctly fills bytes in valid kernel memory.
 unsafe impl Memset for Infallible {
@@ -209,5 +266,16 @@ unsafe impl Memset for Fallible {
         // SAFETY: The safety is upheld by the caller.
         let failed_bytes = unsafe { __memset_fallible(dst, value, len) };
         len - failed_bytes
+    }
+}
+
+// SAFETY: Delegates to architecture MMIO fill entry,
+// which uses MMIO-safe stores on CVM guests and optimized string ops otherwise.
+unsafe impl Memset for Io {
+    type Result = ();
+
+    unsafe fn memset(dst: *mut u8, value: u8, len: usize) {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe { memset_mmio(dst, value, len) };
     }
 }

--- a/ostd/src/mm/io/mod.rs
+++ b/ostd/src/mm/io/mod.rs
@@ -252,6 +252,22 @@ pub enum Fallible {}
 /// to indicate the property of the underlying memory.
 pub enum Infallible {}
 
+/// A marker type for I/O memory regions.
+///
+/// This marker is used by [`memcpy`] and [`memset`]
+/// to indicate that a source or destination operand
+/// resides in I/O memory (MMIO).
+///
+/// Unlike [`Fallible`] and [`Infallible`],
+/// `Io` cannot statically determine
+/// whether a memory access will fault:
+/// MMIO fallibility is platform-dependent.
+/// For example, on Intel TDX
+/// every MMIO access triggers a #VE exception,
+/// whereas on a non-CVM x86 host
+/// the same access completes without faulting.
+pub(crate) enum Io {}
+
 /// Fallible memory read from a `VmWriter`.
 pub trait FallibleVmRead<F> {
     /// Reads all data into the writer until one of the three conditions is met:
@@ -930,6 +946,28 @@ impl<Fallibility> VmWriter<'_, Fallibility> {
         self.cursor = self.cursor.wrapping_add(nbytes);
 
         self
+    }
+
+    /// Creates a clone of this writer, requiring exclusive access.
+    ///
+    /// This method is analogous to [`Clone::clone`], but takes `&mut self`
+    /// instead of `&self`. The `&mut self` receiver is necessary because
+    /// `VmWriter` cannot safely implement `Clone`:
+    /// the underlying buffer may be a mutable slice,
+    /// and two concurrent writers would violate Rust's aliasing rules.
+    ///
+    /// The returned writer has the same cursor position and limit as `self`.
+    /// Because it borrows `self` mutably,
+    /// the original writer cannot be used until the returned writer is dropped.
+    ///
+    /// Note that writes through the returned writer
+    /// do **not** advance the cursor of the original writer.
+    pub fn clone_exclusive(&mut self) -> VmWriter<'_, Fallibility> {
+        VmWriter {
+            cursor: self.cursor,
+            end: self.end,
+            phantom: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Related to #2948, #2785.