### PR TITLE
Fix inotify_poll test race on SMP

### DIFF
--- a/test/initramfs/src/regression/fs/inotify/inotify_poll.c
+++ b/test/initramfs/src/regression/fs/inotify/inotify_poll.c
@@ -99,8 +99,6 @@ int main(void)
 		return 3;
 	}
 
-	char buf[4096]
-		__attribute__((aligned(__alignof__(struct inotify_event))));
 	/* FIONREAD should indicate pending bytes before read */
 	int pending = 0;
 	if (ioctl(ifd, FIONREAD, &pending) < 0)
@@ -109,6 +107,13 @@ int main(void)
 		fprintf(stderr, "FIONREAD should be > 0 when POLLIN set\n");
 		return 5;
 	}
+
+	/* Wait for the child to finish so all events are queued, then drain. */
+	int status = 0;
+	waitpid(pid, &status, 0);
+
+	char buf[4096]
+		__attribute__((aligned(__alignof__(struct inotify_event))));
 	ssize_t len = read(ifd, buf, sizeof(buf));
 	if (len < 0)
 		die("read");
@@ -129,8 +134,6 @@ int main(void)
 		}
 	}
 
-	int status = 0;
-	waitpid(pid, &status, 0);
 	close(ifd);
 	unlink(file);
 	rmdir(dir);


### PR DESCRIPTION
Fix a race condition in the `inotify_poll` regression test that caused sporadic failures on SMP systems (observed with `INTEL_TDX=1 SMP=4`).

The child process's `IN_MODIFY` event could arrive after the parent's `read()`, leaving it in the queue when the subsequent `poll(0)` check expects an empty state. Moving `waitpid` before `read` ensures all events are queued before draining.

See CI failure: https://github.com/asterinas/asterinas/actions/runs/27310628212/job/80679644490