### PR TITLE
Fix cross-compilation issues in OSDK and NixOS

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -70,7 +70,7 @@ runs:
         [[ "${{ matrix.id }}" == "compile" ]] && CMD+="make kernel"
         [[ "${{ matrix.id }}" == "usermode_test" ]] && CMD+="make test"
         [[ "${{ matrix.id }}" == "ktest" ]] && CMD+="make ktest NETDEV=tap"
-        [[ -n "${{ inputs.arch }}" ]] && CMD+=" OSDK_TARGET_ARCH=${{ inputs.arch }}"
+        [[ -n "${{ inputs.arch }}" ]] && CMD+=" TARGET_ARCH=${{ inputs.arch }}"
         
         echo "Executing: $CMD"
         eval $CMD
@@ -86,7 +86,7 @@ runs:
         [[ -n "${{ inputs.smp }}" ]] && CMD+=" SMP=${{ inputs.smp }}"
         [[ -n "${{ inputs.netdev }}" ]] && CMD+=" NETDEV=${{ inputs.netdev }}"
         [[ -n "${{ inputs.scheme }}" ]] && CMD+=" SCHEME=${{ inputs.scheme }}"
-        [[ -n "${{ inputs.arch }}" ]] && CMD+=" OSDK_TARGET_ARCH=${{ inputs.arch }}"
+        [[ -n "${{ inputs.arch }}" ]] && CMD+=" TARGET_ARCH=${{ inputs.arch }}"
         [[ -n "${{ inputs.extra_blocklists }}" ]] && CMD+=" EXTRA_BLOCKLISTS=${{ inputs.extra_blocklists }}"
         [[ -n "${{ inputs.conformance_test_suite }}" ]] && CMD+=" CONFORMANCE_TEST_SUITE=${{ inputs.conformance_test_suite }}"
         [[ -n "${{ inputs.conformance_test_workdir }}" ]] && CMD+=" CONFORMANCE_TEST_WORKDIR=${{ inputs.conformance_test_workdir }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Key Makefile targets:
 | `make format`        | Auto-format Rust, Nix, and C code                    |
 | `make docs`          | Build rustdocs for all crates                        |
 
-Set `OSDK_TARGET_ARCH` to `x86_64` (default), `riscv64`, or `loongarch64`.
+Set `TARGET_ARCH` to `x86_64` (default), `riscv64`, or `loongarch64`.
 
 ## Toolchain
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # =========================== Makefile options. ===============================
 
 # Global build options.
-OSDK_TARGET_ARCH ?= x86_64
+TARGET_ARCH ?= x86_64
 BENCHMARK ?= none
 BOOT_METHOD ?= grub-rescue-iso
 BOOT_PROTOCOL ?= multiboot2
@@ -88,12 +88,14 @@ DEV_TRUSTED_PUBLIC_KEY ?= aster-nixos-dev.cachix.org-1:xrCbE2flfliFTQCY/2HeJoT2t
 
 # ========================= End of Makefile options. ==========================
 
+export OSDK_TARGET_ARCH=$(TARGET_ARCH)
+
 SHELL := /bin/bash
 
 CARGO_OSDK := ~/.cargo/bin/cargo-osdk
 
 # Common arguments for `cargo osdk` `build`, `run` and `test` commands.
-CARGO_OSDK_COMMON_ARGS := --target-arch=$(OSDK_TARGET_ARCH)
+CARGO_OSDK_COMMON_ARGS :=
 # The build arguments also apply to the `cargo osdk run` command.
 CARGO_OSDK_BUILD_ARGS := --kcmd-args="ostd.log_level=$(LOG_LEVEL)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="console=$(CONSOLE)"
@@ -122,7 +124,7 @@ CARGO_OSDK_COMMON_ARGS += --profile release-lto
 OSTD_TASK_STACK_SIZE_IN_PAGES = 8
 else ifeq ($(RELEASE), 1)
 CARGO_OSDK_COMMON_ARGS += --release
-	ifeq ($(OSDK_TARGET_ARCH), riscv64)
+	ifeq ($(TARGET_ARCH), riscv64)
 	# FIXME: Unwinding in RISC-V seems to cost more stack space, so we increase
 	# the stack size for it. This may need further investigation.
 	# See https://github.com/asterinas/asterinas/pull/2383#discussion_r2307673156
@@ -151,9 +153,9 @@ BOOT_METHOD = qemu-direct
 endif
 
 ifeq ($(SCHEME), "")
-	ifeq ($(OSDK_TARGET_ARCH), riscv64)
+	ifeq ($(TARGET_ARCH), riscv64)
 	SCHEME = riscv
-	else ifeq ($(OSDK_TARGET_ARCH), loongarch64)
+	else ifeq ($(TARGET_ARCH), loongarch64)
 	SCHEME = loongarch
 	endif
 endif
@@ -188,7 +190,7 @@ CARGO_OSDK_COMMON_ARGS += --grub-boot-protocol=$(BOOT_PROTOCOL)
 endif
 
 ifeq ($(ENABLE_KVM), 1)
-	ifeq ($(OSDK_TARGET_ARCH), x86_64)
+	ifeq ($(TARGET_ARCH), x86_64)
 	CARGO_OSDK_COMMON_ARGS += --qemu-args="-accel kvm"
 	endif
 endif
@@ -381,7 +383,7 @@ docs: $(CARGO_OSDK)
 	@# Include --document-private-items to fully check internal documentation.
 	@RUSTDOCFLAGS="-Dwarnings --document-private-items -Arustdoc::private_intra_doc_links" \
 		cargo osdk doc -p aster-kernel --no-deps
-	@if [ "$(OSDK_TARGET_ARCH)" = "x86_64" ]; then \
+	@if [ "$(TARGET_ARCH)" = "x86_64" ]; then \
 		cd ostd/libs/linux-bzimage/setup && RUSTDOCFLAGS="-Dwarnings" cargo osdk doc --no-deps; \
 	fi
 
@@ -415,7 +417,7 @@ check: $(CARGO_OSDK)
 	done
 	@
 	@# Check compilation of the Rust code
-	@OSDK_TARGET_ARCH="$(OSDK_TARGET_ARCH)" ./tools/clippy_check.sh workspace
+	@./tools/clippy_check.sh workspace
 	@
 	@# Check formatting issues of the C code and Nix files (regression tests)
 	@$(MAKE) --no-print-directory -C test/initramfs check

--- a/distro/aster_nixos_installer/default.nix
+++ b/distro/aster_nixos_installer/default.nix
@@ -1,6 +1,7 @@
 { disable-systemd ? "false", stage-2-hook ? "/bin/sh -l", log-level ? "error"
 , console ? "hvc0", extra-substituters ? "", extra-trusted-public-keys ? ""
-, config-file-name ? "configuration.nix", pkgs ? import <nixpkgs> { } }:
+, config-file-name ? "configuration.nix", target_platform ? "x86_64-linux"
+, pkgs ? import <nixpkgs> { } }:
 let
   aster-kernel = builtins.path {
     name = "aster-kernel-osdk-bin";
@@ -16,6 +17,7 @@ let
       aster-stage-2-hook = stage-2-hook;
       aster-log-level = log-level;
       aster-console = console;
+      aster-target-platform = target_platform;
       aster-substituters = extra-substituters;
       aster-trusted-public-keys = extra-trusted-public-keys;
     };
@@ -25,6 +27,7 @@ let
     replacements = {
       aster-configuration = aster_configuration;
       aster-etc-nixos = etc-nixos;
+      aster-target-platform = target_platform;
       aster-substituters = extra-substituters;
       aster-trusted-public-keys = extra-trusted-public-keys;
     };

--- a/distro/aster_nixos_installer/templates/aster_configuration.nix
+++ b/distro/aster_nixos_installer/templates/aster_configuration.nix
@@ -1,6 +1,9 @@
 # The system-wide settings for AsterNixOS.
 
 { config, lib, pkgs, ... }: {
+  # Keep NixOS host platform aligned with the selected target architecture.
+  config.nixpkgs.hostPlatform = lib.mkDefault "@aster-target-platform@";
+
   # Imports all Nix files located under the 'modules' directory.
   #
   # Each Nix file within the 'modules' directory contributes a specific part to the overall 'configuration.nix'.

--- a/distro/aster_nixos_installer/templates/install_nixos.sh
+++ b/distro/aster_nixos_installer/templates/install_nixos.sh
@@ -136,6 +136,8 @@ COMMON_NIX_ARGS=(
     --option extra-trusted-public-keys "@aster-trusted-public-keys@"
 )
 
+NIX_SYSTEM="@aster-target-platform@"
+
 # Pre-build the NixOS system closure on the host
 # so that the result is cached in the host's Nix store.
 # Without this, nixos-install would build the system inside the (possibly empty) target image,
@@ -143,6 +145,8 @@ COMMON_NIX_ARGS=(
 #
 # See: https://www.mankier.com/8/nixos-install#--system
 SYSTEM_CLOSURE=$(nix-build '<nixpkgs/nixos>' -A system \
+    --option extra-platforms "${NIX_SYSTEM}" \
+    --argstr system "${NIX_SYSTEM}" \
     -I "nixos-config=${BUILD_DIR}/etc/nixos/configuration.nix" \
     "${COMMON_NIX_ARGS[@]}" \
     --no-out-link)

--- a/distro/iso_image/default.nix
+++ b/distro/iso_image/default.nix
@@ -1,9 +1,10 @@
 { pkgs ? import <nixpkgs> { }, autoInstall ? false, extra-substituters ? ""
 , config-file-name ? "configuration.nix", extra-trusted-public-keys ? ""
-, version ? "", ... }:
+, target_platform ? "x86_64-linux", version ? "", ... }:
 let
   installer = pkgs.callPackage ../aster_nixos_installer {
-    inherit extra-substituters extra-trusted-public-keys config-file-name;
+    inherit extra-substituters extra-trusted-public-keys config-file-name
+      target_platform;
   };
   configuration = {
     imports = [

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
-OSDK_TARGET_ARCH ?= x86_64
+TARGET_ARCH ?= x86_64
 SMP ?= 1
 VERBOSE ?= 1
 ENABLE_CONFORMANCE_TEST ?= false
@@ -46,7 +46,7 @@ endif
 all: build
 
 .PHONY: build
-ifeq ($(OSDK_TARGET_ARCH), loongarch64)
+ifeq ($(TARGET_ARCH), loongarch64)
 build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
@@ -58,7 +58,7 @@ endif
 $(INITRAMFS_IMAGE): $(INITRAMFS)
 	@nix-build \
 		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(OSDK_TARGET_ARCH) \
+		--argstr target $(TARGET_ARCH) \
 		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
 		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
@@ -75,7 +75,7 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 $(INITRAMFS):
 	@nix-build \
 		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(OSDK_TARGET_ARCH) \
+		--argstr target $(TARGET_ARCH) \
 		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
 		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \

--- a/test/initramfs/README.md
+++ b/test/initramfs/README.md
@@ -63,9 +63,9 @@ entry format.
 The test suite supports building for multiple architectures, including `x86_64` and `riscv64`. You can specify the desired architecture by running:
 
 ```bash
-make kernel OSDK_TARGET_ARCH=x86_64
+make kernel TARGET_ARCH=x86_64
 # or
-make kernel OSDK_TARGET_ARCH=riscv64
+make kernel TARGET_ARCH=riscv64
 ```
 
 The build artifacts (initramfs) can be found in the `test/initramfs/build` directory after the compilation.

--- a/tools/nixos/build_iso.sh
+++ b/tools/nixos/build_iso.sh
@@ -4,17 +4,22 @@
 
 set -e
 
+TARGET_ARCH=${TARGET_ARCH:-x86_64}
+# Accept config file name as parameter, default to "configuration.nix"
+CONFIG_FILE_NAME=${1:-"configuration.nix"}
+
 SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ASTERINAS_DIR=$(realpath ${SCRIPT_DIR}/../..)
 DISTRO_DIR=$(realpath ${ASTERINAS_DIR}/distro)
 TARGET_DIR=${ASTERINAS_DIR}/target/nixos
 VERSION=$(cat ${ASTERINAS_DIR}/VERSION)
-# Accept config file name as parameter, default to "configuration.nix"
-CONFIG_FILE_NAME=${1:-"configuration.nix"}
+
+NIX_SYSTEM=$("${SCRIPT_DIR}/print_target_nix_system.sh" "${TARGET_ARCH}") || exit 1
 
 mkdir -p ${TARGET_DIR}
 
 nix-build ${DISTRO_DIR}/iso_image \
+    --argstr target_platform "${NIX_SYSTEM}" \
     --arg autoInstall ${AUTO_INSTALL} \
     --argstr config-file-name "${CONFIG_FILE_NAME}" \
     --argstr extra-substituters "${RELEASE_SUBSTITUTER} ${DEV_SUBSTITUTER}" \

--- a/tools/nixos/build_nixos.sh
+++ b/tools/nixos/build_nixos.sh
@@ -4,16 +4,21 @@
 
 set -e
 
+TARGET_ARCH=${TARGET_ARCH:-x86_64}
+# Accept config file name as parameter, default to "configuration.nix"
+CONFIG_FILE_NAME=${1:-"configuration.nix"}
+
 SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ASTERINAS_DIR=$(realpath ${SCRIPT_DIR}/../..)
 ASTER_IMAGE_PATH=${ASTERINAS_DIR}/target/nixos/asterinas.img
 DISTRO_DIR=$(realpath ${ASTERINAS_DIR}/distro)
-# Accept config file name as parameter, default to "configuration.nix"
-CONFIG_FILE_NAME=${1:-"configuration.nix"}
 CONFIG_PATH=${DISTRO_DIR}/etc_nixos/${CONFIG_FILE_NAME}
+
+NIX_SYSTEM=$("${SCRIPT_DIR}/print_target_nix_system.sh" "${TARGET_ARCH}") || exit 1
 
 pushd $DISTRO_DIR
 nix-build aster_nixos_installer/default.nix \
+    --argstr target_platform "${NIX_SYSTEM}" \
     --argstr disable-systemd "${NIXOS_DISABLE_SYSTEMD}" \
     --argstr stage-2-hook "${NIXOS_STAGE_2_INIT}" \
     --argstr log-level "${LOG_LEVEL}" \

--- a/tools/nixos/print_target_nix_system.sh
+++ b/tools/nixos/print_target_nix_system.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+TARGET_ARCH=${1:-${TARGET_ARCH:-x86_64}}
+
+case "${TARGET_ARCH}" in
+    x86_64)
+        echo "x86_64-linux"
+        ;;
+    aarch64)
+        echo "aarch64-linux"
+        ;;
+    riscv64)
+        echo "riscv64-linux"
+        ;;
+    loongarch64)
+        echo "loongarch64-linux"
+        ;;
+    *)
+        echo "Error: unsupported TARGET_ARCH=${TARGET_ARCH}" >&2
+        exit 1
+        ;;
+esac

--- a/tools/nixos/run.sh
+++ b/tools/nixos/run.sh
@@ -18,22 +18,28 @@ if [ "$#" -ne 1 ]; then
 fi
 
 MODE=$1
+TARGET_ARCH=${TARGET_ARCH:-x86_64}
 SCRIPT_DIR=$(dirname "$0")
 ASTERINAS_DIR=$(realpath "${SCRIPT_DIR}/../..")
+
+# tools/qemu_args.sh currently emits x86_64-specific arguments.
+# Reject other architectures to avoid invoking non-x86 QEMU with incompatible args.
+if [ "${TARGET_ARCH}" != "x86_64" ]; then
+    echo "Error: tools/nixos/run.sh currently supports only TARGET_ARCH=x86_64; got ${TARGET_ARCH}" >&2
+    exit 1
+fi
 
 # Change to Asterinas root directory to ensure all scripts run from the correct location.
 cd "${ASTERINAS_DIR}"
 
-# Base QEMU arguments
-BASE_QEMU_ARGS="qemu-system-x86_64 \
-    -bios /root/ovmf/release/OVMF.fd \
-"
+# Get base QEMU arguments from qemu_args.sh script
+QEMU_ARGS=$(${ASTERINAS_DIR}/tools/qemu_args.sh common 2>/dev/null)
 
-# Mode-specific QEMU arguments
+# Add mode-specific disk and device arguments
 case "$MODE" in
     nixos)
         NIXOS_DIR="${ASTERINAS_DIR}/target/nixos"
-        QEMU_ARGS="${BASE_QEMU_ARGS} \
+        QEMU_ARGS="${QEMU_ARGS} \
             -drive if=none,format=raw,id=u0,file=${NIXOS_DIR}/asterinas.img \
             -device virtio-blk-pci,drive=u0,disable-legacy=on,disable-modern=off \
         "
@@ -53,7 +59,7 @@ case "$MODE" in
         dd if=/dev/zero of="${ASTER_IMAGE_PATH}" bs=1M count=${NIXOS_DISK_SIZE_IN_MB} status=none
         echo "Image created successfully!"
 
-        QEMU_ARGS="${BASE_QEMU_ARGS} \
+        QEMU_ARGS="${QEMU_ARGS} \
             -cdrom ${ISO_IMAGE_PATH} -boot d \
             -drive if=none,format=raw,id=u0,file=${ASTER_IMAGE_PATH} \
             -device virtio-blk-pci,drive=u0,disable-legacy=on,disable-modern=off \
@@ -68,11 +74,7 @@ if [ "${ENABLE_KVM}" = "1" ]; then
     QEMU_ARGS="${QEMU_ARGS} -accel kvm"
 fi
 
-COMMON_QEMU_ARGS=$(${ASTERINAS_DIR}/tools/qemu_args.sh common 2>/dev/null)
-QEMU_ARGS="
-    ${QEMU_ARGS} \
-    ${COMMON_QEMU_ARGS} \
-"
+QEMU_BIN=${QEMU_BIN:-qemu-system-${TARGET_ARCH}}
 
 # The kernel uses a specific value to signal a successful shutdown via the
 # isa-debug-exit device.
@@ -83,7 +85,7 @@ QEMU_SUCCESS_EXIT_CODE=$(((KERNEL_SUCCESS_EXIT_CODE << 1) | 1))
 
 # Execute QEMU
 # shellcheck disable=SC2086
-${QEMU_ARGS} || exit_code=$?
+${QEMU_BIN} ${QEMU_ARGS} || exit_code=$?
 exit_code=${exit_code:-0}
 
 # Check if the execution was successful:


### PR DESCRIPTION
fix #3138

The first commits reverts `OSDK_TARGET_ARCH` to `TARGET_ARCH`, since there's an OSDK argument `--target` for this purpose. Duplicating the functionality with another environment variable is weird. Letting other scripts unrelated with OSDK use this variable is also weird because of the `OSDK_` prefix.

The second commit enforces building `TARGET_ARCH` NixOS image, not the host-native image. The root cause of #3138 is failing to boot Arm64 NixOS on x86 VM.