### PR TITLE
Fix some sendfile problems

### DIFF
--- a/kernel/src/syscall/sendfile.rs
+++ b/kernel/src/syscall/sendfile.rs
@@ -7,7 +7,7 @@ use crate::{
     fs::{
         self,
         file::{
-            InodeHandle, InodeType, SeekFrom,
+            InodeHandle, InodeType, SeekFrom, StatusFlags,
             file_table::{RawFileDesc, WithFileTable},
         },
     },
@@ -38,10 +38,14 @@ pub fn sys_sendfile(
         out_fd, in_fd, offset, count
     );
 
+    if offset.is_some_and(|off| off.checked_add(count).is_none()) {
+        return_errno_with_message!(Errno::EINVAL, "offset + count overflows");
+    }
+
     let mut count = if count < 0 {
         return_errno_with_message!(Errno::EINVAL, "count cannot be negative");
     } else {
-        count as usize
+        count.cast_unsigned()
     };
 
     let (out_file, in_file) = ctx
@@ -49,58 +53,86 @@ pub fn sys_sendfile(
         .borrow_file_table_mut()
         .read_with(|inner| {
             let out_file = inner.get_file(out_fd.try_into()?)?.clone();
-            // FIXME: the in_file must support mmap-like operations (i.e., it cannot be a socket).
             let in_file = inner.get_file(in_fd.try_into()?)?.clone();
             Ok::<_, Error>((out_file, in_file))
         })?;
 
-    // sendfile can send at most `MAX_COUNT` bytes
+    // `sendfile` can transfer at most `MAX_COUNT` bytes.
     const MAX_COUNT: usize = 0x7fff_f000;
     if count > MAX_COUNT {
         count = MAX_COUNT;
     }
 
-    let origin_f_pos = if offset.is_none() {
-        let outfile_is_pipe = out_file
-            .downcast_ref::<InodeHandle>()
-            .is_some_and(|inode_handle| {
-                inode_handle.path().inode().type_() == InodeType::NamedPipe
-            });
+    let outfile_is_pipe = out_file
+        .downcast_ref::<InodeHandle>()
+        .is_some_and(|inode_handle| inode_handle.path().inode().type_() == InodeType::NamedPipe);
 
-        // If the output file is a pipe, Linux requires the input file to be seekable.
+    // The saved offset is used to restore the correct file position in case a short write occurs.
+    let origin_f_pos = if offset.is_none() {
+        // When no explicit offset is provided,
+        // `in_file` must be seekable
+        // so that we can track and restore its file position correctly.
+        //
+        // Linux normally requires `in_file` to be seekable.
         // See <https://elixir.bootlin.com/linux/v7.0/source/fs/splice.c#L1038>.
-        // If the output file is not a pipe, the input file does not need to be seekable,
-        // so we simply store the offset if available.
-        // The saved offset is used to restore the correct file position in case a short write occurs.
-        if outfile_is_pipe {
-            Some(
-                in_file.seek(SeekFrom::Current(0)).map_err(|_| {
-                    Error::with_message(Errno::EINVAL, "the in_file is not seekable")
-                })?,
-            )
-        } else {
-            in_file.seek(SeekFrom::Current(0)).ok()
-        }
+        // The one exception is when `out_file` is a pipe,
+        // where `sendfile` is desugared into `splice`,
+        // which can handle non-seekable `in_file`s.
+        //
+        // We do not yet support the pipe case
+        // and reject non-seekable `in_file`s unconditionally for simplicity.
+        // TODO: Support `sendfile` from a non-seekable `in_file` to a pipe.
+        Some(in_file.seek(SeekFrom::Current(0)).map_err(|_| {
+            if outfile_is_pipe {
+                warn!("sendfile from a non-seekable in_file to a pipe is not yet supported");
+            }
+            Error::with_message(Errno::EINVAL, "in_file is not seekable")
+        })?)
     } else {
         None
     };
 
+    // Verify that `in_file` is readable and `out_file` is writable upfront,
+    // even if the total transfer count is zero.
+    if !in_file.access_mode().is_readable() {
+        return_errno_with_message!(Errno::EBADF, "in_file is not readable");
+    }
+    if !out_file.access_mode().is_writable() {
+        return_errno_with_message!(Errno::EBADF, "out_file is not writable");
+    }
+
+    // Linux returns `EINVAL` when `in_file` is a directory,
+    // because directories do not implement `splice_read`.
+    // We do not yet have `splice_read` on `FileLike`,
+    // so we perform this check manually.
+    let in_file_is_dir = in_file
+        .downcast_ref::<InodeHandle>()
+        .is_some_and(|inode_handle| inode_handle.path().inode().type_() == InodeType::Dir);
+    if in_file_is_dir {
+        return_errno_with_message!(Errno::EINVAL, "in_file is a directory");
+    }
+
+    // Sending to an append-only file is not allowed.
+    if !outfile_is_pipe && out_file.status_flags().contains(StatusFlags::O_APPEND) {
+        return_errno_with_message!(Errno::EINVAL, "out_file is opened with O_APPEND");
+    }
+
     const BUFFER_SIZE: usize = PAGE_SIZE;
     let mut buffer = vec![0u8; BUFFER_SIZE].into_boxed_slice();
     let mut total_len = 0;
-    let mut offset = offset.map(|offset| offset as usize);
+    let mut offset = offset.map(|offset| offset.cast_unsigned());
     let mut short_write_occurs = false;
 
     while total_len < count {
         // The offset decides how to read from `in_file`.
-        // If offset is `Some(_)`, the data will be read from the given offset,
+        // If the offset is `Some(_)`, the data will be read from the given offset,
         // and after reading, the file offset of `in_file` will remain unchanged.
-        // If offset is `None`, the data will be read from the file offset,
+        // If the offset is `None`, the data will be read from the file offset,
         // and the file offset of `in_file` is adjusted
         // to reflect the number of bytes read from `in_file`.
         let max_readlen = buffer.len().min(count - total_len);
 
-        // Read from `in_file`
+        // Read from `in_file`.
         let read_res = if let Some(offset) = offset {
             in_file.read_bytes_at(offset, &mut buffer[..max_readlen])
         } else {
@@ -123,7 +155,7 @@ pub fn sys_sendfile(
         }
 
         // Note: `sendfile` allows sending partial data,
-        // so short reads and short writes are all acceptable
+        // so short reads and short writes are all acceptable.
         let write_res = out_file.write_bytes(&buffer[..read_len]);
 
         match write_res {
@@ -143,17 +175,9 @@ pub fn sys_sendfile(
                     short_write_occurs = true;
                     break;
                 }
-
                 if offset.is_none() {
-                    if let Some(origin_f_pos) = origin_f_pos {
-                        in_file.seek(SeekFrom::Start(origin_f_pos))?;
-                    } else {
-                        error!(
-                            "the file position of in_file may be incorrect due to a write error"
-                        );
-                    }
+                    in_file.seek(SeekFrom::Start(origin_f_pos.unwrap()))?;
                 }
-
                 return Err(e);
             }
         }
@@ -162,16 +186,13 @@ pub fn sys_sendfile(
     if let Some(offset) = offset {
         ctx.user_space().write_val(offset_ptr, &(offset as isize))?;
     } else if short_write_occurs {
-        if let Some(origin_f_pos) = origin_f_pos {
-            // Seek `in_file` to the position corresponding to the last byte actually transferred.
-            // Note: since the file offset lock is not held between saving `origin_f_pos` and this
-            // point, a race condition may occur if another thread reads from the same file
-            // concurrently. Linux permits this behavior and leaves it to userspace to avoid such races.
-            let new_f_pos = origin_f_pos + total_len;
-            in_file.seek(SeekFrom::Start(new_f_pos))?;
-        } else {
-            error!("the file position of in_file may be incorrect due to a short write");
-        }
+        // Seek `in_file` to the position corresponding to the last byte actually transferred.
+        // Note: Since the file offset lock is not held
+        // between saving `origin_f_pos` and this point,
+        // a race condition may occur if another thread reads from the same file concurrently.
+        // Linux permits this behavior and leaves it to userspace to avoid such races.
+        let new_f_pos = origin_f_pos.unwrap() + total_len;
+        in_file.seek(SeekFrom::Start(new_f_pos))?;
     }
 
     fs::vfs::notify::on_access(&in_file);

--- a/test/initramfs/src/conformance/gvisor/blocklists/sendfile_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/sendfile_test
@@ -1,7 +1,2 @@
-SendFileTest.DoNotSendfileIfOutfileIsAppendOnly
-SendFileTest.Overflow
-SendFileTest.SendFileToSelf
+# TODO: Support `F_GETPIPE_SZ` for `fcntl` syscall.
 SendFileTest.SendPipeBlocks
-SendFileTest.SendPipeWouldBlock
-SendFileTest.SendToNotARegularFile
-SendFileTest.SendToSpecialFile

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1342,20 +1342,20 @@ semop03
 
 sendfile02
 sendfile02_64
-# sendfile03
-# sendfile03_64
-# sendfile04
-# sendfile04_64
+sendfile03
+sendfile03_64
+sendfile04
+sendfile04_64
 sendfile05
 sendfile05_64
 sendfile06
 sendfile06_64
-# sendfile07
-# sendfile07_64
+sendfile07
+sendfile07_64
 sendfile08
 sendfile08_64
-# sendfile09
-# sendfile09_64
+sendfile09
+sendfile09_64
 
 # sendmsg01
 # sendmsg02


### PR DESCRIPTION
This PR addresses the issues raised in https://github.com/asterinas/asterinas/pull/3191#issuecomment-4448076510. As suggested, we now reject all non-seekable `in_file`s, which ensures that the file position of `in_file` can be correctly updated based on the number of bytes actually written.

We also fix all other failing sendfile test cases in the gVisor and LTP test suites, primarily by adding missing boundary checks. Two gVisor test cases still fail, but they are not directly related to the sendfile implementation itself — comments have been added to document the reasons.

Additionally, we remove the comment `FIXME: the in_file must support mmap-like operations (i.e., it cannot be a socket)`., as it was based on a misreading of the [Linux manual](https://man7.org/linux/man-pages/man2/sendfile.2.html):

```plain
       The in_fd argument must correspond to a file which supports
       mmap(2)-like operations (i.e., it cannot be a socket).  Except
       since Linux 5.12 and if out_fd is a pipe, in which case sendfile()
       desugars to a splice(2) and its restrictions apply.
```

As the manual clarifies, when out_fd is a pipe, in_fd is allowed to be a socket.