### PR TITLE
Increase NixOS test default timeout from 5min to 10min

### DIFF
--- a/test/nixos/Makefile
+++ b/test/nixos/Makefile
@@ -2,7 +2,7 @@
 
 NIXOS_TEST_SUITE ?=
 NIXOS_TEST_CASE ?=
-NIXOS_TEST_TIMEOUT ?= 5min
+NIXOS_TEST_TIMEOUT ?= 10min
 
 # Generated configuration file name
 TEST_CONFIG_FILE_NAME := _configuration_for_test.nix

--- a/test/nixos/README.md
+++ b/test/nixos/README.md
@@ -121,7 +121,7 @@ make run_nixos NIXOS_TEST_SUITE=my-test
 # Run a specific test case
 make run_nixos NIXOS_TEST_SUITE=my-test NIXOS_TEST_CASE=echo_print_message
 
-# Customize timeout with units (default: 5min)
+# Customize timeout with units (default: 10min)
 make run_nixos NIXOS_TEST_SUITE=my-test NIXOS_TEST_TIMEOUT=10min    # 10 minutes
 make run_nixos NIXOS_TEST_SUITE=my-test NIXOS_TEST_TIMEOUT=600s   # 600 seconds
 make run_nixos NIXOS_TEST_SUITE=my-test NIXOS_TEST_TIMEOUT=600000ms  # 600000 milliseconds
@@ -148,6 +148,6 @@ Make variables:
 - **`NIXOS_TEST_CASE`**: Specific test case to run (optional, runs all if not specified)
 
 Framework environment variables:
-- **`NIXOS_TEST_TIMEOUT`**: Timeout for command execution with unit suffix (optional, default: 5min)
+- **`NIXOS_TEST_TIMEOUT`**: Timeout for command execution with unit suffix (optional, default: 10min)
   - Supported formats: `<number>ms` (milliseconds), `<number>s` (seconds), `<number>min` (minutes)
   - Examples: `300000ms`, `300s`, `5min`

--- a/test/nixos/common/framework/src/lib.rs
+++ b/test/nixos/common/framework/src/lib.rs
@@ -177,7 +177,7 @@ pub fn __nixos_test_main() -> Result<(), Box<dyn std::error::Error>> {
         .ok()
         .map(|v| parse_timeout(&v))
         .transpose()?
-        .unwrap_or(300_000); // Default: 5 minutes
+        .unwrap_or(600_000); // Default: 10 minutes
 
     let all_test_cases: Vec<&TestCase> = inventory::iter::<TestCase>().collect();
 
@@ -343,7 +343,7 @@ ENVIRONMENT VARIABLES:
     NIXOS_TEST_TIMEOUT      Timeout for command execution
                             Supports: <number>ms, <number>s, <number>min
                             Examples: 300000ms, 300s, 5min
-                            (default: 5min = 300000ms)
+                            (default: 10min = 600000ms)
 
 "
     );


### PR DESCRIPTION
Increase the default NixOS test timeout from 5 minutes to 10 minutes, since the `nix-and-nixos-tools` test suite is prone to timing out under the previous limit.