### PR TITLE
Introduce Klint's `not_using_prelude` check

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 
 use align_ext::AlignExt;
 use aster_util::mem_obj_slice::Slice;
-use bitvec::array::BitArray;
+use bitvec::prelude::BitArray;
 use int_to_c_enum::TryFromInt;
 use io_util::{
     IoError,
@@ -13,10 +13,11 @@ use io_util::{
 use ostd::{
     Error,
     mm::{
-        HasSize, Infallible, USegment, VmReader, VmWriter,
+        Infallible, USegment, VmReader, VmWriter,
         dma::DmaStream,
         io::util::{HasVmReaderWriter, VmReaderWriterResult},
     },
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock, WaitQueue},
 };
 use spin::Once;

--- a/kernel/comps/framebuffer/src/console.rs
+++ b/kernel/comps/framebuffer/src/console.rs
@@ -8,7 +8,8 @@ use aster_console::{
     mode::{ConsoleMode, KeyboardMode, KeyboardModeFlags},
 };
 use ostd::{
-    mm::{HasSize, VmReader},
+    mm::VmReader,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
 };
 use spin::Once;

--- a/kernel/comps/framebuffer/src/framebuffer.rs
+++ b/kernel/comps/framebuffer/src/framebuffer.rs
@@ -3,10 +3,11 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use ostd::{
-    Error, Result,
+    Error,
     boot::boot_info,
     io::IoMem,
-    mm::{CachePolicy, HasSize, VmIo},
+    mm::{CachePolicy, VmIo},
+    prelude::*,
     sync::Mutex,
 };
 use spin::Once;

--- a/kernel/comps/mlsdisk/src/layers/2-edit/journal.rs
+++ b/kernel/comps/mlsdisk/src/layers/2-edit/journal.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-use lending_iterator::LendingIterator;
+use lending_iterator::prelude::LendingIterator;
 use ostd_pod::{IntoBytes, Pod};
 use serde::{
     Deserialize, Serialize,

--- a/kernel/comps/mlsdisk/src/layers/5-disk/mlsdisk.rs
+++ b/kernel/comps/mlsdisk/src/layers/5-disk/mlsdisk.rs
@@ -16,7 +16,7 @@ use core::{
 };
 
 use device_id::DeviceId;
-use ostd::mm::{HasSize, VmIo};
+use ostd::mm::VmIo;
 use ostd_pod::{FromZeros, Pod};
 
 use super::{

--- a/kernel/comps/mlsdisk/src/util/bitmap.rs
+++ b/kernel/comps/mlsdisk/src/util/bitmap.rs
@@ -2,7 +2,7 @@
 
 use core::ops::Index;
 
-use bittle::{Bits, BitsMut};
+use bittle::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;

--- a/kernel/comps/network/src/buffer.rs
+++ b/kernel/comps/network/src/buffer.rs
@@ -4,11 +4,11 @@ use alloc::sync::Arc;
 use core::marker::PhantomData;
 
 use ostd::{
-    Result,
     mm::{
-        Daddr, HasDaddr, HasSize, Infallible, VmReader, VmWriter,
+        Daddr, HasDaddr, Infallible, VmReader, VmWriter,
         dma::{FromDevice, ToDevice},
     },
+    prelude::*,
 };
 use ostd_pod::Pod;
 

--- a/kernel/comps/network/src/dma_pool.rs
+++ b/kernel/comps/network/src/dma_pool.rs
@@ -7,7 +7,7 @@ use alloc::{
 use core::ops::Range;
 
 use aster_softirq::BottomHalfDisabled;
-use bitvec::array::BitArray;
+use bitvec::prelude::BitArray;
 use ostd::{
     mm::{
         Daddr, FrameAllocOptions, HasDaddr, Infallible, PAGE_SIZE, VmReader, VmWriter,

--- a/kernel/comps/nvme/src/device/block_device.rs
+++ b/kernel/comps/nvme/src/device/block_device.rs
@@ -28,8 +28,8 @@ use aster_block::{
 use aster_util::safe_ptr::SafePtr;
 use device_id::DeviceId;
 use ostd::{
-    debug, error, info,
-    mm::{HasDaddr, HasSize, PAGE_SIZE, dma::DmaStream},
+    mm::{HasDaddr, PAGE_SIZE, dma::DmaStream},
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard, WaitQueue},
     timer::Jiffies,
 };
@@ -814,9 +814,8 @@ mod test {
     };
     use io_util::batch::IoBatch;
     use ostd::{
-        info,
         mm::{FrameAllocOptions, VmIo, VmReader, io::util::HasVmReaderWriter},
-        prelude::ktest,
+        prelude::*,
     };
 
     use super::{BioType, IoOp, NvmeBlockDevice};

--- a/kernel/comps/nvme/src/nvme_queue.rs
+++ b/kernel/comps/nvme/src/nvme_queue.rs
@@ -12,7 +12,7 @@ use core::{
 use aster_util::{field_ptr, safe_ptr::SafePtr};
 use ostd::{
     mm::{HasDaddr, dma::DmaCoherent},
-    warn,
+    prelude::*,
 };
 
 use crate::{

--- a/kernel/comps/nvme/src/transport/pci/transport.rs
+++ b/kernel/comps/nvme/src/transport/pci/transport.rs
@@ -11,7 +11,7 @@ use aster_pci::{
 };
 use ostd::{
     bus::BusProbeError,
-    error, info,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
 };
 

--- a/kernel/comps/pci/src/arch/loongarch/mod.rs
+++ b/kernel/comps/pci/src/arch/loongarch/mod.rs
@@ -6,9 +6,7 @@ use core::{alloc::Layout, ops::RangeInclusive};
 
 use align_ext::AlignExt;
 use fdt::node::FdtNode;
-use ostd::{
-    Error, arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, prelude::Paddr, sync::SpinLock, warn,
-};
+use ostd::{Error, arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, prelude::*, sync::SpinLock};
 use spin::Once;
 
 use crate::PciDeviceLocation;

--- a/kernel/comps/pci/src/arch/riscv/mod.rs
+++ b/kernel/comps/pci/src/arch/riscv/mod.rs
@@ -4,7 +4,7 @@
 
 use core::ops::RangeInclusive;
 
-use ostd::{Error, arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, warn};
+use ostd::{Error, arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, prelude::*};
 use spin::Once;
 
 use crate::PciDeviceLocation;

--- a/kernel/comps/pci/src/bus.rs
+++ b/kernel/comps/pci/src/bus.rs
@@ -5,7 +5,7 @@
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
-use ostd::{bus::BusProbeError, debug, error};
+use ostd::{bus::BusProbeError, prelude::*};
 
 use super::{PciCommonDevice, device_info::PciDeviceId};
 

--- a/kernel/comps/pci/src/capability/mod.rs
+++ b/kernel/comps/pci/src/capability/mod.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 
 use align_ext::AlignExt;
 use int_to_c_enum::TryFromInt;
-use ostd::Result;
+use ostd::prelude::*;
 
 use self::{
     msix::{CapabilityMsixData, RawCapabilityMsix},

--- a/kernel/comps/pci/src/capability/msix.rs
+++ b/kernel/comps/pci/src/capability/msix.rs
@@ -4,7 +4,7 @@
 
 use alloc::vec::Vec;
 
-use ostd::{Error, Result, io::IoMem, irq::IrqLine, mm::VmIoOnce};
+use ostd::{Error, io::IoMem, irq::IrqLine, mm::VmIoOnce, prelude::*};
 
 use crate::{
     PciDeviceLocation,

--- a/kernel/comps/pci/src/capability/vendor.rs
+++ b/kernel/comps/pci/src/capability/vendor.rs
@@ -2,7 +2,7 @@
 
 //! Vendor-specific capability support.
 
-use ostd::{Error, Result};
+use ostd::{Error, prelude::*};
 
 use crate::PciDeviceLocation;
 

--- a/kernel/comps/pci/src/cfg_space.rs
+++ b/kernel/comps/pci/src/cfg_space.rs
@@ -6,10 +6,11 @@
 
 use bitflags::bitflags;
 use ostd::{
-    Error, Result,
+    Error,
     arch::device::io_port::{PortRead, PortWrite},
     io::IoMem,
     mm::{PodOnce, VmIoOnce},
+    prelude::*,
 };
 
 use super::PciDeviceLocation;

--- a/kernel/comps/pci/src/common_device.rs
+++ b/kernel/comps/pci/src/common_device.rs
@@ -2,7 +2,7 @@
 
 //! PCI device common definitions or functions.
 
-use ostd::Result;
+use ostd::prelude::*;
 
 use crate::{
     capability::{RawCapabilities, msix::CapabilityMsixData, vendor::CapabilityVndrData},

--- a/kernel/comps/time/src/rtc/cmos.rs
+++ b/kernel/comps/time/src/rtc/cmos.rs
@@ -17,8 +17,8 @@ use core::num::NonZeroU8;
 
 use ostd::{arch::{device::io_port::{ReadWriteAccess, WriteOnlyAccess}, kernel::ACPI_INFO}, io::IoPort, sync::SpinLock, warn};
 
-use crate::SystemTime;
 use super::Driver;
+use crate::SystemTime;
 
 pub struct RtcCmos {
     access: SpinLock<CmosAccess>,
@@ -41,7 +41,10 @@ impl Driver for RtcCmos {
 
         let acpi_info = ACPI_INFO.get().unwrap();
 
-        if acpi_info.boot_flags.is_some_and(|flags| flags.use_time_and_alarm_namespace_for_rtc()) {
+        if acpi_info
+            .boot_flags
+            .is_some_and(|flags| flags.use_time_and_alarm_namespace_for_rtc())
+        {
             // "If set, indicates that the CMOS RTC is either not implemented, or does not exist at
             // the legacy addresses". See:
             // <https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html#ia-pc-boot-architecture-flags>.
@@ -140,7 +143,8 @@ impl CmosAccess {
     }
 
     pub(self) fn read_century(&mut self) -> Option<u8> {
-        self.century_register.map(|r| self.read_register_impl(r.get()))
+        self.century_register
+            .map(|r| self.read_register_impl(r.get()))
     }
 
     pub(self) fn read_status_a(&mut self) -> StatusA {
@@ -181,7 +185,9 @@ impl CmosData {
         let mut now = Self::from_rtc_raw(&mut access);
         // Retry if the new value differs from the old one. An RTC update may occur in the
         // meantime, which would result in an invalid value.
-        while let new = Self::from_rtc_raw(&mut access) && now != new {
+        while let new = Self::from_rtc_raw(&mut access)
+            && now != new
+        {
             now = new;
         }
 
@@ -231,11 +237,14 @@ impl CmosData {
 
         self.second = bcd_to_binary(self.second);
         self.minute = bcd_to_binary(self.minute);
-        self.hour = bcd_to_binary(self.hour & !Self::HOUR_IS_AFTERNOON) | (self.hour & Self::HOUR_IS_AFTERNOON);
+        self.hour = bcd_to_binary(self.hour & !Self::HOUR_IS_AFTERNOON)
+            | (self.hour & Self::HOUR_IS_AFTERNOON);
         self.day = bcd_to_binary(self.day);
         self.month = bcd_to_binary(self.month);
         self.year = bcd_to_binary(self.year as u8) as u16;
-        self.century = self.century.and_then(|c| NonZeroU8::new(bcd_to_binary(c.get())));
+        self.century = self
+            .century
+            .and_then(|c| NonZeroU8::new(bcd_to_binary(c.get())));
     }
 
     const HOUR_IS_AFTERNOON: u8 = 0x80;
@@ -251,7 +260,11 @@ impl CmosData {
     fn modify_year(&mut self) {
         const DEFAULT_21_CENTURY: u8 = 20;
 
-        self.year += (self.century.map(NonZeroU8::get).unwrap_or(DEFAULT_21_CENTURY) as u16) * 100;
+        self.year += (self
+            .century
+            .map(NonZeroU8::get)
+            .unwrap_or(DEFAULT_21_CENTURY) as u16)
+            * 100;
     }
 }
 

--- a/kernel/comps/time/src/rtc/cmos.rs
+++ b/kernel/comps/time/src/rtc/cmos.rs
@@ -15,7 +15,15 @@
 
 use core::num::NonZeroU8;
 
-use ostd::{arch::{device::io_port::{ReadWriteAccess, WriteOnlyAccess}, kernel::ACPI_INFO}, io::IoPort, sync::SpinLock, warn};
+use ostd::{
+    arch::{
+        device::io_port::{ReadWriteAccess, WriteOnlyAccess},
+        kernel::ACPI_INFO,
+    },
+    io::IoPort,
+    prelude::*,
+    sync::SpinLock,
+};
 
 use super::Driver;
 use crate::SystemTime;

--- a/kernel/comps/time/src/rtc/goldfish.rs
+++ b/kernel/comps/time/src/rtc/goldfish.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use chrono::{DateTime, Datelike, Timelike};
-use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, warn};
+use chrono::prelude::{DateTime, *};
+use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, prelude::*};
 
-use crate::{rtc::Driver, SystemTime};
+use crate::{SystemTime, rtc::Driver};
 
 pub struct RtcGoldfish {
     io_mem: IoMem,

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -22,8 +22,8 @@ use aster_util::mem_obj_slice::Slice;
 use device_id::{DeviceId, MinorId};
 use ostd::{
     arch::trap::TrapFrame,
-    debug, info,
     mm::{PAGE_SIZE, VmIo, dma::DmaStream},
+    prelude::*,
     sync::SpinLock,
 };
 

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -7,8 +7,8 @@ use aster_console::{AnyConsoleDevice, ConsoleCallback};
 use aster_util::mem_obj_slice::Slice;
 use ostd::{
     arch::trap::TrapFrame,
-    debug,
     mm::{VmReader, dma::DmaStream, io::util::HasVmReaderWriter},
+    prelude::*,
     sync::{Rcu, SpinLock},
 };
 

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -19,9 +19,9 @@ use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use ostd::{
     arch::trap::TrapFrame,
-    debug, info,
     io::IoMem,
     mm::{HasDaddr, PAGE_SIZE, dma::DmaStream},
+    prelude::*,
     sync::SpinLock,
 };
 use ostd_pod::IntoBytes;

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use aster_bigtcp::device::{Checksum, DeviceCapabilities, Medium};
 use aster_network::{AnyNetworkDevice, EthernetAddr, NetError, RxBuffer, TxBuffer};
 use aster_util::slot_vec::SlotVec;
-use ostd::{arch::trap::TrapFrame, debug, sync::SpinLock, warn};
+use ostd::{arch::trap::TrapFrame, prelude::*, sync::SpinLock};
 
 use super::{config::VirtioNetConfig, header::VirtioNetHdr};
 use crate::{

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -8,7 +8,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use aster_softirq::BottomHalfDisabled;
 use ostd::{
     arch::trap::TrapFrame,
-    debug,
+    prelude::*,
     sync::{SpinLock, SpinLockGuard},
 };
 use spin::Once;

--- a/kernel/comps/virtio/src/device/socket/packet.rs
+++ b/kernel/comps/virtio/src/device/socket/packet.rs
@@ -4,8 +4,8 @@
 
 use aster_network::{RxBuffer, TxBuffer, TxBufferBuilder};
 use ostd::{
-    Result,
     mm::{Infallible, VmReader, VmWriter},
+    prelude::*,
 };
 
 use crate::device::socket::{

--- a/kernel/comps/virtio/src/dma_buf.rs
+++ b/kernel/comps/virtio/src/dma_buf.rs
@@ -4,9 +4,12 @@ use alloc::sync::Arc;
 
 use aster_network::{RxBuffer, TxBuffer, dma_pool::DmaSegment};
 use aster_util::mem_obj_slice::Slice;
-use ostd::mm::{
-    HasDaddr, HasSize,
-    dma::{DmaCoherent, DmaDirection, DmaStream},
+use ostd::{
+    mm::{
+        HasDaddr,
+        dma::{DmaCoherent, DmaDirection, DmaStream},
+    },
+    prelude::*,
 };
 
 /// A DMA-capable buffer.

--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -19,7 +19,7 @@ use device::{
     entropy::device::EntropyDevice, input::device::InputDevice, network::device::NetworkDevice,
     socket::device::SocketDevice,
 };
-use ostd::{error, warn};
+use ostd::prelude::*;
 use spin::Once;
 use transport::{DeviceStatus, mmio::VIRTIO_MMIO_DRIVER, pci::VIRTIO_PCI_DRIVER};
 

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -12,8 +12,8 @@ use aster_rights::{Dup, TRightSet, TRights, Write};
 use aster_util::{field_ptr, safe_ptr::SafePtr};
 use bitflags::bitflags;
 use ostd::{
-    debug,
-    mm::{HasPaddr, PodOnce, Split, dma::DmaCoherent},
+    mm::{PodOnce, Split, dma::DmaCoherent},
+    prelude::*,
 };
 
 use crate::{

--- a/kernel/comps/virtio/src/transport/mmio/bus/arch/x86.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/arch/x86.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub(super) use ostd::arch::irq::MappedIrqLine;
-use ostd::{arch::irq::IRQ_CHIP, debug};
+use ostd::{arch::irq::IRQ_CHIP, prelude::*};
 
 use crate::transport::mmio::bus::MmioRegisterError;
 

--- a/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
@@ -4,7 +4,7 @@
 
 use alloc::{collections::VecDeque, fmt::Debug, sync::Arc, vec::Vec};
 
-use ostd::{bus::BusProbeError, debug, error};
+use ostd::{bus::BusProbeError, prelude::*};
 
 use super::common_device::MmioCommonDevice;
 

--- a/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/common_device.rs
@@ -3,12 +3,7 @@
 //! MMIO device common definitions or functions.
 
 use int_to_c_enum::TryFromInt;
-use ostd::{
-    Error, Result, info,
-    io::IoMem,
-    irq::IrqLine,
-    mm::{HasPaddr, VmIoOnce},
-};
+use ostd::{Error, io::IoMem, irq::IrqLine, mm::VmIoOnce, prelude::*};
 
 use super::arch::MappedIrqLine;
 

--- a/kernel/comps/virtio/src/transport/mmio/bus/mod.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/mod.rs
@@ -5,7 +5,7 @@
 use core::ops::Range;
 
 use bus::MmioBus;
-use ostd::{debug, io::IoMem, irq::IrqLine, sync::SpinLock};
+use ostd::{io::IoMem, irq::IrqLine, prelude::*, sync::SpinLock};
 
 use crate::transport::mmio::bus::common_device::{
     MmioCommonDevice, mmio_check_magic, mmio_read_device_id,
@@ -48,7 +48,7 @@ fn try_register_mmio_device<F>(
     map_irq_line: F,
 ) -> Result<(), MmioRegisterError>
 where
-    F: FnOnce(IrqLine) -> ostd::Result<arch::MappedIrqLine>,
+    F: FnOnce(IrqLine) -> Result<arch::MappedIrqLine>,
 {
     let start_addr = mmio_range.start;
     let Ok(io_mem) = IoMem::acquire(mmio_range) else {

--- a/kernel/comps/virtio/src/transport/mmio/device.rs
+++ b/kernel/comps/virtio/src/transport/mmio/device.rs
@@ -9,8 +9,8 @@ use ostd::{
     io::IoMem,
     irq::IrqCallbackFunction,
     mm::{HasDaddr, PAGE_SIZE, dma::DmaCoherent},
+    prelude::*,
     sync::RwLock,
-    warn,
 };
 
 use super::{

--- a/kernel/comps/virtio/src/transport/pci/capability.rs
+++ b/kernel/comps/virtio/src/transport/pci/capability.rs
@@ -3,7 +3,7 @@
 use aster_pci::{
     capability::vendor::CapabilityVndrData, cfg_space::BarAccess, common_device::BarManager,
 };
-use ostd::{io::IoMem, warn};
+use ostd::{io::IoMem, prelude::*};
 
 #[expect(clippy::enum_variant_names)]
 #[repr(u8)]

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -9,11 +9,10 @@ use aster_pci::{
 use aster_util::{field_ptr, safe_ptr::SafePtr};
 use ostd::{
     bus::BusProbeError,
-    info,
     io::IoMem,
     irq::IrqCallbackFunction,
     mm::{HasDaddr, dma::DmaCoherent},
-    warn,
+    prelude::*,
 };
 
 use super::{common_cfg::VirtioPciCommonCfg, msix::VirtioMsixManager};

--- a/kernel/comps/virtio/src/transport/pci/legacy.rs
+++ b/kernel/comps/virtio/src/transport/pci/legacy.rs
@@ -7,11 +7,10 @@ use aster_pci::{cfg_space::BarAccess, common_device::PciCommonDevice};
 use aster_util::safe_ptr::SafePtr;
 use ostd::{
     bus::BusProbeError,
-    info,
     io::IoMem,
     irq::IrqCallbackFunction,
     mm::{HasDaddr, PAGE_SIZE, dma::DmaCoherent},
-    warn,
+    prelude::*,
 };
 
 use crate::{

--- a/kernel/libs/aster-util/src/mem_obj_slice.rs
+++ b/kernel/libs/aster-util/src/mem_obj_slice.rs
@@ -12,10 +12,13 @@
 use alloc::sync::Arc;
 use core::{borrow::Borrow, fmt::Debug, ops::Range};
 
-use ostd::mm::{
-    HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
-    dma::DmaStream,
-    io::util::{HasVmReaderWriter, VmReaderWriterResult},
+use ostd::{
+    mm::{
+        Daddr, HasDaddr, Infallible, VmReader, VmWriter,
+        dma::DmaStream,
+        io::util::{HasVmReaderWriter, VmReaderWriterResult},
+    },
+    prelude::*,
 };
 
 macro_rules! assert_in_range {
@@ -39,13 +42,13 @@ impl<MemObj: HasSize> HasSize for Slice<MemObj> {
 }
 
 impl<MemObj: HasSize + HasPaddr> HasPaddr for Slice<MemObj> {
-    fn paddr(&self) -> ostd::mm::Paddr {
+    fn paddr(&self) -> Paddr {
         self.mem_obj().paddr() + self.offset().start
     }
 }
 
 impl<MemObj: HasSize + HasDaddr> HasDaddr for Slice<MemObj> {
-    fn daddr(&self) -> ostd::mm::Daddr {
+    fn daddr(&self) -> Daddr {
         self.mem_obj().daddr() + self.offset().start
     }
 }
@@ -102,13 +105,13 @@ impl<MemObj: HasSize + HasVmReaderWriter<Types = VmReaderWriterResult>> HasVmRea
 {
     type Types = VmReaderWriterResult;
 
-    fn reader(&self) -> ostd::prelude::Result<VmReader<'_, Infallible>> {
+    fn reader(&self) -> Result<VmReader<'_, Infallible>> {
         let mut reader = self.mem_obj().reader()?;
         reader.skip(self.offset().start).limit(self.size());
         Ok(reader)
     }
 
-    fn writer(&self) -> ostd::prelude::Result<VmWriter<'_, Infallible>> {
+    fn writer(&self) -> Result<VmWriter<'_, Infallible>> {
         let mut writer = self.mem_obj().writer()?;
         writer.skip(self.offset().start).limit(self.size());
         Ok(writer)
@@ -123,7 +126,7 @@ impl<MemObj: HasSize + Borrow<Arc<DmaStream>>> Slice<MemObj> {
     ///
     /// The method will call [`DmaStream::sync_from_device`] with the offset
     /// range of this slice.
-    pub fn sync_from_device(&self) -> ostd::prelude::Result<()> {
+    pub fn sync_from_device(&self) -> Result<()> {
         self.mem_obj()
             .borrow()
             .sync_from_device(self.offset().clone())
@@ -133,7 +136,7 @@ impl<MemObj: HasSize + Borrow<Arc<DmaStream>>> Slice<MemObj> {
     ///
     /// The method will call [`DmaStream::sync_to_device`] with the offset
     /// range of this slice.
-    pub fn sync_to_device(&self) -> ostd::prelude::Result<()> {
+    pub fn sync_to_device(&self) -> Result<()> {
         self.mem_obj()
             .borrow()
             .sync_to_device(self.offset().clone())

--- a/kernel/libs/aster-util/src/safe_ptr.rs
+++ b/kernel/libs/aster-util/src/safe_ptr.rs
@@ -5,8 +5,8 @@ use core::{fmt::Debug, marker::PhantomData};
 use aster_rights::{Dup, Exec, Full, Read, Signal, TRightSet, TRights, Write};
 use aster_rights_proc::require;
 use ostd::{
-    Result,
-    mm::{Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce, dma::DmaDirection},
+    mm::{Daddr, HasDaddr, PodOnce, VmIo, VmIoOnce, dma::DmaDirection},
+    prelude::*,
 };
 use ostd_pod::Pod;
 

--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{borrow::ToOwned, collections::btree_set::BTreeSet, string::String, vec::Vec};
-use core::{arch::x86_64::CpuidResult, ffi::CStr, fmt, str};
+use alloc::borrow::ToOwned;
+use core::{arch::x86_64::CpuidResult, fmt, str};
 
 use ostd::{
     arch::{
@@ -12,13 +12,12 @@ use ostd::{
         tsc_freq,
     },
     cpu::{PinCurrentCpu, num_cpus},
-    mm::Vaddr,
-    sync::SpinLock,
     task::DisabledPreemptGuard,
 };
 
 use crate::{
     cpu::LinuxAbi,
+    prelude::*,
     vm::{perms::VmPerms, vmar::PageFaultInfo},
 };
 

--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::{
-    fmt::Debug,
     sync::atomic::{AtomicU8, AtomicUsize, Ordering},
     time::Duration,
 };

--- a/kernel/src/device/evdev/mod.rs
+++ b/kernel/src/device/evdev/mod.rs
@@ -10,10 +10,7 @@
 mod file;
 
 use alloc::format;
-use core::{
-    fmt::Debug,
-    sync::atomic::{AtomicU32, Ordering},
-};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_input::{
     event_type_codes::SynEvent,

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -2,7 +2,7 @@
 
 use aster_framebuffer::{ColorMapEntry, FRAMEBUFFER, FrameBuffer, MAX_CMAP_SIZE, PixelFormat};
 use device_id::{DeviceId, MajorId, MinorId};
-use ostd::mm::{HasPaddr, HasSize, VmIo};
+use ostd::{mm::VmIo, prelude::*};
 
 use super::{Device, DeviceType, DevtmpfsInodeMeta, registry::char};
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
         file::{Mappable, PerOpenFileOps, StatusFlags},
         vfs::inode::FileOps,
     },
-    prelude::*,
+    prelude::{Result, *},
     process::signal::{PollHandle, Pollable},
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -44,7 +44,8 @@ use aster_util::{field_ptr, safe_ptr::SafePtr};
 use device_id::{DeviceId, MinorId};
 use ostd::{
     const_assert,
-    mm::{FrameAllocOptions, HasPaddr, HasSize, USegment, VmIo, dma::DmaCoherent},
+    mm::{FrameAllocOptions, USegment, VmIo, dma::DmaCoherent},
+    prelude::*,
     sync::{RwMutexWriteGuard, WaitQueue},
 };
 use spin::Once;
@@ -61,7 +62,7 @@ use crate::{
         file::{PerOpenFileOps, StatusFlags},
         vfs::inode::FileOps,
     },
-    prelude::*,
+    prelude::{Result, *},
     process::signal::{PollHandle, Pollable},
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };

--- a/kernel/src/device/tty/vt/keyboard/handler.rs
+++ b/kernel/src/device/tty/vt/keyboard/handler.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_console::mode::{KeyboardMode, KeyboardModeFlags};
 use aster_framebuffer::{ConsoleCallbacks, FRAMEBUFFER_CONSOLE};
 use aster_input::{
@@ -11,10 +9,13 @@ use aster_input::{
 };
 use spin::Once;
 
-use crate::device::tty::vt::keyboard::{
-    CursorKey, LockKeyFlags, LockKeysState, ModifierKey, ModifierKeyFlags, ModifierKeysState,
-    NumpadKey,
-    keysym::{FuncId, KeySym, SpecialHandler, get_keysym},
+use crate::{
+    device::tty::vt::keyboard::{
+        CursorKey, LockKeyFlags, LockKeysState, ModifierKey, ModifierKeyFlags, ModifierKeysState,
+        NumpadKey,
+        keysym::{FuncId, KeySym, SpecialHandler, get_keysym},
+    },
+    prelude::*,
 };
 
 #[derive(Debug)]

--- a/kernel/src/device/tty/vt/keyboard/keysym.rs
+++ b/kernel/src/device/tty/vt/keyboard/keysym.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, vec, vec::Vec};
-
 use aster_input::event_type_codes::KeyCode;
 use spin::Once;
 
-use crate::device::tty::vt::{
-    VtIndex,
-    keyboard::{CursorKey, ModifierKey, ModifierKeyFlags, NumpadKey},
+use crate::{
+    device::tty::vt::{
+        VtIndex,
+        keyboard::{CursorKey, ModifierKey, ModifierKeyFlags, NumpadKey},
+    },
+    prelude::*,
 };
 
 /// The symbolic representation of a key under a given modifier state.

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::string::ToString;
-
 use aster_framebuffer::{CONSOLE_NAME, FRAMEBUFFER_CONSOLE};
-use ostd::info;
+
+use crate::prelude::*;
 
 pub fn init() {
     for device in aster_input::all_devices() {

--- a/kernel/src/events/epoll/entry.rs
+++ b/kernel/src/events/epoll/entry.rs
@@ -1,21 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{
-    collections::vec_deque::VecDeque,
-    sync::{Arc, Weak},
-};
 use core::{
     fmt::Display,
     sync::atomic::{AtomicBool, Ordering},
 };
 
 use keyable_arc::{KeyableArc, KeyableWeak};
-use ostd::sync::{LocalIrqDisabled, Mutex, MutexGuard, SpinLock, SpinLockGuard};
+use ostd::sync::LocalIrqDisabled;
 
 use super::{EpollEvent, EpollFlags};
 use crate::{
     events::{self, IoEvents},
     fs::file::{FileLike, file_table::FileDesc},
+    prelude::*,
     process::signal::{PollHandle, Pollee},
 };
 

--- a/kernel/src/fs/file/file_attr/creation_flags.rs
+++ b/kernel/src/fs/file/file_attr/creation_flags.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use bitflags::bitflags;
+use crate::prelude::bitflags;
 
 bitflags! {
     pub struct CreationFlags: u32 {

--- a/kernel/src/fs/file/file_attr/status_flags.rs
+++ b/kernel/src/fs/file/file_attr/status_flags.rs
@@ -3,7 +3,8 @@
 use core::sync::atomic::AtomicU32;
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use bitflags::bitflags;
+
+use crate::prelude::bitflags;
 
 bitflags! {
     pub struct StatusFlags: u32 {

--- a/kernel/src/fs/file/inode_attr/type.rs
+++ b/kernel/src/fs/file/inode_attr/type.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use int_to_c_enum::TryFromInt;
-
 use crate::{device::DeviceType, prelude::*};
 
 #[repr(u16)]

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
@@ -1,23 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_systree::{Error, MAX_ATTR_SIZE, Result, SysAttrSetBuilder, SysPerms, SysStr};
 use aster_util::{per_cpu_counter::PerCpuCounter, printer::VmPrinter};
-use ostd::{
-    cpu::CpuId,
-    mm::{VmReader, VmWriter},
-    sync::SpinLock,
-    task::atomic_mode::AsAtomicModeGuard,
-    timer::Jiffies,
-    warn,
-};
+use ostd::{cpu::CpuId, task::atomic_mode::AsAtomicModeGuard, timer::Jiffies};
 
 use crate::{
     fs::cgroupfs::systree_node::{CgroupSysNode, CgroupSystem},
+    prelude::*,
     process::Process,
-    util::ReadCString,
 };
 
 /// A sub-controller responsible for CPU resource management in the cgroup subsystem.

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_systree::{Error, Result, SysAttrSetBuilder, SysPerms, SysStr};
 use aster_util::printer::VmPrinter;
-use ostd::{
-    cpu::num_cpus,
-    mm::{VmReader, VmWriter},
-};
+use ostd::cpu::num_cpus;
+
+use crate::prelude::*;
 
 /// A sub-controller responsible for CPU resource management in the cgroup subsystem.
 pub struct CpuSetController {

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_systree::{Error, Result, SysAttrSetBuilder, SysPerms, SysStr};
-use ostd::mm::{VmReader, VmWriter};
+
+use crate::prelude::*;
 
 /// A sub-controller responsible for memory resource management in the cgroup subsystem.
 ///

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::vec_deque::VecDeque, sync::Arc};
 use core::{
     fmt::Display,
     str::FromStr,
@@ -9,19 +8,18 @@ use core::{
 
 use aster_systree::{Error, Result, SysAttrSetBuilder, SysBranchNode, SysObj};
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use bitflags::bitflags;
-use ostd::{
-    mm::{VmReader, VmWriter},
-    sync::Rcu,
-};
+use ostd::sync::Rcu;
 
-use crate::fs::cgroupfs::{
-    CgroupMembership, CgroupNode,
-    controller::{
-        cpu::CpuController, cpuset::CpuSetController, memory::MemoryController,
-        pids::PidsController,
+use crate::{
+    fs::cgroupfs::{
+        CgroupMembership, CgroupNode,
+        controller::{
+            cpu::CpuController, cpuset::CpuSetController, memory::MemoryController,
+            pids::PidsController,
+        },
+        systree_node::CgroupSysNode,
     },
-    systree_node::CgroupSysNode,
+    prelude::*,
 };
 
 pub(super) mod cpu;

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_systree::{Error, MAX_ATTR_SIZE, Result, SysAttrSetBuilder, SysPerms, SysStr};
 use aster_util::printer::VmPrinter;
-use ostd::mm::{VmReader, VmWriter};
 
 use super::TryChargeError;
-use crate::{process::posix_thread::PID_MAX, util::ReadCString};
+use crate::{prelude::*, process::posix_thread::PID_MAX};
 
 /// A sub-controller responsible for PID resource management in the cgroup subsystem.
 ///

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_systree::EmptyNode;
 use ostd::task::Task;
 use spin::Once;
@@ -9,7 +7,6 @@ use spin::Once;
 use super::inode::CgroupInode;
 use crate::{
     fs::{
-        Result,
         pseudofs::AnonDeviceId,
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
@@ -18,7 +15,7 @@ use crate::{
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
-    process::posix_thread::AsThreadLocal,
+    prelude::*,
 };
 
 /// A file system for managing cgroups.

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use aster_systree::SysNode;
 use spin::Once;
 
 use super::inode::ConfigInode;
-use crate::fs::{
-    Result,
-    configfs::systree_node::ConfigRootNode,
-    pseudofs::AnonDeviceId,
-    utils::systree_inode::SysTreeInodeTy,
-    vfs::{
-        file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-        inode::Inode,
-        registry::{FsCreationCtx, FsProperties, FsType},
+use crate::{
+    fs::{
+        configfs::systree_node::ConfigRootNode,
+        pseudofs::AnonDeviceId,
+        utils::systree_inode::SysTreeInodeTy,
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            inode::Inode,
+            registry::{FsCreationCtx, FsProperties, FsType},
+        },
     },
+    prelude::*,
 };
 
 /// A file system that provides a user-space interface for configuring kernel objects.

--- a/kernel/src/fs/fs_impls/configfs/systree_node.rs
+++ b/kernel/src/fs/fs_impls/configfs/systree_node.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::{Arc, Weak};
-use core::fmt::Debug;
-
 use aster_systree::{
     BranchNodeFields, Result, SysAttrSet, SysBranchNode, SysObj, SysPerms, SysStr,
     inherit_sys_branch_node,
 };
 use inherit_methods_macro::inherit_methods;
 use spin::Once;
+
+use crate::prelude::*;
 
 /// The `SysTree` node that represents the root node of the `ConfigFs`.
 #[derive(Debug)]

--- a/kernel/src/fs/fs_impls/configfs/test.rs
+++ b/kernel/src/fs/fs_impls/configfs/test.rs
@@ -17,22 +17,14 @@
 //! The `demo_set` is initially empty. One can create directories to trigger creating an in-kernel object
 //! that represents a new demo. Each demo has two attributes called `attr_a` and `attr_b`.
 
-use alloc::{string::ToString, sync::Arc};
-use core::{
-    fmt::Debug,
-    sync::atomic::{AtomicU32, Ordering},
-};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_systree::{
     BranchNodeFields, Error, NormalNodeFields, Result, SysAttrSet, SysAttrSetBuilder, SysObj,
     SysPerms, SysStr, inherit_sys_branch_node, inherit_sys_leaf_node,
 };
 use inherit_methods_macro::inherit_methods;
-use ostd::{
-    mm::{VmReader, VmWriter},
-    prelude::ktest,
-};
-use ostd_pod::IntoBytes;
+use ostd::prelude::ktest;
 use spin::Once;
 
 use crate::{
@@ -40,6 +32,7 @@ use crate::{
         file::{InodeType, mkmod},
         vfs::file_system::FileSystem,
     },
+    prelude::*,
     time::clocks::init_for_ktest as time_init_for_ktest,
 };
 

--- a/kernel/src/fs/fs_impls/ext2/prelude.rs
+++ b/kernel/src/fs/fs_impls/ext2/prelude.rs
@@ -14,7 +14,7 @@ pub(super) use aster_block::{
 pub(super) use io_util::batch::IoBatch;
 pub(super) use ostd::{
     mm::{Frame, FrameAllocOptions, Segment, USegment, VmIo},
-    sync::{RwMutex, RwMutexReadGuard, RwMutexWriteGuard},
+    sync::{RwMutexReadGuard, RwMutexWriteGuard},
 };
 
 pub(super) use super::utils::{Dirty, IsPowerOf};

--- a/kernel/src/fs/fs_impls/ext2/xattr.rs
+++ b/kernel/src/fs/fs_impls/ext2/xattr.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::{HasSize, io::util::HasVmReaderWriter};
+use ostd::{mm::io::util::HasVmReaderWriter, prelude::*};
 
 use super::{Ext2, Inode, block_ptr::Ext2Bid, prelude::*};
-use crate::fs::vfs::xattr::{XATTR_NAME_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags};
+use crate::{
+    fs::vfs::xattr::{XATTR_NAME_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
+    prelude::Result,
+};
 
 const EXT2_XATTR_MAGIC: u32 = 0xEA020000;
 

--- a/kernel/src/fs/fs_impls/pseudofs/allocator.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/allocator.rs
@@ -2,8 +2,9 @@
 
 use device_id::{DeviceId, MajorId, MinorId};
 use id_alloc::IdAlloc;
-use ostd::sync::Mutex;
 use spin::Once;
+
+use crate::prelude::*;
 
 /// An anonymous device ID that automatically recycles itself on drop.
 #[derive(Debug)]

--- a/kernel/src/fs/fs_impls/sysfs/kernel.rs
+++ b/kernel/src/fs/fs_impls/sysfs/kernel.rs
@@ -12,16 +12,15 @@
 //! - [cpu_byteorder](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-kernel-cpu_byteorder)
 //! - [address_bits](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-kernel-address_bits)
 
-use alloc::sync::Arc;
-
 use aster_systree::{
     BranchNodeFields, Error, Result, SysAttrSetBuilder, SysBranchNode, SysNode, SysPerms, SysStr,
     inherit_sys_branch_node,
 };
 use aster_util::printer::VmPrinter;
 use inherit_methods_macro::inherit_methods;
-use ostd::mm::{VmReader, VmWriter};
 use spin::Once;
+
+use crate::prelude::*;
 
 /// Registers a new kernel `SysNode`.
 pub(super) fn register(config_obj: Arc<dyn SysNode>) -> crate::prelude::Result<()> {

--- a/kernel/src/fs/fs_impls/sysfs/test.rs
+++ b/kernel/src/fs/fs_impls/sysfs/test.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{borrow::Cow, format, vec};
-use core::fmt::Debug;
+use alloc::{borrow::Cow, format};
 
 use aster_systree::{
     BranchNodeFields, Error as SysTreeError, NormalNodeFields, Result as SysTreeResult,

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -2,7 +2,7 @@
 
 use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
 use device_id::{DeviceId, MajorId, MinorId};
-use lending_iterator::LendingIterator;
+use lending_iterator::prelude::LendingIterator;
 use libflate::gzip::Decoder as GZipDecoder;
 use no_std_io2::io::{Cursor, Read};
 use ostd::boot::boot_info;

--- a/kernel/src/fs/utils/id_bitmap.rs
+++ b/kernel/src/fs/utils/id_bitmap.rs
@@ -3,11 +3,7 @@
 use core::ops::Range;
 
 use aster_block::BLOCK_SIZE;
-use bitvec::{
-    order::Lsb0,
-    slice::BitSlice,
-    view::{AsBits, AsMutBits},
-};
+use bitvec::prelude::*;
 
 use crate::prelude::*;
 
@@ -199,12 +195,9 @@ impl Debug for IdBitmap {
 
 #[cfg(ktest)]
 mod test {
-    use alloc::vec;
-
-    use aster_block::BLOCK_SIZE;
     use ostd::prelude::ktest;
 
-    use super::IdBitmap;
+    use super::*;
 
     #[ktest]
     fn bitmap_alloc_out_of_bounds() {

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -6,7 +6,6 @@ use core::{
 };
 
 use align_ext::AlignExt;
-use bitflags::bitflags;
 use hashbrown::HashMap;
 
 use crate::{

--- a/kernel/src/fs/vfs/notify/mod.rs
+++ b/kernel/src/fs/vfs/notify/mod.rs
@@ -3,7 +3,6 @@
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use bitflags::bitflags;
 
 use crate::{
     fs::{

--- a/kernel/src/ipc/semaphore/system_v/mod.rs
+++ b/kernel/src/ipc/semaphore/system_v/mod.rs
@@ -2,7 +2,7 @@
 
 //! System V semaphore.
 
-use bitflags::bitflags;
+use crate::prelude::bitflags;
 
 pub mod sem;
 pub mod sem_set;

--- a/kernel/src/net/iface/poll.rs
+++ b/kernel/src/net/iface/poll.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::time::Duration;
 
-use ostd::{debug, timer::Jiffies};
+use ostd::timer::Jiffies;
 
 use super::{Iface, iter_all_ifaces};
 use crate::{
+    prelude::*,
     sched::{Nice, SchedPolicy},
     thread::kernel_thread::ThreadOptions,
-    time::wait::WaitTimeout,
 };
 
 pub fn init_in_first_kthread() {

--- a/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::vec;
 use core::str::FromStr;
 
 use ostd::prelude::*;

--- a/kernel/src/net/socket/vsock/transport/port.rs
+++ b/kernel/src/net/socket/vsock/transport/port.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::collections::btree_map::BTreeMap;
-
 use crate::{
-    error::{Errno, Error, return_errno_with_message},
+    error::return_errno_with_message,
     net::socket::vsock::{
         addr::{VMADDR_CID_ANY, VMADDR_PORT_ANY, VsockSocketAddr},
         transport::{
@@ -11,7 +9,7 @@ use crate::{
             space::{VsockSpace, vsock_space},
         },
     },
-    prelude::Result,
+    prelude::*,
     process::signal::Pollee,
 };
 

--- a/kernel/src/net/socket/vsock/transport/timer.rs
+++ b/kernel/src/net/socket/vsock/transport/timer.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_softirq::{BottomHalfDisabled, Taskless};
-use ostd::sync::SpinLock;
 use spin::Once;
 
-use crate::net::socket::vsock::transport::{conn_id::ConnId, space::vsock_space};
+use crate::{
+    net::socket::vsock::transport::{conn_id::ConnId, space::vsock_space},
+    prelude::*,
+};
 
 static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
 

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -17,11 +17,9 @@ pub use aster_logger::{print, println};
 pub use bitflags::bitflags;
 pub use int_to_c_enum::TryFromInt;
 pub use ostd::{
-    alert, crit, debug, emerg, error, info,
-    mm::{FallibleVmRead, FallibleVmWrite, PAGE_SIZE, Vaddr, VmReader, VmWriter},
-    notice,
+    mm::{FallibleVmRead, FallibleVmWrite, PAGE_SIZE, VmReader, VmWriter},
+    prelude::{Vaddr, alert, crit, debug, emerg, error, info, notice, warn},
     sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
-    warn,
 };
 pub use ostd_pod::{FromBytes, FromZeros, IntoBytes, Pod};
 

--- a/kernel/src/process/credentials/capabilities.rs
+++ b/kernel/src/process/credentials/capabilities.rs
@@ -3,7 +3,8 @@
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use bitflags::bitflags;
+
+use crate::prelude::bitflags;
 
 bitflags! {
     /// Represents a set of Linux capabilities.

--- a/kernel/src/process/credentials/secure_bits.rs
+++ b/kernel/src/process/credentials/secure_bits.rs
@@ -3,7 +3,6 @@
 use core::sync::atomic::{AtomicU16, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use bitflags::bitflags;
 
 use crate::prelude::*;
 

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use int_to_c_enum::TryFromInt;
 use ostd::{
     cpu::num_cpus,
     sync::{PreemptDisabled, Waiter, Waker},

--- a/kernel/src/process/posix_thread/personality.rs
+++ b/kernel/src/process/posix_thread/personality.rs
@@ -2,9 +2,8 @@
 
 use core::sync::atomic::Ordering;
 
-use bitflags::bitflags;
-
 use super::PosixThread;
+use crate::prelude::*;
 
 bitflags! {
     pub struct Personality: u32 {

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{
-    boxed::Box,
-    sync::{Arc, Weak},
-    vec::Vec,
-};
-
 use id_alloc::IdAlloc;
-use ostd::{cpu::PrivilegeLevel, irq::InterruptLevel, sync::Mutex, timer};
+use ostd::{cpu::PrivilegeLevel, irq::InterruptLevel, timer};
 
 use super::Process;
 use crate::{
     fs::cgroupfs::{CpuStatKind, charge_cpu_time},
+    prelude::*,
     process::{
         posix_thread::AsPosixThread,
         signal::{constants::SIGALRM, signals::kernel::KernelSignal},

--- a/kernel/src/process/program_loader/elf/relocate.rs
+++ b/kernel/src/process/program_loader/elf/relocate.rs
@@ -2,7 +2,7 @@
 
 use core::ops::Range;
 
-use ostd::mm::Vaddr;
+use ostd::prelude::Vaddr;
 
 /// A virtual range and its relocated address.
 pub(super) struct RelocatedRange {

--- a/kernel/src/process/program_loader/shebang.rs
+++ b/kernel/src/process/program_loader/shebang.rs
@@ -44,11 +44,9 @@ pub fn parse_shebang_line(file_first_page: &[u8]) -> Result<Option<Vec<CString>>
 
 #[cfg(ktest)]
 mod test {
-    use alloc::{ffi::CString, vec};
-
     use ostd::prelude::*;
 
-    use super::parse_shebang_line;
+    use super::*;
 
     #[ktest]
     fn parse_shebang_line_with_multiple_args() {

--- a/kernel/src/process/signal/sig_action.rs
+++ b/kernel/src/process/signal/sig_action.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use bitflags::bitflags;
-
 use super::{
     c_types::sigaction_t,
     constants::*,

--- a/kernel/src/process/signal/signals/mod.rs
+++ b/kernel/src/process/signal/signals/mod.rs
@@ -5,9 +5,8 @@ pub mod kernel;
 pub mod raw;
 pub mod user;
 
-use core::{any::Any, fmt::Debug};
-
 use super::{c_types::siginfo_t, sig_num::SigNum};
+use crate::prelude::*;
 
 pub trait Signal: Send + Sync + Debug + Any {
     /// Returns the number of the signal.

--- a/kernel/src/process/signal/signals/raw.rs
+++ b/kernel/src/process/signal/signals/raw.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt::Debug;
-
-use crate::process::signal::{c_types::siginfo_t, sig_num::SigNum, signals::Signal};
+use crate::{
+    prelude::*,
+    process::signal::{c_types::siginfo_t, sig_num::SigNum, signals::Signal},
+};
 
 /// A signal that carries raw [`siginfo_t`] information.
 #[derive(Clone, Copy)]

--- a/kernel/src/process/signal/signals/user.rs
+++ b/kernel/src/process/signal/signals/user.rs
@@ -4,7 +4,7 @@
 
 use super::Signal;
 use crate::{
-    context::Context,
+    prelude::*,
     process::{
         Pid, Uid,
         signal::{

--- a/kernel/src/process/status.rs
+++ b/kernel/src/process/status.rs
@@ -4,10 +4,11 @@
 
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use ostd::sync::SpinLock;
-
 use super::ExitCode;
-use crate::process::{WaitOptions, signal::sig_num::SigNum};
+use crate::{
+    prelude::*,
+    process::{WaitOptions, signal::sig_num::SigNum},
+};
 
 /// The status of a process.
 ///

--- a/kernel/src/process/sync/condvar.rs
+++ b/kernel/src/process/sync/condvar.rs
@@ -3,12 +3,11 @@
 #![expect(dead_code)]
 #![expect(unused_variables)]
 
-use alloc::sync::Arc;
 use core::time::Duration;
 
-use ostd::sync::{MutexGuard, SpinLock, WaitQueue};
+use ostd::sync::WaitQueue;
 
-use crate::time::wait::WaitTimeout;
+use crate::prelude::*;
 
 /// Represents potential errors during lock operations on synchronization primitives,
 /// specifically for operations associated with a `Condvar` (Condition Variable).
@@ -265,7 +264,7 @@ impl Condvar {
 
 #[cfg(ktest)]
 mod test {
-    use ostd::{prelude::*, sync::Mutex};
+    use ostd::prelude::*;
 
     use super::*;
     use crate::thread::{Thread, kernel_thread::ThreadOptions};

--- a/kernel/src/sched/sched_class/fair.rs
+++ b/kernel/src/sched/sched_class/fair.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::BinaryHeap, sync::Arc};
+use alloc::collections::BinaryHeap;
 use core::{
     cmp::{self, Reverse},
     sync::atomic::{AtomicU64, Ordering},
@@ -8,7 +8,6 @@ use core::{
 
 use ostd::{
     cpu::{CpuId, num_cpus},
-    sync::SpinLock,
     task::{
         Task,
         scheduler::{EnqueueFlags, UpdateFlags},
@@ -20,6 +19,7 @@ use super::{
     time::{base_slice_clocks, min_period_clocks},
 };
 use crate::{
+    prelude::*,
     sched::nice::{Nice, NiceValue},
     thread::AsThread,
 };
@@ -183,7 +183,7 @@ impl FairAttr {
 /// run queue implemented by `BTreeSet` in the `FairClassRq`.
 struct FairQueueItem(Arc<Task>, u64);
 
-impl core::fmt::Debug for FairQueueItem {
+impl Debug for FairQueueItem {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.key())
     }

--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use ostd::task::{
     Task,
     scheduler::{EnqueueFlags, UpdateFlags},
 };
 
 use super::{CurrentRuntime, SchedAttr, SchedClassRq};
+use crate::prelude::*;
 
 /// The per-cpu run queue for the IDLE scheduling class.
 ///
@@ -22,7 +21,7 @@ impl IdleClassRq {
     }
 }
 
-impl core::fmt::Debug for IdleClassRq {
+impl Debug for IdleClassRq {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.entity.is_some() {
             write!(f, "Idle: occupied")?;

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -4,14 +4,13 @@
 
 #![warn(unused)]
 
-use alloc::{boxed::Box, sync::Arc};
-use core::{fmt, ops::Bound, sync::atomic::Ordering};
+use core::{ops::Bound, sync::atomic::Ordering};
 
 use ostd::{
     arch::read_tsc as sched_clock,
     cpu::{CpuId, CpuSet, PinCurrentCpu, all_cpus},
     irq::disable_local,
-    sync::{LocalIrqDisabled, SpinLock},
+    sync::LocalIrqDisabled,
     task::{
         AtomicCpuId, Task,
         scheduler::{
@@ -26,7 +25,10 @@ use super::{
     nice::Nice,
     stats::{SchedulerStats, set_stats_from_scheduler},
 };
-use crate::thread::{AsThread, Thread};
+use crate::{
+    prelude::*,
+    thread::{AsThread, Thread},
+};
 
 mod policy;
 mod time;
@@ -115,7 +117,7 @@ impl CurrentRuntime {
 
 /// The run queue for scheduling classes (the main trait). Scheduling classes
 /// should implement this trait to function as expected.
-trait SchedClassRq: Send + fmt::Debug {
+trait SchedClassRq: Send + Debug {
     /// Enqueues a task into the run queue.
     fn enqueue(&mut self, task: Arc<Task>, flags: Option<EnqueueFlags>);
 

--- a/kernel/src/sched/sched_class/policy.rs
+++ b/kernel/src/sched/sched_class/policy.rs
@@ -3,11 +3,9 @@
 use core::sync::atomic::{AtomicU8, Ordering::Relaxed};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use int_to_c_enum::TryFromInt;
-use ostd::sync::SpinLock;
 
 pub use super::real_time::{RealTimePolicy, RealTimePriority};
-use crate::sched::nice::Nice;
+use crate::{prelude::*, sched::nice::Nice};
 
 /// The User-chosen scheduling policy.
 ///

--- a/kernel/src/sched/sched_class/real_time.rs
+++ b/kernel/src/sched/sched_class/real_time.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::VecDeque, sync::Arc};
 use core::{
     array,
     num::NonZero,
@@ -8,7 +7,7 @@ use core::{
 };
 
 use aster_util::ranged_integer::RangedU8;
-use bitvec::{BitArr, bitarr};
+use bitvec::prelude::*;
 use ostd::{
     cpu::CpuId,
     task::{
@@ -18,7 +17,7 @@ use ostd::{
 };
 
 use super::{CurrentRuntime, SchedAttr, SchedClassRq, time::base_slice_clocks};
-use crate::thread::AsThread;
+use crate::{prelude::*, thread::AsThread};
 
 pub type RealTimePriority = RangedU8<1, 99>;
 
@@ -91,7 +90,7 @@ struct PrioArray {
     queue: [VecDeque<Arc<Task>>; 100],
 }
 
-impl core::fmt::Debug for PrioArray {
+impl Debug for PrioArray {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PrioArray")
             .field_with("map", |f| {

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use ostd::task::{
     Task,
     scheduler::{EnqueueFlags, UpdateFlags},
 };
 
 use super::{CurrentRuntime, SchedAttr, SchedClassRq};
+use crate::prelude::*;
 
 /// The per-cpu run queue for the STOP scheduling class.
 ///
@@ -23,7 +22,7 @@ impl StopClassRq {
     }
 }
 
-impl core::fmt::Debug for StopClassRq {
+impl Debug for StopClassRq {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.entity.is_some() {
             write!(f, "Stop: occupied")?;

--- a/kernel/src/sched/stats/loadavg.rs
+++ b/kernel/src/sched/stats/loadavg.rs
@@ -7,10 +7,9 @@
 use core::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
 use aster_util::fixed_point::FixedU32;
-use ostd::{
-    sync::RwLock,
-    timer::{self, TIMER_FREQ},
-};
+use ostd::timer::{self, TIMER_FREQ};
+
+use crate::prelude::*;
 
 /// Fixed-point representation of the load average.
 ///

--- a/kernel/src/security/tsm.rs
+++ b/kernel/src/security/tsm.rs
@@ -11,21 +11,14 @@
 //! For more information about the interface,
 //! checkout Linux's [documentation](https://www.kernel.org/doc/Documentation/ABI/testing/configfs-tsm).
 
-use alloc::{boxed::Box, string::ToString, sync::Arc};
-use core::fmt::Debug;
-
 use aster_systree::{
     BranchNodeFields, Error, NormalNodeFields, Result, SysAttrSetBuilder, SysObj, SysPerms, SysStr,
     inherit_sys_branch_node, inherit_sys_leaf_node,
 };
 use aster_util::printer::VmPrinter;
 use inherit_methods_macro::inherit_methods;
-use ostd::{
-    mm::{FallibleVmRead, FallibleVmWrite, VmReader, VmWriter},
-    sync::RwMutex,
-};
 
-use crate::{device::misc::tdxguest::tdx_get_quote, fs::configfs};
+use crate::{device::misc::tdxguest::tdx_get_quote, fs::configfs, prelude::*};
 
 #[derive(Debug)]
 struct Tsm {

--- a/kernel/src/security/tsm_mr.rs
+++ b/kernel/src/security/tsm_mr.rs
@@ -17,19 +17,16 @@
 //! For more information about the TSM-MR ABI, see the Linux kernel
 //! [documentation](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-virtual-misc-tdx_guest).
 
-use alloc::sync::Arc;
-
 use aster_systree::{
     BranchNodeFields, Error, NormalNodeFields, Result, SysAttrSetBuilder, SysObj, SysPerms, SysStr,
     inherit_sys_branch_node, inherit_sys_leaf_node,
 };
 use inherit_methods_macro::inherit_methods;
-use ostd::{
-    mm::{FallibleVmRead, FallibleVmWrite, VmReader, VmWriter},
-    sync::RwMutex,
-};
 
-use crate::device::misc::tdxguest::{self, MeasurementReg, Rtmr, SHA384_DIGEST_SIZE};
+use crate::{
+    device::misc::tdxguest::{self, MeasurementReg, Rtmr, SHA384_DIGEST_SIZE},
+    prelude::*,
+};
 
 pub(super) fn init() {
     let node = {

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -2,7 +2,6 @@
 
 use core::time::Duration;
 
-use int_to_c_enum::TryFromInt;
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use bitflags::bitflags;
-
 use super::SyscallReturn;
 use crate::{
     fs::{

--- a/kernel/src/syscall/getrusage.rs
+++ b/kernel/src/syscall/getrusage.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use int_to_c_enum::TryFromInt;
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -11,7 +11,6 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use bitflags::bitflags;
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;

--- a/kernel/src/thread/work_queue/simple_scheduler.rs
+++ b/kernel/src/thread/work_queue/simple_scheduler.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Weak;
-
 use super::worker_pool::{WorkerPool, WorkerScheduler};
+use crate::prelude::*;
 
 /// SimpleScheduler is the simplest scheduling implementation.
 /// Only when there is a liveness problem in the workerpool, increase the workers,

--- a/kernel/src/time/clocks/cpu_clock.rs
+++ b/kernel/src/time/clocks/cpu_clock.rs
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::time::Duration;
 
-use ostd::{
-    sync::{LocalIrqDisabled, SpinLock},
-    timer::Jiffies,
-};
+use ostd::{sync::LocalIrqDisabled, timer::Jiffies};
 
-use crate::time::Clock;
+use crate::prelude::*;
 
 /// A clock used to record the CPU time for processes and threads.
 pub struct CpuClock {

--- a/kernel/src/time/clocks/system_wide.rs
+++ b/kernel/src/time/clocks/system_wide.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
 use core::time::Duration;
 
 use aster_time::read_monotonic_time;
-use ostd::{cpu::PinCurrentCpu, cpu_local, sync::SpinLock, task::disable_preempt, timer::Jiffies};
+use ostd::{cpu::PinCurrentCpu, cpu_local, task::disable_preempt, timer::Jiffies};
 use paste::paste;
 use spin::Once;
 
-use crate::time::{
-    self, Clock, SystemTime, system_time::START_TIME_AS_DURATION, timer::TimerManager,
+use crate::{
+    prelude::*,
+    time::{self, SystemTime, system_time::START_TIME_AS_DURATION, timer::TimerManager},
 };
 
 /// The Clock that reads the jiffies, and turn the counter into `Duration`.

--- a/kernel/src/time/core/timer.rs
+++ b/kernel/src/time/core/timer.rs
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{
-    boxed::Box,
-    collections::BinaryHeap,
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::collections::BinaryHeap;
 use core::{
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 
-use ostd::sync::{LocalIrqDisabled, SpinLock, SpinLockGuard};
+use ostd::sync::LocalIrqDisabled;
 
-use super::Clock;
+use crate::prelude::*;
 
 /// A timeout, represented in one of the two ways.
 #[derive(Clone, Debug)]

--- a/kernel/src/time/softirq.rs
+++ b/kernel/src/time/softirq.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, vec, vec::Vec};
-
 use aster_softirq::{SoftIrqLine, softirq_id::TIMER_SOFTIRQ_ID};
 use ostd::{sync::RcuOption, timer};
+
+use crate::prelude::*;
 
 #[expect(clippy::type_complexity)]
 static TIMER_SOFTIRQ_CALLBACKS: RcuOption<Box<Vec<fn()>>> = RcuOption::new_none();

--- a/kernel/src/util/ioctl/sealed.rs
+++ b/kernel/src/util/ioctl/sealed.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use int_to_c_enum::TryFromInt;
+use crate::prelude::TryFromInt;
 
 /// An ioctl command that follows Linux-style encoding.
 ///

--- a/kernel/src/util/net/options/ip.rs
+++ b/kernel/src/util/net/options/ip.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use int_to_c_enum::TryFromInt;
-
 use super::{RawSocketOption, SocketOption, impl_raw_socket_option};
 use crate::{
     net::socket::ip::options::{Hdrincl, Recverr, Tos, Ttl},

--- a/kernel/src/util/random.rs
+++ b/kernel/src/util/random.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 use spin::Once;
 
 use crate::prelude::*;

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -122,8 +122,6 @@ impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
 
 #[cfg(ktest)]
 mod test {
-    use alloc::vec;
-
     use ostd::prelude::*;
 
     use super::*;

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -12,20 +12,18 @@
 //! ([`Vmo`]) that encapsulates both the data and the vDSO routines. The VMO is intended to be
 //! mapped into the address space of every user space process for efficient access.
 
-use alloc::sync::Arc;
 use core::{mem::ManuallyDrop, time::Duration};
 
 use aster_time::{Instant, read_monotonic_time};
 use aster_util::coeff::Coeff;
 use ostd::{
     const_assert,
-    mm::{PAGE_SIZE, UFrame, VmIo, VmIoOnce, VmReader},
-    sync::SpinLock,
+    mm::{UFrame, VmIo, VmIoOnce},
 };
-use ostd_pod::IntoBytes;
 use spin::Once;
 
 use crate::{
+    prelude::*,
     syscall::ClockId,
     time::{
         START_TIME, SystemTime,

--- a/kernel/src/vm/page_cache/cache_page.rs
+++ b/kernel/src/vm/page_cache/cache_page.rs
@@ -9,7 +9,8 @@ use core::{
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use ostd::{
     impl_untyped_frame_meta_for,
-    mm::{Frame, FrameAllocOptions, HasPaddr},
+    mm::{Frame, FrameAllocOptions},
+    prelude::HasPaddr,
     sync::WaitQueue,
 };
 

--- a/kernel/src/vm/page_cache/tests/mod.rs
+++ b/kernel/src/vm/page_cache/tests/mod.rs
@@ -3,8 +3,6 @@
 //! Regression tests for the page-cache subsystem in the
 //! concurrency scenarios.
 
-use alloc::vec;
-
 use ostd::{mm::VmIo, prelude::ktest};
 
 use self::utils::{IoCompletion, IoKind, MockPageCacheBackend, wait_until};

--- a/kernel/src/vm/page_cache/tests/utils.rs
+++ b/kernel/src/vm/page_cache/tests/utils.rs
@@ -2,7 +2,7 @@
 
 //! Test-only helpers for deterministic page-cache I/O scheduling.
 
-use alloc::{format, vec};
+use alloc::format;
 use core::fmt;
 
 use aster_block::{

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -23,10 +23,7 @@ use core::{
 
 use align_ext::AlignExt;
 use io_util::batch::IoBatch;
-use ostd::{
-    mm::{HasPaddr, io::util::HasVmReaderWriter},
-    task::disable_preempt,
-};
+use ostd::{mm::io::util::HasVmReaderWriter, prelude::HasPaddr, task::disable_preempt};
 use xarray::{Cursor, LockedXArray, XArray};
 
 use crate::{

--- a/kernel/src/vm/perms.rs
+++ b/kernel/src/vm/perms.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_rights::Rights;
-use bitflags::bitflags;
 use ostd::mm::PageFlags;
 
 use crate::prelude::*;

--- a/kernel/src/vm/vmar/handle.rs
+++ b/kernel/src/vm/vmar/handle.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::{Arc, Weak};
 use core::ops::Deref;
 
-use crate::{process::ProcessVm, vm::vmar::Vmar};
+use crate::{prelude::*, process::ProcessVm, vm::vmar::Vmar};
 
 /// A VMAR handle that is owned by a POSIX thread.
 ///

--- a/kernel/src/vm/vmar/interval_set.rs
+++ b/kernel/src/vm/vmar/interval_set.rs
@@ -2,8 +2,10 @@
 
 //! Intervals and interval sets used in VMARs.
 
-use alloc::collections::btree_map::{BTreeMap, Cursor, CursorMut};
+use alloc::collections::btree_map::{Cursor, CursorMut};
 use core::ops::Range;
+
+use crate::prelude::*;
 
 /// The interval of an item in an interval set.
 ///
@@ -242,8 +244,6 @@ where
 
 #[cfg(ktest)]
 mod tests {
-    use alloc::{vec, vec::Vec};
-
     use ostd::prelude::ktest;
 
     use super::*;

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -9,7 +9,7 @@ mod vm_mapping;
 
 mod vmar_impls;
 
-use ostd::mm::Vaddr;
+use ostd::prelude::Vaddr;
 
 pub use self::{
     handle::VmarHandle,

--- a/osdk/deps/frame-allocator/src/cache.rs
+++ b/osdk/deps/frame-allocator/src/cache.rs
@@ -4,11 +4,7 @@
 
 use core::{alloc::Layout, cell::RefCell};
 
-use ostd::{
-    cpu_local,
-    irq::DisabledLocalIrqGuard,
-    mm::{PAGE_SIZE, Paddr},
-};
+use ostd::{cpu_local, irq::DisabledLocalIrqGuard, mm::PAGE_SIZE, prelude::*};
 
 cpu_local! {
     static CACHE: RefCell<CacheOfSizes> = RefCell::new(CacheOfSizes::new());

--- a/osdk/deps/frame-allocator/src/chunk.rs
+++ b/osdk/deps/frame-allocator/src/chunk.rs
@@ -2,7 +2,8 @@
 
 use ostd::{
     impl_frame_meta_for,
-    mm::{HasPaddr, PAGE_SIZE, Paddr, UniqueFrame, frame::linked_list::Link},
+    mm::{PAGE_SIZE, UniqueFrame, frame::linked_list::Link},
+    prelude::*,
 };
 
 /// The order of a buddy chunk.

--- a/osdk/deps/frame-allocator/src/lib.rs
+++ b/osdk/deps/frame-allocator/src/lib.rs
@@ -30,11 +30,7 @@ extern crate alloc;
 
 use core::alloc::Layout;
 
-use ostd::{
-    cpu::PinCurrentCpu,
-    irq,
-    mm::{Paddr, frame::GlobalFrameAllocator},
-};
+use ostd::{cpu::PinCurrentCpu, irq, mm::frame::GlobalFrameAllocator, prelude::*};
 
 mod cache;
 mod chunk;

--- a/osdk/deps/frame-allocator/src/pools/mod.rs
+++ b/osdk/deps/frame-allocator/src/pools/mod.rs
@@ -12,7 +12,7 @@ use core::{
 use ostd::{
     cpu_local,
     irq::DisabledLocalIrqGuard,
-    mm::Paddr,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock, SpinLockGuard},
 };
 

--- a/osdk/deps/frame-allocator/src/set.rs
+++ b/osdk/deps/frame-allocator/src/set.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::{HasPaddr, Paddr, frame::linked_list::LinkedList};
+use ostd::mm::frame::linked_list::LinkedList;
+use ostd::prelude::*;
 
 use crate::chunk::{BuddyOrder, FreeChunk, FreeHeadMeta, size_of_order};
 

--- a/osdk/deps/frame-allocator/src/test.rs
+++ b/osdk/deps/frame-allocator/src/test.rs
@@ -5,11 +5,8 @@
 use core::alloc::Layout;
 
 use ostd::{
-    mm::{
-        FrameAllocOptions, HasPaddr, PAGE_SIZE, Paddr, Segment, UniqueFrame,
-        frame::GlobalFrameAllocator,
-    },
-    prelude::ktest,
+    mm::{FrameAllocOptions, PAGE_SIZE, Segment, UniqueFrame, frame::GlobalFrameAllocator},
+    prelude::*,
 };
 
 use super::FrameAllocator;

--- a/osdk/deps/heap-allocator/src/slab_cache.rs
+++ b/osdk/deps/heap-allocator/src/slab_cache.rs
@@ -5,10 +5,11 @@
 use core::alloc::AllocError;
 
 use ostd::mm::{
-    PAGE_SIZE, Paddr,
+    PAGE_SIZE,
     frame::linked_list::LinkedList,
     heap::{HeapSlot, Slab, SlabMeta},
 };
+use ostd::prelude::*;
 
 const EXPECTED_EMPTY_SLABS: usize = 4;
 const MAX_EMPTY_SLABS: usize = 16;

--- a/osdk/deps/test-kernel/src/lib.rs
+++ b/osdk/deps/test-kernel/src/lib.rs
@@ -16,10 +16,10 @@ use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::{any::Any, format_args};
 
 use ostd::{
-    early_print, early_println,
     ktest::{
         KtestError, KtestItem, KtestIter, get_ktest_crate_whitelist, get_ktest_test_whitelist,
     },
+    prelude::*,
 };
 use owo_colors::OwoColorize;
 use path::{KtestPath, SuffixTrie};
@@ -73,7 +73,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     // If not caught, abort the kernel.
     early_println!("An uncaught panic occurred: {:#?}", throw_info);
 
-    ostd::prelude::abort();
+    abort();
 }
 
 /// Run all the tests registered by `#[ktest]` in the `.ktest_array` section.

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -59,11 +59,11 @@ pub fn main() {
         OsdkSubcommand::Test(test_args) => {
             execute_test_command(&load_config(&test_args.common_args), test_args);
         }
-        OsdkSubcommand::Check(args) => execute_forwarded_command("check", &args.args, args.ktests),
-        OsdkSubcommand::Clippy(args) => {
-            execute_forwarded_command("clippy", &args.args, args.ktests)
+        OsdkSubcommand::Check(args) => execute_forwarded_command("check", args),
+        OsdkSubcommand::Clippy(args) => execute_forwarded_command("clippy", args),
+        OsdkSubcommand::Doc(args) => {
+            execute_forwarded_command("doc", &args.to_doc_subcommand_args())
         }
-        OsdkSubcommand::Doc(args) => execute_forwarded_command("doc", &args.args, false),
     }
 }
 
@@ -108,6 +108,11 @@ pub struct KtestWithForwardedArguments {
     #[arg(long, help = "Check all targets that have `ktest = true` set")]
     pub ktests: bool,
     #[arg(
+        long,
+        help = "Check kernel-specific code via KLint, only companied with `cargo osdk check`"
+    )]
+    pub klint: bool,
+    #[arg(
         help = "The full set of Cargo arguments",
         trailing_var_arg = true,
         allow_hyphen_values = true
@@ -123,6 +128,16 @@ pub struct ForwardedArguments {
         allow_hyphen_values = true
     )]
     pub args: Vec<String>,
+}
+
+impl ForwardedArguments {
+    fn to_doc_subcommand_args(&self) -> KtestWithForwardedArguments {
+        KtestWithForwardedArguments {
+            ktests: false,
+            klint: false,
+            args: self.args.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Parser)]

--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -311,7 +311,7 @@ impl DebugProfileOutArgs {
     /// output path to the file to override the file name.
     pub fn output_path(&self, hint: Option<&PathBuf>) -> PathBuf {
         self.output.clone().unwrap_or_else(|| {
-            use chrono::{DateTime, offset::Local};
+            use chrono::prelude::{DateTime, Local};
             let file_stem = if let Some(hint) = hint {
                 format!(
                     "{}",

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -15,33 +15,43 @@ pub use self::{
     profile::execute_profile_command, run::execute_run_command, test::execute_test_command,
 };
 
-use crate::{arch::get_default_arch, error_msg};
+use crate::{arch::get_default_arch, cli::KtestWithForwardedArguments, error_msg};
+use std::{env, process};
 
 /// Execute the forwarded cargo command with arguments.
-///
-/// The `cfg_ktest` parameter controls whether `cfg(ktest)` is enabled.
-pub fn execute_forwarded_command(subcommand: &str, args: &Vec<String>, cfg_ktest: bool) {
+pub fn execute_forwarded_command(subcommand: &str, cli: &KtestWithForwardedArguments) {
     let mut cargo = util::cargo();
     cargo.arg(subcommand).args(util::COMMON_CARGO_ARGS);
-    if !args.contains(&"--target".to_owned()) {
+    if !cli.args.contains(&"--target".to_owned()) {
         cargo.arg("--target").arg(get_default_arch().triple());
     }
-    cargo.args(args);
+    cargo.args(&cli.args);
 
-    let env_rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    let env_rustflags = env::var("RUSTFLAGS").unwrap_or_default();
     let rustflags = env_rustflags + " --check-cfg cfg(ktest)";
-    let rustflags = if cfg_ktest {
+    let rustflags = if cli.ktests {
         rustflags + " --cfg ktest"
     } else {
         rustflags
     };
-
     cargo.env("RUSTFLAGS", rustflags);
+
+    if cli.klint {
+        if subcommand != "check" {
+            error_msg!("`--klint` must be used only with `cargo osdk check`");
+            process::exit(1);
+        }
+        let Ok(path) = which::which("klint") else {
+            error_msg!("Command `klint` is not found. Please install it and put it in $PATH.");
+            process::exit(1);
+        };
+        cargo.env("RUSTC", path);
+    }
 
     // When generating documentation via `cargo doc`, the `--check-cfg cfg(ktest)` flag
     // must be specified in both `RUSTFLAGS` and `RUSTDOCFLAGS`.
     if subcommand == "doc" {
-        let env_rustdocflags = std::env::var("RUSTDOCFLAGS").unwrap_or_default();
+        let env_rustdocflags = env::var("RUSTDOCFLAGS").unwrap_or_default();
         let rustdocflags = env_rustdocflags + " --check-cfg cfg(ktest)";
         cargo.env("RUSTDOCFLAGS", rustdocflags);
     }
@@ -49,6 +59,6 @@ pub fn execute_forwarded_command(subcommand: &str, args: &Vec<String>, cfg_ktest
     let status = cargo.status().expect("Failed to execute cargo");
     if !status.success() {
         error_msg!("Command {:?} failed with status: {:?}", cargo, status);
-        std::process::exit(status.code().unwrap_or(1));
+        process::exit(status.code().unwrap_or(1));
     }
 }

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -4,7 +4,7 @@
 
 use proc_macro::{Diagnostic, Level, Span, TokenStream};
 use quote::quote;
-use rand::{Rng, distr::Alphanumeric};
+use rand::{distr::Alphanumeric, prelude::*};
 use syn::{Expr, Ident, ItemFn, parse_macro_input};
 
 /// A macro attribute to mark the kernel entry point.

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -7,7 +7,8 @@ use crate::{
         BootloaderAcpiArg, BootloaderFramebufferArg,
         memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
     },
-    mm::{Paddr, kspace::paddr_to_vaddr},
+    mm::kspace::paddr_to_vaddr,
+    prelude::*,
 };
 
 global_asm!(include_str!("header.S"));

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -9,7 +9,8 @@ use crate::{
         BootloaderAcpiArg, BootloaderFramebufferArg,
         memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
     },
-    mm::{Paddr, kspace::paddr_to_vaddr},
+    mm::kspace::paddr_to_vaddr,
+    prelude::*,
 };
 
 global_asm!(include_str!("header.S"));

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -44,7 +44,8 @@ use crate::{
         memory_region::{MemoryRegion, MemoryRegionType},
         smp::PerApRawInfo,
     },
-    mm::{PAGE_SIZE, Paddr, paddr_to_vaddr},
+    mm::{PAGE_SIZE, paddr_to_vaddr},
+    prelude::*,
     task::disable_preempt,
 };
 

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -2,7 +2,6 @@
 
 //! CPU execution context control.
 
-use alloc::boxed::Box;
 use core::arch::x86_64::{_fxrstor64, _fxsave64, _xrstor64, _xsave64};
 
 use bitflags::bitflags;
@@ -22,9 +21,8 @@ use crate::{
         trap::{RawUserContext, TrapFrame},
     },
     cpu::PrivilegeLevel,
-    debug,
     irq::call_irq_callback_functions,
-    mm::Vaddr,
+    prelude::*,
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 

--- a/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/context_table.rs
@@ -7,12 +7,12 @@ use alloc::collections::BTreeMap;
 use super::second_stage::IommuPtConfig;
 use crate::{
     arch::iommu::dma_remapping::PciDeviceLocation,
-    debug,
     mm::{
-        Daddr, Frame, FrameAllocOptions, HasPaddr, PAGE_SIZE, Paddr, PageFlags, PageTable, VmIo,
+        Daddr, Frame, FrameAllocOptions, PAGE_SIZE, PageFlags, PageTable, VmIo,
         page_prop::{CachePolicy, PageProperty, PrivilegedPageFlags as PrivFlags},
         page_table::PageTableError,
     },
+    prelude::*,
     task::disable_preempt,
 };
 

--- a/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
@@ -7,11 +7,9 @@ use spin::Once;
 use super::IommuError;
 use crate::{
     arch::iommu::registers::{CapabilitySagaw, IOMMU_REGS},
-    info,
     mm::{Daddr, PageTable},
-    prelude::Paddr,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock},
-    warn,
 };
 
 mod context_table;

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -2,10 +2,13 @@
 
 use core::{marker::PhantomData, ops::Range};
 
-use crate::mm::{
-    Paddr, PageProperty, PagingConstsTrait, PagingLevel, PodOnce,
-    page_prop::{CachePolicy, PageFlags, PageTableFlags, PrivilegedPageFlags as PrivFlags},
-    page_table::{PageTableConfig, PteScalar, PteTrait},
+use crate::{
+    mm::{
+        PageProperty, PagingConstsTrait, PagingLevel, PodOnce,
+        page_prop::{CachePolicy, PageFlags, PageTableFlags, PrivilegedPageFlags as PrivFlags},
+        page_table::{PageTableConfig, PteScalar, PteTrait},
+    },
+    prelude::*,
 };
 
 /// The page table used by iommu maps the device address

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::vec::Vec;
 use core::{fmt::Debug, ptr::NonNull};
 
 use bitflags::bitflags;
@@ -10,8 +9,8 @@ use volatile::{VolatileRef, access::ReadWrite};
 use super::registers::Capability;
 use crate::{
     arch::trap::TrapFrame,
-    error, info,
     irq::IrqLine,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock},
 };
 

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/mod.rs
@@ -9,7 +9,7 @@ pub(super) use table::IntRemappingTable;
 
 use crate::{
     arch::iommu::registers::{ExtendedCapabilityFlags, IOMMU_REGS},
-    info, warn,
+    prelude::*,
 };
 
 pub struct IrtEntryHandle {

--- a/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
+++ b/ostd/src/arch/x86/iommu/interrupt_remapping/table.rs
@@ -8,7 +8,8 @@ use int_to_c_enum::TryFromInt;
 
 use super::IrtEntryHandle;
 use crate::{
-    mm::{FrameAllocOptions, HasPaddr, PAGE_SIZE, Segment, io::util::HasVmReaderWriter},
+    mm::{FrameAllocOptions, PAGE_SIZE, Segment, io::util::HasVmReaderWriter},
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock},
 };
 

--- a/ostd/src/arch/x86/iommu/invalidate/mod.rs
+++ b/ostd/src/arch/x86/iommu/invalidate/mod.rs
@@ -4,7 +4,7 @@ use queue::Queue;
 use spin::Once;
 
 use super::registers::{ExtendedCapabilityFlags, IOMMU_REGS};
-use crate::{info, sync::SpinLock, warn};
+use crate::{prelude::*, sync::SpinLock};
 
 pub mod descriptor;
 pub mod queue;

--- a/ostd/src/arch/x86/iommu/registers/mod.rs
+++ b/ostd/src/arch/x86/iommu/registers/mod.rs
@@ -38,9 +38,9 @@ use crate::{
         },
         kernel::acpi::dmar::{Dmar, Remapping},
     },
-    debug,
     io::IoMemAllocatorBuilder,
     mm::{PAGE_SIZE, paddr_to_vaddr},
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock},
 };
 

--- a/ostd/src/arch/x86/irq/chip/ioapic.rs
+++ b/ostd/src/arch/x86/irq/chip/ioapic.rs
@@ -3,9 +3,10 @@
 use bit_field::BitField;
 
 use crate::{
-    Error, Result, info,
+    Error,
     io::{IoMem, IoMemAllocatorBuilder, Sensitive},
     irq::IrqLine,
+    prelude::*,
 };
 
 /// I/O Advanced Programmable Interrupt Controller (APIC).

--- a/ostd/src/arch/x86/irq/chip/mod.rs
+++ b/ostd/src/arch/x86/irq/chip/mod.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, vec::Vec};
 use core::{
     fmt,
     ops::{Deref, DerefMut},
@@ -10,8 +9,8 @@ use ioapic::IoApic;
 use spin::Once;
 
 use crate::{
-    Error, Result, arch::kernel::acpi::get_acpi_tables, info, io::IoMemAllocatorBuilder,
-    irq::IrqLine, sync::SpinLock,
+    Error, arch::kernel::acpi::get_acpi_tables, io::IoMemAllocatorBuilder, irq::IrqLine,
+    prelude::*, sync::SpinLock,
 };
 
 mod ioapic;

--- a/ostd/src/arch/x86/irq/chip/pic.rs
+++ b/ostd/src/arch/x86/irq/chip/pic.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     arch::device::io_port::WriteOnlyAccess,
-    info,
     io::{IoPort, sensitive_io_port},
+    prelude::*,
 };
 
 sensitive_io_port! {

--- a/ostd/src/arch/x86/kernel/acpi/mod.rs
+++ b/ostd/src/arch/x86/kernel/acpi/mod.rs
@@ -23,9 +23,8 @@ use spin::Once;
 
 use crate::{
     boot::{self, BootloaderAcpiArg},
-    info,
     mm::paddr_to_vaddr,
-    warn,
+    prelude::*,
 };
 
 #[derive(Clone, Debug)]

--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -8,7 +8,7 @@ use x86::{
 use super::ApicTimer;
 use crate::{
     io::{IoMem, Sensitive},
-    mm::{HasPaddr, HasSize},
+    prelude::*,
 };
 
 #[derive(Debug)]

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -7,8 +7,8 @@ use crate::{
         timer::pit::{self, OperatingMode},
         trap::TrapFrame,
     },
-    info,
     irq::IrqLine,
+    prelude::*,
     timer::TIMER_FREQ,
 };
 

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -13,13 +13,16 @@ use x86_64::{
     structures::paging::PhysFrame,
 };
 
-use crate::mm::{
-    PAGE_SIZE, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
-    dma::DmaDirection,
-    page_prop::{
-        CachePolicy, PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags,
+use crate::{
+    mm::{
+        PAGE_SIZE, PagingConstsTrait, PagingLevel, PodOnce,
+        dma::DmaDirection,
+        page_prop::{
+            CachePolicy, PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags,
+        },
+        page_table::{PteScalar, PteTrait},
     },
-    page_table::{PteScalar, PteTrait},
+    prelude::*,
 };
 
 mod pat;

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -9,8 +9,8 @@ use crate::{
         trap::TrapFrame,
         tsc_freq,
     },
-    info,
     irq::IrqLine,
+    prelude::*,
     task::disable_preempt,
     timer::TIMER_FREQ,
 };

--- a/ostd/src/boot/memory_region.rs
+++ b/ostd/src/boot/memory_region.rs
@@ -6,7 +6,10 @@ use core::ops::Deref;
 
 use align_ext::AlignExt;
 
-use crate::mm::{PAGE_SIZE, Paddr, Vaddr, kspace::kernel_loaded_offset};
+use crate::{
+    mm::{PAGE_SIZE, kspace::kernel_loaded_offset},
+    prelude::*,
+};
 
 /// The type of initial memory regions that are needed for the kernel.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/ostd/src/cpu/local/dyn_cpu_local.rs
+++ b/ostd/src/cpu/local/dyn_cpu_local.rs
@@ -8,10 +8,10 @@ use bitvec::prelude::{BitVec, bitvec};
 
 use super::{AnyStorage, CpuLocal};
 use crate::{
-    Result,
     cpu::{CpuId, PinCurrentCpu, all_cpus, num_cpus},
     irq::DisabledLocalIrqGuard,
-    mm::{FrameAllocOptions, HasPaddr, PAGE_SIZE, Segment, Vaddr, paddr_to_vaddr},
+    mm::{FrameAllocOptions, PAGE_SIZE, Segment, paddr_to_vaddr},
+    prelude::*,
     util::id_set::Id,
 };
 

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -56,7 +56,8 @@ use static_cpu_local::StaticStorage;
 use super::CpuId;
 use crate::{
     irq::DisabledLocalIrqGuard,
-    mm::{PAGE_SIZE, Paddr, frame::allocator, paddr_to_vaddr},
+    mm::{PAGE_SIZE, frame::allocator, paddr_to_vaddr},
+    prelude::*,
     util::id_set::Id,
 };
 
@@ -314,7 +315,7 @@ mod is_used {
 mod test {
     use core::cell::RefCell;
 
-    use ostd_macros::ktest;
+    use crate::prelude::ktest;
 
     #[ktest]
     fn cpu_local() {

--- a/ostd/src/io/io_mem/allocator.rs
+++ b/ostd/src/io/io_mem/allocator.rs
@@ -2,15 +2,14 @@
 
 //! I/O Memory allocator.
 
-use alloc::vec::Vec;
 use core::ops::Range;
 
 use spin::Once;
 
 use crate::{
-    debug, info,
     io::io_mem::{Insensitive, IoMem, Sensitive},
     mm::{CachePolicy, PageFlags},
+    prelude::*,
     util::range_alloc::RangeAllocator,
 };
 

--- a/ostd/src/io/io_port/allocator.rs
+++ b/ostd/src/io/io_port/allocator.rs
@@ -8,8 +8,8 @@ use spin::Once;
 
 use super::IoPort;
 use crate::{
-    debug,
     io::RawIoPortRange,
+    prelude::*,
     sync::{LocalIrqDisabled, SpinLock},
 };
 

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -9,11 +9,12 @@ use crate::{
     arch::irq,
     error::Error,
     mm::{
-        Daddr, FrameAllocOptions, HasDaddr, HasPaddr, HasPaddrRange, HasSize, Infallible,
-        PAGE_SIZE, Paddr, Segment, Split, VmReader, VmWriter,
+        Daddr, FrameAllocOptions, HasDaddr, HasPaddrRange, Infallible, PAGE_SIZE, Segment, Split,
+        VmReader, VmWriter,
         io::util::{HasVmReaderWriter, VmReaderWriterIdentity},
         kspace::kvirt_area::KVirtArea,
     },
+    prelude::*,
 };
 
 /// A DMA memory object that can be accessed in a cache-coherent manner.

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -9,12 +9,13 @@ use crate::{
     arch::{irq, mm::can_sync_dma},
     error::Error,
     mm::{
-        Daddr, FrameAllocOptions, HasDaddr, HasPaddr, HasPaddrRange, HasSize, Infallible,
-        PAGE_SIZE, Paddr, Split, USegment, VmReader, VmWriter,
+        Daddr, FrameAllocOptions, HasDaddr, HasPaddrRange, Infallible, PAGE_SIZE, Split, USegment,
+        VmReader, VmWriter,
         io::util::{HasVmReaderWriter, VmReaderWriterResult},
         kspace::kvirt_area::KVirtArea,
         paddr_to_vaddr,
     },
+    prelude::*,
 };
 
 /// [`DmaDirection`] limits the data flow direction of [`DmaStream`] and

--- a/ostd/src/mm/dma/util.rs
+++ b/ostd/src/mm/dma/util.rs
@@ -8,11 +8,12 @@ use crate::{
     cpu::{AtomicCpuSet, CpuSet},
     impl_frame_meta_for, irq,
     mm::{
-        CachePolicy, Daddr, FrameAllocOptions, HasPaddr, HasSize, PAGE_SIZE, Paddr, PageFlags,
-        PageProperty, PrivilegedPageFlags, Segment,
+        CachePolicy, Daddr, FrameAllocOptions, PAGE_SIZE, PageFlags, PageProperty,
+        PrivilegedPageFlags, Segment,
         kspace::kvirt_area::KVirtArea,
         tlb::{TlbFlushOp, TlbFlusher},
     },
+    prelude::*,
     task::disable_preempt,
 };
 #[cfg(any(debug_assertions, all(target_arch = "x86_64", feature = "cvm_guest")))]
@@ -190,7 +191,7 @@ pub(super) unsafe fn unprepare_dma(pa_range: &Range<Paddr>, daddr: Option<Daddr>
 /// outlives the following [`dealloc_protect_physical_range()`] call.
 #[cfg(any(debug_assertions, all(target_arch = "x86_64", feature = "cvm_guest")))]
 unsafe fn alloc_unprotect_physical_range(pa_range: &Range<Paddr>) {
-    use alloc::{vec, vec::Vec};
+    use alloc::vec;
 
     debug_assert!(pa_range.start.is_multiple_of(PAGE_SIZE));
     debug_assert!(pa_range.end.is_multiple_of(PAGE_SIZE));

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -6,10 +6,7 @@ use super::{
     Frame,
     meta::{AnyFrameMeta, MetaSlot},
 };
-use crate::{
-    mm::{HasPaddr, Paddr},
-    sync::non_null::NonNullPtr,
-};
+use crate::{prelude::*, sync::non_null::NonNullPtr};
 
 /// A struct that can work as `&'a Frame<M>`.
 pub struct FrameRef<'a, M: AnyFrameMeta + ?Sized> {

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -16,11 +16,7 @@ use super::{
     meta::{AnyFrameMeta, get_slot},
     unique::UniqueFrame,
 };
-use crate::{
-    arch::mm::PagingConsts,
-    mm::{Paddr, Vaddr},
-    panic::abort,
-};
+use crate::{arch::mm::PagingConsts, prelude::*};
 
 /// A linked list of frames.
 ///

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -20,7 +20,10 @@ pub(crate) mod mapping {
     //! in [`FRAME_METADATA_RANGE`].
 
     use super::MetaSlot;
-    use crate::mm::{PAGE_SIZE, Paddr, PagingConstsTrait, Vaddr, kspace::FRAME_METADATA_RANGE};
+    use crate::{
+        mm::{PAGE_SIZE, PagingConstsTrait, kspace::FRAME_METADATA_RANGE},
+        prelude::*,
+    };
 
     /// Converts a physical address of a base frame to the virtual address of the metadata slot.
     pub(crate) const fn frame_to_meta<C: PagingConstsTrait>(paddr: Paddr) -> Vaddr {
@@ -49,15 +52,15 @@ use core::{
 use crate::{
     arch::mm::PagingConsts,
     boot::memory_region::MemoryRegionType,
-    const_assert, info,
+    const_assert,
     mm::{
-        CachePolicy, Infallible, PAGE_SIZE, Paddr, PageFlags, PageProperty, PrivilegedPageFlags,
-        Segment, Vaddr, VmReader,
+        CachePolicy, Infallible, PAGE_SIZE, PageFlags, PageProperty, PrivilegedPageFlags, Segment,
+        VmReader,
         frame::allocator::{self, EarlyAllocatedFrameMeta},
         paddr_to_vaddr, page_size,
         page_table::boot_pt,
     },
-    panic::abort,
+    prelude::*,
     util::ops::range_difference,
 };
 

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -56,7 +56,8 @@ pub use segment::Segment;
 use untyped::{AnyUFrameMeta, UFrame};
 
 use crate::{
-    mm::{HasPaddr, HasSize, PAGE_SIZE, Paddr, PagingConsts, PagingLevel, Vaddr},
+    mm::{PAGE_SIZE, PagingConsts, PagingLevel},
+    prelude::*,
     sync::RcuDrop,
 };
 

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -8,7 +8,10 @@ use super::{
     Frame, inc_frame_ref_count,
     meta::{AnyFrameMeta, GetFrameError},
 };
-use crate::mm::{AnyUFrameMeta, HasPaddr, HasSize, PAGE_SIZE, Paddr, Split};
+use crate::{
+    mm::{AnyUFrameMeta, PAGE_SIZE, Split},
+    prelude::*,
+};
 
 /// A contiguous range of homogeneous physical memory frames.
 ///

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -8,7 +8,10 @@ use super::{
     AnyFrameMeta, Frame, MetaSlot,
     meta::{GetFrameError, REF_COUNT_UNIQUE},
 };
-use crate::mm::{HasPaddr, HasSize, PAGE_SIZE, Paddr, PagingConsts, PagingLevel, frame::mapping};
+use crate::{
+    mm::{PAGE_SIZE, PagingConsts, PagingLevel, frame::mapping},
+    prelude::*,
+};
 
 /// An owning frame pointer.
 ///

--- a/ostd/src/mm/frame/untyped.rs
+++ b/ostd/src/mm/frame/untyped.rs
@@ -10,13 +10,16 @@
 //! [`VmIo`]: crate::mm::VmIo
 
 use super::{Frame, Segment, meta::AnyFrameMeta};
-use crate::mm::{
-    HasPaddr, HasSize, Infallible,
-    io::{
-        VmReader, VmWriter,
-        util::{HasVmReaderWriter, VmReaderWriterIdentity},
+use crate::{
+    mm::{
+        Infallible,
+        io::{
+            VmReader, VmWriter,
+            util::{HasVmReaderWriter, VmReaderWriterIdentity},
+        },
+        paddr_to_vaddr,
     },
-    paddr_to_vaddr,
+    prelude::*,
 };
 
 /// The metadata of untyped frame.

--- a/ostd/src/mm/heap/mod.rs
+++ b/ostd/src/mm/heap/mod.rs
@@ -7,7 +7,7 @@ use core::{
     ptr::NonNull,
 };
 
-use crate::mm::Vaddr;
+use crate::prelude::*;
 
 mod slab;
 mod slot;

--- a/ostd/src/mm/heap/slab.rs
+++ b/ostd/src/mm/heap/slab.rs
@@ -5,10 +5,13 @@
 use core::{alloc::AllocError, ptr::NonNull};
 
 use super::{slot::HeapSlot, slot_list::SlabSlotList};
-use crate::mm::{
-    FrameAllocOptions, HasPaddr, HasSize, PAGE_SIZE, UniqueFrame,
-    frame::{linked_list::Link, meta::AnyFrameMeta},
-    paddr_to_vaddr,
+use crate::{
+    mm::{
+        FrameAllocOptions, PAGE_SIZE, UniqueFrame,
+        frame::{linked_list::Link, meta::AnyFrameMeta},
+        paddr_to_vaddr,
+    },
+    prelude::*,
 };
 
 /// A slab.
@@ -85,7 +88,7 @@ impl<const SLOT_SIZE: usize> Slab<SLOT_SIZE> {
     ///
     /// If the size is less than `SLOT_SIZE` or [`PAGE_SIZE`], the size will be
     /// the maximum of the two.
-    pub fn new() -> crate::prelude::Result<Self> {
+    pub fn new() -> Result<Self> {
         const { assert!(SLOT_SIZE <= PAGE_SIZE) };
         // To ensure we can store a pointer in each slot.
         const { assert!(SLOT_SIZE >= size_of::<usize>()) };

--- a/ostd/src/mm/heap/slot.rs
+++ b/ostd/src/mm/heap/slot.rs
@@ -7,9 +7,9 @@ use core::{alloc::AllocError, ptr::NonNull};
 use crate::{
     impl_frame_meta_for,
     mm::{
-        FrameAllocOptions, PAGE_SIZE, Paddr, Segment, Vaddr, kspace::LINEAR_MAPPING_BASE_VADDR,
-        paddr_to_vaddr,
+        FrameAllocOptions, PAGE_SIZE, Segment, kspace::LINEAR_MAPPING_BASE_VADDR, paddr_to_vaddr,
     },
+    prelude::*,
 };
 
 /// A slot that will become or has been turned from a heap allocation.
@@ -111,7 +111,7 @@ impl HeapSlot {
             crate::error!(
                 "Deallocating a large slot that was not allocated with `HeapSlot::alloc_large`"
             );
-            crate::panic::abort();
+            abort();
         };
 
         debug_assert_eq!(size % PAGE_SIZE, 0);

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -9,11 +9,12 @@ use super::{KERNEL_PAGE_TABLE, KernelPtConfig, MappedItem};
 use crate::{
     irq,
     mm::{
-        HasSize, PAGE_SIZE, Paddr, Split, Vaddr,
+        PAGE_SIZE, Split,
         frame::{Frame, meta::AnyFrameMeta},
         page_prop::PageProperty,
         page_table::largest_pages,
     },
+    prelude::*,
 };
 
 mod allocator {

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -46,7 +46,7 @@ use spin::Once;
 mod test;
 
 use super::{
-    Frame, HasSize, Paddr, PagingConstsTrait, Vaddr,
+    Frame, PagingConstsTrait,
     frame::{
         Segment,
         meta::{AnyFrameMeta, MetaPageMeta, mapping},
@@ -57,8 +57,9 @@ use super::{
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
     boot::memory_region::MemoryRegionType,
-    const_assert, info,
-    mm::{HasPaddr, PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
+    const_assert,
+    mm::{PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
+    prelude::*,
     task::disable_preempt,
 };
 

--- a/ostd/src/mm/mem_obj.rs
+++ b/ostd/src/mm/mem_obj.rs
@@ -2,11 +2,10 @@
 
 //! Traits for memory objects.
 
-use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use alloc::rc::Rc;
 use core::ops::Range;
 
-use super::Paddr;
-use crate::mm::Daddr;
+use crate::{mm::Daddr, prelude::*};
 
 /// Memory objects that have a start physical address.
 pub trait HasPaddr {

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -17,8 +17,7 @@ use crate::{
     cpu::num_cpus,
     cpu_local_cell,
     mm::{
-        Frame, FrameAllocOptions, PAGE_SIZE, Paddr, PageProperty, PagingConstsTrait, PagingLevel,
-        Vaddr,
+        Frame, FrameAllocOptions, PAGE_SIZE, PageProperty, PagingConstsTrait, PagingLevel,
         frame::{
             self,
             allocator::{self, EarlyAllocatedFrameMeta},
@@ -27,6 +26,7 @@ use crate::{
         page_prop::PageTableFlags,
         page_table::PteScalar,
     },
+    prelude::*,
     sync::SpinLock,
 };
 

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -9,12 +9,13 @@ use align_ext::AlignExt;
 use super::Cursor;
 use crate::{
     mm::{
-        HasPaddr, Vaddr, nr_subpage_per_huge, paddr_to_vaddr,
+        nr_subpage_per_huge, paddr_to_vaddr,
         page_table::{
             PageTable, PageTableConfig, PageTableGuard, PageTableNodeRef, PagingConstsTrait,
             PagingLevel, PteScalar, PteStateRef, PteTrait, load_pte, page_size, pte_index,
         },
     },
+    prelude::*,
     task::atomic_mode::InAtomicMode,
 };
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -39,9 +39,10 @@ use super::{
 };
 use crate::{
     mm::{
-        PageProperty, Vaddr,
+        PageProperty,
         page_table::{PageTableNode, is_valid_range},
     },
+    prelude::*,
     sync::RcuDrop,
     task::atomic_mode::InAtomicMode,
 };

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -15,12 +15,13 @@ use core::{
 use ostd_pod::Pod;
 
 use super::{
-    HasPaddr, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr, kspace::KernelPtConfig,
-    nr_subpage_per_huge, page_prop::PageProperty, page_size, vm_space::UserPtConfig,
+    PagingConstsTrait, PagingLevel, PodOnce, kspace::KernelPtConfig, nr_subpage_per_huge,
+    page_prop::PageProperty, page_size, vm_space::UserPtConfig,
 };
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
     mm::page_prop::PageTableFlags,
+    prelude::*,
     task::{atomic_mode::AsAtomicModeGuard, disable_preempt},
 };
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -5,12 +5,13 @@
 use super::{PageTableGuard, PageTableNode, PteState, PteStateRef, PteTrait};
 use crate::{
     mm::{
-        HasPaddr, nr_subpage_per_huge,
+        nr_subpage_per_huge,
         page_prop::PageProperty,
         page_size,
         page_table::{PageTableConfig, PageTableNodeRef, PteScalar},
     },
     panic::PanicGuard,
+    prelude::*,
     sync::RcuDrop,
     task::atomic_mode::InAtomicMode,
 };

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -42,11 +42,12 @@ pub(in crate::mm) use self::{
 use super::{PageTableConfig, PteTrait, nr_subpage_per_huge};
 use crate::{
     mm::{
-        FrameAllocOptions, HasPaddr, Infallible, PagingConstsTrait, PagingLevel, VmReader,
+        FrameAllocOptions, Infallible, PagingConstsTrait, PagingLevel, VmReader,
         frame::{Frame, FrameRef, meta::AnyFrameMeta},
         paddr_to_vaddr,
         page_table::{PteScalar, load_pte, store_pte},
     },
+    prelude::*,
     task::atomic_mode::InAtomicMode,
 };
 

--- a/ostd/src/mm/page_table/node/pte_state.rs
+++ b/ostd/src/mm/page_table/node/pte_state.rs
@@ -9,9 +9,10 @@ use ostd_pod::FromZeros;
 use super::{PageTableNode, PageTableNodeRef, PteTrait};
 use crate::{
     mm::{
-        HasPaddr, PageTableFlags, PagingLevel,
+        PageTableFlags, PagingLevel,
         page_table::{PageTableConfig, PteScalar},
     },
+    prelude::*,
     sync::RcuDrop,
 };
 

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -10,7 +10,6 @@ use crate::{
         page_prop::{CachePolicy, PageFlags},
         vm_space::VmItem,
     },
-    prelude::*,
     task::disable_preempt,
 };
 

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -2,7 +2,6 @@
 
 //! TLB flush operations.
 
-use alloc::vec::Vec;
 use core::{
     mem::MaybeUninit,
     ops::Range,
@@ -10,7 +9,7 @@ use core::{
 };
 
 use super::{
-    PAGE_SIZE, Vaddr,
+    PAGE_SIZE,
     frame::{Frame, meta::AnyFrameMeta},
 };
 use crate::{
@@ -18,6 +17,7 @@ use crate::{
     const_assert,
     cpu::{AtomicCpuSet, CpuSet, PinCurrentCpu},
     cpu_local,
+    prelude::*,
     smp::IpiSender,
     sync::{LocalIrqDisabled, RcuDrop, SpinLock},
 };

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -2,7 +2,7 @@
 
 //! Panic support.
 
-use crate::early_println;
+use crate::prelude::*;
 
 extern crate cfg_if;
 extern crate gimli;
@@ -91,7 +91,7 @@ pub fn print_stack_trace() {
         UnwindContext, UnwindReasonCode,
     };
 
-    use crate::{early_print, sync::SpinLock};
+    use crate::sync::SpinLock;
 
     /// We acquire a global lock to prevent the frames in the stack trace from
     /// interleaving. The spin lock is used merely for its simplicity.

--- a/ostd/src/prelude.rs
+++ b/ostd/src/prelude.rs
@@ -17,7 +17,7 @@ pub(crate) use alloc::{boxed::Box, sync::Arc, vec::Vec};
 pub use ostd_macros::ktest;
 
 pub use crate::{
-    alert, crit, debug, early_print as print, early_println as println, emerg, error, info,
+    alert, crit, debug, early_print, early_println, emerg, error, info,
     mm::{HasPaddr, HasSize, Paddr, Vaddr},
     notice,
     panic::abort,

--- a/ostd/src/util/id_set.rs
+++ b/ostd/src/util/id_set.rs
@@ -26,7 +26,7 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use bitvec::{order::Lsb0, view::BitView};
+use bitvec::prelude::*;
 use smallvec::SmallVec;
 
 use crate::const_assert;

--- a/tools/clippy_check.sh
+++ b/tools/clippy_check.sh
@@ -76,7 +76,7 @@ run_workspace_clippy() {
         cd "$PROJECT_ROOT"
         RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
         RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
-        RUSTC="klint" RUSTFLAGS="-Dwarnings" cargo check --target x86_64-unknown-none
+        RUSTFLAGS="-Dwarnings" cargo osdk check --ktests --klint
     )
 
     build_package_args "--non-default-ones" non_default_package_args
@@ -107,7 +107,7 @@ run_workspace_clippy() {
             cd "$PROJECT_ROOT/$LINUX_BZIMAGE_SETUP_DIR"
             RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
             RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
-            RUSTC="klint" RUSTFLAGS="-Dwarnings" cargo check --target x86_64-unknown-none
+            RUSTFLAGS="-Dwarnings" cargo osdk check --ktests --klint
         )
     fi
 }

--- a/tools/clippy_check.sh
+++ b/tools/clippy_check.sh
@@ -60,6 +60,7 @@ run_check_osdk() {
     (
         cd "$PROJECT_ROOT/osdk"
         RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-deps
+        RUSTC="klint" RUSTFLAGS="-Dwarnings" cargo check
     )
 }
 
@@ -75,6 +76,7 @@ run_workspace_clippy() {
         cd "$PROJECT_ROOT"
         RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
         RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
+        RUSTC="klint" RUSTFLAGS="-Dwarnings" cargo check --target x86_64-unknown-none
     )
 
     build_package_args "--non-default-ones" non_default_package_args
@@ -105,6 +107,7 @@ run_workspace_clippy() {
             cd "$PROJECT_ROOT/$LINUX_BZIMAGE_SETUP_DIR"
             RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
             RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
+            RUSTC="klint" RUSTFLAGS="-Dwarnings" cargo check --target x86_64-unknown-none
         )
     fi
 }


### PR DESCRIPTION
The PR
* applies KLint to Asterinas, and fixes all the not_using_prelude warnings
* adds `--klint` argument for `cargo osdk check`
* declares `Result` in prelude module with default type parameter `E`
  * I can remove this breaking change, because it's unnecessary for the fix

The code requires asterinas container v0.17.2-20260508 to work.

Also see https://github.com/asterinas/asterinas/issues/2967 for the context.

<details><summary>Click to expand and view sample klint diagnostics suggesting that imports can be replaced by the prelude modules of `ostd`, `rand`, and `bitvec`.
</summary>
<p>

Full warnings are [here](https://github.com/os-checker/asterinas/actions/runs/23113661880/job/67135354514).

```rust
    Checking aster-virtio v0.1.0 (/asterinas/kernel/comps/virtio)
warning: this item is available via prelude
  --> kernel/comps/virtio/src/device/block/device.rs:26:10
   |
26 |     mm::{HasSize, VmIo, dma::DmaStream},
   |          ^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
 --> kernel/comps/virtio/src/dma_buf.rs:8:15
  |
8 |     HasDaddr, HasSize,
  |               ^^^^^^^
  |
  = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/comps/virtio/src/queue.rs:15:16
   |
15 | use ostd::mm::{HasPaddr, PodOnce, Split, dma::DmaCoherent};
   |                ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
 --> kernel/comps/virtio/src/transport/mmio/bus/common_device.rs:8:12
  |
8 |     Error, Result,
  |            ^^^^^^
  |
  = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/comps/virtio/src/transport/mmio/bus/common_device.rs:11:10
   |
11 |     mm::{HasPaddr, VmIoOnce},
   |          ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: `aster-virtio` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.67s
Checking kernel/libs/aster-bigtcp
warning: this item is available via prelude
 --> ostd/libs/ostd-macros/src/lib.rs:8:12
  |
8 | use rand::{Rng, distr::Alphanumeric};
  |            ^^^
  |
  = help: import with `rand::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `ostd-macros` (lib) generated 1 warning
warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:14
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |              ^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:27
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |                           ^^^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead

warning: `ostd` (lib) generated 2 warnings
warning: this item is available via prelude
 --> osdk/deps/heap-allocator/src/slab_cache.rs:8:16
  |
8 |     PAGE_SIZE, Paddr,
  |                ^^^^^
  |
  = help: import with `ostd::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `osdk-heap-allocator` (lib) generated 1 warning
warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:15
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |               ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:25
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |                         ^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
 --> kernel/libs/aster-util/src/safe_ptr.rs:8:12
  |
8 |     Error, Result,
  |            ^^^^^^
  |
  = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:26
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                          ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:36
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                                    ^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: `aster-util` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
Checking kernel/libs/aster-util
warning: this item is available via prelude
 --> ostd/libs/ostd-macros/src/lib.rs:8:12
  |
8 | use rand::{Rng, distr::Alphanumeric};
  |            ^^^
  |
  = help: import with `rand::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `ostd-macros` (lib) generated 1 warning
warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:14
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |              ^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:27
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |                           ^^^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead

warning: `ostd` (lib) generated 2 warnings
warning: this item is available via prelude
 --> osdk/deps/heap-allocator/src/slab_cache.rs:8:16
  |
8 |     PAGE_SIZE, Paddr,
  |                ^^^^^
  |
  = help: import with `ostd::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `osdk-heap-allocator` (lib) generated 1 warning
warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:15
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |               ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:25
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |                         ^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
 --> kernel/libs/aster-util/src/safe_ptr.rs:8:12
  |
8 |     Error, Result,
  |            ^^^^^^
  |
  = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:26
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                          ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:36
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                                    ^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: `aster-util` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
Checking kernel/libs/device-id
warning: this item is available via prelude
 --> ostd/libs/ostd-macros/src/lib.rs:8:12
  |
8 | use rand::{Rng, distr::Alphanumeric};
  |            ^^^
  |
  = help: import with `rand::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `ostd-macros` (lib) generated 1 warning
warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:14
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |              ^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:27
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |                           ^^^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead

warning: `ostd` (lib) generated 2 warnings
warning: this item is available via prelude
 --> osdk/deps/heap-allocator/src/slab_cache.rs:8:16
  |
8 |     PAGE_SIZE, Paddr,
  |                ^^^^^
  |
  = help: import with `ostd::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `osdk-heap-allocator` (lib) generated 1 warning
warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:15
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |               ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/mem_obj_slice.rs:16:25
   |
16 |     HasDaddr, HasPaddr, HasSize, Infallible, VmReader, VmWriter,
   |                         ^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
 --> kernel/libs/aster-util/src/safe_ptr.rs:8:12
  |
8 |     Error, Result,
  |            ^^^^^^
  |
  = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:26
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                          ^^^^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:36
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                                    ^^^^^
   = help: import with `ostd::prelude::*` instead

warning: this item is available via prelude
  --> kernel/libs/aster-util/src/safe_ptr.rs:10:36
   |
10 |         Daddr, HasDaddr, HasPaddr, Paddr, PodOnce, VmIo, VmIoOnce,
   |                                    ^^^^^
   |
   = help: import with `ostd::prelude::*` instead

warning: `aster-util` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
Checking kernel/libs/xarray
warning: this item is available via prelude
 --> ostd/libs/ostd-macros/src/lib.rs:8:12
  |
8 | use rand::{Rng, distr::Alphanumeric};
  |            ^^^
  |
  = help: import with `rand::prelude::*` instead
  = note: `#[warn(klint::not_using_prelude)]` on by default

warning: `ostd-macros` (lib) generated 1 warning
warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:14
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |              ^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead
   = note: `#[warn(klint::not_using_prelude)]` on by default

warning: this item is available via prelude
  --> ostd/src/util/id_set.rs:29:27
   |
29 | use bitvec::{order::Lsb0, view::BitView};
   |                           ^^^^^^^^^^^^^
   |
   = help: import with `bitvec::prelude::*` instead

warning: `ostd` (lib) generated 2 warnings
```

</p>
</details> 

