### PR TITLE
Reject ioctl on O_PATH fds

### DIFF
--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -21,6 +21,16 @@ pub fn sys_ioctl(
     debug!("raw_fd = {}, raw_ioctl = {:#x?}", raw_fd, raw_ioctl,);
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let fd = raw_fd.try_into()?;
+
+    let file = get_file_fast!(&mut file_table, fd);
+    if file.status_flags().contains(StatusFlags::O_PATH) {
+        return_errno_with_message!(
+            Errno::EBADF,
+            "ioctl does not support O_PATH file descriptors"
+        );
+    }
+    drop(file);
 
     // First, handle the ioctl command that affects the file descriptor.
     if let Some(res) = handle_fd_ioctl(&mut file_table, raw_fd, raw_ioctl) {
@@ -28,7 +38,7 @@ pub fn sys_ioctl(
         return Ok(SyscallReturn::Return(0));
     }
 
-    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+    let file = get_file_fast!(&mut file_table, fd);
 
     // Then, handle the ioctl command the affects the file description.
     let res = if let Some(res) = handle_file_ioctl(&**file, raw_ioctl) {

--- a/test/initramfs/src/conformance/gvisor/blocklists/ioctl_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/ioctl_test
@@ -1,6 +1,5 @@
 IoctlTest.BadFileDescriptor
 IoctlTest.InvalidControlNumber
-IoctlTest.IoctlWithOpath
 IoctlTest.FIONBIOSucceeds
 IoctlTest.FIONBIOFails
 IoctlTest.FIOASYNCFails

--- a/test/initramfs/src/regression/io/file_io/access_err.c
+++ b/test/initramfs/src/regression/io/file_io/access_err.c
@@ -207,6 +207,9 @@ FN_TEST(path)
 	TEST_ERRNO(write(fd, buf, sizeof(buf)), EBADF);
 	TEST_ERRNO(lseek(fd, 0, SEEK_SET), EBADF);
 	TEST_ERRNO(lseek(fd, 0, SEEK_END), EBADF);
+	TEST_ERRNO(ioctl(fd, FIONBIO, &fd), EBADF);
+	TEST_ERRNO(ioctl(fd, FIONCLEX), EBADF);
+	TEST_ERRNO(ioctl(fd, FIOCLEX), EBADF);
 	TEST_ERRNO(ioctl(fd, TCGETS), EBADF);
 	TEST_ERRNO(ftruncate(fd, 1), EBADF);
 	TEST_ERRNO(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1), EBADF);


### PR DESCRIPTION
## Summary

- Make `ioctl(2)` reject `O_PATH` file descriptors with `EBADF` before handling fd-level or file-level commands.
- Extend the existing `access_err` regression to cover `FIONBIO`, `FIONCLEX`, and `FIOCLEX` on an `O_PATH` fd.
- Remove `IoctlTest.IoctlWithOpath` from the gVisor blocklist.

## Test Plan

- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso RUSTFLAGS="-Dwarnings --check-cfg cfg(ktest)" cargo clippy -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-none -p aster-kernel --no-deps`
- `make -C test/initramfs/src/regression check`
- `make -C test/initramfs/src/regression/io/file_io access_err`
- `./test/initramfs/src/regression/io/file_io/access_err` on Linux as a reference behavior check
- `git diff --check`

## Notes

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
