### PR TITLE
Fix kernel builds that fail during dependency resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ install_osdk:
 	@# The `OSDK_LOCAL_DEV` environment variable is used for local development
 	@# without the need to publish the changes of OSDK's self-hosted
 	@# dependencies to `crates.io`.
-	@OSDK_LOCAL_DEV=1 cargo install cargo-osdk --path osdk
+	@OSDK_LOCAL_DEV=1 cargo install --locked cargo-osdk --path osdk
 
 # This will install and update OSDK automatically
 $(CARGO_OSDK): $(OSDK_SRC_FILES)

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -99,6 +99,7 @@ pub fn new_base_crate(
         std::fs::remove_dir_all(&base_crate_tmp_path).unwrap();
         if cargo_result.is_ok_and(|res| res) && main_rs_result.is_ok_and(|res| res) {
             info!("Reusing existing base crate");
+            sync_workspace_lockfile(&base_crate_path);
             return base_crate_path;
         }
     }
@@ -154,6 +155,8 @@ fn do_new_base_crate(
     // Create the src directory
     fs::create_dir_all(base_crate_path.as_ref().join("src")).unwrap();
 
+    sync_workspace_lockfile(base_crate_path.as_ref());
+
     // Write Cargo.toml
     let cargo_toml = include_str!("Cargo.toml.template");
     let cargo_toml = cargo_toml.replace("#NAME#", &(dep_crate_name.to_string() + "-osdk-bin"));
@@ -204,6 +207,24 @@ fn do_new_base_crate(
 
     // Get back to the original directory
     std::env::set_current_dir(original_dir).unwrap();
+}
+
+// Seed the generated base crate with the workspace lockfile so Cargo can
+// reuse the repository's pinned dependency graph, including yanked crates
+// that remain buildable as long as they are already locked.
+fn sync_workspace_lockfile(base_crate_path: impl AsRef<Path>) {
+    let workspace_root = {
+        let meta = get_cargo_metadata(None::<&str>, None::<&[&str]>).unwrap();
+        PathBuf::from(meta.get("workspace_root").unwrap().as_str().unwrap())
+    };
+    let workspace_lockfile = workspace_root.join("Cargo.lock");
+    if workspace_lockfile.exists() {
+        fs::copy(
+            workspace_lockfile,
+            base_crate_path.as_ref().join("Cargo.lock"),
+        )
+        .unwrap();
+    }
 }
 
 fn add_manifest_dependency(

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -181,7 +181,10 @@ fn install_setup_with_arch(
     cmd.arg("--root").arg(install_dir.as_ref());
     if matches!(option_env!("OSDK_LOCAL_DEV"), Some("1")) {
         let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = crate_dir.parent().unwrap();
         let setup_dir = crate_dir.join("../ostd/libs/linux-bzimage/setup");
+        cmd.current_dir(workspace_root);
+        cmd.arg("--locked");
         cmd.arg("--path").arg(setup_dir);
     } else {
         cmd.arg("--version").arg(env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
Fix #3132

This pr keeps the build on the repository's pinned dependency graph instead
of asking Cargo to resolve dependencies again in two places:

- install `cargo-osdk` with `cargo install --locked`
- seed OSDK-generated base crates with the workspace `Cargo.lock`