### PR TITLE
Support TIOCINQ on Unix sockets

### DIFF
--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -12,7 +12,10 @@ use crate::{
         vfs::path::Path,
     },
     prelude::*,
-    util::{MultiRead, MultiWrite},
+    util::{
+        MultiRead, MultiWrite,
+        ioctl::{RawIoctl, dispatch_ioctl},
+    },
 };
 
 pub mod ip;
@@ -127,6 +130,11 @@ pub trait Socket: private::SocketPrivate + Send + Sync {
 
     /// Returns a reference to the pseudo path associated with this socket.
     fn pseudo_path(&self) -> &Path;
+
+    /// Returns the number of bytes that can be read without blocking.
+    fn num_bytes_to_read(&self) -> Result<usize> {
+        return_errno_with_message!(Errno::ENOTTY, "the socket does not support FIONREAD")
+    }
 }
 
 impl<T: Socket + 'static> FileLike for T {
@@ -167,6 +175,22 @@ impl<T: Socket + 'static> FileLike for T {
             self.set_nonblocking(false);
         }
         Ok(())
+    }
+
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        use crate::util::ioctl::common_defs::GetNumBytesToRead;
+
+        dispatch_ioctl!(match raw_ioctl {
+            cmd @ GetNumBytesToRead => {
+                let bytes_to_read = i32::try_from(self.num_bytes_to_read()?).map_err(|_| {
+                    Error::with_message(Errno::EOVERFLOW, "the readable byte count is too large")
+                })?;
+
+                cmd.write(&bytes_to_read)?;
+                Ok(0)
+            }
+            _ => return_errno_with_message!(Errno::ENOTTY, "the ioctl command is unknown"),
+        })
     }
 
     fn access_mode(&self) -> AccessMode {

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -218,6 +218,15 @@ impl MessageReceiver {
         &self.queue
     }
 
+    pub(super) fn num_bytes_to_read(&self) -> usize {
+        self.queue
+            .inner
+            .lock()
+            .as_ref()
+            .and_then(|inner| inner.messages.front().map(|msg| msg.bytes.len()))
+            .unwrap_or(0)
+    }
+
     pub(super) fn pollee(&self) -> &Pollee {
         &self.queue.pollee
     }

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -301,6 +301,10 @@ impl Socket for UnixDatagramSocket {
     fn pseudo_path(&self) -> &Path {
         &self.pseudo_path
     }
+
+    fn num_bytes_to_read(&self) -> Result<usize> {
+        Ok(self.local_receiver.num_bytes_to_read())
+    }
 }
 
 fn do_unix_getsockopt(option: &mut dyn SocketOption, socket: &UnixDatagramSocket) -> Result<()> {

--- a/kernel/src/net/socket/unix/stream/connected.rs
+++ b/kernel/src/net/socket/unix/stream/connected.rs
@@ -332,6 +332,10 @@ impl Connected {
         self.inner.this_end().is_pass_cred.load(Ordering::Relaxed)
     }
 
+    pub(super) fn num_bytes_to_read(&self) -> usize {
+        self.inner.this_end().reader.lock().len()
+    }
+
     pub(super) fn check_io_events(&self) -> IoEvents {
         let this_end = self.inner.this_end();
         let mut events = IoEvents::empty();

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -517,6 +517,13 @@ impl Socket for UnixStreamSocket {
     fn pseudo_path(&self) -> &Path {
         &self.pseudo_path
     }
+
+    fn num_bytes_to_read(&self) -> Result<usize> {
+        match self.state.read().as_ref() {
+            State::Connected(connected) => Ok(connected.num_bytes_to_read()),
+            State::Init(_) | State::Listen(_) => Ok(0),
+        }
+    }
 }
 
 fn do_unix_getsockopt(option: &mut dyn SocketOption, state: &State) -> Result<()> {

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_pair_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_pair_test
@@ -2,7 +2,6 @@
 AllUnixDomainSockets/UnixSocketPairTest.RecvmmsgTimeoutAfterRecv/*
 
 # TODO: Support `ioctl` operations on sockets
-AllUnixDomainSockets/UnixSocketPairTest.TIOCINQSucceeds/*
 AllUnixDomainSockets/UnixSocketPairTest.TIOCOUTQSucceeds/*
 AllUnixDomainSockets/UnixSocketPairTest.NetdeviceIoctlsSucceed/*
 

--- a/test/initramfs/src/regression/network/socketpair.c
+++ b/test/initramfs/src/regression/network/socketpair.c
@@ -1,17 +1,73 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include <stdio.h>
-#include <sys/socket.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #define MESG1 "Hello from child"
 #define MESG2 "Hello from parent"
+
+static void check_fionread(int type)
+{
+	int sockets[2];
+	int pending = -1;
+	char buf[8];
+
+	if (socketpair(AF_UNIX, type, 0, sockets) < 0) {
+		perror("create socket pair for FIONREAD");
+		exit(1);
+	}
+
+	if (ioctl(sockets[1], FIONREAD, &pending) < 0) {
+		perror("FIONREAD on empty socket");
+		exit(1);
+	}
+	if (pending != 0) {
+		fprintf(stderr, "FIONREAD on empty socket got %d\n", pending);
+		exit(1);
+	}
+
+	if (send(sockets[0], "abc", 3, 0) != 3) {
+		perror("send for FIONREAD");
+		exit(1);
+	}
+	if (ioctl(sockets[1], FIONREAD, &pending) < 0) {
+		perror("FIONREAD on readable socket");
+		exit(1);
+	}
+	if (pending != 3) {
+		fprintf(stderr, "FIONREAD on readable socket got %d\n",
+			pending);
+		exit(1);
+	}
+
+	if (recv(sockets[1], buf, sizeof(buf), 0) < 0) {
+		perror("recv for FIONREAD");
+		exit(1);
+	}
+	if (ioctl(sockets[1], FIONREAD, &pending) < 0) {
+		perror("FIONREAD after recv");
+		exit(1);
+	}
+	if (pending != 0) {
+		fprintf(stderr, "FIONREAD after recv got %d\n", pending);
+		exit(1);
+	}
+
+	close(sockets[0]);
+	close(sockets[1]);
+}
 
 int main()
 {
 	int sockets[2], child;
 	char buf[1024];
+	check_fionread(SOCK_STREAM);
+	check_fionread(SOCK_DGRAM);
+	check_fionread(SOCK_SEQPACKET);
+
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
 		perror("create socket pair");
 		exit(1);


### PR DESCRIPTION
## Summary

- Add socket `ioctl(FIONREAD)` / `TIOCINQ` support through the common socket `FileLike` implementation.
- Report readable bytes for UNIX stream and seqpacket sockets from the receive ring buffer.
- Report the next datagram length for UNIX datagram sockets, matching Linux `FIONREAD` behavior.
- Add regression coverage for `FIONREAD` on `SOCK_STREAM`, `SOCK_DGRAM`, and `SOCK_SEQPACKET` UNIX socket pairs.
- Remove `AllUnixDomainSockets/UnixSocketPairTest.TIOCINQSucceeds/*` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/network socketpair`
- `./test/initramfs/src/regression/network/socketpair` on Linux as a reference behavior check
- `git diff --check`

## Notes

This PR intentionally leaves `TIOCOUTQ` and netdevice ioctls unsupported because they require different socket accounting or network-device query paths. Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
