### PR TITLE
Support BLKPBSZGET for block devices

### DIFF
--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -87,6 +87,9 @@ mod ioctl_defs {
     /// ioctl must return that larger value. Otherwise user programs will align
     /// correctly for the device but still hit `EINVAL` at the filesystem.
     pub(super) type BlkGetSectorSize = ioc!(BLKSSZGET, 0x12, 104, NoData);
+
+    /// Returns the physical block size of the block device.
+    pub(super) type BlkGetPhysicalBlockSize = ioc!(BLKPBSZGET, 0x12, 123, NoData);
 }
 
 /// Represents a block device inode in the filesystem.
@@ -213,6 +216,13 @@ impl PerOpenFileOps for OpenBlockFile {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {
+            _cmd @ BlkGetPhysicalBlockSize => {
+                // Block devices currently expose a single effective I/O granularity, so use the
+                // same value as the reported logical block size.
+                let physical_block_size = SECTOR_SIZE.max(BLOCK_SIZE) as i32;
+                current_userspace!().write_val(raw_ioctl.arg(), &physical_block_size)?;
+                Ok(0)
+            }
             _cmd @ BlkGetSectorSize => {
                 // TODO: Query the per-device logical block size once block device metadata
                 // exposes it. For now, report the effective minimum I/O granularity enforced

--- a/test/initramfs/src/regression/io/file_io/block_device.c
+++ b/test/initramfs/src/regression/io/file_io/block_device.c
@@ -72,6 +72,27 @@ FN_TEST(seek_end_matches_block_device_size)
 }
 END_TEST()
 
+// Verifies that block devices report Linux-compatible logical and physical
+// block sizes.
+FN_TEST(block_size_ioctls)
+{
+	int fd;
+	int logical_sector_size = 0;
+	int physical_block_size = 0;
+
+	fd = TEST_SUCC(open_block_device());
+
+	TEST_SUCC(ioctl(fd, BLKSSZGET, &logical_sector_size));
+	TEST_RES(0, logical_sector_size > 0 &&
+			    logical_sector_size % SECTOR_SIZE == 0);
+	TEST_SUCC(ioctl(fd, BLKPBSZGET, &physical_block_size));
+	TEST_RES(0, physical_block_size >= logical_sector_size &&
+			    physical_block_size % logical_sector_size == 0);
+
+	TEST_SUCC(close_block_device(fd));
+}
+END_TEST()
+
 // Verifies that short and non-sector-aligned block-device reads return the
 // requested byte range instead of leaking sector-sized read internals.
 FN_TEST(short_unaligned_pread_matches_sector_bytes)


### PR DESCRIPTION
Title: Support BLKPBSZGET for block devices

Branch: fix-blkpbszget

Issue context:
- Addresses the missing BLKPBSZGET ioctl from the block-device compatibility gaps discussed in asterinas/asterinas#3211.

Summary:
- Adds BLKPBSZGET dispatch beside the existing BLKSSZGET and BLKGETSIZE64 handling.
- Reports the effective physical block granularity as `max(SECTOR_SIZE, BLOCK_SIZE)` until per-device physical block-size metadata is exposed.
- Adds a regression test that checks BLKSSZGET and BLKPBSZGET both succeed and that physical block size is a positive multiple of logical sector size.

Test plan:
- `git diff --check`
- `gcc -fsyntax-only -Wall -Wextra -Itest/initramfs/src/regression test/initramfs/src/regression/io/file_io/block_device.c`

Pending upstream validation:
- `make kernel` and VM regression testing are blocked locally by Docker Hub TLS EOF when pulling `asterinas/asterinas:0.18.0-20260618`.
- Pinned Rust toolchain `nightly-2026-04-03` installation is blocked locally by TLS EOF from `static.rust-lang.org`.
