### PR TITLE
Extend `InodeIo` with more file opeartions on per open data

### DIFF
--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -16,8 +16,8 @@ use super::EvdevDevice;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -356,7 +356,7 @@ impl Pollable for EvdevFile {
     }
 }
 
-impl InodeIo for EvdevFile {
+impl FileOps for EvdevFile {
     fn read_at(
         &self,
         _offset: usize,
@@ -405,7 +405,7 @@ impl InodeIo for EvdevFile {
     }
 }
 
-impl FileIo for EvdevFile {
+impl PerOpenFileOps for EvdevFile {
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is an evdev file");
     }

--- a/kernel/src/device/evdev/mod.rs
+++ b/kernel/src/device/evdev/mod.rs
@@ -31,7 +31,7 @@ use super::{
     Device, DeviceType, DevtmpfsInodeMeta,
     registry::char::{MajorIdOwner, acquire_major, register, unregister},
 };
-use crate::{fs::file::FileIo, prelude::*, util::ring_buffer::RbProducer};
+use crate::{fs::file::PerOpenFileOps, prelude::*, util::ring_buffer::RbProducer};
 
 /// Major device number for evdev devices.
 const EVDEV_MAJOR_ID: u16 = 13;
@@ -203,7 +203,7 @@ impl Device for EvdevDevice {
         )))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         // Get the device from the registry.
         let devices = EVDEV_DEVICES.lock();
         let Some(evdev) = devices.get(&self.id.minor()) else {
@@ -215,7 +215,7 @@ impl Device for EvdevDevice {
 
         // Create a new opened evdev file for this evdev device.
         let file = evdev.create_file(EVDEV_BUFFER_SIZE)?;
-        Ok(file as Box<dyn FileIo>)
+        Ok(file as Box<dyn PerOpenFileOps>)
     }
 }
 

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -9,8 +9,8 @@ use crate::{
     context::current_userspace,
     events::IoEvents,
     fs::{
-        file::{FileIo, Mappable, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{Mappable, PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -232,7 +232,7 @@ impl Device for Fb {
         Some(DevtmpfsInodeMeta::new("fb0"))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         let Some(framebuffer) = FRAMEBUFFER.get() else {
             return Err(Error::with_message(
                 Errno::ENODEV,
@@ -401,7 +401,7 @@ impl Pollable for FbHandle {
     }
 }
 
-impl InodeIo for FbHandle {
+impl FileOps for FbHandle {
     fn read_at(
         &self,
         offset: usize,
@@ -486,7 +486,7 @@ impl InodeIo for FbHandle {
     }
 }
 
-impl FileIo for FbHandle {
+impl PerOpenFileOps for FbHandle {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/device/mem/file.rs
+++ b/kernel/src/device/mem/file.rs
@@ -3,8 +3,8 @@
 use crate::{
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -96,7 +96,7 @@ impl Pollable for MemFile {
     }
 }
 
-impl InodeIo for MemFile {
+impl FileOps for MemFile {
     fn read_at(
         &self,
         _offset: usize,
@@ -136,7 +136,7 @@ impl InodeIo for MemFile {
     }
 }
 
-impl FileIo for MemFile {
+impl PerOpenFileOps for MemFile {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/device/mem/mod.rs
+++ b/kernel/src/device/mem/mod.rs
@@ -30,7 +30,7 @@ use super::{
     registry::char::{MajorIdOwner, acquire_major, register},
 };
 use crate::{
-    fs::file::{FileIo, mkmod},
+    fs::file::{PerOpenFileOps, mkmod},
     prelude::*,
 };
 
@@ -76,7 +76,7 @@ impl Device for MemDevice {
         })
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(self.file))
     }
 }

--- a/kernel/src/device/misc/hwrng.rs
+++ b/kernel/src/device/misc/hwrng.rs
@@ -12,8 +12,8 @@ use crate::{
     device::{Device, DeviceType, DevtmpfsInodeMeta, registry::char},
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -56,7 +56,7 @@ impl Device for HwRngDevice {
         Some(DevtmpfsInodeMeta::new("hwrng"))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         // TODO: Reject non-read-only opens with `EINVAL`
         // once device `open` callbacks receive `AccessMode`.
         // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L169>.
@@ -76,7 +76,7 @@ impl Pollable for HwRngFile {
     }
 }
 
-impl InodeIo for HwRngFile {
+impl FileOps for HwRngFile {
     fn read_at(
         &self,
         _offset: usize,
@@ -140,7 +140,7 @@ impl InodeIo for HwRngFile {
     }
 }
 
-impl FileIo for HwRngFile {
+impl PerOpenFileOps for HwRngFile {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -58,8 +58,8 @@ use crate::{
     device::{Device, DeviceType, DevtmpfsInodeMeta, registry::char::register},
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -97,7 +97,7 @@ impl Device for TdxGuest {
         Some(DevtmpfsInodeMeta::new("tdx_guest"))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(TdxGuestFile))
     }
 }
@@ -155,7 +155,7 @@ impl Pollable for TdxGuestFile {
     }
 }
 
-impl InodeIo for TdxGuestFile {
+impl FileOps for TdxGuestFile {
     fn read_at(
         &self,
         _offset: usize,
@@ -175,7 +175,7 @@ impl InodeIo for TdxGuestFile {
     }
 }
 
-impl FileIo for TdxGuestFile {
+impl PerOpenFileOps for TdxGuestFile {
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "seek is not supported")
     }

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -18,7 +18,7 @@ pub use registry::lookup;
 
 use crate::{
     fs::{
-        file::{FileIo, InodeMode, InodeType, mkmod},
+        file::{InodeMode, InodeType, PerOpenFileOps, mkmod},
         ramfs::RamFs,
         vfs::{
             inode::MknodType,
@@ -41,7 +41,7 @@ pub trait Device: Send + Sync + 'static {
 
     /// Opens the device, returning a file-like object that the userspace can interact with by
     /// doing I/O.
-    fn open(&self) -> Result<Box<dyn FileIo>>;
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>>;
 }
 
 impl Debug for dyn Device {

--- a/kernel/src/device/pty/driver.rs
+++ b/kernel/src/device/pty/driver.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     events::IoEvents,
-    fs::file::FileIo,
+    fs::file::PerOpenFileOps,
     prelude::*,
     process::signal::Pollee,
     util::{
@@ -119,7 +119,7 @@ impl TtyDriver for PtyDriver {
         None
     }
 
-    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {
+    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(PtySlaveFile::new(tty)?))
     }
 

--- a/kernel/src/device/pty/file.rs
+++ b/kernel/src/device/pty/file.rs
@@ -6,8 +6,8 @@ use crate::{
     device::PtySlave,
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -60,7 +60,7 @@ impl Pollable for PtySlaveFile {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents;
 }
 
-impl InodeIo for PtySlaveFile {
+impl FileOps for PtySlaveFile {
     fn read_at(
         &self,
         _offset: usize,
@@ -81,7 +81,7 @@ impl InodeIo for PtySlaveFile {
 }
 
 #[inherit_methods(from = "self.0")]
-impl FileIo for PtySlaveFile {
+impl PerOpenFileOps for PtySlaveFile {
     fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32>;
 
     fn check_seekable(&self) -> Result<()> {

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -10,8 +10,8 @@ use crate::{
     events::IoEvents,
     fs::{
         devpts::Ptmx,
-        file::{AccessMode, FileIo, OpenArgs, StatusFlags, file_table::FdFlags, mkmod},
-        vfs::{inode::InodeIo, path::FsPath},
+        file::{AccessMode, OpenArgs, PerOpenFileOps, StatusFlags, file_table::FdFlags, mkmod},
+        vfs::{inode::FileOps, path::FsPath},
     },
     prelude::*,
     process::{
@@ -90,7 +90,7 @@ impl Pollable for PtyMaster {
     }
 }
 
-impl InodeIo for PtyMaster {
+impl FileOps for PtyMaster {
     fn read_at(
         &self,
         _offset: usize,
@@ -138,7 +138,7 @@ impl InodeIo for PtyMaster {
     }
 }
 
-impl FileIo for PtyMaster {
+impl PerOpenFileOps for PtyMaster {
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is a pty");
     }

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -9,8 +9,8 @@ use crate::{
     device::{Device, DeviceType, DevtmpfsInodeMeta, add_node},
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::{inode::InodeIo, path::PathResolver},
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::{inode::FileOps, path::PathResolver},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -81,19 +81,19 @@ impl Device for BlockFile {
         Some(DevtmpfsInodeMeta::new(self.0.name()))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(OpenBlockFile(self.0.clone())))
     }
 }
 
 /// Represents an opened block device file ready for I/O operations.
 //
-// TODO: This type wraps an `Arc<dyn BlockDevice>` in another `Box` just to implement the `FileIo`
-// trait. It leads to redundant vtable dispatch and heap allocation. We should devise a better
-// strategy to eliminate the unnecessary intermediate `Box`.
+// TODO: This type wraps an `Arc<dyn BlockDevice>` in another `Box` just to implement the
+// `PerOpenFileOps` trait. It leads to redundant vtable dispatch and heap allocation. We should
+// devise a better strategy to eliminate the unnecessary intermediate `Box`.
 struct OpenBlockFile(Arc<dyn BlockDevice>);
 
-impl InodeIo for OpenBlockFile {
+impl FileOps for OpenBlockFile {
     fn read_at(
         &self,
         offset: usize,
@@ -126,7 +126,7 @@ impl Pollable for OpenBlockFile {
     }
 }
 
-impl FileIo for OpenBlockFile {
+impl PerOpenFileOps for OpenBlockFile {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/device/tty/device.rs
+++ b/kernel/src/device/tty/device.rs
@@ -20,7 +20,7 @@ use crate::{
             vt::{VtDriver, tty1_device},
         },
     },
-    fs::file::{FileIo, mkmod},
+    fs::file::{PerOpenFileOps, mkmod},
     prelude::*,
     process::{JobControl, Terminal},
 };
@@ -49,7 +49,7 @@ impl Device for Tty0Device {
         Some(DevtmpfsInodeMeta::new("tty0"))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         self.active_vt().open()
     }
 }
@@ -78,7 +78,7 @@ impl Device for TtyDevice {
         Some(DevtmpfsInodeMeta::with_mode("tty", mkmod!(a+rw)))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         let Some(terminal) = current!().terminal() else {
             return_errno_with_message!(
                 Errno::ENOTTY,
@@ -140,7 +140,7 @@ impl Device for SystemConsole {
         Some(DevtmpfsInodeMeta::new("console"))
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         self.inner.open()
     }
 }

--- a/kernel/src/device/tty/driver.rs
+++ b/kernel/src/device/tty/driver.rs
@@ -5,7 +5,7 @@ use crate::{
         DevtmpfsInodeMeta,
         tty::{Tty, termio::CTermios},
     },
-    fs::file::FileIo,
+    fs::file::PerOpenFileOps,
     prelude::*,
     util::ioctl::RawIoctl,
 };
@@ -28,7 +28,7 @@ pub trait TtyDriver: Send + Sync + 'static {
     /// Opens the TTY.
     ///
     /// This function will be called when opening `/dev/tty`.
-    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>>
+    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>>
     where
         Self: Sized;
 

--- a/kernel/src/device/tty/file.rs
+++ b/kernel/src/device/tty/file.rs
@@ -6,8 +6,8 @@ use super::{Tty, TtyDriver};
 use crate::{
     events::IoEvents,
     fs::{
-        file::{FileIo, StatusFlags},
-        vfs::inode::InodeIo,
+        file::{PerOpenFileOps, StatusFlags},
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -27,7 +27,7 @@ impl<D: TtyDriver> Pollable for TtyFile<D> {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents;
 }
 
-impl<D: TtyDriver> InodeIo for TtyFile<D> {
+impl<D: TtyDriver> FileOps for TtyFile<D> {
     fn read_at(
         &self,
         _offset: usize,
@@ -48,7 +48,7 @@ impl<D: TtyDriver> InodeIo for TtyFile<D> {
 }
 
 #[inherit_methods(from = "self.0")]
-impl<D: TtyDriver> FileIo for TtyFile<D> {
+impl<D: TtyDriver> PerOpenFileOps for TtyFile<D> {
     fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32>;
 
     fn check_seekable(&self) -> Result<()> {

--- a/kernel/src/device/tty/hvc.rs
+++ b/kernel/src/device/tty/hvc.rs
@@ -13,7 +13,7 @@ use crate::{
         registry::char,
         tty::{file::TtyFile, termio::CTermios},
     },
-    fs::file::FileIo,
+    fs::file::PerOpenFileOps,
     prelude::*,
 };
 
@@ -31,7 +31,7 @@ impl TtyDriver for HvcDriver {
         Some(DevtmpfsInodeMeta::new(format!("hvc{}", index)))
     }
 
-    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {
+    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(TtyFile::new(tty)))
     }
 

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -7,7 +7,7 @@ use self::{line_discipline::LineDiscipline, termio::CFontOp};
 use crate::{
     device::{Device, DeviceType, DevtmpfsInodeMeta},
     events::IoEvents,
-    fs::file::{FileIo, StatusFlags},
+    fs::file::{PerOpenFileOps, StatusFlags},
     prelude::*,
     process::{
         JobControl, Terminal, broadcast_signal_async,
@@ -330,7 +330,7 @@ impl<D: TtyDriver> Device for Tty<D> {
         self.driver.devtmpfs_meta(self.index)
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         D::open(self.weak_self.upgrade().unwrap())
     }
 }

--- a/kernel/src/device/tty/serial.rs
+++ b/kernel/src/device/tty/serial.rs
@@ -13,7 +13,7 @@ use crate::{
         registry::char,
         tty::{file::TtyFile, termio::CTermios},
     },
-    fs::file::FileIo,
+    fs::file::PerOpenFileOps,
     prelude::*,
 };
 
@@ -38,7 +38,7 @@ impl TtyDriver for SerialDriver {
         )))
     }
 
-    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {
+    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(TtyFile::new(tty)))
     }
 

--- a/kernel/src/device/tty/vt/driver.rs
+++ b/kernel/src/device/tty/vt/driver.rs
@@ -18,7 +18,7 @@ use crate::{
         registry::char,
         tty::{CFontOp, Tty, TtyDriver, file::TtyFile, termio::CTermios},
     },
-    fs::file::FileIo,
+    fs::file::PerOpenFileOps,
     prelude::*,
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };
@@ -106,7 +106,7 @@ impl TtyDriver for VtDriver {
         Some(DevtmpfsInodeMeta::new(format!("tty{}", index)))
     }
 
-    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn FileIo>> {
+    fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(TtyFile::new(tty)))
     }
 

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -16,7 +16,7 @@ use crate::{
         pipe::PipeHandle,
         utils::DirentVisitor,
         vfs::{
-            inode::{FallocMode, InodeIo},
+            inode::{FallocMode, FileOps},
             inode_ext::InodeExt,
             path::Path,
             range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
@@ -29,10 +29,10 @@ use crate::{
 
 pub struct InodeHandle {
     path: Path,
-    /// `file_io` is similar to the `file_private` field in Linux's `file` structure. If `file_io`
-    /// is `Some(_)`, typical file operations including `read`, `write`, `poll`, and `ioctl` will
-    /// be provided by `file_io`, instead of `path`.
-    file_io: Option<Box<dyn FileIo>>,
+    /// `open_file` is similar to the `file_private` field in Linux's `file` structure. If
+    /// `open_file` is `Some(_)`, typical file operations including `read`, `write`, `poll`,
+    /// and `ioctl` will be provided by the per-open file object instead of `path`.
+    open_file: Option<Box<dyn PerOpenFileOps>>,
     offset: Mutex<usize>,
     status_flags: AtomicStatusFlags,
     rights: Rights,
@@ -57,19 +57,19 @@ impl InodeHandle {
         status_flags: StatusFlags,
     ) -> Result<Self> {
         let inode = path.inode();
-        let (file_io, rights) = if status_flags.contains(StatusFlags::O_PATH) {
+        let (open_file, rights) = if status_flags.contains(StatusFlags::O_PATH) {
             (None, Rights::empty())
         } else if inode.type_() == InodeType::Dir && access_mode.is_writable() {
             return_errno_with_message!(Errno::EISDIR, "a directory cannot be opened writable");
         } else {
-            let file_io = inode.open(access_mode, status_flags).transpose()?;
+            let open_file = inode.open(access_mode, status_flags).transpose()?;
             let rights = Rights::from(access_mode);
-            (file_io, rights)
+            (open_file, rights)
         };
 
         Ok(Self {
             path,
-            file_io,
+            open_file,
             offset: Mutex::new(0),
             status_flags: AtomicStatusFlags::new(status_flags),
             rights,
@@ -89,10 +89,10 @@ impl InodeHandle {
         self.rights
     }
 
-    fn inode_io_and_is_offset_aware(&self) -> (&dyn InodeIo, bool) {
-        if let Some(ref file_io) = self.file_io {
-            let is_offset_aware = file_io.is_offset_aware();
-            return (file_io.as_ref(), is_offset_aware);
+    fn file_ops_and_is_offset_aware(&self) -> (&dyn FileOps, bool) {
+        if let Some(ref open_file) = self.open_file {
+            let is_offset_aware = open_file.is_offset_aware();
+            return (open_file.as_ref(), is_offset_aware);
         }
 
         let inode = self.path.inode();
@@ -100,12 +100,12 @@ impl InodeHandle {
         (inode.as_ref(), is_offset_aware)
     }
 
-    /// Returns the `InodeIo` for positional I/O, rejecting files
+    /// Returns the `FileOps` for positional I/O, rejecting files
     /// that do not support `pread`/`pwrite`.
-    fn inode_io_for_positional_io(&self) -> Result<&dyn InodeIo> {
-        if let Some(ref file_io) = self.file_io {
-            file_io.check_positional_io()?;
-            return Ok(file_io.as_ref());
+    fn file_ops_for_positional_io(&self) -> Result<&dyn FileOps> {
+        if let Some(ref open_file) = self.open_file {
+            open_file.check_positional_io()?;
+            return Ok(open_file.as_ref());
         }
 
         let inode = self.path.inode();
@@ -221,23 +221,23 @@ impl InodeHandle {
         Ok(())
     }
 
-    pub fn downcast_file_io<T: 'static>(&self) -> Result<Option<&T>> {
+    pub fn downcast_open_file<T: 'static>(&self) -> Result<Option<&T>> {
         if self.rights.is_empty() {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        let Some(file_io) = self.file_io.as_ref() else {
+        let Some(open_file) = self.open_file.as_ref() else {
             return Ok(None);
         };
 
-        Ok((file_io.as_ref() as &dyn Any).downcast_ref::<T>())
+        Ok((open_file.as_ref() as &dyn Any).downcast_ref::<T>())
     }
 }
 
 impl Pollable for InodeHandle {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
-        if let Some(ref file_io) = self.file_io {
-            return file_io.poll(mask, poller);
+        if let Some(ref open_file) = self.open_file {
+            return open_file.poll(mask, poller);
         }
 
         if self.rights.is_empty() {
@@ -255,16 +255,16 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
 
-        let (inode_io, is_offset_aware) = self.inode_io_and_is_offset_aware();
+        let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return inode_io.read_at(0, writer, status_flags);
+            return file_ops.read_at(0, writer, status_flags);
         }
 
         let mut offset = self.offset.lock();
 
-        let len = inode_io.read_at(*offset, writer, status_flags)?;
+        let len = file_ops.read_at(*offset, writer, status_flags)?;
         *offset += len;
 
         Ok(len)
@@ -275,56 +275,56 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
 
-        let (inode_io, is_offset_aware) = self.inode_io_and_is_offset_aware();
+        let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return inode_io.write_at(0, reader, status_flags);
+            return file_ops.write_at(0, reader, status_flags);
         }
 
         let mut offset = self.offset.lock();
 
-        // FIXME: How can we deal with the `O_APPEND` flag if `file_io` is set?
-        if status_flags.contains(StatusFlags::O_APPEND) && self.file_io.is_none() {
+        // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
+        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
             // FIXME: `O_APPEND` should ensure that new content is appended even if another process
             // is writing to the file concurrently.
             *offset = self.path.size();
         }
 
-        let len = inode_io.write_at(*offset, reader, status_flags)?;
+        let len = file_ops.write_at(*offset, reader, status_flags)?;
         *offset += len;
 
         Ok(len)
     }
 
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let inode_io = self.inode_io_for_positional_io()?;
+        let file_ops = self.file_ops_for_positional_io()?;
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
 
         let status_flags = self.status_flags();
 
-        inode_io.read_at(offset, writer, status_flags)
+        file_ops.read_at(offset, writer, status_flags)
     }
 
     fn write_at(&self, mut offset: usize, reader: &mut VmReader) -> Result<usize> {
-        let inode_io = self.inode_io_for_positional_io()?;
+        let file_ops = self.file_ops_for_positional_io()?;
         if !self.rights.contains(Rights::WRITE) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
 
         let status_flags = self.status_flags();
 
-        // FIXME: How can we deal with the `O_APPEND` flag if `file_io` is set?
-        if status_flags.contains(StatusFlags::O_APPEND) && self.file_io.is_none() {
+        // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
+        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
             // If the file has the `O_APPEND` flag, the offset is ignored.
             // FIXME: `O_APPEND` should ensure that new content is appended even if another process
             // is writing to the file concurrently.
             offset = self.path.size();
         }
 
-        inode_io.write_at(offset, reader, status_flags)
+        file_ops.write_at(offset, reader, status_flags)
     }
 
     fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
@@ -332,8 +332,8 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        if let Some(ref file_io) = self.file_io {
-            return file_io.ioctl(raw_ioctl);
+        if let Some(ref open_file) = self.open_file {
+            return open_file.ioctl(raw_ioctl);
         }
 
         return_errno_with_message!(Errno::ENOTTY, "ioctl is not supported");
@@ -349,10 +349,10 @@ impl FileLike for InodeHandle {
             // If the inode has a page cache, it is a file-backed mapping and
             // we return the VMO as the mappable object.
             Ok(Mappable::Vmo(page_cache.as_vmo().clone()))
-        } else if let Some(ref file_io) = self.file_io {
+        } else if let Some(ref open_file) = self.open_file {
             // Otherwise, it is a special file (e.g. device file) and we should
             // return the file-specific mappable object.
-            file_io.mappable()
+            open_file.mappable()
         } else {
             return_errno_with_message!(Errno::ENODEV, "the file is not mappable");
         }
@@ -382,9 +382,9 @@ impl FileLike for InodeHandle {
         // "packet" mode is not yet supported. Remove this check once "packet"
         // mode is implemented.
         if self
-            .file_io
+            .open_file
             .as_ref()
-            .and_then(|file_io| (file_io.as_ref() as &dyn Any).downcast_ref::<PipeHandle>())
+            .and_then(|open_file| (open_file.as_ref() as &dyn Any).downcast_ref::<PipeHandle>())
             .is_some()
         {
             crate::fs::pipe::check_status_flags(new_status_flags)?;
@@ -404,9 +404,9 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        if let Some(ref file_io) = self.file_io {
-            file_io.check_seekable()?;
-            if file_io.is_offset_aware() {
+        if let Some(ref open_file) = self.open_file {
+            open_file.check_seekable()?;
+            if open_file.is_offset_aware() {
                 // TODO: Figure out whether we need to add support for seeking from the end of
                 // special files.
                 return do_seek_util(&self.offset, pos, None);
@@ -521,17 +521,18 @@ pub enum SeekFrom {
     Current(isize),
 }
 
-/// A trait for file-like objects that provide custom I/O operations.
+/// Provides file operations for one opened file description.
 ///
-/// This trait is typically implemented for special files like devices or
-/// named pipes (FIFOs), which have behaviors different from regular on-disk files.
-pub trait FileIo: Pollable + InodeIo + Any + Send + Sync + 'static {
+/// A per-open file object can hold file-description-specific state and override
+/// operations that are not purely inode-backed, such as state and operations for
+/// devices, pipes, namespace files, and procfs files.
+pub trait PerOpenFileOps: Pollable + FileOps + Any + Send + Sync + 'static {
     /// Checks whether the `seek()` operation should fail.
     fn check_seekable(&self) -> Result<()>;
 
     /// Returns whether the `read()`/`write()` operation should use and advance the offset.
     ///
-    /// If [`FileIo::check_seekable`] succeeds but this method returns `false`,
+    /// If [`PerOpenFileOps::check_seekable`] succeeds but this method returns `false`,
     /// the offset in the `seek()` operation will be ignored.
     /// In that case, the `seek()` operation will do nothing but succeed.
     fn is_offset_aware(&self) -> bool;
@@ -542,7 +543,7 @@ pub trait FileIo: Pollable + InodeIo + Any + Send + Sync + 'static {
     /// most files. Override this for files that support positional I/O
     /// but not seeking (e.g., nsfs).
     ///
-    /// [`check_seekable`]: FileIo::check_seekable
+    /// [`check_seekable`]: PerOpenFileOps::check_seekable
     fn check_positional_io(&self) -> Result<()> {
         self.check_seekable()
     }

--- a/kernel/src/fs/file/mod.rs
+++ b/kernel/src/fs/file/mod.rs
@@ -20,4 +20,4 @@ pub(crate) use inode_attr::mode::{
     chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask,
 };
 pub use inode_attr::{mode::InodeMode, permission::Permission, r#type::InodeType};
-pub use inode_handle::{FileIo, InodeHandle, SeekFrom};
+pub use inode_handle::{InodeHandle, PerOpenFileOps, SeekFrom};

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy},
+            inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
@@ -171,7 +171,7 @@ impl RootInode {
     }
 }
 
-impl InodeIo for RootInode {
+impl FileOps for RootInode {
     fn read_at(
         &self,
         _offset: usize,
@@ -188,6 +188,43 @@ impl InodeIo for RootInode {
         _status_flags: StatusFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+            // Read the 3 special entries.
+            if *offset == 0 {
+                visitor.visit(".", self.ino(), self.type_(), *offset)?;
+                *offset += 1;
+            }
+            if *offset == 1 {
+                visitor.visit("..", self.ino(), self.type_(), *offset)?;
+                *offset += 1;
+            }
+            if *offset == 2 {
+                visitor.visit("ptmx", self.ptmx.ino(), self.ptmx.type_(), *offset)?;
+                *offset += 1;
+            }
+
+            // Read the slaves.
+            let slaves = self.slaves.read();
+            let start_offset = *offset;
+            for (idx, (name, node)) in slaves
+                .idxes_and_items()
+                .map(|(idx, (name, node))| (idx + 3, (name, node)))
+                .skip_while(|(idx, _)| idx < &start_offset)
+            {
+                visitor.visit(name.as_ref(), node.ino(), node.type_(), idx)?;
+                *offset = idx + 1;
+            }
+            Ok(())
+        };
+
+        let mut iterate_offset = offset;
+        match try_readdir(&mut iterate_offset, visitor) {
+            Err(e) if offset == iterate_offset => Err(e),
+            _ => Ok(iterate_offset - offset),
+        }
     }
 }
 
@@ -273,43 +310,6 @@ impl Inode for RootInode {
 
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::EPERM))
-    }
-
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
-            // Read the 3 special entries.
-            if *offset == 0 {
-                visitor.visit(".", self.ino(), self.type_(), *offset)?;
-                *offset += 1;
-            }
-            if *offset == 1 {
-                visitor.visit("..", self.ino(), self.type_(), *offset)?;
-                *offset += 1;
-            }
-            if *offset == 2 {
-                visitor.visit("ptmx", self.ptmx.ino(), self.ptmx.type_(), *offset)?;
-                *offset += 1;
-            }
-
-            // Read the slaves.
-            let slaves = self.slaves.read();
-            let start_offset = *offset;
-            for (idx, (name, node)) in slaves
-                .idxes_and_items()
-                .map(|(idx, (name, node))| (idx + 3, (name, node)))
-                .skip_while(|(idx, _)| idx < &start_offset)
-            {
-                visitor.visit(name.as_ref(), node.ino(), node.type_(), idx)?;
-                *offset = idx + 1;
-            }
-            Ok(())
-        };
-
-        let mut iterate_offset = offset;
-        match try_readdir(&mut iterate_offset, visitor) {
-            Err(e) if offset == iterate_offset => Err(e),
-            _ => Ok(iterate_offset - offset),
-        }
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -5,7 +5,7 @@ use device_id::{DeviceId, MajorId, MinorId};
 use super::*;
 use crate::{
     device::DevtmpfsInodeMeta,
-    fs::file::{AccessMode, FileIo},
+    fs::file::{AccessMode, PerOpenFileOps},
 };
 
 /// Same major number with Linux.
@@ -49,7 +49,7 @@ impl Ptmx {
 
 // Many methods are left to do nothing because every time the ptmx is being opened,
 // it returns the pty master. So the ptmx can not be used at upper layer.
-impl InodeIo for Ptmx {
+impl FileOps for Ptmx {
     fn read_at(
         &self,
         _offset: usize,
@@ -154,7 +154,7 @@ impl Inode for Ptmx {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         Some(self.inner.open())
     }
 }
@@ -172,7 +172,7 @@ impl Device for Inner {
         None
     }
 
-    fn open(&self) -> Result<Box<dyn FileIo>> {
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
         let devpts = self.0.upgrade().unwrap();
         Ok(devpts.create_master_slave_pair()?.0)
     }

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -6,7 +6,7 @@
 use super::*;
 use crate::{
     device::PtySlave,
-    fs::file::{AccessMode, FileIo},
+    fs::file::{AccessMode, PerOpenFileOps},
 };
 
 /// Same major number with Linux, the minor number is the index of slave.
@@ -38,7 +38,7 @@ impl PtySlaveInode {
     }
 }
 
-impl InodeIo for PtySlaveInode {
+impl FileOps for PtySlaveInode {
     fn read_at(
         &self,
         _offset: usize,
@@ -142,7 +142,7 @@ impl Inode for PtySlaveInode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         Some(self.device.open())
     }
 }

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -31,7 +31,7 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            inode::{Extension, FileOps, Inode, Metadata, MknodType, SymbolicLink},
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
         },
     },
@@ -1294,7 +1294,7 @@ fn check_corner_cases_for_rename(
     Ok(())
 }
 
-impl InodeIo for ExfatInode {
+impl FileOps for ExfatInode {
     fn read_at(
         &self,
         offset: usize,
@@ -1319,6 +1319,62 @@ impl InodeIo for ExfatInode {
         } else {
             self.write_at(offset, reader)
         }
+    }
+
+    fn readdir_at(&self, dir_cnt: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        let inner = self.inner.upread();
+
+        if dir_cnt >= (inner.num_sub_inodes + 2) as usize {
+            return Ok(0);
+        }
+
+        let mut empty_visitor = EmptyVisitor;
+
+        let dir_read = {
+            let fs = inner.fs();
+            let fs_guard = fs.lock();
+
+            let mut dir_read = 0usize;
+
+            if dir_cnt == 0
+                && visitor
+                    .visit(".", inner.ino, inner.inode_type, 0xFFFFFFFFFFFFFFFEusize)
+                    .is_ok()
+            {
+                dir_read += 1;
+            }
+
+            if dir_cnt <= 1 {
+                let parent_inode = inner.get_parent_inode().unwrap();
+                let parent_inner = parent_inode.inner.read();
+                let ino = parent_inner.ino;
+                let type_ = parent_inner.inode_type;
+                if visitor
+                    .visit("..", ino, type_, 0xFFFFFFFFFFFFFFFFusize)
+                    .is_ok()
+                {
+                    dir_read += 1;
+                }
+            }
+
+            // Skip . and ..
+            let dir_to_skip = dir_cnt.saturating_sub(2);
+
+            // Skip previous directories.
+            let (off, _) = inner.visit_sub_inodes(0, dir_to_skip, &mut empty_visitor, &fs_guard)?;
+            let (_, read) = inner.visit_sub_inodes(
+                off,
+                inner.num_sub_inodes as usize - dir_to_skip,
+                visitor,
+                &fs_guard,
+            )?;
+            dir_read += read;
+            dir_read
+        };
+
+        inner.upgrade().update_atime()?;
+
+        Ok(dir_read)
     }
 }
 
@@ -1489,62 +1545,6 @@ impl Inode for ExfatInode {
 
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         return_errno_with_message!(Errno::EINVAL, "unsupported operation")
-    }
-
-    fn readdir_at(&self, dir_cnt: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        let inner = self.inner.upread();
-
-        if dir_cnt >= (inner.num_sub_inodes + 2) as usize {
-            return Ok(0);
-        }
-
-        let mut empty_visitor = EmptyVisitor;
-
-        let dir_read = {
-            let fs = inner.fs();
-            let fs_guard = fs.lock();
-
-            let mut dir_read = 0usize;
-
-            if dir_cnt == 0
-                && visitor
-                    .visit(".", inner.ino, inner.inode_type, 0xFFFFFFFFFFFFFFFEusize)
-                    .is_ok()
-            {
-                dir_read += 1;
-            }
-
-            if dir_cnt <= 1 {
-                let parent_inode = inner.get_parent_inode().unwrap();
-                let parent_inner = parent_inode.inner.read();
-                let ino = parent_inner.ino;
-                let type_ = parent_inner.inode_type;
-                if visitor
-                    .visit("..", ino, type_, 0xFFFFFFFFFFFFFFFFusize)
-                    .is_ok()
-                {
-                    dir_read += 1;
-                }
-            }
-
-            // Skip . and ..
-            let dir_to_skip = dir_cnt.saturating_sub(2);
-
-            // Skip previous directories.
-            let (off, _) = inner.visit_sub_inodes(0, dir_to_skip, &mut empty_visitor, &fs_guard)?;
-            let (_, read) = inner.visit_sub_inodes(
-                off,
-                inner.num_sub_inodes as usize - dir_to_skip,
-                visitor,
-                &fs_guard,
-            )?;
-            dir_read += read;
-            dir_read
-        };
-
-        inner.upgrade().update_atime()?;
-
-        Ok(dir_read)
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -8,11 +8,11 @@ use crate::{
     device,
     fs::{
         ext2::{FilePerm, Inode as Ext2Inode},
-        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -21,7 +21,7 @@ use crate::{
     vm::page_cache::PageCache,
 };
 
-impl InodeIo for Ext2Inode {
+impl FileOps for Ext2Inode {
     fn read_at(
         &self,
         offset: usize,
@@ -46,6 +46,10 @@ impl InodeIo for Ext2Inode {
         } else {
             self.write_at(offset, reader)
         }
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        self.readdir_at(offset, visitor)
     }
 }
 
@@ -129,7 +133,7 @@ impl Inode for Ext2Inode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         match self.inode_type() {
             inode_type @ (InodeType::BlockDevice | InodeType::CharDevice) => {
                 let device_id = self.device_id();
@@ -182,10 +186,6 @@ impl Inode for Ext2Inode {
 
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
         Ok(self.lookup(name)?)
-    }
-
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        self.readdir_at(offset, visitor)
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -19,12 +19,12 @@ use ostd::{
 
 use crate::{
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         pseudofs::AnonDeviceId,
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
             path::{FsPath, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
@@ -555,7 +555,7 @@ impl OverlayInode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>>;
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
     pub fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
     pub fn list_xattr(
         &self,
@@ -945,7 +945,7 @@ fn is_opaque_dir(inode: &Arc<dyn Inode>) -> Result<bool> {
 }
 
 #[inherit_methods(from = "self")]
-impl InodeIo for OverlayInode {
+impl FileOps for OverlayInode {
     fn read_at(
         &self,
         offset: usize,
@@ -958,6 +958,7 @@ impl InodeIo for OverlayInode {
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize>;
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize>;
 }
 
 #[inherit_methods(from = "self")]
@@ -987,8 +988,7 @@ impl Inode for OverlayInode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>>;
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize>;
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()>;
     fn unlink(&self, name: &str) -> Result<()>;
     fn rmdir(&self, name: &str) -> Result<()>;

--- a/kernel/src/fs/fs_impls/procfs/cmdline.rs
+++ b/kernel/src/fs/fs_impls/procfs/cmdline.rs
@@ -11,7 +11,7 @@ use ostd::boot::boot_info;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -29,7 +29,7 @@ impl CmdLineFileOps {
     }
 }
 
-impl FileOps for CmdLineFileOps {
+impl ProcFileOps for CmdLineFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/cpuinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/cpuinfo.rs
@@ -17,7 +17,7 @@ use crate::{
     arch::cpu::CpuInformation,
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -35,7 +35,7 @@ impl CpuInfoFileOps {
     }
 }
 
-impl FileOps for CpuInfoFileOps {
+impl ProcFileOps for CpuInfoFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/filesystems.rs
+++ b/kernel/src/fs/fs_impls/procfs/filesystems.rs
@@ -5,7 +5,7 @@ use aster_util::printer::{VmPrinter, VmPrinterError};
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::{inode::Inode, registry::FsProperties},
     },
     prelude::*,
@@ -23,7 +23,7 @@ impl FileSystemsFileOps {
     }
 }
 
-impl FileOps for FileSystemsFileOps {
+impl ProcFileOps for FileSystemsFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/loadavg.rs
+++ b/kernel/src/fs/fs_impls/procfs/loadavg.rs
@@ -10,7 +10,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -30,7 +30,7 @@ impl LoadAvgFileOps {
     }
 }
 
-impl FileOps for LoadAvgFileOps {
+impl ProcFileOps for LoadAvgFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/meminfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/meminfo.rs
@@ -11,7 +11,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -29,7 +29,7 @@ impl MemInfoFileOps {
     }
 }
 
-impl FileOps for MemInfoFileOps {
+impl ProcFileOps for MemInfoFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -3,7 +3,7 @@
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use template::{
-    DirOps, ListedEntry, ProcDir, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
+    ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
     listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
     visit_readdir_entries,
 };
@@ -172,7 +172,7 @@ impl RootDirOps {
     ];
 }
 
-impl DirOps for RootDirOps {
+impl ProcDirOps for RootDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Ok(pid) = name.parse::<Pid>() {
             let pid_entry = {

--- a/kernel/src/fs/fs_impls/procfs/mounts.rs
+++ b/kernel/src/fs/fs_impls/procfs/mounts.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{ProcSym, SymOps},
+        procfs::template::{ProcSym, ProcSymOps},
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
@@ -21,7 +21,7 @@ impl MountsSymOps {
     }
 }
 
-impl SymOps for MountsSymOps {
+impl ProcSymOps for MountsSymOps {
     fn read_link(&self) -> Result<SymbolicLink> {
         Ok(SymbolicLink::Plain("self/mounts".to_string()))
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/mod.rs
@@ -3,7 +3,7 @@
 use super::{
     StaticEntryWithOps,
     template::{
-        DirOps, ProcDir, ReaddirEntry, listed_entries_from_table, lookup_child_from_table,
+        ProcDir, ProcDirOps, ReaddirEntry, listed_entries_from_table, lookup_child_from_table,
         visit_listed_entries,
     },
 };
@@ -54,7 +54,7 @@ impl PidDirOps {
     ];
 }
 
-impl DirOps for PidDirOps {
+impl ProcDirOps for PidDirOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/auxv.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -21,7 +21,7 @@ impl AuxvFileOps {
     }
 }
 
-impl FileOps for AuxvFileOps {
+impl ProcFileOps for AuxvFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cgroup.rs
@@ -9,7 +9,7 @@ use crate::{
         file::mkmod,
         procfs::{
             pid::TidDirOps,
-            template::{FileOps, ProcFile},
+            template::{ProcFile, ProcFileOps},
         },
         vfs::inode::Inode,
     },
@@ -27,7 +27,7 @@ impl CgroupFileOps {
     }
 }
 
-impl FileOps for CgroupFileOps {
+impl ProcFileOps for CgroupFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cmdline.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -21,7 +21,7 @@ impl CmdlineFileOps {
     }
 }
 
-impl FileOps for CmdlineFileOps {
+impl ProcFileOps for CmdlineFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -21,7 +21,7 @@ impl CommFileOps {
     }
 }
 
-impl FileOps for CommFileOps {
+impl ProcFileOps for CommFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/environ.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -21,7 +21,7 @@ impl EnvironFileOps {
     }
 }
 
-impl FileOps for EnvironFileOps {
+impl ProcFileOps for EnvironFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/exe.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{ProcSym, SymOps},
+        procfs::template::{ProcSym, ProcSymOps},
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
@@ -23,7 +23,7 @@ impl ExeSymOps {
     }
 }
 
-impl SymOps for ExeSymOps {
+impl ProcSymOps for ExeSymOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
@@ -13,7 +13,7 @@ use crate::{
             mkmod,
         },
         procfs::template::{
-            DirOps, FileOps, ListedEntry, ProcDir, ProcFile, ProcSym, ReaddirEntry, SymOps,
+            DirOps, ListedEntry, ProcDir, ProcFile, ProcFileOps, ProcSym, ReaddirEntry, SymOps,
             keyed_readdir_entries, visit_readdir_entries,
         },
         vfs::inode::{Inode, RevalidationPolicy, SymbolicLink},
@@ -296,7 +296,7 @@ impl FdOps for FileInfoOps {
     }
 }
 
-impl FileOps for FileInfoOps {
+impl ProcFileOps for FileInfoOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.tid_dir_ops.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/fd.rs
@@ -13,8 +13,8 @@ use crate::{
             mkmod,
         },
         procfs::template::{
-            DirOps, ListedEntry, ProcDir, ProcFile, ProcFileOps, ProcSym, ReaddirEntry, SymOps,
-            keyed_readdir_entries, visit_readdir_entries,
+            ListedEntry, ProcDir, ProcDirOps, ProcFile, ProcFileOps, ProcSym, ProcSymOps,
+            ReaddirEntry, keyed_readdir_entries, visit_readdir_entries,
         },
         vfs::inode::{Inode, RevalidationPolicy, SymbolicLink},
     },
@@ -43,7 +43,7 @@ impl<T: FdOps> FdDirOps<T> {
     }
 }
 
-impl<T: FdOps> DirOps for FdDirOps<T> {
+impl<T: FdOps> ProcDirOps for FdDirOps<T> {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.dir.thread()
     }
@@ -229,7 +229,7 @@ impl FdOps for FileSymOps {
     }
 }
 
-impl SymOps for FileSymOps {
+impl ProcSymOps for FileSymOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.tid_dir_ops.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
@@ -6,7 +6,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -24,7 +24,7 @@ impl GidMapFileOps {
     }
 }
 
-impl FileOps for GidMapFileOps {
+impl ProcFileOps for GidMapFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -6,9 +6,9 @@ use super::TidDirOps;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, FileIo, StatusFlags, mkmod},
+        file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
-        vfs::inode::{Inode, InodeIo},
+        vfs::inode::{FileOps, Inode},
     },
     prelude::*,
     process::{
@@ -39,7 +39,7 @@ impl ProcFileOpsByHandle for MapsFileOps {
         &self,
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Result<Box<dyn FileIo>> {
+    ) -> Result<Box<dyn PerOpenFileOps>> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");
         };
@@ -72,7 +72,7 @@ impl Pollable for MapsFileHandle {
     }
 }
 
-impl InodeIo for MapsFileHandle {
+impl FileOps for MapsFileHandle {
     fn read_at(
         &self,
         offset: usize,
@@ -119,7 +119,7 @@ impl InodeIo for MapsFileHandle {
     }
 }
 
-impl FileIo for MapsFileHandle {
+impl PerOpenFileOps for MapsFileHandle {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{AccessMode, FileIo, StatusFlags, mkmod},
-        procfs::template::{FileOpsByHandle, ProcFile},
+        procfs::template::{ProcFile, ProcFileOpsByHandle},
         vfs::inode::{Inode, InodeIo},
     },
     prelude::*,
@@ -30,7 +30,7 @@ impl MapsFileOps {
     }
 }
 
-impl FileOpsByHandle for MapsFileOps {
+impl ProcFileOpsByHandle for MapsFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -5,7 +5,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{AccessMode, FileIo, StatusFlags, mkmod},
-        procfs::template::{FileOpsByHandle, ProcFile},
+        procfs::template::{ProcFile, ProcFileOpsByHandle},
         vfs::inode::{Inode, InodeIo},
     },
     prelude::*,
@@ -27,7 +27,7 @@ impl MemFileOps {
     }
 }
 
-impl FileOpsByHandle for MemFileOps {
+impl ProcFileOpsByHandle for MemFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -4,9 +4,9 @@ use super::TidDirOps;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, FileIo, StatusFlags, mkmod},
+        file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
-        vfs::inode::{Inode, InodeIo},
+        vfs::inode::{FileOps, Inode},
     },
     prelude::*,
     process::{
@@ -36,7 +36,7 @@ impl ProcFileOpsByHandle for MemFileOps {
         &self,
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Result<Box<dyn FileIo>> {
+    ) -> Result<Box<dyn PerOpenFileOps>> {
         let Some(process) = self.0.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");
         };
@@ -69,7 +69,7 @@ impl Pollable for MemFileHandle {
     }
 }
 
-impl InodeIo for MemFileHandle {
+impl FileOps for MemFileHandle {
     fn read_at(
         &self,
         offset: usize,
@@ -125,7 +125,7 @@ impl InodeIo for MemFileHandle {
     }
 }
 
-impl FileIo for MemFileHandle {
+impl PerOpenFileOps for MemFileHandle {
     fn check_seekable(&self) -> Result<()> {
         Ok(())
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -15,7 +15,7 @@ use crate::{
                 status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
-                DirOps, ListedEntry, ProcDir, ReaddirEntry, keyed_readdir_entries,
+                ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
                 listed_entries_from_table, lookup_child_from_table, visit_listed_entries,
                 visit_readdir_entries,
             },
@@ -130,7 +130,7 @@ impl TidDirOps {
     ];
 }
 
-impl DirOps for TidDirOps {
+impl ProcDirOps for TidDirOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.thread()
     }
@@ -183,7 +183,7 @@ impl TidDirOps {
     }
 }
 
-impl DirOps for TaskDirOps {
+impl ProcDirOps for TaskDirOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -6,7 +6,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::{
             file_system::FsFlags,
             inode::Inode,
@@ -151,7 +151,7 @@ impl MountInfoFileOps {
     }
 }
 
-impl FileOps for MountInfoFileOps {
+impl ProcFileOps for MountInfoFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mounts.rs
@@ -8,7 +8,7 @@ use crate::{
         file::mkmod,
         procfs::{
             pid::task::mountinfo::make_mount_point_path,
-            template::{FileOps, ProcFile},
+            template::{ProcFile, ProcFileOps},
         },
         vfs::{
             inode::Inode,
@@ -110,7 +110,7 @@ impl MountsFileOps {
     }
 }
 
-impl FileOps for MountsFileOps {
+impl ProcFileOps for MountsFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountstats.rs
@@ -8,7 +8,7 @@ use crate::{
         file::mkmod,
         procfs::{
             pid::task::mountinfo::make_mount_point_path,
-            template::{FileOps, ProcFile},
+            template::{ProcFile, ProcFileOps},
         },
         vfs::{inode::Inode, path::PathResolver},
     },
@@ -81,7 +81,7 @@ impl MountStatsFileOps {
     }
 }
 
-impl FileOps for MountStatsFileOps {
+impl ProcFileOps for MountStatsFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -9,7 +9,8 @@ use crate::{
         procfs::{
             pid::TidDirOps,
             template::{
-                DirOps, ListedEntry, ProcDir, ProcSym, ReaddirEntry, SymOps, visit_listed_entries,
+                ListedEntry, ProcDir, ProcDirOps, ProcSym, ProcSymOps, ReaddirEntry,
+                visit_listed_entries,
             },
         },
         pseudofs::NsCommonOps,
@@ -135,7 +136,7 @@ fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
     None
 }
 
-impl DirOps for NsDirOps {
+impl ProcDirOps for NsDirOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.dir.thread()
     }
@@ -271,7 +272,7 @@ impl<T: NsCommonOps> NsSymOps<T> {
     }
 }
 
-impl<T: NsCommonOps> SymOps for NsSymOps<T> {
+impl<T: NsCommonOps> ProcSymOps for NsSymOps<T> {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.dir.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
@@ -8,7 +8,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile, read_i32_from},
+        procfs::template::{ProcFile, ProcFileOps, read_i32_from},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -25,7 +25,7 @@ impl OomScoreAdjFileOps {
     }
 }
 
-impl FileOps for OomScoreAdjFileOps {
+impl ProcFileOps for OomScoreAdjFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -8,7 +8,7 @@ use super::{super::PidDirOps, TidDirOps};
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -106,7 +106,7 @@ impl StatFileOps {
     }
 }
 
-impl FileOps for StatFileOps {
+impl ProcFileOps for StatFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.dir.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -6,7 +6,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -73,7 +73,7 @@ impl StatusFileOps {
     }
 }
 
-impl FileOps for StatusFileOps {
+impl ProcFileOps for StatusFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
@@ -6,7 +6,7 @@ use super::TidDirOps;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -24,7 +24,7 @@ impl UidMapFileOps {
     }
 }
 
-impl FileOps for UidMapFileOps {
+impl ProcFileOps for UidMapFileOps {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         self.0.thread()
     }

--- a/kernel/src/fs/fs_impls/procfs/self_.rs
+++ b/kernel/src/fs/fs_impls/procfs/self_.rs
@@ -3,7 +3,7 @@
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{ProcSym, SymOps},
+        procfs::template::{ProcSym, ProcSymOps},
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
@@ -19,7 +19,7 @@ impl SelfSymOps {
     }
 }
 
-impl SymOps for SelfSymOps {
+impl ProcSymOps for SelfSymOps {
     fn read_link(&self) -> Result<SymbolicLink> {
         Ok(SymbolicLink::Plain(current!().pid().to_string()))
     }

--- a/kernel/src/fs/fs_impls/procfs/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/stat.rs
@@ -14,7 +14,7 @@ use ostd::util::id_set::Id;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -143,7 +143,7 @@ impl StatFileOps {
     }
 }
 
-impl FileOps for StatFileOps {
+impl ProcFileOps for StatFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/cap_last_cap.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/cap_last_cap.rs
@@ -5,7 +5,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -22,7 +22,7 @@ impl CapLastCapFileOps {
     }
 }
 
-impl FileOps for CapLastCapFileOps {
+impl ProcFileOps for CapLastCapFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -9,7 +9,7 @@ use crate::{
                 cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
             },
             template::{
-                DirOps, ListedEntry, ReaddirEntry, listed_entries_from_table,
+                ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
                 lookup_child_from_table, visit_listed_entries,
             },
         },
@@ -44,7 +44,7 @@ impl KernelDirOps {
     ];
 }
 
-impl DirOps for KernelDirOps {
+impl ProcDirOps for KernelDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
             (f)(this_dir.this_weak().clone())

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/pid_max.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/pid_max.rs
@@ -5,7 +5,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -22,7 +22,7 @@ impl PidMaxFileOps {
     }
 }
 
-impl FileOps for PidMaxFileOps {
+impl ProcFileOps for PidMaxFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
@@ -8,7 +8,7 @@ use crate::{
         procfs::{
             StaticEntry,
             template::{
-                DirOps, FileOps, ProcDir, ProcFile, ReaddirEntry, listed_entries_from_table,
+                DirOps, ProcDir, ProcFile, ProcFileOps, ReaddirEntry, listed_entries_from_table,
                 lookup_child_from_table, read_i32_from, visit_listed_entries,
             },
         },
@@ -69,7 +69,7 @@ impl PtraceScopeFileOps {
     }
 }
 
-impl FileOps for PtraceScopeFileOps {
+impl ProcFileOps for PtraceScopeFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/yama.rs
@@ -8,8 +8,9 @@ use crate::{
         procfs::{
             StaticEntry,
             template::{
-                DirOps, ProcDir, ProcFile, ProcFileOps, ReaddirEntry, listed_entries_from_table,
-                lookup_child_from_table, read_i32_from, visit_listed_entries,
+                ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, read_i32_from,
+                visit_listed_entries,
             },
         },
         vfs::inode::Inode,
@@ -36,7 +37,7 @@ impl YamaDirOps {
     )];
 }
 
-impl DirOps for YamaDirOps {
+impl ProcDirOps for YamaDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
             (f)(this_dir.this_weak().clone())

--- a/kernel/src/fs/fs_impls/procfs/sys/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/mod.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     fs::{
         file::{InodeType, mkmod},
-        procfs::template::{DirOps, ProcDir, lookup_child_from_table},
+        procfs::template::{ProcDir, ProcDirOps, lookup_child_from_table},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -31,7 +31,7 @@ impl SysDirOps {
         &[("kernel", InodeType::Dir, KernelDirOps::new_inode)];
 }
 
-impl DirOps for SysDirOps {
+impl ProcDirOps for SysDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
             (f)(this_dir.this_weak().clone())

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -15,7 +15,7 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
-            inode::{Extension, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy},
+            inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
             path::{is_dot, is_dotdot},
         },
     },
@@ -29,14 +29,14 @@ use crate::{
 /// `ProcDir` owns the directory implementation object,
 /// tracks parent linkage for `.` and `..`,
 /// and forwards inode methods that are common to all procfs directories.
-pub struct ProcDir<D: DirOps> {
+pub struct ProcDir<D: ProcDirOps> {
     inner: D,
     this: Weak<ProcDir<D>>,
     parent: Option<Weak<dyn Inode>>,
     common: Common,
 }
 
-impl<D: DirOps> ProcDir<D> {
+impl<D: ProcDirOps> ProcDir<D> {
     /// Creates the root procfs directory inode.
     pub fn new_root(
         dir: D,
@@ -91,7 +91,7 @@ impl<D: DirOps> ProcDir<D> {
     }
 }
 
-impl<D: DirOps + 'static> InodeIo for ProcDir<D> {
+impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
     fn read_at(
         &self,
         _offset: usize,
@@ -109,10 +109,50 @@ impl<D: DirOps + 'static> InodeIo for ProcDir<D> {
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
     }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        /// Returns the always-present `.` and `..` entries for a procfs directory.
+        fn special_entries<D: ProcDirOps + 'static>(
+            dir: &ProcDir<D>,
+        ) -> impl Iterator<Item = (&'static str, Arc<dyn Inode>, usize)> {
+            let this_inode: Arc<dyn Inode> = dir.this();
+            let parent_inode = dir.parent().unwrap_or_else(|| this_inode.clone());
+            [(".", this_inode, 1), ("..", parent_inode, 2)].into_iter()
+        }
+
+        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+            for (name, inode, next_offset) in special_entries(self) {
+                if next_offset <= *offset {
+                    continue;
+                }
+
+                visitor.visit(name, inode.ino(), inode.type_(), next_offset)?;
+                *offset = next_offset;
+            }
+
+            self.inner.visit_entries_from_offset(*offset, |child| {
+                visitor.visit(
+                    child.name.as_ref(),
+                    child.ino,
+                    child.type_,
+                    child.next_offset,
+                )?;
+                *offset = child.next_offset;
+                Ok(())
+            })?;
+            Ok(())
+        };
+
+        let mut iterate_offset = offset;
+        match try_readdir(&mut iterate_offset, visitor) {
+            Err(e) if iterate_offset == offset => Err(e),
+            _ => Ok(iterate_offset - offset),
+        }
+    }
 }
 
 #[inherit_methods(from = "self.common")]
-impl<D: DirOps + 'static> Inode for ProcDir<D> {
+impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
     fn size(&self) -> usize;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
@@ -149,46 +189,6 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
 
     fn mknod(&self, _name: &str, _mode: InodeMode, _type_: MknodType) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::EPERM))
-    }
-
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        /// Returns the always-present `.` and `..` entries for a procfs directory.
-        fn special_entries<D: DirOps + 'static>(
-            dir: &ProcDir<D>,
-        ) -> impl Iterator<Item = (&'static str, Arc<dyn Inode>, usize)> {
-            let this_inode: Arc<dyn Inode> = dir.this();
-            let parent_inode = dir.parent().unwrap_or_else(|| this_inode.clone());
-            [(".", this_inode, 1), ("..", parent_inode, 2)].into_iter()
-        }
-
-        let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
-            for (name, inode, next_offset) in special_entries(self) {
-                if next_offset <= *offset {
-                    continue;
-                }
-
-                visitor.visit(name, inode.ino(), inode.type_(), next_offset)?;
-                *offset = next_offset;
-            }
-
-            self.inner.visit_entries_from_offset(*offset, |child| {
-                visitor.visit(
-                    child.name.as_ref(),
-                    child.ino,
-                    child.type_,
-                    child.next_offset,
-                )?;
-                *offset = child.next_offset;
-                Ok(())
-            })?;
-            Ok(())
-        };
-
-        let mut iterate_offset = offset;
-        match try_readdir(&mut iterate_offset, visitor) {
-            Err(e) if iterate_offset == offset => Err(e),
-            _ => Ok(iterate_offset - offset),
-        }
     }
 
     fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
@@ -236,7 +236,7 @@ impl<D: DirOps + 'static> Inode for ProcDir<D> {
     }
 }
 
-pub trait DirOps: Sync + Send + Sized {
+pub trait ProcDirOps: Sync + Send + Sized {
     /// Returns the thread whose credentials own this procfs inode.
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         None
@@ -291,7 +291,7 @@ pub trait DirOps: Sync + Send + Sized {
 /// A statically declared procfs child entry.
 ///
 /// The tuple stores the exported filename,
-/// the inode type reported to [`Inode::readdir_at`],
+/// the inode type reported to [`FileOps::readdir_at`],
 /// and the constructor used by lookup paths to instantiate the inode.
 pub type StaticDirEntry<Fp> = (&'static str, InodeType, Fp);
 
@@ -335,7 +335,7 @@ mod readdir {
     //!
     //! # Vocabulary
     //!
-    //! - **Offset** - the cursor passed to `Inode::readdir_at`. Maps to
+    //! - **Offset** - the cursor passed to `FileOps::readdir_at`. Maps to
     //!   `dirent::d_off`. Offsets `1` and `2` are reserved for `.` and `..`.
     //!
     //! - **Key** - an integer that uniquely identifies one dynamic child
@@ -377,10 +377,10 @@ mod readdir {
         }
     }
 
-    /// A directory entry emitted by [`DirOps::visit_entries_from_offset`].
+    /// A directory entry emitted by [`ProcDirOps::visit_entries_from_offset`].
     ///
     /// The `next_offset` is the continuation offset that should be used as the
-    /// starting point of the next [`Inode::readdir_at`] call.
+    /// starting point of the next [`FileOps::readdir_at`] call.
     pub struct ReaddirEntry<'a> {
         pub(super) name: Cow<'a, str>,
         pub(super) ino: u64,
@@ -407,7 +407,7 @@ mod readdir {
 
     /// A placeholder inode number for procfs entries.
     ///
-    /// [`Inode::readdir_at`] reports procfs entries without instantiating child inodes first,
+    /// [`FileOps::readdir_at`] reports procfs entries without instantiating child inodes first,
     /// so the inode number returned here is only a placeholder.
     /// Lookup still creates the real child inode on demand when the path is opened.
     //

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -19,12 +19,12 @@ use crate::{
     thread::Thread,
 };
 
-pub struct ProcFile<F: FileOps> {
+pub struct ProcFile<F: ProcFileOps> {
     inner: F,
     common: Common,
 }
 
-impl<F: FileOps> ProcFile<F> {
+impl<F: ProcFileOps> ProcFile<F> {
     pub fn new(file: F, parent: Weak<dyn Inode>, mode: InodeMode) -> Arc<Self> {
         let common = {
             let fs = parent.upgrade().unwrap().fs();
@@ -48,7 +48,7 @@ impl<F: FileOps> ProcFile<F> {
     }
 }
 
-impl<F: FileOps + 'static> InodeIo for ProcFile<F> {
+impl<F: ProcFileOps + 'static> InodeIo for ProcFile<F> {
     fn read_at(
         &self,
         offset: usize,
@@ -69,7 +69,7 @@ impl<F: FileOps + 'static> InodeIo for ProcFile<F> {
 }
 
 #[inherit_methods(from = "self.common")]
-impl<F: FileOps + 'static> Inode for ProcFile<F> {
+impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
     fn size(&self) -> usize;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
@@ -123,7 +123,7 @@ impl<F: FileOps + 'static> Inode for ProcFile<F> {
     }
 }
 
-pub trait FileOps: Sync + Send {
+pub trait ProcFileOps: Sync + Send {
     /// Returns the thread whose credentials own this procfs inode.
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         None
@@ -144,7 +144,7 @@ pub trait FileOps: Sync + Send {
     }
 }
 
-pub trait FileOpsByHandle: Sync + Send {
+pub trait ProcFileOpsByHandle: Sync + Send {
     /// Returns the thread whose credentials own this procfs inode.
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         None
@@ -153,9 +153,9 @@ pub trait FileOpsByHandle: Sync + Send {
     fn open(&self, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Box<dyn FileIo>>;
 }
 
-impl<T: FileOpsByHandle> FileOps for T {
+impl<T: ProcFileOpsByHandle> ProcFileOps for T {
     fn owner_thread(&self) -> Option<Arc<Thread>> {
-        FileOpsByHandle::owner_thread(self)
+        ProcFileOpsByHandle::owner_thread(self)
     }
 
     fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -7,11 +7,11 @@ use inherit_methods_macro::inherit_methods;
 use super::Common;
 use crate::{
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, InodeIo, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
         },
     },
     prelude::*,
@@ -48,7 +48,7 @@ impl<F: ProcFileOps> ProcFile<F> {
     }
 }
 
-impl<F: ProcFileOps + 'static> InodeIo for ProcFile<F> {
+impl<F: ProcFileOps + 'static> FileOps for ProcFile<F> {
     fn read_at(
         &self,
         offset: usize,
@@ -118,7 +118,7 @@ impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         self.inner.open(access_mode, status_flags)
     }
 }
@@ -139,7 +139,7 @@ pub trait ProcFileOps: Sync + Send {
         &self,
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         None
     }
 }
@@ -150,7 +150,11 @@ pub trait ProcFileOpsByHandle: Sync + Send {
         None
     }
 
-    fn open(&self, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Box<dyn FileIo>>;
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Result<Box<dyn PerOpenFileOps>>;
 }
 
 impl<T: ProcFileOpsByHandle> ProcFileOps for T {
@@ -170,7 +174,7 @@ impl<T: ProcFileOpsByHandle> ProcFileOps for T {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         Some(self.open(access_mode, status_flags))
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/mod.rs
@@ -4,12 +4,12 @@ use core::time::Duration;
 
 pub(super) use self::{
     dir::{
-        DirOps, ListedEntry, ProcDir, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
+        ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
         listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
         visit_listed_entries, visit_readdir_entries,
     },
     file::{ProcFile, ProcFileOps, ProcFileOpsByHandle, read_i32_from},
-    sym::{ProcSym, SymOps},
+    sym::{ProcSym, ProcSymOps},
 };
 use crate::{
     fs::{

--- a/kernel/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/mod.rs
@@ -8,7 +8,7 @@ pub(super) use self::{
         listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
         visit_listed_entries, visit_readdir_entries,
     },
-    file::{FileOps, FileOpsByHandle, ProcFile, read_i32_from},
+    file::{ProcFile, ProcFileOps, ProcFileOpsByHandle, read_i32_from},
     sym::{ProcSym, SymOps},
 };
 use crate::{

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -11,7 +11,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, InodeIo, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
         },
     },
     prelude::*,
@@ -19,12 +19,12 @@ use crate::{
     thread::Thread,
 };
 
-pub struct ProcSym<S: SymOps> {
+pub struct ProcSym<S: ProcSymOps> {
     inner: S,
     common: Common,
 }
 
-impl<S: SymOps> ProcSym<S> {
+impl<S: ProcSymOps> ProcSym<S> {
     pub fn new(sym: S, parent: Weak<dyn Inode>, mode: InodeMode) -> Arc<Self> {
         let common = {
             let fs = parent.upgrade().unwrap().fs();
@@ -45,7 +45,7 @@ impl<S: SymOps> ProcSym<S> {
     }
 }
 
-impl<S: SymOps + 'static> InodeIo for ProcSym<S> {
+impl<S: ProcSymOps + 'static> FileOps for ProcSym<S> {
     fn read_at(
         &self,
         _offset: usize,
@@ -66,7 +66,7 @@ impl<S: SymOps + 'static> InodeIo for ProcSym<S> {
 }
 
 #[inherit_methods(from = "self.common")]
-impl<S: SymOps + 'static> Inode for ProcSym<S> {
+impl<S: ProcSymOps + 'static> Inode for ProcSym<S> {
     fn size(&self) -> usize;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
@@ -106,7 +106,7 @@ impl<S: SymOps + 'static> Inode for ProcSym<S> {
     }
 }
 
-pub trait SymOps: Sync + Send {
+pub trait ProcSymOps: Sync + Send {
     /// Returns the thread whose credentials own this procfs inode.
     fn owner_thread(&self) -> Option<Arc<Thread>> {
         None

--- a/kernel/src/fs/fs_impls/procfs/thread_self.rs
+++ b/kernel/src/fs/fs_impls/procfs/thread_self.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{ProcSym, SymOps},
+        procfs::template::{ProcSym, ProcSymOps},
         vfs::inode::{Inode, SymbolicLink},
     },
     prelude::*,
@@ -22,7 +22,7 @@ impl ThreadSelfSymOps {
     }
 }
 
-impl SymOps for ThreadSelfSymOps {
+impl ProcSymOps for ThreadSelfSymOps {
     fn read_link(&self) -> Result<SymbolicLink> {
         let pid = current!().pid();
         let tid = current_thread!().as_posix_thread().unwrap().tid();

--- a/kernel/src/fs/fs_impls/procfs/uptime.rs
+++ b/kernel/src/fs/fs_impls/procfs/uptime.rs
@@ -10,7 +10,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     prelude::*,
@@ -43,7 +43,7 @@ impl UptimeFileOps {
     }
 }
 
-impl FileOps for UptimeFileOps {
+impl ProcFileOps for UptimeFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/procfs/version.rs
+++ b/kernel/src/fs/fs_impls/procfs/version.rs
@@ -10,7 +10,7 @@ use aster_util::printer::VmPrinter;
 use crate::{
     fs::{
         file::mkmod,
-        procfs::template::{FileOps, ProcFile},
+        procfs::template::{ProcFile, ProcFileOps},
         vfs::inode::Inode,
     },
     net::uts_ns::UtsName,
@@ -29,7 +29,7 @@ impl VersionFileOps {
     }
 }
 
-impl FileOps for VersionFileOps {
+impl ProcFileOps for VersionFileOps {
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -39,11 +39,11 @@ use spin::Once;
 
 use crate::{
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, Inode, InodeIo, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata},
         },
     },
     prelude::*,
@@ -235,7 +235,7 @@ impl PseudoInode {
     }
 }
 
-impl InodeIo for PseudoInode {
+impl FileOps for PseudoInode {
     fn read_at(
         &self,
         _offset: usize,
@@ -354,7 +354,7 @@ impl Inode for PseudoInode {
         &self,
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         Some(Err(Error::with_message(
             Errno::ENXIO,
             "the pseudo inode is not re-openable",

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -11,14 +11,14 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, FileIo, InodeHandle, InodeMode, InodeType, StatusFlags,
+            AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, StatusFlags,
             file_table::{FdFlags, FileDesc},
             mkmod,
         },
         pseudofs::{NaivePseudoFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, InodeIo, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata},
             path::{Dentry, Mount, Path},
         },
     },
@@ -126,7 +126,7 @@ impl<T: NsCommonOps> Inode for NsInode<T> {
         &self,
         access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         // FIXME: This may not be the most appropriate place to check the access mode,
         // but the check must not be bypassed even if the current process has the
         // CAP_DAC_OVERRIDE capability. It is hard to find a better place for it,
@@ -141,7 +141,7 @@ impl<T: NsCommonOps> Inode for NsInode<T> {
         let ns_file = NsFile {
             ns: self.ns.clone(),
         };
-        Some(Ok(Box::new(ns_file) as Box<dyn FileIo>))
+        Some(Ok(Box::new(ns_file) as Box<dyn PerOpenFileOps>))
     }
 
     fn set_mode(&self, _mode: InodeMode) -> Result<()> {
@@ -150,7 +150,7 @@ impl<T: NsCommonOps> Inode for NsInode<T> {
 }
 
 #[inherit_methods(from = "self.common")]
-impl<T: NsCommonOps> InodeIo for NsInode<T> {
+impl<T: NsCommonOps> FileOps for NsInode<T> {
     fn read_at(
         &self,
         _offset: usize,
@@ -177,7 +177,7 @@ impl<T: NsCommonOps> NsFile<T> {
     }
 }
 
-impl<T: NsCommonOps> FileIo for NsFile<T> {
+impl<T: NsCommonOps> PerOpenFileOps for NsFile<T> {
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "ns files are not seekable");
     }
@@ -246,7 +246,7 @@ impl<T: NsCommonOps> Pollable for NsFile<T> {
     }
 }
 
-impl<T: NsCommonOps> InodeIo for NsFile<T> {
+impl<T: NsCommonOps> FileOps for NsFile<T> {
     fn read_at(
         &self,
         _offset: usize,

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -19,14 +19,14 @@ use super::{memfd::MemfdInode, xattr::RamXattr, *};
 use crate::{
     device::{self, DeviceType},
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, Permission, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags, mkmod},
         pipe::Pipe,
         pseudofs::AnonDeviceId,
         tmpfs::{self, TMPFS_MAGIC},
         utils::{CStr256, DirentVisitor},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, SymbolicLink},
+            inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
@@ -252,7 +252,7 @@ impl Inner {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         match self {
             Self::BlockDevice(device_id) | Self::CharDevice(device_id) => {
                 let Some(device_id) = DeviceId::from_encoded_u64(*device_id) else {
@@ -628,7 +628,7 @@ impl RamInode {
     }
 }
 
-impl InodeIo for RamInode {
+impl FileOps for RamInode {
     fn read_at(
         &self,
         offset: usize,
@@ -691,6 +691,23 @@ impl InodeIo for RamInode {
             _ => return_errno_with_message!(Errno::EISDIR, "write is not supported"),
         };
         Ok(written_len)
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        if self.typ != InodeType::Dir {
+            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
+        }
+
+        let cnt = self
+            .inner
+            .as_direntry()
+            .unwrap()
+            .read()
+            .visit_entry(offset, visitor)?;
+
+        self.set_atime(now());
+
+        Ok(cnt)
     }
 }
 
@@ -846,7 +863,7 @@ impl Inode for RamInode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         self.inner.open(access_mode, status_flags)
     }
 
@@ -892,23 +909,6 @@ impl Inode for RamInode {
         }
 
         Ok(new_inode)
-    }
-
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-
-        let cnt = self
-            .inner
-            .as_direntry()
-            .unwrap()
-            .read()
-            .visit_entry(offset, visitor)?;
-
-        self.set_atime(now());
-
-        Ok(cnt)
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -17,7 +17,7 @@ use crate::{
         tmpfs::TmpFs,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FallocMode, Inode, InodeIo, Metadata},
+            inode::{Extension, FallocMode, FileOps, Inode, Metadata},
             path::{Mount, Path},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -96,7 +96,7 @@ impl MemfdInode {
 }
 
 #[inherit_methods(from = "self.inode")]
-impl InodeIo for MemfdInode {
+impl FileOps for MemfdInode {
     fn read_at(
         &self,
         offset: usize,

--- a/kernel/src/fs/pipe/anon_pipe.rs
+++ b/kernel/src/fs/pipe/anon_pipe.rs
@@ -6,12 +6,12 @@ use inherit_methods_macro::inherit_methods;
 
 use crate::{
     fs::{
-        file::{AccessMode, FileIo, InodeHandle, InodeMode, InodeType, StatusFlags, mkmod},
+        file::{AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         pipe::Pipe,
         pseudofs::{PipeFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, InodeIo, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata},
         },
     },
     prelude::*,
@@ -59,7 +59,7 @@ impl AnonPipeInode {
 }
 
 #[inherit_methods(from = "self.pseudo_inode")]
-impl InodeIo for AnonPipeInode {
+impl FileOps for AnonPipeInode {
     fn read_at(
         &self,
         _offset: usize,
@@ -100,7 +100,7 @@ impl Inode for AnonPipeInode {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         Some(self.pipe.open_anon(access_mode, status_flags))
     }
 }

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -10,9 +10,9 @@ use ostd::sync::WaitQueue;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, FileIo, StatusFlags},
+        file::{AccessMode, PerOpenFileOps, StatusFlags},
         utils::{Endpoint, EndpointState},
-        vfs::inode::InodeIo,
+        vfs::inode::FileOps,
     },
     prelude::*,
     process::{
@@ -29,7 +29,7 @@ use crate::{
     },
 };
 
-/// A handle for a pipe that implements `FileIo`.
+/// A handle for a pipe that implements `PerOpenFileOps`.
 ///
 /// Once a handle for a `Pipe` exists, the corresponding pipe object will
 /// not be dropped.
@@ -44,14 +44,14 @@ impl PipeHandle {
     }
 
     fn try_read(&self, writer: &mut VmWriter) -> Result<usize> {
-        // `InodeHandle` checks the access mode before calling methods in `FileIo`.
+        // `InodeHandle` checks the access mode before calling methods in `PerOpenFileOps`.
         debug_assert!(self.access_mode.is_readable());
 
         self.inner.reader.try_read(writer)
     }
 
     fn try_write(&self, reader: &mut VmReader) -> Result<usize> {
-        // `InodeHandle` checks the access mode before calling methods in `FileIo`.
+        // `InodeHandle` checks the access mode before calling methods in `PerOpenFileOps`.
         debug_assert!(self.access_mode.is_writable());
 
         self.inner.writer.try_write(reader)
@@ -96,7 +96,7 @@ impl Drop for PipeHandle {
     }
 }
 
-impl InodeIo for PipeHandle {
+impl FileOps for PipeHandle {
     fn read_at(
         &self,
         _offset: usize,
@@ -136,7 +136,7 @@ impl InodeIo for PipeHandle {
     }
 }
 
-impl FileIo for PipeHandle {
+impl PerOpenFileOps for PipeHandle {
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is a FIFO file")
     }
@@ -184,7 +184,7 @@ impl Pipe {
 
     /// Opens the named pipe with the specified access mode and status flags.
     ///
-    /// Returns a handle that implements `FileIo` for performing I/O operations.
+    /// Returns a handle that implements `PerOpenFileOps` for performing I/O operations.
     ///
     /// The open behavior follows POSIX semantics:
     /// - Opening for read-only blocks until a writer opens the pipe.
@@ -197,7 +197,7 @@ impl Pipe {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Result<Box<dyn FileIo>> {
+    ) -> Result<Box<dyn PerOpenFileOps>> {
         self.open_handle(access_mode, status_flags, true)
     }
 
@@ -206,7 +206,7 @@ impl Pipe {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Result<Box<dyn FileIo>> {
+    ) -> Result<Box<dyn PerOpenFileOps>> {
         self.open_handle(access_mode, status_flags, false)
     }
 
@@ -216,7 +216,7 @@ impl Pipe {
         access_mode: AccessMode,
         status_flags: StatusFlags,
         is_named_pipe: bool,
-    ) -> Result<Box<dyn FileIo>> {
+    ) -> Result<Box<dyn PerOpenFileOps>> {
         check_status_flags(status_flags)?;
 
         let mut pipe = self.pipe.lock();
@@ -519,8 +519,8 @@ mod test {
 
     fn test_blocking<W, R>(write: W, read: R, ordering: Ordering)
     where
-        W: FnOnce(Box<dyn FileIo>) + Send + 'static,
-        R: FnOnce(Box<dyn FileIo>) + Send + 'static,
+        W: FnOnce(Box<dyn PerOpenFileOps>) + Send + 'static,
+        R: FnOnce(Box<dyn PerOpenFileOps>) + Send + 'static,
     {
         let pipe = Pipe::new();
         let reader = pipe
@@ -641,7 +641,7 @@ mod test {
         );
     }
 
-    fn read(reader: &dyn FileIo, buf: &mut [u8]) -> crate::prelude::Result<usize> {
+    fn read(reader: &dyn PerOpenFileOps, buf: &mut [u8]) -> crate::prelude::Result<usize> {
         reader.read_at(
             0,
             &mut VmWriter::from(buf).to_fallible(),
@@ -649,7 +649,7 @@ mod test {
         )
     }
 
-    fn write(writer: &dyn FileIo, buf: &[u8]) -> crate::prelude::Result<usize> {
+    fn write(writer: &dyn PerOpenFileOps, buf: &[u8]) -> crate::prelude::Result<usize> {
         writer.write_at(
             0,
             &mut VmReader::from(buf).to_fallible(),

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -9,12 +9,12 @@ use aster_systree::{
 
 use crate::{
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{
-                Extension, FallocMode, Inode, InodeIo, Metadata, MknodType, RevalidationPolicy,
+                Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RevalidationPolicy,
                 SymbolicLink,
             },
         },
@@ -311,7 +311,7 @@ pub(in crate::fs) enum SysTreeNodeKind {
     Symlink(Arc<dyn SysSymlink>),
 }
 
-impl<KInode: SysTreeInodeTy + Send + Sync + 'static> InodeIo for KInode {
+impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
     default fn read_at(
         &self,
         offset: usize,
@@ -344,6 +344,70 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> InodeIo for KInode {
         };
 
         Ok(len)
+    }
+
+    default fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        // Why interpreting the `offset` argument as an inode number?
+        //
+        // It may take multiple `getdents` system calls
+        // -- and thus multiple calls to this method --
+        // to list a large directory when the syscall is provided a small buffer.
+        // Between these calls,
+        // the directory may have new entries added or existing ones removed
+        // by some concurrent users that are working on the directory.
+        // In such situations,
+        // missing some of the concurrently-added entries is inevitable,
+        // but reporting the same entry multiple times would be
+        // very confusing to the user.
+        //
+        // To address this issue,
+        // the `readdir_at` method reports entries starting from a user-given `offset`
+        // and returns an increment that the next call should be put on the `offset` argument
+        // to avoid getting duplicated entries.
+        //
+        // Different file systems may interpret the meaning of
+        // the `offset` argument differently:
+        // one may take it as a _byte_ offset,
+        // while the other may treat it as an _index_.
+        // This freedom is guaranteed by Linux as documented in
+        // [the man page of getdents](https://man7.org/linux/man-pages/man2/getdents.2.html).
+        //
+        // Our implementation of sysfs interprets the `offset`
+        // as an _inode number_.
+        // By inode numbers, directory entries will have a _stable_ order
+        // across different calls to `readdir_at`.
+        // The `new_dentry_iter` is responsible for filtering out entries
+        // with inode numbers less than `start_ino`.
+        let start_ino = offset as Ino;
+        let mut count = 0;
+        let mut last_ino = start_ino;
+
+        let dentries = {
+            let mut dentries: Vec<_> = self.new_dentry_iter(start_ino).collect();
+            dentries.sort_by_key(|d| d.ino);
+            dentries
+        };
+
+        for dentry in dentries {
+            let res = visitor.visit(&dentry.name, dentry.ino, dentry.type_, dentry.ino as usize);
+
+            if res.is_err() {
+                if count == 0 {
+                    return_errno_with_message!(Errno::EINVAL, "dirent visitor error");
+                } else {
+                    break;
+                }
+            }
+            count += 1;
+            last_ino = dentry.ino;
+        }
+
+        if count == 0 {
+            return Ok(0);
+        }
+
+        let next_ino = last_ino + 1;
+        Ok((next_ino - start_ino) as usize)
     }
 }
 
@@ -517,70 +581,6 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         }
     }
 
-    default fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        // Why interpreting the `offset` argument as an inode number?
-        //
-        // It may take multiple `getdents` system calls
-        // -- and thus multiple calls to this method --
-        // to list a large directory when the syscall is provided a small buffer.
-        // Between these calls,
-        // the directory may have new entries added or existing ones removed
-        // by some concurrent users that are working on the directory.
-        // In such situations,
-        // missing some of the concurrently-added entries is inevitable,
-        // but reporting the same entry multiple times would be
-        // very confusing to the user.
-        //
-        // To address this issue,
-        // the `readdir_at` method reports entries starting from a user-given `offset`
-        // and returns an increment that the next call should be put on the `offset` argument
-        // to avoid getting duplicated entries.
-        //
-        // Different file systems may interpret the meaning of
-        // the `offset` argument differently:
-        // one may take it as a _byte_ offset,
-        // while the other may treat it as an _index_.
-        // This freedom is guaranteed by Linux as documented in
-        // [the man page of getdents](https://man7.org/linux/man-pages/man2/getdents.2.html).
-        //
-        // Our implementation of sysfs interprets the `offset`
-        // as an _inode number_.
-        // By inode numbers, directory entries will have a _stable_ order
-        // across different calls to `readdir_at`.
-        // The `new_dentry_iter` is responsible for filtering out entries
-        // with inode numbers less than `start_ino`.
-        let start_ino = offset as Ino;
-        let mut count = 0;
-        let mut last_ino = start_ino;
-
-        let dentries = {
-            let mut dentries: Vec<_> = self.new_dentry_iter(start_ino).collect();
-            dentries.sort_by_key(|d| d.ino);
-            dentries
-        };
-
-        for dentry in dentries {
-            let res = visitor.visit(&dentry.name, dentry.ino, dentry.type_, dentry.ino as usize);
-
-            if res.is_err() {
-                if count == 0 {
-                    return_errno_with_message!(Errno::EINVAL, "dirent visitor error");
-                } else {
-                    break;
-                }
-            }
-            count += 1;
-            last_ino = dentry.ino;
-        }
-
-        if count == 0 {
-            return Ok(0);
-        }
-
-        let next_ino = last_ino + 1;
-        Ok((next_ino - start_ino) as usize)
-    }
-
     default fn read_link(&self) -> Result<SymbolicLink> {
         match &self.node_kind() {
             SysTreeNodeKind::Symlink(s) => Ok(SymbolicLink::Plain(s.target_path().to_string())),
@@ -596,7 +596,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         &self,
         _access_mode: AccessMode,
         _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         None
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -17,7 +17,7 @@ use super::{
 use crate::{
     device::{Device, DeviceType},
     fs::{
-        file::{AccessMode, FileIo, InodeMode, InodeType, Permission, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags},
         utils::DirentVisitor,
         vfs::path::Path,
     },
@@ -294,11 +294,12 @@ bitflags! {
     }
 }
 
-/// I/O operations in an [`Inode`].
+/// Provides basic file operations.
 ///
-/// This abstracts the common I/O operations used by both [`Inode`] (for regular files) and
-/// [`FileIo`] (for special files).
-pub trait InodeIo {
+/// For inode-backed files without per-`open()` state, [`Inode`] implements this
+/// trait directly. For files whose behavior depends on state created by `open`,
+/// the per-`open()` object implements this trait through [`PerOpenFileOps`].
+pub trait FileOps {
     /// Reads data from the file into the given `VmWriter`.
     fn read_at(
         &self,
@@ -314,9 +315,14 @@ pub trait InodeIo {
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize>;
+
+    /// Reads directory entries from the given offset.
+    fn readdir_at(&self, _offset: usize, _visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        return_errno_with_message!(Errno::ENOTDIR, "readdir is not supported");
+    }
 }
 
-pub trait Inode: Any + InodeIo + Send + Sync {
+pub trait Inode: Any + FileOps + Send + Sync {
     fn size(&self) -> usize;
 
     fn resize(&self, new_size: usize) -> Result<()>;
@@ -367,12 +373,8 @@ pub trait Inode: Any + InodeIo + Send + Sync {
         &self,
         access_mode: AccessMode,
         status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn FileIo>>> {
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
         None
-    }
-
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        Err(Error::new(Errno::ENOTDIR))
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -157,7 +157,7 @@ fn try_apply_ns_from_inode<T: NsCommonOps>(
     flags: CloneFlags,
     apply: impl FnOnce(Arc<T>) -> Result<()>,
 ) -> Result<bool> {
-    let Some(ns_file) = inode_handle.downcast_file_io::<NsFile<T>>()? else {
+    let Some(ns_file) = inode_handle.downcast_open_file::<NsFile<T>>()? else {
         return Ok(false);
     };
 


### PR DESCRIPTION
Fixes #3071.

The current implementation in Asterinas delegates specific file operations (like seek/readdir) down to the Inode layer (via InodeHandle).

The Problem: 
- Many FUSE operations require a File Handle (fh), which is stored in the `file->private_data` in Linux. 

Maybe we should delegates those file opeartions to `FileIo`(which is renamed to `OpenFileOps` in this PR) for special files.

See https://github.com/asterinas/asterinas/issues/3071 for details

