### PR TITLE
Fix virtio-blk flush feature detection and handling

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -474,7 +474,7 @@ impl DeviceInner {
     /// Flushes any cached data from the guest to the persistent storage on the host.
     /// This will be ignored if the device doesn't support the `VIRTIO_BLK_F_FLUSH` feature.
     fn flush(&self, bio_request: BioRequest) {
-        if self.features.support_flush {
+        if !self.features.support_flush {
             bio_request.into_bios().for_each(|bio| {
                 bio.complete(BioStatus::Complete);
             });

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -200,7 +200,7 @@ impl ConfigManager<VirtioBlockConfig> {
 
 impl VirtioBlockFeature {
     pub(self) fn new(transport: &dyn VirtioTransport) -> Self {
-        let support_flush = transport.read_device_features() & BlockFeatures::FLUSH.bits() == 1;
+        let support_flush = (transport.read_device_features() & BlockFeatures::FLUSH.bits()) != 0;
         VirtioBlockFeature { support_flush }
     }
 }


### PR DESCRIPTION
Fix two bugs about VIRTIO_BLK_F_FLUSH :

- 1. In `VirtioBlockFeature::new()` , `== 1` should be `!= 0`; since `FLUSH` is bit 9 `support_flush` may always be false.

- 2. The condition in `flush()` that checks whether `VIRTIO_BLK_F_FLUSH ` is supported appears to be written backwards.