### PR TITLE
Add route/kernel per-namespace socket

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -20,7 +20,7 @@ use crate::{
         },
     },
     ipc::IpcNamespace,
-    net::uts_ns::UtsNamespace,
+    net::{net_ns::NetNamespace, uts_ns::UtsNamespace},
     prelude::*,
     process::{NsProxy, UserNamespace, posix_thread::AsPosixThread},
     thread::Thread,
@@ -52,13 +52,15 @@ enum NsProxyEntry {
     Ipc,
     /// The mount namespace.
     Mnt,
+    /// The network namespace.
+    Net,
     /// The UTS namespace.
     Uts,
 }
 
 impl NsProxyEntry {
     /// All supported `NsProxy`-backed namespace entries.
-    const ALL: &[Self] = &[Self::Cgroup, Self::Ipc, Self::Mnt, Self::Uts];
+    const ALL: &[Self] = &[Self::Cgroup, Self::Ipc, Self::Mnt, Self::Net, Self::Uts];
 
     /// Returns the filename of this namespace entry under `/proc/[pid]/ns/`.
     fn as_str(self) -> &'static str {
@@ -66,6 +68,7 @@ impl NsProxyEntry {
             Self::Cgroup => "cgroup",
             Self::Ipc => "ipc",
             Self::Mnt => "mnt",
+            Self::Net => "net",
             Self::Uts => "uts",
         }
     }
@@ -76,6 +79,7 @@ impl NsProxyEntry {
             "cgroup" => Some(Self::Cgroup),
             "ipc" => Some(Self::Ipc),
             "mnt" => Some(Self::Mnt),
+            "net" => Some(Self::Net),
             "uts" => Some(Self::Uts),
             _ => None,
         }
@@ -104,6 +108,11 @@ impl NsProxyEntry {
                 ns_proxy.mnt_ns().get_path(),
                 parent,
             ),
+            Self::Net => NsSymOps::<NetNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.net_ns().get_path(),
+                parent,
+            ),
             Self::Uts => NsSymOps::<UtsNamespace>::new_inode(
                 dir.clone(),
                 ns_proxy.uts_ns().get_path(),
@@ -124,6 +133,9 @@ fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<MountNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<NetNamespace>>() {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<UserNamespace>>() {

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -388,7 +388,6 @@ pub enum NsType {
     Cgroup,
     Ipc,
     Mnt,
-    #[expect(unused)]
     Net,
     #[expect(unused)]
     Pid,

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub mod iface;
+pub mod net_ns;
 pub mod socket;
 pub mod uts_ns;
 

--- a/kernel/src/net/net_ns.rs
+++ b/kernel/src/net/net_ns.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The network namespace.
+//!
+//! A network namespace isolates network resources (interfaces, routing tables,
+//! sockets, etc.) from other namespaces. Each namespace maintains its own
+//! independent set of network resources.
+//!
+//! The kernel-side netlink route socket is per-namespace, so that route
+//! queries see only the interfaces belonging to the calling namespace.
+
+use spin::Once;
+
+use crate::{
+    fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
+    net::socket::netlink::route::kernel::NetlinkRouteKernelSocket,
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+};
+
+/// The network namespace.
+///
+/// Each network namespace owns one kernel-side netlink route socket,
+/// which handles route requests (e.g. link/address queries) originating
+/// from user space within that namespace.
+pub struct NetNamespace {
+    /// The kernel-side netlink route socket for this namespace.
+    netlink_route_kernel: NetlinkRouteKernelSocket,
+    /// Owner user namespace.
+    owner: Arc<UserNamespace>,
+    /// Stashed dentry for nsfs.
+    stashed_dentry: StashedDentry,
+}
+
+impl NetNamespace {
+    /// Returns a reference to the singleton initial network namespace.
+    pub fn get_init_singleton() -> &'static Arc<NetNamespace> {
+        static INIT: Once<Arc<NetNamespace>> = Once::new();
+
+        INIT.call_once(|| {
+            let owner = UserNamespace::get_init_singleton().clone();
+            Self::new(owner)
+        })
+    }
+
+    fn new(owner: Arc<UserNamespace>) -> Arc<Self> {
+        let stashed_dentry = StashedDentry::new();
+        Arc::new(Self {
+            netlink_route_kernel: NetlinkRouteKernelSocket::new(),
+            owner,
+            stashed_dentry,
+        })
+    }
+
+    /// Clones a new network namespace from `self`.
+    pub fn new_clone(
+        &self,
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        owner.check_cap(CapSet::SYS_ADMIN, posix_thread)?;
+        Ok(Self::new(owner))
+    }
+
+    /// Returns the kernel-side netlink route socket for this namespace.
+    pub(in crate::net) fn netlink_route_kernel(&self) -> NetlinkRouteKernelSocket {
+        self.netlink_route_kernel
+    }
+}
+
+impl NsCommonOps for NetNamespace {
+    const TYPE: NsType = NsType::Net;
+
+    fn owner_user_ns(&self) -> Option<&Arc<UserNamespace>> {
+        Some(&self.owner)
+    }
+
+    fn parent(&self) -> Result<&Arc<Self>> {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "a network namespace does not have a parent namespace"
+        );
+    }
+
+    fn stashed_dentry(&self) -> &StashedDentry {
+        &self.stashed_dentry
+    }
+}

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -43,7 +43,7 @@ mod kobject_uevent;
 mod message;
 mod options;
 mod receiver;
-mod route;
+pub(in crate::net) mod route;
 mod table;
 
 pub use addr::{GroupIdSet, NetlinkSocketAddr};

--- a/kernel/src/net/socket/netlink/route/kernel/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/mod.rs
@@ -5,6 +5,8 @@
 
 use core::marker::PhantomData;
 
+use ostd::task::Task;
+
 use super::message::{RtnlMessage, RtnlSegment};
 use crate::{
     net::socket::netlink::{
@@ -15,16 +17,26 @@ use crate::{
     prelude::*,
 };
 
-mod addr;
-mod link;
-mod util;
+pub(in crate::net) mod addr;
+pub(in crate::net) mod link;
+pub(in crate::net) mod util;
 
-pub(super) struct NetlinkRouteKernelSocket {
+/// The kernel-side netlink route socket.
+///
+/// Each network namespace owns one instance of this socket, which handles
+/// netlink route requests (e.g. link/address queries) originating from
+/// user space within that namespace.
+///
+/// This is a zero-sized type (contains only `PhantomData`), so it is
+/// `Copy` — we can return it by value from a per-namespace lookup
+/// without needing `unsafe` lifetime extension.
+#[derive(Copy, Clone)]
+pub(in crate::net) struct NetlinkRouteKernelSocket {
     _private: PhantomData<()>,
 }
 
 impl NetlinkRouteKernelSocket {
-    const fn new() -> Self {
+    pub(in crate::net) const fn new() -> Self {
         Self {
             _private: PhantomData,
         }
@@ -70,9 +82,15 @@ impl NetlinkRouteKernelSocket {
     }
 }
 
-/// FIXME: NETLINK_ROUTE_KERNEL should be a per-network namespace socket
-static NETLINK_ROUTE_KERNEL: NetlinkRouteKernelSocket = NetlinkRouteKernelSocket::new();
-
-pub(super) fn get_netlink_route_kernel() -> &'static NetlinkRouteKernelSocket {
-    &NETLINK_ROUTE_KERNEL
+/// Returns the kernel-side netlink route socket for the current thread's
+/// network namespace.
+///
+/// `NetlinkRouteKernelSocket` is a zero-sized `Copy` type, so we return it
+/// by value from the per-namespace instance — no `unsafe` required.
+pub(super) fn get_netlink_route_kernel() -> NetlinkRouteKernelSocket {
+    let current_task = Task::current().unwrap();
+    let thread_local = current_task.as_thread_local().unwrap();
+    let ns_proxy_ref = thread_local.borrow_ns_proxy();
+    let ns_proxy = ns_proxy_ref.unwrap();
+    ns_proxy.net_ns().netlink_route_kernel()
 }

--- a/kernel/src/net/socket/netlink/route/mod.rs
+++ b/kernel/src/net/socket/netlink/route/mod.rs
@@ -7,7 +7,7 @@ pub(super) use message::RtnlMessage;
 use crate::net::socket::netlink::{common::NetlinkSocket, table::NetlinkRouteProtocol};
 
 mod bound;
-mod kernel;
+pub(in crate::net) mod kernel;
 mod message;
 
 pub type NetlinkRouteSocket = NetlinkSocket<NetlinkRouteProtocol>;

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -5,7 +5,7 @@ use spin::Once;
 use crate::{
     fs::{cgroupfs::CgroupNamespace, vfs::path::MountNamespace},
     ipc::IpcNamespace,
-    net::uts_ns::UtsNamespace,
+    net::{net_ns::NetNamespace, uts_ns::UtsNamespace},
     prelude::*,
     process::{CloneFlags, Process, UserNamespace, posix_thread::PosixThread},
 };
@@ -21,6 +21,7 @@ pub struct NsProxy {
     cgroup_ns: Arc<CgroupNamespace>,
     ipc_ns: Arc<IpcNamespace>,
     mnt_ns: Arc<MountNamespace>,
+    net_ns: Arc<NetNamespace>,
     uts_ns: Arc<UtsNamespace>,
 }
 
@@ -33,6 +34,7 @@ impl NsProxy {
                 cgroup_ns: CgroupNamespace::get_init_singleton().clone(),
                 ipc_ns: IpcNamespace::get_init_singleton().clone(),
                 mnt_ns: MountNamespace::get_init_singleton().clone(),
+                net_ns: NetNamespace::get_init_singleton().clone(),
                 uts_ns: UtsNamespace::get_init_singleton().clone(),
             })
         })
@@ -86,6 +88,11 @@ impl NsProxy {
             builder.mnt_ns(new_mnt_ns);
         }
 
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWNET) {
+            let new_net_ns = self.net_ns.new_clone(user_ns.clone(), posix_thread)?;
+            builder.net_ns(new_net_ns);
+        }
+
         if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
             let new_uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
             builder.uts_ns(new_uts_ns);
@@ -111,6 +118,11 @@ impl NsProxy {
         &self.mnt_ns
     }
 
+    /// Returns the associated network namespace.
+    pub fn net_ns(&self) -> &Arc<NetNamespace> {
+        &self.net_ns
+    }
+
     /// Returns the associated UTS namespace.
     pub fn uts_ns(&self) -> &Arc<UtsNamespace> {
         &self.uts_ns
@@ -126,6 +138,7 @@ pub struct NsProxyBuilder<'a> {
     cgroup_ns: Option<Arc<CgroupNamespace>>,
     ipc_ns: Option<Arc<IpcNamespace>>,
     mnt_ns: Option<Arc<MountNamespace>>,
+    net_ns: Option<Arc<NetNamespace>>,
     uts_ns: Option<Arc<UtsNamespace>>,
 }
 
@@ -137,6 +150,7 @@ impl<'a> NsProxyBuilder<'a> {
             cgroup_ns: None,
             ipc_ns: None,
             mnt_ns: None,
+            net_ns: None,
             uts_ns: None,
         }
     }
@@ -159,6 +173,12 @@ impl<'a> NsProxyBuilder<'a> {
         self
     }
 
+    /// Sets the new network namespace for the context being built.
+    pub fn net_ns(&mut self, net_ns: Arc<NetNamespace>) -> &mut Self {
+        self.net_ns = Some(net_ns);
+        self
+    }
+
     /// Sets the new UTS namespace for the context being built.
     pub fn uts_ns(&mut self, uts_ns: Arc<UtsNamespace>) -> &mut Self {
         self.uts_ns = Some(uts_ns);
@@ -172,18 +192,21 @@ impl<'a> NsProxyBuilder<'a> {
             cgroup_ns: new_cgroup,
             ipc_ns: new_ipc,
             mnt_ns: new_mnt,
+            net_ns: new_net,
             uts_ns: new_uts,
         } = self;
 
         let new_cgroup = new_cgroup.unwrap_or_else(|| old_proxy.cgroup_ns.clone());
         let new_ipc = new_ipc.unwrap_or_else(|| old_proxy.ipc_ns.clone());
         let new_mnt = new_mnt.unwrap_or_else(|| old_proxy.mnt_ns.clone());
+        let new_net = new_net.unwrap_or_else(|| old_proxy.net_ns.clone());
         let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
 
         NsProxy {
             cgroup_ns: new_cgroup,
             ipc_ns: new_ipc,
             mnt_ns: new_mnt,
+            net_ns: new_net,
             uts_ns: new_uts,
         }
     }
@@ -196,6 +219,7 @@ pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
     const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWCGROUP
         .union(CloneFlags::CLONE_NEWIPC)
         .union(CloneFlags::CLONE_NEWNS)
+        .union(CloneFlags::CLONE_NEWNET)
         .union(CloneFlags::CLONE_NEWUTS);
 
     let unsupported_flags =

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -18,7 +18,7 @@ use crate::{
         vfs::path::MountNamespace,
     },
     ipc::IpcNamespace,
-    net::uts_ns::UtsNamespace,
+    net::{net_ns::NetNamespace, uts_ns::UtsNamespace},
     prelude::*,
     process::{
         CloneFlags, ContextSetNsAdminApi, NsProxy, NsProxyBuilder, PidFile,
@@ -99,6 +99,11 @@ fn build_proxy_from_pid_file(
         set_mnt_ns(&mut builder, target_ns, ctx)?;
     }
 
+    if flags.contains(CloneFlags::CLONE_NEWNET) {
+        let target_ns = target_proxy.net_ns();
+        set_net_ns(&mut builder, target_ns, ctx)?;
+    }
+
     if flags.contains(CloneFlags::CLONE_NEWUTS) {
         let target_ns = target_proxy.uts_ns();
         set_uts_ns(&mut builder, target_ns, ctx)?;
@@ -139,6 +144,9 @@ fn build_proxy_from_ns_file(
         })?
         || try_apply_ns_from_inode::<MountNamespace>(inode_handle, flags, |ns| {
             set_mnt_ns(&mut builder, &ns, ctx)
+        })?
+        || try_apply_ns_from_inode::<NetNamespace>(inode_handle, flags, |ns| {
+            set_net_ns(&mut builder, &ns, ctx)
         })?
         || try_apply_ns_from_inode::<UtsNamespace>(inode_handle, flags, |ns| {
             set_uts_ns(&mut builder, &ns, ctx)
@@ -213,6 +221,18 @@ fn set_mnt_ns(
     // TODO: Are the checks above sufficient?
 
     builder.mnt_ns(target_ns.clone());
+
+    Ok(())
+}
+
+fn set_net_ns(
+    builder: &mut NsProxyBuilder,
+    target_ns: &Arc<NetNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    check_set_ns_perms(target_ns, ctx)?;
+
+    builder.net_ns(target_ns.clone());
 
     Ok(())
 }


### PR DESCRIPTION
https://www.gitlink.org.cn/competitions/track1_2026Asterinas

https://github.com/asterinas/ccf-open-inno-competition

<img width="986" height="74" alt="image" src="https://github.com/user-attachments/assets/19398bc7-a48b-4e3a-b943-161bdb843a84" />

Currently, there is a TODO indicating that it should be a per-namespace socket (kernel/src/net/socket/netlink/route/kernel/mod.rs:73)
If the NetlinkRouteKernelSocket returns a pointer, unsafe should be used, and it contains PhantomData, which is a zero-size type. Here, Copy is used