### PR TITLE
Enable `qemu-direct` support for `linux-efi-*` boot protocols

### DIFF
--- a/.github/workflows/benchmark_x86.yml
+++ b/.github/workflows/benchmark_x86.yml
@@ -107,7 +107,7 @@ jobs:
       max-parallel: 1
     timeout-minutes: 60
     container: 
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
 
     steps:

--- a/.github/workflows/benchmark_x86_tdx.yml
+++ b/.github/workflows/benchmark_x86_tdx.yml
@@ -108,7 +108,7 @@ jobs:
       max-parallel: 1
     timeout-minutes: 60
     container: 
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
 
     steps:

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -20,7 +20,7 @@ jobs:
   check_api_docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.17.1-20260317
+    container: asterinas/asterinas:0.17.1-20260319
 
     steps: 
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -12,7 +12,7 @@ jobs:
   push-cachix:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:
@@ -93,7 +93,7 @@ jobs:
       - name: Build ISO
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: asterinas/asterinas:0.17.1-20260317
+          image: asterinas/asterinas:0.17.1-20260319
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
             export ASTER_BUILD_TIMESTAMP=`date '+%a %b %e %H:%M:%S %Z %Y'`

--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: asterinas/asterinas:0.17.1-20260317
+    container: asterinas/asterinas:0.17.1-20260319
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_sctrace.yml
+++ b/.github/workflows/publish_sctrace.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: asterinas/asterinas:0.17.1-20260317
+    container: asterinas/asterinas:0.17.1-20260319
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -17,7 +17,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: asterinas/asterinas:0.17.1-20260317
+    container: asterinas/asterinas:0.17.1-20260319
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/push_cachix_dev.yml
+++ b/.github/workflows/push_cachix_dev.yml
@@ -17,7 +17,7 @@ jobs:
   push-pkgs:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_asterinas_vsock.yml
+++ b/.github/workflows/test_asterinas_vsock.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             docker run \
               --privileged --network=host --device=/dev/kvm \
-              -v ./:/root/asterinas asterinas/asterinas:0.17.1-20260317 \
+              -v ./:/root/asterinas asterinas/asterinas:0.17.1-20260319 \
               make run_kernel AUTO_TEST=vsock ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1 &
       - name: Run Vsock Client on Host
         id: host_vsock_client

--- a/.github/workflows/test_iso_image.yml
+++ b/.github/workflows/test_iso_image.yml
@@ -19,7 +19,7 @@ jobs:
   iso-test:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_loongarch.yml
+++ b/.github/workflows/test_loongarch.yml
@@ -11,7 +11,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
     strategy:
       matrix:

--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -26,7 +26,7 @@ jobs:
   full-nixos-test:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: -v /dev:/dev --privileged
     
     strategy:

--- a/.github/workflows/test_nixos_minimal.yml
+++ b/.github/workflows/test_nixos_minimal.yml
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 30
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: asterinas/asterinas:0.17.1-20260317
+          image: asterinas/asterinas:0.17.1-20260319
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
             make nixos NIXOS_TEST_SUITE=hello NIXOS_DISK_SIZE_IN_MB=6144

--- a/.github/workflows/test_riscv.yml
+++ b/.github/workflows/test_riscv.yml
@@ -11,7 +11,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -38,7 +38,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
       volumes:
         # Map the following directories on the host into the container so that

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -11,7 +11,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -38,7 +38,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['asterinas/asterinas:0.17.1-20260317', 'asterinas/osdk:0.17.1-20260317']
+        image: ['asterinas/asterinas:0.17.1-20260319', 'asterinas/osdk:0.17.1-20260319']
       fail-fast: false
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/test_x86_tdx.yml
+++ b/.github/workflows/test_x86_tdx.yml
@@ -10,7 +10,7 @@ jobs:
   integration-test:
     runs-on: self-hosted
     container:
-      image: asterinas/asterinas:0.17.1-20260317
+      image: asterinas/asterinas:0.17.1-20260319
       options: --device=/dev/kvm --privileged
     strategy:
       matrix:
@@ -58,7 +58,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        image: ['asterinas/asterinas:0.17.1-20260317', 'asterinas/osdk:0.17.1-20260317']
+        image: ['asterinas/asterinas:0.17.1-20260319', 'asterinas/osdk:0.17.1-20260319']
       fail-fast: false
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/validate_scmls.yml
+++ b/.github/workflows/validate_scmls.yml
@@ -19,7 +19,7 @@ jobs:
   validate_scmls:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: asterinas/asterinas:0.17.1-20260317
+    container: asterinas/asterinas:0.17.1-20260319
     steps:
       - uses: actions/checkout@v4
       - name: Validate SCML files with sctrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ All development is done inside the project Docker container:
 ```bash
 docker run -it --privileged --network=host --device=/dev/kvm -v /dev:/dev \
   -v $(pwd)/asterinas:/root/asterinas \
-  asterinas/asterinas:0.17.1-20260317
+  asterinas/asterinas:0.17.1-20260319
 ```
 
 Key Makefile targets:

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,10 @@ endif
 
 ifeq ($(BOOT_PROTOCOL), multiboot)
 BOOT_METHOD = qemu-direct
-OVMF = off
+endif
+
+ifeq ($(SCHEME), microvm)
+BOOT_METHOD = qemu-direct
 endif
 
 ifeq ($(SCHEME), "")

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,6 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/benchmark/common/bench_runner.sh $(BENCHM
 endif
 
 ifeq ($(INTEL_TDX), 1)
-BOOT_METHOD = grub-qcow2
 BOOT_PROTOCOL = linux-efi-handover64
 CARGO_OSDK_COMMON_ARGS += --scheme tdx
 endif

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Follow the steps below to get Asterinas up and running.
 2. Run a Docker container as the development environment:
 
     ```bash
-    docker run -it --privileged --network=host -v /dev:/dev -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.17.1-20260317
+    docker run -it --privileged --network=host -v /dev:/dev -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.17.1-20260319
     ```
 
 3. Inside the container,

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -78,7 +78,7 @@ since `distro/README.md` references them -->
                 --network=host \
                 -v /dev:/dev \
                 -v $(pwd)/asterinas:/root/asterinas \
-                asterinas/asterinas:0.17.1-20260317
+                asterinas/asterinas:0.17.1-20260319
     ```
 
 3. Inside the container, go to the project folder to build and run Asterinas.

--- a/book/src/kernel/intel-tdx.md
+++ b/book/src/kernel/intel-tdx.md
@@ -66,7 +66,7 @@ The following result is an example:
 2. Run a Docker container as the development environment.
 
     ```bash
-    docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.17.1-20260317
+    docker run -it --privileged --network=host --device=/dev/kvm -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.17.1-20260319
     ```
     
 3. Inside the container,

--- a/book/src/osdk/guide/intel-tdx.md
+++ b/book/src/osdk/guide/intel-tdx.md
@@ -32,7 +32,7 @@ Therefore, it is recommended to use a Docker image to deploy the environment.
 Run a TDX Docker container:
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kvm asterinas/osdk:0.17.1-20260317
+docker run -it --privileged --network=host --device=/dev/kvm asterinas/osdk:0.17.1-20260319
 ```
 
 ## Edit `OSDK.toml` for Intel TDX support

--- a/osdk/src/bundle/bin.rs
+++ b/osdk/src/bundle/bin.rs
@@ -91,6 +91,10 @@ impl AsterBin {
         self.stripped
     }
 
+    pub fn typ(&self) -> &AsterBinType {
+        &self.typ
+    }
+
     /// Copy the binary to the `base` directory and convert the path to a relative path.
     pub fn copy_to(self, base: impl AsRef<Path>) -> Self {
         let file_name = self.path.file_name().unwrap();

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -4,7 +4,7 @@ pub mod bin;
 pub mod file;
 pub mod vm_image;
 
-use bin::AsterBin;
+use bin::{AsterBin, AsterBinType};
 use file::{BundleFile, Initramfs};
 use std::{
     io::{BufRead, BufReader, Write},
@@ -24,7 +24,7 @@ use crate::{
     arch::Arch,
     config::{
         Config,
-        scheme::{ActionChoice, BootMethod},
+        scheme::{ActionChoice, BootMethod, BootProtocol},
     },
     error::Errno,
     error_msg,
@@ -148,6 +148,19 @@ impl Bundle {
                 if self.manifest.aster_bin.is_none() {
                     return Err("Kernel binary is required for direct QEMU booting".to_owned());
                 };
+
+                // Validate the kernel binary type against the configured boot protocol.
+                // This prevents reusing an incompatible binary (e.g. ELF vs. `bzImage`) when
+                // switching boot methods (for example, from a Grub ISO to `qemu-direct`),
+                // which would otherwise cause boot failures.
+                let aster_bin_type = self.manifest.aster_bin.as_ref().unwrap().typ();
+                let expects_linux = matches!(aster_bin_type, AsterBinType::BzImage(_));
+                let actual_linux = config_action.grub.boot_protocol == BootProtocol::Linux;
+                if expects_linux != actual_linux {
+                    return Err(
+                        "The boot protocol is not compatible with the kernel binary".to_owned()
+                    );
+                }
             }
             BootMethod::GrubRescueIso => {
                 let Some(ref vm_image) = self.manifest.vm_image else {

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::SystemTime,
 };
 
-use bin::make_elf_for_qemu;
+use bin::{make_elf_for_qemu, make_install_bzimage};
 
 use super::util::{COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH, cargo, profile_name_adapter};
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
     cli::BuildArgs,
     config::{
         Config,
-        scheme::{ActionChoice, BootMethod},
+        scheme::{ActionChoice, BootMethod, BootProtocol},
     },
     error::Errno,
     error_msg,
@@ -132,9 +132,9 @@ pub fn do_cached_build(
     action: ActionChoice,
     rustflags: &[&str],
 ) -> Bundle {
-    let (build, boot) = match action {
-        ActionChoice::Run => (&config.run.build, &config.run.boot),
-        ActionChoice::Test => (&config.test.build, &config.test.boot),
+    let (build, boot, grub) = match action {
+        ActionChoice::Run => (&config.run.build, &config.run.boot, &config.run.grub),
+        ActionChoice::Test => (&config.test.build, &config.test.boot, &config.test.grub),
     };
 
     let mut rustflags = rustflags.to_vec();
@@ -183,8 +183,17 @@ pub fn do_cached_build(
             bundle.consume_aster_bin(aster_elf);
         }
         BootMethod::QemuDirect => {
-            let qemu_elf = make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf);
-            bundle.consume_aster_bin(qemu_elf);
+            let aster_bin = match grub.boot_protocol {
+                BootProtocol::Linux => make_install_bzimage(
+                    &osdk_output_directory,
+                    &osdk_output_directory,
+                    &aster_elf,
+                    build.linux_x86_legacy_boot,
+                    config.build.encoding.clone(),
+                ),
+                _ => make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf),
+            };
+            bundle.consume_aster_bin(aster_bin);
         }
     }
 

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -165,6 +165,14 @@ if [ "$BOOT_METHOD" = "qemu-direct" ]; then
     fi
 fi
 
+# When using `grub-rescue-iso` or `grub-qcow2` boot, OVMF must be enabled.
+# Currently, the project's `grub-mkrescue` (in container image) only contained
+# `x86_64-efi` platform modules — no `i386-pc`. This meant the generated ISO/qcow2
+# could only be loaded by OVMF.
+if [ "$BOOT_METHOD" = "grub-rescue-iso" ] || [ "$BOOT_METHOD" = "grub-qcow2" ]; then
+    OVMF="on"
+fi
+
 if [ "$OVMF" = "on" ]; then
     if [ "$1" = "microvm" ]; then
         QEMU_ARGS="${QEMU_ARGS} \

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -7,7 +7,8 @@
 #  - scheme: "normal", "test", "microvm" or "iommu";
 # Other arguments are configured via environmental variables:
 #  - OVMF: "on" or "off";
-#  - BOOT_METHOD: "qemu-direct", "grub-rescue-iso", "linux-efi-pe64" or "linux-efi-handover64";
+#  - BOOT_METHOD: "qemu-direct", "grub-rescue-iso" or "grub-qcow2";
+#  - BOOT_PROTOCOL: "multiboot", "multiboot2", "linux-legacy32", "linux-efi-pe64" or "linux-efi-handover64";
 #  - NETDEV: "user" or "tap";
 #  - VHOST: "off" or "on";
 #  - VSOCK: "off" or "on";
@@ -113,62 +114,65 @@ if [ "$1" = "iommu" ]; then
     # TODO: Add support for enabling IOMMU on AMD platforms
 fi
 
-QEMU_ARGS="\
-    $COMMON_QEMU_ARGS \
-    -machine q35,kernel-irqchip=split \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
-    -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
-    -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
-    $CONSOLE_ARGS \
-    $IOMMU_EXTRA_ARGS \
-"
-
-MICROVM_QEMU_ARGS="\
-    $COMMON_QEMU_ARGS \
-    -machine microvm,rtc=on \
-    -nodefaults \
-    -no-user-config \
-    -device virtio-blk-device,drive=x0,serial=vext2 \
-    -device virtio-blk-device,drive=x1,serial=vexfat \
-    -device virtio-keyboard-device \
-    -device virtio-net-device,netdev=net01 \
-    -device virtio-serial-device \
-    $CONSOLE_ARGS \
-"
+if [ "$1" = "microvm" ]; then
+    QEMU_ARGS="\
+        $COMMON_QEMU_ARGS \
+        -machine microvm,rtc=on \
+        -nodefaults \
+        -no-user-config \
+        -device virtio-blk-device,drive=x0,serial=vext2 \
+        -device virtio-blk-device,drive=x1,serial=vexfat \
+        -device virtio-keyboard-device \
+        -device virtio-net-device,netdev=net01 \
+        -device virtio-serial-device \
+        $CONSOLE_ARGS \
+    "
+else
+    QEMU_ARGS="\
+        $COMMON_QEMU_ARGS \
+        -machine q35,kernel-irqchip=split \
+        -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
+        -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
+        $CONSOLE_ARGS \
+        $IOMMU_EXTRA_ARGS \
+    "
+fi
 
 if [ "$VSOCK" = "on" ]; then
     # RAND_CID=$(shuf -i 3-65535 -n 1)
     RAND_CID=3
     echo "[$1] Launched QEMU VM with CID $RAND_CID" 1>&2
     if [ "$1" = "microvm" ]; then
-        MICROVM_QEMU_ARGS="
-            $MICROVM_QEMU_ARGS \
+        QEMU_ARGS="$QEMU_ARGS \
             -device vhost-vsock-device,guest-cid=$RAND_CID \
         "
     else
-        QEMU_ARGS="
-            $QEMU_ARGS \
+        QEMU_ARGS="$QEMU_ARGS \
             -device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=$RAND_CID,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
         "
     fi
 fi
 
-
-if [ "$1" = "microvm" ]; then
-    QEMU_ARGS=$MICROVM_QEMU_ARGS
-    echo $QEMU_ARGS
-    exit 0
+# When using qemu-direct boot, OVMF depends on the boot protocol:
+# linux-efi-* protocols require OVMF; other protocols (e.g. multiboot) do not.
+if [ "$BOOT_METHOD" = "qemu-direct" ]; then
+    if [ "$BOOT_PROTOCOL" = "linux-efi-pe64" ] || [ "$BOOT_PROTOCOL" = "linux-efi-handover64" ]; then
+        OVMF="on"
+    else
+        OVMF="off"
+    fi
 fi
 
 if [ "$OVMF" = "on" ]; then
-    if [ "$BOOT_METHOD" = "qemu-direct" ]; then
-        echo "QEMU direct boot is not compatible with OVMF, ignoring OVMF" 1>&2
-    else
-        OVMF_PATH="/root/ovmf/release"
+    if [ "$1" = "microvm" ]; then
         QEMU_ARGS="${QEMU_ARGS} \
-            -drive if=pflash,format=raw,unit=0,readonly=on,file=$OVMF_PATH/OVMF_CODE.fd \
-            -drive if=pflash,format=raw,unit=1,file=$OVMF_PATH/OVMF_VARS.fd \
+            -bios /root/ovmf/release/microvm/MICROVM.fd \
+        "
+    else
+        QEMU_ARGS="${QEMU_ARGS} \
+            -bios /root/ovmf/release/OVMF.fd \
         "
     fi
 fi


### PR DESCRIPTION
This PR re-applies the changes originally introduced in #3019 and adds OVMF when using `linux-efi-*` boot protocols with `qemu-direct` boot method.