### PR TITLE
Fix `access_mode` and `FileLike::read/write` default values

### DIFF
--- a/kernel/src/events/epoll/file.rs
+++ b/kernel/src/events/epoll/file.rs
@@ -261,14 +261,6 @@ impl Pollable for EpollFile {
 
 // Implement the common methods required by FileHandle
 impl FileLike for EpollFile {
-    fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "epoll files do not support read");
-    }
-
-    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "epoll files do not support write");
-    }
-
     fn ioctl(&self, _raw_ioctl: RawIoctl) -> Result<i32> {
         return_errno_with_message!(Errno::ENOTTY, "epoll files do not support ioctl");
     }

--- a/kernel/src/events/epoll/file.rs
+++ b/kernel/src/events/epoll/file.rs
@@ -12,7 +12,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            CreationFlags, FileLike,
+            AccessMode, CreationFlags, FileLike,
             file_table::{FdFlags, FileDesc, get_file_fast},
         },
         pseudofs::AnonInodeFs,
@@ -271,6 +271,11 @@ impl FileLike for EpollFile {
 
     fn ioctl(&self, _raw_ioctl: RawIoctl) -> Result<i32> {
         return_errno_with_message!(Errno::ENOTTY, "epoll files do not support ioctl");
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventpoll.c#L2191>.
+        AccessMode::O_RDWR
     }
 
     fn path(&self) -> &Path {

--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -79,9 +79,27 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::EINVAL, "set_status_flags is not supported");
     }
 
-    fn access_mode(&self) -> AccessMode {
-        AccessMode::O_RDWR
-    }
+    /// Returns the access mode of this file.
+    ///
+    /// The access mode indicates whether the file descriptor is readable or writable.
+    /// Readability is required for operations
+    /// such as [`read`], [`read_at`], and read-only memory mappings.
+    /// Writability is required for operations
+    /// such as [`write`], [`write_at`], [`resize`], [`fallocate`],
+    /// and writable memory mappings.
+    ///
+    /// For inode-backed files,
+    /// their access modes are determined dynamically for each opened file.
+    /// For special files such as epoll files, eventfd files, and pid files,
+    /// they are determined statically by the file types.
+    ///
+    /// [`read`]: FileLike::read
+    /// [`read_at`]: FileLike::read_at
+    /// [`write`]: FileLike::write
+    /// [`write_at`]: FileLike::write_at
+    /// [`resize`]: FileLike::resize
+    /// [`fallocate`]: FileLike::fallocate
+    fn access_mode(&self) -> AccessMode;
 
     fn seek(&self, seek_from: SeekFrom) -> Result<usize> {
         return_errno_with_message!(Errno::ESPIPE, "seek is not supported");

--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -20,12 +20,48 @@ use crate::{
 
 /// The basic operations defined on a file
 pub trait FileLike: Pollable + Send + Sync + Any {
+    /// Reads data from this file.
+    ///
+    /// By default, this method returns `EBADF`
+    /// if the file is not readable,
+    /// or `EINVAL` if the file type does not support `read`.
+    /// These are distinct conditions:
+    /// [`access_mode`] may say that a file is readable,
+    /// while the file type still does not support `read`,
+    /// as with epoll files and pid files.
+    ///
+    /// Implementors should override this method if the file type supports reads.
+    /// An overriding implementation must check whether [`access_mode`] is readable
+    /// before performing the operation.
+    ///
+    /// [`access_mode`]: FileLike::access_mode
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        return_errno_with_message!(Errno::EBADF, "the file is not valid for reading");
+        if !self.access_mode().is_readable() {
+            return_errno_with_message!(Errno::EBADF, "the file is not opened for reading");
+        }
+        return_errno_with_message!(Errno::EINVAL, "read is not supported for this file type");
     }
 
+    /// Writes data to this file.
+    ///
+    /// By default, this method returns `EBADF`
+    /// if the file is not writable,
+    /// or `EINVAL` if the file type does not support `write`.
+    /// These are distinct conditions:
+    /// [`access_mode`] may say that a file is writable,
+    /// while the file type still does not support `write`,
+    /// as with epoll files and pid files.
+    ///
+    /// Implementors should override this method if the file type supports writes.
+    /// An overriding implementation must check whether [`access_mode`] is writable
+    /// before performing the operation.
+    ///
+    /// [`access_mode`]: FileLike::access_mode
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
-        return_errno_with_message!(Errno::EBADF, "the file is not valid for writing");
+        if !self.access_mode().is_writable() {
+            return_errno_with_message!(Errno::EBADF, "the file is not opened for writing");
+        }
+        return_errno_with_message!(Errno::EINVAL, "write is not supported for this file type");
     }
 
     /// Read at the given file offset.

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -362,6 +362,7 @@ impl FileLike for InotifyFile {
     }
 
     fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/notify/inotify/inotify_user.c#L711>.
         AccessMode::O_RDONLY
     }
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -7,7 +7,7 @@ use util::{MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr};
 
 use crate::{
     fs::{
-        file::{CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::SockFs,
         vfs::path::Path,
     },
@@ -167,6 +167,11 @@ impl<T: Socket + 'static> FileLike for T {
             self.set_nonblocking(false);
         }
         Ok(())
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/net/socket.c#L483>.
+        AccessMode::O_RDWR
     }
 
     fn as_socket(&self) -> Option<&dyn Socket> {

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -76,14 +76,6 @@ impl PidFile {
 }
 
 impl FileLike for PidFile {
-    fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "PID file cannot be read");
-    }
-
-    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "PID file cannot be written");
-    }
-
     fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
         return_errno_with_message!(
             Errno::EINVAL,

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::{
     events::IoEvents,
     fs::{
-        file::{CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::PidfdFs,
         vfs::path::Path,
     },
@@ -114,6 +114,11 @@ impl FileLike for PidFile {
         } else {
             StatusFlags::empty()
         }
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/kernel/fork.c#L1898>.
+        AccessMode::O_RDWR
     }
 
     fn path(&self) -> &Path {

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -22,7 +22,7 @@ use super::SyscallReturn;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::AnonInodeFs,
         vfs::path::Path,
     },
@@ -229,6 +229,11 @@ impl FileLike for EventFile {
         // TODO: deal with other flags
 
         Ok(())
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L401>.
+        AccessMode::O_RDWR
     }
 
     fn path(&self) -> &Path {

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -252,10 +252,6 @@ impl FileLike for SignalFile {
         }
     }
 
-    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
-        return_errno_with_message!(Errno::EBADF, "signalfd does not support write operations");
-    }
-
     fn status_flags(&self) -> StatusFlags {
         if self.is_non_blocking() {
             StatusFlags::O_NONBLOCK

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -19,7 +19,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            CreationFlags, FileLike, StatusFlags,
+            AccessMode, CreationFlags, FileLike, StatusFlags,
             file_table::{FdFlags, RawFileDesc, get_file_fast},
         },
         pseudofs::AnonInodeFs,
@@ -267,6 +267,11 @@ impl FileLike for SignalFile {
     fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
         self.set_non_blocking(new_flags.contains(StatusFlags::O_NONBLOCK));
         Ok(())
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/signalfd.c#L276>.
+        AccessMode::O_RDWR
     }
 
     fn path(&self) -> &Path {

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -228,10 +228,6 @@ impl FileLike for TimerfdFile {
         Ok(read_len)
     }
 
-    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
-        return_errno_with_message!(Errno::EINVAL, "the file is not valid for writing");
-    }
-
     fn status_flags(&self) -> StatusFlags {
         if self.is_nonblocking() {
             StatusFlags::O_NONBLOCK

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -12,7 +12,7 @@ use super::clockid_t;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::AnonInodeFs,
         vfs::path::Path,
     },
@@ -252,6 +252,11 @@ impl FileLike for TimerfdFile {
             .unwrap();
 
         Ok(())
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/timerfd.c#L436>.
+        AccessMode::O_RDWR
     }
 
     fn path(&self) -> &Path {


### PR DESCRIPTION
The first commit addresses https://github.com/asterinas/asterinas/pull/3226#discussion_r3245707097. Each file type now implements `access_mode` individually. A reference to the corresponding Linux behavior is also added.

The second commit fixes another issue discovered during the refactor. In Linux, whether a file is readable or writable is not determined solely by `FMODE_READ`/`FMODE_WRITE`. Linux also checks whether the file has read/write methods implemented; if so, it sets `FMODE_CAN_READ` and `FMODE_CAN_WRITE` accordingly when initializing a `struct file`. If a file has `FMODE_READ`/`FMODE_WRITE` set but lacks the corresponding read/write method, Linux returns `EINVAL`. This behavior can serve as a default implementation shared across all file types, allowing us to remove several redundant per-type implementations.

https://elixir.bootlin.com/linux/v7.0/source/fs/file_table.c#L330
```C
if ((file->f_mode & FMODE_WRITE) &&
       likely(fop->write || fop->write_iter))
      file->f_mode |= FMODE_CAN_WRITE;
```

https://elixir.bootlin.com/linux/v7.0/source/fs/read_write.c#L672
```C
if (!(file->f_mode & FMODE_WRITE))
      return -EBADF;
if (!(file->f_mode & FMODE_CAN_WRITE))
      return -EINVAL;
```