### PR TITLE
Make use of ` save_from_cpu_with_irq_disabled` and improve the FS/GS base code

### DIFF
--- a/kernel/src/process/posix_thread/cpu_sync.rs
+++ b/kernel/src/process/posix_thread/cpu_sync.rs
@@ -79,12 +79,24 @@ use ostd::irq::DisabledLocalIrqGuard;
 /// It is **not** `Sync` and must not be accessed across threads.
 ///
 /// All methods assume kernel preemption cannot occur
-/// for the duration of the call (the existing `ThreadLocal` discipline).
+/// for the duration of the call.
+/// In the current architecture, this is always true
+/// because kernel preemption was never implemented.
 ///
-/// [`before_schedule`]:  Self::before_schedule
+/// More importantly, we cannot implement kernel preemption
+/// without refactoring the `ThreadLocal` mechanism
+/// because `ThreadLocal` cannot be accessed in interrupt handlers
+/// for soundness reasons.
+/// But such access is necessary for the preempted schedule.
+///
+/// Therefore, we omit the preemption guards for better performance and
+/// defer preemption considerations to future work.
+///
+/// [`before_schedule`]: Self::before_schedule
 /// [`before_user_exec`]: Self::before_user_exec
-/// [`get`]:              Self::get
-/// [`set`]:              Self::set
+/// [`get`]: Self::get
+/// [`set`]: Self::set
+#[derive(Debug)]
 pub struct CpuSync<R> {
     location: Cell<CanonicalValueLocation>,
     reg: RefCell<R>,
@@ -97,7 +109,7 @@ impl<R: UserReg> CpuSync<R> {
     /// The CPU register is presumed to
     /// hold some other task's bytes (or nobody's)
     /// until the first [`Self::before_user_exec`] loads `reg` onto it.
-    pub const fn new(reg: R) -> Self {
+    pub(super) const fn new(reg: R) -> Self {
         Self {
             location: Cell::new(CanonicalValueLocation::InMemory),
             reg: RefCell::new(reg),
@@ -141,14 +153,6 @@ impl<R: UserReg> CpuSync<R> {
         }
     }
 
-    /// Returns where the canonical value currently lives.
-    ///
-    /// Only useful for diagnostics.
-    #[expect(unused)]
-    pub fn location(&self) -> CanonicalValueLocation {
-        self.location.get()
-    }
-
     // ---- Lifecycle callbacks ----
 
     /// Scheduler hook: this task is about to be switched off the CPU.
@@ -156,7 +160,7 @@ impl<R: UserReg> CpuSync<R> {
     /// This hook method ensures that
     /// the canonical value of the register `R` is saved into `self`
     /// and the canonical value location is marked `InMemory`.
-    pub fn before_schedule(&self, guard: &DisabledLocalIrqGuard) {
+    pub(super) fn before_schedule(&self, guard: &DisabledLocalIrqGuard) {
         let loc = self.location.get();
         if loc == CanonicalValueLocation::OnCpu {
             self.reg.borrow_mut().save_from_cpu_with_irq_disabled(guard);
@@ -174,9 +178,9 @@ impl<R: UserReg> CpuSync<R> {
     /// This hook method ensures that
     /// the canonical value of the register `R` is loaded to the CPU hardware
     /// and the canonical value location is marked `OnCpu`.
-    pub fn before_user_exec(&self) {
+    pub(super) fn before_user_exec(&self, guard: &DisabledLocalIrqGuard) {
         if self.location.get() == CanonicalValueLocation::InMemory {
-            self.reg.borrow().restore_to_cpu();
+            self.reg.borrow().restore_to_cpu_with_irq_disabled(guard);
         }
         self.location.set(CanonicalValueLocation::OnCpu);
     }
@@ -208,11 +212,21 @@ pub trait UserReg {
     ///
     /// May be invoked in any IRQ state.
     fn restore_to_cpu(&self);
+
+    /// Writes `self`'s value into the CPU register(s),
+    /// with the caller's guarantee that local IRQs are disabled.
+    ///
+    /// Implementors may override to take a cheaper path
+    /// that is only safe with IRQs disabled
+    /// The default falls back to [`Self::restore_to_cpu`].
+    fn restore_to_cpu_with_irq_disabled(&self, _guard: &DisabledLocalIrqGuard) {
+        self.restore_to_cpu();
+    }
 }
 
 /// Where the latest canonical value of a [`UserReg`] currently lives.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CanonicalValueLocation {
+enum CanonicalValueLocation {
     /// Only the in-memory copy holds the canonical value.
     InMemory,
     /// Only the CPU register holds the canonical value.
@@ -221,7 +235,7 @@ pub enum CanonicalValueLocation {
     Both,
 }
 
-// ---------- UserReg impls for ostd register types ----------
+// ---------- `UserReg` impls for OSTD register types ----------
 
 impl UserReg for ostd::arch::cpu::context::FpuContext {
     fn save_from_cpu(&mut self) {
@@ -247,10 +261,20 @@ impl UserReg for ostd::arch::cpu::context::FsBase {
 #[cfg(target_arch = "x86_64")]
 impl UserReg for ostd::arch::cpu::context::GsBase {
     fn save_from_cpu(&mut self) {
-        self.save();
+        let guard = ostd::irq::disable_local();
+        self.save(&guard);
+    }
+
+    fn save_from_cpu_with_irq_disabled(&mut self, guard: &DisabledLocalIrqGuard) {
+        self.save(guard);
     }
 
     fn restore_to_cpu(&self) {
-        self.load();
+        let guard = ostd::irq::disable_local();
+        self.load(&guard);
+    }
+
+    fn restore_to_cpu_with_irq_disabled(&self, guard: &DisabledLocalIrqGuard) {
+        self.load(guard)
     }
 }

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -287,12 +287,12 @@ impl SuppUserContext {
         }
     }
 
-    pub fn before_user_exec(&self) {
-        self.fpu.before_user_exec();
+    pub fn before_user_exec(&self, guard: &DisabledLocalIrqGuard) {
+        self.fpu.before_user_exec(guard);
         #[cfg(target_arch = "x86_64")]
         {
-            self.fs_base.before_user_exec();
-            self.gs_base.before_user_exec();
+            self.fs_base.before_user_exec(guard);
+            self.gs_base.before_user_exec(guard);
         }
     }
 }

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -55,13 +55,11 @@ fn post_schedule_handler() {
     }
 }
 
-fn pre_user_run_handler() {
+fn pre_user_run_handler(guard: &DisabledLocalIrqGuard) {
     let task = Task::current().unwrap();
-    let Some(thread_local) = task.as_thread_local() else {
-        return;
-    };
+    let thread_local = task.as_thread_local().unwrap();
 
-    thread_local.supp_user_context().before_user_exec();
+    thread_local.supp_user_context().before_user_exec(guard);
 }
 
 pub(super) fn init() {

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -12,7 +12,7 @@ use crate::x86::amd64_efi::alloc::alloc_pages;
 
 pub(super) const PAGE_SIZE: u64 = 4096;
 
-/// SAFETY: The name does not collide with other symbols.
+// SAFETY: The name does not collide with other symbols.
 #[unsafe(no_mangle)]
 unsafe extern "sysv64" fn main_efi_common64(
     handle: Handle,

--- a/ostd/libs/linux-bzimage/setup/src/x86/legacy_i386/mod.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/legacy_i386/mod.rs
@@ -11,7 +11,7 @@ global_asm!(include_str!("setup.S"));
 
 const ASTER_ENTRY_POINT: *const () = 0x8001000 as _;
 
-/// SAFETY: The name does not collide with other symbols.
+// SAFETY: The name does not collide with other symbols.
 #[unsafe(export_name = "main_legacy32")]
 extern "cdecl" fn main_legacy32(boot_params_ptr: *mut BootParams) -> ! {
     crate::println!(

--- a/ostd/libs/ostd-macros/src/lib.rs
+++ b/ostd/libs/ostd-macros/src/lib.rs
@@ -251,7 +251,7 @@ pub fn global_heap_allocator_slot_map(_attr: TokenStream, item: TokenStream) -> 
     );
 
     quote!(
-        /// SAFETY: The name does not collide with other symbols.
+        // SAFETY: The name does not collide with other symbols.
         #[unsafe(no_mangle)]
         const extern "Rust" fn __global_heap_slot_info_from_layout(
             layout: ::core::alloc::Layout,

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -145,7 +145,6 @@ impl UserContextApiInternal for UserContext {
     {
         let ret = loop {
             crate::task::scheduler::might_preempt();
-            crate::task::call_pre_user_run_handler();
             self.user_context.run();
 
             let cause = loongArch64::register::estat::read().cause();

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -289,10 +289,10 @@ impl PageTableEntry {
 
 impl PodOnce for PageTableEntry {}
 
-/// SAFETY: The implementation is safe because:
-///  - `from_usize` and `into_usize` are not overridden;
-///  - `from_repr` and `repr` are correctly implemented;
-///  - a zeroed PTE represents an absent entry.
+// SAFETY: The implementation is safe because:
+//  - `from_usize` and `into_usize` are not overridden;
+//  - `from_repr` and `repr` are correctly implemented;
+//  - a zeroed PTE represents an absent entry.
 unsafe impl PteTrait for PageTableEntry {
     fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
         match repr {

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -77,10 +77,15 @@ impl RawUserContext {
     /// On return, the context will be reset to the status before the trap.
     /// Trap reason will be placed at `estat`.
     pub(in crate::arch) fn run(&mut self) {
+        let guard = crate::irq::disable_local();
+
+        crate::task::call_pre_user_run_handler(&guard);
+
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after switching `SAVE_SCRATCH` will mess up the CPU state.
-        crate::arch::irq::disable_local();
-        unsafe { run_user(self) }
+        core::mem::forget(guard);
+
+        unsafe { run_user(self) };
     }
 }
 

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -179,7 +179,6 @@ impl UserContextApiInternal for UserContext {
     {
         loop {
             crate::task::scheduler::might_preempt();
-            crate::task::call_pre_user_run_handler();
             self.user_context.run();
 
             let scause = riscv::register::scause::read();

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -281,10 +281,10 @@ impl PageTableEntry {
 
 impl PodOnce for PageTableEntry {}
 
-/// SAFETY: The implementation is safe because:
-///  - `from_usize` and `into_usize` are not overridden;
-///  - `from_repr` and `repr` are correctly implemented;
-///  - a zeroed PTE represents an absent entry.
+// SAFETY: The implementation is safe because:
+//  - `from_usize` and `into_usize` are not overridden;
+//  - `from_repr` and `repr` are correctly implemented;
+//  - a zeroed PTE represents an absent entry.
 unsafe impl PteTrait for PageTableEntry {
     fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
         match repr {

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -121,10 +121,15 @@ impl RawUserContext {
     /// On return, the context will be reset to the status before the trap.
     /// Trap reason and error code will be placed at `scause` and `stval`.
     pub(in crate::arch) fn run(&mut self) {
+        let guard = crate::irq::disable_local();
+
+        crate::task::call_pre_user_run_handler(&guard);
+
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after switching `sscratch` will mess up the CPU state.
-        crate::arch::irq::disable_local();
-        unsafe { run_user(self) }
+        core::mem::forget(guard);
+
+        unsafe { run_user(self) };
     }
 }
 

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     cpu::PrivilegeLevel,
     debug,
-    irq::{call_irq_callback_functions, disable_local},
+    irq::{DisabledLocalIrqGuard, call_irq_callback_functions},
     mm::Vaddr,
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
@@ -113,9 +113,10 @@ impl GsBase {
     }
 
     /// Saves the current CPU GS base into this struct.
-    pub fn save(&mut self) {
-        let _guard = disable_local();
-        // SAFETY: Reading the user GS base does not affect kernel code.
+    pub fn save(&mut self, _guard: &DisabledLocalIrqGuard) {
+        // SAFETY:
+        // 1. In these steps, we have disabled the IRQ and are not using the kernel GS base.
+        // 2. Reading the user GS base does not affect kernel code.
         unsafe {
             swapgs();
             self.0 = rdgsbase() as usize;
@@ -124,9 +125,10 @@ impl GsBase {
     }
 
     /// Loads this struct's GS base onto the CPU.
-    pub fn load(&self) {
-        let _guard = disable_local();
-        // SAFETY: Writing the user GS base does not affect kernel code.
+    pub fn load(&self, _guard: &DisabledLocalIrqGuard) {
+        // SAFETY:
+        // 1. In these steps, we have disabled the IRQ and are not using the kernel GS base.
+        // 2. Writing the user GS base does not affect kernel code.
         unsafe {
             swapgs();
             wrgsbase(self.0 as u64);
@@ -315,7 +317,6 @@ impl UserContextApiInternal for UserContext {
         // Return when it is syscall or cpu exception type is Fault or Trap.
         loop {
             crate::task::scheduler::might_preempt();
-            crate::task::call_pre_user_run_handler();
             self.user_context.run();
 
             let exception =

--- a/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/second_stage.rs
@@ -167,10 +167,10 @@ impl PageTableEntry {
 
 impl PodOnce for PageTableEntry {}
 
-/// SAFETY: The implementation is safe because:
-///  - `from_usize` and `into_usize` are not overridden;
-///  - `from_repr` and `repr` are correctly implemented;
-///  - a zeroed PTE represents an absent entry.
+// SAFETY: The implementation is safe because:
+//  - `from_usize` and `into_usize` are not overridden;
+//  - `from_repr` and `repr` are correctly implemented;
+//  - a zeroed PTE represents an absent entry.
 unsafe impl PteTrait for PageTableEntry {
     fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
         match repr {

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -294,10 +294,10 @@ impl PageTableEntry {
 
 impl PodOnce for PageTableEntry {}
 
-/// SAFETY: The implementation is safe because:
-///  - `from_usize` and `into_usize` are not overridden;
-///  - `from_repr` and `repr` are correctly implemented;
-///  - a zeroed PTE represents an absent entry.
+// SAFETY: The implementation is safe because:
+//  - `from_usize` and `into_usize` are not overridden;
+//  - `from_repr` and `repr` are correctly implemented;
+//  - a zeroed PTE represents an absent entry.
 unsafe impl PteTrait for PageTableEntry {
     fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
         match repr {

--- a/ostd/src/arch/x86/trap/syscall.rs
+++ b/ostd/src/arch/x86/trap/syscall.rs
@@ -81,11 +81,14 @@ impl RawUserContext {
     /// If `trap_num` is `0x100`, it will go user by `sysret` (`rcx` and `r11` are dropped),
     /// otherwise it will use `iret`.
     pub(in crate::arch) fn run(&mut self) {
+        let guard = crate::irq::disable_local();
+
+        crate::task::call_pre_user_run_handler(&guard);
+
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after executing `swapgs` will mess up the CPU state.
-        crate::arch::irq::disable_local();
-        unsafe {
-            syscall_return(self);
-        }
+        core::mem::forget(guard);
+
+        unsafe { syscall_return(self) };
     }
 }

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -37,7 +37,7 @@ static PRE_SCHEDULE_HANDLER: Once<fn(&DisabledLocalIrqGuard)> = Once::new();
 
 static POST_SCHEDULE_HANDLER: Once<fn()> = Once::new();
 
-static PRE_USER_RUN_HANDLER: Once<fn()> = Once::new();
+static PRE_USER_RUN_HANDLER: Once<fn(&DisabledLocalIrqGuard)> = Once::new();
 
 /// Injects a handler to be executed before scheduling.
 pub fn inject_pre_schedule_handler(handler: fn(&DisabledLocalIrqGuard)) {
@@ -50,7 +50,7 @@ pub fn inject_post_schedule_handler(handler: fn()) {
 }
 
 /// Injects a handler to be executed right before entering user mode.
-pub fn inject_pre_user_run_handler(handler: fn()) {
+pub fn inject_pre_user_run_handler(handler: fn(&DisabledLocalIrqGuard)) {
     PRE_USER_RUN_HANDLER.call_once(|| handler);
 }
 
@@ -58,9 +58,9 @@ pub fn inject_pre_user_run_handler(handler: fn()) {
 ///
 /// Called by architecture-specific `execute()` implementations
 /// right before entering user mode.
-pub(crate) fn call_pre_user_run_handler() {
+pub(crate) fn call_pre_user_run_handler(guard: &DisabledLocalIrqGuard) {
     if let Some(handler) = PRE_USER_RUN_HANDLER.get() {
-        handler();
+        handler(guard);
     }
 }
 


### PR DESCRIPTION
For some reason,  `save_from_cpu_with_irq_disabled` is introduced in https://github.com/asterinas/asterinas/pull/3286, but it is not properly implemented. This PR resolves this issue and several others.