### PR TITLE
Remove riscv32 trap code

### DIFF
--- a/ostd/src/arch/riscv/trap/trap.S
+++ b/ostd/src/arch/riscv/trap/trap.S
@@ -16,10 +16,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-# Constants / Macros defined in Rust code:
-#   XLENB
-#   LOAD
-#   STORE
+# Constant and Macros for riscv64:
+.equ XLENB, 8
+.macro LOAD_SP a1, a2
+    ld \a1, \a2*XLENB(sp)
+.endm
+.macro STORE_SP a1, a2
+    sd \a1, \a2*XLENB(sp)
+.endm
 
 .text
 

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -9,8 +9,8 @@
 //
 // We make the following new changes:
 // * Implement the `trap_handler` of Asterinas.
-// * Concatenate multiple `global_asm!` statements.
 // * Remove riscv32 code.
+// * Move XLENB, LOAD_SP, and STORE_SP into trap.S.
 //
 // These changes are released under the following license:
 //
@@ -23,28 +23,18 @@ use crate::arch::cpu::{
     extension::{IsaExtensions, has_extensions},
 };
 
-global_asm!(
-    #[cfg(target_arch = "riscv64")]
-    r"
-    .equ XLENB, 8
-    .macro LOAD_SP a1, a2
-        ld \a1, \a2*XLENB(sp)
-    .endm
-    .macro STORE_SP a1, a2
-        sd \a1, \a2*XLENB(sp)
-    .endm
-    ",
-    include_str!("trap.S"),
-    SSTATUS_FS_MASK = const SSTATUS_FS_MASK,
-    SSTATUS_SUM = const SSTATUS_SUM
-);
-
 /// FPU status bits.
 /// Reference: <https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#sstatus>.
 pub(in crate::arch) const SSTATUS_FS_MASK: usize = 0b11 << 13;
 /// Supervisor User Memory access bit.
 /// Reference: <https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#sstatus>.
 pub(in crate::arch) const SSTATUS_SUM: usize = 0b1 << 18;
+
+global_asm!(
+    include_str!("trap.S"),
+    SSTATUS_FS_MASK = const SSTATUS_FS_MASK,
+    SSTATUS_SUM = const SSTATUS_SUM
+);
 
 /// Initialize interrupt handling for the current HART.
 ///

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -10,6 +10,7 @@
 // We make the following new changes:
 // * Implement the `trap_handler` of Asterinas.
 // * Concatenate multiple `global_asm!` statements.
+// * Remove riscv32 code.
 //
 // These changes are released under the following license:
 //
@@ -23,16 +24,6 @@ use crate::arch::cpu::{
 };
 
 global_asm!(
-    #[cfg(target_arch = "riscv32")]
-    r"
-    .equ XLENB, 4
-    .macro LOAD_SP a1, a2
-        lw \a1, \a2*XLENB(sp)
-    .endm
-    .macro STORE_SP a1, a2
-        sw \a1, \a2*XLENB(sp)
-    .endm
-    ",
     #[cfg(target_arch = "riscv64")]
     r"
     .equ XLENB, 8


### PR DESCRIPTION
This PR
* removes riscv32 code from trap.rs
  * because Asterinas doesn't target riscv32
* moves XLENB, LOAD_SP, and STORE_SP into riscv trap.S

See https://github.com/asterinas/asterinas/pull/3269#discussion_r3296508240