### PR TITLE
Refactor ANSI escape sequence processing

### DIFF
--- a/kernel/comps/framebuffer/src/ansi_escape.rs
+++ b/kernel/comps/framebuffer/src/ansi_escape.rs
@@ -6,7 +6,18 @@ use crate::Pixel;
 #[derive(Debug)]
 pub(super) struct EscapeFsm {
     state: WaitFor,
-    params: [u32; MAX_PARAMS],
+    params: [Option<u32>; MAX_PARAMS],
+}
+
+/// The mode for "Erase in Display" (ED) commands.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/drivers/tty/vt/vt.c#L1488>.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EraseInDisplay {
+    CursorToEnd,
+    CursorToBeginning,
+    EntireScreen,
+    EntireScreenAndScrollback,
 }
 
 /// A trait to execute operations from ANSI escape sequences.
@@ -18,15 +29,37 @@ pub(super) trait EscapeOp {
     fn set_fg_color(&mut self, val: Pixel);
     /// Sets the background color.
     fn set_bg_color(&mut self, val: Pixel);
+
+    /// Erases part or all of the display.
+    fn erase_in_display(&mut self, mode: EraseInDisplay);
 }
 
 const MAX_PARAMS: usize = 8;
+const MAX_OSC_LEN: u8 = 128;
 
+// FIXME: Currently we only support a few ANSI escape sequences, and we just swallow the
+// unsupported ones.
 #[derive(Clone, Copy, Debug)]
 enum WaitFor {
+    /// Waits for an ESC to start the ANSI escape sequence.
     Escape,
+    /// Waits for a bracket after the ESC.
+    ///
+    /// "ESC[" will start a Control Sequence Introducer (CSI) sequence and "ESC]" will start a
+    /// Operating System Command (OSC) sequence.
     Bracket,
-    Params(u8),
+    /// Waits for CSI parameters.
+    ///
+    /// This will be terminated by a byte in the range 0x40 through 0x7E.
+    Csi {
+        idx: u8,
+        is_private: bool,
+        in_intermediate: bool,
+    },
+    /// Waits for OSC payload.
+    ///
+    /// This will be terminated by a bell (BEL, 0x07) or a String Terminator (ST, "ESC\").
+    Osc { len: u8, is_last_esc: bool },
 }
 
 /// Foreground and background colors.
@@ -69,92 +102,250 @@ const COLORS: [Pixel; 16] = [
 ];
 
 impl EscapeFsm {
+    /// The ESC character.
+    const ESC: u8 = 0x1b;
+    /// The BEL character.
+    const BEL: u8 = 0x07;
+
     pub(super) fn new() -> Self {
         Self {
             state: WaitFor::Escape,
-            params: [0; MAX_PARAMS],
+            params: [None; MAX_PARAMS],
         }
     }
 
-    /// Tries to eat a character as part of the ANSI escape sequence.
+    /// Tries to eat a byte as part of the ANSI escape sequence.
     ///
-    /// This method returns a boolean value indicating whether the character is part of an ANSI
-    /// escape sequence. In other words, if the method returns true, then the character has been
-    /// eaten and should not be displayed in the console.
+    /// Returns `true` if the byte is consumed by the FSM and should not be rendered as text.
+    /// Returns `false` if the byte is not part of an escape sequence and should be rendered.
     pub(super) fn eat<T: EscapeOp>(&mut self, byte: u8, op: &mut T) -> bool {
-        let num_params = match (self.state, byte) {
-            // Handle '\033'.
-            (WaitFor::Escape, 0o33) => {
-                self.state = WaitFor::Bracket;
-                return true;
-            }
-            (WaitFor::Escape, _) => {
-                // This is not an ANSI escape sequence.
-                return false;
+        match self.state {
+            WaitFor::Escape => {
+                if byte == Self::ESC {
+                    self.state = WaitFor::Bracket;
+                    return true;
+                }
+                false
             }
 
-            // Handle '['.
-            (WaitFor::Bracket, b'[') => {
-                self.state = WaitFor::Params(0);
-                self.params[0] = 0;
-                return true;
-            }
-            (WaitFor::Bracket, _) => {
-                // The character is invalid. We cannot handle it, so we are aborting the ANSI
-                // escape sequence.
-                self.state = WaitFor::Escape;
-                return true;
+            WaitFor::Bracket => {
+                match byte {
+                    // CSI begins.
+                    b'[' => {
+                        self.params.fill(None);
+                        self.state = WaitFor::Csi {
+                            idx: 0,
+                            is_private: false,
+                            in_intermediate: false,
+                        };
+                    }
+
+                    // OSC begins.
+                    b']' => {
+                        self.state = WaitFor::Osc {
+                            len: 0,
+                            is_last_esc: false,
+                        }
+                    }
+
+                    // The character is invalid. We cannot handle it, so we are aborting the ANSI
+                    // escape sequence.
+                    _ => self.state = WaitFor::Escape,
+                }
+
+                true
             }
 
-            // Handle numeric parameters.
-            (WaitFor::Params(i), b'0'..=b'9') => {
-                let param = &mut self.params[i as usize];
-                *param = param.wrapping_mul(10).wrapping_add((byte - b'0') as u32);
-                return true;
-            }
-            (WaitFor::Params(i), b';') if (i as usize + 1) < MAX_PARAMS => {
-                self.state = WaitFor::Params(i + 1);
-                self.params[i as usize + 1] = 0;
-                return true;
-            }
-            (WaitFor::Params(_), b';') => {
-                // There are too many parameters. We cannot handle that many, so we are aborting
-                // the ANSI escape sequence.
-                self.state = WaitFor::Escape;
-                return true;
+            WaitFor::Csi {
+                idx,
+                is_private,
+                in_intermediate,
+            } => {
+                self.parse_csi(byte, idx, is_private, in_intermediate, op);
+                true
             }
 
-            // Break and handle the final action.
-            (WaitFor::Params(i), _) => {
-                self.state = WaitFor::Escape;
-                (i + 1) as usize
-            }
-        };
+            WaitFor::Osc { len, is_last_esc } => {
+                match byte {
+                    // Terminate the OSC sequence by a BEL or a ST.
+                    Self::BEL => self.state = WaitFor::Escape,
+                    b'\\' if is_last_esc => self.state = WaitFor::Escape,
 
+                    // Swallow the OSC payload.
+                    _ => {
+                        if len > MAX_OSC_LEN {
+                            self.state = WaitFor::Escape;
+                            return false;
+                        }
+                        self.state = WaitFor::Osc {
+                            len: len + 1,
+                            is_last_esc: byte == Self::ESC,
+                        }
+                    }
+                }
+
+                true
+            }
+        }
+    }
+
+    /// Parses CSI arguments.
+    fn parse_csi<T: EscapeOp>(
+        &mut self,
+        byte: u8,
+        idx: u8,
+        is_private: bool,
+        in_intermediate: bool,
+        op: &mut T,
+    ) {
         match byte {
-            // CUP - Cursor Position
-            b'H' if num_params == 2 => {
+            // Intermediate bytes (0x20..=0x2F).
+            // We transition to the intermediate section once we see any intermediate byte;
+            // later bytes must be either intermediate or final.
+            0x20..=0x2f => {
+                self.state = WaitFor::Csi {
+                    idx,
+                    is_private,
+                    in_intermediate: true,
+                };
+            }
+
+            // Parameter bytes (0x30..=0x3F).
+            0x30..=0x3f if !in_intermediate => {
+                match byte {
+                    // Digits contribute to numeric parameters.
+                    b'0'..=b'9' => {
+                        let i = idx as usize;
+                        if i < MAX_PARAMS {
+                            let p = &mut self.params[i];
+                            *p = Some(
+                                p.unwrap_or(0)
+                                    .saturating_mul(10)
+                                    .saturating_add((byte - b'0') as u32),
+                            );
+                        }
+                        self.state = WaitFor::Csi {
+                            idx,
+                            is_private,
+                            in_intermediate: false,
+                        };
+                    }
+
+                    // ';' separates numeric parameters.
+                    b';' => {
+                        let next = idx + 1;
+                        if (next as usize) < MAX_PARAMS {
+                            // If there are no digits for this parameter, it will remain `None`.
+                            self.state = WaitFor::Csi {
+                                idx: next,
+                                is_private,
+                                in_intermediate: false,
+                            };
+                        } else {
+                            // There are too many parameters. We cannot handle that many, so
+                            // we are aborting the ANSI escape sequence.
+                            self.state = WaitFor::Escape;
+                        }
+                    }
+
+                    // The behavior of ':' is not defined by the standard. We don't support it,
+                    // so we are aborting the ANSI escape sequence.
+                    b':' => self.state = WaitFor::Escape,
+
+                    // Sequences containing "<=>?" are private. We swallow them and mark
+                    // `is_private`.
+                    b'<' | b'=' | b'>' | b'?' => {
+                        self.state = WaitFor::Csi {
+                            idx,
+                            is_private: true,
+                            in_intermediate: false,
+                        };
+                    }
+
+                    _ => unreachable!(),
+                }
+            }
+
+            // Parameter bytes in the intermediate section are illegal by the formal grammar.
+            // We'll abort and swallow to avoid leaking garbage.
+            0x30..=0x3f if in_intermediate => {
+                self.state = WaitFor::Escape;
+            }
+
+            // Final byte (0x40..=0x7E): ends the CSI.
+            0x40..=0x7e => {
+                self.state = WaitFor::Escape;
+
+                let num_params = idx as usize + 1;
+                self.handle_csi(byte, num_params, is_private, op);
+            }
+
+            // Terminal behavior is undefined if a CSI contains bytes outside 0x20..=0x7E.
+            // We'll abort and swallow to avoid leaking garbage.
+            _ => {
+                self.state = WaitFor::Escape;
+            }
+        }
+    }
+
+    /// Handles the "Control Sequence Introducer" sequence.
+    fn handle_csi<T: EscapeOp>(
+        &self,
+        final_byte: u8,
+        num_params: usize,
+        is_private: bool,
+        op: &mut T,
+    ) {
+        if is_private {
+            // For now we don't handle any private sequences, so just swallow them.
+            return;
+        }
+
+        match final_byte {
+            // CUP - Cursor Position: CSI n ; m H
+            b'H' => {
+                // `n` and `m` are 1-based row and column numbers, respectively.
+                // They default to 1 if the parameter is missing.
+                let row_1b = self.param_or(0, 1);
+                let col_1b = self.param_or(1, 1);
+
                 op.set_cursor(
-                    self.params[1].saturating_sub(1) as usize,
-                    self.params[0].saturating_sub(1) as usize,
+                    col_1b.saturating_sub(1) as usize,
+                    row_1b.saturating_sub(1) as usize,
                 );
             }
 
-            // SGR - Select Graphic Rendition
-            b'm' => self.handle_srg(num_params, op),
+            // ED - Erase in Display: CSI n J
+            b'J' => {
+                // The default mode is `CursorToEnd` if the parameter is missing.
+                let n = self.param_or(0, 0);
+                let mode = match n {
+                    0 => EraseInDisplay::CursorToEnd,
+                    1 => EraseInDisplay::CursorToBeginning,
+                    2 => EraseInDisplay::EntireScreen,
+                    3 => EraseInDisplay::EntireScreenAndScrollback,
+                    _ => {
+                        // Invalid parameter.
+                        return;
+                    }
+                };
 
-            // Invalid or unsupported
+                op.erase_in_display(mode);
+            }
+
+            // SGR - Select Graphic Rendition
+            b'm' => self.handle_sgr(num_params, op),
+
+            // Unknown CSI: swallow silently.
             _ => {}
         }
-
-        true
     }
 
     /// Handles the "Select Graphic Rendition" sequence.
-    fn handle_srg<T: EscapeOp>(&self, num_params: usize, op: &mut T) {
+    fn handle_sgr<T: EscapeOp>(&self, num_params: usize, op: &mut T) {
         let mut cursor = 0;
         while cursor < num_params {
-            let op_code = self.params[cursor];
+            let op_code = self.param_or(cursor, 0) as u8;
             cursor += 1;
 
             match op_code {
@@ -167,15 +358,15 @@ impl EscapeFsm {
                 // Set foreground colors
                 // Reference: <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
                 30..=37 => op.set_fg_color(COLORS[op_code as usize - 30]),
-                38 if num_params - cursor >= 2 && self.params[cursor] == 5 => {
-                    op.set_fg_color(Self::get_256_color(self.params[cursor + 1] as u8));
+                38 if num_params - cursor >= 2 && self.param_or(cursor, 0) == 5 => {
+                    op.set_fg_color(Self::get_256_color(self.param_or(cursor + 1, 0) as u8));
                     cursor += 2;
                 }
-                38 if num_params - cursor >= 4 && self.params[cursor] == 2 => {
+                38 if num_params - cursor >= 4 && self.param_or(cursor, 0) == 2 => {
                     op.set_fg_color(Pixel {
-                        red: self.params[cursor + 1] as u8,
-                        green: self.params[cursor + 2] as u8,
-                        blue: self.params[cursor + 3] as u8,
+                        red: self.param_or(cursor + 1, 0) as u8,
+                        green: self.param_or(cursor + 2, 0) as u8,
+                        blue: self.param_or(cursor + 3, 0) as u8,
                     });
                     cursor += 4;
                 }
@@ -186,15 +377,15 @@ impl EscapeFsm {
                 // Set background colors
                 // Reference: <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>
                 40..=47 => op.set_bg_color(COLORS[op_code as usize - 40]),
-                48 if num_params - cursor >= 2 && self.params[cursor] == 5 => {
-                    op.set_bg_color(Self::get_256_color(self.params[cursor + 1] as u8));
+                48 if num_params - cursor >= 2 && self.param_or(cursor, 0) == 5 => {
+                    op.set_bg_color(Self::get_256_color(self.param_or(cursor + 1, 0) as u8));
                     cursor += 2;
                 }
-                48 if num_params - cursor >= 4 && self.params[cursor] == 2 => {
+                48 if num_params - cursor >= 4 && self.param_or(cursor, 0) == 2 => {
                     op.set_bg_color(Pixel {
-                        red: self.params[cursor + 1] as u8,
-                        green: self.params[cursor + 2] as u8,
-                        blue: self.params[cursor + 3] as u8,
+                        red: self.param_or(cursor + 1, 0) as u8,
+                        green: self.param_or(cursor + 2, 0) as u8,
+                        blue: self.param_or(cursor + 3, 0) as u8,
                     });
                     cursor += 4;
                 }
@@ -247,6 +438,11 @@ impl EscapeFsm {
 
         Pixel { red, green, blue }
     }
+
+    /// Gets the parameter at the given index, or returns the default value if it is absent.
+    fn param_or(&self, i: usize, default: u32) -> u32 {
+        self.params.get(i).and_then(|p| *p).unwrap_or(default)
+    }
 }
 
 #[cfg(ktest)]
@@ -260,6 +456,7 @@ mod test {
         y: usize,
         fg: Pixel,
         bg: Pixel,
+        last_ed: Option<EraseInDisplay>,
     }
 
     impl Default for State {
@@ -269,6 +466,7 @@ mod test {
                 y: 0,
                 fg: Pixel::WHITE,
                 bg: Pixel::BLACK,
+                last_ed: None,
             }
         }
     }
@@ -285,6 +483,10 @@ mod test {
 
         fn set_bg_color(&mut self, val: Pixel) {
             self.bg = val;
+        }
+
+        fn erase_in_display(&mut self, mode: EraseInDisplay) {
+            self.last_ed = Some(mode);
         }
     }
 
@@ -311,6 +513,49 @@ mod test {
         eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[0;0H");
         assert_eq!(state.x, 0);
         assert_eq!(state.y, 0);
+
+        assert!(!esc_fsm.eat(b'a', &mut state));
+
+        // If parameters are missing, the cursor should move to the first row and column.
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[H");
+        assert_eq!(state.x, 0);
+        assert_eq!(state.y, 0);
+
+        assert!(!esc_fsm.eat(b'a', &mut state));
+    }
+
+    #[ktest]
+    fn erase_in_display() {
+        let mut esc_fsm = EscapeFsm::new();
+        let mut state = State::default();
+
+        // If parameters are missing, erase from the cursor to the end of the screen.
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[J");
+        assert_eq!(state.last_ed, Some(EraseInDisplay::CursorToEnd));
+        state.last_ed = None;
+
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[0J");
+        assert_eq!(state.last_ed, Some(EraseInDisplay::CursorToEnd));
+        state.last_ed = None;
+
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[1J");
+        assert_eq!(state.last_ed, Some(EraseInDisplay::CursorToBeginning));
+        state.last_ed = None;
+
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[2J");
+        assert_eq!(state.last_ed, Some(EraseInDisplay::EntireScreen));
+        state.last_ed = None;
+
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[3J");
+        assert_eq!(
+            state.last_ed,
+            Some(EraseInDisplay::EntireScreenAndScrollback)
+        );
+        state.last_ed = None;
+
+        // If the parameter is invalid, do nothing.
+        eat_escape_sequence(&mut esc_fsm, &mut state, b"\x1B[4J");
+        assert_eq!(state.last_ed, None);
 
         assert!(!esc_fsm.eat(b'a', &mut state));
     }

--- a/kernel/comps/framebuffer/src/console.rs
+++ b/kernel/comps/framebuffer/src/console.rs
@@ -15,7 +15,7 @@ use spin::Once;
 
 use crate::{
     FRAMEBUFFER, FrameBuffer, Pixel,
-    ansi_escape::{EscapeFsm, EscapeOp},
+    ansi_escape::{EraseInDisplay, EscapeFsm, EscapeOp},
 };
 
 /// A text console rendered onto the framebuffer.
@@ -293,6 +293,50 @@ impl ConsoleState {
             ConsoleMode::Graphics
         }
     }
+
+    /// Fills a rectangular pixel region `[x0, x1) × [y0, y1)` with the given color.
+    ///
+    /// The caller must pass arguments that form a valid rectangle within the framebuffer, i.e.,
+    /// `x0 ≤ x1 ≤ w` and `y0 ≤ y1 ≤ h`, where `w` and `h` are the framebuffer width and height.
+    fn fill_rect_pixels(&mut self, x0: usize, y0: usize, x1: usize, y1: usize, color: Pixel) {
+        debug_assert!(x1 <= self.backend.width());
+        debug_assert!(y1 <= self.backend.height());
+
+        let rendered_pixel = self.backend.render_pixel(color);
+        let rendered_pixel_size = rendered_pixel.nbytes();
+        let row_bytes = (x1 - x0) * rendered_pixel_size;
+
+        for y in y0..y1 {
+            let off = self.backend.calc_offset(x0, y).as_usize();
+            let buf = &mut self.bytes[off..off + row_bytes];
+
+            // Write pixels to the console buffer.
+            for chunk in buf.chunks_exact_mut(rendered_pixel_size) {
+                chunk.copy_from_slice(rendered_pixel.as_slice());
+            }
+
+            // Write pixels to the framebuffer.
+            if self.is_output_enabled {
+                self.backend.write_bytes_at(off, buf).unwrap();
+            }
+        }
+    }
+
+    /// Calculates the pixel coordinates for the cursor cell.
+    fn cursor_cell_rect(&self) -> (usize, usize, usize, usize) {
+        let cx0 = self.x_pos;
+        let cx1 = cx0 + self.font.width();
+        // `min` is necessary if we are at the end of the line.
+        let cx1 = cx1.min(self.backend.width());
+
+        let cy0 = self.y_pos;
+        let cy1 = cy0 + self.font.height();
+        // This will always hold because we will scroll if it is no longer true after a new line or
+        // font change.
+        debug_assert!(cy1 <= self.backend.height());
+
+        (cx0, cy0, cx1, cy1)
+    }
 }
 
 impl EscapeOp for ConsoleState {
@@ -312,5 +356,38 @@ impl EscapeOp for ConsoleState {
 
     fn set_bg_color(&mut self, val: Pixel) {
         self.bg_color = val;
+    }
+
+    fn erase_in_display(&mut self, mode: EraseInDisplay) {
+        let bg = self.bg_color;
+        let w = self.backend.width();
+        let h = self.backend.height();
+
+        let (cx0, cy0, cx1, cy1) = self.cursor_cell_rect();
+
+        match mode {
+            EraseInDisplay::CursorToEnd => {
+                // Clear from the cursor to the end of the line, within the cursor row.
+                self.fill_rect_pixels(cx0, cy0, w, cy1, bg);
+
+                // Clear all rows below the cursor row.
+                if cy1 < h {
+                    self.fill_rect_pixels(0, cy1, w, h, bg);
+                }
+            }
+            EraseInDisplay::CursorToBeginning => {
+                // Clear all rows above the cursor row.
+                if cy0 > 0 {
+                    self.fill_rect_pixels(0, 0, w, cy0, bg);
+                }
+
+                // Clear from the start of the line to the cursor, within the cursor row.
+                self.fill_rect_pixels(0, cy0, cx1, cy1, bg);
+            }
+            EraseInDisplay::EntireScreen | EraseInDisplay::EntireScreenAndScrollback => {
+                // Clear the entire screen.
+                self.fill_rect_pixels(0, 0, w, h, bg);
+            }
+        }
     }
 }


### PR DESCRIPTION
# Refactor ANSI escape sequence processing

Improved the handling of ANSI escape sequences, providing more comprehensive support for CSI sequences, while also silently handling OSC sequences.

With this PR, the screen output is now cleaner, and running the `clear` command in the command line to clear the screen is fully supported.

## Previous Behavior

- Run with `make run_nixos`, and then open the vnc.

  <img width="1058" height="712" alt="image" src="https://github.com/user-attachments/assets/e6052895-e3d9-4d0e-ae27-58a277efe56f" />

- Run with `make BOOT_PROTOCOL=linux-efi-handover64 run_kernel`, and then execute the command `setsid sh -c 'exec sh -i < /dev/tty1 > /dev/tty1 2>&1'`. Open the vnc viewer and execute the `clear` command.

  <img width="906" height="620" alt="image" src="https://github.com/user-attachments/assets/e6d5c610-9703-482a-a5de-8a691ab165c7" />

---

**References**:

- [CSI](https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands)

- [OSC](https://en.wikipedia.org/wiki/ANSI_escape_code#Operating_System_Command_sequences)
