### PR TITLE
Increase LTP timeout multiplier for slow CI machines

### DIFF
--- a/test/initramfs/src/conformance/ltp/run_ltp_test.sh
+++ b/test/initramfs/src/conformance/ltp/run_ltp_test.sh
@@ -7,6 +7,8 @@ TEST_TMP_DIR=${CONFORMANCE_TEST_WORKDIR:-/tmp}
 LOG_FILE=$TEST_TMP_DIR/result.log
 RESULT=0
 
+export LTP_TIMEOUT_MUL=5
+
 rm -f $LOG_FILE
 CREATE_ENTRIES=1 $LTP_DIR/runltp -f syscalls -Q -p -d $TEST_TMP_DIR -l $LOG_FILE
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Increase LTP timeout multiplier (`LTP_TIMEOUT_MUL=5`) to prevent
sporadic test timeouts on slower CI machines.

See CI failure: https://github.com/asterinas/asterinas/actions/runs/27310628212/job/80679644554
