### PR TITLE
Unblock mknod existing path test

### DIFF
--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/mknod_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/mknod_test
@@ -1,1 +1,2 @@
+MknodTest.MknodOnExistingPathFails
 MknodTest.RegularFilePermissions

--- a/test/initramfs/src/conformance/gvisor/blocklists/mknod_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/mknod_test
@@ -6,7 +6,6 @@ MknodTest.FifoTruncNoOp
 
 # Buggy or unimplemented in exfat and ext2.
 MknodTest.MknodAtFIFO
-MknodTest.MknodOnExistingPathFails
 
 # This test cannot pass in Linux when run as root, and
 # it has been removed from the latest version of gVisor.

--- a/test/initramfs/src/regression/fs/ext2/mknod.c
+++ b/test/initramfs/src/regression/fs/ext2/mknod.c
@@ -11,6 +11,8 @@
 #define NULL_DEVICE_PATH "/ext2/my_null_device"
 #define ZERO_DEVICE_PATH "/ext2/my_zero_device"
 #define FIFO_PATH "/ext2/myfifo.fifo"
+#define EXISTING_FILE_PATH "/ext2/mknod_existing_file"
+#define EXISTING_SYMLINK_PATH "/ext2/mknod_existing_symlink"
 
 FN_TEST(make_device_node)
 {
@@ -56,5 +58,19 @@ FN_TEST(make_fifo_node)
 	TEST_SUCC(close(reader_fd));
 	TEST_SUCC(close(writer_fd));
 	TEST_SUCC(unlink(FIFO_PATH));
+}
+END_TEST()
+
+FN_TEST(mknod_on_existing_paths_returns_eexist)
+{
+	int fd = TEST_SUCC(open(EXISTING_FILE_PATH, O_CREAT | O_RDWR, 0666));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(symlink(EXISTING_FILE_PATH, EXISTING_SYMLINK_PATH));
+
+	TEST_ERRNO(mknod(EXISTING_FILE_PATH, S_IFIFO, 0), EEXIST);
+	TEST_ERRNO(mknod(EXISTING_SYMLINK_PATH, S_IFIFO, 0), EEXIST);
+
+	TEST_SUCC(unlink(EXISTING_SYMLINK_PATH));
+	TEST_SUCC(unlink(EXISTING_FILE_PATH));
 }
 END_TEST()


### PR DESCRIPTION
## Summary

- add an ext2 regression for `mknod` on an existing regular file and an existing symlink
- document the expected Linux-compatible `EEXIST` result for both paths
- unblock gVisor `MknodTest.MknodOnExistingPathFails` for the base/ext2 configuration while keeping it blocked for exFAT

## Test

- `clang-format -i test/initramfs/src/regression/fs/ext2/mknod.c`
- `make -C test/initramfs/src/regression/fs/ext2 mknod`
- `make -C test/initramfs/src/regression check`
- `cargo fmt --check`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo check -p aster-kernel --target x86_64-unknown-none`
- `VDSO_LIBRARY_DIR=/root/linux_vdso cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`
- `git diff --check`

After opening the PR, upstream CI showed that exFAT still needs its filesystem-specific blocklist entry for this gVisor case, so the test is now removed from the common blocklist and retained in `blocklists.exfat/mknod_test`.

I also checked Linux behavior in WSL with libc `mknod` calls and confirmed both an existing regular file and an existing symlink fail with `errno = 17` (`EEXIST`).

Full local VM regression is not available in this WSL environment because `nix-build` is missing. Pulling `asterinas/asterinas:0.18.0-20260618` previously failed with Docker Hub EOF while downloading layers, so full VM regression is left to upstream CI.
