### PR TITLE
Fix book links and add link check

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -4,14 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - VERSION
       - book/**
-      - .github/workflows/update-website.yml
+      - .github/workflows/publish_website.yml
   push:
     branches:
       - main
     paths:
+      - VERSION
       - book/**
-      - .github/workflows/update-website.yml
+      - .github/workflows/publish_website.yml
 
 jobs:
   build_and_deploy:
@@ -23,12 +25,29 @@ jobs:
         with:
           repository: 'asterinas/asterinas'
           path: 'asterinas'
-      
+
+      - name: Cache .lycheecache
+        uses: actions/cache@v6
+        with:
+          path: asterinas/book/.lycheecache
+          key: lychee-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          # Cache lookup strategy:
+          # 1) Exact key (os + ref_name + sha), hit on rerun of the same commit.
+          # 2) If exact key misses, restore by os + ref_name prefix; newest match wins.
+          # 3) Final fallback is os-only prefix; newest match wins.
+          # Multiple restore-keys lines are intentional for progressive fallback (from specific to broad).
+          restore-keys: |
+            lychee-${{ runner.os }}-${{ github.ref_name }}
+            lychee-${{ runner.os }}-
+
       - name: Build the website
+        env:
+          # Avoid hitting rate limit when lychee accesses github links.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd asterinas/book
-          mdbook-mermaid install
-          mdbook build
+          make check
+          make
 
       - name: Deploy website
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -4,14 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - VERSION
       - book/**
-      - .github/workflows/update-website.yml
+      - .github/workflows/publish_website.yml
   push:
     branches:
       - main
     paths:
+      - VERSION
       - book/**
-      - .github/workflows/update-website.yml
+      - .github/workflows/publish_website.yml
 
 jobs:
   build_and_deploy:
@@ -24,11 +26,28 @@ jobs:
           repository: 'asterinas/asterinas'
           path: 'asterinas'
 
+      - name: Cache .lycheecache
+        uses: actions/cache@v6
+        with:
+          path: asterinas/book/.lycheecache
+          key: lychee-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          # Cache lookup strategy:
+          # 1) Exact key (os + ref_name + sha), hit on rerun of the same commit.
+          # 2) If exact key misses, restore by os + ref_name prefix; newest match wins.
+          # 3) Final fallback is os-only prefix; newest match wins.
+          # Multiple restore-keys lines are intentional for progressive fallback (from specific to broad).
+          restore-keys: |
+            lychee-${{ runner.os }}-${{ github.ref_name }}
+            lychee-${{ runner.os }}-
+
       - name: Build the website
+        env:
+          # Avoid hitting rate limit when lychee accesses github links.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd asterinas/book
-          mdbook-mermaid install
-          mdbook build
+          make
+          make check
 
       - name: Deploy website
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/Makefile
+++ b/Makefile
@@ -397,13 +397,6 @@ docs: $(CARGO_OSDK)
 		cd ostd/libs/linux-bzimage/setup && RUSTDOCFLAGS="-Dwarnings" cargo osdk doc --no-deps; \
 	fi
 
-.PHONY: book
-book: book/mermaid.min.js book/mermaid-init.js
-	@cd book && mdbook build
-
-book/mermaid.min.js book/mermaid-init.js:
-	@mdbook-mermaid install book/
-
 .PHONY: format
 format:
 	@./tools/format_all.sh

--- a/Makefile
+++ b/Makefile
@@ -398,13 +398,6 @@ docs: $(CARGO_OSDK)
 		cd ostd/libs/linux-bzimage/setup && RUSTDOCFLAGS="-Dwarnings" cargo osdk doc --no-deps; \
 	fi
 
-.PHONY: book
-book: book/mermaid.min.js book/mermaid-init.js
-	@cd book && mdbook build
-
-book/mermaid.min.js book/mermaid-init.js:
-	@mdbook-mermaid install book/
-
 .PHONY: format
 format:
 	@# Trim trailing whitespace from all git-tracked, non-patch files

--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,3 +1,4 @@
 book
 mermaid.min.js
 mermaid-init.js
+.lycheecache

--- a/book/Makefile
+++ b/book/Makefile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+
+.PHONY: build
+build: mermaid.min.js mermaid-init.js
+	@mdbook build
+
+mermaid.min.js mermaid-init.js:
+	@mdbook-mermaid install
+
+.PHONY: check
+check: check_rust_api_doc_version check_invalid_or_broken_links
+
+.PHONY: check_rust_api_doc_version
+check_rust_api_doc_version:
+	@./check_rust_api_doc_version.sh
+
+.PHONY: check_invalid_or_broken_links
+check_invalid_or_broken_links:
+	@./check_invalid_or_broken_links.sh

--- a/book/Makefile
+++ b/book/Makefile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+
+.PHONY: build
+build: mermaid.min.js mermaid-init.js
+	@mdbook build
+
+mermaid.min.js mermaid-init.js:
+	@mdbook-mermaid install
+
+.PHONY: check
+check: check_rust_api_doc_version check_invalid_or_broken_links
+
+.PHONY: check_rust_api_doc_version
+check_rust_api_doc_version:
+	@./check_rust_api_doc_version.sh
+
+.PHONY: check_invalid_or_broken_links
+check_invalid_or_broken_links: build
+	@./check_invalid_or_broken_links.sh

--- a/book/check_invalid_or_broken_links.sh
+++ b/book/check_invalid_or_broken_links.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+# Temporary files:
+# - JSON_FILE stores lychee JSON output.
+# - URLS_FILE stores failed http/https links extracted from lychee output.
+# - CACHE_UPDATES_FILE stores recovered links to write back into .lycheecache.
+# - CACHE_MERGED_FILE is the merged cache output before replace.
+JSON_FILE="$(mktemp /tmp/lychee-result-XXXXXX.json)"
+URLS_FILE="$(mktemp /tmp/lychee-failed-urls-XXXXXX.txt)"
+CACHE_UPDATES_FILE="$(mktemp /tmp/lychee-cache-updates-XXXXXX.txt)"
+CACHE_MERGED_FILE="$(mktemp /tmp/lychee-cache-merged-XXXXXX.txt)"
+
+cleanup() {
+  rm -f "$JSON_FILE" "$URLS_FILE" "$CACHE_UPDATES_FILE" "$CACHE_MERGED_FILE"
+}
+trap cleanup EXIT
+
+print_lychee_summary() {
+  echo "lychee summary:"
+  echo "  total.......$LYCHEE_TOTAL"
+  echo "  unique......$LYCHEE_UNIQUE"
+  echo "  successful..$LYCHEE_SUCCESSFUL"
+  echo "  timeouts....$LYCHEE_TIMEOUTS"
+  echo "  redirected..$LYCHEE_REDIRECTS"
+  echo "  excluded....$LYCHEE_EXCLUDED"
+  echo "  unknown.....$LYCHEE_UNKNOWN"
+  echo "  errors......$LYCHEE_ERRORS"
+  echo "  unsupported.$LYCHEE_UNSUPPORTED"
+}
+
+# Run lychee once and capture JSON output for fallback processing.
+echo "[1/3] Running lychee..."
+LYCHEE_EXIT=0
+if ! lychee --config lychee.toml --format json --no-progress src/ >"$JSON_FILE"; then
+  LYCHEE_EXIT=$?
+fi
+
+# Collect unique failed http/https links from lychee error/timeout maps.
+jq -r '
+  [
+    (.error_map // {} | to_entries[]? | .value[]? | .url?),
+    (.timeout_map // {} | to_entries[]? | .value[]? | .url?)
+  ]
+  | map(select(type == "string" and test("^https?://")))
+  | unique
+  | .[]
+' "$JSON_FILE" >"$URLS_FILE"
+
+# Print lychee raw stats (same data source as detailed format summary).
+LYCHEE_TOTAL="$(jq -r '.total // 0' "$JSON_FILE")"
+LYCHEE_UNIQUE="$(jq -r '.unique // 0' "$JSON_FILE")"
+LYCHEE_SUCCESSFUL="$(jq -r '.successful // 0' "$JSON_FILE")"
+LYCHEE_TIMEOUTS="$(jq -r '.timeouts // 0' "$JSON_FILE")"
+LYCHEE_REDIRECTS="$(jq -r '.redirects // 0' "$JSON_FILE")"
+LYCHEE_EXCLUDED="$(jq -r '.excludes // 0' "$JSON_FILE")"
+LYCHEE_UNKNOWN="$(jq -r '.unknown // 0' "$JSON_FILE")"
+LYCHEE_ERRORS="$(jq -r '.errors // 0' "$JSON_FILE")"
+LYCHEE_UNSUPPORTED="$(jq -r '.unsupported // 0' "$JSON_FILE")"
+
+TOTAL_FAILED_BY_LYCHEE="$(wc -l <"$URLS_FILE" | tr -d ' ')"
+echo "lychee failed links: $TOTAL_FAILED_BY_LYCHEE"
+if [ "$TOTAL_FAILED_BY_LYCHEE" -eq 0 ]; then
+  print_lychee_summary
+  exit "$LYCHEE_EXIT"
+fi
+
+# Retry failed links using plain curl; report recovered/failed links.
+echo "[2/3] Curl fallback on lychee-failed links..."
+RECOVERED=0
+FAILED=0
+while IFS= read -r url; do
+  [ -z "$url" ] && continue
+  STATUS_CODE="$(curl -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)"
+  CURL_EXIT=$?
+  if [ "$CURL_EXIT" -eq 0 ]; then
+    RECOVERED=$((RECOVERED + 1))
+    echo "RECOVERED: $url (status=$STATUS_CODE)"
+    # Status code is recorded as 200 in .lycheecache to let lychee skip the link next time.
+    printf '%s,%s,%s\n' "$url" "200" "$(date +%s)" >>"$CACHE_UPDATES_FILE"
+  else
+    FAILED=$((FAILED + 1))
+    echo "FAILED:    $url"
+  fi
+done <"$URLS_FILE"
+
+# Write recovered links into .lycheecache as url,status,timestamp.
+UPDATED_CACHE_LINES=0
+if [ -s "$CACHE_UPDATES_FILE" ]; then
+  if [ -f .lycheecache ]; then
+    # Merge cache with URL-level deduplication:
+    # - First pass (updates): keep the latest recovered record by URL.
+    # - Second pass (existing cache): keep only URLs not present in updates.
+    # - End: append updated records so recovered entries replace old ones.
+    awk -F, '
+      NR==FNR { new[$1]=$0; order[++n]=$1; next }
+      !($1 in new) { print }
+      END { for (i=1; i<=n; i++) print new[order[i]] }
+    ' "$CACHE_UPDATES_FILE" .lycheecache >"$CACHE_MERGED_FILE"
+  else
+    cat "$CACHE_UPDATES_FILE" >"$CACHE_MERGED_FILE"
+  fi
+  mv "$CACHE_MERGED_FILE" .lycheecache
+  UPDATED_CACHE_LINES="$(wc -l <"$CACHE_UPDATES_FILE" | tr -d ' ')"
+fi
+
+echo "[3/3] Summary: lychee_failed=$TOTAL_FAILED_BY_LYCHEE recovered=$RECOVERED still_failed=$FAILED"
+echo "[3/3] Cache updated lines: $UPDATED_CACHE_LINES"
+print_lychee_summary
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/book/check_invalid_or_broken_links.sh
+++ b/book/check_invalid_or_broken_links.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# Temporary files:
+# - `JSON_FILE` stores lychee JSON output.
+# - `URLS_FILE` stores failed http/https links extracted from lychee output.
+# - `CACHE_UPDATES_FILE` stores recovered links to write back into .lycheecache.
+# - `CACHE_MERGED_FILE` is the merged cache output before replace.
+OUT_DIR="$(mktemp -d /tmp/lychee-XXXXXX)"
+JSON_FILE="$OUT_DIR"/result.json
+URLS_FILE="$OUT_DIR"/failed-urls.txt
+CACHE_UPDATES_FILE="$OUT_DIR"/cache-updates.txt
+CACHE_MERGED_FILE="$OUT_DIR"/cache-merged.txt
+
+# Remove `/tmp/lychee` files when the script exits.
+cleanup() {
+  rm -rf "$OUT_DIR"
+}
+trap cleanup EXIT
+
+print_lychee_summary() {
+  echo "lychee summary:"
+  echo "  total.......$LYCHEE_TOTAL"
+  echo "  unique......$LYCHEE_UNIQUE"
+  echo "  successful..$LYCHEE_SUCCESSFUL"
+  echo "  timeouts....$LYCHEE_TIMEOUTS"
+  echo "  redirected..$LYCHEE_REDIRECTS"
+  echo "  excluded....$LYCHEE_EXCLUDED"
+  echo "  unknown.....$LYCHEE_UNKNOWN"
+  echo "  errors......$LYCHEE_ERRORS"
+  echo "  unsupported.$LYCHEE_UNSUPPORTED"
+}
+
+# Run lychee once and capture JSON output for fallback processing.
+echo "[1/3] Running lychee..."
+LYCHEE_EXIT=0
+if ! lychee --config lychee.toml --format json --no-progress book/**/*.html >"$JSON_FILE"; then
+  LYCHEE_EXIT=$?
+fi
+
+# Collect unique failed http/https links from lychee error/timeout maps.
+jq -r '
+  [
+    (.error_map // {} | to_entries[]? | .value[]? | .url?),
+    (.timeout_map // {} | to_entries[]? | .value[]? | .url?)
+  ]
+  | map(select(type == "string"))
+  | unique
+  | .[]
+' "$JSON_FILE" >"$URLS_FILE"
+
+# Print lychee raw stats (same data source as detailed format summary).
+LYCHEE_TOTAL="$(jq -r '.total // 0' "$JSON_FILE")"
+LYCHEE_UNIQUE="$(jq -r '.unique // 0' "$JSON_FILE")"
+LYCHEE_SUCCESSFUL="$(jq -r '.successful // 0' "$JSON_FILE")"
+LYCHEE_TIMEOUTS="$(jq -r '.timeouts // 0' "$JSON_FILE")"
+LYCHEE_REDIRECTS="$(jq -r '.redirects // 0' "$JSON_FILE")"
+LYCHEE_EXCLUDED="$(jq -r '.excludes // 0' "$JSON_FILE")"
+LYCHEE_UNKNOWN="$(jq -r '.unknown // 0' "$JSON_FILE")"
+LYCHEE_ERRORS="$(jq -r '.errors // 0' "$JSON_FILE")"
+LYCHEE_UNSUPPORTED="$(jq -r '.unsupported // 0' "$JSON_FILE")"
+
+TOTAL_FAILED_BY_LYCHEE="$(wc -l <"$URLS_FILE" | tr -d ' ')"
+echo "lychee failed links: $TOTAL_FAILED_BY_LYCHEE"
+if [ "$TOTAL_FAILED_BY_LYCHEE" -eq 0 ]; then
+  print_lychee_summary
+  echo "All links pass!"
+  exit "$LYCHEE_EXIT"
+fi
+
+# Retry failed links using plain curl; report recovered/failed links.
+echo "[2/3] Curl fallback on lychee-failed links..."
+RECOVERED=0
+FAILED=0
+while IFS= read -r url; do
+  [ -z "$url" ] && continue
+  if [[ $url == file://* ]]; then
+    # Just warn against this local file link is not accessible without further check.
+    FAILED=$((FAILED + 1))
+    echo "FAILED:    $url"
+    continue
+  fi
+
+  STATUS_CODE="$(curl -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)"
+  CURL_EXIT=$?
+  if [ "$CURL_EXIT" -eq 0 ]; then
+    RECOVERED=$((RECOVERED + 1))
+    echo "RECOVERED: $url (status=$STATUS_CODE)"
+    # Status code is recorded as 200 in .lycheecache to let lychee skip the link next time.
+    printf '%s,%s,%s\n' "$url" "200" "$(date +%s)" >>"$CACHE_UPDATES_FILE"
+  else
+    FAILED=$((FAILED + 1))
+    echo "FAILED:    $url"
+  fi
+done <"$URLS_FILE"
+
+# Write recovered links into .lycheecache as url,status,timestamp.
+UPDATED_CACHE_LINES=0
+if [ -s "$CACHE_UPDATES_FILE" ]; then
+  if [ -f .lycheecache ]; then
+    # Merge cache with URL-level deduplication:
+    # - First pass (updates): keep the latest recovered record by URL.
+    # - Second pass (existing cache): keep only URLs not present in updates.
+    # - End: append updated records so recovered entries replace old ones.
+    awk -F, '
+      NR==FNR { new[$1]=$0; order[++n]=$1; next }
+      !($1 in new) { print }
+      END { for (i=1; i<=n; i++) print new[order[i]] }
+    ' "$CACHE_UPDATES_FILE" .lycheecache >"$CACHE_MERGED_FILE"
+  else
+    cat "$CACHE_UPDATES_FILE" >"$CACHE_MERGED_FILE"
+  fi
+  mv "$CACHE_MERGED_FILE" .lycheecache
+  UPDATED_CACHE_LINES="$(wc -l <"$CACHE_UPDATES_FILE" | tr -d ' ')"
+fi
+
+echo "[3/3] Summary: lychee_failed=$TOTAL_FAILED_BY_LYCHEE recovered=$RECOVERED still_failed=$FAILED"
+echo "[3/3] Cache updated lines: $UPDATED_CACHE_LINES"
+print_lychee_summary
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/book/check_rust_api_doc_version.sh
+++ b/book/check_rust_api_doc_version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+VERSION_FILE="${SCRIPT_DIR}/VERSION"
+BOOK_SRC_DIR="${SCRIPT_DIR}/book/src"
+
+TARGET_VERSION=$(tr -d '[:space:]' <"${VERSION_FILE}")
+echo "Target version for validation: ${TARGET_VERSION}"
+
+echo "Scanning directory: ${BOOK_SRC_DIR}"
+
+# Define the search pattern.
+# This regex looks for 'asterinas.github.io/api-docs/'
+# followed by any version number that IS NOT '${TARGET_VERSION}/'.
+# (?!${ESCAPED_TARGET_VERSION}/) is a negative lookahead.
+ESCAPED_TARGET_VERSION=${TARGET_VERSION//./\\.}
+PATTERN="asterinas\\.github\\.io/api-docs/(?!${ESCAPED_TARGET_VERSION}/)[0-9]+\\.[0-9]+\\.[0-9]+"
+MISMATCHES=$(grep -rPn "${PATTERN}" "${BOOK_SRC_DIR}" || true)
+
+if [ -n "${MISMATCHES}" ]; then
+  echo "----------------------------------------------------------------"
+  echo "ERROR: Found links with outdated or incorrect versions:"
+  echo "${MISMATCHES}"
+  echo "----------------------------------------------------------------"
+  echo "Please update the links above to match version ${TARGET_VERSION}."
+  exit 1
+fi
+
+echo "SUCCESS: All found links match version ${TARGET_VERSION}."

--- a/book/check_rust_api_doc_version.sh
+++ b/book/check_rust_api_doc_version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+ASTERINAS_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)
+VERSION_FILE="${ASTERINAS_ROOT}/VERSION"
+BOOK_SRC_DIR="${ASTERINAS_ROOT}/book/src"
+
+TARGET_VERSION=$(tr -d '[:space:]' <"${VERSION_FILE}")
+echo "Target version for validation: ${TARGET_VERSION}"
+
+echo "Scanning directory: ${BOOK_SRC_DIR}"
+
+# Define the search pattern.
+# This regex looks for 'asterinas.github.io/api-docs/'
+# followed by any version number that IS NOT '${TARGET_VERSION}/'.
+# (?!${ESCAPED_TARGET_VERSION}/) is a negative lookahead.
+ESCAPED_TARGET_VERSION=${TARGET_VERSION//./\\.}
+PATTERN="asterinas\\.github\\.io/api-docs/(?!${ESCAPED_TARGET_VERSION}/)[0-9]+\\.[0-9]+\\.[0-9]+"
+MISMATCHES=$(grep -rPn "${PATTERN}" "${BOOK_SRC_DIR}" || true)
+
+if [ -n "${MISMATCHES}" ]; then
+  echo "----------------------------------------------------------------"
+  echo "ERROR: Found links with outdated or incorrect versions:"
+  echo "${MISMATCHES}"
+  echo "----------------------------------------------------------------"
+  echo "Please update the links above to match version ${TARGET_VERSION}."
+  exit 1
+fi
+
+echo "SUCCESS: All found links match version ${TARGET_VERSION}."

--- a/book/lychee.toml
+++ b/book/lychee.toml
@@ -1,0 +1,45 @@
+# This is the configuration for lychee to check invalid or broken links.
+# See https://lychee.cli.rs/guides/config/ for the meanings.
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "error"
+
+# Output format of final status report.
+format = "detailed"
+
+# Don't show interactive progress bar while checking links.
+no_progress = true
+
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = true
+
+# Exclude the paths from getting checked. The values are treated as regular expressions.
+exclude_path = [
+  "SUMMARY.md", # The valid empty links are flagged out by lychee.
+]
+
+# Request method
+method = "get"
+
+# Custom request headers
+header = { "accept" = "text/html" }
+
+user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+
+# Enable link caching. This can be helpful to avoid checking the same links on multiple runs.
+# .lycheecache will be generated.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "90d"
+
+# Number of threads to utilize. Defaults to number of cores available to the system if omitted.
+threads = 1
+# Maximum number of concurrent link checks.
+max_concurrency = 3
+
+# More strictly limit the access rate to gnu websites.
+[hosts."www.gnu.org"]
+concurrency = 1
+request_interval = "2s"

--- a/book/lychee.toml
+++ b/book/lychee.toml
@@ -1,0 +1,57 @@
+# This is the configuration for lychee to check invalid or broken links.
+# See https://lychee.cli.rs/guides/config/ for the meanings.
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "error"
+
+# Output format of final status report.
+format = "detailed"
+
+# Don't show interactive progress bar while checking links.
+no_progress = true
+
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = true
+
+# Exclude the paths from getting checked. The values are treated as regular expressions.
+exclude_path = [
+  "SUMMARY.md", # The valid empty links are flagged out by lychee.
+]
+
+# Root path to use when checking absolute local links.
+root_dir = "book"
+# Enable the checking of fragments in links, both anchor fragments and text fragments.
+include_fragments = "full"
+# Remap URI via regex, mainly to replace local `page#anchor` with `page/index.html#anchor`.
+# The first remap keeps `page.html#anchor`, otherwise it would be made into the invalid `page.html/index.html#anchor`.
+remap = [
+  "(file:///.+)\\.html#(.+) $0",
+  "(file:///.+)#(.+) $1/index.html#$2",
+  "(file:///.+)/README.html $1/index.html",
+]
+
+# Request method
+method = "get"
+
+# Custom request headers
+header = { "accept" = "text/html" }
+
+user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+
+# Enable link caching. This can be helpful to avoid checking the same links on multiple runs.
+# .lycheecache will be generated.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "90d"
+
+# Number of threads to utilize. Defaults to number of cores available to the system if omitted.
+threads = 1
+# Maximum number of concurrent link checks.
+max_concurrency = 3
+
+# More strictly limit the access rate to gnu websites.
+[hosts."www.gnu.org"]
+concurrency = 1
+request_interval = "2s"

--- a/book/src/distro/popular-applications/file-management-and-terminal/README.md
+++ b/book/src/distro/popular-applications/file-management-and-terminal/README.md
@@ -154,7 +154,7 @@ xzgrep "pattern" file.txt.xz
 
 ### Zip
 
-[Zip](https://www.info-zip.org/) is a file compression and archive utility.
+[Zip](http://www.info-zip.org/) is a file compression and archive utility.
 
 #### Installation
 
@@ -457,7 +457,7 @@ ag --cc "main"
 
 ### tree
 
-[tree](http://mama.indstate.edu/users/ice/tree/) displays directory structures in a tree format.
+[tree](http://oldmanprogrammer.net/source.php?dir=projects/tree) displays directory structures in a tree format.
 
 #### Installation
 

--- a/book/src/distro/popular-applications/networking/README.md
+++ b/book/src/distro/popular-applications/networking/README.md
@@ -212,7 +212,7 @@ drill -x 8.8.8.8
 
 ### whois
 
-[whois](https://packages.qa.debian.org/w/whois.html) queries domain registration information.
+[whois](https://tracker.debian.org/pkg/whois) queries domain registration information.
 
 #### Installation
 

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -18,7 +18,7 @@ establishes Asterinas as a more secure and dependable kernel option.
 * Asterinas surpasses Linux in terms of developer friendliness.
 It empowers kernel developers to
 (1) utilize the more productive Rust programming language,
-(2) leverage a purpose-built toolkit called [OSDK]() to streamline their workflows,
+(2) leverage a purpose-built toolkit called [OSDK](../osdk/guide/) to streamline their workflows,
 and (3) choose between releasing their kernel modules as open source
 or keeping them proprietary,
 thanks to the flexibility offered by [MPL](../).

--- a/book/src/kernel/intel-tdx.md
+++ b/book/src/kernel/intel-tdx.md
@@ -37,7 +37,7 @@ For more information, see [our talk on OC3'24](https://www.youtube.com/watch?v=3
 
 Please make sure your server supports Intel TDX.
 
-See [this guide](https://github.com/canonical/tdx/tree/noble-24.04?tab=readme-ov-file#4-setup-host-os)
+See [this guide](https://github.com/canonical/tdx#4-setup-host-os)
 or other materials to enable Intel TDX in host OS.
 
 To verify the TDX host status,

--- a/book/src/kernel/the-framekernel-architecture.md
+++ b/book/src/kernel/the-framekernel-architecture.md
@@ -70,8 +70,7 @@ if doing it outside is possible.
 * **Efficiency.**
 The safe API provided by the framework is only allowed
 to introduce minimal overheads.
-Ideally, these APIs should be realized
-as [zero-cost abstractions](https://monomorph.is/posts/zero-cost-abstractions/).
+Ideally, these APIs should be realized as zero-cost abstractions.
 
 Fortunately, our efforts
 to design and implement an OS framework meeting these standards

--- a/book/src/osdk/guide/intel-tdx.md
+++ b/book/src/osdk/guide/intel-tdx.md
@@ -7,7 +7,7 @@ Intel TDX can provide a more secure environment for your OS.
 
 Please make sure your server supports Intel TDX.
 
-See [this guide](https://github.com/canonical/tdx/tree/noble-24.04?tab=readme-ov-file#4-setup-host-os)
+See [this guide](https://github.com/canonical/tdx#4-setup-host-os)
 or other materials to enable Intel TDX in host OS.
 
 To verify the TDX host status, you can type:

--- a/book/src/ostd/soundness/safe-kernel-logic.md
+++ b/book/src/ostd/soundness/safe-kernel-logic.md
@@ -26,9 +26,9 @@ OSTD prevents this unconditionally:
 > **Safety Invariant.** A task cannot sleep while in atomic mode.
 
 OSTD tracks atomic mode using guard types.
-[`DisabledPreemptGuard`](https://asterinas.github.io/api-docs/0.17.1/ostd/task/struct.DisabledPreemptGuard.html)
+[`DisabledPreemptGuard`](https://asterinas.github.io/api-docs/0.18.0/ostd/task/struct.DisabledPreemptGuard.html)
 disables preemption for its lifetime,
-and [`DisabledLocalIrqGuard`](https://asterinas.github.io/api-docs/0.17.1/ostd/irq/struct.DisabledLocalIrqGuard.html)
+and [`DisabledLocalIrqGuard`](https://asterinas.github.io/api-docs/0.18.0/ostd/irq/struct.DisabledLocalIrqGuard.html)
 disables local IRQs
 (which also implies preemption is disabled).
 Both guards are `!Send` —
@@ -45,7 +45,7 @@ so any attempt to sleep while holding a spinlock is caught.
 ## Synchronization Primitives
 
 OSTD provides six synchronization primitives:
-[`SpinLock`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.SpinLock.html), [`Mutex`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.Mutex.html), [`RwLock`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.RwLock.html), [`RwMutex`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.RwMutex.html), [`Rcu`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.Rcu.html), and [`WaitQueue`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.WaitQueue.html).
+[`SpinLock`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.SpinLock.html), [`Mutex`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.Mutex.html), [`RwLock`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.RwLock.html), [`RwMutex`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.RwMutex.html), [`Rcu`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.Rcu.html), and [`WaitQueue`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.WaitQueue.html).
 Their soundness rests on two design principles:
 
 **Principle 1: Guards are `!Send`.**
@@ -58,7 +58,7 @@ which would corrupt the CPU-local preemption state
 is tied to the acquiring CPU).
 
 **Principle 2: Atomic mode is entered before lock acquisition.**
-[`SpinLock::lock()`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.SpinLock.html#method.lock)
+[`SpinLock::lock()`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.SpinLock.html#method.lock)
 disables preemption (or IRQs) *before* entering the CAS loop.
 If the order were reversed (acquire lock, then disable preemption),
 there would be a window where the lock is held
@@ -68,22 +68,22 @@ and if the interrupt handler tries to acquire the same lock,
 a deadlock results.
 
 The kind of guard —
-preemption-only ([`PreemptDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/enum.PreemptDisabled.html))
-or IRQ-disabled ([`LocalIrqDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/enum.LocalIrqDisabled.html)) —
+preemption-only ([`PreemptDisabled`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/enum.PreemptDisabled.html))
+or IRQ-disabled ([`LocalIrqDisabled`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/enum.LocalIrqDisabled.html)) —
 is chosen at lock declaration time
 and statically enforced by the type system,
 ensuring consistent usage throughout the lock's lifetime.
 
 ### RCU (Read-Copy-Update)
 
-[`Rcu<P>`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.Rcu.html) provides lock-free read access with deferred reclamation:
+[`Rcu<P>`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.Rcu.html) provides lock-free read access with deferred reclamation:
 
 - **Read side**:
-  [`Rcu::read()`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.Rcu.html#method.read) disables preemption
+  [`Rcu::read()`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.Rcu.html#method.read) disables preemption
   and loads the pointer with `Acquire` ordering.
   The read-side critical section is non-preemptible.
 - **Write side**:
-  [`Rcu::update(new_ptr)`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.Rcu.html#method.update) atomically swaps the pointer
+  [`Rcu::update(new_ptr)`](https://asterinas.github.io/api-docs/0.18.0/ostd/sync/struct.Rcu.html#method.update) atomically swaps the pointer
   and enqueues the old value for deferred drop.
 - **Grace period**:
   OSTD detects when all CPUs have left
@@ -108,14 +108,14 @@ OSTD provides two CPU-local storage mechanisms:
 
 **`cpu_local!` (static variables)**:
 Access requires a `DisabledLocalIrqGuard`
-via [`CpuLocal::get_with(&irq_guard)`](https://asterinas.github.io/api-docs/0.17.1/ostd/cpu/local/struct.CpuLocal.html#method.get_with).
+via [`CpuLocal::get_with(&irq_guard)`](https://asterinas.github.io/api-docs/0.18.0/ostd/cpu/local/struct.CpuLocal.html#method.get_with).
 This ensures two properties:
 - The task is pinned to the current CPU
   (IRQs disabled implies no preemption and no migration).
 - No interrupt handler can observe a partially-modified state.
 
 For `Sync` types,
-[`CpuLocal::get_on_cpu(target_cpu)`](https://asterinas.github.io/api-docs/0.17.1/ostd/cpu/local/struct.CpuLocal.html#method.get_on_cpu) allows remote access without a guard
+[`CpuLocal::get_on_cpu(target_cpu)`](https://asterinas.github.io/api-docs/0.18.0/ostd/cpu/local/struct.CpuLocal.html#method.get_on_cpu) allows remote access without a guard
 (since `Sync` types are safe to share across threads).
 
 **`cpu_local_cell!` (cell variables)**:

--- a/book/src/ostd/soundness/safe-kernel-logic.md
+++ b/book/src/ostd/soundness/safe-kernel-logic.md
@@ -68,8 +68,8 @@ and if the interrupt handler tries to acquire the same lock,
 a deadlock results.
 
 The kind of guard —
-preemption-only ([`PreemptDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.PreemptDisabled.html))
-or IRQ-disabled ([`LocalIrqDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/struct.LocalIrqDisabled.html)) —
+preemption-only ([`PreemptDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/enum.PreemptDisabled.html))
+or IRQ-disabled ([`LocalIrqDisabled`](https://asterinas.github.io/api-docs/0.17.1/ostd/sync/enum.LocalIrqDisabled.html)) —
 is chosen at lock declaration time
 and statically enforced by the type system,
 ensuring consistent usage throughout the lock's lifetime.

--- a/book/src/ostd/soundness/safe-kernel-peripheral-interactions.md
+++ b/book/src/ostd/soundness/safe-kernel-peripheral-interactions.md
@@ -16,10 +16,10 @@ catastrophic for memory safety.
 OSTD provides two DMA abstractions,
 both restricted to untyped memory:
 
-* **[`DmaCoherent`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/dma/struct.DmaCoherent.html)**: Cache-coherent DMA mapping.
-  Created from a [`Segment<()>`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/segment/struct.Segment.html) (untyped).
-* **[`DmaStream`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/dma/struct.DmaStream.html)**: Streaming DMA mapping.
-  Created from a [`USegment`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/segment/type.USegment.html) (untyped).
+* **[`DmaCoherent`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/dma/struct.DmaCoherent.html)**: Cache-coherent DMA mapping.
+  Created from a [`Segment<()>`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/segment/struct.Segment.html) (untyped).
+* **[`DmaStream`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/dma/struct.DmaStream.html)**: Streaming DMA mapping.
+  Created from a [`USegment`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/segment/type.USegment.html) (untyped).
 
 **IOMMU enforcement**:
 When IOMMU DMA remapping is enabled (the default on x86),
@@ -73,7 +73,7 @@ by reading/writing specific physical addresses.
 Some MMIO regions are sensitive (APIC, IOMMU registers)
 and must not be accessible to device drivers.
 
-OSTD's [`IoMem`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoMem.html) type has two sensitivity levels,
+OSTD's [`IoMem`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoMem.html) type has two sensitivity levels,
 enforced at the type level:
 
 ```rust
@@ -87,7 +87,7 @@ pub struct IoMem<S: SecuritySensitivity> { ... }
 - `IoMem<Insensitive>`:
   Provides safe `reader()` and `writer()` methods
   via the `HasVmReaderWriter` trait.
-  Available to device drivers via [`IoMem::acquire(range)`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoMem.html#method.acquire).
+  Available to device drivers via [`IoMem::acquire(range)`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoMem.html#method.acquire).
 
 The [`IoMemAllocator`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/io/io_mem/allocator.rs#L18) enforces the boundary:
 1. At initialization,
@@ -107,13 +107,13 @@ it cannot access kernel-critical hardware.
 ## I/O Port Access Control (x86)
 
 I/O ports,
-represented as [`IoPort`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoPort.html),
+represented as [`IoPort`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoPort.html),
 are an x86-specific mechanism for device communication.
 The same sensitivity distinction applies:
 
 - `IoPort::new(port)` is `pub(crate) unsafe` —
   for OSTD-internal use only.
-- [`IoPort::acquire(port)`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoPort.html#method.acquire) is the safe public API.
+- [`IoPort::acquire(port)`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoPort.html#method.acquire) is the safe public API.
   It requests the port from the [`IoPortAllocator`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/io/io_port/allocator.rs#L17).
 
 The `IoPortAllocator` removes sensitive ports at initialization.
@@ -130,7 +130,7 @@ before clients can access it.
 
 ## Interrupt Handling
 
-Device interrupts are managed through the [`IrqLine`](https://asterinas.github.io/api-docs/0.17.1/ostd/irq/struct.IrqLine.html) abstraction.
+Device interrupts are managed through the [`IrqLine`](https://asterinas.github.io/api-docs/0.18.0/ostd/irq/struct.IrqLine.html) abstraction.
 Clients register callbacks
 but cannot manipulate the IDT, APIC, or interrupt routing directly.
 All interrupt configuration is mediated by OSTD's safe APIs.

--- a/book/src/ostd/soundness/safe-memory-management.md
+++ b/book/src/ostd/soundness/safe-memory-management.md
@@ -35,7 +35,7 @@ because no external entity can access them.
 **Untyped frames** are raw byte buffers.
 They do not host Rust objects.
 They are accessed exclusively through
-a POD (Plain Old Data) copy interface ([`VmReader`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/io/struct.VmReader.html)/[`VmWriter`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/io/struct.VmWriter.html))
+a POD (Plain Old Data) copy interface ([`VmReader`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/io/struct.VmReader.html)/[`VmWriter`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/io/struct.VmWriter.html))
 that **never creates Rust references to the frame contents**.
 
 > **Safety Invariant:** Untyped frames are never accessed via Rust references.
@@ -68,16 +68,16 @@ since user-space accesses may trigger page faults.
 
 ## Type-Level Encoding
 
-[`Frame<M>`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/struct.Frame.html) is parameterized by a metadata type `M`.
+[`Frame<M>`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/struct.Frame.html) is parameterized by a metadata type `M`.
 Clients associate custom metadata with each frame by choosing `M` —
 for example, page table nodes store `PageTablePageMeta`
 and heap slabs store `SlabMeta`.
-[`Frame::meta()`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/struct.Frame.html#method.meta) provides typed access to the per-frame metadata.
+[`Frame::meta()`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/struct.Frame.html#method.meta) provides typed access to the per-frame metadata.
 
 The same type parameter enforces the typed/untyped distinction
 at compile time.
 `VmReader`/`VmWriter` access to frame contents
-is gated on `M` implementing [`AnyUFrameMeta`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/untyped/trait.AnyUFrameMeta.html):
+is gated on `M` implementing [`AnyUFrameMeta`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/untyped/trait.AnyUFrameMeta.html):
 
 ```rust
 // Only untyped frames expose reader()/writer()
@@ -108,7 +108,7 @@ type UFrame = Frame<dyn AnyUFrameMeta>;
 type USegment = Segment<dyn AnyUFrameMeta>;
 ```
 
-[`AnyFrameMeta`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/meta/trait.AnyFrameMeta.html) is `unsafe`,
+[`AnyFrameMeta`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/meta/trait.AnyFrameMeta.html) is `unsafe`,
 preventing clients from implementing it directly
 (kernel code enforces `#![deny(unsafe_code)]`).
 Instead, OSTD provides safe macros —
@@ -117,7 +117,7 @@ and [`impl_untyped_frame_meta_for!`](https://github.com/asterinas/asterinas/blob
 that produce correct implementations.
 A client cannot misclassify a frame's sensitivity
 because only the macros can set the
-[`AnyFrameMeta::is_untyped()`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/meta/trait.AnyFrameMeta.html#method.is_untyped) return value.
+[`AnyFrameMeta::is_untyped()`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/meta/trait.AnyFrameMeta.html#method.is_untyped) return value.
 
 ## The Frame Lifecycle
 
@@ -143,7 +143,7 @@ stateDiagram-v2
 Special states:
 - [`REF_COUNT_UNUSED`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/mm/frame/meta.rs#L124) (`u64::MAX`):
   Frame is not in use.
-  Only [`Frame::from_unused(paddr, metadata)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/struct.Frame.html#method.from_unused) can transition out.
+  Only [`Frame::from_unused(paddr, metadata)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/struct.Frame.html#method.from_unused) can transition out.
 - `0`: Busy —
   frame is being constructed or destructed.
   No concurrent access permitted.

--- a/book/src/ostd/soundness/safe-policy-injection.md
+++ b/book/src/ostd/soundness/safe-policy-injection.md
@@ -18,8 +18,8 @@ but it cannot cause UB.
 ## Task Scheduler
 
 The scheduler is injected via two safe traits:
-[`Scheduler<T>`](https://asterinas.github.io/api-docs/0.17.1/ostd/task/scheduler/trait.Scheduler.html) (global scheduling decisions)
-and [`LocalRunQueue<T>`](https://asterinas.github.io/api-docs/0.17.1/ostd/task/scheduler/trait.LocalRunQueue.html) (per-CPU run queue management).
+[`Scheduler<T>`](https://asterinas.github.io/api-docs/0.18.0/ostd/task/scheduler/trait.Scheduler.html) (global scheduling decisions)
+and [`LocalRunQueue<T>`](https://asterinas.github.io/api-docs/0.18.0/ostd/task/scheduler/trait.LocalRunQueue.html) (per-CPU run queue management).
 Neither trait contains `unsafe` methods.
 
 **The threat**:
@@ -37,7 +37,7 @@ the CAS fails and the CPU spins until the flag becomes `false`.
 
 This defense is unconditional —
 it does not depend on the scheduler being correct.
-Even if the scheduler's [`LocalRunQueue::pick_next()`](https://asterinas.github.io/api-docs/0.17.1/ostd/task/scheduler/trait.LocalRunQueue.html#method.pick_next) returns a task
+Even if the scheduler's [`LocalRunQueue::pick_next()`](https://asterinas.github.io/api-docs/0.18.0/ostd/task/scheduler/trait.LocalRunQueue.html#method.pick_next) returns a task
 that is actively running on another CPU,
 the CAS loop prevents the second CPU from entering the task's context.
 The first CPU will eventually switch away from the task
@@ -53,7 +53,7 @@ The `switched_to_cpu` CAS prevents this unconditionally.
 
 ## Frame Allocator
 
-The frame allocator is injected via the [`GlobalFrameAllocator`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/allocator/trait.GlobalFrameAllocator.html) trait (safe).
+The frame allocator is injected via the [`GlobalFrameAllocator`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/allocator/trait.GlobalFrameAllocator.html) trait (safe).
 The allocator decides which physical addresses to return
 for allocation requests.
 
@@ -64,7 +64,7 @@ an address outside physical memory,
 or an address in a reserved region.
 
 **The defense**:
-[`Frame::from_unused(paddr, metadata)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/struct.Frame.html#method.from_unused) enforces the invariant
+[`Frame::from_unused(paddr, metadata)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/struct.Frame.html#method.from_unused) enforces the invariant
 by checking the frame metadata:
 
 > **Safety Invariant.** The allocator cannot trick OSTD into creating two `Frame` handles to the same physical page.
@@ -77,7 +77,7 @@ The atomic CAS on the reference count prevents double-allocation.
 
 ## Slab Allocator
 
-The slab allocator is injected via the [`GlobalHeapAllocator`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/trait.GlobalHeapAllocator.html) trait (safe).
+The slab allocator is injected via the [`GlobalHeapAllocator`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/trait.GlobalHeapAllocator.html) trait (safe).
 
 **The threat**:
 A buggy slab allocator might return a slot that is already allocated
@@ -87,14 +87,14 @@ or a slot from a freed slab.
 
 **The defenses**:
 OSTD controls key slab allocator building blocks
-such as [`Slab`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/type.Slab.html) and [`HeapSlot`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/struct.HeapSlot.html)
+such as [`Slab`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/type.Slab.html) and [`HeapSlot`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/struct.HeapSlot.html)
 to prevent an injected slab allocator
 from tricking OSTD into using invalid memory slots.
 
 > **Safety Invariant.** A `Slab` cannot be freed while any of its slots are still allocated.
 
-[`SlabMeta::alloc()`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/struct.SlabMeta.html#method.alloc) increments
-and [`Slab::dealloc(slot)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/type.Slab.html#method.dealloc) decrements `nr_allocated`.
+[`SlabMeta::alloc()`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/struct.SlabMeta.html#method.alloc) increments
+and [`Slab::dealloc(slot)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/type.Slab.html#method.dealloc) decrements `nr_allocated`.
 The slab panics on drop if `nr_allocated > 0`,
 preventing use-after-free of slab memory.
 Additionally, `Slab::dealloc(slot)` validates
@@ -116,7 +116,7 @@ Mismatches cause abort before the memory is used.
 [`HeapSlot::new()`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/mm/heap/slot.rs#L69) is `pub(super) unsafe`,
 so only OSTD's heap module can create `HeapSlot` values.
 The injected allocator receives `HeapSlot`s
-from `SlabMeta::alloc()` or [`HeapSlot::alloc_large(size)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/heap/struct.HeapSlot.html#method.alloc_large)
+from `SlabMeta::alloc()` or [`HeapSlot::alloc_large(size)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/heap/struct.HeapSlot.html#method.alloc_large)
 and must return them through `GlobalHeapAllocator::dealloc()` —
 it cannot construct arbitrary slots pointing to sensitive memory.
 
@@ -124,13 +124,13 @@ it cannot construct arbitrary slots pointing to sensitive memory.
 
 Beyond the three complex policies above,
 OSTD has simpler injection points
-for [logging](https://asterinas.github.io/api-docs/0.17.1/ostd/log/logger/fn.inject_logger.html),
-[power management](https://asterinas.github.io/api-docs/0.17.1/ostd/power/fn.inject_restart_handler.html),
-[scheduling hooks](https://asterinas.github.io/api-docs/0.17.1/ostd/task/fn.inject_pre_schedule_handler.html),
-[page fault handling](https://asterinas.github.io/api-docs/0.17.1/ostd/arch/trap/fn.inject_user_page_fault_handler.html),
-[SMP boot](https://asterinas.github.io/api-docs/0.17.1/ostd/boot/smp/fn.register_ap_entry.html),
-[interrupt bottom halves](https://asterinas.github.io/api-docs/0.17.1/ostd/irq/fn.register_bottom_half_handler_l1.html),
-and [timer callbacks](https://asterinas.github.io/api-docs/0.17.1/ostd/timer/fn.register_callback_on_cpu.html).
+for [logging](https://asterinas.github.io/api-docs/0.18.0/ostd/log/logger/fn.inject_logger.html),
+[power management](https://asterinas.github.io/api-docs/0.18.0/ostd/power/fn.inject_restart_handler.html),
+[scheduling hooks](https://asterinas.github.io/api-docs/0.18.0/ostd/task/fn.inject_pre_schedule_handler.html),
+[page fault handling](https://asterinas.github.io/api-docs/0.18.0/ostd/arch/trap/fn.inject_user_page_fault_handler.html),
+[SMP boot](https://asterinas.github.io/api-docs/0.18.0/ostd/boot/smp/fn.register_ap_entry.html),
+[interrupt bottom halves](https://asterinas.github.io/api-docs/0.18.0/ostd/irq/fn.register_bottom_half_handler_l1.html),
+and [timer callbacks](https://asterinas.github.io/api-docs/0.18.0/ostd/timer/fn.register_callback_on_cpu.html).
 
 These callbacks are fundamentally different
 from the scheduler and allocators:

--- a/book/src/ostd/soundness/safe-user-kernel-interactions.md
+++ b/book/src/ostd/soundness/safe-user-kernel-interactions.md
@@ -1,9 +1,9 @@
 # Safe User-Kernel Interactions
 
 OSTD provides three API categories for user-kernel interactions:
-entering/exiting user space ([`UserMode`](https://asterinas.github.io/api-docs/0.17.1/ostd/user/struct.UserMode.html), [`UserContext`](https://asterinas.github.io/api-docs/0.17.1/ostd/arch/cpu/context/struct.UserContext.html)),
-managing user address spaces ([`VmSpace`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.VmSpace.html)),
-and accessing user memory ([`VmReader<Fallible>`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/io/struct.VmReader.html), [`VmWriter<Fallible>`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/io/struct.VmWriter.html)).
+entering/exiting user space ([`UserMode`](https://asterinas.github.io/api-docs/0.18.0/ostd/user/struct.UserMode.html), [`UserContext`](https://asterinas.github.io/api-docs/0.18.0/ostd/arch/cpu/context/struct.UserContext.html)),
+managing user address spaces ([`VmSpace`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html)),
+and accessing user memory ([`VmReader<Fallible>`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/io/struct.VmReader.html), [`VmWriter<Fallible>`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/io/struct.VmWriter.html)).
 
 ## UserMode and UserContext
 
@@ -19,14 +19,14 @@ It is `!Send`:
 once created on a task,
 it cannot be sent to another,
 preventing cross-task confusion of register state.
-[`UserMode::context()`](https://asterinas.github.io/api-docs/0.17.1/ostd/user/struct.UserMode.html#method.context)
-and [`UserMode::context_mut()`](https://asterinas.github.io/api-docs/0.17.1/ostd/user/struct.UserMode.html#method.context_mut)
+[`UserMode::context()`](https://asterinas.github.io/api-docs/0.18.0/ostd/user/struct.UserMode.html#method.context)
+and [`UserMode::context_mut()`](https://asterinas.github.io/api-docs/0.18.0/ostd/user/struct.UserMode.html#method.context_mut)
 give access to the underlying `UserContext`
 for register inspection and modification between entries.
 
 Clients may set arbitrary values in `UserContext`,
 but the sanitization inside
-[`UserMode::execute(has_kernel_event)`](https://asterinas.github.io/api-docs/0.17.1/ostd/user/struct.UserMode.html#method.execute)
+[`UserMode::execute(has_kernel_event)`](https://asterinas.github.io/api-docs/0.18.0/ostd/user/struct.UserMode.html#method.execute)
 ensures kernel safety invariants
 are enforced every time before entering user space:
 
@@ -55,8 +55,8 @@ The above safety measures are key to achieving the following invariant:
 
 `VmSpace` manages a user-space page table.
 To modify page table mappings,
-clients obtain a [`CursorMut`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.CursorMut.html)
-via [`VmSpace::cursor_mut(guard, &range)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.VmSpace.html#method.cursor_mut),
+clients obtain a [`CursorMut`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.CursorMut.html)
+via [`VmSpace::cursor_mut(guard, &range)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html#method.cursor_mut),
 which gives exclusive access to a virtual address range within the page table.
 
 The key safety invariant of `VmSpace` is:
@@ -66,11 +66,11 @@ The key safety invariant of `VmSpace` is:
 `CursorMut` exposes exactly two methods for creating mappings,
 and neither accepts typed frames:
 
-- [`CursorMut::map(frame, prop)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.CursorMut.html#method.map)
+- [`CursorMut::map(frame, prop)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.CursorMut.html#method.map)
   accepts a `UFrame` — an untyped frame.
   There is no code path that converts a typed `Frame<M>` to `UFrame`
   unless `M: AnyUFrameMeta`.
-- [`CursorMut::map_iomem(io_mem, prop, len, offset)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.CursorMut.html#method.map_iomem)
+- [`CursorMut::map_iomem(io_mem, prop, len, offset)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.CursorMut.html#method.map_iomem)
   accepts an `IoMem` (defaulting to `IoMem<Insensitive>`) —
   peripheral MMIO memory that does not host Rust objects.
 
@@ -95,8 +95,8 @@ for [untyped frames](safe-memory-management.md#the-solution-typed-and-untyped-fr
 
 > **Safety Invariant.** The kernel never creates Rust references to user memory.
 
-[`VmSpace::reader(vaddr, len)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.VmSpace.html#method.reader)
-and [`VmSpace::writer(vaddr, len)`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.VmSpace.html#method.writer)
+[`VmSpace::reader(vaddr, len)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html#method.reader)
+and [`VmSpace::writer(vaddr, len)`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html#method.writer)
 are the only safe APIs for user memory access.
 They return `VmReader<Fallible>` / `VmWriter<Fallible>` cursors —
 the same raw-pointer-based mechanism used for untyped frame access,

--- a/book/src/ostd/soundness/sensitivity-classification.md
+++ b/book/src/ostd/soundness/sensitivity-classification.md
@@ -19,7 +19,7 @@ OSTD adopts the following design principle:
 |----------|---------------|-----------|---------------|
 | Kernel-mode registers (CR0–CR4, MSRs, GDT/IDT/TSS pointers, kernel GS base) | **Sensitive** | Can corrupt execution environment | Set once at boot; never exposed to clients |
 | Kernel-mode traps (exception/interrupt handlers) | **Sensitive** | Can hijack control flow | IDT configured at boot; handlers are internal |
-| User-mode registers (GP registers, user RFLAGS subset, FS base) | Insensitive | Cannot directly affect kernel state | Exposed via [`UserContext`](https://asterinas.github.io/api-docs/0.17.1/ostd/arch/cpu/context/struct.UserContext.html) with sanitization |
+| User-mode registers (GP registers, user RFLAGS subset, FS base) | Insensitive | Cannot directly affect kernel state | Exposed via [`UserContext`](https://asterinas.github.io/api-docs/0.18.0/ostd/arch/cpu/context/struct.UserContext.html) with sanitization |
 | User-mode traps | Insensitive | Routed through kernel trap handler | Dispatched by OSTD; clients handle via callbacks |
 
 `UserContext` sanitizes user-visible registers:
@@ -37,8 +37,8 @@ Kernel-mode registers are never represented in any client-visible type.
 | Kernel heap pages | **Sensitive** | Heap corruption = type confusion | Typed frames ([`SlabMeta`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/mm/heap/slab.rs#L31)); never exposed |
 | Page table pages | **Sensitive** | PT corruption = arbitrary memory access | Typed frames ([`PageTablePageMeta`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/mm/page_table/node/mod.rs#L265)); managed by OSTD |
 | Frame metadata pages | **Sensitive** | Metadata corruption = use-after-free | In dedicated [`FRAME_METADATA_RANGE`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/mm/kspace/mod.rs#L114); never exposed |
-| User-space virtual memory | Insensitive | Kernel safety does not depend on it | Manipulated safely via [`VmSpace`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/vm_space/struct.VmSpace.html) |
-| Untyped physical memory pages | Insensitive | Do not host Rust objects; accessed only via POD copy | Exposed as [`UFrame`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/untyped/type.UFrame.html) / [`USegment`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/frame/segment/type.USegment.html); used for user pages, DMA buffers |
+| User-space virtual memory | Insensitive | Kernel safety does not depend on it | Manipulated safely via [`VmSpace`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html) |
+| Untyped physical memory pages | Insensitive | Do not host Rust objects; accessed only via POD copy | Exposed as [`UFrame`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/untyped/type.UFrame.html) / [`USegment`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/frame/segment/type.USegment.html); used for user pages, DMA buffers |
 
 The sensitive/insensitive distinction maps directly
 to the typed/untyped frame distinction
@@ -52,14 +52,14 @@ which can be safely shared.
 
 | Resource | Classification | Rationale | OSTD Handling |
 |----------|---------------|-----------|---------------|
-| Local APIC | **Sensitive** | Can reset CPUs, mask interrupts | [`IoMem`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoMem.html)`<Sensitive>`, `pub(crate)` only |
+| Local APIC | **Sensitive** | Can reset CPUs, mask interrupts | [`IoMem`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoMem.html)`<Sensitive>`, `pub(crate)` only |
 | I/O APIC | **Sensitive** | Can redirect interrupts | `IoMem<Sensitive>`, `pub(crate)` only |
 | IOMMU | **Sensitive** | Controls DMA access | `IoMem<Sensitive>`, `pub(crate)` only |
 | PIC (8259A) | **Sensitive** | Legacy interrupt controller | Sensitive I/O ports, `pub(crate)` only |
-| Peripheral MMIO (NIC, disk, USB, GPU) | Insensitive | Failure confined to the device | `IoMem<Insensitive>` via [`IoMem::acquire(range)`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoMem.html#method.acquire) |
-| Peripheral I/O ports | Insensitive | Failure confined to the device | [`IoPort`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoPort.html) via [`IoPort::acquire(port)`](https://asterinas.github.io/api-docs/0.17.1/ostd/io/struct.IoPort.html#method.acquire) |
-| Peripheral interrupts | Insensitive | Routed through OSTD's IRQ framework | [`IrqLine`](https://asterinas.github.io/api-docs/0.17.1/ostd/irq/struct.IrqLine.html) callback registration |
-| DMA mappings | Insensitive | Restricted by IOMMU to untyped memory | [`DmaCoherent`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/dma/struct.DmaCoherent.html) / [`DmaStream`](https://asterinas.github.io/api-docs/0.17.1/ostd/mm/dma/struct.DmaStream.html) APIs |
+| Peripheral MMIO (NIC, disk, USB, GPU) | Insensitive | Failure confined to the device | `IoMem<Insensitive>` via [`IoMem::acquire(range)`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoMem.html#method.acquire) |
+| Peripheral I/O ports | Insensitive | Failure confined to the device | [`IoPort`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoPort.html) via [`IoPort::acquire(port)`](https://asterinas.github.io/api-docs/0.18.0/ostd/io/struct.IoPort.html#method.acquire) |
+| Peripheral interrupts | Insensitive | Routed through OSTD's IRQ framework | [`IrqLine`](https://asterinas.github.io/api-docs/0.18.0/ostd/irq/struct.IrqLine.html) callback registration |
+| DMA mappings | Insensitive | Restricted by IOMMU to untyped memory | [`DmaCoherent`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/dma/struct.DmaCoherent.html) / [`DmaStream`](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/dma/struct.DmaStream.html) APIs |
 
 Internally, OSTD maintains two I/O resource allocators ([`IoMemAllocator`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/io/io_mem/allocator.rs#L18), [`IoPortAllocator`](https://github.com/asterinas/asterinas/blob/9ea44ed2b60bc81a5efb18af79e41fc07bf3d523/ostd/src/io/io_port/allocator.rs#L17))
 that are initialized at boot time by removing all sensitive ranges.

--- a/book/src/to-contribute/coding-guidelines/for-development/observability.md
+++ b/book/src/to-contribute/coding-guidelines/for-development/observability.md
@@ -31,7 +31,7 @@ log::info!("VirtIO block device initialized: {} sectors", num_sectors);
 println!("VirtIO block device initialized: {} sectors", num_sectors);
 ```
 
-[`ostd::log`]: https://asterinas.github.io/api-docs/0.17.2/ostd/log/
+[`ostd::log`]: https://asterinas.github.io/api-docs/0.18.0/ostd/log/
 
 ### Choose appropriate log levels (`log-levels`) {#log-levels}
 

--- a/book/src/to-contribute/coding-guidelines/for-development/observability.md
+++ b/book/src/to-contribute/coding-guidelines/for-development/observability.md
@@ -7,7 +7,7 @@ provided by the [`ostd::log`] module:
 `debug!`, `info!`, `notice!`, `warn!`, `error!`,
 `crit!`, `alert!`, `emerg!`.
 Import them via `use ostd::prelude::*`
-or `use ostd::log::{info, warn, ...}`.
+or `use ostd::{info, warn, ...}`.
 
 Do not use the third-party [`log`](https://docs.rs/log) crate directly.
 OSTD provides a bridge that forwards messages
@@ -31,7 +31,7 @@ log::info!("VirtIO block device initialized: {} sectors", num_sectors);
 println!("VirtIO block device initialized: {} sectors", num_sectors);
 ```
 
-[`ostd::log`]: https://asterinas.github.io/ostd/ostd/log/
+[`ostd::log`]: https://asterinas.github.io/api-docs/0.17.2/ostd/log/
 
 ### Choose appropriate log levels (`log-levels`) {#log-levels}
 

--- a/book/src/to-contribute/coding-guidelines/rust-guidelines/select-topics/logging.md
+++ b/book/src/to-contribute/coding-guidelines/rust-guidelines/select-topics/logging.md
@@ -10,7 +10,7 @@ provided by the [`ostd::log`] module:
 `debug!`, `info!`, `notice!`, `warn!`, `error!`,
 `crit!`, `alert!`, `emerg!`.
 Import them via `use ostd::prelude::*`
-or `use ostd::log::{info, warn, ...}`.
+or `use ostd::{info, warn, ...}`.
 
 Do not use the third-party [`log`](https://docs.rs/log) crate directly.
 OSTD provides a bridge that forwards messages
@@ -34,7 +34,7 @@ log::info!("VirtIO block device initialized: {} sectors", num_sectors);
 println!("VirtIO block device initialized: {} sectors", num_sectors);
 ```
 
-[`ostd::log`]: https://asterinas.github.io/ostd/ostd/log/
+[`ostd::log`]: https://asterinas.github.io/api-docs/0.17.2/ostd/log/
 
 ### Choose appropriate log levels (`log-levels`) {#log-levels}
 

--- a/book/src/to-contribute/coding-guidelines/rust-guidelines/select-topics/logging.md
+++ b/book/src/to-contribute/coding-guidelines/rust-guidelines/select-topics/logging.md
@@ -34,7 +34,7 @@ log::info!("VirtIO block device initialized: {} sectors", num_sectors);
 println!("VirtIO block device initialized: {} sectors", num_sectors);
 ```
 
-[`ostd::log`]: https://asterinas.github.io/api-docs/0.17.2/ostd/log/
+[`ostd::log`]: https://asterinas.github.io/api-docs/0.18.0/ostd/log/
 
 ### Choose appropriate log levels (`log-levels`) {#log-levels}
 

--- a/book/src/to-contribute/version-bump.md
+++ b/book/src/to-contribute/version-bump.md
@@ -40,19 +40,20 @@ except during the version bump process.
 
 ## How to Bump Versions
 
-We recommend a three-commit procedure to bump versions:
+We recommend a four-commit procedure to bump versions:
 1. **Commit 1 "Bump the Docker image version"** triggers the generation of a new Docker image.
 2. **Commit 2 "Switch to a new Docker image"** makes the codebase use the new Docker image.
 3. **Commit 3 "Bump the project version"** triggers the release of new crates.
+4. **Commit 4 "Update API doc hyperlinks in the Book"** updates all Book links to use the latest API doc version.
 
 Depending on your exact purpose,
-you may complete the version bump process with at most three commits within two PRs.
+you may complete the version bump process with at most four commits within two or three PRs.
 * **To make non-breaking changes to the Docker images**,
 submit Commit 1 in a PR, then Commit 2 in another.
 * **To make breaking changes to the Docker images and the crates' APIs**,
-submit Commit 1 in a PR, then Commit 2 and 3 in another.
+submit Commit 1 in the first PR, then Commits 2 and 3 in the second, and Commit 4 in the third.
 
-Across the three commits,
+Across the four commits,
 you will be assisted with a convenient utility script, `tools/bump_version.sh`,
 
 ### Commit 1: "Bump the Docker image version"
@@ -104,3 +105,15 @@ Pack these changes into a third commit and
 submit the last two commits in a single PR.
 After the PR is merged into the `main` branch,
 the CI will automatically publish the new crate versions.
+
+### Commit 4: "Update API doc hyperlinks in the Book"
+
+After new API docs are published, run:
+
+```
+./bump_version.sh --api_doc_hyperlinks_in_book
+```
+
+This command mechanically updates API doc hyperlinks in Book pages
+to point to the current project version.
+Submit the changes in a single-commit PR.

--- a/book/src/to-contribute/version-bump.md
+++ b/book/src/to-contribute/version-bump.md
@@ -40,19 +40,20 @@ except during the version bump process.
 
 ## How to Bump Versions
 
-We recommend a three-commit procedure to bump versions:
+We recommend a four-commit procedure to bump versions:
 1. **Commit 1 "Bump the Docker image version"** triggers the generation of a new Docker image.
 2. **Commit 2 "Switch to a new Docker image"** makes the codebase use the new Docker image.
 3. **Commit 3 "Bump the project version"** triggers the release of new crates.
+4. **Commit 4 "Update API doc hyperlinks in the Book"** updates all Book links to use the latest API doc version.
 
 Depending on your exact purpose,
-you may complete the version bump process with at most three commits within two PRs.
+you may complete the version bump process with at most four commits within two or three PRs.
 * **To make non-breaking changes to the Docker images**,
 submit Commit 1 in a PR, then Commit 2 in another.
 * **To make breaking changes to the Docker images and the crates' APIs**,
-submit Commit 1 in a PR, then Commit 2 and 3 in another.
+submit Commit 1 in the first PR, then Commits 2 and 3 in the second, and Commit 4 in the third.
 
-Across the three commits,
+Across the four commits,
 you will be assisted with a convenient utility script, `tools/bump_version.sh`,
 
 ### Commit 1: "Bump the Docker image version"
@@ -104,3 +105,22 @@ Pack these changes into a third commit and
 submit the last two commits in a single PR.
 After the PR is merged into the `main` branch,
 the CI will automatically publish the new crate versions.
+
+### Commit 4: "Update API doc hyperlinks in the Book"
+
+After new API docs are published, run:
+
+```
+./bump_version.sh --api_doc_hyperlinks_in_book
+```
+
+This command mechanically updates API doc hyperlinks in Book pages
+to point to the current project version.
+
+Then, validate all hyperlinks in the Book are valid:
+
+```
+cd ../book && make check
+```
+
+Submit the changes in a single-commit PR.

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -10,6 +10,7 @@ set -e
 #   --docker_version_file [major|minor|patch|date]   Bump the Docker image version in the DOCKER_IMAGE_VERSION file under the project root
 #   --docker_version_refs                            Update all references to the Docker image version throughout the codebase
 #   --version_file                                   Bump the project version to match the Docker image version
+#   --api_doc_hyperlinks_in_book                     Update all API doc hyperlinks in the Book to match VERSION
 #   --help, -h                                       Show this help message
 # Options:
 #   major, minor, patch, date                        The version part to increment when bumping the Docker image version
@@ -50,6 +51,7 @@ print_help() {
     echo "  --docker_version_file [major|minor|patch|date]   Bump the Docker image version in the DOCKER_IMAGE_VERSION file under the project root"
     echo "  --docker_version_refs                            Update all references to the Docker image version throughout the codebase"
     echo "  --version_file                                   Bump the project version to match the Docker image version"
+    echo "  --api_doc_hyperlinks_in_book                     Update all API doc hyperlinks in the Book to match VERSION"
     echo "  --help, -h                                       Show this help message"
     echo ""
     echo "The [major|minor|patch|date] options for --docker_version_file specify which part of the"
@@ -144,6 +146,21 @@ update_all_docker_version_refs() {
     done
 }
 
+update_api_doc_hyperlinks_in_book() {
+    new_version=$(cat ${VERSION_PATH})
+
+    # This matches 'asterinas.github.io/api-docs/' followed by any X.Y.Z version.
+    SEARCH_PATTERN="asterinas\.github\.io/api-docs/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+"
+    REPLACE_STR="asterinas\.github\.io/api-docs/${new_version}"
+
+    grep -rl "asterinas.github.io/api-docs/" "$BOOK_SRC_DIR" | while read -r file; do
+        # We use '|' as a delimiter for sed to avoid escaping the slashes in the URL.
+        sed -i "s|$SEARCH_PATTERN|$REPLACE_STR|g" "$file"
+    done
+
+    echo "Updated Book API doc hyperlinks to ${new_version}"
+}
+
 # Update project dependencies (Cargo.toml and Cargo.lock)
 update_project_dependencies() {
     # Update the versions in Cargo.toml
@@ -199,6 +216,7 @@ OSDK_DIR=${ASTER_SRC_DIR}/osdk
 OSDK_CARGO_TOML_PATH=${OSDK_DIR}/Cargo.toml
 SCTRACE_DIR=${ASTER_SRC_DIR}/tools/sctrace
 SCTRACE_CARGO_TOML_PATH=${SCTRACE_DIR}/Cargo.toml
+BOOK_SRC_DIR=${ASTER_SRC_DIR}/book/src
 VERSION_PATH=${ASTER_SRC_DIR}/VERSION
 DOCKER_IMAGE_VERSION_PATH=${ASTER_SRC_DIR}/DOCKER_IMAGE_VERSION
 
@@ -219,7 +237,10 @@ case "$command" in
     "--version_file")
         sync_project_version
         ;;
+    "--api_doc_hyperlinks_in_book")
+        update_api_doc_hyperlinks_in_book
+        ;;
     *)
-        echo "Warning: Using --docker_version_file, --docker_version_refs, or --version_file instead."
+        echo "Warning: Using --docker_version_file, --docker_version_refs, --version_file, or --api_doc_hyperlinks_in_book instead."
         ;;
 esac


### PR DESCRIPTION
This PR improves book links by
* updating the version in api-docs links from v0.17.1 to v0.17.2
* fixing dead links
* adding `check_dead_links` and `check_latest_version` in publish_website workflow
  * the VERSION file change will trigger the workflow 
* notifying the api-docs containing latest version are available, and triggering publish_website again