### PR TITLE
Add /proc/sys/vm numeric files

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use self::kernel::KernelDirOps;
+use self::{kernel::KernelDirOps, vm::VmDirOps};
 use super::{
     StaticEntry,
     template::{ReaddirEntry, listed_entries_from_table, visit_listed_entries},
@@ -15,6 +15,7 @@ use crate::{
 };
 
 mod kernel;
+mod vm;
 
 /// Represents the inode at `/proc/sys`.
 pub struct SysDirOps;
@@ -27,8 +28,10 @@ impl SysDirOps {
         ProcDir::new(Self, parent, mkmod!(a+rx))
     }
 
-    const STATIC_ENTRIES: &'static [StaticEntry] =
-        &[("kernel", InodeType::Dir, KernelDirOps::new_inode)];
+    const STATIC_ENTRIES: &'static [StaticEntry] = &[
+        ("kernel", InodeType::Dir, KernelDirOps::new_inode),
+        ("vm", InodeType::Dir, VmDirOps::new_inode),
+    ];
 }
 
 impl ProcDirOps for SysDirOps {

--- a/kernel/src/fs/fs_impls/procfs/sys/vm/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/vm/mod.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            ProcDir, StaticEntry,
+            template::{
+                ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry, listed_entries_from_table,
+                lookup_child_from_table, visit_listed_entries,
+            },
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+};
+
+const MAX_MAP_COUNT: usize = 1_048_576;
+const MMAP_MIN_ADDR: usize = 65_536;
+const OVERCOMMIT_MEMORY: usize = 0;
+
+/// Represents the inode at `/proc/sys/vm`.
+pub struct VmDirOps;
+
+impl VmDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/mm/util.c>
+        ProcDir::new(Self, parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntry] = &[
+        (
+            "max_map_count",
+            InodeType::File,
+            MaxMapCountFileOps::new_inode,
+        ),
+        (
+            "mmap_min_addr",
+            InodeType::File,
+            MmapMinAddrFileOps::new_inode,
+        ),
+        (
+            "overcommit_memory",
+            InodeType::File,
+            OvercommitMemoryFileOps::new_inode,
+        ),
+    ];
+}
+
+impl ProcDirOps for VmDirOps {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
+    }
+}
+
+struct MaxMapCountFileOps;
+
+impl MaxMapCountFileOps {
+    fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ReadOnlyValueFileOps::new_inode(parent, "max_map_count", MAX_MAP_COUNT)
+    }
+}
+
+struct MmapMinAddrFileOps;
+
+impl MmapMinAddrFileOps {
+    fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ReadOnlyValueFileOps::new_inode(parent, "mmap_min_addr", MMAP_MIN_ADDR)
+    }
+}
+
+struct OvercommitMemoryFileOps;
+
+impl OvercommitMemoryFileOps {
+    fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ReadOnlyValueFileOps::new_inode(parent, "overcommit_memory", OVERCOMMIT_MEMORY)
+    }
+}
+
+struct ReadOnlyValueFileOps {
+    name: &'static str,
+    value: usize,
+}
+
+impl ReadOnlyValueFileOps {
+    fn new_inode(parent: Weak<dyn Inode>, name: &'static str, value: usize) -> Arc<dyn Inode> {
+        ProcFile::new(Self { name, value }, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for ReadOnlyValueFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", self.value)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!("writing to `/proc/sys/vm/{}` is not supported", self.name);
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to the `/proc/sys/vm` file is not supported"
+        );
+    }
+}

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -37,9 +37,6 @@ ProcSysKernelHostname.MatchesUname
 ProcSysKernelKeysMax.Exists
 ProcSysKernelKeysMax.InvalidMaxKeysValue
 ProcSysKernelKeysMax.SetMaxKeys
-ProcSysVmMaxmapCount.HasNumericValue
-ProcSysVmMmapMinAddr.HasNumericValue
-ProcSysVmOvercommitMemory.HasNumericValue
 ProcTask.ChildTaskDir
 ProcTask.CommCanSetPeerThreadName
 ProcTask.CommCanSetSelfThreadName

--- a/test/initramfs/src/regression/fs/procfs/sys_vm.c
+++ b/test/initramfs/src/regression/fs/procfs/sys_vm.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define CHECK_NUMERIC_FILE(path, expected)                                  \
+	do {                                                                \
+		char buf[64] = { 0 };                                       \
+		char *end;                                                  \
+		int fd = TEST_SUCC(open((path), O_RDONLY));                 \
+		ssize_t bytes_read =                                        \
+			TEST_RES(read(fd, buf, sizeof(buf) - 1), _ret > 0); \
+                                                                            \
+		TEST_SUCC(close(fd));                                       \
+		TEST_RES(buf[bytes_read - 1], _ret == '\n');                \
+		errno = 0;                                                  \
+		unsigned long long value = strtoull(buf, &end, 10);         \
+		int parse_errno = errno;                                    \
+		TEST_RES(parse_errno, _ret == 0);                           \
+		TEST_RES(end > buf, _ret == 1);                             \
+		TEST_RES(*end, _ret == '\n');                               \
+		TEST_RES(value, _ret == (expected));                        \
+	} while (0)
+
+FN_TEST(proc_sys_vm_numeric_files)
+{
+	CHECK_NUMERIC_FILE("/proc/sys/vm/max_map_count", 1048576);
+	CHECK_NUMERIC_FILE("/proc/sys/vm/mmap_min_addr", 65536);
+	CHECK_NUMERIC_FILE("/proc/sys/vm/overcommit_memory", 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -133,6 +133,7 @@ echo "All mount bind file test passed."
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
+./procfs/sys_vm
 ./procfs/tid
 
 ./pseudofs/fallocate


### PR DESCRIPTION
## Summary
- Add /proc/sys/vm with max_map_count, mmap_min_addr, and overcommit_memory.
- Report Linux-compatible numeric values with trailing newlines.
- Add a procfs regression test that verifies each file is readable and numeric.
- Remove ProcSysVmMaxmapCount.HasNumericValue, ProcSysVmMmapMinAddr.HasNumericValue, and ProcSysVmOvercommitMemory.HasNumericValue from the gVisor proc blocklist.

## Test
- cargo +nightly-2026-04-03 fmt --check
- gcc -Wall -Werror -fsyntax-only test/initramfs/src/regression/fs/procfs/sys_vm.c
- make -C test/initramfs/src/regression check
- make -C test/initramfs/src/regression/fs/procfs BUILD_DIR=/tmp/asterinas-proc-sys-vm-build OUTPUT_DIR=/tmp/asterinas-proc-sys-vm-out
- gcc -Wall -Werror -static -lpthread test/initramfs/src/regression/fs/procfs/sys_vm.c -o /tmp/procfs-sys-vm-test && /tmp/procfs-sys-vm-test
- VDSO_LIBRARY_DIR=/root/linux_vdso timeout 900 make check (passes Rust workspace checks, linux-bzimage setup checks, and regression C format check; local run then stops because this WSL environment lacks nixfmt)
