### PR TITLE
Optimized the build & install workflow of nixos

### DIFF
--- a/distro/aster_nixos_installer/templates/install_nixos.sh
+++ b/distro/aster_nixos_installer/templates/install_nixos.sh
@@ -131,9 +131,25 @@ cp @aster-configuration@ ${BUILD_DIR}/etc/nixos/aster_configuration.nix
 cp -r @aster-etc-nixos@/modules ${BUILD_DIR}/etc/nixos
 cp -r @aster-etc-nixos@/overlays ${BUILD_DIR}/etc/nixos
 
+COMMON_NIX_ARGS=(
+    --option extra-substituters "@aster-substituters@"
+    --option extra-trusted-public-keys "@aster-trusted-public-keys@"
+)
+
+# Pre-build the NixOS system closure on the host
+# so that the result is cached in the host's Nix store.
+# Without this, nixos-install would build the system inside the (possibly empty) target image,
+# causing redundant downloads after every `make clean`.
+#
+# See: https://www.mankier.com/8/nixos-install#--system
+SYSTEM_CLOSURE=$(nix-build '<nixpkgs/nixos>' -A system \
+    -I "nixos-config=${BUILD_DIR}/etc/nixos/configuration.nix" \
+    "${COMMON_NIX_ARGS[@]}" \
+    --no-out-link)
+
 export PATH=${PATH}:/run/current-system/sw/bin
 nixos-install --root ${BUILD_DIR} --no-root-passwd \
-    --option extra-substituters "@aster-substituters@" \
-    --option extra-trusted-public-keys "@aster-trusted-public-keys@"
+    --system "${SYSTEM_CLOSURE}" \
+    "${COMMON_NIX_ARGS[@]}"
 
 echo "Congratulations! Asterinas NixOS has been installed successfully!"


### PR DESCRIPTION
# Overview

This PR optimizes the NixOS installation script by decoupling the system build from the installation process. By using `nix-build` separately, we ensure that the Nix store can effectively cache packages even across different build sessions.

# Motivation

Previously, running `make clean` followed by `make nixos` would often cause Nix to lose track of intermediate build states. This forced the script to re-download all packages defined in configuration.nix every time.

For large packages like `cudatoolkit`, these redundant downloads significantly increased the total build time and network overhead.

With this change, `nix-build` can better leverage the Nix store. Even if the local make environment is cleaned, the Nix store paths remain valid, allowing `nix-build` to detect that the packages (like CUDA) already exist locally, skipping the download phase entirely.

---

**Reference**:

* [nixos-install](https://www.mankier.com/8/nixos-install#--system)