### PR TITLE
Optimize infallible `read_val`/`write_val`

### DIFF
--- a/ostd/src/mm/io/mod.rs
+++ b/ostd/src/mm/io/mod.rs
@@ -442,24 +442,14 @@ impl<'a> VmReader<'a, Infallible> {
             return Err(Error::InvalidArgs);
         }
 
-        let mut val = MaybeUninit::<T>::uninit();
+        let cursor = self.cursor.cast::<T>();
 
-        // SAFETY:
-        // - The memory range points to typed memory.
-        // - The validity requirements for write accesses are met because the pointer is converted
-        //   from a mutable pointer where the underlying storage outlives the temporary lifetime
-        //   and no other Rust references to the same storage exist during the lifetime.
-        // - The type, i.e., `T`, is plain-old-data.
-        let mut writer =
-            unsafe { VmWriter::from_kernel_space(val.as_mut_ptr().cast(), size_of::<T>()) };
-        self.read(&mut writer);
-        debug_assert!(!writer.has_avail());
+        // SAFETY: We have checked that the number of bytes remaining is at least the size of `T`.
+        // All other safety requirements are the same as for `Self::read`.
+        let val = unsafe { core::intrinsics::unaligned_volatile_load(cursor) };
+        self.cursor = self.cursor.wrapping_add(size_of::<T>());
 
-        // SAFETY:
-        // - `self.read` has initialized all the bytes in `val`.
-        // - The type is plain-old-data.
-        let val_inited = unsafe { val.assume_init() };
-        Ok(val_inited)
+        Ok(val)
     }
 
     /// Reads a value of the `PodOnce` type using one non-tearing memory load.
@@ -711,8 +701,13 @@ impl<'a> VmWriter<'a, Infallible> {
             return Err(Error::InvalidArgs);
         }
 
-        let mut reader = VmReader::from(new_val.as_bytes());
-        self.write(&mut reader);
+        let cursor = self.cursor.cast::<T>();
+
+        // SAFETY: We have checked that the number of bytes remaining is at least the size of `T`.
+        // All other safety requirements are the same as for `Self::write`.
+        unsafe { core::intrinsics::unaligned_volatile_store(cursor, *new_val) };
+        self.cursor = self.cursor.wrapping_add(size_of::<T>());
+
         Ok(())
     }
 


### PR DESCRIPTION
We can use `core::intrinsics::unaligned_volatile_load` to implement `VmReader::Infallible::read_val`. This results in shorter Rust code and shorter generated assembly.

I checked the generated assembly for the following method:
```patch
diff --git a/kernel/src/syscall/getpid.rs b/kernel/src/syscall/getpid.rs
index 207e9cec7..d3c72afc9 100644
--- a/kernel/src/syscall/getpid.rs
+++ b/kernel/src/syscall/getpid.rs
@@ -5,6 +5,25 @@ use crate::prelude::*;
 
 pub fn sys_getpid(ctx: &Context) -> Result<SyscallReturn> {
     let pid = ctx.process.pid();
-    debug!("pid = {}", pid);
+    debug!("pid = {} {}", pid, experiment_read_val as *const () as usize);
     Ok(SyscallReturn::Return(pid as _))
 }
+
+
+#[expect(unsafe_code)]
+#[inline(never)]
+#[unsafe(no_mangle)]
+pub fn experiment_read_val(mut reader: ostd::mm::io::VmReader<ostd::mm::io::Infallible>) {
+    #[repr(C)]
+    #[derive(Clone, Copy, Pod)]
+    struct Data {
+        foo: u64,
+        bar: u64,
+        baz: u64,
+    }
+
+    let data: Data = reader.read_val().unwrap();
+    assert_eq!(data.foo, 1);
+    assert_eq!(data.bar, 2);
+    assert_eq!(data.baz, 3);
+}
```

Before this PR:
```patch
ffffffff881dfca1:       48 8b 07                mov    (%rdi),%rax
ffffffff881dfca4:       48 8b 4f 08             mov    0x8(%rdi),%rcx
ffffffff881dfca8:       48 89 44 24 20          mov    %rax,0x20(%rsp)
ffffffff881dfcad:       48 89 4c 24 28          mov    %rcx,0x28(%rsp)
ffffffff881dfcb2:       48 8b 47 10             mov    0x10(%rdi),%rax
ffffffff881dfcb6:       48 89 44 24 30          mov    %rax,0x30(%rsp)
ffffffff881dfcbb:       48 8b 44 24 20          mov    0x20(%rsp),%rax
ffffffff881dfcc0:       48 89 04 24             mov    %rax,(%rsp)
ffffffff881dfcc4:       48 8b 4c 24 28          mov    0x28(%rsp),%rcx
ffffffff881dfcc9:       48 89 4c 24 08          mov    %rcx,0x8(%rsp)
ffffffff881dfcce:       48 8b 4c 24 30          mov    0x30(%rsp),%rcx
ffffffff881dfcd3:       48 89 4c 24 10          mov    %rcx,0x10(%rsp)
ffffffff881dfcd8:       48 83 f8 01             cmp    $0x1,%rax
ffffffff881dfcdc:       75 15                   jne    ffffffff881dfcf3 <experiment_read_val+0x63>
ffffffff881dfcde:       48 83 7c 24 08 02       cmpq   $0x2,0x8(%rsp)
ffffffff881dfce4:       75 27                   jne    ffffffff881dfd0d <experiment_read_val+0x7d>
ffffffff881dfce6:       48 83 7c 24 10 03       cmpq   $0x3,0x10(%rsp)
ffffffff881dfcec:       75 3b                   jne    ffffffff881dfd29 <experiment_read_val+0x99>
```

After this PR:
```patch
ffffffff8810ce0d:       48 8b 47 10             mov    0x10(%rdi),%rax
ffffffff8810ce11:       48 8b 17                mov    (%rdi),%rdx
ffffffff8810ce14:       48 8b 4f 08             mov    0x8(%rdi),%rcx
ffffffff8810ce18:       48 89 54 24 10          mov    %rdx,0x10(%rsp)
ffffffff8810ce1d:       48 89 4c 24 18          mov    %rcx,0x18(%rsp)
ffffffff8810ce22:       48 89 44 24 20          mov    %rax,0x20(%rsp)
ffffffff8810ce27:       48 83 fa 01             cmp    $0x1,%rdx
ffffffff8810ce2b:       75 3a                   jne    ffffffff8810ce67 <experiment_read_val+0x67>
ffffffff8810ce2d:       48 83 f9 02             cmp    $0x2,%rcx
ffffffff8810ce31:       75 50                   jne    ffffffff8810ce83 <experiment_read_val+0x83>
ffffffff8810ce33:       48 83 f8 03             cmp    $0x3,%rax
ffffffff8810ce37:       75 66                   jne    ffffffff8810ce9f <experiment_read_val+0x9f>
```