### PR TITLE
Move `orig_syscall_ret` to `ThreadLocal`

### DIFF
--- a/kernel/src/arch/x86/ptrace.rs
+++ b/kernel/src/arch/x86/ptrace.rs
@@ -58,7 +58,7 @@ impl From<&GeneralRegs> for CUserRegsStruct {
     /// Builds the register snapshot from saved general-purpose registers.
     ///
     /// `orig_rax` is left at zero. Callers needing the syscall-entry
-    /// value should assign it from `PosixThread::orig_syscall_ret`.
+    /// value should assign it from `ThreadLocal::orig_syscall_ret`.
     fn from(regs: &GeneralRegs) -> Self {
         let mut out = Self::default();
         let bytes = out.as_mut_bytes();
@@ -77,7 +77,7 @@ impl CUserRegsStruct {
     /// Validates the user-supplied `regs` and then applies it into `regs`.
     ///
     /// `orig_rax` is ignored. Callers should separately assign this
-    /// field to `PosixThread::orig_syscall_ret`.
+    /// field to `ThreadLocal::orig_syscall_ret`.
     ///
     /// # Errors
     ///
@@ -172,7 +172,7 @@ macro_rules! off {
 /// Each entry covers one `usize` field in `CUserRegsStruct` that is either
 /// backed by `GeneralRegs` or fixed to an ABI-defined value.
 /// `orig_rax` is the only exception: it is stored in
-/// `PosixThread::orig_syscall_ret` rather than `GeneralRegs`.
+/// `ThreadLocal::orig_syscall_ret` rather than `GeneralRegs`.
 const REG_RULES: &[RegRule] = &[
     RegRule::rw(off!(rax), |r| r.rax, |r, v| r.rax = v, Policy::Set),
     RegRule::rw(off!(rbx), |r| r.rbx, |r, v| r.rbx = v, Policy::Set),

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize};
+use core::sync::atomic::{AtomicU32, AtomicU64};
 
 use ostd::{
     arch::cpu::context::{FpuContext, UserContext},
@@ -16,7 +16,7 @@ use crate::{
     prelude::*,
     process::{
         Credentials, NsProxy, Process, UserNamespace,
-        posix_thread::{NOT_A_SYSCALL, name::ThreadName},
+        posix_thread::name::ThreadName,
         signal::{sig_mask::AtomicSigMask, sig_queues::SigQueues},
     },
     sched::{Nice, SchedPolicy},
@@ -185,7 +185,6 @@ impl PosixThreadBuilder {
                     tracee_status: Once::new(),
                     tracees: Once::new(),
                     exit_code: AtomicU32::new(0),
-                    orig_syscall_ret: AtomicUsize::new(NOT_A_SYSCALL),
                     personality: AtomicU32::new(0),
                 }
             };

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use aster_rights::{ReadDupOp, ReadOp, ReadWriteOp};
 use ostd::{
@@ -47,9 +47,6 @@ pub use posix_thread_ext::AsPosixThread;
 pub use robust_list::RobustListHead;
 pub use thread_local::{AsThreadLocal, FileTableRefMut, ThreadLocal};
 
-/// Sentinel for [`PosixThread::orig_syscall_ret`] on non-syscall entries.
-pub const NOT_A_SYSCALL: usize = usize::MAX;
-
 pub struct PosixThread {
     // Immutable part
     process: Weak<Process>,
@@ -79,12 +76,11 @@ pub struct PosixThread {
     /// when enqueuing a signal, along with the reason why the thread is paused.
     signalled_waker: SpinLock<Option<(Arc<Waker>, PauseReason)>>,
 
+    // Time
     /// A profiling clock measures the user CPU time and kernel CPU time in the thread.
     prof_clock: Arc<ProfClock>,
-
     /// A manager that manages timers based on the user CPU time of the current thread.
     virtual_timer_manager: Arc<TimerManager>,
-
     /// A manager that manages timers based on the profiling clock of the current thread.
     prof_timer_manager: Arc<TimerManager>,
 
@@ -99,19 +95,14 @@ pub struct PosixThread {
     /// The default timer slack value for this thread.
     default_timer_slack_ns: AtomicU64,
 
+    // Ptrace
     /// Status of being traced.
     tracee_status: Once<TraceeStatus>,
-
     /// Threads traced by this thread.
     tracees: Once<Mutex<BTreeMap<Tid, Arc<Thread>>>>,
 
     /// Exit code of this thread.
     exit_code: AtomicU32,
-
-    /// Original syscall-return register value captured
-    /// at the most recent kernel entry,
-    /// or [`NOT_A_SYSCALL`] for non-syscall entries.
-    orig_syscall_ret: AtomicUsize,
 
     /// The personality value for this thread.
     personality: AtomicU32,
@@ -260,18 +251,6 @@ impl PosixThread {
         if let Some((waker, _)) = &*self.signalled_waker.lock() {
             waker.wake_up();
         }
-    }
-
-    /// Returns the original syscall-return register value
-    /// for the most recent kernel entry.
-    pub(in crate::process) fn orig_syscall_ret(&self) -> usize {
-        self.orig_syscall_ret.load(Ordering::Relaxed)
-    }
-
-    /// Sets the original syscall-return register value
-    /// for the most recent kernel entry.
-    pub fn set_orig_syscall_ret(&self, value: usize) {
-        self.orig_syscall_ret.store(value, Ordering::Relaxed);
     }
 
     /// Enqueues a thread-directed signal.

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -10,7 +10,7 @@ use ostd::{arch::cpu::context::UserContext, sync::Waiter};
 
 use super::{AsPosixThread, PosixThread};
 #[cfg(target_arch = "x86_64")]
-use crate::{arch::ptrace as arch_ptrace, process::posix_thread::NOT_A_SYSCALL};
+use crate::arch::ptrace as arch_ptrace;
 use crate::{
     prelude::*,
     process::{
@@ -484,7 +484,7 @@ impl TraceeStatus {
         #[cfg(target_arch = "x86_64")]
         {
             state.general_regs = Some(*user_ctx.general_regs());
-            state.orig_syscall_ret = ctx.posix_thread.orig_syscall_ret();
+            state.set_orig_syscall_ret(ctx.thread_local.orig_syscall_ret());
         }
         self.is_stopped.store(true, Ordering::Relaxed);
         drop(state);
@@ -512,7 +512,7 @@ impl TraceeStatus {
             #[cfg(target_arch = "x86_64")]
             {
                 state.general_regs = None;
-                state.orig_syscall_ret = NOT_A_SYSCALL;
+                state.clear_orig_syscall_ret();
             }
             state.is_tracing_syscall = false;
             self.is_stopped.store(false, Ordering::Relaxed);
@@ -527,9 +527,8 @@ impl TraceeStatus {
         {
             let regs = state.general_regs.take().unwrap();
             *user_ctx.general_regs_mut() = regs;
-            ctx.posix_thread
-                .set_orig_syscall_ret(state.orig_syscall_ret);
-            state.orig_syscall_ret = NOT_A_SYSCALL;
+            ctx.thread_local
+                .set_orig_syscall_ret(state.take_orig_syscall_ret());
         }
 
         PtraceStopResult::Continued(signal)
@@ -729,7 +728,8 @@ struct TraceeState {
     /// The general-purpose registers of the tracee at the time of ptrace-stop.
     #[cfg(target_arch = "x86_64")]
     general_regs: Option<GeneralRegs>,
-    /// The value of `PosixThread::orig_syscall_ret` at the time of ptrace-stop.
+    /// The value of `ThreadLocal::orig_syscall_ret` at the time of ptrace-stop,
+    /// or [`Self::NOT_A_SYSCALL`] for non-syscall stops.
     #[cfg(target_arch = "x86_64")]
     orig_syscall_ret: usize,
 }
@@ -745,11 +745,30 @@ impl TraceeState {
             #[cfg(target_arch = "x86_64")]
             general_regs: None,
             #[cfg(target_arch = "x86_64")]
-            orig_syscall_ret: NOT_A_SYSCALL,
+            orig_syscall_ret: Self::NOT_A_SYSCALL,
         }
     }
 
     fn tracer(&self) -> Option<Arc<Thread>> {
         self.tracer.upgrade()
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl TraceeState {
+    const NOT_A_SYSCALL: usize = usize::MAX;
+
+    fn set_orig_syscall_ret(&mut self, value: Option<usize>) {
+        self.orig_syscall_ret = value.unwrap_or(Self::NOT_A_SYSCALL);
+    }
+
+    fn take_orig_syscall_ret(&mut self) -> Option<usize> {
+        let value = self.orig_syscall_ret;
+        self.clear_orig_syscall_ret();
+        (value != Self::NOT_A_SYSCALL).then_some(value)
+    }
+
+    fn clear_orig_syscall_ret(&mut self) {
+        self.orig_syscall_ret = Self::NOT_A_SYSCALL;
     }
 }

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -46,6 +46,9 @@ pub struct ThreadLocal {
     /// Saved signal mask. It will be restored either after the signal handler, or upon
     /// return from the system call if there is no signal handler to run.
     sig_mask_saved: Cell<Option<SigMask>>,
+    /// Original syscall-return register value captured
+    /// at the most recent kernel entry, or `None` for non-syscall entries.
+    orig_syscall_ret: Cell<Option<usize>>,
 
     // Namespaces.
     user_ns: RefCell<Arc<UserNamespace>>,
@@ -76,6 +79,7 @@ impl ThreadLocal {
             fpu_state: Cell::new(FpuState::Unloaded),
             sig_stack: RefCell::new(SigStack::default()),
             sig_mask_saved: Cell::new(None),
+            orig_syscall_ret: Cell::new(None),
             user_ns: RefCell::new(user_ns),
             ns_proxy: RefCell::new(Some(ns_proxy)),
         }
@@ -168,6 +172,18 @@ impl ThreadLocal {
 
     pub(in crate::process) fn sig_mask_saved(&self) -> &Cell<Option<SigMask>> {
         &self.sig_mask_saved
+    }
+
+    /// Returns the original syscall-return register value
+    /// for the most recent kernel entry.
+    pub(in crate::process) fn orig_syscall_ret(&self) -> Option<usize> {
+        self.orig_syscall_ret.get()
+    }
+
+    /// Sets the original syscall-return register value
+    /// for the most recent kernel entry.
+    pub fn set_orig_syscall_ret(&self, value: Option<usize>) {
+        self.orig_syscall_ret.set(value);
     }
 
     pub fn borrow_user_ns(&self) -> Ref<'_, Arc<UserNamespace>> {

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -35,9 +35,7 @@ use crate::{
     prelude::*,
     process::{
         TermStatus,
-        posix_thread::{
-            ContextPthreadAdminApi, NOT_A_SYSCALL, do_exit_group, ptrace::PtraceStopResult,
-        },
+        posix_thread::{ContextPthreadAdminApi, do_exit_group, ptrace::PtraceStopResult},
         signal::{c_types::stack_t, constants::SIGKILL},
     },
 };
@@ -53,8 +51,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
     // other pending unmasked signals until the next trap. Consider a looped scan.
     //
     // For details, see <https://github.com/asterinas/asterinas/pull/2984/#discussion_r3137275994>.
-    let orig_syscall_ret = ctx.posix_thread.orig_syscall_ret();
-    let syscall_restart = if orig_syscall_ret != NOT_A_SYSCALL
+    let syscall_restart = if let Some(orig_syscall_ret) = ctx.thread_local.orig_syscall_ret()
         && user_ctx.syscall_ret() == -(Errno::ERESTARTSYS as i32) as usize
     {
         // We should never return `ERESTARTSYS` to the userspace.
@@ -145,7 +142,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
                 sig_dispositions.set_default(sig_num);
             }
 
-            if let Some(pre_syscall_ret) = syscall_restart
+            if let Some(orig_syscall_ret) = syscall_restart
                 && flags.contains(SigActionFlags::SA_RESTART)
             {
                 #[cfg(target_arch = "x86_64")]
@@ -155,7 +152,7 @@ pub fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
                 #[cfg(target_arch = "loongarch64")]
                 const SYSCALL_INSTR_LEN: usize = 4; // syscall
 
-                user_ctx.set_syscall_ret(pre_syscall_ret);
+                user_ctx.set_syscall_ret(orig_syscall_ret);
                 user_ctx
                     .set_instruction_pointer(user_ctx.instruction_pointer() - SYSCALL_INSTR_LEN);
             }

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -14,9 +14,7 @@ use crate::{
     cpu::LinuxAbi,
     prelude::*,
     process::{
-        posix_thread::{
-            AsPosixThread, FIRST_POSIX_TID, NOT_A_SYSCALL, ThreadLocal, ptrace::PtraceStopResult,
-        },
+        posix_thread::{AsPosixThread, FIRST_POSIX_TID, ThreadLocal, ptrace::PtraceStopResult},
         signal::{HandlePendingSignal, PauseReason, handle_pending_signal},
     },
     syscall::handle_syscall,
@@ -83,12 +81,12 @@ pub fn create_new_user_task(
             match return_reason {
                 ReturnReason::UserException => {
                     let exception = user_ctx.take_exception().unwrap();
-                    ctx.posix_thread.set_orig_syscall_ret(NOT_A_SYSCALL);
+                    ctx.thread_local.set_orig_syscall_ret(None);
                     handle_exception(&ctx, user_ctx, exception)
                 }
                 ReturnReason::UserSyscall => {
-                    ctx.posix_thread
-                        .set_orig_syscall_ret(user_ctx.syscall_ret());
+                    ctx.thread_local
+                        .set_orig_syscall_ret(Some(user_ctx.syscall_ret()));
 
                     let res = ctx.posix_thread.ptrace_may_stop_on_syscall(&ctx, user_ctx);
                     if !matches!(res, PtraceStopResult::Interrupted) {
@@ -98,7 +96,7 @@ pub fn create_new_user_task(
                     }
                 }
                 ReturnReason::KernelEvent => {
-                    ctx.posix_thread.set_orig_syscall_ret(NOT_A_SYSCALL);
+                    ctx.thread_local.set_orig_syscall_ret(None);
                 }
             };
 


### PR DESCRIPTION
It seems that we can move `orig_syscall_ret` from `PosixThread` to `ThreadLocal`. We can use `Cell<Option<usize>>` in `ThreadLocal`, which seems more reasonable.

@vvvvsv Maybe help to confirm that this aligns with your intention? Thanks!