### PR TITLE
Remove `log!` from prelude & Remove `#[macro_export]` in `aster-kernel`

### DIFF
--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -53,7 +53,6 @@ pub(crate) struct CurrentUserSpace<'a>(Ref<'a, Option<Arc<Vmar>>>);
 ///
 /// This is slower than [`Context::user_space`]. Don't use this getter
 /// If you get the access to the [`Context`].
-#[macro_export]
 macro_rules! current_userspace {
     () => {
         $crate::context::CurrentUserSpace::new(
@@ -64,6 +63,8 @@ macro_rules! current_userspace {
         )
     };
 }
+
+pub(crate) use current_userspace;
 
 impl<'a> CurrentUserSpace<'a> {
     /// Creates a new `CurrentUserSpace` from the current task.
@@ -282,3 +283,35 @@ fn check_vaddr_lowerbound(va: Vaddr) -> ostd::Result<()> {
     }
     Ok(())
 }
+
+/// Returns the current process.
+///
+/// # Panics
+///
+/// This macro will panic if the current task is not associated with a process. For example, it will
+/// happen if the current task is a kernel thread.
+macro_rules! current {
+    () => {
+        $crate::process::Process::current().unwrap()
+    };
+}
+
+pub(crate) use current;
+
+/// Returns the current thread.
+///
+/// # Panics
+///
+/// This macro will panic if the current task is not associated with a thread.
+///
+/// Except for unit tests, all tasks should be associated with threads. To write code that can be
+/// called directly in unit tests, consider using [`Thread::current`] instead.
+///
+/// [`Thread::current`]: crate::thread::Thread::current
+macro_rules! current_thread {
+    () => {
+        $crate::thread::Thread::current().expect("the current task is not associated with a thread")
+    };
+}
+
+pub(crate) use current_thread;

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -8,7 +8,7 @@ use ostd::mm::{HasPaddr, HasSize, VmIo, VmReader, VmWriter};
 
 use super::{Device, DeviceType, registry::char};
 use crate::{
-    current_userspace,
+    context::current_userspace,
     events::IoEvents,
     fs::{
         file::{FileIo, Mappable, StatusFlags},

--- a/kernel/src/device/mem/file.rs
+++ b/kernel/src/device/mem/file.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::vec;
-
 use ostd::mm::{FallibleVmWrite, VmReader, VmWriter};
 
 use crate::{
@@ -11,9 +9,8 @@ use crate::{
         file::{FileIo, StatusFlags},
         vfs::inode::InodeIo,
     },
-    prelude::Result,
+    prelude::*,
     process::signal::{PollHandle, Pollable},
-    return_errno_with_message,
     util::random,
 };
 

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -223,8 +223,8 @@ static TDX_REPORT: Once<RwMutex<USegment>> = Once::new();
 ///
 /// RTMRs are the only measurement registers that can be extended at runtime
 /// via [`extend_tdx_mr`].
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum Rtmr {
+#[derive(Clone, Copy, Debug)]
+pub enum Rtmr {
     Rtmr0,
     Rtmr1,
     Rtmr2,
@@ -232,8 +232,8 @@ pub(crate) enum Rtmr {
 }
 
 /// TDX measurement register.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum MeasurementReg {
+#[derive(Clone, Copy, Debug)]
+pub enum MeasurementReg {
     MrConfigId,
     MrOwner,
     MrOwnerConfig,
@@ -242,7 +242,7 @@ pub(crate) enum MeasurementReg {
 }
 
 /// Gets the TDX quote given the specified data in `inblob`.
-pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
+pub fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
     const GET_QUOTE_IN_FLIGHT: u64 = 0xFFFF_FFFF_FFFF_FFFF;
     const GET_QUOTE_BUF_SIZE: usize = 8 * 1024;
 
@@ -298,7 +298,7 @@ pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
 /// Most callers that only need to read a measurement register after an extend
 /// should use [`get_tdx_mr_refresh`] instead, which combines the refresh and
 /// the register read atomically.
-pub(crate) fn refresh_tdx_report(inblob: Option<&[u8]>) -> Result<()> {
+pub fn refresh_tdx_report(inblob: Option<&[u8]>) -> Result<()> {
     let report = TDX_REPORT
         .get()
         .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
@@ -306,7 +306,7 @@ pub(crate) fn refresh_tdx_report(inblob: Option<&[u8]>) -> Result<()> {
     refresh_tdx_report_locked(&report, inblob)
 }
 
-pub(crate) const SHA384_DIGEST_SIZE: usize = 48;
+pub const SHA384_DIGEST_SIZE: usize = 48;
 
 /// Gets the measurement register value from the cached TDX report.
 ///
@@ -315,7 +315,7 @@ pub(crate) const SHA384_DIGEST_SIZE: usize = 48;
 /// [`get_tdx_mr_refresh`] call. If the register may have been updated by a
 /// recent [`extend_tdx_mr`], use [`get_tdx_mr_refresh`] instead to obtain the
 /// current hardware value.
-pub(crate) fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
+pub fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
     let report = TDX_REPORT
         .get()
         .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
@@ -338,7 +338,7 @@ pub(crate) fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]
 /// Use this function after [`extend_tdx_mr`] to observe the updated RTMR
 /// value. If no extend has occurred and the cached report is still current,
 /// the cheaper [`get_tdx_mr`] can be used instead.
-pub(crate) fn get_tdx_mr_refresh(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
+pub fn get_tdx_mr_refresh(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
     let report = TDX_REPORT
         .get()
         .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
@@ -361,7 +361,7 @@ pub(crate) fn get_tdx_mr_refresh(reg: MeasurementReg) -> Result<[u8; SHA384_DIGE
 /// atomically regenerates the report and reads the register. Alternatively,
 /// call [`refresh_tdx_report`] and then [`get_tdx_mr`] if you need to refresh
 /// once and read multiple registers.
-pub(crate) fn extend_tdx_mr(reg: Rtmr, data: &[u8; SHA384_DIGEST_SIZE]) -> Result<()> {
+pub fn extend_tdx_mr(reg: Rtmr, data: &[u8; SHA384_DIGEST_SIZE]) -> Result<()> {
     let index = match reg {
         Rtmr::Rtmr0 => 0,
         Rtmr::Rtmr1 => 1,

--- a/kernel/src/device/tty/vt/driver.rs
+++ b/kernel/src/device/tty/vt/driver.rs
@@ -12,7 +12,7 @@ use ostd::mm::{Infallible, VmIo, VmReader, VmWriter};
 use spin::Once;
 
 use crate::{
-    current_userspace,
+    context::current_userspace,
     device::{
         registry::char,
         tty::{CFontOp, Tty, TtyDriver, file::TtyFile, termio::CTermios},

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -363,16 +363,18 @@ impl From<aster_util::printer::VmPrinterError> for Error {
     }
 }
 
-#[macro_export]
 macro_rules! return_errno {
     ($errno: expr) => {
         return Err($crate::error::Error::new($errno))
     };
 }
 
-#[macro_export]
+pub(crate) use return_errno;
+
 macro_rules! return_errno_with_message {
     ($errno: expr, $message: expr) => {
         return Err($crate::error::Error::with_message($errno, $message))
     };
 }
+
+pub(crate) use return_errno_with_message;

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{
-    collections::VecDeque,
-    string::String,
-    sync::{Arc, Weak},
-};
+use alloc::collections::VecDeque;
 use core::{
     fmt::Display,
     sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
@@ -29,7 +25,6 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
-    return_errno_with_message,
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };
 

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -165,7 +165,7 @@ fn print_banner() {
     println!("{}", logo_ascii_art::get_gradient_color_version());
 }
 
-pub(crate) fn on_first_process_startup(ctx: &Context) {
+pub(super) fn on_first_process_startup(ctx: &Context) {
     component::init_all(InitStage::Process, component::parse_metadata!()).unwrap();
     crate::device::init_in_first_process(ctx).unwrap();
     crate::fs::init_in_first_process(ctx);

--- a/kernel/src/net/socket/ip/addr.rs
+++ b/kernel/src/net/socket/ip/addr.rs
@@ -2,7 +2,7 @@
 
 use aster_bigtcp::wire::{IpAddress, IpEndpoint, Ipv4Address};
 
-use crate::{net::socket::util::SocketAddr, prelude::*, return_errno_with_message};
+use crate::{net::socket::util::SocketAddr, prelude::*};
 
 impl TryFrom<SocketAddr> for IpEndpoint {
     type Error = Error;

--- a/kernel/src/net/socket/util/datagram_common.rs
+++ b/kernel/src/net/socket/util/datagram_common.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::sync::RwMutex;
-
 use super::SendRecvFlags;
 use crate::{
     events::IoEvents,
     prelude::*,
     process::signal::Pollee,
-    return_errno_with_message,
     util::{MultiRead, MultiWrite},
 };
 

--- a/kernel/src/net/socket/vsock/common.rs
+++ b/kernel/src/net/socket/vsock/common.rs
@@ -17,7 +17,7 @@ use super::{
         listen::Listen,
     },
 };
-use crate::{prelude::*, return_errno_with_message, util::MultiRead};
+use crate::{prelude::*, util::MultiRead};
 
 /// Manage all active sockets
 pub struct VsockSpace {

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -16,7 +16,7 @@ pub(crate) use core::{any::Any, ffi::CStr, fmt::Debug};
 pub(crate) use bitflags::bitflags;
 pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use ostd::{
-    alert, crit, debug, emerg, error, info, log,
+    alert, crit, debug, emerg, error, info,
     mm::{FallibleVmRead, FallibleVmWrite, PAGE_SIZE, Vaddr, VmReader, VmWriter},
     notice,
     sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -13,6 +13,7 @@ pub(crate) use alloc::{
 };
 pub(crate) use core::{any::Any, ffi::CStr, fmt::Debug};
 
+pub(crate) use aster_logger::{print, println};
 pub(crate) use bitflags::bitflags;
 pub(crate) use int_to_c_enum::TryFromInt;
 pub(crate) use ostd::{
@@ -24,40 +25,12 @@ pub(crate) use ostd::{
 };
 pub(crate) use ostd_pod::{FromBytes, FromZeros, IntoBytes, Pod};
 
-/// return current process
-#[macro_export]
-macro_rules! current {
-    () => {
-        $crate::process::Process::current().unwrap()
-    };
-}
-
-/// Returns the current thread.
-///
-/// # Panics
-///
-/// This macro will panic if the current task is not associated with a thread.
-///
-/// Except for unit tests, all tasks should be associated with threads. To write code that can be
-/// called directly in unit tests, consider using [`Thread::current`] instead.
-///
-/// [`Thread::current`]: crate::thread::Thread::current
-#[macro_export]
-macro_rules! current_thread {
-    () => {
-        $crate::thread::Thread::current().expect("the current task is not associated with a thread")
-    };
-}
-
-pub(crate) use aster_logger::{print, println};
-
 pub(crate) use crate::{
-    context::{Context, CurrentUserSpace},
-    current, current_thread,
-    error::{Errno, Error},
+    context::{Context, CurrentUserSpace, current, current_thread},
+    error::{Errno, Error, return_errno, return_errno_with_message},
     process::{posix_thread::AsThreadLocal, signal::Pause},
     time::{Clock, wait::WaitTimeout},
     util::ReadCString,
 };
+
 pub(crate) type Result<T> = core::result::Result<T, Error>;
-pub(crate) use crate::{return_errno, return_errno_with_message};

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -2,7 +2,7 @@
 
 #![expect(unused)]
 
-pub(crate) use alloc::{
+pub use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
     ffi::CString,
@@ -11,26 +11,30 @@ pub(crate) use alloc::{
     vec,
     vec::Vec,
 };
-pub(crate) use core::{any::Any, ffi::CStr, fmt::Debug};
+pub use core::{any::Any, ffi::CStr, fmt::Debug};
 
-pub(crate) use aster_logger::{print, println};
-pub(crate) use bitflags::bitflags;
-pub(crate) use int_to_c_enum::TryFromInt;
-pub(crate) use ostd::{
+pub use aster_logger::{print, println};
+pub use bitflags::bitflags;
+pub use int_to_c_enum::TryFromInt;
+pub use ostd::{
     alert, crit, debug, emerg, error, info,
     mm::{FallibleVmRead, FallibleVmWrite, PAGE_SIZE, Vaddr, VmReader, VmWriter},
     notice,
     sync::{Mutex, MutexGuard, RwLock, RwMutex, SpinLock, SpinLockGuard},
     warn,
 };
-pub(crate) use ostd_pod::{FromBytes, FromZeros, IntoBytes, Pod};
+pub use ostd_pod::{FromBytes, FromZeros, IntoBytes, Pod};
 
-pub(crate) use crate::{
-    context::{Context, CurrentUserSpace, current, current_thread},
-    error::{Errno, Error, return_errno, return_errno_with_message},
+pub use crate::{
+    context::Context,
+    error::{Errno, Error},
     process::{posix_thread::AsThreadLocal, signal::Pause},
     time::{Clock, wait::WaitTimeout},
     util::ReadCString,
 };
+pub(crate) use crate::{
+    context::{CurrentUserSpace, current, current_thread},
+    error::{return_errno, return_errno_with_message},
+};
 
-pub(crate) type Result<T> = core::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -15,8 +15,8 @@ use super::{
     signal::{constants::SIGCHLD, sig_disposition::SigDispositions, sig_num::SigNum},
 };
 use crate::{
+    context::current_userspace,
     cpu::LinuxAbi,
-    current_userspace,
     fs::{
         cgroupfs::{CgroupMembership, CgroupSysNode},
         file::file_table::{FdFlags, FileTable, RawFileDesc},

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -8,7 +8,7 @@ use super::{
     robust_list::wake_robust_futex,
 };
 use crate::{
-    current_userspace,
+    context::current_userspace,
     prelude::*,
     process::{
         TermStatus,

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -8,7 +8,7 @@ use ostd::{
 use spin::Once;
 
 use crate::{
-    current_userspace,
+    context::current_userspace,
     prelude::*,
     process::VmarSnapshot,
     time::wait::ManagedTimeout,

--- a/kernel/src/process/posix_thread/robust_list.rs
+++ b/kernel/src/process/posix_thread/robust_list.rs
@@ -5,7 +5,7 @@
 use ostd::{mm::VmIo, task::Task};
 
 use crate::{
-    current_userspace,
+    context::current_userspace,
     prelude::*,
     process::posix_thread::futex::{FutexVisibility, futex_wake},
     thread::Tid,

--- a/kernel/src/process/process/terminal.rs
+++ b/kernel/src/process/process/terminal.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
-
 use super::{JobControl, Pgid, Process, Session, session::SessionGuard};
 use crate::{
     device::Device,
-    prelude::{Errno, Error, Result, current, return_errno_with_message, warn},
+    prelude::*,
     process::pid_table,
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -437,7 +437,7 @@ fn use_alternate_signal_stack(
 /// Writes a `u64` integer to the user's stack.
 #[cfg(target_arch = "x86_64")]
 fn write_u64_to_user_stack(sp: u64, value: u64) -> Result<u64> {
-    use crate::current_userspace;
+    use crate::context::current_userspace;
 
     let sp = sp.wrapping_sub(size_of::<u64>() as u64);
     current_userspace!().write_val(sp as _, &value)?;

--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 use ostd::mm::VmIo;
 
 use crate::{
-    current_userspace,
+    context::current_userspace,
     prelude::*,
     process::posix_thread::futex::{
         FutexFlags, FutexOp, FutexVisibility, futex_op_and_flags_from_u32, futex_requeue,

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -322,13 +322,16 @@ macro_rules! impl_syscall_nums_and_dispatch_fn {
             match syscall_number {
                 $(
                     $num => {
-                        $crate::log_syscall_entry!($name);
+                        $crate::syscall::log_syscall_entry!($name);
                         $crate::syscall::dispatch_fn_inner!(args, ctx, user_ctx, $handler $args)
                     }
                 )*
                 _ => {
                     ostd::warn!("Unimplemented syscall number: {}", syscall_number);
-                    $crate::return_errno_with_message!($crate::error::Errno::ENOSYS, "Syscall was unimplemented");
+                    $crate::error::return_errno_with_message!(
+                        $crate::error::Errno::ENOSYS,
+                        "Syscall was unimplemented"
+                    );
                 }
             }
         }
@@ -388,15 +391,17 @@ pub fn handle_syscall(ctx: &Context, user_ctx: &mut UserContext) {
     }
 }
 
-#[macro_export]
 macro_rules! log_syscall_entry {
     ($syscall_name: tt) => {
         if ostd::log_enabled!(ostd::log::Level::Info) {
             let syscall_name_str = stringify!($syscall_name);
-            let pid = $crate::current!().pid();
+            let pid = $crate::context::current!().pid();
             let tid = {
                 use $crate::process::posix_thread::AsPosixThread;
-                $crate::current_thread!().as_posix_thread().unwrap().tid()
+                $crate::context::current_thread!()
+                    .as_posix_thread()
+                    .unwrap()
+                    .tid()
             };
             ostd::info!(
                 "[pid={}][tid={}][id={}][{}]",
@@ -408,3 +413,5 @@ macro_rules! log_syscall_entry {
         }
     };
 }
+
+use log_syscall_entry;

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -10,8 +10,8 @@ use ostd::{
 
 use super::{Thread, oops};
 use crate::{
+    context::current_userspace,
     cpu::LinuxAbi,
-    current_userspace,
     prelude::*,
     process::{
         posix_thread::{AsPosixThread, AsThreadLocal, FIRST_POSIX_TID, ThreadLocal},

--- a/kernel/src/util/ioctl/mod.rs
+++ b/kernel/src/util/ioctl/mod.rs
@@ -101,7 +101,7 @@ use core::marker::PhantomData;
 use aster_util::safe_ptr::SafePtr;
 use sealed::{DataSpec, IoctlCmd, IoctlDir, PtrDataSpec};
 
-use crate::{current_userspace, prelude::*};
+use crate::{context::current_userspace, prelude::*};
 
 pub mod common_defs;
 mod sealed;

--- a/kernel/src/util/net/addr/family.rs
+++ b/kernel/src/util/net/addr/family.rs
@@ -5,7 +5,7 @@ use core::cmp::min;
 use ostd::{mm::VmIo, task::Task};
 
 use super::{ip::CSocketAddrInet, netlink::CSocketAddrNetlink, unix, vsock::CSocketAddrVm};
-use crate::{current_userspace, net::socket::util::SocketAddr, prelude::*};
+use crate::{context::current_userspace, net::socket::util::SocketAddr, prelude::*};
 
 /// Address family.
 ///

--- a/kernel/src/util/net/options/ip.rs
+++ b/kernel/src/util/net/options/ip.rs
@@ -2,12 +2,10 @@
 
 use int_to_c_enum::TryFromInt;
 
-use super::RawSocketOption;
+use super::{RawSocketOption, SocketOption, impl_raw_socket_option};
 use crate::{
-    impl_raw_socket_option,
     net::socket::ip::options::{Hdrincl, Recverr, Tos, Ttl},
     prelude::*,
-    util::net::options::SocketOption,
 };
 
 /// Socket options for IP socket.

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -75,7 +75,6 @@ pub trait RawSocketOption: SocketOption {
 }
 
 /// Impl `RawSocketOption` for a struct which implements `SocketOption`.
-#[macro_export]
 macro_rules! impl_raw_socket_option {
     ($option:ty) => {
         impl RawSocketOption for $option {
@@ -106,7 +105,6 @@ macro_rules! impl_raw_socket_option {
 }
 
 /// Impl `RawSocketOption` for a struct which is for only `getsockopt` and implements `SocketOption`.
-#[macro_export]
 macro_rules! impl_raw_sock_option_get_only {
     ($option:ty) => {
         impl RawSocketOption for $option {
@@ -133,7 +131,6 @@ macro_rules! impl_raw_sock_option_get_only {
 }
 
 /// Impl `RawSocketOption` for a struct which is for only `setsockopt` and implements `SocketOption`.
-#[macro_export]
 macro_rules! impl_raw_sock_option_set_only {
     ($option:ty) => {
         impl RawSocketOption for $option {
@@ -159,6 +156,11 @@ macro_rules! impl_raw_sock_option_set_only {
         }
     };
 }
+
+// Export macros to sub-modules
+use impl_raw_sock_option_get_only;
+use impl_raw_sock_option_set_only;
+use impl_raw_socket_option;
 
 pub fn new_raw_socket_option(
     level: CSocketOptionLevel,

--- a/kernel/src/util/net/options/netlink.rs
+++ b/kernel/src/util/net/options/netlink.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::RawSocketOption;
+use super::{RawSocketOption, SocketOption, impl_raw_sock_option_set_only};
 use crate::{
-    impl_raw_sock_option_set_only,
     net::socket::netlink::{AddMembership, DropMembership},
     prelude::*,
-    util::net::options::SocketOption,
 };
 
 /// Socket options for netlink socket.

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -2,9 +2,9 @@
 
 use ostd::mm::VmIo;
 
-use super::RawSocketOption;
+use super::{RawSocketOption, impl_raw_sock_option_get_only, impl_raw_socket_option};
 use crate::{
-    current_userspace, impl_raw_sock_option_get_only, impl_raw_socket_option,
+    context::current_userspace,
     net::socket::options::{
         AcceptConn, Broadcast, Error, KeepAlive, Linger, PassCred, PeerCred, PeerGroups, Priority,
         RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,

--- a/kernel/src/util/net/options/tcp.rs
+++ b/kernel/src/util/net/options/tcp.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::RawSocketOption;
+use super::{RawSocketOption, SocketOption, impl_raw_socket_option};
 use crate::{
-    impl_raw_socket_option,
     net::socket::ip::stream_options::{
         Congestion, DeferAccept, Inq, KeepIdle, MaxSegment, NoDelay, SynCnt, UserTimeout,
         WindowClamp,
     },
     prelude::*,
-    util::net::options::SocketOption,
 };
 
 /// Sock options for tcp socket.

--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -5,7 +5,7 @@ use core::{num::NonZeroU8, time::Duration};
 use ostd::mm::VmIo;
 
 use crate::{
-    current_userspace,
+    context::current_userspace,
     net::socket::{
         ip::{options::IpTtl, stream_options::CongestionControl},
         unix::CUserCred,
@@ -46,7 +46,7 @@ macro_rules! impl_read_write_for_32bit_type {
                 if (max_len as usize) < size_of::<$pod_ty>() {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
                 }
-                Ok(crate::current_userspace!().read_val::<$pod_ty>(addr)?)
+                Ok(crate::context::current_userspace!().read_val::<$pod_ty>(addr)?)
             }
         }
 
@@ -58,7 +58,7 @@ macro_rules! impl_read_write_for_32bit_type {
                     return_errno_with_message!(Errno::EINVAL, "max_len is too short");
                 }
 
-                crate::current_userspace!().write_val(addr, self)?;
+                crate::context::current_userspace!().write_val(addr, self)?;
                 Ok(write_len)
             }
         }

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -232,7 +232,7 @@ const PREBUILT_VDSO_LIB: &[u8] =
 /// This constant is specific to the prebuilt vDSO library and can be obtained from
 /// `readelf -s vdso_riscv64.so | grep '__vdso_rt_sigreturn'`.
 #[cfg(target_arch = "riscv64")]
-pub(crate) const __VDSO_RT_SIGRETURN_OFFSET: usize = 0x5b0;
+pub const __VDSO_RT_SIGRETURN_OFFSET: usize = 0x5b0;
 
 impl Vdso {
     /// Constructs a new `Vdso`, including an initialized `VdsoData` and a VMO of the vDSO.
@@ -380,7 +380,7 @@ pub(super) fn init_in_first_kthread() {
 /// Returns the vDSO VMO.
 ///
 /// This function will return `None` if vDSO does not exist (e.g., if it has not been initialized).
-pub(crate) fn vdso_vmo() -> Option<Arc<Vmo>> {
+pub fn vdso_vmo() -> Option<Arc<Vmo>> {
     VDSO.get().map(|vdso| vdso.vmo.clone())
 }
 

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -22,7 +22,7 @@ impl Vmar {
     /// use ostd::mm::PAGE_SIZE;
     ///
     /// use crate::{
-    ///     current_userspace,
+    ///     context::current_userspace,
     ///     vm::{perms::VmPerms, vmar::VmarMapOffset, vmo::VmoOptions},
     /// };
     ///

--- a/ostd/src/log/level.rs
+++ b/ostd/src/log/level.rs
@@ -41,8 +41,8 @@ use core::fmt;
 /// | Info         | Info (6)           | |
 /// | Debug        | Debug (7)          | |
 /// | Trace        | Debug (7)          | Bridge only; no `trace!` macro in OSTD |
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Level {
     /// System is unusable.
     Emerg = 0,
@@ -107,8 +107,8 @@ impl fmt::Display for Level {
 /// LevelFilter::Error(4)   -> Emerg(0), Alert(1), Crit(2), Error(3)
 /// LevelFilter::Debug(8)   -> everything
 /// ```
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum LevelFilter {
     /// All logging disabled.
     Off = 0,

--- a/ostd/src/prelude.rs
+++ b/ostd/src/prelude.rs
@@ -13,7 +13,7 @@ pub(crate) use alloc::{boxed::Box, sync::Arc, vec::Vec};
 pub use ostd_macros::ktest;
 
 pub use crate::{
-    alert, crit, debug, early_print as print, early_println as println, emerg, error, info, log,
+    alert, crit, debug, early_print as print, early_println as println, emerg, error, info,
     mm::{HasPaddr, HasSize, Paddr, Vaddr},
     notice,
     panic::abort,


### PR DESCRIPTION
1. Remove `log!` from prelude
   - It does not seem useful. It has no users. Since a user needs to manually import the `LogLevel` type anyway, `log!` should be imported manually as well.
2. Remove `#[macro_export]` in `aster-kernel`
    - `aster-kernel` has no downstream users. So I don't think having `#[macro_export]` in it makes any sense..