### PR TITLE
Support SiFive UART console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ name = "aster-uart"
 version = "0.1.0"
 dependencies = [
  "aster-console",
+ "aster-util",
  "component",
  "fdt",
  "inherit-methods-macro",

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ COVERAGE ?= 0
 # Asterinas will automatically fall back to tty0 if hvc0 is not available.
 # Note that currently the virtual terminal (tty0) can only work with
 # linux-efi-handover64 and linux-efi-pe64 boot protocol.
+ifeq ($(SCHEME), sifive_u)
+CONSOLE ?= ttyS0
+else
 CONSOLE ?= hvc0
+endif
 # End of global build options.
 
 # GDB debugging and profiling options.

--- a/kernel/comps/uart/Cargo.toml
+++ b/kernel/comps/uart/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [dependencies]
 aster-console.workspace = true
+aster-util.workspace = true
 component.workspace = true
 inherit-methods-macro.workspace = true
 ostd.workspace = true

--- a/kernel/comps/uart/src/arch/riscv/mod.rs
+++ b/kernel/comps/uart/src/arch/riscv/mod.rs
@@ -3,11 +3,17 @@
 use ostd::arch::boot::DEVICE_TREE;
 
 mod ns16550a;
+mod sifive;
 
 pub(super) fn init() {
     let device_tree = DEVICE_TREE.get().unwrap();
 
-    if let Some(ns16550a_node) = device_tree.find_compatible(&["ns16550a"]) {
+    if let Some(ns16550a_node) = device_tree.find_compatible(&ns16550a::FDT_COMPATIBLES) {
         ns16550a::init(ns16550a_node);
+        return;
+    }
+
+    if let Some(sifive_node) = device_tree.find_compatible(&sifive::FDT_COMPATIBLES) {
+        sifive::init(sifive_node);
     }
 }

--- a/kernel/comps/uart/src/arch/riscv/ns16550a.rs
+++ b/kernel/comps/uart/src/arch/riscv/ns16550a.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+//! NS16550A UART console support.
+
 use alloc::string::ToString;
 
 use fdt::node::FdtNode;
@@ -17,6 +19,8 @@ use crate::{
     CONSOLE_NAME,
     console::{Uart, UartConsole},
 };
+
+pub(super) const FDT_COMPATIBLES: [&str; 1] = ["ns16550a"];
 
 /// Access to serial registers via `IoMem`.
 struct SerialAccess {
@@ -47,7 +51,11 @@ pub(super) fn init(fdt_node: FdtNode) {
     };
 
     let reg_addr = reg.starting_address as usize;
-    let Ok(io_mem) = IoMem::acquire(reg_addr..reg_addr + reg_size) else {
+    let Some(reg_end) = reg_addr.checked_add(reg_size) else {
+        ostd::info!("Invalid I/O memory range found in NS16550A node");
+        return;
+    };
+    let Ok(io_mem) = IoMem::acquire(reg_addr..reg_end) else {
         ostd::info!("I/O memory is not available for NS16550A");
         return;
     };

--- a/kernel/comps/uart/src/arch/riscv/sifive.rs
+++ b/kernel/comps/uart/src/arch/riscv/sifive.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! SiFive UART console support.
+
+use alloc::string::ToString;
+
+use aster_util::{field_ptr, safe_ptr::SafePtr};
+use fdt::node::FdtNode;
+use ostd::{
+    arch::irq::{self, InterruptSourceInFdt, MappedIrqLine},
+    io::IoMem,
+    irq::IrqLine,
+    sync::{LocalIrqDisabled, SpinLock},
+};
+use spin::Once;
+
+use crate::{
+    CONSOLE_NAME,
+    console::{Uart, UartConsole, UartMut},
+};
+
+pub(super) const FDT_COMPATIBLES: [&str; 2] = ["sifive,uart0", "sifive,fu540-c000-uart"];
+
+/// IRQ line for UART serial.
+static IRQ_LINE: Once<MappedIrqLine> = Once::new();
+
+pub(super) fn init(fdt_node: FdtNode) {
+    let Some(reg) = fdt_node.reg().and_then(|mut regs| regs.next()) else {
+        ostd::info!("Failed to read 'reg' property from SiFive UART node");
+        return;
+    };
+    let Some(reg_size) = reg.size else {
+        ostd::info!("Incomplete 'reg' property found in SiFive UART node");
+        return;
+    };
+
+    let reg_addr = reg.starting_address as usize;
+    let Some(reg_end) = reg_addr.checked_add(reg_size) else {
+        ostd::info!("Invalid I/O memory range found in SiFive UART node");
+        return;
+    };
+    let Ok(io_mem) = IoMem::acquire(reg_addr..reg_end) else {
+        ostd::info!("I/O memory is not available for SiFive UART");
+        return;
+    };
+
+    let Some(intr_parent) = fdt_node
+        .property("interrupt-parent")
+        .and_then(|prop| prop.as_usize())
+    else {
+        ostd::info!("Failed to read 'interrupt-parent' property from SiFive UART node");
+        return;
+    };
+    let Some(intr) = fdt_node.interrupts().and_then(|mut intrs| intrs.next()) else {
+        ostd::info!("Failed to read 'interrupts' property from SiFive UART node");
+        return;
+    };
+
+    let Ok(mut irq_line) = IrqLine::alloc().and_then(|irq_line| {
+        irq::IRQ_CHIP.get().unwrap().map_fdt_pin_to(
+            InterruptSourceInFdt {
+                interrupt_parent: intr_parent as u32,
+                interrupt: intr as u32,
+            },
+            irq_line,
+        )
+    }) else {
+        ostd::info!("IRQ line is not available for SiFive UART");
+        return;
+    };
+
+    let clock_hz = fdt_node
+        .property("clock-frequency")
+        .and_then(|prop| prop.as_usize())
+        .and_then(|freq| u32::try_from(freq).ok())
+        // FIXME: Real FU540 device trees may provide the UART clock through
+        // a PRCI clock provider instead of a direct `clock-frequency` property.
+        .unwrap_or(SifiveUart::DEFAULT_CLOCK_HZ);
+
+    let mut uart: SpinLock<SifiveUart, LocalIrqDisabled> = SpinLock::new(SifiveUart::new(io_mem));
+    uart.get_mut().init(clock_hz);
+
+    let uart_console = UartConsole::new(uart);
+
+    aster_console::register_device(CONSOLE_NAME.to_string(), uart_console.clone());
+
+    let cloned_uart_console = uart_console.clone();
+    irq_line.on_active(move |_| cloned_uart_console.trigger_input_callbacks());
+    IRQ_LINE.call_once(move || irq_line);
+    uart_console.uart().flush();
+
+    ostd::info!("Registered SiFive UART as a console");
+}
+
+struct SifiveUart {
+    registers: SafePtr<Registers, IoMem>,
+}
+
+impl SifiveUart {
+    const DEFAULT_CLOCK_HZ: u32 = 500_000_000;
+    const TARGET_BAUD: u32 = 115_200;
+
+    const TXDATA_FULL: u32 = 1 << 31;
+    const RXDATA_EMPTY: u32 = 1 << 31;
+    const TXCTRL_TXEN: u32 = 1;
+    const RXCTRL_RXEN: u32 = 1;
+    const IE_RXWM: u32 = 1 << 1;
+
+    fn new(io_mem: IoMem) -> Self {
+        Self {
+            registers: SafePtr::new(io_mem, 0),
+        }
+    }
+
+    fn init(&mut self, clock_hz: u32) {
+        let divisor = clock_hz
+            .checked_div(Self::TARGET_BAUD)
+            .and_then(|quotient| quotient.checked_sub(1))
+            .unwrap_or(0);
+
+        field_ptr!(&self.registers, Registers, div)
+            .write_once(&divisor)
+            .unwrap();
+        field_ptr!(&self.registers, Registers, txctrl)
+            .write_once(&Self::TXCTRL_TXEN)
+            .unwrap();
+        field_ptr!(&self.registers, Registers, rxctrl)
+            .write_once(&Self::RXCTRL_RXEN)
+            .unwrap();
+        field_ptr!(&self.registers, Registers, ie)
+            .write_once(&Self::IE_RXWM)
+            .unwrap();
+    }
+}
+
+impl UartMut for SifiveUart {
+    fn send_byte(&mut self, byte: u8) {
+        let txdata = field_ptr!(&self.registers, Registers, txdata);
+        while txdata.read_once().unwrap() & Self::TXDATA_FULL != 0 {
+            core::hint::spin_loop();
+        }
+
+        txdata.write_once(&u32::from(byte)).unwrap();
+    }
+
+    fn recv_byte(&mut self) -> Option<u8> {
+        let rxdata = field_ptr!(&self.registers, Registers, rxdata)
+            .read_once()
+            .unwrap();
+        if rxdata & Self::RXDATA_EMPTY != 0 {
+            return None;
+        }
+
+        Some(rxdata as u8)
+    }
+}
+
+// Register layout and bit definitions are from the SiFive FU540-C000 Manual,
+// Chapter 13 "Universal Asynchronous Receiver/Transmitter (UART)".
+// Reference: <https://pdos.csail.mit.edu/6.828/2025/readings/FU540-C000-v1.0.pdf>
+#[repr(C)]
+struct Registers {
+    txdata: u32,
+    rxdata: u32,
+    txctrl: u32,
+    rxctrl: u32,
+    ie: u32,
+    _ip: u32,
+    div: u32,
+}

--- a/kernel/comps/uart/src/console.rs
+++ b/kernel/comps/uart/src/console.rs
@@ -86,7 +86,16 @@ pub(super) trait Uart {
     fn flush(&self);
 }
 
-impl<A: Ns16550aAccess> Uart for SpinLock<Ns16550aUart<A>, LocalIrqDisabled> {
+/// A trait that abstracts byte-wise UART device operations.
+pub(super) trait UartMut {
+    /// Sends one byte to UART.
+    fn send_byte(&mut self, byte: u8);
+
+    /// Receives one byte from UART.
+    fn recv_byte(&mut self) -> Option<u8>;
+}
+
+impl<T: UartMut> Uart for SpinLock<T, LocalIrqDisabled> {
     fn send(&self, buf: &[u8]) {
         let mut uart = self.lock();
 
@@ -94,9 +103,9 @@ impl<A: Ns16550aAccess> Uart for SpinLock<Ns16550aUart<A>, LocalIrqDisabled> {
             // TODO: This is termios-specific behavior and should be part of the TTY implementation
             // instead of the serial console implementation. See the ONLCR flag for more details.
             if *byte == b'\n' {
-                uart.send(b'\r');
+                uart.send_byte(b'\r');
             }
-            uart.send(*byte);
+            uart.send_byte(*byte);
         }
     }
 
@@ -104,7 +113,7 @@ impl<A: Ns16550aAccess> Uart for SpinLock<Ns16550aUart<A>, LocalIrqDisabled> {
         let mut uart = self.lock();
 
         for (i, byte) in buf.iter_mut().enumerate() {
-            let Some(recv_byte) = uart.recv() else {
+            let Some(recv_byte) = uart.recv_byte() else {
                 return i;
             };
             *byte = recv_byte;
@@ -116,13 +125,23 @@ impl<A: Ns16550aAccess> Uart for SpinLock<Ns16550aUart<A>, LocalIrqDisabled> {
     fn flush(&self) {
         let mut uart = self.lock();
 
-        while uart.recv().is_some() {}
+        while uart.recv_byte().is_some() {}
     }
 }
 
 #[inherit_methods(from = "(**self)")]
-impl<A: Ns16550aAccess> Uart for &SpinLock<Ns16550aUart<A>, LocalIrqDisabled> {
+impl<T: UartMut> Uart for &SpinLock<T, LocalIrqDisabled> {
     fn send(&self, buf: &[u8]);
     fn recv(&self, buf: &mut [u8]) -> usize;
     fn flush(&self);
+}
+
+impl<A: Ns16550aAccess> UartMut for Ns16550aUart<A> {
+    fn send_byte(&mut self, byte: u8) {
+        self.send(byte);
+    }
+
+    fn recv_byte(&mut self) -> Option<u8> {
+        self.recv()
+    }
 }

--- a/test/initramfs/src/init
+++ b/test/initramfs/src/init
@@ -23,8 +23,14 @@ mount -t sysfs none /sys
 mount -t proc none /proc
 mount -t cgroup2 none /sys/fs/cgroup
 mount -t configfs none /sys/kernel/config
-mount -t ext2 /dev/vda /ext2
-mount -t exfat /dev/vdb /exfat
+
+if [ -b /dev/vda ]; then
+    mount -t ext2 /dev/vda /ext2
+fi
+
+if [ -b /dev/vdb ]; then
+    mount -t exfat /dev/vdb /exfat
+fi
 
 # When the init process starts,
 # it does not have a process group, session, or controlling terminal.


### PR DESCRIPTION
## Summary
This PR improves Asterinas support for QEMU's `sifive_u` machine, which emulates the SiFive HiFive Unleashed board based on the FU540-C000 SoC.
This PR is also a reimplementation of the unfinished work in #2529 , with the support and under the framework of #2837 .

## Background
Asterinas already had RISC-V boot support and NS16550A UART support, but QEMU's `sifive_u` machine exposes a SiFive UART rather than an NS16550A-compatible UART. As a result, the kernel could print early output and the Asterinas banner, but the boot flow would not reliably reach an interactive shell through the expected serial console path.

## References
- [QEMU RISC-V board model documentation](https://www.qemu.org/docs/master/system/target-riscv.html#choosing-a-board-model)
- [QEMU `sifive_u` board documentation](https://www.qemu.org/docs/master/system/riscv/sifive_u.html)
- [SiFive HiFive Unleashed documentation](https://www.sifive.com/boards/hifive-unleashed#documentation)
- [SiFive FU540-C000 Manual](https://pdos.csail.mit.edu/6.828/2025/readings/FU540-C000-v1.0.pdf)

The FU540-C000 manual describes the UART instances, MMIO register layout, TX/RX control registers, interrupt enable/pending registers, and baud-rate divisor register. The implementation follows those register definitions for `txdata`, `rxdata`, `txctrl`, `rxctrl`, `ie`, `ip`, and `div`.
The QEMU `sifive_u` documentation also notes that QEMU generates a DTB for the guest and that guest software should discover devices through that DTB. This PR follows that model by discovering the UART from the device tree rather than hardcoding its MMIO address.

## Main Behavior
- Discover a SiFive UART from the RISC-V device tree.
- Support both `sifive,uart0` and `sifive,fu540-c000-uart` compatible strings.
- Register the SiFive UART as the kernel serial console.
- Enable RX interrupts so the interactive shell can receive input.
- Use `ttyS0` as the default console for the `sifive_u` scheme.
- Avoid expensive initramfs gzip decompression for `sifive_u`.
- Make optional test block-device mounts conditional.

## Testing
The PR is validated by the following check:
```
make run_kernel TARGET_ARCH=riscv64 SCHEME=sifive_u
```
Before this PR, the kernel boot halts without interactive shell prompt. Now, the kernel boots on QEMU `sifive_u` scheme normally.
The following checks have been made:
```
sh -n test/initramfs/src/init
cargo fmt --check
CARGO_TARGET_DIR=/tmp/asterinas-cargo-target cargo check -p aster-uart --target riscv64imac-unknown-none-elf
make run_kernel TARGET_ARCH=riscv64 SCHEME=riscv RELEASE=1 AUTO_TEST=boot
```
The generic RISC-V boot test was included to make sure the existing NS16550A-based riscv scheme still works after adding the SiFive-specific UART path.

## Gaps and Future Work
This PR enables the current QEMU sifive_u boot path and interactive serial console, but there are still follow-up items for fuller HiFive Unleashed / FU540 support:
- The UART clock handling is still incomplete for real FU540-style device trees. The driver reads a direct `clock-frequency` property when available, but real FU540 device trees may provide the UART clock through the PRCI clock provider instead. A future PR should parse the `clocks` phandle or add proper PRCI clock support.
- The `500 MHz` UART clock fallback is suitable for the current HiFive Unleashed/QEMU path, but it should not be treated as a general SiFive UART clock solution.
- Exiting the init shell still reaches the current poweroff failure path on `sifive_u`. This PR intentionally does not work around that by forcing reboot; proper shutdown support should be addressed separately.
- This PR focuses on the serial console path. Other HiFive Unleashed peripherals, such as SD card, Ethernet, SPI, GPIO, DMA, and full PRCI support, remain future work.