### PR TITLE
Add /proc/sys/kernel shm files

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,10 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps,
+                pid_max::PidMaxFileOps,
+                shm::{ShmAllFileOps, ShmMaxFileOps, ShmMniFileOps},
+                yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -21,6 +24,7 @@ use crate::{
 
 mod cap_last_cap;
 mod pid_max;
+mod shm;
 mod yama;
 
 /// Represents the inode at `/proc/sys/kernel`.
@@ -41,6 +45,9 @@ impl KernelDirOps {
             CapLastCapFileOps::new_inode,
         ),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
+        ("shmall", InodeType::File, ShmAllFileOps::new_inode),
+        ("shmmax", InodeType::File, ShmMaxFileOps::new_inode),
+        ("shmmni", InodeType::File, ShmMniFileOps::new_inode),
     ];
 }
 

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/shm.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/shm.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+};
+
+const SHMALL: u64 = u64::MAX - (1u64 << 24);
+const SHMMAX: u64 = u64::MAX - (1u64 << 24);
+const SHMMNI: u64 = 4096;
+
+enum ShmSysctlField {
+    All,
+    Max,
+    Mni,
+}
+
+struct ShmSysctlFileOps {
+    field: ShmSysctlField,
+}
+
+impl ShmSysctlFileOps {
+    fn new_inode(parent: Weak<dyn Inode>, field: ShmSysctlField) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/ipc/ipc_sysctl.c#L292>
+        ProcFile::new(Self { field }, parent, mkmod!(a+r, u+w))
+    }
+
+    fn name(&self) -> &'static str {
+        match self.field {
+            ShmSysctlField::All => "shmall",
+            ShmSysctlField::Max => "shmmax",
+            ShmSysctlField::Mni => "shmmni",
+        }
+    }
+
+    fn value(&self) -> u64 {
+        match self.field {
+            ShmSysctlField::All => SHMALL,
+            ShmSysctlField::Max => SHMMAX,
+            ShmSysctlField::Mni => SHMMNI,
+        }
+    }
+}
+
+impl ProcFileOps for ShmSysctlFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", self.value())?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!(
+            "writing to `/proc/sys/kernel/{}` is not supported",
+            self.name()
+        );
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to the System V shared-memory sysctl file is not supported"
+        );
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/shmall`.
+pub struct ShmAllFileOps;
+
+impl ShmAllFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ShmSysctlFileOps::new_inode(parent, ShmSysctlField::All)
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/shmmax`.
+pub struct ShmMaxFileOps;
+
+impl ShmMaxFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ShmSysctlFileOps::new_inode(parent, ShmSysctlField::Max)
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/shmmni`.
+pub struct ShmMniFileOps;
+
+impl ShmMniFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ShmSysctlFileOps::new_inode(parent, ShmSysctlField::Mni)
+    }
+}

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -6,7 +6,6 @@ Proc.Statfs
 ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteNonRoot
 ProcFilesystems.OverflowID
-ProcFilesystems.PresenceOfShmMaxMniAll
 ProcPid.AccessDeny
 ProcPidCwd.Subprocess
 ProcPidRoot.Subprocess

--- a/test/initramfs/src/regression/fs/procfs/sys_kernel_shm.c
+++ b/test/initramfs/src/regression/fs/procfs/sys_kernel_shm.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+struct shm_sysctl_case {
+	const char *name;
+	const char *path;
+	const char *expected;
+};
+
+static const struct shm_sysctl_case SHM_SYSCTL_CASES[] = {
+	{ "shmall", "/proc/sys/kernel/shmall", "18446744073692774399\n" },
+	{ "shmmax", "/proc/sys/kernel/shmmax", "18446744073692774399\n" },
+	{ "shmmni", "/proc/sys/kernel/shmmni", "4096\n" },
+};
+
+static void read_file(const char *path, char *buf, size_t buf_size)
+{
+	int fd = CHECK(open(path, O_RDONLY));
+	ssize_t bytes = CHECK(read(fd, buf, buf_size - 1));
+
+	buf[bytes] = '\0';
+	CHECK(close(fd));
+}
+
+static int has_dir_entry(const char *name)
+{
+	DIR *dir = opendir("/proc/sys/kernel");
+	CHECK(dir == NULL ? -1 : 0);
+
+	int found = 0;
+	for (struct dirent *entry = readdir(dir); entry != NULL;
+	     entry = readdir(dir)) {
+		if (strcmp(entry->d_name, name) == 0 &&
+		    entry->d_type == DT_REG) {
+			found = 1;
+			break;
+		}
+	}
+	CHECK(closedir(dir));
+
+	return found;
+}
+
+FN_TEST(shm_sysctl_files_have_linux_default_values)
+{
+	for (size_t i = 0;
+	     i < sizeof(SHM_SYSCTL_CASES) / sizeof(SHM_SYSCTL_CASES[0]); i++) {
+		char buf[64];
+
+		read_file(SHM_SYSCTL_CASES[i].path, buf, sizeof(buf));
+		TEST_RES(strcmp(buf, SHM_SYSCTL_CASES[i].expected) == 0,
+			 _ret == 0);
+	}
+}
+END_TEST()
+
+FN_TEST(shm_sysctl_files_are_user_writable_regular_files)
+{
+	for (size_t i = 0;
+	     i < sizeof(SHM_SYSCTL_CASES) / sizeof(SHM_SYSCTL_CASES[0]); i++) {
+		struct stat st;
+
+		TEST_SUCC(stat(SHM_SYSCTL_CASES[i].path, &st));
+		TEST_RES(S_ISREG(st.st_mode), _ret != 0);
+		TEST_RES((st.st_mode & 0777) == 0644, _ret == 1);
+	}
+}
+END_TEST()
+
+FN_TEST(shm_sysctl_files_are_listed)
+{
+	for (size_t i = 0;
+	     i < sizeof(SHM_SYSCTL_CASES) / sizeof(SHM_SYSCTL_CASES[0]); i++) {
+		TEST_RES(has_dir_entry(SHM_SYSCTL_CASES[i].name), _ret == 1);
+	}
+}
+END_TEST()


### PR DESCRIPTION
## Summary

- Add `/proc/sys/kernel/shmall`, `/proc/sys/kernel/shmmax`, and `/proc/sys/kernel/shmmni` with Linux default numeric values and `0644` metadata.
- Keep writes unsupported for now, matching the existing `/proc/sys/kernel/pid_max` style for sysctl files that Asterinas does not yet make mutable.
- Add procfs regression coverage for values, metadata, and directory entries.
- Remove the corresponding gVisor blocklist entry: `ProcFilesystems.PresenceOfShmMaxMniAll`.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target riscv64imac-unknown-none-elf --no-deps`
- `make -C test/initramfs/src/regression/fs/procfs sys_kernel_shm`
- `git diff --check`

`make kernel` was not runnable in the local WSL environment because `nix-build` is not installed, and pulling the official Docker image failed with Docker Hub EOF. The PR is covered by upstream CI for the full kernel/runtime path.
