### PR TITLE
Support IPC namespace

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -20,6 +20,7 @@ use crate::{
             path::{MountNamespace, Path},
         },
     },
+    ipc::IpcNamespace,
     net::uts_ns::UtsNamespace,
     prelude::*,
     process::{NsProxy, UserNamespace, posix_thread::AsPosixThread},
@@ -49,6 +50,8 @@ impl NsDirOps {
 enum NsProxyEntry {
     /// The cgroup namespace.
     Cgroup,
+    /// The IPC namespace.
+    Ipc,
     /// The mount namespace.
     Mnt,
     /// The UTS namespace.
@@ -57,12 +60,13 @@ enum NsProxyEntry {
 
 impl NsProxyEntry {
     /// All supported `NsProxy`-backed namespace entries.
-    const ALL: &[Self] = &[Self::Cgroup, Self::Mnt, Self::Uts];
+    const ALL: &[Self] = &[Self::Cgroup, Self::Ipc, Self::Mnt, Self::Uts];
 
     /// Returns the filename of this namespace entry under `/proc/[pid]/ns/`.
     fn as_str(self) -> &'static str {
         match self {
             Self::Cgroup => "cgroup",
+            Self::Ipc => "ipc",
             Self::Mnt => "mnt",
             Self::Uts => "uts",
         }
@@ -72,6 +76,7 @@ impl NsProxyEntry {
     fn from_str(s: &str) -> Option<Self> {
         match s {
             "cgroup" => Some(Self::Cgroup),
+            "ipc" => Some(Self::Ipc),
             "mnt" => Some(Self::Mnt),
             "uts" => Some(Self::Uts),
             _ => None,
@@ -84,6 +89,7 @@ impl NsProxyEntry {
             Self::Cgroup => {
                 NsSymOps::<CgroupNamespace>::new_inode(ns_proxy.cgroup_ns().get_path(), parent)
             }
+            Self::Ipc => NsSymOps::<IpcNamespace>::new_inode(ns_proxy.ipc_ns().get_path(), parent),
             Self::Mnt => {
                 NsSymOps::<MountNamespace>::new_inode(ns_proxy.mnt_ns().get_path(), parent)
             }
@@ -95,6 +101,7 @@ impl NsProxyEntry {
     fn current_path(self, ns_proxy: &NsProxy) -> Path {
         match self {
             Self::Cgroup => ns_proxy.cgroup_ns().get_path(),
+            Self::Ipc => ns_proxy.ipc_ns().get_path(),
             Self::Mnt => ns_proxy.mnt_ns().get_path(),
             Self::Uts => ns_proxy.uts_ns().get_path(),
         }
@@ -106,6 +113,9 @@ impl NsProxyEntry {
 /// Returns `None` if the inode is not a known namespace symlink type.
 fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
     if let Some(sym) = inode.downcast_ref::<NsSymlink<CgroupNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<IpcNamespace>>() {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<MountNamespace>>() {
@@ -245,6 +255,10 @@ impl DirOps for NsDirOps {
 
         if child.downcast_ref::<NsSymlink<UtsNamespace>>().is_some() {
             return cached_path == &ns_proxy.uts_ns().get_path();
+        }
+
+        if child.downcast_ref::<NsSymlink<IpcNamespace>>().is_some() {
+            return cached_path == &ns_proxy.ipc_ns().get_path();
         }
 
         // TODO: Support additional namespace types.

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -357,7 +357,6 @@ impl StashedDentry {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NsType {
     Cgroup,
-    #[expect(unused)]
     Ipc,
     Mnt,
     #[expect(unused)]

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -155,7 +155,6 @@ fn init_in_first_kthread(path_resolver: &PathResolver) {
     crate::device::init_in_first_kthread();
     crate::net::init_in_first_kthread();
     crate::fs::init_in_first_kthread(path_resolver);
-    crate::ipc::init_in_first_kthread();
     #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     crate::vdso::init_in_first_kthread();
 }

--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::collections::btree_map::BTreeMap;
+
+use id_alloc::IdAlloc;
+
+use super::key_t;
+use crate::prelude::*;
+
+/// Maps IPC IDs to objects and manages ID allocation.
+///
+/// Lock ordering:
+/// `objects` -> `id_allocator`.
+pub(crate) struct IpcIds<T> {
+    objects: RwLock<BTreeMap<key_t, T>>,
+    id_allocator: SpinLock<IdAlloc>,
+}
+
+impl<T> IpcIds<T> {
+    /// Creates an IPC ID table with IDs in `1..=max_id`.
+    pub(crate) fn new(max_id: usize) -> Self {
+        let mut id_allocator = IdAlloc::with_capacity(max_id + 1);
+        // Remove the first index 0 (IPC IDs start from 1).
+        id_allocator.alloc();
+
+        Self {
+            objects: RwLock::new(BTreeMap::new()),
+            id_allocator: SpinLock::new(id_allocator),
+        }
+    }
+
+    /// Calls `op` with the object identified by `id`.
+    pub(crate) fn with<R, F>(&self, key: key_t, op: F) -> Result<R>
+    where
+        F: FnOnce(&T) -> Result<R>,
+    {
+        let objects = self.objects.read();
+        let object = objects.get(&key).ok_or(Error::new(Errno::ENOENT))?;
+        op(object)
+    }
+
+    /// Removes the object identified by `key`.
+    pub(crate) fn remove<F>(&self, key: key_t, may_remove: F) -> Result<()>
+    where
+        F: FnOnce(&T) -> Result<()>,
+    {
+        let mut objects = self.objects.write();
+        let object = objects.get(&key).ok_or(Error::new(Errno::ENOENT))?;
+        may_remove(object)?;
+        objects.remove(&key).ok_or(Error::new(Errno::ENOENT))?;
+        Ok(())
+    }
+
+    /// Inserts a new object with an automatically allocated key.
+    pub(crate) fn insert_auto<F>(&self, new_object_fn: F) -> Result<key_t>
+    where
+        F: FnOnce(key_t) -> Result<T>,
+    {
+        let mut objects = self.objects.write();
+        let mut id_allocator = self.id_allocator.lock();
+        let key = id_allocator.alloc().ok_or(Error::new(Errno::ENOSPC))? as key_t;
+        let object = match new_object_fn(key) {
+            Ok(object) => object,
+            Err(err) => {
+                id_allocator.free(key as usize);
+                return Err(err);
+            }
+        };
+        objects.insert(key, object);
+        Ok(key)
+    }
+
+    /// Inserts a new object at `key`.
+    pub(crate) fn insert_at<F>(&self, key: key_t, new_object_fn: F) -> Result<()>
+    where
+        F: FnOnce(key_t) -> Result<T>,
+    {
+        let mut objects = self.objects.write();
+        let mut id_allocator = self.id_allocator.lock();
+        id_allocator
+            .alloc_specific(key as usize)
+            .ok_or(Error::new(Errno::EEXIST))?;
+        let object = match new_object_fn(key) {
+            Ok(object) => object,
+            Err(err) => {
+                id_allocator.free(key as usize);
+                return Err(err);
+            }
+        };
+        objects.insert(key, object);
+        Ok(())
+    }
+
+    /// Frees `key` back to the allocator.
+    pub(crate) fn free_key(&self, key: key_t) {
+        self.id_allocator.lock().free(key as usize);
+    }
+}

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Defines the IPC namespace abstraction.
+//!
+//! An IPC namespace isolates System V IPC resources from other namespaces.
+//! It currently manages semaphore sets only, while message queues and shared
+//! memory remain to be added.
+//!
+//! Each namespace stores its semaphore sets in a per-namespace map keyed by
+//! IPC key and uses a dedicated ID allocator to assign semaphore identifiers.
+
+use aster_rights::ReadOp;
+use spin::Once;
+
+use super::{
+    ipc_ids::IpcIds,
+    key_t,
+    semaphore::system_v::{
+        PermissionMode,
+        sem_set::{SEMMNI, SemaphoreSet},
+    },
+};
+use crate::{
+    fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
+    ipc::IpcFlags,
+    prelude::*,
+    process::{
+        Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
+    },
+};
+
+/// The IPC namespace.
+///
+/// An IPC namespace isolates System V IPC objects
+/// (semaphores, message queues, shared memory).
+/// Each namespace maintains its own independent set
+/// of IPC resources and identifier allocator.
+///
+/// Lock ordering:
+/// `sem_ids` -> `SemaphoreSet::inner`.
+pub struct IpcNamespace {
+    /// Semaphore sets within this namespace.
+    sem_ids: IpcIds<SemaphoreSet>,
+    /// Owner user namespace.
+    owner: Arc<UserNamespace>,
+    /// Stashed dentry for nsfs.
+    stashed_dentry: StashedDentry,
+}
+
+impl IpcNamespace {
+    /// Returns a reference to the singleton initial IPC namespace.
+    pub fn get_init_singleton() -> &'static Arc<IpcNamespace> {
+        static INIT: Once<Arc<IpcNamespace>> = Once::new();
+
+        INIT.call_once(|| {
+            let owner = UserNamespace::get_init_singleton().clone();
+            Self::new(owner)
+        })
+    }
+
+    fn new(owner: Arc<UserNamespace>) -> Arc<Self> {
+        let stashed_dentry = StashedDentry::new();
+
+        Arc::new(Self {
+            sem_ids: IpcIds::new(SEMMNI),
+            owner,
+            stashed_dentry,
+        })
+    }
+
+    /// Clones a new IPC namespace from `self`.
+    ///
+    /// The new namespace starts with an empty set of IPC resources.
+    pub fn new_clone(
+        &self,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        Ok(Self::new(owner))
+    }
+
+    /// Calls `op` with the semaphore set identified by `semid`.
+    pub fn with_sem_set<T, F>(
+        &self,
+        semid: key_t,
+        num_sems: Option<usize>,
+        required_perm: PermissionMode,
+        op: F,
+    ) -> Result<T>
+    where
+        F: FnOnce(&SemaphoreSet) -> Result<T>,
+    {
+        if semid <= 0 {
+            return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
+        }
+
+        self.sem_ids
+            .with(semid, |sem_set| {
+                Self::validate_sem_set(semid, sem_set, num_sems, required_perm)?;
+                op(sem_set)
+            })
+            .map_err(Self::map_sem_id_error)
+    }
+
+    /// Removes the semaphore set identified by `semid`.
+    pub fn remove_sem_set<F>(&self, semid: key_t, may_remove: F) -> Result<()>
+    where
+        F: FnOnce(&SemaphoreSet) -> Result<()>,
+    {
+        if semid <= 0 {
+            return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
+        }
+
+        self.sem_ids
+            .remove(semid, may_remove)
+            .map_err(Self::map_sem_id_error)
+    }
+
+    /// Returns the existing semaphore set or creates a new one.
+    pub fn get_or_create_sem_set(
+        self: &Arc<Self>,
+        key: key_t,
+        num_sems: usize,
+        flags: IpcFlags,
+        mode: u16,
+        credentials: Credentials<ReadOp>,
+    ) -> Result<key_t> {
+        const IPC_NEW: key_t = 0;
+
+        if key < 0 {
+            return_errno_with_message!(Errno::EINVAL, "semaphore key must not be negative");
+        }
+
+        if key == IPC_NEW || (key as usize > SEMMNI && flags.contains(IpcFlags::IPC_CREAT)) {
+            if num_sems == 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "num_sems must not be zero when creating"
+                );
+            }
+            return self.create_sem_set(num_sems, mode, credentials);
+        }
+
+        let mut credentials = Some(credentials);
+        loop {
+            match self.sem_ids.with(key, |sem_set| {
+                Self::validate_sem_set(
+                    key,
+                    sem_set,
+                    Some(num_sems),
+                    PermissionMode::ALTER | PermissionMode::READ,
+                )?;
+                if flags.contains(IpcFlags::IPC_CREAT | IpcFlags::IPC_EXCL) {
+                    return_errno_with_message!(
+                        Errno::EEXIST,
+                        "semaphore set already exists with IPC_EXCL"
+                    );
+                }
+
+                Ok(key)
+            }) {
+                Ok(key) => return Ok(key),
+                Err(err) if err.error() == Errno::ENOENT && flags.contains(IpcFlags::IPC_CREAT) => {
+                }
+                Err(err) => return Err(err),
+            }
+
+            if num_sems == 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "num_sems must not be zero when creating"
+                );
+            }
+
+            match self.sem_ids.insert_at(key, |key| {
+                let Some(credentials) = credentials.take() else {
+                    return_errno_with_message!(Errno::EINVAL, "credentials were already consumed");
+                };
+                SemaphoreSet::new(key, num_sems, mode, credentials, self)
+            }) {
+                Ok(()) => return Ok(key),
+                Err(err) if err.error() == Errno::EEXIST => continue,
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    fn validate_sem_set(
+        key: key_t,
+        sem_set: &SemaphoreSet,
+        num_sems: Option<usize>,
+        required_perm: PermissionMode,
+    ) -> Result<()> {
+        if key <= 0 {
+            return_errno_with_message!(Errno::EINVAL, "semaphore key must be positive");
+        }
+
+        if let Some(num_sems) = num_sems
+            && num_sems > sem_set.num_sems()
+        {
+            return_errno_with_message!(Errno::EINVAL, "num_sems exceeds the set size");
+        }
+
+        if !required_perm.is_empty() {
+            // TODO: Support permission check
+            warn!("Semaphore doesn't support permission check now");
+        }
+
+        Ok(())
+    }
+
+    /// Creates a new semaphore set and returns its key.
+    fn create_sem_set(
+        self: &Arc<Self>,
+        num_sems: usize,
+        mode: u16,
+        credentials: Credentials<ReadOp>,
+    ) -> Result<key_t> {
+        self.sem_ids
+            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, credentials, self))
+    }
+
+    /// Frees a semaphore key back to the allocator.
+    pub(super) fn free_sem_key(&self, key: key_t) {
+        self.sem_ids.free_key(key);
+    }
+
+    fn map_sem_id_error(err: Error) -> Error {
+        if err.error() == Errno::ENOENT {
+            Error::new(Errno::EINVAL)
+        } else {
+            err
+        }
+    }
+}
+
+impl NsCommonOps for IpcNamespace {
+    const TYPE: NsType = NsType::Ipc;
+
+    fn owner_user_ns(&self) -> Option<&Arc<UserNamespace>> {
+        Some(&self.owner)
+    }
+
+    fn parent(&self) -> Result<&Arc<Self>> {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "an IPC namespace does not have a parent namespace"
+        );
+    }
+
+    fn stashed_dentry(&self) -> &StashedDentry {
+        &self.stashed_dentry
+    }
+}

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -5,7 +5,11 @@ use crate::{
     process::{Gid, Uid},
 };
 
+mod ipc_ids;
+pub mod ipc_ns;
 pub mod semaphore;
+
+pub use ipc_ns::IpcNamespace;
 
 #[expect(non_camel_case_types)]
 pub type key_t = i32;
@@ -95,8 +99,4 @@ impl IpcPermission {
             mode,
         }
     }
-}
-
-pub(super) fn init_in_first_kthread() {
-    semaphore::init_in_first_kthread();
 }

--- a/kernel/src/ipc/semaphore/mod.rs
+++ b/kernel/src/ipc/semaphore/mod.rs
@@ -5,7 +5,3 @@
 
 pub mod posix;
 pub mod system_v;
-
-pub(super) fn init_in_first_kthread() {
-    system_v::init_in_first_kthread();
-}

--- a/kernel/src/ipc/semaphore/system_v/mod.rs
+++ b/kernel/src/ipc/semaphore/system_v/mod.rs
@@ -14,7 +14,3 @@ bitflags! {
         const READ   = 0o004;
     }
 }
-
-pub(super) fn init_in_first_kthread() {
-    sem_set::init_in_first_kthread();
-}

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -9,9 +9,12 @@ use core::{
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use ostd::sync::{PreemptDisabled, Waiter, Waker};
 
-use super::sem_set::{SEMVMX, SemSetInner};
+use super::{
+    PermissionMode,
+    sem_set::{SEMVMX, SemSetInner},
+};
 use crate::{
-    ipc::{IpcFlags, key_t, semaphore::system_v::sem_set::sem_sets},
+    ipc::{IpcFlags, IpcNamespace, key_t},
     prelude::*,
     process::Pid,
     time::{
@@ -123,10 +126,13 @@ pub fn sem_op(
     sem_id: key_t,
     sops: Vec<SemBuf>,
     timeout: Option<Duration>,
+    ipc_ns: &Arc<IpcNamespace>,
     ctx: &Context,
 ) -> Result<()> {
-    debug_assert!(sem_id > 0);
-    debug!("sops: {:?}", sops);
+    if sem_id <= 0 {
+        return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
+    }
+    debug!("[semop] sops: {:?}", sops);
 
     let pid = ctx.process.pid();
     let mut pending_op = PendingOp {
@@ -144,74 +150,85 @@ pub fn sem_op(
         warn!("Found duplicate sop");
     }
 
-    let local_sem_sets = sem_sets();
-    let sem_set = local_sem_sets
-        .get(&sem_id)
-        .ok_or(Error::new(Errno::EINVAL))?;
-    let mut inner = sem_set.inner();
+    enum SemOpResult {
+        Completed,
+        Pending {
+            status: Arc<AtomicStatus>,
+            waiter: Waiter,
+        },
+    }
 
-    if perform_atomic_semop(&mut inner.sems, &mut pending_op)? {
-        if alter {
-            let wake_queue = do_smart_update(&mut inner, &pending_op);
-            for wake_op in wake_queue {
-                wake_op.set_status(Status::Normal);
-                if let Some(waker) = wake_op.waker {
-                    waker.wake_up();
+    let sem_op_result = ipc_ns.with_sem_set(sem_id, None, PermissionMode::empty(), |sem_set| {
+        let mut inner = sem_set.inner();
+
+        if perform_atomic_semop(&mut inner.sems, &mut pending_op)? {
+            if alter {
+                let wake_queue = do_smart_update(&mut inner, &pending_op);
+                for wake_op in wake_queue {
+                    wake_op.set_status(Status::Normal);
+                    if let Some(waker) = wake_op.waker {
+                        waker.wake_up();
+                    }
                 }
             }
+
+            sem_set.update_otime();
+            return Ok(SemOpResult::Completed);
         }
 
-        sem_set.update_otime();
-        return Ok(());
-    }
+        // Prepare to wait
+        let status = pending_op.status.clone();
+        let (waiter, waker) = Waiter::new_pair();
 
-    // Prepare to wait
-    let status = pending_op.status.clone();
-    let (waiter, waker) = Waiter::new_pair();
+        // Check if timeout exists to avoid calling `Arc::clone()`
+        if let Some(timeout) = timeout {
+            pending_op.waker = Some(waker.clone());
 
-    // Check if timeout exists to avoid calling `Arc::clone()`
-    if let Some(timeout) = timeout {
-        pending_op.waker = Some(waker.clone());
+            let jiffies_timer =
+                JIFFIES_TIMER_MANAGER
+                    .get()
+                    .unwrap()
+                    .create_timer(move |_guard: TimerGuard| {
+                        waker.wake_up();
+                    });
+            jiffies_timer.lock().set_timeout(Timeout::After(timeout));
+        } else {
+            pending_op.waker = Some(waker);
+        }
 
-        let jiffies_timer =
-            JIFFIES_TIMER_MANAGER
-                .get()
-                .unwrap()
-                .create_timer(move |_guard: TimerGuard| {
-                    waker.wake_up();
-                });
-        jiffies_timer.lock().set_timeout(Timeout::After(timeout));
-    } else {
-        pending_op.waker = Some(waker);
-    }
+        if alter {
+            inner.pending_alter.push_back(pending_op);
+        } else {
+            inner.pending_const.push_back(pending_op);
+        }
 
-    if alter {
-        inner.pending_alter.push_back(pending_op);
-    } else {
-        inner.pending_const.push_back(pending_op);
-    }
+        Ok(SemOpResult::Pending { status, waiter })
+    })?;
 
-    drop(inner);
-    drop(local_sem_sets);
+    match sem_op_result {
+        SemOpResult::Completed => Ok(()),
+        SemOpResult::Pending { status, waiter } => {
+            waiter.wait();
+            match status.load(Ordering::Relaxed) {
+                Status::Normal => Ok(()),
+                Status::Removed => Err(Error::new(Errno::EIDRM)),
+                Status::Pending => {
+                    // FIXME: Lookup may be time-consuming.
+                    ipc_ns.with_sem_set(sem_id, None, PermissionMode::empty(), |sem_set| {
+                        let mut inner = sem_set.inner();
+                        let pending_ops = if alter {
+                            &mut inner.pending_alter
+                        } else {
+                            &mut inner.pending_const
+                        };
+                        pending_ops.retain(|op| op.pid != pid);
 
-    waiter.wait();
-    match status.load(Ordering::Relaxed) {
-        Status::Normal => Ok(()),
-        Status::Removed => Err(Error::new(Errno::EIDRM)),
-        Status::Pending => {
-            // FIXME: Getting sem_sets maybe time-consuming.
-            let sem_sets = sem_sets();
-            let sem_set = sem_sets.get(&sem_id).ok_or(Error::new(Errno::EINVAL))?;
-            let mut inner = sem_set.inner();
+                        Ok(())
+                    })?;
 
-            let pending_ops = if alter {
-                &mut inner.pending_alter
-            } else {
-                &mut inner.pending_const
-            };
-            pending_ops.retain(|op| op.pid != pid);
-
-            Err(Error::new(Errno::EAGAIN))
+                    Err(Error::new(Errno::EAGAIN))
+                }
+            }
         }
     }
 }
@@ -321,7 +338,7 @@ fn perform_atomic_semop(sems: &mut Box<[Semaphore]>, pending_op: &mut PendingOp)
         // Zero condition
         if op.sem_op == 0 && result != 0 {
             if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno!(Errno::EAGAIN);
+                return_errno_with_message!(Errno::EAGAIN, "semaphore would block on wait-for-zero");
             } else {
                 return Ok(false);
             }
@@ -330,14 +347,14 @@ fn perform_atomic_semop(sems: &mut Box<[Semaphore]>, pending_op: &mut PendingOp)
         result += i32::from(op.sem_op);
         if result < 0 {
             if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno!(Errno::EAGAIN);
+                return_errno_with_message!(Errno::EAGAIN, "semaphore would block on decrement");
             } else {
                 return Ok(false);
             }
         }
 
         if result > SEMVMX {
-            return_errno!(Errno::ERANGE);
+            return_errno_with_message!(Errno::ERANGE, "semaphore value exceeds SEMVMX");
         }
         if flags.contains(IpcFlags::SEM_UNDO) {
             todo!()

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::btree_map::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_rights::ReadOp;
-use id_alloc::IdAlloc;
-use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
-use spin::Once;
+use ostd::sync::PreemptDisabled;
 
-use super::{
-    PermissionMode,
-    sem::{PendingOp, Status, update_pending_alter, wake_const_ops},
-};
+use super::sem::{PendingOp, Status, update_pending_alter, wake_const_ops};
 use crate::{
-    ipc::{IpcPermission, key_t, semaphore::system_v::sem::Semaphore},
+    ipc::{IpcNamespace, IpcPermission, key_t, semaphore::system_v::sem::Semaphore},
     prelude::*,
     process::{Credentials, Pid},
     time::clocks::RealTimeCoarseClock,
@@ -39,7 +34,7 @@ pub const SEMAEM: i32 = SEMVMX;
 #[derive(Debug)]
 pub struct SemaphoreSet {
     /// Number of semaphores in the set
-    nsems: usize,
+    num_sems: usize,
     /// Inner
     inner: SpinLock<SemSetInner>,
     /// Semaphore permission
@@ -48,9 +43,11 @@ pub struct SemaphoreSet {
     sem_ctime: AtomicU64,
     /// Last semop time.
     sem_otime: AtomicU64,
+    /// The IPC namespace.
+    ipc_ns: Weak<IpcNamespace>,
 }
 
-// https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/ipcbuf.h
+// Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/ipcbuf.h#L22>.
 #[padding_struct]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
@@ -154,13 +151,13 @@ impl SemaphoreSet {
         count
     }
 
-    pub fn nsems(&self) -> usize {
-        self.nsems
+    pub fn num_sems(&self) -> usize {
+        self.num_sems
     }
 
     pub fn setval(&self, sem_num: usize, val: i32, pid: Pid) -> Result<()> {
-        if !(0..SEMVMX).contains(&val) {
-            return_errno!(Errno::ERANGE);
+        if !(0..=SEMVMX).contains(&val) {
+            return_errno_with_message!(Errno::ERANGE, "semaphore value out of range");
         }
 
         let mut inner = self.inner();
@@ -217,11 +214,19 @@ impl SemaphoreSet {
         self.inner.lock()
     }
 
-    fn new(key: key_t, nsems: usize, mode: u16, credentials: Credentials<ReadOp>) -> Result<Self> {
-        debug_assert!(nsems <= SEMMSL);
+    pub(in crate::ipc) fn new(
+        key: key_t,
+        num_sems: usize,
+        mode: u16,
+        credentials: Credentials<ReadOp>,
+        ipc_ns: &Arc<IpcNamespace>,
+    ) -> Result<Self> {
+        if num_sems > SEMMSL {
+            return_errno_with_message!(Errno::EINVAL, "num_sems exceeds SEMMSL");
+        }
 
-        let mut sems = Vec::with_capacity(nsems);
-        for _ in 0..nsems {
+        let mut sems = Vec::with_capacity(num_sems);
+        for _ in 0..num_sems {
             sems.push(Semaphore::new(0));
         }
 
@@ -229,7 +234,7 @@ impl SemaphoreSet {
             IpcPermission::new_sem_perm(key, credentials.euid(), credentials.egid(), mode);
 
         Ok(Self {
-            nsems,
+            num_sems,
             permission,
             sem_ctime: AtomicU64::new(RealTimeCoarseClock::get().read_time().as_secs()),
             sem_otime: AtomicU64::new(0),
@@ -238,6 +243,7 @@ impl SemaphoreSet {
                 pending_alter: LinkedList::new(),
                 pending_const: LinkedList::new(),
             }),
+            ipc_ns: Arc::downgrade(ipc_ns),
         })
     }
 
@@ -256,7 +262,7 @@ impl SemaphoreSet {
             sem_perm: ipc_perm,
             sem_otime: self.sem_otime.load(Ordering::Relaxed),
             sem_ctime: self.sem_ctime.load(Ordering::Relaxed),
-            sem_nsems: self.nsems as u64,
+            sem_nsems: self.num_sems as u64,
             ..SemidDs::default()
         }
     }
@@ -282,97 +288,17 @@ impl Drop for SemaphoreSet {
             }
         }
         pending_const.clear();
+        drop(inner);
 
-        ID_ALLOCATOR
-            .get()
-            .unwrap()
-            .lock()
-            .free(self.permission.key() as usize);
-    }
-}
-
-pub fn create_sem_set_with_id(
-    id: key_t,
-    nsems: usize,
-    mode: u16,
-    credentials: Credentials<ReadOp>,
-) -> Result<()> {
-    debug_assert!(nsems <= SEMMSL);
-    debug_assert!(id > 0);
-    if id as usize > SEMMNI {
-        return_errno_with_message!(Errno::ENOENT, "id larger than SEMMNI");
-    }
-
-    ID_ALLOCATOR
-        .get()
-        .unwrap()
-        .lock()
-        .alloc_specific(id as usize)
-        .ok_or(Error::new(Errno::EEXIST))?;
-
-    let mut sem_sets = SEMAPHORE_SETS.write();
-    sem_sets.insert(id, SemaphoreSet::new(id, nsems, mode, credentials)?);
-
-    Ok(())
-}
-
-/// Checks the semaphore. Return Ok if the semaphore exists and pass the check.
-pub fn check_sem(id: key_t, nsems: Option<usize>, required_perm: PermissionMode) -> Result<()> {
-    debug_assert!(id > 0);
-
-    let sem_sets = SEMAPHORE_SETS.read();
-    let sem_set = sem_sets.get(&id).ok_or(Error::new(Errno::ENOENT))?;
-
-    if let Some(nsems) = nsems {
-        debug_assert!(nsems <= SEMMSL);
-        if nsems > sem_set.nsems() {
-            return_errno!(Errno::EINVAL);
+        if let Some(ipc_ns) = self.ipc_ns.upgrade() {
+            ipc_ns.free_sem_key(self.permission.key());
+        } else {
+            // `upgrade()` returns `None` when the IPC namespace itself is being destroyed.
+            // In that path, dropping the namespace's semaphore-set map
+            // cascades into `SemaphoreSet::drop`,
+            // after the last strong reference to the namespace is already gone.
+            // Skipping `free_sem_key()` is correct
+            // because the namespace's ID allocator is being dropped together with the namespace.
         }
     }
-
-    if !required_perm.is_empty() {
-        // TODO: Support permission check
-        warn!("Semaphore doesn't support permission check now");
-    }
-
-    Ok(())
-}
-
-pub fn create_sem_set(nsems: usize, mode: u16, credentials: Credentials<ReadOp>) -> Result<key_t> {
-    debug_assert!(nsems <= SEMMSL);
-
-    let id = ID_ALLOCATOR
-        .get()
-        .unwrap()
-        .lock()
-        .alloc()
-        .ok_or(Error::new(Errno::ENOSPC))? as i32;
-
-    let mut sem_sets = SEMAPHORE_SETS.write();
-    sem_sets.insert(id, SemaphoreSet::new(id, nsems, mode, credentials)?);
-
-    Ok(id)
-}
-
-pub fn sem_sets<'a>() -> RwLockReadGuard<'a, BTreeMap<key_t, SemaphoreSet>, PreemptDisabled> {
-    SEMAPHORE_SETS.read()
-}
-
-pub fn sem_sets_mut<'a>() -> RwLockWriteGuard<'a, BTreeMap<key_t, SemaphoreSet>, PreemptDisabled> {
-    SEMAPHORE_SETS.write()
-}
-
-static ID_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
-
-/// Semaphore sets in system
-static SEMAPHORE_SETS: RwLock<BTreeMap<key_t, SemaphoreSet>> = RwLock::new(BTreeMap::new());
-
-pub(super) fn init_in_first_kthread() {
-    ID_ALLOCATOR.call_once(|| {
-        let mut id_alloc = IdAlloc::with_capacity(SEMMNI + 1);
-        // Remove the first index 0
-        id_alloc.alloc();
-
-        SpinLock::new(id_alloc)
-    });
 }

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -4,6 +4,7 @@ use spin::Once;
 
 use crate::{
     fs::{cgroupfs::CgroupNamespace, vfs::path::MountNamespace},
+    ipc::IpcNamespace,
     net::uts_ns::UtsNamespace,
     prelude::*,
     process::{CloneFlags, Process, UserNamespace, posix_thread::PosixThread},
@@ -18,6 +19,7 @@ use crate::{
 /// 2. The PID namespace, which is included in the `Process` struct (TODO).
 pub struct NsProxy {
     cgroup_ns: Arc<CgroupNamespace>,
+    ipc_ns: Arc<IpcNamespace>,
     mnt_ns: Arc<MountNamespace>,
     uts_ns: Arc<UtsNamespace>,
 }
@@ -29,6 +31,7 @@ impl NsProxy {
         INIT.call_once(|| {
             Arc::new(NsProxy {
                 cgroup_ns: CgroupNamespace::get_init_singleton().clone(),
+                ipc_ns: IpcNamespace::get_init_singleton().clone(),
                 mnt_ns: MountNamespace::get_init_singleton().clone(),
                 uts_ns: UtsNamespace::get_init_singleton().clone(),
             })
@@ -73,14 +76,19 @@ impl NsProxy {
             builder.cgroup_ns(new_cgroup_ns);
         }
 
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWIPC) {
+            let new_ipc_ns = self.ipc_ns.new_clone(user_ns.clone(), posix_thread)?;
+            builder.ipc_ns(new_ipc_ns);
+        }
+
         if clone_ns_flags.contains(CloneFlags::CLONE_NEWNS) {
             let new_mnt_ns = self.mnt_ns.new_clone(user_ns.clone(), posix_thread)?;
             builder.mnt_ns(new_mnt_ns);
         }
 
         if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
-            let uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
-            builder.uts_ns(uts_ns);
+            let new_uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
+            builder.uts_ns(new_uts_ns);
         }
 
         // TODO: Support other namespaces.
@@ -91,6 +99,11 @@ impl NsProxy {
     /// Returns the associated cgroup namespace.
     pub fn cgroup_ns(&self) -> &Arc<CgroupNamespace> {
         &self.cgroup_ns
+    }
+
+    /// Returns the associated IPC namespace.
+    pub fn ipc_ns(&self) -> &Arc<IpcNamespace> {
+        &self.ipc_ns
     }
 
     /// Returns the associated mount namespace.
@@ -111,6 +124,7 @@ pub struct NsProxyBuilder<'a> {
 
     // Fields for new namespaces.
     cgroup_ns: Option<Arc<CgroupNamespace>>,
+    ipc_ns: Option<Arc<IpcNamespace>>,
     mnt_ns: Option<Arc<MountNamespace>>,
     uts_ns: Option<Arc<UtsNamespace>>,
 }
@@ -121,6 +135,7 @@ impl<'a> NsProxyBuilder<'a> {
         Self {
             old_proxy,
             cgroup_ns: None,
+            ipc_ns: None,
             mnt_ns: None,
             uts_ns: None,
         }
@@ -129,6 +144,12 @@ impl<'a> NsProxyBuilder<'a> {
     /// Sets the new cgroup namespace for the context being built.
     pub fn cgroup_ns(&mut self, cgroup_ns: Arc<CgroupNamespace>) -> &mut Self {
         self.cgroup_ns = Some(cgroup_ns);
+        self
+    }
+
+    /// Sets the new IPC namespace for the context being built.
+    pub fn ipc_ns(&mut self, ipc_ns: Arc<IpcNamespace>) -> &mut Self {
+        self.ipc_ns = Some(ipc_ns);
         self
     }
 
@@ -149,16 +170,19 @@ impl<'a> NsProxyBuilder<'a> {
         let Self {
             old_proxy,
             cgroup_ns: new_cgroup,
+            ipc_ns: new_ipc,
             mnt_ns: new_mnt,
             uts_ns: new_uts,
         } = self;
 
         let new_cgroup = new_cgroup.unwrap_or_else(|| old_proxy.cgroup_ns.clone());
+        let new_ipc = new_ipc.unwrap_or_else(|| old_proxy.ipc_ns.clone());
         let new_mnt = new_mnt.unwrap_or_else(|| old_proxy.mnt_ns.clone());
         let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
 
         NsProxy {
             cgroup_ns: new_cgroup,
+            ipc_ns: new_ipc,
             mnt_ns: new_mnt,
             uts_ns: new_uts,
         }
@@ -167,9 +191,10 @@ impl<'a> NsProxyBuilder<'a> {
 
 /// Checks if the given `flags` contain any unsupported namespace-related flags.
 ///
-/// This method does _not_ check CLONE_NEWUSER since it's handled separately.
+/// This method does _not_ check `CLONE_NEWUSER` since it's handled separately.
 pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
     const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWCGROUP
+        .union(CloneFlags::CLONE_NEWIPC)
         .union(CloneFlags::CLONE_NEWNS)
         .union(CloneFlags::CLONE_NEWUTS);
 

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -6,11 +6,7 @@ use super::SyscallReturn;
 use crate::{
     ipc::{
         IpcControlCmd,
-        semaphore::system_v::{
-            PermissionMode,
-            sem::Semaphore,
-            sem_set::{SemaphoreSet, check_sem, sem_sets, sem_sets_mut},
-        },
+        semaphore::system_v::{PermissionMode, sem::Semaphore},
     },
     prelude::*,
     process::Pid,
@@ -24,7 +20,7 @@ pub fn sys_semctl(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     if semid <= 0 || semnum < 0 {
-        return_errno!(Errno::EINVAL)
+        return_errno_with_message!(Errno::EINVAL, "invalid semid or semnum")
     }
 
     let cmd = IpcControlCmd::try_from(cmd)?;
@@ -33,30 +29,33 @@ pub fn sys_semctl(
         semid, semnum, cmd, arg
     );
 
+    let ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let ipc_ns = ns_proxy.unwrap().ipc_ns();
+
     match cmd {
         IpcControlCmd::IPC_RMID => {
-            let mut sem_sets_mut = sem_sets_mut();
-            let sem_set = sem_sets_mut.get(&semid).ok_or(Error::new(Errno::EINVAL))?;
-
             let euid = ctx.posix_thread.credentials().euid();
-            let permission = sem_set.permission();
-            let can_removed = (euid == permission.uid()) || (euid == permission.cuid());
-            if !can_removed {
-                return_errno!(Errno::EPERM);
-            }
+            ipc_ns.remove_sem_set(semid, |sem_set| {
+                let permission = sem_set.permission();
+                let can_remove = (euid == permission.uid()) || (euid == permission.cuid());
+                if !can_remove {
+                    return_errno_with_message!(
+                        Errno::EPERM,
+                        "no permission to remove semaphore set"
+                    );
+                }
 
-            sem_sets_mut
-                .remove(&semid)
-                .ok_or(Error::new(Errno::EINVAL))?;
+                Ok(())
+            })?;
         }
         IpcControlCmd::SEM_SETVAL => {
             // In setval, arg is parse as i32
             let val = arg as i32;
             if val < 0 {
-                return_errno!(Errno::ERANGE);
+                return_errno_with_message!(Errno::ERANGE, "semaphore value must not be negative");
             }
 
-            check_and_ctl(semid, PermissionMode::ALTER, |sem_set| {
+            ipc_ns.with_sem_set(semid, None, PermissionMode::ALTER, |sem_set| {
                 sem_set.setval(semnum as usize, val, ctx.process.pid())
             })?;
         }
@@ -64,7 +63,7 @@ pub fn sys_semctl(
             fn sem_val(sem: &Semaphore) -> i32 {
                 sem.val()
             }
-            let val: i32 = check_and_ctl(semid, PermissionMode::READ, |sem_set| {
+            let val: i32 = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
                 sem_set.get(semnum as usize, &sem_val)
             })?;
 
@@ -74,28 +73,28 @@ pub fn sys_semctl(
             fn sem_pid(sem: &Semaphore) -> Pid {
                 sem.latest_modified_pid()
             }
-            let pid: Pid = check_and_ctl(semid, PermissionMode::READ, |sem_set| {
+            let pid: Pid = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
                 sem_set.get(semnum as usize, &sem_pid)
             })?;
 
             return Ok(SyscallReturn::Return(pid as isize));
         }
         IpcControlCmd::SEM_GETZCNT => {
-            let cnt: usize = check_and_ctl(semid, PermissionMode::READ, |sem_set| {
+            let cnt: usize = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
                 Ok(sem_set.pending_const_count(semnum as u16))
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::SEM_GETNCNT => {
-            let cnt: usize = check_and_ctl(semid, PermissionMode::READ, |sem_set| {
+            let cnt: usize = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
                 Ok(sem_set.pending_alter_count(semnum as u16))
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::IPC_STAT => {
-            check_and_ctl(semid, PermissionMode::READ, |sem_set| {
+            ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
                 let semid_ds = sem_set.semid_ds();
                 Ok(ctx.user_space().write_val(arg as Vaddr, &semid_ds)?)
             })?;
@@ -104,14 +103,4 @@ pub fn sys_semctl(
     }
 
     Ok(SyscallReturn::Return(0))
-}
-
-fn check_and_ctl<T, F>(semid: i32, permission: PermissionMode, ctl_func: F) -> Result<T>
-where
-    F: FnOnce(&SemaphoreSet) -> Result<T>,
-{
-    check_sem(semid, None, permission)?;
-    let sem_sets = sem_sets();
-    let sem_set = sem_sets.get(&semid).ok_or(Error::new(Errno::EINVAL))?;
-    ctl_func(sem_set)
 }

--- a/kernel/src/syscall/semget.rs
+++ b/kernel/src/syscall/semget.rs
@@ -2,68 +2,36 @@
 
 use super::SyscallReturn;
 use crate::{
-    ipc::{
-        IpcFlags,
-        semaphore::system_v::{
-            PermissionMode,
-            sem_set::{SEMMNI, SEMMSL, check_sem, create_sem_set, create_sem_set_with_id},
-        },
-    },
+    ipc::{IpcFlags, semaphore::system_v::sem_set::SEMMSL},
     prelude::*,
 };
 
-pub fn sys_semget(key: i32, nsems: i32, semflags: i32, ctx: &Context) -> Result<SyscallReturn> {
-    if nsems < 0 || nsems as usize > SEMMSL {
-        return_errno!(Errno::EINVAL);
+pub fn sys_semget(key: i32, num_sems: i32, semflags: i32, ctx: &Context) -> Result<SyscallReturn> {
+    if num_sems < 0 || num_sems as usize > SEMMSL {
+        return_errno_with_message!(Errno::EINVAL, "invalid num_sems value");
     }
     if key < 0 {
-        return_errno!(Errno::EINVAL);
+        return_errno_with_message!(Errno::EINVAL, "semaphore key must not be negative");
     }
 
     let flags = IpcFlags::from_bits_truncate(semflags as u32);
     let mode: u16 = (semflags as u32 & 0x1FF) as u16;
-    let nsems = nsems as usize;
+    let num_sems = num_sems as usize;
     let credentials = ctx.posix_thread.credentials();
 
     debug!(
-        "[sys_semget] key = {}, nsems = {}, flags = {:?}",
-        key, nsems, semflags
+        "[sys_semget] key = {}, num_sems = {}, flags = {:?}",
+        key, num_sems, semflags
     );
 
-    // Create a new semaphore set directly
-    const IPC_NEW: i32 = 0;
-    if key == IPC_NEW || (key as usize > SEMMNI && flags.contains(IpcFlags::IPC_CREAT)) {
-        if nsems == 0 {
-            return_errno!(Errno::EINVAL);
-        }
-        return Ok(SyscallReturn::Return(
-            create_sem_set(nsems, mode, credentials)? as isize,
-        ));
-    }
+    let ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let ipc_ns = ns_proxy.unwrap().ipc_ns();
 
-    // Get a semaphore set, and create if necessary
-    match check_sem(
+    Ok(SyscallReturn::Return(ipc_ns.get_or_create_sem_set(
         key,
-        Some(nsems),
-        PermissionMode::ALTER | PermissionMode::READ,
-    ) {
-        Ok(_) => {
-            if flags.contains(IpcFlags::IPC_CREAT | IpcFlags::IPC_EXCL) {
-                return_errno!(Errno::EEXIST);
-            }
-        }
-        Err(err) => {
-            let need_create = err.error() == Errno::ENOENT && flags.contains(IpcFlags::IPC_CREAT);
-            if !need_create {
-                return Err(err);
-            }
-            if nsems == 0 {
-                return_errno!(Errno::EINVAL);
-            }
-
-            create_sem_set_with_id(key, nsems, mode, credentials)?
-        }
-    };
-
-    Ok(SyscallReturn::Return(key as isize))
+        num_sems,
+        flags,
+        mode,
+        credentials,
+    )? as isize))
 }

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -53,10 +53,10 @@ fn do_sys_semtimedop(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     if sem_id <= 0 || nsops == 0 {
-        return_errno!(Errno::EINVAL);
+        return_errno_with_message!(Errno::EINVAL, "invalid sem_id or nsops");
     }
     if nsops > SEMOPM {
-        return_errno!(Errno::E2BIG);
+        return_errno_with_message!(Errno::E2BIG, "nsops exceeds SEMOPM");
     }
 
     let user_space = ctx.user_space();
@@ -65,7 +65,10 @@ fn do_sys_semtimedop(
         semops.push(user_space.read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?);
     }
 
-    sem_op(sem_id, semops, timeout, ctx)?;
+    let ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let ipc_ns = ns_proxy.unwrap().ipc_ns();
+
+    sem_op(sem_id, semops, timeout, ipc_ns, ctx)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -17,6 +17,7 @@ use crate::{
         pseudofs::{NsCommonOps, NsFile},
         vfs::path::MountNamespace,
     },
+    ipc::IpcNamespace,
     net::uts_ns::UtsNamespace,
     prelude::*,
     process::{
@@ -88,6 +89,11 @@ fn build_proxy_from_pid_file(
         set_cgroup_ns(&mut builder, target_ns, ctx)?;
     }
 
+    if flags.contains(CloneFlags::CLONE_NEWIPC) {
+        let target_ns = target_proxy.ipc_ns();
+        set_ipc_ns(&mut builder, target_ns, ctx)?;
+    }
+
     if flags.contains(CloneFlags::CLONE_NEWNS) {
         let target_ns = target_proxy.mnt_ns();
         set_mnt_ns(&mut builder, target_ns, ctx)?;
@@ -127,6 +133,9 @@ fn build_proxy_from_ns_file(
     let applied = false
         || try_apply_ns_from_inode::<CgroupNamespace>(inode_handle, flags, |ns| {
             set_cgroup_ns(&mut builder, &ns, ctx)
+        })?
+        || try_apply_ns_from_inode::<IpcNamespace>(inode_handle, flags, |ns| {
+            set_ipc_ns(&mut builder, &ns, ctx)
         })?
         || try_apply_ns_from_inode::<MountNamespace>(inode_handle, flags, |ns| {
             set_mnt_ns(&mut builder, &ns, ctx)
@@ -171,6 +180,18 @@ fn set_cgroup_ns(
     check_set_ns_perms(target_ns, ctx)?;
 
     builder.cgroup_ns(target_ns.clone());
+
+    Ok(())
+}
+
+fn set_ipc_ns(
+    builder: &mut NsProxyBuilder,
+    target_ns: &Arc<IpcNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    check_set_ns_perms(target_ns, ctx)?;
+
+    builder.ipc_ns(target_ns.clone());
 
     Ok(())
 }

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -39,6 +39,10 @@ fn apply_implied_flags(flags: &mut CloneFlags) {
         *flags |= CloneFlags::CLONE_THREAD | CloneFlags::CLONE_FS;
     }
 
+    if flags.contains(CloneFlags::CLONE_NEWIPC) {
+        *flags |= CloneFlags::CLONE_SYSVSEM;
+    }
+
     if flags.contains(CloneFlags::CLONE_SIGHAND) {
         *flags |= CloneFlags::CLONE_THREAD;
     }

--- a/test/initramfs/src/regression/security/namespace/ipc_ns_sem.c
+++ b/test/initramfs/src/regression/security/namespace/ipc_ns_sem.c
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define STACK_SIZE (1024 * 1024)
+
+// A unique key for semaphore creation.
+#define SEM_KEY_BASE 0x1234
+
+union semun {
+	int val;
+	struct semid_ds *buf;
+	unsigned short *array;
+};
+
+// --- Helper functions ---
+
+// Creates a semaphore set with 1 semaphore and returns its ID.
+// Returns -1 on failure.
+static int create_sem(int key)
+{
+	return semget(key, 1, IPC_CREAT | IPC_EXCL | 0666);
+}
+
+// Tries to get an existing semaphore set by key.
+// Returns the semaphore ID, or -1 if not found.
+static int get_sem(int key)
+{
+	return semget(key, 1, 0666);
+}
+
+// Removes a semaphore set by ID.
+static int remove_sem(int semid)
+{
+	union semun arg;
+	return semctl(semid, 0, IPC_RMID, arg);
+}
+
+// Sets the value of a semaphore.
+static int set_sem_val(int semid, int val)
+{
+	union semun arg;
+	arg.val = val;
+	return semctl(semid, 0, SETVAL, arg);
+}
+
+// Gets the value of a semaphore.
+static int get_sem_val(int semid)
+{
+	return semctl(semid, 0, GETVAL);
+}
+
+// --- Test: Semaphore sharing within the same IPC namespace ---
+//
+// A parent creates a semaphore, then forks a child (without CLONE_NEWIPC).
+// The child should be able to see and modify the same semaphore.
+
+FN_TEST(sem_shared_in_same_ipc_ns)
+{
+	int key = SEM_KEY_BASE + 1;
+	int semid = TEST_SUCC(create_sem(key));
+	TEST_SUCC(set_sem_val(semid, 10));
+
+	pid_t pid = TEST_SUCC(fork());
+
+	if (pid == 0) {
+		// Child: should see the same semaphore
+		int child_semid = CHECK(get_sem(key));
+		CHECK_WITH(semctl(child_semid, 0, GETVAL), _ret == 10);
+
+		// Modify the value
+		union semun arg;
+		arg.val = 20;
+		CHECK(semctl(child_semid, 0, SETVAL, arg));
+		_exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	// Parent: verify the child's modification is visible
+	TEST_RES(get_sem_val(semid), _ret == 20);
+
+	TEST_SUCC(remove_sem(semid));
+}
+END_TEST()
+
+// --- Test: Semaphore isolation via unshare(CLONE_NEWIPC) ---
+//
+// A parent creates a semaphore, then the child calls unshare(CLONE_NEWIPC).
+// After unshare, the child should NOT see the parent's semaphore,
+// and a semaphore created by the child should NOT be visible to the parent.
+
+FN_TEST(sem_isolation_via_unshare)
+{
+	int parent_key = SEM_KEY_BASE + 2;
+	int child_key = SEM_KEY_BASE + 3;
+
+	int parent_semid = TEST_SUCC(create_sem(parent_key));
+	TEST_SUCC(set_sem_val(parent_semid, 42));
+
+	pid_t pid = TEST_SUCC(fork());
+
+	if (pid == 0) {
+		// Child: unshare IPC namespace
+		CHECK(unshare(CLONE_NEWIPC));
+
+		// The parent's semaphore should NOT be visible
+		CHECK_WITH(get_sem(parent_key), _ret < 0 && errno == ENOENT);
+
+		// Create a new semaphore in the child's IPC namespace
+		int child_semid = CHECK(create_sem(child_key));
+
+		union semun arg;
+		arg.val = 99;
+		CHECK((semctl(child_semid, 0, SETVAL, arg)));
+
+		// Clean up child's semaphore
+		CHECK(semctl(child_semid, 0, IPC_RMID, arg));
+		_exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	// Parent: the child's semaphore should NOT be visible
+	TEST_ERRNO(get_sem(child_key), ENOENT);
+
+	// Parent: own semaphore should still be accessible
+	TEST_RES(get_sem_val(parent_semid), _ret == 42);
+
+	TEST_SUCC(remove_sem(parent_semid));
+}
+END_TEST()
+
+// --- Test: Semaphore isolation via clone(CLONE_NEWIPC) ---
+//
+// Clone a child into a new IPC namespace. The child should start with
+// an empty set of IPC resources and should not see the parent's semaphore.
+
+static int clone_newipc_child_fn(void *arg)
+{
+	int parent_key = *(int *)arg;
+
+	// The parent's semaphore should NOT be visible
+	CHECK_WITH(get_sem(parent_key), _ret < 0 && errno == ENOENT);
+
+	// Create a new semaphore in the child's own namespace
+	int child_key = SEM_KEY_BASE + 5;
+	int child_semid = CHECK(create_sem(child_key));
+
+	union semun sarg;
+	sarg.val = 77;
+	CHECK(semctl(child_semid, 0, SETVAL, sarg));
+
+	// Clean up
+	CHECK(semctl(child_semid, 0, IPC_RMID, sarg));
+	return 0;
+}
+
+FN_TEST(sem_isolation_via_clone)
+{
+	int parent_key = SEM_KEY_BASE + 4;
+	int parent_semid = TEST_SUCC(create_sem(parent_key));
+	TEST_SUCC(set_sem_val(parent_semid, 55));
+
+	char *stack = malloc(STACK_SIZE);
+	char *stack_top = stack + STACK_SIZE;
+
+	pid_t pid = TEST_SUCC(clone(clone_newipc_child_fn, stack_top,
+				    CLONE_NEWIPC | SIGCHLD, &parent_key));
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	// Parent: own semaphore should still be intact
+	TEST_RES(get_sem_val(parent_semid), _ret == 55);
+
+	// Parent: the child's semaphore (key SEM_KEY_BASE + 5) should NOT be visible
+	int child_key = SEM_KEY_BASE + 5;
+	TEST_ERRNO(get_sem(child_key), ENOENT);
+
+	free(stack);
+	TEST_SUCC(remove_sem(parent_semid));
+}
+END_TEST()
+
+// --- Test: Independent semaphore keys across IPC namespaces ---
+//
+// Two children in separate IPC namespaces should be able to create semaphores
+// with the same key without conflict.
+
+static int clone_independent_child_fn(void *arg)
+{
+	int key = *(int *)arg;
+
+	int semid = CHECK(create_sem(key));
+
+	union semun sarg;
+	sarg.val = 123;
+	CHECK(semctl(semid, 0, SETVAL, sarg));
+
+	// Clean up
+	CHECK(semctl(semid, 0, IPC_RMID, sarg));
+	return 0;
+}
+
+FN_TEST(sem_same_key_across_namespaces)
+{
+	int shared_key = SEM_KEY_BASE + 6;
+
+	char *stack1 = malloc(STACK_SIZE);
+	char *stack1_top = stack1 + STACK_SIZE;
+	char *stack2 = malloc(STACK_SIZE);
+	char *stack2_top = stack2 + STACK_SIZE;
+
+	// Clone two children, each in a new IPC namespace
+	pid_t pid1 = TEST_SUCC(clone(clone_independent_child_fn, stack1_top,
+				     CLONE_NEWIPC | SIGCHLD, &shared_key));
+
+	pid_t pid2 = TEST_SUCC(clone(clone_independent_child_fn, stack2_top,
+				     CLONE_NEWIPC | SIGCHLD, &shared_key));
+
+	int status;
+	TEST_RES(waitpid(pid1, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	TEST_RES(waitpid(pid2, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	free(stack1);
+	free(stack2);
+}
+END_TEST()
+
+// --- Test: Semaphore operations (semop) work correctly in a new IPC namespace ---
+//
+// Clone a child into a new IPC namespace. The child creates a semaphore, performs
+// semop (V then P operations), and verifies values.
+
+static int clone_semop_child_fn(void *arg)
+{
+	(void)arg;
+
+	int key = SEM_KEY_BASE + 7;
+	int semid = CHECK(create_sem(key));
+
+	// Initialize semaphore value to 0
+	union semun sarg;
+	sarg.val = 0;
+	CHECK(semctl(semid, 0, SETVAL, sarg));
+
+	// Perform V operation (increment by 3)
+	struct sembuf sop;
+	sop.sem_num = 0;
+	sop.sem_op = 3;
+	sop.sem_flg = 0;
+	CHECK(semop(semid, &sop, 1));
+
+	// Verify value is 3
+	CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 3);
+
+	// Perform P operation (decrement by 1)
+	sop.sem_op = -1;
+	CHECK(semop(semid, &sop, 1));
+
+	// Verify value is 2
+	CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 2);
+
+	// Clean up
+	CHECK(semctl(semid, 0, IPC_RMID, sarg));
+	return 0;
+}
+
+FN_TEST(sem_operations_in_new_ipc_ns)
+{
+	char *stack = malloc(STACK_SIZE);
+	char *stack_top = stack + STACK_SIZE;
+
+	pid_t pid = TEST_SUCC(clone(clone_semop_child_fn, stack_top,
+				    CLONE_NEWIPC | SIGCHLD, NULL));
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	free(stack);
+}
+END_TEST()
+
+// --- Test: Parent IPC namespace is unaffected by child namespace exit ---
+//
+// A child creates a semaphore in a new IPC namespace and exits without
+// explicitly removing it. This test verifies only that the parent's IPC
+// namespace remains unaffected after the child exits.
+
+FN_TEST(sem_parent_namespace_unaffected_on_child_ns_exit)
+{
+	int parent_key = SEM_KEY_BASE + 8;
+	int parent_semid = TEST_SUCC(create_sem(parent_key));
+	TEST_SUCC(set_sem_val(parent_semid, 100));
+
+	pid_t pid = TEST_SUCC(fork());
+
+	if (pid == 0) {
+		CHECK(unshare(CLONE_NEWIPC));
+
+		// Create a semaphore in the new namespace and intentionally
+		// do not remove it before exit.
+		int child_key = SEM_KEY_BASE + 9;
+		int child_semid = CHECK(create_sem(child_key));
+
+		union semun arg;
+		arg.val = 50;
+		CHECK(semctl(child_semid, 0, SETVAL, arg));
+
+		// Exit without cleaning up
+		_exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	// Parent's semaphore should still be intact
+	TEST_RES(get_sem_val(parent_semid), _ret == 100);
+
+	TEST_SUCC(remove_sem(parent_semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -40,11 +40,7 @@
 static const char *ns_files[] = { "cgroup", "ipc", "mnt", "user", "uts" };
 static const char *ns_names[] = { "cgroup", "ipc", "mnt", "user", "uts" };
 static const int clone_flags[] = {
-	CLONE_NEWCGROUP,
-	CLONE_NEWIPC,
-	CLONE_NEWNS,
-	CLONE_NEWUSER,
-	CLONE_NEWUTS,
+	CLONE_NEWCGROUP, CLONE_NEWIPC, CLONE_NEWNS, CLONE_NEWUSER, CLONE_NEWUTS,
 };
 static const size_t ns_count = sizeof(ns_files) / sizeof(ns_files[0]);
 

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -37,10 +37,11 @@
  *     but noted here for future reference).
  * `clone_flags` lists the corresponding CLONE_NEW* flag for each entry.
  */
-static const char *ns_files[] = { "cgroup", "mnt", "user", "uts" };
-static const char *ns_names[] = { "cgroup", "mnt", "user", "uts" };
+static const char *ns_files[] = { "cgroup", "ipc", "mnt", "user", "uts" };
+static const char *ns_names[] = { "cgroup", "ipc", "mnt", "user", "uts" };
 static const int clone_flags[] = {
 	CLONE_NEWCGROUP,
+	CLONE_NEWIPC,
 	CLONE_NEWNS,
 	CLONE_NEWUSER,
 	CLONE_NEWUTS,

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -9,6 +9,7 @@ set -e
 ./capability/execve
 
 ./namespace/cgroup_ns
+./namespace/ipc_ns_sem
 ./namespace/mnt_ns
 ./namespace/proc_nsfs
 ./namespace/setns


### PR DESCRIPTION
Based on #2966.

This PR adds basic support for IPC namespaces. An IPC namespace is used to isolate certain IPC resources, including semaphores, message queues (`/dev/mqueue`), and shared memory segments. Since only semaphores are currently supported in our implementation, the scope of this PR is limited to semaphore isolation accordingly.

Required by #2911.