### PR TITLE
Reverse mappings for file-backed memory mappings

### DIFF
--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -352,10 +352,10 @@ impl FileLike for InodeHandle {
         }
 
         let inode = self.path().inode();
-        if let Some(ref page_cache) = inode.page_cache() {
+        if let Some(page_cache) = inode.page_cache() {
             // If the inode has a page cache, it is a file-backed mapping and
             // we return the VMO as the mappable object.
-            Ok(Mappable::Vmo(page_cache.as_vmo().clone()))
+            Ok(Mappable::Vmo(page_cache))
         } else if let Some(ref open_file) = self.open_file {
             // Otherwise, it is a special file (e.g. device file) and we should
             // return the file-specific mappable object.

--- a/kernel/src/fs/fs_impls/exfat/bitmap.rs
+++ b/kernel/src/fs/fs_impls/exfat/bitmap.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![expect(dead_code)]
-#![expect(unused_variables)]
 
 use core::ops::Range;
 
@@ -10,11 +9,11 @@ use bitvec::prelude::*;
 
 use super::{
     constants::EXFAT_RESERVED_CLUSTERS,
-    dentry::{ExfatBitmapDentry, ExfatDentry, ExfatDentryIterator},
+    dentry::ExfatBitmapDentry,
     fat::{ClusterID, ExfatChain},
     fs::ExfatFs,
 };
-use crate::{fs::exfat::fat::FatChainFlags, prelude::*, vm::page_cache::PageCache};
+use crate::{fs::exfat::fat::FatChainFlags, prelude::*};
 
 // TODO: use u64
 type BitStore = u8;
@@ -34,27 +33,10 @@ pub(super) struct ExfatBitmap {
 }
 
 impl ExfatBitmap {
-    pub(super) fn load(
+    pub(super) fn load_bitmap_from_dentry(
         fs_weak: Weak<ExfatFs>,
-        root_page_cache: &PageCache,
-        root_chain: ExfatChain,
+        dentry: &ExfatBitmapDentry,
     ) -> Result<Self> {
-        let dentry_iterator = ExfatDentryIterator::new(root_page_cache, 0, None)?;
-
-        for dentry_result in dentry_iterator {
-            let dentry = dentry_result?;
-            if let ExfatDentry::Bitmap(bitmap_dentry) = dentry {
-                // If the last bit of bitmap is 0, it is a valid bitmap.
-                if (bitmap_dentry.flags & 0x1) == 0 {
-                    return Self::load_bitmap_from_dentry(fs_weak.clone(), &bitmap_dentry);
-                }
-            }
-        }
-
-        return_errno_with_message!(Errno::EINVAL, "bitmap not found")
-    }
-
-    fn load_bitmap_from_dentry(fs_weak: Weak<ExfatFs>, dentry: &ExfatBitmapDentry) -> Result<Self> {
         let fs = fs_weak.upgrade().unwrap();
         let num_clusters = (dentry.size as usize).align_up(fs.cluster_size()) / fs.cluster_size();
 
@@ -183,7 +165,6 @@ impl ExfatBitmap {
         let unit_size: u32 = (BITS_PER_BYTE * size_of::<BitStore>()) as u32;
         while cur_unit_index < total_cluster_num {
             let leading_zeros = bytes[cur_unit_index as usize].leading_zeros();
-            let head_cluster_num = unit_size - cur_unit_offset;
             if leading_zeros == 0 {
                 // Fall over to the next unit, we need to continue checking.
                 cur_unit_index += 1;

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -106,15 +106,11 @@ impl ExfatFs {
 
         let root = ExfatInode::build_root_inode(weak_fs.clone(), root_chain.clone())?;
 
-        let root_page_cache = root.page_cache().unwrap();
-
-        let upcase_table =
-            ExfatUpcaseTable::load(weak_fs.clone(), &root_page_cache, root_chain.clone())?;
-
-        let bitmap = ExfatBitmap::load(weak_fs.clone(), &root_page_cache, root_chain.clone())?;
-
-        *exfat_fs.bitmap.lock() = bitmap;
+        let upcase_table = root.read_upcase_table()?;
         *exfat_fs.upcase_table.lock() = upcase_table;
+
+        let bitmap = root.read_bitmap()?;
+        *exfat_fs.bitmap.lock() = bitmap;
 
         // TODO: Handle UTF-8
 

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -26,7 +26,10 @@ use super::{
 };
 use crate::{
     fs::{
-        exfat::{dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs},
+        exfat::{
+            bitmap::ExfatBitmap, dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs,
+            upcase_table::ExfatUpcaseTable,
+        },
         file::{InodeMode, InodeType, StatusFlags, mkmod},
         utils::DirentVisitor,
         vfs::{
@@ -37,10 +40,10 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    vm::page_cache::{BlockAsPageCacheBackend, PageCache},
+    vm::page_cache::{BlockAsPageCacheBackend, PageCache, Vmo},
 };
 
-///Inode number
+/// Inode number
 pub type Ino = u64;
 
 bitflags! {
@@ -325,12 +328,14 @@ impl ExfatInodeInner {
         }
 
         let parent = self.get_parent_inode().unwrap_or_else(|| unimplemented!());
-        let page_cache = parent.page_cache().unwrap();
+        let parent_inner = parent.inner.read();
 
         // Need to read the latest dentry set from parent inode.
 
-        let mut dentry_set =
-            ExfatDentrySet::read_from(&page_cache, self.dentry_entry as usize * DENTRY_SIZE)?;
+        let mut dentry_set = ExfatDentrySet::read_from(
+            &parent_inner.page_cache,
+            self.dentry_entry as usize * DENTRY_SIZE,
+        )?;
 
         let mut file_dentry = dentry_set.get_file_dentry();
         let mut stream_dentry = dentry_set.get_stream_dentry();
@@ -364,9 +369,11 @@ impl ExfatInodeInner {
         let start_off = self.dentry_entry as usize * DENTRY_SIZE;
         let bytes = dentry_set.to_le_bytes();
 
-        page_cache.write_bytes(start_off, &bytes)?;
+        parent_inner.page_cache.write_bytes(start_off, &bytes)?;
         if sync {
-            page_cache.flush_range(start_off..start_off + bytes.len())?;
+            parent_inner
+                .page_cache
+                .flush_range(start_off..start_off + bytes.len())?;
         }
 
         Ok(())
@@ -836,7 +843,8 @@ impl ExfatInode {
         let fs = inner.fs();
         let fs_guard = fs.lock();
         let mut inner = self.inner.write();
-        inner.page_cache.resize(0, inner.size)?;
+        let old_size = inner.size;
+        inner.page_cache.resize(0, old_size)?;
         inner.resize(0, &fs_guard)?;
         Ok(())
     }
@@ -1037,6 +1045,37 @@ impl ExfatInode {
             parent_hash,
             fs_guard,
         )
+    }
+
+    pub(super) fn read_bitmap(&self) -> Result<ExfatBitmap> {
+        let inner = self.inner.read();
+        let dentry_iterator = ExfatDentryIterator::new(&inner.page_cache, 0, None)?;
+
+        for dentry_result in dentry_iterator {
+            let dentry = dentry_result?;
+            if let ExfatDentry::Bitmap(bitmap_dentry) = dentry {
+                // If the last bit is 0, it is a valid bitmap.
+                if (bitmap_dentry.flags & 0x1) == 0 {
+                    return ExfatBitmap::load_bitmap_from_dentry(inner.fs.clone(), &bitmap_dentry);
+                }
+            }
+        }
+
+        return_errno_with_message!(Errno::EINVAL, "bitmap not found")
+    }
+
+    pub(super) fn read_upcase_table(&self) -> Result<ExfatUpcaseTable> {
+        let inner = self.inner.read();
+        let dentry_iterator = ExfatDentryIterator::new(&inner.page_cache, 0, None)?;
+
+        for dentry_result in dentry_iterator {
+            let dentry = dentry_result?;
+            if let ExfatDentry::Upcase(upcase_dentry) = dentry {
+                return ExfatUpcaseTable::load_table_from_dentry(inner.fs.clone(), &upcase_dentry);
+            }
+        }
+
+        return_errno_with_message!(Errno::EINVAL, "upcase table not found")
     }
 
     /// Find empty dentry. If not found, expand the cluster chain.
@@ -1256,7 +1295,8 @@ impl ExfatInode {
         if delete_contents {
             if is_dir {
                 let mut inner = inode.inner.write();
-                inner.page_cache.resize(0, inner.size)?;
+                let old_size = inner.size;
+                inner.page_cache.resize(0, old_size)?;
                 inner.resize(0, fs_guard)?;
             }
             // Set the delete flag.
@@ -1515,8 +1555,8 @@ impl Inode for ExfatInode {
         self.inner.read().fs()
     }
 
-    fn page_cache(&self) -> Option<PageCache> {
-        Some(self.inner.read().page_cache.clone())
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
+        Some(self.inner.read().page_cache.as_vmo().clone())
     }
 
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>> {

--- a/kernel/src/fs/fs_impls/exfat/upcase_table.rs
+++ b/kernel/src/fs/fs_impls/exfat/upcase_table.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![expect(dead_code)]
-#![expect(unused_variables)]
 
 use align_ext::AlignExt;
 
 use super::{
     constants::UNICODE_SIZE,
-    dentry::{ExfatDentry, ExfatDentryIterator, ExfatUpcaseDentry, UTF16Char},
+    dentry::{ExfatUpcaseDentry, UTF16Char},
     fat::ExfatChain,
     fs::ExfatFs,
     utils::calc_checksum_32,
 };
-use crate::{fs::exfat::fat::FatChainFlags, prelude::*, vm::page_cache::PageCache};
+use crate::{fs::exfat::fat::FatChainFlags, prelude::*};
 
 const UPCASE_MANDATORY_SIZE: usize = 128;
 
@@ -30,24 +29,10 @@ impl ExfatUpcaseTable {
         }
     }
 
-    pub(super) fn load(
+    pub(super) fn load_table_from_dentry(
         fs_weak: Weak<ExfatFs>,
-        root_page_cache: &PageCache,
-        root_chain: ExfatChain,
+        dentry: &ExfatUpcaseDentry,
     ) -> Result<Self> {
-        let dentry_iterator = ExfatDentryIterator::new(root_page_cache, 0, None)?;
-
-        for dentry_result in dentry_iterator {
-            let dentry = dentry_result?;
-            if let ExfatDentry::Upcase(upcase_dentry) = dentry {
-                return Self::load_table_from_dentry(fs_weak, &upcase_dentry);
-            }
-        }
-
-        return_errno_with_message!(Errno::EINVAL, "Upcase table not found")
-    }
-
-    fn load_table_from_dentry(fs_weak: Weak<ExfatFs>, dentry: &ExfatUpcaseDentry) -> Result<Self> {
         if (dentry.size as usize) < UPCASE_MANDATORY_SIZE * UNICODE_SIZE {
             return_errno_with_message!(Errno::EINVAL, "Upcase table too small")
         }

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    vm::page_cache::PageCache,
+    vm::page_cache::Vmo,
 };
 
 impl FileOps for Ext2Inode {
@@ -133,7 +133,7 @@ impl Inode for Ext2Inode {
         self.set_ctime(time)
     }
 
-    fn page_cache(&self) -> Option<PageCache> {
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
         self.page_cache()
     }
 

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -480,11 +480,15 @@ mod test {
 
     use super::{super::RAW_BLOCK_PTRS_LEN, *};
     use crate::{
-        fs::ext2::{
-            inode::test::make_live_file_inode,
-            test_utils::{Ext2FixtureBuilder, assert_errno, create_file},
+        fs::{
+            ext2::{
+                inode::test::make_live_file_inode,
+                test_utils::{Ext2FixtureBuilder, assert_errno, create_file},
+            },
+            vfs::inode::Inode,
         },
         time::clocks,
+        vm::page_cache::VmoMapMode,
     };
 
     #[ktest]
@@ -522,47 +526,46 @@ mod test {
         assert_eq!(readback, base_data);
     }
 
-    // TODO: Enable this test once page-table dirty bits are propagated back to
-    // the VMO. Currently the hardware dirty flag set by mmap writes is not
-    // reflected in the VMO's dirty tracking, so a subsequent buffered write to
-    // the same page overwrites the mmap-dirtied region with zeros (the page
-    // cache sees the page as clean and re-zeroes the hole portion). Once the
-    // VM subsystem flushes PTE dirty bits back to the VMO, this test should
-    // pass and can be re-enabled.
-    // #[ktest]
-    // fn file_sparse_buffered_write_preserves_mmap_dirty_tail() {
-    //     let (_f, root) = default_fixture();
-    //     let file = create_file(&root, "mmap_dirty_tail");
-    //     let vmo = VfsInodeTrait::page_cache(file.as_ref()).unwrap().as_vmo();
+    #[ktest]
+    fn file_sparse_buffered_write_preserves_mmap_dirty_tail() {
+        clocks::init_for_ktest();
 
-    //     VfsInodeTrait::resize(file.as_ref(), BLOCK_SIZE * 3).unwrap();
+        let f = Ext2FixtureBuilder::new(1, 256)
+            .with_free_blocks(2, 2)
+            .with_free_inodes(1000, 1000)
+            .build()
+            .unwrap();
+        let root = f.root();
+        let file: Arc<dyn Inode> = create_file(&root, "mmap_dirty_tail") as _;
+        let vmo = file.page_cache().unwrap();
 
-    //     let block_start = BLOCK_SIZE;
-    //     let mmap_offset = block_start + 200;
-    //     let mmap_payload = [0x5au8; 32];
+        file.resize(BLOCK_SIZE * 3).unwrap();
 
-    //     let page = vmo.commit_on(block_start / PAGE_SIZE).unwrap();
-    //     page.write_bytes(mmap_offset % PAGE_SIZE, &mmap_payload)
-    //         .unwrap();
-    //     vmo.mark_page_dirty(block_start).unwrap();
+        let block_start = BLOCK_SIZE;
+        let mmap_offset = block_start + 200;
+        let mmap_payload = [0x5au8; 32];
 
-    //     let buffered_offset = block_start + 100;
-    //     let buffered_payload = [0xa5u8; 100];
-    //     assert_eq!(
-    //         write_file_at(
-    //             &file,
-    //             buffered_offset,
-    //             &buffered_payload,
-    //             StatusFlags::empty()
-    //         )
-    //         .unwrap(),
-    //         buffered_payload.len()
-    //     );
+        vmo.commit_on(block_start / PAGE_SIZE, VmoMapMode::SharedWrite)
+            .unwrap();
+        let (page, mode) = vmo
+            .try_commit_page(block_start, VmoMapMode::SharedWrite)
+            .unwrap();
+        assert_eq!(mode, VmoMapMode::SharedWrite);
+        page.write_bytes(mmap_offset % PAGE_SIZE, &mmap_payload)
+            .unwrap();
 
-    //     let read_back =
-    //         read_file_at(&file, mmap_offset, mmap_payload.len(), StatusFlags::empty()).unwrap();
-    //     assert_eq!(read_back, mmap_payload);
-    // }
+        let buffered_offset = block_start + 100;
+        let buffered_payload = [0xa5u8; 100];
+        assert_eq!(
+            file.write_bytes_at(buffered_offset, &buffered_payload)
+                .unwrap(),
+            buffered_payload.len()
+        );
+
+        let mut read_back = [0xffu8; 32];
+        file.read_bytes_at(mmap_offset, &mut read_back).unwrap();
+        assert_eq!(read_back, mmap_payload);
+    }
 
     #[ktest]
     fn falloc_allocate_returns_enospc_after_consuming_blocks() {

--- a/kernel/src/fs/fs_impls/ext2/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/mod.rs
@@ -83,7 +83,10 @@ use self::{
     symlink::FastSymlinkTarget,
 };
 use super::{fs::Ext2, prelude::*, xattr::Xattr};
-use crate::fs::{ext2::utils, file::InodeMode, pipe::Pipe, vfs::inode::Extension};
+use crate::{
+    fs::{ext2::utils, file::InodeMode, pipe::Pipe, vfs::inode::Extension},
+    vm::page_cache::Vmo,
+};
 
 const MAX_LINK_COUNT: u16 = 32000;
 /// Size of the ext2 inode `i_block` byte area used by fast symlinks.
@@ -209,7 +212,7 @@ impl Inode {
     }
 
     /// Returns a clone of the data page cache for this inode if it has one.
-    pub(super) fn page_cache(&self) -> Option<PageCache> {
+    pub(super) fn page_cache(&self) -> Option<Arc<Vmo>> {
         self.inner.read().page_cache_clone()
     }
 }
@@ -458,15 +461,15 @@ impl InodeInner {
         self.payload.raw_block_ptrs(self.desc.file_acl)
     }
 
-    fn page_cache_clone(&self) -> Option<PageCache> {
-        self.payload.page_cache().cloned()
+    fn page_cache_clone(&self) -> Option<Arc<Vmo>> {
+        self.payload.page_cache().map(PageCache::as_vmo).cloned()
     }
 
     fn resize_page_cache(&mut self, new_size_bytes: usize, old_size_bytes: usize) -> Result<()> {
         let InodePayload::DataBacked {
             page_cache,
             block_manager,
-        } = &self.payload
+        } = &mut self.payload
         else {
             return_errno_with_message!(Errno::EINVAL, "inode has no data page cache");
         };

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    vm::page_cache::PageCache,
+    vm::page_cache::Vmo,
 };
 
 const OVERLAY_FS_MAGIC: u64 = 0x794C7630;
@@ -489,7 +489,7 @@ impl OverlayInode {
         &self.extension
     }
 
-    pub fn page_cache(&self) -> Option<PageCache> {
+    pub fn page_cache(&self) -> Option<Arc<Vmo>> {
         let _ = self.get_top_valid_inode().page_cache()?;
         // Do copy-up for the potential memory mapping operations
         let upper = self.build_upper_recursively_if_needed().unwrap();
@@ -990,7 +990,7 @@ impl Inode for OverlayInode {
     fn set_mtime(&self, time: Duration);
     fn ctime(&self) -> Duration;
     fn set_ctime(&self, time: Duration);
-    fn page_cache(&self) -> Option<PageCache>;
+    fn page_cache(&self) -> Option<Arc<Vmo>>;
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>>;
     fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Arc<dyn Inode>>;
     fn open(
@@ -1242,7 +1242,7 @@ impl FsType for OverlayFsType {
 // TODO: Enrich the tests to cover more cases.
 #[cfg(ktest)]
 mod tests {
-    use ostd::{mm::VmIo, prelude::ktest};
+    use ostd::prelude::ktest;
 
     use super::*;
     use crate::fs::{
@@ -1578,7 +1578,10 @@ mod tests {
         let f1 = root.lookup("f1").unwrap();
         assert_eq!(f1.size(), 0);
         f1.resize(PAGE_SIZE).unwrap();
-        f1.page_cache().unwrap().write_val(0, &3u8).unwrap();
+        f1.page_cache()
+            .unwrap()
+            .write(0, &mut VmReader::from([3].as_slice()).to_fallible())
+            .unwrap();
         f1.set_atime(Duration::default());
         f1.sync_data().unwrap();
         let mut data = [0u8; 1];

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -39,7 +39,7 @@ use crate::{
     process::{Gid, Uid, posix_thread::AsPosixThread},
     thread::Thread,
     time::clocks::RealTimeCoarseClock,
-    vm::page_cache::PageCache,
+    vm::page_cache::{PageCache, Vmo},
 };
 
 /// A volatile file system whose data and metadata exists only in memory.
@@ -728,7 +728,7 @@ impl FileOps for RamInode {
             InodeType::File => {
                 let now = now();
 
-                let page_cache = self.inner.as_file().unwrap().lock();
+                let mut page_cache = self.inner.as_file().unwrap().lock();
 
                 let mut inode_meta = self.metadata.lock();
                 let file_size = inode_meta.size;
@@ -775,10 +775,10 @@ impl FileOps for RamInode {
 }
 
 impl Inode for RamInode {
-    fn page_cache(&self) -> Option<PageCache> {
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
         self.inner
             .as_file()
-            .map(|page_cache| page_cache.lock().clone())
+            .map(|page_cache| page_cache.lock().as_vmo().clone())
     }
 
     fn size(&self) -> usize {
@@ -793,7 +793,7 @@ impl Inode for RamInode {
             return_errno_with_message!(Errno::EINVAL, "the inode is not a regular file");
         }
 
-        let page_cache = self.inner.as_file().unwrap().lock();
+        let mut page_cache = self.inner.as_file().unwrap().lock();
         let mut inode_meta = self.metadata.lock();
         let file_size = inode_meta.size;
         if file_size == new_size {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    vm::{page_cache::PageCache, perms::VmPerms},
+    vm::{page_cache::Vmo, perms::VmPerms},
 };
 
 pub(super) fn init() {
@@ -163,7 +163,7 @@ impl Inode for MemfdInode {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn page_cache(&self) -> Option<PageCache>;
+    fn page_cache(&self) -> Option<Arc<Vmo>>;
     fn extension(&self) -> &Extension;
     fn set_xattr(
         &self,

--- a/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -65,7 +65,7 @@ impl VirtioFsInode {
         self.set_size(new_size);
         let is_mtime_changed = old_mtime != inner.metadata.last_modify_at;
 
-        let Some(page_cache) = &inner.page_cache else {
+        let Some(page_cache) = &mut inner.page_cache else {
             return Ok(());
         };
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    vm::page_cache::PageCache,
+    vm::page_cache::{PageCache, Vmo},
 };
 
 /// Represents a cached virtio-fs inode and its kernel-side state.
@@ -253,6 +253,10 @@ impl InodeInner {
     fn page_cache(&self) -> Option<&PageCache> {
         self.page_cache.as_ref()
     }
+
+    fn page_cache_mut(&mut self) -> Option<&mut PageCache> {
+        self.page_cache.as_mut()
+    }
 }
 
 impl Inode for VirtioFsInode {
@@ -336,8 +340,13 @@ impl Inode for VirtioFsInode {
         self.set_time(TimeField::Change, time);
     }
 
-    fn page_cache(&self) -> Option<PageCache> {
-        self.inner.read().page_cache.clone()
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
+        self.inner
+            .read()
+            .page_cache
+            .as_ref()
+            .map(PageCache::as_vmo)
+            .cloned()
     }
 
     fn open(

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -150,7 +150,7 @@ impl VirtioFsInode {
             .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "virtiofs write size overflow"))?;
 
         let old_size = self.size();
-        let page_cache = inner.page_cache().unwrap();
+        let page_cache = inner.page_cache_mut().unwrap();
 
         if requested_end > old_size {
             // Extend the visible EOF before growing the page cache.

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -22,7 +22,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid},
     time::clocks::RealTimeCoarseClock,
-    vm::page_cache::PageCache,
+    vm::page_cache::Vmo,
 };
 
 type Ino = u64;
@@ -483,7 +483,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         unimplemented!("fs() method should be implemented by the concrete inode type");
     }
 
-    default fn page_cache(&self) -> Option<PageCache> {
+    default fn page_cache(&self) -> Option<Arc<Vmo>> {
         None
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     security::lsm::hooks as lsm_hooks,
     time::clocks::RealTimeCoarseClock,
-    vm::page_cache::PageCache,
+    vm::page_cache::Vmo,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -387,7 +387,7 @@ pub trait Inode: Any + FileOps + Send + Sync {
 
     fn set_ctime(&self, time: Duration);
 
-    fn page_cache(&self) -> Option<PageCache> {
+    fn page_cache(&self) -> Option<Arc<Vmo>> {
         None
     }
 

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -421,7 +421,7 @@ fn map_segment_vmo(
     if segment_size != 0 {
         let vm_map_options = vmar
             .new_map(segment_size, perms)?
-            .vmo(elf_vmo.as_vmo().clone())
+            .vmo(elf_vmo.clone())
             .path(elf_file.clone())
             .vmo_offset(segment_offset)
             .offset(VmarMapOffset::FixedReplace(offset))

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -32,7 +32,7 @@ use crate::{
         clocks::MonotonicClock,
         timer::{Timeout, TimerGuard},
     },
-    vm::page_cache::{Vmo, VmoOptions},
+    vm::page_cache::{Vmo, VmoMapMode, VmoOptions},
 };
 
 const CLOCK_TAI: usize = 11;
@@ -257,7 +257,9 @@ impl Vdso {
                 .write(VDSO_VMO_LAYOUT.text_segment_offset, &mut reader)
                 .unwrap();
 
-            let data_frame = vdso_vmo.try_commit_page(0).unwrap();
+            let (data_frame, _) = vdso_vmo
+                .try_commit_page(0, VmoMapMode::SharedWrite)
+                .unwrap();
             (vdso_vmo, data_frame)
         };
 

--- a/kernel/src/vm/page_cache/cache_page.rs
+++ b/kernel/src/vm/page_cache/cache_page.rs
@@ -28,6 +28,9 @@ pub enum PageState {
     /// `Dirty` indicates a page which content has been updated and not written back to underlying disk.
     /// The page is available to read, write, and map.
     Dirty = 2,
+    /// `Evicted` indicates an evicted page which content has been initialized.
+    /// The page is available to read, not available to write and map.
+    Evicted = 3,
 }
 
 impl From<PageState> for u8 {
@@ -55,6 +58,11 @@ impl PageState {
     /// Checks if the page is dirty.
     pub(super) fn is_dirty(self) -> bool {
         matches!(self, Self::Dirty)
+    }
+
+    /// Checks if the page is evicted.
+    pub(super) fn is_evicted(self) -> bool {
+        matches!(self, Self::Evicted)
     }
 }
 
@@ -285,6 +293,16 @@ impl<PageRef: Borrow<CachePage>> LockedCachePage<PageRef> {
         self.metadata()
             .state
             .store(PageState::Dirty, Ordering::Release);
+    }
+
+    /// Marks the page as evicted.
+    ///
+    /// This indicates that the page has been evicted and is no longer
+    /// associated with the page cache.
+    pub(super) fn set_evicted(&self) {
+        self.metadata()
+            .state
+            .store(PageState::Evicted, Ordering::Release);
     }
 
     /// Sets the writing back flag of the page, indicating that the page

--- a/kernel/src/vm/page_cache/cache_page.rs
+++ b/kernel/src/vm/page_cache/cache_page.rs
@@ -17,30 +17,17 @@ use crate::prelude::*;
 
 /// The state of a page in the page cache.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum PageState {
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+pub enum PageState {
     /// `Uninit` indicates a new allocated page which content has not been initialized.
-    /// The page is available to write, not available to read.
+    /// The page is available to write, not available to read or map.
     Uninit = 0,
     /// `UpToDate` indicates a page which content is consistent with corresponding disk content.
-    /// The page is available to read and write.
+    /// The page is available to read and map, not available to write.
     UpToDate = 1,
     /// `Dirty` indicates a page which content has been updated and not written back to underlying disk.
-    /// The page is available to read and write.
+    /// The page is available to read, write, and map.
     Dirty = 2,
-}
-
-impl TryFrom<u8> for PageState {
-    type Error = Error;
-
-    fn try_from(value: u8) -> Result<Self> {
-        match value {
-            0 => Ok(Self::Uninit),
-            1 => Ok(Self::UpToDate),
-            2 => Ok(Self::Dirty),
-            _ => return_errno_with_message!(Errno::EINVAL, "invalid page state"),
-        }
-    }
 }
 
 impl From<PageState> for u8 {
@@ -53,6 +40,23 @@ define_atomic_version_of_integer_like_type!(PageState, try_from = true, {
     #[derive(Debug)]
     struct AtomicPageState(AtomicU8);
 });
+
+impl PageState {
+    /// Checks if the page is uninitialized.
+    pub(super) fn is_uninit(self) -> bool {
+        matches!(self, Self::Uninit)
+    }
+
+    /// Checks if the page is up-to-date.
+    pub(super) fn is_up_to_date(self) -> bool {
+        matches!(self, Self::UpToDate)
+    }
+
+    /// Checks if the page is dirty.
+    pub(super) fn is_dirty(self) -> bool {
+        matches!(self, Self::Dirty)
+    }
+}
 
 /// A page in the page cache.
 pub type CachePage = Frame<CachePageMeta>;
@@ -160,28 +164,9 @@ pub trait CachePageExt: Sized {
         Ok(page)
     }
 
-    /// Checks if the page is uninitialized.
-    fn is_uninit(&self) -> bool {
-        matches!(
-            self.metadata().state.load(Ordering::Acquire),
-            PageState::Uninit
-        )
-    }
-
-    /// Checks if the page is up-to-date.
-    fn is_up_to_date(&self) -> bool {
-        matches!(
-            self.metadata().state.load(Ordering::Acquire),
-            PageState::UpToDate
-        )
-    }
-
-    /// Checks if the page is dirty.
-    fn is_dirty(&self) -> bool {
-        matches!(
-            self.metadata().state.load(Ordering::Acquire),
-            PageState::Dirty
-        )
+    /// Returns the state of the cache page.
+    fn state(&self) -> PageState {
+        self.metadata().state.load(Ordering::Acquire)
     }
 }
 
@@ -232,13 +217,13 @@ impl CachePageExt for CachePage {
 
     fn ensure_init(&self, init_fn: impl FnOnce(LockedCachePage) -> Result<()>) -> Result<()> {
         // Fast path: if the page is already initialized, return immediately without waiting.
-        if !self.is_uninit() {
+        if !self.state().is_uninit() {
             return Ok(());
         }
 
         let locked_page = self.lock_guard();
         // Check again after acquiring the lock to avoid duplicate initialization.
-        if !locked_page.is_uninit() {
+        if !locked_page.state().is_uninit() {
             return Ok(());
         }
 

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -74,9 +74,6 @@
 //
 // TODO: Implement built-in synchronization between mappings and [`PageCache`]
 // to meet reverse-mapping constraints above.
-// TODO: Remove the `VmIo` implementation for `PageCache` and make operations
-// that need to be protected by upper locks accept `&mut self`, and modify the
-// related usages.
 
 use core::{
     ops::{Deref, Range},
@@ -96,7 +93,7 @@ mod tests;
 mod vmo;
 
 pub use cache_page::{CachePage, CachePageExt, CachePageMeta, LockedCachePage};
-pub use vmo::{Vmo, VmoCommitError, VmoFlags, VmoOptions, WritableMappingStatus};
+pub use vmo::{Vmo, VmoCommitError, VmoFlags, VmoOptions};
 
 /// The page cache for a file-like object.
 ///
@@ -112,35 +109,37 @@ pub use vmo::{Vmo, VmoCommitError, VmoFlags, VmoOptions, WritableMappingStatus};
 /// - the higher-level synchronization that keeps metadata, buffered I/O,
 ///   invalidation, and VM mappings coherent.
 ///
-/// See the module-level documentation of [`crate::vm::page_cache`], especially the
-/// `Synchronization Model`, for the complete concurrency contract and the API
-/// lists covered by the filesystem lock and the reverse-mapping /
-/// invalidation lock.
-///
 /// Filesystems backed by persistent or remote storage create it with
 /// [`PageCache::new_with_backend`] and a [`PageCacheBackend`]. Purely
 /// in-memory filesystems can use [`PageCache::new_anon`] to get the same
 /// buffered-I/O interface without a backend.
 ///
+/// A `PageCache` is more than just an `Arc<Vmo>` wrapper. It acts as a unique
+/// handle to the underlying [`Vmo`], enabling additional operations and
+/// enforcing the correct concurrency contract (see the module-level
+/// documentation of [`crate::vm::page_cache`]). Typically, a user (such as a
+/// file system) should place a `PageCache` inside a [`Mutex`] or [`RwMutex`].
+/// Operations requiring exclusive access to the page cache handle require
+/// `&mut self`, so a proper inode or file system lock must be obtained in
+/// advance.
+///
 /// Reach for [`PageCache::as_vmo`] only when a lower-level consumer such as
 /// memory mapping or page-fault code must operate on the underlying [`Vmo`]
 /// directly.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PageCache(Arc<Vmo>);
 
 impl PageCache {
     /// Creates a page cache with a backend and the specified initial capacity
     /// in bytes.
     pub fn new_with_backend(size: usize, backend: Weak<dyn PageCacheBackend>) -> Result<Self> {
-        Ok(Self::from(
-            VmoOptions::new_page_cache(size, backend).alloc()?,
-        ))
+        Ok(Self(VmoOptions::new_page_cache(size, backend).alloc()?))
     }
 
     /// Creates an anonymous page cache with the specified initial capacity in
     /// bytes.
     pub fn new_anon(size: usize) -> Result<Self> {
-        Ok(Self::from(VmoOptions::new_anon(size).alloc()?))
+        Ok(Self(VmoOptions::new_anon(size).alloc()?))
     }
 
     /// Returns the wrapped [`Vmo`].
@@ -154,11 +153,6 @@ impl PageCache {
     /// remains responsible for tracking EOF separately.
     pub fn size(&self) -> usize {
         self.0.size()
-    }
-
-    /// Returns the writable mapping status of the underlying VMO.
-    pub fn writable_mapping_status(&self) -> &WritableMappingStatus {
-        self.0.writable_mapping_status()
     }
 
     /// Resizes the page-cache capacity to cover a new file size.
@@ -203,7 +197,7 @@ impl PageCache {
     ///
     /// use crate::vm::page_cache::PageCache;
     ///
-    /// let page_cache = PageCache::new_anon(0).unwrap();
+    /// let mut page_cache = PageCache::new_anon(0).unwrap();
     ///
     /// // Extend: publish the new file size first, then grow the page cache
     /// // with the previous file size.
@@ -222,7 +216,7 @@ impl PageCache {
     // TODO: Integrate a reverse-mapping lock or equivalent synchronization so
     // shrink/truncate can coordinate with mapped pages and concurrent page
     // faults.
-    pub fn resize(&self, new_file_size: usize, old_file_size: usize) -> Result<()> {
+    pub fn resize(&mut self, new_file_size: usize, old_file_size: usize) -> Result<()> {
         let vmo = &self.0;
         assert!(vmo.flags.contains(VmoFlags::RESIZABLE));
 
@@ -327,18 +321,15 @@ impl PageCache {
     }
 }
 
-impl From<Arc<Vmo>> for PageCache {
-    fn from(vmo: Arc<Vmo>) -> Self {
-        Self(vmo)
-    }
-}
-
 impl VmIo for PageCache {
     fn read(&self, offset: usize, writer: &mut VmWriter) -> ostd::Result<()> {
         self.0.read(offset, writer)?;
         Ok(())
     }
 
+    // TODO: This should require `&mut` to ensure that the caller holds the
+    // inode lock. However, we need to fix the exfat code first, since it does
+    // not hold the write lock when handling `write()`.
     fn write(&self, offset: usize, reader: &mut VmReader) -> ostd::Result<()> {
         self.0.write(offset, reader)?;
         Ok(())

--- a/kernel/src/vm/page_cache/mod.rs
+++ b/kernel/src/vm/page_cache/mod.rs
@@ -46,34 +46,62 @@
 //!
 //! The page-cache subsystem serializes per-page state transitions, including
 //! the backend page states in [`cache_page::PageState`] and the auxiliary
-//! writeback tracking bit in [`CachePageMeta`]. It does not provide whole-file
-//! serialization or page-table quiescence.
+//! writeback tracking bit in [`CachePageMeta`].
 //!
-//! Callers still need higher-level synchronization in two buckets:
+//! [`PageCache`] is stored inside a filesystem-level lock or inode lock. It
+//! prevents conflicting buffered I/O and resizing. However, it cannot prevent
+//! concurrent page faults. They need to be synchronized with page table locks,
+//! the reverse-mapping lock, and per-page locks. This module handles the
+//! complexity in cooperation with [`super::vmar`].
 //!
-//! - **Filesystem metadata / buffered-I/O lock.** Hold the inode- or file-level
-//!   lock that stabilizes file size, extent metadata, and write
-//!   ordering around filesystem-facing buffered access. The affected APIs are:
-//!   - buffered reads through the [`VmIo`] implementation on [`PageCache`],
-//!     such as [`VmIo::read_bytes`];
-//!   - buffered writes through the [`VmIo`] implementation on [`PageCache`],
-//!     such as [`VmIo::write_bytes`];
-//!   - zero-filling writes through [`PageCache::fill_zeros`];
-//!   - standalone [`PageCache::flush_range`] calls when `fsync`-like ordering
-//!     matters; and
-//!   - both sides of [`PageCache::resize`], because the file size and
-//!     page-cache capacity must be updated in one critical section.
-//! - **Reverse-mapping / invalidation lock.** Hold the lock shared with the
-//!   page-table and page-fault side whenever cached pages may disappear or the
-//!   accessible VMO range may shrink. The affected APIs are:
-//!   - shrinking [`PageCache::resize`];
-//!   - [`PageCache::evict_range`];
-//!   - [`PageCache::invalidate_range`]; and
-//!   - mapping-side access through [`Vmo::commit_on`], [`Vmo::try_commit_page`]
-//!     or [`Vmo::try_operate_on_range`] on the same file range.
-//
-// TODO: Implement built-in synchronization between mappings and [`PageCache`]
-// to meet reverse-mapping constraints above.
+//! A complete overview of how cached file I/O ("read"/"write" below),
+//! `O_DIRECT` file I/O ("read (direct)"/"write (direct)"), page cache
+//! management operations ("resize"/"flush"/"evict"), and page faults
+//! ("fault (load)"/"fault (store)") interact with each other when they are
+//! invoked concurrently is shown below.
+//!
+//! |                | read            | write           | read (direct) | write (direct)  | resize      | flush       | evict       | fault (load) | fault (store) |
+//! |----------------|-----------------|-----------------|---------------|-----------------|-------------|-------------|-------------|--------------|---------------|
+//! | read           | N/A             |                 |               |                 |             |             |             |              |               |
+//! | write          | inode*          | inode*          |               |                 |             |             |             |              |               |
+//! | read (direct)  | N/A             | (flush)         | N/A           |                 |             |             |             |              |               |
+//! | write (direct) | (flush + evict) | (flush + evict) | inode*        | inode*          |             |             |             |              |               |
+//! | resize         | inode           | inode           | inode         | inode           | inode       |             |             |              |               |
+//! | flush          | N/A             | page            | (flush)       | (flush + evict) | rmap + page | rmap + page |             |              |               |
+//! | evict          | N/A             | page            | (flush)       | (flush + evict) | rmap + page | rmap + page | rmap + page |              |               |
+//! | fault (load)   | N/A             | N/A             | N/A           | (flush + evict) | PT + xarray | N/A         | PT + page   | N/A          |               |
+//! | fault (store)  | N/A             | N/A             | (flush)       | (flush + evict) | PT + xarray | PT + page   | PT + page   | N/A          | N/A           |
+//!
+//! The annotations in the table are explained below.
+//!
+//!  - If two operations have no semantic conflicts, even if they are called
+//!    concurrently (e.g., if both operations try to read something), the
+//!    corresponding entry is noted as `N/A`.
+//!
+//!  - Userspace programs should not mix cached and direct file I/O. Otherwise,
+//!    data corruption caused by the program will be the user's fault. The
+//!    corresponding entry is noted as `(OP)` where `OP` is the operation
+//!    inserted by the filesystem before starting direct file I/O, which
+//!    ensures the correctness when the two operations are called
+//!    **sequentially**.
+//!
+//!  - For two operations protected by the inode lock, the entry is noted as
+//!    `inode` or `inode*`. The latter, `inode*`, means that lock usage is not
+//!    yet enforced at the page cache layer or the Rust type level (i.e.,
+//!    [`PageCache`] operations do not yet take `&mut self`).
+//!
+//!  - In this table, `flush` and `evict` are assumed to be able to be called
+//!    without holding the inode lock (e.g., under memory pressure). But as we
+//!    have not implemented any related mechanisms, they can currently only be
+//!    called from the filesystem while holding at least the inode read lock.
+//!
+//!  - For interactions between page faults and page cache management, the
+//!    correct order of multiple locks is important to ensure that the cached
+//!    page is always in a consistent state, even when operations are called
+//!    concurrently. The corresponding entry is noted as `LockA + LockB`. We
+//!    use `rmap` to denote the reverse-mapping lock, `PT` to denote the page
+//!    table lock, `page` to denote the page lock, and `xarray` to denote the
+//!    lock of VMO pages. For details, see the comments in the implementation.
 
 use core::{
     ops::{Deref, Range},
@@ -93,7 +121,7 @@ mod tests;
 mod vmo;
 
 pub use cache_page::{CachePage, CachePageExt, CachePageMeta, LockedCachePage};
-pub use vmo::{Vmo, VmoCommitError, VmoFlags, VmoOptions};
+pub use vmo::{Vmo, VmoCommitError, VmoFlags, VmoMapMode, VmoOptions};
 
 /// The page cache for a file-like object.
 ///
@@ -177,7 +205,7 @@ impl PageCache {
     /// `PageCache::resize` only updates the page-aligned [`Vmo`] capacity. The
     /// filesystem must keep that capacity synchronized with its own file size
     /// under the same inode- or file-level lock that excludes conflicting
-    /// buffered I/O, page faults, and invalidation.
+    /// buffered I/O and resizing.
     ///
     /// The required ordering is:
     ///
@@ -212,10 +240,6 @@ impl PageCache {
     /// page_cache.resize(file_size, old_file_size).unwrap();
     /// assert_eq!(page_cache.size(), PAGE_SIZE);
     /// ```
-    //
-    // TODO: Integrate a reverse-mapping lock or equivalent synchronization so
-    // shrink/truncate can coordinate with mapped pages and concurrent page
-    // faults.
     pub fn resize(&mut self, new_file_size: usize, old_file_size: usize) -> Result<()> {
         let vmo = &self.0;
         assert!(vmo.flags.contains(VmoFlags::RESIZABLE));
@@ -228,6 +252,12 @@ impl PageCache {
             self.fill_zeros(old_file_size..fill_zero_end)?;
         }
 
+        let rmap = if new_file_size < old_file_size {
+            Some(vmo.rmap.lock())
+        } else {
+            None
+        };
+
         let new_cache_size = new_file_size.align_up(PAGE_SIZE);
         let locked_pages = vmo.pages.lock();
         let old_cache_size = vmo.size();
@@ -237,12 +267,12 @@ impl PageCache {
 
         vmo.size.store(new_cache_size, Ordering::Release);
 
-        if new_cache_size < old_cache_size {
+        if let Some(locked_rmap) = rmap {
             let decommit_range = new_cache_size..old_cache_size;
             if let Some(backed_vmo) = vmo.as_backed_vmo() {
-                backed_vmo.decommit_pages(locked_pages, &decommit_range)?;
+                backed_vmo.decommit_pages(locked_rmap, locked_pages, &decommit_range)?;
             } else {
-                vmo.decommit_anon_pages(locked_pages, decommit_range)?;
+                vmo.decommit_anon_pages(locked_rmap, locked_pages, decommit_range)?;
             }
         }
 
@@ -258,9 +288,6 @@ impl PageCache {
     /// Filesystems that need `fsync`-like guarantees must still exclude
     /// concurrent writers or repeat the operation until their own ordering
     /// requirements are met.
-    ///
-    /// Callers must hold the filesystem-level lock that serializes operations in
-    /// the target range.
     ///
     /// If the given range exceeds the current size of the page cache, only the pages within
     /// the valid range will be flushed.
@@ -278,17 +305,6 @@ impl PageCache {
     /// pages are left in place. This is useful for invalidating cached data that
     /// is no longer needed and can be re-read from the backend if necessary
     /// (e.g., before direct I/O operations).
-    ///
-    /// Callers must hold the filesystem-level lock that serializes operations in
-    /// the target range.
-    ///
-    /// Because this method can detach pages from the cache, callers must also
-    /// hold the reverse-mapping / page-table invalidation lock that excludes
-    /// concurrent page faults and mapped access to the same range.
-    //
-    // TODO: Integrate a reverse-mapping lock or equivalent synchronization so
-    // eviction can coordinate with mapped pages and concurrent page faults
-    // before removing cached pages from the page cache.
     #[cfg_attr(not(ktest), expect(dead_code))]
     pub fn evict_range(&self, range: Range<usize>) -> Result<()> {
         let Some(vmo) = self.0.as_backed_vmo() else {

--- a/kernel/src/vm/page_cache/tests/mod.rs
+++ b/kernel/src/vm/page_cache/tests/mod.rs
@@ -5,10 +5,13 @@
 
 use alloc::vec;
 
-use ostd::{mm::VmIo, prelude::ktest};
+use ostd::{
+    mm::{VmIo, io::util::HasVmReaderWriter},
+    prelude::ktest,
+};
 
 use self::utils::{IoCompletion, IoKind, MockPageCacheBackend, wait_until};
-use super::{PageCache, PageCacheBackend, VmoCommitError};
+use super::{PageCache, PageCacheBackend, Vmo, VmoCommitError, VmoMapMode};
 use crate::{prelude::*, thread::kernel_thread::ThreadOptions};
 
 mod utils;
@@ -17,6 +20,33 @@ mod utils;
 fn new_backend_page_cache(backend: &Arc<MockPageCacheBackend>, num_pages: usize) -> PageCache {
     let backend_dyn: Arc<dyn PageCacheBackend> = backend.clone();
     PageCache::new_with_backend(num_pages * PAGE_SIZE, Arc::downgrade(&backend_dyn)).unwrap()
+}
+
+/// Creates a locked page cache that models the inode-level lock held by
+/// filesystem callers before touching the page cache.
+fn new_locked_backend_page_cache(
+    backend: &Arc<MockPageCacheBackend>,
+    num_pages: usize,
+) -> Arc<RwMutex<PageCache>> {
+    Arc::new(RwMutex::new(new_backend_page_cache(backend, num_pages)))
+}
+
+/// Simulates stores through a shared writable VMO mapping.
+///
+/// A store page fault first commits page 0 for shared writes, which marks an
+/// up-to-date backend page dirty. The actual byte copy then writes the
+/// committed frame directly, matching mapped-memory stores without routing
+/// through the page-cache write API.
+fn write_vmo_bytes(vmo: &Vmo, bytes: &[u8]) {
+    assert!(!bytes.is_empty());
+    assert!(bytes.len() <= PAGE_SIZE);
+
+    vmo.commit_on(0, VmoMapMode::SharedWrite).unwrap();
+    let (page, _) = vmo.try_commit_page(0, VmoMapMode::SharedWrite).unwrap();
+
+    let mut reader = VmReader::from(bytes);
+    let mut writer = page.writer();
+    assert_eq!(writer.write(&mut reader), bytes.len());
 }
 
 /// Serializes a cold read and a later overwrite with the caller-provided
@@ -30,8 +60,7 @@ fn concurrent_read_and_write() {
     let new_pattern = vec![0xa5; PAGE_SIZE];
     backend.set_persisted_page_bytes(0, &old_pattern);
 
-    let page_cache = new_backend_page_cache(&backend, 1);
-    let io_lock = Arc::new(Mutex::new(()));
+    let page_cache = Arc::new(Mutex::new(new_backend_page_cache(&backend, 1)));
     let observed_read_result = Arc::new(Mutex::new(None::<Vec<u8>>));
     let writer_started = Arc::new(Mutex::new(false));
     let writer_finished = Arc::new(Mutex::new(false));
@@ -40,10 +69,9 @@ fn concurrent_read_and_write() {
     // caller-provided buffered-I/O lock while the writer attempts to enter.
     let read_thread = {
         let page_cache = page_cache.clone();
-        let io_lock = io_lock.clone();
         let observed_read_result = observed_read_result.clone();
         ThreadOptions::new(move || {
-            let _io_guard = io_lock.lock();
+            let page_cache = page_cache.lock();
             let mut read_buffer = vec![0; PAGE_SIZE];
             page_cache.read_bytes(0, &mut read_buffer).unwrap();
             *observed_read_result.lock() = Some(read_buffer);
@@ -60,13 +88,12 @@ fn concurrent_read_and_write() {
     // has completed.
     let write_thread = {
         let page_cache = page_cache.clone();
-        let io_lock = io_lock.clone();
         let writer_started = writer_started.clone();
         let writer_finished = writer_finished.clone();
         let new_pattern = new_pattern.clone();
         ThreadOptions::new(move || {
             *writer_started.lock() = true;
-            let _io_guard = io_lock.lock();
+            let page_cache = page_cache.lock();
             page_cache.write_bytes(0, &new_pattern).unwrap();
             *writer_finished.lock() = true;
         })
@@ -87,7 +114,7 @@ fn concurrent_read_and_write() {
     assert_eq!(backend.read_count(0), 1);
 
     let mut read_buffer = vec![0; PAGE_SIZE];
-    page_cache.read_bytes(0, &mut read_buffer).unwrap();
+    page_cache.lock().read_bytes(0, &mut read_buffer).unwrap();
     assert_eq!(read_buffer, new_pattern);
 }
 
@@ -98,10 +125,14 @@ fn concurrent_write_and_flush() {
     let backend = MockPageCacheBackend::new(1);
     backend.set_completion(IoKind::Write, IoCompletion::Deferred);
 
-    let page_cache = new_backend_page_cache(&backend, 1);
+    let page_cache = new_locked_backend_page_cache(&backend, 1);
+    let vmo = page_cache.read().as_vmo().clone();
     let first_dirty_pattern = vec![0x11; PAGE_SIZE];
     let latest_dirty_pattern = vec![0x22; PAGE_SIZE];
-    page_cache.write_bytes(0, &first_dirty_pattern).unwrap();
+    page_cache
+        .write()
+        .write_bytes(0, &first_dirty_pattern)
+        .unwrap();
 
     let flush_result = Arc::new(Mutex::new(None::<Result<()>>));
     let writer_finished = Arc::new(Mutex::new(false));
@@ -112,7 +143,7 @@ fn concurrent_write_and_flush() {
         let page_cache = page_cache.clone();
         let flush_result = flush_result.clone();
         ThreadOptions::new(move || {
-            *flush_result.lock() = Some(page_cache.flush_range(0..PAGE_SIZE));
+            *flush_result.lock() = Some(page_cache.read().flush_range(0..PAGE_SIZE));
         })
         .spawn()
     };
@@ -122,11 +153,11 @@ fn concurrent_write_and_flush() {
     // Re-dirty the same page while the first writeback is in flight. A later
     // flush must persist this newest version instead of silently dropping it.
     let writer_thread = {
-        let page_cache = page_cache.clone();
+        let vmo = vmo.clone();
         let writer_finished = writer_finished.clone();
         let latest_dirty_pattern = latest_dirty_pattern.clone();
         ThreadOptions::new(move || {
-            page_cache.write_bytes(0, &latest_dirty_pattern).unwrap();
+            write_vmo_bytes(&vmo, &latest_dirty_pattern);
             *writer_finished.lock() = true;
         })
         .spawn()
@@ -142,10 +173,10 @@ fn concurrent_write_and_flush() {
     assert!(flush_result.lock().take().unwrap().is_ok());
 
     backend.set_completion(IoKind::Write, IoCompletion::Immediate);
-    page_cache.flush_range(0..PAGE_SIZE).unwrap();
+    page_cache.read().flush_range(0..PAGE_SIZE).unwrap();
 
     let mut read_buffer = vec![0; PAGE_SIZE];
-    page_cache.read_bytes(0, &mut read_buffer).unwrap();
+    page_cache.read().read_bytes(0, &mut read_buffer).unwrap();
     assert_eq!(read_buffer, latest_dirty_pattern);
     assert_eq!(backend.write_count(0), 2);
     assert_eq!(backend.persisted_page_bytes(0), latest_dirty_pattern);
@@ -158,10 +189,14 @@ fn concurrent_write_and_evict() {
     let backend = MockPageCacheBackend::new(1);
     backend.set_completion(IoKind::Write, IoCompletion::Deferred);
 
-    let page_cache = new_backend_page_cache(&backend, 1);
+    let page_cache = new_locked_backend_page_cache(&backend, 1);
+    let vmo = page_cache.read().as_vmo().clone();
     let first_dirty_pattern = vec![0x52; PAGE_SIZE];
     let latest_dirty_pattern = vec![0x7d; PAGE_SIZE];
-    page_cache.write_bytes(0, &first_dirty_pattern).unwrap();
+    page_cache
+        .write()
+        .write_bytes(0, &first_dirty_pattern)
+        .unwrap();
 
     // Race a flush+evict sequence against a new writer after writeback has
     // already started. This checks that a page re-dirtied before eviction
@@ -171,6 +206,7 @@ fn concurrent_write_and_evict() {
         let page_cache = page_cache.clone();
         let flush_and_evict_result = flush_and_evict_result.clone();
         ThreadOptions::new(move || {
+            let page_cache = page_cache.read();
             let result = page_cache
                 .flush_range(0..PAGE_SIZE)
                 .and_then(|()| page_cache.evict_range(0..PAGE_SIZE));
@@ -184,10 +220,10 @@ fn concurrent_write_and_evict() {
     // Dirty the page again before the first writeback completes. Eviction
     // should leave this newest dirty page resident in cache.
     let writer_thread = {
-        let page_cache = page_cache.clone();
+        let vmo = vmo.clone();
         let latest_dirty_pattern = latest_dirty_pattern.clone();
         ThreadOptions::new(move || {
-            page_cache.write_bytes(0, &latest_dirty_pattern).unwrap();
+            write_vmo_bytes(&vmo, &latest_dirty_pattern);
         })
         .spawn()
     };
@@ -201,12 +237,12 @@ fn concurrent_write_and_evict() {
     assert!(flush_and_evict_result.lock().take().unwrap().is_ok());
 
     let mut read_buffer = vec![0; PAGE_SIZE];
-    page_cache.read_bytes(0, &mut read_buffer).unwrap();
+    page_cache.read().read_bytes(0, &mut read_buffer).unwrap();
     assert_eq!(read_buffer, latest_dirty_pattern);
     assert_eq!(backend.read_count(0), 0);
 
     backend.set_completion(IoKind::Write, IoCompletion::Immediate);
-    page_cache.flush_range(0..PAGE_SIZE).unwrap();
+    page_cache.read().flush_range(0..PAGE_SIZE).unwrap();
     assert_eq!(backend.write_count(0), 2);
     assert_eq!(backend.persisted_page_bytes(0), latest_dirty_pattern);
 }
@@ -219,7 +255,8 @@ fn concurrent_commit_and_truncate() {
     backend.set_completion(IoKind::Read, IoCompletion::Deferred);
     backend.set_persisted_page_bytes(1, &[0x9b; PAGE_SIZE]);
 
-    let page_cache = new_backend_page_cache(&backend, 2);
+    let page_cache = new_locked_backend_page_cache(&backend, 2);
+    let vmo = page_cache.read().as_vmo().clone();
     let commit_second_page_result = Arc::new(Mutex::new(None::<Result<()>>));
     let resize_result = Arc::new(Mutex::new(None::<Result<()>>));
     let resize_started = Arc::new(Mutex::new(false));
@@ -228,10 +265,11 @@ fn concurrent_commit_and_truncate() {
     // Commit page 1 and pause its backend read so truncate can shrink the VMO
     // while that commit is still waiting for initialization to finish.
     let commit_thread = {
-        let vmo = page_cache.as_vmo().clone();
+        let vmo = vmo.clone();
         let commit_second_page_result = commit_second_page_result.clone();
         ThreadOptions::new(move || {
-            *commit_second_page_result.lock() = Some(vmo.commit_on(1).map(|_| ()));
+            *commit_second_page_result.lock() =
+                Some(vmo.commit_on(1, VmoMapMode::SharedRead).map(|_| ()));
         })
         .spawn()
     };
@@ -245,7 +283,7 @@ fn concurrent_commit_and_truncate() {
         let resize_finished = resize_finished.clone();
         ThreadOptions::new(move || {
             *resize_started.lock() = true;
-            *resize_result.lock() = Some(page_cache.resize(PAGE_SIZE, 2 * PAGE_SIZE));
+            *resize_result.lock() = Some(page_cache.write().resize(PAGE_SIZE, 2 * PAGE_SIZE));
             *resize_finished.lock() = true;
         })
         .spawn()
@@ -263,12 +301,17 @@ fn concurrent_commit_and_truncate() {
     assert!(commit_second_page_result.lock().take().unwrap().is_ok());
     assert!(resize_result.lock().take().unwrap().is_ok());
     assert_eq!(
-        page_cache.as_vmo().commit_on(1).unwrap_err().error(),
+        vmo.commit_on(1, VmoMapMode::SharedRead)
+            .unwrap_err()
+            .error(),
         Errno::EINVAL
     );
 
     let mut read_buffer = vec![0; PAGE_SIZE];
-    page_cache.read_bytes(PAGE_SIZE, &mut read_buffer).unwrap();
+    page_cache
+        .read()
+        .read_bytes(PAGE_SIZE, &mut read_buffer)
+        .unwrap();
     assert_eq!(read_buffer, vec![0; PAGE_SIZE]);
 }
 
@@ -281,11 +324,11 @@ fn concurrent_page_faults() {
     backend.set_persisted_page_bytes(0, &[0x6b; PAGE_SIZE]);
 
     let page_cache = new_backend_page_cache(&backend, 1);
-    let vmo = page_cache.as_vmo();
+    let vmo = page_cache.as_vmo().clone();
     // The first page-fault style probe should report that backend I/O is
     // needed because the page has not been committed yet.
     assert!(matches!(
-        vmo.try_commit_page(0),
+        vmo.try_commit_page(0, VmoMapMode::SharedRead),
         Err(VmoCommitError::NeedIo { index: 0 })
     ));
 
@@ -298,15 +341,15 @@ fn concurrent_page_faults() {
         let vmo = vmo.clone();
         let first_commit_finished = first_commit_finished.clone();
         ThreadOptions::new(move || {
-            vmo.commit_on(0).unwrap();
+            vmo.commit_on(0, VmoMapMode::SharedRead).unwrap();
             *first_commit_finished.lock() = true;
         })
         .spawn()
     };
 
     backend.wait_for_deferred_bios(IoKind::Read, 1);
-    match vmo.try_commit_page(0) {
-        Err(VmoCommitError::WaitUntilInit { index: 0, .. }) => {}
+    match vmo.try_commit_page(0, VmoMapMode::SharedRead) {
+        Err(VmoCommitError::NeedIo { index: 0 }) => {}
         other => panic!("unexpected page-fault state: {other:?}"),
     }
 
@@ -316,7 +359,7 @@ fn concurrent_page_faults() {
         let vmo = vmo.clone();
         let second_commit_finished = second_commit_finished.clone();
         ThreadOptions::new(move || {
-            vmo.commit_on(0).unwrap();
+            vmo.commit_on(0, VmoMapMode::SharedRead).unwrap();
             *second_commit_finished.lock() = true;
         })
         .spawn()
@@ -350,7 +393,7 @@ fn persistent_backend_errors() {
     backend.set_completion(IoKind::Read, IoCompletion::Deferred);
 
     let page_cache = new_backend_page_cache(&backend, 1);
-    let vmo = page_cache.as_vmo();
+    let vmo = page_cache.as_vmo().clone();
     let first_error = Arc::new(Mutex::new(None::<Errno>));
     let second_error = Arc::new(Mutex::new(None::<Errno>));
 
@@ -361,7 +404,11 @@ fn persistent_backend_errors() {
         let vmo = vmo.clone();
         let first_error = first_error.clone();
         ThreadOptions::new(move || {
-            *first_error.lock() = Some(vmo.commit_on(0).unwrap_err().error());
+            *first_error.lock() = Some(
+                vmo.commit_on(0, VmoMapMode::SharedRead)
+                    .unwrap_err()
+                    .error(),
+            );
         })
         .spawn()
     };
@@ -372,7 +419,11 @@ fn persistent_backend_errors() {
         let vmo = vmo.clone();
         let second_error = second_error.clone();
         ThreadOptions::new(move || {
-            *second_error.lock() = Some(vmo.commit_on(0).unwrap_err().error());
+            *second_error.lock() = Some(
+                vmo.commit_on(0, VmoMapMode::SharedRead)
+                    .unwrap_err()
+                    .error(),
+            );
         })
         .spawn()
     };
@@ -404,7 +455,8 @@ fn delayed_io_completion() {
     let latest_dirty_pattern = vec![0x33; PAGE_SIZE];
     backend.set_persisted_page_bytes(0, &persisted_pattern);
 
-    let page_cache = new_backend_page_cache(&backend, 1);
+    let page_cache = new_locked_backend_page_cache(&backend, 1);
+    let vmo = page_cache.read().as_vmo().clone();
     let first_read_result = Arc::new(Mutex::new(None::<Vec<u8>>));
     let second_read_result = Arc::new(Mutex::new(None::<Vec<u8>>));
 
@@ -415,7 +467,7 @@ fn delayed_io_completion() {
         let first_read_result = first_read_result.clone();
         ThreadOptions::new(move || {
             let mut read_buffer = vec![0; PAGE_SIZE];
-            page_cache.read_bytes(0, &mut read_buffer).unwrap();
+            page_cache.read().read_bytes(0, &mut read_buffer).unwrap();
             *first_read_result.lock() = Some(read_buffer);
         })
         .spawn()
@@ -425,7 +477,7 @@ fn delayed_io_completion() {
         let second_read_result = second_read_result.clone();
         ThreadOptions::new(move || {
             let mut read_buffer = vec![0; PAGE_SIZE];
-            page_cache.read_bytes(0, &mut read_buffer).unwrap();
+            page_cache.read().read_bytes(0, &mut read_buffer).unwrap();
             *second_read_result.lock() = Some(read_buffer);
         })
         .spawn()
@@ -443,7 +495,10 @@ fn delayed_io_completion() {
 
     // Start one deferred writeback, then dirty the page again before it
     // completes so a second flush must wait for `is_writing_back` to clear.
-    page_cache.write_bytes(0, &first_dirty_pattern).unwrap();
+    page_cache
+        .write()
+        .write_bytes(0, &first_dirty_pattern)
+        .unwrap();
 
     let first_flush_result = Arc::new(Mutex::new(None::<Result<()>>));
     let second_flush_result = Arc::new(Mutex::new(None::<Result<()>>));
@@ -454,14 +509,14 @@ fn delayed_io_completion() {
         let page_cache = page_cache.clone();
         let first_flush_result = first_flush_result.clone();
         ThreadOptions::new(move || {
-            *first_flush_result.lock() = Some(page_cache.flush_range(0..PAGE_SIZE));
+            *first_flush_result.lock() = Some(page_cache.read().flush_range(0..PAGE_SIZE));
         })
         .spawn()
     };
 
     backend.wait_for_deferred_bios(IoKind::Write, 1);
 
-    page_cache.write_bytes(0, &latest_dirty_pattern).unwrap();
+    write_vmo_bytes(&vmo, &latest_dirty_pattern);
 
     let second_flush_thread = {
         let page_cache = page_cache.clone();
@@ -470,7 +525,7 @@ fn delayed_io_completion() {
         let second_flush_finished = second_flush_finished.clone();
         ThreadOptions::new(move || {
             *second_flush_started.lock() = true;
-            *second_flush_result.lock() = Some(page_cache.flush_range(0..PAGE_SIZE));
+            *second_flush_result.lock() = Some(page_cache.read().flush_range(0..PAGE_SIZE));
             *second_flush_finished.lock() = true;
         })
         .spawn()

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -591,7 +591,7 @@ impl Vmo {
                     Ok(written_size) => written_size,
                     Err((err, written_size)) => {
                         // If the page is not initialized, keep it as it is on a partial write.
-                        if written_size > 0 && locked_page.is_up_to_date() {
+                        if written_size > 0 && locked_page.state().is_up_to_date() {
                             locked_page.set_dirty();
                         }
                         return Err(Error::from(err));
@@ -702,8 +702,9 @@ impl<'a> BackedVmo<'a> {
         }
 
         let page_idx_range = get_page_idx_range(range);
-        let dirty_pages =
-            self.collect_pages_if(locked_pages, page_idx_range, |_, page| page.is_dirty());
+        let dirty_pages = self.collect_pages_if(locked_pages, page_idx_range, |_, page| {
+            page.state().is_dirty()
+        });
 
         let mut io_batch = IoBatch::with_capacity(dirty_pages.len());
         for (idx, page) in dirty_pages {
@@ -730,8 +731,9 @@ impl<'a> BackedVmo<'a> {
         }
 
         let page_idx_range = get_page_idx_range(range);
-        let pages_to_evict =
-            self.collect_pages_if(locked_pages, page_idx_range, |_, page| page.is_up_to_date());
+        let pages_to_evict = self.collect_pages_if(locked_pages, page_idx_range, |_, page| {
+            page.state().is_up_to_date()
+        });
         self.wait_for_writeback_and_remove_pages(pages_to_evict);
 
         Ok(())
@@ -806,7 +808,7 @@ impl<'a> BackedVmo<'a> {
         };
 
         // Check if the page is initialized.
-        if !commit_mode.skips_backend_read() && page.is_uninit() {
+        if !commit_mode.skips_backend_read() && page.state().is_uninit() {
             return Err(VmoCommitError::WaitUntilInit {
                 index: page_idx,
                 page: page.clone(),

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -31,7 +31,10 @@ use xarray::{Cursor, LockedXArray, XArray};
 
 use crate::{
     prelude::*,
-    vm::page_cache::{CachePage, CachePageExt, PageCacheBackend},
+    vm::{
+        page_cache::{CachePage, CachePageExt, PageCacheBackend},
+        vmar::Rmap,
+    },
 };
 
 mod options;
@@ -131,6 +134,8 @@ pub struct Vmo {
     // not have the knowledge to determine if they belong to memfd. We may want to enhance
     // `VmoOptions` to make VMOs aware of whether its writable mappings should be tracked.
     pub(super) writable_mapping_status: WritableMappingStatus,
+    /// Reserve mappings.
+    pub(super) rmap: Mutex<Rmap>,
 }
 
 impl Debug for Vmo {
@@ -343,6 +348,18 @@ impl Vmo {
         // VMOs with a backend do not use this field.
         debug_assert!(!self.has_backend());
         &self.writable_mapping_status
+    }
+
+    /// Returns reverse mappings of the VMO.
+    ///
+    /// Holding either this lock or the VMAR lock ensures the stability of the
+    /// associated VM mappings. In other words, when adding, removing, or
+    /// moving a VM mapping, both this lock and the VMAR lock must be held.
+    ///
+    /// To avoid deadlocks, acquire this lock after the VMAR lock in cases both
+    /// locks need to be acquired.
+    pub fn rmap(&self) -> &Mutex<Rmap> {
+        &self.rmap
     }
 
     /// Decommits anonymous pages in the specified byte range.

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -214,8 +214,9 @@ impl Vmo {
     ///
     /// For anonymous VMOs the page is zero-filled on first access.
     /// For VMOs with a backend this may perform synchronous I/O.
-    pub fn commit_on(&self, page_idx: usize) -> Result<CachePage> {
-        self.commit_on_internal(page_idx, CommitMode::Read)
+    pub fn commit_on(&self, page_idx: usize) -> Result<()> {
+        self.commit_on_internal(page_idx, CommitMode::Read)?;
+        Ok(())
     }
 
     fn commit_on_internal(&self, page_idx: usize, commit_mode: CommitMode) -> Result<CachePage> {
@@ -416,7 +417,8 @@ impl Vmo {
                 page_offset = 0;
             }
 
-            // `current_idx < page_idx_range.end` guarantees at least one page is successfully collected here.
+            // `current_idx < page_idx_range.end` guarantees at least one page is successfully
+            // collected here.
             current_idx = page_batch.last().unwrap().0 + 1;
         }
 
@@ -548,7 +550,8 @@ impl Vmo {
                 *page_offset = 0;
             }
 
-            // `current_idx < page_idx_range.end` guarantees at least one page is successfully collected here.
+            // `current_idx < page_idx_range.end` guarantees at least one page is successfully
+            // collected here.
             current_idx = page_batch.last().unwrap().0 + 1;
         }
 
@@ -573,7 +576,8 @@ impl Vmo {
         while current_idx < page_idx_range.end {
             self.collect_pages(current_idx, page_idx_range.end, commit_mode, page_batch)?;
 
-            // `current_idx < page_idx_range.end` guarantees at least one page is successfully collected here.
+            // `current_idx < page_idx_range.end` guarantees at least one page is successfully
+            // collected here.
             let next_idx = page_batch.last().unwrap().0 + 1;
 
             for (_, page) in page_batch.drain(..) {

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -32,7 +32,7 @@ use xarray::{Cursor, LockedXArray, XArray};
 use crate::{
     prelude::*,
     vm::{
-        page_cache::{CachePage, CachePageExt, PageCacheBackend},
+        page_cache::{CachePage, CachePageExt, PageCacheBackend, cache_page::PageState},
         vmar::Rmap,
     },
 };
@@ -103,8 +103,11 @@ pub use options::VmoOptions;
 ///   materialized as zeros.
 /// - `Uninit -> Dirty`: a full-page overwrite commits and keeps the page
 ///   locked until the writer has copied its new contents.
-/// - `UpToDate -> Dirty`: buffered writes modify the page under the page lock.
+/// - `UpToDate -> Dirty`: buffered writes modify the page under the page lock,
+///   or the page is mapped writably to userspace.
 /// - `Dirty -> UpToDate`: the VMO writeback path hands the page to the backend.
+/// - `UpToDate -> Evicted`: the page is evicted and the page lock is held until
+///   the page is removed from the VMO.
 ///
 /// The auxiliary `is_writing_back` bit is set under the page lock, then cleared
 /// later by the BIO completion callback after the writeback state has been
@@ -214,13 +217,84 @@ impl CommitMode {
     }
 }
 
+/// A mode specified when committing a new [`Vmo`] page to the map in a page table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmoMapMode {
+    /// The page is private. It can be a snapshot.
+    Private,
+    /// The page is shared. It needs to be read.
+    SharedRead,
+    /// The page is shared. It needs to be read and written.
+    SharedWrite,
+}
+
+impl VmoMapMode {
+    /// Ensures that the page can be mapped to a page table.
+    fn ensure(self, page: CachePage) {
+        match page.state() {
+            PageState::UpToDate if self.is_write() => {
+                let locked_page = page.lock_guard();
+                if locked_page.state().is_up_to_date() {
+                    locked_page.set_dirty();
+                }
+            }
+            PageState::UpToDate | PageState::Dirty => (),
+            PageState::Evicted if !self.is_shared() => (),
+            state @ (PageState::Uninit | PageState::Evicted) => {
+                // We shouldn't reach this point if the page is not initialized. `CommitMode::Read`
+                // should have been specified earlier to either read the page from the backend
+                // storage or report an error if reading fails.
+                debug_assert_eq!(state, PageState::Evicted);
+                // The page may be evicted. It still contains valid data. However, it cannot be
+                // mapped to a page table. We acquire the page lock here so that, when the caller
+                // retries, it won't see this page anymore.
+                let _ = page.lock_guard();
+            }
+        }
+    }
+
+    /// Tries to ensure that the page can be mapped to a page table without blocking.
+    ///
+    /// On success, returns a mode that satisfies `self` but may grant the caller more permissions
+    /// when mapping `page`. See also the "Map modes" section in [`Vmo::try_commit_page`].
+    fn try_ensure(self, page_idx: usize, page: &CachePage) -> Result<Self, VmoCommitError> {
+        match page.state() {
+            PageState::UpToDate if self.is_write() => {
+                if let Some(locked_page) = page.try_lock_guard()
+                    && locked_page.state().is_up_to_date()
+                {
+                    locked_page.set_dirty();
+                    Ok(Self::SharedWrite)
+                } else {
+                    Err(VmoCommitError::NeedIo { index: page_idx })
+                }
+            }
+            PageState::UpToDate => Ok(Self::SharedRead),
+            PageState::Dirty => Ok(Self::SharedWrite),
+            PageState::Evicted if !self.is_shared() => Ok(Self::Private),
+            PageState::Uninit | PageState::Evicted => {
+                Err(VmoCommitError::NeedIo { index: page_idx })
+            }
+        }
+    }
+
+    fn is_write(self) -> bool {
+        matches!(self, Self::SharedWrite)
+    }
+
+    fn is_shared(self) -> bool {
+        matches!(self, Self::SharedRead | Self::SharedWrite)
+    }
+}
+
 impl Vmo {
     /// Commits the page at `page_idx`, blocking on backend I/O if required.
     ///
     /// For anonymous VMOs the page is zero-filled on first access.
     /// For VMOs with a backend this may perform synchronous I/O.
-    pub fn commit_on(&self, page_idx: usize) -> Result<()> {
-        self.commit_on_internal(page_idx, CommitMode::Read)?;
+    pub fn commit_on(&self, page_idx: usize, map_mode: VmoMapMode) -> Result<()> {
+        let page = self.commit_on_internal(page_idx, CommitMode::Read)?;
+        map_mode.ensure(page);
         Ok(())
     }
 
@@ -252,7 +326,28 @@ impl Vmo {
     ///
     /// If the commit operation needs to perform I/O, it will return a
     /// [`VmoCommitError::NeedIo`].
-    pub fn try_commit_page(&self, offset: usize) -> Result<CachePage, VmoCommitError> {
+    ///
+    /// If the VMO corresponds to a page cache, callers must hold the page table
+    /// lock and insert the committed page atomically to the page table after
+    /// this method returns.
+    ///
+    /// # Map modes
+    ///
+    /// `map_mode` specifies the requested mapping mode for the page in the page
+    /// table. If successful, this method returns another [`VmoMapMode`] that
+    /// grants at least the requested mode, but may grant additional permissions
+    /// according to the page state. Callers can use this information to prevent
+    /// some future page faults.
+    ///
+    /// For example, if the page is already dirty, mapping it as writable is
+    /// permitted even if only read access is required in `map_mode`. In this
+    /// case, the requested mode (`map_mode`) is [`VmoMapMode::SharedRead`] but
+    /// the granted mode (the return value) is [`VmoMapMode::SharedWrite`].
+    pub fn try_commit_page(
+        &self,
+        offset: usize,
+        map_mode: VmoMapMode,
+    ) -> Result<(CachePage, VmoMapMode), VmoCommitError> {
         let page_idx = offset / PAGE_SIZE;
         if offset >= self.size() {
             return Err(VmoCommitError::Err(Error::with_message(
@@ -261,10 +356,14 @@ impl Vmo {
             )));
         }
 
-        let guard = disable_preempt();
-        let mut cursor = self.pages.cursor(&guard, page_idx as u64);
-        self.try_commit_with_cursor(&mut cursor, CommitMode::Read)
-            .map(|(_, page)| page)
+        let (_, page) = {
+            let guard = disable_preempt();
+            let mut cursor = self.pages.cursor(&guard, page_idx as u64);
+            // `VmoMapMode::try_ensure` checks if the page has been initialized.
+            self.try_commit_with_cursor(&mut cursor, CommitMode::Overwrite)?
+        };
+        let mode = map_mode.try_ensure(page_idx, &page)?;
+        Ok((page, mode))
     }
 
     fn try_commit_with_cursor(
@@ -293,17 +392,34 @@ impl Vmo {
     ///
     /// Once a commit operation needs to perform I/O, it will return a
     /// [`VmoCommitError::NeedIo`].
+    ///
+    /// If the VMO corresponds to a page cache, callers must hold the page table
+    /// lock and insert the committed page atomically to the page table inside
+    /// the operation.
     pub fn try_operate_on_range<F>(
         &self,
         range: &Range<usize>,
-        operate: F,
+        mut operate: F,
+        map_mode: VmoMapMode,
     ) -> Result<(), VmoCommitError>
     where
         F: FnMut(
             &mut dyn FnMut() -> Result<(usize, CachePage), VmoCommitError>,
         ) -> Result<(), VmoCommitError>,
     {
-        self.try_operate_on_range_internal(range, operate, CommitMode::Read)
+        self.try_operate_on_range_internal(
+            range,
+            |commit_fn| {
+                let mut new_commit_fn = || {
+                    let (idx, page) = commit_fn()?;
+                    map_mode.try_ensure(idx, &page)?;
+                    Ok((idx, page))
+                };
+                operate(&mut new_commit_fn)
+            },
+            // `VmoMapMode::try_ensure` checks if the page has been initialized.
+            CommitMode::Overwrite,
+        )
     }
 
     fn try_operate_on_range_internal<F>(
@@ -365,6 +481,7 @@ impl Vmo {
     /// Decommits anonymous pages in the specified byte range.
     pub(super) fn decommit_anon_pages(
         &self,
+        mut locked_rmap: MutexGuard<Rmap>,
         mut locked_pages: LockedXArray<CachePage>,
         range: Range<usize>,
     ) -> Result<()> {
@@ -373,6 +490,9 @@ impl Vmo {
         let page_idx_range = get_page_idx_range(&range);
         let mut cursor = locked_pages.cursor_mut(page_idx_range.start as u64);
 
+        // We remove pages before unmapping them in the page table. So a concurrent page fault will
+        // synchronize via the page table lock. Either the mapped item will be unmapped below or the
+        // page fault handler will commit the page and be blocked on the reverse-mapping lock.
         loop {
             cursor.remove();
             let page_idx = cursor.next_present();
@@ -380,6 +500,10 @@ impl Vmo {
                 break;
             }
         }
+
+        drop(locked_pages);
+
+        locked_rmap.unmap(page_idx_range.start * PAGE_SIZE..page_idx_range.end * PAGE_SIZE);
 
         Ok(())
     }
@@ -595,10 +719,17 @@ impl Vmo {
 
             // `current_idx < page_idx_range.end` guarantees at least one page is successfully
             // collected here.
-            let next_idx = page_batch.last().unwrap().0 + 1;
+            let mut next_idx = page_batch.last().unwrap().0 + 1;
 
-            for (_, page) in page_batch.drain(..) {
+            for (idx, page) in page_batch.drain(..) {
                 let locked_page = page.lock();
+
+                let state = locked_page.state();
+                if state.is_evicted() {
+                    // Retry. We will not see this page again because we've acquired the page lock.
+                    next_idx = idx;
+                    continue;
+                }
 
                 let written_size = match locked_page
                     .writer()
@@ -608,7 +739,7 @@ impl Vmo {
                     Ok(written_size) => written_size,
                     Err((err, written_size)) => {
                         // If the page is not initialized, keep it as it is on a partial write.
-                        if written_size > 0 && locked_page.state().is_up_to_date() {
+                        if written_size > 0 && state.is_up_to_date() {
                             locked_page.set_dirty();
                         }
                         return Err(Error::from(err));
@@ -710,48 +841,142 @@ pub struct BackedVmo<'a> {
     backend: Arc<dyn PageCacheBackend>,
 }
 
+enum PageSelection {
+    Flush,
+    Evict,
+}
+
+impl PageSelection {
+    fn should_collect(&self, page: &CachePage) -> bool {
+        let state = page.state();
+        match self {
+            PageSelection::Flush if state.is_dirty() => true,
+            PageSelection::Flush if state.is_uninit() => false,
+            PageSelection::Flush if let Some(locked_page) = page.try_lock_guard() => {
+                locked_page.is_writing_back()
+            }
+            // We need to wait for all the pages that are being written back to finish before
+            // returning from `flush()`. But we don't know whether this page is being writing back
+            // because `try_lock_guard()` fails. So let's be conservative and collect this page.
+            PageSelection::Flush => true,
+            PageSelection::Evict => state.is_up_to_date(),
+        }
+    }
+}
+
 impl<'a> BackedVmo<'a> {
     /// Writes back dirty pages in the specified byte range to the backend storage.
     pub(super) fn flush_dirty_pages(&self, range: &Range<usize>) -> Result<()> {
-        let locked_pages = self.vmo.pages.lock();
         if range.start >= self.size() {
             return Ok(());
         }
 
-        let page_idx_range = get_page_idx_range(range);
-        let dirty_pages = self.collect_pages_if(locked_pages, page_idx_range, |_, page| {
-            page.state().is_dirty()
-        });
+        let mut locked_rmap = self.rmap.lock();
 
-        let mut io_batch = IoBatch::with_capacity(dirty_pages.len());
-        for (idx, page) in dirty_pages {
+        let page_idx_range = get_page_idx_range(range);
+        let pages_to_flush = self.collect_pages_if(&page_idx_range, PageSelection::Flush);
+        if pages_to_flush.is_empty() {
+            return Ok(());
+        }
+
+        // We must lock and mark all pages as up-to-date before freezing them in the page table. A
+        // concurrent page fault caused by a write operation will synchronize via the page table
+        // lock. Either the mapped item will be freezed below or the page fault handler will see the
+        // page as up to date and be blocked on the page lock.
+        let mut locked_dirty_pages = Vec::new();
+        let mut maybe_writing_back_pages = Vec::new();
+        for (idx, page) in pages_to_flush {
+            if !page.state().is_dirty() {
+                maybe_writing_back_pages.push(page);
+                continue;
+            }
             let locked_page = page.lock();
+            if locked_page.state().is_dirty() {
+                locked_page.set_up_to_date();
+                locked_dirty_pages.push((idx, locked_page));
+            } else if locked_page.is_writing_back() {
+                maybe_writing_back_pages.push(locked_page.unlock());
+            }
+        }
+
+        locked_rmap.freeze(page_idx_range.start * PAGE_SIZE..page_idx_range.end * PAGE_SIZE);
+
+        // As long as the pages are locked and their state is `UpToDate`, no one can write to them.
+        // Therefore, we can release the reverse-mapping lock now.
+        drop(locked_rmap);
+
+        let mut io_batch = IoBatch::with_capacity(locked_dirty_pages.len());
+        for (idx, locked_page) in locked_dirty_pages {
             self.backend
                 .write_page_async(idx, locked_page, &mut io_batch)?;
         }
+        io_batch.wait_all()?;
 
-        io_batch.wait_all().map_err(Into::into)
+        for page in maybe_writing_back_pages {
+            let locked_page = page.lock();
+            locked_page.wait_until_finish_writing_back();
+        }
+
+        Ok(())
     }
 
     /// Removes up-to-date (clean) pages in the specified byte range from the page cache.
     ///
     /// Only pages in the `UpToDate` state are removed. Dirty and uninitialized
     /// pages are left in place.
-    //
-    // TODO: Returns `Err` if any up-to-date page has been mapped.
-    // TODO: Integrate reverse mappings or an explicit invalidation lock so this
-    // path can coordinate with page faults.
     pub(super) fn evict_up_to_date_pages(&self, range: &Range<usize>) -> Result<()> {
-        let locked_pages = self.vmo.pages.lock();
         if range.start >= self.size() {
             return Ok(());
         }
 
+        let mut locked_rmap = self.rmap.lock();
+
         let page_idx_range = get_page_idx_range(range);
-        let pages_to_evict = self.collect_pages_if(locked_pages, page_idx_range, |_, page| {
-            page.state().is_up_to_date()
-        });
-        self.wait_for_writeback_and_remove_pages(pages_to_evict);
+        let up_to_date_pages = self.collect_pages_if(&page_idx_range, PageSelection::Evict);
+        if up_to_date_pages.is_empty() {
+            return Ok(());
+        }
+
+        // We need to lock all pages and ensure they are up to date under the page lock. In
+        // addition, we mark pages to be removed as `Evicted` before unmapping them in the page
+        // table. A concurrent page fault will synchronize via the page table lock. Either the
+        // mapped item will be unmapped below or the page fault handler will see the page as removed
+        // and be blocked on the page lock.
+        let locked_up_to_date_pages = up_to_date_pages
+            .into_iter()
+            .filter_map(|(idx, page)| {
+                let locked_page = page.lock();
+                if !locked_page.state().is_up_to_date() {
+                    return None;
+                }
+                locked_page.set_evicted();
+                Some((idx, locked_page))
+            })
+            .collect::<Vec<_>>();
+        if locked_up_to_date_pages.is_empty() {
+            return Ok(());
+        }
+
+        locked_rmap.unmap(page_idx_range.start * PAGE_SIZE..page_idx_range.end * PAGE_SIZE);
+
+        // As long as the pages are locked and their state is `Evicted`, no one can read from them.
+        // Therefore, we can release the reverse-mapping lock now.
+        drop(locked_rmap);
+
+        for (idx, page) in locked_up_to_date_pages {
+            page.wait_until_finish_writing_back();
+            let mut locked_pages = self.pages.lock();
+            let mut cursor_mut = locked_pages.cursor_mut(idx as u64);
+            let removed_page = cursor_mut.remove();
+            // The page won't be evicted because it has already been marked as `Evicted`. It won't
+            // be decommitted either, as the caller should hold a file system lock that prevents
+            // concurrent resizing.
+            //
+            // TODO: If we allowing pages to be evicted without holding the file system lock, the
+            // old page may be decommitted and replaced by another page. In this case, we must
+            // reload and recheck the page before removing it.
+            debug_assert_eq!(removed_page.unwrap().paddr(), page.paddr());
+        }
 
         Ok(())
     }
@@ -763,15 +988,30 @@ impl<'a> BackedVmo<'a> {
     /// finish before removing the page from the `XArray`.
     pub(super) fn decommit_pages(
         &self,
+        mut locked_rmap: MutexGuard<Rmap>,
         locked_pages: LockedXArray<CachePage>,
         range: &Range<usize>,
     ) -> Result<()> {
         // Do not check `self.size()` here. It contains the new size, however, we want to decommit
         // pages outside of the new range. See `PageCache::resize` for a concrete example.
 
+        // We remove pages before unmapping them in the page table. So a concurrent page fault will
+        // synchronize via the page table lock. Either the mapped item will be unmapped below or the
+        // page fault handler will see the new size after acquiring the lock in `self.pages`.
         let page_idx_range = get_page_idx_range(range);
-        let pages_to_decommit = self.collect_pages_if(locked_pages, page_idx_range, |_, _| true);
-        self.wait_for_writeback_and_remove_pages(pages_to_decommit);
+        let removed_pages = self.remove_pages_in(locked_pages, &page_idx_range);
+        if removed_pages.is_empty() {
+            return Ok(());
+        }
+
+        locked_rmap.unmap(page_idx_range.start * PAGE_SIZE..page_idx_range.end * PAGE_SIZE);
+
+        drop(locked_rmap);
+
+        for (_, page) in removed_pages {
+            let locked_page = page.lock();
+            locked_page.wait_until_finish_writing_back();
+        }
 
         Ok(())
     }
@@ -835,74 +1075,73 @@ impl<'a> BackedVmo<'a> {
         Ok((page_idx, page.clone()))
     }
 
-    /// Collects pages in the specified page-index range that satisfy `should_collect`.
-    ///
-    /// The pages are only read (not removed) from the XArray.
-    fn collect_pages_if<F>(
+    /// Collects pages in the specified page index range.
+    fn collect_pages_if(
         &self,
-        locked_pages: LockedXArray<CachePage>,
-        page_idx_range: Range<usize>,
-        mut should_collect: F,
-    ) -> Vec<(usize, CachePage)>
-    where
-        F: FnMut(usize, &CachePage) -> bool,
-    {
+        page_idx_range: &Range<usize>,
+        cond: PageSelection,
+    ) -> Vec<(usize, CachePage)> {
         if page_idx_range.is_empty() {
             return Vec::new();
         }
 
         let mut collected_pages = Vec::new();
 
-        let mut cursor = locked_pages.cursor(page_idx_range.start as u64);
-        if let Some(page) = cursor.load()
-            && should_collect(page_idx_range.start, &page)
-        {
-            collected_pages.push((page_idx_range.start, page.clone()));
-        }
+        let preempt_guard = disable_preempt();
+        let mut cursor = self
+            .pages
+            .cursor(&preempt_guard, page_idx_range.start as u64);
+        let mut index = page_idx_range.start;
 
-        while let Some(page_idx) = cursor.next_present() {
-            let page_idx = page_idx as usize;
-            if page_idx >= page_idx_range.end {
-                break;
+        loop {
+            if let Some(page) = cursor.load()
+                && cond.should_collect(&page)
+            {
+                collected_pages.push((index, page.clone()));
             }
 
-            let page = cursor.load().unwrap();
-            if should_collect(page_idx, &page) {
-                collected_pages.push((page_idx, page.clone()));
+            let Some(next_index) = cursor.next_present() else {
+                break;
+            };
+            index = next_index as usize;
+            if index >= page_idx_range.end {
+                break;
             }
         }
 
         collected_pages
     }
 
-    /// Waits for writeback on collected pages, then removes them from the `XArray`.
-    ///
-    /// The pages are collected before this function is called so the `XArray`
-    /// lock can be released while waiting for in-flight writeback to finish.
-    /// Waiting before removal also prevents a later commit from installing a
-    /// new page for the same index and starting duplicate BIOs while the old
-    /// page is still under writeback.
-    fn wait_for_writeback_and_remove_pages(&self, pages_to_remove: Vec<(usize, CachePage)>) {
-        for (_, page) in pages_to_remove.iter() {
-            let locked_page = page.lock_guard();
-            locked_page.wait_until_finish_writing_back();
+    /// Removes pages in the specified page index range.
+    fn remove_pages_in(
+        &self,
+        mut locked_pages: LockedXArray<CachePage>,
+        page_idx_range: &Range<usize>,
+    ) -> Vec<(usize, CachePage)> {
+        if page_idx_range.is_empty() {
+            return Vec::new();
         }
 
-        let mut locked_pages = self.vmo.pages.lock();
+        let mut removed_pages = Vec::new();
 
-        for (page_idx, page) in pages_to_remove {
-            let mut cursor = locked_pages.cursor_mut(page_idx as u64);
+        let mut cursor_mut = locked_pages.cursor_mut(page_idx_range.start as u64);
+        let mut index = page_idx_range.start;
 
-            // The caller will hold the higher-level lock that excludes concurrent
-            // removal, read/write and page fault handling, so the collected index
-            // still identifies the page that need to be deleted.
-            debug_assert!(
-                cursor
-                    .load()
-                    .is_some_and(|current_page| current_page.paddr() == page.paddr())
-            );
-            cursor.remove();
+        loop {
+            if let Some(page) = cursor_mut.remove() {
+                removed_pages.push((index, page.clone()));
+            }
+
+            let Some(next_index) = cursor_mut.next_present() else {
+                break;
+            };
+            index = next_index as usize;
+            if index >= page_idx_range.end {
+                break;
+            }
         }
+
+        removed_pages
     }
 }
 

--- a/kernel/src/vm/page_cache/vmo/options.rs
+++ b/kernel/src/vm/page_cache/vmo/options.rs
@@ -198,13 +198,13 @@ mod test {
     fn resize() {
         use crate::vm::page_cache::PageCache;
 
-        let vmo = PageCache::new_anon(PAGE_SIZE).unwrap();
-        vmo.write_val(10, &42u8).unwrap();
-        vmo.resize(2 * PAGE_SIZE, vmo.size()).unwrap();
-        assert_eq!(vmo.size(), 2 * PAGE_SIZE);
-        assert_eq!(vmo.read_val::<u8>(10).unwrap(), 42);
-        vmo.write_val(PAGE_SIZE + 20, &123u8).unwrap();
-        vmo.resize(PAGE_SIZE, vmo.size()).unwrap();
-        assert_eq!(vmo.read_val::<u8>(10).unwrap(), 42);
+        let mut page_cache = PageCache::new_anon(PAGE_SIZE).unwrap();
+        page_cache.write_val(10, &42u8).unwrap();
+        page_cache.resize(2 * PAGE_SIZE, page_cache.size()).unwrap();
+        assert_eq!(page_cache.size(), 2 * PAGE_SIZE);
+        assert_eq!(page_cache.read_val::<u8>(10).unwrap(), 42);
+        page_cache.write_val(PAGE_SIZE + 20, &123u8).unwrap();
+        page_cache.resize(PAGE_SIZE, page_cache.size()).unwrap();
+        assert_eq!(page_cache.read_val::<u8>(10).unwrap(), 42);
     }
 }

--- a/kernel/src/vm/page_cache/vmo/options.rs
+++ b/kernel/src/vm/page_cache/vmo/options.rs
@@ -11,7 +11,10 @@ use xarray::XArray;
 use super::{Vmo, VmoFlags, WritableMappingStatus};
 use crate::{
     prelude::*,
-    vm::page_cache::{CachePage, CachePageMeta, PageCacheBackend},
+    vm::{
+        page_cache::{CachePage, CachePageMeta, PageCacheBackend},
+        vmar::Rmap,
+    },
 };
 
 /// Options for allocating a root VMO.
@@ -109,12 +112,14 @@ fn alloc_vmo(
     let size = size.align_up(PAGE_SIZE);
     let pages = committed_pages_if_continuous(flags, size)?;
     let writable_mapping_status = WritableMappingStatus::default();
+    let rmap = Rmap::new();
     Ok(Vmo {
         backend,
         flags,
         pages,
         size: AtomicUsize::new(size),
         writable_mapping_status,
+        rmap: Mutex::new(rmap),
     })
 }
 

--- a/kernel/src/vm/vmar/interval_set.rs
+++ b/kernel/src/vm/vmar/interval_set.rs
@@ -48,6 +48,11 @@ where
         }
     }
 
+    /// Returns the number of elements in the interval set.
+    pub fn len(&self) -> usize {
+        self.btree.len()
+    }
+
     /// Inserts an interval item into the interval set.
     pub fn insert(&mut self, item: V) {
         let range = item.range();

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -4,6 +4,7 @@
 
 mod handle;
 mod interval_set;
+mod rmap;
 mod util;
 mod vm_mapping;
 
@@ -13,6 +14,7 @@ use ostd::mm::Vaddr;
 
 pub use self::{
     handle::VmarHandle,
+    rmap::{Rmap, RmapEntry},
     vmar_impls::{
         RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo, remap::RemapOldMappingAction,
     },

--- a/kernel/src/vm/vmar/rmap.rs
+++ b/kernel/src/vm/vmar/rmap.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{collections::btree_map::BTreeMap, sync::Weak, vec::Vec};
+use core::ops::Range;
+
+use keyable_arc::KeyableWeak;
+use ostd::{
+    mm::{PAGE_SIZE, PageFlags, Vaddr, tlb::TlbFlushOp},
+    task::disable_preempt,
+};
+
+use crate::vm::vmar::{RssType, Vmar, vmar_impls::RssDelta};
+
+/// Reverse mappings from a [`Vmo`] to [`Vmar`]s.
+///
+/// [`Vmo`]: crate::vm::page_cache::Vmo
+pub struct Rmap {
+    entries: BTreeMap<KeyableWeak<Vmar>, Vec<RmapEntry>>,
+}
+
+/// A reverse mapping entry.
+#[derive(Copy, Clone, Debug)]
+pub struct RmapEntry {
+    /// The virtual address.
+    pub vaddr: Vaddr,
+    /// The VMO offset.
+    pub offset: usize,
+    /// The mapping size.
+    pub size: usize,
+}
+
+impl Rmap {
+    pub(in crate::vm) const fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Inserts a new reverse mapping entry.
+    pub fn insert(&mut self, vmar: Weak<Vmar>, entry: RmapEntry) {
+        self.entries
+            .entry(KeyableWeak::from(vmar))
+            .or_default()
+            .push(entry)
+    }
+
+    /// Removes a reverse mapping entry.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the reverse mapping entry does not exist.
+    pub fn remove(&mut self, vmar: Weak<Vmar>, vaddr: Vaddr) {
+        use alloc::collections::btree_map::Entry;
+
+        let key = KeyableWeak::from(vmar);
+        let Entry::Occupied(mut map_entry) = self.entries.entry(key) else {
+            panic!("the entry to remove does not exist")
+        };
+
+        let entries = map_entry.get_mut();
+        let index = entries
+            .iter()
+            .position(|entry| entry.vaddr == vaddr)
+            .expect("the entry to remove does not exist");
+        entries.swap_remove(index);
+
+        if entries.is_empty() {
+            map_entry.remove();
+        }
+    }
+
+    /// Iterates over all reverse mappings and unmaps the given offset range.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the offset range is not aligned to the page boundary.
+    pub fn unmap(&mut self, offset: Range<usize>) {
+        debug_assert!(offset.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(offset.end.is_multiple_of(PAGE_SIZE));
+
+        self.entries.retain(|vmar, entries| {
+            let Some(vmar) = vmar.upgrade() else {
+                return false;
+            };
+
+            let mut rss_delta = RssDelta::new(&vmar);
+
+            for entry in entries {
+                let vmo_range =
+                    entry.offset.max(offset.start)..(entry.offset + entry.size).min(offset.end);
+                if vmo_range.is_empty() {
+                    continue;
+                }
+
+                let addr_range = (vmo_range.start - entry.offset + entry.vaddr)
+                    ..(vmo_range.end - entry.offset + entry.vaddr);
+
+                let preempt_guard = disable_preempt();
+                let mut cursor_mut = vmar
+                    .vm_space()
+                    .cursor_mut(&preempt_guard, &addr_range)
+                    .unwrap();
+                rss_delta.add(
+                    RssType::File,
+                    -(cursor_mut.unmap(addr_range.len()) as isize),
+                );
+                cursor_mut.flusher().dispatch_tlb_flush();
+                cursor_mut.flusher().sync_tlb_flush();
+            }
+
+            true
+        });
+    }
+
+    /// Iterates over all reverse mappings and freezes (i.e., makes read-only) the given offset
+    /// range.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the offset range is not aligned to the page boundary.
+    pub fn freeze(&mut self, offset: Range<usize>) {
+        debug_assert!(offset.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(offset.end.is_multiple_of(PAGE_SIZE));
+
+        self.entries.retain(|vmar, entries| {
+            let Some(vmar) = vmar.upgrade() else {
+                return false;
+            };
+
+            for entry in entries {
+                let vmo_range =
+                    entry.offset.max(offset.start)..(entry.offset + entry.size).min(offset.end);
+                if vmo_range.is_empty() {
+                    continue;
+                }
+
+                let addr_range = (vmo_range.start - entry.offset + entry.vaddr)
+                    ..(vmo_range.end - entry.offset + entry.vaddr);
+
+                let preempt_guard = disable_preempt();
+                let mut cursor_mut = vmar
+                    .vm_space()
+                    .cursor_mut(&preempt_guard, &addr_range)
+                    .unwrap();
+                loop {
+                    let addr = cursor_mut.virt_addr();
+                    if addr >= addr_range.end {
+                        break;
+                    }
+                    let len = addr_range.end - addr;
+                    if let Some(va) =
+                        cursor_mut.protect_next(len, |page_flags, _| *page_flags -= PageFlags::W)
+                    {
+                        cursor_mut
+                            .flusher()
+                            .issue_tlb_flush(TlbFlushOp::for_range(va));
+                    } else {
+                        break;
+                    }
+                }
+                cursor_mut.flusher().dispatch_tlb_flush();
+                cursor_mut.flusher().sync_tlb_flush();
+            }
+
+            true
+        });
+    }
+}

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -906,8 +906,8 @@ impl MappedVmo {
     ///
     /// This method may involve I/O operations if the VMO needs to fetch
     /// a page from the underlying page cache.
-    pub fn commit_on(&self, page_idx: usize) -> Result<UFrame> {
-        self.vmo.commit_on(page_idx).map(|frame| frame.into())
+    pub fn commit_on(&self, page_idx: usize) -> Result<()> {
+        self.vmo.commit_on(page_idx)
     }
 
     /// Traverses the indices within a specified range of a VMO sequentially.

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -30,7 +30,7 @@ use crate::{
     prelude::*,
     process::LockedHeap,
     vm::{
-        page_cache::{CachePage, Vmo, VmoCommitError},
+        page_cache::{CachePage, Vmo, VmoCommitError, VmoMapMode},
         perms::VmPerms,
     },
 };
@@ -472,11 +472,20 @@ impl VmMapping {
                         return Ok(());
                     }
                     assert!(is_write);
-                    // Perform COW if it is a write access to a shared mapping.
 
-                    // Skip if the page fault is already handled.
-                    if prop.flags.contains(PageFlags::W) {
-                        return Ok(());
+                    // For shared mappings, ensure that the VMO allows the page to be written.
+                    if self.is_shared
+                        && let MappedMemory::Vmo(vmo) = &self.mapped_mem
+                        && let Err(err) = vmo.get_committed_frame(
+                            page_aligned_addr - self.map_to_addr,
+                            VmoMapMode::SharedWrite,
+                        )
+                    {
+                        let index = err.pending_index()?;
+                        drop(cursor);
+                        drop(preempt_guard);
+                        vmo.commit_on(index, VmoMapMode::SharedWrite)?;
+                        continue 'retry;
                     }
 
                     // If the forked child or parent immediately unmaps the page after
@@ -493,6 +502,7 @@ impl VmMapping {
                         cursor.flusher().issue_tlb_flush(TlbFlushOp::for_range(va));
                         cursor.flusher().dispatch_tlb_flush();
                     } else {
+                        // Perform COW if it is a write access to a private mapping.
                         let new_frame = duplicate_frame(&frame)?;
                         prop.flags |= new_flags;
                         cursor.unmap(PAGE_SIZE);
@@ -522,7 +532,9 @@ impl VmMapping {
                             let index = err.pending_index()?;
                             drop(cursor);
                             drop(preempt_guard);
-                            self.vmo().unwrap().commit_on(index)?;
+                            self.vmo()
+                                .unwrap()
+                                .commit_on(index, self.vmo_map_mode_from_is_write(is_write))?;
                             continue 'retry;
                         }
                     };
@@ -556,7 +568,7 @@ impl VmMapping {
     fn prepare_page(
         &self,
         page_aligned_addr: Vaddr,
-        write: bool,
+        is_write: bool,
     ) -> Result<(UFrame, bool), VmoCommitError> {
         let mut is_readonly = false;
 
@@ -581,17 +593,28 @@ impl VmMapping {
             return Ok((FrameAllocOptions::new().alloc_frame()?.into(), is_readonly));
         }
 
-        let page = vmo.get_committed_frame(page_offset)?;
-        if !self.is_shared && write {
+        let (page, mode) =
+            vmo.get_committed_frame(page_offset, self.vmo_map_mode_from_is_write(is_write))?;
+        if !self.is_shared && is_write {
             // Write access to private VMO-backed mapping. Performs COW directly.
-            Ok((duplicate_frame(&page)?.into(), is_readonly))
+            Ok((duplicate_frame(&page.into())?.into(), is_readonly))
         } else {
             // Operations to shared mapping or read access to private VMO-backed mapping.
             // If read access to private VMO-backed mapping triggers a page fault,
             // the map should be readonly. If user next tries to write to the frame,
             // another page fault will be triggered which will performs a COW (Copy-On-Write).
-            is_readonly = !self.is_shared;
-            Ok((page, is_readonly))
+            is_readonly = !self.is_shared || mode != VmoMapMode::SharedWrite;
+            Ok((page.into(), is_readonly))
+        }
+    }
+
+    fn vmo_map_mode_from_is_write(&self, is_write: bool) -> VmoMapMode {
+        if !self.is_shared {
+            VmoMapMode::Private
+        } else if !is_write {
+            VmoMapMode::SharedRead
+        } else {
+            VmoMapMode::SharedWrite
         }
     }
 
@@ -627,6 +650,11 @@ impl VmMapping {
         }
 
         let vm_perms = self.perms - VmPerms::WRITE;
+        let mode = if !self.is_shared {
+            VmoMapMode::Private
+        } else {
+            VmoMapMode::SharedRead
+        };
 
         'retry: loop {
             let preempt_guard = disable_preempt();
@@ -655,12 +683,12 @@ impl VmMapping {
 
             let start_offset = start_addr - self.map_to_addr;
             let end_offset = end_addr - self.map_to_addr;
-            match vmo.try_operate_on_range(&(start_offset..end_offset), operate) {
+            match vmo.try_operate_on_range(&(start_offset..end_offset), operate, mode) {
                 Ok(_) => return Ok(()),
                 Err(err) => {
                     let index = err.pending_index()?;
                     drop(preempt_guard);
-                    vmo.commit_on(index)?;
+                    vmo.commit_on(index, mode)?;
                     start_addr = (index * PAGE_SIZE - vmo.offset()) + self.map_to_addr;
                     continue 'retry;
                 }
@@ -803,10 +831,12 @@ impl VmMapping {
 
     /// Change the perms of the mapping.
     pub(super) fn protect(self, vm_space: &VmSpace, perms: VmPerms) -> Self {
-        let mut new_flags = PageFlags::from(perms);
-        if self.is_cow() && !self.perms.contains(VmPerms::WRITE) {
-            new_flags.remove(PageFlags::W);
-        }
+        // We should never convert a page to a writable page directly.
+        //  - For private mappings, we may need to perform Copy-On-Write (COW)
+        //    before doing so.
+        //  - For shared mappings, the page may need to be marked as a dirty
+        //    page in the page cache.
+        let new_flags = PageFlags::from(perms) - PageFlags::W;
 
         let preempt_guard = disable_preempt();
         let range = self.range();
@@ -919,19 +949,22 @@ impl MappedVmo {
     /// If the VMO has not committed a frame at this index, it will commit
     /// one first and return it. If the commit operation needs to perform I/O,
     /// it will return a [`VmoCommitError::NeedIo`].
-    fn get_committed_frame(&self, page_offset: usize) -> Result<UFrame, VmoCommitError> {
+    fn get_committed_frame(
+        &self,
+        page_offset: usize,
+        map_mode: VmoMapMode,
+    ) -> Result<(CachePage, VmoMapMode), VmoCommitError> {
         debug_assert!(page_offset.is_multiple_of(PAGE_SIZE));
         self.vmo
-            .try_commit_page(self.offset + page_offset)
-            .map(|frame| frame.into())
+            .try_commit_page(self.offset + page_offset, map_mode)
     }
 
     /// Commits a page at a specific page index.
     ///
     /// This method may involve I/O operations if the VMO needs to fetch
     /// a page from the underlying page cache.
-    pub fn commit_on(&self, page_idx: usize) -> Result<()> {
-        self.vmo.commit_on(page_idx)
+    pub fn commit_on(&self, page_idx: usize, map_mode: VmoMapMode) -> Result<()> {
+        self.vmo.commit_on(page_idx, map_mode)
     }
 
     /// Traverses the indices within a specified range of a VMO sequentially.
@@ -945,6 +978,7 @@ impl MappedVmo {
         &self,
         range: &Range<usize>,
         operate: F,
+        map_mode: VmoMapMode,
     ) -> Result<(), VmoCommitError>
     where
         F: FnMut(
@@ -952,7 +986,7 @@ impl MappedVmo {
         ) -> Result<(), VmoCommitError>,
     {
         let range = self.offset + range.start..self.offset + range.end;
-        self.vmo.try_operate_on_range(&range, operate)
+        self.vmo.try_operate_on_range(&range, operate, map_mode)
     }
 
     /// Gets a reference to the underlying VMO.

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -18,7 +18,10 @@ use ostd::{
     task::disable_preempt,
 };
 
-use super::{RssType, Vmar, interval_set::Interval, util::is_intersected, vmar_impls::RssDelta};
+use super::{
+    PageFaultInfo, Rmap, RssType, Vmar, interval_set::Interval, util::is_intersected,
+    vmar_impls::RssDelta,
+};
 use crate::{
     fs::vfs::{
         inode::Inode,
@@ -29,7 +32,6 @@ use crate::{
     vm::{
         page_cache::{CachePage, Vmo, VmoCommitError},
         perms::VmPerms,
-        vmar::PageFaultInfo,
     },
 };
 
@@ -172,6 +174,28 @@ impl VmMapping {
             MappedMemory::Vmo(vmo) => Some(vmo),
             _ => None,
         }
+    }
+
+    /// Returns a reference to the VMO for reserve mappings.
+    ///
+    /// This method will return `Some(_)` if this mapping is shared and
+    /// VMO-backed.
+    //
+    // FIXME: According to Linux behavior, private mappings and COWed pages
+    // are also affected by file operations (e.g., truncation). So reverse
+    // mappings should also include them. We don't do this for now, as the
+    // man pages say that private mappings have unspecified behavior if the
+    // file content changes later on.
+    pub(super) fn vmo_for_rmap(&self) -> Option<&Arc<Vmo>> {
+        match &self.mapped_mem {
+            MappedMemory::Vmo(vmo) if self.is_shared => Some(vmo.vmo()),
+            _ => None,
+        }
+    }
+
+    /// Locks reserve mappings of [`Self::vmo_for_rmap`].
+    pub(super) fn lock_rmap(&self) -> Option<MutexGuard<'_, Rmap>> {
+        self.vmo_for_rmap().map(|vmo| vmo.rmap().lock())
     }
 
     /// Returns the mapping's RSS type.

--- a/kernel/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/src/vm/vmar/vmar_impls/fork.rs
@@ -105,7 +105,11 @@ fn cow_copy_pt(src: &mut CursorMut<'_>, dst: &mut CursorMut<'_>, size: usize) ->
                 // Manually advance the source cursor.
                 // In the `MappedRam` case, the cursor is advanced by `protect_next`.
                 // However, this does not apply to the `MappedIoMem` case.
-                src.jump(mapped_va + PAGE_SIZE).unwrap();
+                let next_va = mapped_va + PAGE_SIZE;
+                if next_va == end_va {
+                    break;
+                }
+                src.jump(next_va).unwrap();
             }
         }
 
@@ -258,7 +262,7 @@ mod test {
 
         let vm_space = VmSpace::new();
         let map_range = PAGE_SIZE..(PAGE_SIZE * 2);
-        let cow_range = 0..PAGE_SIZE * 512 * 512;
+        let cow_range = map_range.clone();
         let page_property = PageProperty::new_user(PageFlags::RW, CachePolicy::Uncacheable);
         let preempt_guard = disable_preempt();
 

--- a/kernel/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/src/vm/vmar/vmar_impls/fork.rs
@@ -9,7 +9,7 @@ use ostd::{
     task::disable_preempt,
 };
 
-use super::{RssDelta, VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, Vmar};
+use super::{RssDelta, Vmar};
 use crate::{prelude::*, process::ProcessVm, vm::vmar::VmarHandle};
 
 impl Vmar {
@@ -25,21 +25,27 @@ impl Vmar {
             let inner = vmar.inner.read();
             let mut new_inner = new_vmar.inner.write();
 
-            // Clone mappings.
-            let preempt_guard = disable_preempt();
-            let range = VMAR_LOWEST_ADDR..VMAR_CAP_ADDR;
-            let new_vmspace = new_vmar.vm_space();
-            let mut new_cursor = new_vmspace.cursor_mut(&preempt_guard, &range).unwrap();
-            let cur_vmspace = vmar.vm_space();
-            let mut cur_cursor = cur_vmspace.cursor_mut(&preempt_guard, &range).unwrap();
             let mut rss_delta = RssDelta::new(&new_vmar);
+            let mut remaining = inner.vm_mappings.len();
 
+            // Clone mappings.
             for vm_mapping in inner.vm_mappings.iter() {
+                remaining -= 1;
+
                 let base = vm_mapping.map_to_addr();
+                let range = base..vm_mapping.map_end();
+
+                let mut rmap = vm_mapping.lock_rmap();
 
                 // Clone the `VmMapping` to the new VMAR.
                 let new_mapping = vm_mapping.new_fork();
-                new_inner.insert_without_try_merge(new_mapping);
+                new_inner.insert_without_try_merge(&new_vmar, new_mapping, rmap.as_deref_mut());
+
+                let preempt_guard = disable_preempt();
+                let new_vmspace = new_vmar.vm_space();
+                let mut new_cursor = new_vmspace.cursor_mut(&preempt_guard, &range).unwrap();
+                let cur_vmspace = vmar.vm_space();
+                let mut cur_cursor = cur_vmspace.cursor_mut(&preempt_guard, &range).unwrap();
 
                 // Protect the mapping and copy to the new page table for COW.
                 cur_cursor.jump(base).unwrap();
@@ -48,12 +54,17 @@ impl Vmar {
                 let num_copied =
                     cow_copy_pt(&mut cur_cursor, &mut new_cursor, vm_mapping.map_size());
 
+                // We need to ensure that no writes can be performed to COW
+                // pages only after `fork()` returns. So we can perform a full
+                // TLB flush only when handling the last mapping.
+                if remaining == 0 {
+                    cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::for_all());
+                    cur_cursor.flusher().dispatch_tlb_flush();
+                    cur_cursor.flusher().sync_tlb_flush();
+                }
+
                 rss_delta.add(vm_mapping.rss_type(), num_copied as isize);
             }
-
-            cur_cursor.flusher().issue_tlb_flush(TlbFlushOp::for_all());
-            cur_cursor.flusher().dispatch_tlb_flush();
-            cur_cursor.flusher().sync_tlb_flush();
         }
 
         Ok(new_vmar)

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -349,10 +349,7 @@ impl<'a> VmarMapOptions<'a> {
         let (mapped_mem, io_mem) = match mappable {
             Some(Mappable::Vmo(vmo)) => {
                 if let Some(ref path) = path {
-                    debug_assert!(Arc::ptr_eq(
-                        &vmo,
-                        &path.inode().page_cache().unwrap().as_vmo().clone()
-                    ));
+                    debug_assert!(Arc::ptr_eq(&vmo, &path.inode().page_cache().unwrap()));
                 }
 
                 let is_writable_tracked = if let Some(ref path) = path

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -310,7 +310,7 @@ impl<'a> VmarMapOptions<'a> {
             VmarMapOffset::FixedReplace(map_to_addr) => {
                 let mut rss_delta = RssDelta::new(parent);
                 inner.alloc_free_region_exact_truncate(
-                    parent.vm_space(),
+                    parent,
                     map_to_addr,
                     map_size,
                     &mut rss_delta,
@@ -382,6 +382,9 @@ impl<'a> VmarMapOptions<'a> {
             perms | may_perms,
         );
 
+        let vmo_for_rmap = vm_mapping.vmo_for_rmap().cloned();
+        let mut rmap = vmo_for_rmap.as_ref().map(|vmo| vmo.rmap().lock());
+
         // Populate device memory if needed before adding to VMAR.
         //
         // We have to map before inserting the `VmMapping` into the tree,
@@ -393,7 +396,7 @@ impl<'a> VmarMapOptions<'a> {
         }
 
         // Add the mapping to the VMAR.
-        inner.insert_try_merge(vm_mapping);
+        inner.insert_try_merge(parent, vm_mapping, rmap.as_deref_mut());
 
         Ok(map_to_addr)
     }

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -20,16 +20,16 @@ use aster_util::per_cpu_counter::PerCpuCounter;
 use ostd::{cpu::CpuId, mm::VmSpace};
 
 use super::{
-    VMAR_CAP_ADDR, VMAR_LOWEST_ADDR,
+    Rmap, RmapEntry, VMAR_CAP_ADDR, VMAR_LOWEST_ADDR,
     interval_set::{Interval, IntervalSet},
-    is_userspace_vaddr,
+    is_userspace_vaddr, is_userspace_vaddr_range,
     util::{self, get_intersected_range},
     vm_mapping::{MappedMemory, MappedVmo, VmMapping},
 };
 use crate::{
     prelude::*,
     process::{INIT_STACK_SIZE, Process, ProcessVm, ResourceType},
-    vm::vmar::is_userspace_vaddr_range,
+    vm::page_cache::Vmo,
 };
 
 /// The upper bound for allocations under the `MAP_32BIT` mmap flag.
@@ -51,6 +51,8 @@ pub struct Vmar {
     process_vm: ProcessVm,
     /// The number of handles that this `Vmar` has (see [`super::VmarHandle`])
     num_handles: AtomicUsize,
+    /// Weak self reference
+    weak_self: Weak<Self>,
 }
 
 impl Vmar {
@@ -61,12 +63,13 @@ impl Vmar {
         let inner = VmarInner::new();
         let vm_space = VmSpace::new();
         let rss_counters = array::from_fn(|_| PerCpuCounter::new());
-        Arc::new(Vmar {
+        Arc::new_cyclic(move |weak_self| Vmar {
             inner: RwMutex::new(inner),
             vm_space: Arc::new(vm_space),
             rss_counters,
             process_vm,
             num_handles: AtomicUsize::new(1),
+            weak_self: weak_self.clone(),
         })
     }
 
@@ -167,6 +170,27 @@ impl Drop for RssDelta<'_> {
     }
 }
 
+/// A holder for a reverse mapping entry that is to be removed.
+///
+/// This holds the [`Vmo`] object, so the lock guard for reverse mappings can
+/// have a correct lifetime (see [`Self::remove`]).
+#[must_use]
+struct RmapToRemove {
+    vmo: Option<Arc<Vmo>>,
+}
+
+impl RmapToRemove {
+    pub(self) fn new(vmo: Option<Arc<Vmo>>) -> Self {
+        Self { vmo }
+    }
+
+    pub(self) fn remove(&mut self, vmar: &Vmar, addr: Vaddr) -> Option<MutexGuard<'_, Rmap>> {
+        let mut rmap = self.vmo.as_ref()?.rmap().lock();
+        rmap.remove(vmar.weak_self.clone(), addr);
+        Some(rmap)
+    }
+}
+
 struct VmarInner {
     /// The mapped pages and associated metadata.
     ///
@@ -227,8 +251,24 @@ impl VmarInner {
     /// any neighboring mappings.
     ///
     /// Make sure the insertion doesn't exceed address space limit.
-    fn insert_without_try_merge(&mut self, vm_mapping: VmMapping) {
+    fn insert_without_try_merge(
+        &mut self,
+        vmar: &Vmar,
+        vm_mapping: VmMapping,
+        rmap: Option<&mut Rmap>,
+    ) {
         self.total_vm += vm_mapping.map_size();
+
+        if let Some(rmap) = rmap {
+            rmap.insert(
+                vmar.weak_self.clone(),
+                RmapEntry {
+                    vaddr: vm_mapping.map_to_addr(),
+                    offset: vm_mapping.vmo().unwrap().offset(),
+                    size: vm_mapping.map_size(),
+                },
+            );
+        }
         self.vm_mappings.insert(vm_mapping);
     }
 
@@ -239,7 +279,12 @@ impl VmarInner {
     /// that are adjacent and compatible, in order to reduce fragmentation.
     ///
     /// Make sure the insertion doesn't exceed address space limit.
-    fn insert_try_merge(&mut self, vm_mapping: VmMapping) {
+    fn insert_try_merge(
+        &mut self,
+        vmar: &Vmar,
+        vm_mapping: VmMapping,
+        mut rmap: Option<&mut Rmap>,
+    ) {
         self.total_vm += vm_mapping.map_size();
         let mut vm_mapping = vm_mapping;
         let addr = vm_mapping.map_to_addr();
@@ -249,6 +294,9 @@ impl VmarInner {
             vm_mapping = new_mapping;
             if let Some(addr) = to_remove {
                 self.vm_mappings.remove(&addr);
+                if let Some(rmap) = rmap.as_deref_mut() {
+                    rmap.remove(vmar.weak_self.clone(), addr);
+                }
             }
         }
 
@@ -257,17 +305,33 @@ impl VmarInner {
             vm_mapping = new_mapping;
             if let Some(addr) = to_remove {
                 self.vm_mappings.remove(&addr);
+                if let Some(rmap) = rmap.as_deref_mut() {
+                    rmap.remove(vmar.weak_self.clone(), addr);
+                }
             }
         }
 
+        if let Some(rmap) = rmap {
+            rmap.insert(
+                vmar.weak_self.clone(),
+                RmapEntry {
+                    vaddr: vm_mapping.map_to_addr(),
+                    offset: vm_mapping.vmo().unwrap().offset(),
+                    size: vm_mapping.map_size(),
+                },
+            );
+        }
         self.vm_mappings.insert(vm_mapping);
     }
 
     /// Removes a `VmMapping` based on the provided key from the `Vmar`.
-    fn remove(&mut self, key: &Vaddr) -> Option<VmMapping> {
+    fn remove(&mut self, key: &Vaddr) -> Option<(VmMapping, RmapToRemove)> {
         let vm_mapping = self.vm_mappings.remove(key)?;
         self.total_vm -= vm_mapping.map_size();
-        Some(vm_mapping)
+
+        let rmap_to_remove = RmapToRemove::new(vm_mapping.vmo_for_rmap().cloned());
+
+        Some((vm_mapping, rmap_to_remove))
     }
 
     /// Finds a set of [`VmMapping`]s that intersect with the provided range.
@@ -312,7 +376,7 @@ impl VmarInner {
     /// the mappings that intersect with the range.
     fn alloc_free_region_exact_truncate(
         &mut self,
-        vm_space: &VmSpace,
+        vmar: &Vmar,
         offset: Vaddr,
         size: usize,
         rss_delta: &mut RssDelta,
@@ -324,19 +388,26 @@ impl VmarInner {
         }
 
         for vm_mapping_addr in mappings_to_remove {
-            let vm_mapping = self.remove(&vm_mapping_addr).unwrap();
+            let (vm_mapping, mut rmap_to_remove) = self.remove(&vm_mapping_addr).unwrap();
+            let mut rmap = rmap_to_remove.remove(vmar, vm_mapping_addr);
+
             let vm_mapping_range = vm_mapping.range();
             let intersected_range = get_intersected_range(&range, &vm_mapping_range);
 
             let (left, taken, right) = vm_mapping.split_range(&intersected_range);
             if let Some(left) = left {
-                self.insert_without_try_merge(left);
+                self.insert_without_try_merge(vmar, left, rmap.as_deref_mut());
             }
             if let Some(right) = right {
-                self.insert_without_try_merge(right);
+                self.insert_without_try_merge(vmar, right, rmap.as_deref_mut());
             }
 
-            rss_delta.add(taken.rss_type(), -(taken.unmap(vm_space) as isize));
+            // Note that `rmap` must be dropped before `taken`. Otherwise,
+            // there is a possibility of a deadlock because a device mapping
+            // may attempt to access its reverse mappings in `Drop`.
+            drop(rmap);
+
+            rss_delta.add(taken.rss_type(), -(taken.unmap(&vmar.vm_space) as isize));
         }
 
         Ok(offset..(offset + size))
@@ -423,7 +494,7 @@ impl VmarInner {
     /// Enlarges the last mapping if the new size is larger.
     fn resize_mapping(
         &mut self,
-        vm_space: &VmSpace,
+        vmar: &Vmar,
         map_addr: Vaddr,
         old_size: usize,
         new_size: usize,
@@ -451,7 +522,7 @@ impl VmarInner {
                 return_errno_with_message!(Errno::EINVAL, "the address range overflows");
             }
             self.alloc_free_region_exact_truncate(
-                vm_space,
+                vmar,
                 map_addr + new_size,
                 old_size - new_size,
                 rss_delta,
@@ -478,9 +549,10 @@ impl VmarInner {
         }
 
         self.check_extra_size_fits_rlimit(new_size - old_size)?;
-        let last_mapping = self.remove(&last_mapping_addr).unwrap();
+        let (last_mapping, mut rmap_to_remove) = self.remove(&last_mapping_addr).unwrap();
+        let mut rmap = rmap_to_remove.remove(vmar, last_mapping_addr);
         let last_mapping = last_mapping.enlarge(new_size - old_size);
-        self.insert_try_merge(last_mapping);
+        self.insert_try_merge(vmar, last_mapping, rmap.as_deref_mut());
         Ok(())
     }
 }

--- a/kernel/src/vm/vmar/vmar_impls/protect.rs
+++ b/kernel/src/vm/vmar/vmar_impls/protect.rs
@@ -19,7 +19,6 @@ impl Vmar {
         debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
 
         let mut inner = self.inner.write();
-        let vm_space = self.vm_space();
 
         let mut protect_mappings = Vec::new();
 
@@ -43,12 +42,15 @@ impl Vmar {
             let new_perms = perms | (vm_mapping_perms & VmPerms::ALL_MAY_PERMS);
             new_perms.check()?;
 
-            let Some(vm_mapping) = inner.remove(&vm_mapping_range.start) else {
+            let Some((vm_mapping, mut rmap_to_remove)) = inner.remove(&vm_mapping_range.start)
+            else {
                 // This can happen only if the mapping is merged to the previous one (just
                 // protected before). We can skip this mapping because its property is already
                 // correct.
                 continue;
             };
+            let mut rmap = rmap_to_remove.remove(self, vm_mapping_range.start);
+
             let vm_mapping_range = vm_mapping.range();
             let intersected_range = get_intersected_range(&range, &vm_mapping_range);
 
@@ -57,15 +59,15 @@ impl Vmar {
 
             // Puts the rest back.
             if let Some(left) = left {
-                inner.insert_without_try_merge(left);
+                inner.insert_without_try_merge(self, left, rmap.as_deref_mut());
             }
             if let Some(right) = right {
-                inner.insert_without_try_merge(right);
+                inner.insert_without_try_merge(self, right, rmap.as_deref_mut());
             }
 
             // Protects part of the `VmMapping`.
-            let taken = taken.protect(vm_space.as_ref(), new_perms);
-            inner.insert_try_merge(taken);
+            let taken = taken.protect(self.vm_space(), new_perms);
+            inner.insert_try_merge(self, taken, rmap.as_deref_mut());
         }
 
         if last_mapping_end < range.end {

--- a/kernel/src/vm/vmar/vmar_impls/remap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/remap.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::ops::Range;
+
 use ostd::{mm::vm_space::VmQueriedItem, task::disable_preempt};
 
 use super::{RssDelta, Vmar, util::is_intersected};
@@ -55,7 +57,7 @@ impl Vmar {
         // `map_addr..map_addr + old_size` have a mapping. If not,
         // we should return an `Err`.
 
-        inner.resize_mapping(&self.vm_space, map_addr, old_size, new_size, &mut rss_delta)
+        inner.resize_mapping(self, map_addr, old_size, new_size, &mut rss_delta)
     }
 
     /// Remaps the original mapping to a new address and/or size.
@@ -116,7 +118,7 @@ impl Vmar {
         }
         let (old_size, old_range) = if new_size < old_size {
             inner.alloc_free_region_exact_truncate(
-                &self.vm_space,
+                self,
                 old_addr + new_size,
                 old_size - new_size,
                 &mut rss_delta,
@@ -141,12 +143,7 @@ impl Vmar {
                     "remap: the new range overlaps with the old one"
                 );
             }
-            inner.alloc_free_region_exact_truncate(
-                &self.vm_space,
-                new_addr,
-                new_size,
-                &mut rss_delta,
-            )?
+            inner.alloc_free_region_exact_truncate(self, new_addr, new_size, &mut rss_delta)?
         } else {
             // Fast path: expand the old mapping in place to the new size.
             // Skip when `action` is `RemapOldMappingAction::Keep` since we must
@@ -158,41 +155,75 @@ impl Vmar {
                     .is_ok()
             {
                 let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
-                let old_mapping = inner.remove(&old_mapping_addr).unwrap();
+                let (old_mapping, mut rmap_to_remove) = inner.remove(&old_mapping_addr).unwrap();
+                let mut rmap = rmap_to_remove.remove(self, old_mapping_addr);
                 let new_mapping = old_mapping.enlarge(new_size - old_size);
-                inner.insert_try_merge(new_mapping);
+                inner.insert_try_merge(self, new_mapping, rmap.as_deref_mut());
                 return Ok(old_range.start);
             }
 
             inner.alloc_free_region(new_size, PAGE_SIZE)?
         };
 
-        // Create a new `VmMapping` at the target address.
         let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
-        let new_mapping = if action == RemapOldMappingAction::Unmap {
-            let vm_mapping = inner.remove(&old_mapping_addr).unwrap();
+        if action == RemapOldMappingAction::Unmap {
+            let (vm_mapping, mut rmap_to_remove) = inner.remove(&old_mapping_addr).unwrap();
+            let mut rmap = rmap_to_remove.remove(self, old_mapping_addr);
+
             let (left, old_mapping, right) = vm_mapping.split_range(&old_range);
             if let Some(left) = left {
-                inner.insert_without_try_merge(left);
+                inner.insert_without_try_merge(self, left, rmap.as_deref_mut());
             }
             if let Some(right) = right {
-                inner.insert_without_try_merge(right);
+                inner.insert_without_try_merge(self, right, rmap.as_deref_mut());
             }
+
+            // Create a new `VmMapping` at the target address.
             // Note that we have ensured that `new_size >= old_size` at the beginning.
-            old_mapping.clone_for_remap_at(new_range.start)
+            let new_mapping = old_mapping.clone_for_remap_at(new_range.start);
+            inner.insert_try_merge(
+                self,
+                new_mapping.enlarge(new_size - old_size),
+                rmap.as_deref_mut(),
+            );
+
+            // Move the mapping before dropping `rmap`.
+            self.move_pt(old_range, new_range.clone());
         } else {
             let old_mapping = inner.vm_mappings.find_one(&old_mapping_addr).unwrap();
-            old_mapping.clone_range_for_remap_at(old_addr..old_addr + old_size, new_range.start)
-        };
+            let vmo_for_rmap = old_mapping.vmo_for_rmap().cloned();
+            let mut rmap = vmo_for_rmap.as_ref().map(|vmo| vmo.rmap().lock());
 
-        inner.insert_try_merge(new_mapping.enlarge(new_size - old_size));
+            // Create a new `VmMapping` at the target address.
+            // Note that we have ensured that `new_size >= old_size` at the beginning.
+            let new_mapping = old_mapping
+                .clone_range_for_remap_at(old_addr..old_addr + old_size, new_range.start);
+            inner.insert_try_merge(
+                self,
+                new_mapping.enlarge(new_size - old_size),
+                rmap.as_deref_mut(),
+            );
 
+            // Move the mapping before dropping `rmap`.
+            self.move_pt(old_range, new_range.clone());
+        }
+
+        Ok(new_range.start)
+    }
+
+    /// Moves the mapping.
+    ///
+    /// If there are associated reverse mappings, we must hold the reverse mapping lock to avoid
+    /// race conditions with unmapping from reverse mappings.
+    fn move_pt(&self, old_range: Range<Vaddr>, new_range: Range<Vaddr>) {
         let preempt_guard = disable_preempt();
         let total_range = old_range.start.min(new_range.start)..old_range.end.max(new_range.end);
-        let vmspace = self.vm_space();
-        let mut cursor = vmspace.cursor_mut(&preempt_guard, &total_range).unwrap();
+        let mut cursor = self
+            .vm_space
+            .cursor_mut(&preempt_guard, &total_range)
+            .unwrap();
 
-        // Move the mapping.
+        let old_size = old_range.len();
         let mut current_offset = 0;
         while current_offset < old_size {
             cursor.jump(old_range.start + current_offset).unwrap();
@@ -232,7 +263,5 @@ impl Vmar {
 
         cursor.flusher().dispatch_tlb_flush();
         cursor.flusher().sync_tlb_flush();
-
-        Ok(new_range.start)
     }
 }

--- a/kernel/src/vm/vmar/vmar_impls/unmap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/unmap.rs
@@ -16,6 +16,11 @@ impl Vmar {
     /// After being cleared, this VMAR will become an empty VMAR.
     pub(super) fn clear(&self) {
         let mut inner = self.inner.write();
+        for vm_mapping in inner.vm_mappings.iter() {
+            if let Some(mut rmap) = vm_mapping.lock_rmap() {
+                rmap.remove(self.weak_self.clone(), vm_mapping.map_to_addr());
+            }
+        }
         inner.vm_mappings.clear();
 
         // Keep `inner` locked to avoid race conditions.
@@ -42,12 +47,7 @@ impl Vmar {
 
         let mut inner = self.inner.write();
         let mut rss_delta = RssDelta::new(self);
-        inner.alloc_free_region_exact_truncate(
-            &self.vm_space,
-            range.start,
-            range.len(),
-            &mut rss_delta,
-        )?;
+        inner.alloc_free_region_exact_truncate(self, range.start, range.len(), &mut rss_delta)?;
         Ok(())
     }
 

--- a/test/initramfs/src/conformance/xfstests/full.list
+++ b/test/initramfs/src/conformance/xfstests/full.list
@@ -10,6 +10,7 @@ generic/014
 generic/023
 generic/027
 generic/028
+generic/029
 generic/030
 generic/035
 generic/069

--- a/test/initramfs/src/conformance/xfstests/short.list
+++ b/test/initramfs/src/conformance/xfstests/short.list
@@ -9,6 +9,7 @@ generic/013
 generic/014
 generic/023
 generic/028
+generic/029
 generic/030
 generic/035
 generic/069

--- a/test/initramfs/src/regression/memory/mmap/rev_map_common.h
+++ b/test/initramfs/src/regression/memory/mmap/rev_map_common.h
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+#include "../../common/test.h"
+
+#define PAGE_SIZE 4096
+
+static int fd;
+static char *mapped_buf;
+static char read_buf[PAGE_SIZE] __attribute__((aligned(PAGE_SIZE)));
+static char expected_buf[PAGE_SIZE] __attribute__((aligned(PAGE_SIZE)));
+
+FN_SETUP(open)
+{
+	fd = CHECK(
+		open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR | O_DIRECT, 0644));
+	mapped_buf = CHECK_WITH(mmap(NULL, PAGE_SIZE * 2,
+				     PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+				_ret != MAP_FAILED);
+
+	CHECK(ftruncate(fd, PAGE_SIZE * 2));
+}
+END_SETUP()
+
+// Mixing O_DIRECT access with cached access concurrently will corrupt the
+// data. However, it should be fine if all accesses are sequential.
+
+FN_TEST(memory_write_then_syscall_read)
+{
+	// Write by memory.
+	strcpy(&mapped_buf[3], "hello");
+	strcpy(&expected_buf[3], "hello");
+
+	// Barrier.
+	asm volatile("" : : : "memory");
+
+	// Read by syscall.
+	TEST_RES(pread(fd, read_buf, PAGE_SIZE, 0), _ret == PAGE_SIZE);
+	TEST_RES(memcmp(read_buf, expected_buf, PAGE_SIZE), _ret == 0);
+
+	// Read by memory.
+	TEST_RES(memcmp(mapped_buf, expected_buf, PAGE_SIZE), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(syscall_write_then_memory_read)
+{
+	// Write by syscall.
+	strcpy(&expected_buf[6], "world");
+	TEST_RES(pwrite(fd, expected_buf, PAGE_SIZE, 0), _ret == PAGE_SIZE);
+
+	// Barrier.
+	asm volatile("" : : : "memory");
+
+	// Read by memory.
+	TEST_RES(memcmp(mapped_buf, expected_buf, PAGE_SIZE), _ret == 0);
+
+	// Read by syscall.
+	TEST_RES(pread(fd, read_buf, PAGE_SIZE, 0), _ret == PAGE_SIZE);
+	TEST_RES(memcmp(read_buf, expected_buf, PAGE_SIZE), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(memory_write_after_mprotect)
+{
+	// Write by memory after an `mprotect`.
+	//
+	// This is to ensure that an `mprotect` will not mark a page
+	// as writable unless it is also marked as dirty.
+	TEST_SUCC(mprotect(mapped_buf, PAGE_SIZE,
+			   PROT_READ | PROT_WRITE | PROT_EXEC));
+	strcpy(&mapped_buf[9], "protected");
+	strcpy(&expected_buf[9], "protected");
+
+	// Barrier.
+	asm volatile("" : : : "memory");
+
+	// Read by syscall.
+	TEST_RES(pread(fd, read_buf, PAGE_SIZE, 0), _ret == PAGE_SIZE);
+	TEST_RES(memcmp(read_buf, expected_buf, PAGE_SIZE), _ret == 0);
+
+	// Read by memory.
+	TEST_RES(memcmp(mapped_buf, expected_buf, PAGE_SIZE), _ret == 0);
+}
+END_TEST()
+
+// Truncating the file will remove the mapped pages. Note that this also
+// includes COWed pages in private mappings.
+
+static int check_page_does_not_exist(char *ptr)
+{
+	pid_t child;
+	int status;
+
+	child = CHECK(fork());
+
+	if (child == 0) {
+		*(volatile char *)ptr = 1;
+		exit(EXIT_FAILURE);
+	}
+
+	CHECK_WITH(wait(&status), _ret == child);
+
+	if (WIFSIGNALED(status) &&
+	// FIXME: Asterinas will send a wrong signal for a nonexistent page.
+#ifdef __asterinas__
+	    WTERMSIG(status) == SIGSEGV
+#else
+	    WTERMSIG(status) == SIGBUS
+#endif
+	)
+		return 0;
+
+	errno = EFAULT;
+	return -1;
+}
+
+FN_TEST(truncate_mapped_pages)
+{
+	strcpy(&mapped_buf[PAGE_SIZE], "hello, world");
+
+	// After truncation, a shared page must disappear.
+	TEST_SUCC(ftruncate(fd, PAGE_SIZE));
+	asm volatile("" : : : "memory");
+	TEST_SUCC(check_page_does_not_exist(&mapped_buf[PAGE_SIZE]));
+
+	// The new page should be a zero page.
+	TEST_SUCC(ftruncate(fd, PAGE_SIZE * 2));
+	asm volatile("" : : : "memory");
+	TEST_RES(mapped_buf[PAGE_SIZE], _ret == 0);
+}
+END_TEST()
+
+FN_TEST(truncate_cowed_pages)
+{
+	int fd;
+	char *private_buf;
+
+	fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+	private_buf =
+		TEST_SUCC(mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE,
+			       MAP_PRIVATE, fd, 0));
+
+	// The page shares. We haven't written anything yet, so there are no COWs.
+	TEST_RES(pwrite(fd, "hello", 6, PAGE_SIZE), _ret == 6);
+	asm volatile("" : : : "memory");
+	TEST_RES(strcmp(&private_buf[PAGE_SIZE], "hello"), _ret == 0);
+
+	// This ensures that the page shares.
+	TEST_RES(pwrite(fd, "world", 6, PAGE_SIZE), _ret == 6);
+	asm volatile("" : : : "memory");
+	TEST_RES(strcmp(&private_buf[PAGE_SIZE], "world"), _ret == 0);
+
+	// Now COWs happen.
+	strcpy(&private_buf[PAGE_SIZE], "deadbeef");
+	TEST_RES(pwrite(fd, "foofoobarbar", 12, PAGE_SIZE), _ret == 12);
+	asm volatile("" : : : "memory");
+	TEST_RES(strcmp(&private_buf[PAGE_SIZE], "deadbeef"), _ret == 0);
+
+	// After truncation, a COWed page should also disappear according to Linux.
+	TEST_SUCC(ftruncate(fd, PAGE_SIZE));
+	asm volatile("" : : : "memory");
+	// FIXME: In Asterinas, we build reverse mappings only for shared mappings.
+#ifdef __asterinas__
+	TEST_RES(strcmp(&private_buf[PAGE_SIZE], "deadbeef"), _ret == 0);
+#else
+	TEST_SUCC(check_page_does_not_exist(&private_buf[PAGE_SIZE]));
+
+	// The new page should be a zero page.
+	TEST_SUCC(ftruncate(fd, PAGE_SIZE * 2));
+	asm volatile("" : : : "memory");
+	TEST_RES(private_buf[PAGE_SIZE], _ret == 0);
+#endif
+
+	TEST_SUCC(munmap(private_buf, PAGE_SIZE * 2));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(munmap(mapped_buf, PAGE_SIZE * 2));
+	CHECK(close(fd));
+	CHECK(unlink(TEST_FILE));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/memory/mmap/rev_map_ext2.c
+++ b/test/initramfs/src/regression/memory/mmap/rev_map_ext2.c
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define TEST_FILE "/ext2/test_rev_map"
+#include "rev_map_common.h"

--- a/test/initramfs/src/regression/memory/mmap/rev_map_tmpfs.c
+++ b/test/initramfs/src/regression/memory/mmap/rev_map_tmpfs.c
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define TEST_FILE "/tmp/test_rev_map"
+#include "rev_map_common.h"

--- a/test/initramfs/src/regression/memory/run_test.sh
+++ b/test/initramfs/src/regression/memory/run_test.sh
@@ -13,3 +13,5 @@ set -e
 ./mmap/mmap_readahead
 ./mmap/mmap_shared_filebacked
 ./mmap/mmap_vmrss
+./mmap/rev_map_ext2
+./mmap/rev_map_tmpfs


### PR DESCRIPTION
This PR adds reverse mappings for file-backed memory mappings.

## Major changes

### Commit "Make `PageCache` a unique handle"

`PageCache` is not long `Clone`able. It is a unique handle that locates behind the inode lock. Resizing requires `&mut self`.

Ideally, both `fill_zeros` and `write` would also require `&mut self`. However, this has been left as a TODO because the extfat implementations still need to be able to write without a mutable reference.

### Commit "Add basic reverse mapping implementation"

This adds `Rmap` and ensure that all shared file-backed mappings are recorded in it.

```rust
/// Reverse mappings from a [`Vmo`] to [`Vmar`]s.
///
/// [`Vmo`]: super::Vmo
pub struct Rmap {
    entries: BTreeMap<KeyableWeak<Vmar>, Vec<RmapEntry>>,
}
```

### Commit "Integrate reverse mappings to page cache"

This implements https://github.com/asterinas/asterinas/issues/3295. For more details, see the issue description.

Closes https://github.com/asterinas/asterinas/issues/3295.

## Discussion

### More tests.

I originally expected xfstests to contain a number of useful reverse mapping tests. However, according to https://github.com/asterinas/asterinas/issues/3142, there do not seem to be many.

I have enabled `generic/029`, but `generic/647` still needs to remain disabled due to #3257.

I have also added some regression tests but there are not many because I cannot figure out more. It seems that `sync()` and its interaction with the page table entries are difficult to test, and their effects are less observable from userspace.

### Concucrency tests.

As shown in #3295, the concurrency model is complex because of its various interactions with the page table, reverse mappings, and the inode. However, writing reasonable tests is difficult because it is hard to inject a page fault (e.g., lock the page table and call `Vmo::try_commit_page`) at the right time and customize it (e.g., in the middle of file operations such as `evict`, `sync`, `read`, `write`). Additionally, we lack the ability to create a `Vmar` in ktest.

I haven't found a solution yet, so this PR lacks concurrency tests.

### Documentations.

I added comments to various page cache operations to explain when to unmap pages and why releasing a lock is OK. I have also inserted the table in #3295 as module-level documentation. Is this enough or is this the best way to explain the concurrency model?

### Efficiency.

Unless there are trivial optimizations that I missed, I'd like to treat efficiency problems outside the scope of this PR. Having reverse mappings is essential for correctness, which always outweighs efficiency.

For example, we currently unmap the entire VMO offset range when evicting pages, regardless of whether the page itself is evicted or not. Dirty pages will always be kept, since losing data is not an option. We may want to optimize this in the future to unmap only clean pages.

### Private mappings.

Linux maintains reverse mappings, even for private ones. I am quite surprised that private mappings are also affected by file operations. Even after being COWed, a page in a private mapping will be unmapped if the corresponding file range is truncated.

However, I did not implement this behavior in this PR. Besides invoking additional complexities (e.g., a COWed page not being unmapped when the page is evicted from the page cache but only when the file range is truncated), our private mapping behavior is already broken, even without considering reverse mappings.

The following code, which existed before this PR (and this PR does not touch), is incorrect. If the file range is not present, we should trigger a SIGBUS, even for private mappings:
https://github.com/asterinas/asterinas/blob/e80904666fcc97085605f1e8118b86bc738c13c8/kernel/src/vm/vmar/vm_mapping.rs#L544-L547

In other words, if we don't trigger a SIGBUS when mapping a new page, then there is no reason to trigger one at file truncation either. So, I decided to leave this for future work.