### PR TITLE
Add /proc/sys/kernel/keys/maxkeys

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/keys.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/keys.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::sync::atomic::{AtomicI32, Ordering};
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            StaticEntry,
+            template::{
+                ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, read_i32_from,
+                visit_listed_entries,
+            },
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+};
+
+const DEFAULT_MAXKEYS: i32 = 200;
+
+static MAXKEYS: AtomicI32 = AtomicI32::new(DEFAULT_MAXKEYS);
+
+/// Represents the inode at `/proc/sys/kernel/keys`.
+pub struct KeysDirOps;
+
+impl KeysDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/security/keys/sysctl.c>
+        ProcDir::new(Self, parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntry] =
+        &[("maxkeys", InodeType::File, MaxKeysFileOps::new_inode)];
+}
+
+impl ProcDirOps for KeysDirOps {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/keys/maxkeys`.
+struct MaxKeysFileOps;
+
+impl MaxKeysFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for MaxKeysFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", MAXKEYS.load(Ordering::Relaxed))?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (val, read_bytes) = read_i32_from(reader)?;
+        if val < 0 {
+            return_errno_with_message!(Errno::EINVAL, "the maxkeys value cannot be negative");
+        }
+
+        MAXKEYS.store(val, Ordering::Relaxed);
+
+        Ok(read_bytes)
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,8 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps, keys::KeysDirOps, pid_max::PidMaxFileOps,
+                yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -20,6 +21,7 @@ use crate::{
 };
 
 mod cap_last_cap;
+mod keys;
 mod pid_max;
 mod yama;
 
@@ -40,6 +42,7 @@ impl KernelDirOps {
             InodeType::File,
             CapLastCapFileOps::new_inode,
         ),
+        ("keys", InodeType::Dir, KeysDirOps::new_inode),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
     ];
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -34,9 +34,6 @@ ProcSelfRoot.IsRoot
 ProcSelfStat.PopulateWriteRSS
 ProcSysKernelHostname.Exists
 ProcSysKernelHostname.MatchesUname
-ProcSysKernelKeysMax.Exists
-ProcSysKernelKeysMax.InvalidMaxKeysValue
-ProcSysKernelKeysMax.SetMaxKeys
 ProcSysVmMaxmapCount.HasNumericValue
 ProcSysVmMmapMinAddr.HasNumericValue
 ProcSysVmOvercommitMemory.HasNumericValue

--- a/test/initramfs/src/regression/fs/procfs/keys_maxkeys.c
+++ b/test/initramfs/src/regression/fs/procfs/keys_maxkeys.c
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define MAXKEYS_PATH "/proc/sys/kernel/keys/maxkeys"
+
+static long read_maxkeys(void)
+{
+	char buf[64] = { 0 };
+	char *end;
+	int fd = open(MAXKEYS_PATH, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	ssize_t bytes_read = read(fd, buf, sizeof(buf) - 1);
+	int saved_errno = errno;
+	if (close(fd) < 0) {
+		return -1;
+	}
+
+	if (bytes_read <= 0) {
+		errno = bytes_read < 0 ? saved_errno : EINVAL;
+		return -1;
+	}
+	if (buf[bytes_read - 1] != '\n') {
+		errno = EINVAL;
+		return -1;
+	}
+
+	errno = 0;
+	long value = strtol(buf, &end, 10);
+	if (errno != 0) {
+		return -1;
+	}
+	if (end <= buf || *end != '\n') {
+		errno = EINVAL;
+		return -1;
+	}
+
+	errno = 0;
+	return value;
+}
+
+FN_TEST(proc_sys_kernel_keys_maxkeys)
+{
+	TEST_RES(read_maxkeys(), _ret == 200);
+
+	int fd = TEST_SUCC(open(MAXKEYS_PATH, O_WRONLY));
+	TEST_ERRNO(write(fd, "-1", 2), EINVAL);
+	TEST_SUCC(close(fd));
+	TEST_RES(read_maxkeys(), _ret == 200);
+
+	fd = TEST_SUCC(open(MAXKEYS_PATH, O_WRONLY));
+	TEST_RES(write(fd, "100", 3), _ret == 3);
+	TEST_SUCC(close(fd));
+	TEST_RES(read_maxkeys(), _ret == 100);
+
+	fd = TEST_SUCC(open(MAXKEYS_PATH, O_WRONLY));
+	TEST_RES(write(fd, "200", 3), _ret == 3);
+	TEST_SUCC(close(fd));
+	TEST_RES(read_maxkeys(), _ret == 200);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -130,6 +130,7 @@ echo "All mount bind file test passed."
 ./procfs/dentry_cache
 ./procfs/fd
 ./procfs/getdents
+./procfs/keys_maxkeys
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid


### PR DESCRIPTION
## Summary
- Add /proc/sys/kernel/keys/maxkeys under procfs.
- Default maxkeys to 200, reject negative writes with EINVAL, and allow valid writes to update the value.
- Add a regression test for read, invalid write, valid write, and restore behavior.
- Remove ProcSysKernelKeysMax.Exists, ProcSysKernelKeysMax.InvalidMaxKeysValue, and ProcSysKernelKeysMax.SetMaxKeys from the gVisor proc blocklist.

## Test
- cargo +nightly-2026-04-03 fmt --check
- gcc -Wall -Werror -fsyntax-only test/initramfs/src/regression/fs/procfs/keys_maxkeys.c
- make -C test/initramfs/src/regression check
- make -C test/initramfs/src/regression/fs/procfs BUILD_DIR=/tmp/asterinas-proc-sys-kernel-keys-build OUTPUT_DIR=/tmp/asterinas-proc-sys-kernel-keys-out
- gcc -Wall -Werror -static -lpthread test/initramfs/src/regression/fs/procfs/keys_maxkeys.c -o /tmp/procfs-keys-maxkeys-test && /tmp/procfs-keys-maxkeys-test
- VDSO_LIBRARY_DIR=/root/linux_vdso timeout 900 make check (passes Rust workspace checks, linux-bzimage setup checks, and regression C format check; local run then stops because this WSL environment lacks nixfmt)
