### PR TITLE
Fix pipe handling and futex wake matching

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -13,7 +13,7 @@ use ostd::{
 use crate::{
     prelude::*,
     process::{
-        Process,
+        Process, VmarSnapshot,
         posix_thread::{PosixThread, ThreadLocal},
     },
     thread::Thread,
@@ -84,6 +84,11 @@ impl<'a> CurrentUserSpace<'a> {
     /// This method will panic if the current process has cleared its `Vmar`.
     pub fn vmar(&self) -> &Vmar {
         self.0.as_ref().unwrap()
+    }
+
+    /// Takes a snapshot of the current VMAR identity.
+    pub fn vmar_snapshot(&self) -> VmarSnapshot {
+        VmarSnapshot::from(Arc::downgrade(self.0.as_ref().unwrap()))
     }
 
     /// Returns whether the VMAR is shared with other processes or threads.

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -23,7 +23,10 @@ use crate::{
             signals::user::{UserSignal, UserSignalKind},
         },
     },
-    util::ring_buffer::{RbConsumer, RbProducer, RingBuffer},
+    util::{
+        ioctl::{RawIoctl, dispatch_ioctl},
+        ring_buffer::{RbConsumer, RbProducer, RingBuffer},
+    },
 };
 
 /// A handle for a pipe that implements `FileIo`.
@@ -52,6 +55,10 @@ impl PipeHandle {
         debug_assert!(self.access_mode.is_writable());
 
         self.inner.writer.try_write(reader)
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.inner.reader.buffer_len()
     }
 }
 
@@ -136,6 +143,20 @@ impl FileIo for PipeHandle {
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        use crate::util::ioctl::common_defs::GetNumBytesToRead;
+
+        dispatch_ioctl!(match raw_ioctl {
+            cmd @ GetNumBytesToRead => {
+                let bytes_to_read = self.bytes_to_read() as i32;
+
+                cmd.write(&bytes_to_read)?;
+                Ok(0)
+            }
+            _ => return_errno_with_message!(Errno::ENOTTY, "the ioctl command is unknown"),
+        })
     }
 }
 
@@ -384,6 +405,10 @@ impl PipeReader {
         };
 
         self.state.read_with(read)
+    }
+
+    fn buffer_len(&self) -> usize {
+        self.consumer.lock().len()
     }
 
     fn peer_shutdown(&self) {

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -3,7 +3,9 @@
 use ostd::{mm::VmIo, task::Task};
 
 use super::{
-    AsPosixThread, AsThreadLocal, ThreadLocal, futex::futex_wake, robust_list::wake_robust_futex,
+    AsPosixThread, AsThreadLocal, ThreadLocal,
+    futex::{FutexVisibility, futex_wake},
+    robust_list::wake_robust_futex,
 };
 use crate::{
     current_userspace,
@@ -124,7 +126,7 @@ fn wake_clear_ctid(thread_local: &ThreadLocal) {
     let _ = current_userspace!()
         .write_val(clear_ctid, &0u32)
         .inspect_err(|err| debug!("exit: cannot clear the child TID: {:?}", err));
-    let _ = futex_wake(clear_ctid, 1, None)
+    let _ = futex_wake(clear_ctid, 1, FutexVisibility::Shared)
         .inspect_err(|err| debug!("exit: cannot wake the futex on the child TID: {:?}", err));
 
     thread_local.clear_child_tid().set(0);

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -262,7 +262,7 @@ impl FutexWakeOpEncode {
             FutexWakeOp::FUTEX_OP_SET => oparg,
             FutexWakeOp::FUTEX_OP_ADD => oparg.wrapping_add(old_val),
             FutexWakeOp::FUTEX_OP_OR => oparg | old_val,
-            FutexWakeOp::FUTEX_OP_ANDN => oparg & !old_val,
+            FutexWakeOp::FUTEX_OP_ANDN => !oparg & old_val,
             FutexWakeOp::FUTEX_OP_XOR => oparg ^ old_val,
         }
     }

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -8,22 +8,44 @@ use ostd::{
 use spin::Once;
 
 use crate::{
+    current_userspace,
     prelude::*,
-    process::Pid,
+    process::VmarSnapshot,
     time::wait::ManagedTimeout,
-    vm::{perms::VmPerms, vmar::PageFaultInfo},
+    vm::{perms::VmPerms, vmar::PageFaultInfo, vmo::Vmo},
 };
 
 type FutexBitSet = u32;
 
 const FUTEX_BITSET_MATCH_ANY: FutexBitSet = 0xFFFF_FFFF;
 
+/// Specifies whether a futex is scoped to the current process or shared through
+/// its backing mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FutexVisibility {
+    /// Uses the calling process's private futex namespace.
+    Private,
+    /// Derives the futex identity from the backing mapping when possible, and
+    /// otherwise falls back to a process-local shared identity.
+    Shared,
+}
+
+impl From<FutexFlags> for FutexVisibility {
+    fn from(flags: FutexFlags) -> Self {
+        if flags.contains(FutexFlags::FUTEX_PRIVATE) {
+            Self::Private
+        } else {
+            Self::Shared
+        }
+    }
+}
+
 pub fn futex_wait(
     futex_addr: u64,
     futex_val: i32,
     timeout: Option<ManagedTimeout>,
     ctx: &Context,
-    pid: Option<Pid>,
+    visibility: FutexVisibility,
 ) -> Result<()> {
     futex_wait_bitset(
         futex_addr as _,
@@ -31,7 +53,7 @@ pub fn futex_wait(
         timeout,
         FUTEX_BITSET_MATCH_ANY,
         ctx,
-        pid,
+        visibility,
     )
 }
 
@@ -41,7 +63,7 @@ pub fn futex_wait_bitset(
     timeout: Option<ManagedTimeout>,
     bitset: FutexBitSet,
     ctx: &Context,
-    pid: Option<Pid>,
+    visibility: FutexVisibility,
 ) -> Result<()> {
     debug!(
         "futex_wait_bitset: addr = {:#x}, val = {}, bitset = {:#x}",
@@ -52,11 +74,10 @@ pub fn futex_wait_bitset(
         return_errno_with_message!(Errno::EINVAL, "at least one bit should be set");
     }
 
-    let futex_key = FutexKey::new(futex_addr, bitset, pid)?;
+    let user_space = ctx.user_space();
+    let futex_key = FutexKey::new(futex_addr, bitset, &user_space, visibility)?;
     let (_, futex_bucket_ref) = get_futex_bucket(&futex_key);
     let (futex_item, waiter) = FutexItem::create(futex_key);
-
-    let user_space = ctx.user_space();
 
     let (mut futex_bucket, val) = loop {
         // Lock the futex bucket first to avoid race conditions.
@@ -118,15 +139,19 @@ pub fn futex_wait_bitset(
     }
 }
 
-pub fn futex_wake(futex_addr: Vaddr, max_count: usize, pid: Option<Pid>) -> Result<usize> {
-    futex_wake_bitset(futex_addr, max_count, FUTEX_BITSET_MATCH_ANY, pid)
+pub fn futex_wake(
+    futex_addr: Vaddr,
+    max_count: usize,
+    visibility: FutexVisibility,
+) -> Result<usize> {
+    futex_wake_bitset(futex_addr, max_count, FUTEX_BITSET_MATCH_ANY, visibility)
 }
 
 pub fn futex_wake_bitset(
     futex_addr: Vaddr,
     max_count: usize,
     bitset: FutexBitSet,
-    pid: Option<Pid>,
+    visibility: FutexVisibility,
 ) -> Result<usize> {
     debug!(
         "futex_wake_bitset: addr = {:#x}, max_count = {}, bitset = {:#x}",
@@ -137,7 +162,7 @@ pub fn futex_wake_bitset(
         return_errno_with_message!(Errno::EINVAL, "at least one bit should be set");
     }
 
-    let futex_key = FutexKey::new(futex_addr, bitset, pid)?;
+    let futex_key = FutexKey::new(futex_addr, bitset, &current_userspace!(), visibility)?;
     let (_, futex_bucket_ref) = get_futex_bucket(&futex_key);
     let mut futex_bucket = futex_bucket_ref.lock();
     let res = futex_bucket.remove_and_wake_items(&futex_key, max_count);
@@ -261,14 +286,23 @@ pub fn futex_wake_op(
     max_count_2: usize,
     wake_op_bits: u32,
     ctx: &Context,
-    pid: Option<Pid>,
+    visibility: FutexVisibility,
 ) -> Result<usize> {
     let wake_op = FutexWakeOpEncode::from_u32(wake_op_bits)?;
 
-    let futex_key_1 = FutexKey::new(futex_addr_1, FUTEX_BITSET_MATCH_ANY, pid)?;
-    let futex_key_2 = FutexKey::new(futex_addr_2, FUTEX_BITSET_MATCH_ANY, pid)?;
-
     let user_space = ctx.user_space();
+    let futex_key_1 = FutexKey::new(
+        futex_addr_1,
+        FUTEX_BITSET_MATCH_ANY,
+        &user_space,
+        visibility,
+    )?;
+    let futex_key_2 = FutexKey::new(
+        futex_addr_2,
+        FUTEX_BITSET_MATCH_ANY,
+        &user_space,
+        visibility,
+    )?;
 
     let (mut futex_bucket_1, mut futex_bucket_2, old_val) = loop {
         let (futex_bucket_1, futex_bucket_2) = lock_bucket_pairs(&futex_key_1, &futex_key_2);
@@ -313,14 +347,21 @@ pub fn futex_requeue(
     max_nwakes: usize,
     max_nrequeues: usize,
     futex_new_addr: Vaddr,
-    pid: Option<Pid>,
+    ctx: &Context,
+    visibility: FutexVisibility,
 ) -> Result<usize> {
     if futex_new_addr == futex_addr {
-        return futex_wake(futex_addr, max_nwakes, pid);
+        return futex_wake(futex_addr, max_nwakes, visibility);
     }
 
-    let futex_key = FutexKey::new(futex_addr, FUTEX_BITSET_MATCH_ANY, pid)?;
-    let futex_new_key = FutexKey::new(futex_new_addr, FUTEX_BITSET_MATCH_ANY, pid)?;
+    let user_space = ctx.user_space();
+    let futex_key = FutexKey::new(futex_addr, FUTEX_BITSET_MATCH_ANY, &user_space, visibility)?;
+    let futex_new_key = FutexKey::new(
+        futex_new_addr,
+        FUTEX_BITSET_MATCH_ANY,
+        &user_space,
+        visibility,
+    )?;
 
     let (mut futex_bucket, futex_new_bucket) = lock_bucket_pairs(&futex_key, &futex_new_key);
 
@@ -445,9 +486,6 @@ impl FutexBucket {
         let mut count = 0;
 
         self.items.retain(|item| {
-            // FIXME: `match_up` only checks the hash, which may wake up unrelated futex items. We
-            // need to check a globally unique identifier here instead. This is important because
-            // the number of woken items will be returned as the system call return value.
             if item.key.match_up(key) && count < max_count && item.wake() {
                 count += 1;
                 false
@@ -515,21 +553,30 @@ impl FutexItem {
     }
 }
 
-/// The key of a futex used to mark a futex word.
+/// The identity used for futex namespace and backing selection.
+#[derive(Debug, Clone)]
+enum FutexIdentity {
+    Private { vmar: VmarSnapshot, addr: Vaddr },
+    SharedLocal { vmar: VmarSnapshot, addr: Vaddr },
+    Shared { vmo: Weak<Vmo>, offset: usize },
+}
+
+/// The lookup key used for futex bucket selection and matching.
 #[derive(Debug, Clone)]
 struct FutexKey {
-    /// A hash value deterministically computed from the `Vaddr` and `Option<Pid>`
-    /// associated with the futex on instantiation.
+    /// A hash value deterministically computed from the futex identity.
     hash: usize,
+    identity: FutexIdentity,
     bitset: FutexBitSet,
 }
 
 impl FutexKey {
-    // FIXME: Shared mappings can be mapped to different virtual addresses in different processes.
-    // Using the virtual address as the key does not makes any sense at all. We need to use a
-    // global identifier here, e.g., something like the one used in the Linux implementation:
-    // <https://elixir.bootlin.com/linux/v6.17/source/kernel/futex/core.c#L533-L544>.
-    pub(self) fn new(addr: Vaddr, bitset: FutexBitSet, pid: Option<Pid>) -> Result<Self> {
+    pub(self) fn new(
+        addr: Vaddr,
+        bitset: FutexBitSet,
+        user_space: &CurrentUserSpace<'_>,
+        visibility: FutexVisibility,
+    ) -> Result<Self> {
         // "On all platforms, futexes are four-byte integers that must be aligned on a four-byte
         // boundary."
         // Reference: <https://man7.org/linux/man-pages/man2/futex.2.html>.
@@ -540,21 +587,103 @@ impl FutexKey {
             );
         }
 
-        // Use `jhash` to hash `addr` and `pid`.
-        let hash = {
-            let addr_low = addr as u32;
-            let addr_high = (addr >> 32) as u32;
-            // Choose a different jhash seed (or salt) for each process (unless the futex is shared)
-            // to prevent common key patterns from causing excessive collisions in the table.
-            let seed = pid.unwrap_or(u32::MAX);
-            jhash::jhash_2vals(addr_low, addr_high, seed) as usize
+        let identity = match visibility {
+            FutexVisibility::Private => FutexIdentity::Private {
+                vmar: user_space.vmar_snapshot(),
+                addr,
+            },
+            FutexVisibility::Shared => {
+                let backing = user_space
+                    .vmar()
+                    .query(addr..addr + 1)
+                    .iter()
+                    .next()
+                    .map(|mapping| mapping.futex_backing(addr))
+                    .transpose()?
+                    .flatten();
+
+                backing.map_or(
+                    FutexIdentity::SharedLocal {
+                        vmar: user_space.vmar_snapshot(),
+                        addr,
+                    },
+                    |(vmo, offset)| FutexIdentity::Shared { vmo, offset },
+                )
+            }
         };
 
-        Ok(Self { hash, bitset })
+        let hash = identity.hash();
+
+        Ok(Self {
+            hash,
+            identity,
+            bitset,
+        })
     }
 
     pub(self) fn match_up(&self, another: &Self) -> bool {
-        self.hash == another.hash && (self.bitset & another.bitset) != 0
+        self.identity.match_up(&another.identity) && (self.bitset & another.bitset) != 0
+    }
+}
+
+impl FutexIdentity {
+    fn hash(&self) -> usize {
+        // Use a distinct `initval` salt for each futex namespace so that
+        // `Private`, `SharedLocal`, and `Shared` keys do not collapse into the
+        // same buckets when their folded key material happens to match.
+        match self {
+            FutexIdentity::Private { vmar, addr } => {
+                let vmar_id = vmar.as_ptr() as u64;
+                let vmar_mix = (vmar_id as u32) ^ ((vmar_id >> 32) as u32).rotate_left(16);
+                jhash::jhash_3vals(*addr as u32, (*addr >> 32) as u32, vmar_mix, 0) as usize
+            }
+            FutexIdentity::SharedLocal { vmar, addr } => {
+                let vmar_id = vmar.as_ptr() as u64;
+                let vmar_mix = (vmar_id as u32) ^ ((vmar_id >> 32) as u32).rotate_left(16);
+                jhash::jhash_3vals(*addr as u32, (*addr >> 32) as u32, vmar_mix, 1) as usize
+            }
+            FutexIdentity::Shared { vmo, offset } => {
+                let vmo_id = Weak::as_ptr(vmo) as u64;
+                let vmo_mix = (vmo_id as u32) ^ ((vmo_id >> 32) as u32).rotate_left(16);
+                jhash::jhash_3vals(*offset as u32, (*offset >> 32) as u32, vmo_mix, 2) as usize
+            }
+        }
+    }
+
+    fn match_up(&self, another: &Self) -> bool {
+        match (self, another) {
+            (
+                FutexIdentity::Private {
+                    vmar: left_vmar,
+                    addr: left_addr,
+                },
+                FutexIdentity::Private {
+                    vmar: right_vmar,
+                    addr: right_addr,
+                },
+            )
+            | (
+                FutexIdentity::SharedLocal {
+                    vmar: left_vmar,
+                    addr: left_addr,
+                },
+                FutexIdentity::SharedLocal {
+                    vmar: right_vmar,
+                    addr: right_addr,
+                },
+            ) => left_addr == right_addr && left_vmar.ptr_eq(right_vmar),
+            (
+                FutexIdentity::Shared {
+                    vmo: left_vmo,
+                    offset: left_offset,
+                },
+                FutexIdentity::Shared {
+                    vmo: right_vmo,
+                    offset: right_offset,
+                },
+            ) => left_offset == right_offset && Weak::ptr_eq(left_vmo, right_vmo),
+            _ => false,
+        }
     }
 }
 

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -4,7 +4,12 @@
 
 use ostd::{mm::VmIo, task::Task};
 
-use crate::{current_userspace, prelude::*, process::posix_thread::futex::futex_wake, thread::Tid};
+use crate::{
+    current_userspace,
+    prelude::*,
+    process::posix_thread::futex::{FutexVisibility, futex_wake},
+    thread::Tid,
+};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
@@ -158,7 +163,7 @@ pub fn wake_robust_futex(futex_addr: Vaddr, tid: Tid) -> Result<()> {
                 // Wake up one waiter and break out from the loop.
                 if new_val & FUTEX_WAITERS != 0 {
                     debug!("wake the robust futex at {:#x}", futex_addr);
-                    futex_wake(futex_addr, 1, None)?;
+                    futex_wake(futex_addr, 1, FutexVisibility::Shared)?;
                 }
                 break;
             }

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -164,7 +164,26 @@ pub struct ProcessVmarGuard<'a> {
 // NOTE: Upgrading the `Weak<Vmar>` in the snapshot is not permitted,
 // as this will cause the `Vmar` to be dropped in the wrong context,
 // and break the reference count used in `CurrentUserSpace::is_vmar_shared`.
+#[derive(Debug, Clone)]
 pub struct VmarSnapshot(Weak<Vmar>);
+
+impl VmarSnapshot {
+    /// Returns the raw identity pointer of the captured `Vmar`.
+    pub fn as_ptr(&self) -> *const Vmar {
+        Weak::as_ptr(&self.0)
+    }
+
+    /// Returns whether two snapshots refer to the same `Vmar`.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Weak::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl From<Weak<Vmar>> for VmarSnapshot {
+    fn from(snapshot: Weak<Vmar>) -> Self {
+        Self(snapshot)
+    }
+}
 
 impl<'a> ProcessVmarGuard<'a> {
     /// Creates a new VMAR guard from the mutex guard.

--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -8,8 +8,8 @@ use crate::{
     current_userspace,
     prelude::*,
     process::posix_thread::futex::{
-        FutexFlags, FutexOp, futex_op_and_flags_from_u32, futex_requeue, futex_wait,
-        futex_wait_bitset, futex_wake, futex_wake_bitset, futex_wake_op,
+        FutexFlags, FutexOp, FutexVisibility, futex_op_and_flags_from_u32, futex_requeue,
+        futex_wait, futex_wait_bitset, futex_wake, futex_wake_bitset, futex_wake_op,
     },
     syscall::SyscallReturn,
     time::{
@@ -79,15 +79,11 @@ pub fn sys_futex(
         )))
     };
 
-    let pid = if futex_flags.contains(FutexFlags::FUTEX_PRIVATE) {
-        Some(ctx.process.pid())
-    } else {
-        None
-    };
+    let visibility = FutexVisibility::from(futex_flags);
     let res = match futex_op {
         FutexOp::FUTEX_WAIT => {
             let timeout = get_futex_timeout(utime_addr)?;
-            futex_wait(futex_addr as _, futex_val as _, timeout, ctx, pid).map(|_| 0)
+            futex_wait(futex_addr as _, futex_val as _, timeout, ctx, visibility).map(|_| 0)
         }
         FutexOp::FUTEX_WAIT_BITSET => {
             let timeout = get_futex_timeout(utime_addr)?;
@@ -97,17 +93,17 @@ pub fn sys_futex(
                 timeout,
                 bitset as _,
                 ctx,
-                pid,
+                visibility,
             )
             .map(|_| 0)
         }
         FutexOp::FUTEX_WAKE => {
             let max_count = futex_val_to_max_count(futex_val);
-            futex_wake(futex_addr as _, max_count, pid)
+            futex_wake(futex_addr as _, max_count, visibility)
         }
         FutexOp::FUTEX_WAKE_BITSET => {
             let max_count = futex_val_to_max_count(futex_val);
-            futex_wake_bitset(futex_addr as _, max_count, bitset as _, pid)
+            futex_wake_bitset(futex_addr as _, max_count, bitset as _, visibility)
         }
         FutexOp::FUTEX_REQUEUE => {
             let max_nwakes = futex_val_to_max_count(futex_val);
@@ -119,7 +115,8 @@ pub fn sys_futex(
                 max_nwakes,
                 max_nrequeues,
                 futex_new_addr as _,
-                pid,
+                ctx,
+                visibility,
             )
         }
         FutexOp::FUTEX_WAKE_OP => {
@@ -132,7 +129,7 @@ pub fn sys_futex(
                 futex_val_to_max_count(futex_val_2),
                 bitset,
                 ctx,
-                pid,
+                visibility,
             )
         }
         _ => {

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -171,6 +171,28 @@ impl VmMapping {
         }
     }
 
+    /// Returns the shared futex backing identity for the address if available.
+    pub fn futex_backing(&self, addr: Vaddr) -> Result<Option<(Weak<Vmo>, usize)>> {
+        if !self.is_shared {
+            return Ok(None);
+        }
+
+        let mapped_vmo = match &self.mapped_mem {
+            MappedMemory::Vmo(mapped_vmo) => mapped_vmo,
+            MappedMemory::Anonymous => return Ok(None),
+            MappedMemory::Device => {
+                return_errno_with_message!(
+                    Errno::EFAULT,
+                    "shared futexes on device mappings are not supported"
+                );
+            }
+        };
+
+        let offset = mapped_vmo.offset() + (addr - self.map_to_addr);
+
+        Ok(Some((Arc::downgrade(mapped_vmo.vmo()), offset)))
+    }
+
     /// Returns whether this mapping can be expanded.
     ///
     /// Device mappings cannot be expanded as they represent fixed-size MMIO

--- a/test/initramfs/src/apps/ipc/pipe/process_pipe_available.c
+++ b/test/initramfs/src/apps/ipc/pipe/process_pipe_available.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * This reproduces the JDK `ProcessPipeInputStream.processExited()` path on
+ * Unix. After the child exits, OpenJDK probes `available()` on the process
+ * pipe. Supporting `FIONREAD` on pipes avoids the fallback path that would
+ * otherwise probe seekability with `lseek(fd, 0, SEEK_CUR)`.
+ */
+FN_TEST(process_pipe_available_probe)
+{
+	int fildes[2];
+	char buf[4] = { 0 };
+	struct stat stat_buf;
+
+	TEST_SUCC(pipe(fildes));
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(fildes[0]));
+		CHECK_WITH(write(fildes[1], "abc", 3), _ret == 3);
+		_exit(0);
+	}
+
+	TEST_SUCC(close(fildes[1]));
+	TEST_RES(waitpid(pid, NULL, 0), _ret == pid);
+
+	TEST_RES(fstat(fildes[0], &stat_buf), S_ISFIFO(stat_buf.st_mode));
+
+	int pending = -1;
+	TEST_RES(ioctl(fildes[0], FIONREAD, &pending), pending == 3);
+	TEST_ERRNO(lseek(fildes[0], 0, SEEK_CUR), ESPIPE);
+
+	TEST_RES(read(fildes[0], buf, sizeof(buf)),
+		 _ret == 3 && memcmp(buf, "abc", 3) == 0);
+
+	TEST_SUCC(close(fildes[0]));
+}
+END_TEST()

--- a/test/initramfs/src/apps/ipc/run_test.sh
+++ b/test/initramfs/src/apps/ipc/run_test.sh
@@ -5,6 +5,7 @@
 set -e
 
 ./pipe/pipe_err
+./pipe/process_pipe_available
 ./pipe/short_rw
 
 ./shm/posix_shm

--- a/test/initramfs/src/syscall/gvisor/blocklists/futex_test
+++ b/test/initramfs/src/syscall/gvisor/blocklists/futex_test
@@ -1,10 +1,4 @@
-# PrivateFutexTest needs FUTEX_WAKE_OP
-PrivateFutexTest.*
 RobustFutexTest.*
-SharedFutexTest.WakeInterprocessFile_NoRandomSave
-
-SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon/0
-SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon_NoRandomSave/*
 
 SharedPrivate/PrivateAndSharedFutexTest.PIBasic/*
 SharedPrivate/PrivateAndSharedFutexTest.PIConcurrency/0
@@ -13,8 +7,5 @@ SharedPrivate/PrivateAndSharedFutexTest.PIConcurrency_NoRandomSave/*
 SharedPrivate/PrivateAndSharedFutexTest.PIWaiters/*
 SharedPrivate/PrivateAndSharedFutexTest.PITryLock/*
 SharedPrivate/PrivateAndSharedFutexTest.PITryLockConcurrency_NoRandomSave/*
-# WakeAll_NoRandomSave/* encounters a segmentation fault
-SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/0
-SharedPrivate/PrivateAndSharedFutexTest.WakeAll_NoRandomSave/1
 # WakeAfterCOWBreak_NoRandomSave/* hangs sometimes
 SharedPrivate/PrivateAndSharedFutexTest.WakeAfterCOWBreak_NoRandomSave/0

--- a/test/initramfs/src/syscall/ltp/testcases/all.txt
+++ b/test/initramfs/src/syscall/ltp/testcases/all.txt
@@ -1847,15 +1847,15 @@ writev06
 # futex_cmp_requeue02
 futex_wait01
 futex_wait02
-# futex_wait03
+futex_wait03
 futex_wait04
 # futex_wait05
 # futex_waitv01
 # futex_waitv02
 # futex_waitv03
 futex_wake01
-# futex_wake02
-# futex_wake03
+futex_wake02
+futex_wake03
 # futex_wake04
 futex_wait_bitset01
 


### PR DESCRIPTION
## Summary

This PR fixes two issues exposed by running a small Java reproducer on Asterinas NixOS:

1. `FileInputStream.available()` on a pipe could fail with `Illegal seek`.
2. After fixing the pipe issue, the Java process could still hang in `Process.waitFor()` and never exit.

The fixes are split into two commits on purpose:

- the first commit fixes `FIONREAD` on pipe handles and removes the `Illegal seek` failure;
- the second commit fixes `futex_wake` matching across address spaces and removes the remaining hang.

Together they make the reproducer complete successfully.

## Bug Reproducer

The following Java program reproduces the problem. It starts a child Java process, reads its combined stdout/stderr through a pipe, and then waits for the child to exit.

```java
import java.io.BufferedReader;
import java.io.InputStreamReader;
import java.io.IOException;

public class GetJdkProps {
    public static void main(String[] args) throws Exception {
        String jdkHome = System.getenv("JAVA_HOME");
        if (jdkHome == null || jdkHome.isEmpty()) {
            System.err.println("JAVA_HOME is not set.");
            return;
        }

        String javaCmd = jdkHome + "/bin/java";
        ProcessBuilder pb = new ProcessBuilder(
                javaCmd,
                "-XshowSettings:properties",
                "-version"
        );
        pb.redirectErrorStream(true);

        Process p = pb.start();

        try (BufferedReader br = new BufferedReader(
                new InputStreamReader(p.getInputStream()))) {
            String line;
            while ((line = br.readLine()) != null) {
                System.out.println(line);
            }
        }

        int exitCode = p.waitFor();
        System.out.println("Exit code: " + exitCode);
    }
}
```

This can be reproduced in the NixOS environment as follows.

If Java is not already enabled in the NixOS image, add the following option to `distro/etc_nixos/configuration.nix`:

```nix
programs.java.enable = true;
```

Then build and run NixOS:

```bash
make nixos
make run_nixos
```

Inside the NixOS shell, save the program above as `GetJdkProps.java`, then run:

```bash
javac GetJdkProps.java
java GetJdkProps
```

## Behavior Before and After Each Commit

### Without either commit

Running `java GetJdkProps` fails with:

```text
Exception in thread "main" java.io.IOException: Illegal seek
```

This happens while OpenJDK is reading the child process output pipe.

### With only the first commit

After applying the first commit, the `Illegal seek` error is gone and the child Java process output can be read successfully.

However, the reproducer still does not finish: it prints the child output, and then hangs instead of returning from `waitFor()`.

### With both commits

After additionally applying the second commit, the reproducer completes normally.

## Root Cause

This issue turned out to have two independent parts.

### 1. Pipe `FIONREAD` support was missing

OpenJDK probes process pipes via `available()`. On Unix, this path expects `FIONREAD` to work on pipe file descriptors.

Before the first commit, pipe handles did not implement this ioctl, so OpenJDK fell back to probing seekability and hit `lseek(..., SEEK_CUR)` on a pipe, which correctly returns `ESPIPE`. That surfaced in Java as `java.io.IOException: Illegal seek`.

The first commit fixes this by implementing `FIONREAD` for pipe handles and returning the current readable byte count from the pipe buffer.

### 2. Futex wakeups were not matched correctly across address spaces

After the pipe issue was fixed, the reproducer still hung while waiting for the child process to exit.

The remaining problem was in futex keying and wake matching. The old logic relied on a hash derived from virtual address and process-local information, which is insufficient for correct matching once different address spaces or shared mappings are involved. In particular, `clear_child_tid` wakeups need to wake the waiter in the right futex namespace rather than anything that happens to collide by hash.

The second commit fixes this by:

- distinguishing private and shared futex namespaces explicitly with `FutexIdentity`;
- comparing futex identity directly during wake matching instead of comparing only hashes;

This makes the `clear_child_tid` wake target the correct waiter, so `waitFor()` can return normally.
