### PR TITLE
Update Rust guidelines on visibility modifiers

### DIFF
--- a/book/src/to-contribute/coding-guidelines/rust-guidelines/language-items/modules-and-crates.md
+++ b/book/src/to-contribute/coding-guidelines/rust-guidelines/language-items/modules-and-crates.md
@@ -19,9 +19,14 @@ pub(super) fn init() -> Result<(), I8042ControllerError> {
 pub static I8042_CONTROLLER: ...
 ```
 
+Inside the `aster-kernel` crate, `pub(crate)` and `pub` are equivalent,
+as the crate has no downstream consumers.
+Prefer the shorter `pub`.
+
 See also:
-PR [#2951](https://github.com/asterinas/asterinas/pull/2951)
-and [#2605](https://github.com/asterinas/asterinas/pull/2605#discussion_r2720506912).
+PR [#2951](https://github.com/asterinas/asterinas/pull/2951),
+[#2605](https://github.com/asterinas/asterinas/pull/2605#discussion_r2720506912),
+and [#3154](https://github.com/asterinas/asterinas/pull/3154#discussion_r3100905375).
 
 ### Qualify function calls with the parent module (`qualified-fn-imports`) {#qualified-fn-imports}
 


### PR DESCRIPTION
Codifies the style preference from #3154 as a coding guideline: inside `aster-kernel`, `pub(crate)` and `pub` are equivalent since the crate has no downstream consumers, so prefer the shorter `pub`. Also refreshes the "See also" links with related PRs.