### PR TITLE
Replace `has_kernel_event` and `inject_pre_user_run_handler` with `UserModeHooks`

### DIFF
--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -55,18 +55,10 @@ fn post_schedule_handler() {
     }
 }
 
-fn pre_user_run_handler(guard: &DisabledLocalIrqGuard) {
-    let task = Task::current().unwrap();
-    let thread_local = task.as_thread_local().unwrap();
-
-    thread_local.supp_user_context().before_user_exec(guard);
-}
-
 pub(super) fn init() {
     CONTEXT_SWITCH_COUNTER.call_once(PerCpuCounter::new);
     ostd::task::inject_pre_schedule_handler(pre_schedule_handler);
     ostd::task::inject_post_schedule_handler(post_schedule_handler);
-    ostd::task::inject_pre_user_run_handler(pre_user_run_handler);
     ostd::arch::trap::inject_user_page_fault_handler(exception::page_fault_handler);
 }
 

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -2,10 +2,11 @@
 
 use ostd::{
     arch::cpu::context::UserContext,
+    irq::DisabledLocalIrqGuard,
     mm::VmIo,
     sync::Waiter,
     task::{Task, TaskOptions},
-    user::{ReturnReason, UserContextApi, UserMode},
+    user::{ReturnReason, UserContextApi, UserMode, UserModeHooks},
 };
 
 use super::{Thread, oops};
@@ -62,8 +63,6 @@ pub fn create_new_user_task(
             task: &current_task,
         };
 
-        let has_kernel_event_fn = || ctx.has_pending();
-
         // The startup method is only executed when the first user thread starts up.
         if ctx.posix_thread.tid() == FIRST_POSIX_TID {
             crate::init::on_first_process_startup(&ctx);
@@ -71,7 +70,7 @@ pub fn create_new_user_task(
 
         while !current_thread.is_exited() {
             // Execute the user code
-            let return_reason = user_mode.execute(has_kernel_event_fn);
+            let return_reason = user_mode.execute(&ctx);
 
             // Handle user events
             let user_ctx = user_mode.context_mut();
@@ -134,4 +133,16 @@ pub fn create_new_user_task(
     .local_data(thread_local)
     .build()
     .expect("spawn task failed")
+}
+
+impl UserModeHooks for Context<'_> {
+    fn has_kernel_event(&self) -> bool {
+        self.has_pending()
+    }
+
+    fn pre_user_run(&self, guard: &DisabledLocalIrqGuard) {
+        self.thread_local
+            .supp_user_context()
+            .before_user_exec(guard);
+    }
 }

--- a/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
+++ b/osdk/tests/examples_in_book/write_a_kernel_in_100_lines_templates/lib.rs
@@ -19,7 +19,7 @@ use ostd::mm::{
 use ostd::power::{poweroff, ExitCode};
 use ostd::prelude::*;
 use ostd::task::{disable_preempt, Task, TaskOptions};
-use ostd::user::{ReturnReason, UserMode};
+use ostd::user::{DummyUserHooks, ReturnReason, UserMode};
 
 /// The kernel's boot and initialization process is managed by OSTD.
 /// After the process is done, the kernel's execution environment
@@ -77,7 +77,7 @@ fn create_user_task(vm_space: Arc<VmSpace>) -> Arc<Task> {
             // The execute method returns when system
             // calls or CPU exceptions occur or some
             // events specified by the kernel occur.
-            let return_reason = user_mode.execute(|| false);
+            let return_reason = user_mode.execute(&DummyUserHooks);
 
             // The CPU registers of the user space
             // can be accessed and manipulated via

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     cpu::PrivilegeLevel,
     irq::call_irq_callback_functions,
-    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+    user::{ReturnReason, UserContextApi, UserContextApiInternal, UserModeHooks},
 };
 
 /// General registers
@@ -139,13 +139,13 @@ impl UserContext {
 }
 
 impl UserContextApiInternal for UserContext {
-    fn execute<F>(&mut self, mut has_kernel_event: F) -> ReturnReason
-    where
-        F: FnMut() -> bool,
-    {
+    fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
         let ret = loop {
             crate::task::scheduler::might_preempt();
-            self.user_context.run();
+
+            let guard = crate::irq::disable_local();
+            hooks.pre_user_run(&guard);
+            self.user_context.run(guard);
 
             let cause = loongArch64::register::estat::read().cause();
             let badv = loongArch64::register::badv::read().raw();
@@ -235,7 +235,7 @@ impl UserContextApiInternal for UserContext {
                 }
             }
 
-            if has_kernel_event() {
+            if hooks.has_kernel_event() {
                 break ReturnReason::KernelEvent;
             }
         };

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -2,7 +2,7 @@
 
 use core::arch::global_asm;
 
-use crate::arch::cpu::context::GeneralRegs;
+use crate::{arch::cpu::context::GeneralRegs, irq::DisabledLocalIrqGuard};
 
 global_asm!(include_str!("trap.S"));
 
@@ -76,11 +76,7 @@ impl RawUserContext {
     ///
     /// On return, the context will be reset to the status before the trap.
     /// Trap reason will be placed at `estat`.
-    pub(in crate::arch) fn run(&mut self) {
-        let guard = crate::irq::disable_local();
-
-        crate::task::call_pre_user_run_handler(&guard);
-
+    pub(in crate::arch) fn run(&mut self, guard: DisabledLocalIrqGuard) {
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after switching `SAVE_SCRATCH` will mess up the CPU state.
         core::mem::forget(guard);

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -17,7 +17,7 @@ use crate::{
         trap::{RawUserContext, SSTATUS_FS_MASK, TrapFrame, handle_irq},
     },
     cpu::PrivilegeLevel,
-    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+    user::{ReturnReason, UserContextApi, UserContextApiInternal, UserModeHooks},
 };
 
 /// Userspace CPU context, including general-purpose registers and exception information.
@@ -173,13 +173,13 @@ impl UserContext {
 }
 
 impl UserContextApiInternal for UserContext {
-    fn execute<F>(&mut self, mut has_kernel_event: F) -> ReturnReason
-    where
-        F: FnMut() -> bool,
-    {
+    fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
         loop {
             crate::task::scheduler::might_preempt();
-            self.user_context.run();
+
+            let guard = crate::irq::disable_local();
+            hooks.pre_user_run(&guard);
+            self.user_context.run(guard);
 
             let scause = riscv::register::scause::read();
             let Ok(cause) = Trap::<Interrupt, Exception>::try_from(scause.cause()) else {
@@ -214,7 +214,7 @@ impl UserContextApiInternal for UserContext {
                 }
             }
 
-            if has_kernel_event() {
+            if hooks.has_kernel_event() {
                 break ReturnReason::KernelEvent;
             }
         }

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -18,9 +18,12 @@
 
 use core::arch::{asm, global_asm};
 
-use crate::arch::cpu::{
-    context::GeneralRegs,
-    extension::{IsaExtensions, has_extensions},
+use crate::{
+    arch::cpu::{
+        context::GeneralRegs,
+        extension::{IsaExtensions, has_extensions},
+    },
+    irq::DisabledLocalIrqGuard,
 };
 
 /// FPU status bits.
@@ -120,11 +123,7 @@ impl RawUserContext {
     ///
     /// On return, the context will be reset to the status before the trap.
     /// Trap reason and error code will be placed at `scause` and `stval`.
-    pub(in crate::arch) fn run(&mut self) {
-        let guard = crate::irq::disable_local();
-
-        crate::task::call_pre_user_run_handler(&guard);
-
+    pub(in crate::arch) fn run(&mut self, guard: DisabledLocalIrqGuard) {
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after switching `sscratch` will mess up the CPU state.
         core::mem::forget(guard);

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     debug,
     irq::{DisabledLocalIrqGuard, call_irq_callback_functions},
     mm::Vaddr,
-    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+    user::{ReturnReason, UserContextApi, UserContextApiInternal, UserModeHooks},
 };
 
 cfg_if! {
@@ -304,10 +304,7 @@ impl UserContext {
 }
 
 impl UserContextApiInternal for UserContext {
-    fn execute<F>(&mut self, mut has_kernel_event: F) -> ReturnReason
-    where
-        F: FnMut() -> bool,
-    {
+    fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
         // set interrupt flag so that in user mode it can receive external interrupts
         // set ID flag which means cpu support CPUID instruction
         self.user_context.general.rflags |= (RFlags::INTERRUPT_FLAG | RFlags::ID).bits() as usize;
@@ -317,7 +314,10 @@ impl UserContextApiInternal for UserContext {
         // Return when it is syscall or cpu exception type is Fault or Trap.
         loop {
             crate::task::scheduler::might_preempt();
-            self.user_context.run();
+
+            let guard = crate::irq::disable_local();
+            hooks.pre_user_run(&guard);
+            self.user_context.run(guard);
 
             let exception =
                 CpuException::new(self.user_context.trap_num, self.user_context.error_code);
@@ -356,7 +356,7 @@ impl UserContextApiInternal for UserContext {
                 }
             }
 
-            if has_kernel_event() {
+            if hooks.has_kernel_event() {
                 break ReturnReason::KernelEvent;
             }
         }

--- a/ostd/src/arch/x86/trap/syscall.rs
+++ b/ostd/src/arch/x86/trap/syscall.rs
@@ -27,7 +27,7 @@ use x86_64::{
 };
 
 use super::RawUserContext;
-use crate::mm::PagingConstsTrait;
+use crate::{irq::DisabledLocalIrqGuard, mm::PagingConstsTrait};
 
 global_asm!(
     include_str!("syscall.S"),
@@ -80,11 +80,7 @@ impl RawUserContext {
     ///
     /// If `trap_num` is `0x100`, it will go user by `sysret` (`rcx` and `r11` are dropped),
     /// otherwise it will use `iret`.
-    pub(in crate::arch) fn run(&mut self) {
-        let guard = crate::irq::disable_local();
-
-        crate::task::call_pre_user_run_handler(&guard);
-
+    pub(in crate::arch) fn run(&mut self, guard: DisabledLocalIrqGuard) {
         // Return to userspace with interrupts disabled. Otherwise, interrupts
         // after executing `swapgs` will mess up the CPU state.
         core::mem::forget(guard);

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -37,8 +37,6 @@ static PRE_SCHEDULE_HANDLER: Once<fn(&DisabledLocalIrqGuard)> = Once::new();
 
 static POST_SCHEDULE_HANDLER: Once<fn()> = Once::new();
 
-static PRE_USER_RUN_HANDLER: Once<fn(&DisabledLocalIrqGuard)> = Once::new();
-
 /// Injects a handler to be executed before scheduling.
 pub fn inject_pre_schedule_handler(handler: fn(&DisabledLocalIrqGuard)) {
     PRE_SCHEDULE_HANDLER.call_once(|| handler);
@@ -47,21 +45,6 @@ pub fn inject_pre_schedule_handler(handler: fn(&DisabledLocalIrqGuard)) {
 /// Injects a handler to be executed after scheduling.
 pub fn inject_post_schedule_handler(handler: fn()) {
     POST_SCHEDULE_HANDLER.call_once(|| handler);
-}
-
-/// Injects a handler to be executed right before entering user mode.
-pub fn inject_pre_user_run_handler(handler: fn(&DisabledLocalIrqGuard)) {
-    PRE_USER_RUN_HANDLER.call_once(|| handler);
-}
-
-/// Runs the pre-user-run handler if one has been injected.
-///
-/// Called by architecture-specific `execute()` implementations
-/// right before entering user mode.
-pub(crate) fn call_pre_user_run_handler(guard: &DisabledLocalIrqGuard) {
-    if let Some(handler) = PRE_USER_RUN_HANDLER.get() {
-        handler(guard);
-    }
 }
 
 /// A task that executes a function to the end.

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -2,16 +2,17 @@
 
 //! User mode.
 
-use crate::arch::{cpu::context::UserContext, trap::TrapFrame};
+use crate::{
+    arch::{cpu::context::UserContext, trap::TrapFrame},
+    irq::DisabledLocalIrqGuard,
+};
 
-/// Specific architectures need to implement this trait. This should only used in [`UserMode`]
+/// The internal interface that every CPU architecture-specific [`UserContext`] implements.
 ///
-/// Only visible in `ostd`.
+/// This should only used in [`UserMode`]. It is only visible in `ostd`.
 pub(crate) trait UserContextApiInternal {
     /// Starts executing in the user mode.
-    fn execute<F>(&mut self, has_kernel_event: F) -> ReturnReason
-    where
-        F: FnMut() -> bool;
+    fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason;
 
     /// Uses the information inside CpuContext to build a trapframe
     fn as_trap_frame(&self) -> TrapFrame;
@@ -46,18 +47,24 @@ pub trait UserContextApi {
 /// Here is a sample code on how to use `UserMode`.
 ///  
 /// ```no_run
-/// use ostd::task::Task;
+/// # fn handle_return(_reason: crate::user::ReturnReason) {}
+/// #
+/// use crate::{
+///     arch::cpu::context::UserContext,
+///     user::{DummyUserHooks, UserMode},
+/// };
 ///
-/// let current = Task::current();
-/// let user_ctx = current.user_ctx()
-///     .expect("the current task is not associated with a user context");
-/// let mut user_mode = UserMode::new(UserContext::clone(user_ctx));
+/// let user_ctx = UserContext::default();
+/// let mut user_mode = UserMode::new(user_ctx);
+///
+/// // Note: Users should activate a suitable `VmSpace` before to support
+/// // user-mode execution.
+///
 /// loop {
 ///     // Execute in the user space until some interesting events occur.
-///     // Note: users should activate a suitable `VmSpace` before to support
-///     // user-mode execution.
-///     let return_reason = user_mode.execute(|| false);
-///     todo!("handle the event, e.g., syscall");
+///     let return_reason = user_mode.execute(&DummyUserHooks);
+///     // Handle the event, e.g., a system call.
+///     handle_return(return_reason);
 /// }
 /// ```
 pub struct UserMode {
@@ -87,12 +94,9 @@ impl UserMode {
     /// and updating the user-mode CPU context,
     /// this method can be invoked again to go back to the user space.
     #[track_caller]
-    pub fn execute<F>(&mut self, has_kernel_event: F) -> ReturnReason
-    where
-        F: FnMut() -> bool,
-    {
+    pub fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
         crate::task::atomic_mode::might_sleep();
-        self.context.execute(has_kernel_event)
+        self.context.execute(hooks)
     }
 
     /// Returns an immutable reference the user-mode CPU context.
@@ -106,9 +110,9 @@ impl UserMode {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
 /// A reason as to why the control of the CPU is returned from
 /// the user space to the kernel.
+#[derive(Debug, Eq, PartialEq)]
 pub enum ReturnReason {
     /// A system call is issued by the user space.
     UserSyscall,
@@ -117,3 +121,26 @@ pub enum ReturnReason {
     /// A kernel event is pending
     KernelEvent,
 }
+
+/// Hooks that will be called during [`UserMode::execute`].
+pub trait UserModeHooks {
+    /// Checks whether a kernel event is pending.
+    ///
+    /// This method will be called after user space is interrupted
+    /// by external interrupts. If the result is `true`,
+    /// [`UserMode::execute`] will return with [`ReturnReason::KernelEvent`].
+    fn has_kernel_event(&self) -> bool {
+        false
+    }
+
+    /// Prepares user space execution.
+    ///
+    /// This method will be called just before entering user space.
+    /// Local IRQs are disabled and will only be enabled after entering user space.
+    fn pre_user_run(&self, _guard: &DisabledLocalIrqGuard) {}
+}
+
+/// A struct that provides dummy (no-op) user mode hooks.
+pub struct DummyUserHooks;
+
+impl UserModeHooks for DummyUserHooks {}


### PR DESCRIPTION
Emmm... This should be my last follow-up to https://github.com/asterinas/asterinas/pull/3286. Hopefully!

`UserModeHooks` sounds like a better idea than `inject_pre_user_run_handler`, doesn't it?
```rust
/// Hooks that will be called during [`UserMode::execute`].
pub trait UserModeHooks {
    /// Checks whether a kernel event is pending.
    ///
    /// This method will be called after user space is interrupted
    /// by external interrupts. If the result is `true`,
    /// [`UserMode::execute`] will return with [`ReturnReason::KernelEvent`].
    fn has_kernel_event(&self) -> bool {
        false
    }

    /// Prepares user space execution.
    ///
    /// This method will be called just before entering user space.
    /// Local IRQs are disabled and will only be enabled after entering user space.
    fn pre_user_run(&self, _guard: &DisabledLocalIrqGuard) {}
}

impl UserMode {
    pub fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason;
}
```