### PR TITLE
Fix `pidfd_send_signal` returning EPERM for NULL siginfo

### DIFF
--- a/kernel/src/syscall/pidfd_send_signal.rs
+++ b/kernel/src/syscall/pidfd_send_signal.rs
@@ -39,17 +39,21 @@ pub fn sys_pidfd_send_signal(
 
     let target = get_target_from_pidfd(pidfd, flags, ctx)?;
 
-    let is_self = match &target {
-        SignalTarget::Thread { tid, tgid: _ } => *tid == ctx.posix_thread.tid(),
-        SignalTarget::Process { pid } => *pid == ctx.posix_thread.tid(),
-        SignalTarget::ProcessGroup { pgid: _ } => false,
-    };
+    // Only check `si_code` permissions when the user explicitly provided a siginfo.
+    // When `info_ptr` is `NULL`, the kernel generates the siginfo, so no restriction applies.
+    if info_ptr != 0 {
+        let is_self = match &target {
+            SignalTarget::Thread { tid, tgid: _ } => *tid == ctx.posix_thread.tid(),
+            SignalTarget::Process { pid } => *pid == ctx.posix_thread.tid(),
+            SignalTarget::ProcessGroup { pgid: _ } => false,
+        };
 
-    if !is_self && (siginfo.si_code >= 0 || siginfo.si_code == SI_TKILL) {
-        return_errno_with_message!(
-            Errno::EPERM,
-            "signals with custom code can only be sent to the current thread/process"
-        );
+        if !is_self && (siginfo.si_code >= 0 || siginfo.si_code == SI_TKILL) {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "signals with custom code can only be sent to the current thread/process"
+            );
+        }
     }
 
     match target {

--- a/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
+++ b/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
@@ -78,13 +78,46 @@ END_TEST()
 FN_TEST(pidfd_send_signal_process)
 {
 	TEST_SUCC(pidfd_send_signal(process_pidfd, sig, &siginfo, 0));
-	TEST_SUCC(waitid(P_PID, process_pid, NULL, WNOWAIT | WEXITED));
+	TEST_SUCC(waitid(P_PID, process_pid, NULL, WEXITED));
 }
 END_TEST()
 
 FN_SETUP(cleanup_process)
 {
 	CHECK(close(process_pidfd));
+}
+END_SETUP()
+
+/* ========================
+ *  Tests for NULL siginfo
+ * ======================== */
+
+int null_info_child_pid;
+int null_info_pidfd;
+
+FN_SETUP(create_null_info_process)
+{
+	null_info_child_pid = CHECK(fork());
+	if (null_info_child_pid == 0) {
+		while (1) {
+			usleep(100);
+		}
+	}
+
+	null_info_pidfd = CHECK(pidfd_open(null_info_child_pid, 0));
+}
+END_SETUP()
+
+FN_TEST(pidfd_send_signal_null_info)
+{
+	TEST_SUCC(pidfd_send_signal(null_info_pidfd, SIGTERM, NULL, 0));
+	TEST_SUCC(waitid(P_PID, null_info_child_pid, NULL, WEXITED));
+}
+END_TEST()
+
+FN_SETUP(cleanup_null_info_process)
+{
+	CHECK(close(null_info_pidfd));
 }
 END_SETUP()
 


### PR DESCRIPTION
In kernel/src/syscall/pidfd_send_signal.rs, the `si_code` permission check is now guarded by `if info_ptr != 0`, 
so it only applies when the user explicitly provides a `siginfo_t` structure.

Linux code logic:
https://elixir.bootlin.com/linux/v6.15/source/kernel/signal.c#L4027-L4041
```C
	if (info) {
		int ret;

		ret = copy_siginfo_from_user_any(&kinfo, info);
		if (unlikely(ret))
			return ret;

		if (unlikely(sig != kinfo.si_signo))
			return -EINVAL;

		/* Only allow sending arbitrary signals to yourself. */
		if ((task_pid(current) != pid || type > PIDTYPE_TGID) &&
		    (kinfo.si_code >= 0 || kinfo.si_code == SI_TKILL))
			return -EPERM;
	} else {
```


### Describe the bug
`pidfd_send_signal()` returns -1 when sending a signal via a valid pidfd obtained from `pidfd_open()`. 
On Linux, this works correctly — signals can be sent to a process via its pidfd.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <errno.h>
#include <string.h>
#include <signal.h>
#include <unistd.h>
#include <sys/syscall.h>
#include <sys/wait.h>

int main(void) {
    pid_t child = fork();
    if (child == 0) { pause(); _exit(0); }

    int pidfd = syscall(SYS_pidfd_open, child, 0);
    printf("pidfd_open(%d): fd=%d\n", child, pidfd);

    int ret = syscall(SYS_pidfd_send_signal, pidfd, SIGTERM, NULL, 0);
    printf("pidfd_send_signal(SIGTERM): ret=%d errno=%d (%s)\n",
           ret, errno, ret == 0 ? "success" : strerror(errno));

    waitpid(child, NULL, 0);
    close(pidfd);
    return 0;
}
```

### Expected behavior
`pidfd_send_signal` should return 0 and deliver SIGTERM to the child process.

### Log
- In Asterinas:
```
pidfd_open(11, 0): fd=3 errno=none
pidfd_send_signal(SIGTERM): ret=-1
```
- In Linux:
```
pidfd_open(7, 0): fd=3 errno=none
pidfd_send_signal(SIGTERM): ret=0
```
