### PR TITLE
Fix `getcwd` not returning ERANGE for small buffer

### DIFF
--- a/kernel/src/syscall/getcwd.rs
+++ b/kernel/src/syscall/getcwd.rs
@@ -27,8 +27,10 @@ pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn
 
     let cwd = CString::new(abs_path)?;
     let bytes = cwd.as_bytes_with_nul();
-    let write_len = len.min(bytes.len());
-    ctx.user_space().write_bytes(buf, &bytes[..write_len])?;
+    if bytes.len() > len {
+        return_errno_with_message!(Errno::ERANGE, "the CWD buffer is too small");
+    }
+    ctx.user_space().write_bytes(buf, bytes)?;
 
-    Ok(SyscallReturn::Return(write_len as _))
+    Ok(SyscallReturn::Return(bytes.len() as _))
 }

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -3,6 +3,7 @@
 SUBDIRS := \
 	ext2 \
 	fdatasync \
+	getcwd \
 	inotify \
 	isolation \
 	mount \

--- a/test/initramfs/src/regression/fs/getcwd/Makefile
+++ b/test/initramfs/src/regression/fs/getcwd/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/getcwd/getcwd.c
+++ b/test/initramfs/src/regression/fs/getcwd/getcwd.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(getcwd_small_buffer_returns_erange)
+{
+	char small[1];
+	TEST_ERRNO(getcwd(small, 1), ERANGE);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -112,6 +112,8 @@ echo "Start mount bind file test......"
 test_mount_bind_file
 echo "All mount bind file test passed."
 
+./getcwd/getcwd
+
 ./inotify/inotify_align
 ./inotify/inotify_poll
 ./inotify/inotify_unlink


### PR DESCRIPTION
This PR makes Asterinas return ERANGE when the buffer cannot hold the full path including the null terminator, 
matching Linux's behavior in https://elixir.bootlin.com/linux/v6.15/source/fs/d_path.c#L439-L440
```C
		else if (unlikely(len > size))
			error = -ERANGE;
```

When `getcwd()` is called with a buffer too small to hold the current working directory path, it should return NULL and set `errno` to `ERANGE`. On Asterinas, it returns success and writes a truncated path into the buffer, which can cause buffer overflows and incorrect behavior in programs that rely on the ERANGE error to resize their buffer.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <string.h>
#include <errno.h>
#include <unistd.h>

int main(void) {
    char small[1]; /* too small for any path */
    errno = 0;
    char *ret = getcwd(small, 1);
    printf("getcwd(buf, 1): ret=%p errno=%d (%s)\n",
           ret, errno, ret == NULL ? strerror(errno) : "success");
    return 0;
}
```

### Expected behavior
`getcwd()` should return NULL and set `errno` to `ERANGE`.

### Log
- In Asterinas:
```
getcwd(buf=1): ret=0x7ffffff08d6e errno=0 (Success)
```
- In Linux:
```
getcwd(buf=1): ret=(nil) errno=34 (Numerical result out of range)
```
