### PR TITLE
Dispatch kernel params by command-line order

### DIFF
--- a/kernel/comps/cmdline/src/dispatch.rs
+++ b/kernel/comps/cmdline/src/dispatch.rs
@@ -9,6 +9,7 @@ use alloc::{
     collections::BTreeMap,
     ffi::CString,
     string::{String, ToString},
+    vec,
     vec::Vec,
 };
 
@@ -117,8 +118,8 @@ fn dispatch_params(cmdline: &str) -> InitprocArgs {
     }
 
     // Step 2: Tokenize the kernel command line and group recognized param by normalized name.
-    let mut grouped: BTreeMap<String, Vec<Option<&str>>> = BTreeMap::new();
-    for arg in split_arg(cmdline) {
+    let mut grouped: BTreeMap<String, (Vec<Option<&str>>, usize)> = BTreeMap::new();
+    for (pos, arg) in split_arg(cmdline).enumerate() {
         // Everything after "--" goes to init.
         if kcmdline_end {
             result.argv.push(CString::new(arg).unwrap());
@@ -138,7 +139,13 @@ fn dispatch_params(cmdline: &str) -> InitprocArgs {
 
         if registry.contains_key(normalized.as_str()) {
             // Group by normalized name
-            grouped.entry(normalized).or_default().push(value);
+            grouped
+                .entry(normalized)
+                .and_modify(|occurrences| {
+                    occurrences.0.push(value);
+                    occurrences.1 = pos;
+                })
+                .or_insert_with(|| (vec![value], pos));
         } else {
             // Unknown parameter: forward to init
             if key.contains('.') {
@@ -160,15 +167,23 @@ fn dispatch_params(cmdline: &str) -> InitprocArgs {
     }
 
     // Step 3: Dispatch each group to its handler.
-    let (early_params, params): (Vec<_>, Vec<_>) = grouped
+    let (mut early_params, mut params): (Vec<_>, Vec<_>) = grouped
         .iter()
-        .filter_map(|(name, occurrences)| registry.get(name.as_str()).map(|p| (*p, occurrences)))
-        .partition(|(p, _)| p.early);
+        .filter_map(|(name, occurrences)| {
+            registry
+                .get(name.as_str())
+                .map(|param| (*param, occurrences.1, occurrences.0.as_slice()))
+        })
+        .partition(|(param, _, _)| param.early);
+
+    for pending_params in [&mut early_params, &mut params] {
+        pending_params.sort_by_key(|(_, last_pos, _)| *last_pos);
+    }
 
     early_params
         .into_iter()
         .chain(params)
-        .for_each(|(param, occurrences)| (param.setup_fn)(occurrences));
+        .for_each(|(param, _, occurrences)| (param.setup_fn)(occurrences));
 
     result
 }
@@ -215,5 +230,50 @@ mod tests {
         let args = dispatch_params("log_level=4 console=ttyS0 console=ttyS1");
         assert!(args.argv().is_empty());
         assert!(args.envp().is_empty());
+    }
+
+    #[ktest]
+    fn registered_params_dispatched_by_last_position() {
+        use core::sync::atomic::{AtomicU8, Ordering};
+
+        struct SetOne;
+        struct SetTwo;
+
+        static VALUE: AtomicU8 = AtomicU8::new(0);
+        static SET_ONE: SetOne = SetOne;
+        static SET_TWO: SetTwo = SetTwo;
+
+        impl crate::parse::ParamStorage for SetOne {
+            type Value = bool;
+
+            fn store_param(&self, value: Self::Value) {
+                if value {
+                    VALUE.store(1, Ordering::Relaxed);
+                }
+            }
+        }
+
+        impl crate::parse::ParamStorage for SetTwo {
+            type Value = bool;
+
+            fn store_param(&self, value: Self::Value) {
+                if value {
+                    VALUE.store(2, Ordering::Relaxed);
+                }
+            }
+        }
+
+        crate::define_flag_param!("test_set_one", SET_ONE);
+        crate::define_flag_param!("test_set_two", SET_TWO);
+
+        let args = dispatch_params("test_set_one test_set_two");
+        assert!(args.argv().is_empty());
+        assert!(args.envp().is_empty());
+        assert_eq!(VALUE.load(Ordering::Relaxed), 2);
+
+        let args = dispatch_params("test_set_two test_set_one");
+        assert!(args.argv().is_empty());
+        assert!(args.envp().is_empty());
+        assert_eq!(VALUE.load(Ordering::Relaxed), 1);
     }
 }

--- a/kernel/comps/cmdline/src/lib.rs
+++ b/kernel/comps/cmdline/src/lib.rs
@@ -22,9 +22,11 @@
 //!   into the `inventory` registry.
 //! - At early boot the `dispatch` module builds a lookup table from the
 //!   registry, tokenizes the kernel command line, groups recognized
-//!   occurrences and calls the corresponding setup functions. Unrecognized
-//!   tokens are forwarded to the init process as `argv` (bare tokens) or
-//!   `envp` (`key=value`).
+//!   occurrences and calls the corresponding setup functions in
+//!   command-line order (sorted by the last occurrence position of each
+//!   parameter). Early parameters are dispatched before regular ones.
+//!   Unrecognized tokens are forwarded to the init process as `argv`
+//!   (bare tokens) or `envp` (`key=value`).
 //!
 //! Relationship to components
 //! - This crate integrates with the component initialization system. The cmdline


### PR DESCRIPTION
This PR updates kernel command-line parameter dispatching to preserve command-line order across different registered keys.

Linux has command-line parameters where multiple flag keys control the same behavior. A typical example is `ro` and `rw`: both configure the root filesystem mount mode, and Linux applies them with **last-wins** semantics. For example, `ro` `rw` results in read-write, while `rw` `ro` results in read-only.

Previously, Asterinas grouped parameters by key and dispatched groups in map order. That works for repeated occurrences of the same key, but it loses ordering between different keys. As a result, parameters like `ro` and `rw` cannot cleanly share one underlying state while preserving Linux-compatible last-wins behavior.

This PR records the last command-line position for each recognized parameter key. Before dispatching, it partitions early and regular parameters as before, then sorts each group by the recorded last position. This keeps the existing early/non-early dispatch boundary while making cross-key flag interactions deterministic and compatible with Linux-style command-line semantics.