### PR TITLE
Correct and optimize the create-related operations in `Ext2`

### DIFF
--- a/kernel/src/fs/fs_impls/ext2/inode/dir/dir_entry.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/dir_entry.rs
@@ -317,12 +317,12 @@ pub(super) struct DirBlockViewIter<'a> {
 }
 
 impl DirBlockViewIter<'_> {
-    /// Reads the next entry header and name.
+    /// Reads the next entry header and advances the iterator.
     ///
-    /// Returns `(offset_within_block, DirEntry)` when an entry is found. The
-    /// `offset_within_block` is relative to the `DirBlockView`'s start, not
-    /// absolute.
-    pub(super) fn next_entry(&mut self) -> Result<Option<(usize, DirEntry<'_>)>> {
+    /// Returns `(offset_within_block, DirEntryHeader)` when an entry is found.
+    /// The `offset_within_block` is relative to the start of the
+    /// `DirBlockView`.
+    pub(super) fn next_entry_header(&mut self) -> Result<Option<(usize, DirEntryHeader)>> {
         let end = self.block.offset + self.block.limit;
         if self.cursor >= end {
             return Ok(None);
@@ -330,9 +330,27 @@ impl DirBlockViewIter<'_> {
 
         let header = self.block.read_header(self.cursor)?;
         let rec_len = header.rec_len as usize;
-        let name_len = header.name_len as usize;
+        let entry_offset = self.cursor - self.block.offset;
+        self.cursor += rec_len;
+
+        Ok(Some((entry_offset, header)))
+    }
+
+    /// Reads the next entry and advances the iterator.
+    ///
+    /// Returns `(offset_within_block, DirEntry)` when an entry is found. The
+    /// `offset_within_block` is relative to the start of the `DirBlockView`.
+    /// Deleted entries are returned with an empty `name`.
+    ///
+    /// The returned `name` borrows from the iterator's reusable buffer.
+    pub(super) fn next_entry(&mut self) -> Result<Option<(usize, DirEntry<'_>)>> {
+        let Some((entry_offset, header)) = self.next_entry_header()? else {
+            return Ok(None);
+        };
+
         let name = if header.ino != 0 {
-            let name_abs_offset = self.cursor + Self::HEADER_LEN;
+            let name_len = header.name_len as usize;
+            let name_abs_offset = self.block.offset + entry_offset + Self::HEADER_LEN;
             self.block
                 .page_cache
                 .read_bytes(name_abs_offset, &mut self.name_buf[..name_len])?;
@@ -340,9 +358,6 @@ impl DirBlockViewIter<'_> {
         } else {
             &[]
         };
-
-        let entry_offset = self.cursor - self.block.offset;
-        self.cursor += rec_len;
 
         Ok(Some((entry_offset, DirEntry { header, name })))
     }

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -123,11 +123,12 @@ impl Inode {
         let is_dir = type_ == InodeType::Dir;
         let dir_entry_file_type = DirEntryFileType::from(type_);
 
-        // Scan for a slot before creating the child inode to avoid wasting
-        // an inode allocation when the name already exists (EEXIST).
+        // Find a slot before creating the child inode to avoid wasting
+        // an inode allocation if the directory cannot accept a new entry.
+        // The VFS dentry layer has already validated that `name` is absent.
         let fs = self.fs()?;
         let mut parent_inner = self.inner.write();
-        let slot = match parent_inner.scan_dir_for_slot(name)? {
+        let slot = match parent_inner.find_dir_slot(name.len())? {
             Some(slot) => slot,
             None => parent_inner.grow_dir_block(&fs)?,
         };
@@ -179,7 +180,7 @@ impl Inode {
         }
 
         let dir_inner = guards.inner_mut(self.ino());
-        let slot = match dir_inner.scan_dir_for_slot(name)? {
+        let slot = match dir_inner.find_dir_slot(name.len())? {
             Some(slot) => slot,
             None => dir_inner.grow_dir_block(&fs)?,
         };
@@ -466,7 +467,7 @@ impl InodeInner {
         ino: Ext2Ino,
         file_type: DirEntryFileType,
     ) -> Result<()> {
-        let slot = match self.scan_dir_for_slot(name)? {
+        let slot = match self.find_dir_slot(name.len())? {
             Some(slot) => slot,
             None => self.grow_dir_block(fs)?,
         };
@@ -488,8 +489,8 @@ impl InodeInner {
             let mut entry_iter = block.iter_entries();
 
             loop {
-                let (_entry_offset, entry) = match entry_iter.next_entry() {
-                    Ok(Some(pair)) => pair,
+                let entry = match entry_iter.next_entry() {
+                    Ok(Some((_, entry))) => entry,
                     Ok(None) => break,
                     Err(_) => return false,
                 };
@@ -579,14 +580,16 @@ impl InodeInner {
         Ok(advanced)
     }
 
-    /// Scans directory blocks for a reusable slot or a duplicate entry.
-    fn scan_dir_for_slot(&self, name: &str) -> Result<Option<DirSlotInfo>> {
+    /// Finds a reusable slot for a directory entry name of `name_len` bytes.
+    ///
+    /// Returns `None` if existing directory blocks have no reusable space. The
+    /// returned slot may be a deleted entry or the spare tail of a live entry.
+    fn find_dir_slot(&self, name_len: usize) -> Result<Option<DirSlotInfo>> {
         if self.inode_type() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
 
-        let name_bytes = name.as_bytes();
-        let new_rec_len = DirEntryHeader::min_rec_len(name_bytes.len()) as usize;
+        let new_rec_len = DirEntryHeader::min_rec_len(name_len) as usize;
         debug_assert!(new_rec_len <= BLOCK_SIZE);
 
         let file_size = self.file_size();
@@ -598,19 +601,14 @@ impl InodeInner {
             let block = DirBlockView::from_index(page_cache, block_idx, file_size);
             let mut entry_iter = block.iter_entries();
 
-            while let Some((entry_offset, entry)) = entry_iter.next_entry()? {
-                let ino = entry.header.ino;
-                let rec_len = entry.header.rec_len as usize;
-
-                // Check for duplicate name.
-                if ino != 0 && entry.name == name_bytes {
-                    return_errno!(Errno::EEXIST);
-                }
+            while let Some((entry_offset, header)) = entry_iter.next_entry_header()? {
+                let ino = header.ino;
+                let rec_len = header.rec_len as usize;
 
                 let used_rec_len = if ino == 0 {
                     0
                 } else {
-                    DirEntryHeader::min_rec_len(entry.header.name_len as usize) as usize
+                    DirEntryHeader::min_rec_len(header.name_len as usize) as usize
                 };
 
                 // Free entry can be reused, occupied entry can be split.

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use hashbrown::HashMap;
-use ostd::sync::RwMutexWriteGuard;
+use ostd::sync::{RwMutexUpgradeableGuard, RwMutexWriteGuard};
 
 use super::{is_dot, is_dot_or_dotdot, is_dotdot};
 use crate::{
@@ -396,25 +396,7 @@ impl DirDentry<'_> {
         type_: InodeType,
         mode: InodeMode,
     ) -> Result<Arc<Dentry>> {
-        let children = self.children.upread();
-        if let Some(entry) = children.find(name)
-            && entry.is_positive()
-        {
-            if self.revalidate_cached_entry(name, &entry) {
-                return_errno_with_message!(Errno::EEXIST, "the dentry already exists");
-            }
-
-            let mut children = children.upgrade();
-            let _ = children.remove(name);
-            let new_inode = self.inode.create(name, type_, mode)?;
-
-            let new_child = Dentry::new(
-                new_inode,
-                DentryOptions::Named((String::from(name), self.this())),
-            );
-            return Ok(self.insert_positive_child(&mut children, name, new_child));
-        }
-
+        let children = self.validate_child_absent(name)?;
         let new_inode = self.inode.create(name, type_, mode)?;
         let mut children = children.upgrade();
         let new_child = Dentry::new(
@@ -423,6 +405,43 @@ impl DirDentry<'_> {
         );
 
         Ok(self.insert_positive_child(&mut children, name, new_child))
+    }
+
+    /// Validates that `name` is absent and keeps that result stable for creation.
+    fn validate_child_absent<'a>(
+        &'a self,
+        name: &str,
+    ) -> Result<RwMutexUpgradeableGuard<'a, DentryChildren>> {
+        let mut children = self.children.upread();
+
+        if let Some(cached_entry) = children.find(name) {
+            if self.revalidate_cached_entry(name, &cached_entry) {
+                return match cached_entry {
+                    CachedDentry::Positive { .. } => {
+                        return_errno_with_message!(Errno::EEXIST, "the dentry already exists")
+                    }
+                    CachedDentry::Negative => Ok(children),
+                };
+            }
+
+            let mut children_for_update = children.upgrade();
+            let _ = children_for_update.remove(name);
+            children = children_for_update.downgrade();
+        }
+
+        match self.inode.lookup(name) {
+            Ok(inode) => {
+                let existing_child = Dentry::new(
+                    inode,
+                    DentryOptions::Named((String::from(name), self.this())),
+                );
+                let mut children_for_update = children.upgrade();
+                self.insert_positive_child(&mut children_for_update, name, existing_child);
+                return_errno_with_message!(Errno::EEXIST, "the dentry already exists");
+            }
+            Err(error) if error.error() == Errno::ENOENT => Ok(children),
+            Err(error) => Err(error),
+        }
     }
 
     /// Inserts a positive child dentry into the directory cache.
@@ -527,11 +546,7 @@ impl DirDentry<'_> {
         mode: InodeMode,
         type_: MknodType,
     ) -> Result<Arc<Dentry>> {
-        let children = self.children.upread();
-        if children.contains_positive(name) {
-            return_errno!(Errno::EEXIST);
-        }
-
+        let children = self.validate_child_absent(name)?;
         let inode = self.inode.mknod(name, mode, type_)?;
         let new_child = Dentry::new(
             inode,
@@ -544,11 +559,7 @@ impl DirDentry<'_> {
 
     /// Links a new `Dentry` by `link()` the old inode.
     pub(super) fn link(&self, old_inode: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        let children = self.children.upread();
-        if children.contains_positive(name) {
-            return_errno!(Errno::EEXIST);
-        }
-
+        let children = self.validate_child_absent(name)?;
         self.inode.link(old_inode, name)?;
         let dentry = Dentry::new(
             old_inode.clone(),
@@ -902,13 +913,6 @@ impl DentryChildren {
     /// Finds a cached dentry by name.
     fn find(&self, name: &str) -> Option<CachedDentry> {
         self.entries.get(name).cloned()
-    }
-
-    /// Checks if a positive dentry with the given name exists.
-    fn contains_positive(&self, name: &str) -> bool {
-        self.entries
-            .get(name)
-            .is_some_and(|child| child.is_positive())
     }
 
     /// Inserts a positive dentry.


### PR DESCRIPTION
Currently, when the VFS performs create-related operations, it only checks whether there is a child with the same name in the dentry cache, and then directly calls the filesystem layer’s `create` operation. At the same time, our filesystem-layer implementation does not properly check for duplicate names. As a result, due to races or later eviction under memory pressure, the corresponding child may be absent from the dentry cache even though a child with the same name actually exists in the filesystem layer, which can lead to creating duplicate entries.

Therefore, the first commit in this PR moves the complete duplicate-name check into the VFS layer, which reduces the complexity of the filesystem-layer logic and is consistent with Linux’s behavior. 

The second commit optimizes the slot lookup in `Ext2` file creation, reducing many unnecessary page cache read operations.