### PR TITLE
Do not increase RSS when COW

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -163,8 +163,8 @@ impl FileOps for StatFileOps {
 
         let (vsize, rss) = if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
-            let anon = vmar_ref.get_rss_counter(RssType::RSS_ANONPAGES);
-            let file = vmar_ref.get_rss_counter(RssType::RSS_FILEPAGES);
+            let anon = vmar_ref.get_rss_counter(RssType::Anon);
+            let file = vmar_ref.get_rss_counter(RssType::File);
             let rss = anon + file;
             (vsize, rss)
         } else {

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -145,8 +145,8 @@ impl FileOps for StatusFileOps {
 
         if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
-            let anon = vmar_ref.get_rss_counter(RssType::RSS_ANONPAGES) * (PAGE_SIZE / 1024);
-            let file = vmar_ref.get_rss_counter(RssType::RSS_FILEPAGES) * (PAGE_SIZE / 1024);
+            let anon = vmar_ref.get_rss_counter(RssType::Anon) * (PAGE_SIZE / 1024);
+            let file = vmar_ref.get_rss_counter(RssType::File) * (PAGE_SIZE / 1024);
             let rss = anon + file;
             writeln!(
                 printer,

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -166,8 +166,8 @@ impl VmMapping {
     /// Returns the mapping's RSS type.
     pub fn rss_type(&self) -> RssType {
         match &self.mapped_mem {
-            MappedMemory::Anonymous => RssType::RSS_ANONPAGES,
-            MappedMemory::Vmo(_) | MappedMemory::Device => RssType::RSS_FILEPAGES,
+            MappedMemory::Anonymous => RssType::Anon,
+            MappedMemory::Vmo(_) | MappedMemory::Device => RssType::File,
         }
     }
 
@@ -441,7 +441,10 @@ impl VmMapping {
                         cursor.unmap(PAGE_SIZE);
                         cursor.jump(va.start).unwrap();
                         cursor.map(new_frame.into(), prop);
-                        rss_delta.add(self.rss_type(), 1);
+                        // FIXME: Linux re-classifies the page from `File` to `Anon` in RSS,
+                        // when a COW on a file-backed mapping happens.
+                        // We currently do not support this re-classification,
+                        // since it will introduce some complexity when unmapping this page.
                     }
                     cursor.flusher().sync_tlb_flush();
                 }

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -86,13 +86,12 @@ impl Vmar {
 
 /// The type representing categories of Resident Set Size (RSS).
 ///
-/// See <https://github.com/torvalds/linux/blob/fac04efc5c793dccbd07e2d59af9f90b7fc0dca4/include/linux/mm_types_task.h#L26..L32>
+/// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/include/linux/mm_types_task.h#L26-L32>
 #[repr(u32)]
-#[expect(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, TryFromInt)]
 pub enum RssType {
-    RSS_FILEPAGES = 0,
-    RSS_ANONPAGES = 1,
+    File = 0,
+    Anon = 1,
 }
 
 const NUM_RSS_COUNTERS: usize = 2;

--- a/test/initramfs/src/apps/memory/mmap/mmap_vmrss.c
+++ b/test/initramfs/src/apps/memory/mmap/mmap_vmrss.c
@@ -15,6 +15,32 @@
 #define NUM_PAGES 1024
 #define TOTAL_SIZE (PAGE_SIZE * NUM_PAGES)
 
+// The RSS count in Linux may differ slightly from the expected value,
+// because its per-CPU counters are updated lazily.
+#ifdef __asterinas__
+long get_rss_deviation_kb()
+{
+	return 0;
+}
+#else
+long get_rss_deviation_kb()
+{
+	static long cached_deviation_kb = -1;
+
+	if (cached_deviation_kb >= 0)
+		return cached_deviation_kb;
+
+	// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/lib/percpu_counter.c#L258-L264>.
+	long nrcpus = CHECK(sysconf(_SC_NPROCESSORS_ONLN));
+	long batch = nrcpus * 2;
+	if (batch < 32)
+		batch = 32;
+	// Anon pages and file pages are counted in separate per-CPU counters.
+	cached_deviation_kb = batch * 2 * (PAGE_SIZE / 1024);
+	return cached_deviation_kb;
+}
+#endif
+
 typedef enum rss_type {
 	anon,
 	file,
@@ -68,6 +94,10 @@ long get_vm_rss_kb(rss_type type)
 	return rss_kb;
 }
 
+// Tests whether the returned RSS value is within the expected range.
+#define TEST_RSS(expr, expected) \
+	TEST_RES(expr, (labs(_ret - (expected)) <= get_rss_deviation_kb()))
+
 FN_TEST(rss_anon)
 {
 	void *mem = TEST_SUCC(mmap(NULL, TOTAL_SIZE, PROT_READ | PROT_WRITE,
@@ -88,17 +118,17 @@ FN_TEST(rss_anon)
 		*p = 42;
 	}
 
-	TEST_RES(get_vm_rss_kb(anon),
-		 _ret - rss_anon_before == NUM_PAGES * (PAGE_SIZE / 1024));
-	TEST_RES(get_vm_rss_kb(file), _ret == rss_file_before);
-	TEST_RES(get_vm_rss_kb(total),
-		 _ret - rss_before == NUM_PAGES * (PAGE_SIZE / 1024));
+	TEST_RSS(get_vm_rss_kb(anon),
+		 rss_anon_before + NUM_PAGES * (PAGE_SIZE / 1024));
+	TEST_RSS(get_vm_rss_kb(file), rss_file_before);
+	TEST_RSS(get_vm_rss_kb(total),
+		 rss_before + NUM_PAGES * (PAGE_SIZE / 1024));
 
 	TEST_SUCC(munmap(mem, TOTAL_SIZE));
 
-	TEST_RES(get_vm_rss_kb(anon), _ret == rss_anon_before);
-	TEST_RES(get_vm_rss_kb(file), _ret == rss_file_before);
-	TEST_RES(get_vm_rss_kb(total), _ret == rss_before);
+	TEST_RSS(get_vm_rss_kb(anon), rss_anon_before);
+	TEST_RSS(get_vm_rss_kb(file), rss_file_before);
+	TEST_RSS(get_vm_rss_kb(total), rss_before);
 }
 END_TEST()
 
@@ -118,26 +148,48 @@ FN_TEST(rss_file)
 	long rss_file_before = TEST_SUCC(get_vm_rss_kb(file));
 	long rss_before = TEST_SUCC(get_vm_rss_kb(total));
 
-	void *mem = TEST_SUCC(
-		mmap(NULL, TOTAL_SIZE, PROT_READ, MAP_PRIVATE, fd, 0));
+	void *mem = TEST_SUCC(mmap(NULL, TOTAL_SIZE, PROT_READ | PROT_WRITE,
+				   MAP_PRIVATE, fd, 0));
 
 	// Trigger page faults
 	for (int i = 0; i < NUM_PAGES; ++i) {
-		volatile char x = *((char *)mem + i * PAGE_SIZE);
-		x++;
+		volatile char *p = (char *)mem + i * PAGE_SIZE;
+		(void)*p;
 	}
 
-	TEST_RES(get_vm_rss_kb(file),
-		 _ret - rss_file_before == NUM_PAGES * (PAGE_SIZE / 1024));
-	TEST_RES(get_vm_rss_kb(anon), _ret == rss_anon_before);
-	TEST_RES(get_vm_rss_kb(total),
-		 _ret - rss_before == NUM_PAGES * (PAGE_SIZE / 1024));
+	TEST_RSS(get_vm_rss_kb(anon), rss_anon_before);
+	TEST_RSS(get_vm_rss_kb(file),
+		 rss_file_before + NUM_PAGES * (PAGE_SIZE / 1024));
+	TEST_RSS(get_vm_rss_kb(total),
+		 rss_before + NUM_PAGES * (PAGE_SIZE / 1024));
+
+	// Trigger COW
+	for (int i = 0; i < NUM_PAGES; ++i) {
+		volatile char *p = (char *)mem + i * PAGE_SIZE;
+		*p = 42;
+	}
+
+	// Linux re-classifies a page from `File` to `Anon` in RSS,
+	// when a COW on a file-backed mapping happens.
+	// Currently Asterinas does not support this re-classification.
+#ifdef __asterinas__
+	TEST_RSS(get_vm_rss_kb(anon), rss_anon_before);
+	TEST_RSS(get_vm_rss_kb(file),
+		 rss_file_before + NUM_PAGES * (PAGE_SIZE / 1024));
+#else
+	TEST_RSS(get_vm_rss_kb(anon),
+		 rss_anon_before + NUM_PAGES * (PAGE_SIZE / 1024));
+	TEST_RSS(get_vm_rss_kb(file), rss_file_before);
+#endif
+
+	TEST_RSS(get_vm_rss_kb(total),
+		 rss_before + NUM_PAGES * (PAGE_SIZE / 1024));
 
 	TEST_SUCC(munmap(mem, TOTAL_SIZE));
 
-	TEST_RES(get_vm_rss_kb(anon), _ret == rss_anon_before);
-	TEST_RES(get_vm_rss_kb(file), _ret == rss_file_before);
-	TEST_RES(get_vm_rss_kb(total), _ret == rss_before);
+	TEST_RSS(get_vm_rss_kb(anon), rss_anon_before);
+	TEST_RSS(get_vm_rss_kb(file), rss_file_before);
+	TEST_RSS(get_vm_rss_kb(total), rss_before);
 
 	TEST_SUCC(close(fd));
 	TEST_SUCC(unlink(filename));


### PR DESCRIPTION
The RSS of a `Vmar` should not be increased when a COW happens.

Linux re-classify the page from `RssFile` to `RssAnon` in the RSS counter when a COW on a file-backed mapping happens. This PR currently does not support this re-classification, since it will introduce extra complexity when unmapping the page.

The RSS count in Linux may differ slightly from the expected value, because its per-CPU counters are updated lazily. This PR relaxes the restriction in `mmap_vmrss` on Linux, allowing it to pass on Linux.