### PR TITLE
Use page size for procfs statfs

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -68,7 +68,7 @@ const PROC_MAGIC: u64 = 0x9fa0;
 /// Root Inode ID.
 const PROC_ROOT_INO: u64 = 1;
 /// Block size.
-const BLOCK_SIZE: usize = 1024;
+const BLOCK_SIZE: usize = PAGE_SIZE;
 
 struct ProcFs {
     _anon_device_id: AnonDeviceId,

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -2,7 +2,6 @@ Proc.GetdentsEnoent
 Proc.PidReuse
 Proc.PidTidIOAccounting
 Proc.RegressionTestB236035339
-Proc.Statfs
 ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteNonRoot
 ProcFilesystems.OverflowID

--- a/test/initramfs/src/regression/fs/procfs/statfs.c
+++ b/test/initramfs/src/regression/fs/procfs/statfs.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <limits.h>
+#include <linux/magic.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(proc_statfs)
+{
+	struct statfs st;
+
+	TEST_SUCC(statfs("/proc", &st));
+	TEST_RES(st.f_type, _ret == PROC_SUPER_MAGIC);
+	TEST_RES(st.f_bsize, _ret == getpagesize());
+	TEST_RES(st.f_namelen, _ret == NAME_MAX);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -133,6 +133,7 @@ echo "All mount bind file test passed."
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
+./procfs/statfs
 ./procfs/tid
 
 ./pseudofs/fallocate


### PR DESCRIPTION
## Summary

- Report the system page size as procfs `statfs(2)` block size, matching Linux and the gVisor `Proc.Statfs` expectation.
- Keep the existing procfs magic and name length behavior unchanged.
- Add procfs regression coverage for `/proc` `f_type`, `f_bsize`, and `f_namelen`.
- Remove `Proc.Statfs` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs statfs`
- `./test/initramfs/src/regression/fs/procfs/statfs` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
