### PR TITLE
Support `root` boot parameter

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -19,7 +19,7 @@ kcmd_args = [
     "HOME=/",
     "USER=root",
     "PATH=/bin:/benchmark",
-    "init=/init",
+    "rdinit=/init",
 ]
 init_args = ["sh", "-l"]
 initramfs = "test/initramfs/build/initramfs.cpio.gz"

--- a/book/src/distro/popular-applications/containerization-and-virtualization/README.md
+++ b/book/src/distro/popular-applications/containerization-and-virtualization/README.md
@@ -144,7 +144,7 @@ qemu-system-$(uname -m) \
   -initrd /run/current-system/initrd \
   -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
   -nographic -no-reboot \
-  -append 'console=ttyS0 panic=-1 init=/bin/init'
+  -append 'console=ttyS0 panic=-1 rdinit=/bin/init'
 ```
 
 > **Note**: Running the Asterinas kernel requires the `linux/multiboot` boot protocol (**multiboot2 is not supported**).

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -4,19 +4,18 @@ This section documents kernel command-line parameters supported by Asterinas.
 
 ## Inherited from Linux
 
-### `init`
+### `rdinit`
 
-Run the specified binary as `init`.
+Run the specified initramfs binary as the first userspace process.
 
 Example:
 ```text
-init=/bin/busybox
+rdinit=/bin/busybox
 ```
 
 Notes:
-- The value is the path to the executable.
-- If omitted, Asterinas will try to execute from the following paths in order:
-  `/sbin/init`, `/etc/init`, `/bin/init`, `/bin/sh`.
+- The value is the path to the executable in the initramfs root.
+- If omitted, Asterinas will try to execute `/init` from the initramfs root.
 
 ### `console`
 

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -17,6 +17,52 @@ Notes:
 - The value is the path to the executable in the initramfs root.
 - If omitted, Asterinas will try to execute `/init` from the initramfs root.
 
+### `root`
+
+Mount the specified block device as the real root filesystem when no initramfs
+init is selected to run.
+
+Example:
+```text
+root=/dev/vda2
+```
+
+Notes:
+- The value currently must name a registered block device under `/dev`, such as
+  `/dev/vda2`.
+- By default, the initramfs init is `/init`; `rdinit` overrides it with another
+  path.
+- If the selected initramfs init is present, that program is responsible for
+  switching to the real root filesystem.
+
+### `rootfstype`
+
+Select the filesystem type used for the real root filesystem.
+
+Example:
+```text
+root=/dev/vda2 rootfstype=ext2
+```
+
+Valid values:
+- `ext2`
+
+### `init`
+
+Run the specified executable as the first userspace process from the real root
+filesystem.
+
+Example:
+```text
+root=/dev/vda2 rootfstype=ext2 init=/nix/var/nix/profiles/system/stage-2-init
+```
+
+Notes:
+- `init` is used only after Asterinas mounts the real root filesystem via
+  `root=`.
+- If omitted, Asterinas tries `/sbin/init`, `/etc/init`, `/bin/init`, and
+  `/bin/sh`, in that order.
+
 ### `console`
 
 Select console devices for kernel messages.

--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -78,17 +78,14 @@ in {
   # TODO: Fix errors and warnings from systemd and remove this setting.
   environment.sessionVariables = { SYSTEMD_LOG_LEVEL = "crit"; };
   system.systemBuilderCommands = ''
-    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin ostd.log_level=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- sh /init root=/dev/vda2 init=/nix/var/nix/profiles/system/stage-2-init rd.break=${
+    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin ostd.log_level=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- root=/dev/vda2 init=/nix/var/nix/profiles/system/init rd.break=${
       if config.aster_nixos.break-into-stage-1-shell then "1" else "0"
     }"  > $out/kernel-params
-    mv $out/init $out/stage-2-init
-    sed -i 's_^\([[:space:]]*\)\(exec > >(tee -i /run/log/stage-2-init.log) 2>&1\)$_\1# \2_' $out/stage-2-init
+    sed -i 's_^\([[:space:]]*\)\(exec > >(tee -i /run/log/stage-2-init.log) 2>&1\)$_\1# \2_' $out/init
     if [ "${config.aster_nixos.disable-systemd}" = "true" ]; then
-      sed -i 's/^[[:space:]]*echo "starting systemd..."$/# &/' $out/stage-2-init
-      sed -i 's/^[[:space:]]*exec \/run\/current-system\/systemd\/lib\/systemd\/systemd "$@"$/# &/' $out/stage-2-init
+      sed -i 's/^[[:space:]]*echo "starting systemd..."$/# &/' $out/init
+      sed -i 's/^[[:space:]]*exec \/run\/current-system\/systemd\/lib\/systemd\/systemd "$@"$/# &/' $out/init
     fi
-    rm -rf $out/init
-    ln -s /bin/busybox $out/init
     ln -s ${kernel} $out/kernel
     ln -s ${initramfs}/initrd $out/initrd
   '';

--- a/kernel/comps/block/src/lib.rs
+++ b/kernel/comps/block/src/lib.rs
@@ -149,25 +149,35 @@ pub fn lookup(id: DeviceId) -> Option<Arc<dyn BlockDevice>> {
     DEVICE_REGISTRY.lock().get(&id.to_raw()).cloned()
 }
 
-static DEVICE_REGISTRY: Mutex<BTreeMap<u32, Arc<dyn BlockDevice>>> = Mutex::new(BTreeMap::new());
-
-#[init_component]
-fn init() -> Result<(), ComponentInitError> {
-    device_id::init();
-
-    Ok(())
+/// Looks up a block device by its kernel device name.
+pub fn lookup_by_name(name: &str) -> Option<Arc<dyn BlockDevice>> {
+    DEVICE_REGISTRY
+        .lock()
+        .values()
+        .find(|device| device.name() == name)
+        .cloned()
 }
 
-#[init_component(process)]
-fn init_in_first_process() -> Result<(), ComponentInitError> {
+pub fn init_in_first_kthread() {
     let devices = collect_all();
     for device in devices {
+        if device.is_partition() {
+            continue;
+        }
+
         let Some(partition_info) = partition::parse(&device) else {
             continue;
         };
 
         device.set_partitions(partition_info);
     }
+}
+
+static DEVICE_REGISTRY: Mutex<BTreeMap<u32, Arc<dyn BlockDevice>>> = Mutex::new(BTreeMap::new());
+
+#[init_component]
+fn init() -> Result<(), ComponentInitError> {
+    device_id::init();
 
     Ok(())
 }

--- a/kernel/comps/block/src/partition.rs
+++ b/kernel/comps/block/src/partition.rs
@@ -268,6 +268,10 @@ impl BlockDevice for PartitionNode {
     fn id(&self) -> DeviceId {
         self.id
     }
+
+    fn is_partition(&self) -> bool {
+        true
+    }
 }
 
 impl PartitionNode {

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -167,6 +167,7 @@ pub fn init_in_first_kthread() {
     misc::init_in_first_kthread();
     evdev::init_in_first_kthread();
     fb::init_in_first_kthread();
+    aster_block::init_in_first_kthread();
 }
 
 /// Initializes the device nodes in devtmpfs after mounting rootfs.

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -111,7 +111,10 @@ impl Ext2MountOptions {
 
 impl Ext2 {
     /// Opens and loads an Ext2 filesystem from a block device.
-    pub(super) fn open(device: Arc<dyn BlockDevice>, data: Option<&CStr>) -> Result<Arc<Self>> {
+    pub(in crate::fs) fn open(
+        device: Arc<dyn BlockDevice>,
+        data: Option<&CStr>,
+    ) -> Result<Arc<Self>> {
         let super_block = {
             let raw_super_block = device.read_val::<RawSuperBlock>(SUPER_BLOCK_OFFSET)?;
             SuperBlock::try_from(raw_super_block)?

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::str::FromStr;
+
 use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
 use device_id::{DeviceId, MajorId, MinorId};
 use lending_iterator::LendingIterator;
@@ -8,10 +10,14 @@ use no_std_io2::io::{Cursor, Read};
 use ostd::boot::boot_info;
 
 use super::{
+    ext2::Ext2,
     file::{InodeMode, InodeType},
-    vfs::path::{FsPath, PathResolver, is_dot},
+    vfs::{
+        file_system::FileSystem,
+        path::{FsPath, Mount, MountNamespace, PathResolver, is_dot},
+    },
 };
-use crate::{fs::vfs::inode::MknodType, prelude::*};
+use crate::{fs::vfs::inode::MknodType, prelude::*, process::UserNamespace};
 
 struct BoxedReader<'a>(Box<dyn Read + 'a>);
 
@@ -27,11 +33,40 @@ impl Read for BoxedReader<'_> {
     }
 }
 
-/// Unpack and prepare the rootfs from the initramfs CPIO buffer.
+macro_rules! define_rootfs_types {
+    ($($variant:ident => $name:literal),+ $(,)?) => {
+        /// Identifies a root filesystem type candidate.
+        pub enum RootFsType {
+            $($variant),+
+        }
+
+        impl RootFsType {
+            /// Contains all supported root filesystem types.
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+        }
+
+        impl FromStr for RootFsType {
+            type Err = core::convert::Infallible;
+
+            fn from_str(type_name: &str) -> Result<Self, Self::Err> {
+                match type_name {
+                    $($name => Ok(Self::$variant),)+
+                    _ => panic!("unsupported root filesystem type '{}'", type_name),
+                }
+            }
+        }
+    };
+}
+
+define_rootfs_types! {
+    Ext2 => "ext2",
+}
+
 pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
-    let initramfs_buf = boot_info()
-        .initramfs
-        .ok_or_else(|| Error::with_message(Errno::EINVAL, "no initramfs found"))?;
+    // Unpack the initramfs CPIO buffer into the bootstrap rootfs.
+    let Some(initramfs_buf) = boot_info().initramfs else {
+        return Ok(());
+    };
 
     let (reader, suffix) = match &initramfs_buf[..4] {
         // Gzip magic number: 0x1F 0x8B
@@ -56,6 +91,47 @@ pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
 
     println!("[kernel] rootfs is ready");
     Ok(())
+}
+
+/// Mounts the specified block device as a root filesystem in a new mount namespace.
+pub fn mount(root: &str, rootfs_types: &[RootFsType]) -> Result<Arc<MountNamespace>> {
+    // Treat `root=/dev/...` as a Linux-compatible root device spec, not as a
+    // VFS path lookup. Linux also mounts the root filesystem before
+    // auto-mounting devtmpfs on `/dev`.
+    // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/base/devtmpfs.c#L358-L359>.
+    let device_name = root
+        .strip_prefix("/dev/")
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "root must name a /dev block device"))?;
+    let device = aster_block::lookup_by_name(device_name)
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "root block device not found"))?;
+    let fs = open_rootfs_from_candidates(device, rootfs_types)?;
+
+    let owner = UserNamespace::get_init_singleton().clone();
+    let mount_namespace =
+        MountNamespace::new_with_root(owner, |weak_ns| Mount::new_root(fs, weak_ns.clone()))?;
+    println!("[kernel] mounted {} as the root filesystem", root);
+    Ok(mount_namespace)
+}
+
+fn open_rootfs_from_candidates(
+    device: Arc<dyn aster_block::BlockDevice>,
+    rootfs_types: &[RootFsType],
+) -> Result<Arc<dyn FileSystem>> {
+    for rootfs_type in rootfs_types {
+        let result = match rootfs_type {
+            RootFsType::Ext2 => {
+                Ext2::open(device.clone(), None).map(|fs| fs as Arc<dyn FileSystem>)
+            }
+        };
+
+        match result {
+            Ok(fs) => return Ok(fs),
+            Err(err) if err.error() == Errno::EINVAL => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    return_errno_with_message!(Errno::ENODEV, "no root filesystem type could mount root")
 }
 
 fn try_append_entry_to_rootfs(

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -63,7 +63,10 @@ impl MountNamespace {
     /// The closure receives a `Weak<Self>` so that mounts in the new tree can
     /// reference the namespace being constructed. Construction uses `UniqueArc`
     /// to allow mutable initialization while still providing `Weak` references.
-    fn new_with_root<F>(owner: Arc<UserNamespace>, build_root_fn: F) -> Result<Arc<Self>>
+    pub(in crate::fs) fn new_with_root<F>(
+        owner: Arc<UserNamespace>,
+        build_root_fn: F,
+    ) -> Result<Arc<Self>>
     where
         F: FnOnce(&Weak<Self>) -> Result<Arc<Mount>>,
     {

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -139,7 +139,7 @@ fn first_kthread() {
 
     INIT_PROCESS.call_once(|| {
         let karg = INIT_PROC_ARGS.get().unwrap();
-        let init_path = INIT_PATH.get().map(|s| s.as_str());
+        let init_path = RDINIT_PATH.get().map(|s| s.as_str());
         spawn_init_process(init_path, karg.argv().to_vec(), karg.envp().to_vec())
             .expect("Failed to run the init process")
     });
@@ -170,5 +170,5 @@ pub(super) fn on_first_process_startup(ctx: &Context) {
     crate::fs::init_in_first_process(ctx);
 }
 
-static INIT_PATH: Once<String> = Once::new();
-aster_cmdline::define_kv_param!("init", INIT_PATH);
+static RDINIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -2,18 +2,26 @@
 
 //! Kernel initialization.
 
+use core::str::FromStr;
+
 use aster_cmdline::INIT_PROC_ARGS;
 use component::InitStage;
 use ostd::{cpu::CpuId, util::id_set::Id};
 use spin::once::Once;
 
 use crate::{
-    fs::vfs::path::{MountNamespace, PathResolver},
+    fs::{
+        rootfs::{self, RootFsType},
+        vfs::path::{FsPath, MountNamespace, PathResolver},
+    },
     prelude::*,
     process::{Process, spawn_init_process},
     sched::SchedPolicy,
     thread::kernel_thread::ThreadOptions,
 };
+
+const DEFAULT_ROOTFS_INIT_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
+const DEFAULT_INITRAMFS_INIT_PATH: &str = "/init";
 
 pub(super) fn main() {
     // Initialize the global states for all CPUs.
@@ -135,13 +143,66 @@ fn first_kthread() {
     let fs_resolver = init_mnt_ns.new_path_resolver();
     init_in_first_kthread(&fs_resolver);
 
+    enum BootInit<'a> {
+        Initramfs(&'a str),
+        Rootfs {
+            mnt_ns: Arc<MountNamespace>,
+            init_path: &'a str,
+        },
+    }
+
+    let initramfs_init = RDINIT_PATH.get().map(String::as_str).or_else(|| {
+        fs_resolver
+            .lookup(&FsPath::try_from(DEFAULT_INITRAMFS_INIT_PATH).unwrap())
+            .is_ok()
+            .then_some(DEFAULT_INITRAMFS_INIT_PATH)
+    });
+
+    let boot_init = if let Some(init_path) = initramfs_init {
+        BootInit::Initramfs(init_path)
+    } else {
+        let root = ROOT_PATH
+            .get()
+            .expect("Neither an initramfs init nor root= was provided");
+        let rootfs_types = ROOTFS_TYPE
+            .get()
+            .map(|rootfs_types| rootfs_types.as_slice())
+            .unwrap_or(RootFsType::ALL);
+        let mnt_ns =
+            rootfs::mount(root, rootfs_types).expect("Failed to mount the root filesystem");
+
+        let init_path = INIT_PATH
+            .get()
+            .map(String::as_str)
+            .or_else(|| {
+                let resolver = mnt_ns.new_path_resolver();
+                DEFAULT_ROOTFS_INIT_PATHS
+                    .iter()
+                    .copied()
+                    .find(|path| resolver.lookup(&FsPath::try_from(*path).unwrap()).is_ok())
+            })
+            .expect("No init executable was found on the root filesystem");
+
+        BootInit::Rootfs { mnt_ns, init_path }
+    };
+
     print_banner();
 
     INIT_PROCESS.call_once(|| {
         let karg = INIT_PROC_ARGS.get().unwrap();
-        let init_path = RDINIT_PATH.get().map(|s| s.as_str());
-        spawn_init_process(init_path, karg.argv().to_vec(), karg.envp().to_vec())
-            .expect("Failed to run the init process")
+        let argv = karg.argv().to_vec();
+        let envp = karg.envp().to_vec();
+        match boot_init {
+            BootInit::Initramfs(init_path) => {
+                println!("[kernel] running {} as the initramfs init", init_path);
+                spawn_init_process(init_mnt_ns.clone(), init_path, argv, envp)
+            }
+            BootInit::Rootfs { mnt_ns, init_path } => {
+                println!("[kernel] running {} as the real-root init", init_path);
+                spawn_init_process(mnt_ns, init_path, argv, envp)
+            }
+        }
+        .expect("Failed to run the init process")
     });
 }
 
@@ -172,3 +233,36 @@ pub(super) fn on_first_process_startup(ctx: &Context) {
 
 static RDINIT_PATH: Once<String> = Once::new();
 aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);
+
+static ROOT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("root", ROOT_PATH);
+
+/// Contains root filesystem type candidates.
+struct RootFsTypes(Vec<RootFsType>);
+
+impl RootFsTypes {
+    /// Returns the root filesystem type candidates as a slice.
+    fn as_slice(&self) -> &[RootFsType] {
+        self.0.as_slice()
+    }
+}
+
+impl FromStr for RootFsTypes {
+    type Err = core::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let candidates = value
+            .split(',')
+            .filter(|type_name| !type_name.is_empty())
+            .map(str::parse)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self(candidates))
+    }
+}
+
+static ROOTFS_TYPE: Once<RootFsTypes> = Once::new();
+aster_cmdline::define_kv_param!("rootfstype", ROOTFS_TYPE);
+
+static INIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("init", INIT_PATH);

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        Credentials, ProcessVm, UserNamespace, pid_table,
+        Credentials, NsProxy, NsProxyBuilder, ProcessVm, UserNamespace, pid_table,
         posix_thread::{PosixThreadBuilder, ThreadName, allocate_posix_tid},
         program_loader::ProgramToLoad,
         rlimit::new_resource_limits_for_init,
@@ -25,12 +25,13 @@ use crate::{
 
 /// Creates and schedules the init process to run.
 pub fn spawn_init_process(
-    executable_path: Option<&str>,
+    mnt_ns: Arc<MountNamespace>,
+    executable_path: &str,
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let executable_path = executable_path.unwrap_or("/init");
     let process = create_init_process(
+        mnt_ns,
         executable_path,
         with_init_argv0(executable_path, argv),
         envp,
@@ -58,12 +59,13 @@ fn with_init_argv0(executable_path: &str, mut argv: Vec<CString>) -> Vec<CString
 }
 
 fn create_init_process(
+    mnt_ns: Arc<MountNamespace>,
     executable_path: &str,
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
     let fs = {
-        let fs_resolver = MountNamespace::get_init_singleton().new_path_resolver();
+        let fs_resolver = mnt_ns.new_path_resolver();
         ThreadFsInfo::new(fs_resolver)
     };
     let fs_path = FsPath::try_from(executable_path)?;
@@ -87,7 +89,7 @@ fn create_init_process(
         user_ns,
     );
 
-    let init_task = create_init_task(pid, &init_proc, fs, vmar, elf_path, argv, envp)?;
+    let init_task = create_init_task(pid, &init_proc, mnt_ns, fs, vmar, elf_path, argv, envp)?;
     init_proc.tasks().lock().insert(init_task).unwrap();
 
     Ok(init_proc)
@@ -108,9 +110,11 @@ fn set_bootstrap_session_and_group(process: &Arc<Process>) {
 }
 
 /// Creates the init task from the given executable file.
+#[expect(clippy::too_many_arguments)]
 fn create_init_task(
     tid: Tid,
     process: &Arc<Process>,
+    mnt_ns: Arc<MountNamespace>,
     fs: ThreadFsInfo,
     vmar: VmarHandle,
     elf_path: Path,
@@ -137,9 +141,18 @@ fn create_init_task(
 
     let thread_name = ThreadName::new_from_executable_path(&elf_abs_path);
 
+    let ns_proxy = {
+        let mut builder = NsProxyBuilder::new(NsProxy::get_init_singleton());
+        builder.mnt_ns(mnt_ns);
+        Arc::new(builder.build())
+    };
+    let user_ns = process.user_ns().lock().clone();
+
     let thread_builder =
         PosixThreadBuilder::new(tid, thread_name, Box::new(user_ctx), credentials, vmar)
             .process(Arc::downgrade(process))
+            .user_ns(user_ns)
+            .ns_proxy(ns_proxy)
             .fs(Arc::new(fs));
     Ok(thread_builder.build())
 }

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -29,15 +29,12 @@ pub fn spawn_init_process(
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let process = if let Some(executable_path) = executable_path {
-        create_init_process(
-            executable_path,
-            with_init_argv0(executable_path, argv),
-            envp,
-        )?
-    } else {
-        create_default_init_process(argv, envp)?
-    };
+    let executable_path = executable_path.unwrap_or("/init");
+    let process = create_init_process(
+        executable_path,
+        with_init_argv0(executable_path, argv),
+        envp,
+    )?;
 
     // Linux starts the init process without placing it in a process group or session.
     // It joins one only after userspace first calls `setsid()`.
@@ -51,28 +48,6 @@ pub fn spawn_init_process(
     process.run();
 
     Ok(process)
-}
-
-fn create_default_init_process(argv: Vec<CString>, envp: Vec<CString>) -> Result<Arc<Process>> {
-    // Linux probes the fallback init executables in this order:
-    // <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1634>.
-    const DEFAULT_INIT_EXEC_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
-
-    let mut last_error = None;
-
-    for default_init_exec_path in DEFAULT_INIT_EXEC_PATHS {
-        // FIXME: Avoid cloning `argv` and `envp` for each fallback candidate.
-        match create_init_process(
-            default_init_exec_path,
-            with_init_argv0(default_init_exec_path, argv.clone()),
-            envp.clone(),
-        ) {
-            Ok(process) => return Ok(process),
-            Err(error) => last_error = Some(error),
-        }
-    }
-
-    Err(last_error.unwrap())
 }
 
 fn with_init_argv0(executable_path: &str, mut argv: Vec<CString>) -> Vec<CString> {

--- a/osdk/src/config/test/OSDK.toml.full
+++ b/osdk/src/config/test/OSDK.toml.full
@@ -12,7 +12,7 @@ boot.kcmd_args = [
     "HOME=/",
     "USER=root",
     "PATH=/bin:/benchmark",
-    "init=/usr/bin/busybox",
+    "rdinit=/usr/bin/busybox",
 ]
 boot.init_args = ["sh", "-l"]
 boot.initramfs = "/tmp/osdk_test_file"

--- a/test/nixos/tests/containerization-and-virtualization/src/main.rs
+++ b/test/nixos/tests/containerization-and-virtualization/src/main.rs
@@ -96,7 +96,7 @@ fn qemu_tcg_run_aster(nixos_shell: &mut Session) -> Result<(), Error> {
     // Run a Asterinas kernel inside QEMU using the TCG software emulator.
     //
     // Use `grep -v /bin/echo` to filter out lines that affect matching, such as:
-    //   [EFI stub] Loaded the cmdline: "console=ttyS0 panic=-1 init=/bin/echo Entered userspace initrd=initrd"
+    //   [EFI stub] Loaded the cmdline: "console=ttyS0 panic=-1 rdinit=/bin/echo Entered userspace initrd=initrd"
     const CMD: &str = concat!(
         "qemu-system-$(uname -m) ",
         "-accel tcg ",
@@ -107,7 +107,7 @@ fn qemu_tcg_run_aster(nixos_shell: &mut Session) -> Result<(), Error> {
         "-initrd /run/current-system/initrd ",
         "-device isa-debug-exit,iobase=0xf4,iosize=0x04 ",
         "-nographic -no-reboot ",
-        "-append 'console=ttyS0 panic=-1 init=/bin/echo Entered userspace' ",
+        "-append 'console=ttyS0 panic=-1 rdinit=/bin/echo Entered userspace' ",
         "| grep -v /bin/echo"
     );
     nixos_shell.run_cmd_and_expect(CMD, "Entered userspace")?;


### PR DESCRIPTION
This PR adds Linux-compatible `boot` parameter support for selecting the `initramfs` entry point and mounting a root filesystem.

Main changes:
  - Correct the previous `init=` usage to `rdinit=` for selecting the initramfs entry point, matching Linux semantics.
  - Resolve Linux-style `/dev/...` root device specs through block-device lookup before `/dev` is mounted, aligning with Linux where `root=/dev/...` is parsed before `devtmpfs` is mounted.
  - Document the supported `root`-related kernel parameters.
  - Clean up the NixOS init handoff command line by relying on the default `/init` entry point in `initramfs` instead of spelling it out explicitly.