### PR TITLE
Fix `pidfd_send_signal` rejecting signal 0

### DIFF
--- a/kernel/src/syscall/pidfd_send_signal.rs
+++ b/kernel/src/syscall/pidfd_send_signal.rs
@@ -28,44 +28,54 @@ pub fn sys_pidfd_send_signal(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let flags = PidfdSendSignalFlags::try_from(flags)?;
-    let sig_num = SigNum::try_from(sig_num as u8)?;
+    let sig_num = if sig_num == 0 {
+        None
+    } else {
+        Some(SigNum::try_from(sig_num as u8)?)
+    };
     debug!(
         "pidfd={}, info_ptr={:#x}, flags={:?}",
         pidfd, info_ptr, flags
     );
 
-    let siginfo = read_siginfo_from_user(info_ptr, sig_num, ctx)?;
-    let signal = RawSignal::new(siginfo);
-
     let target = get_target_from_pidfd(pidfd, flags, ctx)?;
 
-    // Only check `si_code` permissions when the user explicitly provided a siginfo.
-    // When `info_ptr` is `NULL`, the kernel generates the siginfo, so no restriction applies.
-    if info_ptr != 0 {
-        let is_self = match &target {
-            SignalTarget::Thread { tid, tgid: _ } => *tid == ctx.posix_thread.tid(),
-            SignalTarget::Process { pid } => *pid == ctx.posix_thread.tid(),
-            SignalTarget::ProcessGroup { pgid: _ } => false,
-        };
+    let signal = if let Some(sig_num) = sig_num {
+        let siginfo = read_siginfo_from_user(info_ptr, sig_num, ctx)?;
 
-        if !is_self && (siginfo.si_code >= 0 || siginfo.si_code == SI_TKILL) {
-            return_errno_with_message!(
-                Errno::EPERM,
-                "signals with custom code can only be sent to the current thread/process"
-            );
+        // Only check `si_code` permissions when the user explicitly provided a siginfo.
+        // When `info_ptr` is `NULL`, the kernel generates the siginfo, so no restriction applies.
+        if info_ptr != 0 {
+            let is_self = match &target {
+                SignalTarget::Thread { tid, tgid: _ } => *tid == ctx.posix_thread.tid(),
+                SignalTarget::Process { pid } => *pid == ctx.posix_thread.tid(),
+                SignalTarget::ProcessGroup { pgid: _ } => false,
+            };
+
+            if !is_self && (siginfo.si_code >= 0 || siginfo.si_code == SI_TKILL) {
+                return_errno_with_message!(
+                    Errno::EPERM,
+                    "signals with custom code can only be sent to the current thread/process"
+                );
+            }
         }
-    }
+
+        Some(RawSignal::new(siginfo))
+    } else {
+        None
+    };
 
     match target {
         SignalTarget::Thread { tid, tgid } => {
-            let signal = Some(Box::new(signal) as Box<dyn Signal>);
+            let signal = signal.map(|s| Box::new(s) as Box<dyn Signal>);
             tgkill(tid, Some(tgid), signal, ctx)?;
         }
         SignalTarget::Process { pid } => {
-            kill(pid, Some(Box::new(signal) as Box<dyn Signal>), ctx)?;
+            let signal = signal.map(|s| Box::new(s) as Box<dyn Signal>);
+            kill(pid, signal, ctx)?;
         }
         SignalTarget::ProcessGroup { pgid } => {
-            kill_group(pgid, Some(signal), ctx)?;
+            kill_group(pgid, signal, ctx)?;
         }
     }
 

--- a/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
+++ b/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
@@ -122,6 +122,41 @@ FN_SETUP(cleanup_null_info_process)
 END_SETUP()
 
 /* ==========================
+ *  Tests for null signal (0)
+ * ========================== */
+
+int null_sig_child_pid;
+int null_sig_pidfd;
+
+FN_SETUP(create_null_sig_process)
+{
+	null_sig_child_pid = CHECK(fork());
+	if (null_sig_child_pid == 0) {
+		while (1) {
+			usleep(100);
+		}
+	}
+
+	null_sig_pidfd = CHECK(pidfd_open(null_sig_child_pid, 0));
+}
+END_SETUP()
+
+FN_TEST(pidfd_send_signal_null_signal)
+{
+	// Signal 0 is a null signal used for permission/existence checks
+	TEST_SUCC(pidfd_send_signal(null_sig_pidfd, 0, NULL, 0));
+}
+END_TEST()
+
+FN_SETUP(cleanup_null_sig_process)
+{
+	CHECK(kill(null_sig_child_pid, SIGKILL));
+	CHECK(waitid(P_PID, null_sig_child_pid, NULL, WEXITED));
+	CHECK(close(null_sig_pidfd));
+}
+END_SETUP()
+
+/* ==========================
  *  Tests for `PIDFD_SELF_*`
  * ========================== */
 


### PR DESCRIPTION
Modified sys_pidfd_send_signal to accept signal 0 as a null signal, matching Linux behavior.
https://elixir.bootlin.com/linux/v6.15/source/kernel/signal.c#L1418-L1419
```C
	if (!ret && sig)
		ret = do_send_sig_info(sig, info, p, type);
```

### Describe the bug
Asterinas rejects signal number 0 in `pidfd_send_signal` with EINVAL, 
while Linux accepts it as a "null signal" that only performs permission and existence checks without actually delivering any signal. 

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <signal.h>
#include <unistd.h>
#include <sys/syscall.h>

#ifndef SYS_pidfd_send_signal
#define SYS_pidfd_send_signal 424
#endif

#ifndef SYS_pidfd_open
#define SYS_pidfd_open 434
#endif

int main(void) {
    int pidfd = syscall(SYS_pidfd_open, getpid(), 0);
    if (pidfd < 0) {
        perror("pidfd_open");
        return 1;
    }

    errno = 0;
    int ret = syscall(SYS_pidfd_send_signal, pidfd, 0, NULL, 0);
    if (ret == 0) {
        printf("VERDICT: LINUX behavior — signal 0 accepted (null signal for permission check)\n");
    } else {
        printf("VERDICT: ASTERINAS behavior — signal 0 rejected with errno=%d (%s)\n",
               errno, strerror(errno));
    }

    close(pidfd);
    return 0;
}
```

### Expected behavior
On Linux, `pidfd_send_signal(pidfd, 0, NULL, 0)` returns 0 (success) when the target process exists and the caller has permission to signal it. It returns -1 with ESRCH if the target is dead, or EPERM if lacking permission. No signal is delivered.

### Log
- In Asterinas:
```
VERDICT: ASTERINAS behavior — signal 0 rejected with errno=22 (Invalid argument)
```
- In Linux:
```
VERDICT: LINUX behavior — signal 0 accepted (null signal for permission check)
```