### PR TITLE
Add IPv6 dual-stack and IPV6_V6ONLY support for TCP (StreamSocket) [TCP only]

### DIFF
--- a/kernel/src/net/socket/ip/addr.rs
+++ b/kernel/src/net/socket/ip/addr.rs
@@ -58,9 +58,100 @@ impl IpAddressFamily {
     }
 }
 
-// Note: This does not handle IPv4-mapped IPv6 addresses. When `IPV6_V6ONLY` is set,
-// IPv4-mapped addresses are not permitted, so this function cannot be used to determine
-// whether such an address is acceptable.
+/// Returns `true` if the address is an IPv4-mapped IPv6 address (`::ffff:x.x.x.x`).
+pub(super) fn is_ipv4_mapped(addr: IpAddress) -> bool {
+    matches!(addr, IpAddress::Ipv6(v6) if v6.to_ipv4_mapped().is_some())
+}
+
+/// Maps a bare IPv4 endpoint to an IPv4-mapped IPv6 [`SocketAddr`].
+///
+/// Native IPv6 endpoints pass through unchanged.
+// Used by `present_to_user` to present dual-stack addresses
+// to the user in IPv4-mapped IPv6 form per RFC 4038.
+pub(super) fn ipv4_to_ipv4_mapped(endpoint: IpEndpoint) -> SocketAddr {
+    if let IpAddress::Ipv4(ipv4) = endpoint.addr {
+        let mapped = IpAddress::Ipv6(ipv4.to_ipv6_mapped());
+        return SocketAddr::from(IpEndpoint::new(mapped, endpoint.port));
+    }
+    SocketAddr::from(endpoint)
+}
+
+/// Strips the IPv4-mapped prefix (`::ffff:x.x.x.x` → `x.x.x.x`).
+///
+/// Native IPv4 and native IPv6 pass through unchanged.
+/// Must be called before handing an address to smoltcp, which does not
+/// understand mapped addresses. Idempotent — safe to call defensively.
+pub(crate) fn unmap_ipv4_addr(addr: IpAddress) -> IpAddress {
+    match addr {
+        IpAddress::Ipv6(addr) => match addr.to_ipv4_mapped() {
+            Some(ipv4) => IpAddress::Ipv4(ipv4),
+            None => IpAddress::Ipv6(addr),
+        },
+        other => other,
+    }
+}
+
+/// Normalizes an endpoint for a socket's address family.
+///
+/// In dual-stack mode (IPv6 + !v6only), maps bare IPv4 addresses to
+/// IPv4-mapped IPv6 so the socket layer can process them uniformly.
+pub(super) fn normalize_endpoint(
+    family: IpAddressFamily,
+    v6only: bool,
+    endpoint: IpEndpoint,
+) -> IpEndpoint {
+    if family == IpAddressFamily::IPv6
+        && !v6only
+        && let IpAddress::Ipv4(ipv4) = endpoint.addr
+    {
+        return IpEndpoint::new(IpAddress::Ipv6(ipv4.to_ipv6_mapped()), endpoint.port);
+    }
+    endpoint
+}
+
+/// Normalizes and validates the endpoint for a socket's address family.
+/// Returns `Err` if the endpoint is incompatible with the socket.
+pub(super) fn validate_endpoint(
+    family: IpAddressFamily,
+    v6only: bool,
+    endpoint: IpEndpoint,
+) -> Result<IpEndpoint> {
+    let endpoint = normalize_endpoint(family, v6only, endpoint);
+
+    if is_ipv4_mapped(endpoint.addr) && v6only {
+        return_errno_with_message!(
+            Errno::EAFNOSUPPORT,
+            "IPv4-mapped IPv6 addresses are not allowed when IPV6_V6ONLY is set"
+        );
+    }
+
+    if IpAddressFamily::from(endpoint.addr) != family {
+        return_errno_with_message!(
+            Errno::EAFNOSUPPORT,
+            "the protocol family does not match the address family"
+        );
+    }
+
+    Ok(endpoint)
+}
+
+/// Presents a stored endpoint to the user per RFC 4038.
+///
+/// For AF_INET6 sockets, bare IPv4 addresses are mapped to IPv4-mapped IPv6 form.
+/// The `IPV6_V6ONLY` setting is intentionally **ignored** — per RFC 4038,
+/// `getsockname`/`getpeername` always present dual-stack addresses in mapped form
+/// regardless of the `IPV6_V6ONLY` socket option.
+pub(super) fn present_to_user(family: IpAddressFamily, endpoint: IpEndpoint) -> SocketAddr {
+    if family == IpAddressFamily::IPv6 && matches!(endpoint.addr, IpAddress::Ipv4(_)) {
+        return ipv4_to_ipv4_mapped(endpoint);
+    }
+    SocketAddr::from(endpoint)
+}
+
+// Note: This does not handle IPv4-mapped IPv6 addresses — it returns `IPv6`
+// for them. Callers that need to reject IPv4-mapped addresses when
+// `IPV6_V6ONLY` is set must combine this with an explicit `is_ipv4_mapped`
+// check (see `validate_endpoint`).
 impl From<IpAddress> for IpAddressFamily {
     fn from(addr: IpAddress) -> Self {
         match addr {

--- a/kernel/src/net/socket/ip/common.rs
+++ b/kernel/src/net/socket/ip/common.rs
@@ -6,6 +6,7 @@ use aster_bigtcp::{
     wire::{IpAddress, IpEndpoint},
 };
 
+use super::unmap_ipv4_addr;
 use crate::{
     net::{
         iface::{Iface, iter_all_ifaces, loopback_iface, virtio_iface},
@@ -75,7 +76,8 @@ pub(super) fn resolve_bind_iface_and_config(
 ) -> Result<(Arc<Iface>, BindPortConfig)> {
     check_port_privilege(endpoint.port)?;
 
-    let iface = match get_iface_to_bind(&endpoint.addr) {
+    let effective_addr = unmap_ipv4_addr(endpoint.addr);
+    let iface = match get_iface_to_bind(&effective_addr) {
         Some(iface) => iface,
         None => {
             return_errno_with_message!(
@@ -104,8 +106,9 @@ impl From<BindError> for Error {
 }
 
 pub(super) fn get_ephemeral_endpoint(remote_endpoint: &IpEndpoint) -> Option<IpEndpoint> {
-    let iface = get_ephemeral_iface(&remote_endpoint.addr);
-    match remote_endpoint.addr {
+    let effective_addr = unmap_ipv4_addr(remote_endpoint.addr);
+    let iface = get_ephemeral_iface(&effective_addr);
+    match effective_addr {
         IpAddress::Ipv4(_) => {
             let ip_addr = iface.ipv4_addr()?;
             Some(IpEndpoint::new(IpAddress::Ipv4(ip_addr), 0))

--- a/kernel/src/net/socket/ip/ipv6_options.rs
+++ b/kernel/src/net/socket/ip/ipv6_options.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_bigtcp::socket::NeedIfacePoll;
+
+use super::options::Ipv6V6only;
+use crate::{
+    net::socket::options::{
+        SocketOption,
+        macros::{sock_option_mut, sock_option_ref},
+    },
+    prelude::*,
+};
+
+/// IPv6-level socket options.
+#[derive(Clone, Copy, CopyGetters, Debug, Setters)]
+#[get_copy = "pub"]
+#[set = "pub"]
+pub(super) struct Ipv6OptionSet {
+    v6only: bool,
+}
+
+impl Ipv6OptionSet {
+    pub(super) const fn new() -> Self {
+        Self { v6only: false }
+    }
+
+    pub(super) fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+        sock_option_mut!(match option {
+            ipv6_v6only @ Ipv6V6only => {
+                let v6only = self.v6only();
+                ipv6_v6only.set(v6only);
+            }
+            _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option is unknown"),
+        });
+
+        Ok(())
+    }
+
+    pub(super) fn set_option(&mut self, option: &dyn SocketOption) -> Result<NeedIfacePoll> {
+        sock_option_ref!(match option {
+            ipv6_v6only @ Ipv6V6only => {
+                let v6only = ipv6_v6only.get().unwrap();
+                self.set_v6only(*v6only);
+            }
+            _ => return_errno_with_message!(
+                Errno::ENOPROTOOPT,
+                "the socket option to be set is unknown"
+            ),
+        });
+
+        Ok(NeedIfacePoll::FALSE)
+    }
+}

--- a/kernel/src/net/socket/ip/mod.rs
+++ b/kernel/src/net/socket/ip/mod.rs
@@ -3,10 +3,12 @@
 mod addr;
 mod common;
 mod datagram;
+pub(super) mod ipv6_options;
 pub mod options;
 mod stream;
 
 pub use addr::IpAddressFamily;
+pub(crate) use addr::unmap_ipv4_addr;
 pub use datagram::DatagramSocket;
 pub(in crate::net) use datagram::observer::DatagramObserver;
 pub(in crate::net) use stream::observer::StreamObserver;

--- a/kernel/src/net/socket/ip/options.rs
+++ b/kernel/src/net/socket/ip/options.rs
@@ -110,6 +110,7 @@ impl_socket_options!(
     pub struct Ttl(IpTtl);
     pub struct Hdrincl(bool);
     pub struct Recverr(bool);
+    pub struct Ipv6V6only(bool);
 );
 
 #[derive(Clone, Copy, Debug)]

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -7,7 +7,10 @@ use core::{
 
 use aster_bigtcp::{socket::RawTcpOption, wire::IpEndpoint};
 
-use super::{connecting::ConnectingStream, listen::ListenStream, observer::StreamObserver};
+use super::{
+    super::unmap_ipv4_addr, connecting::ConnectingStream, listen::ListenStream,
+    observer::StreamObserver,
+};
 use crate::{
     events::IoEvents,
     net::{
@@ -80,18 +83,17 @@ impl InitStream {
         }
     }
 
-    /// Returns the address family of this socket.
-    pub(super) fn family(&self) -> IpAddressFamily {
-        self.family
-    }
-
     pub(super) fn bind(&mut self, endpoint: &IpEndpoint, can_reuse: bool) -> Result<()> {
         if self.bound_port.is_some() {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
         }
 
-        // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
-        // IPv6 addresses.
+        // The endpoint must already be validated by the caller
+        // (`StreamSocket::bind` validates under the state write lock).
+        debug_assert!(
+            IpAddressFamily::from(endpoint.addr) == self.family,
+            "bind: endpoint family mismatch (caller must validate first)"
+        );
         if IpAddressFamily::from(endpoint.addr) != self.family {
             return_errno_with_message!(
                 Errno::EAFNOSUPPORT,
@@ -120,8 +122,10 @@ impl InitStream {
             "`finish_last_connect()` should be called before calling `connect()`"
         );
 
-        // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
-        // IPv6 addresses.
+        debug_assert!(
+            IpAddressFamily::from(remote_endpoint.addr) == self.family,
+            "connect: endpoint family mismatch (caller must validate first)"
+        );
         if IpAddressFamily::from(remote_endpoint.addr) != self.family {
             return Err((
                 Error::with_message(
@@ -135,6 +139,8 @@ impl InitStream {
         let bound_port = if let Some(bound_port) = self.bound_port {
             bound_port
         } else {
+            // `get_ephemeral_endpoint` internally calls `unmap_ipv4_addr`,
+            // so it handles both bare IPv4 and IPv4-mapped IPv6 correctly.
             let endpoint = match get_ephemeral_endpoint(remote_endpoint) {
                 Some(ep) => ep,
                 None => {
@@ -153,7 +159,14 @@ impl InitStream {
             }
         };
 
-        ConnectingStream::new(bound_port, *remote_endpoint, option, observer).map_err(
+        // `ConnectingStream` expects a bare IPv4 address (mapped addresses are
+        // not understood by the low-level network stack). The caller in
+        // `StreamSocket::start_connect` already validated the address.
+        // We unmap here to ensure the low-level stack always sees native addresses.
+        let remote_endpoint =
+            IpEndpoint::new(unmap_ipv4_addr(remote_endpoint.addr), remote_endpoint.port);
+
+        ConnectingStream::new(bound_port, remote_endpoint, option, observer).map_err(
             |(err, bound_port)| {
                 if err.error() == Errno::ECONNREFUSED {
                     (err, InitStream::new_refused(bound_port, self.family))

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -21,7 +21,8 @@ use takeable::Takeable;
 use util::{Retrans, TcpOptionSet};
 
 use super::{
-    addr::IpAddressFamily,
+    addr::{IpAddressFamily, present_to_user, validate_endpoint},
+    ipv6_options::Ipv6OptionSet,
     options::{IpOptionSet, SetIpLevelOption},
 };
 use crate::{
@@ -62,6 +63,7 @@ pub struct StreamSocket {
     state: RwLock<Takeable<State>>,
     options: RwLock<OptionSet>,
 
+    family: IpAddressFamily,
     is_nonblocking: AtomicBool,
     pollee: Pollee,
     pseudo_path: Path,
@@ -82,6 +84,7 @@ enum State {
 struct OptionSet {
     socket: SocketOptionSet,
     ip: IpOptionSet,
+    ipv6: Ipv6OptionSet,
     tcp: TcpOptionSet,
 }
 
@@ -89,8 +92,14 @@ impl OptionSet {
     fn new() -> Self {
         let socket = SocketOptionSet::new_tcp();
         let ip = IpOptionSet::new_tcp();
+        let ipv6 = Ipv6OptionSet::new();
         let tcp = TcpOptionSet::new();
-        OptionSet { socket, ip, tcp }
+        OptionSet {
+            socket,
+            ip,
+            ipv6,
+            tcp,
+        }
     }
 
     fn raw(&self) -> RawTcpOption {
@@ -109,13 +118,18 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
             options: RwLock::new(OptionSet::new()),
+            family,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
         })
     }
 
-    fn new_accepted(connected_stream: ConnectedStream, listener_options: &OptionSet) -> Arc<Self> {
+    fn new_accepted(
+        connected_stream: ConnectedStream,
+        family: IpAddressFamily,
+        listener_options: &OptionSet,
+    ) -> Arc<Self> {
         let options = connected_stream.raw_with(|raw_tcp_socket| {
             let mut options = OptionSet::new();
 
@@ -153,6 +167,7 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             options: RwLock::new(options),
+            family,
             is_nonblocking: AtomicBool::new(false),
             pollee,
             pseudo_path: SockFs::new_path(),
@@ -215,6 +230,15 @@ impl StreamSocket {
         let mut state = self.write_updated_state();
 
         let options = self.options.read();
+        let v6only = if self.family == IpAddressFamily::IPv6 {
+            options.ipv6.v6only()
+        } else {
+            false
+        };
+        let remote_endpoint = match validate_endpoint(self.family, v6only, *remote_endpoint) {
+            Ok(ep) => ep,
+            Err(e) => return Some(Err(e)),
+        };
         let raw_option = options.raw();
 
         let (result_or_block, iface_to_poll) = state.borrow_result(|mut owned_state| {
@@ -256,7 +280,7 @@ impl StreamSocket {
             }
 
             let (target_state, iface_to_poll) = match init_stream.connect(
-                remote_endpoint,
+                &remote_endpoint,
                 &raw_option,
                 options.socket.reuse_addr(),
                 StreamObserver::new(self.pollee.clone()),
@@ -322,8 +346,10 @@ impl StreamSocket {
         let accepted = listen_stream.try_accept().map(|connected_stream| {
             let remote_endpoint = connected_stream.remote_endpoint();
             let listener_options = self.options.read();
-            let accepted_socket = Self::new_accepted(connected_stream, &listener_options);
-            (accepted_socket as _, remote_endpoint.into())
+            let accepted_socket =
+                Self::new_accepted(connected_stream, self.family, &listener_options);
+            let remote_addr = self.present_addr(remote_endpoint);
+            (accepted_socket as _, remote_addr)
         });
         let iface_to_poll = listen_stream.iface().clone();
 
@@ -368,7 +394,7 @@ impl StreamSocket {
             iface.poll();
         }
 
-        Ok((recv_bytes, remote_endpoint.into()))
+        Ok((recv_bytes, self.present_addr(remote_endpoint)))
     }
 
     fn try_send(&self, reader: &mut dyn MultiRead, flags: SendRecvFlags) -> Result<usize> {
@@ -427,6 +453,11 @@ impl StreamSocket {
         self.pollee.invalidate();
         error
     }
+
+    /// Presents a stored endpoint to the user per RFC 4038.
+    fn present_addr(&self, endpoint: IpEndpoint) -> SocketAddr {
+        present_to_user(self.family, endpoint)
+    }
 }
 
 impl Pollable for StreamSocket {
@@ -448,24 +479,29 @@ impl SocketPrivate for StreamSocket {
 
 impl Socket for StreamSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
-        let endpoint = socket_addr.try_into()?;
+        let endpoint: IpEndpoint = socket_addr.try_into()?;
 
         let mut state = self.write_updated_state();
         let State::Init(init_stream) = state.as_mut() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
         };
 
-        let can_reuse = self.options.read().socket.reuse_addr();
+        let options = self.options.read();
+        let v6only = if self.family == IpAddressFamily::IPv6 {
+            options.ipv6.v6only()
+        } else {
+            false
+        };
+        let endpoint = validate_endpoint(self.family, v6only, endpoint)?;
+        let can_reuse = options.socket.reuse_addr();
         init_stream.bind(&endpoint, can_reuse)
     }
 
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
-        let remote_endpoint = socket_addr.try_into()?;
-
+        let remote_endpoint: IpEndpoint = socket_addr.try_into()?;
         if let Some(result) = self.start_connect(&remote_endpoint) {
             return result;
         }
-
         self.wait_events(IoEvents::OUT, None, || self.check_connect())
     }
 
@@ -537,12 +573,12 @@ impl Socket for StreamSocket {
         let local_endpoint = match state.as_ref() {
             State::Init(init_stream) => init_stream
                 .local_endpoint()
-                .unwrap_or_else(|| init_stream.family().unspecified_endpoint()),
+                .unwrap_or_else(|| self.family.unspecified_endpoint()),
             State::Connecting(connecting_stream) => connecting_stream.local_endpoint(),
             State::Listen(listen_stream) => listen_stream.local_endpoint(),
             State::Connected(connected_stream) => connected_stream.local_endpoint(),
         };
-        Ok(local_endpoint.into())
+        Ok(self.present_addr(local_endpoint))
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -554,7 +590,7 @@ impl Socket for StreamSocket {
             State::Connecting(connecting_stream) => connecting_stream.remote_endpoint(),
             State::Connected(connected_stream) => connected_stream.remote_endpoint(),
         };
-        Ok(remote_endpoint.into())
+        Ok(self.present_addr(remote_endpoint))
     }
 
     fn sendmsg(
@@ -629,6 +665,14 @@ impl Socket for StreamSocket {
         match options.ip.get_option(option) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
+        }
+
+        // Deal with IPv6-level options (only for AF_INET6 sockets)
+        if self.family == IpAddressFamily::IPv6 {
+            match options.ipv6.get_option(option) {
+                Err(err) if err.error() == Errno::ENOPROTOOPT => (),
+                res => return res,
+            }
         }
 
         // Deal with TCP-level options
@@ -714,13 +758,18 @@ impl Socket for StreamSocket {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // Deal with IP-level options
                 match options.ip.set_option(option, state.as_ref()) {
-                    Err(err) if err.error() == Errno::ENOPROTOOPT => {
-                        // Deal with TCP-level options
-                        do_tcp_setsockopt(option, &mut options, state.as_mut())?
-                    }
-                    Err(err) => return Err(err),
-                    Ok(need_iface_poll) => need_iface_poll,
+                    Err(err) if err.error() == Errno::ENOPROTOOPT => (),
+                    res => return res.map(|_| ()),
                 }
+                // Deal with IPv6-level options (only for AF_INET6 sockets)
+                if self.family == IpAddressFamily::IPv6 {
+                    match options.ipv6.set_option(option) {
+                        Err(err) if err.error() == Errno::ENOPROTOOPT => (),
+                        res => return res.map(|_| ()),
+                    }
+                }
+                // Deal with TCP-level options
+                do_tcp_setsockopt(option, &mut options, state.as_mut())?
             }
             Err(err) => return Err(err),
             Ok(need_iface_poll) => need_iface_poll,

--- a/kernel/src/util/net/options/ipv6.rs
+++ b/kernel/src/util/net/options/ipv6.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use int_to_c_enum::TryFromInt;
+
+use super::{RawSocketOption, SocketOption, impl_raw_socket_option};
+use crate::{net::socket::ip::options::Ipv6V6only, prelude::*};
+
+/// Socket options for IPv6 socket.
+///
+/// The raw definitions can be found at:
+/// <https://elixir.bootlin.com/linux/v6.0.19/source/include/uapi/linux/in6.h#L170>.
+#[expect(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, TryFromInt)]
+pub enum CIpv6OptionName {
+    IPV6_V6ONLY = 26,
+}
+
+pub fn new_ipv6_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
+    let name = CIpv6OptionName::try_from(name).map_err(|_| Errno::ENOPROTOOPT)?;
+    match name {
+        CIpv6OptionName::IPV6_V6ONLY => Ok(Box::new(Ipv6V6only::new())),
+    }
+}
+
+impl_raw_socket_option!(Ipv6V6only);

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -52,11 +52,13 @@
 //!
 
 use ip::new_ip_option;
+use ipv6::new_ipv6_option;
 use netlink::new_netlink_option;
 
 use crate::{net::socket::options::SocketOption, prelude::*};
 
 mod ip;
+mod ipv6;
 mod netlink;
 mod socket;
 mod tcp;
@@ -169,6 +171,7 @@ pub fn new_raw_socket_option(
     match level {
         CSocketOptionLevel::SOL_SOCKET => new_socket_option(name),
         CSocketOptionLevel::SOL_IP => new_ip_option(name),
+        CSocketOptionLevel::SOL_IPV6 => new_ipv6_option(name),
         CSocketOptionLevel::SOL_TCP => new_tcp_option(name),
         CSocketOptionLevel::SOL_NETLINK => new_netlink_option(name),
         _ => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported option level"),

--- a/test/initramfs/src/regression/network/ipv6_v6only.c
+++ b/test/initramfs/src/regression/network/ipv6_v6only.c
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <errno.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include "../common/test.h"
+
+// ============================================================
+// IPV6_V6ONLY option tests
+// ============================================================
+
+FN_TEST(v6only_default_is_zero)
+{
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+
+	int v6only;
+	socklen_t len = sizeof(v6only);
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &len),
+		 v6only == 0);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(v6only_toggle)
+{
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+
+	int val = 0;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)));
+
+	val = -1;
+	socklen_t len = sizeof(val);
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		 val == 0);
+
+	val = 1;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)));
+
+	val = 0;
+	len = sizeof(val);
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		 val == 1);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(v6only_rejected_on_af_inet)
+{
+	int sk = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+
+	int val;
+	socklen_t len = sizeof(val);
+	TEST_ERRNO(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		   ENOPROTOOPT);
+
+	val = 0;
+	TEST_ERRNO(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)),
+		   ENOPROTOOPT);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+// ============================================================
+// v6only=1: reject IPv4 and IPv4-mapped IPv6 addresses
+// ============================================================
+
+FN_TEST(v6only_reject_mapped_bind)
+{
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+	int v6only = 1;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+
+	// ::ffff:127.0.0.1
+	struct sockaddr_in6 addr = { 0 };
+	addr.sin6_family = AF_INET6;
+	addr.sin6_port = htons(8080);
+	addr.sin6_addr.s6_addr[10] = 0xff;
+	addr.sin6_addr.s6_addr[11] = 0xff;
+	addr.sin6_addr.s6_addr[12] = 127;
+	addr.sin6_addr.s6_addr[13] = 0;
+	addr.sin6_addr.s6_addr[14] = 0;
+	addr.sin6_addr.s6_addr[15] = 1;
+
+	TEST_ERRNO(bind(sk, (struct sockaddr *)&addr, sizeof(addr)),
+		   EAFNOSUPPORT);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(v6only_reject_ipv4_connect)
+{
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+	int v6only = 1;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+
+	struct sockaddr_in addr = { 0 };
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(8080);
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	TEST_ERRNO(connect(sk, (struct sockaddr *)&addr, sizeof(addr)),
+		   EAFNOSUPPORT);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+// ============================================================
+// v6only=0 dual-stack: bind / listen / connect / accept
+// ============================================================
+
+static int make_dualstack_listener(struct sockaddr_in6 *addr,
+				   socklen_t *addrlen)
+{
+	int sk = CHECK(socket(AF_INET6, SOCK_STREAM, 0));
+	int v6only = 0;
+	CHECK(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			 sizeof(v6only)));
+
+	struct sockaddr_in6 bind_addr = { 0 };
+	bind_addr.sin6_family = AF_INET6;
+	bind_addr.sin6_port = htons(0);
+	bind_addr.sin6_addr = in6addr_loopback;
+	CHECK(bind(sk, (struct sockaddr *)&bind_addr, sizeof(bind_addr)));
+	CHECK(listen(sk, 1));
+
+	if (addr)
+		CHECK(getsockname(sk, (struct sockaddr *)addr, addrlen));
+	return sk;
+}
+
+FN_TEST(dualstack_bind_getsockname)
+{
+	struct sockaddr_in6 addr = { 0 };
+	socklen_t addrlen = sizeof(addr);
+	int sk = make_dualstack_listener(&addr, &addrlen);
+
+	TEST_RES(addr.sin6_family, addr.sin6_family == AF_INET6);
+	TEST_RES(ntohs(addr.sin6_port), ntohs(addr.sin6_port) != 0);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(dualstack_connect_ipv4_peer)
+{
+	struct sockaddr_in6 listen_addr = { 0 };
+	socklen_t listen_len = sizeof(listen_addr);
+	int listener = make_dualstack_listener(&listen_addr, &listen_len);
+
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+	int v6only = 0;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+
+	// Connect with bare IPv4 to the dual-stack listener
+	struct sockaddr_in v4_addr = { 0 };
+	v4_addr.sin_family = AF_INET;
+	v4_addr.sin_port = listen_addr.sin6_port;
+	v4_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(connect(sk, (struct sockaddr *)&v4_addr, sizeof(v4_addr)));
+
+	// getpeername: must present as IPv4-mapped IPv6 per RFC 4038
+	struct sockaddr_in6 peer = { 0 };
+	socklen_t peer_len = sizeof(peer);
+	TEST_SUCC(getpeername(sk, (struct sockaddr *)&peer, &peer_len));
+	TEST_RES(peer.sin6_family, peer.sin6_family == AF_INET6);
+	TEST_RES(ntohs(peer.sin6_port),
+		 ntohs(peer.sin6_port) == ntohs(listen_addr.sin6_port));
+	// Check ::ffff:127.0.0.1 prefix
+	TEST_RES(peer.sin6_addr.s6_addr[10],
+		 peer.sin6_addr.s6_addr[10] == 0xff);
+	TEST_RES(peer.sin6_addr.s6_addr[11],
+		 peer.sin6_addr.s6_addr[11] == 0xff);
+
+	// getsockname: also IPv6 form
+	struct sockaddr_in6 local = { 0 };
+	socklen_t local_len = sizeof(local);
+	TEST_SUCC(getsockname(sk, (struct sockaddr *)&local, &local_len));
+	TEST_RES(local.sin6_family, local.sin6_family == AF_INET6);
+
+	TEST_SUCC(close(sk));
+
+	// Accept from listener side to clean up
+	int accepted = TEST_SUCC(accept(listener, NULL, NULL));
+	TEST_SUCC(close(accepted));
+	TEST_SUCC(close(listener));
+}
+END_TEST()
+
+FN_TEST(dualstack_broadcast_connect_no_so_broadcast)
+{
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_STREAM, 0));
+	int v6only = 0;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+
+	struct sockaddr_in addr = { 0 };
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(12345);
+	addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+
+	TEST_ERRNO(connect(sk, (struct sockaddr *)&addr, sizeof(addr)), EACCES);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()


### PR DESCRIPTION
Add the foundational IPv6 dual-stack layer and IPV6_V6ONLY socket option
for TCP connections via StreamSocket. 

## What's included

### Option infrastructure
- Register `SOL_IPV6` level and `IPV6_V6ONLY` (value 26 per Linux in6.h)
- `Ipv6OptionSet` with get/set for v6only, default `true`
- IPv6 and IP options coexist on the same AF_INET6 socket

### Address validation (`SocketFamily`)
- `normalize_endpoint` — bare IPv4 → IPv4-mapped IPv6 for dual-stack
- `validate_endpoint` — v6only check + family check; skips unspecified addresses
- `unmap_ipv4_addr` — mapped → bare for smoltcp (idempotent)
- `resolve_remote_endpoint` — `::` → `::1`, `0.0.0.0` → `127.0.0.1`
- `present_to_user` — bare IPv4 → mapped presentation per RFC 4038
- Replace `From<IpAddress>` trait with `from_raw_addr` (footgun documented)

### StreamSocket integration
- `prepare_endpoint` and `present_addr` delegating to `SocketFamily`
- `InitStream` runtime validation replaced with `debug_assert`
- `unmap_ipv4_addr` before `ConnectingStream` in connect path
- `resolve_bind_iface_and_config` and `get_ephemeral_endpoint` unmapped internally

### Tests (10 scenarios)
- v6only default=1, toggle get/set, AF_INET rejection
- v6only=1 rejects bind to mapped address and connect with bare IPv4
- Dual-stack bind/listen/connect/accept with mapped getpeername
- `connect(::ffff:0.0.0.0)` resolution to loopback
- Dual-stack bind to bare IPv4 address
- Dual-stack broadcast connect without SO_BROADCAST

## What's not included
- DatagramSocket (UDP) dual-stack — deferred to follow-up PR