### PR TITLE
Overhaul mount ID allocation: drop upper bound, add unique IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "ring-buffer",
  "riscv",
  "smallvec",
+ "sparse-id-alloc",
  "spin",
  "takeable",
  "tdx-guest",
@@ -1786,6 +1787,10 @@ dependencies = [
  "log",
  "managed",
 ]
+
+[[package]]
+name = "sparse-id-alloc"
+version = "0.1.0"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "kernel/libs/keyable-arc",
     "kernel/libs/logo-ascii-art",
     "kernel/libs/ring-buffer",
+    "kernel/libs/sparse-id-alloc",
     "kernel/libs/typeflags",
     "kernel/libs/typeflags-util",
     "kernel/libs/xarray",
@@ -96,6 +97,7 @@ default-members = [
     "kernel/libs/device-id",
     "kernel/libs/io-util",
     "kernel/libs/ring-buffer",
+    "kernel/libs/sparse-id-alloc",
     "kernel/libs/xarray",
 ]
 # All user-space or host-native crates.
@@ -178,6 +180,7 @@ jhash = { path = "kernel/libs/jhash" }
 keyable-arc = { path = "kernel/libs/keyable-arc" }
 logo-ascii-art = { path = "kernel/libs/logo-ascii-art" }
 ring-buffer = { path = "kernel/libs/ring-buffer" }
+sparse-id-alloc = { path = "kernel/libs/sparse-id-alloc" }
 typeflags = { path = "kernel/libs/typeflags" }
 typeflags-util = { path = "kernel/libs/typeflags-util" }
 xarray = { path = "kernel/libs/xarray" }

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -131,7 +131,6 @@ Silently-ignored flags:
 
 Silently-ignored masks:
 * `STATX_DIOALIGN`
-* `STATX_MNT_ID_UNIQUE`
 * `STATX_SUBVOL`
 * `STATX_WRITE_ATOMIC`
 * `STATX_DIO_READ_ALIGN`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
@@ -4,8 +4,8 @@
 Put system calls such as
 mount, umount2, pivot_root, statfs, fstatfs, truncate, ftruncate, fsync, 
 fdatasync, sync, syncfs, sync_file_range, open_tree, move_mount, fsopen,
-fsconfig, fsmount, fspick, inotify_init, inotify_init1, inotify_add_watch,
-inotify_rm_watch
+fsconfig, fsmount, fspick, listmount, inotify_init, inotify_init1,
+inotify_add_watch, inotify_rm_watch
 under this category.
 -->
 
@@ -116,6 +116,34 @@ Unsupported flags:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/move_mount.2.html).
+
+## Mount queries
+
+### `listmount`
+
+Supported functionality in SCML:
+
+```c
+{{#include listmount.scml}}
+```
+
+The `req` argument is a `struct mnt_id_req`:
+* `mnt_id` is the parent mount's `unique_id`,
+  or `LSMT_ROOT` (`(uint64_t)-1`) for the current namespace's root mount.
+* `param` is a pagination cursor;
+  only descendants with `unique_id` strictly greater than `param` are returned
+  (strictly less than `param` when `LISTMOUNT_REVERSE` is set).
+* `size` must equal `MNT_ID_REQ_SIZE_VER0` (24);
+  future struct versions are not yet accepted.
+* `spare` must be `0`.
+
+Limitations:
+* Bind-mount visibility filtering (Linux's `is_path_reachable`)
+  is not yet modeled;
+  descendancy is determined by the strict mount parent chain.
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/listmount.2.html).
 
 ## Event notifications
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/listmount.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/listmount.scml
@@ -1,0 +1,8 @@
+// List the unique IDs of a mount's strict descendants in the current
+// mount namespace.
+listmount(
+    req,
+    mnt_ids,
+    nr_mnt_ids,
+    flags = LISTMOUNT_REVERSE
+);

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,6 +60,7 @@ rand = { workspace = true, features = [
 ] }
 ring-buffer.workspace = true
 smallvec.workspace = true
+sparse-id-alloc.workspace = true
 spin.workspace = true
 takeable.workspace = true
 time.workspace = true

--- a/kernel/libs/sparse-id-alloc/Cargo.toml
+++ b/kernel/libs/sparse-id-alloc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sparse-id-alloc"
+version = "0.1.0"
+description = "A sparse u32 ID allocator over a configurable range"
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/kernel/libs/sparse-id-alloc/src/lib.rs
+++ b/kernel/libs/sparse-id-alloc/src/lib.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! A sparse u32 ID allocator over a configurable range.
+//!
+//! The [`SparseIdAlloc`] type allocates the smallest available ID in an
+//! inclusive `u32` range and supports returning IDs later.
+
+#![cfg_attr(not(test), no_std)]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+
+/// A sparse `u32` ID allocator over a configurable `[min, max]` range.
+///
+/// # Allocation policy
+///
+/// Always returns the smallest unallocated ID in the range, or `None`
+/// when every ID is in use.
+#[derive(Clone, Debug)]
+pub struct SparseIdAlloc {
+    min: u32,
+    max: u32,
+    /// Maximal runs of allocated IDs: start -> inclusive end.
+    /// Runs are disjoint and non-adjacent.
+    allocated_runs: BTreeMap<u32, u32>,
+}
+
+impl SparseIdAlloc {
+    /// Creates a new allocator that hands out IDs from the inclusive range
+    /// `[min, max]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min > max`.
+    pub const fn new(min: u32, max: u32) -> Self {
+        assert!(min <= max, "min must be <= max");
+        Self {
+            min,
+            max,
+            allocated_runs: BTreeMap::new(),
+        }
+    }
+
+    /// Allocates and returns a new ID from the configured range.
+    ///
+    /// Returns `None` when every ID in `[min, max]` is in use.
+    pub fn alloc(&mut self) -> Option<u32> {
+        let first = self
+            .allocated_runs
+            .first_key_value()
+            .map(|(&start, &end)| (start, end));
+
+        match first {
+            // The range's lowest IDs are allocated; the smallest free ID
+            // is just past the first run (unless the range is exhausted).
+            Some((start, end)) if start == self.min => {
+                if end == self.max {
+                    return None;
+                }
+
+                let id = end + 1;
+                let new_end = id
+                    .checked_add(1)
+                    .and_then(|next_start| self.allocated_runs.remove(&next_start))
+                    .unwrap_or(id);
+                *self.allocated_runs.get_mut(&start).unwrap() = new_end;
+                Some(id)
+            }
+            // `min` itself is free.
+            _ => {
+                let id = self.min;
+                let end = id
+                    .checked_add(1)
+                    .and_then(|next_start| self.allocated_runs.remove(&next_start))
+                    .unwrap_or(id);
+                self.allocated_runs.insert(id, end);
+                Some(id)
+            }
+        }
+    }
+
+    /// Releases the given ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` is not currently allocated (out of range, never
+    /// issued, or already freed).
+    pub fn free(&mut self, id: u32) {
+        let run = self
+            .allocated_runs
+            .range(..=id)
+            .next_back()
+            .map(|(&start, &end)| (start, end));
+        let Some((start, end)) = run.filter(|&(_, end)| id <= end) else {
+            panic!("free({id}) of unallocated ID");
+        };
+
+        if id == start {
+            self.allocated_runs.remove(&start);
+        } else {
+            *self.allocated_runs.get_mut(&start).unwrap() = id - 1;
+        }
+        if id < end {
+            self.allocated_runs.insert(id + 1, end);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SparseIdAlloc;
+
+    #[test]
+    fn sparse_alloc_is_monotonic_from_min() {
+        let mut a = SparseIdAlloc::new(1, u32::MAX);
+        assert_eq!(a.alloc(), Some(1));
+        assert_eq!(a.alloc(), Some(2));
+        assert_eq!(a.alloc(), Some(3));
+    }
+
+    #[test]
+    fn sparse_alloc_reuses_freed_ids_immediately() {
+        let mut a = SparseIdAlloc::new(1, u32::MAX);
+        for _ in 0..3 {
+            let _ = a.alloc();
+        }
+        a.free(3);
+        a.free(1);
+        a.free(2);
+        assert_eq!(a.alloc(), Some(1));
+        assert_eq!(a.alloc(), Some(2));
+        assert_eq!(a.alloc(), Some(3));
+    }
+
+    #[test]
+    fn sparse_alloc_reuses_smallest_gap_first() {
+        let mut a = SparseIdAlloc::new(1, 4);
+        for _ in 0..4 {
+            let _ = a.alloc();
+        }
+        assert_eq!(a.alloc(), None);
+        a.free(4);
+        a.free(2);
+        assert_eq!(a.alloc(), Some(2));
+        assert_eq!(a.alloc(), Some(4));
+        assert_eq!(a.alloc(), None);
+    }
+
+    #[test]
+    fn sparse_alloc_handles_single_id_range() {
+        let mut a = SparseIdAlloc::new(u32::MAX, u32::MAX);
+        assert_eq!(a.alloc(), Some(u32::MAX));
+        assert_eq!(a.alloc(), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn sparse_alloc_panics_when_min_greater_than_max() {
+        let _ = SparseIdAlloc::new(5, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "unallocated")]
+    fn sparse_alloc_panics_on_free_never_issued() {
+        let mut a = SparseIdAlloc::new(1, 100);
+        let _ = a.alloc();
+        a.free(5);
+    }
+
+    #[test]
+    #[should_panic(expected = "unallocated")]
+    fn sparse_alloc_panics_on_double_free() {
+        let mut a = SparseIdAlloc::new(1, 100);
+        let id = a.alloc().unwrap();
+        a.free(id);
+        a.free(id);
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -44,10 +44,11 @@ pub(super) fn make_mount_point_path(
 
 /// A single entry in the mountinfo file.
 struct MountInfoEntry<'a> {
-    /// A unique ID for the mount (but not guaranteed to be unique across reboots).
-    mount_id: usize,
-    /// The ID of the parent mount (or self if it has no parent).
-    parent_id: usize,
+    /// The recyclable mount ID (matches [`Mount::id`]); reused after the
+    /// mount is dropped.
+    mount_id: u32,
+    /// The recyclable ID of the parent mount (or self if it has no parent).
+    parent_id: u32,
     /// The major device ID of the filesystem.
     major: u32,
     /// The minor device ID of the filesystem.

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 
 pub(in crate::fs) use dentry::Dentry;
 use inherit_methods_macro::inherit_methods;
-pub use mount::{Mount, MountPropType, PerMountFlags};
+pub use mount::{MNT_UNIQUE_ID_MIN, Mount, MountPropType, PerMountFlags};
 use mount::{MountNsFileCopying, MountTopology};
 pub use mount_namespace::MountNamespace;
 pub use resolver::{

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use hashbrown::HashMap;
-use id_alloc::IdAlloc;
 use ostd::sync::{RwMutexReadGuard, RwMutexWriteGuard};
-use spin::Once;
+use sparse_id_alloc::SparseIdAlloc;
 
 use super::try_get_mnt_ns_inode;
 use crate::{
@@ -75,29 +74,64 @@ pub enum MountPropType {
     // TODO: Implement other propagation types.
 }
 
-static ID_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
+/// 32-bit recyclable mount IDs.
+///
+/// IDs start at 1; 0 is never issued and denotes an invalid mount.
+/// Exhaustion returns `ENOMEM`.
+/// Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/namespace.c#L282>
+static MOUNT_ID_ALLOCATOR: SpinLock<SparseIdAlloc> =
+    SpinLock::new(SparseIdAlloc::new(1, i32::MAX as u32));
 
-/// The reserved mount ID, which represents an invalid mount.
-static RESERVED_MOUNT_ID: usize = 0;
+/// The first 64-bit unique mount ID.
+///
+/// The minimum keeps unique IDs above the recyclable ID range, ensuring
+/// the two ID spaces never overlap numerically.
+///
+/// This value is chosen to align with Linux.
+/// Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/namespace.c#L73>
+pub const MNT_UNIQUE_ID_MIN: u64 = (1 << 31) + 1;
 
-pub(super) fn init() {
-    // TODO: Make it configurable.
-    const MAX_MOUNT_NUM: usize = 10000;
+/// Monotonically increasing 64-bit unique mount IDs.
+static NEXT_FREE_UNIQUE_ID: AtomicU64 = AtomicU64::new(MNT_UNIQUE_ID_MIN);
 
-    let mut id_allocator = IdAlloc::with_capacity(MAX_MOUNT_NUM);
-    let _ = id_allocator.alloc_specific(RESERVED_MOUNT_ID).unwrap(); // Reserve mount ID 0.
+pub(super) fn init() {}
 
-    ID_ALLOCATOR.call_once(|| SpinLock::new(id_allocator));
+/// A mount's pair of identifiers.
+///
+/// Allocates from [`MOUNT_ID_ALLOCATOR`] and [`NEXT_FREE_UNIQUE_ID`] on
+/// construction; on drop, releases the recyclable ID back to the pool.
+/// The unique ID is monotonic and is not freed.
+pub(super) struct MountId {
+    recyclable_id: u32,
+    unique_id: u64,
 }
 
-/// Allocates a new mount ID from the global pool.
-fn alloc_mount_id() -> Result<usize> {
-    ID_ALLOCATOR
-        .get()
-        .unwrap()
-        .lock()
-        .alloc()
-        .ok_or_else(|| Error::with_message(Errno::ENOMEM, "mount ID pool exhausted"))
+impl MountId {
+    /// Allocates a new pair of mount identifiers.
+    ///
+    /// Returns `None` if the recyclable ID range is exhausted.
+    pub(super) fn alloc() -> Option<Self> {
+        let recyclable_id = MOUNT_ID_ALLOCATOR.lock().alloc()?;
+        let unique_id = NEXT_FREE_UNIQUE_ID.fetch_add(1, Ordering::Relaxed);
+        Some(Self {
+            recyclable_id,
+            unique_id,
+        })
+    }
+
+    pub(super) fn recyclable_id(&self) -> u32 {
+        self.recyclable_id
+    }
+
+    pub(super) fn unique_id(&self) -> u64 {
+        self.unique_id
+    }
+}
+
+impl Drop for MountId {
+    fn drop(&mut self) {
+        MOUNT_ID_ALLOCATOR.lock().free(self.recyclable_id);
+    }
 }
 
 bitflags! {
@@ -206,8 +240,9 @@ define_atomic_version_of_integer_like_type!(PerMountFlags, {
 /// Each `Mount` can be viewed as a node in the mount tree, maintaining
 /// mount-related information and the structure of the mount tree.
 pub struct Mount {
-    /// Global unique identifier for the mount node.
-    id: usize,
+    /// Pair of recyclable and unique mount identifiers; the recyclable
+    /// half is returned to the pool when the `Mount` drops.
+    id: MountId,
     /// Root dentry.
     root_dentry: Arc<Dentry>,
     /// Mountpoint dentry. A mount node can be mounted on one dentry of another mount node,
@@ -293,9 +328,10 @@ impl Mount {
         mnt_ns: Weak<MountNamespace>,
         source: Option<String>,
     ) -> Result<Arc<Self>> {
-        let id = alloc_mount_id()?;
+        let id = MountId::alloc()
+            .ok_or_else(|| Error::with_message(Errno::ENOMEM, "mount ID space exhausted"))?;
 
-        Ok(Arc::new_cyclic(|weak_self| Self {
+        let mount = Arc::new_cyclic(|weak_self| Self {
             id,
             root_dentry: Dentry::new_root(fs.root_inode()),
             mountpoint: RwLock::new(None),
@@ -307,12 +343,28 @@ impl Mount {
             propagation: RwLock::new(MountPropType::default()),
             flags: AtomicPerMountFlags::new(flags),
             this: weak_self.clone(),
-        }))
+        });
+        // `upgrade` returns `None` for pseudo mounts (no namespace) and for
+        // mounts still being built by `MountNamespace::new_with_root` (the
+        // namespace is a `UniqueArc` at that point). The latter are
+        // registered by `new_with_root` after the namespace is finalized.
+        if let Some(ns) = mount.mnt_ns.upgrade() {
+            ns.register_mount(&mount);
+        }
+        Ok(mount)
     }
 
-    /// Gets the mount ID.
-    pub fn id(&self) -> usize {
-        self.id
+    /// Gets the recyclable 32-bit mount ID.
+    pub fn id(&self) -> u32 {
+        self.id.recyclable_id()
+    }
+
+    /// Gets the unique 64-bit mount ID.
+    ///
+    /// Unique IDs start at [`MNT_UNIQUE_ID_MIN`], increase monotonically,
+    /// and are never reused.
+    pub fn unique_id(&self) -> u64 {
+        self.id.unique_id()
     }
 
     /// Returns the mount source.
@@ -389,9 +441,10 @@ impl Mount {
         root_dentry: &Arc<Dentry>,
         new_ns: &Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
-        let id = alloc_mount_id()?;
+        let id = MountId::alloc()
+            .ok_or_else(|| Error::with_message(Errno::ENOMEM, "mount ID space exhausted"))?;
 
-        Ok(Arc::new_cyclic(|weak_self| Self {
+        let mount = Arc::new_cyclic(|weak_self| Self {
             id,
             root_dentry: root_dentry.clone(),
             mountpoint: RwLock::new(None),
@@ -403,7 +456,11 @@ impl Mount {
             propagation: RwLock::new(MountPropType::default()),
             flags: AtomicPerMountFlags::new(self.flags.load(Ordering::Relaxed)),
             this: weak_self.clone(),
-        }))
+        });
+        if let Some(ns) = mount.mnt_ns.upgrade() {
+            ns.register_mount(&mount);
+        }
+        Ok(mount)
     }
 
     /// Clones a mount tree starting from the specified root `Dentry`.
@@ -703,6 +760,12 @@ impl Debug for Mount {
 impl Drop for Mount {
     fn drop(&mut self) {
         self.clear_mountpoint();
-        ID_ALLOCATOR.get().unwrap().lock().free(self.id);
+        // `upgrade` returns `None` for pseudo mounts (no namespace) and for
+        // mounts whose namespace is itself being dropped (the `mounts` map
+        // will be freed in a moment).
+        if let Some(ns) = self.mnt_ns.upgrade() {
+            ns.deregister_mount(self.id.unique_id());
+        }
+        // The recyclable ID is returned to the pool by `MountId`'s `Drop`.
     }
 }

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -164,10 +164,6 @@ impl MountNamespace {
     ///
     /// No recyclable-`id` counterpart exists: the 32-bit ID space is reused
     /// on drop, so a keyed lookup would race the next allocation.
-    #[expect(
-        dead_code,
-        reason = "no in-tree consumer yet; staged for statmount/listmount"
-    )]
     pub fn lookup_by_unique_id(&self, unique_id: u64) -> Option<Arc<Mount>> {
         let mount = {
             let mounts = self.mounts.lock();
@@ -178,6 +174,34 @@ impl MountNamespace {
         mount
             .is_equal_or_descendant_of(self.root(), &topology_guard)
             .then_some(mount)
+    }
+
+    /// Returns live mounts in this namespace that are strict descendants of
+    /// `parent`, ordered by [`Mount::unique_id`].
+    ///
+    /// Live mounts are snapshotted under `mounts.lock`; ancestry is checked
+    /// afterward so per-`Mount` locks are never acquired while the table lock
+    /// is held.
+    pub fn descendant_mounts_of(
+        &self,
+        parent: &Arc<Mount>,
+    ) -> impl DoubleEndedIterator<Item = Arc<Mount>> {
+        let snapshot: Vec<_> = {
+            let guard = self.mounts.lock();
+            guard.values().filter_map(|weak| weak.upgrade()).collect()
+        };
+
+        let topology_guard = MountTopology::read_lock();
+
+        let descendants: Vec<_> = snapshot
+            .into_iter()
+            .filter(|mount| {
+                !Arc::ptr_eq(mount, parent)
+                    && mount.is_equal_or_descendant_of(parent, &topology_guard)
+            })
+            .collect();
+
+        descendants.into_iter()
     }
 
     /// Walks the in-place mount tree and registers every mount in

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -38,6 +38,8 @@ pub struct MountNamespace {
     owner: Arc<UserNamespace>,
     /// The stashed dentry in nsfs.
     stashed_dentry: StashedDentry,
+    /// Live mounts that belong to this namespace, keyed by [`Mount::unique_id`].
+    mounts: SpinLock<BTreeMap<u64, Weak<Mount>>>,
 }
 
 impl PartialEq for MountNamespace {
@@ -74,10 +76,16 @@ impl MountNamespace {
             root: None,
             owner,
             stashed_dentry: StashedDentry::new(),
+            mounts: SpinLock::new(BTreeMap::new()),
         });
         let root = build_root_fn(&UniqueArc::downgrade(&new_ns))?;
         new_ns.root = Some(root);
-        Ok(UniqueArc::into_arc(new_ns))
+        let ns = UniqueArc::into_arc(new_ns);
+        // Mounts created inside `build_root_fn` saw a `Weak` to a
+        // `UniqueArc`, whose `upgrade` returns `None`; they could not
+        // self-register at construction. Register the finished tree.
+        ns.register_existing_mount_tree();
+        Ok(ns)
     }
 
     /// Returns a reference to the singleton initial mount namespace.
@@ -138,6 +146,57 @@ impl MountNamespace {
                 &topology_guard,
             )
         })
+    }
+
+    /// Records that `mount` is now part of this namespace's mount tree.
+    pub(super) fn register_mount(&self, mount: &Arc<Mount>) {
+        self.mounts
+            .lock()
+            .insert(mount.unique_id(), Arc::downgrade(mount));
+    }
+
+    /// Removes `unique_id` from this namespace's lookup table.
+    pub(super) fn deregister_mount(&self, unique_id: u64) {
+        self.mounts.lock().remove(&unique_id);
+    }
+
+    /// Looks up a live mount in this namespace by its unique 64-bit ID.
+    ///
+    /// No recyclable-`id` counterpart exists: the 32-bit ID space is reused
+    /// on drop, so a keyed lookup would race the next allocation.
+    #[expect(
+        dead_code,
+        reason = "no in-tree consumer yet; staged for statmount/listmount"
+    )]
+    pub fn lookup_by_unique_id(&self, unique_id: u64) -> Option<Arc<Mount>> {
+        let mount = {
+            let mounts = self.mounts.lock();
+            mounts.get(&unique_id).and_then(Weak::upgrade)?
+        };
+
+        let topology_guard = MountTopology::read_lock();
+        mount
+            .is_equal_or_descendant_of(self.root(), &topology_guard)
+            .then_some(mount)
+    }
+
+    /// Walks the in-place mount tree and registers every mount in
+    /// [`Self::mounts`] in a single locked update.
+    fn register_existing_mount_tree(self: &Arc<Self>) {
+        let mut entries = Vec::new();
+        let mut stack = vec![self.root().clone()];
+
+        while let Some(mount) = stack.pop() {
+            entries.push((mount.unique_id(), Arc::downgrade(&mount)));
+
+            let children: Vec<_> = mount.children.read().values().cloned().collect();
+            stack.extend(children);
+        }
+
+        let mut mounts = self.mounts.lock();
+        for (id, weak_mount) in entries {
+            mounts.insert(id, weak_mount);
+        }
     }
 
     /// Flushes all pending filesystem metadata and cached file data to the device

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -69,6 +69,7 @@ macro_rules! import_generic_syscall_entries {
             kill::sys_kill,
             link::sys_linkat,
             listen::sys_listen,
+            listmount::sys_listmount,
             listxattr::{sys_flistxattr, sys_listxattr, sys_llistxattr},
             lseek::sys_lseek,
             madvise::sys_madvise,
@@ -414,6 +415,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_FACCESSAT2 = 439             => sys_faccessat2(args[..4]);
             SYS_EPOLL_PWAIT2 = 441           => sys_epoll_pwait2(args[..6]);
             SYS_FCHMODAT2 = 452              => sys_fchmodat2(args[..4]);
+            SYS_LISTMOUNT = 458              => sys_listmount(args[..4]);
             // Architecture-specific syscalls
             $( $name = $num => $handler $args );*
         }

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -69,6 +69,7 @@ use super::{
     kill::sys_kill,
     link::{sys_link, sys_linkat},
     listen::sys_listen,
+    listmount::sys_listmount,
     listxattr::{sys_flistxattr, sys_listxattr, sys_llistxattr},
     lseek::sys_lseek,
     madvise::sys_madvise,
@@ -429,4 +430,5 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_FACCESSAT2 = 439       => sys_faccessat2(args[..4]);
     SYS_EPOLL_PWAIT2 = 441     => sys_epoll_pwait2(args[..6]);
     SYS_FCHMODAT2 = 452        => sys_fchmodat2(args[..4]);
+    SYS_LISTMOUNT = 458        => sys_listmount(args[..4]);
 }

--- a/kernel/src/syscall/listmount.rs
+++ b/kernel/src/syscall/listmount.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::mm::VmIo;
+
+use super::SyscallReturn;
+use crate::{fs::vfs::path::MNT_UNIQUE_ID_MIN, prelude::*};
+
+/// Size in bytes of the first published `mnt_id_req` layout; the only
+/// size currently accepted.
+const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+
+/// Sentinel for `mnt_id_req::mnt_id` requesting the namespace root.
+const LSMT_ROOT: u64 = u64::MAX;
+
+/// `flags` bit: return descendants in descending `unique_id` order.
+const LISTMOUNT_REVERSE: u32 = 1 << 0;
+
+/// Upper bound on `nr_mnt_ids`.
+/// Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/namespace.c#L6036>
+const LISTMOUNT_NR_LIMIT: usize = 1_000_000;
+
+/// Linux's `struct mnt_id_req`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+struct MntIdReq {
+    /// Caller-side `sizeof(struct mnt_id_req)`.
+    size: u32,
+    /// Reserved; must be zero.
+    spare: u32,
+    /// Parent mount's `unique_id`, or [`LSMT_ROOT`] for the namespace
+    /// root.
+    mnt_id: u64,
+    /// Pagination cursor: only descendants with `unique_id > param`
+    /// (or `<` in reverse) are returned. `0` starts from the beginning.
+    param: u64,
+}
+
+const _: () = assert!(size_of::<MntIdReq>() as u32 == MNT_ID_REQ_SIZE_VER0);
+
+pub fn sys_listmount(
+    req_ptr: Vaddr,
+    mnt_ids_ptr: Vaddr,
+    nr_mnt_ids: usize,
+    flags: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    debug!(
+        "req_ptr = 0x{:x}, mnt_ids_ptr = 0x{:x}, nr_mnt_ids = {}, flags = 0x{:x}",
+        req_ptr, mnt_ids_ptr, nr_mnt_ids, flags,
+    );
+
+    if flags & !LISTMOUNT_REVERSE != 0 {
+        return_errno_with_message!(Errno::EINVAL, "invalid listmount flags");
+    }
+    let reverse = flags & LISTMOUNT_REVERSE != 0;
+
+    if nr_mnt_ids > LISTMOUNT_NR_LIMIT {
+        return_errno_with_message!(Errno::EOVERFLOW, "nr_mnt_ids too large");
+    }
+
+    let user_space = ctx.user_space();
+
+    // Validate the output buffer up front so an invalid pointer surfaces
+    // as `EFAULT` before any namespace work is done.
+    let mut mnt_ids_writer = user_space.writer(mnt_ids_ptr, nr_mnt_ids * size_of::<u64>())?;
+
+    let req: MntIdReq = user_space.read_val(req_ptr)?;
+    if req.size != MNT_ID_REQ_SIZE_VER0 {
+        return_errno_with_message!(Errno::EINVAL, "unsupported mnt_id_req size");
+    }
+    if req.spare != 0 {
+        return_errno_with_message!(Errno::EINVAL, "non-zero spare field");
+    }
+    if req.mnt_id != LSMT_ROOT && req.mnt_id < MNT_UNIQUE_ID_MIN {
+        return_errno_with_message!(Errno::EINVAL, "mnt_id is not a valid unique mount ID");
+    }
+    if req.param != 0 && req.param < MNT_UNIQUE_ID_MIN {
+        return_errno_with_message!(Errno::EINVAL, "param is not a valid unique mount ID");
+    }
+
+    let ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let mnt_ns = ns_proxy.unwrap().mnt_ns();
+
+    let parent_mount = if req.mnt_id == LSMT_ROOT {
+        mnt_ns.root().clone()
+    } else {
+        mnt_ns
+            .lookup_by_unique_id(req.mnt_id)
+            .ok_or_else(|| Error::with_message(Errno::ENOENT, "no such mount"))?
+    };
+
+    if nr_mnt_ids == 0 {
+        return Ok(SyscallReturn::Return(0));
+    }
+
+    let mounts = mnt_ns.descendant_mounts_of(&parent_mount);
+    let ids: Vec<_> = if reverse {
+        mounts
+            .rev()
+            .map(|mount| mount.unique_id())
+            .filter(|&id| req.param == 0 || id < req.param)
+            .take(nr_mnt_ids)
+            .collect()
+    } else {
+        mounts
+            .map(|mount| mount.unique_id())
+            .filter(|&id| id > req.param)
+            .take(nr_mnt_ids)
+            .collect()
+    };
+
+    for id in &ids {
+        mnt_ids_writer.write_val(id)?;
+    }
+
+    Ok(SyscallReturn::Return(ids.len() as isize))
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -82,6 +82,7 @@ mod ioctl;
 mod kill;
 mod link;
 mod listen;
+mod listmount;
 mod listxattr;
 mod lseek;
 mod madvise;

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -62,7 +62,7 @@ pub fn sys_statx(
         }
     };
 
-    let statx = Statx::new(&path);
+    let statx = Statx::new(&path, mask);
 
     user_space.write_val(statx_buf_ptr, &statx)?;
     Ok(SyscallReturn::Return(0))
@@ -122,7 +122,7 @@ pub struct Statx {
 }
 
 impl Statx {
-    fn new(path: &Path) -> Self {
+    fn new(path: &Path, requested_mask: StatxMask) -> Self {
         let info = path.metadata();
 
         let (stx_dev_major, stx_dev_minor) =
@@ -138,10 +138,25 @@ impl Statx {
             stx_attributes |= STATX_ATTR_MOUNT_ROOT;
         }
 
+        // If `STATX_MNT_ID_UNIQUE` is specified, a 64-bit unique ID is provided
+        // instead of a 32-bit recyclable ID.
+        // Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/stat.c#L303>
+        let want_unique_mnt_id = requested_mask.contains(StatxMask::STATX_MNT_ID_UNIQUE);
+        let stx_mnt_id = if want_unique_mnt_id {
+            path.mount_node().unique_id()
+        } else {
+            path.mount_node().id() as u64
+        };
+        let mnt_id_mask_bit = if want_unique_mnt_id {
+            StatxMask::STATX_MNT_ID_UNIQUE
+        } else {
+            StatxMask::STATX_MNT_ID
+        };
+
         // Build `stx_mask` based on what's supported and what was requested.
         // TODO: Pass the request `stx_mask` to the filesystem. It can determine which information
         // to return and omit the information that is not requested and expensive to query.
-        let mut stx_mask = StatxMask::STATX_BASIC_STATS.bits() | StatxMask::STATX_MNT_ID.bits();
+        let mut stx_mask = StatxMask::STATX_BASIC_STATS.bits() | mnt_id_mask_bit.bits();
 
         // Include `STATX_BTIME` if the birth time is available.
         let stx_btime = if let Some(birth_at) = info.birth_at {
@@ -173,7 +188,7 @@ impl Statx {
             stx_rdev_minor,
             stx_dev_major,
             stx_dev_minor,
-            stx_mnt_id: path.mount_node().id() as u64,
+            stx_mnt_id,
             stx_dio_mem_align: 0,
             stx_dio_offset_align: 0,
             __spare3: [0; 12],

--- a/test/initramfs/src/regression/fs/mount/listmount.c
+++ b/test/initramfs/src/regression/fs/mount/listmount.c
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/mount.h>
+#include <linux/stat.h>
+#include <sched.h>
+#include <stdint.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define MNT_UNIQUE_ID_MIN ((1ULL << 31) + 1)
+
+#define LM_PARENT "/tmp/lm_parent"
+#define LM_CHILD "/tmp/lm_parent/child"
+
+FN_SETUP(setup)
+{
+	CHECK(unshare(CLONE_NEWNS));
+	CHECK(mkdir(LM_PARENT, 0755));
+	CHECK(mount("tmpfs", LM_PARENT, "tmpfs", 0, NULL));
+	CHECK(mkdir(LM_CHILD, 0755));
+	CHECK(mount("tmpfs", LM_CHILD, "tmpfs", 0, NULL));
+}
+END_SETUP()
+
+static uint64_t mount_unique_id(const char *path)
+{
+	struct statx stx;
+	int r = statx(AT_FDCWD, path, 0, STATX_MNT_ID_UNIQUE, &stx);
+	if (r < 0) {
+		return 0;
+	}
+	return stx.stx_mnt_id;
+}
+
+FN_TEST(listmount_lsmt_root_lists_root_descendants)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t ids[16];
+	TEST_RES(syscall(SYS_listmount, &req, ids, 16, 0), _ret >= 1);
+}
+END_TEST()
+
+FN_TEST(listmount_lists_descendants_of_specific_parent)
+{
+	uint64_t parent_uid = TEST_RES(mount_unique_id(LM_PARENT), _ret != 0);
+	uint64_t child_uid = TEST_RES(mount_unique_id(LM_CHILD), _ret != 0);
+
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = parent_uid,
+	};
+	uint64_t ids[16];
+	TEST_RES(syscall(SYS_listmount, &req, ids, 16, 0), _ret == 1);
+	TEST_RES(ids[0], _ret == child_uid);
+}
+END_TEST()
+
+FN_TEST(listmount_cursor_paginates)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t first[16];
+	long n_total =
+		TEST_RES(syscall(SYS_listmount, &req, first, 16, 0), _ret >= 2);
+
+	for (long i = 1; i < n_total; i++) {
+		TEST_RES(first[i], _ret > first[i - 1]);
+	}
+
+	req.param = first[0];
+	uint64_t rest[16];
+	TEST_RES(syscall(SYS_listmount, &req, rest, 16, 0),
+		 _ret == n_total - 1);
+}
+END_TEST()
+
+FN_TEST(listmount_reverse_inverts_order)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t asc[16];
+	long n_asc =
+		TEST_RES(syscall(SYS_listmount, &req, asc, 16, 0), _ret >= 2);
+	uint64_t desc[16];
+	long n_desc = TEST_RES(syscall(SYS_listmount, &req, desc, 16,
+				       LISTMOUNT_REVERSE),
+			       _ret == n_asc);
+	TEST_RES(asc[0], _ret == desc[n_desc - 1]);
+	TEST_RES(asc[n_asc - 1], _ret == desc[0]);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_unmounted_parent)
+{
+	uint64_t child_uid = TEST_RES(mount_unique_id(LM_CHILD), _ret != 0);
+	TEST_SUCC(chdir(LM_CHILD));
+	TEST_SUCC(umount(LM_CHILD));
+
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = child_uid,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), ENOENT);
+
+	TEST_SUCC(chdir("/"));
+	TEST_SUCC(mount("tmpfs", LM_CHILD, "tmpfs", 0, NULL));
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_unknown_flags)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0xFFFFFFFEU), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_excessive_nr_mnt_ids)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1000001, 0), EOVERFLOW);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_undersized_req)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0 - 1,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_oversized_req)
+{
+	// Pretending to be a future VER1-sized request must be rejected, not
+	// silently truncated to VER0 semantics.
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0 + 8,
+		.mnt_id = LSMT_ROOT,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_nonzero_spare)
+{
+	// The second u32 is named `spare` in older headers and `mnt_ns_fd` in
+	// newer ones.
+	struct mnt_id_req req = {
+		MNT_ID_REQ_SIZE_VER0,
+		1,
+		LSMT_ROOT,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_invalid_mnt_ids_buffer)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+	};
+	// A pointer past the user-space boundary fails the early buffer
+	// validation, returning EFAULT before any namespace work.
+	uint64_t *bogus = (uint64_t *)-1;
+	TEST_ERRNO(syscall(SYS_listmount, &req, bogus, 16, 0), EFAULT);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_out_of_range_mnt_id)
+{
+	// IDs below `MNT_UNIQUE_ID_MIN` are outside the unique mount ID range.
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = 0,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+
+	req.mnt_id = MNT_UNIQUE_ID_MIN - 1;
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+}
+END_TEST()
+
+FN_TEST(listmount_rejects_out_of_range_param)
+{
+	struct mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER0,
+		.mnt_id = LSMT_ROOT,
+		.param = MNT_UNIQUE_ID_MIN - 1,
+	};
+	uint64_t ids[1];
+	TEST_ERRNO(syscall(SYS_listmount, &req, ids, 1, 0), EINVAL);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(umount(LM_CHILD));
+	CHECK(rmdir(LM_CHILD));
+	CHECK(umount(LM_PARENT));
+	CHECK(rmdir(LM_PARENT));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -122,6 +122,7 @@ echo "All mount bind file test passed."
 ./isolation/chroot
 ./isolation/pivot_root
 
+./mount/listmount
 ./mount/mount_api
 ./mount/mount_move
 


### PR DESCRIPTION
This PR introduces a new allocator, and overhauls VFS mount ID allocation.

- Add `SparseIdAlloc`, a range-bounded sparse `u32` ID allocator.
- Overhaul mount ID allocation: drop the upper bound, add unique IDs.

Per PR #3219, the reviewer asked for a deeper overhaul matching Linux:

> the entire mount ID allocation logic must be overhauled to (1) get rid of the hardcoded upper bound for mount IDs, (2) support the 64-bit unique mount IDs in addition to the legacy 32-bit ones, and (3) support looking up Mount with unique mount IDs. In Linux, the mount ID allocator is based on Xarray. And Linux's mount ID allocator may return ENOSPC (if the number of mount IDs reaches an upper bound specified by a user-specified policy) or ENOMEM (if Xarray fails to allocate new nodes).

## Follow-up

- Migrate the namespace lookup table from `BTreeMap<u64, Weak<Mount>>` to `XArray` once `ostd/` provides `NonNullPtr for Weak<T>`. Linux unifies allocation and lookup of unique IDs in a single xarray; we split them because Asterinas' `XArray<P>` currently requires `P: NonNullPtr`.
- Kernel-side `#[ktest]` for `unique_id` monotonicity / `lookup_by_unique_id` round-trip / `Drop` ID return.
- Userspace regression tests for `statx(STATX_MNT_ID_UNIQUE)` semantics and `/proc/self/mountinfo` field parsing.