### PR TITLE
Add `ptrace(PTRACE_PEEK/POKE_TEXT/DATA)`

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
@@ -91,7 +91,11 @@ Supported functionality in SCML:
 
 Supported requests:
 * `PTRACE_TRACEME`
+* `PTRACE_PEEKTEXT`
+* `PTRACE_PEEKDATA`
 * `PTRACE_PEEKUSER` (x86-64 only)
+* `PTRACE_POKETEXT`
+* `PTRACE_POKEDATA`
 * `PTRACE_POKEUSER` (x86-64 only)
 * `PTRACE_CONT`
 * `PTRACE_KILL`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/ptrace.scml
@@ -1,8 +1,20 @@
 // Request that the calling thread should be traced by its parent
 ptrace(request = PTRACE_TRACEME, tid, addr, data);
 
+// Read one word from the tracee's text space
+ptrace(request = PTRACE_PEEKTEXT, tid, addr, data);
+
+// Read one word from the tracee's data space
+ptrace(request = PTRACE_PEEKDATA, tid, addr, data);
+
 // Read one word from the tracee's USER area
 ptrace(request = PTRACE_PEEKUSER, tid, addr, data);
+
+// Write one word to the tracee's text space
+ptrace(request = PTRACE_POKETEXT, tid, addr, data);
+
+// Write one word to the tracee's data space
+ptrace(request = PTRACE_POKEDATA, tid, addr, data);
 
 // Write one word to the tracee's USER area
 ptrace(request = PTRACE_POKEUSER, tid, addr, data);

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -14,7 +14,7 @@ use crate::{arch::ptrace as arch_ptrace, process::posix_thread::NOT_A_SYSCALL};
 use crate::{
     prelude::*,
     process::{
-        CloneArgs, CloneFlags, WaitOptions,
+        CloneArgs, CloneFlags, Process, WaitOptions,
         signal::{
             DequeuedSignal, PauseReason,
             c_types::siginfo_t,
@@ -188,6 +188,26 @@ impl PosixThread {
     pub fn ptrace_poke_user(&self, offset: usize, value: usize) -> Result<()> {
         let status = self.get_tracee_status()?;
         status.poke_user(offset, value)
+    }
+
+    /// Reads one word from the tracee's memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread is not ptrace-stopped.
+    pub fn ptrace_peek_data(&self, addr: usize) -> Result<usize> {
+        let status = self.get_tracee_status()?;
+        status.peek_data(self.weak_process(), addr)
+    }
+
+    /// Writes one word to the tracee's memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ESRCH` if this thread is not ptrace-stopped.
+    pub fn ptrace_poke_data(&self, addr: usize, value: usize) -> Result<()> {
+        let status = self.get_tracee_status()?;
+        status.poke_data(self.weak_process(), addr, value)
     }
 
     /// Sets ptrace options for this thread.
@@ -630,6 +650,44 @@ impl TraceeStatus {
         arch_ptrace::write_user_word(regs, &mut orig_syscall_ret, offset, value)?;
         state.orig_syscall_ret = orig_syscall_ret;
         Ok(())
+    }
+
+    fn peek_data(&self, process: &Weak<Process>, addr: usize) -> Result<usize> {
+        // Hold the lock first to avoid race conditions.
+        let state = self.state.lock();
+        self.check_ptrace_stopped(&state)?;
+
+        let process = process.upgrade().unwrap();
+        let vmar_guard = process.lock_vmar();
+        let Some(vmar) = vmar_guard.as_ref() else {
+            return_errno_with_message!(Errno::EIO, "the process has exited");
+        };
+
+        let mut value = [0u8; size_of::<usize>()];
+        let mut writer = VmWriter::from(value.as_mut_slice()).to_fallible();
+        match vmar.read_alien(addr, &mut writer) {
+            Ok(bytes) if bytes == value.len() => Ok(usize::from_ne_bytes(value)),
+            _ => return_errno_with_message!(Errno::EIO, "failed to read tracee memory"),
+        }
+    }
+
+    fn poke_data(&self, process: &Weak<Process>, addr: usize, value: usize) -> Result<()> {
+        // Hold the lock first to avoid race conditions.
+        let state = self.state.lock();
+        self.check_ptrace_stopped(&state)?;
+
+        let process = process.upgrade().unwrap();
+        let vmar_guard = process.lock_vmar();
+        let Some(vmar) = vmar_guard.as_ref() else {
+            return_errno_with_message!(Errno::EIO, "the process has exited");
+        };
+
+        let value = value.to_ne_bytes();
+        let mut reader = VmReader::from(value.as_slice()).to_fallible();
+        match vmar.write_alien(addr, &mut reader) {
+            Ok(bytes) if bytes == value.len() => Ok(()),
+            _ => return_errno_with_message!(Errno::EIO, "failed to write tracee memory"),
+        }
     }
 
     fn set_options(&self, options: PtraceOptions) -> Result<()> {

--- a/kernel/src/syscall/ptrace.rs
+++ b/kernel/src/syscall/ptrace.rs
@@ -40,6 +40,13 @@ pub fn sys_ptrace(
 
             do_ptrace_attach(&parent_main_thread, current_thread)?;
         }
+        PtraceRequest::PTRACE_PEEKTEXT | PtraceRequest::PTRACE_PEEKDATA => {
+            let tracee = ctx.posix_thread.get_tracee(tid)?;
+            let tracee = tracee.as_posix_thread().unwrap();
+
+            let val = tracee.ptrace_peek_data(addr)?;
+            ctx.user_space().write_val(data, &val)?;
+        }
         #[cfg(target_arch = "x86_64")]
         PtraceRequest::PTRACE_PEEKUSER => {
             let tracee = ctx.posix_thread.get_tracee(tid)?;
@@ -47,6 +54,12 @@ pub fn sys_ptrace(
 
             let val = tracee.ptrace_peek_user(addr)?;
             ctx.user_space().write_val(data, &val)?;
+        }
+        PtraceRequest::PTRACE_POKETEXT | PtraceRequest::PTRACE_POKEDATA => {
+            let tracee = ctx.posix_thread.get_tracee(tid)?;
+            let tracee = tracee.as_posix_thread().unwrap();
+
+            tracee.ptrace_poke_data(addr, data)?;
         }
         #[cfg(target_arch = "x86_64")]
         PtraceRequest::PTRACE_POKEUSER => {
@@ -172,9 +185,17 @@ fn parse_ptrace_injected_signal(data: usize) -> Result<Option<SigNum>> {
 enum PtraceRequest {
     /// Indicates that this thread should be traced by its parent.
     PTRACE_TRACEME = 0,
+    /// Reads a word from the thread's text space at address `addr`.
+    PTRACE_PEEKTEXT = 1,
+    /// Reads a word from the thread's data space at address `addr`.
+    PTRACE_PEEKDATA = 2,
     /// Reads a word from the thread's user area at offset `addr`.
     #[cfg(target_arch = "x86_64")]
     PTRACE_PEEKUSER = 3,
+    /// Writes the word `data` to the thread's text space at address `addr`.
+    PTRACE_POKETEXT = 4,
+    /// Writes the word `data` to the thread's data space at address `addr`.
+    PTRACE_POKEDATA = 5,
     /// Writes the word `data` to the thread's user area at offset `addr`.
     #[cfg(target_arch = "x86_64")]
     PTRACE_POKEUSER = 6,
@@ -200,14 +221,6 @@ enum PtraceRequest {
     /// Gets the `siginfo` of the last ptrace-stop.
     PTRACE_GETSIGINFO = 0x4202,
     // TODO: Support other operations.
-    // /// Reads a word from the thread's text space at address `addr`.
-    // PTRACE_PEEKTEXT = 1,
-    // /// Reads a word from the thread's data space at address `addr`.
-    // PTRACE_PEEKDATA = 2,
-    // /// Writes the word `data` to the thread's text space at address `addr`.
-    // PTRACE_POKETEXT = 4,
-    // /// Writes the word `data` to the thread's data space at address `addr`.
-    // PTRACE_POKEDATA = 5,
     // /// Gets all floating-point registers used by the thread.
     // PTRACE_GETFPREGS = 14,
     // /// Sets all floating-point registers used by the thread.

--- a/test/initramfs/src/regression/process/ptrace/ptrace.c
+++ b/test/initramfs/src/regression/process/ptrace/ptrace.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,6 +54,14 @@ static int read_tracer_pid(pid_t pid)
 
 	CHECK(fclose(status_file));
 	return tracer_pid;
+}
+
+static unsigned long read_proc_mem_word(int proc_mem_fd, unsigned long addr)
+{
+	unsigned long value = 0;
+	CHECK_WITH(pread(proc_mem_fd, &value, sizeof(value), (off_t)addr),
+		   _ret == sizeof(value));
+	return value;
 }
 
 FN_TEST(ptrace_signal_stop_wait_continue)
@@ -491,6 +500,73 @@ FN_TEST(ptrace_syscall_stop_wait_continue)
 		 _ret == pid && WIFSTOPPED(status) &&
 			 WSTOPSIG(status) == (SIGTRAP | 0x80));
 
+	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ptrace_peek_poke_data)
+{
+	SKIP_TEST_IF(read_yama_scope() == YAMA_SCOPE_NO_ATTACH);
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(pipefd[0]));
+
+		unsigned long *word =
+			CHECK_WITH(mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+					MAP_PRIVATE | MAP_ANONYMOUS, -1, 0),
+				   _ret != MAP_FAILED);
+		*word = 0x0123456789abcdefUL;
+
+		unsigned long addr = (unsigned long)word;
+		CHECK(write(pipefd[1], &addr, sizeof(addr)));
+		CHECK(close(pipefd[1]));
+
+		CHECK(ptrace(PTRACE_TRACEME, 0, 0, 0));
+		CHECK(raise(SIGSTOP));
+
+		if (*word != 0x0fedcba987654321UL) {
+			CHECK(munmap(word, 4096));
+			_exit(1);
+		}
+		CHECK(munmap(word, 4096));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+
+	unsigned long addr = 0;
+	TEST_RES(read(pipefd[0], &addr, sizeof(addr)), _ret == sizeof(addr));
+	TEST_SUCC(close(pipefd[0]));
+
+	int status = 0;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSTOPPED(status) &&
+						   WSTOPSIG(status) == SIGSTOP);
+
+	char mempath[64];
+	TEST_RES(snprintf(mempath, sizeof(mempath), "/proc/%d/mem", pid),
+		 _ret > 0 && _ret < (int)sizeof(mempath));
+	int proc_mem_fd = TEST_SUCC(open(mempath, O_RDWR));
+
+	unsigned long proc_word = read_proc_mem_word(proc_mem_fd, addr);
+
+	TEST_RES(ptrace(PTRACE_PEEKDATA, pid, (void *)addr, 0),
+		 _ret == proc_word);
+	TEST_RES(ptrace(PTRACE_PEEKTEXT, pid, (void *)addr, 0),
+		 _ret == proc_word);
+
+	unsigned long new_value = 0x0fedcba987654321UL;
+	TEST_SUCC(ptrace(PTRACE_POKEDATA, pid, (void *)addr, new_value));
+	TEST_RES(read_proc_mem_word(proc_mem_fd, addr), _ret == new_value);
+	TEST_SUCC(ptrace(PTRACE_POKETEXT, pid, (void *)addr, new_value));
+	TEST_RES(read_proc_mem_word(proc_mem_fd, addr), _ret == new_value);
+
+	TEST_SUCC(close(proc_mem_fd));
 	TEST_SUCC(ptrace(PTRACE_CONT, pid, 0, 0));
 	TEST_RES(waitpid(pid, &status, 0),
 		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);


### PR DESCRIPTION
Required for supporting `strace`.

>        PTRACE_PEEKTEXT
>        PTRACE_PEEKDATA
>               Read a word at the address addr in the tracee's memory,
>               returning the word as the result of the ptrace() call.
>               Linux does not have separate text and data address spaces,
>               so these two operations are currently equivalent.  (data is
>               ignored; but see NOTES.)
> 
>        PTRACE_POKETEXT
>        PTRACE_POKEDATA
>               Copy the word data to the address addr in the tracee's
>               memory.  As for PTRACE_PEEKTEXT and PTRACE_PEEKDATA, these
>               two operations are currently equivalent.


>    C library/kernel differences
>        At the system call level, the PTRACE_PEEKTEXT, PTRACE_PEEKDATA,
>        and PTRACE_PEEKUSER operations have a different API: they store
>        the result at the address specified by the data parameter, and the
>        return value is the error flag.  The glibc wrapper function
>        provides the API given in DESCRIPTION above, with the result being
>        returned via the function return value.
> 
https://man7.org/linux/man-pages/man2/ptrace.2.html