### PR TITLE
Support cgroup namespace

### DIFF
--- a/kernel/src/fs/fs_impls/cgroupfs/cgroup_ns.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/cgroup_ns.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::Arc;
+
+use aster_systree::SysBranchNode;
+use spin::Once;
+
+use crate::{
+    fs::{
+        cgroupfs::{CgroupNode, CgroupSysNode, CgroupSystem},
+        pseudofs::{NsCommonOps, NsType, StashedDentry},
+    },
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// The cgroup namespace for the unified cgroup hierarchy.
+pub struct CgroupNamespace {
+    root: Arc<dyn CgroupSysNode>,
+    owner: Arc<UserNamespace>,
+    stashed_dentry: StashedDentry,
+}
+
+impl CgroupNamespace {
+    /// Returns a reference to the singleton initial cgroup namespace.
+    pub fn get_init_singleton() -> &'static Arc<Self> {
+        static INIT: Once<Arc<CgroupNamespace>> = Once::new();
+
+        INIT.call_once(|| {
+            Arc::new(Self {
+                root: CgroupSystem::singleton().clone(),
+                owner: UserNamespace::get_init_singleton().clone(),
+                stashed_dentry: StashedDentry::new(),
+            })
+        })
+    }
+
+    /// Creates a new cgroup namespace rooted at the given cgroup.
+    pub fn new_clone(
+        current_cgroup: Option<Arc<CgroupNode>>,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+
+        let root: Arc<dyn CgroupSysNode> = match current_cgroup {
+            Some(current_cgroup) => current_cgroup,
+            None => CgroupSystem::singleton().clone(),
+        };
+
+        Ok(Arc::new(Self {
+            root,
+            owner,
+            stashed_dentry: StashedDentry::new(),
+        }))
+    }
+
+    /// Returns the cgroup subtree root exposed by this namespace.
+    pub fn root_node(&self) -> Arc<dyn SysBranchNode> {
+        self.root.clone()
+    }
+
+    /// Renders the cgroup path visible from this namespace.
+    ///
+    /// Linux reports `/proc/[pid]/cgroup` relative to the namespace root.
+    /// When the target lies outside that subtree, the path climbs up with
+    /// `..` components instead of failing.
+    pub fn virtualize_path(&self, cgroup: Arc<dyn CgroupSysNode>) -> String {
+        let root_path = self.root.path();
+        let cgroup_path = cgroup.path();
+        virtualize_path_from(root_path.as_ref(), cgroup_path.as_ref())
+    }
+}
+
+fn virtualize_path_from(root_path: &str, target_path: &str) -> String {
+    fn path_components(path: &str) -> impl Iterator<Item = &str> + Clone + '_ {
+        path.split('/').filter(|component| !component.is_empty())
+    }
+
+    let root_components = path_components(root_path);
+    let target_components = path_components(target_path);
+    let shared_len = root_components
+        .clone()
+        .zip(target_components.clone())
+        .take_while(|(root_component, target_component)| root_component == target_component)
+        .count();
+    let root_suffix = root_components.clone().skip(shared_len);
+    let target_suffix = target_components.clone().skip(shared_len);
+
+    // `SysObj::path()` already returns canonical absolute cgroup paths, so
+    // virtualization reduces to computing a relative path between them.
+    root_suffix
+        .map(|_| "..")
+        .chain(target_suffix)
+        .fold(String::from("/"), |mut path, component| {
+            if path.len() > 1 {
+                path.push('/');
+            }
+            path.push_str(component);
+            path
+        })
+}
+
+impl NsCommonOps for CgroupNamespace {
+    const TYPE: NsType = NsType::Cgroup;
+
+    fn owner_user_ns(&self) -> Option<&Arc<UserNamespace>> {
+        Some(&self.owner)
+    }
+
+    fn parent(&self) -> Result<&Arc<Self>> {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "a cgroup namespace does not have a parent namespace"
+        );
+    }
+
+    fn stashed_dentry(&self) -> &StashedDentry {
+        &self.stashed_dentry
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::virtualize_path_from;
+
+    #[ktest]
+    fn virtualize_cgroup_path_for_same_node() {
+        assert_eq!(virtualize_path_from("/", "/"), "/");
+        assert_eq!(virtualize_path_from("/base", "/base"), "/");
+    }
+
+    #[ktest]
+    fn virtualize_cgroup_path_for_descendant() {
+        assert_eq!(virtualize_path_from("/base", "/base/nested"), "/nested");
+    }
+
+    #[ktest]
+    fn virtualize_cgroup_path_for_sibling() {
+        assert_eq!(virtualize_path_from("/base", "/peer"), "/../peer");
+    }
+
+    #[ktest]
+    fn virtualize_cgroup_path_for_ancestor() {
+        assert_eq!(virtualize_path_from("/base", "/"), "/..");
+    }
+}

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -4,13 +4,13 @@ use alloc::sync::Arc;
 
 use aster_block::BlockDevice;
 use aster_systree::EmptyNode;
+use ostd::task::Task;
 use spin::Once;
 
 use super::inode::CgroupInode;
 use crate::{
     fs::{
         Result,
-        cgroupfs::systree_node::CgroupSystem,
         pseudofs::AnonDeviceId,
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
@@ -20,13 +20,13 @@ use crate::{
         },
     },
     prelude::*,
+    process::posix_thread::AsThreadLocal,
 };
 
 /// A file system for managing cgroups.
 pub(super) struct CgroupFs {
     _anon_device_id: AnonDeviceId,
     sb: SuperBlock,
-    root: Arc<dyn Inode>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
 
@@ -40,19 +40,17 @@ impl CgroupFs {
     pub(super) fn singleton() -> &'static Arc<CgroupFs> {
         static SINGLETON: Once<Arc<CgroupFs>> = Once::new();
 
-        SINGLETON.call_once(|| Self::new(CgroupSystem::singleton().clone()))
+        SINGLETON.call_once(Self::new)
     }
 
-    fn new(root_node: Arc<CgroupSystem>) -> Arc<Self> {
+    fn new() -> Arc<Self> {
         let anon_device_id =
             AnonDeviceId::acquire().expect("no device ID is available for cgroupfs");
         let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
-        let root_inode = CgroupInode::new_root(root_node, &sb);
 
         Arc::new(Self {
             _anon_device_id: anon_device_id,
             sb,
-            root: root_inode,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
     }
@@ -69,7 +67,12 @@ impl FileSystem for CgroupFs {
     }
 
     fn root_inode(&self) -> Arc<dyn Inode> {
-        self.root.clone()
+        let current_task = Task::current().unwrap();
+        let thread_local = current_task.as_thread_local().unwrap();
+        let ns_proxy = thread_local.borrow_ns_proxy();
+        let cgroup_namespace = ns_proxy.unwrap().cgroup_ns();
+
+        CgroupInode::new_root(cgroup_namespace.root_node(), &self.sb)
     }
 
     fn sb(&self) -> SuperBlock {

--- a/kernel/src/fs/fs_impls/cgroupfs/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/mod.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
+pub use cgroup_ns::CgroupNamespace;
 use fs::CgroupFsType;
+pub(in crate::fs) use systree_node::CgroupSystem;
 pub use systree_node::{CgroupMembership, CgroupNode, CgroupSysNode};
 
+mod cgroup_ns;
 mod controller;
 mod fs;
 mod inode;

--- a/kernel/src/fs/fs_impls/cgroupfs/systree_node.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/systree_node.rs
@@ -273,7 +273,7 @@ impl CgroupMembership {
 ///
 /// The cgroup system provides v2 unified hierarchy, and is also used as a root
 /// node in the cgroup systree.
-pub(super) struct CgroupSystem {
+pub(in crate::fs) struct CgroupSystem {
     fields: BranchNodeFields<CgroupNode, Self>,
     controller: Controller,
 }
@@ -344,7 +344,7 @@ impl CgroupNode {
 
 impl CgroupSystem {
     /// Returns the `CgroupSystem` singleton.
-    pub(super) fn singleton() -> &'static Arc<CgroupSystem> {
+    pub(in crate::fs) fn singleton() -> &'static Arc<CgroupSystem> {
         static SINGLETON: Once<Arc<CgroupSystem>> = Once::new();
 
         SINGLETON.call_once(Self::new)

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_systree::SysObj;
 use aster_util::printer::VmPrinter;
+use ostd::task::Task;
 
 use crate::{
     fs::{
+        cgroupfs::{CgroupSysNode, CgroupSystem},
         file::mkmod,
         procfs::{
             pid::TidDirOps,
@@ -13,6 +14,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    process::posix_thread::AsThreadLocal,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/cgroup` (and also `/proc/[pid]/cgroup`).
@@ -30,13 +32,16 @@ impl CgroupFileOps {
 
 impl FileOps for CgroupFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let path = self
-            .0
-            .process_ref
-            .cgroup()
-            .get()
-            .map(|cgroup| cgroup.path())
-            .unwrap_or_else(|| "/".into());
+        let cgroup: Arc<dyn CgroupSysNode> = match self.0.process_ref.cgroup().get() {
+            Some(cgroup) => cgroup.clone(),
+            None => CgroupSystem::singleton().clone(),
+        };
+
+        let current_task = Task::current().unwrap();
+        let thread_local = current_task.as_thread_local().unwrap();
+        let ns_proxy = thread_local.borrow_ns_proxy();
+        let cgroup_ns = ns_proxy.unwrap().cgroup_ns();
+        let path = cgroup_ns.virtualize_path(cgroup);
 
         let mut printer = VmPrinter::new_skip(writer, offset);
         writeln!(printer, "0::{}", path)?;

--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -7,6 +7,7 @@ use ostd::sync::RwMutexUpgradeableGuard;
 
 use crate::{
     fs::{
+        cgroupfs::CgroupNamespace,
         file::mkmod,
         procfs::{
             pid::TidDirOps,
@@ -46,29 +47,33 @@ impl NsDirOps {
 /// Namespace entries backed by the thread's [`NsProxy`].
 #[derive(Clone, Copy)]
 enum NsProxyEntry {
-    /// The UTS namespace.
-    Uts,
+    /// The cgroup namespace.
+    Cgroup,
     /// The mount namespace.
     Mnt,
+    /// The UTS namespace.
+    Uts,
 }
 
 impl NsProxyEntry {
     /// All supported `NsProxy`-backed namespace entries.
-    const ALL: &[Self] = &[Self::Uts, Self::Mnt];
+    const ALL: &[Self] = &[Self::Cgroup, Self::Mnt, Self::Uts];
 
     /// Returns the filename of this namespace entry under `/proc/[pid]/ns/`.
     fn as_str(self) -> &'static str {
         match self {
-            Self::Uts => "uts",
+            Self::Cgroup => "cgroup",
             Self::Mnt => "mnt",
+            Self::Uts => "uts",
         }
     }
 
     /// Parses a namespace entry name, returning `None` for unrecognized names.
     fn from_str(s: &str) -> Option<Self> {
         match s {
-            "uts" => Some(Self::Uts),
+            "cgroup" => Some(Self::Cgroup),
             "mnt" => Some(Self::Mnt),
+            "uts" => Some(Self::Uts),
             _ => None,
         }
     }
@@ -76,18 +81,22 @@ impl NsProxyEntry {
     /// Creates a symlink inode for this namespace entry.
     fn new_sym_inode(self, ns_proxy: &NsProxy, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         match self {
-            Self::Uts => NsSymOps::<UtsNamespace>::new_inode(ns_proxy.uts_ns().get_path(), parent),
+            Self::Cgroup => {
+                NsSymOps::<CgroupNamespace>::new_inode(ns_proxy.cgroup_ns().get_path(), parent)
+            }
             Self::Mnt => {
                 NsSymOps::<MountNamespace>::new_inode(ns_proxy.mnt_ns().get_path(), parent)
             }
+            Self::Uts => NsSymOps::<UtsNamespace>::new_inode(ns_proxy.uts_ns().get_path(), parent),
         }
     }
 
     /// Returns the current namespace path for this entry.
     fn current_path(self, ns_proxy: &NsProxy) -> Path {
         match self {
-            Self::Uts => ns_proxy.uts_ns().get_path(),
+            Self::Cgroup => ns_proxy.cgroup_ns().get_path(),
             Self::Mnt => ns_proxy.mnt_ns().get_path(),
+            Self::Uts => ns_proxy.uts_ns().get_path(),
         }
     }
 }
@@ -96,13 +105,16 @@ impl NsProxyEntry {
 ///
 /// Returns `None` if the inode is not a known namespace symlink type.
 fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<CgroupNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<MountNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<UserNamespace>>() {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<UtsNamespace>>() {
-        return Some(&sym.inner().ns_path);
-    }
-    if let Some(sym) = inode.downcast_ref::<NsSymlink<MountNamespace>>() {
         return Some(&sym.inner().ns_path);
     }
     // TODO: Support additional namespace types.
@@ -223,12 +235,16 @@ impl DirOps for NsDirOps {
             return false;
         };
 
-        if child.downcast_ref::<NsSymlink<UtsNamespace>>().is_some() {
-            return cached_path == &ns_proxy.uts_ns().get_path();
+        if child.downcast_ref::<NsSymlink<CgroupNamespace>>().is_some() {
+            return cached_path == &ns_proxy.cgroup_ns().get_path();
         }
 
         if child.downcast_ref::<NsSymlink<MountNamespace>>().is_some() {
             return cached_path == &ns_proxy.mnt_ns().get_path();
+        }
+
+        if child.downcast_ref::<NsSymlink<UtsNamespace>>().is_some() {
+            return cached_path == &ns_proxy.uts_ns().get_path();
         }
 
         // TODO: Support additional namespace types.

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -351,32 +351,31 @@ impl StashedDentry {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NsType {
-    Uts,
-    User,
+    Cgroup,
+    #[expect(unused)]
+    Ipc,
     Mnt,
+    #[expect(unused)]
+    Net,
     #[expect(unused)]
     Pid,
     #[expect(unused)]
     Time,
-    #[expect(unused)]
-    Cgroup,
-    #[expect(unused)]
-    Ipc,
-    #[expect(unused)]
-    Net,
+    User,
+    Uts,
 }
 
 impl NsType {
     const fn as_str(&self) -> &'static str {
         match self {
-            NsType::Uts => "uts",
-            NsType::User => "user",
-            NsType::Mnt => "mnt",
-            NsType::Pid => "pid",
-            NsType::Time => "time",
             NsType::Cgroup => "cgroup",
             NsType::Ipc => "ipc",
+            NsType::Mnt => "mnt",
             NsType::Net => "net",
+            NsType::Pid => "pid",
+            NsType::Time => "time",
+            NsType::User => "user",
+            NsType::Uts => "uts",
         }
     }
 }
@@ -384,14 +383,14 @@ impl NsType {
 impl From<NsType> for CloneFlags {
     fn from(value: NsType) -> Self {
         match value {
-            NsType::Uts => CloneFlags::CLONE_NEWUTS,
-            NsType::User => CloneFlags::CLONE_NEWUSER,
-            NsType::Mnt => CloneFlags::CLONE_NEWNS,
-            NsType::Pid => CloneFlags::CLONE_NEWPID,
-            NsType::Time => CloneFlags::CLONE_NEWTIME,
             NsType::Cgroup => CloneFlags::CLONE_NEWCGROUP,
             NsType::Ipc => CloneFlags::CLONE_NEWIPC,
+            NsType::Mnt => CloneFlags::CLONE_NEWNS,
             NsType::Net => CloneFlags::CLONE_NEWNET,
+            NsType::Pid => CloneFlags::CLONE_NEWPID,
+            NsType::Time => CloneFlags::CLONE_NEWTIME,
+            NsType::User => CloneFlags::CLONE_NEWUSER,
+            NsType::Uts => CloneFlags::CLONE_NEWUTS,
         }
     }
 }

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -22,6 +22,11 @@ pub trait FileSystem: Any + Sync + Send {
     fn sync(&self) -> Result<()>;
 
     /// Returns the root inode of this file system.
+    ///
+    /// For each mount, the VFS invokes this method only once and eagerly when
+    /// it creates the mount root. It never defers the lookup to a later path
+    /// walk. For mounts created by `mount()`, the call happens in the thread
+    /// context that performs the syscall.
     fn root_inode(&self) -> Arc<dyn Inode>;
 
     /// Returns the super block of this file system.

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -259,7 +259,9 @@ impl CloneFlags {
             | CloneFlags::CLONE_CHILD_SETTID
             | CloneFlags::CLONE_CHILD_CLEARTID
             | CloneFlags::CLONE_VFORK
+            | CloneFlags::CLONE_NEWCGROUP
             | CloneFlags::CLONE_NEWNS
+            | CloneFlags::CLONE_NEWUTS
             | CloneFlags::CLONE_PARENT;
         let unsupported_flags = *self - supported_flags;
         if !unsupported_flags.is_empty() {
@@ -378,8 +380,9 @@ fn clone_child_task(
     let child_ns_proxy = clone_ns_proxy(
         thread_local.borrow_ns_proxy().unwrap(),
         &child_user_ns,
-        clone_flags,
+        process,
         posix_thread,
+        clone_flags,
     )?;
 
     // Clone default timer slack
@@ -492,8 +495,9 @@ fn clone_child_process(
     let child_ns_proxy = clone_ns_proxy(
         thread_local.borrow_ns_proxy().unwrap(),
         &child_user_ns,
-        clone_flags,
+        process,
         posix_thread,
+        clone_flags,
     )?;
 
     // Clone default timer slack
@@ -747,10 +751,11 @@ fn clone_user_ns(
 fn clone_ns_proxy(
     parent_ns_proxy: &Arc<NsProxy>,
     user_ns: &Arc<UserNamespace>,
-    clone_flags: CloneFlags,
+    process: &Process,
     posix_thread: &PosixThread,
+    clone_flags: CloneFlags,
 ) -> Result<Arc<NsProxy>> {
-    parent_ns_proxy.new_clone(user_ns, clone_flags, posix_thread)
+    parent_ns_proxy.new_clone(user_ns, process, posix_thread, clone_flags)
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -3,10 +3,10 @@
 use spin::Once;
 
 use crate::{
-    fs::vfs::path::MountNamespace,
+    fs::{cgroupfs::CgroupNamespace, vfs::path::MountNamespace},
     net::uts_ns::UtsNamespace,
     prelude::*,
-    process::{CloneFlags, UserNamespace, posix_thread::PosixThread},
+    process::{CloneFlags, Process, UserNamespace, posix_thread::PosixThread},
 };
 
 /// A struct that acts as a per-thread proxy to give access to most namespaces.
@@ -17,8 +17,9 @@ use crate::{
 /// 1. The user namespace, which is included in the `Process` struct.
 /// 2. The PID namespace, which is included in the `Process` struct (TODO).
 pub struct NsProxy {
-    uts_ns: Arc<UtsNamespace>,
+    cgroup_ns: Arc<CgroupNamespace>,
     mnt_ns: Arc<MountNamespace>,
+    uts_ns: Arc<UtsNamespace>,
 }
 
 impl NsProxy {
@@ -27,8 +28,9 @@ impl NsProxy {
         static INIT: Once<Arc<NsProxy>> = Once::new();
         INIT.call_once(|| {
             Arc::new(NsProxy {
-                uts_ns: UtsNamespace::get_init_singleton().clone(),
+                cgroup_ns: CgroupNamespace::get_init_singleton().clone(),
                 mnt_ns: MountNamespace::get_init_singleton().clone(),
+                uts_ns: UtsNamespace::get_init_singleton().clone(),
             })
         })
     }
@@ -45,8 +47,9 @@ impl NsProxy {
     pub(in crate::process) fn new_clone(
         self: &Arc<Self>,
         user_ns: &Arc<UserNamespace>,
-        clone_flags: CloneFlags,
+        process: &Process,
         posix_thread: &PosixThread,
+        clone_flags: CloneFlags,
     ) -> Result<Arc<Self>> {
         let clone_ns_flags = (clone_flags & CloneFlags::CLONE_NS_FLAGS) - CloneFlags::CLONE_NEWUSER;
 
@@ -63,9 +66,11 @@ impl NsProxy {
 
         let mut builder = NsProxyBuilder::new(self);
 
-        if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
-            let uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
-            builder.uts_ns(uts_ns);
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWCGROUP) {
+            let current_cgroup = process.cgroup().get().as_deref().map(Arc::clone);
+            let new_cgroup_ns =
+                CgroupNamespace::new_clone(current_cgroup, user_ns.clone(), posix_thread)?;
+            builder.cgroup_ns(new_cgroup_ns);
         }
 
         if clone_ns_flags.contains(CloneFlags::CLONE_NEWNS) {
@@ -73,19 +78,29 @@ impl NsProxy {
             builder.mnt_ns(new_mnt_ns);
         }
 
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
+            let uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
+            builder.uts_ns(uts_ns);
+        }
+
         // TODO: Support other namespaces.
 
         Ok(Arc::new(builder.build()))
     }
 
-    /// Returns the associated UTS namespace.
-    pub fn uts_ns(&self) -> &Arc<UtsNamespace> {
-        &self.uts_ns
+    /// Returns the associated cgroup namespace.
+    pub fn cgroup_ns(&self) -> &Arc<CgroupNamespace> {
+        &self.cgroup_ns
     }
 
     /// Returns the associated mount namespace.
     pub fn mnt_ns(&self) -> &Arc<MountNamespace> {
         &self.mnt_ns
+    }
+
+    /// Returns the associated UTS namespace.
+    pub fn uts_ns(&self) -> &Arc<UtsNamespace> {
+        &self.uts_ns
     }
 }
 
@@ -95,8 +110,9 @@ pub struct NsProxyBuilder<'a> {
     old_proxy: &'a NsProxy,
 
     // Fields for new namespaces.
-    uts_ns: Option<Arc<UtsNamespace>>,
+    cgroup_ns: Option<Arc<CgroupNamespace>>,
     mnt_ns: Option<Arc<MountNamespace>>,
+    uts_ns: Option<Arc<UtsNamespace>>,
 }
 
 impl<'a> NsProxyBuilder<'a> {
@@ -104,14 +120,15 @@ impl<'a> NsProxyBuilder<'a> {
     pub fn new(old_proxy: &'a NsProxy) -> Self {
         Self {
             old_proxy,
-            uts_ns: None,
+            cgroup_ns: None,
             mnt_ns: None,
+            uts_ns: None,
         }
     }
 
-    /// Sets the new UTS namespace.
-    pub fn uts_ns(&mut self, uts_ns: Arc<UtsNamespace>) -> &mut Self {
-        self.uts_ns = Some(uts_ns);
+    /// Sets the new cgroup namespace for the context being built.
+    pub fn cgroup_ns(&mut self, cgroup_ns: Arc<CgroupNamespace>) -> &mut Self {
+        self.cgroup_ns = Some(cgroup_ns);
         self
     }
 
@@ -121,20 +138,29 @@ impl<'a> NsProxyBuilder<'a> {
         self
     }
 
+    /// Sets the new UTS namespace for the context being built.
+    pub fn uts_ns(&mut self, uts_ns: Arc<UtsNamespace>) -> &mut Self {
+        self.uts_ns = Some(uts_ns);
+        self
+    }
+
     /// Builds the new `NsProxy`.
     pub fn build(self) -> NsProxy {
         let Self {
             old_proxy,
-            uts_ns: new_uts,
+            cgroup_ns: new_cgroup,
             mnt_ns: new_mnt,
+            uts_ns: new_uts,
         } = self;
 
-        let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
+        let new_cgroup = new_cgroup.unwrap_or_else(|| old_proxy.cgroup_ns.clone());
         let new_mnt = new_mnt.unwrap_or_else(|| old_proxy.mnt_ns.clone());
+        let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
 
         NsProxy {
-            uts_ns: new_uts,
+            cgroup_ns: new_cgroup,
             mnt_ns: new_mnt,
+            uts_ns: new_uts,
         }
     }
 }
@@ -143,7 +169,9 @@ impl<'a> NsProxyBuilder<'a> {
 ///
 /// This method does _not_ check CLONE_NEWUSER since it's handled separately.
 pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
-    const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWUTS.union(CloneFlags::CLONE_NEWNS);
+    const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWCGROUP
+        .union(CloneFlags::CLONE_NEWNS)
+        .union(CloneFlags::CLONE_NEWUTS);
 
     let unsupported_flags =
         (flags & CloneFlags::CLONE_NS_FLAGS) - SUPPORTED_FLAGS - CloneFlags::CLONE_NEWUSER;

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -56,8 +56,12 @@ impl ContextUnshareAdminApi for Context<'_> {
         let mut thread_local_ns_proxy_ref = self.thread_local.borrow_ns_proxy_mut();
         let thread_local_ns_proxy = thread_local_ns_proxy_ref.unwrap();
 
-        let new_ns_proxy =
-            thread_local_ns_proxy.new_clone(&user_ns_ref, flags, self.posix_thread)?;
+        let new_ns_proxy = thread_local_ns_proxy.new_clone(
+            &user_ns_ref,
+            self.process.as_ref(),
+            self.posix_thread,
+            flags,
+        )?;
 
         if flags.contains(CloneFlags::CLONE_NEWNS) {
             self.thread_local

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -12,6 +12,7 @@
 
 use crate::{
     fs::{
+        cgroupfs::CgroupNamespace,
         file::{FileLike, InodeHandle, file_table::RawFileDesc},
         pseudofs::{NsCommonOps, NsFile},
         vfs::path::MountNamespace,
@@ -82,14 +83,19 @@ fn build_proxy_from_pid_file(
 
     let mut builder = NsProxyBuilder::new(current_proxy);
 
-    if flags.contains(CloneFlags::CLONE_NEWUTS) {
-        let target_ns = target_proxy.uts_ns();
-        set_uts_ns(&mut builder, target_ns, ctx)?;
+    if flags.contains(CloneFlags::CLONE_NEWCGROUP) {
+        let target_ns = target_proxy.cgroup_ns();
+        set_cgroup_ns(&mut builder, target_ns, ctx)?;
     }
 
     if flags.contains(CloneFlags::CLONE_NEWNS) {
         let target_ns = target_proxy.mnt_ns();
         set_mnt_ns(&mut builder, target_ns, ctx)?;
+    }
+
+    if flags.contains(CloneFlags::CLONE_NEWUTS) {
+        let target_ns = target_proxy.uts_ns();
+        set_uts_ns(&mut builder, target_ns, ctx)?;
     }
 
     // TODO: Support setting other namespaces from the target process.
@@ -119,11 +125,14 @@ fn build_proxy_from_ns_file(
 
     #[expect(clippy::nonminimal_bool)]
     let applied = false
-        || try_apply_ns_from_inode::<UtsNamespace>(inode_handle, flags, |ns| {
-            set_uts_ns(&mut builder, &ns, ctx)
+        || try_apply_ns_from_inode::<CgroupNamespace>(inode_handle, flags, |ns| {
+            set_cgroup_ns(&mut builder, &ns, ctx)
         })?
         || try_apply_ns_from_inode::<MountNamespace>(inode_handle, flags, |ns| {
             set_mnt_ns(&mut builder, &ns, ctx)
+        })?
+        || try_apply_ns_from_inode::<UtsNamespace>(inode_handle, flags, |ns| {
+            set_uts_ns(&mut builder, &ns, ctx)
         })?;
     // TODO: Support setting other namespaces from the ns file.
 
@@ -154,24 +163,14 @@ fn try_apply_ns_from_inode<T: NsCommonOps>(
     Ok(true)
 }
 
-fn set_uts_ns(
+fn set_cgroup_ns(
     builder: &mut NsProxyBuilder,
-    target_ns: &Arc<UtsNamespace>,
+    target_ns: &Arc<CgroupNamespace>,
     ctx: &Context,
 ) -> Result<()> {
-    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
-    // and the current user namespace.
-    target_ns
-        .owner_user_ns()
-        .unwrap()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
-    ctx.thread_local
-        .borrow_user_ns()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    check_set_ns_perms(target_ns, ctx)?;
 
-    // TODO: Are the checks above sufficient?
-
-    builder.uts_ns(target_ns.clone());
+    builder.cgroup_ns(target_ns.clone());
 
     Ok(())
 }
@@ -181,15 +180,7 @@ fn set_mnt_ns(
     target_ns: &Arc<MountNamespace>,
     ctx: &Context,
 ) -> Result<()> {
-    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
-    // and the current user namespace.
-    target_ns
-        .owner_user_ns()
-        .unwrap()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
-    ctx.thread_local
-        .borrow_user_ns()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    check_set_ns_perms(target_ns, ctx)?;
 
     if ctx.thread_local.is_fs_shared() {
         return_errno_with_message!(
@@ -201,6 +192,34 @@ fn set_mnt_ns(
     // TODO: Are the checks above sufficient?
 
     builder.mnt_ns(target_ns.clone());
+
+    Ok(())
+}
+
+fn set_uts_ns(
+    builder: &mut NsProxyBuilder,
+    target_ns: &Arc<UtsNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    check_set_ns_perms(target_ns, ctx)?;
+
+    builder.uts_ns(target_ns.clone());
+
+    Ok(())
+}
+
+fn check_set_ns_perms<T: NsCommonOps>(target_ns: &Arc<T>, ctx: &Context) -> Result<()> {
+    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
+    // and the current user namespace.
+    target_ns
+        .owner_user_ns()
+        .unwrap()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    ctx.thread_local
+        .borrow_user_ns()
+        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+
+    // TODO: Are the checks above sufficient?
 
     Ok(())
 }

--- a/test/initramfs/src/regression/security/namespace/cgroup_ns.c
+++ b/test/initramfs/src/regression/security/namespace/cgroup_ns.c
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define CGROUP_ROOT "/sys/fs/cgroup"
+#define TEST_BASE_CGROUP CGROUP_ROOT "/cgns-base"
+#define TEST_LEAF_CGROUP TEST_BASE_CGROUP "/leaf"
+#define TEST_SIBLING_CGROUP CGROUP_ROOT "/cgns-sibling"
+#define TEST_MOUNT_DIR "/tmp/cgns-mnt"
+#define TEST_MOUNT_LEAF TEST_MOUNT_DIR "/leaf"
+#define TEST_MOUNT_SIBLING TEST_MOUNT_DIR "/cgns-sibling"
+
+static int g_initial_cgroup_ns_fd;
+static int g_initial_mount_ns_fd;
+
+static int move_pid_to_cgroup(const char *dir, pid_t pid)
+{
+	char path[PATH_MAX];
+	char pid_text[32];
+	int fd;
+	ssize_t count;
+
+	snprintf(path, sizeof(path), "%s/cgroup.procs", dir);
+	fd = open(path, O_WRONLY);
+	if (fd < 0)
+		return -1;
+
+	snprintf(pid_text, sizeof(pid_text), "%d", pid);
+	count = write(fd, pid_text, strlen(pid_text));
+	close(fd);
+	if (count != (ssize_t)strlen(pid_text)) {
+		if (count >= 0)
+			errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int check_proc_cgroup(pid_t pid, const char *expected)
+{
+	char path[64];
+	char content[PATH_MAX];
+	int fd;
+	ssize_t count;
+
+	snprintf(path, sizeof(path), "/proc/%d/cgroup", pid);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+
+	count = read(fd, content, sizeof(content) - 1);
+	close(fd);
+	if (count < 0)
+		return -1;
+
+	content[count] = '\0';
+	if (strcmp(content, expected) != 0) {
+		errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int read_namespace_inode(const char *path, ino_t *inode)
+{
+	struct stat stat_buf;
+
+	if (stat(path, &stat_buf) < 0)
+		return -1;
+
+	*inode = stat_buf.st_ino;
+	return 0;
+}
+
+static int read_self_cgroup_ns_inode(ino_t *inode)
+{
+	return read_namespace_inode("/proc/self/ns/cgroup", inode);
+}
+
+static int read_task_cgroup_ns_inode(pid_t tid, ino_t *inode)
+{
+	char path[64];
+
+	snprintf(path, sizeof(path), "/proc/self/task/%d/ns/cgroup", tid);
+	return read_namespace_inode(path, inode);
+}
+
+static int read_process_cgroup_ns_inode(pid_t pid, ino_t *inode)
+{
+	char path[64];
+
+	snprintf(path, sizeof(path), "/proc/%d/ns/cgroup", pid);
+	return read_namespace_inode(path, inode);
+}
+
+static int check_mount_root(const char *mount_point, const char *expected_root)
+{
+	FILE *mountinfo = fopen("/proc/self/mountinfo", "r");
+	char line[512];
+
+	if (!mountinfo)
+		return -1;
+
+	while (fgets(line, sizeof(line), mountinfo)) {
+		char root[256];
+		char seen_mount_point[256];
+		char fs_type[64];
+
+		if (sscanf(line, "%*s %*s %*s %255s %255s %*s - %63s", root,
+			   seen_mount_point, fs_type) != 3)
+			continue;
+		if (strcmp(seen_mount_point, mount_point) != 0)
+			continue;
+		if (strcmp(fs_type, "cgroup2") != 0)
+			continue;
+
+		fclose(mountinfo);
+		if (strcmp(root, expected_root) != 0) {
+			errno = EIO;
+			return -1;
+		}
+
+		return 0;
+	}
+
+	fclose(mountinfo);
+	errno = ENOENT;
+	return -1;
+}
+
+static int reset_self(void)
+{
+	if (setns(g_initial_cgroup_ns_fd, CLONE_NEWCGROUP) < 0)
+		return -1;
+	if (move_pid_to_cgroup(CGROUP_ROOT, getpid()) < 0)
+		return -1;
+	if (setns(g_initial_mount_ns_fd, CLONE_NEWNS) < 0)
+		return -1;
+
+	return 0;
+}
+
+enum new_cgroup_ns_t {
+	KEEP_OLD_CGROUP_NS = 0,
+	MOVE_TO_NEW_CGROUP_NS = 1,
+};
+
+static pid_t spawn_paused_process(const char *cgroup_dir,
+				  enum new_cgroup_ns_t new_cgroup)
+{
+	pid_t child = CHECK(fork());
+
+	if (child == 0) {
+		CHECK(move_pid_to_cgroup(cgroup_dir, getpid()));
+		if (new_cgroup)
+			CHECK(unshare(CLONE_NEWCGROUP));
+		pause();
+		_exit(0);
+	}
+
+	/* Wait until the child executes `pause()`. */
+	CHECK(usleep(50000));
+
+	return child;
+}
+
+static void kill_paused_process(pid_t pid)
+{
+	CHECK(kill(pid, SIGKILL));
+	CHECK_WITH(waitpid(pid, NULL, 0), _ret == pid);
+}
+
+struct thread_probe {
+	pthread_barrier_t ready;
+	pthread_barrier_t release;
+	pid_t tid;
+};
+
+static void *unshare_cgroup_ns_thread(void *arg)
+{
+	struct thread_probe *probe = arg;
+
+	probe->tid = CHECK(syscall(SYS_gettid));
+	CHECK(unshare(CLONE_NEWCGROUP));
+	CHECK_WITH(pthread_barrier_wait(&probe->ready),
+		   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	CHECK_WITH(pthread_barrier_wait(&probe->release),
+		   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+
+	return NULL;
+}
+
+FN_SETUP(init)
+{
+	g_initial_cgroup_ns_fd = CHECK(open("/proc/self/ns/cgroup", O_RDONLY));
+	g_initial_mount_ns_fd = CHECK(open("/proc/self/ns/mnt", O_RDONLY));
+
+	CHECK(mkdir(TEST_BASE_CGROUP, 0755));
+	CHECK(mkdir(TEST_LEAF_CGROUP, 0755));
+	CHECK(mkdir(TEST_SIBLING_CGROUP, 0755));
+	CHECK(mkdir(TEST_MOUNT_DIR, 0755));
+}
+END_SETUP()
+
+/*
+ * `unshare(CLONE_NEWCGROUP)` only changes the calling thread's namespace.
+ * Other threads in the same process keep the original namespace inode.
+ */
+FN_TEST(cgroup_namespace_stays_thread_local)
+{
+	struct thread_probe probe = {};
+	pthread_t thread;
+	ino_t main_before;
+	ino_t main_after;
+	ino_t worker_ns;
+
+	TEST_SUCC(read_self_cgroup_ns_inode(&main_before));
+
+	TEST_RES(pthread_barrier_init(&probe.ready, NULL, 2), _ret == 0);
+	TEST_RES(pthread_barrier_init(&probe.release, NULL, 2), _ret == 0);
+	TEST_RES(pthread_create(&thread, NULL, unshare_cgroup_ns_thread,
+				&probe),
+		 _ret == 0);
+
+	TEST_RES(pthread_barrier_wait(&probe.ready),
+		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	TEST_RES(read_self_cgroup_ns_inode(&main_after),
+		 main_before == main_after);
+	TEST_RES(read_task_cgroup_ns_inode(probe.tid, &worker_ns),
+		 worker_ns != main_after);
+	TEST_RES(pthread_barrier_wait(&probe.release),
+		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+
+	TEST_RES(pthread_join(thread, NULL), _ret == 0);
+	TEST_RES(pthread_barrier_destroy(&probe.ready), _ret == 0);
+	TEST_RES(pthread_barrier_destroy(&probe.release), _ret == 0);
+}
+END_TEST()
+
+/*
+ * `/proc/<pid>/cgroup` is rendered from the caller's active cgroup namespace:
+ * the namespace root becomes `/`, descendants stay reachable beneath it, and
+ * cgroups outside the root are shown through `..`.
+ */
+FN_TEST(proc_cgroup_follows_callers_namespace)
+{
+	int rooted_ns_fd;
+	pid_t sibling_child;
+
+	sibling_child =
+		spawn_paused_process(TEST_SIBLING_CGROUP, KEEP_OLD_CGROUP_NS);
+	TEST_SUCC(move_pid_to_cgroup(TEST_BASE_CGROUP, getpid()));
+	TEST_SUCC(check_proc_cgroup(sibling_child, "0::/cgns-sibling\n"));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/cgns-base\n"));
+
+	TEST_SUCC(unshare(CLONE_NEWCGROUP));
+	rooted_ns_fd = TEST_SUCC(open("/proc/self/ns/cgroup", O_RDONLY));
+	TEST_SUCC(check_proc_cgroup(sibling_child, "0::/../cgns-sibling\n"));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/\n"));
+
+	TEST_SUCC(move_pid_to_cgroup(TEST_LEAF_CGROUP, getpid()));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/leaf\n"));
+
+	TEST_SUCC(setns(g_initial_cgroup_ns_fd, CLONE_NEWCGROUP));
+	TEST_SUCC(move_pid_to_cgroup(CGROUP_ROOT, getpid()));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/\n"));
+
+	TEST_SUCC(setns(rooted_ns_fd, CLONE_NEWCGROUP));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/..\n"));
+
+	TEST_SUCC(reset_self());
+	TEST_SUCC(close(rooted_ns_fd));
+	kill_paused_process(sibling_child);
+}
+END_TEST()
+
+/*
+ * Joining another task's cgroup namespace should immediately re-virtualize
+ * `/proc/self/cgroup` against that namespace's root.
+ */
+FN_TEST(setns_revirtualizes_proc_cgroup)
+{
+	ino_t child_ns;
+	ino_t joined_ns;
+	pid_t child;
+	int pidfd;
+
+	TEST_SUCC(move_pid_to_cgroup(TEST_BASE_CGROUP, getpid()));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/cgns-base\n"));
+
+	child = spawn_paused_process(TEST_BASE_CGROUP, MOVE_TO_NEW_CGROUP_NS);
+	TEST_SUCC(read_process_cgroup_ns_inode(child, &child_ns));
+
+	pidfd = TEST_SUCC(syscall(SYS_pidfd_open, child, 0));
+	TEST_SUCC(setns(pidfd, CLONE_NEWCGROUP));
+
+	TEST_RES(read_self_cgroup_ns_inode(&joined_ns), joined_ns == child_ns);
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/\n"));
+
+	TEST_SUCC(reset_self());
+	TEST_SUCC(close(pidfd));
+	kill_paused_process(child);
+}
+END_TEST()
+
+/*
+ * A fresh `cgroup2` mount inside a cgroup namespace starts at the namespace
+ * root, so descendants below that root stay visible and siblings above it do
+ * not appear in the mount tree.
+ */
+FN_TEST(cgroup_mount_starts_at_namespace_root)
+{
+	TEST_SUCC(move_pid_to_cgroup(TEST_BASE_CGROUP, getpid()));
+	TEST_SUCC(unshare(CLONE_NEWCGROUP));
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	TEST_SUCC(mount("none", TEST_MOUNT_DIR, "cgroup2", 0, NULL));
+
+	TEST_SUCC(check_mount_root(TEST_MOUNT_DIR, "/"));
+	TEST_SUCC(access(TEST_MOUNT_LEAF, F_OK));
+	TEST_ERRNO(access(TEST_MOUNT_SIBLING, F_OK), ENOENT);
+
+	TEST_SUCC(umount(TEST_MOUNT_DIR));
+	TEST_SUCC(reset_self());
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(rmdir(TEST_MOUNT_DIR));
+	CHECK(rmdir(TEST_LEAF_CGROUP));
+	CHECK(rmdir(TEST_BASE_CGROUP));
+	CHECK(rmdir(TEST_SIBLING_CGROUP));
+	CHECK(close(g_initial_mount_ns_fd));
+	CHECK(close(g_initial_cgroup_ns_fd));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -37,9 +37,14 @@
  *     but noted here for future reference).
  * `clone_flags` lists the corresponding CLONE_NEW* flag for each entry.
  */
-static const char *ns_files[] = { "uts", "mnt", "user" };
-static const char *ns_names[] = { "uts", "mnt", "user" };
-static const int clone_flags[] = { CLONE_NEWUTS, CLONE_NEWNS, CLONE_NEWUSER };
+static const char *ns_files[] = { "cgroup", "mnt", "user", "uts" };
+static const char *ns_names[] = { "cgroup", "mnt", "user", "uts" };
+static const int clone_flags[] = {
+	CLONE_NEWCGROUP,
+	CLONE_NEWNS,
+	CLONE_NEWUSER,
+	CLONE_NEWUTS,
+};
 static const size_t ns_count = sizeof(ns_files) / sizeof(ns_files[0]);
 
 /* -------------------------------------------------------------------------- */

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -8,6 +8,7 @@ set -e
 ./capability/capset
 ./capability/execve
 
+./namespace/cgroup_ns
 ./namespace/mnt_ns
 ./namespace/proc_nsfs
 ./namespace/setns


### PR DESCRIPTION
This PR introduces cgroup namespaces, which allow a task to observe the unified cgroup hierarchy from a namespace-specific root while preserving its underlying cgroup membership. 

This functionality is required by #2911.