### PR TITLE
Add QEMU test for virtualization applications

### DIFF
--- a/book/src/distro/popular-applications/containerization-and-virtualization/README.md
+++ b/book/src/distro/popular-applications/containerization-and-virtualization/README.md
@@ -80,3 +80,73 @@ skopeo inspect docker://docker.io/library/alpine:latest
 # List all tags for a repository
 skopeo list-tags docker://docker.io/library/alpine
 ```
+
+## Virtualization
+
+### QEMU
+
+[QEMU](https://www.qemu.org/) is the most widely used open-source machine emulator and virtualizer. It supports full system emulation as well as user-mode binary translation.
+
+Asterinas does not yet support hardware-assisted virtualization (KVM), therefore QEMU runs exclusively with **TCG** (Tiny Code Generator / software emulation) on Asterinas NixOS.
+
+#### Installation
+
+```nix
+environment.systemPackages = with pkgs; [ qemu_kvm ];
+
+environment.variables = {
+  LINUX_BZIMAGE = "${pkgs.linuxPackages.kernel}/bzImage";
+  OVMF_PATH = "${pkgs.OVMF.fd}/FV/OVMF.fd";
+};
+```
+
+#### Environment Variables
+
+The following environment variables are automatically provided **when building the NixOS test suite**:
+
+- `LINUX_BZIMAGE`: Path to the standard Linux kernel bzImage
+- `OVMF_PATH`: Path to the OVMF (UEFI) firmware
+
+You can enable them by building with:
+
+```bash
+make nixos NIXOS_TEST_SUITE=containerization-and-virtualization
+```
+
+#### Verified Usage
+
+##### Display QEMU version
+
+```bash
+qemu-system-$(uname -m) --version
+```
+
+##### Run Linux kernel with TCG
+
+```bash
+qemu-system-$(uname -m) \
+  -accel tcg \
+  -kernel $LINUX_BZIMAGE \
+  -nographic -no-reboot \
+  -append 'console=ttyS0 panic=-1'
+```
+
+##### Run Asterinas kernel with TCG
+
+```bash
+qemu-system-$(uname -m) \
+  -accel tcg \
+  -cpu Icelake-Server \
+  -machine q35 -m 1G \
+  -bios $OVMF_PATH \
+  -kernel /run/current-system/kernel \
+  -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+  -nographic -no-reboot \
+  -append 'console=ttyS0 panic=-1'
+```
+
+> **Note**: Running the Asterinas kernel requires the `linux/multiboot` boot protocol (**multiboot2 is not supported**).
+> Compile Asterinas with:
+> ```bash
+> make nixos BOOT_PROTOCOL=linux NIXOS_TEST_SUITE=containerization-and-virtualization
+> ```

--- a/test/nixos/tests/containerization-and-virtualization/extra_config.nix
+++ b/test/nixos/tests/containerization-and-virtualization/extra_config.nix
@@ -1,6 +1,11 @@
 { pkgs, ... }:
 
 {
-  environment.systemPackages = with pkgs; [ skopeo ];
+  environment.systemPackages = with pkgs; [ skopeo qemu_kvm ];
   virtualisation.podman.enable = true;
+
+  environment.variables = {
+    LINUX_BZIMAGE = "${pkgs.linuxPackages.kernel}/bzImage";
+    OVMF_PATH = "${pkgs.OVMF.fd}/FV/OVMF.fd";
+  };
 }

--- a/test/nixos/tests/containerization-and-virtualization/src/main.rs
+++ b/test/nixos/tests/containerization-and-virtualization/src/main.rs
@@ -59,3 +59,49 @@ fn skopeo_inspect_image(nixos_shell: &mut Session) -> Result<(), Error> {
     nixos_shell.run_cmd_and_expect("skopeo list-tags docker://docker.io/library/alpine", "Tags")?;
     Ok(())
 }
+
+// ============================================================================
+// Qemu
+// ============================================================================
+
+#[nixos_test]
+fn qemu_display_version(nixos_shell: &mut Session) -> Result<(), Error> {
+    // Verifies that the QEMU emulator is available and reports its version.
+    nixos_shell.run_cmd_and_expect(
+        "qemu-system-$(uname -m) --version",
+        "QEMU emulator version",
+    )?;
+    Ok(())
+}
+
+#[nixos_test]
+fn qemu_tcg_run_linux(nixos_shell: &mut Session) -> Result<(), Error> {
+    // Run a Linux kernel inside QEMU using the TCG software emulator.
+    const CMD: &str = concat!(
+        "qemu-system-$(uname -m) ",
+        "-accel tcg ",
+        "-kernel $LINUX_BZIMAGE ",
+        "-nographic -no-reboot ",
+        "-append 'console=ttyS0 panic=-1'"
+    );
+    nixos_shell.run_cmd_and_expect(CMD, "Linux version")?;
+    Ok(())
+}
+
+#[nixos_test]
+fn qemu_tcg_run_aster(nixos_shell: &mut Session) -> Result<(), Error> {
+    // Run a Asterinas kernel inside QEMU using the TCG software emulator.
+    const CMD: &str = concat!(
+        "qemu-system-$(uname -m) ",
+        "-accel tcg ",
+        "-cpu Icelake-Server ",
+        "-machine q35 -m 1G ",
+        "-bios $OVMF_PATH ",
+        "-kernel /run/current-system/kernel ",
+        "-device isa-debug-exit,iobase=0xf4,iosize=0x04 ",
+        "-nographic -no-reboot ",
+        "-append 'console=ttyS0 panic=-1'"
+    );
+    nixos_shell.run_cmd_and_expect(CMD, "Spawn the first kernel thread")?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add QEMU test cases to the virtualization.

## Motivation

QEMU is the most widely used open-source machine emulator and virtualizer in the Linux ecosystem. It serves as the foundation for nearly all major virtualization platforms — KVM, Xen, and cloud hypervisors (QEMU underpins Firecracker, Cloud Hypervisor, and libvirt-based stacks). It is also the standard tool for OS development, CI testing, and embedded system emulation across all major architectures (x86_64, RISC-V, ARM, LoongArch).

Asterinas does not yet support hardware virtualization (KVM), so QEMU can only run with TCG software emulation on Asterinas NixOS. Adding QEMU tests validates this critical use case: TCG-based virtualization is the only path available today.

## Changes

- Add `qemu_kvm` to `environment.systemPackages`
- Provide `LINUX_BZIMAGE` and `OVMF_PATH` environment variables for tests
- Add comprehensive QEMU tests:
    - `qemu_display_version`: verify QEMU binary availability
    - `qemu_tcg_run_linux`: boot standard Linux kernel with TCG
    - `qemu_tcg_run_aster`: boot Asterinas kernel with TCG
- Add QEMU section to `book/src/distro/popular-applications/containerization-and-virtualization/README.md`, documenting installation and verified usage
