### PR TITLE
Add `/proc/[tid]`

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -7,9 +7,17 @@ use ostd::sync::RwMutexUpgradeableGuard;
 use template::{DirOps, ProcDir, lookup_child_from_table, populate_children_from_table};
 
 use self::{
-    cmdline::CmdLineFileOps, cpuinfo::CpuInfoFileOps, loadavg::LoadAvgFileOps,
-    meminfo::MemInfoFileOps, mounts::MountsSymOps, pid::PidDirOps, self_::SelfSymOps,
-    sys::SysDirOps, thread_self::ThreadSelfSymOps, uptime::UptimeFileOps, version::VersionFileOps,
+    cmdline::CmdLineFileOps,
+    cpuinfo::CpuInfoFileOps,
+    loadavg::LoadAvgFileOps,
+    meminfo::MemInfoFileOps,
+    mounts::MountsSymOps,
+    pid::{PidDirOps, TidDirOps},
+    self_::SelfSymOps,
+    sys::SysDirOps,
+    thread_self::ThreadSelfSymOps,
+    uptime::UptimeFileOps,
+    version::VersionFileOps,
 };
 use crate::{
     events::Observer,
@@ -28,6 +36,7 @@ use crate::{
     process::{
         Pid,
         pid_table::{self, PidEvent},
+        posix_thread::AsPosixThread,
     },
 };
 
@@ -182,16 +191,26 @@ impl DirOps for RootDirOps {
     // called with the PID table locked.
 
     fn lookup_child(&self, dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        if let Ok(pid) = name.parse::<Pid>()
-            && let pid_table = pid_table::pid_table_mut()
-            && let Some(process_ref) = pid_table.get_process(pid)
-        {
-            let mut cached_children = dir.cached_children().write();
-            return Ok(cached_children
-                .put_entry_if_not_found(name, move || {
-                    PidDirOps::new_inode(process_ref, dir.this_weak().clone())
-                })
-                .clone());
+        if let Ok(pid) = name.parse::<Pid>() {
+            let pid_table = pid_table::pid_table_mut();
+
+            if let Some(process_ref) = pid_table.get_process(pid) {
+                let mut cached_children = dir.cached_children().write();
+                return Ok(cached_children
+                    .put_entry_if_not_found(name, move || {
+                        PidDirOps::new_inode(process_ref, dir.this_weak().clone())
+                    })
+                    .clone());
+            }
+
+            if let Some(thread_ref) = pid_table.get_thread(pid) {
+                let process_ref = thread_ref.as_posix_thread().unwrap().process();
+                return Ok(TidDirOps::new_inode(
+                    process_ref,
+                    thread_ref,
+                    dir.this_weak().clone(),
+                ));
+            }
         }
 
         let mut cached_children = dir.cached_children().write();

--- a/kernel/src/fs/fs_impls/procfs/pid/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/mod.rs
@@ -7,16 +7,13 @@ use super::template::{
     DirOps, ProcDir, ProcDirBuilder, lookup_child_from_table, populate_children_from_table,
 };
 use crate::{
-    fs::{
-        file::mkmod,
-        procfs::pid::task::{TaskDirOps, TidDirOps},
-        vfs::inode::Inode,
-    },
+    fs::{file::mkmod, procfs::pid::task::TaskDirOps, vfs::inode::Inode},
     prelude::*,
     process::Process,
 };
 
 mod task;
+pub(super) use task::TidDirOps;
 
 /// Represents the inode at `/proc/[pid]`.
 pub struct PidDirOps(
@@ -35,7 +32,7 @@ impl PidDirOps {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3493>
         ProcDirBuilder::new(Self(tid_dir_ops), mkmod!(a+rx))
             .parent(parent)
-            // The PID directories must be volatile, because it is just associated with one process.
+            // The PID directory must be volatile, because it is just associated with one process.
             .volatile()
             .build()
             .unwrap()

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -70,7 +70,7 @@ impl TaskDirOps {
 
 /// Represents the inode at `/proc/[pid]/task/[tid]`.
 #[derive(Clone)]
-pub(super) struct TidDirOps {
+pub struct TidDirOps {
     pub(super) process_ref: Arc<Process>,
     /// If `thread_ref` is `None`, this corresponds to a process-level `/proc/[pid]/*` file.
     /// Otherwise, this corresponds to a thread-level `/proc/[pid]/task/[tid]/*` file.
@@ -92,6 +92,8 @@ impl TidDirOps {
             mkmod!(a+rx),
         )
         .parent(parent)
+        // The TID directory must be volatile, because it is just associated with one thread.
+        .volatile()
         .build()
         .unwrap()
     }

--- a/test/initramfs/src/regression/fs/procfs/Makefile
+++ b/test/initramfs/src/regression/fs/procfs/Makefile
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
+EXTRA_C_FLAGS := -lpthread
+
 include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/procfs/tid.c
+++ b/test/initramfs/src/regression/fs/procfs/tid.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+struct tid_test_context {
+	int ready_pipe[2];
+	int exit_pipe[2];
+	pid_t tid;
+};
+
+static void print_command(char *command, size_t command_len, const char *format,
+			  int id)
+{
+	CHECK_WITH(snprintf(command, command_len, format, id),
+		   _ret > 0 && _ret < command_len);
+}
+
+static void *thread_fn(void *arg)
+{
+	struct tid_test_context *context = arg;
+	char ch;
+
+	context->tid = CHECK(syscall(SYS_gettid));
+	CHECK_WITH(write(context->ready_pipe[1], "R", 1), _ret == 1);
+	CHECK_WITH(read(context->exit_pipe[0], &ch, 1), _ret == 1 && ch == 'X');
+
+	return NULL;
+}
+
+FN_TEST(proc_root_tid_entry)
+{
+	struct tid_test_context context = {
+		.ready_pipe = { -1, -1 },
+		.exit_pipe = { -1, -1 },
+		.tid = -1,
+	};
+	char command[128];
+	char ch;
+	pthread_t thread;
+	pid_t pid = TEST_SUCC(getpid());
+
+	TEST_SUCC(pipe(context.ready_pipe));
+	TEST_SUCC(pipe(context.exit_pipe));
+	TEST_SUCC(pthread_create(&thread, NULL, thread_fn, &context));
+	TEST_RES(read(context.ready_pipe[0], &ch, 1),
+		 _ret == 1 && ch == 'R' && context.tid > 0 &&
+			 context.tid != pid);
+
+	print_command(command, sizeof(command), "ls /proc/%d > /dev/null",
+		      context.tid);
+	TEST_RES(system(command), _ret == 0);
+
+	print_command(command, sizeof(command),
+		      "ls /proc -al | grep ' %d$' > /dev/null", context.tid);
+	TEST_RES(system(command), _ret != 0);
+
+	print_command(command, sizeof(command),
+		      "ls /proc -al | grep ' %d$' > /dev/null", pid);
+	TEST_RES(system(command), _ret == 0);
+
+	TEST_RES(write(context.exit_pipe[1], "X", 1), _ret == 1);
+	TEST_SUCC(pthread_join(thread, NULL));
+	TEST_SUCC(close(context.ready_pipe[0]));
+	TEST_SUCC(close(context.ready_pipe[1]));
+	TEST_SUCC(close(context.exit_pipe[0]));
+	TEST_SUCC(close(context.exit_pipe[1]));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -115,6 +115,7 @@ echo "All mount bind file test passed."
 ./procfs/dentry_cache
 ./procfs/mountstats
 ./procfs/pid_mem
+./procfs/tid
 
 ./pseudofs/memfd_access_err
 ./pseudofs/pseudo_dentry


### PR DESCRIPTION
Required for #2323. Fix https://github.com/asterinas/asterinas/issues/2940.

This PR adds `/proc/[tid]`s. They can be looked up from `/proc`, but not included in `readdir(/proc)`.



> /proc/tid subdirectories
>               Each one of these subdirectories contains files and
>               subdirectories exposing information about the thread with
>               the corresponding thread ID.  The contents of these
>               directories are the same as the corresponding
>               /proc/pid/task/tid directories.
>               The /proc/tid subdirectories are not visible when iterating
>               through /proc with [getdents(2)](https://man7.org/linux/man-pages/man2/getdents.2.html) (and thus are not visible
>               when one uses [ls(1)](https://man7.org/linux/man-pages/man1/ls.1.html) to view the contents of /proc).
> 

Reference: https://man7.org/linux/man-pages/man5/proc.5.html