### PR TITLE
Mark ACPI region reclaimable for Multiboot

### DIFF
--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -90,10 +90,25 @@ fn parse_acpi_arg(boot_params: &BootParams) -> BootloaderAcpiArg {
     let rsdp = boot_params.acpi_rsdp_addr;
 
     if rsdp == 0 {
-        BootloaderAcpiArg::NotProvided
+        if is_efi_boot(boot_params) {
+            BootloaderAcpiArg::NotProvided
+        } else {
+            BootloaderAcpiArg::ScanBios
+        }
     } else {
         BootloaderAcpiArg::Rsdp(rsdp.try_into().expect("RSDP address overflowed!"))
     }
+}
+
+fn is_efi_boot(boot_params: &BootParams) -> bool {
+    const EFI32_LOADER_SIGNATURE: u32 = u32::from_le_bytes(*b"EL32");
+    const EFI64_LOADER_SIGNATURE: u32 = u32::from_le_bytes(*b"EL64");
+
+    let efi_info = boot_params.efi_info;
+    matches!(
+        efi_info.efi_loader_signature,
+        EFI32_LOADER_SIGNATURE | EFI64_LOADER_SIGNATURE
+    )
 }
 
 fn parse_framebuffer_info(boot_params: &BootParams) -> Option<BootloaderFramebufferArg> {

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -62,7 +62,7 @@ fn parse_initramfs(mb1_info: &MultibootLegacyInfo) -> Option<&[u8]> {
 fn parse_acpi_arg(_mb1_info: &MultibootLegacyInfo) -> BootloaderAcpiArg {
     // Multiboot v1 is BIOS-oriented and does not define a standard field for
     // the RSDP or the EFI System Table.
-    BootloaderAcpiArg::NotProvided
+    BootloaderAcpiArg::ScanBios
 }
 
 fn parse_framebuffer_info(mb1_info: &MultibootLegacyInfo) -> Option<BootloaderFramebufferArg> {

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::arch::global_asm;
+use core::{arch::global_asm, num::NonZeroUsize};
+
+use acpi::rsdp::Rsdp;
 
 use crate::{
+    arch::kernel::acpi::AcpiMemoryHandler,
     boot::{
         BootloaderAcpiArg, BootloaderFramebufferArg,
         memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
@@ -57,8 +60,8 @@ fn parse_initramfs(mb1_info: &MultibootLegacyInfo) -> Option<&[u8]> {
 }
 
 fn parse_acpi_arg(_mb1_info: &MultibootLegacyInfo) -> BootloaderAcpiArg {
-    // The multiboot protocol does not contain RSDP address.
-    // TODO: What about UEFI?
+    // Multiboot v1 is BIOS-oriented and does not define a standard field for
+    // the RSDP or the EFI System Table.
     BootloaderAcpiArg::NotProvided
 }
 
@@ -78,13 +81,30 @@ fn parse_framebuffer_info(mb1_info: &MultibootLegacyInfo) -> Option<BootloaderFr
 fn parse_memory_regions(mb1_info: &MultibootLegacyInfo) -> MemoryRegionArray {
     let mut regions = MemoryRegionArray::new();
 
+    // The Multiboot protocol does not report ACPI regions explicitly. An ACPI
+    // region may live above the highest usable physical memory region when the
+    // total memory size is below 2G. We therefore mark it as reclaimable to
+    // include it in the linear mappings and allow access.
+    //
+    // FIXME: The ACPI specification does not guarantee that all ACPI tables
+    // are contiguous and do not cross region boundaries. See ACPI 6.4, Section
+    // 5.1, "Overview of the System Description Table Architecture".
+    // A full ACPI table graph scan may eventually be unavoidable.
+    let acpi_root_table_address = find_acpi_root_table_address();
+
     // Add the regions in the multiboot protocol.
     for entry in mb1_info.get_memory_map() {
-        let region = MemoryRegion::new(
-            entry.base_addr().try_into().unwrap(),
-            entry.length().try_into().unwrap(),
-            entry.memory_type(),
-        );
+        let base = entry.base_addr().try_into().unwrap();
+        let len = entry.length().try_into().unwrap();
+        let mut typ = entry.memory_type();
+        if typ == MemoryRegionType::Reserved
+            && acpi_root_table_address
+                .is_some_and(|address| (base..(base + len)).contains(&address.get()))
+        {
+            typ = MemoryRegionType::Reclaimable;
+        }
+
+        let region = MemoryRegion::new(base, len, typ);
         regions.push(region).unwrap();
     }
 
@@ -119,6 +139,23 @@ fn parse_memory_regions(mb1_info: &MultibootLegacyInfo) -> MemoryRegionArray {
     }
 
     regions.into_non_overlapping()
+}
+
+fn find_acpi_root_table_address() -> Option<NonZeroUsize> {
+    // Multiboot v1 is BIOS-oriented: its entry state and boot information are
+    // based on the legacy PC BIOS model, and it has no standard EFI System
+    // Table field. So we use the BIOS RSDP scan as the legacy fallback.
+    //
+    // SAFETY: The Multiboot v1 entry path is treated as BIOS-compatible.
+    let Ok(rsdp) = (unsafe { Rsdp::search_for_on_bios(AcpiMemoryHandler {}) }) else {
+        return None;
+    };
+
+    if rsdp.revision() == 0 {
+        NonZeroUsize::new(rsdp.rsdt_address() as usize)
+    } else {
+        NonZeroUsize::new(rsdp.xsdt_address() as usize)
+    }
 }
 
 /// Representation of Multiboot Information according to specification.

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -56,9 +56,20 @@ fn parse_acpi_arg(mb2_info: &BootInformation) -> BootloaderAcpiArg {
     } else if let Some(v1_tag) = mb2_info.rsdp_v1_tag() {
         // Fall back to RSDP v1
         BootloaderAcpiArg::Rsdt(v1_tag.rsdt_address())
-    } else {
+    } else if is_efi_boot(mb2_info) {
         BootloaderAcpiArg::NotProvided
+    } else {
+        BootloaderAcpiArg::ScanBios
     }
+}
+
+fn is_efi_boot(mb2_info: &BootInformation) -> bool {
+    mb2_info.efi_sdt32_tag().is_some()
+        || mb2_info.efi_sdt64_tag().is_some()
+        || mb2_info.efi_memory_map_tag().is_some()
+        || mb2_info.efi_bs_not_exited_tag().is_some()
+        || mb2_info.efi_ih32_tag().is_some()
+        || mb2_info.efi_ih64_tag().is_some()
 }
 
 fn parse_framebuffer_info(mb2_info: &BootInformation) -> Option<BootloaderFramebufferArg> {

--- a/ostd/src/arch/x86/kernel/acpi/mod.rs
+++ b/ostd/src/arch/x86/kernel/acpi/mod.rs
@@ -74,8 +74,8 @@ pub(crate) fn get_acpi_tables() -> Option<&'static AcpiTables<AcpiMemoryHandler>
             BootloaderAcpiArg::Xsdt(addr) => unsafe {
                 AcpiTables::from_rsdt(AcpiMemoryHandler {}, 1, addr).unwrap()
             },
-            BootloaderAcpiArg::NotProvided => {
-                // We search by ourselves if the bootloader decides not to provide a rsdp location.
+            BootloaderAcpiArg::ScanBios => {
+                // SAFETY: The selected boot path permits legacy BIOS RSDP scanning.
                 let rsdp = unsafe { Rsdp::search_for_on_bios(AcpiMemoryHandler {}) };
                 match rsdp {
                     Ok(map) => unsafe {
@@ -86,6 +86,10 @@ pub(crate) fn get_acpi_tables() -> Option<&'static AcpiTables<AcpiMemoryHandler>
                         return SyncAcpiTables(None);
                     }
                 }
+            }
+            BootloaderAcpiArg::NotProvided => {
+                warn!("ACPI info not found!");
+                return SyncAcpiTables(None);
             }
         };
 

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -52,8 +52,10 @@ static INFO: Once<BootInfo> = Once::new();
 /// This is because bootloaders differ in such behaviors.
 #[derive(Clone, Copy, Debug)]
 pub enum BootloaderAcpiArg {
-    /// The bootloader does not provide one, a manual search is needed.
+    /// The bootloader does not provide one.
     NotProvided,
+    /// The boot path permits scanning legacy BIOS regions for the RSDP.
+    ScanBios,
     /// Physical address of the RSDP.
     Rsdp(usize),
     /// Address of RSDT provided in RSDP v1.


### PR DESCRIPTION
Fixes #3030.

For more background, you can see the discussion under #3030.

The address of the ACPI tables can potentially be higher than all usable memory regions, particularly when the boot memory is small (e.g., less than 4GB). In such cases, since the kernel page table's linear mapping only covers up to the last usable memory region, the ACPI table area may not be mapped, leading to a kernel page fault and panic when accessed. This can be reproduced by running `make run_kernel BOOT_PROTOCOL=multiboot MEM=2G`, and the panic message can be observed in `qemu-serial.log`.

For boot protocols other than Multiboot, the ACPI table regions are passed in as boot parameters, which allows us to know the ACPI region ranges and establish the necessary mappings accordingly. However, the Multiboot protocol does not include this information in its boot parameters, so we resort to searching the BIOS region to locate the ACPI tables. This approach is based on the existing `get_acpi_tables` implementation, but it remains unsound — especially when booting via UEFI. I have added comments to document this limitation.