### PR TITLE
Adjust some comments in OSTD

### DIFF
--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -238,9 +238,12 @@ impl<D: DmaDirection> DmaStream<D> {
         };
         let range = va_range.start + byte_range.start..va_range.start + byte_range.end;
 
-        // SAFETY: We've checked that the range is inbound, so the virtual
-        // address range and the DMA direction correspond to a DMA region
-        // (they're part of `self`).
+        // SAFETY:
+        // 1. We've checked that the range is inbound, so the virtual address
+        //    range and the DMA direction correspond to a DMA region (they're
+        //    part of `self`).
+        // 2. `can_sync_dma()` is either checked above (for `Inner::Kva`) or
+        //    checked when constructing `self` (for `Inner::Segment`).
         unsafe { crate::arch::mm::sync_dma_range::<D>(range) };
 
         Ok(())

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -189,6 +189,7 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
         split_huge: bool,
     ) -> Option<Vaddr> {
         assert_eq!(len % C::BASE_PAGE_SIZE, 0);
+
         let end = self.va + len;
         assert!(end <= self.barrier_va.end);
         debug_assert_eq!(end % C::BASE_PAGE_SIZE, 0);
@@ -264,7 +265,6 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
             self.va = va;
             return Ok(());
         }
-
         debug_assert!(self.barrier_va.contains(&self.va));
 
         loop {
@@ -410,8 +410,12 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     ///  - the physical address to be mapped is valid and safe to use.
     pub unsafe fn map(&mut self, item: C::Item) {
         assert!(self.0.va < self.0.barrier_va.end);
+
         let (_, level, _) = C::item_raw_info(&item);
-        assert!(level <= C::HIGHEST_TRANSLATION_LEVEL);
+        assert!(
+            level <= C::HIGHEST_TRANSLATION_LEVEL,
+            "cursor level not suitable for mapping"
+        );
         let size = page_size::<C>(level);
         assert_eq!(
             self.0.va % size,
@@ -419,7 +423,10 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
             "cursor virtual address not aligned for mapping"
         );
         let end = self.0.va + size;
-        assert!(end <= self.0.barrier_va.end);
+        assert!(
+            end <= self.0.barrier_va.end,
+            "cursor virtual address out-of-bound for mapping"
+        );
 
         let rcu_guard = self.0.rcu_guard;
 

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -290,13 +290,13 @@ impl Cursor<'_> {
         self.0.find_next(len)
     }
 
-    /// Jump to the virtual address.
+    /// Jumps to the virtual address.
     pub fn jump(&mut self, va: Vaddr) -> Result<()> {
         self.0.jump(va)?;
         Ok(())
     }
 
-    /// Get the virtual address of the current slot.
+    /// Gets the virtual address of the current slot.
     pub fn virt_addr(&self) -> Vaddr {
         self.0.virt_addr()
     }
@@ -334,7 +334,7 @@ impl<'a> CursorMut<'a> {
         self.pt_cursor.find_next(len)
     }
 
-    /// Jump to the virtual address.
+    /// Jumps to the virtual address.
     ///
     /// This is the same as [`Cursor::jump`].
     pub fn jump(&mut self, va: Vaddr) -> Result<()> {
@@ -342,12 +342,12 @@ impl<'a> CursorMut<'a> {
         Ok(())
     }
 
-    /// Get the virtual address of the current slot.
+    /// Gets the virtual address of the current slot.
     pub fn virt_addr(&self) -> Vaddr {
         self.pt_cursor.virt_addr()
     }
 
-    /// Get the dedicated TLB flusher for this cursor.
+    /// Gets the dedicated TLB flusher for this cursor.
     pub fn flusher(&mut self) -> &mut TlbFlusher<'a, DisabledPreemptGuard> {
         &mut self.flusher
     }
@@ -449,6 +449,7 @@ impl<'a> CursorMut<'a> {
     /// splitting the operation into multiple small ones.
     ///
     /// # Panics
+    ///
     /// Panics if:
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -45,6 +45,7 @@ use crate::task::atomic_mode::AsAtomicModeGuard;
 /// while the lock is held.
 ///
 /// # Usage
+///
 /// The lock can be used in scenarios where data needs to be read frequently
 /// but written to occasionally.
 ///
@@ -110,6 +111,21 @@ const READER: usize = 1;
 const WRITER: usize = 1 << (usize::BITS - 1);
 const UPGRADEABLE_READER: usize = 1 << (usize::BITS - 2);
 const BEING_UPGRADED: usize = 1 << (usize::BITS - 3);
+
+/// This bit is reserved as an overflow sentinel.
+/// We intentionally cap read guards before counter growth can affect
+/// `BEING_UPGRADED` / `UPGRADEABLE_READER` / `WRITER` bits.
+/// This is defense-in-depth with no extra runtime cost.
+///
+/// This follows the same strategy as Rust std's `Arc`,
+/// which uses `isize::MAX` as a sentinel to prevent its reference count
+/// from overflowing into values that could compromise safety.
+///
+/// On 64-bit platforms (the only targets Asterinas supports),
+/// a counter overflow is not a practical concern:
+/// incrementing one-by-one from zero to `MAX_READER` (2^60)
+/// would take hundreds of years even at billions of increments per second.
+/// Nevertheless, this sentinel provides an extra layer of safety at no runtime cost.
 const MAX_READER: usize = 1 << (usize::BITS - 4);
 
 impl<T, G> RwLock<T, G> {

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -38,6 +38,7 @@ use super::WaitQueue;
 /// while the mutex is held.
 ///
 /// # Usage
+///
 /// The mutex can be used in scenarios where data needs to be read frequently
 /// but written to occasionally.
 ///
@@ -100,6 +101,10 @@ const READER: usize = 1;
 const WRITER: usize = 1 << (usize::BITS - 1);
 const UPGRADEABLE_READER: usize = 1 << (usize::BITS - 2);
 const BEING_UPGRADED: usize = 1 << (usize::BITS - 3);
+
+/// This bit is reserved as an overflow sentinel.
+/// For more details, see comments on the `MAX_READER` constant
+/// in the [`super::rwlock`] module.
 const MAX_READER: usize = 1 << (usize::BITS - 4);
 
 impl<T> RwMutex<T> {


### PR DESCRIPTION
 - The reason why the second safety precondition will be satisfied is not documented:
https://github.com/asterinas/asterinas/blob/917ed44d2a3ca0d443198a3cd58566f08baea888/ostd/src/arch/riscv/mm/mod.rs#L110-L116
https://github.com/asterinas/asterinas/blob/917ed44d2a3ca0d443198a3cd58566f08baea888/ostd/src/mm/dma/dma_stream.rs#L241-L244
 - Adjust doc comments in `ostd/src/mm/vm_space.rs` to conform [`rfc1574-summary`](https://asterinas.github.io/book/to-contribute/coding-guidelines/rust-guidelines/language-items/comments-and-documentation.html#rfc1574-summary).
 - Add some panic messages to `ostd/src/mm/page_table/cursor/mod.rs` for consistency purposes.
 - **EDIT:** I included the comment adjustment required by https://github.com/asterinas/asterinas/issues/2977#issuecomment-3986154921 in this PR. Closes #2977.