### PR TITLE
Introduce `RawUid` and `Uid` to reject invalid UIDs (and GIDs)

### DIFF
--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -1441,8 +1441,8 @@ impl Inode for ExfatInode {
             type_: inner.inode_type,
             mode: inner.make_mode(),
             nr_hard_links: nlinks,
-            uid: Uid::new(inner.fs().mount_option().fs_uid as u32),
-            gid: Gid::new(inner.fs().mount_option().fs_gid as u32),
+            uid: Uid::from_raw(inner.fs().mount_option().fs_uid as u32),
+            gid: Gid::from_raw(inner.fs().mount_option().fs_gid as u32),
             container_dev_id: inner.fs().container_device_id(),
             self_dev_id: None,
         }
@@ -1486,7 +1486,7 @@ impl Inode for ExfatInode {
     }
 
     fn owner(&self) -> Result<Uid> {
-        Ok(Uid::new(
+        Ok(Uid::from_raw(
             self.inner.read().fs().mount_option().fs_uid as u32,
         ))
     }
@@ -1497,7 +1497,7 @@ impl Inode for ExfatInode {
     }
 
     fn group(&self) -> Result<Gid> {
-        Ok(Gid::new(
+        Ok(Gid::from_raw(
             self.inner.read().fs().mount_option().fs_gid as u32,
         ))
     }

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -584,7 +584,7 @@ impl Ext2 {
             return true;
         }
 
-        let reserved_gid_value = Gid::from(reserved_gid);
+        let reserved_gid_value = Gid::from_raw(reserved_gid);
         if !reserved_gid_value.is_root() {
             if credentials.fsgid() == reserved_gid_value {
                 return true;

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -91,7 +91,7 @@ impl Inode for Ext2Inode {
     }
 
     fn owner(&self) -> Result<Uid> {
-        Ok(Uid::new(self.uid()))
+        Ok(Uid::from_raw(self.uid()))
     }
 
     fn set_owner(&self, uid: Uid) -> Result<()> {
@@ -99,7 +99,7 @@ impl Inode for Ext2Inode {
     }
 
     fn group(&self) -> Result<Gid> {
-        Ok(Gid::new(self.gid()))
+        Ok(Gid::from_raw(self.gid()))
     }
 
     fn set_group(&self, gid: Gid) -> Result<()> {

--- a/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
@@ -70,8 +70,8 @@ impl Inode {
             type_: self.type_,
             mode: inner.mode(),
             nr_hard_links: inner.link_count() as usize,
-            uid: Uid::new(inner.uid()),
-            gid: Gid::new(inner.gid()),
+            uid: Uid::from_raw(inner.uid()),
+            gid: Gid::from_raw(inner.gid()),
             container_dev_id,
             self_dev_id,
         }

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -1271,7 +1271,7 @@ mod tests {
                     StatusFlags::empty(),
                 )
                 .unwrap();
-            f2_inode.set_group(Gid::new(77)).unwrap();
+            f2_inode.set_group(Gid::from_raw(77)).unwrap();
             f2_inode
                 .set_xattr(
                     XattrName::try_from_full_name("trusted.f2_xattr_name").unwrap(),
@@ -1474,7 +1474,7 @@ mod tests {
         f2.read_bytes_at(0, data.as_mut_slice()).unwrap();
         assert_eq!(data, [8u8, 8, 9, 9]);
 
-        assert_eq!(f2.group().unwrap(), Gid::new(77));
+        assert_eq!(f2.group().unwrap(), Gid::from_raw(77));
 
         let mut xattr_value = [0u8; 14];
         f2.get_xattr(

--- a/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/gid_map.rs
@@ -35,13 +35,7 @@ impl ProcFileOps for GidMapFileOps {
         // This is the default GID map for the initial user namespace.
         // TODO: Retrieve the GID map from the user namespace of the current process
         // instead of returning this hard-coded value.
-        writeln!(
-            printer,
-            "{:>10} {:>10} {:>10}",
-            0,
-            0,
-            u32::from(Gid::INVALID)
-        )?;
+        writeln!(printer, "{:>10} {:>10} {:>10}", 0, 0, Gid::RAW_INVALID)?;
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/uid_map.rs
@@ -35,13 +35,7 @@ impl ProcFileOps for UidMapFileOps {
         // This is the default UID map for the initial user namespace.
         // TODO: Retrieve the UID map from the user namespace of the current process
         // instead of returning this hard-coded value.
-        writeln!(
-            printer,
-            "{:>10} {:>10} {:>10}",
-            0,
-            0,
-            u32::from(Uid::INVALID)
-        )?;
+        writeln!(printer, "{:>10} {:>10} {:>10}", 0, 0, Uid::RAW_INVALID)?;
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -207,8 +207,8 @@ pub(in crate::fs::fs_impls::virtiofs) fn metadata_from_attr(
         type_: InodeType::from_raw_mode(attr.mode() as u16).unwrap_or(InodeType::Unknown),
         mode: InodeMode::from_bits_truncate(attr.mode() as u16),
         nr_hard_links: attr.nlink() as usize,
-        uid: Uid::new(attr.uid()),
-        gid: Gid::new(attr.gid()),
+        uid: Uid::from_raw(attr.uid()),
+        gid: Gid::from_raw(attr.gid()),
         container_dev_id,
         self_dev_id: if attr.rdev() == 0 {
             None

--- a/kernel/src/net/socket/unix/cred.rs
+++ b/kernel/src/net/socket/unix/cred.rs
@@ -5,7 +5,7 @@ use aster_rights_proc::require;
 
 use crate::{
     prelude::*,
-    process::{Credentials, Gid, Pid, Uid, posix_thread::AsPosixThread},
+    process::{Credentials, Gid, Pid, RawGid, RawUid, Uid, posix_thread::AsPosixThread},
 };
 
 pub(super) struct SocketCred<R = ReadOp> {
@@ -40,8 +40,8 @@ impl<R: TRights> SocketCred<R> {
     pub(super) fn to_effective_c_cred(&self) -> CUserCred {
         CUserCred {
             pid: self.pid,
-            uid: self.cred.euid(),
-            gid: self.cred.egid(),
+            uid: self.cred.euid().as_raw(),
+            gid: self.cred.egid().as_raw(),
         }
     }
 
@@ -50,8 +50,8 @@ impl<R: TRights> SocketCred<R> {
     pub(super) fn to_real_c_cred(&self) -> CUserCred {
         CUserCred {
             pid: self.pid,
-            uid: self.cred.ruid(),
-            gid: self.cred.rgid(),
+            uid: self.cred.ruid().as_raw(),
+            gid: self.cred.rgid().as_raw(),
         }
     }
 
@@ -85,24 +85,24 @@ impl<R: TRights> SocketCred<R> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Pod)]
 pub struct CUserCred {
     pid: Pid,
-    uid: Uid,
-    gid: Gid,
+    uid: RawUid,
+    gid: RawGid,
 }
 
 impl CUserCred {
     pub(in crate::net) const fn new_invalid() -> Self {
         Self {
             pid: 0,
-            uid: Uid::INVALID,
-            gid: Gid::INVALID,
+            uid: Uid::RAW_INVALID,
+            gid: Gid::RAW_INVALID,
         }
     }
 
     pub(in crate::net) const fn new_overflow() -> Self {
         Self {
             pid: 0,
-            uid: Uid::OVERFLOW,
-            gid: Gid::OVERFLOW,
+            uid: Uid::OVERFLOW.as_raw(),
+            gid: Gid::OVERFLOW.as_raw(),
         }
     }
 }

--- a/kernel/src/process/credentials/group.rs
+++ b/kernel/src/process/credentials/group.rs
@@ -6,15 +6,18 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use crate::prelude::*;
 
+/// The raw GID type at the syscall ABI boundary, matching Linux's `gid_t`.
+pub type RawGid = u32;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Pod)]
 pub struct Gid(u32);
 
 impl Gid {
-    /// The invalid GID, typically used to indicate that no valid GID is found when returning to user space.
+    /// The raw value representing an invalid GID (`(gid_t)-1` in Linux).
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L51>.
-    pub const INVALID: Gid = Gid(u32::MAX);
+    pub const RAW_INVALID: RawGid = u32::MAX;
 
     /// The overflow GID, typically used to indicate that group mappings between namespaces fail.
     ///
@@ -22,14 +25,37 @@ impl Gid {
     /// configured via `/proc/sys/kernel/overflowgid`.
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/kernel/sys.c#L167>.
-    pub const OVERFLOW: Gid = Self::new(65534);
+    pub const OVERFLOW: Gid = Self(65534);
 
-    pub const fn new(gid: u32) -> Self {
+    /// Creates a `Gid` from a raw value, returning `None` if the value is the
+    /// invalid sentinel (i.e., [`Self::RAW_INVALID`]).
+    pub const fn new(gid: RawGid) -> Option<Self> {
+        if gid == Self::RAW_INVALID {
+            None
+        } else {
+            Some(Self(gid))
+        }
+    }
+
+    /// Creates a `Gid` from a raw value without checking for the invalid sentinel.
+    ///
+    /// This is intended for filesystem use where any raw GID stored on disk is valid.
+    pub const fn from_raw(gid: RawGid) -> Self {
         Self(gid)
+    }
+
+    /// Returns whether this GID has a valid mapping (i.e., is not the invalid sentinel).
+    pub const fn has_valid_mapping(&self) -> bool {
+        self.0 != Self::RAW_INVALID
     }
 
     pub const fn new_root() -> Self {
         Self(ROOT_GID)
+    }
+
+    /// Returns the underlying raw GID value.
+    pub const fn as_raw(&self) -> RawGid {
+        self.0
     }
 
     pub const fn is_root(&self) -> bool {
@@ -39,19 +65,21 @@ impl Gid {
 
 const ROOT_GID: u32 = 0;
 
-impl From<u32> for Gid {
-    fn from(value: u32) -> Self {
-        Self::new(value)
-    }
-}
-
 impl From<Gid> for u32 {
     fn from(value: Gid) -> Self {
         value.0
     }
 }
 
-define_atomic_version_of_integer_like_type!(Gid, {
+impl TryFrom<u32> for Gid {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::new(value).ok_or_else(|| Error::with_message(Errno::EINVAL, "the GID is invalid"))
+    }
+}
+
+define_atomic_version_of_integer_like_type!(Gid, try_from = true, {
     #[derive(Debug)]
     pub(super) struct AtomicGid(AtomicU32);
 });

--- a/kernel/src/process/credentials/mod.rs
+++ b/kernel/src/process/credentials/mod.rs
@@ -11,9 +11,9 @@ mod user;
 use aster_rights::FullOp;
 use capabilities::CapSet;
 use credentials_::Credentials_;
-pub use group::Gid;
+pub use group::{Gid, RawGid};
 pub use secure_bits::SecureBits;
-pub use user::Uid;
+pub use user::{RawUid, Uid};
 
 use crate::prelude::*;
 

--- a/kernel/src/process/credentials/user.rs
+++ b/kernel/src/process/credentials/user.rs
@@ -6,6 +6,9 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use crate::prelude::*;
 
+/// The raw UID type at the syscall ABI boundary, matching Linux's `uid_t`.
+pub type RawUid = u32;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Pod)]
 pub struct Uid(u32);
@@ -13,10 +16,10 @@ pub struct Uid(u32);
 const ROOT_UID: u32 = 0;
 
 impl Uid {
-    /// The invalid UID, typically used to indicate that no valid UID is found when returning to user space.
+    /// The raw value representing an invalid UID (`(uid_t)-1` in Linux).
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/include/linux/uidgid.h#L50>.
-    pub const INVALID: Uid = Self::new(u32::MAX);
+    pub const RAW_INVALID: RawUid = u32::MAX;
 
     /// The overflow UID, typically used to indicate that user mappings between namespaces fail.
     ///
@@ -24,24 +27,41 @@ impl Uid {
     /// configured via `/proc/sys/kernel/overflowuid`.
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.15/source/kernel/sys.c#L166>.
-    pub const OVERFLOW: Uid = Self::new(65534);
+    pub const OVERFLOW: Uid = Self(65534);
 
     pub const fn new_root() -> Self {
         Self(ROOT_UID)
     }
 
-    pub const fn new(uid: u32) -> Self {
+    /// Creates a `Uid` from a raw value, returning `None` if the value is the
+    /// invalid sentinel (i.e., [`Self::RAW_INVALID`]).
+    pub const fn new(uid: RawUid) -> Option<Self> {
+        if uid == Self::RAW_INVALID {
+            None
+        } else {
+            Some(Self(uid))
+        }
+    }
+
+    /// Creates a `Uid` from a raw value without checking for the invalid sentinel.
+    ///
+    /// This is intended for filesystem use where any raw UID stored on disk is valid.
+    pub const fn from_raw(uid: RawUid) -> Self {
         Self(uid)
+    }
+
+    /// Returns whether this UID has a valid mapping (i.e., is not the invalid sentinel).
+    pub const fn has_valid_mapping(&self) -> bool {
+        self.0 != Self::RAW_INVALID
+    }
+
+    /// Returns the underlying raw UID value.
+    pub const fn as_raw(&self) -> RawUid {
+        self.0
     }
 
     pub const fn is_root(&self) -> bool {
         self.0 == ROOT_UID
-    }
-}
-
-impl From<u32> for Uid {
-    fn from(value: u32) -> Self {
-        Self::new(value)
     }
 }
 
@@ -51,7 +71,15 @@ impl From<Uid> for u32 {
     }
 }
 
-define_atomic_version_of_integer_like_type!(Uid, {
+impl TryFrom<u32> for Uid {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::new(value).ok_or_else(|| Error::with_message(Errno::EINVAL, "the UID is invalid"))
+    }
+}
+
+define_atomic_version_of_integer_like_type!(Uid, try_from = true, {
     #[derive(Debug)]
     pub(super) struct AtomicUid(AtomicU32);
 });

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -329,9 +329,11 @@ fn set_uid_from_elf(
 ) -> Result<()> {
     if elf_inode.mode()?.has_set_uid() {
         let uid = elf_inode.owner()?;
-        credentials.set_euid(uid);
-
-        current.clear_parent_death_signal();
+        // Ignore suid if the UID has no valid mapping (e.g., raw_uid == -1 on disk).
+        if uid.has_valid_mapping() {
+            credentials.set_euid(uid);
+            current.clear_parent_death_signal();
+        }
     }
 
     // No matter whether the ELF inode has `set_uid` bit, SUID should be reset.
@@ -350,9 +352,11 @@ fn set_gid_from_elf(
 ) -> Result<()> {
     if elf_inode.mode()?.has_set_gid() {
         let gid = elf_inode.group()?;
-        credentials.set_egid(gid);
-
-        current.clear_parent_death_signal();
+        // Ignore sgid if the GID has no valid mapping (e.g., raw_gid == -1 on disk).
+        if gid.has_valid_mapping() {
+            credentials.set_egid(gid);
+            current.clear_parent_death_signal();
+        }
     }
 
     // No matter whether the ELF inode has `set_gid` bit, SGID should be reset.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -24,7 +24,7 @@ mod term_status;
 mod wait;
 
 pub use clone::{CloneArgs, CloneFlags, clone_child};
-pub use credentials::{Credentials, Gid, Uid};
+pub use credentials::{Credentials, Gid, RawGid, RawUid, Uid};
 pub use execve::do_execve;
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use namespace::{

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -8,14 +8,22 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
-    process::{Gid, Uid},
+    process::{Gid, RawGid, RawUid, Uid},
 };
 
-pub fn sys_fchown(raw_fd: RawFileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    debug!("raw_fd = {}, uid = {}, gid = {}", raw_fd, uid, gid);
+pub fn sys_fchown(
+    raw_fd: RawFileDesc,
+    raw_uid: RawUid,
+    raw_gid: RawGid,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    debug!(
+        "raw_fd = {}, raw_uid = {}, raw_gid = {}",
+        raw_fd, raw_uid, raw_gid
+    );
 
-    let uid = to_optional_id(uid, Uid::new)?;
-    let gid = to_optional_id(gid, Gid::new)?;
+    let uid = Uid::new(raw_uid);
+    let gid = Gid::new(raw_gid);
     if uid.is_none() && gid.is_none() {
         return Ok(SyscallReturn::Return(0));
     }
@@ -32,16 +40,26 @@ pub fn sys_fchown(raw_fd: RawFileDesc, uid: i32, gid: i32, ctx: &Context) -> Res
     Ok(SyscallReturn::Return(0))
 }
 
-pub fn sys_chown(path_ptr: Vaddr, uid: i32, gid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    sys_fchownat(AT_FDCWD, path_ptr, uid, gid, 0, ctx)
+pub fn sys_chown(
+    path_ptr: Vaddr,
+    raw_uid: RawUid,
+    raw_gid: RawGid,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    sys_fchownat(AT_FDCWD, path_ptr, raw_uid, raw_gid, 0, ctx)
 }
 
-pub fn sys_lchown(path_ptr: Vaddr, uid: i32, gid: i32, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_lchown(
+    path_ptr: Vaddr,
+    raw_uid: RawUid,
+    raw_gid: RawGid,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
     sys_fchownat(
         AT_FDCWD,
         path_ptr,
-        uid,
-        gid,
+        raw_uid,
+        raw_gid,
         ChownFlags::AT_SYMLINK_NOFOLLOW.bits(),
         ctx,
     )
@@ -50,8 +68,8 @@ pub fn sys_lchown(path_ptr: Vaddr, uid: i32, gid: i32, ctx: &Context) -> Result<
 pub fn sys_fchownat(
     dirfd: RawFileDesc,
     path_ptr: Vaddr,
-    uid: i32,
-    gid: i32,
+    raw_uid: RawUid,
+    raw_gid: RawGid,
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
@@ -59,16 +77,16 @@ pub fn sys_fchownat(
     let flags = ChownFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(
-        "dirfd = {}, path = {:?}, uid = {}, gid = {}, flags = {:?}",
-        dirfd, path_name, uid, gid, flags
+        "dirfd = {}, path = {:?}, raw_uid = {}, raw_gid = {}, flags = {:?}",
+        dirfd, path_name, raw_uid, raw_gid, flags
     );
 
     if flags.contains(ChownFlags::AT_EMPTY_PATH) && path_name.is_empty() {
-        return sys_fchown(dirfd, uid, gid, ctx);
+        return sys_fchown(dirfd, raw_uid, raw_gid, ctx);
     }
 
-    let uid = to_optional_id(uid, Uid::new)?;
-    let gid = to_optional_id(gid, Gid::new)?;
+    let uid = Uid::new(raw_uid);
+    let gid = Gid::new(raw_gid);
     if uid.is_none() && gid.is_none() {
         return Ok(SyscallReturn::Return(0));
     }
@@ -94,19 +112,6 @@ pub fn sys_fchownat(
         path.set_group(gid)?;
     }
     Ok(SyscallReturn::Return(0))
-}
-
-fn to_optional_id<T>(id: i32, f: impl Fn(u32) -> T) -> Result<Option<T>> {
-    let id = if id >= 0 {
-        Some(f(id as u32))
-    } else if id == -1 {
-        // If the owner or group is specified as -1, then that ID is not changed.
-        None
-    } else {
-        return_errno!(Errno::EINVAL);
-    };
-
-    Ok(id)
 }
 
 bitflags! {

--- a/kernel/src/syscall/get_priority.rs
+++ b/kernel/src/syscall/get_priority.rs
@@ -100,8 +100,12 @@ impl PriorityTarget {
             Which::PRIO_USER => {
                 let uid = if who == 0 {
                     ctx.posix_thread.credentials().ruid()
+                } else if let Some(uid) = Uid::new(who) {
+                    uid
                 } else {
-                    Uid::new(who)
+                    // Linux does not validate the UID here. An invalid UID
+                    // simply finds no matching processes and returns `ESRCH`.
+                    return_errno_with_message!(Errno::ESRCH, "invalid UID");
                 };
                 Self::User(uid)
             }

--- a/kernel/src/syscall/setfsgid.rs
+++ b/kernel/src/syscall/setfsgid.rs
@@ -3,15 +3,11 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, posix_thread::ContextPthreadAdminApi},
+    process::{Gid, RawGid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setfsgid(gid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let fsgid = if gid >= 0 {
-        Some(Gid::new(gid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setfsgid(raw_gid: RawGid, ctx: &Context) -> Result<SyscallReturn> {
+    let fsgid = Gid::new(raw_gid);
 
     debug!("fsgid = {:?}", fsgid);
 

--- a/kernel/src/syscall/setfsuid.rs
+++ b/kernel/src/syscall/setfsuid.rs
@@ -3,15 +3,11 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Uid, posix_thread::ContextPthreadAdminApi},
+    process::{RawUid, Uid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setfsuid(uid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let fsuid = if uid >= 0 {
-        Some(Uid::new(uid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setfsuid(raw_uid: RawUid, ctx: &Context) -> Result<SyscallReturn> {
+    let fsuid = Uid::new(raw_uid);
 
     debug!("fsuid = {:?}", fsuid);
 

--- a/kernel/src/syscall/setgid.rs
+++ b/kernel/src/syscall/setgid.rs
@@ -3,15 +3,11 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, posix_thread::ContextPthreadAdminApi},
+    process::{Gid, RawGid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setgid(gid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    if gid < 0 {
-        return_errno_with_message!(Errno::EINVAL, "GIDs cannot be negative");
-    }
-
-    let gid = Gid::new(gid.cast_unsigned());
+pub fn sys_setgid(raw_gid: RawGid, ctx: &Context) -> Result<SyscallReturn> {
+    let gid = Gid::try_from(raw_gid)?;
     debug!("gid = {:?}", gid);
 
     let credentials = ctx.credentials_mut();

--- a/kernel/src/syscall/setgroups.rs
+++ b/kernel/src/syscall/setgroups.rs
@@ -5,7 +5,9 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, credentials::capabilities::CapSet, posix_thread::ContextPthreadAdminApi},
+    process::{
+        Gid, RawGid, credentials::capabilities::CapSet, posix_thread::ContextPthreadAdminApi,
+    },
     security::lsm::hooks as lsm_hooks,
 };
 
@@ -24,8 +26,9 @@ pub fn sys_setgroups(size: usize, group_list_addr: Vaddr, ctx: &Context) -> Resu
 
     let mut new_groups = BTreeSet::new();
     for idx in 0..size {
-        let addr = group_list_addr + idx * size_of::<Gid>();
-        let gid = ctx.user_space().read_val(addr)?;
+        let addr = group_list_addr + idx * size_of::<RawGid>();
+        let raw_gid: RawGid = ctx.user_space().read_val(addr)?;
+        let gid = Gid::try_from(raw_gid)?;
         new_groups.insert(gid);
     }
 

--- a/kernel/src/syscall/setregid.rs
+++ b/kernel/src/syscall/setregid.rs
@@ -3,21 +3,12 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, posix_thread::ContextPthreadAdminApi},
+    process::{Gid, RawGid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setregid(rgid: i32, egid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let rgid = if rgid >= 0 {
-        Some(Gid::new(rgid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let egid = if egid >= 0 {
-        Some(Gid::new(egid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setregid(rgid: RawGid, egid: RawGid, ctx: &Context) -> Result<SyscallReturn> {
+    let rgid = Gid::new(rgid);
+    let egid = Gid::new(egid);
 
     debug!("rgid = {:?}, egid = {:?}", rgid, egid);
 

--- a/kernel/src/syscall/setresgid.rs
+++ b/kernel/src/syscall/setresgid.rs
@@ -3,27 +3,18 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Gid, posix_thread::ContextPthreadAdminApi},
+    process::{Gid, RawGid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setresgid(rgid: i32, egid: i32, sgid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let rgid = if rgid >= 0 {
-        Some(Gid::new(rgid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let egid = if egid >= 0 {
-        Some(Gid::new(egid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let sgid = if sgid >= 0 {
-        Some(Gid::new(sgid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setresgid(
+    rgid: RawGid,
+    egid: RawGid,
+    sgid: RawGid,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let rgid = Gid::new(rgid);
+    let egid = Gid::new(egid);
+    let sgid = Gid::new(sgid);
 
     debug!("rgid = {:?}, egid = {:?}, sgid = {:?}", rgid, egid, sgid);
 

--- a/kernel/src/syscall/setresuid.rs
+++ b/kernel/src/syscall/setresuid.rs
@@ -3,27 +3,18 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Uid, posix_thread::ContextPthreadAdminApi},
+    process::{RawUid, Uid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setresuid(ruid: i32, euid: i32, suid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let ruid = if ruid >= 0 {
-        Some(Uid::new(ruid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let euid = if euid >= 0 {
-        Some(Uid::new(euid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let suid = if suid >= 0 {
-        Some(Uid::new(suid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setresuid(
+    ruid: RawUid,
+    euid: RawUid,
+    suid: RawUid,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let ruid = Uid::new(ruid);
+    let euid = Uid::new(euid);
+    let suid = Uid::new(suid);
 
     debug!("ruid = {:?}, euid = {:?}, suid = {:?}", ruid, euid, suid);
 

--- a/kernel/src/syscall/setreuid.rs
+++ b/kernel/src/syscall/setreuid.rs
@@ -3,21 +3,12 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Uid, posix_thread::ContextPthreadAdminApi},
+    process::{RawUid, Uid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setreuid(ruid: i32, euid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    let ruid = if ruid >= 0 {
-        Some(Uid::new(ruid.cast_unsigned()))
-    } else {
-        None
-    };
-
-    let euid = if euid >= 0 {
-        Some(Uid::new(euid.cast_unsigned()))
-    } else {
-        None
-    };
+pub fn sys_setreuid(ruid: RawUid, euid: RawUid, ctx: &Context) -> Result<SyscallReturn> {
+    let ruid = Uid::new(ruid);
+    let euid = Uid::new(euid);
 
     debug!("ruid = {:?}, euid = {:?}", ruid, euid);
 

--- a/kernel/src/syscall/setuid.rs
+++ b/kernel/src/syscall/setuid.rs
@@ -3,15 +3,11 @@
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{Uid, posix_thread::ContextPthreadAdminApi},
+    process::{RawUid, Uid, posix_thread::ContextPthreadAdminApi},
 };
 
-pub fn sys_setuid(uid: i32, ctx: &Context) -> Result<SyscallReturn> {
-    if uid < 0 {
-        return_errno_with_message!(Errno::EINVAL, "UIDs cannot be negative");
-    }
-
-    let uid = Uid::new(uid.cast_unsigned());
+pub fn sys_setuid(raw_uid: RawUid, ctx: &Context) -> Result<SyscallReturn> {
+    let uid = Uid::try_from(raw_uid)?;
     debug!("uid = {:?}", uid);
 
     let credentials = ctx.credentials_mut();

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 SUBDIRS := \
+	chown \
 	ext2 \
 	fdatasync \
 	getcwd \

--- a/test/initramfs/src/regression/fs/chown/Makefile
+++ b/test/initramfs/src/regression/fs/chown/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/chown/chown.c
+++ b/test/initramfs/src/regression/fs/chown/chown.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define TEST_FILE "/tmp/chown_test"
+
+FN_SETUP(create_test_file)
+{
+	int fd = CHECK(open(TEST_FILE, O_CREAT | O_WRONLY | O_TRUNC, 0644));
+	CHECK(close(fd));
+}
+END_SETUP()
+
+FN_TEST(chown_negative_uid_as_unsigned)
+{
+	// -2 cast to `uid_t` (32-bit unsigned) is 4294967294.
+	// Linux treats all non-(-1) values as unsigned.
+	TEST_SUCC(chown(TEST_FILE, -2, -1));
+
+	struct stat st;
+	TEST_RES(stat(TEST_FILE, &st), st.st_uid == (uid_t)-2);
+
+	TEST_SUCC(chown(TEST_FILE, 0, 0));
+}
+END_TEST()
+
+FN_TEST(chown_negative_gid_as_unsigned)
+{
+	TEST_SUCC(chown(TEST_FILE, -1, -2));
+
+	struct stat st;
+	TEST_RES(stat(TEST_FILE, &st), st.st_gid == (gid_t)-2);
+
+	TEST_SUCC(chown(TEST_FILE, 0, 0));
+}
+END_TEST()
+
+FN_TEST(chown_minus_one_no_change)
+{
+	TEST_SUCC(chown(TEST_FILE, 1000, 1000));
+
+	// -1 means "no change" for both UID and GID.
+	TEST_SUCC(chown(TEST_FILE, -1, -1));
+
+	struct stat st;
+	TEST_RES(stat(TEST_FILE, &st), st.st_uid == 1000 && st.st_gid == 1000);
+
+	TEST_SUCC(chown(TEST_FILE, 0, 0));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(unlink(TEST_FILE));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -112,6 +112,8 @@ echo "Start mount bind file test......"
 test_mount_bind_file
 echo "All mount bind file test passed."
 
+./chown/chown
+
 ./getcwd/getcwd
 
 ./inotify/inotify_align


### PR DESCRIPTION
Cast all non-(-1) values to u32 to match Linux behavior.



`chown()` rejects any negative uid or gid value other than -1 with `EINVAL`. On Linux, negative values are treated as unsigned ~~(e.g., `uid=-2` becomes `uid_t(65534)` = `nobody`). This affects programs that use the `nobody` user (uid 65534, which is `-2` when passed as `int`).~~

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <errno.h>
#include <string.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/stat.h>

int main(void) {
    const char *path = "/tmp/chown_test";
    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
    close(fd);

    errno = 0;
    int ret = chown(path, -2, -1); /* -2 = uid 65534 (nobody) */
    printf("chown(path, -2, -1): ret=%d errno=%d (%s)\n",
           ret, errno, ret == 0 ? "success" : strerror(errno));

    if (ret == 0) {
        struct stat st;
        stat(path, &st);
        printf("new uid=%d\n", st.st_uid);
    }

    unlink(path);
    return 0;
}
```

### Expected behavior
`chown(path, -2, -1)` should succeed and set the uid to ~~65534 (nobody).~~

### Log
- In Asterinas:
```
chown(path, -2, -1): ret=-1 errno=22 (Invalid argument)
```
- In Linux:
```
chown(path, -2, -1): ret=0 errno=0 (success)
new uid=-2
```