### PR TITLE
Fix access mode validation

### DIFF
--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -13,7 +13,7 @@ use crate::{
 pub fn sys_faccessat(
     dirfd: RawFileDesc,
     path_ptr: Vaddr,
-    mode: u16,
+    mode: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!(
@@ -24,7 +24,7 @@ pub fn sys_faccessat(
     do_faccessat(dirfd, path_ptr, mode, 0, ctx)
 }
 
-pub fn sys_access(path_ptr: Vaddr, mode: u16, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_access(path_ptr: Vaddr, mode: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("access: path_ptr = {:#x}, mode = {:o}", path_ptr, mode);
 
     do_faccessat(AT_FDCWD, path_ptr, mode, 0, ctx)
@@ -33,7 +33,7 @@ pub fn sys_access(path_ptr: Vaddr, mode: u16, ctx: &Context) -> Result<SyscallRe
 pub fn sys_faccessat2(
     dirfd: RawFileDesc,
     path_ptr: Vaddr,
-    mode: u16,
+    mode: u32,
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
@@ -54,7 +54,7 @@ bitflags! {
 }
 
 bitflags! {
-    struct AccessMode: u16 {
+    struct AccessMode: u32 {
         const R_OK = 0x4;
         const W_OK = 0x2;
         const X_OK = 0x1;
@@ -66,7 +66,7 @@ bitflags! {
 fn do_faccessat(
     dirfd: RawFileDesc,
     path_ptr: Vaddr,
-    mode: u16,
+    mode: u32,
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {

--- a/test/initramfs/src/conformance/gvisor/blocklists/access_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/access_test
@@ -1,2 +1,0 @@
-AccessTest.InvalidModeRoot
-AccessTest.InvalidModes

--- a/test/initramfs/src/regression/io/file_io/access_err.c
+++ b/test/initramfs/src/regression/io/file_io/access_err.c
@@ -42,6 +42,16 @@ FN_SETUP(create)
 }
 END_SETUP()
 
+FN_TEST(access_mode)
+{
+	TEST_ERRNO(access(FILENAME, 0x10000), EINVAL);
+	TEST_ERRNO(access(FILENAME, -1), EINVAL);
+	TEST_ERRNO(faccessat(AT_FDCWD, FILENAME, 0x10000, 0), EINVAL);
+	TEST_ERRNO(syscall(SYS_faccessat2, AT_FDCWD, FILENAME, 0x10000, 0),
+		   EINVAL);
+}
+END_TEST()
+
 FN_TEST(readable)
 {
 	int fd;

--- a/test/initramfs/src/regression/security/lsm/yama.c
+++ b/test/initramfs/src/regression/security/lsm/yama.c
@@ -15,14 +15,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#ifndef SYS_pidfd_getfd
-#ifdef __NR_pidfd_getfd
-#define SYS_pidfd_getfd __NR_pidfd_getfd
-#elif defined(__x86_64__)
-#define SYS_pidfd_getfd 438
-#endif
-#endif
-
 #include "../../common/test.h"
 
 enum {


### PR DESCRIPTION
## Summary

Fix `access`, `faccessat`, and `faccessat2` mode validation by preserving the full syscall argument width before checking valid `R_OK`/`W_OK`/`X_OK` bits.

Previously, invalid high bits could be truncated before validation, so some invalid modes were treated as valid permission checks instead of returning `EINVAL`.

## Changes

- Use `u32` for the access mode argument and `AccessMode` bitflags.
- Add regression for invalid access modes.
- Unblock the corresponding gVisor `access_test` cases.

## Testing

- `TEST_TMPDIR=/tmp ./access_test --gtest_filter=AccessTest.InvalidModeRoot:AccessTest.InvalidModes`

  ```text
  [==========] 2 tests from 1 test suite ran.
  [  PASSED  ] 2 tests.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  ```

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```