### PR TITLE
Check `high_watermark` against `avail_pages` intead of `all_pages`

### DIFF
--- a/kernel/comps/network/src/dma_pool.rs
+++ b/kernel/comps/network/src/dma_pool.rs
@@ -46,7 +46,8 @@ impl<D: DmaDirection> DmaPool<D> {
     /// To optimize performance, the pool employs a lazy deallocation strategy:
     /// A DMAable page is freed only if it meets the following conditions:
     /// 1. The page is currently not in use;
-    /// 2. The total number of allocated DMAable pages exceeds the specified `high_watermark`.
+    /// 2. The total number of available DMAable pages (i.e., allocated pages that have at
+    ///    least one free segment) exceeds the specified `high_watermark`.
     ///
     /// The returned pool can be used to allocate small segments for DMA usage.
     /// All allocated segments will have the same DMA direction
@@ -253,22 +254,27 @@ impl<D: DmaDirection> Drop for DmaSegment<D> {
         let pool = page.pool.upgrade().unwrap();
 
         // Keep the same lock order as `pool.alloc_segment`
-        // Lock order: pool.avail_pages -> pool.all_pages -> page.allocated_segments
+        // Lock order: pool.avail_pages -> pool.all_pages
+        //             pool.avail_pages -> page.allocated_segments
         let mut avail_pages = pool.avail_pages.lock();
-        let mut all_pages = pool.all_pages.lock();
 
-        let mut allocated_segments = page.allocated_segments.lock();
+        let (became_avail, became_free) = {
+            let mut allocated_segments = page.allocated_segments.lock();
 
-        let nr_blocks_per_page = PAGE_SIZE / self.size;
-        let became_avail = get_next_free_index(&allocated_segments, nr_blocks_per_page).is_none();
+            let nr_blocks_per_page = PAGE_SIZE / self.size;
+            let became_avail =
+                get_next_free_index(&allocated_segments, nr_blocks_per_page).is_none();
 
-        debug_assert!((page.daddr()..page.daddr() + PAGE_SIZE).contains(&self.daddr()));
-        let segment_idx = (self.daddr() - page.daddr()) / self.size;
-        allocated_segments.set(segment_idx, false);
+            debug_assert!((page.daddr()..page.daddr() + PAGE_SIZE).contains(&self.daddr()));
+            let segment_idx = (self.daddr() - page.daddr()) / self.size;
+            allocated_segments.set(segment_idx, false);
 
-        let became_free = allocated_segments.not_any();
+            let became_free = allocated_segments.not_any();
+            (became_avail, became_free)
+        };
 
-        if became_free && all_pages.len() > pool.high_watermark {
+        if became_free && avail_pages.len() > pool.high_watermark {
+            let mut all_pages = pool.all_pages.lock();
             avail_pages.retain(|page_| !Arc::ptr_eq(page_, &page));
             all_pages.retain(|page_| !Arc::ptr_eq(page_, &page));
             return;
@@ -332,7 +338,7 @@ mod test {
             .collect();
         assert_eq!(pool.num_pages(), 100);
         drop(segments1);
-        assert_eq!(pool.num_pages(), 50);
+        assert_eq!(pool.num_pages(), 51);
     }
 
     #[ktest]


### PR DESCRIPTION
I don't know the original intention behind checking `high_watermark` against `all_pages`:
https://github.com/asterinas/asterinas/blob/05da550acc93870e70dbae175065bfd9201cf4ce/kernel/comps/network/src/dma_pool.rs#L271

This is a bit problematic because we currently have `HIGH_WATERMARK == QUEUE_SIZE`:
https://github.com/asterinas/asterinas/blob/05da550acc93870e70dbae175065bfd9201cf4ce/kernel/comps/virtio/src/device/socket/buffer.rs#L17
https://github.com/asterinas/asterinas/blob/05da550acc93870e70dbae175065bfd9201cf4ce/kernel/comps/virtio/src/device/network/device.rs#L361

In addition, after receiving a packet, we refill the queue to prepare for the next RX. This happens before we free the packet.
https://github.com/asterinas/asterinas/blob/05da550acc93870e70dbae175065bfd9201cf4ce/kernel/comps/virtio/src/device/network/device.rs#L172-L176
So at this point, there are `QUEUE_SIZE + 1` pages in `all_pages`. When we free the packet, its page returns to the memory allocator without entering the pool. This is slow because every packet must be allocated from the memory allocator and mapped as a DMA page. This disregards the purpose of the DMA pool.

### Performance results

Tested via:
```
# make run_kernel RELEASE=1 NETDEV=tap VHOST=on ENABLE_BENCHMARK_TEST=true
(Asterinas guest) # /benchmark/bin/iperf3 -s -B 10.0.2.15
(Linux host)      # iperf3 -c 10.0.2.15 -p 5201 -u -l 1460 -b 50G
```

Before this PR:
```
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  19.2 GBytes  16.5 Gbits/sec  0.000 ms  0/14109969 (0%)  sender
[  5]   0.00-10.01  sec  7.03 GBytes  6.03 Gbits/sec  0.007 ms  8939659/14109878 (63%)  receiver
```

After this PR:
```
[  5]   0.00-10.00  sec  17.9 GBytes  15.4 Gbits/sec  0.000 ms  0/13149632 (0%)  sender
[  5]   0.00-10.01  sec  11.8 GBytes  10.1 Gbits/sec  0.002 ms  4492697/13149577 (34%)  receiver
```

There are still gaps between our results and Linux's:
```
[  5]   0.00-10.00  sec  14.2 GBytes  12.2 Gbits/sec  0.000 ms  0/10478468 (0%)  sender
[  5]   0.00-10.00  sec  14.2 GBytes  12.2 Gbits/sec  0.001 ms  11644/10478405 (0.11%)  receiver
```

The gap can be mitigated further (Asterinas can achieve `13.0 Gbps`, which is higher than Linux's `12.2 Gbps`) by doing the following:
```diff
diff --git a/kernel/libs/aster-bigtcp/src/socket/unbound.rs b/kernel/libs/aster-bigtcp/src/socket/unbound.rs
index 730dcf2b4..e47645e88 100644
--- a/kernel/libs/aster-bigtcp/src/socket/unbound.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/unbound.rs
@@ -48,5 +48,5 @@ pub const TCP_SEND_BUF_LEN: usize = 65536 * 2;
 
 // UDP socket buffer sizes:
 pub const UDP_SEND_PAYLOAD_LEN: usize = 65536;
-pub const UDP_RECV_PAYLOAD_LEN: usize = 65536;
-const UDP_METADATA_LEN: usize = 256;
+pub const UDP_RECV_PAYLOAD_LEN: usize = 64 * 1024 * 1024;
+const UDP_METADATA_LEN: usize = 65536;
```

However, I don't think it's a reasonable change. Further investigation is needed, so I am not including those changes in this PR.