### PR TITLE
Init ACPI table only once

### DIFF
--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -231,7 +231,7 @@ unsafe fn wake_up_aps_via_mailbox(num_cpus: u32) {
     let acpi_tables = get_acpi_tables().unwrap();
     for ap_num in 1..num_cpus {
         wakeup_aps(
-            &acpi_tables,
+            acpi_tables,
             AcpiMemoryHandler {},
             ap_num,
             (AP_BOOT_START_PA + offset) as u64,

--- a/ostd/src/arch/x86/kernel/acpi/mod.rs
+++ b/ostd/src/arch/x86/kernel/acpi/mod.rs
@@ -44,33 +44,47 @@ impl AcpiHandler for AcpiMemoryHandler {
     fn unmap_physical_region<T>(_region: &acpi::PhysicalMapping<Self, T>) {}
 }
 
-pub(crate) fn get_acpi_tables() -> Option<AcpiTables<AcpiMemoryHandler>> {
-    let acpi_tables = match boot::EARLY_INFO.get().unwrap().acpi_arg {
-        BootloaderAcpiArg::Rsdp(addr) => unsafe {
-            AcpiTables::from_rsdp(AcpiMemoryHandler {}, addr).unwrap()
-        },
-        BootloaderAcpiArg::Rsdt(addr) => unsafe {
-            AcpiTables::from_rsdt(AcpiMemoryHandler {}, 0, addr).unwrap()
-        },
-        BootloaderAcpiArg::Xsdt(addr) => unsafe {
-            AcpiTables::from_rsdt(AcpiMemoryHandler {}, 1, addr).unwrap()
-        },
-        BootloaderAcpiArg::NotProvided => {
-            // We search by ourselves if the bootloader decides not to provide a rsdp location.
-            let rsdp = unsafe { Rsdp::search_for_on_bios(AcpiMemoryHandler {}) };
-            match rsdp {
-                Ok(map) => unsafe {
-                    AcpiTables::from_rsdp(AcpiMemoryHandler {}, map.physical_start()).unwrap()
-                },
-                Err(_) => {
-                    warn!("ACPI info not found!");
-                    return None;
+struct SyncAcpiTables(Option<AcpiTables<AcpiMemoryHandler>>);
+
+// SAFETY: This relies on the current implementation of `AcpiTables`,
+// which provides thread-safe access to read-only ACPI table data,
+// so `Sync` is sound for the wrapper.
+// FIXME: It depends on implementation details of `AcpiTables`, which should be avoided.
+unsafe impl Sync for SyncAcpiTables {}
+
+static ACPI_TABLES: Once<SyncAcpiTables> = Once::new();
+
+pub(crate) fn get_acpi_tables() -> Option<&'static AcpiTables<AcpiMemoryHandler>> {
+    let acpi_tables = ACPI_TABLES.call_once(|| {
+        let acpi_tables = match boot::EARLY_INFO.get().unwrap().acpi_arg {
+            BootloaderAcpiArg::Rsdp(addr) => unsafe {
+                AcpiTables::from_rsdp(AcpiMemoryHandler {}, addr).unwrap()
+            },
+            BootloaderAcpiArg::Rsdt(addr) => unsafe {
+                AcpiTables::from_rsdt(AcpiMemoryHandler {}, 0, addr).unwrap()
+            },
+            BootloaderAcpiArg::Xsdt(addr) => unsafe {
+                AcpiTables::from_rsdt(AcpiMemoryHandler {}, 1, addr).unwrap()
+            },
+            BootloaderAcpiArg::NotProvided => {
+                // We search by ourselves if the bootloader decides not to provide a rsdp location.
+                let rsdp = unsafe { Rsdp::search_for_on_bios(AcpiMemoryHandler {}) };
+                match rsdp {
+                    Ok(map) => unsafe {
+                        AcpiTables::from_rsdp(AcpiMemoryHandler {}, map.physical_start()).unwrap()
+                    },
+                    Err(_) => {
+                        warn!("ACPI info not found!");
+                        return SyncAcpiTables(None);
+                    }
                 }
             }
-        }
-    };
+        };
 
-    Some(acpi_tables)
+        SyncAcpiTables(Some(acpi_tables))
+    });
+
+    acpi_tables.0.as_ref()
 }
 
 /// The platform information provided by the ACPI tables.

--- a/ostd/src/arch/x86/timer/hpet.rs
+++ b/ostd/src/arch/x86/timer/hpet.rs
@@ -138,7 +138,7 @@ impl Hpet {
 pub fn init() -> Result<(), AcpiError> {
     let tables = get_acpi_tables().unwrap();
 
-    let hpet_info = HpetInfo::new(&tables)?;
+    let hpet_info = HpetInfo::new(tables)?;
     assert_ne!(hpet_info.base_address, 0, "HPET address should not be zero");
 
     let base = NonNull::new(paddr_to_vaddr(hpet_info.base_address) as *mut u8).unwrap();


### PR DESCRIPTION
While running Asterinas as the guest kernel for Kata Containers, I found that ACPI table initialization always results in a panic. This panic issue has been documented in #3030.

I also noticed that `AcpiTables` is initialized multiple times across the codebase, even though all call sites ultimately use the same instance. Therefore, I think it makes sense to wrap it in a `Once` so that it is initialized only once.

One complication is that the `AcpiTables` type from the `acpi` crate does not implement `Sync`(https://docs.rs/acpi/5.2.0/acpi/struct.AcpiTables.html#impl-Sync-for-AcpiTables%3CH%3E). To address this, I introduced a wrapper type `SyncAcpiTables` to make it safe to share across threads.