### PR TITLE
Avoid redundant checks when implementing the `Inode` trait

### DIFF
--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -36,7 +36,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
 
     // Create the "ptmx" symlink.
     let ptmx = dev.new_fs_child("ptmx", InodeType::SymLink, mkmod!(a+rwx))?;
-    ptmx.inode().write_link("pts/ptmx")?;
+    ptmx.write_link("pts/ptmx")?;
     Ok(())
 }
 

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -375,7 +375,7 @@ impl FileLike for InodeHandle {
             // FIXME: It's allowed to `ftruncate` an append-only file on Linux.
             return_errno_with_message!(Errno::EPERM, "can not resize append-only file");
         }
-        self.path.inode().resize(new_size)
+        self.path.resize(new_size)
     }
 
     fn status_flags(&self) -> StatusFlags {

--- a/kernel/src/fs/fs_impls/cgroupfs/inode.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/inode.rs
@@ -9,7 +9,6 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, Inode, Metadata, RevalidationPolicy},
-            path::{is_dot, is_dotdot},
         },
     },
     prelude::*,
@@ -89,13 +88,6 @@ impl Inode for CgroupInode {
     }
 
     fn rmdir(&self, name: &str) -> Result<()> {
-        if is_dot(name) {
-            return_errno_with_message!(Errno::EINVAL, "rmdir on .");
-        }
-        if is_dotdot(name) {
-            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..");
-        }
-
         let SysTreeNodeKind::Branch(branch_node) = self.node_kind() else {
             return_errno_with_message!(Errno::ENOTDIR, "the current node is not a branch node");
         };

--- a/kernel/src/fs/fs_impls/cgroupfs/inode.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/inode.rs
@@ -8,7 +8,7 @@ use crate::{
         utils::systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, Metadata, RevalidationPolicy},
+            inode::{Extension, Inode, InodeVfsOps, Metadata, RevalidationPolicy},
         },
     },
     prelude::*,
@@ -80,13 +80,13 @@ impl SysTreeInodeTy for CgroupInode {
             .upgrade()
             .expect("invalid weak reference to `self`")
     }
-}
 
-impl Inode for CgroupInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         CgroupFs::singleton().clone()
     }
+}
 
+impl InodeVfsOps for CgroupInode {
     fn rmdir(&self, name: &str) -> Result<()> {
         let SysTreeNodeKind::Branch(branch_node) = self.node_kind() else {
             return_errno_with_message!(Errno::ENOTDIR, "the current node is not a branch node");

--- a/kernel/src/fs/fs_impls/configfs/inode.rs
+++ b/kernel/src/fs/fs_impls/configfs/inode.rs
@@ -7,7 +7,7 @@ use crate::{
         utils::systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, Metadata},
+            inode::{Extension, Metadata},
         },
     },
     prelude::*,
@@ -77,9 +77,7 @@ impl SysTreeInodeTy for ConfigInode {
     fn extension(&self) -> &Extension {
         &self.extension
     }
-}
 
-impl Inode for ConfigInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         ConfigFs::singleton().clone()
     }

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -17,7 +17,9 @@ use crate::{
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
+            inode::{
+                Extension, FileOps, Inode, InodeVfsOps, Metadata, MknodType, RevalidationPolicy,
+            },
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
@@ -228,13 +230,84 @@ impl FileOps for RootInode {
     }
 }
 
+impl InodeVfsOps for RootInode {
+    fn resize(&self, new_size: usize) -> Result<()> {
+        Err(Error::new(Errno::EISDIR))
+    }
+
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        match name {
+            "." | ".." => {
+                return_errno_with_message!(Errno::EISDIR, "the devpts directory cannot be unlinked")
+            }
+            "ptmx" => return_errno_with_message!(Errno::EPERM, "the ptmx inode cannot be unlinked"),
+            slave => {
+                if self.slaves.read().find_entry_by_name(slave).is_none() {
+                    return_errno_with_message!(Errno::ENOENT, "the slave inode does not exist");
+                }
+                return_errno_with_message!(Errno::EPERM, "the slave inode cannot be unlinked");
+            }
+        }
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        let inode = match name {
+            "." | ".." => self.fs.upgrade().unwrap().root_inode(),
+            // Call the "open" method of ptmx to create a master and slave pair.
+            "ptmx" => self.ptmx.clone(),
+            slave => self
+                .slaves
+                .read()
+                .find_entry_by_name(slave)
+                .cloned()
+                .ok_or(Error::new(Errno::ENOENT))?,
+        };
+        Ok(inode)
+    }
+
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+    }
+
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        // Slave entries are created by opening `ptmx` and removed when the
+        // master is dropped, bypassing VFS dentry updates. Always retry lookup
+        // so a cached dentry cannot refer to a removed or reused pty index.
+        //
+        // TODO: Add a devpts-to-VFS dentry invalidation/update path for slave
+        // add/remove, similar to Linux devpts dropping slave dentries on pty
+        // teardown. Then this conservative revalidation can be relaxed.
+        false
+    }
+
+    fn revalidate_absent(&self, _name: &str) -> bool {
+        false
+    }
+}
+
 impl Inode for RootInode {
     fn size(&self) -> usize {
         self.metadata.read().size
-    }
-
-    fn resize(&self, new_size: usize) -> Result<()> {
-        Err(Error::new(Errno::EISDIR))
     }
 
     fn metadata(&self) -> Metadata {
@@ -304,76 +377,7 @@ impl Inode for RootInode {
         self.metadata.write().last_meta_change_at = time;
     }
 
-    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    fn unlink(&self, name: &str) -> Result<()> {
-        match name {
-            "." | ".." => {
-                return_errno_with_message!(Errno::EISDIR, "the devpts directory cannot be unlinked")
-            }
-            "ptmx" => return_errno_with_message!(Errno::EPERM, "the ptmx inode cannot be unlinked"),
-            slave => {
-                if self.slaves.read().find_entry_by_name(slave).is_none() {
-                    return_errno_with_message!(Errno::ENOENT, "the slave inode does not exist");
-                }
-                return_errno_with_message!(Errno::EPERM, "the slave inode cannot be unlinked");
-            }
-        }
-    }
-
-    fn rmdir(&self, name: &str) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
-        let inode = match name {
-            "." | ".." => self.fs().root_inode(),
-            // Call the "open" method of ptmx to create a master and slave pair.
-            "ptmx" => self.ptmx.clone(),
-            slave => self
-                .slaves
-                .read()
-                .find_entry_by_name(slave)
-                .cloned()
-                .ok_or(Error::new(Errno::ENOENT))?,
-        };
-        Ok(inode)
-    }
-
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
     fn fs(&self) -> Arc<dyn FileSystem> {
         self.fs.upgrade().unwrap()
-    }
-
-    fn revalidation_policy(&self) -> RevalidationPolicy {
-        RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
-    }
-
-    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
-        // Slave entries are created by opening `ptmx` and removed when the
-        // master is dropped, bypassing VFS dentry updates. Always retry lookup
-        // so a cached dentry cannot refer to a removed or reused pty index.
-        //
-        // TODO: Add a devpts-to-VFS dentry invalidation/update path for slave
-        // add/remove, similar to Linux devpts dropping slave dentries on pty
-        // teardown. Then this conservative revalidation can be relaxed.
-        false
-    }
-
-    fn revalidate_absent(&self, _name: &str) -> bool {
-        false
     }
 }

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -69,13 +69,23 @@ impl FileOps for Ptmx {
     }
 }
 
+impl InodeVfsOps for Ptmx {
+    fn resize(&self, new_size: usize) -> Result<()> {
+        Ok(())
+    }
+
+    fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        Some(self.inner.open())
+    }
+}
+
 impl Inode for Ptmx {
     fn size(&self) -> usize {
         self.metadata.read().size
-    }
-
-    fn resize(&self, new_size: usize) -> Result<()> {
-        Ok(())
     }
 
     fn metadata(&self) -> Metadata {
@@ -148,14 +158,6 @@ impl Inode for Ptmx {
     fn fs(&self) -> Arc<dyn FileSystem> {
         // FIXME: The below code may panic if the devpts is dropped.
         self.devpts().unwrap()
-    }
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        Some(self.inner.open())
     }
 }
 

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -58,13 +58,23 @@ impl FileOps for PtySlaveInode {
     }
 }
 
+impl InodeVfsOps for PtySlaveInode {
+    fn resize(&self, new_size: usize) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        Some(self.device.open())
+    }
+}
+
 impl Inode for PtySlaveInode {
     fn size(&self) -> usize {
         self.metadata.read().size
-    }
-
-    fn resize(&self, new_size: usize) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
     }
 
     fn metadata(&self) -> Metadata {
@@ -136,13 +146,5 @@ impl Inode for PtySlaveInode {
 
     fn fs(&self) -> Arc<dyn FileSystem> {
         self.fs.upgrade().unwrap()
-    }
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        Some(self.device.open())
     }
 }

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -31,7 +31,7 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, MknodType, SymbolicLink},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata, MknodType, SymbolicLink},
         },
     },
     prelude::*,
@@ -1380,15 +1380,7 @@ impl FileOps for ExfatInode {
     }
 }
 
-impl Inode for ExfatInode {
-    fn ino(&self) -> u64 {
-        self.inner.read().ino
-    }
-
-    fn size(&self) -> usize {
-        self.inner.read().size
-    }
-
+impl InodeVfsOps for ExfatInode {
     fn resize(&self, new_size: usize) -> Result<()> {
         let inner = self.inner.upread();
 
@@ -1416,102 +1408,6 @@ impl Inode for ExfatInode {
         }
 
         Ok(())
-    }
-
-    fn metadata(&self) -> Metadata {
-        let inner = self.inner.read();
-
-        let blk_size = inner.fs().sector_size();
-
-        let nlinks = if inner.inode_type.is_directory() {
-            (inner.num_sub_dirs + 2) as usize
-        } else {
-            1
-        };
-
-        Metadata {
-            ino: inner.ino,
-            size: inner.size,
-            optimal_block_size: blk_size,
-            nr_sectors_allocated: inner.nr_sectors_allocated(),
-            last_access_at: inner.atime.as_duration().unwrap_or_default(),
-            last_modify_at: inner.mtime.as_duration().unwrap_or_default(),
-            last_meta_change_at: inner.ctime.as_duration().unwrap_or_default(),
-            type_: inner.inode_type,
-            mode: inner.make_mode(),
-            nr_hard_links: nlinks,
-            uid: Uid::new(inner.fs().mount_option().fs_uid as u32),
-            gid: Gid::new(inner.fs().mount_option().fs_gid as u32),
-            container_dev_id: inner.fs().container_device_id(),
-            self_dev_id: None,
-        }
-    }
-
-    fn type_(&self) -> InodeType {
-        self.inner.read().inode_type
-    }
-
-    fn mode(&self) -> Result<InodeMode> {
-        Ok(self.inner.read().make_mode())
-    }
-
-    fn set_mode(&self, mode: InodeMode) -> Result<()> {
-        //Pass through
-        Ok(())
-    }
-
-    fn atime(&self) -> Duration {
-        self.inner.read().atime.as_duration().unwrap_or_default()
-    }
-
-    fn set_atime(&self, time: Duration) {
-        self.inner.write().atime = DosTimestamp::from_duration(time).unwrap_or_default();
-    }
-
-    fn mtime(&self) -> Duration {
-        self.inner.read().mtime.as_duration().unwrap_or_default()
-    }
-
-    fn set_mtime(&self, time: Duration) {
-        self.inner.write().mtime = DosTimestamp::from_duration(time).unwrap_or_default();
-    }
-
-    fn ctime(&self) -> Duration {
-        self.inner.read().ctime.as_duration().unwrap_or_default()
-    }
-
-    fn set_ctime(&self, time: Duration) {
-        self.inner.write().ctime = DosTimestamp::from_duration(time).unwrap_or_default();
-    }
-
-    fn owner(&self) -> Result<Uid> {
-        Ok(Uid::new(
-            self.inner.read().fs().mount_option().fs_uid as u32,
-        ))
-    }
-
-    fn set_owner(&self, uid: Uid) -> Result<()> {
-        // Pass through.
-        Ok(())
-    }
-
-    fn group(&self) -> Result<Gid> {
-        Ok(Gid::new(
-            self.inner.read().fs().mount_option().fs_gid as u32,
-        ))
-    }
-
-    fn set_group(&self, gid: Gid) -> Result<()> {
-        // Pass through.
-        Ok(())
-    }
-
-    fn fs(&self) -> Arc<dyn FileSystem> {
-        self.inner.read().fs()
-    }
-
-    fn page_cache(&self) -> Option<PageCache> {
-        Some(self.inner.read().page_cache.clone())
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
@@ -1670,6 +1566,112 @@ impl Inode for ExfatInode {
 
     fn write_link(&self, target: &str) -> Result<()> {
         return_errno_with_message!(Errno::EINVAL, "unsupported operation")
+    }
+}
+
+impl Inode for ExfatInode {
+    fn ino(&self) -> u64 {
+        self.inner.read().ino
+    }
+
+    fn size(&self) -> usize {
+        self.inner.read().size
+    }
+
+    fn metadata(&self) -> Metadata {
+        let inner = self.inner.read();
+
+        let blk_size = inner.fs().sector_size();
+
+        let nlinks = if inner.inode_type.is_directory() {
+            (inner.num_sub_dirs + 2) as usize
+        } else {
+            1
+        };
+
+        Metadata {
+            ino: inner.ino,
+            size: inner.size,
+            optimal_block_size: blk_size,
+            nr_sectors_allocated: inner.nr_sectors_allocated(),
+            last_access_at: inner.atime.as_duration().unwrap_or_default(),
+            last_modify_at: inner.mtime.as_duration().unwrap_or_default(),
+            last_meta_change_at: inner.ctime.as_duration().unwrap_or_default(),
+            type_: inner.inode_type,
+            mode: inner.make_mode(),
+            nr_hard_links: nlinks,
+            uid: Uid::new(inner.fs().mount_option().fs_uid as u32),
+            gid: Gid::new(inner.fs().mount_option().fs_gid as u32),
+            container_dev_id: inner.fs().container_device_id(),
+            self_dev_id: None,
+        }
+    }
+
+    fn type_(&self) -> InodeType {
+        self.inner.read().inode_type
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.inner.read().make_mode())
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        //Pass through
+        Ok(())
+    }
+
+    fn atime(&self) -> Duration {
+        self.inner.read().atime.as_duration().unwrap_or_default()
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.inner.write().atime = DosTimestamp::from_duration(time).unwrap_or_default();
+    }
+
+    fn mtime(&self) -> Duration {
+        self.inner.read().mtime.as_duration().unwrap_or_default()
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.inner.write().mtime = DosTimestamp::from_duration(time).unwrap_or_default();
+    }
+
+    fn ctime(&self) -> Duration {
+        self.inner.read().ctime.as_duration().unwrap_or_default()
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.inner.write().ctime = DosTimestamp::from_duration(time).unwrap_or_default();
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(Uid::new(
+            self.inner.read().fs().mount_option().fs_uid as u32,
+        ))
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        // Pass through.
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(Gid::new(
+            self.inner.read().fs().mount_option().fs_gid as u32,
+        ))
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        // Pass through.
+        Ok(())
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.inner.read().fs()
+    }
+
+    fn page_cache(&self) -> Option<PageCache> {
+        Some(self.inner.read().page_cache.clone())
     }
 
     fn sync_all(&self) -> Result<()> {

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -32,7 +32,6 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, MknodType, SymbolicLink},
-            path::{is_dot, is_dot_or_dotdot, is_dotdot},
         },
     },
     prelude::*,
@@ -1518,19 +1517,6 @@ impl Inode for ExfatInode {
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
-        {
-            let inner = self.inner.read();
-            if !inner.inode_type.is_directory() {
-                return_errno!(Errno::ENOTDIR)
-            }
-            if name.len() > MAX_NAME_LENGTH {
-                return_errno!(Errno::ENAMETOOLONG)
-            }
-
-            if inner.lookup_by_name(name, false, &fs_guard).is_ok() {
-                return_errno!(Errno::EEXIST)
-            }
-        }
 
         let result = self.add_entry(name, type_, mode, &fs_guard)?;
         let _ = fs.insert_inode(result.clone());
@@ -1555,16 +1541,6 @@ impl Inode for ExfatInode {
     }
 
     fn unlink(&self, name: &str) -> Result<()> {
-        if !self.inner.read().inode_type.is_directory() {
-            return_errno!(Errno::ENOTDIR)
-        }
-        if name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
-        if is_dot_or_dotdot(name) {
-            return_errno!(Errno::EISDIR)
-        }
-
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
 
@@ -1586,19 +1562,6 @@ impl Inode for ExfatInode {
     }
 
     fn rmdir(&self, name: &str) -> Result<()> {
-        if !self.inner.read().inode_type.is_directory() {
-            return_errno!(Errno::ENOTDIR)
-        }
-        if is_dot(name) {
-            return_errno_with_message!(Errno::EINVAL, "rmdir on .")
-        }
-        if is_dotdot(name) {
-            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..")
-        }
-        if name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
-
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
 
@@ -1645,20 +1608,9 @@ impl Inode for ExfatInode {
     }
 
     fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
-        if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
-            return_errno!(Errno::EISDIR);
-        }
-        if old_name.len() > MAX_NAME_LENGTH || new_name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
         let Some(target_) = target.downcast_ref::<ExfatInode>() else {
             return_errno_with_message!(Errno::EINVAL, "not an exfat inode")
         };
-        if !self.inner.read().inode_type.is_directory()
-            || !target_.inner.read().inode_type.is_directory()
-        {
-            return_errno!(Errno::ENOTDIR)
-        }
 
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -20,7 +20,10 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
+            inode::{
+                Extension, FallocMode, FileOps, Inode, InodeVfsOps, Metadata, MknodType,
+                SymbolicLink,
+            },
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -61,13 +64,107 @@ impl FileOps for Ext2Inode {
     }
 }
 
+impl InodeVfsOps for Ext2Inode {
+    fn resize(&self, new_size: usize) -> Result<()> {
+        self.resize(new_size)
+    }
+
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        Ok(self.create(name, type_, mode.into())?)
+    }
+
+    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
+        let (inode_type, device_id) = match type_ {
+            MknodType::CharDevice(dev_id) => (InodeType::CharDevice, Some(dev_id)),
+            MknodType::BlockDevice(dev_id) => (InodeType::BlockDevice, Some(dev_id)),
+            MknodType::NamedPipe => (InodeType::NamedPipe, None),
+        };
+
+        let new_inode = self.create(name, inode_type, mode.into())?;
+        if let Some(device_id) = device_id {
+            // Store the ext2 special-file device encoding in `i_block`.
+            new_inode.set_device_id(device_id)?;
+        }
+
+        Ok(new_inode)
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        Ok(self.lookup(name)?)
+    }
+
+    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
+        let old = old
+            .downcast_ref::<Ext2Inode>()
+            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
+        self.link(old, name)
+    }
+
+    fn unlink(&self, name: &str) -> Result<()> {
+        self.unlink(name)
+    }
+
+    fn rmdir(&self, name: &str) -> Result<()> {
+        self.rmdir(name)
+    }
+
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+        let target = target
+            .downcast_ref::<Ext2Inode>()
+            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
+        self.rename(old_name, target, new_name)
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        self.read_link().map(SymbolicLink::Plain)
+    }
+
+    fn write_link(&self, target: &str) -> Result<()> {
+        self.write_link(target)
+    }
+
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        match self.inode_type() {
+            inode_type @ (InodeType::BlockDevice | InodeType::CharDevice) => {
+                let device_id = self.device_id();
+                let Some(device_id) = DeviceId::from_encoded_u64(device_id) else {
+                    return Some(Err(Error::with_message(
+                        Errno::ENODEV,
+                        "the device ID is invalid",
+                    )));
+                };
+                let device_type = inode_type
+                    .device_type()
+                    .expect("BlockDevice and CharDevice always have a device type");
+                let Some(device) = device::lookup(device_type, device_id) else {
+                    return Some(Err(Error::with_message(
+                        Errno::ENODEV,
+                        "the required device ID does not exist",
+                    )));
+                };
+
+                Some(device.open())
+            }
+            InodeType::NamedPipe => {
+                let pipe = self.pipe().expect("NamedPipe inode must have a pipe");
+                Some(pipe.open_named(access_mode, status_flags))
+            }
+            _ => None,
+        }
+    }
+
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
+        self.fallocate(mode, offset, len)
+    }
+}
+
 impl Inode for Ext2Inode {
     fn size(&self) -> usize {
         self.file_size()
-    }
-
-    fn resize(&self, new_size: usize) -> Result<()> {
-        self.resize(new_size)
     }
 
     fn metadata(&self) -> Metadata {
@@ -134,94 +231,6 @@ impl Inode for Ext2Inode {
         self.page_cache()
     }
 
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        match self.inode_type() {
-            inode_type @ (InodeType::BlockDevice | InodeType::CharDevice) => {
-                let device_id = self.device_id();
-                let Some(device_id) = DeviceId::from_encoded_u64(device_id) else {
-                    return Some(Err(Error::with_message(
-                        Errno::ENODEV,
-                        "the device ID is invalid",
-                    )));
-                };
-                let device_type = inode_type
-                    .device_type()
-                    .expect("BlockDevice and CharDevice always have a device type");
-                let Some(device) = device::lookup(device_type, device_id) else {
-                    return Some(Err(Error::with_message(
-                        Errno::ENODEV,
-                        "the required device ID does not exist",
-                    )));
-                };
-
-                Some(device.open())
-            }
-            InodeType::NamedPipe => {
-                let pipe = self.pipe().expect("NamedPipe inode must have a pipe");
-                Some(pipe.open_named(access_mode, status_flags))
-            }
-            _ => None,
-        }
-    }
-
-    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
-        Ok(self.create(name, type_, mode.into())?)
-    }
-
-    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
-        let (inode_type, device_id) = match type_ {
-            MknodType::CharDevice(dev_id) => (InodeType::CharDevice, Some(dev_id)),
-            MknodType::BlockDevice(dev_id) => (InodeType::BlockDevice, Some(dev_id)),
-            MknodType::NamedPipe => (InodeType::NamedPipe, None),
-        };
-
-        let new_inode = self.create(name, inode_type, mode.into())?;
-        if let Some(device_id) = device_id {
-            // Store the ext2 special-file device encoding in `i_block`.
-            new_inode.set_device_id(device_id)?;
-        }
-
-        Ok(new_inode)
-    }
-
-    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
-        Ok(self.lookup(name)?)
-    }
-
-    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        let old = old
-            .downcast_ref::<Ext2Inode>()
-            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.link(old, name)
-    }
-
-    fn unlink(&self, name: &str) -> Result<()> {
-        self.unlink(name)
-    }
-
-    fn rmdir(&self, name: &str) -> Result<()> {
-        self.rmdir(name)
-    }
-
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
-        let target = target
-            .downcast_ref::<Ext2Inode>()
-            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.rename(old_name, target, new_name)
-    }
-
-    fn read_link(&self) -> Result<SymbolicLink> {
-        self.read_link().map(SymbolicLink::Plain)
-    }
-
-    fn write_link(&self, target: &str) -> Result<()> {
-        self.write_link(target)
-    }
-
     fn sync_all(&self) -> Result<()> {
         self.sync_all()?;
         let fs = self.fs()?;
@@ -242,10 +251,6 @@ impl Inode for Ext2Inode {
             return_errno_with_message!(Errno::EIO, "failed to flush block device");
         }
         Ok(())
-    }
-
-    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
-        self.fallocate(mode, offset, len)
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -24,7 +24,10 @@ use crate::{
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
+            inode::{
+                Extension, FallocMode, FileOps, Inode, InodeVfsOps, Metadata, MknodType,
+                SymbolicLink,
+            },
             path::{FsPath, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
@@ -962,9 +965,28 @@ impl FileOps for OverlayInode {
 }
 
 #[inherit_methods(from = "self")]
+impl InodeVfsOps for OverlayInode {
+    fn resize(&self, new_size: usize) -> Result<()>;
+    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>>;
+    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>>;
+    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()>;
+    fn unlink(&self, name: &str) -> Result<()>;
+    fn rmdir(&self, name: &str) -> Result<()>;
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>>;
+    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()>;
+    fn read_link(&self) -> Result<SymbolicLink>;
+    fn write_link(&self, target: &str) -> Result<()>;
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()>;
+}
+
+#[inherit_methods(from = "self")]
 impl Inode for OverlayInode {
     fn size(&self) -> usize;
-    fn resize(&self, new_size: usize) -> Result<()>;
     fn metadata(&self) -> Metadata;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
@@ -982,23 +1004,8 @@ impl Inode for OverlayInode {
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
     fn page_cache(&self) -> Option<PageCache>;
-    fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>>;
-    fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>>;
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
-    fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()>;
-    fn unlink(&self, name: &str) -> Result<()>;
-    fn rmdir(&self, name: &str) -> Result<()>;
-    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>>;
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()>;
-    fn read_link(&self) -> Result<SymbolicLink>;
-    fn write_link(&self, target: &str) -> Result<()>;
     fn sync_all(&self) -> Result<()>;
     fn sync_data(&self) -> Result<()>;
-    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()>;
     fn fs(&self) -> Arc<dyn FileSystem>;
     fn set_xattr(
         &self,

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -15,7 +15,9 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
-            inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
+            inode::{
+                Extension, FileOps, Inode, InodeVfsOps, Metadata, MknodType, RevalidationPolicy,
+            },
             path::{is_dot, is_dotdot},
         },
     },
@@ -151,36 +153,9 @@ impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
     }
 }
 
-#[inherit_methods(from = "self.common")]
-impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
-    fn size(&self) -> usize;
-    fn extension(&self) -> &Extension;
-    fn ino(&self) -> u64;
-    fn mode(&self) -> Result<InodeMode>;
-    fn set_mode(&self, mode: InodeMode) -> Result<()>;
-    fn owner(&self) -> Result<Uid>;
-    fn set_owner(&self, uid: Uid) -> Result<()>;
-    fn group(&self) -> Result<Gid>;
-    fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
-    fn fs(&self) -> Arc<dyn FileSystem>;
-
-    fn metadata(&self) -> Metadata {
-        let owner_thread = self.inner.owner_thread();
-        self.common.metadata_with_owner(owner_thread)
-    }
-
+impl<D: ProcDirOps + 'static> InodeVfsOps for ProcDir<D> {
     fn resize(&self, _new_size: usize) -> Result<()> {
         Err(Error::new(Errno::EISDIR))
-    }
-
-    fn type_(&self) -> InodeType {
-        InodeType::Dir
     }
 
     fn create(&self, _name: &str, _type_: InodeType, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
@@ -228,6 +203,35 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
 
     fn revalidate_absent(&self, name: &str) -> bool {
         self.inner.revalidate_absent(name)
+    }
+}
+
+#[inherit_methods(from = "self.common")]
+impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
+    fn size(&self) -> usize;
+    fn extension(&self) -> &Extension;
+    fn ino(&self) -> u64;
+    fn mode(&self) -> Result<InodeMode>;
+    fn set_mode(&self, mode: InodeMode) -> Result<()>;
+    fn owner(&self) -> Result<Uid>;
+    fn set_owner(&self, uid: Uid) -> Result<()>;
+    fn group(&self) -> Result<Gid>;
+    fn set_group(&self, gid: Gid) -> Result<()>;
+    fn atime(&self) -> Duration;
+    fn set_atime(&self, time: Duration);
+    fn mtime(&self) -> Duration;
+    fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
+    fn fs(&self) -> Arc<dyn FileSystem>;
+
+    fn metadata(&self) -> Metadata {
+        let owner_thread = self.inner.owner_thread();
+        self.common.metadata_with_owner(owner_thread)
+    }
+
+    fn type_(&self) -> InodeType {
+        InodeType::Dir
     }
 
     fn seek_end(&self) -> Option<usize> {

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -11,7 +11,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata, SymbolicLink},
         },
     },
     prelude::*,
@@ -68,6 +68,29 @@ impl<F: ProcFileOps + 'static> FileOps for ProcFile<F> {
     }
 }
 
+impl<F: ProcFileOps + 'static> InodeVfsOps for ProcFile<F> {
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        // Resizing files under `/proc` will succeed, but will do nothing.
+        Ok(())
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        Err(Error::new(Errno::EINVAL))
+    }
+
+    fn write_link(&self, _target: &str) -> Result<()> {
+        Err(Error::new(Errno::EINVAL))
+    }
+
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        self.inner.open(access_mode, status_flags)
+    }
+}
+
 #[inherit_methods(from = "self.common")]
 impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
     fn size(&self) -> usize;
@@ -92,34 +115,13 @@ impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
         self.common.metadata_with_owner(owner_thread)
     }
 
-    fn resize(&self, _new_size: usize) -> Result<()> {
-        // Resizing files under `/proc` will succeed, but will do nothing.
-        Ok(())
-    }
-
     fn type_(&self) -> InodeType {
         InodeType::File
-    }
-
-    fn read_link(&self) -> Result<SymbolicLink> {
-        Err(Error::new(Errno::EINVAL))
-    }
-
-    fn write_link(&self, _target: &str) -> Result<()> {
-        Err(Error::new(Errno::EINVAL))
     }
 
     fn seek_end(&self) -> Option<usize> {
         // Seeking regular files under `/proc` with `SEEK_END` will fail.
         None
-    }
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        self.inner.open(access_mode, status_flags)
     }
 }
 

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -11,7 +11,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata, SymbolicLink},
         },
     },
     prelude::*,
@@ -65,6 +65,20 @@ impl<S: ProcSymOps + 'static> FileOps for ProcSym<S> {
     }
 }
 
+impl<S: ProcSymOps + 'static> InodeVfsOps for ProcSym<S> {
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        self.inner.read_link()
+    }
+
+    fn write_link(&self, _target: &str) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+}
+
 #[inherit_methods(from = "self.common")]
 impl<S: ProcSymOps + 'static> Inode for ProcSym<S> {
     fn size(&self) -> usize;
@@ -89,20 +103,8 @@ impl<S: ProcSymOps + 'static> Inode for ProcSym<S> {
         self.common.metadata_with_owner(owner_thread)
     }
 
-    fn resize(&self, _new_size: usize) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
     fn type_(&self) -> InodeType {
         InodeType::SymLink
-    }
-
-    fn read_link(&self) -> Result<SymbolicLink> {
-        self.inner.read_link()
-    }
-
-    fn write_link(&self, _target: &str) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata},
         },
     },
     prelude::*,
@@ -261,13 +261,26 @@ impl FileOps for PseudoInode {
     }
 }
 
+impl InodeVfsOps for PseudoInode {
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "pseudo inodes can not be resized");
+    }
+
+    fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        Some(Err(Error::with_message(
+            Errno::ENXIO,
+            "the pseudo inode is not re-openable",
+        )))
+    }
+}
+
 impl Inode for PseudoInode {
     fn size(&self) -> usize {
         self.metadata.lock().size
-    }
-
-    fn resize(&self, _new_size: usize) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "pseudo inodes can not be resized");
     }
 
     fn metadata(&self) -> Metadata {
@@ -348,17 +361,6 @@ impl Inode for PseudoInode {
 
     fn set_ctime(&self, time: Duration) {
         self.metadata.lock().last_meta_change_at = time;
-    }
-
-    fn open(
-        &self,
-        _access_mode: AccessMode,
-        _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        Some(Err(Error::with_message(
-            Errno::ENXIO,
-            "the pseudo inode is not re-openable",
-        )))
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -18,7 +18,7 @@ use crate::{
         pseudofs::{NaivePseudoFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata},
             path::{Dentry, Mount, Path},
         },
     },
@@ -102,25 +102,8 @@ impl<T: NsCommonOps> NsInode<T> {
 }
 
 #[inherit_methods(from = "self.common")]
-impl<T: NsCommonOps> Inode for NsInode<T> {
-    fn size(&self) -> usize;
+impl<T: NsCommonOps> InodeVfsOps for NsInode<T> {
     fn resize(&self, _new_size: usize) -> Result<()>;
-    fn metadata(&self) -> Metadata;
-    fn extension(&self) -> &Extension;
-    fn ino(&self) -> u64;
-    fn type_(&self) -> InodeType;
-    fn mode(&self) -> Result<InodeMode>;
-    fn owner(&self) -> Result<Uid>;
-    fn set_owner(&self, uid: Uid) -> Result<()>;
-    fn group(&self) -> Result<Gid>;
-    fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
-    fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn open(
         &self,
@@ -143,6 +126,27 @@ impl<T: NsCommonOps> Inode for NsInode<T> {
         };
         Some(Ok(Box::new(ns_file) as Box<dyn PerOpenFileOps>))
     }
+}
+
+#[inherit_methods(from = "self.common")]
+impl<T: NsCommonOps> Inode for NsInode<T> {
+    fn size(&self) -> usize;
+    fn metadata(&self) -> Metadata;
+    fn extension(&self) -> &Extension;
+    fn ino(&self) -> u64;
+    fn type_(&self) -> InodeType;
+    fn mode(&self) -> Result<InodeMode>;
+    fn owner(&self) -> Result<Uid>;
+    fn set_owner(&self, uid: Uid) -> Result<()>;
+    fn group(&self) -> Result<Gid>;
+    fn set_group(&self, gid: Gid) -> Result<()>;
+    fn atime(&self) -> Duration;
+    fn set_atime(&self, time: Duration);
+    fn mtime(&self) -> Duration;
+    fn set_mtime(&self, time: Duration);
+    fn ctime(&self) -> Duration;
+    fn set_ctime(&self, time: Duration);
+    fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn set_mode(&self, _mode: InodeMode) -> Result<()> {
         return_errno_with_message!(Errno::EPERM, "the mode of ns inodes cannot be changed");

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -30,7 +30,7 @@ use crate::{
                 Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
                 SymbolicLink,
             },
-            path::{is_dot, is_dot_or_dotdot, is_dotdot},
+            path::{is_dot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -404,14 +404,6 @@ impl DirEntry {
 
     fn set_parent(&mut self, parent: Weak<RamInode>) {
         self.parent = parent;
-    }
-
-    fn contains_entry(&self, name: &str) -> bool {
-        if is_dot_or_dotdot(name) {
-            true
-        } else {
-            self.idx_map.contains_key(name.as_bytes())
-        }
     }
 
     fn get_entry(&self, name: &str) -> Option<(usize, Arc<RamInode>)> {
@@ -861,18 +853,6 @@ impl Inode for RamInode {
     }
 
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
-        if name.len() > NAME_MAX {
-            return_errno!(Errno::ENAMETOOLONG);
-        }
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-
-        let self_dir = self.inner.as_direntry().unwrap().upread();
-        if self_dir.contains_entry(name) {
-            return_errno_with_message!(Errno::EEXIST, "entry exists");
-        }
-
         let new_inode = match type_ {
             MknodType::CharDevice(dev_id) | MknodType::BlockDevice(dev_id) => {
                 let dev_type = type_.device_type().unwrap();
@@ -893,7 +873,7 @@ impl Inode for RamInode {
             ),
         };
 
-        let mut self_dir = self_dir.upgrade();
+        let mut self_dir = self.inner.as_direntry().unwrap().write();
         self_dir.append_entry(name, new_inode.clone());
         drop(self_dir);
 
@@ -910,18 +890,6 @@ impl Inode for RamInode {
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
-        if name.len() > NAME_MAX {
-            return_errno!(Errno::ENAMETOOLONG);
-        }
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-
-        let self_dir = self.inner.as_direntry().unwrap().upread();
-        if self_dir.contains_entry(name) {
-            return_errno_with_message!(Errno::EEXIST, "entry exists");
-        }
-
         let fs = self.fs.upgrade().unwrap();
         let new_inode = match type_ {
             InodeType::File => RamInode::new_file(&fs, mode, Uid::new_root(), Gid::new_root()),
@@ -937,7 +905,7 @@ impl Inode for RamInode {
             }
         };
 
-        let mut self_dir = self_dir.upgrade();
+        let mut self_dir = self.inner.as_direntry().unwrap().write();
         self_dir.append_entry(name, new_inode.clone());
         drop(self_dir);
 
@@ -958,10 +926,6 @@ impl Inode for RamInode {
         mode: InodeMode,
         hard_linkability: HardLinkability,
     ) -> Result<Arc<dyn Inode>> {
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-
         let fs = self.fs.upgrade().unwrap();
         Ok(RamInode::new_tmpfile(
             &fs,
@@ -973,27 +937,14 @@ impl Inode for RamInode {
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        if !Arc::ptr_eq(&self.fs(), &old.fs()) {
-            return_errno_with_message!(Errno::EXDEV, "not same fs");
-        }
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-
         let old = old
             .downcast_ref::<RamInode>()
             .ok_or(Error::new(Errno::EXDEV))?;
-        if old.typ == InodeType::Dir {
-            return_errno_with_message!(Errno::EPERM, "old is a dir");
-        }
         if old.hard_linkability == HardLinkability::Unlinkable {
             return_errno_with_message!(Errno::ENOENT, "tmpfile is not linkable");
         }
 
         let mut self_dir = self.inner.as_direntry().unwrap().write();
-        if self_dir.contains_entry(name) {
-            return_errno_with_message!(Errno::EEXIST, "entry exist");
-        }
         self_dir.append_entry(name, old.this.upgrade().unwrap());
         let now = now();
 
@@ -1014,14 +965,7 @@ impl Inode for RamInode {
     }
 
     fn unlink(&self, name: &str) -> Result<()> {
-        if is_dot_or_dotdot(name) {
-            return_errno_with_message!(Errno::EISDIR, "unlink . or ..");
-        }
-
         let target = self.find(name)?;
-        if target.typ == InodeType::Dir {
-            return_errno_with_message!(Errno::EISDIR, "unlink on dir");
-        }
 
         // When we got the lock, the dir may have been modified by another thread
         let mut self_dir = self.inner.as_direntry().unwrap().write();
@@ -1046,17 +990,7 @@ impl Inode for RamInode {
     }
 
     fn rmdir(&self, name: &str) -> Result<()> {
-        if is_dot(name) {
-            return_errno_with_message!(Errno::EINVAL, "rmdir on .");
-        }
-        if is_dotdot(name) {
-            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..");
-        }
-
         let target = self.find(name)?;
-        if target.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "rmdir on not dir");
-        }
 
         // When we got the lock, the dir may have been modified by another thread
         let (mut self_dir, target_dir) = write_lock_two_direntries_by_ino(
@@ -1094,26 +1028,9 @@ impl Inode for RamInode {
     }
 
     fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
-        if is_dot_or_dotdot(old_name) {
-            return_errno_with_message!(Errno::EISDIR, "old_name is . or ..");
-        }
-        if is_dot_or_dotdot(new_name) {
-            return_errno_with_message!(Errno::EISDIR, "new_name is . or ..");
-        }
-
         let target = target
             .downcast_ref::<RamInode>()
             .ok_or(Error::new(Errno::EXDEV))?;
-
-        if !Arc::ptr_eq(&self.fs(), &target.fs()) {
-            return_errno_with_message!(Errno::EXDEV, "not same fs");
-        }
-        if self.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
-        }
-        if target.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "target is not dir");
-        }
 
         // Perform necessary checks to ensure that `dst_inode` can be replaced by `src_inode`.
         let check_replace_inode =

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -27,8 +27,8 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{
-                Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
-                SymbolicLink,
+                Extension, FallocMode, FileOps, HardLinkability, Inode, InodeVfsOps, Metadata,
+                MknodType, SymbolicLink,
             },
             path::{is_dot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
@@ -745,17 +745,7 @@ impl FileOps for RamInode {
     }
 }
 
-impl Inode for RamInode {
-    fn page_cache(&self) -> Option<PageCache> {
-        self.inner
-            .as_file()
-            .map(|page_cache| page_cache.lock().clone())
-    }
-
-    fn size(&self) -> usize {
-        self.metadata.lock().size
-    }
-
+impl InodeVfsOps for RamInode {
     fn resize(&self, new_size: usize) -> Result<()> {
         if self.typ == InodeType::Dir {
             return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
@@ -787,71 +777,6 @@ impl Inode for RamInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
-        self.metadata.lock().atime
-    }
-
-    fn set_atime(&self, time: Duration) {
-        self.metadata.lock().set_atime(time);
-    }
-
-    fn mtime(&self) -> Duration {
-        self.metadata.lock().mtime
-    }
-
-    fn set_mtime(&self, time: Duration) {
-        self.metadata.lock().set_mtime(time);
-    }
-
-    fn ctime(&self) -> Duration {
-        self.metadata.lock().ctime
-    }
-
-    fn set_ctime(&self, time: Duration) {
-        self.metadata.lock().set_ctime(time);
-    }
-
-    fn ino(&self) -> u64 {
-        self.ino
-    }
-
-    fn type_(&self) -> InodeType {
-        self.typ
-    }
-
-    fn mode(&self) -> Result<InodeMode> {
-        Ok(self.metadata.lock().mode)
-    }
-
-    fn set_mode(&self, mode: InodeMode) -> Result<()> {
-        let mut inode_meta = self.metadata.lock();
-        inode_meta.mode = mode;
-        inode_meta.set_ctime(now());
-        Ok(())
-    }
-
-    fn owner(&self) -> Result<Uid> {
-        Ok(self.metadata.lock().uid)
-    }
-
-    fn set_owner(&self, uid: Uid) -> Result<()> {
-        let mut inode_meta = self.metadata.lock();
-        inode_meta.uid = uid;
-        inode_meta.set_ctime(now());
-        Ok(())
-    }
-
-    fn group(&self) -> Result<Gid> {
-        Ok(self.metadata.lock().gid)
-    }
-
-    fn set_group(&self, gid: Gid) -> Result<()> {
-        let mut inode_meta = self.metadata.lock();
-        inode_meta.gid = gid;
-        inode_meta.set_ctime(now());
-        Ok(())
-    }
-
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         let new_inode = match type_ {
             MknodType::CharDevice(dev_id) | MknodType::BlockDevice(dev_id) => {
@@ -879,14 +804,6 @@ impl Inode for RamInode {
 
         self.metadata.lock().inc_size();
         Ok(new_inode)
-    }
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        self.inner.open(access_mode, status_flags)
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
@@ -1204,33 +1121,12 @@ impl Inode for RamInode {
         Ok(())
     }
 
-    fn metadata(&self) -> Metadata {
-        let rdev = self.inner.device_id().unwrap_or(0);
-        let inode_metadata = self.metadata.lock();
-        Metadata {
-            ino: self.ino as _,
-            size: inode_metadata.size,
-            optimal_block_size: BLOCK_SIZE,
-            nr_sectors_allocated: inode_metadata.nr_sectors_allocated(),
-            last_access_at: inode_metadata.atime,
-            last_modify_at: inode_metadata.mtime,
-            last_meta_change_at: inode_metadata.ctime,
-            type_: self.typ,
-            mode: inode_metadata.mode,
-            nr_hard_links: inode_metadata.nlinks,
-            uid: inode_metadata.uid,
-            gid: inode_metadata.gid,
-            container_dev_id: self.container_dev_id,
-            self_dev_id: if rdev == 0 {
-                None
-            } else {
-                DeviceId::from_encoded_u64(rdev)
-            },
-        }
-    }
-
-    fn fs(&self) -> Arc<dyn FileSystem> {
-        Weak::upgrade(&self.fs).unwrap()
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        self.inner.open(access_mode, status_flags)
     }
 
     fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
@@ -1263,6 +1159,112 @@ impl Inode for RamInode {
                 );
             }
         }
+    }
+}
+
+impl Inode for RamInode {
+    fn size(&self) -> usize {
+        self.metadata.lock().size
+    }
+
+    fn atime(&self) -> Duration {
+        self.metadata.lock().atime
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.metadata.lock().set_atime(time);
+    }
+
+    fn mtime(&self) -> Duration {
+        self.metadata.lock().mtime
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.metadata.lock().set_mtime(time);
+    }
+
+    fn ctime(&self) -> Duration {
+        self.metadata.lock().ctime
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.lock().set_ctime(time);
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn type_(&self) -> InodeType {
+        self.typ
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.metadata.lock().mode)
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        let mut inode_meta = self.metadata.lock();
+        inode_meta.mode = mode;
+        inode_meta.set_ctime(now());
+        Ok(())
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata.lock().uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        let mut inode_meta = self.metadata.lock();
+        inode_meta.uid = uid;
+        inode_meta.set_ctime(now());
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.metadata.lock().gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        let mut inode_meta = self.metadata.lock();
+        inode_meta.gid = gid;
+        inode_meta.set_ctime(now());
+        Ok(())
+    }
+
+    fn page_cache(&self) -> Option<PageCache> {
+        self.inner
+            .as_file()
+            .map(|page_cache| page_cache.lock().clone())
+    }
+
+    fn metadata(&self) -> Metadata {
+        let rdev = self.inner.device_id().unwrap_or(0);
+        let inode_metadata = self.metadata.lock();
+        Metadata {
+            ino: self.ino as _,
+            size: inode_metadata.size,
+            optimal_block_size: BLOCK_SIZE,
+            nr_sectors_allocated: inode_metadata.nr_sectors_allocated(),
+            last_access_at: inode_metadata.atime,
+            last_modify_at: inode_metadata.mtime,
+            last_meta_change_at: inode_metadata.ctime,
+            type_: self.typ,
+            mode: inode_metadata.mode,
+            nr_hard_links: inode_metadata.nlinks,
+            uid: inode_metadata.uid,
+            gid: inode_metadata.gid,
+            container_dev_id: self.container_dev_id,
+            self_dev_id: if rdev == 0 {
+                None
+            } else {
+                DeviceId::from_encoded_u64(rdev)
+            },
+        }
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        Weak::upgrade(&self.fs).unwrap()
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -17,7 +17,7 @@ use crate::{
         tmpfs::TmpFs,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FallocMode, FileOps, Inode, Metadata},
+            inode::{Extension, FallocMode, FileOps, Inode, InodeVfsOps, Metadata},
             path::{Mount, Path},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -146,6 +146,35 @@ impl FileOps for MemfdInode {
     }
 }
 
+impl InodeVfsOps for MemfdInode {
+    fn resize(&self, new_size: usize) -> Result<()> {
+        let seals = self.seals.lock();
+        let old_size = self.inode.size();
+        if seals.contains(FileSeals::F_SEAL_SHRINK) && new_size < old_size {
+            return_errno_with_message!(Errno::EPERM, "the file is sealed against shrinking");
+        }
+        if seals.contains(FileSeals::F_SEAL_GROW) && new_size > old_size {
+            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
+        }
+
+        self.inode.resize(new_size)
+    }
+
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
+        let seals = self.seals.lock();
+        if seals.contains(FileSeals::F_SEAL_GROW) && offset + len > self.inode.size() {
+            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
+        }
+        if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE)
+            && mode == FallocMode::PunchHoleKeepSize
+        {
+            return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
+        }
+
+        self.inode.fallocate(mode, offset, len)
+    }
+}
+
 #[inherit_methods(from = "self.inode")]
 impl Inode for MemfdInode {
     fn metadata(&self) -> Metadata;
@@ -175,19 +204,6 @@ impl Inode for MemfdInode {
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize>;
     fn remove_xattr(&self, name: XattrName) -> Result<()>;
 
-    fn resize(&self, new_size: usize) -> Result<()> {
-        let seals = self.seals.lock();
-        let old_size = self.inode.size();
-        if seals.contains(FileSeals::F_SEAL_SHRINK) && new_size < old_size {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against shrinking");
-        }
-        if seals.contains(FileSeals::F_SEAL_GROW) && new_size > old_size {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
-        }
-
-        self.inode.resize(new_size)
-    }
-
     fn set_mode(&self, mode: InodeMode) -> Result<()> {
         let seals = self.seals.lock();
         if seals.contains(FileSeals::F_SEAL_EXEC)
@@ -200,20 +216,6 @@ impl Inode for MemfdInode {
         }
 
         self.inode.set_mode(mode)
-    }
-
-    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
-        let seals = self.seals.lock();
-        if seals.contains(FileSeals::F_SEAL_GROW) && offset + len > self.inode.size() {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
-        }
-        if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE)
-            && mode == FallocMode::PunchHoleKeepSize
-        {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
-        }
-
-        self.inode.fallocate(mode, offset, len)
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/sysfs/inode.rs
+++ b/kernel/src/fs/fs_impls/sysfs/inode.rs
@@ -7,7 +7,7 @@ use crate::{
         utils::systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, Inode, Metadata},
+            inode::{Extension, Inode, InodeVfsOps, Metadata},
         },
     },
     prelude::*,
@@ -85,13 +85,13 @@ impl SysTreeInodeTy for SysFsInode {
     fn extension(&self) -> &Extension {
         &self.extension
     }
-}
 
-impl Inode for SysFsInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         SysFs::singleton().clone()
     }
+}
 
+impl InodeVfsOps for SysFsInode {
     fn create(&self, _name: &str, _type_: InodeType, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
         Err(Error::with_message(
             Errno::EPERM,

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -43,7 +43,9 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, RevalidationPolicy, SymbolicLink},
+            inode::{
+                Extension, FileOps, Inode, InodeVfsOps, Metadata, RevalidationPolicy, SymbolicLink,
+            },
         },
     },
     prelude::*,
@@ -191,10 +193,6 @@ impl VirtioFsInode {
 
         fs.lookup_inode_from_cache(lookup_reply, request_attr_version)
     }
-
-    fn type_(&self) -> InodeType {
-        self.type_
-    }
 }
 
 /// An inode timestamp field updated through `SETATTR`.
@@ -253,11 +251,7 @@ impl InodeInner {
     }
 }
 
-impl Inode for VirtioFsInode {
-    fn size(&self) -> usize {
-        self.size()
-    }
-
+impl InodeVfsOps for VirtioFsInode {
     fn resize(&self, new_size: usize) -> Result<()> {
         if self.type_() != InodeType::File {
             return_errno_with_message!(Errno::EISDIR, "resize on non-regular file");
@@ -268,90 +262,6 @@ impl Inode for VirtioFsInode {
 
         let setattr_req = SetattrReq::new(SetattrValid::FATTR_SIZE).set_size(size);
         self.setattr(setattr_req)
-    }
-
-    fn metadata(&self) -> Metadata {
-        self.inner.read().metadata
-    }
-
-    fn ino(&self) -> u64 {
-        self.nodeid().as_u64()
-    }
-
-    fn type_(&self) -> InodeType {
-        self.type_
-    }
-
-    fn mode(&self) -> Result<InodeMode> {
-        Ok(self.inner.read().metadata.mode)
-    }
-
-    fn set_mode(&self, mode: InodeMode) -> Result<()> {
-        let mode_bits = self.type_() as u32 | u32::from(mode.bits());
-        let setattr_req = SetattrReq::new(SetattrValid::FATTR_MODE).set_mode(mode_bits);
-        self.setattr(setattr_req)
-    }
-
-    fn owner(&self) -> Result<Uid> {
-        Ok(self.inner.read().metadata.uid)
-    }
-
-    fn set_owner(&self, uid: Uid) -> Result<()> {
-        let setattr_req = SetattrReq::new(SetattrValid::FATTR_UID).set_uid(uid.into());
-        self.setattr(setattr_req)
-    }
-
-    fn group(&self) -> Result<Gid> {
-        Ok(self.inner.read().metadata.gid)
-    }
-
-    fn set_group(&self, gid: Gid) -> Result<()> {
-        let setattr_req = SetattrReq::new(SetattrValid::FATTR_GID).set_gid(gid.into());
-        self.setattr(setattr_req)
-    }
-
-    fn atime(&self) -> Duration {
-        self.inner.read().metadata.last_access_at
-    }
-
-    fn set_atime(&self, time: Duration) {
-        self.set_time(TimeField::Access, time);
-    }
-
-    fn mtime(&self) -> Duration {
-        self.inner.read().metadata.last_modify_at
-    }
-
-    fn set_mtime(&self, time: Duration) {
-        self.set_time(TimeField::Modify, time);
-    }
-
-    fn ctime(&self) -> Duration {
-        self.inner.read().metadata.last_meta_change_at
-    }
-
-    fn set_ctime(&self, time: Duration) {
-        self.set_time(TimeField::Change, time);
-    }
-
-    fn page_cache(&self) -> Option<PageCache> {
-        self.inner.read().page_cache.clone()
-    }
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        match self.type_ {
-            InodeType::File => Some(self.open_file(access_mode, status_flags)),
-            InodeType::Dir => Some(self.open_directory(access_mode, status_flags)),
-            // TODO: Support opening special files like device files and named pipes.
-            _ => Some(Err(Error::with_message(
-                Errno::EOPNOTSUPP,
-                "opening this virtiofs inode type is not supported",
-            ))),
-        }
     }
 
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
@@ -471,23 +381,6 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn sync_data(&self) -> Result<()> {
-        let inner = self.inner.write();
-        let Some(page_cache) = &inner.page_cache else {
-            return Ok(());
-        };
-        let cached_size = page_cache.size();
-        if cached_size > 0 {
-            page_cache.flush_range(0..cached_size)?;
-        }
-
-        Ok(())
-    }
-
-    fn fs(&self) -> Arc<dyn FileSystem> {
-        self.fs_ref()
-    }
-
     fn revalidation_policy(&self) -> RevalidationPolicy {
         match self.type_ {
             InodeType::Dir => {
@@ -520,6 +413,113 @@ impl Inode for VirtioFsInode {
         let target = fs.session().readlink(self.nodeid())?;
 
         Ok(SymbolicLink::Plain(target))
+    }
+
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        match self.type_ {
+            InodeType::File => Some(self.open_file(access_mode, status_flags)),
+            InodeType::Dir => Some(self.open_directory(access_mode, status_flags)),
+            // TODO: Support opening special files like device files and named pipes.
+            _ => Some(Err(Error::with_message(
+                Errno::EOPNOTSUPP,
+                "opening this virtiofs inode type is not supported",
+            ))),
+        }
+    }
+}
+
+impl Inode for VirtioFsInode {
+    fn size(&self) -> usize {
+        self.size()
+    }
+
+    fn metadata(&self) -> Metadata {
+        self.inner.read().metadata
+    }
+
+    fn ino(&self) -> u64 {
+        self.nodeid().as_u64()
+    }
+
+    fn type_(&self) -> InodeType {
+        self.type_
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.inner.read().metadata.mode)
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        let mode_bits = self.type_ as u32 | u32::from(mode.bits());
+        let setattr_req = SetattrReq::new(SetattrValid::FATTR_MODE).set_mode(mode_bits);
+        self.setattr(setattr_req)
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.inner.read().metadata.uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        let setattr_req = SetattrReq::new(SetattrValid::FATTR_UID).set_uid(uid.into());
+        self.setattr(setattr_req)
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.inner.read().metadata.gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        let setattr_req = SetattrReq::new(SetattrValid::FATTR_GID).set_gid(gid.into());
+        self.setattr(setattr_req)
+    }
+
+    fn atime(&self) -> Duration {
+        self.inner.read().metadata.last_access_at
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.set_time(TimeField::Access, time);
+    }
+
+    fn mtime(&self) -> Duration {
+        self.inner.read().metadata.last_modify_at
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.set_time(TimeField::Modify, time);
+    }
+
+    fn ctime(&self) -> Duration {
+        self.inner.read().metadata.last_meta_change_at
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.set_time(TimeField::Change, time);
+    }
+
+    fn page_cache(&self) -> Option<PageCache> {
+        self.inner.read().page_cache.clone()
+    }
+
+    fn sync_data(&self) -> Result<()> {
+        let inner = self.inner.write();
+        let Some(page_cache) = &inner.page_cache else {
+            return Ok(());
+        };
+        let cached_size = page_cache.size();
+        if cached_size > 0 {
+            page_cache.flush_range(0..cached_size)?;
+        }
+
+        Ok(())
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs_ref()
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/pipe/anon_pipe.rs
+++ b/kernel/src/fs/pipe/anon_pipe.rs
@@ -11,7 +11,7 @@ use crate::{
         pseudofs::{PipeFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, InodeVfsOps, Metadata},
         },
     },
     prelude::*,
@@ -75,9 +75,21 @@ impl FileOps for AnonPipeInode {
 }
 
 #[inherit_methods(from = "self.pseudo_inode")]
+impl InodeVfsOps for AnonPipeInode {
+    fn resize(&self, _new_size: usize) -> Result<()>;
+
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        Some(self.pipe.open_anon(access_mode, status_flags))
+    }
+}
+
+#[inherit_methods(from = "self.pseudo_inode")]
 impl Inode for AnonPipeInode {
     fn size(&self) -> usize;
-    fn resize(&self, _new_size: usize) -> Result<()>;
     fn metadata(&self) -> Metadata;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
@@ -95,12 +107,4 @@ impl Inode for AnonPipeInode {
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
-
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        Some(self.pipe.open_anon(access_mode, status_flags))
-    }
 }

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -98,7 +98,7 @@ fn try_append_entry_to_rootfs(
                 entry.read_all(&mut link_data)?;
                 core::str::from_utf8(&link_data)?.to_string()
             };
-            path.inode().write_link(&link_content)?;
+            path.write_link(&link_content)?;
         }
         FileType::Char => {
             let device_id = try_device_id_from_metadata(metadata)?;

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -14,15 +14,14 @@ use crate::{
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{
-                Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RevalidationPolicy,
-                SymbolicLink,
+                Extension, FallocMode, FileOps, Inode, InodeVfsOps, Metadata, MknodType,
+                RevalidationPolicy, SymbolicLink,
             },
         },
     },
     prelude::*,
     process::{Gid, Uid},
     time::clocks::RealTimeCoarseClock,
-    vm::page_cache::PageCache,
 };
 
 type Ino = u64;
@@ -31,8 +30,7 @@ type Ino = u64;
 /// e.g., a `SysFs` inode and a `CgroupFs` inode.
 ///
 /// The struct implementing this trait will have a default implementation for
-/// the [`Inode`] trait. Users only need to additionally implement the
-/// [`Inode::fs`] method.
+/// the [`Inode`] trait and [`InodeVfsOps`].
 #[expect(dead_code)]
 pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     fn new_arc(
@@ -53,6 +51,8 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     fn set_mode(&self, mode: InodeMode) -> Result<()>;
 
     fn extension(&self) -> &Extension;
+
+    fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn parent(&self) -> &Weak<Self>;
 
@@ -411,79 +411,11 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
     }
 }
 
-impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
-    default fn type_(&self) -> InodeType {
-        self.metadata().type_
-    }
-
-    default fn metadata(&self) -> Metadata {
-        let mut metadata = *self.metadata();
-        metadata.mode = self.mode().unwrap();
-        metadata
-    }
-
-    default fn ino(&self) -> u64 {
-        self.metadata().ino
-    }
-
-    default fn mode(&self) -> Result<InodeMode> {
-        self.mode()
-    }
-
-    default fn set_mode(&self, mode: InodeMode) -> Result<()> {
-        self.set_mode(mode)
-    }
-
-    default fn size(&self) -> usize {
-        self.metadata().size
-    }
-
+impl<KInode: SysTreeInodeTy + Send + Sync + 'static> InodeVfsOps for KInode {
     default fn resize(&self, _new_size: usize) -> Result<()> {
         // The `resize` operation should be ignored by kernelfs inodes,
         // and should not incur an error.
         Ok(())
-    }
-
-    default fn atime(&self) -> Duration {
-        self.metadata().last_access_at
-    }
-
-    default fn set_atime(&self, _time: Duration) {}
-
-    default fn mtime(&self) -> Duration {
-        self.metadata().last_modify_at
-    }
-
-    default fn set_mtime(&self, _time: Duration) {}
-
-    default fn ctime(&self) -> Duration {
-        self.metadata().last_meta_change_at
-    }
-
-    default fn set_ctime(&self, _time: Duration) {}
-
-    default fn owner(&self) -> Result<Uid> {
-        Ok(self.metadata().uid)
-    }
-
-    default fn set_owner(&self, _uid: Uid) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    default fn group(&self) -> Result<Gid> {
-        Ok(self.metadata().gid)
-    }
-
-    default fn set_group(&self, _gid: Gid) -> Result<()> {
-        Err(Error::new(Errno::EPERM))
-    }
-
-    default fn fs(&self) -> Arc<dyn FileSystem> {
-        unimplemented!("fs() method should be implemented by the concrete inode type");
-    }
-
-    default fn page_cache(&self) -> Option<PageCache> {
-        None
     }
 
     default fn create(
@@ -588,26 +520,6 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         Err(Error::new(Errno::EPERM))
     }
 
-    default fn open(
-        &self,
-        _access_mode: AccessMode,
-        _status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        None
-    }
-
-    default fn sync_all(&self) -> Result<()> {
-        Ok(())
-    }
-
-    default fn sync_data(&self) -> Result<()> {
-        Ok(())
-    }
-
-    default fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
-        Err(Error::new(Errno::EOPNOTSUPP))
-    }
-
     default fn revalidation_policy(&self) -> RevalidationPolicy {
         RevalidationPolicy::empty()
     }
@@ -618,6 +530,92 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
 
     default fn revalidate_absent(&self, _name: &str) -> bool {
         true
+    }
+
+    default fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        None
+    }
+
+    default fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        Err(Error::new(Errno::EOPNOTSUPP))
+    }
+}
+
+impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
+    default fn type_(&self) -> InodeType {
+        self.metadata().type_
+    }
+
+    default fn metadata(&self) -> Metadata {
+        let mut metadata = *self.metadata();
+        metadata.mode = self.mode().unwrap();
+        metadata
+    }
+
+    default fn ino(&self) -> u64 {
+        self.metadata().ino
+    }
+
+    default fn mode(&self) -> Result<InodeMode> {
+        self.mode()
+    }
+
+    default fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.set_mode(mode)
+    }
+
+    default fn size(&self) -> usize {
+        self.metadata().size
+    }
+
+    default fn atime(&self) -> Duration {
+        self.metadata().last_access_at
+    }
+
+    default fn set_atime(&self, _time: Duration) {}
+
+    default fn mtime(&self) -> Duration {
+        self.metadata().last_modify_at
+    }
+
+    default fn set_mtime(&self, _time: Duration) {}
+
+    default fn ctime(&self) -> Duration {
+        self.metadata().last_meta_change_at
+    }
+
+    default fn set_ctime(&self, _time: Duration) {}
+
+    default fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata().uid)
+    }
+
+    default fn set_owner(&self, _uid: Uid) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    default fn group(&self) -> Result<Gid> {
+        Ok(self.metadata().gid)
+    }
+
+    default fn set_group(&self, _gid: Gid) -> Result<()> {
+        Err(Error::new(Errno::EPERM))
+    }
+
+    default fn fs(&self) -> Arc<dyn FileSystem> {
+        SysTreeInodeTy::fs(self)
+    }
+
+    default fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    default fn sync_data(&self) -> Result<()> {
+        Ok(())
     }
 
     default fn extension(&self) -> &Extension {

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -492,10 +492,6 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         _type_: InodeType,
         mode: InodeMode,
     ) -> Result<Arc<dyn Inode>> {
-        if name.len() > super::NAME_MAX {
-            return_errno!(Errno::ENAMETOOLONG);
-        }
-
         let SysTreeNodeKind::Branch(branch_node) = &self.node_kind() else {
             return_errno_with_message!(Errno::ENOTDIR, "self is not a dir");
         };

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -335,49 +335,38 @@ pub trait FileOps {
     }
 }
 
-pub trait Inode: Any + FileOps + Send + Sync {
-    fn size(&self) -> usize;
-
+/// Provides inode operations that should only be called by the VFS layer.
+///
+/// These methods rely on VFS-side validation, permission checks, dentry-cache
+/// coordination, mountpoint checks, or path-resolution rules. Code outside
+/// `crate::fs` should use VFS wrappers such as [`Path`] instead.
+pub(in crate::fs) trait InodeVfsOps {
+    /// Resizes a regular file.
+    ///
+    /// # VFS guarantees
+    ///
+    /// The inode type is [`InodeType::File`].
     fn resize(&self, new_size: usize) -> Result<()>;
 
-    fn metadata(&self) -> Metadata;
-
-    fn ino(&self) -> u64;
-
-    fn type_(&self) -> InodeType;
-
-    fn mode(&self) -> Result<InodeMode>;
-
-    fn set_mode(&self, mode: InodeMode) -> Result<()>;
-
-    fn owner(&self) -> Result<Uid>;
-
-    fn set_owner(&self, uid: Uid) -> Result<()>;
-
-    fn group(&self) -> Result<Gid>;
-
-    fn set_group(&self, gid: Gid) -> Result<()>;
-
-    fn atime(&self) -> Duration;
-
-    fn set_atime(&self, time: Duration);
-
-    fn mtime(&self) -> Duration;
-
-    fn set_mtime(&self, time: Duration);
-
-    fn ctime(&self) -> Duration;
-
-    fn set_ctime(&self, time: Duration);
-
-    fn page_cache(&self) -> Option<PageCache> {
-        None
-    }
-
+    /// Creates a child inode under this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - No child named `name` exists under `self` when the method is called.
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Creates an unnamed temporary file under this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
     fn create_tmpfile(
         &self,
         mode: InodeMode,
@@ -386,61 +375,105 @@ pub trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
+    /// Creates a special child inode under this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - No child named `name` exists under `self` when the method is called.
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
-    fn open(
-        &self,
-        access_mode: AccessMode,
-        status_flags: StatusFlags,
-    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
-        None
-    }
-
+    /// Adds a hard link named `name` to `old` under this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
+    /// - `old` is not a directory.
+    /// - `self` and `old` belong to the same filesystem instance.
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - No child named `name` exists under `self` when the method is called.
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Removes a non-directory child named `name` from this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - The resolved child exists and is not a directory.
+    /// - The target child is not a mountpoint.
     fn unlink(&self, name: &str) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Removes an empty directory child named `name` from this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - Write permission on `self` has been checked.
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - The resolved child exists and is a directory.
+    /// - The target child is not a mountpoint.
     fn rmdir(&self, name: &str) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Looks up a child named `name` in this directory.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::Dir`].
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Renames `old_name` from this directory to `new_name` under `target`.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type of both `self` and `target` is [`InodeType::Dir`].
+    /// - `self` and `target` belong to the same filesystem instance.
+    /// - Write permission on both directories has been checked.
+    /// - `old_name` and `new_name` are ordinary child names: non-empty,
+    ///   contain no `/`, are not `.` or `..`, and are no longer than
+    ///   `NAME_MAX`.
+    /// - The overwritten target child, if any, is not a mountpoint.
     fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
+    /// Reads the symlink target.
+    ///
+    /// # VFS guarantees
+    ///
+    /// The inode type is [`InodeType::SymLink`].
     fn read_link(&self) -> Result<SymbolicLink> {
         Err(Error::new(Errno::EISDIR))
     }
 
+    /// Replaces the symlink target.
+    ///
+    /// # VFS guarantees
+    ///
+    /// The inode type is [`InodeType::SymLink`].
     fn write_link(&self, target: &str) -> Result<()> {
         Err(Error::new(Errno::EISDIR))
     }
-
-    fn sync_all(&self) -> Result<()> {
-        Ok(())
-    }
-
-    fn sync_data(&self) -> Result<()> {
-        Ok(())
-    }
-
-    /// Manipulates a range of space of the file according to the specified allocate mode,
-    /// the manipulated range starts at `offset` and continues for `len` bytes.
-    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
-        return_errno!(Errno::EOPNOTSUPP);
-    }
-
-    fn fs(&self) -> Arc<dyn FileSystem>;
 
     /// Returns the revalidation policy for cached children of this directory.
     ///
@@ -448,6 +481,10 @@ pub trait Inode: Any + FileOps + Send + Sync {
     ///
     /// Default: empty (no revalidation).
     /// Correct for filesystems where all mutations go through the VFS.
+    ///
+    /// # VFS guarantees
+    ///
+    /// The inode type is [`InodeType::Dir`].
     fn revalidation_policy(&self) -> RevalidationPolicy {
         RevalidationPolicy::empty()
     }
@@ -461,10 +498,14 @@ pub trait Inode: Any + FileOps + Send + Sync {
     ///
     /// See [`RevalidationPolicy`] for the full protocol description.
     ///
-    /// # Precondition
+    /// # VFS guarantees
     ///
-    /// Only called when `self.revalidation_policy()` includes `REVALIDATE_EXISTS`.
-    /// Otherwise, the return value is considered garbage.
+    /// - The inode type is [`InodeType::Dir`].
+    /// - `self.revalidation_policy()` includes
+    ///   [`RevalidationPolicy::REVALIDATE_EXISTS`].
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
+    /// - `child` is the cached child inode named `name`.
     fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
         true
     }
@@ -478,12 +519,113 @@ pub trait Inode: Any + FileOps + Send + Sync {
     ///
     /// See [`RevalidationPolicy`] for the full protocol description.
     ///
-    /// # Precondition
+    /// # VFS guarantees
     ///
-    /// Only called when `self.revalidation_policy()` includes `REVALIDATE_ABSENT`.
-    /// Otherwise, the return value is considered garbage.
+    /// - The inode type is [`InodeType::Dir`].
+    /// - `self.revalidation_policy()` includes
+    ///   [`RevalidationPolicy::REVALIDATE_ABSENT`].
+    /// - `name` is an ordinary child name: non-empty, contains no `/`, is not
+    ///   `.` or `..`, and is no longer than `NAME_MAX`.
     fn revalidate_absent(&self, _name: &str) -> bool {
         true
+    }
+
+    /// Opens inode-specific per-open file operations, if needed.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The open is not an `O_PATH` open.
+    /// - If the inode type is [`InodeType::Dir`], the access mode is not
+    ///   writable.
+    /// - Permission has been checked (unless `O_PATH`).
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        None
+    }
+
+    /// Manipulates a range of file space according to `mode`.
+    ///
+    /// # VFS guarantees
+    ///
+    /// - The inode type is [`InodeType::File`] or [`InodeType::Dir`].
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
+        return_errno!(Errno::EOPNOTSUPP);
+    }
+}
+
+/// Provides public inode operations.
+///
+/// These methods can be called outside the VFS directly since they
+/// do not require any VFS guarantees.
+#[expect(private_bounds)]
+pub trait Inode: InodeVfsOps + Any + FileOps + Send + Sync {
+    /// Returns the current file size.
+    fn size(&self) -> usize;
+
+    /// Returns the full metadata snapshot.
+    fn metadata(&self) -> Metadata;
+
+    /// Returns the inode number within the filesystem.
+    fn ino(&self) -> u64;
+
+    /// Returns the inode type.
+    fn type_(&self) -> InodeType;
+
+    /// Returns the permission mode.
+    fn mode(&self) -> Result<InodeMode>;
+
+    /// Changes the permission mode.
+    fn set_mode(&self, mode: InodeMode) -> Result<()>;
+
+    /// Returns the owner UID.
+    fn owner(&self) -> Result<Uid>;
+
+    /// Changes the owner UID.
+    fn set_owner(&self, uid: Uid) -> Result<()>;
+
+    /// Returns the owner GID.
+    fn group(&self) -> Result<Gid>;
+
+    /// Changes the owner GID.
+    fn set_group(&self, gid: Gid) -> Result<()>;
+
+    /// Returns the last access time.
+    fn atime(&self) -> Duration;
+
+    /// Changes the last access time.
+    fn set_atime(&self, time: Duration);
+
+    /// Returns the last modification time.
+    fn mtime(&self) -> Duration;
+
+    /// Changes the last modification time.
+    fn set_mtime(&self, time: Duration);
+
+    /// Returns the last metadata-change time.
+    fn ctime(&self) -> Duration;
+
+    /// Changes the last metadata-change time.
+    fn set_ctime(&self, time: Duration);
+
+    /// Flushes all dirty data and metadata for this inode.
+    fn sync_all(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Flushes dirty file data for this inode.
+    fn sync_data(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Returns the filesystem instance that owns this inode.
+    fn fs(&self) -> Arc<dyn FileSystem>;
+
+    /// Returns the page cache backing this inode, if any.
+    fn page_cache(&self) -> Option<PageCache> {
+        None
     }
 
     /// Returns the end position for [`SeekFrom::End`].
@@ -502,9 +644,7 @@ pub trait Inode: Any + FileOps + Send + Sync {
         }
     }
 
-    /// Gets the extension of this inode.
-    fn extension(&self) -> &Extension;
-
+    /// Sets an extended attribute.
     fn set_xattr(
         &self,
         name: XattrName,
@@ -514,14 +654,17 @@ pub trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
+    /// Reads an extended attribute.
     fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize> {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
+    /// Lists extended attributes in `namespace`.
     fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize> {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
 
+    /// Removes an extended attribute.
     fn remove_xattr(&self, name: XattrName) -> Result<()> {
         Err(Error::new(Errno::EOPNOTSUPP))
     }
@@ -591,6 +734,9 @@ pub trait Inode: Any + FileOps + Send + Sync {
 
         Ok(())
     }
+
+    /// Returns the extension storage for this inode.
+    fn extension(&self) -> &Extension;
 }
 
 impl dyn Inode {

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -13,6 +13,7 @@ use crate::{
     fs::{
         self,
         file::{InodeMode, InodeType},
+        utils::NAME_MAX,
         vfs::{
             inode::{Inode, MknodType, RevalidationPolicy},
             inode_ext::InodeExt,
@@ -396,6 +397,8 @@ impl DirDentry<'_> {
         type_: InodeType,
         mode: InodeMode,
     ) -> Result<Arc<Dentry>> {
+        validate_new_child_name(name)?;
+
         let children = self.validate_child_absent(name)?;
         let new_inode = self.inode.create(name, type_, mode)?;
         let mut children = children.upgrade();
@@ -500,6 +503,7 @@ impl DirDentry<'_> {
     /// [`super::PathResolver::lookup_at_path`].
     pub(in crate::fs) fn lookup_child(&self, name: &str) -> Result<Arc<Dentry>> {
         debug_assert!(!is_dot_or_dotdot(name));
+        validate_child_name(name)?;
 
         let mut children = self.children.upread();
 
@@ -546,6 +550,8 @@ impl DirDentry<'_> {
         mode: InodeMode,
         type_: MknodType,
     ) -> Result<Arc<Dentry>> {
+        validate_new_child_name(name)?;
+
         let children = self.validate_child_absent(name)?;
         let inode = self.inode.mknod(name, mode, type_)?;
         let new_child = Dentry::new(
@@ -559,6 +565,14 @@ impl DirDentry<'_> {
 
     /// Links a new `Dentry` by `link()` the old inode.
     pub(super) fn link(&self, old_inode: &Arc<dyn Inode>, name: &str) -> Result<()> {
+        validate_new_child_name(name)?;
+        if old_inode.type_() == InodeType::Dir {
+            return_errno_with_message!(Errno::EPERM, "hard links to directories are not allowed");
+        }
+        if !Arc::ptr_eq(&self.inode.fs(), &old_inode.fs()) {
+            return_errno_with_message!(Errno::EXDEV, "the operation cannot cross filesystems");
+        }
+
         let children = self.validate_child_absent(name)?;
         self.inode.link(old_inode, name)?;
         let dentry = Dentry::new(
@@ -575,12 +589,22 @@ impl DirDentry<'_> {
 
     /// Deletes a `Dentry` by `unlink()` the inner inode.
     pub(super) fn unlink(&self, name: &str) -> Result<()> {
+        validate_child_name(name)?;
         if is_dot_or_dotdot(name) {
             return_errno_with_message!(Errno::EINVAL, "unlink on . or ..");
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.unlink(name))?;
+        let child_inode = self.remove_child(
+            name,
+            |child_inode| {
+                if child_inode.type_() == InodeType::Dir {
+                    return_errno_with_message!(Errno::EISDIR, "unlink on a directory");
+                }
+                Ok(())
+            },
+            |dir_inode, name| dir_inode.unlink(name),
+        )?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
@@ -605,6 +629,7 @@ impl DirDentry<'_> {
 
     /// Deletes a directory `Dentry` by `rmdir()` the inner inode.
     pub(super) fn rmdir(&self, name: &str) -> Result<()> {
+        validate_child_name(name)?;
         if is_dot(name) {
             return_errno_with_message!(Errno::EINVAL, "rmdir on .");
         }
@@ -613,7 +638,16 @@ impl DirDentry<'_> {
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.rmdir(name))?;
+        let child_inode = self.remove_child(
+            name,
+            |child_inode| {
+                if child_inode.type_() != InodeType::Dir {
+                    return_errno_with_message!(Errno::ENOTDIR, "rmdir on a non-directory");
+                }
+                Ok(())
+            },
+            |dir_inode, name| dir_inode.rmdir(name),
+        )?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         if nlinks == 0 {
@@ -638,6 +672,7 @@ impl DirDentry<'_> {
     fn remove_child(
         &self,
         name: &str,
+        validate_child_fn: impl FnOnce(&dyn Inode) -> Result<()>,
         remove_child_fn: impl FnOnce(&dyn Inode, &str) -> Result<()>,
     ) -> Result<Arc<dyn Inode>> {
         let dir_inode = self.inode();
@@ -669,6 +704,7 @@ impl DirDentry<'_> {
             None => dir_inode.lookup(name)?,
         };
 
+        validate_child_fn(child_inode.as_ref())?;
         remove_child_fn(dir_inode.as_ref(), name)?;
         if cached_child.is_some() {
             children.upgrade().delete(name);
@@ -689,6 +725,8 @@ impl DirDentry<'_> {
         if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
             return_errno_with_message!(Errno::EISDIR, "old_name or new_name is a directory");
         }
+        validate_child_name(old_name)?;
+        validate_child_name(new_name)?;
 
         let old_dir_inode = old_dir.inode();
         let new_dir_inode = new_dir.inode();
@@ -1066,4 +1104,27 @@ fn write_lock_children_on_two_dentries<'a>(
             unreachable!("two distinct DirDentry's with identical DentryKey")
         }
     }
+}
+
+fn validate_child_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return_errno_with_message!(Errno::ENOENT, "the child name is empty");
+    }
+    if name.len() > NAME_MAX {
+        return_errno_with_message!(Errno::ENAMETOOLONG, "the child name is too long");
+    }
+    if name.as_bytes().contains(&b'/') {
+        return_errno_with_message!(Errno::EINVAL, "the child name contains a path separator");
+    }
+
+    Ok(())
+}
+
+fn validate_new_child_name(name: &str) -> Result<()> {
+    validate_child_name(name)?;
+    if is_dot_or_dotdot(name) {
+        return_errno_with_message!(Errno::EEXIST, "the child already exists");
+    }
+
+    Ok(())
 }

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         pseudofs::NsInode,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            inode::{HardLinkability, Inode, Metadata, MknodType},
+            inode::{HardLinkability, Inode, Metadata, MknodType, SymbolicLink},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -62,13 +62,7 @@ impl Path {
 
     /// Creates a new `Path` to represent the child directory of a file system.
     pub fn new_fs_child(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Self> {
-        if self
-            .inode()
-            .check_permission(Permission::MAY_WRITE)
-            .is_err()
-        {
-            return_errno!(Errno::EACCES);
-        }
+        self.check_write_permission()?;
         let new_child_dentry = self
             .dentry
             .as_dir_dentry_or_err()?
@@ -86,14 +80,10 @@ impl Path {
         mode: InodeMode,
         hard_linkability: HardLinkability,
     ) -> Result<Self> {
-        if self
-            .inode()
-            .check_permission(Permission::MAY_WRITE)
-            .is_err()
-        {
-            return_errno!(Errno::EACCES);
-        }
-        let tmp_inode = self.inode().create_tmpfile(mode, hard_linkability)?;
+        self.check_write_permission()?;
+
+        let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
+        let tmp_inode = dir_dentry.inode().create_tmpfile(mode, hard_linkability)?;
         let tmp_dentry = Dentry::new_anonymous(tmp_inode, self.dentry.clone());
         Ok(Self::new(self.mount.clone(), tmp_dentry))
     }
@@ -265,6 +255,18 @@ impl Path {
 
     fn this(&self) -> Self {
         self.clone()
+    }
+
+    fn check_write_permission(&self) -> Result<()> {
+        if self
+            .inode()
+            .check_permission(Permission::MAY_WRITE)
+            .is_err()
+        {
+            return_errno!(Errno::EACCES);
+        }
+
+        Ok(())
     }
 }
 
@@ -522,6 +524,7 @@ impl Path {
 
     /// Creates a `Path` by making an inode of the `type_` with the `mode`.
     pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Self> {
+        self.check_write_permission()?;
         let inner = self
             .dentry
             .as_dir_dentry_or_err()?
@@ -534,17 +537,20 @@ impl Path {
         if !Arc::ptr_eq(&old.mount, &self.mount) {
             return_errno_with_message!(Errno::EXDEV, "the operation cannot cross mounts");
         }
+        self.check_write_permission()?;
 
         self.dentry.as_dir_dentry_or_err()?.link(old.inode(), name)
     }
 
     /// Unlinks a name from the `Path`.
     pub fn unlink(&self, name: &str) -> Result<()> {
+        self.check_write_permission()?;
         self.dentry.as_dir_dentry_or_err()?.unlink(name)
     }
 
     /// Removes a directory by `rmdir()` the inner inode.
     pub fn rmdir(&self, name: &str) -> Result<()> {
+        self.check_write_permission()?;
         self.dentry.as_dir_dentry_or_err()?.rmdir(name)
     }
 
@@ -553,8 +559,37 @@ impl Path {
         if !Arc::ptr_eq(&self.mount, &new_dir.mount) {
             return_errno_with_message!(Errno::EXDEV, "the operation cannot cross mounts");
         }
+        self.check_write_permission()?;
+        new_dir.check_write_permission()?;
 
         DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name)
+    }
+
+    /// Resizes the regular file at this path.
+    pub fn resize(&self, size: usize) -> Result<()> {
+        match self.type_() {
+            InodeType::File => self.inode().resize(size),
+            InodeType::Dir => return_errno_with_message!(Errno::EISDIR, "resize on a directory"),
+            _ => return_errno_with_message!(Errno::EINVAL, "resize on a non-regular file"),
+        }
+    }
+
+    /// Reads the target of the symbolic link at this path.
+    pub fn read_link(&self) -> Result<SymbolicLink> {
+        if self.type_() != InodeType::SymLink {
+            return_errno_with_message!(Errno::EINVAL, "readlink on a non-symlink");
+        }
+
+        self.inode().read_link()
+    }
+
+    /// Replaces the target of the symbolic link at this path.
+    pub fn write_link(&self, target: &str) -> Result<()> {
+        if self.type_() != InodeType::SymLink {
+            return_errno_with_message!(Errno::EINVAL, "write_link on a non-symlink");
+        }
+
+        self.inode().write_link(target)
     }
 }
 
@@ -568,7 +603,6 @@ impl Path {
     pub fn mode(&self) -> Result<InodeMode>;
     pub fn set_mode(&self, mode: InodeMode) -> Result<()>;
     pub fn size(&self) -> usize;
-    pub fn resize(&self, size: usize) -> Result<()>;
     pub fn owner(&self) -> Result<Uid>;
     pub fn set_owner(&self, uid: Uid) -> Result<()>;
     pub fn group(&self) -> Result<Gid>;

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -691,7 +691,7 @@ impl PathResolver {
                 if follows >= SYMLINKS_MAX {
                     return_errno_with_message!(Errno::ELOOP, "there are too many symlinks");
                 }
-                let read_link_res = next_path.inode().read_link()?;
+                let read_link_res = next_path.read_link()?;
                 match read_link_res {
                     SymbolicLink::Plain(mut tmp_link_path) => {
                         let link_path_remain = {

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -41,7 +41,7 @@ pub fn sys_readlinkat(
         let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Allow)?;
         let path = path_resolver.lookup_no_follow(&fs_path)?;
 
-        match path.inode().read_link()? {
+        match path.read_link()? {
             SymbolicLink::Plain(s) => s,
             SymbolicLink::Path(path) => path_resolver.make_abs_path(&path).into_string(),
         }

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -42,7 +42,7 @@ pub fn sys_symlinkat(
     };
 
     let new_path = dir_path.new_fs_child(&link_name, InodeType::SymLink, mkmod!(a+rwx))?;
-    new_path.inode().write_link(&target)?;
+    new_path.write_link(&target)?;
     fs::vfs::notify::on_create(&dir_path, || link_name);
     Ok(SyscallReturn::Return(0))
 }


### PR DESCRIPTION
Based on #3311.

When reviewing filesystem-related implementations, I often find many checks that are redundant with those already performed in the VFS layer. The reason this happens is that we have not clearly defined what checks are handled on the VFS side. By explicitly documenting these completed pre-checks in the `Inode` documentation, this PR aims to give future filesystem implementers a clearer understanding of them.

At the same time, this PR removes some existing redundant checks and consolidates certain checks into the VFS layer wherever possible. The guiding principle here is that checks that are general and required by every filesystem can usually be handled in the VFS layer.

Includes #3118.