### PR TITLE
Make getsockopt support short integer optlen buffers

### DIFF
--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -52,13 +52,10 @@ macro_rules! impl_read_write_for_32bit_type {
 
         impl WriteToUser for $pod_ty {
             fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-                let write_len = size_of::<$pod_ty>();
+                let bytes = self.to_ne_bytes();
+                let write_len = bytes.len().min(max_len as usize);
 
-                if (max_len as usize) < write_len {
-                    return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-                }
-
-                crate::context::current_userspace!().write_val(addr, self)?;
+                current_userspace!().write_bytes(addr, &bytes[..write_len])?;
                 Ok(write_len)
             }
         }
@@ -123,18 +120,14 @@ impl WriteToUser for IpTtl {
 
 impl WriteToUser for Option<Error> {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = size_of::<i32>();
-
-        if (max_len as usize) < write_len {
-            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-        }
-
         let val = match self {
             None => 0i32,
             Some(error) => error.error() as i32,
         };
+        let bytes = val.to_ne_bytes();
+        let write_len = bytes.len().min(max_len as usize);
 
-        current_userspace!().write_val(addr, &val)?;
+        current_userspace!().write_bytes(addr, &bytes[..write_len])?;
         Ok(write_len)
     }
 }

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -122,6 +122,35 @@ FN_TEST(socket_error)
 }
 END_TEST()
 
+FN_TEST(short_getsockopt_int)
+{
+	int option = 1;
+	unsigned char keepalive[sizeof(int)] = { 0xaa, 0xaa, 0xaa, 0xaa };
+	unsigned char expected[sizeof(int)];
+	int expected_value = 1;
+	int error = 0x12345678;
+	socklen_t keepalive_len = 2;
+	socklen_t error_len = 0;
+
+	memcpy(expected, &expected_value, sizeof(expected));
+
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &option,
+			     sizeof(option)));
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, keepalive,
+			    &keepalive_len),
+		 keepalive_len == 2);
+	TEST_RES(memcmp(keepalive, expected, keepalive_len), _ret == 0);
+	TEST_RES(0, keepalive[2] == 0xaa && keepalive[3] == 0xaa);
+
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_ERROR, &error,
+			    &error_len),
+		 error_len == 0 && error == 0x12345678);
+	TEST_ERRNO(setsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &option,
+			      2),
+		   EINVAL);
+}
+END_TEST()
+
 FN_TEST(nagle)
 {
 	int option = 1;


### PR DESCRIPTION
Title: Make getsockopt support short integer optlen buffers

Branch: fix-getsockopt-partial-optlen

Summary:
- Allows integer-valued getsockopt options to return as many bytes as the caller-provided optlen can hold, matching Linux behavior for short buffers.
- Keeps setsockopt validation strict, so undersized input buffers still return EINVAL.
- Adds regression coverage for a two-byte SO_KEEPALIVE getsockopt buffer, a zero-length SO_ERROR buffer, and the unchanged undersized setsockopt failure.

Test plan:
- `git diff --check`
- `gcc -fsyntax-only -Wall -Wextra -Itest/initramfs/src/regression test/initramfs/src/regression/network/sockoption.c`
- `gcc -Wall -Wextra -Itest/initramfs/src/regression test/initramfs/src/regression/network/sockoption.c -o /tmp/asterinas_sockoption_regression`
- `/tmp/asterinas_sockoption_regression`

Pending upstream validation:
- `make kernel` and VM regression testing are blocked locally by Docker Hub TLS EOF when pulling `asterinas/asterinas:0.18.0-20260618`.
- Pinned Rust toolchain `nightly-2026-04-03` installation is blocked locally by TLS EOF from `static.rust-lang.org`.
