### PR TITLE
Add unused KCODE32 slot in x86 GDT to align USER_CS and USER_SS with Linux

### DIFF
--- a/kernel/src/arch/x86/ptrace.rs
+++ b/kernel/src/arch/x86/ptrace.rs
@@ -348,3 +348,14 @@ fn write_word(bytes: &mut [u8], offset: usize, value: usize) {
 const fn word_range(offset: usize) -> Range<usize> {
     offset..offset + size_of::<usize>()
 }
+
+// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/arch/x86/include/asm/segment.h#L188-L189>
+const LINUX_USER_CS: usize = 0x33;
+const LINUX_USER_SS: usize = 0x2b;
+
+// Some applications (e.g., GDB), rely on `ptrace` exposing Linux's
+// conventional x86-64 user segment selector values.
+//
+// See: <https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/nat/x86-linux.c#l124>.
+ostd::const_assert!(LINUX_USER_CS == USER_CS_VALUE);
+ostd::const_assert!(LINUX_USER_SS == USER_SS_VALUE);

--- a/ostd/src/arch/x86/trap/gdt.rs
+++ b/ostd/src/arch/x86/trap/gdt.rs
@@ -47,9 +47,10 @@ pub(super) unsafe fn init_on_cpu() {
     // intended for switching to a new kernel CS.
     assert_eq!(CS::get_reg(), KERNEL_CS);
 
-    // Allocate a new GDT with 8 entries.
+    // Allocate a new GDT with 9 entries.
     let gdt = Box::new([
-        0, KCODE64, KDATA, /* UCODE32 (not used) */ 0, UDATA, UCODE64, tss0, tss1,
+        0, KCODE64, KDATA, /* KCODE32 (not used) */ 0, /* UCODE32 (not used) */ 0, UDATA,
+        UCODE64, tss0, tss1,
     ]);
     let gdt = &*Box::leak(gdt);
     assert_eq!(gdt[KERNEL_CS.index() as usize], KCODE64);
@@ -70,14 +71,14 @@ pub(super) unsafe fn init_on_cpu() {
     unsafe { lgdt(&gdtr) };
 
     // Load the TSS.
-    let tss_sel = SegmentSelector::new(6, PrivilegeLevel::Ring0);
+    let tss_sel = SegmentSelector::new(7, PrivilegeLevel::Ring0);
     assert_eq!(gdt[tss_sel.index() as usize], tss0);
     assert_eq!(gdt[(tss_sel.index() + 1) as usize], tss1);
     // SAFETY: The selector points to the TSS descriptors in the GDT.
     unsafe { load_tss(tss_sel) };
 
     // Set up the selectors for the `syscall` and `sysret` instructions.
-    let sysret = SegmentSelector::new(3, PrivilegeLevel::Ring3);
+    let sysret = SegmentSelector::new(4, PrivilegeLevel::Ring3);
     assert_eq!(gdt[(sysret.index() + 1) as usize], UDATA);
     assert_eq!(gdt[(sysret.index() + 2) as usize], UCODE64);
     let syscall = SegmentSelector::new(1, PrivilegeLevel::Ring0);
@@ -126,5 +127,5 @@ const UDATA: u64 = 0x00CF_F300_0000_FFFF;
 const KERNEL_CS: SegmentSelector = SegmentSelector::new(1, PrivilegeLevel::Ring0);
 const KERNEL_SS: SegmentSelector = SegmentSelector::new(2, PrivilegeLevel::Ring0);
 
-pub(super) const USER_CS: SegmentSelector = SegmentSelector::new(5, PrivilegeLevel::Ring3);
-pub(super) const USER_SS: SegmentSelector = SegmentSelector::new(4, PrivilegeLevel::Ring3);
+pub(super) const USER_CS: SegmentSelector = SegmentSelector::new(6, PrivilegeLevel::Ring3);
+pub(super) const USER_SS: SegmentSelector = SegmentSelector::new(5, PrivilegeLevel::Ring3);


### PR DESCRIPTION
Running GDB on current main branch's x86-64 builds produces the following warning:

```
warning: Selected architecture i386:x86-64 is not compatible with reported target architecture i386
warning: Architecture rejected target-supplied description
```

This is because [GDB expects the value of CS on x86-64 Linux to be `0x33`](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/nat/x86-linux.c#l124). On the current main branch, it is `0x2b`. Adding an empty entry before `UCODE64` and `UDATA` makes the values of CS and SS match Linux: `cs = 0x33, ss = 0x2b`.

Alternative: add a patch to GDB to suppress this warning. This would be less elegant.


Required for #2323.
