### PR TITLE
Add x86 cpuinfo required fields

### DIFF
--- a/kernel/src/arch/x86/cpu.rs
+++ b/kernel/src/arch/x86/cpu.rs
@@ -823,9 +823,7 @@ impl fmt::Display for CpuInformation {
             writeln!(f, "cpu MHz\t\t: Unknown")?;
         }
 
-        if let Some(cache_size) = self.cache_size {
-            writeln!(f, "cache size\t: {} KB", cache_size)?;
-        }
+        writeln!(f, "cache size\t: {} KB", self.cache_size.unwrap_or(0))?;
 
         // Note that we don't support NUMA now, so we assume that all CPUs are on the same package
         // (i.e., their physical IDs are all zeros).
@@ -865,7 +863,13 @@ impl fmt::Display for CpuInformation {
              bugs\t\t:\n"
         )?;
 
-        // TODO: Add the `bogomips` field.
+        let bogomips_x100 = self.cpu_khz.map(|cpu_khz| cpu_khz / 5).unwrap_or(0);
+        writeln!(
+            f,
+            "bogomips\t: {}.{:02}",
+            bogomips_x100 / 100,
+            bogomips_x100 % 100
+        )?;
 
         if let Some(tlb_size) = self.tlb_size {
             writeln!(f, "TLB size\t: {} 4K pages", tlb_size)?;

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -3,7 +3,6 @@ Proc.PidReuse
 Proc.PidTidIOAccounting
 Proc.RegressionTestB236035339
 Proc.Statfs
-ProcCpuinfo.RequiredFieldsArePresent
 ProcCpuinfo.DeniesWriteNonRoot
 ProcFilesystems.OverflowID
 ProcFilesystems.PresenceOfShmMaxMniAll

--- a/test/initramfs/src/regression/fs/procfs/cpuinfo_required_fields.c
+++ b/test/initramfs/src/regression/fs/procfs/cpuinfo_required_fields.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../../common/test.h"
+
+#define CPUINFO_BUF_SIZE 65536
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
+#if defined(__x86_64__) || defined(__i386__)
+static const char *required_fields[] = {
+	"processor",	 "vendor_id",	     "cpu family",
+	"model\t\t:",	 "model name",	     "stepping",
+	"cpu MHz",	 "cache size",	     "physical id",
+	"siblings",	 "core id",	     "cpu cores",
+	"apicid\t\t:",	 "initial apicid",   "fpu\t\t:",
+	"fpu_exception", "cpuid level",	     "wp",
+	"bogomips",	 "clflush size",     "cache_alignment",
+	"address sizes", "power management",
+};
+#elif defined(__riscv)
+static const char *required_fields[] = { "processor", "hart" };
+#else
+static const char *required_fields[] = { "processor" };
+#endif
+
+FN_TEST(cpuinfo_required_fields)
+{
+	char cpuinfo[CPUINFO_BUF_SIZE];
+	FILE *fp = TEST_SUCC(fopen("/proc/cpuinfo", "r"));
+	size_t len = TEST_RES(fread(cpuinfo, 1, sizeof(cpuinfo) - 1, fp),
+			      _ret > 0 && _ret < sizeof(cpuinfo));
+
+	TEST_SUCC(fclose(fp));
+	cpuinfo[len] = '\0';
+
+	for (size_t i = 0; i < ARRAY_SIZE(required_fields); i++) {
+		TEST_RES(strstr(cpuinfo, required_fields[i]) != NULL,
+			 _ret != 0);
+	}
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -128,6 +128,7 @@ echo "All mount bind file test passed."
 ./overlayfs/readdir_small_buffer
 
 ./procfs/dentry_cache
+./procfs/cpuinfo_required_fields
 ./procfs/fd
 ./procfs/getdents
 ./procfs/mountstats


### PR DESCRIPTION
## Summary

- Add the x86 `/proc/cpuinfo` `bogomips` field derived from the measured TSC frequency.
- Always print the x86 `cache size` field, using `0 KB` when CPUID cache probing cannot determine a value.
- Add procfs regression coverage for the gVisor required `/proc/cpuinfo` fields.
- Remove `ProcCpuinfo.RequiredFieldsArePresent` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs cpuinfo_required_fields`
- `./test/initramfs/src/regression/fs/procfs/cpuinfo_required_fields` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
