### PR TITLE
Add namespace plumbing for container runtimes

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/ns.rs
@@ -22,7 +22,7 @@ use crate::{
     ipc::IpcNamespace,
     net::uts_ns::UtsNamespace,
     prelude::*,
-    process::{NsProxy, UserNamespace, posix_thread::AsPosixThread},
+    process::{NetNamespace, NsProxy, PidNamespace, UserNamespace, posix_thread::AsPosixThread},
     thread::Thread,
 };
 
@@ -52,13 +52,24 @@ enum NsProxyEntry {
     Ipc,
     /// The mount namespace.
     Mnt,
+    /// The network namespace.
+    Net,
+    /// The PID namespace.
+    Pid,
     /// The UTS namespace.
     Uts,
 }
 
 impl NsProxyEntry {
     /// All supported `NsProxy`-backed namespace entries.
-    const ALL: &[Self] = &[Self::Cgroup, Self::Ipc, Self::Mnt, Self::Uts];
+    const ALL: &[Self] = &[
+        Self::Cgroup,
+        Self::Ipc,
+        Self::Mnt,
+        Self::Net,
+        Self::Pid,
+        Self::Uts,
+    ];
 
     /// Returns the filename of this namespace entry under `/proc/[pid]/ns/`.
     fn as_str(self) -> &'static str {
@@ -66,6 +77,8 @@ impl NsProxyEntry {
             Self::Cgroup => "cgroup",
             Self::Ipc => "ipc",
             Self::Mnt => "mnt",
+            Self::Net => "net",
+            Self::Pid => "pid",
             Self::Uts => "uts",
         }
     }
@@ -76,6 +89,8 @@ impl NsProxyEntry {
             "cgroup" => Some(Self::Cgroup),
             "ipc" => Some(Self::Ipc),
             "mnt" => Some(Self::Mnt),
+            "net" => Some(Self::Net),
+            "pid" => Some(Self::Pid),
             "uts" => Some(Self::Uts),
             _ => None,
         }
@@ -104,11 +119,33 @@ impl NsProxyEntry {
                 ns_proxy.mnt_ns().get_path(),
                 parent,
             ),
+            Self::Net => NsSymOps::<NetNamespace>::new_inode(
+                dir.clone(),
+                ns_proxy.net_ns().get_path(),
+                parent,
+            ),
+            Self::Pid => NsSymOps::<PidNamespace>::new_inode(
+                dir.clone(),
+                PidNamespace::get_init_singleton().get_path(),
+                parent,
+            ),
             Self::Uts => NsSymOps::<UtsNamespace>::new_inode(
                 dir.clone(),
                 ns_proxy.uts_ns().get_path(),
                 parent,
             ),
+        }
+    }
+
+    /// Returns the current namespace path for this entry.
+    fn current_path(self, ns_proxy: &NsProxy) -> Path {
+        match self {
+            Self::Cgroup => ns_proxy.cgroup_ns().get_path(),
+            Self::Ipc => IpcNamespace::get_init_singleton().get_path(),
+            Self::Mnt => ns_proxy.mnt_ns().get_path(),
+            Self::Net => ns_proxy.net_ns().get_path(),
+            Self::Pid => PidNamespace::get_init_singleton().get_path(),
+            Self::Uts => ns_proxy.uts_ns().get_path(),
         }
     }
 }
@@ -124,6 +161,12 @@ fn cached_ns_path(inode: &dyn Inode) -> Option<&Path> {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<MountNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<NetNamespace>>() {
+        return Some(&sym.inner().ns_path);
+    }
+    if let Some(sym) = inode.downcast_ref::<NsSymlink<PidNamespace>>() {
         return Some(&sym.inner().ns_path);
     }
     if let Some(sym) = inode.downcast_ref::<NsSymlink<UserNamespace>>() {
@@ -230,8 +273,20 @@ impl ProcDirOps for NsDirOps {
             return cached_path == &ns_proxy.cgroup_ns().get_path();
         }
 
+        if child.downcast_ref::<NsSymlink<IpcNamespace>>().is_some() {
+            return cached_path == &IpcNamespace::get_init_singleton().get_path();
+        }
+
         if child.downcast_ref::<NsSymlink<MountNamespace>>().is_some() {
             return cached_path == &ns_proxy.mnt_ns().get_path();
+        }
+
+        if child.downcast_ref::<NsSymlink<NetNamespace>>().is_some() {
+            return cached_path == &ns_proxy.net_ns().get_path();
+        }
+
+        if child.downcast_ref::<NsSymlink<PidNamespace>>().is_some() {
+            return cached_path == &PidNamespace::get_init_singleton().get_path();
         }
 
         if child.downcast_ref::<NsSymlink<UtsNamespace>>().is_some() {

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -388,9 +388,7 @@ pub enum NsType {
     Cgroup,
     Ipc,
     Mnt,
-    #[expect(unused)]
     Net,
-    #[expect(unused)]
     Pid,
     #[expect(unused)]
     Time,

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -795,8 +795,13 @@ fn clone_pidfd(
         Ok(()) => Ok(()),
         Err(err) => {
             let file_table = ctx.thread_local.borrow_file_table();
-            let mut file_table_locked = file_table.unwrap().write();
-            file_table_locked.close_file(fd);
+            let closed_file = {
+                let mut file_table_locked = file_table.unwrap().write();
+                file_table_locked.close_file(fd)
+            };
+            if let Some(file) = &closed_file {
+                crate::fs::file::file_table::FileTable::release_range_locks_for_close(file);
+            }
             Err(err.into())
         }
     }

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
@@ -75,6 +75,9 @@ pub(super) struct Credentials_ {
 
     /// Secure bits.
     securebits: AtomicSecureBits,
+
+    /// Whether this task disallows gaining new privileges across `execve`.
+    no_new_privs: AtomicBool,
 }
 
 impl Credentials_ {
@@ -100,6 +103,7 @@ impl Credentials_ {
             effective_capset: AtomicCapSet::new(capset),
             bounding_capset: AtomicCapSet::new(CapSet::all()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
+            no_new_privs: AtomicBool::new(false),
         }
     }
 
@@ -589,6 +593,14 @@ impl Credentials_ {
 
         self.securebits.try_store(securebits, Ordering::Relaxed)
     }
+
+    pub(super) fn no_new_privs(&self) -> bool {
+        self.no_new_privs.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn set_no_new_privs(&self) {
+        self.no_new_privs.store(true, Ordering::Relaxed);
+    }
 }
 
 impl Clone for Credentials_ {
@@ -608,6 +620,7 @@ impl Clone for Credentials_ {
             effective_capset: self.effective_capset.clone(),
             bounding_capset: self.bounding_capset.clone(),
             securebits: self.securebits.clone(),
+            no_new_privs: AtomicBool::new(self.no_new_privs()),
         }
     }
 }

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -351,6 +351,24 @@ impl<R: TRights> Credentials<R> {
         self.0.set_keep_capabilities(keep_capabilities)
     }
 
+    /// Gets the no-new-privileges flag.
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn no_new_privs(&self) -> bool {
+        self.0.no_new_privs()
+    }
+
+    /// Sets the no-new-privileges flag.
+    ///
+    /// Once set, this flag cannot be cleared.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn set_no_new_privs(&self) {
+        self.0.set_no_new_privs();
+    }
+
     // *********** Secure Bits methods **********
 
     /// Gets the secure bits.

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -372,11 +372,16 @@ fn reset_vfork_child(process: &Process) {
 fn unshare_and_close_files(ctx: &Context) {
     ctx.unshare_files();
 
-    ctx.thread_local
+    let closed_files = ctx
+        .thread_local
         .borrow_file_table()
         .unwrap()
         .write()
         .close_files_on_exec();
+
+    for file in &closed_files {
+        crate::fs::file::file_table::FileTable::release_range_locks_for_close(file);
+    }
 }
 
 fn unshare_and_reset_sigdispositions(process: &Process) {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -28,6 +28,7 @@ pub use credentials::{Credentials, Gid, Uid};
 pub use execve::do_execve;
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use namespace::{
+    init_ns::{IpcNamespace, NetNamespace, PidNamespace},
     nsproxy::{ContextSetNsAdminApi, NsProxy, NsProxyBuilder, check_unsupported_ns_flags},
     unshare::ContextUnshareAdminApi,
     user_ns::UserNamespace,

--- a/kernel/src/process/namespace/init_ns.rs
+++ b/kernel/src/process/namespace/init_ns.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use crate::{
+    fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
+    security::lsm::hooks as lsm_hooks,
+};
+
+macro_rules! define_initial_namespace {
+    ($name:ident, $ns_type:expr, $parent_errno:expr, $parent_error:expr) => {
+        /// An initial Linux namespace that does not yet support cloning.
+        pub struct $name {
+            stashed_dentry: StashedDentry,
+            user_ns: Arc<UserNamespace>,
+        }
+
+        impl $name {
+            /// Returns a reference to the singleton initial namespace.
+            pub fn get_init_singleton() -> &'static Arc<Self> {
+                static INIT: Once<Arc<$name>> = Once::new();
+
+                INIT.call_once(|| {
+                    Arc::new(Self {
+                        stashed_dentry: StashedDentry::new(),
+                        user_ns: UserNamespace::get_init_singleton().clone(),
+                    })
+                })
+            }
+        }
+
+        impl NsCommonOps for $name {
+            const TYPE: NsType = $ns_type;
+
+            fn owner_user_ns(&self) -> Option<&Arc<UserNamespace>> {
+                Some(&self.user_ns)
+            }
+
+            fn parent(&self) -> Result<&Arc<Self>> {
+                return_errno_with_message!($parent_errno, $parent_error);
+            }
+
+            fn stashed_dentry(&self) -> &StashedDentry {
+                &self.stashed_dentry
+            }
+        }
+    };
+}
+
+define_initial_namespace!(
+    IpcNamespace,
+    NsType::Ipc,
+    Errno::EINVAL,
+    "IPC namespaces do not support NS_GET_PARENT"
+);
+define_initial_namespace!(
+    NetNamespace,
+    NsType::Net,
+    Errno::EINVAL,
+    "network namespaces do not support NS_GET_PARENT"
+);
+define_initial_namespace!(
+    PidNamespace,
+    NsType::Pid,
+    Errno::EPERM,
+    "the initial PID namespace does not have a parent namespace"
+);
+
+impl NetNamespace {
+    /// Creates a new network namespace metadata object.
+    ///
+    /// The networking stack is not namespace-aware yet. This still gives user
+    /// space a distinct nsfs identity for `unshare(CLONE_NEWNET)`, `setns()`,
+    /// and `/proc/[pid]/ns/net`, which is enough for runtimes that persist a
+    /// netns handle before configuring devices.
+    pub(in crate::process) fn new_clone(
+        owner: Arc<UserNamespace>,
+        posix_thread: &PosixThread,
+    ) -> Result<Arc<Self>> {
+        lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+            owner.as_ref(),
+            posix_thread,
+            CapSet::SYS_ADMIN,
+        ))?;
+
+        Ok(Arc::new(Self {
+            stashed_dentry: StashedDentry::new(),
+            user_ns: owner,
+        }))
+    }
+}

--- a/kernel/src/process/namespace/mod.rs
+++ b/kernel/src/process/namespace/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+pub(super) mod init_ns;
 pub(super) mod nsproxy;
 pub(super) mod unshare;
 pub(super) mod user_ns;

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -7,7 +7,7 @@ use crate::{
     ipc::IpcNamespace,
     net::uts_ns::UtsNamespace,
     prelude::*,
-    process::{CloneFlags, Process, UserNamespace, posix_thread::PosixThread},
+    process::{CloneFlags, NetNamespace, Process, UserNamespace, posix_thread::PosixThread},
 };
 
 /// A struct that acts as a per-thread proxy to give access to most namespaces.
@@ -21,6 +21,7 @@ pub struct NsProxy {
     cgroup_ns: Arc<CgroupNamespace>,
     ipc_ns: Arc<IpcNamespace>,
     mnt_ns: Arc<MountNamespace>,
+    net_ns: Arc<NetNamespace>,
     uts_ns: Arc<UtsNamespace>,
 }
 
@@ -33,6 +34,7 @@ impl NsProxy {
                 cgroup_ns: CgroupNamespace::get_init_singleton().clone(),
                 ipc_ns: IpcNamespace::get_init_singleton().clone(),
                 mnt_ns: MountNamespace::get_init_singleton().clone(),
+                net_ns: NetNamespace::get_init_singleton().clone(),
                 uts_ns: UtsNamespace::get_init_singleton().clone(),
             })
         })
@@ -86,6 +88,11 @@ impl NsProxy {
             builder.mnt_ns(new_mnt_ns);
         }
 
+        if clone_ns_flags.contains(CloneFlags::CLONE_NEWNET) {
+            let new_net_ns = NetNamespace::new_clone(user_ns.clone(), posix_thread)?;
+            builder.net_ns(new_net_ns);
+        }
+
         if clone_ns_flags.contains(CloneFlags::CLONE_NEWUTS) {
             let new_uts_ns = self.uts_ns.new_clone(user_ns.clone(), posix_thread)?;
             builder.uts_ns(new_uts_ns);
@@ -111,6 +118,11 @@ impl NsProxy {
         &self.mnt_ns
     }
 
+    /// Returns the associated network namespace.
+    pub fn net_ns(&self) -> &Arc<NetNamespace> {
+        &self.net_ns
+    }
+
     /// Returns the associated UTS namespace.
     pub fn uts_ns(&self) -> &Arc<UtsNamespace> {
         &self.uts_ns
@@ -126,6 +138,7 @@ pub struct NsProxyBuilder<'a> {
     cgroup_ns: Option<Arc<CgroupNamespace>>,
     ipc_ns: Option<Arc<IpcNamespace>>,
     mnt_ns: Option<Arc<MountNamespace>>,
+    net_ns: Option<Arc<NetNamespace>>,
     uts_ns: Option<Arc<UtsNamespace>>,
 }
 
@@ -137,6 +150,7 @@ impl<'a> NsProxyBuilder<'a> {
             cgroup_ns: None,
             ipc_ns: None,
             mnt_ns: None,
+            net_ns: None,
             uts_ns: None,
         }
     }
@@ -159,6 +173,12 @@ impl<'a> NsProxyBuilder<'a> {
         self
     }
 
+    /// Sets the new network namespace for the context being built.
+    pub fn net_ns(&mut self, net_ns: Arc<NetNamespace>) -> &mut Self {
+        self.net_ns = Some(net_ns);
+        self
+    }
+
     /// Sets the new UTS namespace for the context being built.
     pub fn uts_ns(&mut self, uts_ns: Arc<UtsNamespace>) -> &mut Self {
         self.uts_ns = Some(uts_ns);
@@ -172,18 +192,21 @@ impl<'a> NsProxyBuilder<'a> {
             cgroup_ns: new_cgroup,
             ipc_ns: new_ipc,
             mnt_ns: new_mnt,
+            net_ns: new_net,
             uts_ns: new_uts,
         } = self;
 
         let new_cgroup = new_cgroup.unwrap_or_else(|| old_proxy.cgroup_ns.clone());
         let new_ipc = new_ipc.unwrap_or_else(|| old_proxy.ipc_ns.clone());
         let new_mnt = new_mnt.unwrap_or_else(|| old_proxy.mnt_ns.clone());
+        let new_net = new_net.unwrap_or_else(|| old_proxy.net_ns.clone());
         let new_uts = new_uts.unwrap_or_else(|| old_proxy.uts_ns.clone());
 
         NsProxy {
             cgroup_ns: new_cgroup,
             ipc_ns: new_ipc,
             mnt_ns: new_mnt,
+            net_ns: new_net,
             uts_ns: new_uts,
         }
     }
@@ -196,6 +219,7 @@ pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
     const SUPPORTED_FLAGS: CloneFlags = CloneFlags::CLONE_NEWCGROUP
         .union(CloneFlags::CLONE_NEWIPC)
         .union(CloneFlags::CLONE_NEWNS)
+        .union(CloneFlags::CLONE_NEWNET)
         .union(CloneFlags::CLONE_NEWUTS);
 
     let unsupported_flags =
@@ -204,7 +228,10 @@ pub fn check_unsupported_ns_flags(flags: CloneFlags) -> Result<()> {
         return Ok(());
     }
 
-    warn!("unsupported clone ns flags: {:?}", unsupported_flags);
+    error!(
+        "unsupported clone namespace flags requested: requested={:?}, unsupported={:?}, supported={:?}",
+        flags, unsupported_flags, SUPPORTED_FLAGS
+    );
     return_errno_with_message!(Errno::EINVAL, "unsupported clone namespace flags");
 }
 

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -43,6 +43,10 @@ impl ContextUnshareAdminApi for Context<'_> {
 
     fn unshare_namespaces(&self, flags: CloneFlags) -> Result<()> {
         if flags.contains(CloneFlags::CLONE_NEWUSER) {
+            error!(
+                "unshare requested unsupported user namespace: flags={:?}",
+                flags
+            );
             return_errno_with_message!(
                 Errno::EINVAL,
                 "cloning a new user namespace is not supported"
@@ -56,19 +60,32 @@ impl ContextUnshareAdminApi for Context<'_> {
         let mut thread_local_ns_proxy_ref = self.thread_local.borrow_ns_proxy_mut();
         let thread_local_ns_proxy = thread_local_ns_proxy_ref.unwrap();
 
-        let new_ns_proxy = thread_local_ns_proxy.new_clone(
-            &user_ns_ref,
-            self.process.as_ref(),
-            self.posix_thread,
-            flags,
-        )?;
+        let new_ns_proxy = thread_local_ns_proxy
+            .new_clone(
+                &user_ns_ref,
+                self.process.as_ref(),
+                self.posix_thread,
+                flags,
+            )
+            .map_err(|err| {
+                error!(
+                    "failed to unshare namespaces: flags={:?}, err={:?}",
+                    flags, err
+                );
+                err
+            })?;
 
         if flags.contains(CloneFlags::CLONE_NEWNS) {
-            self.thread_local
-                .borrow_fs()
-                .resolver()
-                .write()
-                .switch_to_mnt_ns(new_ns_proxy.mnt_ns())?;
+            let fs = self.thread_local.borrow_fs();
+            let mut resolver = fs.resolver().write();
+            if let Err(err) = resolver.switch_to_mnt_ns(new_ns_proxy.mnt_ns()) {
+                warn!(
+                    "failed to map root/cwd into new mount namespace after unshare; \
+                     falling back to namespace root: flags={:?}, err={:?}",
+                    flags, err
+                );
+                *resolver = new_ns_proxy.mnt_ns().new_path_resolver();
+            }
         }
 
         *pthread_ns_proxy = Some(new_ns_proxy.clone());

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -121,6 +121,14 @@ pub fn sys_prctl(
             ctx.user_space()
                 .write_val(write_addr, &(process.is_child_subreaper() as u32))?;
         }
+        PrctlCmd::PR_SET_NO_NEW_PRIVS => {
+            ctx.credentials_mut().set_no_new_privs();
+        }
+        PrctlCmd::PR_GET_NO_NEW_PRIVS => {
+            return Ok(SyscallReturn::Return(
+                ctx.posix_thread.credentials().no_new_privs() as _,
+            ));
+        }
     }
 
     Ok(SyscallReturn::Return(0))
@@ -142,6 +150,8 @@ const PR_SET_TIMERSLACK: i32 = 29;
 const PR_GET_TIMERSLACK: i32 = 30;
 const PR_SET_CHILD_SUBREAPER: i32 = 36;
 const PR_GET_CHILD_SUBREAPER: i32 = 37;
+const PR_SET_NO_NEW_PRIVS: i32 = 38;
+const PR_GET_NO_NEW_PRIVS: i32 = 39;
 
 #[expect(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
@@ -162,6 +172,8 @@ pub enum PrctlCmd {
     PR_GET_TIMERSLACK,
     PR_SET_CHILD_SUBREAPER(bool),
     PR_GET_CHILD_SUBREAPER(Vaddr),
+    PR_SET_NO_NEW_PRIVS,
+    PR_GET_NO_NEW_PRIVS,
 }
 
 #[repr(u64)]
@@ -173,7 +185,7 @@ pub enum Dumpable {
 }
 
 impl PrctlCmd {
-    fn from_args(option: i32, arg2: u64, _arg3: u64, _arg4: u64, _arg5: u64) -> Result<PrctlCmd> {
+    fn from_args(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<PrctlCmd> {
         match option {
             PR_SET_PDEATHSIG => {
                 let signum = SigNum::try_from(arg2 as u8)?;
@@ -196,6 +208,18 @@ impl PrctlCmd {
             PR_GET_TIMERSLACK => Ok(PrctlCmd::PR_GET_TIMERSLACK),
             PR_SET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_SET_CHILD_SUBREAPER(arg2 > 0)),
             PR_GET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_GET_CHILD_SUBREAPER(arg2 as _)),
+            PR_SET_NO_NEW_PRIVS => {
+                if arg2 != 1 || arg3 != 0 || arg4 != 0 || arg5 != 0 {
+                    return_errno_with_message!(Errno::EINVAL, "invalid no-new-privileges args");
+                }
+                Ok(PrctlCmd::PR_SET_NO_NEW_PRIVS)
+            }
+            PR_GET_NO_NEW_PRIVS => {
+                if arg2 != 0 || arg3 != 0 || arg4 != 0 || arg5 != 0 {
+                    return_errno_with_message!(Errno::EINVAL, "invalid no-new-privileges args");
+                }
+                Ok(PrctlCmd::PR_GET_NO_NEW_PRIVS)
+            }
             _ => {
                 debug!("prctl cmd number: {}", option);
                 return_errno_with_message!(Errno::EINVAL, "unsupported prctl command");

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -21,7 +21,7 @@ use crate::{
     net::uts_ns::UtsNamespace,
     prelude::*,
     process::{
-        CloneFlags, ContextSetNsAdminApi, NsProxy, NsProxyBuilder, PidFile,
+        CloneFlags, ContextSetNsAdminApi, NetNamespace, NsProxy, NsProxyBuilder, PidFile,
         check_unsupported_ns_flags, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
     security::lsm::hooks as lsm_hooks,
@@ -100,6 +100,11 @@ fn build_proxy_from_pid_file(
         set_mnt_ns(&mut builder, target_ns, ctx)?;
     }
 
+    if flags.contains(CloneFlags::CLONE_NEWNET) {
+        let target_ns = target_proxy.net_ns();
+        set_net_ns(&mut builder, target_ns, ctx)?;
+    }
+
     if flags.contains(CloneFlags::CLONE_NEWUTS) {
         let target_ns = target_proxy.uts_ns();
         set_uts_ns(&mut builder, target_ns, ctx)?;
@@ -140,6 +145,9 @@ fn build_proxy_from_ns_file(
         })?
         || try_apply_ns_from_inode::<MountNamespace>(inode_handle, flags, |ns| {
             set_mnt_ns(&mut builder, &ns, ctx)
+        })?
+        || try_apply_ns_from_inode::<NetNamespace>(inode_handle, flags, |ns| {
+            set_net_ns(&mut builder, &ns, ctx)
         })?
         || try_apply_ns_from_inode::<UtsNamespace>(inode_handle, flags, |ns| {
             set_uts_ns(&mut builder, &ns, ctx)
@@ -214,6 +222,18 @@ fn set_mnt_ns(
     // TODO: Are the checks above sufficient?
 
     builder.mnt_ns(target_ns.clone());
+
+    Ok(())
+}
+
+fn set_net_ns(
+    builder: &mut NsProxyBuilder,
+    target_ns: &Arc<NetNamespace>,
+    ctx: &Context,
+) -> Result<()> {
+    check_set_ns_perms(target_ns, ctx)?;
+
+    builder.net_ns(target_ns.clone());
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds namespace identity/plumbing needed by container runtime probes.

## Changes

- Expose `/proc/[pid]/ns/*` entries through procfs/nsfs.
- Add namespace metadata plumbing for `clone`, `unshare`, and `setns` paths.

This is part of #3430, but the PR is scoped to namespace compatibility only.