### PR TITLE
Fix `getsockopt` and `setsockopt` returning EINVAL instead of EFAULT for NULL optlen

### DIFF
--- a/kernel/src/syscall/getsockopt.rs
+++ b/kernel/src/syscall/getsockopt.rs
@@ -18,9 +18,6 @@ pub fn sys_getsockopt(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let level = CSocketOptionLevel::try_from(level).map_err(|_| Errno::EOPNOTSUPP)?;
-    if optlen_addr == 0 {
-        return_errno_with_message!(Errno::EINVAL, "optlen_addr is null pointer");
-    }
 
     let user_space = ctx.user_space();
     let optlen: u32 = user_space.read_val(optlen_addr)?;

--- a/kernel/src/syscall/setsockopt.rs
+++ b/kernel/src/syscall/setsockopt.rs
@@ -16,9 +16,6 @@ pub fn sys_setsockopt(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let level = CSocketOptionLevel::try_from(level).map_err(|_| Errno::EOPNOTSUPP)?;
-    if optval == 0 {
-        return_errno_with_message!(Errno::EINVAL, "optval is null pointer");
-    }
 
     debug!(
         "level = {:?}, sockfd = {}, optname = {}, optval = {}",

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -65,6 +65,15 @@ FN_TEST(invalid_socket_option)
 }
 END_TEST()
 
+FN_TEST(null_optlen)
+{
+	int val;
+	TEST_ERRNO(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &val,
+			      NULL),
+		   EFAULT);
+}
+END_TEST()
+
 int refresh_connection()
 {
 	close(sk_connected);

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -74,6 +74,18 @@ FN_TEST(null_optlen)
 }
 END_TEST()
 
+FN_TEST(null_optval)
+{
+	socklen_t len = sizeof(int);
+	TEST_ERRNO(setsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, NULL,
+			      sizeof(int)),
+		   EFAULT);
+	TEST_ERRNO(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, NULL,
+			      &len),
+		   EFAULT);
+}
+END_TEST()
+
 int refresh_connection()
 {
 	close(sk_connected);


### PR DESCRIPTION
Removed the explicit null pointer check for optlen_addr in kernel/src/syscall/getsockopt.rs (lines 21-23). 
Previously, when optlen_addr == 0 (NULL), Asterinas returned EINVAL. Now the NULL address falls through to user_space.read_val(optlen_addr) which naturally produces EFAULT when attempting to read from address 0, matching Linux behavior.

### Describe the bug
When `getsockopt` is called with `optlen=NULL`, Asterinas returns EINVAL (errno=22) with message "optlen_addr is null pointer", while Linux returns EFAULT (errno=14). The root cause is an explicit null check in `kernel/src/syscall/getsockopt.rs:21-23` that returns EINVAL before the pointer dereference that would naturally produce EFAULT.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <errno.h>
#include <string.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <unistd.h>

int main(void) {
    int sock = socket(AF_INET, SOCK_STREAM, 0);
    if (sock < 0) {
        printf("SKIP: could not create socket: %s\n", strerror(errno));
        return 1;
    }

    int val = 0;
    errno = 0;
    int ret = getsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &val, NULL);
    if (ret == -1 && errno == EFAULT) {
        printf("VERDICT: LINUX behavior — NULL optlen returns EFAULT\n");
    } else if (ret == -1 && errno == EINVAL) {
        printf("VERDICT: ASTERINAS behavior — NULL optlen returns EINVAL\n");
    } else {
        printf("VERDICT: UNKNOWN — ret=%d, errno=%d (%s)\n",
               ret, errno, strerror(errno));
    }

    close(sock);
    return 0;
}
```

### Expected behavior
On Linux, `getsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &val, NULL)` returns -1 with `errno=EFAULT` (14).

### Log
- In Asterinas:
```
VERDICT: ASTERINAS behavior — NULL optlen returns EINVAL
```
- In Linux:
```
VERDICT: LINUX behavior — NULL optlen returns EFAULT
```