### PR TITLE
Support MSG_PEEK and MSG_TRUNC

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -109,6 +109,17 @@ define_boolean_value!(
     NeedIfacePoll
 );
 
+/// Describes how receive data is handled.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiveBehavior {
+    /// Consumes received data after copying it.
+    Normal,
+    /// Copies received data without consuming it.
+    Peek,
+    /// Consumes received data without copying it.
+    Discard,
+}
+
 impl<T: Inner<E>, E: Ext> SocketBg<T, E> {
     pub(crate) fn notify_dead_events(self: Arc<Self>)
     where

--- a/kernel/libs/aster-bigtcp/src/socket/bound/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/mod.rs
@@ -5,7 +5,7 @@ mod tcp_conn;
 mod tcp_listen;
 mod udp;
 
-pub use common::NeedIfacePoll;
+pub use common::{NeedIfacePoll, ReceiveBehavior};
 pub use tcp_conn::{ConnectState, RawTcpSocketExt, TcpConnection};
 pub(crate) use tcp_conn::{TcpConnectionBg, TcpProcessResult};
 pub use tcp_listen::TcpListener;

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -3,6 +3,7 @@
 use alloc::{
     boxed::Box,
     sync::{Arc, Weak},
+    vec,
 };
 use core::{
     num::NonZeroUsize,
@@ -509,6 +510,60 @@ impl<E: Ext> TcpConnection<E> {
             }
 
             need_wrap_continuation = false;
+        };
+
+        let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;
+        let poll_at = socket.poll_at(iface.context_mut());
+        let need_poll = iface.update_next_poll_at_ms(&self.0, poll_at);
+
+        Ok((result, need_poll))
+    }
+
+    /// Peeks some data.
+    ///
+    /// Polling the iface _may_ be required after this method succeeds.
+    pub fn peek<F, CopyErr>(
+        &self,
+        f: F,
+        max_len: usize,
+    ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<RecvError, CopyErr>>
+    where
+        F: FnOnce(&[u8]) -> Result<usize, (CopyErr, usize)>,
+    {
+        let common = self.iface().common();
+        let mut iface = common.interface();
+
+        let mut socket = self.0.inner.lock();
+
+        if socket.is_recv_shut && socket.recv_queue() == 0 {
+            return Err(IoError::Socket(RecvError::Finished));
+        }
+
+        let recv_len = socket.recv_queue().min(max_len);
+        let result = match socket.peek(recv_len) {
+            Ok(socket_buffer) if socket_buffer.len() == recv_len => f(socket_buffer),
+            Ok(_) => {
+                let mut socket_buffer = vec![0; recv_len];
+                let peeked_len = socket.peek_slice(&mut socket_buffer)?;
+                f(&socket_buffer[..peeked_len])
+            }
+            Err(err) => {
+                if socket.is_rst_closed {
+                    socket.is_rst_closed = false;
+                    return Err(IoError::Socket(RecvError::ConnReset));
+                }
+                return Err(err.into());
+            }
+        };
+
+        let result = match result {
+            Ok(recv_bytes) => recv_bytes,
+            Err((err, recv_bytes)) => {
+                if recv_bytes == 0 {
+                    return Err(IoError::Copy(err));
+                }
+                recv_bytes
+            }
         };
 
         let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -19,7 +19,7 @@ use smoltcp::{
 };
 
 use super::{
-    common::{Inner, NeedIfacePoll, Socket, SocketBg},
+    common::{Inner, NeedIfacePoll, ReceiveBehavior, Socket, SocketBg},
     tcp_listen::TcpListenerBg,
 };
 use crate::{
@@ -109,6 +109,115 @@ impl<E: Ext> RawTcpSocketExt<E> {
     /// [`TcpConnection::clear_rst_closed`], [`TcpConnection::send`], or [`TcpConnection::recv`].
     pub fn is_rst_closed(&self) -> bool {
         self.is_rst_closed
+    }
+
+    fn recv_without_peek<F, CopyErr>(
+        &mut self,
+        receive_behavior: ReceiveBehavior,
+        max_len: usize,
+        f: &mut F,
+    ) -> Result<usize, IoError<RecvError, CopyErr>>
+    where
+        F: FnMut(&[u8]) -> Result<usize, (CopyErr, usize)>,
+    {
+        let mut total_recv_bytes = 0;
+        let mut need_wrap_continuation = true;
+
+        loop {
+            if total_recv_bytes >= max_len {
+                break Ok(total_recv_bytes);
+            }
+
+            let remaining_len = max_len - total_recv_bytes;
+            let mut recv_bytes = 0;
+            let mut socket_buffer_len = 0;
+
+            // `socket.recv` exposes the largest contiguous readable range. If the receive ring
+            // buffer wraps, one logical stream read may span two such ranges, so continue at most
+            // once while holding the same socket lock to avoid an avoidable short read.
+            let recv_result = self.recv(|socket_buffer| {
+                socket_buffer_len = socket_buffer.len().min(remaining_len);
+                let socket_buffer = &socket_buffer[..socket_buffer_len];
+
+                let copy_result = match receive_behavior {
+                    ReceiveBehavior::Normal => f(socket_buffer).map(|current_recv_bytes| {
+                        recv_bytes = current_recv_bytes;
+                    }),
+                    ReceiveBehavior::Discard => {
+                        recv_bytes = socket_buffer_len;
+                        Ok(())
+                    }
+                    ReceiveBehavior::Peek => unreachable!(),
+                };
+
+                match copy_result {
+                    Ok(()) => (recv_bytes, Ok(())),
+                    Err((err, current_recv_bytes)) => {
+                        recv_bytes = current_recv_bytes;
+                        (current_recv_bytes, Err(err))
+                    }
+                }
+            });
+
+            let copy_result = match recv_result {
+                Err(_) if self.is_rst_closed && total_recv_bytes == 0 => {
+                    self.is_rst_closed = false;
+                    return Err(IoError::Socket(RecvError::ConnReset));
+                }
+                Err(_) if total_recv_bytes > 0 => break Ok(total_recv_bytes),
+                res => res?,
+            };
+
+            total_recv_bytes += recv_bytes;
+
+            if let Err(err) = copy_result {
+                if total_recv_bytes == 0 {
+                    return Err(IoError::Copy(err));
+                }
+                break Ok(total_recv_bytes);
+            }
+
+            if recv_bytes < socket_buffer_len
+                || total_recv_bytes >= max_len
+                || !need_wrap_continuation
+            {
+                break Ok(total_recv_bytes);
+            }
+
+            need_wrap_continuation = false;
+        }
+    }
+
+    fn recv_with_peek<F, CopyErr>(
+        &mut self,
+        max_len: usize,
+        f: &mut F,
+    ) -> Result<usize, IoError<RecvError, CopyErr>>
+    where
+        F: FnMut(&[u8]) -> Result<usize, (CopyErr, usize)>,
+    {
+        let recv_len = self.recv_queue().min(max_len);
+        let peek_result = match self.peek(recv_len) {
+            Ok(socket_buffer) if socket_buffer.len() == recv_len => f(socket_buffer),
+            Ok(_) => {
+                let mut socket_buffer = vec![0; recv_len];
+                let peeked_len = self.peek_slice(&mut socket_buffer)?;
+                f(&socket_buffer[..peeked_len])
+            }
+            Err(err) => {
+                if self.is_rst_closed {
+                    self.is_rst_closed = false;
+                    return Err(IoError::Socket(RecvError::ConnReset));
+                }
+                return Err(err.into());
+            }
+        };
+
+        match peek_result {
+            Ok(recv_bytes) => Ok(recv_bytes),
+            Err((err, 0)) => Err(IoError::Copy(err)),
+            Err((_, recv_bytes)) => Ok(recv_bytes),
+        }
     }
 }
 
@@ -449,10 +558,12 @@ impl<E: Ext> TcpConnection<E> {
     /// Polling the iface _may_ be required after this method succeeds.
     pub fn recv<F, CopyErr>(
         &self,
+        receive_behavior: ReceiveBehavior,
+        max_len: usize,
         mut f: F,
     ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<RecvError, CopyErr>>
     where
-        F: FnMut(&mut [u8]) -> Result<usize, (CopyErr, usize)>,
+        F: FnMut(&[u8]) -> Result<usize, (CopyErr, usize)>,
     {
         let common = self.iface().common();
         let mut iface = common.interface();
@@ -463,107 +574,10 @@ impl<E: Ext> TcpConnection<E> {
             return Err(IoError::Socket(RecvError::Finished));
         }
 
-        let mut total_recv_bytes = 0;
-        let mut need_wrap_continuation = true;
-
-        let result = loop {
-            let mut recv_bytes = 0;
-            let mut socket_buffer_len = 0;
-
-            // `socket.recv` exposes the largest contiguous readable range. If the receive ring
-            // buffer wraps, one logical stream read may span two such ranges, so continue at most
-            // once while holding the same socket lock to avoid an avoidable short read.
-            let recv_result = socket.recv(|socket_buffer| {
-                socket_buffer_len = socket_buffer.len();
-                match f(socket_buffer) {
-                    Ok(current_recv_bytes) => {
-                        recv_bytes = current_recv_bytes;
-                        (current_recv_bytes, Ok(()))
-                    }
-                    Err((err, current_recv_bytes)) => {
-                        recv_bytes = current_recv_bytes;
-                        (current_recv_bytes, Err(err))
-                    }
-                }
-            });
-
-            let copy_result = match recv_result {
-                Err(_) if socket.is_rst_closed && total_recv_bytes == 0 => {
-                    socket.is_rst_closed = false;
-                    return Err(IoError::Socket(RecvError::ConnReset));
-                }
-                Err(_) if total_recv_bytes > 0 => break total_recv_bytes,
-                res => res?,
-            };
-
-            total_recv_bytes += recv_bytes;
-
-            if let Err(err) = copy_result {
-                if total_recv_bytes == 0 {
-                    return Err(IoError::Copy(err));
-                }
-                break total_recv_bytes;
-            }
-
-            if recv_bytes < socket_buffer_len || !need_wrap_continuation {
-                break total_recv_bytes;
-            }
-
-            need_wrap_continuation = false;
-        };
-
-        let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;
-        let poll_at = socket.poll_at(iface.context_mut());
-        let need_poll = iface.update_next_poll_at_ms(&self.0, poll_at);
-
-        Ok((result, need_poll))
-    }
-
-    /// Peeks some data.
-    ///
-    /// Polling the iface _may_ be required after this method succeeds.
-    pub fn peek<F, CopyErr>(
-        &self,
-        f: F,
-        max_len: usize,
-    ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<RecvError, CopyErr>>
-    where
-        F: FnOnce(&[u8]) -> Result<usize, (CopyErr, usize)>,
-    {
-        let common = self.iface().common();
-        let mut iface = common.interface();
-
-        let mut socket = self.0.inner.lock();
-
-        if socket.is_recv_shut && socket.recv_queue() == 0 {
-            return Err(IoError::Socket(RecvError::Finished));
-        }
-
-        let recv_len = socket.recv_queue().min(max_len);
-        let result = match socket.peek(recv_len) {
-            Ok(socket_buffer) if socket_buffer.len() == recv_len => f(socket_buffer),
-            Ok(_) => {
-                let mut socket_buffer = vec![0; recv_len];
-                let peeked_len = socket.peek_slice(&mut socket_buffer)?;
-                f(&socket_buffer[..peeked_len])
-            }
-            Err(err) => {
-                if socket.is_rst_closed {
-                    socket.is_rst_closed = false;
-                    return Err(IoError::Socket(RecvError::ConnReset));
-                }
-                return Err(err.into());
-            }
-        };
-
-        let result = match result {
-            Ok(recv_bytes) => recv_bytes,
-            Err((err, recv_bytes)) => {
-                if recv_bytes == 0 {
-                    return Err(IoError::Copy(err));
-                }
-                recv_bytes
-            }
+        let result = if receive_behavior == ReceiveBehavior::Peek {
+            socket.recv_with_peek(max_len, &mut f)?
+        } else {
+            socket.recv_without_peek(receive_behavior, max_len, &mut f)?
         };
 
         let result = NonZeroUsize::new(result).ok_or(IoError::NoProgress)?;

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -179,6 +179,21 @@ impl<E: Ext> UdpSocket<E> {
         Ok(result)
     }
 
+    /// Peeks some data.
+    ///
+    /// Polling the iface is _not_ required after this method succeeds.
+    pub fn peek<F, R>(&self, f: F) -> Result<R, smoltcp::socket::udp::RecvError>
+    where
+        F: FnOnce(&[u8], UdpMetadata) -> R,
+    {
+        let mut socket = self.0.inner.socket.lock();
+
+        let (data, meta) = socket.peek()?;
+        let result = f(data, *meta);
+
+        Ok(result)
+    }
+
     /// Calls `f` with an immutable reference to the associated [`RawUdpSocket`].
     //
     // NOTE: If a mutable reference is required, add a method above that correctly updates the next

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -11,7 +11,7 @@ use smoltcp::{
     wire::{IpRepr, UdpRepr},
 };
 
-use super::common::{Inner, Socket, SocketBg};
+use super::common::{Inner, ReceiveBehavior, Socket, SocketBg};
 use crate::{
     errors::udp::SendError,
     ext::Ext,
@@ -167,29 +167,29 @@ impl<E: Ext> UdpSocket<E> {
     /// Receives some data.
     ///
     /// Polling the iface is _not_ required after this method succeeds.
-    pub fn recv<F, R>(&self, f: F) -> Result<R, smoltcp::socket::udp::RecvError>
+    pub fn recv<F, R>(
+        &self,
+        receive_behavior: ReceiveBehavior,
+        f: F,
+    ) -> Result<R, smoltcp::socket::udp::RecvError>
     where
         F: FnOnce(&[u8], UdpMetadata) -> R,
     {
         let mut socket = self.0.inner.socket.lock();
 
-        let (data, meta) = socket.recv()?;
-        let result = f(data, meta);
-
-        Ok(result)
-    }
-
-    /// Peeks some data.
-    ///
-    /// Polling the iface is _not_ required after this method succeeds.
-    pub fn peek<F, R>(&self, f: F) -> Result<R, smoltcp::socket::udp::RecvError>
-    where
-        F: FnOnce(&[u8], UdpMetadata) -> R,
-    {
-        let mut socket = self.0.inner.socket.lock();
-
-        let (data, meta) = socket.peek()?;
-        let result = f(data, *meta);
+        let result = match receive_behavior {
+            ReceiveBehavior::Normal | ReceiveBehavior::Discard => {
+                // UDP receives a whole datagram at once. `Discard` does not need a separate
+                // socket operation because the callback can observe the datagram length without
+                // copying from `data`.
+                let (data, meta) = socket.recv()?;
+                f(data, meta)
+            }
+            ReceiveBehavior::Peek => {
+                let (data, meta) = socket.peek()?;
+                f(data, *meta)
+            }
+        };
 
         Ok(result)
     }

--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -6,7 +6,8 @@ mod option;
 mod unbound;
 
 pub use bound::{
-    ConnectState, NeedIfacePoll, RawTcpSocketExt, TcpConnection, TcpListener, UdpSocket,
+    ConnectState, NeedIfacePoll, RawTcpSocketExt, ReceiveBehavior, TcpConnection, TcpListener,
+    UdpSocket,
 };
 pub(crate) use bound::{TcpConnectionBg, TcpListenerBg, TcpProcessResult, UdpSocketBg};
 pub use event::{SocketEventObserver, SocketEvents};

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -2,6 +2,7 @@
 
 use aster_bigtcp::{
     errors::udp::{RecvError, SendError},
+    socket::ReceiveBehavior,
     wire::IpEndpoint,
 };
 
@@ -9,7 +10,7 @@ use crate::{
     events::IoEvents,
     net::{
         iface::{BoundPort, Iface, UdpSocket},
-        socket::util::{SendRecvFlags, datagram_common},
+        socket::util::{SendRecvFlags, datagram_common, recv_output_flags, recv_result_len},
     },
     prelude::*,
     util::{MultiRead, MultiWrite},
@@ -56,28 +57,30 @@ impl datagram_common::Bound for BoundDatagram {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
+        output_flags: &mut SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
-        let result = if flags.contains(SendRecvFlags::MSG_PEEK) {
-            self.bound_socket.peek(|packet, udp_metadata| {
-                let copied_res = writer
-                    .write(&mut VmReader::from(packet))
-                    .map_err(Into::into);
-                let endpoint = udp_metadata.endpoint;
-                (copied_res, endpoint)
-            })
+        let receive_behavior = if flags.contains(SendRecvFlags::MSG_PEEK) {
+            ReceiveBehavior::Peek
         } else {
-            self.bound_socket.recv(|packet, udp_metadata| {
+            ReceiveBehavior::Normal
+        };
+        let result = self
+            .bound_socket
+            .recv(receive_behavior, |packet, udp_metadata| {
+                let message_len = packet.len();
                 let copied_res = writer
                     .write(&mut VmReader::from(packet))
                     .map_err(Into::into);
                 let endpoint = udp_metadata.endpoint;
-                (copied_res, endpoint)
-            })
-        };
+                (copied_res, endpoint, message_len)
+            });
 
         match result {
-            Ok((Ok(res), endpoint)) => Ok((res, endpoint)),
-            Ok((Err(e), _)) => Err(e),
+            Ok((Ok(copied_len), endpoint, message_len)) => {
+                *output_flags = recv_output_flags(copied_len, message_len);
+                Ok((recv_result_len(flags, copied_len, message_len), endpoint))
+            }
+            Ok((Err(e), _, _)) => Err(e),
             Err(RecvError::Exhausted) => {
                 return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
             }

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -55,15 +55,25 @@ impl datagram_common::Bound for BoundDatagram {
     fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
-        let result = self.bound_socket.recv(|packet, udp_metadata| {
-            let copied_res = writer
-                .write(&mut VmReader::from(packet))
-                .map_err(Into::into);
-            let endpoint = udp_metadata.endpoint;
-            (copied_res, endpoint)
-        });
+        let result = if flags.contains(SendRecvFlags::MSG_PEEK) {
+            self.bound_socket.peek(|packet, udp_metadata| {
+                let copied_res = writer
+                    .write(&mut VmReader::from(packet))
+                    .map_err(Into::into);
+                let endpoint = udp_metadata.endpoint;
+                (copied_res, endpoint)
+            })
+        } else {
+            self.bound_socket.recv(|packet, udp_metadata| {
+                let copied_res = writer
+                    .write(&mut VmReader::from(packet))
+                    .map_err(Into::into);
+                let endpoint = udp_metadata.endpoint;
+                (copied_res, endpoint)
+            })
+        };
 
         match result {
             Ok((Ok(res), endpoint)) => Ok((res, endpoint)),

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -74,12 +74,15 @@ impl DatagramSocket {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
-    ) -> Result<(usize, SocketAddr)> {
+    ) -> Result<(usize, SocketAddr, SendRecvFlags)> {
+        let mut output_flags = SendRecvFlags::empty();
         let recv_bytes = self
             .inner
             .read()
-            .try_recv(writer, flags)
-            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
+            .try_recv(writer, flags, &mut output_flags)
+            .map(|(recv_bytes, remote_endpoint)| {
+                (recv_bytes, remote_endpoint.into(), output_flags)
+            })?;
         self.pollee.invalidate();
 
         Ok(recv_bytes)
@@ -192,6 +195,7 @@ impl Socket for DatagramSocket {
         let MessageHeader {
             addr,
             control_messages,
+            ..
         } = message_header;
 
         let endpoint = match addr {
@@ -228,12 +232,13 @@ impl Socket for DatagramSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let (received_bytes, peer_addr) =
+        let (received_bytes, peer_addr, output_flags) =
             self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
 
         // TODO: Receive control message
 
-        let message_header = MessageHeader::new(Some(peer_addr), Vec::new());
+        let message_header =
+            MessageHeader::new_with_flags(Some(peer_addr), Vec::new(), output_flags);
 
         Ok((received_bytes, message_header))
     }

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -72,11 +72,18 @@ impl ConnectedStream {
     pub(super) fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, NeedIfacePoll)> {
-        let result = self
-            .tcp_conn
-            .recv(|socket_buffer| writer.write(&mut VmReader::from(&*socket_buffer)));
+        let result = if flags.contains(SendRecvFlags::MSG_PEEK) {
+            let writer_len = writer.sum_lens();
+            self.tcp_conn.peek(
+                |socket_buffer| writer.write(&mut VmReader::from(socket_buffer)),
+                writer_len,
+            )
+        } else {
+            self.tcp_conn
+                .recv(|socket_buffer| writer.write(&mut VmReader::from(&*socket_buffer)))
+        };
 
         match result {
             Ok((recv_bytes, need_poll)) => Ok((recv_bytes.get(), need_poll)),

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::convert::Infallible;
+
 use aster_bigtcp::{
     errors::tcp::{IoError, RecvError, SendError},
-    socket::{NeedIfacePoll, RawTcpSetOption},
+    socket::{NeedIfacePoll, RawTcpSetOption, ReceiveBehavior},
     wire::IpEndpoint,
 };
 
@@ -74,16 +76,48 @@ impl ConnectedStream {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, NeedIfacePoll)> {
-        let result = if flags.contains(SendRecvFlags::MSG_PEEK) {
-            let writer_len = writer.sum_lens();
-            self.tcp_conn.peek(
-                |socket_buffer| writer.write(&mut VmReader::from(socket_buffer)),
-                writer_len,
-            )
+        if flags.contains(SendRecvFlags::MSG_TRUNC) {
+            let receive_behavior = if flags.contains(SendRecvFlags::MSG_PEEK) {
+                ReceiveBehavior::Peek
+            } else {
+                ReceiveBehavior::Discard
+            };
+            let result = self.tcp_conn.recv::<_, Infallible>(
+                receive_behavior,
+                writer.sum_lens(),
+                |socket_buffer| Ok(socket_buffer.len()),
+            );
+
+            return match result {
+                Ok((recv_bytes, need_poll)) => Ok((recv_bytes.get(), need_poll)),
+                Err(IoError::NoProgress) => {
+                    return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty")
+                }
+                Err(IoError::Copy(err)) => match err {},
+                Err(IoError::Socket(RecvError::Finished | RecvError::InvalidState)) => {
+                    Ok((0, NeedIfacePoll::FALSE))
+                }
+                Err(IoError::Socket(RecvError::ConnReset)) => {
+                    return_errno_with_message!(Errno::ECONNRESET, "the connection is reset")
+                }
+            };
+        }
+
+        let receive_behavior = if flags.contains(SendRecvFlags::MSG_PEEK) {
+            ReceiveBehavior::Peek
         } else {
-            self.tcp_conn
-                .recv(|socket_buffer| writer.write(&mut VmReader::from(&*socket_buffer)))
+            ReceiveBehavior::Normal
         };
+        let max_len = if receive_behavior == ReceiveBehavior::Peek {
+            writer.sum_lens()
+        } else {
+            usize::MAX
+        };
+        let result = self
+            .tcp_conn
+            .recv(receive_behavior, max_len, |socket_buffer| {
+                writer.write(&mut VmReader::from(socket_buffer))
+            });
 
         match result {
             Ok((recv_bytes, need_poll)) => Ok((recv_bytes.get(), need_poll)),

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -94,12 +94,15 @@ where
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
-    ) -> Result<(usize, SocketAddr)> {
+    ) -> Result<(usize, SocketAddr, SendRecvFlags)> {
+        let mut output_flags = SendRecvFlags::empty();
         let recv_bytes = self
             .inner
             .read()
-            .try_recv(writer, flags)
-            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
+            .try_recv(writer, flags, &mut output_flags)
+            .map(|(recv_bytes, remote_endpoint)| {
+                (recv_bytes, remote_endpoint.into(), output_flags)
+            })?;
         self.pollee.invalidate();
 
         Ok(recv_bytes)
@@ -151,6 +154,7 @@ where
         let MessageHeader {
             addr,
             control_messages,
+            ..
         } = message_header;
 
         let remote = match addr {
@@ -177,11 +181,12 @@ where
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, MessageHeader)> {
-        let (received_len, addr) = self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+        let (received_len, addr, output_flags) =
+            self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
 
         // TODO: Receive control message
 
-        let message_header = MessageHeader::new(Some(addr), Vec::new());
+        let message_header = MessageHeader::new_with_flags(Some(addr), Vec::new(), output_flags);
 
         Ok((received_len, message_header))
     }

--- a/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::Sub;
-
 use super::message::UeventMessage;
 use crate::{
     events::IoEvents,
     net::socket::{
         netlink::{NetlinkSocketAddr, common::BoundNetlink},
-        util::{SendRecvFlags, datagram_common},
+        util::{SendRecvFlags, datagram_common, recv_output_flags, recv_result_len},
     },
     prelude::*,
     util::{MultiRead, MultiWrite},
@@ -61,17 +59,20 @@ impl datagram_common::Bound for BoundNetlinkUevent {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
+        output_flags: &mut SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
-        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
-        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+        // TODO: Deal with other flags.
+        if !flags.is_all_supported() {
             warn!("unsupported flags: {:?}", flags);
         }
 
         let mut receive_queue = self.receive_queue.lock();
 
         receive_queue.dequeue_if(|response, response_len| {
-            let len = response_len.min(writer.sum_lens());
+            let copied_len = response_len.min(writer.sum_lens());
             response.write_to(writer)?;
+            *output_flags = recv_output_flags(copied_len, response_len);
+            let len = recv_result_len(flags, copied_len, response_len);
 
             let remote = *response.src_addr();
 

--- a/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
@@ -81,7 +81,7 @@ fn multicast_synthetic_uevent() {
         UeventMessage::new(uevent, NetlinkSocketAddr::new(0, GroupIdSet::new(0x1)));
     NetlinkUeventProtocol::multicast(GroupIdSet::new(0x1), uevent_message).unwrap();
 
-    let (len, _) = socket
+    let (len, _, _) = socket
         .try_recv(&mut writer, SendRecvFlags::empty())
         .unwrap();
     let s = core::str::from_utf8(&buffer[..len]).unwrap();

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::Sub;
-
 use super::message::{RtnlMessage, RtnlSegment};
 use crate::{
     events::IoEvents,
@@ -12,7 +10,7 @@ use crate::{
             message::{ContinueRead, ProtocolSegment},
             route::kernel::get_netlink_route_kernel,
         },
-        util::{SendRecvFlags, datagram_common},
+        util::{SendRecvFlags, datagram_common, recv_output_flags, recv_result_len},
     },
     prelude::*,
     util::{MultiRead, MultiWrite},
@@ -101,17 +99,20 @@ impl datagram_common::Bound for BoundNetlinkRoute {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
+        output_flags: &mut SendRecvFlags,
     ) -> Result<(usize, NetlinkSocketAddr)> {
-        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
-        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+        // TODO: Deal with other flags.
+        if !flags.is_all_supported() {
             warn!("unsupported flags: {:?}", flags);
         }
 
         let mut receive_queue = self.receive_queue.lock();
 
         receive_queue.dequeue_if(|response, response_len| {
-            let len = response_len.min(writer.sum_lens());
+            let copied_len = response_len.min(writer.sum_lens());
             response.write_to(writer)?;
+            *output_flags = recv_output_flags(copied_len, response_len);
+            let len = recv_result_len(flags, copied_len, response_len);
 
             // TODO: The message can only come from kernel socket currently.
             let remote = NetlinkSocketAddr::new_unspecified();

--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -274,50 +274,40 @@ impl AuxiliaryData {
 
     /// Generates the control messages from the auxiliary data.
     pub(super) fn generate_control(&mut self, is_pass_cred: bool) -> Vec<ControlMessage> {
-        let mut ctrl_msgs = Vec::new();
+        let files = (!self.files.is_empty()).then(|| FileMessage {
+            files: core::mem::take(&mut self.files),
+        });
 
-        let Self { files, cred } = self;
-
-        if is_pass_cred {
-            let unix_ctrl_msg = UnixControlMessage(Message::Cred(CredMessage {
-                cred: cred
-                    .as_ref()
-                    .map(SocketCred::to_real_c_cred)
-                    .unwrap_or_else(CUserCred::new_overflow),
-            }));
-            ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
-        }
-
-        if !files.is_empty() {
-            let unix_ctrl_msg = UnixControlMessage(Message::Files(FileMessage {
-                files: core::mem::take(files),
-            }));
-            ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
-        }
-
-        ctrl_msgs
+        Self::generate_control_from_parts(self.cred.as_ref(), files, is_pass_cred)
     }
 
     /// Generates the control messages without consuming the auxiliary data.
     pub(super) fn generate_control_cloned(&self, is_pass_cred: bool) -> Vec<ControlMessage> {
-        let mut ctrl_msgs = Vec::new();
+        let files = (!self.files.is_empty()).then(|| FileMessage {
+            files: self.files.clone(),
+        });
 
-        let Self { files, cred } = self;
+        Self::generate_control_from_parts(self.cred.as_ref(), files, is_pass_cred)
+    }
+
+    fn generate_control_from_parts(
+        cred: Option<&SocketCred>,
+        files: Option<FileMessage>,
+        is_pass_cred: bool,
+    ) -> Vec<ControlMessage> {
+        let mut ctrl_msgs = Vec::new();
 
         if is_pass_cred {
             let unix_ctrl_msg = UnixControlMessage(Message::Cred(CredMessage {
                 cred: cred
-                    .as_ref()
                     .map(SocketCred::to_real_c_cred)
                     .unwrap_or_else(CUserCred::new_overflow),
             }));
             ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
         }
 
-        if !files.is_empty() {
-            let unix_ctrl_msg = UnixControlMessage(Message::Files(FileMessage {
-                files: files.clone(),
-            }));
+        if let Some(files) = files {
+            let unix_ctrl_msg = UnixControlMessage(Message::Files(files));
             ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
         }
 

--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -298,6 +298,32 @@ impl AuxiliaryData {
         ctrl_msgs
     }
 
+    /// Generates the control messages without consuming the auxiliary data.
+    pub(super) fn generate_control_cloned(&self, is_pass_cred: bool) -> Vec<ControlMessage> {
+        let mut ctrl_msgs = Vec::new();
+
+        let Self { files, cred } = self;
+
+        if is_pass_cred {
+            let unix_ctrl_msg = UnixControlMessage(Message::Cred(CredMessage {
+                cred: cred
+                    .as_ref()
+                    .map(SocketCred::to_real_c_cred)
+                    .unwrap_or_else(CUserCred::new_overflow),
+            }));
+            ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
+        }
+
+        if !files.is_empty() {
+            let unix_ctrl_msg = UnixControlMessage(Message::Files(FileMessage {
+                files: files.clone(),
+            }));
+            ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
+        }
+
+        ctrl_msgs
+    }
+
     /// Returns whether the auxiliary data contains nothing.
     pub(super) fn is_empty(&self) -> bool {
         self.files.is_empty() && self.cred.is_none()

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -17,7 +17,7 @@ use crate::{
             addr::{UnixSocketAddrBound, UnixSocketAddrKey},
             ctrl_msg::AuxiliaryData,
         },
-        util::{ControlMessage, SendRecvFlags},
+        util::{ControlMessage, SendRecvFlags, recv_output_flags, recv_result_len},
     },
     prelude::*,
     process::signal::Pollee,
@@ -168,7 +168,7 @@ impl MessageReceiver {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
-    ) -> Result<(usize, Vec<ControlMessage>, UnixSocketAddr)> {
+    ) -> Result<(usize, Vec<ControlMessage>, UnixSocketAddr, SendRecvFlags)> {
         let mut inner = self.queue.inner.lock();
         let inner = inner.as_mut().unwrap();
 
@@ -176,14 +176,18 @@ impl MessageReceiver {
             if !inner.is_shutdown {
                 return_errno_with_message!(Errno::EAGAIN, "the receive buffer is empty");
             } else {
-                return Ok((0, Vec::new(), UnixSocketAddr::Unnamed));
+                return Ok((
+                    0,
+                    Vec::new(),
+                    UnixSocketAddr::Unnamed,
+                    SendRecvFlags::empty(),
+                ));
             }
         };
 
+        let message_len = msg.bytes.len();
         let len = writer.write(&mut VmReader::from(msg.bytes.as_slice()))?;
-        if len != msg.bytes.len() {
-            warn!("setting MSG_TRUNC is not supported");
-        }
+        let output_flags = recv_output_flags(len, message_len);
 
         let is_pass_cred = self.queue.is_pass_cred.load(Ordering::Relaxed);
         let src = msg.src.clone();
@@ -201,7 +205,12 @@ impl MessageReceiver {
             msg.aux.generate_control(is_pass_cred)
         };
 
-        Ok((len, ctrl_msgs, src))
+        Ok((
+            recv_result_len(flags, len, message_len),
+            ctrl_msgs,
+            src,
+            output_flags,
+        ))
     }
 
     pub(super) fn shutdown(&self) {

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -17,7 +17,7 @@ use crate::{
             addr::{UnixSocketAddrBound, UnixSocketAddrKey},
             ctrl_msg::AuxiliaryData,
         },
-        util::ControlMessage,
+        util::{ControlMessage, SendRecvFlags},
     },
     prelude::*,
     process::signal::Pollee,
@@ -167,6 +167,7 @@ impl MessageReceiver {
     pub(super) fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>, UnixSocketAddr)> {
         let mut inner = self.queue.inner.lock();
         let inner = inner.as_mut().unwrap();
@@ -184,18 +185,23 @@ impl MessageReceiver {
             warn!("setting MSG_TRUNC is not supported");
         }
 
-        let mut msg = inner.messages.pop_front().unwrap();
-        inner.total_length -= msg.bytes.len();
-
         let is_pass_cred = self.queue.is_pass_cred.load(Ordering::Relaxed);
-        let ctrl_msgs = msg.aux.generate_control(is_pass_cred);
+        let src = msg.src.clone();
 
-        self.queue.pollee.invalidate();
-        // A writer may still fail if the free space is not enough.
-        // So we have to wake up all the writers here.
-        self.queue.send_wait_queue.wake_all();
+        let ctrl_msgs = if flags.contains(SendRecvFlags::MSG_PEEK) {
+            msg.aux.generate_control_cloned(is_pass_cred)
+        } else {
+            let mut msg = inner.messages.pop_front().unwrap();
+            inner.total_length -= msg.bytes.len();
 
-        Ok((len, ctrl_msgs, msg.src))
+            self.queue.pollee.invalidate();
+            // A writer may still fail if the free space is not enough.
+            // So we have to wake up all the writers here.
+            self.queue.send_wait_queue.wake_all();
+            msg.aux.generate_control(is_pass_cred)
+        };
+
+        Ok((len, ctrl_msgs, src))
     }
 
     pub(super) fn shutdown(&self) {

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -291,7 +291,7 @@ impl Socket for UnixDatagramSocket {
         }
 
         let (received_bytes, control_messages, peer_addr) =
-            self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer))?;
+            self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer, flags))?;
 
         let message_header = MessageHeader::new(Some(peer_addr.into()), control_messages);
 

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -268,6 +268,7 @@ impl Socket for UnixDatagramSocket {
         let MessageHeader {
             addr,
             control_messages,
+            ..
         } = message_header;
 
         let remote_addr = match addr {
@@ -290,10 +291,11 @@ impl Socket for UnixDatagramSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let (received_bytes, control_messages, peer_addr) =
+        let (received_bytes, control_messages, peer_addr, output_flags) =
             self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer, flags))?;
 
-        let message_header = MessageHeader::new(Some(peer_addr.into()), control_messages);
+        let message_header =
+            MessageHeader::new_with_flags(Some(peer_addr.into()), control_messages, output_flags);
 
         Ok((received_bytes, message_header))
     }

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -14,7 +14,9 @@ use crate::{
         unix::{
             UnixSocketAddr, addr::UnixSocketAddrBound, cred::SocketCred, ctrl_msg::AuxiliaryData,
         },
-        util::{ControlMessage, SendRecvFlags, SockShutdownCmd},
+        util::{
+            ControlMessage, SendRecvFlags, SockShutdownCmd, recv_output_flags, recv_result_len,
+        },
     },
     prelude::*,
     process::signal::Pollee,
@@ -118,13 +120,13 @@ impl Connected {
         writer: &mut dyn MultiWrite,
         is_seqpacket: bool,
         flags: SendRecvFlags,
-    ) -> Result<(usize, Vec<ControlMessage>)> {
+    ) -> Result<(usize, Vec<ControlMessage>, SendRecvFlags)> {
         let is_empty = writer.is_empty();
         if is_empty && !is_seqpacket {
             if self.inner.this_end().reader.lock().is_empty() {
                 return_errno_with_message!(Errno::EAGAIN, "the channel is empty");
             }
-            return Ok((0, Vec::new()));
+            return Ok((0, Vec::new(), SendRecvFlags::empty()));
         }
 
         let this_end = self.inner.this_end();
@@ -150,7 +152,7 @@ impl Connected {
             } else {
                 Vec::new()
             };
-            return Ok((read_len, ctrl_msgs));
+            return Ok((read_len, ctrl_msgs, SendRecvFlags::empty()));
         }
 
         let mut all_aux = peer_end.all_aux.lock();
@@ -169,12 +171,23 @@ impl Connected {
             };
             let read_len = reader.peek_fallible_with_max_len(writer, message_len)?;
             let ctrl_msgs = aux_data.generate_control_cloned(is_pass_cred);
+            let output_flags = if is_seqpacket {
+                recv_output_flags(read_len, message_len)
+            } else {
+                SendRecvFlags::empty()
+            };
+            let result_len = if is_seqpacket {
+                recv_result_len(flags, read_len, message_len)
+            } else {
+                read_len
+            };
 
-            return Ok((read_len, ctrl_msgs));
+            return Ok((result_len, ctrl_msgs, output_flags));
         }
 
         let mut aux_prev_data: Option<AuxiliaryData> = None;
         let mut read_tot_len = 0;
+        let mut message_len = 0;
 
         let aux_data = loop {
             let read_start = reader.head();
@@ -218,9 +231,9 @@ impl Connected {
             // Record the current auxiliary data. Break if the read is incomplete or this is a
             // `SOCK_SEQPACKET` socket.
             if is_seqpacket {
+                message_len = aux_len;
                 aux_prev_data = Some(all_aux.pop_front().unwrap().data);
                 if read_len < aux_len {
-                    warn!("setting MSG_TRUNC is not supported");
                     reader.skip(aux_len - read_len);
                 }
                 break aux_prev_data.as_mut().unwrap();
@@ -246,7 +259,18 @@ impl Connected {
             .has_aux
             .store(!all_aux.is_empty(), Ordering::Relaxed);
 
-        Ok((read_tot_len, ctrl_msgs))
+        let output_flags = if is_seqpacket {
+            recv_output_flags(read_tot_len, message_len)
+        } else {
+            SendRecvFlags::empty()
+        };
+        let result_len = if is_seqpacket {
+            recv_result_len(flags, read_tot_len, message_len)
+        } else {
+            read_tot_len
+        };
+
+        Ok((result_len, ctrl_msgs, output_flags))
     }
 
     pub(super) fn try_write(

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -14,7 +14,7 @@ use crate::{
         unix::{
             UnixSocketAddr, addr::UnixSocketAddrBound, cred::SocketCred, ctrl_msg::AuxiliaryData,
         },
-        util::{ControlMessage, SockShutdownCmd},
+        util::{ControlMessage, SendRecvFlags, SockShutdownCmd},
     },
     prelude::*,
     process::signal::Pollee,
@@ -117,6 +117,7 @@ impl Connected {
         &self,
         writer: &mut dyn MultiWrite,
         is_seqpacket: bool,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>)> {
         let is_empty = writer.is_empty();
         if is_empty && !is_seqpacket {
@@ -138,9 +139,12 @@ impl Connected {
 
         // Fast path: There are no auxiliary data to receive.
         if !peer_end.has_aux.load(Ordering::Relaxed) {
-            let read_len = self
-                .inner
-                .read_with(move || reader.read_fallible_with_max_len(writer, no_aux_len))?;
+            let read_len = if flags.contains(SendRecvFlags::MSG_PEEK) {
+                reader.peek_fallible_with_max_len(writer, no_aux_len)?
+            } else {
+                self.inner
+                    .read_with(move || reader.read_fallible_with_max_len(writer, no_aux_len))?
+            };
             let ctrl_msgs = if is_pass_cred {
                 AuxiliaryData::default().generate_control(is_pass_cred)
             } else {
@@ -150,6 +154,25 @@ impl Connected {
         }
 
         let mut all_aux = peer_end.all_aux.lock();
+
+        if flags.contains(SendRecvFlags::MSG_PEEK) {
+            let read_start = reader.head();
+            let default_aux = AuxiliaryData::default();
+            let (message_len, aux_data) = if let Some(front) = all_aux.front() {
+                if front.start == read_start {
+                    ((front.end - read_start).0, &front.data)
+                } else {
+                    ((front.start - read_start).0, &default_aux)
+                }
+            } else {
+                (reader.len(), &default_aux)
+            };
+            let read_len = reader.peek_fallible_with_max_len(writer, message_len)?;
+            let ctrl_msgs = aux_data.generate_control_cloned(is_pass_cred);
+
+            return Ok((read_len, ctrl_msgs));
+        }
+
         let mut aux_prev_data: Option<AuxiliaryData> = None;
         let mut read_tot_len = 0;
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -229,10 +229,10 @@ impl UnixStreamSocket {
     fn try_recv(
         &self,
         buf: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>)> {
         match self.state.read().as_ref() {
-            State::Connected(connected) => connected.try_read(buf, self.is_seqpacket),
+            State::Connected(connected) => connected.try_read(buf, self.is_seqpacket, flags),
             State::Init(_) | State::Listen(_) => {
                 return_errno_with_message!(Errno::EINVAL, "the socket is not connected")
             }

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -230,7 +230,7 @@ impl UnixStreamSocket {
         &self,
         buf: &mut dyn MultiWrite,
         flags: SendRecvFlags,
-    ) -> Result<(usize, Vec<ControlMessage>)> {
+    ) -> Result<(usize, Vec<ControlMessage>, SendRecvFlags)> {
         match self.state.read().as_ref() {
             State::Connected(connected) => connected.try_read(buf, self.is_seqpacket, flags),
             State::Init(_) | State::Listen(_) => {
@@ -472,6 +472,7 @@ impl Socket for UnixStreamSocket {
         let MessageHeader {
             control_messages,
             addr,
+            ..
         } = message_header;
 
         // According to the Linux man pages, `EISCONN` _may_ be returned when the destination
@@ -506,10 +507,10 @@ impl Socket for UnixStreamSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let (received_bytes, control_messages) =
+        let (received_bytes, control_messages, output_flags) =
             self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
 
-        let message_header = MessageHeader::new(None, control_messages);
+        let message_header = MessageHeader::new_with_flags(None, control_messages, output_flags);
 
         Ok((received_bytes, message_header))
     }

--- a/kernel/src/net/socket/util/datagram_common.rs
+++ b/kernel/src/net/socket/util/datagram_common.rs
@@ -43,6 +43,7 @@ pub trait Bound {
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
+        output_flags: &mut SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)>;
     fn try_send(
         &self,
@@ -137,12 +138,13 @@ where
         &self,
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
+        output_flags: &mut SendRecvFlags,
     ) -> Result<(usize, UnboundSocket::Endpoint)> {
         match self {
             Inner::Unbound(_) => {
                 return_errno_with_message!(Errno::EAGAIN, "the socket is not bound");
             }
-            Inner::Bound(bound_datagram) => bound_datagram.try_recv(writer, flags),
+            Inner::Bound(bound_datagram) => bound_datagram.try_recv(writer, flags, output_flags),
         }
     }
 

--- a/kernel/src/net/socket/util/message_header.rs
+++ b/kernel/src/net/socket/util/message_header.rs
@@ -2,7 +2,7 @@
 
 use align_ext::AlignExt;
 
-use super::SocketAddr;
+use super::{SendRecvFlags, SocketAddr};
 use crate::{net::socket::unix::UnixControlMessage, prelude::*, util::net::CSocketOptionLevel};
 
 /// Message header used for sendmsg/recvmsg.
@@ -10,6 +10,7 @@ use crate::{net::socket::unix::UnixControlMessage, prelude::*, util::net::CSocke
 pub struct MessageHeader {
     pub(in crate::net) addr: Option<SocketAddr>,
     pub(in crate::net) control_messages: Vec<ControlMessage>,
+    pub(in crate::net) flags: SendRecvFlags,
 }
 
 impl MessageHeader {
@@ -18,6 +19,20 @@ impl MessageHeader {
         Self {
             addr,
             control_messages,
+            flags: SendRecvFlags::empty(),
+        }
+    }
+
+    /// Creates a new `MessageHeader` with receive output flags.
+    pub const fn new_with_flags(
+        addr: Option<SocketAddr>,
+        control_messages: Vec<ControlMessage>,
+        flags: SendRecvFlags,
+    ) -> Self {
+        Self {
+            addr,
+            control_messages,
+            flags,
         }
     }
 
@@ -29,6 +44,11 @@ impl MessageHeader {
     /// Returns the control messages.
     pub fn control_messages(&self) -> &Vec<ControlMessage> {
         &self.control_messages
+    }
+
+    /// Returns the output flags.
+    pub fn flags(&self) -> SendRecvFlags {
+        self.flags
     }
 }
 

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -13,6 +13,6 @@ pub use linger_option::LingerOption;
 pub(super) use message_header::CControlHeader;
 pub use message_header::{ControlMessage, MessageHeader};
 pub(super) use port_privilege::check_port_privilege;
-pub use send_recv_flags::SendRecvFlags;
+pub use send_recv_flags::{SendRecvFlags, recv_output_flags, recv_result_len};
 pub use shutdown_cmd::SockShutdownCmd;
 pub use socket_addr::SocketAddr;

--- a/kernel/src/net/socket/util/send_recv_flags.rs
+++ b/kernel/src/net/socket/util/send_recv_flags.rs
@@ -37,7 +37,7 @@ bitflags! {
 
 impl SendRecvFlags {
     fn supported_flags() -> Self {
-        SendRecvFlags::empty()
+        SendRecvFlags::MSG_PEEK
     }
 
     pub fn is_all_supported(&self) -> bool {

--- a/kernel/src/net/socket/util/send_recv_flags.rs
+++ b/kernel/src/net/socket/util/send_recv_flags.rs
@@ -37,11 +37,29 @@ bitflags! {
 
 impl SendRecvFlags {
     fn supported_flags() -> Self {
-        SendRecvFlags::MSG_PEEK
+        SendRecvFlags::MSG_PEEK | SendRecvFlags::MSG_TRUNC
     }
 
     pub fn is_all_supported(&self) -> bool {
         let supported_flags = Self::supported_flags();
         supported_flags.contains(*self)
+    }
+}
+
+/// Returns the receive length visible to user space.
+pub fn recv_result_len(flags: SendRecvFlags, copied_len: usize, message_len: usize) -> usize {
+    if flags.contains(SendRecvFlags::MSG_TRUNC) {
+        message_len
+    } else {
+        copied_len
+    }
+}
+
+/// Returns flags that describe how the message was received.
+pub fn recv_output_flags(copied_len: usize, message_len: usize) -> SendRecvFlags {
+    if copied_len < message_len {
+        SendRecvFlags::MSG_TRUNC
+    } else {
+        SendRecvFlags::empty()
     }
 }

--- a/kernel/src/net/socket/vsock/stream/mod.rs
+++ b/kernel/src/net/socket/vsock/stream/mod.rs
@@ -370,6 +370,7 @@ impl Socket for VsockStreamSocket {
         let MessageHeader {
             control_messages,
             addr,
+            ..
         } = message_header;
 
         // According to the Linux man pages, `EISCONN` _may_ be returned when the destination

--- a/kernel/src/net/socket/vsock/transport/connection/recv.rs
+++ b/kernel/src/net/socket/vsock/transport/connection/recv.rs
@@ -19,7 +19,7 @@ impl Connection {
     pub(in crate::net::socket::vsock) fn try_recv(
         &mut self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<usize> {
         // We use a packet-pool approach here so a receive attempt either completes for the chosen
         // packets or leaves the receive queue unchanged.
@@ -50,13 +50,20 @@ impl Connection {
         // Packets can only be received from a `&mut connection`. Therefore, releasing the state
         // lock does not cause race conditions. We need to release the lock in order to copy to
         // userspace.
-        let result = packets.copy_to_userspace(writer);
+        let is_peek = flags.contains(SendRecvFlags::MSG_PEEK);
+        let result = if is_peek {
+            packets.copy_to_userspace_peek(writer)
+        } else {
+            packets.copy_to_userspace(writer)
+        };
         let recv_len = *result.as_ref().unwrap_or(&0);
 
-        self.inner
-            .state
-            .lock()
-            .ungrab_packets_and_finish_recv(&self.inner, packets, recv_len);
+        let mut state = self.inner.state.lock();
+        if is_peek {
+            state.undo_pop_rx_packets(packets);
+        } else {
+            state.ungrab_packets_and_finish_recv(&self.inner, packets, recv_len);
+        }
 
         self.inner.pollee.invalidate();
 
@@ -96,6 +103,29 @@ impl PoppedRxPackets<'_> {
 
         self.packets = &mut [];
         self.read_offset = 0;
+        Ok(total_write_len)
+    }
+
+    fn copy_to_userspace_peek(&self, writer: &mut dyn MultiWrite) -> Result<usize> {
+        let mut read_offset = self.read_offset;
+        let mut total_write_len = 0;
+
+        for packet in self.packets.iter() {
+            let packet = packet.as_ref().unwrap();
+
+            let mut payload = packet.payload();
+            payload.skip(read_offset);
+
+            let write_len = writer.write(&mut payload)?;
+            total_write_len += write_len;
+
+            if payload.has_remain() {
+                return Ok(total_write_len);
+            }
+
+            read_offset = 0;
+        }
+
         Ok(total_write_len)
     }
 

--- a/kernel/src/net/socket/vsock/transport/connection/recv.rs
+++ b/kernel/src/net/socket/vsock/transport/connection/recv.rs
@@ -50,16 +50,12 @@ impl Connection {
         // Packets can only be received from a `&mut connection`. Therefore, releasing the state
         // lock does not cause race conditions. We need to release the lock in order to copy to
         // userspace.
-        let is_peek = flags.contains(SendRecvFlags::MSG_PEEK);
-        let result = if is_peek {
-            packets.copy_to_userspace_peek(writer)
-        } else {
-            packets.copy_to_userspace(writer)
-        };
+        let receive_behavior = ReceiveBehavior::from_flags(flags);
+        let result = packets.receive(receive_behavior, writer);
         let recv_len = *result.as_ref().unwrap_or(&0);
 
         let mut state = self.inner.state.lock();
-        if is_peek {
+        if receive_behavior.is_peek() {
             state.undo_pop_rx_packets(packets);
         } else {
             state.ungrab_packets_and_finish_recv(&self.inner, packets, recv_len);
@@ -71,12 +67,51 @@ impl Connection {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReceiveBehavior {
+    Normal,
+    Peek,
+    Discard,
+    PeekDiscard,
+}
+
+impl ReceiveBehavior {
+    fn from_flags(flags: SendRecvFlags) -> Self {
+        match (
+            flags.contains(SendRecvFlags::MSG_PEEK),
+            flags.contains(SendRecvFlags::MSG_TRUNC),
+        ) {
+            (true, true) => Self::PeekDiscard,
+            (true, false) => Self::Peek,
+            (false, true) => Self::Discard,
+            (false, false) => Self::Normal,
+        }
+    }
+
+    fn is_peek(self) -> bool {
+        matches!(self, Self::Peek | Self::PeekDiscard)
+    }
+}
+
 struct PoppedRxPackets<'a> {
     packets: &'a mut [Option<RxPacket>],
     read_offset: usize,
 }
 
 impl PoppedRxPackets<'_> {
+    fn receive(
+        &mut self,
+        receive_behavior: ReceiveBehavior,
+        writer: &mut dyn MultiWrite,
+    ) -> Result<usize> {
+        match receive_behavior {
+            ReceiveBehavior::Normal => self.copy_to_userspace(writer),
+            ReceiveBehavior::Peek => self.copy_to_userspace_peek(writer),
+            ReceiveBehavior::Discard => Ok(self.skip_payload(writer.sum_lens())),
+            ReceiveBehavior::PeekDiscard => Ok(self.payload_len().min(writer.sum_lens())),
+        }
+    }
+
     fn copy_to_userspace(&mut self, writer: &mut dyn MultiWrite) -> Result<usize> {
         let mut read_offset = self.read_offset;
         let mut total_write_len = 0;
@@ -134,6 +169,52 @@ impl PoppedRxPackets<'_> {
         core::mem::swap(&mut self.packets, &mut packets);
         packets = &mut packets[n..];
         core::mem::swap(&mut self.packets, &mut packets);
+    }
+
+    fn skip_payload(&mut self, mut max_len: usize) -> usize {
+        let mut total_len = 0;
+        let mut read_offset = self.read_offset;
+
+        for (i, packet) in self.packets.iter().enumerate() {
+            let packet = packet.as_ref().unwrap();
+            let payload_len = packet.payload_len() - read_offset;
+            let skip_len = payload_len.min(max_len);
+
+            total_len += skip_len;
+            max_len -= skip_len;
+
+            if skip_len < payload_len {
+                read_offset += skip_len;
+                self.skip_packets(i);
+                self.read_offset = read_offset;
+                return total_len;
+            }
+
+            if max_len == 0 {
+                self.skip_packets(i + 1);
+                self.read_offset = 0;
+                return total_len;
+            }
+
+            read_offset = 0;
+        }
+
+        self.packets = &mut [];
+        self.read_offset = 0;
+        total_len
+    }
+
+    fn payload_len(&self) -> usize {
+        let mut total_len = 0;
+        let mut read_offset = self.read_offset;
+
+        for packet in self.packets.iter() {
+            let packet = packet.as_ref().unwrap();
+            total_len += packet.payload_len() - read_offset;
+            read_offset = 0;
+        }
+
+        total_len
     }
 }
 

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -50,6 +50,7 @@ pub fn sys_recvmsg(
     let control_messages = message_header.control_messages();
     c_user_msghdr.msg_controllen =
         c_user_msghdr.write_control_messages_to_user(control_messages, &user_space)? as _;
+    c_user_msghdr.msg_flags = message_header.flags().bits() as u32;
 
     user_space.write_val(user_msghdr_ptr, &c_user_msghdr)?;
 

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -79,6 +79,15 @@ pub trait ConsumerU8Ext {
         writer: &mut dyn MultiWrite,
         max_len: usize,
     ) -> Result<usize>;
+
+    /// Copies data from the ring buffer into `writer` without consuming it.
+    ///
+    /// Returns the number of bytes copied.
+    fn peek_fallible_with_max_len(
+        &self,
+        writer: &mut dyn MultiWrite,
+        max_len: usize,
+    ) -> Result<usize>;
 }
 
 impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
@@ -117,6 +126,35 @@ impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
 
         self.commit_read(read_len);
         Ok(read_len)
+    }
+
+    fn peek_fallible_with_max_len(
+        &self,
+        writer: &mut dyn MultiWrite,
+        max_len: usize,
+    ) -> Result<usize> {
+        let len = self.len().min(max_len);
+
+        let head = self.head();
+        let offset = head.0 & (self.capacity() - 1);
+
+        if offset + len > self.capacity() {
+            let mut read_len = 0;
+
+            let mut reader = self.segment().reader();
+            reader.skip(offset).limit(self.capacity() - offset);
+            read_len += writer.write(&mut reader)?;
+
+            let mut reader = self.segment().reader();
+            reader.limit(len - (self.capacity() - offset));
+            read_len += writer.write(&mut reader)?;
+
+            Ok(read_len)
+        } else {
+            let mut reader = self.segment().reader();
+            reader.skip(offset).limit(len);
+            Ok(writer.write(&mut reader)?)
+        }
     }
 }
 

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -100,30 +100,7 @@ impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
         writer: &mut dyn MultiWrite,
         max_len: usize,
     ) -> Result<usize> {
-        let len = self.len().min(max_len);
-
-        let head = self.head();
-        let offset = head.0 & (self.capacity() - 1);
-
-        let read_len = if offset + len > self.capacity() {
-            // Read from two separate parts
-            let mut read_len = 0;
-
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(self.capacity() - offset);
-            read_len += writer.write(&mut reader)?;
-
-            let mut reader = self.segment().reader();
-            reader.limit(len - (self.capacity() - offset));
-            read_len += writer.write(&mut reader)?;
-
-            read_len
-        } else {
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(len);
-            writer.write(&mut reader)?
-        };
-
+        let read_len = copy_consumer_to_writer(self, writer, max_len)?;
         self.commit_read(read_len);
         Ok(read_len)
     }
@@ -133,28 +110,36 @@ impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
         writer: &mut dyn MultiWrite,
         max_len: usize,
     ) -> Result<usize> {
-        let len = self.len().min(max_len);
+        copy_consumer_to_writer(self, writer, max_len)
+    }
+}
 
-        let head = self.head();
-        let offset = head.0 & (self.capacity() - 1);
+fn copy_consumer_to_writer<R: Deref<Target = RingBuffer<u8>>>(
+    consumer: &Consumer<u8, R>,
+    writer: &mut dyn MultiWrite,
+    max_len: usize,
+) -> Result<usize> {
+    let len = consumer.len().min(max_len);
 
-        if offset + len > self.capacity() {
-            let mut read_len = 0;
+    let head = consumer.head();
+    let offset = head.0 & (consumer.capacity() - 1);
 
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(self.capacity() - offset);
-            read_len += writer.write(&mut reader)?;
+    if offset + len > consumer.capacity() {
+        let mut read_len = 0;
 
-            let mut reader = self.segment().reader();
-            reader.limit(len - (self.capacity() - offset));
-            read_len += writer.write(&mut reader)?;
+        let mut reader = consumer.segment().reader();
+        reader.skip(offset).limit(consumer.capacity() - offset);
+        read_len += writer.write(&mut reader)?;
 
-            Ok(read_len)
-        } else {
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(len);
-            Ok(writer.write(&mut reader)?)
-        }
+        let mut reader = consumer.segment().reader();
+        reader.limit(len - (consumer.capacity() - offset));
+        read_len += writer.write(&mut reader)?;
+
+        Ok(read_len)
+    } else {
+        let mut reader = consumer.segment().reader();
+        reader.skip(offset).limit(len);
+        Ok(writer.write(&mut reader)?)
     }
 }
 

--- a/test/initramfs/src/regression/network/msg_peek_trunc.c
+++ b/test/initramfs/src/regression/network/msg_peek_trunc.c
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define PAYLOAD "abcdef"
+#define PAYLOAD_LEN 6
+#define SHORT_LEN 3
+
+static int set_nonblocking(int fd)
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+
+	if (flags < 0) {
+		return -1;
+	}
+
+	return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static ssize_t recvmsg_with_flags(int fd, int flags, char *buf, size_t len,
+				  int *msg_flags)
+{
+	struct iovec iov = { .iov_base = buf, .iov_len = len };
+	struct msghdr msg = { .msg_iov = &iov, .msg_iovlen = 1 };
+	ssize_t ret = recvmsg(fd, &msg, flags);
+
+	*msg_flags = msg.msg_flags;
+	return ret;
+}
+
+static int open_unix_pair(int type, int *send_fd, int *recv_fd)
+{
+	int fds[2];
+
+	if (socketpair(AF_UNIX, type | SOCK_NONBLOCK, 0, fds) < 0) {
+		return -1;
+	}
+
+	*send_fd = fds[0];
+	*recv_fd = fds[1];
+	return 0;
+}
+
+static int open_tcp_pair(int *send_fd, int *recv_fd)
+{
+	int listener = -1;
+	int client = -1;
+	int server = -1;
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	listener = socket(AF_INET, SOCK_STREAM, 0);
+	client = socket(AF_INET, SOCK_STREAM, 0);
+	if (listener < 0 || client < 0) {
+		goto fail;
+	}
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if (bind(listener, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
+	    getsockname(listener, (struct sockaddr *)&addr, &addr_len) < 0 ||
+	    listen(listener, 1) < 0 ||
+	    connect(client, (struct sockaddr *)&addr, addr_len) < 0) {
+		goto fail;
+	}
+
+	server = accept(listener, NULL, NULL);
+	if (server < 0 || set_nonblocking(server) < 0) {
+		goto fail;
+	}
+
+	close(listener);
+	*send_fd = client;
+	*recv_fd = server;
+	return 0;
+
+fail:
+	if (listener >= 0) {
+		close(listener);
+	}
+	if (client >= 0) {
+		close(client);
+	}
+	if (server >= 0) {
+		close(server);
+	}
+	return -1;
+}
+
+static int open_udp_pair(int *send_fd, int *recv_fd)
+{
+	int sender = -1;
+	int receiver = -1;
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	sender = socket(AF_INET, SOCK_DGRAM, 0);
+	receiver = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+	if (sender < 0 || receiver < 0) {
+		goto fail;
+	}
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if (bind(receiver, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
+	    getsockname(receiver, (struct sockaddr *)&addr, &addr_len) < 0 ||
+	    connect(sender, (struct sockaddr *)&addr, addr_len) < 0) {
+		goto fail;
+	}
+
+	*send_fd = sender;
+	*recv_fd = receiver;
+	return 0;
+
+fail:
+	if (sender >= 0) {
+		close(sender);
+	}
+	if (receiver >= 0) {
+		close(receiver);
+	}
+	return -1;
+}
+
+static int test_msg_peek_connected(int send_fd, int recv_fd, int is_record)
+{
+	char buf[PAYLOAD_LEN] = {};
+	int msg_flags = 0;
+	size_t peek_len = is_record ? PAYLOAD_LEN : SHORT_LEN;
+	ssize_t ret;
+
+	if (send(send_fd, PAYLOAD, PAYLOAD_LEN, 0) != PAYLOAD_LEN) {
+		return -1;
+	}
+
+	ret = recvmsg_with_flags(recv_fd, MSG_PEEK, buf, peek_len, &msg_flags);
+	if (ret != (ssize_t)peek_len || (msg_flags & MSG_TRUNC) != 0 ||
+	    memcmp(buf, PAYLOAD, peek_len) != 0) {
+		return -1;
+	}
+
+	memset(buf, 0, sizeof(buf));
+	ret = recv(recv_fd, buf, sizeof(buf), 0);
+	if (ret != PAYLOAD_LEN || memcmp(buf, PAYLOAD, PAYLOAD_LEN) != 0) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int run_connected_socket_tests(int (*open_pair)(int *, int *),
+				      int is_record)
+{
+	int send_fd;
+	int recv_fd;
+	int ret;
+
+	if (open_pair(&send_fd, &recv_fd) < 0) {
+		return -1;
+	}
+	ret = test_msg_peek_connected(send_fd, recv_fd, is_record);
+	close(send_fd);
+	close(recv_fd);
+	return ret;
+}
+
+static int open_unix_stream_pair(int *send_fd, int *recv_fd)
+{
+	return open_unix_pair(SOCK_STREAM, send_fd, recv_fd);
+}
+
+static int open_unix_seqpacket_pair(int *send_fd, int *recv_fd)
+{
+	return open_unix_pair(SOCK_SEQPACKET, send_fd, recv_fd);
+}
+
+static int open_unix_datagram_pair(int *send_fd, int *recv_fd)
+{
+	return open_unix_pair(SOCK_DGRAM, send_fd, recv_fd);
+}
+
+static int open_unix_raw_pair(int *send_fd, int *recv_fd)
+{
+	return open_unix_pair(SOCK_RAW, send_fd, recv_fd);
+}
+
+static int open_netlink_route(int type)
+{
+	int fd = socket(AF_NETLINK, type | SOCK_NONBLOCK, NETLINK_ROUTE);
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+
+	if (fd < 0) {
+		return -1;
+	}
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+static int send_getlink_request(int fd, unsigned int seq)
+{
+	struct {
+		struct nlmsghdr hdr;
+		struct ifinfomsg info;
+	} req = {
+		.hdr = {
+			.nlmsg_len = sizeof(req),
+			.nlmsg_type = RTM_GETLINK,
+			.nlmsg_flags = NLM_F_REQUEST,
+			.nlmsg_seq = seq,
+		},
+		.info = {
+			.ifi_family = AF_UNSPEC,
+			.ifi_change = 0xffffffff,
+		},
+	};
+
+	return send(fd, &req, sizeof(req), 0) == sizeof(req) ? 0 : -1;
+}
+
+static int test_netlink_msg_peek(int type)
+{
+	int fd = open_netlink_route(type);
+	char peek_buf[8192] = {};
+	char recv_buf[8192] = {};
+	int msg_flags = 0;
+	ssize_t peek_len;
+	ssize_t recv_len;
+
+	if (fd < 0) {
+		return -1;
+	}
+	if (send_getlink_request(fd, 1) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	peek_len = recvmsg_with_flags(fd, MSG_PEEK, peek_buf, sizeof(peek_buf),
+				      &msg_flags);
+	if (peek_len <= 0 || (msg_flags & MSG_TRUNC) != 0) {
+		close(fd);
+		return -1;
+	}
+
+	recv_len = recv(fd, recv_buf, sizeof(recv_buf), 0);
+	close(fd);
+	return recv_len == peek_len &&
+			       memcmp(recv_buf, peek_buf, peek_len) == 0 ?
+		       0 :
+		       -1;
+}
+
+FN_TEST(msg_peek_trunc)
+{
+	TEST_RES(run_connected_socket_tests(open_tcp_pair, 0), _ret == 0);
+	TEST_RES(run_connected_socket_tests(open_udp_pair, 1), _ret == 0);
+	TEST_RES(run_connected_socket_tests(open_unix_stream_pair, 0),
+		 _ret == 0);
+	TEST_RES(run_connected_socket_tests(open_unix_seqpacket_pair, 1),
+		 _ret == 0);
+	TEST_RES(run_connected_socket_tests(open_unix_datagram_pair, 1),
+		 _ret == 0);
+	TEST_RES(run_connected_socket_tests(open_unix_raw_pair, 1), _ret == 0);
+	TEST_RES(test_netlink_msg_peek(SOCK_RAW), _ret == 0);
+	TEST_RES(test_netlink_msg_peek(SOCK_DGRAM), _ret == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/msg_peek_trunc.c
+++ b/test/initramfs/src/regression/network/msg_peek_trunc.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -13,198 +14,18 @@
 
 #define PAYLOAD "abcdef"
 #define PAYLOAD_LEN 6
+#define TCP_SETTLE_USEC 100000
 #define SHORT_LEN 3
-
-static int set_nonblocking(int fd)
-{
-	int flags = fcntl(fd, F_GETFL, 0);
-
-	if (flags < 0) {
-		return -1;
-	}
-
-	return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-}
 
 static ssize_t recvmsg_with_flags(int fd, int flags, char *buf, size_t len,
 				  int *msg_flags)
 {
 	struct iovec iov = { .iov_base = buf, .iov_len = len };
 	struct msghdr msg = { .msg_iov = &iov, .msg_iovlen = 1 };
-	ssize_t ret = recvmsg(fd, &msg, flags);
+	ssize_t ret = CHECK(recvmsg(fd, &msg, flags));
 
 	*msg_flags = msg.msg_flags;
 	return ret;
-}
-
-static int open_unix_pair(int type, int *send_fd, int *recv_fd)
-{
-	int fds[2];
-
-	if (socketpair(AF_UNIX, type | SOCK_NONBLOCK, 0, fds) < 0) {
-		return -1;
-	}
-
-	*send_fd = fds[0];
-	*recv_fd = fds[1];
-	return 0;
-}
-
-static int open_tcp_pair(int *send_fd, int *recv_fd)
-{
-	int listener = -1;
-	int client = -1;
-	int server = -1;
-	struct sockaddr_in addr = { .sin_family = AF_INET };
-	socklen_t addr_len = sizeof(addr);
-
-	listener = socket(AF_INET, SOCK_STREAM, 0);
-	client = socket(AF_INET, SOCK_STREAM, 0);
-	if (listener < 0 || client < 0) {
-		goto fail;
-	}
-
-	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	if (bind(listener, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
-	    getsockname(listener, (struct sockaddr *)&addr, &addr_len) < 0 ||
-	    listen(listener, 1) < 0 ||
-	    connect(client, (struct sockaddr *)&addr, addr_len) < 0) {
-		goto fail;
-	}
-
-	server = accept(listener, NULL, NULL);
-	if (server < 0 || set_nonblocking(server) < 0) {
-		goto fail;
-	}
-
-	close(listener);
-	*send_fd = client;
-	*recv_fd = server;
-	return 0;
-
-fail:
-	if (listener >= 0) {
-		close(listener);
-	}
-	if (client >= 0) {
-		close(client);
-	}
-	if (server >= 0) {
-		close(server);
-	}
-	return -1;
-}
-
-static int open_udp_pair(int *send_fd, int *recv_fd)
-{
-	int sender = -1;
-	int receiver = -1;
-	struct sockaddr_in addr = { .sin_family = AF_INET };
-	socklen_t addr_len = sizeof(addr);
-
-	sender = socket(AF_INET, SOCK_DGRAM, 0);
-	receiver = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
-	if (sender < 0 || receiver < 0) {
-		goto fail;
-	}
-
-	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	if (bind(receiver, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
-	    getsockname(receiver, (struct sockaddr *)&addr, &addr_len) < 0 ||
-	    connect(sender, (struct sockaddr *)&addr, addr_len) < 0) {
-		goto fail;
-	}
-
-	*send_fd = sender;
-	*recv_fd = receiver;
-	return 0;
-
-fail:
-	if (sender >= 0) {
-		close(sender);
-	}
-	if (receiver >= 0) {
-		close(receiver);
-	}
-	return -1;
-}
-
-static int test_msg_peek_connected(int send_fd, int recv_fd, int is_record)
-{
-	char buf[PAYLOAD_LEN] = {};
-	int msg_flags = 0;
-	size_t peek_len = is_record ? PAYLOAD_LEN : SHORT_LEN;
-	ssize_t ret;
-
-	if (send(send_fd, PAYLOAD, PAYLOAD_LEN, 0) != PAYLOAD_LEN) {
-		return -1;
-	}
-
-	ret = recvmsg_with_flags(recv_fd, MSG_PEEK, buf, peek_len, &msg_flags);
-	if (ret != (ssize_t)peek_len || (msg_flags & MSG_TRUNC) != 0 ||
-	    memcmp(buf, PAYLOAD, peek_len) != 0) {
-		return -1;
-	}
-
-	memset(buf, 0, sizeof(buf));
-	ret = recv(recv_fd, buf, sizeof(buf), 0);
-	if (ret != PAYLOAD_LEN || memcmp(buf, PAYLOAD, PAYLOAD_LEN) != 0) {
-		return -1;
-	}
-
-	return 0;
-}
-
-static int run_connected_socket_tests(int (*open_pair)(int *, int *),
-				      int is_record)
-{
-	int send_fd;
-	int recv_fd;
-	int ret;
-
-	if (open_pair(&send_fd, &recv_fd) < 0) {
-		return -1;
-	}
-	ret = test_msg_peek_connected(send_fd, recv_fd, is_record);
-	close(send_fd);
-	close(recv_fd);
-	return ret;
-}
-
-static int open_unix_stream_pair(int *send_fd, int *recv_fd)
-{
-	return open_unix_pair(SOCK_STREAM, send_fd, recv_fd);
-}
-
-static int open_unix_seqpacket_pair(int *send_fd, int *recv_fd)
-{
-	return open_unix_pair(SOCK_SEQPACKET, send_fd, recv_fd);
-}
-
-static int open_unix_datagram_pair(int *send_fd, int *recv_fd)
-{
-	return open_unix_pair(SOCK_DGRAM, send_fd, recv_fd);
-}
-
-static int open_unix_raw_pair(int *send_fd, int *recv_fd)
-{
-	return open_unix_pair(SOCK_RAW, send_fd, recv_fd);
-}
-
-static int open_netlink_route(int type)
-{
-	int fd = socket(AF_NETLINK, type | SOCK_NONBLOCK, NETLINK_ROUTE);
-	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
-
-	if (fd < 0) {
-		return -1;
-	}
-	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-		close(fd);
-		return -1;
-	}
-
-	return fd;
 }
 
 static int send_getlink_request(int fd, unsigned int seq)
@@ -228,50 +49,381 @@ static int send_getlink_request(int fd, unsigned int seq)
 	return send(fd, &req, sizeof(req), 0) == sizeof(req) ? 0 : -1;
 }
 
-static int test_netlink_msg_peek(int type)
+#ifdef __asterinas__
+static int buffer_has_byte(const char *buf, size_t len, char byte)
 {
-	int fd = open_netlink_route(type);
-	char peek_buf[8192] = {};
-	char recv_buf[8192] = {};
-	int msg_flags = 0;
-	ssize_t peek_len;
-	ssize_t recv_len;
-
-	if (fd < 0) {
-		return -1;
-	}
-	if (send_getlink_request(fd, 1) < 0) {
-		close(fd);
-		return -1;
+	for (size_t i = 0; i < len; i++) {
+		if (buf[i] != byte) {
+			return 0;
+		}
 	}
 
-	peek_len = recvmsg_with_flags(fd, MSG_PEEK, peek_buf, sizeof(peek_buf),
-				      &msg_flags);
-	if (peek_len <= 0 || (msg_flags & MSG_TRUNC) != 0) {
-		close(fd);
-		return -1;
-	}
-
-	recv_len = recv(fd, recv_buf, sizeof(recv_buf), 0);
-	close(fd);
-	return recv_len == peek_len &&
-			       memcmp(recv_buf, peek_buf, peek_len) == 0 ?
-		       0 :
-		       -1;
+	return 1;
 }
 
-FN_TEST(msg_peek_trunc)
+FN_TEST(tcp_msg_peek_wrapped_receive_buffer)
 {
-	TEST_RES(run_connected_socket_tests(open_tcp_pair, 0), _ret == 0);
-	TEST_RES(run_connected_socket_tests(open_udp_pair, 1), _ret == 0);
-	TEST_RES(run_connected_socket_tests(open_unix_stream_pair, 0),
-		 _ret == 0);
-	TEST_RES(run_connected_socket_tests(open_unix_seqpacket_pair, 1),
-		 _ret == 0);
-	TEST_RES(run_connected_socket_tests(open_unix_datagram_pair, 1),
-		 _ret == 0);
-	TEST_RES(run_connected_socket_tests(open_unix_raw_pair, 1), _ret == 0);
-	TEST_RES(test_netlink_msg_peek(SOCK_RAW), _ret == 0);
-	TEST_RES(test_netlink_msg_peek(SOCK_DGRAM), _ret == 0);
+	int listener;
+	int send_fd;
+	int recv_fd;
+	int status_flags;
+	int msg_flags = 0;
+	int tcp_recv_buf_len = 0;
+	socklen_t optlen = sizeof(tcp_recv_buf_len);
+	size_t two_thirds_buf_len;
+	char *buf;
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	listener = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+	send_fd = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(listener, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(listener, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(listen(listener, 1));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+	recv_fd = TEST_RES(accept(listener, NULL, NULL), _ret >= 0);
+	status_flags = TEST_RES(fcntl(recv_fd, F_GETFL, 0), _ret >= 0);
+	TEST_SUCC(fcntl(recv_fd, F_SETFL, status_flags | O_NONBLOCK));
+	TEST_SUCC(close(listener));
+
+	TEST_RES(getsockopt(recv_fd, SOL_SOCKET, SO_RCVBUF, &tcp_recv_buf_len,
+			    &optlen),
+		 _ret == 0 && tcp_recv_buf_len >= 3);
+	two_thirds_buf_len = (tcp_recv_buf_len / 3) * 2;
+
+	buf = TEST_RES(malloc(two_thirds_buf_len), _ret != NULL);
+	memset(buf, 'a', two_thirds_buf_len);
+
+	TEST_RES(send(send_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)two_thirds_buf_len);
+	usleep(TCP_SETTLE_USEC);
+	TEST_RES(recv(recv_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)two_thirds_buf_len);
+	usleep(TCP_SETTLE_USEC);
+	TEST_RES(send(send_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)two_thirds_buf_len);
+	usleep(TCP_SETTLE_USEC);
+
+	memset(buf, 0, two_thirds_buf_len);
+	TEST_RES(recvmsg_with_flags(recv_fd, MSG_PEEK, buf, two_thirds_buf_len,
+				    &msg_flags),
+		 _ret == (ssize_t)two_thirds_buf_len &&
+			 (msg_flags & MSG_TRUNC) == 0 &&
+			 buffer_has_byte(buf, two_thirds_buf_len, 'a'));
+
+	memset(buf, 0, two_thirds_buf_len);
+	TEST_RES(recv(recv_fd, buf, two_thirds_buf_len, 0),
+		 _ret == (ssize_t)two_thirds_buf_len &&
+			 buffer_has_byte(buf, two_thirds_buf_len, 'a'));
+	TEST_ERRNO(recv(recv_fd, buf, two_thirds_buf_len, MSG_DONTWAIT),
+		   EAGAIN);
+
+	free(buf);
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+#endif
+
+FN_TEST(tcp_msg_peek)
+{
+	int listener;
+	int send_fd;
+	int recv_fd;
+	int status_flags;
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	listener = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+	send_fd = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(listener, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(listener, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(listen(listener, 1));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+	recv_fd = TEST_RES(accept(listener, NULL, NULL), _ret >= 0);
+	status_flags = TEST_RES(fcntl(recv_fd, F_GETFL, 0), _ret >= 0);
+	TEST_SUCC(fcntl(recv_fd, F_SETFL, status_flags | O_NONBLOCK));
+	TEST_SUCC(close(listener));
+
+	TEST_RES(send(send_fd, PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(recv_fd, MSG_PEEK, buf, SHORT_LEN,
+				    &msg_flags),
+		 _ret == SHORT_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, SHORT_LEN) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(recv_fd, buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN && memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+
+FN_TEST(tcp_msg_trunc)
+{
+	int listener;
+	int send_fd;
+	int recv_fd;
+	int status_flags;
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	listener = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+	send_fd = TEST_RES(socket(AF_INET, SOCK_STREAM, 0), _ret >= 0);
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(listener, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(listener, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(listen(listener, 1));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+	recv_fd = TEST_RES(accept(listener, NULL, NULL), _ret >= 0);
+	status_flags = TEST_RES(fcntl(recv_fd, F_GETFL, 0), _ret >= 0);
+	TEST_SUCC(fcntl(recv_fd, F_SETFL, status_flags | O_NONBLOCK));
+	TEST_SUCC(close(listener));
+
+	TEST_RES(send(send_fd, PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(recv_fd, MSG_TRUNC, buf, SHORT_LEN,
+				    &msg_flags),
+		 _ret == SHORT_LEN && (msg_flags & MSG_TRUNC) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(recv_fd, buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN - SHORT_LEN &&
+			 memcmp(buf, PAYLOAD + SHORT_LEN,
+				PAYLOAD_LEN - SHORT_LEN) == 0);
+
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+
+FN_TEST(udp_msg_peek)
+{
+	int send_fd;
+	int recv_fd;
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	send_fd = TEST_RES(socket(AF_INET, SOCK_DGRAM, 0), _ret >= 0);
+	recv_fd = TEST_RES(socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0),
+			   _ret >= 0);
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(recv_fd, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(recv_fd, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+
+	TEST_RES(send(send_fd, PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(recv_fd, MSG_PEEK, buf, PAYLOAD_LEN,
+				    &msg_flags),
+		 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(recv_fd, buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN && memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+
+FN_TEST(udp_msg_trunc)
+{
+	int send_fd;
+	int recv_fd;
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	send_fd = TEST_RES(socket(AF_INET, SOCK_DGRAM, 0), _ret >= 0);
+	recv_fd = TEST_RES(socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0),
+			   _ret >= 0);
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(recv_fd, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(recv_fd, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+
+	TEST_RES(send(send_fd, PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(recv_fd, MSG_TRUNC, buf, SHORT_LEN,
+				    &msg_flags),
+		 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) != 0 &&
+			 memcmp(buf, PAYLOAD, SHORT_LEN) == 0);
+	TEST_ERRNO(recv(recv_fd, buf, sizeof(buf), MSG_DONTWAIT), EAGAIN);
+
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+
+FN_TEST(unix_stream_msg_peek)
+{
+	int fds[2] = { -1, -1 };
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds));
+	TEST_RES(send(fds[0], PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(fds[1], MSG_PEEK, buf, SHORT_LEN,
+				    &msg_flags),
+		 _ret == SHORT_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, SHORT_LEN) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(fds[1], buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN && memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(unix_stream_msg_trunc)
+{
+	int fds[2] = { -1, -1 };
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds));
+	TEST_RES(send(fds[0], PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+	TEST_RES(recvmsg_with_flags(fds[1], MSG_TRUNC, buf, SHORT_LEN,
+				    &msg_flags),
+		 _ret == SHORT_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, SHORT_LEN) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(fds[1], buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN - SHORT_LEN &&
+			 memcmp(buf, PAYLOAD + SHORT_LEN,
+				PAYLOAD_LEN - SHORT_LEN) == 0);
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(unix_record_msg_peek)
+{
+	int types[] = { SOCK_SEQPACKET, SOCK_DGRAM, SOCK_RAW };
+
+	for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+		int fds[2] = { -1, -1 };
+		int msg_flags = 0;
+		char buf[PAYLOAD_LEN] = {};
+
+		TEST_SUCC(
+			socketpair(AF_UNIX, types[i] | SOCK_NONBLOCK, 0, fds));
+		TEST_RES(send(fds[0], PAYLOAD, PAYLOAD_LEN, 0),
+			 _ret == PAYLOAD_LEN);
+		TEST_RES(recvmsg_with_flags(fds[1], MSG_PEEK, buf, PAYLOAD_LEN,
+					    &msg_flags),
+			 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+				 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+		memset(buf, 0, sizeof(buf));
+		TEST_RES(recv(fds[1], buf, sizeof(buf), 0),
+			 _ret == PAYLOAD_LEN &&
+				 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+		TEST_SUCC(close(fds[0]));
+		TEST_SUCC(close(fds[1]));
+	}
+}
+END_TEST()
+
+FN_TEST(unix_record_msg_trunc)
+{
+	int types[] = { SOCK_SEQPACKET, SOCK_DGRAM, SOCK_RAW };
+
+	for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+		int fds[2] = { -1, -1 };
+		int msg_flags = 0;
+		char buf[PAYLOAD_LEN] = {};
+
+		TEST_SUCC(
+			socketpair(AF_UNIX, types[i] | SOCK_NONBLOCK, 0, fds));
+		TEST_RES(send(fds[0], PAYLOAD, PAYLOAD_LEN, 0),
+			 _ret == PAYLOAD_LEN);
+		TEST_RES(recvmsg_with_flags(fds[1], MSG_TRUNC, buf, SHORT_LEN,
+					    &msg_flags),
+			 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) != 0 &&
+				 memcmp(buf, PAYLOAD, SHORT_LEN) == 0);
+		TEST_ERRNO(recv(fds[1], buf, sizeof(buf), MSG_DONTWAIT),
+			   EAGAIN);
+
+		TEST_SUCC(close(fds[0]));
+		TEST_SUCC(close(fds[1]));
+	}
+}
+END_TEST()
+
+FN_TEST(netlink_msg_peek)
+{
+	int types[] = { SOCK_RAW, SOCK_DGRAM };
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+
+	for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+		int fd;
+		int msg_flags = 0;
+		char peek_buf[8192] = {};
+		char recv_buf[8192] = {};
+		ssize_t peek_len;
+
+		fd = TEST_RES(socket(AF_NETLINK, types[i] | SOCK_NONBLOCK,
+				     NETLINK_ROUTE),
+			      _ret >= 0);
+		TEST_SUCC(bind(fd, (struct sockaddr *)&addr, sizeof(addr)));
+		TEST_RES(send_getlink_request(fd, i + 1), _ret == 0);
+
+		peek_len = TEST_RES(recvmsg_with_flags(fd, MSG_PEEK, peek_buf,
+						       sizeof(peek_buf),
+						       &msg_flags),
+				    _ret > 0 && (msg_flags & MSG_TRUNC) == 0);
+		TEST_RES(recv(fd, recv_buf, sizeof(recv_buf), 0),
+			 _ret == peek_len &&
+				 memcmp(recv_buf, peek_buf, peek_len) == 0);
+
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(netlink_msg_trunc)
+{
+	int types[] = { SOCK_RAW, SOCK_DGRAM };
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+
+	for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+		int fd;
+		int msg_flags = 0;
+		char buf[sizeof(struct nlmsghdr)] = {};
+
+		fd = TEST_RES(socket(AF_NETLINK, types[i] | SOCK_NONBLOCK,
+				     NETLINK_ROUTE),
+			      _ret >= 0);
+		TEST_SUCC(bind(fd, (struct sockaddr *)&addr, sizeof(addr)));
+		TEST_RES(send_getlink_request(fd, i + 1), _ret == 0);
+
+		TEST_RES(recvmsg_with_flags(fd, MSG_TRUNC, buf, sizeof(buf),
+					    &msg_flags),
+			 _ret > (ssize_t)sizeof(buf) &&
+				 (msg_flags & MSG_TRUNC) != 0);
+		TEST_ERRNO(recv(fd, buf, sizeof(buf), MSG_DONTWAIT), EAGAIN);
+
+		TEST_SUCC(close(fd));
+	}
 }
 END_TEST()

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -17,6 +17,7 @@ sleep 0.2
 ./unix_client
 
 ./listen_backlog
+./msg_peek_trunc
 ./privileged_ports
 ./send_buf_full
 ./sendmmsg


### PR DESCRIPTION
This PR adds support for the MSG_PEEK and MSG_TRUNC flags. The primary motivation is to enable the ip command on NixOS and to support network configuration via Netlink in Kata Containers.

On NixOS, the ip command uses a zero-length buffer along with MSG_PEEK | MSG_TRUNC to query the length of the next incoming Netlink message. With this PR, the ip command now works correctly.

The semantics of MSG_PEEK are straightforward: it receives a message without removing it from the receive queue, so the same message can be received again on the next call.

The semantics of MSG_TRUNC are as follows:

1. For UDP, Netlink, and UNIX datagram sockets, it returns the actual length of the incoming message, even if the message is larger than the user-provided buffer.
2. For TCP/UNIX stream sockets, it causes the data to be discarded rather than written into the user's buffer. If both MSG_PEEK and MSG_TRUNC are provided, MSG_PEEK takes effect. The data will not be discarded.

See https://man7.org/linux/man-pages/man2/recvmsg.2.html and https://man7.org/linux/man-pages/man7/tcp.7.html.