### PR TITLE
Mark `call_ostd_main` as unsafe and rename it to `start_kernel`

### DIFF
--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -125,7 +125,7 @@ unsafe extern "C" fn loongarch_boot(
     let cmdline_ptr = paddr_to_vaddr(cmdline_paddr) as *const i8;
     let cmdline = unsafe { CStr::from_ptr(cmdline_ptr) }.to_str();
 
-    use crate::boot::{EARLY_INFO, EarlyBootInfo, call_ostd_main};
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
 
     EARLY_INFO.call_once(|| EarlyBootInfo {
         bootloader_name: parse_bootloader_name(),
@@ -138,5 +138,5 @@ unsafe extern "C" fn loongarch_boot(
 
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
-    unsafe { call_ostd_main() };
+    unsafe { start_kernel() };
 }

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -128,7 +128,7 @@ unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
     let fdt = unsafe { fdt::Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 
-    use crate::boot::{EARLY_INFO, EarlyBootInfo, call_ostd_main};
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
 
     EARLY_INFO.call_once(|| EarlyBootInfo {
         bootloader_name: parse_bootloader_name(),
@@ -141,5 +141,5 @@ unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
 
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
-    unsafe { call_ostd_main() };
+    unsafe { start_kernel() };
 }

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -205,7 +205,7 @@ unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
     let params = unsafe { &*params_ptr };
     assert_eq!({ params.hdr.header }, LINUX_BOOT_HEADER_MAGIC);
 
-    use crate::boot::{EARLY_INFO, EarlyBootInfo, call_ostd_main};
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
 
     #[cfg(feature = "cvm_guest")]
     init_cvm_guest();
@@ -221,5 +221,5 @@ unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
 
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
-    unsafe { call_ostd_main() };
+    unsafe { start_kernel() };
 }

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -376,7 +376,7 @@ unsafe extern "sysv64" fn __multiboot_entry(boot_magic: u32, boot_params: u64) -
     let mb1_info =
         unsafe { &*(paddr_to_vaddr(boot_params as usize) as *const MultibootLegacyInfo) };
 
-    use crate::boot::{EARLY_INFO, EarlyBootInfo, call_ostd_main};
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
 
     EARLY_INFO.call_once(|| EarlyBootInfo {
         bootloader_name: parse_bootloader_name(mb1_info).unwrap_or("Unknown Multiboot Loader"),
@@ -389,5 +389,5 @@ unsafe extern "sysv64" fn __multiboot_entry(boot_magic: u32, boot_params: u64) -
 
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
-    unsafe { call_ostd_main() };
+    unsafe { start_kernel() };
 }

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -151,7 +151,7 @@ unsafe extern "sysv64" fn __multiboot2_entry(boot_magic: u32, boot_params: u64) 
     let mb2_info =
         unsafe { BootInformation::load(boot_params as *const BootInformationHeader).unwrap() };
 
-    use crate::boot::{EARLY_INFO, EarlyBootInfo, call_ostd_main};
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
 
     EARLY_INFO.call_once(|| EarlyBootInfo {
         bootloader_name: parse_bootloader_name(&mb2_info).unwrap_or("Unknown Multiboot2 Loader"),
@@ -164,5 +164,5 @@ unsafe extern "sysv64" fn __multiboot2_entry(boot_magic: u32, boot_params: u64) 
 
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
-    unsafe { call_ostd_main() };
+    unsafe { start_kernel() };
 }

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -113,10 +113,13 @@ pub(crate) fn init_after_heap() {
     });
 }
 
-/// Initializes OSTD and then jumps to the `#[ostd::main]` entry point.
+/// Starts the kernel.
 ///
-/// Any kernel that uses the `ostd` crate should define a function marked with
-/// `#[ostd::main]` as the kernel's entry function.
+/// The job of this function is to continue the early bootstrap (started in [`arch::boot`])
+/// and performs the initialization of OSTD.
+/// Eventually, it transfers control to the entrypoint function
+/// that the user of OSTD defines with `#[ostd::main]`,
+/// which completes the kernel initialization.
 ///
 /// # Safety
 ///
@@ -124,7 +127,7 @@ pub(crate) fn init_after_heap() {
 /// [`arch::boot`] module.
 ///
 /// [`arch::boot`]: crate::arch::boot
-pub(crate) unsafe fn call_ostd_main() -> ! {
+pub(crate) unsafe fn start_kernel() -> ! {
     // The entry point of kernel code, which should be defined by the package that
     // uses OSTD.
     unsafe extern "Rust" {


### PR DESCRIPTION
`call_ostd_main` needs to be marked as `unsafe` because it requires the caller to uphold some safety preconditions, ensuring that `ostd::init` can be called safely.
https://github.com/asterinas/asterinas/blob/c9032ad97cbc002afcc5eab41c837a850fb70aa0/ostd/src/boot/mod.rs#L129-L130

This change is already discussed in https://github.com/asterinas/asterinas/issues/2928#issuecomment-3872848397.