### PR TITLE
Fix fork and vfork panic on pids.max exhaustion

### DIFF
--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -10,12 +10,12 @@ use crate::{
 
 pub fn sys_fork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
     let clone_args = CloneArgs::for_fork();
-    let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
+    let child_pid = clone_child(ctx, parent_context, clone_args)?;
     Ok(SyscallReturn::Return(child_pid as _))
 }
 
 pub fn sys_vfork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
     let clone_args = CloneArgs::for_vfork();
-    let child_pid = clone_child(ctx, parent_context, clone_args).unwrap();
+    let child_pid = clone_child(ctx, parent_context, clone_args)?;
     Ok(SyscallReturn::Return(child_pid as _))
 }


### PR DESCRIPTION
This PR fixes a kernel panic in `fork` and `vfork` when process creation is rejected by the cgroup v2 pids controller.

In `clone` and `clone3`, the `clone_child()` uses `?` already.

https://github.com/asterinas/asterinas/blob/b05d53e9661f650ab21abd0bf367fe0632b2df39/kernel/src/syscall/clone.rs#L28