### PR TITLE
(Lots of) bug fixes to System V semaphores

### DIFF
--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -2,24 +2,27 @@
 
 use alloc::collections::btree_map::BTreeMap;
 
+use aster_util::ranged_integer::RangedU32;
 use id_alloc::IdAlloc;
 
-use super::key_t;
 use crate::prelude::*;
+
+/// An IPC ID.
+pub type IpcId = RangedU32<1, { i32::MAX as u32 }>;
 
 /// Maps IPC IDs to objects and manages ID allocation.
 ///
 /// Lock ordering:
 /// `objects` -> `id_allocator`.
 pub(super) struct IpcIds<T> {
-    objects: RwMutex<BTreeMap<key_t, T>>,
+    objects: RwMutex<BTreeMap<IpcId, T>>,
     id_allocator: SpinLock<IdAlloc>,
 }
 
 impl<T> IpcIds<T> {
     /// Creates an IPC ID table with IDs in `1..=max_id`.
-    pub(super) fn new(max_id: usize) -> Self {
-        let mut id_allocator = IdAlloc::with_capacity(max_id + 1);
+    pub(super) fn new(max_id: IpcId) -> Self {
+        let mut id_allocator = IdAlloc::with_capacity(max_id.get() as usize + 1);
         // Remove the first index 0 (IPC IDs start from 1).
         id_allocator.alloc_specific(0).unwrap();
 
@@ -29,22 +32,22 @@ impl<T> IpcIds<T> {
         }
     }
 
-    /// Calls `op` with the object identified by `key`.
-    pub(super) fn with<R, F>(&self, key: key_t, op: F) -> core::result::Result<R, IdNotExistError>
+    /// Calls `op` with the object identified by `id`.
+    pub(super) fn with<R, F>(&self, id: IpcId, op: F) -> core::result::Result<R, IdNotExistError>
     where
         F: FnOnce(&T) -> R,
     {
         let objects = self.objects.read();
 
-        let Some(object) = objects.get(&key) else {
+        let Some(object) = objects.get(&id) else {
             return Err(IdNotExistError);
         };
 
         Ok(op(object))
     }
 
-    /// Removes the object identified by `key`.
-    pub(super) fn remove<F>(&self, key: key_t, may_remove: F) -> Result<()>
+    /// Removes the object identified by `id`.
+    pub(super) fn remove<F>(&self, id: IpcId, may_remove: F) -> Result<()>
     where
         F: FnOnce(&T) -> Result<()>,
     {
@@ -52,65 +55,70 @@ impl<T> IpcIds<T> {
 
         let mut objects = self.objects.write();
 
-        let Entry::Occupied(entry) = objects.entry(key) else {
+        let Entry::Occupied(entry) = objects.entry(id) else {
             return_errno_with_message!(Errno::EINVAL, "the ID does not exist");
         };
 
         may_remove(entry.get())?;
         entry.remove();
 
-        self.id_allocator.lock().free(key as usize);
+        self.id_allocator.lock().free(id.get() as usize);
 
         Ok(())
     }
 
-    /// Inserts a new object with an automatically allocated key.
-    pub(super) fn insert_auto<F>(&self, new_object_fn: F) -> Result<key_t>
+    /// Inserts a new object with an automatically allocated ID.
+    pub(super) fn insert_auto<F>(&self, new_object_fn: F) -> Result<IpcId>
     where
-        F: FnOnce(key_t) -> Result<T>,
+        F: FnOnce(IpcId) -> Result<T>,
     {
         let mut objects = self.objects.write();
 
-        let Some(key) = self.id_allocator.lock().alloc().map(|key| key as key_t) else {
+        let Some(id) = self
+            .id_allocator
+            .lock()
+            .alloc()
+            .map(|id| IpcId::new(id as u32))
+        else {
             return_errno_with_message!(Errno::ENOSPC, "all IDs are exhausted");
         };
 
-        let object = match new_object_fn(key) {
+        let object = match new_object_fn(id) {
             Ok(object) => object,
             Err(err) => {
-                self.id_allocator.lock().free(key as usize);
+                self.id_allocator.lock().free(id.get() as usize);
                 return Err(err);
             }
         };
-        objects.insert(key, object);
+        objects.insert(id, object);
 
-        Ok(key)
+        Ok(id)
     }
 
-    /// Inserts a new object at `key`.
-    pub(super) fn insert_at<F>(&self, key: key_t, new_object_fn: F) -> Result<()>
+    /// Inserts a new object at `id`.
+    pub(super) fn insert_at<F>(&self, id: IpcId, new_object_fn: F) -> Result<()>
     where
-        F: FnOnce(key_t) -> Result<T>,
+        F: FnOnce(IpcId) -> Result<T>,
     {
         let mut objects = self.objects.write();
 
         if self
             .id_allocator
             .lock()
-            .alloc_specific(key as usize)
+            .alloc_specific(id.get() as usize)
             .is_none()
         {
             return_errno_with_message!(Errno::EEXIST, "the ID already exists");
         }
 
-        let object = match new_object_fn(key) {
+        let object = match new_object_fn(id) {
             Ok(object) => object,
             Err(err) => {
-                self.id_allocator.lock().free(key as usize);
+                self.id_allocator.lock().free(id.get() as usize);
                 return Err(err);
             }
         };
-        objects.insert(key, object);
+        objects.insert(id, object);
 
         Ok(())
     }

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -13,8 +13,8 @@ use aster_rights::ReadOp;
 use spin::Once;
 
 use super::{
+    IPC_PRIVATE, IpcFlags, IpcId, IpcKey,
     ipc_ids::IpcIds,
-    key_t,
     semaphore::system_v::{
         PermissionMode,
         sem_set::{SEMMNI, SemaphoreSet},
@@ -22,7 +22,6 @@ use super::{
 };
 use crate::{
     fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
-    ipc::IpcFlags,
     prelude::*,
     process::{
         Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
@@ -59,10 +58,16 @@ impl IpcNamespace {
     }
 
     fn new(owner: Arc<UserNamespace>) -> Arc<Self> {
+        const MAX_SEM_ID: IpcId = {
+            assert!(SEMMNI <= u32::MAX as usize);
+            IpcId::new(SEMMNI as u32)
+        };
+
+        let sem_ids = IpcIds::new(MAX_SEM_ID);
         let stashed_dentry = StashedDentry::new();
 
         Arc::new(Self {
-            sem_ids: IpcIds::new(SEMMNI),
+            sem_ids,
             owner,
             stashed_dentry,
         })
@@ -83,117 +88,88 @@ impl IpcNamespace {
     /// Calls `op` with the semaphore set identified by `semid`.
     pub fn with_sem_set<T, F>(
         &self,
-        semid: key_t,
+        semid: IpcId,
         required_perm: PermissionMode,
         op: F,
     ) -> Result<T>
     where
         F: FnOnce(&SemaphoreSet) -> Result<T>,
     {
-        if semid <= 0 {
-            return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
-        }
-
         self.sem_ids.with(semid, |sem_set| {
-            Self::validate_sem_set(semid, sem_set, None, required_perm)?;
+            Self::validate_sem_set(sem_set, required_perm)?;
             op(sem_set)
         })?
     }
 
     /// Removes the semaphore set identified by `semid`.
-    pub fn remove_sem_set<F>(&self, semid: key_t, may_remove: F) -> Result<()>
+    pub fn remove_sem_set<F>(&self, semid: IpcId, may_remove: F) -> Result<()>
     where
         F: FnOnce(&SemaphoreSet) -> Result<()>,
     {
-        if semid <= 0 {
-            return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
-        }
-
         self.sem_ids.remove(semid, may_remove)
     }
 
     /// Returns the existing semaphore set or creates a new one.
     pub fn get_or_create_sem_set(
         &self,
-        key: key_t,
+        key: IpcKey,
         num_sems: usize,
         flags: IpcFlags,
         mode: u16,
         credentials: Credentials<ReadOp>,
-    ) -> Result<key_t> {
-        const IPC_NEW: key_t = 0;
-
-        if key < 0 {
-            return_errno_with_message!(Errno::EINVAL, "semaphore key must not be negative");
-        }
-
-        if key == IPC_NEW || (key as usize > SEMMNI && flags.contains(IpcFlags::IPC_CREAT)) {
-            if num_sems == 0 {
-                return_errno_with_message!(
-                    Errno::EINVAL,
-                    "num_sems must not be zero when creating"
-                );
-            }
+    ) -> Result<IpcId> {
+        if key == IPC_PRIVATE {
             return self.create_sem_set(num_sems, mode, credentials);
         }
 
+        // For now, we compute `semid` by hashing `key`. If the hash conflicts, we will simply
+        // return an error. See the TODO below.
+        const { assert!(SEMMNI <= u32::MAX as usize) };
+        let semid = IpcId::new(key.cast_unsigned() % SEMMNI as u32 + 1);
+
         loop {
-            match self.sem_ids.with(key, |sem_set| {
-                Self::validate_sem_set(
-                    key,
-                    sem_set,
-                    Some(num_sems),
-                    PermissionMode::ALTER | PermissionMode::READ,
-                )?;
+            match self.sem_ids.with(semid, |sem_set| {
+                if sem_set.permission().key() != key {
+                    if flags.contains(IpcFlags::IPC_CREAT) {
+                        // TODO: Manage all keys in a data structure (e.g., a map)
+                        return_errno_with_message!(Errno::ENOSPC, "key hashes conflict");
+                    }
+                    return_errno_with_message!(Errno::ENOENT, "the key does not exist");
+                }
+
+                Self::validate_sem_set(sem_set, PermissionMode::ALTER | PermissionMode::READ)?;
+
                 if flags.contains(IpcFlags::IPC_CREAT | IpcFlags::IPC_EXCL) {
                     return_errno_with_message!(
                         Errno::EEXIST,
-                        "semaphore set already exists with IPC_EXCL"
+                        "the semaphore set already exists with IPC_EXCL"
                     );
                 }
 
-                Ok(key)
+                if sem_set.num_sems() < num_sems {
+                    return_errno_with_message!(Errno::EINVAL, "the semaphore set is too small");
+                }
+
+                Ok(semid)
             }) {
                 Err(_id_not_exist) if flags.contains(IpcFlags::IPC_CREAT) => {}
                 Err(_id_not_exist) => {
-                    return_errno_with_message!(Errno::ENOENT, "the ID does not exist");
+                    return_errno_with_message!(Errno::ENOENT, "the key does not exist");
                 }
                 Ok(result) => return result,
             }
 
-            if num_sems == 0 {
-                return_errno_with_message!(
-                    Errno::EINVAL,
-                    "num_sems must not be zero when creating"
-                );
-            }
-
-            match self.sem_ids.insert_at(key, |key| {
+            match self.sem_ids.insert_at(semid, |_| {
                 SemaphoreSet::new(key, num_sems, mode, &credentials)
             }) {
-                Ok(()) => return Ok(key),
+                Ok(()) => return Ok(semid),
                 Err(err) if err.error() == Errno::EEXIST => continue,
                 Err(err) => return Err(err),
             }
         }
     }
 
-    fn validate_sem_set(
-        key: key_t,
-        sem_set: &SemaphoreSet,
-        num_sems: Option<usize>,
-        required_perm: PermissionMode,
-    ) -> Result<()> {
-        if key <= 0 {
-            return_errno_with_message!(Errno::EINVAL, "semaphore key must be positive");
-        }
-
-        if let Some(num_sems) = num_sems
-            && num_sems > sem_set.num_sems()
-        {
-            return_errno_with_message!(Errno::EINVAL, "num_sems exceeds the set size");
-        }
-
+    fn validate_sem_set(_sem_set: &SemaphoreSet, required_perm: PermissionMode) -> Result<()> {
         if !required_perm.is_empty() {
             // TODO: Support permission check
             warn!("Semaphore doesn't support permission check now");
@@ -202,15 +178,15 @@ impl IpcNamespace {
         Ok(())
     }
 
-    /// Creates a new semaphore set and returns its key.
+    /// Creates a new semaphore set and returns its ID.
     fn create_sem_set(
         &self,
         num_sems: usize,
         mode: u16,
         credentials: Credentials<ReadOp>,
-    ) -> Result<key_t> {
+    ) -> Result<IpcId> {
         self.sem_ids
-            .insert_auto(|key| SemaphoreSet::new(key, num_sems, mode, &credentials))
+            .insert_auto(|_| SemaphoreSet::new(IPC_PRIVATE, num_sems, mode, &credentials))
     }
 }
 

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -36,21 +36,22 @@ bitflags! {
     }
 }
 
+// TODO: Add support for the commented-out commands below
 #[expect(non_camel_case_types)]
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, TryFromInt)]
 pub enum IpcControlCmd {
     IPC_RMID = 0,
-    IPC_SET = 1,
+    // IPC_SET = 1,
     IPC_STAT = 2,
 
     SEM_GETPID = 11,
     SEM_GETVAL = 12,
-    SEM_GETALL = 13,
+    // SEM_GETALL = 13,
     SEM_GETNCNT = 14,
     SEM_GETZCNT = 15,
     SEM_SETVAL = 16,
-    SEM_SETALL = 17,
+    // SEM_SETALL = 17,
 }
 
 #[derive(Debug)]

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -6,13 +6,22 @@ use crate::{
 };
 
 mod ipc_ids;
-pub mod ipc_ns;
+mod ipc_ns;
 pub mod semaphore;
 
+pub use ipc_ids::IpcId;
 pub use ipc_ns::IpcNamespace;
 
-#[expect(non_camel_case_types)]
-pub type key_t = i32;
+/// An IPC key.
+///
+/// This key is specified by and can be looked up in userspace. Do not confuse it with the
+/// identifier [`IpcId`], which is specified by the kernel and returned to userspace upon lookup.
+pub type IpcKey = i32;
+
+/// A private IPC key.
+///
+/// This key cannot be looked up.
+const IPC_PRIVATE: IpcKey = 0;
 
 bitflags! {
     pub struct IpcFlags: u32{
@@ -46,7 +55,7 @@ pub enum IpcControlCmd {
 
 #[derive(Debug)]
 pub struct IpcPermission {
-    key: key_t,
+    key: IpcKey,
     /// Owner's UID
     uid: Uid,
     /// Owner's GID
@@ -60,7 +69,7 @@ pub struct IpcPermission {
 }
 
 impl IpcPermission {
-    pub fn key(&self) -> key_t {
+    pub fn key(&self) -> IpcKey {
         self.key
     }
 
@@ -89,7 +98,7 @@ impl IpcPermission {
         self.mode
     }
 
-    pub(self) fn new_sem_perm(key: key_t, uid: Uid, gid: Gid, mode: u16) -> Self {
+    pub(self) fn new_sem_perm(key: IpcKey, uid: Uid, gid: Gid, mode: u16) -> Self {
         Self {
             key,
             uid,

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -298,15 +298,17 @@ pub(super) fn update_pending_alter(
 ) {
     let mut cursor = pending_alter.cursor_front_mut();
     while let Some(alter_op) = cursor.current() {
-        if let Ok(true) = perform_atomic_semop(sems, alter_op) {
-            let mut alter_op = cursor.remove_current_as_list().unwrap();
-
-            do_smart_wakeup_zero(sems, pending_const, alter_op.front().unwrap(), wake_queue);
-
-            wake_queue.append(&mut alter_op);
-        } else {
+        let Ok(true) = perform_atomic_semop(sems, alter_op) else {
             cursor.move_next();
-        }
+            continue;
+        };
+
+        let mut alter_op = cursor.remove_current_as_list().unwrap();
+        do_smart_wakeup_zero(sems, pending_const, alter_op.front().unwrap(), wake_queue);
+        wake_queue.append(&mut alter_op);
+
+        // Retry from the beginning since we've performed some alteration.
+        cursor = pending_alter.cursor_front_mut();
     }
 }
 

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -28,11 +28,15 @@ pub struct SemBuf {
 }
 
 #[repr(u16)]
-#[derive(Clone, Copy, Debug, TryFromInt)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromInt)]
 pub(super) enum Status {
     Normal = 0,
     Pending = 1,
     Removed = 2,
+
+    // Errors
+    ErrWouldBlock = 4,
+    ErrValRange = 5,
 }
 
 impl From<Status> for u16 {
@@ -57,9 +61,29 @@ pub(super) struct PendingOp {
 pub(super) enum PendingBlocker {
     Zero(usize),
     Decrease(usize),
+    NotBlock,
 }
 
 impl PendingOp {
+    fn new(sops: Vec<SemBuf>, pid: Pid, num_sems: usize) -> Result<Self> {
+        for op in sops.iter() {
+            if op.sem_num as usize >= num_sems {
+                return_errno_with_message!(Errno::EFBIG, "the semaphore number is out of bounds");
+            }
+            if IpcFlags::from_bits_truncate(op.sem_flags as u32).contains(IpcFlags::SEM_UNDO) {
+                // TODO: Add support for the `SEM_UNDO` flag
+                return_errno_with_message!(Errno::EINVAL, "SEM_UNDO is not supported yet");
+            }
+        }
+
+        Ok(Self {
+            sops,
+            status: Arc::new(AtomicStatus::new(Status::Pending)),
+            waker: None,
+            pid,
+        })
+    }
+
     pub(super) fn sops_iter(&self) -> Iter<'_, SemBuf> {
         self.sops.iter()
     }
@@ -73,23 +97,40 @@ impl PendingOp {
     }
 
     /// Returns the ID of the semaphore that the operation is blocked on, if there is one.
-    pub(super) fn blocker(&self, sems: &[Semaphore]) -> Option<PendingBlocker> {
+    ///
+    /// The caller should provide `sems` whose size matches the number used to construct this
+    /// `PendingOp`. Otherwise, this method may panic.
+    pub(super) fn blocker(
+        &self,
+        sems: &[Semaphore],
+    ) -> core::result::Result<PendingBlocker, Status> {
         for op in self.sops.iter() {
             let sem_num = op.sem_num as usize;
-            let sem = sems.get(sem_num)?;
+            let sem = sems.get(sem_num).unwrap();
             let val = sem.val();
+
+            let flags = IpcFlags::from_bits_truncate(op.sem_flags as u32);
 
             // Zero condition
             if op.sem_op == 0 && val != 0 {
-                return Some(PendingBlocker::Zero(sem_num));
+                if flags.contains(IpcFlags::IPC_NOWAIT) {
+                    return Err(Status::ErrWouldBlock);
+                }
+                return Ok(PendingBlocker::Zero(sem_num));
             }
 
             if i32::from(op.sem_op) < -val {
-                return Some(PendingBlocker::Decrease(sem_num));
+                if flags.contains(IpcFlags::IPC_NOWAIT) {
+                    return Err(Status::ErrWouldBlock);
+                }
+                return Ok(PendingBlocker::Decrease(sem_num));
+            }
+            if i32::from(op.sem_op) > SEMVMX - val {
+                return Err(Status::ErrValRange);
             }
         }
 
-        None
+        Ok(PendingBlocker::NotBlock)
     }
 }
 
@@ -158,18 +199,13 @@ pub fn sem_op(
 
     let is_alter = check_alter_sop(&sops);
 
-    let mut pending_op = PendingOp {
-        sops,
-        status: Arc::new(AtomicStatus::new(Status::Pending)),
-        waker: None,
-        pid: ctx.process.pid(),
-    };
-
     // TODO: Support permission check
     warn!("Semaphore operation doesn't support permission check now");
 
     enum SemOpResult {
-        Completed,
+        Completed {
+            status: Status,
+        },
         Pending {
             status: Arc<AtomicStatus>,
             waiter: Waiter,
@@ -177,13 +213,19 @@ pub fn sem_op(
     }
 
     let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
+        let mut pending_op = PendingOp::new(sops, ctx.process.pid(), sem_set.num_sems())?;
+
         let mut inner = sem_set.inner();
 
-        if perform_atomic_semop(&mut inner.sems, &mut pending_op)? {
+        // Try to perform the operation without blocking
+        if let Some(status) = perform_atomic_semop(&mut inner.sems, &mut pending_op) {
+            if status != Status::Normal {
+                return Ok(SemOpResult::Completed { status });
+            }
+
             if is_alter {
                 let wake_queue = do_smart_update(&mut inner, &pending_op);
                 for wake_op in wake_queue {
-                    wake_op.set_status(Status::Normal);
                     if let Some(waker) = wake_op.waker {
                         waker.wake_up();
                     }
@@ -191,7 +233,8 @@ pub fn sem_op(
             }
 
             sem_set.update_otime();
-            return Ok(SemOpResult::Completed);
+
+            return Ok(SemOpResult::Completed { status });
         }
 
         // Prepare to wait
@@ -209,8 +252,35 @@ pub fn sem_op(
         Ok(SemOpResult::Pending { status, waiter })
     })?;
 
-    let (result, status) = match sem_op_result {
-        SemOpResult::Completed => return Ok(()),
+    fn map_status_to_result(status: Status, waiter_error: Option<Error>) -> Result<()> {
+        match status {
+            Status::Normal => Ok(()),
+            Status::Removed => {
+                return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
+            }
+            Status::Pending => {
+                if let Some(err) = waiter_error
+                    && err.error() == Errno::ETIME
+                {
+                    return_errno_with_message!(Errno::EAGAIN, "the time limit is reached");
+                } else {
+                    return_errno_with_message!(
+                        Errno::EINTR,
+                        "the current thread is interrupted by a signal"
+                    )
+                }
+            }
+            Status::ErrWouldBlock => {
+                return_errno_with_message!(Errno::EAGAIN, "the semaphore operation would block");
+            }
+            Status::ErrValRange => {
+                return_errno_with_message!(Errno::ERANGE, "the semaphore value exceeds SEMVMX");
+            }
+        }
+    }
+
+    let (waiter_result, status) = match sem_op_result {
+        SemOpResult::Completed { status } => return map_status_to_result(status, None),
         SemOpResult::Pending { status, waiter } => {
             let result = waiter.pause_timeout(&timeout.as_ref().into());
             (result, status)
@@ -233,24 +303,7 @@ pub fn sem_op(
         });
     }
 
-    match status.load(Ordering::Relaxed) {
-        Status::Normal => Ok(()),
-        Status::Removed => {
-            return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
-        }
-        Status::Pending => {
-            if let Err(err) = result
-                && err.error() == Errno::ETIME
-            {
-                return_errno_with_message!(Errno::EAGAIN, "the time limit is reached");
-            } else {
-                return_errno_with_message!(
-                    Errno::EINTR,
-                    "the current thread is interrupted by a signal"
-                )
-            }
-        }
-    }
+    map_status_to_result(status.load(Ordering::Relaxed), waiter_result.err())
 }
 
 /// Checks whether there are two operations that will operate on the same semaphore and the first
@@ -318,12 +371,18 @@ pub(super) fn update_pending_alter(
 ) {
     let mut cursor = pending_alter.cursor_front_mut();
     while let Some(alter_op) = cursor.current() {
-        let Ok(true) = perform_atomic_semop(sems, alter_op) else {
+        let Some(status) = perform_atomic_semop(sems, alter_op) else {
             cursor.move_next();
             continue;
         };
+        alter_op.set_status(status);
 
         let mut alter_op = cursor.remove_current_as_list().unwrap();
+        if status != Status::Normal {
+            wake_queue.append(&mut alter_op);
+            continue;
+        }
+
         do_smart_wakeup_zero(sems, pending_const, alter_op.front().unwrap(), wake_queue);
         wake_queue.append(&mut alter_op);
 
@@ -360,7 +419,8 @@ pub(super) fn wake_const_ops(
 ) {
     let mut cursor = pending_const.cursor_front_mut();
     while let Some(const_op) = cursor.current() {
-        if let Ok(true) = perform_atomic_semop(sems, const_op) {
+        if let Some(status) = perform_atomic_semop(sems, const_op) {
+            const_op.set_status(status);
             wake_queue.append(&mut cursor.remove_current_as_list().unwrap());
         } else {
             cursor.move_next();
@@ -370,45 +430,16 @@ pub(super) fn wake_const_ops(
 
 /// Performs atomic semaphore operations.
 ///
-/// 1. Return `Ok(true)` if all the operations succeed.
-/// 2. Return `Ok(false)` if the caller needs to wait.
-/// 3. Return `Err(err)` if the operations cause an error.
+/// 1. Return `Some(Status::Normal)` if all the operations succeed.
+/// 2. Return `None` if the caller needs to wait.
+/// 3. Return `Some(error_status)` if the operations cause an error.
 ///
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L719>
-fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> Result<bool> {
-    for op in pending_op.sops_iter() {
-        let flags = IpcFlags::from_bits_truncate(op.sem_flags as u32);
-
-        let Some(sem) = sems.get(op.sem_num as usize) else {
-            return_errno_with_message!(Errno::EFBIG, "the semaphore number is out of bounds");
-        };
-        let mut result = sem.val();
-
-        // Zero condition
-        if op.sem_op == 0 && result != 0 {
-            if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno_with_message!(Errno::EAGAIN, "the semaphore value is not zero");
-            } else {
-                return Ok(false);
-            }
-        }
-
-        result += i32::from(op.sem_op);
-        if result < 0 {
-            if flags.contains(IpcFlags::IPC_NOWAIT) {
-                return_errno_with_message!(Errno::EAGAIN, "the semaphore value is too small");
-            } else {
-                return Ok(false);
-            }
-        }
-
-        if result > SEMVMX {
-            return_errno_with_message!(Errno::ERANGE, "semaphore value exceeds SEMVMX");
-        }
-        if flags.contains(IpcFlags::SEM_UNDO) {
-            // TODO: Add support for the `SEM_UNDO` flag
-            return_errno_with_message!(Errno::EINVAL, "SEM_UNDO is not supported yet");
-        }
+fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> Option<Status> {
+    match pending_op.blocker(sems) {
+        Ok(PendingBlocker::NotBlock) => (),
+        Ok(PendingBlocker::Zero(_) | PendingBlocker::Decrease(_)) => return None,
+        Err(status) => return Some(status),
     }
 
     // Success, do operation
@@ -418,5 +449,5 @@ fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> R
         sem.latest_modified_pid = pending_op.pid;
     }
 
-    Ok(true)
+    Some(Status::Normal)
 }

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -17,10 +17,6 @@ use crate::{
     ipc::{IpcFlags, IpcId, IpcNamespace},
     prelude::*,
     process::Pid,
-    time::{
-        clocks::JIFFIES_TIMER_MANAGER,
-        timer::{Timeout, TimerGuard},
-    },
 };
 
 #[repr(C)]
@@ -155,8 +151,6 @@ pub fn sem_op(
         },
     }
 
-    let mut timer = None;
-
     let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
         let mut inner = sem_set.inner();
 
@@ -178,24 +172,9 @@ pub fn sem_op(
         // Prepare to wait
         let status = pending_op.status.clone();
         let (waiter, waker) = Waiter::new_pair();
+        pending_op.waker = Some(waker);
 
-        // Check if timeout exists to avoid calling `Arc::clone()`
-        if let Some(timeout) = timeout {
-            pending_op.waker = Some(waker.clone());
-
-            let jiffies_timer =
-                JIFFIES_TIMER_MANAGER
-                    .get()
-                    .unwrap()
-                    .create_timer(move |_guard: TimerGuard| {
-                        waker.wake_up();
-                    });
-            jiffies_timer.lock().set_timeout(Timeout::After(timeout));
-            timer = Some(jiffies_timer);
-        } else {
-            pending_op.waker = Some(waker);
-        }
-
+        // Insert the operation to the pending list
         if alter {
             inner.pending_alter.push_back(pending_op);
         } else {
@@ -205,11 +184,11 @@ pub fn sem_op(
         Ok(SemOpResult::Pending { status, waiter })
     })?;
 
-    let status = match sem_op_result {
+    let (result, status) = match sem_op_result {
         SemOpResult::Completed => return Ok(()),
         SemOpResult::Pending { status, waiter } => {
-            waiter.wait();
-            status
+            let result = waiter.pause_timeout(&timeout.as_ref().into());
+            (result, status)
         }
     };
 
@@ -235,7 +214,16 @@ pub fn sem_op(
             return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
         }
         Status::Pending => {
-            return_errno_with_message!(Errno::EAGAIN, "the time limit is reached");
+            if let Err(err) = result
+                && err.error() == Errno::ETIME
+            {
+                return_errno_with_message!(Errno::EAGAIN, "the time limit is reached");
+            } else {
+                return_errno_with_message!(
+                    Errno::EINTR,
+                    "the current thread is interrupted by a signal"
+                )
+            }
         }
     }
 }

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -27,12 +27,6 @@ pub struct SemBuf {
     sem_flags: i16,
 }
 
-impl SemBuf {
-    pub(super) fn sem_num(&self) -> u16 {
-        self.sem_num
-    }
-}
-
 #[repr(u16)]
 #[derive(Clone, Copy, Debug, TryFromInt)]
 pub(super) enum Status {
@@ -59,6 +53,12 @@ pub(super) struct PendingOp {
     pid: Pid,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PendingBlocker {
+    Zero(usize),
+    Decrease(usize),
+}
+
 impl PendingOp {
     pub(super) fn sops_iter(&self) -> Iter<'_, SemBuf> {
         self.sops.iter()
@@ -70,6 +70,26 @@ impl PendingOp {
 
     pub(super) fn waker(&self) -> Option<&Arc<Waker>> {
         self.waker.as_ref()
+    }
+
+    /// Returns the ID of the semaphore that the operation is blocked on, if there is one.
+    pub(super) fn blocker(&self, sems: &[Semaphore]) -> Option<PendingBlocker> {
+        for op in self.sops.iter() {
+            let sem_num = op.sem_num as usize;
+            let sem = sems.get(sem_num)?;
+            let val = sem.val();
+
+            // Zero condition
+            if op.sem_op == 0 && val != 0 {
+                return Some(PendingBlocker::Zero(sem_num));
+            }
+
+            if i32::from(op.sem_op) < -val {
+                return Some(PendingBlocker::Decrease(sem_num));
+            }
+        }
+
+        None
     }
 }
 

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -89,7 +89,7 @@ pub struct Semaphore {
     /// The PID of the process that last modified the semaphore.
     ///
     /// This includes the following cases:
-    /// - through `semop` with a non-zero `sem_op`,
+    /// - through `semop` with a zero or non-zero `sem_op`,
     /// - through `semctl` with `SETVAL` and `SETALL`, and
     /// - through `SEM_UNDO` on process exit.
     latest_modified_pid: Pid,
@@ -115,7 +115,7 @@ impl Semaphore {
     pub(super) fn new(val: i32) -> Self {
         Self {
             val,
-            latest_modified_pid: current!().pid(),
+            latest_modified_pid: 0,
         }
     }
 }
@@ -394,10 +394,8 @@ fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> R
     // Success, do operation
     for op in pending_op.sops_iter() {
         let sem = &mut sems[op.sem_num as usize];
-        if op.sem_op != 0 {
-            sem.val += i32::from(op.sem_op);
-            sem.latest_modified_pid = pending_op.pid;
-        }
+        sem.val += i32::from(op.sem_op);
+        sem.latest_modified_pid = pending_op.pid;
     }
 
     Ok(true)

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -155,6 +155,8 @@ pub fn sem_op(
         },
     }
 
+    let mut timer = None;
+
     let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
         let mut inner = sem_set.inner();
 
@@ -189,6 +191,7 @@ pub fn sem_op(
                         waker.wake_up();
                     });
             jiffies_timer.lock().set_timeout(Timeout::After(timeout));
+            timer = Some(jiffies_timer);
         } else {
             pending_op.waker = Some(waker);
         }
@@ -218,7 +221,7 @@ pub fn sem_op(
                         } else {
                             &mut inner.pending_const
                         };
-                        pending_ops.retain(|op| op.pid != pid);
+                        pending_ops.retain(|op| !Arc::ptr_eq(&op.status, &status));
 
                         Ok(())
                     })?;

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -205,30 +205,37 @@ pub fn sem_op(
         Ok(SemOpResult::Pending { status, waiter })
     })?;
 
-    match sem_op_result {
-        SemOpResult::Completed => Ok(()),
+    let status = match sem_op_result {
+        SemOpResult::Completed => return Ok(()),
         SemOpResult::Pending { status, waiter } => {
             waiter.wait();
-            match status.load(Ordering::Relaxed) {
-                Status::Normal => Ok(()),
-                Status::Removed => Err(Error::new(Errno::EIDRM)),
-                Status::Pending => {
-                    // FIXME: Lookup may be time-consuming.
-                    ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
-                        let mut inner = sem_set.inner();
-                        let pending_ops = if alter {
-                            &mut inner.pending_alter
-                        } else {
-                            &mut inner.pending_const
-                        };
-                        pending_ops.retain(|op| !Arc::ptr_eq(&op.status, &status));
+            status
+        }
+    };
 
-                        Ok(())
-                    })?;
+    if matches!(status.load(Ordering::Relaxed), Status::Pending) {
+        // Remove and check again to avoid race conditions
+        let _ = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
+            let mut inner = sem_set.inner();
+            let pending_ops = if alter {
+                &mut inner.pending_alter
+            } else {
+                &mut inner.pending_const
+            };
+            // FIXME: This may be time-consuming
+            pending_ops.retain(|op| !Arc::ptr_eq(&op.status, &status));
 
-                    Err(Error::new(Errno::EAGAIN))
-                }
-            }
+            Ok(())
+        });
+    }
+
+    match status.load(Ordering::Relaxed) {
+        Status::Normal => Ok(()),
+        Status::Removed => {
+            return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
+        }
+        Status::Pending => {
+            return_errno_with_message!(Errno::EAGAIN, "the time limit is reached");
         }
     }
 }

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -127,21 +127,26 @@ pub fn sem_op(
     ipc_ns: &Arc<IpcNamespace>,
     ctx: &Context,
 ) -> Result<()> {
-    let pid = ctx.process.pid();
+    let has_dup = check_dup_sops(&sops);
+    if has_dup {
+        warn!("Multiple operations on the same semaphore are not supported");
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "multiple operations on the same semaphore are not supported"
+        );
+    }
+
+    let is_alter = check_alter_sop(&sops);
+
     let mut pending_op = PendingOp {
         sops,
         status: Arc::new(AtomicStatus::new(Status::Pending)),
         waker: None,
-        pid,
+        pid: ctx.process.pid(),
     };
 
     // TODO: Support permission check
     warn!("Semaphore operation doesn't support permission check now");
-
-    let (alter, dupsop) = get_sops_flags(&pending_op);
-    if dupsop {
-        warn!("Found duplicate sop");
-    }
 
     enum SemOpResult {
         Completed,
@@ -155,7 +160,7 @@ pub fn sem_op(
         let mut inner = sem_set.inner();
 
         if perform_atomic_semop(&mut inner.sems, &mut pending_op)? {
-            if alter {
+            if is_alter {
                 let wake_queue = do_smart_update(&mut inner, &pending_op);
                 for wake_op in wake_queue {
                     wake_op.set_status(Status::Normal);
@@ -175,7 +180,7 @@ pub fn sem_op(
         pending_op.waker = Some(waker);
 
         // Insert the operation to the pending list
-        if alter {
+        if is_alter {
             inner.pending_alter.push_back(pending_op);
         } else {
             inner.pending_const.push_back(pending_op);
@@ -196,7 +201,7 @@ pub fn sem_op(
         // Remove and check again to avoid race conditions
         let _ = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
             let mut inner = sem_set.inner();
-            let pending_ops = if alter {
+            let pending_ops = if is_alter {
                 &mut inner.pending_alter
             } else {
                 &mut inner.pending_const
@@ -226,6 +231,41 @@ pub fn sem_op(
             }
         }
     }
+}
+
+/// Checks whether there are two operations that will operate on the same semaphore and the first
+/// operation is an alteration operation.
+fn check_dup_sops(sops: &[SemBuf]) -> bool {
+    fn check_dup_slow(sops: &[SemBuf]) -> bool {
+        for (i, op_i) in sops.iter().enumerate() {
+            if op_i.sem_op == 0 {
+                continue;
+            }
+            for op_j in sops[i + 1..].iter() {
+                if op_i.sem_num == op_j.sem_num {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    let mut mask = 0;
+    for op in sops.iter() {
+        let bit = 1u64 << (op.sem_num % 64);
+        if mask & bit != 0 {
+            return check_dup_slow(sops);
+        }
+        if op.sem_op != 0 {
+            mask |= bit;
+        }
+    }
+    false
+}
+
+/// Checks whether there is an operation that will change the value of a semaphore.
+fn check_alter_sop(sops: &[SemBuf]) -> bool {
+    sops.iter().any(|op| op.sem_op != 0)
 }
 
 /// Looks for operations that can be completed after an alteration operation and then completes
@@ -304,26 +344,6 @@ pub(super) fn wake_const_ops(
             cursor.move_next();
         }
     }
-}
-
-/// Iter the sops and return the flags (alter, dupsop)
-fn get_sops_flags(pending_op: &PendingOp) -> (bool, bool) {
-    let mut alter = false;
-    let mut dupsop = false;
-    let mut dup = 0;
-    for sop in pending_op.sops_iter() {
-        let mask: u64 = 1 << ((sop.sem_num) % 64);
-
-        if (dup & mask) != 0 {
-            dupsop = true;
-        }
-
-        if sop.sem_op != 0 {
-            alter = true;
-            dup |= mask;
-        }
-    }
-    (alter, dupsop)
 }
 
 /// Performs atomic semaphore operations.

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -354,7 +354,7 @@ fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedLis
         do_smart_wakeup_zero(sems, pending_const, pending_op, &mut wake_queue);
     }
     if !pending_alter.is_empty() {
-        update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
+        let _ = update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
     }
 
     wake_queue
@@ -362,13 +362,19 @@ fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedLis
 
 /// Looks for alteration operations that can be completed and then completes them.
 ///
+/// This method returns whether at least one operation has been completed. The caller should update
+/// the semaphore set's `otime`.
+///
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L949>
+#[must_use]
 pub(super) fn update_pending_alter(
     sems: &mut [Semaphore],
     pending_alter: &mut LinkedList<PendingOp>,
     pending_const: &mut LinkedList<PendingOp>,
     wake_queue: &mut LinkedList<PendingOp>,
-) {
+) -> bool {
+    let mut has_completed = false;
+
     let mut cursor = pending_alter.cursor_front_mut();
     while let Some(alter_op) = cursor.current() {
         let Some(status) = perform_atomic_semop(sems, alter_op) else {
@@ -382,6 +388,7 @@ pub(super) fn update_pending_alter(
             wake_queue.append(&mut alter_op);
             continue;
         }
+        has_completed = true;
 
         do_smart_wakeup_zero(sems, pending_const, alter_op.front().unwrap(), wake_queue);
         wake_queue.append(&mut alter_op);
@@ -389,6 +396,8 @@ pub(super) fn update_pending_alter(
         // Retry from the beginning since we've performed some alteration.
         cursor = pending_alter.cursor_front_mut();
     }
+
+    has_completed
 }
 
 /// Wakes up pending tasks on constant operations if an alteration operation made those constant
@@ -403,7 +412,7 @@ fn do_smart_wakeup_zero(
 ) {
     for sop in pending_op.sops_iter() {
         if sems.get(sop.sem_num as usize).unwrap().val == 0 {
-            wake_const_ops(sems, pending_const, wake_queue);
+            let _ = wake_const_ops(sems, pending_const, wake_queue);
             return;
         }
     }
@@ -411,21 +420,30 @@ fn do_smart_wakeup_zero(
 
 /// Wakes up pending tasks on constant operations if they can be completed.
 ///
+/// This method returns whether at least one operation has been completed. The caller should update
+/// the semaphore set's `otime`.
+///
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L854>
+#[must_use]
 pub(super) fn wake_const_ops(
     sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
     wake_queue: &mut LinkedList<PendingOp>,
-) {
+) -> bool {
+    let mut has_completed = false;
+
     let mut cursor = pending_const.cursor_front_mut();
     while let Some(const_op) = cursor.current() {
         if let Some(status) = perform_atomic_semop(sems, const_op) {
+            has_completed |= status == Status::Normal;
             const_op.set_status(status);
             wake_queue.append(&mut cursor.remove_current_as_list().unwrap());
         } else {
             cursor.move_next();
         }
     }
+
+    has_completed
 }
 
 /// Performs atomic semaphore operations.

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -384,7 +384,8 @@ fn perform_atomic_semop(sems: &mut [Semaphore], pending_op: &mut PendingOp) -> R
             return_errno_with_message!(Errno::ERANGE, "semaphore value exceeds SEMVMX");
         }
         if flags.contains(IpcFlags::SEM_UNDO) {
-            todo!()
+            // TODO: Add support for the `SEM_UNDO` flag
+            return_errno_with_message!(Errno::EINVAL, "SEM_UNDO is not supported yet");
         }
     }
 

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -14,7 +14,7 @@ use super::{
     sem_set::{SEMVMX, SemSetInner},
 };
 use crate::{
-    ipc::{IpcFlags, IpcNamespace, key_t},
+    ipc::{IpcFlags, IpcId, IpcNamespace},
     prelude::*,
     process::Pid,
     time::{
@@ -125,17 +125,12 @@ impl Semaphore {
 }
 
 pub fn sem_op(
-    sem_id: key_t,
+    sem_id: IpcId,
     sops: Vec<SemBuf>,
     timeout: Option<Duration>,
     ipc_ns: &Arc<IpcNamespace>,
     ctx: &Context,
 ) -> Result<()> {
-    if sem_id <= 0 {
-        return_errno_with_message!(Errno::EINVAL, "semaphore ID must be positive");
-    }
-    debug!("[semop] sops: {:?}", sops);
-
     let pid = ctx.process.pid();
     let mut pending_op = PendingOp {
         sops,

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -177,9 +177,8 @@ impl SemaphoreSet {
         let mut wake_queue = LinkedList::new();
         if val == 0 {
             wake_const_ops(sems, pending_const, &mut wake_queue);
-        } else {
-            update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
         }
+        update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
 
         for wake_op in wake_queue {
             wake_op.set_status(Status::Normal);

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -133,12 +133,12 @@ impl SemaphoreSet {
         let count_const = inner
             .pending_const
             .iter()
-            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Zero(sem_num)))
+            .filter(|op| op.blocker(&inner.sems) == Ok(PendingBlocker::Zero(sem_num)))
             .count();
         let count_alter = inner
             .pending_alter
             .iter()
-            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Zero(sem_num)))
+            .filter(|op| op.blocker(&inner.sems) == Ok(PendingBlocker::Zero(sem_num)))
             .count();
         Ok(count_const + count_alter)
     }
@@ -154,7 +154,7 @@ impl SemaphoreSet {
         let count = inner
             .pending_alter
             .iter()
-            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Decrease(sem_num)))
+            .filter(|op| op.blocker(&inner.sems) == Ok(PendingBlocker::Decrease(sem_num)))
             .count();
         Ok(count)
     }
@@ -184,7 +184,6 @@ impl SemaphoreSet {
         update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
 
         for wake_op in wake_queue {
-            wake_op.set_status(Status::Normal);
             if let Some(waker) = wake_op.waker() {
                 waker.wake_up();
             }

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -120,32 +120,40 @@ impl SemSetInner {
 }
 
 impl SemaphoreSet {
-    pub fn pending_const_count(&self, sem_num: u16) -> usize {
+    pub fn pending_const_count(&self, sem_num: usize) -> Result<usize> {
+        if sem_num >= self.num_sems {
+            return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
+        }
+
         let inner = self.inner.lock();
         let pending_const = &inner.pending_const;
         let mut count = 0;
         for i in pending_const.iter() {
             for sem_buf in i.sops_iter() {
-                if sem_buf.sem_num() == sem_num {
+                if sem_buf.sem_num() as usize == sem_num {
                     count += 1;
                 }
             }
         }
-        count
+        Ok(count)
     }
 
-    pub fn pending_alter_count(&self, sem_num: u16) -> usize {
+    pub fn pending_alter_count(&self, sem_num: usize) -> Result<usize> {
+        if sem_num >= self.num_sems {
+            return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
+        }
+
         let inner = self.inner.lock();
         let pending_alter = &inner.pending_alter;
         let mut count = 0;
         for i in pending_alter.iter() {
             for sem_buf in i.sops_iter() {
-                if sem_buf.sem_num() == sem_num {
+                if sem_buf.sem_num() as usize == sem_num {
                     count += 1;
                 }
             }
         }
-        count
+        Ok(count)
     }
 
     pub fn num_sems(&self) -> usize {

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -5,7 +5,9 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_rights::ReadOp;
 
-use super::sem::{PendingOp, Semaphore, Status, update_pending_alter, wake_const_ops};
+use super::sem::{
+    PendingBlocker, PendingOp, Semaphore, Status, update_pending_alter, wake_const_ops,
+};
 use crate::{
     ipc::{IpcKey, IpcPermission},
     prelude::*,
@@ -120,39 +122,40 @@ impl SemSetInner {
 }
 
 impl SemaphoreSet {
-    pub fn pending_const_count(&self, sem_num: usize) -> Result<usize> {
+    /// Counts the number of pending operations waiting for the semaphore at `sem_num` to become
+    /// zero.
+    pub fn pending_zero_count(&self, sem_num: usize) -> Result<usize> {
         if sem_num >= self.num_sems {
             return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
         }
 
         let inner = self.inner.lock();
-        let pending_const = &inner.pending_const;
-        let mut count = 0;
-        for i in pending_const.iter() {
-            for sem_buf in i.sops_iter() {
-                if sem_buf.sem_num() as usize == sem_num {
-                    count += 1;
-                }
-            }
-        }
-        Ok(count)
+        let count_const = inner
+            .pending_const
+            .iter()
+            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Zero(sem_num)))
+            .count();
+        let count_alter = inner
+            .pending_alter
+            .iter()
+            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Zero(sem_num)))
+            .count();
+        Ok(count_const + count_alter)
     }
 
-    pub fn pending_alter_count(&self, sem_num: usize) -> Result<usize> {
+    /// Counts the number of pending operations waiting for the semaphore at `sem_num` to be able to
+    /// decrease by a certain amount.
+    pub fn pending_decrease_count(&self, sem_num: usize) -> Result<usize> {
         if sem_num >= self.num_sems {
             return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
         }
 
         let inner = self.inner.lock();
-        let pending_alter = &inner.pending_alter;
-        let mut count = 0;
-        for i in pending_alter.iter() {
-            for sem_buf in i.sops_iter() {
-                if sem_buf.sem_num() as usize == sem_num {
-                    count += 1;
-                }
-            }
-        }
+        let count = inner
+            .pending_alter
+            .iter()
+            .filter(|op| op.blocker(&inner.sems) == Some(PendingBlocker::Decrease(sem_num)))
+            .count();
         Ok(count)
     }
 

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -5,9 +5,9 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_rights::ReadOp;
 
-use super::sem::{PendingOp, Status, update_pending_alter, wake_const_ops};
+use super::sem::{PendingOp, Semaphore, Status, update_pending_alter, wake_const_ops};
 use crate::{
-    ipc::{IpcPermission, key_t, semaphore::system_v::sem::Semaphore},
+    ipc::{IpcKey, IpcPermission},
     prelude::*,
     process::{Credentials, Pid},
     time::clocks::RealTimeCoarseClock,
@@ -225,13 +225,16 @@ impl SemaphoreSet {
     }
 
     pub(in crate::ipc) fn new(
-        key: key_t,
+        key: IpcKey,
         num_sems: usize,
         mode: u16,
         credentials: &Credentials<ReadOp>,
     ) -> Result<Self> {
+        if num_sems == 0 {
+            return_errno_with_message!(Errno::EINVAL, "the number of semaphores is zero")
+        }
         if num_sems > SEMMSL {
-            return_errno_with_message!(Errno::EINVAL, "num_sems exceeds SEMMSL");
+            return_errno_with_message!(Errno::EINVAL, "the number of semaphores exceeds SEMMSL");
         }
 
         let mut sems = Vec::with_capacity(num_sems);
@@ -257,7 +260,7 @@ impl SemaphoreSet {
 
     pub fn semid_ds(&self) -> SemidDs {
         let ipc_perm = IpcPerm {
-            key: self.permission.key() as u32,
+            key: self.permission.key().cast_unsigned(),
             uid: self.permission.uid().into(),
             gid: self.permission.gid().into(),
             cuid: self.permission.cuid().into(),

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -178,10 +178,12 @@ impl SemaphoreSet {
         sem.set_latest_modified_pid(pid);
 
         let mut wake_queue = LinkedList::new();
+        let mut has_completed_op = false;
         if val == 0 {
-            wake_const_ops(sems, pending_const, &mut wake_queue);
+            has_completed_op |= wake_const_ops(sems, pending_const, &mut wake_queue);
         }
-        update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
+        has_completed_op |=
+            update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
 
         for wake_op in wake_queue {
             if let Some(waker) = wake_op.waker() {
@@ -190,6 +192,10 @@ impl SemaphoreSet {
         }
 
         self.update_ctime();
+        if has_completed_op {
+            self.update_otime();
+        }
+
         Ok(())
     }
 

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -5,7 +5,7 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     ipc::{
-        IpcControlCmd,
+        IpcControlCmd, IpcId,
         semaphore::system_v::{PermissionMode, sem::Semaphore},
     },
     prelude::*,
@@ -15,17 +15,17 @@ use crate::{
 pub fn sys_semctl(
     semid: i32,
     semnum: i32,
-    cmd: i32,
+    op: i32,
     arg: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if semid <= 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid semid")
-    }
+    let Ok(semid) = IpcId::try_from(semid.cast_unsigned()) else {
+        return_errno_with_message!(Errno::EINVAL, "non-positive semaphore IDs are invalid");
+    };
+    let cmd = IpcControlCmd::try_from(op)?;
 
-    let cmd = IpcControlCmd::try_from(cmd)?;
     debug!(
-        "semid = {}, semnum = {}, cmd = {:?}, arg = {:x}",
+        "semctl: semid = {:?}, semnum = {}, cmd = {:?}, arg = {:x}",
         semid, semnum, cmd, arg
     );
 

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -19,8 +19,8 @@ pub fn sys_semctl(
     arg: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if semid <= 0 || semnum < 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid semid or semnum")
+    if semid <= 0 {
+        return_errno_with_message!(Errno::EINVAL, "invalid semid")
     }
 
     let cmd = IpcControlCmd::try_from(cmd)?;
@@ -77,14 +77,14 @@ pub fn sys_semctl(
         }
         IpcControlCmd::SEM_GETNCNT => {
             let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                Ok(sem_set.pending_alter_count(semnum as u16))
+                sem_set.pending_alter_count(semnum as usize)
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::SEM_GETZCNT => {
             let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                Ok(sem_set.pending_const_count(semnum as u16))
+                sem_set.pending_const_count(semnum as usize)
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -77,14 +77,14 @@ pub fn sys_semctl(
         }
         IpcControlCmd::SEM_GETNCNT => {
             let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                sem_set.pending_alter_count(semnum as usize)
+                sem_set.pending_decrease_count(semnum as usize)
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));
         }
         IpcControlCmd::SEM_GETZCNT => {
             let cnt: usize = ipc_ns.with_sem_set(semid, PermissionMode::READ, |sem_set| {
-                sem_set.pending_const_count(semnum as usize)
+                sem_set.pending_zero_count(semnum as usize)
             })?;
 
             return Ok(SyscallReturn::Return(cnt as isize));

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -97,7 +97,6 @@ pub fn sys_semctl(
                 sem_set.setval(semnum as usize, val, ctx.process.pid())
             })?;
         }
-        _ => todo!("Need to support {:?} in SYS_SEMCTL", cmd),
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/semget.rs
+++ b/kernel/src/syscall/semget.rs
@@ -1,37 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::SyscallReturn;
-use crate::{
-    ipc::{IpcFlags, semaphore::system_v::sem_set::SEMMSL},
-    prelude::*,
-};
+use crate::{ipc::IpcFlags, prelude::*};
 
-pub fn sys_semget(key: i32, num_sems: i32, semflags: i32, ctx: &Context) -> Result<SyscallReturn> {
-    if num_sems < 0 || num_sems as usize > SEMMSL {
-        return_errno_with_message!(Errno::EINVAL, "invalid num_sems value");
-    }
-    if key < 0 {
-        return_errno_with_message!(Errno::EINVAL, "semaphore key must not be negative");
-    }
-
-    let flags = IpcFlags::from_bits_truncate(semflags as u32);
-    let mode: u16 = (semflags as u32 & 0x1FF) as u16;
-    let num_sems = num_sems as usize;
-    let credentials = ctx.posix_thread.credentials();
+pub fn sys_semget(key: i32, nsems: i32, semflg: i32, ctx: &Context) -> Result<SyscallReturn> {
+    let num_sems = nsems as usize;
+    let flags = IpcFlags::from_bits_truncate(semflg.cast_unsigned());
+    let mode: u16 = (semflg.cast_unsigned() & 0x1FF) as u16;
 
     debug!(
-        "[sys_semget] key = {}, num_sems = {}, flags = {:?}",
-        key, num_sems, semflags
+        "semget: key = {}, num_sems = {}, flags = {:?}, mode = {:03o}",
+        key, num_sems, flags, mode
     );
 
     let ns_proxy = ctx.thread_local.borrow_ns_proxy();
     let ipc_ns = ns_proxy.unwrap().ipc_ns();
 
-    Ok(SyscallReturn::Return(ipc_ns.get_or_create_sem_set(
-        key,
-        num_sems,
-        flags,
-        mode,
-        credentials,
-    )? as isize))
+    let credentials = ctx.posix_thread.credentials();
+    let semid = ipc_ns.get_or_create_sem_set(key, num_sems, flags, mode, credentials)?;
+
+    Ok(SyscallReturn::Return(semid.get() as isize))
 }

--- a/kernel/src/syscall/semop.rs
+++ b/kernel/src/syscall/semop.rs
@@ -6,34 +6,28 @@ use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
-    ipc::semaphore::system_v::{
-        sem::{SemBuf, sem_op},
-        sem_set::SEMOPM,
+    ipc::{
+        IpcId,
+        semaphore::system_v::{
+            sem::{SemBuf, sem_op},
+            sem_set::SEMOPM,
+        },
     },
     prelude::*,
     time::timespec_t,
 };
 
-pub fn sys_semop(sem_id: i32, tsops: Vaddr, nsops: usize, ctx: &Context) -> Result<SyscallReturn> {
-    debug!(
-        "sem_id = {:?}, tsops_vaddr = {:x?}, nsops = {:?}",
-        sem_id, tsops, nsops
-    );
-    do_sys_semtimedop(sem_id, tsops, nsops, None, ctx)
+pub fn sys_semop(semid: i32, sops: Vaddr, nsops: usize, ctx: &Context) -> Result<SyscallReturn> {
+    do_sys_semtimedop(semid, sops, nsops, None, ctx)
 }
 
 pub fn sys_semtimedop(
-    sem_id: i32,
-    tsops: Vaddr,
+    semid: i32,
+    sops: Vaddr,
     nsops: usize,
     timeout: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    debug!(
-        "sem_id = {:?}, tsops_vaddr = {:x?}, nsops = {:?}, timeout_vaddr = {:x?}",
-        sem_id, tsops, nsops, timeout
-    );
-
     let timeout = if timeout == 0 {
         None
     } else {
@@ -42,33 +36,42 @@ pub fn sys_semtimedop(
         )?)
     };
 
-    do_sys_semtimedop(sem_id, tsops, nsops, timeout, ctx)
+    do_sys_semtimedop(semid, sops, nsops, timeout, ctx)
 }
 
 fn do_sys_semtimedop(
-    sem_id: i32,
-    tsops: Vaddr,
+    semid: i32,
+    sops: Vaddr,
     nsops: usize,
     timeout: Option<Duration>,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if sem_id <= 0 || nsops == 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid sem_id or nsops");
+    debug!(
+        "semop: semid = {:?}, sops = {:#x}, nsops = {:?}, timeout = {:?}",
+        semid, sops, nsops, timeout
+    );
+
+    let Ok(semid) = IpcId::try_from(semid.cast_unsigned()) else {
+        return_errno_with_message!(Errno::EINVAL, "non-positive semaphore IDs are invalid");
+    };
+
+    if nsops == 0 {
+        return_errno_with_message!(Errno::EINVAL, "the number of operations is zero");
     }
     if nsops > SEMOPM {
-        return_errno_with_message!(Errno::E2BIG, "nsops exceeds SEMOPM");
+        return_errno_with_message!(Errno::E2BIG, "the number of operations exceeds SEMOPM");
     }
 
     let user_space = ctx.user_space();
     let mut semops = Vec::with_capacity(nsops);
     for i in 0..nsops {
-        semops.push(user_space.read_val::<SemBuf>(tsops + size_of::<SemBuf>() * i)?);
+        semops.push(user_space.read_val::<SemBuf>(sops + size_of::<SemBuf>() * i)?);
     }
 
     let ns_proxy = ctx.thread_local.borrow_ns_proxy();
     let ipc_ns = ns_proxy.unwrap().ipc_ns();
 
-    sem_op(sem_id, semops, timeout, ipc_ns, ctx)?;
+    sem_op(semid, semops, timeout, ipc_ns, ctx)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/semaphore_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/semaphore_test
@@ -4,14 +4,6 @@ SemaphoreTest.SemCtlValAll
 SemaphoreTest.SemInfo
 SemaphoreTest.SemIpcSet
 SemaphoreTest.SemopGetncnt
-SemaphoreTest.SemopGetncntOnSetRemoval
-SemaphoreTest.SemopGetncntOnSignal
 SemaphoreTest.SemopGetzcnt
-SemaphoreTest.SemopGetzcntOnSetRemoval
-SemaphoreTest.SemopGetzcntOnSignal
-# SemOpMultiNoBlock requires handling the dupsop situation
+# TODO: Support multiple operations on the same semaphore in a `semop` syscall
 SemaphoreTest.SemOpMultiNoBlock
-SemaphoreTest.SemOpNamespace
-# SemOpRandom will failed in vmar/mod.rs:336:13:assertion failed.
-SemaphoreTest.SemOpRandom
-SemaphoreTest.SemTimedOpBlock

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1323,7 +1323,7 @@ select03
 # semctl04
 # semctl05
 # semctl06
-# semctl07
+semctl07
 # semctl08
 # semctl09
 
@@ -1333,7 +1333,7 @@ semget01
 
 # semop01
 # semop02
-# semop03
+semop03
 # semop04
 # semop05
 

--- a/test/initramfs/src/regression/ipc/Makefile
+++ b/test/initramfs/src/regression/ipc/Makefile
@@ -2,6 +2,7 @@
 
 SUBDIRS := \
 	pipe \
+	sem \
 	shm \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/ipc/run_test.sh
+++ b/test/initramfs/src/regression/ipc/run_test.sh
@@ -8,4 +8,6 @@ set -e
 ./pipe/process_pipe_available
 ./pipe/short_rw
 
+./sem/sem
+
 ./shm/posix_shm

--- a/test/initramfs/src/regression/ipc/sem/Makefile
+++ b/test/initramfs/src/regression/ipc/sem/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+EXTRA_C_FLAGS := -static -lpthread
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -259,3 +259,27 @@ FN_TEST(semop_is_interrupted_by_signal)
 	TEST_SUCC(remove_sem_set(semid));
 }
 END_TEST()
+
+FN_TEST(semop_duplicate_semnum)
+{
+	struct sembuf ops[2] = {
+		{ .sem_num = 0, .sem_op = 1, .sem_flg = 0 },
+		{ .sem_num = 0, .sem_op = -1, .sem_flg = IPC_NOWAIT },
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	/*
+	 * FIXME: Linux supports multiple operations on the same semaphore in a
+	 * single `semop`, but Asterinas rejects this unsupported case before
+	 * applying any operation.
+	 */
+#ifdef __asterinas__
+	TEST_ERRNO(semop(semid, ops, 2), EOPNOTSUPP);
+#else
+	TEST_SUCC(semop(semid, ops, 2));
+#endif
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -87,6 +87,13 @@ static int get_sem_ncnt(int semid, int semnum)
 	return semctl(semid, semnum, GETNCNT, arg);
 }
 
+static int get_sem_zcnt(int semid, int semnum)
+{
+	union semun arg = { 0 };
+
+	return semctl(semid, semnum, GETZCNT, arg);
+}
+
 static void *timed_semop_thread(void *data)
 {
 	struct timed_semop_args *args = data;
@@ -222,6 +229,7 @@ FN_TEST(semctl_set_zeros_wake_pending_alterations)
 	wait.semid = semid;
 	TEST_SUCC(start_timed_semop_thread(&thread, &wait));
 	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_zcnt(semid, 0), _ret == 1);
 
 	TEST_SUCC(set_sem_val(semid, 0, 0));
 	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == 0);
@@ -403,6 +411,54 @@ FN_TEST(semop_updates_pid_with_or_without_alteration)
 	TEST_RES(semctl(semid, 1, GETPID, arg), _ret == 0);
 	TEST_SUCC(semop(semid, &op, 1));
 	TEST_RES(semctl(semid, 1, GETPID, arg), _ret == getpid());
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semctl_waiter_counts_report_blocking_semnum)
+{
+	struct timed_semop_args wait = {
+		.nops = 2,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = 0, .sem_flg = 0 },
+			 { .sem_num = 1, .sem_op = -1, .sem_flg = 0 } },
+	};
+	pthread_t thread;
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	wait.semid = semid;
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+
+	TEST_SUCC(start_timed_semop_thread(&thread, &wait));
+	sleep_ms(SETTLE_MS);
+
+	// We're waiting at the first semaphore for zeros.
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 0);
+	TEST_RES(get_sem_zcnt(semid, 0), _ret == 1);
+	TEST_RES(get_sem_ncnt(semid, 1), _ret == 0);
+	TEST_RES(get_sem_zcnt(semid, 1), _ret == 0);
+
+	TEST_SUCC(set_sem_val(semid, 0, 0));
+	sleep_ms(SETTLE_MS);
+
+	// We're waiting at the second semaphore for decreasing.
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 0);
+	TEST_RES(get_sem_zcnt(semid, 0), _ret == 0);
+	TEST_RES(get_sem_ncnt(semid, 1), _ret == 1);
+	TEST_RES(get_sem_zcnt(semid, 1), _ret == 0);
+
+	TEST_SUCC(set_sem_val(semid, 1, 1));
+	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == 0);
+
+	// There are no waiters.
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 0);
+	TEST_RES(get_sem_zcnt(semid, 0), _ret == 0);
+	TEST_RES(get_sem_ncnt(semid, 1), _ret == 0);
+	TEST_RES(get_sem_zcnt(semid, 1), _ret == 0);
+
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+	TEST_RES(get_sem_val(semid, 1), _ret == 0);
 
 	TEST_SUCC(remove_sem_set(semid));
 }

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -16,6 +16,7 @@
 
 #define SEMMNI 320000
 #define SEMMSL 320000
+#define SEMOPM 500
 #define SEMVMX 32767
 
 #define CUSTOM_KEY 0xdeadbeef
@@ -153,6 +154,14 @@ FN_SETUP(install_signal_handler)
 }
 END_SETUP()
 
+FN_TEST(semget_reject_bad_semmnum)
+{
+	TEST_ERRNO(create_sem_set(0), EINVAL);
+	TEST_ERRNO(create_sem_set(-1), EINVAL);
+	TEST_ERRNO(create_sem_set(SEMMSL + 1), EINVAL);
+}
+END_TEST()
+
 FN_TEST(semget_accept_arbitrary_keys)
 {
 	int semid = TEST_SUCC(semget(CUSTOM_KEY, 1, IPC_CREAT | 0600));
@@ -187,6 +196,27 @@ FN_TEST(semget_accept_arbitrary_keys)
 }
 END_TEST()
 
+FN_TEST(semctl_reject_bad_semid)
+{
+	union semun arg = { 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+	int bad_semids[2] = { semid + 1, -1 };
+	int i, bad_semid;
+
+	for (i = 0; i < 2; ++i) {
+		bad_semid = bad_semids[i];
+		TEST_ERRNO(semctl(bad_semid, 0, IPC_STAT, arg), EINVAL);
+		TEST_ERRNO(semctl(bad_semid, 0, IPC_RMID, arg), EINVAL);
+		TEST_ERRNO(semctl(bad_semid, 0, GETNCNT, arg), EINVAL);
+		TEST_ERRNO(semctl(bad_semid, 0, GETZCNT, arg), EINVAL);
+		TEST_ERRNO(semctl(bad_semid, 0, GETVAL, arg), EINVAL);
+		TEST_ERRNO(semctl(bad_semid, 0, SETVAL, arg), EINVAL);
+	}
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
 FN_TEST(semctl_ipc_commands_ignore_semnum)
 {
 	union semun arg = { 0 };
@@ -208,6 +238,30 @@ FN_TEST(semctl_waiter_counts_reject_bad_semnum)
 	TEST_ERRNO(semctl(semid, 1, GETNCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, -1, GETZCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, 1, GETZCNT, arg), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semctl_get_set_values_reject_bad_semnum)
+{
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_ERRNO(get_sem_val(semid, 1), EINVAL);
+	TEST_ERRNO(get_sem_val(semid, -1), EINVAL);
+	TEST_ERRNO(set_sem_val(semid, 1, 0), EINVAL);
+	TEST_ERRNO(set_sem_val(semid, -1, 0), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semctl_set_values_reject_bad_values)
+{
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_ERRNO(set_sem_val(semid, 0, SEMVMX + 1), ERANGE);
+	TEST_ERRNO(set_sem_val(semid, 0, -1), ERANGE);
 
 	TEST_SUCC(remove_sem_set(semid));
 }
@@ -236,6 +290,61 @@ FN_TEST(semctl_set_zeros_wake_pending_alterations)
 	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == 0);
 	TEST_RES(get_sem_val(semid, 0), _ret == 0);
 	TEST_RES(get_sem_val(semid, 1), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_reject_bad_nops)
+{
+	struct sembuf op = { .sem_num = 0, .sem_op = 1, .sem_flg = 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_ERRNO(semop(semid, &op, 0), EINVAL);
+	TEST_ERRNO(semop(semid, &op, SEMOPM + 1), E2BIG);
+	TEST_ERRNO(semop(semid, &op, -1), E2BIG);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_reject_bad_semid)
+{
+	struct sembuf op = { .sem_num = 0, .sem_op = 1, .sem_flg = 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_ERRNO(semop(semid + 1, &op, 1), EINVAL);
+	TEST_ERRNO(semop(-1, &op, 1), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_reject_bad_semnum)
+{
+	struct sembuf ops[2] = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 },
+				 { .sem_num = 1, .sem_op = 0, .sem_flg = 0 } };
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	ops[1].sem_num = 2;
+	TEST_ERRNO(semop(semid, ops, 2), EFBIG);
+
+	ops[1].sem_num = -1;
+	TEST_ERRNO(semop(semid, ops, 2), EFBIG);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_reject_bad_values)
+{
+	struct sembuf op = { .sem_num = 0, .sem_op = 1, .sem_flg = 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+
+	op.sem_op = SEMVMX;
+	TEST_ERRNO(semop(semid, &op, 1), ERANGE);
 
 	TEST_SUCC(remove_sem_set(semid));
 }

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+
+#include "../../common/test.h"
+
+union semun {
+	int val;
+	struct semid_ds *buf;
+	unsigned short *array;
+};
+
+static int create_sem_set(int nsems)
+{
+	return semget(IPC_PRIVATE, nsems, IPC_CREAT | 0600);
+}
+
+static int remove_sem_set(int semid)
+{
+	union semun arg = { 0 };
+
+	return semctl(semid, 0, IPC_RMID, arg);
+}
+
+FN_TEST(semctl_ipc_commands_ignore_semnum)
+{
+	union semun arg = { 0 };
+	struct semid_ds semid_ds;
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	arg.buf = &semid_ds;
+	TEST_SUCC(semctl(semid, -1, IPC_STAT, arg));
+	TEST_SUCC(semctl(semid, -1, IPC_RMID, arg));
+}
+END_TEST()
+
+FN_TEST(semctl_waiter_counts_reject_bad_semnum)
+{
+	union semun arg = { 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_ERRNO(semctl(semid, -1, GETNCNT, arg), EINVAL);
+	TEST_ERRNO(semctl(semid, 1, GETNCNT, arg), EINVAL);
+	TEST_ERRNO(semctl(semid, -1, GETZCNT, arg), EINVAL);
+	TEST_ERRNO(semctl(semid, 1, GETZCNT, arg), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -283,3 +283,28 @@ FN_TEST(semop_duplicate_semnum)
 	TEST_SUCC(remove_sem_set(semid));
 }
 END_TEST()
+
+FN_TEST(semop_sem_undo)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	/*
+	 * FIXME: Linux applies `SEM_UNDO`, but Asterinas rejects the flag as it
+	 * is not supported.
+	 */
+#ifdef __asterinas__
+	TEST_ERRNO(semop(semid, &op, 1), EINVAL);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+#else
+	TEST_SUCC(semop(semid, &op, 1));
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+#endif
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -16,6 +16,7 @@
 
 #define SEMMNI 320000
 #define SEMMSL 320000
+#define SEMVMX 32767
 
 #define CUSTOM_KEY 0xdeadbeef
 
@@ -459,6 +460,33 @@ FN_TEST(semctl_waiter_counts_report_blocking_semnum)
 
 	TEST_RES(get_sem_val(semid, 0), _ret == 0);
 	TEST_RES(get_sem_val(semid, 1), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semtimedop_reports_error_after_blocking)
+{
+	struct timed_semop_args wait = {
+		.nops = 2,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 },
+			 { .sem_num = 1, .sem_op = 1, .sem_flg = 0 } },
+	};
+	pthread_t thread;
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	TEST_SUCC(set_sem_val(semid, 1, SEMVMX));
+
+	wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&thread, &wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == ERANGE);
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+	TEST_RES(get_sem_val(semid, 1), _ret == SEMVMX);
 
 	TEST_SUCC(remove_sem_set(semid));
 }

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -4,9 +4,11 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <signal.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -118,6 +120,22 @@ static int join_timed_semop_thread(pthread_t thread,
 	return args->error;
 }
 
+static void signal_handler(int signum)
+{
+	(void)signum;
+}
+
+FN_SETUP(install_signal_handler)
+{
+	struct sigaction action = {
+		.sa_handler = signal_handler,
+	};
+
+	CHECK(sigemptyset(&action.sa_mask));
+	CHECK(sigaction(SIGUSR1, &action, NULL));
+}
+END_SETUP()
+
 FN_TEST(semget_accept_arbitrary_keys)
 {
 	int semid = TEST_SUCC(semget(CUSTOM_KEY, 1, IPC_CREAT | 0600));
@@ -212,6 +230,31 @@ FN_TEST(semop_timeout_keeps_same_process_waiters)
 	TEST_SUCC(semop(semid, &post, 1));
 	TEST_RES(join_timed_semop_thread(long_thread, &long_wait), _ret == 0);
 	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_is_interrupted_by_signal)
+{
+	struct sembuf wait = { .sem_num = 0, .sem_op = -1, .sem_flg = 0 };
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t child = TEST_SUCC(fork());
+	int status;
+
+	if (child == 0) {
+		CHECK_WITH(semop(semid, &wait, 1),
+			   _ret == -1 && errno == EINTR);
+		_exit(0);
+	}
+
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+	TEST_SUCC(kill(child, SIGUSR1));
+
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 0);
 
 	TEST_SUCC(remove_sem_set(semid));
 }

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -3,8 +3,12 @@
 #define _GNU_SOURCE
 
 #include <errno.h>
+#include <pthread.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "../../common/test.h"
 
@@ -13,11 +17,38 @@
 
 #define CUSTOM_KEY 0xdeadbeef
 
+#define SETTLE_MS 100
+#define SHORT_TIMEOUT_MS 1000
+#define LONG_TIMEOUT_MS 4000
+
 union semun {
 	int val;
 	struct semid_ds *buf;
 	unsigned short *array;
 };
+
+struct timed_semop_args {
+	int semid;
+	struct sembuf ops[2];
+	size_t nops;
+	long timeout_ms;
+	int error;
+};
+
+static struct timespec timespec_from_ms(long milliseconds)
+{
+	return (struct timespec){
+		.tv_sec = milliseconds / 1000,
+		.tv_nsec = (milliseconds % 1000) * 1000000L,
+	};
+}
+
+static void sleep_ms(long milliseconds)
+{
+	struct timespec request = timespec_from_ms(milliseconds);
+
+	CHECK(nanosleep(&request, NULL));
+}
 
 static int create_sem_set(int nsems)
 {
@@ -29,6 +60,62 @@ static int remove_sem_set(int semid)
 	union semun arg = { 0 };
 
 	return semctl(semid, 0, IPC_RMID, arg);
+}
+
+static int get_sem_val(int semid, int semnum)
+{
+	union semun arg = { 0 };
+
+	return semctl(semid, semnum, GETVAL, arg);
+}
+
+static int get_sem_ncnt(int semid, int semnum)
+{
+	union semun arg = { 0 };
+
+	return semctl(semid, semnum, GETNCNT, arg);
+}
+
+static void *timed_semop_thread(void *data)
+{
+	struct timed_semop_args *args = data;
+	struct timespec timeout = timespec_from_ms(args->timeout_ms);
+
+	errno = 0;
+	if (syscall(SYS_semtimedop, args->semid, args->ops, args->nops,
+		    &timeout) == 0) {
+		args->error = 0;
+	} else {
+		args->error = errno;
+	}
+
+	return NULL;
+}
+
+static int start_timed_semop_thread(pthread_t *thread,
+				    struct timed_semop_args *args)
+{
+	int error = pthread_create(thread, NULL, &timed_semop_thread, args);
+
+	if (error != 0) {
+		errno = error;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int join_timed_semop_thread(pthread_t thread,
+				   const struct timed_semop_args *args)
+{
+	int error = pthread_join(thread, NULL);
+
+	if (error != 0) {
+		errno = error;
+		return -1;
+	}
+
+	return args->error;
 }
 
 FN_TEST(semget_accept_arbitrary_keys)
@@ -86,6 +173,45 @@ FN_TEST(semctl_waiter_counts_reject_bad_semnum)
 	TEST_ERRNO(semctl(semid, 1, GETNCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, -1, GETZCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, 1, GETZCNT, arg), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semop_timeout_keeps_same_process_waiters)
+{
+	struct timed_semop_args short_wait = {
+		.nops = 1,
+		.timeout_ms = SHORT_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 } },
+	};
+	struct timed_semop_args long_wait = {
+		.nops = 1,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 } },
+	};
+	struct sembuf post = { .sem_num = 0, .sem_op = 1, .sem_flg = 0 };
+	pthread_t short_thread;
+	pthread_t long_thread;
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	short_wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&short_thread, &short_wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+
+	long_wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&long_thread, &long_wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 2);
+
+	TEST_RES(join_timed_semop_thread(short_thread, &short_wait),
+		 _ret == EAGAIN);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+
+	TEST_SUCC(semop(semid, &post, 1));
+	TEST_RES(join_timed_semop_thread(long_thread, &long_wait), _ret == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
 
 	TEST_SUCC(remove_sem_set(semid));
 }

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -8,6 +8,11 @@
 
 #include "../../common/test.h"
 
+#define SEMMNI 320000
+#define SEMMSL 320000
+
+#define CUSTOM_KEY 0xdeadbeef
+
 union semun {
 	int val;
 	struct semid_ds *buf;
@@ -25,6 +30,40 @@ static int remove_sem_set(int semid)
 
 	return semctl(semid, 0, IPC_RMID, arg);
 }
+
+FN_TEST(semget_accept_arbitrary_keys)
+{
+	int semid = TEST_SUCC(semget(CUSTOM_KEY, 1, IPC_CREAT | 0600));
+	int semid2;
+
+	/*
+	 * FIXME: Asterinas rejects keys that hash to the same ID.
+	 */
+#ifdef __asterinas__
+	TEST_ERRNO(semget(CUSTOM_KEY + SEMMNI, 1, IPC_CREAT | 0600), ENOSPC);
+	TEST_ERRNO(semget(CUSTOM_KEY + SEMMNI, 0, 0), ENOENT);
+	semid2 = TEST_RES(semget(CUSTOM_KEY + 1, 1, IPC_CREAT | 0600),
+			  _ret != semid);
+#else
+	TEST_ERRNO(semget(CUSTOM_KEY + SEMMNI, 0, 0), ENOENT);
+	semid2 = TEST_RES(semget(CUSTOM_KEY + SEMMNI, 1, IPC_CREAT | 0600),
+			  _ret != semid);
+#endif
+
+	TEST_RES(semget(CUSTOM_KEY, 0, IPC_CREAT | 0600), _ret == semid);
+	TEST_RES(semget(CUSTOM_KEY, 1, IPC_CREAT | 0600), _ret == semid);
+	TEST_ERRNO(semget(CUSTOM_KEY, 0, IPC_CREAT | IPC_EXCL | 0600), EEXIST);
+	TEST_ERRNO(semget(CUSTOM_KEY, 1, IPC_CREAT | IPC_EXCL | 0600), EEXIST);
+
+	TEST_ERRNO(semget(CUSTOM_KEY, 2, IPC_CREAT | 0600), EINVAL);
+	TEST_ERRNO(semget(CUSTOM_KEY, -1, IPC_CREAT | 0600), EINVAL);
+	TEST_ERRNO(semget(CUSTOM_KEY, 2, 0), EINVAL);
+	TEST_ERRNO(semget(CUSTOM_KEY, -1, 0), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+	TEST_SUCC(remove_sem_set(semid2));
+}
+END_TEST()
 
 FN_TEST(semctl_ipc_commands_ignore_semnum)
 {

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -387,3 +387,23 @@ FN_TEST(semop_retries_pending_alterations)
 	TEST_SUCC(remove_sem_set(semid));
 }
 END_TEST()
+
+FN_TEST(semop_updates_pid_with_or_without_alteration)
+{
+	union semun arg = { 0 };
+	struct sembuf op = { .sem_num = 0, .sem_op = 0, .sem_flg = 0 };
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	TEST_RES(semctl(semid, 0, GETPID, arg), _ret == 0);
+	TEST_SUCC(semop(semid, &op, 1));
+	TEST_RES(semctl(semid, 0, GETPID, arg), _ret == getpid());
+
+	op.sem_num = 1;
+	op.sem_op = 1;
+	TEST_RES(semctl(semid, 1, GETPID, arg), _ret == 0);
+	TEST_SUCC(semop(semid, &op, 1));
+	TEST_RES(semctl(semid, 1, GETPID, arg), _ret == getpid());
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -308,3 +308,46 @@ FN_TEST(semop_sem_undo)
 	TEST_SUCC(remove_sem_set(semid));
 }
 END_TEST()
+
+FN_TEST(semop_retries_pending_alterations)
+{
+	struct timed_semop_args first_wait = {
+		.nops = 1,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 } },
+	};
+	struct timed_semop_args second_wait = {
+		.nops = 2,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = 1, .sem_flg = 0 },
+			 { .sem_num = 1, .sem_op = -1, .sem_flg = 0 } },
+	};
+	struct sembuf release_second = {
+		.sem_num = 1,
+		.sem_op = 1,
+		.sem_flg = 0,
+	};
+	pthread_t first_thread;
+	pthread_t second_thread;
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	first_wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&first_thread, &first_wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+
+	second_wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&second_thread, &second_wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 1), _ret == 1);
+
+	TEST_SUCC(semop(semid, &release_second, 1));
+	TEST_RES(join_timed_semop_thread(second_thread, &second_wait),
+		 _ret == 0);
+	TEST_RES(join_timed_semop_thread(first_thread, &first_wait), _ret == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+	TEST_RES(get_sem_val(semid, 1), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -491,3 +491,34 @@ FN_TEST(semtimedop_reports_error_after_blocking)
 	TEST_SUCC(remove_sem_set(semid));
 }
 END_TEST()
+
+FN_TEST(semop_updates_otime_after_blocking)
+{
+	union semun arg = { 0 };
+	struct timed_semop_args wait = {
+		.nops = 1,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = -1, .sem_flg = 0 } }
+	};
+	pthread_t thread;
+	struct semid_ds semid_ds;
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&thread, &wait));
+	sleep_ms(SETTLE_MS);
+	TEST_RES(get_sem_ncnt(semid, 0), _ret == 1);
+
+	arg.buf = &semid_ds;
+	TEST_RES(semctl(semid, 0, IPC_STAT, arg), semid_ds.sem_otime == 0);
+
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	arg.buf = &semid_ds;
+	TEST_RES(semctl(semid, 0, IPC_STAT, arg), semid_ds.sem_otime != 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -71,6 +71,15 @@ static int get_sem_val(int semid, int semnum)
 	return semctl(semid, semnum, GETVAL, arg);
 }
 
+static int set_sem_val(int semid, int semnum, int val)
+{
+	union semun arg = {
+		.val = val,
+	};
+
+	return semctl(semid, semnum, SETVAL, arg);
+}
+
 static int get_sem_ncnt(int semid, int semnum)
 {
 	union semun arg = { 0 };
@@ -191,6 +200,33 @@ FN_TEST(semctl_waiter_counts_reject_bad_semnum)
 	TEST_ERRNO(semctl(semid, 1, GETNCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, -1, GETZCNT, arg), EINVAL);
 	TEST_ERRNO(semctl(semid, 1, GETZCNT, arg), EINVAL);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semctl_set_zeros_wake_pending_alterations)
+{
+	struct timed_semop_args wait = {
+		.nops = 2,
+		.timeout_ms = LONG_TIMEOUT_MS,
+		.ops = { { .sem_num = 0, .sem_op = 0, .sem_flg = 0 },
+			 { .sem_num = 1, .sem_op = -1, .sem_flg = 0 } },
+	};
+	pthread_t thread;
+	int semid = TEST_SUCC(create_sem_set(2));
+
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+	TEST_SUCC(set_sem_val(semid, 1, 1));
+
+	wait.semid = semid;
+	TEST_SUCC(start_timed_semop_thread(&thread, &wait));
+	sleep_ms(SETTLE_MS);
+
+	TEST_SUCC(set_sem_val(semid, 0, 0));
+	TEST_RES(join_timed_semop_thread(thread, &wait), _ret == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+	TEST_RES(get_sem_val(semid, 1), _ret == 0);
 
 	TEST_SUCC(remove_sem_set(semid));
 }


### PR DESCRIPTION
~~This PR is based on #3198. Please review it first.~~

There are many bugs in the System V semaphore implementation. This PR contains a series of bug fixes.

Each commit fixes one bug, or two if they're closely related. Each commit also adds a regression test for the fixed problem. I hope I won't need to explain each commit, as the bug is obvious to me. Again, please let me know if you have any questions.

 - "Fix race on timed out `semop`": This is the only commit in this PR that does not have a regression test. It's a race condition with an extremely small window, so it's difficult to test. The problem is illustrated in the following example:
```
[ Thread A ]              [ Thread B ]                    Timer

semop()

   waiter.wait()

                                                          waker.wake_up()

   status.load()
     = Pending

                          semctl(SETVAL)

                              perform_atomic_semop()
                              status.store(Normal)

   pending_op.retain()

   return EAGAIN
```


In this case, Thread A sees the `semop` system call return `EAGAIN`. However, the operation has already been performed in Thread B, which is problematic.

Perhaps I should squash some commits here? I'm not sure, but I'm happy to follow any guidance.

Fixes https://github.com/asterinas/asterinas/issues/1370. After this PR, the test case mentioned in that issue will be rejected as unsupported.