### PR TITLE
Fix some thread name problems

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
+    process::posix_thread::AsPosixThread,
     thread::Thread,
 };
 
@@ -27,20 +28,12 @@ impl ProcFileOps for CommFileOps {
     }
 
     fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
-        let Some(process) = self.0.process() else {
-            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
         };
 
-        let vmar_guard = process.lock_vmar();
-        let Some(vmar) = vmar_guard.as_ref() else {
-            // According to Linux behavior, return an empty string
-            // if the process is a zombie process.
-            return Ok(0);
-        };
-
-        let executable_file_name = vmar.process_vm().executable_file().name();
-        let mut comm = executable_file_name.as_bytes().to_vec();
-        comm.truncate(TASK_COMM_LEN - 1);
+        let posix_thread = thread.as_posix_thread().unwrap();
+        let mut comm = posix_thread.thread_name().lock().name().to_bytes().to_vec();
         comm.push(b'\n');
 
         let mut vm_reader = VmReader::from(&comm[offset.min(comm.len())..]);
@@ -57,5 +50,3 @@ impl ProcFileOps for CommFileOps {
         );
     }
 }
-
-const TASK_COMM_LEN: usize = 16;

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -10,7 +10,7 @@ use ostd::{
 
 use super::{
     Credentials, Pid, Process, pid_table,
-    posix_thread::{AsPosixThread, PosixThreadBuilder, ThreadName},
+    posix_thread::{AsPosixThread, PosixThreadBuilder},
     rlimit::ResourceLimits,
     signal::{constants::SIGCHLD, sig_disposition::SigDispositions, sig_num::SigNum},
 };
@@ -557,16 +557,7 @@ fn clone_child_process(
         let child_vmar_arc = child_vmar.clone_arc();
 
         let mut child_thread_builder = {
-            let thread_name = {
-                let executable_path = child_vmar.process_vm().executable_file();
-                thread_local
-                    .borrow_fs()
-                    .resolver()
-                    .read()
-                    .make_abs_path(executable_path)
-                    .into_string()
-            };
-            let child_thread_name = ThreadName::new_from_executable_path(&thread_name);
+            let child_thread_name = ctx.posix_thread.thread_name().lock().clone();
 
             let credentials = {
                 let credentials = ctx.posix_thread.credentials();

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -10,10 +10,7 @@ use ostd::{
 
 use super::process_vm::activate_vmar;
 use crate::{
-    fs::vfs::{
-        inode::Inode,
-        path::{Path, PathResolver},
-    },
+    fs::vfs::{inode::Inode, path::Path},
     prelude::*,
     process::{
         ContextUnshareAdminApi, Credentials, Process, pid_table,
@@ -34,6 +31,7 @@ use crate::{
 
 pub fn do_execve(
     elf_file: Path,
+    thread_name: ThreadName,
     argv_ptr_ptr: Vaddr,
     envp_ptr_ptr: Vaddr,
     ctx: &Context,
@@ -86,8 +84,8 @@ pub fn do_execve(
     let res = do_execve_no_return(
         ctx,
         user_context,
-        &path_resolver,
         elf_file,
+        thread_name,
         new_vmar,
         &elf_load_info,
     );
@@ -146,8 +144,8 @@ fn read_cstring_vec(
 fn do_execve_no_return(
     ctx: &Context,
     user_context: &mut UserContext,
-    path_resolver: &PathResolver,
     elf_file: Path,
+    thread_name: ThreadName,
     new_vmar: VmarHandle,
     elf_load_info: &ElfLoadInfo,
 ) -> Result<()> {
@@ -186,9 +184,7 @@ fn do_execve_no_return(
     // Unshare file descriptor table and close files with O_CLOEXEC flag.
     unshare_and_close_files(ctx);
 
-    // Update the process's executable path and set the thread name
-    let executable_path = path_resolver.make_abs_path(&elf_file).into_string();
-    *posix_thread.thread_name().lock() = ThreadName::new_from_executable_path(&executable_path);
+    *posix_thread.thread_name().lock() = thread_name;
 
     // Unshare and reset signal dispositions to their default actions.
     unshare_and_reset_sigdispositions(process);

--- a/kernel/src/syscall/execve.rs
+++ b/kernel/src/syscall/execve.rs
@@ -9,7 +9,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
-    process::do_execve,
+    process::{do_execve, posix_thread::ThreadName},
 };
 
 pub fn sys_execve(
@@ -19,12 +19,19 @@ pub fn sys_execve(
     ctx: &Context,
     user_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    let elf_file = {
+    let (elf_file, thread_name) = {
         let flags = OpenFlags::empty();
         lookup_executable_file(AT_FDCWD, filename_ptr, flags, ctx)?
     };
 
-    do_execve(elf_file, argv_ptr_ptr, envp_ptr_ptr, ctx, user_context)?;
+    do_execve(
+        elf_file,
+        thread_name,
+        argv_ptr_ptr,
+        envp_ptr_ptr,
+        ctx,
+        user_context,
+    )?;
     Ok(SyscallReturn::NoReturn)
 }
 
@@ -37,13 +44,20 @@ pub fn sys_execveat(
     ctx: &Context,
     user_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    let elf_file = {
+    let (elf_file, thread_name) = {
         let flags = OpenFlags::from_bits(flags)
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
         lookup_executable_file(dfd, filename_ptr, flags, ctx)?
     };
 
-    do_execve(elf_file, argv_ptr_ptr, envp_ptr_ptr, ctx, user_context)?;
+    do_execve(
+        elf_file,
+        thread_name,
+        argv_ptr_ptr,
+        envp_ptr_ptr,
+        ctx,
+        user_context,
+    )?;
     Ok(SyscallReturn::NoReturn)
 }
 
@@ -52,13 +66,13 @@ fn lookup_executable_file(
     filename_ptr: Vaddr,
     flags: OpenFlags,
     ctx: &Context,
-) -> Result<Path> {
+) -> Result<(Path, ThreadName)> {
     let filename = ctx
         .user_space()
         .read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
 
+    let filename = filename.to_string_lossy();
     let path = {
-        let filename = filename.to_string_lossy();
         let fs_path = FsPath::from_fd_at(dfd, &filename, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
         let fs_ref = ctx.thread_local.borrow_fs();
@@ -70,7 +84,16 @@ fn lookup_executable_file(
         }
     };
 
-    Ok(path)
+    // For a non-empty `filename`, Linux derives the thread name from the
+    // user-supplied exec path before symlink resolution. `execveat` with
+    // `AT_EMPTY_PATH` has no such path, so fall back to the resolved file name.
+    let thread_name = if filename.is_empty() {
+        ThreadName::new_from_executable_path(&path.name())
+    } else {
+        ThreadName::new_from_executable_path(&filename)
+    };
+
+    Ok((path, thread_name))
 }
 
 bitflags::bitflags! {

--- a/test/initramfs/src/regression/process/execve/execve_comm.c
+++ b/test/initramfs/src/regression/process/execve/execve_comm.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define CHILD_PATH "/test/process/execve/execve_comm_child"
+/* `/proc/self/comm` truncates the executable name to 15 visible bytes. */
+#define CHILD_COMM "execve_comm_chi"
+#define CHILD_COMM_ENV "EXPECTED_COMM=" CHILD_COMM
+#define LINK_PATH "/tmp/exec_link"
+#define LINK_NAME "exec_link"
+#define LINK_NAME_ENV "EXPECTED_COMM=" LINK_NAME
+
+FN_TEST(execve_symlink)
+{
+	char *const argv[] = { "custom-argv0", NULL };
+	char *const envp[] = { LINK_NAME_ENV, NULL };
+	int status;
+	pid_t pid;
+
+	unlink(LINK_PATH);
+	TEST_SUCC(symlink(CHILD_PATH, LINK_PATH));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		execve(LINK_PATH, argv, envp);
+		_exit(127);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	unlink(LINK_PATH);
+}
+END_TEST()
+
+FN_TEST(execveat_empty_path)
+{
+	char *const argv[] = { "custom-argv0", NULL };
+	char *const envp[] = { CHILD_COMM_ENV, NULL };
+	int child_fd;
+	int status;
+	pid_t pid;
+
+	child_fd = TEST_SUCC(open(CHILD_PATH, O_RDONLY));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		execveat(child_fd, "", argv, envp, AT_EMPTY_PATH);
+		_exit(127);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(close(child_fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/execve/execve_comm_child.c
+++ b/test/initramfs/src/regression/process/execve/execve_comm_child.c
@@ -9,6 +9,22 @@
 
 #define EXPECTED_COMM_ENV "EXPECTED_COMM"
 
+static int check_proc_comm(const char *expected_comm)
+{
+	char expected_comm_with_newline[64];
+	char comm[64];
+	FILE *file;
+
+	snprintf(expected_comm_with_newline, sizeof(expected_comm_with_newline),
+		 "%s\n", expected_comm);
+
+	file = CHECK_WITH(fopen("/proc/self/comm", "r"), _ret != NULL);
+	CHECK_WITH(fgets(comm, sizeof(comm), file), _ret != NULL);
+	CHECK_WITH(fclose(file), _ret == 0);
+
+	return strcmp(comm, expected_comm_with_newline) != 0;
+}
+
 static int check_proc_stat(const char *expected_comm)
 {
 	char expected_prefix[64];
@@ -32,6 +48,7 @@ FN_TEST(exec_comm)
 	const char *expected_comm =
 		CHECK_WITH(getenv(EXPECTED_COMM_ENV), _ret != NULL);
 
+	TEST_RES(check_proc_comm(expected_comm), _ret == 0);
 	TEST_RES(check_proc_stat(expected_comm), _ret == 0);
 }
 END_TEST()

--- a/test/initramfs/src/regression/process/execve/execve_comm_child.c
+++ b/test/initramfs/src/regression/process/execve/execve_comm_child.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define EXPECTED_COMM_ENV "EXPECTED_COMM"
+
+static int check_proc_stat(const char *expected_comm)
+{
+	char expected_prefix[64];
+	char stat[128];
+	FILE *file;
+	int pid;
+
+	file = CHECK_WITH(fopen("/proc/self/stat", "r"), _ret != NULL);
+	CHECK_WITH(fgets(stat, sizeof(stat), file), _ret != NULL);
+	CHECK_WITH(fclose(file), _ret == 0);
+
+	pid = getpid();
+	snprintf(expected_prefix, sizeof(expected_prefix), "%d (%s) ", pid,
+		 expected_comm);
+
+	return strncmp(stat, expected_prefix, strlen(expected_prefix)) != 0;
+}
+
+FN_TEST(exec_comm)
+{
+	const char *expected_comm =
+		CHECK_WITH(getenv(EXPECTED_COMM_ENV), _ret != NULL);
+
+	TEST_RES(check_proc_stat(expected_comm), _ret == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/prctl/thread_name.c
+++ b/test/initramfs/src/regression/process/prctl/thread_name.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define THREAD_NAME "fork_comm"
+
+static int check_proc_stat_comm(const char *expected_comm)
+{
+	char expected_prefix[64];
+	char stat[128];
+	FILE *file;
+	int pid;
+
+	file = CHECK_WITH(fopen("/proc/self/stat", "r"), _ret != NULL);
+	CHECK_WITH(fgets(stat, sizeof(stat), file), _ret != NULL);
+	CHECK_WITH(fclose(file), _ret == 0);
+
+	pid = getpid();
+	snprintf(expected_prefix, sizeof(expected_prefix), "%d (%s) ", pid,
+		 expected_comm);
+
+	return strncmp(stat, expected_prefix, strlen(expected_prefix)) != 0;
+}
+
+FN_TEST(fork_inherits_thread_name)
+{
+	int status;
+	pid_t pid;
+
+	TEST_SUCC(prctl(PR_SET_NAME, THREAD_NAME));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		_exit(check_proc_stat_comm(THREAD_NAME));
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -39,6 +39,7 @@ set -e
 ./prctl/capbset
 ./prctl/secure_bits
 ./prctl/subreaper
+./prctl/thread_name
 
 ./pthread/pthread_signal_test
 ./pthread/pthread_test

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -16,6 +16,7 @@ set -e
 ./cpu_affinity/cpu_affinity
 
 ./execve/execve
+./execve/execve_comm
 ./execve/execve_err
 ./execve/execve_memfd
 ./execve/execve_mt_parent


### PR DESCRIPTION
This PR fixes the process names shown by BusyBox `ps` on Asterinas.

Before this change, after running `make run_kernel`, `ps aux` could show command names wrapped in braces. BusyBox prints `{comm} cmdline` when the process `comm` name does not match the basename of `argv[0]`. In this code path, BusyBox gets `comm` from `/proc/[pid]/stat`(from thread name) and the command line from `/proc/[pid]/cmdline`（by reading from init stack）.

```plain
~ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 {init} /bin/sh /init sh -l
    8 root      0:00 {busybox} script /dev/null -q -c sh -l
    9 root      0:00 {busybox} sh -l
   10 root      0:00 {busybox} ps aux
```

The root cause was that Asterinas did not preserve Linux-compatible thread names in several cases:

1. `execve` through a symlink derived the thread name from the resolved path. Linux derives it from the user-supplied exec path before symlink resolution. For `execveat` with `AT_EMPTY_PATH`, there is no user-supplied path, so this PR keeps using the resolved file name.

2. `fork` derived the child thread name from the executable path. It should inherit the parent's thread name instead, otherwise names set by `PR_SET_NAME` are lost.

3. `/proc/[pid]/comm` and `/proc/[pid]/task/[tid]/comm` reported the executable file name. They should report the thread name, so names set by `PR_SET_NAME` remain visible and procfs is consistent with `/proc/[pid]/stat`.

After this PR, `ps aux` shows:

```plain
~ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 {init} /bin/sh /init sh -l
    8 root      0:00 script /dev/null -q -c sh -l
    9 root      0:00 sh -l
   10 root      0:00 ps aux
```

The remaining `{init}` is expected. Asterinas boots `/init` via `init=/init` and passes `sh -l` as init arguments. The kernel prepends the init executable path, so the script starts with `/init sh -l`. Since `/init` is a shebang script with `#!/bin/sh`, the loader runs the interpreter with the command line `/bin/sh /init sh -l`.

The thread name, however, is still derived from the executed script path `/init`, so `comm` is `init`. BusyBox compares this with `argv[0]`, whose basename is `sh`, sees that they differ, and intentionally prints `{init} /bin/sh /init sh -l`. This matches normal Linux behavior for shebang scripts and is not the bug fixed by this PR.