### PR TITLE
Update SCML coverage for `mknod` and TCP socket options

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -153,7 +153,7 @@ which are summarized in the table below.
 | 130     | rt_sigsuspend          | ✅             | 💯 |
 | 131     | sigaltstack            | ✅             | 💯 |
 | 132     | utime                  | ✅             | 💯 |
-| 133     | mknod                  | ✅             | 💯 |
+| 133     | mknod                  | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#mknod-and-mknodat) |
 | 134     | uselib                 | ❌             | N/A |
 | 135     | personality            | ❌             | N/A |
 | 136     | ustat                  | ❌             | N/A |
@@ -279,7 +279,7 @@ which are summarized in the table below.
 | 256     | migrate_pages          | ❌             | N/A |
 | 257     | openat                 | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#open-and-openat) |
 | 258     | mkdirat                | ✅             | 💯 |
-| 259     | mknodat                | ✅             | 💯 |
+| 259     | mknodat                | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#mknod-and-mknodat) |
 | 260     | fchownat               | ✅             | 💯 |
 | 261     | futimesat              | ✅             | 💯 |
 | 262     | newfstatat             | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#newfstatat) |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -168,3 +168,17 @@ Supported functionality in SCML:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/utimensat.2.html).
+
+### `mknod` and `mknodat`
+
+Supported functionality in SCML:
+
+```c
+{{#include mknod_and_mknodat.scml}}
+```
+
+Unsupported File types:
+* `S_IFSOCK`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/mknod.2.html).

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/fully_covered.scml
@@ -87,10 +87,6 @@ umask(mask);
 utime(path, times);
 utimes(path, times);
 
-// Create a filesystem node
-mknod(path, mode, dev);
-mknodat(dirfd, path, mode, dev);
-
 // Change timestamps of a file relative to a directory file descriptor
 futimesat(dirfd, path, times);
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/mknod_and_mknodat.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/mknod_and_mknodat.scml
@@ -1,0 +1,7 @@
+supported_filetype = S_IFREG | S_IFCHR | S_IFBLK | S_IFIFO;
+supported_perms = S_ISUID | S_ISGID | S_ISVTX | <INTEGER>;
+supported_mode = <supported_filetype> | <supported_perms>;
+
+// Create a filesystem node (file, device special file, or named pipe)
+mknod(path, mode = <supported_mode>, dev);
+mknodat(dirfd, path, mode = <supported_mode>, dev);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/getsockopt_and_setsockopt.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/getsockopt_and_setsockopt.scml
@@ -7,7 +7,8 @@ ip_options = IP_TOS | IP_TTL | IP_HDRINCL;
 
 tcp_options = TCP_NODELAY | TCP_MAXSEG | TCP_KEEPIDLE | TCP_SYNCNT |
               TCP_DEFER_ACCEPT | TCP_WINDOW_CLAMP | TCP_CONGESTION |
-              TCP_USER_TIMEOUT | TCP_INQ;
+              TCP_USER_TIMEOUT | TCP_INQ | TCP_KEEPINTVL |
+              TCP_KEEPCNT;
 
 // Get options at socket level
 getsockopt(


### PR DESCRIPTION
- Document partial SCML coverage for `mknod` and `mknodat`.
- Add `TCP_KEEPINTVL` and `TCP_KEEPCNT` to the SCML coverage for `getsockopt` and `setsockopt`. See #3303 

Closes #3357 