### PR TITLE
Fix atomic mode violation in Condvar::wait_timeout timeout path

### DIFF
--- a/kernel/src/process/sync/condvar.rs
+++ b/kernel/src/process/sync/condvar.rs
@@ -167,8 +167,7 @@ impl Condvar {
         match res {
             Ok(()) => Ok((lock.lock(), false)),
             Err(_) => {
-                let mut counter = self.counter.lock();
-                counter.waiter_count -= 1;
+                self.counter.lock().waiter_count -= 1;
                 Err(LockErr::Timeout((lock.lock(), true)))
             }
         }


### PR DESCRIPTION
Fixes #3157.

## Problem
    
In `Condvar::wait_timeout`, the `Err(_)` (timeout) path held `self.counter` (a `SpinLock` with `PreemptDisabled` guard) across a call to `lock.lock()` (a `Mutex`). 
When the mutex is contested, `Mutex::lock` may sleep (`WaitQueue::wait_until` → `park_current` → `switch_to_task` →
`might_sleep`), which panics if `guard_count > 0`.
    
```
match res {
    Ok(()) => Ok((lock.lock(), false)),
    Err(_) => {
        let mut counter = self.counter.lock();  // guard_count +1
        counter.waiter_count -= 1;
        Err(LockErr::Timeout((lock.lock(), true))) // ⚠️ might_sleep with guard held
    }  // counter dropped here — too late
}
```
    
## Solution

Replace the named `SpinLockGuard` binding with an inline temporary, which Rust drops at the statement semicolon before `lock.lock()` runs.
    
```
Err(_) => {
    - let mut counter = self.counter.lock();
    - counter.waiter_count -= 1;
    +    self.counter.lock().waiter_count -= 1;
    Err(LockErr::Timeout((lock.lock(), true)))
}
```
    
## Related

- Issue #3157 (Case 3)