### PR TITLE
Support MSG_PEEK for all sockets

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/README.md
@@ -100,9 +100,6 @@ Supported functionality in SCML:
 {{#include recvfrom_and_recvmsg.scml}}
 ```
 
-Partially-supported flags:
-* `MSG_PEEK` because it is only supported in netlink socket
-
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/recvfrom.2.html).
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/recvfrom_and_recvmsg.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/recvfrom_and_recvmsg.scml
@@ -1,7 +1,10 @@
+// Supported message receive flags
+recv_flags = MSG_PEEK;
+
 // Receive message from a socket
 recvfrom(
     sockfd, buf, size,
-    flags = 0,
+    flags = <recv_flags>,
     src_addr, addrlen
 );
 
@@ -9,5 +12,5 @@ recvfrom(
 recvmsg(
     sockfd,
     msg,
-    flags = 0
+    flags = <recv_flags>
 );

--- a/kernel/libs/aster-bigtcp/src/socket/bound/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/mod.rs
@@ -12,3 +12,19 @@ pub use tcp_listen::TcpListener;
 pub(crate) use tcp_listen::TcpListenerBg;
 pub use udp::UdpSocket;
 pub(crate) use udp::UdpSocketBg;
+
+/// Describes how receive operations consume queued data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiveBehavior {
+    /// Removes received data from the receive buffer.
+    Recv,
+    /// Leaves received data in the receive buffer.
+    Peek,
+}
+
+impl ReceiveBehavior {
+    /// Returns whether received data should be removed from the receive buffer.
+    pub fn will_consume_data(self) -> bool {
+        self == Self::Recv
+    }
+}

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -18,6 +18,7 @@ use smoltcp::{
 };
 
 use super::{
+    ReceiveBehavior,
     common::{Inner, NeedIfacePoll, Socket, SocketBg},
     tcp_listen::TcpListenerBg,
 };
@@ -445,12 +446,13 @@ impl<E: Ext> TcpConnection<E> {
     /// Receives some data.
     ///
     /// Polling the iface _may_ be required after this method succeeds.
-    pub fn recv<F, CopyErr>(
+    pub fn recv<CopyFn, CopyErr>(
         &self,
-        mut f: F,
+        behavior: ReceiveBehavior,
+        mut copy_fn: CopyFn,
     ) -> Result<(NonZeroUsize, NeedIfacePoll), IoError<RecvError, CopyErr>>
     where
-        F: FnMut(&mut [u8]) -> Result<usize, (CopyErr, usize)>,
+        CopyFn: FnMut(&[u8]) -> Result<usize, (CopyErr, usize)>,
     {
         let common = self.iface().common();
         let mut iface = common.interface();
@@ -462,7 +464,7 @@ impl<E: Ext> TcpConnection<E> {
         }
 
         let mut total_recv_bytes = 0;
-        let mut need_wrap_continuation = true;
+        let mut need_wrap_continuation = behavior.will_consume_data();
 
         let result = loop {
             let mut recv_bytes = 0;
@@ -471,9 +473,9 @@ impl<E: Ext> TcpConnection<E> {
             // `socket.recv` exposes the largest contiguous readable range. If the receive ring
             // buffer wraps, one logical stream read may span two such ranges, so continue at most
             // once while holding the same socket lock to avoid an avoidable short read.
-            let recv_result = socket.recv(|socket_buffer| {
+            let mut copy_socket_buffer = |socket_buffer: &[u8]| {
                 socket_buffer_len = socket_buffer.len();
-                match f(socket_buffer) {
+                match copy_fn(socket_buffer) {
                     Ok(current_recv_bytes) => {
                         recv_bytes = current_recv_bytes;
                         (current_recv_bytes, Ok(()))
@@ -483,7 +485,23 @@ impl<E: Ext> TcpConnection<E> {
                         (current_recv_bytes, Err(err))
                     }
                 }
-            });
+            };
+
+            let recv_result = match behavior {
+                ReceiveBehavior::Recv => {
+                    socket.recv(|socket_buffer| copy_socket_buffer(socket_buffer))
+                }
+                ReceiveBehavior::Peek => {
+                    // FIXME: This implementation relies on `socket.peek()`, which only returns the
+                    // first contiguous readable range. We need more powerful smoltcp APIs to peek the
+                    // wrapped receive buffer without extra caching and copying.
+                    let recv_queue = socket.recv_queue();
+                    socket.peek(recv_queue).map(|socket_buffer| {
+                        let (_, copy_result) = copy_socket_buffer(socket_buffer);
+                        copy_result
+                    })
+                }
+            };
 
             let copy_result = match recv_result {
                 Err(_) if socket.is_rst_closed && total_recv_bytes == 0 => {

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -11,7 +11,10 @@ use smoltcp::{
     wire::{IpRepr, UdpRepr},
 };
 
-use super::common::{Inner, Socket, SocketBg};
+use super::{
+    ReceiveBehavior,
+    common::{Inner, Socket, SocketBg},
+};
 use crate::{
     errors::udp::SendError,
     ext::Ext,
@@ -166,14 +169,24 @@ impl<E: Ext> UdpSocket<E> {
     /// Receives some data.
     ///
     /// Polling the iface is _not_ required after this method succeeds.
-    pub fn recv<F, R>(&self, f: F) -> Result<R, smoltcp::socket::udp::RecvError>
+    pub fn recv<CopyFn, R>(
+        &self,
+        behavior: ReceiveBehavior,
+        copy_fn: CopyFn,
+    ) -> Result<R, smoltcp::socket::udp::RecvError>
     where
-        F: FnOnce(&[u8], UdpMetadata) -> R,
+        CopyFn: FnOnce(&[u8], UdpMetadata) -> R,
     {
         let mut socket = self.0.inner.socket.lock();
 
-        let (data, meta) = socket.recv()?;
-        let result = f(data, meta);
+        let (data, meta) = match behavior {
+            ReceiveBehavior::Recv => socket.recv()?,
+            ReceiveBehavior::Peek => {
+                let (data, meta) = socket.peek()?;
+                (data, *meta)
+            }
+        };
+        let result = copy_fn(data, meta);
 
         Ok(result)
     }

--- a/kernel/libs/aster-bigtcp/src/socket/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/mod.rs
@@ -6,7 +6,8 @@ mod option;
 mod unbound;
 
 pub use bound::{
-    ConnectState, NeedIfacePoll, RawTcpSocketExt, TcpConnection, TcpListener, UdpSocket,
+    ConnectState, NeedIfacePoll, RawTcpSocketExt, ReceiveBehavior, TcpConnection, TcpListener,
+    UdpSocket,
 };
 pub(crate) use bound::{TcpConnectionBg, TcpListenerBg, TcpProcessResult, UdpSocketBg};
 pub use event::{SocketEventObserver, SocketEvents};

--- a/kernel/libs/ring-buffer/src/lib.rs
+++ b/kernel/libs/ring-buffer/src/lib.rs
@@ -466,6 +466,11 @@ impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
 }
 
 impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
+    /// Returns the underlying ring buffer.
+    pub fn ring_buffer(&self) -> &RingBuffer<T> {
+        &self.rb
+    }
+
     /// Commits a read operation by advancing the head pointer.
     ///
     /// This method is intended for advanced use cases where the caller reads
@@ -475,7 +480,7 @@ impl<T, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
     /// # Panics
     ///
     /// Panics if `len` exceeds the number of available items in the buffer.
-    pub fn commit_read(&self, len: usize) {
+    pub fn commit_read(&mut self, len: usize) {
         assert!(
             len <= self.len(),
             "commit_read: len exceeds available items"

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -404,7 +404,12 @@ impl PipeReader {
             consumer.read_fallible(writer)
         };
 
-        self.state.read_with(read)
+        let read_len = self.state.read_with(read)?;
+        if read_len > 0 {
+            self.state.notify_read();
+        }
+
+        Ok(read_len)
     }
 
     fn buffer_len(&self) -> usize {
@@ -462,6 +467,9 @@ impl PipeWriter {
         };
 
         let res = self.state.write_with(write);
+        if res.is_ok() {
+            self.state.notify_write();
+        }
         if res.is_err_and(|e| e.error() == Errno::EPIPE)
             && let Some(posix_thread) = current_thread!().as_posix_thread()
         {

--- a/kernel/src/fs/utils/endpoint.rs
+++ b/kernel/src/fs/utils/endpoint.rs
@@ -122,7 +122,7 @@ impl AsRef<EndpointState> for EndpointState {
 }
 
 impl<T: AsRef<EndpointState>> Endpoint<T> {
-    /// Reads from the endpoint and updates the local/remote [`Pollee`]s.
+    /// Reads from the endpoint.
     ///
     /// Note that if `read` returns `Ok(0)`, it is assumed that there is no data to read and an
     /// [`Errno::EAGAIN`] error will be returned instead.
@@ -139,8 +139,6 @@ impl<T: AsRef<EndpointState>> Endpoint<T> {
         let read_len = read()?;
 
         if read_len > 0 {
-            self.peer_end().as_ref().pollee.notify(IoEvents::OUT);
-            self.this_end().as_ref().pollee.invalidate();
             Ok(read_len)
         } else if is_shutdown {
             Ok(0)
@@ -149,7 +147,7 @@ impl<T: AsRef<EndpointState>> Endpoint<T> {
         }
     }
 
-    /// Writes to the endpoint and updates the local/remote [`Pollee`]s.
+    /// Writes to the endpoint.
     ///
     /// Note that if `write` returns `Ok(0)`, it is assumed that there is no space to write and an
     /// [`Errno::EAGAIN`] error will be returned instead.
@@ -166,13 +164,23 @@ impl<T: AsRef<EndpointState>> Endpoint<T> {
 
         let written_len = write()?;
 
-        if written_len > 0 {
-            self.peer_end().as_ref().pollee.notify(IoEvents::IN);
-            self.this_end().as_ref().pollee.invalidate();
-            Ok(written_len)
-        } else {
+        if written_len == 0 {
             return_errno_with_message!(Errno::EAGAIN, "the channel is full");
         }
+
+        Ok(written_len)
+    }
+
+    /// Notifies the local/remote [`Pollee`]s that data have been read.
+    pub fn notify_read(&self) {
+        self.peer_end().as_ref().pollee.notify(IoEvents::OUT);
+        self.this_end().as_ref().pollee.invalidate();
+    }
+
+    /// Notifies the local/remote [`Pollee`]s that data have been written.
+    pub fn notify_write(&self) {
+        self.peer_end().as_ref().pollee.notify(IoEvents::IN);
+        self.this_end().as_ref().pollee.invalidate();
     }
 
     /// Polls the I/O events in the local [`Pollee`].

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(min_specialization)]
 #![feature(thin_box)]
 #![feature(unique_rc_arc)]
+#![feature(vec_deque_truncate_front)]
 #![register_tool(component_access_control)]
 
 extern crate alloc;

--- a/kernel/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/src/net/socket/ip/datagram/bound.rs
@@ -55,15 +55,17 @@ impl datagram_common::Bound for BoundDatagram {
     fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
-        let result = self.bound_socket.recv(|packet, udp_metadata| {
-            let copied_res = writer
-                .write(&mut VmReader::from(packet))
-                .map_err(Into::into);
-            let endpoint = udp_metadata.endpoint;
-            (copied_res, endpoint)
-        });
+        let result = self
+            .bound_socket
+            .recv(flags.receive_behavior(), |packet, udp_metadata| {
+                let copied_res = writer
+                    .write(&mut VmReader::from(packet))
+                    .map_err(Into::into);
+                let endpoint = udp_metadata.endpoint;
+                (copied_res, endpoint)
+            });
 
         match result {
             Ok((Ok(res), endpoint)) => Ok((res, endpoint)),

--- a/kernel/src/net/socket/ip/stream/connected.rs
+++ b/kernel/src/net/socket/ip/stream/connected.rs
@@ -72,11 +72,13 @@ impl ConnectedStream {
     pub(super) fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, NeedIfacePoll)> {
         let result = self
             .tcp_conn
-            .recv(|socket_buffer| writer.write(&mut VmReader::from(&*socket_buffer)));
+            .recv(flags.receive_behavior(), |socket_buffer| {
+                writer.write(&mut VmReader::from(socket_buffer))
+            });
 
         match result {
             Ok((recv_bytes, need_poll)) => Ok((recv_bytes.get(), need_poll)),

--- a/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/bound.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::Sub;
-
 use super::message::UeventMessage;
 use crate::{
     events::IoEvents,
@@ -62,8 +60,8 @@ impl datagram_common::Bound for BoundNetlinkUevent {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, Self::Endpoint)> {
-        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
-        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+        // TODO: Deal with other flags.
+        if !flags.is_all_supported() {
             warn!("unsupported flags: {:?}", flags);
         }
 
@@ -75,7 +73,7 @@ impl datagram_common::Bound for BoundNetlinkUevent {
 
             let remote = *response.src_addr();
 
-            let should_dequeue = !flags.contains(SendRecvFlags::MSG_PEEK);
+            let should_dequeue = flags.receive_behavior().will_consume_data();
             Ok((should_dequeue, (len, remote)))
         })
     }

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::Sub;
-
 use super::message::{RtnlMessage, RtnlSegment};
 use crate::{
     events::IoEvents,
@@ -102,8 +100,8 @@ impl datagram_common::Bound for BoundNetlinkRoute {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, NetlinkSocketAddr)> {
-        // TODO: Deal with other flags. Only MSG_PEEK is handled here.
-        if !flags.sub(SendRecvFlags::MSG_PEEK).is_all_supported() {
+        // TODO: Deal with other flags.
+        if !flags.is_all_supported() {
             warn!("unsupported flags: {:?}", flags);
         }
 
@@ -116,7 +114,7 @@ impl datagram_common::Bound for BoundNetlinkRoute {
             // TODO: The message can only come from kernel socket currently.
             let remote = NetlinkSocketAddr::new_unspecified();
 
-            let should_dequeue = !flags.contains(SendRecvFlags::MSG_PEEK);
+            let should_dequeue = flags.receive_behavior().will_consume_data();
             Ok((should_dequeue, (len, remote)))
         })
     }

--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt;
+use core::{fmt, mem};
 
+use aster_bigtcp::socket::ReceiveBehavior;
 use aster_rights::ReadOp;
 use ostd::task::Task;
 
@@ -274,7 +275,11 @@ impl AuxiliaryData {
     }
 
     /// Generates the control messages from the auxiliary data.
-    pub(super) fn generate_control(&mut self, is_pass_cred: bool) -> Vec<ControlMessage> {
+    pub(super) fn generate_control(
+        &mut self,
+        behavior: ReceiveBehavior,
+        is_pass_cred: bool,
+    ) -> Vec<ControlMessage> {
         let mut ctrl_msgs = Vec::new();
 
         let Self { files, cred } = self;
@@ -290,9 +295,11 @@ impl AuxiliaryData {
         }
 
         if !files.is_empty() {
-            let unix_ctrl_msg = UnixControlMessage(Message::Files(FileMessage {
-                files: core::mem::take(files),
-            }));
+            let files = match behavior {
+                ReceiveBehavior::Recv => mem::take(files),
+                ReceiveBehavior::Peek => files.clone(),
+            };
+            let unix_ctrl_msg = UnixControlMessage(Message::Files(FileMessage { files }));
             ctrl_msgs.push(ControlMessage::Unix(unix_ctrl_msg));
         }
 

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -13,7 +13,7 @@ use crate::{
             addr::{UnixSocketAddrBound, UnixSocketAddrKey},
             ctrl_msg::AuxiliaryData,
         },
-        util::ControlMessage,
+        util::{ControlMessage, SendRecvFlags},
     },
     prelude::*,
     process::signal::Pollee,
@@ -163,6 +163,7 @@ impl MessageReceiver {
     pub(super) fn try_recv(
         &self,
         writer: &mut dyn MultiWrite,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>, UnixSocketAddr)> {
         let mut inner = self.queue.inner.lock();
         let inner = inner.as_mut().unwrap();
@@ -180,18 +181,26 @@ impl MessageReceiver {
             warn!("setting MSG_TRUNC is not supported");
         }
 
-        let mut msg = inner.messages.pop_front().unwrap();
-        inner.total_length -= msg.bytes.len();
-
         let is_pass_cred = self.queue.is_pass_cred.load(Ordering::Relaxed);
-        let ctrl_msgs = msg.aux.generate_control(is_pass_cred);
+        let src = msg.src.clone();
 
-        self.queue.pollee.invalidate();
-        // A writer may still fail if the free space is not enough.
-        // So we have to wake up all the writers here.
-        self.queue.send_wait_queue.wake_all();
+        let behavior = flags.receive_behavior();
+        let ctrl_msgs = if behavior.will_consume_data() {
+            let mut message = inner.messages.pop_front().unwrap();
+            inner.total_length -= message.bytes.len();
 
-        Ok((len, ctrl_msgs, msg.src))
+            self.queue.pollee.invalidate();
+            // A writer may still fail if the free space is not enough.
+            // So we have to wake up all the writers here.
+            self.queue.send_wait_queue.wake_all();
+
+            message.aux.generate_control(behavior, is_pass_cred)
+        } else {
+            let message = inner.messages.front_mut().unwrap();
+            message.aux.generate_control(behavior, is_pass_cred)
+        };
+
+        Ok((len, ctrl_msgs, src))
     }
 
     pub(super) fn shutdown(&self) {

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -291,7 +291,7 @@ impl Socket for UnixDatagramSocket {
         }
 
         let (received_bytes, control_messages, peer_addr) =
-            self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer))?;
+            self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer, flags))?;
 
         let message_header = MessageHeader::new(Some(peer_addr.into()), control_messages);
 

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -14,13 +14,13 @@ use crate::{
         unix::{
             UnixSocketAddr, addr::UnixSocketAddrBound, cred::SocketCred, ctrl_msg::AuxiliaryData,
         },
-        util::{ControlMessage, SockShutdownCmd},
+        util::{ControlMessage, SendRecvFlags, SockShutdownCmd},
     },
     prelude::*,
     process::signal::Pollee,
     util::{
         MultiRead, MultiWrite,
-        ring_buffer::{ConsumerU8Ext, ProducerU8Ext, RbConsumer, RbProducer, RingBuffer},
+        ring_buffer::{ProducerU8Ext, RbConsumer, RbProducer, RingBuffer, RingBufferU8Ext},
     },
 };
 
@@ -117,6 +117,7 @@ impl Connected {
         &self,
         writer: &mut dyn MultiWrite,
         is_seqpacket: bool,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>)> {
         let is_empty = writer.is_empty();
         if is_empty && !is_seqpacket {
@@ -135,14 +136,24 @@ impl Connected {
         let no_aux_len = reader.len();
 
         let is_pass_cred = this_end.is_pass_cred.load(Ordering::Relaxed);
+        let behavior = flags.receive_behavior();
 
         // Fast path: There are no auxiliary data to receive.
         if !peer_end.has_aux.load(Ordering::Relaxed) {
-            let read_len = self
-                .inner
-                .read_with(move || reader.read_fallible_with_max_len(writer, no_aux_len))?;
+            let read_len = self.inner.read_with(|| {
+                let head = reader.head();
+                let copy_range = head..head + Wrapping(no_aux_len);
+                reader.ring_buffer().pick_fallible(copy_range, writer)
+            })?;
+            if behavior.will_consume_data() {
+                reader.commit_read(read_len);
+                if read_len > 0 {
+                    self.inner.notify_read();
+                }
+            }
+
             let ctrl_msgs = if is_pass_cred {
-                AuxiliaryData::default().generate_control(is_pass_cred)
+                AuxiliaryData::default().generate_control(behavior, is_pass_cred)
             } else {
                 Vec::new()
             };
@@ -150,79 +161,116 @@ impl Connected {
         }
 
         let mut all_aux = peer_end.all_aux.lock();
-        let mut aux_prev_data: Option<AuxiliaryData> = None;
-        let mut read_tot_len = 0;
+        let mut aux_pos = 0;
 
-        let aux_data = loop {
-            let read_start = reader.head();
-            let (aux_len, aux_front) = if let Some(front) = all_aux.front_mut() {
+        let read_base = reader.head();
+        let mut read_tot_len = 0;
+        let mut trunc_len = 0;
+
+        loop {
+            let read_start = read_base + Wrapping(read_tot_len);
+            let (aux_len, aux_front) = if let Some(front) = all_aux.get(aux_pos) {
                 if front.start == read_start {
                     ((front.end - read_start).0, Some(front))
                 } else {
                     ((front.start - read_start).0, None)
                 }
             } else {
-                (usize::MAX, None)
+                ((reader.tail() - read_start).0, None)
             };
 
             // Unless the auxiliary data we have already received is a subset of the current
             // auxiliary data, we cannot receive additional bytes.
-            if let Some(prev) = aux_prev_data.as_mut() {
-                let is_subset = if let Some(front) = aux_front.as_ref() {
-                    prev.is_subset_of(&front.data, is_pass_cred)
-                } else {
-                    prev.is_subset_of(&AuxiliaryData::default(), is_pass_cred)
+            if read_tot_len > 0 {
+                let is_subset = match (aux_pos.checked_sub(1), aux_front.as_ref()) {
+                    (Some(prev_pos), Some(front)) => {
+                        let prev = all_aux.get(prev_pos).unwrap();
+                        prev.data.is_subset_of(&front.data, is_pass_cred)
+                    }
+                    (Some(prev_pos), None) => {
+                        let prev = all_aux.get(prev_pos).unwrap();
+                        prev.data
+                            .is_subset_of(&AuxiliaryData::default(), is_pass_cred)
+                    }
+                    (None, Some(front)) => {
+                        AuxiliaryData::default().is_subset_of(&front.data, is_pass_cred)
+                    }
+                    (None, None) => true,
                 };
                 if !is_subset {
-                    break prev;
+                    break;
                 }
             }
 
             // Read the payload bytes of the current auxiliary data.
-            let read_res = if !is_empty && aux_len > 0 {
-                self.inner
-                    .read_with(|| reader.read_fallible_with_max_len(writer, aux_len))
+            let read_res = if !is_empty && (aux_len > 0 || aux_front.is_none()) {
+                self.inner.read_with(|| {
+                    let copy_range = read_start..read_start + Wrapping(aux_len);
+                    reader.ring_buffer().pick_fallible(copy_range, writer)
+                })
             } else {
                 Ok(0)
             };
             let read_len = match read_res {
                 Ok(read_len) => read_len,
-                Err(_) if read_tot_len > 0 => break aux_prev_data.as_mut().unwrap(),
+                Err(_) if read_tot_len > 0 => break,
                 Err(err) => return Err(err),
             };
+
             read_tot_len += read_len;
+            if aux_front.is_some() {
+                aux_pos += 1;
+            }
 
             // Record the current auxiliary data. Break if the read is incomplete or this is a
             // `SOCK_SEQPACKET` socket.
             if is_seqpacket {
-                aux_prev_data = Some(all_aux.pop_front().unwrap().data);
                 if read_len < aux_len {
                     warn!("setting MSG_TRUNC is not supported");
-                    reader.skip(aux_len - read_len);
+                    trunc_len = aux_len - read_len;
                 }
-                break aux_prev_data.as_mut().unwrap();
-            } else if let Some(front) = aux_front {
-                if read_len < aux_len {
-                    front.start += read_len;
-                    break &mut front.data;
-                }
-                aux_prev_data = Some(all_aux.pop_front().unwrap().data);
-            } else {
-                aux_prev_data = Some(AuxiliaryData::default());
-                if read_len < aux_len {
-                    break aux_prev_data.as_mut().unwrap();
-                }
+                break;
+            } else if read_len < aux_len {
+                break;
             }
-        };
+        }
 
+        // Consume the payload bytes that we've read.
+        if behavior.will_consume_data() {
+            let consume_tot_len = read_tot_len + trunc_len;
+            reader.commit_read(consume_tot_len);
+            if consume_tot_len > 0 {
+                self.inner.notify_read();
+            }
+        }
         drop(reader);
 
-        let ctrl_msgs = aux_data.generate_control(is_pass_cred);
-        debug_assert!(is_seqpacket || read_tot_len != 0);
-        peer_end
-            .has_aux
-            .store(!all_aux.is_empty(), Ordering::Relaxed);
+        // Consume the auxiliary data that we've read.
+        let ctrl_msgs = if aux_pos >= 1 {
+            let aux_data = all_aux.get_mut(aux_pos - 1).unwrap();
+            debug_assert!((aux_data.start - read_base).0 <= read_tot_len);
 
+            let ctrl_msgs = aux_data.data.generate_control(behavior, is_pass_cred);
+            if behavior.will_consume_data() {
+                let remaining_aux_count = all_aux.len() - (aux_pos - 1);
+                all_aux.truncate_front(remaining_aux_count);
+                let consume_len = read_tot_len + trunc_len;
+                if (all_aux.front().unwrap().end - read_base).0 <= consume_len {
+                    all_aux.pop_front();
+                } else {
+                    all_aux.front_mut().unwrap().start = read_base + Wrapping(consume_len);
+                }
+                peer_end
+                    .has_aux
+                    .store(!all_aux.is_empty(), Ordering::Relaxed);
+            }
+            ctrl_msgs
+        } else {
+            let mut default_aux_data = AuxiliaryData::default();
+            default_aux_data.generate_control(behavior, is_pass_cred)
+        };
+
+        debug_assert!(is_seqpacket || read_tot_len != 0);
         Ok((read_tot_len, ctrl_msgs))
     }
 
@@ -253,12 +301,11 @@ impl Connected {
         // Fast path: There are no auxiliary data to transmit.
         if aux_data.is_empty() && !is_seqpacket && !need_pass_cred {
             let mut writer = this_end.writer.lock();
-            return self.inner.write_with(move || {
-                if is_seqpacket && writer.free_len() < reader.sum_lens() {
-                    return Ok(0);
-                }
-                writer.write_fallible(reader)
-            });
+            let write_len = self
+                .inner
+                .write_with(move || writer.write_fallible(reader))?;
+            self.inner.notify_write();
+            return Ok(write_len);
         }
 
         let mut all_aux = this_end.all_aux.lock();
@@ -299,6 +346,8 @@ impl Connected {
             end: write_start + Wrapping(write_len),
         };
         all_aux.push_back(aux_range);
+
+        self.inner.notify_write();
 
         Ok(write_len)
     }

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -229,10 +229,10 @@ impl UnixStreamSocket {
     fn try_recv(
         &self,
         buf: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<(usize, Vec<ControlMessage>)> {
         match self.state.read().as_ref() {
-            State::Connected(connected) => connected.try_read(buf, self.is_seqpacket),
+            State::Connected(connected) => connected.try_read(buf, self.is_seqpacket, flags),
             State::Init(_) | State::Listen(_) => {
                 return_errno_with_message!(Errno::EINVAL, "the socket is not connected")
             }

--- a/kernel/src/net/socket/util/send_recv_flags.rs
+++ b/kernel/src/net/socket/util/send_recv_flags.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_bigtcp::socket::ReceiveBehavior;
+
 use crate::prelude::*;
 
 bitflags! {
@@ -37,11 +39,20 @@ bitflags! {
 
 impl SendRecvFlags {
     fn supported_flags() -> Self {
-        SendRecvFlags::empty()
+        SendRecvFlags::MSG_PEEK
     }
 
     pub fn is_all_supported(&self) -> bool {
         let supported_flags = Self::supported_flags();
         supported_flags.contains(*self)
+    }
+
+    /// Returns whether receive operations should consume or peek data.
+    pub fn receive_behavior(&self) -> ReceiveBehavior {
+        if self.contains(SendRecvFlags::MSG_PEEK) {
+            ReceiveBehavior::Peek
+        } else {
+            ReceiveBehavior::Recv
+        }
     }
 }

--- a/kernel/src/net/socket/vsock/transport/connection/recv.rs
+++ b/kernel/src/net/socket/vsock/transport/connection/recv.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_bigtcp::socket::ReceiveBehavior;
 use aster_virtio::device::socket::{header::VirtioVsockOp, packet::RxPacket};
 
 use crate::{
@@ -19,7 +20,7 @@ impl Connection {
     pub(in crate::net::socket::vsock) fn try_recv(
         &mut self,
         writer: &mut dyn MultiWrite,
-        _flags: SendRecvFlags,
+        flags: SendRecvFlags,
     ) -> Result<usize> {
         // We use a packet-pool approach here so a receive attempt either completes for the chosen
         // packets or leaves the receive queue unchanged.
@@ -50,15 +51,19 @@ impl Connection {
         // Packets can only be received from a `&mut connection`. Therefore, releasing the state
         // lock does not cause race conditions. We need to release the lock in order to copy to
         // userspace.
-        let result = packets.copy_to_userspace(writer);
+        let behavior = flags.receive_behavior();
+        let result = packets.copy_to_userspace(writer, behavior);
         let recv_len = *result.as_ref().unwrap_or(&0);
 
-        self.inner
-            .state
-            .lock()
-            .ungrab_packets_and_finish_recv(&self.inner, packets, recv_len);
-
-        self.inner.pollee.invalidate();
+        if behavior.will_consume_data() {
+            self.inner
+                .state
+                .lock()
+                .ungrab_packets_and_finish_recv(&self.inner, packets, recv_len);
+            self.inner.pollee.invalidate();
+        } else {
+            self.inner.state.lock().undo_pop_rx_packets(packets);
+        }
 
         result
     }
@@ -70,7 +75,11 @@ struct PoppedRxPackets<'a> {
 }
 
 impl PoppedRxPackets<'_> {
-    fn copy_to_userspace(&mut self, writer: &mut dyn MultiWrite) -> Result<usize> {
+    fn copy_to_userspace(
+        &mut self,
+        writer: &mut dyn MultiWrite,
+        behavior: ReceiveBehavior,
+    ) -> Result<usize> {
         let mut read_offset = self.read_offset;
         let mut total_write_len = 0;
 
@@ -84,18 +93,22 @@ impl PoppedRxPackets<'_> {
             total_write_len += write_len;
 
             if payload.has_remain() {
-                read_offset += write_len;
-
-                self.skip_packets(i);
-                self.read_offset = read_offset;
+                if behavior.will_consume_data() {
+                    read_offset += write_len;
+                    self.skip_packets(i);
+                    self.read_offset = read_offset;
+                }
                 return Ok(total_write_len);
             }
 
             read_offset = 0;
         }
 
-        self.packets = &mut [];
-        self.read_offset = 0;
+        if behavior.will_consume_data() {
+            self.packets = &mut [];
+            self.read_offset = 0;
+        }
+
         Ok(total_write_len)
     }
 

--- a/kernel/src/util/ring_buffer.rs
+++ b/kernel/src/util/ring_buffer.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::Deref;
+use core::{
+    num::Wrapping,
+    ops::{Deref, Range},
+};
 
 use ostd::mm::io::util::HasVmReaderWriter;
 pub use ring_buffer::{Consumer, Producer, RbConsumer, RbProducer, RingBuffer};
@@ -64,6 +67,48 @@ impl<R: Deref<Target = RingBuffer<u8>>> ProducerU8Ext for Producer<u8, R> {
     }
 }
 
+/// Extension methods for byte ring buffers.
+pub trait RingBufferU8Ext {
+    /// Picks data from an absolute ring-counter range into `writer` without consuming it.
+    ///
+    /// Returns the number of bytes copied.
+    fn pick_fallible(
+        &self,
+        range: Range<Wrapping<usize>>,
+        writer: &mut dyn MultiWrite,
+    ) -> Result<usize>;
+}
+
+impl RingBufferU8Ext for RingBuffer<u8> {
+    fn pick_fallible(
+        &self,
+        range: Range<Wrapping<usize>>,
+        writer: &mut dyn MultiWrite,
+    ) -> Result<usize> {
+        let len = (range.end - range.start).0;
+        let offset = range.start.0 & (self.capacity() - 1);
+
+        if offset + len > self.capacity() {
+            // Read from two separate parts
+            let mut read_len = 0;
+
+            let mut reader = self.segment().reader();
+            reader.skip(offset).limit(self.capacity() - offset);
+            read_len += writer.write(&mut reader)?;
+
+            let mut reader = self.segment().reader();
+            reader.limit(len - (self.capacity() - offset));
+            read_len += writer.write(&mut reader)?;
+
+            Ok(read_len)
+        } else {
+            let mut reader = self.segment().reader();
+            reader.skip(offset).limit(len);
+            Ok(writer.write(&mut reader)?)
+        }
+    }
+}
+
 /// Extension methods for reading bytes from a [`Consumer<u8, _>`].
 pub trait ConsumerU8Ext {
     /// Reads data from the ring buffer into `writer`.
@@ -92,29 +137,10 @@ impl<R: Deref<Target = RingBuffer<u8>>> ConsumerU8Ext for Consumer<u8, R> {
         max_len: usize,
     ) -> Result<usize> {
         let len = self.len().min(max_len);
-
         let head = self.head();
-        let offset = head.0 & (self.capacity() - 1);
-
-        let read_len = if offset + len > self.capacity() {
-            // Read from two separate parts
-            let mut read_len = 0;
-
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(self.capacity() - offset);
-            read_len += writer.write(&mut reader)?;
-
-            let mut reader = self.segment().reader();
-            reader.limit(len - (self.capacity() - offset));
-            read_len += writer.write(&mut reader)?;
-
-            read_len
-        } else {
-            let mut reader = self.segment().reader();
-            reader.skip(offset).limit(len);
-            writer.write(&mut reader)?
-        };
-
+        let read_len = self
+            .ring_buffer()
+            .pick_fallible(head..head + Wrapping(len), writer)?;
         self.commit_read(read_len);
         Ok(read_len)
     }

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_dgram_local_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_dgram_local_test
@@ -1,6 +1,5 @@
-# TODO: Support `MSG_DONTWAIT` and `MSG_PEEK`
+# TODO: Support `MSG_DONTWAIT`
 DgramUnixSockets/NonStreamSocketPairTest.SplitRecv/*
-DgramUnixSockets/NonStreamSocketPairTest.SinglePeek/*
 DgramUnixSockets/NonStreamSocketPairTest.RecvmsgTruncPeekDontwaitZeroLen/*
 
 # TODO: Support `SO_SNDTIMEO`

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_pair_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_pair_test
@@ -17,6 +17,3 @@ AllUnixDomainSockets/UnixSocketPairCmsgTest.CredPassTruncatedMsgCtrunc/*
 
 # TODO: Support `MSG_CMSG_CLOEXEC`
 AllUnixDomainSockets/UnixSocketPairCmsgTest.CloexecRecvFDPass/*
-
-# TODO: Support `MSG_PEEK`
-AllUnixDomainSockets/UnixSocketPairCmsgTest.FDPassPeek/*

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_seqpacket_local_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_seqpacket_local_test
@@ -1,6 +1,5 @@
-# TODO: Support `MSG_DONTWAIT` and `MSG_PEEK`
+# TODO: Support `MSG_DONTWAIT`
 SeqpacketUnixSockets/NonStreamSocketPairTest.SplitRecv/*
-SeqpacketUnixSockets/NonStreamSocketPairTest.SinglePeek/*
 SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgTruncPeekDontwaitZeroLen/*
 
 # TODO: Support `SO_SNDTIMEO`

--- a/test/initramfs/src/regression/network/msg_peek.c
+++ b/test/initramfs/src/regression/network/msg_peek.c
@@ -331,3 +331,73 @@ FN_TEST(unix_raw_msg_peek)
 	SOCKETPAIR_CLOSE();
 }
 END_TEST()
+
+static int send_getlink_request(int fd, unsigned int seq)
+{
+	struct {
+		struct nlmsghdr hdr;
+		struct ifinfomsg info;
+	} req = {
+		.hdr = {
+			.nlmsg_len = sizeof(req),
+			.nlmsg_type = RTM_GETLINK,
+			.nlmsg_flags = NLM_F_REQUEST,
+			.nlmsg_seq = seq,
+		},
+		.info = {
+			.ifi_family = AF_UNSPEC,
+			.ifi_change = 0xffffffff,
+		},
+	};
+	return send(fd, &req, sizeof(req), 0) == sizeof(req) ? 0 : -1;
+}
+
+FN_TEST(netlink_raw_msg_peek)
+{
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+	int fd;
+	int msg_flags = 0;
+	char peek_buf[8192] = {};
+	char recv_buf[8192] = {};
+	ssize_t peek_len;
+
+	fd = TEST_SUCC(socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE));
+	TEST_SUCC(bind(fd, (struct sockaddr *)&addr, sizeof(addr)));
+
+	TEST_RES(send_getlink_request(fd, 1), _ret == 0);
+
+	peek_len = TEST_RES(peek_message(fd, peek_buf, sizeof(peek_buf),
+					 &msg_flags),
+			    _ret > 0 && (msg_flags & MSG_TRUNC) == 0);
+
+	TEST_RES(recv(fd, recv_buf, sizeof(recv_buf), 0),
+		 _ret == peek_len && memcmp(recv_buf, peek_buf, peek_len) == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(netlink_dgram_msg_peek)
+{
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+	int fd;
+	int msg_flags = 0;
+	char peek_buf[8192] = {};
+	char recv_buf[8192] = {};
+	ssize_t peek_len;
+
+	fd = TEST_SUCC(socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE));
+	TEST_SUCC(bind(fd, (struct sockaddr *)&addr, sizeof(addr)));
+
+	TEST_RES(send_getlink_request(fd, 2), _ret == 0);
+
+	peek_len = TEST_RES(peek_message(fd, peek_buf, sizeof(peek_buf),
+					 &msg_flags),
+			    _ret > 0 && (msg_flags & MSG_TRUNC) == 0);
+
+	TEST_RES(recv(fd, recv_buf, sizeof(recv_buf), 0),
+		 _ret == peek_len && memcmp(recv_buf, peek_buf, peek_len) == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/msg_peek.c
+++ b/test/initramfs/src/regression/network/msg_peek.c
@@ -80,3 +80,36 @@ FN_SETUP(close_tcp_listener)
 	CHECK(close(tcp_listener));
 }
 END_SETUP()
+
+FN_TEST(udp_msg_peek)
+{
+	int send_fd;
+	int recv_fd;
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+	struct sockaddr_in addr = { .sin_family = AF_INET };
+	socklen_t addr_len = sizeof(addr);
+
+	send_fd = TEST_SUCC(socket(AF_INET, SOCK_DGRAM, 0));
+	recv_fd = TEST_SUCC(socket(AF_INET, SOCK_DGRAM, 0));
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	TEST_SUCC(bind(recv_fd, (struct sockaddr *)&addr, sizeof(addr)));
+	TEST_SUCC(getsockname(recv_fd, (struct sockaddr *)&addr, &addr_len));
+	TEST_SUCC(connect(send_fd, (struct sockaddr *)&addr, addr_len));
+
+	TEST_RES(send(send_fd, PAYLOAD, PAYLOAD_LEN, 0), _ret == PAYLOAD_LEN);
+
+	// Peeking a datagram must not consume the datagram.
+	TEST_RES(peek_message(recv_fd, buf, PAYLOAD_LEN, &msg_flags),
+		 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(recv_fd, buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN && memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	TEST_SUCC(close(send_fd));
+	TEST_SUCC(close(recv_fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/msg_peek.c
+++ b/test/initramfs/src/regression/network/msg_peek.c
@@ -31,6 +31,48 @@ static socklen_t tcp_addr_len = sizeof(tcp_addr);
 		TEST_SUCC(usleep(APPEND_SETTLE_USEC));      \
 	} while (0)
 
+#define UNIX_STREAM_WAIT_APPENDED_READABLE() \
+	TEST_SUCC(usleep(APPEND_SETTLE_USEC))
+
+#define UNIX_STREAM_CONNECT()                                        \
+	do {                                                         \
+		int fds[2] = { -1, -1 };                             \
+		TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, fds)); \
+		send_fd = fds[0];                                    \
+		recv_fd = fds[1];                                    \
+	} while (0)
+
+#define SOCKETPAIR_CONNECT(socket_type) \
+	TEST_SUCC(socketpair(AF_UNIX, (socket_type), 0, fds))
+
+#define SOCKETPAIR_CLOSE()                \
+	do {                              \
+		TEST_SUCC(close(fds[0])); \
+		TEST_SUCC(close(fds[1])); \
+	} while (0)
+
+#define SOCKETPAIR_SEND(offset, len)                         \
+	TEST_RES(send(fds[0], PAYLOAD + (offset), (len), 0), \
+		 _ret == (ssize_t)(len))
+
+#define SOCKETPAIR_PEEK(offset, len)                                           \
+	do {                                                                   \
+		memset(buf, 0, sizeof(buf));                                   \
+		msg_flags = 0;                                                 \
+		TEST_RES(peek_message(fds[1], buf, (len), &msg_flags),         \
+			 _ret == (ssize_t)(len) &&                             \
+				 (msg_flags & MSG_TRUNC) == 0 &&               \
+				 memcmp(buf, PAYLOAD + (offset), (len)) == 0); \
+	} while (0)
+
+#define SOCKETPAIR_RECV(offset, len)                                           \
+	do {                                                                   \
+		memset(buf, 0, sizeof(buf));                                   \
+		TEST_RES(recv(fds[1], buf, (len), 0),                          \
+			 _ret == (ssize_t)(len) &&                             \
+				 memcmp(buf, PAYLOAD + (offset), (len)) == 0); \
+	} while (0)
+
 static ssize_t peek_message(int fd, char *buf, size_t len, int *msg_flags)
 {
 	struct iovec iov = { .iov_base = buf, .iov_len = len };
@@ -111,5 +153,147 @@ FN_TEST(udp_msg_peek)
 
 	TEST_SUCC(close(send_fd));
 	TEST_SUCC(close(recv_fd));
+}
+END_TEST()
+
+#define PREFIX unix_stream_
+#define CONNECT() UNIX_STREAM_CONNECT()
+#define WAIT_APPENDED_READABLE() UNIX_STREAM_WAIT_APPENDED_READABLE()
+#include "msg_peek_stream.h"
+#undef PREFIX
+#undef CONNECT
+#undef WAIT_APPENDED_READABLE
+
+FN_TEST(unix_stream_msg_peek_with_passcred)
+{
+	int fds[2] = { -1, -1 };
+	int optval = 1;
+	char buf[PAYLOAD_LEN] = {};
+	char control[CMSG_SPACE(sizeof(struct ucred))] = {};
+	struct iovec iov = { .iov_base = buf, .iov_len = sizeof(buf) };
+	struct msghdr msg = {
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = control,
+		.msg_controllen = sizeof(control),
+	};
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+	TEST_SUCC(setsockopt(fds[1], SOL_SOCKET, SO_PASSCRED, &optval,
+			     sizeof(optval)));
+
+	TEST_RES(send(fds[0], PAYLOAD, SHORT_LEN, 0), _ret == SHORT_LEN);
+	TEST_RES(send(fds[0], PAYLOAD + SHORT_LEN, PAYLOAD_LEN - SHORT_LEN, 0),
+		 _ret == PAYLOAD_LEN - SHORT_LEN);
+
+	TEST_RES(recvmsg(fds[1], &msg, MSG_PEEK),
+		 _ret == PAYLOAD_LEN && (msg.msg_flags & MSG_CTRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+	TEST_RES(CMSG_FIRSTHDR(&msg),
+		 _ret != NULL && _ret->cmsg_level == SOL_SOCKET &&
+			 _ret->cmsg_type == SCM_CREDENTIALS &&
+			 _ret->cmsg_len >= CMSG_LEN(sizeof(struct ucred)));
+
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(recv(fds[1], buf, sizeof(buf), 0),
+		 _ret == PAYLOAD_LEN && memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(unix_seqpacket_msg_peek)
+{
+	int fds[2] = { -1, -1 };
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN * 2] = {};
+
+	SOCKETPAIR_CONNECT(SOCK_SEQPACKET);
+
+	SOCKETPAIR_SEND(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_PEEK(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_RECV(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_SEND(0, PAYLOAD_LEN);
+	SOCKETPAIR_SEND(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+
+	memset(buf, 0, sizeof(buf));
+	msg_flags = 0;
+	TEST_RES(peek_message(fds[1], buf, sizeof(buf), &msg_flags),
+		 _ret == PAYLOAD_LEN && (msg_flags & MSG_TRUNC) == 0 &&
+			 memcmp(buf, PAYLOAD, PAYLOAD_LEN) == 0);
+
+	SOCKETPAIR_RECV(0, PAYLOAD_LEN);
+	SOCKETPAIR_RECV(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+
+	SOCKETPAIR_CLOSE();
+}
+END_TEST()
+
+FN_TEST(unix_seqpacket_msg_peek_with_scm_rights)
+{
+	int fds[2] = { -1, -1 };
+	int pipe_fds[2] = { -1, -1 };
+	int *cdata;
+	char buf[1] = {};
+	char control[CMSG_SPACE(sizeof(int))] = {};
+	struct iovec iov = { .iov_base = buf, .iov_len = 0 };
+	struct msghdr msg = {
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = control,
+		.msg_controllen = sizeof(control),
+	};
+	struct cmsghdr *chdr = CMSG_FIRSTHDR(&msg);
+	int peeked_fd;
+	int received_fd;
+
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fds));
+	TEST_SUCC(pipe(pipe_fds));
+
+	chdr->cmsg_level = SOL_SOCKET;
+	chdr->cmsg_type = SCM_RIGHTS;
+	chdr->cmsg_len = CMSG_LEN(sizeof(int));
+	cdata = (int *)CMSG_DATA(chdr);
+	cdata[0] = pipe_fds[0];
+	TEST_RES(sendmsg(fds[0], &msg, 0), _ret == 0);
+
+	memset(control, 0, sizeof(control));
+	msg.msg_controllen = sizeof(control);
+	TEST_RES(recvmsg(fds[1], &msg, MSG_PEEK),
+		 _ret == 0 && (msg.msg_flags & MSG_CTRUNC) == 0 &&
+			 (chdr = CMSG_FIRSTHDR(&msg)) &&
+			 chdr->cmsg_level == SOL_SOCKET &&
+			 chdr->cmsg_type == SCM_RIGHTS &&
+			 chdr->cmsg_len >= CMSG_LEN(sizeof(int)));
+	cdata = (int *)CMSG_DATA(chdr);
+	peeked_fd = cdata[0];
+
+	TEST_RES(write(pipe_fds[1], "p", 1), _ret == 1);
+	TEST_RES(read(peeked_fd, buf, 1), _ret == 1 && buf[0] == 'p');
+
+	memset(control, 0, sizeof(control));
+	msg.msg_controllen = sizeof(control);
+	TEST_RES(recvmsg(fds[1], &msg, 0),
+		 _ret == 0 && (msg.msg_flags & MSG_CTRUNC) == 0 &&
+			 (chdr = CMSG_FIRSTHDR(&msg)) &&
+			 chdr->cmsg_level == SOL_SOCKET &&
+			 chdr->cmsg_type == SCM_RIGHTS &&
+			 chdr->cmsg_len >= CMSG_LEN(sizeof(int)));
+	cdata = (int *)CMSG_DATA(chdr);
+	received_fd = cdata[0];
+
+	TEST_RES(write(pipe_fds[1], "r", 1), _ret == 1);
+	TEST_RES(read(received_fd, buf, 1), _ret == 1 && buf[0] == 'r');
+
+	TEST_SUCC(close(peeked_fd));
+	TEST_SUCC(close(received_fd));
+	TEST_SUCC(close(pipe_fds[0]));
+	TEST_SUCC(close(pipe_fds[1]));
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
 }
 END_TEST()

--- a/test/initramfs/src/regression/network/msg_peek.c
+++ b/test/initramfs/src/regression/network/msg_peek.c
@@ -297,3 +297,37 @@ FN_TEST(unix_seqpacket_msg_peek_with_scm_rights)
 	TEST_SUCC(close(fds[1]));
 }
 END_TEST()
+
+FN_TEST(unix_dgram_msg_peek)
+{
+	int fds[2] = { -1, -1 };
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	SOCKETPAIR_CONNECT(SOCK_DGRAM);
+
+	SOCKETPAIR_SEND(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_PEEK(0, PAYLOAD_LEN);
+	SOCKETPAIR_RECV(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_CLOSE();
+}
+END_TEST()
+
+FN_TEST(unix_raw_msg_peek)
+{
+	int fds[2] = { -1, -1 };
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	SOCKETPAIR_CONNECT(SOCK_RAW);
+
+	SOCKETPAIR_SEND(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_PEEK(0, PAYLOAD_LEN);
+	SOCKETPAIR_RECV(0, PAYLOAD_LEN);
+
+	SOCKETPAIR_CLOSE();
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/msg_peek.c
+++ b/test/initramfs/src/regression/network/msg_peek.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define PAYLOAD "abcdef"
+#define PAYLOAD_LEN 6
+#define APPEND_SETTLE_USEC 100000
+#define SHORT_LEN 3
+
+static int tcp_listener;
+static struct sockaddr_in tcp_addr = { .sin_family = AF_INET };
+static socklen_t tcp_addr_len = sizeof(tcp_addr);
+
+#define TCP_CONNECT() refresh_connection(&send_fd, &recv_fd)
+
+#define TCP_WAIT_APPENDED_READABLE()                        \
+	do {                                                \
+		/*                                        \
+		 * `poll` cannot wait for the suffix here \
+		 * because the peeked prefix keeps the    \
+		 * receive side readable.                 \
+		 */ \
+		TEST_SUCC(usleep(APPEND_SETTLE_USEC));      \
+	} while (0)
+
+static ssize_t peek_message(int fd, char *buf, size_t len, int *msg_flags)
+{
+	struct iovec iov = { .iov_base = buf, .iov_len = len };
+	struct msghdr msg = { .msg_iov = &iov, .msg_iovlen = 1 };
+	ssize_t ret = recvmsg(fd, &msg, MSG_PEEK);
+
+	if (ret >= 0)
+		*msg_flags = msg.msg_flags;
+	return ret;
+}
+
+FN_SETUP(create_tcp_listener)
+{
+	tcp_listener = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	tcp_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	CHECK(bind(tcp_listener, (struct sockaddr *)&tcp_addr, tcp_addr_len));
+	CHECK(getsockname(tcp_listener, (struct sockaddr *)&tcp_addr,
+			  &tcp_addr_len));
+	CHECK(listen(tcp_listener, 1));
+}
+END_SETUP()
+
+static void refresh_connection(int *send_fd, int *recv_fd)
+{
+	int connected_fd = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+	int accepted_fd;
+
+	CHECK(connect(connected_fd, (struct sockaddr *)&tcp_addr,
+		      tcp_addr_len));
+	accepted_fd = CHECK(accept(tcp_listener, NULL, NULL));
+
+	*send_fd = connected_fd;
+	*recv_fd = accepted_fd;
+}
+
+#define PREFIX tcp_
+#define CONNECT() TCP_CONNECT()
+#define WAIT_APPENDED_READABLE() TCP_WAIT_APPENDED_READABLE()
+#include "msg_peek_stream.h"
+#undef PREFIX
+#undef CONNECT
+#undef WAIT_APPENDED_READABLE
+
+FN_SETUP(close_tcp_listener)
+{
+	CHECK(close(tcp_listener));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/network/msg_peek_stream.h
+++ b/test/initramfs/src/regression/network/msg_peek_stream.h
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#define TEST_NAME(name) TEST_NAME1(PREFIX, name)
+#define TEST_NAME1(prefix, name) TEST_NAME2(prefix, name)
+#define TEST_NAME2(prefix, name) prefix##name
+#define DEFINE_TEST(name) DEFINE_TEST1(TEST_NAME(name))
+#define DEFINE_TEST1(name) FN_TEST(name)
+
+#define FDS()        \
+	int send_fd; \
+	int recv_fd
+
+#define SEND(offset, len)                                     \
+	TEST_RES(send(send_fd, PAYLOAD + (offset), (len), 0), \
+		 _ret == (ssize_t)(len))
+
+#define PEEK(offset, len)                                                      \
+	do {                                                                   \
+		memset(buf, 0, sizeof(buf));                                   \
+		msg_flags = 0;                                                 \
+		TEST_RES(peek_message(recv_fd, buf, (len), &msg_flags),        \
+			 _ret == (ssize_t)(len) &&                             \
+				 (msg_flags & MSG_TRUNC) == 0 &&               \
+				 memcmp(buf, PAYLOAD + (offset), (len)) == 0); \
+	} while (0)
+
+#define RECV(offset, len)                                                      \
+	do {                                                                   \
+		memset(buf, 0, sizeof(buf));                                   \
+		TEST_RES(recv(recv_fd, buf, (len), 0),                         \
+			 _ret == (ssize_t)(len) &&                             \
+				 memcmp(buf, PAYLOAD + (offset), (len)) == 0); \
+	} while (0)
+
+#define CLOSE()                            \
+	do {                               \
+		TEST_SUCC(close(send_fd)); \
+		TEST_SUCC(close(recv_fd)); \
+	} while (0)
+
+DEFINE_TEST(short_peek_short_reads)
+{
+	FDS();
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	CONNECT();
+
+	SEND(0, PAYLOAD_LEN);
+	PEEK(0, SHORT_LEN);
+	RECV(0, SHORT_LEN);
+	RECV(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+
+	CLOSE();
+}
+END_TEST()
+
+DEFINE_TEST(short_peek_full_read)
+{
+	FDS();
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	CONNECT();
+
+	SEND(0, PAYLOAD_LEN);
+	PEEK(0, SHORT_LEN);
+	RECV(0, PAYLOAD_LEN);
+
+	CLOSE();
+}
+END_TEST()
+
+DEFINE_TEST(full_peek_short_reads)
+{
+	FDS();
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	CONNECT();
+
+	SEND(0, PAYLOAD_LEN);
+	PEEK(0, PAYLOAD_LEN);
+	RECV(0, SHORT_LEN);
+	RECV(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+
+	CLOSE();
+}
+END_TEST()
+
+DEFINE_TEST(append_after_peek_short_reads)
+{
+	FDS();
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	CONNECT();
+
+	SEND(0, SHORT_LEN);
+	PEEK(0, SHORT_LEN);
+
+	SEND(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+	WAIT_APPENDED_READABLE();
+	RECV(0, SHORT_LEN);
+	RECV(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+
+	CLOSE();
+}
+END_TEST()
+
+DEFINE_TEST(append_after_peek_full_read)
+{
+	FDS();
+	int msg_flags = 0;
+	char buf[PAYLOAD_LEN] = {};
+
+	CONNECT();
+
+	SEND(0, SHORT_LEN);
+	PEEK(0, SHORT_LEN);
+
+	SEND(SHORT_LEN, PAYLOAD_LEN - SHORT_LEN);
+	WAIT_APPENDED_READABLE();
+	RECV(0, PAYLOAD_LEN);
+
+	CLOSE();
+}
+END_TEST()
+
+#undef TEST_NAME
+#undef TEST_NAME1
+#undef TEST_NAME2
+#undef DEFINE_TEST
+#undef DEFINE_TEST1
+#undef FDS
+#undef SEND
+#undef PEEK
+#undef RECV
+#undef CLOSE

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -17,6 +17,7 @@ sleep 0.2
 ./unix_client
 
 ./listen_backlog
+./msg_peek
 ./privileged_ports
 ./send_buf_full
 ./sendmmsg


### PR DESCRIPTION
This PR is part of #3202. I moved the `MSG_PEEK` implementation here since #3202 has grown quite large.

`MSG_PEEK` allows receiving a message without consuming the data from the buffer.

One issue I encountered during implementation involves how TCP sockets handle wrap-around in the ring buffer — that is, when a read reaches the end of the ring buffer but the remaining data wraps around to the beginning. Currently, this is handled by issuing two separate receive calls to ensure both segments are fully read. However, this becomes problematic for MSG_PEEK: with the current approach, a peek can only return the segment up to the end of the ring buffer. To also retrieve the wrapped-around segment at the beginning, we would need to first consume the first segment via a regular receive, and then issue another peek — which defeats the purpose.

I also considered maintaining a temporary peek buffer inside the socket, but this does not seem ideal either, as it would introduce an additional memory copy. For now, this wrap-around case is left unhandled.