### PR TITLE
Remove remaining `Ordering::SeqCst` usages

### DIFF
--- a/kernel/comps/softirq/src/taskless.rs
+++ b/kernel/comps/softirq/src/taskless.rs
@@ -191,15 +191,14 @@ mod test {
     use core::sync::atomic::AtomicUsize;
 
     use ostd::prelude::*;
+    use spin::Once;
 
     use super::*;
 
     fn init() {
-        static DONE: AtomicBool = AtomicBool::new(false);
-        if !DONE.load(Ordering::SeqCst) {
-            let _ = super::super::init();
-            DONE.store(true, Ordering::SeqCst);
-        }
+        static INIT: Once<()> = Once::new();
+
+        INIT.call_once(|| super::super::init().unwrap());
     }
 
     #[ktest]

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -127,7 +127,7 @@ impl ExfatFs {
 
     pub(super) fn alloc_inode_number(&self) -> Ino {
         self.highest_inode_number
-            .fetch_add(1, core::sync::atomic::Ordering::SeqCst)
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed)
     }
 
     pub(super) fn find_opened_inode(&self, hash: usize) -> Option<Arc<ExfatInode>> {

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -195,7 +195,7 @@ impl ContextSetNsAdminApi for Context<'_> {
         let mut thread_local_ns_proxy = self.thread_local.borrow_ns_proxy_mut();
 
         // TODO: When setting a specific namespace,
-        // other dependent fields of a posix thread may also need to be updated.
+        // other dependent fields of a POSIX thread may also need to be updated.
 
         if !Arc::ptr_eq(&thread_local_ns_proxy.unwrap().mnt_ns, &ns_proxy.mnt_ns) {
             *self.thread_local.borrow_fs().resolver().write() = ns_proxy.mnt_ns.new_path_resolver();

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -23,7 +23,7 @@ use crate::{
     time::{TimerManager, clocks::ProfClock},
 };
 
-/// The builder to build a posix thread
+/// The builder to build a POSIX thread
 pub struct PosixThreadBuilder {
     // The essential part
     tid: Tid,

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -365,13 +365,14 @@ impl ContextPthreadAdminApi for Context<'_> {
     }
 }
 
+/// The TID of the first POSIX thread (i.e., the main thread of the init process).
 pub const FIRST_POSIX_TID: Tid = 1;
 
 static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(FIRST_POSIX_TID);
 
-/// Allocates a new tid for the new posix thread
+/// Allocates a new TID for the new POSIX thread.
 pub fn allocate_posix_tid() -> Tid {
-    let tid = POSIX_TID_ALLOCATOR.fetch_add(1, Ordering::SeqCst);
+    let tid = POSIX_TID_ALLOCATOR.fetch_add(1, Ordering::Relaxed);
     if tid >= PID_MAX {
         // When the kernel's next PID value reaches `PID_MAX`,
         // it should wrap back to a minimum PID value.
@@ -385,9 +386,9 @@ pub fn allocate_posix_tid() -> Tid {
     tid
 }
 
-/// Returns the last allocated tid
+/// Returns the last allocated TID.
 pub fn last_tid() -> Tid {
-    POSIX_TID_ALLOCATOR.load(Ordering::SeqCst) - 1
+    POSIX_TID_ALLOCATOR.load(Ordering::Relaxed) - 1
 }
 
 /// The maximum allowed process ID.

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -55,9 +55,11 @@ pub use terminal::Terminal;
 /// Process ID.
 pub type Pid = u32;
 
+/// The PID of the init process.
 pub const INIT_PROCESS_PID: Pid = FIRST_POSIX_TID;
 
 define_atomic_version_of_integer_like_type!(Pid, {
+    /// Atomic [`Pid`].
     #[derive(Debug)]
     pub struct AtomicPid(AtomicU32);
 });

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -65,11 +65,11 @@ pub fn sys_timer_create(
                         process.enqueue_signal(Box::new(signal));
                     })
                 }
-                // Spawn a posix thread to run the `sigev_function`, which is stored in
+                // Spawn a POSIX thread to run the `sigev_function`, which is stored in
                 // `sig_event.sigev_un._sigev_thread`.
                 //
                 // TODO: enable this instructions. Currently the system does not provide an API to spawn
-                // a posix thread to run a specified function.
+                // a POSIX thread to run a specified function.
                 SigNotify::SIGEV_THREAD => {
                     unimplemented!()
                 }

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -73,7 +73,7 @@ where
 ///  - no [`with_borrow`] calls are performed on this CPU after this dismissal;
 pub(crate) unsafe fn dismiss() {
     IS_DISMISSED.store(true);
-    if DISMISS_COUNT.fetch_add(1, Ordering::SeqCst) as usize == num_cpus() - 1 {
+    if DISMISS_COUNT.fetch_add(1, Ordering::AcqRel) as usize == num_cpus() - 1 {
         let boot_pt = BOOT_PAGE_TABLE.lock().take().unwrap();
 
         dfs_walk_on_leave::<PageTableEntry, PagingConsts>(


### PR DESCRIPTION
`Ordering::SeqCst` is used to establish a global order between two atomic variables that cannot be accurately modeled via the "happens-before" relation. See the example at https://sabrinajewson.org/rust-nomicon/atomics/seqcst.html.

I don't believe we have a valid usecase in our current code base. It only exists for historical reasons because we didn't choose the proper order for our project in the early days. Most of them have already been removed. Only a few use cases remain. This PR removes the remaining uses.