### PR TITLE
Refactor sigset size validation

### DIFF
--- a/kernel/src/process/signal/sig_mask.rs
+++ b/kernel/src/process/signal/sig_mask.rs
@@ -28,7 +28,7 @@ pub type SigMask = SigSet;
 /// Because that all the signal numbers are in the range of 1 to 64, casting
 /// a signal set from `u64` to `SigSet` will always succeed.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Pod)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SigSet {
     bits: u64,
 }
@@ -126,6 +126,13 @@ impl ops::Not for SigSet {
     }
 }
 
+// This is to allow hexadecimally formatting a `SigSet` when debug printing it.
+impl LowerHex for SigSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        LowerHex::fmt(&self.bits, f)
+    }
+}
+
 impl SigSet {
     pub fn new_empty() -> Self {
         SigSet { bits: 0 }
@@ -155,13 +162,6 @@ impl SigSet {
     pub fn intersects(&self, other: impl Into<Self>) -> bool {
         let other = other.into();
         self.bits & other.bits != 0
-    }
-}
-
-// This is to allow hexadecimally formatting a `SigSet` when debug printing it.
-impl LowerHex for SigSet {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        LowerHex::fmt(&self.bits, f) // delegate to u64's implementation
     }
 }
 

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -4,7 +4,10 @@ use core::time::Duration;
 
 use ostd::mm::VmIo;
 
-use super::SyscallReturn;
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
+};
 use crate::{
     events::{EpollCtl, EpollEvent, EpollFile, EpollFlags, IoEvents},
     fs::file::{
@@ -12,7 +15,7 @@ use crate::{
         file_table::{FdFlags, RawFileDesc, get_file_fast},
     },
     prelude::*,
-    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
+    process::posix_thread::ContextPthreadAdminApi,
     time::timespec_t,
 };
 
@@ -112,11 +115,11 @@ fn do_epoll_pwait2(
     };
 
     if sigmask_addr != 0 {
-        if sigmask_size != size_of::<SigMask>() {
-            return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
-        }
+        let size_policy = RequireFullSize::new(sigmask_size)?;
 
-        let sigmask = ctx.user_space().read_val::<SigMask>(sigmask_addr)?;
+        let user_space = ctx.user_space();
+        let sigmask_ptr = UserSigSetPtr::new(&user_space, sigmask_addr, size_policy);
+        let sigmask = sigmask_ptr.read_val()?;
         ctx.save_and_set_sig_mask(sigmask);
     }
 

--- a/kernel/src/syscall/ppoll.rs
+++ b/kernel/src/syscall/ppoll.rs
@@ -4,12 +4,12 @@ use core::time::Duration;
 
 use ostd::mm::VmIo;
 
-use super::{SyscallReturn, poll::do_sys_poll};
-use crate::{
-    prelude::*,
-    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
-    time::timespec_t,
+use super::{
+    SyscallReturn,
+    poll::do_sys_poll,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
 };
+use crate::{prelude::*, process::posix_thread::ContextPthreadAdminApi, time::timespec_t};
 
 pub fn sys_ppoll(
     fds: Vaddr,
@@ -29,11 +29,10 @@ pub fn sys_ppoll(
     };
 
     if sigmask_addr != 0 {
-        if sigmask_size != size_of::<SigMask>() {
-            return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
-        }
+        let size_policy = RequireFullSize::new(sigmask_size)?;
 
-        let sigmask = user_space.read_val::<SigMask>(sigmask_addr)?;
+        let sigmask_ptr = UserSigSetPtr::new(&user_space, sigmask_addr, size_policy);
+        let sigmask = sigmask_ptr.read_val()?;
         ctx.save_and_set_sig_mask(sigmask);
     }
 

--- a/kernel/src/syscall/pselect6.rs
+++ b/kernel/src/syscall/pselect6.rs
@@ -4,7 +4,11 @@ use core::time::Duration;
 
 use ostd::mm::VmIo;
 
-use super::{SyscallReturn, select::do_sys_select};
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
+    select::do_sys_select,
+};
 use crate::{
     fs::file::file_table::RawFileDesc,
     prelude::*,
@@ -33,11 +37,10 @@ pub fn sys_pselect6(
     if sigmask_addr != 0 {
         let sigmask_with_size = user_space.read_val::<SigMaskWithSize>(sigmask_addr)?;
         if sigmask_with_size.addr != 0 {
-            if sigmask_with_size.size != size_of::<SigMask>() {
-                return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
-            }
+            let size_policy = RequireFullSize::new(sigmask_with_size.size)?;
 
-            let sigmask = user_space.read_val::<SigMask>(sigmask_with_size.addr)?;
+            let sigmask_ptr = UserSigSetPtr::new(&user_space, sigmask_with_size.addr, size_policy);
+            let sigmask: SigMask = sigmask_ptr.read_val()?;
             ctx.save_and_set_sig_mask(sigmask);
         }
     }

--- a/kernel/src/syscall/rt_sigaction.rs
+++ b/kernel/src/syscall/rt_sigaction.rs
@@ -2,7 +2,7 @@
 
 use ostd::mm::VmIo;
 
-use super::SyscallReturn;
+use super::{SyscallReturn, rt_sigprocmask::RequireFullSize};
 use crate::{
     prelude::*,
     process::{
@@ -22,7 +22,7 @@ pub fn sys_rt_sigaction(
     sig_num: u8,
     sig_action_addr: Vaddr,
     old_sig_action_addr: Vaddr,
-    sigset_size: u64,
+    sigset_size: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let sig_num = SigNum::try_from(sig_num)?;
@@ -34,9 +34,8 @@ pub fn sys_rt_sigaction(
         sigset_size
     );
 
-    if sigset_size != 8 {
-        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8");
-    }
+    // Validate the size of the signal set
+    RequireFullSize::new(sigset_size)?;
 
     let sig_dispositions = ctx.process.sig_dispositions().lock();
     let mut sig_dispositions = sig_dispositions.lock();

--- a/kernel/src/syscall/rt_sigpending.rs
+++ b/kernel/src/syscall/rt_sigpending.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::mm::VmIo;
-
-use super::SyscallReturn;
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{AllowTruncSize, UserSigSetPtr},
+};
 use crate::{prelude::*, process::signal::HandlePendingSignal};
 
 pub fn sys_rt_sigpending(
@@ -14,21 +15,20 @@ pub fn sys_rt_sigpending(
         "u_set_ptr = 0x{:x},  sigset_size = {}",
         u_set_ptr, sigset_size
     );
-    if sigset_size != 8 {
-        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8")
-    }
-    do_rt_sigpending(u_set_ptr, ctx)?;
+    let size_policy = AllowTruncSize::new(sigset_size)?;
+    do_rt_sigpending(u_set_ptr, size_policy, ctx)?;
     Ok(SyscallReturn::Return(0))
 }
 
-fn do_rt_sigpending(set_ptr: Vaddr, ctx: &Context) -> Result<()> {
+fn do_rt_sigpending(set_ptr: Vaddr, size_policy: AllowTruncSize, ctx: &Context) -> Result<()> {
     let combined_signals = {
         let sig_mask_value = ctx.posix_thread.sig_mask();
         let sig_pending_value = ctx.pending_signals();
         sig_mask_value & sig_pending_value
     };
 
-    ctx.user_space()
-        .write_val(set_ptr, &u64::from(combined_signals))?;
+    let user_space = ctx.user_space();
+    let set_ptr = UserSigSetPtr::new(&user_space, set_ptr, size_policy);
+    set_ptr.write_val(&combined_signals)?;
     Ok(())
 }

--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -5,7 +5,7 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
+    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigSet},
 };
 
 pub fn sys_rt_sigprocmask(
@@ -20,10 +20,9 @@ pub fn sys_rt_sigprocmask(
         "mask op = {:?}, set_ptr = 0x{:x}, oldset_ptr = 0x{:x}, sigset_size = {}",
         mask_op, set_ptr, oldset_ptr, sigset_size
     );
-    if sigset_size != 8 {
-        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8");
-    }
-    do_rt_sigprocmask(mask_op, set_ptr, oldset_ptr, ctx)?;
+
+    let size_policy = RequireFullSize::new(sigset_size)?;
+    do_rt_sigprocmask(mask_op, set_ptr, oldset_ptr, size_policy, ctx)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -31,17 +30,21 @@ fn do_rt_sigprocmask(
     mask_op: MaskOp,
     set_ptr: Vaddr,
     oldset_ptr: Vaddr,
+    size_policy: RequireFullSize,
     ctx: &Context,
 ) -> Result<()> {
     let old_sig_mask_value = ctx.posix_thread.sig_mask();
     debug!("old sig mask value: 0x{:x}", old_sig_mask_value);
-    if oldset_ptr != 0 {
-        ctx.user_space()
-            .write_val(oldset_ptr, &old_sig_mask_value)?;
+    let user_space = ctx.user_space();
+
+    let oldset_ptr = UserSigSetPtr::new(&user_space, oldset_ptr, size_policy);
+    if oldset_ptr.addr() != 0 {
+        oldset_ptr.write_val(&old_sig_mask_value)?;
     }
 
-    if set_ptr != 0 {
-        let read_mask = ctx.user_space().read_val::<SigMask>(set_ptr)?;
+    let set_ptr = UserSigSetPtr::new(&user_space, set_ptr, size_policy);
+    if set_ptr.addr() != 0 {
+        let read_mask = set_ptr.read_val()?;
         match mask_op {
             MaskOp::Block => {
                 ctx.set_sig_mask(old_sig_mask_value + read_mask);
@@ -65,4 +68,89 @@ pub enum MaskOp {
     Block = 0,
     Unblock = 1,
     SetMask = 2,
+}
+
+/// A user-space pointer to a [`SigSet`] bound to a size policy `P`,
+/// which governs how strict the `sigsetsize` argument must be.
+pub(super) struct UserSigSetPtr<'a, 'b, P> {
+    user_space: &'a CurrentUserSpace<'b>,
+    addr: Vaddr,
+    size_policy: P,
+}
+
+impl<'a, 'b, P> UserSigSetPtr<'a, 'b, P> {
+    pub(super) fn new(user_space: &'a CurrentUserSpace<'b>, addr: Vaddr, size_policy: P) -> Self {
+        Self {
+            user_space,
+            addr,
+            size_policy,
+        }
+    }
+
+    /// Returns the user-space address this pointer refers to.
+    pub(super) fn addr(&self) -> Vaddr {
+        self.addr
+    }
+}
+
+/// Size policy requiring the full size of [`SigSet`].
+///
+/// Used by syscalls whose Linux ABI demands that `sigsetsize`
+/// be exactly `size_of::<SigSet>()`.
+#[derive(Clone, Copy)]
+pub(super) struct RequireFullSize;
+
+impl RequireFullSize {
+    /// Validates that `size` is exactly `size_of::<SigSet>()`.
+    pub(super) fn new(size: usize) -> Result<Self> {
+        if size != size_of::<SigSet>() {
+            return_errno_with_message!(Errno::EINVAL, "the sigset size is invalid");
+        }
+        Ok(RequireFullSize)
+    }
+}
+
+/// Size policy allowing a [`SigSet`] to be written in a truncated form.
+///
+/// Used by syscalls `rt_sigpending`, whose Linux ABI rejects only sizes
+/// greater than `size_of::<SigSet>()` and copies at most the requested number of bytes.
+#[derive(Clone, Copy)]
+pub(super) struct AllowTruncSize {
+    real_size: usize,
+}
+
+impl AllowTruncSize {
+    /// Validates that `size` is not greater than `size_of::<SigSet>()`.
+    pub(super) fn new(size: usize) -> Result<Self> {
+        if size > size_of::<SigSet>() {
+            return_errno_with_message!(Errno::EINVAL, "the sigset size is too large");
+        }
+        Ok(AllowTruncSize { real_size: size })
+    }
+}
+
+impl<'a, 'b> UserSigSetPtr<'a, 'b, RequireFullSize> {
+    /// Reads a full [`SigSet`] from user space.
+    pub(super) fn read_val(&self) -> Result<SigSet> {
+        let val: u64 = self.user_space.read_val(self.addr)?;
+        Ok(SigSet::from(val))
+    }
+
+    /// Writes a full [`SigSet`] to user space.
+    pub(super) fn write_val(&self, sigset: &SigSet) -> Result<()> {
+        self.user_space.write_val(self.addr, &u64::from(*sigset))?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> UserSigSetPtr<'a, 'b, AllowTruncSize> {
+    /// Writes a possibly truncated [`SigSet`] to user space.
+    ///
+    /// Only the first `sigsetsize` bytes (stored in the policy) are written.
+    pub(super) fn write_val(&self, sigset: &SigSet) -> Result<()> {
+        let bytes = u64::from(*sigset).to_ne_bytes();
+        self.user_space
+            .write_bytes(self.addr, &bytes[..self.size_policy.real_size])?;
+        Ok(())
+    }
 }

--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -5,7 +5,7 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
+    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigSet},
 };
 
 pub fn sys_rt_sigprocmask(
@@ -20,10 +20,9 @@ pub fn sys_rt_sigprocmask(
         "mask op = {:?}, set_ptr = 0x{:x}, oldset_ptr = 0x{:x}, sigset_size = {}",
         mask_op, set_ptr, oldset_ptr, sigset_size
     );
-    if sigset_size != 8 {
-        return_errno_with_message!(Errno::EINVAL, "sigset size is not equal to 8");
-    }
-    do_rt_sigprocmask(mask_op, set_ptr, oldset_ptr, ctx)?;
+
+    let size_policy = RequireFullSize::new(sigset_size)?;
+    do_rt_sigprocmask(mask_op, set_ptr, oldset_ptr, size_policy, ctx)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -31,17 +30,21 @@ fn do_rt_sigprocmask(
     mask_op: MaskOp,
     set_ptr: Vaddr,
     oldset_ptr: Vaddr,
+    size_policy: RequireFullSize,
     ctx: &Context,
 ) -> Result<()> {
     let old_sig_mask_value = ctx.posix_thread.sig_mask();
     debug!("old sig mask value: 0x{:x}", old_sig_mask_value);
-    if oldset_ptr != 0 {
-        ctx.user_space()
-            .write_val(oldset_ptr, &old_sig_mask_value)?;
+    let user_space = ctx.user_space();
+
+    let oldset_ptr = UserSigSetPtr::new(&user_space, oldset_ptr, size_policy);
+    if oldset_ptr.addr() != 0 {
+        oldset_ptr.write_val(&old_sig_mask_value)?;
     }
 
-    if set_ptr != 0 {
-        let read_mask = ctx.user_space().read_val::<SigMask>(set_ptr)?;
+    let set_ptr = UserSigSetPtr::new(&user_space, set_ptr, size_policy);
+    if set_ptr.addr() != 0 {
+        let read_mask = set_ptr.read_val()?;
         match mask_op {
             MaskOp::Block => {
                 ctx.set_sig_mask(old_sig_mask_value + read_mask);
@@ -65,4 +68,89 @@ enum MaskOp {
     Block = 0,
     Unblock = 1,
     SetMask = 2,
+}
+
+/// A user-space pointer to a [`SigSet`] bound to a size policy `P`,
+/// which governs how strict the `sigsetsize` argument must be.
+pub(super) struct UserSigSetPtr<'a, 'b, P> {
+    user_space: &'a CurrentUserSpace<'b>,
+    addr: Vaddr,
+    size_policy: P,
+}
+
+impl<'a, 'b, P> UserSigSetPtr<'a, 'b, P> {
+    pub(super) fn new(user_space: &'a CurrentUserSpace<'b>, addr: Vaddr, size_policy: P) -> Self {
+        Self {
+            user_space,
+            addr,
+            size_policy,
+        }
+    }
+
+    /// Returns the user-space address this pointer refers to.
+    pub(super) fn addr(&self) -> Vaddr {
+        self.addr
+    }
+}
+
+/// Size policy requiring the full size of [`SigSet`].
+///
+/// Used by syscalls whose Linux ABI demands that `sigsetsize`
+/// be exactly `size_of::<SigSet>()`.
+#[derive(Clone, Copy)]
+pub(super) struct RequireFullSize;
+
+impl RequireFullSize {
+    /// Validates that `size` is exactly `size_of::<SigSet>()`.
+    pub(super) fn new(size: usize) -> Result<Self> {
+        if size != size_of::<SigSet>() {
+            return_errno_with_message!(Errno::EINVAL, "the sigset size is invalid");
+        }
+        Ok(RequireFullSize)
+    }
+}
+
+/// Size policy allowing a [`SigSet`] to be written in a truncated form.
+///
+/// Used by syscalls `rt_sigpending`, whose Linux ABI rejects only sizes
+/// greater than `size_of::<SigSet>()` and copies at most the requested number of bytes.
+#[derive(Clone, Copy)]
+pub(super) struct AllowTruncSize {
+    real_size: usize,
+}
+
+impl AllowTruncSize {
+    /// Validates that `size` is not greater than `size_of::<SigSet>()`.
+    pub(super) fn new(size: usize) -> Result<Self> {
+        if size > size_of::<SigSet>() {
+            return_errno_with_message!(Errno::EINVAL, "the sigset size is too large");
+        }
+        Ok(AllowTruncSize { real_size: size })
+    }
+}
+
+impl<'a, 'b> UserSigSetPtr<'a, 'b, RequireFullSize> {
+    /// Reads a full [`SigSet`] from user space.
+    pub(super) fn read_val(&self) -> Result<SigSet> {
+        let val: u64 = self.user_space.read_val(self.addr)?;
+        Ok(SigSet::from(val))
+    }
+
+    /// Writes a full [`SigSet`] to user space.
+    pub(super) fn write_val(&self, sigset: &SigSet) -> Result<()> {
+        self.user_space.write_val(self.addr, &u64::from(*sigset))?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> UserSigSetPtr<'a, 'b, AllowTruncSize> {
+    /// Writes a possibly truncated [`SigSet`] to user space.
+    ///
+    /// Only the first `sigsetsize` bytes (stored in the policy) are written.
+    pub(super) fn write_val(&self, sigset: &SigSet) -> Result<()> {
+        let bytes = u64::from(*sigset).to_ne_bytes();
+        self.user_space
+            .write_bytes(self.addr, &bytes[..self.size_policy.real_size])?;
+        Ok(())
+    }
 }

--- a/kernel/src/syscall/rt_sigsuspend.rs
+++ b/kernel/src/syscall/rt_sigsuspend.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{mm::VmIo, sync::Waiter};
+use ostd::sync::Waiter;
 
-use super::SyscallReturn;
-use crate::{
-    prelude::*,
-    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
 };
+use crate::{prelude::*, process::posix_thread::ContextPthreadAdminApi};
 
 pub fn sys_rt_sigsuspend(
     sigmask_addr: Vaddr,
@@ -18,11 +18,11 @@ pub fn sys_rt_sigsuspend(
         sigmask_addr, sigmask_size
     );
 
-    if sigmask_size != size_of::<SigMask>() {
-        return_errno_with_message!(Errno::EINVAL, "invalid sigmask size");
-    }
+    let size_policy = RequireFullSize::new(sigmask_size)?;
 
-    let sigmask = ctx.user_space().read_val::<SigMask>(sigmask_addr)?;
+    let user_space = ctx.user_space();
+    let sigmask_ptr = UserSigSetPtr::new(&user_space, sigmask_addr, size_policy);
+    let sigmask = sigmask_ptr.read_val()?;
     ctx.save_and_set_sig_mask(sigmask);
 
     // Wait until receiving any signal

--- a/kernel/src/syscall/rt_sigtimedwait.rs
+++ b/kernel/src/syscall/rt_sigtimedwait.rs
@@ -4,13 +4,16 @@ use core::time::Duration;
 
 use ostd::{mm::VmIo, sync::Waiter};
 
-use super::SyscallReturn;
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
+};
 use crate::{
     prelude::*,
     process::signal::{
         HandlePendingSignal,
         constants::{SIGKILL, SIGSTOP},
-        sig_mask::{SigMask, SigSet},
+        sig_mask::SigMask,
         signals::Signal,
         with_sigmask_changed,
     },
@@ -29,14 +32,14 @@ pub fn sys_rt_sigtimedwait(
         set_ptr, info_ptr, timeout_ptr, sigset_size
     );
 
-    // Validate sigset size
-    if sigset_size != size_of::<SigMask>() {
-        return_errno_with_message!(Errno::EINVAL, "invalid sigset size");
-    }
+    // Validate the size of the signal set.
+    let size_policy = RequireFullSize::new(sigset_size)?;
 
+    let user_space = ctx.user_space();
+    let sigmask_ptr = UserSigSetPtr::new(&user_space, set_ptr, size_policy);
     // Read the signal set
     let mask = {
-        let mut set: SigSet = ctx.user_space().read_val(set_ptr)?;
+        let mut set = sigmask_ptr.read_val()?;
 
         // Remove SIGKILL and SIGSTOP as they cannot be waited for
         set -= SIGKILL;

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -12,9 +12,11 @@ use core::{
 };
 
 use bitflags::bitflags;
-use ostd::mm::VmIo;
 
-use super::SyscallReturn;
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
+};
 use crate::{
     events::IoEvents,
     fs::{
@@ -60,11 +62,11 @@ pub fn sys_signalfd4(
         raw_fd, mask_ptr, sizemask, flags
     );
 
-    if sizemask != size_of::<SigMask>() {
-        return Err(Error::with_message(Errno::EINVAL, "invalid mask size"));
-    }
+    let size_policy = RequireFullSize::new(sizemask)?;
 
-    let mut mask = ctx.user_space().read_val::<SigMask>(mask_ptr)?;
+    let user_space = ctx.user_space();
+    let sigmask_ptr = UserSigSetPtr::new(&user_space, mask_ptr, size_policy);
+    let mut mask = sigmask_ptr.read_val()?;
     mask -= SIGKILL;
     mask -= SIGSTOP;
 

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -9,9 +9,11 @@
 use core::{fmt::Display, sync::atomic::Ordering};
 
 use bitflags::bitflags;
-use ostd::mm::VmIo;
 
-use super::SyscallReturn;
+use super::{
+    SyscallReturn,
+    rt_sigprocmask::{RequireFullSize, UserSigSetPtr},
+};
 use crate::{
     events::IoEvents,
     fs::{
@@ -56,11 +58,11 @@ pub fn sys_signalfd4(
         raw_fd, mask_ptr, sizemask, flags
     );
 
-    if sizemask != size_of::<SigMask>() {
-        return_errno_with_message!(Errno::EINVAL, "invalid mask size");
-    }
+    let size_policy = RequireFullSize::new(sizemask)?;
 
-    let mut mask = ctx.user_space().read_val::<SigMask>(mask_ptr)?;
+    let user_space = ctx.user_space();
+    let sigmask_ptr = UserSigSetPtr::new(&user_space, mask_ptr, size_policy);
+    let mut mask = sigmask_ptr.read_val()?;
     mask -= SIGKILL;
     mask -= SIGSTOP;
 

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -59,6 +59,7 @@ fi
 ./signal/kill
 ./signal/parent_death_signal
 ./signal/pidfd_send_signal
+./signal/rt_sigpending
 ./signal/signal_fd
 ./signal/signal_test2
 

--- a/test/initramfs/src/regression/process/signal/rt_sigpending.c
+++ b/test/initramfs/src/regression/process/signal/rt_sigpending.c
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "../../common/test.h"
+
+static long rt_sigpending(void *set, size_t sigsetsize)
+{
+	return syscall(SYS_rt_sigpending, set, sigsetsize);
+}
+
+sigset_t blocked;
+
+FN_SETUP(block_sigusr1)
+{
+	sigemptyset(&blocked);
+	sigaddset(&blocked, SIGUSR1);
+	CHECK(sigprocmask(SIG_BLOCK, &blocked, NULL));
+	CHECK(raise(SIGUSR1));
+}
+END_SETUP()
+
+FN_TEST(sigsetsize_larger_than_eight_rejected)
+{
+	unsigned char buf[16];
+
+	TEST_ERRNO(rt_sigpending(buf, 9), EINVAL);
+	TEST_ERRNO(rt_sigpending(buf, 16), EINVAL);
+}
+END_TEST()
+
+FN_TEST(sigsetsize_equal_to_eight)
+{
+	unsigned long val = 0;
+
+	TEST_SUCC(rt_sigpending(&val, 8));
+	TEST_RES(rt_sigpending(&val, 8), val & (1UL << (SIGUSR1 - 1)));
+}
+END_TEST()
+
+FN_TEST(sigsetsize_smaller_than_eight)
+{
+	unsigned char buf[8];
+
+	// sigsetsize = 4: should write the lower 4 bytes containing SIGUSR1
+	memset(buf, 0, sizeof(buf));
+	TEST_RES(rt_sigpending(buf, 4),
+		 buf[((SIGUSR1 - 1) / 8)] & (1U << ((SIGUSR1 - 1) % 8)));
+
+	// sigsetsize = 0: no-op, should succeed
+	TEST_SUCC(rt_sigpending(buf, 0));
+}
+END_TEST()
+
+FN_TEST(null_pointer_rejected)
+{
+	TEST_ERRNO(rt_sigpending(NULL, 8), EFAULT);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	signal(SIGUSR1, SIG_IGN);
+	CHECK(sigprocmask(SIG_UNBLOCK, &blocked, NULL));
+}
+END_SETUP()


### PR DESCRIPTION
Changed the size validation from `sigset_size != 8` to `sigset_size > 8`, matching Linux behavior.
https://elixir.bootlin.com/linux/v6.15/source/kernel/signal.c#L3390-L3395
```c
SYSCALL_DEFINE2(rt_sigpending, sigset_t __user *, uset, size_t, sigsetsize)
{
	sigset_t set;

	if (sigsetsize > sizeof(*uset))
		return -EINVAL;
```

### Describe the bug
Asterinas's `rt_sigpending` implementation requires `sigsetsize` to be exactly 8, returning `EINVAL` for any other value. Linux only rejects `sigsetsize > sizeof(sigset_t)` (i.e., > 8 on x86-64) and allows smaller sizes, copying only `sigsetsize` bytes to userspace.

Root cause: `kernel/src/syscall/rt_sigpending.rs:17-18` uses `sigset_size != 8` instead of `sigset_size > 8`.

### To Reproduce
```c
#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <signal.h>
#include <unistd.h>
#include <sys/syscall.h>
#include <stdint.h>

int main(void) {
    sigset_t blocked;
    unsigned char buf[8];

    /* Block SIGUSR1 and raise it so there's something pending */
    sigemptyset(&blocked);
    sigaddset(&blocked, SIGUSR1);
    sigprocmask(SIG_BLOCK, &blocked, NULL);
    raise(SIGUSR1);

    /* Test 1: sigsetsize=4 (partial copy) */
    memset(buf, 0xAA, sizeof(buf));
    errno = 0;
    long ret = syscall(SYS_rt_sigpending, buf, 4);
    if (ret == 0) {
        unsigned int val = *(unsigned int *)buf;
        printf("VERDICT: LINUX behavior — sigsetsize=4 returns 0, partial copy val=0x%x\n", val);
    } else {
        printf("VERDICT: ASTERINAS behavior — sigsetsize=4 returns %ld errno=%s\n",
               ret, strerror(errno));
    }

    /* Test 2: sigsetsize=0 */
    errno = 0;
    ret = syscall(SYS_rt_sigpending, buf, 0);
    if (ret == 0) {
        printf("VERDICT: LINUX behavior — sigsetsize=0 returns 0\n");
    } else {
        printf("VERDICT: ASTERINAS behavior — sigsetsize=0 returns %ld errno=%s\n",
               ret, strerror(errno));
    }

    /* Clean up */
    signal(SIGUSR1, SIG_IGN);
    sigprocmask(SIG_UNBLOCK, &blocked, NULL);
    return 0;
}
```

### Expected behavior
On Linux, `rt_sigpending` with `sigsetsize` less than 8 (but >= 0) should succeed (return 0) and copy only `sigsetsize` bytes of the pending signal set to the userspace buffer. The kernel checks `sigsetsize > sizeof(sigset_t)` and only rejects values larger than 8.

### Log
- In Asterinas:
```
VERDICT: ASTERINAS behavior — sigsetsize=4 returns -1 errno=Invalid argument
VERDICT: ASTERINAS behavior — sigsetsize=0 returns -1 errno=Invalid argument
```
- In Linux:
```
VERDICT: LINUX behavior — sigsetsize=4 returns 0, partial copy val=0x200
VERDICT: LINUX behavior — sigsetsize=0 returns 0
```