### PR TITLE
Fix block device error codes and enhance virtio-blk feature negotiation

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -27,7 +27,7 @@ use ostd::{
     sync::SpinLock,
 };
 
-use super::{BlockFeatures, VirtioBlockConfig, VirtioBlockFeature};
+use super::{BlockFeatures, VirtioBlockConfig};
 use crate::{
     VIRTIO_BLOCK_MAJOR_ID,
     device::{
@@ -124,10 +124,8 @@ impl BlockDevice {
     }
 
     /// Negotiate features for the device specified bits 0~23
-    pub(crate) fn negotiate_features(features: u64) -> u64 {
-        let mut support_features = BlockFeatures::from_bits_truncate(features);
-        support_features.remove(BlockFeatures::MQ);
-        support_features.bits
+    pub(crate) fn negotiate_features(device_features: u64) -> u64 {
+        BlockFeatures::negotiated_with_device(device_features).bits()
     }
 }
 
@@ -199,7 +197,7 @@ impl aster_block::BlockDevice for BlockDevice {
 #[derive(Debug)]
 struct DeviceInner {
     config_manager: ConfigManager<VirtioBlockConfig>,
-    features: VirtioBlockFeature,
+    features: BlockFeatures,
     queue: SpinLock<VirtQueue>,
     transport: SpinLock<Box<dyn VirtioTransport>>,
     block_requests: Arc<DmaStream>,
@@ -218,7 +216,16 @@ impl DeviceInner {
         let config = config_manager.read_config();
         debug!("virio_blk_config = {:?}", config);
 
-        let block_size = config_manager.block_size();
+        let features = BlockFeatures::negotiated_with_device(transport.read_device_features());
+
+        let block_size = if features.contains(BlockFeatures::BLK_SIZE) {
+            config_manager.block_size()
+        } else {
+            // Fall back to standard sector size SECTOR_SIZE (512 bytes)
+            // Reference:
+            // <https://docs.oasis-open.org/virtio/virtio/v1.2/virtio-v1.2.html#x1-2790004>
+            VirtioBlockConfig::sector_size()
+        };
         if block_size != VirtioBlockConfig::sector_size() {
             ostd::error!("block size {} is not supported yet", block_size);
             return Err(VirtioDeviceError::UnsupportedConfig);
@@ -233,8 +240,6 @@ impl DeviceInner {
                 "Multi-Queue Block IO Queueing Mechanism is not supported yet; using the first queue"
             );
         }
-
-        let features = VirtioBlockFeature::new(transport.as_ref());
 
         let queue = VirtQueue::new(0, Self::QUEUE_SIZE, transport.as_mut())?;
 
@@ -477,7 +482,7 @@ impl DeviceInner {
     /// Flushes any cached data from the guest to the persistent storage on the host.
     /// This will be ignored if the device doesn't support the `VIRTIO_BLK_F_FLUSH` feature.
     fn flush(&self, bio_request: BioRequest) {
-        if !self.features.support_flush {
+        if !self.features.contains(BlockFeatures::FLUSH) {
             bio_request.into_bios().for_each(|bio| {
                 bio.complete(BioStatus::Complete);
             });

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -30,6 +30,14 @@ bitflags! {
         const MQ            = 1 << 12;
         const DISCARD       = 1 << 13;
         const WRITE_ZEROES  = 1 << 14;
+
+        const ALL_SUPPORTED = Self::BLK_SIZE.bits() | Self::FLUSH.bits();
+    }
+}
+
+impl BlockFeatures {
+    pub(super) fn negotiated_with_device(device_features: u64) -> Self {
+        BlockFeatures::from_bits_truncate(device_features) & Self::ALL_SUPPORTED
     }
 }
 
@@ -116,12 +124,6 @@ struct VirtioBlockTopology {
     opt_io_size: u32,
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
-struct VirtioBlockFeature {
-    support_flush: bool,
-}
-
 impl VirtioBlockConfig {
     pub(self) fn new_manager(transport: &dyn VirtioTransport) -> ConfigManager<Self> {
         let safe_ptr = transport
@@ -195,12 +197,5 @@ impl ConfigManager<VirtioBlockConfig> {
             .unwrap() as usize;
 
         (cap_high << 32) | cap_low
-    }
-}
-
-impl VirtioBlockFeature {
-    pub(self) fn new(transport: &dyn VirtioTransport) -> Self {
-        let support_flush = (transport.read_device_features() & BlockFeatures::FLUSH.bits()) != 0;
-        VirtioBlockFeature { support_flush }
     }
 }

--- a/kernel/comps/virtio/src/device/network/config.rs
+++ b/kernel/comps/virtio/src/device/network/config.rs
@@ -50,7 +50,7 @@ bitflags! {
 }
 
 impl NetworkFeatures {
-    pub(super) fn support_features() -> Self {
+    pub(super) fn supported_features() -> Self {
         NetworkFeatures::VIRTIO_NET_F_MAC | NetworkFeatures::VIRTIO_NET_F_STATUS
     }
 }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -56,7 +56,7 @@ impl PollStatistics {
 impl NetworkDevice {
     pub(crate) fn negotiate_features(device_features: u64) -> u64 {
         let device_features = NetworkFeatures::from_bits_truncate(device_features);
-        let supported_features = NetworkFeatures::support_features();
+        let supported_features = NetworkFeatures::supported_features();
         let network_features = device_features & supported_features;
 
         if network_features != device_features {

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -240,7 +240,7 @@ impl From<aster_block::bio::BioStatus> for Error {
     fn from(err_status: aster_block::bio::BioStatus) -> Self {
         match err_status {
             aster_block::bio::BioStatus::NotSupported => {
-                Error::with_message(Errno::EIO, "I/O operation is not supported")
+                Error::with_message(Errno::EOPNOTSUPP, "I/O operation is not supported")
             }
             aster_block::bio::BioStatus::NoSpace => {
                 Error::with_message(Errno::ENOSPC, "Insufficient space on device")
@@ -257,7 +257,7 @@ impl From<io_util::IoError> for Error {
     fn from(error: io_util::IoError) -> Self {
         match error {
             io_util::IoError::Unsupported => {
-                Error::with_message(Errno::EIO, "I/O operation is not supported")
+                Error::with_message(Errno::EOPNOTSUPP, "I/O operation is not supported")
             }
             io_util::IoError::OutOfSpace => {
                 Error::with_message(Errno::ENOSPC, "Insufficient space on device")


### PR DESCRIPTION
## Summary
This PR fix block device error codes and enhance virtio-blk feature negotiation.

## Changes
- Fix bio error reporting to use EOPNOTSUPP for unsupported operations
- Enhance virtio-blk feature negotiation for BLK_SIZE and FLUSH
- Rename `support_features` to `supported_features` for NetworkFeatures to better reflect its purpose

