### PR TITLE
Add NOREPLACE flag support for rename

### DIFF
--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -18,6 +18,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
+            path::RenameMode,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
     },
@@ -350,7 +351,13 @@ impl Inode for RootInode {
         Ok(inode)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        _mode: RenameMode,
+    ) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -32,7 +32,7 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, MknodType, SymbolicLink},
-            path::{is_dot, is_dot_or_dotdot, is_dotdot},
+            path::{RenameMode, is_dot, is_dot_or_dotdot, is_dotdot},
         },
     },
     prelude::*,
@@ -1283,16 +1283,23 @@ fn is_block_aligned(off: usize) -> bool {
 fn check_corner_cases_for_rename(
     old_inode: &Arc<ExfatInode>,
     exist_inode: &Arc<ExfatInode>,
+    is_exchange: bool,
 ) -> Result<()> {
     // Check for two corner cases here.
     let old_inode_is_dir = old_inode.inner.read().inode_type.is_directory();
-    // If old_inode represents a directory, the exist 'new_name' must represents a empty directory.
-    if old_inode_is_dir && !exist_inode.inner.read().is_empty_dir()? {
-        return_errno!(Errno::ENOTEMPTY)
+    let exist_inode_is_dir = exist_inode.inner.read().inode_type.is_directory();
+    // Type must match for both modes
+    if old_inode_is_dir != exist_inode_is_dir {
+        if old_inode_is_dir {
+            return_errno!(Errno::ENOTDIR)
+        } else {
+            return_errno!(Errno::EISDIR)
+        }
     }
-    // If old_inode represents a file, the exist 'new_name' must also represents a file.
-    if !old_inode_is_dir && exist_inode.inner.read().inode_type.is_directory() {
-        return_errno!(Errno::EISDIR)
+    // If not exchange mode, and old_inode represents a directory,
+    // the exist 'new_name' must represents a empty directory.
+    if !is_exchange && old_inode_is_dir && !exist_inode.inner.read().is_empty_dir()? {
+        return_errno!(Errno::ENOTEMPTY)
     }
     Ok(())
 }
@@ -1644,7 +1651,13 @@ impl Inode for ExfatInode {
         Ok(inode)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
         if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
             return_errno!(Errno::EISDIR);
         }
@@ -1674,42 +1687,103 @@ impl Inode for ExfatInode {
             .inner
             .read()
             .lookup_by_name(old_name, true, &fs_guard)?;
-        // FIXME: Users may be confused, since inode with the same upper case name will be removed.
-        let lookup_exist_result = target_
-            .inner
-            .read()
-            .lookup_by_name(new_name, false, &fs_guard);
-        // Check for the corner cases.
-        if let Ok(ref exist_inode) = lookup_exist_result {
-            check_corner_cases_for_rename(&old_inode, exist_inode)?;
-        }
 
-        // All checks are done here. This is a valid rename and it needs to modify the metadata.
-        self.delete_inode(old_inode.clone(), false, &fs_guard)?;
-        // Create the new dentries.
-        let new_inode =
-            target_.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
-        // Update metadata.
-        old_inode.copy_metadata_from(new_inode);
-        // Update its children's parent_hash.
-        old_inode.update_subdir_parent_hash(&fs_guard)?;
-        // Insert back.
-        let _ = fs.insert_inode(old_inode.clone());
-        // Remove the exist 'new_name' file.
-        if let Ok(exist_inode) = lookup_exist_result {
-            target_.delete_inode(exist_inode, true, &fs_guard)?;
+        if mode == RenameMode::Exchange {
+            // FIXME: Users may be confused, since inode with the same upper case name will be removed.
+            // Exchange mode: new_name must exist
+            let exist_inode = target_
+                .inner
+                .read()
+                .lookup_by_name(new_name, true, &fs_guard)?;
+            check_corner_cases_for_rename(&old_inode, &exist_inode, true)?;
+
+            // Perform exchange
+            // Step 1: Delete both entries from their parents (without freeing inodes)
+            self.delete_inode(old_inode.clone(), false, &fs_guard)?;
+            target_.delete_inode(exist_inode.clone(), false, &fs_guard)?;
+
+            // Step 2: Add them back in swapped positions
+            // Create the new dentries.
+            let new_old_inode =
+                target_.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
+            let new_exist_inode = self.add_entry(
+                old_name,
+                exist_inode.type_(),
+                exist_inode.mode()?,
+                &fs_guard,
+            )?;
+
+            // Step 3: Update metadata
+            old_inode.copy_metadata_from(new_old_inode);
+            exist_inode.copy_metadata_from(new_exist_inode);
+
+            // Step 4: Update children's parent_hash if needed
+            // Update its children's parent_hash.
+            old_inode.update_subdir_parent_hash(&fs_guard)?;
+            exist_inode.update_subdir_parent_hash(&fs_guard)?;
+
+            // Step 5: Insert back into inode cache
+            // Insert back.
+            let _ = fs.insert_inode(old_inode.clone());
+            let _ = fs.insert_inode(exist_inode.clone());
+
+            // Step 6: Update times
+            // Update the times.
+            self.inner.write().update_atime_and_mtime()?;
+            target_.inner.write().update_atime_and_mtime()?;
+            old_inode.inner.write().update_atime_and_mtime()?;
+            exist_inode.inner.write().update_atime_and_mtime()?;
+
+            // Step 7: Sync if needed
+            // Sync
+            if self.inner.read().is_sync() || target_.inner.read().is_sync() {
+                // TODO: what if fs crashed between syncing?
+                old_inode.inner.read().sync_all(&fs_guard)?;
+                exist_inode.inner.read().sync_all(&fs_guard)?;
+                target_.inner.read().sync_all(&fs_guard)?;
+                self.inner.read().sync_all(&fs_guard)?;
+            }
+
+            Ok(())
+        } else {
+            // Normal rename mode
+            // FIXME: Users may be confused, since inode with the same upper case name will be removed.
+            let lookup_exist_result = target_
+                .inner
+                .read()
+                .lookup_by_name(new_name, false, &fs_guard);
+            // Check for the corner cases.
+            if let Ok(ref exist_inode) = lookup_exist_result {
+                check_corner_cases_for_rename(&old_inode, exist_inode, false)?;
+            }
+
+            // All checks are done here. This is a valid rename and it needs to modify the metadata.
+            self.delete_inode(old_inode.clone(), false, &fs_guard)?;
+            // Create the new dentries.
+            let new_inode =
+                target_.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
+            // Update metadata.
+            old_inode.copy_metadata_from(new_inode);
+            // Update its children's parent_hash.
+            old_inode.update_subdir_parent_hash(&fs_guard)?;
+            // Insert back.
+            let _ = fs.insert_inode(old_inode.clone());
+            // Remove the exist 'new_name' file.
+            if let Ok(exist_inode) = lookup_exist_result {
+                target_.delete_inode(exist_inode, true, &fs_guard)?;
+            }
+            // Update the times.
+            self.inner.write().update_atime_and_mtime()?;
+            target_.inner.write().update_atime_and_mtime()?;
+            // Sync
+            if self.inner.read().is_sync() || target_.inner.read().is_sync() {
+                // TODO: what if fs crashed between syncing?
+                old_inode.inner.read().sync_all(&fs_guard)?;
+                target_.inner.read().sync_all(&fs_guard)?;
+                self.inner.read().sync_all(&fs_guard)?;
+            }
+            Ok(())
         }
-        // Update the times.
-        self.inner.write().update_atime_and_mtime()?;
-        target_.inner.write().update_atime_and_mtime()?;
-        // Sync
-        if self.inner.read().is_sync() || target_.inner.read().is_sync() {
-            // TODO: what if fs crashed between syncing?
-            old_inode.inner.read().sync_all(&fs_guard)?;
-            target_.inner.read().sync_all(&fs_guard)?;
-            self.inner.read().sync_all(&fs_guard)?;
-        }
-        Ok(())
     }
 
     fn read_link(&self) -> Result<SymbolicLink> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -21,6 +21,7 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
+            path::RenameMode,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -207,11 +208,18 @@ impl Inode for Ext2Inode {
         self.rmdir(name)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
         let target = target
             .downcast_ref::<Ext2Inode>()
             .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.rename(old_name, target, new_name)
+        // Use fully qualified syntax to call the inherent method, not the trait method
+        Ext2Inode::rename(self, old_name, target, new_name, mode)
     }
 
     fn read_link(&self) -> Result<SymbolicLink> {

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -11,7 +11,10 @@ mod dir_entry;
 
 use self::dir_entry::{DOT_BYTE, DOT_DOT_BYTE, DirBlockView, DirEntryFileType, DirEntryHeader};
 use super::{super::Ext2, FileFlags, FilePerm, Inode, InodeInner, MAX_LINK_COUNT};
-use crate::fs::ext2::{prelude::*, utils};
+use crate::fs::{
+    ext2::{prelude::*, utils},
+    vfs::path::RenameMode,
+};
 
 /// Information about a candidate directory entry slot.
 #[derive(Clone, Copy, Debug)]
@@ -235,6 +238,7 @@ impl Inode {
         old_name: &str,
         target: &Inode,
         new_name: &str,
+        mode: RenameMode,
     ) -> Result<()> {
         let fs = self.fs()?;
         let is_same_dir = self.ino == target.ino;
@@ -250,7 +254,14 @@ impl Inode {
         };
         let old_ino = old_info.ino;
         let old_inode = fs.read_inode(old_ino)?;
-        let replaced_inode = {
+        let replaced_inode = if mode == RenameMode::Exchange {
+            // For exchange, we need the new_name entry to exist
+            let new_info = {
+                let target_inner = target.inner.read();
+                target_inner.find_entry_info(new_name)?
+            };
+            Some(fs.read_inode(new_info.ino)?)
+        } else {
             let target_inner = target.inner.read();
             target_inner
                 .find_entry_info(new_name)
@@ -264,16 +275,26 @@ impl Inode {
         // lock all related inodes in order, without rechecking the lookup
         // result.
         // Step 2: lock all participating inodes in global ino order.
-        let lock_targets = [
-            self as &Inode,
-            target,
-            old_inode.as_ref(),
-            replaced_inode.as_deref().unwrap_or(old_inode.as_ref()),
-        ];
+        let lock_targets = if mode == RenameMode::Exchange {
+            let replaced_inode_ref = replaced_inode.as_ref().unwrap();
+            vec![
+                self as &Inode,
+                target,
+                old_inode.as_ref(),
+                replaced_inode_ref,
+            ]
+        } else {
+            vec![
+                self as &Inode,
+                target,
+                old_inode.as_ref(),
+                replaced_inode.as_deref().unwrap_or(old_inode.as_ref()),
+            ]
+        };
         let mut guards = MultiInodeInnerGuards::lock(&lock_targets);
 
         // Step 3: validate invariants under lock.
-        self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref())?;
+        self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref(), mode)?;
 
         // Step 4: apply directory mutations and metadata updates.
         self.apply_dir_mutations(
@@ -283,6 +304,7 @@ impl Inode {
             &old_inode,
             replaced_inode.as_deref(),
             new_name,
+            mode,
         )?;
 
         Ok(())
@@ -293,6 +315,7 @@ impl Inode {
         guards: &MultiInodeInnerGuards,
         old_inode: &Inode,
         replaced_inode: Option<&Inode>,
+        mode: RenameMode,
     ) -> Result<()> {
         // Step 3.1: sanity-check that the moved directory's `..` still
         // points to the source parent. A mismatch indicates on-disk
@@ -309,13 +332,16 @@ impl Inode {
         if let Some(replaced) = replaced_inode {
             let replaced_is_dir = replaced.type_ == InodeType::Dir;
             let old_is_dir = old_inode.type_ == InodeType::Dir;
-            if old_is_dir && !replaced_is_dir {
-                return_errno!(Errno::ENOTDIR);
+            if old_is_dir != replaced_is_dir {
+                // Type mismatch
+                if old_is_dir {
+                    return_errno!(Errno::ENOTDIR);
+                } else {
+                    return_errno!(Errno::EISDIR);
+                }
             }
-            if !old_is_dir && replaced_is_dir {
-                return_errno!(Errno::EISDIR);
-            }
-            if replaced_is_dir {
+            if !matches!(mode, RenameMode::Exchange) && replaced_is_dir {
+                // For non-exchange modes, replaced directory must be empty
                 let replaced_inner = guards.inner(replaced.ino());
                 if !replaced_inner.empty_dir(replaced.ino()) {
                     return_errno!(Errno::ENOTEMPTY);
@@ -326,6 +352,7 @@ impl Inode {
         Ok(())
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn apply_dir_mutations(
         &self,
         guards: &mut MultiInodeInnerGuards,
@@ -334,6 +361,7 @@ impl Inode {
         old_inode: &Inode,
         replaced_inode: Option<&Inode>,
         new_name: &str,
+        mode: RenameMode,
     ) -> Result<()> {
         let old_is_dir = old_inode.type_ == InodeType::Dir;
         let has_replaced = replaced_inode.is_some();
@@ -342,66 +370,125 @@ impl Inode {
         let moved_file_type = DirEntryFileType::from(old_inode.type_);
         let fs = self.fs()?;
 
-        // Step 4.1: apply directory entry mutations.
-        if is_same_dir {
-            let dir_inner = guards.inner_mut(self.ino);
-            if has_replaced {
+        if mode == RenameMode::Exchange {
+            let replaced_inode_ref = replaced_inode.unwrap();
+            let replaced_is_dir = replaced_inode_ref.type_ == InodeType::Dir;
+            let replaced_file_type = DirEntryFileType::from(replaced_inode_ref.type_);
+            let replaced_ino = replaced_inode_ref.ino();
+
+            if is_same_dir {
+                // Exchange in same directory
+                let dir_inner = guards.inner_mut(self.ino);
                 dir_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                dir_inner.overwrite_entry(old_name, replaced_ino, replaced_file_type)?;
+                dir_inner.set_mtime_ctime(utils::now());
             } else {
-                dir_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
-            }
-            // Re-read the source entry because `add_target_entry` may have
-            // split it (shrinking its `rec_len`), making any prior info stale.
-            let old_info = &dir_inner.find_entry_info(old_name)?;
-            dir_inner.delete_entry(old_info)?;
-            if old_is_dir && has_replaced {
-                dir_inner.dec_link_count(1);
-            }
-            dir_inner.set_mtime_ctime(utils::now());
-        } else {
-            let target_inner = guards.inner_mut(target.ino);
-            if has_replaced {
+                // Exchange between different directories
+                let target_inner = guards.inner_mut(target.ino);
                 target_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
-            } else {
-                target_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
-            }
-            if old_is_dir && !has_replaced {
-                target_inner.inc_link_count(1);
-            }
-            target_inner.set_mtime_ctime(utils::now());
-            let source_inner = guards.inner_mut(self.ino);
-            let old_info = &source_inner.find_entry_info(old_name)?;
-            source_inner.delete_entry(old_info)?;
-            if old_is_dir {
-                source_inner.dec_link_count(1);
-            }
-            source_inner.set_mtime_ctime(utils::now());
-        }
+                target_inner.set_mtime_ctime(utils::now());
 
-        // Step 4.2: update replaced inode link count.
-        if let Some(replaced) = replaced_inode {
-            let replaced_inner = guards.inner_mut(replaced.ino());
-            replaced_inner.set_ctime(utils::now());
-            if old_is_dir {
-                replaced_inner.dec_link_count(1);
-            }
-            replaced_inner.dec_link_count(1);
+                let source_inner = guards.inner_mut(self.ino);
+                source_inner.overwrite_entry(old_name, replaced_ino, replaced_file_type)?;
+                source_inner.set_mtime_ctime(utils::now());
 
-            if replaced_inner.link_count() == 0 {
-                replaced_inner.write_back_inode_desc(&fs, replaced.ino())?;
-                let _ = fs.remove_inode(replaced.ino());
+                // Update parent pointers if needed
+                if old_is_dir {
+                    let old_inner = guards.inner_mut(old_inode.ino());
+                    let dotdot_entry_info = old_inner.find_entry_info("..")?;
+                    old_inner.set_entry_target(
+                        &dotdot_entry_info,
+                        target.ino,
+                        DirEntryFileType::Dir,
+                    )?;
+                    old_inner.remove_flags(FileFlags::INDEX_DIR);
+                    old_inner.set_mtime_ctime(utils::now());
+                }
+                if replaced_is_dir {
+                    let replaced_inner = guards.inner_mut(replaced_inode_ref.ino());
+                    let dotdot_entry_info = replaced_inner.find_entry_info("..")?;
+                    replaced_inner.set_entry_target(
+                        &dotdot_entry_info,
+                        self.ino,
+                        DirEntryFileType::Dir,
+                    )?;
+                    replaced_inner.remove_flags(FileFlags::INDEX_DIR);
+                    replaced_inner.set_mtime_ctime(utils::now());
+                }
             }
-        }
 
-        // Step 4.3: update moved inode metadata.
-        let old_inner = guards.inner_mut(old_inode.ino());
-        if old_is_dir && !is_same_dir {
-            let dotdot_entry_info = old_inner.find_entry_info("..")?;
-            old_inner.set_entry_target(&dotdot_entry_info, target.ino, DirEntryFileType::Dir)?;
-            old_inner.remove_flags(FileFlags::INDEX_DIR);
-            old_inner.set_mtime_ctime(utils::now());
-        } else {
+            // Update ctime for both inodes
+            let old_inner = guards.inner_mut(old_inode.ino());
             old_inner.set_ctime(utils::now());
+            let replaced_inner = guards.inner_mut(replaced_inode_ref.ino());
+            replaced_inner.set_ctime(utils::now());
+        } else {
+            // Original non-exchange mode logic
+            // Step 4.1: apply directory entry mutations.
+            if is_same_dir {
+                let dir_inner = guards.inner_mut(self.ino);
+                if has_replaced {
+                    dir_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                } else {
+                    dir_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
+                }
+                // Re-read the source entry because `add_target_entry` may have
+                // split it (shrinking its `rec_len`), making any prior info stale.
+                let old_info = &dir_inner.find_entry_info(old_name)?;
+                dir_inner.delete_entry(old_info)?;
+                if old_is_dir && has_replaced {
+                    dir_inner.dec_link_count(1);
+                }
+                dir_inner.set_mtime_ctime(utils::now());
+            } else {
+                let target_inner = guards.inner_mut(target.ino);
+                if has_replaced {
+                    target_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                } else {
+                    target_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
+                }
+                if old_is_dir && !has_replaced {
+                    target_inner.inc_link_count(1);
+                }
+                target_inner.set_mtime_ctime(utils::now());
+                let source_inner = guards.inner_mut(self.ino);
+                let old_info = &source_inner.find_entry_info(old_name)?;
+                source_inner.delete_entry(old_info)?;
+                if old_is_dir {
+                    source_inner.dec_link_count(1);
+                }
+                source_inner.set_mtime_ctime(utils::now());
+            }
+
+            // Step 4.2: update replaced inode link count.
+            if let Some(replaced) = replaced_inode {
+                let replaced_inner = guards.inner_mut(replaced.ino());
+                replaced_inner.set_ctime(utils::now());
+                if old_is_dir {
+                    replaced_inner.dec_link_count(1);
+                }
+                replaced_inner.dec_link_count(1);
+
+                if replaced_inner.link_count() == 0 {
+                    replaced_inner.write_back_inode_desc(&fs, replaced.ino())?;
+                    let _ = fs.remove_inode(replaced.ino());
+                }
+            }
+
+            // Step 4.3: update moved inode metadata.
+            let old_inner = guards.inner_mut(old_inode.ino());
+            if old_is_dir && !is_same_dir {
+                let dotdot_entry_info = old_inner.find_entry_info("..")?;
+                old_inner.set_entry_target(
+                    &dotdot_entry_info,
+                    target.ino,
+                    DirEntryFileType::Dir,
+                )?;
+                old_inner.remove_flags(FileFlags::INDEX_DIR);
+                old_inner.set_mtime_ctime(utils::now());
+            } else {
+                old_inner.set_ctime(utils::now());
+            }
         }
 
         Ok(())

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -25,7 +25,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
-            path::{FsPath, Path},
+            path::{FsPath, Path, RenameMode},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -524,7 +524,13 @@ impl OverlayInode {
         upper.write_link(target)
     }
 
-    pub fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+    pub fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        _mode: RenameMode,
+    ) -> Result<()> {
         // TODO: Support the rename operation based on the `redirect_mode` feature,
         // rename the upper only may unexpectedly reveal the lower inodes.
         return_errno_with_message!(
@@ -993,7 +999,13 @@ impl Inode for OverlayInode {
     fn unlink(&self, name: &str) -> Result<()>;
     fn rmdir(&self, name: &str) -> Result<()>;
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>>;
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()>;
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()>;
     fn read_link(&self) -> Result<SymbolicLink>;
     fn write_link(&self, target: &str) -> Result<()>;
     fn sync_all(&self) -> Result<()>;

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -16,7 +16,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
-            path::{is_dot, is_dotdot},
+            path::{RenameMode, is_dot, is_dotdot},
         },
     },
     prelude::*,
@@ -214,7 +214,13 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
         self.inner.lookup_child(self, name)
     }
 
-    fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        _mode: RenameMode,
+    ) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -30,7 +30,7 @@ use crate::{
                 Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
                 SymbolicLink,
             },
-            path::{is_dot, is_dot_or_dotdot, is_dotdot},
+            path::{RenameMode, is_dot, is_dot_or_dotdot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -1093,7 +1093,13 @@ impl Inode for RamInode {
         Ok(inode as _)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
         if is_dot_or_dotdot(old_name) {
             return_errno_with_message!(Errno::EISDIR, "old_name is . or ..");
         }
@@ -1145,77 +1151,100 @@ impl Inode for RamInode {
                 Ok(())
             };
 
-        // Rename in the same directory
-        if self.ino == target.ino {
-            let mut self_dir = self.inner.as_direntry().unwrap().write();
-            let (src_idx, src_inode) = self_dir
-                .get_entry(old_name)
-                .ok_or(Error::new(Errno::ENOENT))?;
-            let is_dir = src_inode.typ == InodeType::Dir;
+        // Check for exchange compatibility
+        let check_exchange_inode = |inode1: &Arc<RamInode>, inode2: &Arc<RamInode>| -> Result<()> {
+            if inode1.ino == inode2.ino {
+                return Ok(());
+            }
 
-            if let Some((dst_idx, dst_inode)) = self_dir.get_entry(new_name) {
-                check_replace_inode(&src_inode, &dst_inode)?;
-                self_dir.remove_entry(dst_idx);
-                self_dir.substitute_entry(src_idx, (CStr256::from(new_name), src_inode.clone()));
+            // For exchange, both must be either directories or non-directories
+            if (inode1.typ == InodeType::Dir) != (inode2.typ == InodeType::Dir) {
+                if inode1.typ == InodeType::Dir {
+                    return_errno_with_message!(Errno::ENOTDIR, "new path is not a directory");
+                } else {
+                    return_errno_with_message!(Errno::EISDIR, "new path is a directory");
+                }
+            }
+            Ok(())
+        };
+
+        if mode == RenameMode::Exchange {
+            // Exchange mode
+            if self.ino == target.ino {
+                // Exchange in the same directory
+                let mut self_dir = self.inner.as_direntry().unwrap().write();
+                let (src_idx, src_inode) = self_dir
+                    .get_entry(old_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+                let (dst_idx, dst_inode) = self_dir
+                    .get_entry(new_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+
+                check_exchange_inode(&src_inode, &dst_inode)?;
+
+                // Exchange the entries
+                let old_entry = self_dir.remove_entry(src_idx).unwrap();
+                let new_entry = self_dir.remove_entry(dst_idx).unwrap();
+
+                self_dir.append_entry(old_name, new_entry.1.clone());
+                self_dir.append_entry(new_name, old_entry.1.clone());
+
                 drop(self_dir);
 
                 let now = now();
                 let mut self_meta = self.metadata.lock();
-                self_meta.dec_size();
-                if is_dir {
-                    self_meta.dec_nlinks();
-                }
                 self_meta.set_mtime(now);
                 self_meta.set_ctime(now);
                 drop(self_meta);
                 src_inode.set_ctime(now);
                 dst_inode.set_ctime(now);
-            } else {
-                self_dir.substitute_entry(src_idx, (CStr256::from(new_name), src_inode.clone()));
-                drop(self_dir);
-                let now = now();
-                let mut self_meta = self.metadata.lock();
-                self_meta.set_mtime(now);
-                self_meta.set_ctime(now);
-                drop(self_meta);
-                src_inode.set_ctime(now);
-            }
-        }
-        // Or rename across different directories
-        else {
-            let (mut self_dir, mut target_dir) = write_lock_two_direntries_by_ino(
-                (self.ino, self.inner.as_direntry().unwrap()),
-                (target.ino, target.inner.as_direntry().unwrap()),
-            );
-            let self_inode_arc = self.this.upgrade().unwrap();
-            let target_inode_arc = target.this.upgrade().unwrap();
-            let (src_idx, src_inode) = self_dir
-                .get_entry(old_name)
-                .ok_or(Error::new(Errno::ENOENT))?;
-            // Avoid renaming a directory to a subdirectory of itself
-            if Arc::ptr_eq(&src_inode, &target_inode_arc) {
-                return_errno!(Errno::EINVAL);
-            }
-            let is_dir = src_inode.typ == InodeType::Dir;
 
-            if let Some((dst_idx, dst_inode)) = target_dir.get_entry(new_name) {
-                // Avoid renaming a subdirectory to a directory.
-                if Arc::ptr_eq(&self_inode_arc, &dst_inode) {
-                    return_errno!(Errno::ENOTEMPTY);
+                // If exchanging directories, update their parent pointers
+                let _src_is_dir = src_inode.typ == InodeType::Dir;
+                let _dst_is_dir = dst_inode.typ == InodeType::Dir;
+                // Since we're in same directory, no need to change parent pointers
+                // but we should update ctime regardless
+            } else {
+                // Exchange across different directories
+                let (mut self_dir, mut target_dir) = write_lock_two_direntries_by_ino(
+                    (self.ino, self.inner.as_direntry().unwrap()),
+                    (target.ino, target.inner.as_direntry().unwrap()),
+                );
+                let self_inode_arc = self.this.upgrade().unwrap();
+                let target_inode_arc = target.this.upgrade().unwrap();
+                let (src_idx, src_inode) = self_dir
+                    .get_entry(old_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+                let (dst_idx, dst_inode) = target_dir
+                    .get_entry(new_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+
+                // Check for circular references
+                let src_is_dir = src_inode.typ == InodeType::Dir;
+                let dst_is_dir = dst_inode.typ == InodeType::Dir;
+
+                // Check if swapping would create a circular reference
+                if src_is_dir && Arc::ptr_eq(&target_inode_arc, &src_inode) {
+                    return_errno!(Errno::EINVAL);
                 }
-                check_replace_inode(&src_inode, &dst_inode)?;
-                self_dir.remove_entry(src_idx);
-                target_dir.remove_entry(dst_idx);
-                target_dir.append_entry(new_name, src_inode.clone());
+                if dst_is_dir && Arc::ptr_eq(&self_inode_arc, &dst_inode) {
+                    return_errno!(Errno::EINVAL);
+                }
+
+                check_exchange_inode(&src_inode, &dst_inode)?;
+
+                // Exchange the entries
+                let src_entry = self_dir.remove_entry(src_idx).unwrap();
+                let dst_entry = target_dir.remove_entry(dst_idx).unwrap();
+
+                target_dir.append_entry(new_name, src_entry.1.clone());
+                self_dir.append_entry(old_name, dst_entry.1.clone());
+
                 drop(self_dir);
                 drop(target_dir);
 
                 let now = now();
                 let mut self_meta = self.metadata.lock();
-                self_meta.dec_size();
-                if is_dir {
-                    self_meta.dec_nlinks();
-                }
                 self_meta.set_mtime(now);
                 self_meta.set_ctime(now);
                 drop(self_meta);
@@ -1223,42 +1252,146 @@ impl Inode for RamInode {
                 target_meta.set_mtime(now);
                 target_meta.set_ctime(now);
                 drop(target_meta);
+                src_inode.set_ctime(now);
                 dst_inode.set_ctime(now);
-                src_inode.set_ctime(now);
-            } else {
-                self_dir.remove_entry(src_idx);
-                target_dir.append_entry(new_name, src_inode.clone());
-                drop(self_dir);
-                drop(target_dir);
 
-                let now = now();
-                let mut self_meta = self.metadata.lock();
-                self_meta.dec_size();
-                if is_dir {
-                    self_meta.dec_nlinks();
+                // Update directory parent pointers if needed
+                if src_is_dir {
+                    src_inode
+                        .inner
+                        .as_direntry()
+                        .unwrap()
+                        .write()
+                        .set_parent(target.this.clone());
                 }
-                self_meta.set_mtime(now);
-                self_meta.set_ctime(now);
-                drop(self_meta);
-
-                let mut target_meta = target.metadata.lock();
-                target_meta.inc_size();
-                if is_dir {
-                    target_meta.inc_nlinks();
+                if dst_is_dir {
+                    dst_inode
+                        .inner
+                        .as_direntry()
+                        .unwrap()
+                        .write()
+                        .set_parent(self.this.clone());
                 }
-                target_meta.set_mtime(now);
-                target_meta.set_ctime(now);
-                drop(target_meta);
-                src_inode.set_ctime(now);
             }
+        } else {
+            // Original non-exchange mode logic
+            // Rename in the same directory
+            if self.ino == target.ino {
+                let mut self_dir = self.inner.as_direntry().unwrap().write();
+                let (src_idx, src_inode) = self_dir
+                    .get_entry(old_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+                let is_dir = src_inode.typ == InodeType::Dir;
 
-            if is_dir {
-                src_inode
-                    .inner
-                    .as_direntry()
-                    .unwrap()
-                    .write()
-                    .set_parent(target.this.clone());
+                if let Some((dst_idx, dst_inode)) = self_dir.get_entry(new_name) {
+                    check_replace_inode(&src_inode, &dst_inode)?;
+                    self_dir.remove_entry(dst_idx);
+                    self_dir
+                        .substitute_entry(src_idx, (CStr256::from(new_name), src_inode.clone()));
+                    drop(self_dir);
+
+                    let now = now();
+                    let mut self_meta = self.metadata.lock();
+                    self_meta.dec_size();
+                    if is_dir {
+                        self_meta.dec_nlinks();
+                    }
+                    self_meta.set_mtime(now);
+                    self_meta.set_ctime(now);
+                    drop(self_meta);
+                    src_inode.set_ctime(now);
+                    dst_inode.set_ctime(now);
+                } else {
+                    self_dir
+                        .substitute_entry(src_idx, (CStr256::from(new_name), src_inode.clone()));
+                    drop(self_dir);
+                    let now = now();
+                    let mut self_meta = self.metadata.lock();
+                    self_meta.set_mtime(now);
+                    self_meta.set_ctime(now);
+                    drop(self_meta);
+                    src_inode.set_ctime(now);
+                }
+            }
+            // Or rename across different directories
+            else {
+                let (mut self_dir, mut target_dir) = write_lock_two_direntries_by_ino(
+                    (self.ino, self.inner.as_direntry().unwrap()),
+                    (target.ino, target.inner.as_direntry().unwrap()),
+                );
+                let self_inode_arc = self.this.upgrade().unwrap();
+                let target_inode_arc = target.this.upgrade().unwrap();
+                let (src_idx, src_inode) = self_dir
+                    .get_entry(old_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+                // Avoid renaming a directory to a subdirectory of itself
+                if Arc::ptr_eq(&src_inode, &target_inode_arc) {
+                    return_errno!(Errno::EINVAL);
+                }
+                let is_dir = src_inode.typ == InodeType::Dir;
+
+                if let Some((dst_idx, dst_inode)) = target_dir.get_entry(new_name) {
+                    // Avoid renaming a subdirectory to a directory.
+                    if Arc::ptr_eq(&self_inode_arc, &dst_inode) {
+                        return_errno!(Errno::ENOTEMPTY);
+                    }
+                    check_replace_inode(&src_inode, &dst_inode)?;
+                    self_dir.remove_entry(src_idx);
+                    target_dir.remove_entry(dst_idx);
+                    target_dir.append_entry(new_name, src_inode.clone());
+                    drop(self_dir);
+                    drop(target_dir);
+
+                    let now = now();
+                    let mut self_meta = self.metadata.lock();
+                    self_meta.dec_size();
+                    if is_dir {
+                        self_meta.dec_nlinks();
+                    }
+                    self_meta.set_mtime(now);
+                    self_meta.set_ctime(now);
+                    drop(self_meta);
+                    let mut target_meta = target.metadata.lock();
+                    target_meta.set_mtime(now);
+                    target_meta.set_ctime(now);
+                    drop(target_meta);
+                    dst_inode.set_ctime(now);
+                    src_inode.set_ctime(now);
+                } else {
+                    self_dir.remove_entry(src_idx);
+                    target_dir.append_entry(new_name, src_inode.clone());
+                    drop(self_dir);
+                    drop(target_dir);
+
+                    let now = now();
+                    let mut self_meta = self.metadata.lock();
+                    self_meta.dec_size();
+                    if is_dir {
+                        self_meta.dec_nlinks();
+                    }
+                    self_meta.set_mtime(now);
+                    self_meta.set_ctime(now);
+                    drop(self_meta);
+
+                    let mut target_meta = target.metadata.lock();
+                    target_meta.inc_size();
+                    if is_dir {
+                        target_meta.inc_nlinks();
+                    }
+                    target_meta.set_mtime(now);
+                    target_meta.set_ctime(now);
+                    drop(target_meta);
+                    src_inode.set_ctime(now);
+                }
+
+                if is_dir {
+                    src_inode
+                        .inner
+                        .as_direntry()
+                        .unwrap()
+                        .write()
+                        .set_parent(target.this.clone());
+                }
             }
         }
         Ok(())

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -44,6 +44,7 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, RevalidationPolicy, SymbolicLink},
+            path::RenameMode,
         },
     },
     prelude::*,
@@ -450,7 +451,16 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
+        if mode == RenameMode::Exchange {
+            return_errno_with_message!(Errno::EINVAL, "exchange not supported");
+        }
         let target = target.downcast_ref::<VirtioFsInode>().unwrap();
 
         let fs = self.fs_ref();

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -17,6 +17,7 @@ use crate::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RevalidationPolicy,
                 SymbolicLink,
             },
+            path::RenameMode,
         },
     },
     prelude::*,
@@ -548,6 +549,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         _old_name: &str,
         _target: &Arc<dyn Inode>,
         _new_name: &str,
+        _mode: RenameMode,
     ) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -19,7 +19,7 @@ use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags},
         utils::DirentVisitor,
-        vfs::path::Path,
+        vfs::path::{Path, RenameMode},
     },
     prelude::*,
     process::{
@@ -419,7 +419,13 @@ pub trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::ENOTDIR))
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -8,7 +8,7 @@ use core::{
 use hashbrown::HashMap;
 use ostd::sync::{RwMutexUpgradeableGuard, RwMutexWriteGuard};
 
-use super::{is_dot, is_dot_or_dotdot, is_dotdot};
+use super::{RenameMode, is_dot, is_dot_or_dotdot, is_dotdot};
 use crate::{
     fs::{
         self,
@@ -677,66 +677,194 @@ impl DirDentry<'_> {
     }
 
     /// Renames a `Dentry` to the new `Dentry` by `rename()` the inner inode.
+    ///
+    /// When `mode` is `RenameMode::NoReplace`, the operation fails with
+    /// `EEXIST` if the target `new_name` already exists. This check is
+    /// performed under the dentry write lock to avoid TOCTOU races.
     pub(super) fn rename(
         old_dir_arc: &Arc<Dentry>,
         old_name: &str,
         new_dir_arc: &Arc<Dentry>,
         new_name: &str,
+        mode: RenameMode,
     ) -> Result<()> {
         let old_dir = old_dir_arc.as_dir_dentry_or_err()?;
         let new_dir = new_dir_arc.as_dir_dentry_or_err()?;
 
-        if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
-            return_errno_with_message!(Errno::EISDIR, "old_name or new_name is a directory");
+        if is_dot_or_dotdot(old_name) {
+            return_errno_with_message!(Errno::EBUSY, "old_name is . or ..");
+        }
+        if is_dot_or_dotdot(new_name) {
+            let errno = if mode == RenameMode::NoReplace {
+                Errno::EEXIST
+            } else {
+                Errno::EBUSY
+            };
+            return_errno_with_message!(errno, "new_name is . or ..");
         }
 
         let old_dir_inode = old_dir.inode();
         let new_dir_inode = new_dir.inode();
 
-        // The two are the same dentry, we just modify the name
-        if Arc::ptr_eq(old_dir_arc, new_dir_arc) {
-            if old_name == new_name {
-                return Ok(());
-            }
+        if mode == RenameMode::Exchange {
+            // The two are the same dentry, exchange two names
+            if Arc::ptr_eq(old_dir_arc, new_dir_arc) {
+                if old_name == new_name {
+                    return Ok(());
+                }
 
-            let mut children = old_dir.children.write();
-            children.check_mountpoint(new_name)?;
-            let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
+                let mut children = old_dir.children.write();
+                children.check_mountpoint(old_name)?;
+                children.check_mountpoint(new_name)?;
+                let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
+                let new_dentry = children.probe_cached_child_for_rename(&old_dir, new_name)?;
 
-            old_dir_inode.rename(old_name, old_dir_inode, new_name)?;
+                old_dir_inode.rename(old_name, old_dir_inode, new_name, mode)?;
 
-            match old_dentry.as_ref() {
-                Some(dentry) => {
+                // Update dentries: swap their positions
+                if let (Some(old_dentry), Some(new_dentry)) =
+                    (old_dentry.as_ref(), new_dentry.as_ref())
+                {
+                    // Remove both from the cache
                     children.delete(old_name);
-                    dentry
+                    children.delete(new_name);
+                    // Swap names and parents (though same parent)
+                    old_dentry
                         .name_and_parent
                         .set(new_name, old_dir_arc.clone())
                         .unwrap();
-                    old_dir.insert_positive_child(&mut children, new_name, dentry.clone());
-                }
-                None => {
+                    new_dentry
+                        .name_and_parent
+                        .set(old_name, old_dir_arc.clone())
+                        .unwrap();
+                    // Reinsert them with swapped names
+                    old_dir.insert_positive_child(&mut children, new_name, old_dentry.clone());
+                    old_dir.insert_positive_child(&mut children, old_name, new_dentry.clone());
+                } else {
+                    // Handle cases where one or both weren't cached
+                    // Just remove both cached entries (if any) to let them be re-looked up
+                    children.remove(old_name);
                     children.remove(new_name);
                 }
-            }
-        } else {
-            // The two are different dentries
-            let (mut self_children, mut new_dir_children) =
-                write_lock_children_on_two_dentries(&old_dir, &new_dir);
-            let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
-            new_dir_children.check_mountpoint(new_name)?;
+            } else {
+                // The two are different dentries, exchange across them
+                let (mut self_children, mut new_dir_children) =
+                    write_lock_children_on_two_dentries(&old_dir, &new_dir);
+                let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
+                let new_dentry =
+                    new_dir_children.probe_cached_child_for_rename(&new_dir, new_name)?;
+                self_children.check_mountpoint(old_name)?;
+                new_dir_children.check_mountpoint(new_name)?;
 
-            old_dir_inode.rename(old_name, new_dir_inode, new_name)?;
-            match old_dentry.as_ref() {
-                Some(dentry) => {
+                old_dir_inode.rename(old_name, new_dir_inode, new_name, mode)?;
+
+                // Update dentries: swap their positions
+                if let (Some(old_dentry), Some(new_dentry)) =
+                    (old_dentry.as_ref(), new_dentry.as_ref())
+                {
+                    // Remove both from the cache
                     self_children.delete(old_name);
-                    dentry
+                    new_dir_children.delete(new_name);
+                    // Swap names and parents
+                    old_dentry
                         .name_and_parent
                         .set(new_name, new_dir_arc.clone())
                         .unwrap();
-                    new_dir.insert_positive_child(&mut new_dir_children, new_name, dentry.clone());
-                }
-                None => {
+                    new_dentry
+                        .name_and_parent
+                        .set(old_name, old_dir_arc.clone())
+                        .unwrap();
+                    // Reinsert them in new locations
+                    new_dir.insert_positive_child(
+                        &mut new_dir_children,
+                        new_name,
+                        old_dentry.clone(),
+                    );
+                    old_dir.insert_positive_child(&mut self_children, old_name, new_dentry.clone());
+                } else {
+                    // Handle cases where one or both weren't cached
+                    self_children.remove(old_name);
                     new_dir_children.remove(new_name);
+                }
+            }
+        } else {
+            // Original non-exchange mode logic
+            // The two are the same dentry, we just modify the name
+            if Arc::ptr_eq(old_dir_arc, new_dir_arc) {
+                if old_name == new_name {
+                    match mode {
+                        RenameMode::Replace => return Ok(()),
+                        RenameMode::NoReplace => {
+                            return_errno_with_message!(
+                                Errno::EEXIST,
+                                "the new path already exists"
+                            );
+                        }
+                        RenameMode::Exchange => unreachable!(),
+                    };
+                }
+
+                let mut children = old_dir.children.write();
+                children.check_mountpoint(new_name)?;
+                if mode == RenameMode::NoReplace {
+                    let target_exists = match children.find(new_name) {
+                        Some(entry) => entry.is_positive(),
+                        None => old_dir_inode.lookup(new_name).is_ok(),
+                    };
+                    if target_exists {
+                        return_errno_with_message!(Errno::EEXIST, "the new path already exists");
+                    }
+                }
+                let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
+
+                old_dir_inode.rename(old_name, old_dir_inode, new_name, mode)?;
+
+                match old_dentry.as_ref() {
+                    Some(dentry) => {
+                        children.delete(old_name);
+                        dentry
+                            .name_and_parent
+                            .set(new_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(&mut children, new_name, dentry.clone());
+                    }
+                    None => {
+                        children.remove(new_name);
+                    }
+                }
+            } else {
+                // The two are different dentries
+                let (mut self_children, mut new_dir_children) =
+                    write_lock_children_on_two_dentries(&old_dir, &new_dir);
+                let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
+                new_dir_children.check_mountpoint(new_name)?;
+                if mode == RenameMode::NoReplace {
+                    let target_exists = match new_dir_children.find(new_name) {
+                        Some(entry) => entry.is_positive(),
+                        None => new_dir_inode.lookup(new_name).is_ok(),
+                    };
+                    if target_exists {
+                        return_errno_with_message!(Errno::EEXIST, "the new path already exists");
+                    }
+                }
+
+                old_dir_inode.rename(old_name, new_dir_inode, new_name, mode)?;
+                match old_dentry.as_ref() {
+                    Some(dentry) => {
+                        self_children.delete(old_name);
+                        dentry
+                            .name_and_parent
+                            .set(new_name, new_dir_arc.clone())
+                            .unwrap();
+                        new_dir.insert_positive_child(
+                            &mut new_dir_children,
+                            new_name,
+                            dentry.clone(),
+                        );
+                    }
+                    None => {
+                        new_dir_children.remove(new_name);
+                    }
                 }
             }
         }

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -35,6 +35,17 @@ mod mount;
 mod mount_namespace;
 mod resolver;
 
+/// Specifies the behavior of `renameat2()` when renaming a path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RenameMode {
+    /// Replaces the destination if it already exists.
+    Replace,
+    /// Fails with `EEXIST` if the destination already exists.
+    NoReplace,
+    /// Exchanges the source and destination paths.
+    Exchange,
+}
+
 /// A `Path` is used to represent an exact location in the VFS tree.
 ///
 /// Each `Path` corresponds to a node in the VFS tree, and a single node
@@ -549,12 +560,22 @@ impl Path {
     }
 
     /// Renames a `Path` to the new `Path` by `rename()` the inner inode.
-    pub fn rename(&self, old_name: &str, new_dir: &Self, new_name: &str) -> Result<()> {
+    ///
+    /// The `mode` parameter controls the rename semantics:
+    /// - [`RenameMode::Replace`]: replaces the target if it exists (default).
+    /// - [`RenameMode::NoReplace`]: fails with `EEXIST` if the target exists.
+    pub fn rename(
+        &self,
+        old_name: &str,
+        new_dir: &Self,
+        new_name: &str,
+        mode: RenameMode,
+    ) -> Result<()> {
         if !Arc::ptr_eq(&self.mount, &new_dir.mount) {
             return_errno_with_message!(Errno::EXDEV, "the operation cannot cross mounts");
         }
 
-        DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name)
+        DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name, mode)
     }
 }
 

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -4,7 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{InodeType, file_table::RawFileDesc},
-        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath},
+        vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, RenameMode, SplitPath},
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
@@ -28,10 +28,9 @@ pub fn sys_renameat2(
     let Some(flags) = Flags::from_bits(flags) else {
         return_errno_with_message!(Errno::EINVAL, "invalid flags");
     };
-    // TODO: Add support for handling the `NOREPLACE`, `EXCHANGE`, and `WHITEOUT` flags.
-    if !flags.is_empty() {
-        warn!("unsupported flags: {:?}", flags);
-        return_errno_with_message!(Errno::EINVAL, "unsupported flags");
+    // TODO: Add support for handling the `WHITEOUT` flag.
+    if flags.contains(Flags::WHITEOUT) || flags.contains(Flags::NOREPLACE | Flags::EXCHANGE) {
+        return_errno_with_message!(Errno::EINVAL, "invalid renameat2 flag combination");
     }
 
     let fs_ref = ctx.thread_local.borrow_fs();
@@ -51,9 +50,6 @@ pub fn sys_renameat2(
 
     let new_path_name = new_path_name.to_string_lossy();
     let (new_parent_path, new_name) = {
-        if old_path.type_() != InodeType::Dir && new_path_name.ends_with('/') {
-            return_errno_with_message!(Errno::EISDIR, "the new path is a directory");
-        }
         let (new_parent_path_name, new_name) = new_path_name.split_dirname_and_basename()?;
         let new_parent_fs_path =
             FsPath::from_fd_at(new_dirfd, new_parent_path_name, EmptyPathStr::Reject)?;
@@ -63,14 +59,63 @@ pub fn sys_renameat2(
         )
     };
 
-    if old_path.type_() == InodeType::Dir && new_parent_path.is_equal_or_descendant_of(&old_path) {
-        return_errno_with_message!(
-            Errno::EINVAL,
-            "the new path is inside the old directory or its subtree"
-        );
+    // Check for new path existence and type for exchange mode
+    if flags.contains(Flags::EXCHANGE) {
+        // Try to lookup new path
+        let new_path_result = path_resolver.lookup_at_path(&new_parent_path, &new_name);
+        let Ok(new_path) = new_path_result else {
+            return_errno_with_message!(Errno::ENOENT, "the new path does not exist");
+        };
+        // Check type compatibility
+        if (old_path.type_() == InodeType::Dir) != (new_path.type_() == InodeType::Dir) {
+            if old_path.type_() == InodeType::Dir {
+                return_errno_with_message!(Errno::ENOTDIR, "the new path is not a directory");
+            } else {
+                return_errno_with_message!(Errno::EISDIR, "the new path is a directory");
+            }
+        }
+        // Check for circularity: old path cannot be an ancestor of new parent
+        if old_path.type_() == InodeType::Dir
+            && new_parent_path.is_equal_or_descendant_of(&old_path)
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the new path is inside the old directory or its subtree"
+            );
+        }
+        // Check for circularity: new path cannot be an ancestor of old parent
+        if new_path.type_() == InodeType::Dir
+            && old_parent_path.is_equal_or_descendant_of(&new_path)
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the old path is inside the new directory or its subtree"
+            );
+        }
+    } else {
+        // Original checks for non-exchange modes
+        if old_path.type_() != InodeType::Dir && new_path_name.ends_with('/') {
+            return_errno_with_message!(Errno::EISDIR, "the new path is a directory");
+        }
+        if old_path.type_() == InodeType::Dir
+            && new_parent_path.is_equal_or_descendant_of(&old_path)
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the new path is inside the old directory or its subtree"
+            );
+        }
     }
 
-    old_parent_path.rename(old_name, &new_parent_path, &new_name)?;
+    let rename_mode = if flags.contains(Flags::EXCHANGE) {
+        RenameMode::Exchange
+    } else if flags.contains(Flags::NOREPLACE) {
+        RenameMode::NoReplace
+    } else {
+        RenameMode::Replace
+    };
+
+    old_parent_path.rename(old_name, &new_parent_path, &new_name, rename_mode)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1245,8 +1245,8 @@ rename14
 #renameat test cases
 # renameat01
 
-# renameat201
-# renameat202
+renameat201
+renameat202
 
 # request_key01
 # request_key02


### PR DESCRIPTION
https://github.com/asterinas/ccf-open-inno-competition

<img width="1111" height="60" alt="image" src="https://github.com/user-attachments/assets/6f22a902-e16b-449e-903d-1c724153545d" />
Add NOREPLACE flag support for rename.

Move the noreplace check to the interior of the write lock of DirDentry::rename, rather than the lock-free check at the syscall layer.
Eliminate TOCTOU race condition: The check is completed within the dentry write lock, and cannot be bypassed by other threads.
Covering cache miss: When the dentry cache misses, call inode.lookup() to query the actual file system.
sys_rename/sys_renameat: Pass false directly to maintain the original semantics.