### PR TITLE
Complete `/proc/pid/stat` output for ps compatibility

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::Ordering;
+use core::{sync::atomic::Ordering, time::Duration};
 
 use aster_util::printer::VmPrinter;
+use ostd::timer::TIMER_FREQ;
 
 use super::{super::PidDirOps, TidDirOps};
 use crate::{
@@ -12,7 +13,12 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::posix_thread::{AsPosixThread, SleepingState},
+    process::{
+        Process, ResourceType,
+        posix_thread::{AsPosixThread, SleepingState},
+        signal::{HandlePendingSignal, sig_action::SigAction, sig_mask::SigMask},
+    },
+    sched::{LinuxSchedPolicy, RealTimePriority, SchedPolicy},
     thread::Thread,
     vm::vmar::RssType,
 };
@@ -42,16 +48,17 @@ use crate::{
 /// - stime            : Time spent in kernel mode (clock ticks).
 /// - cutime           : Child processes' user mode time.
 /// - cstime           : Child processes' kernel mode time.
-/// - priority         : Process priority or nice value.
+/// - priority         : Kernel scheduling priority.
 /// - nice             : Nice value (-20 to 19; lower is higher priority).
 /// - num_threads      : Number of threads.
+/// - itrealvalue      : Time before the next `SIGALRM`.
 /// - starttime        : Process start time since boot (clock ticks).
 /// - vsize            : Virtual memory size (bytes).
 /// - rss              : Resident Set Size (pages in real memory).
 /// - rsslim           : Soft memory limit (bytes).
 /// - startcode        : Start address of executable code.
 /// - endcode          : End address of executable code.
-/// - startstack       : Bottom address of process stack.
+/// - startstack       : Initial top address of process stack.
 /// - kstkesp          : Current stack pointer (ESP).
 /// - kstkeip          : Current instruction pointer (EIP).
 /// - signal           : Bitmap of pending signals.
@@ -159,7 +166,9 @@ impl ProcFileOps for StatFileOps {
             (0, -1)
         };
 
+        // Placeholder: kernel flags are not exposed yet.
         let flags = 0;
+        // Placeholder: page-fault counters are not tracked per process/thread yet.
         let min_flt = 0;
         let cmin_flt = 0;
         let maj_flt = 0;
@@ -176,28 +185,107 @@ impl ProcFileOps for StatFileOps {
             )
         };
 
-        let cutime = 0;
-        let cstime = 0;
-        let priority = 0;
+        let (cutime, cstime) = {
+            let (user_time, kernel_time) = process.reaped_children_stats().lock().get();
+            (
+                duration_to_jiffies(user_time),
+                duration_to_jiffies(kernel_time),
+            )
+        };
+
+        let (priority, rt_priority, policy) = sched_values(&thread);
         let nice = process.nice().load(Ordering::Relaxed).value().get();
         let num_threads = process.tasks().lock().as_slice().len();
-        let itrealvalue = 0;
-        let starttime = 0;
+        let itrealvalue =
+            duration_to_jiffies(process.timer_manager().alarm_timer().lock().remain());
+        let starttime = process.start_time().as_u64();
 
-        let (vsize, rss) = if let Some(vmar_ref) = process.lock_vmar().as_ref() {
+        let (
+            vsize,
+            rss,
+            startcode,
+            endcode,
+            startstack,
+            start_data,
+            end_data,
+            start_brk,
+            arg_start,
+            arg_end,
+            env_start,
+            env_end,
+        ) = if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
             let anon = vmar_ref.get_rss_counter(RssType::Anon);
             let file = vmar_ref.get_rss_counter(RssType::File);
             let rss = anon + file;
-            (vsize, rss)
+            let process_vm = vmar_ref.process_vm();
+            let code_range = process_vm.code_range();
+            let data_range = process_vm.data_range();
+            let init_stack = process_vm.init_stack();
+            let argv_range = init_stack.argv_range();
+            let envp_range = init_stack.envp_range();
+            let start_brk = process_vm.heap().lock().heap_low();
+
+            (
+                vsize,
+                rss,
+                code_range.start,
+                code_range.end,
+                init_stack.user_stack_top(),
+                data_range.start,
+                data_range.end,
+                start_brk,
+                argv_range.start,
+                argv_range.end,
+                envp_range.start,
+                envp_range.end,
+            )
         } else {
-            (0, 0)
+            (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        };
+
+        let rsslim = process
+            .resource_limits()
+            .get_rlimit(ResourceType::RLIMIT_RSS)
+            .get_cur();
+
+        // Placeholder: saved SP/IP and wait-channel addresses are not exposed by `Thread`.
+        let kstkesp = 0;
+        let kstkeip = 0;
+        let wchan = 0;
+
+        let signal = u64::from(posix_thread.pending_signals());
+        let blocked = u64::from(posix_thread.sig_mask());
+        let (sigignore, sigcatch) = signal_disposition_masks(&process);
+
+        // Placeholder: swap accounting is not implemented yet.
+        let nswap = 0;
+        let cnswap = 0;
+
+        let exit_signal = process
+            .exit_signal()
+            .map(|sig_num| sig_num.as_u8() as i32)
+            .unwrap_or(0);
+        let processor = thread
+            .sched_attr()
+            .last_cpu()
+            .map(|cpu| u32::from(cpu) as usize)
+            .unwrap_or(0);
+
+        // Placeholder: block I/O delay and guest-time accounting are not implemented yet.
+        let delayacct_blkio_ticks = 0;
+        let guest_time = 0;
+        let cguest_time = 0;
+
+        let exit_code = match self.mode {
+            StatMode::Process => process.status().exit_code(),
+            StatMode::Thread => posix_thread.exit_code(),
         };
 
         let mut printer = VmPrinter::new_skip(writer, offset);
         writeln!(
             printer,
-            "{} ({}) {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
+            "{} ({}) {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
             pid,
             comm,
             state,
@@ -221,9 +309,104 @@ impl ProcFileOps for StatFileOps {
             itrealvalue,
             starttime,
             vsize,
-            rss
+            rss,
+            rsslim,
+            startcode,
+            endcode,
+            startstack,
+            kstkesp,
+            kstkeip,
+            signal,
+            blocked,
+            sigignore,
+            sigcatch,
+            wchan,
+            nswap,
+            cnswap,
+            exit_signal,
+            processor,
+            rt_priority,
+            policy,
+            delayacct_blkio_ticks,
+            guest_time,
+            cguest_time,
+            start_data,
+            end_data,
+            start_brk,
+            arg_start,
+            arg_end,
+            env_start,
+            env_end,
+            exit_code
         )?;
 
         Ok(printer.bytes_written())
     }
+}
+
+/// Converts a duration into kernel clock ticks.
+fn duration_to_jiffies(duration: Duration) -> u64 {
+    const NSEC_PER_SEC: u64 = 1_000_000_000;
+    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC / TIMER_FREQ;
+    const { assert!(NSEC_PER_SEC.is_multiple_of(TIMER_FREQ)) };
+
+    let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
+    let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;
+    sec_jiffies.saturating_add(subsec_jiffies)
+}
+
+/// Returns the `priority`, `rt_priority`, and `policy` values for `/proc/<pid>/stat`.
+fn sched_values(thread: &Thread) -> (i32, u8, i32) {
+    const MAX_RT_PRIORITY: u8 = RealTimePriority::MAX.get();
+    const RT_PRIORITY_LIMIT: u8 = MAX_RT_PRIORITY + 1;
+    const NICE_TO_PRIORITY_OFFSET: i32 = 20;
+
+    let policy = thread.sched_attr().policy();
+
+    let (priority, rt_priority) = match policy {
+        SchedPolicy::Stop => (-i32::from(MAX_RT_PRIORITY) - 1, MAX_RT_PRIORITY),
+        SchedPolicy::RealTime { rt_prio, .. } => {
+            // `SchedPolicy` stores real-time priorities in the scheduler's
+            // internal order, where smaller values have higher priority.
+            // This is the reverse of Linux's user-visible RT priority
+            // used by `/proc/<pid>/stat`.
+            // For example, an internal RT priority of 1 is reported as 99.
+            // FIXME: Use the same conversion helper (i.e., `rt_to_static`)
+            // as the `sched*` syscalls once it is available outside the
+            // `syscall` module.
+            let rt_priority = RT_PRIORITY_LIMIT - rt_prio.get();
+            (-i32::from(rt_priority) - 1, rt_priority)
+        }
+        SchedPolicy::Fair(nice) => (NICE_TO_PRIORITY_OFFSET + nice.value().get() as i32, 0),
+        SchedPolicy::Idle => (NICE_TO_PRIORITY_OFFSET, 0),
+    };
+    let linux_policy = LinuxSchedPolicy::from(policy);
+
+    (priority, rt_priority, linux_policy as i32)
+}
+
+/// Returns the ignored and caught standard-signal masks for `/proc/<pid>/stat`.
+fn signal_disposition_masks(process: &Process) -> (u64, u64) {
+    let dispositions = process.sig_dispositions().lock();
+    let dispositions = dispositions.lock();
+    let mut ignored = 0_u64;
+    let mut caught = 0_u64;
+
+    for (sig_num, sig_action) in dispositions.iter() {
+        // Linux only exposes standard signals in `sigignore` and `sigcatch`.
+        if !sig_num.is_std() {
+            break;
+        }
+
+        let bit = u64::from(SigMask::from(sig_num));
+        match sig_action {
+            SigAction::Dfl => {}
+            // `sigignore` tracks explicitly ignored signals, while `sigcatch` tracks
+            // signals with user-registered handlers.
+            SigAction::Ign => ignored |= bit,
+            SigAction::User { .. } => caught |= bit,
+        }
+    }
+
+    (ignored, caught)
 }

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -5,6 +5,8 @@ use core::{
     time::Duration,
 };
 
+use ostd::timer::Jiffies;
+
 use self::timer_manager::PosixTimerManager;
 use super::{
     pid_table::{self, PidTable},
@@ -124,7 +126,6 @@ pub struct Process {
     /// Instead of letting the init process to reap all orphan zombie processes,
     /// a subreaper can reap orphan zombie processes among its descendants.
     is_child_subreaper: AtomicBool,
-
     /// Whether the process has a subreaper that will reap it when the
     /// process becomes orphaned.
     ///
@@ -139,15 +140,16 @@ pub struct Process {
     sig_queues: SigQueues,
     /// The signal that the process should receive when parent process exits.
     parent_death_signal: AtomicSigNum,
-
     /// The signal that should be sent to the parent when this process exits.
     exit_signal: AtomicSigNum,
 
+    // Time
     /// A profiling clock measures the user CPU time and kernel CPU time of the current process.
     prof_clock: Arc<ProfClock>,
-
     /// A manager that manages timer resources and utilities of the process.
     timer_manager: PosixTimerManager,
+    /// Process start time since boot.
+    start_time: Jiffies,
 
     // Namespaces
     /// The user namespace
@@ -262,6 +264,7 @@ impl Process {
             oom_score_adj: AtomicI16::new(oom_score_adj),
             timer_manager: PosixTimerManager::new(&prof_clock, process_ref),
             prof_clock,
+            start_time: Jiffies::elapsed(),
             user_ns: Mutex::new(user_ns),
         })
     }
@@ -293,6 +296,11 @@ impl Process {
     /// Gets the timer resources and utilities of the process.
     pub fn timer_manager(&self) -> &PosixTimerManager {
         &self.timer_manager
+    }
+
+    /// Returns the process start time since boot.
+    pub fn start_time(&self) -> Jiffies {
+        self.start_time
     }
 
     pub fn tasks(&self) -> &Mutex<TaskSet> {

--- a/kernel/src/process/process_vm/heap.rs
+++ b/kernel/src/process/process_vm/heap.rs
@@ -149,6 +149,11 @@ impl Heap {
 }
 
 impl LockedHeap<'_> {
+    /// Returns the lowest address of the heap.
+    pub fn heap_low(&self) -> Vaddr {
+        self.heap_range().start
+    }
+
     /// Returns the current heap range.
     pub fn heap_range(&self) -> &Range<Vaddr> {
         let inner = self.inner.as_ref().expect("Heap is not initialized");

--- a/kernel/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/src/process/process_vm/init_stack/mod.rs
@@ -160,6 +160,16 @@ impl InitStack {
         self.pos()
     }
 
+    /// Returns the range that held the initial arguments.
+    pub fn argv_range(&self) -> Range<Vaddr> {
+        self.argv_range.lock().clone()
+    }
+
+    /// Returns the range that held the initial environment variables.
+    pub fn envp_range(&self) -> Range<Vaddr> {
+        self.envp_range.lock().clone()
+    }
+
     /// Maps the VMO of the init stack and constructs a writer to initialize its content.
     pub(super) fn map_and_write(
         &self,

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -12,6 +12,7 @@
 mod heap;
 mod init_stack;
 
+use core::ops::Range;
 #[cfg(target_arch = "riscv64")]
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -70,6 +71,10 @@ pub struct ProcessVm {
     init_stack: InitStack,
     /// The user heap
     heap: Heap,
+    /// The code range from the executable file.
+    code_range: SpinLock<Range<Vaddr>>,
+    /// The data range from the executable file.
+    data_range: SpinLock<Range<Vaddr>>,
     /// The executable file.
     executable_file: Path,
     /// The base address for vDSO segment
@@ -83,6 +88,8 @@ impl ProcessVm {
         Self {
             init_stack: InitStack::new(),
             heap: Heap::new_uninitialized(),
+            code_range: SpinLock::new(0..0),
+            data_range: SpinLock::new(0..0),
             executable_file,
             #[cfg(target_arch = "riscv64")]
             vdso_base: AtomicUsize::new(0),
@@ -94,6 +101,8 @@ impl ProcessVm {
         Self {
             init_stack: process_vm.init_stack.clone(),
             heap: Heap::fork_from(heap_guard),
+            code_range: SpinLock::new(process_vm.code_range.lock().clone()),
+            data_range: SpinLock::new(process_vm.data_range.lock().clone()),
             executable_file: process_vm.executable_file.clone(),
             #[cfg(target_arch = "riscv64")]
             vdso_base: AtomicUsize::new(process_vm.vdso_base.load(Ordering::Relaxed)),
@@ -108,6 +117,16 @@ impl ProcessVm {
     /// Returns the user heap.
     pub fn heap(&self) -> &Heap {
         &self.heap
+    }
+
+    /// Returns the code range from the executable file.
+    pub fn code_range(&self) -> Range<Vaddr> {
+        self.code_range.lock().clone()
+    }
+
+    /// Returns the data range from the executable file.
+    pub fn data_range(&self) -> Range<Vaddr> {
+        self.data_range.lock().clone()
     }
 
     /// Returns a reference to the executable `Path`.
@@ -135,6 +154,16 @@ impl ProcessVm {
     ) -> Result<()> {
         self.heap()
             .map_and_init_heap(vmar, data_segment_size, heap_base)
+    }
+
+    /// Updates the code range from the executable file.
+    pub(super) fn set_code_range(&self, range: Range<Vaddr>) {
+        *self.code_range.lock() = range;
+    }
+
+    /// Updates the data range from the executable file.
+    pub(super) fn set_data_range(&self, range: Range<Vaddr>) {
+        *self.data_range.lock() = range;
     }
 
     /// Returns the base address for vDSO segment.

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -2,6 +2,8 @@
 
 //! ELF file parser.
 
+use core::ops::Range;
+
 use align_ext::AlignExt;
 
 use super::{
@@ -61,6 +63,10 @@ pub fn load_elf_to_vmar(
     )]
     let (elf_mapped_info, entry_point, mut aux_vec) =
         map_vmos_and_build_aux_vec(vmar, ldso, &elf_headers, &elf_file)?;
+    vmar.process_vm()
+        .set_code_range(elf_mapped_info.code_range.clone());
+    vmar.process_vm()
+        .set_data_range(elf_mapped_info.data_range.clone());
 
     // Map the vDSO and set the entry.
     // Since the vDSO does not require being mapped to any specific address,
@@ -76,7 +82,7 @@ pub fn load_elf_to_vmar(
         .map_and_write_init_stack(vmar, argv, envp, aux_vec)?;
     vmar.process_vm().map_and_init_heap(
         vmar,
-        elf_mapped_info.data_segment_size,
+        elf_mapped_info.data_range.len(),
         elf_mapped_info.heap_base,
     )?;
 
@@ -205,8 +211,10 @@ fn load_ldso(vmar: &Vmar, ldso_file: &Path, ldso_elf: &ElfHeaders) -> Result<Lds
 struct ElfMappedInfo {
     /// The range covering all the mapped segments.
     full_range: RelocatedRange,
-    /// The size of the data segment.
-    data_segment_size: usize,
+    /// The executable code range after relocation.
+    code_range: Range<Vaddr>,
+    /// The data range after relocation.
+    data_range: Range<Vaddr>,
     /// The base address for the heap start.
     heap_base: Vaddr,
 }
@@ -333,14 +341,34 @@ fn map_segment_vmos(
         map_segment_vmo(loadable_phdr, elf_file, vmar, map_at)?;
     }
 
-    // Calculate the data segment size.
-    // According to Linux behavior, the data segment only includes the last loadable segment.
+    // The code range spans all executable loadable segments after relocation.
+    let code_range = elf
+        .loadable_phdrs()
+        .iter()
+        .filter(|phdr| phdr.vm_perms().contains(VmPerms::EXEC))
+        .map(|phdr| {
+            let range = phdr.virt_range();
+            let start = relocated_range
+                .relocated_addr_of(range.start)
+                .expect("`calc_total_vaddr_bounds()` should cover all segments");
+            start..(start + range.len())
+        })
+        .reduce(|acc_range, range| acc_range.start.min(range.start)..acc_range.end.max(range.end))
+        .unwrap_or(0..0);
+
+    // According to Linux behavior, the data range only includes the last loadable segment.
     // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/binfmt_elf.c#L1200-L1227>
-    let data_segment_size = elf.find_last_vaddr_bound().map_or(0, |range| range.len());
+    let data_range = elf.find_last_vaddr_bound().map_or(0..0, |range| {
+        let start = relocated_range
+            .relocated_addr_of(range.start)
+            .expect("`calc_total_vaddr_bounds()` should cover all segments");
+        start..(start + range.len())
+    });
 
     Ok(ElfMappedInfo {
         full_range: relocated_range,
-        data_segment_size,
+        code_range,
+        data_range,
         heap_base: heap_base.unwrap_or(map_range.end),
     })
 }

--- a/kernel/src/process/signal/sig_disposition.rs
+++ b/kernel/src/process/signal/sig_disposition.rs
@@ -30,6 +30,17 @@ impl SigDispositions {
         self.map[idx]
     }
 
+    /// Returns all signal dispositions in ascending signal-number order.
+    ///
+    /// The iterator covers standard and real-time signals.
+    pub fn iter(&self) -> impl Iterator<Item = (SigNum, SigAction)> + '_ {
+        self.map.iter().enumerate().map(|(idx, sig_action)| {
+            let sig_num = MIN_STD_SIG_NUM + idx as u8;
+
+            (SigNum::from_u8(sig_num), *sig_action)
+        })
+    }
+
     pub fn set(&mut self, num: SigNum, sa: SigAction) -> Result<SigAction> {
         check_sigaction(&sa)?;
         let idx = Self::num_to_idx(num);

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -7,7 +7,8 @@ mod stats;
 pub use self::{
     nice::{AtomicNice, Nice},
     sched_class::{
-        RealTimePolicy, RealTimePriority, SchedAttr, SchedPolicy, init, init_on_each_cpu,
+        LinuxSchedPolicy, RealTimePolicy, RealTimePriority, SchedAttr, SchedPolicy, init,
+        init_on_each_cpu,
     },
     stats::{loadavg, nr_queued_and_running},
 };

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -38,7 +38,7 @@ mod stop;
 
 use self::policy::{SchedPolicyKind, SchedPolicyState};
 pub use self::{
-    policy::SchedPolicy,
+    policy::{LinuxSchedPolicy, SchedPolicy},
     real_time::{RealTimePolicy, RealTimePriority},
 };
 
@@ -207,7 +207,7 @@ impl SchedAttr {
         })
     }
 
-    fn last_cpu(&self) -> Option<CpuId> {
+    pub fn last_cpu(&self) -> Option<CpuId> {
         self.last_cpu.get()
     }
 

--- a/kernel/src/sched/sched_class/policy.rs
+++ b/kernel/src/sched/sched_class/policy.rs
@@ -30,6 +30,43 @@ impl Default for SchedPolicy {
     }
 }
 
+/// The Linux scheduling policy code.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.17.7/source/include/uapi/linux/sched.h#L112>.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, TryFromInt)]
+pub enum LinuxSchedPolicy {
+    Normal = 0,
+    Fifo = 1,
+    RoundRobin = 2,
+    Batch = 3, // Not supported.
+    Iso = 4,   // Reserved but not implemented yet on Linux.
+    Idle = 5,
+    Deadline = 6, // Not supported.
+    Ext = 7,      // Not supported.
+}
+
+/// Projects internal scheduling policies onto Linux's user-visible policy codes.
+///
+/// This projection is many-to-one: `Stop` is reported as `Fifo`, and the
+/// kernel-only `Idle` policy is reported as `Normal`.
+impl From<SchedPolicy> for LinuxSchedPolicy {
+    fn from(policy: SchedPolicy) -> Self {
+        match policy {
+            SchedPolicy::Stop => LinuxSchedPolicy::Fifo,
+            SchedPolicy::RealTime {
+                rt_policy: RealTimePolicy::Fifo,
+                ..
+            } => LinuxSchedPolicy::Fifo,
+            SchedPolicy::RealTime {
+                rt_policy: RealTimePolicy::RoundRobin { .. },
+                ..
+            } => LinuxSchedPolicy::RoundRobin,
+            SchedPolicy::Fair(_) | SchedPolicy::Idle => LinuxSchedPolicy::Normal,
+        }
+    }
+}
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, TryFromInt)]
 pub(super) enum SchedPolicyKind {

--- a/kernel/src/syscall/sched_get_priority_max.rs
+++ b/kernel/src/syscall/sched_get_priority_max.rs
@@ -3,7 +3,10 @@
 use core::ops::RangeInclusive;
 
 use super::SyscallReturn;
-use crate::{prelude::*, sched::RealTimePriority};
+use crate::{
+    prelude::*,
+    sched::{LinuxSchedPolicy, RealTimePriority},
+};
 
 pub(super) const fn rt_to_static(prio: RealTimePriority) -> u32 {
     (100 - prio.get()) as u32
@@ -19,20 +22,21 @@ pub(super) const fn static_to_rt(prio: u32) -> Result<RealTimePriority> {
 
 pub(super) const RT_PRIORITY_RANGE: RangeInclusive<u32> =
     rt_to_static(RealTimePriority::MAX)..=rt_to_static(RealTimePriority::MIN);
-pub(super) const SCHED_PRIORITY_RANGE: &[RangeInclusive<u32>] = &[
-    0..=0,             // SCHED_NORMAL
-    RT_PRIORITY_RANGE, // SCHED_FIFO
-    RT_PRIORITY_RANGE, // SCHED_RR
-    0..=0,             // SCHED_BATCH
-    0..=0,             // SCHED_ISO
-    0..=0,             // SCHED_IDLE
-    0..=0,             // SCHED_DEADLINE
-    0..=0,             // SCHED_EXT
-];
+
+pub(super) const fn sched_priority_range(policy: LinuxSchedPolicy) -> RangeInclusive<u32> {
+    match policy {
+        LinuxSchedPolicy::Fifo | LinuxSchedPolicy::RoundRobin => RT_PRIORITY_RANGE,
+        LinuxSchedPolicy::Normal
+        | LinuxSchedPolicy::Batch
+        | LinuxSchedPolicy::Iso
+        | LinuxSchedPolicy::Idle
+        | LinuxSchedPolicy::Deadline
+        | LinuxSchedPolicy::Ext => 0..=0,
+    }
+}
 
 pub fn sys_sched_get_priority_max(policy: u32, _: &Context) -> Result<SyscallReturn> {
-    let range = SCHED_PRIORITY_RANGE
-        .get(policy as usize)
-        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid scheduling policy"))?;
+    let linux_policy = LinuxSchedPolicy::try_from(policy)?;
+    let range = sched_priority_range(linux_policy);
     Ok(SyscallReturn::Return(*range.end() as isize))
 }

--- a/kernel/src/syscall/sched_get_priority_min.rs
+++ b/kernel/src/syscall/sched_get_priority_min.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{SyscallReturn, sched_get_priority_max::SCHED_PRIORITY_RANGE};
-use crate::prelude::*;
+use super::{SyscallReturn, sched_get_priority_max::sched_priority_range};
+use crate::{prelude::*, sched::LinuxSchedPolicy};
 
 pub fn sys_sched_get_priority_min(policy: u32, _: &Context) -> Result<SyscallReturn> {
-    let range = SCHED_PRIORITY_RANGE
-        .get(policy as usize)
-        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid scheduling policy"))?;
+    let linux_policy = LinuxSchedPolicy::try_from(policy)?;
+    let range = sched_priority_range(linux_policy);
     Ok(SyscallReturn::Return(*range.start() as isize))
 }

--- a/kernel/src/syscall/sched_getattr.rs
+++ b/kernel/src/syscall/sched_getattr.rs
@@ -4,24 +4,15 @@ use ostd::{const_assert, mm::VmIo};
 
 use super::{
     SyscallReturn,
-    sched_get_priority_max::{SCHED_PRIORITY_RANGE, rt_to_static, static_to_rt},
+    sched_get_priority_max::{rt_to_static, sched_priority_range, static_to_rt},
 };
 use crate::{
     prelude::*,
     process::pid_table,
-    sched::{Nice, RealTimePolicy, SchedAttr, SchedPolicy},
+    sched::{LinuxSchedPolicy, Nice, RealTimePolicy, SchedAttr, SchedPolicy},
     thread::Tid,
     util::CopyCompat,
 };
-
-pub(super) const SCHED_NORMAL: u32 = 0;
-pub(super) const SCHED_FIFO: u32 = 1;
-pub(super) const SCHED_RR: u32 = 2;
-// pub(super) const SCHED_BATCH: u32 = 3; // Not supported.
-// SCHED_ISO: Reserved but not implemented yet on Linux.
-pub(super) const SCHED_IDLE: u32 = 5;
-// pub(super) const SCHED_DEADLINE: u32 = 6; // Not supported.
-// pub(super) const SCHED_EXT: u32 = 7; // Not supported.
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
@@ -63,16 +54,16 @@ impl TryFrom<SchedPolicy> for LinuxSchedAttr {
     fn try_from(value: SchedPolicy) -> Result<Self> {
         Ok(match value {
             SchedPolicy::Stop => LinuxSchedAttr {
-                sched_policy: SCHED_FIFO,
+                sched_policy: LinuxSchedPolicy::Fifo as u32,
                 sched_priority: 99, // Linux uses 99 as the default priority for STOP tasks.
                 ..Default::default()
             },
 
             SchedPolicy::RealTime { rt_prio, rt_policy } => LinuxSchedAttr {
                 sched_policy: match rt_policy {
-                    RealTimePolicy::Fifo => SCHED_FIFO,
-                    RealTimePolicy::RoundRobin { .. } => SCHED_RR,
-                },
+                    RealTimePolicy::Fifo => LinuxSchedPolicy::Fifo,
+                    RealTimePolicy::RoundRobin { .. } => LinuxSchedPolicy::RoundRobin,
+                } as u32,
                 sched_priority: rt_to_static(rt_prio),
                 ..Default::default()
             },
@@ -81,12 +72,12 @@ impl TryFrom<SchedPolicy> for LinuxSchedAttr {
             // `SchedPolicy::Fair` instead of `SchedPolicy::Idle`. Tasks of the
             // latter policy are invisible to the user API.
             SchedPolicy::Fair(Nice::MAX) => LinuxSchedAttr {
-                sched_policy: SCHED_IDLE,
+                sched_policy: LinuxSchedPolicy::Idle as u32,
                 ..Default::default()
             },
 
             SchedPolicy::Fair(nice) => LinuxSchedAttr {
-                sched_policy: SCHED_NORMAL,
+                sched_policy: LinuxSchedPolicy::Normal as u32,
                 sched_nice: nice.value().get().into(),
                 ..Default::default()
             },
@@ -103,12 +94,14 @@ impl TryFrom<LinuxSchedAttr> for SchedPolicy {
     type Error = Error;
 
     fn try_from(value: LinuxSchedAttr) -> Result<Self> {
-        Ok(match value.sched_policy {
-            SCHED_FIFO | SCHED_RR => SchedPolicy::RealTime {
+        let linux_policy = LinuxSchedPolicy::try_from(value.sched_policy)?;
+
+        Ok(match linux_policy {
+            LinuxSchedPolicy::Fifo | LinuxSchedPolicy::RoundRobin => SchedPolicy::RealTime {
                 rt_prio: static_to_rt(value.sched_priority)?,
-                rt_policy: match value.sched_policy {
-                    SCHED_FIFO => RealTimePolicy::Fifo,
-                    SCHED_RR => RealTimePolicy::RoundRobin {
+                rt_policy: match linux_policy {
+                    LinuxSchedPolicy::Fifo => RealTimePolicy::Fifo,
+                    LinuxSchedPolicy::RoundRobin => RealTimePolicy::RoundRobin {
                         base_slice_factor: None,
                     },
                     _ => unreachable!(),
@@ -119,7 +112,7 @@ impl TryFrom<LinuxSchedAttr> for SchedPolicy {
                 return_errno_with_message!(Errno::EINVAL, "invalid scheduling priority")
             }
 
-            SCHED_NORMAL => SchedPolicy::Fair(Nice::new(
+            LinuxSchedPolicy::Normal => SchedPolicy::Fair(Nice::new(
                 i8::try_from(value.sched_nice)
                     .ok()
                     .and_then(|n| n.try_into().ok())
@@ -129,9 +122,14 @@ impl TryFrom<LinuxSchedAttr> for SchedPolicy {
             // The SCHED_IDLE policy is mapped to the highest nice value of
             // `SchedPolicy::Fair` instead of `SchedPolicy::Idle`. Tasks of the
             // latter policy are invisible to the user API.
-            SCHED_IDLE => SchedPolicy::Fair(Nice::MAX),
+            LinuxSchedPolicy::Idle => SchedPolicy::Fair(Nice::MAX),
 
-            _ => return_errno_with_message!(Errno::EINVAL, "invalid scheduling policy"),
+            LinuxSchedPolicy::Batch
+            | LinuxSchedPolicy::Iso
+            | LinuxSchedPolicy::Deadline
+            | LinuxSchedPolicy::Ext => {
+                return_errno_with_message!(Errno::EINVAL, "invalid scheduling policy")
+            }
         })
     }
 }
@@ -183,7 +181,9 @@ pub(super) fn write_linux_sched_attr_to_user(
 
     attr.size = (size_of::<LinuxSchedAttr>() as u32).min(user_size);
 
-    let range = &SCHED_PRIORITY_RANGE[attr.sched_policy as usize];
+    let linux_policy = LinuxSchedPolicy::try_from(attr.sched_policy)
+        .expect("all user-visible scheduling policies should be valid");
+    let range = sched_priority_range(linux_policy);
     attr.sched_util_min = *range.start();
     attr.sched_util_max = *range.end();
 

--- a/kernel/src/syscall/set_priority.rs
+++ b/kernel/src/syscall/set_priority.rs
@@ -35,6 +35,9 @@ pub fn sys_set_priority(which: i32, who: u32, prio: i32, ctx: &Context) -> Resul
         if new_nice < limit {
             return_errno!(Errno::EACCES);
         }
+        // FIXME: `setpriority` updates only the per-process nice value. Fair
+        // scheduler state is kept in each thread's `SchedPolicy::Fair`, so it
+        // should be updated from the same source of truth.
         process.nice().store(new_nice, Ordering::Relaxed);
     }
 


### PR DESCRIPTION
This PR fixes a ps compatibility issue I hit when running Asterinas as the kata guest kernel: running `ps` in the guest could trigger a segmentation fault because `/proc/[pid]/stat` was incomplete.

Previously, only a subset of the 52 `/proc/[pid]/stat` fields was implemented. This PR fills in the missing fields and also reviews the existing ones. Wherever the kernel can provide a real value, the field now uses it. Where no real value is available yet, the field remains `0` and is annotated with a comment to mark it as a placeholder.

The second commit is a cleanup commit that refactors some scheduler-related code by replacing the previously defined constants with the `LinuxSchedPolicy` enum.