### PR TITLE
Introduce `Dentry` revalidate mechanism

### DIFF
--- a/kernel/src/events/mod.rs
+++ b/kernel/src/events/mod.rs
@@ -12,5 +12,5 @@ pub use self::{
     events::{Events, EventsFilter},
     io_events::IoEvents,
     observer::Observer,
-    subject::{Subject, SyncSubject},
+    subject::SyncSubject,
 };

--- a/kernel/src/events/subject.rs
+++ b/kernel/src/events/subject.rs
@@ -15,6 +15,7 @@ use crate::prelude::*;
 /// outer lock also permits it.
 pub struct Subject<E: Events>(BTreeSet<KeyableWeak<dyn Observer<E>>>);
 
+#[expect(dead_code)]
 impl<E: Events> Subject<E> {
     /// Creates an empty subject.
     pub const fn new() -> Self {

--- a/kernel/src/fs/fs_impls/cgroupfs/inode.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/inode.rs
@@ -12,7 +12,7 @@ use crate::{
         utils::systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, Metadata},
+            inode::{Extension, Inode, Metadata, RevalidationPolicy},
             path::{is_dot, is_dotdot},
         },
     },
@@ -121,10 +121,25 @@ impl Inode for CgroupInode {
         Ok(())
     }
 
-    fn is_dentry_cacheable(&self) -> bool {
-        // Attribute nodes should not be cached because they may be dynamically
-        // created or removed based on the state of the cgroup controller.
-        // Caching them could result in stale or incorrect entries.
-        !matches!(self.node_kind, SysTreeNodeKind::Attr(..))
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        match self.node_kind() {
+            SysTreeNodeKind::Branch(_) | SysTreeNodeKind::Leaf(_) => {
+                RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+            }
+            SysTreeNodeKind::Attr(..) | SysTreeNodeKind::Symlink(_) => RevalidationPolicy::empty(),
+        }
+    }
+
+    fn revalidate_exists(&self, _name: &str, child: &dyn Inode) -> bool {
+        // Attribute nodes in the cache should not be trusted because they
+        // may be dynamically created or removed based on the state of the
+        // cgroup controller.
+        child
+            .downcast_ref::<Self>()
+            .is_some_and(|child| !matches!(child.node_kind(), SysTreeNodeKind::Attr(..)))
+    }
+
+    fn revalidate_absent(&self, _name: &str) -> bool {
+        false
     }
 }

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, Inode, InodeIo, Metadata, MknodType},
+            inode::{Extension, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy},
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
@@ -358,7 +358,22 @@ impl Inode for RootInode {
         self.fs.upgrade().unwrap()
     }
 
-    fn is_dentry_cacheable(&self) -> bool {
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+    }
+
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        // Slave entries are created by opening `ptmx` and removed when the
+        // master is dropped, bypassing VFS dentry updates. Always retry lookup
+        // so a cached dentry cannot refer to a removed or reused pty index.
+        //
+        // TODO: Add a devpts-to-VFS dentry invalidation/update path for slave
+        // add/remove, similar to Linux devpts dropping slave dentries on pty
+        // teardown. Then this conservative revalidation can be relaxed.
+        false
+    }
+
+    fn revalidate_absent(&self, _name: &str) -> bool {
         false
     }
 }

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -163,10 +163,6 @@ impl Inode for Ptmx {
     ) -> Option<Result<Box<dyn FileIo>>> {
         Some(self.inner.open())
     }
-
-    fn is_dentry_cacheable(&self) -> bool {
-        false
-    }
 }
 
 impl Device for Inner {

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -62,14 +62,6 @@ impl InodeIo for PtySlaveInode {
 }
 
 impl Inode for PtySlaveInode {
-    /// Do not cache dentry in DCACHE.
-    ///
-    /// The slave will be deleted by the master when the master is released.
-    /// So we should not cache the dentry.
-    fn is_dentry_cacheable(&self) -> bool {
-        false
-    }
-
     fn size(&self) -> usize {
         self.metadata.read().size
     }

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -1734,10 +1734,6 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn is_dentry_cacheable(&self) -> bool {
-        true
-    }
-
     fn extension(&self) -> &Extension {
         &self.extension
     }

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -2,9 +2,11 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-use template::{DirOps, ProcDir, lookup_child_from_table, populate_children_from_table};
+use template::{
+    DirOps, ListedEntry, ProcDir, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
+    listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
+    visit_readdir_entries,
+};
 
 use self::{
     cmdline::CmdLineFileOps,
@@ -20,23 +22,21 @@ use self::{
     version::VersionFileOps,
 };
 use crate::{
-    events::Observer,
     fs::{
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::{filesystems::FileSystemsFileOps, stat::StatFileOps},
         pseudofs::AnonDeviceId,
-        utils::{DirEntryVecExt, NAME_MAX},
+        utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::Inode,
+            inode::{Inode, RevalidationPolicy},
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
     process::{
         Pid,
-        pid_table::{self, PidEvent},
-        posix_thread::AsPosixThread,
+        pid_table::{self, PidEntryType},
     },
 };
 
@@ -145,102 +145,131 @@ impl RootDirOps {
     pub fn new_inode(fs: Weak<ProcFs>, sb: &SuperBlock) -> Arc<dyn Inode> {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/root.c#L368>
         let fs: Weak<dyn FileSystem> = fs;
-        let root_inode = ProcDir::new_root(Self, fs, PROC_ROOT_INO, sb, mkmod!(a+rx));
-
-        let weak_ptr = Arc::downgrade(&root_inode);
-        pid_table::pid_table_mut().register_observer(weak_ptr);
-
-        root_inode
+        ProcDir::new_root(Self, fs, PROC_ROOT_INO, sb, mkmod!(a+rx))
     }
 
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(&'static str, fn(Weak<dyn Inode>) -> Arc<dyn Inode>)] = &[
-        ("cmdline", CmdLineFileOps::new_inode),
-        ("cpuinfo", CpuInfoFileOps::new_inode),
-        ("filesystems", FileSystemsFileOps::new_inode),
-        ("loadavg", LoadAvgFileOps::new_inode),
-        ("meminfo", MemInfoFileOps::new_inode),
-        ("mounts", MountsSymOps::new_inode),
-        ("self", SelfSymOps::new_inode),
-        ("stat", StatFileOps::new_inode),
-        ("sys", SysDirOps::new_inode),
-        ("thread-self", ThreadSelfSymOps::new_inode),
-        ("uptime", UptimeFileOps::new_inode),
-        ("version", VersionFileOps::new_inode),
+    const STATIC_ENTRIES: &'static [StaticDirEntry<fn(Weak<dyn Inode>) -> Arc<dyn Inode>>] = &[
+        ("cmdline", InodeType::File, CmdLineFileOps::new_inode),
+        ("cpuinfo", InodeType::File, CpuInfoFileOps::new_inode),
+        (
+            "filesystems",
+            InodeType::File,
+            FileSystemsFileOps::new_inode,
+        ),
+        ("loadavg", InodeType::File, LoadAvgFileOps::new_inode),
+        ("meminfo", InodeType::File, MemInfoFileOps::new_inode),
+        ("mounts", InodeType::SymLink, MountsSymOps::new_inode),
+        ("self", InodeType::SymLink, SelfSymOps::new_inode),
+        ("stat", InodeType::File, StatFileOps::new_inode),
+        ("sys", InodeType::Dir, SysDirOps::new_inode),
+        (
+            "thread-self",
+            InodeType::SymLink,
+            ThreadSelfSymOps::new_inode,
+        ),
+        ("uptime", InodeType::File, UptimeFileOps::new_inode),
+        ("version", InodeType::File, VersionFileOps::new_inode),
     ];
 }
 
-impl Observer<PidEvent> for ProcDir<RootDirOps> {
-    fn on_events(&self, events: &PidEvent) {
-        let PidEvent::Exit(pid) = events;
-
-        let mut cached_children = self.cached_children().write();
-        cached_children.remove_entry_by_name(&pid.to_string());
-    }
-}
-
 impl DirOps for RootDirOps {
-    // Lock order: PID table -> cached entries
-    //
-    // Note that inverting the lock order is non-trivial because `Observer::on_events` will be
-    // called with the PID table locked.
-
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Ok(pid) = name.parse::<Pid>() {
-            let pid_table = pid_table::pid_table_mut();
-
-            if let Some(process_ref) = pid_table.get_process(pid) {
-                let mut cached_children = dir.cached_children().write();
-                return Ok(cached_children
-                    .put_entry_if_not_found(name, move || {
-                        PidDirOps::new_inode(process_ref, dir.this_weak().clone())
-                    })
-                    .clone());
-            }
-
-            if let Some(thread_ref) = pid_table.get_thread(pid) {
-                let process_ref = thread_ref.as_posix_thread().unwrap().process();
-                return Ok(TidDirOps::new_inode(
-                    process_ref,
-                    thread_ref,
-                    dir.this_weak().clone(),
-                ));
+            let pid_entry = {
+                let pid_table = pid_table::pid_table_mut();
+                pid_table.get_entry(pid)
+            };
+            if let Some(pid_entry) = pid_entry
+                && let Some(type_) = pid_entry.type_()
+            {
+                return Ok(match type_ {
+                    PidEntryType::Process => {
+                        PidDirOps::new_inode(pid_entry, this_dir.this_weak().clone())
+                    }
+                    PidEntryType::Thread => {
+                        TidDirOps::new_inode(pid_entry, this_dir.this_weak().clone())
+                    }
+                });
             }
         }
 
-        let mut cached_children = dir.cached_children().write();
-
-        if let Some(child) =
-            lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(dir.this_weak().clone())
-            })
-        {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
             return Ok(child);
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let pid_table = pid_table::pid_table_mut();
-        let mut cached_children = dir.cached_children().write();
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, mut visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        const FIRST_PID_OFFSET: usize = 2 + RootDirOps::STATIC_ENTRIES.len();
+        visit_readdir_entries(
+            sequential_readdir_entries(offset, 2, listed_entries_from_table(Self::STATIC_ENTRIES)),
+            &mut visit_fn,
+        )?;
 
-        for process_ref in pid_table.iter_processes() {
-            let pid = process_ref.pid().to_string();
-            cached_children.put_entry_if_not_found(&pid, move || {
-                PidDirOps::new_inode(process_ref, dir.this_weak().clone())
-            });
+        // Collect PIDs before visiting entries, as `visit_fn` may copy data to user memory.
+        let process_pids = {
+            let pid_table = pid_table::pid_table_mut();
+            pid_table
+                .iter_processes()
+                .filter_map(|process| usize::try_from(process.pid()).ok())
+                .collect::<Vec<_>>()
+        };
+
+        visit_readdir_entries(
+            keyed_readdir_entries(offset, FIRST_PID_OFFSET, process_pids, |process_pid| {
+                ListedEntry::new(process_pid.to_string(), InodeType::Dir)
+            }),
+            visit_fn,
+        )
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+    }
+
+    fn revalidate_exists(&self, name: &str, child: &dyn Inode) -> bool {
+        if name.parse::<Pid>().is_err() {
+            // For non-numeric names, the set of valid children does not change over time,
+            // so we can rely on the cache without revalidating.
+            return true;
+        };
+
+        if let Some(child) = child.downcast_ref::<ProcDir<PidDirOps>>() {
+            // If the child's `PidEntry` still has the associated process, it will not be removed
+            // from the `PidTable` and remains alive.
+            matches!(
+                child.inner().pid_entry().type_(),
+                Some(PidEntryType::Process)
+            )
+        } else if let Some(child) = child.downcast_ref::<ProcDir<TidDirOps>>() {
+            // If the child's `PidEntry` still has the associated thread, it will not be removed
+            // from the `PidTable` and remains alive.
+            matches!(
+                child.inner().pid_entry().type_(),
+                Some(PidEntryType::Thread)
+            )
+        } else {
+            false
         }
+    }
 
-        drop(pid_table);
+    fn revalidate_absent(&self, name: &str) -> bool {
+        let Ok(pid) = name.parse::<Pid>() else {
+            return true;
+        };
 
-        populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(dir.this_weak().clone())
-        });
+        let pid_entry = {
+            let pid_table = pid_table::pid_table_mut();
+            pid_table.get_entry(pid)
+        };
 
-        cached_children.downgrade()
+        pid_entry.is_none_or(|pid_entry| pid_entry.type_().is_none())
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/pid/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/mod.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-
 use super::template::{
-    DirOps, ProcDir, ProcDirBuilder, lookup_child_from_table, populate_children_from_table,
+    DirOps, ProcDir, ProcDirBuilder, ReaddirEntry, StaticDirEntry, listed_entries_from_table,
+    lookup_child_from_table, visit_listed_entries,
 };
 use crate::{
-    fs::{file::mkmod, procfs::pid::task::TaskDirOps, vfs::inode::Inode},
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::pid::task::TaskDirOps,
+        vfs::inode::{Inode, RevalidationPolicy},
+    },
     prelude::*,
-    process::Process,
+    process::pid_table::{PidEntry, PidEntryType},
 };
 
 mod task;
@@ -24,65 +26,80 @@ pub struct PidDirOps(
 );
 
 impl PidDirOps {
-    pub fn new_inode(process_ref: Arc<Process>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let tid_dir_ops = TidDirOps {
-            process_ref,
-            thread_ref: None,
-        };
+    pub fn new_inode(pid_entry: Arc<PidEntry>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        let this = Self(TidDirOps::new(pid_entry));
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3493>
-        ProcDirBuilder::new(Self(tid_dir_ops), mkmod!(a+rx))
+        ProcDirBuilder::new(this, mkmod!(a+rx))
             .parent(parent)
-            // The PID directory must be volatile, because it is just associated with one process.
-            .volatile()
             .build()
             .unwrap()
     }
 
+    pub(super) fn pid_entry(&self) -> &Arc<PidEntry> {
+        self.0.pid_entry()
+    }
+
+    pub(super) fn tid_dir_ops(&self) -> &TidDirOps {
+        &self.0
+    }
+
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(
-        &'static str,
-        fn(&PidDirOps, Weak<dyn Inode>) -> Arc<dyn Inode>,
-    )] = &[("task", TaskDirOps::new_inode)];
+    const STATIC_ENTRIES: &[StaticDirEntry<fn(&PidDirOps, Weak<dyn Inode>) -> Arc<dyn Inode>>] = &[
+        ("task", InodeType::Dir, TaskDirOps::new_inode),
+        (
+            "stat",
+            InodeType::File,
+            task::stat::StatFileOps::new_process_inode,
+        ),
+    ];
 }
 
 impl DirOps for PidDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if self.0.pid_entry().type_().is_none() {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        }
 
         // Look up entries that either exist under `/proc/<pid>`
         // but not under `/proc/<pid>/task/<tid>`,
         // or entries whose contents differ between `/proc/<pid>` and `/proc/<pid>/task/<tid>`.
-        if let Some(child) =
-            lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(self, dir.this_weak().clone())
-            })
-        {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(self, this_dir.this_weak().clone())
+        }) {
             return Ok(child);
         }
 
         // For all other children, the content is the same under both `/proc/<pid>` and `/proc/<pid>/task/<tid>`.
         self.0
-            .lookup_child_locked(&mut cached_children, dir.this_weak().clone(), name)
+            .lookup_static_child(this_dir.this_weak().clone(), name)
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS
+    }
 
-        // Populate entries that either exist under `/proc/<pid>`
-        // but not under `/proc/<pid>/task/<tid>`,
-        // or whose contents differ between the two paths.
-        populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(self, dir.this_weak().clone())
-        });
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        matches!(self.pid_entry().type_(), Some(PidEntryType::Process))
+    }
 
-        // Populate the remaining children that are identical
-        // under both `/proc/<pid>` and `/proc/<pid>/task/<tid>`.
-        self.0
-            .populate_children_locked(&mut cached_children, dir.this_weak().clone());
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        if self.0.pid_entry().type_().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the process does not exist");
+        }
 
-        cached_children.downgrade()
+        const PROCESS_OVERRIDE_NAMES: &[&str] = &["stat"];
+
+        // Add the children that are inherited from `/proc/<pid>/task/<tid>` but not overridden
+        // by process-specific entries under `/proc/<pid>`.
+        let listed_entries = listed_entries_from_table(Self::STATIC_ENTRIES).chain(
+            self.0
+                .static_listed_entries()
+                .filter(|entry| !PROCESS_OVERRIDE_NAMES.contains(&entry.name())),
+        );
+
+        visit_listed_entries(offset, listed_entries, visit_fn)
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
@@ -8,17 +8,15 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/auxv` (and also `/proc/[pid]/auxv`).
-pub struct AuxvFileOps(Arc<Process>);
+pub struct AuxvFileOps(TidDirOps);
 
 impl AuxvFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3325>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(u+r))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(u+r))
             .parent(parent)
             .build()
             .unwrap()
@@ -27,7 +25,11 @@ impl AuxvFileOps {
 
 impl FileOps for AuxvFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let vmar_guard = process.lock_vmar();
         let Some(init_stack_reader) = vmar_guard.init_stack_reader() else {
             // According to Linux behavior, return an empty file
             // if the process is a zombie process.

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
@@ -32,7 +32,11 @@ impl CgroupFileOps {
 
 impl FileOps for CgroupFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let cgroup: Arc<dyn CgroupSysNode> = match self.0.process_ref.cgroup().get() {
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let cgroup: Arc<dyn CgroupSysNode> = match process.cgroup().get() {
             Some(cgroup) => cgroup.clone(),
             None => CgroupSystem::singleton().clone(),
         };

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
@@ -8,17 +8,15 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/cmdline` (and also `/proc/[pid]/cmdline`).
-pub struct CmdlineFileOps(Arc<Process>);
+pub struct CmdlineFileOps(TidDirOps);
 
 impl CmdlineFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3340>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r))
             .parent(parent)
             .build()
             .unwrap()
@@ -27,7 +25,11 @@ impl CmdlineFileOps {
 
 impl FileOps for CmdlineFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let vmar_guard = process.lock_vmar();
         let Some(init_stack_reader) = vmar_guard.init_stack_reader() else {
             // According to Linux behavior, return an empty string
             // if the process is a zombie process.

--- a/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
@@ -8,17 +8,15 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/comm` (and also `/proc/[pid]/comm`).
-pub struct CommFileOps(Arc<Process>);
+pub struct CommFileOps(TidDirOps);
 
 impl CommFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3336>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r, u+w))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r, u+w))
             .parent(parent)
             .build()
             .unwrap()
@@ -27,7 +25,11 @@ impl CommFileOps {
 
 impl FileOps for CommFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let vmar_guard = process.lock_vmar();
         let Some(vmar) = vmar_guard.as_ref() else {
             // According to Linux behavior, return an empty string
             // if the process is a zombie process.

--- a/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
@@ -8,17 +8,15 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/environ` (and also `/proc/[pid]/environ`).
-pub struct EnvironFileOps(Arc<Process>);
+pub struct EnvironFileOps(TidDirOps);
 
 impl EnvironFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3324>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(u+r))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(u+r))
             .parent(parent)
             .build()
             .unwrap()
@@ -27,7 +25,11 @@ impl EnvironFileOps {
 
 impl FileOps for EnvironFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let vmar_guard = process.lock_vmar();
         let Some(init_stack_reader) = vmar_guard.init_stack_reader() else {
             // According to Linux behavior, return an empty string
             // if the process is a zombie process.

--- a/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
@@ -8,19 +8,17 @@ use crate::{
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/exe` (and also `/proc/[pid]/exe`).
-pub struct ExeSymOps(Arc<Process>);
+pub struct ExeSymOps(TidDirOps);
 
 impl ExeSymOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference:
         // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3350>
         // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L174-L175>
-        ProcSymBuilder::new(Self(process_ref), mkmod!(a+rwx))
+        ProcSymBuilder::new(Self(dir.clone()), mkmod!(a+rwx))
             .parent(parent)
             .build()
             .unwrap()
@@ -29,7 +27,11 @@ impl ExeSymOps {
 
 impl SymOps for ExeSymOps {
     fn read_link(&self) -> Result<SymbolicLink> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        let vmar_guard = process.lock_vmar();
         let Some(vmar) = vmar_guard.as_ref() else {
             return_errno_with_message!(Errno::ENOENT, "the process has exited");
         };

--- a/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
@@ -2,23 +2,22 @@
 
 use core::marker::PhantomData;
 
-use aster_util::{printer::VmPrinter, slot_vec::SlotVec};
-use ostd::sync::RwMutexUpgradeableGuard;
+use aster_util::printer::VmPrinter;
 
 use super::TidDirOps;
 use crate::{
     fs::{
         file::{
-            AccessMode, FileLike, chmod,
+            AccessMode, FileLike, InodeType, chmod,
             file_table::{FileDesc, RawFileDesc},
             mkmod,
         },
         procfs::template::{
-            DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFile, ProcFileBuilder, ProcSym,
-            ProcSymBuilder, SymOps,
+            DirOps, FileOps, ListedEntry, ProcDir, ProcDirBuilder, ProcFile, ProcFileBuilder,
+            ProcSym, ProcSymBuilder, ReaddirEntry, SymOps, keyed_readdir_entries,
+            visit_readdir_entries,
         },
-        utils::DirEntryVecExt,
-        vfs::inode::{Inode, SymbolicLink},
+        vfs::inode::{Inode, RevalidationPolicy, SymbolicLink},
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -47,20 +46,15 @@ impl<T: FdOps> FdDirOps<T> {
 }
 
 impl<T: FdOps> DirOps for FdDirOps<T> {
-    // Lock order: cached entries -> file table
-    //
-    // Note that inverting the lock order is non-trivial because the file table is protected by a
-    // spin lock but the cached entries are protected by a mutex.
-
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         let Ok(raw_fd) = name.parse::<RawFileDesc>() else {
             return_errno_with_message!(Errno::ENOENT, "the name is not a valid FD");
         };
         let fd = raw_fd.try_into()?;
 
-        let mut cached_children = dir.cached_children().write();
-
-        let thread = self.dir.thread();
+        let Some(thread) = self.dir.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let access_mode = if let Some(file_table) = posix_thread.file_table().lock().as_ref()
@@ -71,70 +65,58 @@ impl<T: FdOps> DirOps for FdDirOps<T> {
             return_errno_with_message!(Errno::ENOENT, "the file does not exist");
         };
 
-        let child = T::new_inode(self.dir.clone(), fd, access_mode, dir.this_weak().clone());
-        // The old entry is likely outdated given that `lookup_child` is called. Race conditions
-        // may occur, but caching the file descriptor (which aligns with the Linux implementation)
-        // is inherently racy, so preventing race conditions is not very meaningful.
-        cached_children.remove_entry_by_name(name);
-        cached_children.put((String::from(name), child.clone()));
-
-        Ok(child)
+        Ok(T::new_inode(
+            self.dir.clone(),
+            fd,
+            access_mode,
+            this_dir.this_weak().clone(),
+        ))
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-
-        let thread = self.dir.thread();
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        let Some(thread) = self.dir.thread() else {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let file_table = posix_thread.file_table().lock();
         let Some(file_table) = file_table.as_ref() else {
-            *cached_children = SlotVec::new();
-            return cached_children.downgrade();
+            // The thread has exited.
+            return Ok(());
         };
 
-        let file_table = file_table.read();
+        // Collect the list of FDs first before visiting entries. This can avoid holding the file
+        // table lock while calling `visit_fn`, which may break the atomic mode.
+        let file_descs = {
+            let file_table = file_table.read();
+            file_table
+                .fds_and_files()
+                .map(|(file_desc, _)| usize::from(file_desc))
+                .collect::<Vec<_>>()
+        };
 
-        // Remove outdated entries.
-        for i in 0..cached_children.slots_len() {
-            let Some((_, child)) = cached_children.get(i) else {
-                continue;
-            };
-            let child = child.downcast_ref::<T::NodeType>().unwrap();
-            let child_ops = T::ref_from_inode(child);
-
-            let Ok(file) = file_table.get_file(child_ops.file_desc()) else {
-                cached_children.remove(i);
-                continue;
-            };
-            if !child_ops.is_valid(file) {
-                cached_children.remove(i);
-            }
-        }
-
-        // Add new entries.
-        for (file_desc, file) in file_table.fds_and_files() {
-            cached_children.put_entry_if_not_found(&file_desc.to_string(), || {
-                T::new_inode(
-                    self.dir.clone(),
-                    file_desc,
-                    file.access_mode(),
-                    dir.this_weak().clone(),
-                )
-            });
-        }
-
-        cached_children.downgrade()
+        visit_readdir_entries(
+            keyed_readdir_entries(offset, 2, file_descs, |file_desc| {
+                ListedEntry::new(file_desc.to_string(), T::entry_inode_type())
+            }),
+            visit_fn,
+        )
     }
 
-    fn validate_child(&self, child: &dyn Inode) -> bool {
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+    }
+
+    fn revalidate_exists(&self, _name: &str, child: &dyn Inode) -> bool {
         let child = child.downcast_ref::<T::NodeType>().unwrap();
         let child_ops = T::ref_from_inode(child);
 
-        let thread = self.dir.thread();
+        let Some(thread) = self.dir.thread() else {
+            return false;
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         if let Some(file_table) = posix_thread.file_table().lock().as_ref()
@@ -144,6 +126,27 @@ impl<T: FdOps> DirOps for FdDirOps<T> {
         } else {
             false
         }
+    }
+
+    fn revalidate_absent(&self, name: &str) -> bool {
+        let Ok(file_desc) = name.parse::<RawFileDesc>() else {
+            return true;
+        };
+        let Ok(file_desc) = file_desc.try_into() else {
+            return true;
+        };
+
+        let Some(thread) = self.dir.thread() else {
+            return true;
+        };
+        let posix_thread = thread.as_posix_thread().unwrap();
+
+        let file_table = posix_thread.file_table().lock();
+        let Some(file_table) = file_table.as_ref() else {
+            return true;
+        };
+
+        file_table.read().get_file(file_desc).is_err()
     }
 }
 
@@ -158,6 +161,8 @@ pub(super) trait FdOps: Send + Sync + 'static {
     ) -> Arc<dyn Inode>;
 
     fn file_desc(&self) -> FileDesc;
+
+    fn entry_inode_type() -> InodeType;
 
     fn is_valid(&self, correspond_file: &Arc<dyn FileLike>) -> bool;
 
@@ -206,6 +211,10 @@ impl FdOps for FileSymOps {
         self.file_desc
     }
 
+    fn entry_inode_type() -> InodeType {
+        InodeType::SymLink
+    }
+
     fn is_valid(&self, correspond_file: &Arc<dyn FileLike>) -> bool {
         // We'll treat the old entry as valid and reuse it if the access mode is the same,
         // even if the file is different.
@@ -219,7 +228,9 @@ impl FdOps for FileSymOps {
 
 impl SymOps for FileSymOps {
     fn read_link(&self) -> Result<SymbolicLink> {
-        let thread = self.tid_dir_ops.thread();
+        let Some(thread) = self.tid_dir_ops.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let file_table = posix_thread.file_table().lock();
@@ -267,6 +278,10 @@ impl FdOps for FileInfoOps {
         self.file_desc
     }
 
+    fn entry_inode_type() -> InodeType {
+        InodeType::File
+    }
+
     fn is_valid(&self, _correspond_file: &Arc<dyn FileLike>) -> bool {
         true
     }
@@ -278,7 +293,9 @@ impl FdOps for FileInfoOps {
 
 impl FileOps for FileInfoOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let thread = self.tid_dir_ops.thread();
+        let Some(thread) = self.tid_dir_ops.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let info = if let Some(file_table) = posix_thread.file_table().lock().as_ref()

--- a/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
@@ -10,18 +10,17 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::{Gid, Process},
+    process::Gid,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/gid_map` (and also `/proc/[pid]/gid_map`).
 #[expect(dead_code)]
-pub struct GidMapFileOps(Arc<Process>);
+pub struct GidMapFileOps(TidDirOps);
 
 impl GidMapFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3403>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r, u+w))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r, u+w))
             .parent(parent)
             .build()
             .unwrap()

--- a/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        Process, VmarSnapshot,
+        VmarSnapshot,
         posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
         signal::{PollHandle, Pollable},
     },
@@ -20,13 +20,12 @@ use crate::{
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/maps` (and also `/proc/[pid]/maps`).
-pub struct MapsFileOps(Arc<Process>);
+pub struct MapsFileOps(TidDirOps);
 
 impl MapsFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3343>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r))
             .parent(parent)
             .build()
             .unwrap()
@@ -39,11 +38,14 @@ impl FileOpsByHandle for MapsFileOps {
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
     ) -> Result<Box<dyn FileIo>> {
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
         // Hold the process VMAR lock while checking access permissions and
         // taking the VMAR identity snapshot to prevent race conditions.
-        let vmar_guard = self.0.lock_vmar();
+        let vmar_guard = process.lock_vmar();
 
-        self.0
+        process
             .main_thread()
             .as_posix_thread()
             .unwrap()
@@ -59,7 +61,7 @@ impl FileOpsByHandle for MapsFileOps {
 }
 
 /// A file handle opened from `/proc/[pid]/task/[tid]/maps` (and also `/proc/[pid]/maps`).
-struct MapsFileHandle(Arc<Process>, VmarSnapshot);
+struct MapsFileHandle(TidDirOps, VmarSnapshot);
 
 impl Pollable for MapsFileHandle {
     fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
@@ -77,7 +79,10 @@ impl InodeIo for MapsFileHandle {
     ) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+        let vmar_guard = process.lock_vmar();
         if !vmar_guard.is_same_as(&self.1) {
             // The process has executed a new program.
             return Ok(0);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -10,20 +10,19 @@ use crate::{
     },
     prelude::*,
     process::{
-        Process, VmarSnapshot,
+        VmarSnapshot,
         posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
         signal::{PollHandle, Pollable},
     },
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/mem` (and also `/proc/[pid]/mem`).
-pub struct MemFileOps(Arc<Process>);
+pub struct MemFileOps(TidDirOps);
 
 impl MemFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3347>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(u+rw))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(u+rw))
             .parent(parent)
             .build()
             .unwrap()
@@ -36,11 +35,14 @@ impl FileOpsByHandle for MemFileOps {
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
     ) -> Result<Box<dyn FileIo>> {
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
         // Hold the process VMAR lock while checking access permissions and
         // taking the VMAR identity snapshot to prevent race conditions.
-        let vmar_guard = self.0.lock_vmar();
+        let vmar_guard = process.lock_vmar();
 
-        self.0
+        process
             .main_thread()
             .as_posix_thread()
             .unwrap()
@@ -56,7 +58,7 @@ impl FileOpsByHandle for MemFileOps {
 }
 
 /// A file handle opened from `/proc/[pid]/task/[tid]/mem` (and also `/proc/[pid]/mem`).
-struct MemFileHandle(Arc<Process>, VmarSnapshot);
+struct MemFileHandle(TidDirOps, VmarSnapshot);
 
 impl Pollable for MemFileHandle {
     fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
@@ -72,7 +74,11 @@ impl InodeIo for MemFileHandle {
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            // The process does not exist.
+            return Ok(0);
+        };
+        let vmar_guard = process.lock_vmar();
         if !vmar_guard.is_same_as(&self.1) {
             // The process has executed a new program.
             return Ok(0);
@@ -95,7 +101,11 @@ impl InodeIo for MemFileHandle {
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
-        let vmar_guard = self.0.lock_vmar();
+        let Some(process) = self.0.process() else {
+            // The process does not exist.
+            return Ok(0);
+        };
+        let vmar_guard = process.lock_vmar();
         if !vmar_guard.is_same_as(&self.1) {
             // The process has executed a new program.
             return Ok(0);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-
 use super::PidDirOps;
 use crate::{
-    events::Observer,
     fs::{
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::{
             pid::task::{
                 auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
@@ -18,16 +14,16 @@ use crate::{
                 status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
-                DirOps, ProcDir, ProcDirBuilder, lookup_child_from_table,
-                populate_children_from_table,
+                DirOps, ListedEntry, ProcDir, ProcDirBuilder, ReaddirEntry, StaticDirEntry,
+                keyed_readdir_entries, listed_entries_from_table, lookup_child_from_table,
+                visit_listed_entries, visit_readdir_entries,
             },
         },
-        utils::DirEntryVecExt,
-        vfs::inode::Inode,
+        vfs::inode::{Inode, RevalidationPolicy},
     },
     prelude::*,
-    process::{Process, posix_thread::AsPosixThread, task_set::TidEvent},
-    thread::{AsThread, Thread, Tid},
+    process::{Process, pid_table, pid_table::PidEntry, posix_thread::AsPosixThread},
+    thread::{Thread, Tid},
 };
 
 mod auxv;
@@ -45,119 +41,139 @@ mod mounts;
 mod mountstats;
 mod ns;
 mod oom_score_adj;
-mod stat;
+pub(super) mod stat;
 mod status;
 mod uid_map;
 
 /// Represents the inode at `/proc/[pid]/task`.
-pub struct TaskDirOps(Arc<Process>);
+pub struct TaskDirOps(Arc<PidEntry>);
 
 impl TaskDirOps {
     pub fn new_inode(dir: &PidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.0.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3316>
-        let task_dir_inode = ProcDirBuilder::new(Self(process_ref), mkmod!(a+rx))
+        ProcDirBuilder::new(Self(dir.pid_entry().clone()), mkmod!(a+rx))
             .parent(parent)
             .build()
-            .unwrap();
+            .unwrap()
+    }
 
-        let weak_ptr = Arc::downgrade(&task_dir_inode);
-        dir.0.process_ref.tasks().lock().register_observer(weak_ptr);
-
-        task_dir_inode
+    fn process(&self) -> Option<Arc<Process>> {
+        self.0.process_of_thread()
     }
 }
 
 /// Represents the inode at `/proc/[pid]/task/[tid]`.
 #[derive(Clone)]
 pub struct TidDirOps {
-    pub(super) process_ref: Arc<Process>,
-    /// If `thread_ref` is `None`, this corresponds to a process-level `/proc/[pid]/*` file.
-    /// Otherwise, this corresponds to a thread-level `/proc/[pid]/task/[tid]/*` file.
-    pub(super) thread_ref: Option<Arc<Thread>>,
+    pid_entry: Arc<PidEntry>,
 }
 
 impl TidDirOps {
-    pub fn new_inode(
-        process_ref: Arc<Process>,
-        thread_ref: Arc<Thread>,
-        parent: Weak<dyn Inode>,
-    ) -> Arc<dyn Inode> {
+    pub fn new(pid_entry: Arc<PidEntry>) -> Self {
+        Self { pid_entry }
+    }
+
+    pub fn new_inode(pid_entry: Arc<PidEntry>, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         ProcDirBuilder::new(
-            Self {
-                process_ref,
-                thread_ref: Some(thread_ref),
-            },
+            Self { pid_entry },
             // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3796>
             mkmod!(a+rx),
         )
         .parent(parent)
-        // The TID directory must be volatile, because it is just associated with one thread.
-        .volatile()
         .build()
         .unwrap()
     }
 
-    pub fn thread(&self) -> Arc<Thread> {
-        self.thread_ref
-            .clone()
-            .unwrap_or_else(|| self.process_ref.main_thread())
+    pub fn pid_entry(&self) -> &Arc<PidEntry> {
+        &self.pid_entry
+    }
+
+    pub(super) fn process(&self) -> Option<Arc<Process>> {
+        self.pid_entry.process_of_thread()
+    }
+
+    pub(super) fn thread(&self) -> Option<Arc<Thread>> {
+        self.pid_entry.thread()
+    }
+
+    pub(super) fn thread_and_process(&self) -> Option<(Arc<Thread>, Arc<Process>)> {
+        let thread = self.thread()?;
+        let process = thread.as_posix_thread().unwrap().weak_process().upgrade()?;
+
+        Some((thread, process))
     }
 
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(
-        &'static str,
+    const STATIC_ENTRIES: &'static [StaticDirEntry<
         fn(&TidDirOps, Weak<dyn Inode>) -> Arc<dyn Inode>,
-    )] = &[
-        ("auxv", AuxvFileOps::new_inode),
-        ("cgroup", CgroupFileOps::new_inode),
-        ("cmdline", CmdlineFileOps::new_inode),
-        ("comm", CommFileOps::new_inode),
-        ("environ", EnvironFileOps::new_inode),
-        ("exe", ExeSymOps::new_inode),
-        ("fd", FdDirOps::<fd::FileSymOps>::new_inode),
-        ("fdinfo", FdDirOps::<fd::FileInfoOps>::new_inode),
-        ("gid_map", GidMapFileOps::new_inode),
-        ("mem", MemFileOps::new_inode),
-        ("mountinfo", MountInfoFileOps::new_inode),
-        ("mountstats", MountStatsFileOps::new_inode),
-        ("ns", NsDirOps::new_inode),
-        ("oom_score_adj", OomScoreAdjFileOps::new_inode),
-        ("stat", StatFileOps::new_inode),
-        ("status", StatusFileOps::new_inode),
-        ("uid_map", UidMapFileOps::new_inode),
-        ("maps", MapsFileOps::new_inode),
-        ("mounts", MountsFileOps::new_inode),
+    >] = &[
+        ("auxv", InodeType::File, AuxvFileOps::new_inode),
+        ("cgroup", InodeType::File, CgroupFileOps::new_inode),
+        ("cmdline", InodeType::File, CmdlineFileOps::new_inode),
+        ("comm", InodeType::File, CommFileOps::new_inode),
+        ("environ", InodeType::File, EnvironFileOps::new_inode),
+        ("exe", InodeType::SymLink, ExeSymOps::new_inode),
+        ("fd", InodeType::Dir, FdDirOps::<fd::FileSymOps>::new_inode),
+        (
+            "fdinfo",
+            InodeType::Dir,
+            FdDirOps::<fd::FileInfoOps>::new_inode,
+        ),
+        ("gid_map", InodeType::File, GidMapFileOps::new_inode),
+        ("mem", InodeType::File, MemFileOps::new_inode),
+        ("mountinfo", InodeType::File, MountInfoFileOps::new_inode),
+        ("mountstats", InodeType::File, MountStatsFileOps::new_inode),
+        ("ns", InodeType::Dir, NsDirOps::new_inode),
+        (
+            "oom_score_adj",
+            InodeType::File,
+            OomScoreAdjFileOps::new_inode,
+        ),
+        ("stat", InodeType::File, StatFileOps::new_thread_inode),
+        ("status", InodeType::File, StatusFileOps::new_inode),
+        ("uid_map", InodeType::File, UidMapFileOps::new_inode),
+        ("maps", InodeType::File, MapsFileOps::new_inode),
+        ("mounts", InodeType::File, MountsFileOps::new_inode),
     ];
 }
 
 impl DirOps for TidDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
-        self.lookup_child_locked(&mut cached_children, dir.this_weak().clone(), name)
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if self.pid_entry().type_().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread or the process does not exist");
+        };
+
+        self.lookup_static_child(this_dir.this_weak().clone(), name)
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-        self.populate_children_locked(&mut cached_children, dir.this_weak().clone());
-        cached_children.downgrade()
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        if self.pid_entry().type_().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread or the process does not exist");
+        };
+
+        visit_listed_entries(offset, self.static_listed_entries(), visit_fn)
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS
+    }
+
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        self.pid_entry().type_().is_some()
     }
 }
 
 impl TidDirOps {
-    pub(super) fn lookup_child_locked(
+    pub(super) fn lookup_static_child(
         &self,
-        cached_children: &mut SlotVec<(String, Arc<dyn Inode>)>,
         this_ptr: Weak<dyn Inode>,
         name: &str,
     ) -> Result<Arc<dyn Inode>> {
         if let Some(child) =
-            lookup_child_from_table(name, cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(self, this_ptr)
-            })
+            lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| (f)(self, this_ptr))
         {
             return Ok(child);
         }
@@ -165,79 +181,114 @@ impl TidDirOps {
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
-    pub(super) fn populate_children_locked(
-        &self,
-        cached_children: &mut SlotVec<(String, Arc<dyn Inode>)>,
-        this_ptr: Weak<dyn Inode>,
-    ) {
-        populate_children_from_table(cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(self, this_ptr.clone())
-        });
-    }
-}
-
-impl Observer<TidEvent> for ProcDir<TaskDirOps> {
-    fn on_events(&self, events: &TidEvent) {
-        let TidEvent::Exit(tid) = events;
-
-        let mut cached_children = self.cached_children().write();
-        cached_children.remove_entry_by_name(&tid.to_string());
+    pub(super) fn static_listed_entries(&self) -> impl Iterator<Item = ListedEntry<'_>> + '_ {
+        listed_entries_from_table(Self::STATIC_ENTRIES)
     }
 }
 
 impl DirOps for TaskDirOps {
-    // Lock order: task set -> cached entries
-    //
-    // Note that inverting the lock order is non-trivial because `Observer::on_events` will be
-    // called with the task set locked.
-
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         let Ok(tid) = name.parse::<Tid>() else {
             return_errno_with_message!(Errno::ENOENT, "the name is not a valid TID");
         };
 
-        for task in self.0.tasks().lock().as_slice() {
-            let thread_ref = task.as_thread().unwrap();
-            if thread_ref.as_posix_thread().unwrap().tid() != tid {
-                continue;
-            }
+        // Note: After a PID-number recycling mechanism is introduced, there may be a race here:
+        // - If a PID number is recycled as soon as its `PidEntry` is removed from the `PidTable`,
+        //   then before the `PidTable` lock is acquired below, the current inode’s `PidEntry` may
+        //   already have been removed and replaced with a new entry using the same PID number.
+        //   In that case, it is possible that the main thread of the `Process` obtained here has not
+        //   yet been deleted, causing `contains_tid` to return true even though we have actually
+        //   retrieved the wrong `PidEntry`.
+        // - If the PID number is not recycled until the `PidEntry` is dropped, then this race does not arise.
+        //
+        // TODO: Revisit and handle this potential race as appropriate once PID-number recycling is implemented.
+        let Some(process) = self.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
 
-            let mut cached_children = dir.cached_children().write();
-            return Ok(cached_children
-                .put_entry_if_not_found(name, || {
-                    TidDirOps::new_inode(
-                        self.0.clone(),
-                        thread_ref.clone(),
-                        dir.this_weak().clone(),
-                    )
-                })
-                .clone());
+        // Lock order: PID table -> tasks of process
+
+        let pid_table = pid_table::pid_table_mut();
+
+        let contains_tid = process
+            .tasks()
+            .lock()
+            .as_slice()
+            .iter()
+            .any(|task| task.as_posix_thread().unwrap().tid() == tid);
+        if !contains_tid {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
         }
 
-        return_errno_with_message!(Errno::ENOENT, "the thread does not exist")
+        let Some(pid_entry) = pid_table.get_entry(tid) else {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        };
+
+        Ok(TidDirOps::new_inode(
+            pid_entry,
+            this_dir.this_weak().clone(),
+        ))
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let tasks = self.0.tasks().lock();
-        let mut cached_dentries = dir.cached_children().write();
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        let Some(process) = self.process() else {
+            return_errno_with_message!(Errno::ENOENT, "the process does not exist");
+        };
 
-        for task in tasks.as_slice() {
-            let thread_ref = task.as_thread().unwrap();
-            cached_dentries.put_entry_if_not_found(
-                &task.as_posix_thread().unwrap().tid().to_string(),
-                || {
-                    TidDirOps::new_inode(
-                        self.0.clone(),
-                        thread_ref.clone(),
-                        dir.this_weak().clone(),
-                    )
-                },
-            );
+        // Collect TIDs before visiting entries, as `visit_fn` may copy data to user memory.
+        let tids = process
+            .tasks()
+            .lock()
+            .as_slice()
+            .iter()
+            .filter_map(|task| usize::try_from(task.as_posix_thread().unwrap().tid()).ok())
+            .collect::<Vec<_>>();
+
+        visit_readdir_entries(
+            keyed_readdir_entries(offset, 2, tids, |tid| {
+                ListedEntry::new(tid.to_string(), InodeType::Dir)
+            }),
+            visit_fn,
+        )
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+    }
+
+    fn revalidate_exists(&self, name: &str, child: &dyn Inode) -> bool {
+        if name.parse::<Tid>().is_err() {
+            // For non-numeric names, the set of valid children does not change over time,
+            // so we can rely on the cache without revalidating.
+            return true;
         }
 
-        cached_dentries.downgrade()
+        if let Some(child) = child.downcast_ref::<ProcDir<TidDirOps>>() {
+            // If the child's `PidEntry` still has the associated thread, it will not be removed
+            // from the `PidTable` and remains alive.
+            child.inner().pid_entry().type_().is_some()
+        } else {
+            false
+        }
+    }
+
+    fn revalidate_absent(&self, name: &str) -> bool {
+        let Ok(tid) = name.parse::<Tid>() else {
+            return true;
+        };
+
+        let Some(process) = self.process() else {
+            return true;
+        };
+
+        process
+            .tasks()
+            .lock()
+            .as_slice()
+            .iter()
+            .all(|task| task.as_posix_thread().unwrap().tid() != tid)
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -155,7 +155,9 @@ impl MountInfoFileOps {
 
 impl FileOps for MountInfoFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let thread = self.0.thread();
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let fs = posix_thread.read_fs();

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
@@ -114,7 +114,9 @@ impl MountsFileOps {
 
 impl FileOps for MountsFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let thread = self.0.thread();
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let fs = posix_thread.read_fs();

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
@@ -85,7 +85,9 @@ impl MountStatsFileOps {
 
 impl FileOps for MountStatsFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let thread = self.0.thread();
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let fs = posix_thread.read_fs();

--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -2,21 +2,20 @@
 
 use core::marker::PhantomData;
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-
 use crate::{
     fs::{
         cgroupfs::CgroupNamespace,
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::{
             pid::TidDirOps,
-            template::{DirOps, ProcDir, ProcDirBuilder, ProcSym, ProcSymBuilder, SymOps},
+            template::{
+                DirOps, ListedEntry, ProcDir, ProcDirBuilder, ProcSym, ProcSymBuilder,
+                ReaddirEntry, SymOps, visit_listed_entries,
+            },
         },
         pseudofs::NsCommonOps,
-        utils::DirEntryVecExt,
         vfs::{
-            inode::{Inode, SymbolicLink},
+            inode::{Inode, RevalidationPolicy, SymbolicLink},
             path::{MountNamespace, Path},
         },
     },
@@ -96,16 +95,6 @@ impl NsProxyEntry {
             Self::Uts => NsSymOps::<UtsNamespace>::new_inode(ns_proxy.uts_ns().get_path(), parent),
         }
     }
-
-    /// Returns the current namespace path for this entry.
-    fn current_path(self, ns_proxy: &NsProxy) -> Path {
-        match self {
-            Self::Cgroup => ns_proxy.cgroup_ns().get_path(),
-            Self::Ipc => ns_proxy.ipc_ns().get_path(),
-            Self::Mnt => ns_proxy.mnt_ns().get_path(),
-            Self::Uts => ns_proxy.uts_ns().get_path(),
-        }
-    }
 }
 
 /// Extracts the cached namespace path from a `NsSymlink<T>` inode.
@@ -132,114 +121,85 @@ fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
 }
 
 impl DirOps for NsDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
-
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if name == "user" {
-            let current_path = {
-                let user_ns = self.dir.process_ref.user_ns().lock();
-                user_ns.get_path()
+            let Some(process) = self.dir.process() else {
+                return_errno_with_message!(Errno::ESRCH, "the process does not exist");
             };
-            // Reuse the cached inode if the user namespace hasn't changed.
-            if let Some(cached) = cached_children.find_entry_by_name(name)
-                && cached_ns_path(&**cached) == Some(&current_path)
-            {
-                return Ok(cached.clone());
-            }
 
-            let inode = NsSymOps::<UserNamespace>::new_inode(current_path, dir.this_weak().clone());
-            cached_children.remove_entry_by_name(name);
-            cached_children.put((name.to_string(), inode.clone()));
-            return Ok(inode);
+            let user_ns = process.user_ns().lock();
+            return Ok(NsSymOps::<UserNamespace>::new_inode(
+                user_ns.get_path(),
+                this_dir.this_weak().clone(),
+            ));
         }
 
         // Validate the name and get the current namespace path.
         let entry = NsProxyEntry::from_str(name)
             .ok_or_else(|| Error::with_message(Errno::ENOENT, "the file does not exist"))?;
 
-        let thread = self.dir.thread();
+        let Some(thread) = self.dir.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+
         let ns_proxy_guard = thread.as_posix_thread().unwrap().ns_proxy().lock();
         let ns_proxy = ns_proxy_guard
             .as_ref()
             .ok_or_else(|| Error::with_message(Errno::ENOENT, "the thread has exited"))?;
-        let current_path = entry.current_path(ns_proxy);
-
-        // Reuse the cached inode if the namespace hasn't changed.
-        if let Some(cached) = cached_children.find_entry_by_name(name)
-            && cached_ns_path(&**cached) == Some(&current_path)
-        {
-            return Ok(cached.clone());
-        }
-
-        let inode = entry.new_sym_inode(ns_proxy, dir.this_weak().clone());
-        cached_children.remove_entry_by_name(name);
-        cached_children.put((name.to_string(), inode.clone()));
-        Ok(inode)
+        Ok(entry.new_sym_inode(ns_proxy, this_dir.this_weak().clone()))
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-
-        // Refresh `NsProxy`-backed entries only when the namespace has changed
-        // or the proxy has been dropped.
-        let thread = self.dir.thread();
-        let ns_proxy = thread.as_posix_thread().unwrap().ns_proxy().lock();
-
-        for entry in NsProxyEntry::ALL {
-            let name = entry.as_str();
-            match ns_proxy.as_ref() {
-                Some(ns_proxy) => {
-                    let current_path = entry.current_path(ns_proxy);
-                    let needs_update = cached_children
-                        .find_entry_by_name(name)
-                        .is_none_or(|cached| cached_ns_path(&**cached) != Some(&current_path));
-                    if needs_update {
-                        cached_children.remove_entry_by_name(name);
-                        let inode = entry.new_sym_inode(ns_proxy, dir.this_weak().clone());
-                        cached_children.put((name.to_string(), inode));
-                    }
-                }
-                None => {
-                    // `NsProxy` is gone; remove the stale entry if present.
-                    cached_children.remove_entry_by_name(name);
-                }
-            }
-        }
-
-        drop(ns_proxy);
-
-        // Refresh the user namespace entry only when it has changed.
-        let user_ns_path = {
-            let user_ns = self.dir.process_ref.user_ns().lock();
-            user_ns.get_path()
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        let Some(thread) = self.dir.thread() else {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
         };
-        let user_needs_update = cached_children
-            .find_entry_by_name("user")
-            .is_none_or(|cached| cached_ns_path(&**cached) != Some(&user_ns_path));
-        if user_needs_update {
-            cached_children.remove_entry_by_name("user");
-            let user_inode =
-                NsSymOps::<UserNamespace>::new_inode(user_ns_path, dir.this_weak().clone());
-            cached_children.put(("user".to_string(), user_inode));
-        }
 
-        cached_children.downgrade()
+        let has_ns_proxy = thread
+            .as_posix_thread()
+            .unwrap()
+            .ns_proxy()
+            .lock()
+            .as_ref()
+            .is_some();
+        let ns_proxy_entries = has_ns_proxy
+            .then_some(NsProxyEntry::ALL)
+            .into_iter()
+            .flat_map(|entries| {
+                entries
+                    .iter()
+                    .map(|entry| ListedEntry::new(entry.as_str(), InodeType::SymLink))
+            });
+
+        let user_entry = Some(ListedEntry::new("user", InodeType::SymLink)).into_iter();
+
+        visit_listed_entries(offset, ns_proxy_entries.chain(user_entry), visit_fn)
     }
 
-    fn validate_child(&self, child: &dyn Inode) -> bool {
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        // Files in the `ns` directory will not appear implicitly. They can only disappear
+        // implicitly. Therefore, it is sufficient to revalidate only their existence.
+        RevalidationPolicy::REVALIDATE_EXISTS
+    }
+
+    fn revalidate_exists(&self, _name: &str, child: &dyn Inode) -> bool {
         let Some(cached_path) = cached_ns_path(child) else {
             return false;
         };
 
         if child.downcast_ref::<NsSymlink<UserNamespace>>().is_some() {
-            let user_ns = self.dir.process_ref.user_ns().lock();
+            let Some(process) = self.dir.process() else {
+                return false;
+            };
+            let user_ns = process.user_ns().lock();
             return cached_path == &user_ns.get_path();
         }
 
-        let thread = self.dir.thread();
+        let Some(thread) = self.dir.thread() else {
+            return false;
+        };
         let ns_proxy = thread.as_posix_thread().unwrap().ns_proxy().lock();
         let Some(ns_proxy) = ns_proxy.as_ref() else {
             return false;

--- a/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
@@ -12,17 +12,15 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::Process,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/oom_score_adj` (and also `/proc/[pid]/oom_score_adj`).
-pub struct OomScoreAdjFileOps(Arc<Process>);
+pub struct OomScoreAdjFileOps(TidDirOps);
 
 impl OomScoreAdjFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3386>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r, u+w))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r, u+w))
             .parent(parent)
             .build()
             .unwrap()
@@ -33,7 +31,10 @@ impl FileOps for OomScoreAdjFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 
-        let oom_score_adj = self.0.oom_score_adj().load(Ordering::Relaxed);
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+        let oom_score_adj = process.oom_score_adj().load(Ordering::Relaxed);
         writeln!(printer, "{}", oom_score_adj)?;
 
         Ok(printer.bytes_written())
@@ -51,7 +52,10 @@ impl FileOps for OomScoreAdjFileOps {
         // does not have the `SYS_RESOURCE` capability, we should fail with
         // `EACCES`. See
         // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L1152>.
-        self.0.oom_score_adj().store(val as i16, Ordering::Relaxed);
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+        process.oom_score_adj().store(val as i16, Ordering::Relaxed);
 
         Ok(read_bytes)
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::Ordering;
 
 use aster_util::printer::VmPrinter;
 
-use super::TidDirOps;
+use super::{super::PidDirOps, TidDirOps};
 use crate::{
     fs::{
         file::mkmod,
@@ -75,12 +75,33 @@ use crate::{
 /// - env_start        : Start address of environment variables.
 /// - env_end          : End address of environment variables.
 /// - exit_code        : Process exit code as returned by waitpid(2).
-pub struct StatFileOps(TidDirOps);
+pub struct StatFileOps {
+    dir: TidDirOps,
+    mode: StatMode,
+}
+
+#[derive(Clone, Copy)]
+enum StatMode {
+    Process,
+    Thread,
+}
 
 impl StatFileOps {
-    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+    pub fn new_thread_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        Self::new_inode_with_mode(dir.clone(), StatMode::Thread, parent)
+    }
+
+    pub fn new_process_inode(dir: &PidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        Self::new_inode_with_mode(dir.tid_dir_ops().clone(), StatMode::Process, parent)
+    }
+
+    fn new_inode_with_mode(
+        dir: TidDirOps,
+        mode: StatMode,
+        parent: Weak<dyn Inode>,
+    ) -> Arc<dyn Inode> {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3341>
-        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r))
+        ProcFileBuilder::new(Self { dir, mode }, mkmod!(a+r))
             .parent(parent)
             .build()
             .unwrap()
@@ -89,8 +110,9 @@ impl StatFileOps {
 
 impl FileOps for StatFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let process = self.0.process_ref.as_ref();
-        let thread = self.0.thread();
+        let Some((thread, process)) = self.dir.thread_and_process() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread or the process does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
 
         // According to the Linux implementation, a process's `/proc/<pid>/stat` should be
@@ -142,10 +164,9 @@ impl FileOps for StatFileOps {
         let cmaj_flt = 0;
 
         let (utime, stime) = {
-            let prof_clock = if self.0.thread_ref.is_none() {
-                process.prof_clock()
-            } else {
-                posix_thread.prof_clock()
+            let prof_clock = match self.mode {
+                StatMode::Process => process.prof_clock(),
+                StatMode::Thread => posix_thread.prof_clock(),
             };
             (
                 prof_clock.user_clock().read_jiffies().as_u64(),

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -79,8 +79,9 @@ impl FileOps for StatusFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 
-        let process = self.0.process_ref.as_ref();
-        let thread = self.0.thread();
+        let Some((thread, process)) = self.0.thread_and_process() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread or the process does not exist");
+        };
         let posix_thread = thread.as_posix_thread().unwrap();
         let credentials = posix_thread.credentials();
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -163,13 +163,11 @@ impl FileOps for StatusFileOps {
             )?;
         }
 
-        if process.pid() == posix_thread.tid() {
-            writeln!(
-                printer,
-                "Threads:\t{}",
-                process.tasks().lock().as_slice().len()
-            )?;
-        }
+        writeln!(
+            printer,
+            "Threads:\t{}",
+            process.tasks().lock().as_slice().len()
+        )?;
 
         writeln!(
             printer,

--- a/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
@@ -10,18 +10,17 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::{Process, Uid},
+    process::Uid,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/uid_map` (and also `/proc/[pid]/uid_map`).
 #[expect(dead_code)]
-pub struct UidMapFileOps(Arc<Process>);
+pub struct UidMapFileOps(TidDirOps);
 
 impl UidMapFileOps {
     pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
-        let process_ref = dir.process_ref.clone();
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3402>
-        ProcFileBuilder::new(Self(process_ref), mkmod!(a+r, u+w))
+        ProcFileBuilder::new(Self(dir.clone()), mkmod!(a+r, u+w))
             .parent(parent)
             .build()
             .unwrap()

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-
 use crate::{
     fs::{
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::{
             ProcDir,
             sys::kernel::{
                 cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
             },
             template::{
-                DirOps, ProcDirBuilder, lookup_child_from_table, populate_children_from_table,
+                DirOps, ProcDirBuilder, ReaddirEntry, StaticDirEntry, listed_entries_from_table,
+                lookup_child_from_table, visit_listed_entries,
             },
         },
         vfs::inode::Inode,
@@ -39,38 +37,36 @@ impl KernelDirOps {
     }
 
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(&'static str, fn(Weak<dyn Inode>) -> Arc<dyn Inode>)] = &[
-        ("cap_last_cap", CapLastCapFileOps::new_inode),
-        ("pid_max", PidMaxFileOps::new_inode),
-        ("yama", YamaDirOps::new_inode),
+    const STATIC_ENTRIES: &'static [StaticDirEntry<fn(Weak<dyn Inode>) -> Arc<dyn Inode>>] = &[
+        (
+            "cap_last_cap",
+            InodeType::File,
+            CapLastCapFileOps::new_inode,
+        ),
+        ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
+        ("yama", InodeType::Dir, YamaDirOps::new_inode),
     ];
 }
 
 impl DirOps for KernelDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
-
-        if let Some(child) =
-            lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(dir.this_weak().clone())
-            })
-        {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
             return Ok(child);
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-
-        populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(dir.this_weak().clone())
-        });
-
-        cached_children.downgrade()
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::{printer::VmPrinter, slot_vec::SlotVec};
-use ostd::sync::RwMutexUpgradeableGuard;
+use aster_util::printer::VmPrinter;
 
 use crate::{
     fs::{
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::template::{
-            DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder, lookup_child_from_table,
-            populate_children_from_table, read_i32_from,
+            DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder, ReaddirEntry,
+            StaticDirEntry, listed_entries_from_table, lookup_child_from_table, read_i32_from,
+            visit_listed_entries,
         },
         vfs::inode::Inode,
     },
@@ -31,36 +31,33 @@ impl YamaDirOps {
     }
 
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(&'static str, fn(Weak<dyn Inode>) -> Arc<dyn Inode>)] =
-        &[("ptrace_scope", PtraceScopeFileOps::new_inode)];
+    const STATIC_ENTRIES: &'static [StaticDirEntry<fn(Weak<dyn Inode>) -> Arc<dyn Inode>>] = &[(
+        "ptrace_scope",
+        InodeType::File,
+        PtraceScopeFileOps::new_inode,
+    )];
 }
 
 impl DirOps for YamaDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
-
-        if let Some(child) =
-            lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(dir.this_weak().clone())
-            })
-        {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
             return Ok(child);
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-
-        populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(dir.this_weak().clone())
-        });
-
-        cached_children.downgrade()
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
     }
 }
 

--- a/kernel/src/fs/fs_impls/procfs/sys/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/mod.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_util::slot_vec::SlotVec;
-use ostd::sync::RwMutexUpgradeableGuard;
-
 use self::kernel::KernelDirOps;
-use super::template::populate_children_from_table;
+use super::template::{
+    ReaddirEntry, StaticDirEntry, listed_entries_from_table, visit_listed_entries,
+};
 use crate::{
     fs::{
-        file::mkmod,
+        file::{InodeType, mkmod},
         procfs::template::{DirOps, ProcDir, ProcDirBuilder, lookup_child_from_table},
         vfs::inode::Inode,
     },
@@ -31,35 +30,29 @@ impl SysDirOps {
     }
 
     #[expect(clippy::type_complexity)]
-    const STATIC_ENTRIES: &'static [(&'static str, fn(Weak<dyn Inode>) -> Arc<dyn Inode>)] =
-        &[("kernel", KernelDirOps::new_inode)];
+    const STATIC_ENTRIES: &'static [StaticDirEntry<fn(Weak<dyn Inode>) -> Arc<dyn Inode>>] =
+        &[("kernel", InodeType::Dir, KernelDirOps::new_inode)];
 }
 
 impl DirOps for SysDirOps {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let mut cached_children = dir.cached_children().write();
-
-        if let Some(child) =
-            lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
-                (f)(dir.this_weak().clone())
-            })
-        {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
             return Ok(child);
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>> {
-        let mut cached_children = dir.cached_children().write();
-
-        populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
-            (f)(dir.this_weak().clone())
-        });
-
-        cached_children.downgrade()
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/template/builder.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/builder.rs
@@ -35,13 +35,14 @@ impl<O: DirOps> ProcDirBuilder<O> {
         self.optional_builder(|ob| ob.parent(parent))
     }
 
-    pub fn volatile(self) -> Self {
-        self.optional_builder(|ob| ob.volatile())
-    }
-
     pub fn build(mut self) -> Result<Arc<ProcDir<O>>> {
-        let (fs, parent, is_volatile) = self.optional_builder.take().unwrap().build()?;
-        Ok(ProcDir::new(self.dir, fs, parent, is_volatile, self.mode))
+        let optional = self.optional_builder.take().unwrap().build()?;
+        Ok(ProcDir::new(
+            self.dir,
+            optional.fs,
+            optional.parent,
+            self.mode,
+        ))
     }
 
     fn optional_builder<F>(mut self, f: F) -> Self
@@ -76,14 +77,9 @@ impl<O: FileOps> ProcFileBuilder<O> {
         self.optional_builder(|ob| ob.parent(parent))
     }
 
-    #[expect(dead_code)]
-    pub fn volatile(self) -> Self {
-        self.optional_builder(|ob| ob.volatile())
-    }
-
     pub fn build(mut self) -> Result<Arc<ProcFile<O>>> {
-        let (fs, _, is_volatile) = self.optional_builder.take().unwrap().build()?;
-        Ok(ProcFile::new(self.file, fs, is_volatile, self.mode))
+        let optional = self.optional_builder.take().unwrap().build()?;
+        Ok(ProcFile::new(self.file, optional.fs, self.mode))
     }
 
     fn optional_builder<F>(mut self, f: F) -> Self
@@ -118,14 +114,9 @@ impl<O: SymOps> ProcSymBuilder<O> {
         self.optional_builder(|ob| ob.parent(parent))
     }
 
-    #[expect(dead_code)]
-    pub fn volatile(self) -> Self {
-        self.optional_builder(|ob| ob.volatile())
-    }
-
     pub fn build(mut self) -> Result<Arc<ProcSym<O>>> {
-        let (fs, _, is_volatile) = self.optional_builder.take().unwrap().build()?;
-        Ok(ProcSym::new(self.sym, fs, is_volatile, self.mode))
+        let optional = self.optional_builder.take().unwrap().build()?;
+        Ok(ProcSym::new(self.sym, optional.fs, self.mode))
     }
 
     fn optional_builder<F>(mut self, f: F) -> Self
@@ -140,15 +131,16 @@ impl<O: SymOps> ProcSymBuilder<O> {
 
 struct OptionalBuilder {
     parent: Option<Weak<dyn Inode>>,
-    is_volatile: bool,
+}
+
+struct OptionalBuildResult {
+    fs: Weak<dyn FileSystem>,
+    parent: Option<Weak<dyn Inode>>,
 }
 
 impl OptionalBuilder {
     fn new() -> Self {
-        Self {
-            parent: None,
-            is_volatile: false,
-        }
+        Self { parent: None }
     }
 
     pub fn parent(mut self, parent: Weak<dyn Inode>) -> Self {
@@ -156,29 +148,15 @@ impl OptionalBuilder {
         self
     }
 
-    pub fn volatile(mut self) -> Self {
-        self.is_volatile = true;
-        self
-    }
-
-    #[expect(clippy::type_complexity)]
-    pub fn build(self) -> Result<(Weak<dyn FileSystem>, Option<Weak<dyn Inode>>, bool)> {
+    pub fn build(self) -> Result<OptionalBuildResult> {
         let Some(parent) = self.parent else {
             return_errno_with_message!(Errno::EINVAL, "must have parent");
         };
-        let parent_inode = parent.upgrade().unwrap();
-        let fs = Arc::downgrade(&parent_inode.fs());
+        let fs = Arc::downgrade(&parent.upgrade().unwrap().fs());
 
-        // The volatile property is inherited from parent.
-        let is_volatile = {
-            let mut is_volatile = self.is_volatile;
-            if !parent_inode.is_dentry_cacheable() {
-                is_volatile = true;
-            }
-
-            is_volatile
-        };
-
-        Ok((fs, Some(parent), is_volatile))
+        Ok(OptionalBuildResult {
+            fs,
+            parent: Some(parent),
+        })
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! Reusable procfs directory inode templates and `readdir` helpers.
+
+use alloc::borrow::Cow;
 use core::time::Duration;
 
-use aster_util::slot_vec::SlotVec;
 use inherit_methods_macro::inherit_methods;
-use ostd::sync::RwMutexUpgradeableGuard;
 
 use super::Common;
 use crate::{
     fs::{
         file::{InodeMode, InodeType, StatusFlags},
-        utils::{DirEntryVecExt, DirentVisitor},
+        procfs::{BLOCK_SIZE, ProcFs},
+        utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
-            inode::{Extension, Inode, InodeIo, Metadata, MknodType},
+            inode::{Extension, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy},
             path::{is_dot, is_dotdot},
         },
     },
@@ -21,52 +23,61 @@ use crate::{
     process::{Gid, Uid},
 };
 
+/// Wraps directory-specific procfs operations as a VFS inode.
+///
+/// `ProcDir` owns the directory implementation object,
+/// tracks parent linkage for `.` and `..`,
+/// and forwards inode methods that are common to all procfs directories.
 pub struct ProcDir<D: DirOps> {
     inner: D,
     this: Weak<ProcDir<D>>,
     parent: Option<Weak<dyn Inode>>,
-    cached_children: RwMutex<SlotVec<(String, Arc<dyn Inode>)>>,
     common: Common,
 }
 
 impl<D: DirOps> ProcDir<D> {
-    pub(in crate::fs::fs_impls::procfs) fn new_root(
+    /// Creates the root procfs directory inode.
+    pub fn new_root(
         dir: D,
         fs: Weak<dyn FileSystem>,
         ino: u64,
         sb: &SuperBlock,
         mode: InodeMode,
     ) -> Arc<Self> {
-        let metadata = Metadata::new_dir(ino, mode, super::BLOCK_SIZE, sb.container_dev_id);
-        let common = Common::new(metadata, fs, false);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, sb.container_dev_id);
+        let common = Common::new(metadata, fs);
 
         Arc::new_cyclic(|weak_self| Self {
             inner: dir,
             this: weak_self.clone(),
             parent: None,
-            cached_children: RwMutex::new(SlotVec::new()),
             common,
         })
     }
 
+    /// Creates a non-root procfs directory inode under `parent`.
     pub(super) fn new(
         dir: D,
         fs: Weak<dyn FileSystem>,
         parent: Option<Weak<dyn Inode>>,
-        is_volatile: bool,
         mode: InodeMode,
     ) -> Arc<Self> {
-        let common = new_dir_common(fs, mode, is_volatile);
+        let common = {
+            let arc_fs = fs.upgrade().unwrap();
+            let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
+            let ino = procfs.alloc_id();
+            let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, procfs.sb().container_dev_id);
+            Common::new(metadata, fs)
+        };
         Arc::new_cyclic(|weak_self| Self {
             inner: dir,
             this: weak_self.clone(),
             parent,
-            cached_children: RwMutex::new(SlotVec::new()),
             common,
         })
     }
 
-    pub fn this(&self) -> Arc<ProcDir<D>> {
+    fn this(&self) -> Arc<ProcDir<D>> {
         self.this.upgrade().unwrap()
     }
 
@@ -74,21 +85,14 @@ impl<D: DirOps> ProcDir<D> {
         &self.this
     }
 
-    pub fn parent(&self) -> Option<Arc<dyn Inode>> {
+    fn parent(&self) -> Option<Arc<dyn Inode>> {
         self.parent.as_ref().and_then(|p| p.upgrade())
     }
 
-    pub fn cached_children(&self) -> &RwMutex<SlotVec<(String, Arc<dyn Inode>)>> {
-        &self.cached_children
+    /// Returns the directory-specific procfs operations.
+    pub fn inner(&self) -> &D {
+        &self.inner
     }
-}
-
-fn new_dir_common(fs: Weak<dyn FileSystem>, mode: InodeMode, is_volatile: bool) -> Common {
-    let fs_ref = fs.upgrade().unwrap();
-    let procfs = fs_ref.downcast_ref::<super::ProcFs>().unwrap();
-    let ino = procfs.alloc_id();
-    let metadata = Metadata::new_dir(ino, mode, super::BLOCK_SIZE, procfs.sb().container_dev_id);
-    Common::new(metadata, fs, is_volatile)
 }
 
 impl<D: DirOps + 'static> InodeIo for ProcDir<D> {
@@ -148,35 +152,35 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
     }
 
     fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        /// Returns the always-present `.` and `..` entries for a procfs directory.
+        fn special_entries<D: DirOps + 'static>(
+            dir: &ProcDir<D>,
+        ) -> impl Iterator<Item = (&'static str, Arc<dyn Inode>, usize)> {
+            let this_inode: Arc<dyn Inode> = dir.this();
+            let parent_inode = dir.parent().unwrap_or_else(|| this_inode.clone());
+            [(".", this_inode, 1), ("..", parent_inode, 2)].into_iter()
+        }
+
         let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
-            // Read the two special entries.
-            if *offset == 0 {
-                let this_inode = self.this();
-                visitor.visit(
-                    ".",
-                    this_inode.common.ino(),
-                    this_inode.common.type_(),
-                    *offset,
-                )?;
-                *offset += 1;
-            }
-            if *offset == 1 {
-                let parent_inode = self.parent().unwrap_or(self.this());
-                visitor.visit("..", parent_inode.ino(), parent_inode.type_(), *offset)?;
-                *offset += 1;
+            for (name, inode, next_offset) in special_entries(self) {
+                if next_offset <= *offset {
+                    continue;
+                }
+
+                visitor.visit(name, inode.ino(), inode.type_(), next_offset)?;
+                *offset = next_offset;
             }
 
-            // Read the normal child entries.
-            let cached_children = self.inner.populate_children(self);
-            let start_offset = *offset;
-            for (idx, (name, child)) in cached_children
-                .idxes_and_items()
-                .map(|(idx, (name, child))| (idx + 2, (name, child)))
-                .skip_while(|(idx, _)| idx < &start_offset)
-            {
-                visitor.visit(name.as_ref(), child.ino(), child.type_(), idx)?;
-                *offset = idx + 1;
-            }
+            self.inner.visit_entries_from_offset(*offset, |child| {
+                visitor.visit(
+                    child.name.as_ref(),
+                    child.ino,
+                    child.type_,
+                    child.next_offset,
+                )?;
+                *offset = child.next_offset;
+                Ok(())
+            })?;
             Ok(())
         };
 
@@ -207,14 +211,6 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
             return Ok(self.parent().unwrap_or(self.this()));
         }
 
-        let cached_children = self.cached_children.read();
-        if let Some(inode) = cached_children.find_entry_by_name(name)
-            && self.inner.validate_child(inode.as_ref())
-        {
-            return Ok(inode.clone());
-        }
-        drop(cached_children);
-
         self.inner.lookup_child(self, name)
     }
 
@@ -222,8 +218,16 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn is_dentry_cacheable(&self) -> bool {
-        !self.common.is_volatile()
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        self.inner.revalidation_policy()
+    }
+
+    fn revalidate_exists(&self, name: &str, child: &dyn Inode) -> bool {
+        self.inner.revalidate_exists(name, child)
+    }
+
+    fn revalidate_absent(&self, name: &str) -> bool {
+        self.inner.revalidate_absent(name)
     }
 
     fn seek_end(&self) -> Option<usize> {
@@ -233,52 +237,259 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
 }
 
 pub trait DirOps: Sync + Send + Sized {
-    fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>>;
+    /// Looks up a child inode in `this_dir` by name.
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>>;
 
-    fn populate_children<'a>(
-        &self,
-        dir: &'a ProcDir<Self>,
-    ) -> RwMutexUpgradeableGuard<'a, SlotVec<(String, Arc<dyn Inode>)>>;
+    /// Visits readdir entries whose continuation offsets are strictly greater than `offset`.
+    ///
+    /// Build entries with helpers from the [`readdir`] submodule and forward to
+    /// [`readdir::visit_readdir_entries`]. Common patterns:
+    ///
+    /// - Static or sequential children: [`readdir::sequential_readdir_entries`]
+    ///   or the [`readdir::visit_listed_entries`] convenience wrapper.
+    /// - Children identified by a stable integer key: [`readdir::keyed_readdir_entries`].
+    /// - Mixed children: invoke [`readdir::visit_readdir_entries`] more than
+    ///   once per call, once per group. See `RootDirOps`.
+    ///
+    /// The default implementation reports no entries.
+    fn visit_entries_from_offset<'a, F>(&'a self, _offset: usize, _visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        Ok(())
+    }
 
+    /// Returns the dentry cache revalidation policy for this directory.
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::empty()
+    }
+
+    /// Checks whether a positive lookup result still exists.
+    ///
+    /// This method is only consulted when [`Self::revalidation_policy`] includes
+    /// `REVALIDATE_EXISTS`.
     #[must_use]
-    fn validate_child(&self, _child: &dyn Inode) -> bool {
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        true
+    }
+
+    /// Checks whether a negative lookup result is still absent.
+    ///
+    /// This method is only consulted when [`Self::revalidation_policy`] includes
+    /// `REVALIDATE_ABSENT`.
+    #[must_use]
+    fn revalidate_absent(&self, _name: &str) -> bool {
         true
     }
 }
 
+/// A statically declared procfs child entry.
+///
+/// The tuple stores the exported filename,
+/// the inode type reported to [`Inode::readdir_at`],
+/// and the constructor used by lookup paths to instantiate the inode.
+pub type StaticDirEntry<Fp> = (&'static str, InodeType, Fp);
+
+/// Looks up a statically declared child from a `StaticDirEntry` table.
+///
+/// The `constructor_adaptor` receives the stored constructor payload
+/// and can bind any per-directory context that is needed at the call site.
 pub fn lookup_child_from_table<Fp, F>(
     name: &str,
-    cached_children: &mut SlotVec<(String, Arc<dyn Inode>)>,
-    table: &[(&str, Fp)],
+    table: &[StaticDirEntry<Fp>],
     constructor_adaptor: F,
 ) -> Option<Arc<dyn Inode>>
 where
     Fp: Copy,
     F: FnOnce(Fp) -> Arc<dyn Inode>,
 {
-    for (child_name, child_constructor) in table.iter() {
-        if *child_name == name {
-            return Some(
-                cached_children
-                    .put_entry_if_not_found(name, || (constructor_adaptor)(*child_constructor))
-                    .clone(),
-            );
+    table
+        .iter()
+        .find(|(child_name, _, _)| *child_name == name)
+        .map(|(_, _, child_constructor)| (constructor_adaptor)(*child_constructor))
+}
+
+/// Converts a static procfs child table into listed entries.
+pub fn listed_entries_from_table<'a, Fp>(
+    table: &'a [StaticDirEntry<Fp>],
+) -> impl Iterator<Item = ListedEntry<'a>> + 'a
+where
+    Fp: Copy + 'a,
+{
+    table
+        .iter()
+        .map(|(name, type_, _)| ListedEntry::new(*name, *type_))
+}
+
+mod readdir {
+    //! `readdir` resumption types and strategies.
+    //!
+    //! When user space calls `getdents`, it passes an offset and expects the
+    //! kernel to emit entries strictly past it. Each emitted entry carries a
+    //! continuation offset that user space remembers for the next call.
+    //!
+    //! # Vocabulary
+    //!
+    //! - **Offset** - the cursor passed to `Inode::readdir_at`. Maps to
+    //!   `dirent::d_off`. Offsets `1` and `2` are reserved for `.` and `..`.
+    //!
+    //! - **Key** - an integer that uniquely identifies one dynamic child
+    //!   (PID, TID, FD). Comes from kernel state, not iteration order.
+    //!
+    //! - **Continuation offset** - the offset stored in [`ReaddirEntry`].
+    //!   Computed by [`sequential_readdir_entries`] from index or
+    //!   [`keyed_readdir_entries`] from key:
+    //!
+    //!   ```text
+    //!   continuation_offset = first_entry_offset + index + 1   // sequential_*
+    //!   continuation_offset = first_entry_offset + key   + 1   // keyed_*
+    //!   ```
+
+    use super::*;
+
+    /// A listed entry that is currently visible in a procfs directory.
+    ///
+    /// Unlike [`ReaddirEntry`], this type does not carry a continuation offset.
+    /// It is intended for higher-level directory descriptions,
+    /// while [`ReaddirEntry`] derives offsets from the iteration strategy.
+    pub struct ListedEntry<'a> {
+        pub(super) name: Cow<'a, str>,
+        pub(super) type_: InodeType,
+    }
+
+    impl<'a> ListedEntry<'a> {
+        /// Creates a listed entry with the given filename and inode type.
+        pub fn new(name: impl Into<Cow<'a, str>>, type_: InodeType) -> Self {
+            Self {
+                name: name.into(),
+                type_,
+            }
+        }
+
+        /// Returns the filename of the listed entry.
+        pub fn name(&self) -> &str {
+            self.name.as_ref()
         }
     }
 
-    None
-}
+    /// A directory entry emitted by [`DirOps::visit_entries_from_offset`].
+    ///
+    /// The `next_offset` is the continuation offset that should be used as the
+    /// starting point of the next [`Inode::readdir_at`] call.
+    pub struct ReaddirEntry<'a> {
+        pub(super) name: Cow<'a, str>,
+        pub(super) ino: u64,
+        pub(super) type_: InodeType,
+        pub(super) next_offset: usize,
+    }
 
-pub fn populate_children_from_table<Fp, F>(
-    cached_children: &mut SlotVec<(String, Arc<dyn Inode>)>,
-    table: &[(&str, Fp)],
-    constructor_adaptor: F,
-) where
-    Fp: Copy,
-    F: Fn(Fp) -> Arc<dyn Inode>,
-{
-    for (child_name, child_constructor) in table.iter() {
-        cached_children
-            .put_entry_if_not_found(child_name, || (constructor_adaptor)(*child_constructor));
+    impl<'a> ReaddirEntry<'a> {
+        /// Creates an entry with an explicit continuation offset.
+        pub(super) fn new(
+            name: impl Into<Cow<'a, str>>,
+            ino: u64,
+            type_: InodeType,
+            next_offset: usize,
+        ) -> Self {
+            Self {
+                name: name.into(),
+                ino,
+                type_,
+                next_offset,
+            }
+        }
+    }
+
+    /// A placeholder inode number for procfs entries.
+    ///
+    /// [`Inode::readdir_at`] reports procfs entries without instantiating child inodes first,
+    /// so the inode number returned here is only a placeholder.
+    /// Lookup still creates the real child inode on demand when the path is opened.
+    //
+    // TODO: Adopt deterministic inode numbers derived from stable entity identity
+    // (for example, PID) as the long-term fix for `d_ino`/`st_ino` consistency.
+    pub(super) const PLACEHOLDER_DIRENT_INO: u64 = 2;
+
+    /// Builds sequential directory entries whose continuation offsets increase by one.
+    ///
+    /// This helper is appropriate for directories whose visible children already
+    /// have a deterministic iteration order.
+    /// It reserves offsets `1` and `2` for `.` and `..`,
+    /// so callers typically pass `2` as `first_entry_offset`.
+    pub fn sequential_readdir_entries<'a, I>(
+        offset: usize,
+        first_entry_offset: usize,
+        entries: I,
+    ) -> impl Iterator<Item = ReaddirEntry<'a>>
+    where
+        I: IntoIterator<Item = ListedEntry<'a>>,
+    {
+        entries
+            .into_iter()
+            .enumerate()
+            .filter_map(move |(idx, entry)| {
+                let next_offset = first_entry_offset.saturating_add(idx).saturating_add(1);
+                let ListedEntry { name, type_ } = entry;
+                (next_offset > offset)
+                    .then(|| ReaddirEntry::new(name, PLACEHOLDER_DIRENT_INO, type_, next_offset))
+            })
+    }
+
+    /// Builds directory entries whose offsets are derived from stable integer keys.
+    ///
+    /// This is useful for procfs directories such as `/proc`, `/proc/[pid]/task`,
+    /// and `/proc/[pid]/fd`, where Linux uses identifiers like PID, TID, or FD to
+    /// keep iteration stable across mutations.
+    ///
+    /// Names are produced only after the corresponding key passes the offset check.
+    /// The resulting continuation offset for key `k` is `first_entry_offset + k + 1`,
+    /// so callers should provide non-negative keys in increasing order.
+    /// Keys do not need to be dense,
+    /// but each key must stay stable for the duration of one directory snapshot.
+    pub fn keyed_readdir_entries<'a, I, F>(
+        offset: usize,
+        first_entry_offset: usize,
+        keys: I,
+        mut entry_fn: F,
+    ) -> impl Iterator<Item = ReaddirEntry<'a>>
+    where
+        I: IntoIterator<Item = usize>,
+        F: FnMut(usize) -> ListedEntry<'a>,
+    {
+        let start_key = offset.saturating_sub(first_entry_offset);
+        keys.into_iter().filter_map(move |key| {
+            let next_offset = first_entry_offset.saturating_add(key).saturating_add(1);
+            (key >= start_key && next_offset > offset).then(|| {
+                let ListedEntry { name, type_ } = entry_fn(key);
+                ReaddirEntry::new(name, PLACEHOLDER_DIRENT_INO, type_, next_offset)
+            })
+        })
+    }
+
+    /// Visits the given [`ReaddirEntry`] values in order, calling `visit_fn` for each one.
+    pub fn visit_readdir_entries<'a, I, F>(entries: I, mut visit_fn: F) -> Result<()>
+    where
+        I: IntoIterator<Item = ReaddirEntry<'a>>,
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        for entry in entries {
+            visit_fn(entry)?;
+        }
+
+        Ok(())
+    }
+
+    /// Visits listed entries using sequential continuation offsets.
+    pub fn visit_listed_entries<'a, I, F>(offset: usize, listed: I, visit_fn: F) -> Result<()>
+    where
+        I: IntoIterator<Item = ListedEntry<'a>>,
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_readdir_entries(sequential_readdir_entries(offset, 2, listed), visit_fn)
     }
 }
+
+pub use readdir::{
+    ListedEntry, ReaddirEntry, keyed_readdir_entries, sequential_readdir_entries,
+    visit_listed_entries, visit_readdir_entries,
+};

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -8,6 +8,7 @@ use super::Common;
 use crate::{
     fs::{
         file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags},
+        procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, Inode, InodeIo, Metadata, SymbolicLink},
@@ -23,13 +24,18 @@ pub struct ProcFile<F: FileOps> {
 }
 
 impl<F: FileOps> ProcFile<F> {
-    pub(super) fn new(
-        file: F,
-        fs: Weak<dyn FileSystem>,
-        is_volatile: bool,
-        mode: InodeMode,
-    ) -> Arc<Self> {
-        let common = new_file_common(fs, mode, is_volatile);
+    pub(super) fn new(file: F, fs: Weak<dyn FileSystem>, mode: InodeMode) -> Arc<Self> {
+        let common = {
+            let arc_fs = fs.upgrade().unwrap();
+            let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
+            let metadata = Metadata::new_file(
+                procfs.alloc_id(),
+                mode,
+                BLOCK_SIZE,
+                procfs.sb().container_dev_id,
+            );
+            Common::new(metadata, fs)
+        };
         Arc::new(Self {
             inner: file,
             common,
@@ -39,18 +45,6 @@ impl<F: FileOps> ProcFile<F> {
     pub fn inner(&self) -> &F {
         &self.inner
     }
-}
-
-fn new_file_common(fs: Weak<dyn FileSystem>, mode: InodeMode, is_volatile: bool) -> Common {
-    let fs_ref = fs.upgrade().unwrap();
-    let procfs = fs_ref.downcast_ref::<super::ProcFs>().unwrap();
-    let metadata = Metadata::new_file(
-        procfs.alloc_id(),
-        mode,
-        super::BLOCK_SIZE,
-        procfs.sb().container_dev_id,
-    );
-    Common::new(metadata, fs, is_volatile)
 }
 
 impl<F: FileOps + 'static> InodeIo for ProcFile<F> {
@@ -108,10 +102,6 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
 
     fn write_link(&self, _target: &str) -> Result<()> {
         Err(Error::new(Errno::EINVAL))
-    }
-
-    fn is_dentry_cacheable(&self) -> bool {
-        !self.common.is_volatile()
     }
 
     fn seek_end(&self) -> Option<usize> {

--- a/kernel/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/mod.rs
@@ -4,14 +4,17 @@ use core::time::Duration;
 
 pub(super) use self::{
     builder::{ProcDirBuilder, ProcFileBuilder, ProcSymBuilder},
-    dir::{DirOps, ProcDir, lookup_child_from_table, populate_children_from_table},
+    dir::{
+        DirOps, ListedEntry, ProcDir, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
+        listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
+        visit_listed_entries, visit_readdir_entries,
+    },
     file::{FileOps, FileOpsByHandle, ProcFile, read_i32_from},
     sym::{ProcSym, SymOps},
 };
-use super::{BLOCK_SIZE, ProcFs};
 use crate::{
     fs::{
-        file::{InodeMode, InodeType},
+        file::InodeMode,
         vfs::{
             file_system::FileSystem,
             inode::{Extension, Metadata},
@@ -30,16 +33,14 @@ struct Common {
     metadata: RwLock<Metadata>,
     extension: Extension,
     fs: Weak<dyn FileSystem>,
-    is_volatile: bool,
 }
 
 impl Common {
-    fn new(metadata: Metadata, fs: Weak<dyn FileSystem>, is_volatile: bool) -> Self {
+    fn new(metadata: Metadata, fs: Weak<dyn FileSystem>) -> Self {
         Self {
             metadata: RwLock::new(metadata),
             extension: Extension::new(),
             fs,
-            is_volatile,
         }
     }
 
@@ -53,10 +54,6 @@ impl Common {
 
     fn ino(&self) -> u64 {
         self.metadata.read().ino
-    }
-
-    fn type_(&self) -> InodeType {
-        self.metadata.read().type_
     }
 
     fn size(&self) -> usize {
@@ -112,10 +109,6 @@ impl Common {
     fn set_group(&self, gid: Gid) -> Result<()> {
         self.metadata.write().gid = gid;
         Ok(())
-    }
-
-    fn is_volatile(&self) -> bool {
-        self.is_volatile
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -8,6 +8,7 @@ use super::Common;
 use crate::{
     fs::{
         file::{InodeMode, InodeType, StatusFlags},
+        procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, Inode, InodeIo, Metadata, SymbolicLink},
@@ -23,31 +24,24 @@ pub struct ProcSym<S: SymOps> {
 }
 
 impl<S: SymOps> ProcSym<S> {
-    pub(super) fn new(
-        sym: S,
-        fs: Weak<dyn FileSystem>,
-        is_volatile: bool,
-        mode: InodeMode,
-    ) -> Arc<Self> {
-        let common = new_symlink_common(fs, mode, is_volatile);
+    pub(super) fn new(sym: S, fs: Weak<dyn FileSystem>, mode: InodeMode) -> Arc<Self> {
+        let common = {
+            let arc_fs = fs.upgrade().unwrap();
+            let procfs = arc_fs.downcast_ref::<ProcFs>().unwrap();
+            let metadata = Metadata::new_symlink(
+                procfs.alloc_id(),
+                mode,
+                BLOCK_SIZE,
+                procfs.sb().container_dev_id,
+            );
+            Common::new(metadata, fs)
+        };
         Arc::new(Self { inner: sym, common })
     }
 
     pub fn inner(&self) -> &S {
         &self.inner
     }
-}
-
-fn new_symlink_common(fs: Weak<dyn FileSystem>, mode: InodeMode, is_volatile: bool) -> Common {
-    let fs_ref = fs.upgrade().unwrap();
-    let procfs = fs_ref.downcast_ref::<super::ProcFs>().unwrap();
-    let metadata = Metadata::new_symlink(
-        procfs.alloc_id(),
-        mode,
-        super::BLOCK_SIZE,
-        procfs.sb().container_dev_id,
-    );
-    Common::new(metadata, fs, is_volatile)
 }
 
 impl<S: SymOps + 'static> InodeIo for ProcSym<S> {
@@ -104,10 +98,6 @@ impl<S: SymOps + 'static> Inode for ProcSym<S> {
 
     fn write_link(&self, _target: &str) -> Result<()> {
         Err(Error::new(Errno::EPERM))
-    }
-
-    fn is_dentry_cacheable(&self) -> bool {
-        !self.common.is_volatile()
     }
 }
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -19,7 +19,10 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
-            inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            inode::{
+                Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy,
+                SymbolicLink,
+            },
         },
     },
     prelude::*,
@@ -614,7 +617,15 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
-    default fn is_dentry_cacheable(&self) -> bool {
+    default fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::empty()
+    }
+
+    default fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        true
+    }
+
+    default fn revalidate_absent(&self, _name: &str) -> bool {
         true
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -233,6 +233,67 @@ impl MknodType {
     }
 }
 
+bitflags! {
+    /// Policy that controls when the VFS revalidates cached inode entries.
+    ///
+    /// # Why revalidation is needed
+    ///
+    /// Normally, inode creation and deletion go through VFS operations such as
+    /// `create`, `unlink`, `mkdir`, and `rmdir`. This lets the VFS keep its
+    /// dentry cache consistent with the underlying filesystem.
+    ///
+    /// However, some filesystems create or delete inodes without going through
+    /// the VFS. For example, procfs entries under `/proc` appear and disappear
+    /// as processes are forked and reaped. Networked filesystems may also be
+    /// modified by remote peers. For such filesystems, the VFS must revalidate
+    /// cached entries by asking the parent directory whether a cached child is
+    /// still valid.
+    ///
+    /// # Revalidation protocol
+    ///
+    /// A directory inode declares its policy through
+    /// [`Inode::revalidation_policy`].
+    ///
+    /// - [`REVALIDATE_EXISTS`](Self::REVALIDATE_EXISTS) makes the VFS call
+    ///   [`Inode::revalidate_exists`] on positive cache hits. If it returns
+    ///   `false`, the cached entry is dropped and the lookup is retried.
+    /// - [`REVALIDATE_ABSENT`](Self::REVALIDATE_ABSENT) makes the VFS call
+    ///   [`Inode::revalidate_absent`] on negative cache hits. If it returns
+    ///   `false`, the cached entry is dropped and the lookup is retried.
+    ///
+    /// If neither flag is set, cached entries are trusted unconditionally. The
+    /// policy must be fixed for each inode. Non-directory inodes should return
+    /// an empty policy.
+    ///
+    /// # Performance
+    ///
+    /// The revalidation callbacks run on every matching cache hit, so
+    /// filesystems should keep them cheap.
+    pub struct RevalidationPolicy: u8 {
+        /// Revalidate positive cache entries (cached child inodes).
+        ///
+        /// Set this when the directory may spontaneously
+        /// _lose_ children without going through VFS `unlink`/`rmdir`.
+        /// For example, procfs sets this on `/proc`
+        /// because PID directories disappear when processes exit.
+        ///
+        /// When set, every positive cache hit calls
+        /// [`Inode::revalidate_exists`] on the parent directory.
+        const REVALIDATE_EXISTS = 1 << 0;
+
+        /// Revalidate negative cache entries (names known to be absent).
+        ///
+        /// Set this when the directory may spontaneously _gain_ children
+        /// without going through VFS `create`/`mkdir`/`link`.
+        /// For example, procfs sets this on `/proc`
+        /// because PID directories appear when processes are forked.
+        ///
+        /// When set, every negative cache hit calls
+        /// [`Inode::revalidate_absent`] on the parent directory.
+        const REVALIDATE_ABSENT = 1 << 1;
+    }
+}
+
 /// I/O operations in an [`Inode`].
 ///
 /// This abstracts the common I/O operations used by both [`Inode`] (for regular files) and
@@ -358,24 +419,47 @@ pub trait Inode: Any + InodeIo + Send + Sync {
 
     fn fs(&self) -> Arc<dyn FileSystem>;
 
-    /// Returns whether a VFS dentry for this inode should be put into the dentry cache.
+    /// Returns the revalidation policy for cached children of this directory.
     ///
-    /// The dentry cache in the VFS layer can accelerate the lookup of inodes. So usually,
-    /// it is preferable to use the dentry cache. And thus, the default return value of this method
-    /// is `true`.
+    /// See [`RevalidationPolicy`] for the full protocol description.
     ///
-    /// But this caching can raise consistency issues in certain use cases. Specifically, the dentry
-    /// cache works on the assumption that all FS operations go through the dentry layer first.
-    /// This is why the dentry cache can reflect the up-to-date FS state. Yet, this assumption
-    /// may be broken. If the inodes of a file system may "disappear" without unlinking through the
-    /// VFS layer, then their dentries should not be cached. For example, an inode in procfs
-    /// (say, `/proc/1/fd/2`) can "disappear" without notice from the perspective of the dentry cache.
-    /// So for such inodes, they are incompatible with the dentry cache. And this method returns `false`.
+    /// Default: empty (no revalidation).
+    /// Correct for filesystems where all mutations go through the VFS.
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::empty()
+    }
+
+    /// Checks whether a cached child inode still exists under this directory.
     ///
-    /// Note that if any ancestor directory of an inode has this method returns `false`, then
-    /// this inode would not be cached by the dentry cache, even when the method of this
-    /// inode returns `true`.
-    fn is_dentry_cacheable(&self) -> bool {
+    /// Called on a positive cache hit
+    /// when [`RevalidationPolicy::REVALIDATE_EXISTS`] is set.
+    /// Returns `true` if `child` is still a valid child named `name`;
+    /// `false` if the entry should be dropped and the lookup retried.
+    ///
+    /// See [`RevalidationPolicy`] for the full protocol description.
+    ///
+    /// # Precondition
+    ///
+    /// Only called when `self.revalidation_policy()` includes `REVALIDATE_EXISTS`.
+    /// Otherwise, the return value is considered garbage.
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        true
+    }
+
+    /// Checks whether a name is still absent under this directory.
+    ///
+    /// Called on a negative cache hit
+    /// when [`RevalidationPolicy::REVALIDATE_ABSENT`] is set.
+    /// Returns `true` if `name` is still absent;
+    /// `false` if a child may now exist and the lookup should be retried.
+    ///
+    /// See [`RevalidationPolicy`] for the full protocol description.
+    ///
+    /// # Precondition
+    ///
+    /// Only called when `self.revalidation_policy()` includes `REVALIDATE_ABSENT`.
+    /// Otherwise, the return value is considered garbage.
+    fn revalidate_absent(&self, _name: &str) -> bool {
         true
     }
 

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -2,7 +2,7 @@
 
 use core::{
     ops::Deref,
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
 use hashbrown::HashMap;
@@ -14,7 +14,7 @@ use crate::{
         self,
         file::{InodeMode, InodeType},
         vfs::{
-            inode::{Inode, MknodType},
+            inode::{Inode, MknodType, RevalidationPolicy},
             inode_ext::InodeExt,
         },
     },
@@ -26,10 +26,16 @@ pub(in crate::fs) struct Dentry {
     inode: Arc<dyn Inode>,
     type_: InodeType,
     name_and_parent: NameAndParent,
-    children: Option<RwMutex<DentryChildren>>,
+    dir_state: Option<DentryDirState>,
     flags: AtomicU32,
     mount_count: AtomicU32,
     this: Weak<Dentry>,
+}
+
+/// Per-directory cache state.
+struct DentryDirState {
+    children: RwMutex<DentryChildren>,
+    revalidation_policy: RevalidationPolicy,
 }
 
 /// The name and parent of a `Dentry`.
@@ -107,14 +113,18 @@ impl Dentry {
             DentryOptions::Pseudo(name_fn) => NameAndParent::Pseudo(name_fn),
         };
 
-        let children =
-            matches!(inode.type_(), InodeType::Dir).then(|| RwMutex::new(DentryChildren::new()));
+        let type_ = inode.type_();
+        let is_dir = type_ == InodeType::Dir;
+        let dir_state = is_dir.then(|| DentryDirState {
+            children: RwMutex::new(DentryChildren::new()),
+            revalidation_policy: inode.revalidation_policy(),
+        });
 
         Arc::new_cyclic(|weak_self| Self {
-            type_: inode.type_(),
+            type_,
             inode,
             name_and_parent,
-            children,
+            dir_state,
             flags: AtomicU32::new(DentryFlags::empty().bits()),
             mount_count: AtomicU32::new(0),
             this: weak_self.clone(),
@@ -156,12 +166,6 @@ impl Dentry {
     /// Gets the inner inode.
     pub(super) fn inode(&self) -> &Arc<dyn Inode> {
         &self.inode
-    }
-
-    /// Returns whether the dentry can be cached.
-    fn is_dentry_cacheable(&self) -> bool {
-        // Should we store it as a dentry flag?
-        self.inode.is_dentry_cacheable()
     }
 
     fn flags(&self) -> DentryFlags {
@@ -228,9 +232,9 @@ impl Dentry {
     }
 
     pub(super) fn as_dir_dentry_or_err(&self) -> Result<DirDentry<'_>> {
-        debug_assert_eq!(self.children.is_some(), self.type_ == InodeType::Dir);
+        debug_assert_eq!(self.dir_state.is_some(), self.type_ == InodeType::Dir);
 
-        let Some(children) = &self.children else {
+        let Some(dir_state) = &self.dir_state else {
             return_errno_with_message!(
                 Errno::ENOTDIR,
                 "the dentry is not related to a directory inode"
@@ -239,7 +243,8 @@ impl Dentry {
 
         Ok(DirDentry {
             inner: self,
-            children,
+            children: &dir_state.children,
+            revalidation_policy: dir_state.revalidation_policy,
         })
     }
 }
@@ -248,6 +253,7 @@ impl Dentry {
 pub(super) struct DirDentry<'a> {
     inner: &'a Dentry,
     children: &'a RwMutex<DentryChildren>,
+    revalidation_policy: RevalidationPolicy,
 }
 
 impl Deref for DirDentry<'_> {
@@ -267,39 +273,86 @@ impl DirDentry<'_> {
         mode: InodeMode,
     ) -> Result<Arc<Dentry>> {
         let children = self.children.upread();
-        if children.contains_valid(name) {
-            return_errno!(Errno::EEXIST);
+        if let Some(entry) = children.find(name)
+            && entry.is_positive()
+        {
+            if self.revalidate_cached_entry(name, &entry) {
+                return_errno_with_message!(Errno::EEXIST, "the dentry already exists");
+            }
+
+            let mut children = children.upgrade();
+            let _ = children.remove(name);
+            let new_inode = self.inode.create(name, type_, mode)?;
+
+            return Ok(self.insert_created_child(&mut children, name, new_inode));
         }
 
         let new_inode = self.inode.create(name, type_, mode)?;
-        let name = String::from(name);
-        let new_child = Dentry::new(new_inode, DentryOptions::Leaf((name.clone(), self.this())));
+        let mut children = children.upgrade();
 
-        if new_child.is_dentry_cacheable() {
-            children.upgrade().insert(name, new_child.clone());
+        Ok(self.insert_created_child(&mut children, name, new_inode))
+    }
+
+    fn insert_created_child(
+        &self,
+        children: &mut DentryChildren,
+        name: &str,
+        inode: Arc<dyn Inode>,
+    ) -> Arc<Dentry> {
+        let name = String::from(name);
+        let new_child = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
+
+        children.insert_positive(name, new_child.clone());
+
+        new_child
+    }
+
+    /// Looks up `name` relative to this dentry.
+    ///
+    /// On a cache miss, this method instantiates the child through the file
+    /// system and inserts it into the cache before returning the resulting
+    /// child dentry.
+    ///
+    /// This method does not interpret `"."` or `".."`, does not check search
+    /// permission, and does not resolve overmounted children. Callers that need
+    /// full path-component semantics should use
+    /// [`super::PathResolver::lookup_at_path`].
+    pub(in crate::fs) fn lookup_child(&self, name: &str) -> Result<Arc<Dentry>> {
+        debug_assert!(!is_dot_or_dotdot(name));
+
+        let mut children = self.children.upread();
+
+        // Looks up via the dentry cache.
+        if let Some(cached_entry) = children.find(name) {
+            if self.revalidate_cached_entry(name, &cached_entry) {
+                return match cached_entry {
+                    CachedDentry::Positive { dentry } => Ok(dentry),
+                    CachedDentry::Negative => {
+                        return_errno_with_message!(Errno::ENOENT, "found a negative dentry")
+                    }
+                };
+            }
+
+            let mut children_for_update = children.upgrade();
+            let _ = children_for_update.remove(name);
+            children = children_for_update.downgrade();
         }
 
-        Ok(new_child)
-    }
+        // Looks up via the file system.
 
-    /// Lookups a target `Dentry` from the cache in children.
-    pub(super) fn lookup_via_cache(&self, name: &str) -> Result<Option<Arc<Dentry>>> {
-        let children = self.children.read();
-        children.find(name)
-    }
+        let inode = match self.inode.lookup(name) {
+            Ok(inode) => inode,
+            Err(error) if error.error() == Errno::ENOENT => {
+                children.upgrade().insert_negative(name.to_string());
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
 
-    /// Lookups a target `Dentry` from the file system.
-    pub(super) fn lookup_via_fs(&self, name: &str) -> Result<Arc<Dentry>> {
-        let children = self.children.upread();
-
-        // TODO: Add a right implementation to cache negative dentry.
-        let inode = self.inode.lookup(name)?;
         let name = String::from(name);
+        // TODO: Use a better storage strategy to avoid extra string allocations.
         let target = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
-
-        if target.is_dentry_cacheable() {
-            children.upgrade().insert(name, target.clone());
-        }
+        children.upgrade().insert_positive(name, target.clone());
 
         Ok(target)
     }
@@ -312,7 +365,7 @@ impl DirDentry<'_> {
         type_: MknodType,
     ) -> Result<Arc<Dentry>> {
         let children = self.children.upread();
-        if children.contains_valid(name) {
+        if children.contains_positive(name) {
             return_errno!(Errno::EEXIST);
         }
 
@@ -320,9 +373,7 @@ impl DirDentry<'_> {
         let name = String::from(name);
         let new_child = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
 
-        if new_child.is_dentry_cacheable() {
-            children.upgrade().insert(name, new_child.clone());
-        }
+        children.upgrade().insert_positive(name, new_child.clone());
 
         Ok(new_child)
     }
@@ -330,7 +381,7 @@ impl DirDentry<'_> {
     /// Links a new `Dentry` by `link()` the old inode.
     pub(super) fn link(&self, old_inode: &Arc<dyn Inode>, name: &str) -> Result<()> {
         let children = self.children.upread();
-        if children.contains_valid(name) {
+        if children.contains_positive(name) {
             return_errno!(Errno::EEXIST);
         }
 
@@ -341,9 +392,9 @@ impl DirDentry<'_> {
             DentryOptions::Leaf((name.clone(), self.this())),
         );
 
-        if dentry.is_dentry_cacheable() {
-            children.upgrade().insert(name.clone(), dentry.clone());
-        }
+        children
+            .upgrade()
+            .insert_positive(name.clone(), dentry.clone());
         fs::vfs::notify::on_link(dentry.parent().unwrap().inode(), dentry.inode(), || name);
         Ok(())
     }
@@ -354,28 +405,8 @@ impl DirDentry<'_> {
             return_errno_with_message!(Errno::EINVAL, "unlink on . or ..");
         }
 
-        let children = self.children.upread();
-        children.check_mountpoint(name)?;
-
-        let mut children = children.upgrade();
-        let dir_inode = &self.inode;
-
-        let child_inode = if let Some(cached_dentry) = children.entry(name)? {
-            let child_inode = cached_dentry.inode().clone();
-
-            dir_inode.unlink(name)?;
-            children.delete(name);
-
-            child_inode
-        } else {
-            // Cache miss: need to lookup from the underlying filesystem
-            let child_inode = dir_inode.lookup(name)?;
-            dir_inode.unlink(name)?;
-
-            child_inode
-        };
-
-        drop(children);
+        let dir_inode = self.inode();
+        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.unlink(name))?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
@@ -407,28 +438,8 @@ impl DirDentry<'_> {
             return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..");
         }
 
-        let children = self.children.upread();
-        children.check_mountpoint(name)?;
-
-        let mut children = children.upgrade();
-        let dir_inode = &self.inode;
-
-        let child_inode = if let Some(cached_dentry) = children.entry(name)? {
-            let child_inode = cached_dentry.inode().clone();
-
-            dir_inode.rmdir(name)?;
-            children.delete(name);
-
-            child_inode
-        } else {
-            // Cache miss: need to lookup from the underlying filesystem
-            let child_inode = dir_inode.lookup(name)?;
-            dir_inode.rmdir(name)?;
-
-            child_inode
-        };
-
-        drop(children);
+        let dir_inode = self.inode();
+        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.rmdir(name))?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         if nlinks == 0 {
@@ -448,6 +459,47 @@ impl DirDentry<'_> {
                 .remove_subscribers(removed_nr_subscribers);
         }
         Ok(())
+    }
+
+    fn remove_child(
+        &self,
+        name: &str,
+        remove_child_fn: impl FnOnce(&dyn Inode, &str) -> Result<()>,
+    ) -> Result<Arc<dyn Inode>> {
+        let dir_inode = self.inode();
+        let mut children = self.children.upread();
+        let cached_child = match children.find(name) {
+            None => None,
+            Some(cached_entry) if !self.revalidate_cached_entry(name, &cached_entry) => {
+                let mut children_for_update = children.upgrade();
+                let _ = children_for_update.remove(name);
+                children = children_for_update.downgrade();
+                None
+            }
+            Some(cached_entry) => {
+                if cached_entry.is_mountpoint() {
+                    return_errno_with_message!(Errno::EBUSY, "dentry is mountpoint");
+                }
+
+                match cached_entry {
+                    CachedDentry::Positive { dentry } => Some(dentry),
+                    CachedDentry::Negative => {
+                        return_errno_with_message!(Errno::ENOENT, "found a negative dentry")
+                    }
+                }
+            }
+        };
+
+        let child_inode = match &cached_child {
+            Some(child) => child.inode().clone(),
+            None => dir_inode.lookup(name)?,
+        };
+
+        remove_child_fn(dir_inode.as_ref(), name)?;
+        if cached_child.is_some() {
+            children.upgrade().delete(name);
+        }
+        Ok(child_inode)
     }
 
     /// Renames a `Dentry` to the new `Dentry` by `rename()` the inner inode.
@@ -473,13 +525,12 @@ impl DirDentry<'_> {
                 return Ok(());
             }
 
-            let children = old_dir.children.upread();
-            let old_dentry = children.check_mountpoint_then_find(old_name)?;
+            let mut children = old_dir.children.write();
             children.check_mountpoint(new_name)?;
+            let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
 
             old_dir_inode.rename(old_name, old_dir_inode, new_name)?;
 
-            let mut children = children.upgrade();
             match old_dentry.as_ref() {
                 Some(dentry) => {
                     children.delete(old_name);
@@ -487,19 +538,17 @@ impl DirDentry<'_> {
                         .name_and_parent
                         .set(new_name, old_dir_arc.clone())
                         .unwrap();
-                    if dentry.is_dentry_cacheable() {
-                        children.insert(String::from(new_name), dentry.clone());
-                    }
+                    children.insert_positive(String::from(new_name), dentry.clone());
                 }
                 None => {
-                    children.delete(new_name);
+                    children.remove(new_name);
                 }
             }
         } else {
             // The two are different dentries
             let (mut self_children, mut new_dir_children) =
                 write_lock_children_on_two_dentries(&old_dir, &new_dir);
-            let old_dentry = self_children.check_mountpoint_then_find(old_name)?;
+            let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
             new_dir_children.check_mountpoint(new_name)?;
 
             old_dir_inode.rename(old_name, new_dir_inode, new_name)?;
@@ -510,27 +559,55 @@ impl DirDentry<'_> {
                         .name_and_parent
                         .set(new_name, new_dir_arc.clone())
                         .unwrap();
-                    if dentry.is_dentry_cacheable() {
-                        new_dir_children.insert(String::from(new_name), dentry.clone());
-                    }
+                    new_dir_children.insert_positive(String::from(new_name), dentry.clone());
                 }
                 None => {
-                    new_dir_children.delete(new_name);
+                    new_dir_children.remove(new_name);
                 }
             }
         }
         Ok(())
     }
+
+    /// Revalidates a cached entry.
+    ///
+    /// Returns `true` if the cached entry is still valid, or `false` if it should be invalidated.
+    fn revalidate_cached_entry(&self, name: &str, cached_entry: &CachedDentry) -> bool {
+        let policy = self.revalidation_policy;
+        if policy.is_empty() {
+            return true;
+        }
+
+        if policy.contains(RevalidationPolicy::REVALIDATE_EXISTS)
+            && let CachedDentry::Positive { dentry } = cached_entry
+        {
+            return self.inode.revalidate_exists(name, dentry.inode().as_ref());
+        }
+
+        if policy.contains(RevalidationPolicy::REVALIDATE_ABSENT)
+            && let CachedDentry::Negative = cached_entry
+        {
+            return self.inode.revalidate_absent(name);
+        }
+
+        true
+    }
 }
 
 impl Debug for Dentry {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Dentry")
+        let mut debug = f.debug_struct("Dentry");
+        debug
             .field("inode", &self.inode)
             .field("type_", &self.type_)
             .field("flags", &self.flags)
-            .field("mount_count", &self.mount_count)
-            .finish_non_exhaustive()
+            .field("mount_count", &self.mount_count);
+        if let Some(dir_state) = &self.dir_state {
+            debug
+                .field("children", &*dir_state.children.read())
+                .field("revalidation_policy", &dir_state.revalidation_policy);
+        }
+        debug.finish_non_exhaustive()
     }
 }
 
@@ -570,100 +647,193 @@ enum DentryOptions {
     Pseudo(fn(&dyn Inode) -> String),
 }
 
-/// Manages child dentries, including both valid and negative entries.
+/// Manages child dentries in the per-directory cache.
 ///
 /// A _negative_ dentry reflects a failed filename lookup, saving potential
 /// repeated and costly lookups in the future.
+//
+// TODO: Implement a global reclamation mechanism for `DentryCache` to avoid unbounded growth
+// of cached dentries.
+#[derive(Debug)]
+struct DentryChildren {
+    entries: HashMap<String, CachedDentry>,
+}
+
+#[derive(Clone, Debug)]
+enum CachedDentry {
+    Positive { dentry: Arc<Dentry> },
+    Negative,
+}
+
+impl CachedDentry {
+    fn new_positive(dentry: Arc<Dentry>) -> Self {
+        Self::Positive { dentry }
+    }
+
+    fn new_negative() -> Self {
+        Self::Negative
+    }
+
+    fn into_dentry(self) -> Option<Arc<Dentry>> {
+        match self {
+            Self::Positive { dentry } => Some(dentry),
+            Self::Negative => None,
+        }
+    }
+
+    fn is_mountpoint(&self) -> bool {
+        match self {
+            Self::Positive { dentry } => dentry.is_mountpoint(),
+            Self::Negative => false,
+        }
+    }
+
+    fn is_positive(&self) -> bool {
+        matches!(self, Self::Positive { .. })
+    }
+}
+
 // TODO: Address the issue of negative dentry bloating. See the reference
 // https://lwn.net/Articles/894098/ for more details.
-struct DentryChildren {
-    dentries: HashMap<String, Option<Arc<Dentry>>>,
-}
+#[cfg(debug_assertions)]
+const NEGATIVE_ENTRY_LIMIT: usize = 10000;
+#[cfg(debug_assertions)]
+static NEGATIVE_ENTRY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl DentryChildren {
     /// Creates an empty dentry cache.
     fn new() -> Self {
         Self {
-            dentries: HashMap::new(),
+            entries: HashMap::new(),
         }
     }
 
-    /// Checks if a valid dentry with the given name exists.
-    fn contains_valid(&self, name: &str) -> bool {
-        self.dentries.get(name).is_some_and(|child| child.is_some())
+    /// Finds a cached dentry by name.
+    fn find(&self, name: &str) -> Option<CachedDentry> {
+        self.entries.get(name).cloned()
     }
 
-    /// Checks if a negative dentry with the given name exists.
-    #[expect(dead_code)]
-    fn contains_negative(&self, name: &str) -> bool {
-        self.dentries.get(name).is_some_and(|child| child.is_none())
+    /// Checks if a positive dentry with the given name exists.
+    fn contains_positive(&self, name: &str) -> bool {
+        self.entries
+            .get(name)
+            .is_some_and(|child| child.is_positive())
     }
 
-    /// Finds a dentry by name. Returns error for negative entries.
-    fn find(&self, name: &str) -> Result<Option<Arc<Dentry>>> {
-        match self.dentries.get(name) {
-            Some(Some(child)) => Ok(Some(child.clone())),
-            Some(None) => return_errno_with_message!(Errno::ENOENT, "found a negative dentry"),
-            None => Ok(None),
+    /// Inserts a positive dentry.
+    fn insert_positive(&mut self, name: String, dentry: Arc<Dentry>) {
+        let prev = self
+            .entries
+            .insert(name, CachedDentry::new_positive(dentry));
+
+        #[cfg(debug_assertions)]
+        if matches!(prev, Some(CachedDentry::Negative)) {
+            NEGATIVE_ENTRY_COUNTER.fetch_sub(1, Ordering::Relaxed);
         }
-    }
-
-    /// Inserts a valid cacheable dentry.
-    fn insert(&mut self, name: String, dentry: Arc<Dentry>) {
-        // Assume the caller has checked that the dentry is cacheable
-        // and will be newly created if looked up from the parent.
-        debug_assert!(dentry.is_dentry_cacheable());
-        let _ = self.dentries.insert(name, Some(dentry));
     }
 
     /// Inserts a negative dentry.
-    #[expect(dead_code)]
-    fn insert_negative(&mut self, name: String) {
-        let _ = self.dentries.insert(name, None);
-    }
-
-    /// Deletes a dentry by name, turning it into a negative entry if exists.
-    fn delete(&mut self, name: &str) -> Option<Arc<Dentry>> {
-        self.dentries.get_mut(name).and_then(Option::take)
-    }
-
-    /// Probes the corresponding cache entry by name.
     ///
-    /// Returns:
-    /// - `Ok(Some(entry))` for a valid dentry,
-    /// - `Ok(None)` for cache miss,
-    /// - `Err(ENOENT)` for a negative dentry.
-    fn entry(&self, name: &str) -> Result<Option<Arc<Dentry>>> {
-        match self.dentries.get(name) {
-            Some(Some(dentry)) => Ok(Some(dentry.clone())),
-            Some(None) => return_errno_with_message!(Errno::ENOENT, "found a negative dentry"),
-            None => Ok(None),
+    /// This operation should not overwrite an existing entry.
+    fn insert_negative(&mut self, name: String) {
+        let prev = self.entries.insert(name, CachedDentry::new_negative());
+        debug_assert!(
+            prev.is_none(),
+            "insert_negative overwrote an existing entry",
+        );
+
+        #[cfg(debug_assertions)]
+        {
+            let new_count = NEGATIVE_ENTRY_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+            if new_count > NEGATIVE_ENTRY_LIMIT as u64 {
+                warn!("number of negative dentries has reached {}", new_count);
+            }
         }
+    }
+
+    /// Deletes a positive dentry by name, turning it into a negative entry if exists.
+    fn delete(&mut self, name: &str) {
+        let Some((_, exist_entry)) = self.entries.get_key_value_mut(name) else {
+            return;
+        };
+        if exist_entry.is_positive() {
+            #[cfg(debug_assertions)]
+            {
+                let new_count = NEGATIVE_ENTRY_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+                if new_count > NEGATIVE_ENTRY_LIMIT as u64 {
+                    warn!("number of negative dentries has reached {}", new_count);
+                }
+            }
+            *exist_entry = CachedDentry::new_negative()
+        }
+    }
+
+    /// Removes a dentry by name without installing a negative cache entry.
+    fn remove(&mut self, name: &str) -> Option<Arc<Dentry>> {
+        let removed_entry = self.entries.remove(name);
+        #[cfg(debug_assertions)]
+        if matches!(removed_entry, Some(CachedDentry::Negative)) {
+            NEGATIVE_ENTRY_COUNTER.fetch_sub(1, Ordering::Relaxed);
+        }
+
+        removed_entry.and_then(CachedDentry::into_dentry)
     }
 
     /// Checks whether the dentry is a mount point. Returns an error if it is.
     fn check_mountpoint(&self, name: &str) -> Result<()> {
-        if let Some(Some(dentry)) = self.dentries.get(name)
-            && dentry.is_mountpoint()
+        if let Some(entry) = self.entries.get(name)
+            && entry.is_mountpoint()
         {
-            return_errno_with_message!(Errno::EBUSY, "dentry is mountpint");
+            return_errno_with_message!(Errno::EBUSY, "dentry is mountpoint");
         }
 
         Ok(())
     }
 
-    /// Checks if dentry is a mount point, then retrieves it.
-    fn check_mountpoint_then_find(&self, name: &str) -> Result<Option<Arc<Dentry>>> {
-        match self.dentries.get(name) {
-            Some(Some(dentry)) => {
-                if dentry.is_mountpoint() {
-                    return_errno_with_message!(Errno::EBUSY, "dentry is mountpoint");
-                }
-                Ok(Some(dentry.clone()))
-            }
-            Some(None) => return_errno_with_message!(Errno::ENOENT, "found a negative dentry"),
-            None => Ok(None),
+    /// Probes a cached child `Dentry` before a rename operation.
+    ///
+    /// Returns:
+    /// - `Ok(Some(entry))` for a valid positive dentry,
+    /// - `Ok(None)` for a cache miss or a stale entry,
+    /// - `Err(ENOENT)` for a valid negative dentry,
+    /// - `Err(EBUSY)` for a dentry that is a mountpoint.
+    fn probe_cached_child_for_rename(
+        &mut self,
+        dir: &DirDentry<'_>,
+        name: &str,
+    ) -> Result<Option<Arc<Dentry>>> {
+        let Some(cached_entry) = self.find(name) else {
+            return Ok(None);
+        };
+
+        if !dir.revalidate_cached_entry(name, &cached_entry) {
+            let _ = self.remove(name);
+            return Ok(None);
         }
+
+        if cached_entry.is_mountpoint() {
+            return_errno_with_message!(Errno::EBUSY, "dentry is mountpoint");
+        }
+
+        match cached_entry {
+            CachedDentry::Positive { dentry } => Ok(Some(dentry)),
+            CachedDentry::Negative => {
+                return_errno_with_message!(Errno::ENOENT, "found a negative dentry")
+            }
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for DentryChildren {
+    fn drop(&mut self) {
+        let negative_count = self
+            .entries
+            .values()
+            .filter(|entry| matches!(entry, CachedDentry::Negative))
+            .count();
+
+        NEGATIVE_ENTRY_COUNTER.fetch_sub(negative_count as u64, Ordering::Relaxed);
     }
 }
 
@@ -676,13 +846,19 @@ fn write_lock_children_on_two_dentries<'a>(
 ) {
     let this_key = this.key();
     let other_key = other.key();
-    if this_key < other_key {
-        let this = this.children.write();
-        let other = other.children.write();
-        (this, other)
-    } else {
-        let other = other.children.write();
-        let this = this.children.write();
-        (this, other)
+    match this_key.cmp(&other_key) {
+        core::cmp::Ordering::Less => {
+            let this = this.children.write();
+            let other = other.children.write();
+            (this, other)
+        }
+        core::cmp::Ordering::Greater => {
+            let other = other.children.write();
+            let this = this.children.write();
+            (this, other)
+        }
+        core::cmp::Ordering::Equal => {
+            unreachable!("two distinct DirDentry's with identical DentryKey")
+        }
     }
 }

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -284,27 +284,65 @@ impl DirDentry<'_> {
             let _ = children.remove(name);
             let new_inode = self.inode.create(name, type_, mode)?;
 
-            return Ok(self.insert_created_child(&mut children, name, new_inode));
+            let new_child = Dentry::new(
+                new_inode,
+                DentryOptions::Leaf((String::from(name), self.this())),
+            );
+            return Ok(self.insert_positive_child(&mut children, name, new_child));
         }
 
         let new_inode = self.inode.create(name, type_, mode)?;
         let mut children = children.upgrade();
+        let new_child = Dentry::new(
+            new_inode,
+            DentryOptions::Leaf((String::from(name), self.this())),
+        );
 
-        Ok(self.insert_created_child(&mut children, name, new_inode))
+        Ok(self.insert_positive_child(&mut children, name, new_child))
     }
 
-    fn insert_created_child(
+    /// Inserts a positive child dentry into the directory cache.
+    fn insert_positive_child(
         &self,
         children: &mut DentryChildren,
         name: &str,
-        inode: Arc<dyn Inode>,
+        child: Arc<Dentry>,
     ) -> Arc<Dentry> {
-        let name = String::from(name);
-        let new_child = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
+        // TODO: Use a better storage strategy to avoid extra string allocations.
+        children.insert_positive(String::from(name), child.clone());
+        self.revalidate_positive_children_if_needed(children);
 
-        children.insert_positive(name, new_child.clone());
+        child
+    }
 
-        new_child
+    /// Periodically revalidates cached positive children in this directory.
+    //
+    // TODO: This is a workaround to keep large `DentryChildren` caches from retaining stale
+    // positive entries for too long when the directory asks the VFS to revalidate
+    // existing children.
+    fn revalidate_positive_children_if_needed(&self, children: &mut DentryChildren) {
+        const POSITIVE_CHILD_REVALIDATION_INTERVAL: usize = 1024;
+        const POSITIVE_CHILD_REVALIDATION_CACHE_SIZE_THRESHOLD: usize = 1024;
+
+        if !self
+            .revalidation_policy
+            .contains(RevalidationPolicy::REVALIDATE_EXISTS)
+        {
+            return;
+        }
+
+        // Workaround: until `DentryCache` has a proper reclamation mechanism, periodically
+        // scan large caches and evict positive entries that fail `revalidate_exists`.
+        children.insert_count = children.insert_count.wrapping_add(1);
+        if !children
+            .insert_count
+            .is_multiple_of(POSITIVE_CHILD_REVALIDATION_INTERVAL)
+            || children.entries.len() <= POSITIVE_CHILD_REVALIDATION_CACHE_SIZE_THRESHOLD
+        {
+            return;
+        }
+
+        children.revalidate_positive_entries(self);
     }
 
     /// Looks up `name` relative to this dentry.
@@ -349,12 +387,13 @@ impl DirDentry<'_> {
             Err(error) => return Err(error),
         };
 
-        let name = String::from(name);
-        // TODO: Use a better storage strategy to avoid extra string allocations.
-        let target = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
-        children.upgrade().insert_positive(name, target.clone());
+        let target = Dentry::new(
+            inode,
+            DentryOptions::Leaf((String::from(name), self.this())),
+        );
+        let mut children = children.upgrade();
 
-        Ok(target)
+        Ok(self.insert_positive_child(&mut children, name, target))
     }
 
     /// Creates a `Dentry` by making an inode of the `type_` with the `mode`.
@@ -370,12 +409,13 @@ impl DirDentry<'_> {
         }
 
         let inode = self.inode.mknod(name, mode, type_)?;
-        let name = String::from(name);
-        let new_child = Dentry::new(inode, DentryOptions::Leaf((name.clone(), self.this())));
+        let new_child = Dentry::new(
+            inode,
+            DentryOptions::Leaf((String::from(name), self.this())),
+        );
+        let mut children = children.upgrade();
 
-        children.upgrade().insert_positive(name, new_child.clone());
-
-        Ok(new_child)
+        Ok(self.insert_positive_child(&mut children, name, new_child))
     }
 
     /// Links a new `Dentry` by `link()` the old inode.
@@ -386,16 +426,15 @@ impl DirDentry<'_> {
         }
 
         self.inode.link(old_inode, name)?;
-        let name = String::from(name);
         let dentry = Dentry::new(
             old_inode.clone(),
-            DentryOptions::Leaf((name.clone(), self.this())),
+            DentryOptions::Leaf((String::from(name), self.this())),
         );
-
-        children
-            .upgrade()
-            .insert_positive(name.clone(), dentry.clone());
-        fs::vfs::notify::on_link(dentry.parent().unwrap().inode(), dentry.inode(), || name);
+        let mut children = children.upgrade();
+        self.insert_positive_child(&mut children, name, dentry.clone());
+        fs::vfs::notify::on_link(dentry.parent().unwrap().inode(), dentry.inode(), || {
+            name.to_string()
+        });
         Ok(())
     }
 
@@ -538,7 +577,7 @@ impl DirDentry<'_> {
                         .name_and_parent
                         .set(new_name, old_dir_arc.clone())
                         .unwrap();
-                    children.insert_positive(String::from(new_name), dentry.clone());
+                    old_dir.insert_positive_child(&mut children, new_name, dentry.clone());
                 }
                 None => {
                     children.remove(new_name);
@@ -559,7 +598,7 @@ impl DirDentry<'_> {
                         .name_and_parent
                         .set(new_name, new_dir_arc.clone())
                         .unwrap();
-                    new_dir_children.insert_positive(String::from(new_name), dentry.clone());
+                    new_dir.insert_positive_child(&mut new_dir_children, new_name, dentry.clone());
                 }
                 None => {
                     new_dir_children.remove(new_name);
@@ -657,6 +696,7 @@ enum DentryOptions {
 #[derive(Debug)]
 struct DentryChildren {
     entries: HashMap<String, CachedDentry>,
+    insert_count: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -705,6 +745,7 @@ impl DentryChildren {
     fn new() -> Self {
         Self {
             entries: HashMap::new(),
+            insert_count: 0,
         }
     }
 
@@ -821,6 +862,16 @@ impl DentryChildren {
                 return_errno_with_message!(Errno::ENOENT, "found a negative dentry")
             }
         }
+    }
+
+    fn revalidate_positive_entries(&mut self, dir: &DirDentry<'_>) {
+        self.entries
+            .retain(|name, cached_entry| match cached_entry {
+                CachedDentry::Positive { dentry } => {
+                    dir.inode.revalidate_exists(name, dentry.inode().as_ref())
+                }
+                CachedDentry::Negative => true,
+            });
     }
 }
 

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -431,14 +431,8 @@ impl PathResolver {
         } else if super::is_dotdot(name) {
             self.resolve_parent(path).unwrap_or_else(|| path.this())
         } else {
-            let target_inner_opt = dir_dentry.lookup_via_cache(name)?;
-            match target_inner_opt {
-                Some(target_inner) => Path::new(path.mount.clone(), target_inner),
-                None => {
-                    let target_inner = dir_dentry.lookup_via_fs(name)?;
-                    Path::new(path.mount.clone(), target_inner)
-                }
-            }
+            let target_dentry = dir_dentry.lookup_child(name)?;
+            Path::new(path.mount.clone(), target_dentry)
         };
 
         Ok(target_path.get_top_path())

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -449,6 +449,9 @@ fn clone_child_task(
             )
         })?;
 
+    let child_thread = child_task.as_thread().unwrap();
+    pid_table::pid_table_mut().insert_thread(child_tid, child_thread);
+
     Ok(child_task)
 }
 

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -263,7 +263,7 @@ fn make_current_main_thread(ctx: &Context) {
     assert_eq!(tasks.as_slice().len(), 2);
     assert!(core::ptr::eq(ctx.task, tasks.as_slice()[1].as_ref()));
 
-    tasks.swap_main(pid, old_tid);
+    tasks.swap_main();
     ctx.posix_thread.set_main(pid);
 
     if let Some(tracer_tracees) = tracer_tracees.as_mut()

--- a/kernel/src/process/pid_table.rs
+++ b/kernel/src/process/pid_table.rs
@@ -11,7 +11,6 @@ use alloc::collections::btree_map::Entry;
 
 use super::{Pgid, Pid, Process, ProcessGroup, Session, Sid};
 use crate::{
-    events::{Events, Observer, Subject},
     prelude::*,
     process::posix_thread::AsPosixThread,
     thread::{Thread, Tid},
@@ -24,9 +23,8 @@ static PID_TABLE: Mutex<PidTable> = Mutex::new(PidTable::new());
 /// Combines the process, process-group, session, and thread tables into a
 /// single structure.
 pub struct PidTable {
-    entries: BTreeMap<u32, Arc<Mutex<PidEntry>>>,
+    entries: BTreeMap<u32, Arc<PidEntry>>,
     process_count: usize,
-    subject: Subject<PidEvent>,
 }
 
 impl PidTable {
@@ -34,15 +32,14 @@ impl PidTable {
         Self {
             entries: BTreeMap::new(),
             process_count: 0,
-            subject: Subject::new(),
         }
     }
 
     /// Returns the entry for the given ID, or creates a new one if absent.
-    fn get_or_create_entry(&mut self, id: u32) -> &Arc<Mutex<PidEntry>> {
+    fn get_or_create_entry(&mut self, id: u32) -> &Arc<PidEntry> {
         self.entries
             .entry(id)
-            .or_insert_with(|| Arc::new(Mutex::new(PidEntry::new())))
+            .or_insert_with(|| Arc::new(PidEntry::new()))
     }
 
     // ---- Thread operations ----
@@ -165,8 +162,6 @@ impl PidTable {
             pid_entry.is_empty()
         };
 
-        self.subject.notify_observers(&PidEvent::Exit(pid));
-
         if should_remove {
             map_entry.remove();
         }
@@ -257,11 +252,9 @@ impl PidTable {
         }
     }
 
-    // ---- Observer operations ----
-
-    /// Registers an observer which watches `PidEvent`.
-    pub fn register_observer(&mut self, observer: Weak<dyn Observer<PidEvent>>) {
-        self.subject.register_observer(observer);
+    /// Returns the entry for the given numeric identifier.
+    pub fn get_entry(&self, id: u32) -> Option<Arc<PidEntry>> {
+        self.entries.get(&id).cloned()
     }
 }
 
@@ -284,15 +277,91 @@ impl PidTable {
 /// are atomic with respect to the corresponding `PidEntry`. In other words,
 /// there will never be a `PidEntry` in the [`PidTable`] that is associated with
 /// a [`Process`], but at some intermediate moment has only an associated [`Thread`].
-struct PidEntry {
+pub struct PidEntry {
+    inner: Mutex<PidEntryInner>,
+}
+
+struct PidEntryInner {
     thread: Weak<Thread>,
     process: Weak<Process>,
     process_group: Weak<ProcessGroup>,
     session: Weak<Session>,
 }
 
+/// The process/thread type represented by a [`PidEntry`].
+///
+/// [`PidTable`]'s guarantees for process/thread update operations ensure that its
+/// entry is never seen in an intermediate [`PidEntryType`].
+pub enum PidEntryType {
+    /// The entry tracks a live process. The associated thread, if any, is
+    /// the process's main thread.
+    Process,
+    /// The entry tracks a non-main POSIX thread (one whose TID differs
+    /// from any live process's PID).
+    Thread,
+}
+
 impl PidEntry {
     /// Creates a new empty `PidEntry`.
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(PidEntryInner::new()),
+        }
+    }
+
+    /// Locks and returns access to the entry internals.
+    fn lock(&self) -> MutexGuard<'_, PidEntryInner> {
+        self.inner.lock()
+    }
+
+    /// Returns the thread associated with the entry, if any.
+    pub fn thread(&self) -> Option<Arc<Thread>> {
+        self.lock().thread()
+    }
+
+    /// Returns the process of the thread associated with the entry, if any.
+    ///
+    /// This method is not limited to the process slot.
+    /// If the entry only tracks a thread,
+    /// this returns the process that the thread belongs to.
+    ///
+    /// This is useful for procfs lookups that need process-scoped state for
+    /// either `/proc/[pid]` or `/proc/[pid]/task/[tid]`.
+    pub fn process_of_thread(&self) -> Option<Arc<Process>> {
+        let inner = self.lock();
+
+        if let Some(process) = inner.process() {
+            return Some(process);
+        }
+
+        if let Some(thread) = inner.thread() {
+            return Some(thread.as_posix_thread().unwrap().process());
+        }
+
+        None
+    }
+
+    /// Returns whether the entry is associated with a process or a thread.
+    ///
+    /// If a process and a thread share this numeric ID, returns
+    /// [`PidEntryType::Process`].
+    pub fn type_(&self) -> Option<PidEntryType> {
+        let inner = self.lock();
+
+        if inner.has_live_process() {
+            return Some(PidEntryType::Process);
+        }
+
+        if inner.has_live_thread() {
+            return Some(PidEntryType::Thread);
+        }
+
+        None
+    }
+}
+
+impl PidEntryInner {
+    /// Creates a new empty `PidEntryInner`.
     fn new() -> Self {
         Self {
             thread: Weak::new(),
@@ -404,15 +473,6 @@ impl PidEntry {
 pub fn pid_table_mut() -> MutexGuard<'static, PidTable> {
     PID_TABLE.lock()
 }
-
-/// An event emitted when a process exits.
-#[derive(Clone, Copy)]
-pub enum PidEvent {
-    /// A process with the given PID has exited.
-    Exit(Pid),
-}
-
-impl Events for PidEvent {}
 
 /// Extension methods for `Weak<T>` values stored in `PidEntry`.
 ///

--- a/kernel/src/process/pid_table.rs
+++ b/kernel/src/process/pid_table.rs
@@ -47,15 +47,23 @@ impl PidTable {
 
     // ---- Thread operations ----
 
-    /// Inserts a thread into the table.
+    /// Inserts a non-main thread into the table.
+    ///
+    /// This method requires the target entry not to track a process. A
+    /// process's main thread must be inserted with [`Self::insert_process`].
     pub(super) fn insert_thread(&mut self, tid: Tid, thread: &Arc<Thread>) {
         debug_assert_eq!(tid, thread.as_posix_thread().unwrap().tid());
 
-        let entry = self.get_or_create_entry(tid);
-        entry.lock().set_thread(thread);
+        let mut entry = self.get_or_create_entry(tid).lock();
+        debug_assert!(!entry.has_live_process());
+
+        entry.set_thread(thread);
     }
 
-    /// Removes a thread from the table.
+    /// Removes a non-main thread from the table.
+    ///
+    /// This method requires the target entry not to track a process. A
+    /// process's main thread must be removed with [`Self::remove_process`].
     pub(super) fn remove_thread(&mut self, tid: Tid) {
         let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
             return;
@@ -63,6 +71,8 @@ impl PidTable {
 
         let should_remove = {
             let mut pid_entry = map_entry.get().lock();
+            debug_assert!(!pid_entry.has_live_process());
+
             pid_entry.clear_thread();
             // Drop the locked PID entry before removing the B-tree entry.
             pid_entry.is_empty()
@@ -73,7 +83,9 @@ impl PidTable {
         }
     }
 
-    /// Removes a thread from the table and returns it.
+    /// Removes a non-main thread from the table and returns it.
+    ///
+    /// This method requires the target entry not to track a process.
     pub(super) fn take_thread(&mut self, tid: Tid) -> Option<Arc<Thread>> {
         let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
             return None;
@@ -81,6 +93,8 @@ impl PidTable {
 
         let (thread, should_remove) = {
             let mut pid_entry = map_entry.get().lock();
+            debug_assert!(!pid_entry.has_live_process());
+
             let thread = pid_entry.thread()?;
             pid_entry.clear_thread();
             // Drop the locked PID entry before removing the B-tree entry.
@@ -118,21 +132,22 @@ impl PidTable {
 
     // ---- Process operations ----
 
-    /// Inserts a process into the table.
+    /// Inserts a process and its main thread into the table.
     pub(super) fn insert_process(&mut self, pid: Pid, process: &Arc<Process>) {
-        debug_assert!(
-            !self
-                .entries
-                .get(&pid)
-                .is_some_and(|entry| entry.lock().has_live_process())
-        );
+        // `set_process` will assert the process slot is empty.
         self.process_count += 1;
 
         let entry = self.get_or_create_entry(pid);
-        entry.lock().set_process(process);
+        let mut entry = entry.lock();
+        entry.set_process(process);
+        entry.set_thread(&process.main_thread());
     }
 
-    /// Removes a process from the table and notifies observers.
+    /// Removes a process and its main thread from the table.
+    //
+    // TODO: Add an active reclamation mechanism for dentries corresponding to `PidEntry`
+    // in the procfs `DentryCache`, so that invalid dentries can be released as promptly
+    // as possible.
     pub(super) fn remove_process(&mut self, pid: Pid) {
         let Entry::Occupied(map_entry) = self.entries.entry(pid) else {
             return;
@@ -141,10 +156,11 @@ impl PidTable {
         let should_remove = {
             let mut pid_entry = map_entry.get().lock();
 
-            debug_assert!(pid_entry.has_live_process());
+            // `clear_process` will assert the process slot is not empty.
             self.process_count -= 1;
 
             pid_entry.clear_process();
+            pid_entry.clear_thread();
             // Drop the locked PID entry before removing the B-tree entry.
             pid_entry.is_empty()
         };
@@ -261,6 +277,13 @@ impl PidTable {
 /// corresponding `PidEntry`s. With this ownership model, processes are owned
 /// by their parents, while process groups and sessions are owned by their
 /// member processes and are reclaimed automatically after the last process is reaped.
+///
+/// # Atomicity of process/thread updates
+///
+/// [`PidTable`] guarantees that process/thread insertion and removal operations
+/// are atomic with respect to the corresponding `PidEntry`. In other words,
+/// there will never be a `PidEntry` in the [`PidTable`] that is associated with
+/// a [`Process`], but at some intermediate moment has only an associated [`Thread`].
 struct PidEntry {
     thread: Weak<Thread>,
     process: Weak<Process>,
@@ -281,55 +304,55 @@ impl PidEntry {
 
     /// Sets the thread reference.
     fn set_thread(&mut self, thread: &Arc<Thread>) {
-        debug_assert!(self.thread.is_dangling());
+        debug_assert!(!self.has_live_thread());
         self.thread = Arc::downgrade(thread);
     }
 
     /// Clears the thread reference.
     fn clear_thread(&mut self) {
-        debug_assert!(!self.thread.is_dangling());
+        debug_assert!(self.has_live_thread());
         self.thread = Weak::new();
     }
 
     /// Replaces the thread reference.
     fn replace_thread(&mut self, thread: &Arc<Thread>) {
-        debug_assert!(!self.thread.is_dangling());
+        debug_assert!(self.has_live_thread());
         self.thread = Arc::downgrade(thread);
     }
 
     /// Sets the process reference.
     fn set_process(&mut self, process: &Arc<Process>) {
-        debug_assert!(self.process.is_dangling());
+        debug_assert!(!self.has_live_process());
         self.process = Arc::downgrade(process);
     }
 
     /// Clears the process reference.
     fn clear_process(&mut self) {
-        debug_assert!(!self.process.is_dangling());
+        debug_assert!(self.has_live_process());
         self.process = Weak::new();
     }
 
     /// Sets the process group reference.
     fn set_process_group(&mut self, group: &Arc<ProcessGroup>) {
-        debug_assert!(self.process_group.is_dangling());
+        debug_assert!(!self.has_live_process_group());
         self.process_group = Arc::downgrade(group);
     }
 
     /// Clears the process group reference.
     fn clear_process_group(&mut self) {
-        debug_assert!(!self.process_group.is_dangling());
+        debug_assert!(self.has_live_process_group());
         self.process_group = Weak::new();
     }
 
     /// Sets the session reference.
     fn set_session(&mut self, session: &Arc<Session>) {
-        debug_assert!(self.session.is_dangling());
+        debug_assert!(!self.has_live_session());
         self.session = Arc::downgrade(session);
     }
 
     /// Clears the session reference.
     fn clear_session(&mut self) {
-        debug_assert!(!self.session.is_dangling());
+        debug_assert!(self.has_live_session());
         self.session = Weak::new();
     }
 
@@ -348,6 +371,11 @@ impl PidEntry {
         self.process_group.upgrade()
     }
 
+    /// Returns whether the entry still tracks a live thread.
+    fn has_live_thread(&self) -> bool {
+        !self.thread.is_dangling()
+    }
+
     /// Returns whether the entry still tracks a live process.
     fn has_live_process(&self) -> bool {
         !self.process.is_dangling()
@@ -358,12 +386,17 @@ impl PidEntry {
         !self.process_group.is_dangling()
     }
 
+    /// Returns whether the entry still tracks a live session.
+    fn has_live_session(&self) -> bool {
+        !self.session.is_dangling()
+    }
+
     /// Returns `true` if the entry no longer tracks any live object.
     fn is_empty(&self) -> bool {
-        self.thread.is_dangling()
-            && self.process.is_dangling()
-            && self.process_group.is_dangling()
-            && self.session.is_dangling()
+        !self.has_live_thread()
+            && !self.has_live_process()
+            && !self.has_live_process_group()
+            && !self.has_live_session()
     }
 }
 

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     fs::{file::file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::{
-        Credentials, NsProxy, Process, UserNamespace, pid_table,
+        Credentials, NsProxy, Process, UserNamespace,
         posix_thread::name::ThreadName,
         signal::{sig_mask::AtomicSigMask, sig_queues::SigQueues},
     },
@@ -204,7 +204,6 @@ impl PosixThreadBuilder {
                 ns_proxy,
             );
 
-            pid_table::pid_table_mut().insert_thread(tid, &thread);
             task::create_new_user_task(user_ctx, thread, thread_local)
         })
     }

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -73,7 +73,7 @@ fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
         }
         current_thread.exit();
 
-        tasks.remove_exited(&current_task, posix_thread.tid())
+        tasks.remove_exited(&current_task)
     };
 
     // This is put after `current_thread.exit()`,

--- a/kernel/src/process/task_set.rs
+++ b/kernel/src/process/task_set.rs
@@ -7,12 +7,7 @@ use ostd::{
     task::{CurrentTask, Task},
 };
 
-use super::Pid;
-use crate::{
-    events::{Events, Observer, Subject},
-    prelude::*,
-    thread::Tid,
-};
+use crate::prelude::*;
 
 /// A task set that maintains all tasks in a POSIX process.
 pub struct TaskSet {
@@ -21,7 +16,6 @@ pub struct TaskSet {
     has_exited_group: bool,
     in_execve: bool,
     execve_waker: Option<Arc<Waker>>,
-    subject: Subject<TidEvent>,
 }
 
 impl TaskSet {
@@ -33,7 +27,6 @@ impl TaskSet {
             has_exited_group: false,
             in_execve: false,
             execve_waker: None,
-            subject: Subject::new(),
         }
     }
 
@@ -60,7 +53,7 @@ impl TaskSet {
     /// # Panics
     ///
     /// This method will panic if the task is not in the task set.
-    pub(super) fn remove_exited(&mut self, task: &CurrentTask, tid: Tid) -> bool {
+    pub(super) fn remove_exited(&mut self, task: &CurrentTask) -> bool {
         let position = self
             .tasks
             .iter()
@@ -72,7 +65,6 @@ impl TaskSet {
             self.has_exited_main = true;
         } else {
             self.tasks.swap_remove(position);
-            self.notify_tid_exit(tid);
         }
 
         if let Some(waker) = self.execve_waker.as_ref() {
@@ -90,15 +82,12 @@ impl TaskSet {
     /// Removes the main task and makes the remaining task become the main task.
     ///
     /// The method should only be calling when doing execve.
-    pub(super) fn swap_main(&mut self, pid: Pid, tid: Tid) {
+    pub(super) fn swap_main(&mut self) {
         // This is an extremely internal method. The caller must uphold certain invariants, update
         // the thread status, modify the PID table entry, etc.
 
         self.tasks.swap_remove(0);
         self.has_exited_main = false;
-
-        self.notify_tid_exit(pid);
-        self.notify_tid_exit(tid);
     }
 
     /// Sets a flag that denotes that an `exit_group` has been initiated.
@@ -141,11 +130,6 @@ impl TaskSet {
     pub(super) fn clear_execve_waker(&mut self) {
         self.execve_waker = None;
     }
-
-    /// Notifies `TidEvent::Exit` events to the subject.
-    fn notify_tid_exit(&mut self, tid: Tid) {
-        self.subject.notify_observers(&TidEvent::Exit(tid));
-    }
 }
 
 impl TaskSet {
@@ -158,22 +142,4 @@ impl TaskSet {
     pub fn main(&self) -> &Arc<Task> {
         &self.tasks[0]
     }
-
-    /// Registers an observer which watches `TidEvent`.
-    pub fn register_observer(&mut self, observer: Weak<dyn Observer<TidEvent>>) {
-        self.subject.register_observer(observer);
-    }
-
-    /// Unregisters an observer which watches `TidEvent`.
-    #[expect(dead_code)]
-    pub fn unregister_observer(&mut self, observer: &Weak<dyn Observer<TidEvent>>) {
-        self.subject.unregister_observer(observer);
-    }
 }
-
-#[derive(Clone, Copy)]
-pub enum TidEvent {
-    Exit(Tid),
-}
-
-impl Events for TidEvent {}

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -347,9 +347,14 @@ fn reap_zombie_child(
     let mut pid_table = pid_table::pid_table_mut();
 
     // Lock order: children of process -> PID table -> tasks of process
-    for task in child_process.tasks().lock().as_slice() {
-        pid_table.remove_thread(task.as_posix_thread().unwrap().tid());
-    }
+    debug_assert_eq!(child_process.tasks().lock().as_slice().len(), 1);
+    debug_assert_eq!(
+        child_process.tasks().lock().as_slice()[0]
+            .as_posix_thread()
+            .unwrap()
+            .tid(),
+        child_pid
+    );
 
     // Lock order: children of process -> PID table
     // -> group of process -> group inner -> session inner

--- a/test/initramfs/src/regression/fs/ext2/rename.c
+++ b/test/initramfs/src/regression/fs/ext2/rename.c
@@ -17,6 +17,8 @@
 
 #define DIR_RENAMED_CHILD DIR_RENAMED "/child"
 #define DIR_RENAMED_GRANDCHILD DIR_RENAMED_CHILD "/grandchild"
+#define FILE_A BASE_DIR "/A"
+#define FILE_B BASE_DIR "/B"
 
 #define CROSS_MOUNT_DIR BASE_DIR "/mnt"
 #define CROSS_MOUNT_DIR_CHILD CROSS_MOUNT_DIR "/child"
@@ -42,6 +44,8 @@ static void ensure_test_tree(void)
 
 static void cleanup_test_tree(void)
 {
+	CHECK_WITH(unlink(FILE_A), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(unlink(FILE_B), _ret == 0 || errno == ENOENT);
 	remove_if_exists(DIR_TARGET);
 	remove_if_exists(DIR_RENAMED_GRANDCHILD);
 	remove_if_exists(DIR_RENAMED_CHILD);
@@ -93,6 +97,27 @@ FN_TEST(rename_to_new_name)
 	TEST_SUCC(access(DIR_RENAMED_CHILD, F_OK));
 	TEST_ERRNO(access(DIR, F_OK), ENOENT);
 
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(rename_overwrites_negative_cache_on_ext2)
+{
+	ensure_dir(BASE_DIR);
+
+	int fd_a = TEST_SUCC(open(FILE_A, O_CREAT | O_WRONLY, 0644));
+	TEST_SUCC(close(fd_a));
+	int fd_b = TEST_SUCC(open(FILE_B, O_CREAT | O_WRONLY, 0644));
+	TEST_SUCC(close(fd_b));
+
+	TEST_SUCC(unlink(FILE_B));
+	TEST_ERRNO(access(FILE_B, F_OK), ENOENT);
+
+	TEST_SUCC(rename(FILE_A, FILE_B));
+	TEST_SUCC(access(FILE_B, F_OK));
+	TEST_SUCC(access(FILE_B, F_OK));
+
+	TEST_SUCC(unlink(FILE_B));
 	cleanup_test_tree();
 }
 END_TEST()

--- a/test/initramfs/src/regression/fs/ext2/rmdir.c
+++ b/test/initramfs/src/regression/fs/ext2/rmdir.c
@@ -12,8 +12,8 @@
 
 #include "../../common/test.h"
 
-#define NON_EMPTY_DIR "/test_non_empty_dir"
-#define NON_EMPTY_CHILD "/test_non_empty_dir/test.txt"
+#define NON_EMPTY_DIR "/ext2/test_non_empty_dir"
+#define NON_EMPTY_CHILD "/ext2/test_non_empty_dir/test.txt"
 
 static void remove_file_if_exists(const char *path)
 {

--- a/test/initramfs/src/regression/fs/procfs/Makefile
+++ b/test/initramfs/src/regression/fs/procfs/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
-EXTRA_C_FLAGS := -lpthread
+EXTRA_C_FLAGS := -static -lpthread
 
 include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/procfs/getdents.c
+++ b/test/initramfs/src/regression/fs/procfs/getdents.c
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+#define CHILD_COUNT 16
+#define EXTRA_FD_COUNT 3
+#define MAX_DIRENTS 128
+#define MID_DIRENT_BUF_SIZE 256
+#define NORMAL_DIRENT_BUF_SIZE 512
+#define SMALL_DIRENT_BUF_SIZE 128
+
+struct linux_dirent64 {
+	uint64_t d_ino;
+	int64_t d_off;
+	unsigned short d_reclen;
+	unsigned char d_type;
+	char d_name[];
+};
+
+struct proc_dirent {
+	char name[256];
+	unsigned char type;
+	int64_t next_off;
+};
+
+static int extra_fds[EXTRA_FD_COUNT];
+
+static size_t append_dirents(struct proc_dirent *entries, size_t count,
+			     void *buf, ssize_t bytes)
+{
+	for (size_t pos = 0; pos < (size_t)bytes;) {
+		struct linux_dirent64 *dirent =
+			(struct linux_dirent64 *)((char *)buf + pos);
+
+		snprintf(entries[count].name, sizeof(entries[count].name), "%s",
+			 dirent->d_name);
+		entries[count].type = dirent->d_type;
+		entries[count].next_off = dirent->d_off;
+		count++;
+		pos += dirent->d_reclen;
+	}
+
+	return count;
+}
+
+static int is_dot_dirent(const char *name)
+{
+	return strcmp(name, ".") == 0 || strcmp(name, "..") == 0;
+}
+
+static unsigned char dirent_type_from_mode(mode_t mode)
+{
+	if (S_ISREG(mode)) {
+		return DT_REG;
+	}
+	if (S_ISDIR(mode)) {
+		return DT_DIR;
+	}
+	if (S_ISLNK(mode)) {
+		return DT_LNK;
+	}
+	if (S_ISCHR(mode)) {
+		return DT_CHR;
+	}
+	if (S_ISBLK(mode)) {
+		return DT_BLK;
+	}
+	if (S_ISFIFO(mode)) {
+		return DT_FIFO;
+	}
+	if (S_ISSOCK(mode)) {
+		return DT_SOCK;
+	}
+	return DT_UNKNOWN;
+}
+
+static int same_visible_dirent(const struct proc_dirent *lhs,
+			       const struct proc_dirent *rhs)
+{
+	return strcmp(lhs->name, rhs->name) == 0 && lhs->type == rhs->type;
+}
+
+FN_SETUP(open_extra_proc_fds)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(extra_fds); i++) {
+		extra_fds[i] = CHECK(dup(STDIN_FILENO));
+	}
+}
+END_SETUP()
+
+FN_TEST(proc_self_dirent_types_match_stat)
+{
+	/*
+	 * Scans `/proc/self` with `getdents64` and verifies that every visible
+	 * directory entry reports the same file type as `fstatat` sees without
+	 * following symlinks.
+	 */
+	struct proc_dirent entries[MAX_DIRENTS];
+	char buf[NORMAL_DIRENT_BUF_SIZE];
+	size_t count = 0;
+	int fd = TEST_SUCC(open("/proc/self", O_RDONLY | O_DIRECTORY));
+
+	for (;;) {
+		ssize_t bytes =
+			TEST_RES(syscall(SYS_getdents64, fd, buf, sizeof(buf)),
+				 _ret >= 0);
+		if (bytes <= 0) {
+			break;
+		}
+
+		count = append_dirents(entries, count, buf, bytes);
+	}
+
+	for (size_t i = 0; i < count; i++) {
+		struct stat stat_buf;
+
+		if (is_dot_dirent(entries[i].name)) {
+			continue;
+		}
+
+		TEST_RES(fstatat(fd, entries[i].name, &stat_buf,
+				 AT_SYMLINK_NOFOLLOW),
+			 entries[i].type ==
+				 dirent_type_from_mode(stat_buf.st_mode));
+	}
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(proc_self_task_dirent_types_match_stat)
+{
+	/*
+	 * Scans `/proc/self/task` with `getdents64` and checks that task
+	 * directory entries expose a `d_type` consistent with their `fstatat`
+	 * file type.
+	 */
+	struct proc_dirent entries[MAX_DIRENTS];
+	char buf[NORMAL_DIRENT_BUF_SIZE];
+	size_t count = 0;
+	int fd = TEST_SUCC(open("/proc/self/task", O_RDONLY | O_DIRECTORY));
+
+	for (;;) {
+		ssize_t bytes =
+			TEST_RES(syscall(SYS_getdents64, fd, buf, sizeof(buf)),
+				 _ret >= 0);
+		if (bytes <= 0) {
+			break;
+		}
+
+		count = append_dirents(entries, count, buf, bytes);
+	}
+
+	for (size_t i = 0; i < count; i++) {
+		struct stat stat_buf;
+
+		if (is_dot_dirent(entries[i].name)) {
+			continue;
+		}
+
+		TEST_RES(fstatat(fd, entries[i].name, &stat_buf,
+				 AT_SYMLINK_NOFOLLOW),
+			 entries[i].type ==
+				 dirent_type_from_mode(stat_buf.st_mode));
+	}
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(proc_self_fd_dirent_types_match_stat)
+{
+	/*
+	 * Scans `/proc/self/fd` while several descriptors are open and verifies
+	 * that each file-descriptor entry's `d_type` matches `fstatat`.
+	 */
+	struct proc_dirent entries[MAX_DIRENTS];
+	char buf[NORMAL_DIRENT_BUF_SIZE];
+	size_t count = 0;
+	int fd = TEST_SUCC(open("/proc/self/fd", O_RDONLY | O_DIRECTORY));
+
+	for (;;) {
+		ssize_t bytes =
+			TEST_RES(syscall(SYS_getdents64, fd, buf, sizeof(buf)),
+				 _ret >= 0);
+		if (bytes <= 0) {
+			break;
+		}
+
+		count = append_dirents(entries, count, buf, bytes);
+	}
+
+	for (size_t i = 0; i < count; i++) {
+		struct stat stat_buf;
+
+		if (is_dot_dirent(entries[i].name)) {
+			continue;
+		}
+
+		TEST_RES(fstatat(fd, entries[i].name, &stat_buf,
+				 AT_SYMLINK_NOFOLLOW),
+			 entries[i].type ==
+				 dirent_type_from_mode(stat_buf.st_mode));
+	}
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(proc_self_fd_d_off_resumes_from_next_entry)
+{
+	/*
+	 * Reads a prefix of `/proc/self/fd`, seeks to the last entry's `d_off`,
+	 * and verifies that the resumed scan equals the suffix of a full scan.
+	 */
+	struct proc_dirent full_scan[MAX_DIRENTS];
+	struct proc_dirent prefix[MAX_DIRENTS];
+	struct proc_dirent resumed[MAX_DIRENTS];
+	char normal_buf[NORMAL_DIRENT_BUF_SIZE];
+	char small_buf[SMALL_DIRENT_BUF_SIZE];
+	size_t full_count = 0;
+	size_t prefix_count = 0;
+	size_t resumed_count = 0;
+	int fd = TEST_SUCC(open("/proc/self/fd", O_RDONLY | O_DIRECTORY));
+
+	ssize_t prefix_bytes = TEST_RES(syscall(SYS_getdents64, fd, small_buf,
+						sizeof(small_buf)),
+					_ret > 0);
+
+	prefix_count =
+		append_dirents(prefix, prefix_count, small_buf, prefix_bytes);
+	TEST_RES(prefix_count, _ret > 0);
+
+	int64_t next_off = prefix[prefix_count - 1].next_off;
+	TEST_RES(lseek(fd, 0, SEEK_SET), _ret == 0);
+
+	for (;;) {
+		ssize_t bytes = TEST_RES(syscall(SYS_getdents64, fd, normal_buf,
+						 sizeof(normal_buf)),
+					 _ret >= 0);
+		if (bytes <= 0) {
+			break;
+		}
+
+		full_count = append_dirents(full_scan, full_count, normal_buf,
+					    bytes);
+	}
+
+	TEST_RES(lseek(fd, next_off, SEEK_SET), _ret == next_off);
+
+	for (;;) {
+		ssize_t bytes = TEST_RES(syscall(SYS_getdents64, fd, normal_buf,
+						 sizeof(normal_buf)),
+					 _ret >= 0);
+		if (bytes <= 0) {
+			break;
+		}
+
+		resumed_count = append_dirents(resumed, resumed_count,
+					       normal_buf, bytes);
+	}
+
+	size_t split_count = prefix_count + resumed_count;
+	TEST_RES(split_count, _ret == full_count);
+
+	size_t compare_count = split_count < full_count ? split_count :
+							  full_count;
+	for (size_t i = 0; i < compare_count; i++) {
+		const struct proc_dirent *actual =
+			i < prefix_count ? &prefix[i] :
+					   &resumed[i - prefix_count];
+
+		TEST_RES(same_visible_dirent(actual, &full_scan[i]), _ret);
+	}
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(getdents_proc_continues_when_child_reaped_mid_iteration)
+{
+	/*
+	 * Reaping a still-unemitted `/proc/<pid>` child between small
+	 * `getdents64` calls must not make the `/proc` root scan fail with the
+	 * child's lookup error.
+	 */
+	pid_t children[CHILD_COUNT];
+	bool child_seen[CHILD_COUNT] = {};
+	bool child_reaped[CHILD_COUNT] = {};
+	char buf[MID_DIRENT_BUF_SIZE];
+	int64_t last_off = 0;
+	size_t nonzero_reads = 0;
+	size_t reaped_mid_iteration = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(children); i++) {
+		pid_t pid = fork();
+		if (pid == 0) {
+			_exit(0);
+		}
+
+		TEST_RES(pid, _ret > 0);
+		children[i] = pid;
+	}
+
+	int fd = TEST_SUCC(open("/proc", O_RDONLY | O_DIRECTORY));
+
+	for (;;) {
+		errno = 0;
+		ssize_t bytes = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+		int saved_errno = errno;
+
+		TEST_RES(saved_errno,
+			 bytes >= 0 || (_ret != ENOENT && _ret != ESRCH));
+		TEST_RES(bytes, _ret >= 0);
+		if (bytes < 0) {
+			break;
+		}
+		if (bytes == 0) {
+			break;
+		}
+
+		nonzero_reads++;
+		bool valid_dirents = true;
+		bool monotonic_offsets = true;
+		for (size_t pos = 0; pos < (size_t)bytes;) {
+			struct linux_dirent64 *dirent =
+				(struct linux_dirent64 *)((char *)buf + pos);
+
+			if (dirent->d_reclen == 0 ||
+			    pos + dirent->d_reclen > (size_t)bytes) {
+				valid_dirents = false;
+				break;
+			}
+			if (dirent->d_off <= last_off) {
+				monotonic_offsets = false;
+			}
+			last_off = dirent->d_off;
+
+			for (size_t i = 0; i < ARRAY_SIZE(children); i++) {
+				char name[32];
+
+				snprintf(name, sizeof(name), "%d", children[i]);
+				if (strcmp(dirent->d_name, name) == 0) {
+					child_seen[i] = true;
+					break;
+				}
+			}
+
+			pos += dirent->d_reclen;
+		}
+		TEST_RES(valid_dirents, _ret);
+		TEST_RES(monotonic_offsets, _ret);
+
+		for (size_t i = 0; i < ARRAY_SIZE(children); i++) {
+			if (child_seen[i] || child_reaped[i]) {
+				continue;
+			}
+
+			TEST_RES(waitpid(children[i], NULL, 0),
+				 _ret == children[i]);
+			child_reaped[i] = true;
+			reaped_mid_iteration++;
+			break;
+		}
+	}
+
+	TEST_RES(nonzero_reads, _ret > 1);
+	TEST_RES(reaped_mid_iteration, _ret > 0);
+
+	for (size_t i = 0; i < ARRAY_SIZE(children); i++) {
+		if (!child_reaped[i]) {
+			TEST_RES(waitpid(children[i], NULL, 0),
+				 _ret == children[i]);
+		}
+	}
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_SETUP(close_extra_proc_fds)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(extra_fds); i++) {
+		CHECK(close(extra_fds[i]));
+	}
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/procfs/tid.c
+++ b/test/initramfs/src/regression/fs/procfs/tid.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -44,9 +45,12 @@ FN_TEST(proc_root_tid_entry)
 	};
 	char command[128];
 	char ch;
+	struct stat first;
+	struct stat second;
 	pthread_t thread;
 	pid_t pid = TEST_SUCC(getpid());
 
+	/* Keep a non-leader thread alive while probing its procfs entry. */
 	TEST_SUCC(pipe(context.ready_pipe));
 	TEST_SUCC(pipe(context.exit_pipe));
 	TEST_SUCC(pthread_create(&thread, NULL, thread_fn, &context));
@@ -54,18 +58,27 @@ FN_TEST(proc_root_tid_entry)
 		 _ret == 1 && ch == 'R' && context.tid > 0 &&
 			 context.tid != pid);
 
+	/* /proc/<tid> exists while the non-leader thread is alive. */
 	print_command(command, sizeof(command), "ls /proc/%d > /dev/null",
 		      context.tid);
 	TEST_RES(system(command), _ret == 0);
 
+	/* Repeated lookups of the live /proc/<tid> entry resolve to one inode. */
+	print_command(command, sizeof(command), "/proc/%d", context.tid);
+	TEST_SUCC(stat(command, &first));
+	TEST_RES(stat(command, &second), first.st_ino == second.st_ino);
+
+	/* The non-leader tid is directly lookable but not listed in /proc. */
 	print_command(command, sizeof(command),
 		      "ls /proc -al | grep ' %d$' > /dev/null", context.tid);
 	TEST_RES(system(command), _ret != 0);
 
+	/* The process leader remains listed in /proc. */
 	print_command(command, sizeof(command),
 		      "ls /proc -al | grep ' %d$' > /dev/null", pid);
 	TEST_RES(system(command), _ret == 0);
 
+	/* Release the thread after all /proc/<tid> observations are done. */
 	TEST_RES(write(context.exit_pipe[1], "X", 1), _ret == 1);
 	TEST_SUCC(pthread_join(thread, NULL));
 	TEST_SUCC(close(context.ready_pipe[0]));

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -116,6 +116,7 @@ echo "All mount bind file test passed."
 
 ./procfs/dentry_cache
 ./procfs/mountstats
+./procfs/getdents
 ./procfs/pid_mem
 ./procfs/tid
 

--- a/test/initramfs/src/regression/process/exit/exit_procfs.c
+++ b/test/initramfs/src/regression/process/exit/exit_procfs.c
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
+
 #include "../../common/test.h"
 
-#include <unistd.h>
+#include <fcntl.h>
 #include <pthread.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 
@@ -93,5 +96,221 @@ FN_TEST(exit_procfs)
 		thread_master(EXIT_PARENT_FIRST);
 	}
 	TEST_RES(wait(&stat), WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+}
+END_TEST()
+
+struct status_thread_state {
+	volatile pid_t tid;
+	volatile int should_exit;
+};
+
+static void *status_thread_slave(void *arg)
+{
+	struct status_thread_state *state = arg;
+
+	state->tid = syscall(SYS_gettid);
+	while (!state->should_exit) {
+		usleep(10 * 1000);
+	}
+
+	return NULL;
+}
+
+FN_TEST(task_status_reports_threads_for_non_leader)
+{
+	/*
+	 * Verifies that both the thread-group leader and a non-leader thread
+	 * expose the same `Threads:\t2` line in their own task `status` files.
+	 */
+	pthread_t pthread;
+	struct status_thread_state state = {
+		.tid = 0,
+		.should_exit = 0,
+	};
+	pid_t main_tid = TEST_SUCC(syscall(SYS_gettid));
+	char main_tid_name[32];
+	char worker_tid_name[32];
+	char status_buf[2048];
+	int task_dir_fd, tid_dir_fd, status_fd;
+
+	TEST_SUCC(pthread_create(&pthread, NULL, status_thread_slave, &state));
+	while (state.tid == 0) {
+		usleep(10 * 1000);
+	}
+
+	task_dir_fd =
+		TEST_SUCC(open("/proc/self/task", O_RDONLY | O_DIRECTORY));
+	TEST_RES(snprintf(main_tid_name, sizeof(main_tid_name), "%d", main_tid),
+		 _ret > 0 && _ret < (int)sizeof(main_tid_name));
+	TEST_RES(snprintf(worker_tid_name, sizeof(worker_tid_name), "%d",
+			  state.tid),
+		 _ret > 0 && _ret < (int)sizeof(worker_tid_name));
+
+	tid_dir_fd = TEST_SUCC(
+		openat(task_dir_fd, main_tid_name, O_RDONLY | O_DIRECTORY));
+	status_fd = TEST_SUCC(openat(tid_dir_fd, "status", O_RDONLY));
+	memset(status_buf, 0, sizeof(status_buf));
+	TEST_RES(read(status_fd, status_buf, sizeof(status_buf) - 1),
+		 _ret > 0 && strstr(status_buf, "Threads:\t2\n") != NULL);
+	TEST_SUCC(close(status_fd));
+	TEST_SUCC(close(tid_dir_fd));
+
+	tid_dir_fd = TEST_SUCC(
+		openat(task_dir_fd, worker_tid_name, O_RDONLY | O_DIRECTORY));
+	status_fd = TEST_SUCC(openat(tid_dir_fd, "status", O_RDONLY));
+	memset(status_buf, 0, sizeof(status_buf));
+	TEST_RES(read(status_fd, status_buf, sizeof(status_buf) - 1),
+		 _ret > 0 && strstr(status_buf, "Threads:\t2\n") != NULL);
+	TEST_SUCC(close(status_fd));
+	TEST_SUCC(close(tid_dir_fd));
+	TEST_SUCC(close(task_dir_fd));
+
+	state.should_exit = 1;
+	TEST_SUCC(pthread_join(pthread, NULL));
+}
+END_TEST()
+
+FN_TEST(reaped_procfs_returns_esrch_for_stale_fds)
+{
+	/*
+	 * Verifies that procfs handles kept open while a process is alive all
+	 * revalidate after reap and report `ESRCH` instead of stale content.
+	 */
+	pid_t pid;
+	int proc_dir_fd, task_dir_fd, tid_dir_fd;
+	int proc_status_fd, proc_maps_fd, tid_status_fd;
+	int stat;
+	char proc_path[128];
+	char leader_tid_name[32];
+	char read_buf[1];
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		usleep(200 * 1000);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid),
+		 _ret > 0 && _ret < (int)sizeof(proc_path));
+	proc_dir_fd = TEST_SUCC(open(proc_path, O_RDONLY | O_DIRECTORY));
+	task_dir_fd =
+		TEST_SUCC(openat(proc_dir_fd, "task", O_RDONLY | O_DIRECTORY));
+	proc_status_fd = TEST_SUCC(openat(proc_dir_fd, "status", O_RDONLY));
+	proc_maps_fd = TEST_SUCC(openat(proc_dir_fd, "maps", O_RDONLY));
+	TEST_RES(snprintf(leader_tid_name, sizeof(leader_tid_name), "%d", pid),
+		 _ret > 0 && _ret < (int)sizeof(leader_tid_name));
+	tid_dir_fd = TEST_SUCC(
+		openat(task_dir_fd, leader_tid_name, O_RDONLY | O_DIRECTORY));
+	tid_status_fd = TEST_SUCC(openat(tid_dir_fd, "status", O_RDONLY));
+	TEST_SUCC(close(tid_dir_fd));
+
+	TEST_RES(waitpid(pid, &stat, 0),
+		 _ret == pid && WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+
+	TEST_ERRNO(openat(proc_dir_fd, "status", O_RDONLY), ESRCH);
+	TEST_ERRNO(openat(proc_dir_fd, "task", O_RDONLY | O_DIRECTORY), ESRCH);
+	TEST_ERRNO(openat(proc_dir_fd, "fd", O_RDONLY | O_DIRECTORY), ESRCH);
+	TEST_ERRNO(openat(proc_dir_fd, "ns", O_RDONLY | O_DIRECTORY), ESRCH);
+
+	TEST_ERRNO(openat(task_dir_fd, leader_tid_name, O_RDONLY | O_DIRECTORY),
+		   ESRCH);
+
+	/*
+	 * The stale descriptors should fail before returning any payload, so a
+	 * one-byte buffer is enough to exercise the `read` path.
+	 */
+	TEST_ERRNO(read(proc_status_fd, read_buf, sizeof(read_buf)), ESRCH);
+	TEST_ERRNO(read(proc_maps_fd, read_buf, sizeof(read_buf)), ESRCH);
+	TEST_ERRNO(read(tid_status_fd, read_buf, sizeof(read_buf)), ESRCH);
+
+	TEST_SUCC(close(proc_dir_fd));
+	TEST_SUCC(close(task_dir_fd));
+	TEST_SUCC(close(proc_status_fd));
+	TEST_SUCC(close(proc_maps_fd));
+	TEST_SUCC(close(tid_status_fd));
+}
+END_TEST()
+
+FN_TEST(procfs_status_and_exe_distinguish_zombie_and_reaped_paths)
+{
+	/*
+	 * Verifies that zombie tasks still expose zombie `status` but hide
+	 * `exe`, and that after reap the same paths split into `ENOENT` for
+	 * fresh lookups and `ESRCH` for lookups through stale proc dir fds.
+	 */
+	const char *zombie_state_line = "State:\tZ (zombie)\n";
+	pid_t pid;
+	int proc_dir_fd, proc_status_fd;
+	int zombie_status_fd, zombie_stale_status_fd;
+	int stat;
+	char proc_path[128];
+	char status_path[128];
+	char exe_path[128];
+	char status_buf[2048];
+	char read_buf[1];
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		usleep(200 * 1000);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid),
+		 _ret > 0 && _ret < (int)sizeof(proc_path));
+	proc_dir_fd = TEST_SUCC(open(proc_path, O_RDONLY | O_DIRECTORY));
+	proc_status_fd = TEST_SUCC(openat(proc_dir_fd, "status", O_RDONLY));
+	TEST_RES(snprintf(status_path, sizeof(status_path), "/proc/%d/status",
+			  pid),
+		 _ret > 0 && _ret < (int)sizeof(status_path));
+	TEST_RES(snprintf(exe_path, sizeof(exe_path), "/proc/%d/exe", pid),
+		 _ret > 0 && _ret < (int)sizeof(exe_path));
+
+	/*
+	 * Wait until the child exits but keep it waitable so procfs still
+	 * exposes zombie-only state.
+	 */
+	TEST_SUCC(waitid(P_PID, pid, NULL, WEXITED | WNOWAIT));
+
+	zombie_status_fd = TEST_SUCC(open(status_path, O_RDONLY));
+	memset(status_buf, 0, sizeof(status_buf));
+	TEST_RES(read(zombie_status_fd, status_buf, sizeof(status_buf) - 1),
+		 _ret > 0 && strstr(status_buf, zombie_state_line) != NULL);
+	TEST_SUCC(close(zombie_status_fd));
+
+	zombie_stale_status_fd =
+		TEST_SUCC(openat(proc_dir_fd, "status", O_RDONLY));
+	memset(status_buf, 0, sizeof(status_buf));
+	TEST_RES(read(zombie_stale_status_fd, status_buf,
+		      sizeof(status_buf) - 1),
+		 _ret > 0 && strstr(status_buf, zombie_state_line) != NULL);
+	TEST_SUCC(close(zombie_stale_status_fd));
+
+	TEST_ERRNO(open(exe_path, O_RDONLY), ENOENT);
+	TEST_ERRNO(openat(proc_dir_fd, "exe", O_RDONLY), ENOENT);
+	TEST_ERRNO(readlink(exe_path, read_buf, sizeof(read_buf)), ENOENT);
+	TEST_ERRNO(readlinkat(proc_dir_fd, "exe", read_buf, sizeof(read_buf)),
+		   ENOENT);
+
+	TEST_RES(waitpid(pid, &stat, 0),
+		 _ret == pid && WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+
+	TEST_ERRNO(open(status_path, O_RDONLY), ENOENT);
+	TEST_ERRNO(openat(proc_dir_fd, "status", O_RDONLY), ESRCH);
+
+	/*
+	 * The status file opened while the child was live should revalidate on
+	 * each access, so it reports `ESRCH` after reap instead of returning
+	 * stale bytes.
+	 */
+	TEST_ERRNO(read(proc_status_fd, read_buf, sizeof(read_buf)), ESRCH);
+
+	TEST_ERRNO(open(exe_path, O_RDONLY), ENOENT);
+	TEST_ERRNO(openat(proc_dir_fd, "exe", O_RDONLY), ESRCH);
+	TEST_ERRNO(readlink(exe_path, read_buf, sizeof(read_buf)), ENOENT);
+	TEST_ERRNO(readlinkat(proc_dir_fd, "exe", read_buf, sizeof(read_buf)),
+		   ESRCH);
+
+	TEST_SUCC(close(proc_dir_fd));
+	TEST_SUCC(close(proc_status_fd));
 }
 END_TEST()

--- a/test/initramfs/src/regression/security/namespace/Makefile
+++ b/test/initramfs/src/regression/security/namespace/Makefile
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
+EXTRA_C_FLAGS := -static -lpthread
+
 include ../../common/Makefile

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 #include <linux/nsfs.h>
 #include <linux/sched.h>
 #include <poll.h>
@@ -43,6 +44,16 @@ static const int clone_flags[] = {
 	CLONE_NEWCGROUP, CLONE_NEWIPC, CLONE_NEWNS, CLONE_NEWUSER, CLONE_NEWUTS,
 };
 static const size_t ns_count = sizeof(ns_files) / sizeof(ns_files[0]);
+
+#define DOT_DOTDOT_DIRENT_BUF_SIZE 48
+
+struct linux_dirent64 {
+	uint64_t d_ino;
+	int64_t d_off;
+	unsigned short d_reclen;
+	unsigned char d_type;
+	char d_name[];
+};
 
 /* -------------------------------------------------------------------------- */
 
@@ -472,5 +483,48 @@ FN_TEST(open_with_o_path)
 	TEST_ERRNO(lseek(nsfd, 0, SEEK_SET), EBADF);
 
 	TEST_SUCC(close(nsfd));
+}
+END_TEST()
+
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Verify that a stale `/proc/<pid>/ns` directory fd fails with ENOENT once
+ * iteration advances past `.` and `..`.
+ */
+FN_TEST(stale_ns_dir_getdents_after_reap)
+{
+	char path[PATH_MAX];
+	char buf[DOT_DOTDOT_DIRENT_BUF_SIZE];
+	int status;
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		pause();
+		_exit(1);
+	}
+
+	TEST_RES(snprintf(path, sizeof(path), "/proc/%d/ns", pid),
+		 _ret > 0 && _ret < (int)sizeof(path));
+	int dirfd = TEST_SUCC(open(path, O_RDONLY | O_DIRECTORY));
+
+	ssize_t bytes = TEST_RES(
+		syscall(SYS_getdents64, dirfd, buf, sizeof(buf)), _ret > 0);
+	struct linux_dirent64 *first = (struct linux_dirent64 *)buf;
+	struct linux_dirent64 *second =
+		(struct linux_dirent64 *)(buf + first->d_reclen);
+
+	TEST_RES(bytes,
+		 first->d_reclen > 0 &&
+			 (size_t)bytes == first->d_reclen + second->d_reclen);
+	TEST_RES(strcmp(first->d_name, "."), _ret == 0);
+	TEST_RES(strcmp(second->d_name, ".."), _ret == 0);
+
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status) &&
+						   WTERMSIG(status) == SIGKILL);
+
+	TEST_ERRNO(syscall(SYS_getdents64, dirfd, buf, sizeof(buf)), ENOENT);
+	TEST_SUCC(close(dirfd));
 }
 END_TEST()


### PR DESCRIPTION
This PR implements `Dentry` revalidation mechanism, replacing the original `is_dentry_cacheable` API. With this PR, all dentries will first enter the `DentryCache`, and then be revalidated on demand upon a cache hit. This PR also provide more complete support for negative dentry in `DentryCache`.

Through this PR, the original validation logic in `procfs` has been handed over to the VFS layer, allowing the internal cache to be removed. The offset consistency semantics for `readdir` operations in `procfs`, previously provided by the `SlotVec` cache, are now handled through an additional API to prevent offset inconsistencies caused by changes in directory contents during consecutive `getdents` operations.

This PR does not modify the existing caching mechanisms for `devpts` and `cgroupfs`, preserving their original semantics. Their more specific revalidation mechanisms will be implemented later.