### PR TITLE
Bump `uefi` and `uefi-raw` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
  "tdx-guest",
  "uart_16550",
  "uefi",
- "uefi-raw",
+ "uefi-raw 0.14.0",
  "xmas-elf",
 ]
 
@@ -1256,7 +1256,7 @@ dependencies = [
  "multiboot2-common",
  "ptr_meta 0.3.0",
  "thiserror",
- "uefi-raw",
+ "uefi-raw 0.8.0",
 ]
 
 [[package]]
@@ -1971,26 +1971,26 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.32.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f17ea8502a6bd414acb2bf5194f90ca4c48e33a2d18cb57eab3294d2050d99"
+checksum = "66ab9569afdd1e33a31d8002343aa1df594f055347b1a66136bf9dd6cbc3ec37"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "log",
- "ptr_meta 0.2.0",
+ "ptr_meta 0.3.0",
  "qemu-exit",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.14.0",
  "uguid",
 ]
 
 [[package]]
 name = "uefi-macros"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19ee3a01d435eda42cb9931269b349d28a1762f91ddf01c68d276f74b957cc3"
+checksum = "4687412b5ac74d245d5bfb1733ede50c31be19bf8a4b6a967a29b451bab49e67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2005,6 +2005,16 @@ checksum = "b463030b802e1265a3800fab24df95d3229c202c2e408832a206f05b4d1496ca"
 dependencies = [
  "bitflags 2.9.1",
  "ptr_meta 0.2.0",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3775e5934877acaef4b00f254f252df1e2266903c31e51455c117f4f2824eda"
+dependencies = [
+ "bitflags 2.9.1",
  "uguid",
 ]
 

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -22,12 +22,12 @@ uart_16550.workspace = true
 xmas-elf.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
-uefi = { version = "0.32.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}
-uefi-raw = "0.8.0"
+uefi = { version = "0.37.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}
+uefi-raw = "0.14.0"
 tdx-guest = { version = "0.2.4", optional = true }
 
 [target.x86_64-i386_pm-none.dependencies]
-uefi-raw = "0.8.0"
+uefi-raw = "0.14.0"
 
 [features]
 default = ["cvm_guest"]

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/efi.rs
@@ -4,7 +4,7 @@ use core::{ffi::CStr, mem::MaybeUninit};
 
 use boot::{AllocateType, open_protocol_exclusive};
 use linux_boot_params::BootParams;
-use uefi::{boot::exit_boot_services, mem::memory_map::MemoryMap, prelude::*};
+use uefi::{mem::memory_map::MemoryMap, prelude::*, proto::BootPolicy};
 use uefi_raw::table::system::SystemTable;
 
 use super::decoder::decode_payload;
@@ -186,7 +186,7 @@ fn load_initrd() -> Option<&'static [u8]> {
         (load_file2.0.load_file)(
             &mut load_file2.0,
             device_path.as_ffi_ptr().cast(),
-            false, /* boot_policy */
+            BootPolicy::ExactMatch.into(),
             &mut size,
             core::ptr::null_mut(),
         )
@@ -202,7 +202,7 @@ fn load_initrd() -> Option<&'static [u8]> {
         (load_file2.0.load_file)(
             &mut load_file2.0,
             device_path.as_ffi_ptr().cast(),
-            false, /* boot_policy */
+            BootPolicy::ExactMatch.into(),
             &mut size,
             initrd.as_mut_ptr().cast(),
         )
@@ -228,10 +228,10 @@ fn load_initrd() -> Option<&'static [u8]> {
 }
 
 fn find_rsdp_addr() -> Option<*const ()> {
-    use uefi::table::cfg::{ACPI_GUID, ACPI2_GUID};
+    use uefi::table::cfg::ConfigTableEntry;
 
     // Prefer ACPI2 over ACPI.
-    for acpi_guid in [ACPI2_GUID, ACPI_GUID] {
+    for acpi_guid in [ConfigTableEntry::ACPI2_GUID, ConfigTableEntry::ACPI_GUID] {
         if let Some(rsdp_addr) = system::with_config_table(|table| {
             table
                 .iter()
@@ -315,7 +315,7 @@ fn fill_screen_info(screen_info: &mut linux_boot_params::ScreenInfo) {
 unsafe fn efi_phase_runtime(boot_params: &mut BootParams) -> ! {
     uefi::println!("[EFI stub] Exiting EFI boot services");
     // SAFETY: The safety is upheld by the caller.
-    let memory_map = unsafe { exit_boot_services(uefi::table::boot::MemoryType::LOADER_DATA) };
+    let memory_map = unsafe { boot::exit_boot_services(Some(boot::MemoryType::LOADER_DATA)) };
 
     crate::println!(
         "[EFI stub] Processing {} memory map entries",
@@ -387,11 +387,9 @@ unsafe fn efi_phase_runtime(boot_params: &mut BootParams) -> ! {
     unsafe { super::call_aster_entrypoint(super::ASTER_ENTRY_POINT, boot_params) }
 }
 
-fn parse_memory_type(
-    mem_type: uefi::table::boot::MemoryType,
-) -> Option<linux_boot_params::E820Type> {
+fn parse_memory_type(mem_type: boot::MemoryType) -> Option<linux_boot_params::E820Type> {
     use linux_boot_params::E820Type;
-    use uefi::table::boot::MemoryType;
+    use uefi::boot::MemoryType;
 
     match mem_type {
         // UEFI Specification, 7.2 Memory Allocation Services:


### PR DESCRIPTION
Bump `uefi` from 0.32.0 (2024-09-09) to 0.37.0 (2026-03-22) and `uefi-raw` from 0.8.0 (2024-09-09) to 0.14.0 (2026-03-22).

# Testing

I tested this using `make run_kernel BOOT_PROTOCOL=linux-efi-pe64 AUTO_TEST=boot`