### PR TITLE
Fix duplicate RISC-V console output

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -59,7 +59,7 @@ qemu.args = """\
     --no-reboot \
     -nographic \
     -display none \
-    -serial chardev:mux \
+    -serial file:qemu-serial.log \
     -monitor chardev:mux \
     -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
     -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \


### PR DESCRIPTION
## Summary
- Route the RISC-V UART serial output to `qemu-serial.log` instead of the stdio mux.
- Keep virtconsole connected to the stdio mux so kernel/user-space console output remains visible in the terminal and `qemu.log`.
- Avoid duplicate boot logo and kernel log output during RISC-V QEMU runs.

## Testing
- `CARGO_TARGET_DIR=/tmp/asterinas-target make run_kernel OSDK_TARGET_ARCH=riscv64 AUTO_TEST=boot`
- `CARGO_TARGET_DIR=/tmp/asterinas-target make run_kernel OSDK_TARGET_ARCH=riscv64 AUTO_TEST=boot SMP=4`