### PR TITLE
Add rename support for virtio-fs

### DIFF
--- a/kernel/libs/aster-fuse/src/lib.rs
+++ b/kernel/libs/aster-fuse/src/lib.rs
@@ -51,6 +51,7 @@ pub use self::{
         readdir::ReaddirOperation,
         readlink::{MAX_READLINK_LEN, ReadlinkOperation},
         release::{ReleaseFlags, ReleaseKind, ReleaseOperation, ReleaseReq},
+        rename::{RenameOperation, RenameReq},
         rmdir::RmdirOperation,
         setattr::{SetattrOperation, SetattrReq, SetattrValid},
         statfs::{Kstatfs, StatfsOperation, StatfsReply},

--- a/kernel/libs/aster-fuse/src/ops/mod.rs
+++ b/kernel/libs/aster-fuse/src/ops/mod.rs
@@ -28,6 +28,7 @@ pub mod read;
 pub mod readdir;
 pub mod readlink;
 pub mod release;
+pub mod rename;
 pub mod rmdir;
 pub mod setattr;
 pub mod statfs;

--- a/kernel/libs/aster-fuse/src/ops/rename.rs
+++ b/kernel/libs/aster-fuse/src/ops/rename.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! `FUSE_RENAME` renames a directory entry.
+//!
+//! The request body contains [`RenameReq`] followed by the null-terminated old
+//! name and the null-terminated new name. Successful replies do not carry a
+//! payload.
+
+use ostd::mm::{Infallible, VmReader, VmWriter};
+
+use super::util;
+use crate::{FuseError, FuseNodeId, FuseOpcode, FuseOperation, FuseResult, ReplyExpectation};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct RenameReq {
+    /// Parent directory node that will receive the renamed entry.
+    newdir: FuseNodeId,
+}
+
+impl RenameReq {
+    pub const fn new(newdir: FuseNodeId) -> Self {
+        Self { newdir }
+    }
+}
+
+pub struct RenameOperation<'a> {
+    rename_req: RenameReq,
+    old_name: &'a str,
+    new_name: &'a str,
+}
+
+impl<'a> RenameOperation<'a> {
+    pub fn new(rename_req: RenameReq, old_name: &'a str, new_name: &'a str) -> Self {
+        Self {
+            rename_req,
+            old_name,
+            new_name,
+        }
+    }
+}
+
+impl FuseOperation for RenameOperation<'_> {
+    type Output = ();
+
+    fn opcode(&self) -> FuseOpcode {
+        FuseOpcode::Rename
+    }
+
+    fn body_len(&self) -> usize {
+        util::name_body_len(
+            util::name_body_len(size_of::<RenameReq>(), self.old_name),
+            self.new_name,
+        )
+    }
+
+    fn write_body(&mut self, writer: &mut VmWriter<'_, Infallible>) -> FuseResult<()> {
+        if writer.avail() < self.body_len() {
+            return Err(FuseError::BufferTooSmall);
+        }
+
+        writer.write_val(&self.rename_req).unwrap();
+        writer.write(&mut VmReader::from(self.old_name.as_bytes()));
+        writer.write(&mut VmReader::from(util::NAME_TERMINATOR));
+        writer.write(&mut VmReader::from(self.new_name.as_bytes()));
+        writer.write(&mut VmReader::from(util::NAME_TERMINATOR));
+
+        Ok(())
+    }
+
+    fn reply_expectation(&self) -> ReplyExpectation {
+        ReplyExpectation::HeaderOnly
+    }
+
+    fn parse_reply(
+        _payload_len: usize,
+        _reader: &mut VmReader<'_, Infallible>,
+    ) -> FuseResult<Self::Output> {
+        Ok(())
+    }
+}

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -22,6 +22,7 @@ use aster_fuse::{
         mknod::{MknodOperation, MknodReq},
         open::{OpenReq, OpendirOperation},
         release::ReleaseOptions,
+        rename::{RenameOperation, RenameReq},
         rmdir::RmdirOperation,
         unlink::UnlinkOperation,
     },
@@ -445,6 +446,27 @@ impl Inode for VirtioFsInode {
 
         self.expire_attr_cache();
         child.expire_attr_cache();
+
+        Ok(())
+    }
+
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+        let target = target.downcast_ref::<VirtioFsInode>().unwrap();
+
+        let fs = self.fs_ref();
+
+        // TODO: Invalidate the stale positive dentry for `old_name`
+        // when encountering `ENOENT` once the rename interface can
+        // pass the cached old dentry down.
+        fs.session().do_fuse_op(
+            self.nodeid(),
+            RenameOperation::new(RenameReq::new(target.nodeid()), old_name, new_name),
+        )?;
+
+        self.expire_attr_cache();
+        if self.nodeid() != target.nodeid() {
+            target.expire_attr_cache();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
  ## Summary

This PR implements `rename` support for virtio-fs.

It adds the `FUSE_RENAME` request type to `aster-fuse`, wires it into the virtio-fs inode implementation, and sends the rename operation to the FUSE server with the source name, target parent node ID, and target name.

The PR also updates VFS dentry rename handling to invalidate cached dentries when a remote filesystem reports `ENOENT`, so stale cached entries are removed for revalidation-based filesystems.

  ## Changes

  - Add `RenameReq` and `RenameOperation` for `FUSE_RENAME`.
  - Implement `Inode::rename` for `VirtioFsInode`.
  - Expire virtio-fs attribute caches after successful rename.
  - Remove stale cached dentries when rename fails with `ENOENT` under revalidation policy.