### PR TITLE
Inspect output flags (OPOST/ONLCR/OCRNL) in TTY line discipline for echo path and write path

### DIFF
--- a/kernel/src/device/pty/driver.rs
+++ b/kernel/src/device/pty/driver.rs
@@ -128,12 +128,7 @@ impl TtyDriver for PtyDriver {
 
         let mut len = 0;
         for ch in chs {
-            // TODO: This is termios-specific behavior and should be part of the TTY implementation
-            // instead of the TTY driver implementation. See the ONLCR flag for more details.
-            if *ch == b'\n' && output.capacity() - output.len() >= 2 {
-                output.push(b'\r').unwrap();
-                output.push(b'\n').unwrap();
-            } else if *ch != b'\n' && !output.is_full() {
+            if !output.is_full() {
                 output.push(*ch).unwrap();
             } else if len == 0 {
                 return_errno_with_message!(Errno::EAGAIN, "the output buffer is full");
@@ -164,8 +159,7 @@ impl TtyDriver for PtyDriver {
     }
 
     fn can_push(&self) -> bool {
-        let output = self.output.lock();
-        output.capacity() - output.len() >= 2
+        !self.output.lock().is_full()
     }
 
     fn notify_input(&self) {

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -2,7 +2,7 @@
 
 use ostd::const_assert;
 
-use super::termio::{CCtrlCharId, CTermios, CWinSize};
+use super::termio::{CCtrlCharId, COutputFlags, CTermios, CWinSize};
 use crate::{
     device::tty::termio::{CInputFlags, CLocalFlags},
     prelude::*,
@@ -113,7 +113,7 @@ impl LineDiscipline {
         // Typically, a TTY in raw mode does not echo. But the TTY can also be in a CBREAK mode,
         // with ICANON closed and ECHO opened.
         if self.termios.local_flags().contains(CLocalFlags::ECHO) {
-            self.output_char(ch, echo_callback);
+            self.echo_char(ch, echo_callback);
         }
 
         if self.is_full() {
@@ -157,11 +157,30 @@ impl LineDiscipline {
         Ok(())
     }
 
-    // TODO: respect output flags
-    fn output_char<F: FnMut(&[u8])>(&self, ch: u8, mut echo_callback: F) {
+    /// Echoes a character back to the output, respecting output processing flags.
+    ///
+    /// Currently supported output flags: `OPOST`, `ONLCR`, `OCRNL`.
+    ///
+    /// TODO: Implement remaining output flags: `OLCUC`, `ONOCR`, `ONLRET`, `OFILL`, `OFDEL`.
+    fn echo_char<F: FnMut(&[u8])>(&self, ch: u8, mut echo_callback: F) {
+        let oflags = self.termios.output_flags();
+        let opost = oflags.contains(COutputFlags::OPOST);
+
         match ch {
-            b'\n' => echo_callback(b"\n"),
-            b'\r' => echo_callback(b"\r\n"),
+            b'\n' => {
+                if opost && oflags.contains(COutputFlags::ONLCR) {
+                    echo_callback(b"\r\n");
+                } else {
+                    echo_callback(b"\n");
+                }
+            }
+            b'\r' => {
+                if opost && oflags.contains(COutputFlags::OCRNL) {
+                    echo_callback(b"\n");
+                } else {
+                    echo_callback(b"\r");
+                }
+            }
             ch if ch == self.termios.special_char(CCtrlCharId::VERASE) => {
                 // The driver should erase the current character
                 echo_callback(b"\x08");
@@ -251,6 +270,38 @@ impl LineDiscipline {
     fn flush_line(&mut self) -> Option<()> {
         let bytes = self.current_line.drain();
         self.read_buffer.push_slice(bytes)
+    }
+
+    /// Processes output bytes according to the output flags.
+    ///
+    /// Currently supported output flags: `OPOST`, `ONLCR`, `OCRNL`.
+    ///
+    /// TODO: Implement remaining output flags: `OLCUC`, `ONOCR`, `ONLRET`, `OFILL`, `OFDEL`.
+    pub fn process_output(&self, buf: &[u8]) -> Vec<u8> {
+        let oflags = self.termios.output_flags();
+        if !oflags.contains(COutputFlags::OPOST) {
+            return buf.to_vec();
+        }
+
+        let n_extra = if oflags.contains(COutputFlags::ONLCR) {
+            buf.iter().filter(|&&b| b == b'\n').count()
+        } else {
+            0
+        };
+        let mut result = Vec::with_capacity(buf.len() + n_extra);
+        for &ch in buf {
+            match ch {
+                b'\n' if oflags.contains(COutputFlags::ONLCR) => {
+                    result.push(b'\r');
+                    result.push(b'\n');
+                }
+                b'\r' if oflags.contains(COutputFlags::OCRNL) => {
+                    result.push(b'\n');
+                }
+                _ => result.push(ch),
+            }
+        }
+        result
     }
 
     pub fn window_size(&self) -> CWinSize {

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -215,7 +215,8 @@ impl<D: TtyDriver> Tty<D> {
         if is_nonblocking {
             let _ = self.driver.push_output(&processed)?;
         } else {
-            let _ = self.wait_events(IoEvents::OUT, None, || self.driver.push_output(&processed))?;
+            let _ =
+                self.wait_events(IoEvents::OUT, None, || self.driver.push_output(&processed))?;
         };
         self.pollee.invalidate();
         Ok(write_len)

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -208,15 +208,14 @@ impl<D: TtyDriver> Tty<D> {
 
         let mut buf = vec![0u8; reader.remain().min(IO_CAPACITY)];
         let write_len = reader.read_fallible(&mut buf.as_mut_slice().into())?;
+        let processed = self.ldisc.lock().process_output(&buf[..write_len]);
 
         // TODO: Add support for timeout.
         let is_nonblocking = status_flags.contains(StatusFlags::O_NONBLOCK);
         let len = if is_nonblocking {
-            self.driver.push_output(&buf[..write_len])?
+            self.driver.push_output(&processed)?
         } else {
-            self.wait_events(IoEvents::OUT, None, || {
-                self.driver.push_output(&buf[..write_len])
-            })?
+            self.wait_events(IoEvents::OUT, None, || self.driver.push_output(&processed))?
         };
         self.pollee.invalidate();
         Ok(len)

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -212,13 +212,13 @@ impl<D: TtyDriver> Tty<D> {
 
         // TODO: Add support for timeout.
         let is_nonblocking = status_flags.contains(StatusFlags::O_NONBLOCK);
-        let len = if is_nonblocking {
-            self.driver.push_output(&processed)?
+        if is_nonblocking {
+            let _ = self.driver.push_output(&processed)?;
         } else {
-            self.wait_events(IoEvents::OUT, None, || self.driver.push_output(&processed))?
+            let _ = self.wait_events(IoEvents::OUT, None, || self.driver.push_output(&processed))?;
         };
         self.pollee.invalidate();
-        Ok(len)
+        Ok(write_len)
     }
 
     pub fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {

--- a/kernel/src/device/tty/termio.rs
+++ b/kernel/src/device/tty/termio.rs
@@ -301,6 +301,11 @@ impl CTermios {
     pub fn local_flags(&self) -> &CLocalFlags {
         &self.c_lflags
     }
+
+    /// Returns the output flags.
+    pub(super) fn output_flags(&self) -> &COutputFlags {
+        &self.c_oflags
+    }
 }
 
 /// A window size; `struct winsize` in Linux.

--- a/test/initramfs/src/regression/device/pty/output_flags.c
+++ b/test/initramfs/src/regression/device/pty/output_flags.c
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <pty.h>
+#include <poll.h>
+#include "../../common/test.h"
+
+static int master;
+static int slave;
+
+// Echo path: OPOST|ONLCR (default) — \n is converted to \r\n.
+FN_TEST(echo_onlcr_enabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	// Use default termios: OPOST|ONLCR is on, ECHO is on, ICANON is on.
+	TEST_RES(tcgetattr(slave, &term),
+		 (term.c_oflag & OPOST) && (term.c_oflag & ONLCR));
+
+	// Write "A\r" to master (simulates typing 'A' then Enter).
+	// ICRNL converts \r to \n; ONLCR echoes \n as \r\n.
+	TEST_SUCC(write(master, "A\r", 2));
+
+	// Read the echo from master.
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)), _ret == 3 && buf[0] == 'A' &&
+							 buf[1] == '\r' &&
+							 buf[2] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()
+
+// Echo path: ONLCR off — \n is kept as \n.
+FN_TEST(echo_onlcr_disabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	TEST_SUCC(tcgetattr(slave, &term));
+	term.c_oflag &= ~ONLCR;
+	TEST_SUCC(tcsetattr(slave, TCSANOW, &term));
+
+	// Write just "\r" (Enter). ICRNL converts to \n, echoed as \n.
+	TEST_SUCC(write(master, "\r", 1));
+
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)), _ret == 1 && buf[0] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()
+
+// Echo path: OPOST|OCRNL, ICRNL off — \r is converted to \n.
+FN_TEST(echo_ocrnl_enabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	// Disable ICRNL so \r is not converted to \n on input.
+	// Enable OCRNL so echoed \r is mapped to \n.
+	TEST_SUCC(tcgetattr(slave, &term));
+	term.c_iflag &= ~ICRNL;
+	term.c_oflag |= OCRNL;
+	TEST_SUCC(tcsetattr(slave, TCSANOW, &term));
+
+	// Write just "\r". ICRNL is off so \r stays as \r, OCRNL echoes it as \n.
+	TEST_SUCC(write(master, "\r", 1));
+
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)), _ret == 1 && buf[0] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()
+
+// Write path: OPOST|ONLCR (default) — \n is converted to \r\n.
+FN_TEST(write_onlcr_enabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	TEST_SUCC(tcgetattr(slave, &term));
+	// Turn off echo so only the write-path output is visible.
+	term.c_lflag &= ~ECHO;
+	TEST_SUCC(tcsetattr(slave, TCSANOW, &term));
+
+	// Write to slave; output flags should be applied to what master reads.
+	TEST_SUCC(write(slave, "A\n", 2));
+
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)), _ret == 3 && buf[0] == 'A' &&
+							 buf[1] == '\r' &&
+							 buf[2] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()
+
+// Write path: ONLCR off — \n is kept as \n.
+FN_TEST(write_onlcr_disabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	TEST_SUCC(tcgetattr(slave, &term));
+	term.c_lflag &= ~ECHO;
+	term.c_oflag &= ~ONLCR;
+	TEST_SUCC(tcsetattr(slave, TCSANOW, &term));
+
+	TEST_SUCC(write(slave, "A\n", 2));
+
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)),
+		 _ret == 2 && buf[0] == 'A' && buf[1] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()
+
+// Write path: OPOST|OCRNL — \r is converted to \n.
+FN_TEST(write_ocrnl_enabled)
+{
+	struct termios term;
+	TEST_SUCC(openpty(&master, &slave, NULL, NULL, NULL));
+
+	TEST_SUCC(tcgetattr(slave, &term));
+	term.c_lflag &= ~ECHO;
+	term.c_oflag |= OCRNL;
+	TEST_SUCC(tcsetattr(slave, TCSANOW, &term));
+
+	// Write "\r" to slave; OCRNL maps it to \n on output.
+	TEST_SUCC(write(slave, "\r", 1));
+
+	char buf[16] = { 0 };
+	struct pollfd pfd = { .fd = master, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, -1), _ret == 1 && (pfd.revents & POLLIN));
+	TEST_RES(read(master, buf, sizeof(buf)), _ret == 1 && buf[0] == '\n');
+
+	TEST_SUCC(close(master));
+	TEST_SUCC(close(slave));
+}
+END_TEST()

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -5,6 +5,7 @@
 set -e
 
 ./pty/close_pty
+./pty/output_flags
 ./pty/open_ptmx
 ./pty/open_pty
 ./pty/pty_blocking


### PR DESCRIPTION
## Problem

The TTY line discipline was ignoring termios output flags (`OPOST`, `ONLCR`, `OCRNL`) when echoing characters and processing writes. With the default `OPOST | ONLCR`, a `\n` should be output as `\r\n`, but the code echoed bare `\n` — which might cause the terminal cursor to move down a line without returning to column 0.

The previous PR (#3301) only fixed the echo path and was accidentally closed by me, so I'm opening this new PR. This version adds the missing write path and modifies regression tests.

## Changes

### Write path processing

The write path (`Tty::write`) now runs user data through `process_output` before handing it to the driver, so output flags are respected regardless of whether data comes from echo or from a process writing to the terminal.

### PTY driver cleanup

The PTY driver's `push_output` had a hardcoded `\n → \r\n` expansion with a TODO saying it belonged in the TTY layer. Since `process_output` now handles this, the driver's duplicate expansion is removed. Without this fix, writes through a PTY would double-process newlines (`\n` → `\r\r\n`) and return incorrect byte counts to userspace, causing `EFAULT`.

### Regression tests

Added 6 regression tests covering ONLCR and OCRNL in both echo and write paths, using `TEST_SUCC`/`TEST_RES` rather than `CHECK`:

| Test | Path | Scenario |
|------|------|----------|
| `echo_onlcr_enabled` | Echo | `\n` echoed as `\r\n` with default flags |
| `echo_onlcr_disabled` | Echo | `\n` kept as `\n` when ONLCR is off |
| `echo_ocrnl_enabled` | Echo | `\r` echoed as `\n` with OCRNL, ICRNL off |
| `write_onlcr_enabled` | Write | Slave writes `A\n`, master reads `A\r\n` |
| `write_onlcr_disabled` | Write | Slave writes `A\n`, master reads `A\n` (ONLCR off) |
| `write_ocrnl_enabled` | Write | Slave writes `\r`, master reads `\n` (OCRNL on) |

## Summary

- **`kernel/src/device/tty/termio.rs`** — added `output_flags()` accessor
- **`kernel/src/device/tty/line_discipline.rs`** — `echo_char` respects `OPOST`/`ONLCR`/`OCRNL`, added `process_output`
- **`kernel/src/device/tty/mod.rs`** — write path calls `process_output`, returns correct byte count
- **`kernel/src/device/pty/driver.rs`** — removed hardcoded `\n → \r\n` expansion, cleaned up `can_push`
- **`test/initramfs/src/regression/device/pty/output_flags.c`** — new regression tests
- **`test/initramfs/src/regression/device/run_test.sh`** — registers the new tests

## Behavior reference

Matches Linux `n_tty.c`:
- [ONLCR](https://elixir.bootlin.com/linux/v7.0/source/drivers/tty/n_tty.c#L414) — `\n` → `\r\n`
- [OCRNL](https://elixir.bootlin.com/linux/v7.0/source/drivers/tty/n_tty.c#L427) — `\r` → `\n`
