### PR TITLE
[wip] Implement discard (TRIM) for virtio-blk devices

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -77,6 +77,29 @@ impl Bio {
         }
     }
 
+    /// Constructs a new `Bio` for a discard (TRIM) request.
+    ///
+    /// The `start_sid` is the starting sector id on the device, and `nr_sectors`
+    /// is the number of contiguous sectors to discard.
+    pub fn discard(
+        start_sid: Sid,
+        nr_sectors: usize,
+        complete_fn: Option<BioCompleteFn>,
+    ) -> Self {
+        let end_sid = start_sid + nr_sectors as u64;
+        let metadata = Arc::new(BioMetadata {
+            type_: BioType::Discard,
+            sid_range: start_sid..end_sid,
+            status: AtomicU32::new(BioStatus::Init as u32),
+            wait_queue: WaitQueue::new(),
+        });
+        Self {
+            metadata,
+            complete_fn,
+            segments: Vec::new(),
+        }
+    }
+
     /// Returns the type.
     pub fn type_(&self) -> BioType {
         self.metadata.type_()
@@ -340,7 +363,9 @@ pub enum BioType {
     Write = 1,
     /// Flush the volatile write cache.
     Flush = 2,
-    // TODO: Add support for other BIO types, such as discarding sectors.
+    /// Discard (TRIM) sectors — a hint that the data is no longer needed.
+    Discard = 3,
+    // TODO: Add support for other BIO types (SecureErase, WriteZeroes, Zone*).
 }
 
 /// The status of `Bio`.

--- a/kernel/comps/block/src/impl_block_device.rs
+++ b/kernel/comps/block/src/impl_block_device.rs
@@ -80,6 +80,28 @@ impl dyn BlockDevice {
         let status = bio.submit_and_wait(self)?;
         Ok(status)
     }
+
+    /// Issues a discard (TRIM) request for the given sector-aligned range.
+    ///
+    /// Both `offset` and `len` must be sector-aligned. An empty length is a no-op.
+    pub fn discard(&self, offset: usize, len: usize) -> ostd::Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+
+        if !is_sector_aligned(offset) || !is_sector_aligned(len) {
+            return Err(ostd::Error::InvalidArgs);
+        }
+
+        let nr_sectors = len / SECTOR_SIZE;
+        let start_sid = Sid::from_offset(offset);
+        let bio = Bio::discard(start_sid, nr_sectors, None);
+        let status = bio.submit_and_wait(self)?;
+        match status {
+            BioStatus::Complete => Ok(()),
+            _ => Err(ostd::Error::IoError),
+        }
+    }
 }
 
 impl VmIo for dyn BlockDevice {

--- a/kernel/comps/nvme/src/device/block_device.rs
+++ b/kernel/comps/nvme/src/device/block_device.rs
@@ -131,6 +131,10 @@ impl NvmeBlockDevice {
             BioType::Read => self.device.read(request),
             BioType::Write => self.device.write(request),
             BioType::Flush => self.device.flush(request),
+            BioType::Discard => {
+                // TODO: Implement NVMe Dataset Management command for discard.
+                request.into_bios().for_each(|bio| bio.complete(BioStatus::Complete));
+            }
         }
     }
 }

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -27,7 +27,7 @@ use ostd::{
     sync::SpinLock,
 };
 
-use super::{BlockFeatures, VirtioBlockConfig};
+use super::{BlockFeatures, DISCARD_REQ_SIZE, VirtioBlockConfig, VirtioBlockDiscardReq};
 use crate::{
     VIRTIO_BLOCK_MAJOR_ID,
     device::{
@@ -120,6 +120,7 @@ impl BlockDevice {
             BioType::Read => self.device.read(request),
             BioType::Write => self.device.write(request),
             BioType::Flush => self.device.flush(request),
+            BioType::Discard => self.device.discard(request),
         }
     }
 
@@ -202,6 +203,7 @@ struct DeviceInner {
     transport: SpinLock<Box<dyn VirtioTransport>>,
     block_requests: Arc<DmaStream>,
     block_responses: Arc<DmaStream>,
+    discard_descs: Arc<DmaStream>,
     id_allocator: SyncIdAlloc,
     submitted_requests: SpinLock<BTreeMap<u16, SubmittedRequest>>,
 }
@@ -247,9 +249,12 @@ impl DeviceInner {
             Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
         let block_responses =
             Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
+        let discard_descs =
+            Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
         const {
             assert!(Self::QUEUE_SIZE as usize * REQ_SIZE <= PAGE_SIZE);
             assert!(Self::QUEUE_SIZE as usize * RESP_SIZE <= PAGE_SIZE);
+            assert!(Self::QUEUE_SIZE as usize * DISCARD_REQ_SIZE <= PAGE_SIZE);
         }
 
         let device = Arc::new(Self {
@@ -259,6 +264,7 @@ impl DeviceInner {
             transport: SpinLock::new(transport),
             block_requests,
             block_responses,
+            discard_descs,
             id_allocator: SyncIdAlloc::with_capacity(Self::QUEUE_SIZE as usize),
             submitted_requests: SpinLock::new(BTreeMap::new()),
         });
@@ -464,6 +470,77 @@ impl DeviceInner {
             }
             let token = queue
                 .add_dma_bufs(inputs.as_slice(), &[&resp_slice])
+                .expect("add queue failed");
+            if queue.should_notify() {
+                queue.notify();
+            }
+
+            // Records the submitted request
+            let submitted_request = SubmittedRequest::new(id as u16, bio_request);
+            self.submitted_requests
+                .disable_irq()
+                .lock()
+                .insert(token, submitted_request);
+            return;
+        }
+    }
+
+    /// Discards the specified sectors.
+    fn discard(&self, bio_request: BioRequest) {
+        if !self.features.contains(BlockFeatures::DISCARD) {
+            bio_request.into_bios().for_each(|bio| {
+                bio.complete(BioStatus::Complete);
+            });
+            return;
+        }
+
+        let id = self.id_allocator.alloc();
+        let req_slice = {
+            let req_slice =
+                Slice::new(&self.block_requests, id * REQ_SIZE..(id + 1) * REQ_SIZE);
+            let req = BlockReq {
+                type_: ReqType::Discard as _,
+                reserved: 0,
+                sector: bio_request.sid_range().start.to_raw(),
+            };
+            req_slice.write_val(0, &req).unwrap();
+            req_slice.sync_to_device().unwrap();
+            req_slice
+        };
+
+        let discard_slice = {
+            let discard_slice =
+                Slice::new(&self.discard_descs, id * DISCARD_REQ_SIZE..(id + 1) * DISCARD_REQ_SIZE);
+            let sid_range = bio_request.sid_range();
+            let num_sectors = (sid_range.end.to_raw() - sid_range.start.to_raw()) as u32;
+            let discard_req = VirtioBlockDiscardReq {
+                sector: sid_range.start.to_raw(),
+                num_sectors,
+                flags: 0,
+            };
+            discard_slice.write_val(0, &discard_req).unwrap();
+            discard_slice.sync_to_device().unwrap();
+            discard_slice
+        };
+
+        let resp_slice = {
+            let resp_slice =
+                Slice::new(&self.block_responses, id * RESP_SIZE..(id + 1) * RESP_SIZE);
+            resp_slice.write_val(0, &BlockResp::default()).unwrap();
+            resp_slice.sync_to_device().unwrap();
+            resp_slice
+        };
+
+        // One descriptor for the input `req_slice`, one for the input `discard_slice`,
+        // and one for the output `resp_slice`.
+        let num_used_descs = 3;
+        loop {
+            let mut queue = self.queue.disable_irq().lock();
+            if num_used_descs > queue.available_desc() {
+                continue;
+            }
+            let token = queue
+                .add_dma_bufs(&[&req_slice, &discard_slice], &[&resp_slice])
                 .expect("add queue failed");
             if queue.should_notify() {
                 queue.notify();

--- a/kernel/comps/virtio/src/device/block/mod.rs
+++ b/kernel/comps/virtio/src/device/block/mod.rs
@@ -31,7 +31,8 @@ bitflags! {
         const DISCARD       = 1 << 13;
         const WRITE_ZEROES  = 1 << 14;
 
-        const ALL_SUPPORTED = Self::BLK_SIZE.bits() | Self::FLUSH.bits();
+        const ALL_SUPPORTED =
+            Self::BLK_SIZE.bits() | Self::FLUSH.bits() | Self::DISCARD.bits();
     }
 }
 
@@ -123,6 +124,19 @@ struct VirtioBlockTopology {
     /// Optimal sustained I/O size in logical blocks.
     opt_io_size: u32,
 }
+
+/// A VirtIO block discard descriptor.
+///
+/// Refer to VirtIO 1.2 spec, Section 5.2.6.3 (discard command).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct VirtioBlockDiscardReq {
+    pub sector: u64,
+    pub num_sectors: u32,
+    pub flags: u32,
+}
+
+pub(super) const DISCARD_REQ_SIZE: usize = size_of::<VirtioBlockDiscardReq>();
 
 impl VirtioBlockConfig {
     pub(self) fn new_manager(transport: &dyn VirtioTransport) -> ConfigManager<Self> {

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -87,6 +87,12 @@ mod ioctl_defs {
     /// ioctl must return that larger value. Otherwise user programs will align
     /// correctly for the device but still hit `EINVAL` at the filesystem.
     pub(super) type BlkGetSectorSize = ioc!(BLKSSZGET, 0x12, 104, NoData);
+
+    /// Discards sectors on a block device.
+    ///
+    /// Argument is a `uint64_t[2]` (`{start_byte, length}`), both
+    /// sector-aligned. Discarded reads return zeroes on supported devices.
+    pub(super) type BlkDiscard = ioc!(BLKDISCARD, 0x12, 119, NoData);
 }
 
 /// Represents a block device inode in the filesystem.
@@ -221,6 +227,19 @@ impl PerOpenFileOps for OpenBlockFile {
             cmd @ BlkGetSize64 => {
                 let size = (self.0.metadata().nr_sectors * SECTOR_SIZE) as u64;
                 cmd.write(&size)?;
+                Ok(0)
+            }
+            _cmd @ BlkDiscard => {
+                let [offset, len]: [u64; 2] = current_userspace!().read_val(raw_ioctl.arg())?;
+                let offset = offset as usize;
+                let len = len as usize;
+                if offset % SECTOR_SIZE != 0 || len % SECTOR_SIZE != 0 || len == 0 {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "offset and length must be sector-aligned and non-zero"
+                    );
+                }
+                self.0.discard(offset, len)?;
                 Ok(0)
             }
             _ => return_errno_with_message!(


### PR DESCRIPTION
## Summary

This PR implements the `BLKDISCARD` ioctl for block devices, enabling userspace to issue discard (TRIM) operations to supported block devices. The implementation includes:

- Userspace interface: `BLKDISCARD` ioctl handler in the block device registry

- Core block layer: New `BioType::Discard` and `Bio::discard()` constructor

- VirtIO-blk driver: Full discard/TRIM support using the `VIRTIO_BLK_T_DISCARD` command


The discard operation is a hint to the underlying storage device that the specified range of sectors is no longer in use, allowing the device to optimize garbage collection and improve performance.

## Future Work

- Implement NVMe Dataset Management command for true NVMe discard support

- Consider adding BioType::SecureErase and BioType::WriteZeroes