### PR TITLE
Update Kata networking guide

### DIFF
--- a/book/src/kernel/vm-based-containers/kata.md
+++ b/book/src/kernel/vm-based-containers/kata.md
@@ -29,7 +29,7 @@ The commands in this guide are currently written for x86-64 hosts.
 Verify that the required device nodes exist:
 
 ```bash
-ls /dev/kvm /dev/vhost-vsock
+ls /dev/kvm /dev/vhost-vsock /dev/vhost-net
 ```
 
 If any of them are missing,
@@ -39,10 +39,13 @@ load the matching kernel modules:
 sudo modprobe kvm
 sudo modprobe kvm_intel  # Or use kvm_amd on AMD hosts.
 sudo modprobe vhost_vsock
+sudo modprobe vhost_net
 ```
 
 Then make sure the user running Docker can access
-`/dev/kvm` and `/dev/vhost-vsock`.
+`/dev/kvm`,
+`/dev/vhost-net`,
+and `/dev/vhost-vsock`.
 
 ## Step 2: Enter the Kata-ready environment
 
@@ -66,6 +69,7 @@ KATA_DOCKER_ARGS=(
     --privileged
     --device /dev/kvm
     --device /dev/vhost-vsock
+    --device /dev/vhost-net
     --tmpfs /tmp:exec,mode=1777,size=8g
     --tmpfs /var/lib/containerd:exec,mode=755,size=8g
 )
@@ -76,9 +80,10 @@ These flags are required for Kata:
 - `--cgroupns host` shares the host cgroup namespace
   so that `containerd` inside the container can manage Kata workloads.
 - `--privileged` is required for KVM and nested container management.
-- `--device /dev/kvm` and `--device /dev/vhost-vsock`
-  expose the virtualization devices
-  that Kata needs.
+- `--device /dev/kvm`,
+  `--device /dev/vhost-net`,
+  and `--device /dev/vhost-vsock`
+  expose the virtualization devices that Kata needs.
 - `--tmpfs /tmp:exec,...` and `--tmpfs /var/lib/containerd:exec,...`
   give Kata enough temporary storage space to create containers.
 
@@ -95,7 +100,7 @@ to enter an environment with Kata and Asterinas preinstalled:
 docker run -it \
     "${KATA_DOCKER_ARGS[@]}" \
     -w /root/kata-containers \
-    asterinas/kata:0.17.2-20260407
+    asterinas/kata:0.17.2-20260523
 ```
 
 The command above makes `/root/kata-containers` the working directory,
@@ -118,7 +123,7 @@ docker run -it \
     "${KATA_DOCKER_ARGS[@]}" \
     -v "${ASTERINAS_SRC}:/root/asterinas" \
     -w /root/kata-containers \
-    asterinas/kata:0.17.2-20260407
+    asterinas/kata:0.17.2-20260523
 ```
 
 This setup allows you to rebuild the kernel
@@ -135,7 +140,9 @@ Then continue with [Step 3: Start a Kata workload](#step-3-start-a-kata-workload
 ### Step 3.1: Start services
 
 Start `containerd` and `syslogd`,
-the background services required by Kata:
+the background services required by Kata.
+The service script also prepares the `asterinas` network
+used by the `nerdctl` command below.
 
 ```bash
 tools/kata/kata_services.sh start
@@ -153,12 +160,14 @@ Use `nerdctl` with Kata to start an Alpine container:
 
 ```bash
 nerdctl run \
-    --cgroup-manager cgroupfs \
-    --net none \
     --runtime io.containerd.kata.v2 \
+    --cgroup-manager cgroupfs \
+    --net asterinas \
+    --ip "10.0.2.15" \
+    --entrypoint /bin/sh \
     --name foo \
     -it \
-    docker.io/alpine:latest
+    alpine/curl:8.19.0
 ```
 
 The `nerdctl` flags above are also required:
@@ -166,9 +175,13 @@ The `nerdctl` flags above are also required:
 - `--cgroup-manager cgroupfs` is required because the example runs
   inside a Docker container where the systemd cgroup driver
   is not available.
-- `--net none` is required because Asterinas does not yet support
-  hot-plugged network devices,
-  so workloads inside the guest cannot access the network.
+- `--net asterinas` uses the managed nerdctl network created by
+  `tools/kata/kata_services.sh start`.
+- `--ip "10.0.2.15"` matches the current fixed guest IP
+  expected by the Asterinas networking setup.
+- `--entrypoint /bin/sh` is required for `alpine/curl:8.19.0`
+  because the image's default entrypoint runs `curl`
+  instead of opening a shell.
 
 ### Step 3.3: Verify the guest
 
@@ -199,6 +212,12 @@ look for:
 This is the most direct check that Kata booted an Asterinas guest kernel.
 The `/etc/alpine-release` output should print the Alpine version
 of the container rootfs.
+
+You can also check external network access from the guest:
+
+```bash
+curl https://asterinas.github.io/
+```
 
 ### Step 3.4: Clean up
 


### PR DESCRIPTION
This PR updates the commands for starting Kata with networking enabled. I have modified the Kata runtime to attach a virtio-net device when launching QEMU, so there is no need to support network device hotplug for now.

I have also modified Kata to bypass the network configuration flow that would normally be handled by the Kata agent on the guest kernel side. Instead, networking is configured by creating a network via `nerdctl network create` (which is one step inside `kata-service.sh start`) and specifying the IP address via `nerdctl run`. This ensures that the host-side network configuration matches the gateway and IP values hardcoded in Asterinas, allowing network connectivity to be established.

The updated demo introduced by this PR has been integrated into the CI pipeline of asterinas/kata-containers.