### PR TITLE
Fix virtio-blk flush descriptor count miscalculation

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -493,7 +493,8 @@ impl DeviceInner {
             resp_slice
         };
 
-        let num_used_descs = 1;
+        // One descriptor for the input `req_slice`, one for the output `resp_slice`.
+        let num_used_descs = 2;
         loop {
             let mut queue = self.queue.disable_irq().lock();
             if num_used_descs > queue.available_desc() {


### PR DESCRIPTION
## Problem
In the `flush` method of the virtio-blk driver, the pre‑flight capacity check incorrectly hardcodes `num_used_descs = 1`.
However, the subsequent `add_dma_buf` call submits 2 buffers (1 input `req_slice` + 1 output `resp_slice`), which requires 2 available descriptors.

When the virtqueue has exactly 1 free descriptor slot, the pre‑flight check passes (1 <= 1), but `add_dma_buf `rejects the request because `1 (input) + 1 (output) + num_used > queue_size`, returning BufferTooSmall. The following `.expect()` then triggers a kernel panic.

## How to reproduce
xfstests generic/273 (multiple threads creating and copying files) reliably hits this bug:

```
❯  /xfstests # ./run_xfstests.sh generic/273
FSTYP         -- ext2
PLATFORM      -- Linux/x86_64 (none) 5.13.0 #1 SMP Thu Jan  1 00:00:00 UTC 1970
MKFS_OPTIONS  -- -F -F /dev/vdd
MOUNT_OPTIONS -- -o noload,noacl /dev/vdd /xfstests/scratch
generic/273       [   517.267] ERROR: Uncaught panic:
        add queue failed: BufferTooSmall
        at /root/asterinas/kernel/comps/virtio/src/device/block/device.rs:504
        on CPU 0 by thread Some(Thread { task: (Weak), data: Any { .. }, is_exited: false, cpu_affinity:
AtomicIdSet { bits: [1], phantom: PhantomDataostd::cpu::id::CpuId }, sched_attr: SchedAttr { policy:
SchedPolicyState { kind: AtomicSchedPolicyKind(2), policy: UnsafeCell { .. } }, last_cpu: AtomicCpuId(0),
real_time: RealTimeAttr { prio: 99, time_slice: 44879180 }, fair: FairAttr { weight: 1024, pending_weight: 0,
vruntime: 58202351858 } } })
make: *** [Makefile:311: run_kernel] Error 1
```

## How to fix
Change `num_used_descs` from 1 to 2 to match the actual number of buffers passed to add_dma_buf.