### PR TITLE
Refactor `Dentry` variants to pave the way for `O_TMPFILE`

### DIFF
--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -90,6 +90,44 @@ use crate::{
 /// |  ordinary file or directory |
 /// +-----------------------------+
 /// ```
+///
+/// # Dentries vs inodes
+///
+/// An [`Inode`] *is* the filesystem object:
+/// it owns the file's data and metadata
+/// (type, size, mode, owner, timestamps, link count)
+/// and is implemented per filesystem (e.g. ramfs, ext2).
+/// An inode has no inherent name and no location in the directory tree.
+///
+/// A `Dentry` is the VFS-level cache node that *names* an inode
+/// and places it in the path namespace.
+/// Every `Dentry` references exactly one inode (held as `Arc<dyn Inode>`),
+/// but the reverse is not one-to-one:
+///
+/// - **One inode, many dentries.**
+///   Hard links are several `Named` dentries referencing the same inode;
+///   the inode's link count tracks how many.
+/// - **One inode, no reachable dentry.**
+///   A file unlinked while still open,
+///   or an `Anonymous` (`O_TMPFILE`) inode,
+///   lives on with no `Named` dentry, so path lookup cannot reach it.
+/// - **Directories are one-to-one.**
+///   A directory inode cannot be hard-linked,
+///   so it has exactly one `Named` (or `Root`) dentry;
+///   only the `Dentry` layer holds the parent/child structure
+///   and the children cache that path lookup walks.
+///
+/// Rule of thumb:
+/// operations on *content and metadata*
+/// (`read`, `write`, `stat`, `chmod`)
+/// act on the [`Inode`];
+/// operations on *names and tree shape*
+/// (lookup, `link`, `unlink`, `rename`, mounting)
+/// act on the `Dentry`.
+/// A [`Path`](super::Path) goes one step further
+/// and pairs a `Dentry` with the `Mount` it was reached through,
+/// since mounts let a single `Dentry`
+/// appear at several locations in the namespace.
 pub(in crate::fs) struct Dentry {
     inode: Arc<dyn Inode>,
     type_: InodeType,

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -103,7 +103,7 @@ impl Dentry {
     fn new(inode: Arc<dyn Inode>, options: DentryOptions) -> Arc<Self> {
         let name_and_parent = match options {
             DentryOptions::Root => NameAndParent::Real(None),
-            DentryOptions::Leaf(name_and_parent) => {
+            DentryOptions::Named(name_and_parent) => {
                 NameAndParent::Real(Some(RwLock::new(name_and_parent)))
             }
             DentryOptions::Pseudo(name_fn) => NameAndParent::Pseudo(name_fn),
@@ -282,7 +282,7 @@ impl DirDentry<'_> {
 
             let new_child = Dentry::new(
                 new_inode,
-                DentryOptions::Leaf((String::from(name), self.this())),
+                DentryOptions::Named((String::from(name), self.this())),
             );
             return Ok(self.insert_positive_child(&mut children, name, new_child));
         }
@@ -291,7 +291,7 @@ impl DirDentry<'_> {
         let mut children = children.upgrade();
         let new_child = Dentry::new(
             new_inode,
-            DentryOptions::Leaf((String::from(name), self.this())),
+            DentryOptions::Named((String::from(name), self.this())),
         );
 
         Ok(self.insert_positive_child(&mut children, name, new_child))
@@ -385,7 +385,7 @@ impl DirDentry<'_> {
 
         let target = Dentry::new(
             inode,
-            DentryOptions::Leaf((String::from(name), self.this())),
+            DentryOptions::Named((String::from(name), self.this())),
         );
         let mut children = children.upgrade();
 
@@ -407,7 +407,7 @@ impl DirDentry<'_> {
         let inode = self.inode.mknod(name, mode, type_)?;
         let new_child = Dentry::new(
             inode,
-            DentryOptions::Leaf((String::from(name), self.this())),
+            DentryOptions::Named((String::from(name), self.this())),
         );
         let mut children = children.upgrade();
 
@@ -424,7 +424,7 @@ impl DirDentry<'_> {
         self.inode.link(old_inode, name)?;
         let dentry = Dentry::new(
             old_inode.clone(),
-            DentryOptions::Leaf((String::from(name), self.this())),
+            DentryOptions::Named((String::from(name), self.this())),
         );
         let mut children = children.upgrade();
         self.insert_positive_child(&mut children, name, dentry.clone());
@@ -678,7 +678,7 @@ bitflags! {
 
 enum DentryOptions {
     Root,
-    Leaf((String, Arc<Dentry>)),
+    Named((String, Arc<Dentry>)),
     Pseudo(fn(&dyn Inode) -> String),
 }
 

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -22,6 +22,74 @@ use crate::{
 };
 
 /// A `Dentry` represents a cached filesystem node in the VFS tree.
+///
+/// # Dentry variants
+///
+/// Conceptually, there are four variants of dentries:
+///
+/// - **Root** — the root of a mounted filesystem;
+///   its name derives from the mountpoint.
+///   It has no in-tree parent.
+/// - **Named** — an ordinary entry under a parent directory
+///   with a real, mutable name.
+/// - **Anonymous** — a real filesystem inode that has no name yet:
+///   it keeps a real parent directory,
+///   but is deliberately kept out of the parent's children cache,
+///   so path lookup cannot reach it.
+///   This variant is reserved for temporary files created via `O_TMPFILE`;
+///   such a file can be promoted to a `Named` dentry
+///   by a later `linkat(2)` (future work).
+/// - **Pseudo** — an object with no position in any real filesystem tree
+///   (pipes, sockets, anon-inode fds, namespace/pidfd files, memfd).
+///   It has no parent,
+///   and its name is a synthesized display string
+///   used only for `/proc/<pid>/fd/<n>`.
+///
+/// Only `Root` and `Named` dentries are reachable by path lookup;
+/// `Anonymous` and `Pseudo` are not.
+///
+/// To understand their connections and differences,
+/// ask the following three questions (Q1 to Q3) in the diagram below:
+///
+/// ```text
+/// +-------------------------------------------+
+/// | Q1. In a *real* filesystem tree?          |
+/// +-------------------------------------------+
+///   |
+///   |-- no -->  +-----------------------------+
+///   |           |           Pseudo            |
+///   |           |  pipe, socket, anon_inode,  |
+///   |           |  memfd, ns/pidfd            |
+///   |           +-----------------------------+
+///   | yes
+///   v
+/// +-------------------------------------------+
+/// | Q2. Has a *parent*?                       |
+/// +-------------------------------------------+
+///   |
+///   |-- no -->  +-----------------------------+
+///   |           |            Root             |
+///   |           |  root of a mounted fs       |
+///   |           +-----------------------------+
+///   | yes
+///   v
+/// +-------------------------------------------+
+/// | Q3. Has a *name*?                         |
+/// +-------------------------------------------+
+///   |
+///   |-- no -->  +-----------------------------+
+///   |           |          Anonymous          |
+///   |           |  O_TMPFILE: a real inode    |
+///   |           |  under a real directory,    |
+///   |           |  not yet / never named      |
+///   |           +-----------------------------+
+///   | yes
+///   v
+/// +-----------------------------+
+/// |            Named            |
+/// |  ordinary file or directory |
+/// +-----------------------------+
+/// ```
 pub(in crate::fs) struct Dentry {
     inode: Arc<dyn Inode>,
     type_: InodeType,
@@ -40,7 +108,17 @@ struct DentryDirState {
 
 /// The name and parent of a `Dentry`.
 enum NameAndParent {
+    /// A root or named `Dentry`:
+    /// `None` is the root (name `"/"`, no parent);
+    /// `Some` is a named child whose name and parent can change
+    /// (e.g. on `rename`).
     Real(Option<RwLock<(String, Arc<Dentry>)>>),
+    /// An anonymous child:
+    /// a real parent directory,
+    /// but a fixed `"/"` name and never present in the parent's children cache.
+    Anonymous(Arc<Dentry>),
+    /// A pseudo `Dentry`;
+    /// the `fn` synthesizes its display name.
     Pseudo(fn(&dyn Inode) -> String),
 }
 
@@ -55,15 +133,16 @@ impl NameAndParent {
                 Some(name_and_parent) => name_and_parent.read().0.clone(),
                 None => String::from("/"),
             },
+            NameAndParent::Anonymous(_) => String::from("/"),
             NameAndParent::Pseudo(name_fn) => (name_fn)(inode),
         }
     }
 
     fn parent(&self) -> Option<Arc<Dentry>> {
-        if let NameAndParent::Real(Some(name_and_parent)) = self {
-            Some(name_and_parent.read().1.clone())
-        } else {
-            None
+        match self {
+            NameAndParent::Real(Some(name_and_parent)) => Some(name_and_parent.read().1.clone()),
+            NameAndParent::Anonymous(parent) => Some(parent.clone()),
+            NameAndParent::Real(None) | NameAndParent::Pseudo(_) => None,
         }
     }
 
@@ -71,7 +150,10 @@ impl NameAndParent {
     ///
     /// # Errors
     ///
-    /// Returns `SetNameAndParentError` if the `Dentry` is a root or pseudo `Dentry`.
+    /// Returns `SetNameAndParentError`
+    /// if the `Dentry` is a root, anonymous, or pseudo `Dentry`.
+    /// (Promoting an anonymous `Dentry` to a named one,
+    /// e.g. for `linkat(2)` on an `O_TMPFILE` file, is future work.)
     fn set(&self, name: &str, parent: Arc<Dentry>) -> Result<(), SetNameAndParentError> {
         if let NameAndParent::Real(Some(name_and_parent)) = self {
             let mut name_and_parent = name_and_parent.write();
@@ -92,6 +174,14 @@ impl Dentry {
         Self::new(inode, DentryOptions::Root)
     }
 
+    /// Creates a new anonymous `Dentry` with the given inode and parent.
+    ///
+    /// See the [`Dentry`] type-level documentation for what "anonymous" means.
+    #[expect(dead_code, reason = "constructed by the upcoming O_TMPFILE support")]
+    pub(super) fn new_anonymous(inode: Arc<dyn Inode>, parent: Arc<Dentry>) -> Arc<Self> {
+        Self::new(inode, DentryOptions::Anonymous { parent })
+    }
+
     /// Creates a new pseudo `Dentry` with the given inode and name function.
     pub(super) fn new_pseudo(
         inode: Arc<dyn Inode>,
@@ -106,6 +196,7 @@ impl Dentry {
             DentryOptions::Named(name_and_parent) => {
                 NameAndParent::Real(Some(RwLock::new(name_and_parent)))
             }
+            DentryOptions::Anonymous { parent } => NameAndParent::Anonymous(parent),
             DentryOptions::Pseudo(name_fn) => NameAndParent::Pseudo(name_fn),
         };
 
@@ -648,9 +739,15 @@ impl Debug for Dentry {
 
 /// `DentryKey` is the unique identifier for the corresponding `Dentry`.
 ///
-/// - For non-root dentries, it uses self's name and parent's pointer to form the key,
+/// - For named dentries, it uses self's name and parent's pointer to form the key.
 /// - For the root dentry, it uses "/" and self's pointer to form the key.
 /// - For pseudo dentries, it uses self's name and self's pointer to form the key.
+///
+/// Anonymous dentries have no meaningful `DentryKey`:
+/// they all share a fixed `"/"` name under a real parent,
+/// so their keys would not be unique.
+/// They are never cached by a parent or used as a mountpoint,
+/// so [`Dentry::key`] must not be called on them.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(super) struct DentryKey {
     name: String,
@@ -660,6 +757,15 @@ pub(super) struct DentryKey {
 impl DentryKey {
     /// Forms a `DentryKey` from the corresponding `Dentry`.
     fn new(dentry: &Dentry) -> Self {
+        // Anonymous dentries must not be keyed:
+        // their keys would not be unique,
+        // and they are never cached by a parent or used as a mountpoint.
+        // See the [`DentryKey`] documentation for details.
+        debug_assert!(!matches!(
+            dentry.name_and_parent,
+            NameAndParent::Anonymous(_)
+        ));
+
         let name = dentry.name();
         let parent = dentry.parent().unwrap_or_else(|| dentry.this());
 
@@ -676,9 +782,19 @@ bitflags! {
     }
 }
 
+/// The shape of a [`Dentry`] to create.
+/// See [`Dentry`] for the taxonomy.
 enum DentryOptions {
+    /// Root of a mounted filesystem.
     Root,
+    /// A named entry under a parent directory.
     Named((String, Arc<Dentry>)),
+    /// A real inode parented to a directory
+    /// but kept out of the parent's children cache.
+    /// Reserved for `O_TMPFILE`.
+    Anonymous { parent: Arc<Dentry> },
+    /// An object with no place in any real filesystem tree;
+    /// the `fn` synthesizes its display name for `/proc/<pid>/fd/<n>`.
     Pseudo(fn(&dyn Inode) -> String),
 }
 

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -198,6 +198,18 @@ impl PathResolver {
             return AbsPathResult::Unreachable(path.name());
         }
 
+        // TODO: The paths reported via `/proc/<pid>/fd/<fd>` are currently
+        // incorrect for unlinked-but-open ("deleted") and anonymous
+        // (`O_TMPFILE`) dentries. Linux unhashes such dentries and renders the
+        // path with a trailing " (deleted)" (their dentry name is just "/",
+        // which Asterinas mirrors). Here there is no such detection: an
+        // anonymous dentry's "/" name is walked as an ordinary component, so
+        // e.g. an `O_TMPFILE` file under `/tmp` is rendered as `/tmp//` and
+        // misreported as `Reachable` instead of `Unreachable`. Detecting
+        // unreachable/deleted dentries belongs at this `Path` layer (mirroring
+        // the pseudo-path special-case above); the anonymous side is wired up
+        // together with the `O_TMPFILE` open path in PR #3185.
+
         let mut components = VecDeque::new();
         components.push_front(self.resolve_name(path));
 


### PR DESCRIPTION
## Motivation

PR #3185 implements `O_TMPFILE` support for `open`/`openat`. While designing that work it became clear that an `O_TMPFILE` file does not fit any existing `Dentry` shape: it is a *real* filesystem inode that has a parent directory and lives on a real mount, yet it has no name and is unreachable by path lookup until a later `linkat(2)` promotes it. Forcing it through the existing `Pseudo` shape (pipes/sockets/anon-inode/memfd, which live on private pseudo-mounts) would be semantically wrong and would mis-render `/proc/<pid>/fd/<n>`.

This PR extracts the purely structural `Dentry` groundwork out of #3185 so it can be reviewed on its own, with **no behavior change**. The actual `O_TMPFILE` syscall logic stays in #3185 and builds on top of this.

## What this PR does

- **Rename the `Leaf` dentry option to `Named`.** `Leaf` was a misnomer (a directory that has children is still a `Leaf`); `Named` states the real invariant (a named entry under a parent). Purely internal rename — no public API uses the word "leaf".
- **Add an `Anonymous` dentry option.** A real inode parented to a directory but deliberately kept out of the parent's children cache, so path lookup cannot reach it — the shape an `O_TMPFILE` file needs. It is currently unconstructed (annotated `#[expect(dead_code)]`) and is wired up by #3185; `linkat`-based promotion to `Named` is likewise left to #3185.
- **Document the taxonomy and the dentry/inode relationship.** The type-level docs now describe the four variants (`Root`, `Named`, `Anonymous`, `Pseudo`) with a decision-tree diagram, plus a new "Dentries vs inodes" section.

The three pre-existing shapes behave exactly as before; only the rename, the new (currently unused) variant, and documentation are added.

Related: #3185.