### PR TITLE
Check for address overflow in CursorMut::unmap

### DIFF
--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -6,8 +6,8 @@ use crate::{
     Error,
     io::IoMem,
     mm::{
-        CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PageFlags, PageProperty,
-        UFrame, VmSpace,
+        CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PAGE_SIZE, PageFlags,
+        PageProperty, UFrame, VmSpace,
         io::{VmIo, VmIoFill, VmReader, VmWriter, util::HasVmReaderWriter},
         tlb::TlbFlushOp,
         vm_space::{VmQueriedItem, get_activated_vm_space},
@@ -608,6 +608,25 @@ mod vmspace {
                 .expect("failed to create the mutable cursor");
             cursor_mut.map(frame.clone(), prop);
         }
+    }
+
+    /// Ensures `unmap` panics when `len` overflows the address space
+    /// instead of silently wrapping (issue #3159).
+    #[ktest]
+    #[should_panic(expected = "the unmap length overflows the address space")]
+    fn vmspace_unmap_overflowing_len() {
+        let vmspace = VmSpace::default();
+        let range = 0x1000..0x2000;
+        let preempt_guard = disable_preempt();
+
+        let mut cursor_mut = vmspace
+            .cursor_mut(&preempt_guard, &range)
+            .expect("failed to create the mutable cursor");
+        // Page-aligned `len` that wraps past `usize::MAX` when added to the
+        // cursor's virtual address. Without the checked addition this used
+        // to wrap and bypass the documented out-of-range panic.
+        let overflowing_len = usize::MAX & !(PAGE_SIZE - 1);
+        cursor_mut.unmap(overflowing_len);
     }
 
     /// Unmaps twice using `CursorMut`.

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -464,7 +464,10 @@ impl<'a> CursorMut<'a> {
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.
     pub fn unmap(&mut self, len: usize) -> usize {
-        let end_va = self.virt_addr() + len;
+        let end_va = self
+            .virt_addr()
+            .checked_add(len)
+            .expect("the unmap length overflows the address space");
         let mut num_unmapped: usize = 0;
         loop {
             // SAFETY: It is safe to un-map memory in the userspace. And the


### PR DESCRIPTION
## Summary
`CursorMut::unmap` now computes its end address with `checked_add`, so a `len` large enough to wrap `usize` panics with a clear message instead of silently wrapping. The documented panic contract ("panics if the length is longer than the remaining range of the cursor") previously did not hold in release builds: `self.virt_addr() + len` wrapped, the lower layer's `assert!(end <= self.barrier_va.end)` could then pass unexpectedly, and the unmap became a no-op or operated on a wrong range.

## Why this matters
#3159 traced this exact path (`ostd/src/mm/vm_space.rs`), and junyang-zh confirmed "the wrapping behavior is unintended. We should check it." The unmap path is memory-safety adjacent: an unmap that silently does nothing while the caller believes the range is gone undermines the TLB-flush contract described in the method docs.

This change is scoped to the `unmap` entry path per the issue; the sibling sites Marsman1996 listed (`page_table/cursor/mod.rs`, `kernel/src/vm/vmo/mod.rs`) have the same pattern but separate call contracts, so they are left for follow-ups.

## Testing
- New `#[ktest]` `vmspace_unmap_overflowing_len` locks the panic in: a page-aligned `len` of `usize::MAX & !(PAGE_SIZE - 1)` added to the cursor's address wraps, and the test expects the "the unmap length overflows the address space" panic
- `cargo check -p ostd --target x86_64-unknown-none` (with and without `--cfg ktest`) and `cargo fmt -p ostd -- --check` pass on toolchain nightly-2026-04-03
- Valid page-aligned `len` within range takes the same path as before (`checked_add` returns `Some`), so existing `vmspace_map_unmap` / `vmspace_unmap_twice` behavior is unchanged

Fixes #3159
