### PR TITLE
Report O_LARGEFILE in proc fdinfo

### DIFF
--- a/kernel/src/events/epoll/file.rs
+++ b/kernel/src/events/epoll/file.rs
@@ -12,8 +12,9 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileLike,
+            AccessMode, FileLike,
             file_table::{FdFlags, FileDesc, get_file_fast},
+            proc_fdinfo_flags,
         },
         pseudofs::AnonInodeFs,
         vfs::path::Path,
@@ -282,10 +283,11 @@ impl FileLike for EpollFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
-                if self.fd_flags.contains(FdFlags::CLOEXEC) {
-                    flags |= CreationFlags::O_CLOEXEC.bits();
-                }
+                let flags = proc_fdinfo_flags(
+                    self.inner.status_flags(),
+                    self.inner.access_mode(),
+                    self.fd_flags,
+                );
 
                 writeln!(f, "pos:\t{}", 0)?;
                 writeln!(f, "flags:\t0{:o}", flags)?;

--- a/kernel/src/fs/file/file_attr/status_flags.rs
+++ b/kernel/src/fs/file/file_attr/status_flags.rs
@@ -5,6 +5,12 @@ use core::sync::atomic::AtomicU32;
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use bitflags::bitflags;
 
+/// The internal Linux `O_LARGEFILE` bit reported by `fcntl(F_GETFL)` and proc fdinfo.
+///
+/// On x86_64, userspace `O_LARGEFILE` is defined as zero, so this bit is not
+/// accepted from open flags and is not represented as a `StatusFlags` bit.
+pub const LINUX_O_LARGEFILE: u32 = 0o100000;
+
 bitflags! {
     pub struct StatusFlags: u32 {
         /// append on each write
@@ -17,7 +23,6 @@ bitflags! {
         const O_ASYNC = 1 << 13;
         /// direct I/O
         const O_DIRECT = 1 << 14;
-        /// on x86_64, O_LARGEFILE is 0
         /// not update st_atime
         const O_NOATIME = 1 << 18;
         /// synchronized I/O, data and metadata

--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -8,7 +8,10 @@ use core::fmt::Display;
 
 use ostd::io::IoMem;
 
-use super::{AccessMode, InodeHandle, StatusFlags, file_table::FdFlags, inode_handle::SeekFrom};
+use super::{
+    AccessMode, CreationFlags, InodeHandle, LINUX_O_LARGEFILE, StatusFlags, file_table::FdFlags,
+    inode_handle::SeekFrom,
+};
 use crate::{
     fs::vfs::{inode::FallocMode, path::Path},
     net::socket::Socket,
@@ -17,6 +20,32 @@ use crate::{
     util::ioctl::RawIoctl,
     vm::page_cache::Vmo,
 };
+
+/// Returns the Linux-compatible `flags:` field for `/proc/[pid]/fdinfo/[n]`.
+pub fn proc_fdinfo_flags(
+    status_flags: StatusFlags,
+    access_mode: AccessMode,
+    fd_flags: FdFlags,
+) -> u32 {
+    proc_fdinfo_flags_with_largefile(status_flags, access_mode, fd_flags, false)
+}
+
+/// Returns the Linux-compatible `flags:` field with an explicit `O_LARGEFILE` policy.
+pub fn proc_fdinfo_flags_with_largefile(
+    status_flags: StatusFlags,
+    access_mode: AccessMode,
+    fd_flags: FdFlags,
+    report_largefile: bool,
+) -> u32 {
+    let mut flags = status_flags.bits() | access_mode as u32;
+    if report_largefile {
+        flags |= LINUX_O_LARGEFILE;
+    }
+    if fd_flags.contains(FdFlags::CLOEXEC) {
+        flags |= CreationFlags::O_CLOEXEC.bits();
+    }
+    flags
+}
 
 /// The basic operations defined on a file
 pub trait FileLike: Pollable + Send + Sync + Any {

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -7,8 +7,8 @@ use core::{fmt::Display, sync::atomic::Ordering};
 use aster_rights::Rights;
 
 use super::{
-    AccessMode, AtomicStatusFlags, CreationFlags, FileLike, InodeType, Mappable, StatusFlags,
-    file_table::FdFlags, flock::FlockItem,
+    AccessMode, AtomicStatusFlags, FileLike, InodeType, Mappable, StatusFlags, file_table::FdFlags,
+    flock::FlockItem, proc_fdinfo_flags_with_largefile,
 };
 use crate::{
     events::IoEvents,
@@ -74,6 +74,10 @@ impl InodeHandle {
             status_flags: AtomicStatusFlags::new(status_flags),
             rights,
         })
+    }
+
+    pub fn reports_largefile_bit(&self) -> bool {
+        !self.status_flags().contains(StatusFlags::O_PATH) && self.path.fs().name() != "pipefs"
     }
 
     pub fn path(&self) -> &Path {
@@ -479,10 +483,12 @@ impl FileLike for InodeHandle {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
-                if self.fd_flags.contains(FdFlags::CLOEXEC) {
-                    flags |= CreationFlags::O_CLOEXEC.bits();
-                }
+                let flags = proc_fdinfo_flags_with_largefile(
+                    self.inner.status_flags(),
+                    self.inner.access_mode(),
+                    self.fd_flags,
+                    self.inner.reports_largefile_bit(),
+                );
 
                 writeln!(f, "pos:\t{}", self.inner.offset())?;
                 writeln!(f, "flags:\t0{:o}", flags)?;

--- a/kernel/src/fs/file/mod.rs
+++ b/kernel/src/fs/file/mod.rs
@@ -13,9 +13,9 @@ pub use file_attr::{
     access_mode::AccessMode,
     creation_flags::CreationFlags,
     open_args::OpenArgs,
-    status_flags::{AtomicStatusFlags, StatusFlags},
+    status_flags::{AtomicStatusFlags, LINUX_O_LARGEFILE, StatusFlags},
 };
-pub use file_handle::{FileLike, Mappable};
+pub use file_handle::{FileLike, Mappable, proc_fdinfo_flags, proc_fdinfo_flags_with_largefile};
 pub(crate) use inode_attr::mode::{
     chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask,
 };

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -12,7 +12,7 @@ use hashbrown::HashMap;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, FileLike, StatusFlags, file_table::FdFlags, proc_fdinfo_flags},
         pseudofs::AnonInodeFs,
         vfs::{
             inode::{FallocMode, Inode},
@@ -382,10 +382,11 @@ impl FileLike for InotifyFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
-                if self.fd_flags.contains(FdFlags::CLOEXEC) {
-                    flags |= CreationFlags::O_CLOEXEC.bits();
-                }
+                let flags = proc_fdinfo_flags(
+                    self.inner.status_flags(),
+                    self.inner.access_mode(),
+                    self.fd_flags,
+                );
 
                 writeln!(f, "pos:\t{}", 0)?;
                 writeln!(f, "flags:\t0{:o}", flags)?;

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -7,7 +7,7 @@ use util::{MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr};
 
 use crate::{
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, FileLike, StatusFlags, file_table::FdFlags, proc_fdinfo_flags},
         pseudofs::SockFs,
         vfs::path::Path,
     },
@@ -197,10 +197,7 @@ impl<T: Socket + 'static> FileLike for T {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
-        if fd_flags.contains(FdFlags::CLOEXEC) {
-            flags |= CreationFlags::O_CLOEXEC.bits();
-        }
+        let flags = proc_fdinfo_flags(self.status_flags(), self.access_mode(), fd_flags);
 
         Box::new(FdInfo {
             flags,

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, FileLike, StatusFlags, file_table::FdFlags, proc_fdinfo_flags},
         pseudofs::PidfdFs,
         vfs::path::Path,
     },
@@ -135,10 +135,7 @@ impl FileLike for PidFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
-        if fd_flags.contains(FdFlags::CLOEXEC) {
-            flags |= CreationFlags::O_CLOEXEC.bits();
-        }
+        let flags = proc_fdinfo_flags(self.status_flags(), self.access_mode(), fd_flags);
         let pid = self.process.upgrade().map_or(u32::MAX, |p| p.pid());
 
         Box::new(FdInfo { flags, pid })

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -22,7 +22,10 @@ use super::SyscallReturn;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags,
+            proc_fdinfo_flags,
+        },
         pseudofs::AnonInodeFs,
         vfs::path::Path,
     },
@@ -248,10 +251,11 @@ impl FileLike for EventFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
-                if self.fd_flags.contains(FdFlags::CLOEXEC) {
-                    flags |= CreationFlags::O_CLOEXEC.bits();
-                }
+                let flags = proc_fdinfo_flags(
+                    self.inner.status_flags(),
+                    self.inner.access_mode(),
+                    self.fd_flags,
+                );
 
                 writeln!(f, "pos:\t{}", 0)?;
                 writeln!(f, "flags:\t0{:o}", flags)?;

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -6,7 +6,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{
-            FileLike, StatusFlags,
+            FileLike, InodeHandle, LINUX_O_LARGEFILE, StatusFlags,
             file_table::{FdFlags, FileDesc, RawFileDesc, WithFileTable, get_file_fast},
         },
         ramfs::memfd::{FileSeals, MemfdInodeHandle},
@@ -75,9 +75,18 @@ fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let file = get_file_fast!(&mut file_table, fd);
     let status_flags = file.status_flags();
     let access_mode = file.access_mode();
-    Ok(SyscallReturn::Return(
-        (status_flags.bits() | access_mode as u32) as _,
-    ))
+    let mut flags = status_flags.bits() | access_mode as u32;
+    if should_report_largefile_bit(file.as_ref().as_ref(), status_flags) {
+        flags |= LINUX_O_LARGEFILE;
+    }
+    Ok(SyscallReturn::Return(flags as _))
+}
+
+fn should_report_largefile_bit(file: &dyn FileLike, status_flags: StatusFlags) -> bool {
+    !status_flags.contains(StatusFlags::O_PATH)
+        && file
+            .downcast_ref::<InodeHandle>()
+            .is_some_and(InodeHandle::reports_largefile_bit)
 }
 
 fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -21,6 +21,7 @@ use crate::{
         file::{
             AccessMode, CreationFlags, FileLike, StatusFlags,
             file_table::{FdFlags, RawFileDesc, get_file_fast},
+            proc_fdinfo_flags,
         },
         pseudofs::AnonInodeFs,
         vfs::path::Path,
@@ -286,10 +287,7 @@ impl FileLike for SignalFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
-        if fd_flags.contains(FdFlags::CLOEXEC) {
-            flags |= CreationFlags::O_CLOEXEC.bits();
-        }
+        let flags = proc_fdinfo_flags(self.status_flags(), self.access_mode(), fd_flags);
 
         Box::new(FdInfo {
             flags,

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -12,7 +12,10 @@ use super::clockid_t;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags,
+            proc_fdinfo_flags,
+        },
         pseudofs::AnonInodeFs,
         vfs::path::Path,
     },
@@ -293,10 +296,7 @@ impl FileLike for TimerfdFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
-        if fd_flags.contains(FdFlags::CLOEXEC) {
-            flags |= CreationFlags::O_CLOEXEC.bits();
-        }
+        let flags = proc_fdinfo_flags(self.status_flags(), self.access_mode(), fd_flags);
 
         let timer_guard = self.timer.lock();
         Box::new(FdInfo {

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -25,8 +25,6 @@ ProcSelfAuxv.EntryPresence
 ProcSelfAuxv.EntryValues
 ProcSelfCwd.Absolute
 ProcSelfFd.OpenFd
-# TODO: Support `O_LARGEFILE` flag.
-ProcSelfFdInfo.Flags
 # TODO: Mappings created with only `PROT_WRITE` should be shown as `-w-`.
 ProcSelfMaps.Map2
 ProcSelfMaps.MapUnmap

--- a/test/initramfs/src/regression/fs/procfs/fdinfo_flags.c
+++ b/test/initramfs/src/regression/fs/procfs/fdinfo_flags.c
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define FDINFO_O_LARGEFILE 0100000
+
+static unsigned int read_fdinfo_flags(int fd)
+{
+	char path[64];
+	char buf[512] = { 0 };
+	unsigned int flags = 0;
+
+	CHECK_WITH(snprintf(path, sizeof(path), "/proc/self/fdinfo/%d", fd),
+		   _ret > 0 && (size_t)_ret < sizeof(path));
+
+	int info_fd = CHECK(open(path, O_RDONLY));
+	CHECK(read(info_fd, buf, sizeof(buf) - 1));
+	CHECK(close(info_fd));
+
+	char *flags_line = strstr(buf, "flags:\t0");
+	CHECK(flags_line == NULL ? -1 : 0);
+	CHECK_WITH(sscanf(flags_line, "flags:\t0%o", &flags), _ret == 1);
+
+	return flags;
+}
+
+FN_TEST(regular_file_fdinfo_reports_largefile)
+{
+	const char *path = "/tmp/fdinfo_largefile_regular";
+	int fd = TEST_SUCC(
+		open(path, O_CREAT | O_RDWR | O_TRUNC | O_CLOEXEC | O_NONBLOCK,
+		     0600));
+
+	unsigned int flags = read_fdinfo_flags(fd);
+	int fcntl_flags = TEST_SUCC(fcntl(fd, F_GETFL));
+
+	TEST_RES(flags & FDINFO_O_LARGEFILE, _ret != 0);
+	TEST_RES(flags & O_CLOEXEC, _ret != 0);
+	TEST_RES(flags & O_NONBLOCK, _ret != 0);
+	TEST_RES((flags & O_ACCMODE) == O_RDWR, _ret == 1);
+	TEST_RES(fcntl_flags & FDINFO_O_LARGEFILE, _ret != 0);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(named_pipe_fdinfo_reports_largefile)
+{
+	const char *path = "/tmp/fdinfo_largefile_fifo";
+
+	unlink(path);
+	TEST_SUCC(mkfifo(path, 0600));
+	int fd = TEST_SUCC(open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC));
+
+	unsigned int flags = read_fdinfo_flags(fd);
+	int fcntl_flags = TEST_SUCC(fcntl(fd, F_GETFL));
+
+	TEST_RES(flags & FDINFO_O_LARGEFILE, _ret != 0);
+	TEST_RES(flags & O_CLOEXEC, _ret != 0);
+	TEST_RES(flags & O_NONBLOCK, _ret != 0);
+	TEST_RES((flags & O_ACCMODE) == O_RDONLY, _ret == 1);
+	TEST_RES(fcntl_flags & FDINFO_O_LARGEFILE, _ret != 0);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(opath_fgetfl_does_not_report_largefile)
+{
+	const char *path = "/tmp/fdinfo_largefile_opath";
+	int create_fd =
+		TEST_SUCC(open(path, O_CREAT | O_RDONLY | O_TRUNC, 0600));
+	TEST_SUCC(close(create_fd));
+
+	int fd = TEST_SUCC(open(path, O_PATH | O_CLOEXEC));
+	unsigned int flags = read_fdinfo_flags(fd);
+	int fcntl_flags = TEST_SUCC(fcntl(fd, F_GETFL));
+
+	TEST_RES(flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(fcntl_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(fcntl_flags & O_PATH, _ret != 0);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(anonymous_pipe_fgetfl_does_not_report_largefile)
+{
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	int read_flags = TEST_SUCC(fcntl(pipefd[0], F_GETFL));
+	int write_flags = TEST_SUCC(fcntl(pipefd[1], F_GETFL));
+	unsigned int read_info_flags = read_fdinfo_flags(pipefd[0]);
+	unsigned int write_info_flags = read_fdinfo_flags(pipefd[1]);
+
+	TEST_RES(read_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(write_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(read_info_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(write_info_flags & FDINFO_O_LARGEFILE, _ret == 0);
+
+	TEST_SUCC(close(pipefd[0]));
+	TEST_SUCC(close(pipefd[1]));
+}
+END_TEST()
+
+FN_TEST(socket_fdinfo_does_not_report_largefile)
+{
+	int socketfd[2];
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, socketfd));
+
+	int first_flags = TEST_SUCC(fcntl(socketfd[0], F_GETFL));
+	int second_flags = TEST_SUCC(fcntl(socketfd[1], F_GETFL));
+	unsigned int first_fdinfo_flags = read_fdinfo_flags(socketfd[0]);
+	unsigned int second_fdinfo_flags = read_fdinfo_flags(socketfd[1]);
+
+	TEST_RES(first_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(second_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(first_fdinfo_flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(second_fdinfo_flags & FDINFO_O_LARGEFILE, _ret == 0);
+
+	TEST_SUCC(close(socketfd[0]));
+	TEST_SUCC(close(socketfd[1]));
+}
+END_TEST()
+
+FN_TEST(eventfd_fdinfo_does_not_report_largefile)
+{
+	int fd = TEST_SUCC(eventfd(0, EFD_CLOEXEC));
+	unsigned int flags = read_fdinfo_flags(fd);
+	int fcntl_flags = TEST_SUCC(fcntl(fd, F_GETFL));
+
+	TEST_RES(flags & FDINFO_O_LARGEFILE, _ret == 0);
+	TEST_RES(flags & O_CLOEXEC, _ret != 0);
+	TEST_RES(fcntl_flags & FDINFO_O_LARGEFILE, _ret == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()


### PR DESCRIPTION
## Summary

- Add a shared helper for the `/proc/[pid]/fdinfo/[n]` `flags:` field.
- Report Linux's displayed `O_LARGEFILE` bit (`0100000`) for inode-backed files that carry the large-file policy.
- Keep socket, eventfd, epoll, signalfd, timerfd, pidfd, inotify, anonymous pipe, and `O_PATH` fdinfo output without the large-file bit, matching Linux reference behavior.
- Report Linux's internal `O_LARGEFILE` bit from `fcntl(F_GETFL)` for non-`O_PATH` inode-backed files while keeping anonymous pipes without that bit.
- Add regression coverage for regular files, named FIFOs, `O_PATH`, anonymous pipes, Unix sockets, and eventfd.
- Remove the corresponding gVisor blocklist entry: `ProcSelfFdInfo.Flags`.
- Keep the named-pipe `PipeTest.Flags` blocklist entries because named FIFO `F_GETFL` still needs a separate follow-up.

## Latest Quality Refresh

- 2026-06-26: amended to commit `1ac6629`.
- Rechecked with Linux reference execution of `fdinfo_flags`, `git diff --check`, `cargo fmt --check`, and `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression/fs/procfs fdinfo_flags`
- `make -C test/initramfs/src/regression check`
- `git diff --check`

`make kernel` was not runnable in the local WSL environment because `nix-build` is not installed, and pulling the official Docker image failed with Docker Hub EOF. The PR is covered by upstream CI for the full kernel/runtime path.