### PR TITLE
Non-functionality improvements to System V semaphores

### DIFF
--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -21,7 +21,7 @@ impl<T> IpcIds<T> {
     pub(super) fn new(max_id: usize) -> Self {
         let mut id_allocator = IdAlloc::with_capacity(max_id + 1);
         // Remove the first index 0 (IPC IDs start from 1).
-        id_allocator.alloc();
+        id_allocator.alloc_specific(0).unwrap();
 
         Self {
             objects: RwLock::new(BTreeMap::new()),
@@ -29,14 +29,18 @@ impl<T> IpcIds<T> {
         }
     }
 
-    /// Calls `op` with the object identified by `id`.
-    pub(super) fn with<R, F>(&self, key: key_t, op: F) -> Result<R>
+    /// Calls `op` with the object identified by `key`.
+    pub(super) fn with<R, F>(&self, key: key_t, op: F) -> core::result::Result<R, IdNotExistError>
     where
-        F: FnOnce(&T) -> Result<R>,
+        F: FnOnce(&T) -> R,
     {
         let objects = self.objects.read();
-        let object = objects.get(&key).ok_or(Error::new(Errno::ENOENT))?;
-        op(object)
+
+        let Some(object) = objects.get(&key) else {
+            return Err(IdNotExistError);
+        };
+
+        Ok(op(object))
     }
 
     /// Removes the object identified by `key`.
@@ -44,10 +48,19 @@ impl<T> IpcIds<T> {
     where
         F: FnOnce(&T) -> Result<()>,
     {
+        use alloc::collections::btree_map::Entry;
+
         let mut objects = self.objects.write();
-        let object = objects.get(&key).ok_or(Error::new(Errno::ENOENT))?;
-        may_remove(object)?;
-        objects.remove(&key).ok_or(Error::new(Errno::ENOENT))?;
+
+        let Entry::Occupied(entry) = objects.entry(key) else {
+            return_errno_with_message!(Errno::EINVAL, "the ID does not exist");
+        };
+
+        may_remove(entry.get())?;
+        entry.remove();
+
+        self.id_allocator.lock().free(key as usize);
+
         Ok(())
     }
 
@@ -57,16 +70,20 @@ impl<T> IpcIds<T> {
         F: FnOnce(key_t) -> Result<T>,
     {
         let mut objects = self.objects.write();
-        let mut id_allocator = self.id_allocator.lock();
-        let key = id_allocator.alloc().ok_or(Error::new(Errno::ENOSPC))? as key_t;
+
+        let Some(key) = self.id_allocator.lock().alloc().map(|key| key as key_t) else {
+            return_errno_with_message!(Errno::ENOSPC, "all IDs are exhausted");
+        };
+
         let object = match new_object_fn(key) {
             Ok(object) => object,
             Err(err) => {
-                id_allocator.free(key as usize);
+                self.id_allocator.lock().free(key as usize);
                 return Err(err);
             }
         };
         objects.insert(key, object);
+
         Ok(key)
     }
 
@@ -76,23 +93,34 @@ impl<T> IpcIds<T> {
         F: FnOnce(key_t) -> Result<T>,
     {
         let mut objects = self.objects.write();
-        let mut id_allocator = self.id_allocator.lock();
-        id_allocator
+
+        if self
+            .id_allocator
+            .lock()
             .alloc_specific(key as usize)
-            .ok_or(Error::new(Errno::EEXIST))?;
+            .is_none()
+        {
+            return_errno_with_message!(Errno::EEXIST, "the ID already exists");
+        }
+
         let object = match new_object_fn(key) {
             Ok(object) => object,
             Err(err) => {
-                id_allocator.free(key as usize);
+                self.id_allocator.lock().free(key as usize);
                 return Err(err);
             }
         };
         objects.insert(key, object);
+
         Ok(())
     }
+}
 
-    /// Frees `key` back to the allocator.
-    pub(super) fn free_key(&self, key: key_t) {
-        self.id_allocator.lock().free(key as usize);
+#[derive(Debug)]
+pub(super) struct IdNotExistError;
+
+impl From<IdNotExistError> for Error {
+    fn from(_value: IdNotExistError) -> Self {
+        Error::with_message(Errno::EINVAL, "the ID does not exist")
     }
 }

--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -11,14 +11,14 @@ use crate::prelude::*;
 ///
 /// Lock ordering:
 /// `objects` -> `id_allocator`.
-pub(crate) struct IpcIds<T> {
+pub(super) struct IpcIds<T> {
     objects: RwLock<BTreeMap<key_t, T>>,
     id_allocator: SpinLock<IdAlloc>,
 }
 
 impl<T> IpcIds<T> {
     /// Creates an IPC ID table with IDs in `1..=max_id`.
-    pub(crate) fn new(max_id: usize) -> Self {
+    pub(super) fn new(max_id: usize) -> Self {
         let mut id_allocator = IdAlloc::with_capacity(max_id + 1);
         // Remove the first index 0 (IPC IDs start from 1).
         id_allocator.alloc();
@@ -30,7 +30,7 @@ impl<T> IpcIds<T> {
     }
 
     /// Calls `op` with the object identified by `id`.
-    pub(crate) fn with<R, F>(&self, key: key_t, op: F) -> Result<R>
+    pub(super) fn with<R, F>(&self, key: key_t, op: F) -> Result<R>
     where
         F: FnOnce(&T) -> Result<R>,
     {
@@ -40,7 +40,7 @@ impl<T> IpcIds<T> {
     }
 
     /// Removes the object identified by `key`.
-    pub(crate) fn remove<F>(&self, key: key_t, may_remove: F) -> Result<()>
+    pub(super) fn remove<F>(&self, key: key_t, may_remove: F) -> Result<()>
     where
         F: FnOnce(&T) -> Result<()>,
     {
@@ -52,7 +52,7 @@ impl<T> IpcIds<T> {
     }
 
     /// Inserts a new object with an automatically allocated key.
-    pub(crate) fn insert_auto<F>(&self, new_object_fn: F) -> Result<key_t>
+    pub(super) fn insert_auto<F>(&self, new_object_fn: F) -> Result<key_t>
     where
         F: FnOnce(key_t) -> Result<T>,
     {
@@ -71,7 +71,7 @@ impl<T> IpcIds<T> {
     }
 
     /// Inserts a new object at `key`.
-    pub(crate) fn insert_at<F>(&self, key: key_t, new_object_fn: F) -> Result<()>
+    pub(super) fn insert_at<F>(&self, key: key_t, new_object_fn: F) -> Result<()>
     where
         F: FnOnce(key_t) -> Result<T>,
     {
@@ -92,7 +92,7 @@ impl<T> IpcIds<T> {
     }
 
     /// Frees `key` back to the allocator.
-    pub(crate) fn free_key(&self, key: key_t) {
+    pub(super) fn free_key(&self, key: key_t) {
         self.id_allocator.lock().free(key as usize);
     }
 }

--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 /// Lock ordering:
 /// `objects` -> `id_allocator`.
 pub(super) struct IpcIds<T> {
-    objects: RwLock<BTreeMap<key_t, T>>,
+    objects: RwMutex<BTreeMap<key_t, T>>,
     id_allocator: SpinLock<IdAlloc>,
 }
 
@@ -24,7 +24,7 @@ impl<T> IpcIds<T> {
         id_allocator.alloc_specific(0).unwrap();
 
         Self {
-            objects: RwLock::new(BTreeMap::new()),
+            objects: RwMutex::new(BTreeMap::new()),
             id_allocator: SpinLock::new(id_allocator),
         }
     }

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -95,12 +95,10 @@ impl IpcNamespace {
             return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
         }
 
-        self.sem_ids
-            .with(semid, |sem_set| {
-                Self::validate_sem_set(semid, sem_set, num_sems, required_perm)?;
-                op(sem_set)
-            })
-            .map_err(Self::map_sem_id_error)
+        self.sem_ids.with(semid, |sem_set| {
+            Self::validate_sem_set(semid, sem_set, num_sems, required_perm)?;
+            op(sem_set)
+        })?
     }
 
     /// Removes the semaphore set identified by `semid`.
@@ -112,14 +110,12 @@ impl IpcNamespace {
             return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
         }
 
-        self.sem_ids
-            .remove(semid, may_remove)
-            .map_err(Self::map_sem_id_error)
+        self.sem_ids.remove(semid, may_remove)
     }
 
     /// Returns the existing semaphore set or creates a new one.
     pub fn get_or_create_sem_set(
-        self: &Arc<Self>,
+        &self,
         key: key_t,
         num_sems: usize,
         flags: IpcFlags,
@@ -160,10 +156,11 @@ impl IpcNamespace {
 
                 Ok(key)
             }) {
-                Ok(key) => return Ok(key),
-                Err(err) if err.error() == Errno::ENOENT && flags.contains(IpcFlags::IPC_CREAT) => {
+                Err(_id_not_exist) if flags.contains(IpcFlags::IPC_CREAT) => {}
+                Err(_id_not_exist) => {
+                    return_errno_with_message!(Errno::ENOENT, "the ID does not exist");
                 }
-                Err(err) => return Err(err),
+                Ok(result) => return result,
             }
 
             if num_sems == 0 {
@@ -177,7 +174,7 @@ impl IpcNamespace {
                 let Some(credentials) = credentials.take() else {
                     return_errno_with_message!(Errno::EINVAL, "credentials were already consumed");
                 };
-                SemaphoreSet::new(key, num_sems, mode, credentials, self)
+                SemaphoreSet::new(key, num_sems, mode, credentials)
             }) {
                 Ok(()) => return Ok(key),
                 Err(err) if err.error() == Errno::EEXIST => continue,
@@ -212,26 +209,13 @@ impl IpcNamespace {
 
     /// Creates a new semaphore set and returns its key.
     fn create_sem_set(
-        self: &Arc<Self>,
+        &self,
         num_sems: usize,
         mode: u16,
         credentials: Credentials<ReadOp>,
     ) -> Result<key_t> {
         self.sem_ids
-            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, credentials, self))
-    }
-
-    /// Frees a semaphore key back to the allocator.
-    pub(super) fn free_sem_key(&self, key: key_t) {
-        self.sem_ids.free_key(key);
-    }
-
-    fn map_sem_id_error(err: Error) -> Error {
-        if err.error() == Errno::ENOENT {
-            Error::new(Errno::EINVAL)
-        } else {
-            err
-        }
+            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, credentials))
     }
 }
 

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -84,7 +84,6 @@ impl IpcNamespace {
     pub fn with_sem_set<T, F>(
         &self,
         semid: key_t,
-        num_sems: Option<usize>,
         required_perm: PermissionMode,
         op: F,
     ) -> Result<T>
@@ -96,7 +95,7 @@ impl IpcNamespace {
         }
 
         self.sem_ids.with(semid, |sem_set| {
-            Self::validate_sem_set(semid, sem_set, num_sems, required_perm)?;
+            Self::validate_sem_set(semid, sem_set, None, required_perm)?;
             op(sem_set)
         })?
     }

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -138,7 +138,6 @@ impl IpcNamespace {
             return self.create_sem_set(num_sems, mode, credentials);
         }
 
-        let mut credentials = Some(credentials);
         loop {
             match self.sem_ids.with(key, |sem_set| {
                 Self::validate_sem_set(
@@ -171,10 +170,7 @@ impl IpcNamespace {
             }
 
             match self.sem_ids.insert_at(key, |key| {
-                let Some(credentials) = credentials.take() else {
-                    return_errno_with_message!(Errno::EINVAL, "credentials were already consumed");
-                };
-                SemaphoreSet::new(key, num_sems, mode, credentials)
+                SemaphoreSet::new(key, num_sems, mode, &credentials)
             }) {
                 Ok(()) => return Ok(key),
                 Err(err) if err.error() == Errno::EEXIST => continue,
@@ -215,7 +211,7 @@ impl IpcNamespace {
         credentials: Credentials<ReadOp>,
     ) -> Result<key_t> {
         self.sem_ids
-            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, credentials))
+            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, &credentials))
     }
 }
 

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use ostd::sync::{PreemptDisabled, Waiter, Waker};
+use ostd::sync::{Waiter, Waker};
 
 use super::{
     PermissionMode,
@@ -234,10 +234,7 @@ pub fn sem_op(
 }
 
 /// Update pending const and alter operations, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L1029>
-fn do_smart_update(
-    inner: &mut SpinLockGuard<SemSetInner, PreemptDisabled>,
-    pending_op: &PendingOp,
-) -> LinkedList<PendingOp> {
+fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedList<PendingOp> {
     let mut wake_queue = LinkedList::new();
 
     let (sems, pending_alter, pending_const) = inner.field_mut();
@@ -254,7 +251,7 @@ fn do_smart_update(
 
 /// Look for pending alter operations that can be completed, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L949>
 pub(super) fn update_pending_alter(
-    sems: &mut Box<[Semaphore]>,
+    sems: &mut [Semaphore],
     pending_alter: &mut LinkedList<PendingOp>,
     pending_const: &mut LinkedList<PendingOp>,
     wake_queue: &mut LinkedList<PendingOp>,
@@ -275,7 +272,7 @@ pub(super) fn update_pending_alter(
 
 /// Wakeup all wait for zero tasks, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L893>
 fn do_smart_wakeup_zero(
-    sems: &mut Box<[Semaphore]>,
+    sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
     pending_op: &PendingOp,
     wake_queue: &mut LinkedList<PendingOp>,
@@ -290,7 +287,7 @@ fn do_smart_wakeup_zero(
 
 /// Wakeup pending const operations, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L854>
 pub(super) fn wake_const_ops(
-    sems: &mut Box<[Semaphore]>,
+    sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
     wake_queue: &mut LinkedList<PendingOp>,
 ) {
@@ -328,7 +325,7 @@ fn get_sops_flags(pending_op: &PendingOp) -> (bool, bool) {
 /// 1. Return Ok(true) if the operation success.
 /// 2. Return Ok(false) if the caller needs to wait.
 /// 3. Return Err(err) if the operation cause error.
-fn perform_atomic_semop(sems: &mut Box<[Semaphore]>, pending_op: &mut PendingOp) -> Result<bool> {
+fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> Result<bool> {
     let mut result;
     for op in pending_op.sops_iter() {
         let sem = sems.get(op.sem_num as usize).ok_or(Errno::EFBIG)?;

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -158,7 +158,7 @@ pub fn sem_op(
         },
     }
 
-    let sem_op_result = ipc_ns.with_sem_set(sem_id, None, PermissionMode::empty(), |sem_set| {
+    let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
         let mut inner = sem_set.inner();
 
         if perform_atomic_semop(&mut inner.sems, &mut pending_op)? {
@@ -214,7 +214,7 @@ pub fn sem_op(
                 Status::Removed => Err(Error::new(Errno::EIDRM)),
                 Status::Pending => {
                     // FIXME: Lookup may be time-consuming.
-                    ipc_ns.with_sem_set(sem_id, None, PermissionMode::empty(), |sem_set| {
+                    ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
                         let mut inner = sem_set.inner();
                         let pending_ops = if alter {
                             &mut inner.pending_alter

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -55,7 +55,7 @@ define_atomic_version_of_integer_like_type!(Status, try_from = true, {
     struct AtomicStatus(AtomicU16);
 });
 
-/// Pending atomic semop.
+/// A pending semaphore operation.
 pub(super) struct PendingOp {
     sops: Vec<SemBuf>,
     status: Arc<AtomicStatus>,
@@ -90,10 +90,12 @@ impl Debug for PendingOp {
 #[derive(Debug)]
 pub struct Semaphore {
     val: i32,
-    /// PID of the process that last modified semaphore.
-    /// - through semop with op != 0
-    /// - through semctl with SETVAL and SETALL
-    /// - through SEM_UNDO when task exit
+    /// The PID of the process that last modified the semaphore.
+    ///
+    /// This includes the following cases:
+    /// - through `semop` with a non-zero `sem_op`,
+    /// - through `semctl` with `SETVAL` and `SETALL`, and
+    /// - through `SEM_UNDO` on process exit.
     latest_modified_pid: Pid,
 }
 
@@ -233,7 +235,10 @@ pub fn sem_op(
     }
 }
 
-/// Update pending const and alter operations, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L1029>
+/// Looks for operations that can be completed after an alteration operation and then completes
+/// them.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L1029>
 fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedList<PendingOp> {
     let mut wake_queue = LinkedList::new();
 
@@ -249,7 +254,9 @@ fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedLis
     wake_queue
 }
 
-/// Look for pending alter operations that can be completed, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L949>
+/// Looks for alteration operations that can be completed and then completes them.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L949>
 pub(super) fn update_pending_alter(
     sems: &mut [Semaphore],
     pending_alter: &mut LinkedList<PendingOp>,
@@ -270,7 +277,10 @@ pub(super) fn update_pending_alter(
     }
 }
 
-/// Wakeup all wait for zero tasks, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L893>
+/// Wakes up pending tasks on constant operations if an alteration operation made those constant
+/// operations possible to complete.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L893>
 fn do_smart_wakeup_zero(
     sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
@@ -285,7 +295,9 @@ fn do_smart_wakeup_zero(
     }
 }
 
-/// Wakeup pending const operations, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L854>
+/// Wakes up pending tasks on constant operations if they can be completed.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L854>
 pub(super) fn wake_const_ops(
     sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
@@ -321,21 +333,26 @@ fn get_sops_flags(pending_op: &PendingOp) -> (bool, bool) {
     (alter, dupsop)
 }
 
-/// Perform atomic semop, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L719>
-/// 1. Return Ok(true) if the operation success.
-/// 2. Return Ok(false) if the caller needs to wait.
-/// 3. Return Err(err) if the operation cause error.
+/// Performs atomic semaphore operations.
+///
+/// 1. Return `Ok(true)` if all the operations succeed.
+/// 2. Return `Ok(false)` if the caller needs to wait.
+/// 3. Return `Err(err)` if the operations cause an error.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L719>
 fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> Result<bool> {
-    let mut result;
     for op in pending_op.sops_iter() {
-        let sem = sems.get(op.sem_num as usize).ok_or(Errno::EFBIG)?;
         let flags = IpcFlags::from_bits_truncate(op.sem_flags as u32);
-        result = sem.val();
+
+        let Some(sem) = sems.get(op.sem_num as usize) else {
+            return_errno_with_message!(Errno::EFBIG, "the semaphore number is out of bounds");
+        };
+        let mut result = sem.val();
 
         // Zero condition
         if op.sem_op == 0 && result != 0 {
             if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno_with_message!(Errno::EAGAIN, "semaphore would block on wait-for-zero");
+                return_errno_with_message!(Errno::EAGAIN, "the semaphore value is not zero");
             } else {
                 return Ok(false);
             }
@@ -344,7 +361,7 @@ fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> R
         result += i32::from(op.sem_op);
         if result < 0 {
             if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno_with_message!(Errno::EAGAIN, "semaphore would block on decrement");
+                return_errno_with_message!(Errno::EAGAIN, "the semaphore value is too small");
             } else {
                 return Ok(false);
             }

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -39,7 +39,7 @@ impl SemBuf {
 
 #[repr(u16)]
 #[derive(Clone, Copy, Debug, TryFromInt)]
-pub enum Status {
+pub(super) enum Status {
     Normal = 0,
     Pending = 1,
     Removed = 2,
@@ -234,7 +234,7 @@ pub fn sem_op(
 }
 
 /// Update pending const and alter operations, ref: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L1029>
-pub(super) fn do_smart_update(
+fn do_smart_update(
     inner: &mut SpinLockGuard<SemSetInner, PreemptDisabled>,
     pending_op: &PendingOp,
 ) -> LinkedList<PendingOp> {

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -8,7 +8,7 @@ use ostd::sync::PreemptDisabled;
 
 use super::sem::{PendingOp, Status, update_pending_alter, wake_const_ops};
 use crate::{
-    ipc::{IpcNamespace, IpcPermission, key_t, semaphore::system_v::sem::Semaphore},
+    ipc::{IpcPermission, key_t, semaphore::system_v::sem::Semaphore},
     prelude::*,
     process::{Credentials, Pid},
     time::clocks::RealTimeCoarseClock,
@@ -41,10 +41,8 @@ pub struct SemaphoreSet {
     permission: IpcPermission,
     /// Creation time or last modification via `semctl`
     sem_ctime: AtomicU64,
-    /// Last semop time.
+    /// Last `semop` time
     sem_otime: AtomicU64,
-    /// The IPC namespace.
-    ipc_ns: Weak<IpcNamespace>,
 }
 
 // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/ipcbuf.h#L22>.
@@ -219,7 +217,6 @@ impl SemaphoreSet {
         num_sems: usize,
         mode: u16,
         credentials: Credentials<ReadOp>,
-        ipc_ns: &Arc<IpcNamespace>,
     ) -> Result<Self> {
         if num_sems > SEMMSL {
             return_errno_with_message!(Errno::EINVAL, "num_sems exceeds SEMMSL");
@@ -243,7 +240,6 @@ impl SemaphoreSet {
                 pending_alter: LinkedList::new(),
                 pending_const: LinkedList::new(),
             }),
-            ipc_ns: Arc::downgrade(ipc_ns),
         })
     }
 
@@ -289,16 +285,5 @@ impl Drop for SemaphoreSet {
         }
         pending_const.clear();
         drop(inner);
-
-        if let Some(ipc_ns) = self.ipc_ns.upgrade() {
-            ipc_ns.free_sem_key(self.permission.key());
-        } else {
-            // `upgrade()` returns `None` when the IPC namespace itself is being destroyed.
-            // In that path, dropping the namespace's semaphore-set map
-            // cascades into `SemaphoreSet::drop`,
-            // after the last strong reference to the namespace is already gone.
-            // Skipping `free_sem_key()` is correct
-            // because the namespace's ID allocator is being dropped together with the namespace.
-        }
     }
 }

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -216,7 +216,7 @@ impl SemaphoreSet {
         key: key_t,
         num_sems: usize,
         mode: u16,
-        credentials: Credentials<ReadOp>,
+        credentials: &Credentials<ReadOp>,
     ) -> Result<Self> {
         if num_sems > SEMMSL {
             return_errno_with_message!(Errno::EINVAL, "num_sems exceeds SEMMSL");

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -266,7 +266,8 @@ impl SemaphoreSet {
 
 impl Drop for SemaphoreSet {
     fn drop(&mut self) {
-        let mut inner = self.inner();
+        let inner = self.inner.get_mut();
+
         let pending_alter = &mut inner.pending_alter;
         for pending_alter in pending_alter.iter_mut() {
             pending_alter.set_status(Status::Removed);
@@ -284,6 +285,5 @@ impl Drop for SemaphoreSet {
             }
         }
         pending_const.clear();
-        drop(inner);
     }
 }

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -51,7 +51,7 @@ pub struct SemaphoreSet {
 #[padding_struct]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
-pub struct IpcPerm {
+struct IpcPerm {
     key: u32,
     uid: u32,
     gid: u32,

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -19,12 +19,12 @@ use crate::{
 pub const SEMMNI: usize = 32000;
 /// Maximum number of semaphores per semaphore ID.
 pub const SEMMSL: usize = 32000;
-/// Maximum number of seaphores in all semaphore sets.
+/// Maximum number of semaphores in all semaphore sets.
 #[expect(dead_code)]
 pub const SEMMNS: usize = SEMMNI * SEMMSL;
 /// Maximum number of operations for semop.
 pub const SEMOPM: usize = 500;
-/// MAximum semaphore value.
+/// Maximum semaphore value.
 pub const SEMVMX: i32 = 32767;
 /// Maximum value that can be recorded for semaphore adjustment (SEM_UNDO).
 #[expect(dead_code)]
@@ -154,12 +154,14 @@ impl SemaphoreSet {
 
     pub fn setval(&self, sem_num: usize, val: i32, pid: Pid) -> Result<()> {
         if !(0..=SEMVMX).contains(&val) {
-            return_errno_with_message!(Errno::ERANGE, "semaphore value out of range");
+            return_errno_with_message!(Errno::ERANGE, "the semaphore value exceeds SEMVMX");
         }
 
         let mut inner = self.inner();
         let (sems, pending_alter, pending_const) = inner.field_mut();
-        let sem = sems.get_mut(sem_num).ok_or(Error::new(Errno::EINVAL))?;
+        let Some(sem) = sems.get_mut(sem_num) else {
+            return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
+        };
 
         sem.set_val(val);
         sem.set_latest_modified_pid(pid);
@@ -182,11 +184,14 @@ impl SemaphoreSet {
         Ok(())
     }
 
-    pub fn get<T>(&self, sem_num: usize, func: &dyn Fn(&Semaphore) -> T) -> Result<T> {
+    pub fn get<T>(&self, sem_num: usize, func: fn(&Semaphore) -> T) -> Result<T> {
         let inner = self.inner();
-        Ok(func(
-            inner.sems.get(sem_num).ok_or(Error::new(Errno::EINVAL))?,
-        ))
+        let Some(sem) = inner.sems.get(sem_num) else {
+            return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
+        };
+
+        let result = func(sem);
+        Ok(result)
     }
 
     pub fn permission(&self) -> &IpcPermission {

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_rights::ReadOp;
-use ostd::sync::PreemptDisabled;
 
 use super::sem::{PendingOp, Status, update_pending_alter, wake_const_ops};
 use crate::{
@@ -36,7 +35,7 @@ pub struct SemaphoreSet {
     /// Number of semaphores in the set
     num_sems: usize,
     /// Inner
-    inner: SpinLock<SemSetInner>,
+    inner: Mutex<SemSetInner>,
     /// Semaphore permission
     permission: IpcPermission,
     /// Creation time or last modification via `semctl`
@@ -208,7 +207,7 @@ impl SemaphoreSet {
         );
     }
 
-    pub(super) fn inner(&self) -> SpinLockGuard<'_, SemSetInner, PreemptDisabled> {
+    pub(super) fn inner(&self) -> MutexGuard<'_, SemSetInner> {
         self.inner.lock()
     }
 
@@ -235,7 +234,7 @@ impl SemaphoreSet {
             permission,
             sem_ctime: AtomicU64::new(RealTimeCoarseClock::get().read_time().as_secs()),
             sem_otime: AtomicU64::new(0),
-            inner: SpinLock::new(SemSetInner {
+            inner: Mutex::new(SemSetInner {
                 sems: sems.into_boxed_slice(),
                 pending_alter: LinkedList::new(),
                 pending_const: LinkedList::new(),

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -55,7 +55,7 @@ pub fn sys_semctl(
                 return_errno_with_message!(Errno::ERANGE, "semaphore value must not be negative");
             }
 
-            ipc_ns.with_sem_set(semid, None, PermissionMode::ALTER, |sem_set| {
+            ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
                 sem_set.setval(semnum as usize, val, ctx.process.pid())
             })?;
         }
@@ -63,7 +63,7 @@ pub fn sys_semctl(
             fn sem_val(sem: &Semaphore) -> i32 {
                 sem.val()
             }
-            let val: i32 = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
+            let val: i32 = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
                 sem_set.get(semnum as usize, &sem_val)
             })?;
 
@@ -73,28 +73,28 @@ pub fn sys_semctl(
             fn sem_pid(sem: &Semaphore) -> Pid {
                 sem.latest_modified_pid()
             }
-            let pid: Pid = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
+            let pid: Pid = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
                 sem_set.get(semnum as usize, &sem_pid)
             })?;
 
             return Ok(SyscallReturn::Return(pid as isize));
         }
         IpcControlCmd::SEM_GETZCNT => {
-            let cnt: usize = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
+            let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
                 Ok(sem_set.pending_const_count(semnum as u16))
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::SEM_GETNCNT => {
-            let cnt: usize = ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
+            let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
                 Ok(sem_set.pending_alter_count(semnum as u16))
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::IPC_STAT => {
-            ipc_ns.with_sem_set(semid, None, PermissionMode::READ, |sem_set| {
+            ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
                 let semid_ds = sem_set.semid_ds();
                 Ok(ctx.user_space().write_val(arg as Vaddr, &semid_ds)?)
             })?;

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -36,12 +36,13 @@ pub fn sys_semctl(
         IpcControlCmd::IPC_RMID => {
             let euid = ctx.posix_thread.credentials().euid();
             ipc_ns.remove_sem_set(semid, |sem_set| {
+                // TODO: Consider capabilities in addition to UIDs.
                 let permission = sem_set.permission();
                 let can_remove = (euid == permission.uid()) || (euid == permission.cuid());
                 if !can_remove {
                     return_errno_with_message!(
                         Errno::EPERM,
-                        "no permission to remove semaphore set"
+                        "the process does not have permission to remove the semaphore set"
                     );
                 }
 
@@ -59,7 +60,7 @@ pub fn sys_semctl(
                 sem.latest_modified_pid()
             }
             let pid: Pid = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                sem_set.get(semnum as usize, &sem_pid)
+                sem_set.get(semnum as usize, sem_pid)
             })?;
 
             return Ok(SyscallReturn::Return(pid as isize));
@@ -69,7 +70,7 @@ pub fn sys_semctl(
                 sem.val()
             }
             let val: i32 = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                sem_set.get(semnum as usize, &sem_val)
+                sem_set.get(semnum as usize, sem_val)
             })?;
 
             return Ok(SyscallReturn::Return(val as isize));
@@ -89,11 +90,8 @@ pub fn sys_semctl(
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::SEM_SETVAL => {
-            // In setval, arg is parse as i32
+            // In `SEM_SETVAL`, the argument is parsed as an `i32`.
             let val = arg as i32;
-            if val < 0 {
-                return_errno_with_message!(Errno::ERANGE, "semaphore value must not be negative");
-            }
 
             ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
                 sem_set.setval(semnum as usize, val, ctx.process.pid())

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -48,26 +48,11 @@ pub fn sys_semctl(
                 Ok(())
             })?;
         }
-        IpcControlCmd::SEM_SETVAL => {
-            // In setval, arg is parse as i32
-            let val = arg as i32;
-            if val < 0 {
-                return_errno_with_message!(Errno::ERANGE, "semaphore value must not be negative");
-            }
-
-            ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
-                sem_set.setval(semnum as usize, val, ctx.process.pid())
+        IpcControlCmd::IPC_STAT => {
+            ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
+                let semid_ds = sem_set.semid_ds();
+                Ok(ctx.user_space().write_val(arg as Vaddr, &semid_ds)?)
             })?;
-        }
-        IpcControlCmd::SEM_GETVAL => {
-            fn sem_val(sem: &Semaphore) -> i32 {
-                sem.val()
-            }
-            let val: i32 = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                sem_set.get(semnum as usize, &sem_val)
-            })?;
-
-            return Ok(SyscallReturn::Return(val as isize));
         }
         IpcControlCmd::SEM_GETPID => {
             fn sem_pid(sem: &Semaphore) -> Pid {
@@ -79,12 +64,15 @@ pub fn sys_semctl(
 
             return Ok(SyscallReturn::Return(pid as isize));
         }
-        IpcControlCmd::SEM_GETZCNT => {
-            let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                Ok(sem_set.pending_const_count(semnum as u16))
+        IpcControlCmd::SEM_GETVAL => {
+            fn sem_val(sem: &Semaphore) -> i32 {
+                sem.val()
+            }
+            let val: i32 = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
+                sem_set.get(semnum as usize, &sem_val)
             })?;
 
-            return Ok(SyscallReturn::Return(cnt as isize));
+            return Ok(SyscallReturn::Return(val as isize));
         }
         IpcControlCmd::SEM_GETNCNT => {
             let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
@@ -93,10 +81,22 @@ pub fn sys_semctl(
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
-        IpcControlCmd::IPC_STAT => {
-            ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                let semid_ds = sem_set.semid_ds();
-                Ok(ctx.user_space().write_val(arg as Vaddr, &semid_ds)?)
+        IpcControlCmd::SEM_GETZCNT => {
+            let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
+                Ok(sem_set.pending_const_count(semnum as u16))
+            })?;
+
+            return Ok(SyscallReturn::Return(cnt as isize));
+        }
+        IpcControlCmd::SEM_SETVAL => {
+            // In setval, arg is parse as i32
+            let val = arg as i32;
+            if val < 0 {
+                return_errno_with_message!(Errno::ERANGE, "semaphore value must not be negative");
+            }
+
+            ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
+                sem_set.setval(semnum as usize, val, ctx.process.pid())
             })?;
         }
         _ => todo!("Need to support {:?} in SYS_SEMCTL", cmd),


### PR DESCRIPTION
This PR contains a series of non-functionality improvements to System V semaphores.

There are quite a few commits. However, each one is small, so I hope that will help with the review process. I don't know if it's worth writing descriptions to explain each commit. I think all the commits are obvious improvements. Please let me know if you have any questions.

 - "Convert some spin locks to mutexes": This may be the only commit that does not belong to strict Non-Functionality Changes (NFC). The underlying reason is that there are quite a few semaphores and pending operations, so the execution time under those locks is relatively long. `Mutex` is a better fit than `SpinLock`.

Perhaps I should squash some commits here? I'm not sure, but I'm happy to follow any guidance.