### PR TITLE
Fix dentry cache inconsistency on failed `rmdir`

### DIFF
--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -358,22 +358,24 @@ impl DirDentry<'_> {
         children.check_mountpoint(name)?;
 
         let mut children = children.upgrade();
-        let cached_child = children.delete(name);
-
         let dir_inode = &self.inode;
-        let child_inode = match cached_child {
-            Some(child) => {
-                // Cache hit: use the cached dentry
-                child.inode().clone()
-            }
-            None => {
-                // Cache miss: need to lookup from the underlying filesystem
-                drop(children);
-                dir_inode.lookup(name)?
-            }
+
+        let child_inode = if let Some(cached_dentry) = children.entry(name)? {
+            let child_inode = cached_dentry.inode().clone();
+
+            dir_inode.unlink(name)?;
+            children.delete(name);
+
+            child_inode
+        } else {
+            // Cache miss: need to lookup from the underlying filesystem
+            let child_inode = dir_inode.lookup(name)?;
+            dir_inode.unlink(name)?;
+
+            child_inode
         };
 
-        dir_inode.unlink(name)?;
+        drop(children);
 
         let nlinks = child_inode.metadata().nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
@@ -409,22 +411,24 @@ impl DirDentry<'_> {
         children.check_mountpoint(name)?;
 
         let mut children = children.upgrade();
-        let cached_child = children.delete(name);
-
         let dir_inode = &self.inode;
-        let child_inode = match cached_child {
-            Some(child) => {
-                // Cache hit: use the cached dentry
-                child.inode().clone()
-            }
-            None => {
-                // Cache miss: need to lookup from the underlying filesystem
-                drop(children);
-                dir_inode.lookup(name)?
-            }
+
+        let child_inode = if let Some(cached_dentry) = children.entry(name)? {
+            let child_inode = cached_dentry.inode().clone();
+
+            dir_inode.rmdir(name)?;
+            children.delete(name);
+
+            child_inode
+        } else {
+            // Cache miss: need to lookup from the underlying filesystem
+            let child_inode = dir_inode.lookup(name)?;
+            dir_inode.rmdir(name)?;
+
+            child_inode
         };
 
-        dir_inode.rmdir(name)?;
+        drop(children);
 
         let nlinks = child_inode.metadata().nr_hard_links;
         if nlinks == 0 {
@@ -621,6 +625,20 @@ impl DentryChildren {
     /// Deletes a dentry by name, turning it into a negative entry if exists.
     fn delete(&mut self, name: &str) -> Option<Arc<Dentry>> {
         self.dentries.get_mut(name).and_then(Option::take)
+    }
+
+    /// Probes the corresponding cache entry by name.
+    ///
+    /// Returns:
+    /// - `Ok(Some(entry))` for a valid dentry,
+    /// - `Ok(None)` for cache miss,
+    /// - `Err(ENOENT)` for a negative dentry.
+    fn entry(&self, name: &str) -> Result<Option<Arc<Dentry>>> {
+        match self.dentries.get(name) {
+            Some(Some(dentry)) => Ok(Some(dentry.clone())),
+            Some(None) => return_errno_with_message!(Errno::ENOENT, "found a negative dentry"),
+            None => Ok(None),
+        }
     }
 
     /// Checks whether the dentry is a mount point. Returns an error if it is.

--- a/test/initramfs/src/apps/fs/ext2/rmdir.c
+++ b/test/initramfs/src/apps/fs/ext2/rmdir.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define NON_EMPTY_DIR "/test_non_empty_dir"
+#define NON_EMPTY_CHILD "/test_non_empty_dir/test.txt"
+
+static void remove_file_if_exists(const char *path)
+{
+	if (unlink(path) == -1 && errno != ENOENT) {
+		fprintf(stderr, "cleanup failed: unlink(%s): %s\n", path,
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void remove_dir_if_exists(const char *path)
+{
+	if (rmdir(path) == -1 && errno != ENOENT) {
+		fprintf(stderr, "cleanup failed: rmdir(%s): %s\n", path,
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+
+FN_TEST(rmdir_failed_non_empty_dir)
+{
+	remove_file_if_exists(NON_EMPTY_CHILD);
+	remove_dir_if_exists(NON_EMPTY_DIR);
+
+	TEST_SUCC(mkdir(NON_EMPTY_DIR, 0777));
+	TEST_SUCC(open(NON_EMPTY_CHILD, O_CREAT | O_WRONLY, 0666));
+
+	TEST_ERRNO(rmdir(NON_EMPTY_DIR), ENOTEMPTY);
+
+	TEST_SUCC(unlink(NON_EMPTY_CHILD));
+	TEST_SUCC(rmdir(NON_EMPTY_DIR));
+}
+END_TEST()
+
+FN_TEST(unlink_failed_on_directory)
+{
+	remove_dir_if_exists(NON_EMPTY_DIR);
+
+	TEST_SUCC(mkdir(NON_EMPTY_DIR, 0777));
+	TEST_ERRNO(unlink(NON_EMPTY_DIR), EISDIR);
+
+	TEST_SUCC(rmdir(NON_EMPTY_DIR));
+}
+END_TEST()

--- a/test/initramfs/src/apps/fs/run_test.sh
+++ b/test/initramfs/src/apps/fs/run_test.sh
@@ -88,6 +88,7 @@ test_mount_bind_file() {
 echo "Start ext2 fs test......"
 test_ext2 "/ext2" "test_file.txt"
 ./ext2/mknod
+./ext2/rmdir
 ./ext2/unix_socket
 echo "All ext2 fs test passed."
 


### PR DESCRIPTION
Closes https://github.com/asterinas/asterinas/issues/3015

Currently, the DirDentry implementation removes a child entry from the dentry cache (via children.delete(name)) before attempting the actual filesystem operation (unlink or rmdir). If the underlying filesystem operation fails (for example, attempting to rmdir a non-empty directory), the child remains deleted from the cache.

This results in a cache inconsistency where subsequent lookups for the existing file/directory might result in a "Not Found" error or hit a negative dentry, even though the inode still exists on the storage.

This PR ensures that the children dentry remains populated if the rmdir (specifically for non-empty directories) or unlink returns an error.