### PR TITLE
Use new docker run action in test-nixos-minimal

### DIFF
--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build ISO
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: asterinas/asterinas:0.17.0-20260114
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas

--- a/.github/workflows/test_nixos_minimal.yml
+++ b/.github/workflows/test_nixos_minimal.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run the hello test on AsterNixOS
         timeout-minutes: 30
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: asterinas/asterinas:0.17.0-20260114
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas


### PR DESCRIPTION
Fixes [the test-nixos-minimal CI failure on the main branch](https://github.com/asterinas/asterinas/actions/runs/21969411221/job/63478883624).

The root cause is that [the Docker run action we use](https://github.com/addnab/docker-run-action) has been unmaintained for an extended period and no longer works reliably. The issue we encountered has been reported [here](https://github.com/addnab/docker-run-action/issues/62). Though I don't know why we encounter this problem now.

This PR switches to an [alternative](https://github.com/marketplace/actions/docker-run-action-fork). It's a fork of original action but fixes the problem.