### PR TITLE
net/tcp: dispatch incoming connections to INADDR_ANY listeners

### DIFF
--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -262,16 +262,33 @@ impl<E: Ext> SocketTable<E> {
     }
 
     pub(crate) fn lookup_listener(&self, key: &ListenerKey) -> Option<&Arc<TcpListenerBg<E>>> {
+        // First: try an exact match on (addr, port).
         let bucket = {
             let hash = key.hash();
             let bucket_index = hash & LISTENER_BUCKET_MASK;
             &self.listener_buckets[bucket_index as usize]
         };
+        if let Some(listener) = bucket.listeners.iter().find(|l| l.listener_key() == key) {
+            return Some(listener);
+        }
 
-        bucket
+        // Fallback: try an INADDR_ANY listener on the same port.
+        // Linux uses a separate hash table keyed by port only for wildcard listeners;
+        // here we reuse the same table with a wildcard key.
+        let wildcard_addr = match key.addr {
+            IpAddress::Ipv4(_) => IpAddress::Ipv4(Ipv4Addr::UNSPECIFIED),
+            IpAddress::Ipv6(_) => IpAddress::Ipv6(smoltcp::wire::Ipv6Address::UNSPECIFIED),
+        };
+        let wildcard_key = ListenerKey::new(wildcard_addr, key.port);
+        let wildcard_bucket = {
+            let hash = wildcard_key.hash();
+            let bucket_index = hash & LISTENER_BUCKET_MASK;
+            &self.listener_buckets[bucket_index as usize]
+        };
+        wildcard_bucket
             .listeners
             .iter()
-            .find(|listener| listener.listener_key() == key)
+            .find(|l| l.listener_key() == &wildcard_key)
     }
 
     pub(crate) fn lookup_connection(


### PR DESCRIPTION
## Problem

When a server binds to `0.0.0.0:port` (INADDR_ANY), incoming TCP packets addressed to a specific interface IP are not dispatched to that listener. `lookup_listener()` in `socket_table.rs` performs only an exact `(addr, port)` match, so a listener registered under `UNSPECIFIED:port` is never found when the incoming key carries a concrete IP.

This means any server using `bind(0.0.0.0, port)` — the standard POSIX pattern — never accepts connections on Asterinas.

## Fix

Add a two-stage lookup in `lookup_listener()`:

1. **Exact match** — try the key as-is (specific addr + port)
2. **Wildcard fallback** — if no exact match, retry with `UNSPECIFIED` addr and the same port

This mirrors the approach described in RFC 793 and used by Linux (which maintains a separate wildcard-listener hash table keyed by port only).

## Testing

Validated with a Rust TCP echo server bound to `0.0.0.0:8080` inside Asterinas (Proxmox KVM, virtio-net), receiving connections from the host network. Before this fix: connections timed out. After: accepted correctly.