### PR TITLE
Align metadata of devtmpfs inodes with Linux semantics

### DIFF
--- a/kernel/src/device/evdev/mod.rs
+++ b/kernel/src/device/evdev/mod.rs
@@ -9,7 +9,7 @@
 
 mod file;
 
-use alloc::{format, string::String, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use core::{
     fmt::Debug,
     sync::atomic::{AtomicU32, Ordering},
@@ -29,7 +29,7 @@ use ostd::sync::SpinLock;
 use spin::Once;
 
 use super::{
-    Device, DeviceType,
+    Device, DeviceType, DevtmpfsInodeMeta,
     registry::char::{MajorIdOwner, acquire_major, register, unregister},
 };
 use crate::{fs::file::FileIo, prelude::*, util::ring_buffer::RbProducer};
@@ -197,8 +197,11 @@ impl Device for EvdevDevice {
         self.id
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some(format!("input/event{}", self.id.minor().get()))
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new(format!(
+            "input/event{}",
+            self.id.minor().get()
+        )))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -6,7 +6,7 @@ use aster_framebuffer::{ColorMapEntry, FRAMEBUFFER, FrameBuffer, MAX_CMAP_SIZE, 
 use device_id::{DeviceId, MajorId, MinorId};
 use ostd::mm::{HasPaddr, HasSize, VmIo, VmReader, VmWriter};
 
-use super::{Device, DeviceType, registry::char};
+use super::{Device, DeviceType, DevtmpfsInodeMeta, registry::char};
 use crate::{
     context::current_userspace,
     events::IoEvents,
@@ -226,8 +226,12 @@ impl Device for Fb {
         DeviceId::new(MajorId::new(29), MinorId::new(0))
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some("fb0".into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        // Linux names framebuffer device nodes as `fbN`.
+        // TODO: We currently expose only one framebuffer device,
+        // so the devtmpfs node is fixed to `fb0`.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/video/fbdev/core/fbsysfs.c#L482>.
+        Some(DevtmpfsInodeMeta::new("fb0"))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/mem/file.rs
+++ b/kernel/src/device/mem/file.rs
@@ -74,7 +74,7 @@ impl MemFile {
         }
     }
 
-    pub(super) fn name(&self) -> &str {
+    pub(super) fn name(&self) -> &'static str {
         match self {
             MemFile::Mem => "mem",
             MemFile::Kmem => "kmem",

--- a/kernel/src/device/mem/mod.rs
+++ b/kernel/src/device/mem/mod.rs
@@ -28,10 +28,13 @@ pub use file::{getrandom, geturandom};
 use spin::Once;
 
 use super::{
-    Device, DeviceType,
+    Device, DeviceType, DevtmpfsInodeMeta,
     registry::char::{MajorIdOwner, acquire_major, register},
 };
-use crate::{fs::file::FileIo, prelude::*};
+use crate::{
+    fs::file::{FileIo, mkmod},
+    prelude::*,
+};
 
 /// A memory device.
 #[derive(Debug)]
@@ -61,8 +64,18 @@ impl Device for MemDevice {
         self.id
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some(self.file.name().into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        // Linux's memory-device table uses nonzero modes only for devices
+        // that override devtmpfs's default `u+rw` permissions.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/mem.c#L690>.
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/mem.c#L734>.
+        Some(match self.file {
+            MemFile::Full | MemFile::Null | MemFile::Random | MemFile::Urandom | MemFile::Zero => {
+                DevtmpfsInodeMeta::with_mode(self.file.name(), mkmod!(a+rw))
+            }
+            MemFile::Kmsg => DevtmpfsInodeMeta::with_mode(self.file.name(), mkmod!(a+r, u+w)),
+            _ => DevtmpfsInodeMeta::new(self.file.name()),
+        })
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -59,7 +59,7 @@ use tdx_guest::{
 };
 
 use crate::{
-    device::{Device, DeviceType, registry::char::register},
+    device::{Device, DeviceType, DevtmpfsInodeMeta, registry::char::register},
     events::IoEvents,
     fs::{
         file::{FileIo, StatusFlags},
@@ -97,8 +97,8 @@ impl Device for TdxGuest {
         self.id
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some("tdx_guest".into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new("tdx_guest"))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -9,6 +9,8 @@ mod registry;
 mod shm;
 pub mod tty;
 
+use alloc::borrow::Cow;
+
 use device_id::DeviceId;
 pub use mem::{getrandom, geturandom};
 pub use pty::{PtyMaster, PtySlave, new_pty_pair};
@@ -16,7 +18,7 @@ pub use registry::lookup;
 
 use crate::{
     fs::{
-        file::{FileIo, InodeType, mkmod},
+        file::{FileIo, InodeMode, InodeType, mkmod},
         ramfs::RamFs,
         vfs::{
             inode::MknodType,
@@ -34,8 +36,8 @@ pub trait Device: Send + Sync + 'static {
     /// Returns the device ID.
     fn id(&self) -> DeviceId;
 
-    /// Returns the path where the device should appear in devtmpfs (usually under `/dev`), if any.
-    fn devtmpfs_path(&self) -> Option<String>;
+    /// Returns the metadata that specifies a device inode to be created in devtmpfs, if any.
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>>;
 
     /// Opens the device, returning a file-like object that the userspace can interact with by
     /// doing I/O.
@@ -47,7 +49,7 @@ impl Debug for dyn Device {
         f.debug_struct("Device")
             .field("type", &self.type_())
             .field("id", &self.id())
-            .field("devtmpfs_path", &self.devtmpfs_path())
+            .field("devtmpfs_meta", &self.devtmpfs_meta())
             .finish_non_exhaustive()
     }
 }
@@ -59,6 +61,49 @@ pub enum DeviceType {
     Block,
 }
 
+/// The metadata that describes a device inode in devtmpfs.
+///
+/// The metadata contains the inode path relative to `/dev` and the
+/// permission bits used when creating the inode. Device subsystems can use this
+/// type to override the default mode.
+///
+/// If a device does not specify a mode explicitly, we use `mkmod!(u+rw)`,
+/// matching Linux devtmpfs's default device inode permissions.
+/// Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/base/devtmpfs.c#L11>.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DevtmpfsInodeMeta<'a> {
+    path: Cow<'a, str>,
+    mode: InodeMode,
+}
+
+impl<'a> DevtmpfsInodeMeta<'a> {
+    /// Creates the metadata for a devtmpfs inode with the default mode (`u+rw`).
+    pub fn new(path: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            path: path.into(),
+            mode: mkmod!(u+rw),
+        }
+    }
+
+    /// Creates the metadata for a devtmpfs inode with the specified path and mode.
+    pub fn with_mode(path: impl Into<Cow<'a, str>>, mode: InodeMode) -> Self {
+        Self {
+            path: path.into(),
+            mode,
+        }
+    }
+
+    /// Returns the device inode path relative to `/dev`.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the permission bits of the device inode.
+    pub fn mode(&self) -> InodeMode {
+        self.mode
+    }
+}
+
 /// Adds a device node in `/dev`.
 ///
 /// If the parent path does not exist, it will be created as a directory.
@@ -68,12 +113,12 @@ pub enum DeviceType {
 pub fn add_node(
     dev_type: DeviceType,
     dev_id: u64,
-    path: &str,
+    meta: &DevtmpfsInodeMeta<'_>,
     path_resolver: &PathResolver,
 ) -> Result<Path> {
     let mut dev_path = path_resolver.lookup(&FsPath::try_from("/dev").unwrap())?;
     let mut relative_path = {
-        let relative_path = path.trim_start_matches('/');
+        let relative_path = meta.path().trim_start_matches('/');
         if relative_path.is_empty() {
             return_errno_with_message!(Errno::EINVAL, "the device path is invalid");
         }
@@ -102,7 +147,7 @@ pub fn add_node(
                         DeviceType::Block => MknodType::BlockDevice(dev_id),
                         DeviceType::Char => MknodType::CharDevice(dev_id),
                     };
-                    dev_path = dev_path.mknod(next_name, mkmod!(a+rw), mknod_type)?;
+                    dev_path = dev_path.mknod(next_name, meta.mode(), mknod_type)?;
                 } else {
                     // Create the parent directory
                     dev_path =

--- a/kernel/src/device/pty/driver.rs
+++ b/kernel/src/device/pty/driver.rs
@@ -5,6 +5,7 @@ use ostd::sync::SpinLock;
 use super::file::PtySlaveFile;
 use crate::{
     device::{
+        DevtmpfsInodeMeta,
         pty::packet::{PacketCtrl, PacketStatus},
         tty::{
             Tty, TtyDriver, TtyFlags,
@@ -116,7 +117,7 @@ impl TtyDriver for PtyDriver {
     // Reference: <https://elixir.bootlin.com/linux/v6.17/source/include/uapi/linux/major.h#L147>.
     const DEVICE_MAJOR_ID: u32 = 136;
 
-    fn devtmpfs_path(&self, _index: u32) -> Option<String> {
+    fn devtmpfs_meta(&self, _index: u32) -> Option<DevtmpfsInodeMeta<'_>> {
         None
     }
 

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -6,7 +6,7 @@ use device_id::DeviceId;
 use ostd::mm::VmIo;
 
 use crate::{
-    device::{Device, DeviceType, add_node},
+    device::{Device, DeviceType, DevtmpfsInodeMeta, add_node},
     events::IoEvents,
     fs::{
         file::{FileIo, StatusFlags},
@@ -38,9 +38,9 @@ pub(super) fn init_in_first_kthread() {
 pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> {
     for device in aster_block::collect_all() {
         let device = Arc::new(BlockFile::new(device));
-        if let Some(devtmpfs_path) = device.devtmpfs_path() {
+        if let Some(devtmpfs_meta) = device.devtmpfs_meta() {
             let dev_id = device.id().as_encoded_u64();
-            add_node(DeviceType::Block, dev_id, &devtmpfs_path, path_resolver)?;
+            add_node(DeviceType::Block, dev_id, &devtmpfs_meta, path_resolver)?;
         }
     }
 
@@ -77,8 +77,8 @@ impl Device for BlockFile {
         self.0.id()
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some(self.0.name().into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new(self.0.name()))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/registry/char.rs
+++ b/kernel/src/device/registry/char.rs
@@ -112,9 +112,9 @@ impl Drop for MajorIdOwner {
 
 pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> {
     for device in collect_all() {
-        if let Some(devtmpfs_path) = device.devtmpfs_path() {
+        if let Some(devtmpfs_meta) = device.devtmpfs_meta() {
             let dev_id = device.id().as_encoded_u64();
-            add_node(DeviceType::Char, dev_id, &devtmpfs_path, path_resolver)?;
+            add_node(DeviceType::Char, dev_id, &devtmpfs_meta, path_resolver)?;
         }
     }
 

--- a/kernel/src/device/tty/device.rs
+++ b/kernel/src/device/tty/device.rs
@@ -11,7 +11,7 @@ use spin::Once;
 
 use crate::{
     device::{
-        Device, DeviceType,
+        Device, DeviceType, DevtmpfsInodeMeta,
         registry::char,
         tty::{
             Tty,
@@ -20,7 +20,7 @@ use crate::{
             vt::{VtDriver, tty1_device},
         },
     },
-    fs::file::FileIo,
+    fs::file::{FileIo, mkmod},
     prelude::*,
     process::{JobControl, Terminal},
 };
@@ -45,8 +45,8 @@ impl Device for Tty0Device {
         DeviceId::new(MajorId::new(4), MinorId::new(0))
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some("tty0".into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new("tty0"))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {
@@ -73,8 +73,9 @@ impl Device for TtyDevice {
         DeviceId::new(MajorId::new(5), MinorId::new(0))
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some("tty".into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/tty/tty_io.c#L3511>.
+        Some(DevtmpfsInodeMeta::with_mode("tty", mkmod!(a+rw)))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {
@@ -135,8 +136,8 @@ impl Device for SystemConsole {
         DeviceId::new(MajorId::new(5), MinorId::new(1))
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        Some("console".into())
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new("console"))
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/tty/driver.rs
+++ b/kernel/src/device/tty/driver.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::{
-    device::tty::{Tty, termio::CTermios},
+    device::{
+        DevtmpfsInodeMeta,
+        tty::{Tty, termio::CTermios},
+    },
     fs::file::FileIo,
     prelude::*,
     util::ioctl::RawIoctl,
@@ -19,8 +22,8 @@ pub trait TtyDriver: Send + Sync + 'static {
     /// The device major ID.
     const DEVICE_MAJOR_ID: u32;
 
-    /// Returns the path where the TTY should appear under devtmpfs, if any.
-    fn devtmpfs_path(&self, index: u32) -> Option<String>;
+    /// Returns the metadata that specifies a TTY device inode to be created in devtmpfs, if any.
+    fn devtmpfs_meta(&self, index: u32) -> Option<DevtmpfsInodeMeta<'_>>;
 
     /// Opens the TTY.
     ///

--- a/kernel/src/device/tty/hvc.rs
+++ b/kernel/src/device/tty/hvc.rs
@@ -9,6 +9,7 @@ use spin::Once;
 use super::{Tty, TtyDriver};
 use crate::{
     device::{
+        DevtmpfsInodeMeta,
         registry::char,
         tty::{file::TtyFile, termio::CTermios},
     },
@@ -26,8 +27,8 @@ impl TtyDriver for HvcDriver {
     // Reference: <https://elixir.bootlin.com/linux/v6.17/source/Documentation/admin-guide/devices.txt#L2936>.
     const DEVICE_MAJOR_ID: u32 = 229;
 
-    fn devtmpfs_path(&self, index: u32) -> Option<String> {
-        Some(format!("hvc{}", index))
+    fn devtmpfs_meta(&self, index: u32) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new(format!("hvc{}", index)))
     }
 
     fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -5,7 +5,7 @@ use ostd::sync::LocalIrqDisabled;
 
 use self::{line_discipline::LineDiscipline, termio::CFontOp};
 use crate::{
-    device::{Device, DeviceType},
+    device::{Device, DeviceType, DevtmpfsInodeMeta},
     events::IoEvents,
     fs::file::{FileIo, StatusFlags},
     prelude::*,
@@ -326,8 +326,8 @@ impl<D: TtyDriver> Device for Tty<D> {
         )
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
-        self.driver.devtmpfs_path(self.index)
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        self.driver.devtmpfs_meta(self.index)
     }
 
     fn open(&self) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/tty/serial.rs
+++ b/kernel/src/device/tty/serial.rs
@@ -9,6 +9,7 @@ use spin::Once;
 use super::{Tty, TtyDriver};
 use crate::{
     device::{
+        DevtmpfsInodeMeta,
         registry::char,
         tty::{file::TtyFile, termio::CTermios},
     },
@@ -30,8 +31,11 @@ impl TtyDriver for SerialDriver {
     // Reference: <https://elixir.bootlin.com/linux/v6.17/source/include/uapi/linux/major.h#L18>.
     const DEVICE_MAJOR_ID: u32 = 4;
 
-    fn devtmpfs_path(&self, index: u32) -> Option<String> {
-        Some(format!("ttyS{}", index - Self::MINOR_ID_BASE))
+    fn devtmpfs_meta(&self, index: u32) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new(format!(
+            "ttyS{}",
+            index - Self::MINOR_ID_BASE
+        )))
     }
 
     fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/device/tty/vt/driver.rs
+++ b/kernel/src/device/tty/vt/driver.rs
@@ -14,6 +14,7 @@ use spin::Once;
 use crate::{
     context::current_userspace,
     device::{
+        DevtmpfsInodeMeta,
         registry::char,
         tty::{CFontOp, Tty, TtyDriver, file::TtyFile, termio::CTermios},
     },
@@ -101,8 +102,8 @@ impl TtyDriver for VtDriver {
     // Reference: <https://elixir.bootlin.com/linux/v6.17/source/include/uapi/linux/major.h#L18>.
     const DEVICE_MAJOR_ID: u32 = 4;
 
-    fn devtmpfs_path(&self, index: u32) -> Option<String> {
-        Some(format!("tty{}", index))
+    fn devtmpfs_meta(&self, index: u32) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new(format!("tty{}", index)))
     }
 
     fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -3,11 +3,14 @@
 use device_id::{DeviceId, MajorId, MinorId};
 
 use super::*;
-use crate::fs::{
-    file::{AccessMode, FileIo, StatusFlags},
-    vfs::{
-        file_system::SuperBlock,
-        inode::{Extension, InodeIo},
+use crate::{
+    device::DevtmpfsInodeMeta,
+    fs::{
+        file::{AccessMode, FileIo, StatusFlags},
+        vfs::{
+            file_system::SuperBlock,
+            inode::{Extension, InodeIo},
+        },
     },
 };
 
@@ -175,7 +178,7 @@ impl Device for Inner {
         DeviceId::new(MajorId::new(PTMX_MAJOR_NUM), MinorId::new(PTMX_MINOR_NUM))
     }
 
-    fn devtmpfs_path(&self) -> Option<String> {
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
         None
     }
 

--- a/test/initramfs/src/regression/device/devtmpfs_mode.c
+++ b/test/initramfs/src/regression/device/devtmpfs_mode.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include "../common/test.h"
+
+/*
+ * Device-node modes should normally be covered by the test for each device.
+ * This test covers devtmpfs modes for devices whose tests do not yet exist.
+ */
+
+struct device_node {
+	const char *path;
+	mode_t mode;
+	unsigned int major;
+	unsigned int minor;
+};
+
+static const struct device_node device_nodes[] = {
+	/* Explicit Linux overrides (non-default mode). */
+	{ "/dev/null", 0666, 1, 3 },
+	{ "/dev/zero", 0666, 1, 5 },
+	{ "/dev/tty", 0666, 5, 0 },
+	/*
+	 * Devices that fall back to the kernel devtmpfs default (0600).
+	 *
+	 * Do not replace these modes with values observed on a host Linux.
+	 * Systemd may later change the default modes of these devices in user space.
+	 * Reference: <https://github.com/systemd/systemd/blob/9149c7595305a7c4d105d5d33ba25733af4302eb/rules.d/50-udev-default.rules.in>
+	 */
+	{ "/dev/console", 0600, 5, 1 },
+	{ "/dev/tty0", 0600, 4, 0 },
+	{ "/dev/tty1", 0600, 4, 1 },
+	{ "/dev/ttyS0", 0600, 4, 64 },
+};
+
+FN_TEST(rdev_and_mode)
+{
+	for (size_t i = 0; i < sizeof(device_nodes) / sizeof(device_nodes[0]);
+	     i++) {
+		const struct device_node *node = &device_nodes[i];
+		struct stat stat_buf;
+
+		TEST_RES(stat(node->path, &stat_buf),
+			 S_ISCHR(stat_buf.st_mode) &&
+				 stat_buf.st_rdev ==
+					 makedev(node->major, node->minor) &&
+				 (stat_buf.st_mode & 0777) == node->mode);
+	}
+}
+END_TEST()

--- a/test/initramfs/src/regression/device/full.c
+++ b/test/initramfs/src/regression/device/full.c
@@ -23,8 +23,9 @@ END_SETUP()
 FN_TEST(fstat)
 {
 	struct stat stat;
-	TEST_RES(fstat(fd, &stat),
-		 S_ISCHR(stat.st_mode) && stat.st_rdev == makedev(0x1, 0x7));
+	TEST_RES(fstat(fd, &stat), S_ISCHR(stat.st_mode) &&
+					   stat.st_rdev == makedev(0x1, 0x7) &&
+					   (stat.st_mode & 0777) == 0666);
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/device/random.c
+++ b/test/initramfs/src/regression/device/random.c
@@ -3,9 +3,38 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/fcntl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include "../common/test.h"
 
 #define PAGE_SIZE 4096
+
+struct random_device {
+	const char *path;
+	unsigned int major;
+	unsigned int minor;
+};
+
+static const struct random_device random_devices[] = {
+	{ "/dev/random", 1, 8 },
+	{ "/dev/urandom", 1, 9 },
+};
+
+FN_TEST(rdev_and_mode)
+{
+	for (size_t i = 0;
+	     i < sizeof(random_devices) / sizeof(random_devices[0]); i++) {
+		const struct random_device *device = &random_devices[i];
+		struct stat stat_buf;
+
+		TEST_RES(stat(device->path, &stat_buf),
+			 S_ISCHR(stat_buf.st_mode) &&
+				 stat_buf.st_rdev == makedev(device->major,
+							     device->minor) &&
+				 (stat_buf.st_mode & 0777) == 0666);
+	}
+}
+END_TEST()
 
 FN_TEST(short_rw)
 {

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -9,6 +9,8 @@ set -e
 ./pty/open_pty
 ./pty/pty_blocking
 ./pty/pty_packet_mode
+
+./devtmpfs_mode
 ./evdev
 ./framebuffer
 ./full


### PR DESCRIPTION
## Summary

This change aligns Asterinas devtmpfs node creation more closely with Linux.

It replaces the old path-only device-node interface with a `DevtmpfsNode`
description that carries the metadata required to accurately model Linux
defaults and per-subsystem overrides.

## Changes

* Introduce `DevtmpfsNode` for devtmpfs node metadata
* Switch device registration from `devtmpfs_path()` to `devtmpfs_node()`
* Make devtmpfs default to `root:root` with mode `0600`, matching Linux
* Allow subsystems to override devtmpfs node metadata when needed

## Notes

Linux devtmpfs defaults device nodes to `root:root` with mode `0600`.
Subsystems may override metadata via `device_get_devnode()`. This PR models that behavior explicitly in the kernel device layer.
