### PR TITLE
Fix clone_files regression FD reuse

### DIFF
--- a/test/initramfs/src/regression/process/execve/execve_mt_parent.c
+++ b/test/initramfs/src/regression/process/execve/execve_mt_parent.c
@@ -153,17 +153,21 @@ FN_TEST(clone_files)
 	int pipefds[2];
 	TEST_SUCC(syscall(SYS_pipe2, pipefds, O_CLOEXEC));
 
-	// Duplicate the pipe fd to a high-value FD to prevent it from being reused.
+	// Duplicate the pipe fds to high-value FDs to prevent unrelated
+	// open operations during multi-threaded exec from reusing them.
 	int dupped_pipe_fd = 100;
+	int dupped_pipe_write_fd = 101;
 	TEST_SUCC(syscall(SYS_dup3, pipefds[0], dupped_pipe_fd, O_CLOEXEC));
+	TEST_SUCC(syscall(SYS_dup3, pipefds[1], dupped_pipe_write_fd, 0));
 	TEST_SUCC(close(pipefds[0]));
+	TEST_SUCC(close(pipefds[1]));
 
 	struct clone_args args = { .flags = CLONE_FILES,
 				   .exit_signal = SIGCHLD };
 	pid_t pid = TEST_SUCC(sys_clone3(&args));
 
 	if (pid == 0) {
-		CHECK(close(pipefds[1]));
+		CHECK(close(dupped_pipe_write_fd));
 		exit(EXIT_SUCCESS);
 	}
 
@@ -193,6 +197,6 @@ FN_TEST(clone_files)
 		 _ret == pid && WIFEXITED(status) &&
 			 WEXITSTATUS(status) == 102);
 	TEST_SUCC(close(dupped_pipe_fd));
-	TEST_ERRNO(close(pipefds[1]), EBADF);
+	TEST_ERRNO(close(dupped_pipe_write_fd), EBADF);
 }
 END_TEST()


### PR DESCRIPTION
## Summary

- Fix a false `clone_files` regression failure in `execve_mt_parent`.
- Duplicate the pipe write end to a stable high fd before the `CLONE_FILES` child closes it.
- Avoid unrelated procfs opens during multi-threaded exec reusing the original low-numbered pipe fd.

Fixes #3178.

## Details

The failure in #3178 does not appear to be a `clone3(CLONE_FILES)` implementation bug. The test moved only the pipe read end to a high fd, while continuing to check the original low-numbered write fd.

During the later multi-threaded exec path, procfs opens from sibling threads can reuse that low fd in the shared file table. The parent can then successfully close an unrelated fd, making the test report a false `CLONE_FILES` failure.

This patch duplicates the write end to a high fd as well, closes the original pipe fds, and checks the duplicated write fd instead.

## Test Plan

- `git diff --check`
- `make check`
- `make test`
- `make ktest INITRAMFS_SKIP_GZIP=1`
- `make ktest TARGET_ARCH=riscv64 INITRAMFS_SKIP_GZIP=1 LOG_LEVEL=warn`
- RISC-V targeted run of `/test/process/execve/execve_mt_parent`
  - `test_clone_files summary: 11 tests passed, 0 tests failed`

Also ran full RISC-V regression:

- `test_clone_files` passed there too.
- The full run later failed in unrelated network netlink tests because current upstream RISC-V QEMU does not expose `eth0`; this matches the virtio-net gap discussed in #3179.
