### PR TITLE
Add basic IOMMU support (mainly DMA remapping) for RISC-V

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -28,6 +28,8 @@ sigfault = "sigfault"
 sems = "sems"
 THRE = "THRE"
 TestNG = "TestNG"
+SADE = "SADE"
+GADE = "GADE"
 
 # Files with svg suffix are ignored to check. 
 [type.svg]

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,20 @@ endif
 
 ifneq ($(SCHEME), "")
 CARGO_OSDK_COMMON_ARGS += --scheme $(SCHEME)
+# The iommu scheme needs qemu-direct on riscv64 (no UEFI/GRUB).
+# x86_64 keeps the default grub-rescue-iso from OSDK.toml.
+ifeq ($(SCHEME), iommu)
+	ifeq ($(TARGET_ARCH), riscv64)
+	CARGO_OSDK_COMMON_ARGS += --boot-method="qemu-direct"
+	# QEMU's RISC-V IOMMU emulation places PPN at bits 53:10 instead
+	# of the spec-defined 55:12; enable the corresponding quirk.
+	ifeq ($(FEATURES),)
+		FEATURES := ostd/riscv_iommu_qemu_quirk
+	else
+		FEATURES := $(FEATURES),ostd/riscv_iommu_qemu_quirk
+	endif
+	endif
+endif
 else
 CARGO_OSDK_COMMON_ARGS += --boot-method="$(BOOT_METHOD)"
 endif

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -36,7 +36,7 @@ build.strip_elf = true
 qemu.args = "$(./tools/qemu_args.sh microvm)"
 
 [scheme."iommu"]
-supported_archs = ["x86_64"]
+supported_archs = ["x86_64", "riscv64"]
 qemu.args = "$(./tools/qemu_args.sh iommu)"
 
 [scheme."tdx"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -86,6 +86,7 @@ coverage = ["ostd/coverage"]
 cvm_guest = ["dep:tdx-guest", "ostd/cvm_guest", "aster-virtio/cvm_guest"]
 # By default we use the Sv48 address translation mode.
 riscv_sv39_mode = ["ostd/riscv_sv39_mode"]
+riscv_iommu_qemu_quirk = ["ostd/riscv_iommu_qemu_quirk"]
 
 [lints]
 workspace = true

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -76,6 +76,10 @@ default = ["cvm_guest"]
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
 coverage = ["minicov"]
 riscv_sv39_mode = []
+# Enable the DDT shift quirk required by QEMU's RISC-V IOMMU emulation (PPN
+# at bits 53:10 instead of the spec-defined 55:12). Enable this only when
+# running under QEMU; real hardware follows the spec.
+riscv_iommu_qemu_quirk = []
 
 [lints]
 workspace = true

--- a/ostd/src/arch/riscv/iommu/ddt.rs
+++ b/ostd/src/arch/riscv/iommu/ddt.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device Directory Table (DDT) for the RISC-V IOMMU.
+
+use alloc::collections::BTreeMap;
+
+use super::second_stage::IommuPtConfig;
+use crate::mm::{Frame, FrameAllocOptions, HasPaddr, Paddr, PageTable, VmIo};
+
+// A non-leaf DDT entry.
+//
+// Per the RISC-V IOMMU spec: V at bit 0, 11 reserved bits, PPN at bits 55:12,
+// and 8 reserved bits at the top. QEMU's emulation places PPN at bits 53:10
+// instead; the `riscv_iommu_qemu_quirk` feature (opt-in) enables the shift=10
+// encoding.
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct DdtEntry(u64);
+
+impl DdtEntry {
+    #[cfg(feature = "riscv_iommu_qemu_quirk")]
+    const PPN_SHIFT: u32 = 10;
+    #[cfg(not(feature = "riscv_iommu_qemu_quirk"))]
+    const PPN_SHIFT: u32 = 12;
+    const PPN_MASK: u64 = 0xFFFFFFFFFFF; // 44-bit PPN
+
+    fn is_valid(&self) -> bool {
+        (self.0 & 0x1) != 0
+    }
+
+    fn paddr(&self) -> Paddr {
+        (((self.0 >> Self::PPN_SHIFT) & Self::PPN_MASK) as usize) << 12
+    }
+
+    fn new(paddr: Paddr) -> Self {
+        let ppn = (paddr >> 12) as u64;
+        Self((ppn << Self::PPN_SHIFT) | 0x1)
+    }
+}
+
+// Size in bytes of a Base-format Device Context.
+const DC_SIZE: usize = 32;
+
+// The `MODE` field value for Sv39x4 in `iohgatp` when `fctl.GXL=0`.
+const IOHGATP_MODE_SV39X4: u64 = 8;
+
+/// Errors that can occur during DDT manipulation.
+#[derive(Debug)]
+pub(super) enum DdtError {
+    /// A write to the DDT page failed.
+    ModificationError,
+}
+
+/// Device Directory Table for translating `device_id` to a Device Context.
+pub(super) struct DdtTable {
+    root_frame: Frame<()>,
+    leaf_frames: BTreeMap<Paddr, Frame<()>>,
+}
+
+impl DdtTable {
+    // Entries per root table page (2LVL, base format: 9 bits for DDI[1]).
+    const ROOT_ENTRIES: usize = 1 << 9;
+    // Entries per leaf table page (base format: 7 bits for DDI[0]).
+    const LEAF_ENTRIES: usize = 1 << 7;
+
+    pub(super) fn new() -> Self {
+        Self {
+            root_frame: FrameAllocOptions::new().zeroed(true).alloc_frame().unwrap(),
+            leaf_frames: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the root table physical address.
+    pub(super) fn root_paddr(&self) -> Paddr {
+        self.root_frame.paddr()
+    }
+
+    // Returns the leaf table for `ddi1`, allocating a new zeroed page if absent.
+    fn get_or_create_leaf(&mut self, ddi1: usize) -> Result<&Frame<()>, DdtError> {
+        let root_offset = ddi1 * size_of::<DdtEntry>();
+        let root_entry = self
+            .root_frame
+            .read_val::<DdtEntry>(root_offset)
+            .map_err(|_| DdtError::ModificationError)?;
+
+        if root_entry.is_valid() {
+            let paddr = root_entry.paddr();
+            return Ok(self.leaf_frames.get(&paddr).unwrap());
+        }
+
+        let leaf_frame = FrameAllocOptions::new()
+            .zeroed(true)
+            .alloc_frame()
+            .map_err(|_| DdtError::ModificationError)?;
+        let paddr = leaf_frame.paddr();
+        let entry = DdtEntry::new(paddr);
+        self.root_frame
+            .write_val(root_offset, &entry)
+            .map_err(|_| DdtError::ModificationError)?;
+        self.leaf_frames.insert(paddr, leaf_frame);
+        Ok(self.leaf_frames.get(&paddr).unwrap())
+    }
+
+    /// Writes a Device Context for `device_id` pointing at the given page table.
+    pub(super) fn enable_device(
+        &mut self,
+        device_id: u16,
+        page_table: &PageTable<IommuPtConfig>,
+    ) -> Result<(), DdtError> {
+        let ddi0 = (device_id & 0x7F) as usize;
+        let ddi1 = ((device_id >> 7) & 0x1FF) as usize;
+
+        let leaf = self.get_or_create_leaf(ddi1)?;
+        let dc_offset = ddi0 * DC_SIZE;
+
+        // GSCID is left at 0 because per-VM invalidation is not yet
+        // implemented; all VMs share one invalidation domain.
+        let root_paddr = page_table.root_paddr();
+        let ppn = (root_paddr >> 12) as u64;
+        let iohgatp: u64 = (IOHGATP_MODE_SV39X4 << 60) | ppn;
+        leaf.write_val(dc_offset + 8, &iohgatp)
+            .map_err(|_| DdtError::ModificationError)?;
+
+        let tc: u64 = 0x1;
+        leaf.write_val(dc_offset, &tc)
+            .map_err(|_| DdtError::ModificationError)?;
+
+        // TODO: Issue `IODIR.INVAL_DDT` with DV=1 for the affected `device_id`
+        // after writing a leaf DDT entry. Currently the caller (`init`) issues a
+        // blanket `IOFENCE.C` instead, which is coarser but sufficient.
+
+        Ok(())
+    }
+}

--- a/ostd/src/arch/riscv/iommu/dma_remapping.rs
+++ b/ostd/src/arch/riscv/iommu/dma_remapping.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! DMA remapping for the RISC-V IOMMU.
+//!
+//! The initialization sequence in [`init`] follows spec Chapter 6 software
+//! guidelines: command queue setup (Step 12), fault queue setup (Step 13),
+//! DDT population and activation (Step 15). The DDT is activated last so the
+//! IOMMU never sees partially-initialized state.
+
+use spin::Once;
+
+use super::{
+    IommuError,
+    ddt::DdtTable,
+    queue::{self, Queue},
+    registers,
+    second_stage::IommuPtConfig,
+};
+use crate::{
+    info,
+    mm::{
+        Daddr, PAGE_SIZE, PageProperty, PageTable,
+        page_prop::{CachePolicy, PageFlags, PrivilegedPageFlags as PrivFlags},
+    },
+    prelude::Paddr,
+    sync::{LocalIrqDisabled, SpinLock},
+    task::disable_preempt,
+    warn,
+};
+
+/// Returns `true` if DMA remapping has been initialized and is active.
+pub fn has_dma_remapping() -> bool {
+    PAGE_TABLE.get().is_some()
+}
+
+/// Maps a single page from a device address to a physical address.
+///
+/// # Safety
+///
+/// The physical address must point to untyped DMA memory that outlives this
+/// mapping.
+pub unsafe fn map(daddr: Daddr, paddr: Paddr) -> Result<(), IommuError> {
+    let Some(table) = PAGE_TABLE.get() else {
+        return Err(IommuError::NoIommu);
+    };
+
+    let locked_table = table.lock();
+    let from = daddr..daddr + PAGE_SIZE;
+    let prop = PageProperty {
+        flags: PageFlags::RW,
+        cache: CachePolicy::Uncacheable,
+        priv_flags: PrivFlags::empty(),
+    };
+
+    let preempt_guard = disable_preempt();
+    let mut cursor = locked_table
+        .cursor_mut(&preempt_guard, &from)
+        .map_err(IommuError::ModificationError)?;
+
+    // SAFETY: The caller guarantees that paddr is valid untyped memory.
+    unsafe { cursor.map((paddr, 1, prop)) };
+
+    // TODO: Issue IOTLB invalidation (IOTINVAL.GVMA + IOFENCE.C) so the
+    // IOMMU sees the new PTE. Deferred until hardware testing is possible;
+    // QEMU's IOMMU does not cache translations, so this is not yet needed.
+
+    Ok(())
+}
+
+/// Unmaps a single page at the given device address.
+pub fn unmap(daddr: Daddr) -> Result<(), IommuError> {
+    let Some(table) = PAGE_TABLE.get() else {
+        return Err(IommuError::NoIommu);
+    };
+
+    let locked_table = table.lock();
+    let preempt_guard = disable_preempt();
+    let mut cursor = locked_table
+        .cursor_mut(&preempt_guard, &(daddr..daddr + PAGE_SIZE))
+        .map_err(IommuError::ModificationError)?;
+
+    // SAFETY: Unmapping a page from the IOMMU page table is always safe;
+    // it simply removes a translation that was previously established.
+    let frag = unsafe { cursor.take_next(PAGE_SIZE) };
+    debug_assert!(frag.is_some());
+
+    // TODO: Issue IOTLB invalidation after PTE removal (same rationale as
+    // in `map()`).
+
+    Ok(())
+}
+
+/// Initializes DMA remapping.
+pub fn init() {
+    let caps = {
+        let iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+        iommu_regs.capabilities
+    };
+
+    if !caps.flags().contains(registers::CapabilityFlags::SV39X4) {
+        warn!("Sv39x4 second-stage translation not supported by IOMMU, disabling DMA remapping");
+        return;
+    }
+
+    // Command queue must be set up first so invalidation
+    // commands are available for subsequent steps if needed.
+    let mut cq: Queue<16> = Queue::new();
+    let cq_base = registers::QueueBase::new((cq.base_paddr() >> 12) as u64, cq.log2sz_minus_1());
+    let mut iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+    iommu_regs.cqb.as_mut_ptr().write(cq_base.value());
+    iommu_regs.cqt.as_mut_ptr().write(0);
+    iommu_regs.cqcsr.as_mut_ptr().write(registers::CQCSR_CQEN);
+
+    // CQON should be asserted synchronously after CQEN is written;
+    // give the hardware one pause, then bail if it isn't ready.
+    core::hint::spin_loop();
+    if iommu_regs.cqcsr.as_ptr().read() & registers::CQCSR_CQON == 0 {
+        warn!("Command queue did not become operational, disabling DMA remapping");
+        return;
+    }
+    drop(iommu_regs);
+
+    super::fault::init();
+
+    let mut ddt = DdtTable::new();
+    let page_table = PageTable::<IommuPtConfig>::empty();
+    // TODO: Support multiple `device_id` values by iterating over the PCIe
+    // bus hierarchy (similar to x86's `PciDeviceLocation::all()`). Currently
+    // only `device_id=0` is configured, which covers simple QEMU virt setups
+    // but not real hardware with multiple PCIe endpoints.
+    if let Err(e) = ddt.enable_device(0, &page_table) {
+        warn!("Failed to enable device 0 in DDT: {:?}", e);
+        return;
+    }
+
+    // TODO: Set `DC.tc.SADE=1` and `DC.tc.GADE=1` to enable hardware-managed
+    // Accessed/Dirty bit updates when `capabilities.AMO_HWAD` is set. This
+    // avoids the need for software A/D-bit tracking on second-stage PTEs.
+    // TODO: Write QoS ID into `DC.ta.RCID`/`MCID` when `capabilities.QOSID`
+    // is set, so IOMMU-initiated page table walks are tagged with a QoS
+    // identifier for memory system prioritization.
+
+    // Activate the DDT by writing `ddtp`.
+    let mut iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+
+    let mut ddtp = registers::Ddtp::new();
+    ddtp.set_mode(registers::DDTP_MODE_2LVL as u8);
+    ddtp.set_ppn((ddt.root_paddr() >> 12) as u64);
+    iommu_regs.ddtp.as_mut_ptr().write(ddtp.value());
+
+    // An IOFENCE.C with PR=PW=1 ensures the `ddtp` write is globally
+    // visible and ordered before subsequent operations.
+    let cmd = queue::cmd_iofence_c(true, true);
+    cq.push(&cmd);
+    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+    iommu_regs.cqt.as_mut_ptr().write(cq.tail() as u32);
+    drop(iommu_regs);
+
+    // Transfer ownership to global statics so memory stays alive while the
+    // IOMMU is active.
+    DDT_TABLE.call_once(|| SpinLock::new(ddt));
+    PAGE_TABLE.call_once(|| SpinLock::new(page_table));
+    COMMAND_QUEUE.call_once(|| SpinLock::new(cq));
+
+    info!("DMA remapping enabled (Sv39x4)");
+}
+
+/// Device Directory Table singleton, initialized by [`init`].
+static DDT_TABLE: Once<SpinLock<DdtTable, LocalIrqDisabled>> = Once::new();
+
+/// Shared second-stage page table for all devices, initialized by [`init`].
+static PAGE_TABLE: Once<SpinLock<PageTable<IommuPtConfig>, LocalIrqDisabled>> = Once::new();
+
+/// Command queue singleton for invalidation and fencing commands.
+static COMMAND_QUEUE: Once<SpinLock<Queue<16>, LocalIrqDisabled>> = Once::new();

--- a/ostd/src/arch/riscv/iommu/fault.rs
+++ b/ostd/src/arch/riscv/iommu/fault.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Fault queue management for the RISC-V IOMMU.
+
+use spin::Once;
+
+use super::{queue::Queue, registers};
+use crate::{error, mm::PAGE_SIZE, sync::SpinLock, warn};
+
+/// Fault queue entry size in bytes.
+const FAULT_ENTRY_SIZE: usize = 32;
+
+/// Initializes the fault queue and enables fault reporting.
+pub(super) fn init() {
+    let mut iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+
+    let fq: Queue<32> = Queue::new();
+    let fq_base = registers::QueueBase::new((fq.base_paddr() >> 12) as u64, fq.log2sz_minus_1());
+    iommu_regs.fqb.as_mut_ptr().write(fq_base.value());
+    iommu_regs.fqh.as_mut_ptr().write(0);
+
+    // TODO: Enable the fault queue interrupt (FIE) once the interrupt
+    // handler is wired. FIE is bit 1 in the same register as FQEN.
+    iommu_regs.fqcsr.as_mut_ptr().write(registers::FQCSR_FQEN);
+
+    // FQON should be asserted synchronously after FQEN is written;
+    // give the hardware one pause, then bail if it isn't ready.
+    core::hint::spin_loop();
+    if iommu_regs.fqcsr.as_ptr().read() & registers::FQCSR_FQON == 0 {
+        warn!("Fault queue did not become operational, disabling fault reporting");
+        return;
+    }
+
+    FAULT_QUEUE.call_once(|| SpinLock::new(fq));
+}
+
+/// Drains and logs all pending fault records from the fault queue.
+// TODO: Wire this as the IOMMU fault interrupt handler once the interrupt
+// subsystem supports RISC-V IOMMU fault interrupts.
+pub(super) fn process_faults() {
+    let mut iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+
+    let fqcsr = iommu_regs.fqcsr.as_ptr().read();
+    if fqcsr & (registers::FQCSR_FQMF | registers::FQCSR_FQOF) != 0 {
+        error!("IOMMU fault queue error: fqcsr=0x{:x}", fqcsr);
+        // Clears error bits (write-1-to-clear) to re-enable fault reporting.
+        iommu_regs
+            .fqcsr
+            .as_mut_ptr()
+            .write(fqcsr & (registers::FQCSR_FQMF | registers::FQCSR_FQOF));
+    }
+
+    iommu_regs.ipsr.as_mut_ptr().write(registers::IPSR_FIP);
+
+    let fqt = iommu_regs.fqt.as_ptr().read() as usize;
+    let fqh_val = iommu_regs.fqh.as_ptr().read() as usize;
+
+    if fqt == fqh_val {
+        return;
+    }
+
+    let num_records = if fqt > fqh_val {
+        fqt - fqh_val
+    } else {
+        // Wrap-around case: fqt wrapped past the queue end.
+        (PAGE_SIZE / FAULT_ENTRY_SIZE) - fqh_val + fqt
+    };
+
+    drop(iommu_regs);
+
+    // TODO: Parse individual 32-byte fault records instead of just logging
+    // the count.
+    error!(
+        "IOMMU fault: {} record(s) pending (fqh={}, fqt={})",
+        num_records, fqh_val, fqt
+    );
+
+    let mut iommu_regs = registers::IOMMU_REGS.get().unwrap().lock();
+    iommu_regs.fqh.as_mut_ptr().write(fqt as u32);
+}
+
+/// Fault queue singleton, initialized by [`init`] during IOMMU setup.
+static FAULT_QUEUE: Once<SpinLock<Queue<32>>> = Once::new();

--- a/ostd/src/arch/riscv/iommu/mod.rs
+++ b/ostd/src/arch/riscv/iommu/mod.rs
@@ -1,37 +1,59 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! The IOMMU support.
+//! The IOMMU support for RISC-V.
+//!
+//! Implements DMA remapping via a second-stage page table (Sv39x4) shared across
+//! all devices, connected through a two-level Device Directory Table. Interrupt
+//! remapping is not yet implemented.
+//!
+//! The public interface consists of [`has_dma_remapping`], [`map`], and [`unmap`],
+//! which are called from the generic DMA layer in [`crate::mm::dma`]. Page table
+//! configuration is provided by [`IommuPtConfig`], which implements
+//! [`crate::mm::page_table::PageTableConfig`] for the RISC-V IOMMU's Sv39x4
+//! second-stage translation format.
+//!
+//! See the parent module ([`crate::arch::riscv`]) for the initialization path.
+//!
+//! For more details, see the RISC-V IOMMU specification:
+//! <https://docs.riscv.org/reference/iommu/index.html>.
 
-use crate::mm::{Daddr, Paddr};
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "iommu: "
+    };
+}
+
+mod ddt;
+mod dma_remapping;
+mod fault;
+mod queue;
+mod registers;
+mod second_stage;
+
+pub(crate) use dma_remapping::{has_dma_remapping, map, unmap};
+pub(crate) use second_stage::IommuPtConfig;
+
+use crate::{io::IoMemAllocatorBuilder, mm::page_table::PageTableError};
 
 /// An enumeration representing possible errors related to IOMMU.
 #[derive(Debug)]
 pub(crate) enum IommuError {
     /// No IOMMU is available.
     NoIommu,
+    /// Error encountered during modification of the page table.
+    ModificationError(PageTableError),
 }
 
-///
-/// # Safety
-///
-/// Mapping an incorrect address may lead to a kernel data leak.
-pub(crate) unsafe fn map(_daddr: Daddr, _paddr: Paddr) -> Result<(), IommuError> {
-    Err(IommuError::NoIommu)
+pub(crate) fn init(io_mem_builder: &IoMemAllocatorBuilder) -> Result<(), IommuError> {
+    registers::init(io_mem_builder)?;
+    dma_remapping::init();
+    Ok(())
 }
 
-pub(crate) fn unmap(_daddr: Daddr) -> Result<(), IommuError> {
-    Err(IommuError::NoIommu)
-}
-
-pub(crate) fn init() -> Result<(), IommuError> {
-    // TODO: We will support IOMMU on RISC-V
-    Err(IommuError::NoIommu)
-}
-
-pub(crate) fn has_dma_remapping() -> bool {
-    false
-}
-
+// The generic IRQ layer uses the return value to decide whether to allocate
+// interrupt remapping table entries for MSI/MSI-X. Always `false` until
+// interrupt remapping is implemented.
 pub(crate) fn has_interrupt_remapping() -> bool {
     false
 }

--- a/ostd/src/arch/riscv/iommu/queue.rs
+++ b/ostd/src/arch/riscv/iommu/queue.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! In-memory queue infrastructure for the RISC-V IOMMU.
+
+use crate::mm::{FrameAllocOptions, HasPaddr, PAGE_SIZE, Paddr, Segment, VmIo};
+
+/// A circular buffer of fixed-size entries stored in a dedicated page.
+pub(super) struct Queue<const ENTRY_SIZE: usize> {
+    segment: Segment<()>,
+    capacity: usize,
+    tail: usize,
+}
+
+impl<const ENTRY_SIZE: usize> Queue<ENTRY_SIZE> {
+    /// Creates a queue backed by a single page.
+    pub(super) fn new() -> Self {
+        let segment = FrameAllocOptions::new().alloc_segment(1).unwrap();
+        let capacity = PAGE_SIZE / ENTRY_SIZE;
+        // The IOMMU requires the queue to have at least 2 entries and the
+        // size must be a power of two so log2sz_minus_1() is well-defined.
+        debug_assert!(capacity >= 2 && capacity.is_power_of_two());
+        Self {
+            segment,
+            capacity,
+            tail: 0,
+        }
+    }
+
+    /// Appends an entry at the tail, wrapping around if at capacity.
+    ///
+    /// TODO: Check the hardware's head register (e.g. `cqh`) for available
+    /// space before writing when concurrent command submission (map/unmap
+    /// IOTLB invalidation) is added. Currently, only `init()` pushes a single
+    /// IOFENCE command, so overwriting is impossible.
+    pub(super) fn push(&mut self, entry: &[u8; ENTRY_SIZE]) {
+        if self.tail >= self.capacity {
+            self.tail = 0;
+        }
+        self.segment
+            .write_val(self.tail * ENTRY_SIZE, entry)
+            .unwrap();
+        self.tail += 1;
+    }
+
+    /// Returns the current tail index (the number of entries pushed modulo
+    /// the queue capacity). The IOMMU compares this against its internal
+    /// head index and wraps independently, so the ring wraparound is
+    /// expected.
+    pub(super) fn tail(&self) -> usize {
+        self.tail
+    }
+
+    /// Returns the physical address of the queue memory (for `cqb`/`fqb`/`pqb`).
+    pub(super) fn base_paddr(&self) -> Paddr {
+        self.segment.paddr()
+    }
+
+    /// Returns `log2(queue size) - 1`, the format required by the queue base
+    /// register's LOG2SZ field. The caller must guarantee `capacity` is a
+    /// power of two and >= 2.
+    pub(super) fn log2sz_minus_1(&self) -> u8 {
+        (self.capacity.ilog2() - 1) as u8
+    }
+}
+
+/// A command queue entry.
+pub(super) type CmdEntry = [u8; 16];
+
+/// A fault queue entry.
+pub(super) type FaultEntry = [u8; 32];
+
+// TODO: The func3 field and operand bit positions (PR/PW, DV/DID,
+// GV/AV/PSCV/PSCID, ADDR) within DW0–DW3 must be verified against
+// the command format diagram before hardware testing.
+
+/// Constructs an `IOFENCE.C` command descriptor.
+pub(super) fn cmd_iofence_c(pr: bool, pw: bool) -> CmdEntry {
+    let mut entry = [0u8; 16];
+    let opcode: u32 = 0x02; // IOFENCE
+    let func3: u32 = 0x0; // C
+    let pr_bit = if pr { 1u32 << 15 } else { 0 };
+    let pw_bit = if pw { 1u32 << 14 } else { 0 };
+    entry[0..4].copy_from_slice(&(opcode | func3 | pr_bit | pw_bit).to_le_bytes());
+    entry
+}
+
+/// Constructs an `IODIR.INVAL_DDT` command descriptor.
+pub(super) fn cmd_iodir_inval_ddt(dv: bool, device_id: u16) -> CmdEntry {
+    let mut entry = [0u8; 16];
+    let opcode: u32 = 0x03; // IODIR
+    let dv_bit = if dv { 1u32 << 15 } else { 0 };
+    let dw0 = opcode | dv_bit | (device_id as u32 & 0xFFFFFF);
+    entry[0..4].copy_from_slice(&dw0.to_le_bytes());
+    entry
+}
+
+/// Constructs an `IOTINVAL.VMA` command descriptor.
+#[expect(dead_code)]
+pub(super) fn cmd_iotinval_vma(gv: bool, addr: u64, pscid: u32) -> CmdEntry {
+    let mut entry = [0u8; 16];
+    let opcode: u32 = 0x01; // IOTINVAL
+    let func3: u32 = 0x0; // VMA
+    let gv_bit = if gv { 1u32 << 15 } else { 0 };
+    let av_bit = 1u32 << 14; // address valid
+    let dw0 = opcode | func3 | gv_bit | av_bit | (pscid & 0xFFFFF);
+    entry[0..4].copy_from_slice(&dw0.to_le_bytes());
+    entry[4..8].copy_from_slice(&((addr >> 12) as u32).to_le_bytes());
+    entry[8..12].copy_from_slice(&((addr >> 44) as u32).to_le_bytes());
+    entry
+}
+
+/// Constructs an `IOTINVAL.GVMA` command descriptor.
+// TODO: The `func3` value for GVMA (0x1) is tentative pending spec verification.
+// GVMA is a distinct `func3` from VMA (0x0) within the IOTINVAL opcode.
+#[expect(dead_code)]
+pub(super) fn cmd_iotinval_gvma(gv: bool, av: bool, gscid: u16, addr: u64) -> CmdEntry {
+    let mut entry = [0u8; 16];
+    let opcode: u32 = 0x01; // IOTINVAL
+    let func3: u32 = 0x1; // GVMA
+    let gv_bit = if gv { 1u32 << 15 } else { 0 };
+    let av_bit = if av { 1u32 << 14 } else { 0 };
+    let dw0 = opcode | func3 | gv_bit | av_bit | ((gscid as u32) & 0xFFFF);
+    entry[0..4].copy_from_slice(&dw0.to_le_bytes());
+    entry[4..8].copy_from_slice(&((addr >> 12) as u32).to_le_bytes());
+    entry[8..12].copy_from_slice(&((addr >> 44) as u32).to_le_bytes());
+    entry
+}

--- a/ostd/src/arch/riscv/iommu/registers.rs
+++ b/ostd/src/arch/riscv/iommu/registers.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! MMIO register interface for the RISC-V IOMMU.
+
+use core::ptr::NonNull;
+
+use fdt::Fdt;
+use spin::Once;
+use volatile::{
+    VolatileRef,
+    access::{ReadOnly, ReadWrite},
+};
+
+use super::IommuError;
+use crate::{
+    arch::boot::DEVICE_TREE,
+    io::IoMemAllocatorBuilder,
+    sync::{LocalIrqDisabled, SpinLock},
+};
+
+const IOMMU_COMPATIBLE: &str = "riscv,iommu";
+
+// Register offsets.
+const REG_CAPABILITIES: usize = 0x00;
+const REG_FCTL: usize = 0x08;
+const REG_DDTP: usize = 0x10;
+const REG_CQB: usize = 0x18;
+const REG_CQH: usize = 0x20;
+const REG_CQT: usize = 0x24;
+const REG_FQB: usize = 0x28;
+const REG_FQH: usize = 0x30;
+const REG_FQT: usize = 0x34;
+const REG_PQB: usize = 0x38;
+const REG_PQH: usize = 0x40;
+const REG_PQT: usize = 0x44;
+const REG_CQCSR: usize = 0x48;
+const REG_FQCSR: usize = 0x4C;
+const REG_PQCSR: usize = 0x50;
+const REG_IPSR: usize = 0x54;
+const REG_ICVEC: usize = 0x2F8;
+
+// Queue CSR bit definitions.
+pub(super) const CQCSR_CQEN: u32 = 1 << 0;
+pub(super) const CQCSR_CIE: u32 = 1 << 1;
+pub(super) const CQCSR_CQMF: u32 = 1 << 8;
+pub(super) const CQCSR_CMD_TO: u32 = 1 << 9;
+pub(super) const CQCSR_CMD_ILL: u32 = 1 << 10;
+pub(super) const CQCSR_FENCE_W_IP: u32 = 1 << 11;
+pub(super) const CQCSR_CQON: u32 = 1 << 16;
+pub(super) const CQCSR_BUSY: u32 = 1 << 17;
+
+pub(super) const FQCSR_FQEN: u32 = 1 << 0;
+pub(super) const FQCSR_FIE: u32 = 1 << 1;
+pub(super) const FQCSR_FQMF: u32 = 1 << 8;
+pub(super) const FQCSR_FQOF: u32 = 1 << 9;
+pub(super) const FQCSR_FQON: u32 = 1 << 16;
+pub(super) const FQCSR_BUSY: u32 = 1 << 17;
+
+pub(super) const PQCSR_PQEN: u32 = 1 << 0;
+pub(super) const PQCSR_PIE: u32 = 1 << 1;
+pub(super) const PQCSR_PQMF: u32 = 1 << 8;
+pub(super) const PQCSR_PQOF: u32 = 1 << 9;
+pub(super) const PQCSR_PQON: u32 = 1 << 16;
+pub(super) const PQCSR_BUSY: u32 = 1 << 17;
+
+// ipsr bit definitions.
+pub(super) const IPSR_CIP: u32 = 1 << 0;
+pub(super) const IPSR_FIP: u32 = 1 << 1;
+pub(super) const IPSR_PMIP: u32 = 1 << 2;
+pub(super) const IPSR_PIP: u32 = 1 << 3;
+
+// ddtp mode encodings.
+pub(super) const DDTP_MODE_OFF: u64 = 0;
+pub(super) const DDTP_MODE_BARE: u64 = 1;
+pub(super) const DDTP_MODE_1LVL: u64 = 2;
+pub(super) const DDTP_MODE_2LVL: u64 = 3;
+pub(super) const DDTP_MODE_3LVL: u64 = 4;
+
+/// Capability register (offset 0x00, 64-bit RO).
+#[derive(Clone, Copy, Debug)]
+pub struct Capability(u64);
+
+impl Capability {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn version(&self) -> u8 {
+        (self.0 & 0xFF) as u8
+    }
+
+    pub const fn flags(&self) -> CapabilityFlags {
+        CapabilityFlags::from_bits_truncate(self.0)
+    }
+
+    pub const fn physical_address_size(&self) -> u8 {
+        ((self.0 >> 32) & 0x3F) as u8
+    }
+}
+
+bitflags::bitflags! {
+    pub struct CapabilityFlags: u64 {
+        const SV32 = 1 << 8;
+        const SV39 = 1 << 9;
+        const SV48 = 1 << 10;
+        const SV57 = 1 << 11;
+        const SVRESV = 1 << 14;
+        const SVPBMT = 1 << 15;
+        const SV32X4 = 1 << 16;
+        const SV39X4 = 1 << 17;
+        const SV48X4 = 1 << 18;
+        const SV57X4 = 1 << 19;
+        const AMO_MRIF = 1 << 21;
+        const MSI_FLAT = 1 << 22;
+        const MSI_MRIF = 1 << 23;
+        const AMO_HWAD = 1 << 24;
+        const ATS = 1 << 25;
+        const T2GPA = 1 << 26;
+        const END = 1 << 27;
+        const PD8 = 1 << 38;
+        const PD17 = 1 << 39;
+        const PD20 = 1 << 40;
+        const QOSID = 1 << 41;
+        const NL = 1 << 42;
+        const S = 1 << 43;
+    }
+}
+
+/// Features control register (offset 0x08, 32-bit WARL).
+#[derive(Clone, Copy, Debug)]
+pub struct FeaturesControl(u32);
+
+impl FeaturesControl {
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(&self) -> u32 {
+        self.0
+    }
+
+    pub const fn be(&self) -> bool {
+        (self.0 & 1) != 0
+    }
+
+    pub const fn wsi(&self) -> bool {
+        (self.0 & (1 << 1)) != 0
+    }
+
+    pub const fn gxl(&self) -> bool {
+        (self.0 & (1 << 2)) != 0
+    }
+}
+
+/// Device directory table pointer register (offset 0x10, 64-bit WARL).
+#[derive(Clone, Copy, Debug)]
+pub struct Ddtp(u64);
+
+impl Ddtp {
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    pub fn mode(&self) -> u8 {
+        (self.0 & 0xF) as u8
+    }
+
+    pub fn set_mode(&mut self, mode: u8) {
+        self.0 = (self.0 & !0xF) | (mode as u64 & 0xF);
+    }
+
+    pub fn ppn(&self) -> u64 {
+        (self.0 >> 10) & 0xFFFFFFFFFFF
+    }
+
+    pub fn set_ppn(&mut self, ppn: u64) {
+        self.0 = (self.0 & 0xFC00_0000_0000_03FF) | ((ppn & 0xFFFFFFFFFFF) << 10);
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Queue base register (used for cqb, fqb, pqb; 64-bit WARL).
+#[derive(Clone, Copy, Debug)]
+pub struct QueueBase(u64);
+
+impl QueueBase {
+    pub fn new(ppn: u64, log2sz_minus_1: u8) -> Self {
+        Self(((ppn & 0xFFFFFFFFFFF) << 10) | (log2sz_minus_1 as u64 & 0x1F))
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Queue Control/Status Register (cqcsr/fqcsr/pqcsr; 32-bit).
+#[derive(Clone, Copy, Debug)]
+pub struct QueueCsr(u32);
+
+impl QueueCsr {
+    pub fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    pub fn value(&self) -> u32 {
+        self.0
+    }
+
+    pub fn is_queued(&self) -> bool {
+        (self.0 & 0x1) != 0
+    }
+
+    pub fn is_busy(&self) -> bool {
+        (self.0 & (1 << 17)) != 0
+    }
+}
+
+/// Volatile memory-mapped access to the IOMMU register block.
+// TODO: Add `msi_cfg_tbl` (32 × 16 bytes at 0x300–0x3FF) for MSI interrupt
+// vector configuration when interrupt remapping is implemented.
+pub(super) struct IommuRegisters {
+    pub capabilities: Capability,
+    pub fctl: VolatileRef<'static, u32, ReadWrite>,
+    pub ddtp: VolatileRef<'static, u64, ReadWrite>,
+    pub cqb: VolatileRef<'static, u64, ReadWrite>,
+    pub cqh: VolatileRef<'static, u32, ReadOnly>,
+    pub cqt: VolatileRef<'static, u32, ReadWrite>,
+    pub fqb: VolatileRef<'static, u64, ReadWrite>,
+    pub fqh: VolatileRef<'static, u32, ReadWrite>,
+    pub fqt: VolatileRef<'static, u32, ReadOnly>,
+    pub cqcsr: VolatileRef<'static, u32, ReadWrite>,
+    pub fqcsr: VolatileRef<'static, u32, ReadWrite>,
+    pub ipsr: VolatileRef<'static, u32, ReadWrite>,
+    pub icvec: VolatileRef<'static, u64, ReadWrite>,
+}
+
+impl IommuRegisters {
+    // Creates a volatile register interface from the IOMMU MMIO base address.
+    //
+    // # Safety
+    //
+    // The caller must ensure that `base_register_vaddr` points to a valid IOMMU
+    // register region and that it has exclusive ownership of the IOMMU registers.
+    unsafe fn new(base_register_vaddr: NonNull<u8>) -> Self {
+        // SAFETY: The safety is upheld by the caller.
+        unsafe {
+            let capabilities = Capability::new(
+                VolatileRef::new_read_only(base_register_vaddr.add(REG_CAPABILITIES).cast::<u64>())
+                    .as_ptr()
+                    .read(),
+            );
+
+            Self {
+                capabilities,
+                fctl: VolatileRef::new(base_register_vaddr.add(REG_FCTL).cast::<u32>()),
+                ddtp: VolatileRef::new(base_register_vaddr.add(REG_DDTP).cast::<u64>()),
+                cqb: VolatileRef::new(base_register_vaddr.add(REG_CQB).cast::<u64>()),
+                cqh: VolatileRef::new_read_only(base_register_vaddr.add(REG_CQH).cast::<u32>()),
+                cqt: VolatileRef::new(base_register_vaddr.add(REG_CQT).cast::<u32>()),
+                fqb: VolatileRef::new(base_register_vaddr.add(REG_FQB).cast::<u64>()),
+                fqh: VolatileRef::new(base_register_vaddr.add(REG_FQH).cast::<u32>()),
+                fqt: VolatileRef::new_read_only(base_register_vaddr.add(REG_FQT).cast::<u32>()),
+                cqcsr: VolatileRef::new(base_register_vaddr.add(REG_CQCSR).cast::<u32>()),
+                fqcsr: VolatileRef::new(base_register_vaddr.add(REG_FQCSR).cast::<u32>()),
+                ipsr: VolatileRef::new(base_register_vaddr.add(REG_IPSR).cast::<u32>()),
+                icvec: VolatileRef::new(base_register_vaddr.add(REG_ICVEC).cast::<u64>()),
+            }
+        }
+    }
+}
+
+/// Scans the device tree for a node with `compatible = "riscv,iommu"` and
+/// returns the base physical address from its `reg` property.
+fn probe_iommu_from_fdt(fdt: &Fdt<'_>) -> Option<(usize, usize)> {
+    fdt.all_nodes().find_map(|node| {
+        if node
+            .compatible()
+            .is_some_and(|compatibles| compatibles.all().any(|c| c == IOMMU_COMPATIBLE))
+        {
+            let region = node.reg()?.next()?;
+            let base = region.starting_address as usize;
+            let size = region.size?;
+            Some((base, size))
+        } else {
+            None
+        }
+    })
+}
+
+/// Global IOMMU register singleton.
+pub(super) static IOMMU_REGS: Once<SpinLock<IommuRegisters, LocalIrqDisabled>> = Once::new();
+
+/// Discovers and maps the IOMMU MMIO register region.
+pub(super) fn init(io_mem_builder: &IoMemAllocatorBuilder) -> Result<(), IommuError> {
+    let fdt = DEVICE_TREE.get().ok_or(IommuError::NoIommu)?;
+    let (base_address, region_size) = probe_iommu_from_fdt(fdt).ok_or(IommuError::NoIommu)?;
+
+    if base_address == 0 || region_size == 0 {
+        return Err(IommuError::NoIommu);
+    }
+
+    let region_end = base_address
+        .checked_add(region_size)
+        .ok_or(IommuError::NoIommu)?;
+    let range = base_address..region_end;
+    io_mem_builder.remove(range);
+
+    let base = NonNull::new(crate::mm::paddr_to_vaddr(base_address) as *mut u8)
+        .ok_or(IommuError::NoIommu)?;
+
+    // SAFETY: The safety is upheld by the device tree providing a valid IOMMU base
+    // address and length, and `io_mem_builder.remove()` guaranteeing exclusive
+    // ownership of the MMIO region.
+    let iommu_regs = unsafe { IommuRegisters::new(base) };
+
+    IOMMU_REGS.call_once(|| SpinLock::new(iommu_regs));
+    Ok(())
+}

--- a/ostd/src/arch/riscv/iommu/second_stage.rs
+++ b/ostd/src/arch/riscv/iommu/second_stage.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Second-stage page table configuration for the RISC-V IOMMU (Sv39x4).
+//!
+//! PTE format follows the RISC-V privileged specification and matches the
+//! kernel MMU's `PageTableEntry` layout in `ostd/src/arch/riscv/mm/mod.rs`.
+//! The U (bit 4) and G (bit 5) flags are intentionally omitted: the IOMMU
+//! treats U as "not requesting supervisor privilege," and G has no second-stage
+//! semantic per the IOMMU spec.
+//!
+//! ## Root table limitation
+//!
+//! Full Sv39x4 per the spec requires a 16 KiB root table (2048 entries, 11-bit
+//! VPN[2]) producing a 41-bit IOVA space. This implementation uses a 4 KiB root
+//! table (512 entries, 9-bit VPN[2]), giving an effective 39-bit IOVA space.
+//!
+//! The smaller root table matches the kernel `PageTable` infrastructure's
+//! assumption of uniform 4 KiB tables per level. For most virt/embedded use
+//! cases (IOVA < 512 GiB) this is sufficient; the IOMMU only accesses the first
+//! 4 KiB of the logical 16 KiB root region.
+
+use core::{marker::PhantomData, ops::Range};
+
+use crate::mm::{
+    Paddr, PageProperty, PagingConstsTrait, PagingLevel, PodOnce,
+    page_prop::{CachePolicy, PageFlags, PageTableFlags, PrivilegedPageFlags as PrivFlags},
+    page_table::{PageTableConfig, PteScalar, PteTrait},
+};
+
+/// The IOMMU second-stage page table configuration (Sv39x4).
+// TODO: Add Sv48x4 and Sv57x4 IommuPtConfig variants and select the best
+// available mode at init time based on capabilities.SV48X4 / capabilities.SV57X4.
+#[derive(Clone, Debug)]
+pub struct IommuPtConfig {}
+
+// SAFETY: This implementation is safe because `item_raw_info`,
+// `item_into_raw`, `item_from_raw`, and `item_ref_from_raw` are
+// correctly implemented with respect to the `Item` and `ItemRef` types.
+unsafe impl PageTableConfig for IommuPtConfig {
+    // TODO: Full Sv39x4 requires TOP_LEVEL_INDEX_RANGE = 0..2048 (11-bit VPN[2])
+    // with a 16 KiB root table. Currently limited to 512 entries (9-bit)
+    // because the `PageTable` infrastructure assumes uniform 4 KiB tables.
+    const TOP_LEVEL_INDEX_RANGE: Range<usize> = 0..512;
+
+    type E = PageTableEntry;
+    type C = PagingConsts;
+
+    type Item = PtItem;
+    type ItemRef<'a> = PtItemRef<'a>;
+
+    fn item_raw_info(item: &Self::Item) -> (Paddr, PagingLevel, PageProperty) {
+        (item.0, item.1, item.2)
+    }
+
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
+        (paddr, level, prop)
+    }
+
+    unsafe fn item_ref_from_raw<'a>(
+        _paddr: Paddr,
+        _level: PagingLevel,
+        _prop: PageProperty,
+    ) -> Self::ItemRef<'a> {
+        PhantomData
+    }
+}
+
+pub(crate) type PtItem = (Paddr, PagingLevel, PageProperty);
+pub(crate) type PtItemRef<'a> = PhantomData<&'a ()>;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PagingConsts {}
+
+impl PagingConstsTrait for PagingConsts {
+    const BASE_PAGE_SIZE: usize = 4096;
+    const NR_LEVELS: PagingLevel = 3;
+    // Reduced from 41 (11+9+9+12) due to the 4 KiB root table limitation above.
+    const ADDRESS_WIDTH: usize = 39;
+    const VA_SIGN_EXT: bool = false;
+    const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 1;
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
+}
+
+bitflags::bitflags! {
+    #[repr(C)]
+    #[derive(Pod)]
+    pub struct PteFlags: usize {
+        /// Valid entry.
+        const V =           1 << 0;
+        /// Readable.
+        const R =           1 << 1;
+        /// Writable.
+        const W =           1 << 2;
+        /// Executable.
+        const X =           1 << 3;
+        /// Accessed.
+        const A =           1 << 6;
+        /// Dirty.
+        const D =           1 << 7;
+
+        // Software-available bits.
+        const RSV1 =        1 << 8;
+        const RSV2 =        1 << 9;
+
+        /// PBMT: Non-cacheable, idempotent, weakly-ordered (main memory).
+        const PBMT_NC =     1 << 61;
+        /// PBMT: Non-cacheable, non-idempotent, strongly-ordered (I/O).
+        const PBMT_IO =     1 << 62;
+    }
+}
+
+fn map_flag(val: impl Into<usize>, from: impl Into<usize>, to: impl Into<usize>) -> usize {
+    let v: usize = val.into();
+    let f: usize = from.into();
+    let t: usize = to.into();
+    ((v & f) >> f.ilog2()) << t.ilog2()
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub struct PageTableEntry(usize);
+
+impl PageTableEntry {
+    const PHYS_MASK: usize = 0x003F_FFFF_FFFF_FC00;
+
+    fn new_without_flags(paddr: Paddr) -> Self {
+        Self((paddr >> 12) << 10)
+    }
+
+    fn paddr(&self) -> Paddr {
+        (self.0 & Self::PHYS_MASK) >> 10 << 12
+    }
+
+    fn is_last(&self, level: PagingLevel) -> bool {
+        let rwx = PteFlags::R.bits() | PteFlags::W.bits() | PteFlags::X.bits();
+        level == 1 || (self.0 & rwx) != 0
+    }
+
+    fn prop(&self) -> PageProperty {
+        let flags = map_flag(self.0, PteFlags::R.bits(), PageFlags::R.bits())
+            | map_flag(self.0, PteFlags::W.bits(), PageFlags::W.bits())
+            | map_flag(self.0, PteFlags::X.bits(), PageFlags::X.bits())
+            | map_flag(self.0, PteFlags::A.bits(), PageFlags::ACCESSED.bits())
+            | map_flag(self.0, PteFlags::D.bits(), PageFlags::DIRTY.bits())
+            | map_flag(self.0, PteFlags::RSV2.bits(), PageFlags::AVAIL2.bits());
+
+        let priv_flags = map_flag(self.0, PteFlags::RSV1.bits(), PrivFlags::AVAIL1.bits());
+
+        let cache = if self.0 & PteFlags::PBMT_IO.bits() != 0 {
+            CachePolicy::Uncacheable
+        } else {
+            CachePolicy::Writeback
+        };
+
+        PageProperty {
+            flags: PageFlags::from_bits(flags as u8).unwrap(),
+            cache,
+            priv_flags: PrivFlags::from_bits(priv_flags as u8).unwrap(),
+        }
+    }
+
+    fn pt_flags(&self) -> PageTableFlags {
+        let bits = PageTableFlags::empty().bits() as usize
+            | map_flag(self.0, PteFlags::RSV1.bits(), PageTableFlags::AVAIL1.bits())
+            | map_flag(self.0, PteFlags::RSV2.bits(), PageTableFlags::AVAIL2.bits());
+        PageTableFlags::from_bits(bits as u8).unwrap()
+    }
+
+    fn new_page(paddr: Paddr, _level: PagingLevel, prop: PageProperty) -> Self {
+        let mut flags = PteFlags::V.bits()
+            | map_flag(prop.flags.bits(), PageFlags::R.bits(), PteFlags::R.bits())
+            | map_flag(prop.flags.bits(), PageFlags::W.bits(), PteFlags::W.bits())
+            | map_flag(prop.flags.bits(), PageFlags::X.bits(), PteFlags::X.bits())
+            | map_flag(
+                prop.flags.bits(),
+                PageFlags::ACCESSED.bits(),
+                PteFlags::A.bits(),
+            )
+            | map_flag(
+                prop.flags.bits(),
+                PageFlags::DIRTY.bits(),
+                PteFlags::D.bits(),
+            )
+            | map_flag(
+                prop.priv_flags.bits(),
+                PrivFlags::AVAIL1.bits(),
+                PteFlags::RSV1.bits(),
+            )
+            | map_flag(
+                prop.flags.bits(),
+                PageFlags::AVAIL2.bits(),
+                PteFlags::RSV2.bits(),
+            );
+
+        match prop.cache {
+            CachePolicy::Writeback => (),
+            CachePolicy::Uncacheable => {
+                flags |= PteFlags::PBMT_IO.bits();
+            }
+            _ => panic!("unsupported cache policy for IOMMU"),
+        }
+
+        Self(Self::new_without_flags(paddr).0 | flags)
+    }
+
+    fn new_pt(paddr: Paddr, flags: PageTableFlags) -> Self {
+        let flags = PteFlags::V.bits()
+            | map_flag(
+                flags.bits(),
+                PageTableFlags::AVAIL1.bits(),
+                PteFlags::RSV1.bits(),
+            )
+            | map_flag(
+                flags.bits(),
+                PageTableFlags::AVAIL2.bits(),
+                PteFlags::RSV2.bits(),
+            );
+
+        Self(Self::new_without_flags(paddr).0 | flags)
+    }
+}
+
+impl PodOnce for PageTableEntry {}
+
+// SAFETY: This implementation is safe because `from_repr` and `to_repr`
+// correctly round-trip between the `PteScalar` representation and
+// the hardware PTE format, and a zeroed PTE represents an absent entry (V=0).
+// `from_usize`/`into_usize` are not overridden so the default no-op
+// implementations apply.
+unsafe impl PteTrait for PageTableEntry {
+    fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
+        match repr {
+            PteScalar::Absent => PageTableEntry(0),
+            PteScalar::PageTable(paddr, flags) => Self::new_pt(*paddr, *flags),
+            PteScalar::Mapped(paddr, prop) => Self::new_page(*paddr, level, *prop),
+        }
+    }
+
+    fn to_repr(&self, level: PagingLevel) -> PteScalar {
+        if self.0 & PteFlags::V.bits() == 0 {
+            return PteScalar::Absent;
+        }
+
+        if self.is_last(level) {
+            PteScalar::Mapped(self.paddr(), self.prop())
+        } else {
+            PteScalar::PageTable(self.paddr(), self.pt_flags())
+        }
+    }
+}

--- a/ostd/src/arch/riscv/mod.rs
+++ b/ostd/src/arch/riscv/mod.rs
@@ -57,6 +57,11 @@ pub(crate) unsafe fn late_init_on_bsp() {
     // SAFETY: We're on the BSP and we're ready to boot all APs.
     unsafe { crate::boot::smp::boot_all_aps() };
 
+    match iommu::init(&io_mem_builder) {
+        Ok(_) => {}
+        Err(err) => crate::warn!("IOMMU initialization error: {:?}", err),
+    }
+
     // SAFETY:
     // 1. All the system device memory have been removed from the builder.
     // 2. RISC-V platforms do not have port I/O.

--- a/ostd/src/mm/dma/util.rs
+++ b/ostd/src/mm/dma/util.rs
@@ -35,8 +35,8 @@ use crate::{
 struct DmaBufferMeta;
 impl_frame_meta_for!(DmaBufferMeta);
 
-// TODO: Implement other architectures when their `IommuPtConfig` are ready.
-#[cfg(target_arch = "x86_64")]
+// TODO: Implement LoongArch when its `IommuPtConfig` is ready.
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 mod allocator {
     use crate::{
         arch::iommu,
@@ -266,11 +266,11 @@ unsafe fn dma_remap(pa_range: &Range<Paddr>) -> Option<Daddr> {
 
     let _irq_guard = irq::disable_local();
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     let daddr = allocator::daddr_allocator(&_irq_guard)
         .alloc(pa_range.len())
         .expect("failed to allocate DMA address range");
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "riscv64")))]
     let daddr = pa_range.clone();
 
     for map_paddr in pa_range.clone().step_by(PAGE_SIZE) {

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -2,10 +2,7 @@
 
 //! Virtual memory (VM).
 
-#![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
-    expect(unused_imports)
-)]
+#![cfg_attr(any(target_arch = "loongarch64"), expect(unused_imports))]
 
 pub mod dma;
 pub mod frame;

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -153,6 +153,29 @@ if [ "$ATTACH_XFSTESTS_IMAGES" = "true" ]; then
 fi
 
 if [ "$1" = "iommu" ]; then
+    if [ "$OSDK_TARGET_ARCH" = "riscv64" ]; then
+        QEMU_ARGS="\
+            -cpu rv64,svpbmt=true,zkr=true \
+            -machine virt,iommu-sys=on \
+            -m ${MEM:-8G} \
+            -smp ${SMP:-1} \
+            --no-reboot \
+            -nographic \
+            -display none \
+            -monitor chardev:mux \
+            -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
+            -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
+            -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+            -device virtio-blk-device,drive=x1,iommu_platform=on \
+            -device virtio-blk-device,drive=x0,iommu_platform=on \
+            -device virtio-keyboard-device \
+            -device virtio-serial-device \
+            $CONSOLE_ARGS \
+        "
+        echo $QEMU_ARGS
+        exit 0
+    fi
+
     if [ "$OVMF" = "off" ]; then
         echo "Warning: OVMF is off, enabling it for IOMMU support." 1>&2
         OVMF="on"


### PR DESCRIPTION
# Description
This PR implements DMA remapping support for the RISC-V IOMMU Architecture Specification v1.0.1 in the Asterinas kernel. When the IOMMU scheme is enabled on `riscv64`, the kernel discovers IOMMU hardware via the device tree (`compatible = "riscv,iommu"`), sets up a two-level Device Directory Table (DDT) with a shared Sv39x4 second-stage page table, and performs DMA remapping through the generic `dma_remap()` path — the same code path x86_64 uses for Intel VT-d.
The main gap is interrupt remapping. `has_interrupt_remapping()` returns `false`, so MSI/MSI-X interrupts are not yet remapped through the IOMMU. This is deferred because interrupt remapping requires Extended-format Device Contexts (64 bytes), an MSI page table (MRIF), and an `irq_remapping` module — a substantial follow-up effort.

# Reference
- **Primary reference**: [RISC-V IOMMU Architecture Specification v1.0.1](https://docs.riscv.org/reference/iommu/index.html)
register layout, DDT structure, command/fault queue formats, initialization sequence.
- **Implementation patterns**: The existing x86_64 IOMMU implementation.

# Submodule Illustration
## `registers`
- **Description**
MMIO register interface via `VolatileRef`, type-safe wrappers (`Capability`, `Ddtp`, `QueueBase`, `QueueCsr`), FDT-based hardware discovery (`compatible = "riscv,iommu"`).
- **Reference**
[Spec Chapter 1: Introduction](https://docs.riscv.org/reference/iommu/iommu_intro.html)
[Spec Chapter 5: Memory-mapped Register Interface](https://docs.riscv.org/reference/iommu/iommu_registers.html)

## `second_stage`
- **Description**
`IommuPtConfig`: Sv39x4 3-level page table (39-bit IOVA, 4 KiB pages), PTE format with V/R/W/X/A/D flags + PBMT memory type bits, `PageTableConfig` / `PteTrait` impls for the kernel page table infrastructure.
- **Reference**
[Spec Chapter 2: Data Structures](https://docs.riscv.org/reference/iommu/iommu_data_structures.html)

## `ddt`
- **Description**
Two-level Device Directory Table (2LVL mode), 32-byte Base-format Device Context (`tc`, `iohgatp`, `ta`, `fsc`), `enable_device() `writes a DC pointing `device_id` at a given page table.
- **Reference**
[Spec Chapter 2: Data Structures](https://docs.riscv.org/reference/iommu/iommu_data_structures.html)

## `queue`
- **Description**
Generic` Queue<ENTRY_SIZE>` circular buffer, command entry constructors (`IOFENCE.C`, `IODIR.INVAL_DDT`, `IOTINVAL.VMA`, `IOTINVAL.GVMA`).
- **Reference**
[Spec Chapter 1: Introduction](https://docs.riscv.org/reference/iommu/iommu_intro.html)
[Spec Chapter 3: In-memory Queue Interface](https://docs.riscv.org/reference/iommu/iommu_in_memory_queues.html)

## `dma_remapping`
- **Description**
Public API: `has_dma_remapping()`, `map()`, `unmap()`. Init sequence: CQ (Step 12) → FQ (Step 13) → DDT activation (Step 15) with `ddtp` write last so the IOMMU never sees partially-initialized state.
- **Reference**
[Spec Chapter 6: Software Guidelines](https://docs.riscv.org/reference/iommu/iommu_sw_guidelines.html)

## `fault`
- **Description**
Fault queue allocation, `process_faults()`: drain records from `fqh` to `fqt`, log error bits (`FQMF`/`FQOF`), advance head pointer. Not yet wired to interrupts.
- **Reference**
[Spec Chapter 3: In-memory Queue Interface](https://docs.riscv.org/reference/iommu/iommu_in_memory_queues.html)
[Spec Chapter 6: Software Guidelines](https://docs.riscv.org/reference/iommu/iommu_sw_guidelines.html)

## `mod`
- **Description**
Subsystem entry point: `init()` orchestrates register mapping then DMA remapping setup, `has_interrupt_remapping()` stub.

# Test
The following tests can pass locally:
```shell
make check
cargo check --target riscv64imac-unknown-none-elf
make ktest TARGET_ARCH=riscv64 SCHEME=iommu
make run_kernel TARGET_ARCH=riscv64 SCHEME=iommu
```
Now the `mm::dma` test for x86_64 arch is used to test the implementation of IOMMU for RISC-V as well.
I add an inline print in `ostd/src/arch/riscv/iommu/dma_remapping.rs` `map()` after `cursor.map()`:
```Rust
crate::early_println!("IOMMU map: daddr={:#x} → paddr={:#x}", daddr, paddr);
```
And the output is:
```shell
test ostd::mm::dma::test::dma_coherent::read_write ...IOMMU map: daddr=0x7fffffd000 → paddr=0x260178000
IOMMU map: daddr=0x7fffffe000 → paddr=0x260179000
 ok
test ostd::mm::dma::test::dma_coherent::reader_writer ...IOMMU map: daddr=0x7fffffb000 → paddr=0x26017a000
IOMMU map: daddr=0x7fffffc000 → paddr=0x26017b000
 ok
test ostd::mm::dma::test::dma_coherent::read_write_once ...IOMMU map: daddr=0x7fffff9000 → paddr=0x8a524000
IOMMU map: daddr=0x7fffffa000 → paddr=0x8a525000
 ok
test ostd::mm::dma::test::dma_coherent::zero_length_operations ...IOMMU map: daddr=0x7fffff8000 → paddr=0x26017f000
 ok
test ostd::mm::dma::test::dma_coherent::alloc_uninit_dma_coherent ...IOMMU map: daddr=0x7fffff7000 → paddr=0x8a521000
 ok
test ostd::mm::dma::test::dma_coherent::alloc_with_coherent_device ...IOMMU map: daddr=0x7fffff6000 → paddr=0x8a520000
 ok
test ostd::mm::dma::test::dma_coherent::complex_read_write_patterns ...IOMMU map: daddr=0x7fffff2000 → paddr=0x8a530000
IOMMU map: daddr=0x7fffff3000 → paddr=0x8a531000
IOMMU map: daddr=0x7fffff4000 → paddr=0x8a532000
IOMMU map: daddr=0x7fffff5000 → paddr=0x8a533000
 ok
test ostd::mm::dma::test::dma_stream::to_device ...IOMMU map: daddr=0x7fffff1000 → paddr=0x8a520000
 ok
test ostd::mm::dma::test::dma_stream::read_write ...IOMMU map: daddr=0x7ffffef000 → paddr=0x8a522000
IOMMU map: daddr=0x7fffff0000 → paddr=0x8a523000
 ok
test ostd::mm::dma::test::dma_stream::from_device ...IOMMU map: daddr=0x7ffffee000 → paddr=0x8a523000
 ok
test ostd::mm::dma::test::dma_stream::reader_writer ...IOMMU map: daddr=0x7ffffec000 → paddr=0x8a52c000
IOMMU map: daddr=0x7ffffed000 → paddr=0x8a52d000
 ok
test ostd::mm::dma::test::dma_stream::streaming_map ...IOMMU map: daddr=0x7ffffeb000 → paddr=0x8a526000
 ok
test ostd::mm::dma::test::dma_stream::alloc_dma_stream ...IOMMU map: daddr=0x7ffffe9000 → paddr=0x2601c6000
IOMMU map: daddr=0x7ffffea000 → paddr=0x2601c7000
 ok
test ostd::mm::dma::test::dma_stream::alloc_uninit_dma_stream ...IOMMU map: daddr=0x7ffffe8000 → paddr=0x2601c7000
 ok
test ostd::mm::dma::test::dma_stream::streaming_boundary_conditions ...IOMMU map: daddr=0x7ffffe6000 → paddr=0x8a52c000
IOMMU map: daddr=0x7ffffe7000 → paddr=0x8a52d000
 ok
```
indicating that the address map works.

# Deferred works
1. **Interrupt remapping** (Extended DC, MRIF, `irq_remapping` module, MSI translation)
- **Reason deferred**
Requires substantial infrastructure: 64-byte Device Context with MSI fields (spec Chapter 2), MSI page table for guest MSI writes (Chapter 4), `IrtEntry` allocation mirroring x86's `interrupt_remapping`/ directory. Not needed for DMA correctness — DMA works without it.
- **When to implement**
When MSI/MSI-X interrupt isolation is required (e.g., multi-VM scenarios, assigned devices). 
Follow x86's `interrupt_remapping`/ pattern and spec Chapters 2, 4.

2. **IOTLB invalidation in `map()`/`unmap()`**
- **Reason deferred**
The `COMMAND_QUEUE` singleton and `cmd_iotinval_gvma()` constructor exist, but the GSCID must be read from the DDT Device Context. Without invalidation, the IOMMU may serve stale translations from its TLB. On QEMU this hasn't caused visible issues (the emulated IOMMU may not aggressively cache).
- **When to implement**
When the `COMMAND_QUEUE` singleton is accessible from `map()`/`unmap()`, and the GSCID (currently 0) is plumbed through.
See Spec Chapter 6 §2.8-2.9.

3. **Multiple `device_id` support**
- **Reason deferred**
Currently only `device_id=0` is configured, which covers simple QEMU virt setups. Real hardware with multiple PCIe endpoints requires iterating the PCIe bus hierarchy (similar to x86's `PciDeviceLocation::all()`).
- **When to implement**
When testing on real hardware or QEMU configurations with multiple PCIe devices.

4. **Sv48x4 / Sv57x4 translation modes**
- **Reason deferred**
Only Sv39x4 is implemented. Higher modes require additional `IommuPtConfig` variants with different `ADDRESS_WIDTH`/`NR_LEVELS` values. The x86 implementation has the same limitation (only AGAW_39BIT_3LP).
- **When to implement**
When hardware with `capabilities.SV48X4` or `capabilities.SV57X4` is available. Selection logic would pick Sv57x4 > Sv48x4 > Sv39x4.

5. **Hardware-managed Accessed/Dirty bits (`capabilities.AMO_HWAD`)**
- **Reason deferred**
Requires setting `DC.tc.SADE=1` and `DC.tc.GADE=1`. Without this, the IOMMU does not update A/D bits in PTEs, which is acceptable because the kernel pre-sets A/D bits.
- **When to implement**
When page aging or dirty tracking for DMA pages is needed.

6. **PCIe ATS and PRI (`capabilities.ATS`)**
- **Reason deferred**
Requires Page Request Queue allocation, `DC.tc.EN_ATS=1` / `DC.tc.EN_PRI=1`, and ATS invalidation command (opcode 4). Complex feature with significant spec surface (Chapters 2, 3, 6 §6). Not available in QEMU's current IOMMU implementation.
- **When to implement**
When hardware or QEMU supports PCIe ATS/PRI.

7. **Wire fault interrupts (`fqcsr.FIE`)**
- **Reason deferred**
Requires `icvec` probing (spec §1.2 step 9), MSI or wire-signaled interrupt routing (steps 10-11), and an ISR registered in the interrupt subsystem. Currently `process_faults()` works correctly when polled but is never called automatically.
- **When to implement**
When the RISC-V interrupt subsystem supports IOMMU fault interrupts. Until then, faults are silent unless manually polled.

8. **Per-VM GSCID assignment**
- **Reason deferred**
Currently GSCID=0 for all devices, meaning all VMs share one IOTLB invalidation domain. Non-zero GSCIDs are needed for selective `IOTINVAL.GVMA` shootdown in multi-VM scenarios.
- **When to implement**
When the kernel runs multiple VMs with assigned devices.

9. **Page Request Queue**
- **Reason deferred**
Required for PCIe PRI. Registers at offsets 0x38-0x50, 16-byte entries. Dependent on ATS/PRI (6 above).
- **When to implement**
Same as 6.

10. **Capability version checking**
- **Reason deferred**
`capabilities.version` is not validated during init. The compatible string match (`riscv,iommu`) implies a compatible version, but explicit version gating would be more robust against future spec revisions.
- **When to implement**
When the IOMMU spec publishes a new version warranting incompatibility checks.

11. **Endianness / WSI configuration**
- **Reason deferred**
`fctl.BE` (big-endian) and `fctl.WSI` (wire-signaled interrupts) are not configured. Both are not applicable to current QEMU/test environments (little-endian, MSI-based interrupts).
- **When to implement**
When running on big-endian hardware or platforms using wire-signaled interrupts.

12. **First-stage translation (GVA→GPA, PDT mode)**
- **Reason deferred**
`fsc` is left zeroed (Bare mode, no first-stage). First-stage translation requires writing `iosatp` into `fsc` when `PDTV=0`, or `pdtp` when `PDTV=1`. Not needed for DMA remapping which only uses second-stage.
- **When to implement**
When the IOMMU is used in a hypervisor context translating guest virtual addresses.

13. **QoS ID configuration (`capabilities.QOSID`)**
- **Reason deferred**
`DC.ta.RCID`/`MCID` left zeroed. Needed to tag IOMMU page table walks with QoS identifiers for memory system prioritization.
- **When to implement**
When running on hardware with QoS-aware memory controllers.

14. **Full Sv39x4 root table (16 KiB)**
- **Reason deferred**
Currently using 4 KiB root (512 entries, 9-bit VPN[2]) instead of 16 KiB (2048 entries, 11-bit VPN[2]), producing a 39-bit rather than 41-bit IOVA space. The kernel `PageTable` infrastructure assumes uniform 4 KiB tables per level.
- **When to implement**
When the `PageTable` infrastructure supports non-uniform table sizes, or for IOVA spaces > 512 GiB.