### PR TITLE
Model `virtqueue` as untrusted and use fallible allocation in `aster-virtio`

### DIFF
--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -32,9 +32,7 @@ pub struct EthernetAddr(pub [u8; 6]);
 #[derive(Clone, Copy, Debug)]
 pub enum NetError {
     NotReady,
-    WrongToken,
     Busy,
-    Unknown,
 }
 
 pub trait AnyNetworkDevice: Send + Sync + Any + Debug {

--- a/kernel/comps/network/src/lib.rs
+++ b/kernel/comps/network/src/lib.rs
@@ -33,6 +33,7 @@ pub struct EthernetAddr(pub [u8; 6]);
 pub enum NetError {
     NotReady,
     Busy,
+    NoMemory,
 }
 
 pub trait AnyNetworkDevice: Send + Sync + Any + Debug {

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -305,10 +305,15 @@ impl DeviceInner {
             resp_slice.sync_from_device().unwrap();
             let resp: BlockResp = resp_slice.read_val(0).unwrap();
             self.id_allocator.dealloc(id);
-            match RespStatus::try_from(resp.status).unwrap() {
-                RespStatus::Ok => {}
-                // FIXME: Return an error instead of triggering a kernel panic
-                _ => panic!("io error in block device"),
+            match RespStatus::try_from(resp.status) {
+                Ok(RespStatus::Ok) => {}
+                _ => {
+                    // Completes the bio request with an error
+                    complete_request.bio_request.bios().for_each(|bio| {
+                        bio.complete(BioStatus::IoError);
+                    });
+                    continue;
+                }
             };
 
             // Synchronize DMA mapping if read from the device

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -284,7 +284,7 @@ impl DeviceInner {
             // Pops the complete request
             let complete_request = {
                 let mut queue = self.queue.lock();
-                let Ok((token, _)) = queue.pop_used() else {
+                let Ok((token, _)) = queue.pop_used_with_min_bytes(RESP_SIZE) else {
                     return;
                 };
                 self.submitted_requests.lock().remove(&token).unwrap()

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -23,7 +23,7 @@ use device_id::{DeviceId, MinorId};
 use ostd::{
     arch::trap::TrapFrame,
     debug, info,
-    mm::{HasSize, VmIo, dma::DmaStream},
+    mm::{PAGE_SIZE, VmIo, dma::DmaStream},
     sync::SpinLock,
 };
 
@@ -214,30 +214,38 @@ impl DeviceInner {
     /// Creates and inits the device.
     fn init(mut transport: Box<dyn VirtioTransport>) -> Result<Arc<Self>, VirtioDeviceError> {
         let config_manager = VirtioBlockConfig::new_manager(transport.as_ref());
-        debug!("virio_blk_config = {:?}", config_manager.read_config());
-        assert_eq!(
-            config_manager.block_size(),
-            VirtioBlockConfig::sector_size(),
-            "currently not support customized device logical block size"
-        );
+
+        let config = config_manager.read_config();
+        debug!("virio_blk_config = {:?}", config);
+
+        let block_size = config_manager.block_size();
+        if block_size != VirtioBlockConfig::sector_size() {
+            ostd::error!("block size {} is not supported yet", block_size);
+            return Err(VirtioDeviceError::UnsupportedConfig);
+        }
+
         let num_queues = transport.num_queues();
         if num_queues != 1 {
-            // FIXME: support Multi-Queue Block IO Queueing Mechanism
+            // TODO: Support Multi-Queue Block IO Queueing Mechanism
             // (`BlkFeatures::MQ`) to accelerate multi-processor requests for
             // block devices. When SMP is enabled on x86, the feature is on.
-            // We should also consider negotiating the feature in the future.
-            // return Err(VirtioDeviceError::QueuesAmountDoNotMatch(num_queues, 1));
             ostd::warn!(
-                "Not supporting Multi-Queue Block IO Queueing Mechanism, only using the first queue"
+                "Multi-Queue Block IO Queueing Mechanism is not supported yet; using the first queue"
             );
         }
+
         let features = VirtioBlockFeature::new(transport.as_ref());
-        let queue = VirtQueue::new(0, Self::QUEUE_SIZE, transport.as_mut())
-            .expect("create virtqueue failed");
-        let block_requests = Arc::new(DmaStream::alloc(1, false).unwrap());
-        assert!(Self::QUEUE_SIZE as usize * REQ_SIZE <= block_requests.size());
-        let block_responses = Arc::new(DmaStream::alloc(1, false).unwrap());
-        assert!(Self::QUEUE_SIZE as usize * RESP_SIZE <= block_responses.size());
+
+        let queue = VirtQueue::new(0, Self::QUEUE_SIZE, transport.as_mut())?;
+
+        let block_requests =
+            Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
+        let block_responses =
+            Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
+        const {
+            assert!(Self::QUEUE_SIZE as usize * REQ_SIZE <= PAGE_SIZE);
+            assert!(Self::QUEUE_SIZE as usize * RESP_SIZE <= PAGE_SIZE);
+        }
 
         let device = Arc::new(Self {
             config_manager,

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -46,10 +46,9 @@ impl AnyConsoleDevice for ConsoleDevice {
             if transmit_queue.should_notify() {
                 transmit_queue.notify();
             }
-            while !transmit_queue.can_pop() {
+            while transmit_queue.pop_used().is_err() {
                 spin_loop();
             }
-            transmit_queue.pop_used().unwrap();
         }
     }
 

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -24,8 +24,8 @@ pub struct ConsoleDevice {
     transport: SpinLock<Box<dyn VirtioTransport>>,
     receive_queue: SpinLock<VirtQueue>,
     transmit_queue: SpinLock<VirtQueue>,
-    send_buffer: Arc<DmaStream>,
-    receive_buffer: Arc<DmaStream>,
+    send_buffer: DmaStream,
+    receive_buffer: DmaStream,
     #[expect(clippy::box_collection)]
     callbacks: Rcu<Box<Vec<&'static ConsoleCallback>>>,
 }
@@ -92,13 +92,16 @@ impl ConsoleDevice {
         const RECV0_QUEUE_INDEX: u16 = 0;
         const TRANSMIT0_QUEUE_INDEX: u16 = 1;
         let receive_queue =
-            SpinLock::new(VirtQueue::new(RECV0_QUEUE_INDEX, 2, transport.as_mut()).unwrap());
-        let transmit_queue =
-            SpinLock::new(VirtQueue::new(TRANSMIT0_QUEUE_INDEX, 2, transport.as_mut()).unwrap());
+            SpinLock::new(VirtQueue::new(RECV0_QUEUE_INDEX, 2, transport.as_mut())?);
+        let transmit_queue = SpinLock::new(VirtQueue::new(
+            TRANSMIT0_QUEUE_INDEX,
+            2,
+            transport.as_mut(),
+        )?);
 
-        let send_buffer = Arc::new(DmaStream::alloc(1, false).unwrap());
-
-        let receive_buffer = Arc::new(DmaStream::alloc(1, false).unwrap());
+        let send_buffer = DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?;
+        let receive_buffer =
+            DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?;
 
         let device = Arc::new(Self {
             config_manager,
@@ -172,5 +175,5 @@ impl ConsoleDevice {
 }
 
 fn config_space_change(_: &TrapFrame) {
-    debug!("Virtio-Console device configuration space change");
+    debug!("console device configuration space change");
 }

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -85,15 +85,8 @@ impl InputDevice {
         let event_table = EventTable::new(QUEUE_SIZE as usize);
         for i in 0..event_table.num_events() {
             let event_buf = event_table.get(i);
-            let token = event_queue.add_output_bufs(&[&event_buf]);
-            match token {
-                Ok(value) => {
-                    assert_eq!(value, i as u16);
-                }
-                Err(_) => {
-                    return Err(VirtioDeviceError::QueueUnknownError);
-                }
-            }
+            let token = event_queue.add_output_bufs(&[&event_buf]).unwrap();
+            assert_eq!(token as usize, i);
         }
 
         let device = {
@@ -167,7 +160,7 @@ impl InputDevice {
         let mut event_queue = self.event_queue.disable_irq().lock();
 
         // one interrupt may contain several input events, so it should loop
-        while let Ok((token, _)) = event_queue.pop_used() {
+        while let Ok((token, _)) = event_queue.pop_used_with_min_bytes(EVENT_SIZE) {
             debug_assert!(token < QUEUE_SIZE);
             let ptr = self.event_table.get(token as usize);
             let res = handle_event(&ptr);

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -77,12 +77,10 @@ impl InputDevice {
     /// Create a new VirtIO-Input driver.
     /// msix_vector_left should at least have one element or n elements where n is the virtqueue amount
     pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let mut event_queue = VirtQueue::new(QUEUE_EVENT, QUEUE_SIZE, transport.as_mut())
-            .expect("create event virtqueue failed");
-        let status_queue = VirtQueue::new(QUEUE_STATUS, QUEUE_SIZE, transport.as_mut())
-            .expect("create status virtqueue failed");
+        let mut event_queue = VirtQueue::new(QUEUE_EVENT, QUEUE_SIZE, transport.as_mut())?;
+        let status_queue = VirtQueue::new(QUEUE_STATUS, QUEUE_SIZE, transport.as_mut())?;
 
-        let event_table = EventTable::new(QUEUE_SIZE as usize);
+        let event_table = EventTable::new(QUEUE_SIZE as usize)?;
         for i in 0..event_table.num_events() {
             let event_buf = event_table.get(i);
             let token = event_queue.add_output_bufs(&[&event_buf]).unwrap();
@@ -510,14 +508,13 @@ impl InputDevice {
 /// each of which is large enough to contain a `VirtioInputEvent`.
 #[derive(Debug)]
 struct EventTable {
-    stream: Arc<DmaStream>,
+    stream: DmaStream,
     num_events: usize,
 }
 
 impl EventTable {
-    fn new(num_events: usize) -> Self {
+    fn new(num_events: usize) -> Result<Self, VirtioDeviceError> {
         assert!(num_events * size_of::<VirtioInputEvent>() <= PAGE_SIZE);
-
         debug_assert!(
             VirtioInputEvent::default()
                 .as_bytes()
@@ -525,8 +522,8 @@ impl EventTable {
                 .all(|b| *b == 0)
         );
 
-        let stream = Arc::new(DmaStream::alloc(1, false).unwrap());
-        Self { stream, num_events }
+        let stream = DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?;
+        Ok(Self { stream, num_events })
     }
 
     fn get(&self, idx: usize) -> EventBuf<'_> {

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -87,6 +87,10 @@ impl InputDevice {
             assert_eq!(token as usize, i);
         }
 
+        if event_queue.should_notify() {
+            event_queue.notify();
+        }
+
         let device = {
             let mut device = Self {
                 config: VirtioInputConfig::new(transport.as_mut()),
@@ -188,7 +192,7 @@ impl InputDevice {
             out
         };
 
-        String::from_utf8(out).unwrap()
+        String::from_utf8_lossy(out.as_slice()).to_string()
     }
 
     fn query_config_prop_bits(&self) -> Option<InputProp> {
@@ -530,6 +534,9 @@ impl EventTable {
         assert!(idx < self.num_events);
 
         let offset = idx * EVENT_SIZE;
+        self.stream
+            .sync_from_device(offset..offset + EVENT_SIZE)
+            .unwrap();
         SafePtr::new(&self.stream, offset)
     }
 

--- a/kernel/comps/virtio/src/device/mod.rs
+++ b/kernel/comps/virtio/src/device/mod.rs
@@ -2,7 +2,7 @@
 
 use int_to_c_enum::TryFromInt;
 
-use crate::queue::QueueError;
+use crate::{queue, transport::VirtioTransportError};
 
 pub mod block;
 pub mod console;
@@ -40,17 +40,23 @@ pub(crate) enum VirtioDeviceType {
 
 #[derive(Debug)]
 pub enum VirtioDeviceError {
-    /// queues amount do not match the requirement
-    /// first element is actual value, second element is expect value
-    QueuesAmountDoNotMatch(u16, u16),
-    /// unknown error of queue
-    QueueUnknownError,
-    /// The input virtio capability list contains invalid element
-    CapabilityListError,
+    Transport(VirtioTransportError),
+    ResourceAlloc(ostd::Error),
+    InvalidQueueArgs,
+    UnsupportedConfig,
 }
 
-impl From<QueueError> for VirtioDeviceError {
-    fn from(_: QueueError) -> Self {
-        VirtioDeviceError::QueueUnknownError
+impl From<VirtioTransportError> for VirtioDeviceError {
+    fn from(value: VirtioTransportError) -> Self {
+        Self::Transport(value)
+    }
+}
+
+impl From<queue::CreationError> for VirtioDeviceError {
+    fn from(value: queue::CreationError) -> Self {
+        match value {
+            queue::CreationError::InvalidArgs => Self::InvalidQueueArgs,
+            queue::CreationError::ResourceAlloc(e) => Self::ResourceAlloc(e),
+        }
     }
 }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -17,7 +17,7 @@ use crate::{
             config::NetworkFeatures,
         },
     },
-    queue::{QueueError, VirtQueue},
+    queue::{self, VirtQueue},
     transport::{ConfigManager, VirtioTransport},
 };
 
@@ -33,6 +33,7 @@ pub struct NetworkDevice {
     header: VirtioNetHdr,
     tx_buffers: Vec<Option<TxBuffer>>,
     rx_buffers: SlotVec<RxBuffer>,
+    new_rx_buffer: Option<RxBuffer>,
     transport: Box<dyn VirtioTransport>,
     poll_stat: PollStatistics,
 }
@@ -81,19 +82,18 @@ impl NetworkDevice {
 
         let caps = init_caps(&features, &config);
 
-        let mut send_queue = VirtQueue::new(QUEUE_SEND, QUEUE_SIZE, transport.as_mut())
-            .expect("creating send queue fails");
+        let mut send_queue = VirtQueue::new(QUEUE_SEND, QUEUE_SIZE, transport.as_mut())?;
         send_queue.disable_callback();
 
-        let mut recv_queue = VirtQueue::new(QUEUE_RECV, QUEUE_SIZE, transport.as_mut())
-            .expect("creating recv queue fails");
+        let mut recv_queue = VirtQueue::new(QUEUE_RECV, QUEUE_SIZE, transport.as_mut())?;
 
         let tx_buffers = (0..QUEUE_SIZE).map(|_| None).collect();
 
         let mut rx_buffers = SlotVec::new();
         for i in 0..QUEUE_SIZE {
             let rx_pool = RX_BUFFER_POOL.get().unwrap();
-            let rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool).unwrap();
+            let rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool)
+                .map_err(VirtioDeviceError::ResourceAlloc)?;
             let token = recv_queue.add_output_bufs(&[&rx_buffer]).unwrap();
             assert_eq!(i, token);
             assert_eq!(rx_buffers.put(rx_buffer) as u16, i);
@@ -113,6 +113,7 @@ impl NetworkDevice {
             header: VirtioNetHdr::default(),
             tx_buffers,
             rx_buffers,
+            new_rx_buffer: None,
             transport,
             poll_stat: PollStatistics::new(),
         };
@@ -153,7 +154,7 @@ impl NetworkDevice {
     }
 
     /// Adds a `RxBuffer` to the receive queue.
-    fn add_rx_buffer(&mut self, rx_buffer: RxBuffer) -> Result<(), QueueError> {
+    fn add_rx_buffer(&mut self, rx_buffer: RxBuffer) -> Result<(), queue::AddBufsError> {
         let token = self.recv_queue.add_output_bufs(&[&rx_buffer])?;
         assert!(self.rx_buffers.put_at(token as usize, rx_buffer).is_none());
 
@@ -170,6 +171,16 @@ impl NetworkDevice {
 
     /// Receives a packet from network.
     fn receive(&mut self) -> Result<RxBuffer, NetError> {
+        if self.new_rx_buffer.is_none() {
+            // FIXME: Ideally, we can reuse the returned buffer without creating new buffer.
+            // But this requires locking device to be compatible with smoltcp interface.
+            let rx_pool = RX_BUFFER_POOL.get().unwrap();
+            let new_rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool)
+                .map_err(|_| NetError::NoMemory)?;
+
+            self.new_rx_buffer = Some(new_rx_buffer);
+        }
+
         let (token, len) = self
             .recv_queue
             .pop_used_with_min_bytes(size_of::<VirtioNetHdr>())
@@ -179,11 +190,7 @@ impl NetworkDevice {
         let mut rx_buffer = self.rx_buffers.remove(token as usize).unwrap();
         rx_buffer.set_packet_len(len as usize - size_of::<VirtioNetHdr>());
 
-        // FIXME: Ideally, we can reuse the returned buffer without creating new buffer.
-        // But this requires locking device to be compatible with smoltcp interface.
-        let rx_pool = RX_BUFFER_POOL.get().unwrap();
-        let new_rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool).unwrap();
-
+        let new_rx_buffer = self.new_rx_buffer.take().unwrap();
         self.add_rx_buffer(new_rx_buffer).unwrap();
 
         Ok(rx_buffer)
@@ -201,7 +208,7 @@ impl NetworkDevice {
             &mut VmReader::from(packet).to_fallible(),
             tx_pool,
         )
-        .unwrap();
+        .map_err(|_| NetError::NoMemory)?;
 
         let token = self.send_queue.add_input_bufs(&[&tx_buffer]).unwrap();
 

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -94,7 +94,7 @@ impl NetworkDevice {
         for i in 0..QUEUE_SIZE {
             let rx_pool = RX_BUFFER_POOL.get().unwrap();
             let rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool).unwrap();
-            let token = recv_queue.add_output_bufs(&[&rx_buffer])?;
+            let token = recv_queue.add_output_bufs(&[&rx_buffer]).unwrap();
             assert_eq!(i, token);
             assert_eq!(rx_buffers.put(rx_buffer) as u16, i);
         }
@@ -153,11 +153,8 @@ impl NetworkDevice {
     }
 
     /// Adds a `RxBuffer` to the receive queue.
-    fn add_rx_buffer(&mut self, rx_buffer: RxBuffer) -> Result<(), NetError> {
-        let token = self
-            .recv_queue
-            .add_output_bufs(&[&rx_buffer])
-            .map_err(queue_to_network_error)?;
+    fn add_rx_buffer(&mut self, rx_buffer: RxBuffer) -> Result<(), QueueError> {
+        let token = self.recv_queue.add_output_bufs(&[&rx_buffer])?;
         assert!(self.rx_buffers.put_at(token as usize, rx_buffer).is_none());
 
         self.poll_stat.received_packet += 1;
@@ -173,18 +170,22 @@ impl NetworkDevice {
 
     /// Receives a packet from network.
     fn receive(&mut self) -> Result<RxBuffer, NetError> {
-        let (token, len) = self.recv_queue.pop_used().map_err(queue_to_network_error)?;
+        let (token, len) = self
+            .recv_queue
+            .pop_used_with_min_bytes(size_of::<VirtioNetHdr>())
+            .map_err(|_| NetError::NotReady)?;
         debug!("receive packet: token = {}, len = {}", token, len);
-        let mut rx_buffer = self
-            .rx_buffers
-            .remove(token as usize)
-            .ok_or(NetError::WrongToken)?;
+
+        let mut rx_buffer = self.rx_buffers.remove(token as usize).unwrap();
         rx_buffer.set_packet_len(len as usize - size_of::<VirtioNetHdr>());
+
         // FIXME: Ideally, we can reuse the returned buffer without creating new buffer.
         // But this requires locking device to be compatible with smoltcp interface.
         let rx_pool = RX_BUFFER_POOL.get().unwrap();
         let new_rx_buffer = RxBuffer::new(size_of::<VirtioNetHdr>(), rx_pool).unwrap();
-        self.add_rx_buffer(new_rx_buffer)?;
+
+        self.add_rx_buffer(new_rx_buffer).unwrap();
+
         Ok(rx_buffer)
     }
 
@@ -202,10 +203,7 @@ impl NetworkDevice {
         )
         .unwrap();
 
-        let token = self
-            .send_queue
-            .add_input_bufs(&[&tx_buffer])
-            .map_err(queue_to_network_error)?;
+        let token = self.send_queue.add_input_bufs(&[&tx_buffer]).unwrap();
 
         self.poll_stat.sent_packet += 1;
 
@@ -266,15 +264,6 @@ impl NetworkDevice {
         }
 
         self.poll_stat.received_packet = 0;
-    }
-}
-
-fn queue_to_network_error(err: QueueError) -> NetError {
-    match err {
-        QueueError::NotReady => NetError::NotReady,
-        QueueError::WrongToken => NetError::WrongToken,
-        QueueError::BufferTooSmall => NetError::Busy,
-        _ => NetError::Unknown,
     }
 }
 

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -27,7 +27,7 @@ use crate::{
             handle_recv_irq, register_device,
         },
     },
-    queue::{QueueError, VirtQueue},
+    queue::VirtQueue,
     transport::VirtioTransport,
 };
 
@@ -74,7 +74,7 @@ impl SocketDevice {
         for i in 0..QUEUE_SIZE {
             let rx_pool = RX_BUFFER_POOL.get().unwrap();
             let rx_buffer = RxBuffer::new(size_of::<VirtioVsockHdr>(), rx_pool).unwrap();
-            let token = recv_queue.add_output_bufs(&[&rx_buffer])?;
+            let token = recv_queue.add_output_bufs(&[&rx_buffer]).unwrap();
             assert_eq!(i, token);
             assert_eq!(rx_buffers.put(rx_buffer) as u16, i);
         }
@@ -195,7 +195,10 @@ impl SocketDevice {
             TxBuffer::new(header, &mut VmReader::from(buffer).to_fallible(), tx_pool).unwrap()
         };
 
-        let token = self.send_queue.add_input_bufs(&[&tx_buffer])?;
+        let token = self
+            .send_queue
+            .add_input_bufs(&[&tx_buffer])
+            .map_err(|_| SocketError::QueueError)?;
 
         if self.send_queue.should_notify() {
             self.send_queue.notify();
@@ -207,10 +210,13 @@ impl SocketDevice {
         }
 
         // Pop out the buffer, so we can reuse the send queue further
-        let (pop_token, _) = self.send_queue.pop_used()?;
+        let (pop_token, _) = self
+            .send_queue
+            .pop_used()
+            .map_err(|_| SocketError::QueueError)?;
         debug_assert!(pop_token == token);
         if pop_token != token {
-            return Err(SocketError::QueueError(QueueError::WrongToken));
+            return Err(SocketError::QueueError);
         }
         debug!("send packet succeeds");
         Ok(())
@@ -264,7 +270,10 @@ impl SocketDevice {
         &mut self,
         // connection_info: &mut ConnectionInfo,
     ) -> Result<RxBuffer, SocketError> {
-        let (token, len) = self.recv_queue.pop_used()?;
+        let (token, len) = self
+            .recv_queue
+            .pop_used()
+            .map_err(|_| SocketError::QueueError)?;
         debug!(
             "receive packet in rx_queue: token = {}, len = {}",
             token, len
@@ -272,7 +281,7 @@ impl SocketDevice {
         let mut rx_buffer = self
             .rx_buffers
             .remove(token as usize)
-            .ok_or(QueueError::WrongToken)?;
+            .ok_or(SocketError::QueueError)?;
         rx_buffer.set_packet_len(len as usize);
 
         let rx_pool = RX_BUFFER_POOL.get().unwrap();
@@ -306,7 +315,10 @@ impl SocketDevice {
 
     /// Add a used rx buffer to recv queue,@index is only to check the correctness
     fn add_rx_buffer(&mut self, rx_buffer: RxBuffer, index: u16) -> Result<(), SocketError> {
-        let token = self.recv_queue.add_output_bufs(&[&rx_buffer])?;
+        let token = self
+            .recv_queue
+            .add_output_bufs(&[&rx_buffer])
+            .map_err(|_| SocketError::QueueError)?;
         assert_eq!(index, token);
         assert!(self.rx_buffers.put_at(token as usize, rx_buffer).is_none());
         if self.recv_queue.should_notify() {

--- a/kernel/comps/virtio/src/device/socket/error.rs
+++ b/kernel/comps/virtio/src/device/socket/error.rs
@@ -27,8 +27,6 @@
 //
 use core::{fmt, result};
 
-use crate::queue::QueueError;
-
 /// The error type of VirtIO socket driver.
 #[derive(Debug)]
 pub enum SocketError {
@@ -61,13 +59,7 @@ pub enum SocketError {
     /// Recycled a wrong buffer.
     RecycledWrongBuffer,
     /// Queue Error
-    QueueError(QueueError),
-}
-
-impl From<QueueError> for SocketError {
-    fn from(value: QueueError) -> Self {
-        Self::QueueError(value)
-    }
+    QueueError,
 }
 
 impl From<int_to_c_enum::TryFromIntError> for SocketError {
@@ -116,7 +108,7 @@ impl fmt::Display for SocketError {
                 write!(f, "Peer has insufficient buffer space, try again later")
             }
             Self::RecycledWrongBuffer => write!(f, "Recycled a wrong buffer"),
-            Self::QueueError(_) => write!(f, "Error encountered out of vsock itself!"),
+            Self::QueueError => write!(f, "Error encountered out of vsock itself!"),
         }
     }
 }

--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -36,7 +36,7 @@ macro_rules! __log_prefix {
 pub mod device;
 mod dma_buf;
 mod id_alloc;
-pub mod queue;
+mod queue;
 mod transport;
 
 static VIRTIO_BLOCK_MAJOR_ID: Once<MajorIdOwner> = Once::new();

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -184,6 +184,16 @@ impl VirtQueue {
         })
     }
 
+    /// Adds only input DMA buffers to the virtqueue and returns a token.
+    pub fn add_input_bufs<I: DmaBuf>(&mut self, inputs: &[&I]) -> Result<u16, QueueError> {
+        self.add_dma_bufs(inputs, &[] as &[&I])
+    }
+
+    /// Adds only output DMA buffers to the virtqueue and returns a token.
+    pub fn add_output_bufs<O: DmaBuf>(&mut self, outputs: &[&O]) -> Result<u16, QueueError> {
+        self.add_dma_bufs(&[] as &[&O], outputs)
+    }
+
     /// Adds input and output DMA buffers to the virtqueue and returns a token.
     ///
     /// Ref: linux virtio_ring.c virtqueue_add
@@ -199,8 +209,9 @@ impl VirtQueue {
             return Err(QueueError::BufferTooSmall);
         }
 
-        // Allocate descriptors from the free list.
         let head = self.free_head;
+
+        // Allocate descriptors from the free list.
         let mut last = self.free_head;
         for input in inputs.iter() {
             let desc = &self.descs[self.free_head as usize];
@@ -234,9 +245,8 @@ impl VirtQueue {
         }
         self.num_used += (inputs.len() + outputs.len()) as u16;
 
-        let avail_slot = self.avail_idx & (self.device_queue_size - 1);
-
         {
+            let avail_slot = self.avail_idx & (self.device_queue_size - 1);
             let ring_ptr: SafePtr<[u16; 64], &Arc<DmaCoherent>> =
                 field_ptr!(&self.avail, AvailRing, ring);
             let mut ring_slot_ptr = ring_ptr.cast::<u16>();
@@ -251,19 +261,10 @@ impl VirtQueue {
         field_ptr!(&self.avail, AvailRing, idx)
             .write_once(&self.avail_idx)
             .unwrap();
-
+        // Write barrier.
         fence(Ordering::SeqCst);
+
         Ok(head)
-    }
-
-    /// Adds only input DMA buffers to the virtqueue and returns a token.
-    pub fn add_input_bufs<I: DmaBuf>(&mut self, inputs: &[&I]) -> Result<u16, QueueError> {
-        self.add_dma_bufs(inputs, &[] as &[&I])
-    }
-
-    /// Adds only output DMA buffers to the virtqueue and returns a token.
-    pub fn add_output_bufs<O: DmaBuf>(&mut self, outputs: &[&O]) -> Result<u16, QueueError> {
-        self.add_dma_bufs(&[] as &[&O], outputs)
     }
 
     /// Returns whether there is a used element that can pop.
@@ -279,12 +280,36 @@ impl VirtQueue {
         self.descs.len() - self.num_used as usize
     }
 
+    /// Pops a device-used buffer and returns the token and the buffer length.
+    ///
+    /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
+    pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError> {
+        if !self.can_pop() {
+            return Err(QueueError::NotReady);
+        }
+
+        let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);
+        let element_ptr = {
+            let mut ptr = self.used.borrow_vm();
+            ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);
+            ptr.cast::<UsedElem>()
+        };
+        let index = field_ptr!(&element_ptr, UsedElem, id).read_once().unwrap();
+        let len = field_ptr!(&element_ptr, UsedElem, len).read_once().unwrap();
+
+        self.recycle_descriptors(index as u16);
+        self.last_used_idx = self.last_used_idx.wrapping_add(1);
+
+        Ok((index as u16, len))
+    }
+
     /// Recycles descriptors in the list specified by `head`.
     ///
     /// This will push all linked descriptors at the front of the free list.
     fn recycle_descriptors(&mut self, mut head: u16) {
         let origin_free_head = self.free_head;
         self.free_head = head;
+
         loop {
             let desc = &mut self.descs[head as usize];
             // Set the buffer address and length to 0.
@@ -309,29 +334,6 @@ impl VirtQueue {
                 break;
             }
         }
-    }
-
-    /// Pops a device-used buffer and returns the token and the buffer length.
-    ///
-    /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
-    pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError> {
-        if !self.can_pop() {
-            return Err(QueueError::NotReady);
-        }
-
-        let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);
-        let element_ptr = {
-            let mut ptr = self.used.borrow_vm();
-            ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);
-            ptr.cast::<UsedElem>()
-        };
-        let index = field_ptr!(&element_ptr, UsedElem, id).read_once().unwrap();
-        let len = field_ptr!(&element_ptr, UsedElem, len).read_once().unwrap();
-
-        self.recycle_descriptors(index as u16);
-        self.last_used_idx = self.last_used_idx.wrapping_add(1);
-
-        Ok((index as u16, len))
     }
 
     /// Returns whether the driver should notify the device.

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -35,7 +35,7 @@ pub enum QueueError {
 #[derive(Debug)]
 pub struct VirtQueue {
     /// Descriptor table
-    descs: Vec<SafePtr<Descriptor, Arc<DmaCoherent>>>,
+    descs: Vec<DescriptorSlot>,
     /// Available ring
     avail: SafePtr<AvailRing, Arc<DmaCoherent>>,
     /// Used ring
@@ -56,13 +56,34 @@ pub struct VirtQueue {
     /// The number of used descriptors.
     num_used: u16,
     /// The head descriptor index of the free list.
-    free_head: u16,
+    free_head: Option<u16>,
     /// The next avail ring index.
     avail_idx: u16,
     /// The last-served used ring index.
     last_used_idx: u16,
     /// Whether the callback of this queue is enabled.
     is_callback_enabled: bool,
+}
+
+#[derive(Debug)]
+struct DescriptorSlot {
+    /// The device-visible descriptor stored in DMA-coherent memory.
+    ///
+    /// This memory is shared with the device, so descriptor contents read from it
+    /// may be stale, corrupted, or otherwise untrusted after device access.
+    ptr: SafePtr<Descriptor, Arc<DmaCoherent>>,
+
+    /// The next descriptor in the current driver-managed list.
+    ///
+    /// For an in-use descriptor, this links to the next descriptor in the same
+    /// device-visible buffer chain. For a free descriptor, this links to the next
+    /// descriptor in the free list.
+    next: Option<u16>,
+    /// The total output buffer length for an in-use descriptor chain.
+    ///
+    /// This is set only on the head descriptor of an in-use chain. It records the
+    /// total number of bytes covered by all descriptors in that chain.
+    len: Option<u32>,
 }
 
 impl VirtQueue {
@@ -146,21 +167,24 @@ impl VirtQueue {
             .unwrap();
 
         let mut descs = Vec::with_capacity(size as usize);
-        descs.push(descriptor_ptr);
-        for i in 0..size {
-            let mut desc = descs.get(i as usize).unwrap().clone();
-            let next_i = i + 1;
-            if next_i != size {
-                field_ptr!(&desc, Descriptor, next)
-                    .write_once(&next_i)
-                    .unwrap();
-                desc.add(1);
-                descs.push(desc);
-            } else {
-                field_ptr!(&desc, Descriptor, next)
-                    .write_once(&(0u16))
-                    .unwrap();
-            }
+        descs.push(DescriptorSlot {
+            ptr: descriptor_ptr,
+            next: None,
+            len: None,
+        });
+        for i in 0..size - 1 {
+            let last_desc = &mut descs[i as usize];
+            let new_desc = {
+                let mut ptr = last_desc.ptr.clone();
+                ptr.add(1);
+                DescriptorSlot {
+                    ptr,
+                    next: None,
+                    len: None,
+                }
+            };
+            last_desc.next = Some(i + 1);
+            descs.push(new_desc);
         }
 
         let notify_config = transport.notify_config(idx as usize);
@@ -177,7 +201,7 @@ impl VirtQueue {
             device_queue_size,
             queue_idx: idx as u32,
             num_used: 0,
-            free_head: 0,
+            free_head: Some(0),
             avail_idx: 0,
             last_used_idx: 0,
             is_callback_enabled: true,
@@ -185,16 +209,35 @@ impl VirtQueue {
     }
 
     /// Adds only input DMA buffers to the virtqueue and returns a token.
+    ///
+    /// See [`Self::add_dma_bufs`] for more information about the result.
     pub fn add_input_bufs<I: DmaBuf>(&mut self, inputs: &[&I]) -> Result<u16, QueueError> {
         self.add_dma_bufs(inputs, &[] as &[&I])
     }
 
     /// Adds only output DMA buffers to the virtqueue and returns a token.
+    ///
+    /// See [`Self::add_dma_bufs`] for more information about the result.
     pub fn add_output_bufs<O: DmaBuf>(&mut self, outputs: &[&O]) -> Result<u16, QueueError> {
         self.add_dma_bufs(&[] as &[&O], outputs)
     }
 
     /// Adds input and output DMA buffers to the virtqueue and returns a token.
+    ///
+    /// When successful, the result token is guaranteed to be valid. It will not exceed the queue
+    /// size, and the same token will not be returned twice, unless it has been removed from the
+    /// queue by [`Self::pop_used`] in the meantime.
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if:
+    /// - both `inputs` and `outputs` are empty; or
+    /// - the queue does not have enough free descriptors, that is, [`Self::available_desc`] is
+    ///   smaller than `inputs.len() + outputs.len()`.
+    ///
+    /// If at least one buffer is provided and enough descriptors are available, this method is
+    /// guaranteed to succeed. Callers that have already checked these conditions may unwrap the
+    /// result.
     ///
     /// Ref: linux virtio_ring.c virtqueue_add
     pub fn add_dma_bufs<I: DmaBuf, O: DmaBuf>(
@@ -209,41 +252,63 @@ impl VirtQueue {
             return Err(QueueError::BufferTooSmall);
         }
 
-        let head = self.free_head;
+        let head = self.free_head.unwrap();
+        let mut output_len = 0;
 
         // Allocate descriptors from the free list.
         let mut last = self.free_head;
+        let mut current = self.free_head;
         for input in inputs.iter() {
-            let desc = &self.descs[self.free_head as usize];
-            set_dma_buf(&desc.borrow_vm().restrict::<TRights![Write, Dup]>(), *input);
-            field_ptr!(desc, Descriptor, flags)
+            let desc = &self.descs[current.unwrap() as usize];
+            set_dma_buf(
+                &desc.ptr.borrow_vm().restrict::<TRights![Write, Dup]>(),
+                *input,
+            );
+            field_ptr!(&desc.ptr, Descriptor, flags)
                 .write_once(&DescFlags::NEXT)
                 .unwrap();
-            last = self.free_head;
-            self.free_head = field_ptr!(desc, Descriptor, next).read_once().unwrap();
+            if let Some(next) = desc.next {
+                field_ptr!(&desc.ptr, Descriptor, next)
+                    .write_once(&next)
+                    .unwrap();
+            }
+            last = current;
+            current = desc.next;
         }
         for output in outputs.iter() {
-            let desc = &mut self.descs[self.free_head as usize];
-            set_dma_buf(
-                &desc.borrow_vm().restrict::<TRights![Write, Dup]>(),
+            let desc = &self.descs[current.unwrap() as usize];
+            output_len += set_dma_buf(
+                &desc.ptr.borrow_vm().restrict::<TRights![Write, Dup]>(),
                 *output,
             );
-            field_ptr!(desc, Descriptor, flags)
+            field_ptr!(&desc.ptr, Descriptor, flags)
                 .write_once(&(DescFlags::NEXT | DescFlags::WRITE))
                 .unwrap();
-            last = self.free_head;
-            self.free_head = field_ptr!(desc, Descriptor, next).read_once().unwrap();
+            if let Some(next) = desc.next {
+                field_ptr!(&desc.ptr, Descriptor, next)
+                    .write_once(&next)
+                    .unwrap();
+            }
+            last = current;
+            current = desc.next;
         }
         // Clear `DescFlags::NEXT` in the last descriptor.
         {
-            let desc = &mut self.descs[last as usize];
-            let mut flags: DescFlags = field_ptr!(desc, Descriptor, flags).read_once().unwrap();
+            let desc = &mut self.descs[last.unwrap() as usize];
+            self.free_head = desc.next;
+            desc.next = None;
+            let mut flags: DescFlags = field_ptr!(&desc.ptr, Descriptor, flags)
+                .read_once()
+                .unwrap();
             flags.remove(DescFlags::NEXT);
-            field_ptr!(desc, Descriptor, flags)
+            field_ptr!(&desc.ptr, Descriptor, flags)
                 .write_once(&flags)
                 .unwrap();
         }
+        // Update the number of used descriptors.
         self.num_used += (inputs.len() + outputs.len()) as u16;
+        // Store the length of the DMA buffer in the first descriptor.
+        self.descs[head as usize].len = Some(output_len);
 
         {
             let avail_slot = self.avail_idx & (self.device_queue_size - 1);
@@ -268,6 +333,9 @@ impl VirtQueue {
     }
 
     /// Returns whether there is a used element that can pop.
+    ///
+    /// Even if this method returns true, [`Self::pop_used`] can still return `None`. See the note
+    /// about malfunctioning devices in [`Self::pop_used`] for details.
     pub fn can_pop(&self) -> bool {
         // Read barrier.
         fence(Ordering::SeqCst);
@@ -282,25 +350,78 @@ impl VirtQueue {
 
     /// Pops a device-used buffer and returns the token and the buffer length.
     ///
+    /// When successful, the following is guaranteed:
+    /// - The token is valid.  It will not exceed the queue size. It was previously returned by
+    ///   [`Self::add_dma_bufs`], [`Self::add_input_bufs`], or [`Self::add_output_bufs`], and it has
+    ///   not yet been removed from the queue by this method.
+    /// - The length is valid. It will not exceed the length of the original DMA buffer.
+    ///
+    /// If the device malfunctions, it may report a token or length that violates these guarantees.
+    /// Such reports are logged as errors and ignored; the reported token is not returned to the
+    /// caller, preventing an invalid token from corrupting upper-layer state. If the device
+    /// continues to malfunction, the queue may become stuck because the affected buffer cannot be
+    /// reclaimed.
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if no valid buffers can be popped. Note that this can occur
+    /// even if [`Self::can_pop`] returns true because [`Self::can_pop`] does not check validity.
+    ///
     /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
     pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError> {
-        if !self.can_pop() {
-            return Err(QueueError::NotReady);
+        self.pop_used_with_min_bytes(0)
+    }
+
+    /// Pops a device-used buffer, which is expected to contain at least `min_bytes` bytes, and
+    /// returns the token and the buffer length.
+    ///
+    /// This is the same as [`Self::pop_used`], except it also guarantees that the used buffer is at
+    /// least `min_bytes` bytes. The note about malfunctioning devices in [`Self::pop_used`] applies
+    /// here as well, including extra cases where the used buffer is shorter than `min_bytes`.
+    ///
+    /// For more information, see [`Self::pop_used`].
+    pub fn pop_used_with_min_bytes(&mut self, min_bytes: usize) -> Result<(u16, u32), QueueError> {
+        loop {
+            if !self.can_pop() {
+                return Err(QueueError::NotReady);
+            }
+
+            let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);
+            let element_ptr = {
+                let mut ptr = self.used.borrow_vm();
+                ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);
+                ptr.cast::<UsedElem>()
+            };
+            let index = field_ptr!(&element_ptr, UsedElem, id).read_once().unwrap();
+            let len = field_ptr!(&element_ptr, UsedElem, len).read_once().unwrap();
+            self.last_used_idx = self.last_used_idx.wrapping_add(1);
+
+            let (desc, dma_len) = if let Some(desc) = self.descs.get_mut(index as usize)
+                && let Some(dma_len) = desc.len
+            {
+                (desc, dma_len)
+            } else {
+                ostd::error!(
+                    "invalid used token: {} (queue size: {})",
+                    index,
+                    self.descs.len(),
+                );
+                continue;
+            };
+            if len > dma_len || (len as usize) < min_bytes {
+                ostd::error!(
+                    "invalid used length: {} (expected {}..={})",
+                    len,
+                    min_bytes,
+                    dma_len,
+                );
+                continue;
+            }
+            desc.len = None;
+            self.recycle_descriptors(index as u16);
+
+            return Ok((index as u16, len));
         }
-
-        let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);
-        let element_ptr = {
-            let mut ptr = self.used.borrow_vm();
-            ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);
-            ptr.cast::<UsedElem>()
-        };
-        let index = field_ptr!(&element_ptr, UsedElem, id).read_once().unwrap();
-        let len = field_ptr!(&element_ptr, UsedElem, len).read_once().unwrap();
-
-        self.recycle_descriptors(index as u16);
-        self.last_used_idx = self.last_used_idx.wrapping_add(1);
-
-        Ok((index as u16, len))
     }
 
     /// Recycles descriptors in the list specified by `head`.
@@ -308,29 +429,23 @@ impl VirtQueue {
     /// This will push all linked descriptors at the front of the free list.
     fn recycle_descriptors(&mut self, mut head: u16) {
         let origin_free_head = self.free_head;
-        self.free_head = head;
+        self.free_head = Some(head);
 
         loop {
             let desc = &mut self.descs[head as usize];
             // Set the buffer address and length to 0.
-            field_ptr!(desc, Descriptor, addr)
+            field_ptr!(&desc.ptr, Descriptor, addr)
                 .write_once(&(0u64))
                 .unwrap();
-            field_ptr!(desc, Descriptor, len)
+            field_ptr!(&desc.ptr, Descriptor, len)
                 .write_once(&(0u32))
                 .unwrap();
             self.num_used -= 1;
 
-            let flags: DescFlags = field_ptr!(desc, Descriptor, flags).read_once().unwrap();
-            if flags.contains(DescFlags::NEXT) {
-                field_ptr!(desc, Descriptor, flags)
-                    .write_once(&DescFlags::empty())
-                    .unwrap();
-                head = field_ptr!(desc, Descriptor, next).read_once().unwrap();
+            if let Some(next) = desc.next {
+                head = next;
             } else {
-                field_ptr!(desc, Descriptor, next)
-                    .write_once(&origin_free_head)
-                    .unwrap();
+                desc.next = origin_free_head;
                 break;
             }
         }
@@ -404,17 +519,22 @@ pub struct Descriptor {
 
 type DescriptorPtr<'a> = SafePtr<Descriptor, &'a Arc<DmaCoherent>, TRightSet<TRights![Dup, Write]>>;
 
-fn set_dma_buf<T: DmaBuf>(desc_ptr: &DescriptorPtr, buf: &T) {
-    // TODO: Should we skip the empty DMA buffer or just return an error?
-    debug_assert_ne!(buf.len(), 0);
-
+fn set_dma_buf<T: DmaBuf>(desc_ptr: &DescriptorPtr, buf: &T) -> u32 {
     let daddr = buf.daddr();
+    let len = buf.len();
+
+    debug_assert!(len < (u32::MAX) as usize);
+    // TODO: Should we skip the empty DMA buffer or just return an error?
+    debug_assert_ne!(len, 0);
+
     field_ptr!(desc_ptr, Descriptor, addr)
         .write_once(&(daddr as u64))
         .unwrap();
     field_ptr!(desc_ptr, Descriptor, len)
-        .write_once(&(buf.len() as u32))
+        .write_once(&(len as u32))
         .unwrap();
+
+    len as u32
 }
 
 bitflags! {

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -43,27 +43,27 @@ pub struct VirtQueue {
     /// Notify configuration manager
     notify_config: ConfigManager<u32>,
 
-    /// The index of queue
+    /// The index of the queue.
     queue_idx: u32,
     /// The size of the queue.
     ///
     /// This is both the number of descriptors, and the number of slots in the available and used
     /// rings.
     queue_size: u16,
-    /// The number of used queues.
+    /// The number of used descriptors.
     num_used: u16,
-    /// The head desc index of the free list.
+    /// The head descriptor index of the free list.
     free_head: u16,
-    /// the index of the next avail ring index
+    /// The next avail ring index.
     avail_idx: u16,
-    /// last service used index
+    /// The last-served used ring index.
     last_used_idx: u16,
-    /// Whether the callback of this queue is enabled
+    /// Whether the callback of this queue is enabled.
     is_callback_enabled: bool,
 }
 
 impl VirtQueue {
-    /// Create a new VirtQueue.
+    /// Creates a new virtqueue.
     pub(crate) fn new(
         idx: u16,
         mut size: u16,
@@ -156,7 +156,7 @@ impl VirtQueue {
         })
     }
 
-    /// Add dma buffers to the virtqueue, return a token.
+    /// Adds input and output DMA buffers to the virtqueue and returns a token.
     ///
     /// Ref: linux virtio_ring.c virtqueue_add
     pub fn add_dma_bufs<I: DmaBuf, O: DmaBuf>(
@@ -171,7 +171,7 @@ impl VirtQueue {
             return Err(QueueError::BufferTooSmall);
         }
 
-        // allocate descriptors from free list
+        // Allocate descriptors from the free list.
         let head = self.free_head;
         let mut last = self.free_head;
         for input in inputs.iter() {
@@ -195,7 +195,7 @@ impl VirtQueue {
             last = self.free_head;
             self.free_head = field_ptr!(desc, Descriptor, next).read_once().unwrap();
         }
-        // set last_elem.next = NULL
+        // Clear `DescFlags::NEXT` in the last descriptor.
         {
             let desc = &mut self.descs[last as usize];
             let mut flags: DescFlags = field_ptr!(desc, Descriptor, flags).read_once().unwrap();
@@ -215,10 +215,10 @@ impl VirtQueue {
             ring_slot_ptr.add(avail_slot as usize);
             ring_slot_ptr.write_once(&head).unwrap();
         }
-        // write barrier
+        // Write barrier.
         fence(Ordering::SeqCst);
 
-        // increase head of avail ring
+        // Increase the head index of the avail ring.
         self.avail_idx = self.avail_idx.wrapping_add(1);
         field_ptr!(&self.avail, AvailRing, idx)
             .write_once(&self.avail_idx)
@@ -238,20 +238,20 @@ impl VirtQueue {
         self.add_dma_bufs(&[] as &[&O], outputs)
     }
 
-    /// Whether there is a used element that can pop.
+    /// Returns whether there is a used element that can pop.
     pub fn can_pop(&self) -> bool {
-        // read barrier
+        // Read barrier.
         fence(Ordering::SeqCst);
 
         self.last_used_idx != field_ptr!(&self.used, UsedRing, idx).read_once().unwrap()
     }
 
-    /// The number of free descriptors.
+    /// Returns the number of free descriptors.
     pub fn available_desc(&self) -> usize {
         (self.queue_size - self.num_used) as usize
     }
 
-    /// Recycle descriptors in the list specified by head.
+    /// Recycles descriptors in the list specified by `head`.
     ///
     /// This will push all linked descriptors at the front of the free list.
     fn recycle_descriptors(&mut self, mut head: u16) {
@@ -259,7 +259,7 @@ impl VirtQueue {
         self.free_head = head;
         loop {
             let desc = &mut self.descs[head as usize];
-            // Sets the buffer address and length to 0
+            // Set the buffer address and length to 0.
             field_ptr!(desc, Descriptor, addr)
                 .write_once(&(0u64))
                 .unwrap();
@@ -283,7 +283,7 @@ impl VirtQueue {
         }
     }
 
-    /// Get a token from device used buffers, return (token, len).
+    /// Pops a device-used buffer and returns the token and the buffer length.
     ///
     /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
     pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError> {
@@ -306,15 +306,16 @@ impl VirtQueue {
         Ok((index as u16, len))
     }
 
-    /// whether the driver should notify the device
+    /// Returns whether the driver should notify the device.
     pub fn should_notify(&self) -> bool {
-        // read barrier
+        // Read barrier.
         fence(Ordering::SeqCst);
+
         let flags = field_ptr!(&self.used, UsedRing, flags).read_once().unwrap();
         flags & 0x0001u16 == 0u16
     }
 
-    /// notify that there are available rings
+    /// Notifies the device that there are available elements.
     pub fn notify(&mut self) {
         if self.notify_config.is_modern() {
             self.notify_config
@@ -374,8 +375,9 @@ pub struct Descriptor {
 type DescriptorPtr<'a> = SafePtr<Descriptor, &'a Arc<DmaCoherent>, TRightSet<TRights![Dup, Write]>>;
 
 fn set_dma_buf<T: DmaBuf>(desc_ptr: &DescriptorPtr, buf: &T) {
-    // TODO: skip the empty dma buffer or just return error?
+    // TODO: Should we skip the empty DMA buffer or just return an error?
     debug_assert_ne!(buf.len(), 0);
+
     let daddr = buf.daddr();
     field_ptr!(desc_ptr, Descriptor, addr)
         .write_once(&(daddr as u64))
@@ -386,7 +388,7 @@ fn set_dma_buf<T: DmaBuf>(desc_ptr: &DescriptorPtr, buf: &T) {
 }
 
 bitflags! {
-    /// Descriptor flags
+    /// Descriptor flags.
     #[repr(C)]
     #[derive(Default, Pod)]
     struct DescFlags: u16 {
@@ -411,15 +413,14 @@ pub struct AvailRing {
     used_event: u16, // unused
 }
 
-/// The used ring is where the device returns buffers once it is done with them:
-/// it is only written to by the device, and read by the driver.
+/// The used ring is where the device returns buffers once it is done with them.
+/// It is only written to by the device and read by the driver.
 #[padding_struct]
 #[repr(C, align(4))]
 #[derive(Clone, Copy, Debug, Pod)]
 pub struct UsedRing {
-    // the flag in UsedRing
     flags: u16,
-    // the next index of the used element in ring array
+    /// The next index of the used element in the ring array.
     idx: u16,
     ring: [UsedElem; 64], // actual size: queue_size
     avail_event: u16,     // unused
@@ -433,11 +434,11 @@ pub struct UsedElem {
 }
 
 bitflags! {
-    /// The flags useds in [`AvailRing`]
+    /// The flags used in [`AvailRing`].
     #[repr(C)]
     #[derive(Pod)]
-    pub struct AvailFlags: u16 {
-        /// The flag used to disable virt queue interrupt
+    struct AvailFlags: u16 {
+        /// The flag used to disable virtqueue interrupts.
         const VIRTQ_AVAIL_F_NO_INTERRUPT = 1;
     }
 }

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -21,14 +21,6 @@ use crate::{
     transport::{ConfigManager, VirtioTransport, pci::legacy::VirtioPciLegacyTransport},
 };
 
-#[derive(Debug)]
-pub enum QueueError {
-    InvalidArgs,
-    BufferTooSmall,
-    NotReady,
-    WrongToken,
-}
-
 /// The mechanism for bulk data transport on virtio devices.
 ///
 /// Each device can have zero or more virtqueues.
@@ -65,6 +57,26 @@ pub struct VirtQueue {
     is_callback_enabled: bool,
 }
 
+/// An error returned by [`VirtQueue::new`].
+#[derive(Debug)]
+pub(crate) enum CreationError {
+    InvalidArgs,
+    ResourceAlloc(ostd::Error),
+}
+
+/// An error returned by [`VirtQueue::add_dma_bufs`] and its friends.
+#[derive(Debug)]
+pub enum AddBufsError {
+    InvalidArgs,
+    BufferTooSmall,
+}
+
+/// An error returned by [`VirtQueue::pop_used`] and its friends.
+#[derive(Debug)]
+pub enum PopUsedError {
+    NotReady,
+}
+
 #[derive(Debug)]
 struct DescriptorSlot {
     /// The device-visible descriptor stored in DMA-coherent memory.
@@ -92,65 +104,71 @@ impl VirtQueue {
         idx: u16,
         size: u16,
         transport: &mut dyn VirtioTransport,
-    ) -> Result<Self, QueueError> {
+    ) -> Result<Self, CreationError> {
         if !size.is_power_of_two() {
-            return Err(QueueError::InvalidArgs);
+            return Err(CreationError::InvalidArgs);
         }
 
-        let (descriptor_ptr, avail_ring_ptr, used_ring_ptr, device_queue_size) =
-            if transport.is_legacy_version() {
-                let device_queue_size = transport.max_queue_size(idx).unwrap() as usize;
-                let desc_size = size_of::<Descriptor>() * device_queue_size;
+        let (descriptor_ptr, avail_ring_ptr, used_ring_ptr, device_queue_size) = if transport
+            .is_legacy_version()
+        {
+            let device_queue_size = transport.max_queue_size(idx).unwrap() as usize;
+            let desc_size = size_of::<Descriptor>() * device_queue_size;
 
-                // We should establish a reasonable upper bound on the requested queue size from the
-                // device, but we are unsure of the exact value. We chose 1024 based on the current
-                // need, but it can be increased in the future if necessary.
-                if !device_queue_size.is_power_of_two()
-                    || size as usize > device_queue_size
-                    || device_queue_size > 1024
-                {
-                    return Err(QueueError::InvalidArgs);
-                }
+            // We should establish a reasonable upper bound on the requested queue size from the
+            // device, but we are unsure of the exact value. We chose 1024 based on the current
+            // need, but it can be increased in the future if necessary.
+            if !device_queue_size.is_power_of_two()
+                || size as usize > device_queue_size
+                || device_queue_size > 1024
+            {
+                return Err(CreationError::InvalidArgs);
+            }
 
-                let (dma1, dma2) = {
-                    let align_size = VirtioPciLegacyTransport::QUEUE_ALIGN_SIZE;
-                    let total_frames =
-                        VirtioPciLegacyTransport::calc_virtqueue_size_aligned(device_queue_size)
-                            / align_size;
-                    let dma = DmaCoherent::alloc(total_frames, true).unwrap();
+            let (dma1, dma2) = {
+                let align_size = VirtioPciLegacyTransport::QUEUE_ALIGN_SIZE;
+                let total_frames =
+                    VirtioPciLegacyTransport::calc_virtqueue_size_aligned(device_queue_size)
+                        / align_size;
+                let dma =
+                    DmaCoherent::alloc(total_frames, true).map_err(CreationError::ResourceAlloc)?;
 
-                    let avial_size = size_of::<u16>() * (3 + device_queue_size);
-                    let seg1_frames = (desc_size + avial_size).div_ceil(align_size);
+                let avail_size = size_of::<u16>() * (3 + device_queue_size);
+                let seg1_frames = (desc_size + avail_size).div_ceil(align_size);
 
-                    dma.split(seg1_frames * align_size)
-                };
-
-                let desc_frame_ptr: SafePtr<Descriptor, Arc<DmaCoherent>> =
-                    SafePtr::new(Arc::new(dma1), 0);
-                let mut avail_frame_ptr: SafePtr<AvailRing, Arc<DmaCoherent>> =
-                    desc_frame_ptr.clone().cast();
-                avail_frame_ptr.byte_add(desc_size);
-                let used_frame_ptr: SafePtr<UsedRing, Arc<DmaCoherent>> =
-                    SafePtr::new(Arc::new(dma2), 0);
-
-                (
-                    desc_frame_ptr,
-                    avail_frame_ptr,
-                    used_frame_ptr,
-                    device_queue_size as u16,
-                )
-            } else {
-                if size > 256 {
-                    return Err(QueueError::InvalidArgs);
-                }
-
-                (
-                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-                    size,
-                )
+                dma.split(seg1_frames * align_size)
             };
+
+            let desc_frame_ptr: SafePtr<Descriptor, Arc<DmaCoherent>> =
+                SafePtr::new(Arc::new(dma1), 0);
+            let mut avail_frame_ptr: SafePtr<AvailRing, Arc<DmaCoherent>> =
+                desc_frame_ptr.clone().cast();
+            avail_frame_ptr.byte_add(desc_size);
+            let used_frame_ptr: SafePtr<UsedRing, Arc<DmaCoherent>> =
+                SafePtr::new(Arc::new(dma2), 0);
+
+            (
+                desc_frame_ptr,
+                avail_frame_ptr,
+                used_frame_ptr,
+                device_queue_size as u16,
+            )
+        } else {
+            if size > 256 {
+                return Err(CreationError::InvalidArgs);
+            }
+
+            let desc_frame = DmaCoherent::alloc(1, true).map_err(CreationError::ResourceAlloc)?;
+            let avail_frame = DmaCoherent::alloc(1, true).map_err(CreationError::ResourceAlloc)?;
+            let used_frame = DmaCoherent::alloc(1, true).map_err(CreationError::ResourceAlloc)?;
+
+            (
+                SafePtr::new(Arc::new(desc_frame), 0),
+                SafePtr::new(Arc::new(avail_frame), 0),
+                SafePtr::new(Arc::new(used_frame), 0),
+                size,
+            )
+        };
 
         debug!("queue_desc start paddr:{:x?}", descriptor_ptr.paddr());
         debug!("queue_driver start paddr:{:x?}", avail_ring_ptr.paddr());
@@ -211,14 +229,14 @@ impl VirtQueue {
     /// Adds only input DMA buffers to the virtqueue and returns a token.
     ///
     /// See [`Self::add_dma_bufs`] for more information about the result.
-    pub fn add_input_bufs<I: DmaBuf>(&mut self, inputs: &[&I]) -> Result<u16, QueueError> {
+    pub fn add_input_bufs<I: DmaBuf>(&mut self, inputs: &[&I]) -> Result<u16, AddBufsError> {
         self.add_dma_bufs(inputs, &[] as &[&I])
     }
 
     /// Adds only output DMA buffers to the virtqueue and returns a token.
     ///
     /// See [`Self::add_dma_bufs`] for more information about the result.
-    pub fn add_output_bufs<O: DmaBuf>(&mut self, outputs: &[&O]) -> Result<u16, QueueError> {
+    pub fn add_output_bufs<O: DmaBuf>(&mut self, outputs: &[&O]) -> Result<u16, AddBufsError> {
         self.add_dma_bufs(&[] as &[&O], outputs)
     }
 
@@ -244,12 +262,12 @@ impl VirtQueue {
         &mut self,
         inputs: &[&I],
         outputs: &[&O],
-    ) -> Result<u16, QueueError> {
+    ) -> Result<u16, AddBufsError> {
         if inputs.is_empty() && outputs.is_empty() {
-            return Err(QueueError::InvalidArgs);
+            return Err(AddBufsError::InvalidArgs);
         }
         if inputs.len() + outputs.len() > self.available_desc() {
-            return Err(QueueError::BufferTooSmall);
+            return Err(AddBufsError::BufferTooSmall);
         }
 
         let head = self.free_head.unwrap();
@@ -368,7 +386,7 @@ impl VirtQueue {
     /// even if [`Self::can_pop`] returns true because [`Self::can_pop`] does not check validity.
     ///
     /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
-    pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError> {
+    pub fn pop_used(&mut self) -> Result<(u16, u32), PopUsedError> {
         self.pop_used_with_min_bytes(0)
     }
 
@@ -380,10 +398,13 @@ impl VirtQueue {
     /// here as well, including extra cases where the used buffer is shorter than `min_bytes`.
     ///
     /// For more information, see [`Self::pop_used`].
-    pub fn pop_used_with_min_bytes(&mut self, min_bytes: usize) -> Result<(u16, u32), QueueError> {
+    pub fn pop_used_with_min_bytes(
+        &mut self,
+        min_bytes: usize,
+    ) -> Result<(u16, u32), PopUsedError> {
         loop {
             if !self.can_pop() {
-                return Err(QueueError::NotReady);
+                return Err(PopUsedError::NotReady);
             }
 
             let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -154,7 +154,10 @@ impl VirtQueue {
                 device_queue_size as u16,
             )
         } else {
-            if size > 256 {
+            let max_queue_size = transport.max_queue_size(idx).unwrap() as usize;
+
+            // There can be a maximum of 256 descriptors on one page.
+            if size as usize > max_queue_size || size > 256 {
                 return Err(CreationError::InvalidArgs);
             }
 

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -45,11 +45,14 @@ pub struct VirtQueue {
 
     /// The index of the queue.
     queue_idx: u32,
-    /// The size of the queue.
+    /// The size of the queue as seen by the device.
     ///
-    /// This is both the number of descriptors, and the number of slots in the available and used
-    /// rings.
-    queue_size: u16,
+    /// This is the number of slots in the available and used rings. It can be larger than the
+    /// number of descriptors if the device expects a larger queue, but the driver expects a smaller
+    /// one.
+    ///
+    /// This is _not_ the queue size specified by the driver, which is `desc.len()`.
+    device_queue_size: u16,
     /// The number of used descriptors.
     num_used: u16,
     /// The head descriptor index of the free list.
@@ -66,59 +69,82 @@ impl VirtQueue {
     /// Creates a new virtqueue.
     pub(crate) fn new(
         idx: u16,
-        mut size: u16,
+        size: u16,
         transport: &mut dyn VirtioTransport,
     ) -> Result<Self, QueueError> {
         if !size.is_power_of_two() {
             return Err(QueueError::InvalidArgs);
         }
 
-        let (descriptor_ptr, avail_ring_ptr, used_ring_ptr) = if transport.is_legacy_version() {
-            // Currently, we use one UFrame to place the descriptors and available rings, one UFrame to place used rings
-            // because the virtio-mmio legacy required the address to be continuous. The max queue size is 128.
-            if size > 128 {
-                return Err(QueueError::InvalidArgs);
-            }
-            let queue_size = transport.max_queue_size(idx).unwrap() as usize;
-            let desc_size = size_of::<Descriptor>() * queue_size;
-            size = queue_size as u16;
+        let (descriptor_ptr, avail_ring_ptr, used_ring_ptr, device_queue_size) =
+            if transport.is_legacy_version() {
+                let device_queue_size = transport.max_queue_size(idx).unwrap() as usize;
+                let desc_size = size_of::<Descriptor>() * device_queue_size;
 
-            let (dma1, dma2) = {
-                let align_size = VirtioPciLegacyTransport::QUEUE_ALIGN_SIZE;
-                let total_frames =
-                    VirtioPciLegacyTransport::calc_virtqueue_size_aligned(queue_size) / align_size;
-                let dma = DmaCoherent::alloc(total_frames, true).unwrap();
+                // We should establish a reasonable upper bound on the requested queue size from the
+                // device, but we are unsure of the exact value. We chose 1024 based on the current
+                // need, but it can be increased in the future if necessary.
+                if !device_queue_size.is_power_of_two()
+                    || size as usize > device_queue_size
+                    || device_queue_size > 1024
+                {
+                    return Err(QueueError::InvalidArgs);
+                }
 
-                let avial_size = size_of::<u16>() * (3 + queue_size);
-                let seg1_frames = (desc_size + avial_size).div_ceil(align_size);
+                let (dma1, dma2) = {
+                    let align_size = VirtioPciLegacyTransport::QUEUE_ALIGN_SIZE;
+                    let total_frames =
+                        VirtioPciLegacyTransport::calc_virtqueue_size_aligned(device_queue_size)
+                            / align_size;
+                    let dma = DmaCoherent::alloc(total_frames, true).unwrap();
 
-                dma.split(seg1_frames * align_size)
+                    let avial_size = size_of::<u16>() * (3 + device_queue_size);
+                    let seg1_frames = (desc_size + avial_size).div_ceil(align_size);
+
+                    dma.split(seg1_frames * align_size)
+                };
+
+                let desc_frame_ptr: SafePtr<Descriptor, Arc<DmaCoherent>> =
+                    SafePtr::new(Arc::new(dma1), 0);
+                let mut avail_frame_ptr: SafePtr<AvailRing, Arc<DmaCoherent>> =
+                    desc_frame_ptr.clone().cast();
+                avail_frame_ptr.byte_add(desc_size);
+                let used_frame_ptr: SafePtr<UsedRing, Arc<DmaCoherent>> =
+                    SafePtr::new(Arc::new(dma2), 0);
+
+                (
+                    desc_frame_ptr,
+                    avail_frame_ptr,
+                    used_frame_ptr,
+                    device_queue_size as u16,
+                )
+            } else {
+                if size > 256 {
+                    return Err(QueueError::InvalidArgs);
+                }
+
+                (
+                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
+                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
+                    SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
+                    size,
+                )
             };
-            let desc_frame_ptr: SafePtr<Descriptor, Arc<DmaCoherent>> =
-                SafePtr::new(Arc::new(dma1), 0);
-            let mut avail_frame_ptr: SafePtr<AvailRing, Arc<DmaCoherent>> =
-                desc_frame_ptr.clone().cast();
-            avail_frame_ptr.byte_add(desc_size);
-            let used_frame_ptr: SafePtr<UsedRing, Arc<DmaCoherent>> =
-                SafePtr::new(Arc::new(dma2), 0);
-            (desc_frame_ptr, avail_frame_ptr, used_frame_ptr)
-        } else {
-            if size > 256 {
-                return Err(QueueError::InvalidArgs);
-            }
-            (
-                SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-                SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-                SafePtr::new(Arc::new(DmaCoherent::alloc(1, true).unwrap()), 0),
-            )
-        };
+
         debug!("queue_desc start paddr:{:x?}", descriptor_ptr.paddr());
         debug!("queue_driver start paddr:{:x?}", avail_ring_ptr.paddr());
         debug!("queue_device start paddr:{:x?}", used_ring_ptr.paddr());
 
         transport
-            .set_queue(idx, size, &descriptor_ptr, &avail_ring_ptr, &used_ring_ptr)
+            .set_queue(
+                idx,
+                device_queue_size,
+                &descriptor_ptr,
+                &avail_ring_ptr,
+                &used_ring_ptr,
+            )
             .unwrap();
+
         let mut descs = Vec::with_capacity(size as usize);
         descs.push(descriptor_ptr);
         for i in 0..size {
@@ -138,15 +164,17 @@ impl VirtQueue {
         }
 
         let notify_config = transport.notify_config(idx as usize);
+
         field_ptr!(&avail_ring_ptr, AvailRing, flags)
             .write_once(&AvailFlags::empty())
             .unwrap();
+
         Ok(VirtQueue {
             descs,
             avail: avail_ring_ptr,
             used: used_ring_ptr,
             notify_config,
-            queue_size: size,
+            device_queue_size,
             queue_idx: idx as u32,
             num_used: 0,
             free_head: 0,
@@ -167,7 +195,7 @@ impl VirtQueue {
         if inputs.is_empty() && outputs.is_empty() {
             return Err(QueueError::InvalidArgs);
         }
-        if inputs.len() + outputs.len() + self.num_used as usize > self.queue_size as usize {
+        if inputs.len() + outputs.len() > self.available_desc() {
             return Err(QueueError::BufferTooSmall);
         }
 
@@ -206,7 +234,7 @@ impl VirtQueue {
         }
         self.num_used += (inputs.len() + outputs.len()) as u16;
 
-        let avail_slot = self.avail_idx & (self.queue_size - 1);
+        let avail_slot = self.avail_idx & (self.device_queue_size - 1);
 
         {
             let ring_ptr: SafePtr<[u16; 64], &Arc<DmaCoherent>> =
@@ -248,7 +276,7 @@ impl VirtQueue {
 
     /// Returns the number of free descriptors.
     pub fn available_desc(&self) -> usize {
-        (self.queue_size - self.num_used) as usize
+        self.descs.len() - self.num_used as usize
     }
 
     /// Recycles descriptors in the list specified by `head`.
@@ -291,7 +319,7 @@ impl VirtQueue {
             return Err(QueueError::NotReady);
         }
 
-        let last_used_slot = self.last_used_idx & (self.queue_size - 1);
+        let last_used_slot = self.last_used_idx & (self.device_queue_size - 1);
         let element_ptr = {
             let mut ptr = self.used.borrow_vm();
             ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -26,7 +26,6 @@ pub enum QueueError {
     InvalidArgs,
     BufferTooSmall,
     NotReady,
-    AlreadyUsed,
     WrongToken,
 }
 
@@ -305,39 +304,6 @@ impl VirtQueue {
         self.last_used_idx = self.last_used_idx.wrapping_add(1);
 
         Ok((index as u16, len))
-    }
-
-    /// If the given token is next on the device used queue, pops it and returns the total buffer
-    /// length which was used (written) by the device.
-    ///
-    /// Ref: linux virtio_ring.c virtqueue_get_buf_ctx
-    pub fn pop_used_with_token(&mut self, token: u16) -> Result<u32, QueueError> {
-        if !self.can_pop() {
-            return Err(QueueError::NotReady);
-        }
-
-        let last_used_slot = self.last_used_idx & (self.queue_size - 1);
-        let element_ptr = {
-            let mut ptr = self.used.borrow_vm();
-            ptr.byte_add(offset_of!(UsedRing, ring) + last_used_slot as usize * 8);
-            ptr.cast::<UsedElem>()
-        };
-        let index = field_ptr!(&element_ptr, UsedElem, id).read_once().unwrap();
-        let len = field_ptr!(&element_ptr, UsedElem, len).read_once().unwrap();
-
-        if index as u16 != token {
-            return Err(QueueError::WrongToken);
-        }
-
-        self.recycle_descriptors(index as u16);
-        self.last_used_idx = self.last_used_idx.wrapping_add(1);
-
-        Ok(len)
-    }
-
-    /// Return size of the queue.
-    pub fn size(&self) -> u16 {
-        self.queue_size
     }
 
     /// whether the driver should notify the device


### PR DESCRIPTION
The first few commits are clean-up commits.

The following two sections describe *the last two commits*:

## Commit: Specify virtqueue API contract

The current API design and the implementation of `VirtQueue` assumes that the queue can be trusted. For example, it stores some indexes in a DMA-coherent region:
https://github.com/asterinas/asterinas/blob/c1e6cfe448508b93aef4e2d6bcdbc644e102b719/kernel/comps/virtio/src/queue.rs#L178-L186

If the device writes garbage to the region, our kernel will crash at `&self.descs[self.free_head as usize]`.

The related APIs, such as `pop_used`, do not state whether the returned token or the buffer length is valid. Therefore, it is unclear whether the queue or the device should verify this.

This PR proposes the following API design:
```rust
    /// Adds input and output DMA buffers to the virtqueue and returns a token.
    ///
    /// This method will succeed if the arguments contain at least one buffer and there is
    /// sufficient space in the queue. If the above condition is met, users can then unwrap the
    /// result.
    ///
    /// When successful, the result token is guaranteed to be valid. It will not exceed the queue
    /// size, and the same token will not be returned twice, unless it has been removed from the
    /// queue by [`Self::pop_used`] in the meantime.
    pub fn add_dma_bufs<I: DmaBuf, O: DmaBuf>(
        &mut self,
        inputs: &[&I],
        outputs: &[&O],
    ) -> Result<u16, QueueError>;

    /// Pops a device-used buffer and returns the token and the buffer length.
    ///
    /// When successful, the following is guaranteed:
    /// - The token is valid.  It will not exceed the queue size. It was previously returned by
    ///   [`Self::add_dma_bufs`], [`Self::add_input_bufs`], or [`Self::add_output_bufs`], and it has
    ///   not yet been removed from the queue by this method.
    /// - The length is valid. It will not exceed the length of the original DMA buffer.
    ///
    /// If the device malfunctions, it may report a token or length that violates these guarantees.
    /// Such reports are logged as errors and ignored; the reported token is not returned to the
    /// caller, preventing an invalid token from corrupting upper-layer state. If the device
    /// continues to malfunction, the queue may become stuck because the affected buffer cannot be
    /// reclaimed.
    pub fn pop_used(&mut self) -> Result<(u16, u32), QueueError>;

    /// Pops a device-used buffer containing a header and returns the token and the buffer length.
    ///
    /// This is the same as [`Self::pop_used`], except it also guarantees that the used buffer is at
    /// least `header_len` bytes.
    ///
    /// The note about malfunctioning devices in [`Self::pop_used`] applies here as well, including
    /// extra cases where the used buffer is shorter than `header_len`.
    pub fn pop_used_with_header(&mut self, header_len: usize) -> Result<(u16, u32), QueueError>;
``` 

## Commit: Make queue/memory allocation faillible 

This PR also avoids `unwrap()` on memory allocation APIs, including the two most common scenarios:
 - Allocating a `DmaStream`/`DmaCoherent`.
https://github.com/asterinas/asterinas/blob/c1e6cfe448508b93aef4e2d6bcdbc644e102b719/kernel/comps/virtio/src/device/console/device.rs#L100
 - Allocating a `TxBuffer`/`RxBuffer`.
https://github.com/asterinas/asterinas/blob/c1e6cfe448508b93aef4e2d6bcdbc644e102b719/kernel/comps/virtio/src/device/network/device.rs#L96

### Notes

 1. This PR intentionally skips all the code under `device/socket`. I will address this in my vsock PR.
 2. APIs that cannot fail should continue to use `unwrap()`. These include the following:
   - `DmaStream::reader()`/`DmaStream::writer()`/`DmaStream::sync_from_device()`/`DmaStream::sync_to_device()`.
   - `SafePtr::read_once()`/`SafePtr::write_once()`.
   - `VirtQueue::add_dma_bufs()`/`VirtQueue::add_input_bufs()`/`VirtQueue::add_output_bufs()` (if the caller knows that it has enough space for the new buffers).
   - `VirtioTransport::register_queue_callback()`/`VirtioTransport::register_cfg_callback()`.
   - `Once::get` (for use after initialization methods).