### PR TITLE
Fix fallocate errno for special files

### DIFF
--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -141,8 +141,11 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::ESPIPE, "seek is not supported");
     }
 
-    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
-        return_errno_with_message!(Errno::EOPNOTSUPP, "fallocate is not supported");
+    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        return_errno_with_message!(
+            Errno::ENODEV,
+            "fallocate is not supported for this file type"
+        );
     }
 
     fn as_socket(&self) -> Option<&dyn Socket> {

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -15,7 +15,7 @@ use crate::{
         file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::AnonInodeFs,
         vfs::{
-            inode::Inode,
+            inode::{FallocMode, Inode},
             inode_ext::InodeExt,
             notify::{FsEventSubscriber, FsEvents},
             path::Path,
@@ -359,6 +359,10 @@ impl FileLike for InotifyFile {
             Ordering::Relaxed,
         );
         Ok(())
+    }
+
+    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        return_errno_with_message!(Errno::EBADF, "inotify file is not opened writable");
     }
 
     fn access_mode(&self) -> AccessMode {

--- a/test/initramfs/src/conformance/gvisor/blocklists/fallocate_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/fallocate_test
@@ -1,4 +1,1 @@
-AllocateTest.FallocatePipe
-AllocateTest.FallocateChar
 AllocateTest.FallocateRlimit
-AllocateTest.FallocateOtherFDs

--- a/test/initramfs/src/regression/fs/pseudofs/fallocate.c
+++ b/test/initramfs/src/regression/fs/pseudofs/fallocate.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include "pseudo_file_create.h"
+
+FN_TEST(special_fds)
+{
+	int udp_socket = TEST_SUCC(socket(AF_INET, SOCK_DGRAM, 0));
+
+	struct fd_fallocate_case {
+		int fd;
+		int expected_errno;
+	};
+
+	struct fd_fallocate_case cases[] = {
+		{ pipe_1[0], EBADF },	{ pipe_1[1], ESPIPE },
+		{ pipe_2[0], EBADF },	{ pipe_2[1], ESPIPE },
+		{ sock[0], ENODEV },	{ sock[1], ENODEV },
+		{ epoll_fd, ENODEV },	{ event_fd, ENODEV },
+		{ timer_fd, ENODEV },	{ signal_fd, ENODEV },
+		{ inotify_fd, EBADF },	{ pid_fd, ENODEV },
+		{ mem_fd, 0 },		{ ns_uts_fd, EBADF },
+		{ udp_socket, ENODEV },
+	};
+
+	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		if (cases[i].expected_errno == 0) {
+			TEST_SUCC(fallocate(cases[i].fd, 0, 0, 10));
+		} else {
+			TEST_ERRNO(fallocate(cases[i].fd, 0, 0, 10),
+				   cases[i].expected_errno);
+		}
+	}
+
+	TEST_SUCC(close(udp_socket));
+}
+END_TEST()
+
+#include "pseudo_file_cleanup.h"

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -134,6 +134,7 @@ echo "All mount bind file test passed."
 ./procfs/proc_fd_open_fifo_after_setid
 ./procfs/tid
 
+./pseudofs/fallocate
 ./pseudofs/memfd_access_err
 ./pseudofs/memfd_create
 ./pseudofs/pseudo_dentry


### PR DESCRIPTION
## Summary

Fix `fallocate()` on special `FileLike` objects to return `ENODEV` instead of `EOPNOTSUPP`.

## Changes

- Return `ENODEV` from the default `FileLike::fallocate()` implementation.
- Add regression for `fallocate()` on special `FileLike` objects.
- Unblock the fixed gVisor fallocate cases.

## Testing

- `make check`

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```

## Additional

Linux's `vfs_fallocate()` returns `ENODEV` for targets that are neither regular files nor block devices:
https://elixir.bootlin.com/linux/v7.1/source/fs/open.c#L324
