### PR TITLE
Reject O_DIRECT opens on directories

### DIFF
--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -160,6 +160,12 @@ impl Path {
                 "O_DIRECTORY is specified but the file is not a directory"
             );
         }
+        if inode_type == InodeType::Dir
+            && status_flags.contains(StatusFlags::O_DIRECT)
+            && !status_flags.contains(StatusFlags::O_PATH)
+        {
+            return_errno_with_message!(Errno::EINVAL, "O_DIRECT cannot open a directory");
+        }
 
         if inode_type.is_regular_file()
             && creation_flags.contains(CreationFlags::O_TRUNC)

--- a/test/initramfs/src/conformance/gvisor/blocklists/open_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/open_test
@@ -1,7 +1,6 @@
 OpenTest.AppendConcurrentWrite
 OpenTest.CanTruncateReadOnlyNoWritePermission
 OpenTest.CanTruncateWithStrangePermissions
-OpenTest.DirectoryDirectFails
 OpenTest.OpenNoFollowStillFollowsLinksInPath
 OpenTest.OpenWithStrangeFlags
 OpenTest.OTrunc

--- a/test/initramfs/src/regression/fs/ext2/open_dir.c
+++ b/test/initramfs/src/regression/fs/ext2/open_dir.c
@@ -90,6 +90,12 @@ FN_TEST(open_rdwr_on_dir_returns_eisdir)
 }
 END_TEST()
 
+FN_TEST(open_direct_on_dir_returns_einval)
+{
+	TEST_ERRNO(open(TARGET_DIR, O_RDONLY | O_DIRECT), EINVAL);
+}
+END_TEST()
+
 FN_SETUP(cleanup)
 {
 	CHECK(rmdir(TARGET_DIR));


### PR DESCRIPTION
## Summary

- reject `open(..., O_DIRECT)` on directories with `EINVAL`, matching Linux behavior
- keep `O_PATH` semantics unchanged because Linux ignores `O_DIRECT` when `O_PATH` is set
- add an ext2 regression test and unblock gVisor `OpenTest.DirectoryDirectFails`

## Test

- `cargo fmt`
- `clang-format -i test/initramfs/src/regression/fs/ext2/open_dir.c`
- `make -C test/initramfs/src/regression/fs/ext2 open_dir`
- `make -C test/initramfs/src/regression check`
- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`
- `git diff --check`

I also checked Linux behavior in WSL by calling `open("/tmp", O_DIRECT)` through libc and confirmed it fails with `errno = 22` (`EINVAL`).

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
