### PR TITLE
Add AGENTS.md to Docker version bump script

### DIFF
--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -118,8 +118,9 @@ update_docker_image_version() {
 update_all_docker_version_refs() {
     new_version=$(cat ${DOCKER_IMAGE_VERSION_PATH})
 
-    # Update Docker image versions in README files
+    # Update Docker image versions in README files and AGENTS.md
     update_image_versions ${ASTER_SRC_DIR}/README.md
+    update_image_versions ${ASTER_SRC_DIR}/AGENTS.md
     update_image_versions ${SCRIPT_DIR}/docker/README.md
 
     # Update Docker image versions in the Book


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to the list of files updated by `update_all_docker_version_refs` in `tools/bump_version.sh`
- `AGENTS.md` contains a Docker image version reference (`asterinas/asterinas:{version}`) that was not being updated when the Docker image version was bumped

## Test plan
- [x] Run `./tools/bump_version.sh --docker_version_refs` and verify `AGENTS.md` is updated along with the other files
