### PR TITLE
Remove explicit `unsafe_op_in_unsafe_fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,8 @@ exclude = [
 
 [workspace.lints.rust]
 redundant_imports = "warn"
-unused_qualifications = "warn"
-unsafe_op_in_unsafe_fn = "warn"
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(ktest)'] }
+unused_qualifications = "warn"
 
 [workspace.lints.clippy]
 allow_attributes = "warn"

--- a/kernel/libs/cpio-decoder/src/lib.rs
+++ b/kernel/libs/cpio-decoder/src/lib.rs
@@ -19,6 +19,7 @@
 #![deny(unsafe_code)]
 
 extern crate alloc;
+
 #[cfg(not(test))]
 use alloc::string::{String, ToString};
 use alloc::vec;

--- a/ostd/src/prelude.rs
+++ b/ostd/src/prelude.rs
@@ -5,7 +5,11 @@
 /// A specialized [`Result`] type for this crate.
 ///
 /// [`Result`]: core::result::Result
-pub type Result<T, E = error::Error> = core::result::Result<T, E>;
+#[expect(
+    unused_qualifications,
+    reason = "`error` below is intended to re-export the macro but brings the module into scope"
+)]
+pub type Result<T, E = crate::error::Error> = core::result::Result<T, E>;
 
 pub(crate) use alloc::{boxed::Box, sync::Arc, vec::Vec};
 


### PR DESCRIPTION
The `unsafe_op_in_unsafe_fn` lint was added in https://github.com/asterinas/asterinas/pull/2081 when we were still using Rust 2021.

It is now a `warn-by-default` lint in Rust 2024, so we don't need to list the lint explicitly. I have verified that the lint fires normally after removing it from the explicit warning list.

There are three other minor problems.
 1. `ostd::prelude` re-exports `ostd::error`. It is meant to re-export the log macro, but it also brings the `error` module into scope. This module is not visible to users outside of OSTD, so it does not seem to have much impact. However, I'd like to explicitly note this fact since the `unused_qualifications` lint successfully made me aware of this issue.
    - I could not find a valid solution to this. It appears that Rust does not have a syntax that allows us to re-export only the macro.
 2. Add a missing blank line in `cpio-decoder`.
 3. Sort the list of lint in alphabetical order.

cc @zjp-CN as it's a small follow-up to your PRs.