### PR TITLE
Fix `cargo osdk test` exiting after the first default member

### DIFF
--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -9,7 +9,7 @@ use file::{BundleFile, Initramfs};
 use std::{
     io::{BufRead, BufReader, Write},
     os::unix::net::UnixStream,
-    process,
+    process::{self, ExitStatus},
     time::Duration,
 };
 use tempfile::NamedTempFile;
@@ -50,6 +50,39 @@ pub struct BundleManifest {
     pub config: Config,
     pub action: ActionChoice,
     pub last_modified: SystemTime,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum QemuExit {
+    Success,
+    Failed,
+    Unknown,
+}
+
+pub(crate) fn classify_qemu_exit_status(exit_status: ExitStatus) -> QemuExit {
+    if exit_status.success() {
+        return QemuExit::Success;
+    }
+
+    let Some(qemu_exit_code) = exit_status.code() else {
+        return QemuExit::Unknown;
+    };
+
+    // For x86 QEMU with `isa-debug-exit`, the guest exit code is encoded as
+    // `(code << 1) | 1`. Do not decode QEMU's own failure exit code `1`.
+    if qemu_exit_code == 1 {
+        return QemuExit::Unknown;
+    }
+
+    let kernel_exit_code = qemu_exit_code >> 1;
+    match kernel_exit_code {
+        // Corresponds to `ostd::QemuExitCode::Success`.
+        0x10 => QemuExit::Success,
+        // Corresponds to `ostd::QemuExitCode::Failed`.
+        0x20 => QemuExit::Failed,
+        // Unknown exit code, e.g., a triple fault.
+        _ => QemuExit::Unknown,
+    }
 }
 
 impl Bundle {
@@ -207,6 +240,16 @@ impl Bundle {
     }
 
     pub fn run(&self, config: &Config, action: ActionChoice) {
+        let exit_status = self.run_qemu_and_wait(config, action);
+        // FIXME: When panicking it sometimes returns success, why?
+        match classify_qemu_exit_status(exit_status) {
+            QemuExit::Success => {}
+            QemuExit::Failed => std::process::exit(1),
+            QemuExit::Unknown => std::process::exit(2),
+        }
+    }
+
+    pub(crate) fn run_qemu_and_wait(&self, config: &Config, action: ActionChoice) -> ExitStatus {
         match self.can_run_with_config(config, action) {
             Ok(()) => {}
             Err(msg) => {
@@ -303,23 +346,6 @@ impl Bundle {
             exit_status
         };
 
-        // FIXME: When panicking it sometimes returns success, why?
-        if !exit_status.success() {
-            // FIXME: Exit code manipulation is not needed when using non-x86 QEMU
-            let qemu_exit_code = exit_status.code().unwrap();
-            let kernel_exit_code = qemu_exit_code >> 1;
-            match kernel_exit_code {
-                // Success exit through ACPI.
-                0x0 => std::process::exit(0),
-                // Corresponds to `ostd::QemuExitCode::Success`.
-                0x10 => std::process::exit(0),
-                // Corresponds to `ostd::QemuExitCode::Failed`.
-                0x20 => std::process::exit(1),
-                // Unknown exit code, e.g., a triple fault.
-                _ => std::process::exit(2),
-            }
-        }
-
         fn wait_until_guest_kernel_shutdown(config: &Config, qemu_monitor_stream: &mut UnixStream) {
             let log_file = std::fs::File::open(config.work_dir.join("qemu.log")).unwrap();
 
@@ -345,6 +371,7 @@ impl Bundle {
                 std::thread::sleep(Duration::from_millis(100));
             }
         }
+        exit_status
     }
 
     /// Move the vm_image into the bundle.

--- a/osdk/src/commands/test.rs
+++ b/osdk/src/commands/test.rs
@@ -5,6 +5,7 @@ use std::fs;
 use super::{build::do_cached_build, util::DEFAULT_TARGET_RELPATH};
 use crate::{
     base_crate::{BaseCrateType, new_base_crate},
+    bundle::{QemuExit, classify_qemu_exit_status},
     cli::TestArgs,
     config::{Config, scheme::ActionChoice},
     error::Errno,
@@ -14,13 +15,24 @@ use crate::{
 
 pub fn execute_test_command(config: &Config, args: &TestArgs) {
     let crates = get_current_crates();
+    let mut exit_code = 0;
+
     for crate_info in crates {
         std::env::set_current_dir(crate_info.path).unwrap();
-        test_current_crate(config, args);
+        let qemu_exit = test_current_crate(config, args);
+        exit_code = exit_code.max(match qemu_exit {
+            QemuExit::Success => 0,
+            QemuExit::Failed => 1,
+            QemuExit::Unknown => 2,
+        });
+    }
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
     }
 }
 
-pub fn test_current_crate(config: &Config, args: &TestArgs) {
+pub fn test_current_crate(config: &Config, args: &TestArgs) -> QemuExit {
     let current_crates = get_current_crates();
     if current_crates.len() != 1 {
         error_msg!("The current directory contains more than one crate");
@@ -104,5 +116,6 @@ pub static KTEST_CRATE_WHITELIST: Option<&[&str]> = Some(&{:#?});
     );
     drop(dir_guard);
 
-    bundle.run(config, ActionChoice::Test);
+    let exit_status = bundle.run_qemu_and_wait(config, ActionChoice::Test);
+    classify_qemu_exit_status(exit_status)
 }


### PR DESCRIPTION
#3107 changed `make ktest` from iterating over each crate in the Makefile and invoking cargo osdk run individually, to having OSDK internally iterate over all default members and run ktests for each crate. However, the previous OSDK behavior was to exit immediately after each ktests run invocation, which caused `make ktest` to exit after running only the first crate. This PR fixes that behavior by deferring the exit until all crates have been processed.

https://github.com/asterinas/asterinas/blob/7bcb2fe3849b64788a945d1b916c52a16bce8a0c/osdk/src/bundle/mod.rs#L306-L321