### PR TITLE
Propagate more `VirtioTransportError`s

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -270,12 +270,8 @@ impl DeviceInner {
 
         {
             let mut transport = device.transport.lock();
-            transport
-                .register_cfg_callback(Box::new(handle_config_change))
-                .unwrap();
-            transport
-                .register_queue_callback(0, Box::new(handle_irq), false)
-                .unwrap();
+            transport.register_cfg_callback(Box::new(handle_config_change))?;
+            transport.register_queue_callback(0, Box::new(handle_irq), false)?;
             transport.finish_init();
         }
 

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -122,12 +122,12 @@ impl ConsoleDevice {
             let device = device.clone();
             move |_: &TrapFrame| device.handle_recv_irq()
         };
-        transport
-            .register_queue_callback(RECV0_QUEUE_INDEX, Box::new(handle_console_input), false)
-            .unwrap();
-        transport
-            .register_cfg_callback(Box::new(config_space_change))
-            .unwrap();
+        transport.register_queue_callback(
+            RECV0_QUEUE_INDEX,
+            Box::new(handle_console_input),
+            false,
+        )?;
+        transport.register_cfg_callback(Box::new(config_space_change))?;
         transport.finish_init();
         drop(transport);
 

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -135,9 +135,7 @@ impl InputDevice {
         fn config_space_change(_: &TrapFrame) {
             debug!("input device config space change");
         }
-        transport
-            .register_cfg_callback(Box::new(config_space_change))
-            .unwrap();
+        transport.register_cfg_callback(Box::new(config_space_change))?;
         transport.finish_init();
         drop(transport);
 

--- a/kernel/comps/virtio/src/device/mod.rs
+++ b/kernel/comps/virtio/src/device/mod.rs
@@ -58,6 +58,7 @@ impl From<queue::CreationError> for VirtioDeviceError {
         match value {
             queue::CreationError::InvalidArgs => Self::InvalidQueueArgs,
             queue::CreationError::ResourceAlloc(e) => Self::ResourceAlloc(e),
+            queue::CreationError::Transport(e) => Self::Transport(e),
         }
     }
 }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -133,16 +133,13 @@ impl NetworkDevice {
 
         device
             .transport
-            .register_cfg_callback(Box::new(config_space_change))
-            .unwrap();
+            .register_cfg_callback(Box::new(config_space_change))?;
         device
             .transport
-            .register_queue_callback(QUEUE_SEND, Box::new(handle_send_event), true)
-            .unwrap();
+            .register_queue_callback(QUEUE_SEND, Box::new(handle_send_event), true)?;
         device
             .transport
-            .register_queue_callback(QUEUE_RECV, Box::new(handle_recv_event), true)
-            .unwrap();
+            .register_queue_callback(QUEUE_RECV, Box::new(handle_recv_event), true)?;
 
         device.transport.finish_init();
 

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -67,32 +67,24 @@ impl SocketDevice {
 
         let mut transport = device.transport.lock();
         let weak_device = Arc::downgrade(&device);
-        transport
-            .register_queue_callback(
-                RxQueue::QUEUE_INDEX,
-                Box::new(move |_: &TrapFrame| super::schedule_rx(&weak_device)),
-                true,
-            )
-            .unwrap();
+        transport.register_queue_callback(
+            RxQueue::QUEUE_INDEX,
+            Box::new(move |_: &TrapFrame| super::schedule_rx(&weak_device)),
+            true,
+        )?;
         let weak_device = Arc::downgrade(&device);
-        transport
-            .register_queue_callback(
-                TxQueue::QUEUE_INDEX,
-                Box::new(move |_: &TrapFrame| super::schedule_tx(&weak_device)),
-                true,
-            )
-            .unwrap();
+        transport.register_queue_callback(
+            TxQueue::QUEUE_INDEX,
+            Box::new(move |_: &TrapFrame| super::schedule_tx(&weak_device)),
+            true,
+        )?;
         let weak_device = Arc::downgrade(&device);
-        transport
-            .register_queue_callback(
-                EventQueue::QUEUE_INDEX,
-                Box::new(move |_: &TrapFrame| super::schedule_event(&weak_device)),
-                true,
-            )
-            .unwrap();
-        transport
-            .register_cfg_callback(Box::new(config_space_change))
-            .unwrap();
+        transport.register_queue_callback(
+            EventQueue::QUEUE_INDEX,
+            Box::new(move |_: &TrapFrame| super::schedule_event(&weak_device)),
+            true,
+        )?;
+        transport.register_cfg_callback(Box::new(config_space_change))?;
         transport.finish_init();
         drop(transport);
 

--- a/kernel/comps/virtio/src/queue.rs
+++ b/kernel/comps/virtio/src/queue.rs
@@ -18,7 +18,9 @@ use ostd::{
 
 use crate::{
     dma_buf::DmaBuf,
-    transport::{ConfigManager, VirtioTransport, pci::legacy::VirtioPciLegacyTransport},
+    transport::{
+        ConfigManager, VirtioTransport, VirtioTransportError, pci::legacy::VirtioPciLegacyTransport,
+    },
 };
 
 /// The mechanism for bulk data transport on virtio devices.
@@ -62,6 +64,7 @@ pub struct VirtQueue {
 pub(crate) enum CreationError {
     InvalidArgs,
     ResourceAlloc(ostd::Error),
+    Transport(VirtioTransportError),
 }
 
 /// An error returned by [`VirtQueue::add_dma_bufs`] and its friends.
@@ -112,7 +115,9 @@ impl VirtQueue {
         let (descriptor_ptr, avail_ring_ptr, used_ring_ptr, device_queue_size) = if transport
             .is_legacy_version()
         {
-            let device_queue_size = transport.max_queue_size(idx).unwrap() as usize;
+            let device_queue_size = transport
+                .max_queue_size(idx)
+                .map_err(CreationError::Transport)? as usize;
             let desc_size = size_of::<Descriptor>() * device_queue_size;
 
             // We should establish a reasonable upper bound on the requested queue size from the
@@ -154,7 +159,9 @@ impl VirtQueue {
                 device_queue_size as u16,
             )
         } else {
-            let max_queue_size = transport.max_queue_size(idx).unwrap() as usize;
+            let max_queue_size = transport
+                .max_queue_size(idx)
+                .map_err(CreationError::Transport)? as usize;
 
             // There can be a maximum of 256 descriptors on one page.
             if size as usize > max_queue_size || size > 256 {
@@ -185,7 +192,7 @@ impl VirtQueue {
                 &avail_ring_ptr,
                 &used_ring_ptr,
             )
-            .unwrap();
+            .map_err(CreationError::Transport)?;
 
         let mut descs = Vec::with_capacity(size as usize);
         descs.push(DescriptorSlot {


### PR DESCRIPTION
In https://github.com/asterinas/asterinas/pull/3160, it was decided to continue using `unwrap` when communicating with the transport in some places.

> 2. APIs that cannot fail should continue to use `unwrap()`. These include the following: [..]
>   - `VirtioTransport::register_queue_callback()`/`VirtioTransport::register_cfg_callback()`. [..]

However, this may not be reasonable since unexpected errors can occur when communicating with the device through the transport implementation, which is behind a trait.

Propagating errors with `?` in such places is trivial. This PR converts the `unwrap` to error propagation.

The merged `virtio-rng` implementation is fine. No need to fix it. All other devices are fixed in this PR.