### PR TITLE
Implement group scheduling for cgroup

### DIFF
--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpu.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use aster_systree::{Error, MAX_ATTR_SIZE, Result, SysAttrSetBuilder, SysPerms, SysStr};
@@ -9,7 +9,7 @@ use ostd::{
     cpu::CpuId,
     mm::{VmReader, VmWriter},
     sync::SpinLock,
-    task::atomic_mode::AsAtomicModeGuard,
+    task::{Task, atomic_mode::AsAtomicModeGuard},
     timer::Jiffies,
     warn,
 };
@@ -17,6 +17,8 @@ use ostd::{
 use crate::{
     fs::cgroupfs::systree_node::{CgroupSysNode, CgroupSystem},
     process::Process,
+    sched::{self, TaskGroup},
+    thread::AsThread,
     util::ReadCString,
 };
 
@@ -28,6 +30,8 @@ use crate::{
 pub struct CpuController {
     /// Persistent CPU usage accounting for this cgroup.
     stats: CpuStats,
+    /// Scheduler state used by hierarchical fair group scheduling for this CPU cgroup.
+    task_group: Arc<TaskGroup>,
     /// Optional CPU resource control attributes exposed only when `+cpu` is active.
     control: Option<CpuControl>,
 }
@@ -48,16 +52,16 @@ struct CpuStats {
 struct CpuControl {
     /// A value stores the configured relative CPU share for scheduler integration.
     weight: AtomicU32,
-    /// A value stores the configured CPU bandwidth limit for scheduler integration.
+    /// A value stores the configured CPU bandwidth limit.
     max: SpinLock<CpuMax>,
 }
 
 /// A CPU bandwidth limit.
 #[derive(Clone, Copy)]
 struct CpuMax {
-    /// The configured CPU runtime budget for bandwidth enforcement.
+    /// The configured CPU runtime budget.
     quota_usec: u64,
-    /// The window over which the CPU runtime budget is intended to apply.
+    /// The window over which the CPU runtime budget is configured.
     period_usec: u64,
 }
 
@@ -80,19 +84,21 @@ impl CpuController {
         }
     }
 
-    fn new(is_active: bool) -> Self {
+    fn new(is_active: bool, task_group: Arc<TaskGroup>) -> Self {
         Self {
             stats: CpuStats::new(),
+            task_group,
             control: is_active.then(CpuControl::new),
         }
     }
 
-    /// Initializes CPU usage statistics from the previous sub-controller.
+    /// Inherits persistent state from the previous sub-controller.
     ///
     /// Toggling `+cpu` must reset some controller attributes such as `cpu.weight`
     /// and `cpu.max`, but `cpu.stat` remains visible and continues to report the
-    /// accumulated CPU usage.
-    pub(super) fn init_stats(&mut self, previous: &Self) {
+    /// accumulated CPU usage. The scheduler state is also reused so that existing
+    /// tasks remain associated with the same CPU cgroup scheduling entity.
+    pub(super) fn inherit_state_from(&mut self, previous: &Self) {
         // No one cares which CPU the count is on. Therefore, choose the BSP for simplicity.
         self.stats.user.add_on_cpu(
             CpuId::bsp(),
@@ -102,10 +108,25 @@ impl CpuController {
             CpuId::bsp(),
             isize::try_from(previous.stats.system.sum_all_cpus()).unwrap_or(isize::MAX),
         );
+
+        self.task_group = previous.task_group.clone();
     }
 
     fn control(&self) -> Result<&CpuControl> {
         self.control.as_ref().ok_or(Error::AttributeError)
+    }
+
+    fn sync_weight(&self) {
+        let Some(control) = &self.control else {
+            return;
+        };
+
+        let weight = control.weight.load(Ordering::Relaxed);
+        self.task_group.update_weight(weight);
+    }
+
+    pub(super) fn is_active(&self) -> bool {
+        self.control.is_some()
     }
 
     fn read_cpu_stat(&self, printer: &mut VmPrinter) -> Result<usize> {
@@ -149,17 +170,18 @@ impl CpuController {
 }
 
 impl CpuControl {
+    const DEFAULT_WEIGHT: u32 = 100;
+
     fn new() -> Self {
         // The default CPU weight is 100 and the default CPU bandwidth limit is
         // unlimited quota with a 100ms period.
         //
         // Reference: <https://docs.kernel.org/admin-guide/cgroup-v2.html#cpu-interface-files>
-        const DEFAULT_WEIGHT: u32 = 100;
         const DEFAULT_QUOTA_USEC: u64 = u64::MAX;
         const DEFAULT_PERIOD_USEC: u64 = 100_000;
 
         Self {
-            weight: AtomicU32::new(DEFAULT_WEIGHT),
+            weight: AtomicU32::new(Self::DEFAULT_WEIGHT),
             max: SpinLock::new(CpuMax {
                 quota_usec: DEFAULT_QUOTA_USEC,
                 period_usec: DEFAULT_PERIOD_USEC,
@@ -229,11 +251,6 @@ impl super::SubControl for CpuController {
                     return Err(Error::InvalidOperation);
                 }
 
-                // TODO: Enforce cgroup CPU weight for scheduling and remove this warning.
-                warn!(
-                    "`cpu.weight` is accepted but not enforced yet; weight = {}",
-                    weight
-                );
                 control.weight.store(weight, Ordering::Relaxed);
 
                 Ok(len)
@@ -306,8 +323,16 @@ impl super::SubControl for CpuController {
 }
 
 impl super::SubControlStatic for CpuController {
-    fn new(is_root: bool, is_active: bool) -> Self {
-        Self::new(is_root || is_active)
+    fn new(is_root: bool, is_active: bool, parent_controller: Option<&super::Controller>) -> Self {
+        let task_group = if let Some(parent_controller) = parent_controller {
+            TaskGroup::new_child(
+                &parent_controller.task_group(),
+                sched::DEFAULT_CGROUP_WEIGHT,
+            )
+        } else {
+            sched::root_task_group().clone()
+        };
+        Self::new(is_root || is_active, task_group)
     }
 
     fn type_() -> super::SubCtrlType {
@@ -320,6 +345,18 @@ impl super::SubControlStatic for CpuController {
 }
 
 impl super::SubController<CpuController> {
+    fn effective_task_group(&self) -> Arc<TaskGroup> {
+        let inner = self.inner.as_ref().unwrap();
+        if inner.is_active() {
+            return inner.task_group.clone();
+        }
+
+        self.parent
+            .as_ref()
+            .map(|parent| parent.effective_task_group())
+            .unwrap_or_else(|| sched::root_task_group().clone())
+    }
+
     /// Accounts one [`Jiffies`] of CPU time for this cgroup and all of its ancestors.
     fn account_hierarchy(&self, stat_kind: CpuStatKind) {
         // This is race-free because `charge_cpu_time` holds `cgroup_guard` when
@@ -338,6 +375,47 @@ impl super::Controller {
     /// Charges one [`Jiffies`] in the CPU sub-controller hierarchy.
     fn charge_cpu_time<G: AsAtomicModeGuard + ?Sized>(&self, guard: &G, stat_kind: CpuStatKind) {
         self.cpu.read_with(guard).account_hierarchy(stat_kind);
+    }
+
+    pub(crate) fn sync_cpu_weight(&self) {
+        self.cpu.read().get().inner.as_ref().unwrap().sync_weight();
+    }
+
+    fn task_group(&self) -> Arc<TaskGroup> {
+        self.cpu
+            .read()
+            .get()
+            .inner
+            .as_ref()
+            .unwrap()
+            .task_group
+            .clone()
+    }
+
+    pub(crate) fn effective_task_group(&self) -> Arc<TaskGroup> {
+        self.cpu.read().get().effective_task_group()
+    }
+
+    /// Applies this cgroup's effective CPU control to all threads in `process`.
+    ///
+    /// Returned tasks were dequeued from old fair runqueues and must be woken so
+    /// they can be requeued through the updated task group.
+    pub(crate) fn apply_cpu_control_to_process(&self, process: &Process) -> Vec<Arc<Task>> {
+        let task_group = self.effective_task_group();
+        let mut old_task_groups = Vec::new();
+
+        for task in process.tasks().lock().as_slice() {
+            let Some(thread) = task.as_thread() else {
+                continue;
+            };
+
+            if !thread.is_exited() {
+                old_task_groups.push((task.clone(), thread.task_group()));
+            }
+            thread.set_task_group(task_group.clone());
+        }
+
+        task_group.migrate_tasks_from(&old_task_groups)
     }
 }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/cpuset.rs
@@ -60,7 +60,11 @@ impl super::SubControl for CpuSetController {
 }
 
 impl super::SubControlStatic for CpuSetController {
-    fn new(_is_root: bool, _is_active: bool) -> Self {
+    fn new(
+        _is_root: bool,
+        _is_active: bool,
+        _parent_controller: Option<&super::Controller>,
+    ) -> Self {
         Self { _private: () }
     }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/memory.rs
@@ -44,7 +44,11 @@ impl super::SubControl for MemoryController {
 }
 
 impl super::SubControlStatic for MemoryController {
-    fn new(_is_root: bool, _is_active: bool) -> Self {
+    fn new(
+        _is_root: bool,
+        _is_active: bool,
+        _parent_controller: Option<&super::Controller>,
+    ) -> Self {
         Self { _private: () }
     }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/mod.rs
@@ -43,7 +43,7 @@ trait SubControl {
 /// Defines the static properties and behaviors of a specific cgroup sub-controller.
 trait SubControlStatic: SubControl + Sized + 'static {
     /// Creates a new instance of the sub-controller.
-    fn new(is_root: bool, is_active: bool) -> Self;
+    fn new(is_root: bool, is_active: bool, parent_controller: Option<&Controller>) -> Self;
 
     /// Returns the `SubCtrlType` enum variant corresponding to this sub-controller.
     fn type_() -> SubCtrlType;
@@ -189,7 +189,7 @@ impl<T: SubControlStatic> SubController<T> {
         let inner = if is_active || T::type_() == SubCtrlType::Cpu {
             // `cpu.stat` exists regardless of whether `+cpu` has been enabled, so the
             // CPU sub-controller must remain instantiated even while inactive.
-            Some(T::new(is_root, is_active))
+            Some(T::new(is_root, is_active, parent_controller))
         } else {
             None
         };
@@ -319,66 +319,56 @@ impl Controller {
         controller.write_attr(name, reader)
     }
 
-    /// Activates a sub-control of the specified type.
-    pub(super) fn activate(
+    /// Validates a subtree-control change before applying it.
+    pub(super) fn validate_subtree_control_change(
         &self,
-        ctrl_type: SubCtrlType,
+        enable_set: SubCtrlSet,
+        disable_set: SubCtrlSet,
         current_node: &dyn CgroupSysNode,
         parent_controller: Option<&Controller>,
-        cgroup_membership: &mut CgroupMembership,
     ) -> Result<()> {
-        let mut active_set = self.active_set();
-        if active_set.contains_type(ctrl_type) {
-            return Ok(());
+        for ctrl_type in enable_set.iter_types() {
+            // A cgroup can activate the sub-control only if this
+            // sub-control has been activated in its parent cgroup.
+            if parent_controller
+                .is_some_and(|controller| !controller.active_set().contains_type(ctrl_type))
+            {
+                return Err(Error::NotFound);
+            }
         }
 
-        // A cgroup can activate the sub-control only if this
-        // sub-control has been activated in its parent cgroup.
-        if parent_controller
-            .is_some_and(|controller| !controller.active_set().contains_type(ctrl_type))
-        {
-            return Err(Error::NotFound);
+        for ctrl_type in disable_set.iter_types() {
+            // If any child node has activated this sub-control,
+            // the deactivation operation will be rejected.
+            for child in current_node.children() {
+                let cgroup_child = Arc::downcast::<CgroupNode>(child).unwrap();
+                // This is race-free because if a child wants to activate a sub-controller, it must
+                // acquire the write lock of `CgroupMembership` which has already been held here.
+                if cgroup_child
+                    .controller()
+                    .active_set()
+                    .contains_type(ctrl_type)
+                {
+                    return Err(Error::ResourceUnavailable);
+                }
+            }
         }
-
-        active_set.add_type(ctrl_type);
-        self.active_set.store(active_set, Ordering::Relaxed);
-        self.update_sub_controllers_for_descents(ctrl_type, current_node, cgroup_membership);
 
         Ok(())
     }
 
-    /// Deactivates a sub-control of the specified type.
-    pub(super) fn deactivate(
+    /// Applies a validated subtree-control change.
+    pub(super) fn apply_subtree_control_change(
         &self,
-        ctrl_type: SubCtrlType,
+        new_active_set: SubCtrlSet,
+        changed_set: SubCtrlSet,
         current_node: &dyn CgroupSysNode,
         cgroup_membership: &mut CgroupMembership,
-    ) -> Result<()> {
-        let mut active_set = self.active_set();
-        if !active_set.contains_type(ctrl_type) {
-            return Ok(());
+    ) {
+        self.active_set.store(new_active_set, Ordering::Relaxed);
+        for ctrl_type in changed_set.iter_types() {
+            self.update_sub_controllers_for_descents(ctrl_type, current_node, cgroup_membership);
         }
-
-        // If any child node has activated this sub-control,
-        // the deactivation operation will be rejected.
-        for child in current_node.children() {
-            let cgroup_child = Arc::downcast::<CgroupNode>(child).unwrap();
-            // This is race-free because if a child wants to activate a sub-controller, it must
-            // acquire the write lock of `CgroupMembership` which has already been held here.
-            if cgroup_child
-                .controller()
-                .active_set()
-                .contains_type(ctrl_type)
-            {
-                return Err(Error::InvalidOperation);
-            }
-        }
-
-        active_set.remove_type(ctrl_type);
-        self.active_set.store(active_set, Ordering::Relaxed);
-        self.update_sub_controllers_for_descents(ctrl_type, current_node, cgroup_membership);
-
-        Ok(())
     }
 
     fn update_sub_controllers_for_descents(
@@ -405,11 +395,9 @@ impl Controller {
                     {
                         let guard = child_node.controller().cpu.read();
                         let previous_controller = guard.get();
-                        new_controller
-                            .inner
-                            .as_mut()
-                            .unwrap()
-                            .init_stats(previous_controller.inner.as_ref().unwrap());
+                        let previous_cpu_controller = previous_controller.inner.as_ref().unwrap();
+                        let new_cpu_controller = new_controller.inner.as_mut().unwrap();
+                        new_cpu_controller.inherit_state_from(previous_cpu_controller);
                     }
                     child_node.controller().cpu.update(Arc::new(new_controller));
                 }

--- a/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/controller/pids.rs
@@ -129,7 +129,11 @@ impl super::SubControl for PidsController {
 }
 
 impl super::SubControlStatic for PidsController {
-    fn new(_is_root: bool, _is_active: bool) -> Self {
+    fn new(
+        _is_root: bool,
+        _is_active: bool,
+        _parent_controller: Option<&super::Controller>,
+    ) -> Self {
         Self {
             max_pids: AtomicU32::new(u32::MAX),
             current_count: AtomicU32::new(0),

--- a/kernel/src/fs/fs_impls/cgroupfs/systree_node.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/systree_node.rs
@@ -60,7 +60,10 @@ use aster_systree::{
 };
 use aster_util::printer::VmPrinter;
 use inherit_methods_macro::inherit_methods;
-use ostd::sync::{RwMutexReadGuard, RwMutexWriteGuard};
+use ostd::{
+    sync::{RwMutexReadGuard, RwMutexWriteGuard},
+    task::Task,
+};
 use spin::Once;
 
 use crate::{
@@ -165,24 +168,40 @@ impl CgroupMembership {
             None
         };
 
-        // Try to add the process to the new cgroup first.
-        self.add_process_to_node(&process, new_cgroup)?;
+        if !new_cgroup.controller.active_set().is_empty() {
+            return Err(Error::ResourceUnavailable);
+        }
+
+        let new_cgroup = {
+            let mut new_cgroup_inner = new_cgroup.inner.write();
+            let Some(new_cgroup_inner_ref) = new_cgroup_inner.as_mut() else {
+                return Err(Error::IsDead);
+            };
+
+            if new_cgroup_inner_ref.processes.is_empty() {
+                let old_count = new_cgroup.populated_count.fetch_add(1, Ordering::Relaxed);
+                if old_count == 0 {
+                    new_cgroup.propagate_add_populated();
+                }
+            }
+
+            new_cgroup_inner_ref
+                .processes
+                .insert(process.pid(), Arc::downgrade(&process));
+            let new_cgroup = new_cgroup.fields.weak_self().upgrade().unwrap();
+            process.set_cgroup(Some(new_cgroup.clone()));
+            new_cgroup
+        };
+        let queued_tasks = new_cgroup.controller.apply_cpu_control_to_process(&process);
         new_cgroup.controller.charge_pids();
+
+        for task in queued_tasks {
+            task.wake_up();
+        }
 
         // Remove the process from the old cgroup second.
         if let Some(old_cgroup) = old_cgroup {
-            old_cgroup
-                .with_inner_mut(|old_cgroup_processes| {
-                    old_cgroup_processes.remove(&process.pid()).unwrap();
-                    if old_cgroup_processes.is_empty() {
-                        let old_count = old_cgroup.populated_count.fetch_sub(1, Ordering::Relaxed);
-                        if old_count == 1 {
-                            old_cgroup.propagate_sub_populated();
-                        }
-                    }
-                })
-                .unwrap();
-
+            self.remove_process_from_node(&process, &old_cgroup);
             // Uncharge the pids sub-controller for the old cgroup.
             old_cgroup.controller.uncharge_pids();
         }
@@ -225,9 +244,15 @@ impl CgroupMembership {
                 }
 
                 current_processes.insert(process.pid(), Arc::downgrade(process));
-                process.set_cgroup(Some(new_cgroup.fields.weak_self().upgrade().unwrap()));
+                let new_cgroup = new_cgroup.fields.weak_self().upgrade().unwrap();
+                process.set_cgroup(Some(new_cgroup));
             })
             .ok_or(Error::IsDead)?;
+        let queued_tasks = new_cgroup.controller.apply_cpu_control_to_process(process);
+        debug_assert!(queued_tasks.is_empty());
+        for task in queued_tasks {
+            task.wake_up();
+        }
 
         Ok(())
     }
@@ -242,7 +267,123 @@ impl CgroupMembership {
         };
 
         process.set_cgroup(None);
+        let queued_tasks = CgroupSystem::singleton()
+            .controller()
+            .apply_cpu_control_to_process(process);
 
+        for task in queued_tasks {
+            task.wake_up();
+        }
+
+        self.remove_process_from_node(process, &old_cgroup);
+        old_cgroup.controller.uncharge_pids();
+    }
+
+    /// Synchronizes descendant process state after a `cgroup.subtree_control` change.
+    ///
+    /// Returned tasks were dequeued from old fair runqueues and must be woken so
+    /// they can be requeued through the updated CPU control.
+    fn sync_descendant_controls(
+        &self,
+        changed_set: SubCtrlSet,
+        cgroup_node: &dyn CgroupSysNode,
+    ) -> Vec<Arc<Task>> {
+        let sync_set = changed_set & SubCtrlSet::CPU;
+        if sync_set.is_empty() {
+            return Vec::new();
+        }
+
+        let mut queued_tasks = Vec::new();
+        let mut descents = Vec::new();
+        cgroup_node.visit_children_with(0, &mut |child| {
+            descents.push(child.clone());
+            Some(())
+        });
+
+        while let Some(node) = descents.pop() {
+            let cgroup_node = Arc::downcast::<CgroupNode>(node).unwrap();
+            for ctrl_type in sync_set.iter_types() {
+                match ctrl_type {
+                    SubCtrlType::Cpu => {
+                        queued_tasks.extend(self.sync_cpu_control(&cgroup_node));
+                    }
+                    SubCtrlType::CpuSet | SubCtrlType::Memory | SubCtrlType::Pids => {}
+                }
+            }
+            cgroup_node.visit_children_with(0, &mut |child| {
+                descents.push(child.clone());
+                Some(())
+            });
+        }
+
+        queued_tasks
+    }
+
+    fn sync_cpu_control(&self, cgroup_node: &CgroupNode) -> Vec<Arc<Task>> {
+        let Some(processes) = cgroup_node.with_inner(|processes| {
+            processes
+                .values()
+                .filter_map(Weak::upgrade)
+                .collect::<Vec<_>>()
+        }) else {
+            return Vec::new();
+        };
+
+        let mut queued_tasks = Vec::new();
+        cgroup_node.controller.sync_cpu_weight();
+        let cgroup = cgroup_node.fields.weak_self().upgrade().unwrap();
+        for process in processes {
+            process.set_cgroup(Some(cgroup.clone()));
+            queued_tasks.extend(
+                cgroup_node
+                    .controller
+                    .apply_cpu_control_to_process(&process),
+            );
+        }
+
+        queued_tasks
+    }
+
+    fn apply_subtree_control_write(
+        &mut self,
+        cgroup_node: &dyn CgroupSysNode,
+        parent_controller: Option<&Controller>,
+        has_internal_processes: bool,
+        activate_set: SubCtrlSet,
+        deactivate_set: SubCtrlSet,
+    ) -> Result<Vec<Arc<Task>>> {
+        let controller = cgroup_node.controller();
+        let old_active = controller.active_set();
+        let actual_enable = activate_set - old_active;
+        let actual_disable = deactivate_set & old_active;
+        let changed_set = actual_enable | actual_disable;
+
+        if changed_set.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // According to "no internal processes" rule of cgroupv2, if a non-root
+        // cgroup node has bound processes, it cannot activate any sub-control.
+        //
+        // Reference: <https://man7.org/linux/man-pages/man7/cgroups.7.html>
+        if has_internal_processes && !actual_enable.is_empty() {
+            return Err(Error::ResourceUnavailable);
+        }
+
+        controller.validate_subtree_control_change(
+            actual_enable,
+            actual_disable,
+            cgroup_node,
+            parent_controller,
+        )?;
+
+        let new_active = (old_active | actual_enable) - actual_disable;
+        controller.apply_subtree_control_change(new_active, changed_set, cgroup_node, self);
+
+        Ok(self.sync_descendant_controls(changed_set, cgroup_node))
+    }
+
+    fn remove_process_from_node(&self, process: &Process, old_cgroup: &CgroupNode) {
         old_cgroup
             .with_inner_mut(|old_cgroup_processes| {
                 old_cgroup_processes.remove(&process.pid()).unwrap();
@@ -254,9 +395,6 @@ impl CgroupMembership {
                 }
             })
             .unwrap();
-
-        // Uncharge the pids sub-controller for the old cgroup.
-        old_cgroup.controller.uncharge_pids();
     }
 }
 
@@ -601,7 +739,7 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
                     .ok_or(Error::InvalidOperation)?;
 
                 with_process_cgroup_locked(pid, |process, cgroup_membership| {
-                    cgroup_membership.move_process_to_root(&process);
+                    cgroup_membership.move_process_to_root(process.as_ref());
                     Ok(())
                 })?;
 
@@ -611,13 +749,16 @@ inherit_sys_branch_node!(CgroupSystem, fields, {
                 let (activate_set, deactivate_set, len) = read_subtree_control_from_reader(reader)?;
 
                 let mut cgroup_guard = CgroupMembership::write_lock();
-                for ctrl_type in activate_set.iter_types() {
-                    self.controller
-                        .activate(ctrl_type, self, None, &mut cgroup_guard)?;
-                }
-                for ctrl_type in deactivate_set.iter_types() {
-                    self.controller
-                        .deactivate(ctrl_type, self, &mut cgroup_guard)?;
+                let queued_tasks = cgroup_guard.apply_subtree_control_write(
+                    self,
+                    None,
+                    false,
+                    activate_set,
+                    deactivate_set,
+                )?;
+                drop(cgroup_guard);
+                for task in queued_tasks {
+                    task.wake_up();
                 }
 
                 Ok(len)
@@ -742,39 +883,38 @@ inherit_sys_branch_node!(CgroupNode, fields, {
                 let parent_node = self.cgroup_parent().ok_or(Error::IsDead)?;
                 let parent_controller = parent_node.controller();
 
-                self.with_inner(|processes| {
-                    // According to "no internal processes" rule of cgroupv2, if a non-root
-                    // cgroup node has bound processes, it cannot activate any sub-control.
-                    //
-                    // Reference: <https://man7.org/linux/man-pages/man7/cgroups.7.html>
-                    if !processes.is_empty() {
-                        return Err(Error::ResourceUnavailable);
-                    }
-
-                    for ctrl_type in activate_set.iter_types() {
-                        self.controller.activate(
-                            ctrl_type,
+                let queued_tasks = self
+                    .with_inner(|processes| {
+                        cgroup_guard.apply_subtree_control_write(
                             self,
                             Some(parent_controller),
-                            &mut cgroup_guard,
-                        )?;
-                    }
-                    for ctrl_type in deactivate_set.iter_types() {
-                        self.controller
-                            .deactivate(ctrl_type, self, &mut cgroup_guard)?;
-                    }
+                            !processes.is_empty(),
+                            activate_set,
+                            deactivate_set,
+                        )
+                    })
+                    .ok_or(Error::IsDead)?;
+                let queued_tasks = queued_tasks?;
+                drop(cgroup_guard);
+                for task in queued_tasks {
+                    task.wake_up();
+                }
 
-                    Ok(len)
-                })
-                .ok_or(Error::IsDead)?
+                Ok(len)
             }
             // TODO: Add support for writing other attributes.
-            _ => self
+            _ => {
                 // This write may target a stale controller if the cgroup's sub-controllers
                 // are being concurrently updated. It is the duty of user-space programs
                 // to use proper synchronization to avoid such races.
-                .with_inner(|_| self.controller.write_attr(name, reader))
-                .ok_or(Error::IsDead)?,
+                let result = self
+                    .with_inner(|_| self.controller.write_attr(name, reader))
+                    .ok_or(Error::IsDead)?;
+                if name == "cpu.weight" {
+                    self.controller.sync_cpu_weight();
+                }
+                result
+            }
         }
     }
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -298,11 +298,13 @@ pub fn clone_child(
     clone_args.check(ctx)?;
 
     if clone_args.flags.contains(CloneFlags::CLONE_THREAD) {
+        let _cgroup_read_guard = CgroupMembership::read_lock();
         let child_task = clone_child_task(ctx, parent_context, clone_args)?;
         let child_thread = child_task.as_thread().unwrap();
+        child_thread.set_task_group(ctx.thread.task_group());
         child_thread.run();
-
         let child_tid = child_thread.as_posix_thread().unwrap().tid();
+
         Ok(child_tid)
     } else {
         // Hold the read lock before charge to ensure the cgroup of current process

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -4,7 +4,6 @@ mod nice;
 mod sched_class;
 mod stats;
 
-#[expect(unused_imports)]
 pub(crate) use self::sched_class::{DEFAULT_CGROUP_WEIGHT, TaskGroup, root_task_group};
 pub use self::{
     nice::{AtomicNice, Nice},

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -4,6 +4,8 @@ mod nice;
 mod sched_class;
 mod stats;
 
+#[expect(unused_imports)]
+pub(crate) use self::sched_class::{DEFAULT_CGROUP_WEIGHT, TaskGroup, root_task_group};
 pub use self::{
     nice::{AtomicNice, Nice},
     sched_class::{

--- a/kernel/src/sched/sched_class/fair.rs
+++ b/kernel/src/sched/sched_class/fair.rs
@@ -16,12 +16,12 @@ use ostd::{
 };
 
 use super::{
-    CurrentRuntime, SchedAttr, SchedClassRq,
+    CurrentRuntime, SchedClassRq,
     time::{base_slice_clocks, min_period_clocks},
 };
 use crate::{
     sched::nice::{Nice, NiceValue},
-    thread::AsThread,
+    thread::{AsThread, Thread},
 };
 
 const WEIGHT_0: u64 = 1024;
@@ -320,9 +320,10 @@ impl SchedClassRq for FairClassRq {
     fn update_current(
         &mut self,
         rt: &CurrentRuntime,
-        attr: &SchedAttr,
+        thread: &Thread,
         flags: UpdateFlags,
     ) -> bool {
+        let attr = thread.sched_attr();
         match flags {
             UpdateFlags::Tick | UpdateFlags::Yield | UpdateFlags::Wait => {
                 let (_old_weight, weight) = attr.fair.fetch_weight();

--- a/kernel/src/sched/sched_class/fair.rs
+++ b/kernel/src/sched/sched_class/fair.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::BinaryHeap, sync::Arc};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, Weak},
+};
 use core::{
-    cmp::{self, Reverse},
+    borrow::Borrow,
+    cmp,
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use ostd::{
-    cpu::{CpuId, num_cpus},
+    cpu::{self, CpuId},
     sync::SpinLock,
     task::{
         Task,
@@ -17,14 +21,16 @@ use ostd::{
 
 use super::{
     CurrentRuntime, SchedClassRq,
+    task_group::TaskGroup,
     time::{base_slice_clocks, min_period_clocks},
 };
 use crate::{
-    sched::nice::{Nice, NiceValue},
+    sched::{Nice, nice::NiceValue},
     thread::{AsThread, Thread},
 };
 
-const WEIGHT_0: u64 = 1024;
+pub(super) const WEIGHT_0: u64 = 1024;
+pub(crate) const DEFAULT_CGROUP_WEIGHT: u32 = 100;
 
 const HAS_PENDING: u64 = 1 << (u64::BITS - 1);
 
@@ -68,9 +74,10 @@ pub const fn nice_to_weight(nice: Nice) -> u64 {
     NICE_TO_WEIGHT[(nice.value().get() + 20) as usize]
 }
 
-/// The scheduling entity for the FAIR scheduling class.
+/// The scheduling attributes for a FAIR scheduling entity.
 ///
-/// The structure contains a significant indicator: `vruntime`.
+/// A FAIR entity is either a thread or a task group entity. The structure
+/// contains a significant indicator: `vruntime`.
 ///
 /// # `vruntime`
 ///
@@ -78,37 +85,39 @@ pub const fn nice_to_weight(nice: Nice) -> u64 {
 ///
 ///     vruntime += runtime_delta * WEIGHT_0 / weight
 ///
-/// and a thread with a lower vruntime gains a greater privilege to be
+/// and an entity with a lower vruntime gains a greater privilege to be
 /// scheduled, making the whole run queue balanced on vruntime (thus FAIR).
 ///
 /// # Scheduling periods
 ///
-/// Scheduling periods are designed to calculate the time slice for each threads.
+/// Scheduling periods are designed to calculate the time slice for each entity.
 ///
-/// The time slice for each threads is calculated by the formula:
+/// The time slice for each entity is calculated by the formula:
 ///
 ///     time_slice = period * weight / total_weight
 ///
-/// where `total_weight` is the sum of all weights in the run queue including
-/// the current thread and [`period`](FairClassRq::period) is calculated
-/// regarding the number of running threads.
+/// where `total_weight` is the sum of the queued entity weights plus the
+/// current entity's weight, and [`period`](FairClassRq::period) is calculated
+/// regarding the number of runnable entities.
 ///
-/// When a thread meets the condition below, it will be preempted to the
-/// run queue. See [`FairClassRq::update_current`] for more details.
+/// When the current entity meets the condition below,
+/// [`FairClassRq::update_current`] asks the scheduler to preempt the current
+/// task.
 ///
 ///     period_delta > time_slice
 ///         || vruntime > rq_min_vruntime + normalized_time_slice
 ///
 /// # The weight update process
 ///
-/// The weight of a thread can be updated by the `sched_setattr` syscall series in
-/// any thread. This makes it difficult to re-evaluate the data of its run queue
-/// instantly after the update without a direct backward reference (which is
-/// impossible to be represented in safe Rust).
+/// The weight of an entity can be updated outside the runqueue that currently
+/// contains it, for example by `sched_setattr` for threads or `cpu.weight` for
+/// task groups. This makes it difficult to re-evaluate the runqueue instantly
+/// after the update without making each entity point back to its runqueue.
 ///
 /// To handle this problem, we use a `pending_weight` field to store the new weight.
-/// When the thread is scheduled within the run queue, we will check if the weight
-/// needs to be updated since both the old and new weights are needed for re-evaluation.
+/// When the entity is enqueued, refreshed, or updated as the current entity, we
+/// check if the weight needs to be updated since both the old and new weights
+/// are needed for re-evaluation.
 ///
 /// To indicate whether the weight needs to be updated, we pack the `weight` field
 /// with a bit flag `HAS_PENDING`. When accessing the `weight` field:
@@ -124,19 +133,38 @@ pub const fn nice_to_weight(nice: Nice) -> u64 {
 /// ensures that only one load is needed.
 #[derive(Debug)]
 pub struct FairAttr {
+    /// Stable entity ID for deterministic tie-breaking in runqueue ordering.
+    id: u64,
     // Updates to the `weight` field must be serialized with the `pending_weight` lock.
     weight: AtomicU64,
     pending_weight: SpinLock<u64>,
     vruntime: AtomicU64,
+    queued_weight: SpinLock<u64>,
+    /// Vruntime offset from the source runqueue's `min_vruntime` during migration.
+    migration_lag: SpinLock<Option<u64>>,
 }
 
 impl FairAttr {
     pub fn new(nice: Nice) -> Self {
         let weight = nice_to_weight(nice);
         FairAttr {
+            id: next_entity_id(),
             weight: weight.into(),
             pending_weight: SpinLock::new(weight),
             vruntime: Default::default(),
+            queued_weight: SpinLock::new(weight),
+            migration_lag: SpinLock::new(None),
+        }
+    }
+
+    pub fn from_weight(weight: u64) -> Self {
+        Self {
+            id: next_entity_id(),
+            weight: weight.into(),
+            pending_weight: SpinLock::new(weight),
+            vruntime: Default::default(),
+            queued_weight: SpinLock::new(weight),
+            migration_lag: SpinLock::new(None),
         }
     }
 
@@ -149,9 +177,32 @@ impl FairAttr {
         );
     }
 
+    pub fn update_weight(&self, weight: u64) {
+        let mut pending_weight = self.pending_weight.lock();
+        *pending_weight = weight;
+        self.weight.store(
+            self.weight.load(Ordering::Relaxed) | HAS_PENDING,
+            Ordering::Relaxed,
+        );
+    }
+
     fn update_vruntime(&self, delta: u64, weight: u64) -> u64 {
-        let delta = delta * WEIGHT_0 / weight;
-        self.vruntime.fetch_add(delta, Ordering::Relaxed) + delta
+        let weight = weight.max(1);
+        let delta = delta.saturating_mul(WEIGHT_0) / weight;
+
+        let mut old_vruntime = self.vruntime.load(Ordering::Relaxed);
+        loop {
+            let new_vruntime = old_vruntime.saturating_add(delta);
+            match self.vruntime.compare_exchange_weak(
+                old_vruntime,
+                new_vruntime,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return new_vruntime,
+                Err(current_vruntime) => old_vruntime = current_vruntime,
+            }
+        }
     }
 
     fn fetch_weight(&self) -> (u64, u64) {
@@ -175,23 +226,83 @@ impl FairAttr {
 
         (old_weight, new_weight)
     }
+
+    fn vruntime(&self) -> u64 {
+        self.vruntime.load(Ordering::Relaxed)
+    }
+
+    fn update_vruntime_at_least(&self, vruntime: u64) -> u64 {
+        self.vruntime
+            .fetch_max(vruntime, Ordering::Relaxed)
+            .max(vruntime)
+    }
+
+    fn set_vruntime(&self, vruntime: u64) {
+        self.vruntime.store(vruntime, Ordering::Relaxed);
+    }
+
+    fn save_migration_lag(&self, old_min_vruntime: u64) {
+        let lag = self.vruntime().saturating_sub(old_min_vruntime);
+        *self.migration_lag.lock() = Some(lag);
+    }
+
+    fn take_migration_lag(&self) -> Option<u64> {
+        self.migration_lag.lock().take()
+    }
 }
 
-/// The wrapper for threads in the FAIR run queue.
+#[derive(Clone, Debug)]
+enum FairEntity {
+    Thread(Arc<Task>),
+    Group(Arc<TaskGroup>),
+}
+
+impl FairEntity {
+    fn fair_attr(&self, cpu: CpuId) -> Option<&FairAttr> {
+        match self {
+            Self::Thread(task) => Some(&task.as_thread()?.sched_attr().fair),
+            Self::Group(task_group) => task_group.fair_attr(cpu),
+        }
+    }
+}
+
+/// Wraps a FAIR scheduling entity with its runqueue key.
 ///
-/// This structure is used to provide the capability for keying in the
-/// run queue implemented by `BTreeSet` in the `FairClassRq`.
-struct FairQueueItem(Arc<Task>, u64);
+/// This structure provides the ordering key used by the `BTreeSet` in
+/// [`FairClassRq`].
+#[derive(Clone)]
+struct FairQueueItem {
+    key: (u64, u64),
+    entity: FairEntity,
+}
+
+impl FairQueueItem {
+    fn new(key: (u64, u64), entity: FairEntity) -> Self {
+        Self { key, entity }
+    }
+
+    fn key(&self) -> (u64, u64) {
+        self.key
+    }
+
+    fn entity(&self) -> &FairEntity {
+        &self.entity
+    }
+
+    fn into_entity(self) -> FairEntity {
+        self.entity
+    }
+}
+
+impl Borrow<(u64, u64)> for FairQueueItem {
+    fn borrow(&self) -> &(u64, u64) {
+        &self.key
+    }
+}
 
 impl core::fmt::Debug for FairQueueItem {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.key())
-    }
-}
-
-impl FairQueueItem {
-    fn key(&self) -> u64 {
-        self.1
     }
 }
 
@@ -215,84 +326,368 @@ impl Ord for FairQueueItem {
     }
 }
 
-/// The per-cpu run queue for the FAIR scheduling class.
+fn next_entity_id() -> u64 {
+    static NEXT_ENTITY_ID: AtomicU64 = AtomicU64::new(1);
+    NEXT_ENTITY_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// The per-CPU FAIR runqueue for one task group.
 ///
 /// See [`FairAttr`] for the explanation of vruntimes and scheduling periods.
 ///
-/// The structure contains a `BTreeSet` to store the threads in the run queue to
-/// ensure the efficiency for finding next-to-run threads.
+/// The structure contains a `BTreeSet` to store scheduling entities in the
+/// runqueue, ensuring efficient lookup of the next entity to run.
 #[derive(Debug)]
-pub(super) struct FairClassRq {
-    #[expect(unused)]
+pub(crate) struct FairClassRq {
     cpu: CpuId,
-    /// The ready-to-run threads.
-    entities: BinaryHeap<Reverse<FairQueueItem>>,
-    /// The minimum of vruntime in the run queue. Serves as the initial
-    /// value of newly-enqueued threads.
+    /// The task group this runqueue belongs to.
+    task_group: Weak<TaskGroup>,
+    /// Queued scheduling entities.
+    entities: BTreeSet<FairQueueItem>,
+    /// Maps entity IDs to keys in `entities`.
+    entity_keys: BTreeMap<u64, (u64, u64)>,
+    /// The minimum of vruntime in the run queue. Serves as the initial value of
+    /// newly-enqueued entities.
     min_vruntime: u64,
+    /// Sum of weights of queued entities.
     total_weight: u64,
+    /// Total number of queued tasks in this runqueue and all descendant runqueues.
+    total_queued_task_count: usize,
 }
 
 impl FairClassRq {
-    pub fn new(cpu: CpuId) -> Self {
+    pub(super) fn new(cpu: CpuId, task_group: Weak<TaskGroup>) -> Self {
         Self {
             cpu,
-            entities: BinaryHeap::new(),
+            task_group,
+            entities: BTreeSet::new(),
+            entity_keys: BTreeMap::new(),
             min_vruntime: 0,
             total_weight: 0,
+            total_queued_task_count: 0,
         }
+    }
+
+    pub(super) fn task_group(&self) -> Option<Arc<TaskGroup>> {
+        self.task_group.upgrade()
+    }
+
+    fn min_queued_vruntime(&self) -> Option<u64> {
+        self.entities.iter().next().map(|item| item.key().0)
     }
 
     /// The scheduling period is calculated as the maximum of the following two values:
     ///
     /// 1. The minimum period value, defined by [`min_period_clocks`].
     /// 2. `period = min_granularity * n` where
-    ///    `min_granularity = log2(1 + num_cpus) * base_slice_clocks`, and `n` is the number of
-    ///    runnable threads (including the current running thread).
+    ///    `min_granularity = log2(1 + num_cpus) * base_slice_clocks`, and `n`
+    ///    is the number of queued entities plus the entity being considered.
     ///
     /// The formula is chosen by 3 principles:
     ///
-    /// 1. The scheduling period should reflect the running threads and CPUs;
+    /// 1. The scheduling period should reflect the runnable entities and CPUs;
     /// 2. The scheduling period should not be too low to limit the overhead of context switching;
     /// 3. The scheduling period should not be too high to ensure the scheduling latency
     ///    & responsiveness.
-    fn period(&self) -> u64 {
+    fn period(&self, queued_entity_count: usize) -> u64 {
         let base_slice_clks = base_slice_clocks();
         let min_period_clks = min_period_clocks();
-
-        // `+ 1` means including the current running thread.
+        // `+ 1` means including the entity being considered.
         let period_single_cpu =
-            (base_slice_clks * (self.entities.len() + 1) as u64).max(min_period_clks);
-        period_single_cpu * u64::from((1 + num_cpus()).ilog2())
+            (base_slice_clks * (queued_entity_count + 1) as u64).max(min_period_clks);
+        period_single_cpu * u64::from((1 + cpu::num_cpus()).ilog2())
     }
 
-    /// The virtual time slice for each thread in the run queue, measured in vruntime clocks.
-    fn vtime_slice(&self) -> u64 {
-        self.period() / (self.entities.len() + 1) as u64
+    /// The virtual time slice for each entity in the run queue, measured in
+    /// vruntime clocks.
+    fn vtime_slice(&self, queued_entity_count: usize) -> u64 {
+        self.period(queued_entity_count) / (queued_entity_count + 1) as u64
     }
 
-    /// The time slice for each thread in the run queue, measured in sched clocks.
-    fn time_slice(&self, cur_weight: u64) -> u64 {
-        self.period() * cur_weight / (self.total_weight + cur_weight)
+    /// The time slice for each entity in the run queue, measured in sched clocks.
+    fn time_slice(
+        &self,
+        current_weight: u64,
+        queued_weight: u64,
+        queued_entity_count: usize,
+    ) -> u64 {
+        let total_weight = queued_weight.saturating_add(current_weight).max(1);
+        self.period(queued_entity_count) * current_weight / total_weight
+    }
+
+    fn add_queued_task(&mut self) {
+        self.total_queued_task_count = self.total_queued_task_count.saturating_add(1);
+    }
+
+    fn remove_queued_task(&mut self) {
+        self.total_queued_task_count = self.total_queued_task_count.saturating_sub(1);
+    }
+
+    fn update_queued_task_count_upwards(
+        &mut self,
+        child_group: &Arc<TaskGroup>,
+        update_fn: fn(&mut Self),
+    ) {
+        let Some(self_group) = self.task_group() else {
+            return;
+        };
+        let mut current_group = child_group.clone();
+        while let Some(parent_group) = current_group.parent() {
+            if Arc::ptr_eq(&parent_group, &self_group) {
+                update_fn(self);
+                break;
+            }
+
+            {
+                let mut parent_rq = parent_group.fair_queue(self.cpu).disable_irq().lock();
+                update_fn(&mut parent_rq);
+            }
+            current_group = parent_group;
+        }
+    }
+
+    /// Enqueues an entity into this runqueue, updating `total_weight`.
+    fn enqueue_entity(&mut self, fair_attr: &FairAttr, fair_entity: FairEntity) {
+        let key = (fair_attr.vruntime(), fair_attr.id);
+        if let Some(old_key) = self.entity_keys.get(&fair_attr.id).copied() {
+            self.remove_entity(old_key);
+        }
+
+        let weight = fair_attr.fetch_weight().1;
+        *fair_attr.queued_weight.lock() = weight;
+        let item = FairQueueItem::new(key, fair_entity);
+        if let Some(old_item) = self.entities.replace(item) {
+            let old_entity = old_item.into_entity();
+            if let Some(old_attr) = old_entity.fair_attr(self.cpu) {
+                self.total_weight = self
+                    .total_weight
+                    .saturating_sub(*old_attr.queued_weight.lock());
+            }
+        }
+        self.entity_keys.insert(fair_attr.id, key);
+        self.total_weight += weight;
+    }
+
+    /// Removes the entity at `key`, updating `total_weight`.
+    fn remove_entity(&mut self, key: (u64, u64)) -> Option<FairEntity> {
+        let item = self.entities.take(&key)?;
+        self.entity_keys.remove(&key.1);
+        let fair_entity = item.into_entity();
+        if let Some(fair_attr) = fair_entity.fair_attr(self.cpu) {
+            self.total_weight = self
+                .total_weight
+                .saturating_sub(*fair_attr.queued_weight.lock());
+        }
+        Some(fair_entity)
+    }
+
+    fn remove_entity_by_id(&mut self, entity_id: u64) -> Option<FairEntity> {
+        let key = self.entity_keys.get(&entity_id).copied()?;
+        let fair_entity = self.remove_entity(key);
+        if fair_entity.is_none() {
+            self.entity_keys.remove(&entity_id);
+        }
+        fair_entity
+    }
+
+    fn has_entity(&self, entity_id: u64) -> bool {
+        self.entity_keys.contains_key(&entity_id)
+    }
+
+    /// Refreshes a queued entity after its scheduling attributes change.
+    pub(super) fn refresh_queued_entity(&mut self, fair_attr: &FairAttr) {
+        let Some(fair_entity) = self.remove_entity_by_id(fair_attr.id) else {
+            return;
+        };
+        self.enqueue_entity(fair_attr, fair_entity);
+    }
+
+    pub(super) fn total_queued_task_count(&self) -> usize {
+        self.total_queued_task_count
+    }
+
+    pub(super) fn try_dequeue_task(
+        &mut self,
+        task: &Arc<Task>,
+        task_group: &Arc<TaskGroup>,
+    ) -> bool {
+        let Some(thread) = task.as_thread() else {
+            return false;
+        };
+        let fair_attr = &thread.sched_attr().fair;
+
+        if self
+            .task_group()
+            .is_some_and(|self_group| Arc::ptr_eq(task_group, &self_group))
+        {
+            let Some(queued_entity) = self.remove_entity_by_id(fair_attr.id) else {
+                return false;
+            };
+            drop(queued_entity);
+            fair_attr.save_migration_lag(self.min_vruntime);
+            self.remove_queued_task();
+            return true;
+        }
+
+        let leaf_is_empty = {
+            let mut leaf_rq = task_group.fair_queue(self.cpu).disable_irq().lock();
+            let Some(queued_entity) = leaf_rq.remove_entity_by_id(fair_attr.id) else {
+                return false;
+            };
+            drop(queued_entity);
+            fair_attr.save_migration_lag(leaf_rq.min_vruntime);
+            leaf_rq.remove_queued_task();
+            leaf_rq.is_empty()
+        };
+        self.update_queued_task_count_upwards(task_group, Self::remove_queued_task);
+
+        if leaf_is_empty {
+            let mut current_group = task_group.clone();
+            while let Some(parent_group) = current_group.parent() {
+                if !current_group
+                    .fair_queue(self.cpu)
+                    .disable_irq()
+                    .lock()
+                    .is_empty()
+                {
+                    break;
+                }
+                if let Some(self_group) = self.task_group()
+                    && Arc::ptr_eq(&parent_group, &self_group)
+                {
+                    self.dequeue_group_entity(&current_group);
+                } else {
+                    parent_group
+                        .fair_queue(self.cpu)
+                        .disable_irq()
+                        .lock()
+                        .dequeue_group_entity(&current_group);
+                }
+                current_group = parent_group;
+            }
+        }
+
+        true
+    }
+
+    fn update_current_entity(
+        &mut self,
+        fair_attr: &FairAttr,
+        rt: &CurrentRuntime,
+        flags: UpdateFlags,
+    ) -> bool {
+        let queued_entity = self.remove_entity_by_id(fair_attr.id);
+        let was_queued = queued_entity.is_some();
+        let weight = fair_attr.fetch_weight().1;
+        let vruntime = fair_attr.update_vruntime(rt.delta, weight);
+        if let Some(fair_entity) = queued_entity {
+            self.enqueue_entity(fair_attr, fair_entity);
+        }
+        let min_queued_vruntime = self.min_queued_vruntime();
+        self.min_vruntime = match min_queued_vruntime {
+            Some(min_queued_vruntime) => vruntime.min(min_queued_vruntime),
+            None => vruntime,
+        };
+
+        if self.is_empty() {
+            return false;
+        }
+        if matches!(
+            flags,
+            UpdateFlags::Wait | UpdateFlags::Yield | UpdateFlags::Exit
+        ) {
+            return true;
+        }
+
+        let queued_entity_count = self.len().saturating_sub(usize::from(was_queued));
+        let queued_weight = self
+            .total_weight
+            .saturating_sub(if was_queued { weight } else { 0 });
+        rt.period_delta > self.time_slice(weight, queued_weight, queued_entity_count)
+            || vruntime > self.min_vruntime + self.vtime_slice(queued_entity_count)
+    }
+
+    /// Enqueues `child_group`'s entity into this runqueue.
+    fn enqueue_group_entity(&mut self, child_group: &Arc<TaskGroup>) -> bool {
+        let Some(group_attr) = child_group.fair_attr(self.cpu) else {
+            return false; // root has no group entity attributes
+        };
+
+        if self.has_entity(group_attr.id) {
+            return false; // already active
+        }
+
+        let was_empty = self.entities.is_empty();
+        group_attr.update_vruntime_at_least(self.min_vruntime);
+        self.enqueue_entity(group_attr, FairEntity::Group(child_group.clone()));
+
+        was_empty
+    }
+
+    /// Dequeues `child_group`'s entity from this runqueue.
+    fn dequeue_group_entity(&mut self, child_group: &Arc<TaskGroup>) {
+        let Some(group_attr) = child_group.fair_attr(self.cpu) else {
+            return; // root has no group entity attributes
+        };
+        self.remove_entity_by_id(group_attr.id);
     }
 }
 
 impl SchedClassRq for FairClassRq {
-    fn enqueue(&mut self, entity: Arc<Task>, flags: Option<EnqueueFlags>) {
-        let fair_attr = &entity.as_thread().unwrap().sched_attr().fair;
-        let vruntime = match flags {
-            Some(EnqueueFlags::Spawn) => self.min_vruntime + self.vtime_slice(),
-            _ => self.min_vruntime,
+    fn enqueue(&mut self, task: Arc<Task>, flags: Option<EnqueueFlags>) {
+        let thread = task.as_thread().unwrap();
+        let fair_attr = &thread.sched_attr().fair;
+        let task_group = thread.task_group();
+
+        // If the task belongs to the same group as this runqueue, enqueue directly.
+        if let Some(current_tg) = self.task_group()
+            && Arc::ptr_eq(&task_group, &current_tg)
+        {
+            if let Some(lag) = fair_attr.take_migration_lag() {
+                fair_attr.set_vruntime(self.min_vruntime.saturating_add(lag));
+            } else {
+                let vruntime = match flags {
+                    Some(EnqueueFlags::Spawn) => self.min_vruntime + self.vtime_slice(self.len()),
+                    _ => self.min_vruntime,
+                };
+                fair_attr.update_vruntime_at_least(vruntime);
+            }
+            self.enqueue_entity(fair_attr, FairEntity::Thread(task.clone()));
+            self.add_queued_task();
+            return;
+        }
+
+        let was_empty = {
+            let mut leaf_rq = task_group.fair_queue(self.cpu).disable_irq().lock();
+            let was_empty = leaf_rq.is_empty();
+            leaf_rq.enqueue(task, flags);
+            was_empty
         };
-        let (_old_weight, weight) = fair_attr.fetch_weight();
+        self.update_queued_task_count_upwards(&task_group, Self::add_queued_task);
 
-        let vruntime = fair_attr
-            .vruntime
-            .fetch_max(vruntime, Ordering::Relaxed)
-            .max(vruntime);
+        if was_empty {
+            let Some(self_group) = self.task_group() else {
+                return;
+            };
 
-        self.total_weight += weight;
-        self.entities.push(Reverse(FairQueueItem(entity, vruntime)));
+            let mut child_group = task_group.clone();
+            while let Some(parent_group) = child_group.parent() {
+                let parent_was_empty = if Arc::ptr_eq(&parent_group, &self_group) {
+                    self.enqueue_group_entity(&child_group)
+                } else {
+                    parent_group
+                        .fair_queue(self.cpu)
+                        .disable_irq()
+                        .lock()
+                        .enqueue_group_entity(&child_group)
+                };
+
+                if !parent_was_empty || Arc::ptr_eq(&parent_group, &self_group) {
+                    break;
+                }
+                child_group = parent_group;
+            }
+        }
     }
 
     fn len(&self) -> usize {
@@ -304,44 +699,70 @@ impl SchedClassRq for FairClassRq {
     }
 
     fn pick_next(&mut self) -> Option<Arc<Task>> {
-        let Reverse(FairQueueItem(entity, _)) = self.entities.pop()?;
+        loop {
+            let item = self.entities.iter().next()?.clone();
+            let key = item.key();
+            let owner = item.entity().clone();
 
-        let sched_attr = entity.as_thread().unwrap().sched_attr();
-        let (old_weight, _weight) = sched_attr.fair.fetch_weight();
-        // Equals to:
-        //
-        // self.total_weight = self.total_weight + weight - old_weight;
-        // self.total_weight -= weight;
-        self.total_weight -= old_weight;
+            match owner {
+                FairEntity::Thread(task) => {
+                    self.remove_entity(key);
+                    self.remove_queued_task();
+                    return Some(task);
+                }
+                FairEntity::Group(child_group) => {
+                    let (task, child_is_empty) = {
+                        let mut child_rq = child_group.fair_queue(self.cpu).disable_irq().lock();
+                        let task = child_rq.pick_next();
+                        let child_is_empty = child_rq.is_empty();
+                        (task, child_is_empty)
+                    };
 
-        Some(entity)
+                    let Some(task) = task else {
+                        self.remove_entity(key);
+                        continue;
+                    };
+
+                    self.remove_queued_task();
+                    if child_is_empty {
+                        self.remove_entity(key);
+                    }
+
+                    return Some(task);
+                }
+            }
+        }
     }
 
-    fn update_current(
-        &mut self,
-        rt: &CurrentRuntime,
-        thread: &Thread,
-        flags: UpdateFlags,
-    ) -> bool {
+    fn update_current(&mut self, rt: &CurrentRuntime, thread: &Thread, flags: UpdateFlags) -> bool {
         let attr = thread.sched_attr();
-        match flags {
-            UpdateFlags::Tick | UpdateFlags::Yield | UpdateFlags::Wait => {
-                let (_old_weight, weight) = attr.fair.fetch_weight();
-                let vruntime = attr.fair.update_vruntime(rt.delta, weight);
-                let leftmost = self.entities.peek();
-                self.min_vruntime = match leftmost {
-                    Some(Reverse(leftmost)) => vruntime.min(leftmost.key()),
-                    None => vruntime,
-                };
-                if leftmost.is_none() {
-                    return false;
-                }
+        let task_group = thread.task_group();
+        let Some(self_group) = self.task_group() else {
+            return false;
+        };
 
-                matches!(flags, UpdateFlags::Wait)
-                    || rt.period_delta > self.time_slice(weight)
-                    || vruntime > self.min_vruntime + self.vtime_slice()
+        let mut should_preempt = if Arc::ptr_eq(&task_group, &self_group) {
+            self.update_current_entity(&attr.fair, rt, flags)
+        } else {
+            let mut leaf_rq = task_group.fair_queue(self.cpu).disable_irq().lock();
+            leaf_rq.update_current_entity(&attr.fair, rt, flags)
+        };
+
+        let mut current_group = task_group;
+        while let Some(parent_group) = current_group.parent() {
+            let Some(group_attr) = current_group.fair_attr(self.cpu) else {
+                break;
+            };
+
+            if Arc::ptr_eq(&parent_group, &self_group) {
+                should_preempt |= self.update_current_entity(group_attr, rt, flags);
+            } else {
+                let mut parent_rq = parent_group.fair_queue(self.cpu).disable_irq().lock();
+                should_preempt |= parent_rq.update_current_entity(group_attr, rt, flags);
             }
-            UpdateFlags::Exit => !self.is_empty(),
+            current_group = parent_group;
         }
+
+        should_preempt
     }
 }

--- a/kernel/src/sched/sched_class/idle.rs
+++ b/kernel/src/sched/sched_class/idle.rs
@@ -7,7 +7,8 @@ use ostd::task::{
     scheduler::{EnqueueFlags, UpdateFlags},
 };
 
-use super::{CurrentRuntime, SchedAttr, SchedClassRq};
+use super::{CurrentRuntime, SchedClassRq};
+use crate::thread::Thread;
 
 /// The per-cpu run queue for the IDLE scheduling class.
 ///
@@ -54,7 +55,7 @@ impl SchedClassRq for IdleClassRq {
         self.entity.take()
     }
 
-    fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {
+    fn update_current(&mut self, _: &CurrentRuntime, _: &Thread, _flags: UpdateFlags) -> bool {
         !self.is_empty()
     }
 }

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -134,8 +134,7 @@ trait SchedClassRq: Send + fmt::Debug {
     ///
     /// The return value of this method indicates whether there is another task
     /// **in this run queue** to replace the current one.
-    fn update_current(&mut self, rt: &CurrentRuntime, attr: &SchedAttr, flags: UpdateFlags)
-    -> bool;
+    fn update_current(&mut self, rt: &CurrentRuntime, thread: &Thread, flags: UpdateFlags) -> bool;
 }
 
 /// The scheduling attribute for a thread.
@@ -387,10 +386,10 @@ impl LocalRunQueue for PerCpuClassRqSet {
             let attr = &cur.sched_attr();
 
             match attr.policy_kind() {
-                SchedPolicyKind::Stop => (self.stop.update_current(rt, attr, flags), 0),
-                SchedPolicyKind::RealTime => (self.real_time.update_current(rt, attr, flags), 1),
-                SchedPolicyKind::Fair => (self.fair.update_current(rt, attr, flags), 2),
-                SchedPolicyKind::Idle => (self.idle.update_current(rt, attr, flags), 3),
+                SchedPolicyKind::Stop => (self.stop.update_current(rt, cur, flags), 0),
+                SchedPolicyKind::RealTime => (self.real_time.update_current(rt, cur, flags), 1),
+                SchedPolicyKind::Fair => (self.fair.update_current(rt, cur, flags), 2),
+                SchedPolicyKind::Idle => (self.idle.update_current(rt, cur, flags), 3),
             }
         } else {
             (false, 4)

--- a/kernel/src/sched/sched_class/mod.rs
+++ b/kernel/src/sched/sched_class/mod.rs
@@ -29,17 +29,25 @@ use super::{
 use crate::thread::{AsThread, Thread};
 
 mod policy;
+mod task_group;
 mod time;
 
-mod fair;
+pub(crate) mod fair;
 mod idle;
 mod real_time;
 mod stop;
 
-use self::policy::{SchedPolicyKind, SchedPolicyState};
+pub(crate) use self::{
+    fair::DEFAULT_CGROUP_WEIGHT,
+    task_group::{TaskGroup, root_task_group},
+};
 pub use self::{
     policy::{LinuxSchedPolicy, SchedPolicy},
     real_time::{RealTimePolicy, RealTimePriority},
+};
+use self::{
+    policy::{SchedPolicyKind, SchedPolicyState},
+    task_group::init_root_task_group,
 };
 
 type SchedEntity = (Arc<Task>, Arc<Thread>);
@@ -79,7 +87,7 @@ pub struct ClassScheduler {
 struct PerCpuClassRqSet {
     stop: stop::StopClassRq,
     real_time: real_time::RealTimeClassRq,
-    fair: fair::FairClassRq,
+    fair: Arc<SpinLock<fair::FairClassRq>>,
     idle: idle::IdleClassRq,
     current: Option<(SchedEntity, CurrentRuntime)>,
 }
@@ -265,11 +273,12 @@ impl Scheduler for ClassScheduler {
 
 impl ClassScheduler {
     pub fn new() -> Self {
+        let root_task_group = init_root_task_group(ostd::cpu::num_cpus());
         let class_rq = |cpu| {
             SpinLock::new(PerCpuClassRqSet {
                 stop: stop::StopClassRq::new(),
                 real_time: real_time::RealTimeClassRq::new(cpu),
-                fair: fair::FairClassRq::new(cpu),
+                fair: root_task_group.fair_queue(cpu).clone(),
                 idle: idle::IdleClassRq::new(),
                 current: None,
             })
@@ -282,10 +291,14 @@ impl ClassScheduler {
 
     // TODO: Implement a better algorithm and replace the current naive implementation.
     fn select_cpu(&self, thread: &Thread, flags: EnqueueFlags) -> CpuId {
-        if let Some(last_cpu) = thread.sched_attr().last_cpu() {
+        let affinity = thread.atomic_cpu_affinity().load(Ordering::Relaxed);
+        let last_cpu = thread.sched_attr().last_cpu();
+        if let Some(last_cpu) = last_cpu
+            && affinity.contains(last_cpu)
+        {
             return last_cpu;
         }
-        debug_assert!(flags == EnqueueFlags::Spawn);
+        debug_assert!(flags == EnqueueFlags::Spawn || last_cpu.is_some());
 
         let guard = disable_local();
 
@@ -303,7 +316,6 @@ impl ClassScheduler {
             }
         };
 
-        let affinity = thread.atomic_cpu_affinity().load(Ordering::Relaxed);
         match self.last_chosen_cpu.get() {
             Some(cpu) => {
                 // Perform a round-robin selection starting after the last chosen CPU.
@@ -337,7 +349,7 @@ impl PerCpuClassRqSet {
     fn pick_next_entity(&mut self) -> Option<SchedEntity> {
         (self.stop.pick_next())
             .or_else(|| self.real_time.pick_next())
-            .or_else(|| self.fair.pick_next())
+            .or_else(|| self.fair.lock().pick_next())
             .or_else(|| self.idle.pick_next())
             .and_then(|task| {
                 let thread = task.as_thread()?.clone();
@@ -349,13 +361,14 @@ impl PerCpuClassRqSet {
         match thread.sched_attr().policy_kind() {
             SchedPolicyKind::Stop => self.stop.enqueue(task, flags),
             SchedPolicyKind::RealTime => self.real_time.enqueue(task, flags),
-            SchedPolicyKind::Fair => self.fair.enqueue(task, flags),
+            SchedPolicyKind::Fair => self.fair.lock().enqueue(task, flags),
             SchedPolicyKind::Idle => self.idle.enqueue(task, flags),
         }
     }
 
     fn load_stats(&self) -> PerCpuLoadStats {
-        let queue_len = (self.stop.len() + self.real_time.len() + self.fair.len()) as u32;
+        let fair_queue_len = self.fair.lock().total_queued_task_count();
+        let queue_len = (self.stop.len() + self.real_time.len() + fair_queue_len) as u32;
         let is_idle = match &self.current {
             Some(((_, thread), _)) => thread.sched_attr().policy_kind() == SchedPolicyKind::Idle,
             None => true,
@@ -388,7 +401,7 @@ impl LocalRunQueue for PerCpuClassRqSet {
             match attr.policy_kind() {
                 SchedPolicyKind::Stop => (self.stop.update_current(rt, cur, flags), 0),
                 SchedPolicyKind::RealTime => (self.real_time.update_current(rt, cur, flags), 1),
-                SchedPolicyKind::Fair => (self.fair.update_current(rt, cur, flags), 2),
+                SchedPolicyKind::Fair => (self.fair.lock().update_current(rt, cur, flags), 2),
                 SchedPolicyKind::Idle => (self.idle.update_current(rt, cur, flags), 3),
             }
         } else {
@@ -402,7 +415,7 @@ impl LocalRunQueue for PerCpuClassRqSet {
         should_preempt
             || (lookahead >= 1 && !self.stop.is_empty())
             || (lookahead >= 2 && !self.real_time.is_empty())
-            || (lookahead >= 3 && !self.fair.is_empty())
+            || (lookahead >= 3 && !self.fair.lock().is_empty())
             || (lookahead >= 4 && !self.idle.is_empty())
     }
 
@@ -428,10 +441,17 @@ struct PerCpuLoadStats {
 
 impl SchedulerStats for ClassScheduler {
     fn nr_queued_and_running(&self) -> (u32, u32) {
-        self.rqs.iter().fold((0, 0), |(queued, running), rq| {
-            let PerCpuLoadStats { queue_len, is_idle } = rq.lock().load_stats();
-            (queued + queue_len, running + u32::from(!is_idle))
-        })
+        let mut queued = 0u32;
+        let mut running = 0u32;
+        for rq in self.rqs.iter() {
+            let rq = rq.lock();
+            let load_stats = rq.load_stats();
+            queued += load_stats.queue_len;
+            if !load_stats.is_idle {
+                running += 1;
+            }
+        }
+        (queued, running)
     }
 }
 

--- a/kernel/src/sched/sched_class/real_time.rs
+++ b/kernel/src/sched/sched_class/real_time.rs
@@ -17,8 +17,8 @@ use ostd::{
     },
 };
 
-use super::{CurrentRuntime, SchedAttr, SchedClassRq, time::base_slice_clocks};
-use crate::thread::AsThread;
+use super::{CurrentRuntime, SchedClassRq, time::base_slice_clocks};
+use crate::thread::{AsThread, Thread};
 
 pub type RealTimePriority = RangedU8<1, 99>;
 
@@ -213,13 +213,8 @@ impl SchedClassRq for RealTimeClassRq {
             .inspect(|_| self.nr_running -= 1)
     }
 
-    fn update_current(
-        &mut self,
-        rt: &CurrentRuntime,
-        attr: &SchedAttr,
-        flags: UpdateFlags,
-    ) -> bool {
-        let attr = &attr.real_time;
+    fn update_current(&mut self, rt: &CurrentRuntime, thread: &Thread, flags: UpdateFlags) -> bool {
+        let attr = &thread.sched_attr().real_time;
 
         match flags {
             UpdateFlags::Tick | UpdateFlags::Yield => match attr.time_slice.load(Relaxed) {

--- a/kernel/src/sched/sched_class/stop.rs
+++ b/kernel/src/sched/sched_class/stop.rs
@@ -7,7 +7,8 @@ use ostd::task::{
     scheduler::{EnqueueFlags, UpdateFlags},
 };
 
-use super::{CurrentRuntime, SchedAttr, SchedClassRq};
+use super::{CurrentRuntime, SchedClassRq};
+use crate::thread::Thread;
 
 /// The per-cpu run queue for the STOP scheduling class.
 ///
@@ -55,7 +56,7 @@ impl SchedClassRq for StopClassRq {
         self.entity.take()
     }
 
-    fn update_current(&mut self, _: &CurrentRuntime, _: &SchedAttr, _flags: UpdateFlags) -> bool {
+    fn update_current(&mut self, _: &CurrentRuntime, _: &Thread, _flags: UpdateFlags) -> bool {
         // Stop entities has the lowest priority value. They should never be preempted.
         false
     }

--- a/kernel/src/sched/sched_class/task_group.rs
+++ b/kernel/src/sched/sched_class/task_group.rs
@@ -56,7 +56,6 @@ impl TaskGroup {
     }
 
     /// Creates a child task group under `parent`.
-    #[expect(dead_code)]
     pub(crate) fn new_child(parent: &Arc<TaskGroup>, weight: u32) -> Arc<Self> {
         let cpu_count = cpu::num_cpus();
         Arc::new_cyclic(|weak_self| Self {
@@ -90,7 +89,6 @@ impl TaskGroup {
     }
 
     /// Updates the CPU weight and refreshes any queued group entities.
-    #[expect(dead_code)]
     pub(crate) fn update_weight(&self, weight: u32) {
         let scaled_weight = scale_cgroup_weight(weight);
         let parent = self.parent();

--- a/kernel/src/sched/sched_class/task_group.rs
+++ b/kernel/src/sched/sched_class/task_group.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Task group (cgroup) for hierarchical fair group scheduling.
+//!
+//! # Fair Runqueue Lock Order
+//!
+//! Fair runqueues are per-CPU, and code must not hold fair runqueue locks from
+//! different CPUs at the same time. Any fair runqueue locks held together must
+//! form an ancestor-to-descendant chain on one CPU. If an operation needs to
+//! update the runqueue represented by the current guard, it updates that guard
+//! directly instead of locking the same `SpinLock` again.
+
+use alloc::{
+    boxed::Box,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+
+use ostd::{
+    cpu::{self, CpuId},
+    sync::SpinLock,
+    task::{Task, scheduler::info::CommonSchedInfo},
+    util::id_set::Id,
+};
+
+use super::fair::{self, FairAttr, FairClassRq};
+
+/// A task group representing one cgroup for hierarchical fair group scheduling.
+#[derive(Debug)]
+pub struct TaskGroup {
+    /// Weak parent task group, or `None` for root.
+    parent: Option<Weak<TaskGroup>>,
+
+    /// Per-CPU scheduling attributes for this group's entity in the parent's runqueue.
+    fair_attrs: Box<[FairAttr]>,
+
+    /// Per-CPU fair runqueues for direct member threads and child group entities.
+    fair_rqs: Box<[Arc<SpinLock<FairClassRq>>]>,
+}
+
+impl TaskGroup {
+    /// Creates the root task group.
+    fn new_root(cpu_count: usize) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            parent: None,
+            fair_attrs: Vec::new().into_boxed_slice(),
+            fair_rqs: (0..cpu_count)
+                .map(|cpu| {
+                    Arc::new(SpinLock::new(FairClassRq::new(
+                        CpuId::new(cpu as u32),
+                        weak_self.clone(),
+                    )))
+                })
+                .collect(),
+        })
+    }
+
+    /// Creates a child task group under `parent`.
+    #[expect(dead_code)]
+    pub(crate) fn new_child(parent: &Arc<TaskGroup>, weight: u32) -> Arc<Self> {
+        let cpu_count = cpu::num_cpus();
+        Arc::new_cyclic(|weak_self| Self {
+            parent: Some(Arc::downgrade(parent)),
+            fair_attrs: (0..cpu_count)
+                .map(|_| FairAttr::from_weight(scale_cgroup_weight(weight)))
+                .collect(),
+            fair_rqs: (0..cpu_count)
+                .map(|cpu| {
+                    Arc::new(SpinLock::new(FairClassRq::new(
+                        CpuId::new(cpu as u32),
+                        weak_self.clone(),
+                    )))
+                })
+                .collect(),
+        })
+    }
+
+    /// Returns the parent task group, if any.
+    pub(super) fn parent(&self) -> Option<Arc<TaskGroup>> {
+        self.parent.as_ref()?.upgrade()
+    }
+
+    pub(super) fn fair_queue(&self, cpu: CpuId) -> &Arc<SpinLock<FairClassRq>> {
+        &self.fair_rqs[cpu.as_usize()]
+    }
+
+    /// Returns the per-CPU scheduling attributes for this group's entity.
+    pub(super) fn fair_attr(&self, cpu: CpuId) -> Option<&FairAttr> {
+        self.fair_attrs.get(u32::from(cpu) as usize)
+    }
+
+    /// Updates the CPU weight and refreshes any queued group entities.
+    #[expect(dead_code)]
+    pub(crate) fn update_weight(&self, weight: u32) {
+        let scaled_weight = scale_cgroup_weight(weight);
+        let parent = self.parent();
+
+        for (cpu, fair_attr) in self.fair_attrs.iter().enumerate() {
+            fair_attr.update_weight(scaled_weight);
+            if let Some(parent) = &parent {
+                parent
+                    .fair_queue(CpuId::new(cpu as u32))
+                    .disable_irq()
+                    .lock()
+                    .refresh_queued_entity(fair_attr);
+            }
+        }
+    }
+
+    /// Dequeues queued tasks whose task-group assignment changed to this group.
+    ///
+    /// Running and sleeping tasks are not returned. They observe the new task
+    /// group through their thread metadata when they are enqueued again.
+    ///
+    /// # Locking
+    ///
+    /// Locks only runqueues on each task's current CPU. While the root guard is
+    /// held, any additional guard is for a descendant runqueue on the same CPU.
+    pub(crate) fn migrate_tasks_from(
+        self: &Arc<Self>,
+        tasks: &[(Arc<Task>, Arc<TaskGroup>)],
+    ) -> Vec<Arc<Task>> {
+        let root = root_task_group();
+        let mut queued_tasks = Vec::new();
+
+        for (task, old_group) in tasks {
+            if Arc::ptr_eq(self, old_group) {
+                continue;
+            }
+
+            let Some(cpu) = task.cpu().get() else {
+                continue;
+            };
+
+            let mut root_rq = root.fair_queue(cpu).disable_irq().lock();
+            if root_rq.try_dequeue_task(task, old_group) {
+                task.cpu().set_to_none();
+                queued_tasks.push(task.clone());
+            }
+        }
+
+        queued_tasks
+    }
+}
+
+fn scale_cgroup_weight(weight: u32) -> u64 {
+    u64::from(weight).saturating_mul(fair::WEIGHT_0) / u64::from(fair::DEFAULT_CGROUP_WEIGHT)
+}
+
+/// Global root task group.
+static ROOT_TASK_GROUP: spin::Once<Arc<TaskGroup>> = spin::Once::new();
+
+/// Returns the root task group.
+pub(crate) fn root_task_group() -> &'static Arc<TaskGroup> {
+    init_root_task_group(cpu::num_cpus())
+}
+
+/// Initialises the root task group.
+pub(super) fn init_root_task_group(cpu_count: usize) -> &'static Arc<TaskGroup> {
+    ROOT_TASK_GROUP.call_once(|| TaskGroup::new_root(cpu_count))
+}

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -2,18 +2,22 @@
 
 //! Posix thread implementation
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    fmt,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use aster_util::per_cpu_counter::PerCpuCounter;
 use ostd::{
     cpu::{AtomicCpuSet, CpuId, CpuSet},
     irq::DisabledLocalIrqGuard,
+    sync::Rcu,
     task::Task,
 };
 
 use crate::{
     prelude::*,
-    sched::{SchedAttr, SchedPolicy},
+    sched::{self, SchedAttr, SchedPolicy, TaskGroup},
 };
 mod stats;
 use stats::CONTEXT_SWITCH_COUNTER;
@@ -71,7 +75,6 @@ pub(super) fn init() {
 }
 
 /// A thread is a wrapper on top of task.
-#[derive(Debug)]
 pub struct Thread {
     // immutable part
     /// Low-level info
@@ -85,10 +88,22 @@ pub struct Thread {
     /// Thread CPU affinity
     cpu_affinity: AtomicCpuSet,
     sched_attr: SchedAttr,
+    /// The task group this thread belongs to.
+    task_group: Rcu<Arc<TaskGroup>>,
+}
+
+impl Debug for Thread {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Thread")
+            .field("is_exited", &self.is_exited)
+            .field("cpu_affinity", &self.cpu_affinity)
+            .field("sched_attr", &self.sched_attr)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Thread {
-    /// Never call these function directly
+    /// Never call this function directly.
     pub fn new(
         task: Weak<Task>,
         data: impl Send + Sync + Any,
@@ -96,11 +111,12 @@ impl Thread {
         sched_policy: SchedPolicy,
     ) -> Self {
         Thread {
-            task,
+            task: task.clone(),
             data: Box::new(data),
             is_exited: AtomicBool::new(false),
             cpu_affinity: AtomicCpuSet::new(cpu_affinity),
             sched_attr: SchedAttr::new(sched_policy),
+            task_group: Rcu::new(sched::root_task_group().clone()),
         }
     }
 
@@ -140,6 +156,16 @@ impl Thread {
 
     pub fn sched_attr(&self) -> &SchedAttr {
         &self.sched_attr
+    }
+
+    /// Returns the task group this thread belongs to.
+    pub fn task_group(&self) -> Arc<TaskGroup> {
+        self.task_group.read().get().clone()
+    }
+
+    /// Sets the task group for this thread.
+    pub(crate) fn set_task_group(&self, task_group: Arc<TaskGroup>) {
+        self.task_group.update(task_group);
     }
 
     /// Yields the execution to another thread.

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -122,6 +122,12 @@ impl Task {
         scheduler::run_new_task(self.clone());
     }
 
+    /// Re-enqueues a parked task through the scheduler.
+    #[track_caller]
+    pub fn wake_up(self: &Arc<Self>) {
+        scheduler::unpark_target(self.clone());
+    }
+
     /// Returns the task data.
     pub fn data(&self) -> &Box<dyn Any + Send + Sync> {
         &self.data

--- a/test/initramfs/src/regression/process/cgroup.sh
+++ b/test/initramfs/src/regression/process/cgroup.sh
@@ -8,6 +8,17 @@ CGROUP_ROOT="/sys/fs/cgroup"
 CGROUP_NAME="user"
 PROCESS_ID=1
 BUSY_PID=""
+CHILD_PID=""
+PIDS_BASE_PID=""
+BG1=""
+BG2=""
+PID1=""
+PID2=""
+PID3=""
+BUSY_READY=""
+BUSY_START=""
+PIDS_READY=""
+PIDS_START=""
 
 # --- Helpers ------------------------------------------------------------------
 
@@ -74,6 +85,29 @@ read_cpu_stat_field() {
     exit 1
 }
 
+wait_for_process_state() {
+    local pid=$1
+    local expected_state=$2
+    local description=$3
+    local attempts=0
+
+    while [ "$attempts" -lt 10 ]; do
+        if grep -q "^State:[[:space:]]*$expected_state" "/proc/$pid/status" 2>/dev/null; then
+            echo "$description reached expected state: $(grep '^State:' "/proc/$pid/status")"
+            return
+        fi
+
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+
+    echo "Error: $description did not reach process state $expected_state"
+    if [ -f "/proc/$pid/status" ]; then
+        grep '^State:' "/proc/$pid/status" || true
+    fi
+    exit 1
+}
+
 cleanup() {
     log_step "Cleaning up"
 
@@ -83,6 +117,14 @@ cleanup() {
         wait "$BUSY_PID" 2>/dev/null || true
         BUSY_PID=""
     fi
+
+    for child_pid in "$CHILD_PID" "$PIDS_BASE_PID" "$BG1" "$BG2" "$PID1" "$PID2" "$PID3"; do
+        if [ -n "$child_pid" ]; then
+            kill "$child_pid" 2>/dev/null || true
+            wait "$child_pid" 2>/dev/null || true
+        fi
+    done
+    rm -f "$BUSY_READY" "$BUSY_START" "$PIDS_READY" "$PIDS_START"
 
     if [ -f "$CGROUP_ROOT/cgroup.procs" ]; then
         echo "Moving process $PROCESS_ID back to root cgroup"
@@ -159,6 +201,14 @@ verify "Initial cgroup.events populated=0" \
     "grep '^populated' cgroup.events" \
     "populated 0"
 
+log_step "1.8 Move current task through inactive CPU cgroup"
+verify "Inactive CPU cgroup does not trigger scheduler migration" \
+    "sh -c 'echo \$\$ > $CGROUP_ROOT/$CGROUP_NAME/cgroup.procs && grep -a \"0::/$CGROUP_NAME\" /proc/\$\$/cgroup && echo \$\$ > $CGROUP_ROOT/cgroup.procs'" \
+    "0::/$CGROUP_NAME"
+verify "Current task returned to root after inactive migration" \
+    "grep -a '0::/' /proc/$$/cgroup" \
+    "0::/"
+
 # --- Section 2: Controller activation / deactivation -------------------------
 
 log_section "Section 2: Controller activation / deactivation"
@@ -167,6 +217,21 @@ log_step "2.1 Enable cpu, memory, and pids in root"
 cd "$CGROUP_ROOT"
 echo "+cpu +memory +pids" > cgroup.subtree_control
 verify "root subtree_control has cpu, memory, and pids" \
+    "cat cgroup.subtree_control" \
+    "cpu memory pids"
+
+log_step "2.1.1 No-op enable succeeds in populated root"
+verify "No-op +cpu keeps root subtree_control unchanged" \
+    "echo +cpu > cgroup.subtree_control && cat cgroup.subtree_control" \
+    "cpu memory pids"
+
+log_step "2.1.2 Pure disable succeeds in populated root"
+echo "-pids" > cgroup.subtree_control
+verify "root subtree_control removed pids" \
+    "cat cgroup.subtree_control" \
+    "cpu memory"
+echo "+pids" > cgroup.subtree_control
+verify "root subtree_control restored pids" \
     "cat cgroup.subtree_control" \
     "cpu memory pids"
 
@@ -219,10 +284,17 @@ verify "cpu.max single value preserves period" \
 verify "cpu.max rejects an invalid period" \
     "echo '30000 999' > cpu.max 2>/dev/null || echo rejected" \
     "rejected"
+verify "cpu.max is unchanged after rejected period" \
+    "cat cpu.max" \
+    "30000 200000"
 echo "50000 invalid" > cpu.max
-verify "cpu.max accepts a non-numeric period" \
+verify "cpu.max non-numeric period preserves previous period" \
     "cat cpu.max" \
     "50000 200000"
+echo "50000 300000 extra" > cpu.max
+verify "cpu.max ignores extra fields" \
+    "cat cpu.max" \
+    "50000 300000"
 echo "max 100000" > cpu.max
 verify "cpu.max resets to default value" \
     "cat cpu.max" \
@@ -262,17 +334,29 @@ verify "cpu.max defaults after re-enable" \
 
 log_step "2.2.4 Verify cpu.stat grows for a busy cgroup task"
 CPU_STAT_PATH="$CGROUP_ROOT/$CGROUP_NAME/cpu.stat"
+BUSY_READY=$(mktemp -u)
+BUSY_START=$(mktemp -u)
+mkfifo "$BUSY_READY" "$BUSY_START"
 
 sh -c '
-CGROUP_PATH=$1
-echo $$ > "$CGROUP_PATH/cgroup.procs"
+READY_FIFO=$1
+START_FIFO=$2
+printf "ready\n" > "$READY_FIFO"
+read _ < "$START_FIFO"
 while :; do
     :
 done
-' sh "$CGROUP_ROOT/$CGROUP_NAME" &
+' sh "$BUSY_READY" "$BUSY_START" &
 BUSY_PID=$!
 
-# Give the helper time to join the cgroup and start consuming CPU.
+read _ < "$BUSY_READY"
+echo $BUSY_PID > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+printf "start\n" > "$BUSY_START"
+rm -f "$BUSY_READY" "$BUSY_START"
+BUSY_READY=""
+BUSY_START=""
+
+# Give the helper time to start consuming CPU in the cgroup.
 sleep 1
 
 USAGE_BEFORE=$(read_cpu_stat_field "usage_usec" "$CPU_STAT_PATH")
@@ -328,6 +412,11 @@ verify "Process 1 added to user hierarchy" \
     "cat cgroup.procs | grep -w $PROCESS_ID" \
     "$PROCESS_ID"
 
+log_step "3.1.1 No-op disable succeeds with process attached"
+verify "No-op -pids keeps child subtree_control empty" \
+    "echo -pids > cgroup.subtree_control && cat cgroup.subtree_control" \
+    ""
+
 log_step "3.2 Try enabling pids in child with process attached (expect EBUSY)"
 verify "Cannot enable pids with process attached" \
     "echo +pids > cgroup.subtree_control" \
@@ -347,6 +436,16 @@ verify "pids enabled successfully in child" \
     "cat cgroup.subtree_control" \
     "pids"
 
+log_step "3.4.1 Parent cannot disable pids while child has it enabled"
+cd "$CGROUP_ROOT"
+verify "Cannot disable pids in parent while child has pids enabled" \
+    "echo -pids > cgroup.subtree_control" \
+    "sh: write error: Device or resource busy"
+verify "root subtree_control unchanged after failed pids disable" \
+    "cat cgroup.subtree_control" \
+    "cpu pids"
+cd "$CGROUP_NAME"
+
 log_step "3.5 Try binding process when child pids enabled (expect EBUSY)"
 verify "Cannot bind process when child pids enabled" \
     "echo $PROCESS_ID > cgroup.procs" \
@@ -358,6 +457,46 @@ echo $PROCESS_ID > cgroup.procs
 verify "Process 1 added to user hierarchy" \
     "cat cgroup.procs | grep -w $PROCESS_ID" \
     "$PROCESS_ID"
+
+log_step "3.7 Move process 1 back to root for migration tests"
+cd "$CGROUP_ROOT"
+echo $PROCESS_ID > cgroup.procs
+verify "Process 1 back in root cgroup" \
+    "grep -a '0::/' /proc/$PROCESS_ID/cgroup" \
+    "0::/"
+
+log_step "3.8 Move a sleeping child between cgroups"
+sleep 100 &
+CHILD_PID=$!
+wait_for_process_state "$CHILD_PID" "S" "Sleeping child"
+echo $CHILD_PID > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+verify "Sleeping child moved to user hierarchy" \
+    "grep -a '0::/$CGROUP_NAME' /proc/$CHILD_PID/cgroup" \
+    "0::/$CGROUP_NAME"
+echo $CHILD_PID > "$CGROUP_ROOT/cgroup.procs"
+verify "Sleeping child moved back to root" \
+    "grep -a '0::/' /proc/$CHILD_PID/cgroup" \
+    "0::/"
+kill $CHILD_PID 2>/dev/null || true
+wait $CHILD_PID 2>/dev/null || true
+CHILD_PID=""
+
+log_step "3.9 Move the current task through an active CPU cgroup"
+verify "Current task migrates without EBUSY" \
+    "sh -c 'echo \$\$ > $CGROUP_ROOT/$CGROUP_NAME/cgroup.procs && grep -a \"0::/$CGROUP_NAME\" /proc/\$\$/cgroup && echo \$\$ > $CGROUP_ROOT/cgroup.procs'" \
+    "0::/$CGROUP_NAME"
+verify "Test shell remains in root cgroup" \
+    "grep -a '0::/' /proc/$$/cgroup" \
+    "0::/"
+
+log_step "3.10 Bind a sleeping anchor process for pids tests"
+sleep 100 &
+PIDS_BASE_PID=$!
+wait_for_process_state "$PIDS_BASE_PID" "S" "pids anchor process"
+echo $PIDS_BASE_PID > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+verify "Pids anchor process added to user hierarchy" \
+    "cat $CGROUP_ROOT/$CGROUP_NAME/cgroup.procs | grep -w $PIDS_BASE_PID" \
+    "$PIDS_BASE_PID"
 
 # --- Section 4: pids sub-controller -------------------------------------------
 
@@ -386,22 +525,25 @@ verify "pids.max reset to max" \
 
 log_step "4.1.4 Verify pids.max enforces the fork limit"
 
-# Write a helper script that will run inside the cgroup.
-# It moves itself into the cgroup, then attempts a fork.
+# Write a helper script that the parent moves into the cgroup.
+# It waits there, then attempts a fork.
 # The result (success or failure) is written to a temp file.
-# This helper runs as a completely separate process, so when the
-# fork inside it fails and the shell aborts, our main script is
-# unaffected.
+# This helper runs as a separate process so the main script is unaffected.
 RESULT_FILE=$(mktemp)
 HELPER_SCRIPT=$(mktemp)
+PIDS_READY=$(mktemp -u)
+PIDS_START=$(mktemp -u)
+mkfifo "$PIDS_READY" "$PIDS_START"
 
 cat > "$HELPER_SCRIPT" << 'EOF'
 #!/bin/sh
 CGROUP_PATH="$1"
 RESULT_FILE="$2"
+READY_FIFO="$3"
+START_FIFO="$4"
 
-# Join the cgroup.
-echo $$ > "$CGROUP_PATH/cgroup.procs"
+printf "ready\n" > "$READY_FIFO"
+read _ < "$START_FIFO"
 
 # Read the current pid count (built-in read, no fork).
 read CURRENT_IN_CGROUP < "$CGROUP_PATH/pids.current"
@@ -419,9 +561,15 @@ EOF
 
 chmod +x "$HELPER_SCRIPT"
 
-# Run the helper as a separate process. If it crashes due to fork failure,
-# only the helper exits; our main script continues normally.
-sh "$HELPER_SCRIPT" "$CGROUP_ROOT/$CGROUP_NAME" "$RESULT_FILE" 2>/dev/null || true
+sh "$HELPER_SCRIPT" "$CGROUP_ROOT/$CGROUP_NAME" "$RESULT_FILE" "$PIDS_READY" "$PIDS_START" 2>/dev/null &
+PIDS_HELPER_PID=$!
+read _ < "$PIDS_READY"
+echo $PIDS_HELPER_PID > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+printf "start\n" > "$PIDS_START"
+wait $PIDS_HELPER_PID 2>/dev/null || true
+rm -f "$PIDS_READY" "$PIDS_START"
+PIDS_READY=""
+PIDS_START=""
 
 # The helper has exited (either normally or due to fork failure).
 # Restore pids.max before reading results.
@@ -443,33 +591,25 @@ fi
 
 log_section "Section 4.2: pids.current"
 
-log_step "4.2.1 Check pids.current with process 1 in cgroup"
-verify_ge "pids.current >= 1 with one process" \
+log_step "4.2.1 Check pids.current with the anchor process in cgroup"
+verify_ge "pids.current >= 1 with anchor process" \
     "cat $CGROUP_ROOT/$CGROUP_NAME/pids.current" \
     1
 
 log_step "4.2.2 Spawn a child process and verify pids.current increases"
 
-# Read baseline before the shell joins the cgroup so the cat itself is safe.
 BEFORE=$(cat "$CGROUP_ROOT/$CGROUP_NAME/pids.current")
 echo "pids.current before fork: $BEFORE"
 
-# Move the current shell into the user cgroup.
-echo $$ > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
-
-# Fork the child process that we want to observe.
 sleep 100 &
 CHILD_PID=$!
+wait_for_process_state "$CHILD_PID" "S" "pids.current child"
+echo $CHILD_PID > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
 
-# Use the shell built-in read to avoid an extra fork for the cat.
 read AFTER < "$CGROUP_ROOT/$CGROUP_NAME/pids.current"
-echo "pids.current after fork: $AFTER"
+echo "pids.current after child migration: $AFTER"
 
-# Move the shell back to the root cgroup; subsequent commands are safe.
-echo $$ > "$CGROUP_ROOT/cgroup.procs"
-
-# Verify the count increased (sleep is still running in the background).
-verify_ge "pids.current increased after fork" \
+verify_ge "pids.current increased after child migration" \
     "cat $CGROUP_ROOT/$CGROUP_NAME/pids.current" \
     $((BEFORE + 1))
 
@@ -478,11 +618,12 @@ log_step "4.2.3 Kill child process and verify pids.current decreases"
 # Kill the child and wait for it to fully exit.
 kill $CHILD_PID 2>/dev/null || true
 wait $CHILD_PID 2>/dev/null || true
+CHILD_PID=""
 
 # Give the cgroup accounting a moment to update.
 sleep 0.2
 
-# pids.current should be back to the baseline (shell is no longer in cgroup).
+# pids.current should be back to the baseline anchor process count.
 verify "pids.current back to pre-fork value" \
     "cat $CGROUP_ROOT/$CGROUP_NAME/pids.current" \
     "$BEFORE"
@@ -510,6 +651,8 @@ sleep 100 &
 BG1=$!
 sleep 100 &
 BG2=$!
+wait_for_process_state "$BG1" "S" "first pids.current toggle child"
+wait_for_process_state "$BG2" "S" "second pids.current toggle child"
 echo $BG1 > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
 echo $BG2 > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
 
@@ -574,15 +717,18 @@ verify_ge "pids.peak >= 1 initially" \
     1
 
 log_step "4.3.2 Spawn multiple child processes to drive pids up"
-echo $$ > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
 
 sleep 100 & PID1=$!
 sleep 100 & PID2=$!
 sleep 100 & PID3=$!
+wait_for_process_state "$PID1" "S" "first pids.peak child"
+wait_for_process_state "$PID2" "S" "second pids.peak child"
+wait_for_process_state "$PID3" "S" "third pids.peak child"
+echo $PID1 > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+echo $PID2 > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
+echo $PID3 > "$CGROUP_ROOT/$CGROUP_NAME/cgroup.procs"
 
 read PEAK_DURING < "$CGROUP_ROOT/$CGROUP_NAME/pids.peak"
-
-echo $$ > "$CGROUP_ROOT/cgroup.procs"
 
 echo "pids.peak during burst: $PEAK_DURING"
 verify_ge "pids.peak increased during burst" \
@@ -592,6 +738,9 @@ verify_ge "pids.peak increased during burst" \
 log_step "4.3.3 Kill child processes"
 kill $PID1 $PID2 $PID3 2>/dev/null || true
 wait $PID1 $PID2 $PID3 2>/dev/null || true
+PID1=""
+PID2=""
+PID3=""
 
 log_step "4.3.4 Verify pids.peak is retained after processes exit"
 
@@ -609,14 +758,20 @@ fi
 
 log_section "Section 5: Teardown"
 
-log_step "5.1 Move process 1 back to root"
+log_step "5.1 Stop pids anchor process"
+kill $PIDS_BASE_PID 2>/dev/null || true
+wait $PIDS_BASE_PID 2>/dev/null || true
+PIDS_BASE_PID=""
+sleep 0.2
+
+log_step "5.2 Move process 1 back to root"
 cd "$CGROUP_ROOT"
 echo $PROCESS_ID > cgroup.procs
 verify "Process 1 back in root cgroup" \
     "grep -a '0::' /proc/$PROCESS_ID/cgroup" \
     "0::/"
 
-log_step "5.2 Remove user hierarchy"
+log_step "5.3 Remove user hierarchy"
 rmdir "$CGROUP_NAME"
 verify "user hierarchy removed" \
     "ls -d $CGROUP_NAME" \

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -76,6 +76,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 ./cgroup.sh
+./sched/cgroup_lifecycle_stress
 ./group_session
 ./job_control
 ./pidfd

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -77,6 +77,7 @@ fi
 
 ./cgroup.sh
 ./sched/cgroup_lifecycle_stress
+./sched/cgroup_cpu_weight
 ./group_session
 ./job_control
 ./pidfd

--- a/test/initramfs/src/regression/process/sched/cgroup_cpu_weight.c
+++ b/test/initramfs/src/regression/process/sched/cgroup_cpu_weight.c
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CGROUP_ROOT "/sys/fs/cgroup"
+#define MAX_WORKERS 4
+#define FAIR_WINDOW_SECONDS 8
+#define STARVATION_WINDOW_SECONDS 10
+#define MIN_FAIR_TOTAL_USEC 4000000ULL
+#define MIN_STARVATION_TOTAL_USEC 5000000ULL
+
+struct worker {
+	pid_t pid;
+	int start_fd;
+};
+
+static char group_a[PATH_MAX];
+static char group_b[PATH_MAX];
+static char guard_group[PATH_MAX];
+static struct worker workers[MAX_WORKERS];
+static size_t worker_count;
+
+static void die(const char *message)
+{
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail(const char *message)
+{
+	fprintf(stderr, "FAIL: %s\n", message);
+	exit(EXIT_FAILURE);
+}
+
+static void checked_snprintf(char *buffer, size_t size, const char *format, ...)
+{
+	va_list args;
+	int count;
+
+	va_start(args, format);
+	count = vsnprintf(buffer, size, format, args);
+	va_end(args);
+
+	if (count < 0 || (size_t)count >= size)
+		fail("formatted string is too long");
+}
+
+static void write_text_file(const char *path, const char *text)
+{
+	int fd = open(path, O_WRONLY);
+	size_t len = strlen(text);
+	ssize_t count;
+
+	if (fd < 0)
+		die(path);
+
+	count = write(fd, text, len);
+	if (count != (ssize_t)len) {
+		if (count >= 0)
+			errno = EIO;
+		close(fd);
+		die(path);
+	}
+
+	if (close(fd) < 0)
+		die(path);
+}
+
+static void expect_write_errno(const char *path, const char *text,
+			       int expected_errno)
+{
+	int fd = open(path, O_WRONLY);
+	ssize_t count;
+
+	if (fd < 0)
+		die(path);
+
+	errno = 0;
+	count = write(fd, text, strlen(text));
+	if (count >= 0 || errno != expected_errno) {
+		close(fd);
+		fprintf(stderr,
+			"FAIL: writing \"%s\" to %s got count=%zd errno=%d, expected errno=%d\n",
+			text, path, count, errno, expected_errno);
+		exit(EXIT_FAILURE);
+	}
+
+	if (close(fd) < 0)
+		die(path);
+}
+
+static ssize_t read_text_file(const char *path, char *buffer, size_t size)
+{
+	int fd = open(path, O_RDONLY);
+	ssize_t count;
+
+	if (fd < 0)
+		die(path);
+
+	count = read(fd, buffer, size - 1);
+	if (count < 0) {
+		close(fd);
+		die(path);
+	}
+	buffer[count] = '\0';
+
+	if (close(fd) < 0)
+		die(path);
+
+	return count;
+}
+
+static int has_token(const char *text, const char *token)
+{
+	size_t token_len = strlen(token);
+	const char *cursor = text;
+
+	while ((cursor = strstr(cursor, token)) != NULL) {
+		int before_ok = cursor == text || cursor[-1] == ' ' ||
+				cursor[-1] == '\n' || cursor[-1] == '\t';
+		int after_ok =
+			cursor[token_len] == '\0' || cursor[token_len] == ' ' ||
+			cursor[token_len] == '\n' || cursor[token_len] == '\t';
+
+		if (before_ok && after_ok)
+			return 1;
+		cursor += token_len;
+	}
+
+	return 0;
+}
+
+static void enable_cpu_controller(void)
+{
+	char content[256];
+	char path[PATH_MAX];
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	read_text_file(path, content, sizeof(content));
+	if (!has_token(content, "cpu"))
+		write_text_file(path, "+cpu\n");
+}
+
+static void disable_cpu_controller(void)
+{
+	char content[256];
+	char path[PATH_MAX];
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	read_text_file(path, content, sizeof(content));
+	if (has_token(content, "cpu"))
+		write_text_file(path, "-cpu\n");
+}
+
+static void set_weight(const char *group, unsigned int weight)
+{
+	char path[PATH_MAX];
+	char text[32];
+
+	checked_snprintf(path, sizeof(path), "%s/cpu.weight", group);
+	snprintf(text, sizeof(text), "%u\n", weight);
+	write_text_file(path, text);
+}
+
+static unsigned int read_weight(const char *group)
+{
+	char path[PATH_MAX];
+	char content[64];
+	char *end;
+	unsigned long value;
+
+	checked_snprintf(path, sizeof(path), "%s/cpu.weight", group);
+	read_text_file(path, content, sizeof(content));
+	errno = 0;
+	value = strtoul(content, &end, 10);
+	if (errno != 0 || end == content || value > UINT_MAX)
+		die(path);
+
+	return (unsigned int)value;
+}
+
+static void move_pid_to_cgroup(const char *group, pid_t pid)
+{
+	char path[PATH_MAX];
+	char text[32];
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.procs", group);
+	snprintf(text, sizeof(text), "%d", pid);
+	write_text_file(path, text);
+}
+
+static unsigned long long read_usage_usec(const char *group)
+{
+	char path[PATH_MAX];
+	char content[512];
+	char *usage;
+
+	checked_snprintf(path, sizeof(path), "%s/cpu.stat", group);
+	read_text_file(path, content, sizeof(content));
+
+	usage = strstr(content, "usage_usec ");
+	if (usage == NULL)
+		fail("cpu.stat does not contain usage_usec");
+
+	errno = 0;
+	usage += strlen("usage_usec ");
+	unsigned long long value = strtoull(usage, NULL, 10);
+	if (errno != 0)
+		die(path);
+
+	return value;
+}
+
+static int pin_current_to_cpu0(void)
+{
+	cpu_set_t mask;
+
+	CPU_ZERO(&mask);
+	CPU_SET(0, &mask);
+	return sched_setaffinity(0, sizeof(mask), &mask);
+}
+
+static void worker_loop(int start_fd)
+{
+	char byte;
+	volatile unsigned long counter = 0;
+
+	if (pin_current_to_cpu0() < 0)
+		_exit(EXIT_FAILURE);
+	if (kill(getpid(), SIGSTOP) < 0)
+		_exit(EXIT_FAILURE);
+	if (read(start_fd, &byte, 1) != 1)
+		_exit(EXIT_SUCCESS);
+
+	for (;;) {
+		counter++;
+		if ((counter & 0xfffffUL) == 0)
+			asm volatile("" : : "r"(counter) : "memory");
+	}
+}
+
+static void wait_for_worker_stop(pid_t pid)
+{
+	int status;
+
+	for (;;) {
+		if (waitpid(pid, &status, WUNTRACED) < 0) {
+			if (errno == EINTR)
+				continue;
+			die("waitpid");
+		}
+
+		if (!WIFSTOPPED(status))
+			fail("worker exited before it stopped");
+		return;
+	}
+}
+
+static void wait_for_worker_exit(pid_t pid)
+{
+	for (;;) {
+		if (waitpid(pid, NULL, 0) >= 0)
+			return;
+		if (errno == EINTR)
+			continue;
+		if (errno == ECHILD)
+			return;
+		die("waitpid");
+	}
+}
+
+static void spawn_worker(const char *group)
+{
+	int pipe_fds[2];
+	pid_t pid;
+	struct worker worker;
+
+	if (worker_count >= MAX_WORKERS)
+		fail("too many workers");
+
+	if (pipe(pipe_fds) < 0)
+		die("pipe");
+
+	pid = fork();
+	if (pid < 0)
+		die("fork");
+	if (pid == 0) {
+		close(pipe_fds[1]);
+		worker_loop(pipe_fds[0]);
+		_exit(EXIT_SUCCESS);
+	}
+
+	close(pipe_fds[0]);
+	worker.pid = pid;
+	worker.start_fd = pipe_fds[1];
+	workers[worker_count++] = worker;
+
+	wait_for_worker_stop(pid);
+	move_pid_to_cgroup(group, pid);
+}
+
+static void start_workers(void)
+{
+	for (size_t index = 0; index < worker_count; index++) {
+		if (write(workers[index].start_fd, "x", 1) != 1)
+			die("start worker");
+		close(workers[index].start_fd);
+		workers[index].start_fd = -1;
+	}
+
+	for (size_t index = 0; index < worker_count; index++) {
+		if (kill(workers[index].pid, SIGCONT) < 0)
+			die("continue worker");
+	}
+}
+
+static void stop_workers(void)
+{
+	for (size_t index = 0; index < worker_count; index++) {
+		if (workers[index].start_fd >= 0) {
+			close(workers[index].start_fd);
+			workers[index].start_fd = -1;
+		}
+		if (workers[index].pid > 0)
+			kill(workers[index].pid, SIGKILL);
+	}
+
+	for (size_t index = 0; index < worker_count; index++) {
+		if (workers[index].pid > 0)
+			wait_for_worker_exit(workers[index].pid);
+		workers[index].pid = 0;
+	}
+
+	worker_count = 0;
+}
+
+static void cleanup(void)
+{
+	stop_workers();
+	if (guard_group[0] != '\0')
+		rmdir(guard_group);
+	if (group_b[0] != '\0')
+		rmdir(group_b);
+	if (group_a[0] != '\0')
+		rmdir(group_a);
+}
+
+static void create_test_cgroups(void)
+{
+	char suffix[64];
+
+	checked_snprintf(suffix, sizeof(suffix), "cpuw-%d", getpid());
+	checked_snprintf(group_a, sizeof(group_a), "%s/%s-a", CGROUP_ROOT,
+			 suffix);
+	checked_snprintf(group_b, sizeof(group_b), "%s/%s-b", CGROUP_ROOT,
+			 suffix);
+
+	if (mkdir(group_a, 0755) < 0)
+		die(group_a);
+	if (mkdir(group_b, 0755) < 0)
+		die(group_b);
+}
+
+struct usage_sample {
+	unsigned long long delta_a;
+	unsigned long long delta_b;
+};
+
+static struct usage_sample
+measure_existing_workers_current(int workers_a, int workers_b,
+				 unsigned int window_seconds)
+{
+	unsigned long long before_a;
+	unsigned long long before_b;
+	unsigned long long delta_a;
+	unsigned long long delta_b;
+
+	before_a = read_usage_usec(group_a);
+	before_b = read_usage_usec(group_b);
+
+	start_workers();
+	sleep(window_seconds);
+
+	delta_a = read_usage_usec(group_a) - before_a;
+	delta_b = read_usage_usec(group_b) - before_b;
+
+	stop_workers();
+
+	fprintf(stderr, "current weights workers=%d:%d usage=%llu:%llu\n",
+		workers_a, workers_b, delta_a, delta_b);
+
+	return (struct usage_sample){
+		.delta_a = delta_a,
+		.delta_b = delta_b,
+	};
+}
+
+static struct usage_sample measure_usage_current(int workers_a, int workers_b,
+						 unsigned int window_seconds)
+{
+	for (int index = 0; index < workers_a; index++)
+		spawn_worker(group_a);
+	for (int index = 0; index < workers_b; index++)
+		spawn_worker(group_b);
+
+	return measure_existing_workers_current(workers_a, workers_b,
+						window_seconds);
+}
+
+static struct usage_sample measure_usage(unsigned int weight_a,
+					 unsigned int weight_b, int workers_a,
+					 int workers_b,
+					 unsigned int window_seconds)
+{
+	set_weight(group_a, weight_a);
+	set_weight(group_b, weight_b);
+
+	return measure_usage_current(workers_a, workers_b, window_seconds);
+}
+
+static unsigned int share_basis_points(const struct usage_sample *sample,
+				       unsigned long long min_total)
+{
+	unsigned long long total = sample->delta_a + sample->delta_b;
+
+	if (total < min_total)
+		fail("cpu.stat usage delta is too small");
+
+	return (unsigned int)(sample->delta_a * 10000 / total);
+}
+
+static void expect_share_range(const char *name, unsigned int share_bp,
+			       unsigned int min_bp, unsigned int max_bp)
+{
+	if (share_bp < min_bp || share_bp > max_bp) {
+		fprintf(stderr,
+			"FAIL: %s share_a=%u.%02u%%, expected %u.%02u..%u.%02u%%\n",
+			name, share_bp / 100, share_bp % 100, min_bp / 100,
+			min_bp % 100, max_bp / 100, max_bp % 100);
+		exit(EXIT_FAILURE);
+	}
+
+	fprintf(stderr, "%s share_a=%u.%02u%%\n", name, share_bp / 100,
+		share_bp % 100);
+}
+
+static void test_invalid_weights(void)
+{
+	char path[PATH_MAX];
+
+	set_weight(group_a, 100);
+	checked_snprintf(path, sizeof(path), "%s/cpu.weight", group_a);
+
+	expect_write_errno(path, "0\n", EINVAL);
+	if (read_weight(group_a) != 100)
+		fail("invalid zero weight changed cpu.weight");
+
+	expect_write_errno(path, "10001\n", EINVAL);
+	if (read_weight(group_a) != 100)
+		fail("invalid large weight changed cpu.weight");
+}
+
+static void test_fair_share(const char *name, unsigned int weight_a,
+			    unsigned int weight_b, int workers_a, int workers_b,
+			    unsigned int min_bp, unsigned int max_bp)
+{
+	struct usage_sample sample;
+	unsigned int share_bp = 0;
+
+	sample = measure_usage(weight_a, weight_b, workers_a, workers_b,
+			       FAIR_WINDOW_SECONDS);
+	fprintf(stderr, "weights=%u:%u ", weight_a, weight_b);
+	share_bp = share_basis_points(&sample, MIN_FAIR_TOTAL_USEC);
+
+	expect_share_range(name, share_bp, min_bp, max_bp);
+}
+
+static void test_weight_reset_after_cpu_toggle(void)
+{
+	struct usage_sample sample;
+	unsigned int share_bp;
+	char path[PATH_MAX];
+
+	set_weight(group_a, 300);
+	set_weight(group_b, 100);
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	write_text_file(path, "-cpu\n");
+	write_text_file(path, "+cpu\n");
+
+	if (read_weight(group_a) != 100 || read_weight(group_b) != 100)
+		fail("cpu.weight did not reset to default after cpu toggle");
+
+	sample = measure_usage_current(1, 1, FAIR_WINDOW_SECONDS);
+	share_bp = share_basis_points(&sample, MIN_FAIR_TOTAL_USEC);
+	expect_share_range("default weights after cpu toggle", share_bp, 4500,
+			   5500);
+}
+
+static void test_failed_mixed_disable_is_atomic(void)
+{
+	char content[256];
+	char path[PATH_MAX];
+	unsigned long long before_a;
+	unsigned long long before_b;
+	struct usage_sample sample;
+	unsigned int share_bp;
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	write_text_file(path, "+cpu +memory\n");
+
+	checked_snprintf(guard_group, sizeof(guard_group), "%s/cpuw-%d-guard",
+			 CGROUP_ROOT, getpid());
+	if (mkdir(guard_group, 0755) < 0)
+		die(guard_group);
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 guard_group);
+	write_text_file(path, "+memory\n");
+
+	set_weight(group_a, 10000);
+	set_weight(group_b, 100);
+	spawn_worker(group_a);
+	spawn_worker(group_b);
+
+	before_a = read_usage_usec(group_a);
+	before_b = read_usage_usec(group_b);
+	start_workers();
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	expect_write_errno(path, "-cpu -memory\n", EBUSY);
+	read_text_file(path, content, sizeof(content));
+	if (!has_token(content, "cpu") || !has_token(content, "memory"))
+		fail("failed mixed disable changed subtree_control");
+
+	sleep(FAIR_WINDOW_SECONDS);
+
+	sample.delta_a = read_usage_usec(group_a) - before_a;
+	sample.delta_b = read_usage_usec(group_b) - before_b;
+	stop_workers();
+
+	share_bp = share_basis_points(&sample, MIN_FAIR_TOTAL_USEC);
+	expect_share_range("failed mixed disable keeps cpu weights", share_bp,
+			   8500, 10000);
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 guard_group);
+	write_text_file(path, "-memory\n");
+	if (rmdir(guard_group) < 0)
+		die(guard_group);
+	guard_group[0] = '\0';
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 CGROUP_ROOT);
+	write_text_file(path, "+cpu\n");
+}
+
+static void test_existing_members_regroup_after_cpu_enable(void)
+{
+	struct usage_sample sample;
+	unsigned int share_bp;
+
+	spawn_worker(group_a);
+	spawn_worker(group_b);
+
+	enable_cpu_controller();
+	set_weight(group_a, 300);
+	set_weight(group_b, 100);
+
+	sample = measure_existing_workers_current(1, 1, FAIR_WINDOW_SECONDS);
+	share_bp = share_basis_points(&sample, MIN_FAIR_TOTAL_USEC);
+	expect_share_range("existing members after cpu enable", share_bp, 7000,
+			   8000);
+}
+
+static void test_extreme_weight_starvation(void)
+{
+	struct usage_sample sample =
+		measure_usage(1, 10000, 1, 1, STARVATION_WINDOW_SECONDS);
+
+	(void)share_basis_points(&sample, MIN_STARVATION_TOTAL_USEC);
+
+	if (sample.delta_a == 0)
+		fail("low-weight group received no CPU time");
+	if (sample.delta_b <= sample.delta_a)
+		fail("high-weight group did not dominate extreme-ratio window");
+
+	fprintf(stderr, "extreme 1:10000 low-weight usage=%llu usec\n",
+		sample.delta_a);
+}
+
+int main(void)
+{
+	atexit(cleanup);
+	disable_cpu_controller();
+	create_test_cgroups();
+	test_existing_members_regroup_after_cpu_enable();
+	test_invalid_weights();
+	test_weight_reset_after_cpu_toggle();
+	test_failed_mixed_disable_is_atomic();
+
+	test_fair_share("equal weights", 100, 100, 1, 1, 4500, 5500);
+	test_fair_share("100:200 weights", 100, 200, 1, 1, 2833, 3833);
+	test_fair_share("equal-weight groups with uneven workers", 100, 100, 2,
+			1, 4500, 5500);
+	test_fair_share("changed 100:300 weights", 100, 300, 1, 1, 2000, 3000);
+	test_extreme_weight_starvation();
+
+	fprintf(stderr, "cgroup cpu.weight regression completed\n");
+	return 0;
+}

--- a/test/initramfs/src/regression/process/sched/cgroup_lifecycle_stress.c
+++ b/test/initramfs/src/regression/process/sched/cgroup_lifecycle_stress.c
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CGROUP_ROOT "/sys/fs/cgroup"
+#define MIGRATION_WINDOW_SECONDS 6
+#define MIN_MIGRATION_TOTAL_USEC 3000000ULL
+
+static char base_dir[PATH_MAX];
+static char child_dir[PATH_MAX];
+static char grandchild_dir[PATH_MAX];
+static char load_dir[PATH_MAX];
+static char peer_dir[PATH_MAX];
+
+static pid_t stopped_pid = -1;
+static pid_t sleeping_pid = -1;
+static pid_t load_pid = -1;
+static pid_t target_pid = -1;
+
+static void fail(const char *message)
+{
+	fprintf(stderr, "FAIL: %s\n", message);
+	exit(EXIT_FAILURE);
+}
+
+static void die(const char *message)
+{
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void checked_snprintf(char *buffer, size_t size, const char *format, ...)
+{
+	va_list args;
+	int count;
+
+	va_start(args, format);
+	count = vsnprintf(buffer, size, format, args);
+	va_end(args);
+
+	if (count < 0 || (size_t)count >= size)
+		fail("formatted string is too long");
+}
+
+static void read_text_file(const char *path, char *buffer, size_t size)
+{
+	int fd;
+	ssize_t count;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		die(path);
+
+	count = read(fd, buffer, size - 1);
+	if (count < 0) {
+		close(fd);
+		die(path);
+	}
+	buffer[count] = '\0';
+
+	if (close(fd) < 0)
+		die(path);
+}
+
+static void write_text_file(const char *path, const char *text)
+{
+	int fd;
+	size_t length = strlen(text);
+	ssize_t count;
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0)
+		die(path);
+
+	count = write(fd, text, length);
+	if (count != (ssize_t)length) {
+		if (count >= 0)
+			errno = EIO;
+		close(fd);
+		die(path);
+	}
+
+	if (close(fd) < 0)
+		die(path);
+}
+
+static void try_write_text_file(const char *path, const char *text)
+{
+	int fd;
+	size_t length = strlen(text);
+	ssize_t count;
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0)
+		return;
+
+	count = write(fd, text, length);
+	if (count != (ssize_t)length) {
+		(void)close(fd);
+		return;
+	}
+
+	(void)close(fd);
+}
+
+static int has_token(const char *text, const char *token)
+{
+	size_t token_len = strlen(token);
+	const char *cursor = text;
+
+	while ((cursor = strstr(cursor, token)) != NULL) {
+		int before_ok = cursor == text || cursor[-1] == ' ' ||
+				cursor[-1] == '\n' || cursor[-1] == '\t';
+		int after_ok =
+			cursor[token_len] == '\0' || cursor[token_len] == ' ' ||
+			cursor[token_len] == '\n' || cursor[token_len] == '\t';
+
+		if (before_ok && after_ok)
+			return 1;
+		cursor += token_len;
+	}
+
+	return 0;
+}
+
+static void enable_cpu_subtree(const char *group)
+{
+	char path[PATH_MAX];
+	char content[256];
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.subtree_control",
+			 group);
+	read_text_file(path, content, sizeof(content));
+	if (!has_token(content, "cpu"))
+		write_text_file(path, "+cpu\n");
+}
+
+static void move_pid_to_cgroup(const char *group, pid_t pid)
+{
+	char path[PATH_MAX];
+	char text[32];
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.procs", group);
+	checked_snprintf(text, sizeof(text), "%d", pid);
+	write_text_file(path, text);
+}
+
+static void set_weight(const char *group, unsigned int weight)
+{
+	char path[PATH_MAX];
+	char text[32];
+
+	checked_snprintf(path, sizeof(path), "%s/cpu.weight", group);
+	checked_snprintf(text, sizeof(text), "%u\n", weight);
+	write_text_file(path, text);
+}
+
+static void expect_proc_cgroup(pid_t pid, const char *group)
+{
+	char path[64];
+	char content[PATH_MAX];
+	char expected[PATH_MAX];
+	const char *relative_path;
+
+	if (strncmp(group, CGROUP_ROOT, strlen(CGROUP_ROOT)) != 0)
+		fail("cgroup path is outside cgroup root");
+
+	relative_path = group + strlen(CGROUP_ROOT);
+	checked_snprintf(path, sizeof(path), "/proc/%d/cgroup", pid);
+	read_text_file(path, content, sizeof(content));
+	checked_snprintf(expected, sizeof(expected), "0::%s\n", relative_path);
+
+	if (strcmp(content, expected) != 0) {
+		fprintf(stderr, "FAIL: %s got \"%s\", expected \"%s\"\n", path,
+			content, expected);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static int procs_contains_pid(const char *group, pid_t pid)
+{
+	char path[PATH_MAX];
+	char content[4096];
+	char *line;
+	char *save_ptr = NULL;
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.procs", group);
+	read_text_file(path, content, sizeof(content));
+
+	line = strtok_r(content, "\n", &save_ptr);
+	while (line != NULL) {
+		char *end;
+		errno = 0;
+		long value = strtol(line, &end, 10);
+
+		if (errno == 0 && end != line && *end == '\0' &&
+		    value == (long)pid)
+			return 1;
+
+		line = strtok_r(NULL, "\n", &save_ptr);
+	}
+
+	return 0;
+}
+
+static void expect_pid_in_procs(const char *group, pid_t pid)
+{
+	if (!procs_contains_pid(group, pid)) {
+		fprintf(stderr,
+			"FAIL: pid %d is missing from %s/cgroup.procs\n", pid,
+			group);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void expect_pid_not_in_procs(const char *group, pid_t pid)
+{
+	if (procs_contains_pid(group, pid)) {
+		fprintf(stderr, "FAIL: pid %d is still in %s/cgroup.procs\n",
+			pid, group);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static unsigned long long read_usage_usec(const char *group)
+{
+	char path[PATH_MAX];
+	char content[512];
+	char *usage;
+	unsigned long long value;
+
+	checked_snprintf(path, sizeof(path), "%s/cpu.stat", group);
+	read_text_file(path, content, sizeof(content));
+
+	usage = strstr(content, "usage_usec ");
+	if (usage == NULL)
+		fail("cpu.stat does not contain usage_usec");
+
+	errno = 0;
+	usage += strlen("usage_usec ");
+	value = strtoull(usage, NULL, 10);
+	if (errno != 0)
+		die(path);
+
+	return value;
+}
+
+static unsigned long read_populated(const char *group)
+{
+	char path[PATH_MAX];
+	char content[512];
+	char *line;
+	char *save_ptr = NULL;
+
+	checked_snprintf(path, sizeof(path), "%s/cgroup.events", group);
+	read_text_file(path, content, sizeof(content));
+
+	line = strtok_r(content, "\n", &save_ptr);
+	while (line != NULL) {
+		unsigned long value;
+		if (sscanf(line, "populated %lu", &value) == 1)
+			return value;
+		line = strtok_r(NULL, "\n", &save_ptr);
+	}
+
+	fail("cgroup.events does not contain populated");
+	return 0;
+}
+
+static void expect_populated(const char *group, unsigned long expected)
+{
+	for (int attempt = 0; attempt < 200; attempt++) {
+		if (read_populated(group) == expected)
+			return;
+		usleep(10000);
+	}
+
+	fprintf(stderr,
+		"FAIL: %s/cgroup.events populated is %lu, expected %lu\n",
+		group, read_populated(group), expected);
+	exit(EXIT_FAILURE);
+}
+
+static void pin_current_to_cpu0(void)
+{
+	cpu_set_t mask;
+
+	CPU_ZERO(&mask);
+	CPU_SET(0, &mask);
+	if (sched_setaffinity(0, sizeof(mask), &mask) < 0)
+		die("sched_setaffinity");
+}
+
+static void busy_loop_child(void)
+{
+	volatile unsigned long counter = 0;
+
+	pin_current_to_cpu0();
+	if (kill(getpid(), SIGSTOP) < 0)
+		_exit(EXIT_FAILURE);
+
+	for (;;) {
+		counter++;
+		if ((counter & 0xfffffUL) == 0)
+			asm volatile("" : : "r"(counter) : "memory");
+	}
+}
+
+static void sleeping_child_loop(int ready_fd)
+{
+	char byte = 'x';
+
+	if (write(ready_fd, &byte, 1) != 1)
+		_exit(EXIT_FAILURE);
+	close(ready_fd);
+
+	for (;;)
+		pause();
+}
+
+static void wait_for_child_stop(pid_t pid)
+{
+	int status;
+
+	for (;;) {
+		if (waitpid(pid, &status, WUNTRACED) < 0) {
+			if (errno == EINTR)
+				continue;
+			die("waitpid");
+		}
+
+		if (!WIFSTOPPED(status))
+			fail("child exited before it stopped");
+		return;
+	}
+}
+
+static pid_t spawn_stopped_busy_child(void)
+{
+	pid_t pid = fork();
+
+	if (pid < 0)
+		die("fork");
+	if (pid == 0) {
+		busy_loop_child();
+		_exit(EXIT_FAILURE);
+	}
+
+	wait_for_child_stop(pid);
+	return pid;
+}
+
+static pid_t spawn_sleeping_child(void)
+{
+	int pipe_fds[2];
+	char byte;
+	pid_t pid;
+
+	if (pipe(pipe_fds) < 0)
+		die("pipe");
+
+	pid = fork();
+	if (pid < 0)
+		die("fork");
+	if (pid == 0) {
+		close(pipe_fds[0]);
+		sleeping_child_loop(pipe_fds[1]);
+		_exit(EXIT_FAILURE);
+	}
+
+	close(pipe_fds[1]);
+	if (read(pipe_fds[0], &byte, 1) != 1)
+		die("read child ready pipe");
+	close(pipe_fds[0]);
+
+	return pid;
+}
+
+static void continue_child(pid_t pid)
+{
+	if (kill(pid, SIGCONT) < 0)
+		die("SIGCONT");
+}
+
+static void kill_and_wait(pid_t *pid)
+{
+	int status;
+
+	if (*pid <= 0)
+		return;
+
+	kill(*pid, SIGKILL);
+	for (;;) {
+		if (waitpid(*pid, &status, 0) >= 0)
+			break;
+		if (errno == EINTR)
+			continue;
+		if (errno == ECHILD)
+			break;
+		die("waitpid");
+	}
+
+	*pid = -1;
+}
+
+static void cleanup(void)
+{
+	char path[PATH_MAX];
+
+	kill_and_wait(&target_pid);
+	kill_and_wait(&load_pid);
+	kill_and_wait(&sleeping_pid);
+	kill_and_wait(&stopped_pid);
+
+	if (child_dir[0] != '\0') {
+		checked_snprintf(path, sizeof(path),
+				 "%s/cgroup.subtree_control", child_dir);
+		try_write_text_file(path, "-cpu\n");
+	}
+	if (base_dir[0] != '\0') {
+		checked_snprintf(path, sizeof(path),
+				 "%s/cgroup.subtree_control", base_dir);
+		try_write_text_file(path, "-cpu\n");
+	}
+
+	if (grandchild_dir[0] != '\0')
+		rmdir(grandchild_dir);
+	if (peer_dir[0] != '\0')
+		rmdir(peer_dir);
+	if (load_dir[0] != '\0')
+		rmdir(load_dir);
+	if (child_dir[0] != '\0')
+		rmdir(child_dir);
+	if (base_dir[0] != '\0')
+		rmdir(base_dir);
+}
+
+static void create_cgroup(const char *path)
+{
+	if (mkdir(path, 0755) < 0)
+		die(path);
+}
+
+static void create_test_hierarchy(void)
+{
+	char suffix[64];
+
+	checked_snprintf(suffix, sizeof(suffix), "cglife-%d", getpid());
+	checked_snprintf(base_dir, sizeof(base_dir), "%s/%s", CGROUP_ROOT,
+			 suffix);
+	checked_snprintf(child_dir, sizeof(child_dir), "%s/child", base_dir);
+	checked_snprintf(grandchild_dir, sizeof(grandchild_dir),
+			 "%s/grandchild", child_dir);
+	checked_snprintf(load_dir, sizeof(load_dir), "%s/load", base_dir);
+	checked_snprintf(peer_dir, sizeof(peer_dir), "%s/peer", base_dir);
+
+	enable_cpu_subtree(CGROUP_ROOT);
+	create_cgroup(base_dir);
+	create_cgroup(child_dir);
+	create_cgroup(load_dir);
+	create_cgroup(peer_dir);
+	enable_cpu_subtree(base_dir);
+}
+
+static void test_stopped_migration(void)
+{
+	stopped_pid = spawn_stopped_busy_child();
+
+	move_pid_to_cgroup(child_dir, stopped_pid);
+	expect_proc_cgroup(stopped_pid, child_dir);
+	expect_pid_in_procs(child_dir, stopped_pid);
+	expect_populated(child_dir, 1);
+
+	kill_and_wait(&stopped_pid);
+	expect_populated(child_dir, 0);
+}
+
+static void test_sleeping_grandchild_migration(void)
+{
+	enable_cpu_subtree(child_dir);
+	create_cgroup(grandchild_dir);
+
+	sleeping_pid = spawn_sleeping_child();
+	move_pid_to_cgroup(grandchild_dir, sleeping_pid);
+	expect_proc_cgroup(sleeping_pid, grandchild_dir);
+	expect_pid_in_procs(grandchild_dir, sleeping_pid);
+	expect_populated(child_dir, 1);
+	expect_populated(grandchild_dir, 1);
+
+	kill_and_wait(&sleeping_pid);
+	expect_populated(grandchild_dir, 0);
+}
+
+static void test_runnable_migration_under_load(void)
+{
+	load_pid = spawn_stopped_busy_child();
+	move_pid_to_cgroup(load_dir, load_pid);
+	continue_child(load_pid);
+
+	target_pid = spawn_stopped_busy_child();
+	move_pid_to_cgroup(grandchild_dir, target_pid);
+	continue_child(target_pid);
+
+	sleep(1);
+
+	move_pid_to_cgroup(peer_dir, target_pid);
+	expect_proc_cgroup(target_pid, peer_dir);
+	expect_pid_in_procs(peer_dir, target_pid);
+	expect_pid_not_in_procs(grandchild_dir, target_pid);
+	expect_populated(peer_dir, 1);
+	expect_populated(grandchild_dir, 0);
+
+	kill_and_wait(&target_pid);
+	kill_and_wait(&load_pid);
+	expect_populated(peer_dir, 0);
+	expect_populated(load_dir, 0);
+	expect_populated(child_dir, 0);
+}
+
+static void test_runnable_migration_uses_new_weight(void)
+{
+	unsigned long long load_before;
+	unsigned long long load_delta;
+	unsigned long long peer_before;
+	unsigned long long peer_delta;
+	unsigned long long total_delta;
+	unsigned int peer_share_bp;
+
+	set_weight(load_dir, 100);
+	set_weight(peer_dir, 10000);
+
+	load_pid = spawn_stopped_busy_child();
+	move_pid_to_cgroup(load_dir, load_pid);
+	continue_child(load_pid);
+
+	target_pid = spawn_stopped_busy_child();
+	move_pid_to_cgroup(load_dir, target_pid);
+	continue_child(target_pid);
+
+	sleep(1);
+
+	load_before = read_usage_usec(load_dir);
+	peer_before = read_usage_usec(peer_dir);
+
+	move_pid_to_cgroup(peer_dir, target_pid);
+	expect_proc_cgroup(target_pid, peer_dir);
+	expect_pid_in_procs(peer_dir, target_pid);
+	expect_pid_not_in_procs(load_dir, target_pid);
+
+	sleep(MIGRATION_WINDOW_SECONDS);
+
+	load_delta = read_usage_usec(load_dir) - load_before;
+	peer_delta = read_usage_usec(peer_dir) - peer_before;
+	total_delta = load_delta + peer_delta;
+	if (total_delta < MIN_MIGRATION_TOTAL_USEC)
+		fail("migration weight test collected too little CPU time");
+
+	peer_share_bp = (unsigned int)(peer_delta * 10000 / total_delta);
+	if (peer_share_bp < 7000) {
+		fprintf(stderr,
+			"FAIL: migrated task share=%u.%02u%%, expected at least 70%%\n",
+			peer_share_bp / 100, peer_share_bp % 100);
+		exit(EXIT_FAILURE);
+	}
+
+	fprintf(stderr, "migrated task share=%u.%02u%%\n", peer_share_bp / 100,
+		peer_share_bp % 100);
+
+	kill_and_wait(&target_pid);
+	kill_and_wait(&load_pid);
+	expect_populated(peer_dir, 0);
+	expect_populated(load_dir, 0);
+}
+
+int main(void)
+{
+	atexit(cleanup);
+	pin_current_to_cpu0();
+	create_test_hierarchy();
+
+	test_stopped_migration();
+	test_sleeping_grandchild_migration();
+	test_runnable_migration_under_load();
+	test_runnable_migration_uses_new_weight();
+
+	fprintf(stderr, "cgroup lifecycle stress regression completed\n");
+	return 0;
+}


### PR DESCRIPTION
# Summary

This PR implements **CPU-weight-based group scheduling** for **cgroups**.

Asterinas already exposed CPU controller files such as `cpu.weight` and `cpu.max`. However, the **fair scheduler** still treated all runnable threads as **independent scheduling entities**. As a result, container runtimes could configure CPU settings through `cgroupfs`, but `cpu.weight` did not affect **cgroup-level CPU allocation**.

This PR introduces **task groups** into the fair scheduler. It maps **CPU cgroups** to **scheduler task groups**. The scheduler can now apportion CPU time among groups according to their weights. It then selects runnable tasks inside the chosen group.

This PR only enforces **`cpu.weight`**. CPU bandwidth control for **`cpu.max`** is left for future work.

# Motivation

Container runtimes such as **Podman** and **Kata Containers** rely on **cgroups** as the basic interface for CPU resource management.Podman exposes CPU quota, period, and share-like options. These options are mapped to cgroup CPU controller files such as `cpu.max` and `cpu.weight`. Kata Containers also places CPU-constrained containers into CPU cgroups.

Without **group scheduling**, these cgroup settings are accepted by the `cgroupfs` interface, but they do not affect actual CPU allocation. A container with more runnable tasks can still receive more CPU time simply because each task competes directly in the **root runqueue**.

This PR fixes that gap by making **cgroup CPU weight effective in the scheduler**.

# What is Group Scheduling

A cgroup describes a group of processes and its CPU policy. For example, a container runtime can create a cgroup for a container, move the container's processes into it through `cgroup.procs`, and configure its relative CPU weight through `cpu.weight`. However, these cgroup files are only the **userspace control interface**. To make the policy effective, the scheduler must translate the cgroup into an internal **schedulable object**.

Without group scheduling, the fair scheduler sees only **individual runnable tasks**. If three tasks have the same weight, each task receives roughly one third of the CPU time. This is fair at the **task level**, but not at the **workload level**. If container A has two runnable tasks and container B has one runnable task, container A receives about two thirds of the CPU time simply because it has more tasks.

**Group scheduling changes the unit of fairness.** Instead of placing all tasks directly into the root runqueue, the scheduler represents each cgroup as a **task group**. A task group has its own **scheduling entity**, which competes with other tasks or task groups in the parent runqueue. Once a task group is selected, the scheduler enters that group and selects one runnable task from the group's own runqueue.

Conceptually, scheduling changes from this:

```text
root runqueue
├── task_1
├── task_2
└── task_3
```

to this:

```text
root runqueue
├── group_a.sched_entity
│   └── group_a runqueue
│       ├── task_1
│       └── task_2
└── group_b.sched_entity
    └── group_b runqueue
        └── task_3
```

With this structure, CPU time is first apportioned among groups according to their weights. The CPU time received by a group is then shared among the tasks inside that group.

For example, if container A has two runnable tasks, container B has one runnable task, and both containers have the same `cpu.weight`, the scheduler first gives each container roughly half of the CPU time. The two tasks inside container A then share container A's half, so each receives roughly one quarter. The single task inside container B receives roughly one half.

Therefore, CPU allocation is no longer determined by the number of runnable tasks in each container. Instead, it follows the **workload-level policy** expressed by the **cgroup CPU controller**.

# Design

This PR integrates the **cgroup CPU controller** with the **FAIR scheduler** by introducing **scheduler task groups** and **hierarchical FAIR runqueues**.

The implementation is based on three main pieces:

1. a **TaskGroup abstraction** that represents a scheduler-visible CPU cgroup;
2. **fair scheduling entities** that can represent either a thread or a task group;
3. **cgroupfs integration** that keeps thread and task group membership and `cpu.weight` synchronized with scheduler state.

## Cgroup to TaskGroup Mapping

Each CPU cgroup owns a scheduler **TaskGroup**.

The root CPU cgroup uses the global **root task group**. A non-root CPU cgroup creates a child TaskGroup under its parent cgroup's task group. This mirrors the cgroup hierarchy in the scheduler, while keeping cgroup management and scheduler internals separated.

However, the TaskGroup owned by a cgroup is not always its **effective scheduling group**. In cgroup v2, a cgroup receives CPU control only when its parent enables **`+cpu`** through `cgroup.subtree_control`.

If `+cpu` is enabled for a cgroup, tasks attached to that cgroup are scheduled under its own TaskGroup. If `+cpu` is not enabled, those tasks use the nearest ancestor that has effective CPU control. If no such ancestor exists, they use the root task group.

As a result, changing `cgroup.subtree_control` can change the **effective scheduling group** of descendant tasks even when the tasks themselves are not moved. When CPU control is enabled or disabled, the implementation resynchronizes descendant processes, recomputes their effective task groups, and re-enqueues queued tasks through the updated scheduling hierarchy.

## TaskGroup

**TaskGroup** represents a workload in the FAIR scheduler.

Each task group contains **per-CPU scheduler state**:

- per-CPU FAIR runqueues for direct member threads and child group entities;
- per-CPU FAIR entity attributes for the group entity that appears in the parent runqueue;
- a parent pointer used to walk the scheduling hierarchy.

The root task group is special: it has per-CPU FAIR runqueues, but it has no parent and therefore no group entity attributes.

For a non-root task group, its **group entity** is what competes in the parent group's runqueue. Its own runqueue stores the runnable threads and child group entities that belong to that group.

Conceptually:

```text
root task group
└── root fair_rq[cpu]
    ├── task_a.se
    └── group_b.se
        └── group_b fair_rq[cpu]
            ├── task_b1.se
            └── task_b2.se
```

## FAIR Entity

The FAIR scheduler now treats both **threads** and **task groups** as scheduling entities.

A FAIR entity can be either:

```text
Thread(task)
Group(task_group)
```

Both entity types have FAIR scheduling attributes such as **weight** and **vruntime**. This allows the existing **vruntime-based scheduling logic** to be reused for both task-level fairness and group-level fairness.

The runqueue orders entities by `(vruntime, entity_id)`. The `vruntime` provides fairness, while the stable entity ID provides deterministic tie-breaking.

## Weight

The cgroup v2 `cpu.weight` value is mapped into a **FAIR scheduler weight**.

The default cgroup CPU weight is `100`, which corresponds to the scheduler's normal FAIR weight `1024`. A cgroup weight is scaled as:

```text
scheduler_weight = cpu.weight * 1024 / 100
```

When userspace writes `cpu.weight`, the CPU controller validates and stores the new value. The cgroup node write path then synchronizes this value into the corresponding task group. If the group entity is already queued in a parent FAIR runqueue, the runqueue entry is refreshed so that future scheduling decisions use the new weight.

This makes `cpu.weight` effective for runnable cgroups without requiring userspace to recreate or remigrate the processes.

## Enqueue

When a FAIR task is enqueued, the scheduler checks the thread's current **task group**.

If the task belongs directly to the runqueue's task group, it is enqueued as a thread entity in that runqueue.

If the task belongs to a descendant task group, the scheduler first enqueues the task into the descendant group's leaf runqueue. If that leaf group was previously empty, the scheduler activates the corresponding group entity in its parent runqueue. This activation can propagate upward until an already-active ancestor is reached.

This ensures that a task group competes in its parent runqueue only while it has **runnable work**.

## Pick Next Task

Task selection proceeds from **parent to child**.

At each FAIR runqueue, the scheduler selects the entity with the smallest `vruntime`.

If the selected entity is a thread, that thread is returned as the next task to run.

If the selected entity is a task group, the scheduler enters the child group's FAIR runqueue and repeats the same selection process. This continues until a concrete runnable thread is found.

## Vruntime Accounting

When a thread runs, the scheduler updates two kinds of `vruntime`:

1. the thread's own FAIR `vruntime` in its group runqueue;
2. the group entity `vruntime` for each non-root ancestor task group.

Each entity's `vruntime` is updated according to its weight:

```text
vruntime += runtime_delta * 1024 / weight
```

A larger weight causes `vruntime` to grow more slowly, so that entity remains eligible to run more often over time.

The preemption decision is also derived from the same hierarchy. If either the thread entity or one of its ancestor group entities exceeds its fair time slice, the scheduler can request preemption.

## Cgroup Migration and Controller Changes

When a process is moved through `cgroup.procs`, the implementation updates the task group of all threads in that process.

If a task is already queued in an old FAIR runqueue, the scheduler removes it from that runqueue and re-enqueues it through the new task group. During this update, the scheduler preserves the task's `vruntime` lag relative to the source runqueue's `min_vruntime`. This prevents migration from resetting the task's fair scheduling position.

Running tasks are not forcibly dequeued from the current CPU. Sleeping tasks keep the updated task-group pointer and use it when they later enter the enqueue path.

The same mechanism is reused when `cgroup.subtree_control` changes the effective CPU controller state of descendant cgroups.

## Fork and Thread Inheritance

New threads inherit the task group of their parent thread.

This is required because threads in the same process should remain under the same effective CPU control unless the process is explicitly moved to another cgroup.

For forked processes, cgroup membership is applied through the normal cgroup membership path. This path also assigns the effective CPU task group to the new process.
