### PR TITLE
Fix O_PATH fd handling for xattr

### DIFF
--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -7,7 +7,7 @@ use crate::{
     fs,
     fs::{
         file::{
-            FileLike,
+            FileLike, StatusFlags,
             file_table::{RawFileDesc, get_file_fast},
         },
         vfs::{
@@ -153,7 +153,11 @@ pub(super) fn lookup_path_for_xattr<'a>(
         XattrFileCtx::Path(path) => lookup_path_from_fs(path, ctx, false),
         XattrFileCtx::PathNoFollow(path) => lookup_path_from_fs(path, ctx, true),
         XattrFileCtx::FileHandle(file) => {
-            let path = file.as_inode_handle_or_err()?.path();
+            let file = file.as_inode_handle_or_err()?;
+            if file.status_flags().contains(StatusFlags::O_PATH) {
+                return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
+            }
+            let path = file.path();
             Ok(Cow::Borrowed(path))
         }
     }

--- a/test/initramfs/src/conformance/gvisor/blocklists/eventfd_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/eventfd_test
@@ -1,2 +1,1 @@
 EventfdTest.SpliceFromPipePartialSucceeds
-EventfdTest.NotifyNonZero_NoRandomSave

--- a/test/initramfs/src/conformance/gvisor/blocklists/xattr_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/xattr_test
@@ -1,2 +1,1 @@
 XattrTest.TrustedNamespaceWithCapSysAdmin
-XattrTest.XattrWithOPath

--- a/test/initramfs/src/regression/fs/ext2/xattr.c
+++ b/test/initramfs/src/regression/fs/ext2/xattr.c
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/xattr.h>
 #include <unistd.h>
 
@@ -70,5 +73,30 @@ FN_TEST(xattr_nonexistent_enodata)
 		   ENODATA);
 
 	CHECK(unlink(path));
+}
+END_TEST()
+
+FN_TEST(xattr_with_o_path_fd)
+{
+	const char *path = BASE_DIR "/opath";
+	const char name[] = "user.test";
+	int val = 1234;
+	char buf[sizeof(val)];
+	char list[sizeof(name)];
+
+	int fd = TEST_SUCC(open(path, O_CREAT | O_WRONLY, 0644));
+	TEST_SUCC(close(fd));
+
+	int opath_fd = TEST_SUCC(open(path, O_PATH));
+	TEST_ERRNO(syscall(SYS_fsetxattr, opath_fd, name, &val, sizeof(val), 0),
+		   EBADF);
+	TEST_ERRNO(syscall(SYS_fgetxattr, opath_fd, name, buf, sizeof(buf)),
+		   EBADF);
+	TEST_ERRNO(syscall(SYS_flistxattr, opath_fd, list, sizeof(list)),
+		   EBADF);
+	TEST_ERRNO(syscall(SYS_fremovexattr, opath_fd, name), EBADF);
+
+	TEST_SUCC(close(opath_fd));
+	TEST_SUCC(unlink(path));
 }
 END_TEST()


### PR DESCRIPTION
## Summary

Fix f*xattr syscalls to reject `O_PATH` file descriptors with `EBADF`.

## Changes

- Return `EBADF` for `fsetxattr`, `fgetxattr`, `flistxattr`, and `fremovexattr` when the fd is opened with `O_PATH`.
- Add regression for f*xattr operations on `O_PATH` fds.
- Unblock the gVisor `XattrTest.XattrWithOPath` case.
- Remove the stale gVisor blocklist entry for the old `EventfdTest.NotifyNonZero_NoRandomSave` test name.

## Testing

- `./xattr_test --gtest_filter=XattrTest.XattrWithOPath`

  ```text
  [  PASSED  ] 1 test.
  ```

- `./eventfd_test --gtest_filter=EventfdTest.NotifyNonZero`

  ```text
  [  PASSED  ] 1 test.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

## Aditional

The removed eventfd entry came from the old `asterinas/gvisor` 20200921.0 test name `EventfdTest.NotifyNonZero_NoRandomSave`. The current Docker image builds `google/gvisor` release-20251215.0, where the test is named `EventfdTest.NotifyNonZero`.