### PR TITLE
Remove an unncessary `fs_base.get()` during `clone()`

### DIFF
--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -708,11 +708,12 @@ fn clone_tls_regs(
     tls: u64,
 ) -> (FsBase, GsBase) {
     let supp = thread_local.supp_user_context();
-    let mut child_fs_base = supp.fs_base().get();
+    let child_fs_base = if clone_flags.contains(CloneFlags::CLONE_SETTLS) {
+        FsBase::new(tls as usize)
+    } else {
+        supp.fs_base().get()
+    };
     let child_gs_base = supp.gs_base().get();
-    if clone_flags.contains(CloneFlags::CLONE_SETTLS) {
-        child_fs_base = FsBase::new(tls as usize);
-    }
 
     (child_fs_base, child_gs_base)
 }

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub mod alien_access;
 mod builder;
-pub(super) mod cpu_sync;
+mod cpu_sync;
 mod exit;
 pub mod futex;
 mod name;


### PR DESCRIPTION
Another minor improvement (cc https://github.com/asterinas/asterinas/pull/3286)..

We shouldn't need to call `fs_base().get()` if `CLONE_SETTLS` is specified, right?