### PR TITLE
Replace `impl From<&CpuException> for FaultSignal` with `ToFaultSignal`

### DIFF
--- a/kernel/src/arch/loongarch/signal.rs
+++ b/kernel/src/arch/loongarch/signal.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use loongArch64::register::estat::Exception;
-use ostd::arch::cpu::context::{CpuExceptionInfo, UserContext};
+use ostd::{
+    arch::cpu::context::{CpuExceptionInfo, UserContext},
+    user::UserContextApi,
+};
 
-use crate::process::signal::{
-    SignalContext, constants::*, sig_num::SigNum, signals::fault::FaultSignal,
+use crate::{
+    process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
+    thread::exception::ToFaultSignal,
 };
 
 impl SignalContext for UserContext {
@@ -15,31 +19,53 @@ impl SignalContext for UserContext {
     }
 }
 
-impl From<&CpuExceptionInfo> for FaultSignal {
-    fn from(trap_info: &CpuExceptionInfo) -> Self {
-        let (num, code, addr) = match trap_info.code {
+impl ToFaultSignal for CpuExceptionInfo {
+    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+        use crate::process::signal::constants::*;
+
+        let era = user_ctx.instruction_pointer() as u64;
+
+        let (num, code, addr) = match self.code {
             Exception::LoadPageFault | Exception::StorePageFault | Exception::FetchPageFault => {
-                (SIGSEGV, SEGV_MAPERR, Some(trap_info.page_fault_addr as u64))
+                // FIXME: The code should be `SEGV_ACCERR` for faults within an existing mapping.
+                (SIGSEGV, SEGV_MAPERR, Some(self.page_fault_addr as u64))
             }
             Exception::PageModifyFault
             | Exception::PageNonReadableFault
             | Exception::PageNonExecutableFault
             | Exception::PagePrivilegeIllegal => {
-                (SIGSEGV, SEGV_ACCERR, Some(trap_info.page_fault_addr as u64))
+                (SIGSEGV, SEGV_ACCERR, Some(self.page_fault_addr as u64))
             }
             Exception::FetchInstructionAddressError | Exception::MemoryAccessAddressError => {
+                // TODO: Report `si_addr`.
                 (SIGBUS, BUS_ADRERR, None)
             }
-            Exception::AddressNotAligned => (SIGBUS, BUS_ADRALN, None),
-            Exception::BoundsCheckFault => (SIGSEGV, SEGV_BNDERR, None),
-            Exception::Breakpoint => (SIGTRAP, TRAP_BRKPT, None),
-            Exception::InstructionNotExist | Exception::InstructionPrivilegeIllegal => {
-                (SIGILL, ILL_ILLOPC, None)
+            Exception::AddressNotAligned => {
+                // TODO: Report `si_addr`.
+                (SIGBUS, BUS_ADRALN, None)
             }
-            Exception::FloatingPointUnavailable => (SIGFPE, FPE_FLTINV, None),
-            Exception::Syscall | Exception::TLBRFill => unreachable!(),
+            Exception::BoundsCheckFault => {
+                // TODO: Report `si_addr`, `si_lower`, and `si_upper`.
+                (SIGSEGV, SEGV_BNDERR, None)
+            }
+            Exception::Breakpoint => {
+                // TODO: Decode the faulting `break` instruction and choose the signal and code.
+                (SIGTRAP, TRAP_BRKPT, Some(era))
+            }
+            Exception::InstructionNotExist | Exception::InstructionPrivilegeIllegal => {
+                // Linux uses `SI_KERNEL` without an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/loongarch/kernel/traps.c#L877>
+                (SIGILL, SI_KERNEL, None)
+            }
+            Exception::FloatingPointUnavailable => {
+                // TODO: Support FPU in LoongArch64.
+                (SIGFPE, FPE_FLTINV, Some(era))
+            }
+
+            Exception::Syscall | Exception::TLBRFill => return None,
         };
 
-        FaultSignal::new(num, code, addr)
+        Some(FaultSignal::new(num, code, addr))
     }
 }

--- a/kernel/src/arch/riscv/signal.rs
+++ b/kernel/src/arch/riscv/signal.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::arch::cpu::context::{CpuException, UserContext};
+use ostd::{
+    arch::cpu::context::{CpuException, UserContext},
+    user::UserContextApi,
+};
 
-use crate::process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal};
+use crate::{
+    process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
+    thread::exception::ToFaultSignal,
+};
 
 impl SignalContext for UserContext {
     fn set_arguments(&mut self, sig_num: SigNum, siginfo_addr: usize, ucontext_addr: usize) {
@@ -12,30 +18,45 @@ impl SignalContext for UserContext {
     }
 }
 
-impl From<&CpuException> for FaultSignal {
-    fn from(exception: &CpuException) -> Self {
+impl ToFaultSignal for CpuException {
+    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
         use CpuException::*;
 
         use crate::process::signal::constants::*;
 
-        // FIXME: All the `None` addresses here should be the value of `sepc`
-        // CSR on trap. So we should either encode that in `CpuException` or
-        // pass it as an additional parameter here.
-        let (num, code, addr) = match exception {
-            InstructionMisaligned => (SIGBUS, BUS_ADRALN, None),
-            InstructionFault => (SIGSEGV, SEGV_ACCERR, None),
-            IllegalInstruction(_) => (SIGILL, ILL_ILLOPC, None),
-            Breakpoint => (SIGTRAP, TRAP_BRKPT, None),
-            LoadMisaligned(_) | StoreMisaligned(_) => (SIGBUS, BUS_ADRALN, None),
-            LoadFault(_) | StoreFault(_) => (SIGSEGV, SEGV_ACCERR, None),
-            UserEnvCall => unreachable!(),
-            SupervisorEnvCall => (SIGILL, ILL_ILLTRP, None),
-            InstructionPageFault(addr) | LoadPageFault(addr) | StorePageFault(addr) => {
-                (SIGSEGV, SEGV_MAPERR, Some(*addr as u64))
+        let sepc = user_ctx.instruction_pointer() as u64;
+
+        let (num, code, addr) = match self {
+            InstructionMisaligned => (SIGBUS, BUS_ADRALN, sepc),
+            InstructionFault => (SIGSEGV, SEGV_ACCERR, sepc),
+            IllegalInstruction(_) => (SIGILL, ILL_ILLOPC, sepc),
+            Breakpoint => (SIGTRAP, TRAP_BRKPT, sepc),
+            LoadMisaligned(_) | StoreMisaligned(_) => {
+                // The address should be the memory address, but Linux reports the instruction
+                // address. So we follow it.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/riscv/kernel/traps.c#L230-L232>
+                (SIGBUS, BUS_ADRALN, sepc)
             }
-            Unknown => (SIGILL, ILL_ILLTRP, None),
+            LoadFault(_) | StoreFault(_) => {
+                // The address should be the memory address, but Linux reports the instruction
+                // address. So we follow it.
+                //
+                // Reference:
+                // <https://elixir.bootlin.com/linux/v7.0/source/arch/riscv/kernel/traps.c#L198-L199>
+                // <https://elixir.bootlin.com/linux/v7.0/source/arch/riscv/kernel/traps.c#L252-L253>
+                (SIGSEGV, SEGV_ACCERR, sepc)
+            }
+            SupervisorEnvCall => (SIGILL, ILL_ILLTRP, sepc),
+            InstructionPageFault(addr) | LoadPageFault(addr) | StorePageFault(addr) => {
+                // FIXME: The code should be `SEGV_ACCERR` for faults within an existing mapping.
+                (SIGSEGV, SEGV_MAPERR, *addr as u64)
+            }
+            Unknown => (SIGILL, ILL_ILLTRP, sepc),
+
+            UserEnvCall => return None,
         };
 
-        FaultSignal::new(num, code, addr)
+        Some(FaultSignal::new(num, code, Some(addr)))
     }
 }

--- a/kernel/src/arch/x86/signal.rs
+++ b/kernel/src/arch/x86/signal.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::arch::cpu::context::{CpuException, PageFaultErrorCode, UserContext};
+use ostd::{
+    arch::cpu::context::{CpuException, PageFaultErrorCode, UserContext},
+    user::UserContextApi,
+};
 
-use crate::process::signal::{
-    SignalContext, constants::*, sig_num::SigNum, signals::fault::FaultSignal,
+use crate::{
+    process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
+    thread::exception::ToFaultSignal,
 };
 
 impl SignalContext for UserContext {
@@ -14,20 +18,46 @@ impl SignalContext for UserContext {
     }
 }
 
-impl From<&CpuException> for FaultSignal {
-    fn from(exception: &CpuException) -> Self {
-        let (num, code, addr) = match exception {
-            CpuException::DivisionError => (SIGFPE, FPE_INTDIV, None),
-            CpuException::X87FloatingPointException | CpuException::SIMDFloatingPointException => {
-                (SIGFPE, FPE_FLTDIV, None)
+impl ToFaultSignal for CpuException {
+    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+        use crate::process::signal::constants::*;
+
+        let rip = user_ctx.instruction_pointer() as u64;
+
+        let (num, code, addr) = match self {
+            CpuException::DivisionError => (SIGFPE, FPE_INTDIV, Some(rip)),
+            CpuException::Debug => {
+                // TODO: Derive the code from the debug status.
+                (SIGTRAP, TRAP_TRACE, Some(rip))
             }
-            CpuException::BoundRangeExceeded => (SIGSEGV, SEGV_BNDERR, None),
-            CpuException::AlignmentCheck => (SIGBUS, BUS_ADRALN, None),
-            CpuException::Debug => (SIGTRAP, TRAP_TRACE, None),
-            CpuException::BreakPoint => (SIGTRAP, SI_KERNEL, None),
-            CpuException::InvalidOpcode => (SIGILL, ILL_ILLOPC, None),
-            CpuException::GeneralProtectionFault(..) => (SIGBUS, BUS_ADRERR, None),
+            CpuException::BreakPoint => {
+                // Linux uses `SI_KERNEL` without an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/traps.c#L998>
+                (SIGTRAP, SI_KERNEL, None)
+            }
+            CpuException::Overflow => {
+                // Linux uses `SI_KERNEL` without an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/traps.c#L387>
+                (SIGSEGV, SI_KERNEL, None)
+            }
+            CpuException::InvalidOpcode => (SIGILL, ILL_ILLOPN, Some(rip)),
+            CpuException::StackSegmentFault(..) => {
+                // Linux uses `SI_KERNEL` without an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/traps.c#L519-L520>
+                (SIGBUS, SI_KERNEL, None)
+            }
+            CpuException::GeneralProtectionFault(..) => {
+                // Linux uses `SI_KERNEL` without an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/traps.c#L904-L911>
+                (SIGSEGV, SI_KERNEL, None)
+            }
             CpuException::PageFault(raw_page_fault_info) => {
+                // FIXME: The code should depend on whether the faulting address is covered by a
+                // mapping, not just on the `PRESENT` bit.
                 let code = if raw_page_fault_info
                     .error_code
                     .contains(PageFaultErrorCode::PRESENT)
@@ -39,9 +69,20 @@ impl From<&CpuException> for FaultSignal {
                 let addr = Some(raw_page_fault_info.addr as u64);
                 (SIGSEGV, code, addr)
             }
-            e => panic!("{e:?} cannot be handled via signals ({exception:?})"),
+            CpuException::X87FloatingPointException | CpuException::SIMDFloatingPointException => {
+                // TODO: Derive the code from the floating-point status.
+                (SIGFPE, FPE_FLTDIV, Some(rip))
+            }
+            CpuException::AlignmentCheck => {
+                // Linux does not provide an address.
+                //
+                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/traps.c#L538-L539>
+                (SIGBUS, BUS_ADRALN, None)
+            }
+
+            _ => return None,
         };
 
-        FaultSignal::new(num, code, addr)
+        Some(FaultSignal::new(num, code, addr))
     }
 }

--- a/kernel/src/process/signal/signals/fault.rs
+++ b/kernel/src/process/signal/signals/fault.rs
@@ -25,8 +25,8 @@ impl Signal for FaultSignal {
     }
 
     fn to_info(&self) -> siginfo_t {
-        siginfo_t::new(self.num, self.code)
-        // info.set_si_addr(self.addr.unwrap_or_default() as *const c_void);
-        // info
+        let mut info = siginfo_t::new(self.num, self.code);
+        info.set_si_addr(self.addr.unwrap_or_default() as Vaddr);
+        info
     }
 }

--- a/kernel/src/thread/exception.rs
+++ b/kernel/src/thread/exception.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#![expect(unused_variables)]
-
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 use ostd::arch::cpu::context::CpuException;
 #[cfg(target_arch = "loongarch64")]
@@ -14,8 +12,7 @@ use crate::{
     vm::vmar::{PageFaultInfo, Vmar},
 };
 
-/// We can't handle most exceptions, just send self a fault signal before return to user space.
-pub fn handle_exception(ctx: &Context, context: &UserContext, exception: CpuException) {
+pub(super) fn handle_exception(ctx: &Context, user_ctx: &UserContext, exception: CpuException) {
     debug!("[User Trap] handle exception: {:#x?}", exception);
 
     if let Ok(page_fault_info) = PageFaultInfo::try_from(&exception) {
@@ -26,7 +23,9 @@ pub fn handle_exception(ctx: &Context, context: &UserContext, exception: CpuExce
         }
     }
 
-    generate_fault_signal(exception, ctx);
+    // We cannot handle most exceptions. Send a fault signal to the current thread before returning
+    // to user space.
+    generate_fault_signal(exception, ctx, user_ctx);
 }
 
 /// Handles the page fault occurs in the VMAR.
@@ -44,9 +43,30 @@ fn handle_page_fault_from_vmar(
     Ok(())
 }
 
-/// generate a fault signal for current process.
-fn generate_fault_signal(exception: CpuException, ctx: &Context) {
-    let signal = FaultSignal::from(&exception);
+/// A trait that converts CPU exceptions into fault signals.
+///
+/// This trait should be implemented by architecture-specific code for [`CpuException`].
+pub trait ToFaultSignal {
+    /// Converts a CPU exception into a fault signal.
+    ///
+    /// Returns `None` if the exception must be handled earlier and cannot be delivered as a signal.
+    ///
+    /// POSIX [requires] `SIGILL` and `SIGFPE` to report the address of the faulting instruction,
+    /// and `SIGSEGV` and `SIGBUS` to report the address of the faulting memory reference. Linux
+    /// behavior, however, is highly architecture-specific and does not always follow POSIX: for
+    /// some exceptions, it reports neither the expected code nor the expected address. Linux may
+    /// also attach an instruction address to `SIGTRAP`, but this behavior is not consistent across
+    /// architectures.
+    ///
+    /// [requires]: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html
+    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal>;
+}
+
+/// Generates a fault signal for the current thread.
+fn generate_fault_signal(exception: CpuException, ctx: &Context, user_ctx: &UserContext) {
+    let Some(signal) = exception.to_fault_signal(user_ctx) else {
+        panic!("`{:?}` cannot be handled via signals", exception);
+    };
     ctx.posix_thread.enqueue_signal(Box::new(signal));
 }
 

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -50,11 +50,12 @@ set -e
 ./signal/signal_test2
 
 if [ "$(uname -m)" = "x86_64" ]; then
+    ./signal/fault_signals
     ./signal/sigaltstack
-    ./signal/sigtrap
     ./signal/signal_fpu
     ./signal/signal_rflags_df
     ./signal/signal_test
+    ./signal/sigtrap
 fi
 
 ./group_session

--- a/test/initramfs/src/regression/process/signal/Makefile
+++ b/test/initramfs/src/regression/process/signal/Makefile
@@ -2,11 +2,12 @@
 
 ifneq ($(HOST_PLATFORM), x86_64-linux)
 C_OBJS_FILTER += \
+	fault_signals \
 	sigaltstack \
-	sigtrap \
 	signal_fpu \
 	signal_rflags_df \
-	signal_test
+	signal_test \
+	sigtrap
 endif
 
 include ../../common/Makefile

--- a/test/initramfs/src/regression/process/signal/fault_signals.c
+++ b/test/initramfs/src/regression/process/signal/fault_signals.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "../../common/test.h"
+
+#define TEST_CHILD_RECEIVE_FAULT_SIGNAL(func, sig)                        \
+	pid = TEST_SUCC(fork());                                          \
+	if (pid == 0) {                                                   \
+		func();                                                   \
+		exit(EXIT_FAILURE);                                       \
+	}                                                                 \
+                                                                          \
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid &&                 \
+						   WIFSIGNALED(status) && \
+						   WTERMSIG(status) == (sig));
+
+// This generates #OF. The kernel should respond with a SIGSEGV.
+static void generate_of(void)
+{
+	asm volatile("int $4");
+}
+
+FN_TEST(of_exception_to_sigsegv)
+{
+	pid_t pid;
+	int status;
+
+	TEST_CHILD_RECEIVE_FAULT_SIGNAL(generate_of, SIGSEGV);
+}
+END_TEST()
+
+// This generates #SS. The kernel should respond with a SIGBUS.
+static void generate_ss(void)
+{
+	asm volatile("movabs $0x8000000000000000, %%rax\n\t"
+		     "mov %%rax, %%rsp\n\t"
+		     "push %%rax\n\t"
+		     :
+		     :
+		     : "rax", "memory");
+}
+
+FN_TEST(ss_exception_to_sigsegv)
+{
+	pid_t pid;
+	int status;
+
+	TEST_CHILD_RECEIVE_FAULT_SIGNAL(generate_ss, SIGBUS);
+}
+END_TEST()
+
+static void try_generate_br_via_bound(void)
+{
+	// bound %eax, (%eax)
+	asm volatile(".byte 0x62, 0x00");
+}
+
+static void try_generate_br_via_int5(void)
+{
+	asm volatile("int $5");
+}
+
+static void try_generate_br_via_mpx(void)
+{
+	// bndcl (%rax), %bnd0
+	asm volatile(".byte 0xf3, 0x0f, 0x1a, 0x00");
+}
+
+FN_TEST(br_exception_cannot_be_generated)
+{
+	pid_t pid;
+	int status;
+
+	// The `bound` instruction is not a valid instruction in 64-bit mode.
+	// So it generates SIGILL.
+	TEST_CHILD_RECEIVE_FAULT_SIGNAL(try_generate_br_via_bound, SIGILL);
+
+	// The `int` instruction cannot trigger #BR: the vector-5 gate has DPL 0,
+	// so it is callable only from Ring 0.
+	TEST_CHILD_RECEIVE_FAULT_SIGNAL(try_generate_br_via_int5, SIGSEGV);
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		try_generate_br_via_mpx();
+		exit(EXIT_SUCCESS);
+	}
+
+	// "When Intel MPX is not enabled or not present, all Intel MPX
+	// instructions behave as NOP."
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/signal/sigtrap.c
+++ b/test/initramfs/src/regression/process/signal/sigtrap.c
@@ -12,6 +12,7 @@
 
 static volatile int trap_brkpt_received;
 static volatile int trap_trace_received;
+static void *volatile last_si_addr;
 
 static void sigtrap_handler(int sig, siginfo_t *info, void *ctx)
 {
@@ -27,6 +28,8 @@ static void sigtrap_handler(int sig, siginfo_t *info, void *ctx)
 		uc->uc_mcontext.gregs[REG_EFL] &= ~0x100UL;
 		trap_trace_received = 1;
 	}
+
+	last_si_addr = info->si_addr;
 }
 
 static int trap_brkpt(void)
@@ -61,7 +64,9 @@ END_SETUP()
 
 FN_TEST(sigtrap)
 {
-	TEST_RES(trap_brkpt(), trap_brkpt_received == 1);
-	TEST_RES(trap_trace(), trap_trace_received == 1);
+	TEST_RES(trap_brkpt(),
+		 trap_brkpt_received == 1 && last_si_addr == NULL);
+	TEST_RES(trap_trace(),
+		 trap_trace_received == 1 && last_si_addr != NULL);
 }
 END_TEST()


### PR DESCRIPTION
Previously, we used `impl From<&CpuException> for FaultSignal` to build a fault signal from a CPU exception. However, this approach is problematic.
 1. The `unreachable!()` macro should not appear in the `From` trait. As quoted from [the standard library's documentation](https://doc.rust-lang.org/std/convert/trait.From.html), it does not make much sense:
https://github.com/asterinas/asterinas/blob/83edf72dd107d253ea46902db3ee71e6a823ec2f/kernel/src/arch/riscv/signal.rs#L31
> Note: This trait must not fail. The `From` trait is intended for perfect conversions. If the conversion can fail or is not perfect, use `TryFrom`.
 2. Some information is unavailable. See this FIXME:
https://github.com/asterinas/asterinas/blob/83edf72dd107d253ea46902db3ee71e6a823ec2f/kernel/src/arch/riscv/signal.rs#L21-L23

This PR proposes to add a `ToFaultSignal` trait instead.
```rust
/// A trait that converts CPU exceptions into fault signals.
///
/// This trait should be implemented by architecture-specific code.
pub trait ToFaultSignal {
    /// Converts a CPU exception into a fault signal.
    ///
    /// Returns `None` if the exception must be handled earlier and cannot be
    /// delivered as a signal.
    ///
    /// POSIX [requires] `SIGILL` and `SIGFPE` to report the address of the
    /// faulting instruction, and `SIGSEGV` and `SIGBUS` to report the address
    /// of the faulting memory reference. Linux behavior, however, is highly
    /// architecture-specific and does not always follow POSIX: for some
    /// exceptions, it reports neither the expected code nor the expected
    /// address. Linux may also attach an instruction address to `SIGTRAP`, but
    /// this behavior is not consistent across architectures.
    ///
    /// [requires]: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html
    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal>;
}
```

With the `user_ctx` argument, we can fill more information to the fault signals. So this PR also resolves the aforementioned TODO.

In addition, we previously can also trigger kernel panics by generating #SS and #OF exceptions from userspace:
```c
// This generates #OF. The kernel should respond with a SIGSEGV.
static void generate_of(void)
{
       asm volatile("int $4");
}

// This generates #SS. The kernel should respond with a SIGBUS.
static void generate_ss(void)
{
       asm volatile("movabs $0x8000000000000000, %%rax\n\t"
                    "mov %%rax, %%rsp\n\t"
                    "push %%rax\n\t"
                    :
                    :
                    : "rax", "memory");
}
```

This PR fixes the reachable kernel panics and adds some more regression tests.

However, generating #BR from the user space is impossible with our x86-64 settings. Although there are known methods, none of them work.
```c
// The `bound` instruction is not a valid instruction in 64-bit mode.
// So it generates SIGILL.
static void try_generate_br_via_bound(void)
{
	// bound %eax, (%eax)
	asm volatile(".byte 0x62, 0x00");
}

// The `int` instruction cannot trigger #BR: the vector-5 gate has DPL 0,
// so it is callable only from Ring 0.
static void try_generate_br_via_int5(void)
{
	asm volatile("int $5");
}

// "When Intel MPX is not enabled or not present, all Intel MPX
// instructions behave as NOP."
static void try_generate_br_via_mpx(void)
{
	// bndcl (%rax), %bnd0
	asm volatile(".byte 0xf3, 0x0f, 0x1a, 0x00");
}
```

As mentioned in the `ToFaultSignal` trait's documentation, the Linux implementation is highly architecture-specific and does not consistently adhere to the POSIX standard. I reviewed all the existing code manually and then with the help of Codex, adjusting the signal information accordingly. I added comments in one of the following two cases:
1. The behavior does not match that of Linux due to limitations in our implementation. I add `TODO`/`FIXME` comments for this case. Example:
```rust
            CpuException::X87FloatingPointException | CpuException::SIMDFloatingPointException => {
                // TODO: Derive the code from the floating-point status.
                (SIGFPE, FPE_FLTDIV, Some(rip))
            }
```
2. The behavior does not match POSIX standards, usually because the code and/or address is missing or incorrect. In this case, I include a reference to the Linux source code for confirmation. Example:
```rust
            LoadMisaligned(_) | StoreMisaligned(_) => {
                // The address should be the memory address, but Linux reports the instruction
                // address. So we follow it.
                //
                // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/riscv/kernel/traps.c#L230-L232>
                (SIGBUS, BUS_ADRALN, sepc)
            }
```