### PR TITLE
Remove redundant fs-instance checks from `ramfs` link and rename

### DIFF
--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -891,9 +891,6 @@ impl Inode for RamInode {
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        if !Arc::ptr_eq(&self.fs(), &old.fs()) {
-            return_errno_with_message!(Errno::EXDEV, "not same fs");
-        }
         if self.typ != InodeType::Dir {
             return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
         }
@@ -1018,15 +1015,8 @@ impl Inode for RamInode {
             .downcast_ref::<RamInode>()
             .ok_or(Error::new(Errno::EXDEV))?;
 
-        if !Arc::ptr_eq(&self.fs(), &target.fs()) {
-            return_errno_with_message!(Errno::EXDEV, "not same fs");
-        }
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-        if target.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "target is not dir");
-        }
+        debug_assert!(self.typ == InodeType::Dir);
+        debug_assert!(target.typ == InodeType::Dir);
 
         // Perform necessary checks to ensure that `dst_inode` can be replaced by `src_inode`.
         let check_replace_inode =


### PR DESCRIPTION
## Summary

Remove the explicit filesystem-instance checks from `RamInode::link()` and `RamInode::rename()`.

## Rationale

In Asterinas, the same-mounted-filesystem requirement is already enforced in the VFS path layer before the request reaches the filesystem-specific inode operations:

  - `Path::link()` rejects cross-mount hard links with `EXDEV`
  - `Path::rename()` rejects cross-mount renames with `EXDEV`

  Because of that, the extra `Arc::ptr_eq(&self.fs(), ...)` checks in `ramfs` are redundant for the syscall path.

  These checks are also not a precise match for Linux `EXDEV` semantics. Linux defines `EXDEV` in terms of mounts, not backing filesystem instances:

  > EXDEV oldpath and newpath are not on the same mounted filesystem. (Linux permits a filesystem to be mounted at multiple points, but link() does not work across different mounts, even if the same filesystem is mounted on both.)

Comparing `self.fs()` with the peer inode's `fs()` only checks whether the two inodes belong to the same backing filesystem object.
It does not model the mount-based rule directly.

## Behavior

This change does not relax the user-visible cross-mount restriction for `link(2)` or `rename(2)`. Those checks are still enforced by the VFS path layer.

 It only removes lower-level defensive checks in `ramfs` that are redundant and less semantically accurate than the existing mount-based validation.