### PR TITLE
Refactor mount filesystem creation with `MountContext`

### DIFF
--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -2,7 +2,6 @@
 
 use alloc::sync::Arc;
 
-use aster_block::BlockDevice;
 use aster_systree::EmptyNode;
 use ostd::task::Task;
 use spin::Once;
@@ -14,12 +13,11 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
-    prelude::*,
     process::posix_thread::AsThreadLocal,
 };
 
@@ -95,13 +93,8 @@ impl FsType for CgroupFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(CgroupFs::singleton().clone() as _)
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(CgroupFs::singleton().clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -2,24 +2,20 @@
 
 use alloc::sync::Arc;
 
-use aster_block::BlockDevice;
 use aster_systree::SysNode;
 use spin::Once;
 
 use super::inode::ConfigInode;
-use crate::{
-    fs::{
-        Result,
-        configfs::systree_node::ConfigRootNode,
-        pseudofs::AnonDeviceId,
-        utils::systree_inode::SysTreeInodeTy,
-        vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
-            inode::Inode,
-            registry::{FsProperties, FsType},
-        },
+use crate::fs::{
+    Result,
+    configfs::systree_node::ConfigRootNode,
+    pseudofs::AnonDeviceId,
+    utils::systree_inode::SysTreeInodeTy,
+    vfs::{
+        file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+        inode::Inode,
+        registry::{FsCreationCtx, FsProperties, FsType},
     },
-    prelude::*,
 };
 
 /// A file system that provides a user-space interface for configuring kernel objects.
@@ -97,13 +93,8 @@ impl FsType for ConfigFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(ConfigFs::singleton().clone() as _)
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(ConfigFs::singleton().clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn SysNode>> {

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -16,9 +16,9 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, Inode, InodeIo, Metadata, MknodType},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -133,12 +133,7 @@ impl FsType for DevPtsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(DevPts::new())
     }
 

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -27,10 +27,10 @@ use crate::{
     fs::{
         exfat::{constants::*, inode::Ino},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
             page_cache::{CachePage, PageCache, PageCacheBackend},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -478,13 +478,11 @@ impl FsType for ExfatType {
         FsProperties::NEED_DISK
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        disk: Option<Arc<dyn BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
-        ExfatFs::open(disk.unwrap(), ExfatMountOptions::default()).map(|fs| fs as _)
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(ExfatFs::open(
+            fs_creation_ctx.resolve_block_device()?,
+            ExfatMountOptions::default(),
+        )?)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -12,8 +12,8 @@ use super::{
     super_block::{RawSuperBlock, SUPER_BLOCK_OFFSET, SuperBlock},
 };
 use crate::fs::vfs::{
-    file_system::{FileSystem, FsEventSubscriberStats, FsFlags},
-    registry::{FsProperties, FsType},
+    file_system::{FileSystem, FsEventSubscriberStats},
+    registry::{FsCreationCtx, FsProperties, FsType},
 };
 
 /// The root inode number.
@@ -463,13 +463,8 @@ impl FsType for Ext2Type {
         FsProperties::NEED_DISK
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        disk: Option<Arc<dyn BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ext2::open(disk.unwrap()).map(|fs| fs as _)
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(Ext2::open(fs_creation_ctx.resolve_block_device()?)?)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -23,10 +23,10 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
             path::{FsPath, Path},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -1167,17 +1167,12 @@ impl FsType for OverlayFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let mut lower = Vec::new();
         let mut upper = "";
         let mut work = "";
 
-        let args = args.ok_or(Error::new(Errno::EINVAL))?;
+        let args = fs_creation_ctx.args().ok_or(Error::new(Errno::EINVAL))?;
         let args = args.to_string_lossy();
         let entries = args.split(',');
 
@@ -1221,7 +1216,7 @@ impl FsType for OverlayFsType {
             .collect::<Result<Vec<_>>>()?;
         let work = path_resolver.lookup(&FsPath::try_from(work)?)?;
 
-        OverlayFs::new(upper, lower, work).map(|fs| fs as _)
+        Ok(OverlayFs::new(upper, lower, work)?)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -27,9 +27,9 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{DirEntryVecExt, NAME_MAX},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -129,12 +129,7 @@ impl FsType for ProcFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(ProcFs::new())
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -9,9 +9,9 @@ use crate::{
         pipe::AnonPipeInode,
         pseudofs::NaivePseudoFs,
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FileSystem,
             path::{Mount, Path},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -55,12 +55,7 @@ impl FsType for PipeFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         return_errno_with_message!(Errno::EINVAL, "pipefs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -9,9 +9,9 @@ use crate::{
         file::mkmod,
         pseudofs::{NaivePseudoFs, PseudoInodeType},
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FileSystem,
             path::{Mount, Path},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -63,12 +63,7 @@ impl FsType for SockFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         return_errno_with_message!(Errno::EINVAL, "sockfs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -24,11 +24,11 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{CStr256, DirentVisitor},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
             page_cache::{CachePage, PageCache, PageCacheBackend},
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -1333,12 +1333,7 @@ impl FsType for RamFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(RamFs::new())
     }
 

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -9,9 +9,9 @@ use crate::{
         sysfs::{self, inode::SysFsInode},
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -92,13 +92,8 @@ impl FsType for SysFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
-        Ok(SysFs::singleton().clone() as _)
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(SysFs::singleton().clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -4,9 +4,9 @@ use crate::{
     fs::{
         ramfs::RamFs,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -63,12 +63,7 @@ impl FsType for TmpFsType {
         FsProperties::empty()
     }
 
-    fn create(
-        &self,
-        _flags: FsFlags,
-        _args: Option<CString>,
-        _disk: Option<Arc<dyn aster_block::BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(TmpFs::new())
     }
 

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::ffi::CStr;
+
 use aster_block::BlockDevice;
 use aster_systree::{
     AttrLessBranchNodeFields, SysNode, SysObj, SysPerms, SysStr, inherit_sys_branch_node,
@@ -9,7 +11,10 @@ use spin::Once;
 use crate::{
     fs::{
         fs_impls::sysfs,
-        vfs::file_system::{FileSystem, FsFlags},
+        vfs::{
+            file_system::{FileSystem, FsFlags},
+            path::{AT_FDCWD, FsPath},
+        },
     },
     prelude::*,
 };
@@ -23,15 +28,7 @@ pub trait FsType: Send + Sync + 'static {
     fn properties(&self) -> FsProperties;
 
     /// Creates an instance of this FS type.
-    ///
-    /// The optional `disk` argument must be provided
-    /// if `self.properties()` contains `FsProperties::NEED_DISK`.
-    fn create(
-        &self,
-        flags: FsFlags,
-        args: Option<CString>,
-        disk: Option<Arc<dyn BlockDevice>>,
-    ) -> Result<Arc<dyn FileSystem>>;
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>>;
 
     /// Returns a `SysTree` node that represents the FS type.
     ///
@@ -41,6 +38,72 @@ pub trait FsType: Send + Sync + 'static {
     /// The same result will be returned by this method
     /// when it is called multiple times.
     fn sysnode(&self) -> Option<Arc<dyn SysNode>>;
+}
+
+/// A context that describes the inputs used to create a filesystem instance.
+///
+/// This context will be used by [`FsType::create`].
+pub struct FsCreationCtx<'a> {
+    source: Option<&'a str>,
+    flags: FsFlags,
+    args: Option<&'a CStr>,
+    task_ctx: &'a Context<'a>,
+}
+
+impl<'a> FsCreationCtx<'a> {
+    /// Creates a filesystem creation context from syscall inputs.
+    pub fn new(
+        source: Option<&'a str>,
+        flags: FsFlags,
+        args: Option<&'a CStr>,
+        task_ctx: &'a Context<'a>,
+    ) -> Self {
+        Self {
+            flags,
+            source,
+            args,
+            task_ctx,
+        }
+    }
+
+    /// Returns the user-supplied mount source.
+    pub(in crate::fs) fn source(&self) -> Option<&str> {
+        self.source
+    }
+
+    /// Returns the user-supplied mount flags.
+    #[expect(dead_code)]
+    pub(in crate::fs) fn flags(&self) -> FsFlags {
+        self.flags
+    }
+
+    /// Returns the filesystem-specific mount arguments.
+    pub(in crate::fs) fn args(&self) -> Option<&CStr> {
+        self.args
+    }
+
+    /// Resolves the mount source into a block device.
+    pub(in crate::fs) fn resolve_block_device(&self) -> Result<Arc<dyn BlockDevice>> {
+        let source = self
+            .source()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
+        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, source)?;
+        let path = self
+            .task_ctx
+            .thread_local
+            .borrow_fs()
+            .resolver()
+            .read()
+            .lookup_no_follow(&fs_path)?;
+
+        if !path.type_().is_device() {
+            return_errno_with_message!(Errno::ENODEV, "the path is not a device file");
+        }
+        let id = path.metadata().self_dev_id;
+
+        id.and_then(aster_block::lookup)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))
+    }
 }
 
 bitflags! {

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -7,7 +7,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsFlags},
             path::{AT_FDCWD, FsPath, MountPropType, Path, PerMountFlags},
-            registry::{FsProperties, FsType},
+            registry::{FsCreationCtx, FsType},
         },
     },
     prelude::*,
@@ -227,9 +227,9 @@ fn do_new_mount(
     Ok(())
 }
 
-/// Gets the filesystem by fs_type and dev_name.
+/// Gets the filesystem by fs_type and source.
 fn open_fs(
-    dev_name: Option<&str>,
+    source: Option<&str>,
     flags: MountFlags,
     fs_type: &dyn FsType,
     data_addr: Vaddr,
@@ -242,32 +242,8 @@ fn open_fs(
         Some(user_space.read_cstring(data_addr, MAX_FILENAME_LEN)?)
     };
 
-    let disk = if fs_type.properties().contains(FsProperties::NEED_DISK) {
-        let dev_name = dev_name
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, dev_name)?;
-        let path = ctx
-            .thread_local
-            .borrow_fs()
-            .resolver()
-            .read()
-            .lookup_no_follow(&fs_path)?;
-        if !path.type_().is_device() {
-            return_errno_with_message!(Errno::ENODEV, "the path is not a device file");
-        }
-
-        let id = path.metadata().self_dev_id;
-        let device = id.and_then(aster_block::lookup);
-        if device.is_none() {
-            return_errno_with_message!(Errno::ENODEV, "the device is not found");
-        }
-
-        device
-    } else {
-        None
-    };
-
-    fs_type.create(flags.into(), data, disk)
+    let fs_creation_ctx = FsCreationCtx::new(source, flags.into(), data.as_deref(), ctx);
+    fs_type.create(&fs_creation_ctx)
 }
 
 bitflags! {


### PR DESCRIPTION
  ## Summary

  Refactor filesystem creation during `mount(2)` by introducing
  `MountContext` and passing it through `FsType::create`.

  Instead of threading mount flags, source/data, and block-device lookup
  through separate parameters, the mount path now builds a single context
  object and each filesystem implementation pulls the inputs it needs
  from that context.

  ## Why

  The old interface resolved `source` into a block device in the generic
  mount path and passed the result into `FsType::create`.

  That is too specific for a generic mount API. `source` is interpreted
  differently by different filesystems: for example, ext2/exfat treat it
  as a device path, while virtiofs treats it as a tag. Those semantics
  belong to the filesystem implementation, not to the shared mount layer.

  This change keeps mount inputs in their original form and passes them
  through `MountContext`, so each filesystem can interpret `source` in
  the way that matches its own mount semantics. Common code no longer
  assumes that `source` always means “a block device”.
  ## Notes

  - block-backed filesystems now resolve their backing device through the
    shared mount context helper
  - virtiofs now uses the mount source directly as its tag input