### PR TITLE
Fix `epoll_pwait2` ignoring the sigsetsize argument

### DIFF
--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -404,7 +404,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);
             SYS_PIDFD_GETFD = 438            => sys_pidfd_getfd(args[..3]);
             SYS_FACCESSAT2 = 439             => sys_faccessat2(args[..4]);
-            SYS_EPOLL_PWAIT2 = 441           => sys_epoll_pwait2(args[..5]);
+            SYS_EPOLL_PWAIT2 = 441           => sys_epoll_pwait2(args[..6]);
             SYS_FCHMODAT2 = 452              => sys_fchmodat2(args[..4]);
             // Architecture-specific syscalls
             $( $name = $num => $handler $args );*

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -419,6 +419,6 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);
     SYS_PIDFD_GETFD = 438      => sys_pidfd_getfd(args[..3]);
     SYS_FACCESSAT2 = 439       => sys_faccessat2(args[..4]);
-    SYS_EPOLL_PWAIT2 = 441     => sys_epoll_pwait2(args[..5]);
+    SYS_EPOLL_PWAIT2 = 441     => sys_epoll_pwait2(args[..6]);
     SYS_FCHMODAT2 = 452        => sys_fchmodat2(args[..4]);
 }

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -216,11 +216,12 @@ pub fn sys_epoll_pwait2(
     max_events: i32,
     timeout_addr: Vaddr,
     sigmask: Vaddr,
+    sigmask_size: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!(
-        "epfd = {}, events_addr = 0x{:x}, max_events = {}, timeout_ts = 0x{:x}, sigmask = 0x{:x}",
-        epfd, events_addr, max_events, timeout_addr, sigmask,
+        "epfd = {}, events_addr = 0x{:x}, max_events = {}, timeout_ts = 0x{:x}, sigmask = 0x{:x}, sigmask_size = {}",
+        epfd, events_addr, max_events, timeout_addr, sigmask, sigmask_size,
     );
 
     let timeout: Option<Duration> = if timeout_addr == 0 {
@@ -231,7 +232,15 @@ pub fn sys_epoll_pwait2(
         Some(duration)
     };
 
-    let events_len = do_epoll_pwait2(epfd, events_addr, max_events, timeout, sigmask, 8, ctx)?;
+    let events_len = do_epoll_pwait2(
+        epfd,
+        events_addr,
+        max_events,
+        timeout,
+        sigmask,
+        sigmask_size,
+        ctx,
+    )?;
 
     Ok(SyscallReturn::Return(events_len as _))
 }

--- a/test/initramfs/src/regression/io/epoll/epoll_err.c
+++ b/test/initramfs/src/regression/io/epoll/epoll_err.c
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "../../common/test.h"
-#include <unistd.h>
+#include <signal.h>
 #include <sys/epoll.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
 
 FN_TEST(epoll_add_del)
 {
@@ -160,6 +163,52 @@ FN_TEST(epoll_flags_oneshot)
 	ev.data.fd = rfd;
 	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_MOD, rfd, &ev));
 	TEST_RES(epoll_wait(epfd, &ev, 1, 0), _ret == 1);
+
+	// Clean up
+	TEST_SUCC(close(epfd));
+	TEST_SUCC(close(rfd));
+	TEST_SUCC(close(wfd));
+}
+END_TEST()
+
+FN_TEST(epoll_pwait2_sigsetsize_invalid)
+{
+	int fildes[2];
+	int epfd, rfd, wfd;
+	struct epoll_event ev;
+	struct timespec ts = { 0, 0 };
+	sigset_t mask;
+
+	// Setup pipes
+	TEST_SUCC(pipe(fildes));
+	rfd = fildes[0];
+	wfd = fildes[1];
+
+	// Setup epoll
+	epfd = TEST_SUCC(epoll_create1(0));
+	ev.events = EPOLLIN;
+	ev.data.fd = rfd;
+	TEST_SUCC(epoll_ctl(epfd, EPOLL_CTL_ADD, rfd, &ev));
+
+	// Write something to the pipe
+	TEST_SUCC(write(wfd, "x", 1));
+
+	// If `sigmask` is specified, `sigsetsize` must be 8
+	sigemptyset(&mask);
+	TEST_ERRNO(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, &mask, 0),
+		   EINVAL);
+	TEST_ERRNO(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, &mask, 4),
+		   EINVAL);
+	TEST_RES(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, &mask, 8),
+		 _ret == 1);
+	TEST_ERRNO(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, &mask, 16),
+		   EINVAL);
+
+	// Otherwise, `sigsetsize` will be ignored
+	TEST_RES(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, NULL, 0),
+		 _ret == 1);
+	TEST_RES(syscall(SYS_epoll_pwait2, epfd, &ev, 1, &ts, NULL, 99),
+		 _ret == 1);
 
 	// Clean up
 	TEST_SUCC(close(epfd));


### PR DESCRIPTION
Added `sigmask_size: usize` parameter to `sys_epoll_pwait2` and pass it through to `do_epoll_pwait2` instead of hardcoding 8.
https://elixir.bootlin.com/linux/v6.15/source/kernel/signal.c#L3272-L3279
```c
int set_user_sigmask(const sigset_t __user *umask, size_t sigsetsize)
{
	sigset_t kmask;

	if (!umask)
		return 0;
	if (sigsetsize != sizeof(sigset_t))
		return -EINVAL;
```

Unlike #3382, this is the case that glibc hardcodes `8` in the wrapper. 
However, we still can directly call the syscall to bypass the glibc wrapper.
https://elixir.bootlin.com/glibc/glibc-2.43/source/sysdeps/unix/sysv/linux/epoll_pwait2.c#L22-L28
```c
int
__epoll_pwait2_time64 (int fd, struct epoll_event *ev, int maxev,
		       const struct __timespec64 *tmo, const sigset_t *s)
{
  /* The syscall only supports 64-bit time_t.  */
  return SYSCALL_CANCEL (epoll_pwait2, fd, ev, maxev, tmo, s, __NSIG_BYTES);
}
```