### PR TITLE
Add proc status groups field

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -153,6 +153,12 @@ impl ProcFileOps for StatusFileOps {
                 .unwrap_or(0)
         )?;
 
+        write!(printer, "Groups:\t")?;
+        for gid in credentials.groups().iter() {
+            write!(printer, "{} ", u32::from(*gid))?;
+        }
+        writeln!(printer)?;
+
         if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
             let anon = vmar_ref.get_rss_counter(RssType::Anon) * (PAGE_SIZE / 1024);

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -16,7 +16,6 @@ ProcPidMem.DifferentUserAttached
 ProcPidFile.SubprocessRunning
 ProcPidFile.SubprocessZombie
 ProcPidFile.SubprocessExited
-ProcPidStatusTest.HasBasicFields
 ProcPidStatTest.VmStats
 ProcPidSymlink.SubprocessRunning
 ProcPidSymlink.SubprocessZombied

--- a/test/initramfs/src/regression/fs/procfs/status_groups.c
+++ b/test/initramfs/src/regression/fs/procfs/status_groups.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define STATUS_BUF_SIZE 8192
+#define GROUPS_BUF_SIZE 256
+
+static char *find_status_line(char *status, const char *key)
+{
+	size_t key_len = strlen(key);
+	char *line = status;
+
+	while (line && *line != '\0') {
+		char *next = strchr(line, '\n');
+
+		if (next) {
+			*next = '\0';
+		}
+		if (strncmp(line, key, key_len) == 0) {
+			return line + key_len;
+		}
+		line = next ? next + 1 : NULL;
+	}
+
+	return NULL;
+}
+
+static int append_group_list(char *buf, size_t size, gid_t *groups, int ngroups)
+{
+	size_t len = 0;
+
+	for (int i = 0; i < ngroups; i++) {
+		int written = snprintf(buf + len, size - len, "%u",
+				       (unsigned)groups[i]);
+
+		if (written < 0 || (size_t)written >= size - len) {
+			return -1;
+		}
+		len += written;
+		if (i + 1 < ngroups) {
+			if (len + 1 >= size) {
+				return -1;
+			}
+			buf[len++] = ' ';
+			buf[len] = '\0';
+		}
+	}
+
+	return 0;
+}
+
+static void strip_trailing_spaces(char *str)
+{
+	size_t len = strlen(str);
+
+	while (len > 0 && str[len - 1] == ' ') {
+		str[--len] = '\0';
+	}
+}
+
+FN_TEST(proc_status_groups)
+{
+	char status[STATUS_BUF_SIZE];
+	char expected[GROUPS_BUF_SIZE] = "";
+	gid_t groups[64];
+	int ngroups = TEST_RES(getgroups(64, groups), _ret >= 0);
+	FILE *fp = TEST_SUCC(fopen("/proc/self/status", "r"));
+	size_t len = TEST_RES(fread(status, 1, sizeof(status) - 1, fp),
+			      _ret > 0 && _ret < sizeof(status));
+	char *groups_line;
+
+	TEST_SUCC(fclose(fp));
+	status[len] = '\0';
+	TEST_RES(append_group_list(expected, sizeof(expected), groups, ngroups),
+		 _ret == 0);
+
+	groups_line = find_status_line(status, "Groups:\t");
+	TEST_RES(groups_line != NULL, _ret != 0);
+	strip_trailing_spaces(groups_line);
+	TEST_RES(strcmp(groups_line, expected), _ret == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -133,6 +133,7 @@ echo "All mount bind file test passed."
 ./procfs/mountstats
 ./procfs/pid_mem
 ./procfs/proc_fd_open_fifo_after_setid
+./procfs/status_groups
 ./procfs/tid
 
 ./pseudofs/fallocate


### PR DESCRIPTION
## Summary

- Add the `Groups` field to `/proc/[pid]/status` and `/proc/[pid]/task/[tid]/status`.
- Report supplementary group IDs using the same credentials source as `getgroups(2)`.
- Add procfs regression coverage that compares `/proc/self/status` with `getgroups(2)`.
- Remove `ProcPidStatusTest.HasBasicFields` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs status_groups`
- `./test/initramfs/src/regression/fs/procfs/status_groups` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
