### PR TITLE
Add /proc/[pid]/limits

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/limits.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/limits.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::ResourceType,
+    thread::Thread,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/limits` and `/proc/[pid]/limits`.
+pub struct LimitsFileOps(TidDirOps);
+
+struct LimitSpec {
+    resource: ResourceType,
+    name: &'static str,
+    unit: &'static str,
+}
+
+const LIMIT_SPECS: &[LimitSpec] = &[
+    LimitSpec {
+        resource: ResourceType::RLIMIT_CPU,
+        name: "Max cpu time",
+        unit: "seconds",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_FSIZE,
+        name: "Max file size",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_DATA,
+        name: "Max data size",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_STACK,
+        name: "Max stack size",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_CORE,
+        name: "Max core file size",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_RSS,
+        name: "Max resident set",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_NPROC,
+        name: "Max processes",
+        unit: "processes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_NOFILE,
+        name: "Max open files",
+        unit: "files",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_MEMLOCK,
+        name: "Max locked memory",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_AS,
+        name: "Max address space",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_LOCKS,
+        name: "Max file locks",
+        unit: "locks",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_SIGPENDING,
+        name: "Max pending signals",
+        unit: "signals",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_MSGQUEUE,
+        name: "Max msgqueue size",
+        unit: "bytes",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_NICE,
+        name: "Max nice priority",
+        unit: "",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_RTPRIO,
+        name: "Max realtime priority",
+        unit: "",
+    },
+    LimitSpec {
+        resource: ResourceType::RLIMIT_RTTIME,
+        name: "Max realtime timeout",
+        unit: "us",
+    },
+];
+
+impl LimitsFileOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3332>
+        ProcFile::new(Self(dir.clone()), parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for LimitsFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        writeln!(
+            printer,
+            "{:<25} {:<20} {:<20} Units",
+            "Limit", "Soft Limit", "Hard Limit"
+        )?;
+        for spec in LIMIT_SPECS {
+            let rlimit = process
+                .resource_limits()
+                .get_rlimit(spec.resource)
+                .get_raw_rlimit();
+            write!(printer, "{:<25} ", spec.name)?;
+            write_limit_value(&mut printer, rlimit.cur)?;
+            write!(printer, " ")?;
+            write_limit_value(&mut printer, rlimit.max)?;
+            writeln!(printer, " {}", spec.unit)?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+}
+
+fn write_limit_value(printer: &mut VmPrinter, value: u64) -> Result<()> {
+    if value == u64::MAX {
+        write!(printer, "{:<20}", "unlimited")?;
+    } else {
+        write!(printer, "{:<20}", value)?;
+    }
+    Ok(())
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -9,7 +9,7 @@ use crate::{
             pid::task::{
                 auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
                 comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
+                gid_map::GidMapFileOps, limits::LimitsFileOps, maps::MapsFileOps, mem::MemFileOps,
                 mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
                 ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
                 status::StatusFileOps, uid_map::UidMapFileOps,
@@ -35,6 +35,7 @@ mod environ;
 mod exe;
 mod fd;
 mod gid_map;
+mod limits;
 mod maps;
 mod mem;
 mod mountinfo;
@@ -113,6 +114,7 @@ impl TidDirOps {
             FdDirOps::<fd::FileInfoOps>::new_inode,
         ),
         ("gid_map", InodeType::File, GidMapFileOps::new_inode),
+        ("limits", InodeType::File, LimitsFileOps::new_inode),
         ("mem", InodeType::File, MemFileOps::new_inode),
         ("mountinfo", InodeType::File, MountInfoFileOps::new_inode),
         ("mountstats", InodeType::File, MountStatsFileOps::new_inode),

--- a/test/initramfs/src/conformance/gvisor/blocklists/rlimits_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/rlimits_test
@@ -1,3 +1,2 @@
-RlimitTest.ParseProcPidLimits
 RlimitTest.SetRlimitHigher
 RlimitTest.UnprivilegedSetRlimit

--- a/test/initramfs/src/regression/fs/procfs/limits.c
+++ b/test/initramfs/src/regression/fs/procfs/limits.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <ctype.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define LIMIT_NAME_WIDTH 25
+#define EXPECTED_LIMIT_COUNT 16
+
+static bool is_limit_value(const char *value)
+{
+	if (strcmp(value, "unlimited") == 0) {
+		return true;
+	}
+
+	if (*value == '\0') {
+		return false;
+	}
+
+	for (const char *p = value; *p != '\0'; p++) {
+		if (!isdigit((unsigned char)*p)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool starts_with(const char *str, const char *prefix)
+{
+	return strncmp(str, prefix, strlen(prefix)) == 0;
+}
+
+FN_TEST(self_limits_is_parseable)
+{
+	char buf[8192];
+	int fd;
+	ssize_t len;
+	char *saveptr = NULL;
+	char *line;
+	int entries = 0;
+	bool saw_cpu = false;
+	bool saw_open_files = false;
+	bool saw_realtime_timeout = false;
+
+	fd = TEST_SUCC(open("/proc/self/limits", O_RDONLY));
+	len = TEST_RES(read(fd, buf, sizeof(buf) - 1),
+		       _ret > 0 && _ret < (ssize_t)sizeof(buf) - 1);
+	TEST_SUCC(close(fd));
+	buf[len] = '\0';
+
+	line = strtok_r(buf, "\n", &saveptr);
+	TEST_RES(0, line != NULL);
+	TEST_RES(0, strstr(line, "Soft Limit") != NULL);
+	TEST_RES(0, strstr(line, "Hard Limit") != NULL);
+	TEST_RES(0, strstr(line, "Units") != NULL);
+
+	while ((line = strtok_r(NULL, "\n", &saveptr)) != NULL) {
+		char *field_saveptr = NULL;
+		char *soft;
+		char *hard;
+
+		entries++;
+		TEST_RES(0, strlen(line) >= LIMIT_NAME_WIDTH);
+		saw_cpu |= starts_with(line, "Max cpu time");
+		saw_open_files |= starts_with(line, "Max open files");
+		saw_realtime_timeout |=
+			starts_with(line, "Max realtime timeout");
+
+		soft = strtok_r(line + LIMIT_NAME_WIDTH, " \t", &field_saveptr);
+		hard = strtok_r(NULL, " \t", &field_saveptr);
+		TEST_RES(0, soft != NULL);
+		TEST_RES(0, hard != NULL);
+		TEST_RES(0, is_limit_value(soft));
+		TEST_RES(0, is_limit_value(hard));
+	}
+
+	TEST_RES(0, entries == EXPECTED_LIMIT_COUNT);
+	TEST_RES(0, saw_cpu);
+	TEST_RES(0, saw_open_files);
+	TEST_RES(0, saw_realtime_timeout);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -130,6 +130,7 @@ echo "All mount bind file test passed."
 ./procfs/dentry_cache
 ./procfs/fd
 ./procfs/getdents
+./procfs/limits
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid


### PR DESCRIPTION
## Summary
- add procfs support for /proc/[pid]/limits and /proc/[pid]/task/[tid]/limits
- format all 16 Linux rlimit entries from the process resource-limit table
- add a regression test that parses /proc/self/limits
- remove RlimitTest.ParseProcPidLimits from the gVisor rlimits blocklist

## Test Plan
- cargo +nightly-2026-04-03 fmt --check
- gcc -Wall -Werror -fsyntax-only test/initramfs/src/regression/fs/procfs/limits.c
- make -C test/initramfs/src/regression check
- make -C test/initramfs/src/regression/fs/procfs BUILD_DIR=/tmp/asterinas-procfs-limits-build OUTPUT_DIR=/tmp/asterinas-procfs-limits-out
- host Linux run of limits.c against /proc/self/limits
- VDSO_LIBRARY_DIR=/root/linux_vdso make check reached and passed Rust clippy plus regression C formatting; local run then stopped at missing 
ixfmt, which is available in the project CI image
