### PR TITLE
Replace `libflate` with `zune-inflate` for initramfs decompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "jhash",
  "keyable-arc",
  "lending-iterator",
- "libflate",
  "logo-ascii-art",
  "loongArch64",
  "lru",
@@ -245,6 +244,7 @@ dependencies = [
  "xarray",
  "xmas-elf",
  "zerocopy",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1145,15 +1145,14 @@ name = "linux-bzimage-setup"
 version = "0.18.0"
 dependencies = [
  "cfg-if",
- "libflate",
  "linux-boot-params",
  "log",
- "no_std_io2",
  "tdx-guest",
  "uart_16550",
  "uefi",
  "uefi-raw 0.14.0",
  "xmas-elf",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1762,6 +1761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,4 +2266,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ xmas-elf = "0.10.0"
 # Note: when updating the zerocopy version, 
 # also update it in `ostd/libs/ostd-pod/README.md`.
 zerocopy = { version = "0.8.34", features = [ "derive" ] }
+zune-inflate = { version = "0.2", default-features = false, features = ["gzip", "zlib"] }
 
 # Proc-macro dependencies
 proc-macro2 = { version = "1.0.95", features = ["span-locations"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -46,7 +46,6 @@ io-util.workspace = true
 jhash.workspace = true
 keyable-arc.workspace = true
 lending-iterator.workspace = true
-libflate.workspace = true
 logo-ascii-art.workspace = true
 lru.workspace = true
 no_std_io2.workspace = true
@@ -69,6 +68,7 @@ typeflags-util.workspace = true
 xarray.workspace = true
 xmas-elf.workspace = true
 zerocopy.workspace = true
+zune-inflate.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
 tdx-guest = { version = "0.2.4", optional = true }

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -1,31 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::borrow::Cow;
+
 use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
 use device_id::{DeviceId, MajorId, MinorId};
 use lending_iterator::LendingIterator;
-use libflate::gzip::Decoder as GZipDecoder;
 use no_std_io2::io::{Cursor, Read};
 use ostd::boot::boot_info;
+use zune_inflate::DeflateDecoder;
 
 use super::{
     file::{InodeMode, InodeType},
     vfs::path::{FsPath, PathResolver, is_dot},
 };
 use crate::{fs::vfs::inode::MknodType, prelude::*};
-
-struct BoxedReader<'a>(Box<dyn Read + 'a>);
-
-impl<'a> BoxedReader<'a> {
-    pub fn new(reader: Box<dyn Read + 'a>) -> Self {
-        BoxedReader(reader)
-    }
-}
-
-impl Read for BoxedReader<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> no_std_io2::io::Result<usize> {
-        self.0.read(buf)
-    }
-}
 
 /// Unpack and prepare the rootfs from the initramfs CPIO buffer.
 pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
@@ -36,16 +24,17 @@ pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
     let (reader, suffix) = match &initramfs_buf[..4] {
         // Gzip magic number: 0x1F 0x8B
         &[0x1F, 0x8B, _, _] => {
-            let gzip_decoder = GZipDecoder::new(initramfs_buf)
-                .map_err(|_| Error::with_message(Errno::EINVAL, "invalid gzip buffer"))?;
-            (BoxedReader::new(Box::new(gzip_decoder)), ".gz")
+            let decompressed = DeflateDecoder::new(initramfs_buf)
+                .decode_gzip()
+                .map_err(|_| Error::with_message(Errno::EINVAL, "gzip decompression failed"))?;
+            (Cow::Owned(decompressed), ".gz")
         }
-        _ => (BoxedReader::new(Box::new(Cursor::new(initramfs_buf))), ""),
+        _ => (Cow::Borrowed(initramfs_buf), ""),
     };
 
     println!("[kernel] unpacking initramfs.cpio{} to rootfs ...", suffix);
 
-    let mut decoder = CpioDecoder::new(reader);
+    let mut decoder = CpioDecoder::new(Cursor::new(reader));
 
     while let Some(entry_result) = decoder.next() {
         let mut entry = entry_result?;
@@ -58,8 +47,8 @@ pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
     Ok(())
 }
 
-fn try_append_entry_to_rootfs(
-    entry: &mut CpioEntry<BoxedReader>,
+fn try_append_entry_to_rootfs<R: Read>(
+    entry: &mut CpioEntry<R>,
     path_resolver: &PathResolver,
 ) -> Result<()> {
     // Make sure the name is a relative path, and is not end with "/".

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -14,12 +14,11 @@ path = "src/main.rs"
 
 [dependencies]
 cfg-if.workspace = true
-libflate.workspace = true
 linux-boot-params.workspace = true
 log.workspace = true
-no_std_io2.workspace = true
 uart_16550.workspace = true
 xmas-elf.workspace = true
+zune-inflate.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
 uefi = { version = "0.37.0", features = ["global_allocator", "panic_handler", "logger", "qemu"]}

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/decoder.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/decoder.rs
@@ -7,8 +7,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
-use libflate::{gzip, zlib};
-use no_std_io2::io::Read;
+use zune_inflate::DeflateDecoder;
 
 enum MagicNumber {
     Elf,
@@ -34,20 +33,10 @@ impl TryFrom<&[u8]> for MagicNumber {
 
 /// Detects the format used to encode the payload and decodes the payload accordingly.
 pub fn decode_payload(payload: &[u8]) -> Vec<u8> {
-    let mut kernel = Vec::new();
     let magic = MagicNumber::try_from(payload).unwrap();
     match magic {
-        MagicNumber::Elf => {
-            kernel = payload.to_vec();
-        }
-        MagicNumber::Gzip => {
-            let mut decoder = gzip::Decoder::new(payload).unwrap();
-            decoder.read_to_end(&mut kernel).unwrap();
-        }
-        MagicNumber::Zlib => {
-            let mut decoder = zlib::Decoder::new(payload).unwrap();
-            decoder.read_to_end(&mut kernel).unwrap();
-        }
+        MagicNumber::Elf => payload.to_vec(),
+        MagicNumber::Gzip => DeflateDecoder::new(payload).decode_gzip().unwrap(),
+        MagicNumber::Zlib => DeflateDecoder::new(payload).decode_zlib().unwrap(),
     }
-    kernel
 }


### PR DESCRIPTION
Decompression time comparison (average of 5 runs, in seconds):

### `make run_kernel` (initramfs.cpio.gz: 12M)

| Configuration | libflate | zune-inflate | Speedup |
|---|---|---|---|
| dev | 2.215s | 1.762s | 20.4% faster |
| release-lto | 0.133s | 0.094s | 29.3% faster |

### `make run_kernel ENABLE_BENCHMARK_TEST=true` (initramfs.cpio.gz: 32M)

| Configuration | libflate | zune-inflate | Speedup |
|---|---|---|---|
| dev | 5.941s | 4.675s | 21.3% faster |
| release-lto | 0.379s | 0.245s | 35.4% faster |

### `make run_kernel ENABLE_CONFORMANCE_TEST=true CONFORMANCE_TEST_SUITE=kselftest` (initramfs.cpio.gz: 121M)

| Configuration | libflate | zune-inflate | Speedup |
|---|---|---|---|
| dev | 22.958s | 22.881s | 0.3% faster |
| release-lto | 1.632s | 0.975s | 40.3% faster |

In release-lto builds, `zune-inflate` achieves **29-40% faster** decompression across all tested image sizes.

Dev builds gain ~20% for smaller images, but the advantage nearly disappears at 121M — likely because at that size the bottleneck shifts to memory allocation/copying rather than pure inflate computation.



