### PR TITLE
Bump asterinas/kata version to 0.18.0

### DIFF
--- a/book/src/kernel/vm-based-containers/kata.md
+++ b/book/src/kernel/vm-based-containers/kata.md
@@ -100,7 +100,7 @@ to enter an environment with Kata and Asterinas preinstalled:
 docker run -it \
     "${KATA_DOCKER_ARGS[@]}" \
     -w /root/kata-containers \
-    asterinas/kata:0.17.2-20260523
+    asterinas/kata:0.18.0-20260603
 ```
 
 The command above makes `/root/kata-containers` the working directory,
@@ -123,7 +123,7 @@ docker run -it \
     "${KATA_DOCKER_ARGS[@]}" \
     -v "${ASTERINAS_SRC}:/root/asterinas" \
     -w /root/kata-containers \
-    asterinas/kata:0.17.2-20260523
+    asterinas/kata:0.18.0-20260603
 ```
 
 This setup allows you to rebuild the kernel


### PR DESCRIPTION
The [kata for asterinas 0.18.0 release](https://github.com/asterinas/kata-containers/releases/tag/3.28.0-20260604-asterinas) is ready. We can bump the version for `asterinas/kata` now.