### PR TITLE
Refactor empty-path handling for `*at` syscalls

### DIFF
--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -13,7 +13,7 @@ use crate::{
         fs_impls::sysfs,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            path::{AT_FDCWD, FsPath},
+            path::{AT_FDCWD, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
@@ -87,7 +87,7 @@ impl<'a> FsCreationCtx<'a> {
         let source = self
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, source)?;
+        let fs_path = FsPath::from_fd_at(AT_FDCWD, source, EmptyPathStr::Reject)?;
         let path = self
             .task_ctx
             .thread_local

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -10,7 +10,9 @@ use inherit_methods_macro::inherit_methods;
 use mount::MountNsFileCopying;
 pub use mount::{Mount, MountPropType, PerMountFlags};
 pub use mount_namespace::MountNamespace;
-pub use resolver::{AT_FDCWD, AbsPathResult, FsPath, LookupResult, PathResolver, SplitPath};
+pub use resolver::{
+    AT_FDCWD, AbsPathResult, EmptyPathStr, FsPath, LookupResult, PathResolver, SplitPath,
+};
 
 use crate::{
     fs::{

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -24,6 +24,115 @@ use crate::{
 /// The file descriptor of the current working directory.
 pub const AT_FDCWD: RawFileDesc = -100;
 
+/// The `AT_EMPTY_PATH` flag bit, as defined by Linux.
+pub const AT_EMPTY_PATH: u32 = 0x1000;
+
+/// Policy for how [`FsPath::from_fd_at`] treats an empty `path_str`.
+///
+/// [`FsPath::from_fd_at`] is the entry point that
+/// every `*at` syscall uses to resolve its `(dirfd, path_str)` argument pair.
+/// Whether an empty `path_str` should be rejected, conditionally accepted,
+/// or always accepted depends on the specific syscall's Linux semantics.
+/// This enum makes that decision explicit at every call site.
+///
+/// # Examples
+///
+/// One call per variant, showing the three patterns side by side:
+///
+/// ```ignore
+/// // mkdirat — dentry op, a name is mandatory.
+/// let fs_path = FsPath::from_fd_at(dirfd, &path_str, EmptyPathStr::Reject)?;
+///
+/// // faccessat2 — inode op with a `flags` argument; `""` accepted
+/// // only if the caller passed AT_EMPTY_PATH.
+/// let fs_path = FsPath::from_fd_at(
+///     dirfd,
+///     &path_str,
+///     EmptyPathStr::AllowIfFlag(flags.bits()),
+/// )?;
+///
+/// // readlinkat — inode op with no `flags` argument; `""` accepted
+/// // only when `dirfd` is a real fd rather than `AT_FDCWD`.
+/// let fs_path = FsPath::from_fd_at(dirfd, &path_str, EmptyPathStr::Allow)?;
+/// ```
+///
+/// # Design Rationales
+///
+/// Two questions about a syscall determine which variant is correct:
+///
+/// 1. **Target.** Does the syscall operate on an *inode*
+///    (the data or metadata behind `dirfd`)
+///    or on a *directory entry* (a name inside a parent directory)?
+///    An empty `path_str` means "operate on `dirfd` directly" —
+///    meaningful only for inode ops,
+///    since there is no such thing as a nameless dentry
+///    to create, remove, rename, or open.
+///
+/// 2. **ABI.** Does the syscall carry a `flags` argument
+///    that can hold the [`AT_EMPTY_PATH`] opt-in bit?
+///    `AT_EMPTY_PATH` post-dates most `*at` syscalls,
+///    and callers historically passed `""` by accident (and received `ENOENT`),
+///    so the accept-empty behaviour is opt-in —
+///    and the opt-in must live in a `flags` word.
+///
+/// Quick chooser:
+///
+/// - dentry op → [`Reject`](Self::Reject)
+/// - inode op with a `flags` argument → [`AllowIfFlag`](Self::AllowIfFlag)
+/// - inode op that accepts `""` without a `flags` argument → [`Allow`](Self::Allow)
+///   (rare; see the variant's docs)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EmptyPathStr {
+    /// Always reject an empty `path_str` with `ENOENT`; a name is mandatory.
+    ///
+    /// Use for syscalls whose target is a **directory entry** —
+    /// create, remove, rename, or open a named file.
+    /// Examples: `openat`, `mkdirat`, `mknodat`, `symlinkat`, `unlinkat`,
+    /// `renameat[2]`, and `linkat`'s *newname*.
+    ///
+    /// Also the right choice for the 3-argument forms
+    /// `faccessat`, `fchmodat`, and `futimesat`:
+    /// they are inode ops,
+    /// but they predate [`AT_EMPTY_PATH`] and
+    /// have no `flags` word to carry the opt-in.
+    /// Newer code should prefer `faccessat2` / `fchmodat2` with
+    /// [`AllowIfFlag`](Self::AllowIfFlag).
+    Reject,
+
+    /// Accept an empty `path_str`
+    /// iff [`AT_EMPTY_PATH`] is set in the enclosed raw flag bits;
+    /// otherwise behave like [`Reject`](Self::Reject).
+    ///
+    /// Callers pass their syscall's raw flag bits —
+    /// typically `flags.bits()` after parsing the flag word into a typed `BitFlags`.
+    /// Only the [`AT_EMPTY_PATH`] bit is inspected; the rest are ignored.
+    ///
+    /// Use for **inode-target** syscalls that carry a `flags` argument —
+    /// the common case for attribute queries and modifications on the inode behind `dirfd`.
+    /// Examples: `faccessat2`, `fchmodat2`, `fchownat`, `fstatat` / `newfstatat`,
+    /// `statx`, `utimensat`, `name_to_handle_at`, `execveat`, and `linkat`'s *oldname*.
+    ///
+    /// Any additional gating on top of [`AT_EMPTY_PATH`]
+    /// (for instance, `linkat` also requires `CAP_DAC_READ_SEARCH`)
+    /// stays in the syscall implementation;
+    /// this enum only decides whether an empty `path_str` is syntactically acceptable.
+    AllowIfFlag(u32),
+
+    /// Accept an empty `path_str` and operate on `dirfd` directly.
+    /// No flag is consulted.
+    ///
+    /// `dirfd` must be a real file descriptor; if it is [`AT_FDCWD`],
+    /// [`FsPath::from_fd_at`] still rejects `""` with `ENOENT`.
+    ///
+    /// Use only for inode-target syscalls
+    /// that Linux has chosen to accept an empty `path_str` unconditionally,
+    /// because they have no `flags` argument
+    /// in which [`AT_EMPTY_PATH`] could live.
+    /// This is deliberately rare:
+    /// as of Linux 6.8 the sole such syscall is **`readlinkat`**.
+    Allow,
+}
+
 /// A resolver for [`Path`]s.
 ///
 /// `PathResolver` provides a context for resolving paths, defined by a root directory
@@ -741,14 +850,32 @@ impl<'a> FsPath<'a> {
         })
     }
 
-    /// Creates a new `FsPath` from the given `dirfd` and `path`.
+    /// Constructs an `FsPath` from `(dirfd, path_str)`,
+    /// applying the syscall-specific empty-path-string `policy`.
     ///
-    /// If the FD is not valid (i.e., it's negative and it's not [`AT_FDCWD`]) or the path is empty
-    /// or too long, an error will be returned.
-    pub fn from_fd_and_path(dirfd: RawFileDesc, path: &'a str) -> Result<Self> {
+    /// An empty `path_str` is handled per the variant of `policy`;
+    /// see [`EmptyPathStr`] for the full rule. A non-empty absolute `path`
+    /// ignores `dirfd`; otherwise `dirfd` must be either [`AT_FDCWD`] or a
+    /// valid file descriptor.
+    ///
+    /// # Errors
+    ///
+    /// - `ENOENT` if `path` is empty and `policy` does not permit it.
+    /// - `ENAMETOOLONG` if `path.len() > PATH_MAX`.
+    /// - `EBADF` if `dirfd` is negative and is not [`AT_FDCWD`].
+    pub fn from_fd_at(dirfd: RawFileDesc, path: &'a str, policy: EmptyPathStr) -> Result<Self> {
         if path.is_empty() {
-            return_errno_with_message!(Errno::ENOENT, "the path is empty")
+            let allowed = match policy {
+                EmptyPathStr::Reject => false,
+                EmptyPathStr::AllowIfFlag(f) => f & AT_EMPTY_PATH != 0,
+                EmptyPathStr::Allow => dirfd != AT_FDCWD,
+            };
+            if !allowed {
+                return_errno_with_message!(Errno::ENOENT, "the path is empty");
+            }
+            return Self::from_fd(dirfd);
         }
+
         if path.len() > PATH_MAX {
             return_errno_with_message!(Errno::ENAMETOOLONG, "the path is too long");
         }
@@ -771,7 +898,7 @@ impl<'a> TryFrom<&'a str> for FsPath<'a> {
     type Error = crate::error::Error;
 
     fn try_from(path: &'a str) -> Result<FsPath<'a>> {
-        FsPath::from_fd_and_path(AT_FDCWD, path)
+        FsPath::from_fd_at(AT_FDCWD, path, EmptyPathStr::Reject)
     }
 }
 
@@ -923,5 +1050,46 @@ mod test {
             (" //b//a/ ", Ok((" //b//a", " "))),
         ];
         assert_split_results(&cases, SplitPath::split_dirname_and_basename);
+    }
+
+    #[ktest]
+    fn fs_path_from_fd_at_policy_matrix() {
+        // Reject: empty always ENOENT
+        assert!(
+            FsPath::from_fd_at(AT_FDCWD, "", EmptyPathStr::Reject)
+                .is_err_and(|e| e.error() == Errno::ENOENT)
+        );
+        assert!(
+            FsPath::from_fd_at(3, "", EmptyPathStr::Reject)
+                .is_err_and(|e| e.error() == Errno::ENOENT)
+        );
+
+        // AllowIfFlag: only AT_EMPTY_PATH bit opts in
+        assert!(
+            FsPath::from_fd_at(3, "", EmptyPathStr::AllowIfFlag(0))
+                .is_err_and(|e| e.error() == Errno::ENOENT)
+        );
+        assert!(FsPath::from_fd_at(3, "", EmptyPathStr::AllowIfFlag(AT_EMPTY_PATH)).is_ok());
+        // Unrelated bits do not opt in.
+        assert!(
+            FsPath::from_fd_at(3, "", EmptyPathStr::AllowIfFlag(0x100))
+                .is_err_and(|e| e.error() == Errno::ENOENT)
+        );
+
+        // Allow: rejected when dirfd == AT_FDCWD, permitted otherwise
+        assert!(
+            FsPath::from_fd_at(AT_FDCWD, "", EmptyPathStr::Allow)
+                .is_err_and(|e| e.error() == Errno::ENOENT)
+        );
+        assert!(FsPath::from_fd_at(3, "", EmptyPathStr::Allow).is_ok());
+    }
+
+    #[ktest]
+    fn fs_path_from_fd_at_rejects_too_long() {
+        let long = "a".repeat(PATH_MAX + 1);
+        assert!(
+            FsPath::from_fd_at(AT_FDCWD, &long, EmptyPathStr::Reject)
+                .is_err_and(|e| e.error() == Errno::ENAMETOOLONG)
+        );
     }
 }

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -5,7 +5,7 @@ use crate::{
     fs::{
         file::{Permission, file_table::RawFileDesc},
         utils::PATH_MAX,
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
 };
@@ -83,11 +83,8 @@ fn do_faccessat(
 
     let path = {
         let path_name = path_name.to_string_lossy();
-        let fs_path = if flags.contains(FaccessatFlags::AT_EMPTY_PATH) && path_name.is_empty() {
-            FsPath::from_fd(dirfd)?
-        } else {
-            FsPath::from_fd_and_path(dirfd, &path_name)?
-        };
+        let fs_path =
+            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -9,7 +9,7 @@ use crate::{
             file_table::{RawFileDesc, get_file_fast},
         },
         utils::PATH_MAX,
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
 };
@@ -66,11 +66,8 @@ fn do_fchmodat(
 
     let path = {
         let path_name = path_name.to_string_lossy();
-        let fs_path = if flags.contains(ChmodFlags::AT_EMPTY_PATH) && path_name.is_empty() {
-            FsPath::from_fd(dirfd)?
-        } else {
-            FsPath::from_fd_and_path(dirfd, &path_name)?
-        };
+        let fs_path =
+            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -5,7 +5,7 @@ use crate::{
     fs::{
         file::file_table::{RawFileDesc, get_file_fast},
         utils::PATH_MAX,
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
     process::{Gid, Uid},
@@ -75,7 +75,8 @@ pub fn sys_fchownat(
 
     let path = {
         let path_name = path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &path_name)?;
+        let fs_path =
+            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -6,7 +6,7 @@ use super::{SyscallReturn, constants::*};
 use crate::{
     fs::{
         file::file_table::RawFileDesc,
-        vfs::path::{AT_FDCWD, FsPath, Path},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
     process::do_execve,
@@ -59,11 +59,7 @@ fn lookup_executable_file(
 
     let path = {
         let filename = filename.to_string_lossy();
-        let fs_path = if flags.contains(OpenFlags::AT_EMPTY_PATH) && filename.is_empty() {
-            FsPath::from_fd(dfd)?
-        } else {
-            FsPath::from_fd_and_path(dfd, &filename)?
-        };
+        let fs_path = FsPath::from_fd_at(dfd, &filename, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{InodeType, file_table::RawFileDesc},
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -33,12 +33,12 @@ pub fn sys_linkat(
         let old_path_name = old_path_name.to_string_lossy();
         let new_path_name = new_path_name.to_string_lossy();
 
-        let old_fs_path = if flags.contains(LinkFlags::AT_EMPTY_PATH) && old_path_name.is_empty() {
-            FsPath::from_fd(old_dirfd)?
-        } else {
-            FsPath::from_fd_and_path(old_dirfd, &old_path_name)?
-        };
-        let new_fs_path = FsPath::from_fd_and_path(new_dirfd, &new_path_name)?;
+        let old_fs_path = FsPath::from_fd_at(
+            old_dirfd,
+            &old_path_name,
+            EmptyPathStr::AllowIfFlag(flags.bits()),
+        )?;
+        let new_fs_path = FsPath::from_fd_at(new_dirfd, &new_path_name, EmptyPathStr::Reject)?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/mkdir.rs
+++ b/kernel/src/syscall/mkdir.rs
@@ -5,7 +5,7 @@ use crate::{
     fs,
     fs::{
         file::{InodeMode, InodeType, file_table::RawFileDesc},
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -23,7 +23,7 @@ pub fn sys_mkdirat(
     let fs_ref = ctx.thread_local.borrow_fs();
     let (dir_path, name) = {
         let path = path.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &path)?;
+        let fs_path = FsPath::from_fd_at(dirfd, &path, EmptyPathStr::Reject)?;
         fs_ref
             .resolver()
             .read()

--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -7,7 +7,7 @@ use crate::{
         file::{InodeMode, InodeType, file_table::RawFileDesc},
         vfs::{
             inode::MknodType,
-            path::{AT_FDCWD, FsPath},
+            path::{AT_FDCWD, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
@@ -35,7 +35,7 @@ pub fn sys_mknodat(
 
     let (dir_path, name) = {
         let path_name = path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &path_name)?;
+        let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Reject)?;
         fs_ref
             .resolver()
             .read()

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -6,7 +6,7 @@ use crate::{
         file::InodeType,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            path::{AT_FDCWD, FsPath, MountPropType, Path, PerMountFlags},
+            path::{AT_FDCWD, EmptyPathStr, FsPath, MountPropType, Path, PerMountFlags},
             registry::{FsCreationCtx, FsType},
         },
     },
@@ -37,7 +37,7 @@ pub fn sys_mount(
 
     let dst_path = {
         let dst_name = dst_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &dst_name)?;
+        let fs_path = FsPath::from_fd_at(AT_FDCWD, &dst_name, EmptyPathStr::Reject)?;
         ctx.thread_local
             .borrow_fs()
             .resolver()
@@ -116,7 +116,7 @@ fn do_bind_mount(
             .user_space()
             .read_cstring(src_name_addr, MAX_FILENAME_LEN)?;
         let src_name = src_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &src_name)?;
+        let fs_path = FsPath::from_fd_at(AT_FDCWD, &src_name, EmptyPathStr::Reject)?;
         ctx.thread_local
             .borrow_fs()
             .resolver()
@@ -168,7 +168,7 @@ fn do_move_mount_old(src_name_addr: Vaddr, dst_path: Path, ctx: &Context) -> Res
             .user_space()
             .read_cstring(src_name_addr, MAX_FILENAME_LEN)?;
         let src_name = src_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &src_name)?;
+        let fs_path = FsPath::from_fd_at(AT_FDCWD, &src_name, EmptyPathStr::Reject)?;
         ctx.thread_local
             .borrow_fs()
             .resolver()

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -9,7 +9,7 @@ use crate::{
             StatusFlags,
             file_table::{FdFlags, RawFileDesc},
         },
-        vfs::path::{AT_FDCWD, FsPath, LookupResult, PathResolver},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, LookupResult, PathResolver},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -30,7 +30,7 @@ pub fn sys_openat(
 
     let file_handle = {
         let path = path.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, path.as_ref())?;
+        let fs_path = FsPath::from_fd_at(dirfd, path.as_ref(), EmptyPathStr::Reject)?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let mask_mode = mode & !fs_ref.umask().get();

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -8,7 +8,7 @@ use crate::{
         file::file_table::RawFileDesc,
         vfs::{
             inode::SymbolicLink,
-            path::{AT_FDCWD, FsPath},
+            path::{AT_FDCWD, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
@@ -38,11 +38,7 @@ pub fn sys_readlinkat(
         let path_resolver = fs_ref.resolver().read();
 
         let path_name = path_name.to_string_lossy();
-        let fs_path = if path_name.is_empty() && dirfd != AT_FDCWD {
-            FsPath::from_fd(dirfd)?
-        } else {
-            FsPath::from_fd_and_path(dirfd, &path_name)?
-        };
+        let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Allow)?;
         let path = path_resolver.lookup_no_follow(&fs_path)?;
 
         match path.inode().read_link()? {

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{InodeType, file_table::RawFileDesc},
-        vfs::path::{AT_FDCWD, FsPath, SplitPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -40,7 +40,8 @@ pub fn sys_renameat2(
     let old_path_name = old_path_name.to_string_lossy();
     let (old_parent_path, old_name) = {
         let (old_parent_path_name, old_name) = old_path_name.split_dirname_and_basename()?;
-        let old_fs_path = FsPath::from_fd_and_path(old_dirfd, old_parent_path_name)?;
+        let old_fs_path =
+            FsPath::from_fd_at(old_dirfd, old_parent_path_name, EmptyPathStr::Reject)?;
         (path_resolver.lookup(&old_fs_path)?, old_name)
     };
     let old_path = path_resolver.lookup_at_path(&old_parent_path, old_name)?;
@@ -54,7 +55,8 @@ pub fn sys_renameat2(
             return_errno_with_message!(Errno::EISDIR, "the new path is a directory");
         }
         let (new_parent_path_name, new_name) = new_path_name.split_dirname_and_basename()?;
-        let new_parent_fs_path = FsPath::from_fd_and_path(new_dirfd, new_parent_path_name)?;
+        let new_parent_fs_path =
+            FsPath::from_fd_at(new_dirfd, new_parent_path_name, EmptyPathStr::Reject)?;
         (
             path_resolver.lookup(&new_parent_fs_path)?,
             new_name.to_string(),

--- a/kernel/src/syscall/rmdir.rs
+++ b/kernel/src/syscall/rmdir.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::file_table::RawFileDesc,
-        vfs::path::{AT_FDCWD, FsPath, SplitPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -25,7 +25,7 @@ pub(super) fn sys_rmdirat(
     let path_name = path_name.to_string_lossy();
     let (dir_path, name) = {
         let (parent_path_name, target_name) = path_name.split_dirname_and_basename()?;
-        let fs_path = FsPath::from_fd_and_path(dirfd, parent_path_name)?;
+        let fs_path = FsPath::from_fd_at(dirfd, parent_path_name, EmptyPathStr::Reject)?;
         (
             ctx.thread_local
                 .borrow_fs()

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -11,7 +11,7 @@ use crate::{
             file_table::{RawFileDesc, get_file_fast},
         },
         vfs::{
-            path::{AT_FDCWD, FsPath, Path},
+            path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
             xattr::{
                 XATTR_NAME_MAX_LEN, XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags,
             },
@@ -137,7 +137,7 @@ pub(super) fn lookup_path_for_xattr<'a>(
     let lookup_path_from_fs =
         |path: &CString, ctx: &Context, symlink_no_follow: bool| -> Result<Cow<'_, Path>> {
             let path = path.to_string_lossy();
-            let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &path)?;
+            let fs_path = FsPath::from_fd_at(AT_FDCWD, &path, EmptyPathStr::Reject)?;
             let fs_ref = ctx.thread_local.borrow_fs();
             let path_resolver = fs_ref.resolver().read();
             let path = if symlink_no_follow {

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -8,7 +8,7 @@ use crate::{
         file::file_table::{RawFileDesc, get_file_fast},
         vfs::{
             inode::Metadata,
-            path::{AT_FDCWD, FsPath},
+            path::{AT_FDCWD, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
@@ -64,7 +64,8 @@ pub fn sys_fstatat(
 
     let path = {
         let filename = filename.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &filename)?;
+        let fs_path =
+            FsPath::from_fd_at(dirfd, &filename, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -8,7 +8,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::file_table::RawFileDesc,
-        vfs::path::{FsPath, Path},
+        vfs::path::{EmptyPathStr, FsPath, Path},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -49,12 +49,9 @@ pub fn sys_statx(
 
     let path = {
         let filename = filename.to_string_lossy();
-        let fs_path = if flags.contains(StatxFlags::AT_EMPTY_PATH) && filename.is_empty() {
-            // TODO: We can retrieve the metadata from `FileLike`. See `sys_fstat` as an example.
-            FsPath::from_fd(dirfd)?
-        } else {
-            FsPath::from_fd_and_path(dirfd, &filename)?
-        };
+        // TODO: We can retrieve the metadata from `FileLike`. See `sys_fstat` as an example.
+        let fs_path =
+            FsPath::from_fd_at(dirfd, &filename, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -5,7 +5,7 @@ use crate::{
     fs,
     fs::{
         file::{InodeType, file_table::RawFileDesc, mkmod},
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -32,7 +32,7 @@ pub fn sys_symlinkat(
 
     let (dir_path, link_name) = {
         let link_path_name = link_path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(dirfd, &link_path_name)?;
+        let fs_path = FsPath::from_fd_at(dirfd, &link_path_name, EmptyPathStr::Reject)?;
         ctx.thread_local
             .borrow_fs()
             .resolver()

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -6,7 +6,7 @@ use crate::{
     fs::{
         file::file_table::{RawFileDesc, get_file_fast},
         utils::PATH_MAX,
-        vfs::path::{AT_FDCWD, FsPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
     process::ResourceType,
@@ -32,7 +32,7 @@ pub fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result<Syscal
 
     let dir_path = {
         let path_name = path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &path_name)?;
+        let fs_path = FsPath::from_fd_at(AT_FDCWD, &path_name, EmptyPathStr::Reject)?;
         ctx.thread_local
             .borrow_fs()
             .resolver()

--- a/kernel/src/syscall/umount.rs
+++ b/kernel/src/syscall/umount.rs
@@ -2,7 +2,7 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::vfs::path::{AT_FDCWD, FsPath},
+    fs::vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
 };
@@ -15,7 +15,7 @@ pub fn sys_umount(path_addr: Vaddr, flags: u64, ctx: &Context) -> Result<Syscall
     umount_flags.check_unsupported_flags()?;
 
     let path_name = path_name.to_string_lossy();
-    let fs_path = FsPath::from_fd_and_path(AT_FDCWD, &path_name)?;
+    let fs_path = FsPath::from_fd_at(AT_FDCWD, &path_name, EmptyPathStr::Reject)?;
 
     let target_path = if umount_flags.contains(UmountFlags::UMOUNT_NOFOLLOW) {
         ctx.thread_local

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::file_table::RawFileDesc,
-        vfs::path::{AT_FDCWD, FsPath, SplitPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -28,7 +28,7 @@ pub fn sys_unlinkat(
     let path_name = path_name.to_string_lossy();
     let (dir_path, name) = {
         let (parent_path_name, target_name) = path_name.split_dirname_and_filename()?;
-        let fs_path = FsPath::from_fd_and_path(dirfd, parent_path_name)?;
+        let fs_path = FsPath::from_fd_at(dirfd, parent_path_name, EmptyPathStr::Reject)?;
         (
             ctx.thread_local
                 .borrow_fs()

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -9,7 +9,7 @@ use crate::{
     fs,
     fs::{
         file::file_table::RawFileDesc,
-        vfs::path::{AT_FDCWD, FsPath, Path},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
     time::{clocks::RealTimeCoarseClock, timespec_t, timeval_t},
@@ -20,6 +20,7 @@ use crate::{
 /// and `times[1]` represents the modification time.
 /// The `flags` argument is a bit mask that can include the following values:
 /// - `AT_SYMLINK_NOFOLLOW`: If set, the file is not dereferenced if it is a symbolic link.
+/// - `AT_EMPTY_PATH`: If set, an empty pathname means operating on `dirfd` directly.
 pub fn sys_utimensat(
     dirfd: RawFileDesc,
     pathname_ptr: Vaddr,
@@ -172,8 +173,15 @@ fn do_utimes(
 
     let path = {
         let fs_path = if let Some(pathname) = pathname.as_ref() {
-            FsPath::from_fd_and_path(dirfd, pathname)?
+            FsPath::from_fd_at(dirfd, pathname, EmptyPathStr::AllowIfFlag(flags.bits()))?
         } else {
+            // Matches Linux `do_utimes_fd`: no flags are accepted when pathname is NULL.
+            if !flags.is_empty() {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "flags must be zero when pathname is NULL"
+                );
+            }
             FsPath::from_fd(dirfd)?
         };
 
@@ -255,6 +263,7 @@ const UTIME_OMIT: i64 = (1i64 << 30) - 2i64;
 
 bitflags::bitflags! {
     struct UtimensFlags: u32 {
+        const AT_EMPTY_PATH = 0x1000;
         const AT_SYMLINK_NOFOLLOW = 0x100;
     }
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/stat_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/stat_test
@@ -6,6 +6,8 @@ StatTest.FstatatEmptyPath
 StatTest.FstatatRel
 StatTest.FstatatSymlink
 StatTest.FstatatSymlinkDir
+StatTest.FstatatSymlinkDirWithTrailingSlash
+StatTest.FstatatSymlinkDirWithTrailingSlashSameInode
 StatTest.FstatDirWithOpath
 StatTest.FstatFileWithOpath
 StatTest.LeadingDoubleSlash
@@ -13,6 +15,7 @@ StatTest.LinkCountsWithDirChild
 StatTest.LinkCountsWithRegularFileChild
 StatTest.LinkCountsWithSubdirectories
 StatTest.LstatELOOPPath
+StatTest.LstatSymlinkDir
 StatTest.Nlinks
 StatTest.PathCanContainDotDot
 StatTest.PathCanContainEmptyComponent

--- a/test/initramfs/src/conformance/gvisor/blocklists/chmod_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/chmod_test
@@ -1,3 +1,1 @@
 ChmodTest.FchmodDirSucceeds_NoRandomSave
-ChmodTest.FchmodatDirAbsolutePath
-ChmodTest.FchmodatDir

--- a/test/initramfs/src/conformance/gvisor/blocklists/stat_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/stat_test
@@ -1,4 +1,1 @@
-StatTest.FstatatSymlinkDirWithTrailingSlash
-StatTest.FstatatSymlinkDirWithTrailingSlashSameInode
-StatTest.LstatSymlinkDir
 SimpleStatTest.AnonDeviceAllocatesUniqueInodesAcrossSaveRestore

--- a/test/initramfs/src/conformance/gvisor/blocklists/symlink_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/symlink_test
@@ -1,7 +1,5 @@
 SymlinkTest.CannotCreateSymlinkInReadOnlyDir
 SymlinkTest.PwriteToSymlink
-SymlinkTest.SymlinkAtDegradedPermissions_NoRandomSave
-SymlinkTest.ReadlinkAtDegradedPermissions_NoRandomSave
 SymlinkTest.FollowUpdatesATime
 AbsAndRelTarget/ParamSymlinkTest.CreatLinkCreatesTarget/0
 AbsAndRelTarget/ParamSymlinkTest.CreatLinkCreatesTarget/1

--- a/test/initramfs/src/conformance/gvisor/blocklists/unlink_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/unlink_test
@@ -1,4 +1,3 @@
-UnlinkTest.AtDirDegradedPermissions_NoRandomSave
 UnlinkTest.ParentDegradedPermissions
 UnlinkTest.AtBad
 UnlinkTest.TooLongName

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -8,8 +8,8 @@
 # accept4_01
 
 # access01
-# access02
-# access03
+access02
+access03
 # access04
 
 # acct01
@@ -71,10 +71,10 @@ capset04
 chdir04
 
 chmod01
-# chmod03
+chmod03
 # chmod05
 # chmod06
-# chmod07
+chmod07
 chmod08
 # chmod09
 
@@ -232,7 +232,7 @@ faccessat01
 faccessat02
 
 #faccessat2 test cases
-# faccessat201
+faccessat201
 # faccessat202
 
 #fallocate test cases
@@ -266,18 +266,18 @@ fchdir02
 # fchdir03
 
 fchmod01
-# fchmod02
-# fchmod03
-# fchmod04
+fchmod02
+fchmod03
+fchmod04
 # fchmod05
 # fchmod06
 
 #fchmodat test cases
 fchmodat01
-# fchmodat02
+fchmodat02
 
 # fchmodat2_01
-# fchmodat2_02
+fchmodat2_02
 
 fchown01
 # fchown01_16
@@ -782,8 +782,8 @@ lseek07
 
 lstat01
 lstat01_64
-# lstat02
-# lstat02_64
+lstat02
+lstat02_64
 # lstat03
 # lstat03_64
 
@@ -821,11 +821,11 @@ mkdirat01
 # mkdirat02
 
 mknod01
-# mknod02
+mknod02
 # mknod03
 # mknod04
 # mknod05
-# mknod06
+mknod06
 # mknod07
 # mknod08
 mknod09
@@ -1650,7 +1650,7 @@ string01
 # switch01
 
 symlink02
-# symlink03
+symlink03
 symlink04
 
 #symlinkat test cases
@@ -1739,7 +1739,7 @@ uname02
 # uname04
 
 unlink05
-# unlink07
+unlink07
 # unlink08
 # unlink09
 # unlink10

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -1,3 +1,4 @@
+access02
 bind04
 chdir01A
 chmod01
@@ -8,8 +9,10 @@ creat03
 dup05
 dup203
 dup205
+faccessat201
 fallocate03
 fchmod01
+fchmod02
 fchmodat01
 fchown05
 fchownat01
@@ -27,8 +30,12 @@ link05
 linkat01
 lstat01
 lstat01_64
+lstat02
+lstat02_64
 mkdir04
 mknod01
+mknod02
+mknod06
 mmap06
 mmap19
 mprotect02
@@ -84,6 +91,7 @@ setuid04
 stat02
 stat02_64
 symlink02
+symlink03
 symlink04
 symlinkat01
 truncate02


### PR DESCRIPTION
Fixes #3172

This PR implements the empty-path handling design proposed in #3172 and then enables more LTP syscall cases.