### PR TITLE
Unblock ioctl null-arg tests

### DIFF
--- a/test/initramfs/src/conformance/gvisor/blocklists/ioctl_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/ioctl_test
@@ -2,8 +2,6 @@ IoctlTest.BadFileDescriptor
 IoctlTest.InvalidControlNumber
 IoctlTest.IoctlWithOpath
 IoctlTest.FIONBIOSucceeds
-IoctlTest.FIONBIOFails
-IoctlTest.FIOASYNCFails
 IoctlTest.FIOASYNCHandlesFuseFD
 IoctlTest.FIOASYNCSucceeds
 IoctlTest.FIOASYNCNoTarget

--- a/test/initramfs/src/regression/io/file_io/ioctl_null_arg.c
+++ b/test/initramfs/src/regression/io/file_io/ioctl_null_arg.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(fionbio_fioasync_null_arg)
+{
+	int fd;
+
+	fd = TEST_SUCC(open("/dev/null", O_RDONLY));
+	TEST_ERRNO(ioctl(fd, FIONBIO, NULL), EFAULT);
+	TEST_ERRNO(ioctl(fd, FIOASYNC, NULL), EFAULT);
+	TEST_SUCC(close(fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/io/run_test.sh
+++ b/test/initramfs/src/regression/io/run_test.sh
@@ -15,4 +15,5 @@ set -e
 ./file_io/block_device
 ./file_io/fcntl_lock
 ./file_io/file_err
+./file_io/ioctl_null_arg
 ./file_io/iovec_err


### PR DESCRIPTION
## Summary

- Add a focused regression for `ioctl(FIONBIO, NULL)` and `ioctl(FIOASYNC, NULL)` returning `EFAULT`.
- Remove `IoctlTest.FIONBIOFails` and `IoctlTest.FIOASYNCFails` from the gVisor blocklist.
- Keep the remaining `ioctl_test` blocklist entries unchanged because they cover broader unsupported ioctl behavior.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/io/file_io ioctl_null_arg`
- `./test/initramfs/src/regression/io/file_io/ioctl_null_arg` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
