### PR TITLE
Only calls `on_first_process_startup` when the first user thread starts

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -2,7 +2,7 @@
 
 use core::sync::atomic::Ordering;
 
-use super::{Pid, Process, pid_table};
+use super::{INIT_PROCESS_PID, Pid, Process, pid_table};
 use crate::{
     events::IoEvents, fs::cgroupfs::CgroupMembership, prelude::*,
     process::signal::signals::kernel::KernelSignal,
@@ -61,8 +61,6 @@ fn move_children_to_reaper_process(current_process: &Process) -> BTreeMap<Pid, A
             return children;
         }
     }
-
-    const INIT_PROCESS_PID: Pid = 1;
 
     let init_process = pid_table::pid_table_mut()
         .get_process(INIT_PROCESS_PID)

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -34,8 +34,8 @@ pub use namespace::{
 };
 pub use pid_file::PidFile;
 pub use process::{
-    ExitCode, JobControl, Pgid, Pid, Process, ProcessGroup, ReapedChildrenStats, Session, Sid,
-    Terminal, broadcast_signal_async, enqueue_signal_async, spawn_init_process,
+    ExitCode, INIT_PROCESS_PID, JobControl, Pgid, Pid, Process, ProcessGroup, ReapedChildrenStats,
+    Session, Sid, Terminal, broadcast_signal_async, enqueue_signal_async, spawn_init_process,
 };
 pub use process_filter::ProcessFilter;
 pub use process_vm::{INIT_STACK_SIZE, LockedHeap, ProcessVm, VmarSnapshot};

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -365,7 +365,9 @@ impl ContextPthreadAdminApi for Context<'_> {
     }
 }
 
-static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(1);
+pub const FIRST_POSIX_TID: Tid = 1;
+
+static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(FIRST_POSIX_TID);
 
 /// Allocates a new tid for the new posix thread
 pub fn allocate_posix_tid() -> Tid {

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -8,7 +8,7 @@ use core::{
 use self::timer_manager::PosixTimerManager;
 use super::{
     pid_table::{self, PidTable},
-    posix_thread::AsPosixThread,
+    posix_thread::{AsPosixThread, FIRST_POSIX_TID},
     process_vm::ProcessVmarGuard,
     rlimit::ResourceLimits,
     signal::{
@@ -54,6 +54,8 @@ pub use terminal::Terminal;
 
 /// Process ID.
 pub type Pid = u32;
+
+pub const INIT_PROCESS_PID: Pid = FIRST_POSIX_TID;
 
 define_atomic_version_of_integer_like_type!(Pid, {
     #[derive(Debug)]

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -14,7 +14,7 @@ use crate::{
     current_userspace,
     prelude::*,
     process::{
-        posix_thread::{AsPosixThread, AsThreadLocal, ThreadLocal},
+        posix_thread::{AsPosixThread, AsThreadLocal, FIRST_POSIX_TID, ThreadLocal},
         signal::{HandlePendingSignal, PauseReason, handle_pending_signal},
     },
     syscall::handle_syscall,
@@ -72,7 +72,7 @@ pub fn create_new_user_task(
         let has_kernel_event_fn = || ctx.has_pending();
 
         // The startup method is only executed when the first user thread starts up.
-        if ctx.posix_thread.tid() == 1 {
+        if ctx.posix_thread.tid() == FIRST_POSIX_TID {
             crate::init::on_first_process_startup(&ctx);
         }
 

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -71,7 +71,8 @@ pub fn create_new_user_task(
 
         let has_kernel_event_fn = || ctx.has_pending();
 
-        if ctx.process.is_init_process() {
+        // The startup method is only executed when the first user thread starts up.
+        if ctx.posix_thread.tid() == 1 {
             crate::init::on_first_process_startup(&ctx);
         }
 


### PR DESCRIPTION
Currently, the execution of `on_first_process_startup` depends on whether the current process is the init process. However, this condition is incorrect — if the init process spawns multiple threads, the startup routine would be executed multiple times. The condition should instead check whether the current thread ID is 1, ensuring that the startup routine is only executed when the very first thread starts up.