### PR TITLE
Fix some UDP problems

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -18,33 +18,6 @@ use smoltcp::{
     wire::{IpAddress, IpEndpoint, Ipv4Address, Ipv4Packet, Ipv6Address, Ipv6Packet},
 };
 
-/// An enum representing either an IPv4 or IPv6 packet.
-pub(super) enum IpPacket<'a> {
-    Ipv4(Ipv4Packet<&'a [u8]>),
-    Ipv6(Ipv6Packet<&'a [u8]>),
-}
-
-/// Normalizes IPv4-mapped IPv6 addresses to IPv4 addresses.
-///
-/// IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) should be treated as equivalent
-/// to their IPv4 counterparts for binding purposes. This ensures that binding
-/// to 192.0.2.1:80 and ::ffff:192.0.2.1:80 are treated as the same.
-//
-// TODO: This function currently only handles port binding conflict detection.
-// Full dual-stack support is not yet implemented, including:
-// - Accepting IPv4 connections on IPv6 wildcard socket (binding to `::`)
-// - Returning IPv4-mapped addresses in `accept()` for IPv4 clients
-// - Proper handling of `IPV6_V6ONLY` socket option
-fn normalize_ip_address(addr: IpAddress) -> IpAddress {
-    if let IpAddress::Ipv6(ipv6) = addr
-        && let Some(ipv4) = ipv6.to_ipv4_mapped()
-    {
-        return IpAddress::Ipv4(ipv4);
-    }
-
-    addr
-}
-
 use super::{
     Iface,
     poll::{FnHelper, PollContext, SocketTableAction},
@@ -69,6 +42,33 @@ pub struct IfaceCommon<E: Ext> {
     used_ports: SpinLock<BTreeMap<IpAddress, BTreeMap<u16, PortState>>, BottomHalfDisabled>,
     sockets: SpinLock<SocketTable<E>, BottomHalfDisabled>,
     sched_poll: E::ScheduleNextPoll,
+}
+
+/// An enum representing either an IPv4 or IPv6 packet.
+pub(super) enum IpPacket<'a> {
+    Ipv4(Ipv4Packet<&'a [u8]>),
+    Ipv6(Ipv6Packet<&'a [u8]>),
+}
+
+/// Normalizes IPv4-mapped IPv6 addresses to IPv4 addresses.
+///
+/// IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) should be treated as equivalent
+/// to their IPv4 counterparts for binding purposes. This ensures that binding
+/// to `192.0.2.1:80` and `::ffff:192.0.2.1:80` are treated as the same.
+//
+// TODO: This function currently only handles port binding conflict detection.
+// Full dual-stack support is not yet implemented, including:
+// - Accepting IPv4 connections on IPv6 wildcard socket (binding to `::`).
+// - Returning IPv4-mapped addresses in `accept()` for IPv4 clients.
+// - Proper handling of `IPV6_V6ONLY` socket option.
+fn normalize_ip_address(addr: IpAddress) -> IpAddress {
+    if let IpAddress::Ipv6(ipv6) = addr
+        && let Some(ipv4) = ipv6.to_ipv4_mapped()
+    {
+        return IpAddress::Ipv4(ipv4);
+    }
+
+    addr
 }
 
 impl<E: Ext> IfaceCommon<E> {
@@ -129,7 +129,7 @@ impl<E: Ext> IfaceCommon<E> {
 /// An allocator that allocates a unique index for each interface.
 //
 // FIXME: This allocator is specific to each network namespace.
-pub static INTERFACE_INDEX_ALLOCATOR: AtomicU32 = AtomicU32::new(1);
+static INTERFACE_INDEX_ALLOCATOR: AtomicU32 = AtomicU32::new(1);
 
 // Lock order: `interface` -> `sockets`
 impl<E: Ext> IfaceCommon<E> {

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -6,7 +6,10 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::{
+    ops::Deref,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
 
 use aster_softirq::BottomHalfDisabled;
 use bitflags::bitflags;
@@ -39,7 +42,7 @@ pub struct IfaceCommon<E: Ext> {
     flags: InterfaceFlags,
 
     interface: SpinLock<PollableIface<E>, BottomHalfDisabled>,
-    used_ports: SpinLock<BTreeMap<NormalizedAddress, BTreeMap<u16, PortState>>, BottomHalfDisabled>,
+    used_ports: SpinLock<BTreeMap<PortKey, PortState>, BottomHalfDisabled>,
     sockets: SpinLock<SocketTable<E>, BottomHalfDisabled>,
     sched_poll: E::ScheduleNextPoll,
 }
@@ -153,17 +156,37 @@ const IP_LOCAL_PORT_START: u16 = 32768;
 const IP_LOCAL_PORT_END: u16 = 60999;
 
 impl<E: Ext> IfaceCommon<E> {
-    pub(super) fn bind(
+    pub(super) fn bind_tcp(
         &self,
         iface: Arc<dyn Iface<E>>,
         config: BindPortConfig,
+    ) -> Result<BoundTcpPort<E>, BindError> {
+        self.bind(iface, config, PortProtocol::Tcp)
+            .map(BoundTcpPort)
+    }
+
+    pub(super) fn bind_udp(
+        &self,
+        iface: Arc<dyn Iface<E>>,
+        config: BindPortConfig,
+    ) -> Result<BoundUdpPort<E>, BindError> {
+        self.bind(iface, config, PortProtocol::Udp)
+            .map(BoundUdpPort)
+    }
+
+    fn bind(
+        &self,
+        iface: Arc<dyn Iface<E>>,
+        config: BindPortConfig,
+        protocol: PortProtocol,
     ) -> Result<BoundPort<E>, BindError> {
         let addr = config.addr();
-        let (port, can_reuse) = self.bind_port(config)?;
+        let (port, can_reuse) = self.bind_port(config, protocol)?;
         Ok(BoundPort {
             iface,
             addr,
             port,
+            protocol,
             can_reuse: AtomicBool::new(can_reuse),
         })
     }
@@ -174,13 +197,19 @@ impl<E: Ext> IfaceCommon<E> {
     ///
     /// See <https://en.wikipedia.org/wiki/Ephemeral_port>.
     fn alloc_ephemeral_port(
-        used_ports: &mut BTreeMap<NormalizedAddress, BTreeMap<u16, PortState>>,
+        used_ports: &mut BTreeMap<PortKey, PortState>,
         addr: NormalizedAddress,
+        protocol: PortProtocol,
         _can_reuse: bool,
     ) -> Option<u16> {
-        let address_ports = used_ports.entry(addr).or_default();
+        let mut key = PortKey {
+            addr,
+            port: 0,
+            protocol,
+        };
         for port in IP_LOCAL_PORT_START..=IP_LOCAL_PORT_END {
-            if let Entry::Vacant(..) = address_ports.entry(port) {
+            key.port = port;
+            if !used_ports.contains_key(&key) {
                 return Some(port);
             }
         }
@@ -191,7 +220,11 @@ impl<E: Ext> IfaceCommon<E> {
         None
     }
 
-    fn bind_port(&self, config: BindPortConfig) -> Result<(u16, bool), BindError> {
+    fn bind_port(
+        &self,
+        config: BindPortConfig,
+        protocol: PortProtocol,
+    ) -> Result<(u16, bool), BindError> {
         let mut used_ports = self.used_ports.lock();
         let config_can_reuse = config.can_reuse();
         let addr = NormalizedAddress::from(config.addr());
@@ -199,50 +232,59 @@ impl<E: Ext> IfaceCommon<E> {
         let port = if let Some(port) = config.port() {
             port
         } else {
-            match Self::alloc_ephemeral_port(&mut used_ports, addr, config_can_reuse) {
+            match Self::alloc_ephemeral_port(&mut used_ports, addr, protocol, config_can_reuse) {
                 Some(port) => port,
                 None => return Err(BindError::Exhausted),
             }
         };
 
-        let address_ports = used_ports.entry(addr).or_default();
-        if let Some(port_state) = address_ports.get_mut(&port) {
-            // FIXME: If the socket is not a backlog socket,
-            // we should check whether there is a listening socket on the port.
-            // If there is, the socket cannot be bound to that port.
-            let can_reuse = config.is_backlog() || (port_state.can_reuse() & config_can_reuse);
-            if can_reuse {
-                port_state.nsocket += 1;
-                if config_can_reuse {
-                    port_state.nreuse += 1;
+        let key = PortKey {
+            addr,
+            port,
+            protocol,
+        };
+        let entry = used_ports.entry(key);
+        match entry {
+            Entry::Occupied(mut occupied) => {
+                let port_state = occupied.get_mut();
+                // FIXME: If the socket is not a backlog socket,
+                // we should check whether there is a listening socket on the port.
+                // If there is, the socket cannot be bound to that port.
+                let can_reuse = config.is_backlog() || (port_state.can_reuse() & config_can_reuse);
+                if can_reuse {
+                    port_state.nsocket += 1;
+                    if config_can_reuse {
+                        port_state.nreuse += 1;
+                    }
+                } else {
+                    return Err(BindError::InUse);
                 }
-            } else {
-                return Err(BindError::InUse);
             }
-        } else {
-            let port_state = PortState::new(config_can_reuse);
-            address_ports.insert(port, port_state);
+            Entry::Vacant(vacant) => {
+                let port_state = PortState::new(config_can_reuse);
+                vacant.insert(port_state);
+            }
         };
 
         Ok((port, config_can_reuse))
     }
 
     /// Releases the port so that it can be used again.
-    fn release_port(&self, addr: IpAddress, port: u16, can_reuse: bool) {
-        let addr = NormalizedAddress::from(addr);
+    fn release_port(&self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+        let key = PortKey {
+            addr: NormalizedAddress::from(addr),
+            port,
+            protocol,
+        };
         let mut used_ports = self.used_ports.lock();
-        if let Some(address_ports) = used_ports.get_mut(&addr)
-            && let Some(port_state) = address_ports.get_mut(&port)
-        {
+        if let Entry::Occupied(mut occupied) = used_ports.entry(key) {
+            let port_state = occupied.get_mut();
             port_state.nsocket -= 1;
             if can_reuse {
                 port_state.nreuse -= 1;
             }
             if port_state.nsocket == 0 {
-                address_ports.remove(&port);
-                if address_ports.is_empty() {
-                    used_ports.remove(&addr);
-                }
+                occupied.remove();
             }
         }
     }
@@ -316,12 +358,11 @@ impl<E: Ext> IfaceCommon<E> {
 /// A port bound to an iface.
 ///
 /// When dropped, the port is automatically released.
-//
-// FIXME: TCP and UDP ports are independent. Find a way to track the protocol here.
 pub struct BoundPort<E: Ext> {
     iface: Arc<dyn Iface<E>>,
     addr: IpAddress,
     port: u16,
+    protocol: PortProtocol,
     can_reuse: AtomicBool,
 }
 
@@ -351,15 +392,17 @@ impl<E: Ext> BoundPort<E> {
         let iface_common = self.iface.common();
         let mut used_ports = iface_common.used_ports.lock();
 
+        // Check after locking `used_ports` to avoid race conditions.
         if self.can_reuse.load(Ordering::Relaxed) == can_reuse {
             return;
         }
 
-        let normalized_addr = NormalizedAddress::from(self.addr);
-        if let Some(port_state) = used_ports
-            .get_mut(&normalized_addr)
-            .and_then(|address_ports| address_ports.get_mut(&self.port))
-        {
+        let key = PortKey {
+            addr: NormalizedAddress::from(self.addr),
+            port: self.port,
+            protocol: self.protocol,
+        };
+        if let Some(port_state) = used_ports.get_mut(&key) {
             if can_reuse {
                 port_state.nreuse += 1;
             } else {
@@ -373,10 +416,44 @@ impl<E: Ext> BoundPort<E> {
 
 impl<E: Ext> Drop for BoundPort<E> {
     fn drop(&mut self) {
-        self.iface
-            .common()
-            .release_port(self.addr, self.port, *self.can_reuse.get_mut());
+        self.iface.common().release_port(
+            self.addr,
+            self.port,
+            *self.can_reuse.get_mut(),
+            self.protocol,
+        );
     }
+}
+
+/// A TCP port bound to an iface.
+pub struct BoundTcpPort<E: Ext>(BoundPort<E>);
+/// A UDP port bound to an iface.
+pub struct BoundUdpPort<E: Ext>(BoundPort<E>);
+
+impl<E: Ext> Deref for BoundTcpPort<E> {
+    type Target = BoundPort<E>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<E: Ext> Deref for BoundUdpPort<E> {
+    type Target = BoundPort<E>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct PortKey {
+    addr: NormalizedAddress,
+    port: u16,
+    protocol: PortProtocol,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum PortProtocol {
+    Tcp,
+    Udp,
 }
 
 struct PortState {

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -39,7 +39,7 @@ pub struct IfaceCommon<E: Ext> {
     flags: InterfaceFlags,
 
     interface: SpinLock<PollableIface<E>, BottomHalfDisabled>,
-    used_ports: SpinLock<BTreeMap<IpAddress, BTreeMap<u16, PortState>>, BottomHalfDisabled>,
+    used_ports: SpinLock<BTreeMap<NormalizedAddress, BTreeMap<u16, PortState>>, BottomHalfDisabled>,
     sockets: SpinLock<SocketTable<E>, BottomHalfDisabled>,
     sched_poll: E::ScheduleNextPoll,
 }
@@ -50,25 +50,30 @@ pub(super) enum IpPacket<'a> {
     Ipv6(Ipv6Packet<&'a [u8]>),
 }
 
-/// Normalizes IPv4-mapped IPv6 addresses to IPv4 addresses.
+/// A normalized IP address for binding purposes.
+///
+/// IPv4 addresses are normalized to IPv4-mapped IPv6 addresses. IPv6 addresses
+/// remain unchanged.
 ///
 /// IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) should be treated as equivalent
 /// to their IPv4 counterparts for binding purposes. This ensures that binding
 /// to `192.0.2.1:80` and `::ffff:192.0.2.1:80` are treated as the same.
 //
-// TODO: This function currently only handles port binding conflict detection.
-// Full dual-stack support is not yet implemented, including:
+// TODO: This type currently only handles port binding conflict detection. Full
+// dual-stack support is not yet implemented, including:
 // - Accepting IPv4 connections on IPv6 wildcard socket (binding to `::`).
 // - Returning IPv4-mapped addresses in `accept()` for IPv4 clients.
 // - Proper handling of `IPV6_V6ONLY` socket option.
-fn normalize_ip_address(addr: IpAddress) -> IpAddress {
-    if let IpAddress::Ipv6(ipv6) = addr
-        && let Some(ipv4) = ipv6.to_ipv4_mapped()
-    {
-        return IpAddress::Ipv4(ipv4);
-    }
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct NormalizedAddress(Ipv6Address);
 
-    addr
+impl From<IpAddress> for NormalizedAddress {
+    fn from(value: IpAddress) -> Self {
+        match value {
+            IpAddress::Ipv4(ipv4) => Self(ipv4.to_ipv6_mapped()),
+            IpAddress::Ipv6(ipv6) => Self(ipv6),
+        }
+    }
 }
 
 impl<E: Ext> IfaceCommon<E> {
@@ -169,8 +174,8 @@ impl<E: Ext> IfaceCommon<E> {
     ///
     /// See <https://en.wikipedia.org/wiki/Ephemeral_port>.
     fn alloc_ephemeral_port(
-        used_ports: &mut BTreeMap<IpAddress, BTreeMap<u16, PortState>>,
-        addr: IpAddress,
+        used_ports: &mut BTreeMap<NormalizedAddress, BTreeMap<u16, PortState>>,
+        addr: NormalizedAddress,
         _can_reuse: bool,
     ) -> Option<u16> {
         let address_ports = used_ports.entry(addr).or_default();
@@ -189,7 +194,7 @@ impl<E: Ext> IfaceCommon<E> {
     fn bind_port(&self, config: BindPortConfig) -> Result<(u16, bool), BindError> {
         let mut used_ports = self.used_ports.lock();
         let config_can_reuse = config.can_reuse();
-        let addr = normalize_ip_address(config.addr());
+        let addr = NormalizedAddress::from(config.addr());
 
         let port = if let Some(port) = config.port() {
             port
@@ -224,7 +229,7 @@ impl<E: Ext> IfaceCommon<E> {
 
     /// Releases the port so that it can be used again.
     fn release_port(&self, addr: IpAddress, port: u16, can_reuse: bool) {
-        let addr = normalize_ip_address(addr);
+        let addr = NormalizedAddress::from(addr);
         let mut used_ports = self.used_ports.lock();
         if let Some(address_ports) = used_ports.get_mut(&addr)
             && let Some(port_state) = address_ports.get_mut(&port)
@@ -350,7 +355,7 @@ impl<E: Ext> BoundPort<E> {
             return;
         }
 
-        let normalized_addr = normalize_ip_address(self.addr);
+        let normalized_addr = NormalizedAddress::from(self.addr);
         if let Some(port_state) = used_ports
             .get_mut(&normalized_addr)
             .and_then(|address_ports| address_ports.get_mut(&self.port))

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 
 use smoltcp::wire::{Ipv4Address, Ipv4Cidr, Ipv6Address};
 
-use super::{BoundPort, InterfaceFlags, InterfaceType, port::BindPortConfig};
+use super::{BindPortConfig, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 use crate::{errors::BindError, ext::Ext};
 
 /// A network interface.
@@ -22,20 +22,32 @@ pub trait Iface<E>: internal::IfaceInternal<E> + Send + Sync {
 }
 
 impl<E: Ext> dyn Iface<E> {
-    /// Binds a socket to the iface.
+    // FIXME: The reason for binding the socket and the iface together is because there are
+    // limitations inside smoltcp. See discussion at
+    // <https://github.com/smoltcp-rs/smoltcp/issues/779>.
+
+    /// Binds a TCP port to the iface.
     ///
-    /// After binding the socket to the iface, the iface will handle all packets to and from the
-    /// socket.
-    ///
-    /// If no specific port is given in [`BindPortConfig`], the iface will pick up an ephemeral port
-    /// for the socket.
-    ///
-    /// FIXME: The reason for binding the socket and the iface together is because there are
-    /// limitations inside smoltcp. See discussion at
-    /// <https://github.com/smoltcp-rs/smoltcp/issues/779>.
-    pub fn bind(self: &Arc<Self>, config: BindPortConfig) -> Result<BoundPort<E>, BindError> {
+    /// If no specific port is given in [`BindPortConfig`], the iface will pick up an ephemeral
+    /// port.
+    pub fn bind_tcp(
+        self: &Arc<Self>,
+        config: BindPortConfig,
+    ) -> Result<BoundTcpPort<E>, BindError> {
         let common = self.common();
-        common.bind(self.clone(), config)
+        common.bind_tcp(self.clone(), config)
+    }
+
+    /// Binds a UDP port to the iface.
+    ///
+    /// If no specific port is given in [`BindPortConfig`], the iface will pick up an ephemeral
+    /// port.
+    pub fn bind_udp(
+        self: &Arc<Self>,
+        config: BindPortConfig,
+    ) -> Result<BoundUdpPort<E>, BindError> {
+        let common = self.common();
+        common.bind_udp(self.clone(), config)
     }
 
     /// Returns the interface index.

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -10,7 +10,7 @@ mod port;
 mod sched;
 mod time;
 
-pub use common::{BoundPort, InterfaceFlags, InterfaceType};
+pub use common::{BoundPort, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};

--- a/kernel/libs/aster-bigtcp/src/iface/port.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/port.rs
@@ -9,9 +9,9 @@ pub struct BindPortConfig {
 }
 
 enum PortKind {
-    /// Binds to the specified non-reusable port.
-    CanReuse(u16),
     /// Binds to the specified reusable port.
+    CanReuse(u16),
+    /// Binds to the specified non-reusable port.
     Specified(u16),
     /// Allocates an ephemeral port to bind.
     Ephemeral(bool),

--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::sync::{Arc, Weak};
+use core::ops::Deref;
 
 use smoltcp::wire::IpEndpoint;
 use spin::once::Once;
@@ -21,6 +22,7 @@ pub struct Socket<T: Inner<E>, E: Ext>(pub(super) Takeable<Arc<SocketBg<T, E>>>)
 /// [`TcpListenerInner`]: super::tcp_listen::TcpListenerInner
 /// [`UdpSocketInner`]: super::udp::UdpSocketInner
 pub trait Inner<E: Ext> {
+    type BoundPort: Deref<Target = BoundPort<E>>;
     type Observer: SocketEventObserver;
 
     /// Called by [`Socket::drop`].
@@ -41,7 +43,7 @@ pub trait Inner<E: Ext> {
 /// [`UdpSocketBg`]: super::udp::UdpSocketBg
 /// [`TcpConnection`]: super::tcp_conn::TcpConnection
 pub struct SocketBg<T: Inner<E>, E: Ext> {
-    pub(super) bound: BoundPort<E>,
+    pub(super) bound: T::BoundPort,
     pub(super) inner: T,
     observer: Once<T::Observer>,
 }
@@ -55,7 +57,7 @@ impl<T: Inner<E>, E: Ext> Drop for Socket<T, E> {
 }
 
 impl<T: Inner<E>, E: Ext> Socket<T, E> {
-    pub(super) fn new(bound: BoundPort<E>, inner: T) -> Self {
+    pub(super) fn new(bound: T::BoundPort, inner: T) -> Self {
         Self(Takeable::new(Arc::new(SocketBg {
             bound,
             inner,
@@ -63,7 +65,7 @@ impl<T: Inner<E>, E: Ext> Socket<T, E> {
         })))
     }
 
-    pub(super) fn new_cyclic<F>(bound: BoundPort<E>, inner_fn: F) -> Self
+    pub(super) fn new_cyclic<F>(bound: T::BoundPort, inner_fn: F) -> Self
     where
         F: FnOnce(&Weak<SocketBg<T, E>>) -> T,
     {
@@ -99,7 +101,7 @@ impl<T: Inner<E>, E: Ext> Socket<T, E> {
         self.0.bound.iface()
     }
 
-    pub fn bound_port(&self) -> &BoundPort<E> {
+    pub fn bound_port(&self) -> &T::BoundPort {
         &self.0.bound
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -25,7 +25,7 @@ use crate::{
     define_boolean_value,
     errors::tcp::{ConnectError, IoError, RecvError, SendError},
     ext::Ext,
-    iface::{BoundPort, PollKey, PollableIfaceMut},
+    iface::{BoundTcpPort, PollKey, PollableIfaceMut},
     socket::{
         event::SocketEvents,
         option::{RawTcpOption, RawTcpSetOption},
@@ -253,6 +253,7 @@ impl<E: Ext> TcpConnectionInner<E> {
 }
 
 impl<E: Ext> Inner<E> for TcpConnectionInner<E> {
+    type BoundPort = BoundTcpPort<E>;
     type Observer = E::TcpEventObserver;
 
     fn on_drop(this: &Arc<SocketBg<Self, E>>) {
@@ -292,11 +293,11 @@ impl<E: Ext> TcpConnection<E> {
     ///
     /// Polling the iface is _always_ required after this method succeeds.
     pub fn new_connect(
-        bound: BoundPort<E>,
+        bound: BoundTcpPort<E>,
         remote_endpoint: IpEndpoint,
         option: &RawTcpOption,
         observer: E::TcpEventObserver,
-    ) -> Result<Self, (BoundPort<E>, ConnectError)> {
+    ) -> Result<Self, (BoundTcpPort<E>, ConnectError)> {
         let local_endpoint = bound.endpoint();
 
         let iface = bound.iface().clone();
@@ -358,12 +359,12 @@ impl<E: Ext> TcpConnection<E> {
         }
     }
 
-    /// Converts back to the [`BoundPort`].
+    /// Converts back to the [`BoundTcpPort`].
     ///
     /// This method will succeed if the connection is fully closed and no network events can reach
     /// this connection. We guarantee that this method will always succeed if
     /// [`Self::connect_state`] returns [`ConnectState::Refused`].
-    pub fn into_bound_port(mut self) -> Option<BoundPort<E>> {
+    pub fn into_bound_port(mut self) -> Option<BoundTcpPort<E>> {
         let this: TcpConnectionBg<E> = Arc::into_inner(self.0.take())?;
         Some(this.bound)
     }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -17,7 +17,7 @@ use super::{
 use crate::{
     errors::tcp::ListenError,
     ext::Ext,
-    iface::{BindPortConfig, BoundPort, PollableIfaceMut},
+    iface::{BindPortConfig, BoundTcpPort, PollableIfaceMut},
     socket::{
         option::{RawTcpOption, RawTcpSetOption},
         unbound::{RawTcpSocket, new_tcp_socket},
@@ -50,6 +50,7 @@ impl<E: Ext> TcpListenerInner<E> {
 }
 
 impl<E: Ext> Inner<E> for TcpListenerInner<E> {
+    type BoundPort = BoundTcpPort<E>;
     type Observer = E::TcpEventObserver;
 
     fn on_drop(this: &Arc<SocketBg<Self, E>>) {
@@ -68,11 +69,11 @@ impl<E: Ext> TcpListener<E> {
     ///
     /// Polling the iface is _not_ required after this method succeeds.
     pub fn new_listen(
-        bound: BoundPort<E>,
+        bound: BoundTcpPort<E>,
         max_conn: usize,
         option: &RawTcpOption,
         observer: E::TcpEventObserver,
-    ) -> Result<Self, (BoundPort<E>, ListenError)> {
+    ) -> Result<Self, (BoundTcpPort<E>, ListenError)> {
         let local_endpoint = bound.endpoint();
 
         let iface = bound.iface().clone();
@@ -234,7 +235,7 @@ impl<E: Ext> TcpListenerBg<E> {
         let conn = TcpConnection::new_cyclic(
             self.bound
                 .iface()
-                .bind(BindPortConfig::new_backlog(self.bound.endpoint()))
+                .bind_tcp(BindPortConfig::new_backlog(self.bound.endpoint()))
                 .unwrap(),
             |weak| {
                 TcpConnectionInner::new(

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -15,7 +15,7 @@ use super::common::{Inner, Socket, SocketBg};
 use crate::{
     errors::udp::SendError,
     ext::Ext,
-    iface::BoundPort,
+    iface::BoundUdpPort,
     socket::{RawUdpSocket, event::SocketEvents, unbound::new_udp_socket},
 };
 
@@ -28,6 +28,7 @@ pub struct UdpSocketInner {
 }
 
 impl<E: Ext> Inner<E> for UdpSocketInner {
+    type BoundPort = BoundUdpPort<E>;
     type Observer = E::UdpEventObserver;
 
     fn on_drop(this: &Arc<SocketBg<Self, E>>) {
@@ -103,9 +104,9 @@ impl<E: Ext> UdpSocket<E> {
     ///
     /// Polling the iface is _not_ required after this method succeeds.
     pub fn new_bind(
-        bound: BoundPort<E>,
+        bound: BoundUdpPort<E>,
         observer: E::UdpEventObserver,
-    ) -> Result<Self, (BoundPort<E>, smoltcp::socket::udp::BindError)> {
+    ) -> Result<Self, (BoundUdpPort<E>, smoltcp::socket::udp::BindError)> {
         let local_endpoint = bound.endpoint();
 
         let socket = {

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -147,7 +147,7 @@ impl<E: Ext> UdpSocket<E> {
     {
         let mut socket = self.0.inner.socket.lock();
 
-        if size > socket.packet_send_capacity() {
+        if size > socket.payload_send_capacity() {
             return Err(SendError::TooLarge);
         }
 

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -11,7 +11,8 @@ pub use init::{init, iter_all_ifaces, loopback_iface, virtio_iface};
 pub(super) use poll::init_in_first_kthread;
 
 pub type Iface = dyn aster_bigtcp::iface::Iface<ext::BigtcpExt>;
-pub type BoundPort = aster_bigtcp::iface::BoundPort<ext::BigtcpExt>;
+pub type BoundTcpPort = aster_bigtcp::iface::BoundTcpPort<ext::BigtcpExt>;
+pub type BoundUdpPort = aster_bigtcp::iface::BoundUdpPort<ext::BigtcpExt>;
 
 pub type RawTcpSocketExt = aster_bigtcp::socket::RawTcpSocketExt<ext::BigtcpExt>;
 

--- a/kernel/src/net/socket/ip/addr.rs
+++ b/kernel/src/net/socket/ip/addr.rs
@@ -29,7 +29,7 @@ impl From<IpEndpoint> for SocketAddr {
     }
 }
 
-/// A local endpoint, which indicates that the local endpoint is unspecified.
+/// An IPv4 local endpoint, which indicates that the local endpoint is unspecified.
 ///
 /// According to the Linux man pages and the Linux implementation, `getsockname()` will _not_ fail
 /// even if the socket is unbound. Instead, it will return an unspecified socket address. This
@@ -50,7 +50,7 @@ pub enum IpAddressFamily {
 
 impl IpAddressFamily {
     /// Returns the unspecified endpoint for this address family.
-    pub const fn unspecified_endpoint(&self) -> IpEndpoint {
+    pub(super) const fn unspecified_endpoint(&self) -> IpEndpoint {
         match self {
             IpAddressFamily::IPv4 => UNSPECIFIED_LOCAL_ENDPOINT,
             IpAddressFamily::IPv6 => UNSPECIFIED_LOCAL_ENDPOINT_V6,

--- a/kernel/src/net/socket/ip/common.rs
+++ b/kernel/src/net/socket/ip/common.rs
@@ -8,7 +8,7 @@ use aster_bigtcp::{
 
 use crate::{
     net::{
-        iface::{BoundPort, Iface, iter_all_ifaces, loopback_iface, virtio_iface},
+        iface::{Iface, iter_all_ifaces, loopback_iface, virtio_iface},
         socket::util::check_port_privilege,
     },
     prelude::*,
@@ -69,7 +69,10 @@ fn get_ephemeral_iface(remote_ip_addr: &IpAddress) -> Arc<Iface> {
     }
 }
 
-pub(super) fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundPort> {
+pub(super) fn resolve_bind_iface_and_config(
+    endpoint: &IpEndpoint,
+    can_reuse: bool,
+) -> Result<(Arc<Iface>, BindPortConfig)> {
     check_port_privilege(endpoint.port)?;
 
     let iface = match get_iface_to_bind(&endpoint.addr) {
@@ -84,7 +87,7 @@ pub(super) fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundP
 
     let bind_port_config = BindPortConfig::new(*endpoint, can_reuse);
 
-    Ok(iface.bind(bind_port_config)?)
+    Ok((iface, bind_port_config))
 }
 
 impl From<BindError> for Error {

--- a/kernel/src/net/socket/ip/common.rs
+++ b/kernel/src/net/socket/ip/common.rs
@@ -14,7 +14,7 @@ use crate::{
     prelude::*,
 };
 
-pub(super) fn get_iface_to_bind(ip_addr: &IpAddress) -> Option<Arc<Iface>> {
+fn get_iface_to_bind(ip_addr: &IpAddress) -> Option<Arc<Iface>> {
     match *ip_addr {
         IpAddress::Ipv4(ipv4_addr) => iter_all_ifaces()
             .find(|iface| iface.ipv4_addr().is_some_and(|addr| addr == ipv4_addr))

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -8,7 +8,7 @@ use aster_bigtcp::{
 use crate::{
     events::IoEvents,
     net::{
-        iface::{BoundPort, Iface, UdpSocket},
+        iface::{BoundUdpPort, Iface, UdpSocket},
         socket::util::{SendRecvFlags, datagram_common},
     },
     prelude::*,
@@ -32,7 +32,7 @@ impl BoundDatagram {
         self.bound_socket.iface()
     }
 
-    pub(super) fn bound_port(&self) -> &BoundPort {
+    pub(super) fn bound_port(&self) -> &BoundUdpPort {
         self.bound_socket.bound_port()
     }
 }

--- a/kernel/src/net/socket/ip/datagram/unbound.rs
+++ b/kernel/src/net/socket/ip/datagram/unbound.rs
@@ -5,9 +5,12 @@ use aster_bigtcp::{socket::UdpSocket, wire::IpEndpoint};
 use super::{bound::BoundDatagram, observer::DatagramObserver};
 use crate::{
     events::IoEvents,
-    net::socket::{
-        ip::common::{bind_port, get_ephemeral_endpoint},
-        util::datagram_common,
+    net::{
+        iface::BoundUdpPort,
+        socket::{
+            ip::common::{get_ephemeral_endpoint, resolve_bind_iface_and_config},
+            util::datagram_common,
+        },
     },
     prelude::*,
     process::signal::Pollee,
@@ -69,4 +72,9 @@ impl datagram_common::Unbound for UnboundDatagram {
     fn check_io_events(&self) -> IoEvents {
         IoEvents::OUT
     }
+}
+
+fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundUdpPort> {
+    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse)?;
+    Ok(iface.bind_udp(config)?)
 }

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -10,7 +10,7 @@ use super::observer::StreamObserver;
 use crate::{
     events::IoEvents,
     net::{
-        iface::{BoundPort, Iface, RawTcpSocketExt, TcpConnection},
+        iface::{BoundTcpPort, Iface, RawTcpSocketExt, TcpConnection},
         socket::util::{LingerOption, SendRecvFlags, SockShutdownCmd},
     },
     prelude::*,
@@ -131,7 +131,7 @@ impl ConnectedStream {
         self.tcp_conn.iface()
     }
 
-    pub(super) fn bound_port(&self) -> &BoundPort {
+    pub(super) fn bound_port(&self) -> &BoundTcpPort {
         self.tcp_conn.bound_port()
     }
 

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -10,7 +10,7 @@ use super::{connected::ConnectedStream, init::InitStream, observer::StreamObserv
 use crate::{
     events::IoEvents,
     net::{
-        iface::{BoundPort, Iface, TcpConnection},
+        iface::{BoundTcpPort, Iface, TcpConnection},
         socket::ip::IpAddressFamily,
     },
     prelude::*,
@@ -29,11 +29,11 @@ pub(super) enum ConnResult {
 
 impl ConnectingStream {
     pub(super) fn new(
-        bound_port: BoundPort,
+        bound_port: BoundTcpPort,
         remote_endpoint: IpEndpoint,
         option: &RawTcpOption,
         observer: StreamObserver,
-    ) -> Result<Self, (Error, BoundPort)> {
+    ) -> Result<Self, (Error, BoundTcpPort)> {
         let tcp_conn =
             match TcpConnection::new_connect(bound_port, remote_endpoint, option, observer) {
                 Ok(tcp_conn) => tcp_conn,
@@ -105,7 +105,7 @@ impl ConnectingStream {
         self.tcp_conn.iface()
     }
 
-    pub(super) fn bound_port(&self) -> &BoundPort {
+    pub(super) fn bound_port(&self) -> &BoundTcpPort {
         self.tcp_conn.bound_port()
     }
 

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -11,11 +11,11 @@ use super::{connecting::ConnectingStream, listen::ListenStream, observer::Stream
 use crate::{
     events::IoEvents,
     net::{
-        iface::BoundPort,
+        iface::BoundTcpPort,
         socket::{
             ip::{
                 addr::IpAddressFamily,
-                common::{bind_port, get_ephemeral_endpoint},
+                common::{get_ephemeral_endpoint, resolve_bind_iface_and_config},
             },
             util::SocketAddr,
         },
@@ -24,7 +24,7 @@ use crate::{
 };
 
 pub(super) struct InitStream {
-    bound_port: Option<BoundPort>,
+    bound_port: Option<BoundTcpPort>,
     /// The address family of this socket (IPv4 or IPv6).
     //
     // TODO: Encode the address family in the type system (e.g., `InitStream<IPv4Family>`)
@@ -62,7 +62,7 @@ impl InitStream {
         }
     }
 
-    pub(super) fn new_bound(bound_port: BoundPort, family: IpAddressFamily) -> Self {
+    pub(super) fn new_bound(bound_port: BoundTcpPort, family: IpAddressFamily) -> Self {
         Self {
             bound_port: Some(bound_port),
             family,
@@ -71,7 +71,7 @@ impl InitStream {
         }
     }
 
-    pub(super) fn new_refused(bound_port: BoundPort, family: IpAddressFamily) -> Self {
+    pub(super) fn new_refused(bound_port: BoundTcpPort, family: IpAddressFamily) -> Self {
         Self {
             bound_port: Some(bound_port),
             family,
@@ -104,7 +104,7 @@ impl InitStream {
         Ok(())
     }
 
-    pub(super) fn bound_port(&self) -> Option<&BoundPort> {
+    pub(super) fn bound_port(&self) -> Option<&BoundTcpPort> {
         self.bound_port.as_ref()
     }
 
@@ -271,4 +271,9 @@ impl InitStream {
             None
         }
     }
+}
+
+fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundTcpPort> {
+    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse)?;
+    Ok(iface.bind_tcp(config)?)
 }

--- a/kernel/src/net/socket/ip/stream/listen.rs
+++ b/kernel/src/net/socket/ip/stream/listen.rs
@@ -9,7 +9,7 @@ use aster_bigtcp::{
 use super::{connected::ConnectedStream, observer::StreamObserver};
 use crate::{
     events::IoEvents,
-    net::iface::{BoundPort, Iface, TcpListener},
+    net::iface::{BoundTcpPort, Iface, TcpListener},
     prelude::*,
 };
 
@@ -19,11 +19,11 @@ pub(super) struct ListenStream {
 
 impl ListenStream {
     pub(super) fn new(
-        bound_port: BoundPort,
+        bound_port: BoundTcpPort,
         backlog: usize,
         option: &RawTcpOption,
         observer: StreamObserver,
-    ) -> Result<Self, (BoundPort, Error)> {
+    ) -> Result<Self, (BoundTcpPort, Error)> {
         const SOMAXCONN: usize = 4096;
         let max_conn = SOMAXCONN.min(backlog);
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -557,6 +557,7 @@ fn clone_child_process(
         let child_vmar_arc = child_vmar.clone_arc();
 
         let mut child_thread_builder = {
+            // Inherit the parent's thread name
             let child_thread_name = ctx.posix_thread.thread_name().lock().clone();
 
             let credentials = {

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -184,6 +184,7 @@ fn do_execve_no_return(
     // Unshare file descriptor table and close files with O_CLOEXEC flag.
     unshare_and_close_files(ctx);
 
+    // Set the thread name.
     *posix_thread.thread_name().lock() = thread_name;
 
     // Unshare and reset signal dispositions to their default actions.

--- a/test/initramfs/src/regression/network/udp_err.c
+++ b/test/initramfs/src/regression/network/udp_err.c
@@ -420,3 +420,28 @@ FN_TEST(self_connect)
 	TEST_SUCC(close(sk));
 }
 END_TEST()
+
+FN_TEST(send_and_recv_large_buffer)
+{
+	int receiver = TEST_SUCC(socket(PF_INET, SOCK_DGRAM, 0));
+	int sender = TEST_SUCC(socket(PF_INET, SOCK_DGRAM, 0));
+	char send_buf[1400], receive_buf[sizeof(send_buf)];
+
+	sk_addr.sin_port = htons(8083);
+	TEST_SUCC(bind(receiver, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+	TEST_SUCC(
+		connect(sender, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+
+	memset(send_buf, 'x', sizeof(send_buf));
+	TEST_RES(send(sender, send_buf, sizeof(send_buf), 0),
+		 _ret == sizeof(send_buf));
+
+	memset(receive_buf, 'y', sizeof(receive_buf));
+	TEST_RES(recv(receiver, receive_buf, sizeof(receive_buf), 0),
+		 _ret == sizeof(receive_buf));
+	TEST_RES(memcmp(send_buf, receive_buf, sizeof(receive_buf)), _ret == 0);
+
+	TEST_SUCC(close(receiver));
+	TEST_SUCC(close(sender));
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/udp_err.c
+++ b/test/initramfs/src/regression/network/udp_err.c
@@ -445,3 +445,19 @@ FN_TEST(send_and_recv_large_buffer)
 	TEST_SUCC(close(sender));
 }
 END_TEST()
+
+FN_TEST(bind_tcp_and_udp_to_same_port)
+{
+	int tcp = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+	int udp = TEST_SUCC(socket(PF_INET, SOCK_DGRAM, 0));
+
+	sk_addr.sin_port = htons(8082);
+
+	TEST_SUCC(bind(tcp, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+	TEST_SUCC(listen(tcp, 1));
+	TEST_SUCC(bind(udp, (struct sockaddr *)&sk_addr, sizeof(sk_addr)));
+
+	TEST_SUCC(close(tcp));
+	TEST_SUCC(close(udp));
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/clock_nanosleep/nanosleep_err.c
+++ b/test/initramfs/src/regression/process/clock_nanosleep/nanosleep_err.c
@@ -12,8 +12,9 @@ FN_TEST(clock_nanosleep_unknown_flag_bit)
 {
 	struct timespec req = { .tv_sec = 0, .tv_nsec = 0 };
 
-	// `flags = 2` is neither 0 nor `TIMER_ABSTIME`. Used to trigger
-	// `unreachable!()` and panic the kernel.
-	TEST_SUCC(syscall(SYS_clock_nanosleep, CLOCK_MONOTONIC, 2, &req, NULL));
+	// The flag (`0xdeadbeef`) is neither 0 nor `TIMER_ABSTIME`.
+	// Linux will ignore unknown flag bits.
+	TEST_SUCC(syscall(SYS_clock_nanosleep, CLOCK_MONOTONIC, 0xdeadbeef,
+			  &req, NULL));
 }
 END_TEST()

--- a/test/initramfs/src/regression/process/execve/execve_comm.c
+++ b/test/initramfs/src/regression/process/execve/execve_comm.c
@@ -23,7 +23,6 @@ FN_TEST(execve_symlink)
 	int status;
 	pid_t pid;
 
-	unlink(LINK_PATH);
 	TEST_SUCC(symlink(CHILD_PATH, LINK_PATH));
 
 	pid = TEST_SUCC(fork());
@@ -35,7 +34,7 @@ FN_TEST(execve_symlink)
 	TEST_RES(waitpid(pid, &status, 0),
 		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
 
-	unlink(LINK_PATH);
+	TEST_SUCC(unlink(LINK_PATH));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/process/prctl/thread_name.c
+++ b/test/initramfs/src/regression/process/prctl/thread_name.c
@@ -37,7 +37,8 @@ FN_TEST(fork_inherits_thread_name)
 
 	pid = TEST_SUCC(fork());
 	if (pid == 0) {
-		_exit(check_proc_stat_comm(THREAD_NAME));
+		CHECK_WITH(check_proc_stat_comm(THREAD_NAME), _ret == 0);
+		_exit(0);
 	}
 
 	TEST_RES(waitpid(pid, &status, 0),

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-./cgroup.sh
+./clock_nanosleep/nanosleep_err
 
 ./clone3/clone_exit_signal
 ./clone3/clone_files
@@ -14,8 +14,6 @@ set -e
 ./clone3/clone_process
 
 ./cpu_affinity/cpu_affinity
-
-./clock_nanosleep/nanosleep_err
 
 ./execve/execve
 ./execve/execve_comm
@@ -73,6 +71,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
     ./signal/sigtrap
 fi
 
+./cgroup.sh
 ./group_session
 ./job_control
 ./pidfd


### PR DESCRIPTION
This PR resolves some bugs that were encountered during UDP speed testing with `iperf3`.

 1. The first bug was that we incorrectly checked the number of bytes against the number of packets.
https://github.com/asterinas/asterinas/blob/9fab50ef564ee66a7b50bbd32dddf564831327ef/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs#L150

It should be:
```diff
-        if size > socket.packet_send_capacity() {
+        if size > socket.payload_send_capacity() {
```

 2. The second is to resolve the following FIXME item:
https://github.com/asterinas/asterinas/blob/9fab50ef564ee66a7b50bbd32dddf564831327ef/kernel/libs/aster-bigtcp/src/iface/common.rs#L314-L315

This PR introduces the `PortKey` struct:
```rust
pub struct IfaceCommon<E: Ext> {
    used_ports: SpinLock<BTreeMap<PortKey, PortState>, BottomHalfDisabled>,
    // ..
}

#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
struct PortKey {
    addr: NormalizedAddress,
    port: u16,
    protocol: PortProtocol,
}
```

It also introduces the strongly typed bound ports `BoundTcpPort` and `BoundUdpPort` to avoid creating a TCP socket on a UDP port.
```rust
/// A TCP port bound to an iface.
pub struct BoundTcpPort<E: Ext>(BoundPort<E>);
/// A UDP port bound to an iface.
pub struct BoundUdpPort<E: Ext>(BoundPort<E>);
```

`iperf -u -l 1400` can work under `NETDEV=tap` after this PR. There are some other problems:
 - It does not work under `NETDEV=user` because the UDP port forwarding is not configuerd.
 - `-l 1400` is required. Otherwise either the data rate is zero or the kernel will panic. We support neither IPv4 fragments nor virtio-net jumbo packets. 65535-byte Ethernet frames won't work. 