### PR TITLE
Add `ptrace` syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -121,7 +121,7 @@ which are summarized in the table below.
 | 98      | getrusage              | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#getrusage) |
 | 99      | sysinfo                | ✅             | 💯 |
 | 100     | times                  | ❌             | N/A |
-| 101     | ptrace                 | ❌             | N/A |
+| 101     | ptrace                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#ptrace) |
 | 102     | getuid                 | ✅             | 💯 |
 | 103     | syslog                 | ❌             | N/A |
 | 104     | getgid                 | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
@@ -3,7 +3,7 @@
 <!--
 Put system calls such as
 fork, vfork, clone, execve, exit, exit_group, wait4, waitid,
-getpid, getppid, gettid, setuid, setgid, getuid, getgid, and prctl
+getpid, getppid, gettid, setuid, setgid, getuid, getgid, prctl and ptrace
 under this category.
 -->
 
@@ -80,3 +80,22 @@ Ignored options:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/waitid.2.html).
+
+### `ptrace`
+
+Supported functionality in SCML:
+
+```c
+{{#include ptrace.scml}}
+```
+
+Supported requests:
+* `PTRACE_TRACEME`
+* `PTRACE_CONT`
+
+Additional limitations:
+* Only the main thread of a process can act as the tracer
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/ptrace.2.html).
+

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
@@ -1,0 +1,5 @@
+// Request that the calling thread should be traced by its parent
+ptrace(request = PTRACE_TRACEME, tid, addr, data);
+
+// Resume a ptrace-stopped tracee, optionally injecting a signal
+ptrace(request = PTRACE_CONT, tid, addr, data);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -113,7 +113,14 @@ impl FileOps for StatusFileOps {
         writeln!(printer, "Tgid:\t{}", process.pid())?;
         writeln!(printer, "Pid:\t{}", posix_thread.tid())?;
         writeln!(printer, "PPid:\t{}", process.parent().pid())?;
-        writeln!(printer, "TracerPid:\t{}", 0)?;
+        writeln!(
+            printer,
+            "TracerPid:\t{}",
+            posix_thread
+                .tracer()
+                .map(|tracer| tracer.as_posix_thread().unwrap().tid())
+                .unwrap_or(0)
+        )?;
 
         writeln!(
             printer,

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -17,7 +17,9 @@ use crate::{
     prelude::*,
     process::{
         ContextUnshareAdminApi, Credentials, Process, pid_table,
-        posix_thread::{ContextPthreadAdminApi, ThreadLocal, ThreadName, sigkill_other_threads},
+        posix_thread::{
+            AsPosixThread, ContextPthreadAdminApi, ThreadLocal, ThreadName, sigkill_other_threads,
+        },
         process_vm::{MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS, ProcessVm},
         program_loader::{ProgramToLoad, elf::ElfLoadInfo},
         signal::{
@@ -237,8 +239,12 @@ fn make_current_main_thread(ctx: &Context) {
 
     // The current thread is not the main thread.
 
-    // Lock order: PID table -> tasks of process
+    // Lock order: PID table -> tracer.tracees -> tasks of process
     let mut pid_table = pid_table::pid_table_mut();
+    let tracer = ctx.posix_thread.tracer();
+    let mut tracer_tracees = tracer
+        .as_ref()
+        .map(|tracer| tracer.as_posix_thread().unwrap().tracees().unwrap().lock());
     let mut tasks = ctx.process.tasks().lock();
 
     assert!(tasks.has_exited_main());
@@ -248,7 +254,15 @@ fn make_current_main_thread(ctx: &Context) {
 
     tasks.swap_main(pid, old_tid);
     ctx.posix_thread.set_main(pid);
+
+    if let Some(tracer_tracees) = tracer_tracees.as_mut()
+        && let Some(tracee) = tracer_tracees.remove(&old_tid)
+    {
+        tracer_tracees.insert(pid, tracee);
+    }
+
     drop(tasks);
+    drop(tracer_tracees);
 
     let thread = pid_table.take_thread(old_tid).unwrap();
     pid_table.replace_thread(pid, &thread);

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -24,8 +24,8 @@ use crate::{
         program_loader::{ProgramToLoad, elf::ElfLoadInfo},
         signal::{
             HandlePendingSignal, PauseReason, SigStack,
-            constants::{SIGCHLD, SIGKILL},
-            signals::kernel::KernelSignal,
+            constants::{SIGCHLD, SIGKILL, SIGTRAP},
+            signals::{kernel::KernelSignal, user::UserSignal},
         },
     },
     vm::vmar::Vmar,
@@ -92,6 +92,17 @@ pub fn do_execve(
     if res.is_err() {
         ctx.posix_thread
             .enqueue_signal(Box::new(KernelSignal::new(SIGKILL)));
+    } else {
+        // If the PTRACE_O_TRACEEXEC option is not in effect, all successful
+        // calls to execve(2) by the traced process will cause it to be sent
+        // a SIGTRAP signal, giving the parent a chance to gain control
+        // before the new program begins execution.
+        //
+        // Reference: <https://man7.org/linux/man-pages/man2/ptrace.2.html>
+        if ctx.posix_thread.is_traced() {
+            ctx.posix_thread
+                .enqueue_signal(Box::new(UserSignal::new_kill(SIGTRAP, ctx)));
+        }
     }
 
     ctx.process.tasks().lock().finish_execve();

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -181,6 +181,7 @@ impl PosixThreadBuilder {
                     default_timer_slack_ns: AtomicU64::new(default_timer_slack_ns),
                     tracee_status: Once::new(),
                     tracees: Once::new(),
+                    exit_code: AtomicU32::new(0),
                 }
             };
 

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -8,6 +8,7 @@ use ostd::{
     sync::RwArc,
     task::Task,
 };
+use spin::Once;
 
 use super::{PosixThread, ThreadLocal};
 use crate::{
@@ -178,6 +179,8 @@ impl PosixThreadBuilder {
                     ns_proxy: Mutex::new(Some(ns_proxy.clone())),
                     timer_slack_ns: AtomicU64::new(default_timer_slack_ns),
                     default_timer_slack_ns: AtomicU64::new(default_timer_slack_ns),
+                    tracee_status: Once::new(),
+                    tracees: Once::new(),
                 }
             };
 

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -81,6 +81,11 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
     // holding the `tracees` lock, and can not race with `clear_tracees`.
     posix_thread.clear_tracees();
 
+    if let Some(tracer) = posix_thread.tracer() {
+        let tracer = tracer.as_posix_thread().unwrap();
+        tracer.process().children_wait_queue().wake_all();
+    }
+
     wake_clear_ctid(thread_local);
 
     wake_robust_list(thread_local, posix_thread.tid());

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -72,6 +72,11 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
         tasks.remove_exited(&current_task, posix_thread.tid())
     };
 
+    // This is put after `current_thread.exit()`,
+    // so `attach_tracee` will observe that the tracer has exited while
+    // holding the `tracees` lock, and can not race with `clear_tracees`.
+    posix_thread.clear_tracees();
+
     wake_clear_ctid(thread_local);
 
     wake_robust_list(thread_local, posix_thread.tid());

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -40,6 +40,8 @@ pub fn do_exit_group(term_status: TermStatus) {
 
 /// Exits the current POSIX thread or process.
 fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
+    let exit_code = term_status.as_u32();
+
     let current_task = Task::current().unwrap();
     let current_thread = current_task.as_thread().unwrap();
     let posix_thread = current_thread.as_posix_thread().unwrap();
@@ -59,8 +61,10 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
         // According to Linux's behavior, the last thread's exit code will become the process's
         // exit code, so here we should just overwrite the old value (if any).
         if !has_exited_group && !in_evecve {
-            posix_process.status().set_exit_code(term_status.as_u32());
+            posix_process.status().set_exit_code(exit_code);
         }
+
+        posix_thread.set_exit_code(exit_code);
 
         // We should only change the thread status when running as the thread, so no race
         // conditions can occur in between.

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -33,7 +33,7 @@ mod exit;
 pub mod futex;
 mod name;
 mod posix_thread_ext;
-mod ptrace;
+pub mod ptrace;
 mod robust_list;
 mod thread_local;
 

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -7,6 +7,7 @@ use ostd::{
     sync::{RoArc, RwMutexReadGuard, Waker},
     task::Task,
 };
+use spin::Once;
 
 use super::{
     Credentials, Process,
@@ -19,9 +20,10 @@ use crate::{
     process::{
         Pid,
         namespace::nsproxy::NsProxy,
+        posix_thread::ptrace::TraceeStatus,
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
     },
-    thread::Tid,
+    thread::{Thread, Tid},
     time::{Timer, TimerManager, clocks::ProfClock, timer::TimerGuard},
 };
 
@@ -31,6 +33,7 @@ mod exit;
 pub mod futex;
 mod name;
 mod posix_thread_ext;
+mod ptrace;
 mod robust_list;
 mod thread_local;
 
@@ -90,6 +93,12 @@ pub struct PosixThread {
     timer_slack_ns: AtomicU64,
     /// The default timer slack value for this thread.
     default_timer_slack_ns: AtomicU64,
+
+    /// Status of being traced.
+    tracee_status: Once<TraceeStatus>,
+
+    /// Threads traced by this thread.
+    tracees: Once<Mutex<BTreeMap<Tid, Arc<Thread>>>>,
 }
 
 impl PosixThread {

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     fs::{file::file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::{
-        Pid,
+        ExitCode, Pid,
         namespace::nsproxy::NsProxy,
         posix_thread::ptrace::TraceeStatus,
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
@@ -99,6 +99,9 @@ pub struct PosixThread {
 
     /// Threads traced by this thread.
     tracees: Once<Mutex<BTreeMap<Tid, Arc<Thread>>>>,
+
+    /// Exit code of this thread.
+    exit_code: AtomicU32,
 }
 
 impl PosixThread {
@@ -324,6 +327,16 @@ impl PosixThread {
     pub fn reset_timer_slack_to_default(&self) {
         let default = self.default_timer_slack_ns.load(Ordering::Relaxed);
         self.timer_slack_ns.store(default, Ordering::Relaxed);
+    }
+
+    /// Sets the exit code of this thread.
+    pub(super) fn set_exit_code(&self, exit_code: ExitCode) {
+        self.exit_code.store(exit_code, Ordering::Relaxed);
+    }
+
+    /// Returns the exit code of this thread.
+    pub fn exit_code(&self) -> ExitCode {
+        self.exit_code.load(Ordering::Relaxed)
     }
 }
 

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -2,13 +2,33 @@
 
 //! Ptrace implementation for POSIX threads.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ostd::sync::Waiter;
+
 use super::{AsPosixThread, PosixThread};
 use crate::{
     prelude::*,
+    process::signal::{
+        DequeuedSignal, PauseReason,
+        c_types::siginfo_t,
+        constants::{CLD_TRAPPED, SIGCHLD},
+        signals::raw::RawSignal,
+    },
     thread::{Thread, Tid},
 };
 
+mod util;
+
+pub(in crate::process) use util::PtraceStopResult;
+use util::StopDeliverySignal;
+
 impl PosixThread {
+    /// Returns whether this thread is being traced.
+    pub(in crate::process) fn is_traced(&self) -> bool {
+        self.tracer().is_some()
+    }
+
     /// Returns the tracer of this thread if it is being traced.
     pub fn tracer(&self) -> Option<Arc<Thread>> {
         self.tracee_status.get().and_then(|status| status.tracer())
@@ -28,6 +48,22 @@ impl PosixThread {
     pub(in crate::process) fn detach_tracer(&self) {
         if let Some(status) = self.tracee_status.get() {
             status.detach_tracer();
+            self.wake_signalled_waker();
+        }
+    }
+
+    /// Stops this thread by ptrace with the given signal if it is currently traced.
+    ///
+    /// Returns a [`PtraceStopResult`] indicating why this ptrace-stop ended.
+    pub(in crate::process) fn ptrace_stop(
+        &self,
+        signal: DequeuedSignal,
+        ctx: &Context,
+    ) -> PtraceStopResult {
+        if let Some(status) = self.tracee_status.get() {
+            status.ptrace_stop(signal, ctx)
+        } else {
+            PtraceStopResult::NotTraced(signal)
         }
     }
 }
@@ -88,12 +124,14 @@ impl PosixThread {
 }
 
 pub(super) struct TraceeStatus {
+    is_stopped: AtomicBool,
     state: Mutex<TraceeState>,
 }
 
 impl TraceeStatus {
     pub(super) fn new() -> Self {
         Self {
+            is_stopped: AtomicBool::new(false),
             state: Mutex::new(TraceeState::new()),
         }
     }
@@ -113,18 +151,71 @@ impl TraceeStatus {
     }
 
     fn detach_tracer(&self) {
-        self.state.lock().tracer = Weak::new();
+        // Hold the lock first to avoid race conditions.
+        let mut state = self.state.lock();
+
+        state.tracer = Weak::new();
+        self.is_stopped.store(false, Ordering::Relaxed);
+    }
+
+    fn ptrace_stop(&self, signal: DequeuedSignal, ctx: &Context) -> PtraceStopResult {
+        // Hold the lock first to avoid race conditions.
+        let mut state = self.state.lock();
+
+        let Some(tracer) = state.tracer() else {
+            return PtraceStopResult::NotTraced(signal);
+        };
+
+        debug_assert!(!self.is_ptrace_stopped());
+
+        state.signal.stop(signal);
+        self.is_stopped.store(true, Ordering::Relaxed);
+        drop(state);
+
+        let tracer = tracer.as_posix_thread().unwrap();
+        tracer.enqueue_signal(Box::new(RawSignal::new({
+            let mut siginfo = siginfo_t::new(SIGCHLD, CLD_TRAPPED);
+            siginfo.set_pid_uid_by(ctx);
+            siginfo
+        })));
+        tracer.process().children_wait_queue().wake_all();
+
+        let waiter = Waiter::new_pair().0;
+        if waiter
+            .pause_until_by(
+                || (!self.is_ptrace_stopped()).then_some(()),
+                PauseReason::StopByPtrace,
+            )
+            .is_err()
+        {
+            // A `SIGKILL` interrupts this ptrace-stop.
+            let mut state = self.state.lock();
+            state.signal.clear();
+            self.is_stopped.store(false, Ordering::Relaxed);
+            return PtraceStopResult::Interrupted;
+        };
+
+        let mut state = self.state.lock();
+        let signal = state.signal.clear();
+        PtraceStopResult::Continued(signal)
+    }
+
+    fn is_ptrace_stopped(&self) -> bool {
+        self.is_stopped.load(Ordering::Relaxed)
     }
 }
 
 struct TraceeState {
     tracer: Weak<Thread>,
+    /// The signal associated with the current ptrace-stop and later signal delivery.
+    signal: StopDeliverySignal,
 }
 
 impl TraceeState {
     fn new() -> Self {
         Self {
             tracer: Weak::new(),
+            signal: StopDeliverySignal::default(),
         }
     }
 

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -16,7 +16,7 @@ use crate::{
             c_types::siginfo_t,
             constants::{CLD_TRAPPED, SIGCHLD},
             sig_num::SigNum,
-            signals::raw::RawSignal,
+            signals::{raw::RawSignal, user::UserSignal},
         },
     },
     thread::{Thread, Tid},
@@ -24,6 +24,7 @@ use crate::{
 
 mod util;
 
+pub use util::PtraceContRequest;
 pub(in crate::process) use util::PtraceStopResult;
 use util::StopDeliverySignal;
 
@@ -77,6 +78,31 @@ impl PosixThread {
             .get()
             .and_then(|status| status.wait(options))
     }
+
+    /// Continues this thread from a ptrace-stop.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread is not ptrace-stopped.
+    pub fn ptrace_continue(&self, request: PtraceContRequest, ctx: &Context) -> Result<()> {
+        let status = self.get_tracee_status()?;
+
+        status.resume(request, ctx)?;
+        self.wake_signalled_waker();
+
+        Ok(())
+    }
+
+    /// Returns the tracee status of this thread if it has ever been traced.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread has never been traced.
+    fn get_tracee_status(&self) -> Result<&TraceeStatus> {
+        self.tracee_status
+            .get()
+            .ok_or_else(|| Error::with_message(Errno::ESRCH, "the thread has never been traced"))
+    }
 }
 
 impl PosixThread {
@@ -117,6 +143,17 @@ impl PosixThread {
     /// Returns the tracee map of this thread if it is a tracer.
     pub(in crate::process) fn tracees(&self) -> Option<&Mutex<BTreeMap<Tid, Arc<Thread>>>> {
         self.tracees.get()
+    }
+
+    /// Returns the tracee with the given tid, if it is being traced by this thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if there is no tracee with the given tid.
+    pub fn get_tracee(&self, tid: Tid) -> Result<Arc<Thread>> {
+        self.tracees()
+            .and_then(|tracees| tracees.lock().get(&tid).cloned())
+            .ok_or_else(|| Error::with_message(Errno::ESRCH, "no such tracee"))
     }
 
     /// Clears all tracees of this tracer on exit.
@@ -215,6 +252,14 @@ impl TraceeStatus {
         self.is_stopped.load(Ordering::Relaxed)
     }
 
+    fn check_ptrace_stopped(&self, _state_guard: &MutexGuard<'_, TraceeState>) -> Result<()> {
+        if self.is_ptrace_stopped() {
+            Ok(())
+        } else {
+            return_errno_with_message!(Errno::ESRCH, "the thread is not ptrace-stopped");
+        }
+    }
+
     fn wait(&self, options: WaitOptions) -> Option<SigNum> {
         // Hold the lock first to avoid race conditions.
         let mut state = self.state.lock();
@@ -226,6 +271,23 @@ impl TraceeStatus {
 
         let signal = state.signal.wait(options)?;
         Some(signal.num())
+    }
+
+    fn resume(&self, request: PtraceContRequest, ctx: &Context) -> Result<()> {
+        // Hold the lock first to avoid race conditions.
+        let mut state = self.state.lock();
+        self.check_ptrace_stopped(&state)?;
+
+        if let Some(sig_num) = request.sig_num() {
+            state
+                .signal
+                .inject(Box::new(UserSignal::new_kill(sig_num, ctx)));
+        } else {
+            state.signal.clear();
+        }
+        self.is_stopped.store(false, Ordering::Relaxed);
+
+        Ok(())
     }
 }
 

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ptrace implementation for POSIX threads.
+
+use super::{AsPosixThread, PosixThread};
+use crate::{
+    prelude::*,
+    thread::{Thread, Tid},
+};
+
+impl PosixThread {
+    /// Returns the tracer of this thread if it is being traced.
+    pub fn tracer(&self) -> Option<Arc<Thread>> {
+        self.tracee_status.get().and_then(|status| status.tracer())
+    }
+
+    /// Sets the tracer of this thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EPERM` if this thread is already being traced.
+    fn set_tracer(&self, tracer: Weak<Thread>) -> Result<()> {
+        let status = self.tracee_status.call_once(TraceeStatus::new);
+        status.set_tracer(tracer)
+    }
+
+    /// Detaches the tracer of this thread.
+    pub(in crate::process) fn detach_tracer(&self) {
+        if let Some(status) = self.tracee_status.get() {
+            status.detach_tracer();
+        }
+    }
+}
+
+impl PosixThread {
+    /// Attaches this tracer to the given tracee.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EPERM` if the tracee is already being traced.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tracer_thread` and `self` do not point to the same thread,
+    /// or if `tracee_thread` is not a POSIX thread.
+    pub fn attach_to(&self, tracer_thread: &Arc<Thread>, tracee_thread: Arc<Thread>) -> Result<()> {
+        debug_assert!(core::ptr::eq(
+            tracer_thread.as_posix_thread().unwrap(),
+            self
+        ));
+
+        let tracees = self.tracees.call_once(|| Mutex::new(BTreeMap::new()));
+
+        // Lock order: tracer.tracees -> tracee.tracee_status
+        let mut tracees = tracees.lock();
+        if tracer_thread.is_exited() {
+            // Pretend that the tracer immediately detaches the tracee,
+            // if the tracer has already exited.
+            // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/ptrace.c#L496-L498>
+            return Ok(());
+        }
+
+        let tracee = tracee_thread.as_posix_thread().unwrap();
+        tracee.set_tracer(Arc::downgrade(tracer_thread))?;
+        tracees.insert(tracee.tid(), tracee_thread);
+
+        Ok(())
+    }
+
+    /// Returns the tracee map of this thread if it is a tracer.
+    pub(in crate::process) fn tracees(&self) -> Option<&Mutex<BTreeMap<Tid, Arc<Thread>>>> {
+        self.tracees.get()
+    }
+
+    /// Clears all tracees of this tracer on exit.
+    pub(in crate::process) fn clear_tracees(&self) {
+        let Some(tracees) = self.tracees() else {
+            return;
+        };
+
+        // Lock order: tracer.tracees -> tracee.tracee_status
+        let tracees = tracees.lock();
+        for (_, tracee) in tracees.iter() {
+            let tracee = tracee.as_posix_thread().unwrap();
+            tracee.detach_tracer();
+        }
+    }
+}
+
+pub(super) struct TraceeStatus {
+    state: Mutex<TraceeState>,
+}
+
+impl TraceeStatus {
+    pub(super) fn new() -> Self {
+        Self {
+            state: Mutex::new(TraceeState::new()),
+        }
+    }
+
+    fn tracer(&self) -> Option<Arc<Thread>> {
+        self.state.lock().tracer()
+    }
+
+    fn set_tracer(&self, tracer: Weak<Thread>) -> Result<()> {
+        let mut state = self.state.lock();
+        if state.tracer().is_some() {
+            return_errno_with_message!(Errno::EPERM, "the thread is already being traced");
+        }
+        state.tracer = tracer;
+
+        Ok(())
+    }
+
+    fn detach_tracer(&self) {
+        self.state.lock().tracer = Weak::new();
+    }
+}
+
+struct TraceeState {
+    tracer: Weak<Thread>,
+}
+
+impl TraceeState {
+    fn new() -> Self {
+        Self {
+            tracer: Weak::new(),
+        }
+    }
+
+    fn tracer(&self) -> Option<Arc<Thread>> {
+        self.tracer.upgrade()
+    }
+}

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -9,11 +9,15 @@ use ostd::sync::Waiter;
 use super::{AsPosixThread, PosixThread};
 use crate::{
     prelude::*,
-    process::signal::{
-        DequeuedSignal, PauseReason,
-        c_types::siginfo_t,
-        constants::{CLD_TRAPPED, SIGCHLD},
-        signals::raw::RawSignal,
+    process::{
+        WaitOptions,
+        signal::{
+            DequeuedSignal, PauseReason,
+            c_types::siginfo_t,
+            constants::{CLD_TRAPPED, SIGCHLD},
+            sig_num::SigNum,
+            signals::raw::RawSignal,
+        },
     },
     thread::{Thread, Tid},
 };
@@ -65,6 +69,13 @@ impl PosixThread {
         } else {
             PtraceStopResult::NotTraced(signal)
         }
+    }
+
+    /// Returns the ptrace-stop status changes for the `wait` syscall.
+    pub(in crate::process) fn wait_ptrace_stopped(&self, options: WaitOptions) -> Option<SigNum> {
+        self.tracee_status
+            .get()
+            .and_then(|status| status.wait(options))
     }
 }
 
@@ -202,6 +213,19 @@ impl TraceeStatus {
 
     fn is_ptrace_stopped(&self) -> bool {
         self.is_stopped.load(Ordering::Relaxed)
+    }
+
+    fn wait(&self, options: WaitOptions) -> Option<SigNum> {
+        // Hold the lock first to avoid race conditions.
+        let mut state = self.state.lock();
+
+        // Avoid the race with `detach_tracer` or `resume` in between.
+        if !self.is_ptrace_stopped() {
+            return None;
+        }
+
+        let signal = state.signal.wait(options)?;
+        Some(signal.num())
     }
 }
 

--- a/kernel/src/process/posix_thread/ptrace/util.rs
+++ b/kernel/src/process/posix_thread/ptrace/util.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ptrace utilities for POSIX threads.
+
+use crate::{
+    prelude::*,
+    process::{
+        WaitOptions,
+        signal::{DequeuedSignal, signals::Signal},
+    },
+};
+
+/// The result of a ptrace-stop.
+pub enum PtraceStopResult {
+    /// The ptrace-stop is continued by the tracer,
+    /// or ends because the tracer exits or detaches.
+    Continued(Option<DequeuedSignal>),
+    /// The ptrace-stop is interrupted by `SIGKILL`.
+    Interrupted,
+    /// The thread is not traced, returning the stop signal back.
+    NotTraced(DequeuedSignal),
+}
+
+/// The signal associated with a ptrace-stop and its later signal delivery.
+#[derive(Default)]
+pub(super) enum StopDeliverySignal {
+    /// The signal that has not yet been reported through `wait`.
+    Pending(DequeuedSignal),
+    /// The signal that has been reported through `wait`.
+    Consumed(DequeuedSignal),
+    /// The signal that is injected by the tracer.
+    Injected(DequeuedSignal),
+    /// No ptrace-stop signal is recorded.
+    #[default]
+    Empty,
+}
+
+impl StopDeliverySignal {
+    /// Records the signal associated with a ptrace-stop.
+    pub(super) fn stop(&mut self, signal: DequeuedSignal) {
+        *self = Self::Pending(signal);
+    }
+
+    /// Clears and returns the signal associated with a ptrace-stop,
+    /// unless it has already been consumed by `wait`.
+    pub(super) fn clear(&mut self) -> Option<DequeuedSignal> {
+        let this = core::mem::replace(self, Self::Empty);
+
+        match this {
+            Self::Pending(signal) | Self::Injected(signal) => Some(signal),
+            Self::Consumed(_) | Self::Empty => None,
+        }
+    }
+
+    /// Returns the signal associated with a ptrace-stop,
+    /// if it has not yet been reported through `wait`.
+    pub(super) fn wait(&mut self, options: WaitOptions) -> Option<&dyn Signal> {
+        let this = core::mem::replace(self, Self::Empty);
+
+        match this {
+            Self::Pending(signal) => {
+                if !options.contains(WaitOptions::WNOWAIT) {
+                    *self = Self::Consumed(signal);
+                } else {
+                    *self = Self::Pending(signal);
+                }
+                Some(self.get().unwrap())
+            }
+            Self::Consumed(signal) => {
+                *self = Self::Consumed(signal);
+                None
+            }
+            Self::Injected(_) => unreachable!(),
+            Self::Empty => None,
+        }
+    }
+
+    /// Injects a signal by the tracer.
+    pub(super) fn inject(&mut self, new_signal: Box<dyn Signal>) {
+        let this = core::mem::replace(self, Self::Empty);
+
+        let mut signal = match this {
+            Self::Pending(signal) | Self::Consumed(signal) => signal,
+            Self::Injected(_) | Self::Empty => unreachable!(),
+        };
+
+        signal.set_signal(new_signal);
+        *self = Self::Injected(signal);
+    }
+
+    /// Returns the signal associated with a ptrace-stop,
+    /// but does not change the state.
+    fn get(&self) -> Option<&dyn Signal> {
+        match self {
+            Self::Pending(signal) | Self::Consumed(signal) | Self::Injected(signal) => {
+                Some(signal.signal())
+            }
+            Self::Empty => None,
+        }
+    }
+}

--- a/kernel/src/process/posix_thread/ptrace/util.rs
+++ b/kernel/src/process/posix_thread/ptrace/util.rs
@@ -6,9 +6,29 @@ use crate::{
     prelude::*,
     process::{
         WaitOptions,
-        signal::{DequeuedSignal, signals::Signal},
+        signal::{DequeuedSignal, sig_num::SigNum, signals::Signal},
     },
 };
+
+/// The requests that can continue a stopped tracee.
+pub enum PtraceContRequest {
+    Continue(Option<SigNum>),
+    #[expect(dead_code)]
+    SingleStep(Option<SigNum>),
+    #[expect(dead_code)]
+    Syscall(Option<SigNum>),
+}
+
+impl PtraceContRequest {
+    pub(super) fn sig_num(&self) -> Option<SigNum> {
+        match self {
+            Self::Continue(Some(sig_num))
+            | Self::SingleStep(Some(sig_num))
+            | Self::Syscall(Some(sig_num)) => Some(*sig_num),
+            _ => None,
+        }
+    }
+}
 
 /// The result of a ptrace-stop.
 pub enum PtraceStopResult {

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -680,9 +680,6 @@ impl Process {
     }
 
     /// Stops the process.
-    //
-    // FIXME: `ptrace` is another reason that can cause a process to stop.
-    // Consider extending the method signature to support `ptrace` if necessary.
     pub fn stop(&self, sig_num: SigNum) {
         if self.status.stop_status().stop(sig_num) {
             self.wake_up_parent();

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -64,6 +64,10 @@ impl siginfo_t {
         self.siginfo_fields.common_mut().first = pid_uid;
     }
 
+    pub fn set_pid_uid_by(&mut self, ctx: &Context) {
+        self.set_pid_uid(ctx.process.pid(), ctx.posix_thread.credentials().ruid());
+    }
+
     pub fn set_status(&mut self, status: i32) {
         *self
             .siginfo_fields

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -22,7 +22,7 @@ use ostd::{
     user::UserContextApi,
 };
 pub use pause::{Pause, PauseReason, with_sigmask_changed};
-pub use pending::HandlePendingSignal;
+pub use pending::{DequeuedSignal, HandlePendingSignal};
 pub use poll::{PollAdaptor, PollHandle, Pollable, Pollee, Poller};
 use sig_action::{SigAction, SigActionFlags, SigDefaultAction};
 use sig_mask::SigMask;
@@ -36,7 +36,7 @@ use crate::{
     process::{
         TermStatus,
         posix_thread::{ContextPthreadAdminApi, do_exit_group},
-        signal::{c_types::stack_t, signals::Signal},
+        signal::c_types::stack_t,
     },
 };
 
@@ -67,7 +67,7 @@ pub fn handle_pending_signal(
         .take()
         .map(|mask| RestoreSigMaskGuard { ctx, mask });
 
-    let (signal, sig_action) = if let Some(dequeued_signal) = dequeue_pending_signal(ctx) {
+    let (dequeued, sig_action) = if let Some(dequeued_signal) = dequeue_pending_signal(ctx) {
         dequeued_signal
     } else {
         // Fast path: There is no signal mask to restore.
@@ -84,6 +84,8 @@ pub fn handle_pending_signal(
             return;
         }
     };
+
+    let signal = dequeued.unwrap();
 
     let sig_num = signal.num();
     match sig_action {
@@ -184,7 +186,7 @@ impl Drop for RestoreSigMaskGuard<'_> {
     }
 }
 
-fn dequeue_pending_signal(ctx: &Context) -> Option<(Box<dyn Signal>, SigAction)> {
+fn dequeue_pending_signal(ctx: &Context) -> Option<(DequeuedSignal, SigAction)> {
     let posix_thread = ctx.posix_thread;
 
     let sig_dispositions = ctx.process.sig_dispositions().lock();

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -98,6 +98,15 @@ pub fn handle_pending_signal(
             restorer_addr,
             mask,
         } => {
+            if flags.contains(SigActionFlags::SA_RESETHAND) {
+                // In Linux, SA_RESETHAND corresponds to SA_ONESHOT,
+                // which means the user handler will be executed only once and then reset to the default.
+                // Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/kernel/signal.c#L2761>.
+                let sig_dispositions = ctx.process.sig_dispositions().lock();
+                let mut sig_dispositions = sig_dispositions.lock();
+                sig_dispositions.set_default(sig_num);
+            }
+
             if let Some(pre_syscall_ret) = syscall_restart
                 && flags.contains(SigActionFlags::SA_RESTART)
             {
@@ -190,7 +199,7 @@ fn dequeue_pending_signal(ctx: &Context) -> Option<(DequeuedSignal, SigAction)> 
     let posix_thread = ctx.posix_thread;
 
     let sig_dispositions = ctx.process.sig_dispositions().lock();
-    let mut sig_dispositions = sig_dispositions.lock();
+    let sig_dispositions = sig_dispositions.lock();
 
     let sig_mask = posix_thread.sig_mask();
     let (signal, sig_num, sig_action) = loop {
@@ -204,19 +213,10 @@ fn dequeue_pending_signal(ctx: &Context) -> Option<(DequeuedSignal, SigAction)> 
         break (signal, sig_num, sig_action);
     };
 
-    if let SigAction::User { flags, .. } = &sig_action
-        && flags.contains(SigActionFlags::SA_RESETHAND)
-    {
-        // In Linux, SA_RESETHAND corresponds to SA_ONESHOT,
-        // which means the user handler will be executed only once and then reset to the default.
-        // Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/kernel/signal.c#L2761>.
-        sig_dispositions.set_default(sig_num);
-    }
-
     debug!(
         "sig_num = {:?}, sig_name = {}, sig_action = {:#x?}",
-        signal.num(),
-        signal.num().sig_name(),
+        sig_num,
+        sig_num.sig_name(),
         sig_action
     );
 

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -35,8 +35,8 @@ use crate::{
     prelude::*,
     process::{
         TermStatus,
-        posix_thread::{ContextPthreadAdminApi, do_exit_group},
-        signal::c_types::stack_t,
+        posix_thread::{ContextPthreadAdminApi, do_exit_group, ptrace::PtraceStopResult},
+        signal::{c_types::stack_t, constants::SIGKILL},
     },
 };
 
@@ -51,6 +51,10 @@ pub fn handle_pending_signal(
     ctx: &Context,
     pre_syscall_ret: Option<usize>,
 ) {
+    // FIXME: This function may handle or suppress only one signal per trap, delaying
+    // other pending unmasked signals until the next trap. Consider a looped scan.
+    //
+    // For details, see <https://github.com/asterinas/asterinas/pull/2984/#discussion_r3137275994>.
     let syscall_restart = if let Some(pre_syscall_ret) = pre_syscall_ret
         && user_ctx.syscall_ret() == -(Errno::ERESTARTSYS as i32) as usize
     {
@@ -85,7 +89,42 @@ pub fn handle_pending_signal(
         }
     };
 
-    let signal = dequeued.unwrap();
+    let (signal, sig_action) = if dequeued.num() != SIGKILL {
+        match ctx.posix_thread.ptrace_stop(dequeued, ctx) {
+            PtraceStopResult::Continued(Some(dequeued)) => {
+                // Note that this `dequeued` object outputted by `ptrace_stop`
+                // might be different from the input `dequeued` object
+                // because of tracer manipulation.
+                // But we name both `dequeued` anyway.
+
+                let sig_num = dequeued.num();
+                if ctx.posix_thread.sig_mask().contains(sig_num) {
+                    // Requeue the injected signal to the same signal queue as the
+                    // dequeued stop signal (thread queue or process queue).
+                    //
+                    // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/signal.c#L2770>
+                    requeue_signal(ctx, dequeued);
+                    return;
+                }
+
+                (dequeued.unwrap(), get_sig_action(ctx, sig_num))
+            }
+            PtraceStopResult::Continued(None) => return,
+            PtraceStopResult::Interrupted => {
+                match dequeue_pending_signal(ctx) {
+                    Some((dequeued, action)) if dequeued.num() == SIGKILL => {
+                        (dequeued.unwrap(), action)
+                    }
+                    // SIGKILL was consumed by a sibling thread; this thread will be
+                    // terminated as part of the process-wide exit.
+                    _ => return,
+                }
+            }
+            PtraceStopResult::NotTraced(dequeued) => (dequeued.unwrap(), sig_action),
+        }
+    } else {
+        (dequeued.unwrap(), sig_action)
+    };
 
     let sig_num = signal.num();
     match sig_action {
@@ -206,7 +245,7 @@ fn dequeue_pending_signal(ctx: &Context) -> Option<(DequeuedSignal, SigAction)> 
         let signal = ctx.dequeue_signal(&sig_mask)?;
         let sig_num = signal.num();
         let sig_action = sig_dispositions.get(sig_num);
-        if sig_action.will_ignore(sig_num) {
+        if sig_action.will_ignore(sig_num) && !posix_thread.is_traced() {
             continue;
         }
 
@@ -221,6 +260,26 @@ fn dequeue_pending_signal(ctx: &Context) -> Option<(DequeuedSignal, SigAction)> 
     );
 
     Some((signal, sig_action))
+}
+
+/// Re-queue the ptrace-captured signal.
+///
+/// This appends to the tail of the origin queue,
+/// which (a) loses same-number RT-signal send-order FIFO and
+/// (b) allows newer lower-numbered standard signals queued
+/// during the ptrace stop to preempt this signal.
+/// This is intentionally consistent with Linux's behaviors.
+fn requeue_signal(ctx: &Context, signal: DequeuedSignal) {
+    match signal {
+        DequeuedSignal::FromProcess(signal) => ctx.process.enqueue_signal(signal),
+        DequeuedSignal::FromThread(signal) => ctx.posix_thread.enqueue_signal(signal),
+    }
+}
+
+fn get_sig_action(ctx: &Context, sig_num: SigNum) -> SigAction {
+    let sig_dispositions = ctx.process.sig_dispositions().lock();
+    let sig_dispositions = sig_dispositions.lock();
+    sig_dispositions.get(sig_num)
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -49,6 +49,8 @@ pub trait Pause: WaitTimeout {
     /// This pause happens due to the reason specified. If the reason is `PauseReason::Sleep`,
     /// the caller should use `pause_until` straightforwardly.
     ///
+    /// If the reason is `PauseReason::StopByPtrace`, it can only be interrupted by `SIGKILL`.
+    ///
     /// # Errors
     ///
     /// This method will return an error with [`EINTR`] if a signal is received before the
@@ -145,7 +147,12 @@ impl Pause for Waiter {
         };
 
         let cancel_cond = || {
-            if posix_thread.has_pending() {
+            let has_pending = match reason {
+                PauseReason::StopByPtrace => posix_thread.has_pending_sigkill(),
+                _ => posix_thread.has_pending(),
+            };
+
+            if has_pending {
                 return Err(Error::with_message(
                     Errno::EINTR,
                     "the current thread is interrupted by a signal",
@@ -244,10 +251,10 @@ impl Pause for WaitQueue {
 }
 
 /// The reason why a process is paused by a `pause`-family method.
+#[derive(Debug, Clone, Copy)]
 pub enum PauseReason {
     Sleep,
     StopBySignal,
-    #[expect(dead_code)]
     StopByPtrace,
 }
 

--- a/kernel/src/process/signal/pending.rs
+++ b/kernel/src/process/signal/pending.rs
@@ -6,12 +6,48 @@ use crate::{
         Process,
         posix_thread::PosixThread,
         signal::{
+            SigNum,
             constants::SIGKILL,
             sig_mask::{SigMask, SigSet},
             signals::Signal,
         },
     },
 };
+
+/// A signal dequeued from either the thread or the process queue,
+/// carrying its origin so it can be correctly re-enqueued later.
+pub enum DequeuedSignal {
+    FromProcess(Box<dyn Signal>),
+    FromThread(Box<dyn Signal>),
+}
+
+impl DequeuedSignal {
+    /// Consumes the dequeued signal and returns the inner signal.
+    pub fn unwrap(self) -> Box<dyn Signal> {
+        match self {
+            Self::FromProcess(signal) | Self::FromThread(signal) => signal,
+        }
+    }
+
+    /// Returns a reference to the inner signal.
+    pub(in crate::process) fn signal(&self) -> &dyn Signal {
+        match self {
+            Self::FromProcess(signal) | Self::FromThread(signal) => signal.as_ref(),
+        }
+    }
+
+    /// Returns the signal number of the inner signal.
+    pub(in crate::process) fn num(&self) -> SigNum {
+        self.signal().num()
+    }
+
+    /// Replaces the inner signal with `new_signal`, preserving the origin.
+    pub(in crate::process) fn set_signal(&mut self, new_signal: Box<dyn Signal>) {
+        match self {
+            Self::FromProcess(signal) | Self::FromThread(signal) => *signal = new_signal,
+        }
+    }
+}
 
 /// Trait for handling pending signals.
 pub trait HandlePendingSignal {
@@ -31,7 +67,7 @@ pub trait HandlePendingSignal {
     /// Dequeues the next pending signal that is not masked by `mask`.
     ///
     /// Returns `None` if no such signal is available.
-    fn dequeue_signal(&self, mask: &SigMask) -> Option<Box<dyn Signal>>;
+    fn dequeue_signal(&self, mask: &SigMask) -> Option<DequeuedSignal>;
 }
 
 impl HandlePendingSignal for Context<'_> {
@@ -50,11 +86,17 @@ impl HandlePendingSignal for Context<'_> {
             || self.process.sig_queues().has_pending_signal(SIGKILL)
     }
 
-    fn dequeue_signal(&self, mask: &SigMask) -> Option<Box<dyn Signal>> {
+    fn dequeue_signal(&self, mask: &SigMask) -> Option<DequeuedSignal> {
         self.posix_thread
             .sig_queues()
             .dequeue(mask)
-            .or_else(|| self.process.sig_queues().dequeue(mask))
+            .map(DequeuedSignal::FromThread)
+            .or_else(|| {
+                self.process
+                    .sig_queues()
+                    .dequeue(mask)
+                    .map(DequeuedSignal::FromProcess)
+            })
     }
 }
 
@@ -73,10 +115,16 @@ impl HandlePendingSignal for PosixThread {
             || self.process().sig_queues().has_pending_signal(SIGKILL)
     }
 
-    fn dequeue_signal(&self, mask: &SigMask) -> Option<Box<dyn Signal>> {
+    fn dequeue_signal(&self, mask: &SigMask) -> Option<DequeuedSignal> {
         self.sig_queues()
             .dequeue(mask)
-            .or_else(|| self.process().sig_queues().dequeue(mask))
+            .map(DequeuedSignal::FromThread)
+            .or_else(|| {
+                self.process()
+                    .sig_queues()
+                    .dequeue(mask)
+                    .map(DequeuedSignal::FromProcess)
+            })
     }
 }
 

--- a/kernel/src/process/status.rs
+++ b/kernel/src/process/status.rs
@@ -143,27 +143,35 @@ impl StopStatus {
         self.is_stopped.load(Ordering::Relaxed)
     }
 
-    /// Gets and clears the stop status changes for the `wait` syscall.
+    /// Returns the stop status changes for the `wait` syscall.
     pub(super) fn wait(&self, options: WaitOptions) -> Option<StopWaitStatus> {
         let mut wait_status = self.wait_status.lock();
 
         if options.contains(WaitOptions::WSTOPPED)
             && let Some(StopWaitStatus::Stopped(_)) = wait_status.as_ref()
         {
-            return wait_status.take();
+            return if options.contains(WaitOptions::WNOWAIT) {
+                wait_status.as_ref().cloned()
+            } else {
+                wait_status.take()
+            };
         }
 
         if options.contains(WaitOptions::WCONTINUED)
             && let Some(StopWaitStatus::Continue) = wait_status.as_ref()
         {
-            return wait_status.take();
+            return if options.contains(WaitOptions::WNOWAIT) {
+                wait_status.as_ref().cloned()
+            } else {
+                wait_status.take()
+            };
         }
 
         None
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) enum StopWaitStatus {
     Stopped(SigNum),
     Continue,

--- a/kernel/src/process/status.rs
+++ b/kernel/src/process/status.rs
@@ -16,7 +16,7 @@ use crate::process::{WaitOptions, signal::sig_num::SigNum};
 /// 2. Whether the process is the vfork child, which shares the user-space virtual memory
 ///    with its parent process;
 /// 3. The exit code of the process;
-/// 4. Whether the process is stopped (by a signal or ptrace).
+/// 4. Whether the process is stopped by a signal.
 #[derive(Debug)]
 pub struct ProcessStatus {
     is_zombie: AtomicBool,
@@ -165,8 +165,6 @@ impl StopStatus {
 
 #[derive(Debug)]
 pub(super) enum StopWaitStatus {
-    // FIXME: A process can also be stopped by ptrace.
-    // Extend this enum to support ptrace.
     Stopped(SigNum),
     Continue,
 }

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -8,9 +8,12 @@ use super::{
 use crate::{
     prelude::*,
     process::{
-        ReapedChildrenStats, Uid, pid_table, posix_thread::AsPosixThread, signal::sig_num::SigNum,
+        ReapedChildrenStats, Uid, pid_table,
+        posix_thread::{AsPosixThread, PosixThread},
+        signal::sig_num::SigNum,
         status::StopWaitStatus,
     },
+    thread::{Thread, Tid},
     time::clocks::ProfClock,
 };
 
@@ -30,17 +33,6 @@ bitflags! {
 
 impl WaitOptions {
     pub fn check(&self) -> Result<()> {
-        // FIXME: The syscall `waitid` allows using WNOWAIT with
-        // WSTOPPED or WCONTINUED
-        if self.intersects(WaitOptions::WSTOPPED | WaitOptions::WCONTINUED)
-            && self.contains(WaitOptions::WNOWAIT)
-        {
-            return_errno_with_message!(
-                Errno::EINVAL,
-                "WNOWAIT cannot be used toghther with WSTOPPED or WCONTINUED"
-            );
-        }
-
         let supported_args = WaitOptions::WNOHANG
             | WaitOptions::WSTOPPED
             | WaitOptions::WCONTINUED
@@ -74,45 +66,23 @@ pub fn do_wait(
         |sigmask| sigmask + SIGCHLD,
         || {
             ctx.process.children_wait_queue().pause_until(|| {
-                // Acquire the children lock at first to prevent race conditions.
-                // We want to ensure that multiple waiting threads
-                // do not return the same waited process status.
-                let mut children_lock = ctx.process.children().lock();
-                let children_mut = children_lock.as_mut().unwrap();
+                let has_unready_tracee = match try_wait_tracees(&child_filter, wait_options, ctx) {
+                    WaitResult::Found(status) => return Some(Ok(Some(status))),
+                    WaitResult::MatchedButUnready => true,
+                    WaitResult::NoMatch => false,
+                };
 
-                let unwaited_children = children_mut
-                    .values()
-                    .filter(|child| match &child_filter {
-                        ProcessFilter::Any => true,
-                        ProcessFilter::WithPid(pid) => child.pid() == *pid,
-                        ProcessFilter::WithPgid(pgid) => child.pgid() == *pgid,
-                        ProcessFilter::WithPidfd(pid_file) => match pid_file.process_opt() {
-                            Some(process) => Arc::ptr_eq(&process, child),
-                            None => false,
-                        },
-                    })
-                    .collect::<Box<_>>();
+                let has_unready_child = match try_wait_children(&child_filter, wait_options, ctx) {
+                    WaitResult::Found(status) => return Some(Ok(Some(status))),
+                    WaitResult::MatchedButUnready => true,
+                    WaitResult::NoMatch => false,
+                };
 
-                if unwaited_children.is_empty() {
+                if !has_unready_tracee && !has_unready_child {
                     return Some(Err(Error::with_message(
                         Errno::ECHILD,
                         "the process has no child to wait",
                     )));
-                }
-
-                if let Some(status) = wait_zombie(&unwaited_children) {
-                    if !wait_options.contains(WaitOptions::WNOWAIT) {
-                        reap_zombie_child(
-                            status.pid(),
-                            children_mut,
-                            ctx.process.reaped_children_stats(),
-                        );
-                    }
-                    return Some(Ok(Some(status)));
-                }
-
-                if let Some(status) = wait_stopped_or_continued(&unwaited_children, wait_options) {
-                    return Some(Ok(Some(status)));
                 }
 
                 if wait_options.contains(WaitOptions::WNOHANG) {
@@ -135,68 +105,234 @@ pub fn do_wait(
     Ok(zombie_child)
 }
 
+fn wait_filter(child_pid: Pid, child: &Arc<Process>, child_filter: &ProcessFilter) -> bool {
+    match &child_filter {
+        ProcessFilter::Any => true,
+        ProcessFilter::WithPid(pid) => child_pid == *pid,
+        ProcessFilter::WithPgid(pgid) => child.pgid() == *pgid,
+        ProcessFilter::WithPidfd(pid_file) => match pid_file.process_opt() {
+            Some(process) => Arc::ptr_eq(&process, child),
+            None => false,
+        },
+    }
+}
+
 pub enum WaitStatus {
     Zombie(Arc<Process>),
     Stop(Arc<Process>, SigNum),
     Continue(Arc<Process>),
+    TraceeExit(Arc<Thread>),
+    TraceeStop(Arc<Thread>, SigNum),
 }
 
 impl WaitStatus {
     pub fn pid(&self) -> Pid {
-        self.process().pid()
+        match self.source() {
+            WaitStatusSource::Process(process) => process.pid(),
+            WaitStatusSource::Thread(thread) => thread.tid(),
+        }
     }
 
     pub fn uid(&self) -> Uid {
-        self.process()
-            .main_thread()
-            .as_posix_thread()
-            .unwrap()
-            .credentials()
-            .ruid()
+        match self.source() {
+            WaitStatusSource::Process(process) => process
+                .main_thread()
+                .as_posix_thread()
+                .unwrap()
+                .credentials()
+                .ruid(),
+            WaitStatusSource::Thread(thread) => thread.credentials().ruid(),
+        }
     }
 
     pub fn prof_clock(&self) -> &Arc<ProfClock> {
-        self.process().prof_clock()
+        match self.source() {
+            WaitStatusSource::Process(process) => process.prof_clock(),
+            WaitStatusSource::Thread(thread) => thread.prof_clock(),
+        }
     }
 
-    fn process(&self) -> &Arc<Process> {
+    fn source(&self) -> WaitStatusSource<'_> {
         match self {
             WaitStatus::Zombie(process)
             | WaitStatus::Stop(process, _)
-            | WaitStatus::Continue(process) => process,
+            | WaitStatus::Continue(process) => WaitStatusSource::Process(process.as_ref()),
+            WaitStatus::TraceeExit(thread) | WaitStatus::TraceeStop(thread, _) => {
+                WaitStatusSource::Thread(thread.as_posix_thread().unwrap())
+            }
         }
     }
 }
 
-fn wait_zombie(unwaited_children: &[&Arc<Process>]) -> Option<WaitStatus> {
-    unwaited_children
-        .iter()
-        .find(|child| child.status().is_zombie())
-        .map(|child| WaitStatus::Zombie((*child).clone()))
+enum WaitStatusSource<'a> {
+    Process(&'a Process),
+    Thread(&'a PosixThread),
 }
 
-fn wait_stopped_or_continued(
-    unwaited_children: &[&Arc<Process>],
-    wait_options: WaitOptions,
-) -> Option<WaitStatus> {
-    if !wait_options.intersects(WaitOptions::WSTOPPED | WaitOptions::WCONTINUED) {
-        return None;
-    }
+/// The result of trying to wait for a child/tracee state change.
+enum WaitResult {
+    /// A waitable status is found.
+    Found(WaitStatus),
+    /// At least one target matches, but none is waitable yet.
+    MatchedButUnready,
+    /// No target matches the wait filter.
+    NoMatch,
+}
 
-    // Lock order: children of process -> tasks of process
-    for process in unwaited_children.iter() {
-        let Some(stop_wait_status) = process.wait_stopped_or_continued(wait_options) else {
+/// Checks tracees for exited or ptrace-stopped threads.
+fn try_wait_tracees(
+    child_filter: &ProcessFilter,
+    wait_options: WaitOptions,
+    ctx: &Context,
+) -> WaitResult {
+    // Currently, we only support the main thread as the tracer,
+    // so there is no need to check the tracees of other threads.
+    //
+    // Lock order: tracer.tracees -> tracee.tracee_status
+    let Some(tracees) = ctx.posix_thread.tracees() else {
+        return WaitResult::NoMatch;
+    };
+    let tracees = tracees.lock();
+
+    let mut fallback_result = WaitResult::NoMatch;
+
+    for thread in tracees.values() {
+        let tracee = thread.as_posix_thread().unwrap();
+        let Some(process) = tracee.weak_process().upgrade() else {
             continue;
         };
+        if !wait_filter(tracee.tid(), &process, child_filter) {
+            continue;
+        }
 
-        let wait_status = match stop_wait_status {
-            StopWaitStatus::Stopped(sig_num) => WaitStatus::Stop((*process).clone(), sig_num),
-            StopWaitStatus::Continue => WaitStatus::Continue((*process).clone()),
-        };
-        return Some(wait_status);
+        // We have found at least one tracee matching `child_filter`.
+        fallback_result = WaitResult::MatchedButUnready;
+
+        // Exit/death by signal is reported first to the tracer, then,
+        // when the tracer consumes the waitpid(2) result, to the real
+        // parent (to the real parent only when the whole multithreaded
+        // process exits). If the tracer and the real parent are the same
+        // process, the report is sent only once.
+        //
+        // Reference: <https://man7.org/linux/man-pages/man2/ptrace.2.html>
+        if thread.is_exited() {
+            // Lock order: tracer.tracees -> tracee_process.tasks
+            if Arc::ptr_eq(&process.main_thread(), thread) && !process.status().is_zombie() {
+                // Delay reporting `TraceeExit` for a process's main-thread tracee until the
+                // process becomes zombie.
+                //
+                // This avoids a race when the main thread is the last thread to exit and its
+                // tracer is also its parent: the thread has called `Thread::exit()` but
+                // `ProcessStatus::set_zombie()` has not run yet, so an early wait could
+                // report the same exit twice, first as `WaitStatus::TraceeExit` and
+                // later as `WaitStatus::Zombie`.
+                //
+                // Also matches Linux behavior:
+                // <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/exit.c#L1486-L1487>.
+                continue;
+            }
+
+            let thread = thread.clone();
+            if !wait_options.contains(WaitOptions::WNOWAIT) {
+                cleanup_exited_tracee(&process, &thread, tracees, ctx);
+            }
+            return WaitResult::Found(WaitStatus::TraceeExit(thread));
+        }
+
+        // Waiting for ptrace-stops does not require `WaitOptions::WSTOPPED`.
+        if let Some(sig_num) = tracee.wait_ptrace_stopped(wait_options) {
+            return WaitResult::Found(WaitStatus::TraceeStop(thread.clone(), sig_num));
+        }
     }
 
-    None
+    fallback_result
+}
+
+fn cleanup_exited_tracee(
+    process: &Arc<Process>,
+    thread: &Arc<Thread>,
+    mut tracees: MutexGuard<BTreeMap<Tid, Arc<Thread>>>,
+    ctx: &Context,
+) {
+    let tracee = thread.as_posix_thread().unwrap();
+    tracees.remove(&tracee.tid());
+    tracee.detach_tracer();
+    drop(tracees);
+
+    if !process.status().is_zombie() {
+        return;
+    }
+    if !Arc::ptr_eq(&process.main_thread(), thread) {
+        return;
+    }
+    let tracee_parent = process.parent().lock().process().clone();
+    let is_our_child = core::ptr::eq(Weak::as_ptr(&tracee_parent), Arc::as_ptr(&ctx.process));
+    if !is_our_child {
+        if let Some(parent) = tracee_parent.upgrade() {
+            parent.children_wait_queue().wake_all();
+        }
+        return;
+    }
+
+    reap_zombie_child(
+        process.pid(),
+        ctx.process.children().lock().as_mut().unwrap(),
+        ctx.process.reaped_children_stats(),
+    );
+}
+
+/// Checks children for zombie or stopped/continued events.
+fn try_wait_children(
+    child_filter: &ProcessFilter,
+    wait_options: WaitOptions,
+    ctx: &Context,
+) -> WaitResult {
+    // Acquire the children lock at first to prevent race conditions.
+    // We want to ensure that multiple waiting threads
+    // do not return the same waited process status.
+    let mut children_lock = ctx.process.children().lock();
+    let children_mut = children_lock.as_mut().unwrap();
+
+    let mut fallback_result = WaitResult::NoMatch;
+
+    for child in children_mut.values() {
+        if !wait_filter(child.pid(), child, child_filter) {
+            continue;
+        }
+
+        // We have found at least one child matching `child_filter`.
+        fallback_result = WaitResult::MatchedButUnready;
+
+        if child.main_thread().as_posix_thread().unwrap().is_traced() {
+            continue;
+        }
+
+        if child.status().is_zombie() {
+            let child = child.clone();
+            if !wait_options.contains(WaitOptions::WNOWAIT) {
+                reap_zombie_child(
+                    child.pid(),
+                    children_mut,
+                    ctx.process.reaped_children_stats(),
+                );
+            }
+            return WaitResult::Found(WaitStatus::Zombie(child));
+        }
+
+        if !wait_options.intersects(WaitOptions::WSTOPPED | WaitOptions::WCONTINUED) {
+            continue;
+        }
+        let Some(stop_wait_status) = child.wait_stopped_or_continued(wait_options) else {
+            continue;
+        };
+        let wait_status = match stop_wait_status {
+            StopWaitStatus::Stopped(sig_num) => WaitStatus::Stop(child.clone(), sig_num),
+            StopWaitStatus::Continue => WaitStatus::Continue(child.clone()),
+        };
+        return WaitResult::Found(wait_status);
+    }
+
+    fallback_result
 }
 
 /// Free zombie child with `child_pid`, returns the exit code of child process.

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -91,6 +91,7 @@ macro_rules! import_generic_syscall_entries {
             preadv::{sys_preadv, sys_preadv2, sys_readv},
             prlimit64::{sys_getrlimit, sys_prlimit64, sys_setrlimit},
             pselect6::sys_pselect6,
+            ptrace::sys_ptrace,
             pwrite64::sys_pwrite64,
             pwritev::{sys_pwritev, sys_pwritev2, sys_writev},
             read::sys_read,
@@ -294,6 +295,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_TIMER_DELETE = 111           => sys_timer_delete(args[..1]);
             SYS_CLOCK_GETTIME = 113          => sys_clock_gettime(args[..2]);
             SYS_CLOCK_NANOSLEEP = 115        => sys_clock_nanosleep(args[..4]);
+            SYS_PTRACE = 117                 => sys_ptrace(args[..4]);
             SYS_SCHED_SETPARAM = 118         => sys_sched_setparam(args[..2]);
             SYS_SCHED_SETSCHEDULER = 119     => sys_sched_setscheduler(args[..3]);
             SYS_SCHED_GETSCHEDULER = 120     => sys_sched_getscheduler(args[..1]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -93,6 +93,7 @@ use super::{
     preadv::{sys_preadv, sys_preadv2, sys_readv},
     prlimit64::{sys_getrlimit, sys_prlimit64, sys_setrlimit},
     pselect6::sys_pselect6,
+    ptrace::sys_ptrace,
     pwrite64::sys_pwrite64,
     pwritev::{sys_pwritev, sys_pwritev2, sys_writev},
     read::sys_read,
@@ -270,6 +271,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRLIMIT = 97         => sys_getrlimit(args[..2]);
     SYS_GETRUSAGE = 98         => sys_getrusage(args[..2]);
     SYS_SYSINFO = 99           => sys_sysinfo(args[..1]);
+    SYS_PTRACE = 101           => sys_ptrace(args[..4]);
     SYS_GETUID = 102           => sys_getuid(args[..0]);
     SYS_GETGID = 104           => sys_getgid(args[..0]);
     SYS_SETUID = 105           => sys_setuid(args[..1]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -105,6 +105,7 @@ mod pread64;
 mod preadv;
 mod prlimit64;
 mod pselect6;
+mod ptrace;
 mod pwrite64;
 mod pwritev;
 mod read;

--- a/kernel/src/syscall/ptrace.rs
+++ b/kernel/src/syscall/ptrace.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
+    process::{
+        posix_thread::{AsPosixThread, alien_access::AlienAccessMode, ptrace::PtraceContRequest},
+        signal::sig_num::SigNum,
+    },
     thread::{Thread, Tid},
 };
 
@@ -28,6 +31,15 @@ pub fn sys_ptrace(
             let parent_main_thread = parent_guard.process().upgrade().unwrap().main_thread();
 
             do_ptrace_attach(&parent_main_thread, current_thread)?;
+        }
+        PtraceRequest::PTRACE_CONT => {
+            let sig_num = parse_ptrace_injected_signal(data)?;
+
+            let tracee = ctx.posix_thread.get_tracee(tid)?;
+            tracee
+                .as_posix_thread()
+                .unwrap()
+                .ptrace_continue(PtraceContRequest::Continue(sig_num), ctx)?;
         }
     }
 
@@ -56,12 +68,26 @@ fn do_ptrace_attach(tracer_thread: &Arc<Thread>, tracee_thread: Arc<Thread>) -> 
     tracer.attach_to(tracer_thread, tracee_thread)
 }
 
+fn parse_ptrace_injected_signal(data: u64) -> Result<Option<SigNum>> {
+    if data == 0 {
+        return Ok(None);
+    }
+
+    let sig_num = u8::try_from(data)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid signal number"))?;
+    let sig_num = SigNum::try_from(sig_num)?;
+
+    Ok(Some(sig_num))
+}
+
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
 #[expect(non_camel_case_types)]
 enum PtraceRequest {
     /// Indicate that this thread should be traced by its parent.
     PTRACE_TRACEME = 0,
+    /// Continue the thread.
+    PTRACE_CONT = 7,
     // TODO: Support other operations.
     // /// Return the word in the thread's text space at address ADDR.
     // PTRACE_PEEKTEXT = 1,
@@ -75,8 +101,6 @@ enum PtraceRequest {
     // PTRACE_POKEDATA = 5,
     // /// Write the word DATA into the thread's user area at offset ADDR.
     // PTRACE_POKEUSER = 6,
-    // /// Continue the thread.
-    // PTRACE_CONT = 7,
     // /// Kill the thread.
     // PTRACE_KILL = 8,
     // /// Single step the thread.

--- a/kernel/src/syscall/ptrace.rs
+++ b/kernel/src/syscall/ptrace.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{
+    prelude::*,
+    process::posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
+    thread::{Thread, Tid},
+};
+
+pub fn sys_ptrace(
+    request: u32,
+    tid: Tid,
+    addr: u64,
+    data: u64,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let request = PtraceRequest::try_from(request)
+        .map_err(|_| Error::with_message(Errno::EIO, "invalid ptrace request"))?;
+    debug!(
+        "ptrace: request = {:?}, tid = {}, addr = 0x{:x}, data = 0x{:x}",
+        request, tid, addr, data
+    );
+
+    match request {
+        PtraceRequest::PTRACE_TRACEME => {
+            let current_thread = current_thread!();
+            let parent_guard = ctx.process.parent().lock();
+            let parent_main_thread = parent_guard.process().upgrade().unwrap().main_thread();
+
+            do_ptrace_attach(&parent_main_thread, current_thread)?;
+        }
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn do_ptrace_attach(tracer_thread: &Arc<Thread>, tracee_thread: Arc<Thread>) -> Result<()> {
+    let tracer = tracer_thread.as_posix_thread().unwrap();
+    let tracee = tracee_thread.as_posix_thread().unwrap();
+    if !Arc::ptr_eq(&tracer.process().main_thread(), tracer_thread) {
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "using a non-main thread as a tracer is not supported currently"
+        );
+    }
+
+    if Weak::ptr_eq(tracer.weak_process(), tracee.weak_process()) {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "tracer and tracee must be in different processes"
+        );
+    }
+
+    tracee.check_alien_access_from(tracer, AlienAccessMode::ATTACH_WITH_REAL_CREDS)?;
+
+    tracer.attach_to(tracer_thread, tracee_thread)
+}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+#[expect(non_camel_case_types)]
+enum PtraceRequest {
+    /// Indicate that this thread should be traced by its parent.
+    PTRACE_TRACEME = 0,
+    // TODO: Support other operations.
+    // /// Return the word in the thread's text space at address ADDR.
+    // PTRACE_PEEKTEXT = 1,
+    // /// Return the word in the thread's data space at address ADDR.
+    // PTRACE_PEEKDATA = 2,
+    // /// Return the word in the thread's user area at offset ADDR.
+    // PTRACE_PEEKUSER = 3,
+    // /// Write the word DATA into the thread's text space at address ADDR.
+    // PTRACE_POKETEXT = 4,
+    // /// Write the word DATA into the thread's data space at address ADDR.
+    // PTRACE_POKEDATA = 5,
+    // /// Write the word DATA into the thread's user area at offset ADDR.
+    // PTRACE_POKEUSER = 6,
+    // /// Continue the thread.
+    // PTRACE_CONT = 7,
+    // /// Kill the thread.
+    // PTRACE_KILL = 8,
+    // /// Single step the thread.
+    // PTRACE_SINGLESTEP = 9,
+    // /// Get all general purpose registers used by a thread.
+    // PTRACE_GETREGS = 12,
+    // /// Set all general purpose registers used by a thread.
+    // PTRACE_SETREGS = 13,
+    // /// Get all floating point registers used by a thread.
+    // PTRACE_GETFPREGS = 14,
+    // /// Set all floating point registers used by a thread.
+    // PTRACE_SETFPREGS = 15,
+    // /// Attach to a thread that is already running.
+    // PTRACE_ATTACH = 16,
+    // /// Detach from a thread attached to.
+    // PTRACE_DETACH = 17,
+    // /// Get all extended floating point registers used by a thread.
+    // PTRACE_GETFPXREGS = 18,
+    // /// Set all extended floating point registers used by a thread.
+    // PTRACE_SETFPXREGS = 19,
+    // /// Continue and stop at the next entry to or return from syscall.
+    // PTRACE_SYSCALL = 24,
+    // /// Continue and stop at the next syscall, it will not be executed.
+    // PTRACE_SYSEMU = 31,
+    // /// Single step the thread, the next syscall will not be executed.
+    // PTRACE_SYSEMU_SINGLESTEP = 32,
+    // /// Set ptrace filter options.
+    // PTRACE_SETOPTIONS = 0x4200,
+    // /// Get the siginfo of the last ptrace-stop.
+    // PTRACE_GETSIGINFO = 0x4202,
+    // /// Get register content.
+    // PTRACE_GETREGSET = 0x4204,
+    // /// Set register content.
+    // PTRACE_SETREGSET = 0x4205,
+}

--- a/kernel/src/syscall/rt_sigtimedwait.rs
+++ b/kernel/src/syscall/rt_sigtimedwait.rs
@@ -111,7 +111,8 @@ fn dequeue_signal_with_checking_ignore(
 ) -> Option<Box<dyn Signal>> {
     let sig_dispositions = ctx.process.sig_dispositions().lock();
     let sig_disposition = sig_dispositions.lock();
-    while let Some(signal) = ctx.posix_thread.dequeue_signal(&mask) {
+    while let Some(dequeued) = ctx.posix_thread.dequeue_signal(&mask) {
+        let signal = dequeued.unwrap();
         // If the signal is ignored and not blocked, the signal will be directly dropped.
         if !block_list.contains(signal.num()) && sig_disposition.will_ignore(signal.as_ref()) {
             continue;

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -192,8 +192,8 @@ impl SignalFile {
 
         for _ in 0..max_signals {
             match thread.dequeue_signal(&mask) {
-                Some(signal) => {
-                    writer.write_val(&signal.to_signalfd_siginfo())?;
+                Some(dequeued) => {
+                    writer.write_val(&dequeued.unwrap().to_signalfd_siginfo())?;
                     count += 1;
                 }
                 None => break,

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -5,7 +5,7 @@ use ostd::mm::VmIo;
 use super::{SyscallReturn, getrusage::rusage_t};
 use crate::{
     prelude::*,
-    process::{ProcessFilter, WaitOptions, WaitStatus, do_wait},
+    process::{ProcessFilter, WaitOptions, WaitStatus, do_wait, posix_thread::AsPosixThread},
 };
 
 pub fn sys_wait4(
@@ -23,6 +23,15 @@ pub fn sys_wait4(
     );
     debug!("wait4 current pid = {}", ctx.process.pid());
     let process_filter = ProcessFilter::from_id(wait_pid as _)?;
+
+    if wait_options.intersects(WaitOptions::WSTOPPED | WaitOptions::WCONTINUED)
+        && wait_options.contains(WaitOptions::WNOWAIT)
+    {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "WNOWAIT cannot be used toghther with WSTOPPED or WCONTINUED"
+        );
+    }
 
     let wait_status =
         do_wait(process_filter, wait_options, ctx).map_err(|err| match err.error() {
@@ -56,5 +65,8 @@ fn calculate_status_code(wait_status: &WaitStatus) -> u32 {
         WaitStatus::Zombie(process) => process.status().exit_code(),
         WaitStatus::Stop(_, sig_num) => ((sig_num.as_u8() as u32) << 8) | 0x7f,
         WaitStatus::Continue(_) => 0xffff,
+        WaitStatus::TraceeExit(thread) => thread.as_posix_thread().unwrap().exit_code(),
+        // TODO: Add `PTRACE_EVENT_*` flags.
+        WaitStatus::TraceeStop(_, sig_num) => ((sig_num.as_u8() as u32) << 8) | 0x7f,
     }
 }

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -7,9 +7,12 @@ use crate::{
     prelude::*,
     process::{
         ProcessFilter, WaitOptions, WaitStatus, do_wait,
+        posix_thread::AsPosixThread,
         signal::{
             c_types::siginfo_t,
-            constants::{CLD_CONTINUED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, SIGCHLD, SIGCONT},
+            constants::{
+                CLD_CONTINUED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED, SIGCHLD, SIGCONT,
+            },
         },
     },
 };
@@ -67,22 +70,32 @@ pub fn sys_waitid(
 }
 
 fn calculate_si_code_and_si_status(wait_status: &WaitStatus) -> (i32, i32) {
-    // TODO: Add supports for `CLD_DUMPED` and `CLD_TRAPPED`.
+    let parse_exit_code = |exit_code: u32| {
+        const NORMAL_EXIT_MASK: u32 = 0xff;
+
+        // If the process exits normally, the lowest 8 bits of `status_code`
+        // will be zero. In this case, we return the actual exit code by
+        // shifting the `status_code` right by 8 bits.
+        if (exit_code & NORMAL_EXIT_MASK) == 0 {
+            (CLD_EXITED, (exit_code >> 8) as i32)
+        } else {
+            (CLD_KILLED, exit_code as i32)
+        }
+    };
+
+    // TODO: Add supports for `CLD_DUMPED`.
     match wait_status {
         WaitStatus::Zombie(process) => {
-            const NORMAL_EXIT_MASK: u32 = 0xff;
-
             let exit_code = process.status().exit_code();
-            // If the process exits normally, the lowest 8 bits of `status_code`
-            // will be zero. In this case, we return the actual exit code by
-            // shifting the `status_code` right by 8 bits.
-            if (exit_code & NORMAL_EXIT_MASK) == 0 {
-                (CLD_EXITED, (exit_code >> 8) as i32)
-            } else {
-                (CLD_KILLED, exit_code as i32)
-            }
+            parse_exit_code(exit_code)
         }
         WaitStatus::Stop(_process, signum) => (CLD_STOPPED, signum.as_u8() as i32),
         WaitStatus::Continue(_) => (CLD_CONTINUED, SIGCONT.as_u8() as i32),
+        WaitStatus::TraceeExit(thread) => {
+            let exit_code = thread.as_posix_thread().unwrap().exit_code();
+            parse_exit_code(exit_code)
+        }
+        // TODO: Add `PTRACE_EVENT_*` flags into `si_status`.
+        WaitStatus::TraceeStop(_, signum) => (CLD_TRAPPED, signum.as_u8() as i32),
     }
 }

--- a/test/initramfs/src/regression/common/yama_ptrace_scope.h
+++ b/test/initramfs/src/regression/common/yama_ptrace_scope.h
@@ -12,7 +12,7 @@
 
 #define YAMA_SCOPE_NO_ATTACH 3
 
-static int read_yama_scope(void)
+static inline __attribute__((unused)) int read_yama_scope(void)
 {
 	int fd = CHECK(open("/proc/sys/kernel/yama/ptrace_scope", O_RDONLY));
 	char buf[32] = { 0 };
@@ -22,7 +22,7 @@ static int read_yama_scope(void)
 	return atoi(buf);
 }
 
-static void write_yama_scope(int scope)
+static inline __attribute__((unused)) void write_yama_scope(int scope)
 {
 	int fd = CHECK(open("/proc/sys/kernel/yama/ptrace_scope", O_RDWR));
 	char buf[32] = { 0 };

--- a/test/initramfs/src/regression/process/Makefile
+++ b/test/initramfs/src/regression/process/Makefile
@@ -12,6 +12,7 @@ SUBDIRS := \
 	itimer \
 	prctl \
 	pthread \
+	ptrace \
 	sched \
 	signal \
 

--- a/test/initramfs/src/regression/process/ptrace/Makefile
+++ b/test/initramfs/src/regression/process/ptrace/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/process/ptrace/ptrace.c
+++ b/test/initramfs/src/regression/process/ptrace/ptrace.c
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+#include "../../common/yama_ptrace_scope.h"
+
+static void exit_with_233_handler(int sig)
+{
+	(void)sig;
+	_exit(233);
+}
+
+static void install_handler(int sig, void (*handler)(int))
+{
+	struct sigaction action = {
+		.sa_handler = handler,
+		.sa_flags = 0,
+	};
+
+	CHECK(sigemptyset(&action.sa_mask));
+	CHECK(sigaction(sig, &action, NULL));
+}
+
+static int read_tracer_pid(pid_t pid)
+{
+	char path[64];
+	char line[256];
+	FILE *status_file;
+	int tracer_pid = -1;
+
+	snprintf(path, sizeof(path), "/proc/%d/status", pid);
+	status_file = fopen(path, "r");
+	CHECK_WITH(0, status_file != NULL);
+
+	while (fgets(line, sizeof(line), status_file) != NULL) {
+		if (strncmp(line, "TracerPid:\t", 11) == 0) {
+			tracer_pid = atoi(line + 11);
+			break;
+		}
+	}
+
+	CHECK(fclose(status_file));
+	return tracer_pid;
+}
+
+FN_TEST(ptrace_signal_stop_wait_continue)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGTERM));
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGTERM);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_sigkill_interrupts_ptrace_stop)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGSTOP));
+		_exit(1);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status) &&
+						   WTERMSIG(status) == SIGKILL);
+}
+END_TEST()
+
+FN_TEST(ptrace_execve_reports_sigtrap)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(execl("/bin/true", "/bin/true", NULL));
+		_exit(1);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGTRAP);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_tracer_exit_does_not_reinject_waited_signal)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	int pid_pipe[2];
+	TEST_SUCC(prctl(PR_SET_CHILD_SUBREAPER, 1));
+	TEST_SUCC(pipe(pid_pipe));
+
+	pid_t tracer_pid = TEST_SUCC(fork());
+	if (tracer_pid == 0) {
+		pid_t child_pid;
+		int status = 0;
+
+		CHECK(close(pid_pipe[0]));
+		child_pid = CHECK(fork());
+		if (child_pid == 0) {
+			CHECK(close(pid_pipe[1]));
+			CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+			CHECK(raise(SIGTERM));
+			_exit(1);
+		}
+
+		CHECK(write(pid_pipe[1], &child_pid, sizeof(child_pid)));
+		CHECK(close(pid_pipe[1]));
+		CHECK_WITH(waitpid(child_pid, &status, 0),
+			   _ret == child_pid && WIFSTOPPED(status) &&
+				   WSTOPSIG(status) == SIGTERM);
+		_exit(0);
+	}
+
+	pid_t tracee_pid;
+	TEST_SUCC(close(pid_pipe[1]));
+	TEST_RES(read(pid_pipe[0], &tracee_pid, sizeof(tracee_pid)),
+		 _ret == sizeof(tracee_pid));
+	TEST_SUCC(close(pid_pipe[0]));
+
+	int status = 0;
+	TEST_RES(waitpid(tracer_pid, &status, 0),
+		 _ret == tracer_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+	TEST_RES(waitpid(tracee_pid, &status, 0),
+		 _ret == tracee_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 1);
+}
+END_TEST()
+
+FN_TEST(ptrace_tracer_exit_reinjects_unwaited_signal)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	int pid_pipe[2];
+	TEST_SUCC(prctl(PR_SET_CHILD_SUBREAPER, 1));
+	TEST_SUCC(pipe(pid_pipe));
+
+	pid_t tracer_pid = TEST_SUCC(fork());
+	if (tracer_pid == 0) {
+		CHECK(close(pid_pipe[0]));
+		pid_t tracee_pid = CHECK(fork());
+		if (tracee_pid == 0) {
+			CHECK(close(pid_pipe[1]));
+			install_handler(SIGUSR1, exit_with_233_handler);
+			CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+			CHECK(raise(SIGUSR1));
+			_exit(-1);
+		}
+
+		CHECK(write(pid_pipe[1], &tracee_pid, sizeof(tracee_pid)));
+		CHECK(close(pid_pipe[1]));
+		// Wait for the tracee to stop on the signal without consuming it.
+		siginfo_t info = { 0 };
+		CHECK_WITH(waitid(P_PID, tracee_pid, &info, WSTOPPED | WNOWAIT),
+			   _ret == 0 && info.si_code == CLD_TRAPPED &&
+				   info.si_status == SIGUSR1);
+		_exit(0);
+	}
+
+	pid_t tracee_pid;
+	TEST_SUCC(close(pid_pipe[1]));
+	TEST_RES(read(pid_pipe[0], &tracee_pid, sizeof(tracee_pid)),
+		 _ret == sizeof(tracee_pid));
+	TEST_SUCC(close(pid_pipe[0]));
+
+	int status = 0;
+	TEST_RES(waitpid(tracer_pid, &status, 0),
+		 _ret == tracer_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+	TEST_RES(waitpid(tracee_pid, &status, 0),
+		 _ret == tracee_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 233);
+}
+END_TEST()
+
+FN_TEST(ptrace_cont_injects_signal)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_handler(SIGUSR2, exit_with_233_handler);
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGUSR1));
+		_exit(1);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGUSR1);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, SIGUSR2));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFEXITED(status) &&
+						   WEXITSTATUS(status) == 233);
+}
+END_TEST()
+
+FN_TEST(ptrace_tracee_exit_without_stop)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		_exit(7);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 7);
+}
+END_TEST()
+
+FN_TEST(ptrace_proc_pid_status_reports_tracer_pid)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		if (read_tracer_pid(getpid()) != 0) {
+			_exit(1);
+		}
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		if (read_tracer_pid(getpid()) != getppid()) {
+			_exit(2);
+		}
+		CHECK(raise(SIGSTOP));
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+	TEST_RES(read_tracer_pid(pid), _ret == getpid());
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_invalid_op_fails_with_eio)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGSTOP));
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+	TEST_ERRNO(ptrace(0x3c3c3c3c, pid, 0, 0), EIO);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_double_traceme_fails_with_eperm)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		errno = 0;
+		if (ptrace(PTRACE_TRACEME, 0, 0, 0) != -1 || errno != EPERM) {
+			_exit(1);
+		}
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_cont_non_stopped_tracee_fails_with_esrch)
+{
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		sleep(30);
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_ERRNO(ptrace(PTRACE_CONT, pid, 0, 0), ESRCH);
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status));
+}
+END_TEST()
+
+FN_TEST(ptrace_wait_nohang_on_running_tracee)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGSTOP));
+		for (;;) {
+			pause();
+		}
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, WNOHANG), _ret == 0);
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status));
+}
+END_TEST()
+
+FN_TEST(ptrace_wait_nowait_does_not_consume_ptrace_stop)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGUSR1));
+		_exit(1);
+	}
+
+	siginfo_t info = { 0 };
+
+	TEST_RES(waitid(P_PID, pid, &info, WSTOPPED | WNOWAIT),
+		 _ret == 0 && info.si_code == CLD_TRAPPED &&
+			 info.si_status == SIGUSR1);
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGUSR1);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 1);
+}
+END_TEST()
+
+FN_TEST(ptrace_multiple_tracees)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	const int TRACEE_COUNT = 8;
+	pid_t pids[8];
+	for (int i = 0; i < TRACEE_COUNT; i++) {
+		pids[i] = TEST_SUCC(fork());
+		if (pids[i] == 0) {
+			CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+			CHECK(raise(SIGTERM));
+			_exit(0);
+		}
+	}
+
+	int stop_count = 0;
+	while (stop_count < TRACEE_COUNT) {
+		int status;
+		pid_t waited = TEST_RES(waitpid(0, &status, 0),
+					WIFSTOPPED(status) &&
+						WSTOPSIG(status) == SIGTERM);
+		int found = 0;
+		for (int i = 0; i < TRACEE_COUNT; i++) {
+			if (waited == pids[i]) {
+				found = 1;
+				break;
+			}
+		}
+		TEST_RES(found, _ret == 1);
+		stop_count++;
+	}
+
+	for (int i = 0; i < TRACEE_COUNT; i++) {
+		TEST_SUCC(ptrace(PTRACE_CONT, pids[i], 0, 0));
+	}
+
+	int exit_count = 0;
+	while (exit_count < TRACEE_COUNT) {
+		int status;
+		pid_t waited =
+			TEST_RES(waitpid(0, &status, 0),
+				 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+		int found = 0;
+		for (int i = 0; i < TRACEE_COUNT; i++) {
+			if (waited == pids[i]) {
+				found = 1;
+				break;
+			}
+		}
+		TEST_RES(found, _ret == 1);
+		exit_count++;
+	}
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -40,6 +40,8 @@ set -e
 ./pthread/pthread_signal_test
 ./pthread/pthread_test
 
+./ptrace/ptrace
+
 ./sched/sched_attr_getset
 ./sched/sched_param_getset
 ./sched/sched_param_idle


### PR DESCRIPTION
~Based on https://github.com/asterinas/asterinas/pull/2855.~

This PR and https://github.com/asterinas/asterinas/pull/3065 will complete the phase 1 of https://github.com/asterinas/asterinas/issues/2323. This makes it possible to run a [GDB-like debugger program](https://github.com/asterinas/asterinas/blob/bdebb99bd03b534fca001a214646d3e03f8b8c0d/test/initramfs/src/apps/process/ptrace/ptracer.c) in Asterinas.

This PR contains the basic ptrace stop / wait / continue support. #3065 supports debugging with breakpoints and single-step.

# Design Notes (of this PR and https://github.com/asterinas/asterinas/pull/3065)

Below, we refer to the **tracer** as the thread that traces another thread (e.g., GDB), and the **tracee** as the thread being traced.

## Goal

What exactly is our goal? 
 - Supporting GDB and ensuring that incorrect `ptrace` calls cannot corrupt the kernel,
 - Or fully supporting all `ptrace` calls?

I personally prefer the former. The following discussion is based on it.

## The `ptrace` Model

In Linux, each thread can act as a tracer or a tracee. However, in the GDB usage, the tracer is always a single-threaded process. When GDB debugs a multi-threaded program, its main thread performs `ptrace` on each thread individually. Therefore, we can simplify the implementation by only supporting the main thread as the tracer. 

A debugger interacts with the debuggee as follows:

```
[debugger]                        [debuggee]

                               enters ptrace-stop
returns from wait()
// do something
ptrace(PTRACE_CONT)
                               resumes from ptrace-stop
```


## Ptrace-stops

**Something I said in the community meeting on 2026.02.13 was incorrect. I described “ptrace-stop” as a process-level stop, but that was incorrect. Unlike `SIGSTOP`, which stops the entire process, `ptrace-stop` only stops a single thread.**

In Linux, a ptrace-stop can only be resumed by `PTRACE_CONT`-family ptrace calls, or interrupted by `SIGKILL`.

https://elixir.bootlin.com/linux/v6.16.5/source/include/linux/sched/signal.h#L439-L447
https://elixir.bootlin.com/linux/v6.16.5/source/kernel/signal.c#L721-L736
https://elixir.bootlin.com/linux/v6.16.5/source/kernel/signal.c#L2379

A ptrace-stop can occur in the middle of a system call:

> PTRACE_EVENT_VFORK
>               Stop before return from [vfork(2)](https://man7.org/linux/man-pages/man2/vfork.2.html) or [clone(2)](https://man7.org/linux/man-pages/man2/clone.2.html) with the
>               CLONE_VFORK flag.  When the tracee is continued after this
>               stop, it will wait for child to exit/exec before continuing
>               its execution (in other words, the usual behavior on
>               [vfork(2)](https://man7.org/linux/man-pages/man2/vfork.2.html)).

The tracer needs to be able to read and write the tracee’s register state while it is in a ptrace-stop. Considering the above, this PR implements ptrace-stop as follows:

```rust
struct PosixThread {
    // ...
    tracee_status: Once<TraceeStatus>,
    tracees: Once<Mutex<HashMap<Tid, Arc<Thread>>>>,
}

struct TraceeStatus {
    is_stopped: AtomicBool,
    state: Mutex<TraceeState>,
}

struct TraceeState {
    tracer: Weak<Thread>,
    siginfo: Option<siginfo_t>,
    general_regs: Option<GeneralRegs>,
    options: PtraceOptions,
}
```

```
[tracee]                                                           [tracer]

Acquire tracee_state lock
tracee_state.stop_siginfo = ...;
tracee_state.general_regs = user_ctx.general_regs;
is_ptrace_stopped = true;
Release tracee_state lock

// It only returns in two cases:
// 1) the tracer continues the tracee                       Acquire tracee_state lock
// 2) a SIGKILL is received                                 Read or write tracee_state.general_regs
let res = waiter.wait_until_or_cancelled(                   is_ptrace_stopped = false;
    cond: is_ptrace_stopped == false,                       Release tracee_state lock
    cancel_cond: has_pending_sigkill(),
);

if res.is_ok() {
    Acquire tracee_state lock
    user_ctx.general_regs = tracee_state.general_regs;
    Release tracee_state lock
} else {
    // handle pending SIGKILL
}
```

<details>
<summary> An inferior alternative: Modify `UserContext` concurrently</summary>


Currently in Asterinas, each user thread is the only thread that reads or writes its own registers, so we only need to pass `&mut user_ctx` everywhere. However, with `ptrace`, the tracer can also modify the tracee’s registers via operations such as `PTRACE_SETREGS`.

The design in this PR adds a `Mutex` wrapping each thread's `UserContext`. A normal thread holds this lock throughout its entire lifetime. Only a tracee thread will release the lock when entering a ptrace-stop, and re-acquire the lock when resuming from the ptrace-stop.

https://github.com/asterinas/asterinas/blob/bdebb99bd03b534fca001a214646d3e03f8b8c0d/kernel/src/thread/task.rs#L115-L142

Therefore, for a thread that has never become a tracee, each time it traps into kernel with no pending signals, this PR only adds one atomic acquire (when checking `ctx.posix_thread.is_ptrace_stopped()`). I ran the `lmbench/process_getppid_lat` benchmark on this PR and the [main](https://github.com/asterinas/asterinas/commit/c2edfe05cb3f7edc161a305f097139c6791a30a9) branch, and found no noticeable performance difference between them.

<details>
<summary>On the main branch</summary>

```
root@avalon:~/asterinas# cat result_lmbench-process_getppid_lat.json
[
  {
    "name": "Average syscall latency on Linux",
    "unit": "µs",
    "value": "0.0704",
    "extra": "linux_result"
  },
  {
    "name": "Average syscall latency on Asterinas",
    "unit": "µs",
    "value": "0.1617",
    "extra": "aster_result"
  }
]
```

</details>

<details>
<summary>On this PR</summary>

```
root@avalon:~/asterinas# cat result_lmbench-process_getppid_lat.json
[
  {
    "name": "Average syscall latency on Linux",
    "unit": "µs",
    "value": "0.0787",
    "extra": "linux_result"
  },
  {
    "name": "Average syscall latency on Asterinas",
    "unit": "µs",
    "value": "0.1622",
    "extra": "aster_result"
  }
]
```

</details>

https://github.com/asterinas/asterinas/blob/417d58dbac51a71cbe02b5615a7198184371ebd6/kernel/src/thread/task.rs#L26

Additionally, I think `fn create_new_user_task` should be placed in `mod posix_thread`, since it can only be called by user threads. This would also allow me to make this method private:

https://github.com/asterinas/asterinas/blob/bdebb99bd03b534fca001a214646d3e03f8b8c0d/kernel/src/process/posix_thread/mod.rs#L111-L113

If the code owners agree with this approach, I will open another PR to move this method.

</details>

## Checks When Modifying Registers

When modifying registers via `PTRACE_SETREGS`, we should follow [Linux’s checks](https://elixir.bootlin.com/linux/v6.16.5/source/arch/x86/kernel/ptrace.c#L290-L405):

It includes:

```c
regs->flags = (regs->flags & ~FLAG_MASK) | (value & FLAG_MASK);
```

That is to say, bits outside `FLAG_MASK` in `rflags` remain unchanged.

Therefore, the `set_regs` implementation in this PR is:
1. Copy the old `GeneralRegs`
2. Perform checks and modification on the copied registers
3. Write the result back to `UserContext` if all checks pass

To support this, the `rflags(), set_rflags()` and similar methods previously implemented for `UserContext` are moved to `GeneralRegs` instead. Also, I think reading registers by `user_ctx.general_regs().rax()` is also clearer than `user_ctx.rax()`. The commit "Impl regs getter and setter for `GeneralRegs` instead of `UserContext` on x86_64" contains this change.

### Checks for `rip` and `rsp`

In Linux, `PTRACE_SETREGS` does not validate the values of `rip` and `rsp`. If an invalid value causes an error during `iret`, Linux catches it with the [bad iret handler](https://elixir.bootlin.com/linux/v6.16.5/source/arch/x86/kernel/traps.c#L974).

In this PR, I simply require `rip` and `rsp` to be less than `MAX_USERSPACE_VADDR`. This means the error will be returned earlier from the `ptrace(PTRACE_SETREGS)` call. Since our goal is to support GDB, I think this restriction is OK.

# Reference

https://man7.org/linux/man-pages/man2/ptrace.2.html