### PR TITLE
Netfilter Hook for eBPF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "int-to-c-enum",
  "jhash",
  "ostd",
+ "rbpf",
  "smoltcp",
  "spin",
  "takeable",
@@ -500,6 +501,15 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "component"
@@ -1585,6 +1595,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rbpf"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7fd1b4fdf96615efe17cfd01307737988fd17ece498e36f34d30e98726027d"
+dependencies = [
+ "byteorder",
+ "combine",
+ "hashbrown 0.16.1",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,8 @@ zerocopy = { version = "0.8.34", features = [ "derive" ] }
 proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
 quote = "1.0.35"
 syn = { version = "2.0.77", features = ["full", "parsing", "fold"] }
+# eBPF VM
+rbpf = { version = "0.4", default-features = false }
 
 # Cargo only looks at the profile settings 
 # in the Cargo.toml manifest at the root of the workspace

--- a/kernel/libs/aster-bigtcp/Cargo.toml
+++ b/kernel/libs/aster-bigtcp/Cargo.toml
@@ -11,6 +11,7 @@ bitflags.workspace = true
 int-to-c-enum.workspace = true
 jhash.workspace = true
 ostd.workspace = true
+rbpf.workspace = true
 smoltcp.workspace = true
 spin.workspace = true
 takeable.workspace = true

--- a/kernel/libs/aster-bigtcp/src/lib.rs
+++ b/kernel/libs/aster-bigtcp/src/lib.rs
@@ -22,6 +22,7 @@ pub mod device;
 pub mod errors;
 pub mod ext;
 pub mod iface;
+pub mod netfilter;
 pub mod socket;
 pub mod socket_table;
 pub mod time;

--- a/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
@@ -6,15 +6,12 @@ use rbpf::EbpfVmRaw;
 
 use super::{HookContext, HookFunction, Verdict};
 
-const UDP_SEND_PREFIX_A_BYTECODE: &[u8] = &[
-    0x71, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ldxb r0, [r1 + 0]
-    0x15, 0x00, 0x02, 0x00, 0x61, 0x00, 0x00, 0x00, // jeq r0, 'a', +2
-    0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov64 r0, 0
-    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
-    0xb7, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // mov64 r0, 1
-    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
-];
-
+/// A Netfilter hook that runs a user-provided eBPF program.
+///
+/// The program is executed over the UDP payload. Its return value is mapped
+/// to [`Verdict::Drop`] when `0` and [`Verdict::Accept`] otherwise, matching
+/// the convention of the Linux BPF_PROG_TYPE_NETFILTER `NF_DROP` / `NF_ACCEPT`
+/// return codes.
 pub struct EbpfHook {
     bytecode: Vec<u8>,
 }
@@ -26,13 +23,6 @@ impl EbpfHook {
     pub fn new(bytecode: Vec<u8>) -> core::result::Result<Self, String> {
         EbpfVmRaw::new(Some(&bytecode)).map_err(|error| format!("{error:?}"))?;
         Ok(Self { bytecode })
-    }
-
-    pub(crate) fn builtin_udp_send_prefix_a() -> Self {
-        debug_assert!(EbpfVmRaw::new(Some(UDP_SEND_PREFIX_A_BYTECODE)).is_ok());
-        Self {
-            bytecode: UDP_SEND_PREFIX_A_BYTECODE.to_vec(),
-        }
     }
 
     /// Executes the eBPF program against packet data and returns the raw eBPF value.

--- a/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{format, string::String, vec::Vec};
+
+use rbpf::EbpfVmRaw;
+
+use super::{HookContext, HookFunction, Verdict};
+
+pub struct EbpfHook {
+    bytecode: Vec<u8>,
+}
+
+impl EbpfHook {
+    /// Creates an eBPF hook from raw bytecode.
+    ///
+    /// Returns an error when the rbpf verifier rejects the program.
+    pub fn new(bytecode: Vec<u8>) -> core::result::Result<Self, String> {
+        EbpfVmRaw::new(Some(&bytecode)).map_err(|error| format!("{error:?}"))?;
+        Ok(Self { bytecode })
+    }
+
+    /// Executes the eBPF program against packet data and returns the raw eBPF value.
+    pub fn execute(&self, packet_data: &mut [u8]) -> u64 {
+        let vm = match EbpfVmRaw::new(Some(&self.bytecode)) {
+            Ok(vm) => vm,
+            Err(_) => return 0,
+        };
+
+        vm.execute_program(packet_data).unwrap_or(0)
+    }
+}
+
+impl HookFunction for EbpfHook {
+    fn run(&self, context: &mut HookContext) -> Option<Verdict> {
+        let result = self.execute(context.packet_data_mut());
+        let verdict = if result == 0 {
+            Verdict::Drop
+        } else {
+            Verdict::Accept
+        };
+
+        Some(verdict)
+    }
+}

--- a/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
@@ -3,6 +3,7 @@
 use alloc::{format, string::String, vec::Vec};
 
 use rbpf::EbpfVmRaw;
+use smoltcp::wire::ip::Address;
 
 use super::{HookContext, HookFunction, Verdict};
 
@@ -25,20 +26,81 @@ impl EbpfHook {
         Ok(Self { bytecode })
     }
 
-    /// Executes the eBPF program against packet data and returns the raw eBPF value.
-    pub fn execute(&self, packet_data: &mut [u8]) -> u64 {
+    /// Executes the eBPF program against a buffer that contains a small
+    /// serialized metadata header followed by the packet payload. Returns the
+    /// raw eBPF value.
+    pub fn execute_with_context(&self, context: &mut HookContext) -> u64 {
+        // Serialize a compact, fixed-layout metadata header that precedes the
+        // packet payload in the memory region supplied to the eBPF VM.
+        // Layout (little-endian fields):
+        //  - version: u8 (1)
+        //  - family: u8 (4 for IPv4, 6 for IPv6, 0 unknown)
+        //  - dst_port: u16 (big-endian)
+        //  - src_port: u16 (big-endian) -- currently 0 (unknown)
+        //  - dst_addr: 16 bytes (IPv6-style; IPv4 stored in last 4 bytes)
+        //  - src_addr: 16 bytes (IPv6-style; IPv4 stored in last 4 bytes)
+
+        let meta = context.metadata();
+
+        let mut header = Vec::with_capacity(40);
+        header.push(1u8); // version
+
+        // family + ports
+        let mut family: u8 = 0;
+        let mut dst_port_be: [u8; 2] = [0, 0];
+        let mut src_port_be: [u8; 2] = [0, 0];
+
+        dst_port_be.copy_from_slice(&meta.endpoint.port.to_be_bytes());
+
+        // src_port is not available from UdpMetadata (only local address), leave 0
+
+        // addr slots (IPv6-style, IPv4 in last 4 bytes)
+        let mut dst_addr = [0u8; 16];
+        let mut src_addr = [0u8; 16];
+
+        match meta.endpoint.addr {
+            Address::Ipv4(ipv4) => {
+                family = 4;
+                let octs = ipv4.octets();
+                dst_addr[12..16].copy_from_slice(&octs);
+            }
+        }
+
+        if let Some(local) = meta.local_address {
+            match local {
+                smoltcp::wire::ip::Address::Ipv4(ipv4) => {
+                    let octs = ipv4.octets();
+                    src_addr[12..16].copy_from_slice(&octs);
+                    if family == 0 {
+                        family = 4;
+                    }
+                }
+            }
+        }
+
+        header.push(family);
+        header.extend_from_slice(&dst_port_be);
+        header.extend_from_slice(&src_port_be);
+        header.extend_from_slice(&dst_addr);
+        header.extend_from_slice(&src_addr);
+
+        // Build combined buffer: header || packet
+        let mut combined = Vec::with_capacity(header.len() + context.packet_data().len());
+        combined.extend_from_slice(&header);
+        combined.extend_from_slice(context.packet_data());
+
         let vm = match EbpfVmRaw::new(Some(&self.bytecode)) {
             Ok(vm) => vm,
             Err(_) => return 0,
         };
 
-        vm.execute_program(packet_data).unwrap_or(0)
+        vm.execute_program(combined.as_mut_slice()).unwrap_or(0)
     }
 }
 
 impl HookFunction for EbpfHook {
     fn run(&self, context: &mut HookContext) -> Option<Verdict> {
-        let result = self.execute(context.packet_data_mut());
+        let result = self.execute_with_context(context);
         let verdict = if result == 0 {
             Verdict::Drop
         } else {

--- a/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/ebpf.rs
@@ -6,6 +6,15 @@ use rbpf::EbpfVmRaw;
 
 use super::{HookContext, HookFunction, Verdict};
 
+const UDP_SEND_PREFIX_A_BYTECODE: &[u8] = &[
+    0x71, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ldxb r0, [r1 + 0]
+    0x15, 0x00, 0x02, 0x00, 0x61, 0x00, 0x00, 0x00, // jeq r0, 'a', +2
+    0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov64 r0, 0
+    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    0xb7, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // mov64 r0, 1
+    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+];
+
 pub struct EbpfHook {
     bytecode: Vec<u8>,
 }
@@ -17,6 +26,13 @@ impl EbpfHook {
     pub fn new(bytecode: Vec<u8>) -> core::result::Result<Self, String> {
         EbpfVmRaw::new(Some(&bytecode)).map_err(|error| format!("{error:?}"))?;
         Ok(Self { bytecode })
+    }
+
+    pub(crate) fn builtin_udp_send_prefix_a() -> Self {
+        debug_assert!(EbpfVmRaw::new(Some(UDP_SEND_PREFIX_A_BYTECODE)).is_ok());
+        Self {
+            bytecode: UDP_SEND_PREFIX_A_BYTECODE.to_vec(),
+        }
     }
 
     /// Executes the eBPF program against packet data and returns the raw eBPF value.

--- a/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
@@ -64,6 +64,10 @@ impl HookContext {
         Self { metadata, packet }
     }
 
+    pub fn into_parts(self) -> (UdpMetadata, Vec<u8>) {
+        (self.metadata, self.packet)
+    }
+
     pub fn metadata(&self) -> &UdpMetadata {
         &self.metadata
     }

--- a/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+use ostd::sync::SpinLock;
+use smoltcp::socket::udp::UdpMetadata;
+use spin::once::Once;
+
+pub mod ebpf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Verdict {
+    Accept,
+    Drop,
+}
+
+pub struct Registry {
+    udp_send: SpinLock<Vec<Box<dyn HookFunction>>>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self {
+            udp_send: SpinLock::new(Vec::new()),
+        }
+    }
+
+    pub fn register_udp_send_hook(&mut self, hook: Box<dyn HookFunction>) {
+        self.udp_send.lock().push(hook);
+    }
+
+    pub fn udp_send_hooks_exist(&self) -> bool {
+        !self.udp_send.lock().is_empty()
+    }
+
+    pub fn run_udp_send_hooks(&self, context: &mut HookContext) -> Option<Verdict> {
+        for hook in self.udp_send.lock().iter() {
+            if let Some(verdict) = hook.run(context) {
+                return Some(verdict);
+            }
+        }
+        None
+    }
+}
+
+static NETFILTER_REGISTRY: Once<Arc<Registry>> = Once::new();
+
+pub fn init_registry() {
+    NETFILTER_REGISTRY.call_once(|| Arc::new(Registry::new()));
+}
+
+pub fn registry() -> Option<&'static Arc<Registry>> {
+    NETFILTER_REGISTRY.get()
+}
+
+#[repr(C)]
+pub struct HookContext {
+    metadata: UdpMetadata,
+    packet: Vec<u8>,
+}
+
+impl HookContext {
+    pub fn new(metadata: UdpMetadata, packet: Vec<u8>) -> Self {
+        Self { metadata, packet }
+    }
+
+    pub fn metadata(&self) -> &UdpMetadata {
+        &self.metadata
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut UdpMetadata {
+        &mut self.metadata
+    }
+
+    /// Returns a slice of the packet data.
+    pub fn packet_data(&self) -> &[u8] {
+        &self.packet
+    }
+
+    /// Returns a mutable slice of the packet data.
+    pub fn packet_data_mut(&mut self) -> &mut [u8] {
+        &mut self.packet
+    }
+}
+
+pub trait HookFunction: Send + Sync {
+    fn run(&self, context: &mut HookContext) -> Option<Verdict>;
+}

--- a/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use ostd::sync::SpinLock;
 use smoltcp::socket::udp::UdpMetadata;
@@ -14,25 +15,51 @@ pub enum Verdict {
     Drop,
 }
 
+/// A unique identifier for a registered hook.
+///
+/// Used later to unregister the hook without scanning for identity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HookId(u64);
+
+struct HookEntry {
+    id: HookId,
+    hook: Box<dyn HookFunction>,
+}
+
 pub struct Registry {
-    udp_send: SpinLock<Vec<Box<dyn HookFunction>>>,
+    next_id: AtomicU64,
+    udp_send: SpinLock<Vec<HookEntry>>,
 }
 
 impl Registry {
     pub fn new() -> Self {
         Self {
+            next_id: AtomicU64::new(1),
             udp_send: SpinLock::new(Vec::new()),
         }
     }
 
-    fn new_with_builtin_hooks() -> Self {
-        let mut registry = Self::new();
-        registry.register_udp_send_hook(Box::new(ebpf::EbpfHook::builtin_udp_send_prefix_a()));
-        registry
+    /// Registers a hook function for the UDP send hook point.
+    ///
+    /// Returns a [`HookId`] that can be used with [`Self::unregister_udp_send_hook`]
+    /// to remove the hook later (e.g., when the associated BPF link is closed).
+    pub fn register_udp_send_hook(&self, hook: Box<dyn HookFunction>) -> HookId {
+        let id = HookId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        self.udp_send.lock().push(HookEntry { id, hook });
+        id
     }
 
-    pub fn register_udp_send_hook(&mut self, hook: Box<dyn HookFunction>) {
-        self.udp_send.lock().push(hook);
+    /// Unregisters a previously-registered UDP send hook.
+    ///
+    /// Returns `true` if a matching hook was found and removed.
+    pub fn unregister_udp_send_hook(&self, id: HookId) -> bool {
+        let mut hooks = self.udp_send.lock();
+        if let Some(pos) = hooks.iter().position(|entry| entry.id == id) {
+            hooks.remove(pos);
+            true
+        } else {
+            false
+        }
     }
 
     pub fn udp_send_hooks_exist(&self) -> bool {
@@ -40,8 +67,8 @@ impl Registry {
     }
 
     pub fn run_udp_send_hooks(&self, context: &mut HookContext) -> Option<Verdict> {
-        for hook in self.udp_send.lock().iter() {
-            if let Some(verdict) = hook.run(context) {
+        for entry in self.udp_send.lock().iter() {
+            if let Some(verdict) = entry.hook.run(context) {
                 return Some(verdict);
             }
         }
@@ -49,10 +76,16 @@ impl Registry {
     }
 }
 
+impl Default for Registry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 static NETFILTER_REGISTRY: Once<Arc<Registry>> = Once::new();
 
 pub fn init_registry() {
-    NETFILTER_REGISTRY.call_once(|| Arc::new(Registry::new_with_builtin_hooks()));
+    NETFILTER_REGISTRY.call_once(|| Arc::new(Registry::new()));
 }
 
 pub fn registry() -> Option<&'static Arc<Registry>> {

--- a/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/netfilter/mod.rs
@@ -25,6 +25,12 @@ impl Registry {
         }
     }
 
+    fn new_with_builtin_hooks() -> Self {
+        let mut registry = Self::new();
+        registry.register_udp_send_hook(Box::new(ebpf::EbpfHook::builtin_udp_send_prefix_a()));
+        registry
+    }
+
     pub fn register_udp_send_hook(&mut self, hook: Box<dyn HookFunction>) {
         self.udp_send.lock().push(hook);
     }
@@ -46,14 +52,13 @@ impl Registry {
 static NETFILTER_REGISTRY: Once<Arc<Registry>> = Once::new();
 
 pub fn init_registry() {
-    NETFILTER_REGISTRY.call_once(|| Arc::new(Registry::new()));
+    NETFILTER_REGISTRY.call_once(|| Arc::new(Registry::new_with_builtin_hooks()));
 }
 
 pub fn registry() -> Option<&'static Arc<Registry>> {
     NETFILTER_REGISTRY.get()
 }
 
-#[repr(C)]
 pub struct HookContext {
     metadata: UdpMetadata,
     packet: Vec<u8>,

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, sync::Arc};
+use alloc::{boxed::Box, sync::Arc, vec};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use aster_softirq::BottomHalfDisabled;
@@ -16,6 +16,7 @@ use crate::{
     errors::udp::SendError,
     ext::Ext,
     iface::BoundPort,
+    netfilter::{self, HookContext, Verdict},
     socket::{RawUdpSocket, event::SocketEvents, unbound::new_udp_socket},
 };
 
@@ -148,13 +149,31 @@ impl<E: Ext> UdpSocket<E> {
         F: FnOnce(&mut [u8]) -> R,
     {
         let mut socket = self.0.inner.socket.lock();
+        let mut meta = meta.into();
 
         if size > socket.packet_send_capacity() {
             return Err(SendError::TooLarge);
         }
 
+        let mut packet = vec![0u8; size];
+        let result = f(packet.as_mut_slice());
+
+        if let Some(registry) = netfilter::registry()
+            && registry.udp_send_hooks_exist()
+        {
+            let mut context = HookContext::new(meta, packet);
+            let verdict = registry.run_udp_send_hooks(&mut context);
+
+            // FIXME: Return `SendError` to the caller when the packet is dropped.
+            if matches!(verdict, Some(Verdict::Drop)) {
+                return Ok(result);
+            }
+
+            (meta, packet) = context.into_parts();
+        }
+
         let buffer = socket.send(size, meta)?;
-        let result = f(buffer);
+        buffer.copy_from_slice(packet.as_slice());
 
         self.0
             .inner

--- a/kernel/src/bpf/link.rs
+++ b/kernel/src/bpf/link.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The in-kernel representation of a BPF link.
+//!
+//! A [`BpfLinkFile`] represents an attachment of a loaded eBPF program
+//! to a hook point. Closing the file descriptor detaches the program from
+//! the hook.
+
+use core::fmt::Display;
+
+use aster_bigtcp::netfilter::{self, HookContext, HookFunction, HookId, Verdict};
+
+use super::prog::BpfProgFile;
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{FileLike, file_table::FdFlags},
+        pseudofs::AnonInodeFs,
+        vfs::path::Path,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+};
+
+/// The hook point at which a [`BpfLinkFile`] is attached.
+#[derive(Clone, Copy, Debug)]
+enum AttachPoint {
+    /// The `UdpSocket::send` hook in `aster-bigtcp`.
+    NetfilterUdpSend,
+}
+
+/// A BPF program attached to a hook point.
+pub(crate) struct BpfLinkFile {
+    // Keep the program alive for at least as long as the link exists; the
+    // registry entry borrows the program's bytecode through the hook closure.
+    _prog: Arc<BpfProgFile>,
+    attach: AttachPoint,
+    hook_id: HookId,
+    pseudo_path: Path,
+}
+
+impl BpfLinkFile {
+    /// Attaches `prog` to the netfilter UDP send hook.
+    pub(crate) fn attach_netfilter_udp_send(prog: Arc<BpfProgFile>) -> Result<Arc<Self>> {
+        let registry = netfilter::registry().ok_or_else(|| {
+            Error::with_message(Errno::ENODEV, "the netfilter registry is not initialized")
+        })?;
+
+        let hook = Box::new(ProgHook { prog: prog.clone() });
+        let hook_id = registry.register_udp_send_hook(hook);
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:bpf-link".to_string());
+
+        Ok(Arc::new(Self {
+            _prog: prog,
+            attach: AttachPoint::NetfilterUdpSend,
+            hook_id,
+            pseudo_path,
+        }))
+    }
+}
+
+impl Drop for BpfLinkFile {
+    fn drop(&mut self) {
+        let Some(registry) = netfilter::registry() else {
+            return;
+        };
+        match self.attach {
+            AttachPoint::NetfilterUdpSend => {
+                registry.unregister_udp_send_hook(self.hook_id);
+            }
+        }
+    }
+}
+
+impl Pollable for BpfLinkFile {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        // Links are passive attachments; no IO readiness to report.
+        IoEvents::empty() & mask
+    }
+}
+
+impl FileLike for BpfLinkFile {
+    fn path(&self) -> &Path {
+        &self.pseudo_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, _fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            attach: AttachPoint,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let name = match self.attach {
+                    AttachPoint::NetfilterUdpSend => "netfilter_udp_send",
+                };
+                writeln!(f, "link_type:\t{}", name)
+            }
+        }
+
+        Box::new(FdInfo {
+            attach: self.attach,
+        })
+    }
+}
+
+/// The hook function that the netfilter registry sees.
+///
+/// It forwards the hook invocation to the eBPF program owned by the
+/// referenced [`BpfProgFile`].
+struct ProgHook {
+    prog: Arc<BpfProgFile>,
+}
+
+impl HookFunction for ProgHook {
+    fn run(&self, context: &mut HookContext) -> Option<Verdict> {
+        self.prog.hook().run(context)
+    }
+}

--- a/kernel/src/bpf/mod.rs
+++ b/kernel/src/bpf/mod.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The eBPF subsystem.
+//!
+//! This module implements the first phase of the roadmap in
+//! <https://github.com/asterinas/asterinas/issues/3119>:
+//!
+//! - `BPF_PROG_LOAD`: verifies a user-supplied eBPF program and exposes it
+//!   through a file descriptor.
+//! - `BPF_LINK_CREATE`: attaches a loaded program to a Netfilter hook point
+//!   (currently only the UDP send hook) and exposes the attachment through a
+//!   file descriptor. Closing the descriptor detaches the program.
+//!
+//! The eBPF program is executed by the rbpf interpreter (no JIT), in line with
+//! the roadmap.
+
+mod link;
+mod prog;
+mod uapi;
+
+pub(crate) use link::BpfLinkFile;
+pub(crate) use prog::BpfProgFile;
+pub(crate) use uapi::{
+    AST_HOOK_UDP_SEND, BpfAttachType, BpfCmd, BpfProgType, bpf_link_create_attr, bpf_prog_load_attr,
+};

--- a/kernel/src/bpf/prog.rs
+++ b/kernel/src/bpf/prog.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The in-kernel representation of a loaded eBPF program.
+//!
+//! A [`BpfProgFile`] is a [`FileLike`] that owns verified eBPF bytecode. User
+//! space holds a handle to it via a file descriptor returned by
+//! `bpf(BPF_PROG_LOAD, ...)`; the kernel holds additional `Arc` references
+//! through any [`BpfLinkFile`] that has attached the program to a hook.
+//!
+//! [`BpfLinkFile`]: super::BpfLinkFile
+
+use core::fmt::Display;
+
+use aster_bigtcp::netfilter::ebpf::EbpfHook;
+
+use super::uapi::BpfProgType;
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{FileLike, file_table::FdFlags},
+        pseudofs::AnonInodeFs,
+        vfs::path::Path,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+};
+
+/// A loaded eBPF program exposed as a kernel object.
+pub(crate) struct BpfProgFile {
+    prog_type: BpfProgType,
+    hook: Arc<EbpfHook>,
+    pseudo_path: Path,
+}
+
+impl BpfProgFile {
+    pub(crate) fn new(prog_type: BpfProgType, bytecode: Vec<u8>) -> Result<Arc<Self>> {
+        let hook = EbpfHook::new(bytecode).map_err(|_err| {
+            Error::with_message(Errno::EINVAL, "the eBPF bytecode failed verification")
+        })?;
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:bpf-prog".to_string());
+        Ok(Arc::new(Self {
+            prog_type,
+            hook: Arc::new(hook),
+            pseudo_path,
+        }))
+    }
+
+    pub(crate) fn prog_type(&self) -> BpfProgType {
+        self.prog_type
+    }
+
+    pub(crate) fn hook(&self) -> &Arc<EbpfHook> {
+        &self.hook
+    }
+}
+
+impl Pollable for BpfProgFile {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        // BPF program FDs are passive objects; no IO readiness to report.
+        IoEvents::empty() & mask
+    }
+}
+
+impl FileLike for BpfProgFile {
+    fn path(&self) -> &Path {
+        &self.pseudo_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, _fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            prog_type: BpfProgType,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                writeln!(f, "prog_type:\t{}", self.prog_type as u32)
+            }
+        }
+
+        Box::new(FdInfo {
+            prog_type: self.prog_type,
+        })
+    }
+}

--- a/kernel/src/bpf/uapi.rs
+++ b/kernel/src/bpf/uapi.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! BPF user-visible ABI constants and structures.
+//!
+//! The constants follow Linux UAPI values so standard toolchains such as
+//! libbpf can be used. See <linux/bpf.h>.
+
+use crate::prelude::*;
+
+/// `bpf()` subcommand numbers.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, TryFromInt)]
+pub enum BpfCmd {
+    MapCreate = 0,
+    MapLookupElem = 1,
+    MapUpdateElem = 2,
+    MapDeleteElem = 3,
+    MapGetNextKey = 4,
+    ProgLoad = 5,
+    LinkCreate = 28,
+}
+
+/// Program types recognized by `BPF_PROG_LOAD`.
+///
+/// Only [`BpfProgType::Netfilter`] is supported in phase 1.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, TryFromInt)]
+pub enum BpfProgType {
+    Unspec = 0,
+    Netfilter = 45,
+}
+
+/// Attach types recognized by `BPF_LINK_CREATE`.
+///
+/// Only [`BpfAttachType::Netfilter`] is supported in phase 1.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, TryFromInt)]
+pub enum BpfAttachType {
+    Netfilter = 45,
+}
+
+/// Asterinas-private hook number for the UDP send hook.
+///
+/// Linux's generic netfilter hooks (`NF_INET_*`) do not cleanly map onto the
+/// single "before a UDP packet is handed off to the iface" hook that
+/// `aster-bigtcp` exposes today. Rather than lie about emulating a Linux
+/// hook, we expose the hook under a private identifier until the netfilter
+/// hook coverage grows.
+pub const AST_HOOK_UDP_SEND: u32 = 0x1000;
+
+/// `BPF_PROG_LOAD` attribute layout.
+///
+/// Matches the first fields of the `BPF_PROG_LOAD` arm of `union bpf_attr`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+#[allow(non_camel_case_types)]
+pub struct bpf_prog_load_attr {
+    pub prog_type: u32,
+    pub insn_cnt: u32,
+    pub insns: u64,
+    pub license: u64,
+    pub log_level: u32,
+    pub log_size: u32,
+    pub log_buf: u64,
+    pub kern_version: u32,
+    pub prog_flags: u32,
+    pub prog_name: [u8; 16],
+    pub prog_ifindex: u32,
+    pub expected_attach_type: u32,
+}
+
+/// `BPF_LINK_CREATE` attribute layout (netfilter attach variant).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+#[allow(non_camel_case_types)]
+pub struct bpf_link_create_attr {
+    pub prog_fd: u32,
+    pub target_fd_or_ifindex: u32,
+    pub attach_type: u32,
+    pub flags: u32,
+    /// For the netfilter arm: protocol family (`AF_INET` etc.).
+    pub nf_pf: u32,
+    /// For the netfilter arm: hook number.
+    pub nf_hooknum: u32,
+    /// For the netfilter arm: priority.
+    pub nf_priority: i32,
+    /// For the netfilter arm: flags.
+    pub nf_flags: u32,
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -39,6 +39,7 @@ macro_rules! __log_prefix {
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]
 mod arch;
 
+mod bpf;
 mod context;
 mod cpu;
 mod device;

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -13,4 +13,5 @@ pub fn init() {
 /// Lazy init should be called after spawning init thread.
 pub fn init_in_first_kthread() {
     iface::init_in_first_kthread();
+    aster_bigtcp::netfilter::init_registry();
 }

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -14,6 +14,7 @@ macro_rules! import_generic_syscall_entries {
             accept::{sys_accept, sys_accept4},
             access::{sys_faccessat, sys_faccessat2},
             bind::sys_bind,
+            bpf::sys_bpf,
             brk::sys_brk,
             capget::sys_capget,
             capset::sys_capset,
@@ -392,6 +393,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_RENAMEAT2 = 276              => sys_renameat2(args[..5]);
             SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
             SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
+            SYS_BPF = 280                    => sys_bpf(args[..3]);
             SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);
             SYS_PREADV2 = 286                => sys_preadv2(args[..6]);
             SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -8,6 +8,7 @@ use super::{
     alarm::sys_alarm,
     arch_prctl::sys_arch_prctl,
     bind::sys_bind,
+    bpf::sys_bpf,
     brk::sys_brk,
     capget::sys_capget,
     capset::sys_capset,
@@ -407,6 +408,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_RENAMEAT2 = 316        => sys_renameat2(args[..5]);
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 319     => sys_memfd_create(args[..2]);
+    SYS_BPF = 321              => sys_bpf(args[..3]);
     SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut user_ctx);
     SYS_PREADV2 = 327          => sys_preadv2(args[..6]);
     SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);

--- a/kernel/src/syscall/bpf.rs
+++ b/kernel/src/syscall/bpf.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `bpf()` system call.
+//!
+//! Phase 1 of <https://github.com/asterinas/asterinas/issues/3119> only
+//! supports two subcommands:
+//!
+//! - `BPF_PROG_LOAD`: load an eBPF program.
+//! - `BPF_LINK_CREATE`: attach a loaded program to a Netfilter hook.
+
+use ostd::mm::VmIo;
+
+use super::SyscallReturn;
+use crate::{
+    bpf::{
+        AST_HOOK_UDP_SEND, BpfAttachType, BpfCmd, BpfLinkFile, BpfProgFile, BpfProgType,
+        bpf_link_create_attr, bpf_prog_load_attr,
+    },
+    fs::file::file_table::FdFlags,
+    prelude::*,
+    util::CopyCompat,
+};
+
+/// The maximum number of eBPF instructions accepted by the verifier.
+///
+/// Matches the Linux `BPF_MAXINSNS` constant so off-the-shelf programs load
+/// unchanged.
+const MAX_INSNS: u32 = 4096;
+
+/// The size of a single eBPF instruction in bytes.
+const INSN_SIZE: u32 = 8;
+
+pub fn sys_bpf(cmd: u32, attr_addr: Vaddr, size: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let cmd = BpfCmd::try_from(cmd)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "unknown bpf command"))?;
+    debug!("bpf command = {:?}, attr_size = {}", cmd, size);
+
+    match cmd {
+        BpfCmd::ProgLoad => sys_bpf_prog_load(attr_addr, size as usize, ctx),
+        BpfCmd::LinkCreate => sys_bpf_link_create(attr_addr, size as usize, ctx),
+        _ => return_errno_with_message!(Errno::EINVAL, "bpf command is not supported"),
+    }
+}
+
+fn sys_bpf_prog_load(attr_addr: Vaddr, size: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let attr = ctx
+        .user_space()
+        .read_val_compat::<bpf_prog_load_attr>(attr_addr, size)?;
+
+    let prog_type = BpfProgType::try_from(attr.prog_type).map_err(|_| {
+        Error::with_message(Errno::EINVAL, "the eBPF program type is not supported")
+    })?;
+
+    if !matches!(prog_type, BpfProgType::Netfilter) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "only BPF_PROG_TYPE_NETFILTER is supported in phase 1"
+        );
+    }
+
+    if attr.insn_cnt == 0 || attr.insn_cnt > MAX_INSNS {
+        return_errno_with_message!(Errno::E2BIG, "the eBPF instruction count is out of range");
+    }
+
+    let bytecode_len = attr.insn_cnt.checked_mul(INSN_SIZE).ok_or_else(|| {
+        Error::with_message(Errno::E2BIG, "the eBPF instruction count is out of range")
+    })? as usize;
+    let mut bytecode = vec![0u8; bytecode_len];
+    ctx.user_space()
+        .read_bytes(attr.insns as Vaddr, &mut bytecode)?;
+
+    let prog = BpfProgFile::new(prog_type, bytecode)?;
+
+    let file_table = ctx.thread_local.borrow_file_table();
+    let mut file_table_locked = file_table.unwrap().write();
+    let fd = file_table_locked.insert(prog, FdFlags::empty());
+    Ok(SyscallReturn::Return(fd.into()))
+}
+
+fn sys_bpf_link_create(attr_addr: Vaddr, size: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let attr = ctx
+        .user_space()
+        .read_val_compat::<bpf_link_create_attr>(attr_addr, size)?;
+
+    let attach_type = BpfAttachType::try_from(attr.attach_type)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the eBPF attach type is not supported"))?;
+
+    // The phase 1 roadmap only targets the UDP send hook, which we expose
+    // through an Asterinas-private `hooknum` until we grow proper coverage
+    // of the Linux `NF_INET_*` hook points.
+    if !matches!(attach_type, BpfAttachType::Netfilter) || attr.nf_hooknum != AST_HOOK_UDP_SEND {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "only the Asterinas UDP send netfilter hook is supported"
+        );
+    }
+
+    let file = {
+        let file_table = ctx.thread_local.borrow_file_table();
+        let file_table_locked = file_table.unwrap().read();
+        file_table_locked
+            .get_file((attr.prog_fd as i32).try_into()?)?
+            .clone()
+    };
+    let prog: Arc<BpfProgFile> = Arc::downcast(file)
+        .map_err(|_| Error::with_message(Errno::EBADF, "the fd is not a bpf program"))?;
+
+    if !matches!(prog.prog_type(), BpfProgType::Netfilter) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the program type does not match the attach type"
+        );
+    }
+
+    let link = BpfLinkFile::attach_netfilter_udp_send(prog)?;
+
+    let file_table = ctx.thread_local.borrow_file_table();
+    let mut file_table_locked = file_table.unwrap().write();
+    let fd = file_table_locked.insert(link, FdFlags::empty());
+    Ok(SyscallReturn::Return(fd.into()))
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -23,6 +23,7 @@ mod access;
 mod alarm;
 mod arch_prctl;
 mod bind;
+mod bpf;
 mod brk;
 mod capget;
 mod capset;

--- a/test/initramfs/src/regression/network/Makefile
+++ b/test/initramfs/src/regression/network/Makefile
@@ -3,6 +3,7 @@
 EXTRA_C_FLAGS := -I/usr/include/libnl3 -lnl-3 -lnl-route-3
 
 SUBDIRS := \
+	netfilter_ebpf \
 	vsock \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/network/bpf_udp_hook.c
+++ b/test/initramfs/src/regression/network/bpf_udp_hook.c
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Verify that BPF_PROG_LOAD + BPF_LINK_CREATE attach an eBPF program to the
+// Asterinas UDP send netfilter hook, and that closing the link detaches it.
+//
+// The program loaded here is two eBPF instructions:
+//   mov64 r0, 0
+//   exit
+// which returns 0 — mapped by the kernel to NF_DROP for the netfilter attach
+// type. Once attached, UDP sends succeed at the syscall layer but are silently
+// dropped before hitting the interface; recvfrom on the receiving socket must
+// therefore block. After the link FD is closed the hook is removed and traffic
+// flows again.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#ifndef SYS_bpf
+#define SYS_bpf 321
+#endif
+
+#define BPF_PROG_LOAD 5
+#define BPF_LINK_CREATE 28
+
+#define BPF_PROG_TYPE_NETFILTER 45
+#define BPF_ATTACH_TYPE_NETFILTER 45
+
+// Asterinas-private hook number for the UDP send hook.
+#define AST_HOOK_UDP_SEND 0x1000
+
+struct bpf_prog_load_attr {
+	uint32_t prog_type;
+	uint32_t insn_cnt;
+	uint64_t insns;
+	uint64_t license;
+	uint32_t log_level;
+	uint32_t log_size;
+	uint64_t log_buf;
+	uint32_t kern_version;
+	uint32_t prog_flags;
+	char prog_name[16];
+	uint32_t prog_ifindex;
+	uint32_t expected_attach_type;
+};
+
+struct bpf_link_create_attr {
+	uint32_t prog_fd;
+	uint32_t target_fd_or_ifindex;
+	uint32_t attach_type;
+	uint32_t flags;
+	uint32_t nf_pf;
+	uint32_t nf_hooknum;
+	int32_t nf_priority;
+	uint32_t nf_flags;
+};
+
+// `mov64 r0, 0; exit`.
+static const uint8_t DROP_ALL_BYTECODE[] = {
+	0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static int bpf(int cmd, void *attr, unsigned int size)
+{
+	return syscall(SYS_bpf, cmd, attr, size);
+}
+
+static int sender;
+static int receiver;
+static struct sockaddr_in receiver_addr;
+
+FN_SETUP(sockets)
+{
+	sender = CHECK(socket(AF_INET, SOCK_DGRAM, 0));
+	receiver = CHECK(socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+
+	memset(&receiver_addr, 0, sizeof(receiver_addr));
+	receiver_addr.sin_family = AF_INET;
+	receiver_addr.sin_port = htons(9753);
+	CHECK(inet_aton("127.0.0.1", &receiver_addr.sin_addr));
+	CHECK(bind(receiver, (struct sockaddr *)&receiver_addr,
+		   sizeof(receiver_addr)));
+}
+END_SETUP()
+
+static int send_msg(const char *msg)
+{
+	return sendto(sender, msg, strlen(msg), 0,
+		      (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+}
+
+// Wait up to `timeout_ms` for the receiver to become readable, then read.
+// Returns the number of bytes read, or -1 with errno=EAGAIN on timeout.
+static int recv_msg_timeout(char *buf, int len, int timeout_ms)
+{
+	struct pollfd pfd = { .fd = receiver, .events = POLLIN };
+	int r = poll(&pfd, 1, timeout_ms);
+	if (r == 0) {
+		errno = EAGAIN;
+		return -1;
+	}
+	if (r < 0) {
+		return -1;
+	}
+	return recvfrom(receiver, buf, len, 0, NULL, NULL);
+}
+
+static int recv_msg(char *buf, int len)
+{
+	return recv_msg_timeout(buf, len, 500);
+}
+
+FN_TEST(bpf_udp_hook_drops_then_restores)
+{
+	char buf[64];
+
+	// Baseline: no hook installed, traffic flows.
+	TEST_RES(send_msg("pre"), _ret == 3);
+	TEST_RES(recv_msg(buf, sizeof(buf)),
+		 _ret == 3 && memcmp(buf, "pre", 3) == 0);
+
+	// Load a drop-all eBPF program.
+	struct bpf_prog_load_attr load_attr = {
+		.prog_type = BPF_PROG_TYPE_NETFILTER,
+		.insn_cnt = sizeof(DROP_ALL_BYTECODE) / 8,
+		.insns = (uint64_t)(uintptr_t)DROP_ALL_BYTECODE,
+	};
+	int prog_fd = TEST_RES(
+		bpf(BPF_PROG_LOAD, &load_attr, sizeof(load_attr)), _ret >= 0);
+	SKIP_TEST_IF(prog_fd < 0);
+
+	// Attach it to the UDP send hook.
+	struct bpf_link_create_attr link_attr = {
+		.prog_fd = prog_fd,
+		.attach_type = BPF_ATTACH_TYPE_NETFILTER,
+		.nf_hooknum = AST_HOOK_UDP_SEND,
+	};
+	int link_fd = TEST_RES(
+		bpf(BPF_LINK_CREATE, &link_attr, sizeof(link_attr)), _ret >= 0);
+	SKIP_TEST_IF(link_fd < 0);
+
+	// Drain anything that slipped through before the hook was attached.
+	while (recv_msg_timeout(buf, sizeof(buf), 0) > 0) {
+	}
+
+	// With the drop-all hook attached, sendto still succeeds but the
+	// packet is swallowed; recvfrom must time out.
+	TEST_RES(send_msg("blocked"), _ret == 7);
+	TEST_ERRNO(recv_msg(buf, sizeof(buf)), EAGAIN);
+
+	// Detach by closing the link FD.
+	TEST_SUCC(close(link_fd));
+
+	// Traffic flows again.
+	TEST_RES(send_msg("post"), _ret == 4);
+	TEST_RES(recv_msg(buf, sizeof(buf)),
+		 _ret == 4 && memcmp(buf, "post", 4) == 0);
+
+	TEST_SUCC(close(prog_fd));
+}
+END_TEST()
+
+FN_TEST(bpf_rejects_unknown_prog_type)
+{
+	struct bpf_prog_load_attr load_attr = {
+		.prog_type = 1, // socket filter — unsupported in phase 1.
+		.insn_cnt = sizeof(DROP_ALL_BYTECODE) / 8,
+		.insns = (uint64_t)(uintptr_t)DROP_ALL_BYTECODE,
+	};
+	TEST_ERRNO(bpf(BPF_PROG_LOAD, &load_attr, sizeof(load_attr)), EINVAL);
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/netfilter_ebpf/Makefile
+++ b/test/initramfs/src/regression/network/netfilter_ebpf/Makefile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MPL-2.0
+
+EXTRA_C_FLAGS := -static
+
+include ../../common/Makefile
+
+BIN_FILES := accept.bin drop.bin check_meta.bin
+BIN_OUTPUTS := $(addprefix $(OBJ_OUTPUT_DIR)/,$(BIN_FILES))
+
+all: $(BIN_OUTPUTS)
+
+$(OBJ_OUTPUT_DIR)/%.bin: %.bin | $(OBJ_OUTPUT_DIR)
+	cp $< $@

--- a/test/initramfs/src/regression/network/netfilter_ebpf/loader.c
+++ b/test/initramfs/src/regression/network/netfilter_ebpf/loader.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+
+#ifndef SYS_bpf
+#define SYS_bpf 321
+#endif
+
+#define BPF_PROG_LOAD 5
+#define BPF_LINK_CREATE 28
+
+#define BPF_PROG_TYPE_NETFILTER 45
+#define BPF_ATTACH_TYPE_NETFILTER 45
+
+// Asterinas-private hook number for the UDP send hook.
+#define AST_HOOK_UDP_SEND 0x1000
+
+struct bpf_prog_load_attr {
+	uint32_t prog_type;
+	uint32_t insn_cnt;
+	uint64_t insns;
+	uint64_t license;
+	uint32_t log_level;
+	uint32_t log_size;
+	uint64_t log_buf;
+	uint32_t kern_version;
+	uint32_t prog_flags;
+	char prog_name[16];
+	uint32_t prog_ifindex;
+	uint32_t expected_attach_type;
+};
+
+struct bpf_link_create_attr {
+	uint32_t prog_fd;
+	uint32_t target_fd_or_ifindex;
+	uint32_t attach_type;
+	uint32_t flags;
+	uint32_t nf_pf;
+	uint32_t nf_hooknum;
+	int32_t nf_priority;
+	uint32_t nf_flags;
+};
+
+static int bpf(int cmd, void *attr, unsigned int size)
+{
+	return syscall(SYS_bpf, cmd, attr, size);
+}
+
+static unsigned char *read_file(const char *path, size_t *len)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		perror(path);
+		return NULL;
+	}
+
+	off_t size = lseek(fd, 0, SEEK_END);
+	if (size < 0) {
+		perror("lseek");
+		close(fd);
+		return NULL;
+	}
+	if (lseek(fd, 0, SEEK_SET) < 0) {
+		perror("lseek");
+		close(fd);
+		return NULL;
+	}
+
+	unsigned char *buffer = malloc((size_t)size);
+	if (!buffer) {
+		perror("malloc");
+		close(fd);
+		return NULL;
+	}
+
+	size_t offset = 0;
+	while (offset < (size_t)size) {
+		ssize_t chunk = read(fd, buffer + offset, (size_t)size - offset);
+		if (chunk < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			perror("read");
+			free(buffer);
+			close(fd);
+			return NULL;
+		}
+		if (chunk == 0) {
+			break;
+		}
+		offset += (size_t)chunk;
+	}
+
+	close(fd);
+	*len = offset;
+	return buffer;
+}
+
+static void usage(const char *prog)
+{
+	fprintf(stderr, "usage: %s --prog FILE [--hook N]\n", prog);
+}
+
+int main(int argc, char **argv)
+{
+	const char *prog_path = NULL;
+	uint32_t hook_num = AST_HOOK_UDP_SEND;
+
+	for (int i = 1; i < argc; ++i) {
+		if (strcmp(argv[i], "--prog") == 0 && i + 1 < argc) {
+			prog_path = argv[++i];
+			continue;
+		}
+		if (strcmp(argv[i], "--hook") == 0 && i + 1 < argc) {
+			hook_num = (uint32_t)strtoul(argv[++i], NULL, 0);
+			continue;
+		}
+		usage(argv[0]);
+		return 2;
+	}
+
+	if (!prog_path) {
+		usage(argv[0]);
+		return 2;
+	}
+
+	size_t prog_size = 0;
+	unsigned char *bytecode = read_file(prog_path, &prog_size);
+	if (!bytecode) {
+		return 1;
+	}
+	if ((prog_size % 8) != 0) {
+		fprintf(stderr, "%s: size must be a multiple of 8 bytes\n", prog_path);
+		free(bytecode);
+		return 1;
+	}
+
+	struct bpf_prog_load_attr load_attr = {
+		.prog_type = BPF_PROG_TYPE_NETFILTER,
+		.insn_cnt = (uint32_t)(prog_size / 8),
+		.insns = (uint64_t)(uintptr_t)bytecode,
+	};
+	int prog_fd = bpf(BPF_PROG_LOAD, &load_attr, sizeof(load_attr));
+	if (prog_fd < 0) {
+		perror("BPF_PROG_LOAD");
+		free(bytecode);
+		return 1;
+	}
+
+	struct bpf_link_create_attr link_attr = {
+		.prog_fd = (uint32_t)prog_fd,
+		.attach_type = BPF_ATTACH_TYPE_NETFILTER,
+		.nf_hooknum = hook_num,
+	};
+	int link_fd = bpf(BPF_LINK_CREATE, &link_attr, sizeof(link_attr));
+	if (link_fd < 0) {
+		perror("BPF_LINK_CREATE");
+		close(prog_fd);
+		free(bytecode);
+		return 1;
+	}
+
+	printf("loaded %s: pid=%d prog_fd=%d link_fd=%d hook=%u\n", prog_path,
+	       (int)getpid(), prog_fd, link_fd, hook_num);
+	fflush(stdout);
+
+	free(bytecode);
+
+	for (;;) {
+		pause();
+	}
+}

--- a/test/initramfs/src/regression/network/netfilter_ebpf/packet_test.c
+++ b/test/initramfs/src/regression/network/netfilter_ebpf/packet_test.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#define TEST_PORT 9753
+
+static uint16_t test_port = TEST_PORT;
+
+static int sender = -1;
+static int receiver = -1;
+static struct sockaddr_in receiver_addr;
+
+static void setup_sockets(void)
+{
+	sender = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sender < 0) {
+		perror("socket(sender)");
+		exit(1);
+	}
+
+	receiver = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+	if (receiver < 0) {
+		perror("socket(receiver)");
+		exit(1);
+	}
+
+	memset(&receiver_addr, 0, sizeof(receiver_addr));
+	receiver_addr.sin_family = AF_INET;
+	receiver_addr.sin_port = htons(test_port);
+	if (inet_aton("127.0.0.1", &receiver_addr.sin_addr) == 0) {
+		fprintf(stderr, "inet_aton failed\n");
+		exit(1);
+	}
+
+	if (bind(receiver, (struct sockaddr *)&receiver_addr,
+			 sizeof(receiver_addr)) < 0) {
+		perror("bind");
+		exit(1);
+	}
+}
+
+static int send_msg(const char *msg)
+{
+	return sendto(sender, msg, strlen(msg), 0,
+		      (struct sockaddr *)&receiver_addr, sizeof(receiver_addr));
+}
+
+static int recv_msg_timeout(char *buf, int len, int timeout_ms)
+{
+	struct pollfd pfd = { .fd = receiver, .events = POLLIN };
+	int ready = poll(&pfd, 1, timeout_ms);
+	if (ready == 0) {
+		errno = EAGAIN;
+		return -1;
+	}
+	if (ready < 0) {
+		return -1;
+	}
+	return recvfrom(receiver, buf, len, 0, NULL, NULL);
+}
+
+static void usage(const char *prog)
+{
+	fprintf(stderr,
+		"usage: %s [--expect pass|drop] [-p|--port port] [payload]\n",
+		prog);
+}
+
+int main(int argc, char **argv)
+{
+	const char *expect = "pass";
+	const char *payload = "demo packet";
+
+	for (int i = 1; i < argc; ++i) {
+		if (strcmp(argv[i], "--expect") == 0 && i + 1 < argc) {
+			expect = argv[++i];
+			continue;
+		}
+		if ((strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "--port") == 0) &&
+		    i + 1 < argc) {
+			char *end = NULL;
+			long port = strtol(argv[++i], &end, 10);
+			if (end == argv[i] || *end != '\0' || port <= 0 || port > UINT16_MAX) {
+				fprintf(stderr, "invalid port: %s\n", argv[i]);
+				return 2;
+			}
+			test_port = (uint16_t)port;
+			continue;
+		}
+		if (argv[i][0] == '-') {
+			usage(argv[0]);
+			return 2;
+		}
+		payload = argv[i];
+	}
+
+	setup_sockets();
+
+	char buf[128];
+	while (recv_msg_timeout(buf, sizeof(buf), 0) > 0) {
+	}
+
+	if (send_msg(payload) < 0) {
+		perror("sendto");
+		return 1;
+	}
+
+	int received = recv_msg_timeout(buf, sizeof(buf), 500);
+	int ok = (received >= 0);
+
+	if (strcmp(expect, "pass") == 0) {
+		if (!ok) {
+			fprintf(stderr, "expected packet to pass, but it timed out\n");
+			return 1;
+		}
+		printf("packet passed: %.*s\n", received, buf);
+	} else if (strcmp(expect, "drop") == 0) {
+		if (ok) {
+			fprintf(stderr, "expected packet to drop, but it arrived\n");
+			return 1;
+		}
+		printf("packet dropped as expected\n");
+	} else {
+		usage(argv[0]);
+		return 2;
+	}
+
+	close(sender);
+	close(receiver);
+	return 0;
+}

--- a/test/initramfs/src/regression/network/netfilter_ebpf/run_test.sh
+++ b/test/initramfs/src/regression/network/netfilter_ebpf/run_test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+DIR=$(dirname "$0")
+LOADER="$DIR/loader"
+PACKET_TEST="$DIR/packet_test"
+
+run_case() {
+	prog="$1"
+	expect="$2"
+	payload="$3"
+
+	"$LOADER" --prog "$DIR/$prog" &
+	loader_pid=$!
+	trap 'kill "$loader_pid" 2>/dev/null || true' INT TERM EXIT
+	# Give the hook time to attach before sending packets.
+	sleep 0.2
+	"$PACKET_TEST" --expect "$expect" "$payload"
+	kill "$loader_pid" 2>/dev/null || true
+	wait "$loader_pid" 2>/dev/null || true
+	trap - INT TERM EXIT
+}
+
+run_case accept.bin pass "accept payload"
+run_case drop.bin drop "drop payload"
+run_case check_meta.bin pass "meta payload"
+
+echo "netfilter eBPF demo passed"

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -38,3 +38,5 @@ sleep 0.2
 ./uevent_err
 
 ./bpf_udp_hook
+
+./netfilter_ebpf/run_test.sh

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -36,3 +36,5 @@ sleep 0.2
 ./netlink_route
 ./rtnl_err
 ./uevent_err
+
+./bpf_udp_hook

--- a/tools/ebpf_programs/Makefile
+++ b/tools/ebpf_programs/Makefile
@@ -1,0 +1,18 @@
+CLANG ?= clang
+OBJCOPY ?= llvm-objcopy
+CFLAGS = -O2 -target bpf
+
+PROGS = accept drop check_meta
+
+all: $(PROGS:%=%.bin)
+
+%.o: %.c
+	$(CLANG) $(CFLAGS) -c $< -o $@
+
+%.bin: %.o
+	$(OBJCOPY) -O binary $< $@
+
+clean:
+	rm -f *.o *.bin
+
+.PHONY: all clean

--- a/tools/ebpf_programs/accept.c
+++ b/tools/ebpf_programs/accept.c
@@ -1,0 +1,17 @@
+#include <stddef.h>
+
+// Metadata header layout (must match kernel netfilter serialization)
+struct ebpf_metadata {
+    unsigned char version;          // offset 0
+    unsigned char family;           // offset 1 (4=IPv4, 6=IPv6, 0=unknown)
+    unsigned short dst_port;        // offset 2 (big-endian)
+    unsigned short src_port;        // offset 4 (big-endian)
+    unsigned char dst_addr[16];     // offset 6
+    unsigned char src_addr[16];     // offset 22
+} __attribute__((packed));
+
+__attribute__((section("prog"), used))
+int ebpf_accept(void *ctx) {
+    (void)ctx;
+    return 1;
+}

--- a/tools/ebpf_programs/check_meta.c
+++ b/tools/ebpf_programs/check_meta.c
@@ -1,0 +1,21 @@
+// Metadata header layout (must match kernel netfilter serialization)
+struct ebpf_metadata {
+    unsigned char version;          // offset 0
+    unsigned char family;           // offset 1 (4=IPv4, 6=IPv6, 0=unknown)
+    unsigned short dst_port;        // offset 2 (big-endian)
+    unsigned short src_port;        // offset 4 (big-endian)
+    unsigned char dst_addr[16];     // offset 6
+    unsigned char src_addr[16];     // offset 22
+} __attribute__((packed));
+
+__attribute__((section("prog"), used))
+int ebpf_check_meta(void *ctx) {
+    const struct ebpf_metadata *meta = (const struct ebpf_metadata *)ctx;
+    if (!meta) return 0;
+
+    // Accept only if version==1 and family==4 and dst_port==1234 (in big-endian)
+    if (meta->version == 1 && meta->family == 4 && meta->dst_port == 0xd204) {
+        return 1;
+    }
+    return 0;
+}

--- a/tools/ebpf_programs/drop.c
+++ b/tools/ebpf_programs/drop.c
@@ -1,0 +1,17 @@
+#include <stddef.h>
+
+// Metadata header layout (must match kernel netfilter serialization)
+struct ebpf_metadata {
+    unsigned char version;          // offset 0
+    unsigned char family;           // offset 1 (4=IPv4, 6=IPv6, 0=unknown)
+    unsigned short dst_port;        // offset 2 (big-endian)
+    unsigned short src_port;        // offset 4 (big-endian)
+    unsigned char dst_addr[16];     // offset 6
+    unsigned char src_addr[16];     // offset 22
+} __attribute__((packed));
+
+__attribute__((section("prog"), used))
+int ebpf_drop(void *ctx) {
+    (void)ctx;
+    return 0;
+}


### PR DESCRIPTION
PR for phase 1 of #3119: a Netfilter hook and minimal eBPF support for `BPF_PROG_TYPE_NETFILTER`.
With this, a user-supplied eBPF program can accept/drop outbound UDP packets.

## Implemented

- Netfilter: UDP send hook point, registry, `ACCEPT` / `DROP` verdicts
- eBPF: `BPF_PROG_LOAD`, `BPF_LINK_CREATE`, interpreter execution

The hook lives in `aster-bigtcp`; the context is only materialized when a hook is active.
I add a minimal test `bpf_udp_hook.c` (I've tried several tricks but I only add this minimal test)

## Feedback wanted

- What additional tests should I include
- The current approach is not scalable for multiple hook points. Could it be handled in a future iteration
- How can I better implement the global hook registry
- Whether passing metadata into the BPF program should be done now or in a follow-up

Will rebase and clean up once direction is settled.