### PR TITLE
Fix futex to return ENOSYS for unsupported operations

### DIFF
--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -134,7 +134,7 @@ pub fn sys_futex(
         }
         _ => {
             warn!("futex op = {:?}", futex_op);
-            return_errno_with_message!(Errno::EINVAL, "unsupported futex op");
+            return_errno_with_message!(Errno::ENOSYS, "unsupported futex op");
         }
     }
     .map_err(|err| match err.error() {


### PR DESCRIPTION
This PR fixes the error code returned by futex when the requested futex operation is not implemented by Asterinas.

Previously, unsupported futex operations were rejected with EINVAL:

```rust
_ => {
    warn!("futex op = {:?}", futex_op);
    return_errno_with_message!(Errno::EINVAL, "unsupported futex op");
}
```

For unsupported futex operations, Linux returns -ENOSYS instead of -EINVAL, see [https://elixir.bootlin.com/linux/v7.0.9/source/kernel/futex/syscalls.c#L112](https://elixir.bootlin.com/linux/v7.0.9/source/kernel/futex/syscalls.c#L112)

Therefore, Asterinas should return ENOSYS as well to match Linux behavior.

```rust
_ => {
    warn!("futex op = {:?}", futex_op);
    return_errno_with_message!(Errno::ENOSYS, "unsupported futex op");
}
```

This change allows user-space programs to trigger their fallback paths when an unsupported futex operation is encountered, instead of treating the error as a fatal invalid-argument condition and exiting.