### PR TITLE
Add `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Asterinas Dev Container",
+  "image": "asterinas/asterinas:0.17.2-20260407",
+  // Mount the workspace and the `/dev` directory
+  "workspaceFolder": "/root/asterinas",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/root/asterinas,type=bind",
+  "mounts": ["source=/dev,target=/dev,type=bind"],
+  // Run with privileged mode and host networking
+  "privileged": true,
+  "runArgs": ["--network=host"],
+  // Enable extensions for Rust development
+  "customizations": {
+    "vscode": { "extensions": ["rust-lang.rust-analyzer"] }
+  }
+}

--- a/.github/workflows/test_devcontainer.yml
+++ b/.github/workflows/test_devcontainer.yml
@@ -1,0 +1,32 @@
+name: Test devcontainer
+
+on:
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+  push:
+    branches: [main]
+    paths:
+      - ".devcontainer/**"
+  workflow_run:
+    workflows: ["Publish Docker images"]
+    types:
+      - completed
+
+jobs:
+  test-devcontainer:
+    # DO NOT run when the "Publish Docker images" workflow failed.
+    if: ${{ github.event_name != 'workflow_run'
+      || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify image tag matches DOCKER_IMAGE_VERSION
+        run: |
+          EXPECTED=$(cat DOCKER_IMAGE_VERSION)
+          grep -q "asterinas/asterinas:${EXPECTED}" .devcontainer/devcontainer.json \
+            || { echo "devcontainer.json image doesn't match DOCKER_IMAGE_VERSION"; exit 1; }
+      - name: Build and verify dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: rustc --version && cargo --version && make --version

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Follow the steps below to get Asterinas up and running.
     docker run -it --privileged --network=host -v /dev:/dev -v $(pwd)/asterinas:/root/asterinas asterinas/asterinas:0.17.1-20260319
     ```
 
+    Alternatively, if you use VS Code with the
+    [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+    extension, open the cloned folder and select "Reopen in Container".
+
 3. Inside the container,
 go to the project folder (`/root/asterinas`) and run:
 

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -83,6 +83,10 @@ since `distro/README.md` references them -->
                 asterinas/asterinas:0.17.1-20260319
     ```
 
+    Alternatively, if you use VS Code with the
+    [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+    extension, open the cloned folder and select "Reopen in Container".
+
 3. Inside the container, go to the project folder to build and run Asterinas.
 
     ```bash

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -118,7 +118,8 @@ update_docker_image_version() {
 update_all_docker_version_refs() {
     new_version=$(cat ${DOCKER_IMAGE_VERSION_PATH})
 
-    # Update Docker image versions in README files and AGENTS.md
+    # Update Docker image versions in devcontainer.json, README files, and AGENTS.md
+    update_image_versions ${ASTER_SRC_DIR}/.devcontainer/devcontainer.json
     update_image_versions ${ASTER_SRC_DIR}/README.md
     update_image_versions ${ASTER_SRC_DIR}/AGENTS.md
     update_image_versions ${SCRIPT_DIR}/docker/README.md


### PR DESCRIPTION
‌‌This PR adds a `devcontainer.json` configuration to allow the editor to automatically activate the environment.
It reduces onboarding time for new contributors by providing a pre-configured workspace.