### PR TITLE
Set `procfs` `fd` ownership from task credentials

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     prelude::*,
     process::pid_table::{PidEntry, PidEntryType},
+    thread::Thread,
 };
 
 mod task;
@@ -52,6 +53,10 @@ impl PidDirOps {
 }
 
 impl DirOps for PidDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if self.0.pid_entry().type_().is_none() {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/auxv` (and also `/proc/[pid]/auxv`).
@@ -21,6 +22,10 @@ impl AuxvFileOps {
 }
 
 impl FileOps for AuxvFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsThreadLocal,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/cgroup` (and also `/proc/[pid]/cgroup`).
@@ -28,6 +29,10 @@ impl CgroupFileOps {
 }
 
 impl FileOps for CgroupFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/cmdline` (and also `/proc/[pid]/cmdline`).
@@ -21,6 +22,10 @@ impl CmdlineFileOps {
 }
 
 impl FileOps for CmdlineFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/comm` (and also `/proc/[pid]/comm`).
@@ -21,6 +22,10 @@ impl CommFileOps {
 }
 
 impl FileOps for CommFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/environ` (and also `/proc/[pid]/environ`).
@@ -21,6 +22,10 @@ impl EnvironFileOps {
 }
 
 impl FileOps for EnvironFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/exe` (and also `/proc/[pid]/exe`).
@@ -23,6 +24,10 @@ impl ExeSymOps {
 }
 
 impl SymOps for ExeSymOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_link(&self) -> Result<SymbolicLink> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/fd` (and also `/proc/[pid]/fd`).
@@ -43,6 +44,10 @@ impl<T: FdOps> FdDirOps<T> {
 }
 
 impl<T: FdOps> DirOps for FdDirOps<T> {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.dir.thread()
+    }
+
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         let file_desc = if let Ok(raw_fd) = name.parse::<RawFileDesc>()
             && let Ok(file_desc) = FileDesc::try_from(raw_fd)
@@ -225,6 +230,10 @@ impl FdOps for FileSymOps {
 }
 
 impl SymOps for FileSymOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.tid_dir_ops.thread()
+    }
+
     fn read_link(&self) -> Result<SymbolicLink> {
         let Some(thread) = self.tid_dir_ops.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
@@ -288,6 +297,10 @@ impl FdOps for FileInfoOps {
 }
 
 impl FileOps for FileInfoOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.tid_dir_ops.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(thread) = self.tid_dir_ops.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
@@ -11,10 +11,10 @@ use crate::{
     },
     prelude::*,
     process::Gid,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/gid_map` (and also `/proc/[pid]/gid_map`).
-#[expect(dead_code)]
 pub struct GidMapFileOps(TidDirOps);
 
 impl GidMapFileOps {
@@ -25,6 +25,10 @@ impl GidMapFileOps {
 }
 
 impl FileOps for GidMapFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -16,6 +16,7 @@ use crate::{
         posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
         signal::{PollHandle, Pollable},
     },
+    thread::Thread,
     vm::vmar::{VMAR_CAP_ADDR, VMAR_LOWEST_ADDR},
 };
 
@@ -30,6 +31,10 @@ impl MapsFileOps {
 }
 
 impl FileOpsByHandle for MapsFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn open(
         &self,
         _access_mode: AccessMode,

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -14,6 +14,7 @@ use crate::{
         posix_thread::{AsPosixThread, alien_access::AlienAccessMode},
         signal::{PollHandle, Pollable},
     },
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/mem` (and also `/proc/[pid]/mem`).
@@ -27,6 +28,10 @@ impl MemFileOps {
 }
 
 impl FileOpsByHandle for MemFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn open(
         &self,
         _access_mode: AccessMode,

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -133,6 +133,10 @@ impl TidDirOps {
 }
 
 impl DirOps for TidDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.thread()
+    }
+
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if self.pid_entry().type_().is_none() {
             return_errno_with_message!(Errno::ENOENT, "the thread or the process does not exist");
@@ -182,6 +186,10 @@ impl TidDirOps {
 }
 
 impl DirOps for TaskDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         let Ok(tid) = name.parse::<Tid>() else {
             return_errno_with_message!(Errno::ENOENT, "the name is not a valid TID");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
+    thread::Thread,
 };
 
 /// A helper function to create the mount point path for a given mount (used by `mounts`,
@@ -151,6 +152,10 @@ impl MountInfoFileOps {
 }
 
 impl FileOps for MountInfoFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(thread) = self.0.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
+    thread::Thread,
 };
 
 /// A single entry in the mounts file.
@@ -110,6 +111,10 @@ impl MountsFileOps {
 }
 
 impl FileOps for MountsFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(thread) = self.0.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::AsPosixThread,
+    thread::Thread,
 };
 
 /// A single entry in the `mountstats` file.
@@ -81,6 +82,10 @@ impl MountStatsFileOps {
 }
 
 impl FileOps for MountStatsFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some(thread) = self.0.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -22,6 +22,7 @@ use crate::{
     net::uts_ns::UtsNamespace,
     prelude::*,
     process::{NsProxy, UserNamespace, posix_thread::AsPosixThread},
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/ns` (and also `/proc/[pid]/ns`).
@@ -80,16 +81,33 @@ impl NsProxyEntry {
     }
 
     /// Creates a symlink inode for this namespace entry.
-    fn new_sym_inode(self, ns_proxy: &NsProxy, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+    fn new_sym_inode(
+        self,
+        dir: &TidDirOps,
+        ns_proxy: &NsProxy,
+        parent: Weak<dyn Inode>,
+    ) -> Arc<dyn Inode> {
         match self {
-            Self::Cgroup => {
-                NsSymOps::<CgroupNamespace>::new_inode(ns_proxy.cgroup_ns().get_path(), parent)
-            }
-            Self::Ipc => NsSymOps::<IpcNamespace>::new_inode(ns_proxy.ipc_ns().get_path(), parent),
-            Self::Mnt => {
-                NsSymOps::<MountNamespace>::new_inode(ns_proxy.mnt_ns().get_path(), parent)
-            }
-            Self::Uts => NsSymOps::<UtsNamespace>::new_inode(ns_proxy.uts_ns().get_path(), parent),
+            Self::Cgroup => NsSymOps::<CgroupNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.cgroup_ns().get_path(),
+                parent,
+            ),
+            Self::Ipc => NsSymOps::<IpcNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.ipc_ns().get_path(),
+                parent,
+            ),
+            Self::Mnt => NsSymOps::<MountNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.mnt_ns().get_path(),
+                parent,
+            ),
+            Self::Uts => NsSymOps::<UtsNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.uts_ns().get_path(),
+                parent,
+            ),
         }
     }
 }
@@ -118,6 +136,10 @@ fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
 }
 
 impl DirOps for NsDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.dir.thread()
+    }
+
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if name == "user" {
             let Some(process) = self.dir.process() else {
@@ -126,6 +148,7 @@ impl DirOps for NsDirOps {
 
             let user_ns = process.user_ns().lock();
             return Ok(NsSymOps::<UserNamespace>::new_inode(
+                self.dir.clone(),
                 user_ns.get_path(),
                 this_dir.this_weak().clone(),
             ));
@@ -143,7 +166,7 @@ impl DirOps for NsDirOps {
         let ns_proxy = ns_proxy_guard
             .as_ref()
             .ok_or_else(|| Error::with_message(Errno::ENOENT, "the thread has exited"))?;
-        Ok(entry.new_sym_inode(ns_proxy, this_dir.this_weak().clone()))
+        Ok(entry.new_sym_inode(&self.dir, ns_proxy, this_dir.this_weak().clone()))
     }
 
     fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
@@ -227,15 +250,17 @@ type NsSymlink<T> = ProcSym<NsSymOps<T>>;
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/ns/<type>` (and also `/proc/[pid]/ns/<type>`).
 struct NsSymOps<T: NsCommonOps> {
+    dir: TidDirOps,
     ns_path: Path,
     phantom: PhantomData<T>,
 }
 
 impl<T: NsCommonOps> NsSymOps<T> {
     /// Creates a new symlink inode pointing to the given namespace.
-    fn new_inode(ns_path: Path, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+    fn new_inode(dir: TidDirOps, ns_path: Path, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         ProcSym::new(
             Self {
+                dir,
                 ns_path,
                 phantom: PhantomData,
             },
@@ -247,6 +272,10 @@ impl<T: NsCommonOps> NsSymOps<T> {
 }
 
 impl<T: NsCommonOps> SymOps for NsSymOps<T> {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.dir.thread()
+    }
+
     fn read_link(&self) -> Result<SymbolicLink> {
         Ok(SymbolicLink::Path(self.ns_path.clone()))
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
@@ -12,6 +12,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/oom_score_adj` (and also `/proc/[pid]/oom_score_adj`).
@@ -25,6 +26,10 @@ impl OomScoreAdjFileOps {
 }
 
 impl FileOps for OomScoreAdjFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     prelude::*,
     process::posix_thread::{AsPosixThread, SleepingState},
+    thread::Thread,
     vm::vmar::RssType,
 };
 
@@ -106,6 +107,10 @@ impl StatFileOps {
 }
 
 impl FileOps for StatFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.dir.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let Some((thread, process)) = self.dir.thread_and_process() else {
             return_errno_with_message!(Errno::ESRCH, "the thread or the process does not exist");

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -14,6 +14,7 @@ use crate::{
         credentials::AMBIENT_CAPSET,
         posix_thread::{AsPosixThread, SleepingState},
     },
+    thread::Thread,
     vm::vmar::RssType,
 };
 
@@ -73,6 +74,10 @@ impl StatusFileOps {
 }
 
 impl FileOps for StatusFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
@@ -11,10 +11,10 @@ use crate::{
     },
     prelude::*,
     process::Uid,
+    thread::Thread,
 };
 
 /// Represents the inode at `/proc/[pid]/task/[tid]/uid_map` (and also `/proc/[pid]/uid_map`).
-#[expect(dead_code)]
 pub struct UidMapFileOps(TidDirOps);
 
 impl UidMapFileOps {
@@ -25,6 +25,10 @@ impl UidMapFileOps {
 }
 
 impl FileOps for UidMapFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    thread::Thread,
 };
 
 /// Wraps directory-specific procfs operations as a VFS inode.
@@ -113,7 +114,6 @@ impl<D: DirOps + 'static> InodeIo for ProcDir<D> {
 #[inherit_methods(from = "self.common")]
 impl<D: DirOps + 'static> Inode for ProcDir<D> {
     fn size(&self) -> usize;
-    fn metadata(&self) -> Metadata;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn mode(&self) -> Result<InodeMode>;
@@ -129,6 +129,11 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
+
+    fn metadata(&self) -> Metadata {
+        let owner_thread = self.inner.owner_thread();
+        self.common.metadata_with_owner(owner_thread)
+    }
 
     fn resize(&self, _new_size: usize) -> Result<()> {
         Err(Error::new(Errno::EISDIR))
@@ -232,6 +237,11 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
 }
 
 pub trait DirOps: Sync + Send + Sized {
+    /// Returns the thread whose credentials own this procfs inode.
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        None
+    }
+
     /// Looks up a child inode in `this_dir` by name.
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>>;
 

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    thread::Thread,
 };
 
 pub struct ProcFile<F: FileOps> {
@@ -70,7 +71,6 @@ impl<F: FileOps + 'static> InodeIo for ProcFile<F> {
 #[inherit_methods(from = "self.common")]
 impl<F: FileOps + 'static> Inode for ProcFile<F> {
     fn size(&self) -> usize;
-    fn metadata(&self) -> Metadata;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn mode(&self) -> Result<InodeMode>;
@@ -86,6 +86,11 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
+
+    fn metadata(&self) -> Metadata {
+        let owner_thread = self.inner.owner_thread();
+        self.common.metadata_with_owner(owner_thread)
+    }
 
     fn resize(&self, _new_size: usize) -> Result<()> {
         // Resizing files under `/proc` will succeed, but will do nothing.
@@ -119,6 +124,11 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
 }
 
 pub trait FileOps: Sync + Send {
+    /// Returns the thread whose credentials own this procfs inode.
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        None
+    }
+
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize>;
 
     fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
@@ -135,10 +145,19 @@ pub trait FileOps: Sync + Send {
 }
 
 pub trait FileOpsByHandle: Sync + Send {
+    /// Returns the thread whose credentials own this procfs inode.
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        None
+    }
+
     fn open(&self, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Box<dyn FileIo>>;
 }
 
 impl<T: FileOpsByHandle> FileOps for T {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        FileOpsByHandle::owner_thread(self)
+    }
+
     fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
         unreachable!("`read_at` is never called when `open` returns `Some(_)`")
     }

--- a/kernel/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/mod.rs
@@ -20,13 +20,19 @@ use crate::{
         },
     },
     prelude::*,
-    process::{Gid, Uid},
+    process::{Gid, Uid, posix_thread::AsPosixThread},
+    thread::Thread,
 };
 
 mod dir;
 mod file;
 mod sym;
 
+/// Shared procfs inode state.
+///
+/// FIXME: Procfs permissions should be checked during each operation, not by relying on mutable
+/// inode ownership. See Linux comment:
+/// <https://elixir.bootlin.com/linux/v6.13/source/fs/proc/base.c#L107>.
 struct Common {
     metadata: RwLock<Metadata>,
     extension: Extension,
@@ -48,6 +54,23 @@ impl Common {
 
     fn metadata(&self) -> Metadata {
         *self.metadata.read()
+    }
+
+    fn metadata_with_owner(&self, owner_thread: Option<Arc<Thread>>) -> Metadata {
+        let Some(owner_thread) = owner_thread else {
+            return self.metadata();
+        };
+
+        let credentials = owner_thread.as_posix_thread().unwrap().credentials();
+        let mut metadata = self.metadata.write();
+        // Cache the dynamic owner into the metadata so that if the thread
+        // later exits, subsequent calls fall back to the last known owner
+        // instead of the root user. This is a best-effort attempt to align
+        // with Linux behavior. See:
+        // <https://github.com/asterinas/asterinas/pull/3164#discussion_r3212307770>.
+        metadata.uid = credentials.euid();
+        metadata.gid = credentials.egid();
+        *metadata
     }
 
     fn ino(&self) -> u64 {

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    thread::Thread,
 };
 
 pub struct ProcSym<S: SymOps> {
@@ -67,7 +68,6 @@ impl<S: SymOps + 'static> InodeIo for ProcSym<S> {
 #[inherit_methods(from = "self.common")]
 impl<S: SymOps + 'static> Inode for ProcSym<S> {
     fn size(&self) -> usize;
-    fn metadata(&self) -> Metadata;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn mode(&self) -> Result<InodeMode>;
@@ -83,6 +83,11 @@ impl<S: SymOps + 'static> Inode for ProcSym<S> {
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
+
+    fn metadata(&self) -> Metadata {
+        let owner_thread = self.inner.owner_thread();
+        self.common.metadata_with_owner(owner_thread)
+    }
 
     fn resize(&self, _new_size: usize) -> Result<()> {
         Err(Error::new(Errno::EPERM))
@@ -102,5 +107,10 @@ impl<S: SymOps + 'static> Inode for ProcSym<S> {
 }
 
 pub trait SymOps: Sync + Send {
+    /// Returns the thread whose credentials own this procfs inode.
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        None
+    }
+
     fn read_link(&self) -> Result<SymbolicLink>;
 }

--- a/test/initramfs/src/regression/fs/procfs/proc_fd_open_fifo_after_setid.c
+++ b/test/initramfs/src/regression/fs/procfs/proc_fd_open_fifo_after_setid.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define FIFO_PATH "/tmp/proc-fd-open-fifo-after-setid"
+
+FN_TEST(open_fifo_via_proc_fd_after_setid)
+{
+	char proc_fd_path[64];
+	int fifo_fd;
+	pid_t child;
+	int writer_fd;
+	int status;
+	char buf = 0;
+
+	TEST_SUCC(mkfifo(FIFO_PATH, 0644));
+
+	fifo_fd = TEST_SUCC(open(FIFO_PATH, O_PATH));
+	snprintf(proc_fd_path, sizeof(proc_fd_path), "/proc/self/fd/%d",
+		 fifo_fd);
+
+	child = TEST_SUCC(fork());
+	if (child == 0) {
+		int proc_fd;
+		int reopened_fd;
+		struct stat proc_dir_stat;
+		struct stat proc_stat;
+
+		CHECK(setresgid(-1, 65535, -1));
+		CHECK(setresuid(-1, 65535, -1));
+
+		/*
+		 * FIXME: Asterinas does not support the "dumpable" attribute
+		 * yet. So procfs files are always owned by the user
+		 * corresponding to the thread's effective UID.
+		 *
+		 * When resolving this FIXME, keep in mind that if the
+		 * "dumpable" attribute is not set, the procfs fd entry below
+		 * will be owned by the root user. However, the re-open should
+		 * still succeed because Linux uses special logic to bypass
+		 * the permission check.
+		 */
+#ifdef __asterinas__
+		CHECK(prctl(PR_SET_DUMPABLE, 1));
+		CHECK_WITH(prctl(PR_GET_DUMPABLE), _ret != 1);
+#else
+		CHECK_WITH(prctl(PR_GET_DUMPABLE), _ret != 1);
+		CHECK_WITH(stat("/proc/self/fd", &proc_dir_stat),
+			   proc_dir_stat.st_uid == 0 &&
+				   proc_dir_stat.st_gid == 0);
+		CHECK(prctl(PR_SET_DUMPABLE, 1));
+		CHECK_WITH(prctl(PR_GET_DUMPABLE), _ret == 1);
+#endif
+
+		CHECK_WITH(stat("/proc/self/fd", &proc_dir_stat),
+			   proc_dir_stat.st_uid == 65535 &&
+				   proc_dir_stat.st_gid == 65535);
+
+		// Open the procfs fd entry itself. With `O_PATH | O_NOFOLLOW`, `fstat`
+		// reports the owner of `/proc/self/fd/<n>` instead of the FIFO target.
+		proc_fd = CHECK(open(proc_fd_path, O_PATH | O_NOFOLLOW));
+		CHECK_WITH(fstat(proc_fd, &proc_stat),
+			   proc_stat.st_uid == 65535 &&
+				   proc_stat.st_gid == 65535);
+		CHECK(close(proc_fd));
+
+		// The FIFO target is owned by the root user, yet it is world-readable.
+		// So it can be re-opened.
+		reopened_fd = CHECK(open(proc_fd_path, O_RDONLY));
+		CHECK_WITH(fstat(reopened_fd, &proc_stat),
+			   proc_stat.st_uid == 0 && proc_stat.st_gid == 0);
+
+		CHECK_WITH(read(reopened_fd, &buf, 1), _ret == 1 && buf == 'X');
+		CHECK(close(reopened_fd));
+
+		exit(EXIT_SUCCESS);
+	}
+
+	writer_fd = TEST_SUCC(open(FIFO_PATH, O_WRONLY));
+	TEST_RES(write(writer_fd, "X", 1), _ret == 1);
+	TEST_SUCC(close(writer_fd));
+
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(close(fifo_fd));
+	TEST_SUCC(unlink(FIFO_PATH));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -119,6 +119,7 @@ echo "All mount bind file test passed."
 ./procfs/getdents
 ./procfs/mountstats
 ./procfs/pid_mem
+./procfs/proc_fd_open_fifo_after_setid
 ./procfs/tid
 
 ./pseudofs/memfd_access_err


### PR DESCRIPTION
Set the ownership of `/proc/[pid]/fd`, `/proc/[pid]/fd/<n>`, and `/proc/[pid]/fdinfo/<n>` from the target task credentials instead of leaving them as the `procfs` template default `root:root`.

This fixes cases where a child process changes its `uid/gid` and then opens an inherited FIFO through `/proc/self/fd/<fd>`. Without the correct `procfs` inode ownership, permission checks can reject the open even though Linux allows this path.

This aligns Linux's behavior since Linux updates `proc fd inode` ownership from the target task when instantiating `fd` and `fdinfo` entries:

```c
task_dump_owner(task, 0, &inode->i_uid, &inode->i_gid);
```
This is done through [`tid_fd_update_inode()`](https://github.com/torvalds/linux/blob/b4e07588e743c989499ca24d49e752c074924a9a/fs/proc/fd.c#L127-L141), which is called when creating both [`/proc/[pid]/fd/<n>`](https://github.com/torvalds/linux/blob/b4e07588e743c989499ca24d49e752c074924a9a/fs/proc/fd.c#L220) and [`/proc/[pid]/fdinfo/<n>`](https://github.com/torvalds/linux/blob/b4e07588e743c989499ca24d49e752c074924a9a/fs/proc/fd.c#L384).

Linux also documents why `/proc/[pid]/fd` needs special handling, see [here](https://github.com/torvalds/linux/blob/b4e07588e743c989499ca24d49e752c074924a9a/fs/proc/fd.c#L327-L330):
```c
/* /proc/pid/fd needs a special permission handler so that a process can still
 * access /proc/self/fd after it has executed a setuid().
 */
```