### PR TITLE
Harden Codex review workflow

### DIFF
--- a/.github/workflows/review_pr_with_codex.yml
+++ b/.github/workflows/review_pr_with_codex.yml
@@ -33,6 +33,19 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      # The job-level `contains()` is a substring match. This step does a
+      # stricter check: "@boterinas codex" must appear at the start of a line
+      # so that blockquotes, inline code, or mid-sentence mentions are ignored.
+      - name: Validate trigger command
+        if: github.event_name == 'issue_comment'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if ! printf '%s\n' "$COMMENT_BODY" | grep -qE '^\s*@boterinas\s+codex($|\s)'; then
+            echo "::notice::No valid @boterinas codex command found at start of line."
+            exit 1
+          fi
+
       - name: React to trigger comment
         if: github.event_name == 'issue_comment'
         env:


### PR DESCRIPTION
## Summary

- **Remove `pull_request` auto-trigger.** Codex reviews are now triggered only via `@boterinas codex` comments or `workflow_dispatch`. This prevents untrusted fork code from running with secrets and stops API-credit abuse from arbitrary PR opens.
- **Always restore `.github/codex-output-schema.json` from the base branch.** Fixes the `No such file or directory` failure for PRs predating the schema file, and prevents fork PRs from supplying a crafted schema.
- **Allow `CONTRIBUTOR` to trigger Codex review.** Users who have previously had PRs merged can now invoke `@boterinas codex`.
- **Validate command at start of line.** The job-level `contains()` is a substring match, so blockquotes or mid-sentence mentions could false-trigger. A POSIX-compatible `grep -E` step now requires the command at the start of a line before proceeding.

**Failed run:** https://github.com/asterinas/asterinas/actions/runs/22567342467/job/65366328047

## Why this wasn't caught before merging

The test PR used to validate the Codex workflow was the Codex CI PR itself — which already contained `.github/codex-output-schema.json` in its head branch. So the checkout naturally included the file and the workflow succeeded. The bug only surfaces when reviewing a PR whose branch predates the addition of the schema file.

## Test plan

- [x] Trigger `@boterinas codex` on a PR and verify the review completes successfully
- [x] Verify blockquoted `> @boterinas codex` does not trigger a review
- [x] Verify `workflow_dispatch` still works with a PR number

🤖 Generated with [Claude Code](https://claude.com/claude-code)