### PR TITLE
Add patches for GDB

### DIFF
--- a/.github/workflows/push_cachix_dev.yml
+++ b/.github/workflows/push_cachix_dev.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: asterinas/asterinas:0.17.2-20260508
       options: -v /dev:/dev --privileged
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 

--- a/distro/aster_nixos_installer/templates/aster_configuration.nix
+++ b/distro/aster_nixos_installer/templates/aster_configuration.nix
@@ -32,6 +32,7 @@
   # please refer to https://nixos.org/manual/nixpkgs/stable/#sec-overlays-definition.
   config.nixpkgs.overlays = [
     (import ./overlays/desktop/default.nix)
+    (import ./overlays/gdb/default.nix)
     (import ./overlays/hello-asterinas/default.nix)
     (import ./overlays/podman/default.nix)
     (import ./overlays/switch-to-configuration-ng/default.nix)

--- a/distro/cachix/default.nix
+++ b/distro/cachix/default.nix
@@ -7,6 +7,7 @@ let
   nixos = pkgs.nixos (import "${installer}/etc_nixos/configuration.nix");
   cachixPkgs = with nixos.pkgs;
     [
+      gdb
       hello-asterinas
       xfce.xfdesktop
       xfce.xfwm4

--- a/distro/etc_nixos/overlays/gdb/0001-Bypass-reading-x86-debug-registers.patch
+++ b/distro/etc_nixos/overlays/gdb/0001-Bypass-reading-x86-debug-registers.patch
@@ -1,0 +1,36 @@
+From 29198bccc3cb7c2ec9eeeb5bece1dbb07ed283ad Mon Sep 17 00:00:00 2001
+From: Wang Siyuan <wsy@stu.pku.edu.cn>
+Date: Mon, 18 May 2026 14:35:44 +0800
+Subject: [PATCH 1/2] Bypass reading x86 debug registers
+
+This patch emulates the default state of the x86 debug registers,
+so it can correctly respond when a tracer reads the tracee’s
+debug registers via `PTRACE_PEEKUSER`. In the current implementation,
+the tracee’s x86 debug registers are never actually modified,
+so they always remain at their default values.
+
+---
+ gdb/nat/x86-linux-dregs.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/gdb/nat/x86-linux-dregs.c b/gdb/nat/x86-linux-dregs.c
+index a6c0ea6..0123f90 100644
+--- a/gdb/nat/x86-linux-dregs.c
++++ b/gdb/nat/x86-linux-dregs.c
+@@ -39,6 +39,13 @@ u_debugreg_offset (int regnum)
+ static unsigned long
+ x86_linux_dr_get (ptid_t ptid, int regnum)
+ {
++  if ((0 <= regnum && regnum <= 5) || regnum == DR_CONTROL)
++    return 0;
++  else if (regnum == DR_STATUS)
++    return 0xffff0ff0UL;
++  else
++    gdb_assert_not_reached ("unexpected debug register");
++
+   int tid;
+   unsigned long value;
+
+--
+2.34.1
+

--- a/distro/etc_nixos/overlays/gdb/0002-Do-not-warn-that-disabling-ASLR-failed.patch
+++ b/distro/etc_nixos/overlays/gdb/0002-Do-not-warn-that-disabling-ASLR-failed.patch
@@ -1,0 +1,31 @@
+From 30ddbd9a2cc54073e00f25e78a1737cd6c1ca447 Mon Sep 17 00:00:00 2001
+From: Wang Siyuan <wsy@stu.pku.edu.cn>
+Date: Mon, 18 May 2026 14:35:59 +0800
+Subject: [PATCH 2/2] Do not warn that disabling ASLR failed
+
+This patch suppresses the GDB warning "Error disabling address space randomization".
+TODO: Remove this patch once personality(ADDR_NO_RANDOMIZE) is supported.
+
+---
+ gdb/nat/linux-personality.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gdb/nat/linux-personality.c b/gdb/nat/linux-personality.c
+index a406c73..cee1ab1 100644
+--- a/gdb/nat/linux-personality.c
++++ b/gdb/nat/linux-personality.c
+@@ -43,8 +43,9 @@ maybe_disable_address_space_randomization (int disable_randomization)
+ 	}
+       if (errno != 0 || (m_personality_set
+ 			 && !(personality (0xffffffff) & ADDR_NO_RANDOMIZE)))
+-	warning (_("Error disabling address space randomization: %s"),
+-		 safe_strerror (errno));
++      {
++        // Ignore failures to disable ASLR.
++      }
+     }
+ }
+
+--
+2.34.1
+

--- a/distro/etc_nixos/overlays/gdb/default.nix
+++ b/distro/etc_nixos/overlays/gdb/default.nix
@@ -1,0 +1,10 @@
+self: super:
+
+{
+  gdb = super.gdb.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or [ ]) ++ [
+      ./0001-Bypass-reading-x86-debug-registers.patch
+      ./0002-Do-not-warn-that-disabling-ASLR-failed.patch
+    ];
+  });
+}


### PR DESCRIPTION
Goes after https://github.com/asterinas/asterinas/pull/3246. Required for #2323.

With these patches, we can debug single-threaded processes with GDB.

The first patch emulates the default state of the x86 debug registers, so it can correctly respond when a tracer reads the tracee’s debug registers via `PTRACE_PEEKUSER`. In the current main branch, the tracee’s x86 debug registers are never actually modified, so they always remain at their default values.

The second patch suppresses the GDB warning "Error disabling address space randomization". This patch will be removed once `personality(ADDR_NO_RANDOMIZE)` is supported.