### PR TITLE
Fix error codes for `/proc/self/fd/-1`

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
@@ -47,10 +47,13 @@ impl<T: FdOps> FdDirOps<T> {
 
 impl<T: FdOps> DirOps for FdDirOps<T> {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
-        let Ok(raw_fd) = name.parse::<RawFileDesc>() else {
+        let file_desc = if let Ok(raw_fd) = name.parse::<RawFileDesc>()
+            && let Ok(file_desc) = FileDesc::try_from(raw_fd)
+        {
+            file_desc
+        } else {
             return_errno_with_message!(Errno::ENOENT, "the name is not a valid FD");
         };
-        let fd = raw_fd.try_into()?;
 
         let Some(thread) = self.dir.thread() else {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
@@ -58,7 +61,7 @@ impl<T: FdOps> DirOps for FdDirOps<T> {
         let posix_thread = thread.as_posix_thread().unwrap();
 
         let access_mode = if let Some(file_table) = posix_thread.file_table().lock().as_ref()
-            && let Ok(file) = file_table.read().get_file(fd)
+            && let Ok(file) = file_table.read().get_file(file_desc)
         {
             file.access_mode()
         } else {
@@ -67,7 +70,7 @@ impl<T: FdOps> DirOps for FdDirOps<T> {
 
         Ok(T::new_inode(
             self.dir.clone(),
-            fd,
+            file_desc,
             access_mode,
             this_dir.this_weak().clone(),
         ))

--- a/test/initramfs/src/regression/fs/procfs/fd.c
+++ b/test/initramfs/src/regression/fs/procfs/fd.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+
+#include "../../common/test.h"
+
+FN_TEST(invalid_fd)
+{
+	TEST_ERRNO(open("/proc/self/fd/2147483647", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/2147483648", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/2147483649", O_RDONLY), ENOENT);
+
+	TEST_ERRNO(open("/proc/self/fd/4294967295", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/4294967296", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/4294967297", O_RDONLY), ENOENT);
+
+	TEST_ERRNO(open("/proc/self/fd/-1", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/-2147483648", O_RDONLY), ENOENT);
+	TEST_ERRNO(open("/proc/self/fd/-4294967296", O_RDONLY), ENOENT);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -115,8 +115,9 @@ echo "All mount bind file test passed."
 ./overlayfs/readdir_small_buffer
 
 ./procfs/dentry_cache
-./procfs/mountstats
+./procfs/fd
 ./procfs/getdents
+./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/tid
 


### PR DESCRIPTION
This is not quite correct...
```
~ # cat /proc/self/fd/-1
cat: can't open '/proc/self/fd/-1': Bad file descriptor
```