### PR TITLE
Add `aster_mac` major LSM module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,9 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/test/boot_hello.sh"
 else ifeq ($(AUTO_TEST), lsm-module-selection)
 ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_lsm_module_selection_test.sh"
+else ifeq ($(AUTO_TEST), aster-mac)
+ENABLE_REGRESSION_TEST := true
+CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_aster_mac_test.sh"
 else ifeq ($(AUTO_TEST), vsock)
 ENABLE_REGRESSION_TEST := true
 export VSOCK=on
@@ -292,6 +295,9 @@ else ifeq ($(AUTO_TEST), boot)
 else ifeq ($(AUTO_TEST), lsm-module-selection)
 	@tail --lines 100 qemu.log | grep -q "^LSM module selection test passed." \
 		|| (echo "LSM module selection test failed" && exit 1)
+else ifeq ($(AUTO_TEST), aster-mac)
+	@tail --lines 100 qemu.log | grep -q "^Aster MAC test passed." \
+		|| (echo "Aster MAC test failed" && exit 1)
 else ifeq ($(AUTO_TEST), vsock)
 	@tail --lines 100 qemu.log | grep -q "^Vsock test passed." \
 		|| (echo "Vsock test failed" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
 FEATURES ?=
 NO_DEFAULT_FEATURES ?= 0
 COVERAGE ?= 0
+# Extra kernel command-line arguments, separated by spaces.
+#
+# Example: EXTRA_KCMD_ARGS="lsm=yama"
+EXTRA_KCMD_ARGS ?=
 
 # Specify the primary system console (supported: tty0, ttyS0, hvc0).
 # - tty0: The active virtual terminal (VT).
@@ -104,6 +108,7 @@ CARGO_OSDK_COMMON_ARGS :=
 # The build arguments also apply to the `cargo osdk run` command.
 CARGO_OSDK_BUILD_ARGS := --kcmd-args="ostd.log_level=$(LOG_LEVEL)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="console=$(CONSOLE)"
+CARGO_OSDK_BUILD_ARGS += $(foreach arg,$(EXTRA_KCMD_ARGS),--kcmd-args="$(arg)")
 CARGO_OSDK_TEST_ARGS :=
 
 ifeq ($(AUTO_TEST), conformance)
@@ -123,6 +128,9 @@ CARGO_OSDK_BUILD_ARGS += --kcmd-args="INTEL_TDX=$(INTEL_TDX)"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_regression_test.sh"
 else ifeq ($(AUTO_TEST), boot)
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/boot_hello.sh"
+else ifeq ($(AUTO_TEST), lsm-module-selection)
+ENABLE_REGRESSION_TEST := true
+CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_lsm_module_selection_test.sh"
 else ifeq ($(AUTO_TEST), vsock)
 ENABLE_REGRESSION_TEST := true
 export VSOCK=on
@@ -281,6 +289,9 @@ else ifeq ($(AUTO_TEST), regression)
 else ifeq ($(AUTO_TEST), boot)
 	@tail --lines 100 qemu.log | grep -q "^Successfully booted." \
 		|| (echo "Boot test failed" && exit 1)
+else ifeq ($(AUTO_TEST), lsm-module-selection)
+	@tail --lines 100 qemu.log | grep -q "^LSM module selection test passed." \
+		|| (echo "LSM module selection test failed" && exit 1)
 else ifeq ($(AUTO_TEST), vsock)
 	@tail --lines 100 qemu.log | grep -q "^Vsock test passed." \
 		|| (echo "Vsock test failed" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_lsm_module_selection_test.sh"
 else ifeq ($(AUTO_TEST), aster-mac)
 ENABLE_REGRESSION_TEST := true
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="security=aster_mac"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_aster_mac_test.sh"
 else ifeq ($(AUTO_TEST), vsock)
 ENABLE_REGRESSION_TEST := true

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
+    security,
     util::ioctl::RawIoctl,
 };
 
@@ -56,6 +57,8 @@ impl InodeHandle {
         access_mode: AccessMode,
         status_flags: StatusFlags,
     ) -> Result<Self> {
+        security::file_open(&path, access_mode, status_flags)?;
+
         let inode = path.inode();
         let (open_file, rights) = if status_flags.contains(StatusFlags::O_PATH) {
             (None, Rights::empty())

--- a/kernel/src/fs/fs_impls/cgroupfs/cgroup_ns.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/cgroup_ns.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::CapabilityReason,
 };
 
 /// The cgroup namespace for the unified cgroup hierarchy.
@@ -39,7 +40,11 @@ impl CgroupNamespace {
         owner: Arc<UserNamespace>,
         posix_thread: &PosixThread,
     ) -> Result<Arc<Self>> {
-        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            posix_thread,
+            CapabilityReason::Namespace,
+        )?;
 
         let root: Arc<dyn CgroupSysNode> = match current_cgroup {
             Some(current_cgroup) => current_cgroup,

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -255,6 +255,14 @@ impl Inode for Ext2Inode {
         self.get_xattr(name, value_writer)
     }
 
+    fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize> {
+        self.get_xattr_without_permission_check(name, value_writer)
+    }
+
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize> {
         self.list_xattr(namespace, list_writer)
     }

--- a/kernel/src/fs/fs_impls/ext2/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode.rs
@@ -856,11 +856,24 @@ impl Inode {
     }
 
     pub fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize> {
-        if self.xattr.is_none() {
-            return_errno_with_message!(Errno::ENODATA, "no available xattrs");
-        }
+        let xattr = self
+            .xattr
+            .as_ref()
+            .ok_or(Error::with_message(Errno::ENODATA, "no available xattrs"))?;
         self.check_permission(Permission::MAY_READ)?;
-        self.xattr.as_ref().unwrap().get(name, value_writer)
+        xattr.get(name, value_writer)
+    }
+
+    pub fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize> {
+        let xattr = self
+            .xattr
+            .as_ref()
+            .ok_or(Error::with_message(Errno::ENODATA, "no available xattrs"))?;
+        xattr.get(name, value_writer)
     }
 
     pub fn list_xattr(

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -557,6 +557,11 @@ impl OverlayInode {
         status_flags: StatusFlags,
     ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
     pub fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
+    pub fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize>;
     pub fn list_xattr(
         &self,
         namespace: XattrNamespace,
@@ -1007,6 +1012,11 @@ impl Inode for OverlayInode {
         flags: XattrSetFlags,
     ) -> Result<()>;
     fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
+    fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize>;
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize>;
     fn remove_xattr(&self, name: XattrName) -> Result<()>;
 }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr/current.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr/current.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use super::super::TidDirOps;
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    thread::Thread,
+};
+
+/// Represents the inode at `/proc/[pid]/attr/current`.
+pub(super) struct CurrentFileOps(TidDirOps);
+
+impl CurrentFileOps {
+    /// Creates the inode for `/proc/[pid]/attr/current`.
+    pub(super) fn new_inode(dir: &super::AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir.tid_dir().clone()), parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for CurrentFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        let label = thread
+            .as_posix_thread()
+            .unwrap()
+            .credentials()
+            .aster_mac_label();
+        writeln!(printer, "{}", label)?;
+
+        Ok(printer.bytes_written())
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr/mod.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::template::{
+            ProcDir, ProcDirOps, ReaddirEntry, StaticDirEntry, listed_entries_from_table,
+            lookup_child_from_table, visit_listed_entries,
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    thread::Thread,
+};
+
+mod current;
+
+pub(super) const ATTR_DIR_NAME: &str = "attr";
+
+/// Represents the inode at `/proc/[pid]/attr`.
+#[derive(Clone)]
+pub(super) struct AttrDirOps(TidDirOps);
+
+impl AttrDirOps {
+    /// Creates the inode for `/proc/[pid]/attr`.
+    pub(super) fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDir::new(Self(dir.clone()), parent, mkmod!(a+rx))
+    }
+
+    pub(super) fn tid_dir(&self) -> &TidDirOps {
+        &self.0
+    }
+
+    const STATIC_ENTRIES: &'static [StaticDirEntry<
+        fn(&AttrDirOps, Weak<dyn Inode>) -> Arc<dyn Inode>,
+    >] = &[(
+        "current",
+        InodeType::File,
+        current::CurrentFileOps::new_inode,
+    )];
+}
+
+impl ProcDirOps for AttrDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |constructor| {
+            constructor(self, this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -7,12 +7,25 @@ use crate::{
         procfs::{
             StaticEntryWithOps,
             pid::task::{
-                auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
-                comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
-                mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                attr::{ATTR_DIR_NAME, AttrDirOps},
+                auxv::AuxvFileOps,
+                cgroup::CgroupFileOps,
+                cmdline::CmdlineFileOps,
+                comm::CommFileOps,
+                environ::EnvironFileOps,
+                exe::ExeSymOps,
+                fd::FdDirOps,
+                gid_map::GidMapFileOps,
+                maps::MapsFileOps,
+                mem::MemFileOps,
+                mountinfo::MountInfoFileOps,
+                mounts::MountsFileOps,
+                mountstats::MountStatsFileOps,
+                ns::NsDirOps,
+                oom_score_adj::OomScoreAdjFileOps,
+                stat::StatFileOps,
+                status::StatusFileOps,
+                uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -24,9 +37,11 @@ use crate::{
     },
     prelude::*,
     process::{Process, pid_table, pid_table::PidEntry, posix_thread::AsPosixThread},
+    security,
     thread::{Thread, Tid},
 };
 
+mod attr;
 mod auxv;
 mod cgroup;
 mod cmdline;
@@ -170,16 +185,23 @@ impl TidDirOps {
         name: &str,
     ) -> Result<Arc<dyn Inode>> {
         if let Some(child) =
-            lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| (f)(self, this_ptr))
+            lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| (f)(self, this_ptr.clone()))
         {
             return Ok(child);
+        }
+
+        if name == ATTR_DIR_NAME && security::is_aster_mac_enabled() {
+            return Ok(AttrDirOps::new_inode(self, this_ptr));
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
     pub(super) fn static_listed_entries(&self) -> impl Iterator<Item = ListedEntry<'_>> + '_ {
-        listed_entries_from_table(Self::STATIC_ENTRIES)
+        let attr_entry = security::is_aster_mac_enabled()
+            .then(|| ListedEntry::new(ATTR_DIR_NAME, InodeType::Dir));
+
+        listed_entries_from_table(Self::STATIC_ENTRIES).chain(attr_entry)
     }
 }
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -14,7 +14,6 @@ use crate::{
         credentials::AMBIENT_CAPSET,
         posix_thread::{AsPosixThread, SleepingState},
     },
-    security,
     thread::Thread,
     vm::vmar::RssType,
 };
@@ -193,9 +192,6 @@ impl ProcFileOps for StatusFileOps {
             credentials.bounding_capset().bits()
         )?;
         writeln!(printer, "CapAmb:\t{:016x}", AMBIENT_CAPSET.bits())?;
-        if security::is_aster_mac_enabled() {
-            writeln!(printer, "AsterMacLabel:\t{}", credentials.aster_mac_label())?;
-        }
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -14,6 +14,7 @@ use crate::{
         credentials::AMBIENT_CAPSET,
         posix_thread::{AsPosixThread, SleepingState},
     },
+    security,
     thread::Thread,
     vm::vmar::RssType,
 };
@@ -192,6 +193,9 @@ impl ProcFileOps for StatusFileOps {
             credentials.bounding_capset().bits()
         )?;
         writeln!(printer, "CapAmb:\t{:016x}", AMBIENT_CAPSET.bits())?;
+        if security::is_aster_mac_enabled() {
+            writeln!(printer, "AsterMacLabel:\t{}", credentials.aster_mac_label())?;
+        }
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    security::lsm::is_yama_enabled,
+    security,
 };
 
 mod cap_last_cap;
@@ -52,7 +52,7 @@ impl ProcDirOps for KernelDirOps {
             return Ok(child);
         }
 
-        if name == "yama" && is_yama_enabled() {
+        if name == "yama" && security::is_yama_enabled() {
             return Ok(YamaDirOps::new_inode(this_dir.this_weak().clone()));
         }
 
@@ -63,7 +63,8 @@ impl ProcDirOps for KernelDirOps {
     where
         F: FnMut(ReaddirEntry<'a>) -> Result<()>,
     {
-        let yama_entry = is_yama_enabled().then(|| ListedEntry::new("yama", InodeType::Dir));
+        let yama_entry =
+            security::is_yama_enabled().then(|| ListedEntry::new("yama", InodeType::Dir));
 
         visit_listed_entries(
             offset,

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -1304,6 +1304,16 @@ impl Inode for RamInode {
         self.xattr.get(name, value_writer)
     }
 
+    fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize> {
+        RamXattr::check_file_type_for_xattr(self.typ)
+            .map_err(|_| Error::with_message(Errno::ENODATA, "no available xattrs"))?;
+        self.xattr.get(name, value_writer)
+    }
+
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize> {
         if RamXattr::check_file_type_for_xattr(self.typ).is_err() {
             return Ok(0);

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -172,6 +172,11 @@ impl Inode for MemfdInode {
         flags: XattrSetFlags,
     ) -> Result<()>;
     fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
+    fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize>;
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize>;
     fn remove_xattr(&self, name: XattrName) -> Result<()>;
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -22,7 +22,8 @@ use crate::{
         vfs::path::Path,
     },
     prelude::*,
-    process::{Gid, Uid, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    process::{Gid, Uid, posix_thread::AsPosixThread},
+    security,
     time::clocks::RealTimeCoarseClock,
     vm::page_cache::PageCache,
 };
@@ -510,37 +511,17 @@ pub trait Inode: Any + FileOps + Send + Sync {
     /// Similar to Linux, using "fsuid" here allows setting filesystem permissions
     /// without changing the "normal" uids for other tasks.
     fn check_permission(&self, mut perm: Permission) -> Result<()> {
-        let creds = match Task::current() {
-            Some(task) => match task.as_posix_thread() {
-                Some(thread) => thread.credentials(),
-                None => return Ok(()),
-            },
+        let current = match Task::current() {
+            Some(task) => task,
             None => return Ok(()),
         };
+        let Some(posix_thread) = current.as_posix_thread() else {
+            return Ok(());
+        };
+        let creds = posix_thread.credentials();
 
-        // With DAC_OVERRIDE capability, the user can bypass some permission checks.
-        if creds.effective_capset().contains(CapSet::DAC_OVERRIDE) {
-            // Read/write DACs are always overridable.
-            perm -= Permission::MAY_READ | Permission::MAY_WRITE;
-
-            // Executable DACs are overridable when there is at least one exec bit set.
-            if perm.may_exec() {
-                let metadata = self.metadata();
-                let mode = metadata.mode;
-
-                if mode.is_owner_executable()
-                    || mode.is_group_executable()
-                    || mode.is_other_executable()
-                {
-                    perm -= Permission::MAY_EXEC;
-                } else {
-                    return_errno_with_message!(
-                        Errno::EACCES,
-                        "root execute permission denied: no execute bits set"
-                    );
-                }
-            }
-        }
+        let overridden = security::inode_dac_override(self.metadata().mode, perm, posix_thread)?;
+        perm -= overridden;
 
         perm =
             perm.intersection(Permission::MAY_READ | Permission::MAY_WRITE | Permission::MAY_EXEC);

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -631,6 +631,7 @@ impl Debug for dyn Inode {
 pub struct Extension {
     group1: Once<ThinBox<dyn Any + Send + Sync>>,
     group2: Once<ThinBox<dyn Any + Send + Sync>>,
+    group3: Once<ThinBox<dyn Any + Send + Sync>>,
 }
 
 impl Extension {
@@ -639,6 +640,7 @@ impl Extension {
         Self {
             group1: Once::new(),
             group2: Once::new(),
+            group3: Once::new(),
         }
     }
 
@@ -650,6 +652,11 @@ impl Extension {
     /// Gets the second extension group.
     pub fn group2(&self) -> &Once<ThinBox<dyn Any + Send + Sync>> {
         &self.group2
+    }
+
+    /// Gets the third extension group.
+    pub fn group3(&self) -> &Once<ThinBox<dyn Any + Send + Sync>> {
+        &self.group3
     }
 }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -498,6 +498,19 @@ pub trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
+    /// Gets an xattr for kernel-internal consumers.
+    ///
+    /// User-facing xattr syscalls must call `get_xattr`. This helper is for
+    /// metadata that the kernel must inspect as part of another operation, such
+    /// as loading `security.capability` while executing an executable file.
+    fn get_xattr_without_permission_check(
+        &self,
+        name: XattrName,
+        value_writer: &mut VmWriter,
+    ) -> Result<usize> {
+        self.get_xattr(name, value_writer)
+    }
+
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize> {
         Err(Error::new(Errno::EOPNOTSUPP))
     }

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::CapabilityReason,
 };
 
 /// Represents a mount namespace, which encapsulates a mount tree and provides
@@ -116,7 +117,11 @@ impl MountNamespace {
         owner: Arc<UserNamespace>,
         posix_thread: &PosixThread,
     ) -> Result<Arc<MountNamespace>> {
-        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            posix_thread,
+            CapabilityReason::Namespace,
+        )?;
 
         let root_mount = self.root();
         Self::new_with_root(owner, |weak_ns| {

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -26,6 +26,7 @@ use crate::{
     process::{
         Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
     },
+    security::CapabilityReason,
 };
 
 /// The IPC namespace.
@@ -81,7 +82,11 @@ impl IpcNamespace {
         owner: Arc<UserNamespace>,
         posix_thread: &PosixThread,
     ) -> Result<Arc<Self>> {
-        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            posix_thread,
+            CapabilityReason::Namespace,
+        )?;
         Ok(Self::new(owner))
     }
 

--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -13,7 +13,8 @@ use crate::{
     },
     net::socket::util::{CControlHeader, ControlMessage},
     prelude::*,
-    process::{credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    security::{self, CapabilityReason},
     util::net::CSocketOptionLevel,
 };
 
@@ -205,7 +206,7 @@ enum CControlType {
 #[derive(Default)]
 pub(super) struct AuxiliaryData {
     files: Vec<Arc<dyn FileLike>>,
-    cred: Option<SocketCred>,
+    cred: Option<CUserCred>,
 }
 
 impl AuxiliaryData {
@@ -231,15 +232,24 @@ impl AuxiliaryData {
                     files.append(&mut msg_files);
                 }
                 Message::Cred(CredMessage { cred: msg_cred }) => {
-                    let cur_cred = SocketCred::<ReadOp>::new_current();
-                    if cur_cred.to_real_c_cred() != msg_cred {
-                        // FIXME: Allow this if we're root or have the CAP_SYS_ADMIN capability.
-                        return_errno_with_message!(
-                            Errno::EPERM,
-                            "setting others' credentials is not allowed"
-                        );
+                    let cur_cred = SocketCred::<ReadOp>::new_current().to_real_c_cred();
+                    if cur_cred != msg_cred {
+                        let current = current_thread!();
+                        let posix_thread = current.as_posix_thread().unwrap();
+                        security::capable(
+                            UserNamespace::get_init_singleton().as_ref(),
+                            CapSet::SYS_ADMIN,
+                            posix_thread,
+                            CapabilityReason::Socket,
+                        )
+                        .map_err(|_| {
+                            Error::with_message(
+                                Errno::EPERM,
+                                "setting others' credentials requires CAP_SYS_ADMIN",
+                            )
+                        })?;
                     }
-                    cred = Some(cur_cred);
+                    cred = Some(msg_cred);
                 }
             }
         }
@@ -253,13 +263,14 @@ impl AuxiliaryData {
         {
             warn!("UNIX sockets in SCM_RIGHTS messages can leak kernel resource");
 
-            let credentials = current_thread!().as_posix_thread().unwrap().credentials();
-            if !credentials.effective_capset().contains(CapSet::SYS_ADMIN) {
-                return_errno_with_message!(
-                    Errno::EPERM,
-                    "UNIX sockets in SCM_RIGHTS messages can leak kernel resource"
-                )
-            }
+            let current = current_thread!();
+            let posix_thread = current.as_posix_thread().unwrap();
+            security::capable(
+                UserNamespace::get_init_singleton().as_ref(),
+                CapSet::SYS_ADMIN,
+                posix_thread,
+                CapabilityReason::Socket,
+            )?;
         }
 
         Ok(Self { files, cred })
@@ -268,7 +279,7 @@ impl AuxiliaryData {
     /// Fills the current credentials if there are no credentials.
     pub(super) fn fill_cred(&mut self) {
         if self.cred.is_none() {
-            self.cred = Some(SocketCred::<ReadOp>::new_current());
+            self.cred = Some(SocketCred::<ReadOp>::new_current().to_real_c_cred());
         }
     }
 
@@ -280,10 +291,7 @@ impl AuxiliaryData {
 
         if is_pass_cred {
             let unix_ctrl_msg = UnixControlMessage(Message::Cred(CredMessage {
-                cred: cred
-                    .as_ref()
-                    .map(SocketCred::to_real_c_cred)
-                    .unwrap_or_else(CUserCred::new_overflow),
+                cred: (*cred).unwrap_or_else(CUserCred::new_overflow),
             }));
             ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
         }
@@ -312,10 +320,7 @@ impl AuxiliaryData {
             return false;
         }
 
-        if is_pass_cred
-            && self.cred.as_ref().map(SocketCred::to_real_c_cred)
-                != other.cred.as_ref().map(SocketCred::to_real_c_cred)
-        {
+        if is_pass_cred && self.cred != other.cred {
             return false;
         }
 

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -18,7 +18,8 @@ use crate::{
         unix::{CUserCred, UNIX_DATAGRAM_DEFAULT_BUF_SIZE, UNIX_STREAM_DEFAULT_BUF_SIZE},
     },
     prelude::*,
-    process::{credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    security::{self, CapabilityReason},
 };
 
 #[derive(Clone, CopyGetters, Debug, Setters)]
@@ -261,17 +262,14 @@ impl SocketOptionSet {
 }
 
 fn check_current_privileged() -> Result<()> {
-    let credentials = {
-        let current = current_thread!();
-        let posix_thread = current.as_posix_thread().unwrap();
-        posix_thread.credentials()
-    };
-
-    if credentials.effective_capset().contains(CapSet::NET_ADMIN) {
-        return Ok(());
-    }
-
-    return_errno_with_message!(Errno::EPERM, "the process does not have permissions")
+    let current = current_thread!();
+    let posix_thread = current.as_posix_thread().unwrap();
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::NET_ADMIN,
+        posix_thread,
+        CapabilityReason::Socket,
+    )
 }
 
 fn check_priority(priority: i32) -> Result<()> {

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -7,6 +7,7 @@ use crate::{
     fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::CapabilityReason,
     util::padded,
 };
 
@@ -54,7 +55,11 @@ impl UtsNamespace {
         owner: Arc<UserNamespace>,
         posix_thread: &PosixThread,
     ) -> Result<Arc<Self>> {
-        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            posix_thread,
+            CapabilityReason::Namespace,
+        )?;
         Ok(Self::new(*self.uts_name.read(), owner))
     }
 
@@ -68,7 +73,11 @@ impl UtsNamespace {
     /// This method will fail with `EPERM` if the caller does not have the SYS_ADMIN capability
     /// in the owner user namespace.
     pub fn set_hostname(&self, addr: Vaddr, len: usize, ctx: &Context) -> Result<()> {
-        self.owner.check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+        self.owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            ctx.posix_thread,
+            CapabilityReason::Namespace,
+        )?;
 
         let new_host_name = copy_uts_field_from_user(addr, len as _, ctx)?;
         debug!(
@@ -84,7 +93,11 @@ impl UtsNamespace {
     /// This method will fail with `EPERM` if the caller does not have the SYS_ADMIN capability
     /// in the owner user namespace.
     pub fn set_domainname(&self, addr: Vaddr, len: usize, ctx: &Context) -> Result<()> {
-        self.owner.check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+        self.owner.check_cap_with_reason(
+            CapSet::SYS_ADMIN,
+            ctx.posix_thread,
+            CapabilityReason::Namespace,
+        )?;
 
         let new_domain_name = copy_uts_field_from_user(addr, len as _, ctx)?;
         debug!(

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -5,7 +5,8 @@ use core::sync::atomic::Ordering;
 use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{
-    Gid, SecureBits, Uid, group::AtomicGid, secure_bits::AtomicSecureBits, user::AtomicUid,
+    FileCapabilities, Gid, SecureBits, Uid, group::AtomicGid, secure_bits::AtomicSecureBits,
+    user::AtomicUid,
 };
 use crate::{
     prelude::*,
@@ -190,34 +191,6 @@ impl Credentials_ {
 
     pub(super) fn set_suid(&self, suid: Uid) {
         self.set_resuid_unchecked(None, None, Some(suid));
-
-        // Begin to adjust capabilities.
-        // Reference: The "Transformation of capabilities during execve()" section and
-        // the "Capabilities and execution of programs by root" section in
-        // <https://man7.org/linux/man-pages/man7/capabilities.7.html>.
-
-        let (file_permitted, file_inheritable) =
-            if (self.euid().is_root() || self.ruid().is_root()) && !self.securebits().no_root() {
-                (CapSet::all(), CapSet::all())
-            } else {
-                // TODO: Get the file capabilities from the file system.
-                (CapSet::empty(), CapSet::empty())
-            };
-
-        let file_effective = if self.euid().is_root() && !self.securebits().no_root() {
-            CapSet::all()
-        } else {
-            // TODO: Get the file capabilities from the file system.
-            CapSet::empty()
-        };
-
-        let new_permitted = (self.inheritable_capset() & file_inheritable)
-            | (file_permitted & self.bounding_capset())
-            | AMBIENT_CAPSET;
-        let new_effective = (file_effective & new_permitted) | (!file_effective & AMBIENT_CAPSET);
-
-        self.set_permitted_capset(new_permitted);
-        self.set_effective_capset(new_effective);
     }
 
     // For `setreuid`, the real UID can *NOT* be set to the old saved-set user ID,
@@ -431,6 +404,64 @@ impl Credentials_ {
 
     pub(super) fn set_sgid(&self, sgid: Gid) {
         self.set_resgid_unchecked(None, None, Some(sgid));
+    }
+
+    /// Recomputes capability sets for `execve()` using the executable file's capabilities.
+    pub(super) fn update_capsets_for_exec(
+        &self,
+        file_capabilities: Option<FileCapabilities>,
+    ) -> Result<()> {
+        // Reference: The "Transformation of capabilities during execve()" section and
+        // the "Capabilities and execution of programs by root" section in
+        // <https://man7.org/linux/man-pages/man7/capabilities.7.html>.
+        let no_root = self.securebits().no_root();
+        let has_file_capabilities = file_capabilities.is_some();
+
+        // Linux treats root specially when the executable has no file capabilities, or when the
+        // real UID is root. The setuid-root + file-capability exception is handled by excluding
+        // the `euid == 0` fast path when a file capability xattr is present.
+        let grant_root_file_sets = !no_root
+            && (self.ruid().is_root() || (!has_file_capabilities && self.euid().is_root()));
+
+        let requested_file_permitted =
+            file_capabilities.map_or(CapSet::empty(), FileCapabilities::permitted);
+        let file_permitted = if grant_root_file_sets {
+            CapSet::all()
+        } else {
+            requested_file_permitted
+        };
+        let file_inheritable = if grant_root_file_sets {
+            CapSet::all()
+        } else {
+            file_capabilities.map_or(CapSet::empty(), FileCapabilities::inheritable)
+        };
+
+        let file_effective = if (!no_root && self.euid().is_root())
+            || file_capabilities.is_some_and(FileCapabilities::has_effective_flag)
+        {
+            CapSet::all()
+        } else {
+            CapSet::empty()
+        };
+
+        let new_permitted = (self.inheritable_capset() & file_inheritable)
+            | (file_permitted & self.bounding_capset())
+            | AMBIENT_CAPSET;
+
+        if file_capabilities.is_some_and(FileCapabilities::has_effective_flag)
+            && !new_permitted.contains(requested_file_permitted)
+        {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "the executable requests file capabilities outside the current bounding set"
+            );
+        }
+
+        let new_effective = (file_effective & new_permitted) | (!file_effective & AMBIENT_CAPSET);
+
+        self.set_permitted_capset(new_permitted);
+        self.set_effective_capset(new_effective);
+        Ok(())
     }
 
     // For `setregid`, the real GID can *NOT* be set to the old saved-set GID,

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -9,10 +9,15 @@ use super::{
 };
 use crate::{
     prelude::*,
-    process::credentials::{
-        AMBIENT_CAPSET,
-        capabilities::{AtomicCapSet, CapSet},
+    process::{
+        UserNamespace,
+        credentials::{
+            AMBIENT_CAPSET,
+            capabilities::{AtomicCapSet, CapSet},
+        },
+        posix_thread::AsPosixThread,
     },
+    security::{self, CapabilityReason},
 };
 
 #[derive(Debug)]
@@ -122,7 +127,7 @@ impl Credentials_ {
     }
 
     pub(super) fn set_uid(&self, uid: Uid) -> Result<()> {
-        if self.effective_capset().contains(CapSet::SETUID) {
+        if self.current_has_capability(CapSet::SETUID, CapabilityReason::CredentialsSetUid) {
             self.set_resuid_unchecked(Some(uid), Some(uid), Some(uid));
             Ok(())
         } else {
@@ -164,7 +169,7 @@ impl Credentials_ {
             return Ok(old_fsuid);
         };
 
-        if self.effective_capset().contains(CapSet::SETUID) {
+        if self.current_has_capability(CapSet::SETUID, CapabilityReason::CredentialsSetUid) {
             self.set_fsuid_unchecked(fsuid);
             return Ok(old_fsuid);
         }
@@ -224,7 +229,7 @@ impl Credentials_ {
         suid: Option<&Uid>,
         ruid_may_be_old_suid: bool,
     ) -> Result<()> {
-        if self.effective_capset().contains(CapSet::SETUID) {
+        if self.current_has_capability(CapSet::SETUID, CapabilityReason::CredentialsSetUid) {
             return Ok(());
         }
 
@@ -359,7 +364,7 @@ impl Credentials_ {
     }
 
     pub(super) fn set_gid(&self, gid: Gid) -> Result<()> {
-        if self.effective_capset().contains(CapSet::SETGID) {
+        if self.current_has_capability(CapSet::SETGID, CapabilityReason::CredentialsSetGid) {
             self.set_resgid_unchecked(Some(gid), Some(gid), Some(gid));
             Ok(())
         } else {
@@ -405,7 +410,7 @@ impl Credentials_ {
             return Ok(old_fsgid);
         }
 
-        if self.effective_capset().contains(CapSet::SETGID) {
+        if self.current_has_capability(CapSet::SETGID, CapabilityReason::CredentialsSetGid) {
             self.set_fsgid_unchecked(fsgid);
             return Ok(old_fsgid);
         }
@@ -437,7 +442,7 @@ impl Credentials_ {
         sgid: Option<&Gid>,
         rgid_may_be_old_sgid: bool,
     ) -> Result<()> {
-        if self.effective_capset().contains(CapSet::SETGID) {
+        if self.current_has_capability(CapSet::SETGID, CapabilityReason::CredentialsSetGid) {
             return Ok(());
         }
 
@@ -580,7 +585,7 @@ impl Credentials_ {
     }
 
     pub(super) fn set_securebits(&self, securebits: SecureBits) -> Result<()> {
-        if !self.effective_capset().contains(CapSet::SETPCAP) {
+        if !self.current_has_capability(CapSet::SETPCAP, CapabilityReason::CredentialsSetPcap) {
             return_errno_with_message!(
                 Errno::EPERM,
                 "only threads with CAP_SETPCAP can change secure bits"
@@ -588,6 +593,21 @@ impl Credentials_ {
         }
 
         self.securebits.try_store(securebits, Ordering::Relaxed)
+    }
+
+    fn current_has_capability(&self, capability: CapSet, reason: CapabilityReason) -> bool {
+        let current = current_thread!();
+        let Some(posix_thread) = current.as_posix_thread() else {
+            return false;
+        };
+
+        security::capable(
+            UserNamespace::get_init_singleton().as_ref(),
+            capability,
+            posix_thread,
+            reason,
+        )
+        .is_ok()
     }
 }
 

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -81,6 +81,9 @@ pub(super) struct Credentials_ {
 
     /// Secure bits.
     securebits: AtomicSecureBits,
+
+    /// The current `aster_mac` task label.
+    aster_mac_label: RwLock<String>,
 }
 
 impl Credentials_ {
@@ -106,6 +109,7 @@ impl Credentials_ {
             effective_capset: AtomicCapSet::new(capset),
             bounding_capset: AtomicCapSet::new(CapSet::all()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
+            aster_mac_label: RwLock::new("unconfined".to_string()),
         }
     }
 
@@ -626,6 +630,14 @@ impl Credentials_ {
         self.securebits.try_store(securebits, Ordering::Relaxed)
     }
 
+    pub(super) fn aster_mac_label(&self) -> String {
+        self.aster_mac_label.read().clone()
+    }
+
+    pub(super) fn set_aster_mac_label(&self, label: String) {
+        *self.aster_mac_label.write() = label;
+    }
+
     fn current_has_capability(&self, capability: CapSet, reason: CapabilityReason) -> bool {
         let current = current_thread!();
         let Some(posix_thread) = current.as_posix_thread() else {
@@ -659,6 +671,7 @@ impl Clone for Credentials_ {
             effective_capset: self.effective_capset.clone(),
             bounding_capset: self.bounding_capset.clone(),
             securebits: self.securebits.clone(),
+            aster_mac_label: RwLock::new(self.aster_mac_label.read().clone()),
         }
     }
 }

--- a/kernel/src/process/credentials/file_capabilities.rs
+++ b/kernel/src/process/credentials/file_capabilities.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{Uid, capabilities::CapSet};
+use crate::{
+    fs::vfs::{inode::Inode, xattr::XattrName},
+    prelude::*,
+};
+
+const SECURITY_CAPABILITY_XATTR: &str = "security.capability";
+
+const VFS_CAP_REVISION_MASK: u32 = 0xff00_0000;
+const VFS_CAP_FLAGS_MASK: u32 = 0x00ff_ffff;
+const VFS_CAP_FLAGS_EFFECTIVE: u32 = 0x0000_0001;
+
+const VFS_CAP_REVISION_1: u32 = 0x0100_0000;
+const VFS_CAP_REVISION_2: u32 = 0x0200_0000;
+const VFS_CAP_REVISION_3: u32 = 0x0300_0000;
+
+const XATTR_CAPS_SZ_1: usize = 3 * size_of::<u32>();
+const XATTR_CAPS_SZ_2: usize = 5 * size_of::<u32>();
+const XATTR_CAPS_SZ_3: usize = 6 * size_of::<u32>();
+
+/// File capabilities loaded from the `security.capability` xattr.
+#[derive(Clone, Copy, Debug)]
+pub(in crate::process) struct FileCapabilities {
+    permitted: CapSet,
+    inheritable: CapSet,
+    has_effective_flag: bool,
+    root_uid: Option<Uid>,
+}
+
+impl FileCapabilities {
+    /// Reads file capabilities from an inode's `security.capability` xattr.
+    pub(in crate::process) fn read_from_inode(inode: &Arc<dyn Inode>) -> Result<Option<Self>> {
+        let Some(xattr_name) = XattrName::try_from_full_name(SECURITY_CAPABILITY_XATTR) else {
+            unreachable!("`security.capability` should always parse as a valid xattr name");
+        };
+
+        let mut raw_value = [0u8; XATTR_CAPS_SZ_3];
+        let mut value_writer = VmWriter::from(raw_value.as_mut_slice()).to_fallible();
+        let value_len =
+            match inode.get_xattr_without_permission_check(xattr_name, &mut value_writer) {
+                Ok(value_len) => value_len,
+                Err(error) if matches!(error.error(), Errno::ENODATA | Errno::EOPNOTSUPP) => {
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
+
+        Self::parse(&raw_value[..value_len]).map(Some)
+    }
+
+    pub(in crate::process) const fn permitted(self) -> CapSet {
+        self.permitted
+    }
+
+    pub(in crate::process) const fn inheritable(self) -> CapSet {
+        self.inheritable
+    }
+
+    pub(in crate::process) const fn has_effective_flag(self) -> bool {
+        self.has_effective_flag
+    }
+
+    pub(in crate::process) fn applies_to_root_uid(self, root_uid: Uid) -> bool {
+        self.root_uid
+            .is_none_or(|stored_root_uid| stored_root_uid == root_uid)
+    }
+
+    fn parse(raw_value: &[u8]) -> Result<Self> {
+        let magic_etc = read_u32_le(raw_value, 0)?;
+        let revision = magic_etc & VFS_CAP_REVISION_MASK;
+        let flags = magic_etc & VFS_CAP_FLAGS_MASK;
+        if flags & !VFS_CAP_FLAGS_EFFECTIVE != 0 {
+            return Err(invalid_xattr_error(
+                "file capabilities contain unsupported flag bits",
+            ));
+        }
+
+        let (expected_len, permitted, inheritable, root_uid) = match revision {
+            VFS_CAP_REVISION_1 => (
+                XATTR_CAPS_SZ_1,
+                build_capset(read_u32_le(raw_value, 1)?, 0)?,
+                build_capset(read_u32_le(raw_value, 2)?, 0)?,
+                None,
+            ),
+            VFS_CAP_REVISION_2 => (
+                XATTR_CAPS_SZ_2,
+                build_capset(read_u32_le(raw_value, 1)?, read_u32_le(raw_value, 3)?)?,
+                build_capset(read_u32_le(raw_value, 2)?, read_u32_le(raw_value, 4)?)?,
+                None,
+            ),
+            VFS_CAP_REVISION_3 => (
+                XATTR_CAPS_SZ_3,
+                build_capset(read_u32_le(raw_value, 1)?, read_u32_le(raw_value, 3)?)?,
+                build_capset(read_u32_le(raw_value, 2)?, read_u32_le(raw_value, 4)?)?,
+                Some(Uid::new(read_u32_le(raw_value, 5)?)),
+            ),
+            _ => {
+                return Err(invalid_xattr_error(
+                    "file capabilities use an unsupported xattr revision",
+                ));
+            }
+        };
+
+        if raw_value.len() != expected_len {
+            return Err(invalid_xattr_error(
+                "file capability xattr length does not match its revision",
+            ));
+        }
+
+        Ok(Self {
+            permitted,
+            inheritable,
+            has_effective_flag: flags & VFS_CAP_FLAGS_EFFECTIVE != 0,
+            root_uid,
+        })
+    }
+}
+
+fn read_u32_le(bytes: &[u8], word_index: usize) -> Result<u32> {
+    let start = word_index
+        .checked_mul(size_of::<u32>())
+        .ok_or_else(|| invalid_xattr_error("file capability xattr index overflowed"))?;
+    let end = start + size_of::<u32>();
+    let Some(word_bytes) = bytes.get(start..end) else {
+        return Err(invalid_xattr_error("file capability xattr is truncated"));
+    };
+
+    let mut word = [0u8; size_of::<u32>()];
+    word.copy_from_slice(word_bytes);
+    Ok(u32::from_le_bytes(word))
+}
+
+fn build_capset(lo: u32, hi: u32) -> Result<CapSet> {
+    let bits = lo as u64 | ((hi as u64) << 32);
+    CapSet::try_from(bits)
+        .map_err(|_| invalid_xattr_error("file capabilities contain unsupported capability bits"))
+}
+
+fn invalid_xattr_error(message: &'static str) -> Error {
+    Error::with_message(Errno::EINVAL, message)
+}

--- a/kernel/src/process/credentials/mod.rs
+++ b/kernel/src/process/credentials/mod.rs
@@ -3,6 +3,7 @@
 pub mod c_types;
 pub mod capabilities;
 mod credentials_;
+mod file_capabilities;
 mod group;
 mod secure_bits;
 mod static_cap;
@@ -11,6 +12,7 @@ mod user;
 use aster_rights::FullOp;
 use capabilities::CapSet;
 use credentials_::Credentials_;
+pub(in crate::process) use file_capabilities::FileCapabilities;
 pub use group::Gid;
 pub use secure_bits::SecureBits;
 pub use user::Uid;
@@ -29,5 +31,5 @@ use crate::prelude::*;
 /// - secure bits.
 pub struct Credentials<R = FullOp>(Arc<Credentials_>, R);
 
-// TODO: Support the ambient capability set.
+// TODO: Support the bounding and ambient capability set.
 pub const AMBIENT_CAPSET: CapSet = CapSet::empty();

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -4,7 +4,10 @@ use aster_rights::{Dup, Read, TRights, Write};
 use aster_rights_proc::require;
 use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
-use super::{Credentials, Gid, SecureBits, Uid, capabilities::CapSet, credentials_::Credentials_};
+use super::{
+    Credentials, FileCapabilities, Gid, SecureBits, Uid, capabilities::CapSet,
+    credentials_::Credentials_,
+};
 use crate::prelude::*;
 
 impl<R: TRights> Credentials<R> {
@@ -247,6 +250,19 @@ impl<R: TRights> Credentials<R> {
         self.0.set_sgid(egid);
     }
 
+    /// Recomputes capability sets for `execve()` using the executable file's capabilities.
+    ///
+    /// This method should only be used when executing a new executable file.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub(in crate::process) fn update_capsets_for_exec(
+        &self,
+        file_capabilities: Option<FileCapabilities>,
+    ) -> Result<()> {
+        self.0.update_capsets_for_exec(file_capabilities)
+    }
+
     // *********** Supplementary Groups methods **********
 
     /// Acquires the read lock of supplementary group IDs.
@@ -275,7 +291,7 @@ impl<R: TRights> Credentials<R> {
         self.0.inheritable_capset()
     }
 
-    /// Gets the capabilities that a process can potentially be granted.
+    /// Gets the capabilities that are a process can potentially be granted.
     ///
     /// This method requires the `Read` right.
     #[require(R > Read)]
@@ -283,7 +299,7 @@ impl<R: TRights> Credentials<R> {
         self.0.permitted_capset()
     }
 
-    /// Gets the capabilities that a process can actually use.
+    /// Gets the capabilities that we can actually use.
     ///
     /// This method requires the `Read` right.
     #[require(R > Read)]
@@ -307,7 +323,7 @@ impl<R: TRights> Credentials<R> {
         self.0.set_inheritable_capset(inheritable_capset);
     }
 
-    /// Sets the capabilities that a process can potentially be granted.
+    /// Sets the capabilities that are a process can potentially be granted.
     ///
     /// This method requires the `Write` right.
     #[require(R > Write)]
@@ -315,7 +331,7 @@ impl<R: TRights> Credentials<R> {
         self.0.set_permitted_capset(permitted_capset);
     }
 
-    /// Sets the capabilities that a process can actually use.
+    /// Sets the capabilities that we can actually use.
     ///
     /// This method requires the `Write` right.
     #[require(R > Write)]
@@ -323,17 +339,7 @@ impl<R: TRights> Credentials<R> {
         self.0.set_effective_capset(effective_capset);
     }
 
-    /// Drops one capability from the capability bounding set.
-    ///
-    /// If the caller does not have the `CAP_SETPCAP` capability, this method returns an error.
-    ///
-    /// This method requires the `Write` right.
-    #[require(R > Write)]
-    pub fn drop_bounding_capability(&self, capability: CapSet) -> Result<()> {
-        self.0.drop_bounding_capability(capability)
-    }
-
-    /// Gets the keep-capabilities flag.
+    /// Gets keep capabilities flag.
     ///
     /// This method requires the `Read` right.
     #[require(R > Read)]
@@ -341,7 +347,7 @@ impl<R: TRights> Credentials<R> {
         self.0.keep_capabilities()
     }
 
-    /// Sets the keep-capabilities flag.
+    /// Sets keep capabilities flag.
     ///
     /// If the [`SecureBits::KEEP_CAPS_LOCKED`] is set, this method will return an error.
     ///
@@ -349,6 +355,14 @@ impl<R: TRights> Credentials<R> {
     #[require(R > Write)]
     pub fn set_keep_capabilities(&self, keep_capabilities: bool) -> Result<()> {
         self.0.set_keep_capabilities(keep_capabilities)
+    }
+
+    /// Drops a capability from the bounding set.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn drop_bounding_capability(&self, capability: CapSet) -> Result<()> {
+        self.0.drop_bounding_capability(capability)
     }
 
     // *********** Secure Bits methods **********

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -375,6 +375,14 @@ impl<R: TRights> Credentials<R> {
         self.0.securebits()
     }
 
+    /// Gets the current `aster_mac` security label.
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn aster_mac_label(&self) -> String {
+        self.0.aster_mac_label()
+    }
+
     /// Sets the secure bits.
     ///
     /// If the caller does not have the `CAP_SETPCAP` capability, or if it tries to set locked
@@ -384,5 +392,13 @@ impl<R: TRights> Credentials<R> {
     #[require(R > Write)]
     pub fn set_securebits(&self, securebits: SecureBits) -> Result<()> {
         self.0.set_securebits(securebits)
+    }
+
+    /// Sets the current `aster_mac` security label.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn set_aster_mac_label(&self, label: String) {
+        self.0.set_aster_mac_label(label);
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -16,7 +16,9 @@ use crate::{
     },
     prelude::*,
     process::{
-        ContextUnshareAdminApi, Credentials, Process, pid_table,
+        ContextUnshareAdminApi, Credentials, Process,
+        credentials::FileCapabilities,
+        pid_table,
         posix_thread::{
             AsPosixThread, ContextPthreadAdminApi, ThreadLocal, ThreadName, ptrace::PtraceEvent,
             sigkill_other_threads,
@@ -29,6 +31,7 @@ use crate::{
             signals::kernel::KernelSignal,
         },
     },
+    security,
     vm::vmar::VmarHandle,
 };
 
@@ -168,7 +171,9 @@ fn do_execve_no_return(
     // This prevents race conditions when checking access permissions while opening
     // `/proc/[pid]/mem` or `/proc/[pid]/maps`.
     let (vmar_guard, old_vmar) = activate_vmar(ctx, new_vmar);
-    apply_caps_from_exec(process, ctx.credentials_mut(), elf_file.inode())?;
+    let credentials = ctx.credentials_mut();
+    apply_caps_from_exec(process, &credentials, elf_file.inode())?;
+    security::bprm_committed_creds(&elf_file, &credentials)?;
     drop(vmar_guard);
     drop(old_vmar);
 
@@ -300,11 +305,16 @@ fn set_cpu_context(
 /// The capabilities will be updated accordingly.
 fn apply_caps_from_exec(
     process: &Process,
-    credentials: Credentials<ReadWriteOp>,
+    credentials: &Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
-    set_uid_from_elf(process, &credentials, elf_inode)?;
-    set_gid_from_elf(process, &credentials, elf_inode)?;
+    let current_root_uid = process.user_ns().lock().owner_uid()?;
+    let file_capabilities = FileCapabilities::read_from_inode(elf_inode)?
+        .filter(|file_capabilities| file_capabilities.applies_to_root_uid(current_root_uid));
+
+    set_uid_from_elf(process, credentials, elf_inode)?;
+    set_gid_from_elf(process, credentials, elf_inode)?;
+    credentials.update_capsets_for_exec(file_capabilities)?;
     credentials.set_keep_capabilities(false)?;
 
     Ok(())

--- a/kernel/src/process/kill.rs
+++ b/kernel/src/process/kill.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::{
     prelude::*,
     process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::CapabilityReason,
     thread::Tid,
 };
 
@@ -177,7 +178,7 @@ fn check_signal_perm(target: &PosixThread, ctx: &Context, signum: Option<SigNum>
     if target_process
         .user_ns()
         .lock()
-        .check_cap(CapSet::KILL, ctx.posix_thread)
+        .check_cap_with_reason(CapSet::KILL, ctx.posix_thread, CapabilityReason::Signal)
         .is_ok()
     {
         return Ok(());

--- a/kernel/src/process/namespace/user_ns.rs
+++ b/kernel/src/process/namespace/user_ns.rs
@@ -6,6 +6,7 @@ use crate::{
     fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
     prelude::*,
     process::{Uid, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::{self, CapabilityReason},
 };
 
 /// The user namespace.
@@ -27,20 +28,18 @@ impl UserNamespace {
 
     /// Checks whether the thread has the required capability in this user namespace.
     pub fn check_cap(&self, required: CapSet, posix_thread: &PosixThread) -> Result<()> {
-        // Since creating new user namespaces is not supported at the moment,
-        // there is effectively only one user namespace in the entire system.
-        // Therefore, the thread has a single set of capabilities used for permission checks.
-        // FIXME: Once support for creating new user namespaces is added,
-        // we should verify the thread's capabilities within the relevant user namespace.
-        let cap_set = posix_thread.credentials().effective_capset();
-        if cap_set.contains(required) {
-            return Ok(());
-        }
+        self.check_cap_with_reason(required, posix_thread, CapabilityReason::General)
+    }
 
-        return_errno_with_message!(
-            Errno::EPERM,
-            "the thread does not have the required capability"
-        )
+    /// Checks whether the thread has the required capability in this user namespace
+    /// for a specific kernel operation.
+    pub fn check_cap_with_reason(
+        &self,
+        required: CapSet,
+        posix_thread: &PosixThread,
+        reason: CapabilityReason,
+    ) -> Result<()> {
+        security::capable(self, required, posix_thread, reason)
     }
 
     /// Returns the owner UID of the user namespace.

--- a/kernel/src/process/namespace/user_ns.rs
+++ b/kernel/src/process/namespace/user_ns.rs
@@ -26,11 +26,6 @@ impl UserNamespace {
         })
     }
 
-    /// Checks whether the thread has the required capability in this user namespace.
-    pub fn check_cap(&self, required: CapSet, posix_thread: &PosixThread) -> Result<()> {
-        self.check_cap_with_reason(required, posix_thread, CapabilityReason::General)
-    }
-
     /// Checks whether the thread has the required capability in this user namespace
     /// for a specific kernel operation.
     pub fn check_cap_with_reason(

--- a/kernel/src/process/posix_thread/alien_access.rs
+++ b/kernel/src/process/posix_thread/alien_access.rs
@@ -7,7 +7,10 @@
 use crate::{
     prelude::*,
     process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
-    security::lsm::hooks as lsm_hooks,
+    security::{
+        CapabilityReason,
+        lsm::{AlienAccessContext, hooks as lsm_hooks},
+    },
 };
 
 impl PosixThread {
@@ -25,42 +28,19 @@ impl PosixThread {
             return Ok(());
         }
 
-        let cred = accessor.credentials();
-        let (caller_uid, caller_gid) = if mode.creds() == CredsSource::FsCreds {
-            (cred.fsuid(), cred.fsgid())
-        } else {
-            (cred.ruid(), cred.rgid())
-        };
-
-        let self_cred = self.credentials();
-        let caller_is_same = caller_uid == self_cred.euid()
-            && caller_uid == self_cred.suid()
-            && caller_uid == self_cred.ruid()
-            && caller_gid == self_cred.egid()
-            && caller_gid == self_cred.sgid()
-            && caller_gid == self_cred.rgid();
         let caller_has_cap = self
             .process()
             .user_ns()
             .lock()
-            .check_cap(CapSet::SYS_PTRACE, accessor)
+            .check_cap_with_reason(CapSet::SYS_PTRACE, accessor, CapabilityReason::Ptrace)
             .is_ok();
 
-        if !caller_is_same && !caller_has_cap {
-            return_errno_with_message!(
-                Errno::EPERM,
-                "the calling process does not have the required permissions"
-            );
-        }
-
-        lsm_hooks::on_alien_access(&lsm_hooks::AlienAccessContext::new(
+        lsm_hooks::on_alien_access(&AlienAccessContext::new(
             accessor,
             self,
             mode,
             caller_has_cap,
-        ))?;
-
-        Ok(())
+        ))
     }
 }
 

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     vm::vmar::Vmar,
 };
 
@@ -40,6 +41,7 @@ impl ProgramToLoad {
         envp: Vec<CString>,
     ) -> Result<Self> {
         check_executable_inode(elf_file.inode().as_ref())?;
+        security::bprm_check_security(&elf_file)?;
 
         // A limit to the recursion depth of shebang executables.
         //
@@ -70,6 +72,7 @@ impl ProgramToLoad {
                 path_resolver.lookup(&fs_path)?
             };
             check_executable_inode(interpreter.inode().as_ref())?;
+            security::bprm_check_security(&interpreter)?;
 
             // Update the argument list and the executable inode. Then, try again.
             new_argv.extend(argv);

--- a/kernel/src/process/rlimit.rs
+++ b/kernel/src/process/rlimit.rs
@@ -10,6 +10,7 @@ use super::process_vm::INIT_STACK_SIZE;
 use crate::{
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet},
+    security::CapabilityReason,
 };
 
 // Constants for the boot-time rlimit defaults
@@ -155,7 +156,11 @@ impl RLimit64 {
         let _guard = self.lock.lock();
         if new.max > self.get_max() {
             let init_user_ns = UserNamespace::get_init_singleton();
-            init_user_ns.check_cap(CapSet::SYS_RESOURCE, ctx.posix_thread)?;
+            init_user_ns.check_cap_with_reason(
+                CapSet::SYS_RESOURCE,
+                ctx.posix_thread,
+                CapabilityReason::ResourceLimit,
+            )?;
         }
         let old = RawRLimit64 {
             cur: self.cur.load(Ordering::Relaxed),

--- a/kernel/src/security/lsm/hooks/bprm.rs
+++ b/kernel/src/security/lsm/hooks/bprm.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_rights::ReadWriteOp;
+
+use super::super::modules;
+use crate::{fs::vfs::path::Path, prelude::*, process::Credentials};
+
+/// Runs executable image check hooks in module order.
+pub fn on_bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_check_security(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs post-exec credential hooks in module order.
+pub fn on_bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_committed_creds(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for an executable image security check.
+pub struct BprmCheckContext<'a> {
+    executable: &'a Path,
+}
+
+impl<'a> BprmCheckContext<'a> {
+    /// Creates an executable image check context.
+    pub const fn new(executable: &'a Path) -> Self {
+        Self { executable }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+}
+
+/// The inputs for an executable-label transition after credentials are committed.
+pub struct BprmCommittedCredsContext<'a> {
+    executable: &'a Path,
+    credentials: &'a Credentials<ReadWriteOp>,
+}
+
+impl<'a> BprmCommittedCredsContext<'a> {
+    /// Creates a post-exec credential context.
+    pub const fn new(executable: &'a Path, credentials: &'a Credentials<ReadWriteOp>) -> Self {
+        Self {
+            executable,
+            credentials,
+        }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+
+    /// Returns the committed credentials.
+    pub const fn credentials(&self) -> &'a Credentials<ReadWriteOp> {
+        self.credentials
+    }
+}

--- a/kernel/src/security/lsm/hooks/capability.rs
+++ b/kernel/src/security/lsm/hooks/capability.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// Runs capability hooks in module order.
+pub fn on_capable(context: &CapableContext) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_capable(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking whether a thread has a capability.
+pub struct CapableContext<'a> {
+    user_namespace: &'a UserNamespace,
+    posix_thread: &'a PosixThread,
+    capability: CapSet,
+    reason: CapabilityReason,
+}
+
+impl<'a> CapableContext<'a> {
+    /// Creates a capability check context.
+    pub const fn new(
+        user_namespace: &'a UserNamespace,
+        posix_thread: &'a PosixThread,
+        capability: CapSet,
+        reason: CapabilityReason,
+    ) -> Self {
+        Self {
+            user_namespace,
+            posix_thread,
+            capability,
+            reason,
+        }
+    }
+
+    /// Returns the user namespace where the capability is checked.
+    pub const fn user_namespace(&self) -> &UserNamespace {
+        self.user_namespace
+    }
+
+    /// Returns the thread whose credentials are checked.
+    pub const fn posix_thread(&self) -> &PosixThread {
+        self.posix_thread
+    }
+
+    /// Returns the required capability.
+    pub const fn capability(&self) -> CapSet {
+        self.capability
+    }
+
+    /// Returns the kernel operation that requires the capability.
+    pub const fn reason(&self) -> CapabilityReason {
+        self.reason
+    }
+}
+
+/// The kernel operation that requires a capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityReason {
+    CredentialsSetUid,
+    CredentialsSetGid,
+    CredentialsSetPcap,
+    General,
+    Namespace,
+    Ptrace,
+    ResourceLimit,
+    Reboot,
+    Signal,
+    Socket,
+    Xattr,
+}

--- a/kernel/src/security/lsm/hooks/capability.rs
+++ b/kernel/src/security/lsm/hooks/capability.rs
@@ -66,7 +66,6 @@ pub enum CapabilityReason {
     CredentialsSetUid,
     CredentialsSetGid,
     CredentialsSetPcap,
-    General,
     Namespace,
     Ptrace,
     ResourceLimit,

--- a/kernel/src/security/lsm/hooks/file.rs
+++ b/kernel/src/security/lsm/hooks/file.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::{
+        file::{AccessMode, StatusFlags},
+        vfs::path::Path,
+    },
+    prelude::*,
+};
+
+/// Runs file open hooks in module order.
+pub fn on_file_open(context: &FileOpenContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_open(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking a newly opened file.
+pub struct FileOpenContext<'a> {
+    path: &'a Path,
+    access_mode: AccessMode,
+    status_flags: StatusFlags,
+}
+
+impl<'a> FileOpenContext<'a> {
+    /// Creates a file open context.
+    pub const fn new(path: &'a Path, access_mode: AccessMode, status_flags: StatusFlags) -> Self {
+        Self {
+            path,
+            access_mode,
+            status_flags,
+        }
+    }
+
+    /// Returns the path being opened.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the requested access mode.
+    pub const fn access_mode(&self) -> AccessMode {
+        self.access_mode
+    }
+
+    /// Returns the open status flags.
+    pub const fn status_flags(&self) -> StatusFlags {
+        self.status_flags
+    }
+}

--- a/kernel/src/security/lsm/hooks/inode.rs
+++ b/kernel/src/security/lsm/hooks/inode.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::file::{InodeMode, Permission},
+    prelude::*,
+    process::posix_thread::PosixThread,
+};
+
+/// Runs inode DAC override hooks in module order.
+pub fn on_inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permission> {
+    let mut overridden = Permission::empty();
+
+    for module in modules::active_modules() {
+        overridden |= module.on_inode_dac_override(context)?;
+    }
+
+    Ok(overridden)
+}
+
+/// The inputs for a DAC override decision on an inode.
+pub struct InodeDacOverrideContext<'a> {
+    mode: InodeMode,
+    permission: Permission,
+    posix_thread: &'a PosixThread,
+}
+
+impl<'a> InodeDacOverrideContext<'a> {
+    /// Creates an inode DAC override context.
+    pub const fn new(
+        mode: InodeMode,
+        permission: Permission,
+        posix_thread: &'a PosixThread,
+    ) -> Self {
+        Self {
+            mode,
+            permission,
+            posix_thread,
+        }
+    }
+
+    /// Returns the inode mode.
+    pub const fn mode(&self) -> InodeMode {
+        self.mode
+    }
+
+    /// Returns the requested permission.
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
+
+    /// Returns the thread requesting access.
+    pub const fn posix_thread(&self) -> &PosixThread {
+        self.posix_thread
+    }
+}

--- a/kernel/src/security/lsm/hooks/inode.rs
+++ b/kernel/src/security/lsm/hooks/inode.rs
@@ -2,7 +2,10 @@
 
 use super::super::modules;
 use crate::{
-    fs::file::{InodeMode, Permission},
+    fs::{
+        file::{InodeMode, Permission},
+        vfs::path::Path,
+    },
     prelude::*,
     process::posix_thread::PosixThread,
 };
@@ -18,11 +21,43 @@ pub fn on_inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permis
     Ok(overridden)
 }
 
+/// Runs inode permission hooks in module order.
+pub fn on_inode_permission(context: &InodePermissionContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_inode_permission(context)?;
+    }
+
+    Ok(())
+}
+
 /// The inputs for a DAC override decision on an inode.
 pub struct InodeDacOverrideContext<'a> {
     mode: InodeMode,
     permission: Permission,
     posix_thread: &'a PosixThread,
+}
+
+/// The inputs for a permission check on an inode.
+pub struct InodePermissionContext<'a> {
+    path: &'a Path,
+    permission: Permission,
+}
+
+impl<'a> InodePermissionContext<'a> {
+    /// Creates an inode permission context.
+    pub const fn new(path: &'a Path, permission: Permission) -> Self {
+        Self { path, permission }
+    }
+
+    /// Returns the path being checked.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the requested permission.
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
 }
 
 impl<'a> InodeDacOverrideContext<'a> {

--- a/kernel/src/security/lsm/hooks/inode.rs
+++ b/kernel/src/security/lsm/hooks/inode.rs
@@ -2,10 +2,7 @@
 
 use super::super::modules;
 use crate::{
-    fs::{
-        file::{InodeMode, Permission},
-        vfs::path::Path,
-    },
+    fs::file::{InodeMode, Permission},
     prelude::*,
     process::posix_thread::PosixThread,
 };
@@ -21,43 +18,11 @@ pub fn on_inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permis
     Ok(overridden)
 }
 
-/// Runs inode permission hooks in module order.
-pub fn on_inode_permission(context: &InodePermissionContext<'_>) -> Result<()> {
-    for module in modules::active_modules() {
-        module.on_inode_permission(context)?;
-    }
-
-    Ok(())
-}
-
 /// The inputs for a DAC override decision on an inode.
 pub struct InodeDacOverrideContext<'a> {
     mode: InodeMode,
     permission: Permission,
     posix_thread: &'a PosixThread,
-}
-
-/// The inputs for a permission check on an inode.
-pub struct InodePermissionContext<'a> {
-    path: &'a Path,
-    permission: Permission,
-}
-
-impl<'a> InodePermissionContext<'a> {
-    /// Creates an inode permission context.
-    pub const fn new(path: &'a Path, permission: Permission) -> Self {
-        Self { path, permission }
-    }
-
-    /// Returns the path being checked.
-    pub const fn path(&self) -> &'a Path {
-        self.path
-    }
-
-    /// Returns the requested permission.
-    pub const fn permission(&self) -> Permission {
-        self.permission
-    }
 }
 
 impl<'a> InodeDacOverrideContext<'a> {

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -3,13 +3,33 @@
 //! LSM hook points.
 
 mod alien_access;
+mod capability;
+mod inode;
 
-pub use self::alien_access::{AlienAccessContext, on_alien_access};
-use crate::prelude::*;
+pub use self::{
+    alien_access::{AlienAccessContext, on_alien_access},
+    capability::{CapabilityReason, CapableContext, on_capable},
+    inode::{InodeDacOverrideContext, on_inode_dac_override},
+};
+use crate::{fs::file::Permission, prelude::*};
 
 pub(super) trait LsmAlienAccessHook: Sync {
     /// Handles an alien access attempt.
     fn on_alien_access(&self, _context: &AlienAccessContext) -> Result<()> {
         Ok(())
+    }
+}
+
+pub(super) trait LsmCapabilityHook: Sync {
+    /// Checks whether a thread holds a capability in a user namespace.
+    fn on_capable(&self, _context: &CapableContext) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmInodeHook: Sync {
+    /// Returns which requested DAC permissions may be bypassed on an inode.
+    fn on_inode_dac_override(&self, _context: &InodeDacOverrideContext) -> Result<Permission> {
+        Ok(Permission::empty())
     }
 }

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -16,9 +16,7 @@ pub use self::{
     },
     capability::{CapabilityReason, CapableContext, on_capable},
     file::{FileOpenContext, on_file_open},
-    inode::{
-        InodeDacOverrideContext, InodePermissionContext, on_inode_dac_override, on_inode_permission,
-    },
+    inode::{InodeDacOverrideContext, on_inode_dac_override},
 };
 use crate::{fs::file::Permission, prelude::*};
 
@@ -52,11 +50,6 @@ pub(super) trait LsmInodeHook: Sync {
     /// Returns which requested DAC permissions may be bypassed on an inode.
     fn on_inode_dac_override(&self, _context: &InodeDacOverrideContext) -> Result<Permission> {
         Ok(Permission::empty())
-    }
-
-    /// Checks whether an inode operation may use the requested permission.
-    fn on_inode_permission(&self, _context: &InodePermissionContext<'_>) -> Result<()> {
-        Ok(())
     }
 }
 

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -3,13 +3,22 @@
 //! LSM hook points.
 
 mod alien_access;
+mod bprm;
 mod capability;
+mod file;
 mod inode;
 
 pub use self::{
     alien_access::{AlienAccessContext, on_alien_access},
+    bprm::{
+        BprmCheckContext, BprmCommittedCredsContext, on_bprm_check_security,
+        on_bprm_committed_creds,
+    },
     capability::{CapabilityReason, CapableContext, on_capable},
-    inode::{InodeDacOverrideContext, on_inode_dac_override},
+    file::{FileOpenContext, on_file_open},
+    inode::{
+        InodeDacOverrideContext, InodePermissionContext, on_inode_dac_override, on_inode_permission,
+    },
 };
 use crate::{fs::file::Permission, prelude::*};
 
@@ -27,9 +36,33 @@ pub(super) trait LsmCapabilityHook: Sync {
     }
 }
 
+pub(super) trait LsmBprmHook: Sync {
+    /// Checks whether an executable image may be loaded.
+    fn on_bprm_check_security(&self, _context: &BprmCheckContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Updates security state after executable credentials are committed.
+    fn on_bprm_committed_creds(&self, _context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
 pub(super) trait LsmInodeHook: Sync {
     /// Returns which requested DAC permissions may be bypassed on an inode.
     fn on_inode_dac_override(&self, _context: &InodeDacOverrideContext) -> Result<Permission> {
         Ok(Permission::empty())
+    }
+
+    /// Checks whether an inode operation may use the requested permission.
+    fn on_inode_permission(&self, _context: &InodePermissionContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmFileHook: Sync {
+    /// Checks whether a new file handle may be opened.
+    fn on_file_open(&self, _context: &FileOpenContext<'_>) -> Result<()> {
+        Ok(())
     }
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -7,8 +7,8 @@
 //! inspect common hook contexts before allowing or rejecting an operation.
 //!
 //! This module defines the common LSM traits and hook contexts shared by
-//! built-in modules such as `yama`. Module selection follows the `lsm=` and
-//! legacy `security=` kernel command-line parameters.
+//! built-in modules such as `capability` and `yama`. Module selection follows
+//! the `lsm=` and legacy `security=` kernel command-line parameters.
 
 pub mod hooks;
 mod modules;
@@ -17,8 +17,11 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
-use self::hooks::LsmAlienAccessHook;
-use crate::prelude::*;
+pub use self::hooks::{
+    AlienAccessContext, CapabilityReason, CapableContext, InodeDacOverrideContext,
+};
+use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook};
+use crate::{fs::file::Permission, prelude::*};
 
 bitflags! {
     /// LSM module flags.
@@ -31,7 +34,7 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + Sync {
+trait LsmModule: LsmAlienAccessHook + LsmCapabilityHook + LsmInodeHook + Sync {
     /// Returns the module name.
     fn name(&self) -> &'static str;
 
@@ -50,4 +53,14 @@ pub(super) fn init() {
     for module in modules::active_modules() {
         info!("[kernel] LSM module enabled: {}", module.name());
     }
+}
+
+/// Runs the LSM stack for a capability check.
+pub fn capable(context: &CapableContext) -> Result<()> {
+    hooks::on_capable(context)
+}
+
+/// Runs the LSM stack for a DAC override decision on an inode.
+pub fn inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permission> {
+    hooks::on_inode_dac_override(context)
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -19,7 +19,7 @@ pub mod yama {
 
 pub use self::hooks::{
     AlienAccessContext, BprmCheckContext, BprmCommittedCredsContext, CapabilityReason,
-    CapableContext, FileOpenContext, InodeDacOverrideContext, InodePermissionContext,
+    CapableContext, FileOpenContext, InodeDacOverrideContext,
 };
 use self::hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook};
 pub(super) use self::modules::aster_mac::{
@@ -86,11 +86,6 @@ pub fn bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<(
 /// Runs the LSM stack for a DAC override decision on an inode.
 pub fn inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permission> {
     hooks::on_inode_dac_override(context)
-}
-
-/// Runs the LSM stack for an inode permission check.
-pub fn inode_permission(context: &InodePermissionContext<'_>) -> Result<()> {
-    hooks::on_inode_permission(context)
 }
 
 /// Runs the LSM stack for a file open check.

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -18,9 +18,13 @@ pub mod yama {
 }
 
 pub use self::hooks::{
-    AlienAccessContext, CapabilityReason, CapableContext, InodeDacOverrideContext,
+    AlienAccessContext, BprmCheckContext, BprmCommittedCredsContext, CapabilityReason,
+    CapableContext, FileOpenContext, InodeDacOverrideContext, InodePermissionContext,
 };
-use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook};
+use self::hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook};
+pub(super) use self::modules::aster_mac::{
+    is_aster_mac_inode_xattr, sync_aster_mac_inode_xattr, validate_aster_mac_inode_xattr,
+};
 use crate::{fs::file::Permission, prelude::*};
 
 bitflags! {
@@ -34,7 +38,9 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + LsmCapabilityHook + LsmInodeHook + Sync {
+trait LsmModule:
+    LsmAlienAccessHook + LsmBprmHook + LsmCapabilityHook + LsmFileHook + LsmInodeHook + Sync
+{
     /// Returns the module name.
     fn name(&self) -> &'static str;
 
@@ -49,6 +55,13 @@ pub fn is_yama_enabled() -> bool {
         .any(|module| module.name() == "yama")
 }
 
+/// Returns whether the `aster_mac` LSM is enabled.
+pub fn is_aster_mac_enabled() -> bool {
+    modules::active_modules()
+        .iter()
+        .any(|module| module.name() == "aster_mac")
+}
+
 pub(super) fn init() {
     for module in modules::active_modules() {
         info!("[kernel] LSM module enabled: {}", module.name());
@@ -60,7 +73,27 @@ pub fn capable(context: &CapableContext) -> Result<()> {
     hooks::on_capable(context)
 }
 
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    hooks::on_bprm_check_security(context)
+}
+
+/// Runs the LSM stack after executable credentials are committed.
+pub fn bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    hooks::on_bprm_committed_creds(context)
+}
+
 /// Runs the LSM stack for a DAC override decision on an inode.
 pub fn inode_dac_override(context: &InodeDacOverrideContext) -> Result<Permission> {
     hooks::on_inode_dac_override(context)
+}
+
+/// Runs the LSM stack for an inode permission check.
+pub fn inode_permission(context: &InodePermissionContext<'_>) -> Result<()> {
+    hooks::on_inode_permission(context)
+}
+
+/// Runs the LSM stack for a file open check.
+pub fn file_open(context: &FileOpenContext<'_>) -> Result<()> {
+    hooks::on_file_open(context)
 }

--- a/kernel/src/security/lsm/modules/aster_mac.rs
+++ b/kernel/src/security/lsm/modules/aster_mac.rs
@@ -4,8 +4,7 @@ use alloc::boxed::ThinBox;
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use super::super::{
-    BprmCheckContext, BprmCommittedCredsContext, FileOpenContext, InodePermissionContext, LsmFlags,
-    LsmModule,
+    BprmCheckContext, BprmCommittedCredsContext, FileOpenContext, LsmFlags, LsmModule,
     hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook},
 };
 use crate::{
@@ -69,34 +68,7 @@ impl LsmBprmHook for AsterMacLsm {
     }
 }
 
-impl LsmInodeHook for AsterMacLsm {
-    fn on_inode_permission(&self, context: &InodePermissionContext<'_>) -> Result<()> {
-        let inode = context.path().inode();
-        let rules = inode_security_state(inode.as_ref()).rules(inode.as_ref());
-        let permission = context.permission();
-
-        if permission.may_read() && rules.contains(AsterMacPolicyRules::READ_DENY) {
-            return_errno_with_message!(
-                Errno::EACCES,
-                "read access is denied by the Aster MAC LSM xattr policy"
-            );
-        }
-        if permission.may_write() && rules.contains(AsterMacPolicyRules::WRITE_DENY) {
-            return_errno_with_message!(
-                Errno::EACCES,
-                "write access is denied by the Aster MAC LSM xattr policy"
-            );
-        }
-        if permission.may_exec() && rules.contains(AsterMacPolicyRules::EXEC_DENY) {
-            return_errno_with_message!(
-                Errno::EACCES,
-                "exec access is denied by the Aster MAC LSM xattr policy"
-            );
-        }
-
-        Ok(())
-    }
-}
+impl LsmInodeHook for AsterMacLsm {}
 
 impl LsmFileHook for AsterMacLsm {
     fn on_file_open(&self, context: &FileOpenContext<'_>) -> Result<()> {

--- a/kernel/src/security/lsm/modules/aster_mac.rs
+++ b/kernel/src/security/lsm/modules/aster_mac.rs
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::boxed::ThinBox;
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+use super::super::{
+    BprmCheckContext, BprmCommittedCredsContext, FileOpenContext, InodePermissionContext, LsmFlags,
+    LsmModule,
+    hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook},
+};
+use crate::{
+    fs::{
+        file::StatusFlags,
+        vfs::{
+            inode::Inode,
+            xattr::{XATTR_VALUE_MAX_LEN, XattrName},
+        },
+    },
+    prelude::*,
+};
+
+pub(super) static ASTER_MAC_LSM: AsterMacLsm = AsterMacLsm;
+
+const DEFAULT_TASK_LABEL: &str = "unconfined";
+const DEFAULT_INODE_LABEL: &str = "unlabeled";
+const MANAGED_LABEL_XATTR: &str = "security.aster_mac.label";
+const MAX_LABEL_LEN: usize = 64;
+
+/// Implements a small xattr-driven major MAC module.
+pub(super) struct AsterMacLsm;
+
+impl LsmModule for AsterMacLsm {
+    fn name(&self) -> &'static str {
+        "aster_mac"
+    }
+
+    fn flags(&self) -> LsmFlags {
+        LsmFlags::LEGACY_MAJOR | LsmFlags::EXCLUSIVE
+    }
+}
+
+impl LsmAlienAccessHook for AsterMacLsm {}
+
+impl LsmCapabilityHook for AsterMacLsm {}
+
+impl LsmBprmHook for AsterMacLsm {
+    fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
+        let executable_inode = context.executable().inode();
+        let rules =
+            inode_security_state(executable_inode.as_ref()).rules(executable_inode.as_ref());
+        if rules.contains(AsterMacPolicyRules::EXEC_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "exec is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn on_bprm_committed_creds(&self, context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        let executable_inode = context.executable().inode();
+        let label = inode_security_state(executable_inode.as_ref())
+            .exec_label(executable_inode.as_ref())
+            .unwrap_or_else(|| DEFAULT_TASK_LABEL.to_string());
+        context.credentials().set_aster_mac_label(label);
+
+        Ok(())
+    }
+}
+
+impl LsmInodeHook for AsterMacLsm {
+    fn on_inode_permission(&self, context: &InodePermissionContext<'_>) -> Result<()> {
+        let inode = context.path().inode();
+        let rules = inode_security_state(inode.as_ref()).rules(inode.as_ref());
+        let permission = context.permission();
+
+        if permission.may_read() && rules.contains(AsterMacPolicyRules::READ_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "read access is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+        if permission.may_write() && rules.contains(AsterMacPolicyRules::WRITE_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "write access is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+        if permission.may_exec() && rules.contains(AsterMacPolicyRules::EXEC_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "exec access is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl LsmFileHook for AsterMacLsm {
+    fn on_file_open(&self, context: &FileOpenContext<'_>) -> Result<()> {
+        let inode = context.path().inode();
+        let rules = inode_security_state(inode.as_ref()).rules(inode.as_ref());
+        let status_flags = context.status_flags();
+
+        if rules.contains(AsterMacPolicyRules::OPEN_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "open is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+        if status_flags.contains(StatusFlags::O_PATH) {
+            return Ok(());
+        }
+        if context.access_mode().is_readable() && rules.contains(AsterMacPolicyRules::READ_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "read-open is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+        if context.access_mode().is_writable() && rules.contains(AsterMacPolicyRules::WRITE_DENY) {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "write-open is denied by the Aster MAC LSM xattr policy"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+bitflags! {
+    struct AsterMacPolicyRules: u8 {
+        const OPEN_DENY  = 1 << 0;
+        const READ_DENY  = 1 << 1;
+        const WRITE_DENY = 1 << 2;
+        const EXEC_DENY  = 1 << 3;
+    }
+}
+
+struct AsterMacInodeSecurityState {
+    rules: AtomicU8,
+    has_label: AtomicBool,
+    label: RwLock<String>,
+    is_hydrated: AtomicBool,
+}
+
+impl AsterMacInodeSecurityState {
+    fn new() -> Self {
+        Self {
+            rules: AtomicU8::new(0),
+            has_label: AtomicBool::new(false),
+            label: RwLock::new(String::new()),
+            is_hydrated: AtomicBool::new(false),
+        }
+    }
+
+    fn rules(&self, inode: &dyn Inode) -> AsterMacPolicyRules {
+        self.ensure_hydrated(inode);
+        AsterMacPolicyRules::from_bits_truncate(self.rules.load(Ordering::Relaxed))
+    }
+
+    fn update(&self, rule: AsterMacPolicyRules, enabled: bool) {
+        if enabled {
+            self.rules.fetch_or(rule.bits(), Ordering::Relaxed);
+        } else {
+            self.rules.fetch_and(!rule.bits(), Ordering::Relaxed);
+        }
+        self.is_hydrated.store(true, Ordering::Relaxed);
+    }
+
+    fn exec_label(&self, inode: &dyn Inode) -> Option<String> {
+        self.ensure_hydrated(inode);
+        self.has_label
+            .load(Ordering::Relaxed)
+            .then(|| self.label.read().clone())
+    }
+
+    fn set_label(&self, label: Option<String>) {
+        self.has_label.store(label.is_some(), Ordering::Relaxed);
+        let mut stored_label = self.label.write();
+        *stored_label = label.unwrap_or_else(|| DEFAULT_INODE_LABEL.to_string());
+        self.is_hydrated.store(true, Ordering::Relaxed);
+    }
+
+    fn ensure_hydrated(&self, inode: &dyn Inode) {
+        if self.is_hydrated.load(Ordering::Acquire) {
+            return;
+        }
+
+        let rules = load_inode_policy_rules(inode);
+        let label = load_inode_label(inode);
+        self.rules.store(rules.bits(), Ordering::Relaxed);
+        self.has_label.store(label.is_some(), Ordering::Relaxed);
+        *self.label.write() = label.unwrap_or_else(|| DEFAULT_INODE_LABEL.to_string());
+        self.is_hydrated.store(true, Ordering::Release);
+    }
+}
+
+fn inode_security_state(inode: &dyn Inode) -> &AsterMacInodeSecurityState {
+    inode
+        .extension()
+        .group3()
+        .call_once(|| ThinBox::new_unsize(AsterMacInodeSecurityState::new()))
+        .downcast_ref()
+        .unwrap()
+}
+
+pub(in crate::security) fn is_aster_mac_inode_xattr(name: &XattrName<'_>) -> bool {
+    xattr_rule(name).is_some() || name.full_name() == MANAGED_LABEL_XATTR
+}
+
+pub(in crate::security) fn validate_aster_mac_inode_xattr(
+    name: &XattrName<'_>,
+    value: &[u8],
+) -> Result<()> {
+    if xattr_rule(name).is_some() {
+        parse_policy_value(value)?;
+        return Ok(());
+    }
+    if name.full_name() == MANAGED_LABEL_XATTR {
+        parse_label_value(value)?;
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+pub(in crate::security) fn sync_aster_mac_inode_xattr(
+    inode: &Arc<dyn Inode>,
+    name: &XattrName<'_>,
+    value: Option<&[u8]>,
+) -> Result<()> {
+    let state = inode_security_state(inode.as_ref());
+    state.ensure_hydrated(inode.as_ref());
+
+    if let Some(rule) = xattr_rule(name) {
+        let enabled = match value {
+            Some(value) => parse_policy_value(value)?,
+            None => false,
+        };
+        state.update(rule, enabled);
+        return Ok(());
+    }
+    if name.full_name() == MANAGED_LABEL_XATTR {
+        let label = value.map(parse_label_value).transpose()?;
+        state.set_label(label);
+    }
+
+    Ok(())
+}
+
+fn xattr_rule(name: &XattrName<'_>) -> Option<AsterMacPolicyRules> {
+    match name.full_name() {
+        "security.aster_mac.open" => Some(AsterMacPolicyRules::OPEN_DENY),
+        "security.aster_mac.read" => Some(AsterMacPolicyRules::READ_DENY),
+        "security.aster_mac.write" => Some(AsterMacPolicyRules::WRITE_DENY),
+        "security.aster_mac.exec" => Some(AsterMacPolicyRules::EXEC_DENY),
+        _ => None,
+    }
+}
+
+fn load_inode_policy_rules(inode: &dyn Inode) -> AsterMacPolicyRules {
+    let mut rules = AsterMacPolicyRules::empty();
+
+    for (name, rule) in [
+        ("security.aster_mac.open", AsterMacPolicyRules::OPEN_DENY),
+        ("security.aster_mac.read", AsterMacPolicyRules::READ_DENY),
+        ("security.aster_mac.write", AsterMacPolicyRules::WRITE_DENY),
+        ("security.aster_mac.exec", AsterMacPolicyRules::EXEC_DENY),
+    ] {
+        let Some(value) = read_aster_mac_inode_xattr(inode, name) else {
+            continue;
+        };
+        match parse_policy_value(&value) {
+            Ok(true) => rules |= rule,
+            Ok(false) => {}
+            Err(err) => warn!(
+                "ignore invalid Aster MAC inode policy xattr {} on inode {}: {:?}",
+                name,
+                inode.ino(),
+                err.error()
+            ),
+        }
+    }
+
+    rules
+}
+
+fn load_inode_label(inode: &dyn Inode) -> Option<String> {
+    let value = read_aster_mac_inode_xattr(inode, MANAGED_LABEL_XATTR)?;
+    match parse_label_value(&value) {
+        Ok(label) => Some(label),
+        Err(err) => {
+            warn!(
+                "ignore invalid Aster MAC inode label on inode {}: {:?}",
+                inode.ino(),
+                err.error()
+            );
+            None
+        }
+    }
+}
+
+fn read_aster_mac_inode_xattr(inode: &dyn Inode, full_name: &'static str) -> Option<Vec<u8>> {
+    let xattr_name = XattrName::try_from_full_name(full_name).unwrap();
+    let mut value = vec![0u8; XATTR_VALUE_MAX_LEN.min(MAX_LABEL_LEN.max(16))];
+    let mut writer = VmWriter::from(value.as_mut_slice()).to_fallible();
+
+    match inode.get_xattr_without_permission_check(xattr_name, &mut writer) {
+        Ok(len) => {
+            value.truncate(len);
+            Some(value)
+        }
+        Err(err)
+            if err.error() == Errno::ENODATA
+                || err.error() == Errno::EOPNOTSUPP
+                || err.error() == Errno::EPERM =>
+        {
+            None
+        }
+        Err(err) => {
+            warn!(
+                "failed to read Aster MAC inode xattr {} from inode {}: {:?}",
+                full_name,
+                inode.ino(),
+                err.error()
+            );
+            None
+        }
+    }
+}
+
+fn parse_policy_value(value: &[u8]) -> Result<bool> {
+    let value = core::str::from_utf8(value)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the xattr value is not valid UTF-8"))?;
+    let value = value.trim_matches(|ch: char| ch.is_ascii_whitespace() || ch == '\0');
+
+    match value {
+        "1" | "true" | "deny" => Ok(true),
+        "" | "0" | "false" | "allow" => Ok(false),
+        _ => return_errno_with_message!(
+            Errno::EINVAL,
+            "the xattr value must be one of 0, 1, false, true, allow, or deny"
+        ),
+    }
+}
+
+fn parse_label_value(value: &[u8]) -> Result<String> {
+    let label = core::str::from_utf8(value)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the label is not valid UTF-8"))?;
+    let label = label.trim_matches(|ch: char| ch.is_ascii_whitespace() || ch == '\0');
+
+    if label.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the label cannot be empty");
+    }
+    if label.len() > MAX_LABEL_LEN {
+        return_errno_with_message!(Errno::EINVAL, "the label is too long");
+    }
+    if !label
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-' | ':' | '/'))
+    {
+        return_errno_with_message!(Errno::EINVAL, "the label contains unsupported characters");
+    }
+
+    Ok(label.to_string())
+}

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::{
+    AlienAccessContext, CapableContext, InodeDacOverrideContext, LsmFlags, LsmModule,
+    hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook},
+};
+use crate::{
+    fs::file::Permission,
+    prelude::*,
+    process::{credentials::capabilities::CapSet, posix_thread::alien_access::CredsSource},
+};
+
+pub(super) static CAPABILITY_LSM: CapabilityLsm = CapabilityLsm;
+
+/// Capability-based authorization checks for built-in kernel operations.
+pub(super) struct CapabilityLsm;
+
+impl LsmModule for CapabilityLsm {
+    fn name(&self) -> &'static str {
+        "capability"
+    }
+
+    fn flags(&self) -> LsmFlags {
+        LsmFlags::empty()
+    }
+}
+
+impl LsmCapabilityHook for CapabilityLsm {
+    fn on_capable(&self, context: &CapableContext) -> Result<()> {
+        let _ = (context.user_namespace(), context.reason());
+        if context
+            .posix_thread()
+            .credentials()
+            .effective_capset()
+            .contains(context.capability())
+        {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the thread does not have the required capability"
+        );
+    }
+}
+
+impl LsmAlienAccessHook for CapabilityLsm {
+    fn on_alien_access(&self, context: &AlienAccessContext) -> Result<()> {
+        let accessor_cred = context.accessor().credentials();
+        let (caller_uid, caller_gid) = match context.mode().creds() {
+            CredsSource::FsCreds => (accessor_cred.fsuid(), accessor_cred.fsgid()),
+            CredsSource::RealCreds => (accessor_cred.ruid(), accessor_cred.rgid()),
+        };
+
+        let target_cred = context.target().credentials();
+        let caller_is_same = caller_uid == target_cred.euid()
+            && caller_uid == target_cred.suid()
+            && caller_uid == target_cred.ruid()
+            && caller_gid == target_cred.egid()
+            && caller_gid == target_cred.sgid()
+            && caller_gid == target_cred.rgid();
+        if caller_is_same || context.accessor_has_cap_sys_ptrace() {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the calling process does not have the required permissions"
+        );
+    }
+}
+
+impl LsmInodeHook for CapabilityLsm {
+    fn on_inode_dac_override(&self, context: &InodeDacOverrideContext) -> Result<Permission> {
+        let credentials = context.posix_thread().credentials();
+        if !credentials
+            .effective_capset()
+            .contains(CapSet::DAC_OVERRIDE)
+        {
+            return Ok(Permission::empty());
+        }
+
+        let mut overridden = Permission::empty();
+        let permission = context.permission();
+
+        if permission.may_read() {
+            overridden |= Permission::MAY_READ;
+        }
+        if permission.may_write() {
+            overridden |= Permission::MAY_WRITE;
+        }
+        if permission.may_exec() {
+            let mode = context.mode();
+            if mode.is_owner_executable()
+                || mode.is_group_executable()
+                || mode.is_other_executable()
+            {
+                overridden |= Permission::MAY_EXEC;
+            } else {
+                return_errno_with_message!(
+                    Errno::EACCES,
+                    "root execute permission denied: no execute bits set"
+                );
+            }
+        }
+
+        Ok(overridden)
+    }
+}

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -4,7 +4,7 @@ use core::ptr;
 
 use super::super::{
     AlienAccessContext, CapableContext, InodeDacOverrideContext, LsmFlags, LsmModule,
-    hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook},
+    hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook},
 };
 use crate::{
     fs::file::Permission,
@@ -83,6 +83,8 @@ impl LsmAlienAccessHook for CapabilityLsm {
     }
 }
 
+impl LsmBprmHook for CapabilityLsm {}
+
 impl LsmInodeHook for CapabilityLsm {
     fn on_inode_dac_override(&self, context: &InodeDacOverrideContext) -> Result<Permission> {
         let credentials = context.posix_thread().credentials();
@@ -120,3 +122,5 @@ impl LsmInodeHook for CapabilityLsm {
         Ok(overridden)
     }
 }
+
+impl LsmFileHook for CapabilityLsm {}

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::ptr;
+
 use super::super::{
     AlienAccessContext, CapableContext, InodeDacOverrideContext, LsmFlags, LsmModule,
     hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook},
@@ -27,7 +29,18 @@ impl LsmModule for CapabilityLsm {
 
 impl LsmCapabilityHook for CapabilityLsm {
     fn on_capable(&self, context: &CapableContext) -> Result<()> {
-        let _ = (context.user_namespace(), context.reason());
+        let current_process = context.posix_thread().process();
+        let current_user_ns = current_process.user_ns().lock();
+        if !ptr::eq(current_user_ns.as_ref(), context.user_namespace()) {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "the target user namespace is outside the caller's capability scope"
+            );
+        }
+
+        // Capability bit checks are reason-independent. The reason stays in the
+        // shared context for modules that need operation-specific policy.
+        let _reason = context.reason();
         if context
             .posix_thread()
             .credentials()

--- a/kernel/src/security/lsm/modules/mod.rs
+++ b/kernel/src/security/lsm/modules/mod.rs
@@ -2,28 +2,31 @@
 
 //! Built-in LSM module registration and boot-time selection.
 //!
-//! Linux provides two kernel command-line parameters for choosing enabled LSM
-//! modules: `lsm=` is the modern ordered module list, while `security=` is the
-//! legacy selector for one major LSM.
+//! The kernel always enables mandatory LSMs first. The capability module is
+//! mandatory because ordinary capability enforcement must not depend on boot
+//! parameters.
 //!
-//! When `lsm=` is specified, its comma-separated module names are used as the
-//! enabled LSM stack in that order. Unknown module names are ignored with a
+//! Linux provides two kernel command-line parameters for choosing additional
+//! LSM modules: `lsm=` is the modern ordered module list, while `security=` is
+//! the legacy selector for one major LSM.
+//!
+//! When `lsm=` is specified, its comma-separated module names are appended after
+//! the mandatory modules in that order. Unknown module names are ignored with a
 //! warning, and duplicate names are ignored after their first selection.
 //!
-//! Exclusive modules listed in `lsm=` are also processed in order: the first
-//! selected exclusive module is kept, and later exclusive entries are ignored.
+//! Exclusive modules listed in `lsm=` are processed in order: the first selected
+//! exclusive module is kept, and later exclusive entries are ignored.
 //!
-//! When only `security=` is specified, the default LSM stack is selected first.
-//! The named module is then selected if it is a legacy major LSM; if it is also
-//! exclusive, it replaces the currently selected exclusive module.
-//!
-//! This means `security=` applies after the default stack, while `lsm=` fully
-//! controls the explicit module order.
+//! When only `security=` is specified, the default optional LSM stack is selected
+//! after the mandatory modules. The named module is then selected if it is a
+//! legacy major LSM; if it is also exclusive, it replaces the currently selected
+//! exclusive module.
 //!
 //! If both parameters are specified, `security=` is ignored because `lsm=`
-//! fully describes the enabled stack. If neither parameter is specified, the
-//! default LSM stack is used.
+//! describes the optional enabled stack. If neither parameter is specified, the
+//! mandatory modules plus the default optional stack are used.
 
+mod capability;
 pub mod yama;
 
 use spin::Once;
@@ -37,10 +40,13 @@ static LEGACY_SECURITY_PARAM: Once<String> = Once::new();
 aster_cmdline::define_kv_param!("lsm", LSM_PARAM);
 aster_cmdline::define_kv_param!("security", LEGACY_SECURITY_PARAM);
 
-/// All LSM modules compiled into the kernel.
-static ALL_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];
+/// LSM modules that are always enabled before boot-selected modules.
+static MANDATORY_MODULES: [&'static dyn LsmModule; 1] = [&capability::CAPABILITY_LSM];
 
-/// The fallback LSM stack used when no boot-time selector is specified.
+/// All LSM modules compiled into the kernel.
+static ALL_MODULES: [&'static dyn LsmModule; 2] = [&capability::CAPABILITY_LSM, &yama::YAMA_LSM];
+
+/// The fallback optional LSM stack used when no boot-time selector is specified.
 pub(super) static DEFAULT_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];
 
 static ALL_MODULES_BY_NAME: Once<BTreeMap<&'static str, &'static dyn LsmModule>> = Once::new();
@@ -72,6 +78,7 @@ impl ModuleSelection {
         modules_by_name: &BTreeMap<&'static str, &'static dyn LsmModule>,
     ) -> Self {
         let mut selection = Self::default();
+        selection.push_mandatory_modules();
 
         match (LSM_PARAM.get(), LEGACY_SECURITY_PARAM.get()) {
             (Some(lsm_param), security_param) => {
@@ -138,6 +145,12 @@ impl ModuleSelection {
 
     fn into_modules(self) -> Box<[&'static dyn LsmModule]> {
         self.selected_modules.into_boxed_slice()
+    }
+
+    fn push_mandatory_modules(&mut self) {
+        for module in MANDATORY_MODULES {
+            self.push(module);
+        }
     }
 
     fn push(&mut self, module: &'static dyn LsmModule) {

--- a/kernel/src/security/lsm/modules/mod.rs
+++ b/kernel/src/security/lsm/modules/mod.rs
@@ -26,6 +26,7 @@
 //! describes the optional enabled stack. If neither parameter is specified, the
 //! mandatory modules plus the default optional stack are used.
 
+pub(super) mod aster_mac;
 mod capability;
 pub mod yama;
 
@@ -44,7 +45,11 @@ aster_cmdline::define_kv_param!("security", LEGACY_SECURITY_PARAM);
 static MANDATORY_MODULES: [&'static dyn LsmModule; 1] = [&capability::CAPABILITY_LSM];
 
 /// All LSM modules compiled into the kernel.
-static ALL_MODULES: [&'static dyn LsmModule; 2] = [&capability::CAPABILITY_LSM, &yama::YAMA_LSM];
+static ALL_MODULES: [&'static dyn LsmModule; 3] = [
+    &capability::CAPABILITY_LSM,
+    &yama::YAMA_LSM,
+    &aster_mac::ASTER_MAC_LSM,
+];
 
 /// The fallback optional LSM stack used when no boot-time selector is specified.
 pub(super) static DEFAULT_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -15,6 +15,7 @@ use crate::{
         credentials::capabilities::CapSet,
         posix_thread::{AsPosixThread, alien_access::AlienAccessKind},
     },
+    security::CapabilityReason,
 };
 
 pub static YAMA_LSM: YamaLsm = YamaLsm;
@@ -70,9 +71,10 @@ pub fn get_scope() -> YamaScope {
 
 /// Sets the Yama scope for alien access.
 pub fn set_scope(new_scope: YamaScope) -> Result<()> {
-    UserNamespace::get_init_singleton().check_cap(
+    UserNamespace::get_init_singleton().check_cap_with_reason(
         CapSet::SYS_PTRACE,
         current_thread!().as_posix_thread().unwrap(),
+        CapabilityReason::Ptrace,
     )?;
 
     YAMA_SCOPE

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -6,7 +6,7 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
     AlienAccessContext, LsmFlags, LsmModule,
-    hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook},
+    hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook},
 };
 use crate::{
     prelude::*,
@@ -62,7 +62,11 @@ impl LsmModule for YamaLsm {
 
 impl LsmCapabilityHook for YamaLsm {}
 
+impl LsmBprmHook for YamaLsm {}
+
 impl LsmInodeHook for YamaLsm {}
+
+impl LsmFileHook for YamaLsm {}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -5,8 +5,8 @@ use core::sync::atomic::{AtomicI32, Ordering};
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
-    LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, LsmAlienAccessHook},
+    AlienAccessContext, LsmFlags, LsmModule,
+    hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmInodeHook},
 };
 use crate::{
     prelude::*,
@@ -58,6 +58,10 @@ impl LsmModule for YamaLsm {
         LsmFlags::empty()
     }
 }
+
+impl LsmCapabilityHook for YamaLsm {}
+
+impl LsmInodeHook for YamaLsm {}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -5,18 +5,52 @@ pub mod lsm;
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
+    if #[cfg(all(target_arch = x86_64, feature = cvm_guest))] {
         mod tsm;
         mod tsm_mr;
     }
 }
 
+pub use self::lsm::CapabilityReason;
+use crate::{
+    fs::file::{InodeMode, Permission},
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
 pub(super) fn init() {
     lsm::init();
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_arch = x86_64)]
     ostd::if_tdx_enabled!({
         tsm::init();
         tsm_mr::init();
     });
+}
+
+pub fn capable(
+    user_namespace: &UserNamespace,
+    capability: CapSet,
+    posix_thread: &PosixThread,
+    reason: CapabilityReason,
+) -> Result<()> {
+    lsm::capable(&lsm::CapableContext::new(
+        user_namespace,
+        posix_thread,
+        capability,
+        reason,
+    ))
+}
+
+/// Runs the LSM stack for a DAC override decision on an inode.
+pub fn inode_dac_override(
+    mode: InodeMode,
+    permission: Permission,
+    posix_thread: &PosixThread,
+) -> Result<Permission> {
+    lsm::inode_dac_override(&lsm::InodeDacOverrideContext::new(
+        mode,
+        permission,
+        posix_thread,
+    ))
 }

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -15,14 +15,24 @@ cfg_if! {
 pub use self::lsm::CapabilityReason;
 use crate::{
     fs::{
-        file::{InodeMode, Permission},
-        vfs::path::Path,
+        file::{AccessMode, InodeMode, Permission, StatusFlags},
+        vfs::{inode::Inode, path::Path, xattr::XattrName},
     },
     prelude::*,
     process::{
         Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
     },
 };
+
+/// Returns whether the Yama LSM is enabled.
+pub fn is_yama_enabled() -> bool {
+    lsm::is_yama_enabled()
+}
+
+/// Returns whether the `aster_mac` LSM is enabled.
+pub fn is_aster_mac_enabled() -> bool {
+    lsm::is_aster_mac_enabled()
+}
 
 pub(super) fn init() {
     lsm::init();
@@ -49,9 +59,14 @@ pub fn capable(
     ))
 }
 
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(path: &Path) -> Result<()> {
+    lsm::bprm_check_security(&lsm::BprmCheckContext::new(path))
+}
+
 /// Updates security state after credentials are committed for a new executable.
-pub fn bprm_committed_creds(_path: &Path, _credentials: &Credentials<ReadWriteOp>) -> Result<()> {
-    Ok(())
+pub fn bprm_committed_creds(path: &Path, credentials: &Credentials<ReadWriteOp>) -> Result<()> {
+    lsm::bprm_committed_creds(&lsm::BprmCommittedCredsContext::new(path, credentials))
 }
 
 /// Runs the LSM stack for a DAC override decision on an inode.
@@ -65,4 +80,33 @@ pub fn inode_dac_override(
         permission,
         posix_thread,
     ))
+}
+
+/// Runs the LSM stack for an inode permission check.
+pub fn inode_permission(path: &Path, permission: Permission) -> Result<()> {
+    lsm::inode_permission(&lsm::InodePermissionContext::new(path, permission))
+}
+
+/// Runs the LSM stack for a file open check.
+pub fn file_open(path: &Path, access_mode: AccessMode, status_flags: StatusFlags) -> Result<()> {
+    lsm::file_open(&lsm::FileOpenContext::new(path, access_mode, status_flags))
+}
+
+/// Returns whether an xattr is owned by the `aster_mac` LSM.
+pub fn is_aster_mac_inode_xattr(name: &XattrName<'_>) -> bool {
+    lsm::is_aster_mac_inode_xattr(name)
+}
+
+/// Validates an `aster_mac` inode xattr value before storing it.
+pub fn validate_aster_mac_inode_xattr(name: &XattrName<'_>, value: &[u8]) -> Result<()> {
+    lsm::validate_aster_mac_inode_xattr(name, value)
+}
+
+/// Synchronizes the cached `aster_mac` inode state after an xattr update.
+pub fn sync_aster_mac_inode_xattr(
+    inode: &Arc<dyn Inode>,
+    name: &XattrName<'_>,
+    value: Option<&[u8]>,
+) -> Result<()> {
+    lsm::sync_aster_mac_inode_xattr(inode, name, value)
 }

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -5,7 +5,7 @@ pub mod lsm;
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_arch = x86_64, feature = cvm_guest))] {
+    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
         mod tsm;
         mod tsm_mr;
     }
@@ -21,13 +21,14 @@ use crate::{
 pub(super) fn init() {
     lsm::init();
 
-    #[cfg(target_arch = x86_64)]
+    #[cfg(target_arch = "x86_64")]
     ostd::if_tdx_enabled!({
         tsm::init();
         tsm_mr::init();
     });
 }
 
+/// Runs the LSM stack for a capability check.
 pub fn capable(
     user_namespace: &UserNamespace,
     capability: CapSet,

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod lsm;
 
+use aster_rights::ReadWriteOp;
 use cfg_if::cfg_if;
 
 cfg_if! {
@@ -13,9 +14,14 @@ cfg_if! {
 
 pub use self::lsm::CapabilityReason;
 use crate::{
-    fs::file::{InodeMode, Permission},
+    fs::{
+        file::{InodeMode, Permission},
+        vfs::path::Path,
+    },
     prelude::*,
-    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    process::{
+        Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
+    },
 };
 
 pub(super) fn init() {
@@ -41,6 +47,11 @@ pub fn capable(
         capability,
         reason,
     ))
+}
+
+/// Updates security state after credentials are committed for a new executable.
+pub fn bprm_committed_creds(_path: &Path, _credentials: &Credentials<ReadWriteOp>) -> Result<()> {
+    Ok(())
 }
 
 /// Runs the LSM stack for a DAC override decision on an inode.

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -82,11 +82,6 @@ pub fn inode_dac_override(
     ))
 }
 
-/// Runs the LSM stack for an inode permission check.
-pub fn inode_permission(path: &Path, permission: Permission) -> Result<()> {
-    lsm::inode_permission(&lsm::InodePermissionContext::new(path, permission))
-}
-
 /// Runs the LSM stack for a file open check.
 pub fn file_open(path: &Path, access_mode: AccessMode, status_flags: StatusFlags) -> Result<()> {
     lsm::file_open(&lsm::FileOpenContext::new(path, access_mode, status_flags))

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -8,7 +8,6 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
-    security,
 };
 
 pub fn sys_faccessat(
@@ -102,24 +101,18 @@ fn do_faccessat(
     }
 
     let inode = path.inode();
-    let mut permission = Permission::empty();
-
     // FIXME: The current implementation is dummy
     if mode.contains(AccessMode::R_OK) {
-        permission |= Permission::MAY_READ;
         inode.check_permission(Permission::MAY_READ)?;
     }
 
     if mode.contains(AccessMode::W_OK) {
-        permission |= Permission::MAY_WRITE;
         inode.check_permission(Permission::MAY_WRITE)?;
     }
 
     if mode.contains(AccessMode::X_OK) {
-        permission |= Permission::MAY_EXEC;
         inode.check_permission(Permission::MAY_EXEC)?;
     }
-    security::inode_permission(&path, permission)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security,
 };
 
 pub fn sys_faccessat(
@@ -101,19 +102,24 @@ fn do_faccessat(
     }
 
     let inode = path.inode();
+    let mut permission = Permission::empty();
 
     // FIXME: The current implementation is dummy
     if mode.contains(AccessMode::R_OK) {
+        permission |= Permission::MAY_READ;
         inode.check_permission(Permission::MAY_READ)?;
     }
 
     if mode.contains(AccessMode::W_OK) {
+        permission |= Permission::MAY_WRITE;
         inode.check_permission(Permission::MAY_WRITE)?;
     }
 
     if mode.contains(AccessMode::X_OK) {
+        permission |= Permission::MAY_EXEC;
         inode.check_permission(Permission::MAY_EXEC)?;
     }
+    security::inode_permission(&path, permission)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/capset.rs
+++ b/kernel/src/syscall/capset.rs
@@ -6,12 +6,14 @@ use super::SyscallReturn;
 use crate::{
     prelude::*,
     process::{
+        UserNamespace,
         credentials::{
             c_types::{CUserCapData, CUserCapHeader, LINUX_CAPABILITY_VERSION_3},
             capabilities::CapSet,
         },
         posix_thread::ContextPthreadAdminApi,
     },
+    security::{self, CapabilityReason},
 };
 
 pub fn sys_capset(
@@ -61,7 +63,13 @@ pub fn sys_capset(
     }
     if !(credentials.inheritable_capset() | credentials.permitted_capset())
         .contains(inheritable_capset)
-        && !credentials.effective_capset().contains(CapSet::SETPCAP)
+        && security::capable(
+            UserNamespace::get_init_singleton().as_ref(),
+            CapSet::SETPCAP,
+            ctx.posix_thread,
+            CapabilityReason::CredentialsSetPcap,
+        )
+        .is_err()
     {
         return_errno_with_message!(Errno::EPERM, "inheritable capabilities are not permitted");
     }

--- a/kernel/src/syscall/listxattr.rs
+++ b/kernel/src/syscall/listxattr.rs
@@ -2,7 +2,7 @@
 
 use super::{
     SyscallReturn,
-    setxattr::{XattrFileCtx, lookup_path_for_xattr},
+    setxattr::{XattrFileCtx, current_can_access_trusted_xattr, lookup_path_for_xattr},
 };
 use crate::{
     fs::{
@@ -10,7 +10,6 @@ use crate::{
         vfs::xattr::{XATTR_LIST_MAX_LEN, XattrNamespace},
     },
     prelude::*,
-    process::credentials::capabilities::CapSet,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -94,12 +93,7 @@ fn listxattr(
 }
 
 fn get_current_xattr_namespace(ctx: &Context) -> XattrNamespace {
-    let credentials = ctx.posix_thread.credentials();
-    let permitted_capset = credentials.permitted_capset();
-    let effective_capset = credentials.effective_capset();
-
-    if permitted_capset.contains(CapSet::SYS_ADMIN) && effective_capset.contains(CapSet::SYS_ADMIN)
-    {
+    if current_can_access_trusted_xattr(ctx) {
         XattrNamespace::Trusted
     } else {
         XattrNamespace::User

--- a/kernel/src/syscall/prlimit64.rs
+++ b/kernel/src/syscall/prlimit64.rs
@@ -12,6 +12,7 @@ use crate::{
         posix_thread::AsPosixThread,
         rlimit::{RawRLimit64, SYSCTL_NR_OPEN},
     },
+    security::CapabilityReason,
 };
 
 pub fn sys_getrlimit(resource: u32, rlim_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
@@ -97,7 +98,11 @@ fn check_rlimit_perm(target_process: &Process, ctx: &Context) -> Result<()> {
     if target_process
         .user_ns()
         .lock()
-        .check_cap(CapSet::SYS_RESOURCE, ctx.posix_thread)
+        .check_cap_with_reason(
+            CapSet::SYS_RESOURCE,
+            ctx.posix_thread,
+            CapabilityReason::ResourceLimit,
+        )
         .is_ok()
     {
         return Ok(());

--- a/kernel/src/syscall/reboot.rs
+++ b/kernel/src/syscall/reboot.rs
@@ -3,7 +3,11 @@
 use ostd::power::{ExitCode, poweroff, restart};
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::credentials::capabilities::CapSet};
+use crate::{
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet},
+    security::{self, CapabilityReason},
+};
 
 // Linux reboot magic constants.
 const LINUX_REBOOT_MAGIC1: u32 = 0xfee1dead;
@@ -46,14 +50,12 @@ pub fn sys_reboot(
         return_errno_with_message!(Errno::EINVAL, "the reboot magic is invalid");
     }
 
-    if !ctx
-        .posix_thread
-        .credentials()
-        .effective_capset()
-        .contains(CapSet::SYS_BOOT)
-    {
-        return_errno_with_message!(Errno::EPERM, "reboot without SYS_BOOT is not allowed");
-    }
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::SYS_BOOT,
+        ctx.posix_thread,
+        CapabilityReason::Reboot,
+    )?;
 
     let cmd = RebootCmd::try_from(op)?;
 

--- a/kernel/src/syscall/removexattr.rs
+++ b/kernel/src/syscall/removexattr.rs
@@ -11,6 +11,7 @@ use crate::{
     fs,
     fs::file::file_table::{RawFileDesc, get_file_fast},
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -56,10 +57,15 @@ fn removexattr(
     let name_str = name_cstr.to_string_lossy();
     let xattr_name = parse_xattr_name(name_str.as_ref())?;
     check_xattr_namespace(xattr_name.namespace(), ctx)?;
+    let is_aster_mac_xattr = security::is_aster_mac_inode_xattr(&xattr_name);
 
     match lookup_path_for_xattr(&file_ctx, ctx) {
         Ok(path) => {
             path.remove_xattr(xattr_name)?;
+            if is_aster_mac_xattr {
+                let xattr_name = parse_xattr_name(name_str.as_ref())?;
+                security::sync_aster_mac_inode_xattr(&path.inode(), &xattr_name, None)?;
+            }
             fs::vfs::notify::on_attr_change(&path);
             Ok(())
         }

--- a/kernel/src/syscall/setgroups.rs
+++ b/kernel/src/syscall/setgroups.rs
@@ -5,13 +5,21 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, posix_thread::ContextPthreadAdminApi},
+    process::{
+        Gid, UserNamespace, credentials::capabilities::CapSet, posix_thread::ContextPthreadAdminApi,
+    },
+    security::{self, CapabilityReason},
 };
 
 pub fn sys_setgroups(size: usize, group_list_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("size = {}, group_list_addr = 0x{:x}", size, group_list_addr);
 
-    // TODO: check perm: the calling process should have the CAP_SETGID capability
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::SETGID,
+        ctx.posix_thread,
+        CapabilityReason::CredentialsSetGid,
+    )?;
 
     if size > NGROUPS_MAX {
         return_errno_with_message!(Errno::EINVAL, "size cannot be greater than NGROUPS_MAX");

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -24,6 +24,7 @@ use crate::{
         CloneFlags, ContextSetNsAdminApi, NsProxy, NsProxyBuilder, PidFile,
         check_unsupported_ns_flags, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
+    security::CapabilityReason,
     syscall::SyscallReturn,
 };
 
@@ -232,13 +233,16 @@ fn set_uts_ns(
 fn check_set_ns_perms<T: NsCommonOps>(target_ns: &Arc<T>, ctx: &Context) -> Result<()> {
     // Verify the thread has SYS_ADMIN capability in the target namespace's owner
     // and the current user namespace.
-    target_ns
-        .owner_user_ns()
-        .unwrap()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
-    ctx.thread_local
-        .borrow_user_ns()
-        .check_cap(CapSet::SYS_ADMIN, ctx.posix_thread)?;
+    target_ns.owner_user_ns().unwrap().check_cap_with_reason(
+        CapSet::SYS_ADMIN,
+        ctx.posix_thread,
+        CapabilityReason::Namespace,
+    )?;
+    ctx.thread_local.borrow_user_ns().check_cap_with_reason(
+        CapSet::SYS_ADMIN,
+        ctx.posix_thread,
+        CapabilityReason::Namespace,
+    )?;
 
     // TODO: Are the checks above sufficient?
 

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -18,7 +18,8 @@ use crate::{
         },
     },
     prelude::*,
-    process::credentials::capabilities::CapSet,
+    process::{UserNamespace, credentials::capabilities::CapSet},
+    security::{self, CapabilityReason},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -186,18 +187,21 @@ pub(super) fn parse_xattr_name(name_str: &str) -> Result<XattrName<'_>> {
 }
 
 pub(super) fn check_xattr_namespace(namespace: XattrNamespace, ctx: &Context) -> Result<()> {
-    let credentials = ctx.posix_thread.credentials();
-    let permitted_capset = credentials.permitted_capset();
-    let effective_capset = credentials.effective_capset();
-
-    if namespace == XattrNamespace::Trusted
-        && (!permitted_capset.contains(CapSet::SYS_ADMIN)
-            || !effective_capset.contains(CapSet::SYS_ADMIN))
-    {
+    if namespace == XattrNamespace::Trusted && !current_can_access_trusted_xattr(ctx) {
         return_errno_with_message!(
             Errno::EPERM,
             "try to access trusted xattr without CAP_SYS_ADMIN"
         );
     }
     Ok(())
+}
+
+pub(super) fn current_can_access_trusted_xattr(ctx: &Context) -> bool {
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::SYS_ADMIN,
+        ctx.posix_thread,
+        CapabilityReason::Xattr,
+    )
+    .is_ok()
 }

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -2,6 +2,8 @@
 
 use alloc::borrow::Cow;
 
+use ostd::mm::VmIo;
+
 use super::SyscallReturn;
 use crate::{
     fs,
@@ -112,14 +114,25 @@ fn setxattr(
     let name_str = name_cstr.to_string_lossy();
     let xattr_name = parse_xattr_name(name_str.as_ref())?;
     check_xattr_namespace(xattr_name.namespace(), ctx)?;
+    let is_aster_mac_xattr = security::is_aster_mac_inode_xattr(&xattr_name);
 
     if value_len > XATTR_VALUE_MAX_LEN {
         return_errno_with_message!(Errno::E2BIG, "xattr value too long");
     }
-    let mut value_reader = user_space.reader(value_ptr, value_len)?;
-
     let path = lookup_path_for_xattr(&file_ctx, ctx)?;
+    let mut value = vec![0u8; value_len];
+    user_space.read_bytes(value_ptr, &mut value)?;
+
+    if is_aster_mac_xattr {
+        security::validate_aster_mac_inode_xattr(&xattr_name, &value)?;
+    }
+
+    let mut value_reader = VmReader::from(value.as_slice()).to_fallible();
     path.set_xattr(xattr_name, &mut value_reader, flags)?;
+    if is_aster_mac_xattr {
+        let xattr_name = parse_xattr_name(name_str.as_ref())?;
+        security::sync_aster_mac_inode_xattr(&path.inode(), &xattr_name, Some(&value))?;
+    }
     fs::vfs::notify::on_attr_change(&path);
     Ok(())
 }

--- a/test/initramfs/nix/regression/default.nix
+++ b/test/initramfs/nix/regression/default.nix
@@ -33,6 +33,7 @@ in {
     buildCommand = ''
       mkdir -p $out
       cp ${scripts}/* $out
+      chmod +x $out/*.sh
 
       ${lib.concatMapStringsSep "\n" (name: ''
         ln -sT "${allPkgs.${name}}/${name}" "$out/${name}"

--- a/test/initramfs/src/regression/network/unix_stream_err.c
+++ b/test/initramfs/src/regression/network/unix_stream_err.c
@@ -3,6 +3,25 @@
 #define SOCK_TYPE SOCK_STREAM
 #include "unix_streamlike_prologue.h"
 
+#include <linux/capability.h>
+#include <sys/syscall.h>
+
+static void drop_cap_sys_admin(void)
+{
+	struct __user_cap_header_struct header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+	};
+	struct __user_cap_data_struct data[2] = { 0 };
+
+	CHECK(syscall(SYS_capget, &header, data));
+
+	data[0].effective &= ~(1U << CAP_SYS_ADMIN);
+	data[0].permitted &= ~(1U << CAP_SYS_ADMIN);
+	data[0].inheritable &= ~(1U << CAP_SYS_ADMIN);
+
+	CHECK(syscall(SYS_capset, &header, data));
+}
+
 FN_TEST(sendto)
 {
 	char buf[1] = { 'z' };
@@ -108,6 +127,76 @@ FN_TEST(scm_rights)
 
 	TEST_ERRNO(write(cfds[1], "y", 1), EPIPE);
 	TEST_SUCC(close(cfds[1]));
+
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
+
+FN_TEST(scm_credentials_requires_cap_sys_admin)
+{
+	int fildes[2];
+	char byte = 'x';
+	char control[CMSG_SPACE(sizeof(struct ucred))];
+	struct iovec iov = {
+		.iov_base = &byte,
+		.iov_len = sizeof(byte),
+	};
+	struct msghdr msg = {
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = control,
+		.msg_controllen = sizeof(control),
+	};
+	struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+	struct ucred fake_cred = {
+		.pid = getpid(),
+		.uid = 123,
+		.gid = 456,
+	};
+	struct ucred recv_cred = { 0 };
+	int one = 1;
+	int status;
+	pid_t pid;
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, fildes));
+	TEST_SUCC(setsockopt(fildes[1], SOL_SOCKET, SO_PASSCRED, &one,
+			     sizeof(one)));
+
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_CREDENTIALS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(fake_cred));
+	memcpy(CMSG_DATA(cmsg), &fake_cred, sizeof(fake_cred));
+
+	TEST_RES(sendmsg(fildes[0], &msg, 0), _ret == 1);
+
+	memset(control, 0, sizeof(control));
+	msg.msg_controllen = sizeof(control);
+	TEST_RES(
+		recvmsg(fildes[1], &msg, 0),
+		_ret == 1 && (cmsg = CMSG_FIRSTHDR(&msg)) &&
+			cmsg->cmsg_level == SOL_SOCKET &&
+			cmsg->cmsg_type == SCM_CREDENTIALS &&
+			cmsg->cmsg_len == CMSG_LEN(sizeof(recv_cred)) &&
+			(memcpy(&recv_cred, CMSG_DATA(cmsg), sizeof(recv_cred)),
+			 recv_cred.pid == fake_cred.pid &&
+				 recv_cred.uid == fake_cred.uid &&
+				 recv_cred.gid == fake_cred.gid));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_cap_sys_admin();
+		fake_cred.pid = getpid();
+		msg.msg_controllen = sizeof(control);
+		memcpy(CMSG_DATA(cmsg), &fake_cred, sizeof(fake_cred));
+		if (sendmsg(fildes[0], &msg, 0) < 0 && errno == EPERM) {
+			_exit(EXIT_SUCCESS);
+		}
+		_exit(EXIT_FAILURE);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid);
+	TEST_RES(WIFEXITED(status), WEXITSTATUS(status) == EXIT_SUCCESS);
 
 	TEST_SUCC(close(fildes[0]));
 	TEST_SUCC(close(fildes[1]));

--- a/test/initramfs/src/regression/scripts/run_aster_mac_test.sh
+++ b/test/initramfs/src/regression/scripts/run_aster_mac_test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/test/security/lsm/aster_mac/label_state
+/test/security/lsm/aster_mac/xattr_policy
+
+echo "Aster MAC test passed."

--- a/test/initramfs/src/regression/scripts/run_lsm_module_selection_test.sh
+++ b/test/initramfs/src/regression/scripts/run_lsm_module_selection_test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+/test/security/lsm/module_selection
+
+echo "LSM module selection test passed."

--- a/test/initramfs/src/regression/security/capability/execve.c
+++ b/test/initramfs/src/regression/security/capability/execve.c
@@ -2,9 +2,13 @@
 
 #define _GNU_SOURCE
 
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
+#include <sys/xattr.h>
 #include <linux/capability.h>
 
 #include "../../common/test.h"
@@ -13,7 +17,31 @@ static uid_t root = 0;
 static uid_t nobody = 65534;
 
 #define CAPS_ALL "000001ffffffffff"
+#define CAPS_NET_BIND_SERVICE "0000000000000400"
 #define CAPS_NONE "0000000000000000"
+
+#define SECURITY_CAPABILITY_XATTR "security.capability"
+
+#define AST_VFS_CAP_REVISION_2 0x02000000
+#define AST_VFS_CAP_REVISION_3 0x03000000
+#define AST_VFS_CAP_FLAGS_EFFECTIVE 0x00000001
+
+struct ast_vfs_cap_data_v2 {
+	uint32_t magic_etc;
+	uint32_t permitted_low;
+	uint32_t inheritable_low;
+	uint32_t permitted_high;
+	uint32_t inheritable_high;
+};
+
+struct ast_vfs_cap_data_v3 {
+	uint32_t magic_etc;
+	uint32_t permitted_low;
+	uint32_t inheritable_low;
+	uint32_t permitted_high;
+	uint32_t inheritable_high;
+	uint32_t rootid;
+};
 
 static char child_path[4096];
 
@@ -31,6 +59,78 @@ static int clear_caps(void)
 
 static int noop(void)
 {
+	return 0;
+}
+
+static char *copy_child_to_temp_exec(void)
+{
+	char *exec_path;
+	char template[] = "/tmp/file_caps_execXXXXXX";
+	char buffer[4096];
+	int src_fd;
+	int dst_fd;
+
+	exec_path = CHECK_WITH(strdup(template), _ret != NULL);
+	dst_fd = CHECK(mkstemp(exec_path));
+	src_fd = CHECK(open(child_path, O_RDONLY));
+
+	for (;;) {
+		ssize_t read_len = CHECK(read(src_fd, buffer, sizeof(buffer)));
+		ssize_t written = 0;
+
+		if (read_len == 0) {
+			break;
+		}
+
+		while (written < read_len) {
+			written += CHECK(write(dst_fd, buffer + written,
+					       read_len - written));
+		}
+	}
+
+	CHECK(fchmod(dst_fd, 0755));
+	CHECK(close(src_fd));
+	CHECK(close(dst_fd));
+	return exec_path;
+}
+
+static int run_file_cap_exec_test(const char *expected_effective,
+				  const char *expected_permitted,
+				  const char *expected_inheritable,
+				  const void *xattr_value, size_t xattr_size)
+{
+	char *exec_path;
+	pid_t pid;
+	int ret;
+	int saved_errno;
+	int status;
+
+	exec_path = copy_child_to_temp_exec();
+	CHECK(setxattr(exec_path, SECURITY_CAPABILITY_XATTR, xattr_value,
+		       xattr_size, 0));
+
+	pid = CHECK(fork());
+	if (pid == 0) {
+		CHECK(setresuid(nobody, nobody, nobody));
+		CHECK(execl(exec_path, exec_path, expected_effective,
+			    expected_permitted, expected_inheritable, NULL));
+	}
+
+	ret = waitpid(pid, &status, 0);
+	saved_errno = errno;
+	CHECK(unlink(exec_path));
+	free(exec_path);
+
+	if (ret != pid) {
+		errno = saved_errno;
+		return -1;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		errno = ECHILD;
+		return -1;
+	}
+
 	return 0;
 }
 
@@ -130,3 +230,59 @@ TEST_EXECVE_LOST_CAPS(rnn_lost_caps, root, nobody, nobody, CAPS_ALL);
 // Effective capabilities = CAPS_NONE, permitted capabilities = CAPS_NONE
 TEST_EXECVE_LOST_CAPS(nnr_lost_caps, nobody, nobody, root, CAPS_NONE);
 TEST_EXECVE_LOST_CAPS(nnn_lost_caps, nobody, nobody, nobody, CAPS_NONE);
+
+FN_TEST(file_caps_v2_gain_effective_caps)
+{
+	const struct ast_vfs_cap_data_v2 file_caps = {
+		.magic_etc = AST_VFS_CAP_REVISION_2 |
+			     AST_VFS_CAP_FLAGS_EFFECTIVE,
+		.permitted_low = 1U << CAP_NET_BIND_SERVICE,
+	};
+
+	TEST_SUCC(run_file_cap_exec_test(CAPS_NET_BIND_SERVICE,
+					 CAPS_NET_BIND_SERVICE, CAPS_NONE,
+					 &file_caps, sizeof(file_caps)));
+}
+END_TEST()
+
+FN_TEST(file_caps_v2_gain_permitted_only_caps)
+{
+	const struct ast_vfs_cap_data_v2 file_caps = {
+		.magic_etc = AST_VFS_CAP_REVISION_2,
+		.permitted_low = 1U << CAP_NET_BIND_SERVICE,
+	};
+
+	TEST_SUCC(run_file_cap_exec_test(CAPS_NONE, CAPS_NET_BIND_SERVICE,
+					 CAPS_NONE, &file_caps,
+					 sizeof(file_caps)));
+}
+END_TEST()
+
+FN_TEST(file_caps_v3_rootid_match)
+{
+	const struct ast_vfs_cap_data_v3 file_caps = {
+		.magic_etc = AST_VFS_CAP_REVISION_3 |
+			     AST_VFS_CAP_FLAGS_EFFECTIVE,
+		.permitted_low = 1U << CAP_NET_BIND_SERVICE,
+		.rootid = root,
+	};
+
+	TEST_SUCC(run_file_cap_exec_test(CAPS_NET_BIND_SERVICE,
+					 CAPS_NET_BIND_SERVICE, CAPS_NONE,
+					 &file_caps, sizeof(file_caps)));
+}
+END_TEST()
+
+FN_TEST(file_caps_v3_rootid_mismatch)
+{
+	const struct ast_vfs_cap_data_v3 file_caps = {
+		.magic_etc = AST_VFS_CAP_REVISION_3 |
+			     AST_VFS_CAP_FLAGS_EFFECTIVE,
+		.permitted_low = 1U << CAP_NET_BIND_SERVICE,
+		.rootid = 1234,
+	};
+
+	TEST_SUCC(run_file_cap_exec_test(CAPS_NONE, CAPS_NONE, CAPS_NONE,
+					 &file_caps, sizeof(file_caps)));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/execve.c
+++ b/test/initramfs/src/regression/security/capability/execve.c
@@ -286,3 +286,31 @@ FN_TEST(file_caps_v3_rootid_mismatch)
 					 &file_caps, sizeof(file_caps)));
 }
 END_TEST()
+
+FN_TEST(exec_only_file_without_caps)
+{
+	char *exec_path;
+	pid_t pid;
+	int ret;
+	int status;
+
+	exec_path = copy_child_to_temp_exec();
+	TEST_SUCC(chmod(exec_path, 0111));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(setresuid(nobody, nobody, nobody));
+		CHECK(execl(exec_path, exec_path, CAPS_NONE, CAPS_NONE,
+			    CAPS_NONE, NULL));
+	}
+
+	ret = waitpid(pid, &status, 0);
+	TEST_SUCC(unlink(exec_path));
+	free(exec_path);
+
+	TEST_RES(ret, _ret == pid);
+	if (ret == pid) {
+		TEST_RES(WIFEXITED(status), _ret && WEXITSTATUS(status) == 0);
+	}
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/kill.c
+++ b/test/initramfs/src/regression/security/capability/kill.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <linux/capability.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void read_cap_data(struct __user_cap_data_struct cap_data[2])
+{
+	struct __user_cap_header_struct cap_header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+		.pid = 0,
+	};
+
+	CHECK(syscall(SYS_capget, &cap_header, cap_data));
+}
+
+static void drop_cap_kill(void)
+{
+	struct __user_cap_data_struct cap_data[2] = {};
+
+	read_cap_data(cap_data);
+	cap_data[0].effective &= ~(1U << CAP_KILL);
+	cap_data[0].permitted &= ~(1U << CAP_KILL);
+	cap_data[0].inheritable &= ~(1U << CAP_KILL);
+	CHECK(syscall(SYS_capset,
+		      &(struct __user_cap_header_struct){
+			      .version = _LINUX_CAPABILITY_VERSION_3,
+			      .pid = 0,
+		      },
+		      cap_data));
+}
+
+FN_TEST(kill_requires_cap_kill_for_other_uid)
+{
+	int ready_pipe[2];
+	int release_pipe[2];
+	pid_t pid;
+	char ready_byte;
+	int status;
+
+	CHECK(pipe(ready_pipe));
+	CHECK(pipe(release_pipe));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char byte;
+
+		CHECK(close(ready_pipe[0]));
+		CHECK(close(release_pipe[1]));
+		CHECK(setresgid(1000, 1000, 1000));
+		CHECK(setresuid(1000, 1000, 1000));
+		CHECK(write(ready_pipe[1], "r", 1));
+		CHECK(close(ready_pipe[1]));
+		CHECK(read(release_pipe[0], &byte, sizeof(byte)));
+		CHECK(close(release_pipe[0]));
+		_exit(EXIT_SUCCESS);
+	}
+
+	CHECK(close(ready_pipe[1]));
+	CHECK(close(release_pipe[0]));
+	CHECK(read(ready_pipe[0], &ready_byte, sizeof(ready_byte)));
+	CHECK(close(ready_pipe[0]));
+
+	TEST_SUCC(kill(pid, 0));
+
+	drop_cap_kill();
+	TEST_ERRNO(kill(pid, 0), EPERM);
+
+	CHECK(write(release_pipe[1], "x", 1));
+	CHECK(close(release_pipe[1]));
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/reboot.c
+++ b/test/initramfs/src/regression/security/capability/reboot.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <linux/capability.h>
+#include <linux/reboot.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void read_cap_data(struct __user_cap_data_struct cap_data[2])
+{
+	struct __user_cap_header_struct cap_header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+		.pid = 0,
+	};
+
+	CHECK(syscall(SYS_capget, &cap_header, cap_data));
+}
+
+static void drop_cap_sys_boot(void)
+{
+	struct __user_cap_data_struct cap_data[2] = {};
+
+	read_cap_data(cap_data);
+	cap_data[0].effective &= ~(1U << CAP_SYS_BOOT);
+	cap_data[0].permitted &= ~(1U << CAP_SYS_BOOT);
+	cap_data[0].inheritable &= ~(1U << CAP_SYS_BOOT);
+	CHECK(syscall(SYS_capset,
+		      &(struct __user_cap_header_struct){
+			      .version = _LINUX_CAPABILITY_VERSION_3,
+			      .pid = 0,
+		      },
+		      cap_data));
+}
+
+FN_TEST(reboot_requires_cap_sys_boot)
+{
+	pid_t pid;
+	int status;
+
+	TEST_ERRNO(syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
+			   0xdeadbeefU, 0),
+		   EINVAL);
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		errno = 0;
+		drop_cap_sys_boot();
+		CHECK_WITH(syscall(SYS_reboot, LINUX_REBOOT_MAGIC1,
+				   LINUX_REBOOT_MAGIC2, 0xdeadbeefU, 0),
+			   _ret == -1 && errno == EPERM);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/run_test.sh
+++ b/test/initramfs/src/regression/security/capability/run_test.sh
@@ -15,5 +15,14 @@ echo "[capability] running capset"
 echo "[capability] running setgroups"
 ./setgroups
 
+echo "[capability] running trusted_xattr"
+./trusted_xattr
+
+echo "[capability] running kill"
+./kill
+
+echo "[capability] running reboot"
+./reboot
+
 echo "[capability] running execve"
 ./execve

--- a/test/initramfs/src/regression/security/capability/run_test.sh
+++ b/test/initramfs/src/regression/security/capability/run_test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "[capability] running capabilities"
+./capabilities
+
+echo "[capability] running capset"
+./capset
+
+echo "[capability] running setgroups"
+./setgroups
+
+echo "[capability] running execve"
+./execve

--- a/test/initramfs/src/regression/security/capability/setgroups.c
+++ b/test/initramfs/src/regression/security/capability/setgroups.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <linux/capability.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "../../common/test.h"
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
+static void drop_cap_setgid(void)
+{
+	struct __user_cap_header_struct header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+	};
+	struct __user_cap_data_struct data[2] = { 0 };
+
+	CHECK(syscall(SYS_capget, &header, data));
+
+	data[0].effective &= ~(1 << CAP_SETGID);
+	data[0].permitted &= ~(1 << CAP_SETGID);
+	data[0].inheritable &= ~(1 << CAP_SETGID);
+
+	CHECK(syscall(SYS_capset, &header, data));
+}
+
+static int check_setgroups(bool drop_capability)
+{
+	gid_t groups[] = { 0, 65534 };
+	int status;
+
+	pid_t pid = CHECK(fork());
+
+	if (pid == 0) {
+		if (drop_capability) {
+			drop_cap_setgid();
+		}
+
+		int ret = syscall(SYS_setgroups, ARRAY_SIZE(groups), groups);
+		if (drop_capability) {
+			if (ret < 0 && errno == EPERM) {
+				_exit(EXIT_SUCCESS);
+			}
+			_exit(EXIT_FAILURE);
+		}
+
+		_exit(ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+	}
+
+	CHECK_WITH(waitpid(pid, &status, 0), _ret == pid);
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+FN_TEST(setgroups_requires_cap_setgid)
+{
+	TEST_SUCC(check_setgroups(false));
+	TEST_SUCC(check_setgroups(true));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/trusted_xattr.c
+++ b/test/initramfs/src/regression/security/capability/trusted_xattr.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <fcntl.h>
+#include <linux/capability.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#define TRUSTED_XATTR_NAME "trusted.capability_lsm_test"
+
+static void read_cap_data(struct __user_cap_data_struct cap_data[2])
+{
+	struct __user_cap_header_struct cap_header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+		.pid = 0,
+	};
+
+	CHECK(syscall(SYS_capget, &cap_header, cap_data));
+}
+
+static void drop_cap_sys_admin(void)
+{
+	struct __user_cap_data_struct cap_data[2] = {};
+
+	read_cap_data(cap_data);
+	cap_data[0].effective &= ~(1U << CAP_SYS_ADMIN);
+	cap_data[0].permitted &= ~(1U << CAP_SYS_ADMIN);
+	cap_data[0].inheritable &= ~(1U << CAP_SYS_ADMIN);
+	CHECK(syscall(SYS_capset,
+		      &(struct __user_cap_header_struct){
+			      .version = _LINUX_CAPABILITY_VERSION_3,
+			      .pid = 0,
+		      },
+		      cap_data));
+}
+
+FN_TEST(trusted_xattr_requires_cap_sys_admin)
+{
+	pid_t pid;
+	int status;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char file_template[] = "/tmp/trusted_xattrXXXXXX";
+		const char initial_value[] = "secret";
+		char value_buf[32] = {};
+		char list_buf[128] = {};
+		int file;
+		ssize_t list_len;
+
+		file = CHECK(mkstemp(file_template));
+
+		CHECK(setxattr(file_template, TRUSTED_XATTR_NAME, initial_value,
+			       sizeof(initial_value), 0));
+		CHECK_WITH(getxattr(file_template, TRUSTED_XATTR_NAME,
+				    value_buf, sizeof(value_buf)),
+			   _ret == (ssize_t)sizeof(initial_value) &&
+				   memcmp(value_buf, initial_value,
+					  sizeof(initial_value)) == 0);
+
+		list_len = CHECK(
+			listxattr(file_template, list_buf, sizeof(list_buf)));
+		CHECK_WITH(memmem(list_buf, list_len, TRUSTED_XATTR_NAME,
+				  sizeof(TRUSTED_XATTR_NAME)),
+			   _ret != NULL);
+
+		drop_cap_sys_admin();
+
+		errno = 0;
+		CHECK_WITH(setxattr(file_template, TRUSTED_XATTR_NAME, "other",
+				    sizeof("other"), 0),
+			   _ret == -1 && errno == EPERM);
+		errno = 0;
+		CHECK_WITH(getxattr(file_template, TRUSTED_XATTR_NAME,
+				    value_buf, sizeof(value_buf)),
+			   _ret == -1 && errno == ENODATA);
+		list_len = CHECK(
+			listxattr(file_template, list_buf, sizeof(list_buf)));
+		CHECK_WITH(memmem(list_buf, list_len, TRUSTED_XATTR_NAME,
+				  sizeof(TRUSTED_XATTR_NAME)),
+			   _ret == NULL);
+		errno = 0;
+		CHECK_WITH(removexattr(file_template, TRUSTED_XATTR_NAME),
+			   _ret == -1 && errno == EPERM);
+
+		CHECK(close(file));
+		CHECK(unlink(file_template));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/lsm/Makefile
+++ b/test/initramfs/src/regression/security/lsm/Makefile
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
+SUBDIRS := \
+	aster_mac \
+
 include ../../common/Makefile

--- a/test/initramfs/src/regression/security/lsm/aster_mac/Makefile
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../../common/Makefile

--- a/test/initramfs/src/regression/security/lsm/aster_mac/exec_probe.c
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/exec_probe.c
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+int main(void)
+{
+	return 0;
+}

--- a/test/initramfs/src/regression/security/lsm/aster_mac/label_probe.c
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/label_probe.c
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CURRENT_LABEL_FILE "/proc/self/attr/current"
+
+static int read_current_label(char *buffer, size_t buffer_len)
+{
+	if (buffer_len == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	int fd = open(CURRENT_LABEL_FILE, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	ssize_t read_len = read(fd, buffer, buffer_len - 1);
+	int saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (read_len < 0) {
+		return -1;
+	}
+
+	buffer[read_len] = '\0';
+	buffer[strcspn(buffer, "\n")] = '\0';
+	return 0;
+}
+
+static int expect_child_label(const char *expected)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+
+	if (pid == 0) {
+		char label[128];
+		if (read_current_label(label, sizeof(label)) < 0) {
+			_exit(10);
+		}
+		_exit(strcmp(label, expected) == 0 ? 0 : 11);
+	}
+
+	int status = 0;
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+		return 0;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <expected-label>\n", argv[0]);
+		return 2;
+	}
+
+	char label[128];
+	if (read_current_label(label, sizeof(label)) < 0) {
+		perror("read_current_label");
+		return 3;
+	}
+	if (strcmp(label, argv[1]) != 0) {
+		fprintf(stderr, "label mismatch: got %s, expected %s\n", label, argv[1]);
+		return 4;
+	}
+
+	if (expect_child_label(argv[1]) < 0) {
+		perror("expect_child_label");
+		return 5;
+	}
+
+	return 0;
+}

--- a/test/initramfs/src/regression/security/lsm/aster_mac/label_state.c
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/label_state.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include "../../../common/test.h"
+
+#define CURRENT_LABEL_FILE "/proc/self/attr/current"
+#define LABEL_PROBE_SOURCE "/test/security/lsm/aster_mac/label_probe"
+#define LABEL_PROBE "/tmp/aster_mac_label_probe"
+
+static void copy_file(const char *source, const char *destination)
+{
+	int in_fd = CHECK(open(source, O_RDONLY));
+	int out_fd = CHECK(open(destination, O_CREAT | O_WRONLY | O_TRUNC, 0700));
+	char buffer[4096];
+
+	for (;;) {
+		ssize_t read_len = CHECK(read(in_fd, buffer, sizeof(buffer)));
+		if (read_len == 0) {
+			break;
+		}
+		CHECK(write(out_fd, buffer, read_len));
+	}
+
+	CHECK(close(in_fd));
+	CHECK(close(out_fd));
+	CHECK(chmod(destination, 0700));
+}
+
+static void clear_label_xattr(const char *path)
+{
+	if (removexattr(path, "security.aster_mac.label") == 0 || errno == ENODATA) {
+		return;
+	}
+
+	perror("removexattr");
+	exit(EXIT_FAILURE);
+}
+
+static int read_current_label(char *buffer, size_t buffer_len)
+{
+	if (buffer_len == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	int fd = open(CURRENT_LABEL_FILE, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	ssize_t read_len = read(fd, buffer, buffer_len - 1);
+	int saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (read_len < 0) {
+		return -1;
+	}
+
+	buffer[read_len] = '\0';
+	buffer[strcspn(buffer, "\n")] = '\0';
+	return 0;
+}
+
+static int expect_exec_label(const char *expected)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+
+	if (pid == 0) {
+		execl(LABEL_PROBE, LABEL_PROBE, expected, NULL);
+		_exit(100);
+	}
+
+	int status = 0;
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+		errno = 0;
+		return 0;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+FN_SETUP(prepare_label_probe)
+{
+	copy_file(LABEL_PROBE_SOURCE, LABEL_PROBE);
+	clear_label_xattr(LABEL_PROBE);
+}
+END_SETUP()
+
+FN_TEST(default_task_label_is_visible)
+{
+	char label[128];
+
+	TEST_RES(read_current_label(label, sizeof(label)),
+		 _ret == 0 && strcmp(label, "unconfined") == 0);
+}
+END_TEST()
+
+FN_TEST(exec_transition_updates_current_label)
+{
+	static const char exec_label[] = "domain.exec";
+
+	TEST_SUCC(setxattr(LABEL_PROBE, "security.aster_mac.label", exec_label,
+			   strlen(exec_label), 0));
+	TEST_SUCC(expect_exec_label(exec_label));
+	TEST_SUCC(removexattr(LABEL_PROBE, "security.aster_mac.label"));
+	TEST_SUCC(expect_exec_label("unconfined"));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/lsm/aster_mac/xattr_policy.c
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/xattr_policy.c
@@ -132,13 +132,11 @@ FN_TEST(open_xattr_blocks_o_path_open)
 }
 END_TEST()
 
-FN_TEST(read_xattr_blocks_access_and_open)
+FN_TEST(read_xattr_blocks_read_open)
 {
 	TEST_SUCC(set_policy_xattr(POLICY_FILE, "security.aster_mac.read", "1"));
-	TEST_ERRNO(access(POLICY_FILE, R_OK), EACCES);
 	TEST_ERRNO(open(POLICY_FILE, O_RDONLY), EACCES);
 	TEST_SUCC(removexattr(POLICY_FILE, "security.aster_mac.read"));
-	TEST_SUCC(access(POLICY_FILE, R_OK));
 	int fd = TEST_RES(open(POLICY_FILE, O_RDONLY), _ret >= 0);
 	if (fd >= 0) {
 		TEST_SUCC(close(fd));
@@ -146,13 +144,11 @@ FN_TEST(read_xattr_blocks_access_and_open)
 }
 END_TEST()
 
-FN_TEST(write_xattr_blocks_access_and_open)
+FN_TEST(write_xattr_blocks_write_open)
 {
 	TEST_SUCC(set_policy_xattr(POLICY_FILE, "security.aster_mac.write", "1"));
-	TEST_ERRNO(access(POLICY_FILE, W_OK), EACCES);
 	TEST_ERRNO(open(POLICY_FILE, O_WRONLY), EACCES);
 	TEST_SUCC(removexattr(POLICY_FILE, "security.aster_mac.write"));
-	TEST_SUCC(access(POLICY_FILE, W_OK));
 	int fd = TEST_RES(open(POLICY_FILE, O_WRONLY), _ret >= 0);
 	if (fd >= 0) {
 		TEST_SUCC(close(fd));

--- a/test/initramfs/src/regression/security/lsm/aster_mac/xattr_policy.c
+++ b/test/initramfs/src/regression/security/lsm/aster_mac/xattr_policy.c
@@ -1,0 +1,170 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include "../../../common/test.h"
+
+#define POLICY_FILE "/tmp/aster_mac_open_target"
+#define EXEC_PROBE_SOURCE "/test/security/lsm/aster_mac/exec_probe"
+#define EXEC_PROBE "/tmp/aster_mac_exec_probe"
+
+static void copy_file(const char *source, const char *destination)
+{
+	int in_fd = CHECK(open(source, O_RDONLY));
+	int out_fd = CHECK(open(destination, O_CREAT | O_WRONLY | O_TRUNC, 0700));
+	char buffer[4096];
+
+	for (;;) {
+		ssize_t read_len = CHECK(read(in_fd, buffer, sizeof(buffer)));
+		if (read_len == 0) {
+			break;
+		}
+		CHECK(write(out_fd, buffer, read_len));
+	}
+
+	CHECK(close(in_fd));
+	CHECK(close(out_fd));
+	CHECK(chmod(destination, 0700));
+}
+
+static void clear_policy_xattr(const char *path, const char *name)
+{
+	if (removexattr(path, name) == 0 || errno == ENODATA) {
+		return;
+	}
+
+	perror("removexattr");
+	exit(EXIT_FAILURE);
+}
+
+static int set_policy_xattr(const char *path, const char *name, const char *value)
+{
+	return setxattr(path, name, value, strlen(value), 0);
+}
+
+static int expect_exec_denied(void)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+
+	if (pid == 0) {
+		execl(EXEC_PROBE, EXEC_PROBE, NULL);
+		_exit(errno == EACCES ? 100 : 101);
+	}
+
+	int status = 0;
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 100) {
+		errno = EACCES;
+		return -1;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+static int expect_exec_allowed(void)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+
+	if (pid == 0) {
+		execl(EXEC_PROBE, EXEC_PROBE, NULL);
+		_exit(111);
+	}
+
+	int status = 0;
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+		return 0;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+FN_SETUP(prepare_policy_target)
+{
+	copy_file(EXEC_PROBE_SOURCE, EXEC_PROBE);
+
+	int fd = CHECK(open(POLICY_FILE, O_CREAT | O_RDWR | O_TRUNC, 0700));
+	const char payload[] = "aster-lsm";
+	CHECK(write(fd, payload, sizeof(payload) - 1));
+	CHECK(close(fd));
+
+	clear_policy_xattr(POLICY_FILE, "security.aster_mac.open");
+	clear_policy_xattr(POLICY_FILE, "security.aster_mac.read");
+	clear_policy_xattr(POLICY_FILE, "security.aster_mac.write");
+	clear_policy_xattr(EXEC_PROBE, "security.aster_mac.exec");
+}
+END_SETUP()
+
+FN_TEST(open_xattr_blocks_o_path_open)
+{
+	TEST_SUCC(set_policy_xattr(POLICY_FILE, "security.aster_mac.open", "1"));
+	TEST_ERRNO(open(POLICY_FILE, O_PATH), EACCES);
+	TEST_SUCC(removexattr(POLICY_FILE, "security.aster_mac.open"));
+	int fd = TEST_RES(open(POLICY_FILE, O_PATH), _ret >= 0);
+	if (fd >= 0) {
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(read_xattr_blocks_access_and_open)
+{
+	TEST_SUCC(set_policy_xattr(POLICY_FILE, "security.aster_mac.read", "1"));
+	TEST_ERRNO(access(POLICY_FILE, R_OK), EACCES);
+	TEST_ERRNO(open(POLICY_FILE, O_RDONLY), EACCES);
+	TEST_SUCC(removexattr(POLICY_FILE, "security.aster_mac.read"));
+	TEST_SUCC(access(POLICY_FILE, R_OK));
+	int fd = TEST_RES(open(POLICY_FILE, O_RDONLY), _ret >= 0);
+	if (fd >= 0) {
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(write_xattr_blocks_access_and_open)
+{
+	TEST_SUCC(set_policy_xattr(POLICY_FILE, "security.aster_mac.write", "1"));
+	TEST_ERRNO(access(POLICY_FILE, W_OK), EACCES);
+	TEST_ERRNO(open(POLICY_FILE, O_WRONLY), EACCES);
+	TEST_SUCC(removexattr(POLICY_FILE, "security.aster_mac.write"));
+	TEST_SUCC(access(POLICY_FILE, W_OK));
+	int fd = TEST_RES(open(POLICY_FILE, O_WRONLY), _ret >= 0);
+	if (fd >= 0) {
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(exec_xattr_blocks_execve)
+{
+	TEST_SUCC(set_policy_xattr(EXEC_PROBE, "security.aster_mac.exec", "1"));
+	TEST_ERRNO(expect_exec_denied(), EACCES);
+	TEST_SUCC(removexattr(EXEC_PROBE, "security.aster_mac.exec"));
+	TEST_SUCC(expect_exec_allowed());
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/lsm/module_selection.c
+++ b/test/initramfs/src/regression/security/lsm/module_selection.c
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <ctype.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define CMDLINE_BUFFER_SIZE 4096
+
+static const char *CMDLINE_PATH = "/proc/cmdline";
+static const char *CAP_LAST_CAP_PATH = "/proc/sys/kernel/cap_last_cap";
+static const char *YAMA_DIR_PATH = "/proc/sys/kernel/yama";
+static const char *YAMA_PTRACE_SCOPE_PATH =
+	"/proc/sys/kernel/yama/ptrace_scope";
+
+static void read_cmdline(char cmdline[CMDLINE_BUFFER_SIZE])
+{
+	int fd = CHECK(open(CMDLINE_PATH, O_RDONLY));
+	ssize_t len = CHECK(read(fd, cmdline, CMDLINE_BUFFER_SIZE - 1));
+
+	cmdline[len] = '\0';
+	CHECK(close(fd));
+}
+
+static char *trim(char *string)
+{
+	char *end;
+
+	while (isspace((unsigned char)*string)) {
+		string++;
+	}
+
+	end = string + strlen(string);
+	while (end > string && isspace((unsigned char)*(end - 1))) {
+		end--;
+	}
+	*end = '\0';
+
+	return string;
+}
+
+static bool find_last_lsm_param(char value[CMDLINE_BUFFER_SIZE])
+{
+	char cmdline[CMDLINE_BUFFER_SIZE];
+	char *saveptr = NULL;
+	bool found = false;
+
+	read_cmdline(cmdline);
+	for (char *token = strtok_r(cmdline, " \n", &saveptr); token;
+	     token = strtok_r(NULL, " \n", &saveptr)) {
+		if (strncmp(token, "lsm=", strlen("lsm=")) != 0) {
+			continue;
+		}
+
+		CHECK_WITH(snprintf(value, CMDLINE_BUFFER_SIZE, "%s",
+				    token + strlen("lsm=")),
+			   _ret >= 0 && _ret < CMDLINE_BUFFER_SIZE);
+		found = true;
+	}
+
+	return found;
+}
+
+static bool module_list_contains(const char *list, const char *module_name)
+{
+	char list_copy[CMDLINE_BUFFER_SIZE];
+	char *saveptr = NULL;
+
+	CHECK_WITH(snprintf(list_copy, sizeof(list_copy), "%s", list),
+		   _ret >= 0 && _ret < (int)sizeof(list_copy));
+	for (char *module = strtok_r(list_copy, ",", &saveptr); module;
+	     module = strtok_r(NULL, ",", &saveptr)) {
+		if (strcmp(trim(module), module_name) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool expect_yama_enabled(void)
+{
+	char lsm_param[CMDLINE_BUFFER_SIZE] = "";
+
+	if (!find_last_lsm_param(lsm_param)) {
+		return true;
+	}
+
+	return module_list_contains(lsm_param, "yama");
+}
+
+FN_TEST(capability_static_procfs_entry_is_visible)
+{
+	int fd = TEST_SUCC(open(CAP_LAST_CAP_PATH, O_RDONLY));
+
+	if (fd >= 0) {
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(yama_procfs_visibility_follows_lsm_selection)
+{
+	bool expect_yama = expect_yama_enabled();
+	struct stat statbuf;
+
+	if (expect_yama) {
+		TEST_RES(stat(YAMA_DIR_PATH, &statbuf),
+			 S_ISDIR(statbuf.st_mode));
+		int fd = TEST_SUCC(open(YAMA_PTRACE_SCOPE_PATH, O_RDONLY));
+		if (fd >= 0) {
+			TEST_SUCC(close(fd));
+		}
+	} else {
+		TEST_ERRNO(stat(YAMA_DIR_PATH, &statbuf), ENOENT);
+		TEST_ERRNO(open(YAMA_PTRACE_SCOPE_PATH, O_RDONLY), ENOENT);
+	}
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-./capability/capabilities
-./capability/capset
-./capability/execve
+cd "$(dirname "$0")"
+
+sh ./capability/run_test.sh
 
 ./lsm/yama
 

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -8,6 +8,7 @@ cd "$(dirname "$0")"
 
 sh ./capability/run_test.sh
 
+./lsm/module_selection
 ./lsm/yama
 
 ./namespace/cgroup_ns

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -10,6 +10,10 @@ sh ./capability/run_test.sh
 
 ./lsm/module_selection
 ./lsm/yama
+if [ -r /proc/self/attr/current ]; then
+	./lsm/aster_mac/label_state
+	./lsm/aster_mac/xattr_policy
+fi
 
 ./namespace/cgroup_ns
 ./namespace/ipc_ns_sem


### PR DESCRIPTION
## Summary

This PR adds `aster_mac`, a minimal legacy-major LSM module used to validate the current LSM framework for future major MAC policy modules.

This is opened as a draft PR for early design review. It is not ready for merge.

This PR is stacked on the capability/LSM selector work and should be reviewed after that groundwork is accepted.

It intentionally keeps the policy small and xattr-driven, while exercising the core landing path for a larger MAC module:
- module registration and boot-time selection
- new `bprm`, `file_open`, and `inode_permission` hook plumbing
- per-credential task label state
- cached inode security state
- `/proc/[pid]/attr/current` exposure
- regression coverage through `AUTO_TEST=aster-mac`

## Details

`aster_mac` supports a small set of `security.aster_mac.*` xattrs:

- `security.aster_mac.label`
- `security.aster_mac.open`
- `security.aster_mac.read`
- `security.aster_mac.write`
- `security.aster_mac.exec`

The module is marked as a legacy major/exclusive LSM so it can be selected through the existing LSM selector path.
