### PR TITLE
Support for TDX on-demand lazy accept memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
 name = "linux-bzimage-setup"
 version = "0.18.0"
 dependencies = [
+ "align_ext",
  "cfg-if",
  "linux-boot-params",
  "log",
@@ -1386,6 +1387,7 @@ dependencies = [
  "smallvec",
  "spin",
  "tdx-guest",
+ "uefi-raw 0.8.0",
  "unwinding",
  "volatile 0.6.1",
  "x86",
@@ -1849,14 +1851,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tdx-guest"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be70e62fdd829b19d5e1e03969f125391347e4e33d1419addfe59a45b043005d"
+version = "0.3.1"
+source = "git+https://github.com/Hsy-Intel/tdx-guest?rev=4008e6bb63869e02a98ab1d944b7270a76f06118#4008e6bb63869e02a98ab1d944b7270a76f06118"
 dependencies = [
  "bitflags 1.3.2",
  "iced-x86",
  "log",
  "raw-cpuid",
+ "uefi-raw 0.8.0",
  "x86_64",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.192", default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.13.2"
 uart_16550 = "0.3.0"
+tdx-guest = { git = "https://github.com/Hsy-Intel/tdx-guest", rev = "4008e6bb63869e02a98ab1d944b7270a76f06118" }
 volatile = "0.6.1"
 
 # External dependencies only for safe crates (i.e., crates under kernel or osdk/deps directories)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ BENCHMARK ?= none
 BOOT_METHOD ?= grub-rescue-iso
 BOOT_PROTOCOL ?= multiboot2
 ENABLE_KVM ?= 1
-INTEL_TDX ?= 0
 MEM ?= 8G
 OVMF ?= on
 RELEASE ?= 0
@@ -30,6 +29,14 @@ COVERAGE ?= 0
 # linux-efi-handover64 and linux-efi-pe64 boot protocol.
 CONSOLE ?= hvc0
 # End of global build options.
+
+# Confidential computing options.
+# Enable Intel TDX support.
+INTEL_TDX ?= 0
+# Memory acceptance mode for Intel TDX guests (supported: lazy, eager).
+# This option only takes effect when INTEL_TDX is set to 1.
+ACCEPT_MEMORY_MODE ?= lazy
+# End of confidential computing options.
 
 # GDB debugging and profiling options.
 GDB_TCP_PORT ?= 1234
@@ -150,8 +157,12 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/benchmark/common/bench_runner.sh $(BENCHM
 endif
 
 ifeq ($(INTEL_TDX), 1)
+	ifneq ($(filter $(ACCEPT_MEMORY_MODE),lazy eager),$(ACCEPT_MEMORY_MODE))
+	$(error ACCEPT_MEMORY_MODE must be one of: lazy, eager)
+	endif
 BOOT_PROTOCOL = linux-efi-handover64
 CARGO_OSDK_COMMON_ARGS += --scheme tdx
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="accept_memory=$(ACCEPT_MEMORY_MODE)"
 endif
 
 ifeq ($(BOOT_PROTOCOL), multiboot)

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/benchmark/common/bench_runner.sh $(BENCHM
 endif
 
 ifeq ($(INTEL_TDX), 1)
-	ifneq ($(filter $(ACCEPT_MEMORY_MODE),lazy eager),$(ACCEPT_MEMORY_MODE))
-	$(error ACCEPT_MEMORY_MODE must be one of: lazy, eager)
+	ifneq ($(filter $(ACCEPT_MEMORY_MODE),lazy eager lazy-background),$(ACCEPT_MEMORY_MODE))
+	$(error ACCEPT_MEMORY_MODE must be one of: lazy, eager, lazy-background)
 	endif
 BOOT_PROTOCOL = linux-efi-handover64
 CARGO_OSDK_COMMON_ARGS += --scheme tdx

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -71,7 +71,7 @@ zerocopy.workspace = true
 zune-inflate.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
-tdx-guest = { version = "0.2.4", optional = true }
+tdx-guest = { workspace = true, optional = true }
 x86_64.workspace = true
 
 [target.riscv64imac-unknown-none-elf.dependencies]

--- a/kernel/comps/cmdline/src/unimplemented.rs
+++ b/kernel/comps/cmdline/src/unimplemented.rs
@@ -54,3 +54,27 @@ define_unimplemented_param!(
     "noreplace_smp",
     "initcall_debug"
 );
+
+/// Defines kernel command-line parameters that are handled by OSTD during early boot.
+///
+/// OSTD parses these parameters before the kernel command-line framework initializes.
+/// Registration here prevents them from being forwarded to the init process.
+#[macro_export]
+macro_rules! define_ostd_handled_param {
+    ($($name:expr),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn __kparam_setup(_occurrences: &[Option<&str>]) {
+                    // Intentionally empty: OSTD handles this parameter during
+                    // early boot, before the kernel command-line framework runs.
+                }
+                $crate::submit! {
+                    $crate::KernelParam::new($name, __kparam_setup, false)
+                }
+            };
+        )+
+    };
+}
+
+// Parameters handled directly by OSTD during early boot.
+define_ostd_handled_param!("accept_memory");

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -31,7 +31,7 @@ typeflags-util.workspace = true
 zerocopy.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
-tdx-guest = { version = "0.2.4", optional = true }
+tdx-guest = { workspace = true, optional = true }
 
 [features]
 all = ["cvm_guest"]

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -38,7 +38,11 @@
 //! For the TDX architecture specification see Intel's
 //! [TDX Module Specification](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-trust-domain-extensions.html).
 
-use core::{mem::offset_of, time::Duration};
+use core::{
+    mem::offset_of,
+    sync::atomic::Ordering,
+    time::Duration,
+};
 
 use aster_util::{field_ptr, safe_ptr::SafePtr};
 use device_id::{DeviceId, MinorId};
@@ -261,7 +265,8 @@ pub fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
 
     // FIXME: The `get_quote` API from the `tdx_guest` crate should have been marked `unsafe`
     // because it has no way to determine if the input physical address is safe or not.
-    tdvmcall::get_quote((buf.paddr() as u64) | SHARED_MASK, buf.size() as u64)?;
+    let mask = SHARED_MASK.load(Ordering::Relaxed);
+    tdvmcall::get_quote(buf.paddr() as u64 | mask, buf.size() as u64)?;
 
     // Poll for the quote to be ready.
     let status_ptr = field_ptr!(&header_ptr, TdxQuoteHdr, status);

--- a/kernel/src/fs/fs_impls/procfs/meminfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/meminfo.rs
@@ -50,6 +50,13 @@ impl ProcFileOps for MemInfoFileOps {
         writeln!(printer, "MemFree:\t{} kB", available)?;
         writeln!(printer, "MemAvailable:\t{} kB", available)?;
 
+        #[cfg(feature = "cvm_guest")]
+        writeln!(
+            printer,
+            "Unaccepted:\t{} kB",
+            ostd::mm::frame::load_total_unaccepted_bytes() / 1024
+        )?;
+
         Ok(printer.bytes_written())
     }
 }

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -157,6 +157,16 @@ fn init_in_first_kthread(path_resolver: &PathResolver) {
     crate::fs::init_in_first_kthread(path_resolver);
     #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     crate::vdso::init_in_first_kthread();
+
+    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+    ostd::mm::frame::spawn_background_accept_worker(
+        |task_fn| {
+            ThreadOptions::new(task_fn).spawn();
+        },
+        |duration: core::time::Duration| {
+            crate::time::sleep_for(duration);
+        },
+    );
 }
 
 fn print_banner() {

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -179,3 +179,15 @@ pub struct timezone_t {
     pub tz_minuteswest: i32,
     pub tz_dsttime: i32,
 }
+
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+pub(super) fn sleep_for(duration: Duration) {
+    use crate::time::clocks::MonotonicClock;
+    let waiter = ostd::sync::Waiter::new_pair().0;
+    let timer_manager = MonotonicClock::timer_manager();
+    let timeout = wait::ManagedTimeout::new_with_manager(
+        timer::Timeout::After(duration),
+        timer_manager,
+    );
+    let _ = waiter.wait_until_or_timeout(|| None::<()>, timeout);
+}

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -57,8 +57,9 @@ iced-x86 = { version = "1.21.0", default-features = false, features = [
     "decoder",
     "gas",
 ], optional = true }
-tdx-guest = { version = "0.2.4", optional = true }
+tdx-guest = { workspace = true, optional = true }
 unwinding = { version = "=0.2.8", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+uefi-raw = "0.8.0"
 
 [target.riscv64imac-unknown-none-elf.dependencies]
 riscv = { version = "0.15.0", features = ["s-mode"] }

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+align_ext.workspace = true
 cfg-if.workspace = true
 linux-boot-params.workspace = true
 log.workspace = true
@@ -23,7 +24,7 @@ zune-inflate.workspace = true
 [target.x86_64-unknown-none.dependencies]
 uefi = { version = "0.37.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}
 uefi-raw = "0.14.0"
-tdx-guest = { version = "0.2.4", optional = true }
+tdx-guest = { workspace = true, optional = true }
 
 [target.x86_64-i386_pm-none.dependencies]
 uefi-raw = "0.14.0"

--- a/ostd/libs/linux-bzimage/setup/src/loader.rs
+++ b/ostd/libs/linux-bzimage/setup/src/loader.rs
@@ -2,6 +2,12 @@
 
 use xmas_elf::program::{ProgramHeader, SegmentData};
 
+#[cfg(all(feature = "cvm_guest", target_arch = "x86_64"))]
+extern crate alloc;
+
+#[cfg(all(feature = "cvm_guest", target_arch = "x86_64"))]
+use alloc::vec::Vec;
+
 /// Load the kernel ELF payload to memory.
 pub fn load_elf(file: &[u8]) {
     let elf = xmas_elf::ElfFile::new(file).unwrap();
@@ -17,6 +23,49 @@ pub fn load_elf(file: &[u8]) {
             load_segment(&elf, program);
         }
     }
+}
+
+/// Returns merged physical ranges of all PT_LOAD segments in the ELF file.
+///
+/// Each range is `[p_paddr, p_paddr + p_memsz)`, so `.bss` is included.
+#[cfg(all(feature = "cvm_guest", target_arch = "x86_64"))]
+pub(crate) fn elf_load_ranges(file: &[u8]) -> Vec<(u64, u64)> {
+    let elf = xmas_elf::ElfFile::new(file).unwrap();
+    let mut ranges = Vec::new();
+
+    for ph in elf.program_iter() {
+        if let ProgramHeader::Ph64(program) = ph {
+            if program.get_type().unwrap() == xmas_elf::program::Type::Load && program.mem_size > 0
+            {
+                let start = program.physical_addr;
+                let end = start
+                    .checked_add(program.mem_size)
+                    .expect("[setup] PT_LOAD physical range overflows.");
+                ranges.push((start, end));
+            }
+        } else {
+            panic!(
+                "[setup] Unexpected program header type! Asterinas should be 64-bit ELF binary."
+            );
+        }
+    }
+
+    ranges.sort_unstable_by_key(|(start, _)| *start);
+
+    let mut merged = Vec::new();
+    for (start, end) in ranges {
+        if let Some((_, last_end)) = merged.last_mut()
+            && start <= *last_end
+        {
+            if end > *last_end {
+                *last_end = end;
+            }
+            continue;
+        }
+        merged.push((start, end));
+    }
+
+    merged
 }
 
 fn load_segment(file: &xmas_elf::ElfFile, program: &xmas_elf::program::ProgramHeader64) {

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -1,14 +1,43 @@
 // SPDX-License-Identifier: MPL-2.0
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use core::{ffi::CStr, mem::MaybeUninit};
 
 use boot::{AllocateType, open_protocol_exclusive};
+use cfg_if::cfg_if;
 use linux_boot_params::BootParams;
 use uefi::{mem::memory_map::MemoryMap, prelude::*, proto::BootPolicy};
 use uefi_raw::table::system::SystemTable;
 
 use super::decoder::decode_payload;
 use crate::x86::amd64_efi::alloc::alloc_pages;
+
+cfg_if! {
+    if #[cfg(feature = "cvm_guest")] {
+        use align_ext::AlignExt;
+        use tdx_guest::{
+            is_tdx_guest_early,
+            unaccepted_memory::EfiUnacceptedMemory,
+        };
+        use super::unaccepted_memory::{
+            UnacceptedRange, accept_bitmap_range, allocate_unaccepted_bitmap, find_unaccepted_table,
+            install_unaccepted_bitmap,
+        };
+
+        /// Safety margin added to the kernel footprint to account for
+        /// any additional memory that may be accessed during early boot.
+        const KERNEL_FOOTPRINT_SAFETY_MARGIN: u64 = 2 * 1024 * 1024;
+
+        /// AP execution page range required for AP startup.
+        /// In the linker script, AP_EXEC_MA = 0x8000.
+        const AP_EXEC_RANGE: (u64, u64) = (0x8000, 0x9000);
+
+        /// Kernel load ranges that must be accepted before entering the kernel.
+        type PreAcceptedRanges = Vec<(u64, u64)>;
+    }
+}
 
 pub(super) const PAGE_SIZE: u64 = 4096;
 
@@ -37,11 +66,11 @@ unsafe extern "sysv64" fn main_efi_common64(
         unsafe { &mut *boot_params_ptr }
     };
 
-    efi_phase_boot(boot_params);
+    let early_boot_info = efi_phase_boot(boot_params);
 
     // SAFETY: All previously opened boot service protocols have been closed. At this time, we have
     // no references to the code and data of the boot services.
-    unsafe { efi_phase_runtime(boot_params) };
+    unsafe { efi_phase_runtime(boot_params, early_boot_info) };
 }
 
 fn allocate_boot_params() -> &'static mut BootParams {
@@ -57,7 +86,7 @@ fn allocate_boot_params() -> &'static mut BootParams {
     boot_params
 }
 
-fn efi_phase_boot(boot_params: &mut BootParams) {
+fn efi_phase_boot_common(boot_params: &mut BootParams) -> Vec<u8> {
     uefi::println!(
         "[EFI stub] Loaded with offset {:#x}",
         crate::x86::image_load_offset(),
@@ -95,11 +124,28 @@ fn efi_phase_boot(boot_params: &mut BootParams) {
         fill_screen_info(&mut boot_params.screen_info);
     }
 
+    // Fill the EFI info in boot params.
+    fill_efi_info(boot_params);
+
     // Decode the payload and load it as an ELF file.
     uefi::println!("[EFI stub] Decoding the kernel payload");
     let kernel = decode_payload(crate::x86::payload());
     uefi::println!("[EFI stub] Loading the payload as an ELF file");
     crate::loader::load_elf(&kernel);
+
+    kernel
+}
+
+#[cfg(feature = "cvm_guest")]
+fn efi_phase_boot(boot_params: &mut BootParams) -> PreAcceptedRanges {
+    let kernel = efi_phase_boot_common(boot_params);
+
+    compute_kernel_load_ranges(&kernel)
+}
+
+#[cfg(not(feature = "cvm_guest"))]
+fn efi_phase_boot(boot_params: &mut BootParams) {
+    let _kernel = efi_phase_boot_common(boot_params);
 }
 
 fn load_cmdline() -> Option<&'static CStr> {
@@ -110,14 +156,14 @@ fn load_cmdline() -> Option<&'static CStr> {
             .unwrap();
 
     let Some(load_options) = loaded_image.load_options_as_bytes() else {
-        uefi::println!("[EFI stub] Warning: No cmdline is available!");
+        uefi::println!("[EFI stub] warning: command line is unavailable");
         return None;
     };
 
     if !load_options.len().is_multiple_of(2)
         || load_options.iter().skip(1).step_by(2).any(|c| *c != 0)
     {
-        uefi::println!("[EFI stub] Warning: The cmdline contains non-ASCII characters!");
+        uefi::println!("[EFI stub] warning: command line contains non-ASCII characters");
         return None;
     }
 
@@ -171,12 +217,12 @@ fn load_initrd() -> Option<&'static [u8]> {
     };
 
     let Ok(handle) = boot::locate_device_path::<LoadFile2>(&mut device_path) else {
-        uefi::println!("[EFI stub] Warning: Failed to locate the initrd device!");
+        uefi::println!("[EFI stub] warning: failed to locate initrd device");
         return None;
     };
 
     let Ok(mut load_file2) = open_protocol_exclusive::<LoadFile2>(handle) else {
-        uefi::println!("[EFI stub] Warning: Failed to open the initrd protocol!");
+        uefi::println!("[EFI stub] warning: failed to open initrd protocol");
         return None;
     };
 
@@ -192,7 +238,7 @@ fn load_initrd() -> Option<&'static [u8]> {
         )
     };
     if status != Status::BUFFER_TOO_SMALL {
-        uefi::println!("[EFI stub] Warning: Failed to get the initrd size!");
+        uefi::println!("[EFI stub] warning: failed to get initrd size");
         return None;
     }
 
@@ -208,7 +254,7 @@ fn load_initrd() -> Option<&'static [u8]> {
         )
     };
     if status.is_error() {
-        uefi::println!("[EFI stub] Warning: Failed to load the initrd!");
+        uefi::println!("[EFI stub] warning: failed to load initrd");
         return None;
     }
     assert_eq!(
@@ -243,7 +289,7 @@ fn find_rsdp_addr() -> Option<*const ()> {
         }
     }
 
-    uefi::println!("[EFI stub] Warning: Failed to find the ACPI RSDP address!");
+    uefi::println!("[EFI stub] warning: failed to find ACPI RSDP address");
 
     None
 }
@@ -255,7 +301,7 @@ fn fill_screen_info(screen_info: &mut linux_boot_params::ScreenInfo) {
     };
 
     let Ok(handle) = boot::get_handle_for_protocol::<GraphicsOutput>() else {
-        uefi::println!("[EFI stub] Warning: Failed to locate the graphics handle!");
+        uefi::println!("[EFI stub] warning: failed to locate graphics handle");
         return;
     };
 
@@ -279,7 +325,7 @@ fn fill_screen_info(screen_info: &mut linux_boot_params::ScreenInfo) {
             OpenProtocolAttributes::GetProtocol,
         )
     }) else {
-        uefi::println!("[EFI stub] Warning: Failed to open the graphics protocol!");
+        uefi::println!("[EFI stub] warning: failed to open graphics protocol");
         return;
     };
 
@@ -288,7 +334,7 @@ fn fill_screen_info(screen_info: &mut linux_boot_params::ScreenInfo) {
         PixelFormat::Rgb | PixelFormat::Bgr
     ) {
         uefi::println!(
-            "[EFI stub] Warning: Ignored the framebuffer as the pixel format is not supported!"
+            "[EFI stub] warning: ignored framebuffer because pixel format is unsupported"
         );
         return;
     }
@@ -312,7 +358,42 @@ fn fill_screen_info(screen_info: &mut linux_boot_params::ScreenInfo) {
     );
 }
 
-unsafe fn efi_phase_runtime(boot_params: &mut BootParams) -> ! {
+fn fill_efi_info(boot_params: &mut BootParams) {
+    let Some(system_table) = uefi::table::system_table_raw() else {
+        uefi::println!("[EFI stub] warning: EFI system table is unavailable");
+        return;
+    };
+
+    let systab_addr = u64::try_from(system_table.as_ptr().addr()).unwrap();
+
+    boot_params.efi_info.efi_systab = u32::try_from(systab_addr & 0xFFFF_FFFF).unwrap();
+    boot_params.efi_info.efi_systab_hi = u32::try_from(systab_addr >> 32).unwrap();
+    boot_params.efi_info.efi_loader_signature = u32::from_le_bytes(*b"EL64");
+
+    #[cfg(feature = "debug_print")]
+    {
+        let (efi_systab, efi_systab_hi) = (
+            boot_params.efi_info.efi_systab,
+            boot_params.efi_info.efi_systab_hi,
+        );
+
+        uefi::println!(
+            "[EFI stub] EFI systab set to {:#x} (lo={:#x}, hi={:#x})",
+            systab_addr,
+            efi_systab,
+            efi_systab_hi
+        );
+    }
+}
+
+#[cfg(feature = "cvm_guest")]
+unsafe fn efi_phase_runtime(
+    boot_params: &mut BootParams,
+    kernel_load_ranges: PreAcceptedRanges,
+) -> ! {
+    let unaccepted_info = is_tdx_guest_early()
+        .then(|| prepare_lazy_accept_info().unwrap_or_else(|err| panic!("[EFI stub] {}", err)));
+
     uefi::println!("[EFI stub] Exiting EFI boot services");
     // SAFETY: The safety is upheld by the caller.
     let memory_map = unsafe { boot::exit_boot_services(Some(boot::MemoryType::LOADER_DATA)) };
@@ -321,61 +402,12 @@ unsafe fn efi_phase_runtime(boot_params: &mut BootParams) -> ! {
         "[EFI stub] Processing {} memory map entries",
         memory_map.entries().len()
     );
-    #[cfg(feature = "debug_print")]
-    {
-        memory_map.entries().for_each(|entry| {
-            crate::println!(
-                "    [{:#x}] {:#x} (size={:#x}) {{flags={:#x}}}",
-                entry.ty.0,
-                entry.phys_start,
-                entry.page_count,
-                entry.att.bits()
-            );
-        })
-    }
 
-    // Write the memory map to the E820 table in `boot_params`.
-    let e820_table = &mut boot_params.e820_table;
-    let mut num_entries = 0usize;
-    for entry in memory_map.entries() {
-        let typ = if let Some(e820_type) = parse_memory_type(entry.ty) {
-            e820_type
-        } else {
-            // The memory region is unaccepted (i.e., `MemoryType::UNACCEPTED`).
-            crate::println!("[EFI stub] Accepting pending pages");
-            for page_idx in 0..entry.page_count {
-                // SAFETY: The page to accept represents a page that has not been accepted
-                // (according to the memory map returned by the UEFI firmware).
-                unsafe {
-                    tdx_guest::tdcall::accept_page(0, entry.phys_start + page_idx * PAGE_SIZE)
-                        .unwrap();
-                }
-            }
-            linux_boot_params::E820Type::Ram
-        };
+    populate_e820_from_memory_map(boot_params, &memory_map);
 
-        if num_entries != 0 {
-            let last_entry = &mut e820_table[num_entries - 1];
-            let last_typ = last_entry.typ;
-            if last_typ == typ && last_entry.addr + last_entry.size == entry.phys_start {
-                last_entry.size += entry.page_count * PAGE_SIZE;
-                continue;
-            }
-        }
-
-        if num_entries >= e820_table.len() {
-            crate::println!("[EFI stub] Warning: The number of E820 entries exceeded 128!");
-            break;
-        }
-
-        e820_table[num_entries] = linux_boot_params::BootE820Entry {
-            addr: entry.phys_start,
-            size: entry.page_count * PAGE_SIZE,
-            typ,
-        };
-        num_entries += 1;
-    }
-    boot_params.e820_entries = num_entries as u8;
+    if let Some(unaccepted_info) = unaccepted_info.as_ref() {
+        apply_lazy_accept_info(unaccepted_info, &kernel_load_ranges)
+    };
 
     crate::println!(
         "[EFI stub] Entering the Asterinas entry point at {:p}",
@@ -387,7 +419,70 @@ unsafe fn efi_phase_runtime(boot_params: &mut BootParams) -> ! {
     unsafe { super::call_aster_entrypoint(super::ASTER_ENTRY_POINT, boot_params) }
 }
 
-fn parse_memory_type(mem_type: boot::MemoryType) -> Option<linux_boot_params::E820Type> {
+#[cfg(not(feature = "cvm_guest"))]
+unsafe fn efi_phase_runtime(boot_params: &mut BootParams, _early_boot_info: ()) -> ! {
+    uefi::println!("[EFI stub] Exiting EFI boot services");
+    // SAFETY: The safety is upheld by the caller.
+    let memory_map = unsafe { boot::exit_boot_services(Some(boot::MemoryType::LOADER_DATA)) };
+
+    crate::println!(
+        "[EFI stub] Processing {} memory map entries",
+        memory_map.entries().len()
+    );
+
+    populate_e820_from_memory_map(boot_params, &memory_map);
+
+    crate::println!(
+        "[EFI stub] Entering the Asterinas entry point at {:p}",
+        super::ASTER_ENTRY_POINT,
+    );
+    // SAFETY:
+    // 1. The entry point address is correct and matches the kernel ELF file.
+    // 2. The boot parameter pointer is valid and points to the correct boot parameters.
+    unsafe { super::call_aster_entrypoint(super::ASTER_ENTRY_POINT, boot_params) }
+}
+
+fn populate_e820_from_memory_map<M: MemoryMap>(boot_params: &mut BootParams, memory_map: &M) {
+    let e820_table = &mut boot_params.e820_table;
+    let mut num_entries = 0;
+
+    for entry in memory_map.entries() {
+        #[cfg(feature = "debug_print")]
+        crate::println!(
+            "    [{:#x}] {:#x} (size={:#x}) {{flags={:#x}}}",
+            entry.ty.0,
+            entry.phys_start,
+            entry.page_count,
+            entry.att.bits()
+        );
+
+        let typ = parse_memory_type(entry.ty);
+        if num_entries != 0 {
+            let last_entry = &mut e820_table[num_entries - 1];
+            let last_typ = last_entry.typ;
+            if last_typ == typ && last_entry.addr + last_entry.size == entry.phys_start {
+                last_entry.size += entry.page_count * PAGE_SIZE;
+                continue;
+            }
+        }
+
+        if num_entries >= e820_table.len() {
+            crate::println!("[EFI stub] warning: number of E820 entries exceeded 128");
+            break;
+        }
+
+        e820_table[num_entries] = linux_boot_params::BootE820Entry {
+            addr: entry.phys_start,
+            size: entry.page_count * PAGE_SIZE,
+            typ,
+        };
+        num_entries += 1;
+    }
+
+    boot_params.e820_entries = num_entries as u8;
+}
+
+fn parse_memory_type(mem_type: boot::MemoryType) -> linux_boot_params::E820Type {
     use linux_boot_params::E820Type;
     use uefi::boot::MemoryType;
 
@@ -405,21 +500,198 @@ fn parse_memory_type(mem_type: boot::MemoryType) -> Option<linux_boot_params::E8
         | MemoryType::LOADER_DATA
         | MemoryType::BOOT_SERVICES_CODE
         | MemoryType::BOOT_SERVICES_DATA
-        | MemoryType::CONVENTIONAL => Some(E820Type::Ram),
+        | MemoryType::CONVENTIONAL => E820Type::Ram,
 
         // Some memory types have special meanings.
-        MemoryType::PERSISTENT_MEMORY => Some(E820Type::Pmem),
-        MemoryType::ACPI_RECLAIM => Some(E820Type::Acpi),
-        MemoryType::ACPI_NON_VOLATILE => Some(E820Type::Nvs),
-        MemoryType::UNUSABLE => Some(E820Type::Unusable),
-        MemoryType::UNACCEPTED => None,
+        MemoryType::PERSISTENT_MEMORY => E820Type::Pmem,
+        MemoryType::ACPI_RECLAIM => E820Type::Acpi,
+        MemoryType::ACPI_NON_VOLATILE => E820Type::Nvs,
+        MemoryType::UNUSABLE => E820Type::Unusable,
+        MemoryType::UNACCEPTED => {
+            #[cfg(feature = "cvm_guest")]
+            {
+                if is_tdx_guest_early() {
+                    return E820Type::Ram;
+                }
+            }
+
+            crate::println!("[EFI stub] error: cannot classify unknown EFI memory type");
+            E820Type::Reserved
+        }
 
         // Other memory types are treated as reserved.
         MemoryType::RESERVED
         | MemoryType::RUNTIME_SERVICES_CODE
         | MemoryType::RUNTIME_SERVICES_DATA
         | MemoryType::MMIO
-        | MemoryType::MMIO_PORT_SPACE => Some(E820Type::Reserved),
-        _ => Some(E820Type::Reserved),
+        | MemoryType::MMIO_PORT_SPACE => E820Type::Reserved,
+        _ => E820Type::Reserved,
     }
 }
+
+#[cfg(feature = "cvm_guest")]
+fn compute_kernel_load_ranges(kernel: &[u8]) -> Vec<(u64, u64)> {
+    let raw_kernel_ranges = crate::loader::elf_load_ranges(kernel);
+
+    let mut kernel_load_ranges = Vec::new();
+    if let (Some(&(min_start, _)), Some(&(_, max_end))) =
+        (raw_kernel_ranges.first(), raw_kernel_ranges.last())
+    {
+        let start = min_start.align_down(PAGE_SIZE);
+        let footprint_end = max_end
+            .checked_add(KERNEL_FOOTPRINT_SAFETY_MARGIN)
+            .expect("[EFI stub] kernel footprint end overflowed");
+        let end = footprint_end.align_up(PAGE_SIZE);
+        kernel_load_ranges.push((start, end));
+
+        uefi::println!(
+            "[EFI stub] Kernel footprint calculated: {:#x} - {:#x}",
+            start,
+            end
+        );
+    }
+
+    kernel_load_ranges.push(AP_EXEC_RANGE);
+    kernel_load_ranges
+}
+
+#[cfg(feature = "cvm_guest")]
+fn prepare_lazy_accept_info() -> LazyAcceptInfoResult {
+    // Collect unaccepted memory ranges from the memory map.
+    let pre_exit_memory_map = boot::memory_map(boot::MemoryType::LOADER_DATA)
+        .map_err(|_| "failed to fetch pre-exit memory map for unaccepted bitmap setup")?;
+
+    let mut unaccepted_ranges: Vec<_> = pre_exit_memory_map
+        .entries()
+        .filter(|e| e.ty == boot::MemoryType::UNACCEPTED)
+        .map(|e| UnacceptedRange {
+            start: e.phys_start,
+            end: e.phys_start + e.page_count * PAGE_SIZE,
+        })
+        .collect();
+
+    let (table, fallback_reserved_range) = if let Some(existing) = find_unaccepted_table() {
+        uefi::println!("[EFI stub] Reusing firmware-provided unaccepted memory table");
+        (Some(core::ptr::NonNull::from(existing)), None)
+    } else if unaccepted_ranges.is_empty() {
+        (None, None)
+    } else {
+        uefi::println!(
+            "[EFI stub] Firmware did not provide an unaccepted memory table; installing EFI-stub fallback"
+        );
+        let table = allocate_unaccepted_bitmap(&unaccepted_ranges)
+            .unwrap_or_else(|| panic!("[EFI stub] failed to allocate unaccepted bitmap table"));
+        install_unaccepted_bitmap(table).unwrap_or_else(|err| {
+            panic!(
+                "[EFI stub] failed to install unaccepted bitmap table: {:?}",
+                err
+            )
+        });
+        let table_addr = u64::try_from(core::ptr::from_mut(table).addr())
+            .expect("[EFI stub] fallback unaccepted table address overflowed");
+        let table_size = u64::try_from(size_of::<EfiUnacceptedMemory>())
+            .expect("[EFI stub] fallback unaccepted header size conversion overflowed")
+            .checked_add(table.bitmap_size_bytes())
+            .expect("[EFI stub] fallback unaccepted table size overflowed");
+        let reserved_start = table_addr.align_down(u64::from(table.unit_size_bytes()));
+        let reserved_end = table_addr
+            .checked_add(table_size)
+            .expect("[EFI stub] fallback unaccepted table end overflowed")
+            .align_up(u64::from(table.unit_size_bytes()));
+
+        (
+            Some(core::ptr::NonNull::from(table)),
+            Some(UnacceptedRange {
+                start: reserved_start,
+                end: reserved_end,
+            }),
+        )
+    };
+
+    if let Some(reserved_range) = fallback_reserved_range {
+        uefi::println!(
+            "[EFI stub] Reserving fallback bitmap-covered range from lazy-accept tracking: [{:#x}, {:#x})",
+            reserved_range.start,
+            reserved_range.end
+        );
+        unaccepted_ranges = exclude_unaccepted_range(unaccepted_ranges, reserved_range);
+    }
+
+    Ok(LazyAcceptInfo {
+        unaccepted_ranges,
+        table,
+    })
+}
+
+#[cfg(feature = "cvm_guest")]
+fn exclude_unaccepted_range(
+    unaccepted_ranges: Vec<UnacceptedRange>,
+    excluded_range: UnacceptedRange,
+) -> Vec<UnacceptedRange> {
+    let mut filtered_ranges = Vec::with_capacity(unaccepted_ranges.len() + 1);
+
+    for range in unaccepted_ranges {
+        if excluded_range.end <= range.start || excluded_range.start >= range.end {
+            filtered_ranges.push(range);
+            continue;
+        }
+
+        if range.start < excluded_range.start {
+            filtered_ranges.push(UnacceptedRange {
+                start: range.start,
+                end: excluded_range.start,
+            });
+        }
+
+        if excluded_range.end < range.end {
+            filtered_ranges.push(UnacceptedRange {
+                start: excluded_range.end,
+                end: range.end,
+            });
+        }
+    }
+
+    filtered_ranges
+}
+
+#[cfg(feature = "cvm_guest")]
+fn apply_lazy_accept_info(lazy_accept_info: &LazyAcceptInfo, kernel_load_ranges: &[(u64, u64)]) {
+    if lazy_accept_info.unaccepted_ranges.is_empty() {
+        return;
+    }
+
+    let Some(table) = lazy_accept_info.table else {
+        panic!("[EFI stub] unaccepted memory exists but bitmap table is unavailable");
+    };
+
+    // SAFETY: The pointer comes from the firmware-installed table or EFI allocation and
+    // remains valid for the remainder of the EFI-stub flow.
+    let table = unsafe { &mut *table.as_ptr() };
+
+    for range in &lazy_accept_info.unaccepted_ranges {
+        // SAFETY: Range comes from firmware memory map and table is valid/writable.
+        if let Err(err) = unsafe { table.register_range(range.start, range.end) } {
+            panic!(
+                "[EFI stub] failed to process unaccepted memory range [{:#x}, {:#x}): {:?}",
+                range.start, range.end, err
+            );
+        }
+    }
+
+    // The kernel load ranges should be accepted immediately, even if they are covered by the bitmap,
+    // to ensure the kernel code and data are accessible when the entry point is called.
+    for &(k_start, k_end) in kernel_load_ranges {
+        if !accept_bitmap_range(table, k_start, k_end) {
+            panic!("[EFI stub] failed to accept kernel mapped unaccepted memory via bitmap");
+        }
+    }
+}
+
+#[cfg(feature = "cvm_guest")]
+struct LazyAcceptInfo {
+    unaccepted_ranges: Vec<UnacceptedRange>,
+    table: Option<core::ptr::NonNull<EfiUnacceptedMemory>>,
+}
+
+#[cfg(feature = "cvm_guest")]
+type LazyAcceptInfoResult = Result<LazyAcceptInfo, &'static str>;

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/mod.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/mod.rs
@@ -3,6 +3,8 @@
 pub(super) mod alloc;
 mod decoder;
 mod efi;
+#[cfg(feature = "cvm_guest")]
+mod unaccepted_memory;
 
 use core::arch::{asm, global_asm};
 

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/setup.S
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/setup.S
@@ -25,6 +25,12 @@ entry_efi_handover32:
     // just in case.
     jmp entry_legacy32
 
+// The 32-bit EFI handover offset expected by Linux boot header.
+// Keep this as an absolute symbol so `header.S` can reference it directly
+// without doing cross-unit symbol subtraction.
+.global entry_efi_handover_offset32
+.set entry_efi_handover_offset32, (entry_efi_handover32 - entry_legacy32)
+
 // The 64-bit Linux legacy entry point must be 0x200 bytes after the 32-bit
 // one. This is required by the x86 Linux boot protocol.
 .skip 0x200 - (. - entry_legacy32)

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/unaccepted_memory.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/unaccepted_memory.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! EFI-side bitmap management for TDX unaccepted memory.
+//!
+//! This module builds and installs the Linux-compatible unaccepted-memory table,
+//! marks deferred-accept ranges in the bitmap, and eagerly accepts only the
+//! ranges that must be mapped immediately.
+
+use core::mem::size_of;
+
+use align_ext::AlignExt;
+use tdx_guest::unaccepted_memory::{
+    EFI_UNACCEPTED_UNIT_SIZE, EfiUnacceptedMemory, LINUX_EFI_UNACCEPTED_MEM_TABLE_GUID,
+    LINUX_EFI_UNACCEPTED_MEM_TABLE_VERSION,
+};
+use uefi::boot::{AllocateType, MemoryType};
+
+use crate::x86::amd64_efi::efi::PAGE_SIZE;
+
+pub(crate) fn find_unaccepted_table() -> Option<&'static mut EfiUnacceptedMemory> {
+    let st = uefi::table::system_table_raw()?;
+    let system_table = st.as_ptr();
+
+    // SAFETY: EFI system table pointer is firmware-owned and valid at this phase.
+    let config_table = unsafe { (*system_table).configuration_table };
+    // SAFETY: EFI system table pointer is firmware-owned and valid at this phase.
+    let num_entries = unsafe { (*system_table).number_of_configuration_table_entries };
+
+    if config_table.is_null() || num_entries == 0 {
+        return None;
+    }
+
+    // SAFETY: EFI config table pointer/length come from firmware and are valid here.
+    let entries = unsafe { core::slice::from_raw_parts(config_table, num_entries) };
+    for entry in entries {
+        if entry.vendor_guid == LINUX_EFI_UNACCEPTED_MEM_TABLE_GUID {
+            let ptr = entry.vendor_table.cast::<EfiUnacceptedMemory>();
+            if ptr.is_null() {
+                crate::println!("[EFI stub] warning: unaccepted memory table pointer is null");
+                continue;
+            }
+            if !ptr.is_aligned() {
+                crate::println!(
+                    "[EFI stub] warning: unaccepted memory table pointer is misaligned"
+                );
+                continue;
+            }
+
+            // SAFETY: Pointer is non-null, aligned, and points to a firmware-installed table
+            // with the matching GUID.
+            let table = unsafe { &mut *ptr };
+
+            let version = table.version();
+            if version != LINUX_EFI_UNACCEPTED_MEM_TABLE_VERSION {
+                crate::println!(
+                    "[EFI stub] warning: unknown unaccepted memory table version: {}",
+                    version
+                );
+                return None;
+            }
+
+            if table.unit_size_bytes() == 0 || !table.unit_size_bytes().is_power_of_two() {
+                crate::println!(
+                    "[EFI stub] warning: unaccepted memory table has invalid unit size: {}",
+                    table.unit_size_bytes()
+                );
+                return None;
+            }
+
+            return Some(table);
+        }
+    }
+
+    None
+}
+
+/// Creates a Linux-compatible unaccepted-memory bitmap table for `ranges`.
+pub(crate) fn allocate_unaccepted_bitmap(
+    ranges: &[UnacceptedRange],
+) -> Option<&'static mut EfiUnacceptedMemory> {
+    if ranges.is_empty() {
+        return None;
+    }
+
+    let unit_size = EFI_UNACCEPTED_UNIT_SIZE;
+
+    let mut min_addr = u64::MAX;
+    let mut max_addr = 0u64;
+
+    for range in ranges {
+        debug_assert!(
+            range.start < range.end,
+            "invalid unaccepted range: {:#x} >= {:#x}",
+            range.start,
+            range.end
+        );
+        min_addr = min_addr.min(range.start);
+        max_addr = max_addr.max(range.end);
+    }
+
+    let aligned_start = min_addr.align_down(unit_size);
+    let aligned_end = max_addr.align_up(unit_size);
+
+    let memory_range = aligned_end.checked_sub(aligned_start)?;
+    let bitmap_bits = memory_range / unit_size;
+    let bitmap_bytes = bitmap_bits.div_ceil(8);
+
+    #[cfg(feature = "debug_print")]
+    {
+        uefi::println!("[EFI stub] Creating bitmap for unaccepted memory");
+        uefi::println!(
+            "[EFI stub] Range: {:#x} - {:#x}, Unit: {}KB, Bitmap: {} bytes",
+            aligned_start,
+            aligned_end,
+            unit_size / 1024,
+            bitmap_bytes
+        );
+    }
+
+    let bitmap_bytes_usize = usize::try_from(bitmap_bytes).ok()?;
+    let total_size = size_of::<EfiUnacceptedMemory>().checked_add(bitmap_bytes_usize)?;
+    let pages = total_size.div_ceil(PAGE_SIZE as usize);
+
+    match uefi::boot::allocate_pages(AllocateType::AnyPages, MemoryType::ACPI_RECLAIM, pages) {
+        Ok(addr) => {
+            // SAFETY: The returned pages are owned by us and large enough for header + bitmap.
+            let table = unsafe { &mut *addr.as_ptr().cast::<EfiUnacceptedMemory>() };
+
+            table
+                .init_header(u32::try_from(unit_size).ok()?, aligned_start, bitmap_bytes)
+                .ok()?;
+
+            // SAFETY: `table` points to newly allocated pages large enough for
+            // `EfiUnacceptedMemory` + bitmap bytes, and is uniquely borrowed here.
+            unsafe { table.clear_bitmap() }.ok()?;
+
+            Some(table)
+        }
+        Err(e) => {
+            uefi::println!(
+                "[EFI stub] error: failed to allocate bitmap memory: {:?}",
+                e
+            );
+            None
+        }
+    }
+}
+
+/// Installs the unaccepted-memory bitmap table into EFI config tables.
+pub(crate) fn install_unaccepted_bitmap(
+    table: &EfiUnacceptedMemory,
+) -> Result<(), InstallUnacceptedBitmapError> {
+    let Some(st) = uefi::table::system_table_raw() else {
+        uefi::println!("[EFI stub] error: system table is unavailable");
+        return Err(InstallUnacceptedBitmapError::SystemTableUnavailable);
+    };
+
+    // SAFETY: `st` is provided by firmware and valid during boot services.
+    let Some(boot_services) = (unsafe { (*st.as_ptr()).boot_services.as_ref() }) else {
+        uefi::println!("[EFI stub] boot services are unavailable");
+        return Err(InstallUnacceptedBitmapError::BootServicesUnavailable);
+    };
+
+    let install_config_table = boot_services.install_configuration_table;
+
+    // SAFETY: Firmware boot services is valid at this phase; pointers passed follow EFI ABI.
+    let status = unsafe {
+        install_config_table(
+            core::ptr::from_ref(&LINUX_EFI_UNACCEPTED_MEM_TABLE_GUID),
+            core::ptr::from_ref(table).cast(),
+        )
+    };
+
+    if !status.is_success() {
+        uefi::println!(
+            "[EFI stub] error: failed to install unaccepted memory table: {:?}",
+            status
+        );
+        return Err(InstallUnacceptedBitmapError::InstallFailed);
+    }
+
+    #[cfg(feature = "debug_print")]
+    {
+        uefi::println!("[EFI stub] Unaccepted memory table installed successfully");
+        uefi::println!("  Version: {}", table.version());
+        uefi::println!("  Unit size: {}KB", table.unit_size_bytes() / 1024);
+        uefi::println!("  Physical base: {:#x}", table.phys_base());
+        uefi::println!("  Bitmap size: {} bytes", table.bitmap_size_bytes());
+    }
+
+    Ok(())
+}
+
+/// Accepts bitmap-marked unaccepted units that overlap `start..end`.
+pub(crate) fn accept_bitmap_range(table: &mut EfiUnacceptedMemory, start: u64, end: u64) -> bool {
+    if start >= end {
+        return true;
+    }
+
+    // SAFETY: `table` is exclusively borrowed; method uses table-owned bitmap metadata.
+    match unsafe { table.accept_range(start, end) } {
+        Ok(()) => true,
+        Err(err) => {
+            crate::println!(
+                "[EFI stub] error: failed to accept overlapping marked bitmap units: start={:#x}, end={:#x}, phys_base={:#x}, unit_size={}, bitmap_size={}, err={:?}",
+                start,
+                end,
+                table.phys_base(),
+                table.unit_size_bytes(),
+                table.bitmap_size_bytes(),
+                err
+            );
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum InstallUnacceptedBitmapError {
+    SystemTableUnavailable,
+    BootServicesUnavailable,
+    InstallFailed,
+}
+
+/// Physical range that firmware marks as unaccepted.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct UnacceptedRange {
+    pub start: u64,
+    pub end: u64,
+}

--- a/ostd/libs/linux-bzimage/setup/src/x86/header.S
+++ b/ostd/libs/linux-bzimage/setup/src/x86/header.S
@@ -68,7 +68,7 @@ pref_address:           .quad CODE32_START
 init_size:              .long __executable_size
 
 .if {CFG_TARGET_ARCH_X86_64}
-handover_offset:        .long (entry_efi_handover32 - entry_legacy32)
+handover_offset:        .long entry_efi_handover_offset32
 .else
 handover_offset:        .long 0
 .endif

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -4,6 +4,11 @@
 //!
 
 use linux_boot_params::{BootParams, E820Type, LINUX_BOOT_HEADER_MAGIC};
+#[cfg(feature = "cvm_guest")]
+use tdx_guest::unaccepted_memory::{
+    EfiUnacceptedMemory, LINUX_EFI_UNACCEPTED_MEM_TABLE_GUID,
+    LINUX_EFI_UNACCEPTED_MEM_TABLE_VERSION,
+};
 
 #[cfg(feature = "cvm_guest")]
 use crate::arch::init_cvm_guest;
@@ -225,6 +230,13 @@ unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
     #[cfg(feature = "cvm_guest")]
     init_cvm_guest();
 
+    #[cfg(feature = "cvm_guest")]
+    if_tdx_enabled!({
+        crate::mm::frame::unaccepted::set_unaccepted_memory_table(parse_unaccepted_memory_table(
+            params,
+        ));
+    });
+
     EARLY_INFO.call_once(|| EarlyBootInfo {
         bootloader_name: parse_bootloader_name(params),
         kernel_cmdline: parse_kernel_commandline(params).unwrap_or(""),
@@ -237,4 +249,54 @@ unsafe extern "sysv64" fn __linux_boot(params_ptr: *const BootParams) -> ! {
     // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
     // once after setting up necessary resources.
     unsafe { start_kernel() };
+}
+
+/// Finds the unaccepted-memory table from EFI configuration tables.
+#[cfg(feature = "cvm_guest")]
+fn parse_unaccepted_memory_table(
+    boot_params: &BootParams,
+) -> Option<&'static mut EfiUnacceptedMemory> {
+    let efi_info = boot_params.efi_info;
+    let systab_addr = u64::from(efi_info.efi_systab) | (u64::from(efi_info.efi_systab_hi) << 32);
+
+    if systab_addr == 0 {
+        return None;
+    }
+
+    // SAFETY: `systab_addr` is valid because it is provided by firmware and we have not yet enabled paging.
+    let systab = unsafe { &*(systab_addr as *const uefi_raw::table::system::SystemTable) };
+
+    if systab.configuration_table.is_null() {
+        return None;
+    }
+
+    // SAFETY: `configuration_table` points to a firmware-provided array in the EFI system table.
+    // An empty slice is safe if `number_of_configuration_table_entries` is zero.
+    let entries = unsafe {
+        core::slice::from_raw_parts(
+            systab.configuration_table,
+            systab.number_of_configuration_table_entries,
+        )
+    };
+
+    let table_ptr = entries
+        .iter()
+        .find(|entry| entry.vendor_guid == LINUX_EFI_UNACCEPTED_MEM_TABLE_GUID)?
+        .vendor_table
+        .cast::<EfiUnacceptedMemory>();
+
+    // SAFETY: EFI config table entry points to an installed unaccepted table.
+    let table = unsafe { table_ptr.as_mut() }?;
+
+    if table.version() != LINUX_EFI_UNACCEPTED_MEM_TABLE_VERSION {
+        crate::warn!(
+            "Unknown unaccepted memory table version: {}",
+            table.version()
+        );
+        return None;
+    }
+
+    crate::info!("Found unaccepted memory table at {:p}", table_ptr);
+
+    Some(table)
 }

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use tdx_guest::{
-    SHARED_BIT, SHARED_MASK, TdxTrapFrame,
+    SHARED_MASK, TdxTrapFrame,
     tdcall::{TdCallError, accept_page},
     tdvmcall::{TdVmcallError, map_gpa},
 };
@@ -81,10 +81,7 @@ impl TargetPageState {
     fn as_gpa_mask(self) -> u64 {
         match self {
             Self::Private => 0,
-            Self::Shared => {
-                const { assert!(SHARED_MASK == 1u64 << SHARED_BIT) };
-                SHARED_MASK
-            }
+            Self::Shared => SHARED_MASK.load(core::sync::atomic::Ordering::Relaxed),
         }
     }
 }

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -110,6 +110,11 @@ unsafe fn init() {
     // SAFETY: This function is called only once on the BSP.
     unsafe { mm::kspace::activate_kernel_page_table() };
 
+    #[cfg(target_arch = "x86_64")]
+    arch::if_tdx_enabled!({
+        mm::frame::unaccepted::remap_table_ptr_after_paging();
+    });
+
     sync::init();
 
     boot::init_after_heap();

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -6,7 +6,11 @@ use core::{alloc::Layout, ops::Range};
 
 use align_ext::AlignExt;
 
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+use super::unaccepted;
 use super::{Frame, meta::AnyFrameMeta, segment::Segment};
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+use crate::if_tdx_enabled;
 use crate::{
     boot::memory_region::MemoryRegionType,
     error::Error,
@@ -53,10 +57,9 @@ impl FrameAllocOptions {
     /// Allocates a single frame with additional metadata.
     pub fn alloc_frame_with<M: AnyFrameMeta>(&self, metadata: M) -> Result<Frame<M>> {
         let single_layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE).unwrap();
-        let frame = get_global_frame_allocator()
-            .alloc(single_layout)
-            .map(|paddr| Frame::from_unused(paddr, metadata).unwrap())
-            .ok_or(Error::NoMemory)?;
+        let paddr = alloc_usable_memory(single_layout)?;
+
+        let frame = Frame::from_unused(paddr, metadata).unwrap();
 
         if self.zeroed {
             let addr = paddr_to_vaddr(frame.paddr()) as *mut u8;
@@ -87,13 +90,11 @@ impl FrameAllocOptions {
         if nframes == 0 {
             return Err(Error::InvalidArgs);
         }
-        let layout = Layout::from_size_align(nframes * PAGE_SIZE, PAGE_SIZE).unwrap();
-        let segment = get_global_frame_allocator()
-            .alloc(layout)
-            .map(|start| {
-                Segment::from_unused(start..start + nframes * PAGE_SIZE, metadata_fn).unwrap()
-            })
-            .ok_or(Error::NoMemory)?;
+        let total_size = nframes * PAGE_SIZE;
+        let layout = Layout::from_size_align(total_size, PAGE_SIZE).unwrap();
+        let start = alloc_usable_memory(layout)?;
+
+        let segment = Segment::from_unused(start..start + total_size, metadata_fn).unwrap();
 
         if self.zeroed {
             let addr = paddr_to_vaddr(segment.paddr()) as *mut u8;
@@ -212,6 +213,19 @@ pub(crate) unsafe fn init() {
             // Truncate the early allocated frames if there is an overlap.
             for r1 in range_difference(&(region.base()..region.end()), &range_1) {
                 for r2 in range_difference(&r1, &range_2) {
+                    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+                    if matches!(
+                        if_tdx_enabled!({
+                            unaccepted::try_defer_usable_memory(r2.start, r2.len())
+                        } else {
+                            unaccepted::DeferOutcome::NotUnaccepted
+                        }),
+                        unaccepted::DeferOutcome::Deferred
+                    ) {
+                        crate::info!("Deferring unaccepted frames from usable range: {:x?}", r2);
+                        continue;
+                    }
+
                     crate::info!("Adding free frames to the allocator: {:x?}", r2);
                     get_global_frame_allocator().add_free_memory(r2.start, r2.len());
                 }
@@ -302,12 +316,31 @@ impl EarlyFrameAllocator {
             (&mut self.under_4g_end, self.under_4g_range.end),
             (&mut self.max_end, self.max_range.end),
         ] {
-            let allocated = tail.align_up(align);
-            if let Some(allocated_end) = allocated.checked_add(size)
-                && allocated_end <= end
-            {
-                *tail = allocated_end;
-                return Some(allocated);
+            let mut cursor = *tail;
+            while cursor < end {
+                let allocated = cursor.align_up(align);
+                let Some(allocated_end) = allocated.checked_add(size) else {
+                    break;
+                };
+                if allocated_end > end {
+                    break;
+                }
+
+                #[cfg(feature = "cvm_guest")]
+                let ready = super::accept_unaccepted_memory(allocated, size).is_ok();
+                #[cfg(not(feature = "cvm_guest"))]
+                let ready = true;
+
+                if ready {
+                    *tail = allocated_end;
+                    return Some(allocated);
+                }
+
+                let Some(next_cursor) = allocated.checked_add(PAGE_SIZE) else {
+                    break;
+                };
+                *tail = next_cursor;
+                cursor = next_cursor;
             }
         }
 
@@ -356,6 +389,44 @@ pub(crate) fn early_alloc(layout: Layout) -> Option<Paddr> {
 ///
 /// This function should be called only once after the memory regions are ready.
 pub(crate) unsafe fn init_early_allocator() {
+    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+    if_tdx_enabled!({ unaccepted::init() });
     let mut early_allocator = EARLY_ALLOCATOR.lock();
     *early_allocator = Some(EarlyFrameAllocator::new());
+}
+
+fn alloc_usable_memory(layout: Layout) -> Result<Paddr> {
+    let paddr = get_global_frame_allocator()
+        .alloc(layout)
+        .or_else(|| try_alloc_after_refill(layout))
+        .ok_or(Error::NoMemory)?;
+
+    #[cfg(feature = "cvm_guest")]
+    {
+        super::accept_unaccepted_memory(paddr, layout.size()).map_err(|_| Error::NoMemory)?;
+    }
+
+    Ok(paddr)
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+fn try_alloc_after_refill(layout: Layout) -> Option<Paddr> {
+    crate::if_tdx_enabled!({
+        match unaccepted::try_refill_for_allocation(layout) {
+            Ok(true) => get_global_frame_allocator().alloc(layout),
+            Ok(false) => None,
+            Err(err) => {
+                crate::warn!("Adaptive refill failed: {:?}", err);
+                None
+            }
+        }
+    } else {
+        None
+    })
+}
+
+#[cfg(not(all(target_arch = "x86_64", feature = "cvm_guest")))]
+fn try_alloc_after_refill(layout: Layout) -> Option<Paddr> {
+    let _ = layout;
+    None
 }

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -38,6 +38,9 @@ pub mod segment;
 pub mod unique;
 pub mod untyped;
 
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+pub(crate) mod unaccepted;
+
 mod frame_ref;
 pub use frame_ref::FrameRef;
 
@@ -61,6 +64,61 @@ use crate::{
 };
 
 static MAX_PADDR: AtomicUsize = AtomicUsize::new(0);
+
+/// Loads the total size in bytes of memory that is still unaccepted.
+pub fn load_total_unaccepted_bytes() -> usize {
+    #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+    {
+        crate::if_tdx_enabled!({
+            unaccepted::load_total_unaccepted_bytes()
+        } else {
+            0
+        })
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", feature = "cvm_guest")))]
+    {
+        0
+    }
+}
+
+/// Returns whether the physical range still overlaps unaccepted memory.
+#[cfg(feature = "cvm_guest")]
+pub fn is_range_unaccepted(addr: Paddr, size: usize) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        crate::if_tdx_enabled!({
+            unaccepted::is_range_unaccepted(addr, size)
+        } else {
+            false
+        })
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = (addr, size);
+        false
+    }
+}
+
+/// Accepts the physical range if it is still marked as unaccepted.
+#[cfg(feature = "cvm_guest")]
+pub fn accept_unaccepted_memory(addr: Paddr, size: usize) -> Result<(), AcceptError> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        crate::if_tdx_enabled!({
+            unaccepted::accept_memory_if_needed(addr, size).map_err(AcceptError::from)
+        } else {
+            Ok(())
+        })
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = (addr, size);
+        Ok(())
+    }
+}
 
 /// Returns the maximum physical address that is tracked by frame metadata.
 pub(in crate::mm) fn max_paddr() -> Paddr {
@@ -366,4 +424,20 @@ pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
 
     // SAFETY: We have already held a reference to the frame.
     unsafe { slot.inc_ref_count() };
+}
+
+/// Error type for unaccepted-memory acceptance operations.
+#[cfg(feature = "cvm_guest")]
+#[derive(Debug)]
+pub enum AcceptError {
+    /// Error reported by the TDX guest accept operation.
+    #[cfg(target_arch = "x86_64")]
+    TdxGuest(tdx_guest::AcceptError),
+}
+
+#[cfg(all(feature = "cvm_guest", target_arch = "x86_64"))]
+impl From<tdx_guest::AcceptError> for AcceptError {
+    fn from(value: tdx_guest::AcceptError) -> Self {
+        Self::TdxGuest(value)
+    }
 }

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -120,6 +120,17 @@ pub fn accept_unaccepted_memory(addr: Paddr, size: usize) -> Result<(), AcceptEr
     }
 }
 
+/// Spawns the background memory accept worker for lazy-background accept mode.
+#[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))]
+pub fn spawn_background_accept_worker(
+    spawner: impl Fn(alloc::boxed::Box<dyn FnOnce() + Send>),
+    sleeper: impl Fn(core::time::Duration) + Send + Sync + 'static,
+) {
+    crate::if_tdx_enabled!({
+        unaccepted::spawn_background_accept_worker(spawner, sleeper);
+    });
+}
+
 /// Returns the maximum physical address that is tracked by frame metadata.
 pub(in crate::mm) fn max_paddr() -> Paddr {
     let max_paddr = MAX_PADDR.load(Ordering::Relaxed) as Paddr;

--- a/ostd/src/mm/frame/unaccepted.rs
+++ b/ostd/src/mm/frame/unaccepted.rs
@@ -301,6 +301,33 @@ pub(super) fn load_total_unaccepted_bytes() -> usize {
     TOTAL_UNACCEPTED_BYTES.load(Ordering::Relaxed)
 }
 
+/// Spawns background worker threads that gradually accept deferred memory.
+pub(super) fn spawn_background_accept_worker(
+    spawner: impl Fn(alloc::boxed::Box<dyn FnOnce() + Send>),
+    sleeper: impl Fn(core::time::Duration) + Send + Sync + 'static,
+) {
+    if get_accept_memory_mode() != AcceptMemoryMode::LazyBackground
+        || BACKGROUND_WORKER_STARTED.swap(true, Ordering::AcqRel)
+    {
+        return;
+    }
+
+    let worker_count = background_worker_count();
+    let sleeper = Arc::new(sleeper);
+
+    for worker_id in 0..worker_count {
+        let sleeper = Arc::clone(&sleeper);
+        spawner(alloc::boxed::Box::new(move || {
+            background_accept_worker_loop(worker_id, sleeper)
+        }));
+    }
+
+    crate::info!(
+        "lazy-background accept workers started: count={}",
+        worker_count
+    );
+}
+
 /// Outcome of attempting to defer a usable memory range to the unaccepted reservoir.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeferOutcome {
@@ -319,6 +346,7 @@ pub(super) enum DeferOutcome {
 enum AcceptMemoryMode {
     #[default]
     Lazy,
+    LazyBackground,
     Eager,
 }
 
@@ -330,6 +358,7 @@ impl core::str::FromStr for AcceptMemoryMode {
         // parses before the framework runs, so accept both forms.
         match s {
             "lazy" => Ok(AcceptMemoryMode::Lazy),
+            "lazy-background" | "lazy_background" => Ok(AcceptMemoryMode::LazyBackground),
             "eager" => Ok(AcceptMemoryMode::Eager),
             _ => Err(()),
         }
@@ -342,6 +371,7 @@ fn init_accept_mode_from_cmdline() {
 
     match mode {
         AcceptMemoryMode::Lazy => crate::info!("accept_memory mode: lazy"),
+        AcceptMemoryMode::LazyBackground => crate::info!("accept_memory mode: lazy-background"),
         AcceptMemoryMode::Eager => crate::info!("accept_memory mode: eager"),
     }
 }
@@ -767,6 +797,70 @@ fn segment_boundary_end(addr: Paddr) -> Paddr {
     segment_start.saturating_add(SEGMENT_BYTES)
 }
 
+fn background_accept_worker_loop(
+    worker_id: usize,
+    sleeper: Arc<dyn Fn(core::time::Duration) + Send + Sync>,
+) {
+    use core::{
+        sync::atomic::Ordering::{Acquire, Release},
+        time::Duration,
+    };
+
+    const ITERATION_SLEEP_MS: u64 = 20;
+    const IDLE_SLEEP_MS: u64 = 200;
+
+    crate::info!("lazy-background accept worker {} started", worker_id);
+
+    if load_unaccepted_table().is_none() {
+        return;
+    }
+
+    let sleep_fn = |ms| sleeper(Duration::from_millis(ms));
+
+    while !BACKGROUND_WORKER_DISABLED.load(Acquire) {
+        if EAGER_ACCEPT_COMPLETED.load(Acquire) || BACKGROUND_WORKER_DISABLED.load(Acquire) {
+            break;
+        }
+
+        match refill_deferred_memory(
+            BACKGROUND_REFILL_CHUNK_BYTES,
+            BACKGROUND_REFILL_BUDGET_BYTES,
+        ) {
+            Ok(0) => {
+                if is_reservoir_empty() {
+                    break;
+                }
+                sleep_fn(IDLE_SLEEP_MS);
+            }
+            Ok(_) => sleep_fn(ITERATION_SLEEP_MS),
+            Err(err) => {
+                crate::error!("Background accept worker {} failed: {:?}", worker_id, err);
+                BACKGROUND_WORKER_DISABLED.store(true, Release);
+                break;
+            }
+        }
+    }
+
+    if is_reservoir_empty() && !BACKGROUND_WORKER_DISABLED.load(Acquire) {
+        crate::info!(
+            "lazy-background accept worker {} drained deferred reservoir",
+            worker_id
+        );
+    } else if BACKGROUND_WORKER_DISABLED.load(Acquire) {
+        crate::warn!(
+            "lazy-background accept worker {} stopped: background refill disabled",
+            worker_id
+        );
+    }
+}
+
+fn background_worker_count() -> usize {
+    // Use a small fraction of CPUs for background acceptance to avoid
+    // starving foreground workloads with lock contention and TDCALL overhead.
+    let cpus = crate::cpu::num_cpus();
+    (cpus / 4).clamp(1, BACKGROUND_WORKER_MAX)
+}
+
 struct DeferPlan {
     required_range_slots: [usize; SEGMENT_LOCK_COUNT],
     touched_segments: [usize; SEGMENT_LOCK_COUNT],
@@ -988,6 +1082,12 @@ const SEGMENT_BYTES: usize = 256 * 1024 * 1024;
 const MIN_REFILL_EXTRA_BUDGET_BYTES: usize = 16 * 1024 * 1024;
 const MAX_REFILL_EXTRA_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
+// Target chunk size a background worker tries to accept per successful refill.
+const BACKGROUND_REFILL_CHUNK_BYTES: usize = 2 * 1024 * 1024;
+// Maximum acceptance work a background worker performs in one refill iteration.
+const BACKGROUND_REFILL_BUDGET_BYTES: usize = 4 * 1024 * 1024;
+const BACKGROUND_WORKER_MAX: usize = 16;
+
 static UNACCEPTED_TABLE: AtomicPtr<EfiUnacceptedMemory> = AtomicPtr::new(core::ptr::null_mut());
 static ACCEPT_MEMORY_MODE: Once<AcceptMemoryMode> = Once::new();
 static EAGER_ACCEPT_COMPLETED: AtomicBool = AtomicBool::new(false);
@@ -1006,3 +1106,6 @@ static SEGMENT_STATES: [SpinLock<DeferredSegmentState, LocalIrqDisabled>; SEGMEN
     [const { SpinLock::new(DeferredSegmentState::new()) }; SEGMENT_LOCK_COUNT];
 /// Bit-per-segment hint bitmap used to skip obviously empty deferred segments.
 static NONEMPTY_SEGMENT_HINT_BITMAP: AtomicU64 = AtomicU64::new(0);
+
+static BACKGROUND_WORKER_STARTED: AtomicBool = AtomicBool::new(false);
+static BACKGROUND_WORKER_DISABLED: AtomicBool = AtomicBool::new(false);

--- a/ostd/src/mm/frame/unaccepted.rs
+++ b/ostd/src/mm/frame/unaccepted.rs
@@ -1,0 +1,1008 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Support for **unaccepted memory** in Intel TDX guest VMs.
+//!
+//! # High-level Design
+//!
+//! This module implements the TDX guest memory-accept flow defined by the
+//! Intel TDX module ABI and follows the Linux-compatible EFI unaccepted-memory
+//! bitmap format used at boot.
+//!
+//! The implementation is built around three cooperating components:
+//!
+//! ## 1. Firmware-provided bitmap (correctness source)
+//!
+//! The EFI stub publishes a Linux-compatible *unaccepted-memory bitmap* via the
+//! EFI configuration table.  Each bit represents whether a physical memory unit
+//! is still pending acceptance.  This bitmap is the **single authoritative
+//! correctness source** for unaccepted memory.
+//!
+//! ## 2. Deferred reservoir (storage-level tracking)
+//!
+//! Usable but unaccepted memory discovered during early boot is *deferred* into
+//! a bounded in-kernel reservoir.  The reservoir stores coarse-grained physical
+//! ranges so that acceptance work can be amortized and performed later.
+//!
+//! The reservoir is segmented by physical address to bound fragmentation and
+//! lock contention.  Its capacity is intentionally finite; when the reservoir
+//! is full, memory may be returned directly to the global allocator, relying on
+//! on-demand acceptance as a safe fallback.
+//!
+//! ## 3. Shard-based accept protocol (execution-level concurrency)
+//!
+//! Acceptance is performed by `accept_with_shard_locks`, which uses shard-level
+//! locking and *in-flight* tracking to coordinate concurrent accept operations:
+//!
+//!  * bitmap bits are claimed under a shard lock,
+//!  * slow platform accepts run without holding locks,
+//!  * in-flight ranges distinguish "accepted" from "claimed but still in progress".
+//!
+//! This ensures that no caller ever observes memory as usable before acceptance
+//! has truly completed, even under heavy concurrency.
+//!
+//! # Allocation-time Safety Guarantee
+//!
+//! The global frame allocator is **not assumed** to contain only accepted memory
+//! (e.g. when the deferred reservoir was full during initialization).  Therefore,
+//! every physical allocation path enforces the following invariant:
+//!
+//! > **Memory is accepted before it is first accessed (including zeroing).**
+//!
+//! This invariant makes the design robust against false negatives from lock-free
+//! bitmap reads and guarantees correctness even when deferral capacity is
+//! exceeded.
+//!
+//! # Core Data Structures
+//!
+//! The implementation relies on a small number of core data structures with
+//! clearly separated responsibilities:
+//!
+//! * **`EfiUnacceptedMemory` (bitmap table)**
+//!   Firmware-provided bitmap tracking which physical memory units are still
+//!   pending acceptance.  This is the authoritative correctness source.
+//!
+//! * **Bitmap shards (`ShardState`)**
+//!   Per-shard concurrency control for acceptance.  Shards protect bitmap
+//!   updates and track *in-flight* accept operations so that memory is never
+//!   observed as usable before acceptance completes.
+//!
+//! * **Deferred reservoir segments (`DeferredSegmentState`)**
+//!   Bounded storage for usable-but-unaccepted memory ranges discovered during
+//!   early boot.  Segments group deferred ranges by physical address to bound
+//!   fragmentation and lock contention.
+
+use alloc::sync::Arc;
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering},
+};
+
+use align_ext::AlignExt;
+use spin::Once;
+use tdx_guest::{AcceptError, accept_memory, unaccepted_memory::EfiUnacceptedMemory};
+
+use crate::{
+    mm::{PAGE_SIZE, Paddr},
+    sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
+};
+
+/// Sets the unaccepted-memory table pointer parsed at boot entry.
+pub(crate) fn set_unaccepted_memory_table(table: Option<&'static mut EfiUnacceptedMemory>) {
+    match table {
+        Some(t) => {
+            crate::info!("Set unaccepted memory table pointer to {:p}", t);
+            REFILL_GRANULARITY_BYTES.store(
+                usize::try_from(u64::from(t.unit_size_bytes()))
+                    .ok()
+                    .map(|bytes| bytes.max(PAGE_SIZE).align_up(PAGE_SIZE))
+                    .unwrap_or(PAGE_SIZE),
+                Ordering::Release,
+            );
+
+            let unit_size = u64::from(t.unit_size_bytes());
+            // SAFETY: `t` points to valid table memory from boot info.
+            let total_bits = unsafe { t.pending_unit_count() }.unwrap_or(0);
+            let initial_bytes = total_bits.saturating_mul(unit_size);
+            TOTAL_UNACCEPTED_BYTES.store(initial_bytes as usize, Ordering::Release);
+
+            UNACCEPTED_TABLE.store(t as *mut _, Ordering::Release);
+        }
+        None => {
+            REFILL_GRANULARITY_BYTES.store(0, Ordering::Release);
+            crate::warn!(
+                "Unaccepted memory table is unavailable, lazy-accept bitmap path will be disabled"
+            );
+        }
+    }
+}
+
+/// Rewrites the EFI-table pointer to the kernel linear mapping after the kernel page table
+/// has been activated.
+///
+/// # Precondition
+///
+/// Must be called **before SMP initialization** while only the bootstrap
+/// processor (BSP) is running.  No concurrent readers of `UNACCEPTED_TABLE`
+/// may exist, because the old physical-address mapping may become invalid
+/// after this call.
+pub(crate) fn remap_table_ptr_after_paging() {
+    let Some(old_ptr) = load_unaccepted_table() else {
+        return;
+    };
+
+    let old_addr = old_ptr.as_ptr().addr();
+    if old_addr < crate::mm::kspace::LINEAR_MAPPING_BASE_VADDR {
+        let new_ptr = crate::mm::kspace::paddr_to_vaddr(old_addr) as *mut EfiUnacceptedMemory;
+        UNACCEPTED_TABLE.store(new_ptr, Ordering::Release);
+        crate::info!(
+            "Remapped unaccepted memory table pointer: {:#x} -> {:#x}",
+            old_addr,
+            new_ptr.addr()
+        );
+    }
+}
+
+/// Initializes unaccepted memory support from the boot-time parsed table pointer.
+pub(super) fn init() {
+    init_accept_mode_from_cmdline();
+
+    if load_unaccepted_table().is_some() {
+        try_eager_accept_memory();
+    } else {
+        crate::warn!("Unaccepted memory table is unavailable; fallback accept path will be used");
+    }
+}
+
+/// Attempts to defer a usable range that overlaps unaccepted memory.
+pub(super) fn try_defer_usable_memory(addr: Paddr, size: usize) -> DeferOutcome {
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) || !is_range_unaccepted(addr, size) {
+        return DeferOutcome::NotUnaccepted;
+    }
+
+    let start = addr.align_up(PAGE_SIZE);
+    let end = addr.saturating_add(size).align_down(PAGE_SIZE);
+    if start >= end {
+        // No page-aligned bytes remain after alignment; nothing to defer.
+        return DeferOutcome::NotUnaccepted;
+    }
+
+    let mut defer_plan = build_defer_plan(start, end);
+
+    // Sort touched segments by index to enforce a global lock ordering and
+    // prevent ABBA deadlocks when concurrent callers touch overlapping segments.
+    defer_plan.touched_segments[..defer_plan.num_touched_segments].sort_unstable();
+
+    let mut segment_guards: [Option<SpinLockGuard<'static, DeferredSegmentState, LocalIrqDisabled>>;
+        SEGMENT_LOCK_COUNT] = core::array::from_fn(|_| None);
+
+    for plan_index in 0..defer_plan.num_touched_segments {
+        let segment_index = defer_plan.touched_segments[plan_index];
+        segment_guards[segment_index] = Some(SEGMENT_STATES[segment_index].lock());
+    }
+
+    for plan_index in 0..defer_plan.num_touched_segments {
+        let segment_index = defer_plan.touched_segments[plan_index];
+        let required = defer_plan.required_range_slots[segment_index];
+        let segment_state = segment_guards[segment_index].as_ref().unwrap();
+        // Account for the fact that push_range may merge with existing
+        // adjacent ranges (costing 0 new slots) rather than always appending.
+        // Only report full when there is no merge headroom at all.
+        let available_slots = segment_state
+            .ranges
+            .len()
+            .saturating_sub(segment_state.num_ranges);
+        if available_slots < required && !segment_state.has_merge_potential() {
+            return DeferOutcome::ReservoirFull;
+        }
+    }
+
+    let mut cursor = start;
+    let mut deferred_bytes = 0usize;
+    while cursor < end {
+        let segment_index = segment_index_of(cursor);
+        let segment_end = segment_boundary_end(cursor).min(end);
+        let chunk_size = segment_end - cursor;
+
+        let segment_state = segment_guards[segment_index].as_mut().unwrap();
+        if segment_state.push_range(cursor, chunk_size).is_err() {
+            // Optimistic precheck was wrong; compact first then retry once.
+            segment_state.compact();
+            if segment_state.push_range(cursor, chunk_size).is_err() {
+                return DeferOutcome::ReservoirFull;
+            }
+        }
+        deferred_bytes = deferred_bytes.saturating_add(chunk_size);
+        cursor = segment_end;
+    }
+
+    for plan_index in 0..defer_plan.num_touched_segments {
+        mark_segment_nonempty(defer_plan.touched_segments[plan_index]);
+    }
+
+    TOTAL_DEFERRED_BYTES.fetch_add(deferred_bytes, Ordering::Relaxed);
+    DeferOutcome::Deferred
+}
+
+/// Tries to refill accepted memory from the deferred unaccepted reservoir.
+pub(super) fn try_refill_for_allocation(layout: core::alloc::Layout) -> Result<bool, AcceptError> {
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+        return Ok(false);
+    }
+
+    let request_bytes = layout
+        .size()
+        .max(layout.align())
+        .align_up(PAGE_SIZE)
+        .max(PAGE_SIZE);
+    let target_chunk_bytes = request_bytes.max(get_refill_granularity_bytes());
+    let refill_budget_bytes = calculate_refill_budget_bytes(target_chunk_bytes);
+
+    let accepted_bytes = refill_deferred_memory(target_chunk_bytes, refill_budget_bytes)?;
+    Ok(accepted_bytes > 0)
+}
+
+/// Accepts memory on demand if the target range is still unaccepted.
+pub(super) fn accept_memory_if_needed(addr: Paddr, size: usize) -> Result<(), AcceptError> {
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    let Some(table_ptr) = load_unaccepted_table() else {
+        return Ok(());
+    };
+
+    let end = addr
+        .checked_add(size)
+        .ok_or(AcceptError::ArithmeticOverflow)?;
+
+    // SAFETY: `table_ptr` is initialized from boot info and points to valid table memory.
+    let table = unsafe { &*table_ptr.as_ptr() };
+
+    // Go through shard locks with in-flight tracking: accept_with_shard_locks
+    // will spin-wait if the target range overlaps a concurrent in-progress
+    // accept, ensuring we only return Ok(()) once the memory is truly accepted.
+    accept_with_shard_locks(table, addr as u64, end as u64)
+}
+
+/// Returns an advisory hint on whether the physical range `[addr, addr + size)`
+/// may still overlap unaccepted memory.
+pub(super) fn is_range_unaccepted(addr: Paddr, size: usize) -> bool {
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+        return false;
+    }
+
+    let Some(table_ptr) = load_unaccepted_table() else {
+        return false;
+    };
+
+    // SAFETY: `table_ptr` is initialized from boot info and points to valid table memory.
+    let table = unsafe { &*table_ptr.as_ptr() };
+    let Some(end) = addr.checked_add(size) else {
+        return true;
+    };
+
+    // Lockless advisory bitmap read only.
+    // Concurrent accept operations can make the bitmap temporarily disagree with
+    // the true usability state of the range, so this check must not be used as a
+    // correctness or safety decision. At most it is a policy hint for deferral /
+    // refill decisions; allocation-time safety is enforced by
+    // `accept_memory_if_needed`.
+    //
+    // SAFETY: `table_ptr` is initialized from boot info, the bitmap memory
+    // is valid, and `is_range_pending` uses atomic reads so it is safe under
+    // concurrent bitmap mutation.
+    unsafe { table.is_range_pending(addr as u64, end as u64) }.unwrap_or(true)
+}
+
+pub(super) fn load_total_unaccepted_bytes() -> usize {
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+        return 0;
+    }
+    TOTAL_UNACCEPTED_BYTES.load(Ordering::Relaxed)
+}
+
+/// Outcome of attempting to defer a usable memory range to the unaccepted reservoir.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeferOutcome {
+    /// The range does not contain unaccepted memory; the caller should add it
+    /// to the frame allocator directly.
+    NotUnaccepted,
+    /// The range was deferred to the reservoir for later acceptance.
+    Deferred,
+    /// The reservoir is full; the caller should add the range to the frame
+    /// allocator directly (on-demand acceptance will handle it).
+    ReservoirFull,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+enum AcceptMemoryMode {
+    #[default]
+    Lazy,
+    Eager,
+}
+
+impl core::str::FromStr for AcceptMemoryMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The cmdline framework normalizes hyphens to underscores, but OSTD
+        // parses before the framework runs, so accept both forms.
+        match s {
+            "lazy" => Ok(AcceptMemoryMode::Lazy),
+            "eager" => Ok(AcceptMemoryMode::Eager),
+            _ => Err(()),
+        }
+    }
+}
+
+fn init_accept_mode_from_cmdline() {
+    let mode = parse_accept_mode_from_cmdline();
+    ACCEPT_MEMORY_MODE.call_once(|| mode);
+
+    match mode {
+        AcceptMemoryMode::Lazy => crate::info!("accept_memory mode: lazy"),
+        AcceptMemoryMode::Eager => crate::info!("accept_memory mode: eager"),
+    }
+}
+
+fn parse_accept_mode_from_cmdline() -> AcceptMemoryMode {
+    let Some(boot_info) = crate::boot::EARLY_INFO.get() else {
+        return AcceptMemoryMode::default();
+    };
+
+    let value = boot_info
+        .kernel_cmdline
+        .split_whitespace()
+        .find(|arg| arg.starts_with("accept_memory="))
+        .and_then(|arg| arg.split_once('='))
+        .map(|(_, value)| value);
+
+    match value {
+        Some(v) => v.parse().unwrap_or_else(|()| {
+            crate::warn!("unknown accept_memory mode '{}', fallback to lazy", v);
+            AcceptMemoryMode::default()
+        }),
+        None => AcceptMemoryMode::default(),
+    }
+}
+
+fn try_eager_accept_memory() {
+    if get_accept_memory_mode() != AcceptMemoryMode::Eager {
+        return;
+    }
+
+    if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+        return;
+    }
+
+    let Some(table_ptr) = load_unaccepted_table() else {
+        crate::warn!("accept_memory=eager requested but unaccepted table is unavailable");
+        return;
+    };
+
+    // SAFETY: `table_ptr` is initialized from boot info and points to valid table memory.
+    let table = unsafe { &*table_ptr.as_ptr() };
+
+    let table_phys_base = table.phys_base();
+
+    let Some(coverage_end) = table.bitmap_coverage_end() else {
+        let table_bitmap_size_bytes = table.bitmap_size_bytes();
+        let table_unit_size_bytes = table.unit_size_bytes();
+
+        crate::error!(
+            "unaccepted bitmap coverage overflow: bitmap_size_bytes={}, unit_size_bytes={}, phys_base={:#x}",
+            table_bitmap_size_bytes,
+            table_unit_size_bytes,
+            table_phys_base
+        );
+        return;
+    };
+
+    crate::early_println!("[kernel] Accepting all unaccepted memory ...");
+
+    if accept_with_shard_locks(table, table_phys_base, coverage_end).is_ok() {
+        // Clear deferred ranges first so that observers who see
+        // `EAGER_ACCEPT_COMPLETED == true` also see an empty reservoir,
+        // maintaining the invariant: completed -> reservoir empty.
+        clear_deferred_ranges();
+        EAGER_ACCEPT_COMPLETED.store(true, Ordering::Release);
+        crate::info!(
+            "accept_memory=eager completed: accepted bitmap coverage [{:#x}, {:#x})",
+            table_phys_base,
+            coverage_end
+        );
+    } else {
+        crate::error!(
+            "accept_memory=eager failed: range=[{:#x}, {:#x})",
+            table_phys_base,
+            coverage_end
+        );
+    }
+}
+
+/// Accepts a GPA range using shard-level locking for multi-CPU parallelism.
+///
+/// Uses a **claim → accept → complete** pattern with per-shard in-flight
+/// tracking to avoid holding IRQ-disabled locks during the slow TDX TDCALL
+/// operations while correctly distinguishing "accepted" from "in-progress":
+///
+/// 1. **Claim** (shard lock held, IRQs disabled — brief): scan bitmap for the
+///    next contiguous run of pending bits, clear them, and register the run in
+///    the shard's in-flight list.
+/// 2. **Accept** (no lock, IRQs enabled — slow): perform TDX acceptance.
+/// 3. **Complete** (shard lock held — brief): remove from in-flight list.
+///    On error, additionally restore the bitmap bits (rollback).
+///
+/// Concurrent callers that see bitmap bits already cleared will check the
+/// in-flight list: if the range overlaps an in-flight entry, they spin-wait
+/// until the accepting CPU completes, ensuring no caller returns `Ok(())`
+/// for memory that is still mid-accept.
+fn accept_with_shard_locks(
+    table: &EfiUnacceptedMemory,
+    start: u64,
+    end: u64,
+) -> Result<(), AcceptError> {
+    if start >= end {
+        return Ok(());
+    }
+
+    let mut cursor = start;
+    let mut retry_count = 0u32;
+    while cursor < end {
+        let shard_index = bitmap_shard_index(cursor);
+        let shard_end = bitmap_shard_boundary_end(cursor).min(end);
+
+        // Phase 1: Under shard lock — claim one pending run and register it
+        // as in-flight so concurrent callers can distinguish "accepted" from
+        // "in-progress".
+        let mut retry = false;
+        let claimed = {
+            let mut shard = BITMAP_SHARD_LOCKS[shard_index].lock();
+            if shard.num_inflight >= MAX_INFLIGHT_PER_SHARD {
+                retry = true;
+                None
+            } else {
+                // SAFETY: Shard lock guarantees exclusive access to this bitmap region.
+                let run = unsafe { table.claim_next_pending_run(cursor, shard_end)? };
+                if let Some((rs, re)) = run {
+                    debug_assert!(
+                        rs >= cursor && re <= shard_end && rs < re,
+                        "claim_next_pending_run returned out-of-bounds run: \
+                         cursor={:#x}, shard_end={:#x}, run=[{:#x}, {:#x})",
+                        cursor,
+                        shard_end,
+                        rs,
+                        re
+                    );
+                    if rs > cursor && shard.has_inflight_overlap(cursor, rs) {
+                        // SAFETY: Shard lock guarantees exclusive access.
+                        let _ = unsafe { table.restore_pending_range(rs, re) };
+                        retry = true;
+                        None
+                    } else {
+                        shard.add_inflight(rs, re);
+                        Some((rs, re))
+                    }
+                } else {
+                    None
+                }
+            }
+        };
+
+        if retry {
+            retry_count += 1;
+            for _ in 0..(1u32 << retry_count.min(6)) {
+                core::hint::spin_loop();
+            }
+            continue;
+        }
+        retry_count = 0;
+
+        let Some((run_start, run_end)) = claimed else {
+            let has_overlap = {
+                let shard = BITMAP_SHARD_LOCKS[shard_index].lock();
+                shard.has_inflight_overlap(cursor, shard_end)
+            };
+            if has_overlap {
+                retry_count += 1;
+                for _ in 0..(1u32 << retry_count.min(6)) {
+                    core::hint::spin_loop();
+                }
+                continue;
+            }
+            // No pending and no in-flight: range is truly accepted.
+            cursor = shard_end;
+            continue;
+        };
+
+        // Phase 2: Perform the slow TDX accept with IRQs enabled.
+        // SAFETY: The claimed range is exclusively ours (bits cleared + inflight).
+        let accept_result = unsafe { accept_memory(run_start, run_end) };
+
+        // Phase 3: Under shard lock — remove from in-flight, rollback on error.
+        {
+            let mut shard = BITMAP_SHARD_LOCKS[shard_index].lock();
+            shard.remove_inflight(run_start, run_end);
+            if accept_result.is_err() {
+                // SAFETY: Shard lock guarantees exclusive access.
+                let _ = unsafe { table.restore_pending_range(run_start, run_end) };
+            }
+        }
+
+        match accept_result {
+            Ok(()) => {
+                let accepted_bytes = (run_end - run_start) as usize;
+                TOTAL_UNACCEPTED_BYTES.fetch_sub(accepted_bytes, Ordering::Relaxed);
+                cursor = run_end;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(())
+}
+
+fn refill_deferred_memory(
+    target_chunk_bytes: usize,
+    refill_budget_bytes: usize,
+) -> Result<usize, AcceptError> {
+    let mut accepted_total = 0usize;
+    let mut remaining_budget_bytes = refill_budget_bytes.max(PAGE_SIZE);
+    let base_seed = current_cpu_segment_seed();
+
+    while remaining_budget_bytes >= PAGE_SIZE {
+        if EAGER_ACCEPT_COMPLETED.load(Ordering::Acquire) {
+            return Ok(accepted_total);
+        }
+
+        // Vary the seed across iterations so successive reserves within the
+        // same refill call spread across different segments.
+        let seed = (base_seed + accepted_total / PAGE_SIZE) % SEGMENT_LOCK_COUNT;
+
+        let desired_chunk_bytes = target_chunk_bytes
+            .min(remaining_budget_bytes)
+            .max(PAGE_SIZE)
+            .align_up(PAGE_SIZE);
+
+        let Some((segment_index, chunk_addr, chunk_len)) =
+            reserve_deferred_chunk(seed, desired_chunk_bytes)
+        else {
+            return Ok(accepted_total);
+        };
+
+        match accept_chunk_via_bitmap_table(chunk_addr, chunk_len) {
+            Ok(()) => {
+                TOTAL_DEFERRED_BYTES.fetch_sub(chunk_len, Ordering::Relaxed);
+                super::allocator::get_global_frame_allocator()
+                    .add_free_memory(chunk_addr, chunk_len);
+                accepted_total = accepted_total.saturating_add(chunk_len);
+                remaining_budget_bytes = remaining_budget_bytes.saturating_sub(chunk_len);
+            }
+            Err(err) => {
+                return_deferred_chunk(segment_index, chunk_addr, chunk_len);
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(accepted_total)
+}
+
+fn build_defer_plan(start: Paddr, end: Paddr) -> DeferPlan {
+    let mut required_range_slots = [0; SEGMENT_LOCK_COUNT];
+    let mut touched_segments = [0; SEGMENT_LOCK_COUNT];
+    let mut num_touched_segments = 0;
+    let mut cursor = start;
+
+    while cursor < end {
+        let segment_index = segment_index_of(cursor);
+        if required_range_slots[segment_index] == 0 {
+            touched_segments[num_touched_segments] = segment_index;
+            num_touched_segments += 1;
+        }
+        required_range_slots[segment_index] += 1;
+        cursor = segment_boundary_end(cursor).min(end);
+    }
+
+    DeferPlan {
+        required_range_slots,
+        touched_segments,
+        num_touched_segments,
+    }
+}
+
+fn accept_chunk_via_bitmap_table(addr: Paddr, len: usize) -> Result<(), AcceptError> {
+    let Some(table_ptr) = load_unaccepted_table() else {
+        return Ok(());
+    };
+
+    let end = addr
+        .checked_add(len)
+        .ok_or(AcceptError::ArithmeticOverflow)?;
+
+    // SAFETY: `table_ptr` is initialized from boot info and points to valid table memory.
+    let table = unsafe { &*table_ptr.as_ptr() };
+
+    accept_with_shard_locks(table, addr as u64, end as u64)
+}
+
+fn reserve_deferred_chunk(seed: usize, desired_chunk: usize) -> Option<(usize, Paddr, usize)> {
+    let nonempty_hint = NONEMPTY_SEGMENT_HINT_BITMAP.load(Ordering::Acquire);
+    if nonempty_hint == 0 {
+        return None;
+    }
+
+    for offset in 0..SEGMENT_LOCK_COUNT {
+        let segment_index = (seed + offset) % SEGMENT_LOCK_COUNT;
+        if !is_segment_marked_nonempty(nonempty_hint, segment_index) {
+            continue;
+        }
+
+        let mut segment_state = SEGMENT_STATES[segment_index].lock();
+        if let Some((addr, len)) = segment_state.pop_chunk(desired_chunk) {
+            if segment_state.num_ranges == 0 {
+                mark_segment_empty(segment_index);
+            }
+            return Some((segment_index, addr, len));
+        }
+
+        mark_segment_empty(segment_index);
+    }
+
+    None
+}
+
+fn return_deferred_chunk(segment_index: usize, addr: Paddr, size: usize) {
+    let mut segment_state = SEGMENT_STATES[segment_index].lock();
+    if segment_state.push_range(addr, size).is_err() {
+        segment_state.compact();
+        if segment_state.push_range(addr, size).is_err() {
+            // Reservoir full even after compaction — drop the chunk.
+            // The memory remains pending in the bitmap (bits were restored
+            // by accept_with_shard_locks), so on-demand accept will handle
+            // it.  Adjust TOTAL_DEFERRED_BYTES to keep the counter accurate.
+            TOTAL_DEFERRED_BYTES.fetch_sub(size, Ordering::Relaxed);
+            crate::warn!(
+                "reservoir rollback overflow: segment={}, addr={:#x}, size={:#x}; \
+                 chunk dropped from reservoir",
+                segment_index,
+                addr,
+                size
+            );
+            return;
+        }
+    }
+    mark_segment_nonempty(segment_index);
+}
+
+fn clear_deferred_ranges() {
+    for segment in SEGMENT_STATES.iter().take(SEGMENT_LOCK_COUNT) {
+        let mut segment_state = segment.lock();
+        segment_state.clear();
+    }
+    NONEMPTY_SEGMENT_HINT_BITMAP.store(0, Ordering::Release);
+    TOTAL_DEFERRED_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn calculate_refill_budget_bytes(target_chunk_bytes: usize) -> usize {
+    let extra_budget_bytes =
+        target_chunk_bytes.clamp(MIN_REFILL_EXTRA_BUDGET_BYTES, MAX_REFILL_EXTRA_BUDGET_BYTES);
+    target_chunk_bytes.saturating_add(extra_budget_bytes)
+}
+
+fn get_refill_granularity_bytes() -> usize {
+    let cached = REFILL_GRANULARITY_BYTES.load(Ordering::Acquire);
+    if cached != 0 {
+        return cached;
+    }
+
+    let Some(table_ptr) = load_unaccepted_table() else {
+        return PAGE_SIZE;
+    };
+
+    // SAFETY: `table_ptr` is initialized from boot info and points to valid table memory.
+    let table = unsafe { &*table_ptr.as_ptr() };
+    let granularity = usize::try_from(u64::from(table.unit_size_bytes()))
+        .ok()
+        .map(|bytes| bytes.max(PAGE_SIZE).align_up(PAGE_SIZE))
+        .unwrap_or(PAGE_SIZE);
+    REFILL_GRANULARITY_BYTES.store(granularity, Ordering::Release);
+    granularity
+}
+
+/// Returns a per-CPU seed for distributing segment accesses.
+///
+/// Uses the current CPU ID (racy but sufficient for load distribution) to avoid
+/// contention on a single global atomic counter under high-concurrency refill.
+fn current_cpu_segment_seed() -> usize {
+    u32::from(crate::cpu::CpuId::current_racy()) as usize
+}
+
+fn is_reservoir_empty() -> bool {
+    NONEMPTY_SEGMENT_HINT_BITMAP.load(Ordering::Acquire) == 0
+        && TOTAL_DEFERRED_BYTES.load(Ordering::Relaxed) == 0
+}
+
+fn load_unaccepted_table() -> Option<NonNull<EfiUnacceptedMemory>> {
+    NonNull::new(UNACCEPTED_TABLE.load(Ordering::Acquire))
+}
+
+fn get_accept_memory_mode() -> AcceptMemoryMode {
+    ACCEPT_MEMORY_MODE.get().copied().unwrap_or_default()
+}
+
+fn is_segment_marked_nonempty(nonempty_hint: u64, segment_index: usize) -> bool {
+    debug_assert!(segment_index < SEGMENT_LOCK_COUNT);
+    (nonempty_hint & segment_mask(segment_index)) != 0
+}
+
+fn mark_segment_nonempty(segment_index: usize) {
+    NONEMPTY_SEGMENT_HINT_BITMAP.fetch_or(segment_mask(segment_index), Ordering::Release);
+}
+
+fn mark_segment_empty(segment_index: usize) {
+    NONEMPTY_SEGMENT_HINT_BITMAP.fetch_and(!segment_mask(segment_index), Ordering::Release);
+}
+
+const fn segment_mask(segment_index: usize) -> u64 {
+    1u64 << segment_index
+}
+
+fn bitmap_shard_index(addr: u64) -> usize {
+    (addr as usize / SEGMENT_BYTES) % SEGMENT_LOCK_COUNT
+}
+
+fn bitmap_shard_boundary_end(addr: u64) -> u64 {
+    let shard_start = (addr / SEGMENT_BYTES as u64) * SEGMENT_BYTES as u64;
+    shard_start.saturating_add(SEGMENT_BYTES as u64)
+}
+
+fn segment_index_of(addr: Paddr) -> usize {
+    (addr / SEGMENT_BYTES) % SEGMENT_LOCK_COUNT
+}
+
+fn segment_boundary_end(addr: Paddr) -> Paddr {
+    let segment_start = (addr / SEGMENT_BYTES) * SEGMENT_BYTES;
+    segment_start.saturating_add(SEGMENT_BYTES)
+}
+
+struct DeferPlan {
+    required_range_slots: [usize; SEGMENT_LOCK_COUNT],
+    touched_segments: [usize; SEGMENT_LOCK_COUNT],
+    num_touched_segments: usize,
+}
+
+struct DeferredSegmentState {
+    ranges: [DeferredRange; MAX_DEFERRED_RANGES],
+    num_ranges: usize,
+    /// Round-robin cursor for `pop_chunk` to avoid always scanning from index 0.
+    pop_cursor: usize,
+}
+
+impl DeferredSegmentState {
+    const fn new() -> Self {
+        Self {
+            ranges: [DeferredRange::EMPTY; MAX_DEFERRED_RANGES],
+            num_ranges: 0,
+            pop_cursor: 0,
+        }
+    }
+
+    fn has_merge_potential(&self) -> bool {
+        self.num_ranges >= 1
+    }
+
+    fn push_range(&mut self, addr: Paddr, size: usize) -> Result<(), ReservoirFull> {
+        let start = addr.align_up(PAGE_SIZE);
+        let end = addr.saturating_add(size).align_down(PAGE_SIZE);
+        if start >= end {
+            return Ok(());
+        }
+
+        // Try to merge with an existing adjacent range before appending.
+        for index in 0..self.num_ranges {
+            let r = &mut self.ranges[index];
+            if r.end == start {
+                r.end = end;
+                return Ok(());
+            }
+            if end == r.start {
+                r.start = start;
+                return Ok(());
+            }
+        }
+
+        // Compact when num_ranges exceeds 3/4 capacity to curb fragmentation.
+        if self.num_ranges >= self.ranges.len() * 3 / 4 {
+            self.compact();
+        }
+
+        if self.num_ranges >= self.ranges.len() {
+            return Err(ReservoirFull);
+        }
+
+        self.ranges[self.num_ranges] = DeferredRange { start, end };
+        self.num_ranges += 1;
+        Ok(())
+    }
+
+    /// Sorts ranges by start address and merges adjacent/overlapping entries.
+    fn compact(&mut self) {
+        if self.num_ranges <= 1 {
+            return;
+        }
+
+        // Introsort: O(n log n) worst case, no allocation, available in core.
+        self.ranges[..self.num_ranges].sort_unstable_by_key(|r| r.start);
+
+        // Merge adjacent/overlapping ranges in place.
+        let mut write = 0;
+        for read in 1..self.num_ranges {
+            if self.ranges[read].start <= self.ranges[write].end {
+                // Overlapping or adjacent — extend the current range.
+                if self.ranges[read].end > self.ranges[write].end {
+                    self.ranges[write].end = self.ranges[read].end;
+                }
+            } else {
+                write += 1;
+                self.ranges[write] = self.ranges[read];
+            }
+        }
+        let new_len = write + 1;
+
+        // Clear stale tail entries.
+        for i in new_len..self.num_ranges {
+            self.ranges[i] = DeferredRange::EMPTY;
+        }
+        self.num_ranges = new_len;
+    }
+
+    fn pop_chunk(&mut self, target_len: usize) -> Option<(Paddr, usize)> {
+        let aligned_target = target_len.max(PAGE_SIZE).align_up(PAGE_SIZE);
+        let start_cursor = self.pop_cursor.min(self.num_ranges.saturating_sub(1));
+        for offset in 0..self.num_ranges {
+            let index = (start_cursor + offset) % self.num_ranges;
+            let range = self.ranges[index];
+            if range.is_empty() {
+                continue;
+            }
+
+            let chunk_len = range.len().min(aligned_target).align_down(PAGE_SIZE);
+            if chunk_len >= PAGE_SIZE {
+                let start = range.start;
+                self.ranges[index].start = self.ranges[index].start.saturating_add(chunk_len);
+                if self.ranges[index].is_empty() {
+                    self.remove_range(index);
+                }
+                self.pop_cursor = index.wrapping_add(1);
+                return Some((start, chunk_len));
+            }
+        }
+
+        None
+    }
+
+    fn remove_range(&mut self, index: usize) {
+        debug_assert!(index < self.num_ranges);
+        self.num_ranges -= 1;
+        self.ranges[index] = self.ranges[self.num_ranges];
+        self.ranges[self.num_ranges] = DeferredRange::EMPTY;
+    }
+
+    fn clear(&mut self) {
+        self.num_ranges = 0;
+        self.pop_cursor = 0;
+        self.ranges.fill(DeferredRange::EMPTY);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DeferredRange {
+    start: Paddr,
+    end: Paddr,
+}
+
+impl DeferredRange {
+    const EMPTY: Self = Self { start: 0, end: 0 };
+
+    const fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    const fn is_empty(self) -> bool {
+        self.start >= self.end
+    }
+}
+
+/// Per-shard state tracking ranges currently being accepted (in-flight).
+///
+/// Protected by the corresponding shard's [`SpinLock`].  This allows
+/// concurrent callers to distinguish bitmap bit 0 meaning "accepted"
+/// from "claimed/in-progress", preventing premature use of unaccepted memory.
+struct ShardState {
+    inflight: [(u64, u64); MAX_INFLIGHT_PER_SHARD],
+    num_inflight: usize,
+}
+
+impl ShardState {
+    const fn new() -> Self {
+        Self {
+            inflight: [(0, 0); MAX_INFLIGHT_PER_SHARD],
+            num_inflight: 0,
+        }
+    }
+
+    fn add_inflight(&mut self, start: u64, end: u64) {
+        debug_assert!(self.num_inflight < MAX_INFLIGHT_PER_SHARD);
+        self.inflight[self.num_inflight] = (start, end);
+        self.num_inflight += 1;
+    }
+
+    fn remove_inflight(&mut self, start: u64, end: u64) {
+        for i in 0..self.num_inflight {
+            if self.inflight[i] == (start, end) {
+                self.num_inflight -= 1;
+                self.inflight[i] = self.inflight[self.num_inflight];
+                self.inflight[self.num_inflight] = (0, 0);
+                return;
+            }
+        }
+        debug_assert!(
+            false,
+            "remove_inflight: entry ({:#x}, {:#x}) not found",
+            start, end
+        );
+    }
+
+    fn has_inflight_overlap(&self, start: u64, end: u64) -> bool {
+        for i in 0..self.num_inflight {
+            let (rs, re) = self.inflight[i];
+            if rs < end && re > start {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Error returned when a segment's deferred-range array is full.
+#[derive(Debug)]
+struct ReservoirFull;
+
+// Maximum number of deferred (unaccepted) memory ranges tracked per deferred segment.
+// This bounds fragmentation tolerance.
+// In typical EFI firmware setups, the actual number of ranges
+// is expected to be very small (often < 10). Larger values only matter
+// if firmware reports heavily fragmented unaccepted memory.
+const MAX_DEFERRED_RANGES: usize = 512;
+
+// Maximum number of concurrent in-flight accept operations per bitmap shard.
+const MAX_INFLIGHT_PER_SHARD: usize = 8;
+
+// Number of deferred-memory segments and the matching lock / hint-bitmap slots.
+const SEGMENT_LOCK_COUNT: usize = 64;
+// Physical address span covered by one deferred segment and one bitmap shard.
+const SEGMENT_BYTES: usize = 256 * 1024 * 1024;
+
+const MIN_REFILL_EXTRA_BUDGET_BYTES: usize = 16 * 1024 * 1024;
+const MAX_REFILL_EXTRA_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+
+static UNACCEPTED_TABLE: AtomicPtr<EfiUnacceptedMemory> = AtomicPtr::new(core::ptr::null_mut());
+static ACCEPT_MEMORY_MODE: Once<AcceptMemoryMode> = Once::new();
+static EAGER_ACCEPT_COMPLETED: AtomicBool = AtomicBool::new(false);
+
+static TOTAL_UNACCEPTED_BYTES: AtomicUsize = AtomicUsize::new(0);
+static REFILL_GRANULARITY_BYTES: AtomicUsize = AtomicUsize::new(0);
+/// Tracks the number of bytes currently stored in the deferred reservoir.
+static TOTAL_DEFERRED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Per-shard state that protects the unaccepted bitmap region and tracks
+/// in-flight accept operations.  Each shard covers `SEGMENT_BYTES` of
+/// physical address space, matching the deferred-range segment granularity.
+static BITMAP_SHARD_LOCKS: [SpinLock<ShardState, LocalIrqDisabled>; SEGMENT_LOCK_COUNT] =
+    [const { SpinLock::new(ShardState::new()) }; SEGMENT_LOCK_COUNT];
+static SEGMENT_STATES: [SpinLock<DeferredSegmentState, LocalIrqDisabled>; SEGMENT_LOCK_COUNT] =
+    [const { SpinLock::new(DeferredSegmentState::new()) }; SEGMENT_LOCK_COUNT];
+/// Bit-per-segment hint bitmap used to skip obviously empty deferred segments.
+static NONEMPTY_SEGMENT_HINT_BITMAP: AtomicU64 = AtomicU64::new(0);


### PR DESCRIPTION
# Background and Goal

Background from Linux implementation: 

> UEFI Specification version 2.9 introduces the concept of memory acceptance: some Virtual Machine platforms, such as Intel TDX or AMD SEV-SNP, requiring memory to be accepted before it can be used by the guest. Accepting happens via a protocol specific for the Virtual Machine platform.
> Accepting memory is costly and it makes VMM allocate memory for the accepted guest physical address range. It's better to postpone memory acceptance until memory is needed. It lowers boot time and reduces memory overhead.
> There are several ways kernel can deal with unaccepted memory:
> 1. Accept all the memory during the boot. It is easy to implement and it doesn't have runtime cost once the system is booted. The downside is very long boot time. Accept can be parallelized to multiple CPUs to keep it manageable (i.e. via DEFERRED_STRUCT_PAGE_INIT), but it tends to saturate memory bandwidth and does not scale beyond the point.
> 2. Accept a block of memory on the first use. It requires more infrastructure and changes in page allocator to make it work, but it provides good boot time. On-demand memory accept means latency spikes every time kernel steps onto a new memory block. The spikes will go away once workload data set size gets stabilized or all memory gets accepted.
> 3. Accept all memory in background. Introduce a thread (or multiple) that gets memory accepted proactively. It will minimize time the system experience latency spikes on memory allocation while keeping low boot time. This approach cannot function on its own. It is an extension of 2: background memory acceptance requires functional scheduler, but the page allocator may need to tap into unaccepted memory before that. The downside of the approach is that these threads also steal CPU cycles and memory bandwidth from the user's workload and may hurt user experience.
> Linux implement 1 and 2 for now. 2 is the default. Some workloads may want to use 1 with `accept_memory=eager` in kernel command line.

Currently, Asterinas handles unaccepted memory by calling TDCALL during the EFI stub phase to accept all unaccepted memory at once. This is similar to Solution 1 in Linux, which, while simple enough, significantly increases boot time, and not all pages may be used during the OS's lifetime.

To shorten boot time and optimize resource utilization, this PR, referencing the Linux implementation, adds on-demand accept functionality (Solution 2 in Linux) and accept all memory in background(Solution 3 not implemented in Linux) for dynamically accepting this type of memory.

# Implementation overview

The implementation follows a two-stage model:

EFI stub stage:
- Build an “unaccepted memory bitmap” from firmware memory map.
- Only accept memory required for boundary cases and for booting the kernel image.
- Publish bitmap header and metadata via EFI config table.

Kernel stage:
- Parse and import the bitmap table.
- In early frame allocators, accept physical memory through bitmap information.
- Create `UNACCEPTED_POOL` in the frame-allocator crate to manage unaccepted memory in physical memory.
- On each physical allocation path, accept memory only if bitmap says the range is still unaccepted.
- Provide the size of currently unaccepted mem in `proc/meminfo`.
- Run a background accept worker to accept all unaccepted memory if `lazy-background` mode is configured.

To support the above features, the `EfiUnacceptedMemory` structure and related abstractions (similar to `struct efi_unaccepted_memory` in Linux) and efficient bitmap management have been added to the `tdx-guest` crate.

Users can control the acceptance policy for unacceptable memory by adding `accept_memory=$(ACCEPT_MEMORY_MODE)` to the kernel command line or by adding the `ACCEPT_MEMORY_MODE` parameter (`eager` or `lazy` or `lazy-background`) to the `make run_kernel INTEL_TDX=1` command line. And the `lazy` is the default mode.

The current amount of unaccepted memory can be queried via `/proc/meminfo`.

# Limitation

- Better watermark control strategies.
- Better background acceptance strategies.
- SMP support and stability testing
- No KASLR(kernel address space layout randomization)-driven acceptance policy (Asterinas has no KASLR).
- No `kexec` acceptance policy (Asterinas does not currently support the kexec feature).
- Get unaccepted page num from `vmstat` info (Asterinas does not currently support this virtual file system).
