### PR TITLE
Make inode metadata queries fallible

### DIFF
--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -239,8 +239,8 @@ impl Inode for RootInode {
         Err(Error::new(Errno::EISDIR))
     }
 
-    fn metadata(&self) -> Metadata {
-        *self.metadata.read()
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(*self.metadata.read())
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -79,8 +79,8 @@ impl Inode for Ptmx {
         Ok(())
     }
 
-    fn metadata(&self) -> Metadata {
-        *self.metadata.read()
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(*self.metadata.read())
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -68,8 +68,8 @@ impl Inode for PtySlaveInode {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn metadata(&self) -> Metadata {
-        *self.metadata.read()
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(*self.metadata.read())
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -1422,7 +1422,7 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn metadata(&self) -> Metadata {
+    fn metadata(&self) -> Result<Metadata> {
         let inner = self.inner.read();
 
         let blk_size = inner.fs().sector_size();
@@ -1433,7 +1433,7 @@ impl Inode for ExfatInode {
             1
         };
 
-        Metadata {
+        Ok(Metadata {
             ino: inner.ino,
             size: inner.size,
             optimal_block_size: blk_size,
@@ -1449,7 +1449,7 @@ impl Inode for ExfatInode {
             container_dev_id: inner.fs().container_device_id(),
             self_dev_id: None,
             birth_at: Some(inner.crtime.as_duration().unwrap_or_default()),
-        }
+        })
     }
 
     fn type_(&self) -> InodeType {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -73,8 +73,8 @@ impl Inode for Ext2Inode {
         self.resize(new_size)
     }
 
-    fn metadata(&self) -> Metadata {
-        self.metadata()
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(self.metadata())
     }
 
     fn ino(&self) -> u64 {

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -471,10 +471,10 @@ impl OverlayInode {
         upper.resize(new_size)
     }
 
-    pub fn metadata(&self) -> Metadata {
-        let mut metadata = self.get_top_valid_inode().metadata();
+    pub fn metadata(&self) -> Result<Metadata> {
+        let mut metadata = self.get_top_valid_inode().metadata()?;
         metadata.ino = self.ino;
-        metadata
+        Ok(metadata)
     }
 
     pub fn ino(&self) -> u64 {
@@ -974,7 +974,7 @@ impl FileOps for OverlayInode {
 impl Inode for OverlayInode {
     fn size(&self) -> usize;
     fn resize(&self, new_size: usize) -> Result<()>;
-    fn metadata(&self) -> Metadata;
+    fn metadata(&self) -> Result<Metadata>;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn type_(&self) -> InodeType;

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -172,9 +172,9 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
-    fn metadata(&self) -> Metadata {
+    fn metadata(&self) -> Result<Metadata> {
         let owner_thread = self.inner.owner_thread();
-        self.common.metadata_with_owner(owner_thread)
+        Ok(self.common.metadata_with_owner(owner_thread))
     }
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -87,9 +87,9 @@ impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
-    fn metadata(&self) -> Metadata {
+    fn metadata(&self) -> Result<Metadata> {
         let owner_thread = self.inner.owner_thread();
-        self.common.metadata_with_owner(owner_thread)
+        Ok(self.common.metadata_with_owner(owner_thread))
     }
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/mod.rs
@@ -52,13 +52,9 @@ impl Common {
         self.fs.upgrade().unwrap()
     }
 
-    fn metadata(&self) -> Metadata {
-        *self.metadata.read()
-    }
-
     fn metadata_with_owner(&self, owner_thread: Option<Arc<Thread>>) -> Metadata {
         let Some(owner_thread) = owner_thread else {
-            return self.metadata();
+            return *self.metadata.read();
         };
 
         let credentials = owner_thread.as_posix_thread().unwrap().credentials();

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -84,9 +84,9 @@ impl<S: ProcSymOps + 'static> Inode for ProcSym<S> {
     fn set_ctime(&self, time: Duration);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
-    fn metadata(&self) -> Metadata {
+    fn metadata(&self) -> Result<Metadata> {
         let owner_thread = self.inner.owner_thread();
-        self.common.metadata_with_owner(owner_thread)
+        Ok(self.common.metadata_with_owner(owner_thread))
     }
 
     fn resize(&self, _new_size: usize) -> Result<()> {

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -271,8 +271,8 @@ impl Inode for PseudoInode {
         return_errno_with_message!(Errno::EINVAL, "pseudo inodes can not be resized");
     }
 
-    fn metadata(&self) -> Metadata {
-        *self.metadata.lock()
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(*self.metadata.lock())
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -105,7 +105,7 @@ impl<T: NsCommonOps> NsInode<T> {
 impl<T: NsCommonOps> Inode for NsInode<T> {
     fn size(&self) -> usize;
     fn resize(&self, _new_size: usize) -> Result<()>;
-    fn metadata(&self) -> Metadata;
+    fn metadata(&self) -> Result<Metadata>;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn type_(&self) -> InodeType;

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -1263,10 +1263,10 @@ impl Inode for RamInode {
         Ok(())
     }
 
-    fn metadata(&self) -> Metadata {
+    fn metadata(&self) -> Result<Metadata> {
         let rdev = self.inner.device_id().unwrap_or(0);
         let inode_metadata = self.metadata.lock();
-        Metadata {
+        Ok(Metadata {
             ino: self.ino as _,
             size: inode_metadata.size,
             optimal_block_size: BLOCK_SIZE,
@@ -1286,7 +1286,7 @@ impl Inode for RamInode {
                 DeviceId::from_encoded_u64(rdev)
             },
             birth_at: None,
-        }
+        })
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -148,7 +148,7 @@ impl FileOps for MemfdInode {
 
 #[inherit_methods(from = "self.inode")]
 impl Inode for MemfdInode {
-    fn metadata(&self) -> Metadata;
+    fn metadata(&self) -> Result<Metadata>;
     fn size(&self) -> usize;
     fn atime(&self) -> Duration;
     fn set_atime(&self, time: Duration);

--- a/kernel/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/file.rs
@@ -111,7 +111,7 @@ impl FileOps for VirtioFsFile {
         let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
 
         let write_offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            self.inode.revalidate_attr(fh)?;
+            self.inode.revalidate_attr(Some(fh))?;
             WriteOffset::Append
         } else {
             WriteOffset::Absolute(offset)
@@ -153,7 +153,7 @@ impl PerOpenFileOps for VirtioFsFile {
     fn seek_end(&self) -> Result<Option<usize>> {
         // The cached inode size may be stale. Refreshing attributes here keeps
         // `SEEK_END` consistent with the latest file size on the server.
-        self.inode.revalidate_attr(self.open_handle.fh())?;
+        self.inode.revalidate_attr(Some(self.open_handle.fh()))?;
 
         Ok(Some(self.inode.size()))
     }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -272,8 +272,8 @@ impl Inode for VirtioFsInode {
         self.setattr(setattr_req)
     }
 
-    fn metadata(&self) -> Metadata {
-        self.inner.read().metadata
+    fn metadata(&self) -> Result<Metadata> {
+        Ok(self.inner.read().metadata)
     }
 
     fn ino(&self) -> u64 {
@@ -285,7 +285,7 @@ impl Inode for VirtioFsInode {
     }
 
     fn mode(&self) -> Result<InodeMode> {
-        Ok(self.inner.read().metadata.mode)
+        Ok(self.metadata()?.mode)
     }
 
     fn set_mode(&self, mode: InodeMode) -> Result<()> {
@@ -295,7 +295,7 @@ impl Inode for VirtioFsInode {
     }
 
     fn owner(&self) -> Result<Uid> {
-        Ok(self.inner.read().metadata.uid)
+        Ok(self.metadata()?.uid)
     }
 
     fn set_owner(&self, uid: Uid) -> Result<()> {
@@ -304,7 +304,7 @@ impl Inode for VirtioFsInode {
     }
 
     fn group(&self) -> Result<Gid> {
-        Ok(self.inner.read().metadata.gid)
+        Ok(self.metadata()?.gid)
     }
 
     fn set_group(&self, gid: Gid) -> Result<()> {

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -273,6 +273,7 @@ impl Inode for VirtioFsInode {
     }
 
     fn metadata(&self) -> Result<Metadata> {
+        self.revalidate_attr(None)?;
         Ok(self.inner.read().metadata)
     }
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -58,7 +58,7 @@ impl VirtioFsInode {
         // so cached reads refresh attributes before checking the cached file size.
         // If this flag becomes optional, reads that stay below EOF should be allowed
         // to use still-valid cached attributes.
-        self.revalidate_attr(fh)?;
+        self.revalidate_attr(Some(fh))?;
 
         let inner = self.inner.read();
         let file_size = self.size();
@@ -89,7 +89,7 @@ impl VirtioFsInode {
         // FIXME: Direct reads do not support short reads yet, so `FUSE_READ`
         // must request the actual bytes to read instead of the caller's maximum
         // buffer size. Refresh attributes before using the cached file size.
-        self.revalidate_attr(fh)?;
+        self.revalidate_attr(Some(fh))?;
 
         let _inner = self.inner.read();
         let file_size = self.size();
@@ -605,7 +605,7 @@ impl VirtioFsInode {
     /// so the server may return handle-specific attributes.
     pub(in crate::fs::fs_impls::virtiofs) fn revalidate_attr(
         &self,
-        fh: FuseFileHandle,
+        fh: Option<FuseFileHandle>,
     ) -> Result<()> {
         let now = MonotonicCoarseClock::get().read_time();
         if self.inner.read().is_attr_valid(now) {
@@ -614,10 +614,13 @@ impl VirtioFsInode {
 
         let fs = self.fs_ref();
         let request_attr_version = fs.session().snapshot_attr_version();
-        let attr_reply = fs.session().do_fuse_op(
-            self.nodeid(),
-            GetattrOperation::new(GetattrReq::new(GetattrFlags::GETATTR_FH, fh)),
-        )?;
+        let getattr_req = match fh {
+            Some(fh) => GetattrReq::new(GetattrFlags::GETATTR_FH, fh),
+            None => GetattrReq::new(GetattrFlags::empty(), FuseFileHandle::new(0)),
+        };
+        let attr_reply = fs
+            .session()
+            .do_fuse_op(self.nodeid(), GetattrOperation::new(getattr_req))?;
 
         self.commit_attr_reply(attr_reply, request_attr_version, StaleAttrAction::Discard)?;
 

--- a/kernel/src/fs/pipe/anon_pipe.rs
+++ b/kernel/src/fs/pipe/anon_pipe.rs
@@ -78,7 +78,7 @@ impl FileOps for AnonPipeInode {
 impl Inode for AnonPipeInode {
     fn size(&self) -> usize;
     fn resize(&self, _new_size: usize) -> Result<()>;
-    fn metadata(&self) -> Metadata;
+    fn metadata(&self) -> Result<Metadata>;
     fn extension(&self) -> &Extension;
     fn ino(&self) -> u64;
     fn type_(&self) -> InodeType;

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -417,10 +417,10 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         self.metadata().type_
     }
 
-    default fn metadata(&self) -> Metadata {
+    default fn metadata(&self) -> Result<Metadata> {
         let mut metadata = *self.metadata();
         metadata.mode = self.mode().unwrap();
-        metadata
+        Ok(metadata)
     }
 
     default fn ino(&self) -> u64 {

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -357,7 +357,24 @@ pub trait Inode: Any + FileOps + Send + Sync {
 
     fn resize(&self, new_size: usize) -> Result<()>;
 
-    fn metadata(&self) -> Metadata;
+    /// Returns all inode metadata.
+    ///
+    /// This method returns all metadata fields and is typically used to serve
+    /// syscalls such as `fstat`. Callers must not assume that this operation
+    /// is always cheap. For example, remote filesystems may need to perform
+    /// I/O when getting or updating metadata, and such operations may fail.
+    ///
+    /// If only a specific field is needed, prefer using the dedicated getters
+    /// such as [`size`], [`ino`], [`type_`], [`mode`], [`owner`], and [`group`], which
+    /// are generally cheaper as they return cached data from the inode.
+    ///
+    /// [`size`]: Inode::size
+    /// [`ino`]: Inode::ino
+    /// [`type_`]: Inode::type_
+    /// [`mode`]: Inode::mode
+    /// [`owner`]: Inode::owner
+    /// [`group`]: Inode::group
+    fn metadata(&self) -> Result<Metadata>;
 
     fn ino(&self) -> u64;
 
@@ -562,7 +579,7 @@ pub trait Inode: Any + FileOps + Send + Sync {
         };
 
         let creds = posix_thread.credentials();
-        let metadata = self.metadata();
+        let metadata = self.metadata()?;
         let mode = metadata.mode;
 
         // With DAC_OVERRIDE capability, the user can bypass some permission checks.

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -97,7 +97,7 @@ impl<'a> FsCreationCtx<'a> {
         if !path.type_().is_device() {
             return_errno_with_message!(Errno::ENODEV, "the path is not a device file");
         }
-        let id = path.metadata().self_dev_id;
+        let id = path.metadata()?.self_dev_id;
 
         id.and_then(aster_block::lookup)
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -465,8 +465,8 @@ impl DirDentry<'_> {
         child
     }
 
-    fn has_sticky_bit(&self) -> bool {
-        self.inode.metadata().mode.has_sticky_bit()
+    fn has_sticky_bit(&self) -> Result<bool> {
+        Ok(self.inode.metadata()?.mode.has_sticky_bit())
     }
 
     fn check_sticky_bit_permission(&self, child_inode: &Arc<dyn Inode>) -> Result<()> {
@@ -475,8 +475,8 @@ impl DirDentry<'_> {
             return Ok(());
         };
 
-        let dir_metadata = self.inode.metadata();
-        let child_metadata = child_inode.metadata();
+        let dir_metadata = self.inode.metadata()?;
+        let child_metadata = child_inode.metadata()?;
         let fsuid = posix_thread.credentials().fsuid();
         if fsuid == dir_metadata.uid || fsuid == child_metadata.uid {
             return Ok(());
@@ -664,7 +664,7 @@ impl DirDentry<'_> {
         let dir_inode = self.inode();
         let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.unlink(name))?;
 
-        let nlinks = child_inode.metadata().nr_hard_links;
+        let nlinks = child_inode.metadata()?.nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
         if nlinks == 0 {
             // FIXME: `DELETE_SELF` should be generated after closing the last FD.
@@ -697,7 +697,7 @@ impl DirDentry<'_> {
         let dir_inode = self.inode();
         let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.rmdir(name))?;
 
-        let nlinks = child_inode.metadata().nr_hard_links;
+        let nlinks = child_inode.metadata()?.nr_hard_links;
         if nlinks == 0 {
             // FIXME: `DELETE_SELF` should be generated after closing the last FD.
             fs::vfs::notify::on_inode_removed(&child_inode);
@@ -808,7 +808,7 @@ impl DirDentry<'_> {
 
             Self::check_rename_mode(mode, new_dentry.as_ref())?;
 
-            if self.has_sticky_bit() {
+            if self.has_sticky_bit()? {
                 self.check_sticky_bit_permission(old_dentry.inode())?;
                 if let Some(new_dentry) = new_dentry.as_ref() {
                     self.check_sticky_bit_permission(new_dentry.inode())?;
@@ -855,10 +855,10 @@ impl DirDentry<'_> {
             Self::check_rename_mode(mode, new_dentry.as_ref())?;
             Self::check_rename_cycle(mode, self, &old_dentry, new_dir, new_dentry.as_ref())?;
 
-            if self.has_sticky_bit() {
+            if self.has_sticky_bit()? {
                 self.check_sticky_bit_permission(old_dentry.inode())?;
             }
-            if new_dir.has_sticky_bit()
+            if new_dir.has_sticky_bit()?
                 && let Some(new_dentry) = new_dentry.as_ref()
             {
                 new_dir.check_sticky_bit_permission(new_dentry.inode())?;

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -274,7 +274,7 @@ impl Path {
             return Ok(());
         };
 
-        let metadata = self.metadata();
+        let metadata = self.metadata()?;
         let fsuid = posix_thread.credentials().fsuid();
 
         // The source inode owner can hardlink all they like.
@@ -704,7 +704,7 @@ impl Path {
     pub fn fs(&self) -> Arc<dyn FileSystem>;
     pub fn sync_all(&self) -> Result<()>;
     pub fn sync_data(&self) -> Result<()>;
-    pub fn metadata(&self) -> Metadata;
+    pub fn metadata(&self) -> Result<Metadata>;
     pub fn mode(&self) -> Result<InodeMode>;
     pub fn set_mode(&self, mode: InodeMode) -> Result<()>;
     pub fn size(&self) -> usize;

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -252,7 +252,7 @@ fn from_c_flock_and_file(lock: &c_flock, file: &dyn FileLike) -> Result<FileRang
                 .checked_add(lock.l_start)
                 .ok_or(Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
 
-            RangeLockWhence::SEEK_END => (file.path().inode().metadata().size as off_t)
+            RangeLockWhence::SEEK_END => (file.path().inode().metadata()?.size as off_t)
                 .checked_add(lock.l_start)
                 .ok_or(Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
         }

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -22,7 +22,7 @@ pub fn sys_fstat(raw_fd: RawFileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Res
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
 
-    let stat = Stat::from(file.path().metadata());
+    let stat = Stat::from(file.path().metadata()?);
     ctx.user_space().write_val(stat_buf_ptr, &stat)?;
 
     Ok(SyscallReturn::Return(0))
@@ -72,7 +72,7 @@ pub fn sys_fstatat(
         }
     };
 
-    let stat = Stat::from(path.metadata());
+    let stat = Stat::from(path.metadata()?);
     user_space.write_val(stat_buf_ptr, &stat)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -62,7 +62,7 @@ pub fn sys_statx(
         }
     };
 
-    let statx = Statx::new(&path, mask);
+    let statx = Statx::new(&path, mask)?;
 
     user_space.write_val(statx_buf_ptr, &statx)?;
     Ok(SyscallReturn::Return(0))
@@ -122,8 +122,8 @@ pub struct Statx {
 }
 
 impl Statx {
-    fn new(path: &Path, requested_mask: StatxMask) -> Self {
-        let info = path.metadata();
+    fn new(path: &Path, requested_mask: StatxMask) -> Result<Self> {
+        let info = path.metadata()?;
 
         let (stx_dev_major, stx_dev_minor) =
             device_id::decode_device_numbers(info.container_dev_id.as_encoded_u64());
@@ -166,7 +166,7 @@ impl Statx {
             StatxTimestamp::default()
         };
 
-        Self {
+        Ok(Self {
             // FIXME: All zero fields below are dummy implementations that need to be improved in the future.
             stx_mask,
             stx_blksize: info.optimal_block_size as u32,
@@ -192,7 +192,7 @@ impl Statx {
             stx_dio_mem_align: 0,
             stx_dio_offset_align: 0,
             __spare3: [0; 12],
-        }
+        })
     }
 }
 

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -263,8 +263,11 @@ impl VmMapping {
         let offset = self.vmo().map(|vmo| vmo.offset).unwrap_or(0);
         let (dev_major, dev_minor) = self
             .inode()
-            .map(|inode| {
-                device_id::decode_device_numbers(inode.metadata().container_dev_id.as_encoded_u64())
+            .and_then(|inode| {
+                let metadata = inode.metadata().ok()?;
+                Some(device_id::decode_device_numbers(
+                    metadata.container_dev_id.as_encoded_u64(),
+                ))
             })
             .unwrap_or((0, 0));
         let ino = self.inode().map(|inode| inode.ino()).unwrap_or(0);


### PR DESCRIPTION
Close #3333

## Summary

  - Changes `Inode::metadata()` and `Path::metadata()` to return `Result<Metadata>`.
  - Documents that convenience inode metadata getters return `cached values`, while `metadata()` may be more expensive and should be used when callers need a `filesystem-validated` metadata snapshot.

## Note

- This PR only make inode metadata quiries falliable. Filesystem users of metadata revalidation are not implemented yet. Planned users include procfs (https://github.com/asterinas/asterinas/issues/3390) and virtio-fs.