### PR TITLE
Fix virtio-blk DMA sync for writes

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -440,7 +440,10 @@ impl DeviceInner {
                     .iter()
                     .map(|segment| segment.inner_dma_slice())
             });
-            inputs.extend(dma_slices_iter);
+            for dma_slice in dma_slices_iter {
+                dma_slice.sync_to_device().unwrap();
+                inputs.push(dma_slice);
+            }
             inputs
         };
 


### PR DESCRIPTION
In the virtio-blk write path, the code collected each BIO segment's `inner_dma_slice()` and directly passed those slices into the virtqueue descriptor chain.

That missed the contract of `DmaStream`: when the CPU updates a DMA buffer, `sync_to_device()` must be called before the device is notified to consume it.