### PR TITLE
Update `O_TMPFILE` flag coverage docs

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -27,9 +27,7 @@ Silently-ignored flags:
 
 Partially-supported flags:
 * `O_PATH`
-
-Unsupported flags:
-* `O_TMPFILE`
+* `O_TMPFILE` (only on file systems that support unnamed temporary files, e.g. ramfs)
 
 Supported and unsupported functionality of `openat` are the same as `open`.
 The SCML rules are omitted for brevity.

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/open_and_openat.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/open_and_openat.scml
@@ -43,19 +43,43 @@ openat(
 );
 
 // Status flags that are meaningful with O_PATH
-opath_valid_flags = O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW;
+opath_valid_flags =
+    O_CLOEXEC |
+    O_DIRECTORY |
+    O_NOFOLLOW;
+
 // All other flags are ignored with O_PATH
-opath_ignored_flags = O_CREAT | <creation_flags> | <status_flags>;
+opath_ignored_flags =
+    O_CREAT |
+    O_TMPFILE |
+    <access_mode> |
+    O_EXCL |
+    O_NOCTTY |
+    O_TRUNC |
+    <status_flags>;
+
 // Obtain a file descriptor to indicate a location in FS
 open(
     path,
-    flags = O_PATH | <opath_valid_flags> | <opath_ignored_flags>
+    flags = O_PATH | <opath_valid_flags> | <opath_ignored_flags>,
+    ..
 );
 openat(
     dirfd,
     path,
-    flags = O_PATH | <opath_valid_flags> | <opath_ignored_flags>
+    flags = O_PATH | <opath_valid_flags> | <opath_ignored_flags>,
+    ..
 );
 
 // Create an unnamed file
-// open(path, flags = O_TMPFILE | <creation_flags> | <status_flags>)
+open(
+    path,
+    flags = O_TMPFILE | <access_mode> | <creation_flags> | <status_flags>,
+    mode
+);
+openat(
+    dirfd,
+    path,
+    flags = O_TMPFILE | <access_mode> | <creation_flags> | <status_flags>,
+    mode
+);


### PR DESCRIPTION
## Summary

- Mark `O_TMPFILE` as partially supported instead of unsupported.
- Add SCML coverage for `O_TMPFILE` in `open` and `openat`.
- Refine the SCML flag groups for existing-file opens, file creation, `O_PATH`, and unnamed temporary files.