### PR TITLE
Bind mount ns files

### DIFF
--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -28,6 +28,7 @@ use core::{
 pub use allocator::AnonDeviceId;
 pub use anon_inodefs::AnonInodeFs;
 use device_id::DeviceId;
+pub(in crate::fs) use nsfs::NsInode;
 pub use nsfs::{NsCommonOps, NsFile, NsType, StashedDentry};
 pub use pidfdfs::PidfdFs;
 pub(in crate::fs) use pipefs::PipeFs;

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -63,7 +63,7 @@ impl NsFs {
 }
 
 /// An inode representing a namespace entry in [`NsFs`].
-struct NsInode<T: NsCommonOps> {
+pub(in crate::fs) struct NsInode<T: NsCommonOps> {
     common: PseudoInode,
     ns: Arc<T>,
     name: String,
@@ -89,6 +89,10 @@ impl<T: NsCommonOps> NsInode<T> {
 
     fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(in crate::fs) fn ns(&self) -> &Arc<T> {
+        &self.ns
     }
 }
 
@@ -327,6 +331,26 @@ pub trait NsCommonOps: Any + Send + Sync + 'static + Sized {
 pub struct StashedDentry {
     ino: u64,
     dentry: Mutex<Weak<Dentry>>,
+}
+
+impl PartialEq for StashedDentry {
+    fn eq(&self, other: &Self) -> bool {
+        self.ino == other.ino
+    }
+}
+
+impl Eq for StashedDentry {}
+
+impl PartialOrd for StashedDentry {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StashedDentry {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.ino.cmp(&other.ino)
+    }
 }
 
 impl StashedDentry {

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -7,6 +7,7 @@ use core::time::Duration;
 pub(in crate::fs) use dentry::Dentry;
 use dentry::DirDentry;
 use inherit_methods_macro::inherit_methods;
+use mount::MountNsFileCopying;
 pub use mount::{Mount, MountPropType, PerMountFlags};
 pub use mount_namespace::MountNamespace;
 pub use resolver::{AT_FDCWD, AbsPathResult, FsPath, LookupResult, PathResolver, SplitPath};
@@ -16,6 +17,7 @@ use crate::{
         file::{
             CreationFlags, InodeHandle, InodeMode, InodeType, OpenArgs, Permission, StatusFlags,
         },
+        pseudofs::NsInode,
         vfs::{
             file_system::{FileSystem, FsFlags},
             inode::{Inode, Metadata, MknodType},
@@ -242,6 +244,13 @@ impl Path {
     }
 }
 
+fn try_get_mnt_ns_inode(dentry: &Dentry) -> Option<&NsInode<MountNamespace>> {
+    dentry
+        .inode()
+        .as_ref()
+        .downcast_ref::<NsInode<MountNamespace>>()
+}
+
 impl Path {
     /// Mounts a filesystem at the current path.
     ///
@@ -353,9 +362,12 @@ impl Path {
     ///
     /// # Errors
     ///
-    /// Returns `ENOTDIR` if the `dst_path` is not a directory.
-    /// Returns `EINVAL` if either source or destination path is not in the
-    /// current mount namespace.
+    /// Returns `ENOTDIR` if one of the source and destination is a directory
+    /// and the other is not.
+    ///
+    /// Returns `EINVAL` if any of the following holds:
+    /// - The destination path is not in the current mount namespace.
+    /// - The source path is a mount namespace file that would create a namespace loop.
     pub fn bind_mount_to(&self, dst_path: &Self, recursive: bool, ctx: &Context) -> Result<()> {
         let can_bind = {
             let src_is_dir = self.type_() == InodeType::Dir;
@@ -372,27 +384,29 @@ impl Path {
         let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
         let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
 
-        // Linux only checks whether the destination path belongs to the current mount namespace;
-        // it does not validate the source path.
-        // See <https://elixir.bootlin.com/linux/v6.19/source/fs/namespace.c#L2991>.
+        // Linux does not require the source path to belong to the current
+        // mount namespace, but still rejects source mount namespace files that
+        // would form loops.
         if !current_mnt_ns.owns(&dst_path.mount) {
             return_errno_with_message!(
                 Errno::EINVAL,
                 "the destination path is not in this mount namespace"
             );
         }
-
-        if dst_path
-            .mount_node()
-            .is_equal_or_descendant_of(self.mount_node())
-        {
+        if current_mnt_ns.would_form_mnt_ns_loop(&self.dentry) {
             return_errno_with_message!(
-                Errno::ELOOP,
-                "the destination path is inside the mount subtree"
+                Errno::EINVAL,
+                "the source is a mount namespace file that would create a namespace loop"
             );
         }
 
-        let new_mount = self.mount.clone_mount_tree(&self.dentry, None, recursive);
+        let current_mnt_ns_weak = Arc::downgrade(current_mnt_ns);
+        let new_mount = self.mount.clone_mount_tree(
+            &self.dentry,
+            &current_mnt_ns_weak,
+            recursive,
+            MountNsFileCopying::Copy,
+        );
         new_mount.graft_mount_tree(dst_path);
         Ok(())
     }
@@ -402,14 +416,15 @@ impl Path {
     /// # Errors
     ///
     /// Returns `ENOTDIR` if the `dst_path` is not a directory.
+    ///
     /// Returns `EINVAL` in the following cases:
     /// - The current path is not a mount root.
     /// - The mount of the current path is the root mount.
     /// - Either source or destination path is not in the current mount namespace.
-    /// - The mount tree contains a mount namespace file that would create a namespace loop.
     ///
-    /// Returns `ELOOP` if moving the mount tree would create a mount loop, for
-    /// example, when the destination path is inside the subtree being moved.
+    /// Returns `ELOOP` in the following cases:
+    /// - The destination path is inside the subtree being moved.
+    /// - The mount tree contains a mount namespace file that would create a namespace loop.
     pub fn move_mount_to(&self, dst_path: &Self, ctx: &Context) -> Result<()> {
         if !self.is_mount_root() {
             return_errno_with_message!(Errno::EINVAL, "the path is not a mount root");
@@ -432,6 +447,7 @@ impl Path {
                 "the destination path is not in this mount namespace"
             );
         }
+        current_mnt_ns.check_no_mnt_ns_loop_in_tree(self.mount_node())?;
         if dst_path
             .mount_node()
             .is_equal_or_descendant_of(self.mount_node())

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -374,11 +374,21 @@ impl Path {
 
         // Linux only checks whether the destination path belongs to the current mount namespace;
         // it does not validate the source path.
-        // See <https://elixir.bootlin.com/linux/v6.19/source/fs/namespace.c#L2991>.     
+        // See <https://elixir.bootlin.com/linux/v6.19/source/fs/namespace.c#L2991>.
         if !current_mnt_ns.owns(&dst_path.mount) {
             return_errno_with_message!(
                 Errno::EINVAL,
                 "the destination path is not in this mount namespace"
+            );
+        }
+
+        if dst_path
+            .mount_node()
+            .is_equal_or_descendant_of(self.mount_node())
+        {
+            return_errno_with_message!(
+                Errno::ELOOP,
+                "the destination path is inside the mount subtree"
             );
         }
 
@@ -395,7 +405,11 @@ impl Path {
     /// Returns `EINVAL` in the following cases:
     /// - The current path is not a mount root.
     /// - The mount of the current path is the root mount.
-    /// - Either source or destination path is not in the current mount namespace
+    /// - Either source or destination path is not in the current mount namespace.
+    /// - The mount tree contains a mount namespace file that would create a namespace loop.
+    ///
+    /// Returns `ELOOP` if moving the mount tree would create a mount loop, for
+    /// example, when the destination path is inside the subtree being moved.
     pub fn move_mount_to(&self, dst_path: &Self, ctx: &Context) -> Result<()> {
         if !self.is_mount_root() {
             return_errno_with_message!(Errno::EINVAL, "the path is not a mount root");

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -371,12 +371,10 @@ impl Path {
 
         let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
         let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
-        if !current_mnt_ns.owns(&self.mount) {
-            return_errno_with_message!(
-                Errno::EINVAL,
-                "the source path is not in this mount namespace"
-            );
-        }
+
+        // Linux only checks whether the destination path belongs to the current mount namespace;
+        // it does not validate the source path.
+        // See <https://elixir.bootlin.com/linux/v6.19/source/fs/namespace.c#L2991>.     
         if !current_mnt_ns.owns(&dst_path.mount) {
             return_errno_with_message!(
                 Errno::EINVAL,

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -7,6 +7,7 @@ use hashbrown::HashMap;
 use id_alloc::IdAlloc;
 use spin::Once;
 
+use super::try_get_mnt_ns_inode;
 use crate::{
     fs::{
         file::InodeType,
@@ -21,6 +22,15 @@ use crate::{
     },
     prelude::*,
 };
+
+/// Controls how recursive mount-tree cloning handles mount-namespace files.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MountNsFileCopying {
+    /// Preserves mount-namespace files, matching bind-mount semantics.
+    Copy,
+    /// Omits mount-namespace files, matching mount-namespace cloning semantics.
+    Skip,
+}
 
 /// Mount propagation types.
 ///
@@ -310,13 +320,8 @@ impl Mount {
     /// The new mount node will have the same fs as the original one and
     /// have no parent and children. We should set the parent and children manually.
     ///
-    /// If the `new_ns` is set, the new mount will belong to the given mount namespace.
-    /// Otherwise, it will belong to the same mount namespace as the current mount.
-    fn clone_mount(
-        &self,
-        root_dentry: &Arc<Dentry>,
-        new_ns: Option<&Weak<MountNamespace>>,
-    ) -> Arc<Self> {
+    /// The new mount will belong to the given mount namespace.
+    fn clone_mount(&self, root_dentry: &Arc<Dentry>, new_ns: &Weak<MountNamespace>) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| Self {
             id: ID_ALLOCATOR.get().unwrap().lock().alloc().unwrap(),
             root_dentry: root_dentry.clone(),
@@ -326,7 +331,7 @@ impl Mount {
             propagation: RwLock::new(MountPropType::default()),
             fs: self.fs.clone(),
             source: self.source.clone(),
-            mnt_ns: new_ns.cloned().unwrap_or_else(|| self.mnt_ns.clone()),
+            mnt_ns: new_ns.clone(),
             flags: AtomicPerMountFlags::new(self.flags.load(Ordering::Relaxed)),
             this: weak_self.clone(),
         })
@@ -341,13 +346,16 @@ impl Mount {
     /// If `recursive` is set to `true`, the entire tree will be copied.
     /// Otherwise, only the root mount node will be copied.
     ///
-    /// If the `new_ns` is set, the new mount tree will belong to the given mount namespace.
-    /// Otherwise, it will belong to the same mount namespace as the current mount.
+    /// If `mnt_ns_file_copying` is [`MountNsFileCopying::Skip`], mount namespace
+    /// file mounts are skipped while copying recursive subtrees.
+    ///
+    /// The new mount tree will belong to the given mount namespace.
     pub(super) fn clone_mount_tree(
         &self,
         root_dentry: &Arc<Dentry>,
-        new_ns: Option<&Weak<MountNamespace>>,
+        new_ns: &Weak<MountNamespace>,
         recursive: bool,
+        mnt_ns_file_copying: MountNsFileCopying,
     ) -> Arc<Self> {
         let new_root_mount = self.clone_mount(root_dentry, new_ns);
         if !recursive {
@@ -360,6 +368,12 @@ impl Mount {
             let new_parent_mount = new_stack.pop().unwrap();
             let old_children = old_mount.children.read();
             for old_child_mount in old_children.values() {
+                if mnt_ns_file_copying == MountNsFileCopying::Skip
+                    && try_get_mnt_ns_inode(old_child_mount.root_dentry()).is_some()
+                {
+                    continue;
+                }
+
                 let mountpoint = old_child_mount.mountpoint().unwrap();
                 if !mountpoint.is_equal_or_descendant_of(new_parent_mount.root_dentry()) {
                     continue;

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -2,11 +2,12 @@
 
 use spin::Once;
 
+use super::{mount::MountNsFileCopying, try_get_mnt_ns_inode};
 use crate::{
     fs::{
         fs_impls::ramfs::RamFs,
         pseudofs::{NsCommonOps, NsType, StashedDentry},
-        vfs::path::{Mount, Path, PathResolver},
+        vfs::path::{Dentry, Mount, Path, PathResolver},
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
@@ -25,6 +26,26 @@ pub struct MountNamespace {
     owner: Arc<UserNamespace>,
     /// The stashed dentry in nsfs.
     stashed_dentry: StashedDentry,
+}
+
+impl PartialEq for MountNamespace {
+    fn eq(&self, other: &Self) -> bool {
+        self.stashed_dentry == other.stashed_dentry
+    }
+}
+
+impl Eq for MountNamespace {}
+
+impl PartialOrd for MountNamespace {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MountNamespace {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.stashed_dentry.cmp(&other.stashed_dentry)
+    }
 }
 
 impl MountNamespace {
@@ -79,8 +100,12 @@ impl MountNamespace {
 
         let root_mount = &self.root;
         let new_mnt_ns = Arc::new_cyclic(|weak_self| {
-            let new_root =
-                root_mount.clone_mount_tree(root_mount.root_dentry(), Some(weak_self), true);
+            let new_root = root_mount.clone_mount_tree(
+                root_mount.root_dentry(),
+                weak_self,
+                true,
+                MountNsFileCopying::Skip,
+            );
             let stashed_dentry = StashedDentry::new();
             MountNamespace {
                 root: new_root,
@@ -118,6 +143,41 @@ impl MountNamespace {
     /// Checks whether a given mount belongs to this mount namespace.
     pub fn owns(self: &Arc<Self>, mount: &Mount) -> bool {
         mount.mnt_ns().as_ptr() == Arc::as_ptr(self)
+    }
+
+    /// Returns whether bind-mounting or moving `dentry` into this mount namespace
+    /// would create a mount-namespace loop.
+    pub(super) fn would_form_mnt_ns_loop(&self, dentry: &Dentry) -> bool {
+        let Some(mnt_ns_inode) = try_get_mnt_ns_inode(dentry) else {
+            return false;
+        };
+
+        self >= mnt_ns_inode.ns().as_ref()
+    }
+
+    /// Ensures that importing the mount subtree rooted at `root_mount` into this
+    /// mount namespace would not form a mount-namespace loop.
+    pub(super) fn check_no_mnt_ns_loop_in_tree(&self, root_mount: &Arc<Mount>) -> Result<()> {
+        let mut worklist = VecDeque::new();
+        worklist.push_back(root_mount.clone());
+
+        let mut checked_root_dentries = BTreeSet::new();
+
+        while let Some(mount) = worklist.pop_front() {
+            let root_dentry = mount.root_dentry();
+            if checked_root_dentries.insert(root_dentry.key())
+                && self.would_form_mnt_ns_loop(root_dentry)
+            {
+                return_errno_with_message!(
+                    Errno::ELOOP,
+                    "the mount tree contains a mount namespace file that would create a namespace loop"
+                );
+            }
+            let children = mount.children.read();
+            worklist.extend(children.values().cloned());
+        }
+
+        Ok(())
     }
 }
 

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -361,6 +361,128 @@ END_TEST()
 
 /* -------------------------------------------------------------------------- */
 
+#define BIND_MOUNT_PATH_TEMPLATE "/tmp/test_%s_ns"
+
+#define VERIFY_BIND_MOUNTED_NS(ns_file, expected_ns_type, bind_mount_path)     \
+	do {                                                                   \
+		int nsfd = TEST_SUCC(open(bind_mount_path, O_RDONLY));         \
+                                                                               \
+		TEST_RES(ioctl(nsfd, NS_GET_NSTYPE),                           \
+			 _ret == (expected_ns_type));                          \
+                                                                               \
+		if (strcmp((ns_file), "user") == 0) {                          \
+			TEST_ERRNO(ioctl(nsfd, NS_GET_USERNS), EPERM);         \
+			TEST_ERRNO(ioctl(nsfd, NS_GET_OWNER_UID, 0), EFAULT);  \
+                                                                               \
+			uid_t uid;                                             \
+			TEST_SUCC(ioctl(nsfd, NS_GET_OWNER_UID, &uid));        \
+		} else {                                                       \
+			int userns_fd = TEST_SUCC(ioctl(nsfd, NS_GET_USERNS)); \
+			TEST_SUCC(close(userns_fd));                           \
+                                                                               \
+			TEST_ERRNO(ioctl(nsfd, NS_GET_OWNER_UID, NULL),        \
+				   EINVAL);                                    \
+		}                                                              \
+                                                                               \
+		TEST_SUCC(close(nsfd));                                        \
+	} while (0)
+
+/*
+ * Verify that supported namespace files can be bind-mounted and queried via
+ * nsfs ioctls.
+ */
+FN_TEST(bind_mount_ns)
+{
+	char proc_ns_path[PATH_MAX];
+	char bind_mount_path[PATH_MAX];
+
+	for (size_t i = 0; i < ns_count; i++) {
+		snprintf(bind_mount_path, sizeof(bind_mount_path),
+			 BIND_MOUNT_PATH_TEMPLATE, ns_files[i]);
+
+		/* Ensure the mount-point file exists. */
+		int tmp_fd = TEST_SUCC(open(
+			bind_mount_path, O_CREAT | O_WRONLY | O_TRUNC, 0444));
+		TEST_SUCC(close(tmp_fd));
+
+		snprintf(proc_ns_path, sizeof(proc_ns_path), "/proc/self/ns/%s",
+			 ns_files[i]);
+
+		TEST_SUCC(mount(proc_ns_path, bind_mount_path, NULL, MS_BIND,
+				NULL));
+
+		VERIFY_BIND_MOUNTED_NS(ns_files[i], clone_flags[i],
+				       bind_mount_path);
+		TEST_SUCC(umount(bind_mount_path));
+
+		TEST_SUCC(unlink(bind_mount_path));
+	}
+}
+END_TEST()
+
+/*
+ * Verify bind-mounting behaviour for mount namespace files.
+ *
+ * Bind-mounting the current or an older mount namespace file should fail with
+ * EINVAL, and bind-mounting a newer mount namespace file should succeed.
+ */
+FN_TEST(bind_mount_mnt_ns)
+{
+	char proc_ns_path[PATH_MAX];
+	char bind_mount_path[PATH_MAX];
+	int status;
+
+	snprintf(bind_mount_path, sizeof(bind_mount_path),
+		 BIND_MOUNT_PATH_TEMPLATE, "mnt");
+
+	int tmp_fd = TEST_SUCC(
+		open(bind_mount_path, O_CREAT | O_WRONLY | O_TRUNC, 0444));
+	TEST_SUCC(close(tmp_fd));
+
+	TEST_ERRNO(mount("/proc/self/ns/mnt", bind_mount_path, NULL, MS_BIND,
+			 NULL),
+		   EINVAL);
+
+	struct clone_args args = {
+		.flags = CLONE_NEWNS,
+		.exit_signal = SIGCHLD,
+	};
+	pid_t child = TEST_SUCC(sys_clone3(&args));
+
+	if (child == 0) {
+		while (1)
+			sleep(1000);
+		_exit(1);
+	}
+
+	pid_t older_ns_child = TEST_SUCC(sys_clone3(&args));
+
+	if (older_ns_child == 0) {
+		snprintf(proc_ns_path, sizeof(proc_ns_path), "/proc/%d/ns/mnt",
+			 getppid());
+		CHECK_WITH(mount(proc_ns_path, bind_mount_path, NULL, MS_BIND,
+				 NULL),
+			   _ret < 0 && errno == EINVAL);
+		_exit(0);
+	}
+
+	TEST_RES(waitpid(older_ns_child, &status, 0),
+		 _ret == older_ns_child && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+
+	snprintf(proc_ns_path, sizeof(proc_ns_path), "/proc/%d/ns/mnt", child);
+	TEST_SUCC(mount(proc_ns_path, bind_mount_path, NULL, MS_BIND, NULL));
+	VERIFY_BIND_MOUNTED_NS("mnt", CLONE_NEWNS, bind_mount_path);
+	TEST_SUCC(umount(bind_mount_path));
+
+	TEST_SUCC(kill(child, SIGKILL));
+	TEST_RES(waitpid(child, &status, 0),
+		 _ret == child && WIFSIGNALED(status) &&
+			 WTERMSIG(status) == SIGKILL);
+
+	TEST_SUCC(unlink(bind_mount_path));
+}
+END_TEST()
 #define BIND_MOUNT_PATH "/tmp/test_uts_ns"
 
 /*
@@ -373,10 +495,9 @@ END_TEST()
  * exit, then verifies that ioctl(2) still works (the bind mount keeps
  * the namespace alive). Finally the mount is cleaned up.
  *
- * On Asterinas, bind-mounting namespace files is not yet supported, 
- * so we only verify that the mount(2) call fails with EINVAL. 
- * See the discussion at
- * <https://github.com/asterinas/asterinas/pull/2966#discussion_r2870191714>.
+ * The bind mount should keep the namespace alive even after the creating
+ * process exits, so the mounted path must continue to behave like an `nsfs`
+ * file until it is unmounted.
  */
 FN_TEST(bind_mount_ns_lifetime)
 {
@@ -403,11 +524,6 @@ FN_TEST(bind_mount_ns_lifetime)
 	/* 2. Bind-mount /proc/<child>/ns/uts to BIND_MOUNT_PATH. */
 	snprintf(proc_ns_path, sizeof(proc_ns_path), "/proc/%d/ns/uts", child);
 
-#ifdef __asterinas__
-	/* Asterinas does not yet support bind-mounting namespace files. */
-	TEST_ERRNO(mount(proc_ns_path, BIND_MOUNT_PATH, NULL, MS_BIND, NULL),
-		   EINVAL);
-#else
 	TEST_SUCC(mount(proc_ns_path, BIND_MOUNT_PATH, NULL, MS_BIND, NULL));
 
 	/* 3. Verify ioctl works on the bind-mounted path while the child is alive. */
@@ -416,7 +532,6 @@ FN_TEST(bind_mount_ns_lifetime)
 	int userns_fd = TEST_SUCC(ioctl(nsfd, NS_GET_USERNS));
 	TEST_SUCC(close(userns_fd));
 	TEST_SUCC(close(nsfd));
-#endif
 
 	/* 4. Kill the child and wait for it to exit. */
 	TEST_SUCC(kill(child, SIGKILL));
@@ -425,7 +540,6 @@ FN_TEST(bind_mount_ns_lifetime)
 		 _ret == child && WIFSIGNALED(status) &&
 			 WTERMSIG(status) == SIGKILL);
 
-#ifndef __asterinas__
 	/* 5. Verify ioctl still works after the child has exited.
 	 *    The bind mount keeps the namespace alive. */
 	nsfd = TEST_SUCC(open(BIND_MOUNT_PATH, O_RDONLY));
@@ -436,11 +550,66 @@ FN_TEST(bind_mount_ns_lifetime)
 
 	/* 6. Clean up: unmount and remove the mount point. */
 	TEST_SUCC(umount(BIND_MOUNT_PATH));
-#endif
 	TEST_SUCC(unlink(BIND_MOUNT_PATH));
 }
 END_TEST()
 
+/*
+ * Verify that mount namespace file bind mounts are not copied into a cloned
+ * mount namespace.
+ */
+FN_TEST(clone_newns_skips_bind_mounted_mnt_ns)
+{
+	char proc_ns_path[PATH_MAX];
+	char bind_mount_path[PATH_MAX];
+
+	snprintf(bind_mount_path, sizeof(bind_mount_path),
+		 BIND_MOUNT_PATH_TEMPLATE, "mnt_clone");
+
+	int tmp_fd = TEST_SUCC(
+		open(bind_mount_path, O_CREAT | O_WRONLY | O_TRUNC, 0444));
+	TEST_SUCC(close(tmp_fd));
+
+	struct clone_args args = {
+		.flags = CLONE_NEWNS,
+		.exit_signal = SIGCHLD,
+	};
+	pid_t holder = TEST_SUCC(sys_clone3(&args));
+
+	if (holder == 0) {
+		while (1)
+			sleep(1000);
+		_exit(1);
+	}
+
+	snprintf(proc_ns_path, sizeof(proc_ns_path), "/proc/%d/ns/mnt", holder);
+	TEST_SUCC(mount(proc_ns_path, bind_mount_path, NULL, MS_BIND, NULL));
+
+	pid_t inspector = TEST_SUCC(fork());
+
+	if (inspector == 0) {
+		CHECK(unshare(CLONE_NEWNS));
+
+		int nsfd = CHECK(open(bind_mount_path, O_RDONLY));
+		CHECK_WITH(ioctl(nsfd, NS_GET_NSTYPE),
+			   _ret < 0 && errno == ENOTTY);
+		CHECK(close(nsfd));
+		_exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(inspector, &status, 0),
+		 _ret == inspector && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(umount(bind_mount_path));
+	TEST_SUCC(kill(holder, SIGKILL));
+	TEST_RES(waitpid(holder, &status, 0),
+		 _ret == holder && WIFSIGNALED(status) &&
+			 WTERMSIG(status) == SIGKILL);
+	TEST_SUCC(unlink(bind_mount_path));
+}
+END_TEST()
 /* -------------------------------------------------------------------------- */
 
 /*

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -388,7 +388,7 @@ END_TEST()
 	} while (0)
 
 /*
- * Verify that supported namespace files can be bind-mounted and queried via
+ * Verify that non-mount namespace files can be bind-mounted and queried via
  * nsfs ioctls.
  */
 FN_TEST(bind_mount_ns)
@@ -397,6 +397,9 @@ FN_TEST(bind_mount_ns)
 	char bind_mount_path[PATH_MAX];
 
 	for (size_t i = 0; i < ns_count; i++) {
+		if (clone_flags[i] == CLONE_NEWNS)
+			continue;
+
 		snprintf(bind_mount_path, sizeof(bind_mount_path),
 			 BIND_MOUNT_PATH_TEMPLATE, ns_files[i]);
 


### PR DESCRIPTION
  This PR improves Linux compatibility for `nsfs` bind mounts and updates `proc_nsfs`.

 This PR contains 4 commits: 

  1. Enable `nsfs` bind-mount tests on Asterinas.
  2. Check only the destination mount namespace for bind mounts.
  3. Refactor the mount-loop check helper.
  4. Align mount-namespace `nsfs` bind-mount behavior with Linux.