### PR TITLE
Fix i8042 ACPI presence check

### DIFF
--- a/kernel/comps/i8042/src/controller.rs
+++ b/kernel/comps/i8042/src/controller.rs
@@ -170,7 +170,7 @@ impl I8042Controller {
             .get()
             .unwrap()
             .boot_flags
-            .is_some_and(|flags| !flags.motherboard_implements_8042())
+            .is_some_and(|flags| flags.motherboard_implements_8042())
     }
 
     /// Checks if the kernel command line contains the "i8042.exist" option.


### PR DESCRIPTION
`is_present_acpi()` inverted the FADT flag. drop the `!` so the function returns true when the 8042 bit is set.