### PR TITLE
Enable more gVisor file I/O tests

### DIFF
--- a/test/initramfs/src/conformance/gvisor/blocklists/open_create_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/open_create_test
@@ -1,4 +1,3 @@
 CreateTest.HonorsUmask_NoRandomSave
-CreateTest.CreatWithOTrunc
 CreateTest.CreatDirWithOTruncAndReadOnly
 CreateTest.CreateFailsOnUnpermittedDir

--- a/test/initramfs/src/conformance/gvisor/blocklists/pread64_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/pread64_test
@@ -1,1 +1,0 @@
-Pread64Test.Overflow

--- a/test/initramfs/src/conformance/gvisor/blocklists/read_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/read_test
@@ -1,2 +1,0 @@
-ReadTest.EofAfterRead
-ReadTest.ZeroBuffer

--- a/test/initramfs/src/conformance/gvisor/blocklists/truncate_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/truncate_test
@@ -1,5 +1,4 @@
 FixtureTruncateTest.Truncate
 FixtureTruncateTest.Ftruncate
-FixtureTruncateTest.FtruncateShrinkGrow
 TruncateTest.TruncateNonWriteable
 TruncateTest.FtruncateVirtualTmp_NoRandomSave

--- a/test/initramfs/src/conformance/gvisor/blocklists/write_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/write_test
@@ -1,5 +1,4 @@
 WriteTest.PartialWriteSIGBUS
 WriteTest.PartialWriteSIGSEGV
-WriteTest.PwriteNoChangeOffset
 WriteTest.WriteExceedsRLimit
 WriteTest.WriteNoExceedsRLimit


### PR DESCRIPTION
## Summary

Enable several gVisor file I/O conformance cases that now pass on Asterinas by removing their stale blocklist entries.

## Testing

```sh
cd /opt/gvisor/tests
export TEST_TMPDIR=/tmp

./pread64_test --gtest_filter=Pread64Test.Overflow
# [  PASSED  ] 1 test.

./read_test --gtest_filter='ReadTest.EofAfterRead:ReadTest.ZeroBuffer'
# [  PASSED  ] 2 tests.

./open_create_test --gtest_filter=CreateTest.CreatWithOTrunc
# [  PASSED  ] 1 test.

./write_test --gtest_filter=WriteTest.PwriteNoChangeOffset
# [  PASSED  ] 1 test.

./truncate_test --gtest_filter=FixtureTruncateTest.FtruncateShrinkGrow
# [  PASSED  ] 1 test.
```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  ```

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```