### PR TITLE
Use local vsock endpoint for QEMU-to-QGS quote generation

### DIFF
--- a/book/src/osdk/guide/intel-tdx.md
+++ b/book/src/osdk/guide/intel-tdx.md
@@ -60,7 +60,7 @@ qemu.args = '''\
     -drive file=target/osdk/asterinas/asterinas.qcow2,if=virtio,format=qcow2 \
     -monitor telnet:127.0.0.1:9001,server,nowait \
     -bios /root/ovmf/release/OVMF.fd \
-    -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"2\", \"port\": \"4050\" } }' \
+    -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"1\", \"port\": \"4050\" } }' \
     -cpu host,-kvm-steal-time,pmu=off \
     -machine q35,kernel-irqchip=split,confidential-guest-support=tdx0 \
     -smp 1 \

--- a/osdk/src/config/unix_args.rs
+++ b/osdk/src/config/unix_args.rs
@@ -185,11 +185,11 @@ pub mod test {
 
     #[test]
     fn test_split_kv_array() {
-        let args = "-enable-kvm -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"2\", \"port\": \"4050\" } }'";
+        let args = "-enable-kvm -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"1\", \"port\": \"4050\" } }'";
 
         let expected = &[
             "-enable-kvm",
-            "-object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"2\", \"port\": \"4050\" } }'",
+            "-object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"1\", \"port\": \"4050\" } }'",
         ];
 
         let array = split_to_kv_array(args);

--- a/osdk/tests/util/scheme.tdx.template
+++ b/osdk/tests/util/scheme.tdx.template
@@ -10,7 +10,7 @@ qemu.args = '''
     -monitor pty \
     -nodefaults \
     -bios /root/ovmf/release/OVMF.fd \
-    -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"2\", \"port\": \"4050\" } }' \
+    -object '{ \"qom-type\": \"tdx-guest\", \"id\": \"tdx0\", \"sept-ve-disable\": true, \"quote-generation-socket\": { \"type\": \"vsock\", \"cid\": \"1\", \"port\": \"4050\" } }' \
     -cpu host,-kvm-steal-time,pmu=off \
     -machine q35,kernel-irqchip=split,confidential-guest-support=tdx0 \
     -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off \

--- a/test/initramfs/src/benchmark/bench_linux_and_aster.sh
+++ b/test/initramfs/src/benchmark/bench_linux_and_aster.sh
@@ -160,7 +160,7 @@ run_benchmark() {
             -bios /root/ovmf/release/OVMF.fd
             -nodefaults
             -serial stdio
-            -object '{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "2", "port": "4050" } }'
+            -object '{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "1", "port": "4050" } }'
         )
     fi
 

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -90,7 +90,7 @@ if [ "$1" = "riscv" ]; then
 fi
 
 if [ "$1" = "tdx" ]; then
-    TDX_OBJECT='{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "2", "port": "4050" } }'
+    TDX_OBJECT='{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "1", "port": "4050" } }'
 
     QEMU_ARGS="\
         -m ${MEM:-8G} \


### PR DESCRIPTION
QEMU uses `quote-generation-socket` as the VMM-side endpoint for connecting to QGS, not as a guest AF_VSOCK destination.

The TDX quote flow does not send the request from guest userspace through a guest `AF_VSOCK` socket. Instead, the guest submits the quote request through the TDX attestation path, QEMU reads the request from shared memory, forwards it to QGS, and writes the response back to shared memory.

In Linux vsock addressing, CID 1 is the local endpoint and CID 2 is the host endpoint. Because `quote-generation-socket` is used by QEMU itself when it opens the connection to QGS, the CID must be interpreted in the vsock context of the QEMU process.