### PR TITLE
Add proc cwd symlink

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/cwd.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/cwd.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcSym, ProcSymOps},
+        vfs::inode::{Inode, SymbolicLink},
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    thread::Thread,
+};
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/cwd` (and also `/proc/[pid]/cwd`).
+pub struct CwdSymOps(TidDirOps);
+
+impl CwdSymOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L3312>
+        ProcSym::new(Self(dir.clone()), parent, mkmod!(a+rwx))
+    }
+}
+
+impl ProcSymOps for CwdSymOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+
+        let Some(posix_thread) = thread.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        let cwd = {
+            let fs = posix_thread.read_fs();
+            let resolver = fs.resolver().read();
+            resolver.cwd().clone()
+        };
+
+        Ok(SymbolicLink::Path(cwd))
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -8,8 +8,8 @@ use crate::{
             StaticEntryWithOps,
             pid::task::{
                 auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
-                comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
+                comm::CommFileOps, cwd::CwdSymOps, environ::EnvironFileOps, exe::ExeSymOps,
+                fd::FdDirOps, gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
                 mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
                 ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
                 status::StatusFileOps, uid_map::UidMapFileOps,
@@ -31,6 +31,7 @@ mod auxv;
 mod cgroup;
 mod cmdline;
 mod comm;
+mod cwd;
 mod environ;
 mod exe;
 mod fd;
@@ -104,6 +105,7 @@ impl TidDirOps {
         ("cgroup", InodeType::File, CgroupFileOps::new_inode),
         ("cmdline", InodeType::File, CmdlineFileOps::new_inode),
         ("comm", InodeType::File, CommFileOps::new_inode),
+        ("cwd", InodeType::SymLink, CwdSymOps::new_inode),
         ("environ", InodeType::File, EnvironFileOps::new_inode),
         ("exe", InodeType::SymLink, ExeSymOps::new_inode),
         ("fd", InodeType::Dir, FdDirOps::<fd::FileSymOps>::new_inode),

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -8,7 +8,6 @@ ProcCpuinfo.DeniesWriteNonRoot
 ProcFilesystems.OverflowID
 ProcFilesystems.PresenceOfShmMaxMniAll
 ProcPid.AccessDeny
-ProcPidCwd.Subprocess
 ProcPidRoot.Subprocess
 ProcPidEnviron.MatchesEnviron
 # TODO: Support `ptrace`.
@@ -23,7 +22,6 @@ ProcPidSymlink.SubprocessZombied
 ProcPidSymlink.SubprocessExited
 ProcSelfAuxv.EntryPresence
 ProcSelfAuxv.EntryValues
-ProcSelfCwd.Absolute
 ProcSelfFd.OpenFd
 # TODO: Support `O_LARGEFILE` flag.
 ProcSelfFdInfo.Flags

--- a/test/initramfs/src/regression/fs/procfs/cwd.c
+++ b/test/initramfs/src/regression/fs/procfs/cwd.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define PATH_BUF_SIZE 4096
+
+static int readlink_into(const char *path, char *buf, size_t size)
+{
+	ssize_t len = readlink(path, buf, size - 1);
+
+	if (len <= 0 || len >= (ssize_t)size) {
+		return -1;
+	}
+	buf[len] = '\0';
+	return 0;
+}
+
+FN_TEST(proc_self_cwd)
+{
+	char want[PATH_BUF_SIZE];
+	char got[PATH_BUF_SIZE];
+
+	TEST_RES(getcwd(want, sizeof(want)) != NULL, _ret != 0);
+	TEST_RES(readlink_into("/proc/self/cwd", got, sizeof(got)), _ret == 0);
+	TEST_RES(strcmp(got, want), _ret == 0);
+}
+END_TEST()
+
+FN_TEST(proc_pid_cwd)
+{
+	char want[PATH_BUF_SIZE];
+	char path[PATH_BUF_SIZE];
+	char got[PATH_BUF_SIZE];
+	pid_t child;
+
+	TEST_RES(getcwd(want, sizeof(want)) != NULL, _ret != 0);
+
+	child = fork();
+	if (child == 0) {
+		for (;;) {
+			pause();
+		}
+	}
+	TEST_RES(child, _ret > 0);
+
+	TEST_RES(snprintf(path, sizeof(path), "/proc/%d/cwd", child),
+		 _ret > 0 && _ret < (int)sizeof(path));
+	TEST_RES(readlink_into(path, got, sizeof(got)), _ret == 0);
+	TEST_RES(strcmp(got, want), _ret == 0);
+
+	TEST_SUCC(kill(child, SIGKILL));
+	TEST_RES(waitpid(child, NULL, 0), _ret == child);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -128,6 +128,7 @@ echo "All mount bind file test passed."
 ./overlayfs/readdir_small_buffer
 
 ./procfs/dentry_cache
+./procfs/cwd
 ./procfs/fd
 ./procfs/getdents
 ./procfs/mountstats


### PR DESCRIPTION
## Summary

- Add `/proc/[pid]/cwd` and `/proc/[pid]/task/[tid]/cwd` symlinks backed by the target thread's filesystem current working directory.
- Add procfs regression coverage for `/proc/self/cwd` and a live subprocess `/proc/<pid>/cwd`.
- Remove `ProcSelfCwd.Absolute` and `ProcPidCwd.Subprocess` from the gVisor procfs blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/fs/procfs cwd`
- `./test/initramfs/src/regression/fs/procfs/cwd` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
