### PR TITLE
Fix `pidfd_open` accepting pid=0 instead of returning EINVAL

### DIFF
--- a/kernel/src/syscall/pidfd_open.rs
+++ b/kernel/src/syscall/pidfd_open.rs
@@ -15,8 +15,8 @@ pub fn sys_pidfd_open(pid: Pid, flags: u32, ctx: &Context) -> Result<SyscallRetu
         flags.contains(PidfdFlags::PIDFD_NONBLOCK)
     };
 
-    if pid.cast_signed() < 0 {
-        return_errno_with_message!(Errno::EINVAL, "all negative PIDs are not valid");
+    if pid.cast_signed() <= 0 {
+        return_errno_with_message!(Errno::EINVAL, "non-positive PIDs are not valid");
     }
 
     let process = pid_table::pid_table_mut()

--- a/test/initramfs/src/regression/process/pidfd.c
+++ b/test/initramfs/src/regression/process/pidfd.c
@@ -32,6 +32,13 @@ FN_TEST(pidfd_open)
 }
 END_TEST()
 
+FN_TEST(pidfd_open_invalid_pid)
+{
+	TEST_ERRNO(syscall(SYS_pidfd_open, 0, 0), EINVAL);
+	TEST_ERRNO(syscall(SYS_pidfd_open, -1, 0), EINVAL);
+}
+END_TEST()
+
 FN_TEST(read_write)
 {
 	char buf[1] = {};


### PR DESCRIPTION
Changed `pid.cast_signed() < 0` to `pid.cast_signed() <= 0` in kernel/src/syscall/pidfd_open.rs:18, matching Linux's check

https://elixir.bootlin.com/linux/v6.15/source/kernel/pid.c#L656-L657
```C
	if (pid <= 0)
		return -EINVAL;
```

### Describe the bug
When `pidfd_open` is called with `pid=0`, Linux returns `EINVAL` (since the kernel checks `pid <= 0`), but Asterinas only checks `pid < 0`, allowing pid=0 to pass through. This results in Asterinas returning `ESRCH` (process not found) instead of `EINVAL` for pid=0, which is the wrong errno for this input.

Root cause: `kernel/src/syscall/pidfd_open.rs:18` uses `pid.cast_signed() < 0` instead of `pid.cast_signed() <= 0`.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <errno.h>
#include <string.h>
#include <unistd.h>
#include <sys/syscall.h>

#ifndef SYS_pidfd_open
#define SYS_pidfd_open 434
#endif

int main(void) {
    errno = 0;
    int fd = syscall(SYS_pidfd_open, 0, 0);
    if (fd == -1 && errno == EINVAL) {
        printf("VERDICT: LINUX behavior — pid=0 returns EINVAL\n");
    } else if (fd == -1 && errno == ESRCH) {
        printf("VERDICT: ASTERINAS behavior — pid=0 returns ESRCH instead of EINVAL\n");
    } else {
        printf("VERDICT: UNEXPECTED — fd=%d, errno=%s\n", fd, strerror(errno));
    }
    if (fd >= 0) close(fd);
    return 0;
}
```

### Expected behavior
`pidfd_open(0, 0)` should return -1 with `errno = EINVAL`, matching Linux behavior where pid <= 0 is an invalid argument.

### Log
- In Linux:
```
VERDICT: LINUX behavior — pid=0 returns EINVAL
```
- In Asterinas
```
VERDICT: ASTERINAS behavior — pid=0 returns ESRCH instead of EINVAL
```