### PR TITLE
Remove `-Zbuild-std` from normal build

### DIFF
--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use bin::make_elf_for_qemu;
 
-use super::util::{COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH, cargo, profile_name_adapter};
+use super::util::{DEFAULT_TARGET_RELPATH, OSDK_TEST_CARGO_ARGS, cargo, profile_name_adapter};
 use crate::{
     arch::Arch,
     base_crate::{BaseCrateType, new_base_crate},
@@ -261,7 +261,7 @@ fn build_kernel_elf(
     command
         .arg("--target-dir")
         .arg(cargo_target_directory.as_ref());
-    command.args(COMMON_CARGO_ARGS);
+    command.args(OSDK_TEST_CARGO_ARGS);
     command.arg("--profile=".to_string() + profile);
     for override_config in override_configs {
         command.arg("--config").arg(override_config);

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 /// The `cfg_ktest` parameter controls whether `cfg(ktest)` is enabled.
 pub fn execute_forwarded_command(subcommand: &str, args: &Vec<String>, cfg_ktest: bool) {
     let mut cargo = util::cargo();
-    cargo.arg(subcommand).args(util::COMMON_CARGO_ARGS);
+    cargo.arg(subcommand);
     if !args.contains(&"--target".to_owned()) {
         cargo.arg("--target").arg(get_default_arch().triple());
     }

--- a/osdk/src/commands/util.rs
+++ b/osdk/src/commands/util.rs
@@ -4,10 +4,13 @@ use std::process::Command;
 
 use crate::util::{get_kernel_crate, new_command_checked_exists};
 
-pub const COMMON_CARGO_ARGS: &[&str] = &[
-    "-Zbuild-std=core,alloc,compiler_builtins",
-    "-Zbuild-std-features=compiler-builtins-mem",
-];
+/// Since the pre-compiled `libcore` distribution for bare-metal targets
+/// defaults to the `abort` panic strategy, `cargo osdk test` requires a
+/// recompile via `-Zbuild-std` to enable the `unwind` strategy.
+/// This is necessary for the kernel to catch `#[should_panic]` tests;
+/// otherwise, `gimli` will be unable to perform stack backtraces, preventing
+/// the `unwinding` crate from intercepting panics.
+pub const OSDK_TEST_CARGO_ARGS: &[&str] = &["-Zbuild-std=core,alloc"];
 
 pub const DEFAULT_TARGET_RELPATH: &str = "osdk";
 


### PR DESCRIPTION
Close https://github.com/asterinas/asterinas/issues/3034

~~Asterinas uses the abort panic strategy by default (??)~~, while catching `#[should_panic]` tests requires the unwind strategy. Therefore, this PR removes `COMMON_CARGO_ARGS` from the normal build process and adjusts the `-Zbuild-std` arguments for testing.

The specification of bare-metal targets typically defines the abort panic strategy, causing the pre-compiled libcore to panic with abort. However, the ktest framework requires unwinding to catch `#[should_panic]` tests. Although OSDK passes `-Cpanic=unwind` to rustc when building crates, libcore must be rebuilt to apply the unwind strategy to itself. Consequently, `-Zbuild-std` is still passed when building the testing kernel.

**NOTE:** In my experiments, `compiler_builtins` did not require recompilation; this may have been a historical workaround for custom targets to handle missing symbols.

