### PR TITLE
Add inode cache for virtio-fs

### DIFF
--- a/kernel/libs/aster-fuse/src/ids.rs
+++ b/kernel/libs/aster-fuse/src/ids.rs
@@ -46,7 +46,7 @@ impl FuseFileHandle {
 /// `FuseNodeId`, the old cached inode must be treated as stale and replaced
 /// instead of being retargeted in place.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Pod)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Pod)]
 pub struct FuseNodeId(u64);
 
 impl FuseNodeId {

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -118,11 +118,11 @@ impl VirtioFs {
     /// Reads an inode from a FUSE entry reply via the inode cache.
     pub(super) fn lookup_inode_from_cache(
         self: &Arc<Self>,
-        entry_reply: EntryReply,
+        lookup_reply: EntryReply,
         request_attr_version: AttrVersion,
     ) -> Result<Arc<VirtioFsInode>> {
         self.inode_cache
-            .lookup_inode(entry_reply, request_attr_version, self)
+            .lookup_inode(lookup_reply, request_attr_version, self)
     }
 
     /// Inserts a newly created inode into the inode cache.

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -4,13 +4,13 @@
 //!
 //! This module defines the filesystem type and objects for virtio-fs.
 
-use core::time::Duration;
-
-use aster_fuse::{FUSE_ROOT_ID, Kstatfs, StatfsOperation, ops::lookup::LookupOperation};
-use aster_virtio::device::filesystem::device::{self, FileSystemDevice, FuseSession};
+use aster_fuse::{
+    EntryReply, FUSE_ROOT_ID, Kstatfs, StatfsOperation, ops::lookup::LookupOperation,
+};
+use aster_virtio::device::filesystem::device::{self, AttrVersion, FileSystemDevice, FuseSession};
 use device_id::DeviceId;
 
-use super::{inode::VirtioFsInode, valid_until};
+use super::inode::{InodeCache, VirtioFsInode};
 use crate::{
     fs::{
         pseudofs::AnonDeviceId,
@@ -65,6 +65,7 @@ pub(super) struct VirtioFs {
     root: Arc<VirtioFsInode>,
     tag: String,
     session: Arc<FuseSession>,
+    inode_cache: InodeCache,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
 
@@ -84,25 +85,22 @@ impl VirtioFs {
         let sb = SuperBlock::from((container_dev_id, statfs));
 
         let root_entry = session.do_fuse_op(FUSE_ROOT_ID, LookupOperation::new("."))?;
-        let root_metadata = super::inode::metadata_from_attr(root_entry.attr(), container_dev_id);
-        let attr_valid_until = valid_until(root_entry.attr_valid(), root_entry.attr_valid_nsec());
 
         Ok(Arc::new_cyclic(|weak_fs| {
-            let root = VirtioFsInode::new(
-                FUSE_ROOT_ID,
-                root_entry.generation(),
-                root_metadata,
+            let root = VirtioFsInode::new_root(
+                root_entry,
                 weak_fs.clone(),
-                Duration::MAX,
-                attr_valid_until,
+                container_dev_id,
                 session.bump_attr_version(),
             );
+            let inode_cache = InodeCache::new(&root);
 
             Self {
                 sb,
                 root,
                 tag,
                 session,
+                inode_cache,
                 fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             }
         }))
@@ -110,6 +108,34 @@ impl VirtioFs {
 
     pub(super) fn session(&self) -> &Arc<FuseSession> {
         &self.session
+    }
+
+    /// Returns the device ID of this virtio-fs mount.
+    pub(super) fn container_device_id(&self) -> DeviceId {
+        self.sb.container_dev_id
+    }
+
+    /// Reads an inode from a FUSE entry reply via the inode cache.
+    pub(super) fn lookup_inode_from_cache(
+        self: &Arc<Self>,
+        entry_reply: EntryReply,
+        request_attr_version: AttrVersion,
+    ) -> Result<Arc<VirtioFsInode>> {
+        self.inode_cache
+            .lookup_inode(entry_reply, request_attr_version, self)
+    }
+
+    /// Inserts a newly created inode into the inode cache.
+    pub(super) fn insert_inode_to_cache(&self, inode: &Arc<VirtioFsInode>) {
+        self.inode_cache.insert_inode(inode);
+    }
+
+    /// Removes an inode from the cache if it is still the cached entry.
+    pub(super) fn remove_inode_from_cache(
+        &self,
+        inode: &VirtioFsInode,
+    ) -> Option<Weak<VirtioFsInode>> {
+        self.inode_cache.remove_inode(inode)
     }
 }
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/cache.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/cache.rs
@@ -23,11 +23,11 @@ impl InodeCache {
     /// Looks up an inode by FUSE node ID and validates its generation.
     pub(in crate::fs::fs_impls::virtiofs) fn lookup_inode(
         &self,
-        entry_reply: EntryReply,
+        lookup_reply: EntryReply,
         request_attr_version: AttrVersion,
         fs: &Arc<VirtioFs>,
     ) -> Result<Arc<VirtioFsInode>> {
-        let nodeid = entry_reply.nodeid();
+        let nodeid = lookup_reply.nodeid();
 
         // An `EntryReply` carries a new lookup reference even when the inode is
         // already cached, so cache hits still need to commit the reply.
@@ -36,14 +36,14 @@ impl InodeCache {
             .read()
             .get(&nodeid)
             .and_then(Weak::upgrade)
-            .filter(|inode| inode.generation() == entry_reply.generation())
+            .filter(|inode| inode.generation() == lookup_reply.generation())
         {
             // Reusing a cached inode can still fail while committing the
             // returned attributes, because a size or mtime change may require
             // page-cache resize or invalidation. There is no local recovery
             // path for those page-cache errors, so propagate them to the
             // lookup caller.
-            inode.update_from_entry_reply(&entry_reply, request_attr_version)?;
+            inode.update_from_entry_reply(&lookup_reply, request_attr_version)?;
             return Ok(inode);
         }
 
@@ -53,16 +53,16 @@ impl InodeCache {
         if let Some(inode) = inode_cache
             .get(&nodeid)
             .and_then(Weak::upgrade)
-            .filter(|inode| inode.generation() == entry_reply.generation())
+            .filter(|inode| inode.generation() == lookup_reply.generation())
         {
             drop(inode_cache);
             // See the first cache-hit path above for why committing a fresh
             // `EntryReply` to a cached inode may still fail.
-            inode.update_from_entry_reply(&entry_reply, request_attr_version)?;
+            inode.update_from_entry_reply(&lookup_reply, request_attr_version)?;
             return Ok(inode);
         }
 
-        let inode = VirtioFsInode::new_from_entry_reply(entry_reply, fs);
+        let inode = VirtioFsInode::new_from_entry_reply(lookup_reply, fs);
         inode_cache.insert(nodeid, Arc::downgrade(&inode));
 
         Ok(inode)

--- a/kernel/src/fs/fs_impls/virtiofs/inode/cache.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/cache.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Inode cache for `virtiofs`.
+
+use aster_fuse::{EntryReply, FuseNodeId};
+use aster_virtio::device::filesystem::device::AttrVersion;
+use hashbrown::HashMap;
+
+use super::{VirtioFs, VirtioFsInode};
+use crate::prelude::*;
+
+/// In-memory inode cache keyed by FUSE node ID.
+pub(in crate::fs::fs_impls::virtiofs) struct InodeCache {
+    inodes: RwMutex<HashMap<FuseNodeId, Weak<VirtioFsInode>>>,
+}
+
+impl InodeCache {
+    pub(in crate::fs::fs_impls::virtiofs) fn new(root: &Arc<VirtioFsInode>) -> Self {
+        let inodes = RwMutex::new(HashMap::from_iter([(root.nodeid(), Arc::downgrade(root))]));
+        Self { inodes }
+    }
+
+    /// Looks up an inode by FUSE node ID and validates its generation.
+    pub(in crate::fs::fs_impls::virtiofs) fn lookup_inode(
+        &self,
+        entry_reply: EntryReply,
+        request_attr_version: AttrVersion,
+        fs: &Arc<VirtioFs>,
+    ) -> Result<Arc<VirtioFsInode>> {
+        let nodeid = entry_reply.nodeid();
+
+        // An `EntryReply` carries a new lookup reference even when the inode is
+        // already cached, so cache hits still need to commit the reply.
+        if let Some(inode) = self
+            .inodes
+            .read()
+            .get(&nodeid)
+            .and_then(Weak::upgrade)
+            .filter(|inode| inode.generation() == entry_reply.generation())
+        {
+            // Reusing a cached inode can still fail while committing the
+            // returned attributes, because a size or mtime change may require
+            // page-cache resize or invalidation. There is no local recovery
+            // path for those page-cache errors, so propagate them to the
+            // lookup caller.
+            inode.update_from_entry_reply(&entry_reply, request_attr_version)?;
+            return Ok(inode);
+        }
+
+        // Recheck after taking the write lock because another thread may have
+        // inserted the inode while this lookup waited for exclusive access.
+        let mut inode_cache = self.inodes.write();
+        if let Some(inode) = inode_cache
+            .get(&nodeid)
+            .and_then(Weak::upgrade)
+            .filter(|inode| inode.generation() == entry_reply.generation())
+        {
+            drop(inode_cache);
+            // See the first cache-hit path above for why committing a fresh
+            // `EntryReply` to a cached inode may still fail.
+            inode.update_from_entry_reply(&entry_reply, request_attr_version)?;
+            return Ok(inode);
+        }
+
+        let inode = VirtioFsInode::new_from_entry_reply(entry_reply, fs);
+        inode_cache.insert(nodeid, Arc::downgrade(&inode));
+
+        Ok(inode)
+    }
+
+    /// Inserts an inode by FUSE node ID.
+    pub(in crate::fs::fs_impls::virtiofs) fn insert_inode(&self, inode: &Arc<VirtioFsInode>) {
+        self.inodes
+            .write()
+            .insert(inode.nodeid(), Arc::downgrade(inode));
+    }
+
+    pub(in crate::fs::fs_impls::virtiofs) fn remove_inode(
+        &self,
+        inode: &VirtioFsInode,
+    ) -> Option<Weak<VirtioFsInode>> {
+        let nodeid = inode.nodeid();
+        let mut inodes = self.inodes.write();
+
+        if inodes
+            .get(&nodeid)
+            .is_some_and(|cached_inode| cached_inode.ptr_eq(&inode.weak_self))
+        {
+            return inodes.remove(&nodeid);
+        }
+
+        None
+    }
+}

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -184,11 +184,11 @@ impl VirtioFsInode {
     fn lookup_child_inode(&self, name: &str) -> Result<Arc<VirtioFsInode>> {
         let fs = self.fs_ref();
         let request_attr_version = fs.session().snapshot_attr_version();
-        let entry_reply = fs
+        let lookup_reply = fs
             .session()
             .do_fuse_op(self.nodeid(), LookupOperation::new(name))?;
 
-        fs.lookup_inode_from_cache(entry_reply, request_attr_version)
+        fs.lookup_inode_from_cache(lookup_reply, request_attr_version)
     }
 
     fn type_(&self) -> InodeType {
@@ -357,17 +357,17 @@ impl Inode for VirtioFsInode {
         let fs = self.fs_ref();
         let parent_nodeid = self.nodeid();
         let request_attr_version = fs.session().snapshot_attr_version();
-        let entry_reply = fs
+        let lookup_reply = fs
             .session()
             .do_fuse_op(parent_nodeid, LookupOperation::new(name))?;
 
-        Ok(fs.lookup_inode_from_cache(entry_reply, request_attr_version)?)
+        Ok(fs.lookup_inode_from_cache(lookup_reply, request_attr_version)?)
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
         let fs = self.fs_ref();
         let parent_nodeid = self.nodeid();
-        let entry_reply = match type_ {
+        let create_reply = match type_ {
             InodeType::File => fs.session().do_fuse_op(
                 parent_nodeid,
                 MknodOperation::new(
@@ -397,7 +397,7 @@ impl Inode for VirtioFsInode {
             }
         };
 
-        let child = VirtioFsInode::new_from_entry_reply(entry_reply, &fs);
+        let child = VirtioFsInode::new_from_entry_reply(create_reply, &fs);
         fs.insert_inode_to_cache(&child);
 
         Ok(child)
@@ -410,12 +410,12 @@ impl Inode for VirtioFsInode {
 
         let fs = self.fs_ref();
         let request_attr_version = fs.session().snapshot_attr_version();
-        let entry_reply = fs.session().do_fuse_op(
+        let link_reply = fs.session().do_fuse_op(
             self.nodeid(),
             LinkOperation::new(LinkReq::new(old.nodeid()), name),
         )?;
         old.commit_entry_reply(
-            &entry_reply,
+            &link_reply,
             request_attr_version,
             metadata::StaleAttrAction::MergeLink,
         )?;

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -2,6 +2,7 @@
 
 //! Inode implementation for `virtiofs`.
 
+mod cache;
 mod metadata;
 mod ops;
 mod page_cache;
@@ -12,8 +13,8 @@ use core::{
 };
 
 use aster_fuse::{
-    DirentType, FuseGeneration, FuseNodeId, FuseOpenFlags, LookupCount, ReleaseFlags, ReleaseKind,
-    SetattrReq, SetattrValid,
+    DirentType, EntryReply, FUSE_ROOT_ID, FuseGeneration, FuseNodeId, FuseOpenFlags, LookupCount,
+    ReleaseFlags, ReleaseKind, SetattrReq, SetattrValid,
     ops::{
         link::{LinkOperation, LinkReq},
         lookup::LookupOperation,
@@ -26,6 +27,8 @@ use aster_fuse::{
     },
 };
 use aster_virtio::device::filesystem::device::AttrVersion;
+pub(super) use cache::InodeCache;
+use device_id::DeviceId;
 pub(super) use metadata::metadata_from_attr;
 
 use super::{
@@ -79,8 +82,38 @@ pub(super) struct VirtioFsInode {
 }
 
 impl VirtioFsInode {
-    /// Creates an inode from a fresh FUSE entry or attribute reply.
-    pub(super) fn new(
+    /// Creates the root inode.
+    pub(super) fn new_root(
+        root_entry: EntryReply,
+        fs: Weak<VirtioFs>,
+        container_device_id: DeviceId,
+        attr_version: AttrVersion,
+    ) -> Arc<Self> {
+        Self::new(
+            FUSE_ROOT_ID,
+            root_entry.generation(),
+            metadata_from_attr(root_entry.attr(), container_device_id),
+            fs,
+            Duration::MAX,
+            valid_until(root_entry.attr_valid(), root_entry.attr_valid_nsec()),
+            attr_version,
+        )
+    }
+
+    /// Creates an inode from a fresh FUSE entry reply.
+    pub(super) fn new_from_entry_reply(entry_reply: EntryReply, fs: &Arc<VirtioFs>) -> Arc<Self> {
+        Self::new(
+            entry_reply.nodeid(),
+            entry_reply.generation(),
+            metadata_from_attr(entry_reply.attr(), fs.container_device_id()),
+            Arc::downgrade(fs),
+            valid_until(entry_reply.entry_valid(), entry_reply.entry_valid_nsec()),
+            valid_until(entry_reply.attr_valid(), entry_reply.attr_valid_nsec()),
+            fs.session().bump_attr_version(),
+        )
+    }
+
+    fn new(
         nodeid: FuseNodeId,
         generation: FuseGeneration,
         metadata: Metadata,
@@ -125,6 +158,37 @@ impl VirtioFsInode {
 
     pub(super) fn size(&self) -> usize {
         self.size.load(Ordering::Acquire)
+    }
+
+    /// Updates a cached inode with a fresh FUSE entry reply.
+    ///
+    /// A successful entry reply gives the client one additional lookup
+    /// reference and a refreshed directory-entry TTL. Even though the inode
+    /// object already exists, the cached lookup count and metadata still need
+    /// to observe the reply before the inode is returned to VFS.
+    pub(super) fn update_from_entry_reply(
+        &self,
+        entry_reply: &EntryReply,
+        request_attr_version: AttrVersion,
+    ) -> Result<()> {
+        self.commit_entry_reply(
+            entry_reply,
+            request_attr_version,
+            metadata::StaleAttrAction::Discard,
+        )?;
+        *self.entry_valid_until.lock() =
+            valid_until(entry_reply.entry_valid(), entry_reply.entry_valid_nsec());
+        Ok(())
+    }
+
+    fn lookup_child_inode(&self, name: &str) -> Result<Arc<VirtioFsInode>> {
+        let fs = self.fs_ref();
+        let request_attr_version = fs.session().snapshot_attr_version();
+        let entry_reply = fs
+            .session()
+            .do_fuse_op(self.nodeid(), LookupOperation::new(name))?;
+
+        fs.lookup_inode_from_cache(entry_reply, request_attr_version)
     }
 
     fn type_(&self) -> InodeType {
@@ -292,28 +356,12 @@ impl Inode for VirtioFsInode {
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
         let fs = self.fs_ref();
         let parent_nodeid = self.nodeid();
+        let request_attr_version = fs.session().snapshot_attr_version();
         let entry_reply = fs
             .session()
             .do_fuse_op(parent_nodeid, LookupOperation::new(name))?;
-        let nodeid = entry_reply.nodeid();
 
-        let entry_valid_until =
-            valid_until(entry_reply.entry_valid(), entry_reply.entry_valid_nsec());
-        let attr_valid_until = valid_until(entry_reply.attr_valid(), entry_reply.attr_valid_nsec());
-
-        // TODO: Add an inode cache keyed by `(nodeid, generation)` so hard
-        // links to the same FUSE inode share one `VirtioFsInode`.
-        let inode = VirtioFsInode::new(
-            nodeid,
-            entry_reply.generation(),
-            metadata_from_attr(entry_reply.attr(), fs.sb().container_dev_id),
-            Arc::downgrade(&fs),
-            entry_valid_until,
-            attr_valid_until,
-            fs.session().bump_attr_version(),
-        );
-
-        Ok(inode)
+        Ok(fs.lookup_inode_from_cache(entry_reply, request_attr_version)?)
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
@@ -348,7 +396,11 @@ impl Inode for VirtioFsInode {
                 )
             }
         };
-        Ok(VirtioFsInode::build_child_inode(&fs, entry_reply))
+
+        let child = VirtioFsInode::new_from_entry_reply(entry_reply, &fs);
+        fs.insert_inode_to_cache(&child);
+
+        Ok(child)
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
@@ -373,15 +425,27 @@ impl Inode for VirtioFsInode {
 
     fn unlink(&self, name: &str) -> Result<()> {
         let fs = self.fs_ref();
+        let child = self.lookup_child_inode(name)?;
+
         fs.session()
             .do_fuse_op(self.nodeid(), UnlinkOperation::new(name))?;
+
+        self.expire_attr_cache();
+        child.expire_attr_cache();
+
         Ok(())
     }
 
     fn rmdir(&self, name: &str) -> Result<()> {
         let fs = self.fs_ref();
+        let child = self.lookup_child_inode(name)?;
+
         fs.session()
             .do_fuse_op(self.nodeid(), RmdirOperation::new(name))?;
+
+        self.expire_attr_cache();
+        child.expire_attr_cache();
+
         Ok(())
     }
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -568,25 +568,29 @@ impl VirtioFsInode {
         let old_nodeid = self.nodeid();
         let fs = self.fs_ref();
         let request_attr_version = fs.session().snapshot_attr_version();
-        let entry_reply = fs
+        let lookup_reply = fs
             .session()
             .do_fuse_op(parent_nodeid, LookupOperation::new(name))?;
 
-        if entry_reply.nodeid() != old_nodeid || entry_reply.generation() != self.generation() {
-            if let Err(err) = fs.session().forget(entry_reply.nodeid(), 1) {
+        if lookup_reply.nodeid() != old_nodeid || lookup_reply.generation() != self.generation() {
+            if let Err(err) = fs.session().forget(lookup_reply.nodeid(), 1) {
                 warn!(
                     "virtiofs forget failed for stale lookup inode {}: {:?}",
-                    entry_reply.nodeid().as_u64(),
+                    lookup_reply.nodeid().as_u64(),
                     err
                 );
             }
             return_errno_with_message!(Errno::ESTALE, "virtiofs stale dentry after revalidate");
         }
 
-        self.commit_entry_reply(&entry_reply, request_attr_version, StaleAttrAction::Discard)?;
+        self.commit_entry_reply(
+            &lookup_reply,
+            request_attr_version,
+            StaleAttrAction::Discard,
+        )?;
 
         *self.entry_valid_until.lock() =
-            valid_until(entry_reply.entry_valid(), entry_reply.entry_valid_nsec());
+            valid_until(lookup_reply.entry_valid(), lookup_reply.entry_valid_nsec());
 
         Ok(())
     }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -22,19 +22,16 @@ use super::{
     super::{
         dir::VirtioFsDir,
         file::{CachePolicy, VirtioFsFile},
-        fs::VirtioFs,
         open_handle::VirtioFsOpenHandle,
         valid_until,
     },
     TimeField, VirtioFsInode, WriteOffset,
     metadata::StaleAttrAction,
-    metadata_from_attr,
 };
 use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, StatusFlags},
         utils::DirentVisitor,
-        vfs::file_system::FileSystem,
     },
     prelude::*,
     thread::work_queue::{self, WorkPriority},
@@ -418,31 +415,6 @@ impl VirtioFsInode {
         Ok(Box::new(VirtioFsDir::new(inode, open_handle)))
     }
 
-    /// Builds a child inode from a FUSE entry reply.
-    ///
-    /// This is used for operations that instantiate a new inode cache entry.
-    /// There is no existing cache for that child, so no stale-reply merge is
-    /// needed; the entry and attr TTLs are installed as the initial deadlines.
-    pub(super) fn build_child_inode(
-        fs: &Arc<VirtioFs>,
-        entry_reply: EntryReply,
-    ) -> Arc<VirtioFsInode> {
-        let entry_valid_until =
-            valid_until(entry_reply.entry_valid(), entry_reply.entry_valid_nsec());
-        let attr_reply = FuseAttrReply::from(&entry_reply);
-        let attr_valid_until = valid_until(attr_reply.attr_valid(), attr_reply.attr_valid_nsec());
-
-        VirtioFsInode::new(
-            entry_reply.nodeid(),
-            entry_reply.generation(),
-            metadata_from_attr(attr_reply.attr(), fs.sb().container_dev_id),
-            Arc::downgrade(fs),
-            entry_valid_until,
-            attr_valid_until,
-            fs.session().bump_attr_version(),
-        )
-    }
-
     /// Commits an `EntryReply` reply for this cached inode.
     ///
     /// `EntryReply` replies carry both attributes and one new lookup reference.
@@ -652,6 +624,10 @@ impl Drop for VirtioFsInode {
     // FUSE forgets must run outside Drop: the session may sleep and
     // may need VFS locks; defer to the work queue.
     fn drop(&mut self) {
+        if let Some(fs) = self.fs.upgrade() {
+            fs.remove_inode_from_cache(self);
+        }
+
         let nlookup = self.lookup_count.drain();
         if nlookup > 0 {
             self.forget_async(nlookup);


### PR DESCRIPTION
## Overview
Add an inode cache for virtio-fs, keyed by `(FuseNodeId, FuseGeneration)`, so multiple directory entries or hard links that refer to the same FUSE inode share one `VirtioFsInode` instance.

  ## Motivation

 Before this change, each successful lookup constructed a fresh `VirtioFsInode`, even when the FUSE server returned the samenode ID and generation. This meant hard links to the same file could be represented by different in-memory inode objects.

  ## Changes
  - Add `InodeCache` for virtio-fs, storing weak references by FUSE node ID and generation.
  - Route lookup replies through the inode cache and reuse an existing live inode when possible. Refresh cached inode metadata, entry TTL, and lookup references when a cached inode is reused.
  - Insert newly created virtio-fs inodes into the cache.
  - Remove cached inodes after `unlink`/`rmdir` when the local hard-link count reaches zero.