### PR TITLE
Add JDK test on Asterinas NixOS

### DIFF
--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -103,6 +103,7 @@ jobs:
               { "name": "development-tools", "disk_size": 10240, "timeout_minutes": 45 },
               { "name": "development-tools-go", "disk_size": 8192, "timeout_minutes": 60 },
               { "name": "development-tools-python", "disk_size": 8192, "timeout_minutes": 60 },
+              { "name": "development-tools-openjdk", "disk_size": 8192, "timeout_minutes": 60 },
               { "name": "cicd-and-devops", "disk_size": 8192, "timeout_minutes": 45 },
               { "name": "monitoring-and-observability", "disk_size": 8192 },
               { "name": "web-browsers", "disk_size": 8192 },

--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@ typ = "typ"
 sigfault = "sigfault"
 sems = "sems"
 THRE = "THRE"
+TestNG = "TestNG"
 
 # Files with svg suffix are ignored to check. 
 [type.svg]

--- a/distro/aster_nixos_installer/templates/aster_configuration.nix
+++ b/distro/aster_nixos_installer/templates/aster_configuration.nix
@@ -36,6 +36,7 @@
     (import ./overlays/podman/default.nix)
     (import ./overlays/switch-to-configuration-ng/default.nix)
     (import ./overlays/systemd/default.nix)
+    (import ./overlays/jtreg/default.nix)
   ];
 
   # The Asterinas NixOS special options.

--- a/distro/cachix/default.nix
+++ b/distro/cachix/default.nix
@@ -16,6 +16,7 @@ let
       podman
       podman.man
       aster_systemd
+      jtreg
     ] ++ (with nixos.config; [
       system.build.toplevel
       systemd.package

--- a/distro/etc_nixos/overlays/jtreg/0001-Make-jtreg-use-tools-from-PATH.patch
+++ b/distro/etc_nixos/overlays/jtreg/0001-Make-jtreg-use-tools-from-PATH.patch
@@ -1,0 +1,150 @@
+From 7a8bc3c2d55f1bc4a4b472a4de2ac6d9d7690001 Mon Sep 17 00:00:00 2001
+From: Qingsong Chen <changxian.cqs@antgroup.com>
+Date: Mon, 2 Mar 2026 03:26:07 +0000
+Subject: [PATCH 1/2] Make jtreg use tools from PATH
+
+`jtreg` hardcodes many helper tools as `/bin/*` or `/usr/bin/*`. Those
+paths do not exist in the Nix build sandbox, so the build fails before
+it can produce the image. Use tool names instead and rely on `PATH`,
+which the Nix build environment already populates.
+---
+ make/Defs.gmk  | 80 +++++++++++++++++++++++---------------------------
+ make/Rules.gmk |  2 +-
+ make/jtreg.gmk |  2 +-
+ 3 files changed, 39 insertions(+), 45 deletions(-)
+
+diff --git a/make/Defs.gmk b/make/Defs.gmk
+index 9089e9c7d..b37c5ffd4 100644
+--- a/make/Defs.gmk
++++ b/make/Defs.gmk
+@@ -134,49 +134,31 @@ REGTEST_TOOL_JAVAC_OPTIONS = \
+ 
+ #----- Unix commands
+ 
+-AWK     = /usr/bin/awk
+-CAT 	= /bin/cat
+-CHMOD 	= /bin/chmod
+-CP 	= /bin/cp
+-DIFF 	= /usr/bin/diff
+-ECHO	= /bin/echo
+-FIND	= /usr/bin/find
+-GREP 	:= $(shell if [ -r /bin/grep ]; then echo /bin/grep ; else echo /usr/bin/grep ; fi )
+-LN	= /bin/ln
+-LS	= /bin/ls
+-MKDIR 	= /bin/mkdir
+-MV 	= /bin/mv
+-PANDOC  := $(shell if [ -r /usr/bin/pandoc ]; then \
+-		echo /usr/bin/pandoc ; \
+-	elif [ -r /usr/local/bin/pandoc ]; then \
+-		echo /usr/local/bin/pandoc ; \
+-	elif [ -r /opt/homebrew/bin/tidy ]; then \
+-		echo /opt/homebrew/bin/pandoc ; \
+-	else \
+-		echo /bin/echo "pandoc not available" ; \
+-	fi )
+-PERL	= /usr/bin/perl
+-PRINTF  = /usr/bin/printf
+-RM 	= /bin/rm -rf
+-SED 	:= $(shell if [ -r /bin/sed ]; then echo /bin/sed ; else echo /usr/bin/sed ; fi )
+-SH 	= /bin/sh
+-SORT    = /usr/bin/sort
+-TEST 	= /usr/bin/test
+-ifeq ($(SYSTEM_UNAME), Darwin)
+-TIDY 	:= $(shell if [ -r /usr/local/bin/tidy ]; then \
+-		echo /usr/local/bin/tidy ; \
+-	elif [ -r /opt/homebrew/bin/tidy ]; then \
+-		echo /opt/homebrew/bin/tidy ; \
+-	else \
+-		echo /usr/bin/tidy ; \
+-	fi )
+-else
+-TIDY	= /usr/bin/tidy
+-endif
+-TOUCH 	= /usr/bin/touch
+-UNZIP 	= /usr/bin/unzip
+-WC 	= /usr/bin/wc
+-ZIP 	= /usr/bin/zip
++AWK     = awk
++CAT 	= cat
++CHMOD 	= chmod
++CP 	= cp
++DIFF 	= diff
++ECHO	= echo
++FIND	= find
++GREP 	:= grep
++LN	= ln
++LS	= ls
++MKDIR 	= mkdir
++MV 	= mv
++PANDOC  := pandoc
++PERL	= perl
++PRINTF  = printf
++RM 	= rm -rf
++SED 	:= sed
++SH 	= sh
++SORT    = sort
++TEST 	= test
++TIDY	= tidy
++TOUCH 	= touch
++UNZIP 	= unzip
++WC 	= wc
++ZIP 	= zip
+ 
+ 
+ #----------------------------------------------------------------------
+@@ -212,12 +194,12 @@ BUILD_MILESTONE = dev
+ BUILD_NUMBER = b00
+ 
+ # don't eval dates here directly, because that leads to unstable builds
+-#BUILD_YEAR:sh = /bin/date +"%Y"
+-BUILD_YEAR_CMD = /bin/date '+%Y'
+-#BUILD_DOCDATE:sh = /bin/date +"%B %d, %Y"
+-BUILD_DOCDATE_CMD = /bin/date  +'%B %d, %Y'
+-#BUILD_ZIPDATE:sh = /bin/date '+%d %h %Y'
+-BUILD_ZIPDATE_CMD = /bin/date  '+%d %h %Y'
++#BUILD_YEAR:sh = date +"%Y"
++BUILD_YEAR_CMD = date '+%Y'
++#BUILD_DOCDATE:sh = date +"%B %d, %Y"
++BUILD_DOCDATE_CMD = date  +'%B %d, %Y'
++#BUILD_ZIPDATE:sh = date '+%d %h %Y'
++BUILD_ZIPDATE_CMD = date  '+%d %h %Y'
+ BUILD_NONFCS_MILESTONE_sh = echo $(BUILD_MILESTONE) | sed -e 's/[fF][cC][sS]//'
+ BUILD_NONFCS_MILESTONE = $(BUILD_NONFCS_MILESTONE_sh:sh)
+ 
+@@ -226,7 +208,7 @@ ZIPSFX_VERSION_sh = echo '$(BUILD_VERSION)' | sed -e 's|\([^0-9][^0-9]*\)|_|g'
+ ZIPSFX_MILESTONE_sh = echo '$(BUILD_MILESTONE)'
+ ZIPSFX_BUILD_sh = echo '$(BUILD_NUMBER)'
+ ZIPSFX_NEWBUILD_sh = echo '$(BUILD_NUMBER)' | sed -e 's|[^[0-9]||g' | xargs printf "%d"
+-ZIPSFX_DATE_sh = echo "`$(BUILD_ZIPDATE_CMD)`" | /usr/bin/tr -s '[A-Z] ' '[a-z]_'
++ZIPSFX_DATE_sh = echo "`$(BUILD_ZIPDATE_CMD)`" | tr -s '[A-Z] ' '[a-z]_'
+ 
+ VERBOSE_ZIP_SUFFIX = $(shell $(ZIPSFX_VERSION_sh))-$(shell $(ZIPSFX_MILESTONE_sh))-bin-$(shell $(ZIPSFX_BUILD_sh))-$(shell $(ZIPSFX_DATE_sh))
+ 
+diff --git a/make/Rules.gmk b/make/Rules.gmk
+index 1a9a5601e..c39742150 100644
+--- a/make/Rules.gmk
++++ b/make/Rules.gmk
+@@ -73,7 +73,7 @@ $(IMAGES_DIR)/%.jar: pkgsToFiles.sh
+ 	  echo "$(@F:%.jar=%)-Build: $(BUILD_NUMBER)" ; \
+ 	  echo "$(@F:%.jar=%)-BuildJavaVersion: `$(JDKJAVA) -fullversion 2>&1 | awk '{print $$NF}'  | \
+ 		sed -e 's|^"\(.*\)"$$|Java(TM) 2 SDK, Version \1|'`" ; \
+-	  echo "$(@F:%.jar=%)-BuildDate: `/bin/date +'%B %d, %Y'`" ; \
++	  echo "$(@F:%.jar=%)-BuildDate: `date +'%B %d, %Y'`" ; \
+ 	) \
+ 		> $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%/manifest.txt)
+ 	sh pkgsToFiles.sh $(CLASSDIR) $($(@F:%.jar=PKGS.JAR.%)) > $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%/includes.txt)
+diff --git a/make/jtreg.gmk b/make/jtreg.gmk
+index 5de111727..1e8f8fd27 100644
+--- a/make/jtreg.gmk
++++ b/make/jtreg.gmk
+@@ -344,7 +344,7 @@ ID_COMMAND := $(PRINTF) "git:%s%s\n" \
+ 
+ $(JTREG_IMAGEDIR)/release:
+ 	echo "JTREG_VERSION=$(BUILD_VERSION) $(BUILD_NUMBER)" > $@
+-	echo "BUILD_DATE=`/bin/date +'%B %d, %Y'`" >> $@
++	echo "BUILD_DATE=`date +'%B %d, %Y'`" >> $@
+ 	if [ -r $(TOPDIR)/.git ]; then \
+ 	    echo "SOURCE=$$($(ID_COMMAND))" >> $@ ; \
+ 	elif [ -n "$(SRCREV)" -a -r $(SRCREV) ]; then \
+-- 
+2.43.0

--- a/distro/etc_nixos/overlays/jtreg/0002-Drop-Werror-for-helper-classes-on-JDK-21.patch
+++ b/distro/etc_nixos/overlays/jtreg/0002-Drop-Werror-for-helper-classes-on-JDK-21.patch
@@ -1,0 +1,34 @@
+From 7a8bc3c2d55f1bc4a4b472a4de2ac6d9d7690002 Mon Sep 17 00:00:00 2001
+From: Qingsong Chen <changxian.cqs@antgroup.com>
+Date: Mon, 2 Mar 2026 03:26:08 +0000
+Subject: [PATCH 2/2] Drop -Werror for helper classes on JDK 21
+
+When built with OpenJDK 21, `jtreg`'s helper classes trigger
+`this-escape` warnings in `SearchPath.java`. Remove `-Werror`
+for the helper compilations so `jtreg` builds with the
+JDK shipped in NixOS.
+---
+ make/Defs.gmk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/make/Defs.gmk b/make/Defs.gmk
+index b37c5ff..5a14d04 100644
+--- a/make/Defs.gmk
++++ b/make/Defs.gmk
+@@ -124,12 +124,12 @@ REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS = --patch-module java.base=$(JAVADIR)
+ # for files needed to run agentvm and othervm tests (on platforms back to JDK 8)
+ REGTEST_AGENT_JAVAC = $(JDKHOME)/bin/javac
+ REGTEST_AGENT_JAVAC_OPTIONS = \
+-	$(AGENT_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation -Werror
++	$(AGENT_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation
+ 
+ # for files needed for jtreg tool
+ REGTEST_TOOL_JAVAC = $(JDKHOME)/bin/javac
+ REGTEST_TOOL_JAVAC_OPTIONS = \
+-	$(TOOL_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation -Werror
++	$(TOOL_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation
+ 
+ 
+ #----- Unix commands
+-- 
+2.43.0

--- a/distro/etc_nixos/overlays/jtreg/default.nix
+++ b/distro/etc_nixos/overlays/jtreg/default.nix
@@ -1,0 +1,153 @@
+final: prev: {
+  jtreg = let
+    # JT Harness
+    jtharness = prev.stdenv.mkDerivation rec {
+      pname = "jtharness";
+      version = "6.0-b24";
+      src = prev.fetchzip {
+        url =
+          "https://github.com/openjdk/jtharness/archive/refs/tags/jt${version}.zip";
+        sha256 = "sha256-E0YlUXBVwC+m7ZVF/RYqKXpRneMYY9y3ewtz8+26T/U";
+      };
+      buildInputs = with prev.pkgs; [ ant openjdk21 ];
+      buildPhase = ''
+        ant -DBUILD_DIR=$NIX_BUILD_TOP -f build/build.xml dist
+      '';
+      installPhase = ''
+        mkdir -p $out
+        cp -r $NIX_BUILD_TOP/binaries/* $out
+      '';
+    };
+
+    # AsmTools
+    asmtools = prev.stdenv.mkDerivation rec {
+      pname = "asmtools";
+      version = "7.0-b09";
+      src = prev.fetchzip {
+        url =
+          "https://github.com/openjdk/asmtools/archive/refs/tags/${version}.zip";
+        sha256 = "sha256-jgrAmfgCPisAEMP9oTCKmdjMeLuBpVPKg4pW9SL/4lY";
+      };
+      buildInputs = with prev.pkgs; [ ant openjdk21 ];
+      buildPhase = ''
+        ant -DBUILD_DIR=$NIX_BUILD_TOP -f build/build.xml release
+      '';
+      installPhase = ''
+        mkdir -p $out
+        cp -r $NIX_BUILD_TOP/release/* $out
+      '';
+    };
+
+    # JUnit Platform Console Standalone (includes JUnit Jupiter, JUnit Vintage, and dependencies)
+    junit = prev.stdenv.mkDerivation rec {
+      pname = "junit";
+      version = "1.8.2";
+
+      junit = prev.fetchurl {
+        url =
+          "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${version}/junit-platform-console-standalone-${version}.jar";
+        sha256 = "sha256-3EmPI0Io+ByBi+z7a39x9z3ysOmV+T8lwF/O0Md+Y1Y";
+      };
+
+      license = prev.fetchurl {
+        url =
+          "https://github.com/junit-team/junit-framework/raw/refs/heads/main/LICENSE.md";
+        sha256 = "sha256-WqTNRMERrdF40cLi/jbVikhAEsgBZ9+SX4Js1k1BG/A";
+      };
+
+      buildCommand = ''
+        mkdir -p $out/lib
+
+        cp ${license} $out/LICENSE.md
+        cp ${junit} $out/lib/junit-platform-console-standalone.jar
+      '';
+    };
+
+    # TestNG and its dependencies
+    testng = prev.stdenv.mkDerivation rec {
+      pname = "testng";
+      version = "7.3.0";
+
+      testng = prev.fetchurl {
+        url =
+          "https://repo1.maven.org/maven2/org/testng/testng/${version}/testng-${version}.jar";
+        sha256 = "sha256-Y3J0iPlxfVfw0KD+5aH8EKK+nPz/LsOnGHZW1mPAd04";
+      };
+
+      license = prev.fetchurl {
+        url =
+          "https://github.com/testng-team/testng/raw/refs/tags/${version}/LICENSE.txt";
+        sha256 = "sha256-wbnfEnXnafPbqwANHkV6LUsPKOtdpsd+SNw37rogLtc";
+      };
+
+      jcommander = prev.fetchurl {
+        url =
+          "https://repo1.maven.org/maven2/com/beust/jcommander/1.78/jcommander-1.78.jar";
+        sha256 = "sha256-eJHeu4S1+D6b1XWT6+zjOZq74P2TjPMGs1NMV5E7lhU";
+      };
+
+      guice = prev.fetchurl {
+        url =
+          "https://repo1.maven.org/maven2/com/google/inject/guice/4.2.3/guice-4.2.3.jar";
+        sha256 = "sha256-oh5Q/7tn563FtGz3ueGkgPHg8E/UIB3bHGXakSkGAa8";
+      };
+
+      buildCommand = ''
+        mkdir -p $out/lib
+
+        cp ${license} $out/LICENSE.txt
+        cp ${testng} $out/lib/testng.jar
+        cp ${jcommander} $out/lib/jcommander.jar
+        cp ${guice} $out/lib/guice.jar
+      '';
+    };
+  in prev.stdenv.mkDerivation rec {
+    pname = "jtreg";
+    version = "7.3.1";
+    number = "1";
+    src = prev.fetchzip {
+      url =
+        "https://github.com/openjdk/jtreg/archive/refs/tags/jtreg-${version}+${number}.zip";
+      sha256 = "sha256-m9/BkM2fVfAFYMCMnCEkqZhRbYQYeo2YCyZCt+b0ggg";
+    };
+
+    patches = [
+      ./0001-Make-jtreg-use-tools-from-PATH.patch
+      ./0002-Drop-Werror-for-helper-classes-on-JDK-21.patch
+    ];
+
+    JAVATEST_JAR = "${jtharness}/lib/javatest.jar";
+    JTHARNESS_NOTICES = "${jtharness}/legal/copyright.txt ${jtharness}/LICENSE";
+
+    ASMTOOLS_JAR = "${asmtools}/lib/asmtools.jar";
+    ASMTOOLS_NOTICES = "${asmtools}/LICENSE";
+
+    JUNIT_JARS = "${junit}/lib/junit-platform-console-standalone.jar";
+    JUNIT_NOTICES = "${junit}/LICENSE.md";
+
+    TESTNG_JARS =
+      "${testng}/lib/testng.jar ${testng}/lib/jcommander.jar ${testng}/lib/guice.jar";
+    TESTNG_NOTICES = "${testng}/LICENSE.txt";
+
+    JDKHOME = "${prev.pkgs.openjdk21}";
+    JAVA_SPECIFICATION_VERSION = "21";
+
+    buildInputs = with prev.pkgs; [
+      ant
+      openjdk21
+      hostname
+      pandoc
+      perl
+      html-tidy
+      unzip
+      zip
+    ];
+    buildPhase = ''
+      make BUILD_VERSION=${version} BUILD_NUMBER=${number} -C make
+    '';
+    installPhase = ''
+      mkdir -p $out
+      cp -r build/images/jtreg/* $out
+    '';
+  };
+}

--- a/test/nixos/Cargo.lock
+++ b/test/nixos/Cargo.lock
@@ -503,6 +503,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-development-tools-openjdk"
+version = "0.1.0"
+dependencies = [
+ "nixos-test-framework",
+]
+
+[[package]]
 name = "test-development-tools-python"
 version = "0.1.0"
 dependencies = [

--- a/test/nixos/tests/development-tools-openjdk/Cargo.toml
+++ b/test/nixos/tests/development-tools-openjdk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-development-tools-openjdk"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+nixos-test-framework.workspace = true

--- a/test/nixos/tests/development-tools-openjdk/extra_config.nix
+++ b/test/nixos/tests/development-tools-openjdk/extra_config.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+let
+  jdk = pkgs.openjdk21;
+  jtreg = pkgs.jtreg;
+in {
+  environment.systemPackages = [ jtreg ];
+  environment.variables = { JTREG_HOME = "${jtreg}"; };
+
+  programs.java.package = jdk;
+  programs.java.enable = true;
+
+  system.activationScripts.testFixtures = ''
+    ln -sfT ${jdk.src} /tmp/jdk-src
+  '';
+}

--- a/test/nixos/tests/development-tools-openjdk/src/main.rs
+++ b/test/nixos/tests/development-tools-openjdk/src/main.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The test suite for OpenJDK on Asterinas NixOS.
+//!
+//! Supplements the `OpenJDK` coverage in `development-tools`.
+//!
+//! See `test/nixos/README.md#documentation-maintenance` for sync requirements
+//! between this test suite and the corresponding "Verified Usage" book section.
+
+use nixos_test_framework::*;
+
+nixos_test_main!();
+
+#[nixos_test]
+fn openjdk_regression(nixos_shell: &mut Session) -> Result<(), Error> {
+    // `jtreg -v1 -nr <path>` ends each invocation with a `Test results:` summary
+    // line. A fully successful run uses the exact form:
+    //
+    //   Test results: passed: <count>
+    //
+    // When any selected test fails, errors out, or is skipped, the summary is
+    // no longer this success-only form and instead includes additional result
+    // categories. Each invocation here runs `jtreg` for exactly one entry from
+    // `src/testcases.txt`, so matching the exact success summary is sufficient.
+    let success_regex =
+        Regex::new(r"(?m)^Test results: passed: [0-9]+$").map_err(|err| Error::Pty(err.into()))?;
+
+    let testcases =
+        std::fs::read_to_string("src/testcases.txt").map_err(|err| Error::Pty(err.into()))?;
+    let mut failed_tests = Vec::new();
+    for testcase in testcases
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+    {
+        let cmd = format!("jtreg -v1 -nr -retain:none /tmp/jdk-src/test/jdk/{testcase}");
+        if let Err(err) = nixos_shell.run_cmd_and_expect_regex(&cmd, &success_regex) {
+            failed_tests.push((testcase.to_string(), err));
+        }
+    }
+
+    if !failed_tests.is_empty() {
+        println!("=== Failed OpenJDK regression tests ===");
+        for (test, _) in &failed_tests {
+            println!("  - {test}");
+        }
+        println!("==============================");
+
+        return Err(Error::Aggregated {
+            summary: "Selected OpenJDK regression tests failed!".to_string(),
+            collections: failed_tests,
+        });
+    }
+
+    Ok(())
+}

--- a/test/nixos/tests/development-tools-openjdk/src/testcases.txt
+++ b/test/nixos/tests/development-tools-openjdk/src/testcases.txt
@@ -1,0 +1,127 @@
+# This test list is pinned to `pkgs.openjdk21` and the matching `jdk.src`
+# configured in `test/nixos/tests/development-tools-openjdk/extra_config.nix`.
+#
+# It can be regenerated from the matching OpenJDK source tree with:
+# jtreg -l jdk/test/jdk
+#
+# FIXME: Currently only a subset of `java/io`, `java/lang`, and `java/net`
+# tests are enabled, because:
+# 1. Some tests fail inherently because Asterinas does not yet support the
+#    required kernel features.
+# 2. Although individual tests may pass, enabling more tests increases the
+#    risk of failures induced by JVM or Ext2 issues.
+
+# java/io/BufferedInputStream
+# java/io/BufferedReader
+# java/io/BufferedWriter
+# java/io/ByteArrayInputStream
+# java/io/ByteArrayOutputStream
+# java/io/CharArrayReader
+# java/io/charStreams
+# java/io/ClassCache
+# java/io/Console
+# java/io/DataInputStream
+# java/io/DataOutputStream
+# java/io/etc
+# java/io/Externalizable
+# java/io/File
+# java/io/FileDescriptor
+# java/io/FileInputStream
+# java/io/FileOutputStream
+# java/io/FilePermission
+java/io/FileReader
+java/io/FileWriter
+# java/io/FilterOutputStream
+# java/io/InputStream
+# java/io/InputStreamReader
+# java/io/IOException
+# java/io/LineNumberInputStream
+# java/io/LineNumberReader
+# java/io/ObjectInputStream
+# java/io/ObjectStreamClass
+# java/io/OutputStream
+# java/io/OutputStreamWriter
+# java/io/pathNames
+# java/io/PipedInputStream
+# java/io/PipedOutputStream
+java/io/PipedReader
+java/io/PipedWriter
+# java/io/PrintStream
+# java/io/PrintWriter
+# java/io/PushbackInputStream
+# java/io/PushbackReader
+# java/io/RandomAccessFile
+# java/io/readBytes
+# java/io/Reader
+# java/io/SequenceInputStream
+# java/io/Serializable
+# java/io/StreamTokenizer
+# java/io/StringBufferInputStream
+java/io/StringReader
+java/io/StringWriter
+# java/io/Writer
+# java/io/NegativeInitSize.java
+# java/io/SystemInAvailable.java
+# java/io/Unicode.java
+
+# java/lang/Process
+# java/lang/ProcessBuilder
+# java/lang/ProcessHandle
+# java/lang/runtime
+# java/lang/RuntimePermission
+# java/lang/RuntimeTests
+# java/lang/StackTraceElement
+# java/lang/StackWalker
+# java/lang/Thread
+java/lang/ThreadGroup
+java/lang/ThreadLocal
+
+# java/net/Authenticator
+# java/net/BindException
+# java/net/CookieHandler
+# java/net/DatagramPacket
+# java/net/DatagramSocket
+# java/net/DatagramSocketImpl
+# java/net/httpclient
+# java/net/HttpCookie
+# java/net/HttpURLConnection
+# java/net/IDN
+# java/net/Inet4Address
+# java/net/Inet6Address
+# java/net/InetAddress
+java/net/InetSocketAddress
+# java/net/InterfaceAddress
+# java/net/IPSupport
+# java/net/ipv6tests
+# java/net/JarURLConnection
+# java/net/MulticastSocket
+# java/net/NetworkInterface
+# java/net/PlainSocketImpl
+# java/net/PortUnreachableException
+# java/net/ProxySelector
+# java/net/ResponseCache
+# java/net/ServerSocket
+# java/net/SetFactoryPermission
+# java/net/Socket
+# java/net/SocketException
+# java/net/SocketImpl
+# java/net/SocketInputStream
+# java/net/SocketOption
+# java/net/SocketPermission
+# java/net/Socks
+# java/net/spi
+java/net/UnixDomainSocketAddress
+# java/net/URI
+# java/net/URL
+# java/net/URLClassLoader
+# java/net/URLConnection
+# java/net/URLDecoder
+# java/net/URLEncoder
+# java/net/URLPermission
+# java/net/URLStreamHandler
+# java/net/vthread
+# java/net/whitebox
+# java/net/B6499348.java
+# java/net/HugeDataTransferTest.java
+# java/net/NetworkConfigurationProbe.java
+# java/net/SctpSanity.java


### PR DESCRIPTION
This PR adds support for running JDK tests on Asterinas NixOS using the `jtreg` test framework. The implementation includes:

1. **Add jtreg package**: A complete nix overlay that builds jtreg and its dependencies (jtharness, asmtools, junit, testng) from source
2. **Add JDK testcases**: Initial set of JDK testcases selected for Asterinas NixOS
