### PR TITLE
Support writing /proc/[pid]/comm

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/comm.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::task::Task;
+
 use super::TidDirOps;
 use crate::{
     fs::{
@@ -8,7 +10,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::posix_thread::AsPosixThread,
+    process::posix_thread::{AsPosixThread, MAX_THREAD_NAME_LEN},
     thread::Thread,
 };
 
@@ -32,7 +34,9 @@ impl ProcFileOps for CommFileOps {
             return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
         };
 
-        let posix_thread = thread.as_posix_thread().unwrap();
+        let Some(posix_thread) = thread.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
         let mut comm = posix_thread.thread_name().lock().name().to_bytes().to_vec();
         comm.push(b'\n');
 
@@ -42,11 +46,36 @@ impl ProcFileOps for CommFileOps {
         Ok(bytes_read)
     }
 
-    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
-        warn!("writing to `/proc/[pid]/comm` is not supported");
-        return_errno_with_message!(
-            Errno::EOPNOTSUPP,
-            "writing to `/proc/[pid]/comm` is not supported"
-        );
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let write_len = reader.remain();
+
+        let Some((thread, process)) = self.0.thread_and_process() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+
+        let Some(current_task) = Task::current() else {
+            return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+        };
+        let Some(current_posix_thread) = current_task.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+        };
+        let current_process = current_posix_thread.process();
+        if !Arc::ptr_eq(&current_process, &process) {
+            return_errno_with_message!(Errno::EINVAL, "the thread group is different");
+        }
+
+        let mut name_buf = [0; MAX_THREAD_NAME_LEN - 1];
+        let read_len = write_len.min(name_buf.len());
+        reader.read_fallible(&mut VmWriter::from(&mut name_buf[..read_len]))?;
+
+        let Some(posix_thread) = thread.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        posix_thread
+            .thread_name()
+            .lock()
+            .set_name_from_bytes(&name_buf[..read_len]);
+
+        Ok(write_len)
     }
 }

--- a/kernel/src/process/posix_thread/name.rs
+++ b/kernel/src/process/posix_thread/name.rs
@@ -26,6 +26,10 @@ impl ThreadName {
         self.set_name_as_bytes(name.to_bytes());
     }
 
+    pub fn set_name_from_bytes(&mut self, name_as_bytes: &[u8]) {
+        self.set_name_as_bytes(name_as_bytes);
+    }
+
     fn set_name_as_bytes(&mut self, name_as_bytes: &[u8]) {
         let name_len = name_as_bytes.len().min(MAX_THREAD_NAME_LEN - 1);
         self.0[..name_len].copy_from_slice(&name_as_bytes[..name_len]);

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -41,11 +41,6 @@ ProcSysVmMaxmapCount.HasNumericValue
 ProcSysVmMmapMinAddr.HasNumericValue
 ProcSysVmOvercommitMemory.HasNumericValue
 ProcTask.ChildTaskDir
-ProcTask.CommCanSetPeerThreadName
-ProcTask.CommCanSetSelfThreadName
-ProcTask.CommCannotSetAnotherProcessThreadName
-ProcTask.CommContainsThreadNameAndTrailingNewline
-ProcTask.CommLenLimited
 ProcTask.TaskDirCannotBeDeleted
 ProcTask.VerifyTaskChildren
 ProcTask.VerifyTaskDir

--- a/test/initramfs/src/regression/fs/procfs/comm_write.c
+++ b/test/initramfs/src/regression/fs/procfs/comm_write.c
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define THREAD_NAME "TestThread12345"
+#define LONG_THREAD_NAME "0123456789abcdeXYZ"
+#define TRUNCATED_THREAD_NAME "0123456789abcde\n"
+
+static void format_comm_path(char *path, size_t path_len, pid_t pid, pid_t tid)
+{
+	CHECK_WITH(snprintf(path, path_len, "/proc/%d/task/%d/comm", pid, tid),
+		   _ret > 0 && _ret < path_len);
+}
+
+static ssize_t read_comm(const char *path, char *buf, size_t buf_len)
+{
+	int fd = CHECK(open(path, O_RDONLY));
+	ssize_t len = CHECK(read(fd, buf, buf_len - 1));
+
+	CHECK(close(fd));
+	buf[len] = '\0';
+	return len;
+}
+
+static void *set_comm_from_peer(void *arg)
+{
+	const char *path = arg;
+	int fd = open(path, O_WRONLY);
+	ssize_t len;
+
+	if (fd < 0) {
+		return (void *)(intptr_t)1;
+	}
+
+	len = write(fd, THREAD_NAME, strlen(THREAD_NAME));
+	if (close(fd) != 0 || len != strlen(THREAD_NAME)) {
+		return (void *)(intptr_t)1;
+	}
+
+	return NULL;
+}
+
+static int create_thread(pthread_t *thread, void *(*start_routine)(void *),
+			 void *arg)
+{
+	int error = pthread_create(thread, NULL, start_routine, arg);
+
+	if (error != 0) {
+		errno = error;
+		return -1;
+	}
+
+	errno = 0;
+	return 0;
+}
+
+static int join_thread(pthread_t thread, void **retval)
+{
+	int error = pthread_join(thread, retval);
+
+	if (error != 0) {
+		errno = error;
+		return -1;
+	}
+
+	errno = 0;
+	return 0;
+}
+
+FN_TEST(comm_contains_thread_name_and_trailing_newline)
+{
+	char path[128];
+	char comm[64];
+
+	format_comm_path(path, sizeof(path), getpid(), syscall(SYS_gettid));
+	TEST_SUCC(prctl(PR_SET_NAME, THREAD_NAME));
+	read_comm(path, comm, sizeof(comm));
+
+	TEST_RES(strcmp(comm, THREAD_NAME "\n"), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(comm_can_set_self_thread_name)
+{
+	char path[128];
+	char comm[64];
+	int fd;
+
+	format_comm_path(path, sizeof(path), getpid(), syscall(SYS_gettid));
+	fd = TEST_SUCC(open(path, O_WRONLY));
+	TEST_RES(write(fd, THREAD_NAME, strlen(THREAD_NAME)),
+		 _ret == strlen(THREAD_NAME));
+	TEST_SUCC(close(fd));
+	read_comm(path, comm, sizeof(comm));
+
+	TEST_RES(strcmp(comm, THREAD_NAME "\n"), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(comm_can_set_peer_thread_name)
+{
+	char path[128];
+	char comm[64];
+	pthread_t thread;
+	void *result = NULL;
+
+	format_comm_path(path, sizeof(path), getpid(), syscall(SYS_gettid));
+	TEST_SUCC(create_thread(&thread, set_comm_from_peer, path));
+	TEST_SUCC(join_thread(thread, &result));
+	TEST_RES((intptr_t)result, _ret == 0);
+	read_comm(path, comm, sizeof(comm));
+
+	TEST_RES(strcmp(comm, THREAD_NAME "\n"), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(comm_cannot_set_another_process_thread_name)
+{
+	char path[128];
+	pid_t pid;
+	int status;
+
+	format_comm_path(path, sizeof(path), getpid(), syscall(SYS_gettid));
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		int fd = open(path, O_WRONLY);
+
+		if (fd < 0) {
+			_exit(2);
+		}
+
+		errno = 0;
+		if (write(fd, "x", 1) == -1 && errno == EINVAL) {
+			_exit(0);
+		}
+
+		_exit(1);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(comm_len_limited)
+{
+	char path[128];
+	char comm[64];
+	int fd;
+
+	format_comm_path(path, sizeof(path), getpid(), syscall(SYS_gettid));
+	fd = TEST_SUCC(open(path, O_WRONLY));
+	TEST_RES(write(fd, LONG_THREAD_NAME, strlen(LONG_THREAD_NAME)),
+		 _ret == strlen(LONG_THREAD_NAME));
+	TEST_SUCC(close(fd));
+	read_comm(path, comm, sizeof(comm));
+
+	TEST_RES(strcmp(comm, TRUNCATED_THREAD_NAME), _ret == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -128,6 +128,7 @@ echo "All mount bind file test passed."
 ./overlayfs/readdir_small_buffer
 
 ./procfs/dentry_cache
+./procfs/comm_write
 ./procfs/fd
 ./procfs/getdents
 ./procfs/mountstats


### PR DESCRIPTION
## Summary
- Support writing to `/proc/[pid]/comm` and `/proc/[pid]/task/[tid]/comm`.
- Allow writes only from the same thread group and return `EINVAL` for other processes.
- Truncate names to `TASK_COMM_LEN - 1` bytes and return the original write length.
- Add a procfs regression test and remove the corresponding gVisor `proc_test` blocklist entries.

## Tests
- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs comm_write`
- `cc -Wall -Werror test/initramfs/src/regression/fs/procfs/comm_write.c -o /tmp/asterinas-comm_write -static -lpthread && /tmp/asterinas-comm_write`

## Notes
- I also attempted `VDSO_LIBRARY_DIR=/root/linux_vdso make run_kernel AUTO_TEST=regression BOOT_PROTOCOL=multiboot INITRAMFS_SKIP_GZIP=1 MEM=4G` locally, but this WSL environment lacks `nix-build`. Pulling the official Docker image `asterinas/asterinas:0.18.0-20260618` failed twice with Docker Hub EOF while downloading layers, so full VM regression is left to CI.
