### PR TITLE
Fix invalid RWF flag errors

### DIFF
--- a/kernel/src/syscall/preadv.rs
+++ b/kernel/src/syscall/preadv.rs
@@ -56,7 +56,7 @@ pub fn sys_preadv2(
     let offset = offset_low.cast_signed();
     let flags = match RWFFlag::from_bits(flags) {
         Some(flags) => flags,
-        None => return_errno_with_message!(Errno::EINVAL, "invalid flags"),
+        None => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported flags"),
     };
     let res = if offset == -1 {
         do_sys_readv(raw_fd, io_vec_ptr, io_vec_count, ctx)?

--- a/kernel/src/syscall/pwritev.rs
+++ b/kernel/src/syscall/pwritev.rs
@@ -56,7 +56,7 @@ pub fn sys_pwritev2(
     let offset = offset_low.cast_signed();
     let flags = match RWFFlag::from_bits(flags) {
         Some(flags) => flags,
-        None => return_errno_with_message!(Errno::EINVAL, "invalid flags"),
+        None => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported flags"),
     };
     let res = if offset == -1 {
         do_sys_writev(raw_fd, io_vec_ptr, io_vec_count, ctx)?

--- a/test/initramfs/src/conformance/gvisor/blocklists/preadv2_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/preadv2_test
@@ -1,4 +1,3 @@
 Preadv2Test.Preadv2WithOpath
-Preadv2Test.TestInvalidFlag
 Preadv2Test.TestUnreadableFile
 Preadv2Test.TestUnseekableFileInvalid

--- a/test/initramfs/src/conformance/gvisor/blocklists/pwritev2_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/pwritev2_test
@@ -1,1 +1,0 @@
-Pwritev2Test.InvalidFlag

--- a/test/initramfs/src/regression/io/file_io/iovec_err.c
+++ b/test/initramfs/src/regression/io/file_io/iovec_err.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <sys/fcntl.h>
 #include <sys/socket.h>
+#include <sys/syscall.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
@@ -56,6 +57,21 @@ FN_TEST(writev)
 	TEST_ERRNO(writev(fd, iov_inv, 2), EINVAL);
 
 	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(preadv2_pwritev2_invalid_flags)
+{
+	const char *file_path = "/tmp/iovec_err_invalid_flags";
+	int fd;
+
+	fd = TEST_SUCC(open(file_path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+	TEST_ERRNO(syscall(SYS_preadv2, fd, iov_long, 1, 0, 0, 0xf0),
+		   EOPNOTSUPP);
+	TEST_ERRNO(syscall(SYS_pwritev2, fd, iov_long, 1, 0, 0, 0xf0),
+		   EOPNOTSUPP);
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(file_path));
 }
 END_TEST()
 


### PR DESCRIPTION
## Summary

Fix `preadv2` and `pwritev2` to return `EOPNOTSUPP` instead of `EINVAL` when unsupported `RWF_*` flags are specified.

## Changes

- Return `EOPNOTSUPP` for unsupported `RWF_*` flags in `preadv2` and `pwritev2`.
- Add regression for invalid `preadv2` / `pwritev2` flags.
- Unblock the gVisor `Preadv2Test.TestInvalidFlag` and `Pwritev2Test.InvalidFlag` cases.

## Testing

- `TEST_TMPDIR=/tmp ./preadv2_test --gtest_filter=Preadv2Test.TestInvalidFlag`

  ```text
  [  PASSED  ] 1 test.
  ```

- `TEST_TMPDIR=/tmp ./pwritev2_test --gtest_filter=Pwritev2Test.InvalidFlag`

  ```text
  [  PASSED  ] 1 test.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  ```

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```