### PR TITLE
Report real RSP before the trap in `TrapFrame`

### DIFF
--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -371,7 +371,6 @@ impl UserContextApiInternal for UserContext {
             rsi: self.user_context.general.rsi,
             rdi: self.user_context.general.rdi,
             rbp: self.user_context.general.rbp,
-            rsp: self.user_context.general.rsp,
             r8: self.user_context.general.r8,
             r9: self.user_context.general.r9,
             r10: self.user_context.general.r10,
@@ -380,12 +379,13 @@ impl UserContextApiInternal for UserContext {
             r13: self.user_context.general.r13,
             r14: self.user_context.general.r14,
             r15: self.user_context.general.r15,
-            _pad: 0,
             trap_num: self.user_context.trap_num,
             error_code: self.user_context.error_code,
             rip: self.user_context.general.rip,
             cs: 0,
             rflags: self.user_context.general.rflags,
+            rsp: self.user_context.general.rsp,
+            ss: 0,
         }
     }
 }

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -73,7 +73,6 @@ pub struct TrapFrame {
     pub rsi: usize,
     pub rdi: usize,
     pub rbp: usize,
-    pub rsp: usize,
     pub r8: usize,
     pub r9: usize,
     pub r10: usize,
@@ -82,7 +81,6 @@ pub struct TrapFrame {
     pub r13: usize,
     pub r14: usize,
     pub r15: usize,
-    pub _pad: usize,
 
     pub trap_num: usize,
     pub error_code: usize,
@@ -91,10 +89,11 @@ pub struct TrapFrame {
     pub rip: usize,
     pub cs: usize,
     pub rflags: usize,
+    pub rsp: usize,
+    pub ss: usize,
 }
 
-// The padding field in `TrapFrame` is necessary. Do not attempt to remove it
-// without considering this note. Otherwise, the code will be **unsound**.
+// Be careful: This assertion is a **soundness** requirement.
 //
 // According to the System V AMD64 ABI, the stack pointer should be aligned to
 // at least 16 bytes. The hardware will align the stack pointer to a 16-byte

--- a/ostd/src/arch/x86/trap/trap.S
+++ b/ostd/src/arch/x86/trap/trap.S
@@ -10,8 +10,8 @@
  * We make the following new changes:
  * * Add the `trap_handler_table`.
  * * Adjust some symbol names.
- * * Fix an off-by-one bug to correct the RSP value in the trap frame.
  * * Disable alternate macro mode after using it.
+ * * Report the RSP pushed by the CPU in the trap frame.
  *
  * These changes are released under the following license:
  *
@@ -103,6 +103,8 @@ _trap_from_user:
 
 _trap_from_kernel:
     # kernel stack:
+    # - ss
+    # - rsp                 # ss:rsp is unconditionally pushed in 64-bit mode
     # - rflags
     # - cs
     # - rip
@@ -111,7 +113,6 @@ _trap_from_kernel:
     # - rax
 
     pop rax
-    push 0
     push r15
     push r14
     push r13
@@ -120,8 +121,6 @@ _trap_from_kernel:
     push r10
     push r9
     push r8
-    lea r8, [rsp + 13*8]
-    push r8                 # push rsp
     push rbp
     push rdi
     push rsi
@@ -140,7 +139,6 @@ _trap_from_kernel:
     pop rsi
     pop rdi
     pop rbp
-    pop r8                  # skip rsp
     pop r8
     pop r9
     pop r10
@@ -150,7 +148,7 @@ _trap_from_kernel:
     pop r14
     pop r15
 
-    # skip padding, trap_num, error_code
-    add rsp, 24
+    # skip trap_num, error_code
+    add rsp, 16
 
     iretq


### PR DESCRIPTION
My mistake. I should submit this as https://github.com/asterinas/asterinas/pull/3323 instead. Otherwise, the code keeps changing back and forth....

Although https://github.com/asterinas/asterinas/pull/3323 correctly fixes the soundness issues, it highlights another issue that I wasn't aware of until now.

The CPU aligns the stack pointer to a 16-byte boundary upon an exception/interrupt. The existing method of getting the RSP value is incorrect. We should rely on what the CPU pushes onto the stack.

From the Intel docs:
> 64-bit interrupt service routines that exit with an IRET unconditionally pop SS:RSP off of the interrupt stack frame, even if the target code segment is running in 64-bit mode or at CPL = 0. This is because the original interrupt always pushes SS:RSP.

The new code can correctly obtain the RSP value **before** the trap occurs. The existing code cannot do so because it has no way of learning the RSP value **before the CPU aligns it**.

I have verified the code works correct using GDB:
```
ostd::arch::irq::ops::enable_local_and_halt () at src/arch/x86/irq/ops.rs:38
⚠️ warning: 38	src/arch/x86/irq/ops.rs: No such file or directory
(gdb) p /x $rsp
$1 = 0xffffdfffeffdfa28
(gdb) b trap_handler
Breakpoint 1 at 0xffffffff88b1686c: file src/arch/x86/trap/mod.rs, line 159.
(gdb) c
Continuing.

Breakpoint 1, ostd::arch::trap::trap_handler (f=0xffffdfffeffdf970) at src/arch/x86/trap/mod.rs:159
⚠️ warning: 159	src/arch/x86/trap/mod.rs: No such file or directory
(gdb) p /x f.rsp
$2 = 0xffffdfffeffdfa28
(gdb) p /x f.ss
$3 = 0x10
```

As you can see,
 - `f.rsp` now correctly reports the RSP value at `enable_local_and_halt`;
 - `f.ss` is also the correct kernel SS.