### PR TITLE
Fix O_TRUNC permission check

### DIFF
--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -556,6 +556,13 @@ impl Path {
 
         DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name)
     }
+
+    /// Resizes the file.
+    pub fn resize(&self, size: usize) -> Result<()> {
+        let inode = self.inode();
+        inode.check_permission(Permission::MAY_WRITE)?;
+        inode.resize(size)
+    }
 }
 
 // Methods inherited from `Inode`.
@@ -568,7 +575,6 @@ impl Path {
     pub fn mode(&self) -> Result<InodeMode>;
     pub fn set_mode(&self, mode: InodeMode) -> Result<()>;
     pub fn size(&self) -> usize;
-    pub fn resize(&self, size: usize) -> Result<()>;
     pub fn owner(&self) -> Result<Uid>;
     pub fn set_owner(&self, uid: Uid) -> Result<()>;
     pub fn group(&self) -> Result<Gid>;

--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/open_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/open_test
@@ -2,6 +2,7 @@ OpenTest.AbsPath
 OpenTest.AppendOnly
 OpenTest.AtAbsPath
 OpenTest.AtRelPath
+OpenTest.CanTruncateReadOnlyNoWritePermission
 OpenTest.CanTruncateWriteOnlyNoReadPermission
 OpenTest.CreateWithAppend
 OpenTest.DirectoryWritableFails

--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/truncate_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/truncate_test
@@ -1,0 +1,1 @@
+TruncateTest.TruncateNonWriteable

--- a/test/initramfs/src/conformance/gvisor/blocklists/open_create_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/open_create_test
@@ -1,3 +1,0 @@
-CreateTest.HonorsUmask_NoRandomSave
-CreateTest.CreatDirWithOTruncAndReadOnly
-CreateTest.CreateFailsOnUnpermittedDir

--- a/test/initramfs/src/conformance/gvisor/blocklists/open_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/open_test
@@ -1,5 +1,4 @@
 OpenTest.AppendConcurrentWrite
-OpenTest.CanTruncateReadOnlyNoWritePermission
 OpenTest.CanTruncateWithStrangePermissions
 OpenTest.DirectoryDirectFails
 OpenTest.OpenNoFollowStillFollowsLinksInPath

--- a/test/initramfs/src/conformance/gvisor/blocklists/truncate_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/truncate_test
@@ -1,4 +1,2 @@
 FixtureTruncateTest.Truncate
 FixtureTruncateTest.Ftruncate
-TruncateTest.TruncateNonWriteable
-TruncateTest.FtruncateVirtualTmp_NoRandomSave

--- a/test/initramfs/src/regression/io/file_io/access_err.c
+++ b/test/initramfs/src/regression/io/file_io/access_err.c
@@ -8,9 +8,12 @@
 #include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
+#include "../../common/capability.h"
 #include "../../common/test.h"
 
 #define FILENAME "/tmp/testfile"
@@ -340,6 +343,40 @@ FN_TEST(flags)
 	// `O_PATH | O_CREAT` has no effect.
 	TEST_ERRNO(open("/tmp/file_does_not_exist", O_PATH | O_CREAT, 0644),
 		   ENOENT);
+}
+END_TEST()
+
+FN_TEST(truncation_requires_write_permission)
+{
+	const char data[] = "hello";
+	struct stat st;
+	pid_t pid;
+	int status;
+	int fd;
+
+	fd = TEST_SUCC(open(FILENAME, O_WRONLY | O_TRUNC));
+	TEST_RES(write(fd, data, sizeof(data) - 1),
+		 _ret == (ssize_t)(sizeof(data) - 1));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(chmod(FILENAME, S_IRUSR | S_IRGRP));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_DAC_OVERRIDE);
+		CHECK_WITH(open(FILENAME, O_RDONLY | O_TRUNC),
+			   _ret == -1 && errno == EACCES);
+
+		CHECK_WITH(truncate(FILENAME, 0),
+			   _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(chmod(FILENAME, 0666));
+	TEST_RES(stat(FILENAME, &st),
+		 _ret == 0 && st.st_size == (off_t)(sizeof(data) - 1));
 }
 END_TEST()
 


### PR DESCRIPTION
## Summary

Fix permission checks for truncation.

## Changes

- Check `MAY_WRITE` in `Path::resize`, covering `O_TRUNC` and `truncate`.
- Add regression for `O_RDONLY | O_TRUNC` and `truncate` on a file without write permission.
- Unblock the gVisor truncation permission cases from common blocklists, while keeping exFAT-specific chmod-dependent cases in `blocklists.exfat`.
- Remove now-passing or stale gVisor blocklist entries in `open_create_test` and `truncate_test`.

## Testing

- `make check`

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```