### PR TITLE
Add proc root symlink

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -11,8 +11,8 @@ use crate::{
                 comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
                 gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
                 mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, root::RootSymOps,
+                stat::StatFileOps, status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -42,6 +42,7 @@ mod mounts;
 mod mountstats;
 mod ns;
 mod oom_score_adj;
+mod root;
 pub(super) mod stat;
 mod status;
 mod uid_map;
@@ -122,6 +123,7 @@ impl TidDirOps {
             InodeType::File,
             OomScoreAdjFileOps::new_inode,
         ),
+        ("root", InodeType::SymLink, RootSymOps::new_inode),
         ("stat", InodeType::File, StatFileOps::new_thread_inode),
         ("status", InodeType::File, StatusFileOps::new_inode),
         ("uid_map", InodeType::File, UidMapFileOps::new_inode),

--- a/kernel/src/fs/fs_impls/procfs/pid/task/root.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/root.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcSym, ProcSymOps},
+        vfs::inode::{Inode, SymbolicLink},
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    thread::Thread,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/root` (and also `/proc/[pid]/root`).
+pub struct RootSymOps(TidDirOps);
+
+impl RootSymOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3313>
+        ProcSym::new(Self(dir.clone()), parent, mkmod!(a+rwx))
+    }
+}
+
+impl ProcSymOps for RootSymOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+
+        let Some(posix_thread) = thread.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        let root = {
+            let fs = posix_thread.read_fs();
+            let resolver = fs.resolver().read();
+            resolver.root().clone()
+        };
+
+        Ok(SymbolicLink::Path(root))
+    }
+}

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -30,7 +30,6 @@ ProcSelfFdInfo.Flags
 # TODO: Mappings created with only `PROT_WRITE` should be shown as `-w-`.
 ProcSelfMaps.Map2
 ProcSelfMaps.MapUnmap
-ProcSelfRoot.IsRoot
 ProcSelfStat.PopulateWriteRSS
 ProcSysKernelHostname.Exists
 ProcSysKernelHostname.MatchesUname

--- a/test/initramfs/src/regression/fs/procfs/root.c
+++ b/test/initramfs/src/regression/fs/procfs/root.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(proc_self_root_is_root)
+{
+	char buf[64];
+	struct stat st;
+	ssize_t len;
+
+	TEST_SUCC(lstat("/proc/self/root", &st));
+	TEST_RES(S_ISLNK(st.st_mode), _ret != 0);
+
+	len = TEST_RES(readlink("/proc/self/root", buf, sizeof(buf) - 1),
+		       _ret > 0 && _ret < (ssize_t)sizeof(buf));
+	buf[len] = '\0';
+	TEST_RES(strcmp(buf, "/"), _ret == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -133,6 +133,7 @@ echo "All mount bind file test passed."
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
+./procfs/root
 ./procfs/tid
 
 ./pseudofs/fallocate


### PR DESCRIPTION
## Summary

- Add `/proc/[pid]/root` and `/proc/[pid]/task/[tid]/root` symlinks backed by the target thread's filesystem root.
- Add procfs regression coverage for `/proc/self/root` symlink metadata and `readlink(2)` result.
- Remove `ProcSelfRoot.IsRoot` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs root`
- `./test/initramfs/src/regression/fs/procfs/root` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
