### PR TITLE
Fix a small bug in vsock `recv()`

### DIFF
--- a/kernel/src/net/socket/vsock/transport/connection/recv.rs
+++ b/kernel/src/net/socket/vsock/transport/connection/recv.rs
@@ -145,12 +145,14 @@ impl ConnectionState {
 
             num_packets += 1;
 
+            let mut payload_len = packet_ref.payload_len();
+
             if read_offset.is_none() {
+                payload_len -= self.rx_queue.read_offset;
                 read_offset = Some(self.rx_queue.read_offset);
                 self.rx_queue.read_offset = 0;
             }
 
-            let payload_len = packet_ref.payload_len();
             if payload_len >= max_bytes {
                 break;
             } else {


### PR DESCRIPTION
When receiving packets, we should start counting bytes from the unreceived part of the first packet. However, we previously counted the entire first packet.

This can cause unexpected short reads. For example,
```
 [ Sender ]
   send("ab") = 2
   send("cd") = 2

 [ Receiver ]
   recv(1) = "a"
   recv(2) = "b"   <----- This should be "bc".
```

I have tested this PR via the following regression test. The test failed before this PR and passes after this PR:
<details>
<summary> Regression test </summary>

```diff
diff --git a/test/initramfs/src/regression/network/vsock_err/vsock_err_guest.c b/test/initramfs/src/regression/network/vsock_err/vsock_err_guest.c
index 78b8b5503..1c487f882 100644
--- a/test/initramfs/src/regression/network/vsock_err/vsock_err_guest.c
+++ b/test/initramfs/src/regression/network/vsock_err/vsock_err_guest.c
@@ -30,6 +30,7 @@
 #define GUEST_ACCEPT_PORT 25114
 #define GUEST_RESET_PORT 25115
 #define GUEST_BACKLOG_PORT 25116
+#define PARTIAL_RECV_PORT 25117
 #define REFUSED_PORT 25999
 
 #define CONNECT_DELAY_US 200000
@@ -578,6 +579,29 @@ FN_TEST(peer_shutdown_read_then_write_and_poll)
 }
 END_TEST()
 
+FN_TEST(recv_after_partially_read_packet)
+{
+	struct vsock_test_scenario_handle handle;
+	int sockfd;
+	char byte = '\0';
+	char buf[2] = { 0 };
+
+	TEST_SUCC(VSOCK_TEST_START(send_two_chunks, &handle,
+				   .port = PARTIAL_RECV_PORT));
+	sockfd = TEST_SUCC(connect_to_peer(PARTIAL_RECV_PORT, 0));
+
+	usleep(CONNECT_DELAY_US);
+	TEST_RES(read(sockfd, &byte, sizeof(byte)),
+		 _ret == sizeof(byte) && byte == 'a');
+	TEST_RES(read(sockfd, buf, sizeof(buf)),
+		 (size_t)_ret == sizeof(buf) &&
+			 memcmp(buf, "bc", sizeof(buf)) == 0);
+
+	TEST_SUCC(close(sockfd));
+	TEST_SUCC(vsock_test_wait(handle));
+}
+END_TEST()
+
 FN_TEST(local_and_peer_shutdown_write_poll)
 {
 	struct vsock_test_scenario_handle handle;
diff --git a/test/initramfs/src/regression/network/vsock_err/vsock_err_host.c b/test/initramfs/src/regression/network/vsock_err/vsock_err_host.c
index 89823d8c4..1ebb7fae1 100644
--- a/test/initramfs/src/regression/network/vsock_err/vsock_err_host.c
+++ b/test/initramfs/src/regression/network/vsock_err/vsock_err_host.c
@@ -315,6 +315,42 @@ out:
 	return ret;
 }
 
+VSOCK_HOST_SCENARIO(send_two_chunks)
+{
+	VSOCK_HOST_BIND_ARGS(send_two_chunks);
+	int listener = -1;
+	int accepted = -1;
+	int ret = -1;
+
+	listener = bind_listener(port);
+	if (listener < 0) {
+		goto out;
+	}
+
+	accepted = accept_one(listener);
+	if (accepted < 0) {
+		goto out;
+	}
+
+	if (write(accepted, "ab", 2) != 2) {
+		goto out;
+	}
+	if (write(accepted, "cd", 2) != 2) {
+		goto out;
+	}
+
+	ret = drain_socket(accepted);
+
+out:
+	if (accepted >= 0) {
+		close(accepted);
+	}
+	if (listener >= 0) {
+		close(listener);
+	}
+	return ret;
+}
+
 VSOCK_HOST_SCENARIO(connect_addr)
 {
 	VSOCK_HOST_BIND_ARGS(connect_addr);
diff --git a/test/initramfs/src/regression/network/vsock_err/vsock_err_scenarios.h b/test/initramfs/src/regression/network/vsock_err/vsock_err_scenarios.h
index b34b556c1..02040ec5d 100644
--- a/test/initramfs/src/regression/network/vsock_err/vsock_err_scenarios.h
+++ b/test/initramfs/src/regression/network/vsock_err/vsock_err_scenarios.h
@@ -10,6 +10,7 @@
 	X(send_shutdown, "Sends one payload and shuts down its write side.")               \
 	X(shutdown_read,                                                                   \
 	  "Shuts down read first, then write, on one accepted socket.")                    \
+	X(send_two_chunks, "Sends two payload chunks on one accepted socket.")             \
 	X(connect_addr,                                                                    \
 	  "Connects into one guest listener and reports its local address.")               \
 	X(connect_expect_disconnect,                                                       \
@@ -27,6 +28,8 @@
 
 #define VSOCK_TEST_FIELDS_shutdown_read(F) F(u32, port)
 
+#define VSOCK_TEST_FIELDS_send_two_chunks(F) F(u32, port)
+
 #define VSOCK_TEST_FIELDS_connect_addr(F) F(u32, port)
 
 #define VSOCK_TEST_FIELDS_connect_expect_disconnect(F) F(u32, port)
```
</details>