### PR TITLE
Fix `getcwd` not returning ENAMETOOLONG when path exceeds PATH_MAX

### DIFF
--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -187,8 +187,8 @@ impl PerOpenFileOps for PtyMaster {
 
                     let slave_name = {
                         let devpts_path = path_resolver
-                            .make_abs_path(super::DEV_PTS.get().unwrap())
-                            .into_string();
+                            .make_abs_path(super::DEV_PTS.get().unwrap())?
+                            .into_path_buf();
                         format!("{}/{}", devpts_path, self.slave.index())
                     };
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -30,9 +30,12 @@ pub(super) fn make_mount_point_path(
         "/".to_string()
     } else if let Some(parent) = parent {
         if let Some(mount_point_dentry) = mount.mountpoint() {
+            // TODO: Support paths longer than the path max length.
+            // Reference: <https://elixir.bootlin.com/linux/v6.15/source/fs/seq_file.c#L239>
             path_resolver
                 .make_abs_path(&Path::new(parent.clone(), mount_point_dentry))
-                .into_string()
+                .map(|r| r.into_path_buf().to_string())
+                .unwrap_or_default()
         } else {
             "".to_string()
         }

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::str;
-
 use ostd::task::Task;
 
 use super::{Mount, Path};
@@ -188,14 +186,24 @@ impl PathResolver {
     /// For pseudo paths, the returned string is simply the path's name. For other
     /// unreachable paths, the returned string starts with `/` but represents a partial
     /// path that could not reach the root.
-    pub fn make_abs_path(&self, path: &Path) -> AbsPathResult {
+    pub fn make_abs_path(&self, path: &Path) -> Result<AbsPathResult> {
+        let buf = PathBuffer::with_capacity(PATH_MAX);
+        self.make_abs_path_into(path, buf).ok_or_else(|| {
+            Error::with_message(Errno::ENAMETOOLONG, "the absolute path is too long")
+        })
+    }
+
+    fn make_abs_path_into(&self, path: &Path, mut buf: PathBuffer) -> Option<AbsPathResult> {
         // Handle the root path.
         if path == &self.root {
-            return AbsPathResult::Reachable("/".to_string());
+            buf.prepend_slash().then_some(())?;
+            return Some(AbsPathResult::Reachable(buf));
         }
         // Handle pseudo paths.
         if path.is_pseudo() {
-            return AbsPathResult::Unreachable(path.name());
+            let name = path.name();
+            buf.prepend_bytes(name.as_bytes()).then_some(())?;
+            return Some(AbsPathResult::Unreachable(buf));
         }
 
         // TODO: The paths reported via `/proc/<pid>/fd/<fd>` are currently
@@ -210,37 +218,32 @@ impl PathResolver {
         // the pseudo-path special-case above); the anonymous side is wired up
         // together with the `O_TMPFILE` open path in PR #3185.
 
-        let mut components = VecDeque::new();
-        components.push_front(self.resolve_name(path));
+        buf.prepend_component(&self.resolve_name(path))
+            .then_some(())?;
 
         let mut parent_path = self.resolve_parent(path);
         let mut reach_resolver_root = false;
 
         while let Some(parent_dir) = parent_path {
-            // Stop if we reach the resolver's root.
             if parent_dir == self.root {
                 reach_resolver_root = true;
                 break;
             }
 
             let parent_name = self.resolve_name(&parent_dir);
-            // Stop if we reach an absolute root.
             if parent_name == "/" {
                 break;
             }
 
-            components.push_front(parent_name);
+            buf.prepend_component(&parent_name).then_some(())?;
 
             parent_path = self.resolve_parent(&parent_dir);
         }
 
-        let path_name = alloc::format!("/{}", components.make_contiguous().join("/"));
-        debug_assert!(path_name.starts_with('/'));
-
         if reach_resolver_root {
-            AbsPathResult::Reachable(path_name)
+            Some(AbsPathResult::Reachable(buf))
         } else {
-            AbsPathResult::Unreachable(path_name)
+            Some(AbsPathResult::Unreachable(buf))
         }
     }
 
@@ -469,22 +472,90 @@ impl PathResolver {
     }
 }
 
+/// A buffer that builds an absolute path by prepending components from back to front.
+pub struct PathBuffer {
+    bytes: Vec<u8>,
+    start: usize,
+}
+
+impl PathBuffer {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bytes: vec![0u8; capacity],
+            start: capacity,
+        }
+    }
+
+    /// Returns `false` if there is not enough room.
+    pub fn prepend_bytes(&mut self, data: &[u8]) -> bool {
+        if data.len() > self.start {
+            return false;
+        }
+        self.start -= data.len();
+        self.bytes[self.start..self.start + data.len()].copy_from_slice(data);
+        true
+    }
+
+    fn prepend_component(&mut self, name: &str) -> bool {
+        let name_bytes = name.as_bytes();
+        if name_bytes.len() + 1 > self.start {
+            return false;
+        }
+        self.start -= name_bytes.len();
+        self.bytes[self.start..self.start + name_bytes.len()].copy_from_slice(name_bytes);
+        self.start -= 1;
+        self.bytes[self.start] = b'/';
+        true
+    }
+
+    fn prepend_slash(&mut self) -> bool {
+        self.prepend_bytes(b"/")
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[self.start..]
+    }
+
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(self.as_bytes()).expect("path is valid UTF-8")
+    }
+}
+
+impl Debug for PathBuffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("PathBuffer").field(&self.as_str()).finish()
+    }
+}
+
+impl core::fmt::Display for PathBuffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// The result of resolving an absolute path name.
 ///
 /// If the path can be traced back to the root of the resolver, it is `Reachable`.
 /// Otherwise, it is `Unreachable`.
-#[derive(Clone, Debug)]
 pub enum AbsPathResult {
-    Reachable(String),
-    Unreachable(String),
+    Reachable(PathBuffer),
+    Unreachable(PathBuffer),
+}
+
+impl Debug for AbsPathResult {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AbsPathResult::Reachable(buf) => f.debug_tuple("Reachable").field(buf).finish(),
+            AbsPathResult::Unreachable(buf) => f.debug_tuple("Unreachable").field(buf).finish(),
+        }
+    }
 }
 
 impl AbsPathResult {
-    /// Converts the `AbsPathResult` into a `String`.
-    pub fn into_string(self) -> String {
+    /// Unwraps the inner [`PathBuffer`] regardless of reachability.
+    pub fn into_path_buf(self) -> PathBuffer {
         match self {
-            AbsPathResult::Reachable(s) => s,
-            AbsPathResult::Unreachable(s) => s,
+            AbsPathResult::Reachable(buf) | AbsPathResult::Unreachable(buf) => buf,
         }
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -52,7 +52,7 @@ pub fn do_execve(
 
     debug!(
         "file path: {:?}, argv = {:?}, envp = {:?}",
-        path_resolver.make_abs_path(&elf_file).into_string(),
+        path_resolver.make_abs_path(&elf_file).ok(),
         argv,
         envp
     );

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -8,7 +8,7 @@ use super::{Process, Session};
 use crate::{
     fs::{
         thread_info::ThreadFsInfo,
-        vfs::path::{FsPath, MountNamespace, Path},
+        vfs::path::{FsPath, MountNamespace},
     },
     prelude::*,
     process::{
@@ -95,7 +95,7 @@ fn create_init_process(
     let elf_path = fs.resolver().read().lookup(&fs_path)?;
 
     let pid = allocate_posix_tid();
-    let vmar = VmarHandle::new(ProcessVm::new(elf_path.clone()));
+    let vmar = VmarHandle::new(ProcessVm::new(elf_path));
     let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
     let oom_score_adj = 0;
@@ -112,7 +112,8 @@ fn create_init_process(
         user_ns,
     );
 
-    let init_task = create_init_task(pid, &init_proc, fs, vmar, elf_path, argv, envp)?;
+    let thread_name = ThreadName::new_from_executable_path(executable_path);
+    let init_task = create_init_task(pid, &init_proc, fs, vmar, thread_name, argv, envp)?;
     init_proc.tasks().lock().insert(init_task).unwrap();
 
     Ok(init_proc)
@@ -138,29 +139,29 @@ fn create_init_task(
     process: &Arc<Process>,
     fs: ThreadFsInfo,
     vmar: VmarHandle,
-    elf_path: Path,
+    thread_name: ThreadName,
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Task>> {
     let credentials = Credentials::new_root();
 
-    let (elf_load_info, elf_abs_path) = {
+    let elf_load_info = {
         let path_resolver = fs.resolver().read();
+        let elf_path = process
+            .lock_vmar()
+            .unwrap()
+            .process_vm()
+            .executable_file()
+            .clone();
 
-        let program_to_load =
-            ProgramToLoad::build_from_file(elf_path.clone(), &path_resolver, argv, envp)?;
+        let program_to_load = ProgramToLoad::build_from_file(elf_path, &path_resolver, argv, envp)?;
         let vmar = process.lock_vmar();
-        let elf_load_info = program_to_load.load_to_vmar(vmar.unwrap(), &path_resolver)?;
-        let elf_abs_path = path_resolver.make_abs_path(&elf_path).into_string();
-
-        (elf_load_info, elf_abs_path)
+        program_to_load.load_to_vmar(vmar.unwrap(), &path_resolver)?
     };
 
     let mut user_ctx = UserContext::default();
     user_ctx.set_instruction_pointer(elf_load_info.entry_point as _);
     user_ctx.set_stack_pointer(elf_load_info.user_stack_top as _);
-
-    let thread_name = ThreadName::new_from_executable_path(&elf_abs_path);
 
     let thread_builder =
         PosixThreadBuilder::new(tid, thread_name, Box::new(user_ctx), credentials, vmar)

--- a/kernel/src/syscall/getcwd.rs
+++ b/kernel/src/syscall/getcwd.rs
@@ -9,7 +9,7 @@ pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn
     let abs_path = {
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();
-        path_resolver.make_abs_path(path_resolver.cwd())
+        path_resolver.make_abs_path(path_resolver.cwd())?
     };
 
     debug!("getcwd: {:?}", abs_path);
@@ -20,17 +20,21 @@ pub fn sys_getcwd(buf: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn
     // to conform to POSIX. Here follows Linux's behavior to keep compatibility.
     //
     // Reference: <https://man7.org/linux/man-pages/man3/getcwd.3.html>
-    let abs_path = match abs_path {
-        AbsPathResult::Reachable(s) => s,
-        AbsPathResult::Unreachable(s) => alloc::format!("(unreachable){}", s),
+    let path_buf = match abs_path {
+        AbsPathResult::Reachable(buf) => buf,
+        AbsPathResult::Unreachable(mut buf) => {
+            buf.prepend_bytes(b"(unreachable)");
+            buf
+        }
     };
 
-    let cwd = CString::new(abs_path)?;
-    let bytes = cwd.as_bytes_with_nul();
-    if bytes.len() > len {
+    let path_bytes = path_buf.as_bytes();
+    let total_len = path_bytes.len() + 1;
+    if total_len > len {
         return_errno_with_message!(Errno::ERANGE, "the CWD buffer is too small");
     }
-    ctx.user_space().write_bytes(buf, bytes)?;
+    ctx.user_space().write_bytes(buf, path_bytes)?;
+    ctx.user_space().write_bytes(buf + path_bytes.len(), &[0])?;
 
-    Ok(SyscallReturn::Return(bytes.len() as _))
+    Ok(SyscallReturn::Return(total_len as _))
 }

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -43,7 +43,10 @@ pub fn sys_readlinkat(
 
         match path.inode().read_link()? {
             SymbolicLink::Plain(s) => s,
-            SymbolicLink::Path(path) => path_resolver.make_abs_path(&path).into_string(),
+            SymbolicLink::Path(path) => path_resolver
+                .make_abs_path(&path)?
+                .into_path_buf()
+                .to_string(),
         }
     };
 

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -300,8 +300,12 @@ impl VmMapping {
                 }
             }
 
-            if let Some(path) = &self.path {
-                return Some(Cow::Owned(path_resolver.make_abs_path(path).into_string()));
+            // TODO: Support paths longer than the path max length.
+            // Reference: <https://elixir.bootlin.com/linux/v6.15/source/fs/seq_file.c#L239>
+            if let Some(path) = &self.path
+                && let Ok(abs_path) = path_resolver.make_abs_path(path)
+            {
+                return Some(Cow::Owned(abs_path.into_path_buf().to_string()));
             }
 
             // Reference: <https://github.com/google/gvisor/blob/38123b53da96ff6983fcc103dfe2a9cc4e0d80c8/test/syscalls/linux/proc.cc#L1158-L1172>

--- a/test/initramfs/src/regression/fs/getcwd/getcwd.c
+++ b/test/initramfs/src/regression/fs/getcwd/getcwd.c
@@ -3,6 +3,9 @@
 #define _GNU_SOURCE
 
 #include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
@@ -13,3 +16,42 @@ FN_TEST(getcwd_small_buffer_returns_erange)
 	TEST_ERRNO(getcwd(small, 1), ERANGE);
 }
 END_TEST()
+
+FN_SETUP(getcwd_long_path)
+{
+	CHECK_WITH(mkdir("/tmp/getcwd_long", 0755),
+		   _ret == 0 || errno == EEXIST);
+	CHECK(chdir("/tmp/getcwd_long"));
+
+	char dirname[256];
+	memset(dirname, 'x', 200);
+	dirname[200] = '\0';
+
+	for (int i = 0; i < 25; i++) {
+		CHECK(mkdir(dirname, 0755));
+		CHECK(chdir(dirname));
+	}
+}
+END_SETUP()
+
+FN_TEST(getcwd_enametoolong_when_path_exceeds_path_max)
+{
+	char buf[8192];
+	TEST_ERRNO(syscall(SYS_getcwd, buf, sizeof(buf)), ENAMETOOLONG);
+}
+END_TEST()
+
+FN_SETUP(getcwd_long_path_cleanup)
+{
+	char dirname[256];
+	memset(dirname, 'x', 200);
+	dirname[200] = '\0';
+
+	for (int i = 0; i < 25; i++) {
+		CHECK(chdir(".."));
+		CHECK(rmdir(dirname));
+	}
+	CHECK(chdir("/"));
+	CHECK(rmdir("/tmp/getcwd_long"));
+}
+END_SETUP()


### PR DESCRIPTION
Added a `PATH_MAX` check on the resolved absolute path before checking the user buffer size.

https://elixir.bootlin.com/linux/v6.15/source/fs/d_path.c#L429-L438
```c
		DECLARE_BUFFER(b, page, PATH_MAX);

		prepend_char(&b, 0);
		if (unlikely(prepend_path(&pwd, &root, &b) > 0))
			prepend(&b, "(unreachable)", 13);
		rcu_read_unlock();

		len = PATH_MAX - b.len;
		if (unlikely(len > PATH_MAX))
			error = -ENAMETOOLONG;
```

### Describe the bug
Linux's `getcwd` syscall uses an internal buffer of `PATH_MAX` (4096) bytes to resolve the current working directory path. If the resolved absolute pathname exceeds this limit, the kernel returns `-ENAMETOOLONG`. Asterinas's `sys_getcwd` implementation (`kernel/src/syscall/getcwd.rs`) uses dynamic allocation via Rust's `CString` and `make_abs_path()` (which builds the path using `VecDeque<String>` and `format!`), so there is no PATH_MAX enforcement. This means paths longer than 4096 bytes may succeed on Asterinas where they would fail on Linux.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <string.h>
#include <errno.h>
#include <unistd.h>
#include <sys/syscall.h>
#include <sys/stat.h>
#include <stdlib.h>

/*
 * Test: getcwd should return ENAMETOOLONG when the path exceeds PATH_MAX (4096).
 *
 * Linux uses an internal buffer of PATH_MAX bytes. If the resolved path
 * exceeds this, it returns -ENAMETOOLONG regardless of the user-provided size.
 * Asterinas uses dynamic allocation (CString) with no PATH_MAX limit.
 */
int main(void) {
    /* Create deeply nested directories to exceed PATH_MAX */
    char basedir[256];
    snprintf(basedir, sizeof(basedir), "/tmp/getcwd_long_%d", getpid());
    mkdir(basedir, 0755);
    chdir(basedir);

    /* Create directory names of 200 chars each. 25 levels * 201 = 5025 > 4096 */
    char dirname[256];
    memset(dirname, 'x', 200);
    dirname[200] = '\0';

    int depth = 0;
    for (int i = 0; i < 25; i++) {
        if (mkdir(dirname, 0755) != 0) {
            printf("INFO: mkdir failed at depth %d: %s\n", i, strerror(errno));
            break;
        }
        if (chdir(dirname) != 0) {
            printf("INFO: chdir failed at depth %d: %s\n", i, strerror(errno));
            break;
        }
        depth++;
    }

    printf("INFO: created %d levels of nesting\n", depth);

    /* Now try getcwd with a large buffer */
    char buf[8192];
    errno = 0;
    long ret = syscall(SYS_getcwd, buf, sizeof(buf));
    int err = errno;

    if (ret == -1 && err == ENAMETOOLONG) {
        printf("VERDICT: LINUX behavior — getcwd returns ENAMETOOLONG when path exceeds PATH_MAX (depth=%d)\n", depth);
    } else if (ret > 0) {
        printf("VERDICT: ASTERINAS behavior — getcwd succeeds with long path (len=%ld, depth=%d, no PATH_MAX limit)\n", ret, depth);
    } else {
        printf("VERDICT: UNKNOWN — ret=%ld, errno=%d (%s)\n", ret, err, strerror(err));
    }

    /* Cleanup */
    chdir("/tmp");
    /* Best-effort cleanup of deep dirs */
    char cmd[512];
    snprintf(cmd, sizeof(cmd), "rm -rf %s", basedir);
    system(cmd);

    return 0;
}
```

### Expected behavior
Linux returns `ENAMETOOLONG` (errno 36) when the resolved absolute pathname of the CWD exceeds PATH_MAX (4096 bytes). This happens regardless of the user-provided `size` argument because the kernel's internal resolution buffer is limited to PATH_MAX.

### Log
- In Asterinas:
```
INFO: created 25 levels of nesting
VERDICT: ASTERINAS behavior — getcwd succeeds with long path (len=5045, depth=25, no PATH_MAX limit)
rm: can't stat '/tmp/getcwd_long_10/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx': File name too long
```
- In Linux:
```
INFO: created 25 levels of nesting
VERDICT: LINUX behavior — getcwd returns ENAMETOOLONG when path exceeds PATH_MAX (depth=25)
```
