### PR TITLE
Fix `accept4` silently ignoring invalid flags

### DIFF
--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -29,7 +29,8 @@ pub fn sys_accept4(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!("raw flags = 0x{:x}", flags);
-    let flags = Flags::from_bits_truncate(flags);
+    let flags = Flags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid accept4 flags"))?;
     debug!(
         "sockfd = {}, sockaddr_ptr = 0x{:x}, addrlen_ptr = 0x{:x}, flags = {:?}",
         sockfd, sockaddr_ptr, addrlen_ptr, flags

--- a/test/initramfs/src/regression/network/tcp_err.c
+++ b/test/initramfs/src/regression/network/tcp_err.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <sys/signal.h>
 #include <sys/socket.h>
@@ -297,6 +298,15 @@ FN_TEST(accept)
 	TEST_ERRNO(accept(sk_connected, psaddr, &addrlen), EINVAL);
 
 	TEST_ERRNO(accept(sk_accepted, psaddr, &addrlen), EINVAL);
+}
+END_TEST()
+
+FN_TEST(accept4_invalid_flags)
+{
+	TEST_ERRNO(accept4(sk_listen, NULL, NULL, 0x1), EINVAL);
+	TEST_ERRNO(accept4(sk_listen, NULL, NULL,
+			   ~(SOCK_CLOEXEC | SOCK_NONBLOCK)),
+		   EINVAL);
 }
 END_TEST()
 


### PR DESCRIPTION
Use `Flags::from_bits()` to validate all bits, matching the check at Linux
https://elixir.bootlin.com/linux/v6.15/source/net/socket.c#L1954-L1955
```C
	if (flags & ~(SOCK_CLOEXEC | SOCK_NONBLOCK))
		return -EINVAL;
```

### Describe the bug
When `accept4` is called with flags containing bits other than `SOCK_CLOEXEC` and `SOCK_NONBLOCK`, 
Linux returns `EINVAL`, but Asterinas silently ignores the invalid bits and proceeds with the accept. 
This is because `kernel/src/syscall/accept.rs:32` uses `Flags::from_bits_truncate(flags)` which strips unknown bits, rather than validating them.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <unistd.h>
#include <sys/socket.h>
#include <sys/types.h>
#include <netinet/in.h>
#include <arpa/inet.h>
#include <fcntl.h>

int main(void) {
    int srv = socket(AF_INET, SOCK_STREAM, 0);
    if (srv < 0) {
        printf("SKIP: cannot create socket: %s\n", strerror(errno));
        return 1;
    }

    int opt = 1;
    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));

    struct sockaddr_in addr;
    memset(&addr, 0, sizeof(addr));
    addr.sin_family = AF_INET;
    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
    addr.sin_port = 0;

    if (bind(srv, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
        printf("SKIP: bind failed: %s\n", strerror(errno));
        close(srv);
        return 1;
    }
    if (listen(srv, 5) < 0) {
        printf("SKIP: listen failed: %s\n", strerror(errno));
        close(srv);
        return 1;
    }

    socklen_t len = sizeof(addr);
    getsockname(srv, (struct sockaddr *)&addr, &len);

    int cli = socket(AF_INET, SOCK_STREAM, 0);
    if (cli < 0) {
        printf("SKIP: cannot create client socket: %s\n", strerror(errno));
        close(srv);
        return 1;
    }
    if (connect(cli, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
        printf("SKIP: connect failed: %s\n", strerror(errno));
        close(cli);
        close(srv);
        return 1;
    }

    /* accept4 with invalid flag bit 0x1 */
    errno = 0;
    int ret = accept4(srv, NULL, NULL, 0x1);
    if (ret == -1 && errno == EINVAL) {
        printf("VERDICT: LINUX behavior — accept4(flags=0x1) returns EINVAL for invalid flags\n");
    } else if (ret >= 0) {
        printf("VERDICT: ASTERINAS behavior — accept4(flags=0x1) succeeds (silently ignores invalid flags), fd=%d\n", ret);
        close(ret);
    } else {
        printf("VERDICT: UNKNOWN — accept4(flags=0x1) returned %d, errno=%d (%s)\n",
               ret, errno, strerror(errno));
    }

    close(cli);
    close(srv);
    return 0;
}
```

### Expected behavior
On Linux, `accept4(fd, NULL, NULL, 0x1)` returns -1 with `errno` set to `EINVAL` because the flags value `0x1` is not a valid combination of `SOCK_CLOEXEC` and `SOCK_NONBLOCK`. The check is at `net/socket.c:__sys_accept4_file()`: `if (flags & ~(SOCK_CLOEXEC | SOCK_NONBLOCK)) return -EINVAL;`

### Log
- In Asterinas:
```
VERDICT: ASTERINAS behavior — accept4(flags=0x1) succeeds (silently ignores invalid flags), fd=5
```
- In Linux:
```
VERDICT: LINUX behavior — accept4(flags=0x1) returns EINVAL for invalid flags
```