### PR TITLE
Fetch Codex output schema via API instead of git checkout

### DIFF
--- a/.github/workflows/review_pr_with_codex.yml
+++ b/.github/workflows/review_pr_with_codex.yml
@@ -95,13 +95,18 @@ jobs:
           git remote add base-repo "https://github.com/${{ github.repository }}.git"
           git fetch base-repo "${{ steps.pr_info.outputs.base_ref }}"
 
-      # Always use the base branch's schema so fork PRs cannot supply a
-      # crafted version, and so PRs predating the file still work.
-      - name: Restore Codex output schema from base
+      # Always fetch the schema from the upstream at the workflow commit so
+      # it matches the workflow version. The PR checkout won't have it if the
+      # branch predates the file, and fork PRs should not supply their own.
+      - name: Fetch Codex output schema from upstream
         env:
-          BASE_SHA: ${{ steps.pr_info.outputs.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          git checkout "$BASE_SHA" -- .github/codex-output-schema.json
+          set -euo pipefail
+          mkdir -p .github
+          gh api "repos/${REPOSITORY}/contents/.github/codex-output-schema.json?ref=${{ github.sha }}" \
+            --jq '.content' | base64 -d > .github/codex-output-schema.json
 
       - name: Build prompt
         env:


### PR DESCRIPTION
## Summary

- Replace `git checkout "$BASE_SHA" -- .github/codex-output-schema.json` with a GitHub Contents API call that fetches the schema from the upstream default branch.
- This fixes the `pathspec did not match any file(s) known to git` failure when the PR's base SHA predates the addition of the schema file.

**Failed run:** https://github.com/asterinas/asterinas/actions/runs/22570005117/job/65375173393

## Why this wasn't caught before merging

The previous fix (PR #2997) used `git checkout "$BASE_SHA"` assuming the base SHA would always contain the schema file. This holds when the PR's base branch has been updated after the schema was added. However, PRs opened before the schema was introduced — and never rebased — have a base SHA that predates the file. The test PRs used to validate #2997 were all created after the schema file existed, so the `git checkout` always succeeded.

## Test plan

- [x] Trigger `@boterinas codex` on a PR whose base SHA predates `.github/codex-output-schema.json` and verify the review completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)