### PR TITLE
Fix `readdir` whiteout handling in `overlayfs`

### DIFF
--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -328,8 +328,10 @@ impl OverlayInode {
             .read_at(offset, writer, status_flags)
     }
 
-    /// Returns the children objects in a unified view.
-    /// The object from the upper layer with the same name will mask the lower ones.
+    /// Visits the children objects in a unified view.
+    ///
+    /// Returns the offset increment needed to advance `offset` to the next unread
+    /// entry. If no entries have been visited, returns an error.
     pub fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
         if self.type_ != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
@@ -337,11 +339,30 @@ impl OverlayInode {
 
         let overlay_dir_visitor = self.readdir_inner(offset)?;
 
-        for (offset, (name, ino, type_)) in overlay_dir_visitor.as_merged_view() {
-            visitor.visit(name, *ino, *type_, *offset)?;
+        let mut last_visited_offset: Option<usize> = None;
+        for (entry_offset, (name, ino, type_)) in overlay_dir_visitor.as_merged_view() {
+            if let Err(e) = visitor.visit(name, *ino, *type_, *entry_offset) {
+                // If nothing has been visited yet, propagate the error.
+                // Otherwise, stop early and return what we have so far.
+                if last_visited_offset.is_none() {
+                    return Err(e);
+                }
+                break;
+            }
+            last_visited_offset = Some(*entry_offset);
         }
 
-        Ok(overlay_dir_visitor.cur_offset())
+        // Return the offset increment that advances the caller from the starting `offset`
+        // to one past the last visited dirent offset. Note: this is not guaranteed to be
+        // equal to the number of entries visited, since offsets may encode layer bits.
+        if let Some(last_off) = last_visited_offset {
+            last_off
+                .checked_sub(offset)
+                .and_then(|v| v.checked_add(1))
+                .ok_or(Error::new(Errno::EOVERFLOW))
+        } else {
+            Ok(0)
+        }
     }
 
     /// Deletes the target file by creating a "whiteout" file from the upper layer.
@@ -717,6 +738,7 @@ impl OverlayInode {
     fn readdir_inner(&self, offset: usize) -> Result<OverlayDirVisitor> {
         let mut overlay_visitor = OverlayDirVisitor::new();
         let (mut layer_idx, fs_offset) = UniqueNoGenerator::parse_unique_offset(offset);
+        overlay_visitor.set_cur_layer(layer_idx);
 
         // Process all the potential whiteout files before `layer_idx`
         if layer_idx > 0 {
@@ -1005,9 +1027,12 @@ struct OverlayDirVisitor {
 
 impl DirentVisitor for OverlayDirVisitor {
     fn visit(&mut self, name: &str, fs_ino: u64, type_: InodeType, fs_offset: usize) -> Result<()> {
-        if self.whiteout_only_mode && name.starts_with(WHITEOUT_PREFIX) {
-            self.dir_set
-                .insert(name[WHITEOUT_PREFIX_SIZE..].to_string());
+        if self.whiteout_only_mode {
+            if name.starts_with(WHITEOUT_PREFIX) {
+                self.dir_set
+                    .insert(name[WHITEOUT_PREFIX_SIZE..].to_string());
+            }
+            // We only want to collect the whiteout files in `whiteout_only_mode`, so directly return.
             return Ok(());
         }
 
@@ -1063,11 +1088,8 @@ impl OverlayDirVisitor {
         !self.whiteout_set.is_empty()
     }
 
-    pub fn cur_offset(&self) -> usize {
-        self.dir_map
-            .last_key_value()
-            .map(|(off, _)| *off)
-            .unwrap_or(0)
+    fn cur_offset(&self) -> Option<usize> {
+        self.dir_map.last_key_value().map(|(off, _)| *off)
     }
 
     fn set_cur_layer(&mut self, layer: LayerIdx) {
@@ -1465,6 +1487,75 @@ mod tests {
         )
         .unwrap();
         assert_eq!(xattr_value.as_slice(), "f2_xattr_value".as_bytes());
+    }
+
+    #[ktest]
+    fn resuming_readdir_should_not_produce_duplicates() {
+        crate::time::clocks::init_for_ktest();
+        crate::fs::vfs::init();
+
+        let mode = InodeMode::all();
+        let root = Path::new_fs_root(new_dummy_mount());
+
+        let upper = {
+            let dir = root.new_fs_child("upper", InodeType::Dir, mode).unwrap();
+            // whiteout for "deleted"
+            dir.new_fs_child(".wh.deleted", InodeType::File, mode)
+                .unwrap();
+            // a normal file that should appear exactly once
+            dir.new_fs_child("normal_file", InodeType::File, mode)
+                .unwrap();
+            dir
+        };
+
+        let lower = {
+            let lower_root = Path::new_fs_root(new_dummy_mount());
+            // this file is whited-out by upper, should NOT appear
+            lower_root
+                .new_fs_child("deleted", InodeType::File, mode)
+                .unwrap();
+            // this file only lives in lower, should appear once
+            lower_root
+                .new_fs_child("another_file", InodeType::File, mode)
+                .unwrap();
+            lower_root
+        };
+
+        let work = root.new_fs_child("work", InodeType::Dir, mode).unwrap();
+        let fs = OverlayFs::new(upper, vec![lower], work).unwrap();
+        let root_inode = fs.root_inode();
+
+        // Simulate multiple batched getdents calls: each call passes the accumulated
+        // offset (sum of all previous return values) as the starting offset, mimicking
+        // how inode_handle::readdir accumulates `*offset += read_cnt`.
+        let mut all_names = Vec::<String>::new();
+        let mut offset = 0usize;
+        loop {
+            let mut batch = Vec::<String>::new();
+            let read_cnt = root_inode.readdir_at(offset, &mut batch).unwrap();
+            all_names.extend(batch);
+            if read_cnt == 0 {
+                break;
+            }
+            offset += read_cnt;
+        }
+
+        assert!(
+            !all_names.contains(&"deleted".to_string()),
+            "whited-out file 'deleted' should not appear"
+        );
+
+        let normal_total = all_names.iter().filter(|n| *n == "normal_file").count();
+        assert_eq!(
+            normal_total, 1,
+            "normal_file should appear exactly once, got {normal_total}"
+        );
+
+        let another_total = all_names.iter().filter(|n| *n == "another_file").count();
+        assert_eq!(
+            another_total, 1,
+            "another_file should appear exactly once, got {another_total}"
+        );
     }
 
     #[ktest]

--- a/test/initramfs/src/regression/fs/overlayfs/readdir_small_buffer.c
+++ b/test/initramfs/src/regression/fs/overlayfs/readdir_small_buffer.c
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define BASE_DIR "/ovl_readdir_test"
+#define UPPER_DIR BASE_DIR "/upper"
+#define WORK_DIR BASE_DIR "/work"
+#define LOWER_DIR BASE_DIR "/lower"
+#define MERGED_DIR BASE_DIR "/merged"
+
+#define NUM_UPPER_EXTRA 3
+#define NUM_LOWER_EXTRA 5
+#define ONE_LONG_DIRENT_BUF_SIZE (sizeof(struct linux_dirent64) + NAME_MAX + 1)
+
+struct linux_dirent64 {
+	uint64_t d_ino;
+	int64_t d_off;
+	unsigned short d_reclen;
+	unsigned char d_type;
+	char d_name[];
+};
+
+struct readdir_result {
+	int normal_file;
+	int normal_extra;
+	int another_file;
+	int another_extra;
+	int deleted;
+	int whiteout;
+	int total_entries;
+};
+
+static void create_dir(const char *path)
+{
+	CHECK(mkdir(path, 0755));
+}
+
+static void write_file(const char *path)
+{
+	int fd = CHECK(open(path, O_WRONLY | O_CREAT, 0644));
+	CHECK(write(fd, "data", 4));
+	CHECK(close(fd));
+}
+
+static void setup_overlay_tree(void)
+{
+	create_dir(BASE_DIR);
+	create_dir(UPPER_DIR);
+	create_dir(WORK_DIR);
+	create_dir(LOWER_DIR);
+	create_dir(MERGED_DIR);
+
+	write_file(UPPER_DIR "/normal_file");
+	write_file(UPPER_DIR "/.wh.deleted");
+	write_file(UPPER_DIR "/normal_extra_0");
+	write_file(UPPER_DIR "/normal_extra_1");
+	write_file(UPPER_DIR "/normal_extra_2");
+
+	write_file(LOWER_DIR "/deleted");
+	write_file(LOWER_DIR "/another_file");
+	write_file(LOWER_DIR "/another_extra_0");
+	write_file(LOWER_DIR "/another_extra_1");
+	write_file(LOWER_DIR "/another_extra_2");
+	write_file(LOWER_DIR "/another_extra_3");
+	write_file(LOWER_DIR "/another_extra_4");
+}
+
+static void cleanup_overlay_tree(void)
+{
+	CHECK(unlink(UPPER_DIR "/normal_file"));
+	CHECK(unlink(UPPER_DIR "/.wh.deleted"));
+	CHECK(unlink(UPPER_DIR "/normal_extra_0"));
+	CHECK(unlink(UPPER_DIR "/normal_extra_1"));
+	CHECK(unlink(UPPER_DIR "/normal_extra_2"));
+
+	CHECK(unlink(LOWER_DIR "/deleted"));
+	CHECK(unlink(LOWER_DIR "/another_file"));
+	CHECK(unlink(LOWER_DIR "/another_extra_0"));
+	CHECK(unlink(LOWER_DIR "/another_extra_1"));
+	CHECK(unlink(LOWER_DIR "/another_extra_2"));
+	CHECK(unlink(LOWER_DIR "/another_extra_3"));
+	CHECK(unlink(LOWER_DIR "/another_extra_4"));
+
+	CHECK(rmdir(MERGED_DIR));
+	CHECK(rmdir(WORK_DIR));
+	CHECK(rmdir(UPPER_DIR));
+	CHECK(rmdir(LOWER_DIR));
+	CHECK(rmdir(BASE_DIR));
+}
+
+static void mount_overlay(void)
+{
+	char options[256];
+	snprintf(options, sizeof(options), "lowerdir=%s,upperdir=%s,workdir=%s",
+		 LOWER_DIR, UPPER_DIR, WORK_DIR);
+
+	CHECK(mount("overlay", MERGED_DIR, "overlay", 0, options));
+}
+
+FN_SETUP(init)
+{
+	setup_overlay_tree();
+	mount_overlay();
+}
+
+END_SETUP()
+
+FN_TEST(readdir_small_buffer)
+{
+	int fd = TEST_SUCC(open(MERGED_DIR, O_RDONLY | O_DIRECTORY));
+
+	/*
+	 * Use a buffer that can hold only one maximal-name dirent, so each
+	 * getdents64() call may stop after a single merged entry. The merged
+	 * directory view should still remain complete: lower entries hidden by
+	 * whiteouts must stay hidden, and the whiteout files themselves must not
+	 * appear.
+	 */
+	char buf[ONE_LONG_DIRENT_BUF_SIZE];
+	struct readdir_result result = { 0 };
+
+	for (;;) {
+		int nread =
+			TEST_RES(syscall(SYS_getdents64, fd, buf, sizeof(buf)),
+				 _ret >= 0);
+		if (nread == 0)
+			break;
+
+		for (int pos = 0; pos < nread;) {
+			struct linux_dirent64 *d =
+				(struct linux_dirent64 *)(buf + pos);
+			const char *name = d->d_name;
+
+			if (strcmp(name, "normal_file") == 0) {
+				result.normal_file++;
+			} else if (strncmp(name, "normal_extra_", 13) == 0) {
+				result.normal_extra++;
+			} else if (strcmp(name, "another_file") == 0) {
+				result.another_file++;
+			} else if (strncmp(name, "another_extra_", 14) == 0) {
+				result.another_extra++;
+			} else if (strcmp(name, "deleted") == 0) {
+				result.deleted++;
+			} else if (strncmp(name, ".wh.", 4) == 0) {
+				result.whiteout++;
+			}
+
+			result.total_entries++;
+			pos += d->d_reclen;
+		}
+	}
+
+	TEST_SUCC(close(fd));
+	TEST_RES(result.deleted, _ret == 0);
+	TEST_RES(result.whiteout, _ret == 0);
+	TEST_RES(result.normal_file, _ret == 1);
+	TEST_RES(result.normal_extra, _ret == NUM_UPPER_EXTRA);
+	TEST_RES(result.another_file, _ret == 1);
+	TEST_RES(result.another_extra, _ret == NUM_LOWER_EXTRA);
+	TEST_RES(result.total_entries,
+		 _ret == 2 + 1 + NUM_UPPER_EXTRA + 1 + NUM_LOWER_EXTRA);
+}
+
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(umount(MERGED_DIR));
+	cleanup_overlay_tree();
+}
+
+END_SETUP()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -111,6 +111,7 @@ echo "All mount bind file test passed."
 ./mount/mount_move
 
 ./overlayfs/ovl_test
+./overlayfs/readdir_small_buffer
 
 ./procfs/dentry_cache
 ./procfs/mountstats


### PR DESCRIPTION
Fix incorrect behavior in `overlayfs` `readdir`: during whiteout-only pre-scan non-`.wh` entries were not skipped and could be inserted into the merged view.

Also correct `readdir_at` to return the number of entries visited.