### PR TITLE
Fix `alarm` remaining time rounding to match Linux behavior

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     sched::{LinuxSchedPolicy, RealTimePriority, SchedPolicy},
     thread::Thread,
+    time::NSEC_PER_SEC,
     vm::vmar::RssType,
 };
 
@@ -346,9 +347,8 @@ impl ProcFileOps for StatFileOps {
 
 /// Converts a duration into kernel clock ticks.
 fn duration_to_jiffies(duration: Duration) -> u64 {
-    const NSEC_PER_SEC: u64 = 1_000_000_000;
-    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC / TIMER_FREQ;
-    const { assert!(NSEC_PER_SEC.is_multiple_of(TIMER_FREQ)) };
+    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC as u64 / TIMER_FREQ;
+    const { assert!((NSEC_PER_SEC as u64).is_multiple_of(TIMER_FREQ)) };
 
     let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
     let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;

--- a/kernel/src/syscall/alarm.rs
+++ b/kernel/src/syscall/alarm.rs
@@ -3,7 +3,10 @@
 use core::time::Duration;
 
 use super::SyscallReturn;
-use crate::{prelude::*, time::timer::Timeout};
+use crate::{
+    prelude::*,
+    time::{NSEC_PER_SEC, timer::Timeout},
+};
 
 pub fn sys_alarm(seconds: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("seconds = {}", seconds);
@@ -13,7 +16,11 @@ pub fn sys_alarm(seconds: u32, ctx: &Context) -> Result<SyscallReturn> {
 
     let remaining = timer_guard.remain();
     let mut remaining_secs = remaining.as_secs();
-    if remaining.subsec_nanos() > 0 {
+    // Round up remaining time to match Linux kernel behavior.
+    // Reference: <https://elixir.bootlin.com/linux/v6.15/source/kernel/time/itimer.c#L311-L319>
+    if (remaining_secs == 0 && remaining.subsec_nanos() > 0)
+        || remaining.subsec_nanos() as i64 >= NSEC_PER_SEC / 2
+    {
         remaining_secs += 1;
     }
 

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -24,7 +24,7 @@ pub type suseconds_t = i64;
 
 const NSEC_PER_USEC: i64 = 1_000;
 const USEC_PER_SEC: i64 = 1_000_000;
-const NSEC_PER_SEC: i64 = 1_000_000_000;
+pub const NSEC_PER_SEC: i64 = 1_000_000_000;
 
 pub(super) fn init() {
     system_time::init();


### PR DESCRIPTION
Update the rounding logic to match Linux's alarm_setitimer() implementation in 
https://elixir.bootlin.com/linux/v6.15/source/kernel/time/itimer.c#L311-L319
```C
	/*
	 * We can't return 0 if we have an alarm pending ...  And we'd
	 * better return too much than too little anyway
	 */
	if ((!it_old.it_value.tv_sec && it_old.it_value.tv_nsec) ||
	      it_old.it_value.tv_nsec >= (NSEC_PER_SEC / 2))
		it_old.it_value.tv_sec++;

	return it_old.it_value.tv_sec;
```

### Describe the bug
When `alarm()` returns the remaining time of a previously set alarm, Asterinas rounds up to the next whole second (e.g., 1.5s remaining -> returns 2), 
while Linux truncates to the lower second (1.5s remaining -> returns 1). 
This can cause programs that use the return value of `alarm()` for timing calculations to behave differently.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <unistd.h>
#include <signal.h>

static void handler(int sig) { (void)sig; }

int main(void) {
    struct sigaction sa = { .sa_handler = handler, .sa_flags = 0 };
    sigemptyset(&sa.sa_mask);
    sigaction(SIGALRM, &sa, NULL);

    alarm(3);
    usleep(1500000); /* 1.5 seconds */
    unsigned int rem = alarm(0);

    printf("alarm(3), wait 1.5s, alarm(0) -> remaining = %u\n", rem);
    return 0;
}
```

### Expected behavior
`alarm(0)` should return `1` (1.5 seconds remaining, truncated to 1).

### Log
- In Asterinas:
```
alarm(3), wait 1.5s, alarm(0) -> remaining = 2
```
- In Linux:
```
alarm(3), wait 1.5s, alarm(0) -> remaining = 1
```