### PR TITLE
Support fcntl F_GETPIPE_SZ

### DIFF
--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -10,7 +10,7 @@ use ostd::sync::WaitQueue;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, PerOpenFileOps, StatusFlags},
+        file::{AccessMode, FileLike, InodeHandle, PerOpenFileOps, StatusFlags},
         utils::{Endpoint, EndpointState},
         vfs::inode::FileOps,
     },
@@ -60,6 +60,19 @@ impl PipeHandle {
     fn bytes_to_read(&self) -> usize {
         self.inner.reader.buffer_len()
     }
+
+    fn capacity(&self) -> usize {
+        self.inner.reader.capacity()
+    }
+}
+
+pub(crate) fn pipe_size(file: &dyn FileLike) -> Option<usize> {
+    let inode_handle = file.downcast_ref::<InodeHandle>()?;
+    let Ok(Some(pipe_handle)) = inode_handle.downcast_open_file::<PipeHandle>() else {
+        return None;
+    };
+
+    Some(pipe_handle.capacity())
 }
 
 impl Pollable for PipeHandle {
@@ -409,6 +422,10 @@ impl PipeReader {
 
     fn buffer_len(&self) -> usize {
         self.consumer.lock().len()
+    }
+
+    fn capacity(&self) -> usize {
+        self.consumer.lock().capacity()
     }
 
     fn peer_shutdown(&self) {

--- a/kernel/src/fs/pipe/mod.rs
+++ b/kernel/src/fs/pipe/mod.rs
@@ -6,6 +6,7 @@
 
 pub(super) use anon_pipe::AnonPipeInode;
 pub use anon_pipe::new_file_pair;
+pub(crate) use common::pipe_size;
 pub(super) use common::{Pipe, PipeHandle, check_status_flags};
 
 mod anon_pipe;

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -9,6 +9,7 @@ use crate::{
             FileLike, StatusFlags,
             file_table::{FdFlags, FileDesc, RawFileDesc, WithFileTable, get_file_fast},
         },
+        pipe,
         ramfs::memfd::{FileSeals, MemfdInodeHandle},
         vfs::range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
     },
@@ -35,6 +36,7 @@ pub fn sys_fcntl(raw_fd: RawFileDesc, cmd: i32, arg: u64, ctx: &Context) -> Resu
         }),
         FcntlCmd::F_GETOWN => handle_getown(fd, ctx),
         FcntlCmd::F_SETOWN => handle_setown(fd, arg, ctx),
+        FcntlCmd::F_GETPIPE_SZ => handle_getpipe_sz(fd, ctx),
         FcntlCmd::F_ADD_SEALS => handle_addseal(fd, arg, ctx),
         FcntlCmd::F_GET_SEALS => handle_getseal(fd, ctx),
     }
@@ -166,6 +168,15 @@ fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn>
     Ok(SyscallReturn::Return(0))
 }
 
+fn handle_getpipe_sz(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+    let size = pipe::pipe_size(&**file)
+        .ok_or_else(|| Error::with_message(Errno::EBADF, "the file is not a pipe"))?;
+
+    Ok(SyscallReturn::Return(size as _))
+}
+
 fn handle_addseal(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
     let new_seals = FileSeals::from_bits(arg as u32)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid seals"))?;
@@ -202,6 +213,7 @@ enum FcntlCmd {
     F_SETOWN = 8,
     F_GETOWN = 9,
     F_DUPFD_CLOEXEC = 1030,
+    F_GETPIPE_SZ = 1032,
     F_ADD_SEALS = 1033,
     F_GET_SEALS = 1034,
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/sendfile_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/sendfile_test
@@ -1,2 +1,0 @@
-# TODO: Support `F_GETPIPE_SZ` for `fcntl` syscall.
-SendFileTest.SendPipeBlocks

--- a/test/initramfs/src/regression/ipc/pipe/pipe_err.c
+++ b/test/initramfs/src/regression/ipc/pipe/pipe_err.c
@@ -3,6 +3,7 @@
 #define _GNU_SOURCE
 
 #include "../../common/test.h"
+#include <fcntl.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/poll.h>
@@ -15,6 +16,29 @@ FN_SETUP()
 	signal(SIGPIPE, SIG_IGN);
 }
 END_SETUP()
+
+FN_TEST(fcntl_getpipe_sz)
+{
+	int fildes[2];
+	int file_fd;
+	int size;
+
+	TEST_SUCC(pipe(fildes));
+
+	size = TEST_SUCC(fcntl(fildes[0], F_GETPIPE_SZ));
+	TEST_RES(size, _ret > 0);
+	TEST_RES(fcntl(fildes[1], F_GETPIPE_SZ), _ret == size);
+
+	file_fd = TEST_SUCC(
+		open("/tmp_f_getpipe_sz", O_CREAT | O_RDWR | O_TRUNC, 0600));
+	TEST_ERRNO(fcntl(file_fd, F_GETPIPE_SZ), EBADF);
+
+	TEST_SUCC(close(file_fd));
+	TEST_SUCC(unlink("/tmp_f_getpipe_sz"));
+	TEST_SUCC(close(fildes[0]));
+	TEST_SUCC(close(fildes[1]));
+}
+END_TEST()
 
 FN_TEST(close_without_data_then_read)
 {


### PR DESCRIPTION
## Summary

- Add `fcntl(F_GETPIPE_SZ)` support for pipe file descriptors.
- Share pipe capacity lookup through an internal pipe helper that works for both anonymous pipes and FIFO-backed `InodeHandle`s.
- Add regression coverage for successful `F_GETPIPE_SZ` on both pipe ends and Linux-compatible `EBADF` on non-pipe file descriptors.
- Remove `SendFileTest.SendPipeBlocks` from the gVisor `sendfile_test` blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/ipc/pipe pipe_err`
- `./test/initramfs/src/regression/ipc/pipe/pipe_err` on Linux as a reference behavior check
- `git diff --check`

## Notes

This PR intentionally leaves `F_SETPIPE_SZ` unsupported because the current pipe buffer is fixed-size and resizing requires separate state-management work. Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
