### PR TITLE
Implement ext4 read-only filesystem support foundation

### DIFF
--- a/kernel/src/fs/fs_impls/ext4/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext4/block_group.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Block group and group descriptor for Ext4.
+
+use super::{
+    inode::Inode as Ext4Inode,
+    prelude::*,
+    super_block::SuperBlock,
+};
+
+/// The in-memory rust block group descriptor.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct GroupDescriptor {
+    pub block_bitmap_bid: u64,
+    pub inode_bitmap_bid: u64,
+    pub inode_table_bid: u64,
+    pub free_blocks_count: u32,
+    pub free_inodes_count: u32,
+    pub dirs_count: u16,
+    pub flags: u16,
+}
+
+/// The raw ext4 group descriptor on disk (64 bytes with 64-bit support).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct RawGroupDescriptor {
+    pub block_bitmap_lo: u32,
+    pub inode_bitmap_lo: u32,
+    pub inode_table_lo: u32,
+    pub free_blocks_count_lo: u16,
+    pub free_inodes_count_lo: u16,
+    pub dirs_count_lo: u16,
+    pub flags: u16,
+    pub exclude_bitmap_lo: u32,
+    pub block_bitmap_csum_lo: u16,
+    pub inode_bitmap_csum_lo: u16,
+    pub itable_unused_lo: u16,
+    pub checksum: u16,
+    // 64-bit extensions
+    pub block_bitmap_hi: u32,
+    pub inode_bitmap_hi: u32,
+    pub inode_table_hi: u32,
+    pub free_blocks_count_hi: u16,
+    pub free_inodes_count_hi: u16,
+    pub dirs_count_hi: u16,
+    pub itable_unused_hi: u16,
+    pub checksum_hi: u32,
+    pub reserved: u32,
+}
+
+impl Default for RawGroupDescriptor {
+    fn default() -> Self {
+        Self {
+            block_bitmap_lo: 0,
+            inode_bitmap_lo: 0,
+            inode_table_lo: 0,
+            free_blocks_count_lo: 0,
+            free_inodes_count_lo: 0,
+            dirs_count_lo: 0,
+            flags: 0,
+            exclude_bitmap_lo: 0,
+            block_bitmap_csum_lo: 0,
+            inode_bitmap_csum_lo: 0,
+            itable_unused_lo: 0,
+            checksum: 0,
+            block_bitmap_hi: 0,
+            inode_bitmap_hi: 0,
+            inode_table_hi: 0,
+            free_blocks_count_hi: 0,
+            free_inodes_count_hi: 0,
+            dirs_count_hi: 0,
+            itable_unused_hi: 0,
+            checksum_hi: 0,
+            reserved: 0,
+        }
+    }
+}
+
+impl From<RawGroupDescriptor> for GroupDescriptor {
+    fn from(desc: RawGroupDescriptor) -> Self {
+        Self {
+            block_bitmap_bid: ((desc.block_bitmap_hi as u64) << 32) | desc.block_bitmap_lo as u64,
+            inode_bitmap_bid: ((desc.inode_bitmap_hi as u64) << 32) | desc.inode_bitmap_lo as u64,
+            inode_table_bid: ((desc.inode_table_hi as u64) << 32) | desc.inode_table_lo as u64,
+            free_blocks_count: ((desc.free_blocks_count_hi as u32) << 16) | desc.free_blocks_count_lo as u32,
+            free_inodes_count: ((desc.free_inodes_count_hi as u32) << 16) | desc.free_inodes_count_lo as u32,
+            dirs_count: desc.dirs_count_lo,
+            flags: desc.flags,
+        }
+    }
+}
+
+/// A block group in Ext4.
+#[derive(Debug)]
+pub(super) struct BlockGroup {
+    idx: usize,
+    bg_impl: Arc<BlockGroupImpl>,
+    raw_inodes_cache: PageCache,
+}
+
+struct BlockGroupImpl {
+    inode_table_bid: u64,
+    raw_inodes_size: usize,
+    inner: RwMutex<Inner>,
+    fs: Weak<super::fs::Ext4>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    descriptor: GroupDescriptor,
+    inode_cache: BTreeMap<u32, Arc<Ext4Inode>>,
+    inode_bitmap: crate::fs::utils::IdBitmap,
+}
+
+impl BlockGroup {
+    pub fn load(
+        group_descriptors_segment: &USegment,
+        idx: usize,
+        block_device: &dyn BlockDevice,
+        super_block: &SuperBlock,
+        fs: Weak<super::fs::Ext4>,
+    ) -> Result<Self> {
+        let raw_inodes_size = (super_block.inodes_per_group() as usize) * super_block.inode_size();
+        let desc_size = super_block.desc_size();
+
+        let bg_impl = {
+            let descriptor = {
+                let offset = idx * desc_size;
+                let raw_descriptor = group_descriptors_segment
+                    .read_val::<RawGroupDescriptor>(offset)
+                    .map_err(|_| Error::with_message(Errno::EIO, "failed to read group descriptor"))?;
+                GroupDescriptor::from(raw_descriptor)
+            };
+
+            let inode_bitmap = {
+                let capacity = super_block.inodes_per_group() as usize;
+                if capacity > super_block.block_size() * 8 {
+                    return_errno_with_message!(Errno::EINVAL, "bad inode bitmap capacity");
+                }
+                let mut buf = alloc::vec![0u8; super_block.block_size()];
+                let offset = descriptor.inode_bitmap_bid as usize * super_block.block_size();
+                block_device.read_bytes(offset, &mut buf)?;
+                crate::fs::utils::IdBitmap::from_buf(buf.into_boxed_slice(), capacity as u16)
+            };
+
+            Arc::new(BlockGroupImpl {
+                inode_table_bid: descriptor.inode_table_bid,
+                raw_inodes_size,
+                inner: RwMutex::new(Inner {
+                    descriptor,
+                    inode_cache: BTreeMap::new(),
+                    inode_bitmap,
+                }),
+                fs,
+            })
+        };
+
+        let raw_inodes_cache =
+            PageCache::with_capacity(raw_inodes_size, Arc::downgrade(&bg_impl) as _)?;
+
+        Ok(Self {
+            idx,
+            bg_impl,
+            raw_inodes_cache,
+        })
+    }
+
+    /// Finds and returns the inode by its index within this group.
+    pub fn lookup_inode(&self, inode_idx: u32) -> Result<Arc<Ext4Inode>> {
+        let inner = self.bg_impl.inner.read();
+        if !inner.inode_bitmap.is_allocated(inode_idx as u16) {
+            return_errno!(Errno::ENOENT);
+        }
+        if let Some(inode) = inner.inode_cache.get(&inode_idx) {
+            return Ok(inode.clone());
+        }
+        drop(inner);
+
+        let mut inner = self.bg_impl.inner.write();
+        if !inner.inode_bitmap.is_allocated(inode_idx as u16) {
+            return_errno!(Errno::ENOENT);
+        }
+        if let Some(inode) = inner.inode_cache.get(&inode_idx) {
+            return Ok(inode.clone());
+        }
+
+        let inode = self.load_inode(inode_idx)?;
+        inner.inode_cache.insert(inode_idx, inode.clone());
+        Ok(inode)
+    }
+
+    fn load_inode(&self, inode_idx: u32) -> Result<Arc<Ext4Inode>> {
+        let fs = self.fs();
+        let raw_inode = {
+            let offset = (inode_idx as usize) * fs.inode_size();
+            self.raw_inodes_cache
+                .pages()
+                .read_val::<super::inode::RawInode>(offset)
+                .map_err(|_| Error::with_message(Errno::EIO, "failed to read raw inode"))?
+        };
+        let inode_desc = super::inode::InodeDesc::try_from(raw_inode)?;
+        let ino = inode_idx + self.idx as u32 * fs.inodes_per_group() + 1;
+        Ok(Ext4Inode::new(ino, self.idx, inode_desc, Arc::downgrade(&fs)))
+    }
+
+    fn fs(&self) -> Arc<super::fs::Ext4> {
+        self.bg_impl.fs.upgrade().unwrap()
+    }
+}
+
+impl PageCacheBackend for BlockGroupImpl {
+    fn read_page_async(&self, idx: usize, frame: &CachePage) -> Result<BioWaiter> {
+        let bid = self.inode_table_bid + idx as u64;
+        let bio_segment = BioSegment::new_from_segment(
+            Segment::from(frame.clone()).into(),
+            BioDirection::FromDevice,
+        );
+        self.fs.upgrade().unwrap().read_blocks_async(bid, bio_segment)
+    }
+
+    fn write_page_async(&self, _idx: usize, _frame: &CachePage) -> Result<BioWaiter> {
+        Err(Error::with_message(Errno::EROFS, "read-only filesystem"))
+    }
+
+    fn npages(&self) -> usize {
+        self.raw_inodes_size.div_ceil(BLOCK_SIZE)
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/dir.rs
+++ b/kernel/src/fs/fs_impls/ext4/dir.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 directory entry parsing.
+//!
+//! Ext4 directory entries use the same format as ext2, with the FILETYPE feature
+//! (which is mandatory for ext4) providing the inode type in each entry.
+
+use super::prelude::*;
+
+/// The maximum length of a file name in ext4.
+pub const MAX_FNAME_LEN: usize = 255;
+
+/// The data structure in a directory's data block.
+#[derive(Clone, Debug)]
+pub struct DirEntry {
+    header: DirEntryHeader,
+    name: CStr256,
+}
+
+impl DirEntry {
+    const ALIGN: usize = 4;
+    const HEADER_LEN: usize = size_of::<DirEntryHeader>();
+    pub(super) const PARENT_OFFSET: usize = Self::HEADER_LEN + Self::ALIGN;
+
+    pub fn new(ino: u32, name: &str, inode_type: InodeType) -> Self {
+        let header = DirEntryHeader::new(ino, inode_type, name.len());
+        Self {
+            header,
+            name: CStr256::from(name),
+        }
+    }
+
+    pub fn self_entry(self_ino: u32) -> Self {
+        Self::new(self_ino, ".", InodeType::Dir)
+    }
+
+    pub fn parent_entry(parent_ino: u32) -> Self {
+        Self::new(parent_ino, "..", InodeType::Dir)
+    }
+
+    pub fn ino(&self) -> u32 {
+        self.header.ino
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str().unwrap()
+    }
+
+    pub fn type_(&self) -> InodeType {
+        InodeType::from(DirEntryFileType::from(self.header.inode_type))
+    }
+
+    pub fn record_len(&self) -> usize {
+        self.header.record_len as _
+    }
+
+    fn actual_len(&self) -> usize {
+        (Self::HEADER_LEN + self.header.name_len as usize).align_up(Self::ALIGN)
+    }
+}
+
+/// The header of a directory entry.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct DirEntryHeader {
+    pub ino: u32,
+    pub record_len: u16,
+    pub name_len: u8,
+    pub inode_type: u8,
+}
+
+impl DirEntryHeader {
+    pub fn new(ino: u32, inode_type: InodeType, name_len: usize) -> Self {
+        debug_assert!(name_len <= MAX_FNAME_LEN);
+        let record_len = (DirEntry::HEADER_LEN + name_len).align_up(DirEntry::ALIGN) as u16;
+        Self {
+            ino,
+            record_len,
+            name_len: name_len as u8,
+            inode_type: DirEntryFileType::from(inode_type) as _,
+        }
+    }
+}
+
+/// The type indicator in the directory entry.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DirEntryFileType {
+    Unknown = 0,
+    File = 1,
+    Dir = 2,
+    Char = 3,
+    Block = 4,
+    Fifo = 5,
+    Socket = 6,
+    Symlink = 7,
+}
+
+impl From<u8> for DirEntryFileType {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => Self::File,
+            2 => Self::Dir,
+            3 => Self::Char,
+            4 => Self::Block,
+            5 => Self::Fifo,
+            6 => Self::Socket,
+            7 => Self::Symlink,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<InodeType> for DirEntryFileType {
+    fn from(inode_type: InodeType) -> Self {
+        match inode_type {
+            InodeType::NamedPipe => Self::Fifo,
+            InodeType::CharDevice => Self::Char,
+            InodeType::Dir => Self::Dir,
+            InodeType::BlockDevice => Self::Block,
+            InodeType::File => Self::File,
+            InodeType::SymLink => Self::Symlink,
+            InodeType::Socket => Self::Socket,
+            InodeType::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<DirEntryFileType> for InodeType {
+    fn from(file_type: DirEntryFileType) -> Self {
+        match file_type {
+            DirEntryFileType::Fifo => Self::NamedPipe,
+            DirEntryFileType::Char => Self::CharDevice,
+            DirEntryFileType::Dir => Self::Dir,
+            DirEntryFileType::Block => Self::BlockDevice,
+            DirEntryFileType::File => Self::File,
+            DirEntryFileType::Symlink => Self::SymLink,
+            DirEntryFileType::Socket => Self::Socket,
+            DirEntryFileType::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// A reader for reading directory entries from the page cache.
+pub(super) struct DirEntryReader<'a> {
+    page_cache: &'a PageCache,
+    from_offset: usize,
+    name_buf: Option<[u8; MAX_FNAME_LEN]>,
+}
+
+impl<'a> DirEntryReader<'a> {
+    pub fn new(page_cache: &'a PageCache, from_offset: usize) -> Self {
+        Self {
+            page_cache,
+            from_offset,
+            name_buf: None,
+        }
+    }
+
+    /// Returns whether the directory contains an entry with the given name.
+    pub fn contains_entry(&mut self, name: &str) -> bool {
+        let mut iter = self.iter();
+        iter.any(|entry_item| {
+            if entry_item.name_len() != name.len() {
+                return false;
+            }
+            self.read_name(&entry_item)
+                .map(|b| b == name.as_bytes())
+                .unwrap_or(false)
+        })
+    }
+
+    /// Finds the entry with the given name, returning a DirEntryItem.
+    pub fn find_entry_item(&mut self, name: &str) -> Option<DirEntryItem> {
+        let name_len = name.len();
+        let name_bytes = name.as_bytes();
+        self.iter().find(|entry_item| {
+            if entry_item.name_len() != name_len {
+                return false;
+            }
+            self.read_name(entry_item)
+                .map(|b| b == name_bytes)
+                .unwrap_or(false)
+        })
+    }
+
+    /// Returns the number of valid entries in the directory.
+    pub fn entry_count(&self) -> usize {
+        DirEntryIter {
+            page_cache: self.page_cache,
+            offset: self.from_offset,
+        }
+        .count()
+    }
+
+    /// Returns an iterator over directory entry items, along with name reading capability.
+    pub fn iter_entries(&mut self) -> impl Iterator<Item = DirEntry> + '_ {
+        let iter = self.iter();
+        iter.filter_map(|entry_item| match self.read_name(&entry_item) {
+            Ok(name_buf) => Some(DirEntry {
+                header: entry_item.header,
+                name: CStr256::from(name_buf),
+            }),
+            Err(_) => None,
+        })
+    }
+
+    fn iter(&self) -> DirEntryIter<'a> {
+        DirEntryIter {
+            page_cache: self.page_cache,
+            offset: self.from_offset,
+        }
+    }
+
+    fn read_name(&mut self, entry_item: &DirEntryItem) -> Result<&[u8]> {
+        if self.name_buf.is_none() {
+            self.name_buf = Some([0; MAX_FNAME_LEN]);
+        }
+        let name_len = entry_item.name_len();
+        let name_buf = &mut self.name_buf.as_mut().unwrap()[..name_len];
+        let offset = entry_item.offset + DirEntry::HEADER_LEN;
+        self.page_cache.pages().read_bytes(offset, name_buf)?;
+        Ok(name_buf)
+    }
+}
+
+/// An iterator over directory entries.
+struct DirEntryIter<'a> {
+    page_cache: &'a PageCache,
+    offset: usize,
+}
+
+impl DirEntryIter<'_> {
+    fn read_next_dir_entry(&mut self) -> Option<DirEntryItem> {
+        if self.offset >= self.page_cache.pages().size() {
+            return None;
+        };
+
+        let header = self
+            .page_cache
+            .pages()
+            .read_val::<DirEntryHeader>(self.offset)
+            .ok()?;
+
+        if header.record_len == 0 {
+            return None;
+        }
+
+        let item = DirEntryItem {
+            header,
+            offset: self.offset,
+        };
+
+        self.offset += header.record_len as usize;
+        Some(item)
+    }
+}
+
+impl Iterator for DirEntryIter<'_> {
+    type Item = DirEntryItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next_item = self.read_next_dir_entry()?;
+            if next_item.header.ino == 0
+                || DirEntryFileType::from(next_item.header.inode_type) == DirEntryFileType::Unknown
+            {
+                continue;
+            }
+            return Some(next_item);
+        }
+    }
+}
+
+/// A lightweight representation of a directory entry, without the name.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DirEntryItem {
+    header: DirEntryHeader,
+    offset: usize,
+}
+
+impl DirEntryItem {
+    pub fn header(&self) -> &DirEntryHeader {
+        &self.header
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn ino(&self) -> u32 {
+        self.header.ino
+    }
+
+    pub fn name_len(&self) -> usize {
+        self.header.name_len as _
+    }
+
+    pub fn type_(&self) -> InodeType {
+        InodeType::from(DirEntryFileType::from(self.header.inode_type))
+    }
+
+    pub fn record_len(&self) -> usize {
+        self.header.record_len as _
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/extent.rs
+++ b/kernel/src/fs/fs_impls/ext4/extent.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 extent tree.
+//!
+//! Extents replace the traditional indirect block mapping scheme used by ext2/3.
+
+use super::prelude::*;
+
+/// Magic number for the extent header.
+const EXTENT_MAGIC: u16 = 0xF30A;
+
+/// The root extent header lives in the inode's i_block[] area (60 bytes).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct ExtentHeader {
+    /// Magic number (0xF30A).
+    pub magic: u16,
+    /// Number of valid entries following the header.
+    pub entries: u16,
+    /// Maximum number of entries that can fit.
+    pub max: u16,
+    /// Depth of the tree (0 = leaf nodes).
+    pub depth: u16,
+    /// Generation of the tree.
+    pub generation: u32,
+}
+
+impl Default for ExtentHeader {
+    fn default() -> Self {
+        Self {
+            magic: 0,
+            entries: 0,
+            max: 0,
+            depth: 0,
+            generation: 0,
+        }
+    }
+}
+
+/// An extent index node — points to a child block in the extent tree.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct ExtentIndex {
+    /// Logical block number covered by the child block.
+    pub block: u32,
+    /// Lower 32 bits of the physical block number of the child.
+    pub leaf_lo: u32,
+    /// Upper 16 bits of the physical block number.
+    pub leaf_hi: u16,
+    /// Padding.
+    pub _pad: u16,
+}
+
+impl Default for ExtentIndex {
+    fn default() -> Self {
+        Self {
+            block: 0,
+            leaf_lo: 0,
+            leaf_hi: 0,
+            _pad: 0,
+        }
+    }
+}
+
+impl ExtentIndex {
+    pub fn leaf_bid(&self) -> u64 {
+        ((self.leaf_hi as u64) << 32) | self.leaf_lo as u64
+    }
+}
+
+/// A leaf extent — maps a contiguous range of logical blocks to physical blocks.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct ExtentLeaf {
+    /// First logical block number covered by this extent.
+    pub block: u32,
+    /// Number of blocks covered by this extent.
+    pub len: u16,
+    /// Upper 16 bits of the physical block number.
+    pub start_hi: u16,
+    /// Lower 32 bits of the physical block number.
+    pub start_lo: u32,
+}
+
+impl Default for ExtentLeaf {
+    fn default() -> Self {
+        Self {
+            block: 0,
+            len: 0,
+            start_hi: 0,
+            start_lo: 0,
+        }
+    }
+}
+
+impl ExtentLeaf {
+    pub fn start_bid(&self) -> u64 {
+        ((self.start_hi as u64) << 32) | self.start_lo as u64
+    }
+
+    pub fn len(&self) -> u32 {
+        self.len as u32
+    }
+}
+
+/// An extent tree reader that traverses the extent tree to find a physical block.
+pub(super) struct ExtentReader {
+    pub header: ExtentHeader,
+    data: [u8; 60],
+}
+
+impl ExtentReader {
+    /// Reads the extent header from the raw bytes (typically from inode i_block[]).
+    pub fn new(data: &[u8; 60]) -> Result<Self> {
+        let header = ExtentHeader::read_from_prefix(data)
+            .ok_or(Error::with_message(Errno::EINVAL, "failed to read extent header"))?;
+        if header.magic != EXTENT_MAGIC {
+            return_errno_with_message!(Errno::EINVAL, "bad extent magic");
+        }
+        Ok(Self { header, data: *data })
+    }
+
+    /// Given a logical block number, find its physical block number.
+    /// Returns None if the block is not mapped (sparse/hole).
+    pub fn find_block(
+        &self,
+        logical_block: u32,
+        block_device: &dyn aster_block::BlockDevice,
+        block_size: usize,
+    ) -> Result<Option<u64>> {
+        self.find_block_recursive(logical_block, &self.header, &self.data, block_device, block_size)
+    }
+
+    fn find_block_recursive(
+        &self,
+        logical_block: u32,
+        header: &ExtentHeader,
+        data: &[u8; 60],
+        block_device: &dyn aster_block::BlockDevice,
+        block_size: usize,
+    ) -> Result<Option<u64>> {
+        let entry_size = if header.depth == 0 {
+            size_of::<ExtentLeaf>()
+        } else {
+            size_of::<ExtentIndex>()
+        };
+        let entries_start = size_of::<ExtentHeader>();
+
+        for i in 0..header.entries as usize {
+            let offset = entries_start + i * entry_size;
+            if header.depth == 0 {
+                let leaf = ExtentLeaf::read_from_prefix(&data[offset..])
+                    .ok_or(Error::with_message(Errno::EIO, "failed to read extent leaf"))?;
+                let end = leaf.block as u32 + leaf.len();
+                if logical_block >= leaf.block as u32 && logical_block < end {
+                    let phys_block = leaf.start_bid() + (logical_block - leaf.block as u32) as u64;
+                    return Ok(Some(phys_block));
+                }
+            } else {
+                let idx = ExtentIndex::read_from_prefix(&data[offset..])
+                    .ok_or(Error::with_message(Errno::EIO, "failed to read extent index"))?;
+                if logical_block >= idx.block as u32 {
+                    // Read the child block
+                    let mut child_buf = alloc::vec![0u8; block_size];
+                    let child_bid = idx.leaf_bid();
+                    block_device.read_bytes(child_bid as usize * block_size, &mut child_buf)?;
+
+                    let mut child_data = [0u8; 60];
+                    let copy_len = child_buf.len().min(60);
+                    child_data[..copy_len].copy_from_slice(&child_buf[..copy_len]);
+
+                    let child_header = ExtentHeader::read_from_prefix(&child_data)
+                        .ok_or(Error::with_message(Errno::EIO, "failed to read child extent header"))?;
+                    if child_header.magic != EXTENT_MAGIC {
+                        return_errno_with_message!(Errno::EIO, "bad child extent magic");
+                    }
+
+                    // Create full data from child block
+                    let mut full_child_data = [0u8; 60];
+                    let full_copy_len = child_buf.len().min(60);
+                    full_child_data[..full_copy_len].copy_from_slice(&child_buf[..full_copy_len]);
+
+                    return self.find_block_recursive(
+                        logical_block,
+                        &child_header,
+                        &full_child_data,
+                        block_device,
+                        block_size,
+                    );
+                }
+            }
+        }
+        // Not found — sparse hole
+        Ok(None)
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/fs.rs
+++ b/kernel/src/fs/fs_impls/ext4/fs.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Core Ext4 filesystem object.
+
+use device_id::DeviceId;
+
+use super::{
+    block_group::{BlockGroup, RawGroupDescriptor},
+    inode::Inode as Ext4Inode,
+    prelude::*,
+    super_block::{RawSuperBlock, SUPER_BLOCK_OFFSET, SuperBlock},
+};
+use crate::fs::vfs::{
+    file_system::{FileSystem, FsEventSubscriberStats},
+    registry::{FsCreationCtx, FsProperties, FsType},
+};
+
+/// The root inode number.
+const ROOT_INO: u32 = 2;
+
+/// The Ext4 filesystem.
+#[derive(Debug)]
+pub struct Ext4 {
+    block_device: Arc<dyn BlockDevice>,
+    super_block: RwMutex<Dirty<SuperBlock>>,
+    block_groups: Vec<BlockGroup>,
+    inodes_per_group: u32,
+    blocks_per_group: u64,
+    inode_size: usize,
+    block_size: usize,
+    group_descriptors_segment: USegment,
+    fs_event_subscriber_stats: FsEventSubscriberStats,
+    self_ref: Weak<Self>,
+}
+
+impl Ext4 {
+    /// Opens and loads an Ext4 filesystem from the `block_device`.
+    pub fn open(block_device: Arc<dyn BlockDevice>) -> Result<Arc<Self>> {
+        let super_block = {
+            let raw_super_block = block_device.read_val::<RawSuperBlock>(SUPER_BLOCK_OFFSET)?;
+            SuperBlock::try_from(raw_super_block)?
+        };
+
+        let block_size = super_block.block_size();
+        let group_descriptors_segment: USegment = {
+            let desc_size = super_block.desc_size();
+            let npages = ((super_block.block_groups_count() as usize) * desc_size)
+                .div_ceil(block_size);
+            let segment = FrameAllocOptions::new()
+                .zeroed(false)
+                .alloc_segment(npages)?;
+            let bio_segment =
+                BioSegment::new_from_segment(segment.clone().into(), BioDirection::FromDevice);
+            let gdt_bid = super_block.group_descriptors_bid(0);
+            match block_device.read_blocks(Bid::new(gdt_bid), bio_segment)? {
+                BioStatus::Complete => (),
+                err_status => {
+                    return Err(Error::from(err_status));
+                }
+            }
+            segment.into()
+        };
+
+        let load_block_groups = |fs: Weak<Ext4>,
+                                 block_device: &dyn BlockDevice,
+                                 group_descriptors_segment: &USegment|
+         -> Result<Vec<BlockGroup>> {
+            let block_groups_count = super_block.block_groups_count() as usize;
+            let mut block_groups = Vec::with_capacity(block_groups_count);
+            for idx in 0..block_groups_count {
+                let block_group = BlockGroup::load(
+                    group_descriptors_segment,
+                    idx,
+                    block_device,
+                    &super_block,
+                    fs.clone(),
+                )?;
+                block_groups.push(block_group);
+            }
+            Ok(block_groups)
+        };
+
+        let ext4 = Arc::new_cyclic(|weak_ref| Self {
+            inodes_per_group: super_block.inodes_per_group(),
+            blocks_per_group: super_block.blocks_per_group() as u64,
+            inode_size: super_block.inode_size(),
+            block_size: super_block.block_size(),
+            block_groups: load_block_groups(
+                weak_ref.clone(),
+                block_device.as_ref(),
+                &group_descriptors_segment,
+            )
+            .unwrap(),
+            block_device,
+            super_block: RwMutex::new(Dirty::new(super_block)),
+            group_descriptors_segment,
+            fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+            self_ref: weak_ref.clone(),
+        });
+        Ok(ext4)
+    }
+
+    /// Returns the block device.
+    pub fn block_device(&self) -> &dyn BlockDevice {
+        self.block_device.as_ref()
+    }
+
+    /// Returns the device ID containing this filesystem.
+    pub fn container_device_id(&self) -> DeviceId {
+        self.block_device.id()
+    }
+
+    /// Returns the size of block.
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Returns the size of inode.
+    pub fn inode_size(&self) -> usize {
+        self.inode_size
+    }
+
+    /// Returns the number of inodes in each block group.
+    pub fn inodes_per_group(&self) -> u32 {
+        self.inodes_per_group
+    }
+
+    /// Returns the number of blocks in each block group.
+    pub fn blocks_per_group(&self) -> u64 {
+        self.blocks_per_group
+    }
+
+    /// Returns the super block.
+    pub fn super_block(&self) -> RwMutexReadGuard<'_, Dirty<SuperBlock>> {
+        self.super_block.read()
+    }
+
+    /// Returns the root inode.
+    pub fn root_inode(&self) -> Result<Arc<Ext4Inode>> {
+        self.lookup_inode(ROOT_INO)
+    }
+
+    /// Finds and returns the inode by `ino`.
+    pub(super) fn lookup_inode(&self, ino: u32) -> Result<Arc<Ext4Inode>> {
+        let (_, block_group) = self.block_group_of_ino(ino)?;
+        let inode_idx = self.inode_idx(ino);
+        block_group.lookup_inode(inode_idx)
+    }
+
+    /// Reads contiguous blocks starting from the `bid` synchronously.
+    pub(super) fn read_blocks(&self, bid: u64, bio_segment: BioSegment) -> Result<()> {
+        let status = self
+            .block_device
+            .read_blocks(Bid::new(bid), bio_segment)?;
+        match status {
+            BioStatus::Complete => Ok(()),
+            err_status => Err(Error::from(err_status)),
+        }
+    }
+
+    /// Reads contiguous blocks starting from the `bid` asynchronously.
+    pub(super) fn read_blocks_async(
+        &self,
+        bid: u64,
+        bio_segment: BioSegment,
+    ) -> Result<BioWaiter> {
+        let waiter = self
+            .block_device
+            .read_blocks_async(Bid::new(bid), bio_segment)?;
+        Ok(waiter)
+    }
+
+    fn block_group_of_ino(&self, ino: u32) -> Result<(usize, &BlockGroup)> {
+        let block_group_idx = ((ino - 1) / self.inodes_per_group) as usize;
+        if block_group_idx >= self.block_groups.len() {
+            return_errno!(Errno::ENOENT);
+        }
+        Ok((block_group_idx, &self.block_groups[block_group_idx]))
+    }
+
+    fn inode_idx(&self, ino: u32) -> u32 {
+        (ino - 1) % self.inodes_per_group
+    }
+
+    pub fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        &self.fs_event_subscriber_stats
+    }
+}
+
+pub(super) struct Ext4Type;
+
+impl FsType for Ext4Type {
+    fn name(&self) -> &'static str {
+        "ext4"
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::NEED_DISK
+    }
+
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(Ext4::open(fs_creation_ctx.resolve_block_device()?)?)
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
+        None
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     fs::{
-        ext4::fs::Ext4,
+        ext4::Ext4,
         utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! FileSystem adapter for Ext4.
+
+use crate::{
+    fs::{
+        ext4::fs::Ext4,
+        utils::NAME_MAX,
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            inode::Inode,
+        },
+    },
+    prelude::*,
+};
+
+use super::super::super_block::MAGIC_NUM;
+
+impl FileSystem for Ext4 {
+    fn name(&self) -> &'static str {
+        "ext4"
+    }
+
+    fn sync(&self) -> Result<()> {
+        self.block_device().sync()?;
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root_inode().unwrap()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        let sb = self.super_block();
+        SuperBlock {
+            magic: MAGIC_NUM as _,
+            bsize: sb.block_size(),
+            blocks: sb.blocks_count() as _,
+            bfree: sb.free_blocks_count() as _,
+            bavail: sb.free_blocks_count() as _,
+            files: sb.inodes_count() as _,
+            ffree: sb.free_inodes_count() as _,
+            fsid: 0,
+            namelen: NAME_MAX,
+            frsize: sb.block_size(),
+            flags: 0,
+            container_dev_id: self.container_device_id(),
+        }
+    }
+
+    fn flags(&self) -> FsFlags {
+        FsFlags::empty()
+    }
+
+    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        self.fs_event_subscriber_stats()
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/inode.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Inode adapter for Ext4.
+
+use core::time::Duration;
+
+use device_id::DeviceId;
+
+use crate::{
+    fs::{
+        ext4::{FilePerm, Inode as Ext4Inode},
+        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags},
+        utils::DirentVisitor,
+        vfs::{
+            file_system::FileSystem,
+            inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            xattr::{XattrName, XattrNamespace, XattrSetFlags},
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
+    vm::vmo::Vmo,
+};
+
+impl InodeIo for Ext4Inode {
+    fn read_at(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        self.read_at(offset, writer)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _reader: &mut VmReader,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        return_errno!(Errno::EROFS)
+    }
+}
+
+impl Inode for Ext4Inode {
+    fn size(&self) -> usize {
+        self.file_size()
+    }
+
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn metadata(&self) -> Metadata {
+        let fs = self.fs();
+        Metadata {
+            ino: self.ino() as u64,
+            size: self.file_size(),
+            optimal_block_size: fs.block_size(),
+            nr_sectors_allocated: 0,
+            last_access_at: Duration::ZERO,
+            last_modify_at: Duration::ZERO,
+            last_meta_change_at: Duration::ZERO,
+            type_: self.inode_type(),
+            mode: InodeMode::from_bits_truncate(self.file_perm().bits() as u32),
+            nr_hard_links: 0,
+            uid: Uid::new(0),
+            gid: Gid::new(0),
+            container_dev_id: fs.container_device_id(),
+            self_dev_id: None,
+        }
+    }
+
+    fn atime(&self) -> Duration {
+        Duration::ZERO
+    }
+
+    fn set_atime(&self, _time: Duration) {}
+
+    fn mtime(&self) -> Duration {
+        Duration::ZERO
+    }
+
+    fn set_mtime(&self, _time: Duration) {}
+
+    fn ctime(&self) -> Duration {
+        Duration::ZERO
+    }
+
+    fn set_ctime(&self, _time: Duration) {}
+
+    fn ino(&self) -> u64 {
+        self.ino() as u64
+    }
+
+    fn type_(&self) -> InodeType {
+        self.inode_type()
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(InodeMode::from_bits_truncate(self.file_perm().bits() as u32))
+    }
+
+    fn set_mode(&self, _mode: InodeMode) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(Uid::new(0))
+    }
+
+    fn set_owner(&self, _uid: Uid) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(Gid::new(0))
+    }
+
+    fn set_group(&self, _gid: Gid) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
+        Some(self.page_cache())
+    }
+
+    fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn FileIo>>> {
+        None
+    }
+
+    fn create(&self, _name: &str, _type_: InodeType, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn mknod(&self, _name: &str, _mode: InodeMode, _type_: MknodType) -> Result<Arc<dyn Inode>> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        Ok(self.lookup(name)?)
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        self.readdir_at(offset, visitor)
+    }
+
+    fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn unlink(&self, _name: &str) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn rmdir(&self, _name: &str) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn write_link(&self, _target: &str) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        return_errno!(Errno::EROFS)
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn sync_data(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs()
+    }
+
+    fn extension(&self) -> &Extension {
+        // TODO: implement extension
+        unimplemented!("ext4 inode extension")
+    }
+
+    fn set_xattr(
+        &self,
+        _name: XattrName,
+        _value_reader: &mut VmReader,
+        _flags: XattrSetFlags,
+    ) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP)
+    }
+
+    fn get_xattr(&self, _name: XattrName, _value_writer: &mut VmWriter) -> Result<usize> {
+        return_errno!(Errno::ENODATA)
+    }
+
+    fn list_xattr(&self, _namespace: XattrNamespace, _list_writer: &mut VmWriter) -> Result<usize> {
+        Ok(0)
+    }
+
+    fn remove_xattr(&self, _name: XattrName) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP)
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! VFS adapter layer for Ext4.
+
+mod fs;
+mod inode;

--- a/kernel/src/fs/fs_impls/ext4/inode.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 inode representation.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use inherit_methods_macro::inherit_methods;
+
+use super::{
+    dir::{DirEntryHeader, DirEntryItem, DirEntryReader, MAX_FNAME_LEN},
+    extent::ExtentReader,
+    fs::Ext4,
+    prelude::*,
+};
+
+/// The root inode number.
+const ROOT_INO: u32 = 2;
+
+/// The Ext4 inode.
+pub struct Inode {
+    ino: u32,
+    type_: InodeType,
+    block_group_idx: usize,
+    inner: RwMutex<InodeInner>,
+    fs: Weak<Ext4>,
+}
+
+impl Inode {
+    pub(super) fn new(ino: u32, block_group_idx: usize, desc: InodeDesc, fs: Weak<Ext4>) -> Arc<Self> {
+        Arc::new_cyclic(|_weak_self| Self {
+            ino,
+            type_: desc.type_,
+            block_group_idx,
+            inner: RwMutex::new(InodeInner::new(desc, fs.clone())),
+            fs,
+        })
+    }
+
+    pub fn ino(&self) -> u32 {
+        self.ino
+    }
+
+    pub fn inode_type(&self) -> InodeType {
+        self.type_
+    }
+
+    pub fn fs(&self) -> Arc<Ext4> {
+        self.fs.upgrade().unwrap()
+    }
+
+    pub fn file_size(&self) -> usize {
+        self.inner.read().desc.size
+    }
+
+    pub fn page_cache(&self) -> Arc<Vmo> {
+        self.inner.read().page_cache.pages().clone()
+    }
+
+    /// Look up an entry in a directory by name.
+    pub fn lookup(&self, name: &str) -> Result<Arc<Self>> {
+        if name.len() > MAX_FNAME_LEN {
+            return_errno!(Errno::ENAMETOOLONG);
+        }
+        if self.type_ != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+
+        let mut inner = self.inner.write();
+        let ino = inner
+            .find_entry_item(name)
+            .map(|entry| entry.ino())
+            .ok_or(Error::new(Errno::ENOENT))?;
+        drop(inner);
+        self.fs().lookup_inode(ino)
+    }
+
+    /// Read directory entries starting from the given offset.
+    pub fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        if self.type_ != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+
+        let inner = self.inner.read();
+        let mut dir_entry_reader = DirEntryReader::new(&inner.page_cache, offset);
+        let mut iterate_offset = offset;
+        for dir_entry in dir_entry_reader.iter_entries() {
+            visitor.visit(
+                dir_entry.name(),
+                dir_entry.ino() as u64,
+                dir_entry.type_(),
+                dir_entry.record_len(),
+            )?;
+            iterate_offset += dir_entry.record_len();
+        }
+        Ok(iterate_offset - offset)
+    }
+
+    /// Read file data at the given offset.
+    pub fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        if self.type_ != InodeType::File {
+            return_errno!(Errno::EISDIR);
+        }
+
+        let inner = self.inner.read();
+        let (start, read_len) = {
+            let file_size = inner.desc.size;
+            let start = file_size.min(offset);
+            let end = file_size.min(offset + writer.avail());
+            (start, end - start)
+        };
+
+        inner.page_cache.pages().read(start, writer)?;
+        Ok(read_len)
+    }
+}
+
+impl Debug for Inode {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Inode")
+            .field("ino", &self.ino)
+            .field("block_group_idx", &self.block_group_idx)
+            .finish()
+    }
+}
+
+#[inherit_methods(from = "self.desc")]
+impl Inode {
+    pub fn file_perm(&self) -> FilePerm;
+}
+
+struct InodeInner {
+    desc: InodeDesc,
+    page_cache: PageCache,
+    block_mapper: Arc<InodeBlockMapper>,
+}
+
+impl InodeInner {
+    pub fn new(desc: InodeDesc, fs: Weak<Ext4>) -> Self {
+        let num_page_bytes = (desc.blocks_count() as usize) * BLOCK_SIZE;
+        let block_mapper = Arc::new(InodeBlockMapper {
+            nblocks: AtomicUsize::new(desc.blocks_count() as _),
+            extent_data: RwMutex::new(desc.extent_data),
+            fs,
+        });
+        Self {
+            page_cache: PageCache::with_capacity(
+                num_page_bytes,
+                Arc::downgrade(&block_mapper) as _,
+            )
+            .unwrap(),
+            desc,
+            block_mapper,
+        }
+    }
+
+    pub fn contains_entry(&mut self, name: &str) -> bool {
+        DirEntryReader::new(&self.page_cache, 0).contains_entry(name)
+    }
+
+    pub fn find_entry_item(&mut self, name: &str) -> Option<DirEntryItem> {
+        DirEntryReader::new(&self.page_cache, 0).find_entry_item(name)
+    }
+
+    pub fn entry_count(&self) -> usize {
+        DirEntryReader::new(&self.page_cache, 0).entry_count()
+    }
+}
+
+/// Maps inode logical blocks to physical blocks using extents.
+struct InodeBlockMapper {
+    nblocks: AtomicUsize,
+    extent_data: RwMutex<[u8; 60]>,
+    fs: Weak<Ext4>,
+}
+
+impl PageCacheBackend for InodeBlockMapper {
+    fn read_page_async(&self, idx: usize, frame: &CachePage) -> Result<BioWaiter> {
+        let fs = self.fs.upgrade().ok_or(Error::with_message(Errno::EIO, "fs gone"))?;
+        let extent_reader =
+            ExtentReader::new(&self.extent_data.read()).map_err(|e| Error::from(e))?;
+        let phys_bid = extent_reader
+            .find_block(idx as u32, fs.block_device(), fs.block_size())?
+            .ok_or(Error::with_message(Errno::EIO, "sparse file not supported yet"))?;
+
+        let bio_segment = BioSegment::new_from_segment(
+            Segment::from(frame.clone()).into(),
+            BioDirection::FromDevice,
+        );
+        fs.read_blocks_async(phys_bid, bio_segment)
+    }
+
+    fn write_page_async(&self, _idx: usize, _frame: &CachePage) -> Result<BioWaiter> {
+        Err(Error::with_message(Errno::EROFS, "read-only filesystem"))
+    }
+
+    fn npages(&self) -> usize {
+        self.nblocks.load(Ordering::Acquire)
+    }
+}
+
+/// The in-memory rust inode descriptor for ext4.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct InodeDesc {
+    pub type_: InodeType,
+    pub perm: FilePerm,
+    pub uid: u32,
+    pub gid: u32,
+    pub size: usize,
+    pub atime: Duration,
+    pub ctime: Duration,
+    pub mtime: Duration,
+    pub hard_links: u16,
+    pub sector_count: u32,
+    pub flags: FileFlags,
+    pub extent_data: [u8; 60],
+}
+
+impl InodeDesc {
+    /// Returns the number of blocks utilized by this inode.
+    pub fn blocks_count(&self) -> u32 {
+        if self.type_ == InodeType::SymLink && self.size <= 60 {
+            return 0; // Fast symlink
+        }
+        self.size.div_ceil(BLOCK_SIZE) as u32
+    }
+}
+
+impl TryFrom<RawInode> for InodeDesc {
+    type Error = crate::error::Error;
+
+    fn try_from(inode: RawInode) -> Result<Self> {
+        let inode_type = InodeType::from_raw_mode(inode.mode)?;
+        Ok(Self {
+            type_: inode_type,
+            perm: FilePerm::from_raw_mode(inode.mode)?,
+            uid: ((inode.os_dependent_2.uid_high as u32) << 16) | inode.uid as u32,
+            gid: ((inode.os_dependent_2.gid_high as u32) << 16) | inode.gid as u32,
+            size: if inode_type == InodeType::File {
+                ((inode.size_high as usize) << 32) | inode.size_low as usize
+            } else {
+                inode.size_low as usize
+            },
+            atime: Duration::from(inode.atime),
+            ctime: Duration::from(inode.ctime),
+            mtime: Duration::from(inode.mtime),
+            hard_links: inode.hard_links,
+            sector_count: inode.sector_count,
+            flags: FileFlags::from_bits(inode.flags)
+                .ok_or(Error::with_message(Errno::EINVAL, "invalid file flags"))?,
+            extent_data: inode.block_data,
+        })
+    }
+}
+
+/// The on-disk ext4 inode structure.
+///
+/// Standard inode size is 256 bytes for ext4 (s_inode_size is typically 256).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawInode {
+    pub mode: u16,
+    pub uid: u16,
+    pub size_low: u32,
+    pub atime: UnixTime,
+    pub ctime: UnixTime,
+    pub mtime: UnixTime,
+    pub dtime: UnixTime,
+    pub gid: u16,
+    pub hard_links: u16,
+    pub sector_count: u32,
+    pub flags: u32,
+    pub osd1: u32,
+    /// Extent tree or block pointers (60 bytes).
+    pub block_data: [u8; 60],
+    pub generation: u32,
+    pub file_acl_lo: u32,
+    pub size_high: u32,
+    pub obso_faddr: u32,
+    pub os_dependent_2: Osd2,
+    /// Extra isize fields (beyond 128 bytes).
+    pub extra: [u8; 128],
+}
+
+/// OS dependent Value 2.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct Osd2 {
+    pub frag_num: u8,
+    pub frag_size: u8,
+    pad1: u16,
+    pub uid_high: u16,
+    pub gid_high: u16,
+    reserved2: u32,
+}
+
+bitflags! {
+    pub struct FilePerm: u16 {
+        const S_ISUID = 0o4000;
+        const S_ISGID = 0o2000;
+        const S_ISVTX = 0o1000;
+        const S_IRUSR = 0o0400;
+        const S_IWUSR = 0o0200;
+        const S_IXUSR = 0o0100;
+        const S_IRGRP = 0o0040;
+        const S_IWGRP = 0o0020;
+        const S_IXGRP = 0o0010;
+        const S_IROTH = 0o0004;
+        const S_IWOTH = 0o0002;
+        const S_IXOTH = 0o0001;
+    }
+}
+
+impl FilePerm {
+    pub fn from_raw_mode(mode: u16) -> Result<Self> {
+        const PERM_MASK: u16 = 0o7777;
+        Self::from_bits(mode & PERM_MASK)
+            .ok_or(Error::with_message(Errno::EINVAL, "invalid file perm"))
+    }
+}
+
+bitflags! {
+    pub struct FileFlags: u32 {
+        const SECURE_DEL = 1 << 0;
+        const UNDELETE = 1 << 1;
+        const COMPRESS = 1 << 2;
+        const SYNC_UPDATE = 1 << 3;
+        const IMMUTABLE = 1 << 4;
+        const APPEND_ONLY = 1 << 5;
+        const NO_DUMP = 1 << 6;
+        const NO_ATIME = 1 << 7;
+        const DIRTY = 1 << 8;
+        const COMPRESS_BLK = 1 << 9;
+        const NO_COMPRESS = 1 << 10;
+        const ENCRYPT = 1 << 11;
+        const INDEX_DIR = 1 << 12;
+        const IMAGIC = 1 << 13;
+        const JOURNAL_DATA = 1 << 14;
+        const NO_TAIL = 1 << 15;
+        const DIR_SYNC = 1 << 16;
+        const TOP_DIR = 1 << 17;
+        const EXTENTS = 1 << 18;
+        const RESERVED = 1 << 31;
+    }
+}
+
+impl InodeType {
+    fn from_raw_mode(mode: u16) -> Result<Self> {
+        const TYPE_MASK: u16 = 0o170000;
+        match mode & TYPE_MASK {
+            0o040000 => Ok(InodeType::Dir),
+            0o100000 => Ok(InodeType::File),
+            0o120000 => Ok(InodeType::SymLink),
+            0o060000 => Ok(InodeType::BlockDevice),
+            0o020000 => Ok(InodeType::CharDevice),
+            0o010000 => Ok(InodeType::NamedPipe),
+            0o140000 => Ok(InodeType::Socket),
+            _ => Ok(InodeType::Unknown),
+        }
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/mod.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 filesystem support.
+//!
+//! This module implements read-only Ext4 filesystem support.
+
+pub use fs::Ext4;
+pub use inode::Inode as Ext4Inode;
+pub use super_block::MAGIC_NUM;
+
+use crate::fs::ext4::fs::Ext4Type;
+
+mod block_group;
+mod dir;
+mod extent;
+mod fs;
+mod impl_for_vfs;
+mod inode;
+mod prelude;
+mod super_block;
+
+pub(super) fn init() {
+    crate::fs::vfs::registry::register(&Ext4Type).unwrap();
+}

--- a/kernel/src/fs/fs_impls/ext4/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/mod.rs
@@ -5,10 +5,10 @@
 //! This module implements read-only Ext4 filesystem support.
 
 pub use fs::Ext4;
-pub use inode::Inode as Ext4Inode;
+pub use inode::{FilePerm, Inode as Ext4Inode};
 pub use super_block::MAGIC_NUM;
 
-use crate::fs::ext4::fs::Ext4Type;
+use fs::Ext4Type;
 
 mod block_group;
 mod dir;

--- a/kernel/src/fs/fs_impls/ext4/prelude.rs
+++ b/kernel/src/fs/fs_impls/ext4/prelude.rs
@@ -7,7 +7,7 @@ pub(super) use core::{
 
 pub(super) use align_ext::AlignExt;
 pub(super) use aster_block::{
-    BLOCK_SIZE, BlockDevice, SECTOR_SIZE,
+    BLOCK_SIZE, SECTOR_SIZE,
     bio::{BioDirection, BioSegment, BioStatus, BioWaiter},
     id::Bid,
 };

--- a/kernel/src/fs/fs_impls/ext4/super_block.rs
+++ b/kernel/src/fs/fs_impls/ext4/super_block.rs
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::const_assert;
+
+use super::prelude::*;
+use crate::fs::utils::{IsPowerOf, Str16, Str64};
+use crate::prelude::*;
+use crate::time::UnixTime;
+
+/// Ext4 magic number.
+pub const MAGIC_NUM: u16 = 0xef53;
+
+/// The main superblock is located at byte 1024 from the beginning of the device.
+pub const SUPER_BLOCK_OFFSET: usize = 1024;
+
+const SUPER_BLOCK_SIZE: usize = 1024;
+
+/// The in-memory parsed Ext4 superblock.
+#[derive(Clone, Copy, Debug)]
+pub struct SuperBlock {
+    inodes_count: u32,
+    blocks_count: u64,
+    free_blocks_count: u64,
+    free_inodes_count: u32,
+    first_data_block: u32,
+    block_size: usize,
+    cluster_size: usize,
+    blocks_per_group: u32,
+    clusters_per_group: u32,
+    inodes_per_group: u32,
+    magic: u16,
+    state: FsState,
+    rev_level: RevLevel,
+    inode_size: usize,
+    block_group_idx: usize,
+    feature_compat: FeatureCompatSet,
+    feature_incompat: FeatureInCompatSet,
+    feature_ro_compat: FeatureRoCompatSet,
+    uuid: [u8; 16],
+    volume_name: Str16,
+    last_mounted_dir: Str64,
+    first_ino: u32,
+    min_extra_isize: u16,
+    want_extra_isize: u16,
+    flags: FsFlags,
+    desc_size: usize,
+    s_mnt_count: u16,
+    s_max_mnt_count: u16,
+    s_mtime: UnixTime,
+    s_wtime: UnixTime,
+    s_last_check_time: UnixTime,
+    s_check_interval: u32,
+    s_creator_os: u32,
+    s_def_resuid: u32,
+    s_def_resgid: u32,
+    first_meta_bg: u32,
+    s_reserved_gdt_blocks: u16,
+}
+
+impl TryFrom<RawSuperBlock> for SuperBlock {
+    type Error = crate::error::Error;
+
+    fn try_from(sb: RawSuperBlock) -> Result<Self> {
+        if sb.magic != MAGIC_NUM {
+            return_errno_with_message!(Errno::EINVAL, "bad ext4 magic number");
+        }
+
+        let block_size = (SUPER_BLOCK_SIZE as u32) << sb.log_block_size;
+        if block_size != 1024 && block_size != 2048 && block_size != 4096 {
+            return_errno_with_message!(Errno::EINVAL, "unsupported ext4 block size");
+        }
+
+        let state = FsState::from_bits(sb.state)
+            .ok_or(Error::with_message(Errno::EINVAL, "invalid fs state"))?;
+
+        let rev_level = RevLevel::try_from(sb.rev_level)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "invalid revision level"))?;
+
+        let feature_incompat = FeatureInCompatSet::from_bits(sb.feature_incompat).ok_or(
+            Error::with_message(Errno::EINVAL, "invalid feature incompat set"),
+        )?;
+
+        // These are mandatory for ext4.
+        if !feature_incompat.contains(FeatureInCompatSet::EXTENTS) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "ext4 requires extents feature (consider using ext2 driver)"
+            );
+        }
+
+        let feature_ro_compat = FeatureRoCompatSet::from_bits(sb.feature_ro_compat).ok_or(
+            Error::with_message(Errno::EINVAL, "invalid feature ro compat set"),
+        )?;
+
+        let blocks_count = if feature_incompat.contains(FeatureInCompatSet::_64BIT) {
+            ((sb.blocks_count_hi as u64) << 32) | sb.blocks_count_lo as u64
+        } else {
+            sb.blocks_count_lo as u64
+        };
+
+        let free_blocks_count = if feature_incompat.contains(FeatureInCompatSet::_64BIT) {
+            ((sb.free_blocks_count_hi as u64) << 32) | sb.free_blocks_count_lo as u64
+        } else {
+            sb.free_blocks_count_lo as u64
+        };
+
+        let inode_size = sb.inode_size as usize;
+        if inode_size < 128 {
+            return_errno_with_message!(Errno::EINVAL, "inode size too small");
+        }
+
+        let feature_compat = FeatureCompatSet::from_bits(sb.feature_compat).ok_or(
+            Error::with_message(Errno::EINVAL, "invalid feature compat set"),
+        )?;
+
+        let desc_size = if sb.desc_size != 0 {
+            sb.desc_size as usize
+        } else {
+            32 // Standard ext2/ext4 32-bit group descriptor size
+        };
+
+        Ok(Self {
+            inodes_count: sb.inodes_count,
+            blocks_count,
+            free_blocks_count,
+            free_inodes_count: sb.free_inodes_count,
+            first_data_block: sb.first_data_block,
+            block_size: block_size as usize,
+            cluster_size: ((SUPER_BLOCK_SIZE as u64) << sb.log_cluster_size) as usize,
+            blocks_per_group: sb.blocks_per_group,
+            clusters_per_group: sb.clusters_per_group,
+            inodes_per_group: sb.inodes_per_group,
+            magic: MAGIC_NUM,
+            state,
+            rev_level,
+            inode_size,
+            block_group_idx: sb.block_group_idx as usize,
+            feature_compat,
+            feature_incompat,
+            feature_ro_compat,
+            uuid: sb.uuid,
+            volume_name: sb.volume_name,
+            last_mounted_dir: sb.last_mounted_dir,
+            first_ino: sb.first_ino,
+            min_extra_isize: sb.min_extra_isize,
+            want_extra_isize: sb.want_extra_isize,
+            flags: FsFlags::from_bits_retain(sb.flags),
+            desc_size,
+            s_mnt_count: sb.mnt_count,
+            s_max_mnt_count: sb.max_mnt_count,
+            s_mtime: sb.mtime,
+            s_wtime: sb.wtime,
+            s_last_check_time: sb.last_check_time,
+            s_check_interval: sb.check_interval,
+            s_creator_os: sb.creator_os,
+            s_def_resuid: sb.def_resuid as u32,
+            s_def_resgid: sb.def_resgid as u32,
+            first_meta_bg: sb.first_meta_bg,
+            s_reserved_gdt_blocks: sb.reserved_gdt_blocks,
+        })
+    }
+}
+
+impl SuperBlock {
+    /// Returns the block size.
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Returns the size of inode structure.
+    pub fn inode_size(&self) -> usize {
+        self.inode_size
+    }
+
+    /// Returns total number of inodes.
+    pub fn inodes_count(&self) -> u32 {
+        self.inodes_count
+    }
+
+    /// Returns total number of blocks.
+    pub fn blocks_count(&self) -> u64 {
+        self.blocks_count
+    }
+
+    /// Returns the number of blocks in each block group.
+    pub fn blocks_per_group(&self) -> u32 {
+        self.blocks_per_group
+    }
+
+    /// Returns the number of inodes in each block group.
+    pub fn inodes_per_group(&self) -> u32 {
+        self.inodes_per_group
+    }
+
+    /// Returns the number of block groups.
+    pub fn block_groups_count(&self) -> u32 {
+        self.blocks_count.div_ceil(self.blocks_per_group as u64) as u32
+    }
+
+    /// Returns the filesystem state.
+    pub fn state(&self) -> FsState {
+        self.state
+    }
+
+    /// Returns the incompatible feature set.
+    pub fn feature_incompat(&self) -> FeatureInCompatSet {
+        self.feature_incompat
+    }
+
+    /// Returns the readonly-compatible feature set.
+    pub fn feature_ro_compat(&self) -> FeatureRoCompatSet {
+        self.feature_ro_compat
+    }
+
+    /// Returns the compatible feature set.
+    pub fn feature_compat(&self) -> FeatureCompatSet {
+        self.feature_compat
+    }
+
+    /// Returns the descriptor size.
+    pub fn desc_size(&self) -> usize {
+        self.desc_size
+    }
+
+    /// Checks if the block group backs up superblock and group descriptor.
+    pub fn is_backup_group(&self, block_group_idx: usize) -> bool {
+        if block_group_idx == 0 {
+            return false;
+        }
+        if self
+            .feature_ro_compat
+            .contains(FeatureRoCompatSet::SPARSE_SUPER)
+        {
+            block_group_idx == 1
+                || is_power_of(block_group_idx, 3)
+                || is_power_of(block_group_idx, 5)
+                || is_power_of(block_group_idx, 7)
+        } else {
+            true
+        }
+    }
+
+    /// Returns the starting block id of the superblock inside a block group.
+    pub fn bid(&self, block_group_idx: usize) -> u64 {
+        if block_group_idx == 0 {
+            return (SUPER_BLOCK_OFFSET / self.block_size) as u64;
+        }
+        let super_block_bid = block_group_idx as u64 * self.blocks_per_group as u64;
+        super_block_bid
+    }
+
+    /// Returns the starting block id of the group descriptor table inside a block group.
+    pub fn group_descriptors_bid(&self, block_group_idx: usize) -> u64 {
+        let super_block_bid = self.bid(block_group_idx);
+        super_block_bid + (SUPER_BLOCK_SIZE.div_ceil(self.block_size) as u64)
+    }
+
+    /// Returns the number of free blocks.
+    pub fn free_blocks_count(&self) -> u64 {
+        self.free_blocks_count
+    }
+
+    /// Returns the number of free inodes.
+    pub fn free_inodes_count(&self) -> u32 {
+        self.free_inodes_count
+    }
+}
+
+bitflags! {
+    /// Compatible feature set.
+    pub struct FeatureCompatSet: u32 {
+        const DIR_PREALLOC = 0x1;
+        const IMAGIC_INODES = 0x2;
+        const HAS_JOURNAL = 0x4;
+        const EXT_ATTR = 0x8;
+        const RESIZE_INODE = 0x10;
+        const DIR_INDEX = 0x20;
+        const LAZY_BG = 0x40;
+        const EXCLUDE_INODE = 0x80;
+        const EXCLUDE_BITMAP = 0x100;
+        const SPARSE_SUPER2 = 0x200;
+        const FAST_COMMIT = 0x400;
+        const STABLE_INODES = 0x800;
+        const ORPHAN_FILE = 0x1000;
+    }
+}
+
+bitflags! {
+    /// Incompatible feature set.
+    pub struct FeatureInCompatSet: u32 {
+        const COMPRESSION = 0x1;
+        const FILETYPE = 0x2;
+        const RECOVER = 0x4;
+        const JOURNAL_DEV = 0x8;
+        const META_BG = 0x10;
+        const EXTENTS = 0x40;
+        const _64BIT = 0x80;
+        const MMP = 0x100;
+        const FLEX_BG = 0x200;
+        const EA_INODE = 0x400;
+        const DIRDATA = 0x1000;
+        const CSUM_SEED = 0x2000;
+        const LARGEDIR = 0x4000;
+        const INLINE_DATA = 0x8000;
+        const ENCRYPT = 0x10000;
+        const CASEFOLD = 0x20000;
+    }
+}
+
+bitflags! {
+    /// Readonly-compatible feature set.
+    pub struct FeatureRoCompatSet: u32 {
+        const SPARSE_SUPER = 0x1;
+        const LARGE_FILE = 0x2;
+        const BTREE_DIR = 0x4;
+        const HUGE_FILE = 0x8;
+        const GDT_CSUM = 0x10;
+        const DIR_NLINK = 0x20;
+        const EXTRA_ISIZE = 0x40;
+        const HAS_SNAPSHOT = 0x80;
+        const QUOTA = 0x100;
+        const BIGALLOC = 0x200;
+        const METADATA_CSUM = 0x400;
+        const REPLICA = 0x800;
+        const READONLY = 0x1000;
+        const PROJECT = 0x2000;
+        const VERITY = 0x8000;
+        const ORPHAN_PRESENT = 0x10000;
+    }
+}
+
+bitflags! {
+    /// Filesystem state.
+    pub struct FsState: u16 {
+        const VALID = 0x1;
+        const ERROR = 0x2;
+        const ORPHAN_RECOVERY = 0x4;
+    }
+}
+
+bitflags! {
+    /// Miscellaneous filesystem flags.
+    pub struct FsFlags: u32 {
+        const SIGNED_DIR_HASH = 0x1;
+        const UNSIGNED_DIR_HASH = 0x2;
+        const TEST_DEV = 0x4;
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+pub enum RevLevel {
+    GoodOld = 0,
+    Dynamic = 1,
+}
+
+const_assert!(size_of::<RawSuperBlock>() == SUPER_BLOCK_SIZE);
+
+/// The on-disk Ext4 superblock structure.
+///
+/// It must be exactly 1024 bytes.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawSuperBlock {
+    pub inodes_count: u32,
+    pub blocks_count_lo: u32,
+    pub r_blocks_count_lo: u32,
+    pub free_blocks_count_lo: u32,
+    pub free_inodes_count: u32,
+    pub first_data_block: u32,
+    /// log2(block_size) - 10
+    pub log_block_size: u32,
+    /// log2(cluster_size) - 10
+    pub log_cluster_size: u32,
+    pub blocks_per_group: u32,
+    pub clusters_per_group: u32,
+    pub inodes_per_group: u32,
+    pub mtime: UnixTime,
+    pub wtime: UnixTime,
+    pub mnt_count: u16,
+    pub max_mnt_count: u16,
+    pub magic: u16,
+    pub state: u16,
+    pub errors: u16,
+    pub minor_rev_level: u16,
+    pub last_check_time: UnixTime,
+    pub check_interval: u32,
+    pub creator_os: u32,
+    pub rev_level: u32,
+    pub def_resuid: u16,
+    pub def_resgid: u16,
+    pub first_ino: u32,
+    pub inode_size: u16,
+    pub block_group_idx: u16,
+    pub feature_compat: u32,
+    pub feature_incompat: u32,
+    pub feature_ro_compat: u32,
+    pub uuid: [u8; 16],
+    pub volume_name: Str16,
+    pub last_mounted_dir: Str64,
+    pub algorithm_usage_bitmap: u32,
+    pub prealloc_blocks: u8,
+    pub prealloc_dir_blocks: u8,
+    pub reserved_gdt_blocks: u16,
+    pub journal_uuid: [u8; 16],
+    pub journal_inum: u32,
+    pub journal_dev: u32,
+    pub last_orphan: u32,
+    pub hash_seed: [u32; 4],
+    pub def_hash_version: u8,
+    pub jnl_backup_type: u8,
+    pub desc_size: u16,
+    pub default_mount_opts: u32,
+    pub first_meta_bg: u32,
+    pub mkfs_time: u32,
+    pub jnl_blocks: [u32; 17],
+    // --- 64-bit support fields (offset 0x150) ---
+    pub blocks_count_hi: u32,
+    pub r_blocks_count_hi: u32,
+    pub free_blocks_count_hi: u32,
+    pub min_extra_isize: u16,
+    pub want_extra_isize: u16,
+    pub flags: u32,
+    pub raid_stride: u16,
+    pub mmp_interval: u16,
+    pub mmp_block: u64,
+    pub raid_stripe_width: u32,
+    pub log_groups_per_flex: u8,
+    pub checksum_type: u8,
+    pub reserved_pad: u16,
+    pub kbytes_written: u64,
+    pub snapshot_inum: u32,
+    pub snapshot_id: u32,
+    pub snapshot_r_blocks_count: u64,
+    pub snapshot_list: u32,
+    pub error_count: u32,
+    pub first_error_time: u32,
+    pub first_error_ino: u32,
+    pub first_error_block: u64,
+    pub first_error_func: [u8; 32],
+    pub first_error_line: u32,
+    pub last_error_time: u32,
+    pub last_error_ino: u32,
+    pub last_error_line: u32,
+    pub last_error_block: u64,
+    pub last_error_func: [u8; 32],
+    pub mount_opts: [u8; 64],
+    pub usr_quota_inum: u32,
+    pub grp_quota_inum: u32,
+    pub overhead_blocks: u32,
+    pub backup_bgs: [u32; 2],
+    pub encrypt_algos: [u8; 4],
+    pub encrypt_pw_salt: [u8; 16],
+    pub lpf_ino: u32,
+    pub prj_quota_inum: u32,
+    pub checksum_seed: u32,
+    pub wtime_hi: u8,
+    pub mtime_hi: u8,
+    pub mkfs_time_hi: u8,
+    pub lastcheck_hi: u8,
+    pub first_error_time_hi: u8,
+    pub last_error_time_hi: u8,
+    pub first_error_errcode: u8,
+    pub last_error_errcode: u8,
+    pub encoding: u16,
+    pub encoding_flags: u16,
+    pub orphan_file_inum: u32,
+    reserved: Reserved,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct Reserved([u32; 94]);
+
+impl Default for Reserved {
+    fn default() -> Self {
+        Self([0u32; 94])
+    }
+}

--- a/kernel/src/fs/fs_impls/mod.rs
+++ b/kernel/src/fs/fs_impls/mod.rs
@@ -9,6 +9,7 @@ pub mod configfs;
 pub mod devpts;
 pub mod exfat;
 pub mod ext2;
+pub mod ext4;
 pub mod overlayfs;
 pub mod procfs;
 pub mod pseudofs;
@@ -27,6 +28,7 @@ pub(super) fn init() {
     pseudofs::init();
 
     ext2::init();
+    ext4::init();
     exfat::init();
     overlayfs::init();
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -9,7 +9,7 @@ pub mod utils;
 pub mod vfs;
 
 pub use fs_impls::{
-    cgroupfs, configfs, devpts, exfat, ext2, procfs, pseudofs, ramfs, sysfs, tmpfs,
+    cgroupfs, configfs, devpts, exfat, ext2, ext4, procfs, pseudofs, ramfs, sysfs, tmpfs,
 };
 
 use crate::{

--- a/kernel/src/fs/utils/mod.rs
+++ b/kernel/src/fs/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod systree_inode;
 use core::{
     borrow::Borrow,
     hash::{Hash, Hasher},
+    ops::MulAssign,
 };
 
 use crate::prelude::*;
@@ -191,3 +192,89 @@ impl<const N: usize> Debug for FixedStr<N> {
         }
     }
 }
+
+/// The `Dirty` wraps a value of type `T` with functions similar to that of a rw-lock,
+/// but simply sets a dirty flag on `write()`.
+pub struct Dirty<T: Debug> {
+    value: T,
+    dirty: bool,
+}
+
+impl<T: Debug> Dirty<T> {
+    /// Creates a new Dirty without setting the dirty flag.
+    pub fn new(val: T) -> Dirty<T> {
+        Dirty {
+            value: val,
+            dirty: false,
+        }
+    }
+
+    /// Creates a new Dirty with setting the dirty flag.
+    pub fn new_dirty(val: T) -> Dirty<T> {
+        Dirty {
+            value: val,
+            dirty: true,
+        }
+    }
+
+    /// Returns true if dirty, false otherwise.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Clears the dirty flag.
+    pub fn clear_dirty(&mut self) {
+        self.dirty = false;
+    }
+}
+
+impl<T: Debug> Deref for Dirty<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T: Debug> DerefMut for Dirty<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.dirty = true;
+        &mut self.value
+    }
+}
+
+impl<T: Debug> Drop for Dirty<T> {
+    fn drop(&mut self) {
+        if self.is_dirty() {
+            warn!("[{:?}] is dirty then dropping", self.value);
+        }
+    }
+}
+
+impl<T: Debug> Debug for Dirty<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        let tag = if self.dirty { "Dirty" } else { "Clean" };
+        write!(f, "[{}] {:?}", tag, self.value)
+    }
+}
+
+pub trait IsPowerOf: Copy + Sized + MulAssign + PartialOrd {
+    /// Returns true if and only if `self == x^k` for some `k` where `k > 0`.
+    fn is_power_of(&self, x: Self) -> bool {
+        let mut power = x;
+        while power < *self {
+            power *= x;
+        }
+        power == *self
+    }
+}
+
+macro_rules! impl_ipo_for {
+    ($($ipo_ty:ty),*) => {
+        $(impl IsPowerOf for $ipo_ty {})*
+    };
+}
+
+impl_ipo_for!(
+    u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, isize, usize
+);


### PR DESCRIPTION
Add ext4 filesystem read-only foundation

Implement the skeleton for ext4 read-only support:

- Superblock: full on-disk layout (1024 bytes), feature flag sets (compat/incompat/ro_compat), 64-bit block counts, backup group detection
- Block group: 64-byte group descriptor with 64-bit fields, inode bitmap loading, BlockGroup with lazy inode loading and caching
- Extent tree: ExtentHeader/ExtentIndex/ExtentLeaf parsing, recursive tree traversal for logical-to-physical block mapping
- Inode: 256-byte on-disk format, InodeDesc with extent-based block mapping via InodeBlockMapper, PageCacheBackend integration
- Directory: DirEntry/DirEntryHeader/DirEntryReader for entry iteration and name lookup, FILETYPE support
- VFS adapter: FileSystem trait (sb, sync, root_inode) and Inode trait (only read operations; writes return EROFS)
- Registry: ext4 registered as NEED_DISK filesystem type

Also move Dirty<T> and IsPowerOf trait from ext2 to shared fs/utils for cross-filesystem reuse.
@