### PR TITLE
Add /proc/sys/kernel UTS files

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,10 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps,
+                pid_max::PidMaxFileOps,
+                uts::{OsReleaseFileOps, OsTypeFileOps, VersionFileOps},
+                yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -21,6 +24,7 @@ use crate::{
 
 mod cap_last_cap;
 mod pid_max;
+mod uts;
 mod yama;
 
 /// Represents the inode at `/proc/sys/kernel`.
@@ -40,7 +44,10 @@ impl KernelDirOps {
             InodeType::File,
             CapLastCapFileOps::new_inode,
         ),
+        ("osrelease", InodeType::File, OsReleaseFileOps::new_inode),
+        ("ostype", InodeType::File, OsTypeFileOps::new_inode),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
+        ("version", InodeType::File, VersionFileOps::new_inode),
     ];
 }
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/uts.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/uts.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    net::uts_ns::UtsName,
+    prelude::*,
+};
+
+enum UtsSysctlField {
+    OsType,
+    OsRelease,
+    Version,
+}
+
+struct UtsSysctlFileOps {
+    field: UtsSysctlField,
+}
+
+impl UtsSysctlFileOps {
+    fn new_inode(parent: Weak<dyn Inode>, field: UtsSysctlField) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/sysctl.c#L1765>
+        ProcFile::new(Self { field }, parent, mkmod!(a+r))
+    }
+
+    fn value(&self) -> &'static str {
+        match self.field {
+            UtsSysctlField::OsType => UtsName::SYSNAME,
+            UtsSysctlField::OsRelease => UtsName::RELEASE,
+            UtsSysctlField::Version => UtsName::VERSION,
+        }
+    }
+}
+
+impl ProcFileOps for UtsSysctlFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", self.value())?;
+
+        Ok(printer.bytes_written())
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/ostype`.
+pub struct OsTypeFileOps;
+
+impl OsTypeFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        UtsSysctlFileOps::new_inode(parent, UtsSysctlField::OsType)
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/osrelease`.
+pub struct OsReleaseFileOps;
+
+impl OsReleaseFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        UtsSysctlFileOps::new_inode(parent, UtsSysctlField::OsRelease)
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/version`.
+pub struct VersionFileOps;
+
+impl VersionFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        UtsSysctlFileOps::new_inode(parent, UtsSysctlField::Version)
+    }
+}

--- a/test/initramfs/src/regression/fs/procfs/sys_kernel_uts.c
+++ b/test/initramfs/src/regression/fs/procfs/sys_kernel_uts.c
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+struct uts_sysctl_case {
+	const char *path;
+	const char *expected;
+};
+
+static const struct uts_sysctl_case UTS_SYSCTL_CASES[] = {
+	{ "/proc/sys/kernel/ostype", "Linux\n" },
+	{ "/proc/sys/kernel/osrelease", "5.13.0\n" },
+	{ "/proc/sys/kernel/version", "#1 SMP " },
+};
+
+static void read_file(const char *path, char *buf, size_t buf_size)
+{
+	int fd = CHECK(open(path, O_RDONLY));
+	ssize_t bytes = CHECK(read(fd, buf, buf_size - 1));
+
+	buf[bytes] = '\0';
+	CHECK(close(fd));
+}
+
+static int has_dir_entry(const char *name)
+{
+	DIR *dir = opendir("/proc/sys/kernel");
+	CHECK(dir == NULL ? -1 : 0);
+
+	int found = 0;
+	errno = 0;
+	for (struct dirent *entry = readdir(dir); entry != NULL;
+	     entry = readdir(dir)) {
+		if (strcmp(entry->d_name, name) == 0 &&
+		    entry->d_type == DT_REG) {
+			found = 1;
+			break;
+		}
+		errno = 0;
+	}
+	CHECK(errno == 0 ? 0 : -1);
+	CHECK(closedir(dir));
+
+	return found;
+}
+
+FN_TEST(uts_sysctl_files_match_uname_fields)
+{
+	for (size_t i = 0;
+	     i < sizeof(UTS_SYSCTL_CASES) / sizeof(UTS_SYSCTL_CASES[0]); i++) {
+		char buf[128];
+
+		read_file(UTS_SYSCTL_CASES[i].path, buf, sizeof(buf));
+
+		if (strcmp(UTS_SYSCTL_CASES[i].path,
+			   "/proc/sys/kernel/version") == 0) {
+			TEST_RES(
+				strncmp(buf, UTS_SYSCTL_CASES[i].expected,
+					strlen(UTS_SYSCTL_CASES[i].expected)) ==
+					0,
+				_ret == 0);
+			TEST_RES(strchr(buf, '\n') != NULL, _ret == 1);
+		} else {
+			TEST_RES(strcmp(buf, UTS_SYSCTL_CASES[i].expected) == 0,
+				 _ret == 0);
+		}
+	}
+}
+END_TEST()
+
+FN_TEST(uts_sysctl_files_are_read_only_regular_files)
+{
+	for (size_t i = 0;
+	     i < sizeof(UTS_SYSCTL_CASES) / sizeof(UTS_SYSCTL_CASES[0]); i++) {
+		struct stat st;
+
+		TEST_SUCC(stat(UTS_SYSCTL_CASES[i].path, &st));
+		TEST_RES(S_ISREG(st.st_mode), _ret != 0);
+		TEST_RES((st.st_mode & 0777) == 0444, _ret == 1);
+		TEST_ERRNO(open(UTS_SYSCTL_CASES[i].path, O_WRONLY), EACCES);
+	}
+}
+END_TEST()
+
+FN_TEST(uts_sysctl_files_are_listed)
+{
+	TEST_RES(has_dir_entry("ostype"), _ret == 1);
+	TEST_RES(has_dir_entry("osrelease"), _ret == 1);
+	TEST_RES(has_dir_entry("version"), _ret == 1);
+}
+END_TEST()


### PR DESCRIPTION
## Summary

- Add read-only `/proc/sys/kernel/ostype`, `/proc/sys/kernel/osrelease`, and `/proc/sys/kernel/version`.
- Reuse the existing UTS constants so these sysctl files stay consistent with `uname(2)` and `/proc/version`.
- Add a procfs regression test that checks file contents, `0444` regular-file metadata, write-open rejection, and directory entries.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `make -C test/initramfs/src/regression/fs/procfs`
- `make -C test/initramfs/src/regression check`

`make kernel` was not runnable in the local WSL environment because `nix-build` is not installed, and pulling the official Docker image failed with Docker Hub EOF. The PR is covered by upstream CI for the full kernel/runtime path.
