### PR TITLE
Atomically allocate and zero ext2 data blocks

### DIFF
--- a/kernel/comps/nvme/src/lib.rs
+++ b/kernel/comps/nvme/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 #[macro_use]
 extern crate ostd_pod;
 
-// Set this module's log prefix for `ostd::log`.
+// Set this crate's log prefix for `ostd::log`.
 macro_rules! __log_prefix {
     () => {
         "nvme: "

--- a/kernel/src/fs/fs_impls/ext2/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext2/block_group.rs
@@ -347,7 +347,7 @@ impl BlockGroup {
         for block_bit in range_start..range_end {
             if !metadata.block_bitmap.is_allocated(block_bit) {
                 warn!(
-                    "ext2_free_blocks: bit already cleared for block {}",
+                    "free_blocks: bit already cleared for block {}",
                     self.first_block + start_bit + (block_bit - range_start) as u32
                 );
             } else {
@@ -407,7 +407,7 @@ impl BlockGroup {
         let mut metadata = self.metadata.write();
 
         if !metadata.inode_bitmap.is_allocated(inode_idx) {
-            warn!("ext2_free_inode: inode idx {} already freed", inode_idx);
+            warn!("free_inode: inode idx {} already freed", inode_idx);
             return Ok(false);
         }
 

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -112,7 +112,7 @@ impl BlockPtrTree {
     // and allocate. A cursor over the leaf block could eliminate the second walk.
     pub(in crate::fs::fs_impls::ext2::inode) fn resolve_block_range(
         &mut self,
-        fs: &Arc<Ext2>,
+        fs: &Ext2,
         iblock: Iblock,
         max_blocks: u32,
     ) -> Result<ResolvedBlockRange> {
@@ -647,20 +647,20 @@ impl BlockPtrTree {
     /// placed near the newly allocated metadata when possible. The returned
     /// guard frees all allocated blocks on drop unless `commit` is called after
     /// the blocks have been spliced into the tree.
-    fn allocate_blocks(
+    fn allocate_blocks<'a>(
         &self,
-        fs: &Arc<Ext2>,
+        fs: &'a Ext2,
         indirect_blks: u32,
         data_blks: u32,
         walk: &BlockPointerWalk,
-    ) -> Result<BlockAllocGuard> {
+    ) -> Result<BlockAllocGuard<'a>> {
         let mut alloc_goal = walk
             .visited_entries
             .last()
             .copied()
             .unwrap_or(self.raw_block_ptrs.block_ptrs[0]);
 
-        let mut guard = BlockAllocGuard::new(fs.clone());
+        let mut guard = BlockAllocGuard::new(fs);
         // Allocate the missing indirect metadata first, then place data blocks
         // immediately after the metadata run when possible.
         let mut indirect_blocks = Vec::with_capacity(indirect_blks as usize);
@@ -1123,15 +1123,15 @@ impl BlockPointerWalk {
 
 /// Rollback guard for metadata and data blocks allocated through the block-pointer tree.
 #[derive(Debug)]
-struct BlockAllocGuard {
-    fs: Arc<Ext2>,
+struct BlockAllocGuard<'a> {
+    fs: &'a Ext2,
     indirect_blocks: Vec<Ext2Bid>,
     data_blocks: Range<Ext2Bid>,
     committed: bool,
 }
 
-impl BlockAllocGuard {
-    fn new(fs: Arc<Ext2>) -> Self {
+impl<'a> BlockAllocGuard<'a> {
+    fn new(fs: &'a Ext2) -> Self {
         Self {
             fs,
             indirect_blocks: Vec::new(),
@@ -1155,7 +1155,7 @@ impl BlockAllocGuard {
     }
 }
 
-impl Drop for BlockAllocGuard {
+impl Drop for BlockAllocGuard<'_> {
     fn drop(&mut self) {
         if self.committed {
             return;
@@ -1193,11 +1193,7 @@ mod test {
         time::clocks,
     };
 
-    fn alloc_single_block(
-        tree: &mut BlockPtrTree,
-        fs: &Arc<Ext2>,
-        iblock: Iblock,
-    ) -> Result<Ext2Bid> {
+    fn alloc_single_block(tree: &mut BlockPtrTree, fs: &Ext2, iblock: Iblock) -> Result<Ext2Bid> {
         let step = tree.resolve_block_range(fs, iblock, 1)?;
         let range = match step {
             ResolvedBlockRange::Existing(r) | ResolvedBlockRange::NewlyAllocated(r) => r,

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -660,29 +660,23 @@ impl BlockPtrTree {
             .copied()
             .unwrap_or(self.raw_block_ptrs.block_ptrs[0]);
 
-        let mut guard = BlockAllocGuard::new(fs);
         // Allocate the missing indirect metadata first, then place data blocks
         // immediately after the metadata run when possible.
-        let mut indirect_blocks = Vec::with_capacity(indirect_blks as usize);
+        let mut guard = BlockAllocGuard::new(fs, indirect_blks);
 
-        while (indirect_blocks.len() as u32) < indirect_blks {
-            let remaining_indirect_blks = indirect_blks - indirect_blocks.len() as u32;
+        let mut remaining_indirect_blks = indirect_blks;
+        while remaining_indirect_blks > 0 {
             let allocated = fs.alloc_blocks(remaining_indirect_blks, alloc_goal)?;
             debug_assert!(allocated.end >= allocated.start);
             let allocated_count = allocated.end - allocated.start;
             debug_assert!(allocated_count > 0 && allocated_count <= remaining_indirect_blks);
 
-            indirect_blocks.extend(allocated.clone());
             alloc_goal = allocated.end;
+            remaining_indirect_blks -= allocated_count;
+            guard.extend_indirect_blocks(allocated);
         }
 
-        let data_goal = indirect_blocks
-            .last()
-            .copied()
-            .map_or(alloc_goal, |last_metadata| last_metadata + 1);
-        guard.track_indirect_blocks(indirect_blocks);
-
-        let data_blocks_range = fs.alloc_blocks(data_blks, data_goal)?;
+        let data_blocks_range = fs.alloc_blocks(data_blks, alloc_goal)?;
         debug_assert!(data_blocks_range.end >= data_blocks_range.start);
         let allocated_count = data_blocks_range.end - data_blocks_range.start;
         guard.track_data_blocks(data_blocks_range);
@@ -1131,18 +1125,17 @@ struct BlockAllocGuard<'a> {
 }
 
 impl<'a> BlockAllocGuard<'a> {
-    fn new(fs: &'a Ext2) -> Self {
+    fn new(fs: &'a Ext2, indirect_blocks: u32) -> Self {
         Self {
             fs,
-            indirect_blocks: Vec::new(),
+            indirect_blocks: Vec::with_capacity(indirect_blocks as usize),
             data_blocks: Range { start: 0, end: 0 },
             committed: false,
         }
     }
 
-    fn track_indirect_blocks(&mut self, indirect_blocks: Vec<Ext2Bid>) {
-        debug_assert!(self.indirect_blocks.is_empty());
-        self.indirect_blocks = indirect_blocks;
+    fn extend_indirect_blocks(&mut self, indirect_blocks: Range<Ext2Bid>) {
+        self.indirect_blocks.extend(indirect_blocks);
     }
 
     fn track_data_blocks(&mut self, data_blocks: Range<Ext2Bid>) {

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -140,9 +140,10 @@ impl BlockPtrTree {
 
     /// Truncates blocks to the new byte length (best-effort).
     ///
-    /// Like Linux's `ext2_truncate_blocks`, this is a best-effort operation.
-    /// Errors are logged but not propagated — leaked blocks from partial
-    /// failures are recoverable by e2fsck.
+    /// This is a best-effort operation. Errors are logged but not propagated.
+    /// Leaked blocks from partial failures are recoverable by e2fsck. Linux
+    /// also follows this practice (see
+    /// <https://elixir.bootlin.com/linux/v7.0/source/fs/ext2/inode.c#L1172>).
     pub(in crate::fs::fs_impls::ext2::inode) fn truncate_to_byte_len(
         &mut self,
         fs: &Ext2,
@@ -332,7 +333,7 @@ impl BlockPtrTree {
         detach_level: usize,
     ) -> Result<Option<Ext2Bid>> {
         let detached_bid = if detach_level == 0 {
-            // Subtree root is referenced directly from inode.block_ptrs[].
+            // Subtree root is referenced directly from `inode.block_ptrs[]`.
             let slot = walk.root_slot() as usize;
             let bid = self.raw_block_ptrs.block_ptrs[slot];
             self.raw_block_ptrs.block_ptrs[slot] = 0;

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -152,10 +152,7 @@ impl BlockPtrTree {
         let iblock = match Iblock::try_from(new_size.div_ceil(BLOCK_SIZE)) {
             Ok(ib) => ib,
             Err(_) => {
-                error!(
-                    "ext2 truncate: size exceeds ext2 limits, new_size={}",
-                    new_size
-                );
+                error!("truncate: size exceeds ext2 limits, new_size={}", new_size);
                 return;
             }
         };
@@ -163,26 +160,17 @@ impl BlockPtrTree {
         let walk = match self.walk_at(iblock) {
             Ok(w) => w,
             Err(err) => {
-                error!(
-                    "ext2 truncate: failed to compute block walk, err: {:?}",
-                    err
-                );
+                error!("truncate: failed to compute block walk, err: {:?}", err);
                 return;
             }
         };
 
         if walk.is_direct_data_block() {
             if let Err(err) = self.truncate_direct_slots(fs, walk.root_slot() as usize) {
-                error!(
-                    "ext2 truncate: truncate_direct_slots failed, err: {:?}",
-                    err
-                );
+                error!("truncate: truncate_direct_slots failed, err: {:?}", err);
             }
         } else if let Err(err) = self.truncate_indirect_path(fs, &walk) {
-            error!(
-                "ext2 truncate: truncate_indirect_path failed, err: {:?}",
-                err
-            );
+            error!("truncate: truncate_indirect_path failed, err: {:?}", err);
         }
 
         self.free_indirect_roots_after(fs, walk.root_slot() as usize);
@@ -604,7 +592,7 @@ impl BlockPtrTree {
             if let Err(err) = fs.free_blocks(block_bid, 1) {
                 // Best-effort free path logs errors and proceeds.
                 error!(
-                    "ext2: free_block_subtree: failed to free data block {}: {:?}",
+                    "free_block_subtree: failed to free data block {}: {:?}",
                     block_bid, err
                 );
                 return;
@@ -627,7 +615,7 @@ impl BlockPtrTree {
                     // Skip the damaged subtree after logging the read failure so
                     // cleanup can continue for the remaining subtree.
                     error!(
-                        "ext2: free_block_subtree: failed to read indirect block {} (indirect_levels {})",
+                        "free_block_subtree: failed to read indirect block {} (indirect_levels {})",
                         block_bid, indirect_levels
                     );
                     return;
@@ -641,7 +629,7 @@ impl BlockPtrTree {
 
         if let Err(err) = fs.free_blocks(block_bid, 1) {
             error!(
-                "ext2: free_block_subtree: failed to free indirect block {}: {:?}",
+                "free_block_subtree: failed to free indirect block {}: {:?}",
                 block_bid, err
             );
             return;

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -3,6 +3,7 @@
 //! Logical-to-physical block translation via the ext2 block-pointer tree.
 
 use device_id::{decode_device_numbers, encode_device_numbers};
+use ostd::mm::io::util::HasVmReaderWriter;
 use smallvec::SmallVec;
 
 use super::indirect_block_manager::{IndirectBlock, IndirectBlockManager};
@@ -679,10 +680,30 @@ impl BlockPtrTree {
         let data_blocks_range = fs.alloc_blocks(data_blks, alloc_goal)?;
         debug_assert!(data_blocks_range.end >= data_blocks_range.start);
         let allocated_count = data_blocks_range.end - data_blocks_range.start;
-        guard.track_data_blocks(data_blocks_range);
+        guard.track_data_blocks(data_blocks_range.clone());
         debug_assert!(allocated_count > 0 && allocated_count <= data_blks);
 
+        // We must wait until the blocks are initialized before we can proceed.
+        // Otherwise, concurrent page faults may see uninitialized blocks.
+        //
+        // TODO: In the write path, if the entire block is going to be
+        // overwritten, we should write the real payload instead of zeroing it.
+        Self::zero_new_blocks(fs, &data_blocks_range)?;
+
         Ok(guard)
+    }
+
+    /// Zeroes newly allocated data blocks before exposing them via mapped reads.
+    fn zero_new_blocks(fs: &Ext2, block_range: &Range<Ext2Bid>) -> Result<()> {
+        let mut io_batch = IoBatch::with_capacity(1);
+
+        let bio_segment = BioSegment::alloc(block_range.len(), BioDirection::ToDevice);
+        let mut segment_writer = bio_segment.writer().unwrap();
+        segment_writer.fill_zeros(block_range.len() * BLOCK_SIZE);
+        fs.write_blocks_async(block_range.start, bio_segment, None, &mut io_batch)?;
+
+        io_batch.wait_all()?;
+        Ok(())
     }
 
     /// Splices allocated blocks into the block-pointer tree.

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
@@ -99,14 +99,9 @@ impl InodeBlockManager {
     }
 
     /// Allocates missing data blocks that cover the requested logical block range.
-    pub(super) fn allocate_range_blocks(
-        &self,
-        start_block: usize,
-        end_block: usize,
-    ) -> Result<Vec<Range<Ext2Bid>>> {
+    pub(super) fn allocate_range_blocks(&self, start_block: usize, end_block: usize) -> Result<()> {
         let fs = self.fs()?;
         let mut tree = self.block_ptr_tree.write();
-        let mut new_blocks = Vec::new();
         let mut current_block = start_block;
         while current_block < end_block {
             let iblock = Iblock::try_from(current_block)
@@ -123,11 +118,10 @@ impl InodeBlockManager {
                 ResolvedBlockRange::NewlyAllocated(range) => {
                     debug_assert!(!range.is_empty());
                     current_block += range.len();
-                    new_blocks.push(range);
                 }
             }
         }
-        Ok(new_blocks)
+        Ok(())
     }
 
     /// Updates the cached page-cache capacity bound.

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
@@ -8,7 +8,6 @@ mod indirect_block_manager;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use aster_block::bio::BioCompleteFn;
-use ostd::mm::io::util::HasVmReaderWriter;
 
 use self::block_ptr_tree::ResolvedBlockRange;
 pub(super) use self::block_ptr_tree::{BlockPtrTree, RawBlockPtrs};
@@ -157,11 +156,7 @@ impl BlockAsPageCacheBackend for InodeBlockManager {
             }
             None => {
                 // Encountered a hole, zero fill the page.
-                let mut segment_writer = bio_segment.inner_dma_slice().writer().map_err(|_| {
-                    Error::with_message(Errno::EIO, "failed to access zero-fill bio segment")
-                })?;
-                segment_writer.fill_zeros(bio_segment.nbytes());
-                complete_fn(BioStatus::Complete);
+                complete_fn(BioStatus::Zeros);
                 Ok(())
             }
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
@@ -86,7 +86,7 @@ impl InodeBlockManager {
         let fs = match self.fs() {
             Ok(fs) => fs,
             Err(err) => {
-                error!("ext2 truncate: failed to get fs reference, err: {:?}", err);
+                error!("truncate: failed to get fs reference, err: {:?}", err);
                 return;
             }
         };

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -10,12 +10,9 @@
 use ostd::mm::io::util::HasVmReaderWriter;
 
 use super::{super::Ext2, FileFlags, Inode, InodeInner, io_range::IoRange};
-use crate::{
-    fs::{
-        ext2::{prelude::*, utils},
-        vfs::inode::FallocMode,
-    },
-    vm::page_cache::CachePageExt,
+use crate::fs::{
+    ext2::{prelude::*, utils},
+    vfs::inode::FallocMode,
 };
 
 impl Inode {
@@ -170,14 +167,7 @@ impl Inode {
 
         match mode {
             FallocMode::Allocate => {
-                let allocated_block_ranges = match inner.allocate_range_blocks(offset, end) {
-                    Ok(ranges) => ranges,
-                    Err(err) => {
-                        inner.rollback_fallocate(old_size);
-                        return Err(err);
-                    }
-                };
-                if let Err(err) = inner.zero_new_blocks(&fs, &allocated_block_ranges) {
+                if let Err(err) = inner.allocate_range_blocks(offset, end) {
                     inner.rollback_fallocate(old_size);
                     return Err(err);
                 }
@@ -189,14 +179,7 @@ impl Inode {
                 }
             }
             FallocMode::AllocateKeepSize => {
-                let allocated_block_ranges = match inner.allocate_range_blocks(offset, end) {
-                    Ok(ranges) => ranges,
-                    Err(err) => {
-                        inner.rollback_fallocate(old_size);
-                        return Err(err);
-                    }
-                };
-                if let Err(err) = inner.zero_new_blocks(&fs, &allocated_block_ranges) {
+                if let Err(err) = inner.allocate_range_blocks(offset, end) {
                     inner.rollback_fallocate(old_size);
                     return Err(err);
                 }
@@ -233,20 +216,6 @@ impl InodeInner {
             self.resize_page_cache(end, old_size)?;
         }
 
-        // Note: zero-filling runs before block allocation, and dirty pages are
-        // never evicted by memory pressure (no capacity-based eviction yet), so
-        // concurrent mmap readers always see zeros or valid data from the page
-        // cache. If capacity-based eviction is added in the future, per-page
-        // locks (like Linux's folio lock) will be needed to prevent stale reads
-        // from newly allocated blocks whose zero-filled page has been evicted.
-
-        // If the write extends EOF, zero the partial tail of the old EOF block.
-        if offset > old_size {
-            self.zero_eof_tail(old_size)?;
-        }
-
-        // Treat the write end as the new partial EOF boundary.
-        self.zero_partial_writes(offset, end)?;
         self.allocate_range_blocks(offset, end)?;
         Ok(())
     }
@@ -460,11 +429,8 @@ impl InodeInner {
         let old_size = self.desc.size as usize;
 
         self.resize_page_cache(new_size, old_size)?;
-
         self.block_manager()?.truncate_to_byte_len(new_size);
 
-        // Fill the partial tail of the new EOF block.
-        self.zero_eof_tail(new_size)?;
         self.set_file_size(new_size);
         Ok(())
     }
@@ -478,99 +444,16 @@ impl InodeInner {
         self.ensure_size_within_limit(fs, new_size)?;
         self.resize_page_cache(new_size, old_size)?;
 
-        // Zero the partial tail of the old EOF block and the new EOF block.
-        self.zero_eof_tail(old_size)?;
-        self.zero_eof_tail(new_size)?;
         self.set_file_size(new_size);
         Ok(())
     }
 
-    // NOTE: Make sure the page cache is already resized before calling this function.
-    // When the file expands or shrinks, zero the partial tail of the old EOF block. EOF
-    // cleanup belongs to the operation that changes the file size, such as
-    // write, shrink, expand, or fallocate.
-    fn zero_eof_tail(&self, eof_offset: usize) -> Result<()> {
-        if !eof_offset.is_multiple_of(BLOCK_SIZE) {
-            let block_end = eof_offset.align_up(BLOCK_SIZE);
-            self.page_cache().fill_zeros(eof_offset..block_end)?;
-        }
-        Ok(())
-    }
-
-    // NOTE: Make sure the page cache is already resized before calling this function.
-    // Use this only on write paths for file data, symlinks, and directories.
-    // Conditionally fill zeros for:
-    // 1. The partial start block when it is a hole.
-    // 2. The partial end block when it is a hole.
-    fn zero_partial_writes(&mut self, start: usize, end: usize) -> Result<()> {
-        let start_iblock = Iblock::try_from(start / BLOCK_SIZE)
-            .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
-        let end_iblock = Iblock::try_from(end / BLOCK_SIZE)
-            .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
-
-        if !start.is_multiple_of(BLOCK_SIZE) {
-            let block_start = start.align_down(BLOCK_SIZE);
-            self.zero_partial_block_edge(start_iblock, block_start..start)?;
-        }
-
-        if !end.is_multiple_of(BLOCK_SIZE) {
-            let block_end = end.align_up(BLOCK_SIZE);
-            self.zero_partial_block_edge(end_iblock, end..block_end)?;
-        }
-
-        Ok(())
-    }
-
-    /// Zeroes part of a block at a boundary.
-    ///
-    /// This only touches holes whose page-cache page is still clean (i.e. not
-    /// yet written by `mmap`). It prevents stale data exposure without
-    /// clobbering valid dirty data.
-    fn zero_partial_block_edge(&mut self, iblock: u32, zero_range: Range<usize>) -> Result<()> {
-        if self.block_manager()?.lookup_block(iblock)?.is_some() {
-            return Ok(());
-        }
-        let page_idx = zero_range.start / PAGE_SIZE;
-        let page_cache = self.page_cache();
-        let page = page_cache.as_vmo().commit_on(page_idx)?;
-        if !page.is_dirty() {
-            page_cache.fill_zeros(zero_range)?;
-        }
-        Ok(())
-    }
-
     /// Allocates any missing data blocks covering the requested file byte range.
-    ///
-    /// Because holes in sparse files may gap the allocated blocks, the result is
-    /// returned as a `Vec<Range<Ext2Bid>>` rather than a single contiguous range.
-    fn allocate_range_blocks(&mut self, offset: usize, end: usize) -> Result<Vec<Range<Ext2Bid>>> {
+    fn allocate_range_blocks(&mut self, offset: usize, end: usize) -> Result<()> {
         let start_block = offset / BLOCK_SIZE;
         let end_block = end.div_ceil(BLOCK_SIZE);
-        let new_blocks = self
-            .block_manager()?
-            .allocate_range_blocks(start_block, end_block)?;
-        Ok(new_blocks)
-    }
-
-    /// Zeroes newly allocated data blocks before exposing them via mapped reads.
-    fn zero_new_blocks(&self, fs: &Ext2, ranges: &[Range<Ext2Bid>]) -> Result<()> {
-        if ranges.is_empty() {
-            return Ok(());
-        }
-
-        let mut io_batch = IoBatch::new();
-        for block_range in ranges {
-            if block_range.is_empty() {
-                continue;
-            }
-            let bio_segment = BioSegment::alloc(block_range.len(), BioDirection::ToDevice);
-            let mut segment_writer = bio_segment.writer().unwrap();
-            segment_writer.fill_zeros(block_range.len() * BLOCK_SIZE);
-            fs.write_blocks_async(block_range.start, bio_segment, None, &mut io_batch)?;
-        }
-
-        io_batch.wait_all()?;
-        Ok(())
+        self.block_manager()?
+            .allocate_range_blocks(start_block, end_block)
     }
 
     /// Rejects growth beyond the ext2-representable size limit before mutating state.

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -257,7 +257,7 @@ impl InodeInner {
         }
         if let Err(err) = self.resize_page_cache(old_size, end) {
             error!(
-                "ext2: write_at cleanup page cache resize failed: old_size={}, err={:?}",
+                "write_at: cleanup page cache resize failed: old_size={}, err={:?}",
                 old_size, err
             );
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -72,6 +72,7 @@ impl Inode {
 
         let read_len = writer.avail();
         if !is_block_aligned(offset) || !is_block_aligned(read_len) {
+            // TODO: Implement a fallback mechanism.
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
         }
         if read_len == 0 {
@@ -102,7 +103,7 @@ impl Inode {
         }
 
         if !is_block_aligned(offset) || !is_block_aligned(write_len) {
-            // TODO: fallback to buffer_io like Linux.
+            // TODO: Implement a fallback mechanism.
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
         }
 
@@ -420,7 +421,7 @@ impl InodeInner {
     ) -> Result<()> {
         let write_len = reader.remain();
         debug_assert_eq!(write_len % BLOCK_SIZE, 0);
-        // end is already checked in `InodeInner::write_direct_at`.
+        // `end` is already checked in `InodeInner::write_direct_at`.
         let end = offset + write_len;
         let iblock_start = Iblock::try_from(offset / BLOCK_SIZE)
             .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
@@ -435,7 +436,7 @@ impl InodeInner {
                 IoRange::Mapped(device_range) => {
                     let nblocks = device_range.len();
                     let bio_segment = BioSegment::alloc(nblocks, BioDirection::ToDevice);
-                    bio_segment.writer()?.write_fallible(reader)?;
+                    bio_segment.writer().unwrap().write_fallible(reader)?;
                     fs.write_blocks_async(device_range.start, bio_segment, None, &mut io_batch)?;
                 }
                 IoRange::Hole(_) => {
@@ -563,9 +564,7 @@ impl InodeInner {
                 continue;
             }
             let bio_segment = BioSegment::alloc(block_range.len(), BioDirection::ToDevice);
-            let mut segment_writer = bio_segment.writer().map_err(|_| {
-                Error::with_message(Errno::EIO, "failed to access zero-write bio segment")
-            })?;
+            let mut segment_writer = bio_segment.writer().unwrap();
             segment_writer.fill_zeros(block_range.len() * BLOCK_SIZE);
             fs.write_blocks_async(block_range.start, bio_segment, None, &mut io_batch)?;
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/io_range.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/io_range.rs
@@ -53,8 +53,8 @@ impl<'a> IoRangeIter<'a> {
             .lookup_block_range(start_iblock, max_blocks)?;
 
         if device_block_range.is_empty() {
-            // Linux's ext2 documents the slow case in `ext2_fiemap()`:
-            // `ext2_get_blocks()` iterates unmapped space block by block.  We
+            // Linux's ext2 documents the slow case where it iterates unmapped
+            // space block by block, as shown in the reference link below. We
             // keep the same sparse-file semantics, but optimize by asking the
             // block-pointer tree for a conservative hole run instead of
             // re-walking from the root for every logical block.

--- a/kernel/src/fs/fs_impls/ext2/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/mod.rs
@@ -214,7 +214,7 @@ impl Drop for Inode {
     fn drop(&mut self) {
         if let Err(err) = self.try_reclaim_deleted_inode() {
             debug!(
-                "ext2: failed to reclaim deleted inode {} during drop: {:?}",
+                "failed to reclaim deleted inode {} during drop: {:?}",
                 self.ino, err
             );
         }

--- a/kernel/src/fs/fs_impls/ext2/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/mod.rs
@@ -300,7 +300,7 @@ impl TryFrom<&RawInode> for InodeDesc {
             size |= (raw.size_high as u64) << 32;
         }
 
-        // Aligned with Linux, Linux stores nul in symlink, so the max size is BLOCK_SIZE - 1;
+        // Linux stores the nul byte in symlink, so the maximum size is `BLOCK_SIZE - 1`.
         if type_ == InodeType::SymLink && size >= BLOCK_SIZE as u64 {
             return_errno_with_message!(Errno::EUCLEAN, "corrupted symlink on disk");
         }

--- a/kernel/src/fs/fs_impls/ext2/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/mod.rs
@@ -53,6 +53,13 @@
 //! - <https://www.kernel.org/doc/html/latest/filesystems/ext2.html>
 //! - <https://www.nongnu.org/ext2-doc/ext2.html>
 
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "ext2: "
+    };
+}
+
 pub use fs::Ext2;
 pub use inode::{FilePerm, Inode};
 

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -229,6 +229,9 @@ impl PageCache {
         if new_file_size < old_file_size && !new_file_size.is_multiple_of(PAGE_SIZE) {
             let fill_zero_end = old_file_size.min(new_file_size.align_up(PAGE_SIZE));
             self.fill_zeros(new_file_size..fill_zero_end)?;
+        } else if new_file_size > old_file_size && !old_file_size.is_multiple_of(PAGE_SIZE) {
+            let fill_zero_end = new_file_size.min(old_file_size.align_up(PAGE_SIZE));
+            self.fill_zeros(old_file_size..fill_zero_end)?;
         }
 
         let new_cache_size = new_file_size.align_up(PAGE_SIZE);

--- a/test/initramfs/src/conformance/xfstests/full.list
+++ b/test/initramfs/src/conformance/xfstests/full.list
@@ -21,6 +21,7 @@ generic/102
 generic/109
 generic/124
 generic/126
+generic/127
 generic/129
 generic/130
 generic/132

--- a/test/initramfs/src/conformance/xfstests/short.list
+++ b/test/initramfs/src/conformance/xfstests/short.list
@@ -20,6 +20,7 @@ generic/102
 generic/109
 generic/124
 generic/126
+generic/127
 generic/129
 generic/132
 generic/135


### PR DESCRIPTION
ext2 code calls `Vmo::commit_on`. Doing so will break the lock contract used in the reverse mapping (see https://github.com/asterinas/asterinas/issues/3295).

https://github.com/asterinas/asterinas/blob/f7ff85597d892ec7476489216672b0ad61b7090f/kernel/src/fs/fs_impls/ext2/inode/file.rs#L534-L537

To get a page from a VMO in a racy free way, we must lock the page table lock and use `try_commit_on`. Calling `commit_on` directly cannot prevent the page from being evicting concurrently.

---

Even without this issue, the related code is problematic for some other reasons.

 1. `allocate_range_blocks` and `zero_new_blocks` are racy against concurrent page faults. If a page fault occurs in between, an uninitialized block will be loaded from the disk, which may expose sensitive information. https://github.com/asterinas/asterinas/blob/f7ff85597d892ec7476489216672b0ad61b7090f/kernel/src/fs/fs_impls/ext2/inode/file.rs#L172-L182
 2. `allocate_range_blocks` and `zero_new_blocks` are also racy against concurrent page cache eviction. Currently, we don't have concurrent page cache eviction, but it would be problematic if we did.
 3. It seems that the page cache layer is intended to address EOF-related issues. I am unsure why the ext2 implementation contains duplicate logic. https://github.com/asterinas/asterinas/blob/f7ff85597d892ec7476489216672b0ad61b7090f/kernel/src/fs/fs_impls/ext2/inode/file.rs#L480-L482 https://github.com/asterinas/asterinas/blob/f7ff85597d892ec7476489216672b0ad61b7090f/kernel/src/vm/page_cache/mod.rs#L229-L232

---

This PR proposes zeroing the data blocks (1) **when they are allocated** (2) **while the block manager lock is held**.

Therefore, a page fault (i.e., `Vmo::commit_on`) will see either an unallocated or an initialized block.

Doing so also eliminates the need for the `zero_partial_block_edge`, meaning that there is no longer a `Vmo::commit_on` being called from the FS side.

The downside is that holding the block manager lock for longer may result in less efficient zeroing (e.g., it may be redundant or less batched compared to the state before this PR). But I don't think this is really a big concern. For example, writing to unallocated blocks with `O_DIRECT` incurs a one-off cost due to redundant zeroing, which seems acceptable.