### PR TITLE
Fix RISC-V SIGSEGV si_code for page faults

### DIFF
--- a/kernel/src/arch/loongarch/signal.rs
+++ b/kernel/src/arch/loongarch/signal.rs
@@ -9,6 +9,7 @@ use ostd::{
 use crate::{
     process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
     thread::exception::ToFaultSignal,
+    vm::vmar::PageFaultAddressState,
 };
 
 impl SignalContext for UserContext {
@@ -20,7 +21,11 @@ impl SignalContext for UserContext {
 }
 
 impl ToFaultSignal for CpuExceptionInfo {
-    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+    fn to_fault_signal(
+        &self,
+        user_ctx: &UserContext,
+        _page_fault_address_state: Option<PageFaultAddressState>,
+    ) -> Option<FaultSignal> {
         use crate::process::signal::constants::*;
 
         let era = user_ctx.instruction_pointer() as u64;

--- a/kernel/src/arch/riscv/signal.rs
+++ b/kernel/src/arch/riscv/signal.rs
@@ -8,6 +8,7 @@ use ostd::{
 use crate::{
     process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
     thread::exception::ToFaultSignal,
+    vm::vmar::PageFaultAddressState,
 };
 
 impl SignalContext for UserContext {
@@ -19,7 +20,11 @@ impl SignalContext for UserContext {
 }
 
 impl ToFaultSignal for CpuException {
-    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+    fn to_fault_signal(
+        &self,
+        user_ctx: &UserContext,
+        page_fault_address_state: Option<PageFaultAddressState>,
+    ) -> Option<FaultSignal> {
         use CpuException::*;
 
         use crate::process::signal::constants::*;
@@ -49,8 +54,11 @@ impl ToFaultSignal for CpuException {
             }
             SupervisorEnvCall => (SIGILL, ILL_ILLTRP, sepc),
             InstructionPageFault(addr) | LoadPageFault(addr) | StorePageFault(addr) => {
-                // FIXME: The code should be `SEGV_ACCERR` for faults within an existing mapping.
-                (SIGSEGV, SEGV_MAPERR, *addr as u64)
+                let code = match page_fault_address_state {
+                    Some(PageFaultAddressState::Mapped) => SEGV_ACCERR,
+                    Some(PageFaultAddressState::Unmapped) | None => SEGV_MAPERR,
+                };
+                (SIGSEGV, code, *addr as u64)
             }
             Unknown => (SIGILL, ILL_ILLTRP, sepc),
 

--- a/kernel/src/arch/x86/signal.rs
+++ b/kernel/src/arch/x86/signal.rs
@@ -8,6 +8,7 @@ use ostd::{
 use crate::{
     process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
     thread::exception::ToFaultSignal,
+    vm::vmar::PageFaultAddressState,
 };
 
 impl SignalContext for UserContext {
@@ -19,7 +20,11 @@ impl SignalContext for UserContext {
 }
 
 impl ToFaultSignal for CpuException {
-    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+    fn to_fault_signal(
+        &self,
+        user_ctx: &UserContext,
+        _page_fault_address_state: Option<PageFaultAddressState>,
+    ) -> Option<FaultSignal> {
         use crate::process::signal::constants::*;
 
         let rip = user_ctx.instruction_pointer() as u64;

--- a/kernel/src/thread/exception.rs
+++ b/kernel/src/thread/exception.rs
@@ -9,36 +9,41 @@ use ostd::{arch::cpu::context::UserContext, task::Task};
 use crate::{
     prelude::*,
     process::signal::signals::fault::FaultSignal,
-    vm::vmar::{PageFaultInfo, Vmar},
+    vm::vmar::{PageFaultAddressState, PageFaultInfo, Vmar},
 };
 
 pub(super) fn handle_exception(ctx: &Context, user_ctx: &UserContext, exception: CpuException) {
     debug!("handle exception: {:#x?}", exception);
 
-    if let Ok(page_fault_info) = PageFaultInfo::try_from(&exception) {
+    let page_fault_address_state = if let Ok(page_fault_info) = PageFaultInfo::try_from(&exception)
+    {
         let user_space = ctx.user_space();
         let vmar = user_space.vmar();
-        if handle_page_fault_from_vmar(vmar, &page_fault_info).is_ok() {
-            return;
+        match handle_page_fault_from_vmar(vmar, &page_fault_info) {
+            Ok(()) => return,
+            Err(address_state) => Some(address_state),
         }
-    }
+    } else {
+        None
+    };
 
     // We cannot handle most exceptions. Send a fault signal to the current thread before returning
     // to user space.
-    generate_fault_signal(exception, ctx, user_ctx);
+    generate_fault_signal(exception, ctx, user_ctx, page_fault_address_state);
 }
 
 /// Handles the page fault occurs in the VMAR.
 fn handle_page_fault_from_vmar(
     vmar: &Vmar,
     page_fault_info: &PageFaultInfo,
-) -> core::result::Result<(), ()> {
-    if let Err(e) = vmar.handle_page_fault(page_fault_info) {
+) -> core::result::Result<(), PageFaultAddressState> {
+    if let Err(e) = vmar.handle_page_fault_with_report(page_fault_info) {
         warn!(
             "page fault handler failed: info: {:#x?}, err: {:?}",
-            page_fault_info, e
+            page_fault_info,
+            e.error()
         );
-        return Err(());
+        return Err(e.address_state());
     }
     Ok(())
 }
@@ -59,12 +64,21 @@ pub trait ToFaultSignal {
     /// architectures.
     ///
     /// [requires]: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html
-    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal>;
+    fn to_fault_signal(
+        &self,
+        user_ctx: &UserContext,
+        page_fault_address_state: Option<PageFaultAddressState>,
+    ) -> Option<FaultSignal>;
 }
 
 /// Generates a fault signal for the current thread.
-fn generate_fault_signal(exception: CpuException, ctx: &Context, user_ctx: &UserContext) {
-    let Some(signal) = exception.to_fault_signal(user_ctx) else {
+fn generate_fault_signal(
+    exception: CpuException,
+    ctx: &Context,
+    user_ctx: &UserContext,
+    page_fault_address_state: Option<PageFaultAddressState>,
+) {
+    let Some(signal) = exception.to_fault_signal(user_ctx, page_fault_address_state) else {
         panic!("`{:?}` cannot be handled via signals", exception);
     };
     ctx.posix_thread.enqueue_signal(Box::new(signal));
@@ -81,5 +95,5 @@ pub(super) fn page_fault_handler(info: &CpuException) -> core::result::Result<()
     }
 
     let user_space = CurrentUserSpace::new(thread_local);
-    handle_page_fault_from_vmar(user_space.vmar(), &info.try_into().unwrap())
+    handle_page_fault_from_vmar(user_space.vmar(), &info.try_into().unwrap()).map_err(|_| ())
 }

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -9,6 +9,7 @@ mod vm_mapping;
 mod vmar_impls;
 
 use ostd::mm::Vaddr;
+pub(crate) use vmar_impls::page_fault::PageFaultAddressState;
 pub use vmar_impls::{RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo};
 
 pub const VMAR_LOWEST_ADDR: Vaddr = 0x001_0000; // 64 KiB is the Linux configurable default

--- a/kernel/src/vm/vmar/vmar_impls/page_fault.rs
+++ b/kernel/src/vm/vmar/vmar_impls/page_fault.rs
@@ -5,6 +5,15 @@ use crate::{prelude::*, vm::perms::VmPerms};
 
 impl Vmar {
     pub fn handle_page_fault(&self, page_fault_info: &PageFaultInfo) -> Result<()> {
+        self.handle_page_fault_with_report(page_fault_info)
+            .map_err(PageFaultError::into_error)
+    }
+
+    /// Handles a page fault and reports the faulting address state on failure.
+    pub(crate) fn handle_page_fault_with_report(
+        &self,
+        page_fault_info: &PageFaultInfo,
+    ) -> core::result::Result<(), PageFaultError> {
         let inner = self.inner.read();
 
         let address = page_fault_info.address;
@@ -12,14 +21,58 @@ impl Vmar {
             debug_assert!(vm_mapping.range().contains(&address));
 
             let mut rss_delta = RssDelta::new(self);
-            return vm_mapping.handle_page_fault(&self.vm_space, page_fault_info, &mut rss_delta);
+            return vm_mapping
+                .handle_page_fault(&self.vm_space, page_fault_info, &mut rss_delta)
+                .map_err(|error| PageFaultError::new(PageFaultAddressState::Mapped, error));
         }
 
-        return_errno_with_message!(
-            Errno::EACCES,
-            "no VM mappings contain the page fault address"
-        );
+        Err(PageFaultError::new(
+            PageFaultAddressState::Unmapped,
+            Error::with_message(
+                Errno::EACCES,
+                "no VM mappings contain the page fault address",
+            ),
+        ))
     }
+}
+
+/// An unhandled page fault with VMAR-level context.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PageFaultError {
+    address_state: PageFaultAddressState,
+    error: Error,
+}
+
+impl PageFaultError {
+    fn new(address_state: PageFaultAddressState, error: Error) -> Self {
+        Self {
+            address_state,
+            error,
+        }
+    }
+
+    /// Returns whether the faulting address is covered by a VMAR mapping.
+    pub(crate) fn address_state(&self) -> PageFaultAddressState {
+        self.address_state
+    }
+
+    /// Returns the underlying page-fault handling error.
+    pub(crate) fn error(&self) -> Error {
+        self.error
+    }
+
+    fn into_error(self) -> Error {
+        self.error
+    }
+}
+
+/// Whether a faulting address is covered by a VMAR mapping.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PageFaultAddressState {
+    /// The faulting address is not covered by any VMAR mapping.
+    Unmapped,
+    /// The faulting address is covered by a VMAR mapping.
+    Mapped,
 }
 
 /// Page fault information converted from [`CpuException`].

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -51,6 +51,7 @@ set -e
 ./signal/pidfd_send_signal
 ./signal/signal_fd
 ./signal/signal_test2
+./signal/fault_info
 
 if [ "$(uname -m)" = "x86_64" ]; then
     ./signal/fault_signals

--- a/test/initramfs/src/regression/process/signal/fault_info.c
+++ b/test/initramfs/src/regression/process/signal/fault_info.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define PAGE_SIZE 4096
+
+static int expected_si_code;
+static void *expected_si_addr;
+
+static void sigsegv_handler(int sig, siginfo_t *info, void *context)
+{
+	(void)context;
+
+	if (sig != SIGSEGV) {
+		_exit(100);
+	}
+	if (info->si_code != expected_si_code) {
+		_exit(101);
+	}
+	if (expected_si_addr != NULL && info->si_addr != expected_si_addr) {
+		_exit(102);
+	}
+
+	_exit(0);
+}
+
+static void install_sigsegv_handler(void)
+{
+	struct sigaction action = { 0 };
+	action.sa_sigaction = sigsegv_handler;
+	action.sa_flags = SA_SIGINFO;
+	CHECK(sigemptyset(&action.sa_mask));
+	CHECK(sigaction(SIGSEGV, &action, NULL));
+}
+
+static void trigger_unmapped_fault(void)
+{
+	volatile char value = *(volatile char *)0;
+	(void)value;
+}
+
+static void *prot_none_addr;
+
+static void trigger_prot_none_fault(void)
+{
+	volatile char value = *(volatile char *)prot_none_addr;
+	(void)value;
+}
+
+static int run_sigsegv_case(void (*trigger)(void), int si_code,
+			    void *fault_addr)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+	if (pid == 0) {
+		expected_si_code = si_code;
+		expected_si_addr = fault_addr;
+		install_sigsegv_handler();
+		trigger();
+		_exit(103);
+	}
+
+	int status;
+	if (waitpid(pid, &status, 0) != pid) {
+		return -1;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		errno = EINVAL;
+		return -1;
+	}
+	return 0;
+}
+
+FN_TEST(sigsegv_si_code)
+{
+	TEST_SUCC(run_sigsegv_case(trigger_unmapped_fault, SEGV_MAPERR, NULL));
+
+	prot_none_addr = CHECK_WITH(mmap(NULL, PAGE_SIZE, PROT_NONE,
+					 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0),
+				    _ret != MAP_FAILED);
+	TEST_SUCC(run_sigsegv_case(trigger_prot_none_fault, SEGV_ACCERR,
+				   prot_none_addr));
+	TEST_RES(munmap(prot_none_addr, PAGE_SIZE), _ret == 0);
+}
+END_TEST()


### PR DESCRIPTION
## Summary

- Report whether an unhandled page fault address is covered by an existing VMAR mapping.
- Use that VMAR address state on RISC-V to return `SEGV_ACCERR` for mapped permission faults and `SEGV_MAPERR` for unmapped faults.
- Keep x86_64 and LoongArch page-fault `si_code` behavior unchanged while updating the shared `ToFaultSignal` trait signature.
- Add a cross-arch regression test for `SIGSEGV` `si_code` covering unmapped and `PROT_NONE` faults.

## Tests

- `git diff --check`
- `cargo fmt --check`
- `clang-format --dry-run --Werror test/initramfs/src/regression/process/signal/fault_info.c`
- `make -C test/initramfs/src/regression/process/signal fault_info && ./test/initramfs/src/regression/process/signal/fault_info`
- Docker `make check`
- Docker `make run_kernel OSDK_TARGET_ARCH=riscv64 AUTO_TEST=regression INITRAMFS_SKIP_GZIP=1`
  - Fails before reaching this new test, in `/test/hello_world`, after printing `hello world from hello_c!` and `hello world from hello_pie!`.
  - I reproduced the same `/test/hello_world` failure on a clean `upstream/main` worktree at `d00df2b88`, so this appears to be a baseline/environment issue rather than this patch.
