### PR TITLE
Add /proc/[pid]/oom_score

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -11,8 +11,8 @@ use crate::{
                 comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
                 gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
                 mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                ns::NsDirOps, oom_score::OomScoreFileOps, oom_score_adj::OomScoreAdjFileOps,
+                stat::StatFileOps, status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -41,6 +41,7 @@ mod mountinfo;
 mod mounts;
 mod mountstats;
 mod ns;
+mod oom_score;
 mod oom_score_adj;
 pub(super) mod stat;
 mod status;
@@ -117,6 +118,7 @@ impl TidDirOps {
         ("mountinfo", InodeType::File, MountInfoFileOps::new_inode),
         ("mountstats", InodeType::File, MountStatsFileOps::new_inode),
         ("ns", InodeType::Dir, NsDirOps::new_inode),
+        ("oom_score", InodeType::File, OomScoreFileOps::new_inode),
         (
             "oom_score_adj",
             InodeType::File,

--- a/kernel/src/fs/fs_impls/procfs/pid/task/oom_score.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/oom_score.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::sync::atomic::Ordering;
+
+use aster_util::printer::VmPrinter;
+
+use super::{TidDirOps, oom_score_adj::OOM_SCORE_ADJ_MAX};
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    thread::Thread,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/oom_score` (and also `/proc/[pid]/oom_score`).
+pub struct OomScoreFileOps(TidDirOps);
+
+impl OomScoreFileOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3390>
+        ProcFile::new(Self(dir.clone()), parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for OomScoreFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let Some(process) = self.0.process() else {
+            return_errno_with_message!(Errno::ESRCH, "the process does not exist");
+        };
+
+        // Asterinas does not have OOM killer badness accounting yet, so expose the supported
+        // adjustment component as the process's current killability score.
+        let oom_score_adj = process.oom_score_adj().load(Ordering::Relaxed) as i32;
+        let oom_score = oom_score_adj.clamp(0, OOM_SCORE_ADJ_MAX);
+        writeln!(printer, "{}", oom_score)?;
+
+        Ok(printer.bytes_written())
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/oom_score_adj.rs
@@ -65,4 +65,4 @@ impl ProcFileOps for OomScoreAdjFileOps {
 
 // FIXME: Support OOM killer and move these constants to a more appropriate place.
 const OOM_SCORE_ADJ_MIN: i32 = -1000;
-const OOM_SCORE_ADJ_MAX: i32 = 1000;
+pub(super) const OOM_SCORE_ADJ_MAX: i32 = 1000;

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_pid_oomscore_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_pid_oomscore_test
@@ -1,2 +1,0 @@
-# TODO: Support `/proc/[pid]/oom_score`
-ProcPidOomscoreTest.BasicRead

--- a/test/initramfs/src/regression/fs/procfs/oom_score.c
+++ b/test/initramfs/src/regression/fs/procfs/oom_score.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(read_oom_score)
+{
+	char buf[32];
+	char *end;
+	int fd = TEST_SUCC(open("/proc/self/oom_score", O_RDONLY));
+	ssize_t len = TEST_RES(read(fd, buf, sizeof(buf) - 1),
+			       _ret > 1 && _ret < sizeof(buf));
+
+	TEST_SUCC(close(fd));
+	buf[len] = '\0';
+	TEST_RES(buf[len - 1], _ret == '\n');
+
+	long oom_score = strtol(buf, &end, 10);
+
+	TEST_RES(*end, _ret == '\n');
+	TEST_RES(oom_score, _ret >= 0 && _ret <= 1000);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -131,6 +131,7 @@ echo "All mount bind file test passed."
 ./procfs/fd
 ./procfs/getdents
 ./procfs/mountstats
+./procfs/oom_score
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
 ./procfs/tid


### PR DESCRIPTION
## Summary
- Add read-only `/proc/[pid]/oom_score` and `/proc/[pid]/task/[tid]/oom_score` entries.
- Report the currently supported nonnegative `oom_score_adj` component as the process killability score.
- Add a procfs regression test and remove `ProcPidOomscoreTest.BasicRead` from the gVisor blocklist.

## Latest Quality Refresh
- 2026-06-26: amended to commit `81094f2`.
- Rechecked with `git diff --check`, `cargo fmt --check`, and `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`.

## Tests
- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs oom_score`
- `./test/initramfs/src/regression/fs/procfs/oom_score` on Linux as a reference behavior check

## Notes
- Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` failed twice with Docker Hub EOF while downloading layers, so full VM regression is left to CI.