### PR TITLE
Add /proc/sys/kernel/hostname

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/hostname.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/hostname.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+};
+
+/// Represents the inode at `/proc/sys/kernel/hostname`.
+pub struct HostnameFileOps;
+
+impl HostnameFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/utsname_sysctl.c>
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for HostnameFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let Some(current_task) = Task::current() else {
+            return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+        };
+        let Some(thread_local) = current_task.as_thread_local() else {
+            return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+        };
+        let ns_proxy = thread_local.borrow_ns_proxy();
+        let uts_name = ns_proxy.unwrap().uts_ns().uts_name();
+
+        let mut hostname = uts_name.hostname().to_bytes().to_vec();
+        hostname.push(b'\n');
+
+        let mut vm_reader = VmReader::from(&hostname[offset.min(hostname.len())..]);
+        let bytes_read = writer.write_fallible(&mut vm_reader)?;
+
+        Ok(bytes_read)
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!("writing to `/proc/sys/kernel/hostname` is not supported");
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to `/proc/sys/kernel/hostname` is not supported"
+        );
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,8 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps, hostname::HostnameFileOps, pid_max::PidMaxFileOps,
+                yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -20,6 +21,7 @@ use crate::{
 };
 
 mod cap_last_cap;
+mod hostname;
 mod pid_max;
 mod yama;
 
@@ -40,6 +42,7 @@ impl KernelDirOps {
             InodeType::File,
             CapLastCapFileOps::new_inode,
         ),
+        ("hostname", InodeType::File, HostnameFileOps::new_inode),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
     ];
 }

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -206,6 +206,11 @@ impl UtsName {
             }
         }
     };
+
+    /// Returns the host name.
+    pub fn hostname(&self) -> &CStr {
+        CStr::from_bytes_until_nul(&self.nodename).unwrap()
+    }
 }
 
 impl NsCommonOps for UtsNamespace {

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -32,8 +32,6 @@ ProcSelfMaps.Map2
 ProcSelfMaps.MapUnmap
 ProcSelfRoot.IsRoot
 ProcSelfStat.PopulateWriteRSS
-ProcSysKernelHostname.Exists
-ProcSysKernelHostname.MatchesUname
 ProcSysKernelKeysMax.Exists
 ProcSysKernelKeysMax.InvalidMaxKeysValue
 ProcSysKernelKeysMax.SetMaxKeys

--- a/test/initramfs/src/regression/fs/procfs/hostname.c
+++ b/test/initramfs/src/regression/fs/procfs/hostname.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define HOSTNAME_PATH "/proc/sys/kernel/hostname"
+
+FN_TEST(proc_sys_kernel_hostname_matches_uname)
+{
+	struct utsname uts;
+	char hostname[256] = { 0 };
+	int fd = TEST_SUCC(open(HOSTNAME_PATH, O_RDONLY));
+	ssize_t bytes_read =
+		TEST_RES(read(fd, hostname, sizeof(hostname) - 1), _ret > 0);
+
+	TEST_SUCC(uname(&uts));
+	TEST_RES(hostname[bytes_read - 1], _ret == '\n');
+	hostname[bytes_read - 1] = '\0';
+	TEST_RES(strcmp(hostname, uts.nodename), _ret == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -130,6 +130,7 @@ echo "All mount bind file test passed."
 ./procfs/dentry_cache
 ./procfs/fd
 ./procfs/getdents
+./procfs/hostname
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid


### PR DESCRIPTION
## Summary
- Add /proc/sys/kernel/hostname under procfs and report the current UTS namespace hostname with a trailing newline.
- Add a read-only accessor for the UTS hostname instead of exposing the UTS struct fields.
- Add a regression test that compares /proc/sys/kernel/hostname with uname().nodename.
- Remove ProcSysKernelHostname.Exists and ProcSysKernelHostname.MatchesUname from the gVisor proc blocklist.

## Test
- cargo +nightly-2026-04-03 fmt --check
- gcc -Wall -Werror -fsyntax-only test/initramfs/src/regression/fs/procfs/hostname.c
- make -C test/initramfs/src/regression check
- make -C test/initramfs/src/regression/fs/procfs BUILD_DIR=/tmp/asterinas-proc-sys-hostname-build OUTPUT_DIR=/tmp/asterinas-proc-sys-hostname-out
- gcc -Wall -Werror -static -lpthread test/initramfs/src/regression/fs/procfs/hostname.c -o /tmp/procfs-hostname-test && /tmp/procfs-hostname-test
- VDSO_LIBRARY_DIR=/root/linux_vdso timeout 900 make check (passes Rust workspace checks, linux-bzimage setup checks, and regression C format check; local run then stops because this WSL environment lacks nixfmt)
