### PR TITLE
Support `root` boot parameter

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -37,6 +37,9 @@ inputs:
   mem:
     description: 'Guest memory size'
     required: false
+  rootfs_boot:
+    description: 'Boot directly from rootfs'
+    required: false
 
   # Conformance Test
   conformance_test_suite:
@@ -103,6 +106,7 @@ runs:
         [[ -n "${{ inputs.conformance_test_workdir }}" ]] && CMD+=" CONFORMANCE_TEST_WORKDIR=${{ inputs.conformance_test_workdir }}"
         [[ -n "${{ inputs.boot_protocol }}" ]] && CMD+=" BOOT_PROTOCOL=${{ inputs.boot_protocol }}"
         [[ -n "${{ inputs.mem }}" ]] && CMD+=" MEM=${{ inputs.mem }}"
+        [[ "${{ inputs.rootfs_boot }}" == "true" ]] && CMD+=" INITRAMFS=off CMDLINE='root=/dev/vdd rootfstype=ext2 init=/init'"
         [[ -n "${{ inputs.xfstests_disk_size }}" ]] && CMD+=" XFSTESTS_DISK_SIZE=${{ inputs.xfstests_disk_size }}"
         [[ -n "${{ inputs.xfstests_runlist }}" ]] && CMD+=" XFSTESTS_RUNLIST=${{ inputs.xfstests_runlist }}"
 

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -63,6 +63,7 @@ jobs:
         include:
           - { variant: 'legacy32', boot_protocol: 'linux-legacy32', smp: 4 }
           - { variant: 'multiboot2-smp4', boot_protocol: 'multiboot', smp: 4 }
+          - { variant: 'multiboot2-smp4-rootfs', boot_protocol: 'multiboot', smp: 4, rootfs_boot: true }
     steps:
       - uses: actions/checkout@v4
       - name: Run boot test (${{ matrix.variant }})
@@ -71,6 +72,7 @@ jobs:
           auto_test: 'boot'
           smp: ${{ matrix.smp }}
           boot_protocol: ${{ matrix.boot_protocol }}
+          rootfs_boot: ${{ matrix.rootfs_boot }}
 
   regression-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ OSTD_TASK_STACK_SIZE_IN_PAGES ?= 64
 FEATURES ?=
 NO_DEFAULT_FEATURES ?= 0
 COVERAGE ?= 0
+INITRAMFS ?= on
+CMDLINE ?=
 
 # Specify the primary system console (supported: tty0, ttyS0, hvc0).
 # - tty0: The active virtual terminal (VT).
@@ -105,6 +107,9 @@ CARGO_OSDK_COMMON_ARGS :=
 CARGO_OSDK_BUILD_ARGS := --kcmd-args="loglevel=$(LOG_LEVEL)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="earlycon"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="console=$(CONSOLE)"
+ifneq ($(strip $(CMDLINE)),)
+CARGO_OSDK_BUILD_ARGS += $(foreach arg,$(CMDLINE),--kcmd-args="$(arg)")
+endif
 CARGO_OSDK_TEST_ARGS :=
 
 ifeq ($(AUTO_TEST), conformance)
@@ -209,6 +214,11 @@ endif
 # Skip GZIP to make encoding and decoding of initramfs faster
 ifeq ($(INITRAMFS_SKIP_GZIP),1)
 CARGO_OSDK_INITRAMFS_OPTION := --initramfs=$(abspath test/initramfs/build/initramfs.cpio)
+else
+CARGO_OSDK_INITRAMFS_OPTION := --initramfs=$(abspath test/initramfs/build/initramfs.cpio.gz)
+endif
+
+ifeq ($(INITRAMFS),on)
 CARGO_OSDK_COMMON_ARGS += $(CARGO_OSDK_INITRAMFS_OPTION)
 endif
 
@@ -261,16 +271,32 @@ check_vdso:
 
 .PHONY: initramfs
 initramfs: check_vdso
-	@$(MAKE) --no-print-directory -C test/initramfs
+	@$(MAKE) --no-print-directory -C test/initramfs initramfs-boot-images
+
+.PHONY: rootfs
+rootfs: check_vdso
+	@$(MAKE) --no-print-directory -C test/initramfs rootfs-boot-images
 
 # Build the kernel with an initramfs
 .PHONY: kernel
-kernel: initramfs $(CARGO_OSDK)
+kernel: $(CARGO_OSDK)
+ifeq ($(INITRAMFS),on)
+kernel: initramfs
+else
+kernel: rootfs
+endif
+kernel:
 	@cd kernel && cargo osdk build $(CARGO_OSDK_BUILD_ARGS)
 
 # Build the kernel with an initramfs and then run it
 .PHONY: run_kernel
-run_kernel: initramfs $(CARGO_OSDK)
+run_kernel: $(CARGO_OSDK)
+ifeq ($(INITRAMFS),on)
+run_kernel: initramfs
+else
+run_kernel: rootfs
+endif
+run_kernel:
 	@cd kernel && cargo osdk run $(CARGO_OSDK_BUILD_ARGS)
 # Check the running status of auto tests from the QEMU log
 ifeq ($(AUTO_TEST), conformance)

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -22,7 +22,6 @@ kcmd_args = [
     "PATH=/bin:/benchmark",
 ]
 init_args = ["sh", "-l"]
-initramfs = "test/initramfs/build/initramfs.cpio.gz"
 
 # Special options for testing
 [test.qemu]

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -19,7 +19,6 @@ kcmd_args = [
     "HOME=/",
     "USER=root",
     "PATH=/bin:/benchmark",
-    "init=/init",
 ]
 init_args = ["sh", "-l"]
 initramfs = "test/initramfs/build/initramfs.cpio.gz"

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -20,7 +20,6 @@ kcmd_args = [
     "HOME=/",
     "USER=root",
     "PATH=/bin:/benchmark",
-    "init=/init",
 ]
 init_args = ["sh", "-l"]
 initramfs = "test/initramfs/build/initramfs.cpio.gz"

--- a/book/src/distro/popular-applications/containerization-and-virtualization/README.md
+++ b/book/src/distro/popular-applications/containerization-and-virtualization/README.md
@@ -144,7 +144,7 @@ qemu-system-$(uname -m) \
   -initrd /run/current-system/initrd \
   -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
   -nographic -no-reboot \
-  -append 'console=ttyS0 panic=-1 init=/bin/init'
+  -append 'console=ttyS0 panic=-1 rdinit=/bin/init'
 ```
 
 > **Note**: Running the Asterinas kernel requires the `linux/multiboot` boot protocol (**multiboot2 is not supported**).

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -4,19 +4,18 @@ This section documents kernel command-line parameters supported by Asterinas.
 
 ## Inherited from Linux
 
-### `init`
+### `rdinit`
 
-Run the specified binary as `init`.
+Run the specified initramfs binary as the first userspace process.
 
 Example:
 ```text
-init=/bin/busybox
+rdinit=/bin/busybox
 ```
 
 Notes:
-- The value is the path to the executable.
-- If omitted, Asterinas will try to execute from the following paths in order:
-  `/sbin/init`, `/etc/init`, `/bin/init`, `/bin/sh`.
+- The value is the path to the executable in the initramfs root.
+- If omitted, Asterinas will try to execute `/init` from the initramfs root.
 
 ### `console`
 

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -16,6 +16,81 @@ rdinit=/bin/busybox
 Notes:
 - The value is the path to the executable in the initramfs root.
 - If omitted, Asterinas will try to execute `/init` from the initramfs root.
+- If the specified path cannot be accessed,
+  Asterinas ignores it and proceeds with root filesystem initialization.
+  It does not fall back to `/init` in this case.
+
+### `root`
+
+Mount the specified block device as the root filesystem.
+
+Example:
+```text
+root=/dev/vda2
+```
+
+Notes:
+- The value currently must name a registered block device under `/dev`,
+  such as `/dev/vda2`.
+- Asterinas first determines the boot source. If the path specified by
+  `rdinit` is accessible, or if `rdinit` is absent and `/init` exists, it
+  boots from the initramfs and ignores `root`. Otherwise, it boots from the
+  rootfs, for which `root` is required: Asterinas mounts the specified device
+  as the root filesystem and panics if the parameter is absent.
+
+### `rootfstype`
+
+Select the filesystem type used for the root filesystem.
+
+Example:
+```text
+root=/dev/vda2 rootfstype=ext2
+```
+
+Valid values:
+- `ext2`
+
+### `ro`
+
+Mount the root filesystem read-only.
+This is the default when Asterinas mounts the root filesystem via `root`.
+
+Example:
+```text
+root=/dev/vda2 ro
+```
+
+Notes:
+- This parameter has no effect when Asterinas boots from the initramfs.
+- If both `ro` and `rw` are specified, the last one takes precedence.
+
+### `rw`
+
+Mount the root filesystem read-write.
+
+Example:
+```text
+root=/dev/vda2 rw
+```
+
+Notes:
+- This parameter has no effect when Asterinas boots from the initramfs.
+- `rw` overrides the default read-only root mount.
+- If both `ro` and `rw` are specified, the last one takes precedence.
+
+### `init`
+
+Run the specified executable as the first userspace process from the root filesystem.
+
+Example:
+```text
+root=/dev/vda2 rootfstype=ext2 init=/nix/var/nix/profiles/system/init
+```
+
+Notes:
+- `init` is used only after Asterinas mounts the root filesystem via `root=`.
+- If omitted,
+  Asterinas tries `/sbin/init`, `/etc/init`, `/bin/init`, and `/bin/sh`, in that order.
 
 ### `console`
 

--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -79,17 +79,14 @@ in {
   # TODO: Fix errors and warnings from systemd and remove this setting.
   environment.sessionVariables = { SYSTEMD_LOG_LEVEL = "crit"; };
   system.systemBuilderCommands = ''
-    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin earlycon loglevel=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- sh /init root=/dev/vda2 init=/nix/var/nix/profiles/system/stage-2-init rd.break=${
+    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin earlycon loglevel=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- root=/dev/vda2 init=/nix/var/nix/profiles/system/init rd.break=${
       if config.aster_nixos.break-into-stage-1-shell then "1" else "0"
     }"  > $out/kernel-params
-    mv $out/init $out/stage-2-init
-    sed -i 's_^\([[:space:]]*\)\(exec > >(tee -i /run/log/stage-2-init.log) 2>&1\)$_\1# \2_' $out/stage-2-init
+    sed -i 's_^\([[:space:]]*\)\(exec > >(tee -i /run/log/stage-2-init.log) 2>&1\)$_\1# \2_' $out/init
     if [ "${config.aster_nixos.disable-systemd}" = "true" ]; then
-      sed -i 's/^[[:space:]]*echo "starting systemd..."$/# &/' $out/stage-2-init
-      sed -i 's/^[[:space:]]*exec \/run\/current-system\/systemd\/lib\/systemd\/systemd "$@"$/# &/' $out/stage-2-init
+      sed -i 's/^[[:space:]]*echo "starting systemd..."$/# &/' $out/init
+      sed -i 's/^[[:space:]]*exec \/run\/current-system\/systemd\/lib\/systemd\/systemd "$@"$/# &/' $out/init
     fi
-    rm -rf $out/init
-    ln -s /bin/busybox $out/init
     ln -s ${kernel} $out/kernel
     ln -s ${initramfs}/initrd $out/initrd
   '';

--- a/kernel/core/comps/block/src/lib.rs
+++ b/kernel/core/comps/block/src/lib.rs
@@ -149,25 +149,36 @@ pub fn lookup(id: DeviceId) -> Option<Arc<dyn BlockDevice>> {
     DEVICE_REGISTRY.lock().get(&id.to_raw()).cloned()
 }
 
-static DEVICE_REGISTRY: Mutex<BTreeMap<u32, Arc<dyn BlockDevice>>> = Mutex::new(BTreeMap::new());
-
-#[init_component]
-fn init() -> Result<(), ComponentInitError> {
-    device_id::init();
-
-    Ok(())
+/// Looks up a block device by its kernel device name.
+pub fn lookup_by_name(name: &str) -> Option<Arc<dyn BlockDevice>> {
+    DEVICE_REGISTRY
+        .lock()
+        .values()
+        .find(|device| device.name() == name)
+        .cloned()
 }
 
-#[init_component(process)]
-fn init_in_first_process() -> Result<(), ComponentInitError> {
+/// Scans registered whole-disk devices and updates their partitions.
+pub fn scan_partitions() {
     let devices = collect_all();
     for device in devices {
+        if device.is_partition() {
+            continue;
+        }
+
         let Some(partition_info) = partition::parse(&device) else {
             continue;
         };
 
         device.set_partitions(partition_info);
     }
+}
+
+static DEVICE_REGISTRY: Mutex<BTreeMap<u32, Arc<dyn BlockDevice>>> = Mutex::new(BTreeMap::new());
+
+#[init_component]
+fn init() -> Result<(), ComponentInitError> {
+    device_id::init();
 
     Ok(())
 }

--- a/kernel/core/comps/block/src/partition.rs
+++ b/kernel/core/comps/block/src/partition.rs
@@ -268,6 +268,10 @@ impl BlockDevice for PartitionNode {
     fn id(&self) -> DeviceId {
         self.id
     }
+
+    fn is_partition(&self) -> bool {
+        true
+    }
 }
 
 impl PartitionNode {

--- a/kernel/core/src/device/registry/block.rs
+++ b/kernel/core/src/device/registry/block.rs
@@ -54,6 +54,10 @@ pub(super) fn init_in_first_kthread() {
             ThreadOptions::new(task_fn).spawn();
         }
     }
+
+    // Partition scanning performs synchronous block I/O, so the request
+    // handling threads above must be available first.
+    aster_block::scan_partitions();
 }
 
 pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> {

--- a/kernel/core/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/fs_type.rs
@@ -15,11 +15,12 @@ use crate::fs::vfs::{
 };
 
 /// VFS-visible Ext2 filesystem type.
-pub(super) struct Ext2Type {
+pub(in crate::fs) struct Ext2Type {
     cache: FsCache<DeviceId>,
 }
 
-pub(super) static EXT2_TYPE: Ext2Type = Ext2Type {
+/// The VFS filesystem type descriptor for Ext2.
+pub(in crate::fs) static EXT2_TYPE: Ext2Type = Ext2Type {
     cache: FsCache::new(),
 };
 

--- a/kernel/core/src/fs/fs_impls/ext2/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/mod.rs
@@ -63,7 +63,7 @@ macro_rules! __log_prefix {
 pub use fs::Ext2;
 pub use inode::{FilePerm, Inode};
 
-use self::fs_type::EXT2_TYPE;
+pub(in crate::fs) use self::fs_type::EXT2_TYPE;
 use crate::fs::vfs::registry;
 
 mod block_group;

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -1248,12 +1248,13 @@ mod tests {
     use super::*;
     use crate::fs::{
         ramfs::RamFs,
-        vfs::path::{Mount, MountNamespace},
+        vfs::path::{Mount, MountNamespace, PerMountFlags},
     };
 
     fn new_dummy_mount() -> Arc<Mount> {
         Mount::new_root(
             RamFs::new(),
+            PerMountFlags::default(),
             Arc::downgrade(MountNamespace::get_init_singleton()),
         )
         .unwrap()

--- a/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
@@ -30,6 +30,7 @@ pub use anon_inodefs::AnonInodeFs;
 use device_id::DeviceId;
 pub(in crate::fs) use nsfs::NsInode;
 pub use nsfs::{NsCommonOps, NsFile, NsType, StashedDentry};
+pub(in crate::fs) use nullfs::NullFs;
 pub use pidfdfs::PidfdFs;
 pub(in crate::fs) use pipefs::PipeFs;
 use pipefs::PipeFsType;
@@ -54,6 +55,7 @@ use crate::{
 mod allocator;
 mod anon_inodefs;
 mod nsfs;
+mod nullfs;
 mod pidfdfs;
 mod pipefs;
 mod sockfs;

--- a/kernel/core/src/fs/fs_impls/pseudofs/nullfs.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/nullfs.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The hidden root filesystem of the initial mount namespace.
+//!
+//! The mutable bootstrap rootfs is mounted over this empty filesystem. Keeping the nullfs mount
+//! as the mount-tree root gives the visible rootfs a parent mount, allowing it to be replaced by a
+//! later rootfs pivot.
+//!
+//! Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/namespace.c#L6139-L6201>.
+
+use spin::Once;
+
+use super::NaivePseudoFs;
+use crate::prelude::*;
+
+/// The empty filesystem used as the root mount of the initial mount namespace.
+pub(in crate::fs) struct NullFs;
+
+impl NullFs {
+    /// Returns the singleton null filesystem instance.
+    pub(in crate::fs) fn singleton() -> &'static Arc<NaivePseudoFs> {
+        static NULLFS: Once<Arc<NaivePseudoFs>> = Once::new();
+
+        NaivePseudoFs::singleton(&NULLFS, "nullfs", NULLFS_MAGIC)
+    }
+}
+
+// Nullfs is hidden from the userspace filesystem ABI and needs no public magic number.
+const NULLFS_MAGIC: u64 = 0;

--- a/kernel/core/src/fs/initramfs.rs
+++ b/kernel/core/src/fs/initramfs.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Boot initramfs unpacking and init selection.
+//!
+//! This module unpacks the boot initramfs into the bootstrap VFS root and selects the initramfs
+//! init from the `rdinit` parameter or the default `/init` path.
+
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "initramfs: "
+    };
+}
+
+use alloc::borrow::Cow;
+
+use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
+use device_id::{DeviceId, MajorId, MinorId};
+use lending_iterator::LendingIterator;
+use no_std_io2::io::{Cursor, Read};
+use ostd::boot::boot_info;
+use spin::once::Once;
+use zune_inflate::DeflateDecoder;
+
+use super::{
+    file::{InodeMode, InodeType},
+    vfs::path::{FsPath, Path, PathResolver, is_dot},
+};
+use crate::{fs::vfs::inode::MknodType, prelude::*};
+
+/// Unpacks the boot initramfs into the bootstrap root filesystem.
+///
+/// Returns successfully without changing the filesystem when no initramfs was supplied.
+pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
+    let Some(initramfs_buf) = boot_info().initramfs else {
+        return Ok(());
+    };
+
+    let (reader, suffix) = match &initramfs_buf[..4] {
+        // Gzip magic number: 0x1F 0x8B
+        &[0x1F, 0x8B, _, _] => {
+            let decompressed = DeflateDecoder::new(initramfs_buf)
+                .decode_gzip()
+                .map_err(|_| Error::with_message(Errno::EINVAL, "gzip decompression failed"))?;
+            (Cow::Owned(decompressed), ".gz")
+        }
+        _ => (Cow::Borrowed(initramfs_buf), ""),
+    };
+
+    println!("[kernel] unpacking initramfs.cpio{} to rootfs ...", suffix);
+
+    let mut decoder = CpioDecoder::new(Cursor::new(reader));
+
+    while let Some(entry_result) = decoder.next() {
+        let mut entry = entry_result?;
+        if let Err(e) = try_append_entry_to_rootfs(&mut entry, path_resolver) {
+            warn!("failed to add entry {} to rootfs: {:?}", entry.name(), e);
+        }
+    }
+
+    println!("[kernel] initramfs is ready");
+    Ok(())
+}
+
+/// Finds the init program to run from the initramfs.
+///
+/// Resolves the path specified by `rdinit`, or `/init` when `rdinit` is not provided, and returns
+/// the resolved path together with the original pathname. Returns an error if the pathname is
+/// invalid or cannot be resolved.
+pub fn find_init(path_resolver: &PathResolver) -> Result<(Path, &'static str)> {
+    const DEFAULT_INITRAMFS_INIT_PATH: &str = "/init";
+
+    let init_path = RDINIT_PATH
+        .get()
+        .map(String::as_str)
+        .unwrap_or(DEFAULT_INITRAMFS_INIT_PATH);
+    let path = path_resolver.lookup(&FsPath::try_from(init_path)?)?;
+    Ok((path, init_path))
+}
+
+fn try_append_entry_to_rootfs<R: Read>(
+    entry: &mut CpioEntry<R>,
+    path_resolver: &PathResolver,
+) -> Result<()> {
+    // Make sure the name is a relative path, and is not end with "/".
+    let entry_name = entry.name().trim_start_matches('/').trim_end_matches('/');
+    if entry_name.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "invalid entry name");
+    }
+    if is_dot(entry_name) {
+        return Ok(());
+    }
+
+    // Here we assume that the directory referred by "prefix" must has been created.
+    // The basis of this assumption is：
+    // The mkinitramfs script uses `find` command to ensure that the entries are
+    // sorted that a directory always appears before its child directories and files.
+    let (parent, name) = if let Some((prefix, last)) = entry_name.rsplit_once('/') {
+        (path_resolver.lookup(&FsPath::try_from(prefix)?)?, last)
+    } else {
+        (path_resolver.root().clone(), entry_name)
+    };
+
+    let metadata = entry.metadata();
+    let mode = InodeMode::from_bits_truncate(metadata.permission_mode());
+    match metadata.file_type() {
+        FileType::File => {
+            let path = parent.new_fs_child(name, InodeType::File, mode)?;
+            entry.read_all(path.inode().writer(0))?;
+        }
+        FileType::Dir => {
+            let _ = parent.new_fs_child(name, InodeType::Dir, mode)?;
+        }
+        FileType::Link => {
+            let path = parent.new_fs_child(name, InodeType::SymLink, mode)?;
+            let link_content = {
+                let mut link_data: Vec<u8> = Vec::new();
+                entry.read_all(&mut link_data)?;
+                core::str::from_utf8(&link_data)?.to_string()
+            };
+            path.inode().write_link(&link_content)?;
+        }
+        FileType::Char => {
+            let device_id = try_device_id_from_metadata(metadata)?;
+            parent.mknod(name, mode, MknodType::CharDevice(device_id))?;
+        }
+        FileType::Block => {
+            let device_id = try_device_id_from_metadata(metadata)?;
+            parent.mknod(name, mode, MknodType::BlockDevice(device_id))?;
+        }
+        FileType::FiFo => {
+            parent.mknod(name, mode, MknodType::NamedPipe)?;
+        }
+        FileType::Socket => {
+            return_errno_with_message!(Errno::EINVAL, "socket files are not supported in initramfs")
+        }
+    }
+
+    Ok(())
+}
+
+fn try_device_id_from_metadata(metadata: &FileMetadata) -> Result<u64> {
+    let major = {
+        let dev_maj = u16::try_from(metadata.rdev_maj())?;
+        MajorId::try_from(dev_maj).map_err(|msg| Error::with_message(Errno::EINVAL, msg))?
+    };
+    let minor = MinorId::try_from(metadata.rdev_min())
+        .map_err(|msg| Error::with_message(Errno::EINVAL, msg))?;
+    Ok(DeviceId::new(major, minor).as_encoded_u64())
+}
+
+static RDINIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);

--- a/kernel/core/src/fs/mod.rs
+++ b/kernel/core/src/fs/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod file;
 mod fs_impls;
+pub mod initramfs;
 pub mod pipe;
 pub mod rootfs;
 pub mod thread_info;
@@ -30,7 +31,7 @@ pub fn init_on_each_cpu() {
 }
 
 pub fn init_in_first_kthread(path_resolver: &PathResolver) {
-    rootfs::init_in_first_kthread(path_resolver).unwrap();
+    initramfs::init_in_first_kthread(path_resolver).unwrap();
 }
 
 pub fn init_in_first_process(ctx: &Context) {

--- a/kernel/core/src/fs/rootfs.rs
+++ b/kernel/core/src/fs/rootfs.rs
@@ -1,119 +1,203 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::borrow::Cow;
+//! Root filesystem mounting during boot.
+//!
+//! Asterinas first tries to boot from the initramfs. It checks the path specified by `rdinit`, or
+//! `/init` when `rdinit` is not provided. If the selected path is accessible, Asterinas runs it as
+//! the first userspace process. Otherwise, Asterinas boots from the root filesystem.
+//!
+//! For root filesystem boot, this module mounts a supported filesystem from the block device
+//! specified by `root`. The mounted filesystem replaces the bootstrap root in the initial mount
+//! namespace and becomes the root and working directory of the first userspace process. The
+//! bootstrap root is then detached. The `root` parameter is required when this boot path is
+//! selected, and [`SUPPORTED_ROOTFS_TYPES`] lists the supported filesystem types.
+//!
+//! The following kernel parameters configure root filesystem boot:
+//!
+//! - `root` specifies the block device to mount.
+//! - `rootfstype` specifies a comma-separated list of filesystem type candidates. All supported
+//!   types are tried when it is not provided.
+//! - `ro` and `rw` select read-only or read-write mounting. The root filesystem is read-only by
+//!   default. They use last-wins semantics: the last `ro` or `rw` parameter determines the mount
+//!   mode.
+//! - `init` specifies the init executable on the mounted filesystem. If it is not provided,
+//!   Asterinas tries `/sbin/init`, `/etc/init`, `/bin/init`, and `/bin/sh` in order.
 
-use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
-use device_id::{DeviceId, MajorId, MinorId};
-use lending_iterator::LendingIterator;
-use no_std_io2::io::{Cursor, Read};
-use ostd::boot::boot_info;
-use zune_inflate::DeflateDecoder;
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "rootfs: "
+    };
+}
+
+use core::{
+    str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use aster_cmdline::parse::ParamStorage;
+use spin::once::Once;
 
 use super::{
-    file::{InodeMode, InodeType},
-    vfs::path::{FsPath, PathResolver, is_dot},
+    ext2,
+    vfs::{
+        file_system::FsFlags,
+        path::{FsPath, Mount, MountNamespace, Path, PathResolver, PerMountFlags},
+        registry::{DynFsType, FsAndRoot, FsCreationCtx},
+    },
 };
-use crate::{fs::vfs::inode::MknodType, prelude::*};
+use crate::prelude::*;
 
-/// Unpack and prepare the rootfs from the initramfs CPIO buffer.
-pub fn init_in_first_kthread(path_resolver: &PathResolver) -> Result<()> {
-    let initramfs_buf = boot_info()
-        .initramfs
-        .ok_or_else(|| Error::with_message(Errno::EINVAL, "no initramfs found"))?;
+/// Filesystem types supported for the root filesystem.
+pub static SUPPORTED_ROOTFS_TYPES: &[&dyn DynFsType] = &[&ext2::EXT2_TYPE];
 
-    let (reader, suffix) = match &initramfs_buf[..4] {
-        // Gzip magic number: 0x1F 0x8B
-        &[0x1F, 0x8B, _, _] => {
-            let decompressed = DeflateDecoder::new(initramfs_buf)
-                .decode_gzip()
-                .map_err(|_| Error::with_message(Errno::EINVAL, "gzip decompression failed"))?;
-            (Cow::Owned(decompressed), ".gz")
-        }
-        _ => (Cow::Borrowed(initramfs_buf), ""),
-    };
-
-    println!("[kernel] unpacking initramfs.cpio{} to rootfs ...", suffix);
-
-    let mut decoder = CpioDecoder::new(Cursor::new(reader));
-
-    while let Some(entry_result) = decoder.next() {
-        let mut entry = entry_result?;
-        if let Err(e) = try_append_entry_to_rootfs(&mut entry, path_resolver) {
-            warn!("failed to add entry {} to rootfs: {:?}", entry.name(), e);
-        }
-    }
-
-    println!("[kernel] rootfs is ready");
+/// Mounts and switches to the root filesystem configured by the kernel command line.
+///
+/// The filesystem replaces the bootstrap root mount and becomes the resolver's root and working
+/// directory.
+///
+/// Returns an error if `root` is not provided or the root filesystem cannot be opened or mounted.
+pub fn switch_to_rootfs(path_resolver: &mut PathResolver) -> Result<()> {
+    let root = ROOT_PATH.get().ok_or_else(|| {
+        Error::with_message(Errno::EINVAL, "the `root` parameter was not provided")
+    })?;
+    let (fs_flags, mount_flags) = rootfs_flags();
+    let fs_and_root = open_rootfs(root, fs_flags)?;
+    let rootfs_mount = Mount::new_detached(
+        fs_and_root,
+        mount_flags,
+        Arc::downgrade(MountNamespace::get_init_singleton()),
+        Some(root.to_string()),
+    )?;
+    path_resolver.switch_root_for_boot(rootfs_mount);
+    println!("[kernel] rootfs is ready (mounted from {})", root);
     Ok(())
 }
 
-fn try_append_entry_to_rootfs<R: Read>(
-    entry: &mut CpioEntry<R>,
-    path_resolver: &PathResolver,
-) -> Result<()> {
-    // Make sure the name is a relative path, and is not end with "/".
-    let entry_name = entry.name().trim_start_matches('/').trim_end_matches('/');
-    if entry_name.is_empty() {
-        return_errno_with_message!(Errno::EINVAL, "invalid entry name");
-    }
-    if is_dot(entry_name) {
-        return Ok(());
-    }
-
-    // Here we assume that the directory referred by "prefix" must has been created.
-    // The basis of this assumption is：
-    // The mkinitramfs script uses `find` command to ensure that the entries are
-    // sorted that a directory always appears before its child directories and files.
-    let (parent, name) = if let Some((prefix, last)) = entry_name.rsplit_once('/') {
-        (path_resolver.lookup(&FsPath::try_from(prefix)?)?, last)
-    } else {
-        (path_resolver.root().clone(), entry_name)
+/// Finds the init program specified for booting from the root filesystem.
+///
+/// Resolves the path specified by `init` and returns the resolved path together with the original
+/// pathname. Returns `Ok(None)` when `init` is not provided, and an error if the configured
+/// pathname is invalid or cannot be resolved.
+pub fn find_init(path_resolver: &PathResolver) -> Result<Option<(Path, &'static str)>> {
+    let Some(init_path) = INIT_PATH.get().map(String::as_str) else {
+        return Ok(None);
     };
 
-    let metadata = entry.metadata();
-    let mode = InodeMode::from_bits_truncate(metadata.permission_mode());
-    match metadata.file_type() {
-        FileType::File => {
-            let path = parent.new_fs_child(name, InodeType::File, mode)?;
-            entry.read_all(path.inode().writer(0))?;
-        }
-        FileType::Dir => {
-            let _ = parent.new_fs_child(name, InodeType::Dir, mode)?;
-        }
-        FileType::Link => {
-            let path = parent.new_fs_child(name, InodeType::SymLink, mode)?;
-            let link_content = {
-                let mut link_data: Vec<u8> = Vec::new();
-                entry.read_all(&mut link_data)?;
-                core::str::from_utf8(&link_data)?.to_string()
-            };
-            path.inode().write_link(&link_content)?;
-        }
-        FileType::Char => {
-            let device_id = try_device_id_from_metadata(metadata)?;
-            parent.mknod(name, mode, MknodType::CharDevice(device_id))?;
-        }
-        FileType::Block => {
-            let device_id = try_device_id_from_metadata(metadata)?;
-            parent.mknod(name, mode, MknodType::BlockDevice(device_id))?;
-        }
-        FileType::FiFo => {
-            parent.mknod(name, mode, MknodType::NamedPipe)?;
-        }
-        FileType::Socket => {
-            return_errno_with_message!(Errno::EINVAL, "socket files are not supported in initramfs")
+    let path = path_resolver.lookup(&FsPath::try_from(init_path)?)?;
+    Ok(Some((path, init_path)))
+}
+
+fn open_rootfs(root: &str, fs_flags: FsFlags) -> Result<FsAndRoot> {
+    // Treat a `/dev/...` value of `root` as a Linux-compatible root device spec, not as a VFS path
+    // lookup.
+    // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/base/devtmpfs.c#L358-L359>.
+    let device_name = root
+        .strip_prefix("/dev/")
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "root must name a /dev block device"))?;
+    let device = aster_block::lookup_by_name(device_name)
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "root block device not found"))?;
+    open_rootfs_from_candidates(device, rootfs_types(), fs_flags)
+}
+
+fn open_rootfs_from_candidates(
+    device: Arc<dyn aster_block::BlockDevice>,
+    rootfs_types: &[&dyn DynFsType],
+    fs_flags: FsFlags,
+) -> Result<FsAndRoot> {
+    let mut fs_creation_ctx = FsCreationCtx::from_block_device(device, fs_flags, None);
+    for rootfs_type in rootfs_types {
+        match rootfs_type.get_or_create(&mut fs_creation_ctx) {
+            Ok(fs_and_root) => return Ok(fs_and_root),
+            Err(err) if err.error() == Errno::EINVAL => continue,
+            Err(err) => return Err(err),
         }
     }
 
-    Ok(())
+    return_errno_with_message!(Errno::ENODEV, "no root filesystem type could mount root")
 }
 
-fn try_device_id_from_metadata(metadata: &FileMetadata) -> Result<u64> {
-    let major = {
-        let dev_maj = u16::try_from(metadata.rdev_maj())?;
-        MajorId::try_from(dev_maj).map_err(|msg| Error::with_message(Errno::EINVAL, msg))?
-    };
-    let minor = MinorId::try_from(metadata.rdev_min())
-        .map_err(|msg| Error::with_message(Errno::EINVAL, msg))?;
-    Ok(DeviceId::new(major, minor).as_encoded_u64())
+fn rootfs_flags() -> (FsFlags, PerMountFlags) {
+    let mut fs_flags = FsFlags::empty();
+    let mut mount_flags = PerMountFlags::default();
+    if ROOT_MOUNT_READ_ONLY.load(Ordering::Relaxed) {
+        fs_flags.insert(FsFlags::RDONLY);
+        mount_flags.insert(PerMountFlags::RDONLY);
+    }
+    (fs_flags, mount_flags)
 }
+
+fn rootfs_types() -> &'static [&'static dyn DynFsType] {
+    ROOTFS_TYPES
+        .get()
+        .map(RootFsTypes::as_slice)
+        .unwrap_or(SUPPORTED_ROOTFS_TYPES)
+}
+
+static ROOT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("root", ROOT_PATH);
+
+static INIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("init", INIT_PATH);
+
+/// Root filesystem type candidates.
+struct RootFsTypes(Vec<&'static dyn DynFsType>);
+
+impl RootFsTypes {
+    /// Returns the root filesystem type candidates as a slice.
+    fn as_slice(&self) -> &[&'static dyn DynFsType] {
+        self.0.as_slice()
+    }
+}
+
+impl FromStr for RootFsTypes {
+    type Err = core::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let candidates = value
+            .split(',')
+            .filter(|type_name| !type_name.is_empty())
+            .filter_map(|type_name| {
+                SUPPORTED_ROOTFS_TYPES
+                    .iter()
+                    .copied()
+                    .find(|fs_type| fs_type.name() == type_name)
+            })
+            .collect();
+
+        Ok(Self(candidates))
+    }
+}
+
+static ROOTFS_TYPES: Once<RootFsTypes> = Once::new();
+aster_cmdline::define_kv_param!("rootfstype", ROOTFS_TYPES);
+
+static ROOT_MOUNT_READ_ONLY: AtomicBool = AtomicBool::new(true);
+
+struct SetRootMountReadOnly;
+struct SetRootMountReadWrite;
+
+impl ParamStorage for SetRootMountReadOnly {
+    type Value = bool;
+
+    fn store_param(&self, value: Self::Value) {
+        if value {
+            ROOT_MOUNT_READ_ONLY.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+impl ParamStorage for SetRootMountReadWrite {
+    type Value = bool;
+
+    fn store_param(&self, value: Self::Value) {
+        if value {
+            ROOT_MOUNT_READ_ONLY.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
+static RO_PARAM: SetRootMountReadOnly = SetRootMountReadOnly;
+static RW_PARAM: SetRootMountReadWrite = SetRootMountReadWrite;
+aster_cmdline::define_flag_param!("ro", RO_PARAM);
+aster_cmdline::define_flag_param!("rw", RW_PARAM);

--- a/kernel/core/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/registry.rs
@@ -106,8 +106,12 @@ pub struct FsCreationCtx<'a> {
     source: Option<&'a str>,
     flags: FsFlags,
     args: Option<&'a str>,
-    task_ctx: &'a Context<'a>,
-    block_device: Option<Arc<dyn BlockDevice>>,
+    block_device: BlockDeviceResolution<'a>,
+}
+
+enum BlockDeviceResolution<'a> {
+    Pending(&'a Context<'a>),
+    Resolved(Arc<dyn BlockDevice>),
 }
 
 impl<'a> FsCreationCtx<'a> {
@@ -122,8 +126,21 @@ impl<'a> FsCreationCtx<'a> {
             source,
             flags,
             args,
-            task_ctx,
-            block_device: None,
+            block_device: BlockDeviceResolution::Pending(task_ctx),
+        }
+    }
+
+    /// Creates a file system creation context from an already resolved block device.
+    pub(in crate::fs) fn from_block_device(
+        block_device: Arc<dyn BlockDevice>,
+        flags: FsFlags,
+        args: Option<&'a str>,
+    ) -> Self {
+        Self {
+            source: None,
+            flags,
+            args,
+            block_device: BlockDeviceResolution::Resolved(block_device),
         }
     }
 
@@ -144,20 +161,31 @@ impl<'a> FsCreationCtx<'a> {
 
     /// Resolves the mount source into a block device.
     pub(in crate::fs) fn resolve_block_device(&mut self) -> Result<&Arc<dyn BlockDevice>> {
-        if self.block_device.is_none() {
+        if self.block_device().is_none() {
             self.do_resolve_block_device()?;
         }
 
-        Ok(self.block_device.as_ref().unwrap())
+        Ok(self.block_device().unwrap())
+    }
+
+    fn block_device(&self) -> Option<&Arc<dyn BlockDevice>> {
+        match &self.block_device {
+            BlockDeviceResolution::Pending(_) => None,
+            BlockDeviceResolution::Resolved(block_device) => Some(block_device),
+        }
     }
 
     fn do_resolve_block_device(&mut self) -> Result<()> {
+        let task_ctx = match &self.block_device {
+            BlockDeviceResolution::Pending(task_ctx) => *task_ctx,
+            BlockDeviceResolution::Resolved(_) => return Ok(()),
+        };
+
         let source = self
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
         let fs_path = FsPath::from_fd_at(AT_FDCWD, source, EmptyPathStr::Reject)?;
-        let path = self
-            .task_ctx
+        let path = task_ctx
             .thread_local
             .borrow_fs()
             .resolver()
@@ -172,7 +200,7 @@ impl<'a> FsCreationCtx<'a> {
         let block_device = id
             .and_then(aster_block::lookup)
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))?;
-        self.block_device = Some(block_device);
+        self.block_device = BlockDeviceResolution::Resolved(block_device);
 
         Ok(())
     }

--- a/kernel/core/src/fs/vfs/path/mod.rs
+++ b/kernel/core/src/fs/vfs/path/mod.rs
@@ -378,15 +378,13 @@ impl Path {
         }
 
         let mut topology_guard = MountTopology::write_lock();
-        let child_mount = self.mount.do_mount(
+        self.mount.do_mount(
             fs_and_root,
             flags,
             &self.dentry,
             source,
             &mut topology_guard,
-        )?;
-
-        Ok(child_mount)
+        )
     }
 
     /// Unmounts the filesystem mounted at the current path.

--- a/kernel/core/src/fs/vfs/path/mount.rs
+++ b/kernel/core/src/fs/vfs/path/mount.rs
@@ -284,18 +284,12 @@ impl Mount {
     /// mount node. It is the fs's responsibility to ensure the data consistency.
     pub(in crate::fs) fn new_root(
         fs: Arc<dyn FileSystem>,
+        flags: PerMountFlags,
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
         let source = fs.name().to_string();
         let root_dentry = Dentry::new_root(fs.root_inode());
-        Self::new(
-            root_dentry,
-            fs,
-            PerMountFlags::default(),
-            None,
-            mnt_ns,
-            Some(source),
-        )
+        Self::new(root_dentry, fs, flags, None, mnt_ns, Some(source))
     }
 
     /// Creates a pseudo mount node with an associated FS.

--- a/kernel/core/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/core/src/fs/vfs/path/mount_namespace.rs
@@ -11,8 +11,11 @@ use super::{
 use crate::{
     fs::{
         fs_impls::ramfs::RamFs,
-        pseudofs::{NsCommonOps, NsType, StashedDentry},
-        vfs::path::{Dentry, Mount, Path, PathResolver},
+        pseudofs::{NsCommonOps, NsType, NullFs, StashedDentry},
+        vfs::{
+            path::{Dentry, Mount, Path, PathResolver, PerMountFlags},
+            registry::FsAndRoot,
+        },
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
@@ -95,10 +98,27 @@ impl MountNamespace {
 
         INIT.call_once(|| {
             let owner = UserNamespace::get_init_singleton().clone();
+            let nullfs = NullFs::singleton().clone();
             let rootfs = RamFs::new_rootfs();
 
-            Self::new_with_root(owner, |weak_ns| Mount::new_root(rootfs, weak_ns.clone()))
-                .expect("failed to allocate mount ID for the root mount")
+            let namespace = Self::new_with_root(owner, |weak_ns| {
+                Mount::new_root(nullfs, PerMountFlags::RDONLY, weak_ns.clone())
+            })
+            .expect("failed to create the nullfs root mount");
+
+            let mut topology_guard = MountTopology::write_lock();
+            let root_mount = namespace.root();
+            root_mount
+                .do_mount(
+                    FsAndRoot::new(rootfs),
+                    PerMountFlags::default(),
+                    root_mount.root_dentry(),
+                    Some("rootfs".to_string()),
+                    &mut topology_guard,
+                )
+                .expect("failed to mount rootfs on nullfs");
+
+            namespace
         })
     }
 

--- a/kernel/core/src/fs/vfs/path/resolver.rs
+++ b/kernel/core/src/fs/vfs/path/resolver.rs
@@ -361,6 +361,31 @@ impl PathResolver {
         Ok(())
     }
 
+    /// Switches the bootstrap resolver to `new_root` and detaches its old root mount.
+    ///
+    /// This combines the final topology effects of `pivot_root(".", ".")` followed by detaching
+    /// the old root. The two operations can be performed under one topology lock because no
+    /// userspace process can observe the intermediate mount tree.
+    ///
+    /// This method may only be used before the first userspace process is created, when this is the
+    /// only resolver that can reference the bootstrap root.
+    pub(in crate::fs) fn switch_root_for_boot(&mut self, new_root_mount: Arc<Mount>) {
+        let mut topology_guard = MountTopology::write_lock();
+        let parent_path = {
+            let parent_mount = self.root.mount.parent().unwrap().upgrade().unwrap();
+            let mountpoint = self.root.mount.mountpoint().unwrap();
+            Path::new(parent_mount, mountpoint)
+        };
+
+        self.root.mount.detach_from_parent(&mut topology_guard);
+        new_root_mount.graft_mount_tree(&parent_path, &mut topology_guard);
+        drop(topology_guard);
+
+        let new_root = Path::new_fs_root(new_root_mount);
+        self.root = new_root.clone();
+        self.cwd = new_root;
+    }
+
     /// Changes the root mount in the mount namespace of the calling thread.
     ///
     /// This function moves the original root mount of the calling thread to `put_old_path` and makes

--- a/kernel/core/src/init.rs
+++ b/kernel/core/src/init.rs
@@ -139,7 +139,7 @@ fn first_kthread() {
 
     INIT_PROCESS.call_once(|| {
         let karg = INIT_PROC_ARGS.get().unwrap();
-        let init_path = INIT_PATH.get().map(|s| s.as_str());
+        let init_path = RDINIT_PATH.get().map(|s| s.as_str());
         spawn_init_process(init_path, karg.argv().to_vec(), karg.envp().to_vec())
             .expect("Failed to run the init process")
     });
@@ -170,5 +170,5 @@ pub(super) fn on_first_process_startup(ctx: &Context) {
     crate::fs::init_in_first_process(ctx);
 }
 
-static INIT_PATH: Once<String> = Once::new();
-aster_cmdline::define_kv_param!("init", INIT_PATH);
+static RDINIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);

--- a/kernel/core/src/init.rs
+++ b/kernel/core/src/init.rs
@@ -8,7 +8,10 @@ use ostd::{cpu::CpuId, util::id_set::Id};
 use spin::once::Once;
 
 use crate::{
-    fs::vfs::path::{MountNamespace, PathResolver},
+    fs::{
+        initramfs, rootfs,
+        vfs::path::{FsPath, MountNamespace, Path, PathResolver},
+    },
     prelude::*,
     process::{Process, spawn_init_process},
     sched::SchedPolicy,
@@ -32,6 +35,12 @@ pub(super) fn main() {
         .cpu_affinity(CpuId::bsp().into())
         .sched_policy(SchedPolicy::Idle)
         .spawn();
+}
+
+pub(super) fn on_first_process_startup(ctx: &Context) {
+    component::init_all(InitStage::Process, component::parse_metadata!()).unwrap();
+    crate::device::init_in_first_process(ctx).unwrap();
+    crate::fs::init_in_first_process(ctx);
 }
 
 fn init() {
@@ -134,15 +143,107 @@ fn first_kthread() {
     let init_mnt_ns = MountNamespace::get_init_singleton();
     let fs_resolver = init_mnt_ns.new_path_resolver();
     init_in_first_kthread(&fs_resolver);
+    let boot_init = prepare_boot_init(fs_resolver);
 
     print_banner();
 
     INIT_PROCESS.call_once(|| {
         let karg = INIT_PROC_ARGS.get().unwrap();
-        let init_path = RDINIT_PATH.get().map(|s| s.as_str());
-        spawn_init_process(init_path, karg.argv().to_vec(), karg.envp().to_vec())
-            .expect("Failed to run the init process")
+        let argv = karg.argv().to_vec();
+        let envp = karg.envp().to_vec();
+        boot_init
+            .spawn(argv, envp)
+            .expect("failed to run the init process")
     });
+}
+
+struct BootInit {
+    path_resolver: PathResolver,
+    init_path: Option<(Path, &'static str)>,
+}
+
+impl BootInit {
+    fn spawn(self, argv: Vec<CString>, envp: Vec<CString>) -> Result<Arc<Process>> {
+        let Self {
+            path_resolver,
+            init_path,
+        } = self;
+
+        // Only rootfs boot may have no init path; initramfs boot always provides one.
+        let Some((init_path, init_name)) = init_path else {
+            return spawn_default_rootfs_init(path_resolver, argv, envp);
+        };
+
+        println!("[kernel] running {} as the init process", init_name);
+        spawn_init_process(
+            path_resolver,
+            init_path,
+            with_init_argv0(init_name, argv),
+            envp,
+        )
+    }
+}
+
+fn prepare_boot_init(mut path_resolver: PathResolver) -> BootInit {
+    if let Ok(init_path) = initramfs::find_init(&path_resolver) {
+        return BootInit {
+            path_resolver,
+            init_path: Some(init_path),
+        };
+    }
+
+    rootfs::switch_to_rootfs(&mut path_resolver)
+        .expect("neither an initramfs init nor a usable root filesystem was available");
+    let init_path = rootfs::find_init(&path_resolver).expect("failed to resolve rootfs init path");
+    BootInit {
+        path_resolver,
+        init_path,
+    }
+}
+
+fn spawn_default_rootfs_init(
+    path_resolver: PathResolver,
+    argv: Vec<CString>,
+    envp: Vec<CString>,
+) -> Result<Arc<Process>> {
+    // Linux probes the fallback init executables in this order:
+    // Reference: <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1634>.
+    const DEFAULT_INIT_EXEC_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
+
+    let mut last_error = None;
+
+    for &init_name in DEFAULT_INIT_EXEC_PATHS {
+        // FIXME: Avoid cloning `argv` and `envp` for each fallback candidate.
+        let init_path = match path_resolver.lookup(&FsPath::try_from(init_name).unwrap()) {
+            Ok(path) => path,
+            Err(error) => {
+                last_error = Some(error);
+                continue;
+            }
+        };
+
+        match spawn_init_process(
+            path_resolver.clone(),
+            init_path,
+            with_init_argv0(init_name, argv.clone()),
+            envp.clone(),
+        ) {
+            Ok(process) => {
+                println!("[kernel] running {} as the rootfs init", init_name);
+                return Ok(process);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    Err(last_error.unwrap())
+}
+
+fn with_init_argv0(init_name: &str, mut argv: Vec<CString>) -> Vec<CString> {
+    // Linux prepends the init executable path as `argv[0]`.
+    // Reference: <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1491>.
+    argv.insert(0, CString::new(init_name).unwrap());
+    argv
 }
 
 static INIT_PROCESS: Once<Arc<Process>> = Once::new();
@@ -163,12 +264,3 @@ fn print_banner() {
     println!("");
     println!("{}", logo_ascii_art::get_gradient_color_version());
 }
-
-pub(super) fn on_first_process_startup(ctx: &Context) {
-    component::init_all(InitStage::Process, component::parse_metadata!()).unwrap();
-    crate::device::init_in_first_process(ctx).unwrap();
-    crate::fs::init_in_first_process(ctx);
-}
-
-static RDINIT_PATH: Once<String> = Once::new();
-aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -29,15 +29,12 @@ pub fn spawn_init_process(
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let process = if let Some(executable_path) = executable_path {
-        create_init_process(
-            executable_path,
-            with_init_argv0(executable_path, argv),
-            envp,
-        )?
-    } else {
-        create_default_init_process(argv, envp)?
-    };
+    let executable_path = executable_path.unwrap_or("/init");
+    let process = create_init_process(
+        executable_path,
+        with_init_argv0(executable_path, argv),
+        envp,
+    )?;
 
     // Linux starts the init process without placing it in a process group or session.
     // It joins one only after userspace first calls `setsid()`.
@@ -51,28 +48,6 @@ pub fn spawn_init_process(
     process.run();
 
     Ok(process)
-}
-
-fn create_default_init_process(argv: Vec<CString>, envp: Vec<CString>) -> Result<Arc<Process>> {
-    // Linux probes the fallback init executables in this order:
-    // <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1634>.
-    const DEFAULT_INIT_EXEC_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
-
-    let mut last_error = None;
-
-    for default_init_exec_path in DEFAULT_INIT_EXEC_PATHS {
-        // FIXME: Avoid cloning `argv` and `envp` for each fallback candidate.
-        match create_init_process(
-            default_init_exec_path,
-            with_init_argv0(default_init_exec_path, argv.clone()),
-            envp.clone(),
-        ) {
-            Ok(process) => return Ok(process),
-            Err(error) => last_error = Some(error),
-        }
-    }
-
-    Err(last_error.unwrap())
 }
 
 fn with_init_argv0(executable_path: &str, mut argv: Vec<CString>) -> Vec<CString> {

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -8,7 +8,7 @@ use super::{Process, Session};
 use crate::{
     fs::{
         thread_info::ThreadFsInfo,
-        vfs::path::{FsPath, MountNamespace, Path},
+        vfs::path::{Path, PathResolver},
     },
     prelude::*,
     process::{
@@ -25,16 +25,12 @@ use crate::{
 
 /// Creates and schedules the init process to run.
 pub fn spawn_init_process(
-    executable_path: Option<&str>,
+    path_resolver: PathResolver,
+    init_path: Path,
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let executable_path = executable_path.unwrap_or("/init");
-    let process = create_init_process(
-        executable_path,
-        with_init_argv0(executable_path, argv),
-        envp,
-    )?;
+    let process = create_init_process(path_resolver, init_path, argv, envp)?;
 
     // Linux starts the init process without placing it in a process group or session.
     // It joins one only after userspace first calls `setsid()`.
@@ -50,27 +46,16 @@ pub fn spawn_init_process(
     Ok(process)
 }
 
-fn with_init_argv0(executable_path: &str, mut argv: Vec<CString>) -> Vec<CString> {
-    // Linux prepends the init executable path as `argv[0]`.
-    // Reference: <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1491>.
-    argv.insert(0, CString::new(executable_path).unwrap());
-    argv
-}
-
 fn create_init_process(
-    executable_path: &str,
+    path_resolver: PathResolver,
+    init_path: Path,
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let fs = {
-        let fs_resolver = MountNamespace::get_init_singleton().new_path_resolver();
-        ThreadFsInfo::new(fs_resolver)
-    };
-    let fs_path = FsPath::try_from(executable_path)?;
-    let elf_path = fs.resolver().read().lookup(&fs_path)?;
+    let fs = ThreadFsInfo::new(path_resolver);
 
     let pid = allocate_posix_tid();
-    let vmar = VmarHandle::new(ProcessVm::new(elf_path.clone()));
+    let vmar = VmarHandle::new(ProcessVm::new(init_path.clone()));
     let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
     let oom_score_adj = 0;
@@ -87,7 +72,7 @@ fn create_init_process(
         user_ns,
     );
 
-    let init_task = create_init_task(pid, &init_proc, fs, vmar, elf_path, argv, envp)?;
+    let init_task = create_init_task(pid, &init_proc, fs, vmar, init_path, argv, envp)?;
     init_proc.tasks().lock().insert(init_task).unwrap();
 
     Ok(init_proc)

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -139,7 +139,7 @@ fn first_kthread() {
 
     INIT_PROCESS.call_once(|| {
         let karg = INIT_PROC_ARGS.get().unwrap();
-        let init_path = INIT_PATH.get().map(|s| s.as_str());
+        let init_path = RDINIT_PATH.get().map(|s| s.as_str());
         spawn_init_process(init_path, karg.argv().to_vec(), karg.envp().to_vec())
             .expect("Failed to run the init process")
     });
@@ -170,5 +170,5 @@ pub(super) fn on_first_process_startup(ctx: &Context) {
     crate::fs::init_in_first_process(ctx);
 }
 
-static INIT_PATH: Once<String> = Once::new();
-aster_cmdline::define_kv_param!("init", INIT_PATH);
+static RDINIT_PATH: Once<String> = Once::new();
+aster_cmdline::define_kv_param!("rdinit", RDINIT_PATH);

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -29,15 +29,12 @@ pub fn spawn_init_process(
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let process = if let Some(executable_path) = executable_path {
-        create_init_process(
-            executable_path,
-            with_init_argv0(executable_path, argv),
-            envp,
-        )?
-    } else {
-        create_default_init_process(argv, envp)?
-    };
+    let executable_path = executable_path.unwrap_or("/init");
+    let process = create_init_process(
+        executable_path,
+        with_init_argv0(executable_path, argv),
+        envp,
+    )?;
 
     // Linux starts the init process without placing it in a process group or session.
     // It joins one only after userspace first calls `setsid()`.
@@ -51,28 +48,6 @@ pub fn spawn_init_process(
     process.run();
 
     Ok(process)
-}
-
-fn create_default_init_process(argv: Vec<CString>, envp: Vec<CString>) -> Result<Arc<Process>> {
-    // Linux probes the fallback init executables in this order:
-    // <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1634>.
-    const DEFAULT_INIT_EXEC_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
-
-    let mut last_error = None;
-
-    for default_init_exec_path in DEFAULT_INIT_EXEC_PATHS {
-        // FIXME: Avoid cloning `argv` and `envp` for each fallback candidate.
-        match create_init_process(
-            default_init_exec_path,
-            with_init_argv0(default_init_exec_path, argv.clone()),
-            envp.clone(),
-        ) {
-            Ok(process) => return Ok(process),
-            Err(error) => last_error = Some(error),
-        }
-    }
-
-    Err(last_error.unwrap())
 }
 
 fn with_init_argv0(executable_path: &str, mut argv: Vec<CString>) -> Vec<CString> {

--- a/osdk/src/config/test/OSDK.toml.full
+++ b/osdk/src/config/test/OSDK.toml.full
@@ -12,7 +12,7 @@ boot.kcmd_args = [
     "HOME=/",
     "USER=root",
     "PATH=/bin:/benchmark",
-    "init=/usr/bin/busybox",
+    "rdinit=/usr/bin/busybox",
 ]
 boot.init_args = ["sh", "-l"]
 boot.initramfs = "/tmp/osdk_test_file"

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -18,7 +18,8 @@ NIXPKGS_CACHE_TTL := 2592000 # In seconds
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 BUILD_DIR := $(CUR_DIR)/build
-INITRAMFS := $(BUILD_DIR)/initramfs
+INITRAMFS_DIR := $(BUILD_DIR)/initramfs
+ROOTFS_IMAGE := $(BUILD_DIR)/rootfs.img
 INITRAMFS_SKIP_GZIP ?= 0
 ifeq ($(INITRAMFS_SKIP_GZIP),1)
 INITRAMFS_IMAGE := $(BUILD_DIR)/initramfs.cpio
@@ -54,52 +55,68 @@ ifeq ($(VERBOSE), 0)
 NIX_QUIET = --quiet -Q
 endif
 
-.PHONY: all
-all: build
+BOOT_IMAGE_NIX_ARGS := \
+	--tarball-ttl $(NIXPKGS_CACHE_TTL) \
+	--argstr target $(TARGET_ARCH) \
+	--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
+	--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
+	--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
+	--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
+	--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
+	--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
+	--argstr dnsServer ${DNS_SERVER} \
+	--arg smp $(SMP)
 
-.PHONY: build
+.PHONY: initramfs-boot-images
 ifeq ($(TARGET_ARCH), loongarch64)
-build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
+initramfs-boot-images: data-disk-images
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
-else ifeq ($(BUILD_XFSTESTS_IMAGES), true)
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
 else
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE)
+initramfs-boot-images: $(INITRAMFS_IMAGE) data-disk-images
+endif
+
+.PHONY: data-disk-images
+ifeq ($(TARGET_ARCH), loongarch64)
+data-disk-images: $(EXT2_IMAGE) $(EXFAT_IMAGE)
+else ifeq ($(BUILD_XFSTESTS_IMAGES), true)
+data-disk-images: $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
+else
+data-disk-images: $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE)
 endif
 
 .PHONY: $(INITRAMFS_IMAGE)
-$(INITRAMFS_IMAGE): $(INITRAMFS)
+$(INITRAMFS_IMAGE): $(INITRAMFS_DIR)
 	@nix-build \
-		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(TARGET_ARCH) \
-		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
-		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
-		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
-		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
-		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
-		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
-		--argstr dnsServer ${DNS_SERVER} \
+		$(BOOT_IMAGE_NIX_ARGS) \
 		--arg initramfsCompressed $(INITRAMFS_COMPRESSED) \
-		--arg smp $(SMP) \
 		--out-link $@ \
 		nix -A initramfs-image
 
-.PHONY: $(INITRAMFS)
-$(INITRAMFS):
+.PHONY: $(INITRAMFS_DIR)
+$(INITRAMFS_DIR):
 	@nix-build \
-		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
-		--argstr target $(TARGET_ARCH) \
-		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
-		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
-		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
-		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
-		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
-		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
-		--argstr dnsServer ${DNS_SERVER} \
-		--arg smp $(SMP) \
+		$(BOOT_IMAGE_NIX_ARGS) \
 		--out-link $@ \
 		nix -A initramfs
+
+.PHONY: rootfs-image
+rootfs-image: $(ROOTFS_IMAGE)
+
+.PHONY: rootfs-boot-images
+ifeq ($(TARGET_ARCH), loongarch64)
+rootfs-boot-images:
+	$(error Rootfs image is not supported for loongarch64)
+else
+rootfs-boot-images: rootfs-image data-disk-images
+endif
+
+.PHONY: $(ROOTFS_IMAGE)
+$(ROOTFS_IMAGE):
+	@nix-build \
+		$(BOOT_IMAGE_NIX_ARGS) \
+		--out-link $@ \
+		nix -A rootfs-image
 
 # Prebuild x86_64 packages
 x86_64_pkgs:

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -44,6 +44,7 @@ in rec {
     inherit initramfs;
     compressed = initramfsCompressed;
   };
+  rootfs-image = pkgs.callPackage ./rootfs-image.nix { inherit initramfs; };
 
   # Packages needed by host
   apacheHttpd = pkgs.apacheHttpd;

--- a/test/initramfs/nix/rootfs-image.nix
+++ b/test/initramfs/nix/rootfs-image.nix
@@ -1,0 +1,9 @@
+{ stdenvNoCC, pkgsBuildBuild, initramfs, }:
+stdenvNoCC.mkDerivation {
+  name = "rootfs-image";
+  nativeBuildInputs = with pkgsBuildBuild; [ e2fsprogs ];
+  buildCommand = ''
+    truncate -s 256M "$out"
+    mkfs.ext2 -b 4096 -d ${initramfs} -F "$out"
+  '';
+}

--- a/test/initramfs/src/regression/fs/isolation/pivot_root.c
+++ b/test/initramfs/src/regression/fs/isolation/pivot_root.c
@@ -62,13 +62,6 @@ FN_TEST(pivot_root)
 		 CHROOT_DIR, PIVOT_TARGET_DIR);
 	ensure_dir(pivot_target_full_path);
 
-	// Negative test: pivot_root should fail if the root mount is the rootfs mount.
-	// We skip this in Linux because common test environments (e.g., Docker) do not
-	// use rootfs as the root mount.
-#ifdef __asterinas__
-	TEST_ERRNO(syscall(SYS_pivot_root, CHROOT_DIR, CHROOT_DIR), EINVAL);
-#endif
-
 	TEST_SUCC(chroot(CHROOT_DIR));
 	TEST_SUCC(chdir("/"));
 

--- a/test/nixos/tests/containerization-and-virtualization/src/main.rs
+++ b/test/nixos/tests/containerization-and-virtualization/src/main.rs
@@ -96,7 +96,7 @@ fn qemu_tcg_run_aster(nixos_shell: &mut Session) -> Result<(), Error> {
     // Run a Asterinas kernel inside QEMU using the TCG software emulator.
     //
     // Use `grep -v /bin/echo` to filter out lines that affect matching, such as:
-    //   [EFI stub] Loaded the cmdline: "console=ttyS0 panic=-1 init=/bin/echo Entered userspace initrd=initrd"
+    //   [EFI stub] Loaded the cmdline: "console=ttyS0 panic=-1 rdinit=/bin/echo Entered userspace initrd=initrd"
     const CMD: &str = concat!(
         "qemu-system-$(uname -m) ",
         "-accel tcg ",
@@ -107,7 +107,7 @@ fn qemu_tcg_run_aster(nixos_shell: &mut Session) -> Result<(), Error> {
         "-initrd /run/current-system/initrd ",
         "-device isa-debug-exit,iobase=0xf4,iosize=0x04 ",
         "-nographic -no-reboot ",
-        "-append 'earlycon console=ttyS0 panic=-1 init=/bin/echo Entered userspace' ",
+        "-append 'earlycon console=ttyS0 panic=-1 rdinit=/bin/echo Entered userspace' ",
         "| grep -v /bin/echo"
     );
     nixos_shell.run_cmd_and_expect(CMD, "Entered userspace")?;

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -15,6 +15,7 @@
 #  - VIRTIOFS: "off" or "on";
 #  - VIRTIOFS_TAG: mount tag for virtio-fs device;
 #  - VIRTIOFS_SOCKET: vhost-user socket path for the virtio-fs server;
+#  - INITRAMFS: "on" or "off"; when "off", attach `rootfs.img` as an extra block device.
 #  - CONSOLE: "hvc0" to enable virtio console;
 #  - SMP: number of CPUs;
 #  - MEM: amount of memory, e.g. "8G";
@@ -69,12 +70,22 @@ else
     CONSOLE_ARGS="-serial chardev:mux"
 fi
 
+if [ "$INITRAMFS" = "off" ]; then
+    ROOTFS_DRIVE_ARGS="-drive if=none,format=raw,id=rootfs,file=./test/initramfs/build/rootfs.img"
+fi
+
 if [ "$1" = "riscv" ]; then
     # NOTE: The initramfs assumes that ext2.img, exfat.img, and ltp_dev.img appear as
     # `/dev/vda`, `/dev/vdb`, and `/dev/vdc`, respectively. RISC-V virtio-mmio
     # block devices are discovered in reverse command-line order, so list them
     # in the reverse of the desired device-node order.
+    # When booting without initramfs, `rootfs.img` is placed before these devices
+    # so that it is discovered after them as `/dev/vdd`.
     # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
+    if [ "$INITRAMFS" = "off" ]; then
+        ROOTFS_RISCV_DEVICE_ARGS="-device virtio-blk-device,drive=rootfs"
+    fi
+
     QEMU_ARGS="\
         -cpu rv64,svpbmt=true,zkr=true \
         -machine virt \
@@ -85,9 +96,11 @@ if [ "$1" = "riscv" ]; then
         -display none \
         -monitor chardev:mux \
         -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
+        $ROOTFS_DRIVE_ARGS \
         -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
         -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
         -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
+        $ROOTFS_RISCV_DEVICE_ARGS \
         -device virtio-blk-device,drive=x2 \
         -device virtio-blk-device,drive=x1 \
         -device virtio-blk-device,drive=x0 \
@@ -101,6 +114,9 @@ fi
 
 if [ "$1" = "tdx" ]; then
     TDX_OBJECT='{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "1", "port": "4050" } }'
+    if [ "$INITRAMFS" = "off" ]; then
+        ROOTFS_TDX_DEVICE_ARGS="-device virtio-blk-pci,bus=pcie.0,addr=0xb,drive=rootfs,serial=vrootfs,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off"
+    fi
 
     QEMU_ARGS="\
         -m ${MEM:-8G} \
@@ -116,9 +132,11 @@ if [ "$1" = "tdx" ]; then
         -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
         -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
         -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
+        $ROOTFS_DRIVE_ARGS \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=x2,serial=vltpdev,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
+        $ROOTFS_TDX_DEVICE_ARGS \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES \
         -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off \
         $NETDEV_ARGS \
@@ -149,6 +167,7 @@ COMMON_QEMU_ARGS="\
     -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
     -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
+    $ROOTFS_DRIVE_ARGS \
 "
 
 # Add xfstests drives when the selected conformance suite is `xfstests`.
@@ -172,6 +191,11 @@ if [ "$1" = "iommu" ]; then
     # TODO: Add support for enabling IOMMU on AMD platforms
 fi
 
+if [ "$INITRAMFS" = "off" ]; then
+    ROOTFS_MICROVM_DEVICE_ARGS="-device virtio-blk-device,drive=rootfs,serial=vrootfs"
+    ROOTFS_Q35_DEVICE_ARGS="-device virtio-blk-pci,bus=pcie.0,addr=0xc,drive=rootfs,serial=vrootfs,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA"
+fi
+
 if [ "$1" = "microvm" ]; then
     QEMU_ARGS="\
         $COMMON_QEMU_ARGS \
@@ -181,6 +205,7 @@ if [ "$1" = "microvm" ]; then
         -device virtio-blk-device,drive=x0,serial=vext2 \
         -device virtio-blk-device,drive=x1,serial=vexfat \
         -device virtio-blk-device,drive=x2,serial=vltpdev \
+        $ROOTFS_MICROVM_DEVICE_ARGS \
         -device virtio-keyboard-device \
         -device virtio-net-device,netdev=net01 \
         -device virtio-serial-device \
@@ -193,6 +218,7 @@ else
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=x2,serial=vltpdev,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        $ROOTFS_Q35_DEVICE_ARGS \
         -object rng-random,id=rng0,filename=/dev/urandom \
         -device virtio-rng-pci,bus=pcie.0,addr=0x9,disable-legacy=on,disable-modern=off,rng=rng0,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \


### PR DESCRIPTION
This PR adds Linux-compatible `root` parameter support for selecting the `initramfs` entry point and mounting a root filesystem.

Main changes:
  - Correct the previous `init=` usage to `rdinit=` for selecting the initramfs entry point, matching Linux semantics.
  - Resolve Linux-style `/dev/...` root device specs through block-device lookup before `/dev` is mounted, aligning with Linux where `root=/dev/...` is parsed before `devtmpfs` is mounted.
  - Document the supported `root`-related kernel parameters.
  - Clean up the NixOS init handoff command line by relying on the default `/init` entry point in `initramfs` instead of spelling it out explicitly.