### PR TITLE
 Add `VmarHandle` to count `Vmar` users 

### DIFF
--- a/kernel/src/arch/x86/ptrace.rs
+++ b/kernel/src/arch/x86/ptrace.rs
@@ -397,9 +397,9 @@ const fn word_range(offset: usize) -> Range<usize> {
 const LINUX_USER_CS: usize = 0x33;
 const LINUX_USER_SS: usize = 0x2b;
 
-// Some applications (e.g., GDB), rely on `ptrace` exposing Linux's
+// Some applications (e.g., GDB) rely on `ptrace` exposing Linux's
 // conventional x86-64 user segment selector values.
 //
-// See: <https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/nat/x86-linux.c#l124>.
+// See: <https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/nat/x86-linux.c;h=16391dcde24407fc2c219194bc960f761bd048fe;hb=HEAD#l124>.
 ostd::const_assert!(LINUX_USER_CS == USER_CS_VALUE);
 ostd::const_assert!(LINUX_USER_SS == USER_SS_VALUE);

--- a/kernel/src/context.rs
+++ b/kernel/src/context.rs
@@ -17,7 +17,7 @@ use crate::{
         posix_thread::{PosixThread, ThreadLocal},
     },
     thread::Thread,
-    vm::vmar::{VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, Vmar},
+    vm::vmar::{VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, Vmar, VmarHandle},
 };
 
 /// The context that can be accessed from the current POSIX thread.
@@ -47,7 +47,7 @@ impl Context<'_> {
 // code lints (for *lots of* types that are recursively reached via `CurrentUserSpace`'s APIs). As
 // a workaround, we mark the type as `pub(crate)`. We can restore it to `pub` once the compiler bug
 // is resolved.
-pub(crate) struct CurrentUserSpace<'a>(Ref<'a, Option<Arc<Vmar>>>);
+pub(crate) struct CurrentUserSpace<'a>(Ref<'a, Option<VmarHandle>>);
 
 /// Gets the [`CurrentUserSpace`] from the current task.
 ///
@@ -89,14 +89,7 @@ impl<'a> CurrentUserSpace<'a> {
 
     /// Takes a snapshot of the current VMAR identity.
     pub fn vmar_snapshot(&self) -> VmarSnapshot {
-        VmarSnapshot::from(Arc::downgrade(self.0.as_ref().unwrap()))
-    }
-
-    /// Returns whether the VMAR is shared with other processes or threads.
-    pub fn is_vmar_shared(&self) -> bool {
-        // If the VMAR is not shared, its reference count should be exactly 2:
-        // one reference is held by `ThreadLocal` and the other by `ProcessVm` in `Process`.
-        Arc::strong_count(self.0.as_ref().unwrap()) > 2
+        VmarSnapshot::from(self.0.as_ref().unwrap().clone_weak())
     }
 
     /// Creates a reader to read data from the user space of the current task.

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -521,7 +521,7 @@ pub enum SeekFrom {
     Current(isize),
 }
 
-/// Provides file operations for one opened file description.
+/// File operations for one opened file description.
 ///
 /// A per-open file object can hold file-description-specific state and override
 /// operations that are not purely inode-backed, such as state and operations for

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -294,7 +294,7 @@ bitflags! {
     }
 }
 
-/// Provides basic file operations.
+/// Basic file operations.
 ///
 /// For inode-backed files without per-`open()` state, [`Inode`] implements this
 /// trait directly. For files whose behavior depends on state created by `open`,

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     sched::Nice,
     thread::{AsThread, Tid},
-    vm::vmar::Vmar,
+    vm::vmar::{Vmar, VmarHandle},
 };
 
 bitflags! {
@@ -379,10 +379,18 @@ fn clone_child_task(
     // Clone system V semaphore
     clone_sysvsem(clone_flags)?;
 
+    // Clone VMAR
+    let child_vmar = thread_local
+        .vmar()
+        .borrow()
+        .as_ref()
+        .unwrap()
+        .clone_handle();
+
     // Clone file table
     let child_file_table = clone_files(thread_local.borrow_file_table().unwrap(), clone_flags);
 
-    // Clone fs
+    // Clone FS
     let child_fs = clone_fs(&thread_local.borrow_fs(), clone_flags);
 
     // Clone FPU context
@@ -429,16 +437,21 @@ fn clone_child_task(
             Credentials::new_from(&credentials)
         };
 
-        let mut thread_builder =
-            PosixThreadBuilder::new(child_tid, thread_name, child_user_ctx, credentials)
-                .process(posix_thread.weak_process().clone())
-                .sig_mask(sig_mask)
-                .file_table(child_file_table)
-                .fs(child_fs)
-                .fpu_context(child_fpu_context)
-                .user_ns(child_user_ns)
-                .ns_proxy(child_ns_proxy)
-                .default_timer_slack_ns(default_timer_slack_ns);
+        let mut thread_builder = PosixThreadBuilder::new(
+            child_tid,
+            thread_name,
+            child_user_ctx,
+            credentials,
+            child_vmar,
+        )
+        .process(posix_thread.weak_process().clone())
+        .sig_mask(sig_mask)
+        .file_table(child_file_table)
+        .fs(child_fs)
+        .fpu_context(child_fpu_context)
+        .user_ns(child_user_ns)
+        .ns_proxy(child_ns_proxy)
+        .default_timer_slack_ns(default_timer_slack_ns);
 
         // Deal with SETTID/CLEARTID flags
         clone_parent_settid(child_tid, clone_args.parent_tid, clone_flags)?;
@@ -541,6 +554,8 @@ fn clone_child_process(
     let child_tid = allocate_posix_tid();
 
     let child = {
+        let child_vmar_arc = child_vmar.clone_arc();
+
         let mut child_thread_builder = {
             let thread_name = {
                 let executable_path = child_vmar.process_vm().executable_file();
@@ -558,14 +573,20 @@ fn clone_child_process(
                 Credentials::new_from(&credentials)
             };
 
-            PosixThreadBuilder::new(child_tid, child_thread_name, child_user_ctx, credentials)
-                .sig_mask(child_sig_mask)
-                .file_table(child_file_table)
-                .fs(child_fs)
-                .fpu_context(child_fpu_context)
-                .user_ns(child_user_ns.clone())
-                .ns_proxy(child_ns_proxy)
-                .default_timer_slack_ns(default_timer_slack_ns)
+            PosixThreadBuilder::new(
+                child_tid,
+                child_thread_name,
+                child_user_ctx,
+                credentials,
+                child_vmar,
+            )
+            .sig_mask(child_sig_mask)
+            .file_table(child_file_table)
+            .fs(child_fs)
+            .fpu_context(child_fpu_context)
+            .user_ns(child_user_ns.clone())
+            .ns_proxy(child_ns_proxy)
+            .default_timer_slack_ns(default_timer_slack_ns)
         };
 
         // Deal with SETTID/CLEARTID flags
@@ -577,7 +598,7 @@ fn clone_child_process(
 
         create_child_process(
             child_tid,
-            child_vmar,
+            child_vmar_arc,
             child_resource_limits,
             child_nice,
             child_oom_score_adj,
@@ -636,11 +657,11 @@ fn clone_parent_settid(
     Ok(())
 }
 
-fn clone_vmar(parent_vmar: &Arc<Vmar>, clone_flags: CloneFlags) -> Result<Arc<Vmar>> {
+fn clone_vmar(parent_vmar: &VmarHandle, clone_flags: CloneFlags) -> Result<VmarHandle> {
     // If CLONE_VM is set, the child and parent share the same VMAR.
     // Otherwise, the child has a copy of the parent's VMAR.
     if clone_flags.contains(CloneFlags::CLONE_VM) {
-        Ok(parent_vmar.clone())
+        Ok(parent_vmar.clone_handle())
     } else {
         Ok(Vmar::fork_from(parent_vmar)?)
     }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -29,7 +29,7 @@ use crate::{
             signals::kernel::KernelSignal,
         },
     },
-    vm::vmar::Vmar,
+    vm::vmar::VmarHandle,
 };
 
 pub fn do_execve(
@@ -60,8 +60,8 @@ pub fn do_execve(
     let program_to_load =
         ProgramToLoad::build_from_file(elf_file.clone(), &path_resolver, argv, envp)?;
 
-    let new_vmar = Vmar::new(ProcessVm::new(elf_file.clone()));
-    let elf_load_info = program_to_load.load_to_vmar(new_vmar.as_ref(), &path_resolver)?;
+    let new_vmar = VmarHandle::new(ProcessVm::new(elf_file.clone()));
+    let elf_load_info = program_to_load.load_to_vmar(&new_vmar, &path_resolver)?;
 
     // Ensure no other thread is concurrently performing exit_group or execve.
     // If such an operation is in progress, return EAGAIN.
@@ -148,7 +148,7 @@ fn do_execve_no_return(
     user_context: &mut UserContext,
     path_resolver: &PathResolver,
     elf_file: Path,
-    new_vmar: Arc<Vmar>,
+    new_vmar: VmarHandle,
     elf_load_info: &ElfLoadInfo,
 ) -> Result<()> {
     let Context {
@@ -167,9 +167,10 @@ fn do_execve_no_return(
     // while holding the process VMAR lock.
     // This prevents race conditions when checking access permissions while opening
     // `/proc/[pid]/mem` or `/proc/[pid]/maps`.
-    let vmar_guard = activate_vmar(ctx, new_vmar);
+    let (vmar_guard, old_vmar) = activate_vmar(ctx, new_vmar);
     apply_caps_from_exec(process, ctx.credentials_mut(), elf_file.inode())?;
     drop(vmar_guard);
+    drop(old_vmar);
 
     // After the program has been successfully loaded, the virtual memory of the current process
     // is initialized. Hence, it is necessary to clear the previously recorded robust list.

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -19,7 +19,7 @@ pub(super) fn exit_process(current_process: &Process) {
     current_process.status().set_vfork_child(false);
 
     // Drop fields in `Process`.
-    current_process.lock_vmar().set_vmar(None);
+    drop_after!(current_process.lock_vmar().set_vmar(None));
 
     // Move the children to the reaper process and send them signals. The children should see a new
     // parent when they receive the signal.
@@ -44,6 +44,24 @@ pub(super) fn exit_process(current_process: &Process) {
     cgroup_guard.move_process_to_root(current_process);
     drop(cgroup_guard);
 }
+
+/// Drops a value after releasing the lock or borrow guard.
+///
+/// For example, [`ThreadLocal::vmar`] needs to be borrowed during a context switch. This means that
+/// the kernel may panic if we borrow it as mutable and tries to acquire a mutex while dropping the
+/// last [`VmarHandle`]. This utility macro ensures that the value is dropped only after the borrow
+/// guard has been released, preventing all these issues.
+///
+/// [`ThreadLocal::vmar`]: super::posix_thread::ThreadLocal::vmar
+/// [`VmarHandle`]: crate::vm::vmar::VmarHandle
+macro_rules! drop_after {
+    ($expr:expr) => {
+        let val = $expr;
+        drop(val);
+    };
+}
+
+pub(super) use drop_after;
 
 /// Moves the children to a reaper process.
 ///

--- a/kernel/src/process/posix_thread/alien_access.rs
+++ b/kernel/src/process/posix_thread/alien_access.rs
@@ -7,7 +7,7 @@
 use crate::{
     prelude::*,
     process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
-    security::lsm::{AlienAccessContext, hooks as lsm_hooks},
+    security::lsm::hooks as lsm_hooks,
 };
 
 impl PosixThread {
@@ -53,7 +53,7 @@ impl PosixThread {
             );
         }
 
-        lsm_hooks::on_alien_access(&AlienAccessContext::new(
+        lsm_hooks::on_alien_access(&lsm_hooks::AlienAccessContext::new(
             accessor,
             self,
             mode,

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -22,6 +22,7 @@ use crate::{
     sched::{Nice, SchedPolicy},
     thread::{Thread, Tid, task},
     time::{TimerManager, clocks::ProfClock},
+    vm::vmar::VmarHandle,
 };
 
 /// The builder to build a POSIX thread
@@ -32,6 +33,7 @@ pub struct PosixThreadBuilder {
     user_ctx: Box<UserContext>,
     process: Weak<Process>,
     credentials: Credentials,
+    vmar: VmarHandle,
 
     // Optional part
     set_child_tid: Vaddr,
@@ -53,6 +55,7 @@ impl PosixThreadBuilder {
         thread_name: ThreadName,
         user_ctx: Box<UserContext>,
         credentials: Credentials,
+        vmar: VmarHandle,
     ) -> Self {
         Self {
             tid,
@@ -60,6 +63,7 @@ impl PosixThreadBuilder {
             user_ctx,
             process: Weak::new(),
             credentials,
+            vmar,
             set_child_tid: 0,
             clear_child_tid: 0,
             file_table: None,
@@ -130,6 +134,7 @@ impl PosixThreadBuilder {
             user_ctx,
             process,
             credentials,
+            vmar,
             thread_name,
             set_child_tid,
             clear_child_tid,
@@ -152,8 +157,6 @@ impl PosixThreadBuilder {
 
         let fs = fs
             .unwrap_or_else(|| Arc::new(ThreadFsInfo::new(ns_proxy.mnt_ns().new_path_resolver())));
-
-        let vmar = process.upgrade().unwrap().lock_vmar().dup_vmar().unwrap();
 
         Arc::new_cyclic(|weak_task| {
             let posix_thread = {

--- a/kernel/src/process/posix_thread/exit.rs
+++ b/kernel/src/process/posix_thread/exit.rs
@@ -13,7 +13,7 @@ use crate::{
     prelude::*,
     process::{
         TermStatus,
-        exit::exit_process,
+        exit::{drop_after, exit_process},
         pid_table,
         signal::{constants::SIGKILL, signals::kernel::KernelSignal},
         task_set::TaskSet,
@@ -109,13 +109,13 @@ fn exit_internal(
     }
 
     // Drop fields in `PosixThread`.
-    *posix_thread.file_table().lock() = None;
-    *posix_thread.ns_proxy().lock() = None;
+    drop_after!(posix_thread.file_table().lock().take());
+    drop_after!(posix_thread.ns_proxy().lock().take());
 
     // Drop fields in `ThreadLocal`.
-    *thread_local.vmar().borrow_mut() = None;
-    thread_local.borrow_file_table_mut().remove();
-    thread_local.borrow_ns_proxy_mut().remove();
+    drop_after!(thread_local.vmar().borrow_mut().take());
+    drop_after!(thread_local.borrow_file_table_mut().remove());
+    drop_after!(thread_local.borrow_ns_proxy_mut().remove());
 
     if is_last_thread {
         exit_process(&posix_process);

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -12,7 +12,7 @@ use crate::{
         NsProxy, UserNamespace,
         signal::{SigStack, sig_mask::SigMask},
     },
-    vm::vmar::Vmar,
+    vm::vmar::VmarHandle,
 };
 
 /// Local data for a POSIX thread.
@@ -23,7 +23,7 @@ pub struct ThreadLocal {
     clear_child_tid: Cell<Vaddr>,
 
     // Virtual memory address regions.
-    vmar: RefCell<Option<Arc<Vmar>>>,
+    vmar: RefCell<Option<VmarHandle>>,
     page_fault_disabled: Cell<bool>,
 
     // Robust futexes.
@@ -57,7 +57,7 @@ impl ThreadLocal {
     pub(super) fn new(
         set_child_tid: Vaddr,
         clear_child_tid: Vaddr,
-        vmar: Arc<Vmar>,
+        vmar: VmarHandle,
         file_table: RwArc<FileTable>,
         fs: Arc<ThreadFsInfo>,
         fpu_context: FpuContext,
@@ -89,7 +89,7 @@ impl ThreadLocal {
         &self.clear_child_tid
     }
 
-    pub fn vmar(&self) -> &RefCell<Option<Arc<Vmar>>> {
+    pub fn vmar(&self) -> &RefCell<Option<VmarHandle>> {
         &self.vmar
     }
 
@@ -308,9 +308,9 @@ impl<T> ThreadLocalOptionRefMut<'_, T> {
         self.0.as_mut().unwrap()
     }
 
-    /// Removes the data and drops it.
-    pub(super) fn remove(&mut self) {
-        *self.0 = None;
+    /// Removes the data and returns it.
+    pub(super) fn remove(&mut self) -> Option<T> {
+        self.0.take()
     }
 
     /// Replaces the data with a new one, returning the old one.

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     sched::Nice,
     thread::Tid,
-    vm::vmar::Vmar,
+    vm::vmar::VmarHandle,
 };
 
 /// Creates and schedules the init process to run.
@@ -95,7 +95,7 @@ fn create_init_process(
     let elf_path = fs.resolver().read().lookup(&fs_path)?;
 
     let pid = allocate_posix_tid();
-    let vmar = Vmar::new(ProcessVm::new(elf_path.clone()));
+    let vmar = VmarHandle::new(ProcessVm::new(elf_path.clone()));
     let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
     let oom_score_adj = 0;
@@ -104,7 +104,7 @@ fn create_init_process(
 
     let init_proc = Process::new(
         pid,
-        vmar,
+        vmar.clone_arc(),
         resource_limits,
         nice,
         oom_score_adj,
@@ -112,7 +112,7 @@ fn create_init_process(
         user_ns,
     );
 
-    let init_task = create_init_task(pid, &init_proc, fs, elf_path, argv, envp)?;
+    let init_task = create_init_task(pid, &init_proc, fs, vmar, elf_path, argv, envp)?;
     init_proc.tasks().lock().insert(init_task).unwrap();
 
     Ok(init_proc)
@@ -137,6 +137,7 @@ fn create_init_task(
     tid: Tid,
     process: &Arc<Process>,
     fs: ThreadFsInfo,
+    vmar: VmarHandle,
     elf_path: Path,
     argv: Vec<CString>,
     envp: Vec<CString>,
@@ -161,8 +162,9 @@ fn create_init_task(
 
     let thread_name = ThreadName::new_from_executable_path(&elf_abs_path);
 
-    let thread_builder = PosixThreadBuilder::new(tid, thread_name, Box::new(user_ctx), credentials)
-        .process(Arc::downgrade(process))
-        .fs(Arc::new(fs));
+    let thread_builder =
+        PosixThreadBuilder::new(tid, thread_name, Box::new(user_ctx), credentials, vmar)
+            .process(Arc::downgrade(process))
+            .fs(Arc::new(fs));
     Ok(thread_builder.build())
 }

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -24,7 +24,11 @@ pub use self::{
         aux_vec::{AuxKey, AuxVec},
     },
 };
-use crate::{fs::vfs::path::Path, prelude::*, vm::vmar::Vmar};
+use crate::{
+    fs::vfs::path::Path,
+    prelude::*,
+    vm::vmar::{Vmar, VmarHandle},
+};
 
 /*
  * The user's virtual memory space layout looks like below.
@@ -160,10 +164,6 @@ pub struct ProcessVmarGuard<'a> {
 /// A snapshot of the process VMAR identity.
 ///
 /// This type is used only for identity comparison.
-//
-// NOTE: Upgrading the `Weak<Vmar>` in the snapshot is not permitted,
-// as this will cause the `Vmar` to be dropped in the wrong context,
-// and break the reference count used in `CurrentUserSpace::is_vmar_shared`.
 #[derive(Clone, Debug)]
 pub struct VmarSnapshot(Weak<Vmar>);
 
@@ -225,18 +225,12 @@ impl<'a> ProcessVmarGuard<'a> {
 
     /// Sets a new VMAR for the binding process.
     ///
+    /// This method will return the old VMAR.
+    ///
     /// If the `new_vmar` is `None`, this method will remove the
     /// current VMAR.
-    pub(super) fn set_vmar(&mut self, new_vmar: Option<Arc<Vmar>>) {
-        *self.inner = new_vmar;
-    }
-
-    /// Duplicates a new VMAR from the binding process.
-    ///
-    /// This method should only be used to clone the VMAR in the `Process`
-    /// and store it in the `ThreadLocal`.
-    pub(super) fn dup_vmar(&self) -> Option<Arc<Vmar>> {
-        self.inner.as_ref().cloned()
+    pub(super) fn set_vmar(&mut self, new_vmar: Option<Arc<Vmar>>) -> Option<Arc<Vmar>> {
+        core::mem::replace(&mut *self.inner, new_vmar)
     }
 
     /// Returns a reader for reading contents from
@@ -251,16 +245,28 @@ impl<'a> ProcessVmarGuard<'a> {
 
 /// Activates the [`Vmar`] in the current process's context.
 ///
-/// Returns a [`ProcessVmarGuard`] that keeps the process VMAR lock held.
-pub(super) fn activate_vmar<'a>(ctx: &'a Context<'a>, new_vmar: Arc<Vmar>) -> ProcessVmarGuard<'a> {
+/// Returns a [`ProcessVmarGuard`] that keeps the process VMAR lock held and the old [`Vmar`].
+pub(super) fn activate_vmar<'a>(
+    ctx: &'a Context<'a>,
+    new_vmar: VmarHandle,
+) -> (ProcessVmarGuard<'a>, VmarHandle) {
+    let vmar_arc = new_vmar.clone_arc();
+
     let mut vmar_guard = ctx.process.lock_vmar();
+
     // Disable preemption because `thread_local::vmar()` will be borrowed during a context switch.
-    let _preempt_guard = disable_preempt();
+    let old_vmar = {
+        let _preempt_guard = disable_preempt();
+        let old_vmar = ctx
+            .thread_local
+            .vmar()
+            .borrow_mut()
+            .replace(new_vmar)
+            .unwrap();
+        vmar_arc.vm_space().activate();
+        old_vmar
+    };
+    vmar_guard.set_vmar(Some(vmar_arc));
 
-    *ctx.thread_local.vmar().borrow_mut() = Some(new_vmar.clone());
-    new_vmar.vm_space().activate();
-
-    vmar_guard.set_vmar(Some(new_vmar));
-
-    vmar_guard
+    (vmar_guard, old_vmar)
 }

--- a/kernel/src/sched/sched_class/fair.rs
+++ b/kernel/src/sched/sched_class/fair.rs
@@ -83,7 +83,7 @@ pub const fn nice_to_weight(nice: Nice) -> u64 {
 ///
 /// # Scheduling periods
 ///
-/// Scheduling periods is designed to calculate the time slice for each threads.
+/// Scheduling periods are designed to calculate the time slice for each threads.
 ///
 /// The time slice for each threads is calculated by the formula:
 ///
@@ -113,9 +113,9 @@ pub const fn nice_to_weight(nice: Nice) -> u64 {
 /// To indicate whether the weight needs to be updated, we pack the `weight` field
 /// with a bit flag `HAS_PENDING`. When accessing the `weight` field:
 ///
-/// - If the weight does not need to be updated (i.e. `weight & IS_PENDING == 0`),
+/// - If the weight does not need to be updated (i.e., `weight & HAS_PENDING == 0`),
 ///   we simply return the weight.
-/// - If the weight needs to be updated (i.e. `weight & IS_PENDING != 0`), we try to
+/// - If the weight needs to be updated (i.e., `weight & HAS_PENDING != 0`), we try to
 ///   store the new weight into the `weight` field, which shouldn't take too much time
 ///   since the update frequency is usually relatively low.
 /// - After a successful update, we re-evaluate the data of the run queue.

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -17,7 +17,6 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
-pub use self::hooks::AlienAccessContext;
 use self::hooks::LsmAlienAccessHook;
 use crate::prelude::*;
 
@@ -31,7 +30,7 @@ bitflags! {
     }
 }
 
-/// Defines the common interface for built-in LSM modules.
+/// The common interface for built-in LSM modules.
 trait LsmModule: LsmAlienAccessHook + Sync {
     /// Returns the module name.
     fn name(&self) -> &'static str;

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -4,7 +4,10 @@ use core::sync::atomic::{AtomicI32, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
-use super::super::{AlienAccessContext, LsmFlags, LsmModule, hooks::LsmAlienAccessHook};
+use super::super::{
+    LsmFlags, LsmModule,
+    hooks::{AlienAccessContext, LsmAlienAccessHook},
+};
 use crate::{
     prelude::*,
     process::{

--- a/kernel/src/syscall/unshare.rs
+++ b/kernel/src/syscall/unshare.rs
@@ -76,7 +76,7 @@ fn check_flags(flags: CloneFlags, ctx: &Context) -> Result<()> {
         );
     }
 
-    if flags.contains(CloneFlags::CLONE_VM) && ctx.user_space().is_vmar_shared() {
+    if flags.contains(CloneFlags::CLONE_VM) && ctx.user_space().vmar().has_multiple_handles() {
         return_errno_with_message!(
             Errno::EINVAL,
             "`CLONE_VM` can only be used when the VMAR is not shared"

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -360,7 +360,7 @@ pub trait PageCacheBackend: Sync + Send {
     /// Writes a page to the backend asynchronously.
     ///
     /// If the caller tries to pass an index that exceeds the size of the
-    /// underlying backend (e.g. the file size), this method should fail with
+    /// underlying backend (e.g., the file size), this method should fail with
     /// `EINVAL`. Note that this cannot happen until we support concurrent file
     /// truncation and page writeback.
     //

--- a/kernel/src/vm/vmar/handle.rs
+++ b/kernel/src/vm/vmar/handle.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::sync::{Arc, Weak};
+use core::ops::Deref;
+
+use crate::{process::ProcessVm, vm::vmar::Vmar};
+
+/// A VMAR handle that is owned by a POSIX thread.
+///
+/// Each POSIX thread should hold only one VMAR handle, representing the VMAR it uses. This handle
+/// should be dropped when the thread exits. Once the last handle is dropped, all mappings and page
+/// tables will be cleared.
+pub struct VmarHandle(Arc<Vmar>);
+
+impl Deref for VmarHandle {
+    type Target = Vmar;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for VmarHandle {
+    fn drop(&mut self) {
+        self.0.dec_num_handles();
+    }
+}
+
+impl VmarHandle {
+    /// Creates a new handle that points to a new VMAR.
+    pub fn new(process_vm: ProcessVm) -> Self {
+        Self(Vmar::new(process_vm))
+    }
+
+    /// Clones a new handle.
+    ///
+    /// This should only be used when creating a new POSIX thread that shares the same VMAR.
+    pub fn clone_handle(&self) -> Self {
+        self.0.inc_num_handles();
+        Self(self.0.clone())
+    }
+
+    /// Clones the VMAR object with a strong reference count.
+    pub fn clone_arc(&self) -> Arc<Vmar> {
+        self.0.clone()
+    }
+
+    /// Clones the VMAR object with a weak reference count.
+    pub fn clone_weak(&self) -> Weak<Vmar> {
+        Arc::downgrade(&self.0)
+    }
+}

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -2,6 +2,7 @@
 
 //! User address space management.
 
+mod handle;
 mod interval_set;
 mod util;
 mod vm_mapping;
@@ -9,7 +10,11 @@ mod vm_mapping;
 mod vmar_impls;
 
 use ostd::mm::Vaddr;
-pub use vmar_impls::{RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo};
+
+pub use self::{
+    handle::VmarHandle,
+    vmar_impls::{RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo},
+};
 
 pub const VMAR_LOWEST_ADDR: Vaddr = 0x001_0000; // 64 KiB is the Linux configurable default
 pub const VMAR_CAP_ADDR: Vaddr = ostd::mm::MAX_USERSPACE_VADDR;

--- a/kernel/src/vm/vmar/util.rs
+++ b/kernel/src/vm/vmar/util.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 
 /// Determines whether two ranges are intersected.
-/// returns false if one of the ranges has a length of 0
+/// Returns false if one of the ranges has a length of 0.
 pub fn is_intersected(range1: &Range<usize>, range2: &Range<usize>) -> bool {
     range1.start.max(range2.start) < range1.end.min(range2.end)
 }

--- a/kernel/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/src/vm/vmar/vmar_impls/fork.rs
@@ -1,33 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::array;
-
-use aster_util::per_cpu_counter::PerCpuCounter;
 use ostd::{
     mm::{
-        CachePolicy, PageFlags, VmSpace,
+        CachePolicy, PageFlags,
         tlb::TlbFlushOp,
         vm_space::{CursorMut, VmQueriedItem},
     },
     task::disable_preempt,
 };
 
-use super::{RssDelta, VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, Vmar, VmarInner};
-use crate::{prelude::*, process::ProcessVm};
+use super::{RssDelta, VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, Vmar};
+use crate::{prelude::*, process::ProcessVm, vm::vmar::VmarHandle};
 
 impl Vmar {
     /// Creates a new VMAR whose content is inherited from another
     /// using copy-on-write (COW) technique.
-    pub fn fork_from(vmar: &Self) -> Result<Arc<Self>> {
+    pub fn fork_from(vmar: &Self) -> Result<VmarHandle> {
         // Obtain the heap lock and hold it for the entire method to avoid race conditions.
         let heap_guard = vmar.process_vm.heap().lock();
 
-        let new_vmar = Arc::new(Vmar {
-            inner: RwMutex::new(VmarInner::new()),
-            vm_space: Arc::new(VmSpace::new()),
-            rss_counters: array::from_fn(|_| PerCpuCounter::new()),
-            process_vm: ProcessVm::fork_from(&vmar.process_vm, &heap_guard),
-        });
+        let new_vmar = VmarHandle::new(ProcessVm::fork_from(&vmar.process_vm, &heap_guard));
 
         {
             let inner = vmar.inner.read();
@@ -127,7 +119,7 @@ fn cow_copy_pt(src: &mut CursorMut<'_>, dst: &mut CursorMut<'_>, size: usize) ->
 mod test {
     use ostd::{
         io::IoMem,
-        mm::{FrameAllocOptions, PageProperty},
+        mm::{FrameAllocOptions, PageProperty, VmSpace},
         prelude::*,
     };
 

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -9,7 +9,11 @@ mod query;
 mod remap;
 mod unmap;
 
-use core::{array, ops::Range};
+use core::{
+    array,
+    ops::Range,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use align_ext::AlignExt;
 use aster_util::per_cpu_counter::PerCpuCounter;
@@ -37,15 +41,19 @@ pub struct Vmar {
     inner: RwMutex<VmarInner>,
     /// The attached `VmSpace`
     vm_space: Arc<VmSpace>,
-    /// The RSS counters.
+    /// The RSS counters
     rss_counters: [PerCpuCounter; NUM_RSS_COUNTERS],
     /// The process VM
     process_vm: ProcessVm,
+    /// The number of handles that this `Vmar` has (see [`super::VmarHandle`])
+    num_handles: AtomicUsize,
 }
 
 impl Vmar {
     /// Creates a new VMAR.
-    pub fn new(process_vm: ProcessVm) -> Arc<Self> {
+    ///
+    /// This method should only be invoked by [`super::VmarHandle`].
+    pub(super) fn new(process_vm: ProcessVm) -> Arc<Self> {
         let inner = VmarInner::new();
         let vm_space = VmSpace::new();
         let rss_counters = array::from_fn(|_| PerCpuCounter::new());
@@ -54,6 +62,7 @@ impl Vmar {
             vm_space: Arc::new(vm_space),
             rss_counters,
             process_vm,
+            num_handles: AtomicUsize::new(1),
         })
     }
 
@@ -75,6 +84,32 @@ impl Vmar {
     /// Returns the attached `ProcessVm`.
     pub fn process_vm(&self) -> &ProcessVm {
         &self.process_vm
+    }
+
+    /// Returns whether this VMAR has multiple handles.
+    pub fn has_multiple_handles(&self) -> bool {
+        self.num_handles.load(Ordering::Relaxed) > 1
+    }
+
+    /// Increases the number of handles.
+    ///
+    /// This method should only be invoked by [`super::VmarHandle`].
+    pub(super) fn inc_num_handles(&self) {
+        let old_num_handles = self.num_handles.fetch_add(1, Ordering::Relaxed);
+        debug_assert_ne!(old_num_handles, 0);
+    }
+
+    /// Decreases the number of handles.
+    ///
+    /// This method should only be invoked by [`super::VmarHandle`].
+    pub(super) fn dec_num_handles(&self) {
+        let old_num_handles = self.num_handles.fetch_sub(1, Ordering::Relaxed);
+        debug_assert_ne!(old_num_handles, 0);
+        if old_num_handles == 1 {
+            // Clear all the mappings. The last process using this VMAR exited
+            // or executed a new program, so this VMAR no longer has a handle.
+            self.clear();
+        }
     }
 
     fn add_rss_counter(&self, rss_type: RssType, val: isize) {

--- a/kernel/src/vm/vmar/vmar_impls/unmap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/unmap.rs
@@ -13,9 +13,8 @@ use crate::{
 impl Vmar {
     /// Clears all mappings.
     ///
-    /// After being cleared, this vmar will become an empty vmar
-    #[expect(dead_code)] // TODO: This should be called when the last process drops the VMAR.
-    pub fn clear(&self) {
+    /// After being cleared, this VMAR will become an empty VMAR.
+    pub(super) fn clear(&self) {
         let mut inner = self.inner.write();
         inner.vm_mappings.clear();
 


### PR DESCRIPTION
The purpose of this PR is to prepare reverse mappings of `Vmo` to `Vmar` (`Weak<Vmar>`).

We should be able to unmap pages from `Vmo`. For example, when a file is truncated, all the pages in the truncated range need to be unmapped.

At the very least, we will need access to the `VmSpace` that contains the mapped pages. However, that is not enough. Unmapping pages directly from a `VmSpace` will cause the RSS counters in the `Vmar` to become out of sync:
https://github.com/asterinas/asterinas/blob/09760e3c201821c63502c93f2b10e80b50a27280/kernel/src/vm/vmar/vmar_impls/mod.rs#L40-L41

We can resolve this problem by obtaining a `Vmar` from the reverse mappings. However, this is problematic due to:
https://github.com/asterinas/asterinas/blob/09760e3c201821c63502c93f2b10e80b50a27280/kernel/src/process/process_vm/mod.rs#L163-L166

The purpose of this PR is to relax the limitation. This is achieved by tracking the number of VMAR users separately (e.g. the number of POSIX threads that use that VMAR), rather than relying on the VMAR's reference count.
```rust
struct Vmar {
    // ...
    num_users: AtomicUsize,
}
```

This PR also introduces a strongly typed `VmarHandle` which represents a `Vmar` user. Each POSIX thread holds this handle in its `ThreadLocal`.
```rust
// vmar/handle.rs:

struct VmarHandle(Arc<Vmar>);

impl Drop for VmarHandle {
    fn drop(&mut self) {
        self.0.unmark_shared();
    }
}

// thread_local.rs:

struct ThreadLocal {
    // ...

    vmar: RefCell<Option<VmarHandle>>,
}
```

---

There are some other alternative solutions:
 - Find a way to add RSS counters to `VmSpace`. This is difficult because `VmSpace` lives in OSTD.
 - Wrap the RSS counters in another `Arc` and store them in the reverse mappings. I dislike this solution because it misuses `Arc`.