### PR TITLE
Fix alias handling in `merge_nixos_config.sh`

### DIFF
--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -5,8 +5,9 @@ on:
   push:
     branches:
       - main
-    paths: 
+    paths:
       - VERSION
+      - test/nixos/common/merge_nixos_config.sh
 
 jobs:
   push-cachix:

--- a/.github/workflows/push_cachix_dev.yml
+++ b/.github/workflows/push_cachix_dev.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - .github/workflows/push_cachix_pkgs.yml
       - distro/**
+      - test/nixos/common/merge_nixos_config.sh
   push:
     branches:
       - main
     paths:
       - .github/workflows/push_cachix_pkgs.yml
       - distro/**
+      - test/nixos/common/merge_nixos_config.sh
 
 jobs:
   push-pkgs:

--- a/test/nixos/common/merge_nixos_config.sh
+++ b/test/nixos/common/merge_nixos_config.sh
@@ -9,6 +9,10 @@
 # combination of the two inputs. If the same key is set by both <base_file>
 # and <extra_file>, then the value provided by <extra_file> takes precedence.
 #
+# NOTES: If `<extra_file>` and `<merged_file>` refer to the same file while
+# `<base_file>` is different, the script rejects the invocation to avoid
+# circular import.
+#
 # A NixOS configuration file, usually named `configuration.nix`, is written in
 # the following form:
 #
@@ -40,7 +44,20 @@ if [ ! -f "$EXTRA_FILE" ]; then
     exit 1
 fi
 
+ABS_BASE="$(realpath "$BASE_FILE")"
 ABS_EXTRA="$(realpath "$EXTRA_FILE")"
+ABS_MERGED="$(realpath -m "$MERGED_FILE")"
+
+if [ "$ABS_BASE" = "$ABS_EXTRA" ] && [ "$ABS_EXTRA" = "$ABS_MERGED" ]; then
+    exit 0
+fi
+
+if [ "$ABS_EXTRA" = "$ABS_MERGED" ]; then
+    echo "Error: merged_file must not alias extra_file"
+    exit 1
+fi
+
+BASE_CONTENT="$(cat "$BASE_FILE")"
 
 # Keep the base module embedded so its relative imports resolve from the final
 # generated `configuration.nix`, while importing the extra module from its
@@ -55,9 +72,8 @@ let
   baseModule = (
 EOF
 
-cat "$BASE_FILE" >> "$MERGED_FILE"
-
 printf '%s\n' \
+  "$BASE_CONTENT" \
   '  );' \
   "  extraModule = import $ABS_EXTRA;" \
   '' \


### PR DESCRIPTION
This PR fixes `test/nixos/common/merge_nixos_config.sh` when the input and output paths alias the same file.


Now, we want `merge_nixos_config.sh <base_file> <extra_file> <merged_file>` to generate a `merged_file` that looks like this:

```nix
{ config, lib, pkgs, ... }:
let
  # The content of the original modules is embedded here.
  baseModule = (
    # The full content of <base_file>
  );
  extraModule = import # The absolute path of <extra_file>
  # Evaluate each module with the standard NixOS arguments 
  base = baseModule { inherit config lib pkgs; }; 
  extra = extraModule { inherit config lib pkgs; }; 
in 
  # Deeply merge the base and extra configurations. 
  # The value from extra_file takes precedence. 
  lib.recursiveUpdate base extra
```

The current implementation breaks when the input and output files refer to the same file. This bug was introduced by https://github.com/asterinas/asterinas/pull/3187#discussion_r3194688661, and will break some [CI](https://github.com/asterinas/asterinas/actions/runs/26025044413/job/76496086117). cc @tatetian @cqs21.

The expected behavior is:

 - `base_file == extra_file == merged_file`: no-op
 - `base_file == extra_file != merged_file`: allow
 - `base_file == merged_file != extra_file`: allow, but read base_file before overwriting it
 - `extra_file == merged_file != base_file`: reject
 - `base_file != extra_file != merged_file != base_file`: allow

