### PR TITLE
Fix futimesat with O_PATH fd

### DIFF
--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -8,7 +8,10 @@ use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
 use crate::{
     fs,
     fs::{
-        file::file_table::RawFileDesc,
+        file::{
+            StatusFlags,
+            file_table::{RawFileDesc, get_file_fast},
+        },
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
@@ -171,20 +174,8 @@ fn do_utimes(
         Some(pathname.to_string_lossy().into_owned())
     };
 
-    let path = {
-        let fs_path = if let Some(pathname) = pathname.as_ref() {
-            FsPath::from_fd_at(dirfd, pathname, EmptyPathStr::AllowIfFlag(flags.bits()))?
-        } else {
-            // Matches Linux `do_utimes_fd`: no flags are accepted when pathname is NULL.
-            if !flags.is_empty() {
-                return_errno_with_message!(
-                    Errno::EINVAL,
-                    "flags must be zero when pathname is NULL"
-                );
-            }
-            FsPath::from_fd(dirfd)?
-        };
-
+    let path = if let Some(pathname) = pathname.as_ref() {
+        let fs_path = FsPath::from_fd_at(dirfd, pathname, EmptyPathStr::AllowIfFlag(flags.bits()))?;
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();
         if flags.contains(UtimensFlags::AT_SYMLINK_NOFOLLOW) {
@@ -192,6 +183,21 @@ fn do_utimes(
         } else {
             path_resolver.lookup(&fs_path)?
         }
+    } else {
+        // Linux will reject non-zero flags and `O_PATH` files if the pathname is null.
+        // Reference: <https://elixir.bootlin.com/linux/v7.1/source/fs/utimes.c#L108>
+        if !flags.is_empty() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "flags must be zero when the pathname is NULL"
+            );
+        }
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, dirfd.try_into()?);
+        if file.status_flags().contains(StatusFlags::O_PATH) {
+            return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
+        }
+        file.path().clone()
     };
 
     vfs_utimes(&path, times)

--- a/test/initramfs/src/conformance/gvisor/blocklists/utimes_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/utimes_test
@@ -1,1 +1,0 @@
-FutimesatTest.OnNullPathWithOPath

--- a/test/initramfs/src/regression/fs/utimensat/utimensat.c
+++ b/test/initramfs/src/regression/fs/utimensat/utimensat.c
@@ -70,6 +70,21 @@ FN_TEST(legacy_null_pathname_with_nonzero_flag_returns_einval)
 }
 END_TEST()
 
+FN_TEST(utimensat_null_pathname_with_o_path_returns_ebadf)
+{
+	int opath_fd = TEST_SUCC(open(TEST_FILE, O_PATH));
+	struct timespec times[2] = {
+		{ .tv_sec = 10, .tv_nsec = 0 },
+		{ .tv_sec = 20, .tv_nsec = 0 },
+	};
+
+	TEST_ERRNO(syscall(SYS_utimensat, opath_fd, NULL, times, 0), EBADF);
+	TEST_SUCC(syscall(SYS_utimensat, opath_fd, "", times, AT_EMPTY_PATH));
+
+	TEST_SUCC(close(opath_fd));
+}
+END_TEST()
+
 FN_TEST(at_empty_path_on_o_path_symlink_updates_symlink)
 {
 	const char *symlink_path = "/tmp/utimensat_symlink";


### PR DESCRIPTION
## Summary

Fix `futimesat(fd, NULL, times)` to return `EBADF` when `fd` was opened with `O_PATH`.

## Changes

- Return `EBADF` for the legacy NULL-path `futimesat` case on `O_PATH` file descriptors.
- Add regression for `futimesat(fd, NULL, times)` with an `O_PATH` fd.
- Unblock the gVisor `FutimesatTest.OnNullPathWithOPath` case.

## Testing

- `./utimes_test --gtest_filter=FutimesatTest.OnNullPathWithOPath`

  ```text
  [  PASSED  ] 1 test.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  ```

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```