### PR TITLE
Defer BIO completion to the softirq context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ name = "aster-block"
 version = "0.1.0"
 dependencies = [
  "align_ext",
+ "aster-softirq",
  "aster-util",
  "bitvec",
  "component",

--- a/kernel/comps/block/Cargo.toml
+++ b/kernel/comps/block/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [dependencies]
 align_ext.workspace = true
+aster-softirq.workspace = true
 aster-util.workspace = true
 bitvec.workspace = true
 component.workspace = true

--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -11,7 +11,7 @@ use io_util::{
     batch::{IoBatch, IoCompletion},
 };
 use ostd::{
-    Error,
+    Error, irq,
     mm::{
         HasSize, Infallible, USegment, VmReader, VmWriter,
         dma::DmaStream,
@@ -22,7 +22,9 @@ use ostd::{
 use spin::Once;
 
 use super::{BlockDevice, id::Sid};
-use crate::{BLOCK_SIZE, SECTOR_SIZE, impl_block_device::general_complete_fn, prelude::*};
+use crate::{
+    BLOCK_SIZE, SECTOR_SIZE, completion, impl_block_device::general_complete_fn, prelude::*,
+};
 
 /// The unit for block I/O.
 ///
@@ -237,12 +239,23 @@ impl SubmittedBio {
     }
 
     /// Completes the `Bio` by consuming `self`, releasing the segments, and
-    /// invoking the callback function.
+    /// invoking the callback function from the block softirq whenever the
+    /// caller is in IRQ or softirq context.
     ///
     /// When the driver finishes the request for this `Bio`, it will call this method.
     pub fn complete(self, status: BioStatus) {
         assert!(status != BioStatus::Init && status != BioStatus::Submit);
 
+        if irq::InterruptLevel::current().is_task_context() {
+            // Synchronous in-task completions can still make forward progress
+            // without a later IRQ.
+            self.complete_now(status);
+        } else {
+            completion::enqueue(self, status);
+        }
+    }
+
+    pub(super) fn complete_now(self, status: BioStatus) {
         let Self {
             metadata,
             complete_fn,

--- a/kernel/comps/block/src/completion.rs
+++ b/kernel/comps/block/src/completion.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Provides logic to defer BIO completion to the softirq context.
+
+use core::{cell::RefCell, mem};
+
+use aster_softirq::{SoftIrqLine, softirq_id::BLOCK_SOFTIRQ_ID};
+use component::ComponentInitError;
+use ostd::{cpu_local, irq};
+
+use crate::{
+    bio::{BioStatus, SubmittedBio},
+    prelude::*,
+};
+
+/// A pending BIO completion deferred to the block softirq.
+struct BioCompletion {
+    /// The submitted BIO whose ownership is transferred to the completion path.
+    bio: SubmittedBio,
+    /// The final status reported by the block driver.
+    status: BioStatus,
+}
+
+cpu_local! {
+    /// Stores BIO completions deferred on the current CPU.
+    static BIO_COMPLETION_QUEUE: RefCell<VecDeque<BioCompletion>> =
+        RefCell::new(VecDeque::new());
+}
+
+/// Initializes the block softirq handler.
+pub(super) fn init() -> Result<(), ComponentInitError> {
+    SoftIrqLine::get(BLOCK_SOFTIRQ_ID).enable(handle_block_softirq);
+    Ok(())
+}
+
+/// Enqueues a BIO completion and raises the block softirq if needed.
+///
+/// The queue is CPU-local, so local IRQs are disabled while the queue is
+/// accessed. A softirq is raised only when the queue transitions from empty to
+/// non-empty, which avoids redundant raises while preserving progress.
+pub(super) fn enqueue(bio: SubmittedBio, status: BioStatus) {
+    let irq_guard = irq::disable_local();
+    let queue = BIO_COMPLETION_QUEUE.get_with(&irq_guard);
+    let mut queue = queue.borrow_mut();
+    let should_raise = queue.is_empty();
+    queue.push_back(BioCompletion { bio, status });
+    drop(queue);
+
+    if should_raise {
+        SoftIrqLine::get(BLOCK_SOFTIRQ_ID).raise();
+    }
+}
+
+/// Drains deferred BIO completions for the current CPU.
+fn handle_block_softirq() {
+    let mut completion_queue = VecDeque::new();
+
+    {
+        let irq_guard = irq::disable_local();
+        let queue = BIO_COMPLETION_QUEUE.get_with(&irq_guard);
+        mem::swap(&mut *queue.borrow_mut(), &mut completion_queue);
+    }
+
+    while let Some(completion) = completion_queue.pop_front() {
+        completion.bio.complete_now(completion.status);
+    }
+}

--- a/kernel/comps/block/src/lib.rs
+++ b/kernel/comps/block/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! __log_prefix {
 }
 
 pub mod bio;
+mod completion;
 mod device_id;
 pub mod id;
 mod impl_block_device;
@@ -154,6 +155,7 @@ static DEVICE_REGISTRY: Mutex<BTreeMap<u32, Arc<dyn BlockDevice>>> = Mutex::new(
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
     device_id::init();
+    completion::init()?;
 
     Ok(())
 }

--- a/kernel/comps/softirq/src/softirq_id.rs
+++ b/kernel/comps/softirq/src/softirq_id.rs
@@ -17,3 +17,6 @@ pub const NETWORK_TX_SOFTIRQ_ID: u8 = 3;
 
 /// The corresponding softirq line is used to handle reception network events.
 pub const NETWORK_RX_SOFTIRQ_ID: u8 = 4;
+
+/// The corresponding softirq line is used to complete block I/O requests.
+pub const BLOCK_SOFTIRQ_ID: u8 = 5;

--- a/kernel/src/fs/fs_impls/procfs/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/stat.rs
@@ -121,7 +121,7 @@ impl StatFileOps {
         let softirq_stats: Vec<usize> = softirq_stats.collect();
         let total_softirqs: usize = softirq_stats.iter().sum();
 
-        // We only have 5 defined softirq types; the rest are reserved.
+        // We only have 6 defined softirq types; the rest are reserved.
         // Fill in zeros for the reserved types to match the expected output format.
         writeln!(
             printer,
@@ -132,7 +132,7 @@ impl StatFileOps {
             softirq_stats[TASKLESS_SOFTIRQ_ID as usize],        // TASKLESS
             softirq_stats[NETWORK_TX_SOFTIRQ_ID as usize],      // NETWORK_TX
             softirq_stats[NETWORK_RX_SOFTIRQ_ID as usize],      // NETWORK_RX
-            0usize,                                             // Reserved
+            softirq_stats[BLOCK_SOFTIRQ_ID as usize],           // BLOCK
             0usize,                                             // Reserved
             0usize,                                             // Reserved
             0usize,                                             // Reserved


### PR DESCRIPTION
The current BIO completion callback contains relatively complex logic and executes in hard interrupt context, which can easily impact efficiency. This PR introduces `BLOCK_SOFTIRQ`, consistent with Linux, and defers the aforementioned operations to soft interrupt context.