### PR TITLE
net/netlink/route: implement RTM_NEWADDR, RTM_NEWLINK, RTM_NEWROUTE

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -129,6 +129,14 @@ impl<E: Ext> IfaceCommon<E> {
         self.interface.lock().prefix_len()
     }
 
+    pub(super) fn set_ipv4_cidr(&self, cidr: smoltcp::wire::Ipv4Cidr) {
+        self.interface.lock().set_ipv4_cidr(cidr);
+    }
+
+    pub(super) fn set_ipv4_gateway(&self, gateway: smoltcp::wire::Ipv4Address) {
+        self.interface.lock().set_ipv4_gateway(gateway);
+    }
+
     pub(super) fn sched_poll(&self) -> &E::ScheduleNextPoll {
         &self.sched_poll
     }

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -103,6 +103,16 @@ impl<E: Ext> dyn Iface<E> {
         cidr.broadcast()
     }
 
+    /// Sets the IPv4 CIDR of the interface.
+    pub fn set_ipv4_cidr(&self, cidr: smoltcp::wire::Ipv4Cidr) {
+        self.common().set_ipv4_cidr(cidr);
+    }
+
+    /// Sets the default IPv4 gateway.
+    pub fn set_ipv4_gateway(&self, gateway: smoltcp::wire::Ipv4Address) {
+        self.common().set_ipv4_gateway(gateway);
+    }
+
     /// Returns a reference to the associated [`ScheduleNextPoll`].
     ///
     /// [`ScheduleNextPoll`]: crate::iface::sched::ScheduleNextPoll

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -60,6 +60,23 @@ impl<E: Ext> PollableIface<E> {
     pub(super) fn next_poll_at_ms(&self) -> Option<u64> {
         self.pending_conns.next_poll_at_ms()
     }
+
+    /// Sets the IPv4 CIDR of the interface, replacing the existing IPv4 address.
+    pub(super) fn set_ipv4_cidr(&mut self, cidr: smoltcp::wire::Ipv4Cidr) {
+        self.interface.update_ip_addrs(|ip_addrs| {
+            for addr in ip_addrs.iter_mut() {
+                if let smoltcp::wire::IpCidr::Ipv4(_) = addr {
+                    *addr = smoltcp::wire::IpCidr::Ipv4(cidr);
+                    return;
+                }
+            }
+        });
+    }
+
+    /// Sets the default IPv4 gateway.
+    pub(super) fn set_ipv4_gateway(&mut self, gateway: smoltcp::wire::Ipv4Address) {
+        self.interface.routes_mut().add_default_ipv4_route(gateway).ok();
+    }
 }
 
 impl<E: Ext> PollableIface<E> {

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -95,11 +95,12 @@ where
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, SocketAddr)> {
-        let recv_bytes = self
+        let result = self
             .inner
             .read()
             .try_recv(writer, flags)
-            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
+            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()));
+        let recv_bytes = result?;
         self.pollee.invalidate();
 
         Ok(recv_bytes)

--- a/kernel/src/net/socket/netlink/message/attr/noattr.rs
+++ b/kernel/src/net/socket/netlink/message/attr/noattr.rs
@@ -4,7 +4,7 @@ use super::{Attribute, CAttrHeader};
 use crate::{net::socket::netlink::message::ContinueRead, prelude::*, util::MultiRead};
 
 /// A special type indicates that a segment cannot have attributes.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum NoAttr {}
 
 impl Attribute for NoAttr {

--- a/kernel/src/net/socket/netlink/message/mod.rs
+++ b/kernel/src/net/socket/netlink/message/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// A netlink message can be transmitted to and from user space using a single send/receive syscall.
 /// It consists of one or more [`ProtocolSegment`]s.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Message<T> {
     segments: Vec<T>,
 }

--- a/kernel/src/net/socket/netlink/message/segment/common.rs
+++ b/kernel/src/net/socket/netlink/message/segment/common.rs
@@ -7,7 +7,7 @@ use crate::{
     util::{MultiRead, MultiWrite},
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SegmentCommon<Body, Attr> {
     header: CMsgSegHdr,
     body: Body,

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -102,16 +102,29 @@ impl datagram_common::Bound for BoundNetlinkRoute {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, NetlinkSocketAddr)> {
-        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
-        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+        // TODO: Deal with other flags. Only MSG_PEEK and MSG_TRUNC are handled here.
+        let unsupported = flags.sub(SendRecvFlags::MSG_PEEK).sub(SendRecvFlags::MSG_TRUNC);
+        if !unsupported.is_all_supported() {
             warn!("unsupported flags: {:?}", flags);
         }
+
+        let truncate = flags.contains(SendRecvFlags::MSG_TRUNC);
 
         let mut receive_queue = self.receive_queue.lock();
 
         receive_queue.dequeue_if(|response, response_len| {
-            let len = response_len.min(writer.sum_lens());
-            response.write_to(writer)?;
+            // When MSG_TRUNC is set, return the actual message length even if the
+            // buffer is smaller (or zero). This allows callers like iproute2 to use
+            // MSG_PEEK|MSG_TRUNC with a zero-length buffer to probe the message size.
+            let len = if truncate {
+                response_len
+            } else {
+                response_len.min(writer.sum_lens())
+            };
+
+            if writer.sum_lens() > 0 {
+                response.write_to(writer)?;
+            }
 
             // TODO: The message can only come from kernel socket currently.
             let remote = NetlinkSocketAddr::new_unspecified();

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -9,7 +9,7 @@ use crate::{
     net::{
         iface::{Iface, iter_all_ifaces},
         socket::netlink::{
-            message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
+            message::{CMsgSegHdr, CSegmentType, ErrorSegment, GetRequestFlags, SegHdrCommonFlags},
             route::message::{
                 AddrAttr, AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope, RtnlSegment,
             },
@@ -66,3 +66,46 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
 
     Some(AddrSegment::new(header, addr_message, attrs))
 }
+
+pub(super) fn do_new_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegment>> {
+    use aster_bigtcp::wire::{Ipv4Address, Ipv4Cidr};
+
+    let body = request_segment.body();
+
+    // Only AF_INET supported for now
+    if body.family != CSocketAddrFamily::AF_INET as i32 {
+        return_errno_with_message!(Errno::EAFNOSUPPORT, "only AF_INET is supported");
+    }
+
+    let prefix_len = body.prefix_len;
+
+    // Extract IFA_ADDRESS or IFA_LOCAL from attributes
+    let mut ipv4_addr: Option<[u8; 4]> = None;
+    for attr in request_segment.attrs() {
+        match attr {
+            AddrAttr::Address(octets) => { ipv4_addr = Some(*octets); }
+            AddrAttr::Local(octets)   => { if ipv4_addr.is_none() { ipv4_addr = Some(*octets); } }
+            _ => {}
+        }
+    }
+
+    let octets = ipv4_addr.ok_or_else(|| {
+        Error::with_message(Errno::EINVAL, "no address provided in RTM_NEWADDR")
+    })?;
+
+    let smoltcp_addr = Ipv4Address::new(octets[0], octets[1], octets[2], octets[3]);
+    let cidr = Ipv4Cidr::new(smoltcp_addr, prefix_len);
+
+    // Find the target interface by index
+    let iface_index = body.index.map(|n| n.get()).unwrap_or(0);
+    let iface = iter_all_ifaces()
+        .find(|iface| iface.index() == iface_index)
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "interface not found"))?;
+
+    iface.set_ipv4_cidr(cidr);
+
+    // Send ACK (NLMSG_ERROR with err=0) as Linux does for successful write operations
+    let ack = ErrorSegment::new_from_request(request_segment.header(), None);
+    Ok(vec![RtnlSegment::Error(ack)])
+}
+

--- a/kernel/src/net/socket/netlink/route/kernel/link.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/link.rs
@@ -11,8 +11,10 @@ use crate::{
     net::{
         iface::{Iface, iter_all_ifaces},
         socket::netlink::{
-            message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
-            route::message::{LinkAttr, LinkSegment, LinkSegmentBody, RtnlSegment},
+            addr::GroupIdSet,
+            message::{CMsgSegHdr, CSegmentType, ErrorSegment, GetRequestFlags, SegHdrCommonFlags},
+            route::message::{LinkAttr, LinkSegment, LinkSegmentBody, RtnlMessage, RtnlSegment},
+            table::{NetlinkRouteProtocol, SupportedNetlinkProtocol},
         },
     },
     prelude::*,
@@ -143,3 +145,34 @@ fn iface_to_new_link(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> LinkSeg
 
     LinkSegment::new(header, link_message, attrs)
 }
+
+pub(super) fn do_new_link(request_segment: &LinkSegment) -> Result<Vec<RtnlSegment>> {
+    let iface_index = request_segment
+        .body()
+        .index
+        .map(|n| n.get())
+        .unwrap_or(0);
+    let iface = iter_all_ifaces()
+        .find(|i| i.index() == iface_index)
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "interface not found"))?;
+
+    // Return ACK (error=0 = success)
+    let ack = ErrorSegment::new_from_request(request_segment.header(), None);
+
+    // Send unsolicited RTM_NEWLINK notification to RTMGRP_LINK (group bit 1 = index 0)
+    let notification_header = CMsgSegHdr {
+        len: 0,
+        type_: CSegmentType::NEWLINK as _,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: 0,
+        pid: 0,
+    };
+    let notification_seg = RtnlSegment::NewLink(iface_to_new_link(&notification_header, &iface));
+    let _ = NetlinkRouteProtocol::multicast(
+        GroupIdSet::new(0x1),
+        RtnlMessage::new(vec![notification_seg]),
+    );
+
+    Ok(vec![RtnlSegment::Error(ack)])
+}
+

--- a/kernel/src/net/socket/netlink/route/kernel/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 
 mod addr;
 mod link;
+mod route;
 mod util;
 
 pub(super) struct NetlinkRouteKernelSocket {
@@ -36,8 +37,11 @@ impl NetlinkRouteKernelSocket {
         let request_header = request.header();
 
         let response_segments = match request {
+            RtnlSegment::NewRoute(request_segment) => route::do_new_route(request_segment),
+            RtnlSegment::NewLink(request_segment) => link::do_new_link(request_segment),
             RtnlSegment::GetLink(request_segment) => link::do_get_link(request_segment),
             RtnlSegment::GetAddr(request_segment) => addr::do_get_addr(request_segment),
+            RtnlSegment::NewAddr(request_segment) => addr::do_new_addr(request_segment),
             _ => Err(Error::with_message(
                 Errno::EOPNOTSUPP,
                 "the netlink route request is not supported",

--- a/kernel/src/net/socket/netlink/route/kernel/route.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/route.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Handle route-related requests.
+
+use crate::{
+    net::{
+        iface::iter_all_ifaces,
+        socket::netlink::{
+            message::ErrorSegment,
+            route::message::{RouteAttr, RouteSegment, RtnlSegment},
+        },
+    },
+    prelude::*,
+    util::net::CSocketAddrFamily,
+};
+
+/// Handles RTM_NEWROUTE: adds or replaces a route entry.
+///
+/// For now we only handle the common case of setting a default IPv4 gateway
+/// (`ip route add default via <gw> dev <iface>`).
+pub(super) fn do_new_route(request_segment: &RouteSegment) -> Result<Vec<RtnlSegment>> {
+    use aster_bigtcp::wire::Ipv4Address;
+
+    let body = request_segment.body();
+
+    if body.family != CSocketAddrFamily::AF_INET as u8 {
+        return_errno_with_message!(Errno::EAFNOSUPPORT, "only AF_INET routes are supported");
+    }
+
+    let mut gateway: Option<[u8; 4]> = None;
+    let mut oif: Option<u32> = None;
+
+    for attr in request_segment.attrs() {
+        match attr {
+            RouteAttr::Gateway(gw) => gateway = Some(*gw),
+            RouteAttr::Oif(idx)    => oif = Some(*idx),
+            RouteAttr::Dst(_)      => {}
+        }
+    }
+
+    let gw_octets = gateway.ok_or_else(|| {
+        Error::with_message(Errno::EINVAL, "no gateway in RTM_NEWROUTE")
+    })?;
+    let gateway_addr = Ipv4Address::new(
+        gw_octets[0], gw_octets[1], gw_octets[2], gw_octets[3],
+    );
+
+    // Find the target interface: prefer RTA_OIF match, otherwise use the first
+    // non-loopback interface.
+    let iface = if let Some(idx) = oif {
+        iter_all_ifaces()
+            .find(|i| i.index() == idx)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "interface not found"))?
+    } else {
+        iter_all_ifaces()
+            .find(|i| i.ipv4_addr().is_some())
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "no suitable interface found"))?
+    };
+
+    iface.set_ipv4_gateway(gateway_addr);
+
+    let ack = ErrorSegment::new_from_request(request_segment.header(), None);
+    Ok(vec![RtnlSegment::Error(ack)])
+}

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -27,7 +27,7 @@ enum AddrAttrClass {
     TARGET_NETNSID = 10,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum AddrAttr {
     Address([u8; 4]),
     Local([u8; 4]),
@@ -61,27 +61,22 @@ impl Attribute for AddrAttr {
     where
         Self: Sized,
     {
+        let attr_type = AddrAttrClass::try_from(header.type_()).ok();
         let payload_len = header.payload_len();
-        reader.skip_some(payload_len);
 
-        // GETADDR only supports dump requests. These requests do not have any attributes.
-        // According to the Linux behavior, we should just ignore all the attributes.
-
-        Ok(ContinueRead::Skipped)
-    }
-
-    fn read_all_from(
-        reader: &mut dyn MultiRead,
-        total_len: usize,
-    ) -> Result<ContinueRead<Vec<Self>>>
-    where
-        Self: Sized,
-    {
-        reader.skip_some(total_len);
-
-        // GETADDR only supports dump requests. These requests do not have any attributes.
-        // According to the Linux behavior, we should just ignore all the attributes.
-
-        Ok(ContinueRead::Skipped)
+        match attr_type {
+            Some(AddrAttrClass::ADDRESS) if payload_len == 4 => {
+                let octets: [u8; 4] = reader.read_val_opt()?.unwrap();
+                Ok(ContinueRead::Parsed(AddrAttr::Address(octets)))
+            }
+            Some(AddrAttrClass::LOCAL) if payload_len == 4 => {
+                let octets: [u8; 4] = reader.read_val_opt()?.unwrap();
+                Ok(ContinueRead::Parsed(AddrAttr::Local(octets)))
+            }
+            _ => {
+                reader.skip_some(payload_len);
+                Ok(ContinueRead::Skipped)
+            }
+        }
     }
 }

--- a/kernel/src/net/socket/netlink/route/message/attr/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/link.rs
@@ -82,7 +82,7 @@ enum LinkAttrClass {
     PARENT_DEV_BUS_NAME = 57,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum LinkAttr {
     Name(CString),
     Mtu(u32),

--- a/kernel/src/net/socket/netlink/route/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod addr;
 pub mod link;
+pub mod route;
 
 /// The size limit for interface names.
 const IFNAME_SIZE: usize = 16;

--- a/kernel/src/net/socket/netlink/route/message/attr/route.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/route.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    net::socket::netlink::message::{Attribute, CAttrHeader, ContinueRead},
+    prelude::*,
+    util::MultiRead,
+};
+
+/// Route-related attributes.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L394>.
+#[expect(non_camel_case_types)]
+#[expect(clippy::upper_case_acronyms)]
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+enum RouteAttrClass {
+    UNSPEC    = 0,
+    DST       = 1,
+    SRC       = 2,
+    IIF       = 3,
+    OIF       = 4,
+    GATEWAY   = 5,
+    PRIORITY  = 6,
+    PREFSRC   = 7,
+}
+
+#[derive(Clone, Debug)]
+pub enum RouteAttr {
+    Dst([u8; 4]),
+    Gateway([u8; 4]),
+    Oif(u32),
+}
+
+impl RouteAttr {
+    fn class(&self) -> RouteAttrClass {
+        match self {
+            RouteAttr::Dst(_)     => RouteAttrClass::DST,
+            RouteAttr::Gateway(_) => RouteAttrClass::GATEWAY,
+            RouteAttr::Oif(_)     => RouteAttrClass::OIF,
+        }
+    }
+}
+
+impl Attribute for RouteAttr {
+    fn type_(&self) -> u16 {
+        self.class() as u16
+    }
+
+    fn payload_as_bytes(&self) -> &[u8] {
+        match self {
+            RouteAttr::Dst(addr) | RouteAttr::Gateway(addr) => addr,
+            RouteAttr::Oif(_) => unreachable!("Oif is not written to user space"),
+        }
+    }
+
+    fn read_from(header: &CAttrHeader, reader: &mut dyn MultiRead) -> Result<ContinueRead<Self>>
+    where
+        Self: Sized,
+    {
+        let attr_type = RouteAttrClass::try_from(header.type_()).ok();
+        let payload_len = header.payload_len();
+
+        match attr_type {
+            Some(RouteAttrClass::GATEWAY) if payload_len == 4 => {
+                let octets: [u8; 4] = reader.read_val_opt()?.unwrap();
+                Ok(ContinueRead::Parsed(RouteAttr::Gateway(octets)))
+            }
+            Some(RouteAttrClass::DST) if payload_len == 4 => {
+                let octets: [u8; 4] = reader.read_val_opt()?.unwrap();
+                Ok(ContinueRead::Parsed(RouteAttr::Dst(octets)))
+            }
+            Some(RouteAttrClass::OIF) if payload_len == 4 => {
+                let index: u32 = reader.read_val_opt()?.unwrap();
+                Ok(ContinueRead::Parsed(RouteAttr::Oif(index)))
+            }
+            _ => {
+                reader.skip_some(payload_len);
+                Ok(ContinueRead::Skipped)
+            }
+        }
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/mod.rs
@@ -8,14 +8,19 @@
 mod attr;
 mod segment;
 
-pub(super) use attr::{addr::AddrAttr, link::LinkAttr};
+pub(super) use attr::{addr::AddrAttr, link::LinkAttr, route::RouteAttr};
 pub(super) use segment::{
     RtnlSegment,
     addr::{AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope},
     link::{LinkSegment, LinkSegmentBody},
+    route::RouteSegment,
 };
 
 use crate::net::socket::netlink::message::Message;
 
 /// A netlink route message.
 pub(in crate::net::socket::netlink) type RtnlMessage = Message<RtnlSegment>;
+
+use crate::net::socket::netlink::table::MulticastMessage;
+
+impl MulticastMessage for RtnlMessage {}

--- a/kernel/src/net/socket/netlink/route/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/mod.rs
@@ -38,6 +38,7 @@ pub mod route;
 
 use addr::AddrSegment;
 use link::LinkSegment;
+use route::RouteSegment;
 
 use crate::{
     net::socket::netlink::message::{
@@ -48,12 +49,13 @@ use crate::{
 };
 
 /// The netlink route segment, which is the basic unit of a netlink route message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum RtnlSegment {
     NewLink(LinkSegment),
     GetLink(LinkSegment),
     NewAddr(AddrSegment),
     GetAddr(AddrSegment),
+    NewRoute(RouteSegment),
     Done(DoneSegment),
     Error(ErrorSegment),
 }
@@ -67,6 +69,7 @@ impl ProtocolSegment for RtnlSegment {
             RtnlSegment::NewAddr(addr_segment) | RtnlSegment::GetAddr(addr_segment) => {
                 addr_segment.header()
             }
+            RtnlSegment::NewRoute(route_segment) => route_segment.header(),
             RtnlSegment::Done(done_segment) => done_segment.header(),
             RtnlSegment::Error(error_segment) => error_segment.header(),
         }
@@ -80,6 +83,7 @@ impl ProtocolSegment for RtnlSegment {
             RtnlSegment::NewAddr(addr_segment) | RtnlSegment::GetAddr(addr_segment) => {
                 addr_segment.header_mut()
             }
+            RtnlSegment::NewRoute(route_segment) => route_segment.header_mut(),
             RtnlSegment::Done(done_segment) => done_segment.header_mut(),
             RtnlSegment::Error(error_segment) => error_segment.header_mut(),
         }
@@ -91,11 +95,25 @@ impl ProtocolSegment for RtnlSegment {
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "the reader length is too small"))?;
 
         let segment = match CSegmentType::try_from(header.type_) {
+            Ok(CSegmentType::NOOP) | Ok(CSegmentType::ERROR) | Ok(CSegmentType::DONE) | Ok(CSegmentType::OVERRUN) => {
+                let payload_len = header.calc_payload_len_with_padding(reader)?;
+                reader.skip_some(payload_len);
+                ContinueRead::Skipped
+            }
+            Ok(CSegmentType::NEWROUTE) => {
+                RouteSegment::read_from(&header, reader)?.map(RtnlSegment::NewRoute)
+            }
+            Ok(CSegmentType::NEWLINK) => {
+                LinkSegment::read_from(&header, reader)?.map(RtnlSegment::NewLink)
+            }
             Ok(CSegmentType::GETLINK) => {
                 LinkSegment::read_from(&header, reader)?.map(RtnlSegment::GetLink)
             }
             Ok(CSegmentType::GETADDR) => {
                 AddrSegment::read_from(&header, reader)?.map(RtnlSegment::GetAddr)
+            }
+            Ok(CSegmentType::NEWADDR) => {
+                AddrSegment::read_from(&header, reader)?.map(RtnlSegment::NewAddr)
             }
             _ => {
                 let payload_len = header.calc_payload_len_with_padding(reader)?;
@@ -116,7 +134,7 @@ impl ProtocolSegment for RtnlSegment {
             RtnlSegment::NewAddr(addr_segment) => addr_segment.write_to(writer)?,
             RtnlSegment::Done(done_segment) => done_segment.write_to(writer)?,
             RtnlSegment::Error(error_segment) => error_segment.write_to(writer)?,
-            RtnlSegment::GetAddr(_) | RtnlSegment::GetLink(_) => {
+            RtnlSegment::NewRoute(_) | RtnlSegment::GetAddr(_) | RtnlSegment::GetLink(_) => {
                 unreachable!("kernel should not write get requests to user space");
             }
         }

--- a/kernel/src/net/socket/netlink/route/message/segment/route.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/route.rs
@@ -1,21 +1,97 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use super::legacy::CRtGenMsg;
+use crate::{
+    net::socket::netlink::{
+        message::{SegmentBody, SegmentCommon},
+        route::message::attr::route::RouteAttr,
+    },
+    prelude::*,
+};
+
+pub type RouteSegment = SegmentCommon<RouteSegmentBody, RouteAttr>;
+
+impl SegmentBody for RouteSegmentBody {
+    type CLegacyType = CRtGenMsg;
+    type CType = CRtMsg;
+}
 
 /// `rtmsg` in Linux.
 ///
 /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/rtnetlink.h#L237>.
-#[expect(unused)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
-pub(super) struct CRtMsg {
-    family: u8,
-    dst_len: u8,
-    src_len: u8,
-    tos: u8,
-    table: u8,
-    protocol: u8,
-    scope: u8,
-    type_: u8,
-    flags: u32,
+pub struct CRtMsg {
+    pub family:   u8,
+    pub dst_len:  u8,
+    pub src_len:  u8,
+    pub tos:      u8,
+    pub table:    u8,
+    pub protocol: u8,
+    pub scope:    u8,
+    pub type_:    u8,
+    pub flags:    u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RouteSegmentBody {
+    pub family:   u8,
+    pub dst_len:  u8,
+    pub src_len:  u8,
+    pub tos:      u8,
+    pub table:    u8,
+    pub protocol: u8,
+    pub scope:    u8,
+    pub type_:    u8,
+    pub flags:    u32,
+}
+
+impl TryFrom<CRtMsg> for RouteSegmentBody {
+    type Error = Error;
+
+    fn try_from(value: CRtMsg) -> Result<Self> {
+        Ok(Self {
+            family:   value.family,
+            dst_len:  value.dst_len,
+            src_len:  value.src_len,
+            tos:      value.tos,
+            table:    value.table,
+            protocol: value.protocol,
+            scope:    value.scope,
+            type_:    value.type_,
+            flags:    value.flags,
+        })
+    }
+}
+
+impl From<RouteSegmentBody> for CRtMsg {
+    fn from(value: RouteSegmentBody) -> Self {
+        Self {
+            family:   value.family,
+            dst_len:  value.dst_len,
+            src_len:  value.src_len,
+            tos:      value.tos,
+            table:    value.table,
+            protocol: value.protocol,
+            scope:    value.scope,
+            type_:    value.type_,
+            flags:    value.flags,
+        }
+    }
+}
+
+impl From<CRtGenMsg> for CRtMsg {
+    fn from(value: CRtGenMsg) -> Self {
+        Self {
+            family:   value.family,
+            dst_len:  0,
+            src_len:  0,
+            tos:      0,
+            table:    0,
+            protocol: 0,
+            scope:    0,
+            type_:    0,
+            flags:    0,
+        }
+    }
 }

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -57,7 +57,6 @@ pub trait SupportedNetlinkProtocol {
         socket_table.unicast(dst_port, message)
     }
 
-    #[cfg_attr(not(ktest), expect(dead_code))]
     fn multicast(dst_groups: GroupIdSet, message: Self::Message) -> Result<()>
     where
         Self::Message: MulticastMessage,


### PR DESCRIPTION
## Summary

This PR implements handlers for three write-type rtnetlink requests that were previously unhandled, enabling standard `iproute2` commands to configure network interfaces at runtime on Asterinas:

```sh
ip link set eth0 up
ip addr add 192.168.0.119/24 dev eth0
ip route add default via 192.168.0.1
```

Without this, all three commands either hung indefinitely waiting for a response or returned `EOPNOTSUPP`.

## Changes

### `aster-bigtcp`
- Add `set_ipv4_cidr()` and `set_ipv4_gateway()` to `Iface`, `IfaceCommon`, and `PollableIface` so the smoltcp interface can be reconfigured at runtime from kernel netlink handlers.

### RTM_NEWLINK (`do_new_link`)
- Returns ACK (error=0) so the caller does not block on a third `recvmsg`.
- Multicasts a `RTM_NEWLINK` notification to `RTMGRP_LINK` to unblock any monitoring socket subscribed to link events.

### RTM_NEWADDR (`do_new_addr`)
- Parses `IFA_ADDRESS` / `IFA_LOCAL` attributes from the request.
- Calls `iface.set_ipv4_cidr()` to assign the address to the smoltcp interface.

### RTM_NEWROUTE (`do_new_route`)
- New `RouteSegment` / `RouteAttr` types to fully parse the `rtmsg` body and `RTA_*` attributes.
- Parses `RTA_GATEWAY` and `RTA_OIF`, then calls `iface.set_ipv4_gateway()` to install the default route in smoltcp.

### Base netlink message types (NOOP / ERROR / DONE / OVERRUN)
- These were falling through to the default `SkippedErr(EOPNOTSUPP)` arm.
- Now return `Skipped` (no error sent back), which matches Linux kernel behaviour.

### MSG_TRUNC in `recvmsg`
- Honour `MSG_TRUNC` and return the actual message length even when the writer buffer is zero-length.
- `iproute2` uses `MSG_PEEK | MSG_TRUNC` with `iov_len=0` to probe message size before the real read; without this fix the size was reported as 0 and the subsequent read was mishandled.

## Testing

Tested by booting Asterinas with a NixOS guest that runs the three `iproute2` commands above during `stage-2-init`:
- All three commands complete without hanging.
- The interface responds correctly to ARP for the configured address.
- TCP connections reach the smoltcp stack (RST for unbound ports confirms layer-3 routing is functional).

Only AF_INET is handled; AF_INET6 support is left as a follow-up.
