### PR TITLE
Revert "Support all boot methods for TDX"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/benchmark/common/bench_runner.sh $(BENCHM
 endif
 
 ifeq ($(INTEL_TDX), 1)
+BOOT_METHOD = grub-qcow2
 BOOT_PROTOCOL = linux-efi-handover64
 CARGO_OSDK_COMMON_ARGS += --scheme tdx
 endif

--- a/osdk/src/bundle/bin.rs
+++ b/osdk/src/bundle/bin.rs
@@ -91,10 +91,6 @@ impl AsterBin {
         self.stripped
     }
 
-    pub fn typ(&self) -> &AsterBinType {
-        &self.typ
-    }
-
     /// Copy the binary to the `base` directory and convert the path to a relative path.
     pub fn copy_to(self, base: impl AsRef<Path>) -> Self {
         let file_name = self.path.file_name().unwrap();

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -4,7 +4,7 @@ pub mod bin;
 pub mod file;
 pub mod vm_image;
 
-use bin::{AsterBin, AsterBinType};
+use bin::AsterBin;
 use file::{BundleFile, Initramfs};
 use std::{
     io::{BufRead, BufReader, Write},
@@ -24,7 +24,7 @@ use crate::{
     arch::Arch,
     config::{
         Config,
-        scheme::{ActionChoice, BootMethod, BootProtocol},
+        scheme::{ActionChoice, BootMethod},
     },
     error::Errno,
     error_msg,
@@ -148,19 +148,6 @@ impl Bundle {
                 if self.manifest.aster_bin.is_none() {
                     return Err("Kernel binary is required for direct QEMU booting".to_owned());
                 };
-
-                // Validate the kernel binary type against the configured boot protocol.
-                // This prevents reusing an incompatible binary (e.g. ELF vs. `bzImage`) when
-                // switching boot methods (for example, from a Grub ISO to `qemu-direct`),
-                // which would otherwise cause boot failures.
-                let aster_bin_type = self.manifest.aster_bin.as_ref().unwrap().typ();
-                let expects_linux = matches!(aster_bin_type, AsterBinType::BzImage(_));
-                let actual_linux = config_action.grub.boot_protocol == BootProtocol::Linux;
-                if expects_linux != actual_linux {
-                    return Err(
-                        "The boot protocol is not compatible with the kernel binary".to_owned()
-                    );
-                }
             }
             BootMethod::GrubRescueIso => {
                 let Some(ref vm_image) = self.manifest.vm_image else {

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::SystemTime,
 };
 
-use bin::{make_elf_for_qemu, make_install_bzimage};
+use bin::make_elf_for_qemu;
 
 use super::util::{COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH, cargo, profile_name_adapter};
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
     cli::BuildArgs,
     config::{
         Config,
-        scheme::{ActionChoice, BootMethod, BootProtocol},
+        scheme::{ActionChoice, BootMethod},
     },
     error::Errno,
     error_msg,
@@ -132,9 +132,9 @@ pub fn do_cached_build(
     action: ActionChoice,
     rustflags: &[&str],
 ) -> Bundle {
-    let (build, boot, grub) = match action {
-        ActionChoice::Run => (&config.run.build, &config.run.boot, &config.run.grub),
-        ActionChoice::Test => (&config.test.build, &config.test.boot, &config.test.grub),
+    let (build, boot) = match action {
+        ActionChoice::Run => (&config.run.build, &config.run.boot),
+        ActionChoice::Test => (&config.test.build, &config.test.boot),
     };
 
     let mut rustflags = rustflags.to_vec();
@@ -183,17 +183,8 @@ pub fn do_cached_build(
             bundle.consume_aster_bin(aster_elf);
         }
         BootMethod::QemuDirect => {
-            let aster_bin = match grub.boot_protocol {
-                BootProtocol::Linux => make_install_bzimage(
-                    &osdk_output_directory,
-                    &osdk_output_directory,
-                    &aster_elf,
-                    build.linux_x86_legacy_boot,
-                    config.build.encoding.clone(),
-                ),
-                _ => make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf),
-            };
-            bundle.consume_aster_bin(aster_bin);
+            let qemu_elf = make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf);
+            bundle.consume_aster_bin(qemu_elf);
         }
     }
 


### PR DESCRIPTION
This reverts commit 2a6e8f65f168839019ce321bd7e8db0a8be0c13b.

See https://github.com/asterinas/asterinas/pull/3019#issuecomment-4066797954.

I posted this revert because it's the easiest fix. We can reland the changes later if they do not break the CI. Currently, all PRs are failing CI, which is very annoying.