### PR TITLE
Fix eventfd2 initval type width and ULLONG_MAX write handling

### DIFF
--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -30,13 +30,13 @@ use crate::{
     process::signal::{PollHandle, Pollable, Pollee},
 };
 
-pub fn sys_eventfd(init_val: u64, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_eventfd(init_val: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("init_val = 0x{:x}", init_val);
 
     do_sys_eventfd2(init_val, Flags::empty(), ctx)
 }
 
-pub fn sys_eventfd2(init_val: u64, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+pub fn sys_eventfd2(init_val: u32, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("raw flags = {}", flags);
     let flags = Flags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown flags"))?;
@@ -45,8 +45,8 @@ pub fn sys_eventfd2(init_val: u64, flags: u32, ctx: &Context) -> Result<SyscallR
     do_sys_eventfd2(init_val, flags, ctx)
 }
 
-fn do_sys_eventfd2(init_val: u64, flags: Flags, ctx: &Context) -> Result<SyscallReturn> {
-    let event_file = EventFile::new(init_val, flags);
+fn do_sys_eventfd2(init_val: u32, flags: Flags, ctx: &Context) -> Result<SyscallReturn> {
+    let event_file = EventFile::new(init_val as u64, flags);
     let file_table = ctx.thread_local.borrow_file_table();
     let mut file_table_locked = file_table.unwrap().write();
     let fd_flags = if flags.contains(Flags::EFD_CLOEXEC) {
@@ -192,6 +192,10 @@ impl FileLike for EventFile {
         }
 
         let supplied_value = reader.read_val::<u64>()?;
+
+        if supplied_value == u64::MAX {
+            return_errno_with_message!(Errno::EINVAL, "write value must not be ULLONG_MAX");
+        }
 
         // Try to add counter val at first
         if self.add_counter_val(supplied_value).is_ok() {

--- a/test/initramfs/src/regression/io/eventfd2/eventfd2_err.c
+++ b/test/initramfs/src/regression/io/eventfd2/eventfd2_err.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <sys/eventfd.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+static int efd;
+
+FN_SETUP(create_eventfd_with_large_initval)
+{
+	efd = CHECK(syscall(SYS_eventfd2, 0x100000001ULL, 0));
+}
+END_SETUP()
+
+FN_TEST(initval_truncated_to_u32)
+{
+	uint64_t val = 0;
+	TEST_RES(read(efd, &val, sizeof(val)), _ret == sizeof(val) && val == 1);
+}
+END_TEST()
+
+FN_SETUP(close_first_efd)
+{
+	close(efd);
+}
+END_SETUP()
+
+FN_SETUP(create_nonblocking_eventfd)
+{
+	efd = CHECK(eventfd(0, EFD_NONBLOCK));
+}
+END_SETUP()
+
+FN_TEST(write_ullong_max_returns_einval)
+{
+	uint64_t val = UINT64_MAX;
+	TEST_ERRNO(write(efd, &val, sizeof(val)), EINVAL);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	close(efd);
+}
+END_SETUP()

--- a/test/initramfs/src/regression/io/run_test.sh
+++ b/test/initramfs/src/regression/io/run_test.sh
@@ -9,6 +9,7 @@ set -e
 ./epoll/test_epoll_pwait.sh
 
 ./eventfd2/eventfd2
+./eventfd2/eventfd2_err
 
 ./file_io/access_err
 ./file_io/fcntl_lock


### PR DESCRIPTION
refer: https://elixir.bootlin.com/linux/v6.15/source/fs/eventfd.c


- The Linux `eventfd2` syscall declares `initval` as `unsigned int` (32 bits).
  ```c
  SYSCALL_DEFINE2(eventfd2, unsigned int, count, int, flags)
  ```
- for u64::MAX (ULLONG_MAX) in the write method, returning EINVAL immediately
  ```c
	  if (ucnt == ULLONG_MAX)
		  return -EINVAL;
  ```
