### PR TITLE
Support cgroup CPU sub-controller

### DIFF
--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use aster_systree::{Error, Result, SysAttrSetBuilder, SysPerms, SysStr};
+use aster_util::{per_cpu_counter::PerCpuCounter, printer::VmPrinter};
+use ostd::{
+    cpu::CpuId,
+    mm::{VmReader, VmWriter},
+    task::atomic_mode::AsAtomicModeGuard,
+    timer::Jiffies,
+};
+
+use crate::{
+    fs::cgroupfs::systree_node::{CgroupSysNode, CgroupSystem},
+    process::Process,
+};
+
+/// A sub-controller responsible for CPU resource management in the cgroup subsystem.
+///
+/// This controller always exists so that `cpu.stat` remains readable even before `+cpu`
+/// is enabled. When inactive, only the base usage fields are exposed. The `user` and
+/// `system` counters store CPU time in units of one [`Jiffies`] per increment, and
+/// `usage_usec` is derived from their sum when `cpu.stat` is read.
+pub struct CpuController {
+    is_enabled: AtomicBool,
+    user: PerCpuCounter,
+    system: PerCpuCounter,
+}
+
+/// Specifies the cgroup CPU sub-controller receives one [`Jiffies`] of charge.
+#[derive(Clone, Copy)]
+pub enum CpuStatKind {
+    /// Charges one [`Jiffies`] to `user_usec`.
+    User,
+    /// Charges one [`Jiffies`] to `system_usec`.
+    System,
+}
+
+impl CpuController {
+    pub(super) fn init_attr_set(builder: &mut SysAttrSetBuilder, _is_root: bool) {
+        builder.add(SysStr::from("cpu.stat"), SysPerms::DEFAULT_RO_ATTR_PERMS);
+    }
+
+    fn new(is_enabled: bool) -> Self {
+        Self {
+            is_enabled: AtomicBool::new(is_enabled),
+            user: PerCpuCounter::new(),
+            system: PerCpuCounter::new(),
+        }
+    }
+
+    fn write_cpu_stat_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        /// Converts a per-CPU counter expressed in jiffies to microseconds.
+        fn counter_usec(counter: &PerCpuCounter) -> u64 {
+            let jiffies = u64::try_from(counter.sum_all_cpus()).unwrap_or(u64::MAX);
+            u64::try_from(Jiffies::new(jiffies).as_duration().as_micros()).unwrap_or(u64::MAX)
+        }
+
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let user_usec = counter_usec(&self.user);
+        let system_usec = counter_usec(&self.system);
+        writeln!(
+            printer,
+            "usage_usec {}",
+            user_usec.saturating_add(system_usec)
+        )?;
+        writeln!(printer, "user_usec {}", user_usec)?;
+        writeln!(printer, "system_usec {}", system_usec)?;
+
+        if self.is_enabled.load(Ordering::Relaxed) {
+            // TODO: Support CPU bandwidth control statistics. These fields are reported as `0`
+            // for now because the cgroup CPU sub-controller does not yet implement throttling or
+            // burst accounting.
+            writeln!(printer, "nr_periods 0")?;
+            writeln!(printer, "nr_throttled 0")?;
+            writeln!(printer, "throttled_usec 0")?;
+            writeln!(printer, "nr_bursts 0")?;
+            writeln!(printer, "burst_usec 0")?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+
+    pub(super) fn enable(&self) {
+        self.is_enabled.store(true, Ordering::Relaxed);
+    }
+
+    pub(super) fn disable(&self) {
+        self.is_enabled.store(false, Ordering::Relaxed);
+    }
+
+    /// Accounts one [`Jiffies`] of CPU time on `cpu`.
+    fn account(&self, cpu: CpuId, stat_kind: CpuStatKind) {
+        match stat_kind {
+            CpuStatKind::User => self.user.add_on_cpu(cpu, 1),
+            CpuStatKind::System => self.system.add_on_cpu(cpu, 1),
+        }
+    }
+}
+
+impl super::SubControl for CpuController {
+    fn read_attr_at(&self, name: &str, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        if name != "cpu.stat" {
+            return Err(Error::AttributeError);
+        }
+
+        self.write_cpu_stat_at(offset, writer)
+    }
+
+    fn write_attr(&self, _name: &str, _reader: &mut VmReader) -> Result<usize> {
+        Err(Error::AttributeError)
+    }
+}
+
+impl super::SubControlStatic for CpuController {
+    fn new(is_root: bool, is_active: bool) -> Self {
+        Self::new(is_root || is_active)
+    }
+
+    fn type_() -> super::SubCtrlType {
+        super::SubCtrlType::Cpu
+    }
+
+    fn read_from(controller: &super::Controller) -> Arc<super::SubController<Self>> {
+        controller.cpu.read().get().clone()
+    }
+}
+
+impl super::SubController<CpuController> {
+    pub(super) fn enable(&self) {
+        self.inner.as_ref().unwrap().enable();
+    }
+
+    pub(super) fn disable(&self) {
+        self.inner.as_ref().unwrap().disable();
+    }
+
+    /// Accounts one [`Jiffies`] of CPU time for this cgroup and all of its ancestors.
+    fn account_hierarchy(&self, stat_kind: CpuStatKind) {
+        // This is race-free because `charge_cpu_time` holds `cgroup_guard` when
+        // invoking this method.
+        let cpu = CpuId::current_racy();
+
+        let mut current = Some(self);
+        while let Some(node) = current {
+            node.inner.as_ref().unwrap().account(cpu, stat_kind);
+            current = node.parent.as_deref();
+        }
+    }
+}
+
+impl super::Controller {
+    /// Charges one [`Jiffies`] in the CPU sub-controller hierarchy.
+    fn charge_cpu_time<G: AsAtomicModeGuard + ?Sized>(&self, guard: &G, stat_kind: CpuStatKind) {
+        self.cpu.read_with(guard).account_hierarchy(stat_kind);
+    }
+}
+
+/// Charges one [`Jiffies`] of CPU time to `process`'s cgroup hierarchy.
+///
+/// If `process` is not attached to a non-root cgroup, the charge is applied to the root cgroup.
+pub fn charge_cpu_time(process: &Process, stat_kind: CpuStatKind) {
+    let cgroup_guard = process.cgroup();
+
+    if let Some(cgroup) = cgroup_guard.get() {
+        cgroup
+            .controller()
+            .charge_cpu_time(&cgroup_guard, stat_kind);
+    } else {
+        CgroupSystem::singleton()
+            .controller()
+            .charge_cpu_time(&cgroup_guard, stat_kind);
+    }
+}

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
@@ -60,7 +60,7 @@ impl super::SubControl for CpuSetController {
 }
 
 impl super::SubControlStatic for CpuSetController {
-    fn new(_is_root: bool) -> Self {
+    fn new(_is_root: bool, _is_active: bool) -> Self {
         Self { _private: () }
     }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
@@ -44,7 +44,7 @@ impl super::SubControl for MemoryController {
 }
 
 impl super::SubControlStatic for MemoryController {
-    fn new(_is_root: bool) -> Self {
+    fn new(_is_root: bool, _is_active: bool) -> Self {
         Self { _private: () }
     }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
@@ -17,10 +17,14 @@ use ostd::{
 
 use crate::fs::cgroupfs::{
     CgroupMembership, CgroupNode,
-    controller::{cpuset::CpuSetController, memory::MemoryController, pids::PidsController},
+    controller::{
+        cpu::CpuController, cpuset::CpuSetController, memory::MemoryController,
+        pids::PidsController,
+    },
     systree_node::CgroupSysNode,
 };
 
+pub(super) mod cpu;
 mod cpuset;
 mod memory;
 mod pids;
@@ -35,7 +39,7 @@ trait SubControl {
 /// Defines the static properties and behaviors of a specific cgroup sub-controller.
 trait SubControlStatic: SubControl + Sized + 'static {
     /// Creates a new instance of the sub-controller.
-    fn new(is_root: bool) -> Self;
+    fn new(is_root: bool, is_active: bool) -> Self;
 
     /// Returns the `SubCtrlType` enum variant corresponding to this sub-controller.
     fn type_() -> SubCtrlType;
@@ -47,13 +51,24 @@ trait SubControlStatic: SubControl + Sized + 'static {
 /// The type of a sub-controller in the cgroup subsystem.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum SubCtrlType {
-    Memory,
     CpuSet,
+    Cpu,
+    Memory,
     Pids,
 }
 
 impl SubCtrlType {
-    const ALL: [Self; 3] = [Self::Memory, Self::CpuSet, Self::Pids];
+    // Keep this in the Linux-visible controller order used by `Display`.
+    const ALL: [Self; 4] = [Self::CpuSet, Self::Cpu, Self::Memory, Self::Pids];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CpuSet => "cpuset",
+            Self::Cpu => "cpu",
+            Self::Memory => "memory",
+            Self::Pids => "pids",
+        }
+    }
 }
 
 impl FromStr for SubCtrlType {
@@ -61,8 +76,9 @@ impl FromStr for SubCtrlType {
 
     fn from_str(s: &str) -> Result<Self> {
         match s {
-            "memory" => Ok(SubCtrlType::Memory),
             "cpuset" => Ok(SubCtrlType::CpuSet),
+            "cpu" => Ok(SubCtrlType::Cpu),
+            "memory" => Ok(SubCtrlType::Memory),
             "pids" => Ok(SubCtrlType::Pids),
             _ => Err(Error::NotFound),
         }
@@ -72,9 +88,10 @@ impl FromStr for SubCtrlType {
 bitflags! {
     /// A set of sub-controller types, represented as bitflags.
     pub(super) struct SubCtrlSet: u8 {
-        const MEMORY = 1 << 0;
-        const CPUSET = 1 << 1;
-        const PIDS = 1 << 2;
+        const CPUSET = 1 << 0;
+        const CPU = 1 << 1;
+        const MEMORY = 1 << 2;
+        const PIDS = 1 << 3;
     }
 }
 
@@ -104,14 +121,12 @@ impl SubCtrlSet {
 
 impl Display for SubCtrlSet {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.contains(Self::MEMORY) {
-            write!(f, "memory ")?;
-        }
-        if self.contains(Self::CPUSET) {
-            write!(f, "cpuset ")?;
-        }
-        if self.contains(Self::PIDS) {
-            write!(f, "pids")?;
+        let mut iter = self.iter_types();
+        if let Some(first) = iter.next() {
+            write!(f, "{}", first.as_str())?;
+            for ctrl_type in iter {
+                write!(f, " {}", ctrl_type.as_str())?;
+            }
         }
 
         Ok(())
@@ -121,8 +136,9 @@ impl Display for SubCtrlSet {
 impl From<SubCtrlType> for SubCtrlSet {
     fn from(ctrl_type: SubCtrlType) -> Self {
         match ctrl_type {
-            SubCtrlType::Memory => Self::MEMORY,
             SubCtrlType::CpuSet => Self::CPUSET,
+            SubCtrlType::Cpu => Self::CPU,
+            SubCtrlType::Memory => Self::MEMORY,
             SubCtrlType::Pids => Self::PIDS,
         }
     }
@@ -159,14 +175,17 @@ struct SubController<T: SubControlStatic> {
 
 impl<T: SubControlStatic> SubController<T> {
     fn new(parent_controller: Option<&Controller>) -> Self {
+        let is_root = parent_controller.is_none();
         let is_active = if let Some(parent) = parent_controller {
             parent.active_set().contains_type(T::type_())
         } else {
             true
         };
 
-        let inner = if is_active {
-            Some(T::new(parent_controller.is_none()))
+        let inner = if is_active || T::type_() == SubCtrlType::Cpu {
+            // `cpu.stat` exists regardless of whether `+cpu` has been enabled, so the
+            // CPU sub-controller must remain instantiated even while inactive.
+            Some(T::new(is_root, is_active))
         } else {
             None
         };
@@ -206,36 +225,41 @@ pub struct Controller {
     /// Updates to this set are serialized by `CgroupMembership::write_lock()`.
     active_set: AtomicSubCtrlSet,
 
-    memory: Rcu<Arc<SubController<MemoryController>>>,
     cpuset: Rcu<Arc<SubController<CpuSetController>>>,
+    cpu: Rcu<Arc<SubController<CpuController>>>,
+    memory: Rcu<Arc<SubController<MemoryController>>>,
     pids: Rcu<Arc<SubController<PidsController>>>,
 }
 
 impl Controller {
     /// Creates a new controller manager for a cgroup.
     pub(super) fn new(parent_controller: Option<&Controller>) -> Self {
-        let memory_controller = Arc::new(SubController::new(parent_controller));
         let cpuset_controller = Arc::new(SubController::new(parent_controller));
+        let cpu_controller = Arc::new(SubController::new(parent_controller));
+        let memory_controller = Arc::new(SubController::new(parent_controller));
         let pids_controller = Arc::new(SubController::new(parent_controller));
 
         Self {
             active_set: AtomicSubCtrlSet::new(SubCtrlSet::empty()),
-            memory: Rcu::new(memory_controller),
             cpuset: Rcu::new(cpuset_controller),
+            cpu: Rcu::new(cpu_controller),
+            memory: Rcu::new(memory_controller),
             pids: Rcu::new(pids_controller),
         }
     }
 
     pub(super) fn init_attr_set(builder: &mut SysAttrSetBuilder, is_root: bool) {
-        MemoryController::init_attr_set(builder, is_root);
         CpuSetController::init_attr_set(builder, is_root);
+        CpuController::init_attr_set(builder, is_root);
+        MemoryController::init_attr_set(builder, is_root);
         PidsController::init_attr_set(builder, is_root);
     }
 
     fn read_sub(&self, ctrl_type: SubCtrlType) -> Arc<dyn TryGetSubControl> {
         match ctrl_type {
-            SubCtrlType::Memory => MemoryController::read_from(self),
             SubCtrlType::CpuSet => CpuSetController::read_from(self),
+            SubCtrlType::Cpu => CpuController::read_from(self),
+            SubCtrlType::Memory => MemoryController::read_from(self),
             SubCtrlType::Pids => PidsController::read_from(self),
         }
     }
@@ -367,13 +391,27 @@ impl Controller {
         ) {
             let child_node = child.as_any().downcast_ref::<CgroupNode>().unwrap();
             match ctrl_type {
-                SubCtrlType::Memory => {
-                    let new_controller = Arc::new(SubController::new(Some(parent_controller)));
-                    child_node.controller().memory.update(new_controller);
-                }
                 SubCtrlType::CpuSet => {
                     let new_controller = Arc::new(SubController::new(Some(parent_controller)));
                     child_node.controller().cpuset.update(new_controller);
+                }
+                SubCtrlType::Cpu => {
+                    // Preserve the accumulated CPU accounting while toggling `+cpu` on the
+                    // parent. The base usage fields of `cpu.stat` are always tracked, and only
+                    // the extra throttling-related fields depend on whether the controller is active.
+                    let is_enabled = parent_controller
+                        .active_set()
+                        .contains_type(SubCtrlType::Cpu);
+                    let guard = child_node.controller().cpu.read();
+                    if is_enabled {
+                        guard.get().enable();
+                    } else {
+                        guard.get().disable();
+                    }
+                }
+                SubCtrlType::Memory => {
+                    let new_controller = Arc::new(SubController::new(Some(parent_controller)));
+                    child_node.controller().memory.update(new_controller);
                 }
                 SubCtrlType::Pids => {
                     let mut new_controller: SubController<PidsController> =

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
@@ -129,7 +129,7 @@ impl super::SubControl for PidsController {
 }
 
 impl super::SubControlStatic for PidsController {
-    fn new(_is_root: bool) -> Self {
+    fn new(_is_root: bool, _is_active: bool) -> Self {
         Self {
             max_pids: AtomicU32::new(u32::MAX),
             current_count: AtomicU32::new(0),

--- a/kernel/src/fs/fs_impls/cgroupfs/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub use cgroup_ns::CgroupNamespace;
+pub use controller::cpu::{CpuStatKind, charge_cpu_time};
 use fs::CgroupFsType;
 pub(in crate::fs) use systree_node::CgroupSystem;
 pub use systree_node::{CgroupMembership, CgroupNode, CgroupSysNode};

--- a/kernel/src/process/process/timer_manager.rs
+++ b/kernel/src/process/process/timer_manager.rs
@@ -11,6 +11,7 @@ use ostd::{cpu::PrivilegeLevel, irq::InterruptLevel, sync::Mutex, timer};
 
 use super::Process;
 use crate::{
+    fs::cgroupfs::{CpuStatKind, charge_cpu_time},
     process::{
         posix_thread::AsPosixThread,
         signal::{constants::SIGALRM, signals::kernel::KernelSignal},
@@ -64,9 +65,11 @@ fn update_cpu_time() {
     if is_kernel_interrupted {
         posix_thread.prof_clock().kernel_clock().add_jiffies(1);
         process.prof_clock().kernel_clock().add_jiffies(1);
+        charge_cpu_time(&process, CpuStatKind::System);
     } else {
         posix_thread.prof_clock().user_clock().add_jiffies(1);
         process.prof_clock().user_clock().add_jiffies(1);
+        charge_cpu_time(&process, CpuStatKind::User);
         timer_manager
             .virtual_timer()
             .timer_manager()

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -171,7 +171,7 @@ impl<P: NonNullPtr + Send> RcuInner<P> {
         RcuReadGuardInner {
             obj_ptr: self.ptr.load(Acquire),
             rcu: self,
-            _inner_guard: guard,
+            inner_guard: guard,
         }
     }
 
@@ -207,7 +207,7 @@ impl<P: NonNullPtr> Drop for RcuInner<P> {
 struct RcuReadGuardInner<'a, P: NonNullPtr> {
     obj_ptr: *mut <P as NonNullPtr>::Target,
     rcu: &'a RcuInner<P>,
-    _inner_guard: DisabledPreemptGuard,
+    inner_guard: DisabledPreemptGuard,
 }
 
 impl<P: NonNullPtr + Send> RcuReadGuardInner<'_, P> {
@@ -379,6 +379,12 @@ impl<P: NonNullPtr + Send> RcuReadGuard<'_, P> {
     }
 }
 
+impl<P: NonNullPtr> AsAtomicModeGuard for RcuReadGuard<'_, P> {
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode {
+        self.0.inner_guard.as_atomic_mode_guard()
+    }
+}
+
 impl<P: NonNullPtr + Send> RcuOptionReadGuard<'_, P> {
     /// Gets the reference of the protected data.
     ///
@@ -408,6 +414,12 @@ impl<P: NonNullPtr + Send> RcuOptionReadGuard<'_, P> {
     /// [the ABA problem](https://en.wikipedia.org/wiki/ABA_problem).
     pub fn compare_exchange(self, new_ptr: Option<P>) -> Result<(), Option<P>> {
         self.0.compare_exchange(new_ptr)
+    }
+}
+
+impl<P: NonNullPtr> AsAtomicModeGuard for RcuOptionReadGuard<'_, P> {
+    fn as_atomic_mode_guard(&self) -> &dyn InAtomicMode {
+        self.0.inner_guard.as_atomic_mode_guard()
     }
 }
 

--- a/test/initramfs/src/regression/process/cgroup.sh
+++ b/test/initramfs/src/regression/process/cgroup.sh
@@ -7,6 +7,7 @@ set -e
 CGROUP_ROOT="/sys/fs/cgroup"
 CGROUP_NAME="user"
 PROCESS_ID=1
+BUSY_PID=""
 
 # --- Helpers ------------------------------------------------------------------
 
@@ -58,8 +59,30 @@ verify_ge() {
     fi
 }
 
+read_cpu_stat_field() {
+    local field=$1
+    local path=$2
+
+    while IFS=' ' read -r name value; do
+        if [ "$name" = "$field" ]; then
+            echo "$value"
+            return 0
+        fi
+    done < "$path"
+
+    echo "Error: Failed to read $field from $path"
+    exit 1
+}
+
 cleanup() {
     log_step "Cleaning up"
+
+    if [ -n "$BUSY_PID" ]; then
+        echo "Stopping busy-loop helper: $BUSY_PID"
+        kill "$BUSY_PID" 2>/dev/null || true
+        wait "$BUSY_PID" 2>/dev/null || true
+        BUSY_PID=""
+    fi
 
     if [ -f "$CGROUP_ROOT/cgroup.procs" ]; then
         echo "Moving process $PROCESS_ID back to root cgroup"
@@ -88,6 +111,9 @@ log_step "1.2 Check initial controller attributes"
 verify "cpuset.cpus.effective exists in root" \
     "ls cpuset.cpus.effective" \
     "cpuset.cpus.effective"
+verify "cpu.stat exists in root" \
+    "ls cpu.stat" \
+    "cpu.stat"
 
 log_step "1.3 Create user hierarchy"
 mkdir -p "$CGROUP_NAME"
@@ -103,6 +129,19 @@ log_step "1.5 Check initial memory.max in child"
 verify "memory.max doesn't exist initially" \
     "ls memory.max" \
     "ls: memory.max: No such file or directory"
+verify "cpu.stat exists initially in child" \
+    "ls cpu.stat" \
+    "cpu.stat"
+
+log_step "1.5.1 Check initial child cpu.stat only reports usage fields"
+CPU_STAT_LINES=$(wc -l < cpu.stat)
+echo "cpu.stat lines before enabling CPU sub-controller: $CPU_STAT_LINES"
+if [ "$CPU_STAT_LINES" -ne 3 ]; then
+    echo "Error: inactive child cpu.stat should contain exactly 3 lines"
+    exit 1
+else
+    echo "Verified"
+fi
 
 log_step "1.6 Check initial cgroup of process 1"
 verify "Process 1 initially in root cgroup" \
@@ -118,34 +157,83 @@ verify "Initial cgroup.events populated=0" \
 
 log_section "Section 2: Controller activation / deactivation"
 
-log_step "2.1 Enable memory and pids in root"
+log_step "2.1 Enable cpu, memory, and pids in root"
 cd "$CGROUP_ROOT"
-echo "+memory +pids" > cgroup.subtree_control
-verify "root subtree_control has memory and pids" \
+echo "+cpu +memory +pids" > cgroup.subtree_control
+verify "root subtree_control has cpu, memory, and pids" \
     "cat cgroup.subtree_control" \
-    "memory pids"
+    "cpu memory pids"
 
-log_step "2.2 Check child now has memory.max and pids.max"
+log_step "2.2 Check child now has cpu, memory, and pids controller files"
 cd "$CGROUP_NAME"
 echo "Current directory: $(pwd)"
+verify "cpu.stat still exists" \
+    "ls cpu.stat" \
+    "cpu.stat"
 verify "memory.max now exists" \
     "ls memory.max" \
     "memory.max"
 verify "pids.max now exists" \
     "ls pids.max" \
     "pids.max"
+verify "cpu.stat has nr_periods after enabling CPU sub-controller" \
+    "grep '^nr_periods ' cpu.stat" \
+    "nr_periods 0"
+verify "cpu.stat has burst_usec after enabling CPU sub-controller" \
+    "grep '^burst_usec ' cpu.stat" \
+    "burst_usec 0"
+
+log_step "2.2.1 Verify cpu.stat grows for a busy cgroup task"
+CPU_STAT_PATH="$CGROUP_ROOT/$CGROUP_NAME/cpu.stat"
+
+sh -c '
+CGROUP_PATH=$1
+echo $$ > "$CGROUP_PATH/cgroup.procs"
+while :; do
+    :
+done
+' sh "$CGROUP_ROOT/$CGROUP_NAME" &
+BUSY_PID=$!
+
+# Give the helper time to join the cgroup and start consuming CPU.
+sleep 1
+
+USAGE_BEFORE=$(read_cpu_stat_field "usage_usec" "$CPU_STAT_PATH")
+USER_BEFORE=$(read_cpu_stat_field "user_usec" "$CPU_STAT_PATH")
+echo "cpu.stat before measurement: usage_usec=$USAGE_BEFORE user_usec=$USER_BEFORE"
+
+sleep 2
+
+USAGE_AFTER=$(read_cpu_stat_field "usage_usec" "$CPU_STAT_PATH")
+USER_AFTER=$(read_cpu_stat_field "user_usec" "$CPU_STAT_PATH")
+echo "cpu.stat after measurement: usage_usec=$USAGE_AFTER user_usec=$USER_AFTER"
+
+kill "$BUSY_PID" 2>/dev/null || true
+wait "$BUSY_PID" 2>/dev/null || true
+BUSY_PID=""
+
+USAGE_DELTA=$((USAGE_AFTER - USAGE_BEFORE))
+USER_DELTA=$((USER_AFTER - USER_BEFORE))
+echo "cpu.stat delta: usage_usec=$USAGE_DELTA user_usec=$USER_DELTA"
+
+if [ "$USAGE_DELTA" -lt 1900000 ] || [ "$USER_DELTA" -lt 1900000 ]; then
+    echo "Error: cpu.stat did not charge enough busy CPU time"
+    exit 1
+else
+    echo "Verified"
+fi
 
 log_step "2.3 Check child cgroup.controllers"
-verify "child controllers are memory and pids" \
+verify "child controllers are cpu, memory, and pids" \
     "cat cgroup.controllers" \
-    "memory pids"
+    "cpu memory pids"
 
 log_step "2.4 Disable memory in root"
 cd "$CGROUP_ROOT"
 echo "-memory" > cgroup.subtree_control
 verify "root subtree_control removed memory" \
     "cat cgroup.subtree_control" \
-    "pids"
+    "cpu pids"
 
 log_step "2.5 Check child lost memory.max after deactivation"
 cd "$CGROUP_NAME"


### PR DESCRIPTION
This PR enable the cgroup CPU sub-controller and support a basic attribute `cpu.stat`.

Required by #2911.

Kata checks at startup whether the CPU sub-controller is supported, and it does so using a fairly aggressive `unwrap`-based check... So although Kata does not actually use operations on that sub-controller afterward, in order to avoid adding too many patches to Kata, we would still like to enable at least the most basic CPU sub-controller functionality.