### PR TITLE
Fix panic for unknown flags bits in nanosleep

### DIFF
--- a/kernel/src/syscall/nanosleep.rs
+++ b/kernel/src/syscall/nanosleep.rs
@@ -39,13 +39,7 @@ pub fn sys_clock_nanosleep(
     remain_timespec_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let is_abs_time = if flags == 0 {
-        false
-    } else if flags == TIMER_ABSTIME {
-        true
-    } else {
-        unreachable!()
-    };
+    let is_abs_time = (flags & TIMER_ABSTIME) != 0;
 
     do_clock_nanosleep(
         clockid,

--- a/test/initramfs/src/regression/process/Makefile
+++ b/test/initramfs/src/regression/process/Makefile
@@ -2,6 +2,7 @@
 
 SUBDIRS := \
 	alarm \
+	clock_nanosleep \
 	clone3 \
 	cpu_affinity \
 	execve \

--- a/test/initramfs/src/regression/process/clock_nanosleep/Makefile
+++ b/test/initramfs/src/regression/process/clock_nanosleep/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/process/clock_nanosleep/nanosleep_err.c
+++ b/test/initramfs/src/regression/process/clock_nanosleep/nanosleep_err.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+FN_TEST(clock_nanosleep_unknown_flag_bit)
+{
+	struct timespec req = { .tv_sec = 0, .tv_nsec = 0 };
+
+	// `flags = 2` is neither 0 nor `TIMER_ABSTIME`. Used to trigger
+	// `unreachable!()` and panic the kernel.
+	TEST_SUCC(syscall(SYS_clock_nanosleep, CLOCK_MONOTONIC, 2, &req, NULL));
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -15,6 +15,8 @@ set -e
 
 ./cpu_affinity/cpu_affinity
 
+./clock_nanosleep/nanosleep_err
+
 ./execve/execve
 ./execve/execve_comm
 ./execve/execve_err


### PR DESCRIPTION
`sys_clock_nanosleep` panics the kernel with `unreachable!()` whenever user space passes any flags value other than 0 or `TIMER_ABSTIME` (== 1).

https://github.com/asterinas/asterinas/blob/d1d3b85229eb86979631fc911d76fc78ed039974/kernel/src/syscall/nanosleep.rs#L47

This PR aligns the behavior with Linux: only the `TIMER_ABSTIME` bit is consulted; all other bits in flags are silently ignored.

## PoC
```C
#include <sys/syscall.h>
#include <unistd.h>

struct kts {
    long tv_sec;
    long tv_nsec;
};

int main() {
    struct kts req = {0, 0};
    /* __NR_clock_nanosleep = 230 on x86_64.
       clockid = CLOCK_MONOTONIC (1).
       flags = 2 (not 0, not TIMER_ABSTIME=1) -> hits unreachable!(). */
    syscall(230, 1, 2, &req, 0);
    return 0;
}
```

## Reference
https://elixir.bootlin.com/linux/v6.16.5/source/kernel/time/posix-timers.c#L1345-L1374

`flags & TIMER_ABSTIME`
in
```C
/*
 * sys_clock_nanosleep() for CLOCK_REALTIME and CLOCK_TAI
 */
static int common_nsleep(const clockid_t which_clock, int flags,
			 const struct timespec64 *rqtp)
{
	ktime_t texp = timespec64_to_ktime(*rqtp);

	return hrtimer_nanosleep(texp, flags & TIMER_ABSTIME ?
				 HRTIMER_MODE_ABS : HRTIMER_MODE_REL,
				 which_clock);
}

/*
 * sys_clock_nanosleep() for CLOCK_MONOTONIC and CLOCK_BOOTTIME
 *
 * Absolute nanosleeps for these clocks are time-namespace adjusted.
 */
static int common_nsleep_timens(const clockid_t which_clock, int flags,
				const struct timespec64 *rqtp)
{
	ktime_t texp = timespec64_to_ktime(*rqtp);

	if (flags & TIMER_ABSTIME)
		texp = timens_ktime_to_host(which_clock, texp);

	return hrtimer_nanosleep(texp, flags & TIMER_ABSTIME ?
				 HRTIMER_MODE_ABS : HRTIMER_MODE_REL,
				 which_clock);
}
```
