### PR TITLE
Add `tkill` syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -220,7 +220,7 @@ which are summarized in the table below.
 | 197     | removexattr            | ✅             | 💯 |
 | 198     | lremovexattr           | ✅             | 💯 |
 | 199     | fremovexattr           | ✅             | 💯 |
-| 200     | tkill                  | ❌             | N/A |
+| 200     | tkill                  | ✅             | 💯 |
 | 201     | time                   | ✅             | 💯 |
 | 202     | futex                  | ✅             | [⚠️](syscall-flag-coverage/inter-process-communication/#futex) |
 | 203     | sched_setaffinity      | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/signals-and-timers/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/signals-and-timers/fully_covered.scml
@@ -14,6 +14,9 @@ rt_sigreturn(arg);
 kill(pid, sig);
 
 // Send signal to a thread
+tkill(tid, sig);
+
+// Send signal to a thread within a process
 tgkill(tgid, tid, sig);
 
 // Send signal to the target process referred to by pidfd

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -75,21 +75,30 @@ pub fn kill_group<S: Signal + Clone>(pgid: Pgid, signal: Option<S>, ctx: &Contex
 /// Sends a signal to a target thread, using the current process
 /// as the sender.
 ///
+/// Checks the target thread belongs to the target process if `tgid` is provided.
+///
 /// If `signal` is `None`, this method will only check permission without sending
 /// any signal.
-pub fn tgkill(tid: Tid, tgid: Pid, signal: Option<Box<dyn Signal>>, ctx: &Context) -> Result<()> {
+pub fn tgkill(
+    tid: Tid,
+    tgid: Option<Pid>,
+    signal: Option<Box<dyn Signal>>,
+    ctx: &Context,
+) -> Result<()> {
     let thread = pid_table::pid_table_mut()
         .get_thread(tid)
         .ok_or_else(|| Error::with_message(Errno::ESRCH, "the target thread does not exist"))?;
     let target_posix_thread = thread.as_posix_thread().unwrap();
 
-    // Check the TGID
-    let pid = target_posix_thread.process().pid();
-    if pid != tgid {
-        return_errno_with_message!(
-            Errno::ESRCH,
-            "the combination of the TGID and the TID is not valid"
-        );
+    if let Some(tgid) = tgid {
+        // Check the TGID
+        let pid = target_posix_thread.process().pid();
+        if pid != tgid {
+            return_errno_with_message!(
+                Errno::ESRCH,
+                "the combination of the TGID and the TID is not valid"
+            );
+        }
     }
 
     // Check permission

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -125,6 +125,10 @@ pub fn handle_pending_signal(
                 debug!("Failed to handle user signal: {:?}", e);
                 // If signal handling fails, the process should be terminated with SIGSEGV.
                 // Reference: <https://elixir.bootlin.com/linux/v6.13/source/kernel/signal.c#L3082>
+                //
+                // FIXME: Linux converts a signal-frame setup failure into a SIGSEGV delivery,
+                // instead of killing the process directly.
+                // This can be observed in LTP test `signal06`.
                 do_exit_group(TermStatus::Killed(SIGSEGV));
             }
         }

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -155,7 +155,7 @@ macro_rules! import_generic_syscall_entries {
             symlink::sys_symlinkat,
             sync::{sys_sync, sys_syncfs},
             sysinfo::sys_sysinfo,
-            tgkill::sys_tgkill,
+            tgkill::{sys_tgkill, sys_tkill},
             timer_create::{sys_timer_create, sys_timer_delete},
             timer_settime::{sys_timer_gettime, sys_timer_settime},
             timerfd_create::sys_timerfd_create,
@@ -304,6 +304,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_SCHED_GET_PRIORITY_MAX = 125 => sys_sched_get_priority_max(args[..1]);
             SYS_SCHED_GET_PRIORITY_MIN = 126 => sys_sched_get_priority_min(args[..1]);
             SYS_KILL = 129                   => sys_kill(args[..2]);
+            SYS_TKILL = 130                  => sys_tkill(args[..2]);
             SYS_TGKILL = 131                 => sys_tgkill(args[..3]);
             SYS_SIGALTSTACK = 132            => sys_sigaltstack(args[..2], &user_ctx);
             SYS_RT_SIGSUSPEND = 133          => sys_rt_sigsuspend(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -159,7 +159,7 @@ use super::{
     symlink::{sys_symlink, sys_symlinkat},
     sync::{sys_sync, sys_syncfs},
     sysinfo::sys_sysinfo,
-    tgkill::sys_tgkill,
+    tgkill::{sys_tgkill, sys_tkill},
     time::sys_time,
     timer_create::{sys_timer_create, sys_timer_delete},
     timer_settime::{sys_timer_gettime, sys_timer_settime},
@@ -334,6 +334,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_REMOVEXATTR = 197      => sys_removexattr(args[..2]);
     SYS_LREMOVEXATTR = 198     => sys_lremovexattr(args[..2]);
     SYS_FREMOVEXATTR = 199     => sys_fremovexattr(args[..2]);
+    SYS_TKILL = 200            => sys_tkill(args[..2]);
     SYS_TIME = 201             => sys_time(args[..1]);
     SYS_FUTEX = 202            => sys_futex(args[..6]);
     SYS_SCHED_SETAFFINITY = 203 => sys_sched_setaffinity(args[..3]);

--- a/kernel/src/syscall/pidfd_send_signal.rs
+++ b/kernel/src/syscall/pidfd_send_signal.rs
@@ -54,7 +54,8 @@ pub fn sys_pidfd_send_signal(
 
     match target {
         SignalTarget::Thread { tid, tgid } => {
-            tgkill(tid, tgid, Some(Box::new(signal) as Box<dyn Signal>), ctx)?;
+            let signal = Some(Box::new(signal) as Box<dyn Signal>);
+            tgkill(tid, Some(tgid), signal, ctx)?;
         }
         SignalTarget::Process { pid } => {
             kill(pid, Some(Box::new(signal) as Box<dyn Signal>), ctx)?;

--- a/kernel/src/syscall/tgkill.rs
+++ b/kernel/src/syscall/tgkill.rs
@@ -19,15 +19,24 @@ use crate::{
 
 /// Sends a signal to a thread with `tid` as its thread ID, and `tgid` as its thread group ID.
 pub fn sys_tgkill(tgid: Pid, tid: Tid, sig_num: u8, ctx: &Context) -> Result<SyscallReturn> {
+    do_sys_tgkill(Some(tgid), tid, sig_num, ctx)
+}
+
+/// Sends a signal to a thread with `tid` as its thread ID.
+pub fn sys_tkill(tid: Tid, sig_num: u8, ctx: &Context) -> Result<SyscallReturn> {
+    do_sys_tgkill(None, tid, sig_num, ctx)
+}
+
+fn do_sys_tgkill(tgid: Option<Pid>, tid: Tid, sig_num: u8, ctx: &Context) -> Result<SyscallReturn> {
     let sig_num = if sig_num == 0 {
         None
     } else {
         Some(SigNum::try_from(sig_num)?)
     };
-    debug!("tgid = {}, pid = {}, sig_num = {:?}", tgid, tid, sig_num);
+    debug!("tgid = {:?}, tid = {}, sig_num = {:?}", tgid, tid, sig_num);
 
-    if tgid.cast_signed() < 0 || tid.cast_signed() < 0 {
-        return_errno_with_message!(Errno::EINVAL, "negative TGIDs or TIDs are not valid");
+    if tgid.is_some_and(|tgid| tgid.cast_signed() <= 0) || tid.cast_signed() <= 0 {
+        return_errno_with_message!(Errno::EINVAL, "non-positive TGIDs or TIDs are not valid");
     }
 
     let signal = sig_num.map(|sig_num| {

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1556,7 +1556,7 @@ signal02
 signal03
 signal04
 signal05
-signal06
+# signal06
 
 signalfd01
 signalfd02
@@ -1718,8 +1718,8 @@ timer_delete02
 # timer_settime02
 # timer_settime03
 
-# tkill01
-# tkill02
+tkill01
+tkill02
 
 truncate02
 truncate02_64

--- a/test/initramfs/src/regression/process/signal/kill.c
+++ b/test/initramfs/src/regression/process/signal/kill.c
@@ -87,6 +87,7 @@ FN_TEST(kill_dead_thread)
 	// Killing dead threads will succeed.
 	TEST_SUCC(kill(cpid, SIGCHLD));
 	TEST_SUCC(tgkill(cpid, cpid, SIGCHLD));
+	TEST_SUCC(syscall(SYS_tkill, cpid, SIGCHLD));
 
 	TEST_SUCC(kill(cpid, SIGKILL));
 	TEST_RES(wait(&status), _ret == cpid && WIFSIGNALED(status) &&


### PR DESCRIPTION
The `tkill` syscall is [deprecated](https://man7.org/linux/man-pages/man2/tgkill.2.html). However GDB uses it as a legacy dependency. Required for #2323.

Additionally, `tgkill` should return EINVAL when either `tgid` or `tid` equals to 0.

---

Adding this syscall causes the LTP test `signal06` to fail. This is because, on Linux, if writing the signal frame fails when handling a user signal, the kernel retries a SIGSEGV delivery, instead of killing the process directly. We should fix this issue in a separate PR.
