### PR TITLE
Fix `memfd_create` returning wrong errno for too-long name

### DIFF
--- a/kernel/src/syscall/memfd_create.rs
+++ b/kernel/src/syscall/memfd_create.rs
@@ -10,12 +10,16 @@ use crate::{
 };
 
 pub fn sys_memfd_create(name_addr: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
-    // FIXME: When `name` is too long, `read_cstring` returns `EFAULT`. However,
-    // according to <https://man7.org/linux/man-pages/man2/memfd_create.2.html>,
-    // we should return `EINVAL` in this case.
     let name = ctx
         .user_space()
-        .read_cstring(name_addr, MAX_MEMFD_NAME_LEN + 1)?;
+        .read_cstring(name_addr, MAX_MEMFD_NAME_LEN + 1)
+        .map_err(|err| {
+            if err.error() == Errno::ENAMETOOLONG {
+                Error::with_message(Errno::EINVAL, "the memfd name is too long")
+            } else {
+                err
+            }
+        })?;
     debug!("sys_memfd_create: name = {:?}, flags = {}", name, flags);
 
     let fd = {

--- a/test/initramfs/src/regression/fs/pseudofs/memfd_create.c
+++ b/test/initramfs/src/regression/fs/pseudofs/memfd_create.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(name_too_long)
+{
+	char name[251];
+	memset(name, 'X', 250);
+	name[250] = '\0';
+
+	TEST_ERRNO(memfd_create(name, MFD_CLOEXEC), EINVAL);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -135,6 +135,7 @@ echo "All mount bind file test passed."
 ./procfs/tid
 
 ./pseudofs/memfd_access_err
+./pseudofs/memfd_create
 ./pseudofs/pseudo_dentry
 ./pseudofs/pseudo_dev_id
 ./pseudofs/pseudo_inode


### PR DESCRIPTION
https://elixir.bootlin.com/linux/v6.15/source/mm/memfd.c#L406-L411
```c
	if (len < 0) {
		error = -EFAULT;
		goto err_name;
	} else if (len > MFD_NAME_MAX_LEN) {
		error = -EINVAL;
		goto err_name;
	}
```

also refer to 
https://github.com/asterinas/asterinas/blob/45e0026bff7d020ed311126319b24b069b1d5947/kernel/src/syscall/setxattr.rs#L161-L174