### PR TITLE
Fix `arch_prctl` ARCH_GET_FS/GS returning value

### DIFF
--- a/kernel/src/syscall/arch_prctl.rs
+++ b/kernel/src/syscall/arch_prctl.rs
@@ -2,7 +2,7 @@
 
 use ostd::{
     arch::cpu::context::{FsBase, GsBase},
-    mm::MAX_USERSPACE_VADDR,
+    mm::{MAX_USERSPACE_VADDR, VmIo},
 };
 
 use super::SyscallReturn;
@@ -18,7 +18,7 @@ enum ArchPrctlCode {
     ARCH_GET_GS = 0x1004,
 }
 
-pub fn sys_arch_prctl(code: u64, addr: u64, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_arch_prctl(code: u64, addr: usize, ctx: &Context) -> Result<SyscallReturn> {
     let arch_prctl_code = ArchPrctlCode::try_from(code)?;
     debug!(
         "arch_prctl_code: {:?}, addr = 0x{:x}",
@@ -28,25 +28,33 @@ pub fn sys_arch_prctl(code: u64, addr: u64, ctx: &Context) -> Result<SyscallRetu
     Ok(SyscallReturn::Return(res as _))
 }
 
-fn do_arch_prctl(code: ArchPrctlCode, addr: u64, ctx: &Context) -> Result<u64> {
+fn do_arch_prctl(code: ArchPrctlCode, addr: usize, ctx: &Context) -> Result<u64> {
     let supp = ctx.thread_local.supp_user_context();
 
     match code {
         ArchPrctlCode::ARCH_SET_GS => {
-            if addr as usize >= MAX_USERSPACE_VADDR {
+            if addr >= MAX_USERSPACE_VADDR {
                 return_errno_with_message!(Errno::EPERM, "gsbase must be a userspace address");
             }
-            supp.gs_base().set(GsBase::new(addr as usize));
+            supp.gs_base().set(GsBase::new(addr));
             Ok(0)
         }
         ArchPrctlCode::ARCH_SET_FS => {
-            if addr as usize >= MAX_USERSPACE_VADDR {
+            if addr >= MAX_USERSPACE_VADDR {
                 return_errno_with_message!(Errno::EPERM, "fsbase must be a userspace address");
             }
-            supp.fs_base().set(FsBase::new(addr as usize));
+            supp.fs_base().set(FsBase::new(addr));
             Ok(0)
         }
-        ArchPrctlCode::ARCH_GET_FS => Ok(supp.fs_base().get().addr() as u64),
-        ArchPrctlCode::ARCH_GET_GS => Ok(supp.gs_base().get().addr() as u64),
+        ArchPrctlCode::ARCH_GET_FS => {
+            let base = supp.fs_base().get().addr();
+            ctx.user_space().write_val(addr, &base)?;
+            Ok(0)
+        }
+        ArchPrctlCode::ARCH_GET_GS => {
+            let base = supp.gs_base().get().addr();
+            ctx.user_space().write_val(addr, &base)?;
+            Ok(0)
+        }
     }
 }

--- a/test/initramfs/src/regression/process/arch_prctl/fsgsbase.c
+++ b/test/initramfs/src/regression/process/arch_prctl/fsgsbase.c
@@ -29,9 +29,9 @@ static int cpu_has_fsgsbase(void)
 	return ebx & CPUID_FSGSBASE;
 }
 
-static long arch_get_gs(void)
+static int arch_get_gs(uintptr_t *gs_base)
 {
-	return syscall(SYS_arch_prctl, ARCH_GET_GS, 0);
+	return syscall(SYS_arch_prctl, ARCH_GET_GS, gs_base);
 }
 
 static int arch_set_gs(uintptr_t gs_base)
@@ -56,16 +56,18 @@ FN_TEST(sync_gsbase_from_cpu)
 {
 	SKIP_TEST_IF(!cpu_has_fsgsbase());
 
+	uintptr_t got_gs;
+
 	uintptr_t syscall_gs = (uintptr_t)&gs_slots[0];
 	TEST_SUCC(arch_set_gs(syscall_gs));
 	usleep(100); // Trigger a syscall and context switch.
 	TEST_RES(read_gsbase(), _ret == syscall_gs);
-	TEST_RES(arch_get_gs(), _ret == syscall_gs);
+	TEST_RES(arch_get_gs(&got_gs), got_gs == syscall_gs);
 
 	uintptr_t fsgsbase_gs = (uintptr_t)&gs_slots[1];
 	write_gsbase(fsgsbase_gs);
 	usleep(100); // Trigger a syscall and context switch.
 	TEST_RES(read_gsbase(), _ret == fsgsbase_gs);
-	TEST_RES(arch_get_gs(), _ret == fsgsbase_gs);
+	TEST_RES(arch_get_gs(&got_gs), got_gs == fsgsbase_gs);
 }
 END_TEST()


### PR DESCRIPTION
This PR writes the base value to the userspace address via `write_val` and returns 0 on success, matching the Linux implementation

https://man7.org/linux/man-pages/man2/arch_prctl.2.html

```
On success, arch_prctl() returns 0; on error, -1 is returned, and
       [errno](https://man7.org/linux/man-pages/man3/errno.3.html) is set to indicate the error.
```

### Describe the bug
`arch_prctl(ARCH_GET_FS, &addr)` should write the FS base value to the memory location pointed to by `addr` and return 0 on success. On Asterinas, the FS base value is returned directly as the syscall return value, and `*addr` is left unchanged. This also affects `ARCH_GET_GS`.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <asm/prctl.h>
#include <sys/syscall.h>
#include <unistd.h>

int main(void) {
    unsigned long fs_val = 0xDEADBEEFDEADBEEFUL;
    long ret = syscall(SYS_arch_prctl, ARCH_GET_FS, &fs_val);
    printf("ret=%ld, *addr=0x%lx\n", ret, fs_val);
    // Linux:    ret=0, *addr=<actual FS base>
    // Asterinas: ret=<FS base>, *addr=0xDEADBEEFDEADBEEF (unchanged)
    return 0;
}
```

### Expected behavior
`ret` should be 0 and `fs_val` should contain the FS base address.

### Log
- In Asterinas:
```
ret=5010304, *addr=0xdeadbeefdeadbeef
```
- In Linux:
```
ret=0, *addr=0xa98880
```