### PR TITLE
Revert `TrapFrame::_pad` removal for soundness reasons

### DIFF
--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -380,6 +380,7 @@ impl UserContextApiInternal for UserContext {
             r13: self.user_context.general.r13,
             r14: self.user_context.general.r14,
             r15: self.user_context.general.r15,
+            _pad: 0,
             trap_num: self.user_context.trap_num,
             error_code: self.user_context.error_code,
             rip: self.user_context.general.rip,

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -82,6 +82,7 @@ pub struct TrapFrame {
     pub r13: usize,
     pub r14: usize,
     pub r15: usize,
+    pub _pad: usize,
 
     pub trap_num: usize,
     pub error_code: usize,
@@ -91,6 +92,16 @@ pub struct TrapFrame {
     pub cs: usize,
     pub rflags: usize,
 }
+
+// The padding field in `TrapFrame` is necessary. Do not attempt to remove it
+// without considering this note. Otherwise, the code will be **unsound**.
+//
+// According to the System V AMD64 ABI, the stack pointer should be aligned to
+// at least 16 bytes. The hardware will align the stack pointer to a 16-byte
+// boundary for exceptions and interrupts ("In IA-32e mode, the RSP is aligned
+// to a 16-byte boundary before pushing the stack frame"), so we only need to
+// ensure the size of a `TrapFrame` is also aligned.
+crate::const_assert!(size_of::<TrapFrame>().is_multiple_of(16));
 
 /// Initializes interrupt handling on x86_64.
 ///

--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -111,6 +111,7 @@ _trap_from_kernel:
     # - rax
 
     pop rax
+    push 0
     push r15
     push r14
     push r13
@@ -149,7 +150,7 @@ _trap_from_kernel:
     pop r14
     pop r15
 
-    # skip trap_num and error_code
-    add rsp, 16
+    # skip padding, trap_num, error_code
+    add rsp, 24
 
     iretq

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -228,9 +228,10 @@ impl TaskOptions {
         // the context switch.
         //
         // According to the System V AMD64 ABI, the stack pointer should be aligned
-        // to at least 16 bytes. And a larger alignment is needed if larger arguments
-        // are passed to the function. The `kernel_task_entry` function does not
-        // have any arguments, so we only need to align the stack pointer to 16 bytes.
+        // to at least 16 bytes. A larger alignment is needed if larger arguments
+        // are passed to the function, which is not the case for the
+        // `kernel_task_entry` function because it does not have any arguments. So
+        // we only need to align the stack pointer to 16 bytes.
         ctx.set_stack_pointer(kstack.end_vaddr() - 16);
 
         let new_task = Task {


### PR DESCRIPTION
https://github.com/asterinas/asterinas/pull/3286 removes `TrapFrame::_pad`. But **doing so is unsound** because it violates the calling conventions specified in the System V ABI.

Read this note:
```rust
// The padding field in `TrapFrame` is necessary. Do not attempt to remove it
// without considering this note. Otherwise, the code will be **unsound**.
//
// According to the System V AMD64 ABI, the stack pointer should be aligned to
// at least 16 bytes. The hardware will align the stack pointer to a 16-byte
// boundary for exceptions and interrupts ("In IA-32e mode, the RSP is aligned
// to a 16-byte boundary before pushing the stack frame"), so we only need to
// ensure the size of a `TrapFrame` is also aligned.
crate::const_assert!(size_of::<TrapFrame>().is_multiple_of(16));
```