### PR TITLE
Use asterinas/kata image for kernel developers

### DIFF
--- a/book/src/kernel/vm-based-containers/kata.md
+++ b/book/src/kernel/vm-based-containers/kata.md
@@ -15,9 +15,9 @@ with the stronger isolation boundary of virtual machines.
 It reduces the risk that a compromised workload can affect
 the host or other containers.
 
-This guide uses the
-[Asterinas fork of Kata Containers](https://github.com/asterinas/kata-containers),
-which carries Asterinas-specific patches, helper scripts,
+The Kata Containers setup used in this guide comes from the
+[Asterinas fork of Kata Containers](https://github.com/asterinas/kata-containers).
+The fork carries the Asterinas-specific patches, helper scripts,
 and configuration for building, installing, and testing Kata
 with Asterinas as the guest kernel.
 
@@ -46,11 +46,15 @@ Then make sure the user running Docker can access
 
 ## Step 2: Enter the Kata-ready environment
 
-Use one of the Docker images below to enter an environment
-that can run Asterinas-powered Kata containers.
-End users should use the prebuilt `asterinas/kata` image.
-Kernel developers should use the `asterinas/asterinas` image
-with source mounts.
+We provide the `asterinas/kata` Docker image,
+which is based on `asterinas/asterinas` and bundles
+Kata Containers, the Asterinas guest kernel,
+and the Kata configuration.
+The image also provides helper scripts
+under `/root/kata-containers`.
+Use the same image in one of the two ways below:
+End users can run it directly,
+while kernel developers can mount the Asterinas source tree.
 
 ### Step 2.1: Prepare Docker arguments
 
@@ -94,52 +98,35 @@ docker run -it \
     asterinas/kata:0.17.2-20260407
 ```
 
-The Docker image includes Kata, the Asterinas guest kernel,
-the Kata configuration,
-and the `tools/kata/` helper scripts in `/root/kata-containers`.
-The command above makes `/root/kata-containers` the working directory.
+The command above makes `/root/kata-containers` the working directory,
+so the `tools/kata/` helper scripts are available
+at the relative paths used below.
 
 After entering the container,
 continue with [Step 3: Start a Kata workload](#step-3-start-a-kata-workload).
 
 #### For kernel developers
 
-Clone the Asterinas fork of Kata Containers,
-then run an `asterinas/asterinas` Docker container
-with both source trees mounted:
+Run an `asterinas/kata` Docker container,
+with the Asterinas source tree mounted:
 
 ```bash
 # Assumes the Asterinas source has already been cloned locally.
 ASTERINAS_SRC=$HOME/asterinas
 
-# Clones the Asterinas fork of kata-containers locally as well.
-cd $HOME && git clone https://github.com/asterinas/kata-containers.git
-KATA_SRC=$HOME/kata-containers
-
 docker run -it \
     "${KATA_DOCKER_ARGS[@]}" \
     -v "${ASTERINAS_SRC}:/root/asterinas" \
-    -v "${KATA_SRC}:/root/kata-containers" \
     -w /root/kata-containers \
-    asterinas/asterinas:0.17.2-20260407
+    asterinas/kata:0.17.2-20260407
 ```
 
-This setup lets you rebuild the kernel
+This setup allows you to rebuild the kernel
 and test how kernel changes affect Kata workloads.
 The Asterinas source tree is mounted at `/root/asterinas`.
-The Asterinas fork of Kata Containers is mounted at `/root/kata-containers`.
-Use the Asterinas fork for changes to the Asterinas guest-kernel integration
-until those patches, scripts, and configuration are upstreamed.
 The command above makes `/root/kata-containers` the working directory,
 so the `tools/kata/` helper scripts are available
 at the relative paths used below.
-
-Install the Kata dependencies and configuration
-after entering the `asterinas/asterinas` image:
-
-```bash
-tools/kata/kata_env.sh install
-```
 
 Then continue with [Step 3: Start a Kata workload](#step-3-start-a-kata-workload).
 
@@ -195,14 +182,14 @@ cat /etc/alpine-release
 ```
 
 The `/proc/cmdline` output should contain the Asterinas kernel image path.
-For the prebuilt `asterinas/kata` image,
+If you are using the image's default kernel,
 look for:
 
 ```text
 /opt/kata/share/kata-containers/aster-kernel-osdk-bin.qemu_elf
 ```
 
-For a locally built kernel,
+If you configured a locally built kernel in Step 4,
 look for:
 
 ```text
@@ -227,7 +214,6 @@ This step is for the kernel-developer setup only:
 it requires the Asterinas source tree,
 so it assumes you entered the Kata-ready environment through the
 [For kernel developers](#for-kernel-developers) setup in Step 2.2.
-It is not available from the prebuilt `asterinas/kata` image.
 
 Build the kernel first:
 


### PR DESCRIPTION
This PR updates the kata document to let kernel developers use `asterinas/kata` instead of `asterinas/asterinas`.