### PR TITLE
Fix reachable unwrap panic in mount ID allocator

### DIFF
--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -1240,6 +1240,7 @@ mod tests {
             RamFs::new(),
             Arc::downgrade(MountNamespace::get_init_singleton()),
         )
+        .unwrap()
     }
 
     fn create_overlay_fs() -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
@@ -15,6 +15,11 @@ use crate::{
     process::{Gid, Uid},
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = AnonInodeFs::mount_node();
+}
+
 pub struct AnonInodeFs {
     _private: (),
 }

--- a/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
@@ -40,7 +40,7 @@ impl AnonInodeFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static ANON_INODEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        ANON_INODEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        ANON_INODEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 
     /// Returns the shared inode of the anonymous inode file system singleton.

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -154,6 +154,12 @@ pub(super) fn init() {
     crate::fs::vfs::registry::register(&SockFsType).unwrap();
     // Note: `AnonInodeFs` does not need to be registered in the FS registry.
     // Reference: <https://elixir.bootlin.com/linux/v6.16.5/A/ident/anon_inode_fs_type>
+
+    anon_inodefs::init();
+    nsfs::init();
+    pidfdfs::init();
+    pipefs::init();
+    sockfs::init();
 }
 
 /// Root Inode ID.

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -58,7 +58,7 @@ impl NsFs {
     /// Returns the pseudo mount node of the ns file system.
     pub(self) fn mount_node() -> &'static Arc<Mount> {
         static NSFS_MOUNT: Once<Arc<Mount>> = Once::new();
-        NSFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        NSFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -30,6 +30,11 @@ use crate::{
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = NsFs::mount_node();
+}
+
 /// A pseudo filesystem for namespace files.
 struct NsFs {
     _private: (),

--- a/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
@@ -40,7 +40,7 @@ impl PidfdFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static PIDFDFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIDFDFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        PIDFDFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 
     /// Returns the shared inode of the pidfd file system.

--- a/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
@@ -15,6 +15,11 @@ use crate::{
     process::{Gid, Uid},
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = PidfdFs::mount_node();
+}
+
 pub struct PidfdFs {
     _private: (),
 }

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -40,7 +40,7 @@ impl PipeFs {
     fn mount_node() -> &'static Arc<Mount> {
         static PIPEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIPEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        PIPEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -17,6 +17,11 @@ use crate::{
     prelude::*,
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = PipeFs::mount_node();
+}
+
 pub(in crate::fs) struct PipeFs {
     _private: (),
 }

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -48,7 +48,7 @@ impl SockFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static SOCKFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        SOCKFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        SOCKFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -18,6 +18,11 @@ use crate::{
     process::{Gid, Uid},
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = SockFs::mount_node();
+}
+
 pub struct SockFs {
     _private: (),
 }

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -334,7 +334,7 @@ impl MemfdTmpFs {
     fn mount_node() -> &'static Arc<Mount> {
         static MEMFD_TMPFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        MEMFD_TMPFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()))
+        MEMFD_TMPFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -29,6 +29,11 @@ use crate::{
     vm::{perms::VmPerms, vmo::Vmo},
 };
 
+pub(super) fn init() {
+    // Touch the mount node to trigger the initialization of all singletons.
+    let _ = MemfdTmpFs::mount_node();
+}
+
 /// Maximum file name length for `memfd_create`, excluding the final `\0` byte.
 ///
 /// See <https://man7.org/linux/man-pages/man2/memfd_create.2.html>

--- a/kernel/src/fs/fs_impls/ramfs/mod.rs
+++ b/kernel/src/fs/fs_impls/ramfs/mod.rs
@@ -16,4 +16,5 @@ const NAME_MAX: usize = 255;
 
 pub(super) fn init() {
     crate::fs::vfs::registry::register(&RamFsType).unwrap();
+    memfd::init();
 }

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -408,7 +408,7 @@ impl Path {
             &current_mnt_ns_weak,
             recursive,
             MountNsFileCopying::Copy,
-        );
+        )?;
         new_mount.graft_mount_tree(dst_path);
         Ok(())
     }

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -60,6 +60,16 @@ pub(super) fn init() {
     ID_ALLOCATOR.call_once(|| SpinLock::new(id_allocator));
 }
 
+/// Allocates a new mount ID from the global pool.
+fn alloc_mount_id() -> Result<usize> {
+    ID_ALLOCATOR
+        .get()
+        .unwrap()
+        .lock()
+        .alloc()
+        .ok_or_else(|| Error::with_message(Errno::ENOMEM, "mount ID pool exhausted"))
+}
+
 bitflags! {
     pub struct PerMountFlags: u32 {
         /// Mount read-only.
@@ -235,12 +245,7 @@ impl Mount {
         mnt_ns: Weak<MountNamespace>,
         source: Option<String>,
     ) -> Result<Arc<Self>> {
-        let id = ID_ALLOCATOR
-            .get()
-            .unwrap()
-            .lock()
-            .alloc()
-            .ok_or_else(|| Error::new(Errno::ENOMEM))?;
+        let id = alloc_mount_id()?;
 
         Ok(Arc::new_cyclic(|weak_self| Self {
             id,
@@ -331,12 +336,7 @@ impl Mount {
         root_dentry: &Arc<Dentry>,
         new_ns: &Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
-        let id = ID_ALLOCATOR
-            .get()
-            .unwrap()
-            .lock()
-            .alloc()
-            .ok_or_else(|| Error::new(Errno::ENOMEM))?;
+        let id = alloc_mount_id()?;
 
         Ok(Arc::new_cyclic(|weak_self| Self {
             id,

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -207,7 +207,7 @@ impl Mount {
     pub(in crate::fs) fn new_root(
         fs: Arc<dyn FileSystem>,
         mnt_ns: Weak<MountNamespace>,
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>> {
         let source = fs.name().to_string();
         Self::new(fs, PerMountFlags::default(), None, mnt_ns, Some(source))
     }
@@ -216,7 +216,7 @@ impl Mount {
     ///
     /// This pseudo mount is not mounted on other mount nodes, has no parent, and does not
     /// belong to any mount namespace.
-    pub(in crate::fs) fn new_pseudo(fs: Arc<dyn FileSystem>) -> Arc<Self> {
+    pub(in crate::fs) fn new_pseudo(fs: Arc<dyn FileSystem>) -> Result<Arc<Self>> {
         Self::new(fs, PerMountFlags::KERNMOUNT, None, Weak::new(), None)
     }
 
@@ -234,10 +234,15 @@ impl Mount {
         parent_mount: Option<Weak<Mount>>,
         mnt_ns: Weak<MountNamespace>,
         source: Option<String>,
-    ) -> Arc<Self> {
-        let id = ID_ALLOCATOR.get().unwrap().lock().alloc().unwrap();
+    ) -> Result<Arc<Self>> {
+        let id = ID_ALLOCATOR
+            .get()
+            .unwrap()
+            .lock()
+            .alloc()
+            .ok_or_else(|| Error::new(Errno::ENOMEM))?;
 
-        Arc::new_cyclic(|weak_self| Self {
+        Ok(Arc::new_cyclic(|weak_self| Self {
             id,
             root_dentry: Dentry::new_root(fs.root_inode()),
             mountpoint: RwLock::new(None),
@@ -249,7 +254,7 @@ impl Mount {
             mnt_ns,
             flags: AtomicPerMountFlags::new(flags),
             this: weak_self.clone(),
-        })
+        }))
     }
 
     /// Gets the mount ID.
@@ -293,7 +298,7 @@ impl Mount {
             Some(Arc::downgrade(self)),
             self.mnt_ns.clone(),
             source,
-        );
+        )?;
         self.children.write().insert(key, child_mount.clone());
         child_mount.set_mountpoint(mountpoint);
 
@@ -321,9 +326,20 @@ impl Mount {
     /// have no parent and children. We should set the parent and children manually.
     ///
     /// The new mount will belong to the given mount namespace.
-    fn clone_mount(&self, root_dentry: &Arc<Dentry>, new_ns: &Weak<MountNamespace>) -> Arc<Self> {
-        Arc::new_cyclic(|weak_self| Self {
-            id: ID_ALLOCATOR.get().unwrap().lock().alloc().unwrap(),
+    fn clone_mount(
+        &self,
+        root_dentry: &Arc<Dentry>,
+        new_ns: &Weak<MountNamespace>,
+    ) -> Result<Arc<Self>> {
+        let id = ID_ALLOCATOR
+            .get()
+            .unwrap()
+            .lock()
+            .alloc()
+            .ok_or_else(|| Error::new(Errno::ENOMEM))?;
+
+        Ok(Arc::new_cyclic(|weak_self| Self {
+            id,
             root_dentry: root_dentry.clone(),
             mountpoint: RwLock::new(None),
             parent: RwLock::new(None),
@@ -334,7 +350,7 @@ impl Mount {
             mnt_ns: new_ns.clone(),
             flags: AtomicPerMountFlags::new(self.flags.load(Ordering::Relaxed)),
             this: weak_self.clone(),
-        })
+        }))
     }
 
     /// Clones a mount tree starting from the specified root `Dentry`.
@@ -356,10 +372,10 @@ impl Mount {
         new_ns: &Weak<MountNamespace>,
         recursive: bool,
         mnt_ns_file_copying: MountNsFileCopying,
-    ) -> Arc<Self> {
-        let new_root_mount = self.clone_mount(root_dentry, new_ns);
+    ) -> Result<Arc<Self>> {
+        let new_root_mount = self.clone_mount(root_dentry, new_ns)?;
         if !recursive {
-            return new_root_mount;
+            return Ok(new_root_mount);
         }
 
         let mut stack = vec![self.this()];
@@ -379,7 +395,7 @@ impl Mount {
                     continue;
                 }
                 let new_child_mount =
-                    old_child_mount.clone_mount(old_child_mount.root_dentry(), new_ns);
+                    old_child_mount.clone_mount(old_child_mount.root_dentry(), new_ns)?;
                 let key = mountpoint.key();
                 new_parent_mount
                     .children
@@ -392,7 +408,7 @@ impl Mount {
             }
         }
 
-        new_root_mount
+        Ok(new_root_mount)
     }
 
     /// Sets the propagation type of this mount.
@@ -615,6 +631,7 @@ impl Debug for Mount {
 
 impl Drop for Mount {
     fn drop(&mut self) {
+        self.clear_mountpoint();
         ID_ALLOCATOR.get().unwrap().lock().free(self.id);
     }
 }

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::sync::UniqueArc;
+
 use spin::Once;
 
 use super::{mount::MountNsFileCopying, try_get_mnt_ns_inode};
@@ -21,7 +23,13 @@ use crate::{
 /// rejected and return an `Err`.
 pub struct MountNamespace {
     /// The root mount of this namespace.
-    root: Arc<Mount>,
+    ///
+    /// This field is wrapped within an `Option<_>`
+    /// because the root mount is unknown
+    /// in the beginning of the constructor method (see `new_clone`).
+    /// But if the constructor method completes,
+    /// this field is guaranteed to be `Some(_)`.
+    root: Option<Arc<Mount>>,
     /// The user namespace that owns this mount namespace.
     owner: Arc<UserNamespace>,
     /// The stashed dentry in nsfs.
@@ -58,21 +66,21 @@ impl MountNamespace {
             let owner = UserNamespace::get_init_singleton().clone();
             let rootfs = RamFs::new_rootfs();
 
-            Arc::new_cyclic(|weak_self| {
-                let root = Mount::new_root(rootfs, weak_self.clone());
-                let stashed_dentry = StashedDentry::new();
-                MountNamespace {
-                    root,
-                    owner,
-                    stashed_dentry,
-                }
-            })
+            let mut new_ns = UniqueArc::new(MountNamespace {
+                root: None,
+                owner,
+                stashed_dentry: StashedDentry::new(),
+            });
+            let root = Mount::new_root(rootfs, UniqueArc::downgrade(&new_ns))
+                .expect("failed to allocate mount ID for the root mount");
+            new_ns.root = Some(root);
+            UniqueArc::into_arc(new_ns)
         })
     }
 
     /// Gets the root mount of this namespace.
     pub fn root(&self) -> &Arc<Mount> {
-        &self.root
+        self.root.as_ref().unwrap()
     }
 
     /// Creates a new filesystem resolver for this namespace.
@@ -83,8 +91,8 @@ impl MountNamespace {
     /// The "effective root" refers to the currently visible root directory, which
     /// may differ from the original root filesystem if overlay mounts exist.
     pub fn new_path_resolver(&self) -> PathResolver {
-        let root = Path::new_fs_root(self.root.clone()).get_top_path();
-        let cwd = Path::new_fs_root(self.root.clone()).get_top_path();
+        let root = Path::new_fs_root(self.root().clone()).get_top_path();
+        let cwd = Path::new_fs_root(self.root().clone()).get_top_path();
         PathResolver::new(root, cwd)
     }
 
@@ -98,23 +106,21 @@ impl MountNamespace {
     ) -> Result<Arc<MountNamespace>> {
         owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
 
-        let root_mount = &self.root;
-        let new_mnt_ns = Arc::new_cyclic(|weak_self| {
-            let new_root = root_mount.clone_mount_tree(
-                root_mount.root_dentry(),
-                weak_self,
-                true,
-                MountNsFileCopying::Skip,
-            );
-            let stashed_dentry = StashedDentry::new();
-            MountNamespace {
-                root: new_root,
-                owner,
-                stashed_dentry,
-            }
+        let root_mount = self.root();
+        let mut new_mnt_ns = UniqueArc::new(MountNamespace {
+            root: None,
+            owner,
+            stashed_dentry: StashedDentry::new(),
         });
+        let new_root = root_mount.clone_mount_tree(
+            root_mount.root_dentry(),
+            &UniqueArc::downgrade(&new_mnt_ns),
+            true,
+            MountNsFileCopying::Skip,
+        )?;
+        new_mnt_ns.root = Some(new_root);
 
-        Ok(new_mnt_ns)
+        Ok(UniqueArc::into_arc(new_mnt_ns))
     }
 
     /// Flushes all pending filesystem metadata and cached file data to the device
@@ -122,7 +128,7 @@ impl MountNamespace {
     pub fn sync(&self) -> Result<()> {
         let mut mount_queue = VecDeque::new();
         let mut visited_filesystems = hashbrown::HashSet::new();
-        mount_queue.push_back(self.root.clone());
+        mount_queue.push_back(self.root().clone());
 
         while let Some(current_mount) = mount_queue.pop_front() {
             let fs_ptr = Arc::as_ptr(current_mount.fs());
@@ -186,8 +192,13 @@ impl MountNamespace {
 // detached from their parents and cleared of their mountpoints.
 impl Drop for MountNamespace {
     fn drop(&mut self) {
+        let Some(root) = self.root.as_ref() else {
+            // The constructor must be incomplete
+            // and thus the subsequent cleanup logic can be skipped.
+            return;
+        };
         let mut worklist = VecDeque::new();
-        worklist.push_back(self.root.clone());
+        worklist.push_back(root.clone());
         while let Some(current_mount) = worklist.pop_front() {
             let mut children = current_mount.children.write();
             for (_, child) in children.drain() {

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -57,6 +57,25 @@ impl Ord for MountNamespace {
 }
 
 impl MountNamespace {
+    /// Creates a new `MountNamespace` whose root mount is built by `build_root_fn`.
+    ///
+    /// The closure receives a `Weak<Self>` so that mounts in the new tree can
+    /// reference the namespace being constructed. Construction uses `UniqueArc`
+    /// to allow mutable initialization while still providing `Weak` references.
+    fn new_with_root<F>(owner: Arc<UserNamespace>, build_root_fn: F) -> Result<Arc<Self>>
+    where
+        F: FnOnce(&Weak<Self>) -> Result<Arc<Mount>>,
+    {
+        let mut new_ns = UniqueArc::new(Self {
+            root: None,
+            owner,
+            stashed_dentry: StashedDentry::new(),
+        });
+        let root = build_root_fn(&UniqueArc::downgrade(&new_ns))?;
+        new_ns.root = Some(root);
+        Ok(UniqueArc::into_arc(new_ns))
+    }
+
     /// Returns a reference to the singleton initial mount namespace.
     #[doc(hidden)]
     pub fn get_init_singleton() -> &'static Arc<MountNamespace> {
@@ -66,15 +85,8 @@ impl MountNamespace {
             let owner = UserNamespace::get_init_singleton().clone();
             let rootfs = RamFs::new_rootfs();
 
-            let mut new_ns = UniqueArc::new(MountNamespace {
-                root: None,
-                owner,
-                stashed_dentry: StashedDentry::new(),
-            });
-            let root = Mount::new_root(rootfs, UniqueArc::downgrade(&new_ns))
-                .expect("failed to allocate mount ID for the root mount");
-            new_ns.root = Some(root);
-            UniqueArc::into_arc(new_ns)
+            Self::new_with_root(owner, |weak_ns| Mount::new_root(rootfs, weak_ns.clone()))
+                .expect("failed to allocate mount ID for the root mount")
         })
     }
 
@@ -107,20 +119,14 @@ impl MountNamespace {
         owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
 
         let root_mount = self.root();
-        let mut new_mnt_ns = UniqueArc::new(MountNamespace {
-            root: None,
-            owner,
-            stashed_dentry: StashedDentry::new(),
-        });
-        let new_root = root_mount.clone_mount_tree(
-            root_mount.root_dentry(),
-            &UniqueArc::downgrade(&new_mnt_ns),
-            true,
-            MountNsFileCopying::Skip,
-        )?;
-        new_mnt_ns.root = Some(new_root);
-
-        Ok(UniqueArc::into_arc(new_mnt_ns))
+        Self::new_with_root(owner, |weak_ns| {
+            root_mount.clone_mount_tree(
+                root_mount.root_dentry(),
+                weak_ns,
+                true,
+                MountNsFileCopying::Skip,
+            )
+        })
     }
 
     /// Flushes all pending filesystem metadata and cached file data to the device

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(register_tool)]
 #![feature(min_specialization)]
 #![feature(thin_box)]
+#![feature(unique_rc_arc)]
 #![register_tool(component_access_control)]
 
 extern crate alloc;


### PR DESCRIPTION
This PR fixes a kernel panic caused by `.unwrap()` on mount ID allocation when the fixed-capacity ID pool is exhausted by repeated `mount` syscalls.

The two panic sites (`Mount::new` and `Mount::clone_mount`) now return `Errno::ENOMEM` instead of panicking, matching Linux's behavior in `fs/namespace.c`.

To allow `MountNamespace::new_clone` to propagate the error with `?`, `MountNamespace::root` is changed from `Arc<Mount>` to `Once<Arc<Mount>>`, replacing `Arc::new_cyclic` with a two-phase init pattern (allocate namespace first, then clone mount tree). This mirrors Linux's `alloc_mnt_ns` + `copy_tree` approach in `copy_mnt_ns`.

Closes #3205