### PR TITLE
Remove `v` from the version when installing cargo-expand

### DIFF
--- a/osdk/tools/docker/Dockerfile
+++ b/osdk/tools/docker/Dockerfile
@@ -216,7 +216,7 @@ RUN mkdir -p /github/home \
 # Install cargo tools
 RUN cargo install --locked \
     cargo-binutils \
-    cargo-expand@v1.0.122 \
+    cargo-expand@1.0.122 \
     mdbook@0.5.2 \
     mdbook-mermaid@0.17.0 \
     typos-cli@1.39.0


### PR DESCRIPTION
A follow-up to https://github.com/asterinas/asterinas/pull/3248#issuecomment-4514821308

Need a manual run on the "Publish Docker images" workflow after the PR is merged to continue the publication.