### PR TITLE
Support `PTRACE_SETOPTIONS`

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
@@ -98,11 +98,14 @@ Supported requests:
 * `PTRACE_SINGLESTEP` (x86-64 only)
 * `PTRACE_GETREGS` (x86-64 only)
 * `PTRACE_SETREGS` (x86-64 only)
+* `PTRACE_SETOPTIONS`
+* `PTRACE_GETEVENTMSG`
 * `PTRACE_GETSIGINFO`
 
-Additional limitations:
-* Only the main thread of a process can act as the tracer
-* `PTRACE_PEEKUSER` and `PTRACE_POKEUSER` only support offsets for general-purpose registers
+Limitations:
+* Only the main thread of a process can act as the tracer.
+* `PTRACE_PEEKUSER` and `PTRACE_POKEUSER` only support offsets for general-purpose registers.
+* If a tracee has clone-family options (`PTRACE_O_TRACEFORK`, `PTRACE_O_TRACEVFORK`, `PTRACE_O_TRACEVFORKDONE`, or `PTRACE_O_TRACECLONE`) and then performs a clone-family operation that would trigger a ptrace event, the clone-family operation returns `EOPNOTSUPP`.
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/ptrace.2.html).

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
@@ -22,5 +22,11 @@ ptrace(request = PTRACE_GETREGS, tid, addr, data);
 // Set tracee general-purpose registers
 ptrace(request = PTRACE_SETREGS, tid, addr, data);
 
+// Set the ptrace options of a tracee
+ptrace(request = PTRACE_SETOPTIONS, tid, addr, data);
+
+// Get the message associated with the current ptrace-event-stop
+ptrace(request = PTRACE_GETEVENTMSG, tid, addr, data);
+
 // Get the siginfo associated with the current ptrace-stop
 ptrace(request = PTRACE_GETSIGINFO, tid, addr, data);

--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -23,16 +23,16 @@ use crate::{
 /// The context that can be accessed from the current POSIX thread.
 #[derive(Clone)]
 pub struct Context<'a> {
-    pub process: Arc<Process>,
-    pub thread_local: &'a ThreadLocal,
-    pub posix_thread: &'a PosixThread,
-    pub thread: &'a Thread,
+    pub(crate) process: Arc<Process>,
+    pub(crate) thread_local: &'a ThreadLocal,
+    pub(crate) posix_thread: &'a PosixThread,
+    pub(crate) thread: &'a Thread,
     pub task: &'a Task,
 }
 
 impl Context<'_> {
     /// Gets the userspace of the current task.
-    pub fn user_space(&self) -> CurrentUserSpace<'_> {
+    pub(crate) fn user_space(&self) -> CurrentUserSpace<'_> {
         CurrentUserSpace(self.thread_local.vmar().borrow())
     }
 }

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -236,6 +236,16 @@ impl CloneArgs {
             );
         }
 
+        // TODO: Support clone-family ptrace events and remove this check.
+        if !clone_flags.contains(CloneFlags::CLONE_UNTRACED)
+            && ctx.posix_thread.needs_ptrace_clone_stop(self)
+        {
+            return_errno_with_message!(
+                Errno::EOPNOTSUPP,
+                "ptrace clone events are not supported currently"
+            );
+        }
+
         Ok(())
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -18,14 +18,15 @@ use crate::{
     process::{
         ContextUnshareAdminApi, Credentials, Process, pid_table,
         posix_thread::{
-            AsPosixThread, ContextPthreadAdminApi, ThreadLocal, ThreadName, sigkill_other_threads,
+            AsPosixThread, ContextPthreadAdminApi, ThreadLocal, ThreadName, ptrace::PtraceEvent,
+            sigkill_other_threads,
         },
         process_vm::{MAX_LEN_STRING_ARG, MAX_NR_STRING_ARGS, ProcessVm},
         program_loader::{ProgramToLoad, elf::ElfLoadInfo},
         signal::{
             HandlePendingSignal, PauseReason, SigStack,
-            constants::{SIGCHLD, SIGKILL, SIGTRAP},
-            signals::{kernel::KernelSignal, user::UserSignal},
+            constants::{SIGCHLD, SIGKILL},
+            signals::kernel::KernelSignal,
         },
     },
     vm::vmar::Vmar,
@@ -77,6 +78,8 @@ pub fn do_execve(
     sigkill_other_threads(ctx.task, &task_set);
     drop(task_set);
 
+    let former_tid = ctx.posix_thread.tid();
+
     // After this point, failures in subsequent operations are fatal: the process
     // state may be left inconsistent and it can never return to user mode.
 
@@ -89,20 +92,12 @@ pub fn do_execve(
         &elf_load_info,
     );
 
-    if res.is_err() {
+    if res.is_ok() {
+        ctx.posix_thread
+            .ptrace_may_stop_on(PtraceEvent::Exec(former_tid), ctx, user_context);
+    } else {
         ctx.posix_thread
             .enqueue_signal(Box::new(KernelSignal::new(SIGKILL)));
-    } else {
-        // If the PTRACE_O_TRACEEXEC option is not in effect, all successful
-        // calls to execve(2) by the traced process will cause it to be sent
-        // a SIGTRAP signal, giving the parent a chance to gain control
-        // before the new program begins execution.
-        //
-        // Reference: <https://man7.org/linux/man-pages/man2/ptrace.2.html>
-        if ctx.posix_thread.is_traced() {
-            ctx.posix_thread
-                .enqueue_signal(Box::new(UserSignal::new_kill(SIGTRAP, ctx)));
-        }
     }
 
     ctx.process.tasks().lock().finish_execve();

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{mm::VmIo, task::Task};
+use ostd::{arch::cpu::context::UserContext, mm::VmIo, task::Task};
 
 use super::{
     AsPosixThread, AsThreadLocal, ThreadLocal,
@@ -25,8 +25,8 @@ use crate::{
 /// # Panics
 ///
 /// If the current thread is not a POSIX thread, this method will panic.
-pub fn do_exit(term_status: TermStatus) {
-    exit_internal(term_status, false);
+pub fn do_exit(term_status: TermStatus, ctx: &Context, user_ctx: &mut UserContext) {
+    exit_internal(term_status, false, ctx, user_ctx);
 }
 
 /// Kills all threads and exits the current POSIX process.
@@ -34,12 +34,17 @@ pub fn do_exit(term_status: TermStatus) {
 /// # Panics
 ///
 /// If the current thread is not a POSIX thread, this method will panic.
-pub fn do_exit_group(term_status: TermStatus) {
-    exit_internal(term_status, true);
+pub fn do_exit_group(term_status: TermStatus, ctx: &Context, user_ctx: &mut UserContext) {
+    exit_internal(term_status, true, ctx, user_ctx);
 }
 
 /// Exits the current POSIX thread or process.
-fn exit_internal(term_status: TermStatus, is_exiting_group: bool) {
+fn exit_internal(
+    term_status: TermStatus,
+    is_exiting_group: bool,
+    ctx: &Context,
+    user_ctx: &mut UserContext,
+) {
     let exit_code = term_status.as_u32();
 
     let current_task = Task::current().unwrap();

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -5,6 +5,7 @@ use ostd::{arch::cpu::context::UserContext, mm::VmIo, task::Task};
 use super::{
     AsPosixThread, AsThreadLocal, ThreadLocal,
     futex::{FutexVisibility, futex_wake},
+    ptrace::PtraceEvent,
     robust_list::wake_robust_futex,
 };
 use crate::{
@@ -39,6 +40,10 @@ pub fn do_exit_group(term_status: TermStatus, ctx: &Context, user_ctx: &mut User
 }
 
 /// Exits the current POSIX thread or process.
+//
+// A mutable reference to `user_ctx` is needed because exiting a traced thread
+// may trigger a "exit" ptrace-event-stop, which snapshots the current user
+// register state and may later restore tracer-updated registers.
 fn exit_internal(
     term_status: TermStatus,
     is_exiting_group: bool,
@@ -46,6 +51,8 @@ fn exit_internal(
     user_ctx: &mut UserContext,
 ) {
     let exit_code = term_status.as_u32();
+    ctx.posix_thread
+        .ptrace_may_stop_on(PtraceEvent::Exit(exit_code), ctx, user_ctx);
 
     let current_task = Task::current().unwrap();
     let current_thread = current_task.as_thread().unwrap();

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -18,8 +18,7 @@ use crate::{
         signal::{
             DequeuedSignal, PauseReason,
             c_types::siginfo_t,
-            constants::{CLD_TRAPPED, SIGCHLD, SIGKILL},
-            sig_num::SigNum,
+            constants::{CLD_TRAPPED, SIGCHLD, SIGKILL, SIGTRAP},
             signals::{kernel::KernelSignal, raw::RawSignal, user::UserSignal},
         },
     },
@@ -29,7 +28,7 @@ use crate::{
 mod util;
 
 use util::StopDeliverySignal;
-pub use util::{PtraceContRequest, PtraceOptions};
+pub use util::{PtraceContRequest, PtraceOptions, PtraceWaitStatus};
 pub(in crate::process) use util::{PtraceEvent, PtraceStopResult};
 
 impl PosixThread {
@@ -85,8 +84,27 @@ impl PosixThread {
         }
     }
 
+    /// Stops this thread by ptrace on the `event` if it is currently traced,
+    /// and the corresponding option is enabled.
+    ///
+    /// May block in the event-stop until the tracer continues the stop,
+    /// or until a `SIGKILL` interrupts it.
+    pub(in crate::process) fn ptrace_may_stop_on(
+        &self,
+        event: PtraceEvent,
+        ctx: &Context,
+        user_ctx: &mut UserContext,
+    ) {
+        if let Some(status) = self.tracee_status.get() {
+            status.ptrace_may_stop_on(event, ctx, user_ctx)
+        }
+    }
+
     /// Returns the ptrace-stop status changes for the `wait` syscall.
-    pub(in crate::process) fn wait_ptrace_stopped(&self, options: WaitOptions) -> Option<SigNum> {
+    pub(in crate::process) fn wait_ptrace_stopped(
+        &self,
+        options: WaitOptions,
+    ) -> Option<PtraceWaitStatus> {
         self.tracee_status
             .get()
             .and_then(|status| status.wait(options))
@@ -331,16 +349,60 @@ impl TraceeStatus {
         let _ = user_ctx;
 
         // Hold the lock first to avoid race conditions.
-        let mut state = self.state.lock();
+        let state = self.state.lock();
 
         let Some(tracer) = state.tracer() else {
             return PtraceStopResult::NotTraced(signal);
         };
 
+        self.do_ptrace_stop(state, tracer, signal, None, ctx, user_ctx)
+    }
+
+    fn ptrace_may_stop_on(&self, event: PtraceEvent, ctx: &Context, user_ctx: &mut UserContext) {
+        // Hold the lock first to avoid race conditions.
+        let state = self.state.lock();
+
+        let Some(tracer) = state.tracer() else {
+            return;
+        };
+
+        if !state.options.contains(event.option()) {
+            // If the PTRACE_O_TRACEEXEC option is not in effect, all successful
+            // calls to execve(2) by the traced process will cause it to be sent
+            // a SIGTRAP signal, giving the parent a chance to gain control
+            // before the new program begins execution.
+            //
+            // Reference: <https://man7.org/linux/man-pages/man2/ptrace.2.html>
+            if matches!(&event, PtraceEvent::Exec(_)) {
+                ctx.posix_thread
+                    .enqueue_signal(Box::new(UserSignal::new_kill(SIGTRAP, ctx)));
+            }
+            return;
+        }
+
+        let siginfo = event.siginfo(ctx);
+        let signal = Box::new(RawSignal::new(siginfo));
+        let signal = DequeuedSignal::FromThread(signal);
+
+        self.do_ptrace_stop(state, tracer, signal, Some(event), ctx, user_ctx);
+    }
+
+    fn do_ptrace_stop(
+        &self,
+        mut state: MutexGuard<'_, TraceeState>,
+        tracer: Arc<Thread>,
+        signal: DequeuedSignal,
+        event: Option<PtraceEvent>,
+        ctx: &Context,
+        user_ctx: &mut UserContext,
+    ) -> PtraceStopResult {
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = user_ctx;
+
         debug_assert!(!self.is_ptrace_stopped());
 
         state.signal.stop(signal);
-        state.event = None;
+        state.event = event;
         #[cfg(target_arch = "x86_64")]
         {
             state.general_regs = Some(*user_ctx.general_regs());
@@ -406,7 +468,7 @@ impl TraceeStatus {
         }
     }
 
-    fn wait(&self, options: WaitOptions) -> Option<SigNum> {
+    fn wait(&self, options: WaitOptions) -> Option<PtraceWaitStatus> {
         // Hold the lock first to avoid race conditions.
         let mut state = self.state.lock();
 
@@ -415,8 +477,11 @@ impl TraceeStatus {
             return None;
         }
 
+        let event_status = state.event.as_ref().map(PtraceWaitStatus::from_event);
         let signal = state.signal.wait(options)?;
-        Some(signal.num())
+        let status = event_status.unwrap_or_else(|| PtraceWaitStatus::from_signal(signal.num()));
+
+        Some(status)
     }
 
     fn resume(&self, request: PtraceContRequest, ctx: &Context) -> Result<()> {

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -28,9 +28,9 @@ use crate::{
 
 mod util;
 
-pub use util::PtraceContRequest;
-pub(in crate::process) use util::PtraceStopResult;
 use util::StopDeliverySignal;
+pub use util::{PtraceContRequest, PtraceOptions};
+pub(in crate::process) use util::{PtraceEvent, PtraceStopResult};
 
 impl PosixThread {
     /// Returns whether this thread is being traced.
@@ -140,6 +140,27 @@ impl PosixThread {
     pub fn ptrace_poke_user(&self, offset: usize, value: usize) -> Result<()> {
         let status = self.get_tracee_status()?;
         status.poke_user(offset, value)
+    }
+
+    /// Sets ptrace options for this thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread is not ptrace-stopped.
+    pub fn ptrace_set_options(&self, options: PtraceOptions) -> Result<()> {
+        let status = self.get_tracee_status()?;
+        status.set_options(options)
+    }
+
+    /// Gets the event of the last ptrace-stop,
+    /// if it is a ptrace-event-stop.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread is not ptrace-stopped.
+    pub fn ptrace_get_event(&self) -> Result<Option<PtraceEvent>> {
+        let status = self.get_tracee_status()?;
+        status.get_event()
     }
 
     /// Gets the signal info of this thread for ptrace.
@@ -290,6 +311,7 @@ impl TraceeStatus {
         debug_assert!(!self.is_ptrace_stopped());
 
         state.signal.stop(signal);
+        state.event = None;
         #[cfg(target_arch = "x86_64")]
         {
             state.general_regs = Some(*user_ctx.general_regs());
@@ -317,6 +339,7 @@ impl TraceeStatus {
             // A `SIGKILL` interrupts this ptrace-stop.
             let mut state = self.state.lock();
             state.signal.clear();
+            state.event = None;
             #[cfg(target_arch = "x86_64")]
             {
                 state.general_regs = None;
@@ -328,6 +351,7 @@ impl TraceeStatus {
 
         let mut state = self.state.lock();
         let signal = state.signal.clear();
+        state.event = None;
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -439,6 +463,23 @@ impl TraceeStatus {
         Ok(())
     }
 
+    fn set_options(&self, options: PtraceOptions) -> Result<()> {
+        // Hold the lock first to avoid race conditions.
+        let mut state = self.state.lock();
+        self.check_ptrace_stopped(&state)?;
+
+        state.options = options;
+        Ok(())
+    }
+
+    fn get_event(&self) -> Result<Option<PtraceEvent>> {
+        // Hold the lock first to avoid race conditions.
+        let state = self.state.lock();
+        self.check_ptrace_stopped(&state)?;
+
+        Ok(state.event.clone())
+    }
+
     fn get_siginfo(&self) -> Result<siginfo_t> {
         // Hold the lock first to avoid race conditions.
         let state = self.state.lock();
@@ -452,6 +493,10 @@ struct TraceeState {
     tracer: Weak<Thread>,
     /// The signal associated with the current ptrace-stop and later signal delivery.
     signal: StopDeliverySignal,
+    /// The event associated with the current ptrace-event-stop.
+    event: Option<PtraceEvent>,
+    /// The configured ptrace options.
+    options: PtraceOptions,
     /// The general-purpose registers of the tracee at the time of ptrace-stop.
     #[cfg(target_arch = "x86_64")]
     general_regs: Option<GeneralRegs>,
@@ -465,6 +510,8 @@ impl TraceeState {
         Self {
             tracer: Weak::new(),
             signal: StopDeliverySignal::default(),
+            event: None,
+            options: PtraceOptions::empty(),
             #[cfg(target_arch = "x86_64")]
             general_regs: None,
             #[cfg(target_arch = "x86_64")]

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -18,9 +18,9 @@ use crate::{
         signal::{
             DequeuedSignal, PauseReason,
             c_types::siginfo_t,
-            constants::{CLD_TRAPPED, SIGCHLD},
+            constants::{CLD_TRAPPED, SIGCHLD, SIGKILL},
             sig_num::SigNum,
-            signals::{raw::RawSignal, user::UserSignal},
+            signals::{kernel::KernelSignal, raw::RawSignal, user::UserSignal},
         },
     },
     thread::{Thread, Tid},
@@ -55,8 +55,16 @@ impl PosixThread {
 
     /// Detaches the tracer of this thread.
     pub(in crate::process) fn detach_tracer(&self) {
+        self.detach_tracer_with(|_| {});
+    }
+
+    /// Detaches the tracer of this thread with a callback.
+    fn detach_tracer_with<F>(&self, detach_callback: F)
+    where
+        F: FnOnce(&TraceeState),
+    {
         if let Some(status) = self.tracee_status.get() {
-            status.detach_tracer();
+            status.detach_tracer_with(detach_callback);
             self.wake_signalled_waker();
         }
     }
@@ -242,11 +250,28 @@ impl PosixThread {
             return;
         };
 
+        let mut tracees_to_kill = Vec::new();
+
         // Lock order: tracer.tracees -> tracee.tracee_status
         let tracees = tracees.lock();
-        for (_, tracee) in tracees.iter() {
+        for (_, tracee_thread) in tracees.iter() {
+            let tracee = tracee_thread.as_posix_thread().unwrap();
+            let mut needs_kill = false;
+            tracee.detach_tracer_with(|state| {
+                if state.options.contains(PtraceOptions::PTRACE_O_EXITKILL) {
+                    needs_kill = true;
+                }
+            });
+            if needs_kill {
+                tracees_to_kill.push(tracee_thread.clone());
+            }
+        }
+
+        drop(tracees);
+
+        for tracee in tracees_to_kill {
             let tracee = tracee.as_posix_thread().unwrap();
-            tracee.detach_tracer();
+            tracee.enqueue_signal(Box::new(KernelSignal::new(SIGKILL)));
         }
     }
 }
@@ -278,7 +303,10 @@ impl TraceeStatus {
         Ok(())
     }
 
-    fn detach_tracer(&self) {
+    fn detach_tracer_with<F>(&self, detach_callback: F)
+    where
+        F: FnOnce(&TraceeState),
+    {
         // Hold the lock first to avoid race conditions.
         let mut state = self.state.lock();
 
@@ -289,6 +317,7 @@ impl TraceeStatus {
                 arch_ptrace::disable_single_step(regs);
             }
         }
+        detach_callback(&state);
         self.is_stopped.store(false, Ordering::Relaxed);
     }
 

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -14,7 +14,7 @@ use crate::{arch::ptrace as arch_ptrace, process::posix_thread::NOT_A_SYSCALL};
 use crate::{
     prelude::*,
     process::{
-        WaitOptions,
+        CloneArgs, CloneFlags, WaitOptions,
         signal::{
             DequeuedSignal, PauseReason,
             c_types::siginfo_t,
@@ -98,6 +98,13 @@ impl PosixThread {
         if let Some(status) = self.tracee_status.get() {
             status.ptrace_may_stop_on(event, ctx, user_ctx)
         }
+    }
+
+    /// Returns whether a clone-family ptrace event would be required for `clone_args`.
+    pub(in crate::process) fn needs_ptrace_clone_stop(&self, clone_args: &CloneArgs) -> bool {
+        self.tracee_status
+            .get()
+            .is_some_and(|status| status.needs_clone_stop(clone_args))
     }
 
     /// Returns the ptrace-stop status changes for the `wait` syscall.
@@ -454,6 +461,25 @@ impl TraceeStatus {
         }
 
         PtraceStopResult::Continued(signal)
+    }
+
+    fn needs_clone_stop(&self, clone_args: &CloneArgs) -> bool {
+        let state = self.state.lock();
+        if state.tracer().is_none() {
+            return false;
+        }
+        let options = state.options;
+
+        if clone_args.flags.contains(CloneFlags::CLONE_VFORK) {
+            return options.contains(PtraceOptions::PTRACE_O_TRACEVFORK)
+                || options.contains(PtraceOptions::PTRACE_O_TRACEVFORKDONE);
+        }
+
+        if clone_args.exit_signal == Some(SIGCHLD) {
+            return options.contains(PtraceOptions::PTRACE_O_TRACEFORK);
+        }
+
+        options.contains(PtraceOptions::PTRACE_O_TRACECLONE)
     }
 
     fn is_ptrace_stopped(&self) -> bool {

--- a/kernel/src/process/posix_thread/ptrace/util.rs
+++ b/kernel/src/process/posix_thread/ptrace/util.rs
@@ -5,9 +5,10 @@
 use crate::{
     prelude::*,
     process::{
-        WaitOptions,
+        ExitCode, WaitOptions,
         signal::{DequeuedSignal, sig_num::SigNum, signals::Signal},
     },
+    thread::Tid,
 };
 
 /// The requests that can continue a stopped tracee.
@@ -116,6 +117,76 @@ impl StopDeliverySignal {
                 Some(signal.signal())
             }
             Self::Empty => None,
+        }
+    }
+}
+
+bitflags! {
+    /// Options accepted by `PTRACE_SETOPTIONS`.
+    pub struct PtraceOptions: usize {
+        /// Marks syscall stops with signal number set to `SIGTRAP | 0x80`.
+        const PTRACE_O_TRACESYSGOOD = 1;
+        /// Stops the tracee at `fork` and automatically traces the new thread.
+        const PTRACE_O_TRACEFORK = 1 << PtraceEvent::Fork(0).code();
+        /// Stops the tracee at `vfork` and automatically traces the new thread.
+        const PTRACE_O_TRACEVFORK = 1 << PtraceEvent::Vfork(0).code();
+        /// Stops the tracee at `clone` and automatically traces the new thread.
+        const PTRACE_O_TRACECLONE = 1 << PtraceEvent::Clone(0).code();
+        /// Stops the tracee at `execve`.
+        const PTRACE_O_TRACEEXEC = 1 << PtraceEvent::Exec(0).code();
+        /// Stops the tracee at the completion of `vfork`.
+        const PTRACE_O_TRACEVFORKDONE = 1 << PtraceEvent::VforkDone(0).code();
+        /// Stops the tracee at `exit`.
+        const PTRACE_O_TRACEEXIT = 1 << PtraceEvent::Exit(0).code();
+        /// Send a `SIGKILL` signal to the tracee if the tracer exits.
+        const PTRACE_O_EXITKILL = 1 << 20;
+    }
+}
+
+/// The events of ptrace-event-stops.
+#[derive(Debug, Clone)]
+pub enum PtraceEvent {
+    /// A `fork` event with the new child thread ID.
+    Fork(Tid),
+    /// A `vfork` event with the new child thread ID.
+    Vfork(Tid),
+    /// A `clone` event with the new child thread ID.
+    Clone(Tid),
+    /// An `execve` event with the former thread ID.
+    Exec(Tid),
+    /// A done `vfork` event with the child thread ID.
+    VforkDone(Tid),
+    /// An `exit` event with the tracee's exit code.
+    Exit(ExitCode),
+}
+
+impl PtraceEvent {
+    /// Returns the Linux `PTRACE_EVENT_*` code of this event.
+    const fn code(&self) -> u32 {
+        match self {
+            Self::Fork(_) => 1,
+            Self::Vfork(_) => 2,
+            Self::Clone(_) => 3,
+            Self::Exec(_) => 4,
+            Self::VforkDone(_) => 5,
+            Self::Exit(_) => 6,
+        }
+    }
+
+    /// Returns the `PtraceOptions` corresponding to this event.
+    pub(super) const fn option(&self) -> PtraceOptions {
+        PtraceOptions::from_bits(1 << self.code()).unwrap()
+    }
+
+    /// Returns the message of this event.
+    pub const fn message(&self) -> usize {
+        match self {
+            Self::Fork(tid)
+            | Self::Vfork(tid)
+            | Self::Clone(tid)
+            | Self::Exec(tid)
+            | Self::VforkDone(tid) => *tid as usize,
+            Self::Exit(exit_code) => *exit_code as usize,
         }
     }
 }

--- a/kernel/src/process/posix_thread/ptrace/util.rs
+++ b/kernel/src/process/posix_thread/ptrace/util.rs
@@ -6,7 +6,10 @@ use crate::{
     prelude::*,
     process::{
         ExitCode, WaitOptions,
-        signal::{DequeuedSignal, sig_num::SigNum, signals::Signal},
+        signal::{
+            DequeuedSignal, c_types::siginfo_t, constants::SIGTRAP, sig_num::SigNum,
+            signals::Signal,
+        },
     },
     thread::Tid,
 };
@@ -188,5 +191,35 @@ impl PtraceEvent {
             | Self::VforkDone(tid) => *tid as usize,
             Self::Exit(exit_code) => *exit_code as usize,
         }
+    }
+
+    /// Creates a `siginfo_t` for the ptrace-stop triggered by this event.
+    pub(super) fn siginfo(&self, ctx: &Context) -> siginfo_t {
+        let code = PtraceWaitStatus::from_event(self).0;
+        let mut siginfo = siginfo_t::new(SIGTRAP, code);
+        siginfo.set_pid_uid_by(ctx);
+        siginfo
+    }
+}
+
+/// The `si_status` code of a ptrace-stop for `wait` syscalls.
+#[derive(Copy, Clone)]
+pub struct PtraceWaitStatus(i32);
+
+impl PtraceWaitStatus {
+    pub(super) fn from_event(event: &PtraceEvent) -> Self {
+        Self(SIGTRAP.as_u8() as i32 | ((event.code() as i32) << 8))
+    }
+
+    pub(super) fn from_signal(sig: SigNum) -> Self {
+        Self(sig.as_u8() as i32)
+    }
+
+    pub fn to_wait4_status(self) -> u32 {
+        ((self.0 as u32) << 8) | 0x7f
+    }
+
+    pub fn to_waitid_si_status(self) -> i32 {
+        self.0
     }
 }

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -178,7 +178,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
                 // FIXME: Linux converts a signal-frame setup failure into a SIGSEGV delivery,
                 // instead of killing the process directly.
                 // This can be observed in LTP test `signal06`.
-                do_exit_group(TermStatus::Killed(SIGSEGV));
+                do_exit_group(TermStatus::Killed(SIGSEGV), ctx, user_ctx);
             }
         }
         SigAction::Dfl if ctx.process.is_init_process() => {
@@ -198,7 +198,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
                         sig_num.sig_name()
                     );
                     // The signal terminates the current process. Therefore, we should exit here.
-                    do_exit_group(TermStatus::Killed(sig_num));
+                    do_exit_group(TermStatus::Killed(sig_num), ctx, user_ctx);
                 }
                 SigDefaultAction::Ign => {}
                 SigDefaultAction::Stop => ctx.process.stop(sig_num),

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -9,7 +9,7 @@ use crate::{
     prelude::*,
     process::{
         ReapedChildrenStats, Uid, pid_table,
-        posix_thread::{AsPosixThread, PosixThread},
+        posix_thread::{AsPosixThread, PosixThread, ptrace::PtraceWaitStatus},
         signal::sig_num::SigNum,
         status::StopWaitStatus,
     },
@@ -122,7 +122,7 @@ pub enum WaitStatus {
     Stop(Arc<Process>, SigNum),
     Continue(Arc<Process>),
     TraceeExit(Arc<Thread>),
-    TraceeStop(Arc<Thread>, SigNum),
+    TraceeStop(Arc<Thread>, PtraceWaitStatus),
 }
 
 impl WaitStatus {

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -279,8 +279,8 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_UTIMENSAT = 88               => sys_utimensat(args[..4]);
             SYS_CAPGET = 90                  => sys_capget(args[..2]);
             SYS_CAPSET = 91                  => sys_capset(args[..2]);
-            SYS_EXIT = 93                    => sys_exit(args[..1]);
-            SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1]);
+            SYS_EXIT = 93                    => sys_exit(args[..1], &mut user_ctx);
+            SYS_EXIT_GROUP = 94              => sys_exit_group(args[..1], &mut user_ctx);
             SYS_WAITID = 95                  => sys_waitid(args[..5]);
             SYS_SET_TID_ADDRESS = 96         => sys_set_tid_address(args[..1]);
             SYS_UNSHARE = 97                 => sys_unshare(args[..1]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -236,7 +236,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FORK = 57              => sys_fork(args[..0], &user_ctx);
     SYS_VFORK = 58             => sys_vfork(args[..0], &user_ctx);
     SYS_EXECVE = 59            => sys_execve(args[..3], &mut user_ctx);
-    SYS_EXIT = 60              => sys_exit(args[..1]);
+    SYS_EXIT = 60              => sys_exit(args[..1], &mut user_ctx);
     SYS_WAIT4 = 61             => sys_wait4(args[..4]);
     SYS_KILL = 62              => sys_kill(args[..2]);
     SYS_UNAME = 63             => sys_uname(args[..1]);
@@ -352,7 +352,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_TIMER_DELETE = 226     => sys_timer_delete(args[..1]);
     SYS_CLOCK_GETTIME = 228    => sys_clock_gettime(args[..2]);
     SYS_CLOCK_NANOSLEEP = 230  => sys_clock_nanosleep(args[..4]);
-    SYS_EXIT_GROUP = 231       => sys_exit_group(args[..1]);
+    SYS_EXIT_GROUP = 231       => sys_exit_group(args[..1], &mut user_ctx);
     SYS_EPOLL_WAIT = 232       => sys_epoll_wait(args[..4]);
     SYS_EPOLL_CTL = 233        => sys_epoll_ctl(args[..4]);
     SYS_TGKILL = 234           => sys_tgkill(args[..3]);

--- a/kernel/src/syscall/exit.rs
+++ b/kernel/src/syscall/exit.rs
@@ -1,16 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::arch::cpu::context::UserContext;
+
 use crate::{
     prelude::*,
     process::{TermStatus, posix_thread::do_exit},
     syscall::SyscallReturn,
 };
 
-pub fn sys_exit(exit_code: i32, _ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_exit(
+    exit_code: i32,
+    ctx: &Context,
+    user_ctx: &mut UserContext,
+) -> Result<SyscallReturn> {
     debug!("exid code = {}", exit_code);
 
     let term_status = TermStatus::Exited(exit_code as _);
-    do_exit(term_status);
+    do_exit(term_status, ctx, user_ctx);
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/exit_group.rs
+++ b/kernel/src/syscall/exit_group.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::arch::cpu::context::UserContext;
+
 use crate::{
     prelude::*,
     process::{TermStatus, posix_thread::do_exit_group},
@@ -7,9 +9,13 @@ use crate::{
 };
 
 /// Exit all thread in a process.
-pub fn sys_exit_group(exit_code: u64, _ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_exit_group(
+    exit_code: u64,
+    ctx: &Context,
+    user_ctx: &mut UserContext,
+) -> Result<SyscallReturn> {
     // Exit all thread in current process
     let term_status = TermStatus::Exited(exit_code as _);
-    do_exit_group(term_status);
+    do_exit_group(term_status, ctx, user_ctx);
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/ptrace.rs
+++ b/kernel/src/syscall/ptrace.rs
@@ -8,7 +8,11 @@ use crate::arch::ptrace as arch_ptrace;
 use crate::{
     prelude::*,
     process::{
-        posix_thread::{AsPosixThread, alien_access::AlienAccessMode, ptrace::PtraceContRequest},
+        posix_thread::{
+            AsPosixThread,
+            alien_access::AlienAccessMode,
+            ptrace::{PtraceContRequest, PtraceOptions},
+        },
         signal::{constants::SIGKILL, sig_num::SigNum, signals::user::UserSignal},
     },
     thread::{Thread, Tid},
@@ -92,6 +96,23 @@ pub fn sys_ptrace(
                 .read_val::<arch_ptrace::CUserRegsStruct>(data)?;
             tracee.ptrace_set_regs(regs)?;
         }
+        PtraceRequest::PTRACE_SETOPTIONS => {
+            let options = PtraceOptions::from_bits(data)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid ptrace options"))?;
+
+            let tracee = ctx.posix_thread.get_tracee(tid)?;
+            let tracee = tracee.as_posix_thread().unwrap();
+
+            tracee.ptrace_set_options(options)?;
+        }
+        PtraceRequest::PTRACE_GETEVENTMSG => {
+            let tracee = ctx.posix_thread.get_tracee(tid)?;
+            let tracee = tracee.as_posix_thread().unwrap();
+
+            let event = tracee.ptrace_get_event()?;
+            let eventmsg = event.map(|event| event.message()).unwrap_or(0);
+            ctx.user_space().write_val(data, &eventmsg)?;
+        }
         PtraceRequest::PTRACE_GETSIGINFO => {
             let tracee = ctx.posix_thread.get_tracee(tid)?;
             let siginfo = tracee.as_posix_thread().unwrap().ptrace_get_siginfo()?;
@@ -162,6 +183,10 @@ enum PtraceRequest {
     /// Sets all general-purpose registers used by the thread.
     #[cfg(target_arch = "x86_64")]
     PTRACE_SETREGS = 13,
+    /// Sets ptrace options.
+    PTRACE_SETOPTIONS = 0x4200,
+    /// Gets the message of the last ptrace-event-stop.
+    PTRACE_GETEVENTMSG = 0x4201,
     /// Gets the `siginfo` of the last ptrace-stop.
     PTRACE_GETSIGINFO = 0x4202,
     // TODO: Support other operations.
@@ -191,8 +216,6 @@ enum PtraceRequest {
     // PTRACE_SYSEMU = 31,
     // /// Single-steps the thread, and the next syscall will not be executed.
     // PTRACE_SYSEMU_SINGLESTEP = 32,
-    // /// Sets ptrace filter options.
-    // PTRACE_SETOPTIONS = 0x4200,
     // /// Gets register contents.
     // PTRACE_GETREGSET = 0x4204,
     // /// Sets register contents.

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -66,7 +66,6 @@ fn calculate_status_code(wait_status: &WaitStatus) -> u32 {
         WaitStatus::Stop(_, sig_num) => ((sig_num.as_u8() as u32) << 8) | 0x7f,
         WaitStatus::Continue(_) => 0xffff,
         WaitStatus::TraceeExit(thread) => thread.as_posix_thread().unwrap().exit_code(),
-        // TODO: Add `PTRACE_EVENT_*` flags.
-        WaitStatus::TraceeStop(_, sig_num) => ((sig_num.as_u8() as u32) << 8) | 0x7f,
+        WaitStatus::TraceeStop(_, status) => status.to_wait4_status(),
     }
 }

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -95,7 +95,6 @@ fn calculate_si_code_and_si_status(wait_status: &WaitStatus) -> (i32, i32) {
             let exit_code = thread.as_posix_thread().unwrap().exit_code();
             parse_exit_code(exit_code)
         }
-        // TODO: Add `PTRACE_EVENT_*` flags into `si_status`.
-        WaitStatus::TraceeStop(_, signum) => (CLD_TRAPPED, signum.as_u8() as i32),
+        WaitStatus::TraceeStop(_, status) => (CLD_TRAPPED, status.to_waitid_si_status()),
     }
 }

--- a/test/initramfs/src/regression/process/ptrace/set_options.c
+++ b/test/initramfs/src/regression/process/ptrace/set_options.c
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <sys/user.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+#include "../../common/yama_ptrace_scope.h"
+
+FN_TEST(ptrace_exit_kill)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	int pid_pipe[2];
+	TEST_SUCC(prctl(PR_SET_CHILD_SUBREAPER, 1));
+	TEST_SUCC(pipe(pid_pipe));
+
+	pid_t tracer_pid = TEST_SUCC(fork());
+	if (tracer_pid == 0) {
+		int status;
+
+		CHECK(close(pid_pipe[0]));
+		pid_t tracee_pid = CHECK(fork());
+		if (tracee_pid == 0) {
+			CHECK(close(pid_pipe[1]));
+			CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+			CHECK(raise(SIGSTOP));
+			for (;;) {
+				pause();
+			}
+			_exit(-1);
+		}
+
+		CHECK_WITH(write(pid_pipe[1], &tracee_pid, sizeof(tracee_pid)),
+			   _ret == sizeof(tracee_pid));
+		CHECK(close(pid_pipe[1]));
+
+		CHECK_WITH(waitpid(tracee_pid, &status, 0),
+			   _ret == tracee_pid && WIFSTOPPED(status) &&
+				   WSTOPSIG(status) == SIGSTOP);
+		CHECK(ptrace(PTRACE_SETOPTIONS, tracee_pid, 0,
+			     PTRACE_O_EXITKILL));
+		CHECK(ptrace(PTRACE_CONT, tracee_pid, 0, 0));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pid_pipe[1]));
+	pid_t tracee_pid;
+	TEST_RES(read(pid_pipe[0], &tracee_pid, sizeof(tracee_pid)),
+		 _ret == sizeof(tracee_pid));
+	TEST_SUCC(close(pid_pipe[0]));
+
+	int status;
+	TEST_RES(waitpid(tracer_pid, &status, 0),
+		 _ret == tracer_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+	TEST_RES(waitpid(tracee_pid, &status, 0),
+		 _ret == tracee_pid && WIFSIGNALED(status) &&
+			 WTERMSIG(status) == SIGKILL);
+}
+END_TEST()
+
+FN_TEST(ptrace_setoptions_validation)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGSTOP));
+		for (;;) {
+			pause();
+		}
+		_exit(-1);
+	}
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+	TEST_ERRNO(ptrace(PTRACE_SETOPTIONS, pid, 0, 1ul << 31), EINVAL);
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_ERRNO(ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_TRACEEXIT),
+		   ESRCH);
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status) &&
+						   WTERMSIG(status) == SIGKILL);
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(raise(SIGSTOP));
+		_exit(-1);
+	}
+
+	TEST_RES(waitpid(pid, &status, WUNTRACED),
+		 _ret == pid && WIFSTOPPED(status) &&
+			 WSTOPSIG(status) == SIGSTOP);
+	TEST_ERRNO(ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_TRACEEXIT),
+		   ESRCH);
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status) &&
+						   WTERMSIG(status) == SIGKILL);
+}
+END_TEST()
+
+static int ptrace_event_status(int event)
+{
+	return SIGTRAP | (event << 8);
+}
+
+#define PTRACE_SETOPTIONS_TEST(name, tracee_fn)                             \
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);            \
+	pid_t pid = TEST_SUCC(fork());                                      \
+	if (pid == 0) {                                                     \
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));                     \
+		CHECK(raise(SIGSTOP));                                      \
+		tracee_fn();                                                \
+		_exit(-1);                                                  \
+	}                                                                   \
+                                                                            \
+	int status;                                                         \
+	unsigned long eventmsg;                                             \
+	siginfo_t si;                                                       \
+	TEST_RES(waitpid(pid, &status, 0),                                  \
+		 _ret == pid && WIFSTOPPED(status) &&                       \
+			 WSTOPSIG(status) == SIGSTOP);                      \
+	TEST_SUCC(ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_TRACE##name)); \
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));                          \
+                                                                            \
+	int event_status = ptrace_event_status(PTRACE_EVENT_##name);        \
+	TEST_RES(waitpid(pid, &status, 0),                                  \
+		 _ret == pid && WIFSTOPPED(status) &&                       \
+			 (status >> 8) == event_status);                    \
+	TEST_RES(ptrace(PTRACE_GETSIGINFO, pid, 0, &si),                    \
+		 si.si_signo == SIGTRAP && si.si_code == event_status &&    \
+			 si.si_pid == pid && si.si_uid == getuid());        \
+	TEST_SUCC(ptrace(PTRACE_GETEVENTMSG, pid, 0, &eventmsg));
+
+#define CLEANUP_CHILD()                                                        \
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));                             \
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFEXITED(status) && \
+						   WEXITSTATUS(status) == 0);
+
+static void tracee_exec(void)
+{
+	char *const argv[] = { "/bin/true", NULL };
+	char *const envp[] = { NULL };
+	CHECK(execve("/bin/true", argv, envp));
+	_exit(-1);
+}
+
+FN_TEST(ptrace_trace_exec)
+{
+	PTRACE_SETOPTIONS_TEST(EXEC, tracee_exec);
+
+	TEST_RES(eventmsg, _ret == pid);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+static void tracee_exit(void)
+{
+	_exit(0);
+}
+
+FN_TEST(ptrace_trace_exit)
+{
+	PTRACE_SETOPTIONS_TEST(EXIT, tracee_exit);
+
+	// Confirm the tracee has not yet exited at this point.
+	TEST_RES(waitpid(pid, &status, WNOHANG), _ret == 0);
+	struct user_regs_struct regs = { 0 };
+	TEST_SUCC(ptrace(PTRACE_GETREGS, pid, 0, &regs));
+
+	TEST_RES(eventmsg, WIFEXITED(_ret) && WEXITSTATUS(_ret) == 0);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+// TODO: Support clone-family ptrace events and remove this guard.
+#ifndef __asterinas__
+
+#define CLEANUP_GRAND_CHILD(notify_sig)                             \
+	pid_t grand_child = eventmsg;                               \
+	TEST_RES(waitpid(grand_child, &status, 0),                  \
+		 _ret == grand_child && WIFSTOPPED(status) &&       \
+			 WSTOPSIG(status) == SIGSTOP);              \
+	TEST_SUCC(ptrace(PTRACE_CONT, grand_child, 0, 0));          \
+	TEST_RES(waitpid(grand_child, &status, 0),                  \
+		 _ret == grand_child && WIFEXITED(status) &&        \
+			 WEXITSTATUS(status) == 0);                 \
+	if (notify_sig) {                                           \
+		TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));          \
+		TEST_RES(waitpid(pid, &status, 0),                  \
+			 _ret == pid && WIFSTOPPED(status) &&       \
+				 WSTOPSIG(status) == (notify_sig)); \
+	}
+
+static void tracee_fork(void)
+{
+	CHECK(fork());
+	_exit(0);
+}
+
+FN_TEST(ptrace_trace_fork)
+{
+	PTRACE_SETOPTIONS_TEST(FORK, tracee_fork);
+
+	CLEANUP_GRAND_CHILD(SIGCHLD);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+static int clone_child_fn(void *arg)
+{
+	return 0;
+}
+
+#define STACK_SIZE (1 << 20)
+static void tracee_clone_process(void)
+{
+	static char child_stack[STACK_SIZE];
+	CHECK(clone(clone_child_fn, child_stack + STACK_SIZE, SIGUSR1, NULL));
+	_exit(0);
+}
+
+static void tracee_clone_thread(void)
+{
+	static char child_stack[STACK_SIZE];
+	CHECK(clone(clone_child_fn, child_stack + STACK_SIZE,
+		    CLONE_PARENT | CLONE_THREAD | CLONE_VM | CLONE_SIGHAND,
+		    NULL));
+	_exit(0);
+}
+#undef STACK_SIZE
+
+FN_TEST(ptrace_trace_clone_process)
+{
+	PTRACE_SETOPTIONS_TEST(CLONE, tracee_clone_process);
+
+	CLEANUP_GRAND_CHILD(SIGUSR1);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+FN_TEST(ptrace_trace_clone_thread)
+{
+	PTRACE_SETOPTIONS_TEST(CLONE, tracee_clone_thread);
+
+	CLEANUP_GRAND_CHILD(0);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+static void tracee_vfork(void)
+{
+	CHECK(vfork());
+	_exit(0);
+}
+
+FN_TEST(ptrace_trace_vfork)
+{
+	PTRACE_SETOPTIONS_TEST(VFORK, tracee_vfork);
+
+	CLEANUP_GRAND_CHILD(SIGCHLD);
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+FN_TEST(ptrace_trace_vfork_both)
+{
+#define PTRACE_O_TRACEVFORK_BOTH (PTRACE_O_TRACEVFORK | PTRACE_O_TRACEVFORKDONE)
+// The first ptrace-event-stop is PTRACE_EVENT_VFORK.
+#define PTRACE_EVENT_VFORK_BOTH PTRACE_EVENT_VFORK
+	PTRACE_SETOPTIONS_TEST(VFORK_BOTH, tracee_vfork);
+#undef PTRACE_O_TRACEVFORK_BOTH
+#undef PTRACE_EVENT_VFORK_BOTH
+
+	pid_t grand_child = eventmsg;
+	TEST_RES(waitpid(grand_child, &status, 0),
+		 _ret == grand_child && WIFSTOPPED(status) &&
+			 WSTOPSIG(status) == SIGSTOP);
+	TEST_SUCC(ptrace(PTRACE_CONT, grand_child, 0, 0));
+	TEST_RES(waitpid(grand_child, &status, 0),
+		 _ret == grand_child && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	int vfork_done_status = ptrace_event_status(PTRACE_EVENT_VFORK_DONE);
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFSTOPPED(status) &&
+			 (status >> 8) == vfork_done_status);
+	TEST_RES(ptrace(PTRACE_GETSIGINFO, pid, 0, &si),
+		 si.si_signo == SIGTRAP && si.si_code == vfork_done_status &&
+			 si.si_pid == pid && si.si_uid == getuid());
+	TEST_RES(ptrace(PTRACE_GETEVENTMSG, pid, 0, &eventmsg),
+		 eventmsg == grand_child);
+
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGCHLD);
+
+	CLEANUP_CHILD();
+}
+END_TEST()
+
+#endif

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -43,6 +43,7 @@ set -e
 ./ptrace/debugger
 ./ptrace/ptrace
 ./ptrace/read_write_regs
+./ptrace/set_options
 
 ./sched/sched_attr_getset
 ./sched/sched_param_getset


### PR DESCRIPTION
Based on https://github.com/asterinas/asterinas/pull/3065, and required for #2323.

For reference, please refer to "PTRACE_SETOPTIONS" and "PTRACE_EVENT stops" in [spec description](https://man7.org/linux/man-pages/man2/ptrace.2.html#DESCRIPTION).

This PR does not yet implement clone-family ptrace-event-stops, because I want to focus on supporting GDB for single-threaded programs currently. In this PR, the clone calls that would trigger ptrace-event-stops are rejected.
