### PR TITLE
Add spaces in log messages after `:`

### DIFF
--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -85,13 +85,13 @@ fn virtio_component_init() -> Result<(), ComponentInitError> {
             VirtioDeviceType::Network => NetworkDevice::init(transport),
             VirtioDeviceType::Socket => SocketDevice::init(transport),
             _ => {
-                warn!("Found unimplemented device:{:?}", device_type);
+                warn!("Found unimplemented device: {:?}", device_type);
                 Ok(())
             }
         };
         if res.is_err() {
             error!(
-                "Device initialization error:{:?}, device type:{:?}",
+                "Device initialization error: {:?}, device type: {:?}",
                 res, device_type
             );
         }

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -173,9 +173,9 @@ impl VirtQueue {
             )
         };
 
-        debug!("queue_desc start paddr:{:x?}", descriptor_ptr.paddr());
-        debug!("queue_driver start paddr:{:x?}", avail_ring_ptr.paddr());
-        debug!("queue_device start paddr:{:x?}", used_ring_ptr.paddr());
+        debug!("queue_desc start paddr: {:x?}", descriptor_ptr.paddr());
+        debug!("queue_driver start paddr: {:x?}", avail_ring_ptr.paddr());
+        debug!("queue_device start paddr: {:x?}", used_ring_ptr.paddr());
 
         transport
             .set_queue(

--- a/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/bus.rs
@@ -40,7 +40,7 @@ pub struct MmioBus {
 impl MmioBus {
     /// Registers a MMIO driver to the MMIO bus.
     pub fn register_driver(&mut self, driver: Arc<dyn MmioDriver>) {
-        debug!("Register driver:{:#x?}", driver);
+        debug!("Register driver: {:#x?}", driver);
         let length = self.common_devices.len();
         for _ in (0..length).rev() {
             let common_device = self.common_devices.pop_front().unwrap();

--- a/kernel/comps/virtio/src/transport/pci/capability.rs
+++ b/kernel/comps/virtio/src/transport/pci/capability.rs
@@ -54,7 +54,7 @@ impl VirtioPciCapabilityData {
             3 => VirtioPciCpabilityType::IsrCfg,
             4 => VirtioPciCpabilityType::DeviceCfg,
             5 => VirtioPciCpabilityType::PciCfg,
-            _ => panic!("Unsupported virtio capability type:{:?}", cfg_type),
+            _ => panic!("Unsupported virtio capability type: {:?}", cfg_type),
         };
 
         let offset = vendor_cap.read32(8).unwrap();

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -277,12 +277,12 @@ impl VirtioPciModernTransport {
         let device_type = match VirtioDeviceType::try_from(device_type_value as u8) {
             Ok(device) => device,
             Err(_) => {
-                warn!("Unrecognized virtio-pci device id:{:x?}", device_id);
+                warn!("Unrecognized virtio-pci device ID: {:x?}", device_id);
                 return Err((BusProbeError::DeviceNotMatch, common_device));
             }
         };
 
-        info!("Found device:{:?}", device_type);
+        info!("Found device: {:?}", device_type);
 
         let mut notify = None;
         let mut common_cfg = None;

--- a/kernel/comps/virtio/src/transport/pci/legacy.rs
+++ b/kernel/comps/virtio/src/transport/pci/legacy.rs
@@ -86,13 +86,13 @@ impl VirtioPciLegacyTransport {
             0x1009 => VirtioDeviceType::Transport9P,
             _ => {
                 warn!(
-                    "Unrecognized virtio-pci device id:{:x?}",
+                    "Unrecognized virtio-pci device ID: {:x?}",
                     common_device.device_id().device_id
                 );
                 return Err((BusProbeError::ConfigurationSpaceError, common_device));
             }
         };
-        info!("Found device:{:?}", device_type);
+        info!("Found device: {:?}", device_type);
 
         let config_bar = common_device
             .bar_manager_mut()

--- a/kernel/libs/comp-sys/component/src/lib.rs
+++ b/kernel/libs/comp-sys/component/src/lib.rs
@@ -156,7 +156,7 @@ pub fn init_all(
 }
 
 fn parse_input(components: Vec<ComponentInfo>) -> BTreeMap<String, ComponentInfo> {
-    debug!("All component:{components:?}");
+    debug!("All component: {components:?}");
     let mut out = BTreeMap::new();
     for component in components {
         out.insert(component.path.clone(), component);
@@ -202,7 +202,7 @@ fn match_and_call(
         infos.push(info);
     }
 
-    debug!("Remain components:{components:?}");
+    debug!("Remain components: {components:?}");
 
     if !components.is_empty() {
         info!("Exists components that are not initialized");
@@ -213,9 +213,9 @@ fn match_and_call(
     info!("Components initializing in {stage:?} stage...");
 
     for info in infos {
-        info!("Component initializing:{:?}", info);
+        info!("Component initializing: {:?}", info);
         if let Err(res) = (info.function.unwrap())() {
-            error!("Component initialize error:{:?}", res);
+            error!("Component initialize error: {:?}", res);
         } else {
             info!("Component initialize complete");
         }

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -7,7 +7,7 @@ use ostd::info;
 
 pub fn init() {
     for device in aster_input::all_devices() {
-        info!("Found an input device, name:{}", device.name());
+        info!("Found an input device, name: {}", device.name());
     }
 
     // FIXME: Currently, we have to do this manually to ensure the crates containing the input

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -103,7 +103,7 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
         match status {
             Ok(status) => {
                 if !status.success() {
-                    panic!("Failed to strip kernel elf.");
+                    panic!("Failed to strip kernel ELF");
                 }
             }
             Err(err) => match err.kind() {
@@ -111,7 +111,7 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
                     "`rust-strip` command not found. Please
                     try `cargo install cargo-binutils` and then rerun."
                 ),
-                _ => panic!("Strip kernel elf failed, err:{:#?}", err),
+                _ => panic!("Strip kernel ELF failed, error: {:#?}", err),
             },
         }
     } else {

--- a/ostd/src/arch/x86/kernel/apic/mod.rs
+++ b/ostd/src/arch/x86/kernel/apic/mod.rs
@@ -79,7 +79,7 @@ pub fn get_or_init(_guard: &dyn PinCurrentCpu) -> &(dyn Apic + 'static) {
             xapic.enable();
             let version = xapic.version();
             crate::info!(
-                "xAPIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
+                "xAPIC ID: {:x}, Version: {:x}, Max LVT: {:x}",
                 xapic.id(),
                 version & 0xff,
                 (version >> 16) & 0xff
@@ -91,7 +91,7 @@ pub fn get_or_init(_guard: &dyn PinCurrentCpu) -> &(dyn Apic + 'static) {
             x2apic.enable();
             let version = x2apic.version();
             crate::info!(
-                "x2APIC ID:{:x}, Version:{:x}, Max LVT:{:x}",
+                "x2APIC ID: {:x}, Version: {:x}, Max LVT: {:x}",
                 x2apic.id(),
                 version & 0xff,
                 (version >> 16) & 0xff


### PR DESCRIPTION
I think we prefer:
```rust
info!("Found device: {:?}", device_type);
```
than:
```rust
info!("Found device:{:?}", device_type);
```

Right?

If so, this PR is generated by:
```bash
sed -i 's|\([^:]\):{|\1: {|' kernel/**/*.rs ostd/**/*.rs osdk/src/**/*.rs
```

I manually go through the changes produced by the above command and remove any that are incorrect (e.g., command lines, Linux-compatible procfs files, line/column numbers, etc.). The remaining changes focus solely on log messages.