### PR TITLE
Avoid assigning the init process to any process group or session

### DIFF
--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -4,7 +4,7 @@
 
 use ostd::{arch::cpu::context::UserContext, task::Task, user::UserContextApi};
 
-use super::Process;
+use super::{Process, Session};
 use crate::{
     fs::{
         thread_info::ThreadFsInfo,
@@ -39,7 +39,14 @@ pub fn spawn_init_process(
         create_default_init_process(argv, envp)?
     };
 
-    set_session_and_group(&process);
+    // Linux starts the init process without placing it in a process group or session.
+    // It joins one only after userspace first calls `setsid()`.
+    //
+    // Asterinas instead requires every process to belong to both a process group and
+    // a session. The init process is therefore placed in a bootstrap process group
+    // and session with PGID and SID set to zero. This preserves the same user-visible
+    // behavior.
+    set_bootstrap_session_and_group(&process);
 
     process.run();
 
@@ -111,12 +118,15 @@ fn create_init_process(
     Ok(init_proc)
 }
 
-fn set_session_and_group(process: &Arc<Process>) {
+fn set_bootstrap_session_and_group(process: &Arc<Process>) {
     // Locking order: PID table -> process group
     let mut pid_table = pid_table::pid_table_mut();
 
-    // Create a new process group and session for the process
-    process.set_new_session(&mut process.process_group.lock(), &mut pid_table);
+    // Add the process to the bootstrap process group and session
+    let (session, process_group) = Session::new_bootstrap_pair(process);
+    pid_table.insert_session(session.sid(), &session);
+    pid_table.insert_process_group(process_group.pgid(), &process_group);
+    *process.process_group.lock() = Some(process_group);
 
     // Add the new process to the global table
     pid_table.insert_process(process.pid(), process);

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -52,16 +52,23 @@ pub use process_group::ProcessGroup;
 pub use session::Session;
 pub use terminal::Terminal;
 
-/// Process id.
+/// Process ID.
 pub type Pid = u32;
+
 define_atomic_version_of_integer_like_type!(Pid, {
     #[derive(Debug)]
     pub struct AtomicPid(AtomicU32);
 });
-/// Process group id.
+
+/// Process group ID.
 pub type Pgid = u32;
-/// Session Id.
+/// Session ID.
 pub type Sid = u32;
+
+/// The process group ID for process group created by [`ProcessGroup::new_bootstrap`].
+const BOOTSTRAP_PGID: Pgid = 0;
+/// The session ID for the session created by [`Session::new_bootstrap_pair`].
+const BOOTSTRAP_SID: Sid = 0;
 
 pub type ExitCode = u32;
 

--- a/kernel/src/process/process/process_group.rs
+++ b/kernel/src/process/process/process_group.rs
@@ -2,7 +2,7 @@
 
 use alloc::collections::btree_map::Values;
 
-use super::{Pgid, Pid, Process, Session};
+use super::{BOOTSTRAP_PGID, BOOTSTRAP_SID, Pgid, Pid, Process, Session};
 use crate::{prelude::*, process::signal::signals::Signal};
 
 /// A process group.
@@ -27,16 +27,30 @@ impl ProcessGroup {
     ///
     /// The caller needs to ensure that the process does not belong to other process group.
     pub(super) fn new(process: &Arc<Process>, session: Arc<Session>) -> Arc<Self> {
-        let pid = process.pid();
+        Self::new_with(process.pid(), process, session)
+    }
 
+    /// Creates the bootstrap process group for the init process.
+    ///
+    /// The caller needs to ensure that the process is the init process,
+    /// the process does not belong to other process group, and
+    /// the session is the bootstrap session.
+    pub(super) fn new_bootstrap(process: &Arc<Process>, session: Arc<Session>) -> Arc<Self> {
+        debug_assert!(process.is_init_process());
+        debug_assert_eq!(session.sid(), BOOTSTRAP_SID);
+
+        Self::new_with(BOOTSTRAP_PGID, process, session)
+    }
+
+    fn new_with(pgid: Pgid, process: &Arc<Process>, session: Arc<Session>) -> Arc<Self> {
         let inner = {
             let mut processes = BTreeMap::new();
-            processes.insert(pid, Arc::downgrade(process));
+            processes.insert(process.pid(), Arc::downgrade(process));
             Inner { processes }
         };
 
         Arc::new(ProcessGroup {
-            pgid: pid,
+            pgid,
             session,
             inner: Mutex::new(inner),
         })

--- a/kernel/src/process/process/session.rs
+++ b/kernel/src/process/process/session.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{Pgid, Process, ProcessGroup, Sid, Terminal};
+use super::{BOOTSTRAP_SID, Pgid, Process, ProcessGroup, Sid, Terminal};
 use crate::prelude::*;
 
 /// A session.
@@ -32,19 +32,36 @@ impl Session {
     ///
     /// The caller needs to ensure that the process does not belong to other process group or other
     /// session.
-    pub(in crate::process) fn new_pair(process: &Arc<Process>) -> (Arc<Self>, Arc<ProcessGroup>) {
-        let session = Arc::new(Self {
-            sid: process.pid(),
-            inner: Mutex::new(Inner {
-                process_groups: BTreeMap::new(),
-                terminal: None,
-            }),
-        });
-
+    pub(super) fn new_pair(process: &Arc<Process>) -> (Arc<Self>, Arc<ProcessGroup>) {
+        let session = Self::new_empty(process.pid());
         let process_group = ProcessGroup::new(process, session.clone());
         session.lock().insert_process_group(&process_group);
 
         (session, process_group)
+    }
+
+    /// Creates the bootstrap session/process-group pair for the init process.
+    ///
+    /// The caller needs to ensure that the process is the init process
+    /// and does not belong to other process group or other session.
+    pub(super) fn new_bootstrap_pair(process: &Arc<Process>) -> (Arc<Self>, Arc<ProcessGroup>) {
+        debug_assert!(process.is_init_process());
+
+        let session = Self::new_empty(BOOTSTRAP_SID);
+        let process_group = ProcessGroup::new_bootstrap(process, session.clone());
+        session.lock().insert_process_group(&process_group);
+
+        (session, process_group)
+    }
+
+    fn new_empty(sid: Sid) -> Arc<Self> {
+        Arc::new(Self {
+            sid,
+            inner: Mutex::new(Inner {
+                process_groups: BTreeMap::new(),
+                terminal: None,
+            }),
+        })
     }
 
     /// Returns the session identifier.


### PR DESCRIPTION
The kata-agent requires that the first process (the init process) can call `setsid()` and have it succeed. However, our current implementation assigns a process group (PGID=1) and a session (SID=1) to the init process at creation time. This causes `setsid()` to fail, because a process that is already a process group leader is not permitted to create a new session.

https://github.com/asterinas/asterinas/blob/90607427ced656996fdd5d7423517b539e005670/kernel/src/process/process/mod.rs#L385-L390

On Linux, the init user process inherits `init_task` but is not explicitly assigned a process group or session — both are effectively None until user space takes action. It is only after the init process calls `setsid()` and `ioctl(TIOCSCTTY)` that it acquires a session, a process group, and a controlling terminal. However, strictly following this Linux behavior would break certain invariants in our implementation — for example, it would allow a process to exist without a process group. To avoid this, this PR adopts a pragmatic approach: the init process is placed in a dedicated bootstrap process group(PGID=0) and session(SID=0), distinct from any regular process group or session. So calling setsid will succeed for the init process.

Required by #2911.