### PR TITLE
Fix `Cursor::jump` documentation

### DIFF
--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -245,6 +245,7 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
     }
 
     /// Jumps to the given virtual address.
+    ///
     /// If the target address is out of the range, this method will return `Err`.
     ///
     /// # Panics
@@ -373,8 +374,7 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     ///
     /// # Panics
     ///
-    /// This method panics if the address is out of the range where the cursor is required to operate,
-    /// or has bad alignment.
+    /// This method panics if the address has bad alignment.
     pub fn jump(&mut self, va: Vaddr) -> Result<(), PageTableError> {
         self.0.jump(va)
     }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -291,6 +291,12 @@ impl Cursor<'_> {
     }
 
     /// Jumps to the virtual address.
+    ///
+    /// If the target address is out of the range, this method will return `Err`.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the address has bad alignment.
     pub fn jump(&mut self, va: Vaddr) -> Result<()> {
         self.0.jump(va)?;
         Ok(())
@@ -337,6 +343,10 @@ impl<'a> CursorMut<'a> {
     /// Jumps to the virtual address.
     ///
     /// This is the same as [`Cursor::jump`].
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the address has bad alignment.
     pub fn jump(&mut self, va: Vaddr) -> Result<()> {
         self.pt_cursor.jump(va)?;
         Ok(())


### PR DESCRIPTION
- Document missing panic conditions for `vm_space::Cursor::jump` and `vm_space::CursorMut::jump`.
- Fix the internal documentation for `page_table::CursorMut::jump`.