### PR TITLE
Fix ext2 block-mapping writeback: persist allocations made during page-cache writeback

### DIFF
--- a/kernel/src/fs/fs_impls/ext2/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext2/block_group.rs
@@ -224,7 +224,7 @@ impl BlockGroup {
         // `inode_cache.write()`.
         let inodes: Vec<Arc<Inode>> = self.inode_cache.read().values().cloned().collect();
         for inode in inodes {
-            let _ = inode.sync_all()?;
+            inode.sync_all()?;
         }
         self.sync_inode_table()
     }
@@ -449,7 +449,7 @@ impl BlockGroup {
     }
 
     /// Writes an inode descriptor to the group's inode table `PageCache`.
-    pub(super) fn write_inode_desc(&self, ino: Ext2Ino, raw: &RawInode) -> Result<()> {
+    pub(super) fn write_back_inode_desc(&self, ino: Ext2Ino, raw: &RawInode) -> Result<()> {
         let inode_idx = self.inode_idx_in_group(ino);
         let offset_bytes = (inode_idx as usize) * self.inode_size;
         self.inode_table_cache.write_val(offset_bytes, raw)?;

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -256,7 +256,7 @@ impl Ext2 {
     }
 
     /// Writes an inode descriptor to the group's `PageCache`.
-    pub(super) fn write_inode_desc(&self, ino: Ext2Ino, raw_inode: &RawInode) -> Result<()> {
+    pub(super) fn write_back_inode_desc(&self, ino: Ext2Ino, raw_inode: &RawInode) -> Result<()> {
         {
             let sb = self.super_block.read();
             // Apply ext2 inode-number validity rules before indexing groups.
@@ -269,7 +269,7 @@ impl Ext2 {
             .find_group(ino)
             .ok_or_else(|| Error::with_message(Errno::EIO, "block group index out of range"))?;
 
-        group.write_inode_desc(ino, raw_inode)
+        group.write_back_inode_desc(ino, raw_inode)
     }
 
     /// Allocates up to `count` contiguous blocks.
@@ -393,7 +393,7 @@ impl Ext2 {
             .find_group(ino)
             .ok_or_else(|| Error::with_message(Errno::EIO, "block group index out of range"))?;
 
-        if let Err(err) = self.write_inode_desc(ino, &raw_inode) {
+        if let Err(err) = self.write_back_inode_desc(ino, &raw_inode) {
             if let Ok(was_allocated) = block_group.free_inode(ino, inode_type)
                 && was_allocated
             {
@@ -911,7 +911,7 @@ mod test {
 
         // Free path now takes caller-provided inode type; no inode-table read is needed.
         let raw_dir = make_raw_inode(0o040755, 1, 0);
-        f.ext2.write_inode_desc(ino, &raw_dir).unwrap();
+        f.ext2.write_back_inode_desc(ino, &raw_dir).unwrap();
         f.ext2.free_inode(ino, InodeType::Dir).unwrap();
         assert_eq!(f.ext2.super_block().free_inodes_count(), before_sb_free);
         assert_eq!(f.ext2.block_group(0).free_inodes_count(), before_group_free);
@@ -966,7 +966,10 @@ mod test {
         // Already-free inode: should return Ok and keep counters unchanged.
         let target_ino = f_free.sb.first_ino();
         let raw_file = make_raw_inode(0o100644, 1, 0);
-        f_free.ext2.write_inode_desc(target_ino, &raw_file).unwrap();
+        f_free
+            .ext2
+            .write_back_inode_desc(target_ino, &raw_file)
+            .unwrap();
 
         let before_sb = f_free.ext2.super_block().free_inodes_count();
         let before_group = f_free.ext2.block_group(0).free_inodes_count();

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -223,12 +223,10 @@ impl Inode for Ext2Inode {
     }
 
     fn sync_all(&self) -> Result<()> {
-        let desc_is_dirty = self.sync_all()?;
+        self.sync_all()?;
         let fs = self.fs()?;
-        if desc_is_dirty {
-            let block_group = fs.block_group(self.block_group_idx());
-            block_group.sync_inode_table()?;
-        }
+        let block_group = fs.block_group(self.block_group_idx());
+        block_group.sync_inode_table()?;
         if fs.block_device().sync()? != BioStatus::Complete {
             return_errno_with_message!(Errno::EIO, "failed to flush block device");
         }
@@ -236,12 +234,10 @@ impl Inode for Ext2Inode {
     }
 
     fn sync_data(&self) -> Result<()> {
-        let desc_is_dirty = self.sync_data()?;
+        self.sync_data()?;
         let fs = self.fs()?;
-        if desc_is_dirty {
-            let block_group = fs.block_group(self.block_group_idx());
-            block_group.sync_inode_table()?;
-        }
+        let block_group = fs.block_group(self.block_group_idx());
+        block_group.sync_inode_table()?;
         if fs.block_device().sync()? != BioStatus::Complete {
             return_errno_with_message!(Errno::EIO, "failed to flush block device");
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -30,7 +30,7 @@ const MAX_BLOCK_POINTER_LEVELS: usize = 4;
 /// or to indirect metadata blocks at the level selected by the slot.
 #[derive(Debug)]
 pub(in crate::fs::fs_impls::ext2::inode) struct BlockPtrTree {
-    raw_block_ptrs: RawBlockPtrs,
+    raw_block_ptrs: Dirty<RawBlockPtrs>,
     indirect_blocks_manager: Mutex<IndirectBlockManager>,
 }
 
@@ -41,7 +41,7 @@ impl BlockPtrTree {
         fs: Weak<Ext2>,
     ) -> Self {
         Self {
-            raw_block_ptrs,
+            raw_block_ptrs: Dirty::new(raw_block_ptrs),
             indirect_blocks_manager: Mutex::new(IndirectBlockManager::new(fs)),
         }
     }
@@ -49,6 +49,16 @@ impl BlockPtrTree {
     /// Returns a reference to the raw on-disk block pointer state.
     pub(in crate::fs::fs_impls::ext2::inode) fn raw_block_ptrs(&self) -> &RawBlockPtrs {
         &self.raw_block_ptrs
+    }
+
+    /// Returns whether the `RawBlockPtrs` is dirty.
+    pub(super) fn is_dirty(&self) -> bool {
+        self.raw_block_ptrs.is_dirty()
+    }
+
+    /// Clears the dirty flag for the raw on-disk block pointer state.
+    pub(super) fn clear_dirty(&mut self) {
+        self.raw_block_ptrs.clear_dirty();
     }
 
     /// Flushes all dirty cached indirect blocks to the device.

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
@@ -61,6 +61,16 @@ impl InodeBlockManager {
         *self.block_ptr_tree.read().raw_block_ptrs()
     }
 
+    /// Returns whether the block-pointer tree has uncommitted changes.
+    pub(super) fn is_dirty(&self) -> bool {
+        self.block_ptr_tree.read().is_dirty()
+    }
+
+    /// Clears the block-pointer dirty flag after writeback.
+    pub(super) fn clear_dirty(&self) {
+        self.block_ptr_tree.write().clear_dirty();
+    }
+
     /// Creates an iterator over existing and hole block ranges.
     ///
     /// The returned iterator holds a read lock on the block-pointer tree for

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -87,7 +87,7 @@ impl Inode {
         child_inner.dec_link_count(2);
 
         if child_inner.link_count() == 0 {
-            child_inner.write_back_desc(&fs, entry_info.ino)?;
+            child_inner.write_back_inode_desc(&fs, entry_info.ino)?;
             let _ = fs.remove_inode(entry_info.ino);
         }
 
@@ -222,7 +222,7 @@ impl Inode {
         child_inner.set_ctime(utils::now());
         child_inner.dec_link_count(1);
         if child_inner.link_count() == 0 {
-            child_inner.write_back_desc(&fs, entry_info.ino)?;
+            child_inner.write_back_inode_desc(&fs, entry_info.ino)?;
             let _ = fs.remove_inode(entry_info.ino);
         }
         Ok(())
@@ -387,7 +387,7 @@ impl Inode {
             replaced_inner.dec_link_count(1);
 
             if replaced_inner.link_count() == 0 {
-                replaced_inner.write_back_desc(&fs, replaced.ino())?;
+                replaced_inner.write_back_inode_desc(&fs, replaced.ino())?;
                 let _ = fs.remove_inode(replaced.ino());
             }
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/mod.rs
@@ -474,10 +474,16 @@ impl InodeInner {
 
     fn clear_dirty(&mut self) {
         self.desc.clear_dirty();
+        if let Ok(block_manager) = self.block_manager() {
+            block_manager.clear_dirty();
+        }
     }
 
     fn is_dirty(&self) -> bool {
         self.desc.is_dirty()
+            || self
+                .block_manager()
+                .is_ok_and(|block_manager| block_manager.is_dirty())
     }
 
     fn inode_type(&self) -> InodeType {

--- a/kernel/src/fs/fs_impls/ext2/inode/sync.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/sync.rs
@@ -11,62 +11,45 @@ use super::{super::Ext2, Inode, InodeInner, RawInode};
 use crate::fs::ext2::{prelude::*, utils};
 
 impl Inode {
-    /// Flushes xattr, data pages, and indirect blocks, then writes the inode descriptor back to
-    /// the block group's inode table page cache.
+    /// Flushes all dirty state owned by the inode.
     ///
-    /// Returns `true` if the descriptor was dirty and written back. The caller is responsible for
-    /// flushing the inode table and the block device.
-    pub(in crate::fs::fs_impls::ext2) fn sync_all(&self) -> Result<bool> {
-        // `fsync` step 1: flush the xattr.
+    /// Writes xattrs, data pages, and indirect blocks back before staging dirty
+    /// inode metadata in the block group's inode-table page cache.
+    pub(in crate::fs::fs_impls::ext2) fn sync_all(&self) -> Result<()> {
+        // Step 1: flush the xattr.
         if let Some(xattr) = &self.xattr {
             xattr.flush()?;
         }
 
-        // `fsync` step 2: flush dirty data pages.
+        // Step 2: flush dirty data pages.
         let fs = self.fs()?;
         let mut inner = self.inner.write();
         inner.sync_data_pages()?;
 
-        // `fsync` step 3: flush inode-local indirect metadata before
-        // persisting inode-table state.
+        // Step 3: flush inode-local indirect metadata before inode-table state.
         inner.sync_indirect_blocks()?;
 
-        // `fsync` step 4: persist inode metadata to the inode table page cache.
-        let desc_is_dirty = if inner.is_dirty() {
-            inner.write_back_desc(&fs, self.ino)?;
-            true
-        } else {
-            false
-        };
-
-        Ok(desc_is_dirty)
+        // Step 4: persist inode metadata to the inode-table page cache.
+        inner.write_back_inode_desc(&fs, self.ino)
     }
 
-    /// Flushes dirty data pages, indirect blocks, and dirty inode metadata.
+    /// Flushes dirty file data and the metadata required to retrieve it.
     ///
-    /// Returns `true` if the descriptor was dirty and written back. The caller is responsible for
-    /// flushing the inode table and the block device.
-    pub(in crate::fs::fs_impls::ext2) fn sync_data(&self) -> Result<bool> {
+    /// Writes data pages and indirect blocks back before staging dirty inode
+    /// metadata in the block group's inode-table page cache. This does not flush
+    /// xattrs.
+    pub(in crate::fs::fs_impls::ext2) fn sync_data(&self) -> Result<()> {
         let fs = self.fs()?;
         let mut inner = self.inner.write();
 
-        // `fdatasync` writes back dirty data pages first. The caller is
-        // responsible for the final device-cache flush.
+        // Step 1: flush dirty data pages.
         inner.sync_data_pages()?;
 
-        // `fdatasync` must also persist dirty indirect metadata needed to reach
-        // newly written data blocks before the final device flush.
+        // Step 2: flush inode-local indirect metadata before inode-table state.
         inner.sync_indirect_blocks()?;
 
-        // Persist metadata conservatively whenever the descriptor is dirty so
-        // `fdatasync` does not miss file-size or block-mapping updates.
-        let desc_is_dirty = if inner.is_dirty() {
-            inner.write_back_desc(&fs, self.ino)?;
-            true
-        } else {
-            false
-        };
-        Ok(desc_is_dirty)
+        // Step 3: persist inode metadata to the inode-table page cache.
+        inner.write_back_inode_desc(&fs, self.ino)
     }
 
     /// Attempts final reclaim for a deleted inode.
@@ -99,7 +82,7 @@ impl Inode {
         {
             block_manager.truncate_to_byte_len(0);
         }
-        inner.write_back_desc(&fs, self.ino)?;
+        inner.write_back_inode_desc(&fs, self.ino)?;
 
         fs.free_inode(self.ino, self.type_)?;
         Ok(true)
@@ -107,13 +90,18 @@ impl Inode {
 }
 
 impl InodeInner {
-    /// Serializes the descriptor to disk and clears the dirty flag.
-    pub(super) fn write_back_desc(&mut self, fs: &Ext2, ino: Ext2Ino) -> Result<()> {
+    /// Serializes the descriptor to inode-table page cache if dirty and clears dirty state.
+    pub(super) fn write_back_inode_desc(&mut self, fs: &Ext2, ino: Ext2Ino) -> Result<()> {
+        if !self.is_dirty() {
+            return Ok(());
+        }
+
         let raw_block_ptrs = self.raw_block_ptrs();
         self.desc.block_ptrs = raw_block_ptrs.block_ptrs;
         self.desc.sector_count = raw_block_ptrs.sector_count;
+
         let raw_inode = RawInode::from(&*self.desc);
-        fs.write_inode_desc(ino, &raw_inode)?;
+        fs.write_back_inode_desc(ino, &raw_inode)?;
         self.clear_dirty();
         Ok(())
     }


### PR DESCRIPTION
  ## Problem

Normally all block allocations for a file happen in the foreground via `prepare_write` during `write_at`, which marks the inode descriptor dirty, so `sync` correctly persists the updated block mappings.
  
However, when a file is mapped via `mmap` and a write lands on a hole, the allocation is deferred until page-cache writeback and performed inside `BlockAsPageCacheBackend::submit_write_bio`. In this path `RawBlockPtrs` (`block_ptrs` / `sector_count`) is modified, but the inode descriptor is never marked dirty. Because `fsync` / `fdatasync` gated descriptor writeback solely on `InodeInner::is_dirty()`, they would skip persisting the descriptor: the freshly allocated data blocks reach the disk, but the inode never records the mappings pointing at them, so the data is effectively lost after a remount.

  ## Fix

Give the on-disk block-pointer state its own dirty tracking by wrapping `RawBlockPtrs` in `Dirty<RawBlockPtrs>`, so allocations made anywhere — including during page-cache writeback — are no longer missed at sync time. The flag is exposed through `BlockPtrTree` and `InodeBlockManager` as `is_dirty()` / `clear_dirty()`.
  
`write_back_inode_desc is now:
  
  - treats the inode as needing writeback if either the descriptor dirty flag or the block-pointer dirty flag is set;
  - copies `block_ptrs` / `sector_count` into the descriptor only when the block pointers are dirty;
  - skips the write entirely when nothing is dirty, returning whether a write actually occurred;
  - clears both dirty flags after a successful write.