### PR TITLE
Preserve EOF during cached writeback for virtiofs

### DIFF
--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -156,26 +156,32 @@ impl VirtioFsInode {
         let page_cache = inner.page_cache().unwrap();
 
         if requested_end > old_size {
-            page_cache.resize(requested_end, old_size)?;
+            // Extend the visible EOF before growing the page cache.
+            self.set_size(requested_end);
+            page_cache
+                .resize(requested_end, old_size)
+                .expect("expanding the page cache should not fail");
         }
 
-        // If a later step fails, the enlarged page-cache capacity does not
-        // publish an EOF extension. The cached inode size advances only after
-        // writeback succeeds, and cached reads are limited by that size.
+        let mut write_through_page_cache = || -> Result<()> {
+            page_cache.write(offset, reader).map_err(Error::from)?;
+            page_cache.flush_range(offset..requested_end)
+        };
 
-        page_cache.write(offset, reader)?;
-
-        // FIXME: The page cache writeback API reports only the page index, not
-        // the dirty byte range within the page. Although this call flushes the
-        // requested byte range, the virtio-fs client currently only submits
-        // whole-page writes to the server. This can write bytes outside the
-        // user request.
-        page_cache.flush_range(offset..requested_end)?;
+        if let Err(err) = write_through_page_cache() {
+            if requested_end > old_size {
+                // Roll back in truncate order: shrink the page cache before
+                // restoring the old visible EOF.
+                page_cache.resize(old_size, requested_end)?;
+                self.set_size(old_size);
+            }
+            return Err(err);
+        }
 
         let new_size = self.size().max(requested_end);
         let attr_version = self.fs_ref().session().bump_attr_version();
+
         inner.commit_local_write(new_size, attr_version);
-        self.set_size(new_size);
 
         Ok(write_len)
     }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/page_cache.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/page_cache.rs
@@ -76,9 +76,17 @@ impl PageCacheBackend for VirtioFsInode {
     ) -> Result<()> {
         locked_page.wait_until_finish_writing_back();
 
+        let page_start = page_offset(idx)?;
+        let file_size = self.size();
+        if page_start >= file_size {
+            return_errno_with_message!(Errno::EINVAL, "virtiofs writeback page is beyond EOF");
+        }
+        let writeback_len = PAGE_SIZE.min(file_size - page_start);
+
         let fs = self.fs_ref();
-        let data_buf = fs.session().alloc_write_buf(PAGE_SIZE)?;
-        let page_reader = locked_page.reader();
+        let data_buf = fs.session().alloc_write_buf(writeback_len)?;
+        let mut page_reader = locked_page.reader();
+        page_reader.limit(writeback_len);
 
         data_buf
             .writer()
@@ -105,8 +113,8 @@ impl PageCacheBackend for VirtioFsInode {
         let complete_page = page.clone();
         let write_req = WriteReq::new(
             handle.fh(),
-            page_offset(idx)? as u64,
-            PAGE_SIZE as u32,
+            page_start as u64,
+            writeback_len as u32,
             handle.file_flags(),
             WriteFlags::empty(),
         );

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -174,6 +174,10 @@ impl PageCache {
     /// used to determine the boundary of previously valid data so that only the
     /// discarded range within a partially truncated tail page is zero-filled.
     ///
+    /// Extending the page cache does not eagerly allocate pages and therefore
+    /// cannot return an error. Shrinking may fail because it can zero-fill or
+    /// decommit existing pages.
+    ///
     /// # Size Synchronization
     ///
     /// `PageCache::resize` only updates the page-aligned [`Vmo`] capacity. The


### PR DESCRIPTION
This PR fixes a virtiofs cached-write bug where writing a small file could incorrectly make the file size become one page, typically 4096 bytes.

## Root Cause 
Virtiofs page-cache writeback always submitted a full-page `FUSE_WRITE`, even when the dirty range ended before `EOF`. For example, writing a few bytes to a new file dirtied one cache page, and writeback sent the whole 4096-byte page to the virtiofs server.

## Solution
This PR updates virtiofs writeback to cap each page write by the inode EOF:
  - Cached writes temporarily publish the target EOF before flushing page cache data.
  - `write_page_async` uses the current inode size to calculate the valid writeback length for the page.
  - The final page is written only up to `EOF` instead of always writing `PAGE_SIZE`.