### PR TITLE
Add a read_random implementation for riscv architecture

### DIFF
--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -103,9 +103,75 @@ pub fn read_tsc() -> u64 {
 /// Reads a hardware generated 64-bit random value.
 ///
 /// Returns `None` if no random value was generated.
+///
+/// This implementation uses the RISC-V Entropy Source Extension (Zkr) which
+/// provides access to a physical entropy source via the `seed` CSR.
+///
+/// Reference:
+/// - "RISC-V Cryptography Extensions Volume I: Scalar & Entropy Source Instructions"
+///   - <https://docs.riscv.org/reference/isa/extensions/crypto-scalar/_attachments/riscv-crypto-spec-scalar.pdf>
+///   - Section 2.9: Zkr - Entropy Source Extension
+///   - Section 4.1: The `seed` CSR
 pub fn read_random() -> Option<u64> {
-    // FIXME: Implement a hardware random number generator on RISC-V platforms.
-    None
+    use cpu::extension::{IsaExtensions, has_extensions};
+
+    // Check if the Zkr (Entropy Source) extension is available.
+    if !has_extensions(IsaExtensions::ZKR) {
+        return None;
+    }
+
+    const RETRY_LIMIT: usize = 10;
+
+    const OPST_SHIFT: usize = 30;
+    const OPST_MASK: usize = 0b11 << OPST_SHIFT;
+    const ENTROPY_MASK: usize = 0xFFFF;
+
+    const OPST_ES16: usize = 0b10; // Status indicating entropy is available
+    const OPST_WAIT: usize = 0b01; // Status indicating entropy source is busy (waiting)
+    const OPST_BIST: usize = 0b00; // Status indicating entropy source is in self-test
+    const OPST_DEAD: usize = 0b11; // Status indicating entropy source has failed
+
+    // Read 16-bit entropy from hardware.
+    let read_entropy = || -> Option<u16> {
+        for _ in 0..RETRY_LIMIT {
+            let seed_val: usize;
+            // SAFETY: We've checked that the Zkr extension is available.
+            // Therefore, this is a valid instruction to access the `seed` CSR.
+            unsafe {
+                // The Zkr spec requires using `csrrw` to access `seed` CSR,
+                // which signals polling and flushing. See the spec for more
+                // information.
+                core::arch::asm!(
+                    "csrrw {0}, seed, zero",
+                    out(reg) seed_val,
+                    options(nomem, nostack)
+                );
+            }
+
+            // Extract status bits (bits 31:30).
+            let status = (seed_val & OPST_MASK) >> OPST_SHIFT;
+
+            if status == OPST_ES16 {
+                // Entropy is available: extract 16 bits (bits 15:0).
+                return Some((seed_val & ENTROPY_MASK) as u16);
+            } else if status == OPST_DEAD {
+                // Entropy source failed permanently.
+                return None;
+            } else if status == OPST_WAIT || status == OPST_BIST {
+                // Entropy source busy or running self-test: retry.
+                core::hint::spin_loop();
+            }
+        }
+        None
+    };
+
+    // Collect 4 chunks of 16-bit entropy to form a 64-bit random value.
+    let result = (read_entropy()? as u64)
+        | ((read_entropy()? as u64) << 16)
+        | ((read_entropy()? as u64) << 32)
+        | ((read_entropy()? as u64) << 48);
+
+    Some(result)
 }
 
 pub(crate) fn enable_cpu_features() {

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -61,7 +61,7 @@ if [ "$1" = "riscv" ]; then
     # The ordering below ensures `x1` (ext2.img) is discovered before `x0`, maintaining this assumption.
     # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
     QEMU_ARGS="\
-        -cpu rv64,svpbmt=true \
+        -cpu rv64,svpbmt=true,zkr=true \
         -machine virt \
         -m ${MEM:-8G} \
         -smp ${SMP:-1} \


### PR DESCRIPTION
This PR adds a implementation of `read_random` for RISC-V architecture. It is a function to read hardware generated 64-bit random value. This implementation uses the RISC-V Entropy Source Extension (Zkr) which provides access to a physical entropy source via the `seed` CSR and follows a similar retry pattern as the x86 `RDRAND` version, adapted for RISC-V's 16-bit entropy output. 

The source of reference is [RISC-V Cryptography Extensions Volume I: Scalar & Entropy Source Instructions](https://docs.riscv.org/reference/isa/extensions/crypto-scalar/_attachments/riscv-crypto-spec-scalar.pdf)

The logic goes like:

1. Check hardware support for `Zkr` extension
2. Prepare to build a 64-bit random value from 16-bit pieces.  
- The `seed` CSR only gives 16 bits of entropy per successful read (`ES16` status). So it needs 4 successful chunks to assemble one `u64`.
3. For each of the 4 chunks, poll with retry.
4. Decode status from bits 31:30.
5. Fail if any chunk cannot be obtained in time.
6. Return complete 64-bit result.