### PR TITLE
Introduce a cache mechanism for `FsType`

### DIFF
--- a/kernel/libs/device-id/src/lib.rs
+++ b/kernel/libs/device-id/src/lib.rs
@@ -15,7 +15,7 @@
 use aster_util::ranged_integer::{RangedU16, RangedU32};
 
 /// A device ID, embedding the major ID and minor ID.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct DeviceId(u32);
 
 impl DeviceId {

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         vfs::{
             inode::MknodType,
             path::{FsPath, Path, PathResolver, PerMountFlags},
+            registry::FsAndRoot,
         },
     },
     prelude::*,
@@ -177,7 +178,7 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     // Mount devtmpfs.
     let dev_path = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
     dev_path.mount(
-        RamFs::new(),
+        FsAndRoot::new(RamFs::new()),
         PerMountFlags::default(),
         Some("ramfs".to_string()),
         ctx,

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -4,7 +4,10 @@ use crate::{
     fs::{
         devpts::{DevPts, Ptmx},
         file::{InodeType, mkmod},
-        vfs::path::{FsPath, Path, PathResolver, PerMountFlags},
+        vfs::{
+            path::{FsPath, Path, PathResolver, PerMountFlags},
+            registry::FsAndRoot,
+        },
     },
     prelude::*,
 };
@@ -26,7 +29,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     // Create the "pts" directory and mount devpts on it.
     let devpts_path = dev.new_fs_child("pts", InodeType::Dir, mkmod!(a+rx, u+w))?;
     let devpts_mount = devpts_path.mount(
-        DevPts::new(),
+        FsAndRoot::new(DevPts::new()),
         PerMountFlags::default(),
         Some("devpts".to_string()),
         ctx,

--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -4,7 +4,10 @@ use crate::{
     fs::{
         file::{InodeType, chmod},
         ramfs::RamFs,
-        vfs::path::{FsPath, PathResolver, PerMountFlags},
+        vfs::{
+            path::{FsPath, PathResolver, PerMountFlags},
+            registry::FsAndRoot,
+        },
     },
     prelude::*,
 };
@@ -19,7 +22,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, chmod!(InodeMode::S_ISVTX, a+rwx))?;
     shm_path.mount(
-        RamFs::new_tmpfs(),
+        FsAndRoot::new(RamFs::new_tmpfs()),
         PerMountFlags::default(),
         Some("tmpfs".to_string()),
         ctx,

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -11,7 +11,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsFlags},
             path::{Mount, MountNamespace, Path, PerMountFlags},
-            registry::{FsCreationCtx, FsType},
+            registry::{DynFsType, FsAndRoot, FsCreationCtx},
         },
     },
     prelude::*,
@@ -49,7 +49,7 @@ use crate::{
 ///                              └────────────────┘
 /// ```
 pub struct FsConfigFile {
-    fs_type: &'static dyn FsType,
+    fs_type: &'static dyn DynFsType,
     config: Mutex<FsConfig>,
     common: FileCommon,
 }
@@ -66,13 +66,13 @@ struct FsConfig {
 enum FsConfigState {
     Configuring,
     Failed,
-    AwaitingMount(Arc<dyn FileSystem>),
+    AwaitingMount(FsAndRoot),
     Reconfiguring(Arc<dyn FileSystem>),
 }
 
 impl FsConfigFile {
     /// Creates a filesystem configuration file for a filesystem type.
-    pub fn new(fs_type: &'static dyn FsType) -> Self {
+    pub fn new(fs_type: &'static dyn DynFsType) -> Self {
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string());
         Self {
             fs_type,
@@ -166,23 +166,13 @@ impl FsConfigFile {
             let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
             let fs_creation_ctx =
                 FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
-            let fs = self.fs_type.create(&fs_creation_ctx)?;
-            if Arc::strong_count(&fs) > 1 {
-                let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
-                let context_readonly = config.flags.contains(FsFlags::RDONLY);
-                if extant_readonly != context_readonly {
-                    return_errno_with_message!(
-                        Errno::EBUSY,
-                        "the read-only flag of the extant filesystem does not match"
-                    );
-                }
-            }
-            Ok(fs)
+            let fs_and_root = self.fs_type.get_or_create(&fs_creation_ctx)?;
+            Ok(fs_and_root)
         })();
 
         match result {
-            Ok(fs) => {
-                config.state = FsConfigState::AwaitingMount(fs);
+            Ok(fs_and_root) => {
+                config.state = FsConfigState::AwaitingMount(fs_and_root);
                 Ok(())
             }
             Err(err) => {
@@ -203,8 +193,8 @@ impl FsConfigFile {
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Mount>> {
         let mut config = self.config.lock();
-        let fs = match &config.state {
-            FsConfigState::AwaitingMount(fs) => fs.clone(),
+        let fs_and_root = match &config.state {
+            FsConfigState::AwaitingMount(fs_and_root) => fs_and_root.clone(),
             FsConfigState::Configuring => {
                 return_errno_with_message!(Errno::EINVAL, "the file system is not created");
             }
@@ -219,7 +209,9 @@ impl FsConfigFile {
             }
         };
 
-        let detached_mount = Mount::new_detached(fs.clone(), flags, mnt_ns, config.source.clone())?;
+        let fs = fs_and_root.fs().clone();
+        let detached_mount =
+            Mount::new_detached(fs_and_root, flags, mnt_ns, config.source.clone())?;
         config.source = None;
         config.flags = fs.flags();
         config.extra_options.clear();

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -85,6 +85,8 @@ impl FileSystem for CgroupFs {
 pub(super) struct CgroupFsType;
 
 impl FsType for CgroupFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "cgroup2"
     }

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -85,6 +85,8 @@ impl FileSystem for ConfigFs {
 pub(super) struct ConfigFsType;
 
 impl FsType for ConfigFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "configfs"
     }

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -127,6 +127,8 @@ impl FileSystem for DevPts {
 struct DevPtsType;
 
 impl FsType for DevPtsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "devpts"
     }

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -33,7 +33,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsCreationCtx, FsProperties, FsType},
+            registry::{FsCache, FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -476,9 +476,17 @@ pub struct ExfatMountOptions {
     pub(super) zero_size_dir: bool,
 }
 
-pub(super) struct ExfatType;
+pub(super) struct ExfatType {
+    cache: FsCache<DeviceId>,
+}
+
+pub(super) static EXFAT_TYPE: ExfatType = ExfatType {
+    cache: FsCache::new(),
+};
 
 impl FsType for ExfatType {
+    type Key = DeviceId;
+
     fn name(&self) -> &'static str {
         "exfat"
     }
@@ -488,10 +496,20 @@ impl FsType for ExfatType {
     }
 
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(ExfatFs::open(
-            fs_creation_ctx.resolve_block_device()?,
-            ExfatMountOptions::default(),
-        )?)
+        let disk = fs_creation_ctx.resolve_block_device()?.clone();
+        Ok(ExfatFs::open(disk, ExfatMountOptions::default())?)
+    }
+
+    fn obtain_key_and_cache(
+        &self,
+        fs_creation_ctx: &FsCreationCtx,
+    ) -> Option<(DeviceId, &FsCache<DeviceId>)> {
+        let key = fs_creation_ctx
+            .resolve_block_device()
+            .ok()
+            .map(|disk| disk.id())?;
+
+        Some((key, &self.cache))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/exfat/mod.rs
+++ b/kernel/src/fs/fs_impls/exfat/mod.rs
@@ -10,8 +10,8 @@ mod super_block;
 mod upcase_table;
 mod utils;
 
-use crate::fs::exfat::fs::ExfatType;
+use crate::fs::exfat::fs::EXFAT_TYPE;
 
 pub(super) fn init() {
-    crate::fs::vfs::registry::register(&ExfatType).unwrap();
+    crate::fs::vfs::registry::register(&EXFAT_TYPE).unwrap();
 }

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -31,7 +31,10 @@ use super::{
     super_block::{RawSuperBlock, SUPER_BLOCK_OFFSET, SuperBlock},
 };
 use crate::{
-    fs::{ext2::utils, vfs::file_system::FsEventSubscriberStats},
+    fs::{
+        ext2::utils,
+        vfs::file_system::{AtomicFsFlags, FsEventSubscriberStats, FsFlags},
+    },
     process::{Gid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
     security::lsm::hooks as lsm_hooks,
     thread::Thread,
@@ -59,6 +62,8 @@ pub struct Ext2 {
     group_descriptors_segment: USegment,
     /// Runtime mount options that affect block-count reporting.
     mount_options: Ext2MountOptions,
+    /// Recorded VFS filesystem flags.
+    flags: AtomicFsFlags,
     /// FS event stats for VFS.
     fs_event_subscriber_stats: FsEventSubscriberStats,
     /// Per-filesystem inode generation counter.
@@ -110,7 +115,11 @@ impl Ext2MountOptions {
 
 impl Ext2 {
     /// Opens and loads an Ext2 filesystem from a block device.
-    pub(super) fn open(device: Arc<dyn BlockDevice>, data: Option<&str>) -> Result<Arc<Self>> {
+    pub(super) fn open(
+        device: Arc<dyn BlockDevice>,
+        flags: FsFlags,
+        data: Option<&str>,
+    ) -> Result<Arc<Self>> {
         let super_block = {
             let raw_super_block = device.read_val::<RawSuperBlock>(SUPER_BLOCK_OFFSET)?;
             SuperBlock::try_from(raw_super_block)?
@@ -173,6 +182,7 @@ impl Ext2 {
             nr_inodes_per_group,
             group_descriptors_segment,
             mount_options,
+            flags: AtomicFsFlags::new(flags),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             next_generation: AtomicU32::new(utils::duration_to_ext2_secs(utils::now())),
             self_ref: weak_self.clone(),
@@ -197,6 +207,16 @@ impl Ext2 {
             self.mount_options.stat_block_accounting,
             StatBlockAccounting::IncludeOverhead
         )
+    }
+
+    /// Returns the per file system flags.
+    pub(super) fn fs_flags(&self) -> FsFlags {
+        self.flags.load(Ordering::Relaxed)
+    }
+
+    /// Sets the per file system flags.
+    pub(super) fn set_fs_flags(&self, flags: FsFlags) {
+        self.flags.store(flags, Ordering::Relaxed);
     }
 
     /// Returns a reference to the block group at `group_idx`.
@@ -721,7 +741,12 @@ mod test {
     #[ktest]
     fn stat_minixdf_reports_total() {
         let f = Ext2FixtureBuilder::new(3, 512).build().unwrap();
-        let ext2 = Ext2::open(f.disk.clone() as Arc<dyn BlockDevice>, Some("minixdf")).unwrap();
+        let ext2 = Ext2::open(
+            f.disk.clone() as Arc<dyn BlockDevice>,
+            FsFlags::empty(),
+            Some("minixdf"),
+        )
+        .unwrap();
 
         let stat = FileSystemTrait::sb(ext2.as_ref());
         assert_eq!(stat.blocks, f.sb.total_blocks() as usize);

--- a/kernel/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs_type.rs
@@ -36,8 +36,9 @@ impl FsType for Ext2Type {
 
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let disk = fs_creation_ctx.resolve_block_device()?.clone();
+        let flags = fs_creation_ctx.flags();
         let args = fs_creation_ctx.args();
-        Ext2::open(disk, args).map(|fs| fs as Arc<dyn FileSystem>)
+        Ext2::open(disk, flags, args).map(|fs| fs as Arc<dyn FileSystem>)
     }
 
     fn obtain_key_and_cache(

--- a/kernel/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs_type.rs
@@ -6,17 +6,26 @@
 //! discover and mount ext2 volumes by name (`"ext2"`).
 
 use aster_systree::SysNode;
+use device_id::DeviceId;
 
 use super::{fs::Ext2, prelude::*};
 use crate::fs::vfs::{
     file_system::FileSystem,
-    registry::{FsCreationCtx, FsProperties, FsType},
+    registry::{FsCache, FsCreationCtx, FsProperties, FsType},
 };
 
 /// VFS-visible Ext2 filesystem type.
-pub(super) struct Ext2Type;
+pub(super) struct Ext2Type {
+    cache: FsCache<DeviceId>,
+}
+
+pub(super) static EXT2_TYPE: Ext2Type = Ext2Type {
+    cache: FsCache::new(),
+};
 
 impl FsType for Ext2Type {
+    type Key = DeviceId;
+
     fn name(&self) -> &'static str {
         "ext2"
     }
@@ -26,9 +35,21 @@ impl FsType for Ext2Type {
     }
 
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        let disk = fs_creation_ctx.resolve_block_device()?;
+        let disk = fs_creation_ctx.resolve_block_device()?.clone();
         let args = fs_creation_ctx.args();
         Ext2::open(disk, args).map(|fs| fs as Arc<dyn FileSystem>)
+    }
+
+    fn obtain_key_and_cache(
+        &self,
+        fs_creation_ctx: &FsCreationCtx,
+    ) -> Option<(DeviceId, &FsCache<DeviceId>)> {
+        let key = fs_creation_ctx
+            .resolve_block_device()
+            .ok()
+            .map(|disk| disk.id())?;
+
+        Some((key, &self.cache))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn SysNode>> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
@@ -12,7 +12,7 @@ use crate::{
         fs_impls::ext2::{Ext2, super_block::MAGIC_NUM},
         utils::NAME_MAX,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
             inode::Inode,
         },
     },
@@ -59,6 +59,16 @@ impl FileSystem for Ext2 {
             flags: 0,
             container_dev_id: self.container_device_id(),
         }
+    }
+
+    fn flags(&self) -> FsFlags {
+        self.fs_flags()
+    }
+
+    fn set_fs_flags(&self, flags: FsFlags, _data: Option<&str>, _ctx: &Context) -> Result<()> {
+        self.set_fs_flags(flags);
+        warn!("ext2-specific handling for filesystem flags is not implemented");
+        Ok(())
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {

--- a/kernel/src/fs/fs_impls/ext2/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/mod.rs
@@ -63,7 +63,7 @@ macro_rules! __log_prefix {
 pub use fs::Ext2;
 pub use inode::{FilePerm, Inode};
 
-use self::fs_type::Ext2Type;
+use self::fs_type::EXT2_TYPE;
 use crate::fs::vfs::registry;
 
 mod block_group;
@@ -81,5 +81,5 @@ mod test_utils;
 
 /// Registers the ext2 filesystem type with the VFS registry.
 pub(super) fn init() {
-    registry::register(&Ext2Type).unwrap();
+    registry::register(&EXT2_TYPE).unwrap();
 }

--- a/kernel/src/fs/fs_impls/ext2/test_utils.rs
+++ b/kernel/src/fs/fs_impls/ext2/test_utils.rs
@@ -24,7 +24,7 @@ use super::{
     },
 };
 use crate::{
-    fs::{file::InodeType, fs_impls::ext2::super_block::SuperBlock},
+    fs::{file::InodeType, fs_impls::ext2::super_block::SuperBlock, vfs::file_system::FsFlags},
     prelude::{return_errno_with_message, *},
     time::clocks,
 };
@@ -728,7 +728,7 @@ impl Ext2FixtureBuilder {
         let device: Arc<dyn BlockDevice> = self
             .custom_device
             .unwrap_or_else(|| disk.clone() as Arc<dyn BlockDevice>);
-        let ext2 = Ext2::open(device, None)?;
+        let ext2 = Ext2::open(device, FsFlags::empty(), None)?;
 
         Ok(Ext2Fixture {
             disk,

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -1174,6 +1174,8 @@ struct OverlaySB;
 pub(super) struct OverlayFsType;
 
 impl FsType for OverlayFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "overlay"
     }

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -121,6 +121,8 @@ impl FileSystem for ProcFs {
 struct ProcFsType;
 
 impl FsType for ProcFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "proc"
     }

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -52,6 +52,8 @@ impl PipeFs {
 pub(super) struct PipeFsType;
 
 impl FsType for PipeFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "pipefs"
     }

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -60,6 +60,8 @@ impl SockFs {
 pub(super) struct SockFsType;
 
 impl FsType for SockFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "sockfs"
     }

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -1463,6 +1463,8 @@ fn current_fs_ids() -> (Uid, Gid) {
 pub(super) struct RamFsType;
 
 impl FsType for RamFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "ramfs"
     }

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -83,6 +83,8 @@ impl FileSystem for SysFs {
 pub(super) struct SysFsType;
 
 impl FsType for SysFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "sysfs"
     }

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -32,6 +32,8 @@ pub(in crate::fs) fn default_max_inodes() -> usize {
 pub(super) struct TmpFsType;
 
 impl FsType for TmpFsType {
+    type Key = ();
+
     fn name(&self) -> &'static str {
         "tmpfs"
     }

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -18,7 +18,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
-            registry::{FsCreationCtx, FsProperties, FsType},
+            registry::{FsCache, FsCreationCtx, FsProperties, FsType},
         },
     },
     prelude::*,
@@ -31,9 +31,17 @@ const VIRTIOFS_MAGIC: u64 = 0x6573_5546;
 const BLOCK_SIZE: usize = 4096;
 
 /// The `virtiofs` filesystem type.
-pub(super) struct VirtioFsType;
+pub(super) struct VirtioFsType {
+    cache: FsCache<String>,
+}
+
+pub(super) static VIRTIOFS_TYPE: VirtioFsType = VirtioFsType {
+    cache: FsCache::new(),
+};
 
 impl FsType for VirtioFsType {
+    type Key = String;
+
     fn name(&self) -> &'static str {
         "virtiofs"
     }
@@ -52,6 +60,15 @@ impl FsType for VirtioFsType {
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "virtiofs device is not found"))?;
 
         Ok(VirtioFs::new(device, tag)? as Arc<dyn FileSystem>)
+    }
+
+    fn obtain_key_and_cache(
+        &self,
+        fs_creation_ctx: &FsCreationCtx,
+    ) -> Option<(String, &FsCache<String>)> {
+        let key = fs_creation_ctx.source().map(|tag| tag.to_string())?;
+
+        Some((key, &self.cache))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/virtiofs/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 pub(super) fn init() {
-    crate::fs::vfs::registry::register(&fs::VirtioFsType).unwrap();
+    crate::fs::vfs::registry::register(&fs::VIRTIOFS_TYPE).unwrap();
 }
 
 impl From<FuseError> for Error {

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -158,7 +158,6 @@ impl From<FsFlags> for u32 {
 
 define_atomic_version_of_integer_like_type!(FsFlags, {
     /// An atomic version of `FsFlags`.
-    #[expect(dead_code)]
     #[derive(Debug)]
     pub struct AtomicFsFlags(AtomicU32);
 });

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::collections::btree_map::Entry;
+
 use aster_block::BlockDevice;
 use aster_systree::{
     AttrLessBranchNodeFields, SysNode, SysObj, SysPerms, SysStr, inherit_sys_branch_node,
@@ -11,7 +13,7 @@ use crate::{
         fs_impls::sysfs,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            path::{AT_FDCWD, EmptyPathStr, FsPath},
+            path::{AT_FDCWD, Dentry, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
@@ -19,6 +21,12 @@ use crate::{
 
 /// A type of file system.
 pub trait FsType: Send + Sync + 'static {
+    /// Key used to deduplicate mounts of the same logical FS instance.
+    ///
+    /// Set to `()` (with the default `obtain_key_and_cache` returning `None`) to opt out
+    /// of any caching — every mount is fresh.
+    type Key: Eq + Ord + Clone + Send + Sync + 'static;
+
     /// Gets the name of this FS type such as `"ext4"` or `"sysfs"`.
     fn name(&self) -> &'static str;
 
@@ -27,6 +35,16 @@ pub trait FsType: Send + Sync + 'static {
 
     /// Creates an instance of this FS type.
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>>;
+
+    /// Returns the computed dedup key and the [`FsCache`] for this mount request.
+    ///
+    /// Return `None` to skip the cache mechanism (every mount is fresh).
+    fn obtain_key_and_cache(
+        &self,
+        _fs_creation_ctx: &FsCreationCtx,
+    ) -> Option<(Self::Key, &FsCache<Self::Key>)> {
+        None
+    }
 
     /// Returns a `SysTree` node that represents the FS type.
     ///
@@ -38,18 +56,62 @@ pub trait FsType: Send + Sync + 'static {
     fn sysnode(&self) -> Option<Arc<dyn SysNode>>;
 }
 
-/// A context that describes the inputs used to create a filesystem instance.
+/// Object-safe view of [`FsType`] used by the registry, mount syscall, and procfs.
 ///
-/// This context will be used by [`FsType::create`].
+/// Implemented automatically for every [`FsType`] via a blanket impl, so FS
+/// authors only implement [`FsType`].
+pub trait DynFsType: Send + Sync + 'static {
+    /// Gets the name of this FS type such as `"ext4"` or `"sysfs"`.
+    fn name(&self) -> &'static str;
+
+    /// Gets the properties of this FS type.
+    fn properties(&self) -> FsProperties;
+
+    /// Gets or creates a file system instance along with its root dentry.
+    fn get_or_create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<FsAndRoot>;
+
+    /// Returns a `SysTree` node that represents the FS type.
+    fn sysnode(&self) -> Option<Arc<dyn SysNode>>;
+}
+
+impl<T: FsType> DynFsType for T {
+    fn name(&self) -> &'static str {
+        <T as FsType>::name(self)
+    }
+
+    fn properties(&self) -> FsProperties {
+        <T as FsType>::properties(self)
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn SysNode>> {
+        <T as FsType>::sysnode(self)
+    }
+
+    fn get_or_create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<FsAndRoot> {
+        if let Some((key, cache)) = self.obtain_key_and_cache(fs_creation_ctx) {
+            cache.get_or_create(key, fs_creation_ctx.flags(), || {
+                self.create(fs_creation_ctx)
+            })
+        } else {
+            let fs = self.create(fs_creation_ctx)?;
+            Ok(FsAndRoot::new(fs))
+        }
+    }
+}
+
+/// A context that describes the inputs used to create a file system instance.
+///
+/// This context is used to identify and create a file system instance.
 pub struct FsCreationCtx<'a> {
     source: Option<&'a str>,
     flags: FsFlags,
     args: Option<&'a str>,
     task_ctx: &'a Context<'a>,
+    block_device: Once<Arc<dyn BlockDevice>>,
 }
 
 impl<'a> FsCreationCtx<'a> {
-    /// Creates a filesystem creation context from syscall inputs.
+    /// Creates a file system creation context from syscall inputs.
     pub fn new(
         source: Option<&'a str>,
         flags: FsFlags,
@@ -61,6 +123,7 @@ impl<'a> FsCreationCtx<'a> {
             flags,
             args,
             task_ctx,
+            block_device: Once::new(),
         }
     }
 
@@ -70,18 +133,21 @@ impl<'a> FsCreationCtx<'a> {
     }
 
     /// Returns the user-supplied mount flags.
-    #[expect(dead_code)]
     pub(in crate::fs) fn flags(&self) -> FsFlags {
         self.flags
     }
 
-    /// Returns the filesystem-specific mount arguments.
+    /// Returns the file system specific mount arguments.
     pub(in crate::fs) fn args(&self) -> Option<&str> {
         self.args
     }
 
     /// Resolves the mount source into a block device.
-    pub(in crate::fs) fn resolve_block_device(&self) -> Result<Arc<dyn BlockDevice>> {
+    pub(in crate::fs) fn resolve_block_device(&self) -> Result<&Arc<dyn BlockDevice>> {
+        if let Some(block_device) = self.block_device.get() {
+            return Ok(block_device);
+        }
+
         let source = self
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
@@ -98,9 +164,11 @@ impl<'a> FsCreationCtx<'a> {
             return_errno_with_message!(Errno::ENODEV, "the path is not a device file");
         }
         let id = path.metadata()?.self_dev_id;
+        let block_device = id
+            .and_then(aster_block::lookup)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))?;
 
-        id.and_then(aster_block::lookup)
-            .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))
+        Ok(self.block_device.call_once(|| block_device))
     }
 }
 
@@ -119,12 +187,12 @@ bitflags! {
 /// Registers a new FS type.
 //
 // TODO: Figure out what should happen when unregistering the FS type.
-pub fn register(new_type: &'static dyn FsType) -> Result<()> {
+pub fn register(new_type: &'static dyn DynFsType) -> Result<()> {
     FS_REGISTRY.get().unwrap().register(new_type)
 }
 
 /// Looks up a FS type.
-pub fn look_up(name: &str) -> Option<&'static dyn FsType> {
+pub fn look_up(name: &str) -> Option<&'static dyn DynFsType> {
     FS_REGISTRY
         .get()
         .unwrap()
@@ -138,7 +206,7 @@ pub fn look_up(name: &str) -> Option<&'static dyn FsType> {
 /// and every FS type.
 pub fn with_iter<F, R>(f: F) -> R
 where
-    F: FnOnce(&mut dyn Iterator<Item = (&str, &dyn FsType)>) -> R,
+    F: FnOnce(&mut dyn Iterator<Item = (&str, &dyn DynFsType)>) -> R,
 {
     let guard = FS_REGISTRY.get().unwrap().fs_table.lock();
 
@@ -161,8 +229,120 @@ pub fn init() {
 
 static FS_REGISTRY: Once<Arc<FsRegistry>> = Once::new();
 
+/// A cache of file system instances, keyed by `K`.
+///
+/// `FsType` implementations use this cache to deduplicate mounts that refer to
+/// the same logical file system instance, such as the same block device.
+pub struct FsCache<K: Eq + Ord + Clone + Send + Sync + 'static> {
+    entries: Mutex<BTreeMap<K, WeakFsAndRoot>>,
+}
+
+/// A file system paired with its root [`Dentry`].
+#[derive(Clone)]
+pub struct FsAndRoot {
+    fs: Arc<dyn FileSystem>,
+    root_dentry: Arc<Dentry>,
+}
+
+impl FsAndRoot {
+    /// Creates an `FsAndRoot` by deriving the root dentry from the file system.
+    ///
+    /// This root is the file system root created from [`FileSystem::root_inode`].
+    pub fn new(fs: Arc<dyn FileSystem>) -> Self {
+        let root_dentry = Dentry::new_root(fs.root_inode());
+        Self { fs, root_dentry }
+    }
+
+    /// Consumes the `FsAndRoot` and returns the file system and its root dentry.
+    pub(in crate::fs) fn into_parts(self) -> (Arc<dyn FileSystem>, Arc<Dentry>) {
+        (self.fs, self.root_dentry)
+    }
+
+    /// Returns a reference the file system.
+    pub(in crate::fs) fn fs(&self) -> &Arc<dyn FileSystem> {
+        &self.fs
+    }
+
+    fn downgrade(&self) -> WeakFsAndRoot {
+        WeakFsAndRoot {
+            fs: Arc::downgrade(&self.fs),
+            root_dentry: Arc::downgrade(&self.root_dentry),
+        }
+    }
+}
+
+struct WeakFsAndRoot {
+    fs: Weak<dyn FileSystem>,
+    root_dentry: Weak<Dentry>,
+}
+
+impl WeakFsAndRoot {
+    fn upgrade(&mut self) -> Option<FsAndRoot> {
+        let fs = self.fs.upgrade()?;
+        let root_dentry = self.root_dentry.upgrade().unwrap_or_else(|| {
+            let dentry = Dentry::new_root(fs.root_inode());
+            self.root_dentry = Arc::downgrade(&dentry);
+            dentry
+        });
+        Some(FsAndRoot { fs, root_dentry })
+    }
+}
+
+impl<K: Eq + Ord + Clone + Send + Sync + 'static> FsCache<K> {
+    /// Creates an empty cache.
+    pub(in crate::fs) const fn new() -> Self {
+        Self {
+            entries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Gets or creates a file system and its root dentry for `key`.
+    ///
+    /// A live entry is checked against `required_flags` while the cache is locked and
+    /// returned without invoking `create_fn`. If no live entry exists, invokes
+    /// `create_fn` and derives a root `Dentry`.
+    fn get_or_create<F>(&self, key: K, required_flags: FsFlags, create_fn: F) -> Result<FsAndRoot>
+    where
+        F: FnOnce() -> Result<Arc<dyn FileSystem>>,
+    {
+        let mut entries = self.entries.lock();
+        match entries.entry(key) {
+            Entry::Occupied(mut entry) => {
+                if let Some(fs_and_root) = entry.get_mut().upgrade() {
+                    let extant_readonly = fs_and_root.fs.flags().contains(FsFlags::RDONLY);
+                    let requested_readonly = required_flags.contains(FsFlags::RDONLY);
+                    if extant_readonly != requested_readonly {
+                        return_errno_with_message!(
+                            Errno::EBUSY,
+                            "the read-only flag of the extant file system does not match"
+                        );
+                    }
+                    return Ok(fs_and_root);
+                }
+
+                let fs = match create_fn() {
+                    Ok(fs) => fs,
+                    Err(err) => {
+                        entry.remove();
+                        return Err(err);
+                    }
+                };
+                let fs_and_root = FsAndRoot::new(fs);
+                entry.insert(fs_and_root.downgrade());
+                Ok(fs_and_root)
+            }
+            Entry::Vacant(entry) => {
+                let fs = create_fn()?;
+                let fs_and_root = FsAndRoot::new(fs);
+                entry.insert(fs_and_root.downgrade());
+                Ok(fs_and_root)
+            }
+        }
+    }
+}
+
 struct FsRegistry {
-    fs_table: Mutex<BTreeMap<&'static str, &'static dyn FsType>>,
+    fs_table: Mutex<BTreeMap<&'static str, &'static dyn DynFsType>>,
     systree_fields: AttrLessBranchNodeFields<dyn SysObj, Self>,
 }
 
@@ -188,7 +368,7 @@ impl FsRegistry {
     }
 
     /// Registers a file system control interface.
-    fn register(&self, new_type: &'static dyn FsType) -> Result<()> {
+    fn register(&self, new_type: &'static dyn DynFsType) -> Result<()> {
         let mut fs_table = self.fs_table.lock();
         if fs_table.contains_key(new_type.name()) {
             return_errno_with_message!(Errno::EEXIST, "the file system type already exists");

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -208,9 +208,8 @@ impl NameAndParent {
 impl Dentry {
     /// Creates a new root `Dentry` with the given inode.
     ///
-    /// It is been created during the construction of the `Mount`.
-    /// The `Mount` holds an arc reference to this root `Dentry`.
-    pub(super) fn new_root(inode: Arc<dyn Inode>) -> Arc<Self> {
+    /// It is created during the construction of a mounted filesystem.
+    pub(in crate::fs) fn new_root(inode: Arc<dyn Inode>) -> Arc<Self> {
         Self::new(inode, DentryOptions::Root)
     }
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsFlags},
             inode::{HardLinkability, Inode, Metadata, MknodType, RenameMode},
+            registry::FsAndRoot,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -345,7 +346,7 @@ impl Path {
     /// in the current mount namespace.
     pub fn mount(
         &self,
-        fs: Arc<dyn FileSystem>,
+        fs_and_root: FsAndRoot,
         flags: PerMountFlags,
         source: Option<String>,
         ctx: &Context,
@@ -368,9 +369,13 @@ impl Path {
         }
 
         let mut topology_guard = MountTopology::write_lock();
-        let child_mount =
-            self.mount
-                .do_mount(fs, flags, &self.dentry, source, &mut topology_guard)?;
+        let child_mount = self.mount.do_mount(
+            fs_and_root,
+            flags,
+            &self.dentry,
+            source,
+            &mut topology_guard,
+        )?;
 
         Ok(child_mount)
     }

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -18,6 +18,7 @@ use crate::{
                 dentry::{Dentry, DentryKey},
                 mount_namespace::MountNamespace,
             },
+            registry::FsAndRoot,
         },
     },
     prelude::*,
@@ -248,7 +249,7 @@ pub struct Mount {
     /// Mountpoint dentry. A mount node can be mounted on one dentry of another mount node,
     /// which makes the mount being the child of the mount node.
     mountpoint: RwLock<Option<Arc<Dentry>>>,
-    /// The associated FS.
+    /// The associated mounted filesystem.
     fs: Arc<dyn FileSystem>,
     /// The mount source (e.g., a device path like "/dev/vda" or a filesystem name like "proc").
     ///
@@ -286,7 +287,15 @@ impl Mount {
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
         let source = fs.name().to_string();
-        Self::new(fs, PerMountFlags::default(), None, mnt_ns, Some(source))
+        let root_dentry = Dentry::new_root(fs.root_inode());
+        Self::new(
+            root_dentry,
+            fs,
+            PerMountFlags::default(),
+            None,
+            mnt_ns,
+            Some(source),
+        )
     }
 
     /// Creates a pseudo mount node with an associated FS.
@@ -294,7 +303,15 @@ impl Mount {
     /// This pseudo mount is not mounted on other mount nodes, has no parent, and does not
     /// belong to any mount namespace.
     pub(in crate::fs) fn new_pseudo(fs: Arc<dyn FileSystem>) -> Result<Arc<Self>> {
-        Self::new(fs, PerMountFlags::KERNMOUNT, None, Weak::new(), None)
+        let root_dentry = Dentry::new_root(fs.root_inode());
+        Self::new(
+            root_dentry,
+            fs,
+            PerMountFlags::KERNMOUNT,
+            None,
+            Weak::new(),
+            None,
+        )
     }
 
     /// Creates a mount node that is not attached to the mount tree.
@@ -305,12 +322,13 @@ impl Mount {
     // immutable. This should be changed once mount namespaces can be updated
     // during attach.
     pub fn new_detached(
-        fs: Arc<dyn FileSystem>,
+        fs_and_root: FsAndRoot,
         flags: PerMountFlags,
         mnt_ns: Weak<MountNamespace>,
         source: Option<String>,
     ) -> Result<Arc<Self>> {
-        Self::new(fs, flags, None, mnt_ns, source)
+        let (fs, root_dentry) = fs_and_root.into_parts();
+        Self::new(root_dentry, fs, flags, None, mnt_ns, source)
     }
 
     /// The internal constructor.
@@ -322,6 +340,7 @@ impl Mount {
     /// exist without a mountpoint, ensuring uniformity and security, while all other
     /// mount nodes must be explicitly assigned a mountpoint to maintain structural integrity.
     fn new(
+        root_dentry: Arc<Dentry>,
         fs: Arc<dyn FileSystem>,
         flags: PerMountFlags,
         parent_mount: Option<Weak<Mount>>,
@@ -333,7 +352,7 @@ impl Mount {
 
         let mount = Arc::new_cyclic(|weak_self| Self {
             id,
-            root_dentry: Dentry::new_root(fs.root_inode()),
+            root_dentry,
             mountpoint: RwLock::new(None),
             fs,
             source,
@@ -387,7 +406,7 @@ impl Mount {
     /// Returns the mounted child mount.
     pub(super) fn do_mount(
         self: &Arc<Self>,
-        fs: Arc<dyn FileSystem>,
+        fs_and_root: FsAndRoot,
         flags: PerMountFlags,
         mountpoint: &Arc<Dentry>,
         source: Option<String>,
@@ -398,7 +417,9 @@ impl Mount {
         }
 
         let key = mountpoint.key();
+        let (fs, root_dentry) = fs_and_root.into_parts();
         let child_mount = Self::new(
+            root_dentry,
             fs,
             flags,
             Some(Arc::downgrade(self)),

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -5,9 +5,9 @@ use crate::{
     fs::{
         file::InodeType,
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FsFlags,
             path::{AT_FDCWD, EmptyPathStr, FsPath, MountPropType, Path, PerMountFlags},
-            registry::{FsCreationCtx, FsType},
+            registry::{DynFsType, FsAndRoot, FsCreationCtx},
         },
     },
     prelude::*,
@@ -225,8 +225,8 @@ fn do_new_mount(
         Some(source)
     };
 
-    let fs = open_fs(source.as_deref(), flags, fs_type, data_addr, ctx)?;
-    target_path.mount(fs, flags.into(), source, ctx)?;
+    let fs_and_root = open_fs(source.as_deref(), flags, fs_type, data_addr, ctx)?;
+    target_path.mount(fs_and_root, flags.into(), source, ctx)?;
     Ok(())
 }
 
@@ -234,10 +234,10 @@ fn do_new_mount(
 fn open_fs(
     source: Option<&str>,
     flags: MountFlags,
-    fs_type: &dyn FsType,
+    fs_type: &dyn DynFsType,
     data_addr: Vaddr,
     ctx: &Context,
-) -> Result<Arc<dyn FileSystem>> {
+) -> Result<FsAndRoot> {
     let user_space = ctx.user_space();
     let data = if data_addr == 0 {
         None
@@ -247,7 +247,7 @@ fn open_fs(
     let data = data.as_deref().map(CStr::to_string_lossy);
 
     let fs_creation_ctx = FsCreationCtx::new(source, flags.into(), data.as_deref(), ctx);
-    fs_type.create(&fs_creation_ctx)
+    fs_type.get_or_create(&fs_creation_ctx)
 }
 
 bitflags! {

--- a/test/initramfs/src/regression/fs/ext2/shared_block_device.c
+++ b/test/initramfs/src/regression/fs/ext2/shared_block_device.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#ifndef __asterinas__
+#include <linux/loop.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#endif
+#include <sched.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define PRIMARY_MOUNT "/tmp/shared_block_device_primary"
+#define SECONDARY_MOUNT "/tmp/shared_block_device_secondary"
+#define TEST_FILE "shared_instance_test"
+#define PRIMARY_FILE PRIMARY_MOUNT "/" TEST_FILE
+#define SECONDARY_FILE SECONDARY_MOUNT "/" TEST_FILE
+
+#ifdef __asterinas__
+/* `/dev/vda` is already mounted read-write at `/ext2` by init. */
+#define BLOCK_DEVICE "/dev/vdc"
+
+static const char *block_device_path(void)
+{
+	return BLOCK_DEVICE;
+}
+
+static int open_block_device(void)
+{
+	return open(BLOCK_DEVICE, O_RDWR);
+}
+
+static int close_block_device(int fd)
+{
+	return close(fd);
+}
+#else
+#define LOOP_BACKING_FILE "/tmp/shared_block_device.img"
+#define LOOP_BACKING_FILE_SIZE (16 * 1024 * 1024)
+
+static char loop_path[sizeof("/dev/loop") + 10];
+
+static const char *block_device_path(void)
+{
+	return loop_path;
+}
+
+static void make_ext2_image(void)
+{
+	/*
+	 * Linux test runners do not have the Asterinas ext2 disk image, so
+	 * build a fresh loop-backed ext2 block device for the same mount path.
+	 */
+	int image_fd = CHECK(
+		open(LOOP_BACKING_FILE, O_CREAT | O_RDWR | O_TRUNC, 0600));
+
+	CHECK(ftruncate(image_fd, LOOP_BACKING_FILE_SIZE));
+	CHECK(close(image_fd));
+	CHECK_WITH(system("mke2fs -q -t ext2 -F " LOOP_BACKING_FILE),
+		   _ret == 0);
+}
+
+static int open_block_device(void)
+{
+	make_ext2_image();
+
+	/* Keep the loop fd open until both mounts are unmounted. */
+	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
+	int loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
+	CHECK(close(control_fd));
+
+	snprintf(loop_path, sizeof(loop_path), "/dev/loop%d", loop_number);
+	int loop_fd = CHECK(open(loop_path, O_RDWR));
+	int image_fd = CHECK(open(LOOP_BACKING_FILE, O_RDWR));
+	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
+	CHECK(close(image_fd));
+	return loop_fd;
+}
+
+static int close_block_device(int fd)
+{
+	CHECK(ioctl(fd, LOOP_CLR_FD, 0));
+	CHECK(close(fd));
+	return unlink(LOOP_BACKING_FILE);
+}
+#endif
+
+static void ensure_dir(const char *path)
+{
+	CHECK_WITH(mkdir(path, 0755), _ret >= 0 || errno == EEXIST);
+}
+
+static void unlink_if_exists(const char *path)
+{
+	CHECK_WITH(unlink(path), _ret == 0 || errno == ENOENT);
+}
+
+FN_SETUP(create_mount_dirs)
+{
+	ensure_dir(PRIMARY_MOUNT);
+	ensure_dir(SECONDARY_MOUNT);
+}
+END_SETUP()
+
+FN_TEST(mounts_of_same_block_device_share_filesystem)
+{
+	const char *payload = "shared ext2 instance";
+	const size_t payload_len = strlen(payload);
+	char buffer[sizeof("shared ext2 instance")] = { 0 };
+	struct stat source_stat;
+
+	int block_device_fd = TEST_SUCC(open_block_device());
+	const char *block_device = block_device_path();
+	TEST_RES(stat(block_device, &source_stat),
+		 S_ISBLK(source_stat.st_mode));
+
+	/*
+	 * Mount the same ext2 block device twice in a private mount namespace.
+	 * Both mount points should refer to one shared filesystem instance.
+	 */
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	TEST_SUCC(mount(block_device, PRIMARY_MOUNT, "ext2", 0, ""));
+	TEST_SUCC(mount(block_device, SECONDARY_MOUNT, "ext2", 0, ""));
+
+	unlink_if_exists(PRIMARY_FILE);
+	TEST_ERRNO(open(SECONDARY_FILE, O_RDONLY), ENOENT);
+
+	/* A file created from the primary mount must be visible from the other. */
+	int file_fd = TEST_SUCC(
+		open(PRIMARY_FILE, O_CREAT | O_EXCL | O_WRONLY, 0644));
+	TEST_RES(write(file_fd, payload, payload_len),
+		 _ret == (ssize_t)payload_len);
+	TEST_SUCC(close(file_fd));
+
+	file_fd = TEST_SUCC(open(SECONDARY_FILE, O_RDONLY));
+	TEST_RES(read(file_fd, buffer, sizeof(buffer)),
+		 _ret == (ssize_t)payload_len);
+	TEST_RES(memcmp(buffer, payload, payload_len), _ret == 0);
+	TEST_SUCC(close(file_fd));
+
+	/* Removing the file from the secondary mount must remove the same inode. */
+	TEST_SUCC(unlink(SECONDARY_FILE));
+	TEST_ERRNO(open(PRIMARY_FILE, O_RDONLY), ENOENT);
+
+	TEST_SUCC(umount(SECONDARY_MOUNT));
+	TEST_SUCC(umount(PRIMARY_MOUNT));
+	TEST_SUCC(close_block_device(block_device_fd));
+}
+END_TEST()
+
+FN_TEST(mounts_of_same_block_device_reject_different_readonly_flags)
+{
+	int block_device_fd = TEST_SUCC(open_block_device());
+	const char *block_device = block_device_path();
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	TEST_SUCC(mount(block_device, PRIMARY_MOUNT, "ext2", MS_RDONLY, ""));
+	TEST_ERRNO(mount(block_device, SECONDARY_MOUNT, "ext2", 0, ""), EBUSY);
+
+	TEST_SUCC(umount(PRIMARY_MOUNT));
+	TEST_SUCC(close_block_device(block_device_fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -97,6 +97,7 @@ test_ext2 "/ext2" "test_file.txt"
 ./ext2/readdir
 ./ext2/rename
 ./ext2/rmdir
+./ext2/shared_block_device
 ./ext2/short_rw
 ./ext2/sparse
 ./ext2/symlink


### PR DESCRIPTION
Currently, every time we mount a device, we create a new file system instance. However, having multiple file system instances for the same device means each instance has its own independent locks, and these instances could concurrently modify the contents of the device.

This PR addresses the above situation. With this PR, when the same device is mounted multiple times in different locations, these mount instances can actually share the same file system instance, which is aligned with Linux.