### PR TITLE
Fix linux-legacy32 boot with stripped payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ CARGO_OSDK_COMMON_ARGS += --grub-mkrescue=/usr/bin/grub-mkrescue --grub-boot-pro
 else ifeq ($(BOOT_PROTOCOL), linux-efi-pe64)
 CARGO_OSDK_COMMON_ARGS += --grub-boot-protocol="linux"
 else ifeq ($(BOOT_PROTOCOL), linux-legacy32)
-CARGO_OSDK_COMMON_ARGS += --linux-x86-legacy-boot --grub-boot-protocol="linux"
+CARGO_OSDK_COMMON_ARGS += --linux-x86-legacy-boot --grub-boot-protocol="linux" --strip-elf
 else
 CARGO_OSDK_COMMON_ARGS += --grub-boot-protocol=$(BOOT_PROTOCOL)
 endif

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -13,7 +13,7 @@ use linux_bzimage_builder::{
 use crate::{
     arch::Arch,
     bundle::{
-        bin::{AsterBin, AsterBinType, AsterBzImageMeta, AsterElfMeta},
+        bin::{AsterBin, AsterBinType, AsterBzImageMeta},
         file::BundleFile,
     },
     util::{get_current_crates, hard_link_or_copy, new_command_checked_exists},
@@ -80,7 +80,11 @@ pub fn make_install_bzimage(
     )
 }
 
-pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: bool) -> AsterBin {
+pub fn make_stripped_boot_elf(
+    install_dir: impl AsRef<Path>,
+    elf: &AsterBin,
+    strip: bool,
+) -> AsterBin {
     let result_elf_path = {
         let elf_name = elf
             .path()
@@ -119,6 +123,16 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
         hard_link_or_copy(elf.path(), &result_elf_path).unwrap();
     }
 
+    AsterBin::new(
+        &result_elf_path,
+        elf.arch(),
+        elf.typ().clone(),
+        elf.version().clone(),
+        strip,
+    )
+}
+
+pub fn make_elf_for_qemu(elf: AsterBin) -> AsterBin {
     if elf.arch() == Arch::X86_64 {
         // Because QEMU denies a x86_64 multiboot ELF file (GRUB2 accept it, btw),
         // modify `em_machine` to pretend to be an x86 (32-bit) ELF image,
@@ -128,7 +142,7 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
-            .open(&result_elf_path)
+            .open(elf.path())
             .unwrap();
 
         let bytes: [u8; 2] = [0x03, 0x00];
@@ -138,18 +152,7 @@ pub fn make_elf_for_qemu(install_dir: impl AsRef<Path>, elf: &AsterBin, strip: b
         file.flush().unwrap();
     }
 
-    AsterBin::new(
-        &result_elf_path,
-        elf.arch(),
-        AsterBinType::Elf(AsterElfMeta {
-            has_linux_header: false,
-            has_pvh_header: false,
-            has_multiboot_header: true,
-            has_multiboot2_header: true,
-        }),
-        elf.version().clone(),
-        strip,
-    )
+    elf
 }
 
 fn install_setup_with_arch(

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::SystemTime,
 };
 
-use bin::{make_elf_for_qemu, make_install_bzimage};
+use bin::{make_elf_for_qemu, make_install_bzimage, make_stripped_boot_elf};
 
 use super::util::{COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH, cargo, profile_name_adapter};
 use crate::{
@@ -164,12 +164,14 @@ pub fn do_cached_build(
     }
     let mut bundle = Bundle::new(&bundle_path, config, action);
 
+    let boot_elf = make_stripped_boot_elf(&osdk_output_directory, &aster_elf, build.strip_elf);
+
     match boot.method {
         BootMethod::GrubRescueIso | BootMethod::GrubQcow2 => {
             info!("Building boot device image");
             let bootdev_image = grub::create_bootdev_image(
                 &osdk_output_directory,
-                &aster_elf,
+                &boot_elf,
                 boot.initramfs.as_ref(),
                 config,
                 action,
@@ -187,11 +189,11 @@ pub fn do_cached_build(
                 BootProtocol::Linux => make_install_bzimage(
                     &osdk_output_directory,
                     &osdk_output_directory,
-                    &aster_elf,
+                    &boot_elf,
                     build.linux_x86_legacy_boot,
                     config.build.encoding.clone(),
                 ),
-                _ => make_elf_for_qemu(&osdk_output_directory, &aster_elf, build.strip_elf),
+                _ => make_elf_for_qemu(boot_elf),
             };
             bundle.consume_aster_bin(aster_bin);
         }


### PR DESCRIPTION
  ## Summary

  The linux-legacy32 boot path embeds the kernel ELF into the Linux bzImage
  setup payload. On this branch, the unstripped kernel ELF can become very large
  because it contains debug and symbol sections such as `.debug_info`,
  `.debug_str`, and `.strtab`.

  These sections are not needed for booting, but they still increase the payload
  size. For legacy32 boot, the oversized setup payload can overlap with the
  kernel load range and make the setup code fail before entering Asterinas.

  This PR enables `--strip-elf` for `BOOT_PROTOCOL=linux-legacy32` and derives a
  separate stripped `boot_elf` from the original kernel ELF. The stripped
  `boot_elf` is used only as the Linux bzImage payload for boot loading.

  The original unstripped kernel ELF is still kept in the bundle. It preserves
  debug information for post-run panic analysis and symbolization.

## Test
`make run_kernel AUTO_TEST=boot SMP=4 BOOT_PROTOCOL=linux-legacy32`