### PR TITLE
Make tmpfs visible to statfs-based filesystem probes

### DIFF
--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -22,6 +22,7 @@ use crate::{
         file::{AccessMode, FileIo, InodeMode, InodeType, Permission, StatusFlags, mkmod},
         pipe::Pipe,
         pseudofs::AnonDeviceId,
+        tmpfs::{self, TMPFS_MAGIC},
         utils::{CStr256, DirentVisitor},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
@@ -61,13 +62,41 @@ impl RamFs {
         Self::new_internal("rootfs")
     }
 
+    // TODO: Remove this tmpfs-specific constructor once `TmpFs` no longer
+    // aliases `RamFs`.
+    pub(in crate::fs) fn new_tmpfs() -> Arc<Self> {
+        let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for tmpfs");
+        let sb = {
+            let mut super_block =
+                SuperBlock::new(TMPFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+            let max_blocks = tmpfs::default_max_blocks();
+            let max_inodes = tmpfs::default_max_inodes();
+            super_block.blocks = max_blocks;
+            super_block.bfree = max_blocks;
+            super_block.bavail = max_blocks;
+            super_block.files = max_inodes;
+            super_block.ffree = max_inodes;
+            super_block
+        };
+        Self::new_internal_with_sb("tmpfs", anon_device_id, sb)
+    }
+
     fn new_internal(name: &'static str) -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for ramfs");
+        let sb = SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        Self::new_internal_with_sb(name, anon_device_id, sb)
+    }
+
+    fn new_internal_with_sb(
+        name: &'static str,
+        anon_device_id: AnonDeviceId,
+        sb: SuperBlock,
+    ) -> Arc<Self> {
         let root_dev_id = anon_device_id.id();
         Arc::new_cyclic(move |weak_fs| Self {
             name,
             _anon_device_id: anon_device_id,
-            sb: SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, root_dev_id),
+            sb,
             root: Arc::new_cyclic(|weak_root| RamInode {
                 inner: Inner::new_dir(weak_root.clone(), weak_root.clone()),
                 metadata: SpinLock::new(InodeMeta::new_dir(

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -321,7 +321,7 @@ impl MemfdTmpFs {
     pub(self) fn singleton() -> &'static Arc<TmpFs> {
         static MEMFD_TMPFS: Once<Arc<TmpFs>> = Once::new();
 
-        MEMFD_TMPFS.call_once(TmpFs::new)
+        MEMFD_TMPFS.call_once(TmpFs::new_tmpfs)
     }
 
     pub(self) fn new_path(memfd_inode: Arc<MemfdInode>) -> Path {

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -4,8 +4,7 @@ use crate::{
     fs::{
         ramfs::RamFs,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::Inode,
+            file_system::FileSystem,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
@@ -14,42 +13,20 @@ use crate::{
 
 /// The temporary file system (tmpfs) structure.
 //
-// TODO: Currently, tmpfs is implemented as a thin wrapper around ramfs.
-// In the future we need to implement tmpfs-specific features such as
-// memory limits and swap support.
-pub struct TmpFs {
-    inner: Arc<RamFs>,
+// TODO: `TmpFs` currently aliases `RamFs` and relies on `RamFs::new_tmpfs()`
+// to create tmpfs-flavored ramfs instances. In the future we need to
+// implement a dedicated tmpfs with tmpfs-specific features such as memory
+// limits and swap support.
+pub type TmpFs = RamFs;
+
+// FIXME: These defaults are only a rough approximation for tmpfs-over-ramfs.
+// A dedicated tmpfs implementation should replace them with real tmpfs limit
+// and accounting semantics.
+pub(in crate::fs) fn default_max_blocks() -> usize {
+    crate::vm::mem_total() / PAGE_SIZE / 2
 }
-
-impl TmpFs {
-    pub fn new() -> Arc<Self> {
-        Arc::new(TmpFs {
-            inner: RamFs::new(),
-        })
-    }
-}
-
-impl FileSystem for TmpFs {
-    fn name(&self) -> &'static str {
-        "tmpfs"
-    }
-
-    fn sync(&self) -> Result<()> {
-        // do nothing
-        Ok(())
-    }
-
-    fn root_inode(&self) -> Arc<dyn Inode> {
-        self.inner.root_inode()
-    }
-
-    fn sb(&self) -> SuperBlock {
-        self.inner.sb()
-    }
-
-    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
-        self.inner.fs_event_subscriber_stats()
-    }
+pub(in crate::fs) fn default_max_inodes() -> usize {
+    crate::vm::mem_total() / PAGE_SIZE / 2
 }
 
 pub(super) struct TmpFsType;
@@ -64,7 +41,7 @@ impl FsType for TmpFsType {
     }
 
     fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(TmpFs::new())
+        Ok(TmpFs::new_tmpfs())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/tmpfs/mod.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/mod.rs
@@ -2,13 +2,12 @@
 
 //! Temporary file system (tmpfs) based on ramfs.
 
-pub(super) use fs::TmpFs;
 use fs::TmpFsType;
+pub(super) use fs::{TmpFs, default_max_blocks, default_max_inodes};
 
 mod fs;
 
-#[expect(dead_code)]
-const TMPFS_MAGIC: u64 = 0x0102_1994;
+pub(super) const TMPFS_MAGIC: u64 = 0x0102_1994;
 
 pub(super) fn init() {
     crate::fs::vfs::registry::register(&TmpFsType).unwrap();


### PR DESCRIPTION
## Overview

This PR creates a dedicated `SuperBlock` for tmpfs instead of reusing ramfs’s `SuperBlock`.  
And it fixes `statfs` to query the filesystem of the mount point rather than that of the underlying inode.  
For tmpfs, inodes belong to ramfs, so the old `statfs` returned the wrong superblock.
With this change, tmpfs becomes visible to `statfs`-based filesystem probes.

This is needed for tmpfs support in xfstests.
Previously, tmpfs in Asterinas was a thin wrapper around `RamFs`. Because tmpfs reused ramfs inodes, `statfs()` returned information about the inner ramfs instead of the mounted tmpfs.  
As a result:
- `df -T -P` did not list tmpfs as a normal filesystem.
- xfstests `_fs_type tmpfs_test` returned empty.

This made xfstests believe `TEST_DEV=tmpfs_test` was not mounted, so it mounted tmpfs again on the same target. The duplicate stacked mount caused `findmnt -S tmpfs_test` to return duplicate rows, breaking xfstests mount validation.

Now, tmpfs is properly visible via `statfs`, so xfstests detects the existing mount and no longer remounts it.

## TODO 

`TmpFs::sb()` still contains a TODO because this is a workaround.  
Tmpfs currently wraps `RamFs`, and its inodes still belong to the inner ramfs instance. We override `statfs`‑visible fields in `TmpFs::sb()` to preserve normal `RamFs::new()` semantics.

A cleaner long‑term fix is to implement tmpfs as its own independent filesystem, rather than teaching ramfs about tmpfs‑specific behavior.