### PR TITLE
Fix LTP `readlink` test cases

### DIFF
--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -22,6 +22,10 @@ pub fn sys_readlinkat(
     usr_buf_len: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
+    if usr_buf_len == 0 {
+        return_errno_with_message!(Errno::EINVAL, "the buffer length is zero");
+    }
+
     let user_space = ctx.user_space();
     let path_name = user_space.read_cstring(path_addr, MAX_FILENAME_LEN)?;
     debug!(
@@ -34,7 +38,11 @@ pub fn sys_readlinkat(
         let path_resolver = fs_ref.resolver().read();
 
         let path_name = path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &path_name)?;
+        let fs_path = if path_name.is_empty() && dirfd != AT_FDCWD {
+            FsPath::from_fd(dirfd)?
+        } else {
+            FsPath::from_fd_and_path(dirfd, &path_name)?
+        };
         let path = path_resolver.lookup_no_follow(&fs_path)?;
 
         match path.inode().read_link()? {

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1196,12 +1196,12 @@ read04
 # readdir01
 # readdir21
 
-# readlink01
-# readlink03
+readlink01
+readlink03
 
 #readlinkat test cases
-# readlinkat01
-# readlinkat02
+readlinkat01
+readlinkat02
 
 readv01
 # readv02

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -63,6 +63,10 @@ pwritev201_64
 read01
 read02
 read04
+readlink01
+readlink03
+readlinkat01
+readlinkat02
 readv01
 rename01A
 rmdir03A


### PR DESCRIPTION
This PR fixes LTP `readlink` test failures for two edge cases:
- return `EINVAL` when `readlink()` is called with a zero-length buffer;
- support `readlinkat(fd, "")` on a symlink opened with `O_PATH | O_NOFOLLOW`.

It also enables the related LTP `readlink*` test cases and blocks them on `exfat`.