### PR TITLE
Bump asterinas/coco version with Asterinas 0.18.0

### DIFF
--- a/book/src/kernel/vm-based-containers/coco.md
+++ b/book/src/kernel/vm-based-containers/coco.md
@@ -91,7 +91,7 @@ to enter an environment with CoCo and Asterinas preinstalled:
 ```bash
 docker run -it \
     "${COCO_DOCKER_ARGS[@]}" \
-    asterinas/coco:0.17.2-20260407
+    asterinas/coco:0.18.0-20260603
 ```
 
 The image bundles the CoCo runtime, the Asterinas guest kernel,
@@ -115,7 +115,7 @@ ASTERINAS_SRC=$HOME/asterinas
 docker run -it \
     "${COCO_DOCKER_ARGS[@]}" \
     -v "${ASTERINAS_SRC}:/root/asterinas" \
-    asterinas/coco:0.17.2-20260407
+    asterinas/coco:0.18.0-20260603
 ```
 
 The `asterinas/coco` image is built on top of the `asterinas/asterinas` image,


### PR DESCRIPTION
[CoCo with Asterinas 0.18.0](https://github.com/asterinas/confidential-containers/releases/tag/v0.19.0-20260604) is released, so bump the version of `asterinas/coco` in book.