### PR TITLE
Implement BLKSSZGET ioctl

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
@@ -27,7 +27,7 @@ ioctl(
 );
 
 // Control block devices
-ioctl(fd, op = BLKGETSIZE64, ..);
+ioctl(fd, op = BLKGETSIZE64 | BLKSSZGET, ..);
 
 // Control Trust Domain Extensions (TDX) guest devices
 ioctl(fd, op = TDX_CMD_GET_REPORT0, ..);

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use aster_block::{BlockDevice, SECTOR_SIZE};
+use aster_block::{BLOCK_SIZE, BlockDevice, SECTOR_SIZE};
 use aster_nvme::NvmeBlockDevice;
 use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 use device_id::DeviceId;
 use ostd::mm::VmIo;
 
 use crate::{
+    context::current_userspace,
     device::{Device, DeviceType, DevtmpfsInodeMeta, add_node},
     events::IoEvents,
     fs::{
@@ -65,10 +66,27 @@ pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> 
 }
 
 mod ioctl_defs {
-    use crate::util::ioctl::{OutData, ioc};
+    use crate::util::ioctl::{NoData, OutData, ioc};
 
     // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/linux/fs.h>
+
+    /// Returns the device size in bytes.
     pub(super) type BlkGetSize64 = ioc!(BLKGETSIZE64, 0x12, 114, OutData<u64>);
+
+    /// Returns the logical sector size of the block device.
+    ///
+    /// This is the smallest unit of I/O the device can address and,
+    /// importantly, the minimum alignment required for `O_DIRECT` I/O on
+    /// files backed by this device. Both buffer address and offset must be a
+    /// multiple of this value.
+    ///
+    /// Benchmarks and filesystem tests (for example, `xfstests`, LTP
+    /// `preadv03`/`pwritev03`) rely on this ioctl to size `O_DIRECT` buffers.
+    /// If the effective alignment enforced by the filesystem layered on top
+    /// is larger than the hardware sector, such as `ext2`'s 4 KiB block, this
+    /// ioctl must return that larger value. Otherwise user programs will align
+    /// correctly for the device but still hit `EINVAL` at the filesystem.
+    pub(super) type BlkGetSectorSize = ioc!(BLKSSZGET, 0x12, 104, NoData);
 }
 
 /// Represents a block device inode in the filesystem.
@@ -156,6 +174,15 @@ impl PerOpenFileOps for OpenBlockFile {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {
+            _cmd @ BlkGetSectorSize => {
+                // TODO: Query the per-device logical block size once block device metadata
+                // exposes it. For now, report the effective minimum I/O granularity enforced
+                // by Asterinas filesystems so userspace can use `BLKSSZGET` for `O_DIRECT`
+                // alignment.
+                let sector_size = SECTOR_SIZE.max(BLOCK_SIZE) as i32;
+                current_userspace!().write_val(raw_ioctl.arg(), &sector_size)?;
+                Ok(0)
+            }
             cmd @ BlkGetSize64 => {
                 let size = (self.0.metadata().nr_sectors * SECTOR_SIZE) as u64;
                 cmd.write(&size)?;

--- a/test/initramfs/src/conformance/xfstests/full.list
+++ b/test/initramfs/src/conformance/xfstests/full.list
@@ -58,6 +58,7 @@ generic/393
 generic/401
 generic/406
 generic/412
+generic/418
 generic/428
 generic/437
 generic/438

--- a/test/initramfs/src/conformance/xfstests/short.list
+++ b/test/initramfs/src/conformance/xfstests/short.list
@@ -52,6 +52,7 @@ generic/393
 generic/401
 generic/406
 generic/412
+generic/418
 generic/428
 generic/437
 generic/438


### PR DESCRIPTION
This pull request has introduced the `BLKSSZGET` ioctl, which is similar to the existing `BLKGETSIZE64` ioctl. Some test cases within the `xfstests` suite depend on this particular ioctl for execution.

I'm not sure whether we will add a logical_block_size like Linux ([ref](https://elixir.bootlin.com/linux/v6.18/source/block/ioctl.c#L596)), so I add a TODO here.