### PR TITLE
Map CPU exceptions to fault signals on x86 and LoongArch

### DIFF
--- a/kernel/src/arch/loongarch/signal.rs
+++ b/kernel/src/arch/loongarch/signal.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use loongArch64::register::estat::Exception;
 use ostd::arch::cpu::context::{CpuExceptionInfo, UserContext};
 
-use crate::process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal};
+use crate::process::signal::{
+    SignalContext, constants::*, sig_num::SigNum, signals::fault::FaultSignal,
+};
 
 impl SignalContext for UserContext {
     fn set_arguments(&mut self, sig_num: SigNum, siginfo_addr: usize, ucontext_addr: usize) {
@@ -13,7 +16,30 @@ impl SignalContext for UserContext {
 }
 
 impl From<&CpuExceptionInfo> for FaultSignal {
-    fn from(_trap_info: &CpuExceptionInfo) -> Self {
-        unimplemented!()
+    fn from(trap_info: &CpuExceptionInfo) -> Self {
+        let (num, code, addr) = match trap_info.code {
+            Exception::LoadPageFault | Exception::StorePageFault | Exception::FetchPageFault => {
+                (SIGSEGV, SEGV_MAPERR, Some(trap_info.page_fault_addr as u64))
+            }
+            Exception::PageModifyFault
+            | Exception::PageNonReadableFault
+            | Exception::PageNonExecutableFault
+            | Exception::PagePrivilegeIllegal => {
+                (SIGSEGV, SEGV_ACCERR, Some(trap_info.page_fault_addr as u64))
+            }
+            Exception::FetchInstructionAddressError | Exception::MemoryAccessAddressError => {
+                (SIGBUS, BUS_ADRERR, None)
+            }
+            Exception::AddressNotAligned => (SIGBUS, BUS_ADRALN, None),
+            Exception::BoundsCheckFault => (SIGSEGV, SEGV_BNDERR, None),
+            Exception::Breakpoint => (SIGTRAP, TRAP_BRKPT, None),
+            Exception::InstructionNotExist | Exception::InstructionPrivilegeIllegal => {
+                (SIGILL, ILL_ILLOPC, None)
+            }
+            Exception::FloatingPointUnavailable => (SIGFPE, FPE_FLTINV, None),
+            Exception::Syscall | Exception::TLBRFill => unreachable!(),
+        };
+
+        FaultSignal::new(num, code, addr)
     }
 }

--- a/kernel/src/arch/x86/signal.rs
+++ b/kernel/src/arch/x86/signal.rs
@@ -23,6 +23,8 @@ impl From<&CpuException> for FaultSignal {
             }
             CpuException::BoundRangeExceeded => (SIGSEGV, SEGV_BNDERR, None),
             CpuException::AlignmentCheck => (SIGBUS, BUS_ADRALN, None),
+            CpuException::Debug => (SIGTRAP, TRAP_TRACE, None),
+            CpuException::BreakPoint => (SIGTRAP, SI_KERNEL, None),
             CpuException::InvalidOpcode => (SIGILL, ILL_ILLOPC, None),
             CpuException::GeneralProtectionFault(..) => (SIGBUS, BUS_ADRERR, None),
             CpuException::PageFault(raw_page_fault_info) => {

--- a/kernel/src/process/signal/signals/fault.rs
+++ b/kernel/src/process/signal/signals/fault.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![cfg_attr(target_arch = "loongarch64", expect(dead_code))]
-
 use super::Signal;
 use crate::{
     prelude::*,

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -51,6 +51,7 @@ set -e
 
 if [ "$(uname -m)" = "x86_64" ]; then
     ./signal/sigaltstack
+    ./signal/sigtrap
     ./signal/signal_fpu
     ./signal/signal_rflags_df
     ./signal/signal_test

--- a/test/initramfs/src/regression/process/signal/Makefile
+++ b/test/initramfs/src/regression/process/signal/Makefile
@@ -3,6 +3,7 @@
 ifneq ($(HOST_PLATFORM), x86_64-linux)
 C_OBJS_FILTER += \
 	sigaltstack \
+	sigtrap \
 	signal_fpu \
 	signal_rflags_df \
 	signal_test

--- a/test/initramfs/src/regression/process/signal/sigtrap.c
+++ b/test/initramfs/src/regression/process/signal/sigtrap.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Regression test for mapping #DB and #BP exceptions to SIGTRAP.
+
+#define _GNU_SOURCE
+#include <signal.h>
+#include <string.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+static volatile int trap_brkpt_received;
+static volatile int trap_trace_received;
+
+static void sigtrap_handler(int sig, siginfo_t *info, void *ctx)
+{
+	if (sig != SIGTRAP) {
+		fprintf(stderr, "expected SIGTRAP, got %d\n", sig);
+		_exit(1);
+	}
+
+	if (info->si_code == SI_KERNEL) {
+		trap_brkpt_received = 1;
+	} else if (info->si_code == TRAP_TRACE) {
+		ucontext_t *uc = (ucontext_t *)ctx;
+		uc->uc_mcontext.gregs[REG_EFL] &= ~0x100UL;
+		trap_trace_received = 1;
+	}
+}
+
+static int trap_brkpt(void)
+{
+	trap_brkpt_received = 0;
+	asm volatile("int3");
+	return 0;
+}
+
+static int trap_trace(void)
+{
+	trap_trace_received = 0;
+	asm volatile("pushfq; orq $0x100,(%%rsp); popfq; nop"
+		     :
+		     :
+		     : "memory", "cc");
+	return 0;
+}
+
+FN_SETUP(init)
+{
+	struct sigaction sa;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_sigaction = sigtrap_handler;
+	sa.sa_flags = SA_SIGINFO;
+	sigemptyset(&sa.sa_mask);
+
+	CHECK(sigaction(SIGTRAP, &sa, NULL));
+}
+END_SETUP()
+
+FN_TEST(sigtrap)
+{
+	TEST_RES(trap_brkpt(), trap_brkpt_received == 1);
+	TEST_RES(trap_trace(), trap_trace_received == 1);
+}
+END_TEST()


### PR DESCRIPTION
Map `CpuException::Debug` and `CpuException::BreakPoint` to `SIGTRAP` on x86. Without this, `int3` or the Trap Flag causes a kernel panic instead of delivering a signal.

Implement the full `FaultSignal::from(&CpuExceptionInfo)` for LoongArch, which was previously `unimplemented!()`. RISC-V already had these mappings.

Add an x86_64 regression test (`sigtrap.c`) that exercises both `TRAP_BRKPT` (via `int3`) and `TRAP_TRACE` (via the Trap Flag).

Split out from the GDB debug helpers RFC (#3094) per reviewer request.

Fix https://github.com/asterinas/asterinas/issues/2921.