### PR TITLE
Concatenate multiple `global_asm!` statements in rv trap

### DIFF
--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -9,6 +9,7 @@
 //
 // We make the following new changes:
 // * Implement the `trap_handler` of Asterinas.
+// * Concatenate multiple `global_asm!` statements.
 //
 // These changes are released under the following license:
 //
@@ -21,8 +22,8 @@ use crate::arch::cpu::{
     extension::{IsaExtensions, has_extensions},
 };
 
-#[cfg(target_arch = "riscv32")]
 global_asm!(
+    #[cfg(target_arch = "riscv32")]
     r"
     .equ XLENB, 4
     .macro LOAD_SP a1, a2
@@ -31,10 +32,8 @@ global_asm!(
     .macro STORE_SP a1, a2
         sw \a1, \a2*XLENB(sp)
     .endm
-"
-);
-#[cfg(target_arch = "riscv64")]
-global_asm!(
+    ",
+    #[cfg(target_arch = "riscv64")]
     r"
     .equ XLENB, 8
     .macro LOAD_SP a1, a2
@@ -43,7 +42,10 @@ global_asm!(
     .macro STORE_SP a1, a2
         sd \a1, \a2*XLENB(sp)
     .endm
-"
+    ",
+    include_str!("trap.S"),
+    SSTATUS_FS_MASK = const SSTATUS_FS_MASK,
+    SSTATUS_SUM = const SSTATUS_SUM
 );
 
 /// FPU status bits.
@@ -52,8 +54,6 @@ pub(in crate::arch) const SSTATUS_FS_MASK: usize = 0b11 << 13;
 /// Supervisor User Memory access bit.
 /// Reference: <https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#sstatus>.
 pub(in crate::arch) const SSTATUS_SUM: usize = 0b1 << 18;
-
-global_asm!(include_str!("trap.S"), SSTATUS_FS_MASK = const SSTATUS_FS_MASK, SSTATUS_SUM = const SSTATUS_SUM);
 
 /// Initialize interrupt handling for the current HART.
 ///


### PR DESCRIPTION
solve https://github.com/asterinas/asterinas/pull/3247#discussion_r3265750466

Since the github link to a specific PR discussion is broken, here's what was written:

For the failed [riscv compile](https://github.com/asterinas/asterinas/actions/runs/26088170843/job/76706582443?pr=3247) job, multiple global_asm! statements are not guaranteed to be concatenated continuously, on the contrary, it's [discouraged](https://dirname.github.io/rust-std-doc/unstable-book/library-features/global-asm.html) to share states:

> You may use global_asm! multiple times, anywhere in your crate, in whatever way suits you. However, you should not rely on assembler state (e.g. assembler macros) defined in one global_asm! to be available in another one. It is implementation-defined whether the multiple usages are concatenated into one or assembled separately.

This seems to be a good blind spot in low-level crates.  (e.g. https://github.com/rust-embedded/riscv/issues/321) 