### PR TITLE
Fix virtiofs request queue descriptor exhaustion

### DIFF
--- a/kernel/comps/virtio/src/device/filesystem/device/mod.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/mod.rs
@@ -87,8 +87,8 @@ impl FileSystemDevice {
     /// # Locking
     ///
     /// Builds the request before taking the selected request queue `SpinLock`.
-    /// The queue lock is held only while enqueueing and is released before the
-    /// waiter is returned.
+    /// The submit path may sleep waiting for free queue descriptors, but the
+    /// queue lock is never held across that wait.
     fn submit_fuse_op<Op: FuseOperation>(
         &self,
         nodeid: FuseNodeId,
@@ -100,7 +100,7 @@ impl FileSystemDevice {
         let waiter = request.waiter().clone();
 
         let queue = self.select_request_queue(request.nodeid());
-        self.submit(queue, request);
+        self.submit(queue, request)?;
 
         Ok(waiter)
     }
@@ -176,8 +176,12 @@ impl FileSystemDevice {
         FuseUnique::new(self.next_unique.fetch_add(1, Ordering::Relaxed))
     }
 
-    fn submit(&self, request_queue: &FsRequestQueue, request: FuseRequest) {
-        request_queue.add_request(request);
+    fn submit(
+        &self,
+        request_queue: &FsRequestQueue,
+        request: FuseRequest,
+    ) -> Result<(), FuseError> {
+        request_queue.add_request(request)
     }
 
     fn alloc_and_fill_request_buf(

--- a/kernel/comps/virtio/src/device/filesystem/device/queue.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/queue.rs
@@ -9,11 +9,12 @@
 use alloc::{sync::Arc, vec::Vec};
 use core::mem;
 
+use aster_fuse::FuseError;
 use aster_softirq::Taskless;
 use aster_util::{mem_obj_slice::Slice, slot_vec::SlotVec};
 use ostd::{
     mm::dma::{FromDevice, ToDevice},
-    sync::{LocalIrqDisabled, SpinLock},
+    sync::{LocalIrqDisabled, SpinLock, WaitQueue},
 };
 use smallvec::SmallVec;
 use spin::Once;
@@ -21,9 +22,17 @@ use spin::Once;
 use super::request::FuseRequest;
 use crate::{device::filesystem::pool::FsDmaStorage, queue::VirtQueue};
 
+/// Maximum virtqueue descriptors used by one FUSE request.
+///
+/// Current requests use at most two to-device buffers (request header/body and
+/// optional write payload) and two from-device buffers (reply header and
+/// optional read payload).
+pub(super) const MAX_DMA_BUFS_PER_REQUEST: usize = 4;
+
 /// A virtio-fs request queue and its in-flight request state.
 pub(super) struct FsRequestQueue {
     inner: SpinLock<FsRequestQueueInner, LocalIrqDisabled>,
+    wait_queue: WaitQueue,
     taskless: Once<Arc<Taskless>>,
 }
 
@@ -47,6 +56,7 @@ impl FsRequestQueue {
                 in_flight_requests: SlotVec::new(),
                 pending_completions: Vec::new(),
             }),
+            wait_queue: WaitQueue::new(),
             taskless: Once::new(),
         })
     }
@@ -73,43 +83,65 @@ impl FsRequestQueue {
     }
 
     /// Submits a FUSE request to the virtqueue.
-    pub(super) fn add_request(&self, request: FuseRequest) {
-        let mut inner = self.inner.lock();
-        let token = {
-            let request_bufs = request
-                .request_bufs()
-                .iter()
-                .map(|buf| buf.as_dma_slice())
-                .collect::<SmallVec<[&Slice<FsDmaStorage<ToDevice>>; 2]>>();
-            let reply_bufs = request
-                .waiter()
-                .reply_bufs()
-                .iter()
-                .map(|buf| buf.as_dma_slice())
-                .collect::<SmallVec<[&Slice<FsDmaStorage<FromDevice>>; 2]>>();
+    pub(super) fn add_request(&self, request: FuseRequest) -> Result<(), FuseError> {
+        let num_dma_bufs = request.num_dma_bufs();
+        debug_assert!(num_dma_bufs <= MAX_DMA_BUFS_PER_REQUEST);
 
-            inner
-                .queue
-                .add_dma_bufs(request_bufs.as_slice(), reply_bufs.as_slice())
-                .unwrap()
-        };
+        let mut request = Some(request);
 
-        inner.in_flight_requests.put_at(token as usize, request);
+        self.wait_queue.wait_until(|| {
+            let mut inner = self.inner.lock();
+            if num_dma_bufs > inner.queue.available_desc() {
+                return None;
+            }
 
-        if inner.queue.should_notify() {
-            inner.queue.notify();
-        }
+            let request = request.take().unwrap();
+            let token = {
+                let request_bufs = request
+                    .request_bufs()
+                    .iter()
+                    .map(|buf| buf.as_dma_slice())
+                    .collect::<SmallVec<[&Slice<FsDmaStorage<ToDevice>>; 2]>>();
+                let reply_bufs = request
+                    .waiter()
+                    .reply_bufs()
+                    .iter()
+                    .map(|buf| buf.as_dma_slice())
+                    .collect::<SmallVec<[&Slice<FsDmaStorage<FromDevice>>; 2]>>();
+
+                inner
+                    .queue
+                    .add_dma_bufs(request_bufs.as_slice(), reply_bufs.as_slice())
+                    .unwrap()
+            };
+            inner.in_flight_requests.put_at(token as usize, request);
+
+            if inner.queue.should_notify() {
+                inner.queue.notify();
+            }
+
+            Some(())
+        });
+
+        Ok(())
     }
 
     /// Moves completed virtqueue descriptors into the pending-completion list.
     pub(super) fn drain_completed_requests(&self) {
         let mut inner = self.inner.lock();
+        let mut has_freed_descs = false;
         while let Ok((token, len)) = inner.queue.pop_used() {
+            has_freed_descs = true;
             let reply_len = len as usize;
             let request = inner.in_flight_requests.remove(token as usize).unwrap();
             inner
                 .pending_completions
                 .push(CompletedFuseRequest { request, reply_len });
+        }
+        drop(inner);
+
+        if has_freed_descs {
+            self.wait_queue.wake_all();
         }
     }
 

--- a/kernel/comps/virtio/src/device/filesystem/device/request.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/request.rs
@@ -75,6 +75,11 @@ impl FuseRequest {
         self.request_bufs.as_slice()
     }
 
+    /// Returns the number of virtqueue descriptors needed by this request.
+    pub(super) fn num_dma_bufs(&self) -> usize {
+        self.request_bufs.len() + self.waiter.reply_bufs().iter().count()
+    }
+
     /// Returns the waiter that owns the reply buffers and completion status.
     pub(super) fn waiter(&self) -> &Arc<FuseWaiter> {
         &self.waiter

--- a/kernel/comps/virtio/src/device/filesystem/device/session.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/session.rs
@@ -290,7 +290,7 @@ impl FuseSession {
             .device
             .prepare_request(nodeid, &mut operation, None, None)?;
         self.device
-            .submit(self.device.hiprio_queue.as_ref(), request);
+            .submit(self.device.hiprio_queue.as_ref(), request)?;
 
         Ok(())
     }

--- a/kernel/comps/virtio/src/device/filesystem/device/virtio_ops.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/virtio_ops.rs
@@ -12,7 +12,8 @@ use core::cmp;
 use ostd::{arch::trap::TrapFrame, debug, info};
 
 use super::{
-    DEFAULT_QUEUE_SIZE, FileSystemDevice, HIPRIO_QUEUE_INDEX, queue::FsRequestQueue,
+    DEFAULT_QUEUE_SIZE, FileSystemDevice, HIPRIO_QUEUE_INDEX,
+    queue::{FsRequestQueue, MAX_DMA_BUFS_PER_REQUEST},
     register_device,
 };
 use crate::{
@@ -158,6 +159,10 @@ impl FileSystemDevice {
             .max_queue_size(index)
             .map_err(VirtioDeviceError::from)?;
         let queue_size = DEFAULT_QUEUE_SIZE.min(max_queue_size);
+
+        if queue_size < MAX_DMA_BUFS_PER_REQUEST as u16 {
+            return Err(VirtioDeviceError::UnsupportedConfig);
+        }
 
         VirtQueue::new(index, queue_size, transport).map_err(Into::into)
     }


### PR DESCRIPTION
## Summary
- wait for free virtqueue descriptors before submitting virtio-fs requests
- propagate submit failures through the FUSE submit path instead of unwrapping
- reject virtio-fs queues that cannot fit the maximum descriptors needed by one request