### PR TITLE
Some small improvements for the terminal display

### DIFF
--- a/kernel/comps/framebuffer/src/ansi_escape.rs
+++ b/kernel/comps/framebuffer/src/ansi_escape.rs
@@ -394,7 +394,7 @@ impl EscapeFsm {
                 100..=107 => op.set_bg_color(COLORS[op_code as usize - 100 + 8]),
 
                 // Invalid or unsupported
-                _ => return,
+                _ => {}
             }
         }
     }

--- a/kernel/comps/framebuffer/src/ansi_escape.rs
+++ b/kernel/comps/framebuffer/src/ansi_escape.rs
@@ -20,6 +20,17 @@ pub(super) enum EraseInDisplay {
     EntireScreenAndScrollback,
 }
 
+/// The code for "Device Status Report" (DSR) commands.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/drivers/tty/vt/vt.c#L2507-L2511>.
+pub(super) enum DeviceStatusReportCode {
+    /// Reports the status of the device by transmitting `ESC[0n` if the device is OK.
+    TerminalStatusReport = 5,
+    /// Reports the cursor position (CPR) by transmitting `ESC[n;mR`,
+    /// where n is the row and m is the column.
+    CursorPositionReport = 6,
+}
+
 /// A trait to execute operations from ANSI escape sequences.
 pub(super) trait EscapeOp {
     /// Sets the cursor position.
@@ -32,6 +43,9 @@ pub(super) trait EscapeOp {
 
     /// Erases part or all of the display.
     fn erase_in_display(&mut self, mode: EraseInDisplay);
+
+    /// Reports the device status with the given code.
+    fn device_status_report(&mut self, code: DeviceStatusReportCode);
 }
 
 const MAX_PARAMS: usize = 8;
@@ -336,6 +350,21 @@ impl EscapeFsm {
             // SGR - Select Graphic Rendition
             b'm' => self.handle_sgr(num_params, op),
 
+            // DSR - Device Status Report: CSI n 'n'
+            b'n' => {
+                let n = self.param_or(0, 0);
+                let code = match n {
+                    5 => DeviceStatusReportCode::TerminalStatusReport,
+                    6 => DeviceStatusReportCode::CursorPositionReport,
+                    _ => {
+                        // Invalid parameter.
+                        return;
+                    }
+                };
+
+                op.device_status_report(code);
+            }
+
             // Unknown CSI: swallow silently.
             _ => {}
         }
@@ -487,6 +516,10 @@ mod test {
 
         fn erase_in_display(&mut self, mode: EraseInDisplay) {
             self.last_ed = Some(mode);
+        }
+
+        fn device_status_report(&mut self, _code: DeviceStatusReportCode) {
+            // Not needed for current tests.
         }
     }
 

--- a/kernel/comps/framebuffer/src/console.rs
+++ b/kernel/comps/framebuffer/src/console.rs
@@ -2,12 +2,12 @@
 
 use alloc::{sync::Arc, vec::Vec};
 
-use aster_console::{ConsoleSetFontError, font::BitmapFont, mode::ConsoleMode};
-use ostd::mm::HasSize;
+use aster_console::{ConsoleCallback, ConsoleSetFontError, font::BitmapFont, mode::ConsoleMode};
+use ostd::mm::{HasSize, VmReader};
 
 use crate::{
     FrameBuffer, Pixel,
-    ansi_escape::{EraseInDisplay, EscapeFsm, EscapeOp},
+    ansi_escape::{DeviceStatusReportCode, EraseInDisplay, EscapeFsm, EscapeOp},
 };
 
 /// A text console rendered onto the framebuffer.
@@ -66,6 +66,11 @@ impl FramebufferConsole {
         self.state.set_font(font)
     }
 
+    /// Sets a callback to be called when the console needs to send data back to the terminal.
+    pub fn set_write_callback(&mut self, callback: Arc<ConsoleCallback>) {
+        self.state.write_callback = Some(callback);
+    }
+
     /// Sends a byte slice to the console.
     pub fn send(&mut self, buf: &[u8]) {
         for byte in buf {
@@ -90,7 +95,6 @@ impl core::fmt::Debug for FramebufferConsole {
     }
 }
 
-#[derive(Debug)]
 struct ConsoleState {
     x_pos: usize,
     y_pos: usize,
@@ -100,9 +104,24 @@ struct ConsoleState {
 
     is_active: bool,
     mode: ConsoleMode,
+    write_callback: Option<Arc<ConsoleCallback>>,
 
     bytes: Vec<u8>,
     backend: Arc<FrameBuffer>,
+}
+
+impl core::fmt::Debug for ConsoleState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConsoleState")
+            .field("x_pos", &self.x_pos)
+            .field("y_pos", &self.y_pos)
+            .field("fg_color", &self.fg_color)
+            .field("bg_color", &self.bg_color)
+            .field("font", &self.font)
+            .field("is_active", &self.is_active)
+            .field("mode", &self.mode)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ConsoleState {
@@ -116,6 +135,7 @@ impl ConsoleState {
             font: BitmapFont::new_basic8x8(),
             is_active: false,
             mode: ConsoleMode::Text,
+            write_callback: None,
             bytes: alloc::vec![0; buffer_size],
             backend,
         }
@@ -335,6 +355,28 @@ impl EscapeOp for ConsoleState {
             EraseInDisplay::EntireScreen | EraseInDisplay::EntireScreenAndScrollback => {
                 // Clear the entire screen.
                 self.fill_rect_pixels(0, 0, w, h, bg);
+            }
+        }
+    }
+
+    fn device_status_report(&mut self, code: DeviceStatusReportCode) {
+        match code {
+            DeviceStatusReportCode::TerminalStatusReport => {
+                let resp = b"\x1b[0n";
+
+                if let Some(callback) = self.write_callback.clone() {
+                    callback(VmReader::from(resp.as_slice()));
+                }
+            }
+            DeviceStatusReportCode::CursorPositionReport => {
+                let col = self.x_pos / self.font.width() + 1;
+                let row = self.y_pos / self.font.height() + 1;
+
+                let resp = alloc::format!("\x1b[{};{}R", row, col);
+
+                if let Some(callback) = self.write_callback.clone() {
+                    callback(VmReader::from(resp.as_bytes()));
+                }
             }
         }
     }

--- a/kernel/src/device/tty/vt/manager/console.rs
+++ b/kernel/src/device/tty/vt/manager/console.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Weak;
+use alloc::sync::{Arc, Weak};
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use aster_console::{ConsoleSetFontError, font::BitmapFont, mode::ConsoleMode};
+use aster_console::{ConsoleCallback, ConsoleSetFontError, font::BitmapFont, mode::ConsoleMode};
 use aster_framebuffer::{FRAMEBUFFER, FramebufferConsole};
 use int_to_c_enum::TryFromInt;
 use ostd::sync::{LocalIrqDisabled, SpinLock, SpinLockGuard};
@@ -18,6 +18,7 @@ pub(in crate::device::tty::vt) struct VtConsole {
     keyboard: SpinLock<VtKeyboard, LocalIrqDisabled>,
     is_allocated: AtomicBool,
     backend: SpinLock<VtConsoleBackend, LocalIrqDisabled>,
+    write_callback: SpinLock<Option<Arc<ConsoleCallback>>, LocalIrqDisabled>,
     inner: SpinLock<VtConsoleInner, LocalIrqDisabled>,
 }
 
@@ -151,6 +152,7 @@ impl VtConsole {
             keyboard: SpinLock::new(VtKeyboard::default()),
             is_allocated: AtomicBool::new(false),
             backend: SpinLock::new(VtConsoleBackend::None),
+            write_callback: SpinLock::new(None),
             inner: SpinLock::new(VtConsoleInner::new()),
         }
     }
@@ -194,6 +196,11 @@ impl VtConsole {
             VtConsoleBackend::Framebuffer(c) => c.set_font(font),
             VtConsoleBackend::None => Err(ConsoleSetFontError::InappropriateDevice),
         }
+    }
+
+    /// Sets a callback to be called when the console needs to send data back to the terminal.
+    pub fn set_write_callback(&self, callback: Arc<ConsoleCallback>) {
+        *self.write_callback.lock() = Some(callback);
     }
 }
 
@@ -279,6 +286,11 @@ impl VtConsole {
             && let Some(fb) = FRAMEBUFFER.get()
         {
             let mut console = FramebufferConsole::new(fb.clone());
+
+            if let Some(callback) = self.write_callback.lock().clone() {
+                console.set_write_callback(callback);
+            }
+
             console.set_mode(mode);
             *backend = VtConsoleBackend::Framebuffer(console);
         }

--- a/kernel/src/device/tty/vt/manager/mod.rs
+++ b/kernel/src/device/tty/vt/manager/mod.rs
@@ -5,7 +5,10 @@ mod console;
 use aster_console::mode::ConsoleMode;
 use console::VtModeType;
 pub(super) use console::{VtConsole, VtMode};
-use ostd::sync::{LocalIrqDisabled, WaitQueue};
+use ostd::{
+    mm::Infallible,
+    sync::{LocalIrqDisabled, WaitQueue},
+};
 use spin::Once;
 
 use crate::{
@@ -84,6 +87,23 @@ impl VtManager {
             let vt_index = VtIndex::new((i + 1) as u8).unwrap();
             let driver = VtDriver::new(vt_index);
             let tty = Tty::new(vt_index.get() as u32, driver);
+
+            let tty_weak = Arc::downgrade(&tty);
+            let write_callback = Arc::new(move |mut reader: VmReader<Infallible>| {
+                let mut buf = [0u8; 128];
+                while reader.remain() > 0 {
+                    let count = core::cmp::min(reader.remain(), buf.len());
+                    let mut writer = VmWriter::from(&mut buf[..count]);
+                    reader.read(&mut writer);
+
+                    if let Some(tty_arc) = tty_weak.upgrade() {
+                        let _ = tty_arc.push_input(&buf[..count]);
+                    }
+                }
+            });
+
+            tty.driver().vt_console().set_write_callback(write_callback);
+
             char::register(tty.clone())?;
             Ok::<Arc<Tty<VtDriver>>, Error>(tty)
         })?;


### PR DESCRIPTION
These changes are all visible to verify.

1. The first commit makes the color display normal
2. The second commit makes the software know the terminal size, which can improve the result of display

Before:

<img width="2560" height="1656" alt="image" src="https://github.com/user-attachments/assets/673fe139-68fe-429e-8b23-230717cac998" />

After:

<img width="2560" height="1656" alt="image" src="https://github.com/user-attachments/assets/d987df9a-9dfe-4f2d-bf85-eb819b0a642b" />
