### PR TITLE
Add GDB helpers for kernel debugging

### DIFF
--- a/.github/workflows/test_gdb_helpers.yml
+++ b/.github/workflows/test_gdb_helpers.yml
@@ -1,0 +1,53 @@
+name: Test GDB helpers
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - scripts/gdb/**
+      - Makefile
+      - .github/workflows/test_gdb_helpers.yml
+      - book/src/kernel/debugging-with-gdb.md
+      - book/src/osdk/reference/commands/debug.md
+      - kernel/src/fs/file/file_table.rs
+      - kernel/src/process/pid_table.rs
+      - kernel/src/process/posix_thread/mod.rs
+      - kernel/src/process/posix_thread/name.rs
+      - kernel/src/thread/mod.rs
+      - osdk/src/cli.rs
+      - osdk/src/commands/debug.rs
+      - ostd/src/timer/jiffies.rs
+      - ostd/src/timer/mod.rs
+      - rust-toolchain.toml
+  push:
+    branches:
+      - main
+    paths:
+      - scripts/gdb/**
+      - Makefile
+      - .github/workflows/test_gdb_helpers.yml
+      - book/src/kernel/debugging-with-gdb.md
+      - book/src/osdk/reference/commands/debug.md
+      - kernel/src/fs/file/file_table.rs
+      - kernel/src/process/pid_table.rs
+      - kernel/src/process/posix_thread/mod.rs
+      - kernel/src/process/posix_thread/name.rs
+      - kernel/src/thread/mod.rs
+      - osdk/src/cli.rs
+      - osdk/src/commands/debug.rs
+      - ostd/src/timer/jiffies.rs
+      - ostd/src/timer/mod.rs
+      - rust-toolchain.toml
+
+jobs:
+  gdb-smoke-test:
+    runs-on: ubuntu-4-cores-150GB-ssd
+    container:
+      image: asterinas/asterinas:0.18.0-20260702
+      options: -v /dev:/dev --privileged
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run GDB smoke test
+        run: |
+          make gdb-smoke-test

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ cachix.list
 
 # temporary configuration file for NixOS tests
 distro/etc_nixos/_config_for_test.nix
+
+# Python bytecode cache from the GDB helper scripts
+__pycache__/
+*.py[cod]
+
+# Local GDB configuration
+.gdbinit

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,10 @@ gdb_server: initramfs $(CARGO_OSDK)
 gdb_client: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk debug $(CARGO_OSDK_BUILD_ARGS) --remote :$(GDB_TCP_PORT)
 
+.PHONY: gdb-smoke-test
+gdb-smoke-test: kernel
+	@bash scripts/gdb/test/run_smoke.sh $(CARGO_OSDK_BUILD_ARGS)
+
 .PHONY: profile_server
 profile_server: initramfs $(CARGO_OSDK)
 	@cd kernel && cargo osdk run $(CARGO_OSDK_BUILD_ARGS) --gdb-server addr=:$(GDB_TCP_PORT)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -47,6 +47,7 @@
 * [VM-based Containers](kernel/vm-based-containers/README.md)
     * [Kata Containers](kernel/vm-based-containers/kata.md)
     * [Confidential Containers (CoCo)](kernel/vm-based-containers/coco.md)
+* [Debugging the Kernel with GDB](kernel/debugging-with-gdb.md)
 * [Roadmap](kernel/roadmap.md)
 
 # Asterinas OSTD

--- a/book/src/kernel/debugging-with-gdb.md
+++ b/book/src/kernel/debugging-with-gdb.md
@@ -1,0 +1,157 @@
+# Debugging the Kernel with GDB
+
+## Overview
+
+Asterinas provides GDB helper scripts in `scripts/gdb/`.
+The helpers can be loaded in `rust-gdb` to inspect kernel objects,
+format common wrapper types, and run inspection commands.
+
+The helpers are written in Python and are organized into several modules.
+
+| Module | Description |
+|--------|-------------|
+| `helper/layout.py` | Reads generic Rust wrappers, collections, atomics, and locks |
+| `helper/kernel.py` | Traverses Asterinas kernel objects |
+| `helper/printers.py` | Registers pretty-printers for wrapper types |
+| `helper/commands.py` | Implements `ast-*` inspection commands |
+| `helper/gdb_bridge.py` | Contains small wrappers around the GDB Python API |
+
+## Loading the helpers
+
+When `cargo osdk debug` is run from the Asterinas workspace,
+it loads the helpers automatically.
+
+The helpers can also be loaded manually after connecting `rust-gdb`
+to a running kernel.
+
+```gdb
+(gdb) source scripts/gdb/asterinas-gdb.py
+```
+
+Plain `gdb` can source the script, but some helper functions depend on
+the Rust pretty-printers installed by `rust-gdb`.
+
+## Setting breakpoints
+
+The QEMU GDB server may stop at the x86 reset vector before the kernel
+is mapped at its virtual address. In this state, normal software
+breakpoints cannot be inserted into kernel text.
+
+Use hardware breakpoints when stopping in early kernel code.
+
+```gdb
+(gdb) hbreak __ostd_main
+(gdb) continue
+```
+
+After the kernel has started, continue to a point where the objects of
+interest already exist. For example, the first syscall is late enough
+for PID 1 to be present in the PID table.
+
+```gdb
+(gdb) hbreak aster_kernel::syscall::handle_syscall
+(gdb) continue
+```
+
+## Pretty-printers
+
+The helpers register pretty-printers for the wrapper types that commonly
+hide useful values during debugging.
+
+| Printer | Types |
+|---------|-------|
+| `AtomicScalar` | `core::sync::atomic::Atomic<T>` |
+| `OstdMutex` | `ostd::sync::Mutex<T>` |
+| `OstdRwMutex` | `ostd::sync::RwMutex<T>` |
+| `OstdSpinLock` | `ostd::sync::SpinLock<T, G>` |
+
+Atomic values are printed as scalars.
+Lock wrappers show the lock state and expose the wrapped value as a child.
+
+Examples:
+
+```gdb
+(gdb) p (*$ast_thread(1)).is_exited
+(gdb) p aster_kernel::process::pid_table::PID_TABLE
+```
+
+Use `/r` to print the raw DWARF layout when the wrapper internals are
+needed.
+
+```gdb
+(gdb) p/r (*$ast_thread(1)).is_exited
+```
+
+## Convenience functions
+
+Convenience functions return pointer-like `gdb.Value` objects.
+They are useful when the desired object is reachable only through
+several kernel data structures.
+
+| Function | Returns |
+|----------|---------|
+| `$ast_process(pid)` | `Process *` for the given PID |
+| `$ast_thread(tid)` | `Thread *` for the given TID |
+| `$ast_pid_table()` | `PidTable *` for the global PID table |
+| `$ast_file_table(pid)` | `FileTable *` for the given process |
+
+Examples:
+
+```gdb
+(gdb) p *$ast_process(1)
+(gdb) p (*$ast_process(1)).pid
+(gdb) p *$ast_thread(1)
+(gdb) p *$ast_file_table(1)
+```
+
+## Commands
+
+The helpers also provide commands for inspection tasks that require
+iteration or formatted output.
+
+| Command | Description |
+|---------|-------------|
+| `ast-version` | Print the kernel version |
+| `ast-ps [PID]` | List processes, optionally filtered by PID |
+| `ast-threads` | List threads and their owning PIDs |
+| `ast-pstree` | Show the process tree |
+| `ast-fds <PID>` | List file descriptors for a process |
+| `ast-uptime` | Print uptime from kernel jiffies |
+
+Example:
+
+```gdb
+(gdb) ast-ps
+   PID    PPID  STATE      THREADS  NAME
+     1       0  Running          1  init
+```
+
+## Smoke test
+
+The smoke test boots the kernel with a GDB server, attaches `rust-gdb`,
+loads the helpers, and checks printers, convenience functions, and
+commands.
+
+```bash
+make gdb-smoke-test
+```
+
+The same test is run by `.github/workflows/test_gdb_helpers.yml`.
+
+## Maintenance
+
+The helpers depend on Rust symbol names, type paths, and struct layouts.
+Hardcoded names and constants are kept in
+`scripts/gdb/helper/constants.py`.
+Generic Rust layout traversal is implemented in
+`scripts/gdb/helper/layout.py`.
+Asterinas-specific traversal is implemented in
+`scripts/gdb/helper/kernel.py`.
+
+Rust definitions that are used by the helpers carry a `COUPLED` marker.
+When changing a marked definition, update the referenced helper code in
+the same patch.
+
+```bash
+grep -rn "// COUPLED: scripts/gdb" kernel/ ostd/
+```

--- a/book/src/osdk/reference/commands/debug.md
+++ b/book/src/osdk/reference/commands/debug.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-`cargo osdk debug` is used to debug a remote target via GDB. You need to start
-a running server to debug with. This is accomplished by the `run` subcommand
-with `--gdb-server`. Then you can use the following command to attach to the
-server and do debugging.
+`cargo osdk debug` is used to debug a remote target via `rust-gdb`.
+You need to start a running server to debug with. This is accomplished
+by the `run` subcommand with `--gdb-server`. Then you can use the
+following command to attach to the server and do debugging.
 
 ```bash
 cargo osdk debug [OPTIONS]
@@ -13,6 +13,9 @@ cargo osdk debug [OPTIONS]
 
 Note that when KVM is enabled, hardware-assisted break points (`hbreak`) are
 needed instead of the normal break points (`break`/`b`) in GDB.
+
+When run from the Asterinas workspace, this command also loads the
+project GDB helpers from `scripts/gdb/asterinas-gdb.py`.
 
 ## Options
 

--- a/kernel/src/fs/file/file_table.rs
+++ b/kernel/src/fs/file/file_table.rs
@@ -102,6 +102,7 @@ impl TryFrom<RawFileDesc> for FileDesc {
     }
 }
 
+// COUPLED: scripts/gdb/helper/kernel.py
 #[derive(Clone)]
 pub struct FileTable {
     table: SlotVec<FileTableEntry>,

--- a/kernel/src/process/pid_table.rs
+++ b/kernel/src/process/pid_table.rs
@@ -16,6 +16,7 @@ use crate::{
     thread::{Thread, Tid},
 };
 
+// COUPLED: scripts/gdb/helper/kernel.py
 static PID_TABLE: Mutex<PidTable> = Mutex::new(PidTable::new());
 
 /// The unified PID table.

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -48,6 +48,7 @@ pub use posix_thread_ext::AsPosixThread;
 pub use robust_list::RobustListHead;
 pub use thread_local::{AsThreadLocal, FileTableRefMut, ThreadLocal};
 
+// COUPLED: scripts/gdb/helper/kernel.py
 pub struct PosixThread {
     // Immutable part
     process: Weak<Process>,

--- a/kernel/src/process/posix_thread/name.rs
+++ b/kernel/src/process/posix_thread/name.rs
@@ -2,6 +2,7 @@
 
 use crate::prelude::*;
 
+// COUPLED: scripts/gdb/helper/kernel.py
 pub const MAX_THREAD_NAME_LEN: usize = 16;
 
 #[derive(Clone, Debug)]

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -70,6 +70,7 @@ pub(super) fn init() {
     ostd::arch::trap::inject_user_page_fault_handler(exception::page_fault_handler);
 }
 
+// COUPLED: scripts/gdb/helper/kernel.py
 /// A thread is a wrapper on top of task.
 #[derive(Debug)]
 pub struct Thread {

--- a/osdk/src/commands/debug.rs
+++ b/osdk/src/commands/debug.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use std::path::PathBuf;
+
 use crate::{
     cli::DebugArgs,
     commands::util::bin_file_name,
-    util::{get_kernel_crate, get_target_directory, new_command_checked_exists},
+    util::{
+        get_cargo_metadata, get_kernel_crate, get_target_directory, new_command_checked_exists,
+    },
 };
 
 pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
@@ -15,19 +19,37 @@ pub fn execute_debug_command(_profile: &str, args: &DebugArgs) {
         .join(bin_file_name());
     println!("Debugging {}", file_path.display());
 
-    let mut gdb = new_command_checked_exists("gdb");
+    let mut gdb = new_command_checked_exists("rust-gdb");
     gdb.args([
         format!("{}", file_path.display()).as_str(),
         "-ex",
         format!("target remote {}", remote).as_str(),
     ]);
+
+    if let Some(helper_script) = asterinas_gdb_script() {
+        let source_cmd = format!("source {}", helper_script.display());
+        gdb.args(["-ex", &source_cmd]);
+    }
+
     gdb.status().unwrap();
 }
 
 #[test]
-fn have_gdb_installed() {
-    let output = new_command_checked_exists("gdb").arg("--version").output();
-    assert!(output.is_ok(), "Failed to run gdb");
+fn have_rust_gdb_installed() {
+    let output = new_command_checked_exists("rust-gdb")
+        .arg("--version")
+        .output();
+    assert!(output.is_ok(), "Failed to run rust-gdb");
     let stdout = String::from_utf8_lossy(&output.unwrap().stdout).to_string();
     assert!(stdout.contains("GNU gdb"));
+}
+
+fn asterinas_gdb_script() -> Option<PathBuf> {
+    let metadata = get_cargo_metadata(None::<&str>, None::<&[&str]>)?;
+    let workspace_root = metadata.get("workspace_root")?.as_str()?;
+    let script = PathBuf::from(workspace_root)
+        .join("scripts")
+        .join("gdb")
+        .join("asterinas-gdb.py");
+    script.exists().then_some(script)
 }

--- a/ostd/src/timer/jiffies.rs
+++ b/ostd/src/timer/jiffies.rs
@@ -14,6 +14,7 @@ use super::TIMER_FREQ;
 #[derive(Clone, Copy, Debug)]
 pub struct Jiffies(u64);
 
+// COUPLED: scripts/gdb/helper/kernel.py
 pub(crate) static ELAPSED: AtomicU64 = AtomicU64::new(0);
 
 impl Jiffies {

--- a/ostd/src/timer/mod.rs
+++ b/ostd/src/timer/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 ///
 /// For system performance reasons, this rate cannot be set too high, otherwise most of the time is
 /// spent in executing timer code.
+// COUPLED: scripts/gdb/helper/kernel.py
 pub const TIMER_FREQ: u64 = 1000;
 
 type InterruptCallback = Box<dyn Fn() + Sync + Send>;

--- a/scripts/gdb/asterinas-gdb.py
+++ b/scripts/gdb/asterinas-gdb.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Asterinas GDB Debug Helper Scripts -- Entry Point
+
+This file is sourced by GDB (via .gdbinit or manually) to register
+Asterinas-specific pretty-printers, convenience functions, and commands.
+
+Usage:
+    (gdb) source scripts/gdb/asterinas-gdb.py
+"""
+
+# Add scripts/gdb/ to sys.path first so the `helper` package is
+# importable.  This must happen before `import gdb` because later
+# code does `from helper.xxx import ...` which requires the path
+# to be set up.
+import sys
+import os
+
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
+
+import gdb  # noqa: E402  (must come after sys.path setup)
+
+
+def _has_pretty_printer(scope, name):
+    """Return whether ``scope`` already has a named pretty-printer."""
+    return any(
+        getattr(printer, "name", None) == name
+        for printer in getattr(scope, "pretty_printers", [])
+    )
+
+
+def _check_rust_pretty_printers():
+    """Register the rust-gdb stdlib pretty-printers if available.
+
+    The Asterinas kernel ELF is built for ``x86_64-unknown-none`` and
+    therefore lacks the ``.debug_gdb_scripts`` section that normally
+    triggers automatic loading of the Rust standard-library printers.
+    Even when launched via ``rust-gdb`` (which sets ``PYTHONPATH`` to
+    include ``$rustlib/etc``), the printers stay dormant unless we
+    explicitly call ``register_printers``.
+    """
+    try:
+        import gdb_lookup
+    except ImportError:
+        return False
+    try:
+        objfile = gdb.current_objfile()
+        progspace = gdb.current_progspace()
+        if (
+            (objfile is not None and _has_pretty_printer(objfile, "rust"))
+            or _has_pretty_printer(progspace, "rust")
+        ):
+            return True
+
+        gdb_lookup.register_printers(
+            objfile if objfile is not None else progspace
+        )
+    except Exception:
+        try:
+            progspace = gdb.selected_inferior().progspace
+            if _has_pretty_printer(progspace, "rust"):
+                return True
+            gdb_lookup.register_printers(progspace)
+        except Exception:
+            return False
+    return True
+
+
+class AstVersion(gdb.Command):
+    """Print Asterinas kernel version."""
+
+    def __init__(self):
+        super().__init__("ast-version", gdb.COMMAND_USER)
+
+    def invoke(self, arg, from_tty):
+        version_file = os.path.join(_script_dir, "..", "..", "VERSION")
+        try:
+            with open(version_file) as f:
+                gdb.write(f"Asterinas {f.read().strip()}\n")
+        except OSError:
+            gdb.write("Asterinas (version unknown)\n")
+
+
+def _register():
+    """Register all helpers."""
+    AstVersion()
+
+    loaded = []
+    warnings = []
+    for name in ("printers",):
+        try:
+            mod = __import__(f"helper.{name}", fromlist=[name])
+            if hasattr(mod, "register"):
+                mod.register()
+            loaded.append(name)
+        except Exception as e:
+            warnings.append(f"{name}: {e}")
+    return loaded, warnings
+
+
+if getattr(gdb, "_asterinas_helpers_loaded", False):
+    gdb.write("Asterinas GDB helpers already loaded.\n")
+else:
+    _rust_pp = _check_rust_pretty_printers()
+    _loaded, _warnings = _register()
+    gdb._asterinas_helpers_loaded = True
+
+    if _warnings:
+        for w in _warnings:
+            gdb.write(f"Warning: failed to load helper module: {w}\n")
+
+    if not _rust_pp:
+        gdb.write(
+            "Warning: rust-gdb pretty-printers not detected.\n"
+            "  The Asterinas helpers work best with rust-gdb.\n"
+            "  Use `cargo osdk debug` or launch `rust-gdb` directly.\n"
+        )
+
+    _tag = "rust-pp: active" if _rust_pp else "rust-pp: off"
+    gdb.write(
+        f"Asterinas GDB helpers loaded "
+        f"({', '.join(_loaded) if _loaded else 'core only'}). "
+        f"[{_tag}]. "
+        "Type 'ast-version' to check kernel version.\n"
+    )

--- a/scripts/gdb/asterinas-gdb.py
+++ b/scripts/gdb/asterinas-gdb.py
@@ -90,7 +90,7 @@ def _register():
 
     loaded = []
     warnings = []
-    for name in ("printers",):
+    for name in ("printers", "kernel"):
         try:
             mod = __import__(f"helper.{name}", fromlist=[name])
             if hasattr(mod, "register"):

--- a/scripts/gdb/asterinas-gdb.py
+++ b/scripts/gdb/asterinas-gdb.py
@@ -90,7 +90,7 @@ def _register():
 
     loaded = []
     warnings = []
-    for name in ("printers", "kernel"):
+    for name in ("printers", "kernel", "commands"):
         try:
             mod = __import__(f"helper.{name}", fromlist=[name])
             if hasattr(mod, "register"):

--- a/scripts/gdb/helper/__init__.py
+++ b/scripts/gdb/helper/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MPL-2.0

--- a/scripts/gdb/helper/commands.py
+++ b/scripts/gdb/helper/commands.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+GDB user commands for Asterinas inspection.
+
+Commands only parse arguments and format rows.  The Rust layout knowledge
+is kept in ``helper.kernel``.
+"""
+
+import gdb
+
+from helper import gdb_bridge, kernel
+from helper.layout import IntrospectionError
+
+
+def ast_ps(arg):
+    try:
+        filter_pid = (
+            gdb_bridge.parse_int_arg(arg, "PID") if arg.strip() else None
+        )
+        rows = list(kernel.iter_process_rows(filter_pid))
+        gdb_bridge.write_table(
+            (
+                ("PID", 6, ">"),
+                ("PPID", 6, ">"),
+                ("STATE", 10, "<"),
+                ("THREADS", 7, ">"),
+                ("NAME", None, "<"),
+            ),
+            ((row.pid, row.ppid, row.state, row.thread_count, row.name)
+             for row in rows),
+        )
+        if filter_pid is not None and not rows:
+            gdb.write(f"No process with PID {filter_pid}\n")
+    except ValueError as error:
+        gdb_bridge.write_error(error)
+    except (gdb.error, IntrospectionError) as error:
+        gdb_bridge.write_error(f"cannot read PID table: {error}")
+
+
+def ast_threads(arg):
+    try:
+        gdb_bridge.write_table(
+            (("TID", 6, ">"), ("PID", 6, ">"), ("NAME", None, "<")),
+            ((row.tid, row.pid, row.name) for row in kernel.iter_thread_rows()),
+        )
+    except (gdb.error, IntrospectionError) as error:
+        gdb_bridge.write_error(f"cannot read PID table: {error}")
+
+
+def ast_pstree(arg):
+    try:
+        roots, children, rows_by_pid = kernel.process_tree()
+        if not rows_by_pid:
+            gdb.write("No processes found\n")
+            return
+
+        def walk(pid, prefix, is_last):
+            row = rows_by_pid[pid]
+            connector = "`-- " if is_last else "|-- "
+            gdb.write(f"{prefix}{connector}{row.name}({pid}) [{row.state}]\n")
+            child_prefix = prefix + ("    " if is_last else "|   ")
+            kids = sorted(children.get(pid, []))
+            for idx, child in enumerate(kids):
+                walk(child, child_prefix, idx == len(kids) - 1)
+
+        for root in roots:
+            row = rows_by_pid[root]
+            gdb.write(f"{row.name}({root}) [{row.state}]\n")
+            kids = sorted(children.get(root, []))
+            for idx, child in enumerate(kids):
+                walk(child, "", idx == len(kids) - 1)
+    except (gdb.error, IntrospectionError) as error:
+        gdb_bridge.write_error(f"cannot read PID table: {error}")
+
+
+def ast_fds(arg):
+    try:
+        target_pid = gdb_bridge.parse_int_arg(arg, "PID")
+        rows = kernel.fd_rows(target_pid)
+        gdb_bridge.write_table(
+            (
+                ("FD", 4, ">"),
+                ("FLAGS", 5, ">"),
+                ("TYPE", None, "<"),
+                ("", None, "<"),
+            ),
+            ((row.fd, row.flags, row.fd_type, row.flag_text) for row in rows),
+        )
+    except ValueError:
+        gdb.write("Usage: ast-fds <PID>\n")
+    except LookupError as error:
+        gdb.write(f"{error}\n")
+    except (gdb.error, IntrospectionError) as error:
+        gdb_bridge.write_error(error)
+
+
+def ast_uptime(arg):
+    try:
+        uptime = kernel.uptime_snapshot()
+        total_secs = uptime.jiffies // uptime.frequency_hz
+        millis = uptime.jiffies % uptime.frequency_hz
+        hours = total_secs // 3600
+        mins = (total_secs % 3600) // 60
+        secs = total_secs % 60
+        gdb.write(
+            f"Uptime: {hours:02d}:{mins:02d}:{secs:02d}.{millis:03d}  "
+            f"({uptime.jiffies} jiffies, {uptime.frequency_hz} Hz)\n"
+        )
+    except (gdb.error, IntrospectionError) as error:
+        gdb_bridge.write_error(error)
+
+
+def register():
+    """Register all user commands."""
+    gdb_bridge.Command("ast-ps", ast_ps)
+    gdb_bridge.Command("ast-threads", ast_threads)
+    gdb_bridge.Command("ast-pstree", ast_pstree)
+    gdb_bridge.Command("ast-fds", ast_fds)
+    gdb_bridge.Command("ast-uptime", ast_uptime)

--- a/scripts/gdb/helper/constants.py
+++ b/scripts/gdb/helper/constants.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Single source of truth for kernel-side knowledge the GDB helpers depend on.
+
+When any entry here becomes wrong (renamed symbol, changed layout),
+the helpers may fail or produce misleading output.  Any developer
+updating a coupled Rust data structure should grep this file.
+
+Each entry cross-references the Rust source file that must stay in sync.
+Rust-side ``COUPLED`` markers point at the helper module that traverses
+the coupled layout.
+"""
+
+# --- Crate prefixes ---
+_CRATE = "aster_kernel"
+_OSTD = "ostd"
+_ALLOC = "alloc"
+
+# --- Global symbols ---
+
+# COUPLED -> kernel/src/process/pid_table.rs
+PID_TABLE_SYMBOL = f"{_CRATE}::process::pid_table::PID_TABLE"
+
+# COUPLED -> ostd/src/timer/jiffies.rs
+ELAPSED_JIFFIES_SYMBOL = f"{_OSTD}::timer::jiffies::ELAPSED"
+
+# COUPLED -> ostd/src/timer/mod.rs
+TIMER_FREQ_HZ = 1000
+
+# --- Box<dyn Any> downcast type names ---
+
+# COUPLED -> kernel/src/thread/mod.rs
+TASK_DATA_CONCRETE = (
+    f"{_ALLOC}::sync::Arc<{_CRATE}::thread::Thread, "
+    f"{_ALLOC}::alloc::Global>"
+)
+
+# COUPLED -> kernel/src/process/posix_thread/mod.rs
+THREAD_DATA_CONCRETE = f"{_CRATE}::process::posix_thread::PosixThread"
+
+# --- Layout constants ---
+
+# COUPLED -> kernel/src/process/posix_thread/name.rs
+THREAD_NAME_MAX_LEN = 16
+
+# --- File vtable markers ---
+# Used to identify Arc<dyn FileLike> concrete type from its vtable symbol.
+# COUPLED -> kernel/src/fs/file/file_table.rs
+FILE_VTABLE_MARKERS = (
+    "InodeFile",
+    "Socket",
+    "EventFile",
+    "EpollFile",
+    "TimerFile",
+    "PipeReader",
+    "PipeWriter",
+    "Pipe",
+    "UnixStream",
+    "TcpSocket",
+    "UdpSocket",
+    "DevPts",
+)

--- a/scripts/gdb/helper/gdb_bridge.py
+++ b/scripts/gdb/helper/gdb_bridge.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Small bridge helpers around the GDB Python API.
+
+The rest of the helpers should speak in kernel objects and rows.  This
+module keeps user-interface details such as pointer conversion, argument
+parsing, table formatting, and diagnostic printing in one place.
+"""
+
+import gdb
+
+
+class Command(gdb.Command):
+    """Thin adapter from a Python handler to a GDB command."""
+
+    def __init__(self, name, handler):
+        super().__init__(name, gdb.COMMAND_USER)
+        self._handler = handler
+
+    def invoke(self, arg, from_tty):
+        self._handler(arg)
+
+
+class Function(gdb.Function):
+    """Thin adapter from a Python handler to a GDB convenience function."""
+
+    def __init__(self, name, handler):
+        super().__init__(name)
+        self._handler = handler
+
+    def invoke(self, *args):
+        return self._handler(*args)
+
+
+def to_pointer(value):
+    """Return a pointer-like ``gdb.Value`` for a memory-backed value."""
+    addr = int(value.address) if value.address is not None else None
+    if addr is None:
+        return value
+    return gdb.Value(addr).cast(value.type.pointer())
+
+
+def parse_int_arg(arg, name):
+    """Parse a required integer command argument."""
+    text = arg.strip()
+    if not text:
+        raise ValueError(f"missing {name}")
+    try:
+        return int(text)
+    except ValueError as error:
+        raise ValueError(f"invalid {name} '{text}'") from error
+
+
+def write_error(message):
+    """Print a command error in the normal helper style."""
+    gdb.write(f"Error: {message}\n")
+
+
+def _format_cell(value, width, align):
+    text = str(value)
+    if width is None:
+        return text
+    if align == "<":
+        return text.ljust(width)
+    return text.rjust(width)
+
+
+def write_table(columns, rows):
+    """Write aligned table output.
+
+    ``columns`` is a sequence of ``(header, width, align)`` tuples.
+    ``align`` is ``">"`` or ``"<"``.
+    """
+    gdb.write(
+        "  ".join(
+            _format_cell(header, width, align)
+            for header, width, align in columns
+        )
+        + "\n"
+    )
+    for row in rows:
+        gdb.write(
+            "  ".join(
+                _format_cell(value, width, align)
+                for value, (_header, width, align) in zip(row, columns)
+            )
+            + "\n"
+        )

--- a/scripts/gdb/helper/kernel.py
+++ b/scripts/gdb/helper/kernel.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Asterinas kernel object navigation.
+
+This module is the deep interface between the Rust kernel layout and the
+GDB-facing commands.  It returns kernel values, rows, and snapshots while
+keeping field paths such as ``Process.tasks`` and ``PosixThread.name`` local.
+"""
+
+from dataclasses import dataclass
+
+import gdb
+
+from helper import gdb_bridge
+from helper.constants import (
+    ELAPSED_JIFFIES_SYMBOL,
+    FILE_VTABLE_MARKERS,
+    PID_TABLE_SYMBOL,
+    TASK_DATA_CONCRETE,
+    THREAD_DATA_CONCRETE,
+    THREAD_NAME_MAX_LEN,
+    TIMER_FREQ_HZ,
+)
+from helper.layout import (
+    IntrospectionError,
+    lookup_type,
+    read_btree_map,
+    read_global,
+    read_scalar,
+    read_slot_vec,
+    read_vec,
+    unwrap_arc,
+    unwrap_mutex,
+    unwrap_option,
+    unwrap_weak,
+)
+
+
+@dataclass(frozen=True)
+class ProcessRow:
+    pid: int
+    ppid: int
+    state: str
+    thread_count: int
+    name: str
+
+
+@dataclass(frozen=True)
+class ThreadRow:
+    tid: int
+    pid: int
+    name: str
+
+
+@dataclass(frozen=True)
+class FdRow:
+    fd: int
+    flags: int
+    fd_type: str
+    flag_text: str
+
+
+@dataclass(frozen=True)
+class UptimeSnapshot:
+    jiffies: int
+    frequency_hz: int
+
+
+# --- PID table navigation ---
+#
+# COUPLED: kernel/src/process/pid_table.rs
+#   PID_TABLE: Mutex<PidTable>
+#   PidTable { entries: BTreeMap<u32, Arc<PidEntry>>, ... }
+#   PidEntry { inner: Mutex<PidEntryInner> }
+#   PidEntryInner { thread: Weak<Thread>, process: Weak<Process>, ... }
+
+
+def get_pid_table():
+    """Return the global ``PidTable`` inner value."""
+    table_mutex = read_global(PID_TABLE_SYMBOL)
+    if table_mutex is None:
+        raise IntrospectionError(f"Cannot resolve symbol {PID_TABLE_SYMBOL}")
+    _, pid_table = unwrap_mutex(table_mutex)
+    return pid_table
+
+
+def _unwrap_pid_entry(arc_entry):
+    entry = unwrap_arc(arc_entry)
+    _, inner = unwrap_mutex(entry['inner'])
+    return inner
+
+
+def iter_processes():
+    """Yield ``(pid, Process)`` for every live process."""
+    entries = get_pid_table()['entries']
+    for key, arc_entry in read_btree_map(entries):
+        entry = _unwrap_pid_entry(arc_entry)
+        process = unwrap_weak(entry['process'])
+        if process is not None:
+            yield (int(key), process)
+
+
+def iter_threads():
+    """Yield ``(tid, Thread)`` for every live thread."""
+    entries = get_pid_table()['entries']
+    for key, arc_entry in read_btree_map(entries):
+        entry = _unwrap_pid_entry(arc_entry)
+        thread = unwrap_weak(entry['thread'])
+        if thread is not None:
+            yield (int(key), thread)
+
+
+def find_process(pid):
+    """Return the ``Process`` for ``pid`` or ``None``."""
+    for entry_pid, process in iter_processes():
+        if entry_pid == int(pid):
+            return process
+    return None
+
+
+def find_thread(tid):
+    """Return the ``Thread`` for ``tid`` or ``None``."""
+    for entry_tid, thread in iter_threads():
+        if entry_tid == int(tid):
+            return thread
+    return None
+
+
+# --- Task -> Thread -> PosixThread navigation ---
+#
+# COUPLED: kernel/src/thread/mod.rs, kernel/src/process/posix_thread/mod.rs
+#   Task.data: Box<dyn Any + Send + Sync> actually holds Arc<Thread>
+#   Thread.data: Box<dyn Any + Send + Sync> actually holds PosixThread
+
+
+def _cast_boxed_dyn(box_val, concrete_type_name):
+    concrete_type = lookup_type(concrete_type_name)
+    if concrete_type is None:
+        raise IntrospectionError(f"Cannot resolve type {concrete_type_name}")
+    data_addr = int(box_val['pointer'])
+    return gdb.Value(data_addr).cast(concrete_type.pointer()).dereference()
+
+
+def get_thread_from_task(task_val):
+    """Return the ``Thread`` held by ``Task.data``."""
+    thread_arc = _cast_boxed_dyn(task_val['data'], TASK_DATA_CONCRETE)
+    return unwrap_arc(thread_arc)
+
+
+def get_posix_thread_from_thread(thread_val):
+    """Return the ``PosixThread`` held by ``Thread.data``."""
+    return _cast_boxed_dyn(thread_val['data'], THREAD_DATA_CONCRETE)
+
+
+def get_posix_thread_from_task(task_val):
+    """Return the ``PosixThread`` reached from a ``Task``."""
+    return get_posix_thread_from_thread(get_thread_from_task(task_val))
+
+
+# --- Process and thread row readers ---
+#
+# COUPLED: kernel/src/process/posix_thread/name.rs
+#   ThreadName([u8; MAX_THREAD_NAME_LEN])
+
+
+def _read_ppid(process_val):
+    try:
+        return read_scalar(process_val['parent']['pid'])
+    except (gdb.error, IntrospectionError):
+        return 0
+
+
+def _read_status(process_val):
+    try:
+        status = process_val['status']
+        if bool(read_scalar(status['is_zombie'])):
+            return "Zombie"
+        try:
+            if bool(read_scalar(status['stop_status']['is_stopped'])):
+                return "Stopped"
+        except (gdb.error, IntrospectionError):
+            pass
+        return "Running"
+    except (gdb.error, IntrospectionError):
+        return "?"
+
+
+def _read_thread_count(process_val):
+    try:
+        _, task_set = unwrap_mutex(process_val['tasks'])
+        return int(task_set['tasks']['len'])
+    except (gdb.error, IntrospectionError):
+        return 0
+
+
+def _read_thread_name(posix_thread):
+    if posix_thread is None:
+        return "<unknown>"
+    try:
+        _, name_val = unwrap_mutex(posix_thread['name'])
+        try:
+            buf = name_val['__0']
+        except gdb.error:
+            buf = name_val['0']
+
+        bytes_out = bytearray()
+        for idx in range(THREAD_NAME_MAX_LEN):
+            byte = read_scalar(buf[idx])
+            if byte == 0:
+                break
+            bytes_out.append(byte)
+        return bytes_out.decode('utf-8', errors='replace') or "<unnamed>"
+    except (gdb.error, IntrospectionError):
+        return "<unknown>"
+
+
+def _read_process_name(process_val):
+    try:
+        _, task_set = unwrap_mutex(process_val['tasks'])
+        tasks = read_vec(task_set['tasks'])
+        if tasks:
+            first_task = unwrap_arc(tasks[0])
+            return _read_thread_name(get_posix_thread_from_task(first_task))
+    except (gdb.error, IntrospectionError):
+        pass
+    return "<unknown>"
+
+
+def _read_tid(posix_thread):
+    if posix_thread is None:
+        return 0
+    try:
+        return read_scalar(posix_thread['tid'])
+    except (gdb.error, IntrospectionError):
+        return 0
+
+
+def process_row(pid, process_val):
+    """Return the display row for one process."""
+    return ProcessRow(
+        pid=pid,
+        ppid=_read_ppid(process_val),
+        state=_read_status(process_val),
+        thread_count=_read_thread_count(process_val),
+        name=_read_process_name(process_val),
+    )
+
+
+def iter_process_rows(filter_pid=None):
+    """Yield process rows, optionally filtering by PID."""
+    for pid, process in iter_processes():
+        if filter_pid is not None and pid != filter_pid:
+            continue
+        yield process_row(pid, process)
+
+
+def iter_thread_rows():
+    """Yield thread rows for all live threads."""
+    for tid_key, thread in iter_threads():
+        posix_thread = get_posix_thread_from_thread(thread)
+        tid = _read_tid(posix_thread) if posix_thread is not None else tid_key
+        name = _read_thread_name(posix_thread)
+        pid = 0
+        if posix_thread is not None:
+            process = unwrap_weak(posix_thread['process'])
+            if process is not None:
+                pid = read_scalar(process['pid'])
+
+        yield ThreadRow(tid=tid, pid=pid, name=name)
+
+
+def process_tree():
+    """Return ``(roots, children, rows_by_pid)`` for process-tree output."""
+    rows = list(iter_process_rows())
+    rows_by_pid = {row.pid: row for row in rows}
+    children = {}
+    for row in rows:
+        children.setdefault(row.ppid, []).append(row.pid)
+
+    roots = [
+        pid for pid, row in rows_by_pid.items()
+        if row.ppid not in rows_by_pid
+    ]
+    if not roots and rows_by_pid:
+        roots = sorted(rows_by_pid)[:1]
+    return (sorted(roots), children, rows_by_pid)
+
+
+# --- File table and file descriptor readers ---
+#
+# COUPLED: kernel/src/fs/file/file_table.rs, kernel/src/process/posix_thread/mod.rs
+#   PosixThread.file_table: Mutex<Option<RoArc<FileTable>>>
+#   RoArc<T> = Arc<Inner<T>>; Inner<T> { data: RwLock<T>, ... }
+
+
+def _read_file_table_from_thread(posix_thread):
+    _, ft_option = unwrap_mutex(posix_thread['file_table'])
+    is_some, roarc = unwrap_option(ft_option)
+    if not is_some:
+        return None
+
+    try:
+        inner_arc = roarc['__0']
+    except gdb.error:
+        inner_arc = roarc['0']
+    inner = unwrap_arc(inner_arc)
+    try:
+        return inner['data']['val']['value']
+    except gdb.error:
+        return inner['data']['value']
+
+
+def get_file_table(process_val):
+    """Return the ``FileTable`` for ``process_val`` or ``None``."""
+    _, task_set = unwrap_mutex(process_val['tasks'])
+    for task in read_vec(task_set['tasks']):
+        posix_thread = get_posix_thread_from_task(unwrap_arc(task))
+        if posix_thread is None:
+            continue
+
+        file_table = _read_file_table_from_thread(posix_thread)
+        if file_table is not None:
+            return file_table
+
+    return None
+
+
+def _read_fd_type(entry_val):
+    try:
+        vtable_ptr = entry_val['file']['vtable']['pointer']
+        info = gdb.execute(f"info symbol {int(vtable_ptr)}", to_string=True)
+        if "No symbol" in info:
+            return "?"
+        for marker in FILE_VTABLE_MARKERS:
+            if marker in info:
+                return marker
+        if "vtable" in info:
+            parts = info.split("::")
+            for part in reversed(parts):
+                cleaned = part.split("+")[0].strip().rstrip(">").rstrip(",")
+                if cleaned and len(cleaned) > 2 and cleaned[0].isupper():
+                    return cleaned
+        return info.strip()[:40]
+    except (gdb.error, IntrospectionError):
+        return "?"
+
+
+def fd_rows(pid):
+    """Return file descriptor rows for a process PID."""
+    process = find_process(pid)
+    if process is None:
+        raise LookupError(f"No process with PID {pid}")
+
+    file_table = get_file_table(process)
+    if file_table is None:
+        raise IntrospectionError(f"Cannot read file table for PID {pid}")
+
+    rows = []
+    for fd, entry in read_slot_vec(file_table['table']):
+        flags = read_scalar(entry['flags'])
+        rows.append(
+            FdRow(
+                fd=fd,
+                flags=flags,
+                fd_type=_read_fd_type(entry),
+                flag_text="O_CLOEXEC" if flags & 1 else "",
+            )
+        )
+    return rows
+
+
+# --- Time readers ---
+#
+# COUPLED: ostd/src/timer/mod.rs, ostd/src/timer/jiffies.rs
+
+
+def uptime_snapshot():
+    """Return the current kernel uptime snapshot."""
+    elapsed = read_global(ELAPSED_JIFFIES_SYMBOL)
+    if elapsed is None:
+        raise IntrospectionError("cannot read ELAPSED jiffies")
+    return UptimeSnapshot(
+        jiffies=read_scalar(elapsed),
+        frequency_hz=TIMER_FREQ_HZ,
+    )
+
+
+# --- GDB convenience functions ---
+
+
+def _process_ptr(pid):
+    try:
+        process = find_process(int(pid))
+    except (gdb.error, IntrospectionError) as error:
+        raise gdb.GdbError(f"Cannot read PID table: {error}")
+    if process is None:
+        raise gdb.GdbError(f"No process with PID {int(pid)}")
+    return gdb_bridge.to_pointer(process)
+
+
+def _thread_ptr(tid):
+    try:
+        thread = find_thread(int(tid))
+    except (gdb.error, IntrospectionError) as error:
+        raise gdb.GdbError(f"Cannot read PID table: {error}")
+    if thread is None:
+        raise gdb.GdbError(f"No thread with TID {int(tid)}")
+    return gdb_bridge.to_pointer(thread)
+
+
+def _pid_table_ptr():
+    try:
+        return gdb_bridge.to_pointer(get_pid_table())
+    except (gdb.error, IntrospectionError) as error:
+        raise gdb.GdbError(f"Cannot read PID table: {error}")
+
+
+def _file_table_ptr(pid):
+    try:
+        process = find_process(int(pid))
+    except (gdb.error, IntrospectionError) as error:
+        raise gdb.GdbError(f"Cannot read PID table: {error}")
+    if process is None:
+        raise gdb.GdbError(f"No process with PID {int(pid)}")
+
+    try:
+        table = get_file_table(process)
+    except (gdb.error, IntrospectionError) as error:
+        raise gdb.GdbError(f"Cannot navigate file table: {error}")
+    if table is None:
+        raise gdb.GdbError(f"No file table for PID {int(pid)}")
+    return gdb_bridge.to_pointer(table)
+
+
+def register():
+    """Register kernel object convenience functions."""
+    gdb_bridge.Function("ast_process", _process_ptr)
+    gdb_bridge.Function("ast_thread", _thread_ptr)
+    gdb_bridge.Function("ast_pid_table", _pid_table_ptr)
+    gdb_bridge.Function("ast_file_table", _file_table_ptr)

--- a/scripts/gdb/helper/layout.py
+++ b/scripts/gdb/helper/layout.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Rust layout readers for the GDB Python API.
+
+This module is the only place that understands generic Rust storage
+wrappers such as ``Arc``, ``Weak``, ``Option``, ``Vec``, ``BTreeMap``,
+``Atomic<T>``, and the ostd lock wrappers.  Higher-level helpers use
+these readers instead of spelling out noisy DWARF paths themselves.
+"""
+
+import re
+
+import gdb
+
+
+class IntrospectionError(Exception):
+    """Raised when a type introspection operation fails."""
+
+    pass
+
+
+_type_cache = {}
+
+
+def _resolve_symbol_value(symbol_name):
+    """Resolve a Rust symbol using the GDB mechanisms that survive GDB 15."""
+    try:
+        sym = gdb.lookup_static_symbol(symbol_name)
+        if sym is not None:
+            return sym.value()
+    except (gdb.error, AttributeError):
+        pass
+
+    try:
+        return gdb.parse_and_eval(f"&{symbol_name}").dereference()
+    except gdb.error:
+        pass
+
+    try:
+        addr_out = gdb.execute(f"info address {symbol_name}", to_string=True)
+        match = re.search(r"(0x[0-9a-fA-F]+)", addr_out)
+        if match is None:
+            return None
+
+        type_out = gdb.execute(f"ptype {symbol_name}", to_string=True)
+        type_match = re.match(r"type\s*=\s*(.*)", type_out.strip(), re.DOTALL)
+        if type_match is None:
+            return None
+
+        type_str = type_match.group(1).strip().rstrip(";")
+        return gdb.parse_and_eval(f"*({type_str} *){match.group(1)}")
+    except gdb.error:
+        return None
+
+
+def lookup_type(type_name):
+    """Look up a Rust type name, caching successful lookups."""
+    if type_name in _type_cache:
+        return _type_cache[type_name]
+    try:
+        rust_type = gdb.lookup_type(type_name)
+        _type_cache[type_name] = rust_type
+        return rust_type
+    except gdb.error:
+        return None
+
+
+def read_global(symbol_name):
+    """Read a global symbol value."""
+    return _resolve_symbol_value(symbol_name)
+
+
+def _get_pp(val):
+    try:
+        return gdb.default_visualizer(val)
+    except Exception:
+        return None
+
+
+def _pp_children(pp):
+    try:
+        return list(pp.children())
+    except Exception:
+        return None
+
+
+def _pp_to_string(pp):
+    try:
+        result = pp.to_string()
+        if result is None:
+            return None
+        if isinstance(result, str):
+            return result
+        if hasattr(result, 'value'):
+            length = result.length
+            if length == 0:
+                return ""
+            encoding = result.encoding or "utf-8"
+            return result.value().string(
+                encoding, errors="replace", length=length
+            )
+        return str(result)
+    except Exception:
+        return None
+
+
+def _read_integer_leaf(value, depth=0):
+    if depth > 8:
+        raise IntrospectionError("nested scalar wrapper is too deep")
+
+    try:
+        return int(value)
+    except (gdb.error, TypeError, ValueError):
+        pass
+
+    for field_name in ('__0', '0', 'value', 'v'):
+        try:
+            return _read_integer_leaf(value[field_name], depth + 1)
+        except (gdb.error, KeyError, IntrospectionError):
+            continue
+
+    try:
+        fields = value.type.fields()
+    except (gdb.error, AttributeError):
+        fields = []
+    if len(fields) == 1:
+        try:
+            return _read_integer_leaf(value[fields[0]], depth + 1)
+        except (gdb.error, KeyError, IntrospectionError):
+            pass
+
+    raise IntrospectionError(f"Failed to read integer from {value.type}")
+
+
+def unwrap_atomic(val):
+    """Unwrap a current Rust ``Atomic<T>`` scalar to its inner integer."""
+    try:
+        return _read_integer_leaf(val['v']['value'])
+    except (gdb.error, KeyError, IntrospectionError):
+        pass
+    raise IntrospectionError("Failed to unwrap atomic value")
+
+
+def read_scalar(value):
+    """Read an integer-like scalar, handling atomics and tuple structs."""
+    try:
+        return int(value)
+    except (gdb.error, TypeError, ValueError):
+        pass
+    try:
+        return unwrap_atomic(value)
+    except IntrospectionError:
+        pass
+    return _read_integer_leaf(value)
+
+
+def unwrap_mutex(mutex_val):
+    """Return ``(locked, value)`` for an ostd ``Mutex<T>``."""
+    try:
+        locked = bool(unwrap_atomic(mutex_val['lock']))
+        return (locked, mutex_val['val']['value'])
+    except (gdb.error, IntrospectionError) as error:
+        raise IntrospectionError(f"Failed to unwrap Mutex: {error}")
+
+
+def unwrap_rwmutex_value(rwmutex_val):
+    """Return the inner value of an ostd ``RwMutex<T>``."""
+    try:
+        return rwmutex_val['val']['value']
+    except gdb.error as error:
+        raise IntrospectionError(f"Failed to unwrap RwMutex: {error}")
+
+
+def _require_pp(val, type_name):
+    pp = _get_pp(val)
+    if pp is None:
+        raise IntrospectionError(
+            f"No rust-gdb printer for {type_name}. "
+            "Use rust-gdb instead of plain gdb."
+        )
+    return pp
+
+
+def unwrap_arc(arc_val):
+    """Dereference ``Arc<T>`` to ``T`` via the rust-gdb printer."""
+    children = _pp_children(_require_pp(arc_val, "Arc"))
+    if children is not None:
+        for name, child in children:
+            if name == "value":
+                return child
+    raise IntrospectionError("Failed to unwrap Arc")
+
+
+def unwrap_option(option_val):
+    """Unwrap ``Option<T>`` and return ``(is_some, value_or_none)``."""
+    failed = object()
+
+    def some_payload(active):
+        for field_name in ('__0', '0'):
+            try:
+                return active[field_name]
+            except (gdb.error, KeyError):
+                continue
+
+        try:
+            fields = active.type.fields()
+        except (gdb.error, AttributeError):
+            fields = []
+        if len(fields) == 1:
+            try:
+                return active[fields[0]]
+            except (gdb.error, KeyError):
+                pass
+
+        return active
+
+    def from_tagged_layout():
+        try:
+            fields = option_val.type.fields()
+            if not fields:
+                return (False, None)
+
+            content = option_val[fields[0]]
+            content_fields = content.type.fields()
+            if not content_fields:
+                return (False, None)
+
+            if len(content_fields) == 1:
+                active_field = content_fields[0]
+            else:
+                active_idx = int(content[content_fields[0]]) + 1
+                if active_idx < 1 or active_idx >= len(content_fields):
+                    return failed
+                active_field = content_fields[active_idx]
+
+            if active_field.name == "None":
+                return (False, None)
+
+            return (True, some_payload(content[active_field]))
+        except (gdb.error, KeyError, TypeError, ValueError):
+            return failed
+
+    def from_direct_variant():
+        # Some niche-optimized Options expose only the active variant.
+        try:
+            for field in option_val.type.fields():
+                if field.name == "Some":
+                    return (True, some_payload(option_val[field]))
+        except (gdb.error, KeyError, TypeError):
+            pass
+        return failed
+
+    result = from_tagged_layout()
+    if result is not failed:
+        return result
+
+    result = from_direct_variant()
+    if result is not failed:
+        return result
+
+    pp = _get_pp(option_val)
+    if pp is None:
+        raise IntrospectionError("Failed to unwrap Option")
+
+    children = _pp_children(pp)
+    if children:
+        return (True, children[0][1])
+    text = _pp_to_string(pp)
+    if text is not None and text.strip() == "None":
+        return (False, None)
+
+    raise IntrospectionError("Failed to unwrap Option")
+
+
+def read_vec(vec_val):
+    """Read elements from ``Vec<T>`` via the rust-gdb printer."""
+    children = _pp_children(_require_pp(vec_val, "Vec"))
+    if children is not None:
+        return [child for _name, child in children]
+    raise IntrospectionError("Failed to read Vec")
+
+
+def read_btree_map(btree_map_val):
+    """Yield ``(key, value)`` pairs from ``BTreeMap<K, V>``."""
+    try:
+        children = list(_require_pp(btree_map_val, "BTreeMap").children())
+        for idx in range(0, len(children) - 1, 2):
+            yield (children[idx][1], children[idx + 1][1])
+    except Exception as error:
+        raise IntrospectionError(f"Failed to traverse BTreeMap: {error}")
+
+
+def _usize_max():
+    return (1 << (gdb.lookup_type('usize').sizeof * 8)) - 1
+
+
+def unwrap_weak(weak_val):
+    """Dereference ``Weak<T>``; return ``None`` when the target is gone."""
+    pp = _get_pp(weak_val)
+    if pp is not None:
+        children = _pp_children(pp)
+        if children is not None:
+            for name, child in children:
+                if name == "value":
+                    return child
+            return None
+        raise IntrospectionError("Failed to unwrap Weak")
+
+    try:
+        ptr = weak_val['ptr']['pointer']
+        ptr_int = int(ptr)
+        if ptr_int == 0 or ptr_int == _usize_max():
+            return None
+        arc_inner = ptr.dereference()
+        if read_scalar(arc_inner['strong']) == 0:
+            return None
+        return arc_inner['data']
+    except (gdb.error, IntrospectionError) as error:
+        raise IntrospectionError(f"Failed to unwrap Weak: {error}")
+
+
+def read_slot_vec(slot_vec_val):
+    """Yield ``(index, value)`` for occupied ``SlotVec<T>`` entries."""
+    try:
+        slots = read_vec(slot_vec_val['slots'])
+        for idx, slot in enumerate(slots):
+            is_some, value = unwrap_option(slot)
+            if is_some:
+                yield (idx, value)
+    except (gdb.error, IntrospectionError) as error:
+        raise IntrospectionError(f"Failed to read SlotVec: {error}")

--- a/scripts/gdb/helper/printers.py
+++ b/scripts/gdb/helper/printers.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+GDB pretty-printers for Asterinas wrapper types.
+
+Registers printers for:
+- core::sync::atomic::Atomic<T>
+- ostd::sync::Mutex<T>
+- ostd::sync::RwMutex<T>
+- ostd::sync::SpinLock<T, G>
+
+These printers collapse the noisy internal layout (UnsafeCell, etc.)
+into readable one-line representations, making every GDB display
+command (``p``, ``bt full``, ``info locals``, watchpoints, IDE panels)
+useful out of the box.
+"""
+
+import gdb.printing
+import gdb
+
+from helper.layout import IntrospectionError, unwrap_atomic
+
+
+class AtomicPrinter:
+    """Collapse Atomic<T> storage wrappers to just N."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            raw = unwrap_atomic(self.val)
+            type_name = str(self.val.type)
+            if "Atomic<bool>" in type_name:
+                return "true" if raw else "false"
+            return str(raw)
+        except (IntrospectionError, gdb.error):
+            return None
+
+    def children(self):
+        return []
+
+
+class MutexPrinter:
+    """Show Mutex(locked=<bool>) = <inner T>."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            locked = bool(unwrap_atomic(self.val['lock']))
+            return f"Mutex(locked={'true' if locked else 'false'})"
+        except (IntrospectionError, gdb.error):
+            return None
+
+    def children(self):
+        try:
+            inner = self.val['val']['value']
+            return [("value", inner)]
+        except gdb.error:
+            return []
+
+
+class RwMutexPrinter:
+    """Show RwMutex = <inner T>.
+
+    The lock field is an AtomicUsize with a complex bitfield encoding
+    (reader count, writer flag, upgrade state).  We intentionally do
+    not parse it; just show the inner value.
+    """
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return "RwMutex"
+
+    def children(self):
+        try:
+            inner = self.val['val']['value']
+            return [("value", inner)]
+        except gdb.error:
+            return []
+
+
+class SpinLockPrinter:
+    """Show SpinLock(locked=<bool>) = <inner T>.
+
+    SpinLock<T, G> is #[repr(transparent)] over SpinLockInner<T>,
+    so we traverse val['inner']['val']['value'] for the inner T
+    and val['inner']['lock'] for the lock state.
+    """
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            locked = bool(unwrap_atomic(self.val['inner']['lock']))
+            return f"SpinLock(locked={'true' if locked else 'false'})"
+        except (IntrospectionError, gdb.error):
+            return None
+
+    def children(self):
+        try:
+            inner = self.val['inner']['val']['value']
+            return [("value", inner)]
+        except gdb.error:
+            return []
+
+
+def build_printer():
+    """Build and return the Asterinas pretty-printer collection."""
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("asterinas")
+    pp.add_printer(
+        "AtomicScalar",
+        r"^core::sync::atomic::Atomic<.*>$",
+        AtomicPrinter,
+    )
+    pp.add_printer(
+        "OstdMutex",
+        r"^ostd::sync::(.*::)?Mutex<.*>$",
+        MutexPrinter,
+    )
+    pp.add_printer(
+        "OstdRwMutex",
+        r"^ostd::sync::(.*::)?RwMutex<.*>$",
+        RwMutexPrinter,
+    )
+    pp.add_printer(
+        "OstdSpinLock",
+        r"^ostd::sync::(.*::)?SpinLock<.*>$",
+        SpinLockPrinter,
+    )
+    return pp
+
+
+def register():
+    """Register the Asterinas printers with GDB."""
+    objfile = gdb.current_objfile()
+    scope = objfile if objfile is not None else gdb.current_progspace()
+    gdb.printing.register_pretty_printer(
+        scope, build_printer(), replace=True
+    )

--- a/scripts/gdb/test/run_smoke.sh
+++ b/scripts/gdb/test/run_smoke.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# Smoke test driver for Asterinas GDB debug helpers.
+# Boots the kernel with a GDB server, runs printer assertions, and
+# reports pass/fail.
+#
+# Usage:
+#   ./scripts/gdb/test/run_smoke.sh
+#   make gdb-smoke-test
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SOCKET_PATH="$PROJECT_ROOT/.osdk-gdb-socket"
+
+BUILD_TARGET_ARCH="${OSDK_TARGET_ARCH:-${TARGET_ARCH:-x86_64}}"
+BUILD_PROFILE="dev"
+QEMU_PID=""
+SMOKE_LOG=""
+GDB_STATUS=0
+
+die() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+ensure_rust_gdb() {
+    if ! command -v rust-gdb >/dev/null 2>&1; then
+        die "rust-gdb is required. Use rustup or the Asterinas dev container."
+    fi
+}
+
+target_triple() {
+    case "$1" in
+        aarch64)
+            echo "aarch64-unknown-none-softfloat"
+            ;;
+        riscv64)
+            echo "riscv64imac-unknown-none-elf"
+            ;;
+        x86_64)
+            echo "x86_64-unknown-none"
+            ;;
+        loongarch64)
+            echo "loongarch64-unknown-none-softfloat"
+            ;;
+        *)
+            echo "Error: unsupported target architecture '$1'" >&2
+            return 1
+            ;;
+    esac
+}
+
+artifact_profile() {
+    case "$1" in
+        dev)
+            echo "debug"
+            ;;
+        *)
+            echo "$1"
+            ;;
+    esac
+}
+
+parse_build_args() {
+    local pending_arg=""
+
+    for arg in "$@"; do
+        if [ "$pending_arg" = "profile" ]; then
+            BUILD_PROFILE="$arg"
+            pending_arg=""
+            continue
+        fi
+        if [ "$pending_arg" = "target_arch" ]; then
+            BUILD_TARGET_ARCH="$arg"
+            pending_arg=""
+            continue
+        fi
+
+        case "$arg" in
+            --profile)
+                pending_arg="profile"
+                ;;
+            --profile=*)
+                BUILD_PROFILE="${arg#--profile=}"
+                ;;
+            --release)
+                BUILD_PROFILE="release"
+                ;;
+            --target-arch)
+                pending_arg="target_arch"
+                ;;
+            --target-arch=*)
+                BUILD_TARGET_ARCH="${arg#--target-arch=}"
+                ;;
+        esac
+    done
+
+    if [ -n "$pending_arg" ]; then
+        die "missing value after --${pending_arg/_/-}"
+    fi
+}
+
+# shellcheck disable=SC2317 # Invoked by the EXIT trap.
+cleanup() {
+    if [ -n "$QEMU_PID" ]; then
+        kill -- -"$QEMU_PID" 2>/dev/null || kill "$QEMU_PID" 2>/dev/null || true
+        wait "$QEMU_PID" 2>/dev/null || true
+    fi
+    rm -f "$SOCKET_PATH"
+    if [ -n "$SMOKE_LOG" ]; then
+        rm -f "$SMOKE_LOG"
+    fi
+}
+
+reset_gdb_socket() {
+    # `cargo osdk run` creates this socket beside OSDK.toml.
+    rm -f "$SOCKET_PATH"
+}
+
+start_kernel_gdb_server() {
+    echo "[smoke] Starting kernel with GDB server..."
+    (
+        cd "$PROJECT_ROOT"
+        setsid cargo osdk run "$@" --gdb-server wait-client
+    ) &
+    QEMU_PID=$!
+}
+
+wait_for_gdb_socket() {
+    local timeout_secs=120
+
+    echo "[smoke] Waiting for GDB socket..."
+    for _ in $(seq 1 "$timeout_secs"); do
+        [ -S "$SOCKET_PATH" ] && return
+        sleep 1
+    done
+
+    die "GDB socket did not appear after $timeout_secs seconds"
+}
+
+kernel_elf() {
+    local target
+    local profile_dir
+    local elf
+
+    target="$(target_triple "$BUILD_TARGET_ARCH")"
+    profile_dir="$(artifact_profile "$BUILD_PROFILE")"
+    elf="$PROJECT_ROOT/target/$target/$profile_dir/aster-kernel-osdk-bin"
+
+    if [ ! -f "$elf" ]; then
+        die "kernel ELF with debug symbols not found: $elf"
+    fi
+    echo "$elf"
+}
+
+run_gdb_assertions() {
+    local elf="$1"
+
+    echo "[smoke] Kernel ELF: $elf"
+    echo "[smoke] Running GDB assertions..."
+    SMOKE_LOG="$(mktemp)"
+
+    set +e
+    (
+        cd "$PROJECT_ROOT"
+        timeout 120 rust-gdb --batch \
+            --command=scripts/gdb/test/smoke.gdb \
+            "$elf"
+    ) 2>&1 | tee "$SMOKE_LOG"
+    GDB_STATUS=${PIPESTATUS[0]}
+    set -e
+}
+
+report_result() {
+    if [ "$GDB_STATUS" -ne 0 ]; then
+        echo "[smoke] FAILED - rust-gdb exited with status $GDB_STATUS"
+        exit 1
+    fi
+
+    if grep -q "^SMOKE: all ok$" "$SMOKE_LOG"; then
+        echo "[smoke] PASSED"
+        exit 0
+    fi
+
+    echo "[smoke] FAILED - see output above"
+    exit 1
+}
+
+main() {
+    local elf
+
+    parse_build_args "$@"
+    ensure_rust_gdb
+    reset_gdb_socket
+    start_kernel_gdb_server "$@"
+    wait_for_gdb_socket
+    elf="$(kernel_elf)"
+    run_gdb_assertions "$elf"
+    report_result
+}
+
+trap cleanup EXIT
+main "$@"

--- a/scripts/gdb/test/smoke.gdb
+++ b/scripts/gdb/test/smoke.gdb
@@ -1,0 +1,30 @@
+# Asterinas GDB pretty-printer smoke test
+#
+# Run via: rust-gdb --batch --command=scripts/gdb/test/smoke.gdb <kernel-elf>
+# The wrapper starts QEMU and waits for the OSDK GDB socket.
+
+# Connect and source helpers
+target remote .osdk-gdb-socket
+source scripts/gdb/asterinas-gdb.py
+
+# The QEMU GDB server starts at the x86 reset vector (BIOS running,
+# paging not yet enabled, kernel ELF not loaded into guest memory).
+# First, break at the kernel's ostd entry point so paging is set up.
+# Then advance to the first syscall handler so the init process has
+# been spawned and PID 1 exists in the PID table.
+hbreak __ostd_main
+continue
+delete
+hbreak aster_kernel::syscall::handle_syscall
+continue
+delete
+
+# Run smoke assertions
+python
+import sys
+sys.path.insert(0, "scripts/gdb/test")
+import smoke
+smoke.run()
+end
+
+quit

--- a/scripts/gdb/test/smoke.py
+++ b/scripts/gdb/test/smoke.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Smoke assertions for Asterinas GDB helpers.
+
+The GDB command file handles connection and breakpoints.  This module
+keeps the Python assertions readable and reusable.
+"""
+
+import gdb
+
+from helper import kernel
+from helper.constants import (
+    ELAPSED_JIFFIES_SYMBOL,
+    PID_TABLE_SYMBOL,
+    TASK_DATA_CONCRETE,
+    THREAD_DATA_CONCRETE,
+)
+from helper.layout import (
+    IntrospectionError,
+    lookup_type,
+    read_global,
+    read_scalar,
+    read_vec,
+    unwrap_atomic,
+    unwrap_arc,
+    unwrap_mutex,
+    unwrap_rwmutex_value,
+)
+
+
+checks = []
+HELPER_ERRORS = (gdb.error, IntrospectionError, LookupError)
+
+
+def check(name, cond):
+    checks.append((name, cond))
+
+
+def has_field(value, field_name):
+    try:
+        value[field_name]
+        return True
+    except gdb.error:
+        return False
+
+
+def check_printer(name, value, expected_text, child_name=None,
+                  expect_no_children=False):
+    try:
+        printer = gdb.default_visualizer(value)
+        check(f"{name} has pretty-printer", printer is not None)
+        if printer is None:
+            return
+
+        rendered = str(printer.to_string())
+        check(f"{name} renders as {expected_text}", expected_text in rendered)
+
+        children = list(printer.children())
+        if child_name is not None:
+            check(
+                f"{name} exposes child {child_name}",
+                any(child[0] == child_name for child in children),
+            )
+        if expect_no_children:
+            check(f"{name} hides internal children", len(children) == 0)
+    except Exception as error:
+        gdb.write(f"Warning: {name} printer check failed: {error}\n")
+        check(f"{name} pretty-printer", False)
+
+
+def check_printer_registration():
+    pp_out = gdb.execute("info pretty-printer", to_string=True)
+    check("asterinas printer collection registered", "asterinas" in pp_out)
+    check("AtomicScalar printer registered", "AtomicScalar" in pp_out)
+    check("OstdMutex printer registered", "OstdMutex" in pp_out)
+    check("OstdRwMutex printer registered", "OstdRwMutex" in pp_out)
+    check("OstdSpinLock printer registered", "OstdSpinLock" in pp_out)
+
+
+def check_kernel_symbols():
+    try:
+        pid_table_mutex = read_global(PID_TABLE_SYMBOL)
+        check("PID_TABLE symbol resolves", pid_table_mutex is not None)
+        if pid_table_mutex is not None:
+            _locked, pid_table = unwrap_mutex(pid_table_mutex)
+            check("PID_TABLE unwraps to entries", has_field(pid_table, "entries"))
+
+        elapsed = read_global(ELAPSED_JIFFIES_SYMBOL)
+        check("ELAPSED jiffies symbol resolves", elapsed is not None)
+        if elapsed is not None:
+            check("ELAPSED jiffies is readable", read_scalar(elapsed) >= 0)
+
+        check("Task.data concrete type resolves",
+              lookup_type(TASK_DATA_CONCRETE) is not None)
+        check("Thread.data concrete type resolves",
+              lookup_type(THREAD_DATA_CONCRETE) is not None)
+    except HELPER_ERRORS as error:
+        gdb.write(f"Warning: kernel symbol checks failed: {error}\n")
+        check("kernel symbol checks", False)
+
+
+def check_wrapper_printers():
+    try:
+        thread = kernel.find_thread(1)
+        check("TID 1 is available for wrapper printer checks",
+              thread is not None)
+        posix_thread = kernel.get_posix_thread_from_thread(thread)
+
+        tid = posix_thread['tid']
+        tid_value = unwrap_atomic(tid)
+        check("unwrap_atomic reads Atomic<u32> tid", tid_value == 1)
+        check_printer("Atomic<u32>", tid, str(tid_value),
+                      expect_no_children=True)
+
+        is_exited = thread['is_exited']
+        is_exited_value = bool(unwrap_atomic(is_exited))
+        check("unwrap_atomic reads Atomic<bool> is_exited",
+              is_exited_value is False)
+        check_printer(
+            "Atomic<bool>",
+            is_exited,
+            "true" if is_exited_value else "false",
+            expect_no_children=True,
+        )
+
+        timer_slack = posix_thread['timer_slack_ns']
+        timer_slack_value = unwrap_atomic(timer_slack)
+        check("unwrap_atomic reads Atomic<u64> timer_slack_ns",
+              timer_slack_value >= 0)
+        check_printer("Atomic<u64>", timer_slack, str(timer_slack_value),
+                      expect_no_children=True)
+
+        thread_name = posix_thread['name']
+        locked, _name_value = unwrap_mutex(thread_name)
+        check("unwrap_mutex reads PosixThread.name", isinstance(locked, bool))
+        check_printer(
+            "Mutex<ThreadName>",
+            thread_name,
+            f"Mutex(locked={'true' if locked else 'false'})",
+            child_name="value",
+        )
+
+        thread_fs = posix_thread['fs']
+        _thread_fs_value = unwrap_rwmutex_value(thread_fs)
+        check_printer("RwMutex<ThreadFsInfo>", thread_fs, "RwMutex",
+                      child_name="value")
+
+        signalled_waker = posix_thread['signalled_waker']
+        check_printer("SpinLock<Option<Waker>>", signalled_waker,
+                      "SpinLock(locked=", child_name="value")
+
+        atomic_out = gdb.execute("p (*$ast_thread(1)).is_exited",
+                                 to_string=True)
+        check(
+            "GDB print uses Atomic<bool> pretty-printer",
+            ("false" in atomic_out or "true" in atomic_out)
+            and "UnsafeCell" not in atomic_out,
+        )
+    except Exception as error:
+        gdb.write(f"Warning: wrapper printer checks failed: {error}\n")
+        check("wrapper printer checks", False)
+
+
+def check_direct_prints():
+    try:
+        pid_table = gdb.execute(
+            "p aster_kernel::process::pid_table::PID_TABLE",
+            to_string=True,
+        )
+        check("PID_TABLE renders with Mutex prefix",
+              "Mutex(locked=" in pid_table)
+    except gdb.error:
+        check("PID_TABLE accessible", False)
+
+    try:
+        bootstrap = gdb.execute("p ostd::IN_BOOTSTRAP_CONTEXT",
+                                to_string=True)
+        check("IN_BOOTSTRAP_CONTEXT renders as bool",
+              "false" in bootstrap or "true" in bootstrap)
+        check("IN_BOOTSTRAP_CONTEXT no UnsafeCell",
+              "UnsafeCell" not in bootstrap)
+    except gdb.error:
+        check("IN_BOOTSTRAP_CONTEXT accessible", False)
+
+    try:
+        hwmap = gdb.execute("p ostd::boot::smp::HW_CPU_ID_MAP",
+                            to_string=True)
+        check("HW_CPU_ID_MAP renders with SpinLock prefix",
+              "SpinLock(locked=" in hwmap)
+    except gdb.error:
+        check("HW_CPU_ID_MAP accessible (optional)", True)
+
+
+def check_convenience_functions():
+    try:
+        pid_table = gdb.execute("p *$ast_pid_table()", to_string=True)
+        check("$ast_pid_table() returns PidTable",
+              "entries" in pid_table or "process_count" in pid_table)
+    except gdb.error:
+        check("$ast_pid_table() invocation", False)
+
+    try:
+        proc1 = gdb.execute("p *$ast_process(1)", to_string=True)
+        check("$ast_process(1) returns Process", "pid" in proc1.lower())
+    except gdb.error:
+        check("$ast_process(1) invocation", False)
+
+    try:
+        thread1 = gdb.execute("p *$ast_thread(1)", to_string=True)
+        check(
+            "$ast_thread(1) returns Thread",
+            "data" in thread1
+            or "status" in thread1
+            or "tid" in thread1.lower(),
+        )
+    except gdb.error:
+        check("$ast_thread(1) invocation", False)
+
+    try:
+        ft1 = gdb.execute("p *$ast_file_table(1)", to_string=True)
+        check(
+            "$ast_file_table(1) returns FileTable",
+            "table" in ft1 or "slots" in ft1 or "fds" in ft1.lower(),
+        )
+    except gdb.error:
+        check("$ast_file_table(1) invocation", False)
+
+
+def check_kernel_navigation():
+    try:
+        pid_table = kernel.get_pid_table()
+        check("kernel.get_pid_table reads entries",
+              has_field(pid_table, "entries"))
+
+        process = kernel.find_process(1)
+        check("kernel.find_process(1) returns Process", process is not None)
+        check("kernel.find_process missing PID returns None",
+              kernel.find_process(999999) is None)
+
+        thread = kernel.find_thread(1)
+        check("kernel.find_thread(1) returns Thread", thread is not None)
+        check("kernel.find_thread missing TID returns None",
+              kernel.find_thread(999999) is None)
+
+        row = kernel.process_row(1, process)
+        check("kernel.process_row reads PID", row.pid == 1)
+        check("kernel.process_row reads thread count", row.thread_count >= 1)
+        check("kernel.process_row reads name", bool(row.name))
+
+        _locked, task_set = unwrap_mutex(process['tasks'])
+        tasks = read_vec(task_set['tasks'])
+        check("Process.tasks contains a task", bool(tasks))
+        if tasks:
+            task = unwrap_arc(tasks[0])
+            task_thread = kernel.get_thread_from_task(task)
+            posix_thread = kernel.get_posix_thread_from_task(task)
+            check("Task.data downcasts to Thread",
+                  int(task_thread.address) == int(thread.address))
+            check("Task.data reaches PosixThread", posix_thread is not None)
+
+        file_table = kernel.get_file_table(process)
+        check("kernel.get_file_table(1) returns FileTable",
+              file_table is not None)
+    except HELPER_ERRORS as error:
+        gdb.write(f"Warning: kernel navigation checks failed: {error}\n")
+        check("kernel navigation checks", False)
+
+
+def check_commands():
+    try:
+        rows = list(kernel.iter_process_rows())
+        check("kernel.iter_process_rows sees PID 1",
+              any(row.pid == 1 for row in rows))
+
+        ps = gdb.execute("ast-ps", to_string=True)
+        check("ast-ps has header", "PID" in ps and "PPID" in ps)
+        check("ast-ps lists PID 1",
+              any(line.split() and line.split()[0] == "1"
+                  for line in ps.splitlines()))
+
+        ps_one = gdb.execute("ast-ps 1", to_string=True)
+        check("ast-ps 1 lists PID 1",
+              any(line.split() and line.split()[0] == "1"
+                  for line in ps_one.splitlines()))
+    except HELPER_ERRORS:
+        check("ast-ps runs", False)
+
+    try:
+        thread_rows = list(kernel.iter_thread_rows())
+        check("kernel.iter_thread_rows returns rows", bool(thread_rows))
+
+        threads = gdb.execute("ast-threads", to_string=True)
+        check("ast-threads has header", "TID" in threads)
+    except HELPER_ERRORS:
+        check("ast-threads runs", False)
+
+    try:
+        roots, _children, rows_by_pid = kernel.process_tree()
+        check("kernel.process_tree returns PID 1", 1 in rows_by_pid)
+        check("kernel.process_tree has roots", bool(roots))
+
+        pstree = gdb.execute("ast-pstree", to_string=True)
+        check("ast-pstree lists PID 1", "(1)" in pstree)
+    except HELPER_ERRORS:
+        check("ast-pstree runs", False)
+
+    try:
+        uptime = kernel.uptime_snapshot()
+        check("kernel.uptime_snapshot reads jiffies", uptime.jiffies >= 0)
+
+        uptime_out = gdb.execute("ast-uptime", to_string=True)
+        check("ast-uptime reports jiffies",
+              "jiffies" in uptime_out and "Hz" in uptime_out)
+    except HELPER_ERRORS:
+        check("ast-uptime runs", False)
+
+    try:
+        fd_rows = kernel.fd_rows(1)
+        check("kernel.fd_rows returns a list", isinstance(fd_rows, list))
+
+        fds = gdb.execute("ast-fds 1", to_string=True)
+        check("ast-fds for PID 1 has header", "FD" in fds and "TYPE" in fds)
+        fds_usage = gdb.execute("ast-fds", to_string=True)
+        check("ast-fds without PID reports usage", "Usage:" in fds_usage)
+    except HELPER_ERRORS:
+        check("ast-fds runs", False)
+
+    try:
+        version = gdb.execute("ast-version", to_string=True)
+        check("ast-version reports Asterinas", "Asterinas" in version)
+    except gdb.error:
+        check("ast-version runs", False)
+
+
+def run():
+    check_printer_registration()
+    check_kernel_symbols()
+    check_wrapper_printers()
+    check_direct_prints()
+    check_convenience_functions()
+    check_kernel_navigation()
+    check_commands()
+
+    failures = [name for name, ok in checks if not ok]
+    if failures:
+        gdb.write(f"SMOKE: fail: {', '.join(failures)}\n")
+    else:
+        gdb.write("SMOKE: all ok\n")


### PR DESCRIPTION
## Feature Overview

This PR adds the first version of the Asterinas GDB helpers.

It focuses on basic helper commands and a few high-ROI features for kernel debugging:

- auto-loading the helpers from `cargo osdk debug`;
- pretty-printers for common wrapper types such as atomics and OSTD locks;
- convenience functions for locating processes, threads, the PID table, and file tables;
- inspection commands such as `ast-version`, `ast-ps`, `ast-threads`, `ast-pstree`, `ast-fds`, and `ast-uptime`.

The goal is to make common GDB sessions less repetitive while keeping the helpers non-invasive.

## Framework and Architecture

The implementation keeps the helper code split into small Python modules under `scripts/gdb/helper/`:

- `gdb_bridge.py` wraps the small parts of the GDB Python API that the helpers use.
- `layout.py` reads Rust wrappers and collection layouts.
- `printers.py` registers pretty-printers.
- `kernel.py` knows how to navigate Asterinas kernel objects.
- `commands.py` exposes the user-facing `ast-*` commands.
- `constants.py` keeps symbol names and layout-sensitive constants in one place.

Rust definitions that are coupled to the helper logic are marked with `COUPLED` comments, so future layout changes can update the helper code in the same patch.

## Results and Deliverables

With these helpers loaded, a GDB session can inspect processes, threads, file descriptors, uptime, wrapper values, and key kernel objects with shorter commands and clearer output.

This PR also adds:

- a GDB smoke test that boots the kernel under QEMU and verifies the helper interfaces;
- a focused GitHub Actions workflow for the smoke test;
- documentation in the Asterinas Book and the `cargo osdk debug` reference.

## Agent Skill Extension

An additional Agent Skill repository is available at:

https://github.com/zevorn/asterinas-debugger

It is designed to reuse these GDB helpers for more complex debugging work and reduce manual effort during repeated investigations.

The skill design follows the ideas of Loop Engineering and Humanize: keep the debugging loop evidence-driven, make each step repeatable, and leave room for human review and decision making.

The implementation first defines stable flow primitives for sessions, breakpoints, inspection, and probes. These primitives are then combined into workflows that fit common Asterinas debugging scenarios.

The skill details are outside the scope of this PR. Please see the README in that repository for the full design and usage notes.

## Related Issue

Refs #3094