### PR TITLE
Remove `PageCacheBackend::npages`

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -315,7 +315,7 @@ impl IoCompletion for BioMetadata {
             BioStatus::NotSupported => Err(IoError::Unsupported),
             BioStatus::NoSpace => Err(IoError::OutOfSpace),
             BioStatus::IoError => Err(IoError::Failed),
-            BioStatus::Init | BioStatus::Submit => unreachable!(),
+            BioStatus::Init | BioStatus::Submit | BioStatus::Zeros => unreachable!(),
         }
     }
 }
@@ -359,6 +359,8 @@ pub enum BioStatus {
     NoSpace = 4,
     /// An error occurred while doing I/O.
     IoError = 5,
+    /// No I/O operation is needed because the sectors to read only contain zeros.
+    Zeros = 6,
 }
 
 /// `BioSegment` is the basic memory unit of a block I/O request.

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -380,7 +380,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.fs_size() < idx * PAGE_SIZE {
@@ -389,7 +389,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         self.block_device.read_blocks_async(
             BlockId::new(idx as u64),
             bio_segment,
-            complete_fn,
+            Some(complete_fn),
             io_batch,
         )?;
         Ok(())
@@ -399,7 +399,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.fs_size() < idx * PAGE_SIZE {
@@ -408,7 +408,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         self.block_device.write_blocks_async(
             BlockId::new(idx as u64),
             bio_segment,
-            complete_fn,
+            Some(complete_fn),
             io_batch,
         )?;
         Ok(())

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -384,7 +384,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.fs_size() < idx * PAGE_SIZE {
-            return_errno_with_message!(Errno::EINVAL, "invalid read size")
+            return_errno_with_message!(Errno::EINVAL, "invalid read size");
         }
         self.block_device.read_blocks_async(
             BlockId::new(idx as u64),
@@ -403,7 +403,7 @@ impl BlockAsPageCacheBackend for ExfatFs {
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.fs_size() < idx * PAGE_SIZE {
-            return_errno_with_message!(Errno::EINVAL, "invalid write size")
+            return_errno_with_message!(Errno::EINVAL, "invalid write size");
         }
         self.block_device.write_blocks_async(
             BlockId::new(idx as u64),
@@ -412,10 +412,6 @@ impl BlockAsPageCacheBackend for ExfatFs {
             io_batch,
         )?;
         Ok(())
-    }
-
-    fn npages(&self) -> usize {
-        self.fs_size() / PAGE_SIZE
     }
 }
 

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -140,7 +140,7 @@ impl BlockAsPageCacheBackend for ExfatInode {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         let inner = self.inner.read();
@@ -148,9 +148,7 @@ impl BlockAsPageCacheBackend for ExfatInode {
             return_errno_with_message!(Errno::EINVAL, "invalid read size");
         } else if inner.size <= idx * PAGE_SIZE {
             drop(inner);
-            if let Some(complete_fn) = complete_fn {
-                (complete_fn)(BioStatus::Zeros);
-            }
+            (complete_fn)(BioStatus::Zeros);
             return Ok(());
         }
         let fs = inner.fs();
@@ -158,7 +156,7 @@ impl BlockAsPageCacheBackend for ExfatInode {
         fs.block_device().read_blocks_async(
             BlockId::from_offset(sector_id * inner.fs().sector_size()),
             bio_segment,
-            complete_fn,
+            Some(complete_fn),
             io_batch,
         )?;
         Ok(())
@@ -168,7 +166,7 @@ impl BlockAsPageCacheBackend for ExfatInode {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         let inner = self.inner.read();
@@ -180,7 +178,7 @@ impl BlockAsPageCacheBackend for ExfatInode {
         fs.block_device().write_blocks_async(
             BlockId::from_offset(sector_id * inner.fs().sector_size()),
             bio_segment,
-            complete_fn,
+            Some(complete_fn),
             io_batch,
         )?;
         Ok(())

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -8,7 +8,7 @@ use core::{cmp::Ordering, time::Duration};
 pub(super) use align_ext::AlignExt;
 use aster_block::{
     BLOCK_SIZE, SECTOR_SIZE,
-    bio::{BioCompleteFn, BioDirection, BioSegment},
+    bio::{BioCompleteFn, BioDirection, BioSegment, BioStatus},
     id::{Bid, BlockId},
 };
 use io_util::batch::IoBatch;
@@ -144,8 +144,14 @@ impl BlockAsPageCacheBackend for ExfatInode {
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         let inner = self.inner.read();
-        if inner.size < idx * PAGE_SIZE {
-            return_errno_with_message!(Errno::EINVAL, "Invalid read size")
+        if inner.size_allocated <= idx * PAGE_SIZE {
+            return_errno_with_message!(Errno::EINVAL, "invalid read size");
+        } else if inner.size <= idx * PAGE_SIZE {
+            drop(inner);
+            if let Some(complete_fn) = complete_fn {
+                (complete_fn)(BioStatus::Zeros);
+            }
+            return Ok(());
         }
         let fs = inner.fs();
         let sector_id = inner.get_sector_id(idx * PAGE_SIZE / fs.sector_size())?;
@@ -166,6 +172,9 @@ impl BlockAsPageCacheBackend for ExfatInode {
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         let inner = self.inner.read();
+        if inner.size_allocated <= idx * PAGE_SIZE {
+            return_errno_with_message!(Errno::EINVAL, "invalid write size");
+        }
         let fs = inner.fs();
         let sector_id = inner.get_sector_id(idx * PAGE_SIZE / fs.sector_size())?;
         fs.block_device().write_blocks_async(
@@ -175,10 +184,6 @@ impl BlockAsPageCacheBackend for ExfatInode {
             io_batch,
         )?;
         Ok(())
-    }
-
-    fn npages(&self) -> usize {
-        self.inner.read().size.align_up(PAGE_SIZE) / PAGE_SIZE
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext2/block_group.rs
@@ -327,6 +327,9 @@ impl BlockAsPageCacheBackend for BlockGroupImpl {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if self.raw_inodes_size <= idx * BLOCK_SIZE {
+            return_errno_with_message!(Errno::EINVAL, "invalid read size");
+        }
         let bid = self.inode_table_bid + idx as Ext2Bid;
         self.fs
             .upgrade()
@@ -341,15 +344,14 @@ impl BlockAsPageCacheBackend for BlockGroupImpl {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if self.raw_inodes_size <= idx * BLOCK_SIZE {
+            return_errno_with_message!(Errno::EINVAL, "invalid write size");
+        }
         let bid = self.inode_table_bid + idx as Ext2Bid;
         self.fs
             .upgrade()
             .unwrap()
             .write_blocks_async(bid, bio_segment, complete_fn, io_batch)
-    }
-
-    fn npages(&self) -> usize {
-        self.raw_inodes_size.div_ceil(BLOCK_SIZE)
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext2/block_group.rs
@@ -324,7 +324,7 @@ impl BlockAsPageCacheBackend for BlockGroupImpl {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.raw_inodes_size <= idx * BLOCK_SIZE {
@@ -334,14 +334,14 @@ impl BlockAsPageCacheBackend for BlockGroupImpl {
         self.fs
             .upgrade()
             .unwrap()
-            .read_blocks_async(bid, bio_segment, complete_fn, io_batch)
+            .read_blocks_async(bid, bio_segment, Some(complete_fn), io_batch)
     }
 
     fn submit_write_bio(
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if self.raw_inodes_size <= idx * BLOCK_SIZE {
@@ -351,7 +351,7 @@ impl BlockAsPageCacheBackend for BlockGroupImpl {
         self.fs
             .upgrade()
             .unwrap()
-            .write_blocks_async(bid, bio_segment, complete_fn, io_batch)
+            .write_blocks_async(bid, bio_segment, Some(complete_fn), io_batch)
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1942,7 +1942,7 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if idx >= Ext2Bid::MAX as usize {
@@ -1958,14 +1958,14 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
         };
         let start_bid = dev_range.start as Ext2Bid;
         self.fs()
-            .read_blocks_async(start_bid, bio_segment, complete_fn, io_batch)
+            .read_blocks_async(start_bid, bio_segment, Some(complete_fn), io_batch)
     }
 
     fn submit_write_bio(
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if idx >= Ext2Bid::MAX as usize {
@@ -1981,7 +1981,7 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
         };
         let start_bid = dev_range.start as Ext2Bid;
         self.fs()
-            .write_blocks_async(start_bid, bio_segment, complete_fn, io_batch)
+            .write_blocks_async(start_bid, bio_segment, Some(complete_fn), io_batch)
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -1420,7 +1420,7 @@ impl InodeImpl {
             self.expand_blocks(old_blocks..new_blocks)?;
         }
 
-        // Expands the size
+        // Expands the size (after expanding blocks)
         self.update_size(new_size);
         Ok(())
     }
@@ -1672,13 +1672,13 @@ impl InodeImpl {
         let new_blocks = self.desc.size_to_blocks(new_size);
         let old_blocks = self.desc.blocks_count();
 
+        // Shrinks the size (before shrinking blocks)
+        self.update_size(new_size);
+
         // Shrinks block count if necessary
         if new_blocks < old_blocks {
             self.shrink_blocks(new_blocks..old_blocks);
         }
-
-        // Shrinks the size
-        self.update_size(new_size);
     }
 
     fn update_size(&mut self, new_size: usize) {
@@ -1945,8 +1945,17 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if idx >= Ext2Bid::MAX as usize {
+            return_errno_with_message!(Errno::EINVAL, "invalid read size");
+        }
         let bid = idx as Ext2Bid;
-        let dev_range = DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)?.read()?;
+        let dev_range = {
+            let mut reader = DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)?;
+            if idx >= self.nblocks() {
+                return_errno_with_message!(Errno::EINVAL, "invalid read size");
+            }
+            reader.read()?
+        };
         let start_bid = dev_range.start as Ext2Bid;
         self.fs()
             .read_blocks_async(start_bid, bio_segment, complete_fn, io_batch)
@@ -1959,15 +1968,20 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if idx >= Ext2Bid::MAX as usize {
+            return_errno_with_message!(Errno::EINVAL, "invalid write size");
+        }
         let bid = idx as Ext2Bid;
-        let dev_range = DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)?.read()?;
+        let dev_range = {
+            let mut reader = DeviceRangeReader::new(self, bid..bid + 1 as Ext2Bid)?;
+            if idx >= self.nblocks() {
+                return_errno_with_message!(Errno::EINVAL, "invalid write size");
+            }
+            reader.read()?
+        };
         let start_bid = dev_range.start as Ext2Bid;
         self.fs()
             .write_blocks_async(start_bid, bio_segment, complete_fn, io_batch)
-    }
-
-    fn npages(&self) -> usize {
-        self.nblocks()
     }
 }
 

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -86,7 +86,7 @@ use core::{
 use align_ext::AlignExt;
 use aster_block::bio::{BioCompleteFn, BioDirection, BioSegment, BioStatus};
 use io_util::batch::IoBatch;
-use ostd::mm::{Segment, VmIo, io::util::HasVmReaderWriter};
+use ostd::mm::{Segment, VmIo, VmIoFill, io::util::HasVmReaderWriter};
 
 use crate::prelude::*;
 
@@ -345,6 +345,11 @@ impl VmIo for PageCache {
 /// devices usually implement [`BlockAsPageCacheBackend`] instead.
 pub trait PageCacheBackend: Sync + Send {
     /// Reads a page from the backend asynchronously.
+    ///
+    /// The caller may try to pass an index that exceeds the size of the
+    /// underlying backend (e.g., the file size). This can occur if file
+    /// truncation and a page fault occur at the same time. If this happens,
+    /// this method should fail with `EINVAL`.
     fn read_page_async(
         &self,
         idx: usize,
@@ -353,18 +358,20 @@ pub trait PageCacheBackend: Sync + Send {
     ) -> Result<()>;
 
     /// Writes a page to the backend asynchronously.
+    ///
+    /// If the caller tries to pass an index that exceeds the size of the
+    /// underlying backend (e.g. the file size), this method should fail with
+    /// `EINVAL`. Note that this cannot happen until we support concurrent file
+    /// truncation and page writeback.
+    //
+    // TODO: Revise this behavior once file truncation and page writeback can
+    // happen concurrently.
     fn write_page_async(
         &self,
         idx: usize,
         locked_page: cache_page::LockedCachePage,
         io_batch: &mut IoBatch,
     ) -> Result<()>;
-
-    /// Returns the number of pages addressable in the backend storage.
-    ///
-    /// This defines the upper bound of valid page indices for I/O operations.
-    /// Requests beyond this limit are treated as holes (zero-filled).
-    fn npages(&self) -> usize;
 }
 
 impl dyn PageCacheBackend {
@@ -399,6 +406,9 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
     /// Implementations must attach `complete_fn`, when present, to the
     /// underlying asynchronous I/O so the page-cache layer can mark successful
     /// reads up to date and release the page lock.
+    ///
+    /// Implementations should fail with `EINVAL` for an out-of-bounds `idx`.
+    /// See also [`PageCacheBackend::read_page_async`].
     fn submit_read_bio(
         &self,
         idx: usize,
@@ -413,6 +423,9 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
     /// Implementations must attach `complete_fn`, when present, to the
     /// underlying asynchronous I/O so the page-cache layer can finish writeback
     /// bookkeeping and report failures.
+    ///
+    /// Implementations should fail with `EINVAL` for an out-of-bounds `idx`.
+    /// See also [`PageCacheBackend::write_page_async`].
     fn submit_write_bio(
         &self,
         idx: usize,
@@ -420,12 +433,6 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()>;
-
-    /// Returns the number of pages addressable in the backend storage.
-    ///
-    /// This defines the upper bound of valid page indices for I/O operations.
-    /// Requests beyond this limit are treated as holes (zero-filled).
-    fn npages(&self) -> usize;
 }
 
 impl<T: BlockAsPageCacheBackend> PageCacheBackend for T {
@@ -441,7 +448,10 @@ impl<T: BlockAsPageCacheBackend> PageCacheBackend for T {
         );
 
         let complete_fn: BioCompleteFn = Box::new(move |status| {
-            if status == BioStatus::Complete {
+            if status == BioStatus::Zeros {
+                locked_page.fill_zeros(0, PAGE_SIZE).unwrap();
+                locked_page.set_up_to_date();
+            } else if status == BioStatus::Complete {
                 locked_page.set_up_to_date();
             }
             // The page lock is released when `locked_page` (LockedCachePage) is dropped here.
@@ -498,9 +508,5 @@ impl<T: BlockAsPageCacheBackend> PageCacheBackend for T {
         }
 
         res
-    }
-
-    fn npages(&self) -> usize {
-        BlockAsPageCacheBackend::npages(self)
     }
 }

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -403,9 +403,12 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
     /// Submits read I/O for the page at `idx`.
     ///
     /// `bio_segment` identifies the page memory that must receive the data.
-    /// Implementations must attach `complete_fn`, when present, to the
-    /// underlying asynchronous I/O so the page-cache layer can mark successful
+    /// Implementations must attach `complete_fn` to the underlying
+    /// asynchronous I/O so the page-cache layer can mark successful
     /// reads up to date and release the page lock.
+    ///
+    /// If the page only contains zeros, implementations may call `complete_fn`
+    /// with [`BioStatus::Zeros`], skip I/O, and leave `bio_segment` unfilled.
     ///
     /// Implementations should fail with `EINVAL` for an out-of-bounds `idx`.
     /// See also [`PageCacheBackend::read_page_async`].
@@ -413,15 +416,15 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()>;
 
     /// Submits write I/O for the page at `idx`.
     ///
     /// `bio_segment` contains the stable page snapshot that must be written.
-    /// Implementations must attach `complete_fn`, when present, to the
-    /// underlying asynchronous I/O so the page-cache layer can finish writeback
+    /// Implementations must attach `complete_fn` to the underlying
+    /// asynchronous I/O so the page-cache layer can finish writeback
     /// bookkeeping and report failures.
     ///
     /// Implementations should fail with `EINVAL` for an out-of-bounds `idx`.
@@ -430,7 +433,7 @@ pub trait BlockAsPageCacheBackend: Sync + Send {
         &self,
         idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()>;
 }
@@ -457,7 +460,7 @@ impl<T: BlockAsPageCacheBackend> PageCacheBackend for T {
             // The page lock is released when `locked_page` (LockedCachePage) is dropped here.
         });
 
-        self.submit_read_bio(idx, bio_segment, Some(complete_fn), io_batch)
+        self.submit_read_bio(idx, bio_segment, complete_fn, io_batch)
     }
 
     fn write_page_async(
@@ -498,7 +501,7 @@ impl<T: BlockAsPageCacheBackend> PageCacheBackend for T {
             }
         });
 
-        let res = self.submit_write_bio(idx, bio_segment, Some(complete_fn), io_batch);
+        let res = self.submit_write_bio(idx, bio_segment, complete_fn, io_batch);
         if res.is_err() {
             // If submission fails, re-dirty the page so the next writeback can
             // retry the data that never reached the device queue.

--- a/kernel/src/vm/page_cache/tests/utils.rs
+++ b/kernel/src/vm/page_cache/tests/utils.rs
@@ -336,6 +336,9 @@ impl BlockAsPageCacheBackend for MockPageCacheBackend {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if page_idx >= self.num_pages {
+            return_errno!(Errno::EINVAL);
+        }
         self.submit_bio(IoKind::Read, page_idx, bio_segment, complete_fn, io_batch)
     }
 
@@ -346,10 +349,9 @@ impl BlockAsPageCacheBackend for MockPageCacheBackend {
         complete_fn: Option<BioCompleteFn>,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
+        if page_idx >= self.num_pages {
+            return_errno!(Errno::EINVAL);
+        }
         self.submit_bio(IoKind::Write, page_idx, bio_segment, complete_fn, io_batch)
-    }
-
-    fn npages(&self) -> usize {
-        self.num_pages
     }
 }

--- a/kernel/src/vm/page_cache/tests/utils.rs
+++ b/kernel/src/vm/page_cache/tests/utils.rs
@@ -219,7 +219,7 @@ impl MockPageCacheBackend {
         kind: IoKind,
         page_idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         self.maybe_fail_submission(kind, page_idx)?;
@@ -228,7 +228,7 @@ impl MockPageCacheBackend {
             kind.bio_type(),
             Sid::from_offset(page_idx * PAGE_SIZE),
             vec![bio_segment],
-            complete_fn,
+            Some(complete_fn),
         );
         bio.submit(self, io_batch)
             .map_err(ostd::Error::from)
@@ -333,7 +333,7 @@ impl BlockAsPageCacheBackend for MockPageCacheBackend {
         &self,
         page_idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if page_idx >= self.num_pages {
@@ -346,7 +346,7 @@ impl BlockAsPageCacheBackend for MockPageCacheBackend {
         &self,
         page_idx: usize,
         bio_segment: BioSegment,
-        complete_fn: Option<BioCompleteFn>,
+        complete_fn: BioCompleteFn,
         io_batch: &mut IoBatch,
     ) -> Result<()> {
         if page_idx >= self.num_pages {

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -24,7 +24,7 @@ use core::{
 use align_ext::AlignExt;
 use io_util::batch::IoBatch;
 use ostd::{
-    mm::{HasPaddr, VmIoFill, io::util::HasVmReaderWriter},
+    mm::{HasPaddr, io::util::HasVmReaderWriter},
     task::disable_preempt,
 };
 use xarray::{Cursor, LockedXArray, XArray};
@@ -703,18 +703,12 @@ pub struct BackedVmo<'a> {
 impl<'a> BackedVmo<'a> {
     /// Writes back dirty pages in the specified byte range to the backend storage.
     pub(super) fn flush_dirty_pages(&self, range: &Range<usize>) -> Result<()> {
-        let page_idx_range = get_page_idx_range(range);
-        let npages = self.backend.npages();
-        if page_idx_range.start >= npages {
-            return Ok(());
-        }
-        let page_idx_range = page_idx_range.start..page_idx_range.end.min(npages);
-
         let locked_pages = self.vmo.pages.lock();
         if range.start > self.size() {
             return Ok(());
         }
 
+        let page_idx_range = get_page_idx_range(range);
         let dirty_pages =
             self.collect_pages_if(locked_pages, page_idx_range, |_, page| page.is_dirty());
 
@@ -737,16 +731,14 @@ impl<'a> BackedVmo<'a> {
     // TODO: Integrate reverse mappings or an explicit invalidation lock so this
     // path can coordinate with page faults.
     pub(super) fn evict_up_to_date_pages(&self, range: &Range<usize>) -> Result<()> {
+        let locked_pages = self.vmo.pages.lock();
         if range.start > self.size() {
             return Ok(());
         }
 
         let page_idx_range = get_page_idx_range(range);
-        let npages = self.backend.npages();
-        let locked_pages = self.vmo.pages.lock();
-        let pages_to_evict = self.collect_pages_if(locked_pages, page_idx_range, |idx, page| {
-            idx >= npages || page.is_up_to_date()
-        });
+        let pages_to_evict =
+            self.collect_pages_if(locked_pages, page_idx_range, |_, page| page.is_up_to_date());
         self.wait_for_writeback_and_remove_pages(pages_to_evict);
 
         Ok(())
@@ -784,7 +776,8 @@ impl<'a> BackedVmo<'a> {
         if let Some(page) = cursor.load() {
             let page = page.clone();
             drop(locked_pages);
-            if page_idx < self.backend.npages() && !commit_mode.skips_backend_read() {
+
+            if !commit_mode.skips_backend_read() {
                 page.ensure_init(|locked_page| self.backend.read_page(page_idx, locked_page))?;
                 return Ok(page.into());
             }
@@ -792,32 +785,21 @@ impl<'a> BackedVmo<'a> {
             return Ok(page.into());
         };
 
-        // Page is within the file bounds - need to allocate a cache page.
+        // The page is within the file bounds - need to allocate a cache page.
         let locked_page = CachePage::alloc_uninit()?
             .try_lock()
-            .expect("newly allocated cache page must be unlocked");
-
+            .expect("a newly allocated cache page must be unlocked");
         cursor.store(locked_page.clone());
-
         drop(locked_pages);
 
-        if page_idx < self.backend.npages() {
-            // Page is within the file bounds
-            if commit_mode.skips_backend_read() {
-                // Page will be completely overwritten, no need to read
-                Ok(locked_page.into())
-            } else {
-                let new_page = locked_page.clone();
-                // Read the page from backend storage
-                self.backend.read_page(page_idx, locked_page)?;
-                Ok(new_page.into())
-            }
+        if commit_mode.skips_backend_read() {
+            // The page will be completely overwritten, no need to read.
+            Ok(locked_page.into())
         } else {
-            // Page is beyond file bounds - treat as hole (zero-filled)
-            locked_page.fill_zeros(0, PAGE_SIZE).unwrap();
-            locked_page.set_up_to_date();
-
-            Ok(locked_page.unlock().into())
+            let new_page = locked_page.clone();
+            // Read the page from the backend storage.
+            self.backend.read_page(page_idx, locked_page)?;
+            Ok(new_page.into())
         }
     }
 
@@ -833,9 +815,8 @@ impl<'a> BackedVmo<'a> {
             return Err(VmoCommitError::NeedIo { index: page_idx });
         };
 
-        // If page is within file bounds, check if it's initialized
-        if !commit_mode.skips_backend_read() && page_idx < self.backend.npages() && page.is_uninit()
-        {
+        // Check if the page is initialized.
+        if !commit_mode.skips_backend_read() && page.is_uninit() {
             return Err(VmoCommitError::WaitUntilInit {
                 index: page_idx,
                 page: page.clone(),


### PR DESCRIPTION
When reading the VMO code, it is difficult to determine whether the `npages()` method is used correctly, i.e., whether it will cause races.

##### Problem 1

https://github.com/asterinas/asterinas/blob/818cfd9da9748d587b8346918b2261bed4e4bda2/kernel/src/vm/page_cache/vmo/mod.rs#L792-L797

It isn't immediately clear to me whether the backend `npages()` may change between the query and the operation (i.e., `read_pages`). One possibility is that the change to the `npages()` function can be synchronized via the reverse mapping/invalidation lock, which will be added in the future. However, the code would still be difficult to analyze.

##### Problem 2

https://github.com/asterinas/asterinas/blob/818cfd9da9748d587b8346918b2261bed4e4bda2/kernel/src/vm/page_cache/vmo/mod.rs#L841-L848

Also, I don't understand why we simply return the page when the offset is outside of `npages()`. It appears to leak uninitialized page content to the user space, which is terrible.

##### Problem 3

https://github.com/asterinas/asterinas/blob/818cfd9da9748d587b8346918b2261bed4e4bda2/kernel/src/vm/page_cache/vmo/mod.rs#L832-L842

Another problem is that `npages()` willl break the atomic mode. XArray `Cursor` can only be obtained in the atomic mode, but the code calls `npages()`, which in turns will lock a mutex for exfat:

https://github.com/asterinas/asterinas/blob/818cfd9da9748d587b8346918b2261bed4e4bda2/kernel/src/fs/fs_impls/exfat/inode.rs#L181-L182

---

As a result, I think we should remove `PageCacheBackend::npages()` to solve all three problems. `submit_read_bio` and `submit_write_bio` should validate the `idx` before reading or writing to the disk.

Additionally, submit_read_bio should fill the page with zeros if a file range (in the middle or at the end) isn't allocated on the disk. I found that exfat already takes advantage of this, so I added a `BioStatus::Zeros` to achieve this goal.