### PR TITLE
Use patch section to fix core2 yank temporarily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,8 +553,7 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+source = "git+https://github.com/bbqsrc/core2?rev=545e84bcb0f235b12e21351e0c69767958efe2a7#545e84bcb0f235b12e21351e0c69767958efe2a7"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,11 @@ proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
 quote = "1.0.35"
 syn = { version = "2.0.77", features = ["full", "parsing", "fold"] }
 
+[patch.crates-io]
+# Temporary workaround for the `core2` yank; see #3132.
+# TODO: Remove this git rev pin once upstream `libflate` publishes the fix and `core2` is available again on crates.io.
+core2 = { git = "https://github.com/bbqsrc/core2", rev = "545e84bcb0f235b12e21351e0c69767958efe2a7" }
+
 # Cargo only looks at the profile settings 
 # in the Cargo.toml manifest at the root of the workspace
 

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -292,8 +292,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "core2"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+source = "git+https://github.com/bbqsrc/core2?rev=545e84bcb0f235b12e21351e0c69767958efe2a7#545e84bcb0f235b12e21351e0c69767958efe2a7"
 dependencies = [
  "memchr",
 ]

--- a/osdk/Cargo.toml
+++ b/osdk/Cargo.toml
@@ -33,3 +33,8 @@ rustc_version = "0.4.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.13"
+
+[patch.crates-io]
+# Temporary workaround for the `core2` yank; see #3132.
+# TODO: Once upstream `libflate` publishes the fix and `core2` is available again on crates.io, revert the workaround introduced by PR #3134.
+core2 = { git = "https://github.com/bbqsrc/core2", rev = "545e84bcb0f235b12e21351e0c69767958efe2a7" }

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -310,8 +310,38 @@ fn copy_profile_configurations(workspace_root: impl AsRef<Path>) {
         );
     }
 
+    copy_core2_patch(&target_manifest, &mut manifest);
+
     let content = toml::to_string(&manifest).unwrap();
     fs::write(manifest_path, content).unwrap();
+}
+
+fn copy_core2_patch(source_manifest: &toml::Table, target_manifest: &mut toml::Table) {
+    // Only propagate OSDK's temporary `core2` workaround. Copying the whole
+    // `[patch]` table may also pull unrelated workspace overrides, especially
+    // path-based patches that do not make sense in the generated base crate.
+    let Some(core2_patch) = source_manifest
+        .get("patch")
+        .and_then(toml::Value::as_table)
+        .and_then(|patch| patch.get("crates-io"))
+        .and_then(toml::Value::as_table)
+        .and_then(|crates_io| crates_io.get("core2"))
+        .cloned()
+    else {
+        return;
+    };
+
+    let patch = target_manifest
+        .entry("patch".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .unwrap();
+    let crates_io = patch
+        .entry("crates-io".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .unwrap();
+    crates_io.insert("core2".to_string(), core2_patch);
 }
 
 fn add_feature_entries(


### PR DESCRIPTION
The related discussion can be found in #3132.

This is a temporary fix. Once upstream libflate publishes a new release with the fix, this commit should be reverted.

Note that `cargo publish` [automatically strips the `[patch]` section](https://doc.rust-lang.org/cargo/commands/cargo-package.html#description), so the osdk and ostd publish CI jobs will still fail with this change. We must fix this problem before next release.

```plain
Create the compressed .crate file.

- The original Cargo.toml file is rewritten and normalized.
- [patch], [replace], and [workspace] sections are removed from the manifest.

.......
```
