### PR TITLE
Correct RISC-V default parameter expansions in qemu_args.sh

### DIFF
--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -63,8 +63,8 @@ if [ "$1" = "riscv" ]; then
     QEMU_ARGS="\
         -cpu rv64,svpbmt=true \
         -machine virt \
-        -m ${MEM-:8G} \
-        -smp ${SMP-:1} \
+        -m ${MEM:-8G} \
+        -smp ${SMP:-1} \
         --no-reboot \
         -nographic \
         -display none \


### PR DESCRIPTION
**Fix:**
This is a small patch to correct the RISC-V parameter expansions in `qemu_args.sh`.

**Problem:**
In `qemu_args.sh`, lines 66-67 use the incorrect Bash parameter expansion syntax `${VAR-:VALUE}` instead of `${VAR:-VALUE}`. This causes:
- When MEM or SMP are unset, the defaults expand to literal strings `:8G` and `:1` .
- QEMU receives invalid arguments: `-m :8G` and `-smp :1` .

For example, running:
```
make run_kernel OSDK_TARGET_ARCH=riscv64 SCHEME=riscv
cargo osdk run --target-arch=riscv64 --scheme riscv
```
triggers:
```
qemu-system-riscv64: -m :8G: Parameter 'size' expects a non-negative number below 2^64
Optional suffix k, M, G, T, P or E means kilo-, mega-, giga-, tera-, peta-
and exabytes, respectively.
```

The TDX and x86_64 blocks already use the correct `:-` form (lines 89–90, 116–117).
