### PR TITLE
Implement readahead mechanism

### DIFF
--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -2,7 +2,7 @@
 
 //! Opened Inode-backed File Handle
 
-use core::{fmt::Display, sync::atomic::Ordering};
+use core::{fmt::Display, ops::Range, sync::atomic::Ordering};
 
 use aster_rights::Rights;
 
@@ -34,8 +34,146 @@ pub struct InodeHandle {
     /// and `ioctl` will be provided by the per-open file object instead of `path`.
     open_file: Option<Box<dyn PerOpenFileOps>>,
     offset: Mutex<usize>,
+    readahead: Mutex<ReadaheadState>,
     status_flags: AtomicStatusFlags,
     rights: Rights,
+}
+
+/// Maximum readahead window in pages.
+const MAX_READAHEAD_PAGES: usize = 32;
+
+/// Per-open-file readahead heuristic state.
+#[derive(Debug, Default)]
+struct ReadaheadState {
+    /// Byte offset immediately after the most recent read.
+    prev_pos: Option<usize>,
+    /// Page index where the most recent readahead window started.
+    start_page_idx: usize,
+    /// Total size of the most recent readahead window in pages.
+    nr_window_pages: usize,
+    /// Page index where the next readahead window should be submitted.
+    trigger_page_idx: usize,
+}
+
+impl ReadaheadState {
+    /// Records a completed read.
+    ///
+    /// Returns the page-index range to prefetch.
+    ///
+    /// Reads are treated as sequential when their first page is the same as or
+    /// immediately after the page containing the end of the previous read.
+    fn on_read(&mut self, offset: usize, read_len: usize) -> Option<Range<usize>> {
+        let read_end = offset + read_len;
+        let read_start_idx = offset / PAGE_SIZE;
+        let read_end_idx = read_end.div_ceil(PAGE_SIZE);
+
+        if !self.is_sequential_read(read_start_idx) {
+            self.prev_pos = Some(read_end);
+            self.clear_window();
+            return None;
+        }
+
+        self.prev_pos = Some(read_end);
+
+        if self.nr_window_pages == 0 {
+            return self.start_initial_window(read_start_idx, read_end_idx);
+        }
+
+        self.try_submit_next_window(read_end_idx)
+    }
+
+    /// Returns whether the read continues the previous page-level stream.
+    fn is_sequential_read(&self, read_start_idx: usize) -> bool {
+        let Some(prev_pos) = self.prev_pos else {
+            return read_start_idx == 0;
+        };
+
+        let prev_page_idx = prev_pos / PAGE_SIZE;
+        read_start_idx == prev_page_idx || read_start_idx == prev_page_idx + 1
+    }
+
+    /// Starts the initial window for a sequential stream.
+    fn start_initial_window(
+        &mut self,
+        read_start_idx: usize,
+        read_end_idx: usize,
+    ) -> Option<Range<usize>> {
+        let nr_window_pages = Self::initial_window_pages(read_end_idx - read_start_idx);
+        let readahead_start_idx = read_end_idx;
+        let window_end_idx = read_start_idx + nr_window_pages;
+
+        self.start_page_idx = read_start_idx;
+        self.nr_window_pages = nr_window_pages;
+        self.trigger_page_idx = readahead_start_idx;
+
+        if readahead_start_idx >= window_end_idx {
+            return None;
+        }
+
+        Some(readahead_start_idx..window_end_idx)
+    }
+
+    /// Advances the window after the read reaches the trigger page.
+    fn try_submit_next_window(&mut self, read_end_idx: usize) -> Option<Range<usize>> {
+        let window_end_idx = self.start_page_idx + self.nr_window_pages;
+        if read_end_idx <= self.trigger_page_idx {
+            return None;
+        }
+
+        // If the read passed the whole window, skip pages that demand reads
+        // should already have populated.
+        let new_start_idx = window_end_idx.max(read_end_idx);
+        let nr_new_window_pages = Self::next_window_pages(self.nr_window_pages);
+        let new_end_idx = new_start_idx + nr_new_window_pages;
+
+        self.start_page_idx = new_start_idx;
+        self.nr_window_pages = nr_new_window_pages;
+        self.trigger_page_idx = new_start_idx;
+
+        Some(new_start_idx..new_end_idx)
+    }
+
+    /// Returns the initial total window size in pages.
+    ///
+    /// Reference:
+    /// <https://elixir.bootlin.com/linux/v7.1-rc7/source/mm/readahead.c#L371>.
+    fn initial_window_pages(nr_read_pages: usize) -> usize {
+        debug_assert!(nr_read_pages > 0);
+
+        if nr_read_pages > MAX_READAHEAD_PAGES / 4 {
+            return MAX_READAHEAD_PAGES;
+        }
+
+        let base = nr_read_pages.next_power_of_two();
+        if base <= MAX_READAHEAD_PAGES / 32 {
+            base * 4
+        } else if base <= MAX_READAHEAD_PAGES / 4 {
+            base * 2
+        } else {
+            MAX_READAHEAD_PAGES
+        }
+    }
+
+    /// Returns the next total window size in pages.
+    ///
+    /// Reference:
+    /// <https://elixir.bootlin.com/linux/v7.1-rc7/source/mm/readahead.c#L390>.
+    fn next_window_pages(nr_current_pages: usize) -> usize {
+        if nr_current_pages < MAX_READAHEAD_PAGES / 16 {
+            nr_current_pages * 4
+        } else if nr_current_pages <= MAX_READAHEAD_PAGES / 2 {
+            nr_current_pages * 2
+        } else {
+            MAX_READAHEAD_PAGES
+        }
+    }
+
+    /// Clears the active readahead window.
+    fn clear_window(&mut self) {
+        self.start_page_idx = 0;
+        self.nr_window_pages = 0;
+        self.trigger_page_idx = 0;
+    }
 }
 
 impl InodeHandle {
@@ -71,6 +209,7 @@ impl InodeHandle {
             path,
             open_file,
             offset: Mutex::new(0),
+            readahead: Mutex::new(ReadaheadState::default()),
             status_flags: AtomicStatusFlags::new(status_flags),
             rights,
         })
@@ -237,6 +376,37 @@ impl InodeHandle {
 
         Ok((open_file.as_ref() as &dyn Any).downcast_ref::<T>())
     }
+
+    fn maybe_readahead(&self, offset: usize, read_len: usize, status_flags: StatusFlags) {
+        if read_len == 0 || self.open_file.is_some() || status_flags.contains(StatusFlags::O_DIRECT)
+        {
+            return;
+        }
+        let Some(page_cache) = self.path.inode().page_cache() else {
+            return;
+        };
+
+        // If another reader is updating the heuristic state, skip this opportunity and let
+        // the demand read complete without waiting.
+        let Some(mut readahead) = self.readahead.try_lock() else {
+            return;
+        };
+        let Some(page_idx_range) = readahead.on_read(offset, read_len) else {
+            return;
+        };
+        drop(readahead);
+
+        let file_size = self.path.size();
+        let file_end_idx = file_size.div_ceil(PAGE_SIZE);
+        let readahead_end_idx = page_idx_range.end.min(file_end_idx);
+        if page_idx_range.start >= readahead_end_idx {
+            return;
+        }
+
+        // Readahead must not affect the result of the completed demand read.
+        // Cache population failures only lose this speculative optimization.
+        let _ = page_cache.readahead(page_idx_range.start..readahead_end_idx);
+    }
 }
 
 impl Pollable for InodeHandle {
@@ -267,10 +437,14 @@ impl FileLike for InodeHandle {
             return file_ops.read_at(0, writer, status_flags);
         }
 
-        let mut offset = self.offset.lock();
-
-        let len = file_ops.read_at(*offset, writer, status_flags)?;
-        *offset += len;
+        let (old_offset, len) = {
+            let mut offset = self.offset.lock();
+            let old_offset = *offset;
+            let len = file_ops.read_at(old_offset, writer, status_flags)?;
+            *offset += len;
+            (old_offset, len)
+        };
+        self.maybe_readahead(old_offset, len, status_flags);
 
         Ok(len)
     }
@@ -310,7 +484,10 @@ impl FileLike for InodeHandle {
 
         let status_flags = self.status_flags();
 
-        file_ops.read_at(offset, writer, status_flags)
+        let len = file_ops.read_at(offset, writer, status_flags)?;
+        self.maybe_readahead(offset, len, status_flags);
+
+        Ok(len)
     }
 
     fn write_at(&self, mut offset: usize, reader: &mut VmReader) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -809,6 +809,8 @@ impl ExfatInode {
 
         {
             let mut inner = inner.upgrade();
+            // Evict pages that may have been brought in by concurrent readahead.
+            inner.page_cache.evict_range(start..end).unwrap();
             inner.update_atime_and_mtime()?;
             inner.size = new_size;
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -370,6 +370,10 @@ impl InodeInner {
             return Err(err);
         }
 
+        // Evict pages that may have been brought in by concurrent readahead.
+        self.page_cache()
+            .evict_range(discard_start_bytes..discard_end_bytes)
+            .unwrap();
         self.set_mtime_ctime(utils::now());
         if end > self.file_size() {
             self.set_file_size(end);

--- a/kernel/src/vm/page_cache/cache_page.rs
+++ b/kernel/src/vm/page_cache/cache_page.rs
@@ -103,7 +103,6 @@ pub trait CachePageExt: Sized {
     fn wait_queue(&self) -> &'static WaitQueue;
 
     /// Tries to lock the cache page.
-    #[expect(dead_code)]
     fn try_lock(self) -> Option<LockedCachePage>;
 
     /// Tries to lock the cache page by reference.

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -156,6 +156,15 @@ impl PageCache {
         self.0.size()
     }
 
+    /// Submits speculative read-side population for the specified page-index range.
+    ///
+    /// The operation is best-effort and submission-synchronous: missing pages
+    /// may have backend reads submitted, but this method does not wait for all
+    /// prefetched pages to become readable.
+    pub fn readahead(&self, page_idx_range: Range<usize>) -> Result<()> {
+        self.0.readahead(page_idx_range)
+    }
+
     /// Returns the writable mapping status of the underlying VMO.
     pub fn writable_mapping_status(&self) -> &WritableMappingStatus {
         self.0.writable_mapping_status()
@@ -292,7 +301,6 @@ impl PageCache {
     // TODO: Integrate a reverse-mapping lock or equivalent synchronization so
     // eviction can coordinate with mapped pages and concurrent page faults
     // before removing cached pages from the page cache.
-    #[cfg_attr(not(ktest), expect(dead_code))]
     pub fn evict_range(&self, range: Range<usize>) -> Result<()> {
         let Some(vmo) = self.0.as_backed_vmo() else {
             return Ok(());

--- a/kernel/src/vm/page_cache/tests/mod.rs
+++ b/kernel/src/vm/page_cache/tests/mod.rs
@@ -495,3 +495,76 @@ fn delayed_io_completion() {
     assert!(second_flush_result.lock().take().unwrap().is_ok());
     assert_eq!(backend.persisted_page_bytes(0), latest_dirty_pattern);
 }
+
+/// A demand read after readahead reuses the prefetched page without issuing
+/// a second backend read.
+#[ktest]
+fn readahead_pages_served_by_demand_read() {
+    let backend = MockPageCacheBackend::new(4);
+    let pattern = vec![0xAA; PAGE_SIZE];
+    backend.set_persisted_page_bytes(2, &pattern);
+
+    let page_cache = new_backend_page_cache(&backend, 4);
+    page_cache.readahead(2..3).unwrap();
+
+    // Demand read the same page — should hit the already-populated cache.
+    let mut buf = vec![0u8; PAGE_SIZE];
+    page_cache.read_bytes(2 * PAGE_SIZE, &mut buf).unwrap();
+
+    assert_eq!(backend.read_count(2), 1);
+    assert_eq!(buf, pattern);
+}
+
+/// Readahead skips a page that is already resident (e.g., written before).
+#[ktest]
+fn readahead_skips_resident_pages() {
+    let backend = MockPageCacheBackend::new(2);
+
+    let page_cache = new_backend_page_cache(&backend, 2);
+    // Populate page 0 via a write (makes it resident and dirty).
+    let write_data = vec![0xBB; PAGE_SIZE];
+    page_cache.write_bytes(0, &write_data).unwrap();
+
+    // Readahead the same page — should not submit a backend read.
+    page_cache.readahead(0..1).unwrap();
+    assert_eq!(backend.read_count(0), 0);
+}
+
+/// Readahead clamps the requested range to the page-cache capacity.
+#[ktest]
+fn readahead_clamps_to_vmo_size() {
+    let backend = MockPageCacheBackend::new(3);
+
+    let page_cache = new_backend_page_cache(&backend, 3);
+    // Request far beyond the 3-page capacity.
+    page_cache.readahead(1..10).unwrap();
+
+    assert_eq!(backend.read_count(1), 1);
+    assert_eq!(backend.read_count(2), 1);
+}
+
+/// A demand read succeeds even after a readahead I/O completes with failure.
+#[ktest]
+fn readahead_io_failure_allows_demand_retry() {
+    let backend = MockPageCacheBackend::new(2);
+    backend.set_completion(IoKind::Read, IoCompletion::Deferred);
+
+    let page_cache = new_backend_page_cache(&backend, 2);
+    page_cache.readahead(0..1).unwrap();
+
+    backend.wait_for_deferred_bios(IoKind::Read, 1);
+    // Complete the readahead with an I/O error.
+    backend.complete_next_deferred_bio(IoKind::Read, false);
+
+    // Switch to immediate completion for the demand retry.
+    backend.set_completion(IoKind::Read, IoCompletion::Immediate);
+    let pattern = vec![0xCC; PAGE_SIZE];
+    backend.set_persisted_page_bytes(0, &pattern);
+
+    let mut buf = vec![0u8; PAGE_SIZE];
+    page_cache.read_bytes(0, &mut buf).unwrap();
+
+    // The demand read should have triggered a new backend read.
+    assert_eq!(backend.read_count(0), 2);
+    assert_eq!(buf, pattern);
+}

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -218,6 +218,16 @@ impl Vmo {
         self.commit_on_internal(page_idx, CommitMode::Read)
     }
 
+    /// Submits read-side page-cache population for the specified page-index range.
+    pub(super) fn readahead(&self, page_idx_range: Range<usize>) -> Result<()> {
+        let Some(backed_vmo) = self.as_backed_vmo() else {
+            // Anonymous VMOs (e.g., ramfs) have no I/O latency to hide.
+            return Ok(());
+        };
+
+        backed_vmo.readahead(page_idx_range)
+    }
+
     fn commit_on_internal(&self, page_idx: usize, commit_mode: CommitMode) -> Result<CachePage> {
         if let Some(backed_vmo) = self.as_backed_vmo() {
             return backed_vmo.commit_on_internal(page_idx, commit_mode);
@@ -690,6 +700,47 @@ pub struct BackedVmo<'a> {
 }
 
 impl<'a> BackedVmo<'a> {
+    /// Submits read I/O for pages in the specified page-index range.
+    fn readahead(&self, page_idx_range: Range<usize>) -> Result<()> {
+        let page_count = self.size().div_ceil(PAGE_SIZE);
+        let readahead_end_idx = page_idx_range.end.min(page_count);
+        if page_idx_range.start >= readahead_end_idx {
+            return Ok(());
+        }
+
+        let page_idx_range = page_idx_range.start..readahead_end_idx;
+        let mut io_batch = IoBatch::with_capacity(page_idx_range.len());
+
+        for page_idx in page_idx_range {
+            self.readahead_one(page_idx, &mut io_batch)?;
+        }
+
+        Ok(())
+    }
+
+    /// Submits read I/O for a specific page.
+    fn readahead_one(&self, page_idx: usize, io_batch: &mut IoBatch) -> Result<()> {
+        let mut locked_pages = self.vmo.pages.lock();
+        if page_idx >= self.size().div_ceil(PAGE_SIZE) {
+            return_errno_with_message!(Errno::EINVAL, "the page index is out of range");
+        }
+
+        let mut cursor = locked_pages.cursor_mut(page_idx as u64);
+        if cursor.load().is_some() {
+            return Ok(());
+        }
+
+        let page = CachePage::alloc_uninit()?;
+        let Some(locked_page) = page.try_lock() else {
+            return Ok(());
+        };
+        cursor.store(locked_page.clone());
+        drop(locked_pages);
+
+        self.backend
+            .read_page_async(page_idx, locked_page, io_batch)
+    }
+
     /// Writes back dirty pages in the specified byte range to the backend storage.
     pub(super) fn flush_dirty_pages(&self, range: &Range<usize>) -> Result<()> {
         let locked_pages = self.vmo.pages.lock();


### PR DESCRIPTION
When the new page cache was introduced, the original readahead mechanism was removed. This PR aims to restore that mechanism.

The readahead state is currently stored as a property of the file. This is reasonable and consistent with Linux, because whether the access pattern is sequential is effectively a per-file state. If it were implemented on the VMO instead, the sequential-read state could be disrupted by two files being read concurrently.

However, readahead triggered by page faults is not implemented yet, because `VmMapping` currently does not carry file information and therefore cannot access reusable state. One possible solution is to store a separate state in `MappedVmo`. Another possible solution, though it would require more substantial changes, is to make `VmMapping` store `Option<Arc<dyn FileLike>>` instead of `Option<Path>` as Linux does. Anyway, this part of the logic will likely be implemented in a separate PR.