### PR TITLE
Add proc sys kernel overflow IDs

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,8 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                cap_last_cap::CapLastCapFileOps, overflow_id::OverflowIdFileOps,
+                pid_max::PidMaxFileOps, yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -20,6 +21,7 @@ use crate::{
 };
 
 mod cap_last_cap;
+mod overflow_id;
 mod pid_max;
 mod yama;
 
@@ -39,6 +41,16 @@ impl KernelDirOps {
             "cap_last_cap",
             InodeType::File,
             CapLastCapFileOps::new_inode,
+        ),
+        (
+            "overflowgid",
+            InodeType::File,
+            OverflowIdFileOps::new_gid_inode,
+        ),
+        (
+            "overflowuid",
+            InodeType::File,
+            OverflowIdFileOps::new_uid_inode,
         ),
         ("pid_max", InodeType::File, PidMaxFileOps::new_inode),
     ];

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/overflow_id.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/overflow_id.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::credentials::{Gid, Uid},
+};
+
+enum OverflowIdKind {
+    Uid,
+    Gid,
+}
+
+/// Represents `/proc/sys/kernel/overflowuid` and `/proc/sys/kernel/overflowgid`.
+pub struct OverflowIdFileOps {
+    kind: OverflowIdKind,
+}
+
+impl OverflowIdFileOps {
+    pub fn new_uid_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        Self::new_inode(parent, OverflowIdKind::Uid)
+    }
+
+    pub fn new_gid_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        Self::new_inode(parent, OverflowIdKind::Gid)
+    }
+
+    fn new_inode(parent: Weak<dyn Inode>, kind: OverflowIdKind) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/kernel/sysctl.c#L1720>
+        ProcFile::new(Self { kind }, parent, mkmod!(a+r, u+w))
+    }
+
+    fn name(&self) -> &'static str {
+        match self.kind {
+            OverflowIdKind::Uid => "overflowuid",
+            OverflowIdKind::Gid => "overflowgid",
+        }
+    }
+
+    fn value(&self) -> u32 {
+        match self.kind {
+            OverflowIdKind::Uid => Uid::OVERFLOW.into(),
+            OverflowIdKind::Gid => Gid::OVERFLOW.into(),
+        }
+    }
+}
+
+impl ProcFileOps for OverflowIdFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", self.value())?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!(
+            "writing to `/proc/sys/kernel/{}` is not supported",
+            self.name()
+        );
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to the overflow UID/GID sysctl file is not supported"
+        );
+    }
+}

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -5,7 +5,6 @@ Proc.RegressionTestB236035339
 Proc.Statfs
 ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteNonRoot
-ProcFilesystems.OverflowID
 ProcFilesystems.PresenceOfShmMaxMniAll
 ProcPid.AccessDeny
 ProcPidCwd.Subprocess

--- a/test/initramfs/src/regression/fs/procfs/sys_kernel_overflow_id.c
+++ b/test/initramfs/src/regression/fs/procfs/sys_kernel_overflow_id.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define DEFAULT_OVERFLOW_ID 65534
+
+static long read_overflow_id(const char *path)
+{
+	char buf[32];
+	char *end;
+	int fd = CHECK(open(path, O_RDONLY));
+	ssize_t len = CHECK_WITH(read(fd, buf, sizeof(buf) - 1),
+				 _ret > 1 && _ret < sizeof(buf));
+
+	CHECK(close(fd));
+	buf[len] = '\0';
+	CHECK_WITH(buf[len - 1], _ret == '\n');
+
+	long value = strtol(buf, &end, 10);
+
+	CHECK_WITH(*end, _ret == '\n');
+	return value;
+}
+
+FN_TEST(read_kernel_overflow_ids)
+{
+	TEST_RES(read_overflow_id("/proc/sys/kernel/overflowuid"),
+		 _ret == DEFAULT_OVERFLOW_ID);
+	TEST_RES(read_overflow_id("/proc/sys/kernel/overflowgid"),
+		 _ret == DEFAULT_OVERFLOW_ID);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -133,6 +133,7 @@ echo "All mount bind file test passed."
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
+./procfs/sys_kernel_overflow_id
 ./procfs/tid
 
 ./pseudofs/fallocate


### PR DESCRIPTION
## Summary

- Add `/proc/sys/kernel/overflowuid` and `/proc/sys/kernel/overflowgid` backed by the existing `Uid::OVERFLOW` and `Gid::OVERFLOW` constants.
- Keep writes unsupported for now, matching the current procfs sysctl style for entries that Asterinas does not yet make mutable.
- Add procfs regression coverage for both files and remove `ProcFilesystems.OverflowID` from the gVisor blocklist.

## Latest Quality Refresh

- 2026-06-26: amended to commit `c2781e4`.
- Rechecked with `git diff --check`, `cargo fmt --check`, and `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs sys_kernel_overflow_id`
- `./test/initramfs/src/regression/fs/procfs/sys_kernel_overflow_id` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.