### PR TITLE
Prune stale wait-queue wakers during enqueue

### DIFF
--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -4,7 +4,7 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use super::{LocalIrqDisabled, SpinLock};
-use crate::task::{scheduler, Task};
+use crate::task::{Task, scheduler};
 
 const STALE_WAKER_PRUNE_THRESHOLD: usize = 1024;
 

--- a/ostd/src/sync/wait.rs
+++ b/ostd/src/sync/wait.rs
@@ -4,7 +4,9 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use super::{LocalIrqDisabled, SpinLock};
-use crate::task::{Task, scheduler};
+use crate::task::{scheduler, Task};
+
+const STALE_WAKER_PRUNE_THRESHOLD: usize = 1024;
 
 // # Explanation on the memory orders
 //
@@ -95,9 +97,10 @@ impl WaitQueue {
         loop {
             let mut wakers = self.wakers.lock();
             let Some(waker) = wakers.pop_front() else {
+                self.sync_num_wakers(&wakers);
                 return false;
             };
-            self.num_wakers.fetch_sub(1, Ordering::Release);
+            self.sync_num_wakers(&wakers);
             // Avoid holding lock when calling `wake_up`
             drop(wakers);
 
@@ -119,9 +122,10 @@ impl WaitQueue {
         loop {
             let mut wakers = self.wakers.lock();
             let Some(waker) = wakers.pop_front() else {
+                self.sync_num_wakers(&wakers);
                 break;
             };
-            self.num_wakers.fetch_sub(1, Ordering::Release);
+            self.sync_num_wakers(&wakers);
             // Avoid holding lock when calling `wake_up`
             drop(wakers);
 
@@ -144,8 +148,29 @@ impl WaitQueue {
     #[doc(hidden)]
     pub fn enqueue(&self, waker: Arc<Waker>) {
         let mut wakers = self.wakers.lock();
+        Self::prune_closed_front_wakers(&mut wakers);
+        if wakers.len() >= STALE_WAKER_PRUNE_THRESHOLD {
+            Self::prune_closed_wakers(&mut wakers);
+        }
         wakers.push_back(waker);
-        self.num_wakers.fetch_add(1, Ordering::Acquire);
+        self.sync_num_wakers(&wakers);
+    }
+
+    fn prune_closed_front_wakers(wakers: &mut VecDeque<Arc<Waker>>) {
+        while wakers.front().is_some_and(|waker| waker.is_closed()) {
+            wakers.pop_front();
+        }
+    }
+
+    fn prune_closed_wakers(wakers: &mut VecDeque<Arc<Waker>>) {
+        wakers.retain(|waker| !waker.is_closed());
+    }
+
+    fn sync_num_wakers(&self, wakers: &VecDeque<Arc<Waker>>) {
+        self.num_wakers.store(
+            wakers.len().try_into().unwrap_or(u32::MAX),
+            Ordering::Release,
+        );
     }
 }
 
@@ -280,6 +305,10 @@ impl Waker {
         // the memory order explanation at the top of the file for details.
         let _ = self.has_woken.swap(true, Ordering::Acquire);
     }
+
+    fn is_closed(&self) -> bool {
+        self.has_woken.load(Ordering::Acquire)
+    }
 }
 
 #[cfg(ktest)]
@@ -324,6 +353,43 @@ mod test {
         queue_wake(|queue| {
             queue.wake_all();
         });
+    }
+
+    #[ktest]
+    fn queue_prunes_closed_front_wakers_on_enqueue() {
+        let queue = WaitQueue::new();
+
+        let (waiter, waker) = Waiter::new_pair();
+        queue.enqueue(waker);
+        drop(waiter);
+
+        assert_eq!(queue.num_wakers.load(Ordering::Acquire), 1);
+
+        let (_live_waiter, live_waker) = Waiter::new_pair();
+        queue.enqueue(live_waker);
+
+        assert_eq!(queue.num_wakers.load(Ordering::Acquire), 1);
+        assert!(queue.wake_one());
+        assert!(queue.is_empty());
+    }
+
+    #[ktest]
+    fn queue_prunes_closed_wakers_above_threshold() {
+        let queue = WaitQueue::new();
+
+        let (_live_waiter, live_waker) = Waiter::new_pair();
+        queue.enqueue(live_waker);
+
+        for _ in 0..(STALE_WAKER_PRUNE_THRESHOLD * 2) {
+            let (waiter, waker) = Waiter::new_pair();
+            queue.enqueue(waker);
+            drop(waiter);
+        }
+
+        let num_wakers = queue.num_wakers.load(Ordering::Acquire);
+        assert!(num_wakers > 0);
+        assert!(num_wakers <= STALE_WAKER_PRUNE_THRESHOLD as u32 + 1);
+        assert!(queue.wake_one());
     }
 
     #[ktest]


### PR DESCRIPTION
Title: Prune stale wait-queue wakers during enqueue

Branch: fix-waitqueue-stale-wakers

Issue context:
- Targets asterinas/asterinas#3283, where interrupted flock/fcntl waiters can leave closed wakers queued indefinitely.

Summary:
- Prunes closed wakers from the front of the queue on enqueue.
- Performs a full closed-waker prune once the queue reaches a conservative threshold, preventing stale wakers from growing without bound behind a live waiter.
- Synchronizes the fast-path waker count from the actual queue length after queue mutations.
- Adds ktests for front stale-waker pruning and bounded stale-waker accumulation above the prune threshold.

Test plan:
- `git diff --check`
- `rustfmt +nightly-2025-01-18 --edition 2021 --check ostd/src/sync/wait.rs`

Additional attempted validation:
- `cargo +nightly-2025-01-18 check -p ostd --lib` fails before reaching this change because upstream code uses newer let-chain syntax.
- `cargo +nightly-2025-05-20 check -p ostd --lib` fails before reaching this change because `zerocopy` requires a newer compiler for AVX-512 stdarch items.

Pending upstream validation:
- Pinned Rust toolchain `nightly-2026-04-03` installation is blocked locally by TLS EOF from `static.rust-lang.org`.
- `make kernel` and ktest execution are blocked locally by Docker Hub TLS EOF when pulling `asterinas/asterinas:0.18.0-20260618`.
