### PR TITLE
Support dummy `cpu.weight` and `cpu.max` attributes for cgroup cpu sub-controller

### DIFF
--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
@@ -1,32 +1,64 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicU32, Ordering};
 
-use aster_systree::{Error, Result, SysAttrSetBuilder, SysPerms, SysStr};
+use aster_systree::{Error, MAX_ATTR_SIZE, Result, SysAttrSetBuilder, SysPerms, SysStr};
 use aster_util::{per_cpu_counter::PerCpuCounter, printer::VmPrinter};
 use ostd::{
     cpu::CpuId,
     mm::{VmReader, VmWriter},
+    sync::SpinLock,
     task::atomic_mode::AsAtomicModeGuard,
     timer::Jiffies,
+    warn,
 };
 
 use crate::{
     fs::cgroupfs::systree_node::{CgroupSysNode, CgroupSystem},
     process::Process,
+    util::ReadCString,
 };
 
 /// A sub-controller responsible for CPU resource management in the cgroup subsystem.
 ///
 /// This controller always exists so that `cpu.stat` remains readable even before `+cpu`
-/// is enabled. When inactive, only the base usage fields are exposed. The `user` and
-/// `system` counters store CPU time in units of one [`Jiffies`] per increment, and
-/// `usage_usec` is derived from their sum when `cpu.stat` is read.
+/// is enabled. When inactive, only the base usage fields are exposed and the non-root
+/// CPU control files are hidden.
 pub struct CpuController {
-    is_enabled: AtomicBool,
+    /// Persistent CPU usage accounting for this cgroup.
+    stats: CpuStats,
+    /// Optional CPU resource control attributes exposed only when `+cpu` is active.
+    control: Option<CpuControl>,
+}
+
+/// CPU usage accounting that survives CPU controller toggles.
+struct CpuStats {
+    /// A counter accumulates CPU time spent executing user-space code.
+    ///
+    /// The counter is in units of one [`Jiffies`] per increment.
     user: PerCpuCounter,
+    /// A counter accumulates CPU time spent executing kernel code on behalf of tasks.
+    ///
+    /// The counter is in units of one [`Jiffies`] per increment.
     system: PerCpuCounter,
+}
+
+/// CPU resource controls that are reset whenever `+cpu` is re-enabled.
+struct CpuControl {
+    /// A value stores the configured relative CPU share for scheduler integration.
+    weight: AtomicU32,
+    /// A value stores the configured CPU bandwidth limit for scheduler integration.
+    max: SpinLock<CpuMax>,
+}
+
+/// A CPU bandwidth limit.
+#[derive(Clone, Copy)]
+struct CpuMax {
+    /// The configured CPU runtime budget for bandwidth enforcement.
+    quota_usec: u64,
+    /// The window over which the CPU runtime budget is intended to apply.
+    period_usec: u64,
 }
 
 /// Specifies the cgroup CPU sub-controller receives one [`Jiffies`] of charge.
@@ -39,29 +71,52 @@ pub enum CpuStatKind {
 }
 
 impl CpuController {
-    pub(super) fn init_attr_set(builder: &mut SysAttrSetBuilder, _is_root: bool) {
+    pub(super) fn init_attr_set(builder: &mut SysAttrSetBuilder, is_root: bool) {
         builder.add(SysStr::from("cpu.stat"), SysPerms::DEFAULT_RO_ATTR_PERMS);
-    }
 
-    fn new(is_enabled: bool) -> Self {
-        Self {
-            is_enabled: AtomicBool::new(is_enabled),
-            user: PerCpuCounter::new(),
-            system: PerCpuCounter::new(),
+        if !is_root {
+            builder.add(SysStr::from("cpu.weight"), SysPerms::DEFAULT_RW_ATTR_PERMS);
+            builder.add(SysStr::from("cpu.max"), SysPerms::DEFAULT_RW_ATTR_PERMS);
         }
     }
 
-    fn write_cpu_stat_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    fn new(is_active: bool) -> Self {
+        Self {
+            stats: CpuStats::new(),
+            control: is_active.then(CpuControl::new),
+        }
+    }
+
+    /// Initializes CPU usage statistics from the previous sub-controller.
+    ///
+    /// Toggling `+cpu` must reset some controller attributes such as `cpu.weight`
+    /// and `cpu.max`, but `cpu.stat` remains visible and continues to report the
+    /// accumulated CPU usage.
+    pub(super) fn init_stats(&mut self, previous: &Self) {
+        // No one cares which CPU the count is on. Therefore, choose the BSP for simplicity.
+        self.stats.user.add_on_cpu(
+            CpuId::bsp(),
+            isize::try_from(previous.stats.user.sum_all_cpus()).unwrap_or(isize::MAX),
+        );
+        self.stats.system.add_on_cpu(
+            CpuId::bsp(),
+            isize::try_from(previous.stats.system.sum_all_cpus()).unwrap_or(isize::MAX),
+        );
+    }
+
+    fn control(&self) -> Result<&CpuControl> {
+        self.control.as_ref().ok_or(Error::AttributeError)
+    }
+
+    fn read_cpu_stat(&self, printer: &mut VmPrinter) -> Result<usize> {
         /// Converts a per-CPU counter expressed in jiffies to microseconds.
         fn counter_usec(counter: &PerCpuCounter) -> u64 {
             let jiffies = u64::try_from(counter.sum_all_cpus()).unwrap_or(u64::MAX);
             u64::try_from(Jiffies::new(jiffies).as_duration().as_micros()).unwrap_or(u64::MAX)
         }
 
-        let mut printer = VmPrinter::new_skip(writer, offset);
-
-        let user_usec = counter_usec(&self.user);
-        let system_usec = counter_usec(&self.system);
+        let user_usec = counter_usec(&self.stats.user);
+        let system_usec = counter_usec(&self.stats.system);
         writeln!(
             printer,
             "usage_usec {}",
@@ -70,7 +125,7 @@ impl CpuController {
         writeln!(printer, "user_usec {}", user_usec)?;
         writeln!(printer, "system_usec {}", system_usec)?;
 
-        if self.is_enabled.load(Ordering::Relaxed) {
+        if self.control.is_some() {
             // TODO: Support CPU bandwidth control statistics. These fields are reported as `0`
             // for now because the cgroup CPU sub-controller does not yet implement throttling or
             // burst accounting.
@@ -84,34 +139,169 @@ impl CpuController {
         Ok(printer.bytes_written())
     }
 
-    pub(super) fn enable(&self) {
-        self.is_enabled.store(true, Ordering::Relaxed);
-    }
-
-    pub(super) fn disable(&self) {
-        self.is_enabled.store(false, Ordering::Relaxed);
-    }
-
     /// Accounts one [`Jiffies`] of CPU time on `cpu`.
     fn account(&self, cpu: CpuId, stat_kind: CpuStatKind) {
         match stat_kind {
-            CpuStatKind::User => self.user.add_on_cpu(cpu, 1),
-            CpuStatKind::System => self.system.add_on_cpu(cpu, 1),
+            CpuStatKind::User => self.stats.user.add_on_cpu(cpu, 1),
+            CpuStatKind::System => self.stats.system.add_on_cpu(cpu, 1),
+        }
+    }
+}
+
+impl CpuControl {
+    fn new() -> Self {
+        // The default CPU weight is 100 and the default CPU bandwidth limit is
+        // unlimited quota with a 100ms period.
+        //
+        // Reference: <https://docs.kernel.org/admin-guide/cgroup-v2.html#cpu-interface-files>
+        const DEFAULT_WEIGHT: u32 = 100;
+        const DEFAULT_QUOTA_USEC: u64 = u64::MAX;
+        const DEFAULT_PERIOD_USEC: u64 = 100_000;
+
+        Self {
+            weight: AtomicU32::new(DEFAULT_WEIGHT),
+            max: SpinLock::new(CpuMax {
+                quota_usec: DEFAULT_QUOTA_USEC,
+                period_usec: DEFAULT_PERIOD_USEC,
+            }),
+        }
+    }
+}
+
+impl CpuStats {
+    fn new() -> Self {
+        Self {
+            user: PerCpuCounter::new(),
+            system: PerCpuCounter::new(),
         }
     }
 }
 
 impl super::SubControl for CpuController {
-    fn read_attr_at(&self, name: &str, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        if name != "cpu.stat" {
-            return Err(Error::AttributeError);
-        }
-
-        self.write_cpu_stat_at(offset, writer)
+    fn is_attr_absent(&self, name: &str) -> bool {
+        matches!(name, "cpu.weight" | "cpu.max") && self.control.is_none()
     }
 
-    fn write_attr(&self, _name: &str, _reader: &mut VmReader) -> Result<usize> {
-        Err(Error::AttributeError)
+    fn read_attr_at(&self, name: &str, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        match name {
+            "cpu.stat" => return self.read_cpu_stat(&mut printer),
+            "cpu.weight" => {
+                let weight = self.control()?.weight.load(Ordering::Relaxed);
+                writeln!(printer, "{}", weight)?;
+            }
+            "cpu.max" => {
+                let max = *self.control()?.max.lock();
+                if max.quota_usec == u64::MAX {
+                    writeln!(printer, "max {}", max.period_usec)?;
+                } else {
+                    writeln!(printer, "{} {}", max.quota_usec, max.period_usec)?;
+                }
+            }
+            _ => return Err(Error::AttributeError),
+        }
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_attr(&self, name: &str, reader: &mut VmReader) -> Result<usize> {
+        match name {
+            "cpu.weight" => {
+                let control = self.control()?;
+
+                // The cgroup v2 CPU weight is a scheduling weight in the range 1..=10000.
+                //
+                // Reference: <https://docs.kernel.org/admin-guide/cgroup-v2.html#cpu-interface-files>
+                const MIN_WEIGHT: u32 = 1;
+                const MAX_WEIGHT: u32 = 10_000;
+
+                let (content, len) = reader
+                    .read_cstring_until_end(MAX_ATTR_SIZE)
+                    .map_err(|_| Error::PageFault)?;
+                let weight = content
+                    .to_str()
+                    .map_err(|_| Error::InvalidOperation)?
+                    .trim()
+                    .parse::<u32>()
+                    .map_err(|_| Error::InvalidOperation)?;
+                if !(MIN_WEIGHT..=MAX_WEIGHT).contains(&weight) {
+                    return Err(Error::InvalidOperation);
+                }
+
+                // TODO: Enforce cgroup CPU weight for scheduling and remove this warning.
+                warn!(
+                    "`cpu.weight` is accepted but not enforced yet; weight = {}",
+                    weight
+                );
+                control.weight.store(weight, Ordering::Relaxed);
+
+                Ok(len)
+            }
+            "cpu.max" => {
+                let control = self.control()?;
+
+                // The cgroup v2 CPU bandwidth limit is `$MAX $PERIOD`, where `$MAX` is
+                // either `max` or at least 1ms and `$PERIOD` is in the range 1ms..=1s.
+                //
+                // Reference: <https://docs.kernel.org/admin-guide/cgroup-v2.html#cpu-interface-files>
+                const MIN_QUOTA_USEC: u64 = 1_000;
+                const MIN_PERIOD_USEC: u64 = 1_000;
+                const MAX_PERIOD_USEC: u64 = 1_000_000;
+
+                let (content, len) = reader
+                    .read_cstring_until_end(MAX_ATTR_SIZE)
+                    .map_err(|_| Error::PageFault)?;
+                let content = content
+                    .to_str()
+                    .map_err(|_| Error::InvalidOperation)?
+                    .trim();
+                let mut tokens = content.split_whitespace();
+
+                let Some(quota_token) = tokens.next() else {
+                    return Err(Error::InvalidOperation);
+                };
+                let period_token = tokens.next();
+
+                // Check whether `quota_usec` is valid.
+                let quota_usec = if quota_token == "max" {
+                    u64::MAX
+                } else if let Ok(quota_usec) = quota_token.parse::<u64>() {
+                    if quota_usec < MIN_QUOTA_USEC {
+                        return Err(Error::InvalidOperation);
+                    }
+                    quota_usec
+                } else {
+                    return Err(Error::InvalidOperation);
+                };
+
+                // Check whether `period_usec` is valid.
+                let period_usec = if let Some(period_usec) =
+                    period_token.and_then(|period_token| period_token.parse::<u64>().ok())
+                {
+                    if !(MIN_PERIOD_USEC..=MAX_PERIOD_USEC).contains(&period_usec) {
+                        return Err(Error::InvalidOperation);
+                    }
+                    Some(period_usec)
+                } else {
+                    None
+                };
+
+                // TODO: Enforce CPU bandwidth throttling and remove this warning.
+                warn!(
+                    "`cpu.max` is accepted but not enforced yet; quota = {}, period = {:?}",
+                    quota_usec, period_usec
+                );
+                let mut max = control.max.lock();
+                max.quota_usec = quota_usec;
+                if let Some(period_usec) = period_usec {
+                    max.period_usec = period_usec;
+                }
+
+                Ok(len)
+            }
+            _ => Err(Error::AttributeError),
+        }
     }
 }
 
@@ -130,14 +320,6 @@ impl super::SubControlStatic for CpuController {
 }
 
 impl super::SubController<CpuController> {
-    pub(super) fn enable(&self) {
-        self.inner.as_ref().unwrap().enable();
-    }
-
-    pub(super) fn disable(&self) {
-        self.inner.as_ref().unwrap().disable();
-    }
-
     /// Accounts one [`Jiffies`] of CPU time for this cgroup and all of its ancestors.
     fn account_hierarchy(&self, stat_kind: CpuStatKind) {
         // This is race-free because `charge_cpu_time` holds `cgroup_guard` when

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
@@ -31,6 +31,10 @@ mod pids;
 
 /// A trait to abstract all individual cgroup sub-controllers.
 trait SubControl {
+    fn is_attr_absent(&self, _name: &str) -> bool {
+        false
+    }
+
     fn read_attr_at(&self, name: &str, offset: usize, writer: &mut VmWriter) -> Result<usize>;
 
     fn write_attr(&self, name: &str, reader: &mut VmReader) -> Result<usize>;
@@ -274,12 +278,12 @@ impl Controller {
         };
 
         let sub_controller = self.read_sub(ctrl_type);
-        if sub_controller.try_get().is_none() {
+        let Some(controller) = sub_controller.try_get() else {
             // If the sub-controller is not active, all its attributes are considered absent.
-            true
-        } else {
-            false
-        }
+            return true;
+        };
+
+        controller.is_attr_absent(name)
     }
 
     pub(super) fn read_attr_at(
@@ -396,18 +400,18 @@ impl Controller {
                     child_node.controller().cpuset.update(new_controller);
                 }
                 SubCtrlType::Cpu => {
-                    // Preserve the accumulated CPU accounting while toggling `+cpu` on the
-                    // parent. The base usage fields of `cpu.stat` are always tracked, and only
-                    // the extra throttling-related fields depend on whether the controller is active.
-                    let is_enabled = parent_controller
-                        .active_set()
-                        .contains_type(SubCtrlType::Cpu);
-                    let guard = child_node.controller().cpu.read();
-                    if is_enabled {
-                        guard.get().enable();
-                    } else {
-                        guard.get().disable();
+                    let mut new_controller: SubController<CpuController> =
+                        SubController::new(Some(parent_controller));
+                    {
+                        let guard = child_node.controller().cpu.read();
+                        let previous_controller = guard.get();
+                        new_controller
+                            .inner
+                            .as_mut()
+                            .unwrap()
+                            .init_stats(previous_controller.inner.as_ref().unwrap());
                     }
+                    child_node.controller().cpu.update(Arc::new(new_controller));
                 }
                 SubCtrlType::Memory => {
                     let new_controller = Arc::new(SubController::new(Some(parent_controller)));

--- a/kernel/src/fs/fs_impls/cgroupfs/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/mod.rs
@@ -6,6 +6,13 @@ use fs::CgroupFsType;
 pub(in crate::fs) use systree_node::CgroupSystem;
 pub use systree_node::{CgroupMembership, CgroupNode, CgroupSysNode};
 
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "cgroup: "
+    };
+}
+
 mod cgroup_ns;
 mod controller;
 mod fs;

--- a/test/initramfs/src/regression/process/cgroup.sh
+++ b/test/initramfs/src/regression/process/cgroup.sh
@@ -132,6 +132,12 @@ verify "memory.max doesn't exist initially" \
 verify "cpu.stat exists initially in child" \
     "ls cpu.stat" \
     "cpu.stat"
+verify "cpu.weight doesn't exist initially" \
+    "ls cpu.weight" \
+    "ls: cpu.weight: No such file or directory"
+verify "cpu.max doesn't exist initially" \
+    "ls cpu.max" \
+    "ls: cpu.max: No such file or directory"
 
 log_step "1.5.1 Check initial child cpu.stat only reports usage fields"
 CPU_STAT_LINES=$(wc -l < cpu.stat)
@@ -170,6 +176,12 @@ echo "Current directory: $(pwd)"
 verify "cpu.stat still exists" \
     "ls cpu.stat" \
     "cpu.stat"
+verify "cpu.weight now exists" \
+    "ls cpu.weight" \
+    "cpu.weight"
+verify "cpu.max now exists" \
+    "ls cpu.max" \
+    "cpu.max"
 verify "memory.max now exists" \
     "ls memory.max" \
     "memory.max"
@@ -183,7 +195,72 @@ verify "cpu.stat has burst_usec after enabling CPU sub-controller" \
     "grep '^burst_usec ' cpu.stat" \
     "burst_usec 0"
 
-log_step "2.2.1 Verify cpu.stat grows for a busy cgroup task"
+log_step "2.2.1 Verify cpu.weight dummy read/write"
+verify "cpu.weight defaults to 100" \
+    "cat cpu.weight" \
+    "100"
+echo 250 > cpu.weight
+verify "cpu.weight accepts a valid weight" \
+    "cat cpu.weight" \
+    "250"
+
+log_step "2.2.2 Verify cpu.max dummy read/write"
+verify "cpu.max defaults to max with 100ms period" \
+    "cat cpu.max" \
+    "max 100000"
+echo "50000 200000" > cpu.max
+verify "cpu.max accepts quota and period" \
+    "cat cpu.max" \
+    "50000 200000"
+echo "30000" > cpu.max
+verify "cpu.max single value preserves period" \
+    "cat cpu.max" \
+    "30000 200000"
+verify "cpu.max rejects an invalid period" \
+    "echo '30000 999' > cpu.max 2>/dev/null || echo rejected" \
+    "rejected"
+echo "50000 invalid" > cpu.max
+verify "cpu.max accepts a non-numeric period" \
+    "cat cpu.max" \
+    "50000 200000"
+echo "max 100000" > cpu.max
+verify "cpu.max resets to default value" \
+    "cat cpu.max" \
+    "max 100000"
+
+log_step "2.2.3 Verify cpu controller settings reset after toggle"
+echo 250 > "$CGROUP_ROOT/$CGROUP_NAME/cpu.weight"
+echo "50000 200000" > "$CGROUP_ROOT/$CGROUP_NAME/cpu.max"
+
+cd "$CGROUP_ROOT"
+echo "-cpu" > cgroup.subtree_control
+verify "root subtree_control removed cpu" \
+    "cat cgroup.subtree_control" \
+    "memory pids"
+
+cd "$CGROUP_NAME"
+verify "cpu.weight removed after disabling" \
+    "ls cpu.weight" \
+    "ls: cpu.weight: No such file or directory"
+verify "cpu.max removed after disabling" \
+    "ls cpu.max" \
+    "ls: cpu.max: No such file or directory"
+
+cd "$CGROUP_ROOT"
+echo "+cpu" > cgroup.subtree_control
+verify "root subtree_control restored cpu" \
+    "cat cgroup.subtree_control" \
+    "cpu memory pids"
+
+cd "$CGROUP_NAME"
+verify "cpu.weight defaults after re-enable" \
+    "cat cpu.weight" \
+    "100"
+verify "cpu.max defaults after re-enable" \
+    "cat cpu.max" \
+    "max 100000"
+
+log_step "2.2.4 Verify cpu.stat grows for a busy cgroup task"
 CPU_STAT_PATH="$CGROUP_ROOT/$CGROUP_NAME/cpu.stat"
 
 sh -c '


### PR DESCRIPTION
Required by #2939 .