### PR TITLE
Add /proc/sys/fs/nr_open

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/fs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/fs/mod.rs
@@ -1,40 +1,39 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use self::{fs::FsDirOps, kernel::KernelDirOps};
-use super::{
-    StaticEntry,
-    template::{ReaddirEntry, listed_entries_from_table, visit_listed_entries},
-};
 use crate::{
     fs::{
         file::{InodeType, mkmod},
-        procfs::template::{ProcDir, ProcDirOps, lookup_child_from_table},
+        procfs::{
+            ProcDir, StaticEntry,
+            sys::fs::nr_open::NrOpenFileOps,
+            template::{
+                ProcDirOps, ReaddirEntry, listed_entries_from_table, lookup_child_from_table,
+                visit_listed_entries,
+            },
+        },
         vfs::inode::Inode,
     },
     prelude::*,
 };
 
-mod fs;
-mod kernel;
+mod nr_open;
 
-/// Represents the inode at `/proc/sys`.
-pub struct SysDirOps;
+/// Represents the inode at `/proc/sys/fs`.
+pub struct FsDirOps;
 
-impl SysDirOps {
+impl FsDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         // Reference:
-        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L1566>
-        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L488-L489>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/file_table.c#L139>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L978>
         ProcDir::new(Self, parent, mkmod!(a+rx))
     }
 
-    const STATIC_ENTRIES: &'static [StaticEntry] = &[
-        ("fs", InodeType::Dir, FsDirOps::new_inode),
-        ("kernel", InodeType::Dir, KernelDirOps::new_inode),
-    ];
+    const STATIC_ENTRIES: &'static [StaticEntry] =
+        &[("nr_open", InodeType::File, NrOpenFileOps::new_inode)];
 }
 
-impl ProcDirOps for SysDirOps {
+impl ProcDirOps for FsDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
             (f)(this_dir.this_weak().clone())

--- a/kernel/src/fs/fs_impls/procfs/sys/fs/nr_open.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/fs/nr_open.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::rlimit::SYSCTL_NR_OPEN,
+};
+
+/// Represents the inode at `/proc/sys/fs/nr_open`.
+pub struct NrOpenFileOps;
+
+impl NrOpenFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/file_table.c#L130>
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for NrOpenFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", SYSCTL_NR_OPEN)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!("writing to `/proc/sys/fs/nr_open` is not supported");
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to `/proc/sys/fs/nr_open` is not supported"
+        );
+    }
+}


### PR DESCRIPTION
This PR adds `/proc/sys/fs/nr_open`.

## Changes

- Add the `/proc/sys/fs` procfs directory.
- Add `/proc/sys/fs/nr_open` using the existing `SYSCTL_NR_OPEN` value.

This file is used by applications that inspect the host file descriptor limit.

Part of #3430.