### PR TITLE
Fix RISC-V duplicate output during kernel initialization by redirecting serial output

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -50,29 +50,7 @@ qemu.args = "$(./tools/qemu_args.sh tdx)"
 supported_archs = ["riscv64"]
 boot.method = "qemu-direct"
 build.strip_elf = false
-
-qemu.args = """\
-    -cpu rv64,svpbmt=true \
-    -machine virt \
-    -m ${MEM-:8G} \
-    -smp ${SMP-:1} \
-    --no-reboot \
-    -nographic \
-    -display none \
-    -serial chardev:mux \
-    -monitor chardev:mux \
-    -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
-    -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
-    -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
-    # NOTE: The `/etc/profile.d/init.sh` assumes that `ext2.img` appears as the first block device (`/dev/vda`).
-    # The ordering below ensures `x1` (ext2.img) is discovered before `x0`, maintaining this assumption.
-    # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
-    -device virtio-blk-device,drive=x1 \
-    -device virtio-blk-device,drive=x0 \
-    -device virtio-keyboard-device \
-    -device virtio-serial-device \
-    -device virtconsole,chardev=mux \
-"""
+qemu.args = "$(./tools/qemu_args.sh riscv)"
 
 [scheme."sifive_u"]
 supported_archs = ["riscv64"]

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -56,6 +56,32 @@ else
     CONSOLE_ARGS="-serial chardev:mux"
 fi
 
+if [ "$1" = "riscv" ]; then
+    # NOTE: The `/etc/profile.d/init.sh` assumes that `ext2.img` appears as the first block device (`/dev/vda`).
+    # The ordering below ensures `x1` (ext2.img) is discovered before `x0`, maintaining this assumption.
+    # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
+    QEMU_ARGS="\
+        -cpu rv64,svpbmt=true \
+        -machine virt \
+        -m ${MEM-:8G} \
+        -smp ${SMP-:1} \
+        --no-reboot \
+        -nographic \
+        -display none \
+        -monitor chardev:mux \
+        -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
+        -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
+        -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+        -device virtio-blk-device,drive=x1 \
+        -device virtio-blk-device,drive=x0 \
+        -device virtio-keyboard-device \
+        -device virtio-serial-device \
+        $CONSOLE_ARGS \
+    "
+    echo $QEMU_ARGS
+    exit 0
+fi
+
 if [ "$1" = "tdx" ]; then
     TDX_OBJECT='{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "2", "port": "4050" } }'
 


### PR DESCRIPTION
This PR fixes the problem of duplicate output during kernel initialization in RISC-V scheme by redirecting serial output to `qemu-serial.log`, and moves the RISC-V QEMU run configuration to `qemu_args.sh` in compliance with x86_64 scheme.

Refer to discussions in #3130 and #2936 .

For discussions about long-term modification, refer to #2935.