### PR TITLE
Enable virtio-net for the RISC-V QEMU scheme

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -62,6 +62,7 @@ qemu.args = """\
     -serial chardev:mux \
     -monitor chardev:mux \
     -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
+    -netdev user,id=net01 \
     -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
     # NOTE: The `/etc/profile.d/init.sh` assumes that `ext2.img` appears as the first block device (`/dev/vda`).
@@ -70,6 +71,7 @@ qemu.args = """\
     -device virtio-blk-device,drive=x1 \
     -device virtio-blk-device,drive=x0 \
     -device virtio-keyboard-device \
+    -device virtio-net-device,netdev=net01 \
     -device virtio-serial-device \
     -device virtconsole,chardev=mux \
 """


### PR DESCRIPTION
## Summary

- Add a user-mode QEMU netdev to the RISC-V scheme.
- Attach a `virtio-net-device` so the RISC-V guest exposes a virtio network interface.
- This aligns the RISC-V QEMU scheme with network regression tests that expect both `lo` and `eth0` to be present.

## Test Plan

- `git diff --check upstream/main..HEAD`
- `CARGO_TARGET_DIR=/tmp/asterinas-target make run_kernel OSDK_TARGET_ARCH=riscv64 AUTO_TEST=boot INITRAMFS_SKIP_GZIP=1`

Additional validation while investigating RISC-V regression tests:

- With this change stacked on #3174, `/test/network` passed, including `test_if_nameindex` and `test_get_link_by_libnl`.
- A full RISC-V regression run is currently blocked before the network tests by #3178 (`clone3(CLONE_FILES)` does not share the file table as expected on RISC-V).