### PR TITLE
Check `has_pending` before entering user mode

### DIFF
--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -273,6 +273,10 @@ impl UserContextApiInternal for UserContext {
 
         // Return when it is syscall or cpu exception type is Fault or Trap.
         loop {
+            if has_kernel_event() {
+                break ReturnReason::KernelEvent;
+            }
+
             crate::task::scheduler::might_preempt();
             self.user_context.run();
 
@@ -311,10 +315,6 @@ impl UserContextApiInternal for UserContext {
                     );
                     crate::arch::irq::enable_local();
                 }
-            }
-
-            if has_kernel_event() {
-                break ReturnReason::KernelEvent;
             }
         }
     }


### PR DESCRIPTION
Required for #2323.

This avoids a race condition where a new signal arrives after `handle_pending_signal` but before `user_mode.execute`. The current main branch's implementation returns directly to user space, and the new signal will not be handled until the next trap occurs.

The implementation in this PR still has a similar race condition, but the race window is reduced.