### PR TITLE
Add birth time support to inode metadata

### DIFF
--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -110,8 +110,10 @@ struct ExfatInodeInner {
     atime: DosTimestamp,
     /// Modification time, updated only on write.
     mtime: DosTimestamp,
-    /// Creation time.
+    /// Metadata change time.
     ctime: DosTimestamp,
+    /// Creation time.
+    crtime: DosTimestamp,
 
     /// Number of sub inodes.
     num_sub_inodes: u32,
@@ -335,10 +337,10 @@ impl ExfatInodeInner {
 
         file_dentry.attribute = self.attr.bits();
 
-        file_dentry.create_utc_offset = self.ctime.utc_offset;
-        file_dentry.create_date = self.ctime.date;
-        file_dentry.create_time = self.ctime.time;
-        file_dentry.create_time_cs = self.ctime.increment_10ms;
+        file_dentry.create_utc_offset = self.crtime.utc_offset;
+        file_dentry.create_date = self.crtime.date;
+        file_dentry.create_time = self.crtime.time;
+        file_dentry.create_time_cs = self.crtime.increment_10ms;
 
         file_dentry.modify_utc_offset = self.mtime.utc_offset;
         file_dentry.modify_date = self.mtime.date;
@@ -621,10 +623,11 @@ impl ExfatInodeInner {
         Ok(())
     }
 
-    fn update_atime_and_mtime(&mut self) -> Result<()> {
+    fn update_atime_mtime_and_ctime(&mut self) -> Result<()> {
         let now = DosTimestamp::now()?;
         self.atime = now;
         self.mtime = now;
+        self.ctime = now;
         Ok(())
     }
 }
@@ -729,7 +732,7 @@ impl ExfatInode {
         {
             let mut inner = inner.upgrade();
 
-            inner.update_atime_and_mtime()?;
+            inner.update_atime_mtime_and_ctime()?;
             inner.size = new_size;
         }
 
@@ -809,7 +812,7 @@ impl ExfatInode {
 
         {
             let mut inner = inner.upgrade();
-            inner.update_atime_and_mtime()?;
+            inner.update_atime_mtime_and_ctime()?;
             inner.size = new_size;
         }
 
@@ -860,7 +863,7 @@ impl ExfatInode {
 
         let inode_type = InodeType::Dir;
 
-        let ctime = DosTimestamp::now()?;
+        let timestamp = DosTimestamp::now()?;
 
         let size = root_chain.num_clusters() as usize * sb.cluster_size as usize;
 
@@ -876,9 +879,10 @@ impl ExfatInode {
                 start_chain: root_chain,
                 size,
                 size_allocated: size,
-                atime: ctime,
-                mtime: ctime,
-                ctime,
+                atime: timestamp,
+                mtime: timestamp,
+                ctime: timestamp,
+                crtime: timestamp,
                 num_sub_inodes: 0,
                 num_sub_dirs: 0,
                 name,
@@ -933,7 +937,7 @@ impl ExfatInode {
             InodeType::File
         };
 
-        let ctime = DosTimestamp::new(
+        let crtime = DosTimestamp::new(
             file.create_time,
             file.create_date,
             file.create_time_cs,
@@ -988,7 +992,8 @@ impl ExfatInode {
                 size_allocated,
                 atime,
                 mtime,
-                ctime,
+                ctime: mtime,
+                crtime,
                 num_sub_inodes: 0,
                 num_sub_dirs: 0,
                 name,
@@ -1186,19 +1191,17 @@ impl ExfatInode {
         Ok(())
     }
 
-    /// Copy metadata from the given inode.
+    /// Copies dentry placement from the given inode.
     /// There will be no deadlock since this function is only used in rename and the arg "inode".
     /// is a temporary inode which is only accessible to current thread.
-    fn copy_metadata_from(&self, inode: Arc<ExfatInode>) {
+    fn copy_dentry_position_from(&self, inode: Arc<ExfatInode>) {
         let mut self_inner = self.inner.write();
         let other_inner = inode.inner.read();
 
         self_inner.dentry_set_position = other_inner.dentry_set_position.clone();
         self_inner.dentry_set_size = other_inner.dentry_set_size;
         self_inner.dentry_entry = other_inner.dentry_entry;
-        self_inner.atime = other_inner.atime;
         self_inner.ctime = other_inner.ctime;
-        self_inner.mtime = other_inner.mtime;
         self_inner.name = other_inner.name.clone();
         self_inner.is_deleted = other_inner.is_deleted;
         self_inner.parent_hash = other_inner.parent_hash;
@@ -1445,6 +1448,7 @@ impl Inode for ExfatInode {
             gid: Gid::new(inner.fs().mount_option().fs_gid as u32),
             container_dev_id: inner.fs().container_device_id(),
             self_dev_id: None,
+            birth_at: inner.crtime.as_duration().unwrap_or_default(),
         }
     }
 
@@ -1535,7 +1539,7 @@ impl Inode for ExfatInode {
         let result = self.add_entry(name, type_, mode, &fs_guard)?;
         let _ = fs.insert_inode(result.clone());
 
-        self.inner.write().update_atime_and_mtime()?;
+        self.inner.write().update_atime_mtime_and_ctime()?;
 
         let inner = self.inner.read();
 
@@ -1575,7 +1579,7 @@ impl Inode for ExfatInode {
             return_errno!(Errno::EISDIR)
         }
         self.delete_inode(inode, true, &fs_guard)?;
-        self.inner.write().update_atime_and_mtime()?;
+        self.inner.write().update_atime_mtime_and_ctime()?;
 
         let inner = self.inner.read();
         if inner.is_sync() {
@@ -1611,7 +1615,7 @@ impl Inode for ExfatInode {
             return_errno!(Errno::ENOTEMPTY)
         }
         self.delete_inode(inode, true, &fs_guard)?;
-        self.inner.write().update_atime_and_mtime()?;
+        self.inner.write().update_atime_mtime_and_ctime()?;
 
         let inner = self.inner.read();
         // Sync this inode since size has changed.
@@ -1690,7 +1694,7 @@ impl Inode for ExfatInode {
         let new_inode =
             target_.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
         // Update metadata.
-        old_inode.copy_metadata_from(new_inode);
+        old_inode.copy_dentry_position_from(new_inode);
         // Update its children's parent_hash.
         old_inode.update_subdir_parent_hash(&fs_guard)?;
         // Insert back.
@@ -1700,8 +1704,8 @@ impl Inode for ExfatInode {
             target_.delete_inode(exist_inode, true, &fs_guard)?;
         }
         // Update the times.
-        self.inner.write().update_atime_and_mtime()?;
-        target_.inner.write().update_atime_and_mtime()?;
+        self.inner.write().update_atime_mtime_and_ctime()?;
+        target_.inner.write().update_atime_mtime_and_ctime()?;
         // Sync
         if self.inner.read().is_sync() || target_.inner.read().is_sync() {
             // TODO: what if fs crashed between syncing?

--- a/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
@@ -74,6 +74,7 @@ impl Inode {
             gid: Gid::new(inner.gid()),
             container_dev_id,
             self_dev_id,
+            birth_at: Duration::ZERO,
         }
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -224,6 +224,7 @@ impl PseudoInode {
             gid,
             container_dev_id: dev_id,
             self_dev_id: None,
+            birth_at: Duration::ZERO,
         };
 
         PseudoInode {

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -1309,6 +1309,7 @@ impl Inode for RamInode {
             } else {
                 DeviceId::from_encoded_u64(rdev)
             },
+            birth_at: Duration::ZERO,
         }
     }
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -215,5 +215,6 @@ pub(in crate::fs::fs_impls::virtiofs) fn metadata_from_attr(
         } else {
             DeviceId::from_encoded_u64(attr.rdev() as u64)
         },
+        birth_at: Duration::ZERO,
     }
 }

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -87,6 +87,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             gid: Gid::new_root(),
             container_dev_id: sb.container_dev_id,
             self_dev_id: None,
+            birth_at: Duration::ZERO,
         }
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -122,6 +122,14 @@ pub struct Metadata {
     ///
     /// Corresponds to `st_rdev`.
     pub self_dev_id: Option<DeviceId>,
+
+    /// The timestamp of the file's creation (birth time).
+    ///
+    /// For filesystems that do not record birth time (e.g., ext2), this is
+    /// [`Duration::ZERO`].
+    ///
+    /// Corresponds to `stx_btime`.
+    pub birth_at: Duration,
 }
 
 /// Describes whether an inode may get new hard links.
@@ -155,6 +163,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
+            birth_at: Duration::ZERO,
         }
     }
 
@@ -180,6 +189,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
+            birth_at: Duration::ZERO,
         }
     }
 
@@ -205,6 +215,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
+            birth_at: Duration::ZERO,
         }
     }
 
@@ -231,6 +242,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: Some(device.id()),
+            birth_at: Duration::ZERO,
         }
     }
 }

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -138,9 +138,16 @@ impl Statx {
             stx_attributes |= STATX_ATTR_MOUNT_ROOT;
         }
 
-        let stx_mask = StatxMask::STATX_BASIC_STATS.bits()
-            | StatxMask::STATX_BTIME.bits()
-            | StatxMask::STATX_MNT_ID.bits();
+        // Build `stx_mask` based on what's supported and what was requested
+        let mut stx_mask = StatxMask::STATX_BASIC_STATS.bits() | StatxMask::STATX_MNT_ID.bits();
+
+        // Include `STATX_BTIME` if the birth time is available
+        // TODO: The filesystem supports populating `stx_mask`
+        if !info.birth_at.is_zero() {
+            stx_mask |= StatxMask::STATX_BTIME.bits();
+        }
+
+        let stx_btime = StatxTimestamp::from(info.birth_at);
 
         Self {
             // FIXME: All zero fields below are dummy implementations that need to be improved in the future.
@@ -157,7 +164,7 @@ impl Statx {
             stx_blocks: info.nr_sectors_allocated as u64,
             stx_attributes_mask,
             stx_atime: StatxTimestamp::from(info.last_access_at),
-            stx_btime: StatxTimestamp::from(Duration::ZERO), // TODO: Metadata do not track birth time for now.
+            stx_btime,
             stx_ctime: StatxTimestamp::from(info.last_meta_change_at),
             stx_mtime: StatxTimestamp::from(info.last_modify_at),
             stx_rdev_major,

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -10,6 +10,7 @@ SUBDIRS := \
 	overlayfs \
 	procfs \
 	pseudofs \
+	statx \
 	symlink \
 	tmpfile \
 	utimensat \

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -142,6 +142,8 @@ echo "All mount bind file test passed."
 ./pseudofs/pseudo_inode
 ./pseudofs/pseudo_mount
 
+./statx/btime
+
 ./symlink/symlink
 
 ./tmpfile/tmpfile

--- a/test/initramfs/src/regression/fs/statx/Makefile
+++ b/test/initramfs/src/regression/fs/statx/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/statx/btime.c
+++ b/test/initramfs/src/regression/fs/statx/btime.c
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#ifndef __asterinas__
+#include <linux/loop.h>
+#include <sys/ioctl.h>
+#endif
+#include <linux/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define RAMFS_MOUNT_POINT "/statx_btime_ramfs"
+#define RAMFS_TEST_FILE RAMFS_MOUNT_POINT "/statx_btime_test_file"
+
+#define EXFAT_MOUNT_POINT "/statx_btime_exfat"
+#define EXFAT_TEST_FILE EXFAT_MOUNT_POINT "/statx_btime_test_file"
+#define EXFAT_TEST_FILE_NOT_REQ \
+	EXFAT_MOUNT_POINT "/statx_btime_test_file_not_req"
+
+#ifndef __asterinas__
+#define EXFAT_IMAGE "/tmp/statx_btime_exfat.img"
+#define EXFAT_IMAGE_SIZE (64 * 1024 * 1024)
+#endif
+
+static int fd = -1;
+
+static int created_ramfs_mount_point;
+static int created_exfat_mount_point;
+
+#ifndef __asterinas__
+static int loop_fd = -1;
+static char loop_path[64];
+#endif
+
+static void make_ramfs_mount_point(void)
+{
+	if (mkdir(RAMFS_MOUNT_POINT, 0755) == 0) {
+		created_ramfs_mount_point = 1;
+		return;
+	}
+}
+
+static void make_exfat_mount_point(void)
+{
+	if (mkdir(EXFAT_MOUNT_POINT, 0755) == 0) {
+		created_exfat_mount_point = 1;
+		return;
+	}
+}
+
+#ifndef __asterinas__
+static void create_exfat_image(void)
+{
+	int image_fd =
+		CHECK(open(EXFAT_IMAGE, O_CREAT | O_TRUNC | O_RDWR, 0600));
+
+	CHECK(ftruncate(image_fd, EXFAT_IMAGE_SIZE));
+	CHECK(close(image_fd));
+	CHECK_WITH(system("mkfs.exfat " EXFAT_IMAGE " >/dev/null"), _ret == 0);
+}
+
+static void attach_loop_device(void)
+{
+	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
+	int loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
+
+	CHECK(close(control_fd));
+	CHECK_WITH(snprintf(loop_path, sizeof(loop_path), "/dev/loop%d",
+			    loop_number),
+		   _ret > 0 && (size_t)_ret < sizeof(loop_path));
+
+	int image_fd = CHECK(open(EXFAT_IMAGE, O_RDWR));
+
+	loop_fd = CHECK(open(loop_path, O_RDWR));
+	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
+	CHECK(close(image_fd));
+}
+#endif
+
+FN_SETUP(prepare)
+{
+	make_ramfs_mount_point();
+	CHECK(mount("none", RAMFS_MOUNT_POINT, "ramfs", 0, NULL));
+
+	fd = CHECK(open(RAMFS_TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0644));
+	CHECK(write(fd, "test", 4));
+
+	make_exfat_mount_point();
+#ifdef __asterinas__
+	CHECK(mount("/dev/vdb", EXFAT_MOUNT_POINT, "exfat", 0, ""));
+#else
+	create_exfat_image();
+	attach_loop_device();
+	CHECK(mount(loop_path, EXFAT_MOUNT_POINT, "exfat", 0, ""));
+#endif
+}
+END_SETUP()
+
+FN_TEST(statx_btime_not_requested)
+{
+	struct statx stx;
+	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS,
+			  &stx));
+	TEST_RES(0, (stx.stx_mask & STATX_BTIME) == 0);
+}
+END_TEST()
+
+FN_TEST(statx_btime_ramfs)
+{
+	struct statx stx;
+	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BTIME, &stx));
+	TEST_RES(0, stx.stx_btime.tv_sec == 0 && stx.stx_btime.tv_nsec == 0);
+}
+END_TEST()
+
+FN_TEST(exfat_statx_btime_not_requested)
+{
+	struct statx stx;
+	int test_fd = TEST_SUCC(open(EXFAT_TEST_FILE_NOT_REQ,
+				     O_CREAT | O_TRUNC | O_RDWR, 0644));
+	TEST_SUCC(syscall(SYS_statx, test_fd, "", AT_EMPTY_PATH,
+			  STATX_BASIC_STATS, &stx));
+	// exfat supports birth time, so `STATX_BTIME` should be set even if not requested
+	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
+	TEST_SUCC(close(test_fd));
+}
+END_TEST()
+
+FN_TEST(exfat_statx_reports_birth_time)
+{
+	struct statx stx;
+	struct timespec before_create;
+	struct timespec after_create;
+
+	TEST_SUCC(clock_gettime(CLOCK_REALTIME, &before_create));
+	int test_fd = TEST_SUCC(
+		open(EXFAT_TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, 0644));
+	TEST_SUCC(clock_gettime(CLOCK_REALTIME, &after_create));
+
+	memset(&stx, 0, sizeof(stx));
+	TEST_RES(write(test_fd, "test", 4), _ret == 4);
+	TEST_SUCC(syscall(SYS_statx, test_fd, "", AT_EMPTY_PATH, STATX_BTIME,
+			  &stx));
+	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
+	TEST_RES(0, stx.stx_btime.tv_sec != 0 || stx.stx_btime.tv_nsec != 0);
+	// Verify that the birth time is within the time window around file creation
+	TEST_RES(0, stx.stx_btime.tv_sec >= before_create.tv_sec - 1);
+	TEST_RES(0, stx.stx_btime.tv_sec <= after_create.tv_sec + 1);
+	TEST_SUCC(close(test_fd));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(fd));
+	CHECK(unlink(RAMFS_TEST_FILE));
+	CHECK(unlink(EXFAT_TEST_FILE));
+	CHECK(unlink(EXFAT_TEST_FILE_NOT_REQ));
+	CHECK(umount(EXFAT_MOUNT_POINT));
+	CHECK(umount(RAMFS_MOUNT_POINT));
+
+#ifndef __asterinas__
+	CHECK(ioctl(loop_fd, LOOP_CLR_FD));
+	CHECK(close(loop_fd));
+	CHECK(unlink(EXFAT_IMAGE));
+#endif
+
+	if (created_exfat_mount_point) {
+		CHECK(rmdir(EXFAT_MOUNT_POINT));
+	}
+	if (created_ramfs_mount_point) {
+		CHECK(rmdir(RAMFS_MOUNT_POINT));
+	}
+}
+END_SETUP()


### PR DESCRIPTION
https://github.com/asterinas/ccf-open-inno-competition

<img width="1051" height="62" alt="image" src="https://github.com/user-attachments/assets/d7a552dc-502a-4227-8766-7f66c178c4bc" />

Add a creation_at field to the Metadata struct to support birth time. This resolves the TODO at statx.rs:160 where stx_btime was previously hardcoded to Duration::ZERO.