### PR TITLE
Fix short TCP stream reads across wrapped receive buffer segments

### DIFF
--- a/kernel/libs/aster-bigtcp/src/errors.rs
+++ b/kernel/libs/aster-bigtcp/src/errors.rs
@@ -10,6 +10,22 @@ pub enum BindError {
 }
 
 pub mod tcp {
+    /// An error returned by a TCP stream I/O operation before any byte is transferred.
+    ///
+    /// If some bytes are transferred before a socket or copy error is observed, the
+    /// operation succeeds with the transferred byte count instead.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum IoError<SocketError, CopyError> {
+        /// The operation made no progress.
+        ///
+        /// This usually means the send buffer is full or the receive buffer is empty.
+        NoProgress,
+        /// The underlying TCP socket failed the operation.
+        Socket(SocketError),
+        /// The caller-provided copy function failed.
+        Copy(CopyError),
+    }
+
     /// An error returned by [`TcpListener::new_listen`].
     ///
     /// [`TcpListener::new_listen`]: crate::socket::TcpListener::new_listen
@@ -68,6 +84,12 @@ pub mod tcp {
         }
     }
 
+    impl<CopyError> From<smoltcp::socket::tcp::SendError> for IoError<SendError, CopyError> {
+        fn from(value: smoltcp::socket::tcp::SendError) -> Self {
+            Self::Socket(value.into())
+        }
+    }
+
     /// An error returned by [`TcpConnection::recv`].
     ///
     /// [`TcpConnection::recv`]: crate::socket::TcpConnection::recv
@@ -85,6 +107,12 @@ pub mod tcp {
                 smoltcp::socket::tcp::RecvError::InvalidState => Self::InvalidState,
                 smoltcp::socket::tcp::RecvError::Finished => Self::Finished,
             }
+        }
+    }
+
+    impl<CopyError> From<smoltcp::socket::tcp::RecvError> for IoError<RecvError, CopyError> {
+        fn from(value: smoltcp::socket::tcp::RecvError) -> Self {
+            Self::Socket(value.into())
         }
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -4,7 +4,10 @@ use alloc::{
     boxed::Box,
     sync::{Arc, Weak},
 };
-use core::ops::{Deref, DerefMut};
+use core::{
+    num::NonZeroUsize,
+    ops::{Deref, DerefMut},
+};
 
 use aster_softirq::BottomHalfDisabled;
 use ostd::sync::{SpinLock, SpinLockGuard};
@@ -20,7 +23,7 @@ use super::{
 };
 use crate::{
     define_boolean_value,
-    errors::tcp::{ConnectError, RecvError, SendError},
+    errors::tcp::{ConnectError, IoError, RecvError, SendError},
     ext::Ext,
     iface::{BoundPort, PollKey, PollableIfaceMut},
     socket::{
@@ -370,9 +373,12 @@ impl<E: Ext> TcpConnection<E> {
     /// Sends some data.
     ///
     /// Polling the iface _may_ be required after this method succeeds.
-    pub fn send<F, R>(&self, f: F) -> Result<(R, NeedIfacePoll), SendError>
+    pub fn send<F, CopyErr>(
+        &self,
+        mut f: F,
+    ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<SendError, CopyErr>>
     where
-        F: FnOnce(&mut [u8]) -> (usize, R),
+        F: FnMut(&mut [u8]) -> Result<usize, (CopyErr, usize)>,
     {
         let common = self.iface().common();
         let mut iface = common.interface();
@@ -381,10 +387,56 @@ impl<E: Ext> TcpConnection<E> {
 
         if socket.is_rst_closed {
             socket.is_rst_closed = false;
-            return Err(SendError::ConnReset);
+            return Err(IoError::Socket(SendError::ConnReset));
         }
-        let result = socket.send(f)?;
 
+        let mut total_sent_bytes = 0;
+        let mut need_wrap_continuation = true;
+
+        let result = loop {
+            let mut sent_bytes = 0;
+            let mut socket_buffer_len = 0;
+
+            // `socket.send` exposes the largest contiguous writable range. If the free space in
+            // the transmit ring buffer wraps, one logical stream write may span two such ranges,
+            // so continue at most once while holding the same socket lock to avoid an avoidable
+            // short write.
+            let send_result = socket.send(|socket_buffer| {
+                socket_buffer_len = socket_buffer.len();
+                match f(socket_buffer) {
+                    Ok(current_sent_bytes) => {
+                        sent_bytes = current_sent_bytes;
+                        (current_sent_bytes, Ok(()))
+                    }
+                    Err((err, current_sent_bytes)) => {
+                        sent_bytes = current_sent_bytes;
+                        (current_sent_bytes, Err(err))
+                    }
+                }
+            });
+
+            let copy_result = match send_result {
+                Err(_) if total_sent_bytes > 0 => break total_sent_bytes,
+                res => res?,
+            };
+
+            total_sent_bytes += sent_bytes;
+
+            if let Err(err) = copy_result {
+                if total_sent_bytes == 0 {
+                    return Err(IoError::Copy(err));
+                }
+                break total_sent_bytes;
+            }
+
+            if sent_bytes < socket_buffer_len || !need_wrap_continuation {
+                break total_sent_bytes;
+            }
+
+            need_wrap_continuation = false;
+        };
+
+        let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;
         let poll_at = socket.poll_at(iface.context_mut());
         let need_poll = iface.update_next_poll_at_ms(&self.0, poll_at);
 
@@ -394,9 +446,12 @@ impl<E: Ext> TcpConnection<E> {
     /// Receives some data.
     ///
     /// Polling the iface _may_ be required after this method succeeds.
-    pub fn recv<F, R>(&self, f: F) -> Result<(R, NeedIfacePoll), RecvError>
+    pub fn recv<F, CopyErr>(
+        &self,
+        mut f: F,
+    ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<RecvError, CopyErr>>
     where
-        F: FnOnce(&mut [u8]) -> (usize, R),
+        F: FnMut(&mut [u8]) -> Result<usize, (CopyErr, usize)>,
     {
         let common = self.iface().common();
         let mut iface = common.interface();
@@ -404,16 +459,59 @@ impl<E: Ext> TcpConnection<E> {
         let mut socket = self.0.inner.lock();
 
         if socket.is_recv_shut && socket.recv_queue() == 0 {
-            return Err(RecvError::Finished);
+            return Err(IoError::Socket(RecvError::Finished));
         }
-        let result = match socket.recv(f) {
-            Err(_) if socket.is_rst_closed => {
-                socket.is_rst_closed = false;
-                return Err(RecvError::ConnReset);
-            }
-            res => res,
-        }?;
 
+        let mut total_recv_bytes = 0;
+        let mut need_wrap_continuation = true;
+
+        let result = loop {
+            let mut recv_bytes = 0;
+            let mut socket_buffer_len = 0;
+
+            // `socket.recv` exposes the largest contiguous readable range. If the receive ring
+            // buffer wraps, one logical stream read may span two such ranges, so continue at most
+            // once while holding the same socket lock to avoid an avoidable short read.
+            let recv_result = socket.recv(|socket_buffer| {
+                socket_buffer_len = socket_buffer.len();
+                match f(socket_buffer) {
+                    Ok(current_recv_bytes) => {
+                        recv_bytes = current_recv_bytes;
+                        (current_recv_bytes, Ok(()))
+                    }
+                    Err((err, current_recv_bytes)) => {
+                        recv_bytes = current_recv_bytes;
+                        (current_recv_bytes, Err(err))
+                    }
+                }
+            });
+
+            let copy_result = match recv_result {
+                Err(_) if socket.is_rst_closed && total_recv_bytes == 0 => {
+                    socket.is_rst_closed = false;
+                    return Err(IoError::Socket(RecvError::ConnReset));
+                }
+                Err(_) if total_recv_bytes > 0 => break total_recv_bytes,
+                res => res?,
+            };
+
+            total_recv_bytes += recv_bytes;
+
+            if let Err(err) = copy_result {
+                if total_recv_bytes == 0 {
+                    return Err(IoError::Copy(err));
+                }
+                break total_recv_bytes;
+            }
+
+            if recv_bytes < socket_buffer_len || !need_wrap_continuation {
+                break total_recv_bytes;
+            }
+
+            need_wrap_continuation = false;
+        };
+
+        let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;
         let poll_at = socket.poll_at(iface.context_mut());
         let need_poll = iface.update_next_poll_at_ms(&self.0, poll_at);
 

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -58,7 +58,9 @@ impl datagram_common::Bound for BoundDatagram {
         _flags: SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
         let result = self.bound_socket.recv(|packet, udp_metadata| {
-            let copied_res = writer.write(&mut VmReader::from(packet));
+            let copied_res = writer
+                .write(&mut VmReader::from(packet))
+                .map_err(Into::into);
             let endpoint = udp_metadata.endpoint;
             (copied_res, endpoint)
         });
@@ -91,6 +93,7 @@ impl datagram_common::Bound for BoundDatagram {
                     .inspect_err(|e| {
                         warn!("unexpected UDP packet {e:#?} will be sent");
                     })
+                    .map_err(Into::into)
             });
 
         match result {

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_bigtcp::{
-    errors::tcp::{RecvError, SendError},
+    errors::tcp::{IoError, RecvError, SendError},
     socket::{NeedIfacePoll, RawTcpSetOption},
     wire::IpEndpoint,
 };
@@ -74,29 +74,22 @@ impl ConnectedStream {
         writer: &mut dyn MultiWrite,
         _flags: SendRecvFlags,
     ) -> Result<(usize, NeedIfacePoll)> {
-        let result = self.tcp_conn.recv(|socket_buffer| {
-            match writer.write(&mut VmReader::from(&*socket_buffer)) {
-                Ok(len) => (len, Ok(len)),
-                Err(e) => (0, Err(e)),
-            }
-        });
+        let result = self
+            .tcp_conn
+            .recv(|socket_buffer| writer.write(&mut VmReader::from(&*socket_buffer)));
 
         match result {
-            Ok((Ok(0), need_poll)) => {
-                debug_assert!(!*need_poll);
+            Ok((recv_bytes, need_poll)) => Ok((recv_bytes.get(), need_poll)),
+            Err(IoError::NoProgress) => {
                 return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
             }
-            Ok((Ok(recv_bytes), need_poll)) => Ok((recv_bytes, need_poll)),
-            Ok((Err(e), need_poll)) => {
-                debug_assert!(!*need_poll);
-                Err(e)
-            }
-            Err(RecvError::Finished) | Err(RecvError::InvalidState) => {
+            Err(IoError::Copy(e)) => Err(e.into()),
+            Err(IoError::Socket(RecvError::Finished | RecvError::InvalidState)) => {
                 // `InvalidState` occurs when the connection is reset but `ECONNRESET` was reported
                 // earlier. Linux returns EOF in this case, so we follow it.
                 Ok((0, NeedIfacePoll::FALSE))
             }
-            Err(RecvError::ConnReset) => {
+            Err(IoError::Socket(RecvError::ConnReset)) => {
                 return_errno_with_message!(Errno::ECONNRESET, "the connection is reset")
             }
         }
@@ -107,27 +100,20 @@ impl ConnectedStream {
         reader: &mut dyn MultiRead,
         _flags: SendRecvFlags,
     ) -> Result<(usize, NeedIfacePoll)> {
-        let result = self.tcp_conn.send(|socket_buffer| {
-            match reader.read(&mut VmWriter::from(socket_buffer)) {
-                Ok(len) => (len, Ok(len)),
-                Err(e) => (0, Err(e)),
-            }
-        });
+        let result = self
+            .tcp_conn
+            .send(|socket_buffer| reader.read(&mut VmWriter::from(socket_buffer)));
 
         match result {
-            Ok((Ok(0), need_poll)) => {
-                debug_assert!(!*need_poll);
+            Ok((sent_bytes, need_poll)) => Ok((sent_bytes.get(), need_poll)),
+            Err(IoError::NoProgress) => {
                 return_errno_with_message!(Errno::EAGAIN, "the send buffer is full")
             }
-            Ok((Ok(sent_bytes), need_poll)) => Ok((sent_bytes, need_poll)),
-            Ok((Err(e), need_poll)) => {
-                debug_assert!(!*need_poll);
-                Err(e)
-            }
-            Err(SendError::InvalidState) => {
+            Err(IoError::Copy(e)) => Err(e.into()),
+            Err(IoError::Socket(SendError::InvalidState)) => {
                 return_errno_with_message!(Errno::EPIPE, "the connection is closed");
             }
-            Err(SendError::ConnReset) => {
+            Err(IoError::Socket(SendError::ConnReset)) => {
                 return_errno_with_message!(Errno::ECONNRESET, "the connection is reset");
             }
         }

--- a/kernel/src/net/socket/vsock/transport/connection/send.rs
+++ b/kernel/src/net/socket/vsock/transport/connection/send.rs
@@ -111,7 +111,7 @@ impl Connection {
             let packet_mut = packet_opt.as_mut().unwrap();
             let bytes_written = packet_mut.copy_payload(|mut writer| {
                 writer.limit(remaining_bytes);
-                Ok(reader.read(&mut writer)?)
+                reader.read(&mut writer).map_err(|(err, _)| err)
             })?;
             remaining_bytes -= bytes_written;
         }

--- a/kernel/src/util/iovec.rs
+++ b/kernel/src/util/iovec.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::{Infallible, VmSpace};
+use ostd::{
+    Error as OstdError,
+    mm::{Infallible, VmSpace},
+};
 
 use crate::prelude::*;
 
@@ -179,9 +182,13 @@ pub trait MultiRead: ReadCString {
     ///
     /// # Errors
     ///
-    /// This method returns [`Errno::EFAULT`] if a page fault occurs.
-    /// The position of `self` and the `writer` is left unspecified when this method returns error.
-    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize>;
+    /// This method returns [`OstdError::PageFault`] if a page fault occurs, along with
+    /// the number of bytes copied before the error occurs. When an error is returned,
+    /// both `self` and `writer` are advanced by the returned byte count.
+    fn read(
+        &mut self,
+        writer: &mut VmWriter<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)>;
 
     /// Calculates the total length of data remaining to read.
     fn sum_lens(&self) -> usize;
@@ -206,9 +213,13 @@ pub trait MultiWrite {
     ///
     /// # Errors
     ///
-    /// This method returns [`Errno::EFAULT`] if a page fault occurs.
-    /// The position of `self` and the `reader` is left unspecified when this method returns error.
-    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize>;
+    /// This method returns [`OstdError::PageFault`] if a page fault occurs, along with
+    /// the number of bytes copied before the error occurs. When an error is returned,
+    /// both `self` and `reader` are advanced by the returned byte count.
+    fn write(
+        &mut self,
+        reader: &mut VmReader<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)>;
 
     /// Calculates the length of space available to write.
     fn sum_lens(&self) -> usize;
@@ -224,11 +235,16 @@ pub trait MultiWrite {
 }
 
 impl MultiRead for VmReaderArray<'_> {
-    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize> {
+    fn read(
+        &mut self,
+        writer: &mut VmWriter<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)> {
         let mut total_len = 0;
 
         for reader in &mut self.0 {
-            let copied_len = reader.read_fallible(writer)?;
+            let copied_len = reader
+                .read_fallible(writer)
+                .map_err(|(err, copied_len)| (err, total_len + copied_len))?;
             total_len += copied_len;
             if !writer.has_avail() {
                 break;
@@ -255,8 +271,11 @@ impl MultiRead for VmReaderArray<'_> {
 }
 
 impl MultiRead for VmReader<'_> {
-    fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> Result<usize> {
-        Ok(self.read_fallible(writer)?)
+    fn read(
+        &mut self,
+        writer: &mut VmWriter<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)> {
+        self.read_fallible(writer)
     }
 
     fn sum_lens(&self) -> usize {
@@ -283,11 +302,16 @@ impl dyn MultiRead + '_ {
 }
 
 impl MultiWrite for VmWriterArray<'_> {
-    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize> {
+    fn write(
+        &mut self,
+        reader: &mut VmReader<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)> {
         let mut total_len = 0;
 
         for writer in &mut self.0 {
-            let copied_len = writer.write_fallible(reader)?;
+            let copied_len = writer
+                .write_fallible(reader)
+                .map_err(|(err, copied_len)| (err, total_len + copied_len))?;
             total_len += copied_len;
             if !reader.has_remain() {
                 break;
@@ -314,8 +338,11 @@ impl MultiWrite for VmWriterArray<'_> {
 }
 
 impl MultiWrite for VmWriter<'_> {
-    fn write(&mut self, reader: &mut VmReader<'_, Infallible>) -> Result<usize> {
-        Ok(self.write_fallible(reader)?)
+    fn write(
+        &mut self,
+        reader: &mut VmReader<'_, Infallible>,
+    ) -> core::result::Result<usize, (OstdError, usize)> {
+        self.write_fallible(reader)
     }
 
     fn sum_lens(&self) -> usize {

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -26,6 +26,7 @@ sleep 0.2
 ./tcp_err
 ./tcp_poll
 ./tcp_reuseaddr
+./tcp_wrapped_buffer_io
 ./udp_broadcast
 ./udp_err
 ./unix_datagram_err

--- a/test/initramfs/src/regression/network/tcp_err.c
+++ b/test/initramfs/src/regression/network/tcp_err.c
@@ -493,7 +493,37 @@ FN_TEST(sendmsg_and_recvmsg)
 	iov[1].iov_len = 1;
 	msg.msg_iov = iov;
 	msg.msg_iovlen = 2;
+
+	char recv_buffer[4096] = { 0 };
+	/*
+	 * FIXME: Linux TCP reports `EFAULT` if a copy fault occurs before
+	 * completing the first SKB touched by the call. Later faults may return
+	 * a short count at SKB granularity. Asterinas has no SKBs, so it reports
+	 * byte-granular progress instead.
+	 *
+	 * Reference:
+	 * <https://elixir.bootlin.com/linux/v7.0/source/net/ipv4/tcp.c#L1328-L1329>
+	 * <https://elixir.bootlin.com/linux/v7.0/source/net/ipv4/tcp.c#L1441-L1442>
+	 */
+#ifdef __asterinas__
+	/*
+	 * The good bytes are queued in the TCP stream and must be drained
+	 * before the next case.
+	 */
+	TEST_RES(sendmsg(sk_accepted, &msg, 0), _ret == strlen(good_buffer));
+
+	sleep(1);
+
+	iov[0].iov_base = recv_buffer;
+	iov[0].iov_len = sizeof(recv_buffer);
+	msg.msg_iovlen = 1;
+	TEST_RES(recvmsg(sk_connected, &msg, 0),
+		 _ret == strlen(good_buffer) &&
+			 memcmp(recv_buffer, good_buffer,
+				strlen(good_buffer)) == 0);
+#else
 	TEST_ERRNO(sendmsg(sk_accepted, &msg, 0), EFAULT);
+#endif
 
 	// TEST CASE 4: Receive via a partially bad receive buffer
 
@@ -506,7 +536,7 @@ FN_TEST(sendmsg_and_recvmsg)
 
 	sleep(1);
 
-	char recv_buffer[4096] = { 0 };
+	memset(recv_buffer, 0, sizeof(recv_buffer));
 	iov[0].iov_base = recv_buffer;
 	iov[0].iov_len = 1;
 	TEST_RES(recvmsg(sk_connected, &msg, 0), _ret == 1);
@@ -516,13 +546,36 @@ FN_TEST(sendmsg_and_recvmsg)
 	iov[1].iov_base = (char *)1;
 	iov[1].iov_len = 1;
 	msg.msg_iovlen = 2;
-	TEST_ERRNO(recvmsg(sk_connected, &msg, 0), EFAULT);
 
+	/* FIXME: Refer to the above FIXME regarding sending with a bad buffer. */
+#ifdef __asterinas__
+	/*
+	 * The bytes copied are consumed from the TCP stream, so only the
+	 * remaining bytes are left for the next receive.
+	 */
+	TEST_RES(recvmsg(sk_connected, &msg, 0),
+		 _ret == 1 && recv_buffer[0] == good_buffer[1]);
+
+	memset(recv_buffer, 0, sizeof(recv_buffer));
 	iov[0].iov_base = recv_buffer;
-	iov[0].iov_len = 4096;
+	iov[0].iov_len = sizeof(recv_buffer);
 	msg.msg_iovlen = 1;
 	TEST_RES(recvmsg(sk_connected, &msg, 0),
-		 _ret == strlen(good_buffer) - 1);
+		 _ret == strlen(good_buffer) - 2 &&
+			 memcmp(recv_buffer, good_buffer + 2,
+				strlen(good_buffer) - 2) == 0);
+#else
+	TEST_ERRNO(recvmsg(sk_connected, &msg, 0), EFAULT);
+
+	memset(recv_buffer, 0, sizeof(recv_buffer));
+	iov[0].iov_base = recv_buffer;
+	iov[0].iov_len = sizeof(recv_buffer);
+	msg.msg_iovlen = 1;
+	TEST_RES(recvmsg(sk_connected, &msg, 0),
+		 _ret == strlen(good_buffer) - 1 &&
+			 memcmp(recv_buffer, good_buffer + 1,
+				strlen(good_buffer) - 1) == 0);
+#endif
 
 	// TEST CASE 5: Send a large buffer
 

--- a/test/initramfs/src/regression/network/tcp_wrapped_buffer_io.c
+++ b/test/initramfs/src/regression/network/tcp_wrapped_buffer_io.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define LISTEN_PORT 9999
+#define LISTEN_BACKLOG 4
+#define RECEIVE_BUFFER_FILL_DRAIN_ROUNDS 16
+#define TCP_SETTLE_USEC 100000
+
+/*
+ * Tokio's PollEvented clears readiness after a positive short read on
+ * epoll/kqueue targets because such a read is treated as evidence that the
+ * socket buffer has been drained. If a TCP stream read stops at the tail
+ * fragment of a wrapped receive buffer while bytes remain after the wrap, a
+ * reactor can miss the remaining data and leave the task waiting.
+ *
+ * The same applies to a positive short write, which is not yet covered by
+ * this test.
+ *
+ * See:
+ * https://github.com/tokio-rs/tokio/blob/905c146aeda741ea2202f942a7c3a606dda13da5/tokio/src/io/poll_evented.rs#L182-L213
+ * https://github.com/tokio-rs/tokio/blob/905c146aeda741ea2202f942a7c3a606dda13da5/tokio/src/io/poll_evented.rs#L240-L267
+ *
+ * This test focuses on Asterinas's simple, ring-buffered TCP behavior. On
+ * Linux, there are many other complexities related to SKB management and
+ * receive window advertisement, so this test is likely to fail.
+ *
+ * See:
+ * https://github.com/asterinas/asterinas/pull/3146#issuecomment-4351171818
+ */
+FN_TEST(tcp_read_wrap_receive_buffer_tail)
+{
+	struct sockaddr_in listen_addr = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+		.sin_port = htons(LISTEN_PORT),
+	};
+	int listen_fd = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	int client_fd = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	int server_fd;
+	int tcp_recv_buf_len = 0;
+	socklen_t optlen = sizeof(tcp_recv_buf_len);
+	size_t one_third_buf_len;
+	size_t two_thirds_buf_len;
+	char *buf;
+
+	TEST_SUCC(bind(listen_fd, (struct sockaddr *)&listen_addr,
+		       sizeof(listen_addr)));
+	TEST_SUCC(listen(listen_fd, LISTEN_BACKLOG));
+	TEST_SUCC(connect(client_fd, (struct sockaddr *)&listen_addr,
+			  sizeof(listen_addr)));
+	server_fd = TEST_SUCC(accept(listen_fd, NULL, NULL));
+
+	TEST_RES(getsockopt(client_fd, SOL_SOCKET, SO_RCVBUF, &tcp_recv_buf_len,
+			    &optlen),
+		 _ret == 0 && tcp_recv_buf_len >= 3);
+	one_third_buf_len = tcp_recv_buf_len / 3;
+	two_thirds_buf_len = one_third_buf_len * 2;
+
+	buf = TEST_RES(malloc(two_thirds_buf_len), _ret != NULL);
+	memset(buf, 'a', two_thirds_buf_len);
+
+	TEST_RES(send(server_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)two_thirds_buf_len);
+	usleep(TCP_SETTLE_USEC);
+	TEST_RES(recv(client_fd, buf, one_third_buf_len, 0),
+		 _ret == (ssize_t)one_third_buf_len);
+	usleep(TCP_SETTLE_USEC);
+
+	for (int i = 0; i < RECEIVE_BUFFER_FILL_DRAIN_ROUNDS; i++) {
+		TEST_RES(send(server_fd, buf, two_thirds_buf_len, 0),
+			 _ret == (ssize_t)two_thirds_buf_len);
+		usleep(TCP_SETTLE_USEC);
+		TEST_RES(recv(client_fd, buf, two_thirds_buf_len, 0),
+			 _ret == (ssize_t)two_thirds_buf_len);
+		usleep(TCP_SETTLE_USEC);
+	}
+
+	TEST_RES(recv(client_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)one_third_buf_len);
+
+	free(buf);
+	TEST_SUCC(close(client_fd));
+	TEST_SUCC(close(server_fd));
+	TEST_SUCC(close(listen_fd));
+}
+END_TEST()


### PR DESCRIPTION
Currently, Asterinas returns a short TCP stream read when the TCP receive ring wrapped around, which is harmful in async edge-triggered code.  After seeing a short read, userspace may clear readiness and go back to waiting for the next event, even though unread TCP payload is still buffered in the socket. If no new packet arrives, the task can sleep indefinitely while data is already available. **This directly caused CoCo guest image pulling to stall on Asterinas.**

Conceptually, the unread data in a TCP stream is continuous:
```text
  ... A A A A B B B B ...
```
 But after the receive ring wraps, the same unread bytes may be stored like this:
```text
  [ B B B B . . . . . . . . . . . . . A A A A ]
          ^ tail of ring              ^ head of ring
```
In this situation, the first contiguous fragment visible from the current read pointer is only the tail fragment (`A A A A`), even though the stream still has more unread bytes after the wrap (`B B B B`).

I.e., a single `read()` could stop at that first contiguous fragment and return only the short tail piece. This is inconsistent with Linux stream socket behavior: a stream read should not expose the kernel receive ring's internal segmentation to userspace.

This PR tries to fix in `ConnectedStream::try_recv()` so that if the current contiguous fragment is fully consumed and the userspace buffer still has remaining space, the same syscall continues reading across the wrap boundary.